### PR TITLE
Granting S3 backend temporary access

### DIFF
--- a/physical/s3.go
+++ b/physical/s3.go
@@ -41,6 +41,10 @@ func newS3Backend(conf map[string]string) (Backend, error) {
 	if !ok {
 		secret_key = ""
 	}
+    session_token, ok := conf["session_token"]
+    if !ok {
+            session_token = ""
+    }
 	region, ok := conf["region"]
 	if !ok {
 		region = os.Getenv("AWS_DEFAULT_REGION")
@@ -53,6 +57,7 @@ func newS3Backend(conf map[string]string) (Backend, error) {
 		&credentials.StaticProvider{Value: credentials.Value{
 			AccessKeyID:     access_key,
 			SecretAccessKey: secret_key,
+			SessionToken:    session_token,
 		}},
 		&credentials.EnvProvider{},
 		&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},

--- a/physical/s3_test.go
+++ b/physical/s3_test.go
@@ -69,6 +69,7 @@ func TestS3Backend(t *testing.T) {
 	b, err := NewBackend("s3", map[string]string{
 		"access_key": creds.AccessKeyID,
 		"secret_key": creds.SecretAccessKey,
+		"session_token": creds.SessionToken,
 		"bucket":     bucket,
 	})
 	if err != nil {

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -143,6 +143,8 @@ For S3, the following options are supported:
 
   * `secret_key` - (required) The AWS secret key. It must be provided, but it can also be sourced from the AWS_SECRET_ACCESS_KEY environment variable.
 
+  * `session_token` - (optional) The AWS session_token. It can also be sourced from the AWS_SESSION_TOKEN environment variable.
+
   * `region` (optional) - The AWS region. It can be sourced from the AWS_DEFAULT_REGION environment variable and will default to "us-east-1" if not specified.
 
 #### Backend Reference: MySQL


### PR DESCRIPTION
Using temporary security credentials on the S3 backend. SessionToken is an optional value that can be set on the S3 backend config file.
```
bucket (required) - The name of the S3 bucket to use.

access_key - (required) The AWS access key. It must be provided, but it can also be sourced from the AWS_ACCESS_KEY_ID environment variable.

secret_key - (required) The AWS secret key. It must be provided, but it can also be sourced from the AWS_SECRET_ACCESS_KEY environment variable.

session_token - (optional) The AWS session_token.

region (optional) - The AWS region. It can be sourced from the AWS_DEFAULT_REGION environment variable and will default to "us-east-1" if not specified.
```