### PR TITLE
Add support for key rotation

### DIFF
--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -1,0 +1,73 @@
+package api
+
+func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey/init")
+	resp, err := c.c.RawRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result RekeyStatusResponse
+	err = resp.DecodeJSON(&result)
+	return &result, err
+}
+
+func (c *Sys) RekeyInit(config *RekeyInitRequest) error {
+	r := c.c.NewRequest("PUT", "/v1/sys/rekey/init")
+	if err := r.SetJSONBody(config); err != nil {
+		return err
+	}
+
+	resp, err := c.c.RawRequest(r)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	return err
+}
+
+func (c *Sys) RekeyCancel() error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/init")
+	resp, err := c.c.RawRequest(r)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	return err
+}
+
+func (c *Sys) RekeyUpdate(shard string) (*RekeyUpdateResponse, error) {
+	body := map[string]interface{}{"key": shard}
+
+	r := c.c.NewRequest("PUT", "/v1/sys/rekey/update")
+	if err := r.SetJSONBody(body); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.RawRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result RekeyUpdateResponse
+	err = resp.DecodeJSON(&result)
+	return &result, err
+}
+
+type RekeyInitRequest struct {
+	SecretShares    int `json:"secret_shares"`
+	SecretThreshold int `json:"secret_threshold"`
+}
+
+type RekeyStatusResponse struct {
+	Started  bool
+	T        int
+	N        int
+	Progress int
+	Required int
+}
+
+type RekeyUpdateResponse struct {
+	Complete bool
+	Keys     []string
+}

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -1,0 +1,30 @@
+package api
+
+import "time"
+
+func (c *Sys) Rotate() error {
+	r := c.c.NewRequest("POST", "/v1/sys/rotate")
+	resp, err := c.c.RawRequest(r)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	return err
+}
+
+func (c *Sys) KeyStatus() (*KeyStatus, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/key-status")
+	resp, err := c.c.RawRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	result := new(KeyStatus)
+	err = resp.DecodeJSON(result)
+	return result, err
+}
+
+type KeyStatus struct {
+	Term        int
+	InstallTime time.Time `json:"install_time"`
+}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -208,6 +208,12 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 			}, nil
 		},
 
+		"rotate": func() (cli.Command, error) {
+			return &command.RotateCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"unmount": func() (cli.Command, error) {
 			return &command.UnmountCommand{
 				Meta: meta,

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -118,6 +118,12 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 			}, nil
 		},
 
+		"key-status": func() (cli.Command, error) {
+			return &command.KeyStatusCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"policies": func() (cli.Command, error) {
 			return &command.PolicyListCommand{
 				Meta: meta,

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -160,6 +160,12 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 			}, nil
 		},
 
+		"rekey": func() (cli.Command, error) {
+			return &command.RekeyCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"renew": func() (cli.Command, error) {
 			return &command.RenewCommand{
 				Meta: meta,

--- a/command/key_status.go
+++ b/command/key_status.go
@@ -1,0 +1,67 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KeyStatusCommand is a Command that provides information about the key status
+type KeyStatusCommand struct {
+	Meta
+}
+
+func (c *KeyStatusCommand) Run(args []string) int {
+	flags := c.Meta.FlagSet("key-status", FlagSetDefault)
+	flags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error initializing client: %s", err))
+		return 2
+	}
+
+	status, err := client.Sys().KeyStatus()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error reading audits: %s", err))
+		return 2
+	}
+
+	c.Ui.Output(fmt.Sprintf("Key Term: %d", status.Term))
+	c.Ui.Output(fmt.Sprintf("Installation Time: %v", status.InstallTime))
+	return 0
+}
+
+func (c *KeyStatusCommand) Synopsis() string {
+	return "Provides information about the active encryption key"
+}
+
+func (c *KeyStatusCommand) Help() string {
+	helpText := `
+Usage: vault key-status [options]
+
+  Provides information about the active encryption key. Specifically,
+  the current key term and the key installation time.
+
+General Options:
+
+  -address=addr           The address of the Vault server.
+
+  -ca-cert=path           Path to a PEM encoded CA cert file to use to
+                          verify the Vault server SSL certificate.
+
+  -ca-path=path           Path to a directory of PEM encoded CA cert files
+                          to verify the Vault server SSL certificate. If both
+                          -ca-cert and -ca-path are specified, -ca-path is used.
+
+  -tls-skip-verify        Do not verify TLS certificate. This is highly
+                          not recommended. This is especially not recommended
+                          for unsealing a vault.
+
+`
+	return strings.TrimSpace(helpText)
+}

--- a/command/key_status_test.go
+++ b/command/key_status_test.go
@@ -1,0 +1,30 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/vault"
+	"github.com/mitchellh/cli"
+)
+
+func TestKeyStatus(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	ui := new(cli.MockUi)
+	c := &KeyStatusCommand{
+		Meta: Meta{
+			ClientToken: token,
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-address", addr,
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}

--- a/command/rekey.go
+++ b/command/rekey.go
@@ -1,0 +1,232 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/helper/password"
+)
+
+// RekeyCommand is a Command that rekeys the vault.
+type RekeyCommand struct {
+	Meta
+
+	// Key can be used to pre-seed the key. If it is set, it will not
+	// be asked with the `password` helper.
+	Key string
+}
+
+func (c *RekeyCommand) Run(args []string) int {
+	var init, cancel, status bool
+	var shares, threshold int
+	flags := c.Meta.FlagSet("rekey", FlagSetDefault)
+	flags.BoolVar(&init, "init", false, "")
+	flags.BoolVar(&cancel, "cancel", false, "")
+	flags.BoolVar(&status, "status", false, "")
+	flags.IntVar(&shares, "key-shares", 5, "")
+	flags.IntVar(&threshold, "key-threshold", 3, "")
+	flags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error initializing client: %s", err))
+		return 2
+	}
+
+	// Check if we are running doing any restricted variants
+	if init {
+		return c.initRekey(client, shares, threshold)
+	} else if cancel {
+		return c.cancelRekey(client)
+	} else if status {
+		return c.rekeyStatus(client)
+	}
+
+	// Check if the rekey is started
+	rekeyStatus, err := client.Sys().RekeyStatus()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error reading rekey status: %s", err))
+		return 1
+	}
+
+	// Start the rekey process if not started
+	if !rekeyStatus.Started {
+		err := client.Sys().RekeyInit(&api.RekeyInitRequest{
+			SecretShares:    shares,
+			SecretThreshold: threshold,
+		})
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error initializing rekey: %s", err))
+			return 1
+		}
+	} else {
+		shares = rekeyStatus.N
+		threshold = rekeyStatus.T
+		c.Ui.Output(fmt.Sprintf(
+			"Rekey already in progress\n"+
+				"Key Shares: %d\n"+
+				"Key Threshold: %d\n",
+			shares,
+			threshold,
+		))
+	}
+
+	// Get the unseal key
+	args = flags.Args()
+	value := c.Key
+	if len(args) > 0 {
+		value = args[0]
+	}
+	if value == "" {
+		fmt.Printf("Key (will be hidden): ")
+		value, err = password.Read(os.Stdin)
+		fmt.Printf("\n")
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf(
+				"Error attempting to ask for password. The raw error message\n"+
+					"is shown below, but the most common reason for this error is\n"+
+					"that you attempted to pipe a value into unseal or you're\n"+
+					"executing `vault rekey` from outside of a terminal.\n\n"+
+					"You should use `vault rekey` from a terminal for maximum\n"+
+					"security. If this isn't an option, the unseal key can be passed\n"+
+					"in using the first parameter.\n\n"+
+					"Raw error: %s", err))
+			return 1
+		}
+	}
+
+	// Provide the key, this may potentially complete the update
+	result, err := client.Sys().RekeyUpdate(strings.TrimSpace(value))
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error attempting rekey update: %s", err))
+		return 1
+	}
+
+	// If we are not complete, then dump the status
+	if !result.Complete {
+		return c.rekeyStatus(client)
+	}
+
+	// Provide the keys
+	for i, key := range result.Keys {
+		c.Ui.Output(fmt.Sprintf("Key %d: %s", i+1, key))
+	}
+
+	c.Ui.Output(fmt.Sprintf(
+		"\n"+
+			"Vault rekeyed with %d keys and a key threshold of %d!\n\n"+
+			"Please securely distribute the above keys. Whenever a Vault server\n"+
+			"is started, it must be unsealed with %d (the threshold) of the\n"+
+			"keys above (any of the keys, as long as the total number equals\n"+
+			"the threshold).\n\n"+
+			"Vault does not store the original master key. If you lose the keys\n"+
+			"above such that you no longer have the minimum number (the\n"+
+			"threshold), then your Vault will not be able to be unsealed.",
+		shares,
+		threshold,
+		threshold,
+	))
+	return 0
+}
+
+// initRekey is used to start the rekey process
+func (c *RekeyCommand) initRekey(client *api.Client, shares, threshold int) int {
+	// Start the rekey
+	err := client.Sys().RekeyInit(&api.RekeyInitRequest{
+		SecretShares:    shares,
+		SecretThreshold: threshold,
+	})
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing rekey: %s", err))
+		return 1
+	}
+
+	// Provide the current status
+	return c.rekeyStatus(client)
+}
+
+// cancelRekey is used to abort the rekey process
+func (c *RekeyCommand) cancelRekey(client *api.Client) int {
+	err := client.Sys().RekeyCancel()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to cancel rekey: %s", err))
+		return 1
+	}
+	c.Ui.Output("Rekey canceled.")
+	return 0
+}
+
+// rekeyStatus is used just to fetch and dump the statu
+func (c *RekeyCommand) rekeyStatus(client *api.Client) int {
+	// Check the status
+	status, err := client.Sys().RekeyStatus()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error reading rekey status: %s", err))
+		return 1
+	}
+
+	// Dump the status
+	c.Ui.Output(fmt.Sprintf(
+		"Started: %v\n"+
+			"Key Shares: %d\n"+
+			"Key Threshold: %d\n"+
+			"Rekey Progress: %d\n"+
+			"Required Keys: %d",
+		status.Started,
+		status.N,
+		status.T,
+		status.Progress,
+		status.Required,
+	))
+	return 0
+}
+
+func (c *RekeyCommand) Synopsis() string {
+	return "Rekeys Vault to generate new unseal keys"
+}
+
+func (c *RekeyCommand) Help() string {
+	helpText := `
+Usage: vault rekey [options] [key]
+
+  Unseal the vault by entering a portion of the master key. Once all
+  portions are entered, the Vault will be unsealed.
+
+  Every Vault server initially starts as sealed. It cannot perform any
+  operation except unsealing until it is sealed. Secrets cannot be accessed
+  in any way until the vault is unsealed. This command allows you to enter
+  a portion of the master key to unseal the vault.
+
+  The unseal key can be specified via the command line, but this is
+  not recommended. The key may then live in your terminal history. This
+  only exists to assist in scripting.
+
+General Options:
+
+  -address=addr           The address of the Vault server.
+
+  -ca-cert=path           Path to a PEM encoded CA cert file to use to
+                          verify the Vault server SSL certificate.
+
+  -ca-path=path           Path to a directory of PEM encoded CA cert files
+                          to verify the Vault server SSL certificate. If both
+                          -ca-cert and -ca-path are specified, -ca-path is used.
+
+  -tls-skip-verify        Do not verify TLS certificate. This is highly
+                          not recommended. This is especially not recommended
+                          for unsealing a vault.
+
+Unseal Options:
+
+  -reset                  Reset the unsealing process by throwing away
+                          prior keys in process to unseal the vault.
+
+`
+	return strings.TrimSpace(helpText)
+}

--- a/command/rekey.go
+++ b/command/rekey.go
@@ -195,17 +195,13 @@ func (c *RekeyCommand) Help() string {
 	helpText := `
 Usage: vault rekey [options] [key]
 
-  Unseal the vault by entering a portion of the master key. Once all
-  portions are entered, the Vault will be unsealed.
+  Rekey is used to change the unseal keys. This can be done to generate
+  a new set of unseal keys or to change the number of shares and the
+  required threshold.
 
-  Every Vault server initially starts as sealed. It cannot perform any
-  operation except unsealing until it is sealed. Secrets cannot be accessed
-  in any way until the vault is unsealed. This command allows you to enter
-  a portion of the master key to unseal the vault.
-
-  The unseal key can be specified via the command line, but this is
-  not recommended. The key may then live in your terminal history. This
-  only exists to assist in scripting.
+  Rekey can only be done when the Vault is already unsealed. The operation
+  is done online, but requires that a threshold of the current unseal
+  keys be provided.
 
 General Options:
 
@@ -224,9 +220,22 @@ General Options:
 
 Unseal Options:
 
-  -reset                  Reset the unsealing process by throwing away
-                          prior keys in process to unseal the vault.
+  -init                   Initialize the rekey operation by setting the desired
+                          number of shares and the key threshold. This can only be
+                          done if no rekey is already initiated.
 
+  -cancel				  Reset the rekey process by throwing away
+                          prior keys and the rekey configuration.
+
+  -status                 Prints the status of the current rekey operation.
+                          This can be used to see the status without attempting
+                          to provide an unseal key.
+
+  -key-shares=5           The number of key shares to split the master key
+                          into.
+
+  -key-threshold=3        The number of key shares required to reconstruct
+                          the master key.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/rekey_test.go
+++ b/command/rekey_test.go
@@ -1,0 +1,154 @@
+package command
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/vault"
+	"github.com/mitchellh/cli"
+)
+
+func TestRekey(t *testing.T) {
+	core, key, _ := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	ui := new(cli.MockUi)
+	c := &RekeyCommand{
+		Key: hex.EncodeToString(key),
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	args := []string{"-address", addr}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	config, err := core.SealConfig()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config.SecretShares != 5 {
+		t.Fatal("should rekey")
+	}
+}
+
+func TestRekey_arg(t *testing.T) {
+	core, key, _ := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	ui := new(cli.MockUi)
+	c := &RekeyCommand{
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	args := []string{"-address", addr, hex.EncodeToString(key)}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	config, err := core.SealConfig()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config.SecretShares != 5 {
+		t.Fatal("should rekey")
+	}
+}
+
+func TestRekey_init(t *testing.T) {
+	core, key, _ := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	ui := new(cli.MockUi)
+	c := &RekeyCommand{
+		Key: hex.EncodeToString(key),
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	args := []string{"-address", addr, "-init", "-key-threshold=10", "-key-shares=10"}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	config, err := core.RekeyConfig()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config.SecretShares != 10 {
+		t.Fatal("should rekey")
+	}
+	if config.SecretThreshold != 10 {
+		t.Fatal("should rekey")
+	}
+}
+
+func TestRekey_cancel(t *testing.T) {
+	core, key, _ := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	ui := new(cli.MockUi)
+	c := &RekeyCommand{
+		Key: hex.EncodeToString(key),
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	args := []string{"-address", addr, "-init"}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	args = []string{"-address", addr, "-cancel"}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	config, err := core.RekeyConfig()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config != nil {
+		t.Fatal("should not rekey")
+	}
+}
+
+func TestRekey_status(t *testing.T) {
+	core, key, _ := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	ui := new(cli.MockUi)
+	c := &RekeyCommand{
+		Key: hex.EncodeToString(key),
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	args := []string{"-address", addr, "-init"}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	args = []string{"-address", addr, "-status"}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	if !strings.Contains(string(ui.OutputWriter.Bytes()), "Started: true") {
+		t.Fatalf("bad: %s", ui.OutputWriter.String())
+	}
+}

--- a/command/rotate.go
+++ b/command/rotate.go
@@ -1,0 +1,79 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RotateCommand is a Command that rotates the encryption key being used
+type RotateCommand struct {
+	Meta
+}
+
+func (c *RotateCommand) Run(args []string) int {
+	flags := c.Meta.FlagSet("rotate", FlagSetDefault)
+	flags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error initializing client: %s", err))
+		return 2
+	}
+
+	// Rotate the key
+	err = client.Sys().Rotate()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error with key rotation: %s", err))
+		return 2
+	}
+
+	// Print the key status
+	status, err := client.Sys().KeyStatus()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error reading audits: %s", err))
+		return 2
+	}
+
+	c.Ui.Output(fmt.Sprintf("Key Term: %d", status.Term))
+	c.Ui.Output(fmt.Sprintf("Installation Time: %v", status.InstallTime))
+	return 0
+}
+
+func (c *RotateCommand) Synopsis() string {
+	return "Rotates the backend encryption key used to persist data"
+}
+
+func (c *RotateCommand) Help() string {
+	helpText := `
+Usage: vault rotate [options]
+
+  Rotates the backend encryption key which is used to secure data
+  written to the storage backend. This is done by installing a new key
+  which encrypts new data, while old keys are still used to decrypt
+  secrets written previously. This is an online operation and is not
+  disruptive.
+
+General Options:
+
+  -address=addr           The address of the Vault server.
+
+  -ca-cert=path           Path to a PEM encoded CA cert file to use to
+                          verify the Vault server SSL certificate.
+
+  -ca-path=path           Path to a directory of PEM encoded CA cert files
+                          to verify the Vault server SSL certificate. If both
+                          -ca-cert and -ca-path are specified, -ca-path is used.
+
+  -tls-skip-verify        Do not verify TLS certificate. This is highly
+                          not recommended. This is especially not recommended
+                          for unsealing a vault.
+
+`
+	return strings.TrimSpace(helpText)
+}

--- a/command/rotate_test.go
+++ b/command/rotate_test.go
@@ -1,0 +1,30 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/vault"
+	"github.com/mitchellh/cli"
+)
+
+func TestRotate(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	ui := new(cli.MockUi)
+	c := &RotateCommand{
+		Meta: Meta{
+			ClientToken: token,
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-address", addr,
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}

--- a/http/handler.go
+++ b/http/handler.go
@@ -40,6 +40,8 @@ func Handler(core *vault.Core) http.Handler {
 	mux.Handle("/v1/sys/audit/", handleSysAudit(core))
 	mux.Handle("/v1/sys/leader", handleSysLeader(core))
 	mux.Handle("/v1/sys/health", handleSysHealth(core))
+	mux.Handle("/v1/sys/rotate", handleSysRotate(core))
+	mux.Handle("/v1/sys/key-status", handleSysKeyStatus(core))
 	mux.Handle("/v1/", handleLogical(core))
 
 	// Wrap the handler in another handler to trigger all help paths.

--- a/http/handler.go
+++ b/http/handler.go
@@ -42,6 +42,8 @@ func Handler(core *vault.Core) http.Handler {
 	mux.Handle("/v1/sys/health", handleSysHealth(core))
 	mux.Handle("/v1/sys/rotate", handleSysRotate(core))
 	mux.Handle("/v1/sys/key-status", handleSysKeyStatus(core))
+	mux.Handle("/v1/sys/rekey/init", handleSysRekeyInit(core))
+	mux.Handle("/v1/sys/rekey/update", handleSysRekeyUpdate(core))
 	mux.Handle("/v1/", handleLogical(core))
 
 	// Wrap the handler in another handler to trigger all help paths.

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -1,0 +1,171 @@
+package http
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/vault/vault"
+)
+
+func handleSysRekeyInit(core *vault.Core) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			handleSysRekeyInitGet(core, w, r)
+		case "POST", "PUT":
+			handleSysRekeyInitPut(core, w, r)
+		case "DELETE":
+			handleSysRekeyInitDelete(core, w, r)
+		default:
+			respondError(w, http.StatusMethodNotAllowed, nil)
+		}
+	})
+}
+
+func handleSysRekeyInitGet(core *vault.Core, w http.ResponseWriter, r *http.Request) {
+	// Get the current configuration
+	sealConfig, err := core.SealConfig()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if sealConfig == nil {
+		respondError(w, http.StatusBadRequest, fmt.Errorf(
+			"server is not yet initialized"))
+		return
+	}
+
+	// Get the rekey configuration
+	rekeyConf, err := core.RekeyConfig()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// Get the progress
+	progress, err := core.RekeyProgress()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	// Format the status
+	status := &RekeyStatusResponse{
+		Started:  false,
+		T:        0,
+		N:        0,
+		Progress: progress,
+		Required: sealConfig.SecretThreshold,
+	}
+	if rekeyConf != nil {
+		status.Started = true
+		status.T = rekeyConf.SecretThreshold
+		status.N = rekeyConf.SecretShares
+	}
+	respondOk(w, status)
+}
+
+func handleSysRekeyInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) {
+	// Parse the request
+	var req RekeyRequest
+	if err := parseRequest(r, &req); err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	// Initialize the rekey
+	err := core.RekeyInit(&vault.SealConfig{
+		SecretShares:    req.SecretShares,
+		SecretThreshold: req.SecretThreshold,
+	})
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err)
+		return
+	}
+	respondOk(w, nil)
+}
+
+func handleSysRekeyInitDelete(core *vault.Core, w http.ResponseWriter, r *http.Request) {
+	err := core.RekeyCancel()
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	respondOk(w, nil)
+}
+
+func handleSysRekeyUpdate(core *vault.Core) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			respondError(w, http.StatusMethodNotAllowed, nil)
+			return
+		}
+
+		// Parse the request
+		var req RekeyUpdateRequest
+		if err := parseRequest(r, &req); err != nil {
+			respondError(w, http.StatusBadRequest, err)
+			return
+		}
+		if req.Key == "" {
+			respondError(
+				w, http.StatusBadRequest,
+				errors.New("'key' must specified in request body as JSON"))
+			return
+		}
+
+		// Decode the key, which is hex encoded
+		key, err := hex.DecodeString(req.Key)
+		if err != nil {
+			respondError(
+				w, http.StatusBadRequest,
+				errors.New("'key' must be a valid hex-string"))
+			return
+		}
+
+		// Use the key to make progress on rekey
+		result, err := core.RekeyUpdate(key)
+		if err != nil {
+			respondError(w, http.StatusBadRequest, err)
+			return
+		}
+
+		// Format the response
+		resp := &RekeyUpdateResponse{}
+		if result != nil {
+			resp.Complete = true
+
+			// Encode the keys
+			keys := make([]string, 0, len(result.SecretShares))
+			for _, k := range result.SecretShares {
+				keys = append(keys, hex.EncodeToString(k))
+			}
+			resp.Keys = keys
+		}
+		respondOk(w, resp)
+	})
+}
+
+type RekeyRequest struct {
+	SecretShares    int `json:"secret_shares"`
+	SecretThreshold int `json:"secret_threshold"`
+}
+
+type RekeyStatusResponse struct {
+	Started  bool `json:"started"`
+	T        int  `json:"t"`
+	N        int  `json:"n"`
+	Progress int  `json:"progress"`
+	Required int  `json:"required"`
+}
+
+type RekeyUpdateRequest struct {
+	Key string
+}
+
+type RekeyUpdateResponse struct {
+	Complete bool     `json:"complete"`
+	Keys     []string `json:"keys"`
+}

--- a/http/sys_rekey_test.go
+++ b/http/sys_rekey_test.go
@@ -1,0 +1,149 @@
+package http
+
+import (
+	"encoding/hex"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/vault/vault"
+)
+
+func TestSysRekeyInit_Status(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+	TestServerAuth(t, addr, token)
+
+	resp, err := http.Get(addr + "/v1/sys/rekey/init")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	var actual map[string]interface{}
+	expected := map[string]interface{}{
+		"started":  false,
+		"t":        float64(0),
+		"n":        float64(0),
+		"progress": float64(0),
+		"required": float64(1),
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestSysRekeyInit_Setup(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+	TestServerAuth(t, addr, token)
+
+	resp := testHttpPut(t, addr+"/v1/sys/rekey/init", map[string]interface{}{
+		"secret_shares":    5,
+		"secret_threshold": 3,
+	})
+	testResponseStatus(t, resp, 204)
+
+	resp, err := http.Get(addr + "/v1/sys/rekey/init")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	var actual map[string]interface{}
+	expected := map[string]interface{}{
+		"started":  true,
+		"t":        float64(3),
+		"n":        float64(5),
+		"progress": float64(0),
+		"required": float64(1),
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestSysRekeyInit_Cancel(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+	TestServerAuth(t, addr, token)
+
+	resp := testHttpPut(t, addr+"/v1/sys/rekey/init", map[string]interface{}{
+		"secret_shares":    5,
+		"secret_threshold": 3,
+	})
+	testResponseStatus(t, resp, 204)
+
+	resp = testHttpDelete(t, addr+"/v1/sys/rekey/init")
+	testResponseStatus(t, resp, 204)
+
+	resp, err := http.Get(addr + "/v1/sys/rekey/init")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	var actual map[string]interface{}
+	expected := map[string]interface{}{
+		"started":  false,
+		"t":        float64(0),
+		"n":        float64(0),
+		"progress": float64(0),
+		"required": float64(1),
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestSysRekey_badKey(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+	TestServerAuth(t, addr, token)
+
+	resp := testHttpPut(t, addr+"/v1/sys/rekey/update", map[string]interface{}{
+		"key": "0123",
+	})
+	testResponseStatus(t, resp, 400)
+}
+
+func TestSysRekey_Update(t *testing.T) {
+	core, master, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+	TestServerAuth(t, addr, token)
+
+	resp := testHttpPut(t, addr+"/v1/sys/rekey/init", map[string]interface{}{
+		"secret_shares":    5,
+		"secret_threshold": 3,
+	})
+	testResponseStatus(t, resp, 204)
+
+	resp = testHttpPut(t, addr+"/v1/sys/rekey/update", map[string]interface{}{
+		"key": hex.EncodeToString(master),
+	})
+
+	var actual map[string]interface{}
+	expected := map[string]interface{}{
+		"complete": true,
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+
+	keys := actual["keys"].([]interface{})
+	if len(keys) != 5 {
+		t.Fatalf("bad: %#v", keys)
+	}
+
+	delete(actual, "keys")
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}

--- a/http/sys_rotate.go
+++ b/http/sys_rotate.go
@@ -1,0 +1,49 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/vault"
+)
+
+func handleSysKeyStatus(core *vault.Core) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			respondError(w, http.StatusMethodNotAllowed, nil)
+			return
+		}
+
+		resp, err := core.HandleRequest(requestAuth(r, &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "sys/key-status",
+		}))
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, err)
+			return
+		}
+		respondOk(w, resp.Data)
+	})
+}
+
+func handleSysRotate(core *vault.Core) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "POST":
+		case "PUT":
+		default:
+			respondError(w, http.StatusMethodNotAllowed, nil)
+			return
+		}
+
+		_, err := core.HandleRequest(requestAuth(r, &logical.Request{
+			Operation: logical.WriteOperation,
+			Path:      "sys/rotate",
+		}))
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, err)
+			return
+		}
+		respondOk(w, nil)
+	})
+}

--- a/http/sys_rotate_test.go
+++ b/http/sys_rotate_test.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/vault/vault"
+)
+
+func TestSysRotate(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+	TestServerAuth(t, addr, token)
+
+	resp := testHttpPost(t, addr+"/v1/sys/rotate", map[string]interface{}{})
+	testResponseStatus(t, resp, 204)
+
+	resp, err := http.Get(addr + "/v1/sys/key-status")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	var actual map[string]interface{}
+	expected := map[string]interface{}{
+		"term": float64(2),
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+	delete(actual, "install_time")
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -65,6 +65,10 @@ type SecurityBarrier interface {
 	// be unsealed again to perform any further operations.
 	Seal() error
 
+	// Rotate is used to create a new encryption key. All future writes
+	// should use the new key, while old values should still be decryptable.
+	Rotate() error
+
 	// SecurityBarrier must provide the storage APIs
 	BarrierStorage
 }

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -26,6 +26,10 @@ var (
 const (
 	// barrierInitPath is the path used to store our init sentinel file
 	barrierInitPath = "barrier/init"
+
+	// keyringPath is the location of the keyring data. This is encrypted
+	// by the master key.
+	keyringPath = "core/keyring"
 )
 
 // SecurityBarrier is a critical component of Vault. It is used to wrap

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -77,6 +77,11 @@ type SecurityBarrier interface {
 	// VerifyMaster is used to check if the given key matches the master key
 	VerifyMaster(key []byte) error
 
+	// ReloadKeyring is used to re-read the underlying keyring.
+	// This is used for HA deployments to ensure the latest keyring
+	// is present in the leader.
+	ReloadKeyring() error
+
 	// Seal is used to re-seal the barrier. This requires the barrier to
 	// be unsealed again to perform any further operations.
 	Seal() error
@@ -85,7 +90,8 @@ type SecurityBarrier interface {
 	// should use the new key, while old values should still be decryptable.
 	Rotate() error
 
-	// AddKey is used to add a new key to the keyring
+	// AddKey is used to add a new key to the keyring. This assumes the keyring
+	// has already been updated and does not persist a new keyring.
 	AddKey(k *Key) error
 
 	// ActiveKeyInfo is used to inform details about the active key

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -43,6 +43,15 @@ const (
 	// are deleted after a few minutes, but this provides enough time for the
 	// standby instances to upgrade without causing any disruption.
 	keyringUpgradePrefix = "core/upgrade/"
+
+	// masterKeyPath is the location of the master key. This is encrypted
+	// by the latest key in the keyring. This is only used by standby instances
+	// to handle the case of a rekey. If the active instance does a rekey,
+	// the standby instances can no longer reload the keyring since they
+	// have the old master key. This key can be decrypted if you have the
+	// keyring to discover the new master key. The new master key is then
+	// used to reload the keyring itself.
+	masterKeyPath = "core/master"
 )
 
 // SecurityBarrier is a critical component of Vault. It is used to wrap
@@ -81,6 +90,11 @@ type SecurityBarrier interface {
 	// This is used for HA deployments to ensure the latest keyring
 	// is present in the leader.
 	ReloadKeyring() error
+
+	// ReloadMasterKey is used to re-read the underlying masterkey.
+	// This is used for HA deployments to ensure the latest master key
+	// is available for keyring reloading.
+	ReloadMasterKey() error
 
 	// Seal is used to re-seal the barrier. This requires the barrier to
 	// be unsealed again to perform any further operations.

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -62,6 +62,9 @@ type SecurityBarrier interface {
 	// to be unsealed. If the key is not correct, the barrier remains sealed.
 	Unseal(key []byte) error
 
+	// VerifyMaster is used to check if the given key matches the master key
+	VerifyMaster(key []byte) error
+
 	// Seal is used to re-seal the barrier. This requires the barrier to
 	// be unsealed again to perform any further operations.
 	Seal() error

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -69,6 +69,9 @@ type SecurityBarrier interface {
 	// should use the new key, while old values should still be decryptable.
 	Rotate() error
 
+	// Rekey is used to change the master key used to protect the keyring
+	Rekey([]byte) error
+
 	// SecurityBarrier must provide the storage APIs
 	BarrierStorage
 }

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"errors"
+	"time"
 
 	"github.com/hashicorp/vault/logical"
 )
@@ -69,6 +70,9 @@ type SecurityBarrier interface {
 	// should use the new key, while old values should still be decryptable.
 	Rotate() error
 
+	// ActiveKeyInfo is used to inform details about the active key
+	ActiveKeyInfo() (*KeyInfo, error)
+
 	// Rekey is used to change the master key used to protect the keyring
 	Rekey([]byte) error
 
@@ -104,4 +108,10 @@ func (e *Entry) Logical() *logical.StorageEntry {
 		Key:   e.Key,
 		Value: e.Value,
 	}
+}
+
+// KeyInfo is used to convey information about the encryption key
+type KeyInfo struct {
+	Term        int
+	InstallTime time.Time
 }

--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -88,11 +88,16 @@ type SecurityBarrier interface {
 
 	// Rotate is used to create a new encryption key. All future writes
 	// should use the new key, while old values should still be decryptable.
-	Rotate() error
+	Rotate() (uint32, error)
 
-	// AddKey is used to add a new key to the keyring. This assumes the keyring
-	// has already been updated and does not persist a new keyring.
-	AddKey(k *Key) error
+	// CreateUpgrade creates an upgrade path key to the given term from the previous term
+	CreateUpgrade(term uint32) error
+
+	// DestroyUpgrade destroys the upgrade path key to the given term
+	DestroyUpgrade(term uint32) error
+
+	// CheckUpgrade looks for an upgrade to the current term and installs it
+	CheckUpgrade() (bool, uint32, error)
 
 	// ActiveKeyInfo is used to inform details about the active key
 	ActiveKeyInfo() (*KeyInfo, error)

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -15,13 +15,13 @@ import (
 )
 
 const (
-	// keyEpoch is the hard coded key epoch. Eventually, when
-	// a key ring is supported for online key rotation, the epoch
+	// keyTerm is the hard coded key term. Eventually, when
+	// a key ring is supported for online key rotation, the term
 	// will be incremented and represents the encryption key to use.
-	keyEpoch = 1
+	keyTerm = 1
 
-	// epochSize is the number of bytes used for the key epoch.
-	epochSize = 4
+	// termSize the number of bytes used for the key term.
+	termSize = 4
 
 	// aesgcmVersionByte is prefixed to a message to allow for
 	// future versioning of barrier implementations.
@@ -308,14 +308,14 @@ func (b *AESGCMBarrier) aeadFromKey(key []byte) (cipher.AEAD, error) {
 
 // encrypt is used to encrypt a value
 func (b *AESGCMBarrier) encrypt(gcm cipher.AEAD, plain []byte) []byte {
-	// Allocate the output buffer with room for epoch, version byte,
+	// Allocate the output buffer with room for tern, version byte,
 	// nonce, GCM tag and the plaintext
-	capacity := epochSize + 1 + gcm.NonceSize() + gcm.Overhead() + len(plain)
-	size := epochSize + 1 + gcm.NonceSize()
+	capacity := termSize + 1 + gcm.NonceSize() + gcm.Overhead() + len(plain)
+	size := termSize + 1 + gcm.NonceSize()
 	out := make([]byte, size, capacity)
 
-	// Set the epoch to 1
-	out[3] = keyEpoch
+	// Set the term to 1
+	out[3] = keyTerm
 
 	// Set the version byte
 	out[4] = aesgcmVersionByte
@@ -331,9 +331,9 @@ func (b *AESGCMBarrier) encrypt(gcm cipher.AEAD, plain []byte) []byte {
 
 // decrypt is used to decrypt a value
 func (b *AESGCMBarrier) decrypt(gcm cipher.AEAD, cipher []byte) ([]byte, error) {
-	// Verify the epoch
-	if cipher[0] != 0 || cipher[1] != 0 || cipher[2] != 0 || cipher[3] != keyEpoch {
-		return nil, fmt.Errorf("epoch mis-match")
+	// Verify the term
+	if cipher[0] != 0 || cipher[1] != 0 || cipher[2] != 0 || cipher[3] != keyTerm {
+		return nil, fmt.Errorf("term mis-match")
 	}
 
 	// Verify the version byte

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -321,6 +321,26 @@ func (b *AESGCMBarrier) Rotate() error {
 	return nil
 }
 
+// ActiveKeyInfo is used to inform details about the active key
+func (b *AESGCMBarrier) ActiveKeyInfo() (*KeyInfo, error) {
+	b.l.RLock()
+	defer b.l.RUnlock()
+	if b.sealed {
+		return nil, ErrBarrierSealed
+	}
+
+	// Determine the key install time
+	term := b.keyring.ActiveTerm()
+	key := b.keyring.TermKey(term)
+
+	// Return the key info
+	info := &KeyInfo{
+		Term:        int(term),
+		InstallTime: key.InstallTime,
+	}
+	return info, nil
+}
+
 // Rekey is used to change the master key used to protect the keyring
 func (b *AESGCMBarrier) Rekey(key []byte) error {
 	b.l.Lock()

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -138,7 +138,7 @@ func (b *AESGCMBarrier) persistKeyring(keyring *Keyring) error {
 	// Encrypt the barrier init value
 	value := b.encrypt(initialKeyTerm, gcm, buf)
 
-	// Create the barrierInitPath
+	// Create the keyring physical entry
 	pe := &physical.Entry{
 		Key:   keyringPath,
 		Value: value,
@@ -251,6 +251,11 @@ func (b *AESGCMBarrier) Unseal(key []byte) error {
 	})
 	if err := b.persistKeyring(keyring); err != nil {
 		return err
+	}
+
+	// Delete the old barrier entry
+	if err := b.backend.Delete(barrierInitPath); err != nil {
+		return fmt.Errorf("failed to delete barrier init file: %v", err)
 	}
 
 	// Set the vault as unsealed

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -335,6 +335,20 @@ func (b *AESGCMBarrier) Rotate() error {
 	return nil
 }
 
+// AddKey is used to add a new key to the keyring. This assumes the keyring
+// has already been updated and does not persist a new keyring.
+func (b *AESGCMBarrier) AddKey(k *Key) error {
+	b.l.Lock()
+	defer b.l.Unlock()
+
+	newKeyring, err := b.keyring.AddKey(k)
+	if err != nil {
+		return fmt.Errorf("failed to add new encryption key: %v", err)
+	}
+	b.keyring = newKeyring
+	return nil
+}
+
 // ActiveKeyInfo is used to inform details about the active key
 func (b *AESGCMBarrier) ActiveKeyInfo() (*KeyInfo, error) {
 	b.l.RLock()

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -41,6 +41,19 @@ func TestAESGCMBarrier_Rotate(t *testing.T) {
 	testBarrier_Rotate(t, b)
 }
 
+func TestAESGCMBarrier_Upgrade(t *testing.T) {
+	inm := physical.NewInmem()
+	b1, err := NewAESGCMBarrier(inm)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b2, err := NewAESGCMBarrier(inm)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	testBarrier_Upgrade(t, b1, b2)
+}
+
 func TestAESGCMBarrier_Rekey(t *testing.T) {
 	inm := physical.NewInmem()
 	b, err := NewAESGCMBarrier(inm)

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -54,6 +54,19 @@ func TestAESGCMBarrier_Upgrade(t *testing.T) {
 	testBarrier_Upgrade(t, b1, b2)
 }
 
+func TestAESGCMBarrier_Upgrade_Rekey(t *testing.T) {
+	inm := physical.NewInmem()
+	b1, err := NewAESGCMBarrier(inm)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	b2, err := NewAESGCMBarrier(inm)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	testBarrier_Upgrade_Rekey(t, b1, b2)
+}
+
 func TestAESGCMBarrier_Rekey(t *testing.T) {
 	inm := physical.NewInmem()
 	b, err := NewAESGCMBarrier(inm)

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -114,15 +114,16 @@ func TestEncrypt_Unique(t *testing.T) {
 	b.Initialize(key)
 	b.Unseal(key)
 
-	entry := &Entry{Key: "test", Value: []byte("test")}
-	primary := b.primary
-
-	if primary == nil {
+	if b.keyring == nil {
 		t.Fatalf("barrier is sealed")
 	}
 
-	first := b.encrypt(primary, entry.Value)
-	second := b.encrypt(primary, entry.Value)
+	entry := &Entry{Key: "test", Value: []byte("test")}
+	term := b.keyring.ActiveTerm()
+	primary, _ := b.aeadForTerm(term)
+
+	first := b.encrypt(term, primary, entry.Value)
+	second := b.encrypt(term, primary, entry.Value)
 
 	if bytes.Equal(first, second) == true {
 		t.Fatalf("improper random seeding detected")

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -41,6 +41,15 @@ func TestAESGCMBarrier_Rotate(t *testing.T) {
 	testBarrier_Rotate(t, b)
 }
 
+func TestAESGCMBarrier_Rekey(t *testing.T) {
+	inm := physical.NewInmem()
+	b, err := NewAESGCMBarrier(inm)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	testBarrier_Rekey(t, b)
+}
+
 // Test an upgrade from the old (0.1) barrier/init to the new
 // core/keyring style
 func TestAESGCMBarrier_BackwardsCompatible(t *testing.T) {

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -32,6 +32,15 @@ func TestAESGCMBarrier_Basic(t *testing.T) {
 	testBarrier(t, b)
 }
 
+func TestAESGCMBarrier_Rotate(t *testing.T) {
+	inm := physical.NewInmem()
+	b, err := NewAESGCMBarrier(inm)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	testBarrier_Rotate(t, b)
+}
+
 // Test an upgrade from the old (0.1) barrier/init to the new
 // core/keyring style
 func TestAESGCMBarrier_BackwardsCompatible(t *testing.T) {

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -357,6 +357,12 @@ func testBarrier_Rotate(t *testing.T, b SecurityBarrier) {
 	if info.Term != 3 {
 		t.Fatalf("Bad term: %d", info.Term)
 	}
+
+	// Should be fine to reload keyring
+	err = b.ReloadKeyring()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 }
 
 func testBarrier_Rekey(t *testing.T, b SecurityBarrier) {
@@ -430,5 +436,11 @@ func testBarrier_Rekey(t *testing.T, b SecurityBarrier) {
 	}
 	if out == nil {
 		t.Fatalf("bad: %v", out)
+	}
+
+	// Should be fine to reload keyring
+	err = b.ReloadKeyring()
+	if err != nil {
+		t.Fatalf("err: %v", err)
 	}
 }

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -335,6 +335,28 @@ func testBarrier_Rotate(t *testing.T, b SecurityBarrier) {
 	if out == nil {
 		t.Fatalf("bad: %v", out)
 	}
+
+	// Attempt to do AddKey
+	randKey, _ := b.GenerateKey()
+	newKey := &Key{
+		Term:        3,
+		Version:     1,
+		Value:       randKey,
+		InstallTime: time.Now(),
+	}
+	err = b.AddKey(newKey)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check the key info
+	info, err = b.ActiveKeyInfo()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if info.Term != 3 {
+		t.Fatalf("Bad term: %d", info.Term)
+	}
 }
 
 func testBarrier_Rekey(t *testing.T, b SecurityBarrier) {

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -496,3 +496,36 @@ func testBarrier_Upgrade(t *testing.T, b1, b2 SecurityBarrier) {
 		t.Fatalf("should not have upgrade")
 	}
 }
+
+func testBarrier_Upgrade_Rekey(t *testing.T, b1, b2 SecurityBarrier) {
+	// Initialize the barrier
+	key, _ := b1.GenerateKey()
+	b1.Initialize(key)
+	err := b1.Unseal(key)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	err = b2.Unseal(key)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Rekey to a new key
+	newKey, _ := b1.GenerateKey()
+	err = b1.Rekey(newKey)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Reload the master key
+	err = b2.ReloadMasterKey()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Reload the keyring
+	err = b2.ReloadKeyring()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -112,6 +112,11 @@ func testBarrier(t *testing.T, b SecurityBarrier) {
 		t.Fatalf("should be unsealed")
 	}
 
+	// Verify the master key
+	if err := b.VerifyMaster(key); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
 	// Operations should work
 	out, err := b.Get("test")
 	if err != nil {
@@ -347,10 +352,25 @@ func testBarrier_Rekey(t *testing.T, b SecurityBarrier) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// Verify the master key
+	if err := b.VerifyMaster(key); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
 	// Rekey to a new key
 	newKey, _ := b.GenerateKey()
 	err = b.Rekey(newKey)
 	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Verify the old master key
+	if err := b.VerifyMaster(key); err != ErrBarrierInvalidKey {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Verify the new master key
+	if err := b.VerifyMaster(newKey); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -233,3 +233,75 @@ func testBarrier(t *testing.T, b SecurityBarrier) {
 		t.Fatalf("err: %v", err)
 	}
 }
+
+func testBarrier_Rotate(t *testing.T, b SecurityBarrier) {
+	// Initialize the barrier
+	key, _ := b.GenerateKey()
+	b.Initialize(key)
+	err := b.Unseal(key)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Write a key
+	e1 := &Entry{Key: "test", Value: []byte("test")}
+	if err := b.Put(e1); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Rotate the encryption key
+	err = b.Rotate()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Write another key
+	e2 := &Entry{Key: "foo", Value: []byte("test")}
+	if err := b.Put(e2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Reading both should work
+	out, err := b.Get(e1.Key)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out == nil {
+		t.Fatalf("bad: %v", out)
+	}
+
+	out, err = b.Get(e2.Key)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out == nil {
+		t.Fatalf("bad: %v", out)
+	}
+
+	// Seal and unseal
+	err = b.Seal()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	err = b.Unseal(key)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Reading both should work
+	out, err = b.Get(e1.Key)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out == nil {
+		t.Fatalf("bad: %v", out)
+	}
+
+	out, err = b.Get(e2.Key)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out == nil {
+		t.Fatalf("bad: %v", out)
+	}
+}

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -120,12 +120,12 @@ func testBarrier(t *testing.T, b SecurityBarrier) {
 		t.Fatalf("bad: %v", out)
 	}
 
-	// List should have only "barrier/"
+	// List should have only "core/"
 	keys, err := b.List("")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(keys) != 1 || keys[0] != "barrier/" {
+	if len(keys) != 1 || keys[0] != "core/" {
 		t.Fatalf("bad: %v", keys)
 	}
 
@@ -151,7 +151,7 @@ func testBarrier(t *testing.T, b SecurityBarrier) {
 	if len(keys) != 2 {
 		t.Fatalf("bad: %v", keys)
 	}
-	if keys[0] != "barrier/" || keys[1] != "test" {
+	if keys[0] != "core/" || keys[1] != "test" {
 		t.Fatalf("bad: %v", keys)
 	}
 
@@ -181,7 +181,7 @@ func testBarrier(t *testing.T, b SecurityBarrier) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(keys) != 1 || keys[0] != "barrier/" {
+	if len(keys) != 1 || keys[0] != "core/" {
 		t.Fatalf("bad: %v", keys)
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -993,6 +993,9 @@ func (c *Core) RekeyInit(config *SealConfig) error {
 	if c.sealed {
 		return ErrSealed
 	}
+	if c.standby {
+		return ErrStandby
+	}
 
 	// Prevent multiple concurrent re-keys
 	if c.rekeyConfig != nil {
@@ -1035,6 +1038,9 @@ func (c *Core) RekeyUpdate(key []byte) (*RekeyResult, error) {
 	defer c.stateLock.RUnlock()
 	if c.sealed {
 		return nil, ErrSealed
+	}
+	if c.standby {
+		return nil, ErrStandby
 	}
 
 	c.rekeyLock.Lock()

--- a/vault/core.go
+++ b/vault/core.go
@@ -1185,6 +1185,9 @@ func (c *Core) postUnseal() error {
 		if err := c.checkKeyUpgrades(); err != nil {
 			return err
 		}
+		if err := c.barrier.ReloadMasterKey(); err != nil {
+			return err
+		}
 		if err := c.barrier.ReloadKeyring(); err != nil {
 			return err
 		}

--- a/vault/core.go
+++ b/vault/core.go
@@ -670,7 +670,8 @@ func (c *Core) Initialize(config *SealConfig) (*InitResult, error) {
 		c.logger.Printf("[ERR] core: failed to initialize barrier: %v", err)
 		return nil, fmt.Errorf("failed to initialize barrier: %v", err)
 	}
-	c.logger.Printf("[INFO] core: security barrier initialized")
+	c.logger.Printf("[INFO] core: security barrier initialized (shares: %d, threshold %d)",
+		config.SecretShares, config.SecretThreshold)
 
 	// Unseal the barrier
 	if err := c.barrier.Unseal(masterKey); err != nil {
@@ -1001,6 +1002,8 @@ func (c *Core) RekeyInit(config *SealConfig) error {
 	// Copy the configuration
 	c.rekeyConfig = new(SealConfig)
 	*c.rekeyConfig = *config
+	c.logger.Printf("[INFO] core: rekey initialized (shares: %d, threshold: %d)",
+		c.rekeyConfig.SecretShares, c.rekeyConfig.SecretThreshold)
 	return nil
 }
 
@@ -1111,7 +1114,8 @@ func (c *Core) RekeyUpdate(key []byte) (*RekeyResult, error) {
 		c.logger.Printf("[ERR] core: failed to rekey barrier: %v", err)
 		return nil, fmt.Errorf("failed to rekey barrier: %v", err)
 	}
-	c.logger.Printf("[INFO] core: security barrier rekeyed")
+	c.logger.Printf("[INFO] core: security barrier rekeyed (shares: %d, threshold: %d)",
+		c.rekeyConfig.SecretShares, c.rekeyConfig.SecretThreshold)
 
 	// Store the seal configuration
 	pe := &physical.Entry{

--- a/vault/core.go
+++ b/vault/core.go
@@ -962,6 +962,9 @@ func (c *Core) RekeyProgress() (int, error) {
 	if c.sealed {
 		return 0, ErrSealed
 	}
+	if c.standby {
+		return 0, ErrStandby
+	}
 
 	c.rekeyLock.Lock()
 	defer c.rekeyLock.Unlock()
@@ -974,6 +977,9 @@ func (c *Core) RekeyConfig() (*SealConfig, error) {
 	defer c.stateLock.RUnlock()
 	if c.sealed {
 		return nil, ErrSealed
+	}
+	if c.standby {
+		return nil, ErrStandby
 	}
 
 	c.rekeyLock.Lock()
@@ -1153,6 +1159,9 @@ func (c *Core) RekeyCancel() error {
 	defer c.stateLock.RUnlock()
 	if c.sealed {
 		return ErrSealed
+	}
+	if c.standby {
+		return ErrStandby
 	}
 
 	// Clear any progress or config

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -1511,3 +1511,234 @@ func TestCore_HandleRequest_MountPoint(t *testing.T) {
 		t.Fatalf("bad: %#v", noop.Requests)
 	}
 }
+
+func TestCore_Rekey_Lifecycle(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+
+	// Should be no progress
+	num, err := c.RekeyProgress()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if num != 0 {
+		t.Fatalf("bad: %d", num)
+	}
+
+	// Should be no config
+	conf, err := c.RekeyConfig()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if conf != nil {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	// Cancel should be idempotent
+	err = c.RekeyCancel()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Start a rekey
+	newConf := &SealConfig{
+		SecretThreshold: 3,
+		SecretShares:    5,
+	}
+	err = c.RekeyInit(newConf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Should get config
+	conf, err = c.RekeyConfig()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(conf, newConf) {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	// Cancel should be clear
+	err = c.RekeyCancel()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Should be no config
+	conf, err = c.RekeyConfig()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if conf != nil {
+		t.Fatalf("bad: %v", conf)
+	}
+}
+
+func TestCore_Rekey_Init(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+
+	// Try an invalid config
+	badConf := &SealConfig{
+		SecretThreshold: 5,
+		SecretShares:    1,
+	}
+	err := c.RekeyInit(badConf)
+	if err == nil {
+		t.Fatalf("should fail")
+	}
+
+	// Start a rekey
+	newConf := &SealConfig{
+		SecretThreshold: 3,
+		SecretShares:    5,
+	}
+	err = c.RekeyInit(newConf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Second should fail
+	err = c.RekeyInit(newConf)
+	if err == nil {
+		t.Fatalf("should fail")
+	}
+}
+
+func TestCore_Rekey_Update(t *testing.T) {
+	c, master, root := TestCoreUnsealed(t)
+
+	// Start a rekey
+	newConf := &SealConfig{
+		SecretThreshold: 3,
+		SecretShares:    5,
+	}
+	err := c.RekeyInit(newConf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Provide the master
+	result, err := c.RekeyUpdate(master)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if result == nil || len(result.SecretShares) != 5 {
+		t.Fatalf("Bad: %#v", result)
+	}
+
+	// Should be no progress
+	num, err := c.RekeyProgress()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if num != 0 {
+		t.Fatalf("bad: %d", num)
+	}
+
+	// Should be no config
+	conf, err := c.RekeyConfig()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if conf != nil {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	// SealConfig should update
+	conf, err = c.SealConfig()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(conf, newConf) {
+		t.Fatalf("bad: %#v", conf)
+	}
+
+	// Attempt unseal
+	err = c.Seal(root)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		_, err = c.Unseal(result.SecretShares[i])
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+	if sealed, _ := c.Sealed(); sealed {
+		t.Fatalf("should be unsealed")
+	}
+
+	// Start another rekey, this time we require a quorum!
+	newConf = &SealConfig{
+		SecretThreshold: 1,
+		SecretShares:    1,
+	}
+	err = c.RekeyInit(newConf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Provide the parts master
+	oldResult := result
+	for i := 0; i < 3; i++ {
+		result, err = c.RekeyUpdate(oldResult.SecretShares[i])
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Should be progress
+		num, err := c.RekeyProgress()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if (i == 2 && num != 0) || (i != 2 && num != i+1) {
+			t.Fatalf("bad: %d", num)
+		}
+	}
+	if result == nil || len(result.SecretShares) != 1 {
+		t.Fatalf("Bad: %#v", result)
+	}
+
+	// Attempt unseal
+	err = c.Seal(root)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	unseal, err := c.Unseal(result.SecretShares[0])
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !unseal {
+		t.Fatalf("should be unsealed")
+	}
+
+	// SealConfig should update
+	conf, err = c.SealConfig()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(conf, newConf) {
+		t.Fatalf("bad: %#v", conf)
+	}
+}
+
+func TestCore_Rekey_InvalidMaster(t *testing.T) {
+	c, master, _ := TestCoreUnsealed(t)
+
+	// Start a rekey
+	newConf := &SealConfig{
+		SecretThreshold: 3,
+		SecretShares:    5,
+	}
+	err := c.RekeyInit(newConf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Provide the master (invalid)
+	master[0]++
+	_, err = c.RekeyUpdate(master)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -1513,7 +1513,12 @@ func TestCore_HandleRequest_MountPoint(t *testing.T) {
 }
 
 func TestCore_Rekey_Lifecycle(t *testing.T) {
-	c, _, _ := TestCoreUnsealed(t)
+	c, master, _ := TestCoreUnsealed(t)
+
+	// Verify update not allowed
+	if _, err := c.RekeyUpdate(master); err == nil {
+		t.Fatalf("no rekey in progress")
+	}
 
 	// Should be no progress
 	num, err := c.RekeyProgress()

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -1,0 +1,158 @@
+package vault
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// Keyring is used to manage multiple encryption keys used by
+// the barrier. New keys can be installed and each has a sequential term.
+// The term used to encrypt a key is prefixed to the key written out.
+// All data is encrypted with the latest key, but storing the old keys
+// allows for decryption of keys written previously. Along with the encryption
+// keys, the keyring also tracks the master key. This is necessary so that
+// when a new key is added to the keyring, we can encrypt with the master key
+// and write out the new keyring.
+type Keyring struct {
+	masterKey  []byte
+	keys       map[uint32]*Key
+	activeTerm uint32
+	l          sync.RWMutex
+}
+
+// EncodedKeyring is used for serialization of the keyring
+type EncodedKeyring struct {
+	MasterKey []byte
+	Keys      []*Key
+}
+
+// Key represents a single term, along with the key used.
+type Key struct {
+	Term  uint32
+	Value []byte
+}
+
+// NewKeyring creates a new keyring
+func NewKeyring() *Keyring {
+	k := &Keyring{
+		keys:       make(map[uint32]*Key),
+		activeTerm: 0,
+	}
+	return k
+}
+
+// AddKey adds a new key to the keyring
+func (k *Keyring) AddKey(term uint32, value []byte) error {
+	k.l.Lock()
+	defer k.l.Unlock()
+
+	// Ensure there is no confict
+	if key, ok := k.keys[term]; ok {
+		if !bytes.Equal(key.Value, value) {
+			return fmt.Errorf("Conflicting key for term %d already installed", term)
+		}
+		return nil
+	}
+
+	// Install the new key
+	key := &Key{
+		Term:  term,
+		Value: value,
+	}
+	k.keys[term] = key
+
+	// Update the active term if newer
+	if term > k.activeTerm {
+		k.activeTerm = term
+	}
+	return nil
+}
+
+// RemoveKey removes a new key to the keyring
+func (k *Keyring) RemoveKey(term uint32) error {
+	k.l.Lock()
+	defer k.l.Unlock()
+
+	// Ensure this is not the active key
+	if term == k.activeTerm {
+		return fmt.Errorf("Cannot remove active key")
+	}
+
+	// Delete the key
+	delete(k.keys, term)
+	return nil
+}
+
+// ActiveTerm returns the currently active term
+func (k *Keyring) ActiveTerm() uint32 {
+	k.l.RLock()
+	defer k.l.RUnlock()
+	return k.activeTerm
+}
+
+// ActiveKey returns the active encryption key, or nil
+func (k *Keyring) ActiveKey() *Key {
+	k.l.RLock()
+	defer k.l.RUnlock()
+	return k.keys[k.activeTerm]
+}
+
+// TermKey returns the key for the given term, or nil
+func (k *Keyring) TermKey(term uint32) *Key {
+	k.l.RLock()
+	defer k.l.RUnlock()
+	return k.keys[term]
+}
+
+// SetMasterKey is used to update the master key
+func (k *Keyring) SetMasterKey(val []byte) {
+	k.l.Lock()
+	defer k.l.Unlock()
+	k.masterKey = val
+}
+
+// MasterKey returns the master key
+func (k *Keyring) MasterKey() []byte {
+	k.l.RLock()
+	defer k.l.RUnlock()
+	return k.masterKey
+}
+
+// Serialize is used to create a byte encoded keyring
+func (k *Keyring) Serialize() ([]byte, error) {
+	k.l.RLock()
+	defer k.l.RUnlock()
+
+	// Create the encoded entry
+	enc := EncodedKeyring{
+		MasterKey: k.masterKey,
+	}
+	for _, key := range k.keys {
+		enc.Keys = append(enc.Keys, key)
+	}
+
+	// JSON encode the keyring
+	buf, err := json.Marshal(enc)
+	return buf, err
+}
+
+// DeserializeKeyring is used to deserialize and return a new keyring
+func DeserializeKeyring(buf []byte) (*Keyring, error) {
+	// Deserialize the keyring
+	var enc EncodedKeyring
+	if err := json.Unmarshal(buf, &enc); err != nil {
+		return nil, fmt.Errorf("deserialization failed: %v", err)
+	}
+
+	// Create a new keyring
+	k := NewKeyring()
+	k.SetMasterKey(enc.MasterKey)
+	for _, key := range enc.Keys {
+		if err := k.AddKey(key.Term, key.Value); err != nil {
+			return nil, fmt.Errorf("failed to add key for term %d: %v", key.Term, err)
+		}
+	}
+	return k, nil
+}

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -142,6 +142,18 @@ func (k *Keyring) Serialize() ([]byte, error) {
 	return buf, err
 }
 
+// Wipe is used to prepare for sealing my removing everything from memory
+func (k *Keyring) Wipe() {
+	if k.masterKey != nil {
+		memzero(k.masterKey)
+		k.masterKey = nil
+	}
+	for idx, key := range k.keys {
+		memzero(key.Value)
+		k.keys[idx] = nil
+	}
+}
+
 // DeserializeKeyring is used to deserialize and return a new keyring
 func DeserializeKeyring(buf []byte) (*Keyring, error) {
 	// Deserialize the keyring

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -32,6 +32,7 @@ type EncodedKeyring struct {
 // Key represents a single term, along with the key used.
 type Key struct {
 	Term        uint32
+	Version     int
 	Value       []byte
 	InstallTime time.Time
 }

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -58,6 +58,11 @@ func (k *Keyring) AddKey(key *Key) error {
 		return nil
 	}
 
+	// Add a time if none
+	if key.InstallTime.IsZero() {
+		key.InstallTime = time.Now()
+	}
+
 	// Install the new key
 	k.keys[key.Term] = key
 

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -35,6 +35,21 @@ type Key struct {
 	InstallTime time.Time
 }
 
+// Serialize is used to create a byte encoded key
+func (k *Key) Serialize() ([]byte, error) {
+	buf, err := json.Marshal(k)
+	return buf, err
+}
+
+// DeserializeKey is used to deserialize and return a new key
+func DeserializeKey(buf []byte) (*Key, error) {
+	k := new(Key)
+	if err := json.Unmarshal(buf, k); err != nil {
+		return nil, fmt.Errorf("deserialization failed: %v", err)
+	}
+	return k, nil
+}
+
 // NewKeyring creates a new keyring
 func NewKeyring() *Keyring {
 	k := &Keyring{

--- a/vault/keyring.go
+++ b/vault/keyring.go
@@ -120,8 +120,10 @@ func (k *Keyring) TermKey(term uint32) *Key {
 
 // SetMasterKey is used to update the master key
 func (k *Keyring) SetMasterKey(val []byte) *Keyring {
+	valCopy := make([]byte, len(val))
+	copy(valCopy, val)
 	clone := k.Clone()
-	clone.masterKey = val
+	clone.masterKey = valCopy
 	return clone
 }
 

--- a/vault/keyring_test.go
+++ b/vault/keyring_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestKeyring(t *testing.T) {
@@ -21,7 +22,8 @@ func TestKeyring(t *testing.T) {
 
 	// Add a key
 	testKey := []byte("testing")
-	err := k.AddKey(1, testKey)
+	key1 := &Key{1, testKey, time.Now()}
+	err := k.AddKey(key1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -44,21 +46,23 @@ func TestKeyring(t *testing.T) {
 	}
 
 	// Should handle idempotent set
-	err = k.AddKey(1, testKey)
+	err = k.AddKey(key1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Should not allow conficting set
 	testConflict := []byte("nope")
-	err = k.AddKey(1, testConflict)
+	key1Conf := &Key{1, testConflict, time.Now()}
+	err = k.AddKey(key1Conf)
 	if err == nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Add a new key
 	testSecond := []byte("second")
-	err = k.AddKey(2, testSecond)
+	key2 := &Key{2, testSecond, time.Now()}
+	err = k.AddKey(key2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -136,8 +140,8 @@ func TestKeyring_Serialize(t *testing.T) {
 
 	testKey := []byte("testing")
 	testSecond := []byte("second")
-	k.AddKey(1, testKey)
-	k.AddKey(2, testSecond)
+	k.AddKey(&Key{1, testKey, time.Now()})
+	k.AddKey(&Key{2, testSecond, time.Now()})
 
 	buf, err := k.Serialize()
 	if err != nil {

--- a/vault/keyring_test.go
+++ b/vault/keyring_test.go
@@ -1,0 +1,169 @@
+package vault
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestKeyring(t *testing.T) {
+	k := NewKeyring()
+
+	// Term should be 0
+	if term := k.ActiveTerm(); term != 0 {
+		t.Fatalf("bad: %d", term)
+	}
+
+	// Should have no key
+	if key := k.ActiveKey(); key != nil {
+		t.Fatalf("bad: %v", key)
+	}
+
+	// Add a key
+	testKey := []byte("testing")
+	err := k.AddKey(1, testKey)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Term should be 1
+	if term := k.ActiveTerm(); term != 1 {
+		t.Fatalf("bad: %d", term)
+	}
+
+	// Should have key
+	key := k.ActiveKey()
+	if key == nil {
+		t.Fatalf("bad: %v", key)
+	}
+	if !bytes.Equal(key.Value, testKey) {
+		t.Fatalf("bad: %v", key)
+	}
+	if tKey := k.TermKey(1); tKey != key {
+		t.Fatalf("bad: %v", tKey)
+	}
+
+	// Should handle idempotent set
+	err = k.AddKey(1, testKey)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Should not allow conficting set
+	testConflict := []byte("nope")
+	err = k.AddKey(1, testConflict)
+	if err == nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Add a new key
+	testSecond := []byte("second")
+	err = k.AddKey(2, testSecond)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Term should be 2
+	if term := k.ActiveTerm(); term != 2 {
+		t.Fatalf("bad: %d", term)
+	}
+
+	// Should have key
+	newKey := k.ActiveKey()
+	if newKey == nil {
+		t.Fatalf("bad: %v", key)
+	}
+	if !bytes.Equal(newKey.Value, testSecond) {
+		t.Fatalf("bad: %v", key)
+	}
+	if tKey := k.TermKey(2); tKey != newKey {
+		t.Fatalf("bad: %v", tKey)
+	}
+
+	// Read of old key should work
+	if tKey := k.TermKey(1); tKey != key {
+		t.Fatalf("bad: %v", tKey)
+	}
+
+	// Remove the old key
+	err = k.RemoveKey(1)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Read of old key should not work
+	if tKey := k.TermKey(1); tKey != nil {
+		t.Fatalf("bad: %v", tKey)
+	}
+
+	// Remove the active key should fail
+	err = k.RemoveKey(2)
+	if err == nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestKeyring_MasterKey(t *testing.T) {
+	k := NewKeyring()
+	master := []byte("test")
+	master2 := []byte("test2")
+
+	// Check no master
+	out := k.MasterKey()
+	if out != nil {
+		t.Fatalf("bad: %v", out)
+	}
+
+	// Set master
+	k.SetMasterKey(master)
+	out = k.MasterKey()
+	if !bytes.Equal(out, master) {
+		t.Fatalf("bad: %v", out)
+	}
+
+	// Update master
+	k.SetMasterKey(master2)
+	out = k.MasterKey()
+	if !bytes.Equal(out, master2) {
+		t.Fatalf("bad: %v", out)
+	}
+}
+
+func TestKeyring_Serialize(t *testing.T) {
+	k := NewKeyring()
+	master := []byte("test")
+	k.SetMasterKey(master)
+
+	testKey := []byte("testing")
+	testSecond := []byte("second")
+	k.AddKey(1, testKey)
+	k.AddKey(2, testSecond)
+
+	buf, err := k.Serialize()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	k2, err := DeserializeKeyring(buf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	out := k2.MasterKey()
+	if !bytes.Equal(out, master) {
+		t.Fatalf("bad: %v", out)
+	}
+
+	if k2.ActiveTerm() != k.ActiveTerm() {
+		t.Fatalf("Term mismatch")
+	}
+
+	var i uint32
+	for i = 1; i < k.ActiveTerm(); i++ {
+		key1 := k2.TermKey(i)
+		key2 := k.TermKey(i)
+		if !reflect.DeepEqual(key1, key2) {
+			t.Fatalf("bad: %v %v", key1, key2)
+		}
+	}
+}

--- a/vault/keyring_test.go
+++ b/vault/keyring_test.go
@@ -23,7 +23,7 @@ func TestKeyring(t *testing.T) {
 	// Add a key
 	testKey := []byte("testing")
 	key1 := &Key{Term: 1, Version: 1, Value: testKey, InstallTime: time.Now()}
-	err := k.AddKey(key1)
+	k, err := k.AddKey(key1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestKeyring(t *testing.T) {
 	}
 
 	// Should handle idempotent set
-	err = k.AddKey(key1)
+	k, err = k.AddKey(key1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestKeyring(t *testing.T) {
 	// Should not allow conficting set
 	testConflict := []byte("nope")
 	key1Conf := &Key{Term: 1, Version: 1, Value: testConflict, InstallTime: time.Now()}
-	err = k.AddKey(key1Conf)
+	_, err = k.AddKey(key1Conf)
 	if err == nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestKeyring(t *testing.T) {
 	// Add a new key
 	testSecond := []byte("second")
 	key2 := &Key{Term: 2, Version: 1, Value: testSecond, InstallTime: time.Now()}
-	err = k.AddKey(key2)
+	k, err = k.AddKey(key2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestKeyring(t *testing.T) {
 	}
 
 	// Remove the old key
-	err = k.RemoveKey(1)
+	k, err = k.RemoveKey(1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestKeyring(t *testing.T) {
 	}
 
 	// Remove the active key should fail
-	err = k.RemoveKey(2)
+	k, err = k.RemoveKey(2)
 	if err == nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -119,14 +119,14 @@ func TestKeyring_MasterKey(t *testing.T) {
 	}
 
 	// Set master
-	k.SetMasterKey(master)
+	k = k.SetMasterKey(master)
 	out = k.MasterKey()
 	if !bytes.Equal(out, master) {
 		t.Fatalf("bad: %v", out)
 	}
 
 	// Update master
-	k.SetMasterKey(master2)
+	k = k.SetMasterKey(master2)
 	out = k.MasterKey()
 	if !bytes.Equal(out, master2) {
 		t.Fatalf("bad: %v", out)
@@ -136,12 +136,12 @@ func TestKeyring_MasterKey(t *testing.T) {
 func TestKeyring_Serialize(t *testing.T) {
 	k := NewKeyring()
 	master := []byte("test")
-	k.SetMasterKey(master)
+	k = k.SetMasterKey(master)
 
 	testKey := []byte("testing")
 	testSecond := []byte("second")
-	k.AddKey(&Key{Term: 1, Version: 1, Value: testKey, InstallTime: time.Now()})
-	k.AddKey(&Key{Term: 2, Version: 1, Value: testSecond, InstallTime: time.Now()})
+	k, _ = k.AddKey(&Key{Term: 1, Version: 1, Value: testKey, InstallTime: time.Now()})
+	k, _ = k.AddKey(&Key{Term: 2, Version: 1, Value: testSecond, InstallTime: time.Now()})
 
 	buf, err := k.Serialize()
 	if err != nil {

--- a/vault/keyring_test.go
+++ b/vault/keyring_test.go
@@ -171,3 +171,26 @@ func TestKeyring_Serialize(t *testing.T) {
 		}
 	}
 }
+
+func TestKey_Serialize(t *testing.T) {
+	k := &Key{
+		Term:        10,
+		Version:     1,
+		Value:       []byte("foobarbaz"),
+		InstallTime: time.Now(),
+	}
+
+	buf, err := k.Serialize()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	out, err := DeserializeKey(buf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if !reflect.DeepEqual(k, out) {
+		t.Fatalf("bad: %#v", out)
+	}
+}

--- a/vault/keyring_test.go
+++ b/vault/keyring_test.go
@@ -22,7 +22,7 @@ func TestKeyring(t *testing.T) {
 
 	// Add a key
 	testKey := []byte("testing")
-	key1 := &Key{1, testKey, time.Now()}
+	key1 := &Key{Term: 1, Version: 1, Value: testKey, InstallTime: time.Now()}
 	err := k.AddKey(key1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -53,7 +53,7 @@ func TestKeyring(t *testing.T) {
 
 	// Should not allow conficting set
 	testConflict := []byte("nope")
-	key1Conf := &Key{1, testConflict, time.Now()}
+	key1Conf := &Key{Term: 1, Version: 1, Value: testConflict, InstallTime: time.Now()}
 	err = k.AddKey(key1Conf)
 	if err == nil {
 		t.Fatalf("err: %v", err)
@@ -61,7 +61,7 @@ func TestKeyring(t *testing.T) {
 
 	// Add a new key
 	testSecond := []byte("second")
-	key2 := &Key{2, testSecond, time.Now()}
+	key2 := &Key{Term: 2, Version: 1, Value: testSecond, InstallTime: time.Now()}
 	err = k.AddKey(key2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -140,8 +140,8 @@ func TestKeyring_Serialize(t *testing.T) {
 
 	testKey := []byte("testing")
 	testSecond := []byte("second")
-	k.AddKey(&Key{1, testKey, time.Now()})
-	k.AddKey(&Key{2, testSecond, time.Now()})
+	k.AddKey(&Key{Term: 1, Version: 1, Value: testKey, InstallTime: time.Now()})
+	k.AddKey(&Key{Term: 2, Version: 1, Value: testSecond, InstallTime: time.Now()})
 
 	buf, err := k.Serialize()
 	if err != nil {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -714,8 +714,10 @@ func (b *SystemBackend) handleKeyStatus(
 func (b *SystemBackend) handleRotate(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	if err := b.Core.barrier.Rotate(); err != nil {
+		b.Backend.Logger().Printf("[ERR] sys: failed to create new encryption key: %v", err)
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
+	b.Backend.Logger().Printf("[INFO] sys: installed new encryption key")
 	return nil, nil
 }
 

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -20,6 +20,7 @@ func TestSystemBackend_RootPaths(t *testing.T) {
 		"audit/*",
 		"seal",
 		"raw/*",
+		"rotate",
 	}
 
 	b := testSystemBackend(t)
@@ -666,6 +667,50 @@ func TestSystemBackend_rawDelete(t *testing.T) {
 	}
 	if out != nil {
 		t.Fatalf("policy should be gone")
+	}
+}
+
+func TestSystemBackend_keyStatus(t *testing.T) {
+	b := testSystemBackend(t)
+	req := logical.TestRequest(t, logical.ReadOperation, "key-status")
+	resp, err := b.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	exp := map[string]interface{}{
+		"term": 1,
+	}
+	delete(resp.Data, "install_time")
+	if !reflect.DeepEqual(resp.Data, exp) {
+		t.Fatalf("got: %#v expect: %#v", resp.Data, exp)
+	}
+}
+
+func TestSystemBackend_rotate(t *testing.T) {
+	b := testSystemBackend(t)
+
+	req := logical.TestRequest(t, logical.WriteOperation, "rotate")
+	resp, err := b.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("bad: %v", resp)
+	}
+
+	req = logical.TestRequest(t, logical.ReadOperation, "key-status")
+	resp, err = b.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	exp := map[string]interface{}{
+		"term": 2,
+	}
+	delete(resp.Data, "install_time")
+	if !reflect.DeepEqual(resp.Data, exp) {
+		t.Fatalf("got: %#v expect: %#v", resp.Data, exp)
 	}
 }
 

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -600,6 +600,16 @@ func TestSystemBackend_disableAudit_invalid(t *testing.T) {
 	}
 }
 
+func TestSystemBackend_rawRead_Protected(t *testing.T) {
+	b := testSystemBackend(t)
+
+	req := logical.TestRequest(t, logical.ReadOperation, "raw/"+keyringPath)
+	_, err := b.HandleRequest(req)
+	if err != logical.ErrInvalidRequest {
+		t.Fatalf("err: %v", err)
+	}
+}
+
 func TestSystemBackend_rawRead(t *testing.T) {
 	b := testSystemBackend(t)
 
@@ -610,6 +620,16 @@ func TestSystemBackend_rawRead(t *testing.T) {
 	}
 	if resp.Data["value"].(string)[0] != '{' {
 		t.Fatalf("bad: %v", resp)
+	}
+}
+
+func TestSystemBackend_rawWrite_Protected(t *testing.T) {
+	b := testSystemBackend(t)
+
+	req := logical.TestRequest(t, logical.WriteOperation, "raw/"+keyringPath)
+	_, err := b.HandleRequest(req)
+	if err != logical.ErrInvalidRequest {
+		t.Fatalf("err: %v", err)
 	}
 }
 
@@ -636,6 +656,16 @@ func TestSystemBackend_rawWrite(t *testing.T) {
 	}
 	if p.Paths[0].Prefix != "secret/" || p.Paths[0].Policy != PathPolicyRead {
 		t.Fatalf("Bad: %#v", p)
+	}
+}
+
+func TestSystemBackend_rawDelete_Protected(t *testing.T) {
+	b := testSystemBackend(t)
+
+	req := logical.TestRequest(t, logical.DeleteOperation, "raw/"+keyringPath)
+	_, err := b.HandleRequest(req)
+	if err != logical.ErrInvalidRequest {
+		t.Fatalf("err: %v", err)
 	}
 }
 

--- a/website/source/docs/http/sys-key-status.html.md
+++ b/website/source/docs/http/sys-key-status.html.md
@@ -1,0 +1,38 @@
+---
+layout: "http"
+page_title: "HTTP API: /sys/key-status"
+sidebar_current: "docs-http-rotate-key-status"
+description: |-
+  The '/sys/key-status' endpoint is used to query info about the current encryption key of Vault.
+---
+
+# /sys/key-status
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Returns information about the current encryption key used by Vault.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+    The "term" parameter is the sequential key number, and "install_time" is the time that
+    encryption key was installed.
+
+    ```javascript
+    {
+      "term": 3,
+      "install_time": "2015-05-29T14:50:46.223692553-07:00"
+    }
+    ```
+
+  </dd>
+</dl>

--- a/website/source/docs/http/sys-rekey.html.md
+++ b/website/source/docs/http/sys-rekey.html.md
@@ -1,0 +1,155 @@
+---
+layout: "http"
+page_title: "HTTP API: /sys/rekey/"
+sidebar_current: "docs-http-rotate-rekey"
+description: |-
+  The `/sys/rekey/` endpoints are used to rekey the unseal keys for Vault.
+---
+
+# /sys/rekey/init
+
+## GET
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+      Reads the configuration and progress of the current rekey attempt.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/rekey/init`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+    If a rekey is started, then "n" is the new shares to generate and "t" is
+    the threshold required for the new shares. The "progress" is how many unseal
+    keys have been provided for this rekey, where "required" must be reached to
+    complete.
+
+    ```javascript
+    {
+      "started": true,
+      "t": 3,
+      "n": 5,
+      "progress": 1,
+      "required": 3
+    }
+    ```
+
+  </dd>
+</dl>
+
+## PUT
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Initializes a new rekey attempt. Only a single rekey attempt can take place
+    at a time, and changing the parameters of a rekey requires canceling and starting
+    a new rekey.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>PUT</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/rekey/init`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">secret_shares</span>
+        <span class="param-flags">required</span>
+        The number of shares to split the master key into.
+      </li>
+      <li>
+        <span class="param">secret_threshold</span>
+        <span class="param-flags">required</span>
+        The number of shares required to reconstruct the master key.
+        This must be less than or equal to <code>secret_shares</code>.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+## DELETE
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Cancels any in-progress rekey. This clears the rekey settings as well as any
+    progress made. This must be called to change the parameters of the rekey.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>DELETE</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/rekey/init`</dd>
+
+  <dt>Parameters</dt>
+  <dd>None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+# /sys/rekey/update
+
+## PUT
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Enter a single master key share to progress the rekey of the Vault.
+    If the threshold number of master key shares is reached, Vault
+    will complete the rekey. Otherwise, this API must be called multiple
+    times until that threshold is met.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>PUT</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/rekey/update`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">key</span>
+        <span class="param-flags">required</span>
+        A single master share key.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+    A JSON-encoded object indicating completion and if so with the new master keys:
+
+    ```javascript
+    {
+      "complete": true,
+      "keys": ["one", "two", "three"]
+    }
+    ```
+
+  </dd>
+</dl>
+

--- a/website/source/docs/http/sys-rotate.html.md
+++ b/website/source/docs/http/sys-rotate.html.md
@@ -1,0 +1,37 @@
+---
+layout: "http"
+page_title: "HTTP API: /sys/rotate"
+sidebar_current: "docs-http-rotate-rotate"
+description: |-
+  The `/sys/rotate` endpoint is used to rotate the encryption key.
+---
+
+# /sys/rotate
+
+## PUT
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Trigger a rotation of the backend encryption key. This is the key that is used
+    to encrypt data written to the storage backend, and is not provided to operators.
+    This operation is done online. Future values are encrypted with the new key, while
+    old values are decrypted with previous encryption keys.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>PUT</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/rotate`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+

--- a/website/source/docs/internals/rotation.html.md
+++ b/website/source/docs/internals/rotation.html.md
@@ -1,0 +1,58 @@
+---
+layout: "docs"
+page_title: "Key Rotation"
+sidebar_current: "docs-internals-rotation"
+description: |-
+  Learn about the details of key rotation within Vault.
+---
+
+# Key Rotation
+
+Vault has multiple encryption keys that are used for various purposes. These keys support
+rotation so that they can be periodically changed or in response to a potential leak or
+compromise. It is useful to first understand the
+[high-level architecture](/docs/internals/architecture.html) before learning about key rotation.
+
+As a review, Vault starts in a _sealed_ state. Vault is unsealed by providing the unseal keys.
+By default, Vault uses a technique known as [Shamir's secret sharing algorithm](http://en.wikipedia.org/wiki/Shamir's_Secret_Sharing)
+to split the master key into 5 shares, any 3 of which are required to reconstruct the master
+key. The master key is used to protect the encryption key, which is ultimately used to protect
+data written to the storage backend.
+
+![Keys](/assets/images/keys.png)
+
+To support key rotation, we need to support changing the unseal keys, master key, and the
+backend encryption key. We split this into two seperate operations, `rekey` and `rotate`.
+
+The `rekey` operation is used to generate a new master key. When this is being done,
+it is possible to change the parameters of the key splitting, so that the number of shares
+and the threshold required to unseal can be changed. To perform a rekey a threshold of the
+current unseal keys must be provided. This is to prevent a single malicious operator from
+performing a rekey and invaliding the existing master key.
+
+Performing a rekey is fairly straightforward. The rekey operation must be initialized with
+the new parameters for the split and threshold. Once initialized, the current unseal keys
+must be provided until the threshold is met. Once met, Vault will generate the new master
+key, perform the splitting, and re-encrypt the encryption key with the new master key.
+The new unseal keys are then provided to the operator, and the old unseal keys are no
+longer usable.
+
+The `rotate` operation is used to change the encryption key used to protect data written
+to the storage backend. This key is never provided or visible to operators, who only
+have unseal keys. This simplifies the rotation, as it does not require the current key
+holders unlike the `rekey` operation. When `rotate` is triggered, a new encryption key
+is generated and added to a keyring. All new values written to the storage backend are
+encrypted with the new key. Old values written with previous encryption keys can still
+be decrypted since older keys are saved in the keyring. This allows key rotation to be
+done online, without an expensive re-encryption process.
+
+Both the `rekey` and `rotate` operations can be done online and in a highly available
+configuration. Only the active Vault instance can perform either of the operations
+but standby instances can still assume an active role after either operation. This is
+done by providing an online upgrade path for standby instances. If the current encryption
+key is `N` and a rotation installs `N+1`, Vault creates a special "upgrade" key, which
+provides the `N+1` encryption key protected by the `N` key. This upgrade key is only available
+for a few minutes enabling standby instances do a periodic check for upgrades.
+This allows standby instances to update their keys and stay in-sync with the active Vault
+without requiring operators to perform another unseal.
+

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -27,6 +27,10 @@
 
 						<li<%= sidebar_current("docs-internals-token") %>>
 							<a href="/docs/internals/token.html">Token Authentication</a>
+                        </li>
+
+						<li<%= sidebar_current("docs-internals-rotation") %>>
+							<a href="/docs/internals/rotation.html">Key Rotation</a>
 						</li>
 					</ul>
 				</li>

--- a/website/source/layouts/http.erb
+++ b/website/source/layouts/http.erb
@@ -11,7 +11,7 @@
 				<li<%= sidebar_current("docs-http-overview") %>>
 					<a href="/docs/http/index.html">Overview</a>
 				</li>
-        
+
 				<li<%= sidebar_current("docs-http-libraries") %>>
 					<a href="/docs/http/libraries.html">Libraries</a>
 				</li>
@@ -99,6 +99,23 @@
 					<ul class="nav nav-visible">
 						<li<%= sidebar_current("docs-http-ha-leader") %>>
 							<a href="/docs/http/sys-leader.html">/sys/leader</a>
+						</li>
+					</ul>
+                </li>
+
+                <li<%= sidebar_current("docs-http-rotate") %>>
+					<a href="#">Key Rotation</a>
+					<ul class="nav nav-visible">
+						<li<%= sidebar_current("docs-http-rotate-key-status") %>>
+							<a href="/docs/http/sys-key-status.html">/sys/key-status</a>
+                        </li>
+
+						<li<%= sidebar_current("docs-http-rotate-rekey") %>>
+							<a href="/docs/http/sys-rekey.html">/sys/rekey/</a>
+                        </li>
+
+						<li<%= sidebar_current("docs-http-rotate-rotate") %>>
+							<a href="/docs/http/sys-rotate.html">/sys/rotate</a>
 						</li>
 					</ul>
                 </li>


### PR DESCRIPTION
This PR adds support for key rotation. This allows the master key to be changed as part of a "rekey" operation. During a rekey, the unseal configuration (number of shares, threshold of shares) can be modified. The encryption key which protects the storage backend can also be changed as part of a "rotate" operation.

Both of these can be done online, and in an HA configuration of Vault. The changes to the underlying files  are backwards compatible and Vault does an automatic upgrade of them.