### PR TITLE
Validate field data before we try to access it

### DIFF
--- a/logical/framework/backend.go
+++ b/logical/framework/backend.go
@@ -118,12 +118,20 @@ func (b *Backend) HandleRequest(req *logical.Request) (*logical.Response, error)
 	if !ok {
 		return nil, logical.ErrUnsupportedOperation
 	}
+	
+	fd := FieldData{
+		Raw:    raw,
+		Schema: path.Fields}
+	
+	if req.Operation != logical.HelpOperation {
+	    err := fd.Validate()
+	    if err != nil {
+	        return nil, err
+	    }
+	}
 
 	// Call the callback with the request and the data
-	return callback(req, &FieldData{
-		Raw:    raw,
-		Schema: path.Fields,
-	})
+	return callback(req, &fd)
 }
 
 // logical.Backend impl.

--- a/logical/framework/backend_test.go
+++ b/logical/framework/backend_test.go
@@ -77,6 +77,42 @@ func TestBackendHandleRequest(t *testing.T) {
 	}
 }
 
+func TestBackendHandleRequest_badwrite(t *testing.T) {
+	callback := func(req *logical.Request, data *FieldData) (*logical.Response, error) {
+		return &logical.Response{
+			Data: map[string]interface{}{
+				"value": data.Get("value").(bool),
+			},
+		}, nil
+	}
+
+	b := &Backend{
+		Paths: []*Path{
+			&Path{
+				Pattern: "foo/bar",
+				Fields: map[string]*FieldSchema{
+					"value": &FieldSchema{Type: TypeBool},
+				},
+				Callbacks: map[logical.Operation]OperationFunc{
+					logical.WriteOperation: callback,
+				},
+			},
+		},
+	}
+
+	_, err := b.HandleRequest(&logical.Request{
+		Operation: logical.WriteOperation,
+		Path:      "foo/bar",
+		Data:      map[string]interface{}{"value": "3false3"},
+	})
+	
+
+	if err == nil {
+		t.Fatalf("should have thrown a conversion error")
+	}
+
+}
+
 func TestBackendHandleRequest_404(t *testing.T) {
 	callback := func(req *logical.Request, data *FieldData) (*logical.Response, error) {
 		return &logical.Response{

--- a/logical/framework/field_data.go
+++ b/logical/framework/field_data.go
@@ -18,6 +18,33 @@ type FieldData struct {
 	Schema map[string]*FieldSchema
 }
 
+// Cycle through raw data and validate conversions in
+// the schema, so we don't get an error/panic later when
+// trying to get data out.  Data not in the schema is not
+// an error at this point, so we don't worry about it.
+func (d *FieldData) Validate() error {
+	for field, value := range d.Raw {
+
+		schema, ok := d.Schema[field]
+		if !ok {
+			continue
+		}
+
+		switch schema.Type {
+		case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeString:
+			_, _, err := d.getPrimitive(field, schema)
+			if err != nil {
+				return fmt.Errorf("Error converting input %v for field %s", value, field)
+			}
+		default:
+			return fmt.Errorf("unknown field type %s for field %s",
+			    schema.Type, field)
+		}
+	}
+
+	return nil
+}
+
 // Get gets the value for the given field. If the key is an invalid field,
 // FieldData will panic. If you want a safer version of this method, use
 // GetOk. If the field k is not set, the default value (if set) will be


### PR DESCRIPTION
This adds a validation step in the field data, where we try and make sure data WILL convert to the specified schema types, and if not error earlier out vs. panicing later.

Replaces https://github.com/hashicorp/vault/pull/503