### PR TITLE
Add ability to configure consul lease durations

### DIFF
--- a/builtin/logical/consul/secret_token.go
+++ b/builtin/logical/consul/secret_token.go
@@ -7,7 +7,11 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
-const SecretTokenType = "token"
+const (
+	SecretTokenType      = "token"
+	DefaultLeaseDuration = 1 * time.Hour
+	DefaultGracePeriod   = 10 * time.Minute
+)
 
 func secretToken() *framework.Secret {
 	return &framework.Secret{
@@ -19,8 +23,8 @@ func secretToken() *framework.Secret {
 			},
 		},
 
-		DefaultDuration:    1 * time.Hour,
-		DefaultGracePeriod: 10 * time.Minute,
+		DefaultDuration:    DefaultLeaseDuration,
+		DefaultGracePeriod: DefaultGracePeriod,
 
 		Renew:  framework.LeaseExtend(1*time.Hour, 0),
 		Revoke: secretTokenRevoke,

--- a/website/source/docs/secrets/consul/index.html.md
+++ b/website/source/docs/secrets/consul/index.html.md
@@ -143,6 +143,11 @@ Permission denied
         <span class="param-flags">required</span>
         The base64 encoded Consul ACL policy. This is documented in [more detail here](https://consul.io/docs/internals/acl.html).
       </li>
+      <li>
+        <span class="param">lease</span>
+        <span class="param-flags">optional</span>
+        The lease value provided as a string duration with time suffix. Hour is the largest suffix.
+      </li>
     </ul>
   </dd>
 


### PR DESCRIPTION
Fixes #169.

Add a `lease` parameter to `PUT /consul/roles` to override the default lease period of 1 hour.

I'm seeing acceptance test failures in this same module as per #236, so this change hasn't introduced the regression.