### PR TITLE
LDAP Auth - Add per-user policies and option to login with userPrincipalName

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -140,7 +140,7 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 
 	user, err := b.User(req.Storage, username)
 	if err == nil && user != nil {
-		policies = append(policies, user.Policies...)
+		allgroups = append(allgroups, user.Groups...)
 	}
 
 	for _, e := range sresult.Entries {
@@ -150,6 +150,9 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 		}
 		gname := dn.RDNs[0].Attributes[0].Value
 		allgroups = append(allgroups, gname)
+	}
+
+	for _, gname := range allgroups {
 		group, err := b.Group(req.Storage, gname)
 		if err == nil && group != nil {
 			policies = append(policies, group.Policies...)

--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -21,6 +21,7 @@ func Backend() *framework.Backend {
 			Root: []string{
 				"config",
 				"groups/*",
+				"users/*",
 			},
 
 			Unauthenticated: []string{
@@ -32,6 +33,7 @@ func Backend() *framework.Backend {
 			pathLogin(&b),
 			pathConfig(&b),
 			pathGroups(&b),
+			pathUsers(&b),
 		}),
 
 		AuthRenew: b.pathLoginRenew,
@@ -135,6 +137,12 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 
 	var allgroups []string
 	var policies []string
+
+	user, err := b.User(req.Storage, username)
+	if err == nil && user != nil {
+		policies = append(policies, user.Policies...)
+	}
+
 	for _, e := range sresult.Entries {
 		dn, err := ldap.ParseDN(e.DN)
 		if err != nil || len(dn.RDNs) == 0 || len(dn.RDNs[0].Attributes) == 0 {

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -17,6 +17,7 @@ func TestBackend_basic(t *testing.T) {
 		Steps: []logicaltest.TestStep{
 			testAccStepConfigUrl(t),
 			testAccStepGroup(t, "scientists", "foo"),
+			testAccStepUser(t, "tesla", "bar"),
 			testAccStepLogin(t, "tesla", "password"),
 		},
 	})
@@ -96,6 +97,65 @@ func testAccStepDeleteGroup(t *testing.T, group string) logicaltest.TestStep {
 	}
 }
 
+func TestBackend_userCrud(t *testing.T) {
+	b := Backend()
+
+	logicaltest.Test(t, logicaltest.TestCase{
+		Backend: b,
+		Steps: []logicaltest.TestStep{
+			testAccStepUser(t, "g1", "bar"),
+			testAccStepReadUser(t, "g1", "bar"),
+			testAccStepDeleteUser(t, "g1"),
+			testAccStepReadUser(t, "g1", ""),
+		},
+	})
+}
+
+func testAccStepUser(t *testing.T, user string, policies string) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.WriteOperation,
+		Path:      "users/" + user,
+		Data: map[string]interface{}{
+			"policies": policies,
+		},
+	}
+}
+
+func testAccStepReadUser(t *testing.T, user string, policies string) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.ReadOperation,
+		Path:      "users/" + user,
+		Check: func(resp *logical.Response) error {
+			if resp == nil {
+				if policies == "" {
+					return nil
+				}
+				return fmt.Errorf("bad: %#v", resp)
+			}
+
+			var d struct {
+				Policies string `mapstructure:"policies"`
+			}
+			if err := mapstructure.Decode(resp.Data, &d); err != nil {
+				return err
+			}
+
+			if d.Policies != policies {
+				return fmt.Errorf("bad: %#v", resp)
+			}
+
+			return nil
+		},
+	}
+}
+
+func testAccStepDeleteUser(t *testing.T, user string) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.DeleteOperation,
+		Path:      "users/" + user,
+	}
+}
+
 func testAccStepLogin(t *testing.T, user string, pass string) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.WriteOperation,
@@ -105,7 +165,7 @@ func testAccStepLogin(t *testing.T, user string, pass string) logicaltest.TestSt
 		},
 		Unauthenticated: true,
 
-		Check: logicaltest.TestCheckAuth([]string{"foo"}),
+		Check: logicaltest.TestCheckAuth([]string{"foo", "bar"}),
 	}
 }
 

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -17,7 +17,8 @@ func TestBackend_basic(t *testing.T) {
 		Steps: []logicaltest.TestStep{
 			testAccStepConfigUrl(t),
 			testAccStepGroup(t, "scientists", "foo"),
-			testAccStepUser(t, "tesla", "bar"),
+			testAccStepGroup(t, "engineers", "bar"),
+			testAccStepUser(t, "tesla", "engineers"),
 			testAccStepLogin(t, "tesla", "password"),
 		},
 	})
@@ -111,36 +112,36 @@ func TestBackend_userCrud(t *testing.T) {
 	})
 }
 
-func testAccStepUser(t *testing.T, user string, policies string) logicaltest.TestStep {
+func testAccStepUser(t *testing.T, user string, groups string) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.WriteOperation,
 		Path:      "users/" + user,
 		Data: map[string]interface{}{
-			"policies": policies,
+			"groups": groups,
 		},
 	}
 }
 
-func testAccStepReadUser(t *testing.T, user string, policies string) logicaltest.TestStep {
+func testAccStepReadUser(t *testing.T, user string, groups string) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.ReadOperation,
 		Path:      "users/" + user,
 		Check: func(resp *logical.Response) error {
 			if resp == nil {
-				if policies == "" {
+				if groups == "" {
 					return nil
 				}
 				return fmt.Errorf("bad: %#v", resp)
 			}
 
 			var d struct {
-				Policies string `mapstructure:"policies"`
+				Groups string `mapstructure:"groups"`
 			}
 			if err := mapstructure.Decode(resp.Data, &d); err != nil {
 				return err
 			}
 
-			if d.Policies != policies {
+			if d.Groups != groups {
 				return fmt.Errorf("bad: %#v", resp)
 			}
 

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -29,6 +29,10 @@ func pathConfig(b *backend) *framework.Path {
 				Type:        framework.TypeString,
 				Description: "LDAP domain to use for groups (eg: ou=Groups,dc=example,dc=org)",
 			},
+			"upndomain": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Enables userPrincipalDomain login with [username]@UPNDomain (optional)",
+			},
 			"userattr": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "Attribute used for users (default: cn)",
@@ -89,6 +93,7 @@ func (b *backend) pathConfigRead(
 			"url":          cfg.Url,
 			"userdn":       cfg.UserDN,
 			"groupdn":      cfg.GroupDN,
+			"upndomain":    cfg.UPNDomain,
 			"userattr":     cfg.UserAttr,
 			"certificate":  cfg.Certificate,
 			"insecure_tls": cfg.InsecureTLS,
@@ -116,6 +121,10 @@ func (b *backend) pathConfigWrite(
 	groupdn := d.Get("groupdn").(string)
 	if groupdn != "" {
 		cfg.GroupDN = groupdn
+	}
+	upndomain := d.Get("upndomain").(string)
+	if groupdn != "" {
+		cfg.UPNDomain = upndomain
 	}
 	certificate := d.Get("certificate").(string)
 	if certificate != "" {
@@ -154,6 +163,7 @@ type ConfigEntry struct {
 	Url         string
 	UserDN      string
 	GroupDN     string
+	UPNDomain   string
 	UserAttr    string
 	Certificate string
 	InsecureTLS bool

--- a/builtin/credential/ldap/path_users.go
+++ b/builtin/credential/ldap/path_users.go
@@ -1,0 +1,118 @@
+package ldap
+
+import (
+	"strings"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathUsers(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: `users/(?P<name>.+)`,
+		Fields: map[string]*framework.FieldSchema{
+			"name": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Name of the LDAP user.",
+			},
+
+			"policies": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Comma-separated list of policies associated to the user.",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.DeleteOperation: b.pathUserDelete,
+			logical.ReadOperation:   b.pathUserRead,
+			logical.WriteOperation:  b.pathUserWrite,
+		},
+
+		HelpSynopsis:    pathUserHelpSyn,
+		HelpDescription: pathUserHelpDesc,
+	}
+}
+
+func (b *backend) User(s logical.Storage, n string) (*UserEntry, error) {
+	entry, err := s.Get("user/" + n)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	var result UserEntry
+	if err := entry.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (b *backend) pathUserDelete(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	err := req.Storage.Delete("user/" + d.Get("name").(string))
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathUserRead(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	user, err := b.User(req.Storage, d.Get("name").(string))
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, nil
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"policies": strings.Join(user.Policies, ","),
+		},
+	}, nil
+}
+
+func (b *backend) pathUserWrite(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	policies := strings.Split(d.Get("policies").(string), ",")
+	for i, p := range policies {
+		policies[i] = strings.TrimSpace(p)
+	}
+
+	// Store it
+	entry, err := logical.StorageEntryJSON("user/"+name, &UserEntry{
+		Policies: policies,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Storage.Put(entry); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+type UserEntry struct {
+	Policies []string
+}
+
+const pathUserHelpSyn = `
+Manage users allowed to authenticate.
+`
+
+const pathUserHelpDesc = `
+This endpoint allows you to create, read, update, and delete configuration
+for LDAP users that are allowed to authenticate, and associate policies to
+them.
+
+Deleting a user will not revoke auth for prior authenticated users in that
+user. To do this, do a revoke on "login/<username>" for
+the usernames you want revoked.
+`

--- a/builtin/credential/ldap/path_users.go
+++ b/builtin/credential/ldap/path_users.go
@@ -16,9 +16,9 @@ func pathUsers(b *backend) *framework.Path {
 				Description: "Name of the LDAP user.",
 			},
 
-			"policies": &framework.FieldSchema{
+			"groups": &framework.FieldSchema{
 				Type:        framework.TypeString,
-				Description: "Comma-separated list of policies associated to the user.",
+				Description: "Comma-separated list of additional groups associated with the user.",
 			},
 		},
 
@@ -72,7 +72,7 @@ func (b *backend) pathUserRead(
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"policies": strings.Join(user.Policies, ","),
+			"groups": strings.Join(user.Groups, ","),
 		},
 	}, nil
 }
@@ -80,14 +80,14 @@ func (b *backend) pathUserRead(
 func (b *backend) pathUserWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
-	policies := strings.Split(d.Get("policies").(string), ",")
-	for i, p := range policies {
-		policies[i] = strings.TrimSpace(p)
+	groups := strings.Split(d.Get("groups").(string), ",")
+	for i, g := range groups {
+		groups[i] = strings.TrimSpace(g)
 	}
 
 	// Store it
 	entry, err := logical.StorageEntryJSON("user/"+name, &UserEntry{
-		Policies: policies,
+		Groups: groups,
 	})
 	if err != nil {
 		return nil, err
@@ -100,19 +100,18 @@ func (b *backend) pathUserWrite(
 }
 
 type UserEntry struct {
-	Policies []string
+	Groups []string
 }
 
 const pathUserHelpSyn = `
-Manage users allowed to authenticate.
+Manage additional groups for users allowed to authenticate.
 `
 
 const pathUserHelpDesc = `
 This endpoint allows you to create, read, update, and delete configuration
-for LDAP users that are allowed to authenticate, and associate policies to
-them.
+for LDAP users that are allowed to authenticate, in particular associating
+additional groups to them.
 
-Deleting a user will not revoke auth for prior authenticated users in that
-user. To do this, do a revoke on "login/<username>" for
+Deleting a user will not revoke their auth. To do this, do a revoke on "login/<username>" for
 the usernames you want revoked.
 `

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -108,13 +108,15 @@ $ vault write auth/ldap/groups/scientists policies=foo,bar
 
 This maps the LDAP group "scientists" to the "foo" and "bar" Vault policies.
 
-We can also create a mapping from a specific LDAP user to a Vault policy:
+We can also add specific LDAP users to additional (potentially non-LDAP) groups:
 
 ```
-$ vault write auth/ldap/users/tesla policies=foobar
+$ vault write auth/ldap/groups/engineers policies=foobar
+$ vault write auth/ldap/users/tesla groups=engineers
 ```
 
-This maps the LDAP user "tesla" to the "foobar" Vault policy.
+This adds the LDAP user "tesla" to the "engineers" group, which maps to
+the "foobar" Vault policy.
 
 Finally, we can test this by authenticating:
 

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -90,6 +90,7 @@ $ vault write auth/ldap/config url="ldap://ldap.forumsys.com" \
 		userattr=uid \
         userdn="dc=example,dc=com" \
         groupdn="dc=example,dc=com" \
+        upndomain="forumsys.com" \
         certificate=@ldap_ca_cert.pem \
         insecure_tls=false \
         starttls=true

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -16,7 +16,7 @@ into environments using LDAP without duplicating the user/pass configuration
 in multiple places.
 
 The mapping of groups in LDAP to Vault policies is managed by using the
-`groups/` path.
+`users/` and `groups/` paths.
 
 ## Authentication
 
@@ -108,6 +108,14 @@ $ vault write auth/ldap/groups/scientists policies=foo,bar
 
 This maps the LDAP group "scientists" to the "foo" and "bar" Vault policies.
 
+We can also create a mapping from a specific LDAP user to a Vault policy:
+
+```
+$ vault write auth/ldap/users/tesla policies=foobar
+```
+
+This maps the LDAP user "tesla" to the "foobar" Vault policy.
+
 Finally, we can test this by authenticating:
 
 ```
@@ -116,6 +124,6 @@ Password (will be hidden):
 Successfully authenticated! The policies that are associated
 with this token are listed below:
 
-bar, foo
+bar, foo, foobar
 ```
 


### PR DESCRIPTION
Adds the following to LDAP auth backend:
  - `upndomain` option: when set, users login with `[username]@[upndomain]`, which should match a user's `userPrincipalName` field (an alternate login username for AD servers, see [here] (https://msdn.microsoft.com/en-us/library/ms680857(v=vs.85).aspx) for more information). Many users are used to logging in this way.
  - `users/` path to assign policies to specific users (identified by their login username). This helps when LDAP groups don't map nicely to a level of Vault access.

The `users/` path is essentially copy and paste from the `groups/` path, which seemed like the clearest way to do it despite the duplication. Let me know if you would rather have path_groups refactored.