### PR TITLE
Fix "Edit this page" link

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/hashicorp/middleman-hashicorp.git
-  revision: 482d44991f3292ae36e725ef19a78df027683d1c
+  revision: 53f13a119da3f8874d94135b81efc9f2b681935c
   specs:
     middleman-hashicorp (0.1.0)
       bootstrap-sass (~> 3.3)
@@ -76,7 +76,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (1.8.3)
-    kramdown (1.8.0)
+    kramdown (1.9.0)
     less (2.6.0)
       commonjs (~> 0.2.7)
     libv8 (3.16.14.11)

--- a/website/config.rb
+++ b/website/config.rb
@@ -10,6 +10,8 @@ activate :hashicorp do |h|
   h.bintray_repo    = "mitchellh/vault"
   h.bintray_user    = "mitchellh"
   h.bintray_key     = ENV["BINTRAY_API_KEY"]
+  h.github_slug     = "hashicorp/vault"
+  h.website_root    = "website"
 
   h.minify_javascript = false
 end

--- a/website/source/layouts/_footer.erb
+++ b/website/source/layouts/_footer.erb
@@ -8,7 +8,7 @@
 						<li class="li-under"><a href="/community.html">Community</a></li>
 						<li class="li-under"><a href="/security.html">Security</a></li>
 						<% if current_page.url != '/' %>
-							<li class="li-under"><a href="https://github.com/hashicorp/vault/<%= github_path current_page %>">Edit this page</a></li>
+							<li class="li-under"><a href="<%= github_url :current_page %>">Edit this page</a></li>
 						<% end %>
 					</ul>
 				</div>


### PR DESCRIPTION
The new `github_url` method should work better than `github_path`, which made some inaccurate assumptions. See https://github.com/hashicorp/middleman-hashicorp/pull/14/files.