### PR TITLE
Check for invalid token when authing via cli

### DIFF
--- a/command/auth.go
+++ b/command/auth.go
@@ -151,6 +151,10 @@ func (c *AuthCommand) Run(args []string) int {
 			"Error validating token: %s", err))
 		return 1
 	}
+	if secret == nil {
+		c.Ui.Error(fmt.Sprintf("Error: Invalid token"))
+		return 1
+	}
 
 	// Get the policies we have
 	policiesRaw, ok := secret.Data["policies"]

--- a/command/auth_test.go
+++ b/command/auth_test.go
@@ -82,6 +82,29 @@ func TestAuth_token(t *testing.T) {
 	}
 }
 
+func TestAuth_badToken(t *testing.T) {
+	core, _, _ := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	testAuthInit(t)
+
+	ui := new(cli.MockUi)
+	c := &AuthCommand{
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	args := []string{
+		"-address", addr,
+		"not-a-valid-token",
+	}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
 func TestAuth_method(t *testing.T) {
 	core, _, token := vault.TestCoreUnsealed(t)
 	ln, addr := http.TestServer(t, core)


### PR DESCRIPTION
If a token does not exist, the Read request returns without an error, but the secret returned is `nil`, so we need to check for that.

Fixes #75