### PR TITLE
Cassandra secret backend doc update for connection config

### DIFF
--- a/website/source/docs/secrets/cassandra/index.html.md
+++ b/website/source/docs/secrets/cassandra/index.html.md
@@ -38,7 +38,7 @@ writing one or more hosts, a username, and a password:
 
 ```text
 $ vault write cassandra/config/connection \
-    host=localhost username=cassandra password=cassandra
+    hosts=localhost username=cassandra password=cassandra
 ```
 
 In this case, we've configured Vault with the user "cassandra" and password "cassandra",


### PR DESCRIPTION
Doc update - "hosts" instead "host" for Cassandra connection config