### PR TITLE
Read from stdin with auth command

### DIFF
--- a/command/auth.go
+++ b/command/auth.go
@@ -1,7 +1,9 @@
 package command
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -63,6 +65,17 @@ func (c *AuthCommand) Run(args []string) int {
 
 	// token is where the final token will go
 	handler := c.Handlers[method]
+
+	if len(args) > 0 && args[0] == "-" {
+		stdin := bufio.NewReader(os.Stdin)
+		args[0], err = stdin.ReadString('\n')
+		if err != nil && err != io.EOF {
+			c.Ui.Error(fmt.Sprintf("Error reading from stdin: %s", err))
+			return 1
+		}
+		args[0] = strings.TrimSpace(args[0])
+	}
+
 	if method == "" {
 		token := ""
 		if len(args) > 0 {


### PR DESCRIPTION
Fixes #233.

I'm not sure if reading just one line is sufficient here, but I tested it with multiple auth methods and it seems to cover everything.

``` bash
$ echo -n "e8eb1fda-dead-6113-beef-521ed44b2ceb" | vault auth  -
Successfully authenticated! The policies that are associated
with this token are listed below:

godmode
```