### PR TITLE
Stop panic when vault ssh username fetching fails

### DIFF
--- a/command/ssh.go
+++ b/command/ssh.go
@@ -69,6 +69,7 @@ func (c *SSHCommand) Run(args []string) int {
 		u, err := user.Current()
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error fetching username: %s", err))
+			return 1
 		}
 		username = u.Username
 		ipAddr = input[0]


### PR DESCRIPTION
On linux/amd64 if I run `vault ssh blah` I get a panic:
```
Error fetching username: user: Current not implemented on linux/amd64
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x54cb7b]

goroutine 1 [running]:
github.com/hashicorp/vault/command.(*SSHCommand).Run(0xc8201ae0a0, 0xc82000a320, 0x1, 0x1, 0xc8201bdc28)
	/home/ooesili/golang/src/github.com/hashicorp/vault/command/ssh.go:73 +0x294b
github.com/mitchellh/cli.(*CLI).Run(0xc820106e70, 0xc820106e70, 0x0, 0x0)
	/home/ooesili/golang/src/github.com/hashicorp/vault/Godeps/_workspace/src/github.com/mitchellh/cli/cli.go:112 +0x698
github.com/hashicorp/vault/cli.RunCustom(0xc82000a310, 0x2, 0x2, 0xc8201a8360, 0x2)
	/home/ooesili/golang/src/github.com/hashicorp/vault/cli/main.go:44 +0x452
github.com/hashicorp/vault/cli.Run(0xc82000a310, 0x2, 0x2, 0x9c4ec0)
	/home/ooesili/golang/src/github.com/hashicorp/vault/cli/main.go:11 +0x4c
main.main()
	/home/ooesili/golang/src/github.com/hashicorp/vault/main.go:10 +0x60

goroutine 5 [syscall]:
os/signal.loop()
	/usr/lib/go/src/os/signal/signal_unix.go:22 +0x18
created by os/signal.init.1
	/usr/lib/go/src/os/signal/signal_unix.go:28 +0x37

goroutine 7 [semacquire]:
sync.runtime_Syncsemacquire(0xc8200121c0)
	/usr/lib/go/src/runtime/sema.go:237 +0x201
sync.(*Cond).Wait(0xc8200121b0)
	/usr/lib/go/src/sync/cond.go:62 +0x9b
io.(*pipe).read(0xc820012180, 0xc82020c000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/lib/go/src/io/pipe.go:52 +0x2d2
io.(*PipeReader).Read(0xc82002e278, 0xc82020c000, 0x1000, 0x1000, 0xc82001d978, 0x0, 0x0)
	/usr/lib/go/src/io/pipe.go:134 +0x50
bufio.(*Scanner).Scan(0xc820180d80, 0x2)
	/usr/lib/go/src/bufio/scan.go:180 +0x877
github.com/hashicorp/vault/command.(*Meta).FlagSet.func1(0xc820180d80, 0xc8201ae0a0)
	/home/ooesili/golang/src/github.com/hashicorp/vault/command/meta.go:187 +0x25
created by github.com/hashicorp/vault/command.(*Meta).FlagSet
	/home/ooesili/golang/src/github.com/hashicorp/vault/command/meta.go:190 +0x5e6
```

This seems to be caused by a simple omission of a return statment in an error checking clause. You can see what I mean by looking at the diff for this commit. After the return statement was added, the command stopped panicing:
```
Error fetching username: user: Current not implemented on linux/amd64
```