### PR TITLE
Fix typo in link to Atlas URL on Community page.

### DIFF
--- a/website/source/community.html.erb
+++ b/website/source/community.html.erb
@@ -74,7 +74,7 @@ employees actively contribute to Vault.
 			Jack Pearkes is the creator of the online interactive demo of Vault.
 			He maintains this demo as well as the design and interaction of the
 			Vault website. Jack is an employee of HashiCorp and a primary engineer
-			behind <a href="https//atlas.hashicorp.com">Atlas</a>.
+			behind <a href="https://atlas.hashicorp.com">Atlas</a>.
 			He is also a core committer to
 			<a href="https://www.packer.io">Packer</a>,
 			<a href="https://www.consul.io">Consul</a>, and


### PR DESCRIPTION
Missing a colon after https!