### PR TITLE
Fix panicing vault server

### DIFF
--- a/logical/framework/field_data.go
+++ b/logical/framework/field_data.go
@@ -18,6 +18,11 @@ type FieldData struct {
 	Schema map[string]*FieldSchema
 }
 
+type FieldDataPanic struct {
+	Field string
+	Error error
+}
+
 // Get gets the value for the given field. If the key is an invalid field,
 // FieldData will panic. If you want a safer version of this method, use
 // GetOk. If the field k is not set, the default value (if set) will be
@@ -46,7 +51,7 @@ func (d *FieldData) GetOk(k string) (interface{}, bool) {
 
 	result, ok, err := d.GetOkErr(k)
 	if err != nil {
-		panic(fmt.Sprintf("error reading %s: %s", k, err))
+		panic(FieldDataPanic{k, err})
 	}
 
 	if ok && result == nil {

--- a/logical/framework/field_data_test.go
+++ b/logical/framework/field_data_test.go
@@ -5,6 +5,28 @@ import (
 	"testing"
 )
 
+func TestFieldDataGetPanic(t *testing.T) {
+	data := &FieldData{
+		Raw:    map[string]interface{}{"foo": "false3"},
+		Schema: map[string]*FieldSchema{"foo": &FieldSchema{Type: TypeBool}},
+	}
+
+	defer func() {
+		r := recover()
+		switch r.(type) {
+		case FieldDataPanic:
+			// Expected
+		case nil:
+			t.Error("Should have gotten a panic.")
+		default:
+			t.Error("Unexpected panic received.")
+		}
+	}()
+
+	// Should panic!
+	data.Get("foo")
+}
+
 func TestFieldDataGet(t *testing.T) {
 	cases := map[string]struct {
 		Schema map[string]*FieldSchema


### PR DESCRIPTION
If you specify an invalid boolean value with a PUT, the whole thing panics.  Catch the panic and better error in those cases.