### PR TITLE
Support for HTTP Response overwriting

### DIFF
--- a/logical/response.go
+++ b/logical/response.go
@@ -1,5 +1,24 @@
 package logical
 
+const (
+	// HTTPContentType can be specified in the Data field of a Response
+	// so that the HTTP front end can specify a custom Content-Type associated
+	// with the HTTPRawBody. This can only be used for non-secrets, and should
+	// be avoided unless absolutely necessary, such as implementing a specification.
+	// The value must be a string.
+	HTTPContentType = "http_content_type"
+
+	// HTTPRawBody is the raw content of the HTTP body that goes with the HTTPContentType.
+	// This can only be specified for non-secrets, and should should be similarly
+	// avoided like the HTTPContentType. The value must be a byte slice.
+	HTTPRawBody = "http_raw_body"
+
+	// HTTPStatusCode is the response code the HTTP body that goes with the HTTPContentType.
+	// This can only be specified for non-secrets, and should should be similarly
+	// avoided like the HTTPContentType. The value must be an integer.
+	HTTPStatusCode = "http_status_code"
+)
+
 // Response is a struct that stores the response of a request.
 // It is used to abstract the details of the higher level request protocol.
 type Response struct {


### PR DESCRIPTION
/cc: @jefferai 

This PR adds support for a logical backend to change the HTTP response structure to something custom. This should NOT be used broadly, but is required for certain features like returning a CRL response for TLS. In general, it should only be used when necessary for implementing an external specification, and not for general usage.