### PR TITLE
update doc for app-id

### DIFF
--- a/builtin/credential/app-id/backend.go
+++ b/builtin/credential/app-id/backend.go
@@ -207,4 +207,8 @@ ID policies.
 The user ID can be any value (just like the app ID), however it is
 generally a value unique to a machine, such as a MAC address or instance ID,
 or a value hashed from these unique values.
+
+(Note that it is also possible to authorize multiple app IDs with each
+user ID by writing them as comma-separated values to the map/user-id/<user-id>
+path.)
 `

--- a/website/source/docs/auth/app-id.html.md
+++ b/website/source/docs/auth/app-id.html.md
@@ -109,3 +109,11 @@ This means that if a client authenticates and provide both "foo" and "bar",
 then the app ID will authenticate that client with the policy "root".
 
 In practice, both the user and app ID are likely hard-to-guess UUID-like values.
+
+Note that it is possible to authorize multiple app IDs with each
+user ID by writing them as comma-separated values to the user ID mapping:
+
+```
+$ vault write auth/app-id/map/user-id/bar value=foo,baz cidr_block=10.0.0.0/16
+...
+```


### PR DESCRIPTION
make clearer in doc that user-id can accept multiple app-id mappngs as comma-separated values