### PR TITLE
Use local Consul instance in deploy walkthrough

### DIFF
--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -14,7 +14,7 @@ An example configuration is shown below:
 
 ```javascript
 backend "consul" {
-  address = "demo.consul.io:80"
+  address = "127.0.0.1:8500"
   path = "vault"
 }
 

--- a/website/source/intro/getting-started/deploy.html.md
+++ b/website/source/intro/getting-started/deploy.html.md
@@ -24,7 +24,7 @@ file for Vault is relatively simple. An example is shown below:
 
 ```javascript
 backend "consul" {
-  address = "demo.consul.io:80"
+  address = "127.0.0.1:8500"
   path = "vault"
 }
 
@@ -45,14 +45,16 @@ Within the configuration file, there are two primary configurations:
     API requests. In the example above we're listening on localhost port
     8200 without TLS.
 
-For now, copy and paste the configuration above. Change the `path`
-for Consul to something unique for you to make sure you don't overlap
-with anyone else following this guide. We'll use this demo cluster to
-learn how to deploy Vault.
+For now, copy and paste the configuration above to `example.hcl`. It will
+configure Vault to expect an instance of Consul running locally.
 
-~> **Warning:** The demo consul cluster deletes its data every 30 minutes.
-If this happens while you're learning to use Vault, you'll lose your data.
-Just restart Vault and start over, knowing you have another 30 minutes.
+Starting a local Consul instance takes only a few minutes. Just follow the
+[Consul Getting Started Guide](https://www.consul.io/intro/getting-started/install.html)
+up to the point where you have installed Consul and started it with this command:
+
+```shell
+$ consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul
+```
 
 ## Starting the Server
 


### PR DESCRIPTION
As per hashicorp/vault#217, demo.consul.io prevents sessions from being
created, which means you can't use it as a backend for Vault.