### PR TITLE
Specify Vault listener minimum TLS version

### DIFF
--- a/command/server/listener.go
+++ b/command/server/listener.go
@@ -50,10 +50,24 @@ func listenerWrapTLS(
 		return nil, nil, fmt.Errorf("error loading TLS cert: %s", err)
 	}
 
+	tlslookup := map[string]uint16{
+		"tls10": tls.VersionTLS10,
+		"tls11": tls.VersionTLS11,
+		"tls12": tls.VersionTLS12,
+	}
+	
+	tlsvers, ok := config["tls_min_vers"]
+	if !ok {
+		tlsvers = "tls12"
+	}
+	
 	tlsConf := &tls.Config{}
 	tlsConf.Certificates = []tls.Certificate{cert}
 	tlsConf.NextProtos = []string{"http/1.1"}
-	tlsConf.MinVersion = tls.VersionTLS12 // Minimum version is TLS 1.2
+	tlsConf.MinVersion, ok = tlslookup[tlsvers]
+	if !ok {
+		return nil, nil, fmt.Errorf("'tls_min_vers' value %s not supported, please specify one of [tls10,tls11,tls12]", tlsvers)
+	}
 	tlsConf.ClientAuth = tls.RequestClientCert
 
 	ln = tls.NewListener(ln, tlsConf)

--- a/command/server/listener.go
+++ b/command/server/listener.go
@@ -56,7 +56,7 @@ func listenerWrapTLS(
 		"tls12": tls.VersionTLS12,
 	}
 	
-	tlsvers, ok := config["tls_min_vers"]
+	tlsvers, ok := config["tls_min_version"]
 	if !ok {
 		tlsvers = "tls12"
 	}
@@ -66,7 +66,7 @@ func listenerWrapTLS(
 	tlsConf.NextProtos = []string{"http/1.1"}
 	tlsConf.MinVersion, ok = tlslookup[tlsvers]
 	if !ok {
-		return nil, nil, fmt.Errorf("'tls_min_vers' value %s not supported, please specify one of [tls10,tls11,tls12]", tlsvers)
+		return nil, nil, fmt.Errorf("'tls_min_version' value %s not supported, please specify one of [tls10,tls11,tls12]", tlsvers)
 	}
 	tlsConf.ClientAuth = tls.RequestClientCert
 

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -193,6 +193,10 @@ The supported options are:
   * `tls_key_file` (required unless disabled) - The path to the private key
       for the certificate.
       
+  * `tls_min_vers` (optional) - If provided, specifies the minimum
+      supported version of TLS. Accepted values are "tls10", "tls11"
+      or "tls12". This defaults to "tls12".
+
 ## Telemetry Reference
 
 For the `telemetry` section, there is no resource name. All configuration

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -193,7 +193,7 @@ The supported options are:
   * `tls_key_file` (required unless disabled) - The path to the private key
       for the certificate.
       
-  * `tls_min_vers` (optional) - If provided, specifies the minimum
+  * `tls_min_version` (optional) - If provided, specifies the minimum
       supported version of TLS. Accepted values are "tls10", "tls11"
       or "tls12". This defaults to "tls12".
 

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -195,7 +195,9 @@ The supported options are:
       
   * `tls_min_version` (optional) - If provided, specifies the minimum
       supported version of TLS. Accepted values are "tls10", "tls11"
-      or "tls12". This defaults to "tls12".
+      or "tls12". This defaults to "tls12". WARNING: TLS 1.1 and lower
+      are generally considered less secure; avoid using these if
+      possible.
 
 ## Telemetry Reference
 


### PR DESCRIPTION
Resolves #427. Adds a configuration option to the `listener "tcp"` section:

```
listener "tcp" {
    address = "0.0.0.0:8200"
    tls_cert_file = "/etc/pki/tls/certs/cert.pem"
    tls_key_file = "/etc/pki/tls/private/key.pem"
    tls_min_version = "tls10"
}
```

Acceptable values for `tls_min_version` are `tls10`, `tls11` and `tls12`.