### PR TITLE
Support for key derivation in secret/transit

### DIFF
--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -200,7 +200,7 @@ func testAccStepEncryptContext(
 		Path:      "encrypt/" + name,
 		Data: map[string]interface{}{
 			"plaintext": base64.StdEncoding.EncodeToString([]byte(plaintext)),
-			"context":   context,
+			"context":   base64.StdEncoding.EncodeToString([]byte(context)),
 		},
 		Check: func(resp *logical.Response) error {
 			var d struct {
@@ -213,7 +213,7 @@ func testAccStepEncryptContext(
 				return fmt.Errorf("missing ciphertext")
 			}
 			decryptData["ciphertext"] = d.Ciphertext
-			decryptData["context"] = context
+			decryptData["context"] = base64.StdEncoding.EncodeToString([]byte(context))
 			return nil
 		},
 	}

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -117,7 +117,7 @@ func testAccStepReadPolicy(t *testing.T, name string, expectNone, derived bool) 
 			if d.Derived != derived {
 				return fmt.Errorf("bad: %#v", d)
 			}
-			if derived && d.KDFMode != "hmac-sha256-counter" {
+			if derived && d.KDFMode != kdfMode {
 				return fmt.Errorf("bad: %#v", d)
 			}
 			return nil
@@ -161,7 +161,7 @@ func testAccStepReadRaw(t *testing.T, name string, expectNone, derived bool) log
 			if d.Derived != derived {
 				return fmt.Errorf("bad: %#v", d)
 			}
-			if derived && d.KDFMode != "hmac-sha256-counter" {
+			if derived && d.KDFMode != kdfMode {
 				return fmt.Errorf("bad: %#v", d)
 			}
 			return nil

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -59,9 +59,10 @@ func pathDecryptWrite(
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
 	}
 
-	// Ensure a context for derived keys
-	if p.Derived && len(context) == 0 {
-		return logical.ErrorResponse("missing context for key derivation"), logical.ErrInvalidRequest
+	// Derive the key that should be used
+	key, err := p.DeriveKey([]byte(context))
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 
 	// Guard against a potentially invalid cipher-mode
@@ -83,7 +84,7 @@ func pathDecryptWrite(
 	}
 
 	// Setup the cipher
-	aesCipher, err := aes.NewCipher(p.Key)
+	aesCipher, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -46,7 +46,17 @@ func pathDecryptWrite(
 	if len(value) == 0 {
 		return logical.ErrorResponse("missing ciphertext to decrypt"), logical.ErrInvalidRequest
 	}
-	context := d.Get("context").(string)
+
+	// Decode the context if any
+	contextRaw := d.Get("context").(string)
+	var context []byte
+	if len(contextRaw) != 0 {
+		var err error
+		context, err = base64.StdEncoding.DecodeString(contextRaw)
+		if err != nil {
+			return logical.ErrorResponse("failed to decode context as base64"), logical.ErrInvalidRequest
+		}
+	}
 
 	// Get the policy
 	p, err := getPolicy(req, name)
@@ -60,7 +70,7 @@ func pathDecryptWrite(
 	}
 
 	// Derive the key that should be used
-	key, err := p.DeriveKey([]byte(context))
+	key, err := p.DeriveKey(context)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -73,7 +73,8 @@ func pathEncryptWrite(
 
 	// Error if invalid policy
 	if p == nil {
-		p, err = generatePolicy(req.Storage, name, len(context) != 0)
+		isDerived := len(context) != 0
+		p, err = generatePolicy(req.Storage, name, isDerived)
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf("failed to upsert policy: %v", err)), logical.ErrInvalidRequest
 		}

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -47,12 +47,22 @@ func pathEncryptWrite(
 	if len(value) == 0 {
 		return logical.ErrorResponse("missing plaintext to encrypt"), logical.ErrInvalidRequest
 	}
-	context := d.Get("context").(string)
 
 	// Decode the plaintext value
 	plaintext, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
 		return logical.ErrorResponse("failed to decode plaintext as base64"), logical.ErrInvalidRequest
+	}
+
+	// Decode the context if any
+	contextRaw := d.Get("context").(string)
+	var context []byte
+	if len(contextRaw) != 0 {
+		var err error
+		context, err = base64.StdEncoding.DecodeString(contextRaw)
+		if err != nil {
+			return logical.ErrorResponse("failed to decode context as base64"), logical.ErrInvalidRequest
+		}
 	}
 
 	// Get the policy
@@ -70,7 +80,7 @@ func pathEncryptWrite(
 	}
 
 	// Derive the key that should be used
-	key, err := p.DeriveKey([]byte(context))
+	key, err := p.DeriveKey(context)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}

--- a/builtin/logical/transit/path_raw.go
+++ b/builtin/logical/transit/path_raw.go
@@ -41,6 +41,8 @@ func pathRawRead(
 			"name":        p.Name,
 			"key":         p.Key,
 			"cipher_mode": p.CipherMode,
+			"derived":     p.Derived,
+			"kdf_mode":    p.KDFMode,
 		},
 	}
 	return resp, nil

--- a/builtin/logical/transit/path_raw.go
+++ b/builtin/logical/transit/path_raw.go
@@ -42,8 +42,10 @@ func pathRawRead(
 			"key":         p.Key,
 			"cipher_mode": p.CipherMode,
 			"derived":     p.Derived,
-			"kdf_mode":    p.KDFMode,
 		},
+	}
+	if p.Derived {
+		resp.Data["kdf_mode"] = p.KDFMode
 	}
 	return resp, nil
 }

--- a/helper/kdf/kdf.go
+++ b/helper/kdf/kdf.go
@@ -1,0 +1,77 @@
+// This package is used to implement Key Derivation Functions (KDF)
+// based on the recommendations of NIST SP 800-108. These are useful
+// for generating unique-per-transaction keys, or situations in which
+// a key hierarchy may be useful.
+package kdf
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+)
+
+// PRF is a psuedo-random function that takes a key or seed,
+// as well as additional binary data and generates output that is
+// indistinguishable from random. Examples are cryptographic hash
+// functions or block ciphers.
+type PRF func([]byte, []byte) ([]byte, error)
+
+// CounterMode implements the counter mode KDF that uses a psuedo-random-function (PRF)
+// along with a counter to generate derived keys. The KDF takes a base key
+// a derivation context, and the requried number of output bits.
+func CounterMode(prf PRF, prfLen uint32, base []byte, context []byte, bits uint32) ([]byte, error) {
+	// Ensure the PRF is byte aligned
+	if prfLen%8 != 0 {
+		return nil, fmt.Errorf("PRF must be byte aligned")
+	}
+
+	// Ensure the bits required are byte aligned
+	if bits%8 != 0 {
+		return nil, fmt.Errorf("bits required must be byte aligned")
+	}
+
+	// Determine the number of rounds required
+	rounds := bits / prfLen
+	if bits%prfLen != 0 {
+		rounds++
+	}
+
+	// Allocate and setup the input
+	input := make([]byte, 4+len(context)+4)
+	copy(input[4:], context)
+	binary.BigEndian.PutUint32(input[4+len(context):], bits)
+
+	// Iteratively generate more key material
+	var out []byte
+	var i uint32
+	for i = 0; i < rounds; i++ {
+		// Update the counter in the input string
+		binary.BigEndian.PutUint32(input[:4], i)
+
+		// Compute a more key material
+		part, err := prf(base, input)
+		if err != nil {
+			return nil, err
+		}
+		if uint32(len(part)*8) != prfLen {
+			return nil, fmt.Errorf("PRF length mis-match (%d vs %d)", len(part)*8, prfLen)
+		}
+		out = append(out, part...)
+	}
+
+	// Return the desired number of output bytes
+	return out[:bits/8], nil
+}
+
+const (
+	// HMACSHA256PRFLen is the length of output from HMACSHA256PRF
+	HMACSHA256PRFLen uint32 = 256
+)
+
+// HMACSHA256PRF is a pseudo-random-function (PRF) that uses an HMAC-SHA256
+func HMACSHA256PRF(key []byte, data []byte) ([]byte, error) {
+	hash := hmac.New(sha256.New, key)
+	hash.Write(data)
+	return hash.Sum(nil), nil
+}

--- a/helper/kdf/kdf.go
+++ b/helper/kdf/kdf.go
@@ -20,7 +20,7 @@ type PRF func([]byte, []byte) ([]byte, error)
 // CounterMode implements the counter mode KDF that uses a psuedo-random-function (PRF)
 // along with a counter to generate derived keys. The KDF takes a base key
 // a derivation context, and the requried number of output bits.
-func CounterMode(prf PRF, prfLen uint32, base []byte, context []byte, bits uint32) ([]byte, error) {
+func CounterMode(prf PRF, prfLen uint32, key []byte, context []byte, bits uint32) ([]byte, error) {
 	// Ensure the PRF is byte aligned
 	if prfLen%8 != 0 {
 		return nil, fmt.Errorf("PRF must be byte aligned")
@@ -50,7 +50,7 @@ func CounterMode(prf PRF, prfLen uint32, base []byte, context []byte, bits uint3
 		binary.BigEndian.PutUint32(input[:4], i)
 
 		// Compute a more key material
-		part, err := prf(base, input)
+		part, err := prf(key, input)
 		if err != nil {
 			return nil, err
 		}

--- a/helper/kdf/kdf_test.go
+++ b/helper/kdf/kdf_test.go
@@ -1,0 +1,72 @@
+package kdf
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCounterMode(t *testing.T) {
+	key := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	context := []byte("the quick brown fox")
+	prf := HMACSHA256PRF
+	prfLen := HMACSHA256PRFLen
+
+	// Expect256 was generated in python with
+	// import hashlib, hmac
+	// hash = hashlib.sha256
+	// context = "the quick brown fox"
+	// key = "".join([chr(x) for x in range(1, 17)])
+	// inp = "\x00\x00\x00\x00"+context+"\x00\x00\x01\x00"
+	// digest = hmac.HMAC(key, inp, hash).digest()
+	// print [ord(x) for x in digest]
+	expect256 := []byte{219, 25, 238, 6, 185, 236, 180, 64, 248, 152, 251,
+		153, 79, 5, 141, 222, 66, 200, 66, 143, 40, 3, 101, 221, 206, 163, 102,
+		80, 88, 234, 87, 157}
+
+	for _, l := range []uint32{128, 256, 384, 1024} {
+		out, err := CounterMode(prf, prfLen, key, context, l)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if uint32(len(out)*8) != l {
+			t.Fatalf("bad length: %#v", out)
+		}
+
+		if bytes.Contains(out, key) {
+			t.Fatalf("output contains key")
+		}
+
+		if l == 256 && !bytes.Equal(out, expect256) {
+			t.Fatalf("mis-match")
+		}
+	}
+
+}
+
+func TestHMACSHA256PRF(t *testing.T) {
+	key := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	data := []byte("foobarbaz")
+	out, err := HMACSHA256PRF(key, data)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if uint32(len(out)*8) != HMACSHA256PRFLen {
+		t.Fatalf("Bad len")
+	}
+
+	// Expect was generated in python with:
+	// import hashlib, hmac
+	// hash = hashlib.sha256
+	// msg = "foobarbaz"
+	// key = "".join([chr(x) for x in range(1, 17)])
+	// hm = hmac.HMAC(key, msg, hash)
+	// print [ord(x) for x in hm.digest()]
+	expect := []byte{9, 50, 146, 8, 188, 130, 150, 107, 205, 147, 82, 170,
+		253, 183, 26, 38, 167, 194, 220, 111, 56, 118, 219, 209, 31, 52, 137,
+		90, 246, 133, 191, 124}
+	if !bytes.Equal(expect, out) {
+		t.Fatalf("mis-matched output")
+	}
+}

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -21,9 +21,9 @@ application developers and pushes the burden onto the operators of Vault.
 Operators of Vault generally include the security team at an organization,
 which means they can ensure that data is encrypted/decrypted properly.
 
-The transit backend also supports doing key derivation. This allows data to be
-encrypted within a context such that the same context must be used for
-decryption. This can be used to enable per transaction unique keys which
+As of Vault 0.2, the transit backend also supports doing key derivation. This
+allows data to be encrypted within a context such that the same context must be
+used for decryption. This can be used to enable per transaction unique keys which
 further increase the security of data at rest.
 
 Additionally, since encrypt/decrypt operations must enter the audit log,
@@ -57,10 +57,9 @@ the settings of the "foo" key by reading it:
 ```
 $ vault read transit/keys/foo
 Key        	Value
-name       	foo
-cipher_mode	aes-gcm
+name        foo
+cipher_mode aes-gcm
 derived     false
-kdf_mode
 ````
 
 We can read from the `raw/` endpoint to see the encryption key itself:
@@ -72,7 +71,6 @@ name       	foo
 cipher_mode	aes-gcm
 key        	PhKFTALCmhAhVQfMBAH4+UwJ6J2gybapUH9BsrtIgR8=
 derived     false
-kdf_mode
 ````
 
 Here we can see that the randomly generated encryption key being used, as


### PR DESCRIPTION
This PR adds support for [key derivation](https://en.wikipedia.org/wiki/Key_derivation_function) in the transit secret backend. The `helper/kdf` library is added which implements the NIST800-108 recommended counter mode. The `transit` backend is extended to support a "derived" named key, which requires a `context` to be provided for encrypt and decrypt so that a per-transaction key can be derived.

/cc: @sethvargo 