### PR TITLE
Add a PermitPool to physical and consul/inmem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ IMPROVEMENTS:
  * logical: Responses now contain a "warnings" key containing a list of
    warnings returned from the server. These are conditions that did not require
 failing an operation, but of which the client should be aware. [GH-676]
+ * physical/consul: Consul now uses a connection pool to limit the number of
+   outstanding operations, improving behavior when a lot of operations must
+   happen at once [GH-677]
 
 BUG FIXES:
 

--- a/physical/consul_test.go
+++ b/physical/consul_test.go
@@ -28,8 +28,9 @@ func TestConsulBackend(t *testing.T) {
 	}()
 
 	b, err := NewBackend("consul", map[string]string{
-		"address": addr,
-		"path":    randPath,
+		"address":      addr,
+		"path":         randPath,
+		"max_parallel": "256",
 	})
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -58,8 +59,9 @@ func TestConsulHABackend(t *testing.T) {
 	}()
 
 	b, err := NewBackend("consul", map[string]string{
-		"address": addr,
-		"path":    randPath,
+		"address":      addr,
+		"path":         randPath,
+		"max_parallel": "-1",
 	})
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/physical/consul_test.go
+++ b/physical/consul_test.go
@@ -37,6 +37,33 @@ func TestConsulBackend(t *testing.T) {
 
 	testBackend(t, b)
 	testBackend_ListPrefix(t, b)
+}
+
+func TestConsulHABackend(t *testing.T) {
+	addr := os.Getenv("CONSUL_ADDR")
+	if addr == "" {
+		t.SkipNow()
+	}
+
+	conf := api.DefaultConfig()
+	conf.Address = addr
+	client, err := api.NewClient(conf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	randPath := fmt.Sprintf("vault-%d/", time.Now().Unix())
+	defer func() {
+		client.KV().DeleteTree(randPath, nil)
+	}()
+
+	b, err := NewBackend("consul", map[string]string{
+		"address": addr,
+		"path":    randPath,
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
 	ha, ok := b.(HABackend)
 	if !ok {

--- a/physical/inmem.go
+++ b/physical/inmem.go
@@ -20,7 +20,7 @@ type InmemBackend struct {
 func NewInmem() *InmemBackend {
 	in := &InmemBackend{
 		root:       radix.New(),
-		permitPool: NewPermitPool(64),
+		permitPool: NewPermitPool(DefaultParallelOperations),
 	}
 	return in
 }

--- a/physical/inmem.go
+++ b/physical/inmem.go
@@ -27,11 +27,11 @@ func NewInmem() *InmemBackend {
 
 // Put is used to insert or update an entry
 func (i *InmemBackend) Put(entry *Entry) error {
-	i.l.Lock()
-	defer i.l.Unlock()
-
 	i.permitPool.Acquire()
 	defer i.permitPool.Release()
+
+	i.l.Lock()
+	defer i.l.Unlock()
 
 	i.root.Insert(entry.Key, entry)
 	return nil
@@ -39,11 +39,11 @@ func (i *InmemBackend) Put(entry *Entry) error {
 
 // Get is used to fetch an entry
 func (i *InmemBackend) Get(key string) (*Entry, error) {
-	i.l.RLock()
-	defer i.l.RUnlock()
-
 	i.permitPool.Acquire()
 	defer i.permitPool.Release()
+
+	i.l.RLock()
+	defer i.l.RUnlock()
 
 	if raw, ok := i.root.Get(key); ok {
 		return raw.(*Entry), nil
@@ -53,11 +53,11 @@ func (i *InmemBackend) Get(key string) (*Entry, error) {
 
 // Delete is used to permanently delete an entry
 func (i *InmemBackend) Delete(key string) error {
-	i.l.Lock()
-	defer i.l.Unlock()
-
 	i.permitPool.Acquire()
 	defer i.permitPool.Release()
+
+	i.l.Lock()
+	defer i.l.Unlock()
 
 	i.root.Delete(key)
 	return nil
@@ -66,11 +66,11 @@ func (i *InmemBackend) Delete(key string) error {
 // List is used ot list all the keys under a given
 // prefix, up to the next prefix.
 func (i *InmemBackend) List(prefix string) ([]string, error) {
-	i.l.RLock()
-	defer i.l.RUnlock()
-
 	i.permitPool.Acquire()
 	defer i.permitPool.Release()
+
+	i.l.RLock()
+	defer i.l.RUnlock()
 
 	var out []string
 	seen := make(map[string]interface{})

--- a/physical/physical.go
+++ b/physical/physical.go
@@ -6,6 +6,8 @@ import (
 	"github.com/abiosoft/semaphore"
 )
 
+const DefaultParallelOperations = 128
+
 // Backend is the interface required for a physical
 // backend. A physical backend is used to durably store
 // data outside of Vault. As such, it is completely untrusted,
@@ -103,7 +105,7 @@ func NewPermitPool(permits int) *PermitPool {
 	// the semaphore library panics if it's less than 1,
 	// so instead use something sane
 	if permits < 1 {
-		permits = 64
+		permits = DefaultParallelOperations
 	}
 	return &PermitPool{
 		s: semaphore.New(permits),

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -125,6 +125,9 @@ For Consul, the following options are supported:
 
   * `token` (optional) - An access token to use to write data to Consul.
 
+  * `max_parallel` (optional) - The maximum number of connections to Consul;
+      defaults to "128".
+
   * `tls_skip_verify` (optional) - If non-empty, then TLS host verification
       will be disabled for Consul communication.
       Defaults to false.


### PR DESCRIPTION
The permit pool controls the number of outstanding operations that can
be queued for Consul (and inmem, for testing purposes). This prevents
possible situations where Vault launches thousands of concurrent
connections to Consul if e.g. a huge number of leases need to be
expired.

Fixes #677