### PR TITLE
Policy. Set goto for panic

### DIFF
--- a/vault/policy.go
+++ b/vault/policy.go
@@ -50,7 +50,7 @@ func (p *PathPolicy) TakesPrecedence(other *PathPolicy) bool {
 		case PathPolicyDeny, PathPolicyWrite, PathPolicySudo:
 			return false
 		default:
-			panic("missing case")
+			goto MC
 		}
 
 	case PathPolicySudo:
@@ -60,12 +60,15 @@ func (p *PathPolicy) TakesPrecedence(other *PathPolicy) bool {
 		case PathPolicyDeny, PathPolicySudo:
 			return false
 		default:
-			panic("missing case")
+			goto MC
 		}
 
 	default:
-		panic("missing case")
+		goto MC
 	}
+MC:
+  panic("missing case")
+
 }
 
 // Parse is used to parse the specified ACL rules into an

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -67,7 +67,7 @@ func (p *PathPolicy) TakesPrecedence(other *PathPolicy) bool {
 		goto MC
 	}
 MC:
-  panic("missing case")
+	panic("missing case")
 
 }
 


### PR DESCRIPTION
Some of refactoring. Instead call ```panic("missing case")``` three times, Set goto for this. 