### PR TITLE
Document that Vault Server needs to be running for vault help path

### DIFF
--- a/website/source/docs/commands/help.html.md
+++ b/website/source/docs/commands/help.html.md
@@ -19,7 +19,8 @@ in Vault, and also allows you to discover new paths.
 -> **Important!** The help system is incredibly important in day-to-day
 use of Vault. As a beginner or experienced user of Vault, you'll be using
 the help command a lot to remember how to use different components of
-Vault.
+Vault. Note that the Vault Server must be running and the client configured
+properly to execute this command to look up paths. 
 
 ## Discovering Paths
 


### PR DESCRIPTION
Confused initially, I tried running `vault help secret` by itself and found out that the server needs to be running to execute this command.

Furthermore, the client needs `VAULT_ADDR` configured (`http://127.0.0.1:8200` in dev mode, since it uses https by default) to interact with the server.