### PR TITLE
fix CA compatibility with OpenSSL

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -687,7 +687,11 @@ func addKeyUsages(creationInfo *creationBundle, certTemplate *x509.Certificate) 
 		// Go performs validation not according to spec but according to the Windows
 		// Crypto API, so we add all usages to CA certs
 		certTemplate.KeyUsage = x509.KeyUsage(certTemplate.KeyUsage | x509.KeyUsageCertSign | x509.KeyUsageCRLSign)
-		certTemplate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
+		certTemplate.ExtKeyUsage = []x509.ExtKeyUsage{
+			x509.ExtKeyUsageAny,
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		}
 	}
 }
 


### PR DESCRIPTION
vault master creates CAs which are incompatible with OpenSSL-based TLS clients

See https://gist.github.com/issacg/606e0b37dda524230b45 for the error + fixed behavior