### PR TITLE
fix doc example to submit valid json in POST body

### DIFF
--- a/website/source/docs/auth/userpass.html.md
+++ b/website/source/docs/auth/userpass.html.md
@@ -35,7 +35,7 @@ The password should be sent in the POST body encoded as JSON.
 
 ```shell
 $ curl $VAULT_ADDR/v1/auth/userpass/login/mitchellh \
-    -d "password=foo"
+    -d '{"password: "foo"}'
 ```
 
 The response will be in JSON. For example:


### PR DESCRIPTION
I don't know if there is some version of curl that auto-generates json but the example didn't work for me on curl 7.32.0. Submitting the data as JSON works though.