### PR TITLE
make sure header is below clickable area that hides sidebar

### DIFF
--- a/website/source/assets/stylesheets/_sidebar.scss
+++ b/website/source/assets/stylesheets/_sidebar.scss
@@ -460,7 +460,7 @@ $sidebar-font-weight: 300;
   bottom: 0;
   opacity: 0;
   background: $white;
-  z-index: 2;
+  z-index: $zindex-sidebar-fixed - 1;
 
   -webkit-transition: visibility 0 linear .4s,opacity .4s cubic-bezier(.4,0,.2,1);
   -moz-transition: visibility 0 linear .4s,opacity .4s cubic-bezier(.4,0,.2,1);


### PR DESCRIPTION
Clicking at the top, where the header's located, when the sidebar is open won't close the sidebar. Fix to the overlay is relative to the sidebar so they're both above everything else.
