### PR TITLE
Make the VAULT_TOKEN and VAULT_ADDR copy-pastable in dev mode

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -147,11 +147,13 @@ func (c *ServerCommand) Run(args []string) int {
 				"token has already been authenticated with the CLI, so you can\n"+
 				"immediately begin using the Vault CLI.\n\n"+
 				"The only step you need to take is to set the following\n"+
-				"environment variable since Vault will be talking without TLS:\n\n"+
-				"    export VAULT_ADDR='http://127.0.0.1:8200'\n\n"+
+				"environment variables:\n\n"+
+				"    export VAULT_ADDR='http://127.0.0.1:8200'\n"+
+				"    export VAULT_TOKEN='%s'\n\n"+
 				"The unseal key and root token are reproduced below in case you\n"+
 				"want to seal/unseal the Vault or play with authentication.\n\n"+
 				"Unseal Key: %s\nRoot Token: %s\n",
+			init.RootToken,
 			hex.EncodeToString(init.SecretShares[0]),
 			init.RootToken,
 		))


### PR DESCRIPTION
This allows someone to quickly start a dev mode server and hit the ground
running without the need to copy-paste twice.

```text
==> WARNING: Dev mode is enabled!

In this mode, Vault is completely in-memory and unsealed.
Vault is configured to only have a single unseal key. The root
token has already been authenticated with the CLI, so you can
immediately begin using the Vault CLI.

The only step you need to take is to set the following
environment variables:

    export VAULT_ADDR='http://127.0.0.1:8200'
    export VAULT_TOKEN='babddbdc-fdd4-1781-3ef9-f516da34a6cd'

The unseal key and root token are reproduced below in case you
want to seal/unseal the Vault or play with authentication.

Unseal Key: 46f0787fa6185b405646222386c88eedca7f9b34f393023b1a1dc0839a664992
Root Token: babddbdc-fdd4-1781-3ef9-f516da34a6cd

==> Vault server configuration:

         Log Level: info
             Mlock: supported: false, enabled: false
           Backend: inmem
        Listener 1: tcp (addr: "127.0.0.1:8200", tls: "disabled")

==> Vault server started! Log data will stream in below:
```