### PR TITLE
Fix typo in docs: "it's" -> "its"

### DIFF
--- a/website/source/docs/internals/architecture.html.md
+++ b/website/source/docs/internals/architecture.html.md
@@ -63,7 +63,7 @@ clarify what is being discussed:
   Secrets always have an associated lease. This means clients cannot assume that the secret
   contents can be used indefinitely. Vault will revoke a secret at the end of the lease, and
   an operator may intervene to revoke the secret before the lease is over. This contract
-  between Vault and it's clients is critical, as it allows for changes in keys and policies
+  between Vault and its clients is critical, as it allows for changes in keys and policies
   without manual intervention.
 
 * **Server** - Vault depends on a long-running instance which operates as a server.

--- a/website/source/docs/internals/index.html.md
+++ b/website/source/docs/internals/index.html.md
@@ -9,7 +9,7 @@ description: |-
 # Vault Internals
 
 This section covers the internals of Vault and explains the technical
-details of how Vault functions, it's architecture and security properties.
+details of how Vault functions, its architecture and security properties.
 
 -> **Note:** Knowledge of Vault internals is not
 required to use Vault. If you aren't interested in the internals


### PR DESCRIPTION
Just a couple of small typos in the docs :)