### PR TITLE
Show error if output format is invalid

### DIFF
--- a/command/format.go
+++ b/command/format.go
@@ -21,9 +21,10 @@ func OutputSecret(ui cli.Ui, format string, secret *api.Secret) int {
 	case "yaml":
 		return outputFormatYAML(ui, secret)
 	case "table":
-		fallthrough
-	default:
 		return outputFormatTable(ui, secret, true)
+	default:
+		ui.Error(fmt.Sprintf("Invalid output format: %s", format))
+		return 1
 	}
 }
 


### PR DESCRIPTION
Rather than silently using `table` as a fallback.