### PR TITLE
Fixing various issues around leasing

### DIFF
--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -61,7 +61,7 @@ func (b *backend) pathLogin(
 			Policies:    matched.Entry.Policies,
 			DisplayName: matched.Entry.DisplayName,
 			Metadata: map[string]string{
-				"cert_name": matched.Entry.Name,
+				"cert_name":   matched.Entry.Name,
 				"common_name": connState.PeerCertificates[0].Subject.CommonName,
 			},
 			LeaseOptions: logical.LeaseOptions{
@@ -187,5 +187,5 @@ func (b *backend) pathLoginRenew(
 		return nil, nil
 	}
 
-	return framework.LeaseExtend(cert.Lease, 0)(req, d)
+	return framework.LeaseExtend(cert.Lease, 0, false)(req, d)
 }

--- a/builtin/credential/ldap/path_login.go
+++ b/builtin/credential/ldap/path_login.go
@@ -77,7 +77,7 @@ func (b *backend) pathLoginRenew(
 		return logical.ErrorResponse("policies have changed, revoking login"), nil
 	}
 
-	return framework.LeaseExtend(1*time.Hour, 0)(req, d)
+	return framework.LeaseExtend(1*time.Hour, 0, false)(req, d)
 }
 
 const pathLoginSyn = `

--- a/builtin/credential/userpass/path_login.go
+++ b/builtin/credential/userpass/path_login.go
@@ -68,7 +68,7 @@ func (b *backend) pathLoginRenew(
 		return nil, nil
 	}
 
-	return framework.LeaseExtend(1*time.Hour, 0)(req, d)
+	return framework.LeaseExtend(1*time.Hour, 0, false)(req, d)
 }
 
 const pathLoginSyn = `

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -115,7 +115,7 @@ func (b *backend) secretAccessKeysRenew(
 		lease = &configLease{Lease: 1 * time.Hour}
 	}
 
-	f := framework.LeaseExtend(lease.Lease, lease.LeaseMax)
+	f := framework.LeaseExtend(lease.Lease, lease.LeaseMax, false)
 	return f(req, d)
 }
 

--- a/builtin/logical/consul/secret_token.go
+++ b/builtin/logical/consul/secret_token.go
@@ -26,7 +26,7 @@ func secretToken() *framework.Secret {
 		DefaultDuration:    DefaultLeaseDuration,
 		DefaultGracePeriod: DefaultGracePeriod,
 
-		Renew:  framework.LeaseExtend(1*time.Hour, 0),
+		Renew:  framework.LeaseExtend(0, 0, true),
 		Revoke: secretTokenRevoke,
 	}
 }

--- a/builtin/logical/mysql/secret_creds.go
+++ b/builtin/logical/mysql/secret_creds.go
@@ -44,7 +44,7 @@ func (b *backend) secretCredsRenew(
 		lease = &configLease{Lease: 1 * time.Hour}
 	}
 
-	f := framework.LeaseExtend(lease.Lease, lease.LeaseMax)
+	f := framework.LeaseExtend(lease.Lease, lease.LeaseMax, false)
 	return f(req, d)
 }
 

--- a/builtin/logical/postgresql/secret_creds.go
+++ b/builtin/logical/postgresql/secret_creds.go
@@ -58,7 +58,7 @@ func (b *backend) secretCredsRenew(
 		lease = &configLease{Lease: 1 * time.Hour}
 	}
 
-	f := framework.LeaseExtend(lease.Lease, lease.LeaseMax)
+	f := framework.LeaseExtend(lease.Lease, lease.LeaseMax, false)
 	resp, err := f(req, d)
 	if err != nil {
 		return nil, err

--- a/logical/framework/backend_test.go
+++ b/logical/framework/backend_test.go
@@ -215,7 +215,7 @@ func TestBackendHandleRequest_renew(t *testing.T) {
 func TestBackendHandleRequest_renewExtend(t *testing.T) {
 	secret := &Secret{
 		Type:            "foo",
-		Renew:           LeaseExtend(0, 0),
+		Renew:           LeaseExtend(0, 0, false),
 		DefaultDuration: 5 * time.Minute,
 	}
 	b := &Backend{

--- a/logical/framework/lease.go
+++ b/logical/framework/lease.go
@@ -13,7 +13,7 @@ import (
 // setting it to 2 hours forces a renewal within the next 2 hours again.
 //
 // maxSession is the maximum session length allowed since the original
-// issue time. If this is zero, it is ignored,.
+// issue time. If this is zero, it is ignored.
 func LeaseExtend(max, maxSession time.Duration) OperationFunc {
 	return func(req *logical.Request, data *FieldData) (*logical.Response, error) {
 		lease := detectLease(req)
@@ -21,55 +21,44 @@ func LeaseExtend(max, maxSession time.Duration) OperationFunc {
 			return nil, fmt.Errorf("no lease options for request")
 		}
 
+		// Sanity check the desired increment
+		switch {
+		// Protect against negative leases
+		case lease.LeaseIncrement < 0:
+			return logical.ErrorResponse(
+				"increment must be greater than 0"), logical.ErrInvalidRequest
+
+		// If no lease increment, or too large of an increment, use the max
+		case max > 0 && lease.LeaseIncrement == 0, max > 0 && lease.LeaseIncrement > max:
+			lease.LeaseIncrement = max
+		}
+
+		// Get the current time
 		now := time.Now().UTC()
 
 		// Check if we're passed the issue limit
 		var maxSessionTime time.Time
 		if maxSession > 0 {
 			maxSessionTime = lease.LeaseIssue.Add(maxSession)
-			if maxSessionTime.Sub(now) <= 0 {
+			if maxSessionTime.Before(now) {
 				return logical.ErrorResponse(fmt.Sprintf(
 					"lease can only be renewed up to %s past original issue",
 					maxSession)), logical.ErrInvalidRequest
 			}
 		}
 
-		// Protect against negative leases
-		if lease.LeaseIncrement < 0 {
-			return logical.ErrorResponse(
-				"increment must be greater than 0"), logical.ErrInvalidRequest
-		}
-
-		// If the lease is zero, then assume max
-		if lease.LeaseIncrement == 0 {
-			lease.LeaseIncrement = max
-		}
-
-		// If the increment is greater than the amount of time we have left
-		// on our session, set it to that.
-		if !maxSessionTime.IsZero() {
-			diff := maxSessionTime.Sub(lease.ExpirationTime())
-			if diff < lease.LeaseIncrement {
-				lease.LeaseIncrement = diff
-			}
+		// The new lease is the minimum of the requested LeaseIncrement
+		// or the maxSessionTime
+		requestedLease := now.Add(lease.LeaseIncrement)
+		if !maxSessionTime.IsZero() && requestedLease.After(maxSessionTime) {
+			requestedLease = maxSessionTime
 		}
 
 		// Determine the requested lease
-		newLease := lease.IncrementedLease(lease.LeaseIncrement)
-
-		if max > 0 {
-			// Determine if the requested lease is too long
-			maxExpiration := now.Add(max)
-			newExpiration := now.Add(newLease)
-			if newExpiration.Sub(maxExpiration) > 0 {
-				// The new expiration is past the max expiration. In this
-				// case, admit the longest lease we can.
-				newLease = maxExpiration.Sub(lease.ExpirationTime())
-			}
-		}
+		newLeaseDuration := requestedLease.Sub(now)
 
 		// Set the lease
-		lease.Lease = newLease
+		lease.Lease = newLeaseDuration
 		return &logical.Response{Auth: req.Auth, Secret: req.Secret}, nil
 	}
 }
@@ -80,6 +69,5 @@ func detectLease(req *logical.Request) *logical.LeaseOptions {
 	} else if req.Secret != nil {
 		return &req.Secret.LeaseOptions
 	}
-
 	return nil
 }

--- a/logical/framework/lease.go
+++ b/logical/framework/lease.go
@@ -14,11 +14,20 @@ import (
 //
 // maxSession is the maximum session length allowed since the original
 // issue time. If this is zero, it is ignored.
-func LeaseExtend(max, maxSession time.Duration) OperationFunc {
+//
+// maxFromLease controls if the maximum renewal period comes from the existing
+// lease. This means the value of `max` will be replaced with the existing
+// lease duration.
+func LeaseExtend(max, maxSession time.Duration, maxFromLease bool) OperationFunc {
 	return func(req *logical.Request, data *FieldData) (*logical.Response, error) {
 		lease := detectLease(req)
 		if lease == nil {
 			return nil, fmt.Errorf("no lease options for request")
+		}
+
+		// Check if we should limit max
+		if maxFromLease {
+			max = lease.Lease
 		}
 
 		// Sanity check the desired increment

--- a/logical/lease.go
+++ b/logical/lease.go
@@ -46,22 +46,8 @@ func (l *LeaseOptions) LeaseTotal() time.Duration {
 // ExpirationTime computes the time until expiration including the grace period
 func (l *LeaseOptions) ExpirationTime() time.Time {
 	var expireTime time.Time
-	if !l.LeaseIssue.IsZero() && l.Lease > 0 {
-		expireTime = l.LeaseIssue.UTC().Add(l.LeaseTotal())
+	if l.LeaseEnabled() {
+		expireTime = time.Now().UTC().Add(l.LeaseTotal())
 	}
-
 	return expireTime
-}
-
-// IncrementedLease returns the lease duration that would need to set
-// in order to increment the _current_ lease by the given duration
-// if the auth were re-issued right now.
-func (l *LeaseOptions) IncrementedLease(inc time.Duration) time.Duration {
-	var result time.Duration
-	expireTime := l.ExpirationTime()
-	if expireTime.IsZero() {
-		return result
-	}
-
-	return expireTime.Add(inc).Sub(time.Now().UTC())
 }

--- a/logical/lease_test.go
+++ b/logical/lease_test.go
@@ -5,17 +5,6 @@ import (
 	"time"
 )
 
-func TestLeaseOptionsIncrementedLease(t *testing.T) {
-	var l LeaseOptions
-	l.Lease = 1 * time.Second
-	l.LeaseIssue = time.Now().UTC()
-
-	actual := l.IncrementedLease(1 * time.Second)
-	if actual > 3*time.Second || actual < 1*time.Second {
-		t.Fatalf("bad: %s", actual)
-	}
-}
-
 func TestLeaseOptionsLeaseTotal(t *testing.T) {
 	var l LeaseOptions
 	l.Lease = 1 * time.Hour
@@ -66,12 +55,11 @@ func TestLeaseOptionsLeaseTotal_negGrace(t *testing.T) {
 func TestLeaseOptionsExpirationTime(t *testing.T) {
 	var l LeaseOptions
 	l.Lease = 1 * time.Hour
-	l.LeaseIssue = time.Now().UTC()
 
-	actual := l.ExpirationTime()
-	expected := l.LeaseIssue.Add(l.Lease)
-	if !actual.Equal(expected) {
-		t.Fatalf("bad: %s", actual)
+	limit := time.Now().UTC().Add(time.Hour)
+	exp := l.ExpirationTime()
+	if exp.Before(limit) {
+		t.Fatalf("bad: %s", exp)
 	}
 }
 
@@ -79,11 +67,10 @@ func TestLeaseOptionsExpirationTime_grace(t *testing.T) {
 	var l LeaseOptions
 	l.Lease = 1 * time.Hour
 	l.LeaseGracePeriod = 30 * time.Minute
-	l.LeaseIssue = time.Now().UTC()
 
+	limit := time.Now().UTC().Add(time.Hour + 30*time.Minute)
 	actual := l.ExpirationTime()
-	expected := l.LeaseIssue.Add(l.Lease + l.LeaseGracePeriod)
-	if !actual.Equal(expected) {
+	if actual.Before(limit) {
 		t.Fatalf("bad: %s", actual)
 	}
 }
@@ -92,11 +79,10 @@ func TestLeaseOptionsExpirationTime_graceNegative(t *testing.T) {
 	var l LeaseOptions
 	l.Lease = 1 * time.Hour
 	l.LeaseGracePeriod = -1 * 30 * time.Minute
-	l.LeaseIssue = time.Now().UTC()
 
+	limit := time.Now().UTC().Add(time.Hour)
 	actual := l.ExpirationTime()
-	expected := l.LeaseIssue.Add(l.Lease)
-	if !actual.Equal(expected) {
+	if actual.Before(limit) {
 		t.Fatalf("bad: %s", actual)
 	}
 }

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -337,7 +337,6 @@ func (m *ExpirationManager) RenewToken(source string, token string,
 	// Attach the ClientToken
 	resp.Auth.ClientToken = token
 	resp.Auth.LeaseIncrement = 0
-	resp.Auth.LeaseIssue = time.Now().UTC()
 
 	// Update the lease entry
 	le.Auth = resp.Auth
@@ -366,9 +365,6 @@ func (m *ExpirationManager) Register(req *logical.Request, resp *logical.Respons
 		return "", err
 	}
 
-	// Setup some of the fields on auth
-	resp.Secret.LeaseIssue = time.Now().UTC()
-
 	// Create a lease entry
 	le := leaseEntry{
 		LeaseID:     path.Join(req.Path, generateUUID()),
@@ -376,7 +372,7 @@ func (m *ExpirationManager) Register(req *logical.Request, resp *logical.Respons
 		Path:        req.Path,
 		Data:        resp.Data,
 		Secret:      resp.Secret,
-		IssueTime:   resp.Secret.LeaseIssue,
+		IssueTime:   time.Now().UTC(),
 		ExpireTime:  resp.Secret.ExpirationTime(),
 	}
 
@@ -403,16 +399,13 @@ func (m *ExpirationManager) Register(req *logical.Request, resp *logical.Respons
 func (m *ExpirationManager) RegisterAuth(source string, auth *logical.Auth) error {
 	defer metrics.MeasureSince([]string{"expire", "register-auth"}, time.Now())
 
-	// Setup some of the fields on auth
-	auth.LeaseIssue = time.Now().UTC()
-
 	// Create a lease entry
 	le := leaseEntry{
 		LeaseID:     path.Join(source, m.tokenStore.SaltID(auth.ClientToken)),
 		ClientToken: auth.ClientToken,
 		Auth:        auth,
 		Path:        source,
-		IssueTime:   auth.LeaseIssue,
+		IssueTime:   time.Now().UTC(),
 		ExpireTime:  auth.ExpirationTime(),
 	}
 

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -85,7 +85,10 @@ func NewTokenStore(c *Core) (*TokenStore, error) {
 
 	// Setup the framework endpoints
 	t.Backend = &framework.Backend{
-		AuthRenew: framework.LeaseExtend(0, 0),
+		// Allow a token lease to be extended indefinitely, but each time for only
+		// as much as the original lease allowed for. If the lease has a 1 hour expiration,
+		// it can only be extended up to another hour each time this means.
+		AuthRenew: framework.LeaseExtend(0, 0, true),
 
 		PathsSpecial: &logical.Paths{
 			Root: []string{


### PR DESCRIPTION
There was a bit of a mis-match between how core was handling leasing and how the backends were interacting. There was some funny logic around LeaseIncrement, LeaseIssue and Lease. The old code was reseting the LeaseIssue on renew and then using Lease to track the total lease lifespan causing it to be an accumulator.

Instead, the LeaseIssue time should be fixed at the time of issue, and the Lease value is just the amount to extend expiration by each time. This way both values are relatively static. The LeaseIssue is only used ephemerally for a renew request and is optional.

This should fix a number of issues: #353 #345 #328 
