### PR TITLE
allow underscores in hostnames

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -56,7 +56,7 @@ type caInfoBundle struct {
 }
 
 var (
-	hostnameRegex                = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
+	hostnameRegex                = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-_]*[A-Za-z0-9])$`)
 	oidExtensionBasicConstraints = []int{2, 5, 29, 19}
 )
 


### PR DESCRIPTION
I just ran into this.  I'm not sure if there's a particular reason behind the existing regexp...

```
vault write pki-consul/issue/my.corp.consul common_name=lab-consul-acmain_us-west-2a_i-190c97d0.my.corp.consul
Error writing data to pki-consul/issue/my.corp.consul: Error making API request.

URL: PUT https://127.0.0.1:8200/v1/pki-consul/issue/my.corp.consul
Code: 400. Errors:

* name lab-consul-acmain_us-west-2a_i-190c97d0.my.corp.consul not allowed by this role
```