### PR TITLE
Add configuration options for default lease duration and max lease duration

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -132,8 +132,8 @@ func (c *ServerCommand) Run(args []string) int {
 		LogicalBackends:      c.LogicalBackends,
 		Logger:               logger,
 		DisableMlock:         config.DisableMlock,
-		MaxLeaseDuration:     time.Duration(config.MaxLeaseDuration) * time.Hour,
-		DefaultLeaseDuration: time.Duration(config.DefaultLeaseDuration) * time.Hour,
+		MaxLeaseDuration:     config.MaxLeaseDuration,
+		DefaultLeaseDuration: config.DefaultLeaseDuration,
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error initializing core: %s", err))

--- a/command/server.go
+++ b/command/server.go
@@ -125,13 +125,15 @@ func (c *ServerCommand) Run(args []string) int {
 
 	// Initialize the core
 	core, err := vault.NewCore(&vault.CoreConfig{
-		AdvertiseAddr:      config.Backend.AdvertiseAddr,
-		Physical:           backend,
-		AuditBackends:      c.AuditBackends,
-		CredentialBackends: c.CredentialBackends,
-		LogicalBackends:    c.LogicalBackends,
-		Logger:             logger,
-		DisableMlock:       config.DisableMlock,
+		AdvertiseAddr:        config.Backend.AdvertiseAddr,
+		Physical:             backend,
+		AuditBackends:        c.AuditBackends,
+		CredentialBackends:   c.CredentialBackends,
+		LogicalBackends:      c.LogicalBackends,
+		Logger:               logger,
+		DisableMlock:         config.DisableMlock,
+		MaxLeaseDuration:     time.Duration(config.MaxLeaseDuration) * time.Hour,
+		DefaultLeaseDuration: time.Duration(config.DefaultLeaseDuration) * time.Hour,
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error initializing core: %s", err))

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/hcl"
 	hclobj "github.com/hashicorp/hcl/hcl"
@@ -21,8 +22,10 @@ type Config struct {
 
 	Telemetry *Telemetry     `hcl:"telemetry"`
 
-	MaxLeaseDuration int     `hcl:"max_lease_duration"`
-	DefaultLeaseDuration int `hcl:"default_lease_duration"`
+	MaxLeaseDuration time.Duration `hcl:"-"`
+	MaxLeaseDurationRaw string     `hcl:"max_lease_duration"`
+	DefaultLeaseDuration time.Duration `hcl:"-"`
+	DefaultLeaseDurationRaw string     `hcl:"default_lease_duration"`
 }
 
 // DevConfig is a Config that is used for dev mode of Vault.
@@ -45,8 +48,8 @@ func DevConfig() *Config {
 
 		Telemetry: &Telemetry{},
 
-		MaxLeaseDuration: 30 * 24,
-		DefaultLeaseDuration: 30 * 24,
+		MaxLeaseDuration: 30 * 24 * time.Hour,
+		DefaultLeaseDuration: 30 * 24 * time.Hour,
 	}
 }
 
@@ -156,6 +159,17 @@ func LoadConfigFile(path string) (*Config, error) {
 	var result Config
 	if err := hcl.DecodeObject(&result, obj); err != nil {
 		return nil, err
+	}
+
+	if result.MaxLeaseDurationRaw != "" {
+		if result.MaxLeaseDuration, err = time.ParseDuration(result.MaxLeaseDurationRaw); err != nil {
+			return nil, err
+		}
+	}
+	if result.DefaultLeaseDurationRaw != "" {
+		if result.DefaultLeaseDuration, err = time.ParseDuration(result.DefaultLeaseDurationRaw); err != nil {
+			return nil, err
+		}
 	}
 
 	if objs := obj.Get("listener", false); objs != nil {

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -36,6 +36,9 @@ func TestLoadConfigFile(t *testing.T) {
 		},
 
 		DisableMlock: true,
+
+		MaxLeaseDuration: 10,
+		DefaultLeaseDuration: 10,
 	}
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("bad: %#v", config)
@@ -70,6 +73,9 @@ func TestLoadConfigFile_json(t *testing.T) {
 			StatsdAddr: "",
 			DisableHostname: false,
 		},
+
+		MaxLeaseDuration: 10,
+		DefaultLeaseDuration: 10,
 	}
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("bad: %#v", config)
@@ -117,6 +123,8 @@ func TestLoadConfigDir(t *testing.T) {
 	}
 
 	expected := &Config{
+		DisableMlock: true,
+
 		Listeners: []*Listener{
 			&Listener{
 				Type: "tcp",
@@ -138,6 +146,9 @@ func TestLoadConfigDir(t *testing.T) {
 			StatsdAddr: "baz",
 			DisableHostname: true,
 		},
+
+		MaxLeaseDuration: 10,
+		DefaultLeaseDuration: 10,
 	}
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("bad: %#v", config)

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestLoadConfigFile(t *testing.T) {
@@ -37,8 +38,10 @@ func TestLoadConfigFile(t *testing.T) {
 
 		DisableMlock: true,
 
-		MaxLeaseDuration: 10,
-		DefaultLeaseDuration: 10,
+		MaxLeaseDuration: 10 * time.Hour,
+		MaxLeaseDurationRaw: "10h",
+		DefaultLeaseDuration: 10 * time.Hour,
+		DefaultLeaseDurationRaw: "10h",
 	}
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("bad: %#v", config)
@@ -74,8 +77,10 @@ func TestLoadConfigFile_json(t *testing.T) {
 			DisableHostname: false,
 		},
 
-		MaxLeaseDuration: 10,
-		DefaultLeaseDuration: 10,
+		MaxLeaseDuration: 10 * time.Hour,
+		MaxLeaseDurationRaw: "10h",
+		DefaultLeaseDuration: 10 * time.Hour,
+		DefaultLeaseDurationRaw: "10h",
 	}
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("bad: %#v", config)
@@ -147,8 +152,8 @@ func TestLoadConfigDir(t *testing.T) {
 			DisableHostname: true,
 		},
 
-		MaxLeaseDuration: 10,
-		DefaultLeaseDuration: 10,
+		MaxLeaseDuration: 10 * time.Hour,
+		DefaultLeaseDuration: 10 * time.Hour,
 	}
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("bad: %#v", config)

--- a/command/server/test-fixtures/config-dir/bar.json
+++ b/command/server/test-fixtures/config-dir/bar.json
@@ -5,5 +5,5 @@
         }
     },
 
-    "max_lease_duration": 10
+    "max_lease_duration": "10h"
 }

--- a/command/server/test-fixtures/config-dir/bar.json
+++ b/command/server/test-fixtures/config-dir/bar.json
@@ -3,5 +3,7 @@
         "tcp": {
             "address": "127.0.0.1:443"
         }
-    }
+    },
+
+    "max_lease_duration": 10
 }

--- a/command/server/test-fixtures/config-dir/baz.hcl
+++ b/command/server/test-fixtures/config-dir/baz.hcl
@@ -3,3 +3,5 @@ telemetry {
     statsite_address = "qux"
     disable_hostname = true
 }
+
+default_lease_duration = 10

--- a/command/server/test-fixtures/config-dir/baz.hcl
+++ b/command/server/test-fixtures/config-dir/baz.hcl
@@ -4,4 +4,4 @@ telemetry {
     disable_hostname = true
 }
 
-default_lease_duration = 10
+default_lease_duration = "10h"

--- a/command/server/test-fixtures/config-dir/foo.hcl
+++ b/command/server/test-fixtures/config-dir/foo.hcl
@@ -1,3 +1,5 @@
+disable_mlock = true
+
 backend "consul" {
     foo = "bar"
 }

--- a/command/server/test-fixtures/config.hcl
+++ b/command/server/test-fixtures/config.hcl
@@ -10,3 +10,6 @@ backend "consul" {
     foo = "bar"
     advertise_addr = "foo"
 }
+
+max_lease_duration = 10
+default_lease_duration = 10

--- a/command/server/test-fixtures/config.hcl
+++ b/command/server/test-fixtures/config.hcl
@@ -11,5 +11,5 @@ backend "consul" {
     advertise_addr = "foo"
 }
 
-max_lease_duration = 10
-default_lease_duration = 10
+max_lease_duration = "10h"
+default_lease_duration = "10h"

--- a/command/server/test-fixtures/config.hcl.json
+++ b/command/server/test-fixtures/config.hcl.json
@@ -13,5 +13,8 @@
 
     "telemetry": {
         "statsite_address": "baz"
-    }
+    },
+
+    "max_lease_duration": 10,
+    "default_lease_duration": 10
 }

--- a/command/server/test-fixtures/config.hcl.json
+++ b/command/server/test-fixtures/config.hcl.json
@@ -15,6 +15,6 @@
         "statsite_address": "baz"
     },
 
-    "max_lease_duration": 10,
-    "default_lease_duration": 10
+    "max_lease_duration": "10h",
+    "default_lease_duration": "10h"
 }

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -442,7 +442,7 @@ func TestCore_HandleRequest_Lease_MaxLength(t *testing.T) {
 	if resp == nil || resp.Secret == nil || resp.Data == nil {
 		t.Fatalf("bad: %#v", resp)
 	}
-	if resp.Secret.Lease != maxLeaseDuration {
+	if resp.Secret.Lease != c.maxLeaseDuration {
 		t.Fatalf("bad: %#v", resp.Secret)
 	}
 	if resp.Secret.LeaseID == "" {
@@ -483,7 +483,7 @@ func TestCore_HandleRequest_Lease_DefaultLength(t *testing.T) {
 	if resp == nil || resp.Secret == nil || resp.Data == nil {
 		t.Fatalf("bad: %#v", resp)
 	}
-	if resp.Secret.Lease != defaultLeaseDuration {
+	if resp.Secret.Lease != c.defaultLeaseDuration {
 		t.Fatalf("bad: %#v", resp.Secret)
 	}
 	if resp.Secret.LeaseID == "" {
@@ -829,7 +829,7 @@ func TestCore_HandleLogin_Token(t *testing.T) {
 	}
 
 	// Check that we have a lease with default duration
-	if lresp.Auth.Lease != defaultLeaseDuration {
+	if lresp.Auth.Lease != c.defaultLeaseDuration {
 		t.Fatalf("bad: %#v", lresp.Auth)
 	}
 }
@@ -1016,7 +1016,7 @@ func TestCore_HandleRequest_CreateToken_Lease(t *testing.T) {
 	}
 
 	// Check that we have a lease with default duration
-	if resp.Auth.Lease != defaultLeaseDuration {
+	if resp.Auth.Lease != c.defaultLeaseDuration {
 		t.Fatalf("bad: %#v", resp.Auth)
 	}
 }

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -35,10 +35,10 @@ const (
 	// minRevokeDelay is used to prevent an instant revoke on restore
 	minRevokeDelay = 5 * time.Second
 
-	// maxLeaseDuration is the maximum lease duration
+	// maxLeaseDuration is the default maximum lease duration
 	maxLeaseDuration = 30 * 24 * time.Hour
 
-	// defaultLeaseDuration is the lease duration used when no lease is specified
+	// defaultLeaseDuration is the default lease duration used when no lease is specified
 	defaultLeaseDuration = maxLeaseDuration
 )
 

--- a/website/source/docs/auth/token.html.md
+++ b/website/source/docs/auth/token.html.md
@@ -88,8 +88,9 @@ of the cookie should be "token" and the value should be the token.
         <span class="param">lease</span>
         <span class="param-flags">optional</span>
         The lease period of the token, provided as "1h", where hour is
-        the largest suffix. If not provided, the token is valid for the default
-        lease duration (30 days), or indefinitely if the root policy is used.
+        the largest suffix. If not provided, the token is valid for the
+        [default lease duration](/docs/config/index.html), or
+        indefinitely if the root policy is used.
       </li>
       <li>
         <span class="param">display_name</span>

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -49,6 +49,15 @@ to specify where the configuration is.
 * `telemetry` (optional)  - Configures the telemetry reporting system
   (see below).
 
+* `default_lease_duration` (optional) - Configures the default lease
+  duration for tokens and secrets, specified in hours. Default value
+  is 30 * 24 hours. This value cannot be larger than
+  `max_lease_duration`.
+
+* `max_lease_duration` (optional) - Configures the maximum possible
+  lease duration for tokens and secrets, specified in hours. Default
+  value is 30 * 24 hours.
+
 In production, you should only consider setting the `disable_mlock` option
 on Linux systems that only use encrypted swap or do not use swap at all.
 Vault does not currently support memory locking on Mac OS X and Windows

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -51,12 +51,11 @@ to specify where the configuration is.
 
 * `default_lease_duration` (optional) - Configures the default lease
   duration for tokens and secrets, specified in hours. Default value
-  is 30 * 24 hours. This value cannot be larger than
-  `max_lease_duration`.
+  is 30 days. This value cannot be larger than `max_lease_duration`.
 
 * `max_lease_duration` (optional) - Configures the maximum possible
   lease duration for tokens and secrets, specified in hours. Default
-  value is 30 * 24 hours.
+  value is 30 days.
 
 In production, you should only consider setting the `disable_mlock` option
 on Linux systems that only use encrypted swap or do not use swap at all.


### PR DESCRIPTION
Resolves #407 by adding configuration options `default_lease_duration` and `max_lease_duration`.

Notes:
* If config options are not specified, defaults remain set to 30 * 24 hours.
* I did not write in a hard-coded upper bound to either option. Some use cases (e.g. #451, #388) suggest that a large maximum lease duration may occasionally be sensible, so personally I would defer this responsibility to the end user. However, of course, it's up to the Vault maintainers to determine and enforce an upper bound.