### PR TITLE
helper/password: interrupt should exit readline

### DIFF
--- a/helper/password/password.go
+++ b/helper/password/password.go
@@ -50,6 +50,13 @@ func readline(f *os.File) (string, error) {
 			break
 		}
 
+		// ASCII code 3 is what is sent for a Ctrl-C while reading raw.
+		// If we see that, then get the interrupt. We have to do this here
+		// because terminals in raw mode won't catch it at the shell level.
+		if buf[0] == 3 {
+			return "", ErrInterrupted
+		}
+
 		resultBuf = append(resultBuf, buf[0])
 	}
 


### PR DESCRIPTION
This makes Ctrl-C work properly even when reading from a secure input prompt. 

This should affect `vault unseal` and such (positively, you can quit it now) but is also needed downstream for me in Otto. We use this lib as a way to do secure input for encryption passwords.

Fixes https://github.com/hashicorp/otto/issues/252