### PR TITLE
Basic list support

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -29,13 +29,15 @@ func (c *Logical) Read(path string) (*Secret, error) {
 func (c *Logical) List(path string) (*Secret, error) {
 	r := c.c.NewRequest("LIST", "/v1/"+path)
 	resp, err := c.c.RawRequest(r)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if resp != nil && resp.StatusCode == 404 {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return ParseSecret(resp.Body)
 }

--- a/api/logical.go
+++ b/api/logical.go
@@ -26,6 +26,20 @@ func (c *Logical) Read(path string) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
+func (c *Logical) List(path string) (*Secret, error) {
+	r := c.c.NewRequest("LIST", "/v1/"+path)
+	resp, err := c.c.RawRequest(r)
+	if resp != nil && resp.StatusCode == 404 {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return ParseSecret(resp.Body)
+}
+
 func (c *Logical) Write(path string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/"+path)
 	if err := r.SetJSONBody(data); err != nil {

--- a/api/logical.go
+++ b/api/logical.go
@@ -27,7 +27,8 @@ func (c *Logical) Read(path string) (*Secret, error) {
 }
 
 func (c *Logical) List(path string) (*Secret, error) {
-	r := c.c.NewRequest("LIST", "/v1/"+path)
+	r := c.c.NewRequest("GET", "/v1/"+path)
+	r.Params.Set("list", "true")
 	resp, err := c.c.RawRequest(r)
 	if resp != nil {
 		defer resp.Body.Close()

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -161,6 +161,7 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 		"read": func() (cli.Command, error) {
 			return &command.ReadCommand{
 				Meta: meta,
+				List: false,
 			}, nil
 		},
 
@@ -173,6 +174,13 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 		"delete": func() (cli.Command, error) {
 			return &command.DeleteCommand{
 				Meta: meta,
+			}, nil
+		},
+
+		"list": func() (cli.Command, error) {
+			return &command.ReadCommand{
+				Meta: meta,
+				List: true,
 			}, nil
 		},
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -161,7 +161,12 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 		"read": func() (cli.Command, error) {
 			return &command.ReadCommand{
 				Meta: meta,
-				List: false,
+			}, nil
+		},
+
+		"list": func() (cli.Command, error) {
+			return &command.ListCommand{
+				Meta: meta,
 			}, nil
 		},
 
@@ -174,13 +179,6 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 		"delete": func() (cli.Command, error) {
 			return &command.DeleteCommand{
 				Meta: meta,
-			}, nil
-		},
-
-		"list": func() (cli.Command, error) {
-			return &command.ReadCommand{
-				Meta: meta,
-				List: true,
 			}, nil
 		},
 

--- a/command/format.go
+++ b/command/format.go
@@ -35,9 +35,7 @@ func OutputList(ui cli.Ui, format string, secret *api.Secret) int {
 	case "yaml":
 		return outputFormatYAMLList(ui, secret)
 	case "table":
-		return outputFormatTableList(ui, secret, false)
-	case "bare":
-		return outputFormatTableList(ui, secret, true)
+		return outputFormatTableList(ui, secret)
 	default:
 		ui.Error(fmt.Sprintf("Invalid output format: %s", format))
 		return 1
@@ -150,7 +148,7 @@ func outputFormatTable(ui cli.Ui, s *api.Secret, whitespace bool) int {
 	return 0
 }
 
-func outputFormatTableList(ui cli.Ui, s *api.Secret, bare bool) int {
+func outputFormatTableList(ui cli.Ui, s *api.Secret) int {
 	config := columnize.DefaultConfig()
 	config.Delim = "♨"
 	config.Glue = "\t"
@@ -158,13 +156,11 @@ func outputFormatTableList(ui cli.Ui, s *api.Secret, bare bool) int {
 
 	input := make([]string, 0, 5)
 
-	if !bare {
-		input = append(input, "Keys")
-	}
+	input = append(input, "Keys")
 
-	keys := make([]string, 0, len(s.Data["keys"].([]string)))
-	for _, k := range s.Data["keys"].([]string) {
-		keys = append(keys, k)
+	keys := make([]string, 0, len(s.Data["keys"].([]interface{})))
+	for _, k := range s.Data["keys"].([]interface{}) {
+		keys = append(keys, k.(string))
 	}
 	sort.Strings(keys)
 
@@ -172,19 +168,13 @@ func outputFormatTableList(ui cli.Ui, s *api.Secret, bare bool) int {
 		input = append(input, fmt.Sprintf("%s", k))
 	}
 
-	if !bare && len(s.Warnings) != 0 {
+	if len(s.Warnings) != 0 {
 		input = append(input, "")
 		for _, warning := range s.Warnings {
 			input = append(input, fmt.Sprintf("* %s", warning))
 		}
 	}
 
-	if bare {
-		for _, line := range input {
-			ui.Output(line)
-		}
-	} else {
-		ui.Output(columnize.Format(input, config))
-	}
+	ui.Output(columnize.Format(input, config))
 	return 0
 }

--- a/command/format.go
+++ b/command/format.go
@@ -166,6 +166,7 @@ func outputFormatTableList(ui cli.Ui, s *api.Secret, bare bool) int {
 	for _, k := range s.Data["keys"].([]string) {
 		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 
 	for _, k := range keys {
 		input = append(input, fmt.Sprintf("%s", k))

--- a/command/list.go
+++ b/command/list.go
@@ -1,0 +1,101 @@
+package command
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/vault/api"
+)
+
+// ListCommand is a Command that lists data from the Vault.
+type ListCommand struct {
+	Meta
+}
+
+func (c *ListCommand) Run(args []string) int {
+	var format string
+	var bare bool
+	var err error
+	var secret *api.Secret
+	var flags *flag.FlagSet
+	flags = c.Meta.FlagSet("list", FlagSetDefault)
+	flags.StringVar(&format, "format", "table", "")
+	flags.BoolVar(&bare, "bare", false, "")
+	flags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = flags.Args()
+	if len(args) != 1 || len(args[0]) == 0 {
+		c.Ui.Error("read expects one argument")
+		flags.Usage()
+		return 1
+	}
+
+	path := args[0]
+	if path[0] == '/' {
+		path = path[1:]
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error initializing client: %s", err))
+		return 2
+	}
+
+	secret, err = client.Logical().List(path)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error reading %s: %s", path, err))
+		return 1
+	}
+	if secret == nil {
+		c.Ui.Error(fmt.Sprintf(
+			"No value found at %s", path))
+		return 1
+	}
+	if secret.Data["keys"] == nil {
+		if !bare {
+			c.Ui.Error("No entries found")
+		}
+		return 0
+	}
+
+	if bare {
+		return OutputList(c.Ui, "bare", secret)
+	}
+
+	return OutputList(c.Ui, format, secret)
+}
+
+func (c *ListCommand) Synopsis() string {
+	return "List data or secrets in Vault"
+}
+
+func (c *ListCommand) Help() string {
+	helpText :=
+		`
+Usage: vault list [options] path
+
+  List data from Vault.
+
+  Retrieve a listing of available data. The data returned, if any, is backend-
+  and endpoint-specific.
+
+General Options:
+
+  ` + generalOptionsUsage() + `
+
+Read Options:
+
+  -format=table           The format for output. By default it is a whitespace-
+                          delimited table. This can also be json or yaml.
+
+  -bare                   Causes the key values to be output raw to stdout,
+                          without formatting (except for newlines).
+`
+	return strings.TrimSpace(helpText)
+}

--- a/command/list.go
+++ b/command/list.go
@@ -15,13 +15,11 @@ type ListCommand struct {
 
 func (c *ListCommand) Run(args []string) int {
 	var format string
-	var bare bool
 	var err error
 	var secret *api.Secret
 	var flags *flag.FlagSet
 	flags = c.Meta.FlagSet("list", FlagSetDefault)
 	flags.StringVar(&format, "format", "table", "")
-	flags.BoolVar(&bare, "bare", false, "")
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -58,14 +56,8 @@ func (c *ListCommand) Run(args []string) int {
 		return 1
 	}
 	if secret.Data["keys"] == nil {
-		if !bare {
-			c.Ui.Error("No entries found")
-		}
+		c.Ui.Error("No entries found")
 		return 0
-	}
-
-	if bare {
-		return OutputList(c.Ui, "bare", secret)
 	}
 
 	return OutputList(c.Ui, format, secret)
@@ -93,9 +85,6 @@ Read Options:
 
   -format=table           The format for output. By default it is a whitespace-
                           delimited table. This can also be json or yaml.
-
-  -bare                   Causes the key values to be output raw to stdout,
-                          without formatting (except for newlines).
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/list_test.go
+++ b/command/list_test.go
@@ -61,7 +61,7 @@ func TestList(t *testing.T) {
 	}
 
 	exp := map[string]interface{}{
-		"keys": []interface{}{"secret/foo", "secret/foo/"},
+		"keys": []interface{}{"foo", "foo/"},
 	}
 
 	if !reflect.DeepEqual(secret.Data, exp) {

--- a/command/list_test.go
+++ b/command/list_test.go
@@ -1,0 +1,70 @@
+package command
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/vault"
+	"github.com/mitchellh/cli"
+)
+
+func TestList(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	ui := new(cli.MockUi)
+	c := &ReadCommand{
+		Meta: Meta{
+			ClientToken: token,
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-address", addr,
+		"-format", "json",
+		"secret",
+	}
+
+	// Run once so the client is setup, ignore errors
+	c.Run(args)
+
+	// Get the client so we can write data
+	client, err := c.Client()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	data := map[string]interface{}{"value": "bar"}
+	if _, err := client.Logical().Write("secret/foo", data); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	data = map[string]interface{}{"value": "bar"}
+	if _, err := client.Logical().Write("secret/foo/bar", data); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	secret, err := client.Logical().List("secret/")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if secret == nil {
+		t.Fatalf("err: No value found at secret/")
+	}
+
+	if secret.Data == nil {
+		t.Fatalf("err: Data not found")
+	}
+
+	exp := map[string]interface{}{
+		"keys": []interface{}{"secret/foo", "secret/foo/"},
+	}
+
+	if !reflect.DeepEqual(secret.Data, exp) {
+		t.Fatalf("err: expected %#v, got %#v", exp, secret.Data)
+	}
+}

--- a/command/read.go
+++ b/command/read.go
@@ -13,7 +13,6 @@ import (
 // ReadCommand is a Command that reads data from the Vault.
 type ReadCommand struct {
 	Meta
-	List bool
 }
 
 func (c *ReadCommand) Run(args []string) int {
@@ -22,11 +21,7 @@ func (c *ReadCommand) Run(args []string) int {
 	var err error
 	var secret *api.Secret
 	var flags *flag.FlagSet
-	if c.List {
-		flags = c.Meta.FlagSet("list", FlagSetDefault)
-	} else {
-		flags = c.Meta.FlagSet("read", FlagSetDefault)
-	}
+	flags = c.Meta.FlagSet("read", FlagSetDefault)
 	flags.StringVar(&format, "format", "table", "")
 	flags.StringVar(&field, "field", "", "")
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
@@ -53,11 +48,7 @@ func (c *ReadCommand) Run(args []string) int {
 		return 2
 	}
 
-	if c.List {
-		secret, err = client.Logical().List(path)
-	} else {
-		secret, err = client.Logical().Read(path)
-	}
+	secret, err = client.Logical().Read(path)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(
 			"Error reading %s: %s", path, err))
@@ -94,9 +85,6 @@ func (c *ReadCommand) Run(args []string) int {
 }
 
 func (c *ReadCommand) Synopsis() string {
-	if c.List {
-		return "List data in Vault"
-	}
 	return "Read data or secrets from Vault"
 }
 
@@ -110,21 +98,7 @@ Usage: vault read [options] path
   secrets and configuration as well as generate dynamic values from
   materialized backends. Please reference the documentation for the
   backends in use to determine key structure.
-`
 
-	if c.List {
-		helpText =
-			`
-Usage: vault list [options] path
-
-  List data from Vault.
-
-  Retrieve a listing of available data. The data returned is
-  backend-specific, and not all backends implement listing capability.
-`
-	}
-
-	helpText += `
 General Options:
 
   ` + generalOptionsUsage() + `

--- a/command/read_test.go
+++ b/command/read_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/vault/http"
@@ -132,5 +133,66 @@ func TestRead_field_notFound(t *testing.T) {
 	// Run the read
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
+func TestList(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	ui := new(cli.MockUi)
+	c := &ReadCommand{
+		Meta: Meta{
+			ClientToken: token,
+			Ui:          ui,
+		},
+		List: true,
+	}
+
+	args := []string{
+		"-address", addr,
+		"-format", "json",
+		"secret",
+	}
+
+	// Run once so the client is setup, ignore errors
+	c.Run(args)
+
+	// Get the client so we can write data
+	client, err := c.Client()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	data := map[string]interface{}{"value": "bar"}
+	if _, err := client.Logical().Write("secret/foo", data); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	data = map[string]interface{}{"value": "bar"}
+	if _, err := client.Logical().Write("secret/foo/bar", data); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	secret, err := client.Logical().List("secret/")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if secret == nil {
+		t.Fatalf("err: No value found at secret/")
+	}
+
+	if secret.Data == nil {
+		t.Fatalf("err: Data not found")
+	}
+
+	exp := map[string]interface{}{
+		"keys": []interface{}{"foo", "foo/"},
+	}
+
+	if !reflect.DeepEqual(secret.Data, exp) {
+		t.Fatalf("err: expected %#v, got %#v", exp, secret.Data)
 	}
 }

--- a/command/read_test.go
+++ b/command/read_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/vault/http"
@@ -133,66 +132,5 @@ func TestRead_field_notFound(t *testing.T) {
 	// Run the read
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
-	}
-}
-
-func TestList(t *testing.T) {
-	core, _, token := vault.TestCoreUnsealed(t)
-	ln, addr := http.TestServer(t, core)
-	defer ln.Close()
-
-	ui := new(cli.MockUi)
-	c := &ReadCommand{
-		Meta: Meta{
-			ClientToken: token,
-			Ui:          ui,
-		},
-		List: true,
-	}
-
-	args := []string{
-		"-address", addr,
-		"-format", "json",
-		"secret",
-	}
-
-	// Run once so the client is setup, ignore errors
-	c.Run(args)
-
-	// Get the client so we can write data
-	client, err := c.Client()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	data := map[string]interface{}{"value": "bar"}
-	if _, err := client.Logical().Write("secret/foo", data); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	data = map[string]interface{}{"value": "bar"}
-	if _, err := client.Logical().Write("secret/foo/bar", data); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	secret, err := client.Logical().List("secret/")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	if secret == nil {
-		t.Fatalf("err: No value found at secret/")
-	}
-
-	if secret.Data == nil {
-		t.Fatalf("err: Data not found")
-	}
-
-	exp := map[string]interface{}{
-		"keys": []interface{}{"foo", "foo/"},
-	}
-
-	if !reflect.DeepEqual(secret.Data, exp) {
-		t.Fatalf("err: expected %#v, got %#v", exp, secret.Data)
 	}
 }

--- a/http/logical.go
+++ b/http/logical.go
@@ -29,13 +29,16 @@ func handleLogical(core *vault.Core, dataOnly bool) http.Handler {
 		case "DELETE":
 			op = logical.DeleteOperation
 		case "GET":
+			// Need to call ParseForm to get query params loaded
+			err := r.ParseForm()
+			if err != nil {
+				respondError(w, http.StatusBadRequest, err)
+			}
 			if r.Form.Get("list") == "true" {
 				op = logical.ListOperation
 			} else {
 				op = logical.ReadOperation
 			}
-		case "LIST":
-			op = logical.ListOperation
 		case "POST", "PUT":
 			op = logical.UpdateOperation
 		case "LIST":
@@ -71,7 +74,7 @@ func handleLogical(core *vault.Core, dataOnly bool) http.Handler {
 		if !ok {
 			return
 		}
-		if op == logical.ReadOperation && resp == nil {
+		if (op == logical.ReadOperation || op == logical.ListOperation) && resp == nil {
 			respondError(w, http.StatusNotFound, nil)
 			return
 		}

--- a/http/logical.go
+++ b/http/logical.go
@@ -38,6 +38,8 @@ func handleLogical(core *vault.Core, dataOnly bool) http.Handler {
 			op = logical.ListOperation
 		case "POST", "PUT":
 			op = logical.UpdateOperation
+		case "LIST":
+			op = logical.ListOperation
 		default:
 			respondError(w, http.StatusMethodNotAllowed, nil)
 			return

--- a/http/logical.go
+++ b/http/logical.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/vault/logical"
@@ -29,12 +30,18 @@ func handleLogical(core *vault.Core, dataOnly bool) http.Handler {
 		case "DELETE":
 			op = logical.DeleteOperation
 		case "GET":
+			op = logical.ReadOperation
 			// Need to call ParseForm to get query params loaded
 			queryVals := r.URL.Query()
-			if queryVals.Get("list") == "true" {
-				op = logical.ListOperation
-			} else {
-				op = logical.ReadOperation
+			listStr := queryVals.Get("list")
+			if listStr != "" {
+				list, err := strconv.ParseBool(listStr)
+				if err != nil {
+					respondError(w, http.StatusBadRequest, nil)
+				}
+				if list {
+					op = logical.ListOperation
+				}
 			}
 		case "POST", "PUT":
 			op = logical.UpdateOperation

--- a/http/logical.go
+++ b/http/logical.go
@@ -30,11 +30,8 @@ func handleLogical(core *vault.Core, dataOnly bool) http.Handler {
 			op = logical.DeleteOperation
 		case "GET":
 			// Need to call ParseForm to get query params loaded
-			err := r.ParseForm()
-			if err != nil {
-				respondError(w, http.StatusBadRequest, err)
-			}
-			if r.Form.Get("list") == "true" {
+			queryVals := r.URL.Query()
+			if queryVals.Get("list") == "true" {
 				op = logical.ListOperation
 			} else {
 				op = logical.ReadOperation

--- a/logical/response.go
+++ b/logical/response.go
@@ -141,9 +141,11 @@ func ErrorResponse(text string) *Response {
 
 // ListResponse is used to format a response to a list operation.
 func ListResponse(keys []string) *Response {
-	return &Response{
-		Data: map[string]interface{}{
-			"keys": keys,
-		},
+	resp := &Response{
+		Data: map[string]interface{}{},
 	}
+	if keys != nil {
+		resp.Data["keys"] = keys
+	}
+	return resp
 }

--- a/logical/response.go
+++ b/logical/response.go
@@ -144,7 +144,7 @@ func ListResponse(keys []string) *Response {
 	resp := &Response{
 		Data: map[string]interface{}{},
 	}
-	if keys != nil {
+	if len(keys) != 0 {
 		resp.Data["keys"] = keys
 	}
 	return resp

--- a/vault/core.go
+++ b/vault/core.go
@@ -436,6 +436,12 @@ func (c *Core) HandleRequest(req *logical.Request) (resp *logical.Response, err 
 		return nil, ErrStandby
 	}
 
+	// Allowing writing to a path ending in / makes it extremely difficult to
+	// understand user intent for the filesystem-like backends (generic,
+	// cubbyhole) -- did they want a key named foo/ or did they want to write
+	// to a directory foo/ with no (or forgotten) key, or...? It also affects
+	// lookup, because paths ending in / are considered prefixes by some
+	// backends. Basically, it's all just terrible, so don't allow it.
 	if strings.HasSuffix(req.Path, "/") &&
 		(req.Operation == logical.UpdateOperation ||
 			req.Operation == logical.CreateOperation) {

--- a/vault/core.go
+++ b/vault/core.go
@@ -436,6 +436,12 @@ func (c *Core) HandleRequest(req *logical.Request) (resp *logical.Response, err 
 		return nil, ErrStandby
 	}
 
+	if strings.HasSuffix(req.Path, "/") &&
+		(req.Operation == logical.UpdateOperation ||
+			req.Operation == logical.CreateOperation) {
+		return logical.ErrorResponse("cannot write to a path ending in '/'"), nil
+	}
+
 	var auth *logical.Auth
 	if c.router.LoginPath(req.Path) {
 		resp, auth, err = c.handleLoginRequest(req)

--- a/vault/logical_cubbyhole.go
+++ b/vault/logical_cubbyhole.go
@@ -119,7 +119,7 @@ func (b *CubbyholeBackend) handleWrite(
 
 	path := req.Path
 	if strings.HasSuffix(path, "/") {
-		path = path[:len(path)-1]
+		return logical.ErrorResponse("cannot write to a directory path"), nil
 	}
 
 	// JSON encode the data

--- a/vault/logical_cubbyhole.go
+++ b/vault/logical_cubbyhole.go
@@ -159,22 +159,24 @@ func (b *CubbyholeBackend) handleList(
 		return nil, fmt.Errorf("[ERR] cubbyhole list: Client token empty")
 	}
 
+	// Right now we only handle directories, so ensure it ends with /; however,
+	// some physical backends may not handle the "/" case properly, so only add
+	// it if we're not listing the root
+	path := req.Path
+	if path != "" && !strings.HasSuffix(path, "/") {
+		path = path + "/"
+	}
+
 	// List the keys at the prefix given by the request
-	keys, err := req.Storage.List(req.ClientToken + "/" + req.Path)
+	keys, err := req.Storage.List(req.ClientToken + "/" + path)
 	if err != nil {
 		return nil, err
 	}
 
-	// Strip the token; also, add the path for the same reason as in
-	// passthrough
+	// Strip the token
 	strippedKeys := make([]string, len(keys))
 	for i, key := range keys {
-		ret := strings.TrimPrefix(key, req.ClientToken+"/")
-		if ret == "" {
-			strippedKeys[i] = "."
-		} else {
-			strippedKeys[i] = ret
-		}
+		strippedKeys[i] = strings.TrimPrefix(key, req.ClientToken+"/")
 	}
 
 	// Generate the response

--- a/vault/logical_cubbyhole.go
+++ b/vault/logical_cubbyhole.go
@@ -117,11 +117,6 @@ func (b *CubbyholeBackend) handleWrite(
 		return nil, fmt.Errorf("missing data fields")
 	}
 
-	path := req.Path
-	if strings.HasSuffix(path, "/") {
-		return logical.ErrorResponse("cannot write to a directory path"), nil
-	}
-
 	// JSON encode the data
 	buf, err := json.Marshal(req.Data)
 	if err != nil {
@@ -130,7 +125,7 @@ func (b *CubbyholeBackend) handleWrite(
 
 	// Write out a new key
 	entry := &logical.StorageEntry{
-		Key:   req.ClientToken + "/" + path,
+		Key:   req.ClientToken + "/" + req.Path,
 		Value: buf,
 	}
 	if err := req.Storage.Put(entry); err != nil {

--- a/vault/logical_cubbyhole.go
+++ b/vault/logical_cubbyhole.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/vault/logical"
@@ -167,8 +166,6 @@ func (b *CubbyholeBackend) handleList(
 	for i, key := range keys {
 		strippedKeys[i] = req.MountPoint + req.Path + strings.TrimPrefix(key, req.ClientToken+"/")
 	}
-
-	sort.Strings(strippedKeys)
 
 	// Generate the response
 	return logical.ListResponse(strippedKeys), nil

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -165,6 +165,11 @@ func (b *PassthroughBackend) handleWrite(
 		return logical.ErrorResponse("missing data fields"), nil
 	}
 
+	path := req.Path
+	if strings.HasSuffix(path, "/") {
+		path = path[:len(path)-1]
+	}
+
 	// Check if there is a ttl key; verify parseability if so
 	var ttl string
 	ttl = data.Get("ttl").(string)
@@ -190,7 +195,7 @@ func (b *PassthroughBackend) handleWrite(
 
 	// Write out a new key
 	entry := &logical.StorageEntry{
-		Key:   req.Path,
+		Key:   path,
 		Value: buf,
 	}
 	if err := req.Storage.Put(entry); err != nil {
@@ -223,7 +228,11 @@ func (b *PassthroughBackend) handleList(
 	// path and let users do what they wish.
 	retKeys := make([]string, len(keys))
 	for i, k := range keys {
-		retKeys[i] = req.MountPoint + req.Path + k
+		if k == "" {
+			retKeys[i] = "."
+		} else {
+			retKeys[i] = k
+		}
 	}
 
 	// Generate the response

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -167,7 +167,7 @@ func (b *PassthroughBackend) handleWrite(
 
 	path := req.Path
 	if strings.HasSuffix(path, "/") {
-		path = path[:len(path)-1]
+		return logical.ErrorResponse("cannot write to a directory path"), nil
 	}
 
 	// Check if there is a ttl key; verify parseability if so

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -165,11 +165,6 @@ func (b *PassthroughBackend) handleWrite(
 		return logical.ErrorResponse("missing data fields"), nil
 	}
 
-	path := req.Path
-	if strings.HasSuffix(path, "/") {
-		return logical.ErrorResponse("cannot write to a directory path"), nil
-	}
-
 	// Check if there is a ttl key; verify parseability if so
 	var ttl string
 	ttl = data.Get("ttl").(string)
@@ -195,7 +190,7 @@ func (b *PassthroughBackend) handleWrite(
 
 	// Write out a new key
 	entry := &logical.StorageEntry{
-		Key:   path,
+		Key:   req.Path,
 		Value: buf,
 	}
 	if err := req.Storage.Put(entry); err != nil {

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -226,9 +225,6 @@ func (b *PassthroughBackend) handleList(
 	for i, k := range keys {
 		retKeys[i] = req.MountPoint + req.Path + k
 	}
-
-	// Sort
-	sort.Strings(retKeys)
 
 	// Generate the response
 	return logical.ListResponse(retKeys), nil

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -218,8 +219,19 @@ func (b *PassthroughBackend) handleList(
 		return nil, err
 	}
 
+	// A list of an actual key returns "" in the list, which can cause nasty
+	// things downstream with JSON conversion, including in Go. So, prepend the
+	// path and let users do what they wish.
+	retKeys := make([]string, len(keys))
+	for i, k := range keys {
+		retKeys[i] = req.MountPoint + req.Path + k
+	}
+
+	// Sort
+	sort.Strings(retKeys)
+
 	// Generate the response
-	return logical.ListResponse(keys), nil
+	return logical.ListResponse(retKeys), nil
 }
 
 func (b *PassthroughBackend) GeneratesLeases() bool {

--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -65,7 +65,9 @@ over operations. The capabilities are:
 
   * `delete` - Delete the value at a path.
 
-  * `list` - List values at a path.
+  * `list` - List values at a path. Note that the keys returned by a `list`
+    operation are *not* filtered by policies. You should not store
+    sensitive/secret values in keys.
 
   * `sudo` - Gain access to paths that are _root-protected_. This is _additive_
     to other capabilities, so a path that requires `sudo` access will also

--- a/website/source/docs/http/index.html.md
+++ b/website/source/docs/http/index.html.md
@@ -21,7 +21,7 @@ This documentation is only for the v1 API.
 ~> **Backwards compatibility:** At the current version, Vault does
 not yet promise backwards compatibility even with the v1 prefix. We'll
 remove this warning when this policy changes. We expect we'll reach API
-stability by Vault 0.3.
+stability by Vault 0.7.
 
 ## Transport
 
@@ -33,23 +33,28 @@ depending on user settings.
 
 ## Authentication
 
-Once the Vault is unsealed, every other operation requires
-a _client token_. A user may have a client token explicitly.
-The client token must be sent as the `X-Vault-Token` HTTP header.
+Once the Vault is unsealed, every other operation requires a _client token_. A
+user may have a client token sent to her.  The client token must be sent as the
+`X-Vault-Token` HTTP header.
 
-Otherwise, a client token can be retrieved via
-[authentication backends](/docs/auth/index.html).
+Otherwise, a client token can be retrieved via [authentication
+backends](/docs/auth/index.html).
 
-Each authentication backend will have one or more unauthenticated
-login endpoints. These endpoints can be reached without any authentication,
-and are used for authentication itself. These endpoints are specific
-to each authentication backend.
+Each authentication backend will have one or more unauthenticated login
+endpoints. These endpoints can be reached without any authentication, and are
+used for authentication itself. These endpoints are specific to each
+authentication backend.
 
 Login endpoints for authentication backends that generate an identity will be
 sent down via JSON. The resulting token should be saved on the client or passed
 via the `X-Vault-Token` header for future requests.
 
-## Reading and Writing Secrets
+## Reading, Writing, and Listing Secrets
+
+Different backends implement different APIs according to their functionality.
+The examples below are created with the `generic` backend, which acts like a
+Key/Value store. Read the documentation for a particular backend for detailed
+information on its API; this simply provides a general overview.
 
 Reading a secret via the HTTP API is done by issuing a GET using the
 following URL:
@@ -58,7 +63,8 @@ following URL:
 /v1/secret/foo
 ```
 
-This maps to `secret/foo` where `foo` is the key in the `secret/` backend/
+This maps to `secret/foo` where `foo` is the key in the `secret/` mount, which
+is mounted by default on a fresh Vault install and is of type `generic`.
 
 Here is an example of reading a secret using cURL:
 
@@ -67,6 +73,18 @@ $ curl \
     -H "X-Vault-Token: f3b09679-3001-009d-2b80-9c306ab81aa6" \
     -X GET \
     http://127.0.0.1:8200/v1/secret/foo
+```
+
+You can list secrets as well. To do this, either issue a GET with the query
+parameter `list=true`, or you can use the LIST HTTP verb. For the `generic`
+backend, listing is allowed on directories only, and returns the keys in the
+given directory:
+
+```shell
+$ curl \
+    -H "X-Vault-Token: f3b09679-3001-009d-2b80-9c306ab81aa6" \
+    -X GET \
+    http://127.0.0.1:8200/v1/secret?list=true
 ```
 
 To write a secret, issue a POST on the following URL:
@@ -93,6 +111,11 @@ $ curl \
     -d '{"value":"bar"}' \
     http://127.0.0.1:8200/v1/secret/baz
 ```
+
+Vault currently considers PUT and POST to be synonyms. Rather than trust a
+client's stated intentions, Vault backends can implement an existence check to
+discover whether an operation is actually a create or update operation based on
+the data already stored within Vault.
 
 For more examples, please look at the Vault API client.
 

--- a/website/source/docs/http/index.html.md
+++ b/website/source/docs/http/index.html.md
@@ -21,7 +21,7 @@ This documentation is only for the v1 API.
 ~> **Backwards compatibility:** At the current version, Vault does
 not yet promise backwards compatibility even with the v1 prefix. We'll
 remove this warning when this policy changes. We expect we'll reach API
-stability by Vault 0.7.
+stability by Vault 1.0.
 
 ## Transport
 

--- a/website/source/docs/secrets/cubbyhole/index.html.md
+++ b/website/source/docs/secrets/cubbyhole/index.html.md
@@ -95,7 +95,8 @@ As expected, the value previously set is returned to us.
   <dt>Description</dt>
   <dd>
     Returns a list of secret entries at the specified location. Folders are
-    suffixed with `/`.
+    suffixed with `/`. The input must be a folder; list on a file will not
+    return a value.
   </dd>
 
   <dt>Method</dt>
@@ -119,7 +120,7 @@ As expected, the value previously set is returned to us.
   {
     "auth": null,
     "data": {
-      "keys": ["cubbyhole/foo", "cubbyhole/foo/"]
+      "keys": ["foo", "foo/"]
     },
     "lease_duration": 2592000,
     "lease_id": "",

--- a/website/source/docs/secrets/cubbyhole/index.html.md
+++ b/website/source/docs/secrets/cubbyhole/index.html.md
@@ -96,7 +96,9 @@ As expected, the value previously set is returned to us.
   <dd>
     Returns a list of secret entries at the specified location. Folders are
     suffixed with `/`. The input must be a folder; list on a file will not
-    return a value.
+    return a value. Note that no policy-based filtering is performed on
+    returned keys; it is not recommended to put sensitive or secret values as
+    key names. The values themselves are not accessible via this command.
   </dd>
 
   <dt>Method</dt>

--- a/website/source/docs/secrets/cubbyhole/index.html.md
+++ b/website/source/docs/secrets/cubbyhole/index.html.md
@@ -23,7 +23,7 @@ Also unlike the `generic` backend, because the cubbyhole's lifetime is linked
 to an authentication token, there is no concept of a lease or lease TTL for
 values contained in the token's cubbyhole.
 
-Writing to a key in the `cubbyhole/` backend will replace the old value,
+Writing to a key in the `cubbyhole` backend will replace the old value;
 the sub-fields are not merged together.
 
 ## Quick Start
@@ -52,7 +52,6 @@ As expected, the value previously set is returned to us.
 
 ## API
 
-### /cubbyhole
 #### GET
 
 <dl class="api">
@@ -86,6 +85,47 @@ As expected, the value previously set is returned to us.
       "renewable": false
     }
     ```
+
+  </dd>
+</dl>
+
+#### LIST
+
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Returns a list of secret entries at the specified location. Folders are
+    suffixed with `/`.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/cubbyhole/<path>?list=true`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+     None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+  The example below shows output for a query path of `cubbyhole/` when there
+  are secrets at `cubbyhole/foo` and `cubbyhole/foo/bar`; note the difference
+  in the two entries.
+
+  ```javascript
+  {
+    "auth": null,
+    "data": {
+      "keys": ["cubbyhole/foo", "cubbyhole/foo/"]
+    },
+    "lease_duration": 2592000,
+    "lease_id": "",
+    "renewable": false
+  }
+  ```
 
   </dd>
 </dl>

--- a/website/source/docs/secrets/generic/index.html.md
+++ b/website/source/docs/secrets/generic/index.html.md
@@ -16,7 +16,7 @@ the getting started guide, you interacted with a generic secret backend
 via the `secret/` prefix that Vault mounts by default. You can mount as many
 of these backends at different mount points as you like.
 
-Writing to a key in the `secret/` backend will replace the old value;
+Writing to a key in the `generic` backend will replace the old value;
 sub-fields are not merged together.
 
 This backend honors the distinction between the `create` and `update`
@@ -39,9 +39,6 @@ to the Vault server if it results in clients accessing the value very frequently
 Also note that setting `ttl` does not actually expire the data; it is
 informational only.
 
-N.B.: Prior to version 0.3, the `ttl` parameter was called `lease`. Both will
-work for 0.3, but in 0.4 `lease` will be removed.
-
 As an example, we can write a new key "foo" to the generic backend
 mounted at "secret/" by default:
 
@@ -58,8 +55,7 @@ We can test this by doing a read:
 ```
 $ vault read secret/foo
 Key             Value
-ttl_seconds     3600
-ttl             1h
+lease_duration  3600
 zip             zap
 ```
 
@@ -69,7 +65,6 @@ seconds (one hour) as specified.
 
 ## API
 
-### /secret
 #### GET
 
 <dl class="api">
@@ -97,6 +92,47 @@ seconds (one hour) as specified.
     "auth": null,
     "data": {
       "foo": "bar"
+    },
+    "lease_duration": 2592000,
+    "lease_id": "",
+    "renewable": false
+  }
+  ```
+
+  </dd>
+</dl>
+
+#### LIST
+
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Returns a list of secret entries at the specified location. Folders are
+    suffixed with `/`.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/secret/<path>?list=true`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+     None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+  The example below shows output for a query path of `secret/` when there are
+  secrets at `secret/foo` and `secret/foo/bar`; note the difference in the two
+  entries.
+
+  ```javascript
+  {
+    "auth": null,
+    "data": {
+      "keys": ["secret/foo", "secret/foo/"]
     },
     "lease_duration": 2592000,
     "lease_id": "",

--- a/website/source/docs/secrets/generic/index.html.md
+++ b/website/source/docs/secrets/generic/index.html.md
@@ -109,7 +109,9 @@ seconds (one hour) as specified.
   <dd>
     Returns a list of secret entries at the specified location. Folders are
     suffixed with `/`. The input must be a folder; list on a file will not
-    return a value.
+    return a value. Note that no policy-based filtering is performed on
+    returned keys; it is not recommended to put sensitive or secret values as
+    key names. The values themselves are not accessible via this command.
   </dd>
 
   <dt>Method</dt>

--- a/website/source/docs/secrets/generic/index.html.md
+++ b/website/source/docs/secrets/generic/index.html.md
@@ -108,7 +108,8 @@ seconds (one hour) as specified.
   <dt>Description</dt>
   <dd>
     Returns a list of secret entries at the specified location. Folders are
-    suffixed with `/`.
+    suffixed with `/`. The input must be a folder; list on a file will not
+    return a value.
   </dd>
 
   <dt>Method</dt>
@@ -132,7 +133,7 @@ seconds (one hour) as specified.
   {
     "auth": null,
     "data": {
-      "keys": ["secret/foo", "secret/foo/"]
+      "keys": ["foo", "foo/"]
     },
     "lease_duration": 2592000,
     "lease_id": "",


### PR DESCRIPTION
This puts support for the "list" command into the CLI and API and turns on the ListOperation handler capability. Currently, "generic" and "cubbyhole" will (automatically) work.

Fixes #111 
