### PR TITLE
Fixes #83 (wrong SetConsoleMode import)

### DIFF
--- a/helper/password/password_windows.go
+++ b/helper/password/password_windows.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	kernel32           = syscall.MustLoadDLL("kernel32.dll")
-	setConsoleModeProc = kernel32.MustFindProc("SetConsoleMod")
+	setConsoleModeProc = kernel32.MustFindProc("SetConsoleMode")
 )
 
 // Magic constant from MSDN to control whether charactesr read are


### PR DESCRIPTION
This pull request fixes issue #83 by using the correct kernel32 import (SetConsoleMode instead of SetConsoleMod)