### PR TITLE
Added Gox install to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,12 @@ the appropriate dev tooling already set up for you.
 
 For local dev first make sure Go is properly installed, including setting up a
 [GOPATH](https://golang.org/doc/code.html#GOPATH). After setting up Go,
-install Godeps, a tool we use for vendoring dependencies:
+install Godeps, a tool we use for vendoring dependencies and Gox, a simple cross
+compilation tool:
 
 ```sh
 $ go get github.com/tools/godep
+$ go get github.com/mitchellh/gox
 ...
 ```
 


### PR DESCRIPTION
# What was the problem?
The README.md guide to set up the dev environment for vault missed the step to `go get` gox. Therefore if gox was not present, the `make dev` command exited with error: 
```bash
vault $ make dev
go generate ./...
==> Getting dependencies...
==> Removing old directory...
==> Building...
/home/gulyasm/gocode/src/github.com/hashicorp/vault/scripts/build.sh: line 41: gox: command not found
make: *** [dev] Error 127
```

# What it solves
Added gox install step to README.md for clarification.

# Risks
None, only the README.md was modified.