### PR TITLE
Fail gracefully if a physical backend is not supplied

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -75,6 +75,11 @@ func (c *ServerCommand) Run(args []string) int {
 		}
 	}
 
+	if config.Backend == nil {
+		c.Ui.Error("Error: A physical backend must be specified in the configuration")
+		return 1
+	}
+
 	// If mlock isn't supported, show a warning. We disable this in
 	// dev because it is quite scary to see when first using Vault.
 	if !dev && !mlock.Supported() {


### PR DESCRIPTION
I'd assume this is preferred over printing a stack trace due to misconfiguration.

I wasn't sure where I could add a test for this... if one is necessary just point me in the right direction and I'll add it to this branch.