### PR TITLE
Allow use of pre-existing policies for AWS users

### DIFF
--- a/builtin/logical/aws/path_roles.go
+++ b/builtin/logical/aws/path_roles.go
@@ -82,7 +82,7 @@ func useInlinePolicy(d *framework.FieldData) (bool, error) {
 	ba := d.Get("arn").(string) != ""
 
 	if !bp && !ba {
-		return false, errors.New("At least one of policy or arn should be provided")
+		return false, errors.New("Either policy or arn must be provided")
 	}
 	if bp && ba {
 		return false, errors.New("Only one of policy or arn should be provided")
@@ -127,17 +127,21 @@ func pathRolesWrite(
 }
 
 const pathRolesHelpSyn = `
-Read and write IAM policies that access keys can be made for.
+Read, write and reference IAM policies that access keys can be made for.
 `
 
 const pathRolesHelpDesc = `
 This path allows you to read and write roles that are used to
-create access keys. These roles have IAM policies that map directly to the route to read the
-access keys. For example, if the backend is mounted at "aws" and you
-create a role at "aws/roles/deploy" then a user could request access
-credentials at "aws/creds/deploy".
+create access keys. These roles are associated with IAM policies that
+map directly to the route to read the access keys. For example, if the
+backend is mounted at "aws" and you create a role at "aws/roles/deploy"
+then a user could request access credentials at "aws/creds/deploy".
 
-The policies written are normal IAM policies. Vault will not attempt to
-parse these except to validate that they're basic JSON. To validate the
-keys, attempt to read an access key after writing the policy.
+You can either supply a user inline policy (via the policy argument), or
+provide a reference to an existing AWS policy by supplying the full arn
+reference (via the arn argument). Inline user policies written are normal
+IAM policies. Vault will not attempt to parse these except to validate
+that they're basic JSON. No validation is performed on arn references.
+
+To validate the keys, attempt to read an access key after writing the policy.
 `

--- a/builtin/logical/aws/secret_access_keys_test.go
+++ b/builtin/logical/aws/secret_access_keys_test.go
@@ -4,22 +4,41 @@ import (
 	"testing"
 )
 
-func TestNormalizeDisplayName(t *testing.T) {
-	invalidName := "^#$test name\nshould be normalized)(*"
-	expectedName := "___test_name_should_be_normalized___"
-	normalizedName := normalizeDisplayName(invalidName)
-	if normalizedName != expectedName {
-		t.Fatalf(
-			"normalizeDisplayName does not normalize AWS name correctly: %s",
-			normalizedName)
+func TestNormalizeDisplayName_NormRequired(t *testing.T) {
+
+	invalidNames := map[string]string{
+		"^#$test name\nshould be normalized)(*": "___test_name_should_be_normalized___",
+		"^#$test name1 should be normalized)(*": "___test_name1_should_be_normalized___",
+		"^#$test name  should be normalized)(*": "___test_name__should_be_normalized___",
+		"^#$test name__should be normalized)(*": "___test_name__should_be_normalized___",
 	}
 
-	validName := "test_name_should_normalize_to_itself@example.com"
-	normalizedValidName := normalizeDisplayName(validName)
-	if normalizedValidName != validName {
-		t.Fatalf(
-			"normalizeDisplayName erroneously normalizes valid names: %s",
-			normalizedName)
+	for k, v := range invalidNames {
+		normalizedName := normalizeDisplayName(k)
+		if normalizedName != v {
+			t.Fatalf(
+				"normalizeDisplayName does not normalize AWS name correctly: %s should resolve to %s",
+				k,
+				normalizedName)
+		}
+	}
+}
+
+func TestNormalizeDisplayName_NormNotRequired(t *testing.T) {
+
+	validNames := []string{
+		"test_name_should_normalize_to_itself@example.com",
+		"test1_name_should_normalize_to_itself@example.com",
+		"UPPERlower0123456789-_,.@example.com",
 	}
 
+	for _, n := range validNames {
+		normalizedName := normalizeDisplayName(n)
+		if normalizedName != n {
+			t.Fatalf(
+				"normalizeDisplayName erroneously normalizes valid names: expected %s but normalized to %s",
+				n,
+				normalizedName)
+		}
+	}
 }


### PR DESCRIPTION
@jefferai  this is an initial PR for review/comments on an implementation to address issue #770 (code is however fully functional and tested). As stated by @lcbowen3 it would be useful to have the ability for AWS policies to be controlled by a separate group to those dealing with Vault administration. For example there could be AWS administrators responsible for defining and/or altering policies as needed without having to notify/update the vault administrators who could simply use them. We also need this functionality for some work we are doing so thought I'd have a stab at doing an initial implementation to get the conversation going and ball rolling.

The changes in this PR aim to be fully backward compatible with the existing process, whilst at the same time adding the ability to use an existing managed policy, by supplying an appropriate arn reference.

Assuming the `aws` backend has been mounted and appropriate `aws/config/root` credentials supplied, the actions would go something as follows:

##### Actions for a current process: user supplied (inline) policy
```
// Write policy
vault write aws/roles/deploy policy=@policy.json 

// Obtain new credentials
vault read aws/creds/deploy
Key            	Value
lease_id       	aws/creds/deploy/e21467b5-8934-bbe1-7cad-43688a517e24
lease_duration 	3600
lease_renewable	true
access_key     	********************************
secret_key     	************************************************************

// View policy details
vault read aws/roles/deploy
Key   	Value
policy	{ ... }

// Revoke credentials created
vault revoke aws/creds/deploy/e21467b5-8934-bbe1-7cad-43688a517e24
```

##### Proposed actions for using existing AWS policy via arn ref
```
// Write policy ref
vault write aws/roles/deploy arn=arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess

// Obtain new credentials
vault read aws/creds/deploy
Key            	Value
lease_id       	aws/creds/deploy2/e21467b5-8934-bbe1-7cad-43688a517e24
lease_duration 	3600
lease_renewable	true
access_key     	********************************
secret_key     	************************************************************

// View policy details
vault read aws/roles/deploy
Key	Value
arn	arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess

// Revoke credentials created
vault revoke aws/creds/deploy/e21467b5-8934-bbe1-7cad-43688a517e24
```

The changes in this PR have been tested against both the existing inline policy approach as well as with AWS and Customer managed policies. Let me know if you think this approach fits, or if there are any changes or a different way of doing this that you think is appropriate. If you are happy with it, I can add in some docs for the changes too.

Thanks
Nicki