### PR TITLE
More descriptive errors with specific HTTP return codes

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -156,6 +156,11 @@ func respondError(w http.ResponseWriter, status int, err error) {
 		status = http.StatusServiceUnavailable
 	}
 
+	// Allow HTTPCoded error passthrough to specify a code
+	if t, ok := err.(logical.HTTPCodedError); ok {
+		status = t.Code()
+	}
+
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(status)
 

--- a/http/sys_mount.go
+++ b/http/sys_mount.go
@@ -131,6 +131,7 @@ func handleSysMount(
 			"description": req.Description,
 		},
 	}))
+
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return
@@ -149,6 +150,7 @@ func handleSysUnmount(
 		Path:       "sys/mounts/" + path,
 		Connection: getConnection(r),
 	}))
+	
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err)
 		return

--- a/logical/error.go
+++ b/logical/error.go
@@ -1,0 +1,24 @@
+package logical
+
+type HTTPCodedError interface {
+    Error() string
+    Code() int
+}
+
+func CodedError(c int, s string) HTTPCodedError {
+    return &codedError{s,c}
+}
+
+type codedError struct {
+    s string
+    code int
+}
+
+func (e *codedError) Error() string {
+    return e.s
+}
+
+func (e *codedError) Code() int {
+    return e.code
+}
+

--- a/logical/request.go
+++ b/logical/request.go
@@ -145,6 +145,6 @@ var (
 	// ErrInvalidRequest is returned if the request is invalid
 	ErrInvalidRequest = errors.New("invalid request")
 
-	// ErrPermissionDeneid is returned if the client is not authorized
+	// ErrPermissionDenied is returned if the client is not authorized
 	ErrPermissionDenied = errors.New("permission denied")
 )

--- a/logical/response.go
+++ b/logical/response.go
@@ -13,7 +13,7 @@ const (
 	// avoided like the HTTPContentType. The value must be a byte slice.
 	HTTPRawBody = "http_raw_body"
 
-	// HTTPStatusCode is the response code the HTTP body that goes with the HTTPContentType.
+	// HTTPStatusCode is the response code of the HTTP body that goes with the HTTPContentType.
 	// This can only be specified for non-secrets, and should should be similarly
 	// avoided like the HTTPContentType. The value must be an integer.
 	HTTPStatusCode = "http_status_code"

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -22,7 +22,7 @@ const (
 	// barrier view for the backends.
 	backendBarrierPrefix = "logical/"
 
-	// systemBarrierPrefix is sthe prefix used for the
+	// systemBarrierPrefix is the prefix used for the
 	// system logical backend.
 	systemBarrierPrefix = "sys/"
 )
@@ -139,16 +139,16 @@ func (c *Core) mount(me *MountEntry) error {
 		me.Path += "/"
 	}
 
-	// Prevent protected paths from being unmounted
+	// Prevent protected paths from being mounted
 	for _, p := range protectedMounts {
 		if strings.HasPrefix(me.Path, p) {
-			return fmt.Errorf("cannot mount '%s'", me.Path)
+			return logical.CodedError(403, fmt.Sprintf("cannot mount '%s'", me.Path))
 		}
 	}
 
 	// Verify there is no conflicting mount
 	if match := c.router.MatchingMount(me.Path); match != "" {
-		return fmt.Errorf("existing mount at '%s'", match)
+		return logical.CodedError(409, fmt.Sprintf("existing mount at %s", match))
 	}
 
 	// Generate a new UUID and view


### PR DESCRIPTION
Create a new error class that logical backends can use to specify more concrete error statuses to be returned to the HTTP stack in those cases.  For non-changed cases, existing behavior is preserved.

This was inspired by #235 where double mounts caused a 500 error.  This is because as you go back down the call chain, it doesn't know how to distinguish errors in client input and operation from backend errors.

This updates this specific case to now return a 409 Conflict instead of a 500 error for this specific case, but other cases can also be tackled as needed.  There's at least one other ticket opened for the same type of issue.