### PR TITLE
Revoke permissions before dropping user in postgresql.

### DIFF
--- a/builtin/logical/postgresql/secret_creds.go
+++ b/builtin/logical/postgresql/secret_creds.go
@@ -101,8 +101,62 @@ func (b *backend) secretCredsRevoke(
 		return nil, err
 	}
 
-	// Drop this user
+	// Query for permissions; we need to revoke permissions before we can drop
+	// the role
+	// This isn't done in a transaction because even if we fail along the way,
+	// we want to remove as much access as possible
 	stmt, err := db.Prepare(fmt.Sprintf(
+		"SELECT DISTINCT table_schema FROM information_schema.role_column_grants WHERE grantee='%s';",
+		username))
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var revocationStmts []string
+	for rows.Next() {
+		var schema string
+		err = rows.Scan(&schema)
+		if err != nil {
+			// keep going; remove as many permissions as possible right now
+			continue
+		}
+		revocationStmts = append(revocationStmts, fmt.Sprintf(
+			"REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s FROM %s;",
+			schema, pq.QuoteIdentifier(username)))
+	}
+
+	// again, here, we do not stop on error, as we want to remove as
+	// many permissions as possible right now
+	var lastStmtError error
+	for _, query := range revocationStmts {
+		stmt, err := db.Prepare(query)
+		if err != nil {
+			lastStmtError = err
+			continue
+		}
+		_, err = stmt.Exec()
+		if err != nil {
+			lastStmtError = err
+		}
+	}
+
+	// can't drop if not all privileges are revoked
+	if rows.Err() != nil {
+		return logical.ErrorResponse(fmt.Sprintf("could not generate revocation statements for all rows: %v", rows.Err())), nil
+	}
+	if lastStmtError != nil {
+		return logical.ErrorResponse(fmt.Sprintf("could not perform all revocation statements: %v", lastStmtError)), nil
+	}
+
+	// Drop this user
+	stmt, err = db.Prepare(fmt.Sprintf(
 		"DROP ROLE IF EXISTS %s;", pq.QuoteIdentifier(username)))
 	if err != nil {
 		return nil, err

--- a/logical/testing.go
+++ b/logical/testing.go
@@ -3,6 +3,7 @@ package logical
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 // TestRequest is a helper to create a purely in-memory Request struct.
@@ -57,5 +58,21 @@ func TestStorage(t *testing.T, s Storage) {
 	}
 	if len(keys) > 0 {
 		t.Fatalf("should have no keys to start: %#v", keys)
+	}
+}
+
+func TestSystemView() *StaticSystemView {
+	defaultLeaseTTLVal := time.Hour * 24
+	maxLeaseTTLVal := time.Hour * 24 * 2
+	return &StaticSystemView{
+		DefaultLeaseTTLVal: defaultLeaseTTLVal,
+		MaxLeaseTTLVal:     maxLeaseTTLVal,
+	}
+}
+
+func TestBackendConfig() *BackendConfig {
+	return &BackendConfig{
+		Logger: nil,
+		System: TestSystemView(),
 	}
 }


### PR DESCRIPTION
Currently permissions are not revoked, which can lead revocation to not
actually work properly. This attempts to revoke all permissions and only
then drop the role.

Fixes issue #699