### PR TITLE
Fixing key-status if audit logging is on

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -741,7 +741,7 @@ func (b *SystemBackend) handleKeyStatus(
 	resp := &logical.Response{
 		Data: map[string]interface{}{
 			"term":         info.Term,
-			"install_time": info.InstallTime,
+			"install_time": info.InstallTime.Format(time.RFC3339),
 		},
 	}
 	return resp, nil


### PR DESCRIPTION
If audit logging is enabled `vault key-status` results in a panic due to

```
reflect.Value.Interface: cannot return value obtained from unexported field or method
```

This fixes that by formatting `install_time` before returning.

I think a more general fix is needed since any api that returns unexported fields can cause a panic if audit logging is enabled, I haven't thought about what that might look like though. 