### PR TITLE
add GitHub Enterprise base_url to docs

### DIFF
--- a/website/source/docs/auth/github.html.md
+++ b/website/source/docs/auth/github.html.md
@@ -52,7 +52,10 @@ configure it, use the `/config` endpoint with the following arguments:
      be a part of to authenticate.
   * `base_url` (string, optional) - For GitHub Enterprise or other API-compatible
      servers, the base URL to access the server.
-
+  * `max_ttl` (string, optional) - Maximum duration after which authentication will be expired.
+     This must be a string in a format parsable by Go's [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration)
+  * `ttl` (string, optional) - Duration after which authentication will be expired.
+     This must be a string in a format parsable by Go's [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration)
 
 ###Generate a GitHub Personal Access Token
 Access your Personal Access Tokens in GitHub at [https://github.com/settings/tokens](https://github.com/settings/tokens).

--- a/website/source/docs/auth/github.html.md
+++ b/website/source/docs/auth/github.html.md
@@ -50,6 +50,9 @@ configure it, use the `/config` endpoint with the following arguments:
 
   * `organization` (string, required) - The organization name a user must
      be a part of to authenticate.
+  * `base_url` (string, optional) - For GitHub Enterprise or other API-compatible
+     servers, the base URL to access the server.
+
 
 ###Generate a GitHub Personal Access Token
 Access your Personal Access Tokens in GitHub at [https://github.com/settings/tokens](https://github.com/settings/tokens).


### PR DESCRIPTION
In https://github.com/hashicorp/vault/issues/716 @jefferai confirmed that the GitHub Auth Backend supports GitHub enterprise using an undocumented ``base_url`` parameter. This adds that parameter to the relevant documentation page.