### PR TITLE
Make `vault server` print Vault version

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -30,6 +32,39 @@ import (
 	"github.com/mitchellh/cli"
 )
 
+func GetVersion() string {
+	if GitDescribe != "" {
+		return GitDescribe
+	} else {
+		return Version
+	}
+}
+
+func GetVersionPrerelease() string {
+	if VersionPrerelease != "" {
+		return VersionPrerelease
+	} else {
+		return "dev"
+	}
+}
+
+func GetVersionString() string {
+	var versionString bytes.Buffer
+	var version = GetVersion()
+	var versionPrerelease = GetVersionPrerelease()
+
+	fmt.Fprintf(&versionString, "Vault v%s", version)
+	if versionPrerelease != "" {
+		fmt.Fprintf(&versionString, "-%s", versionPrerelease)
+
+		if GitCommit != "" {
+			fmt.Fprintf(&versionString, " (%s)", GitCommit)
+		}
+	}
+
+	return versionString.String()
+}
+
 // Commands returns the mapping of CLI commands for Vault. The meta
 // parameter lets you set meta options for all commands.
 func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
@@ -44,6 +79,11 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 			ErrorWriter: os.Stderr,
 		}
 	}
+
+	meta.Version = GetVersion()
+	meta.VersionPrerelease = GetVersionPrerelease()
+	meta.Revision = GitCommit
+	meta.VersionString = GetVersionString()
 
 	return map[string]cli.CommandFactory{
 		"init": func() (cli.Command, error) {

--- a/command/meta.go
+++ b/command/meta.go
@@ -36,6 +36,11 @@ type Meta struct {
 	ClientToken string
 	Ui          cli.Ui
 
+	Revision          string
+	Version           string
+	VersionPrerelease string
+	VersionString     string
+
 	// The things below can be set, but aren't common
 	ForceAddress string  // Address to force for API clients
 	ForceConfig  *Config // Force a config, don't load from disk

--- a/command/server.go
+++ b/command/server.go
@@ -178,12 +178,13 @@ func (c *ServerCommand) Run(args []string) int {
 	// Compile server information for output later
 	infoKeys := make([]string, 0, 10)
 	info := make(map[string]string)
+	info["version"] = c.Meta.VersionString
 	info["backend"] = config.Backend.Type
 	info["log level"] = logLevel
 	info["mlock"] = fmt.Sprintf(
 		"supported: %v, enabled: %v",
 		mlock.Supported(), !config.DisableMlock)
-	infoKeys = append(infoKeys, "log level", "mlock", "backend")
+	infoKeys = append(infoKeys, "version", "log level", "mlock", "backend")
 
 	// If the backend supports HA, then note it
 	if _, ok := backend.(physical.HABackend); ok {


### PR DESCRIPTION
```
$ bin/vault server -dev
...
==> Vault server configuration:

           Version: Vault v0.3.1-dev (254dcccf4460fbc067f0f1350124392c7aa033a9+CHANGES)
         Log Level: info
             Mlock: supported: false, enabled: false
           Backend: inmem
        Listener 1: tcp (addr: "127.0.0.1:8200", tls: "disabled")
...
```

Fixes GH-765

Cc: @jefferai, @sudarkoff