### PR TITLE
Website learn more links

### DIFF
--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -46,7 +46,7 @@
 					Vault encrypts and provides access to any secrets. Leases can be associated with secrets, and Vault will automatically revoke secrets after the lease period ends. Access control policies provide strict control over who can access what secrets.
 					</p>
 					<div class="feature-footer">
-						<a class="v-btn black sml" href="/intro">Learn more</a>
+						<a class="v-btn black sml" href="/intro/use-cases.html">Learn more</a>
 					</div>
 				</div> <!-- .feature -->
 
@@ -56,7 +56,7 @@
 					<p>
 						Every secret in Vault is associated with a lease. Clients must renew their secret within the lease period, or request a new secret. Key rolling is as simple as storing a new secret and revoking existing secrets or waiting for the lease period to expire.
 						<div class="feature-footer">
-							<a class="v-btn black sml" href="/intro">Learn more</a>
+							<a class="v-btn black sml" href="/docs/concepts/lease.html">Learn more</a>
 						</div>
 					</p>
 				</div> <!-- .feature -->
@@ -67,7 +67,7 @@
 					<p>
 					Vault stores a detailed audit log of every interaction: authentication, token creation, secret access, secret revocation, and more. Audit logs can be sent to multiple backends to ensure redundant copies. Paired with Vault's strict leasing policies, operators can easily trace back to the source of any secret.
 						<div class="feature-footer">
-							<a class="v-btn black sml" href="/intro">Learn more</a>
+							<a class="v-btn black sml" href="/docs/audit/index.html">Learn more</a>
 						</div>
 					</p>
 				</div> <!-- .feature -->


### PR DESCRIPTION
This switches the "learn more" links to deep link into relevant docs, instead of just landing on the intro. The intro is linked in several other notable places.

cc/ @mitchellh
