### PR TITLE
Vault Test: Disabling mlock for logical.testing.Test()

### DIFF
--- a/logical/testing/testing.go
+++ b/logical/testing/testing.go
@@ -126,6 +126,7 @@ func Test(t TestT, c TestCase) {
 				return c.Factory(conf)
 			},
 		},
+		DisableMlock: true,
 	})
 	if err != nil {
 		t.Fatal("error initializing core: ", err)


### PR DESCRIPTION
Fixes #479 