### PR TITLE
Fix url to point to correct vault domain

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # Vault Website
 
-This subdirectory contains the entire source for the [Vault Website](http://www.vault.io).
+This subdirectory contains the entire source for the [Vault Website](https://vaultproject.io/).
 This is a [Middleman](http://middlemanapp.com) project, which builds a static
 site from these source files.
 


### PR DESCRIPTION
Old url doesn't go to the right place in the `Readme.md`.  Corrected to point to the actual vaultproject.io url