### PR TITLE
Makefile: don't vet Godeps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,13 @@ vet:
 	@go tool vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
 		go get golang.org/x/tools/cmd/vet; \
 	fi
-	@echo "go tool vet $(VETARGS) ."
-	@go tool vet $(VETARGS) . ; if [ $$? -eq 1 ]; then \
-		echo ""; \
-		echo "Vet found suspicious constructs. Please check the reported constructs"; \
-		echo "and fix them if necessary before submitting the code for reviewal."; \
-	fi
+	@go list -f '{{.Dir}}' ./... \
+		| grep -v '.*github.com/hashicorp/vault$$' \
+		| xargs go tool vet ; if [ $$? -eq 1 ]; then \
+			echo ""; \
+			echo "Vet found suspicious constructs. Please check the reported constructs"; \
+			echo "and fix them if necessary before submitting the code for reviewal."; \
+		fi
 
 # generate runs `go generate` to build the dynamically generated
 # source files.


### PR DESCRIPTION
Only vet the actual vault package directories; skip the Godeps directory.