### PR TITLE
use /usr/bin/env to find bash in scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script builds the application from source for multiple platforms.
 set -e

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Get the version from the command line

--- a/scripts/website_push.sh
+++ b/scripts/website_push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the parent directory of where this script is.
 SOURCE="${BASH_SOURCE[0]}"

--- a/terraform/aws/scripts/install.sh.tpl
+++ b/terraform/aws/scripts/install.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Install packages


### PR DESCRIPTION
Not everyone has `bash` located at `/bin/bash`, this is a more portable replacement.