### PR TITLE
Documentation update around path/key name encryption.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ generate them, leading to client errors.
 
 MISC:
 
- * Various documentation fixes and improvements [GH-685] [GH-688] [GH-715]
+ * Various documentation fixes and improvements [GH-685] [GH-688] [GH-697]
+   [GH-715]
 
 ## 0.3.1 (October 6, 2015)
 

--- a/website/source/docs/secrets/generic/index.html.md
+++ b/website/source/docs/secrets/generic/index.html.md
@@ -19,6 +19,10 @@ of these backends at different mount points as you like.
 Writing to a key in the `secret/` backend will replace the old value;
 sub-fields are not merged together.
 
+**Note**: Path and key names are _not_ obfuscated or encrypted; only the values
+set on keys are. You should not store sensitive information as part of a
+secret's path.
+
 ## Quick Start
 
 The generic backend allows for writing keys with arbitrary values. A `ttl` value


### PR DESCRIPTION
Make it clear that path/key names in generic are not encrypted.

Fixes #697