### PR TITLE
Allow s3 bucket to come from config vars

### DIFF
--- a/physical/s3.go
+++ b/physical/s3.go
@@ -32,7 +32,10 @@ func newS3Backend(conf map[string]string) (Backend, error) {
 
 	bucket, ok := conf["bucket"]
 	if !ok {
-		return nil, fmt.Errorf("'bucket' must be set")
+		bucket = os.Getenv("AWS_S3_BUCKET")
+		if bucket == "" {
+			return nil, fmt.Errorf("'bucket' must be set")
+		}
 	}
 
 	access_key, ok := conf["access_key"]


### PR DESCRIPTION
Accept a config var for the s3 bucket would allow to use only env config for the physical.