### PR TITLE
Don't use http.DefaultClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,38 @@
 
 DEPRECATIONS/BREAKING CHANGES:
 
- * Policy Name Casing: Policy names are now normalized to lower-case on write, helping prevent accidental case mismatches. For backwards compatibility, policy names are not currently normalized when reading or deleting. [GH-676]
+ * Policy Name Casing: Policy names are now normalized to lower-case on write,
+   helping prevent accidental case mismatches. For backwards compatibility,
+policy names are not currently normalized when reading or deleting. [GH-676]
 
 IMPROVEMENTS:
 
  * api: API client now uses a 30 second timeout instead of indefinite [GH-681]
- * core: The physical storage read cache can now be disabled via "disable_cache" [GH-674]
+ * core: The physical storage read cache can now be disabled via
+   "disable_cache" [GH-674]
  * core: Tokens can now renew themselves [GH-455]
- * core: Base64-encoded PGP keys can be used with the CLI for `init` and `rekey` operations [GH-653]
+ * core: Base64-encoded PGP keys can be used with the CLI for `init` and
+   `rekey` operations [GH-653]
  * logical: Allow `.` in path-based variables in many more locations [GH-244]
- * logical: Responses now contain a "warnings" key containing a list of warnings returned from the server. These are conditions that did not require failing an operation, but of which the client should be aware. [GH-676]
+ * logical: Responses now contain a "warnings" key containing a list of
+   warnings returned from the server. These are conditions that did not require
+failing an operation, but of which the client should be aware. [GH-676]
 
 BUG FIXES:
 
- * api: API client now checks for a 301 response for redirects. Vault doesn't generate these, but in certain conditions Go's internal HTTP handler can generate them, leading to client errors.
- * cli: `token-create` now supports the `ttl` parameter in addition to the deprecated `lease` parameter. [GH-688]
+ * api: API client now checks for a 301 response for redirects. Vault doesn't
+   generate these, but in certain conditions Go's internal HTTP handler can
+generate them, leading to client errors.
+ * cli: `token-create` now supports the `ttl` parameter in addition to the
+   deprecated `lease` parameter. [GH-688]
  * core: Fix upgrade path for leases created in `generic` prior to 0.3 [GH-673]
  * core: Stale leader entries will now be reaped [GH-679]
- * core: Using `mount-tune` on the auth/token path did not take effect. [GH-688]
- * core: Fix a potential race condition when (un)sealing the vault with metrics enabled [GH-694]
- * everywhere: Don't use http.DefaultClient, as it shares state implicitly and is a source of hard-to-track-down bugs [GH-700]
+ * core: Using `mount-tune` on the auth/token path did not take effect.
+   [GH-688]
+ * core: Fix a potential race condition when (un)sealing the vault with metrics
+   enabled [GH-694]
+ * everywhere: Don't use http.DefaultClient, as it shares state implicitly and
+   is a source of hard-to-track-down bugs [GH-700]
 
 MISC:
 
@@ -31,12 +43,16 @@ MISC:
 
 SECURITY:
 
- * core: In certain failure scenarios, the full values of requests and responses would be logged [GH-665]
+ * core: In certain failure scenarios, the full values of requests and
+   responses would be logged [GH-665]
 
 FEATURES:
 
- * **Settable Maximum Open Connections**: The `mysql` and `postgresql` backends now allow setting the number of maximum open connections to the database, which was previously capped to 2. [GH-661]
- * **Renewable Tokens for GitHub**: The `github` backend now supports specifying a TTL, enabling renewable tokens. [GH-664]
+ * **Settable Maximum Open Connections**: The `mysql` and `postgresql` backends
+   now allow setting the number of maximum open connections to the database,
+which was previously capped to 2. [GH-661]
+ * **Renewable Tokens for GitHub**: The `github` backend now supports
+   specifying a TTL, enabling renewable tokens. [GH-664]
 
 BUG FIXES:
 
@@ -45,76 +61,143 @@ BUG FIXES:
 
 MISC:
 
- * Various minor documentation fixes and improvements [GH-649] [GH-650] [GH-654] [GH-663]
+ * Various minor documentation fixes and improvements [GH-649] [GH-650]
+   [GH-654] [GH-663]
 
 ## 0.3.0 (September 28, 2015)
 
 DEPRECATIONS/BREAKING CHANGES:
 
-Note: deprecations and breaking changes in upcoming releases are announced ahead of time on the "vault-tool" mailing list.
+Note: deprecations and breaking changes in upcoming releases are announced
+ahead of time on the "vault-tool" mailing list.
 
- * **Cookie Authentication Removed**: As of 0.3 the only way to authenticate is via the X-Vault-Token header. Cookie authentication was hard to properly test, could result in browsers/tools/applications saving tokens in plaintext on disk, and other issues. [GH-564]
- * **Terminology/Field Names**: Vault is transitioning from overloading the term "lease" to mean both "a set of metadata" and "the amount of time the metadata is valid". The latter is now being referred to as TTL (or "lease_duration" for backwards-compatibility); some parts of Vault have already switched to using "ttl" and others will follow in upcoming releases. In particular, the "token", "generic", and "pki" backends accept both "ttl" and "lease" but in 0.4 only "ttl" will be accepted. [GH-528]
- * **Downgrade Not Supported**: Due to enhancements in the storage subsytem, values written by Vault 0.3+ will not be able to be read by prior versions of Vault. There are no expected upgrade issues, however, as with all critical infrastructure it is recommended to back up Vault's physical storage before upgrading.
+ * **Cookie Authentication Removed**: As of 0.3 the only way to authenticate is
+   via the X-Vault-Token header. Cookie authentication was hard to properly
+test, could result in browsers/tools/applications saving tokens in plaintext on
+disk, and other issues. [GH-564]
+ * **Terminology/Field Names**: Vault is transitioning from overloading the
+   term "lease" to mean both "a set of metadata" and "the amount of time the
+metadata is valid". The latter is now being referred to as TTL (or
+"lease_duration" for backwards-compatibility); some parts of Vault have already
+switched to using "ttl" and others will follow in upcoming releases. In
+particular, the "token", "generic", and "pki" backends accept both "ttl" and
+"lease" but in 0.4 only "ttl" will be accepted. [GH-528]
+ * **Downgrade Not Supported**: Due to enhancements in the storage subsytem,
+   values written by Vault 0.3+ will not be able to be read by prior versions
+of Vault. There are no expected upgrade issues, however, as with all critical
+infrastructure it is recommended to back up Vault's physical storage before
+upgrading.
 
 FEATURES:
 
- * **SSH Backend**: Vault can now be used to delegate SSH access to machines, via a (recommended) One-Time Password approach or by issuing dynamic keys. [GH-385]
- * **Cubbyhole Backend**: This backend works similarly to the "generic" backend but provides a per-token workspace. This enables some additional authentication workflows (especially for containers) and can be useful to applications to e.g. store local credentials while being restarted or upgraded, rather than persisting to disk. [GH-612]
- * **Transit Backend Improvements**: The transit backend now allows key rotation and datakey generation. For rotation, data encrypted with previous versions of the keys can still be decrypted, down to a (configurable) minimum previous version; there is a rewrap function for manual upgrades of ciphertext to newer versions. Additionally, the backend now allows generating and returning high-entropy keys of a configurable bitsize suitable for AES and other functions; this is returned wrapped by a named key, or optionally both wrapped and plaintext for immediate use. [GH-626]
- * **Global and Per-Mount Default/Max TTL Support**: You can now set the default and maximum Time To Live for leases both globally and per-mount. Per-mount settings override global settings. Not all backends honor these settings yet, but the maximum is a hard limit enforced outside the backend. See the documentation for "/sys/mounts/" for details on configuring per-mount TTLs. [GH-469]
- * **PGP Encryption for Unseal Keys**: When initializing or rotating Vault's master key, PGP/GPG public keys can now be provided. The output keys will be encrypted with the given keys, in order. [GH-570]
- * **Duo Multifactor Authentication Support**: Backends that support MFA can now use Duo as the mechanism. [GH-464]
- * **Performance Improvements**: Users of the "generic" backend will see a significant performance improvement as the backend no longer creates leases, although it does return TTLs (global/mount default, or set per-item) as before. [GH-631]
- * **Codebase Audit**: Vault's codebase was audited by iSEC. (The terms of the audit contract do not allow us to make the results public.) [GH-220]
+ * **SSH Backend**: Vault can now be used to delegate SSH access to machines,
+   via a (recommended) One-Time Password approach or by issuing dynamic keys.
+[GH-385]
+ * **Cubbyhole Backend**: This backend works similarly to the "generic" backend
+   but provides a per-token workspace. This enables some additional
+authentication workflows (especially for containers) and can be useful to
+applications to e.g. store local credentials while being restarted or upgraded,
+rather than persisting to disk. [GH-612]
+ * **Transit Backend Improvements**: The transit backend now allows key
+   rotation and datakey generation. For rotation, data encrypted with previous
+versions of the keys can still be decrypted, down to a (configurable) minimum
+previous version; there is a rewrap function for manual upgrades of ciphertext
+to newer versions. Additionally, the backend now allows generating and
+returning high-entropy keys of a configurable bitsize suitable for AES and
+other functions; this is returned wrapped by a named key, or optionally both
+wrapped and plaintext for immediate use. [GH-626]
+ * **Global and Per-Mount Default/Max TTL Support**: You can now set the
+   default and maximum Time To Live for leases both globally and per-mount.
+Per-mount settings override global settings. Not all backends honor these
+settings yet, but the maximum is a hard limit enforced outside the backend. See
+the documentation for "/sys/mounts/" for details on configuring per-mount TTLs.
+[GH-469]
+ * **PGP Encryption for Unseal Keys**: When initializing or rotating Vault's
+   master key, PGP/GPG public keys can now be provided. The output keys will be
+encrypted with the given keys, in order. [GH-570]
+ * **Duo Multifactor Authentication Support**: Backends that support MFA can
+   now use Duo as the mechanism. [GH-464]
+ * **Performance Improvements**: Users of the "generic" backend will see a
+   significant performance improvement as the backend no longer creates leases,
+although it does return TTLs (global/mount default, or set per-item) as before.
+[GH-631]
+ * **Codebase Audit**: Vault's codebase was audited by iSEC. (The terms of the
+   audit contract do not allow us to make the results public.) [GH-220]
 
 IMPROVEMENTS:
 
  * audit: Log entries now contain a time field [GH-495]
  * audit: Obfuscated audit entries now use hmac-sha256 instead of sha1 [GH-627]
- * backends: Add ability for a cleanup function to be called on backend unmount [GH-608]
+ * backends: Add ability for a cleanup function to be called on backend unmount
+   [GH-608]
  * config: Allow specifying minimum acceptable TLS version [GH-447]
- * core: If trying to mount in a location that is already mounted, be more helpful about the error [GH-510]
+ * core: If trying to mount in a location that is already mounted, be more
+   helpful about the error [GH-510]
  * core: Be more explicit on failure if the issue is invalid JSON [GH-553]
  * core: Tokens can now revoke themselves [GH-620]
- * credential/app-id: Give a more specific error when sending a duplicate POST to sys/auth/app-id [GH-392]
- * credential/github: Support custom API endpoints (e.g. for Github Enterprise) [GH-572]
- * credential/ldap: Add per-user policies and option to login with userPrincipalName [GH-420]
- * credential/token: Allow root tokens to specify the ID of a token being created from CLI [GH-502]
+ * credential/app-id: Give a more specific error when sending a duplicate POST
+   to sys/auth/app-id [GH-392]
+ * credential/github: Support custom API endpoints (e.g. for Github Enterprise)
+   [GH-572]
+ * credential/ldap: Add per-user policies and option to login with
+   userPrincipalName [GH-420]
+ * credential/token: Allow root tokens to specify the ID of a token being
+   created from CLI [GH-502]
  * credential/userpass: Enable renewals for login tokens [GH-623]
  * scripts: Use /usr/bin/env to find Bash instead of hardcoding [GH-446]
- * scripts: Use godep for build scripts to use same environment as tests [GH-404]
+ * scripts: Use godep for build scripts to use same environment as tests
+   [GH-404]
  * secret/mysql: Allow reading configuration data [GH-529]
- * secret/pki: Split "allow_any_name" logic to that and "enforce_hostnames", to allow for non-hostname values (e.g. for client certificates) [GH-555]
- * storage/consul: Allow specifying certificates used to talk to Consul [GH-384]
+ * secret/pki: Split "allow_any_name" logic to that and "enforce_hostnames", to
+   allow for non-hostname values (e.g. for client certificates) [GH-555]
+ * storage/consul: Allow specifying certificates used to talk to Consul
+   [GH-384]
  * storage/mysql: Allow SSL encrypted connections [GH-439]
  * storage/s3: Allow using temporary security credentials [GH-433]
- * telemetry: Put telemetry object in configuration to allow more flexibility [GH-419]
- * testing: Disable mlock for testing of logical backends so as not to require root [GH-479]
+ * telemetry: Put telemetry object in configuration to allow more flexibility
+   [GH-419]
+ * testing: Disable mlock for testing of logical backends so as not to require
+   root [GH-479]
 
 BUG FIXES:
 
  * audit/file: Do not enable auditing if file permissions are invalid [GH-550]
  * backends: Allow hyphens in endpoint patterns (fixes AWS and others) [GH-559]
- * cli: Fixed missing setup of client TLS certificates if no custom CA was provided
- * cli/read: Do not include a carriage return when using raw field output [GH-624]
- * core: Bad input data could lead to a panic for that session, rather than returning an error [GH-503]
+ * cli: Fixed missing setup of client TLS certificates if no custom CA was
+   provided
+ * cli/read: Do not include a carriage return when using raw field output
+   [GH-624]
+ * core: Bad input data could lead to a panic for that session, rather than
+   returning an error [GH-503]
  * core: Allow SHA2-384/SHA2-512 hashed certificates [GH-448]
- * core: Do not return a Secret if there are no uses left on a token (since it will be unable to be used) [GH-615]
- * core: Code paths that called lookup-self would decrement num_uses and potentially immediately revoke a token [GH-552]
- * core: Some /sys/ paths would not properly redirect from a standby to the leader [GH-499] [GH-551]
- * credential/aws: Translate spaces in a token's display name to avoid making IAM unhappy [GH-567]
- * credential/github: Integration failed if more than ten organizations or teams [GH-489]
- * credential/token: Tokens with sudo access to "auth/token/create" can now use root-only options [GH-629]
- * secret/cassandra: Work around backwards-incompatible change made in Cassandra 2.2 preventing Vault from properly setting/revoking leases [GH-549]
- * secret/mysql: Use varbinary instead of varchar to avoid InnoDB/UTF-8 issues [GH-522]
+ * core: Do not return a Secret if there are no uses left on a token (since it
+   will be unable to be used) [GH-615]
+ * core: Code paths that called lookup-self would decrement num_uses and
+   potentially immediately revoke a token [GH-552]
+ * core: Some /sys/ paths would not properly redirect from a standby to the
+   leader [GH-499] [GH-551]
+ * credential/aws: Translate spaces in a token's display name to avoid making
+   IAM unhappy [GH-567]
+ * credential/github: Integration failed if more than ten organizations or
+   teams [GH-489]
+ * credential/token: Tokens with sudo access to "auth/token/create" can now use
+   root-only options [GH-629]
+ * secret/cassandra: Work around backwards-incompatible change made in
+   Cassandra 2.2 preventing Vault from properly setting/revoking leases
+[GH-549]
+ * secret/mysql: Use varbinary instead of varchar to avoid InnoDB/UTF-8 issues
+   [GH-522]
  * secret/postgres: Explicitly set timezone in connections [GH-597]
- * storage/etcd: Renew semaphore periodically to prevent leadership flapping [GH-606]
- * storage/zk: Fix collisions in storage that could lead to data unavailability [GH-411]
+ * storage/etcd: Renew semaphore periodically to prevent leadership flapping
+   [GH-606]
+ * storage/zk: Fix collisions in storage that could lead to data unavailability
+   [GH-411]
 
 MISC:
 
- * Various documentation fixes and improvements [GH-412] [GH-474] [GH-476] [GH-482] [GH-483] [GH-486] [GH-508] [GH-568] [GH-574] [GH-586] [GH-590] [GH-591] [GH-592] [GH-595] [GH-613] [GH-637]
+ * Various documentation fixes and improvements [GH-412] [GH-474] [GH-476]
+   [GH-482] [GH-483] [GH-486] [GH-508] [GH-568] [GH-574] [GH-586] [GH-590]
+[GH-591] [GH-592] [GH-595] [GH-613] [GH-637]
  * Less "armon" in stack traces [GH-453]
  * Sourcegraph integration [GH-456]
 
@@ -123,16 +206,23 @@ MISC:
 FEATURES:
 
  * **Key Rotation Support**: The `rotate` command can be used to rotate the
- master encryption key used to write data to the storage (physical) backend. [GH-277]
- * **Rekey Support**: Rekey can be used to rotate the master key and change
- the configuration of the unseal keys (number of shares, threshold required). [GH-277]
- * **New secret backend: `pki`**: Enable Vault to be a certificate authority and generate
-   signed TLS certificates. [GH-310]
- * **New secret backend: `cassandra`**: Generate dynamic credentials for Cassandra [GH-363]
- * **New storage backend: `etcd`**: store physical data in etcd [GH-259] [GH-297]
- * **New storage backend: `s3`**: store physical data in S3. Does not support HA. [GH-242]
- * **New storage backend: `MySQL`**: store physical data in MySQL. Does not support HA. [GH-324]
- * `transit` secret backend supports derived keys for per-transaction unique keys [GH-399]
+   master encryption key used to write data to the storage (physical) backend.
+[GH-277]
+ * **Rekey Support**: Rekey can be used to rotate the master key and change the
+   configuration of the unseal keys (number of shares, threshold required).
+[GH-277]
+ * **New secret backend: `pki`**: Enable Vault to be a certificate authority
+   and generate signed TLS certificates. [GH-310]
+ * **New secret backend: `cassandra`**: Generate dynamic credentials for
+   Cassandra [GH-363]
+ * **New storage backend: `etcd`**: store physical data in etcd [GH-259]
+   [GH-297]
+ * **New storage backend: `s3`**: store physical data in S3. Does not support
+   HA. [GH-242]
+ * **New storage backend: `MySQL`**: store physical data in MySQL. Does not
+   support HA. [GH-324]
+ * `transit` secret backend supports derived keys for per-transaction unique
+   keys [GH-399]
 
 IMPROVEMENTS:
 
@@ -143,10 +233,10 @@ IMPROVEMENTS:
  * core: allow time duration format in place of seconds for some inputs
  * core: audit log provides more useful information [GH-360]
  * core: graceful shutdown for faster HA failover
- * core: **change policy format** to use explicit globbing [GH-400]
- Any existing policy in Vault is automatically upgraded to avoid issues.
- All policy files must be updated for future writes. Adding the explicit glob
- character `*` to the path specification is all that is required.
+ * core: **change policy format** to use explicit globbing [GH-400] Any
+   existing policy in Vault is automatically upgraded to avoid issues.  All
+policy files must be updated for future writes. Adding the explicit glob
+character `*` to the path specification is all that is required.
  * core: policy merging to give deny highest precedence [GH-400]
  * credential/app-id: Protect against timing attack on app-id
  * credential/cert: Record the common name in the metadata [GH-342]
@@ -155,13 +245,15 @@ IMPROVEMENTS:
  * credential/userpass: Protect against timing attack on password
  * credential/userpass: Use bcrypt for password matching
  * http: response codes improved to reflect error [GH-366]
- * http: the `sys/health` endpoint supports `?standbyok` to return 200 on standby [GH-389]
+ * http: the `sys/health` endpoint supports `?standbyok` to return 200 on
+   standby [GH-389]
  * secret/app-id: Support deleting AppID and UserIDs [GH-200]
  * secret/consul: Fine grained lease control [GH-261]
  * secret/transit: Decouple raw key from key management endpoint [GH-355]
  * secret/transit: Upsert named key when encrypt is used [GH-355]
  * storage/zk: Support for HA configuration [GH-252]
- * storage/zk: Changing node representation. **Backwards incompatible**. [GH-416]
+ * storage/zk: Changing node representation. **Backwards incompatible**.
+   [GH-416]
 
 BUG FIXES:
 
@@ -174,7 +266,8 @@ BUG FIXES:
  * core: fixed leases with negative duration [GH-354]
  * core: token renewal does not create child token
  * core: fixing panic when lease increment is null [GH-408]
- * credential/app-id: Salt the paths in storage backend to avoid information leak
+ * credential/app-id: Salt the paths in storage backend to avoid information
+   leak
  * credential/cert: Fixing client certificate not being requested
  * credential/cert: Fixing panic when no certificate match found [GH-361]
  * http: Accept PUT as POST for sys/auth
@@ -194,7 +287,7 @@ MISC:
 FEATURES:
 
   * **New physical backend: `zookeeper`**: store physical data in Zookeeper.
-      HA not supported yet.
+    HA not supported yet.
   * **New credential backend: `ldap`**: authenticate using LDAP credentials.
 
 IMPROVEMENTS:
@@ -212,8 +305,8 @@ BUG FIXES:
 
   * core: login endpoints should never return secrets
   * core: Internal data should never be returned from core endpoints
-  * core: defer barrier initialization to as late as possible to avoid
-      error cases during init that corrupt data (no data loss)
+  * core: defer barrier initialization to as late as possible to avoid error
+    cases during init that corrupt data (no data loss)
   * core: guard against invalid init config earlier
   * audit/file: create file if it doesn't exist [GH-148]
   * command/*: ignore directories when traversing CA paths [GH-181]
@@ -231,16 +324,16 @@ IMPROVEMENTS:
 
   * core: Very verbose error if mlock fails [GH-59]
   * command/*: On error with TLS oversized record, show more human-friendly
-      error message. [GH-123]
-  * command/read: `lease_renewable` is now outputed along with the secret
-      to show whether it is renewable or not
+    error message. [GH-123]
+  * command/read: `lease_renewable` is now outputed along with the secret to
+    show whether it is renewable or not
   * command/server: Add configuration option to disable mlock
   * command/server: Disable mlock for dev mode so it works on more systems
 
 BUG FIXES:
 
   * core: if token helper isn't absolute, prepend with path to Vault
-      executable, not "vault" (which requires PATH) [GH-60]
+    executable, not "vault" (which requires PATH) [GH-60]
   * core: Any "mapping" routes allow hyphens in keys [GH-119]
   * core: Validate `advertise_addr` is a valid URL with scheme [GH-106]
   * command/auth: Using an invalid token won't crash [GH-75]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ BUG FIXES:
  * core: Stale leader entries will now be reaped [GH-679]
  * core: Using `mount-tune` on the auth/token path did not take effect. [GH-688]
  * core: Fix a potential race condition when (un)sealing the vault with metrics enabled [GH-694]
+ * everywhere: Don't use http.DefaultClient, as it shares state implicitly and is a source of hard-to-track-down bugs [GH-700]
 
 MISC:
 

--- a/api/client.go
+++ b/api/client.go
@@ -12,11 +12,7 @@ import (
 )
 
 var (
-	errRedirect            = errors.New("redirect")
-	defaultHTTPClientSetup sync.Once
-	defaultHTTPClient      = &http.Client{
-		Timeout: time.Second * 30,
-	}
+	errRedirect = errors.New("redirect")
 )
 
 // Config is used to configure the creation of the client.
@@ -30,6 +26,8 @@ type Config struct {
 	// HttpClient is the HTTP client to use, which will currently always have the
 	// same values as http.DefaultClient. This is used to control redirect behavior.
 	HttpClient *http.Client
+
+	redirectSetup sync.Once
 }
 
 // DefaultConfig returns a default configuration for the client. It is
@@ -39,8 +37,10 @@ type Config struct {
 // setting the `VAULT_ADDR` environment variable.
 func DefaultConfig() *Config {
 	config := &Config{
-		Address:    "https://127.0.0.1:8200",
-		HttpClient: defaultHTTPClient,
+		Address: "https://127.0.0.1:8200",
+		HttpClient: &http.Client{
+			Timeout: time.Second * 60,
+		},
 	}
 
 	if addr := os.Getenv("VAULT_ADDR"); addr != "" {
@@ -69,14 +69,21 @@ func NewClient(c *Config) (*Client, error) {
 		return nil, err
 	}
 
-	if c.HttpClient == defaultHTTPClient {
-		defaultHTTPClientSetup.Do(func() {
-			// Ensure redirects are not automatically followed
-			c.HttpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-				return errRedirect
-			}
-		})
+	if c.HttpClient == nil {
+		c.HttpClient = DefaultConfig().HttpClient
 	}
+
+	redirFunc := func() {
+		// Ensure redirects are not automatically followed
+		// Note that this is sane for the API client as it has its own
+		// redirect handling logic (and thus also for command/meta),
+		// but in e.g. http_test actual redirect handling is necessary
+		c.HttpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return errRedirect
+		}
+	}
+
+	c.redirectSetup.Do(redirFunc)
 
 	client := &Client{
 		addr:   u,

--- a/builtin/credential/github/backend.go
+++ b/builtin/credential/github/backend.go
@@ -54,7 +54,7 @@ type backend struct {
 // Client returns the GitHub client to communicate to GitHub via the
 // configured settings.
 func (b *backend) Client(token string) (*github.Client, error) {
-	var tc *http.Client
+	tc := &http.Client{}
 	if token != "" {
 		tc = oauth2.NewClient(oauth2.NoContext, &tokenSource{Value: token})
 	}

--- a/builtin/credential/github/backend_test.go
+++ b/builtin/credential/github/backend_test.go
@@ -26,7 +26,7 @@ func TestBackend_Config(t *testing.T) {
 
 	login_data := map[string]interface{}{
 		// This token has to be replaced with a working token for the test to work.
-		"token": "4fb5f4f0738c7aea5ee06dd595f15236ea78918b",
+		"token": os.Getenv("GITHUB_TOKEN"),
 	}
 	config_data1 := map[string]interface{}{
 		"organization": "hashicorp",

--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -97,6 +98,7 @@ func testAccStepReadUser(t *testing.T, name string) logicaltest.TestStep {
 			awsConfig := &aws.Config{
 				Credentials: creds,
 				Region:      aws.String("us-east-1"),
+				HTTPClient:  &http.Client{},
 			}
 			client := ec2.New(awsConfig)
 

--- a/builtin/logical/aws/client.go
+++ b/builtin/logical/aws/client.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -29,6 +30,7 @@ func clientIAM(s logical.Storage) (*iam.IAM, error) {
 	awsConfig := &aws.Config{
 		Credentials: creds,
 		Region:      aws.String(config.Region),
+		HTTPClient:  &http.Client{},
 	}
 	return iam.New(awsConfig), nil
 }

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func testHttpGet(t *testing.T, token string, addr string) *http.Response {
@@ -46,7 +47,9 @@ func testHttpData(t *testing.T, method string, token string, addr string, body i
 		req.Header.Set("X-Vault-Token", token)
 	}
 
-	client := http.DefaultClient
+	client := &http.Client{
+		Timeout: 60 * time.Second,
+	}
 
 	// From https://github.com/michiwend/gomusicbrainz/pull/4/files
 	defaultRedirectLimit := 30

--- a/physical/consul.go
+++ b/physical/consul.go
@@ -2,11 +2,11 @@ package physical
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"sort"
 	"strings"
 	"time"
-	"net/http"
-	"io/ioutil"
 
 	"crypto/tls"
 	"crypto/x509"
@@ -43,6 +43,7 @@ func newConsulBackend(conf map[string]string) (Backend, error) {
 
 	// Configure the client
 	consulConf := api.DefaultConfig()
+
 	if addr, ok := conf["address"]; ok {
 		consulConf.Address = addr
 	}
@@ -95,7 +96,7 @@ func setupTLSConfig(conf map[string]string) (*tls.Config, error) {
 	}
 
 	_, okCert := conf["tls_cert_file"]
-	_, okKey  := conf["tls_key_file"]
+	_, okKey := conf["tls_key_file"]
 
 	if okCert && okKey {
 		tlsCert, err := tls.LoadX509KeyPair(conf["tls_cert_file"], conf["tls_key_file"])


### PR DESCRIPTION
This strips out http.DefaultClient everywhere I could immediately find
it. Too many things use it and then modify it in incompatible ways.

Unit tests pass, and additionally I ran the acceptance tests for GitHub auth.

Fixes #700, I believe.