### PR TITLE
Update output of `vault status` [ci skip]

### DIFF
--- a/website/source/intro/getting-started/dev-server.html.md
+++ b/website/source/intro/getting-started/dev-server.html.md
@@ -93,6 +93,8 @@ Sealed: false
 Key Shares: 1
 Key Threshold: 1
 Unseal Progress: 0
+
+High-Availability Enabled: false
 ```
 
 If the output looks different, especially if the numbers are different


### PR DESCRIPTION
Just followed the getting started guide and the output of `vault status` has one more line `High-Availability Enabled: false`.