### PR TITLE
etcd HA + tests

### DIFF
--- a/physical/etcd_test.go
+++ b/physical/etcd_test.go
@@ -37,4 +37,10 @@ func TestEtcdBackend(t *testing.T) {
 
 	testBackend(t, b)
 	testBackend_ListPrefix(t, b)
+
+	ha, ok := b.(HABackend)
+	if !ok {
+		t.Fatalf("etcd does not implement HABackend")
+	}
+	testHABackend(t, ha, ha)
 }


### PR DESCRIPTION
Added an HA implementation for the etcd physical backend. The relevant tests that already existed within the `physical` package pass, but there are still a few assumptions made here that I am unsure of.

* The value provided to the lock *should* be set within the same key/value-store namespace as values set without the lock (i.e. should be accessible with `Get` and overwritable with `Put`).
* The channel returned when the lock is acquired is closed when leadership is lost. The lock *should not* attempt to detect if leadership is lost hostilely (e.g. when a semaphore key expires or is deleted by another client).

If either of those are problematic, there's more work to be done here.

Thanks!

Fixes https://github.com/hashicorp/vault/issues/296