### PR TITLE
Use underscores in cassandra username generation

### DIFF
--- a/builtin/logical/cassandra/backend_test.go
+++ b/builtin/logical/cassandra/backend_test.go
@@ -125,4 +125,4 @@ func testAccStepReadRole(t *testing.T, name string, cql string) logicaltest.Test
 }
 
 const testRole = `CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER;
-GRANT ALL PERMISSIONS ON ALL KEYSPACES TO '{{username}}';`
+GRANT ALL PERMISSIONS ON ALL KEYSPACES TO {{username}};`

--- a/builtin/logical/cassandra/path_creds_create.go
+++ b/builtin/logical/cassandra/path_creds_create.go
@@ -2,6 +2,7 @@ package cassandra
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/helper/uuid"
@@ -42,7 +43,7 @@ func (b *backend) pathCredsCreateRead(
 	}
 
 	displayName := req.DisplayName
-	username := fmt.Sprintf("vault-%s-%s-%s-%d", name, displayName, uuid.GenerateUUID(), time.Now().Unix())
+	username := fmt.Sprintf("vault_%s_%s_%s_%d", name, displayName, strings.Replace(uuid.GenerateUUID(), "-", "_", -1), time.Now().Unix())
 	password := uuid.GenerateUUID()
 
 	// Get our connection

--- a/builtin/logical/cassandra/secret_creds.go
+++ b/builtin/logical/cassandra/secret_creds.go
@@ -71,11 +71,6 @@ func (b *backend) secretCredsRevoke(
 		return nil, fmt.Errorf("Error getting session")
 	}
 
-	err = session.Query(fmt.Sprintf("REVOKE ALL PERMISSIONS ON ALL KEYSPACES FROM '%s'", username)).Exec()
-	if err != nil {
-		return nil, fmt.Errorf("Error revoking permissions for user %s", username)
-	}
-
 	err = session.Query(fmt.Sprintf("DROP USER '%s'", username)).Exec()
 	if err != nil {
 		return nil, fmt.Errorf("Error removing user %s", username)

--- a/website/source/docs/secrets/cassandra/index.html.md
+++ b/website/source/docs/secrets/cassandra/index.html.md
@@ -51,7 +51,7 @@ a "readonly" role:
 ```text
 $ vault write cassandra/roles/readonly \
     creation_cql="CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER; \
-    GRANT SELECT ON ALL KEYSPACES TO '{{username}}';"
+    GRANT SELECT ON ALL KEYSPACES TO {{username}};"
 Success! Data written to: cassandra/roles/readonly
 ```
 


### PR DESCRIPTION
Son of #545 .

By avoiding dashes and using underscores instead, we can skip the quoting and avoid the current api incompatibility in username quoting for GRANT statements that currently exists between cassandra 2.1.x and 2.2.x. 

See also https://issues.apache.org/jira/browse/CASSANDRA-10135
