### PR TITLE
Don't recommend exporting VAULT_TOKEN

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -155,11 +155,9 @@ func (c *ServerCommand) Run(args []string) int {
 				"The only step you need to take is to set the following\n"+
 				"environment variables:\n\n"+
 				"    export VAULT_ADDR='http://127.0.0.1:8200'\n"+
-				"    export VAULT_TOKEN='%s'\n\n"+
 				"The unseal key and root token are reproduced below in case you\n"+
 				"want to seal/unseal the Vault or play with authentication.\n\n"+
 				"Unseal Key: %s\nRoot Token: %s\n",
-			init.RootToken,
 			hex.EncodeToString(init.SecretShares[0]),
 			init.RootToken,
 		))


### PR DESCRIPTION
It's not needed by the dev server (which writes ~/.vault-token),
and breaks the Getting Started guide (e.g. #267).