### PR TITLE
Per backend configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ Vagrantfile
 
 dist/*
 
+tags
+
 # Editor backups
 *~
 *.sw[a-z]

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -54,7 +54,7 @@ func (c *Sys) Unmount(path string) error {
 	return err
 }
 
-func (c *Sys) Remount(from, to string, config vault.MountConfig) error {
+func (c *Sys) Remount(from, to string) error {
 	if err := c.checkMountPath(from); err != nil {
 		return err
 	}
@@ -63,15 +63,49 @@ func (c *Sys) Remount(from, to string, config vault.MountConfig) error {
 	}
 
 	body := map[string]interface{}{
-		"from":   from,
-		"to":     to,
-		"config": config,
+		"from": from,
+		"to":   to,
 	}
 
 	r := c.c.NewRequest("POST", "/v1/sys/remount")
 	if err := r.SetJSONBody(body); err != nil {
 		return err
 	}
+
+	resp, err := c.c.RawRequest(r)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	return err
+}
+
+func (c *Sys) TuneMount(path string, config vault.MountConfig) error {
+	if err := c.checkMountPath(path); err != nil {
+		return err
+	}
+
+	body := map[string]interface{}{
+		"config": config,
+	}
+
+	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
+	if err := r.SetJSONBody(body); err != nil {
+		return err
+	}
+
+	resp, err := c.c.RawRequest(r)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	return err
+}
+
+func (c *Sys) MountConfig(path string) error {
+	if err := c.checkMountPath(path); err != nil {
+		return err
+	}
+
+	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 
 	resp, err := c.c.RawRequest(r)
 	if err == nil {

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -54,7 +54,7 @@ func (c *Sys) Unmount(path string) error {
 	return err
 }
 
-func (c *Sys) Remount(from, to string, config *vault.MountConfig) error {
+func (c *Sys) Remount(from, to string, config vault.MountConfig) error {
 	if err := c.checkMountPath(from); err != nil {
 		return err
 	}
@@ -63,11 +63,9 @@ func (c *Sys) Remount(from, to string, config *vault.MountConfig) error {
 	}
 
 	body := map[string]interface{}{
-		"from": from,
-		"to":   to,
-	}
-	if config != nil {
-		body["config"] = *config
+		"from":   from,
+		"to":     to,
+		"config": config,
 	}
 
 	r := c.c.NewRequest("POST", "/v1/sys/remount")
@@ -91,7 +89,7 @@ func (c *Sys) checkMountPath(path string) error {
 }
 
 type Mount struct {
-	Type        string             `json:"type" structs:"type"`
-	Description string             `json:"description" structs:"description"`
-	Config      *vault.MountConfig `json:"config" structs:"config"`
+	Type        string            `json:"type" structs:"type"`
+	Description string            `json:"description" structs:"description"`
+	Config      vault.MountConfig `json:"config" structs:"config"`
 }

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/fatih/structs"
-	"github.com/hashicorp/vault/vault"
 )
 
 func (c *Sys) ListMounts() (map[string]*Mount, error) {
@@ -79,15 +79,12 @@ func (c *Sys) Remount(from, to string) error {
 	return err
 }
 
-func (c *Sys) TuneMount(path string, config vault.MountConfig) error {
+func (c *Sys) TuneMount(path string, config APIMountConfig) error {
 	if err := c.checkMountPath(path); err != nil {
 		return err
 	}
 
-	body := map[string]interface{}{
-		"config": config,
-	}
-
+	body := structs.Map(config)
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 	if err := r.SetJSONBody(body); err != nil {
 		return err
@@ -123,7 +120,12 @@ func (c *Sys) checkMountPath(path string) error {
 }
 
 type Mount struct {
-	Type        string            `json:"type" structs:"type"`
-	Description string            `json:"description" structs:"description"`
-	Config      vault.MountConfig `json:"config" structs:"config"`
+	Type        string         `json:"type" structs:"type"`
+	Description string         `json:"description" structs:"description"`
+	Config      APIMountConfig `json:"config" structs:"config"`
+}
+
+type APIMountConfig struct {
+	DefaultLeaseTTL *time.Duration `json:"default_lease_ttl" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"`
+	MaxLeaseTTL     *time.Duration `json:"max_lease_ttl" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`
 }

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -23,11 +23,13 @@ var (
 
 // Performs basic tests on CA functionality
 func TestBackend_basic(t *testing.T) {
+	defaultLeaseTTLVal := time.Hour * 24
+	maxLeaseTTLVal := time.Hour * 24 * 30
 	b, err := Factory(&logical.BackendConfig{
 		Logger: nil,
 		System: &logical.StaticSystemView{
-			DefaultLeaseTTLVal: time.Hour * 24,
-			MaxLeaseTTLVal:     time.Hour * 24 * 30,
+			DefaultLeaseTTLVal: &defaultLeaseTTLVal,
+			MaxLeaseTTLVal:     &maxLeaseTTLVal,
 		},
 	})
 	if err != nil {
@@ -49,11 +51,13 @@ func TestBackend_basic(t *testing.T) {
 // Generates and tests steps that walk through the various possibilities
 // of role flags to ensure that they are properly restricted
 func TestBackend_roles(t *testing.T) {
+	defaultLeaseTTLVal := time.Hour * 24
+	maxLeaseTTLVal := time.Hour * 24 * 30
 	b, err := Factory(&logical.BackendConfig{
 		Logger: nil,
 		System: &logical.StaticSystemView{
-			DefaultLeaseTTLVal: time.Hour * 24,
-			MaxLeaseTTLVal:     time.Hour * 24 * 30,
+			DefaultLeaseTTLVal: &defaultLeaseTTLVal,
+			MaxLeaseTTLVal:     &maxLeaseTTLVal,
 		},
 	})
 	if err != nil {

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -28,8 +28,8 @@ func TestBackend_basic(t *testing.T) {
 	b, err := Factory(&logical.BackendConfig{
 		Logger: nil,
 		System: &logical.StaticSystemView{
-			DefaultLeaseTTLVal: &defaultLeaseTTLVal,
-			MaxLeaseTTLVal:     &maxLeaseTTLVal,
+			DefaultLeaseTTLVal: defaultLeaseTTLVal,
+			MaxLeaseTTLVal:     maxLeaseTTLVal,
 		},
 	})
 	if err != nil {
@@ -56,8 +56,8 @@ func TestBackend_roles(t *testing.T) {
 	b, err := Factory(&logical.BackendConfig{
 		Logger: nil,
 		System: &logical.StaticSystemView{
-			DefaultLeaseTTLVal: &defaultLeaseTTLVal,
-			MaxLeaseTTLVal:     &maxLeaseTTLVal,
+			DefaultLeaseTTLVal: defaultLeaseTTLVal,
+			MaxLeaseTTLVal:     maxLeaseTTLVal,
 		},
 	})
 	if err != nil {

--- a/builtin/logical/pki/path_issue.go
+++ b/builtin/logical/pki/path_issue.go
@@ -114,7 +114,10 @@ func (b *backend) pathIssueCert(
 
 	var ttl time.Duration
 	if len(ttlField) == 0 {
-		ttl = b.System.DefaultLeaseTTL()
+		ttl, err = b.System().DefaultLeaseTTL()
+		if err != nil {
+			return nil, fmt.Errorf("Error fetching default TTL: %s", err)
+		}
 	} else {
 		ttl, err = time.ParseDuration(ttlField)
 		if err != nil {
@@ -125,7 +128,10 @@ func (b *backend) pathIssueCert(
 
 	var maxTTL time.Duration
 	if len(role.MaxTTL) == 0 {
-		maxTTL = b.System.MaxLeaseTTL()
+		maxTTL, err = b.System().MaxLeaseTTL()
+		if err != nil {
+			return nil, fmt.Errorf("Error fetching max TTL: %s", err)
+		}
 	} else {
 		maxTTL, err = time.ParseDuration(role.MaxTTL)
 		if err != nil {

--- a/builtin/logical/pki/path_issue.go
+++ b/builtin/logical/pki/path_issue.go
@@ -45,8 +45,9 @@ common-delimited list`,
 				Type: framework.TypeString,
 				Description: `The requested Time To Live for the certificate;
 sets the expiration date. If not specified
-the role default TTL it used. Cannot be larer
-than the role max TTL.`,
+the role default, backend default, or system
+default TTL is used, in that order. Cannot
+be later than the role max TTL.`,
 			},
 		},
 
@@ -114,10 +115,7 @@ func (b *backend) pathIssueCert(
 
 	var ttl time.Duration
 	if len(ttlField) == 0 {
-		ttl, err = b.System().DefaultLeaseTTL()
-		if err != nil {
-			return nil, fmt.Errorf("Error fetching default TTL: %s", err)
-		}
+		ttl = b.System().DefaultLeaseTTL()
 	} else {
 		ttl, err = time.ParseDuration(ttlField)
 		if err != nil {
@@ -128,10 +126,7 @@ func (b *backend) pathIssueCert(
 
 	var maxTTL time.Duration
 	if len(role.MaxTTL) == 0 {
-		maxTTL, err = b.System().MaxLeaseTTL()
-		if err != nil {
-			return nil, fmt.Errorf("Error fetching max TTL: %s", err)
-		}
+		maxTTL = b.System().MaxLeaseTTL()
 	} else {
 		maxTTL, err = time.ParseDuration(role.MaxTTL)
 		if err != nil {

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -257,10 +257,7 @@ func (b *backend) pathRoleCreate(
 		entry.MaxTTL = data.Get("lease_max").(string)
 	}
 	var maxTTL time.Duration
-	maxSystemTTL, err := b.System().MaxLeaseTTL()
-	if err != nil {
-		return nil, fmt.Errorf("Error fetching max TTL: %s", err)
-	}
+	maxSystemTTL := b.System().MaxLeaseTTL()
 	if len(entry.MaxTTL) == 0 {
 		maxTTL = maxSystemTTL
 	} else {
@@ -271,16 +268,13 @@ func (b *backend) pathRoleCreate(
 		}
 	}
 	if maxTTL > maxSystemTTL {
-		return logical.ErrorResponse("Requested max TTL is higher than system maximum"), nil
+		return logical.ErrorResponse("Requested max TTL is higher than backend maximum"), nil
 	}
 
 	if len(entry.TTL) == 0 {
 		entry.TTL = data.Get("lease").(string)
 	}
-	ttl, err := b.System().DefaultLeaseTTL()
-	if err != nil {
-		return nil, fmt.Errorf("Error fetching max TTL: %s", err)
-	}
+	ttl := b.System().DefaultLeaseTTL()
 	if len(entry.TTL) != 0 {
 		ttl, err = time.ParseDuration(entry.TTL)
 		if err != nil {
@@ -294,7 +288,7 @@ func (b *backend) pathRoleCreate(
 		if len(entry.TTL) == 0 {
 			ttl = maxTTL
 		} else {
-			return logical.ErrorResponse("\"ttl\" value must be less than \"max_ttl\" and/or system default max lease TTL value"), nil
+			return logical.ErrorResponse("\"ttl\" value must be less than \"max_ttl\" and/or backend default max lease TTL value"), nil
 		}
 	}
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -226,6 +226,12 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 			}, nil
 		},
 
+		"mount-tune": func() (cli.Command, error) {
+			return &command.MountTuneCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"remount": func() (cli.Command, error) {
 			return &command.RemountCommand{
 				Meta: meta,

--- a/command/mount.go
+++ b/command/mount.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/vault"
 )
 
 // MountCommand is a Command that mounts a new mount.
@@ -51,7 +50,7 @@ func (c *MountCommand) Run(args []string) int {
 	mountInfo := &api.Mount{
 		Type:        mountType,
 		Description: description,
-		Config:      vault.MountConfig{},
+		Config:      api.APIMountConfig{},
 	}
 
 	if defaultLeaseTTL != "" {

--- a/command/mounts.go
+++ b/command/mounts.go
@@ -35,17 +35,17 @@ func (c *MountsCommand) Run(args []string) int {
 	}
 
 	paths := make([]string, 0, len(mounts))
-	for path, _ := range mounts {
+	for path := range mounts {
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
 
-	columns := []string{"Path | Type | Description"}
+	columns := []string{"Path | Type | Default TTL | Max TTL | Description"}
 	for _, path := range paths {
 		mount := mounts[path]
 
 		columns = append(columns, fmt.Sprintf(
-			"%s | %s | %s", path, mount.Type, mount.Description))
+			"%s | %s | %s | %s | %s", path, mount.Type, mount.Config.DefaultLeaseTTL, mount.Config.MaxLeaseTTL, mount.Description))
 	}
 
 	c.Ui.Output(columnize.SimpleFormat(columns))
@@ -62,8 +62,9 @@ Usage: vault mounts [options]
 
   Outputs information about the mounted backends.
 
-  This command lists the mounted backends, their mount points, and
-  a human-friendly description of the mount point.
+  This command lists the mounted backends, their mount points, the
+  configured TTLs, and a human-friendly description of the mount point.
+  A TTL of '0' indicates that the system default is being used.
 
 General Options:
 

--- a/command/mounttune.go
+++ b/command/mounttune.go
@@ -81,7 +81,7 @@ func (c *MountTuneCommand) Help() string {
 	helpText := `
   Usage: vault mount-tune [options] path
 
-  Tune configuration options fro a mounted secret backend.
+  Tune configuration options for a mounted secret backend.
 
   Example: vault tune-mount -default-lease-ttl="24h" secret/
 

--- a/command/mounttune.go
+++ b/command/mounttune.go
@@ -1,0 +1,106 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/vault/vault"
+)
+
+// RemountCommand is a Command that remounts a mounted secret backend
+// to a new endpoint.
+type MountTuneCommand struct {
+	Meta
+}
+
+func (c *MountTuneCommand) Run(args []string) int {
+	var defaultLeaseTTL, maxLeaseTTL string
+	flags := c.Meta.FlagSet("mount-tune", FlagSetDefault)
+	flags.StringVar(&defaultLeaseTTL, "default-lease-ttl", "", "")
+	flags.StringVar(&maxLeaseTTL, "max-lease-ttl", "", "")
+	flags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = flags.Args()
+	if len(args) != 1 {
+		flags.Usage()
+		c.Ui.Error(fmt.Sprintf(
+			"\n'mount-tune' expects one arguments: the mount path"))
+		return 1
+	}
+
+	path := args[0]
+
+	mountConfig := vault.MountConfig{}
+	if defaultLeaseTTL != "" {
+		defTTL, err := time.ParseDuration(defaultLeaseTTL)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf(
+				"Error parsing default lease TTL duration: %s", err))
+			return 2
+		}
+		mountConfig.DefaultLeaseTTL = &defTTL
+	}
+	if maxLeaseTTL != "" {
+		maxTTL, err := time.ParseDuration(maxLeaseTTL)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf(
+				"Error parsing max lease TTL duration: %s", err))
+			return 2
+		}
+		mountConfig.MaxLeaseTTL = &maxTTL
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error initializing client: %s", err))
+		return 2
+	}
+
+	if err := client.Sys().TuneMount(path, mountConfig); err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Mount tune error: %s", err))
+		return 2
+	}
+
+	c.Ui.Output(fmt.Sprintf(
+		"Successfully tuned mount '%s'!", path))
+
+	return 0
+}
+
+func (c *MountTuneCommand) Synopsis() string {
+	return "Tune mount configuration parameters"
+}
+
+func (c *MountTuneCommand) Help() string {
+	helpText := `
+  Usage: vault mount-tune [options] path
+
+  Tune configuration options fro a mounted secret backend.
+
+  Example: vault tune-mount -default-lease-ttl="24h" secret/
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+Mount Options:
+
+  -default-lease-ttl=<duration>  Default lease time-to-live for this backend.
+                                 If not specified, uses the global default, or
+                                 the previously set value. Set to '0' to
+                                 explicitly set it to use the global default.
+
+  -max-lease-ttl=<duration>      Max lease time-to-live for this backend.
+                                 If not specified, uses the global default, or
+                                 the previously set value. Set to '0' to
+                                 explicitly set it to use the global default.
+
+`
+	return strings.TrimSpace(helpText)
+}

--- a/command/mounttune.go
+++ b/command/mounttune.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/vault/vault"
 )
 
-// RemountCommand is a Command that remounts a mounted secret backend
+// MountTuneCommand is a Command that remounts a mounted secret backend
 // to a new endpoint.
 type MountTuneCommand struct {
 	Meta

--- a/command/mounttune.go
+++ b/command/mounttune.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/api"
 )
 
 // MountTuneCommand is a Command that remounts a mounted secret backend
@@ -34,7 +34,7 @@ func (c *MountTuneCommand) Run(args []string) int {
 
 	path := args[0]
 
-	mountConfig := vault.MountConfig{}
+	mountConfig := api.APIMountConfig{}
 	if defaultLeaseTTL != "" {
 		defTTL, err := time.ParseDuration(defaultLeaseTTL)
 		if err != nil {

--- a/command/remount.go
+++ b/command/remount.go
@@ -3,6 +3,9 @@ package command
 import (
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/hashicorp/vault/vault"
 )
 
 // RemountCommand is a Command that remounts a mounted secret backend
@@ -12,7 +15,10 @@ type RemountCommand struct {
 }
 
 func (c *RemountCommand) Run(args []string) int {
+	var defaultLeaseTTL, maxLeaseTTL string
 	flags := c.Meta.FlagSet("remount", FlagSetDefault)
+	flags.StringVar(&defaultLeaseTTL, "default_lease_ttl", "", "")
+	flags.StringVar(&maxLeaseTTL, "max_lease_ttl", "", "")
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -29,6 +35,32 @@ func (c *RemountCommand) Run(args []string) int {
 	from := args[0]
 	to := args[1]
 
+	mountConfig := &vault.MountConfig{}
+	var err error
+	var passConfig bool
+	if defaultLeaseTTL != "" {
+		mountConfig.DefaultLeaseTTL, err = time.ParseDuration(defaultLeaseTTL)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf(
+				"Error parsing default lease TTL duration: %s", err))
+			return 1
+		}
+		passConfig = true
+	}
+	if maxLeaseTTL != "" {
+		mountConfig.MaxLeaseTTL, err = time.ParseDuration(maxLeaseTTL)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf(
+				"Error parsing max lease TTL duration: %s", err))
+			return 1
+		}
+		passConfig = true
+	}
+
+	if !passConfig {
+		mountConfig = nil
+	}
+
 	client, err := c.Client()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(
@@ -36,7 +68,7 @@ func (c *RemountCommand) Run(args []string) int {
 		return 2
 	}
 
-	if err := client.Sys().Remount(from, to); err != nil {
+	if err := client.Sys().Remount(from, to, mountConfig); err != nil {
 		c.Ui.Error(fmt.Sprintf(
 			"Unmount error: %s", err))
 		return 2

--- a/http/handler.go
+++ b/http/handler.go
@@ -25,6 +25,7 @@ func Handler(core *vault.Core) http.Handler {
 	mux.Handle("/v1/sys/seal", handleSysSeal(core))
 	mux.Handle("/v1/sys/unseal", handleSysUnseal(core))
 	mux.Handle("/v1/sys/mounts", proxySysRequest(core))
+	mux.Handle("/v1/sys/mounts/", proxySysRequest(core))
 	mux.Handle("/v1/sys/remount", proxySysRequest(core))
 	mux.Handle("/v1/sys/policy", handleSysListPolicies(core))
 	mux.Handle("/v1/sys/policy/", handleSysPolicy(core))

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -34,16 +34,24 @@ func TestSysMounts_headerAuth(t *testing.T) {
 		"secret/": map[string]interface{}{
 			"description": "generic secret storage",
 			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 		"sys/": map[string]interface{}{
 			"description": "system endpoints used for control, policy and debugging",
 			"type":        "system",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
+		t.Fatalf("bad:\nExpected: %#v\nActual: %#v\n", expected, actual)
 	}
 }
 

--- a/http/sys_mount_test.go
+++ b/http/sys_mount_test.go
@@ -20,10 +20,18 @@ func TestSysMounts(t *testing.T) {
 		"secret/": map[string]interface{}{
 			"description": "generic secret storage",
 			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 		"sys/": map[string]interface{}{
 			"description": "system endpoints used for control, policy and debugging",
 			"type":        "system",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 	}
 	testResponseStatus(t, resp, 200)
@@ -52,14 +60,26 @@ func TestSysMount(t *testing.T) {
 		"foo/": map[string]interface{}{
 			"description": "foo",
 			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 		"secret/": map[string]interface{}{
 			"description": "generic secret storage",
 			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 		"sys/": map[string]interface{}{
 			"description": "system endpoints used for control, policy and debugging",
 			"type":        "system",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 	}
 	testResponseStatus(t, resp, 200)
@@ -110,14 +130,26 @@ func TestSysRemount(t *testing.T) {
 		"bar/": map[string]interface{}{
 			"description": "foo",
 			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 		"secret/": map[string]interface{}{
 			"description": "generic secret storage",
 			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 		"sys/": map[string]interface{}{
 			"description": "system endpoints used for control, policy and debugging",
 			"type":        "system",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 	}
 	testResponseStatus(t, resp, 200)
@@ -149,10 +181,18 @@ func TestSysUnmount(t *testing.T) {
 		"secret/": map[string]interface{}{
 			"description": "generic secret storage",
 			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 		"sys/": map[string]interface{}{
 			"description": "system endpoints used for control, policy and debugging",
 			"type":        "system",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 	}
 	testResponseStatus(t, resp, 200)

--- a/http/sys_mount_test.go
+++ b/http/sys_mount_test.go
@@ -317,6 +317,7 @@ func TestSysTuneMount(t *testing.T) {
 			},
 		},
 	}
+
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 
@@ -325,14 +326,14 @@ func TestSysTuneMount(t *testing.T) {
 	}
 
 	resp = testHttpGet(t, token, addr+"/v1/sys/mounts/foo/tune")
+	actual = map[string]interface{}{}
 	expected = map[string]interface{}{
-		"foo/": map[string]interface{}{
-			"config": map[string]interface{}{
-				"default_lease_ttl": float64(time.Duration(time.Hour * 71999)),
-				"max_lease_ttl":     float64(time.Duration(time.Hour * 72000)),
-			},
+		"config": map[string]interface{}{
+			"default_lease_ttl": float64(time.Duration(time.Hour * 71999)),
+			"max_lease_ttl":     float64(time.Duration(time.Hour * 72000)),
 		},
 	}
+
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 

--- a/http/sys_mount_test.go
+++ b/http/sys_mount_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/vault/vault"
 )
@@ -199,5 +200,143 @@ func TestSysUnmount(t *testing.T) {
 	testResponseBody(t, resp, &actual)
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestSysTuneMount(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+	TestServerAuth(t, addr, token)
+
+	resp := testHttpPost(t, token, addr+"/v1/sys/mounts/foo", map[string]interface{}{
+		"type":        "generic",
+		"description": "foo",
+	})
+	testResponseStatus(t, resp, 204)
+
+	resp = testHttpGet(t, token, addr+"/v1/sys/mounts")
+
+	var actual map[string]interface{}
+	expected := map[string]interface{}{
+		"foo/": map[string]interface{}{
+			"description": "foo",
+			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
+		},
+		"secret/": map[string]interface{}{
+			"description": "generic secret storage",
+			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
+		},
+		"sys/": map[string]interface{}{
+			"description": "system endpoints used for control, policy and debugging",
+			"type":        "system",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
+		},
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+
+	// Shorter than system default
+	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
+		"config": map[string]interface{}{
+			"default_lease_ttl": time.Duration(time.Hour * 72),
+		},
+	})
+	testResponseStatus(t, resp, 204)
+
+	// Longer than system default
+	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
+		"config": map[string]interface{}{
+			"default_lease_ttl": time.Duration(time.Hour * 72000),
+		},
+	})
+	testResponseStatus(t, resp, 400)
+
+	// Longer than system default
+	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
+		"config": map[string]interface{}{
+			"max_lease_ttl": time.Duration(time.Hour * 72000),
+		},
+	})
+	testResponseStatus(t, resp, 204)
+
+	// Longer than backend max
+	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
+		"config": map[string]interface{}{
+			"default_lease_ttl": time.Duration(time.Hour * 72001),
+		},
+	})
+	testResponseStatus(t, resp, 400)
+
+	// Shorter than backend max, longer than system max
+	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
+		"config": map[string]interface{}{
+			"default_lease_ttl": time.Duration(time.Hour * 71999),
+		},
+	})
+	testResponseStatus(t, resp, 204)
+
+	resp = testHttpGet(t, token, addr+"/v1/sys/mounts")
+	expected = map[string]interface{}{
+		"foo/": map[string]interface{}{
+			"description": "foo",
+			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(time.Duration(time.Hour * 71999)),
+				"max_lease_ttl":     float64(time.Duration(time.Hour * 72000)),
+			},
+		},
+		"secret/": map[string]interface{}{
+			"description": "generic secret storage",
+			"type":        "generic",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
+		},
+		"sys/": map[string]interface{}{
+			"description": "system endpoints used for control, policy and debugging",
+			"type":        "system",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
+		},
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad:\nExpected: %#v\nActual:%#v", expected, actual)
+	}
+
+	resp = testHttpGet(t, token, addr+"/v1/sys/mounts/foo/tune")
+	expected = map[string]interface{}{
+		"foo/": map[string]interface{}{
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(time.Duration(time.Hour * 71999)),
+				"max_lease_ttl":     float64(time.Duration(time.Hour * 72000)),
+			},
+		},
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad:\nExpected: %#v\nActual:%#v", expected, actual)
 	}
 }

--- a/http/sys_mount_test.go
+++ b/http/sys_mount_test.go
@@ -253,49 +253,37 @@ func TestSysTuneMount(t *testing.T) {
 
 	// Shorter than system default
 	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
-		"config": map[string]interface{}{
-			"default_lease_ttl": time.Duration(time.Hour * 72),
-		},
+		"default_lease_ttl": time.Duration(time.Hour * 72),
 	})
 	testResponseStatus(t, resp, 204)
 
-	// Longer than system default
+	// Longer than system max
 	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
-		"config": map[string]interface{}{
-			"default_lease_ttl": time.Duration(time.Hour * 72000),
-		},
+		"default_lease_ttl": time.Duration(time.Hour * 72000),
 	})
 	testResponseStatus(t, resp, 400)
 
 	// Longer than system default
 	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
-		"config": map[string]interface{}{
-			"max_lease_ttl": time.Duration(time.Hour * 72000),
-		},
+		"max_lease_ttl": time.Duration(time.Hour * 72000),
 	})
 	testResponseStatus(t, resp, 204)
 
 	// Longer than backend max
 	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
-		"config": map[string]interface{}{
-			"default_lease_ttl": time.Duration(time.Hour * 72001),
-		},
+		"default_lease_ttl": time.Duration(time.Hour * 72001),
 	})
 	testResponseStatus(t, resp, 400)
 
 	// Shorter than backend default
 	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
-		"config": map[string]interface{}{
-			"max_lease_ttl": time.Duration(time.Hour * 1),
-		},
+		"max_lease_ttl": time.Duration(time.Hour * 1),
 	})
 	testResponseStatus(t, resp, 400)
 
 	// Shorter than backend max, longer than system max
 	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
-		"config": map[string]interface{}{
-			"default_lease_ttl": time.Duration(time.Hour * 71999),
-		},
+		"default_lease_ttl": time.Duration(time.Hour * 71999),
 	})
 	testResponseStatus(t, resp, 204)
 
@@ -338,10 +326,8 @@ func TestSysTuneMount(t *testing.T) {
 	resp = testHttpGet(t, token, addr+"/v1/sys/mounts/foo/tune")
 	actual = map[string]interface{}{}
 	expected = map[string]interface{}{
-		"config": map[string]interface{}{
-			"default_lease_ttl": float64(time.Duration(time.Hour * 71999)),
-			"max_lease_ttl":     float64(time.Duration(time.Hour * 72000)),
-		},
+		"default_lease_ttl": float64(time.Duration(time.Hour * 71999)),
+		"max_lease_ttl":     float64(time.Duration(time.Hour * 72000)),
 	}
 
 	testResponseStatus(t, resp, 200)
@@ -352,20 +338,16 @@ func TestSysTuneMount(t *testing.T) {
 
 	// Set a low max
 	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/secret/tune", map[string]interface{}{
-		"config": map[string]interface{}{
-			"default_lease_ttl": time.Duration(time.Second * 40),
-			"max_lease_ttl":     time.Duration(time.Second * 80),
-		},
+		"default_lease_ttl": time.Duration(time.Second * 40),
+		"max_lease_ttl":     time.Duration(time.Second * 80),
 	})
 	testResponseStatus(t, resp, 204)
 
 	resp = testHttpGet(t, token, addr+"/v1/sys/mounts/secret/tune")
 	actual = map[string]interface{}{}
 	expected = map[string]interface{}{
-		"config": map[string]interface{}{
-			"default_lease_ttl": float64(time.Duration(time.Second * 40)),
-			"max_lease_ttl":     float64(time.Duration(time.Second * 80)),
-		},
+		"default_lease_ttl": float64(time.Duration(time.Second * 40)),
+		"max_lease_ttl":     float64(time.Duration(time.Second * 80)),
 	}
 
 	testResponseStatus(t, resp, 200)

--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -13,7 +13,10 @@ import (
 
 func handleSysSeal(core *vault.Core) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "PUT" {
+		switch r.Method {
+		case "PUT":
+		case "POST":
+		default:
 			respondError(w, http.StatusMethodNotAllowed, nil)
 			return
 		}
@@ -33,7 +36,10 @@ func handleSysSeal(core *vault.Core) http.Handler {
 
 func handleSysUnseal(core *vault.Core) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "PUT" {
+		switch r.Method {
+		case "PUT":
+		case "POST":
+		default:
 			respondError(w, http.StatusMethodNotAllowed, nil)
 			return
 		}

--- a/logical/framework/backend.go
+++ b/logical/framework/backend.go
@@ -56,11 +56,8 @@ type Backend struct {
 	// See the built-in AuthRenew helpers in lease.go for common callbacks.
 	AuthRenew OperationFunc
 
-	// System provides an interface to access certain system configuration
-	// information, such as globally configured default and max lease TTLs.
-	System logical.SystemView
-
 	logger  *log.Logger
+	system  logical.SystemView
 	once    sync.Once
 	pathsRe []*regexp.Regexp
 }
@@ -146,7 +143,7 @@ func (b *Backend) SpecialPaths() *logical.Paths {
 // Setup is used to initialize the backend with the initial backend configuration
 func (b *Backend) Setup(config *logical.BackendConfig) (logical.Backend, error) {
 	b.logger = config.Logger
-	b.System = config.System
+	b.system = config.System
 	return b, nil
 }
 
@@ -158,6 +155,10 @@ func (b *Backend) Logger() *log.Logger {
 	}
 
 	return log.New(ioutil.Discard, "", 0)
+}
+
+func (b *Backend) System() logical.SystemView {
+	return b.system
 }
 
 // Route looks up the path that would be used for a given path string.

--- a/logical/framework/field_data.go
+++ b/logical/framework/field_data.go
@@ -34,11 +34,11 @@ func (d *FieldData) Validate() error {
 		case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeString:
 			_, _, err := d.getPrimitive(field, schema)
 			if err != nil {
-				return fmt.Errorf("Error converting input %v for field %s", value, field)
+				return fmt.Errorf("Error converting input %v for field %s: %s", value, field, err)
 			}
 		default:
 			return fmt.Errorf("unknown field type %s for field %s",
-			    schema.Type, field)
+				schema.Type, field)
 		}
 	}
 

--- a/logical/logical.go
+++ b/logical/logical.go
@@ -22,6 +22,10 @@ type Backend interface {
 	// ends in '*' then it is a prefix-based match. The '*' can only appear
 	// at the end.
 	SpecialPaths() *Paths
+
+	// System provides an interface to access certain system configuration
+	// information, such as globally configured default and max lease TTLs.
+	System() SystemView
 }
 
 // BackendConfig is provided to the factory to initialize the backend

--- a/logical/system_view.go
+++ b/logical/system_view.go
@@ -6,12 +6,12 @@ import "time"
 // for logical backends to consume
 type SystemView interface {
 	// DefaultLeaseTTL returns the default lease TTL set in Vault configuration
-	DefaultLeaseTTL() time.Duration
+	DefaultLeaseTTL() (time.Duration, error)
 
 	// MaxLeaseTTL returns the max lease TTL set in Vault configuration; backend
 	// authors should take care not to issue credentials that last longer than
 	// this value, as Vault will revoke them
-	MaxLeaseTTL() time.Duration
+	MaxLeaseTTL() (time.Duration, error)
 }
 
 type StaticSystemView struct {
@@ -19,29 +19,10 @@ type StaticSystemView struct {
 	MaxLeaseTTLVal     time.Duration
 }
 
-func (d *StaticSystemView) DefaultLeaseTTL() time.Duration {
-	return d.DefaultLeaseTTLVal
+func (d StaticSystemView) DefaultLeaseTTL() (time.Duration, error) {
+	return d.DefaultLeaseTTLVal, nil
 }
 
-func (d *StaticSystemView) MaxLeaseTTL() time.Duration {
-	return d.MaxLeaseTTLVal
-}
-
-type DynamicSystemView struct {
-	DefaultLeaseTTLVal **time.Duration
-	MaxLeaseTTLVal     **time.Duration
-}
-
-func (d *DynamicSystemView) DefaultLeaseTTL() time.Duration {
-	if *d.DefaultLeaseTTLVal == nil {
-		return 0
-	}
-	return **d.DefaultLeaseTTLVal
-}
-
-func (d *DynamicSystemView) MaxLeaseTTL() time.Duration {
-	if *d.MaxLeaseTTLVal == nil {
-		return 0
-	}
-	return **d.MaxLeaseTTLVal
+func (d StaticSystemView) MaxLeaseTTL() (time.Duration, error) {
+	return d.MaxLeaseTTLVal, nil
 }

--- a/logical/system_view.go
+++ b/logical/system_view.go
@@ -15,14 +15,33 @@ type SystemView interface {
 }
 
 type StaticSystemView struct {
-	DefaultLeaseTTLVal *time.Duration
-	MaxLeaseTTLVal     *time.Duration
+	DefaultLeaseTTLVal time.Duration
+	MaxLeaseTTLVal     time.Duration
 }
 
 func (d *StaticSystemView) DefaultLeaseTTL() time.Duration {
-	return *d.DefaultLeaseTTLVal
+	return d.DefaultLeaseTTLVal
 }
 
 func (d *StaticSystemView) MaxLeaseTTL() time.Duration {
-	return *d.MaxLeaseTTLVal
+	return d.MaxLeaseTTLVal
+}
+
+type DynamicSystemView struct {
+	DefaultLeaseTTLVal **time.Duration
+	MaxLeaseTTLVal     **time.Duration
+}
+
+func (d *DynamicSystemView) DefaultLeaseTTL() time.Duration {
+	if *d.DefaultLeaseTTLVal == nil {
+		return 0
+	}
+	return **d.DefaultLeaseTTLVal
+}
+
+func (d *DynamicSystemView) MaxLeaseTTL() time.Duration {
+	if *d.MaxLeaseTTLVal == nil {
+		return 0
+	}
+	return **d.MaxLeaseTTLVal
 }

--- a/logical/system_view.go
+++ b/logical/system_view.go
@@ -15,14 +15,14 @@ type SystemView interface {
 }
 
 type StaticSystemView struct {
-	DefaultLeaseTTLVal time.Duration
-	MaxLeaseTTLVal     time.Duration
+	DefaultLeaseTTLVal *time.Duration
+	MaxLeaseTTLVal     *time.Duration
 }
 
 func (d *StaticSystemView) DefaultLeaseTTL() time.Duration {
-	return d.DefaultLeaseTTLVal
+	return *d.DefaultLeaseTTLVal
 }
 
 func (d *StaticSystemView) MaxLeaseTTL() time.Duration {
-	return d.MaxLeaseTTLVal
+	return *d.MaxLeaseTTLVal
 }

--- a/logical/system_view.go
+++ b/logical/system_view.go
@@ -6,12 +6,12 @@ import "time"
 // for logical backends to consume
 type SystemView interface {
 	// DefaultLeaseTTL returns the default lease TTL set in Vault configuration
-	DefaultLeaseTTL() (time.Duration, error)
+	DefaultLeaseTTL() time.Duration
 
 	// MaxLeaseTTL returns the max lease TTL set in Vault configuration; backend
 	// authors should take care not to issue credentials that last longer than
 	// this value, as Vault will revoke them
-	MaxLeaseTTL() (time.Duration, error)
+	MaxLeaseTTL() time.Duration
 }
 
 type StaticSystemView struct {
@@ -19,10 +19,10 @@ type StaticSystemView struct {
 	MaxLeaseTTLVal     time.Duration
 }
 
-func (d StaticSystemView) DefaultLeaseTTL() (time.Duration, error) {
-	return d.DefaultLeaseTTLVal, nil
+func (d StaticSystemView) DefaultLeaseTTL() time.Duration {
+	return d.DefaultLeaseTTLVal
 }
 
-func (d StaticSystemView) MaxLeaseTTL() (time.Duration, error) {
-	return d.MaxLeaseTTLVal, nil
+func (d StaticSystemView) MaxLeaseTTL() time.Duration {
+	return d.MaxLeaseTTLVal
 }

--- a/logical/testing/testing.go
+++ b/logical/testing/testing.go
@@ -167,7 +167,11 @@ func Test(t TestT, c TestCase) {
 
 	// Mount the backend
 	prefix := "mnt"
-	if err := client.Sys().Mount(prefix, "test", "acceptance test"); err != nil {
+	mountInfo := &api.Mount{
+		Type:        "test",
+		Description: "acceptance test",
+	}
+	if err := client.Sys().Mount(prefix, mountInfo); err != nil {
 		t.Fatal("error mounting backend: ", err)
 		return
 	}

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -69,7 +69,7 @@ func (c *Core) enableAudit(entry *MountEntry) error {
 	view := NewBarrierView(c.barrier, auditBarrierPrefix+entry.UUID+"/")
 
 	// Update the audit table
-	newTable := c.audit.Clone()
+	newTable := c.audit.ShallowClone()
 	newTable.Entries = append(newTable.Entries, entry)
 	if err := c.persistAudit(newTable); err != nil {
 		return errors.New("failed to update audit table")
@@ -94,7 +94,7 @@ func (c *Core) disableAudit(path string) error {
 	}
 
 	// Remove the entry from the mount table
-	newTable := c.audit.Clone()
+	newTable := c.audit.ShallowClone()
 	found := newTable.Remove(path)
 
 	// Ensure there was a match

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -66,7 +66,7 @@ func (c *Core) enableCredential(entry *MountEntry) error {
 	view := NewBarrierView(c.barrier, credentialBarrierPrefix+entry.UUID+"/")
 
 	// Create the new backend
-	backend, err := c.newCredentialBackend(entry.Type, view, nil)
+	backend, err := c.newCredentialBackend(entry.Type, c.mountEntrySysView(entry), view, nil)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (c *Core) enableCredential(entry *MountEntry) error {
 
 	// Mount the backend
 	path := credentialRoutePrefix + entry.Path
-	if err := c.router.Mount(backend, path, entry.UUID, view); err != nil {
+	if err := c.router.Mount(backend, path, entry, view); err != nil {
 		return err
 	}
 	c.logger.Printf("[INFO] core: enabled credential backend '%s' type: %s",
@@ -242,7 +242,7 @@ func (c *Core) setupCredentials() error {
 		view = NewBarrierView(c.barrier, credentialBarrierPrefix+entry.UUID+"/")
 
 		// Initialize the backend
-		backend, err = c.newCredentialBackend(entry.Type, view, nil)
+		backend, err = c.newCredentialBackend(entry.Type, c.mountEntrySysView(entry), view, nil)
 		if err != nil {
 			c.logger.Printf(
 				"[ERR] core: failed to create credential entry %#v: %v",
@@ -252,7 +252,7 @@ func (c *Core) setupCredentials() error {
 
 		// Mount the backend
 		path := credentialRoutePrefix + entry.Path
-		err = c.router.Mount(backend, path, entry.UUID, view)
+		err = c.router.Mount(backend, path, entry, view)
 		if err != nil {
 			c.logger.Printf("[ERR] core: failed to mount auth entry %#v: %v", entry, err)
 			return loadAuthFailed
@@ -281,7 +281,7 @@ func (c *Core) teardownCredentials() error {
 
 // newCredentialBackend is used to create and configure a new credential backend by name
 func (c *Core) newCredentialBackend(
-	t string, view logical.Storage, conf map[string]string) (logical.Backend, error) {
+	t string, sysView logical.SystemView, view logical.Storage, conf map[string]string) (logical.Backend, error) {
 	f, ok := c.credentialBackends[t]
 	if !ok {
 		return nil, fmt.Errorf("unknown backend type: %s", t)
@@ -291,12 +291,14 @@ func (c *Core) newCredentialBackend(
 		View:   view,
 		Logger: c.logger,
 		Config: conf,
+		System: sysView,
 	}
 
 	b, err := f(config)
 	if err != nil {
 		return nil, err
 	}
+
 	return b, nil
 }
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -72,7 +72,7 @@ func (c *Core) enableCredential(entry *MountEntry) error {
 	}
 
 	// Update the auth table
-	newTable := c.auth.Clone()
+	newTable := c.auth.ShallowClone()
 	newTable.Entries = append(newTable.Entries, entry)
 	if err := c.persistAuth(newTable); err != nil {
 		return errors.New("failed to update auth table")
@@ -149,7 +149,7 @@ func (c *Core) disableCredential(path string) error {
 // removeCredEntry is used to remove an entry in the auth table
 func (c *Core) removeCredEntry(path string) error {
 	// Taint the entry from the auth table
-	newTable := c.auth.Clone()
+	newTable := c.auth.ShallowClone()
 	newTable.Remove(path)
 
 	// Update the auth table
@@ -163,7 +163,7 @@ func (c *Core) removeCredEntry(path string) error {
 // taintCredEntry is used to mark an entry in the auth table as tainted
 func (c *Core) taintCredEntry(path string) error {
 	// Taint the entry from the auth table
-	newTable := c.auth.Clone()
+	newTable := c.auth.ShallowClone()
 	found := newTable.SetTaint(path, true)
 
 	// Ensure there was a match

--- a/vault/core.go
+++ b/vault/core.go
@@ -486,20 +486,12 @@ func (c *Core) handleRequest(req *logical.Request) (retResp *logical.Response, r
 
 		// Apply the default lease if none given
 		if resp.Secret.TTL == 0 {
-			ttl, err := sysView.DefaultLeaseTTL()
-			if err != nil {
-				c.logger.Println(err)
-				return nil, auth, ErrInternalError
-			}
+			ttl := sysView.DefaultLeaseTTL()
 			resp.Secret.TTL = ttl
 		}
 
 		// Limit the lease duration
-		maxTTL, err := sysView.MaxLeaseTTL()
-		if err != nil {
-			c.logger.Println(err)
-			return nil, auth, ErrInternalError
-		}
+		maxTTL := sysView.MaxLeaseTTL()
 		if resp.Secret.TTL > maxTTL {
 			resp.Secret.TTL = maxTTL
 		}

--- a/vault/core.go
+++ b/vault/core.go
@@ -596,7 +596,7 @@ func (c *Core) handleLoginRequest(req *logical.Request) (*logical.Response, *log
 		}
 
 		// Populate the client token
-		resp.Auth.ClientToken = te.ID
+		auth.ClientToken = te.ID
 
 		// Set the default lease if non-provided, root tokens are exempt
 		if auth.TTL == 0 && !strListContains(auth.Policies, "root") {
@@ -604,8 +604,8 @@ func (c *Core) handleLoginRequest(req *logical.Request) (*logical.Response, *log
 		}
 
 		// Limit the lease duration
-		if resp.Auth.TTL > c.maxLeaseTTL {
-			resp.Auth.TTL = c.maxLeaseTTL
+		if auth.TTL > c.maxLeaseTTL {
+			auth.TTL = c.maxLeaseTTL
 		}
 
 		// Register with the expiration manager

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -1,0 +1,54 @@
+package vault
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type dynamicSystemView struct {
+	core *Core
+	path string
+}
+
+func (d dynamicSystemView) DefaultLeaseTTL() (time.Duration, error) {
+	def, _, err := d.fetchTTLs()
+	if err != nil {
+		return 0, err
+	}
+	return def, nil
+}
+
+func (d dynamicSystemView) MaxLeaseTTL() (time.Duration, error) {
+	_, max, err := d.fetchTTLs()
+	if err != nil {
+		return 0, err
+	}
+	return max, nil
+}
+
+// TTLsByPath returns the default and max TTLs corresponding to a particular
+// mount point, or the system default
+func (d dynamicSystemView) fetchTTLs() (def, max time.Duration, retErr error) {
+	// Ensure we end the path in a slash
+	if !strings.HasSuffix(d.path, "/") {
+		d.path += "/"
+	}
+
+	me := d.core.router.MatchingMountEntry(d.path)
+	if me == nil {
+		return 0, 0, fmt.Errorf("[ERR] core: failed to get mount entry for %s", d.path)
+	}
+
+	def = d.core.defaultLeaseTTL
+	max = d.core.maxLeaseTTL
+
+	if me.Config.DefaultLeaseTTL != nil && *me.Config.DefaultLeaseTTL != 0 {
+		def = *me.Config.DefaultLeaseTTL
+	}
+	if me.Config.MaxLeaseTTL != nil && *me.Config.MaxLeaseTTL != 0 {
+		max = *me.Config.MaxLeaseTTL
+	}
+
+	return
+}

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -1,14 +1,10 @@
 package vault
 
-import (
-	"fmt"
-	"strings"
-	"time"
-)
+import "time"
 
 type dynamicSystemView struct {
-	core *Core
-	path string
+	core       *Core
+	mountEntry *MountEntry
 }
 
 func (d dynamicSystemView) DefaultLeaseTTL() (time.Duration, error) {
@@ -30,24 +26,14 @@ func (d dynamicSystemView) MaxLeaseTTL() (time.Duration, error) {
 // TTLsByPath returns the default and max TTLs corresponding to a particular
 // mount point, or the system default
 func (d dynamicSystemView) fetchTTLs() (def, max time.Duration, retErr error) {
-	// Ensure we end the path in a slash
-	if !strings.HasSuffix(d.path, "/") {
-		d.path += "/"
-	}
-
-	me := d.core.router.MatchingMountEntry(d.path)
-	if me == nil {
-		return 0, 0, fmt.Errorf("[ERR] core: failed to get mount entry for %s", d.path)
-	}
-
 	def = d.core.defaultLeaseTTL
 	max = d.core.maxLeaseTTL
 
-	if me.Config.DefaultLeaseTTL != 0 {
-		def = me.Config.DefaultLeaseTTL
+	if d.mountEntry.Config.DefaultLeaseTTL != 0 {
+		def = d.mountEntry.Config.DefaultLeaseTTL
 	}
-	if me.Config.MaxLeaseTTL != 0 {
-		max = me.Config.MaxLeaseTTL
+	if d.mountEntry.Config.MaxLeaseTTL != 0 {
+		max = d.mountEntry.Config.MaxLeaseTTL
 	}
 
 	return

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -7,25 +7,19 @@ type dynamicSystemView struct {
 	mountEntry *MountEntry
 }
 
-func (d dynamicSystemView) DefaultLeaseTTL() (time.Duration, error) {
-	def, _, err := d.fetchTTLs()
-	if err != nil {
-		return 0, err
-	}
-	return def, nil
+func (d dynamicSystemView) DefaultLeaseTTL() time.Duration {
+	def, _ := d.fetchTTLs()
+	return def
 }
 
-func (d dynamicSystemView) MaxLeaseTTL() (time.Duration, error) {
-	_, max, err := d.fetchTTLs()
-	if err != nil {
-		return 0, err
-	}
-	return max, nil
+func (d dynamicSystemView) MaxLeaseTTL() time.Duration {
+	_, max := d.fetchTTLs()
+	return max
 }
 
 // TTLsByPath returns the default and max TTLs corresponding to a particular
 // mount point, or the system default
-func (d dynamicSystemView) fetchTTLs() (def, max time.Duration, retErr error) {
+func (d dynamicSystemView) fetchTTLs() (def, max time.Duration) {
 	def = d.core.defaultLeaseTTL
 	max = d.core.maxLeaseTTL
 

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -43,11 +43,11 @@ func (d dynamicSystemView) fetchTTLs() (def, max time.Duration, retErr error) {
 	def = d.core.defaultLeaseTTL
 	max = d.core.maxLeaseTTL
 
-	if me.Config.DefaultLeaseTTL != nil && *me.Config.DefaultLeaseTTL != 0 {
-		def = *me.Config.DefaultLeaseTTL
+	if me.Config.DefaultLeaseTTL != 0 {
+		def = me.Config.DefaultLeaseTTL
 	}
-	if me.Config.MaxLeaseTTL != nil && *me.Config.MaxLeaseTTL != 0 {
-		max = *me.Config.MaxLeaseTTL
+	if me.Config.MaxLeaseTTL != 0 {
+		max = me.Config.MaxLeaseTTL
 	}
 
 	return

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -78,7 +78,7 @@ func NewExpirationManager(router *Router, view *BarrierView, ts *TokenStore, log
 // initialize the expiration manager
 func (c *Core) setupExpiration() error {
 	// Create a sub-view
-	view := c.systemView.SubView(expirationSubPath)
+	view := c.systemBarrierView.SubView(expirationSubPath)
 
 	// Create the manager
 	mgr := NewExpirationManager(c.router, view, c.tokenStore, c.logger)

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -22,7 +22,7 @@ func TestExpiration_Restore(t *testing.T) {
 	noop := &NoopBackend{}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
-	exp.router.Mount(noop, "prod/aws/", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	paths := []string{
 		"prod/aws/foo",
@@ -175,7 +175,7 @@ func TestExpiration_Revoke(t *testing.T) {
 	noop := &NoopBackend{}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
-	exp.router.Mount(noop, "prod/aws/", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	req := &logical.Request{
 		Operation: logical.ReadOperation,
@@ -213,7 +213,7 @@ func TestExpiration_RevokeOnExpire(t *testing.T) {
 	noop := &NoopBackend{}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
-	exp.router.Mount(noop, "prod/aws/", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	req := &logical.Request{
 		Operation: logical.ReadOperation,
@@ -262,7 +262,7 @@ func TestExpiration_RevokePrefix(t *testing.T) {
 	noop := &NoopBackend{}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
-	exp.router.Mount(noop, "prod/aws/", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	paths := []string{
 		"prod/aws/foo",
@@ -322,7 +322,7 @@ func TestExpiration_RevokeByToken(t *testing.T) {
 	noop := &NoopBackend{}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
-	exp.router.Mount(noop, "prod/aws/", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	paths := []string{
 		"prod/aws/foo",
@@ -441,7 +441,7 @@ func TestExpiration_Renew(t *testing.T) {
 	noop := &NoopBackend{}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
-	exp.router.Mount(noop, "prod/aws/", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	req := &logical.Request{
 		Operation: logical.ReadOperation,
@@ -503,7 +503,7 @@ func TestExpiration_Renew_NotRenewable(t *testing.T) {
 	noop := &NoopBackend{}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
-	exp.router.Mount(noop, "prod/aws/", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	req := &logical.Request{
 		Operation: logical.ReadOperation,
@@ -545,7 +545,7 @@ func TestExpiration_Renew_RevokeOnExpire(t *testing.T) {
 	noop := &NoopBackend{}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
-	exp.router.Mount(noop, "prod/aws/", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	req := &logical.Request{
 		Operation: logical.ReadOperation,
@@ -613,7 +613,7 @@ func TestExpiration_revokeEntry(t *testing.T) {
 	noop := &NoopBackend{}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
-	exp.router.Mount(noop, "", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	le := &leaseEntry{
 		LeaseID: "foo/bar/1234",
@@ -702,7 +702,7 @@ func TestExpiration_renewEntry(t *testing.T) {
 	}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
-	exp.router.Mount(noop, "", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	le := &leaseEntry{
 		LeaseID: "foo/bar/1234",
@@ -764,7 +764,7 @@ func TestExpiration_renewAuthEntry(t *testing.T) {
 	}
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "auth/foo/")
-	exp.router.Mount(noop, "auth/foo/", uuid.GenerateUUID(), view)
+	exp.router.Mount(noop, "auth/foo/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 
 	le := &leaseEntry{
 		LeaseID: "auth/foo/1234",

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -11,7 +11,7 @@ import (
 )
 
 // logical.Factory
-func PassthroughBackendFactory(*logical.BackendConfig) (logical.Backend, error) {
+func PassthroughBackendFactory(conf *logical.BackendConfig) (logical.Backend, error) {
 	var b PassthroughBackend
 	b.Backend = &framework.Backend{
 		Help: strings.TrimSpace(passthroughHelp),
@@ -52,6 +52,11 @@ func PassthroughBackendFactory(*logical.BackendConfig) (logical.Backend, error) 
 			},
 		},
 	}
+
+	if conf == nil {
+		return nil, fmt.Errorf("Configuation passed into backend is nil")
+	}
+	b.Backend.Setup(conf)
 
 	return b, nil
 }

--- a/vault/logical_passthrough_test.go
+++ b/vault/logical_passthrough_test.go
@@ -176,6 +176,12 @@ func TestPassthroughBackend_List(t *testing.T) {
 }
 
 func testPassthroughBackend() logical.Backend {
-	b, _ := PassthroughBackendFactory(nil)
+	b, _ := PassthroughBackendFactory(&logical.BackendConfig{
+		Logger: nil,
+		System: logical.StaticSystemView{
+			DefaultLeaseTTLVal: time.Hour * 24,
+			MaxLeaseTTLVal:     time.Hour * 24 * 30,
+		},
+	})
 	return b
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -45,17 +45,6 @@ func NewSystemBackend(core *Core) logical.Backend {
 
 		Paths: []*framework.Path{
 			&framework.Path{
-				Pattern: "mounts$",
-
-				Callbacks: map[logical.Operation]framework.OperationFunc{
-					logical.ReadOperation: b.handleMountTable,
-				},
-
-				HelpSynopsis:    strings.TrimSpace(sysHelp["mounts"][0]),
-				HelpDescription: strings.TrimSpace(sysHelp["mounts"][1]),
-			},
-
-			&framework.Path{
 				Pattern: "mounts/(?P<path>.+?)/tune$",
 
 				Fields: map[string]*framework.FieldSchema{
@@ -107,6 +96,17 @@ func NewSystemBackend(core *Core) logical.Backend {
 
 				HelpSynopsis:    strings.TrimSpace(sysHelp["mount"][0]),
 				HelpDescription: strings.TrimSpace(sysHelp["mount"][1]),
+			},
+
+			&framework.Path{
+				Pattern: "mounts$",
+
+				Callbacks: map[logical.Operation]framework.OperationFunc{
+					logical.ReadOperation: b.handleMountTable,
+				},
+
+				HelpSynopsis:    strings.TrimSpace(sysHelp["mounts"][0]),
+				HelpDescription: strings.TrimSpace(sysHelp["mounts"][1]),
 			},
 
 			&framework.Path{
@@ -530,7 +530,7 @@ func (b *SystemBackend) handleMountTune(
 				"unable to convert given mount config information: %s", err)),
 			logical.ErrInvalidRequest
 	}
-	
+
 	// Attempt tune
 	if err := b.Core.tuneMount(path, config); err != nil {
 		b.Backend.Logger().Printf("[ERR] sys: tune of path '%s' failed: %v", path, err)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -498,17 +498,9 @@ func (b *SystemBackend) handleMountConfig(
 		return handleError(err)
 	}
 
-	def, err := sysView.DefaultLeaseTTL()
-	if err != nil {
-		b.Backend.Logger().Printf("[ERR] sys: fetching config default TTL of path '%s' failed: %v", path, err)
-		return handleError(err)
-	}
+	def := sysView.DefaultLeaseTTL()
 
-	max, err := sysView.MaxLeaseTTL()
-	if err != nil {
-		b.Backend.Logger().Printf("[ERR] sys: fetching config max TTL of path '%s' failed: %v", path, err)
-		return handleError(err)
-	}
+	max := sysView.MaxLeaseTTL()
 
 	resp := &logical.Response{
 		Data: map[string]interface{}{

--- a/vault/logical_system_helpers.go
+++ b/vault/logical_system_helpers.go
@@ -1,0 +1,51 @@
+package vault
+
+import (
+	"errors"
+	"fmt"
+)
+
+// tuneMount is used to set config on a mount point
+func (b *SystemBackend) tuneMountTTLs(path string, meConfig, newConfig *MountConfig) error {
+	if meConfig.MaxLeaseTTL == newConfig.MaxLeaseTTL &&
+		meConfig.DefaultLeaseTTL == newConfig.DefaultLeaseTTL {
+		return nil
+	}
+
+	if meConfig.DefaultLeaseTTL != 0 {
+		if newConfig.MaxLeaseTTL < meConfig.DefaultLeaseTTL {
+			if newConfig.DefaultLeaseTTL == 0 {
+				return fmt.Errorf("New backend max lease TTL of %d less than backend default lease TTL of %d",
+					newConfig.MaxLeaseTTL, meConfig.DefaultLeaseTTL)
+			}
+			if newConfig.MaxLeaseTTL < newConfig.DefaultLeaseTTL {
+				return fmt.Errorf("New backend max lease TTL of %d less than new backend default lease TTL of %d",
+					newConfig.MaxLeaseTTL, newConfig.DefaultLeaseTTL)
+			}
+		}
+	}
+
+	if meConfig.MaxLeaseTTL == 0 {
+		if newConfig.DefaultLeaseTTL > b.Core.maxLeaseTTL {
+			return fmt.Errorf("New backend default lease TTL of %d greater than system max lease TTL of %d",
+				newConfig.DefaultLeaseTTL, b.Core.maxLeaseTTL)
+		}
+	} else {
+		if meConfig.MaxLeaseTTL < newConfig.DefaultLeaseTTL {
+			return fmt.Errorf("New backend default lease TTL of %d greater than backend max lease TTL of %d",
+				newConfig.DefaultLeaseTTL, meConfig.MaxLeaseTTL)
+		}
+	}
+
+	meConfig.MaxLeaseTTL = newConfig.MaxLeaseTTL
+	meConfig.DefaultLeaseTTL = newConfig.DefaultLeaseTTL
+
+	// Update the mount table
+	if err := b.Core.persistMounts(b.Core.mounts); err != nil {
+		return errors.New("failed to update mount table")
+	}
+
+	b.Core.logger.Printf("[INFO] core: tuned '%s'", path)
+
+	return nil
+}

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/logical"
@@ -39,17 +40,25 @@ func TestSystemBackend_mounts(t *testing.T) {
 	}
 
 	exp := map[string]interface{}{
-		"secret/": map[string]string{
+		"secret/": map[string]interface{}{
 			"type":        "generic",
 			"description": "generic secret storage",
+			"config": map[string]interface{}{
+				"default_lease_ttl": time.Duration(0),
+				"max_lease_ttl":     time.Duration(0),
+			},
 		},
-		"sys/": map[string]string{
+		"sys/": map[string]interface{}{
 			"type":        "system",
 			"description": "system endpoints used for control, policy and debugging",
+			"config": map[string]interface{}{
+				"default_lease_ttl": time.Duration(0),
+				"max_lease_ttl":     time.Duration(0),
+			},
 		},
 	}
 	if !reflect.DeepEqual(resp.Data, exp) {
-		t.Fatalf("got: %#v expect: %#v", resp.Data, exp)
+		t.Fatalf("Got:\n%#v\nExpected:\n%#v", resp.Data, exp)
 	}
 }
 

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -760,10 +760,24 @@ func TestSystemBackend_rotate(t *testing.T) {
 
 func testSystemBackend(t *testing.T) logical.Backend {
 	c, _, _ := TestCoreUnsealed(t)
-	return NewSystemBackend(c)
+	bc := &logical.BackendConfig{
+		Logger: c.logger,
+		System: logical.StaticSystemView{
+			DefaultLeaseTTLVal: time.Hour * 24,
+			MaxLeaseTTLVal:     time.Hour * 24 * 30,
+		},
+	}
+	return NewSystemBackend(c, bc)
 }
 
 func testCoreSystemBackend(t *testing.T) (*Core, logical.Backend, string) {
 	c, _, root := TestCoreUnsealed(t)
-	return c, NewSystemBackend(c), root
+	bc := &logical.BackendConfig{
+		Logger: c.logger,
+		System: logical.StaticSystemView{
+			DefaultLeaseTTLVal: time.Hour * 24,
+			MaxLeaseTTLVal:     time.Hour * 24 * 30,
+		},
+	}
+	return c, NewSystemBackend(c, bc), root
 }

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -47,16 +47,16 @@ func TestSystemBackend_mounts(t *testing.T) {
 			"type":        "generic",
 			"description": "generic secret storage",
 			"config": map[string]interface{}{
-				"default_lease_ttl": resp.Data["secret/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(*time.Duration),
-				"max_lease_ttl":     resp.Data["secret/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(*time.Duration),
+				"default_lease_ttl": resp.Data["secret/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(time.Duration),
+				"max_lease_ttl":     resp.Data["secret/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(time.Duration),
 			},
 		},
 		"sys/": map[string]interface{}{
 			"type":        "system",
 			"description": "system endpoints used for control, policy and debugging",
 			"config": map[string]interface{}{
-				"default_lease_ttl": resp.Data["sys/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(*time.Duration),
-				"max_lease_ttl":     resp.Data["sys/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(*time.Duration),
+				"default_lease_ttl": resp.Data["sys/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(time.Duration),
+				"max_lease_ttl":     resp.Data["sys/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(time.Duration),
 			},
 		},
 	}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -118,8 +118,8 @@ type MountEntry struct {
 
 // MountConfig is used to hold settable options
 type MountConfig struct {
-	DefaultLeaseTTL time.Duration `json:"default_lease_ttl"` // Override for global default
-	MaxLeaseTTL     time.Duration `json:"max_lease_ttl"`     // Override for global default
+	DefaultLeaseTTL time.Duration `json:"default_lease_ttl" structs:"default_lease_ttl"` // Override for global default
+	MaxLeaseTTL     time.Duration `json:"max_lease_ttl" structs:"max_lease_ttl"`         // Override for global default
 }
 
 // Returns a deep copy of the mount entry
@@ -283,7 +283,7 @@ func (c *Core) taintMountEntry(path string) error {
 }
 
 // Remount is used to remount a path at a new mount point.
-func (c *Core) remount(src, dst string) error {
+func (c *Core) remount(src, dst string, config *MountConfig) error {
 	c.mounts.Lock()
 	defer c.mounts.Unlock()
 
@@ -339,6 +339,9 @@ func (c *Core) remount(src, dst string) error {
 		if ent.Path == src {
 			ent.Path = dst
 			ent.Tainted = false
+			if config != nil {
+				ent.Config = *config
+			}
 			break
 		}
 	}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -592,6 +592,11 @@ func (c *Core) mountEntrySysView(me *MountEntry) (logical.SystemView, error) {
 
 // sysViewByPath is a simple helper for MountEntrySysView
 func (c *Core) sysViewByPath(path string) (logical.SystemView, error) {
+	// Ensure we end the path in a slash
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+
 	me, err := c.mountEntryByPath(path)
 	if err != nil {
 		return nil, err
@@ -601,6 +606,11 @@ func (c *Core) sysViewByPath(path string) (logical.SystemView, error) {
 
 // mountEntryByPath searches across all tables to find the MountEntry
 func (c *Core) mountEntryByPath(path string) (*MountEntry, error) {
+	// Ensure we end the path in a slash
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+
 	pathSep := strings.IndexRune(path, '/')
 	if pathSep == -1 {
 		return nil, fmt.Errorf("[ERR] core: failed to find separator for path %s", path)
@@ -621,6 +631,11 @@ func (c *Core) mountEntryByPath(path string) (*MountEntry, error) {
 // TTLsByPath returns the default and max TTLs corresponding to a particular
 // mount point, or the system default
 func (c *Core) TTLsByPath(path string) (def, max time.Duration, retErr error) {
+	// Ensure we end the path in a slash
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+
 	me, err := c.mountEntryByPath(path)
 	if err != nil {
 		return 0, 0, err

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -504,15 +504,15 @@ func (c *Core) MountEntrySysView(me *MountEntry) (logical.SystemView, error) {
 	}
 
 	sysView := &logical.StaticSystemView{
-		DefaultLeaseTTLVal: c.defaultLeaseTTL,
-		MaxLeaseTTLVal:     c.maxLeaseTTL,
+		DefaultLeaseTTLVal: &c.defaultLeaseTTL,
+		MaxLeaseTTLVal:     &c.maxLeaseTTL,
 	}
 
 	if me.Config.DefaultLeaseTTL != 0 {
-		sysView.DefaultLeaseTTLVal = me.Config.DefaultLeaseTTL
+		sysView.DefaultLeaseTTLVal = &me.Config.DefaultLeaseTTL
 	}
 	if me.Config.MaxLeaseTTL != 0 {
-		sysView.MaxLeaseTTLVal = me.Config.MaxLeaseTTL
+		sysView.MaxLeaseTTLVal = &me.Config.MaxLeaseTTL
 	}
 
 	return sysView, nil

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -111,13 +111,13 @@ type MountEntry struct {
 	Type        string            `json:"type"`              // Logical backend Type
 	Description string            `json:"description"`       // User-provided description
 	UUID        string            `json:"uuid"`              // Barrier view UUID
-	Config      MountOptions      `json:"config"`            // Configuration related to this mount (but not backend-derived)
+	Config      MountConfig       `json:"config"`            // Configuration related to this mount (but not backend-derived)
 	Options     map[string]string `json:"options"`           // Backend options
 	Tainted     bool              `json:"tainted,omitempty"` // Set as a Write-Ahead flag for unmount/remount
 }
 
-// MountOptions is used to hold settable options
-type MountOptions struct {
+// MountConfig is used to hold settable options
+type MountConfig struct {
 	DefaultLeaseTTL time.Duration `json:"default_lease_ttl"` // Override for global default
 	MaxLeaseTTL     time.Duration `json:"max_lease_ttl"`     // Override for global default
 }
@@ -497,7 +497,7 @@ func (c *Core) newLogicalBackend(t string, sysView logical.SystemView, view logi
 // mount-specific entries
 func (c *Core) MountEntrySysView(me *MountEntry) (logical.SystemView, error) {
 	if me == nil {
-		return nil, fmt.Errorf("Error: nil MountEntry when generating SystemView")
+		return nil, fmt.Errorf("[ERR] core: nil MountEntry when generating SystemView")
 	}
 
 	sysView := &logical.StaticSystemView{
@@ -531,11 +531,7 @@ func (c *Core) PathSysView(path string) (logical.SystemView, error) {
 	if me == nil {
 		return nil, fmt.Errorf("[ERR] core: failed to find mount entry for path %s", path)
 	}
-	sysView, err := c.MountEntrySysView(me)
-	if err != nil {
-		return nil, fmt.Errorf("[ERR] core: failed to get system view for path %s", path)
-	}
-	return sysView, nil
+	return c.MountEntrySysView(me)
 }
 
 // defaultMountTable creates a default mount table

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -192,7 +192,7 @@ func TestCore_Unmount_Cleanup(t *testing.T) {
 
 func TestCore_Remount(t *testing.T) {
 	c, key, _ := TestCoreUnsealed(t)
-	err := c.remount("secret", "foo", nil)
+	err := c.remount("secret", "foo", MountConfig{})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestCore_Remount_Cleanup(t *testing.T) {
 	}
 
 	// Remount, this should cleanup
-	if err := c.remount("test/", "new/", nil); err != nil {
+	if err := c.remount("test/", "new/", MountConfig{}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -309,7 +309,7 @@ func TestCore_Remount_Cleanup(t *testing.T) {
 
 func TestCore_Remount_Protected(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	err := c.remount("sys", "foo", nil)
+	err := c.remount("sys", "foo", MountConfig{})
 	if err.Error() != "cannot remount 'sys/'" {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -192,7 +192,7 @@ func TestCore_Unmount_Cleanup(t *testing.T) {
 
 func TestCore_Remount(t *testing.T) {
 	c, key, _ := TestCoreUnsealed(t)
-	err := c.remount("secret", "foo", MountConfig{})
+	err := c.remount("secret", "foo")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestCore_Remount_Cleanup(t *testing.T) {
 	}
 
 	// Remount, this should cleanup
-	if err := c.remount("test/", "new/", MountConfig{}); err != nil {
+	if err := c.remount("test/", "new/"); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -309,7 +309,7 @@ func TestCore_Remount_Cleanup(t *testing.T) {
 
 func TestCore_Remount_Protected(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	err := c.remount("sys", "foo", MountConfig{})
+	err := c.remount("sys", "foo")
 	if err.Error() != "cannot remount 'sys/'" {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -192,7 +192,7 @@ func TestCore_Unmount_Cleanup(t *testing.T) {
 
 func TestCore_Remount(t *testing.T) {
 	c, key, _ := TestCoreUnsealed(t)
-	err := c.remount("secret", "foo")
+	err := c.remount("secret", "foo", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestCore_Remount_Cleanup(t *testing.T) {
 	}
 
 	// Remount, this should cleanup
-	if err := c.remount("test/", "new/"); err != nil {
+	if err := c.remount("test/", "new/", nil); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -309,7 +309,7 @@ func TestCore_Remount_Cleanup(t *testing.T) {
 
 func TestCore_Remount_Protected(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	err := c.remount("sys", "foo")
+	err := c.remount("sys", "foo", nil)
 	if err.Error() != "cannot remount 'sys/'" {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -46,7 +46,7 @@ func NewPolicyStore(view *BarrierView) *PolicyStore {
 // when the vault is being unsealed.
 func (c *Core) setupPolicyStore() error {
 	// Create a sub-view
-	view := c.systemView.SubView(policySubPath)
+	view := c.systemBarrierView.SubView(policySubPath)
 
 	// Create the policy store
 	c.policy = NewPolicyStore(view)

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -21,7 +21,7 @@ func mockRollback(t *testing.T) (*RollbackManager, *NoopBackend) {
 			Path: "foo",
 		},
 	}
-	if err := router.Mount(backend, "foo", uuid.GenerateUUID(), nil); err != nil {
+	if err := router.Mount(backend, "foo", &MountEntry{UUID: uuid.GenerateUUID()}, nil); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/vault/router.go
+++ b/vault/router.go
@@ -91,6 +91,15 @@ func (r *Router) Remount(src, dst string) error {
 
 	// Update the mount point
 	r.root.Delete(src)
+	mountEntry, ok := raw.(*mountEntry)
+	if !ok {
+		return fmt.Errorf("Unable to retrieve mount entry at '%s'", src)
+	}
+	sysView := mountEntry.backend.System()
+	dynSysView, ok := sysView.(dynamicSystemView)
+	if ok {
+		dynSysView.path = dst
+	}
 	r.root.Insert(dst, raw)
 	return nil
 }

--- a/vault/router.go
+++ b/vault/router.go
@@ -26,24 +26,24 @@ func NewRouter() *Router {
 	return r
 }
 
-// mountEntry is used to represent a mount point
-type mountEntry struct {
+// routeEntry is used to represent a mount point in the router
+type routeEntry struct {
 	tainted    bool
-	salt       string
 	backend    logical.Backend
+	mountEntry *MountEntry
 	view       *BarrierView
 	rootPaths  *radix.Tree
 	loginPaths *radix.Tree
 }
 
 // SaltID is used to apply a salt and hash to an ID to make sure its not reversable
-func (me *mountEntry) SaltID(id string) string {
-	return salt.SaltID(me.salt, id, salt.SHA1Hash)
+func (re *routeEntry) SaltID(id string) string {
+	return salt.SaltID(re.mountEntry.UUID, id, salt.SHA1Hash)
 }
 
 // Mount is used to expose a logical backend at a given prefix, using a unique salt,
 // and the barrier view for that path.
-func (r *Router) Mount(backend logical.Backend, prefix, salt string, view *BarrierView) error {
+func (r *Router) Mount(backend logical.Backend, prefix string, mountEntry *MountEntry, view *BarrierView) error {
 	r.l.Lock()
 	defer r.l.Unlock()
 
@@ -59,14 +59,15 @@ func (r *Router) Mount(backend logical.Backend, prefix, salt string, view *Barri
 	}
 
 	// Create a mount entry
-	me := &mountEntry{
+	re := &routeEntry{
 		tainted:    false,
 		backend:    backend,
+		mountEntry: mountEntry,
 		view:       view,
 		rootPaths:  pathsToRadix(paths.Root),
 		loginPaths: pathsToRadix(paths.Unauthenticated),
 	}
-	r.root.Insert(prefix, me)
+	r.root.Insert(prefix, re)
 	return nil
 }
 
@@ -91,12 +92,8 @@ func (r *Router) Remount(src, dst string) error {
 
 	// Update the mount point
 	r.root.Delete(src)
-	mountEntry, ok := raw.(*mountEntry)
-	if !ok {
-		return fmt.Errorf("Unable to retrieve mount entry at '%s'", src)
-	}
-	sysView := mountEntry.backend.System()
-	dynSysView, ok := sysView.(dynamicSystemView)
+	routeEntry := raw.(*routeEntry)
+	dynSysView, ok := routeEntry.backend.System().(dynamicSystemView)
 	if ok {
 		dynSysView.path = dst
 	}
@@ -111,7 +108,7 @@ func (r *Router) Taint(path string) error {
 	defer r.l.Unlock()
 	_, raw, ok := r.root.LongestPrefix(path)
 	if ok {
-		raw.(*mountEntry).tainted = true
+		raw.(*routeEntry).tainted = true
 	}
 	return nil
 }
@@ -122,7 +119,7 @@ func (r *Router) Untaint(path string) error {
 	defer r.l.Unlock()
 	_, raw, ok := r.root.LongestPrefix(path)
 	if ok {
-		raw.(*mountEntry).tainted = false
+		raw.(*routeEntry).tainted = false
 	}
 	return nil
 }
@@ -146,7 +143,29 @@ func (r *Router) MatchingView(path string) *BarrierView {
 	if !ok {
 		return nil
 	}
-	return raw.(*mountEntry).view
+	return raw.(*routeEntry).view
+}
+
+// MatchingMountEntry returns the MountEntry used for a path
+func (r *Router) MatchingMountEntry(path string) *MountEntry {
+	r.l.RLock()
+	_, raw, ok := r.root.LongestPrefix(path)
+	r.l.RUnlock()
+	if !ok {
+		return nil
+	}
+	return raw.(*routeEntry).mountEntry
+}
+
+// MatchingSystemView returns the SystemView used for a path
+func (r *Router) MatchingSystemView(path string) logical.SystemView {
+	r.l.RLock()
+	_, raw, ok := r.root.LongestPrefix(path)
+	r.l.RUnlock()
+	if !ok {
+		return nil
+	}
+	return raw.(*routeEntry).backend.System()
 }
 
 // Route is used to route a given request
@@ -166,11 +185,11 @@ func (r *Router) Route(req *logical.Request) (*logical.Response, error) {
 	}
 	defer metrics.MeasureSince([]string{"route", string(req.Operation),
 		strings.Replace(mount, "/", "-", -1)}, time.Now())
-	me := raw.(*mountEntry)
+	re := raw.(*routeEntry)
 
 	// If the path is tainted, we reject any operation except for
 	// Rollback and Revoke
-	if me.tainted {
+	if re.tainted {
 		switch req.Operation {
 		case logical.RevokeOperation, logical.RollbackOperation:
 		default:
@@ -190,12 +209,12 @@ func (r *Router) Route(req *logical.Request) (*logical.Response, error) {
 	}
 
 	// Attach the storage view for the request
-	req.Storage = me.view
+	req.Storage = re.view
 
 	// Hash the request token unless this is the token backend
 	clientToken := req.ClientToken
 	if !strings.HasPrefix(original, "auth/token/") {
-		req.ClientToken = me.SaltID(req.ClientToken)
+		req.ClientToken = re.SaltID(req.ClientToken)
 	}
 
 	// If the request is not a login path, then clear the connection
@@ -214,7 +233,7 @@ func (r *Router) Route(req *logical.Request) (*logical.Response, error) {
 	}()
 
 	// Invoke the backend
-	return me.backend.HandleRequest(req)
+	return re.backend.HandleRequest(req)
 }
 
 // RootPath checks if the given path requires root privileges
@@ -225,13 +244,13 @@ func (r *Router) RootPath(path string) bool {
 	if !ok {
 		return false
 	}
-	me := raw.(*mountEntry)
+	re := raw.(*routeEntry)
 
 	// Trim to get remaining path
 	remain := strings.TrimPrefix(path, mount)
 
 	// Check the rootPaths of this backend
-	match, raw, ok := me.rootPaths.LongestPrefix(remain)
+	match, raw, ok := re.rootPaths.LongestPrefix(remain)
 	if !ok {
 		return false
 	}
@@ -254,13 +273,13 @@ func (r *Router) LoginPath(path string) bool {
 	if !ok {
 		return false
 	}
-	me := raw.(*mountEntry)
+	re := raw.(*routeEntry)
 
 	// Trim to get remaining path
 	remain := strings.TrimPrefix(path, mount)
 
 	// Check the loginPaths of this backend
-	match, raw, ok := me.loginPaths.LongestPrefix(remain)
+	match, raw, ok := re.loginPaths.LongestPrefix(remain)
 	if !ok {
 		return false
 	}

--- a/vault/router.go
+++ b/vault/router.go
@@ -92,11 +92,6 @@ func (r *Router) Remount(src, dst string) error {
 
 	// Update the mount point
 	r.root.Delete(src)
-	routeEntry := raw.(*routeEntry)
-	dynSysView, ok := routeEntry.backend.System().(dynamicSystemView)
-	if ok {
-		dynSysView.path = dst
-	}
 	r.root.Insert(dst, raw)
 	return nil
 }

--- a/vault/router_test.go
+++ b/vault/router_test.go
@@ -55,12 +55,12 @@ func TestRouter_Mount(t *testing.T) {
 	view := NewBarrierView(barrier, "logical/")
 
 	n := &NoopBackend{}
-	err := r.Mount(n, "prod/aws/", uuid.GenerateUUID(), view)
+	err := r.Mount(n, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = r.Mount(n, "prod/aws/", uuid.GenerateUUID(), view)
+	err = r.Mount(n, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 	if !strings.Contains(err.Error(), "cannot mount under existing mount") {
 		t.Fatalf("err: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestRouter_Unmount(t *testing.T) {
 	view := NewBarrierView(barrier, "logical/")
 
 	n := &NoopBackend{}
-	err := r.Mount(n, "prod/aws/", uuid.GenerateUUID(), view)
+	err := r.Mount(n, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestRouter_Remount(t *testing.T) {
 	view := NewBarrierView(barrier, "logical/")
 
 	n := &NoopBackend{}
-	err := r.Mount(n, "prod/aws/", uuid.GenerateUUID(), view)
+	err := r.Mount(n, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestRouter_RootPath(t *testing.T) {
 			"policy/*",
 		},
 	}
-	err := r.Mount(n, "prod/aws/", uuid.GenerateUUID(), view)
+	err := r.Mount(n, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestRouter_LoginPath(t *testing.T) {
 			"oauth/*",
 		},
 	}
-	err := r.Mount(n, "auth/foo/", uuid.GenerateUUID(), view)
+	err := r.Mount(n, "auth/foo/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestRouter_Taint(t *testing.T) {
 	view := NewBarrierView(barrier, "logical/")
 
 	n := &NoopBackend{}
-	err := r.Mount(n, "prod/aws/", uuid.GenerateUUID(), view)
+	err := r.Mount(n, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestRouter_Untaint(t *testing.T) {
 	view := NewBarrierView(barrier, "logical/")
 
 	n := &NoopBackend{}
-	err := r.Mount(n, "prod/aws/", uuid.GenerateUUID(), view)
+	err := r.Mount(n, "prod/aws/", &MountEntry{UUID: uuid.GenerateUUID()}, view)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/router_test.go
+++ b/vault/router_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/vault/helper/uuid"
 	"github.com/hashicorp/vault/logical"
@@ -38,6 +39,13 @@ func (n *NoopBackend) SpecialPaths() *logical.Paths {
 	return &logical.Paths{
 		Root:            n.Root,
 		Unauthenticated: n.Login,
+	}
+}
+
+func (n *NoopBackend) System() logical.SystemView {
+	return logical.StaticSystemView{
+		DefaultLeaseTTLVal: time.Hour * 24,
+		MaxLeaseTTLVal:     time.Hour * 24 * 30,
 	}
 }
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -62,10 +62,12 @@ func TestCore(t *testing.T) *Core {
 		},
 	}
 	noopBackends := make(map[string]logical.Factory)
-	noopBackends["noop"] = func(*logical.BackendConfig) (logical.Backend, error) {
-		return new(framework.Backend), nil
+	noopBackends["noop"] = func(config *logical.BackendConfig) (logical.Backend, error) {
+		b := new(framework.Backend)
+		b.Setup(config)
+		return b, nil
 	}
-	noopBackends["http"] = func(*logical.BackendConfig) (logical.Backend, error) {
+	noopBackends["http"] = func(config *logical.BackendConfig) (logical.Backend, error) {
 		return new(rawHTTP), nil
 	}
 	logicalBackends := make(map[string]logical.Factory)

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os/exec"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 
@@ -261,4 +262,11 @@ func (n *rawHTTP) HandleRequest(req *logical.Request) (*logical.Response, error)
 
 func (n *rawHTTP) SpecialPaths() *logical.Paths {
 	return &logical.Paths{Unauthenticated: []string{"*"}}
+}
+
+func (n *rawHTTP) System() logical.SystemView {
+	return logical.StaticSystemView{
+		DefaultLeaseTTLVal: time.Hour * 24,
+		MaxLeaseTTLVal:     time.Hour * 24 * 30,
+	}
 }

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -48,9 +48,9 @@ type TokenStore struct {
 
 // NewTokenStore is used to construct a token store that is
 // backed by the given barrier view.
-func NewTokenStore(c *Core) (*TokenStore, error) {
+func NewTokenStore(c *Core, config *logical.BackendConfig) (*TokenStore, error) {
 	// Create a sub-view
-	view := c.systemView.SubView(tokenSubPath)
+	view := c.systemBarrierView.SubView(tokenSubPath)
 
 	// Initialize the store
 	t := &TokenStore{
@@ -202,6 +202,8 @@ func NewTokenStore(c *Core) (*TokenStore, error) {
 			},
 		},
 	}
+
+	t.Backend.Setup(config)
 
 	return t, nil
 }

--- a/website/source/docs/http/sys-mounts.html.md
+++ b/website/source/docs/http/sys-mounts.html.md
@@ -21,6 +21,9 @@ description: |-
   <dt>Method</dt>
   <dd>GET</dd>
 
+  <dt>URL</dt>
+  <dd>`/sys/mounts`</dd>
+
   <dt>Parameters</dt>
   <dd>
     None
@@ -47,6 +50,40 @@ description: |-
           "default_lease_ttl": 0,
           "max_lease_ttl": 0
         }
+      }
+    }
+    ```
+
+  </dd>
+</dl>
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    List the given secret backends configuration. `default_lease_ttl`
+    or `max_lease_ttl` values of `0` mean that the system
+    defaults are used by this backend.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/mounts/<mount point>/tune`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+      "config": {
+          "default_lease_ttl": 0,
+          "max_lease_ttl": 0
       }
     }
     ```
@@ -84,6 +121,39 @@ description: |-
       <li>
         <span class="param">config</span>
         <span class="param-flags">optional</span>
+        Config options for this mount. This is an object with
+        two possible values: `default_lease_ttl` and
+        `max_lease_ttl`. These control the default and
+        maximum lease time-to-live, respectively. If set
+        on a specific mount, this overrides the global
+        defaults.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Tune configuration parameters for a given mount point.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>POST</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/mounts/<mount point>/tune`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">config</span>
+        <span class="param-flags">required</span>
         Config options for this mount. This is an object with
         two possible values: `default_lease_ttl` and
         `max_lease_ttl`. These control the default and

--- a/website/source/docs/http/sys-mounts.html.md
+++ b/website/source/docs/http/sys-mounts.html.md
@@ -13,7 +13,9 @@ description: |-
 <dl>
   <dt>Description</dt>
   <dd>
-    Lists all the mounted secret backends.
+    Lists all the mounted secret backends. `default_lease_ttl`
+    or `max_lease_ttl` values of `0` mean that the system
+    defaults are used by this backend.
   </dd>
 
   <dt>Method</dt>
@@ -31,12 +33,20 @@ description: |-
     {
       "aws": {
         "type": "aws",
-        "description": "AWS keys"
+        "description": "AWS keys",
+        "config": {
+          "default_lease_ttl": 0,
+          "max_lease_ttl": 0
+        }
       },
 
       "sys": {
         "type": "system",
-        "description": "system endpoint"
+        "description": "system endpoint",
+        "config": {
+          "default_lease_ttl": 0,
+          "max_lease_ttl": 0
+        }
       }
     }
     ```
@@ -70,6 +80,16 @@ description: |-
         <span class="param">description</span>
         <span class="param-flags">optional</span>
         A human-friendly description of the mount.
+      </li>
+      <li>
+        <span class="param">config</span>
+        <span class="param-flags">optional</span>
+        Config options for this mount. This is an object with
+        two possible values: `default_lease_ttl` and
+        `max_lease_ttl`. These control the default and
+        maximum lease time-to-live, respectively. If set
+        on a specific mount, this overrides the global
+        defaults.
       </li>
     </ul>
   </dd>

--- a/website/source/docs/http/sys-mounts.html.md
+++ b/website/source/docs/http/sys-mounts.html.md
@@ -81,10 +81,8 @@ description: |-
 
     ```javascript
     {
-      "config": {
-          "default_lease_ttl": 0,
-          "max_lease_ttl": 0
-      }
+      "default_lease_ttl": 0,
+      "max_lease_ttl": 0
     }
     ```
 
@@ -152,14 +150,16 @@ description: |-
   <dd>
     <ul>
       <li>
-        <span class="param">config</span>
-        <span class="param-flags">required</span>
-        Config options for this mount. This is an object with
-        two possible values: `default_lease_ttl` and
-        `max_lease_ttl`. These control the default and
-        maximum lease time-to-live, respectively. If set
-        on a specific mount, this overrides the global
-        defaults.
+        <span class="param">default_lease_ttl</span>
+        <span class="param-flags">optional</span>
+        The default time-to-live. If set on a specific mount,
+        overrides the global default.
+      </li>
+      <li>
+        <span class="param">max_lease_ttl</span>
+        <span class="param-flags">optional</span>
+        The maximum time-to-live. If set on a specific mount,
+        overrides the global default.
       </li>
     </ul>
   </dd>

--- a/website/source/docs/http/sys-remount.html.md
+++ b/website/source/docs/http/sys-remount.html.md
@@ -28,8 +28,21 @@ description: |-
       <li>
         <span class="param">to</span>
         <span class="param-flags">required</span>
-        The new mount point.
+        The new mount point. This can be the same
+        as `from` if you simply want to change
+        backend configuration with the `config`
+        parameter.
       </li>
+      <li>
+        <span class="param">config</span>
+        <span class="param-flags">optional</span>
+        Config options for this mount. This is an object with
+        two possible values: `default_lease_ttl` and
+        `max_lease_ttl`. These control the default and
+        maximum lease time-to-live, respectively. If set
+        on a specific mount, this overrides the global
+        defaults.
+    </li>
     </ul>
   </dd>
 

--- a/website/source/docs/http/sys-remount.html.md
+++ b/website/source/docs/http/sys-remount.html.md
@@ -28,21 +28,8 @@ description: |-
       <li>
         <span class="param">to</span>
         <span class="param-flags">required</span>
-        The new mount point. This can be the same
-        as `from` if you simply want to change
-        backend configuration with the `config`
-        parameter.
+        The new mount point.
       </li>
-      <li>
-        <span class="param">config</span>
-        <span class="param-flags">optional</span>
-        Config options for this mount. This is an object with
-        two possible values: `default_lease_ttl` and
-        `max_lease_ttl`. These control the default and
-        maximum lease time-to-live, respectively. If set
-        on a specific mount, this overrides the global
-        defaults.
-    </li>
     </ul>
   </dd>
 


### PR DESCRIPTION
This adds initial support for per-backend configuration. Initially, this enables overriding the global default lease TTL and max lease TTL, but puts all of the plumbing in place for future enhancements.