### PR TITLE
Fix ipv6 address advertisement

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -354,6 +354,11 @@ func (c *ServerCommand) detectAdvertise(detect physical.AdvertiseDetect,
 		return "", err
 	}
 
+	// set [] for ipv6 addresses
+	if strings.Contains(host, ":") && !strings.Contains(host, "]") {
+		host = "[" + host + "]"
+	}
+
 	// Default the port and scheme
 	scheme := "https"
 	port := 8200


### PR DESCRIPTION
Fixes the advertise address to use square brackets when it's an IPv6 address. 
Otherwise you'll get the  ```dial tcp: too many colons in address``` error.

It checks if there already is a bracket, maybe some of the backends store it already with brackets.