### PR TITLE
HTTP should return 503 when sealed

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -147,6 +147,11 @@ func requestAuth(r *http.Request, req *logical.Request) *logical.Request {
 }
 
 func respondError(w http.ResponseWriter, status int, err error) {
+	// Adjust status code when sealed
+	if err == vault.ErrSealed {
+		status = http.StatusServiceUnavailable
+	}
+
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(status)
 

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -43,3 +43,17 @@ func TestSysMounts_headerAuth(t *testing.T) {
 		t.Fatalf("bad: %#v", actual)
 	}
 }
+
+func TestHandler_sealed(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+
+	core.Seal(token)
+
+	resp, err := http.Get(addr + "/v1/secret/foo")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	testResponseStatus(t, resp, 503)
+}


### PR DESCRIPTION
Attempts to address #213, assuming that this is the desired behavior.