### PR TITLE
Add keybase support for PGP keys.

### DIFF
--- a/helper/pgpkeys/flag.go
+++ b/helper/pgpkeys/flag.go
@@ -21,7 +21,36 @@ func (p *PubKeyFilesFlag) Set(value string) error {
 	if len(*p) > 0 {
 		return errors.New("pgp-keys can only be specified once")
 	}
+
+	// First, resolve all the keybase entries...do it in one go so we only
+	// round trip to the API once, then store locally
+	keybaseMap := map[string]string{}
+	keybaseUsers := []string{}
 	for _, keyfile := range strings.Split(value, ",") {
+		if strings.HasPrefix(keyfile, "keybase:") {
+			keybaseUsers = append(keybaseUsers, strings.TrimPrefix(keyfile, "keybase:"))
+		}
+	}
+	keybaseKeys, err := FetchKeybasePubkeys(keybaseUsers)
+	if err != nil {
+		return err
+	}
+	for i, key := range keybaseKeys {
+		keybaseMap[keybaseUsers[i]] = key
+	}
+
+	// Now go through the actual flag, and substitute in resolved keybase
+	// entries where appropriate
+	for _, keyfile := range strings.Split(value, ",") {
+		if strings.HasPrefix(keyfile, "keybase:") {
+			username := strings.TrimPrefix(keyfile, "keybase:")
+			key := keybaseMap[username]
+			if key == "" {
+				return fmt.Errorf("key for keybase user %s was not found in the map")
+			}
+			*p = append(*p, key)
+			continue
+		}
 		if keyfile[0] == '@' {
 			keyfile = keyfile[1:]
 		}

--- a/helper/pgpkeys/flag_test.go
+++ b/helper/pgpkeys/flag_test.go
@@ -128,7 +128,6 @@ func TestPubKeyFilesFlagSetKeybase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
 	fingerprints := []string{}
 	for _, pubkey := range []string(*pkf) {
 		keyBytes, err := base64.StdEncoding.DecodeString(pubkey)

--- a/helper/pgpkeys/flag_test.go
+++ b/helper/pgpkeys/flag_test.go
@@ -1,7 +1,9 @@
 package pgpkeys
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -9,6 +11,9 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp/packet"
 )
 
 func TestPubKeyFilesFlag_implements(t *testing.T) {
@@ -84,7 +89,7 @@ func TestPubKeyFilesFlagSetB64(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error writing pub key 2 to temp file: %s", err)
 	}
-    err = ioutil.WriteFile(tempDir+"/pubkey3", []byte(pubKey3), 0755)
+	err = ioutil.WriteFile(tempDir+"/pubkey3", []byte(pubKey3), 0755)
 	if err != nil {
 		t.Fatalf("Error writing pub key 3 to temp file: %s", err)
 	}
@@ -102,10 +107,56 @@ func TestPubKeyFilesFlagSetB64(t *testing.T) {
 
 	expected := []string{pubKey1, pubKey2}
 	if !reflect.DeepEqual(pkf.String(), fmt.Sprint(expected)) {
-        t.Fatalf("bad: got %s, expected %s", pkf.String(), fmt.Sprint(expected))
+		t.Fatalf("bad: got %s, expected %s", pkf.String(), fmt.Sprint(expected))
 	}
 }
 
+func TestPubKeyFilesFlagSetKeybase(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "vault-test")
+	if err != nil {
+		t.Fatalf("Error creating temporary directory: %s", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	err = ioutil.WriteFile(tempDir+"/pubkey2", []byte(pubKey2), 0755)
+	if err != nil {
+		t.Fatalf("Error writing pub key 2 to temp file: %s", err)
+	}
+
+	pkf := new(PubKeyFilesFlag)
+	err = pkf.Set("keybase:jefferai,@" + tempDir + "/pubkey2" + ",keybase:hashicorp")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	fingerprints := []string{}
+	for _, pubkey := range []string(*pkf) {
+		keyBytes, err := base64.StdEncoding.DecodeString(pubkey)
+		if err != nil {
+			t.Fatalf("bad: %v", err)
+		}
+		pubKeyBuf := bytes.NewBuffer(keyBytes)
+		reader := packet.NewReader(pubKeyBuf)
+		entity, err := openpgp.ReadEntity(reader)
+		if err != nil {
+			t.Fatalf("bad: %v", err)
+		}
+		if entity == nil {
+			t.Fatalf("nil entity encountered")
+		}
+		fingerprints = append(fingerprints, hex.EncodeToString(entity.PrimaryKey.Fingerprint[:]))
+	}
+
+	exp := []string{
+		"0f801f518ec853daff611e836528efcac6caa3db",
+		"cf3d4694c9f57b28cb4092c2eb832c67eb5e8957",
+		"91a6e7f85d05c65630bef18951852d87348ffc4c",
+	}
+
+	if !reflect.DeepEqual(fingerprints, exp) {
+		t.Fatalf("bad: got \n%#v\nexpected\n%#v\n", fingerprints, exp)
+	}
+}
 
 const pubKey1 = `mQENBFXbjPUBCADjNjCUQwfxKL+RR2GA6pv/1K+zJZ8UWIF9S0lk7cVIEfJiprzzwiMwBS5cD0da
 rGin1FHvIWOZxujA7oW0O2TUuatqI3aAYDTfRYurh6iKLC+VS+F7H+/mhfFvKmgr0Y5kDCF1j0T/

--- a/helper/pgpkeys/keybase.go
+++ b/helper/pgpkeys/keybase.go
@@ -11,22 +11,39 @@ import (
 	"golang.org/x/crypto/openpgp"
 )
 
+const (
+	kbPrefix = "keybase:"
+)
+
 // FetchKeybasePubkeys fetches public keys from Keybase given a set of
-// usernames. It doesn't use their client code due to both the API and the fact
-// that it is considered alpha and probably best not to rely on it.
-// The keys are returned as base64-encoded strings.
-func FetchKeybasePubkeys(usernames []string) ([]string, error) {
+// usernames, which are derived from correctly formatted input entries. It
+// doesn't use their client code due to both the API and the fact that it is
+// considered alpha and probably best not to rely on it.  The keys are returned
+// as base64-encoded strings.
+func FetchKeybasePubkeys(input []string) (map[string]string, error) {
 	client := cleanhttp.DefaultClient()
 	if client == nil {
 		return nil, fmt.Errorf("unable to create an http client")
+	}
+
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	usernames := make([]string, 0, len(input))
+	for _, v := range input {
+		if strings.HasPrefix(v, kbPrefix) {
+			usernames = append(usernames, strings.TrimPrefix(v, kbPrefix))
+		}
 	}
 
 	if len(usernames) == 0 {
 		return nil, nil
 	}
 
-	ret := make([]string, 0, len(usernames))
-	resp, err := client.Get(fmt.Sprintf("https://keybase.io/_/api/1.0/user/lookup.json?usernames=%s&fields=public_keys", strings.Join(usernames, ",")))
+	ret := make(map[string]string, len(usernames))
+	url := fmt.Sprintf("https://keybase.io/_/api/1.0/user/lookup.json?usernames=%s&fields=public_keys", strings.Join(usernames, ","))
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +56,7 @@ func FetchKeybasePubkeys(usernames []string) ([]string, error) {
 	}
 
 	type them struct {
-		PublicKeys publicKeys `json:"public_keys"`
+		publicKeys `json:"public_keys"`
 	}
 
 	type kbResp struct {
@@ -69,13 +86,13 @@ func FetchKeybasePubkeys(usernames []string) ([]string, error) {
 	var keyReader *bytes.Reader
 	serializedEntity := bytes.NewBuffer(nil)
 	for i, themVal := range out.Them {
-		keyReader = bytes.NewReader([]byte(themVal.PublicKeys.Primary.Bundle))
+		keyReader = bytes.NewReader([]byte(themVal.Primary.Bundle))
 		entityList, err := openpgp.ReadArmoredKeyRing(keyReader)
 		if err != nil {
 			return nil, err
 		}
 		if len(entityList) != 1 {
-			return nil, fmt.Errorf("primary key could not be deduced for user %s", usernames[i])
+			return nil, fmt.Errorf("primary key could not be parsed for user %s", usernames[i])
 		}
 		if entityList[0] == nil {
 			return nil, fmt.Errorf("primary key was nil for user %s", usernames[i])
@@ -86,7 +103,9 @@ func FetchKeybasePubkeys(usernames []string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error serializing entity for user %s: %s", usernames[i], err)
 		}
-		ret = append(ret, base64.StdEncoding.EncodeToString(serializedEntity.Bytes()))
+
+		// The API returns values in the same ordering requested, so this should properly match
+		ret[kbPrefix+usernames[i]] = base64.StdEncoding.EncodeToString(serializedEntity.Bytes())
 	}
 
 	return ret, nil

--- a/helper/pgpkeys/keybase.go
+++ b/helper/pgpkeys/keybase.go
@@ -1,0 +1,93 @@
+package pgpkeys
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-cleanhttp"
+	"golang.org/x/crypto/openpgp"
+)
+
+// FetchKeybasePubkeys fetches public keys from Keybase given a set of
+// usernames. It doesn't use their client code due to both the API and the fact
+// that it is considered alpha and probably best not to rely on it.
+// The keys are returned as base64-encoded strings.
+func FetchKeybasePubkeys(usernames []string) ([]string, error) {
+	client := cleanhttp.DefaultClient()
+	if client == nil {
+		return nil, fmt.Errorf("unable to create an http client")
+	}
+
+	if len(usernames) == 0 {
+		return nil, nil
+	}
+
+	ret := make([]string, 0, len(usernames))
+	resp, err := client.Get(fmt.Sprintf("https://keybase.io/_/api/1.0/user/lookup.json?usernames=%s&fields=public_keys", strings.Join(usernames, ",")))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	type publicKeys struct {
+		Primary struct {
+			Bundle string
+		}
+	}
+
+	type them struct {
+		PublicKeys publicKeys `json:"public_keys"`
+	}
+
+	type kbResp struct {
+		Status struct {
+			Name string
+		}
+		Them []them
+	}
+
+	out := &kbResp{
+		Them: []them{},
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(out); err != nil {
+		return nil, err
+	}
+
+	if out.Status.Name != "OK" {
+		return nil, fmt.Errorf("got non-OK response: %s", out.Status.Name)
+	}
+
+	if len(out.Them) != len(usernames) {
+		return nil, fmt.Errorf("returned keys length does not match number of provided usernames")
+	}
+
+	var keyReader *bytes.Reader
+	serializedEntity := bytes.NewBuffer(nil)
+	for i, themVal := range out.Them {
+		keyReader = bytes.NewReader([]byte(themVal.PublicKeys.Primary.Bundle))
+		entityList, err := openpgp.ReadArmoredKeyRing(keyReader)
+		if err != nil {
+			return nil, err
+		}
+		if len(entityList) != 1 {
+			return nil, fmt.Errorf("primary key could not be deduced for user %s", usernames[i])
+		}
+		if entityList[0] == nil {
+			return nil, fmt.Errorf("primary key was nil for user %s", usernames[i])
+		}
+
+		serializedEntity.Reset()
+		err = entityList[0].Serialize(serializedEntity)
+		if err != nil {
+			return nil, fmt.Errorf("error serializing entity for user %s: %s", usernames[i], err)
+		}
+		ret = append(ret, base64.StdEncoding.EncodeToString(serializedEntity.Bytes()))
+	}
+
+	return ret, nil
+}

--- a/helper/pgpkeys/keybase_test.go
+++ b/helper/pgpkeys/keybase_test.go
@@ -1,0 +1,41 @@
+package pgpkeys
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp/packet"
+)
+
+func TestFetchKeybasePubkeys(t *testing.T) {
+	ret, err := FetchKeybasePubkeys([]string{"jefferai", "hashicorp"})
+	if err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	fingerprints := []string{}
+	for i, retKey := range ret {
+		data, err := base64.StdEncoding.DecodeString(retKey)
+		if err != nil {
+			t.Fatalf("error decoding key %d: %v", i, err)
+		}
+		entity, err := openpgp.ReadEntity(packet.NewReader(bytes.NewBuffer(data)))
+		if err != nil {
+			t.Fatalf("error parsing key %d: %v", i, err)
+		}
+		fingerprints = append(fingerprints, hex.EncodeToString(entity.PrimaryKey.Fingerprint[:]))
+	}
+
+	exp := []string{
+		"0f801f518ec853daff611e836528efcac6caa3db",
+		"91a6e7f85d05c65630bef18951852d87348ffc4c",
+	}
+
+	if !reflect.DeepEqual(fingerprints, exp) {
+		t.Fatalf("fingerprints do not match; expected \n%#v\ngot\n%#v\n", exp, fingerprints)
+	}
+}

--- a/helper/pgpkeys/keybase_test.go
+++ b/helper/pgpkeys/keybase_test.go
@@ -12,20 +12,21 @@ import (
 )
 
 func TestFetchKeybasePubkeys(t *testing.T) {
-	ret, err := FetchKeybasePubkeys([]string{"jefferai", "hashicorp"})
+	testset := []string{"keybase:jefferai", "keybase:hashicorp"}
+	ret, err := FetchKeybasePubkeys(testset)
 	if err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
 	fingerprints := []string{}
-	for i, retKey := range ret {
-		data, err := base64.StdEncoding.DecodeString(retKey)
+	for _, user := range testset {
+		data, err := base64.StdEncoding.DecodeString(ret[user])
 		if err != nil {
-			t.Fatalf("error decoding key %d: %v", i, err)
+			t.Fatalf("error decoding key for user %s: %v", user, err)
 		}
 		entity, err := openpgp.ReadEntity(packet.NewReader(bytes.NewBuffer(data)))
 		if err != nil {
-			t.Fatalf("error parsing key %d: %v", i, err)
+			t.Fatalf("error parsing key for user %s: %v", user, err)
 		}
 		fingerprints = append(fingerprints, hex.EncodeToString(entity.PrimaryKey.Fingerprint[:]))
 	}


### PR DESCRIPTION
Keys specified in rekey and init operations can now be sourced from
keybase.io by using "keybase:[username]" as the key.