### PR TITLE
Attempt advertise address detection

### DIFF
--- a/physical/consul.go
+++ b/physical/consul.go
@@ -132,6 +132,17 @@ func (c *ConsulBackend) LockWith(key, value string) (Lock, error) {
 	return cl, nil
 }
 
+// DetectHostAddr is used to detect the host address by asking the Consul agent
+func (c *ConsulBackend) DetectHostAddr() (string, error) {
+	agent := c.client.Agent()
+	self, err := agent.Self()
+	if err != nil {
+		return "", err
+	}
+	addr := self["Member"]["Addr"].(string)
+	return addr, nil
+}
+
 // ConsulLock is used to provide the Lock interface backed by Consul
 type ConsulLock struct {
 	client *api.Client

--- a/physical/consul_test.go
+++ b/physical/consul_test.go
@@ -43,4 +43,16 @@ func TestConsulBackend(t *testing.T) {
 		t.Fatalf("consul does not implement HABackend")
 	}
 	testHABackend(t, ha, ha)
+
+	detect, ok := b.(AdvertiseDetect)
+	if !ok {
+		t.Fatalf("consul does not implement AdvertiseDetect")
+	}
+	host, err := detect.DetectHostAddr()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if host == "" {
+		t.Fatalf("bad addr: %v", host)
+	}
 }

--- a/physical/physical.go
+++ b/physical/physical.go
@@ -32,6 +32,14 @@ type HABackend interface {
 	LockWith(key, value string) (Lock, error)
 }
 
+// AdvertiseDetect is an optional interface that an HABackend
+// can implement. If they do, an advertise address can be automatically
+// detected.
+type AdvertiseDetect interface {
+	// DetectHostAddr is used to detect the host address
+	DetectHostAddr() (string, error)
+}
+
 type Lock interface {
 	// Lock is used to acquire the given lock
 	// The stopCh is optional and if closed should interrupt the lock


### PR DESCRIPTION
This PR adds support for advertise address detection. This fixes #103. We should detect and provide a default, which can be overridden. 

/cc: @mitchellh 