### PR TITLE
Move environment variable reading logic to API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ IMPROVEMENTS:
  * api: API client now uses a 60 second timeout instead of indefinite [GH-681]
  * api: Implement LookupSelf, RenewSelf, and RevokeSelf functions for auth
    tokens [GH-739]
+ * api: Standardize environment variable reading logic inside the API; the CLI
+   now uses this but can still override via command-line parameters [GH-618]
  * audit: HMAC-SHA256'd client tokens are now stored with each request entry.
    Previously they were only displayed at creation time; this allows much
    better traceability of client actions. [GH-713]

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -3,13 +3,11 @@ package api
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/hashicorp/hcl"
@@ -95,9 +93,9 @@ func (c *SSHAgentConfig) NewClient() (*Client, error) {
 		var certPool *x509.CertPool
 		var err error
 		if c.CACert != "" {
-			certPool, err = loadCACert(c.CACert)
+			certPool, err = LoadCACert(c.CACert)
 		} else if c.CAPath != "" {
-			certPool, err = loadCAPath(c.CAPath)
+			certPool, err = LoadCAPath(c.CAPath)
 		}
 		if err != nil {
 			return nil, err
@@ -198,75 +196,4 @@ func (c *SSHAgent) Verify(otp string) (*SSHVerifyResponse, error) {
 		return nil, err
 	}
 	return &verifyResp, nil
-}
-
-// Loads the certificate from given path and creates a certificate pool from it.
-func loadCACert(path string) (*x509.CertPool, error) {
-	certs, err := loadCertFromPEM(path)
-	if err != nil {
-		return nil, err
-	}
-
-	result := x509.NewCertPool()
-	for _, cert := range certs {
-		result.AddCert(cert)
-	}
-
-	return result, nil
-}
-
-// Loads the certificates present in the given directory and creates a
-// certificate pool from it.
-func loadCAPath(path string) (*x509.CertPool, error) {
-	result := x509.NewCertPool()
-	fn := func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		certs, err := loadCertFromPEM(path)
-		if err != nil {
-			return err
-		}
-
-		for _, cert := range certs {
-			result.AddCert(cert)
-		}
-		return nil
-	}
-
-	return result, filepath.Walk(path, fn)
-}
-
-// Creates a certificate from the given path
-func loadCertFromPEM(path string) ([]*x509.Certificate, error) {
-	pemCerts, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	certs := make([]*x509.Certificate, 0, 5)
-	for len(pemCerts) > 0 {
-		var block *pem.Block
-		block, pemCerts = pem.Decode(pemCerts)
-		if block == nil {
-			break
-		}
-		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
-			continue
-		}
-
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return nil, err
-		}
-
-		certs = append(certs, cert)
-	}
-
-	return certs, nil
 }

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"flag"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -38,39 +37,5 @@ func TestFlagSet(t *testing.T) {
 			t.Fatalf("%d: flags: %#v\n\nExpected: %#v\nGot: %#v",
 				i, tc.Flags, tc.Expected, actual)
 		}
-	}
-}
-
-func TestEnvSettings(t *testing.T) {
-	os.Setenv("VAULT_CACERT", "/path/to/fake/cert.crt")
-	os.Setenv("VAULT_CAPATH", "/path/to/fake/certs")
-	os.Setenv("VAULT_CLIENT_CERT", "/path/to/fake/client.crt")
-	os.Setenv("VAULT_CLIENT_KEY", "/path/to/fake/client.key")
-	os.Setenv("VAULT_SKIP_VERIFY", "true")
-	defer os.Setenv("VAULT_CACERT", "")
-	defer os.Setenv("VAULT_CAPATH", "")
-	defer os.Setenv("VAULT_CLIENT_CERT", "")
-	defer os.Setenv("VAULT_CLIENT_KEY", "")
-	defer os.Setenv("VAULT_SKIP_VERIFY", "")
-	var m Meta
-
-	// Err is ignored as it is expected that the test settings
-	// will cause errors; just check the flag settings
-	m.Client()
-
-	if m.flagCACert != "/path/to/fake/cert.crt" {
-		t.Fatalf("bad: %s", m.flagAddress)
-	}
-	if m.flagCAPath != "/path/to/fake/certs" {
-		t.Fatalf("bad: %s", m.flagAddress)
-	}
-	if m.flagClientCert != "/path/to/fake/client.crt" {
-		t.Fatalf("bad: %s", m.flagAddress)
-	}
-	if m.flagClientKey != "/path/to/fake/client.key" {
-		t.Fatalf("bad: %s", m.flagAddress)
-	}
-	if m.flagInsecure != true {
-		t.Fatalf("bad: %s", m.flagAddress)
 	}
 }


### PR DESCRIPTION
This allows the same environment variables to be read, parsed, and used
from any API client as was previously handled in the CLI. The CLI now
uses the API environment variable reading capability, then overrides any
values from command line flags, if necessary.

Fixes #618