### PR TITLE
Update middleman-hashicorp

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/hashicorp/middleman-hashicorp.git
-  revision: 53f13a119da3f8874d94135b81efc9f2b681935c
+  revision: b152b6436348e8e1f9990436228b25b4c5c6fcb8
   specs:
     middleman-hashicorp (0.1.0)
       bootstrap-sass (~> 3.3)
@@ -151,7 +151,7 @@ GEM
     redcarpet (3.3.3)
     ref (2.0.0)
     rouge (1.10.1)
-    sass (3.4.18)
+    sass (3.4.19)
     sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)


### PR DESCRIPTION
This pull request updates middleman-hashicorp to the [latest version](https://github.com/hashicorp/middleman-hashicorp/commit/adc13f6edb7979f53fb645bc8d2bf928faea21ad). The gem was updated to handle an edge case in the `path_in_repository` method, which is invoked by `github_url`.