### PR TITLE
Fix quoting in cassandra grant example

### DIFF
--- a/website/source/docs/secrets/cassandra/index.html.md
+++ b/website/source/docs/secrets/cassandra/index.html.md
@@ -51,7 +51,7 @@ a "readonly" role:
 ```text
 $ vault write cassandra/roles/readonly \
     creation_cql="CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER; \
-    GRANT SELECT ON ALL KEYSPACES TO '{{username}}';"
+    GRANT SELECT ON ALL KEYSPACES TO \"{{username}}\";"
 Success! Data written to: cassandra/roles/readonly
 ```
 


### PR DESCRIPTION
With cassandra 2.2.0 the single quotes from the example did not work for the GRANT line, for some reason unknown to me.
Turning (only) these into double quotes works for me.