### PR TITLE
LDAP Auth - Add StartTLS and server CA certificate options

### DIFF
--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -90,7 +90,9 @@ $ vault write auth/ldap/config url="ldap://ldap.forumsys.com" \
 		userattr=uid \
         userdn="dc=example,dc=com" \
         groupdn="dc=example,dc=com" \
+        certificate=@ldap_ca_cert.pem \
         insecure_tls=false \
+        starttls=true
 ...
 ```
 


### PR DESCRIPTION
Adds two new fields to LDAP auth backend configuration.
  * starttls: boolean flag to perform a StartTLS operation (upgrades an unencrypted connection)
  * certificate: the CA certificate to use when verifying the LDAP server certificate 