### PR TITLE
Policy list extention

### DIFF
--- a/command/policy_list.go
+++ b/command/policy_list.go
@@ -2,8 +2,8 @@ package command
 
 import (
 	"fmt"
-	"strings"
 	"github.com/hashicorp/vault/vault"
+	"strings"
 )
 
 const (
@@ -98,7 +98,7 @@ func (c *PolicyListCommand) detailedOutput() int {
 		}
 
 		var deny, write, read, total, sudo int
-		deny, write, read, total,sudo = 0,0,0,0,0
+		deny, write, read, total, sudo = 0, 0, 0, 0, 0
 		pols := make(map[string]int)
 		for _, path := range pol.Paths {
 			if len(path.Prefix) > 0 {
@@ -121,7 +121,7 @@ func (c *PolicyListCommand) detailedOutput() int {
 			"%d. Name: '%s'. Total policies: %d", i+1, policy, total))
 		c.Ui.Output(fmt.Sprintf(
 			"deny: %d, write: %d, read: %d, sudo: %d\n", deny, write, read, sudo))
-		
+
 		output := ""
 		for pol, value := range pols {
 			output += fmt.Sprintf("%s: %d\n", pol, value)

--- a/command/policy_list.go
+++ b/command/policy_list.go
@@ -3,6 +3,14 @@ package command
 import (
 	"fmt"
 	"strings"
+	"github.com/hashicorp/vault/vault"
+)
+
+const (
+	PathPolicyDeny  = "deny"
+	PathPolicyRead  = "read"
+	PathPolicyWrite = "write"
+	PathPolicySudo  = "sudo"
 )
 
 // PolicyListCommand is a Command that enables a new endpoint.
@@ -11,13 +19,18 @@ type PolicyListCommand struct {
 }
 
 func (c *PolicyListCommand) Run(args []string) int {
+	var detailed bool
 	flags := c.Meta.FlagSet("policy-list", FlagSetDefault)
+	flags.BoolVar(&detailed, "detailed", false, "")
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
 
 	args = flags.Args()
+	if detailed {
+		return c.detailedOutput()
+	}
 	if len(args) == 1 {
 		return c.read(args[0])
 	} else if len(args) == 0 {
@@ -47,6 +60,75 @@ func (c *PolicyListCommand) list() int {
 
 	for _, p := range policies {
 		c.Ui.Output(p)
+	}
+
+	return 0
+}
+
+//sorted policy from higher to lower
+func (c *PolicyListCommand) detailedOutput() int {
+	client, err := c.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error initializing client: %s", err))
+		return 2
+	}
+
+	policies, err := client.Sys().ListPolicies()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf(
+			"Error: %s", err))
+		return 1
+	}
+
+	for i, policy := range policies {
+		rules, err := client.Sys().GetPolicy(policy)
+		if err != nil {
+
+		}
+		pol, err := vault.Parse(rules)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf(
+				"Error: %s", err))
+		}
+
+		if policy == "root" {
+			c.Ui.Output(fmt.Sprintf("%d. Name:'%s'", i+1, policy))
+			continue
+		}
+
+		var deny, write, read, total, sudo int
+		deny, write, read, total,sudo = 0,0,0,0,0
+		pols := make(map[string]int)
+		for _, path := range pol.Paths {
+			if len(path.Prefix) > 0 {
+				splitter := strings.Split(path.Prefix, "/")[0]
+				pols[splitter+"/*"]++
+			}
+			switch path.Policy {
+			case PathPolicyDeny:
+				deny++
+			case PathPolicyRead:
+				read++
+			case PathPolicyWrite:
+				write++
+			case PathPolicySudo:
+				sudo++
+			}
+			total++
+		}
+		c.Ui.Output(fmt.Sprintf(
+			"%d. Name: '%s'. Total policies: %d", i+1, policy, total))
+		c.Ui.Output(fmt.Sprintf(
+			"deny: %d, write: %d, read: %d, sudo: %d\n", deny, write, read, sudo))
+		
+		output := ""
+		for pol, value := range pols {
+			output += fmt.Sprintf("%s: %d\n", pol, value)
+		}
+
+		c.Ui.Output(output)
+
 	}
 
 	return 0
@@ -85,6 +167,7 @@ Usage: vault policies [options] [name]
   If a name of a policy is specified, that policy is outputted.
 
 General Options:
+  -detailed               Output detailed information about policies.
 
   ` + generalOptionsUsage()
 	return strings.TrimSpace(helpText)

--- a/command/policy_list_test.go
+++ b/command/policy_list_test.go
@@ -50,3 +50,25 @@ func TestPolicyRead(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 }
+
+func TestPolicyOutputDetailed(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	ui := new(cli.MockUi)
+	c := &PolicyListCommand{
+		Meta: Meta{
+			ClientToken: token,
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-detailed",
+		"-address", addr,
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}


### PR DESCRIPTION
Hi! I added detailed information for command ```vault policies``` and it can be used as ```vault policies -detailed```. This information includes total number of policies for each policy name, number of type of policies and number for each paths. Example ouput for ```vault policies -detailed```
```
1. Name: 'secret'. Total policies: 4
deny: 1, write: 1, read: 2, sudo: 0

secret/*: 3
auth/*: 1

2. Name:'root'
```
Where ```secret``` defines as 
```
path "secret/*" {
  policy = "write"
}

path "secret/foobar" {
  policy = "deny"
}

path "secret/bar" {
    policy = "read"
}

path "auth/token/lookup-self" {
  policy = "read"
}

```