### PR TITLE
Change t.Name to t.Slug to ensure safe names for policy mapping with …

### DIFF
--- a/builtin/credential/github/path_login.go
+++ b/builtin/credential/github/path_login.go
@@ -75,7 +75,8 @@ func (b *backend) pathLogin(
 		}
 
 		// Append the slugs so we can get the policies
-		teamNames = append(teamNames, *t.Slug)
+		teamNames = append(teamNames, *t.Name)
+                teamNames = append(teamNames, *t.Slug)
 	}
 
 	policiesList, err := b.Map.Policies(req.Storage, teamNames...)

--- a/builtin/credential/github/path_login.go
+++ b/builtin/credential/github/path_login.go
@@ -74,8 +74,8 @@ func (b *backend) pathLogin(
 			continue
 		}
 
-		// Append the names so we can get the policies
-		teamNames = append(teamNames, *t.Name)
+		// Append the slugs so we can get the policies
+		teamNames = append(teamNames, *t.Slug)
 	}
 
 	policiesList, err := b.Map.Policies(req.Storage, teamNames...)


### PR DESCRIPTION
I would be interested to see if this change seems logical?
When a Team is created with whitespace it cannot be mapped back to policies, so I think
the below should use the Slug value to ensure safe mapping?