### PR TITLE
Fixed "edit this page" not clickable

### DIFF
--- a/website/source/assets/stylesheets/_footer.scss
+++ b/website/source/assets/stylesheets/_footer.scss
@@ -29,7 +29,8 @@ body.page-sub{
 .edit-page-link{
   position: absolute;
   top: -50px;
-  right: 15px;;
+  right: 15px;
+  z-index: 10;
 
   a{
     text-transform: uppercase;


### PR DESCRIPTION
The link in .edit-page-link is moved using top and right properties, which puts it "under" the layer of the rest of the page (at least in the docs). Changing the z-index fixes it.

**EDIT** Additional informations: I'm using Microsoft Edge 25.10586.  
After further inspection, I found out that the element of class `bs-docs-section` is the culprit, with a z-index of 10.