### PR TITLE
[helper] support mlock on Solaris/SmartOS

### DIFF
--- a/helper/mlock/mlock_solaris.go
+++ b/helper/mlock/mlock_solaris.go
@@ -1,0 +1,17 @@
+// +build solaris
+
+package mlock
+
+import (
+       "syscall"
+       "golang.org/x/sys/unix"
+)
+
+func init() {
+       supported = true
+}
+
+func lockMemory() error {
+       // Mlockall prevents all current and future pages from being swapped out.
+       return unix.Mlockall(syscall.MCL_CURRENT | syscall.MCL_FUTURE)
+}

--- a/helper/mlock/mlock_unavail.go
+++ b/helper/mlock/mlock_unavail.go
@@ -1,4 +1,4 @@
-// +build windows plan9 darwin freebsd openbsd solaris
+// +build windows plan9 darwin freebsd openbsd
 
 package mlock
 


### PR DESCRIPTION
**mlock** on Solaris is in the new `sys/unix` package structure.  With this change, Vault's **mlock** feature functions on Solaris/SmartOS.  The process must have permission `PRIV_PROC_LOCK_MEMORY`, i.e. specified in the SMF as:

```xml
<method_credential ... privileges="proc_lock_memory" />
```

It's likely other unix-y platforms would work with this change, but I have only tested SmartOS.

Thanks for your work!