### PR TITLE
Disable hostname prefix for runtime telemetry

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -357,13 +357,21 @@ func (c *ServerCommand) setupTelementry(config *server.Config) error {
 	*/
 	inm := metrics.NewInmemSink(10*time.Second, time.Minute)
 	metrics.DefaultInmemSignal(inm)
+
+	var telConfig *server.Telemetry
+	if config.Telemetry == nil {
+		telConfig = &server.Telemetry{}
+	} else {
+		telConfig = config.Telemetry
+	}
+
 	metricsConf := metrics.DefaultConfig("vault")
-	metricsConf.EnableHostname = false
+	metricsConf.EnableHostname = !telConfig.DisableHostname
 
 	// Configure the statsite sink
 	var fanout metrics.FanoutSink
-	if config.StatsiteAddr != "" {
-		sink, err := metrics.NewStatsiteSink(config.StatsiteAddr)
+	if telConfig.StatsiteAddr != "" {
+		sink, err := metrics.NewStatsiteSink(telConfig.StatsiteAddr)
 		if err != nil {
 			return err
 		}
@@ -371,8 +379,8 @@ func (c *ServerCommand) setupTelementry(config *server.Config) error {
 	}
 
 	// Configure the statsd sink
-	if config.StatsdAddr != "" {
-		sink, err := metrics.NewStatsdSink(config.StatsdAddr)
+	if telConfig.StatsdAddr != "" {
+		sink, err := metrics.NewStatsdSink(telConfig.StatsdAddr)
 		if err != nil {
 			return err
 		}

--- a/command/server.go
+++ b/command/server.go
@@ -358,6 +358,7 @@ func (c *ServerCommand) setupTelementry(config *server.Config) error {
 	inm := metrics.NewInmemSink(10*time.Second, time.Minute)
 	metrics.DefaultInmemSignal(inm)
 	metricsConf := metrics.DefaultConfig("vault")
+	metricsConf.EnableHostname = false
 
 	// Configure the statsite sink
 	var fanout metrics.FanoutSink

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -29,9 +29,13 @@ func TestLoadConfigFile(t *testing.T) {
 			},
 		},
 
+		Telemetry: &Telemetry{
+			StatsdAddr: "bar",
+			StatsiteAddr: "foo",
+			DisableHostname: false,
+		},
+
 		DisableMlock: true,
-		StatsiteAddr: "foo",
-		StatsdAddr:   "bar",
 	}
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("bad: %#v", config)
@@ -59,6 +63,12 @@ func TestLoadConfigFile_json(t *testing.T) {
 			Config: map[string]string{
 				"foo": "bar",
 			},
+		},
+
+		Telemetry: &Telemetry{
+			StatsiteAddr: "baz",
+			StatsdAddr: "",
+			DisableHostname: false,
 		},
 	}
 	if !reflect.DeepEqual(config, expected) {
@@ -88,6 +98,12 @@ func TestLoadConfigFile_json2(t *testing.T) {
 				"foo": "bar",
 			},
 		},
+
+		Telemetry: &Telemetry{
+			StatsiteAddr: "foo",
+			StatsdAddr: "bar",
+			DisableHostname: true,
+		},
 	}
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("bad: %#v", config)
@@ -115,6 +131,12 @@ func TestLoadConfigDir(t *testing.T) {
 			Config: map[string]string{
 				"foo": "bar",
 			},
+		},
+
+		Telemetry: &Telemetry{
+			StatsiteAddr: "qux",
+			StatsdAddr: "baz",
+			DisableHostname: true,
 		},
 	}
 	if !reflect.DeepEqual(config, expected) {

--- a/command/server/test-fixtures/config-dir/bar.json
+++ b/command/server/test-fixtures/config-dir/bar.json
@@ -3,5 +3,6 @@
         "tcp": {
             "address": "127.0.0.1:443"
         }
-    }
+    },
+    "statsd_addr": "nope"
 }

--- a/command/server/test-fixtures/config-dir/bar.json
+++ b/command/server/test-fixtures/config-dir/bar.json
@@ -3,6 +3,5 @@
         "tcp": {
             "address": "127.0.0.1:443"
         }
-    },
-    "statsd_addr": "nope"
+    }
 }

--- a/command/server/test-fixtures/config-dir/baz.hcl
+++ b/command/server/test-fixtures/config-dir/baz.hcl
@@ -1,0 +1,5 @@
+telemetry {
+    statsd_address = "baz"
+    statsite_address = "qux"
+    disable_hostname = true
+}

--- a/command/server/test-fixtures/config.hcl.json
+++ b/command/server/test-fixtures/config.hcl.json
@@ -9,5 +9,9 @@
         "consul": {
             "foo": "bar"
         }
+    },
+
+    "telemetry": {
+        "statsite_address": "baz"
     }
 }

--- a/command/server/test-fixtures/config2.hcl.json
+++ b/command/server/test-fixtures/config2.hcl.json
@@ -9,5 +9,11 @@
         "consul": {
             "foo": "bar"
         }
+    },
+
+    "telemetry": {
+        "statsd_address": "bar",
+        "statsite_address": "foo",
+        "disable_hostname": true
     }
 }

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -22,6 +22,11 @@ listener "tcp" {
   address = "127.0.0.1:8200"
   tls_disable = 1
 }
+
+telemetry {
+  statsite_address = "127.0.0.1:8125"
+  disable_hostname = true
+}
 ```
 
 After the configuration is written, use the `-config` flag with `vault server`
@@ -41,11 +46,8 @@ to specify where the configuration is.
   server from executing the `mlock` syscall to prevent memory from being
   swapped to disk. This is not recommended in production (see below).
 
-* `statsite_addr` (optional) - An address to a [Statsite](https://github.com/armon/statsite)
-  instances for metrics. This is highly recommended for production usage.
-
-* `statsd_addr` (optional) - This is the same as `statsite_addr` but
-  for StatsD.
+* `telemetry` (optional)  - Configures the telemetry reporting system
+  (see below).
 
 In production, you should only consider setting the `disable_mlock` option
 on Linux systems that only use encrypted swap or do not use swap at all.
@@ -190,3 +192,17 @@ The supported options are:
 
   * `tls_key_file` (required unless disabled) - The path to the private key
       for the certificate.
+      
+## Telemetry Reference
+
+For the `telemetry` section, there is no resource name. All configuration
+is within the object itself.
+
+* `statsite_address` (optional) - An address to a [Statsite](https://github.com/armon/statsite)
+  instances for metrics. This is highly recommended for production usage.
+
+* `statsd_address` (optional) - This is the same as `statsite_address` but
+  for StatsD.
+  
+* `disable_hostname` (optional) - Whether or not to prepend runtime telemetry
+  with the machines hostname. This is a global option. Defaults to false.


### PR DESCRIPTION
Allows for setting prefixes/suffixes downstream from the service. Feels like this should be a configuration directive but the current telemetry config should probably become an object before adding more top level directives.

armon/go-metrics#12