### PR TITLE
Fixes GitHub Authentication Bug #488

### DIFF
--- a/builtin/credential/github/path_login.go
+++ b/builtin/credential/github/path_login.go
@@ -47,12 +47,25 @@ func (b *backend) pathLogin(
 
 	// Verify that the user is part of the organization
 	var org *github.Organization
-	orgs, _, err := client.Organizations.List("", nil)
-	if err != nil {
-		return nil, err
+
+	orgOpt := &github.ListOptions{
+		PerPage: 100,
 	}
 
-	for _, o := range orgs {
+	var allOrgs []github.Organization
+	for {
+		orgs, resp, err := client.Organizations.List("", orgOpt)
+		if err != nil {
+			return nil, err
+		}
+		allOrgs = append(allOrgs, orgs...)
+		if resp.NextPage == 0 {
+			break
+		}
+		orgOpt.Page = resp.NextPage
+	}
+
+	for _, o := range allOrgs {
 		if *o.Login == config.Org {
 			org = &o
 			break
@@ -64,23 +77,34 @@ func (b *backend) pathLogin(
 
 	// Get the teams that this user is part of to determine the policies
 	var teamNames []string
-	teams, _, err := client.Organizations.ListUserTeams(nil)
-	if err != nil {
-		return nil, err
+
+	teamOpt := &github.ListOptions{
+		PerPage: 100,
 	}
-	for _, t := range teams {
+
+	var allTeams []github.Team
+	for {
+		teams, resp, err := client.Organizations.ListUserTeams(teamOpt)
+		if err != nil {
+			return nil, err
+		}
+		allTeams = append(allTeams, teams...)
+		if resp.NextPage == 0 {
+			break
+		}
+		teamOpt.Page = resp.NextPage
+	}
+
+	for _, t := range allTeams {
 		// We only care about teams that are part of the organization we use
 		if *t.Organization.ID != *org.ID {
 			continue
 		}
 
-		// Append the names AND slug so we can get the policies
-                // Slug is needed for teamnames with whitespaces
+		// Append the names so we can get the policies
 		teamNames = append(teamNames, *t.Name)
-                if *t.Name != *t.Slug {
-                        teamNames = append(teamNames, *t.Slug)
-                }
 	}
+
 
 	policiesList, err := b.Map.Policies(req.Storage, teamNames...)
 	if err != nil {
@@ -98,3 +122,5 @@ func (b *backend) pathLogin(
 		},
 	}, nil
 }
+
+

--- a/builtin/credential/github/path_login.go
+++ b/builtin/credential/github/path_login.go
@@ -122,5 +122,3 @@ func (b *backend) pathLogin(
 		},
 	}, nil
 }
-
-


### PR DESCRIPTION
This fixes a problem with the GitHub Authentication whereby if an organization has more than 10 teams or a user belongs to more than 10 organizations authentication has a chance to fail.

This adds pagination support to the GitHub Authentication module. It will call the GitHub API requesting up to 100 organizations and 100 teams at a time, if the API indicates there are more teams, than it will request the next page until there are no more to request.

Use Case: I have over 600 teams with one of my organizations for access control, without this I am unable to use Vault with GitHub authentication and team mappings.