### PR TITLE
Add an option to configure the S3 endpoint

### DIFF
--- a/physical/physical.go
+++ b/physical/physical.go
@@ -69,7 +69,7 @@ type Entry struct {
 // Factory is the factory function to create a physical backend.
 type Factory func(map[string]string) (Backend, error)
 
-// NewBackend returns a new Bckend with the given type and configuration.
+// NewBackend returns a new backend with the given type and configuration.
 // The backend is looked up in the BuiltinBackends variable.
 func NewBackend(t string, conf map[string]string) (Backend, error) {
 	f, ok := BuiltinBackends[t]

--- a/physical/s3.go
+++ b/physical/s3.go
@@ -47,6 +47,10 @@ func newS3Backend(conf map[string]string) (Backend, error) {
 	if !ok {
 		session_token = ""
 	}
+	endpoint, ok := conf["endpoint"]
+	if !ok {
+		endpoint = ""
+	}
 	region, ok := conf["region"]
 	if !ok {
 		region = os.Getenv("AWS_DEFAULT_REGION")
@@ -68,6 +72,7 @@ func newS3Backend(conf map[string]string) (Backend, error) {
 
 	s3conn := s3.New(session.New(&aws.Config{
 		Credentials: creds,
+		Endpoint:    aws.String(endpoint),
 		Region:      aws.String(region),
 	}))
 

--- a/physical/s3.go
+++ b/physical/s3.go
@@ -49,7 +49,7 @@ func newS3Backend(conf map[string]string) (Backend, error) {
 	}
 	endpoint, ok := conf["endpoint"]
 	if !ok {
-		endpoint = ""
+		endpoint = os.Getenv("AWS_S3_ENDPOINT")
 	}
 	region, ok := conf["region"]
 	if !ok {

--- a/physical/s3_test.go
+++ b/physical/s3_test.go
@@ -23,6 +23,10 @@ func TestS3Backend(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// If the variable is empty or doesn't exist, the default
+	// AWS endpoints will be used
+	endpoint := os.Getenv("AWS_S3_ENDPOINT")
+
 	region := os.Getenv("AWS_DEFAULT_REGION")
 	if region == "" {
 		region = "us-east-1"
@@ -30,6 +34,7 @@ func TestS3Backend(t *testing.T) {
 
 	s3conn := s3.New(session.New(&aws.Config{
 		Credentials: credentials.NewEnvCredentials(),
+		Endpoint:    aws.String(endpoint),
 		Region:      aws.String(region),
 	}))
 

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -178,6 +178,8 @@ For S3, the following options are supported:
 
   * `session_token` - (optional) The AWS session_token. It can also be sourced from the AWS_SESSION_TOKEN environment variable.
 
+  * `endpoint` - (optional) An alternative (AWS compatible) S3 endpoint to use. It can also be sourced from the AWS_S3_ENDPOINT environment variable.  
+
   * `region` (optional) - The AWS region. It can be sourced from the AWS_DEFAULT_REGION environment variable and will default to "us-east-1" if not specified.
 
 If you are running your Vault server on an EC2 instance, you can also make use


### PR DESCRIPTION
This enables the use of other (AWS S3 compatible) S3 endpoints.