### PR TITLE
Add reset support to the unseal command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ IMPROVEMENTS:
  * api: API client now uses a 30 second timeout instead of indefinite [GH-681]
  * core: The physical storage read cache can now be disabled via
    "disable_cache" [GH-674]
+ * core: The unsealing process can now be reset midway through (this feature
+   was documented before, but not enabled) [GH-695]
  * core: Tokens can now renew themselves [GH-455]
  * core: Base64-encoded PGP keys can be used with the CLI for `init` and
    `rekey` operations [GH-653]

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -2,15 +2,7 @@ package api
 
 func (c *Sys) SealStatus() (*SealStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/seal-status")
-	resp, err := c.c.RawRequest(r)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var result SealStatusResponse
-	err = resp.DecodeJSON(&result)
-	return &result, err
+	return sealStatusRequest(c, r)
 }
 
 func (c *Sys) Seal() error {
@@ -22,6 +14,17 @@ func (c *Sys) Seal() error {
 	return err
 }
 
+func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
+	body := map[string]interface{}{"reset": true}
+
+	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
+	if err := r.SetJSONBody(body); err != nil {
+		return nil, err
+	}
+
+	return sealStatusRequest(c, r)
+}
+
 func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
 	body := map[string]interface{}{"key": shard}
 
@@ -30,6 +33,10 @@ func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
 		return nil, err
 	}
 
+	return sealStatusRequest(c, r)
+}
+
+func sealStatusRequest(c *Sys, r *Request) (*SealStatusResponse, error) {
 	resp, err := c.c.RawRequest(r)
 	if err != nil {
 		return nil, err

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -129,3 +129,62 @@ func TestSysUnseal_badKey(t *testing.T) {
 		t.Fatalf("bad: %#v", actual)
 	}
 }
+
+func TestSysUnseal_Reset(t *testing.T) {
+	core := vault.TestCore(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+
+	thresh := 3
+	resp := testHttpPut(t, "", addr+"/v1/sys/init", map[string]interface{}{
+		"secret_shares":    5,
+		"secret_threshold": thresh,
+	})
+
+	var actual map[string]interface{}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+	keysRaw, ok := actual["keys"]
+	if !ok {
+		t.Fatalf("no keys: %#v", actual)
+	}
+	for i, key := range keysRaw.([]interface{}) {
+		if i > thresh-2 {
+			break
+		}
+
+		resp := testHttpPut(t, "", addr+"/v1/sys/unseal", map[string]interface{}{
+			"key": key.(string),
+		})
+
+		var actual map[string]interface{}
+		expected := map[string]interface{}{
+			"sealed":   true,
+			"t":        float64(3),
+			"n":        float64(5),
+			"progress": float64(i + 1),
+		}
+		testResponseStatus(t, resp, 200)
+		testResponseBody(t, resp, &actual)
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("\nexpected:\n%#v\nactual:\n%#v\n", expected, actual)
+		}
+	}
+
+	resp = testHttpPut(t, "", addr+"/v1/sys/unseal", map[string]interface{}{
+		"reset": true,
+	})
+
+	actual = map[string]interface{}{}
+	expected := map[string]interface{}{
+		"sealed":   true,
+		"t":        float64(3),
+		"n":        float64(5),
+		"progress": float64(0),
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("\nexpected:\n%#v\nactual:\n%#v\n", expected, actual)
+	}
+}

--- a/vault/core.go
+++ b/vault/core.go
@@ -957,6 +957,17 @@ func (c *Core) SecretProgress() int {
 	return len(c.unlockParts)
 }
 
+// ResetUnsealProcess removes the current unlock parts from memory, to reset
+// the unsealing process
+func (c *Core) ResetUnsealProcess() {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	if !c.sealed {
+		return
+	}
+	c.unlockParts = nil
+}
+
 // Unseal is used to provide one of the key parts to unseal the Vault.
 //
 // They key given as a parameter will automatically be zerod after

--- a/website/source/docs/http/sys-unseal.html.md
+++ b/website/source/docs/http/sys-unseal.html.md
@@ -14,7 +14,9 @@ description: |-
     Enter a single master key share to progress the unsealing of the Vault.
     If the threshold number of master key shares is reached, Vault
     will attempt to unseal the Vault. Otherwise, this API must be
-    called multiple times until that threshold is met.
+    called multiple times until that threshold is met.<br/><br/>Either
+    the `key` or `reset` parameter must be provided; if both are provided,
+    `reset` takes precedence.
   </dd>
 
   <dt>Method</dt>
@@ -25,8 +27,14 @@ description: |-
     <ul>
       <li>
         <span class="param">key</span>
-        <span class="param-flags">required</span>
+        <span class="param-flags">optional</span>
         A single master share key.
+      </li>
+      <li>
+        <span class="param">reset</span>
+        <span class="param-flags">optional</span>
+        A boolean; if true, the previously-provided unseal keys are discarded
+        from memory and the unseal process is reset.
       </li>
     </ul>
   </dd>


### PR DESCRIPTION
Reset clears the provided unseal keys, allowing the process to be begun
again. Includes documentation and unit test changes.

Fixes #695