### PR TITLE
audit/format_json: honor system/environment timezone

### DIFF
--- a/audit/format_json.go
+++ b/audit/format_json.go
@@ -30,7 +30,10 @@ func (f *FormatJSON) FormatRequest(
 	// Encode!
 	enc := json.NewEncoder(w)
 	return enc.Encode(&JSONRequestEntry{
-		Time:  time.Now().UTC().Format(time.RFC3339),
+		// Users desiring audit logs to appear in UTC should set the
+		// TZ environment variable to "UTC" before launching Vault
+		// if the host's default time zone is not UTC already.
+		Time:  time.Now().Format(time.RFC3339),
 		Type:  "request",
 		Error: errString,
 
@@ -87,7 +90,7 @@ func (f *FormatJSON) FormatResponse(
 	// Encode!
 	enc := json.NewEncoder(w)
 	return enc.Encode(&JSONResponseEntry{
-		Time:  time.Now().UTC().Format(time.RFC3339),
+		Time:  time.Now().Format(time.RFC3339),
 		Type:  "response",
 		Error: errString,
 

--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/vault/logical"
 	"errors"
+        "time"
 )
 
 func TestFormatJSON_formatRequest(t *testing.T) {
@@ -48,7 +49,8 @@ func TestFormatJSON_formatRequest(t *testing.T) {
 			t.Fatalf("bad json: %s", err)
 		}
 
-		expectedjson.Time = actualjson.Time
+		expectedjson.Time = time.Now().Format(time.RFC3339)
+		actualjson.Time = expectedjson.Time
 
 		expectedBytes, err := json.Marshal(expectedjson)
 		if err != nil {


### PR DESCRIPTION
Although UTC timestamps are a best practice, users may prefer logs be
rendered in a local time zone.  We may disagree with such a
configuration, but we should allow it to ease integration with legacy
systems.

Fixes #495