### PR TITLE
Add output of reading aws/config/root to the docs

### DIFF
--- a/website/source/intro/getting-started/dynamic-secrets.html.md
+++ b/website/source/intro/getting-started/dynamic-secrets.html.md
@@ -65,7 +65,12 @@ later. Notice you can't read it back:
 
 ```
 $ vault read aws/config/root
-TODO
+Error reading aws/config/root: Error making API request.
+
+URL: GET http://127.0.0.1:8200/v1/aws/config/root
+Code: 500. Errors:
+
+* unsupported operation
 ```
 
 To help keep the credentials secure, the AWS backend doesn't let you


### PR DESCRIPTION
Replace "TODO" with the current command-line output from the Vault dev server.