### PR TITLE
Update mysql docs markdown to fix grammar error

### DIFF
--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -63,7 +63,7 @@ application to renew their credentials at least hourly, and to recycle
 them once per day.
 
 The next step is to configure a role. A role is a logical name that maps
-to a policy used to generated those credentials. For example, lets create
+to a policy used to generate those credentials. For example, lets create
 a "readonly" role:
 
 ```


### PR DESCRIPTION
Changed "... used to **generated** those credentials" to "... used to **generate** those credentials."