### PR TITLE
Fix warnings returned by `make vet`

### DIFF
--- a/vault/policy.go
+++ b/vault/policy.go
@@ -66,7 +66,6 @@ func (p *PathPolicy) TakesPrecedence(other *PathPolicy) bool {
 	default:
 		panic("missing case")
 	}
-	return false
 }
 
 // Parse is used to parse the specified ACL rules into an

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -136,7 +136,7 @@ func TestPolicyStore_v1Upgrade(t *testing.T) {
 
 	// Put a V1 record
 	raw := `path "foo" { policy = "read" }`
-	ps.view.Put(&logical.StorageEntry{"old", []byte(raw)})
+	ps.view.Put(&logical.StorageEntry{Key: "old", Value: []byte(raw)})
 
 	// Do a read
 	p, err := ps.GetPolicy("old")


### PR DESCRIPTION
$GOPATH/src/github.com/hashicorp/vault/vault/policy.go:69: unreachable code
$GOPATH/src/github.com/hashicorp/vault/vault/policy_store_test.go:139: github.com/hashicorp/vault/logical.StorageEntry composite literal uses unkeyed fields