### PR TITLE
Prompt for auth token when no args provided

### DIFF
--- a/command/auth.go
+++ b/command/auth.go
@@ -44,11 +44,6 @@ func (c *AuthCommand) Run(args []string) int {
 	}
 
 	args = flags.Args()
-	if method == "" && len(args) < 1 {
-		flags.Usage()
-		c.Ui.Error("\nError: auth expects at least one argument")
-		return 1
-	}
 
 	tokenHelper, err := c.TokenHelper()
 	if err != nil {


### PR DESCRIPTION
This commit (along with #250) makes `vault auth` work as documented:

> If no -method is specified, then the token is expected. If it is not
> given on the command-line, it will be asked via user input. If the
> token is "-", it will be read from stdin.

Removing this check allows for the tokenAuthHandler's Auth method to handle prompting the user for their token.

``` bash
$ vault auth
Token (will be hidden):
Successfully authenticated! The policies that are associated
with this token are listed below:

godmode
```