### PR TITLE
Corrected HTTP Method for api.TokenAuth.LookupSelf() method

### DIFF
--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -26,7 +26,7 @@ func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
 }
 
 func (c *TokenAuth) LookupSelf() (*Secret, error) {
-	r := c.c.NewRequest("POST", "/v1/auth/token/lookup-self")
+	r := c.c.NewRequest("GET", "/v1/auth/token/lookup-self")
 
 	resp, err := c.c.RawRequest(r)
 	if err != nil {

--- a/api/auth_token_test.go
+++ b/api/auth_token_test.go
@@ -34,6 +34,35 @@ func TestAuthTokenCreate(t *testing.T) {
 	}
 }
 
+func TestAuthTokenLookupSelf(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	config := DefaultConfig()
+	config.Address = addr
+
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.SetToken(token)
+
+	// you should be able to lookup your own token
+	secret, err := client.Auth().Token().LookupSelf()
+	if err != nil {
+		t.Fatalf("should be allowed to lookup self, err = %v", err)
+	}
+
+	if secret.Data["id"] != token {
+		t.Errorf("Did not get back details about our own (self) token, id returned=%s", secret.Data["id"])
+	}
+	if secret.Data["display_name"] != "root" {
+		t.Errorf("Did not get back details about our own (self) token, display_name returned=%s", secret.Data["display_name"])
+	}
+
+}
+
 func TestAuthTokenRenew(t *testing.T) {
 	core, _, token := vault.TestCoreUnsealed(t)
 	ln, addr := http.TestServer(t, core)

--- a/command/auth.go
+++ b/command/auth.go
@@ -180,7 +180,7 @@ func (c *AuthCommand) Run(args []string) int {
 	}
 
 	// Verify the token
-	secret, err := client.Logical().Read("auth/token/lookup-self")
+	secret, err := client.Auth().Token().LookupSelf()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(
 			"Error validating token: %s", err))


### PR DESCRIPTION
Calling the `api.TokenAuth.LookupSelf()` method currently throws the following error due to the use of an HTTP POST instead of GET.
```
		URL: POST http://127.0.0.1:63007/v1/auth/token/lookup-self
		Code: 500. Errors:
		* unsupported operation
```

This PR fixes this and also adds a test