### PR TITLE
Remove unused param to 'vault write aws/roles/deploy'

### DIFF
--- a/website/source/docs/secrets/aws/index.html.md
+++ b/website/source/docs/secrets/aws/index.html.md
@@ -51,7 +51,6 @@ a "deploy" role:
 
 ```text
 $ vault write aws/roles/deploy \
-    name=deploy \
     policy=@policy.json
 ```
 


### PR DESCRIPTION
The name is taken from the path, not the request body.  Having the duplicate key is confusing.