### PR TITLE
Fix nil dereference in API client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -69,6 +69,10 @@ func NewClient(c *Config) (*Client, error) {
 		return nil, err
 	}
 
+	if c.HttpClient == nil {
+		c.HttpClient = http.DefaultClient
+	}
+
 	// Make a copy of the HTTP client so we can configure it without
 	// affecting the original
 	//


### PR DESCRIPTION
The docs say that if HttpClient is nil, http.DefaultClient will be used. However, the code doesn't do this, resulting in a nil dereference.