### PR TITLE
Run preSeal if postUnseal fails.

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	// errLoadAuthFailed if loadCreddentials encounters an error
+	// errLoadAuthFailed if loadCredentials encounters an error
 	errLoadAuthFailed = errors.New("failed to setup auth table")
 )
 
@@ -203,6 +203,7 @@ func (c *Core) loadCredentials() error {
 	// Create and persist the default auth table
 	c.auth = defaultAuthTable()
 	if err := c.persistAuth(c.auth); err != nil {
+		c.logger.Printf("[ERR] core: failed to persist auth table: %v", err)
 		return errLoadAuthFailed
 	}
 	return nil

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -62,6 +62,9 @@ func TestCore_EnableCredential(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	c2.credentialBackends["noop"] = func(*logical.BackendConfig) (logical.Backend, error) {
+		return &NoopBackend{}, nil
+	}
 	unseal, err := c2.Unseal(key)
 	if err != nil {
 		t.Fatalf("err: %v", err)


### PR DESCRIPTION
This also ensures that every error path out of postUnseal returns an
error.

Fixes #733