### PR TITLE
Using SSL to encrypt connections to MYSQL

### DIFF
--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -160,6 +160,8 @@ The MySQL backend has the following options:
 
   * `table` (optional) - The name of the table to use. Defaults to "vault".
 
+  * `tls_ca_file` (optional) - The path to the CA certificate to connect using TLS
+
 #### Backend Reference: Inmem
 
 The in-memory backend has no configuration options.


### PR DESCRIPTION
Allow to specify a certificate params "sslca" to encrypt the connections. 
Taken from sql-driver documentation: https://github.com/go-sql-driver/mysql#tls

Don't hesitate to comment on the naming "sslca", I followed ActiveRecord's naming.

Cheers,
Vivien