### PR TITLE
Support renewable tokens in the app-id auth backend

### DIFF
--- a/logical/framework/path_map.go
+++ b/logical/framework/path_map.go
@@ -22,6 +22,10 @@ type PathMap struct {
 	CaseSensitive bool
 	Salt          *salt.Salt
 
+	// Allows the ability to intercept the request and modify it or cancel before
+	// the default task is performed here
+	Callbacks     map[logical.Operation]OperationFunc
+
 	once sync.Once
 }
 
@@ -132,8 +136,14 @@ func (p *PathMap) Paths() []*Path {
 	}
 }
 
-func (p *PathMap) pathList(
-	req *logical.Request, d *FieldData) (*logical.Response, error) {
+func (p *PathMap) pathList(req *logical.Request, d *FieldData) (*logical.Response, error) {
+	if p.Callbacks[logical.ListOperation] != nil {
+		res, err := p.Callbacks[logical.ListOperation](req, d)
+		if res != nil || err != nil {
+			return res, err
+		}
+	}
+
 	keys, err := req.Storage.List(req.Path)
 	if err != nil {
 		return nil, err
@@ -142,8 +152,14 @@ func (p *PathMap) pathList(
 	return logical.ListResponse(keys), nil
 }
 
-func (p *PathMap) pathSingleRead(
-	req *logical.Request, d *FieldData) (*logical.Response, error) {
+func (p *PathMap) pathSingleRead(req *logical.Request, d *FieldData) (*logical.Response, error) {
+	if p.Callbacks[logical.ReadOperation] != nil {
+		res, err := p.Callbacks[logical.ReadOperation](req, d)
+		if res != nil || err != nil {
+			return res, err
+		}
+	}
+
 	v, err := p.Get(req.Storage, d.Get("key").(string))
 	if err != nil {
 		return nil, err
@@ -154,14 +170,26 @@ func (p *PathMap) pathSingleRead(
 	}, nil
 }
 
-func (p *PathMap) pathSingleWrite(
-	req *logical.Request, d *FieldData) (*logical.Response, error) {
+func (p *PathMap) pathSingleWrite(req *logical.Request, d *FieldData) (*logical.Response, error) {
+	if p.Callbacks[logical.WriteOperation] != nil {
+		res, err := p.Callbacks[logical.WriteOperation](req, d)
+		if res != nil || err != nil {
+			return res, err
+		}
+	}
+
 	err := p.Put(req.Storage, d.Get("key").(string), d.Raw)
 	return nil, err
 }
 
-func (p *PathMap) pathSingleDelete(
-	req *logical.Request, d *FieldData) (*logical.Response, error) {
+func (p *PathMap) pathSingleDelete(req *logical.Request, d *FieldData) (*logical.Response, error) {
+	if p.Callbacks[logical.DeleteOperation] != nil {
+		res, err := p.Callbacks[logical.DeleteOperation](req, d)
+		if res != nil || err != nil {
+			return res, err
+		}
+	}
+
 	err := p.Delete(req.Storage, d.Get("key").(string))
 	return nil, err
 }

--- a/logical/testing/testing.go
+++ b/logical/testing/testing.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/physical"
 	"github.com/hashicorp/vault/vault"
+	"time"
 )
 
 // TestEnvVar must be set to a non-empty value for acceptance tests to run.
@@ -323,6 +324,16 @@ func TestCheckAuthDisplayName(n string) TestCheckFunc {
 		}
 		if n != "" && resp.Auth.DisplayName != "mnt-"+n {
 			return fmt.Errorf("invalid display name: %#v", resp.Auth.DisplayName)
+		}
+
+		return nil
+	}
+}
+
+func TestCheckAuthTTLs(t time.Duration) TestCheckFunc {
+	return func(resp *logical.Response) error {
+		if resp.Auth.TTL.String() != t.String() {
+			return fmt.Errorf("response ttl %s did not match %s", resp.Auth.TTL.String(), t.String())
 		}
 
 		return nil


### PR DESCRIPTION
This PR will ultimately allow for someone using the `app-id` auth backend to greatly reduce the number of leases there are at any given time.

I had to make a few interesting changes to the `PathMap` framework to allow an implementation to hook into the request/response lifecycle for extra validation that didn't seem like to belong in `PathMap` or `PolicyMap`. 

I was unable to write acceptance tests for renewing an `app-id` auth token due to the way the `logical.Testing` framework made assumptions on the a requests path by prefixing it with, at very least, `mnt/`.

I am more than happy to make any changes!