### PR TITLE
Documentation - Change API endpoint path for app-id

### DIFF
--- a/website/source/docs/auth/app-id.html.md
+++ b/website/source/docs/auth/app-id.html.md
@@ -67,7 +67,7 @@ App ID authentication is not allowed via the CLI.
 
 #### Via the API
 
-The endpoint for the App ID login is `/login`. The client is expected
+The endpoint for the App ID login is `auth/app-id/login`. The client is expected
 to provide the `app_id` and `user_id` parameters as part of the request.
 
 ## Configuration


### PR DESCRIPTION
The `/login` path was confusing because its not relative and not consistent with other documentation. Other documentation (e.g., username and password at https://www.vaultproject.io/docs/auth/userpass.html) uses relative path.