### PR TITLE
do not revoke permissions on revoke for cassandra, just drop user.

### DIFF
--- a/builtin/logical/cassandra/backend_test.go
+++ b/builtin/logical/cassandra/backend_test.go
@@ -125,4 +125,4 @@ func testAccStepReadRole(t *testing.T, name string, cql string) logicaltest.Test
 }
 
 const testRole = `CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER;
-GRANT ALL PERMISSIONS ON ALL KEYSPACES TO '{{username}}';`
+GRANT ALL PERMISSIONS ON ALL KEYSPACES TO "{{username}}";`

--- a/builtin/logical/cassandra/secret_creds.go
+++ b/builtin/logical/cassandra/secret_creds.go
@@ -71,11 +71,6 @@ func (b *backend) secretCredsRevoke(
 		return nil, fmt.Errorf("Error getting session")
 	}
 
-	err = session.Query(fmt.Sprintf("REVOKE ALL PERMISSIONS ON ALL KEYSPACES FROM '%s'", username)).Exec()
-	if err != nil {
-		return nil, fmt.Errorf("Error revoking permissions for user %s", username)
-	}
-
 	err = session.Query(fmt.Sprintf("DROP USER '%s'", username)).Exec()
 	if err != nil {
 		return nil, fmt.Errorf("Error removing user %s", username)

--- a/website/source/docs/secrets/cassandra/index.html.md
+++ b/website/source/docs/secrets/cassandra/index.html.md
@@ -51,7 +51,7 @@ a "readonly" role:
 ```text
 $ vault write cassandra/roles/readonly \
     creation_cql="CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER; \
-    GRANT SELECT ON ALL KEYSPACES TO '{{username}}';"
+    GRANT SELECT ON ALL KEYSPACES TO \"{{username}}\";"
 Success! Data written to: cassandra/roles/readonly
 ```
 


### PR DESCRIPTION
Son of #543. We could have switched to double quotes around the username to make this work, but just dropping the user and letting cassandra figure out the revoked privileges works just as well.