### PR TITLE
Change ACL semantics, use explicit glob and deny has highest precedence

### DIFF
--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -112,6 +112,9 @@ func testLayeredACL(t *testing.T, acl *ACL) {
 		{logical.ReadOperation, "prod/foo", true},
 		{logical.ListOperation, "prod/foo", true},
 		{logical.ReadOperation, "prod/aws/foo", false},
+
+		{logical.ReadOperation, "sys/status", false},
+		{logical.WriteOperation, "sys/seal", true},
 	}
 
 	for _, tc := range tcases {
@@ -142,6 +145,9 @@ path "prod/*" {
 path "prod/aws/*" {
 	policy = "deny"
 }
+path "sys/*" {
+	policy = "deny"
+}
 `
 
 var aclPolicy2 = `
@@ -153,6 +159,9 @@ path "stage/aws/policy/*" {
 	policy = "deny"
 }
 path "prod/*" {
+	policy = "write"
+}
+path "sys/seal" {
 	policy = "write"
 }
 `

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -105,7 +105,7 @@ func testLayeredACL(t *testing.T, acl *ACL) {
 
 		{logical.DeleteOperation, "stage/foo", true},
 		{logical.WriteOperation, "stage/aws/foo", false},
-		{logical.WriteOperation, "stage/aws/policy/foo", true},
+		{logical.WriteOperation, "stage/aws/policy/foo", false},
 
 		{logical.DeleteOperation, "prod/foo", true},
 		{logical.WriteOperation, "prod/foo", true},
@@ -124,35 +124,35 @@ func testLayeredACL(t *testing.T, acl *ACL) {
 
 var aclPolicy = `
 name = "dev"
-path "dev/" {
+path "dev/*" {
 	policy = "sudo"
 }
-path "stage/" {
+path "stage/*" {
 	policy = "write"
 }
-path "stage/aws/" {
+path "stage/aws/*" {
 	policy = "read"
 }
-path "stage/aws/policy/" {
+path "stage/aws/policy/*" {
 	policy = "sudo"
 }
-path "prod/" {
+path "prod/*" {
 	policy = "read"
 }
-path "prod/aws/" {
+path "prod/aws/*" {
 	policy = "deny"
 }
 `
 
 var aclPolicy2 = `
 name = "ops"
-path "dev/hide/" {
+path "dev/hide/*" {
 	policy = "deny"
 }
-path "stage/aws/policy/" {
+path "stage/aws/policy/*" {
 	policy = "deny"
 }
-path "prod/" {
+path "prod/*" {
 	policy = "write"
 }
 `

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -636,7 +636,7 @@ func TestCore_HandleRequest_PermissionAllowed(t *testing.T) {
 		Operation: logical.WriteOperation,
 		Path:      "sys/policy/test",
 		Data: map[string]interface{}{
-			"rules": `path "secret/" { policy = "write" }`,
+			"rules": `path "secret/*" { policy = "write" }`,
 		},
 		ClientToken: root,
 	}

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/hcl"
 )
@@ -34,6 +35,7 @@ type Policy struct {
 type PathPolicy struct {
 	Prefix string `hcl:",key"`
 	Policy string
+	Glob   bool
 }
 
 // Parse is used to parse the specified ACL rules into an
@@ -48,6 +50,13 @@ func Parse(rules string) (*Policy, error) {
 
 	// Validate the path policy
 	for _, pp := range p.Paths {
+		// Strip the glob character if found
+		if strings.HasSuffix(pp.Prefix, "*") {
+			pp.Prefix = strings.TrimSuffix(pp.Prefix, "*")
+			pp.Glob = true
+		}
+
+		// Check the policy is valid
 		switch pp.Policy {
 		case PathPolicyDeny:
 		case PathPolicyRead:

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -16,9 +16,9 @@ func TestPolicy_Parse(t *testing.T) {
 	}
 
 	expect := []*PathPolicy{
-		&PathPolicy{"", "deny"},
-		&PathPolicy{"stage/", "sudo"},
-		&PathPolicy{"prod/", "read"},
+		&PathPolicy{"", "deny", true},
+		&PathPolicy{"stage/", "sudo", true},
+		&PathPolicy{"prod/version", "read", false},
 	}
 	if !reflect.DeepEqual(p.Paths, expect) {
 		t.Fatalf("bad: %#v", p)
@@ -30,17 +30,17 @@ var rawPolicy = `
 name = "dev"
 
 # Deny all paths by default
-path "" {
+path "*" {
 	policy = "deny"
 }
 
 # Allow full access to staging
-path "stage/" {
+path "stage/*" {
 	policy = "sudo"
 }
 
 # Limited read privilege to production
-path "prod/" {
+path "prod/version" {
 	policy = "read"
 }
 `

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -5,6 +5,42 @@ import (
 	"testing"
 )
 
+func TestPolicy_TakesPrecedence(t *testing.T) {
+	type tcase struct {
+		a, b       string
+		precedence bool
+	}
+	tests := []tcase{
+		tcase{PathPolicyDeny, PathPolicyDeny, true},
+		tcase{PathPolicyDeny, PathPolicyRead, true},
+		tcase{PathPolicyDeny, PathPolicyWrite, true},
+		tcase{PathPolicyDeny, PathPolicySudo, true},
+
+		tcase{PathPolicyRead, PathPolicyDeny, false},
+		tcase{PathPolicyRead, PathPolicyRead, false},
+		tcase{PathPolicyRead, PathPolicyWrite, false},
+		tcase{PathPolicyRead, PathPolicySudo, false},
+
+		tcase{PathPolicyWrite, PathPolicyDeny, false},
+		tcase{PathPolicyWrite, PathPolicyRead, true},
+		tcase{PathPolicyWrite, PathPolicyWrite, false},
+		tcase{PathPolicyWrite, PathPolicySudo, false},
+
+		tcase{PathPolicySudo, PathPolicyDeny, false},
+		tcase{PathPolicySudo, PathPolicyRead, true},
+		tcase{PathPolicySudo, PathPolicyWrite, true},
+		tcase{PathPolicySudo, PathPolicySudo, false},
+	}
+	for idx, test := range tests {
+		a := &PathPolicy{Policy: test.a}
+		b := &PathPolicy{Policy: test.b}
+		if out := a.TakesPrecedence(b); out != test.precedence {
+			t.Fatalf("bad: idx %d expect: %v out: %v",
+				idx, test.precedence, out)
+		}
+	}
+}
+
 func TestPolicy_Parse(t *testing.T) {
 	p, err := Parse(rawPolicy)
 	if err != nil {

--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -45,6 +45,7 @@ mechanism under "sys".
 ~> Policy paths are matched using the most specific defined policy. This may
 be an exact match or the longest-prefix match of a glob. This means if you
 define a policy for `"secret/foo*"`, the policy would also match `"secret/foobar"`.
+The glob character is only supported at the end of the path specification.
 
 ## Policies
 
@@ -100,3 +101,33 @@ If an _existing_ policy is modified, the modifications propagate
 to all associated users instantly. The above paragraph is more specifically
 stating that you can't add new or remove policies associated with an
 active identity.
+
+## Changes from 0.1
+
+In Vault versions prior to 0.2, the ACL policy language had a slightly
+different specification and semantics. The current specification requires
+that glob behavior explicitly be specified by adding the `*` character to
+the end of a path. Previously, all paths were glob based matches and no
+exact match could be specified.
+
+The other change is that deny had the lowest precedence. This meant if there
+were two policies being merged (e.g. "ops" and "prod") and they had a conflicting
+policy like:
+
+```
+path "sys/seal" {
+    policy = "deny"
+}
+
+path "sys/seal" {
+    policy = "read"
+}
+```
+
+The merge would previously give the "read" higher precedence. The current
+version of Vault prioritizes the explicit deny, so that the "deny" would
+take precedence.
+
+To make all Vault 0.1 policies compatible with Vault 0.2, the explicit
+glob character must be added to all the path prefixes.
+

--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -18,40 +18,45 @@ that describe what parts of Vault a user is allowed to access. An example
 of a policy is shown below:
 
 ```javascript
-path "sys" {
+path "sys/*" {
   policy = "deny"
 }
 
-path "secret" {
+path "secret/*" {
   policy = "write"
 }
 
 path "secret/foo" {
   policy = "read"
 }
+
+path "secret/super-secret" {
+  policy = "deny"
+}
 ```
 
-Policies use prefix-based routing to apply rules. They are deny by default,
-so if a path isn't explicitly given, Vault will reject any access to it.
+Policies use path based matching to apply rules. A policy may be an exact
+match, or might be a glob pattern which uses a prefix. The default policy
+is always deny so if a path isn't explicitly allowed, Vault will reject access to it.
 This works well due to Vault's architecture of being like a filesystem:
 everything has a path associated with it, including the core configuration
 mechanism under "sys".
 
-~> Policy paths are matched using a longest-prefix match, which is the most
-specific defined policy. This means if you define a policy for `"secret/foo"`,
-the policy would also match `"secret/foobar"`.
+~> Policy paths are matched using the most specific defined policy. This may
+be an exact match or the longest-prefix match of a glob. This means if you
+define a policy for `"secret/foo*"`, the policy would also match `"secret/foobar"`.
 
 ## Policies
 
 Allowed policies for a path are:
 
+  * `deny` - No access allowed. Highest precedence.
+
+  * `sudo` - Read, write, and root access to a path.
+
   * `write` - Read, write access to a path.
 
   * `read` - Read-only access to a path.
-
-  * `deny` - No access allowed.
-
-  * `sudo` - Read, write, and root access to a path.
 
 The only non-obvious policy is "sudo". Some routes within Vault and mounted
 backends are marked as _root_ paths. Clients aren't allowed to access root

--- a/website/source/docs/internals/security.html.md
+++ b/website/source/docs/internals/security.html.md
@@ -110,8 +110,8 @@ a level of access granted to a path in Vault. When the policies are merged (if m
 policies are associated with a client), the highest access level permitted is used.
 For example, if the "engineering" policy permits read/write access to the "eng/" path,
 and the "ops" policy permits read access to the "ops/" path, then the user gets the
-union of those. Policy is matched using a longest-prefix match, which is the most
-specific defined policy.
+union of those. Policy is matched using the most specific defined policy, which may be
+an exact match or the longest-prefix match glob pattern.
 
 Certain operations are only permitted by "root" users, which is a distinguished
 policy built into Vault. This is similar to the concept of a root user on a Unix system

--- a/website/source/intro/getting-started/acl.html.md
+++ b/website/source/intro/getting-started/acl.html.md
@@ -47,7 +47,8 @@ aspect of Vault, including mounting backends, authenticating, as well as secret 
 
 In the policy above, a user could write any secret to `secret/`, except
 to `secret/foo`, where only read access is allowed. Policies default to
-deny, so any access to an unspecified path is not allowed.
+deny, so any access to an unspecified path is not allowed. The policy
+langauge changed slightly in Vault 0.2, [see this page for details](/docs/concepts/policies.html).
 
 Save the above policy as `acl.hcl`.
 

--- a/website/source/intro/getting-started/acl.html.md
+++ b/website/source/intro/getting-started/acl.html.md
@@ -30,11 +30,7 @@ format that is also JSON-compatible, so you can use JSON as well. An example
 policy is shown below:
 
 ```javascript
-path "sys" {
-  policy = "deny"
-}
-
-path "secret" {
+path "secret/*" {
   policy = "write"
 }
 
@@ -43,10 +39,11 @@ path "secret/foo" {
 }
 ```
 
-The policy format uses a longest matching prefix system on the API path
-to determine access control. Since everything in Vault must be accessed
-via the API, this gives strict control over every aspect of Vault, including
-mounting backends, authenticating, as well as secret access.
+The policy format uses a prefix matching system on the API path
+to determine access control. The most specific defined policy is used,
+either an exact match or the longest-prefix glob match. Since everything
+in Vault must be accessed via the API, this gives strict control over every
+aspect of Vault, including mounting backends, authenticating, as well as secret access.
 
 In the policy above, a user could write any secret to `secret/`, except
 to `secret/foo`, where only read access is allowed. Policies default to


### PR DESCRIPTION
This PR changes the definition of policies and enforcement semantics in a slight but important way. Previously, all path policies would greedily match or glob implicitly. Deny policies also had the lowest precedence. This made it hard to deny access to specific paths, and impossible to only match an exact path. This changes things to use *explicit* globbing using the `*` wildcard. Deny also takes the highest precedence over any policy preference. This fixes a number of shortcomings with the policy language.

In practice, all old policy definitions must add a `*` to be forward compatible. This is handled automatically for all policies already defined. 

Fixes #335.

/cc: @sethvargo @sean-