### PR TITLE
Renew the semaphore key periodically

### DIFF
--- a/physical/etcd.go
+++ b/physical/etcd.go
@@ -355,9 +355,10 @@ func (c *EtcdLock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) {
 	// Get the local lock before interacting with etcd.
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	var err error
 
 	// Check if the lock is already held.
-	if err := c.assertNotHeld(); err != nil {
+	if err = c.assertNotHeld(); err != nil {
 		return nil, err
 	}
 
@@ -384,14 +385,20 @@ func (c *EtcdLock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) {
 
 	// Create a channel to signal when we lose the semaphore key.
 	done := make(chan struct{})
+	defer func(err *error) {
+		if *err != nil {
+			close(done)
+		}
+	}(&err)
+
 	go c.periodicallyRenewSemaphoreKey(done)
 
 	// Loop until the we current semaphore key matches ours.
 	for semaphoreKey != currentSemaphoreKey {
-		var err error
+		var response *etcd.Response
 
 		// Start a watch of the entire lock directory, providing the stop channel.
-		response, err := c.client.Watch(c.semaphoreDirKey, currentEtcdIndex+1, true, nil, boolStopCh)
+		response, err = c.client.Watch(c.semaphoreDirKey, currentEtcdIndex+1, true, nil, boolStopCh)
 		if err != nil {
 
 			// If the error is not an etcd error, we can assume it's a notification
@@ -401,7 +408,6 @@ func (c *EtcdLock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) {
 			if _, ok := err.(*etcd.EtcdError); !ok {
 				_, err = c.client.Delete(c.semaphoreKey, false)
 			}
-			close(done)
 			return nil, err
 		}
 
@@ -409,14 +415,13 @@ func (c *EtcdLock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) {
 		// this is an error and nothing else needs to be done.
 		if response.Node.Key == semaphoreKey &&
 			(response.Action == "delete" || response.Action == "expire") {
-			close(done)
-			return nil, EtcdSemaphoreKeyRemovedError
+			err = EtcdSemaphoreKeyRemovedError
+			return nil, err
 		}
 
 		// Get the current semaphore key and etcd index.
 		currentSemaphoreKey, _, currentEtcdIndex, err = c.getSemaphoreKey()
 		if err != nil {
-			close(done)
 			return nil, err
 		}
 	}

--- a/physical/etcd.go
+++ b/physical/etcd.go
@@ -385,11 +385,11 @@ func (c *EtcdLock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) {
 
 	// Create a channel to signal when we lose the semaphore key.
 	done := make(chan struct{})
-	defer func(err *error) {
-		if *err != nil {
+	defer func() {
+		if err != nil {
 			close(done)
 		}
-	}(&err)
+	}()
 
 	go c.periodicallyRenewSemaphoreKey(done)
 

--- a/physical/etcd.go
+++ b/physical/etcd.go
@@ -351,7 +351,7 @@ func (c *EtcdLock) watchForKeyRemoval(key string, etcdIndex uint64, closeCh chan
 //
 // If the lock is currently held by this instance of EtcdLock, Lock will
 // return an EtcdLockHeldError error.
-func (c *EtcdLock) Lock(stopCh <-chan struct{}) (doneCh <-chan struct{}, err error) {
+func (c *EtcdLock) Lock(stopCh <-chan struct{}) (doneCh <-chan struct{}, retErr error) {
 	// Get the local lock before interacting with etcd.
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -385,7 +385,7 @@ func (c *EtcdLock) Lock(stopCh <-chan struct{}) (doneCh <-chan struct{}, err err
 	// Create a channel to signal when we lose the semaphore key.
 	done := make(chan struct{})
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			close(done)
 		}
 	}()


### PR DESCRIPTION
The semaphore key is used to determine whether we are the leader or not and is set to expire after TTL of 15 seconds. There was no logic implemented to renew the key before it expired, which caused the leader to step down and change every 15 seconds. A periodic timer is now added to update the key every 5 seconds to renew the TTL.