### PR TITLE
Add help info for -dev flag

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -409,6 +409,10 @@ General Options:
                       specified multiple times. If it is a directory, all
                       files with a ".hcl" or ".json" suffix will be loaded.
 
+  -dev                Enables Dev mode. In this mode, Vault is completely 
+                      in-memory and unsealed. Do not run the Dev server in 
+                      production!
+
   -log-level=info     Log verbosity. Defaults to "info", will be outputted
                       to stderr.
 


### PR DESCRIPTION
Had to look up the documentation on the website on how to set dev mode. The help should show this, I'd think.