### PR TITLE
Spaces in displayName break AWS IAM

### DIFF
--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -46,7 +47,7 @@ func (b *backend) secretAccessKeysCreate(
 
 	// Generate a random username. We don't put the policy names in the
 	// username because the AWS console makes it pretty easy to see that.
-	username := fmt.Sprintf("vault-%s-%d-%d", displayName, time.Now().Unix(), rand.Int31n(10000))
+	username := fmt.Sprintf("vault-%s-%d-%d", normalizeDisplayName(displayName), time.Now().Unix(), rand.Int31n(10000))
 
 	// Write to the WAL that this user will be created. We do this before
 	// the user is created because if switch the order then the WAL put
@@ -140,4 +141,8 @@ func secretAccessKeysRevoke(
 	}
 
 	return nil, nil
+}
+
+func normalizeDisplayName(displayName string) string {
+	return strings.Replace(displayName, " ", "_", -1)
 }

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"fmt"
 	"math/rand"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -144,5 +144,6 @@ func secretAccessKeysRevoke(
 }
 
 func normalizeDisplayName(displayName string) string {
-	return strings.Replace(displayName, " ", "_", -1)
+	re := regexp.MustCompile("[^a-zA-Z+=,.@_-]")
+	return re.ReplaceAllString(displayName, "_")
 }

--- a/builtin/logical/aws/secret_access_keys_test.go
+++ b/builtin/logical/aws/secret_access_keys_test.go
@@ -9,7 +9,17 @@ func TestNormalizeDisplayName(t *testing.T) {
 	expectedName := "___test_name_should_be_normalized___"
 	normalizedName := normalizeDisplayName(invalidName)
 	if normalizedName != expectedName {
-		t.Fatalf("normalizeDisplayName does not normalize AWS name correctly: %s", normalizedName)
+		t.Fatalf(
+			"normalizeDisplayName does not normalize AWS name correctly: %s",
+			normalizedName)
+	}
+
+	validName := "test_name_should_normalize_to_itself@example.com"
+	normalizedValidName := normalizeDisplayName(validName)
+	if normalizedValidName != validName {
+		t.Fatalf(
+			"normalizeDisplayName erroneously normalizes valid names: %s",
+			normalizedName)
 	}
 
 }

--- a/builtin/logical/aws/secret_access_keys_test.go
+++ b/builtin/logical/aws/secret_access_keys_test.go
@@ -1,0 +1,15 @@
+package aws
+
+import (
+	"testing"
+)
+
+func TestNormalizeDisplayName(t *testing.T) {
+	invalidName := "^#$test name\nshould be normalized)(*"
+	expectedName := "___test_name_should_be_normalized___"
+	normalizedName := normalizeDisplayName(invalidName)
+	if normalizedName != expectedName {
+		t.Fatalf("normalizeDisplayName does not normalize AWS name correctly: %s", normalizedName)
+	}
+
+}


### PR DESCRIPTION
This PR simply removes spaces from `displayName` before submitting an IAM request to AWS.

I'm sure there are additional fixes that could be done here, but I discovered this bug while using LDAP authentication.

We authenticate with our LDAP `cn`, which has a space in it. If I authenticate and then try to grab some temporary AWS credentials from the AWS backend, I get the following error, whereas if I authenticate directly with a token, I don't see the error.

```
Code: 400. Errors:

* Error creating IAM user: The specified value for userName is invalid. It must contain only alphanumeric characters and/or the following: +=,.@_-
```
