### PR TITLE
improve documentation for available log levels

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -431,7 +431,8 @@ General Options:
                       production!
 
   -log-level=info     Log verbosity. Defaults to "info", will be outputted
-                      to stderr.
+                      to stderr. Supported values: "trace", "debug", "info",
+                      "warn", "err"
 
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
Available log levels aren't documented anywhere. This PR enumerates available log levels (as hard-coded into server.go). More documentation (not in this PR) is necessary to detail what type of information is logged for different values of log-level.