### PR TITLE
credential/github: case insensitive mappings

### DIFF
--- a/builtin/credential/github/backend.go
+++ b/builtin/credential/github/backend.go
@@ -17,8 +17,7 @@ func Backend() *framework.Backend {
 	var b backend
 	b.Map = &framework.PolicyMap{
 		PathMap: framework.PathMap{
-			Name:            "teams",
-			CaseInsensitive: true,
+			Name: "teams",
 		},
 		DefaultKey: "default",
 	}

--- a/builtin/credential/github/backend.go
+++ b/builtin/credential/github/backend.go
@@ -16,7 +16,10 @@ func Factory(map[string]string) (logical.Backend, error) {
 func Backend() *framework.Backend {
 	var b backend
 	b.Map = &framework.PolicyMap{
-		PathMap:    framework.PathMap{Name: "teams"},
+		PathMap: framework.PathMap{
+			Name:            "teams",
+			CaseInsensitive: true,
+		},
 		DefaultKey: "default",
 	}
 	b.Backend = &framework.Backend{

--- a/builtin/credential/github/backend_test.go
+++ b/builtin/credential/github/backend_test.go
@@ -14,8 +14,9 @@ func TestBackend_basic(t *testing.T) {
 		Backend:  Backend(),
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
-			testAccMap(t),
-			testAccLogin(t),
+			testAccMap(t, "default", "foo"),
+			testAccMap(t, "oWnErs", "bar"),
+			testAccLogin(t, []string{"bar", "foo"}),
 		},
 	})
 }
@@ -40,17 +41,17 @@ func testAccStepConfig(t *testing.T) logicaltest.TestStep {
 	}
 }
 
-func testAccMap(t *testing.T) logicaltest.TestStep {
+func testAccMap(t *testing.T, k string, v string) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.WriteOperation,
-		Path:      "map/teams/default",
+		Path:      "map/teams/" + k,
 		Data: map[string]interface{}{
-			"value": "foo",
+			"value": v,
 		},
 	}
 }
 
-func testAccLogin(t *testing.T) logicaltest.TestStep {
+func testAccLogin(t *testing.T, keys []string) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.WriteOperation,
 		Path:      "login",
@@ -59,6 +60,6 @@ func testAccLogin(t *testing.T) logicaltest.TestStep {
 		},
 		Unauthenticated: true,
 
-		Check: logicaltest.TestCheckAuth([]string{"foo"}),
+		Check: logicaltest.TestCheckAuth(keys),
 	}
 }

--- a/logical/framework/path_map.go
+++ b/logical/framework/path_map.go
@@ -15,9 +15,10 @@ import (
 // The primary use case for this is for credential providers to do their
 // mapping to policies.
 type PathMap struct {
-	Prefix string
-	Name   string
-	Schema map[string]*FieldSchema
+	Prefix          string
+	Name            string
+	Schema          map[string]*FieldSchema
+	CaseInsensitive bool
 
 	once sync.Once
 }
@@ -40,6 +41,11 @@ func (p *PathMap) init() {
 // pathStruct returns the pathStruct for this mapping
 func (p *PathMap) pathStruct(k string) *PathStruct {
 	p.once.Do(p.init)
+
+	// If we don't care about casing, store everything lowercase
+	if p.CaseInsensitive {
+		k = strings.ToLower(k)
+	}
 
 	return &PathStruct{
 		Name:   fmt.Sprintf("map/%s/%s", p.Name, k),

--- a/logical/framework/path_map.go
+++ b/logical/framework/path_map.go
@@ -15,10 +15,10 @@ import (
 // The primary use case for this is for credential providers to do their
 // mapping to policies.
 type PathMap struct {
-	Prefix          string
-	Name            string
-	Schema          map[string]*FieldSchema
-	CaseInsensitive bool
+	Prefix        string
+	Name          string
+	Schema        map[string]*FieldSchema
+	CaseSensitive bool
 
 	once sync.Once
 }
@@ -43,7 +43,7 @@ func (p *PathMap) pathStruct(k string) *PathStruct {
 	p.once.Do(p.init)
 
 	// If we don't care about casing, store everything lowercase
-	if p.CaseInsensitive {
+	if !p.CaseSensitive {
 		k = strings.ToLower(k)
 	}
 

--- a/logical/framework/path_map_test.go
+++ b/logical/framework/path_map_test.go
@@ -46,6 +46,15 @@ func TestPathMap(t *testing.T) {
 		t.Fatalf("bad: %#v", v)
 	}
 
+	// Read via API with other casing
+	v, err = p.Get(storage, "A")
+	if err != nil {
+		t.Fatalf("bad: %#v", err)
+	}
+	if v["value"] != "bar" {
+		t.Fatalf("bad: %#v", v)
+	}
+
 	// Verify List
 	keys, err := p.List(storage, "")
 	if err != nil {


### PR DESCRIPTION
Fixes #163 

Making GitHub team mappings case insensitive. I actually think I'll default `PathMap` to be case insensitive, but I'll do that in a follow-up PR.