### PR TITLE
Make the token store's Create and RootToken functions non-exported.

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -642,7 +642,7 @@ func (c *Core) handleLoginRequest(req *logical.Request) (*logical.Response, *log
 			TTL:          auth.TTL,
 		}
 
-		if err := c.tokenStore.Create(&te); err != nil {
+		if err := c.tokenStore.create(&te); err != nil {
 			c.logger.Printf("[ERR] core: failed to create token: %v", err)
 			return nil, auth, ErrInternalError
 		}
@@ -839,7 +839,7 @@ func (c *Core) Initialize(config *SealConfig) (*InitResult, error) {
 	}
 
 	// Generate a new root token
-	rootToken, err := c.tokenStore.RootToken()
+	rootToken, err := c.tokenStore.rootToken()
 	if err != nil {
 		c.logger.Printf("[ERR] core: root token generation failed: %v", err)
 		return nil, err

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -117,7 +117,7 @@ func TestExpiration_Register(t *testing.T) {
 
 func TestExpiration_RegisterAuth(t *testing.T) {
 	exp := mockExpiration(t)
-	root, err := exp.tokenStore.RootToken()
+	root, err := exp.tokenStore.rootToken()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestExpiration_RegisterAuth(t *testing.T) {
 
 func TestExpiration_RegisterAuth_NoLease(t *testing.T) {
 	exp := mockExpiration(t)
-	root, err := exp.tokenStore.RootToken()
+	root, err := exp.tokenStore.rootToken()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -380,7 +380,7 @@ func TestExpiration_RevokeByToken(t *testing.T) {
 
 func TestExpiration_RenewToken(t *testing.T) {
 	exp := mockExpiration(t)
-	root, err := exp.tokenStore.RootToken()
+	root, err := exp.tokenStore.rootToken()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -411,7 +411,7 @@ func TestExpiration_RenewToken(t *testing.T) {
 
 func TestExpiration_RenewToken_NotRenewable(t *testing.T) {
 	exp := mockExpiration(t)
-	root, err := exp.tokenStore.RootToken()
+	root, err := exp.tokenStore.rootToken()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -652,7 +652,7 @@ func TestExpiration_revokeEntry(t *testing.T) {
 
 func TestExpiration_revokeEntry_token(t *testing.T) {
 	exp := mockExpiration(t)
-	root, err := exp.tokenStore.RootToken()
+	root, err := exp.tokenStore.rootToken()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/vault/helper/salt"
 	"github.com/hashicorp/uuid"
+	"github.com/hashicorp/vault/helper/salt"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 	"github.com/mitchellh/mapstructure"
@@ -278,14 +278,14 @@ func (ts *TokenStore) SaltID(id string) string {
 }
 
 // RootToken is used to generate a new token with root privileges and no parent
-func (ts *TokenStore) RootToken() (*TokenEntry, error) {
+func (ts *TokenStore) rootToken() (*TokenEntry, error) {
 	te := &TokenEntry{
 		Policies:     []string{"root"},
 		Path:         "auth/token/root",
 		DisplayName:  "root",
 		CreationTime: time.Now().Unix(),
 	}
-	if err := ts.Create(te); err != nil {
+	if err := ts.create(te); err != nil {
 		return nil, err
 	}
 	return te, nil
@@ -293,7 +293,7 @@ func (ts *TokenStore) RootToken() (*TokenEntry, error) {
 
 // Create is used to create a new token entry. The entry is assigned
 // a newly generated ID if not provided.
-func (ts *TokenStore) Create(entry *TokenEntry) error {
+func (ts *TokenStore) create(entry *TokenEntry) error {
 	defer metrics.MeasureSince([]string{"token", "create"}, time.Now())
 	// Generate an ID if necessary
 	if entry.ID == "" {
@@ -622,7 +622,7 @@ func (ts *TokenStore) handleCreate(
 	}
 
 	// Create the token
-	if err := ts.Create(&te); err != nil {
+	if err := ts.create(&te); err != nil {
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
 

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -52,7 +52,7 @@ func mockTokenStore(t *testing.T) (*Core, *TokenStore, string) {
 func TestTokenStore_RootToken(t *testing.T) {
 	_, ts, _ := mockTokenStore(t)
 
-	te, err := ts.RootToken()
+	te, err := ts.rootToken()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestTokenStore_CreateLookup(t *testing.T) {
 	c, ts, _ := mockTokenStore(t)
 
 	ent := &TokenEntry{Path: "test", Policies: []string{"dev", "ops"}}
-	if err := ts.Create(ent); err != nil {
+	if err := ts.create(ent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if ent.ID == "" {
@@ -112,7 +112,7 @@ func TestTokenStore_CreateLookup_ProvidedID(t *testing.T) {
 		Path:     "test",
 		Policies: []string{"dev", "ops"},
 	}
-	if err := ts.Create(ent); err != nil {
+	if err := ts.create(ent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if ent.ID != "foobarbaz" {
@@ -170,7 +170,7 @@ func TestTokenStore_UseToken(t *testing.T) {
 
 	// Create a retstricted token
 	ent = &TokenEntry{Path: "test", Policies: []string{"dev", "ops"}, NumUses: 2}
-	if err := ts.Create(ent); err != nil {
+	if err := ts.create(ent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -213,7 +213,7 @@ func TestTokenStore_Revoke(t *testing.T) {
 	_, ts, _ := mockTokenStore(t)
 
 	ent := &TokenEntry{Path: "test", Policies: []string{"dev", "ops"}}
-	if err := ts.Create(ent); err != nil {
+	if err := ts.create(ent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -243,7 +243,7 @@ func TestTokenStore_Revoke_Leases(t *testing.T) {
 	ts.expiration.router.Mount(noop, "", &MountEntry{UUID: ""}, nil)
 
 	ent := &TokenEntry{Path: "test", Policies: []string{"dev", "ops"}}
-	if err := ts.Create(ent); err != nil {
+	if err := ts.create(ent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -289,12 +289,12 @@ func TestTokenStore_Revoke_Orphan(t *testing.T) {
 	_, ts, _ := mockTokenStore(t)
 
 	ent := &TokenEntry{Path: "test", Policies: []string{"dev", "ops"}}
-	if err := ts.Create(ent); err != nil {
+	if err := ts.create(ent); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	ent2 := &TokenEntry{Parent: ent.ID}
-	if err := ts.Create(ent2); err != nil {
+	if err := ts.create(ent2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -316,22 +316,22 @@ func TestTokenStore_RevokeTree(t *testing.T) {
 	_, ts, _ := mockTokenStore(t)
 
 	ent1 := &TokenEntry{}
-	if err := ts.Create(ent1); err != nil {
+	if err := ts.create(ent1); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	ent2 := &TokenEntry{Parent: ent1.ID}
-	if err := ts.Create(ent2); err != nil {
+	if err := ts.create(ent2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	ent3 := &TokenEntry{Parent: ent2.ID}
-	if err := ts.Create(ent3); err != nil {
+	if err := ts.create(ent3); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	ent4 := &TokenEntry{Parent: ent2.ID}
-	if err := ts.Create(ent4); err != nil {
+	if err := ts.create(ent4); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -360,22 +360,22 @@ func TestTokenStore_RevokeSelf(t *testing.T) {
 	_, ts, _ := mockTokenStore(t)
 
 	ent1 := &TokenEntry{}
-	if err := ts.Create(ent1); err != nil {
+	if err := ts.create(ent1); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	ent2 := &TokenEntry{Parent: ent1.ID}
-	if err := ts.Create(ent2); err != nil {
+	if err := ts.create(ent2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	ent3 := &TokenEntry{Parent: ent2.ID}
-	if err := ts.Create(ent3); err != nil {
+	if err := ts.create(ent3); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	ent4 := &TokenEntry{Parent: ent2.ID}
-	if err := ts.Create(ent4); err != nil {
+	if err := ts.create(ent4); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -859,7 +859,7 @@ func TestTokenStore_HandleRequest_RevokePrefix(t *testing.T) {
 	ts := exp.tokenStore
 
 	// Create new token
-	root, err := ts.RootToken()
+	root, err := ts.rootToken()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -926,7 +926,7 @@ func TestTokenStore_HandleRequest_Renew(t *testing.T) {
 	ts := exp.tokenStore
 
 	// Create new token
-	root, err := ts.RootToken()
+	root, err := ts.rootToken()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -970,7 +970,7 @@ func TestTokenStore_HandleRequest_RenewSelf(t *testing.T) {
 	ts := exp.tokenStore
 
 	// Create new token
-	root, err := ts.RootToken()
+	root, err := ts.rootToken()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
Nothing requires them to be exported, and I don't want anything in the
future to think it's okay to simply create a root token when it likes.