### PR TITLE
terraform: allow SG rule customization

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -42,27 +42,35 @@ resource "aws_security_group" "vault" {
     name = "vault"
     description = "Vault servers"
     vpc_id = "${var.vpc-id}"
+}
 
-    ingress {
-        from_port = 22
-        to_port = 22
-        protocol = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
+resource "aws_security_group_rule" "vault-ssh" {
+    security_group_id = "${aws_security_group.vault.id}"
+    type = "ingress"
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+}
 
-    ingress {
-        from_port = 8200
-        to_port = 8200
-        protocol = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
+// This rule allows Vault HTTP API access to individual nodes, since each will
+// need to be addressed individually for unsealing.
+resource "aws_security_group_rule" "vault-http-api" {
+    security_group_id = "${aws_security_group.vault.id}"
+    type = "ingress"
+    from_port = 8200
+    to_port = 8200
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+}
 
-    egress {
-        from_port = 0
-        to_port = 0
-        protocol = "-1"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
+resource "aws_security_group_rule" "vault-egress" {
+    security_group_id = "${aws_security_group.vault.id}"
+    type = "egress"
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
 }
 
 // Launch the ELB that is serving Vault. This has proper health checks
@@ -102,25 +110,31 @@ resource "aws_security_group" "elb" {
     name = "vault-elb"
     description = "Vault ELB"
     vpc_id = "${var.vpc-id}"
+}
 
-    ingress {
-        from_port = 80
-        to_port = 80
-        protocol = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
+resource "aws_security_group_rule" "vault-elb-http" {
+    security_group_id = "${aws_security_group.elb.id}"
+    type = "ingress"
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+}
 
-    ingress {
-        from_port = 443
-        to_port = 443
-        protocol = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
+resource "aws_security_group_rule" "vault-elb-https" {
+    security_group_id = "${aws_security_group.elb.id}"
+    type = "ingress"
+    from_port = 443
+    to_port = 443
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+}
 
-    egress {
-        from_port = 0
-        to_port = 0
-        protocol = "-1"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
+resource "aws_security_group_rule" "vault-elb-egress" {
+    security_group_id = "${aws_security_group.elb.id}"
+    type = "egress"
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
 }

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,3 +1,13 @@
 output "address" {
     value = "${aws_elb.vault.dns_name}"
 }
+
+// Can be used to add additional SG rules to Vault instances.
+output "vault_security_group" {
+    value = "${aws_security_group.vault.id}"
+}
+
+// Can be used to add additional SG rules to the Vault ELB.
+output "elb_security_group" {
+    value = "${aws_security_group.elb.id}"
+}


### PR DESCRIPTION
Switches SG rules to from nested to top-level resources and exports the
SG ids so that users of the module can define additional rules for their
Vault instances and/or the Vault ELB.

While this change should be backwards compatible, applying the new rules
might result in a very brief interruption of Vault service as:

 (1) Old nested-resource SG rules are cleared
 (2) New SG rules are applied one by one