### PR TITLE
Ensure build.sh uses dependencies vendored by godeps

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,9 +19,14 @@ GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
 XC_OS=${XC_OS:-linux darwin windows freebsd openbsd}
 
-# Install dependencies
-echo "==> Getting dependencies..."
-go get ./...
+# Store the original GOPATH so we can move the binary to it later
+ORIGINAL_GOPATH=${GOPATH:-$(go env GOPATH)}
+GOPATH="$(godep path):$ORIGINAL_GOPATH"
+case $(uname) in
+    CYGWIN*)
+        ORIGINAL_GOPATH="$(cygpath $ORIGINAL_GOPATH)"
+        ;;
+esac
 
 # Delete the old dir
 echo "==> Removing old directory..."
@@ -47,14 +52,8 @@ gox \
     .
 
 # Move all the compiled things to the $GOPATH/bin
-GOPATH=${GOPATH:-$(go env GOPATH)}
-case $(uname) in
-    CYGWIN*)
-        GOPATH="$(cygpath $GOPATH)"
-        ;;
-esac
 OLDIFS=$IFS
-IFS=: MAIN_GOPATH=($GOPATH)
+IFS=: MAIN_GOPATH=($ORIGINAL_GOPATH)
 IFS=$OLDIFS
 
 # Copy our OS/Arch to the bin/ directory


### PR DESCRIPTION
Dependencies are already vendored by godeps, so ideally the build script would use these known versions to build the binary.