### PR TITLE
Change "lease" parameter in the generic backend to be "ttl" to reduce confusion.

### DIFF
--- a/logical/lease.go
+++ b/logical/lease.go
@@ -7,7 +7,8 @@ import "time"
 type LeaseOptions struct {
 	// Lease is the duration that this secret is valid for. Vault
 	// will automatically revoke it after the duration + grace period.
-	Lease            time.Duration `json:"lease"`
+	Lease            time.Duration `json:"lease,omitempty"`
+	TTL              time.Duration `json:"ttl,omitempty"`
 	LeaseGracePeriod time.Duration `json:"lease_grace_period"`
 
 	// Renewable, if true, means that this secret can be renewed.

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -184,9 +184,10 @@ const passthroughHelpDescription = `
 The pass-through backend reads and writes arbitrary data into secret storage,
 encrypting it along the way.
 
-A TTL can be specified when writing with the "ttl" field. If given, then
-when the secret is read, the returned lease's duration will be set to
-that value. It is expected that the consumer of this backend properly
-writes renewed keys before the lease is up. In addition, revocation
-must be handled by the user of this backend.
+A TTL can be specified when writing with the "ttl" field. If given, the
+duration of leases returned by this backend will be set to this value. This
+can be used as a hint from the writer of a secret to the consumer of a secret
+that the consumer should re-read the value before the TTL has expired.
+However, any revocation must be handled by the user of this backend; the lease
+duration does not affect the provided data in any way.
 `

--- a/vault/logical_passthrough_test.go
+++ b/vault/logical_passthrough_test.go
@@ -38,7 +38,7 @@ func TestPassthroughBackend_Write(t *testing.T) {
 	}
 }
 
-func TestPassthroughBackend_Read(t *testing.T) {
+func TestPassthroughBackend_Read_Lease(t *testing.T) {
 	b := testPassthroughBackend()
 	req := logical.TestRequest(t, logical.WriteOperation, "foo")
 	req.Data["raw"] = "test"
@@ -62,11 +62,51 @@ func TestPassthroughBackend_Read(t *testing.T) {
 			LeaseOptions: logical.LeaseOptions{
 				Renewable: true,
 				Lease:     time.Hour,
+				TTL:       time.Hour,
 			},
 		},
 		Data: map[string]interface{}{
 			"raw":   "test",
 			"lease": "1h",
+		},
+	}
+
+	resp.Secret.InternalData = nil
+	resp.Secret.LeaseID = ""
+	if !reflect.DeepEqual(resp, expected) {
+		t.Fatalf("bad response.\n\nexpected: %#v\n\nGot: %#v", expected, resp)
+	}
+}
+
+func TestPassthroughBackend_Read_TTL(t *testing.T) {
+	b := testPassthroughBackend()
+	req := logical.TestRequest(t, logical.WriteOperation, "foo")
+	req.Data["raw"] = "test"
+	req.Data["ttl"] = "1h"
+	storage := req.Storage
+
+	if _, err := b.HandleRequest(req); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	req = logical.TestRequest(t, logical.ReadOperation, "foo")
+	req.Storage = storage
+
+	resp, err := b.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	expected := &logical.Response{
+		Secret: &logical.Secret{
+			LeaseOptions: logical.LeaseOptions{
+				Renewable: true,
+				TTL:       time.Hour,
+			},
+		},
+		Data: map[string]interface{}{
+			"raw": "test",
+			"ttl": "1h",
 		},
 	}
 

--- a/website/source/docs/secrets/generic/index.html.md
+++ b/website/source/docs/secrets/generic/index.html.md
@@ -20,13 +20,16 @@ the sub-fields are not merged together.
 
 ## Quick Start
 
-The generic backend allows for writing keys with arbitrary values. The
-only value that is special is the `ttl` key, which can be provided with
-any key to restrict the lease duration of the secret. This is useful to ensure
-clients periodically renew so that key rolling can be time bounded. Note
-that this does not actually expire the data, it is simply a hint to clients
-that they should not go longer than the `ttl` value before refreshing the
-value locally.
+The generic backend allows for writing keys with arbitrary values. A `ttl` value
+can be provided, which affects the duration of generated leases. Specifically,
+this can be used as a hint from the writer of a secret to consumers of a secret
+that the consumer should wait no more than the `ttl` duration before checking
+for a new value. If you expect a secret to change frequently, or if you need
+clients to react quickly to a change in the secret's value, specify a low value
+of `ttl`. Keep in mind that a low `ttl` value may add significant additional load
+to the Vault server if it results in clients accessing the value very frequently.
+Also note that setting `ttl` does not actually expire the data; it is
+informational only.
 
 N.B.: Prior to version 0.3, the `ttl` parameter was called `lease`. Both will
 work for 0.3, but in 0.4 `lease` will be removed. When providing a `lease` value

--- a/website/source/docs/secrets/generic/index.html.md
+++ b/website/source/docs/secrets/generic/index.html.md
@@ -21,15 +21,22 @@ the sub-fields are not merged together.
 ## Quick Start
 
 The generic backend allows for writing keys with arbitrary values. The
-only value that is special is the `lease` key, which can be provided with
-any key to restrict the lease time of the secret. This is useful to ensure
-clients periodically renew so that key rolling can be time bounded.
+only value that is special is the `ttl` key, which can be provided with
+any key to restrict the lease duration of the secret. This is useful to ensure
+clients periodically renew so that key rolling can be time bounded. Note
+that this does not actually expire the data, it is simply a hint to clients
+that they should not go longer than the `ttl` value before refreshing the
+value locally.
+
+N.B.: Prior to version 0.3, the `ttl` parameter was called `lease`. Both will
+work for 0.3, but in 0.4 `lease` will be removed. When providing a `lease` value
+in 0.3, both `lease` and `ttl` will be returned with the same data.
 
 As an example, we can write a new key "foo" to the generic backend
 mounted at "secret/" by default:
 
 ```
-$ vault write secret/foo zip=zap lease=1h
+$ vault write secret/foo zip=zap ttl=1h
 Success! Data written to: secret/foo
 ```
 
@@ -41,10 +48,9 @@ $ vault read secret/foo
 Key           	Value
 lease_id      	secret/foo/e4514713-d5d9-fb14-4177-97a7f7f64518
 lease_duration	3600
-lease         	1h
+ttl		1h
 zip           	zap
 ```
 
-As expected, we get the value previously set back as well as our custom lease.
-The lease_duration has been set to 3600 seconds, or one hour as specified.
-
+As expected, we get the value previously set back as well as our custom TTL.
+The lease_duration has been set to 3600 seconds (one hour) as specified.


### PR DESCRIPTION
"lease" is now deprecated but will remain valid until 0.4.

Fixes #528.