### PR TITLE
Record the common name in TLS metadata

### DIFF
--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -62,6 +62,7 @@ func (b *backend) pathLogin(
 			DisplayName: matched.Entry.DisplayName,
 			Metadata: map[string]string{
 				"cert_name": matched.Entry.Name,
+				"common_name": connState.PeerCertificates[0].Subject.CommonName,
 			},
 			LeaseOptions: logical.LeaseOptions{
 				Renewable: true,


### PR DESCRIPTION
It is useful to be able to save the client cert's Common Name for auditing purposes when using a central CA.

This adds a "common_name" value to the Metadata structure passed from login.