### PR TITLE
Remove tabs from terminal output

### DIFF
--- a/website/source/docs/auth/cert.html.md
+++ b/website/source/docs/auth/cert.html.md
@@ -21,8 +21,8 @@ from an external source.
 
 ### Via the CLI
 ```
-vault auth -method=cert \
-  -ca-cert=ca.pem -client-cert=cert.pem -client-key=key.pem
+$ vault auth -method=cert \
+    -ca-cert=ca.pem -client-cert=cert.pem -client-key=key.pem
 ```
 
 ### Via the API
@@ -31,8 +31,8 @@ certificate and when the login endpoint is hit, the auth backend will determine
 if there is a matching trusted certificate to authenticate the client.
 
 ```
-curl --cacert ca.pem --cert cert.pem --key key.pem \
-  $VAULT_ADDR/v1/auth/cert/login -XPOST
+$ curl --cacert ca.pem --cert cert.pem --key key.pem \
+    $VAULT_ADDR/v1/auth/cert/login -XPOST
 ```
 
 ## Configuration
@@ -57,7 +57,11 @@ trusted certificates that are allowed to authenticate. An example is shown below
 Use `vault path-help` for more details.
 
 ```
-$ vault write auth/cert/certs/web display_name=web policies=web,prod certificate=@web-cert.pem lease=3600
+$ vault write auth/cert/certs/web \
+    display_name=web \
+    policies=web,prod \
+    certificate=@web-cert.pem \
+    lease=3600
 ...
 ```
 

--- a/website/source/docs/auth/github.html.md
+++ b/website/source/docs/auth/github.html.md
@@ -49,7 +49,7 @@ Prior to using the GitHub auth backend, it must be configured. To
 configure it, use the `/config` endpoint with the following arguments:
 
   * `organization` (string, required) - The organization name a user must
-       be a part of to authenticate.
+     be a part of to authenticate.
 
 ###Generate a GitHub Personal Access Token
 Access your Personal Access Tokens in GitHub at [https://github.com/settings/tokens](https://github.com/settings/tokens).

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -46,20 +46,20 @@ The response will be in JSON. For example:
 
 ```javascript
 {
-  "lease_id":"",
-  "renewable":false,
-  "lease_duration":0,
-  "data":null,
-  "auth":{
-    "client_token":"c4f280f6-fdb2-18eb-89d3-589e2e834cdb",
-    "policies":[
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": null,
+  "auth": {
+    "client_token": "c4f280f6-fdb2-18eb-89d3-589e2e834cdb",
+    "policies": [
       "root"
     ],
-    "metadata":{
-      "username":"mitchellh"
+    "metadata": {
+      "username": "mitchellh"
     },
-    "lease_duration":0,
-    "renewable":false
+    "lease_duration": 0,
+    "renewable": false
   }
 }
 ```
@@ -87,13 +87,13 @@ Use `vault path-help` for more details.
 
 ```
 $ vault write auth/ldap/config url="ldap://ldap.forumsys.com" \
-		userattr=uid \
-        userdn="dc=example,dc=com" \
-        groupdn="dc=example,dc=com" \
-        upndomain="forumsys.com" \
-        certificate=@ldap_ca_cert.pem \
-        insecure_tls=false \
-        starttls=true
+    userattr=uid \
+    userdn="dc=example,dc=com" \
+    groupdn="dc=example,dc=com" \
+    upndomain="forumsys.com" \
+    certificate=@ldap_ca_cert.pem \
+    insecure_tls=false \
+    starttls=true
 ...
 ```
 

--- a/website/source/docs/auth/mfa.html.md
+++ b/website/source/docs/auth/mfa.html.md
@@ -61,7 +61,7 @@ options to behave differently (see Duo configuration below).
 
 ### Duo
 
-The Duo MFA type is configured through two paths: `duo/config` and `duo/access`. 
+The Duo MFA type is configured through two paths: `duo/config` and `duo/access`.
 
 `duo/access` contains connection information for the Duo Auth API. To configure:
 

--- a/website/source/docs/auth/token.html.md
+++ b/website/source/docs/auth/token.html.md
@@ -118,11 +118,11 @@ of the header should be "X-Vault-Token" and the value should be the token.
       ```javascript
     {
       "auth": {
-          "client_token": "ABCD",
-          "policies": ["web", "stage"],
-          "metadata": {"user": "armon"},
-          "lease_duration": 3600,
-          "renewable": true,
+        "client_token": "ABCD",
+        "policies": ["web", "stage"],
+        "metadata": {"user": "armon"},
+        "lease_duration": 3600,
+        "renewable": true,
       }
     }
     ```
@@ -346,11 +346,11 @@ of the header should be "X-Vault-Token" and the value should be the token.
     ```javascript
     {
       "auth": {
-          "client_token": "ABCD",
-          "policies": ["web", "stage"],
-          "metadata": {"user": "armon"},
-          "lease_duration": 3600,
-          "renewable": true,
+        "client_token": "ABCD",
+        "policies": ["web", "stage"],
+        "metadata": {"user": "armon"},
+        "lease_duration": 3600,
+        "renewable": true,
       }
     }
     ```

--- a/website/source/docs/auth/userpass.html.md
+++ b/website/source/docs/auth/userpass.html.md
@@ -23,8 +23,8 @@ passwords from an external source.
 
 ```
 $ vault auth -method=userpass \
-  username=foo \
-  password=bar
+    username=foo \
+    password=bar
 ```
 
 #### Via the API
@@ -42,20 +42,20 @@ The response will be in JSON. For example:
 
 ```javascript
 {
-  "lease_id":"",
-  "renewable":false,
-  "lease_duration":0,
-  "data":null,
-  "auth":{
-    "client_token":"c4f280f6-fdb2-18eb-89d3-589e2e834cdb",
-    "policies":[
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": null,
+  "auth": {
+    "client_token": "c4f280f6-fdb2-18eb-89d3-589e2e834cdb",
+    "policies": [
       "root"
     ],
-    "metadata":{
-      "username":"mitchellh"
+    "metadata": {
+      "username": "mitchellh"
     },
-    "lease_duration":0,
-    "renewable":false
+    "lease_duration": 0,
+    "renewable": false
   }
 }
 ```
@@ -83,7 +83,9 @@ users that are allowed to authenticate. An example is shown below.
 Use `vault path-help` for more details.
 
 ```
-$ vault write auth/userpass/users/mitchellh password=foo policies=root
+$ vault write auth/userpass/users/mitchellh \
+    password=foo \
+    policies=root
 ...
 ```
 

--- a/website/source/docs/commands/read-write.html.md
+++ b/website/source/docs/commands/read-write.html.md
@@ -22,7 +22,8 @@ to discover the paths.
 To write data to Vault, you use `vault write`. It is very easy to use:
 
 ```
-$ vault write secret/password value=itsasecret
+$ vault write secret/password \
+    value=itsasecret
 ...
 ```
 
@@ -30,7 +31,9 @@ The above writes a value to `secret/password`. As mentioned in the getting
 started guide, multiple values can also be written:
 
 ```
-$ vault write secret/password value=itsasecret username=something
+$ vault write secret/password \
+    value=itsasecret \
+    username=something
 ...
 ```
 

--- a/website/source/docs/http/index.html.md
+++ b/website/source/docs/http/index.html.md
@@ -63,10 +63,10 @@ This maps to `secret/foo` where `foo` is the key in the `secret/` backend/
 Here is an example of reading a secret using cURL:
 
 ```shell
-curl \
-  -H "X-Vault-Token: f3b09679-3001-009d-2b80-9c306ab81aa6" \
-  -X GET \
-   http://127.0.0.1:8200/v1/secret/foo
+$ curl \
+    -H "X-Vault-Token: f3b09679-3001-009d-2b80-9c306ab81aa6" \
+    -X GET \
+    http://127.0.0.1:8200/v1/secret/foo
 ```
 
 To write a secret, issue a POST on the following URL:
@@ -86,12 +86,12 @@ with a JSON body like:
 Here is an example of writing a secret using cURL:
 
 ```shell
-curl \
-  -H "X-Vault-Token: f3b09679-3001-009d-2b80-9c306ab81aa6" \
-  -H "Content-Type: application/json" \
-  -X POST \
-  -d '{"value":"bar"}' \
-  http://127.0.0.1:8200/v1/secret/baz
+$ curl \
+    -H "X-Vault-Token: f3b09679-3001-009d-2b80-9c306ab81aa6" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    -d '{"value":"bar"}' \
+    http://127.0.0.1:8200/v1/secret/baz
 ```
 
 For more examples, please look at the Vault API client.

--- a/website/source/docs/http/sys-health.html.md
+++ b/website/source/docs/http/sys-health.html.md
@@ -33,13 +33,13 @@ description: |-
 	<dt>Returns</dt>
 	<dd>
 
-```
-{
-    "initialized": true,
-    "sealed": false,
-    "standby": false
-}
-```
+    ```javascript
+    {
+      "initialized": true,
+      "sealed": false,
+      "standby": false
+    }
+    ```
 
     Status Codes:
 

--- a/website/source/docs/secrets/aws/index.html.md
+++ b/website/source/docs/secrets/aws/index.html.md
@@ -116,27 +116,27 @@ The root credentials need permission to perform various IAM actions. These are t
 
 ```javascript
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreateAccessKey",
-                "iam:CreateUser",
-                "iam:PutUserPolicy",
-                "iam:ListGroupsForUser",
-                "iam:ListUserPolicies",
-                "iam:ListAccessKeys",
-                "iam:DeleteAccessKey",
-                "iam:DeleteUserPolicy",
-                "iam:RemoveUserFromGroup",
-                "iam:DeleteUser"
-            ],
-            "Resource": [
-                "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:user/vault-*"
-            ]
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateAccessKey",
+        "iam:CreateUser",
+        "iam:PutUserPolicy",
+        "iam:ListGroupsForUser",
+        "iam:ListUserPolicies",
+        "iam:ListAccessKeys",
+        "iam:DeleteAccessKey",
+        "iam:DeleteUserPolicy",
+        "iam:RemoveUserFromGroup",
+        "iam:DeleteUser"
+      ],
+      "Resource": [
+        "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:user/vault-*"
+      ]
+    }
+  ]
 }
 ```
 
@@ -286,9 +286,9 @@ interactive help output.
 
     ```javascript
     {
-        "data": {
-            "policy": "..."
-        }
+      "data": {
+        "policy": "..."
+      }
     }
     ```
 
@@ -346,10 +346,10 @@ interactive help output.
 
     ```javascript
     {
-        "data": {
-            "access_key": "...",
-            "secret_key": "..."
-        }
+      "data": {
+        "access_key": "...",
+        "secret_key": "..."
+      }
     }
     ```
 

--- a/website/source/docs/secrets/cassandra/index.html.md
+++ b/website/source/docs/secrets/cassandra/index.html.md
@@ -38,7 +38,9 @@ writing one or more hosts, a username, and a password:
 
 ```text
 $ vault write cassandra/config/connection \
-    hosts=localhost username=cassandra password=cassandra
+    hosts=localhost \
+    username=cassandra \
+    password=cassandra
 ```
 
 In this case, we've configured Vault with the user "cassandra" and password "cassandra",
@@ -258,12 +260,12 @@ subpath for interactive help output.
 
     ```javascript
     {
-        "data": {
-            "creation_cql": "CREATE USER...",
-            "revocation_cql": "DROP USER...",
-            "lease": "12h",
-            "lease_grace_period": "1h"
-        }
+      "data": {
+        "creation_cql": "CREATE USER...",
+        "revocation_cql": "DROP USER...",
+        "lease": "12h",
+        "lease_grace_period": "1h"
+      }
     }
     ```
 
@@ -321,10 +323,10 @@ subpath for interactive help output.
 
     ```javascript
     {
-        "data": {
-            "username": "vault-root-1430158508-126",
-            "password": "132ae3ef-5a64-7499-351e-bfe59f3a2a21"
-        }
+      "data": {
+        "username": "vault-root-1430158508-126",
+        "password": "132ae3ef-5a64-7499-351e-bfe59f3a2a21"
+      }
     }
     ```
 

--- a/website/source/docs/secrets/consul/index.html.md
+++ b/website/source/docs/secrets/consul/index.html.md
@@ -31,7 +31,9 @@ Next, we must configure Vault to know how to contact Consul.
 This is done by writing the access information:
 
 ```
-$ vault write consul/config/access address=127.0.0.1:8500 token=root
+$ vault write consul/config/access \
+    address=127.0.0.1:8500 \
+    token=root
 Success! Data written to: consul/config/access
 ```
 
@@ -181,9 +183,9 @@ Permission denied
 
     ```javascript
     {
-        "data": {
-            "policy": "abcdef="
-        }
+      "data": {
+        "policy": "abcdef="
+      }
     }
     ```
 
@@ -240,9 +242,9 @@ Permission denied
 
     ```javascript
     {
-        "data": {
-            "token": "973a31ea-1ec4-c2de-0f63-623f477c2510"
-        }
+      "data": {
+        "token": "973a31ea-1ec4-c2de-0f63-623f477c2510"
+      }
     }
     ```
 

--- a/website/source/docs/secrets/cubbyhole/index.html.md
+++ b/website/source/docs/secrets/cubbyhole/index.html.md
@@ -34,7 +34,8 @@ As an example, we can write a new key "foo" to the `cubbyhole` backend, which
 is mounted at `cubbyhole/`:
 
 ```
-$ vault write cubbyhole/foo zip=zap
+$ vault write cubbyhole/foo \
+    zip=zap
 Success! Data written to: cubbyhole/foo
 ```
 
@@ -74,17 +75,17 @@ As expected, the value previously set is returned to us.
   <dt>Returns</dt>
   <dd>
 
-  ```javascript
-  {
+    ```javascript
+    {
       "auth": null,
       "data": {
-          "foo": "bar"
+        "foo": "bar"
       },
       "lease_duration": 0,
       "lease_id": "",
       "renewable": false
-  }
-  ```
+    }
+    ```
 
   </dd>
 </dl>

--- a/website/source/docs/secrets/generic/index.html.md
+++ b/website/source/docs/secrets/generic/index.html.md
@@ -39,7 +39,9 @@ As an example, we can write a new key "foo" to the generic backend
 mounted at "secret/" by default:
 
 ```
-$ vault write secret/foo zip=zap ttl=1h
+$ vault write secret/foo \
+    zip=zap \
+    ttl=1h
 Success! Data written to: secret/foo
 ```
 
@@ -48,10 +50,10 @@ We can test this by doing a read:
 
 ```
 $ vault read secret/foo
-Key           	Value
-ttl_seconds	3600
-ttl		1h
-zip           	zap
+Key             Value
+ttl_seconds     3600
+ttl             1h
+zip             zap
 ```
 
 As expected, we get the value previously set back as well as our custom TTL
@@ -85,16 +87,16 @@ seconds (one hour) as specified.
 
   ```javascript
   {
-      "auth": null,
-      "data": {
-          "foo": "bar"
-      },
-      "lease_duration": 2592000,
-      "lease_id": "",
-      "renewable": false
+    "auth": null,
+    "data": {
+      "foo": "bar"
+    },
+    "lease_duration": 2592000,
+    "lease_id": "",
+    "renewable": false
   }
   ```
-  
+
   </dd>
 </dl>
 

--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -40,7 +40,8 @@ Next, we must configure Vault to know how to connect to the MySQL
 instance. This is done by providing a DSN (Data Source Name):
 
 ```
-$ vault write mysql/config/connection value="root:root@tcp(192.168.33.10:3306)/"
+$ vault write mysql/config/connection \
+    value="root:root@tcp(192.168.33.10:3306)/"
 Success! Data written to: mysql/config/connection
 ```
 
@@ -53,7 +54,9 @@ Optionally, we can configure the lease settings for credentials generated
 by Vault. This is done by writing to the `config/lease` key:
 
 ```
-$ vault write mysql/config/lease lease=1h lease_max=24h
+$ vault write mysql/config/lease \
+    lease=1h \
+    lease_max=24h
 Success! Data written to: mysql/config/lease
 ```
 
@@ -67,7 +70,8 @@ to a policy used to generate those credentials. For example, lets create
 a "readonly" role:
 
 ```
-$ vault write mysql/roles/readonly sql="CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';GRANT SELECT ON *.* TO '{{name}}'@'%';"
+$ vault write mysql/roles/readonly \
+    sql="CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';GRANT SELECT ON *.* TO '{{name}}'@'%';"
 Success! Data written to: mysql/roles/readonly
 ```
 
@@ -245,9 +249,9 @@ allowed to read.
 
     ```javascript
     {
-        "data": {
-            "sql": "CREATE USER..."
-        }
+      "data": {
+        "sql": "CREATE USER..."
+      }
     }
     ```
 
@@ -305,10 +309,10 @@ allowed to read.
 
     ```javascript
     {
-        "data": {
-            "username": "root-aefa635a-18",
-            "password": "132ae3ef-5a64-7499-351e-bfe59f3a2a21"
-        }
+      "data": {
+        "username": "root-aefa635a-18",
+        "password": "132ae3ef-5a64-7499-351e-bfe59f3a2a21"
+      }
     }
     ```
 

--- a/website/source/docs/secrets/pki/index.html.md
+++ b/website/source/docs/secrets/pki/index.html.md
@@ -74,7 +74,8 @@ Successfully mounted 'pki' at 'pki'!
 Next, Vault must be configured with a root certificate and associated private key. This is done by writing the contents of a file or *stdin*:
 
 ```text
-$ vault write pki/config/ca pem_bundle="@ca_bundle.pem"
+$ vault write pki/config/ca \
+    pem_bundle="@ca_bundle.pem"
 Success! Data written to: pki/config/ca
 ```
 
@@ -99,7 +100,8 @@ Success! Data written to: pki/roles/example-dot-com
 By writing to the `roles/example-dot-com` path we are defining the `example-dot-com` role. To generate a new set of credentials, we simply write to the `issue` endpoint with that role name: Vault is now configured to create and manage certificates!
 
 ```text
-$ vault write pki/issue/example-dot-com common_name=blah.example.com
+$ vault write pki/issue/example-dot-com \
+    common_name=blah.example.com
 Key            	Value
 lease_id       	pki/issue/example-dot-com/819393b5-e1a1-9efd-b72f-4dc3a1972e31
 lease_duration 	259200
@@ -195,9 +197,9 @@ If you get stuck at any time, simply run `vault path-help pki` or with a subpath
 
     ```javascript
     {
-        "data": {
-            "certificate": "-----BEGIN CERTIFICATE-----\nMIIGmDCCBYCgAwIBAgIHBzEB3fTzhTANBgkqhkiG9w0BAQsFADCBjDELMAkGA1UE\n..."
-        }
+      "data": {
+        "certificate": "-----BEGIN CERTIFICATE-----\nMIIGmDCCBYCgAwIBAgIHBzEB3fTzhTANBgkqhkiG9w0BAQsFADCBjDELMAkGA1UE\n..."
+      }
     }
     ...
     ```
@@ -218,14 +220,20 @@ If you get stuck at any time, simply run `vault path-help pki` or with a subpath
     command similar to the following:<br/>
 
     ```text
-    curl -X POST --data "@cabundle.json" http://127.0.0.1:8200/v1/pki/config/ca -H X-Vault-Token:06b9d...
+    $ curl \
+        -H "X-Vault-Token:06b9d..." \
+        -X POST \
+        --data "@cabundle.json" \
+        http://127.0.0.1:8200/v1/pki/config/ca
     ```
 
     Note that if you provide the data through the HTTP API it must be
     JSON-formatted, with newlines replaced with `\n`, like so:
 
-    ```text
-    { "pem_bundle": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END CERTIFICATE-----" }
+    ```javascript
+    {
+      "pem_bundle": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END CERTIFICATE-----"
+    }
     ```
   </dd>
 
@@ -314,13 +322,13 @@ If you get stuck at any time, simply run `vault path-help pki` or with a subpath
   <dt>Returns</dt>
   <dd>
 
-  ```javascript
-  {
+    ```javascript
+    {
       "data": {
-          "success": true
+        "success": true
       }
-  }
-  ```
+    }
+    ```
 
   </dd>
 </dl>
@@ -383,20 +391,20 @@ If you get stuck at any time, simply run `vault path-help pki` or with a subpath
   <dt>Returns</dt>
   <dd>
 
-  ```javascript
-  {
+    ```javascript
+    {
       "lease_id": "pki/issue/test/7ad6cfa5-f04f-c62a-d477-f33210475d05",
       "renewable": false,
       "lease_duration": 21600,
       "data": {
-          "certificate": "-----BEGIN CERTIFICATE-----\nMIIDzDCCAragAwIBAgIUOd0ukLcjH43TfTHFG9qE0FtlMVgwCwYJKoZIhvcNAQEL\n...\numkqeYeO30g1uYvDuWLXVA==\n-----END CERTIFICATE-----\n",
-          "issuing_ca": "-----BEGIN CERTIFICATE-----\nMIIDUTCCAjmgAwIBAgIJAKM+z4MSfw2mMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV\n...\nG/7g4koczXLoUM3OQXd5Aq2cs4SS1vODrYmgbioFsQ3eDHd1fg==\n-----END CERTIFICATE-----\n",
-          "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAnVHfwoKsUG1GDVyWB1AFroaKl2ImMBO8EnvGLRrmobIkQvh+\n...\nQN351pgTphi6nlCkGPzkDuwvtxSxiCWXQcaxrHAL7MiJpPzkIBq1\n-----END RSA PRIVATE KEY-----\n",
-          "serial": "39:dd:2e:90:b7:23:1f:8d:d3:7d:31:c5:1b:da:84:d0:5b:65:31:58"
-      },
-      "auth": null
-  }
-  ```
+        "certificate": "-----BEGIN CERTIFICATE-----\nMIIDzDCCAragAwIBAgIUOd0ukLcjH43TfTHFG9qE0FtlMVgwCwYJKoZIhvcNAQEL\n...\numkqeYeO30g1uYvDuWLXVA==\n-----END CERTIFICATE-----\n",
+        "issuing_ca": "-----BEGIN CERTIFICATE-----\nMIIDUTCCAjmgAwIBAgIJAKM+z4MSfw2mMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV\n...\nG/7g4koczXLoUM3OQXd5Aq2cs4SS1vODrYmgbioFsQ3eDHd1fg==\n-----END CERTIFICATE-----\n",
+        "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAnVHfwoKsUG1GDVyWB1AFroaKl2ImMBO8EnvGLRrmobIkQvh+\n...\nQN351pgTphi6nlCkGPzkDuwvtxSxiCWXQcaxrHAL7MiJpPzkIBq1\n-----END RSA PRIVATE KEY-----\n",
+        "serial": "39:dd:2e:90:b7:23:1f:8d:d3:7d:31:c5:1b:da:84:d0:5b:65:31:58"
+        },
+        "auth": null
+    }
+    ```
 
   </dd>
 </dl>
@@ -434,13 +442,14 @@ If you get stuck at any time, simply run `vault path-help pki` or with a subpath
 
   <dt>Returns</dt>
   <dd>
-  ```javascript
-  {
+
+    ```javascript
+    {
       "data": {
-          "revocation_time": 1433269787
+        "revocation_time": 1433269787
       }
-  }
-  ```
+    }
+    ```
   </dd>
 </dl>
 
@@ -603,21 +612,21 @@ If you get stuck at any time, simply run `vault path-help pki` or with a subpath
 
     ```javascript
     {
-        "data": {
-            "allow_any_name": false,
-            "allow_ip_sans": true,
-            "allow_localhost": true,
-            "allow_subdomains": false,
-            "allow_token_displayname": false,
-            "allowed_base_domain": "example.com",
-            "client_flag": true,
-            "code_signing_flag": false,
-            "key_bits": 2048,
-            "key_type": "rsa",
-            "ttl": "6h",
-            "max_ttl": "12h",
-            "server_flag": true
-        }
+      "data": {
+        "allow_any_name": false,
+        "allow_ip_sans": true,
+        "allow_localhost": true,
+        "allow_subdomains": false,
+        "allow_token_displayname": false,
+        "allowed_base_domain": "example.com",
+        "client_flag": true,
+        "code_signing_flag": false,
+        "key_bits": 2048,
+        "key_type": "rsa",
+        "ttl": "6h",
+        "max_ttl": "12h",
+        "server_flag": true
+      }
     }
     ```
 

--- a/website/source/docs/secrets/postgresql/index.html.md
+++ b/website/source/docs/secrets/postgresql/index.html.md
@@ -251,9 +251,9 @@ subpath for interactive help output.
 
     ```javascript
     {
-        "data": {
-            "sql": "CREATE USER..."
-        }
+      "data": {
+        "sql": "CREATE USER..."
+      }
     }
     ```
 
@@ -311,10 +311,10 @@ subpath for interactive help output.
 
     ```javascript
     {
-        "data": {
-            "username": "root-1430158508-126",
-            "password": "132ae3ef-5a64-7499-351e-bfe59f3a2a21"
-        }
+      "data": {
+        "username": "root-1430158508-126",
+        "password": "132ae3ef-5a64-7499-351e-bfe59f3a2a21"
+      }
     }
     ```
 

--- a/website/source/docs/secrets/ssh/index.html.md
+++ b/website/source/docs/secrets/ssh/index.html.md
@@ -30,7 +30,7 @@ on every path, use `vault path-help` after mounting the backend.
 The `ssh` backend is not mounted by default and needs to be explicitly mounted.
 This is a common step for both OTP and Dynamic Key types.
 
-```shell
+```text
 $ vault mount ssh
 Successfully mounted 'ssh' at 'ssh'!
 ```
@@ -69,8 +69,11 @@ Create a role with the `key_type` parameter set to `otp`. All of the machines
 represented by the role's CIDR list should have helper properly installed and
 configured.
 
-```shell
-$ vault write ssh/roles/otp_key_role key_type=otp default_user=username cidr_list=x.x.x.x/y,m.m.m.m/n
+```text
+$ vault write ssh/roles/otp_key_role \
+    key_type=otp \
+    default_user=username \
+    cidr_list=x.x.x.x/y,m.m.m.m/n
 Success! Data written to: ssh/roles/otp_key_role
 ```
 
@@ -78,7 +81,7 @@ Success! Data written to: ssh/roles/otp_key_role
 
 Create an OTP credential for an IP that belongs to `otp_key_role`.
 
-```shell
+```text
 $ vault write ssh/creds/otp_key_role ip=x.x.x.x
 Key            	Value
 lease_id       	ssh/creds/otp_key_role/73bbf513-9606-4bec-816c-5a2f009765a5
@@ -93,7 +96,7 @@ key_type       	otp
 
 ### Establish an SSH session
 
-```shell
+```text
 $ ssh username@localhost
 Password: <Enter OTP>
 username@ip:~$
@@ -104,7 +107,7 @@ username@ip:~$
 A single CLI command can be used to create a new OTP and invoke SSH with the
 correct paramters to connect to the host.
 
-```shell
+```text
 $ vault ssh -role otp_key_role username@x.x.x.x
 OTP for the session is `b4d47e1b-4879-5f4e-ce5c-7988d7986f37`
 [Note: Install `sshpass` to automate typing in OTP]
@@ -113,7 +116,7 @@ Password: <Enter OTP>
 
 The OTP will be entered automatically using `sshpass` if it is installed.
 
-```shell
+```text
 $ vault ssh -role otp_key_role username@x.x.x.x
 username@ip:~$
 ```
@@ -183,8 +186,9 @@ First, however, the shared secret key must be specified.
 Register a key with a name; this key must have administrative capabilities
 on the remote hosts.
 
-```shell
-$ vault write ssh/keys/dev_key key=@dev_shared_key.pem
+```text
+$ vault write ssh/keys/dev_key \
+    key=@dev_shared_key.pem
 ```
 
 #### Create a Role
@@ -192,8 +196,13 @@ $ vault write ssh/keys/dev_key key=@dev_shared_key.pem
 Next, create a role. All of the machines contained within this CIDR block list
 should be accessible using the registered shared secret key.
 
-```shell
-$ vault write ssh/roles/dynamic_key_role key_type=dynamic key=dev_key admin_user=username default_user=username cidr_list=x.x.x.x/y
+```text
+$ vault write ssh/roles/dynamic_key_role \
+    key_type=dynamic \
+    key=dev_key \
+    admin_user=username \
+    default_user=username \
+    cidr_list=x.x.x.x/y
 Success! Data written to: ssh/roles/dynamic_key_role
 ```
 
@@ -212,7 +221,7 @@ To see the default, see [linux_install_script.go](https://github.com/hashicorp/v
 Create a dynamic key for an IP that is covered by `dynamic_key_role`'s CIDR
 list.
 
-```shell
+```text
 $ vault write ssh/creds/dynamic_key_role ip=x.x.x.x
 Key            	Value
 lease_id       	ssh/creds/dynamic_key_role/8c4d2042-23bc-d6a8-42c2-6ff01cb83cf8
@@ -256,7 +265,7 @@ username       	username
 Save the key to a file (e.g. `dyn_key.pem`) and then use it to establish an
 SSH session.
 
-```shell
+```text
 $ ssh -i dyn_key.pem username@ip
 username@ip:~$
 ```
@@ -266,7 +275,7 @@ username@ip:~$
 Creation of new key, saving to a file, and using it to establish an SSH session
 can all be done with a single Vault CLI command.
 
-```shell
+```text
 $ vault ssh -role dynamic_key_role username@ip
 username@ip:~$
 ```
@@ -468,24 +477,25 @@ username@ip:~$
 
 ```json
 {
-		"admin_user": "username",
-		"cidr_list": "x.x.x.x/y",
-		"default_user": "username",
-		"key": "<key name>",
-		"key_type": "dynamic",
-		"port": 22
+  "admin_user": "username",
+  "cidr_list": "x.x.x.x/y",
+  "default_user": "username",
+  "key": "<key name>",
+  "key_type": "dynamic",
+  "port": 22
 }
 ```
+
   </dd>
 
   <dd>For an OTP role:
 
 ```json
 {
-		"cidr_list": "x.x.x.x/y",
-		"default_user": "username",
-		"key_type": "otp",
-		"port": 22
+  "cidr_list": "x.x.x.x/y",
+  "default_user": "username",
+  "key_type": "otp",
+  "port": 22
 }
 ```
   </dd>

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -183,16 +183,17 @@ only encrypt or decrypt using the named keys they need access to.
   <dd>
 
     ```javascript
-    "data": {
+    {
+      "data": {
         "cipher_mode": "aes-gcm",
         "deletion_allowed": false,
         "derived": false,
         "keys": {
-            "1": 1442851412
+          "1": 1442851412
         },
-    {
         "min_decryption_version": 0,
         "name": "foo"
+      }
     }
     ```
 
@@ -337,9 +338,9 @@ only encrypt or decrypt using the named keys they need access to.
 
     ```javascript
     {
-        "data": {
-            "ciphertext": "vault:v1:abcdefgh"
-        }
+      "data": {
+        "ciphertext": "vault:v1:abcdefgh"
+      }
     }
     ```
 
@@ -383,9 +384,9 @@ only encrypt or decrypt using the named keys they need access to.
 
     ```javascript
     {
-        "data": {
-            "plaintext": "dGhlIHF1aWNrIGJyb3duIGZveAo="
-        }
+      "data": {
+        "plaintext": "dGhlIHF1aWNrIGJyb3duIGZveAo="
+      }
     }
     ```
 
@@ -432,7 +433,7 @@ only encrypt or decrypt using the named keys they need access to.
     ```javascript
     {
       "data": {
-          "ciphertext": "vault:v2:abcdefgh"
+        "ciphertext": "vault:v2:abcdefgh"
       }
     }
     ```
@@ -489,10 +490,10 @@ only encrypt or decrypt using the named keys they need access to.
 
     ```javascript
     {
-        "data": {
-            "plaintext": "dGhlIHF1aWNrIGJyb3duIGZveAo=",
-            "ciphertext": "vault:v1:abcdefgh"
-        }
+      "data": {
+        "plaintext": "dGhlIHF1aWNrIGJyb3duIGZveAo=",
+        "ciphertext": "vault:v1:abcdefgh"
+      }
     }
     ```
 

--- a/website/source/intro/getting-started/apis.html.md
+++ b/website/source/intro/getting-started/apis.html.md
@@ -18,7 +18,7 @@ $ curl http://127.0.0.1:8200/v1/sys/init
 This will return a JSON response:
 
 ```javascript
-{"initialized":true}
+{ "initialized": true }
 ```
 
 ## Accessing Secrets via the REST APIs
@@ -72,9 +72,9 @@ Using the unseal key (not the root token) from above, you can unseal the Vault v
 
 ```
 $ curl \
-  -X PUT \
-  -d '{"key": "69cf1c12a1f65dddd19472330b28cf4e95c657dfbe545877e5765d25d0592b16"}' \
-  http://127.0.0.1:8200/v1/sys/unseal
+    -X PUT \
+    -d '{"key": "69cf1c12a1f65dddd19472330b28cf4e95c657dfbe545877e5765d25d0592b16"}' \
+    http://127.0.0.1:8200/v1/sys/unseal
 ```
 
 Note that you should replace `69cf1c1...` with the generated key from your output. This will return a JSON response:
@@ -94,10 +94,10 @@ We can enable an authentication backend with the following `curl` command:
 
 ```
 $ curl \
-  -X POST \
-  -H "X-Vault-Token:$VAULT_TOKEN" \
-  -d '{"type":"app-id"}' \
-  http://127.0.0.1:8200/v1/sys/auth/app-id
+    -X POST \
+    -H "X-Vault-Token:$VAULT_TOKEN" \
+    -d '{"type":"app-id"}' \
+    http://127.0.0.1:8200/v1/sys/auth/app-id
 ```
 
 Notice that the request to the app-id endpoint needed an authentication token. In this case we are passing the root token generated when we started the Vault server. We could also generate tokens using any other authentication mechanisms, but we will use the root token for simplicity.
@@ -108,10 +108,10 @@ First, we need to associate the application with a particular [ACL policy](/docs
 
 ```
 $ curl \
-  -X POST \
-  -H "X-Vault-Token:$VAULT_TOKEN" \
-  -d '{"value":"root", "display_name":"demo"}' \
-  http://localhost:8200/v1/auth/app-id/map/app-id/152AEA38-85FB-47A8-9CBD-612D645BFACA
+    -X POST \
+    -H "X-Vault-Token:$VAULT_TOKEN" \
+    -d '{"value":"root", "display_name":"demo"}' \
+    http://localhost:8200/v1/auth/app-id/map/app-id/152AEA38-85FB-47A8-9CBD-612D645BFACA
 ```
 
 Note that `152AEA38-85FB-47A8-9CBD-612D645BFACA` is a randomly generated UUID. You can use any tool to generate a UUID, but make sure it is unique.
@@ -120,19 +120,19 @@ Next we need to map the application to a particular "user". In Vault, this is ac
 
 ```
 $ curl \
-  -X POST \
-  -H "X-Vault-Token:$VAULT_TOKEN" \
-  -d '{"value":"152AEA38-85FB-47A8-9CBD-612D645BFACA"}' \
-  http://localhost:8200/v1/auth/app-id/map/user-id/5ADF8218-D7FB-4089-9E38-287465DBF37E
+    -X POST \
+    -H "X-Vault-Token:$VAULT_TOKEN" \
+    -d '{"value":"152AEA38-85FB-47A8-9CBD-612D645BFACA"}' \
+    http://localhost:8200/v1/auth/app-id/map/user-id/5ADF8218-D7FB-4089-9E38-287465DBF37E
 ```
 
 Now your app can identify itself via the app-id and user-id and get access to Vault. The first step is to authenticate:
 
 ```
 $ curl \
-  -X POST \
-  -d '{"app_id":"152AEA38-85FB-47A8-9CBD-612D645BFACA", "user_id": "5ADF8218-D7FB-4089-9E38-287465DBF37E"}' \
-  "http://127.0.0.1:8200/v1/auth/app-id/login"
+    -X POST \
+    -d '{"app_id":"152AEA38-85FB-47A8-9CBD-612D645BFACA", "user_id": "5ADF8218-D7FB-4089-9E38-287465DBF37E"}' \
+    "http://127.0.0.1:8200/v1/auth/app-id/login"
 ```
 
 This will return a response that looks like the following:
@@ -168,19 +168,19 @@ Be sure to replace this with the value returned from your API response. We can n
 
 ```
 $ curl \
-  -X POST \
-  -H "X-Vault-Token:$VAULT_TOKEN" \
-  -H 'Content-type: application/json' \
-  -d '{"bar":"baz"}' \
-  http://127.0.0.1:8200/v1/secret/foo
+    -X POST \
+    -H "X-Vault-Token:$VAULT_TOKEN" \
+    -H 'Content-type: application/json' \
+    -d '{"bar":"baz"}' \
+    http://127.0.0.1:8200/v1/secret/foo
 ```
 
 This will create a new secret named "foo" with the given JSON contents. We can read this value back with the same token:
 
 ```
 $ curl \
-  -H "X-Vault-Token:$VAULT_TOKEN" \
-  http://127.0.0.1:8200/v1/secret/foo
+    -H "X-Vault-Token:$VAULT_TOKEN" \
+    http://127.0.0.1:8200/v1/secret/foo
 ```
 
 This should return a response like this:


### PR DESCRIPTION
This also standardizes on the indentation we use for multi-line commands as well as prefixes all commands with a $ to indicate a shell.

/cc @jefferai 