### PR TITLE
vault: restrict mlockall to just linux for now. Fixes #31

### DIFF
--- a/vault/mlock_avail.go
+++ b/vault/mlock_avail.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd openbsd solaris
+// +build linux
 
 package vault
 

--- a/vault/mlock_unavail.go
+++ b/vault/mlock_unavail.go
@@ -1,4 +1,4 @@
-// +build windows plan9
+// +build windows plan9 darwin freebsd openbsd solaris
 
 package vault
 


### PR DESCRIPTION
cc: @sethvargo 

We should enable this for different operating systems over time as we can vet it.
