### PR TITLE
Update website whitespace and formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ pkg/
 # Vault-specific
 example.hcl
 example.vault.d
+
+# Ruby
+website/vendor/ruby
+website/.bundle

--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'middleman-hashicorp', git: 'https://github.com/hashicorp/middleman-hashicorp'
+gem 'middleman-hashicorp', github: 'hashicorp/middleman-hashicorp'

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/hashicorp/middleman-hashicorp
-  revision: 0e21734c64afcf0c6d35b40b26840254227c1949
+  remote: git://github.com/hashicorp/middleman-hashicorp.git
+  revision: 5d1edbfa4ceec20b33b501f0162e2f881afadfa9
   specs:
     middleman-hashicorp (0.1.0)
       bootstrap-sass (~> 3.3)
@@ -26,7 +26,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    autoprefixer-rails (5.1.8.1)
+    autoprefixer-rails (5.1.11)
       execjs
       json
     bootstrap-sass (3.3.4.1)
@@ -39,7 +39,7 @@ GEM
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1)
+    coffee-script-source (1.9.1.1)
     commonjs (0.2.7)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -117,7 +117,7 @@ GEM
     middleman-syntax (2.0.0)
       middleman-core (~> 3.2)
       rouge (~> 1.0)
-    minitest (5.5.1)
+    minitest (5.6.0)
     multi_json (1.11.0)
     padrino-helpers (0.12.5)
       i18n (~> 0.6, >= 0.6.7)

--- a/website/source/docs/auth/app-id.html.md
+++ b/website/source/docs/auth/app-id.html.md
@@ -36,7 +36,7 @@ An example, real world process for using this provider:
      system tells security operators a unique ID for this machine. This
      process can be scripted, but the key is that it is out-of-band and
      out of reach of configuration management.
-	 (Path: map/user-id/<user-id>)
+   (Path: map/user-id/<user-id>)
 
   4. A new server is provisioned. Configuration management configures the
      app ID, the server itself detects its user ID. With both of these

--- a/website/source/docs/commands/read-write.html.md
+++ b/website/source/docs/commands/read-write.html.md
@@ -98,10 +98,10 @@ Data can be read using `vault read`. This command is very simple:
 
 ```
 $ vault read secret/password
-Key           	Value
-lease_id      	secret/password/76c844fb-aeba-a766-0a50-2b907072233a
-lease_duration	2592000
-value         	itsasecret
+Key             Value
+lease_id        secret/password/76c844fb-aeba-a766-0a50-2b907072233a
+lease_duration  2592000
+value           itsasecret
 ```
 
 You can use the `-format` flag to get various different formats out

--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -17,17 +17,17 @@ Policies are [HCL](https://github.com/hashicorp/hcl) or JSON documents
 that describe what parts of Vault a user is allowed to access. An example
 of a policy is shown below:
 
-```
+```javascript
 path "sys" {
-    policy = "deny"
+  policy = "deny"
 }
 
 path "secret" {
-    policy = "write"
+  policy = "write"
 }
 
 path "secret/foo" {
-    policy = "read"
+  policy = "read"
 }
 ```
 

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -12,15 +12,15 @@ Outside of development mode, Vault servers are configured using a file.
 The format of this file is [HCL](https://github.com/hashicorp/hcl) or JSON.
 An example configuration is shown below:
 
-```
+```javascript
 backend "consul" {
-    address = "demo.consul.io:80"
-    path = "vault"
+  address = "demo.consul.io:80"
+  path = "vault"
 }
 
 listener "tcp" {
-   address = "127.0.0.1:8200"
-   tls_disable = 1
+  address = "127.0.0.1:8200"
+  tls_disable = 1
 }
 ```
 

--- a/website/source/docs/http/index.html.md
+++ b/website/source/docs/http/index.html.md
@@ -57,20 +57,24 @@ backends, credential providers, etc. then append `?help=1` to any
 URL. If you have valid permission to access the path, then the help text
 will be returned with the following structure:
 
-        {
-            "help": "help text"
-        }
+```javascript
+{
+  "help": "help text"
+}
+```
 
 ## Error Response
 
 A common JSON structure is always returned to return errors:
 
-        {
-            "errors": [
-                "message",
-                "another message"
-            ]
-        }
+```javascript
+{
+  "errors": [
+    "message",
+    "another message"
+  ]
+}
+```
 
 This structure will be sent down for any HTTP status greater than
 or equal to 400.
@@ -94,5 +98,3 @@ The following HTTP status codes are used throughout the API.
    try again later. If the error persists, report a bug.
 - `503` - Vault is down for maintenance or is currently sealed.
    Try again later.
-
-

--- a/website/source/docs/http/sys-audit.html.md
+++ b/website/source/docs/http/sys-audit.html.md
@@ -11,97 +11,98 @@ description: |-
 ## GET
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Lists all the available policies.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Lists all the available policies.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>GET</dd>
+  <dt>Method</dt>
+  <dd>GET</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>
+  <dt>Returns</dt>
+  <dd>
 
-```
-{
-	"file": {
-		"type: "file",
-		"description: "Store logs in a file",
-		"options": {
-			"path": "/var/log/file"
-		}
-	}
-}
-```
-	</dd>
+    ```javascript
+    {
+      "file": {
+        "type: "file",
+        "description: "Store logs in a file",
+        "options": {
+          "path": "/var/log/file"
+        }
+      }
+    }
+    ```
+
+  </dd>
 </dl>
 
 ## PUT
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Enable an audit backend.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Enable an audit backend.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>PUT</dd>
+  <dt>Method</dt>
+  <dd>PUT</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/audit/<name>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/audit/<name>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		<ul>
-			<li>
-				<span class="param">type</span>
-				<span class="param-flags">required</span>
-				The type of the audit backend.
-			</li>
-			<li>
-				<span class="param">description</span>
-				<span class="param-flags">optional</span>
-				A description of the audit backend for operators.
-			</li>
-			<li>
-				<span class="param">options</span>
-				<span class="param-flags">optional</span>
-				An object of options to configure the backend. This is
-				dependent on the backend type. Please consult the documentation
-				for the backend type you intend to use.
-			</li>
-		</ul>
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">type</span>
+        <span class="param-flags">required</span>
+        The type of the audit backend.
+      </li>
+      <li>
+        <span class="param">description</span>
+        <span class="param-flags">optional</span>
+        A description of the audit backend for operators.
+      </li>
+      <li>
+        <span class="param">options</span>
+        <span class="param-flags">optional</span>
+        An object of options to configure the backend. This is
+        dependent on the backend type. Please consult the documentation
+        for the backend type you intend to use.
+      </li>
+    </ul>
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
 </dl>
 
 ## DELETE
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Disable the given audit backend.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Disable the given audit backend.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>DELETE</dd>
+  <dt>Method</dt>
+  <dd>DELETE</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/audit/<name>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/audit/<name>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-auth.html.md
+++ b/website/source/docs/http/sys-auth.html.md
@@ -11,91 +11,92 @@ description: |-
 ## GET
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Lists all the enabled auth backends.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Lists all the enabled auth backends.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>GET</dd>
+  <dt>Method</dt>
+  <dd>GET</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>
+  <dt>Returns</dt>
+  <dd>
 
-```
-{
-	"github": {
-		"type": "github",
-		"description": "GitHub auth"
-	}
-}
-```
-	</dd>
+    ```javascript
+    {
+      "github": {
+        "type": "github",
+        "description": "GitHub auth"
+      }
+    }
+    ```
+
+  </dd>
 </dl>
 
 ## POST
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Enable a new auth backend. The auth backend can be accessed
-		and configured via the mount point specified in the URL. This
-		mount point will be exposed under the `auth` prefix. For example,
-		enabling with the `/sys/auth/foo` URL will make the backend
-		available at `/auth/foo`.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Enable a new auth backend. The auth backend can be accessed
+    and configured via the mount point specified in the URL. This
+    mount point will be exposed under the `auth` prefix. For example,
+    enabling with the `/sys/auth/foo` URL will make the backend
+    available at `/auth/foo`.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>POST</dd>
+  <dt>Method</dt>
+  <dd>POST</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/auth/<mount point>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/auth/<mount point>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		<ul>
-			<li>
-				<span class="param">type</span>
-				<span class="param-flags">required</span>
-				The name of the auth backend type, such as "github"
-			</li>
-			<li>
-				<span class="param">description</span>
-				<span class="param-flags">optional</span>
-				A human-friendly description of the auth backend.
-			</li>
-		</ul>
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">type</span>
+        <span class="param-flags">required</span>
+        The name of the auth backend type, such as "github"
+      </li>
+      <li>
+        <span class="param">description</span>
+        <span class="param-flags">optional</span>
+        A human-friendly description of the auth backend.
+      </li>
+    </ul>
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
 </dl>
 
 ## DELETE
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Disable the auth backend at the given mount point.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Disable the auth backend at the given mount point.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>DELETE</dd>
+  <dt>Method</dt>
+  <dd>DELETE</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/auth/<mount point>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/auth/<mount point>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-init.html.md
+++ b/website/source/docs/http/sys-init.html.md
@@ -11,68 +11,68 @@ description: |-
 ## GET
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Return the initialization status of a Vault.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Return the initialization status of a Vault.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>GET</dd>
+  <dt>Method</dt>
+  <dd>GET</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>None</dd>
 
-	<dt>Returns</dt>
-	<dd>
+  <dt>Returns</dt>
+  <dd>
 
-```
-{
-	"initialized": false
-}
-```
-	</dd>
+    ```javascript
+    {
+      "initialize": true
+    }
+    ```
+
+  </dd>
 </dl>
 
 ## PUT
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Initializes a new Vault. The Vault must've not been previously
-		initialized.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Initializes a new Vault. The Vault must've not been previously
+    initialized.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>PUT</dd>
+  <dt>Method</dt>
+  <dd>PUT</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		<ul>
-			<li>
-				<span class="param">secret_shares</span>
-				<span class="param-flags">required</span>
-				The number of shares to split the master key into.
-			</li>
-			<li>
-				<span class="param">secret_threshold</span>
-				<span class="param-flags">required</span>
-				The number of shares required to reconstruct the master key.
-				This must be less than or equal to <code>secret_shares</code>.
-			</li>
-		</ul>
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">secret_shares</span>
+        <span class="param-flags">required</span>
+        The number of shares to split the master key into.
+      </li>
+      <li>
+        <span class="param">secret_threshold</span>
+        <span class="param-flags">required</span>
+        The number of shares required to reconstruct the master key.
+        This must be less than or equal to <code>secret_shares</code>.
+      </li>
+    </ul>
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>
-		A JSON-encoded object including the master keys and initial root token:
+  <dt>Returns</dt>
+  <dd>
+    A JSON-encoded object including the master keys and initial root token:
 
-```
-{
-	"keys": ["one", "two", "three"],
-	"root_token": "foo"
-}
-```
-	</dd>
+    ```javascript
+    {
+      "keys": ["one", "two", "three"],
+      "root_token": "foo"
+    }
+    ```
+
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-leader.html.md
+++ b/website/source/docs/http/sys-leader.html.md
@@ -9,28 +9,29 @@ description: |-
 # /sys/leader
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Returns the high availability status and current leader instance of Vault.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Returns the high availability status and current leader instance of Vault.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>GET</dd>
+  <dt>Method</dt>
+  <dd>GET</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>
+  <dt>Returns</dt>
+  <dd>
 
-```
-{
-	"ha_enabled": true,
-	"is_self": false,
-	"leader_address": "https://127.0.0.1:8200/"
-}
-```
-	</dd>
+    ```javascript
+    {
+      "ha_enabled": true,
+      "is_self": false,
+      "leader_address": "https://127.0.0.1:8200/"
+    }
+    ```
+
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-mounts.html.md
+++ b/website/source/docs/http/sys-mounts.html.md
@@ -11,92 +11,93 @@ description: |-
 ## GET
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Lists all the mounted secret backends.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Lists all the mounted secret backends.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>GET</dd>
+  <dt>Method</dt>
+  <dd>GET</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>
+  <dt>Returns</dt>
+  <dd>
 
-```
-{
-	"aws": {
-		"type": "aws",
-		"description": "AWS keys"
-	},
+    ```javascript
+    {
+      "aws": {
+        "type": "aws",
+        "description": "AWS keys"
+      },
 
-	"sys": {
-		"type": "system",
-		"description": "system endpoint"
-	}
-}
-```
-	</dd>
+      "sys": {
+        "type": "system",
+        "description": "system endpoint"
+      }
+    }
+    ```
+
+  </dd>
 </dl>
 
 ## POST
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Mount a new secret backend to the mount point in the URL.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Mount a new secret backend to the mount point in the URL.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>POST</dd>
+  <dt>Method</dt>
+  <dd>POST</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/mounts/<mount point>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/mounts/<mount point>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		<ul>
-			<li>
-				<span class="param">type</span>
-				<span class="param-flags">required</span>
-				The name of the backend type, such as "aws"
-			</li>
-			<li>
-				<span class="param">description</span>
-				<span class="param-flags">optional</span>
-				A human-friendly description of the mount.
-			</li>
-		</ul>
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">type</span>
+        <span class="param-flags">required</span>
+        The name of the backend type, such as "aws"
+      </li>
+      <li>
+        <span class="param">description</span>
+        <span class="param-flags">optional</span>
+        A human-friendly description of the mount.
+      </li>
+    </ul>
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
 </dl>
 
 ## DELETE
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Unmount the mount point specified in the URL.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Unmount the mount point specified in the URL.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>DELETE</dd>
+  <dt>Method</dt>
+  <dd>DELETE</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/mounts/<mount point>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/mounts/<mount point>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-policy.html.md
+++ b/website/source/docs/http/sys-policy.html.md
@@ -11,81 +11,82 @@ description: |-
 ## GET
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Lists all the available policies.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Lists all the available policies.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>GET</dd>
+  <dt>Method</dt>
+  <dd>GET</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>
+  <dt>Returns</dt>
+  <dd>
 
-```
-{
-	"policies": ["root", "deploy"]
-}
-```
-	</dd>
+    ```javascript
+    {
+      "policies": ["root", "deploy"]
+    }
+    ```
+
+  </dd>
 </dl>
 
 ## PUT
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Add or update a policy. Once a policy is updated, it takes effect
-		immediately to all associated users.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Add or update a policy. Once a policy is updated, it takes effect
+    immediately to all associated users.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>PUT</dd>
+  <dt>Method</dt>
+  <dd>PUT</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/policy/<name>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/policy/<name>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		<ul>
-			<li>
-				<span class="param">rules</span>
-				<span class="param-flags">required</span>
-				The policy document.
-			</li>
-		</ul>
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">rules</span>
+        <span class="param-flags">required</span>
+        The policy document.
+      </li>
+    </ul>
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` respons code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` respons code.
+  </dd>
 </dl>
 
 ## DELETE
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Delete the policy with the given name. This will immediately
-		affect all associated users.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Delete the policy with the given name. This will immediately
+    affect all associated users.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>DELETE</dd>
+  <dt>Method</dt>
+  <dd>DELETE</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/policy/<name>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/policy/<name>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` respons code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` respons code.
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-raw.html.md
+++ b/website/source/docs/http/sys-raw.html.md
@@ -11,85 +11,86 @@ description: |-
 ## GET
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-	    Reads the value of the key at the given path. This is the raw path in the
+  <dt>Description</dt>
+  <dd>
+      Reads the value of the key at the given path. This is the raw path in the
         storage packend and not the logical path that is exposed via the mount system.
-	</dd>
+  </dd>
 
-	<dt>Method</dt>
-	<dd>GET</dd>
+  <dt>Method</dt>
+  <dd>GET</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/raw/<path>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/raw/<path>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>
+  <dt>Returns</dt>
+  <dd>
 
-```
-{
-	"value": "{'foo':'bar'}"
-}
-```
-	</dd>
+    ```javascript
+    {
+      "value": "{'foo':'bar'}"
+    }
+    ```
+
+  </dd>
 </dl>
 
 ## PUT
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-	    Update the value of the key at the given path. This is the raw path in the
+  <dt>Description</dt>
+  <dd>
+      Update the value of the key at the given path. This is the raw path in the
         storage packend and not the logical path that is exposed via the mount system.
-	</dd>
+  </dd>
 
-	<dt>Method</dt>
-	<dd>PUT</dd>
+  <dt>Method</dt>
+  <dd>PUT</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/raw/<path>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/raw/<path>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		<ul>
-			<li>
-				<span class="param">value</span>
-				<span class="param-flags">required</span>
-				The value of the key.
-			</li>
-		</ul>
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">value</span>
+        <span class="param-flags">required</span>
+        The value of the key.
+      </li>
+    </ul>
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
 </dl>
 
 ## DELETE
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Delete the key with given path. This is the raw path in the
+  <dt>Description</dt>
+  <dd>
+    Delete the key with given path. This is the raw path in the
         storage packend and not the logical path that is exposed via the mount system.
-	</dd>
+  </dd>
 
-	<dt>Method</dt>
-	<dd>DELETE</dd>
+  <dt>Method</dt>
+  <dd>DELETE</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/raw/<path>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/raw/<path>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-remount.html.md
+++ b/website/source/docs/http/sys-remount.html.md
@@ -9,31 +9,31 @@ description: |-
 # /sys/remount
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Remount an already-mounted backend to a new mount point.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Remount an already-mounted backend to a new mount point.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>POST</dd>
+  <dt>Method</dt>
+  <dd>POST</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		<ul>
-			<li>
-				<span class="param">from</span>
-				<span class="param-flags">required</span>
-				The previous mount point.
-			</li>
-			<li>
-				<span class="param">to</span>
-				<span class="param-flags">required</span>
-				The new mount point.
-			</li>
-		</ul>
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">from</span>
+        <span class="param-flags">required</span>
+        The previous mount point.
+      </li>
+      <li>
+        <span class="param">to</span>
+        <span class="param-flags">required</span>
+        The new mount point.
+      </li>
+    </ul>
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>`204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-renew.html.md
+++ b/website/source/docs/http/sys-renew.html.md
@@ -9,30 +9,30 @@ description: |-
 # /sys/renew
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Renew a secret, requesting to extend the lease.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Renew a secret, requesting to extend the lease.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>PUT</dd>
+  <dt>Method</dt>
+  <dd>PUT</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/renew/<lease id>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/renew/<lease id>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		<ul>
-			<li>
-				<span class="param">increment</span>
-				<span class="param-flags">optional</span>
-				A requested amount of time in seconds to extend the lease.
-				This is advisory.
-			</li>
-		</ul>
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">increment</span>
+        <span class="param-flags">optional</span>
+        A requested amount of time in seconds to extend the lease.
+        This is advisory.
+      </li>
+    </ul>
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>A secret structure.
-	</dd>
+  <dt>Returns</dt>
+  <dd>A secret structure.
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-revoke-prefix.html.md
+++ b/website/source/docs/http/sys-revoke-prefix.html.md
@@ -9,21 +9,21 @@ description: |-
 # /sys/revoke-prefix
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Revoke all secrets generated under a given prefix immediately.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Revoke all secrets generated under a given prefix immediately.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>PUT</dd>
+  <dt>Method</dt>
+  <dd>PUT</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/revoke-prefix/<path prefix>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/revoke-prefix/<path prefix>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>None</dd>
+  <dt>Parameters</dt>
+  <dd>None</dd>
 
-	<dt>Returns</dt>
-	<dd>A `204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>A `204` response code.
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-revoke.html.md
+++ b/website/source/docs/http/sys-revoke.html.md
@@ -9,21 +9,21 @@ description: |-
 # /sys/revoke
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Revoke a secret immediately.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Revoke a secret immediately.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>PUT</dd>
+  <dt>Method</dt>
+  <dd>PUT</dd>
 
-	<dt>URL</dt>
-	<dd>`/sys/revoke/<lease id>`</dd>
+  <dt>URL</dt>
+  <dd>`/sys/revoke/<lease id>`</dd>
 
-	<dt>Parameters</dt>
-	<dd>None</dd>
+  <dt>Parameters</dt>
+  <dd>None</dd>
 
-	<dt>Returns</dt>
-	<dd>A `204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>A `204` response code.
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-seal-status.html.md
+++ b/website/source/docs/http/sys-seal-status.html.md
@@ -9,29 +9,31 @@ description: |-
 # /sys/seal-status
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Returns the seal status of the Vault.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Returns the seal status of the Vault.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>GET</dd>
+  <dt>Method</dt>
+  <dd>GET</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>The "t" parameter is the threshold, and "n" is the number of shares.
+  <dt>Returns</dt>
+  <dd>
+    The "t" parameter is the threshold, and "n" is the number of shares.
 
-```
-{
-	"sealed": true,
-	"t": 3,
-	"n": 5,
-	"progress": 2
-}
-```
-	</dd>
+    ```javascript
+    {
+      "sealed": true,
+      "t": 3,
+      "n": 5,
+      "progress": 2
+    }
+    ```
+
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-seal.html.md
+++ b/website/source/docs/http/sys-seal.html.md
@@ -9,20 +9,20 @@ description: |-
 # /sys/seal
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Seals the Vault.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Seals the Vault.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>PUT</dd>
+  <dt>Method</dt>
+  <dd>PUT</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		None
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
 
-	<dt>Returns</dt>
-	<dd>A `204` response code.
-	</dd>
+  <dt>Returns</dt>
+  <dd>A `204` response code.
+  </dd>
 </dl>

--- a/website/source/docs/http/sys-unseal.html.md
+++ b/website/source/docs/http/sys-unseal.html.md
@@ -9,33 +9,33 @@ description: |-
 # /sys/unseal
 
 <dl>
-	<dt>Description</dt>
-	<dd>
-		Enter a single master key share to progress the unsealing of the Vault.
-		If the threshold number of master key shares is reached, Vault
-		will attempt to unseal the Vault. Otherwise, this API must be
-		called multiple times until that threshold is met.
-	</dd>
+  <dt>Description</dt>
+  <dd>
+    Enter a single master key share to progress the unsealing of the Vault.
+    If the threshold number of master key shares is reached, Vault
+    will attempt to unseal the Vault. Otherwise, this API must be
+    called multiple times until that threshold is met.
+  </dd>
 
-	<dt>Method</dt>
-	<dd>PUT</dd>
+  <dt>Method</dt>
+  <dd>PUT</dd>
 
-	<dt>Parameters</dt>
-	<dd>
-		<ul>
-			<li>
-				<span class="param">secret_shares</span>
-				<span class="param-flags">required</span>
-				The number of shares to split the master key into.
-			</li>
-			<li>
-				<span class="param">key</span>
-				<span class="param-flags">required</span>
-				A single master share key.
-			</li>
-		</ul>
-	</dd>
-	<dt>Returns</dt>
-	<dd>The same result as `/sys/seal-status`.
-	</dd>
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">secret_shares</span>
+        <span class="param-flags">required</span>
+        The number of shares to split the master key into.
+      </li>
+      <li>
+        <span class="param">key</span>
+        <span class="param-flags">required</span>
+        A single master share key.
+      </li>
+    </ul>
+  </dd>
+  <dt>Returns</dt>
+  <dd>The same result as `/sys/seal-status`.
+  </dd>
 </dl>

--- a/website/source/docs/internals/architecture.html.md
+++ b/website/source/docs/internals/architecture.html.md
@@ -155,4 +155,3 @@ This has been a brief high-level overview of the architecture of Vault. There
 are more details available for each of the sub-systems.
 
 For other details, either consult the code, ask in IRC or reach out to the mailing list.
-

--- a/website/source/docs/internals/high-availability.html.md
+++ b/website/source/docs/internals/high-availability.html.md
@@ -47,4 +47,3 @@ then one of the standbys will take over and become the active instance.
 It is important to note that only _unsealed_ servers act as a standby.
 If a server is still in the sealed state, then it cannot act as a standby
 as it would be unable to serve any requests should the active server fail.
-

--- a/website/source/docs/internals/security.html.md
+++ b/website/source/docs/internals/security.html.md
@@ -146,5 +146,3 @@ prohibitively time consuming. Opening the bank vault requires two-factors: the k
 Similarly, Vault requires multiple shares be provided to reconstruct the master key.
 Once unsealed, each security deposit boxes still requires the owner provide a key, and similarly
 the Vault ACL system protects all the secrets stored.
-
-

--- a/website/source/docs/internals/telemetry.html.md
+++ b/website/source/docs/internals/telemetry.html.md
@@ -46,4 +46,3 @@ Below is sample output of a telemetry dump:
 [2015-04-20 12:24:30 -0700 PDT][S] 'vault.core.handle_request': Count: 2 Min: 0.097 Mean: 0.228 Max: 0.359 Stddev: 0.186 Sum: 0.457
 [2015-04-20 12:24:30 -0700 PDT][S] 'vault.expire.register': Count: 1 Sum: 0.18
 ```
-

--- a/website/source/docs/internals/token.html.md
+++ b/website/source/docs/internals/token.html.md
@@ -51,4 +51,3 @@ a use count of one makes a _one time token_. This means the token can be used
 for a single request before being automatically revoked. This can be generalized
 to any number of uses. Limited use tokens cannot be used to create sub-tokens,
 but they can be a powerful way to allow extremely limited access to Vault.
-

--- a/website/source/docs/modules/create.html.markdown
+++ b/website/source/docs/modules/create.html.markdown
@@ -28,9 +28,9 @@ Within a folder containing Vault configurations, create a subfolder
 the root folder containing the "child" folder, add this to one of the
 Vault files:
 
-```
+```javascript
 module "child" {
-	source = "./child"
+  source = "./child"
 }
 ```
 
@@ -54,11 +54,11 @@ variables or outputs.
 
 In the "child" module we created above, add the following:
 
-```
+```javascript
 variable "memory" {}
 
 output "received" {
-	value = "${var.memory}"
+  value = "${var.memory}"
 }
 ```
 
@@ -67,15 +67,15 @@ that will simply be the value of the memory variable.
 
 You can then configure the module and use the output like so:
 
-```
+```javascript
 module "child" {
-	source = "./child"
+  source = "./child"
 
-	memory = "1G"
+  memory = "1G"
 }
 
 output "child_memory" {
-	value = "${module.child.received}"
+  value = "${module.child.received}"
 }
 ```
 
@@ -98,13 +98,13 @@ the [path interpolated variables](/docs/configuration/interpolation.html).
 
 An example is shown below:
 
-```
+```javascript
 resource "aws_instance" "server" {
-	...
+  ...
 
-	provisioner "remote-exec" {
-		script = "${path.module}/script.sh"
-	}
+  provisioner "remote-exec" {
+    script = "${path.module}/script.sh"
+  }
 }
 ```
 

--- a/website/source/docs/modules/sources.html.markdown
+++ b/website/source/docs/modules/sources.html.markdown
@@ -40,9 +40,9 @@ for example.
 
 An example is shown below:
 
-```
+```javascript
 module "consul" {
-	source = "./consul"
+  source = "./consul"
 }
 ```
 
@@ -56,17 +56,17 @@ automatically instantly available.
 Vault will automatically recognize GitHub URLs and turn them into
 the proper Git repository. The syntax is simple:
 
-```
+```javascript
 module "consul" {
-	source = "github.com/hashicorp/example"
+  source = "github.com/hashicorp/example"
 }
 ```
 
 Subdirectories within the repository can also be referenced:
 
-```
+```javascript
 module "consul" {
-	source = "github.com/hashicorp/example//subdir"
+  source = "github.com/hashicorp/example//subdir"
 }
 ```
 
@@ -86,17 +86,17 @@ Git repositories for more information.
 Vault will automatically recognize BitBucket URLs and turn them into
 the proper Git or Mercurial repository. An example:
 
-```
+```javascript
 module "consul" {
-	source = "bitbucket.org/hashicorp/example"
+  source = "bitbucket.org/hashicorp/example"
 }
 ```
 
 Subdirectories within the repository can also be referenced:
 
-```
+```javascript
 module "consul" {
-	source = "bitbucket.org/hashicorp/example//subdir"
+  source = "bitbucket.org/hashicorp/example//subdir"
 }
 ```
 
@@ -113,9 +113,9 @@ Generic Git repositories are also supported. The value of `source` in this
 case should be a complete Git-compatible URL. Using Git requires that
 Git is installed on your system. Example:
 
-```
+```javascript
 module "consul" {
-	source = "git://hashicorp.com/module.git"
+  source = "git://hashicorp.com/module.git"
 }
 ```
 
@@ -123,9 +123,9 @@ You can also use protocols such as HTTP or SSH, but you'll have to hint
 to Vault (using the forced source type syntax documented below) to use
 Git:
 
-```
+```javascript
 module "consul" {
-	source = "git::https://hashicorp.com/module.git"
+  source = "git::https://hashicorp.com/module.git"
 }
 ```
 
@@ -136,9 +136,9 @@ parameters:
 
 An example of using these parameters is shown below:
 
-```
+```javascript
 module "consul" {
-	source = "git::https://hashicorp.com/module.git?ref=master"
+  source = "git::https://hashicorp.com/module.git?ref=master"
 }
 ```
 
@@ -148,9 +148,9 @@ Generic Mercurial repositories are supported. The value of `source` in this
 case should be a complete Mercurial-compatible URL. Using Mercurial requires that
 Mercurial is installed on your system. Example:
 
-```
+```javascript
 module "consul" {
-	source = "hg::http://hashicorp.com/module.hg"
+  source = "hg::http://hashicorp.com/module.hg"
 }
 ```
 
@@ -191,9 +191,9 @@ one way or the other.
 
 Example:
 
-```
+```javascript
 module "consul" {
-	source = "git::http://hashicorp.com/foo.git"
+  source = "git::http://hashicorp.com/foo.git"
 }
 ```
 

--- a/website/source/docs/modules/usage.html.markdown
+++ b/website/source/docs/modules/usage.html.markdown
@@ -9,10 +9,10 @@ description: Using modules in Vault is very similar to defining resources.
 
 Using modules in Vault is very similar to defining resources:
 
-```
+```javascript
 module "consul" {
-	source = "github.com/hashicorp/consul/vault/aws"
-	servers = 3
+  source = "github.com/hashicorp/consul/vault/aws"
+  servers = 3
 }
 ```
 
@@ -65,11 +65,11 @@ Modules can also specify their own [outputs](/docs/configuration/outputs.html).
 These outputs can be referenced in other places in your configuration.
 For example:
 
-```
+```javascript
 resource "aws_instance" "client" {
-	ami = "ami-123456"
-	instance_type = "m1.small"
-	availability_zone = "${module.consul.server_availability_zone}"
+  ami = "ami-123456"
+  instance_type = "m1.small"
+  availability_zone = "${module.consul.server_availability_zone}"
 }
 ```
 

--- a/website/source/docs/plugins/basics.html.md
+++ b/website/source/docs/plugins/basics.html.md
@@ -50,9 +50,9 @@ are defined is `~/.vaultrc` for Unix-like systems and
 
 An example that configures a new provider is shown below:
 
-```
+```javascript
 providers {
-	privatecloud = "/path/to/privatecloud"
+  privatecloud = "/path/to/privatecloud"
 }
 ```
 
@@ -83,15 +83,15 @@ the road.
 With the directory made, create a `main.go` file. This project will
 be a binary so the package is "main":
 
-```
+```go
 package main
 
 import (
-	"github.com/hashicorp/vault/plugin"
+  "github.com/hashicorp/vault/plugin"
 )
 
 func main() {
-	plugin.Serve(new(MyPlugin))
+  plugin.Serve(new(MyPlugin))
 }
 ```
 

--- a/website/source/docs/plugins/provider.html.md
+++ b/website/source/docs/plugins/provider.html.md
@@ -70,11 +70,11 @@ This structure implements the `ResourceProvider` interface. We
 recommend creating this structure in a function to make testing easier
 later. Example:
 
-```
+```go
 func Provider() *schema.Provider {
-	return &schema.Provider{
-		...
-	}
+  return &schema.Provider{
+    ...
+  }
 }
 ```
 
@@ -100,11 +100,11 @@ As part of the unit tests, you should call `InternalValidate`. This is used
 to verify the structure of the provider and all of the resources, and reports
 an error if it is invalid. An example test is shown below:
 
-```
+```go
 func TestProvider(t *testing.T) {
-	if err := Provider().InternalValidate(); err != nil {
-		t.Fatalf("err: %s", err)
-	}
+  if err := Provider().InternalValidate(); err != nil {
+    t.Fatalf("err: %s", err)
+  }
 }
 ```
 
@@ -118,11 +118,11 @@ These resources are put into the `ResourcesMap` field of the provider
 structure. Again, we recommend creating functions to instantiate these.
 An example is shown below.
 
-```
+```go
 func resourceComputeAddress() *schema.Resource {
-	return &schema.Resource {
-		...
-	}
+  return &schema.Resource {
+    ...
+  }
 }
 ```
 
@@ -202,35 +202,35 @@ subsequent `vault apply` fixes this resource.
 Most of the time, partial state is not required. When it is, it must be
 specifically enabled. An example is shown below:
 
-<pre class="prettyprint">
+```go
 func resourceUpdate(d *schema.ResourceData, meta interface{}) error {
-	// Enable partial state mode
-	d.Partial(true)
+  // Enable partial state mode
+  d.Partial(true)
 
-	if d.HasChange("tags") {
-		// If an error occurs, return with an error,
-		// we didn't finish updating
-		if err := updateTags(d, meta); err != nil {
-			return err
-		}
+  if d.HasChange("tags") {
+    // If an error occurs, return with an error,
+    // we didn't finish updating
+    if err := updateTags(d, meta); err != nil {
+      return err
+    }
 
-		d.SetPartial("tags")
-	}
+    d.SetPartial("tags")
+  }
 
-	if d.HasChange("name") {
-		if err := updateName(d, meta); err != nil {
-			return err
-		}
+  if d.HasChange("name") {
+    if err := updateName(d, meta); err != nil {
+      return err
+    }
 
-		d.SetPartial("name")
-	}
+    d.SetPartial("name")
+  }
 
-	// We succeeded, disable partial mode
-	d.Partial(false)
+  // We succeeded, disable partial mode
+  d.Partial(false)
 
-	return nil
+  return nil
 }
-</pre>
+```
 
 In the example above, it is possible that setting the `tags` succeeds,
 but setting the `name` fails. In this scenario, we want to make sure

--- a/website/source/docs/provisioners/connection.html.markdown
+++ b/website/source/docs/provisioners/connection.html.markdown
@@ -20,15 +20,15 @@ subsequent provisioners connect as a user with more limited permissions.
 
 ## Example usage
 
-```
+```javascript
 # Copies the file as the root user using a password
 provisioner "file" {
-    source = "conf/myapp.conf"
-    destination = "/etc/myapp.conf"
-    connection {
-        user = "root"
-        password = "${var.root_password}"
-    }
+  source = "conf/myapp.conf"
+  destination = "/etc/myapp.conf"
+  connection {
+    user = "root"
+    password = "${var.root_password}"
+  }
 }
 ```
 
@@ -52,4 +52,3 @@ The following arguments are supported:
 
 * `timeout` - The timeout to wait for the connection to become available. This defaults
    to 5 minutes. Should be provided as a string like "30s" or "5m".
-

--- a/website/source/docs/provisioners/file.html.markdown
+++ b/website/source/docs/provisioners/file.html.markdown
@@ -14,21 +14,21 @@ supports `ssh` type [connections](/docs/provisioners/connection.html).
 
 ## Example usage
 
-```
+```javascript
 resource "aws_instance" "web" {
-    ...
+  ...
 
-    # Copies the myapp.conf file to /etc/myapp.conf
-    provisioner "file" {
-        source = "conf/myapp.conf"
-        destination = "/etc/myapp.conf"
-    }
+  # Copies the myapp.conf file to /etc/myapp.conf
+  provisioner "file" {
+    source = "conf/myapp.conf"
+    destination = "/etc/myapp.conf"
+  }
 
-    # Copies the configs.d folder to /etc/configs.d
-    provisioner "file" {
-        source = "conf/configs.d"
-        destination = "/etc"
-    }
+  # Copies the configs.d folder to /etc/configs.d
+  provisioner "file" {
+    source = "conf/configs.d"
+    destination = "/etc"
+  }
 }
 ```
 
@@ -63,4 +63,3 @@ If the source, however, is `/foo/` (a trailing slash is present), and the destin
 
 This behavior was adopted from the standard behavior of rsync. Note that under the covers,
 rsync may or may not be used.
-

--- a/website/source/intro/getting-started/acl.html.md
+++ b/website/source/intro/getting-started/acl.html.md
@@ -29,17 +29,17 @@ Policies in Vault are formatted with
 format that is also JSON-compatible, so you can use JSON as well. An example
 policy is shown below:
 
-```
+```javascript
 path "sys" {
-	policy = "deny"
+  policy = "deny"
 }
 
 path "secret" {
-	policy = "write"
+  policy = "write"
 }
 
 path "secret/foo" {
-	policy = "read"
+  policy = "read"
 }
 ```
 

--- a/website/source/intro/getting-started/deploy.html.md
+++ b/website/source/intro/getting-started/deploy.html.md
@@ -22,15 +22,15 @@ Vault is configured using [HCL](https://github.com/hashicorp/hcl) files.
 As a reminder, these files are also JSON-compatible. The configuration
 file for Vault is relatively simple. An example is shown below:
 
-```
+```javascript
 backend "consul" {
-    address = "demo.consul.io:80"
-    path = "vault"
+  address = "demo.consul.io:80"
+  path = "vault"
 }
 
 listener "tcp" {
-   address = "127.0.0.1:8200"
-   tls_disable = 1
+ address = "127.0.0.1:8200"
+ tls_disable = 1
 }
 ```
 

--- a/website/source/intro/getting-started/dynamic-secrets.html.md
+++ b/website/source/intro/getting-started/dynamic-secrets.html.md
@@ -81,21 +81,21 @@ The AWS backend requires an IAM policy to associate created credentials
 with. For this example, we'll write just one policy, but you can associate
 many policies with the backend. Save a file named "policy.json" with the following contents:
 
-```
+```javascript
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "Stmt1426528957000",
-            "Effect": "Allow",
-            "Action": [
-                "ec2:*"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Stmt1426528957000",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
 }
 ```
 
@@ -119,10 +119,10 @@ special path `aws/<NAME>` where `NAME` is the policy name:
 
 ```
 $ vault read aws/deploy
-Key       	Value
+Key         Value
 lease_id    aws/deploy/0d042c53-aa8a-7ce7-9dfd-310351c465e5
-access_key	AKIAJFN42DVCQWDHQYHQ
-secret_key	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
+access_key  AKIAJFN42DVCQWDHQYHQ
+secret_key  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
 ```
 
 Success! The access and secret key can now be used to perform any EC2

--- a/website/source/intro/getting-started/first-secret.html.md
+++ b/website/source/intro/getting-started/first-secret.html.md
@@ -57,9 +57,9 @@ As you might expect, secrets can be read with `vault read`:
 
 ```
 $ vault read secret/hello
-Key     	Value
-excited 	yes
-value   	world
+Key       Value
+excited   yes
+value     world
 ```
 
 As you can see, the values we wrote are given back to us. Vault read
@@ -73,12 +73,12 @@ a tool like `jq`, you can output the data in JSON format:
 ```
 $ vault read -format=json secret/hello
 {
-	"renewable": false,
-	"lease_duration": 2592000,
-	"data": {
-		"excited": "yes",
-		"value": "world"
-	}
+  "renewable": false,
+  "lease_duration": 2592000,
+  "data": {
+    "excited": "yes",
+    "value": "world"
+  }
 }
 ```
 


### PR DESCRIPTION
It really bugged me that the JSON was not being rendered with the proper indentation. This involved a fix in middleman-hashicorp, but also needed some updating in Vault.

@mitchellh middleman-hashicorp does not like when you use tabs instead of spaces. Redcarpet's markdown parser is :panda_face: when it gets a tab.

![screen shot 2015-04-22 at 7 49 52 pm](https://cloud.githubusercontent.com/assets/408570/7287948/c41c987a-e928-11e4-8185-ee3d1c0ff1fe.png)

![screen shot 2015-04-22 at 7 49 36 pm](https://cloud.githubusercontent.com/assets/408570/7287949/c4222c9a-e928-11e4-9f88-498bc6b39957.png)
