### PR TITLE
Add a cleanLeaderPrefix function to clean up stale leader entries in core/leader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ DEPRECATIONS/BREAKING CHANGES:
 
 IMPROVEMENTS:
 
- * init: Base64-encoded PGP keys can be used with the CLI for `init` and `rekey` operations [GH-653]
  * core: Tokens can now renew themselves [GH-455]
+ * core: Stale leader entries will now be reaped [GH-679]
+ * init: Base64-encoded PGP keys can be used with the CLI for `init` and `rekey` operations [GH-653]
  * logical: Responses now contain a "warnings" key containing a list of warnings returned from the server. These are conditions that did not require failing an operation, but of which the client should be aware. [GH-676]
 
 BUG FIXES:

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -1204,7 +1204,7 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 	}
 
 	// Give time for the entries to clear out; it is conservative at 1/second
-	time.Sleep(7 * time.Second)
+	time.Sleep(10 * leaderPrefixCleanDelay)
 
 	entries, err = core2.barrier.List(coreLeaderPrefix)
 	if err != nil {


### PR DESCRIPTION
Fixes #679.