### PR TITLE
More granular ACL capabilities

### DIFF
--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -2,12 +2,13 @@ package audit
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
-	"encoding/json"
+
+	"errors"
 
 	"github.com/hashicorp/vault/logical"
-	"errors"
 )
 
 func TestFormatJSON_formatRequest(t *testing.T) {
@@ -63,5 +64,5 @@ func TestFormatJSON_formatRequest(t *testing.T) {
 	}
 }
 
-const testFormatJSONReqBasicStr = `{"time":"2015-08-05T13:45:46Z","type":"request","auth":{"display_name":"","policies":["root"],"metadata":null},"request":{"operation":"write","path":"/foo","data":null,"remote_address":"127.0.0.1"},"error":"this is an error"}
+const testFormatJSONReqBasicStr = `{"time":"2015-08-05T13:45:46Z","type":"request","auth":{"display_name":"","policies":["root"],"metadata":null},"request":{"operation":"update","path":"/foo","data":null,"remote_address":"127.0.0.1"},"error":"this is an error"}
 `

--- a/http/logical.go
+++ b/http/logical.go
@@ -29,10 +29,14 @@ func handleLogical(core *vault.Core, dataOnly bool) http.Handler {
 		case "DELETE":
 			op = logical.DeleteOperation
 		case "GET":
-			op = logical.ReadOperation
-		case "POST":
-			fallthrough
-		case "PUT":
+			if r.Form.Get("list") == "true" {
+				op = logical.ListOperation
+			} else {
+				op = logical.ReadOperation
+			}
+		case "LIST":
+			op = logical.ListOperation
+		case "POST", "PUT":
 			op = logical.UpdateOperation
 		default:
 			respondError(w, http.StatusMethodNotAllowed, nil)

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/vault"
 )
 
@@ -187,4 +188,119 @@ func TestSysUnseal_Reset(t *testing.T) {
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected:\n%#v\nactual:\n%#v\n", expected, actual)
 	}
+
+}
+
+// Test Seal's permissions logic, which is slightly different than normal code
+// paths in that it queries the ACL rather than having checkToken do it. This
+// is because it was abusing RootPaths in logical_system, but that caused some
+// haywire with code paths that expected there to be an actual corresponding
+// logical.Path for it. This way is less hacky, but this test ensures that we
+// have not opened up a permissions hole.
+func TestSysSeal_Permissions(t *testing.T) {
+	core, _, root := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+	TestServerAuth(t, addr, root)
+
+	// Set the 'test' policy object to permit write access to sys/seal
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "sys/policy/test",
+		Data: map[string]interface{}{
+			"rules": `path "sys/seal" { capabilities = ["read"] }`,
+		},
+		ClientToken: root,
+	}
+	resp, err := core.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("bad: %#v", resp)
+	}
+
+	// Create a non-root token with access to that policy
+	req.Path = "auth/token/create"
+	req.Data = map[string]interface{}{
+		"id":       "child",
+		"policies": []string{"test"},
+	}
+
+	resp, err = core.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %v %v", err, resp)
+	}
+	if resp.Auth.ClientToken != "child" {
+		t.Fatalf("bad: %#v", resp)
+	}
+
+	// We must go through the HTTP interface since seal doesn't go through HandleRequest
+
+	// We expect this to fail since it needs update and sudo
+	httpResp := testHttpPut(t, "child", addr+"/v1/sys/seal", nil)
+	testResponseStatus(t, httpResp, 500)
+
+	// Now modify to add update capability
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "sys/policy/test",
+		Data: map[string]interface{}{
+			"rules": `path "sys/seal" { capabilities = ["update"] }`,
+		},
+		ClientToken: root,
+	}
+	resp, err = core.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("bad: %#v", resp)
+	}
+
+	// We expect this to fail since it needs sudo
+	httpResp = testHttpPut(t, "child", addr+"/v1/sys/seal", nil)
+	testResponseStatus(t, httpResp, 500)
+
+	// Now modify to just sudo capability
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "sys/policy/test",
+		Data: map[string]interface{}{
+			"rules": `path "sys/seal" { capabilities = ["sudo"] }`,
+		},
+		ClientToken: root,
+	}
+	resp, err = core.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("bad: %#v", resp)
+	}
+
+	// We expect this to fail since it needs update
+	httpResp = testHttpPut(t, "child", addr+"/v1/sys/seal", nil)
+	testResponseStatus(t, httpResp, 500)
+
+	// Now modify to add all needed capabilities
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "sys/policy/test",
+		Data: map[string]interface{}{
+			"rules": `path "sys/seal" { capabilities = ["update", "sudo"] }`,
+		},
+		ClientToken: root,
+	}
+	resp, err = core.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("bad: %#v", resp)
+	}
+
+	// We expect this to work
+	httpResp = testHttpPut(t, "child", addr+"/v1/sys/seal", nil)
+	testResponseStatus(t, httpResp, 204)
 }

--- a/logical/framework/path.go
+++ b/logical/framework/path.go
@@ -53,6 +53,14 @@ type Path struct {
 	// callback will be called.
 	Callbacks map[logical.Operation]OperationFunc
 
+	// ExistenceCheck, if implemented, is used to query whether a given
+	// resource exists or not. This is used for ACL purposes: if an Update
+	// action is specified, and the existence check returns false, the action
+	// is not allowed since the resource must first be created. The reverse is
+	// also true. If not specified, the Update action is forced and the user
+	// must have UpdateCapability on the path.
+	ExistenceCheck func(*logical.Request, *FieldData) (bool, error)
+
 	// Help is text describing how to use this path. This will be used
 	// to auto-generate the help operation. The Path will automatically
 	// generate a parameter listing and URL structure based on the

--- a/logical/framework/path_map.go
+++ b/logical/framework/path_map.go
@@ -122,12 +122,15 @@ func (p *PathMap) Paths() []*Path {
 			Fields: schema,
 
 			Callbacks: map[logical.Operation]OperationFunc{
-				logical.UpdateOperation:  p.pathSingleWrite,
+				logical.CreateOperation: p.pathSingleWrite,
 				logical.ReadOperation:   p.pathSingleRead,
+				logical.UpdateOperation: p.pathSingleWrite,
 				logical.DeleteOperation: p.pathSingleDelete,
 			},
 
 			HelpSynopsis: fmt.Sprintf("Read/write/delete a single %s mapping", p.Name),
+
+			ExistenceCheck: p.pathSingleExistenceCheck,
 		},
 	}
 }
@@ -164,4 +167,13 @@ func (p *PathMap) pathSingleDelete(
 	req *logical.Request, d *FieldData) (*logical.Response, error) {
 	err := p.Delete(req.Storage, d.Get("key").(string))
 	return nil, err
+}
+
+func (p *PathMap) pathSingleExistenceCheck(
+	req *logical.Request, d *FieldData) (bool, error) {
+	v, err := p.Get(req.Storage, d.Get("key").(string))
+	if err != nil {
+		return false, err
+	}
+	return v != nil, nil
 }

--- a/logical/framework/path_struct.go
+++ b/logical/framework/path_struct.go
@@ -64,9 +64,12 @@ func (p *PathStruct) Paths() []*Path {
 		Fields:  p.Schema,
 
 		Callbacks: map[logical.Operation]OperationFunc{
-			logical.UpdateOperation:  p.pathWrite,
+			logical.CreateOperation: p.pathWrite,
+			logical.UpdateOperation: p.pathWrite,
 			logical.DeleteOperation: p.pathDelete,
 		},
+
+		ExistenceCheck: p.pathExistenceCheck,
 
 		HelpSynopsis:    p.HelpSynopsis,
 		HelpDescription: p.HelpDescription,
@@ -102,4 +105,14 @@ func (p *PathStruct) pathDelete(
 	req *logical.Request, d *FieldData) (*logical.Response, error) {
 	err := p.Delete(req.Storage)
 	return nil, err
+}
+
+func (p *PathStruct) pathExistenceCheck(
+	req *logical.Request, d *FieldData) (bool, error) {
+	v, err := p.Get(req.Storage)
+	if err != nil {
+		return false, err
+	}
+
+	return v != nil, nil
 }

--- a/logical/logical.go
+++ b/logical/logical.go
@@ -30,9 +30,10 @@ type Backend interface {
 	// HandleExistenceCheck is used to handle a request and generate a response
 	// indicating whether the given path exists or not; this is used to
 	// understand whether the request must have a Create or Update capability
-	// ACL applied. A nil bool value indicates that no existence check has been
-	// set.
-	HandleExistenceCheck(*Request) (*bool, error)
+	// ACL applied. The first bool indicates whether an existence check
+	// function was found for the backend; the second indicates whether, if an
+	// existence check function was found, the item exists or not.
+	HandleExistenceCheck(*Request) (bool, bool, error)
 
 	Cleanup()
 }

--- a/logical/logical.go
+++ b/logical/logical.go
@@ -27,6 +27,13 @@ type Backend interface {
 	// information, such as globally configured default and max lease TTLs.
 	System() SystemView
 
+	// HandleExistenceCheck is used to handle a request and generate a response
+	// indicating whether the given path exists or not; this is used to
+	// understand whether the request must have a Create or Update capability
+	// ACL applied. A nil bool value indicates that no existence check has been
+	// set.
+	HandleExistenceCheck(*Request) (*bool, error)
+
 	Cleanup()
 }
 

--- a/logical/request.go
+++ b/logical/request.go
@@ -121,8 +121,9 @@ type Operation string
 
 const (
 	// The operations below are called per path
-	ReadOperation   Operation = "read"
-	UpdateOperation            = "write"
+	CreateOperation Operation = "create"
+	ReadOperation             = "read"
+	UpdateOperation           = "update"
 	DeleteOperation           = "delete"
 	ListOperation             = "list"
 	HelpOperation             = "help"
@@ -132,6 +133,10 @@ const (
 	RenewOperation              = "renew"
 	RollbackOperation           = "rollback"
 )
+
+func (o Operation) String() string {
+	return string(o)
+}
 
 var (
 	// ErrUnsupportedOperation is returned if the operation is not supported

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -118,12 +118,11 @@ CHECK:
 		allowed = policy.CapabilitiesBitmap&DeleteCapabilityInt > 0
 	case "create":
 		allowed = policy.CapabilitiesBitmap&CreateCapabilityInt > 0
-	case "revoke":
+
+	// These three re-use UpdateCapabilityInt since that's the most appropraite capability/operation mapping
+	case "revoke", "renew", "rollback":
 		allowed = policy.CapabilitiesBitmap&UpdateCapabilityInt > 0
-	case "renew":
-		allowed = policy.CapabilitiesBitmap&UpdateCapabilityInt > 0
-	case "rollback":
-		allowed = policy.CapabilitiesBitmap&UpdateCapabilityInt > 0
+
 	default:
 		return false, false
 	}

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -14,10 +14,12 @@ var (
 		logical.UpdateOperation:   []string{UpdateCapability},
 		logical.DeleteOperation:   []string{DeleteCapability},
 		logical.ListOperation:     []string{ListCapability},
-		logical.HelpOperation:     []string{CreateCapability, ReadCapability, UpdateCapability, DeleteCapability, ListCapability, SudoCapability, DenyCapability},
 		logical.RevokeOperation:   []string{UpdateCapability},
 		logical.RenewOperation:    []string{UpdateCapability},
 		logical.RollbackOperation: []string{UpdateCapability},
+
+		// Help is special-cased to always be allowed, so we don't need anything in this list
+		logical.HelpOperation: []string{},
 	}
 )
 

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -5,24 +5,6 @@ import (
 	"github.com/hashicorp/vault/logical"
 )
 
-var (
-	// permittedPolicyLevel is used to map each logical operation
-	// into the set of capabilities that allow the operation.
-	permittedPolicyLevels = map[logical.Operation][]string{
-		logical.CreateOperation:   []string{CreateCapability},
-		logical.ReadOperation:     []string{ReadCapability},
-		logical.UpdateOperation:   []string{UpdateCapability},
-		logical.DeleteOperation:   []string{DeleteCapability},
-		logical.ListOperation:     []string{ListCapability},
-		logical.RevokeOperation:   []string{UpdateCapability},
-		logical.RenewOperation:    []string{UpdateCapability},
-		logical.RollbackOperation: []string{UpdateCapability},
-
-		// Help is special-cased to always be allowed, so we don't need anything in this list
-		logical.HelpOperation: []string{},
-	}
-)
-
 // ACL is used to wrap a set of policies to provide
 // an efficient interface for access control.
 type ACL struct {
@@ -71,11 +53,11 @@ func NewACL(policies []*Policy) (*ACL, error) {
 			existing := raw.(*PathCapabilities)
 
 			switch {
-			case existing.CapabilitiesMap[DenyCapability]:
+			case existing.CapabilitiesBitmap&DenyCapabilityInt > 0:
 				// If we are explicitly denied in the existing capability set,
 				// don't save anything else
 
-			case pc.CapabilitiesMap[DenyCapability]:
+			case pc.CapabilitiesBitmap&DenyCapabilityInt > 0:
 				// If this new policy explicitly denies, only save the deny value
 				tree.Insert(pc.Prefix, pc)
 
@@ -83,18 +65,17 @@ func NewACL(policies []*Policy) (*ACL, error) {
 				// Insert the capabilities in this new policy into the existing
 				// value; since it's a pointer we can just modify the
 				// underlying data
-
-				for k, _ := range pc.CapabilitiesMap {
-					existing.CapabilitiesMap[k] = true
-				}
+				existing.CapabilitiesBitmap |= pc.CapabilitiesBitmap
 			}
 		}
 	}
 	return a, nil
 }
 
-// AllowOperation is used to check if the given operation is permitted
-func (a *ACL) AllowOperation(op logical.Operation, path string) (opAllowed bool, sudoPriv bool) {
+// AllowOperation is used to check if the given operation is permitted. The
+// first bool indicates if an op is allowed, the second whether sudo priviliges
+// exist for that op and path.
+func (a *ACL) AllowOperation(op logical.Operation, path string) (allowed bool, sudo bool) {
 	// Fast-path root
 	if a.root {
 		return true, true
@@ -125,5 +106,26 @@ CHECK:
 	// Check if the minimum permissions are met
 	// If "deny" has been explicitly set, only deny will be in the map, so we
 	// only need to check for the existence of other values
-	return policy.CapabilitiesMap[op.String()], policy.CapabilitiesMap[SudoCapability]
+	sudo = policy.CapabilitiesBitmap&SudoCapabilityInt > 0
+	switch op.String() {
+	case "read":
+		allowed = policy.CapabilitiesBitmap&ReadCapabilityInt > 0
+	case "list":
+		allowed = policy.CapabilitiesBitmap&ListCapabilityInt > 0
+	case "update":
+		allowed = policy.CapabilitiesBitmap&UpdateCapabilityInt > 0
+	case "delete":
+		allowed = policy.CapabilitiesBitmap&DeleteCapabilityInt > 0
+	case "create":
+		allowed = policy.CapabilitiesBitmap&CreateCapabilityInt > 0
+	case "revoke":
+		allowed = policy.CapabilitiesBitmap&UpdateCapabilityInt > 0
+	case "renew":
+		allowed = policy.CapabilitiesBitmap&UpdateCapabilityInt > 0
+	case "rollback":
+		allowed = policy.CapabilitiesBitmap&UpdateCapabilityInt > 0
+	default:
+		return false, false
+	}
+	return
 }

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -14,10 +14,11 @@ func TestACL_Root(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if !acl.RootPrivilege("sys/mount/foo") {
+	allowed, rootPrivs := acl.AllowOperation(logical.UpdateOperation, "sys/mount/foo")
+	if !rootPrivs {
 		t.Fatalf("expected root")
 	}
-	if !acl.AllowOperation(logical.UpdateOperation, "sys/mount/foo") {
+	if !allowed {
 		t.Fatalf("expected permission")
 	}
 }
@@ -33,37 +34,50 @@ func TestACL_Single(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if acl.RootPrivilege("sys/mount/foo") {
+	// Type of operation is not important here as we only care about checking
+	// sudo/root
+	_, rootPrivs := acl.AllowOperation(logical.ReadOperation, "sys/mount/foo")
+	if rootPrivs {
 		t.Fatalf("unexpected root")
 	}
 
 	type tcase struct {
-		op     logical.Operation
-		path   string
-		expect bool
+		op        logical.Operation
+		path      string
+		allowed   bool
+		rootPrivs bool
 	}
 	tcases := []tcase{
-		{logical.ReadOperation, "root", false},
-		{logical.HelpOperation, "root", true},
+		{logical.ReadOperation, "root", false, false},
+		{logical.HelpOperation, "root", true, false},
 
-		{logical.ReadOperation, "dev/foo", true},
-		{logical.UpdateOperation, "dev/foo", true},
+		{logical.ReadOperation, "dev/foo", true, true},
+		{logical.UpdateOperation, "dev/foo", true, true},
 
-		{logical.DeleteOperation, "stage/foo", true},
-		{logical.UpdateOperation, "stage/aws/foo", false},
-		{logical.UpdateOperation, "stage/aws/policy/foo", true},
+		{logical.DeleteOperation, "stage/foo", true, false},
+		{logical.ListOperation, "stage/aws/foo", true, true},
+		{logical.UpdateOperation, "stage/aws/foo", true, true},
+		{logical.UpdateOperation, "stage/aws/policy/foo", true, true},
 
-		{logical.DeleteOperation, "prod/foo", false},
-		{logical.UpdateOperation, "prod/foo", false},
-		{logical.ReadOperation, "prod/foo", true},
-		{logical.ListOperation, "prod/foo", true},
-		{logical.ReadOperation, "prod/aws/foo", false},
+		{logical.DeleteOperation, "prod/foo", false, false},
+		{logical.UpdateOperation, "prod/foo", false, false},
+		{logical.ReadOperation, "prod/foo", true, false},
+		{logical.ListOperation, "prod/foo", true, false},
+		{logical.ReadOperation, "prod/aws/foo", false, false},
+
+		{logical.ReadOperation, "foo/bar", true, true},
+		{logical.ListOperation, "foo/bar", false, true},
+		{logical.UpdateOperation, "foo/bar", false, true},
+		{logical.CreateOperation, "foo/bar", true, true},
 	}
 
 	for _, tc := range tcases {
-		out := acl.AllowOperation(tc.op, tc.path)
-		if out != tc.expect {
-			t.Fatalf("bad: case %#v: %v", tc, out)
+		allowed, rootPrivs := acl.AllowOperation(tc.op, tc.path)
+		if allowed != tc.allowed {
+			t.Fatalf("bad: case %#v: %v, %v", tc, allowed, rootPrivs)
+		}
+		if rootPrivs != tc.rootPrivs {
+			t.Fatalf("bad: case %#v: %v, %v", tc, allowed, rootPrivs)
 		}
 	}
 }
@@ -87,40 +101,55 @@ func TestACL_Layered(t *testing.T) {
 }
 
 func testLayeredACL(t *testing.T, acl *ACL) {
-	if acl.RootPrivilege("sys/mount/foo") {
+	// Type of operation is not important here as we only care about checking
+	// sudo/root
+	_, rootPrivs := acl.AllowOperation(logical.ReadOperation, "sys/mount/foo")
+	if rootPrivs {
 		t.Fatalf("unexpected root")
 	}
 
 	type tcase struct {
-		op     logical.Operation
-		path   string
-		expect bool
+		op        logical.Operation
+		path      string
+		allowed   bool
+		rootPrivs bool
 	}
 	tcases := []tcase{
-		{logical.ReadOperation, "root", false},
-		{logical.HelpOperation, "root", true},
+		{logical.ReadOperation, "root", false, false},
+		{logical.HelpOperation, "root", true, false},
 
-		{logical.ReadOperation, "dev/hide/foo", false},
-		{logical.UpdateOperation, "dev/hide/foo", false},
+		{logical.ReadOperation, "dev/foo", true, true},
+		{logical.UpdateOperation, "dev/foo", true, true},
+		{logical.ReadOperation, "dev/hide/foo", false, false},
+		{logical.UpdateOperation, "dev/hide/foo", false, false},
 
-		{logical.DeleteOperation, "stage/foo", true},
-		{logical.UpdateOperation, "stage/aws/foo", false},
-		{logical.UpdateOperation, "stage/aws/policy/foo", false},
+		{logical.DeleteOperation, "stage/foo", true, false},
+		{logical.ListOperation, "stage/aws/foo", true, true},
+		{logical.UpdateOperation, "stage/aws/foo", true, true},
+		{logical.UpdateOperation, "stage/aws/policy/foo", false, false},
 
-		{logical.DeleteOperation, "prod/foo", true},
-		{logical.UpdateOperation, "prod/foo", true},
-		{logical.ReadOperation, "prod/foo", true},
-		{logical.ListOperation, "prod/foo", true},
-		{logical.ReadOperation, "prod/aws/foo", false},
+		{logical.DeleteOperation, "prod/foo", true, false},
+		{logical.UpdateOperation, "prod/foo", true, false},
+		{logical.ReadOperation, "prod/foo", true, false},
+		{logical.ListOperation, "prod/foo", true, false},
+		{logical.ReadOperation, "prod/aws/foo", false, false},
 
-		{logical.ReadOperation, "sys/status", false},
-		{logical.UpdateOperation, "sys/seal", true},
+		{logical.ReadOperation, "sys/status", false, false},
+		{logical.UpdateOperation, "sys/seal", true, true},
+
+		{logical.ReadOperation, "foo/bar", false, false},
+		{logical.ListOperation, "foo/bar", false, false},
+		{logical.UpdateOperation, "foo/bar", false, false},
+		{logical.CreateOperation, "foo/bar", false, false},
 	}
 
 	for _, tc := range tcases {
-		out := acl.AllowOperation(tc.op, tc.path)
-		if out != tc.expect {
-			t.Fatalf("bad: case %#v: %v", tc, out)
+		allowed, rootPrivs := acl.AllowOperation(tc.op, tc.path)
+		if allowed != tc.allowed {
+			t.Fatalf("bad: case %#v: %v, %v", tc, allowed, rootPrivs)
+		}
+		if rootPrivs != tc.rootPrivs {
+			t.Fatalf("bad: case %#v: %v, %v", tc, allowed, rootPrivs)
 		}
 	}
 }
@@ -135,6 +164,7 @@ path "stage/*" {
 }
 path "stage/aws/*" {
 	policy = "read"
+	capabilities = ["update", "sudo"]
 }
 path "stage/aws/policy/*" {
 	policy = "sudo"
@@ -148,6 +178,9 @@ path "prod/aws/*" {
 path "sys/*" {
 	policy = "deny"
 }
+path "foo/bar" {
+	capabilities = ["read", "create", "sudo"]
+}
 `
 
 var aclPolicy2 = `
@@ -157,11 +190,16 @@ path "dev/hide/*" {
 }
 path "stage/aws/policy/*" {
 	policy = "deny"
+	# This should have no effect
+	capabilities = ["read", "update", "sudo"]
 }
 path "prod/*" {
 	policy = "write"
 }
 path "sys/seal" {
-	policy = "write"
+	policy = "sudo"
+}
+path "foo/bar" {
+	capabilities = ["deny"]
 }
 `

--- a/vault/core.go
+++ b/vault/core.go
@@ -751,28 +751,25 @@ func (c *Core) checkToken(req *logical.Request) (*logical.Auth, *TokenEntry, err
 	// Check if this is a root protected path
 	rootPath := c.router.RootPath(req.Path)
 
-	resourceExists := new(bool)
 	if req.Operation == logical.CreateOperation || req.Operation == logical.UpdateOperation {
-		resourceExists, err = c.router.RouteExistenceCheck(req)
+		checkExists, resourceExists, err := c.router.RouteExistenceCheck(req)
 		if err != nil {
 			c.logger.Printf("[ERR] core: failed to run existence check: %v", err)
 			return nil, nil, ErrInternalError
 		}
 
 		switch {
-		case resourceExists == nil:
+		case checkExists == false:
 			// No existence check, so always treate it as an update operation, which is how it is pre 0.5
 			req.Operation = logical.UpdateOperation
-		case *resourceExists == true:
+		case resourceExists == true:
 			// It exists, so force an update operation
 			req.Operation = logical.UpdateOperation
-		case *resourceExists == false:
+		case resourceExists == false:
 			// It doesn't exist, force a create operation
 			req.Operation = logical.CreateOperation
 		default:
-			// ????
-			c.logger.Printf("[ERR] core: failed to check existence check value")
-			return nil, nil, ErrInternalError
+			panic("unreachable code")
 		}
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -751,6 +751,11 @@ func (c *Core) checkToken(req *logical.Request) (*logical.Auth, *TokenEntry, err
 	// Check if this is a root protected path
 	rootPath := c.router.RootPath(req.Path)
 
+	// When we receive a write of either type, rather than require clients to
+	// PUT/POST and trust the operation, we ask the backend to give us the real
+	// skinny -- if the backend implements an existence check, it can tell us
+	// whether a particular resource exists. Then we can mark it as an update
+	// or creation as appropriate.
 	if req.Operation == logical.CreateOperation || req.Operation == logical.UpdateOperation {
 		checkExists, resourceExists, err := c.router.RouteExistenceCheck(req)
 		if err != nil {

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -1,6 +1,10 @@
 package vault
 
-import "time"
+import (
+	"time"
+
+	"github.com/hashicorp/vault/logical"
+)
 
 type dynamicSystemView struct {
 	core       *Core
@@ -38,7 +42,11 @@ func (d dynamicSystemView) SudoPrivilege(path string, token string) bool {
 		return false
 	}
 
-	return acl.RootPrivilege(path)
+	// The operation type isn't important here as this is run from a path the
+	// user has already been given access to; we only care about whether they
+	// have sudo
+	_, rootPrivs := acl.AllowOperation(logical.ReadOperation, path)
+	return rootPrivs
 }
 
 // TTLsByPath returns the default and max TTLs corresponding to a particular

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -47,10 +47,13 @@ func LeaseSwitchedPassthroughBackend(conf *logical.BackendConfig, leases bool) (
 
 				Callbacks: map[logical.Operation]framework.OperationFunc{
 					logical.ReadOperation:   b.handleRead,
-					logical.UpdateOperation:  b.handleWrite,
+					logical.CreateOperation: b.handleWrite,
+					logical.UpdateOperation: b.handleWrite,
 					logical.DeleteOperation: b.handleDelete,
 					logical.ListOperation:   b.handleList,
 				},
+
+				ExistenceCheck: b.handleExistenceCheck,
 
 				HelpSynopsis:    strings.TrimSpace(passthroughHelpSynopsis),
 				HelpDescription: strings.TrimSpace(passthroughHelpDescription),
@@ -88,6 +91,16 @@ func (b *PassthroughBackend) handleRevoke(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	// This is a no-op
 	return nil, nil
+}
+
+func (b *PassthroughBackend) handleExistenceCheck(
+	req *logical.Request, data *framework.FieldData) (bool, error) {
+	out, err := req.Storage.Get(req.Path)
+	if err != nil {
+		return false, fmt.Errorf("existence check failed: %v", err)
+	}
+
+	return out != nil, nil
 }
 
 func (b *PassthroughBackend) handleRead(

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -34,7 +34,6 @@ func NewSystemBackend(core *Core, config *logical.BackendConfig) logical.Backend
 				"revoke-prefix/*",
 				"audit",
 				"audit/*",
-				"seal", // Must be set for Core.Seal() logic
 				"raw/*",
 				"rotate",
 			},
@@ -74,7 +73,7 @@ func NewSystemBackend(core *Core, config *logical.BackendConfig) logical.Backend
 				},
 
 				Callbacks: map[logical.Operation]framework.OperationFunc{
-					logical.ReadOperation:  b.handleMountTuneRead,
+					logical.ReadOperation:   b.handleMountTuneRead,
 					logical.UpdateOperation: b.handleMountTuneWrite,
 				},
 
@@ -105,7 +104,7 @@ func NewSystemBackend(core *Core, config *logical.BackendConfig) logical.Backend
 				},
 
 				Callbacks: map[logical.Operation]framework.OperationFunc{
-					logical.UpdateOperation:  b.handleMount,
+					logical.UpdateOperation: b.handleMount,
 					logical.DeleteOperation: b.handleUnmount,
 				},
 
@@ -234,7 +233,7 @@ func NewSystemBackend(core *Core, config *logical.BackendConfig) logical.Backend
 				},
 
 				Callbacks: map[logical.Operation]framework.OperationFunc{
-					logical.UpdateOperation:  b.handleEnableAuth,
+					logical.UpdateOperation: b.handleEnableAuth,
 					logical.DeleteOperation: b.handleDisableAuth,
 				},
 
@@ -269,7 +268,7 @@ func NewSystemBackend(core *Core, config *logical.BackendConfig) logical.Backend
 
 				Callbacks: map[logical.Operation]framework.OperationFunc{
 					logical.ReadOperation:   b.handlePolicyRead,
-					logical.UpdateOperation:  b.handlePolicySet,
+					logical.UpdateOperation: b.handlePolicySet,
 					logical.DeleteOperation: b.handlePolicyDelete,
 				},
 
@@ -333,7 +332,7 @@ func NewSystemBackend(core *Core, config *logical.BackendConfig) logical.Backend
 				},
 
 				Callbacks: map[logical.Operation]framework.OperationFunc{
-					logical.UpdateOperation:  b.handleEnableAudit,
+					logical.UpdateOperation: b.handleEnableAudit,
 					logical.DeleteOperation: b.handleDisableAudit,
 				},
 
@@ -355,7 +354,7 @@ func NewSystemBackend(core *Core, config *logical.BackendConfig) logical.Backend
 
 				Callbacks: map[logical.Operation]framework.OperationFunc{
 					logical.ReadOperation:   b.handleRawRead,
-					logical.UpdateOperation:  b.handleRawWrite,
+					logical.UpdateOperation: b.handleRawWrite,
 					logical.DeleteOperation: b.handleRawDelete,
 				},
 			},

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -19,7 +19,6 @@ func TestSystemBackend_RootPaths(t *testing.T) {
 		"revoke-prefix/*",
 		"audit",
 		"audit/*",
-		"seal",
 		"raw/*",
 		"rotate",
 	}
@@ -739,7 +738,7 @@ func TestSystemBackend_rawWrite(t *testing.T) {
 	if p == nil || len(p.Paths) == 0 {
 		t.Fatalf("missing policy %#v", p)
 	}
-	if p.Paths[0].Prefix != "secret/" || p.Paths[0].Policy != PathPolicyRead {
+	if p.Paths[0].Prefix != "secret/" || p.Paths[0].Policy != ReadCapability {
 		t.Fatalf("Bad: %#v", p)
 	}
 }

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -8,64 +8,36 @@ import (
 )
 
 const (
-	PathPolicyDeny  = "deny"
-	PathPolicyRead  = "read"
-	PathPolicyWrite = "write"
-	PathPolicySudo  = "sudo"
+	CreateCapability = "create"
+	ReadCapability   = "read"
+	UpdateCapability = "update"
+	DeleteCapability = "delete"
+	ListCapability   = "list"
+	DenyCapability   = "deny"
+	SudoCapability   = "sudo"
+
+	// Backwards compatibility
+	OldDenyPathPolicy  = "deny"
+	OldReadPathPolicy  = "read"
+	OldWritePathPolicy = "write"
+	OldSudoPathPolicy  = "sudo"
 )
 
 // Policy is used to represent the policy specified by
 // an ACL configuration.
 type Policy struct {
-	Name  string        `hcl:"name"`
-	Paths []*PathPolicy `hcl:"path,expand"`
+	Name  string              `hcl:"name"`
+	Paths []*PathCapabilities `hcl:"path,expand"`
 	Raw   string
 }
 
-// PathPolicy represents a policy for a path in the namespace
-type PathPolicy struct {
-	Prefix string `hcl:",key"`
-	Policy string
-	Glob   bool
-}
-
-// TakesPrecedence is used when multiple policies
-// collide on a path to determine which policy takes
-// precendence.
-func (p *PathPolicy) TakesPrecedence(other *PathPolicy) bool {
-	// Handle the full merge matrix
-	switch p.Policy {
-	case PathPolicyDeny:
-		// Deny always takes precendence
-		return true
-
-	case PathPolicyRead:
-		// Read never takes precedence
-		return false
-
-	case PathPolicyWrite:
-		switch other.Policy {
-		case PathPolicyRead:
-			return true
-		case PathPolicyDeny, PathPolicyWrite, PathPolicySudo:
-			return false
-		default:
-			panic("missing case")
-		}
-
-	case PathPolicySudo:
-		switch other.Policy {
-		case PathPolicyRead, PathPolicyWrite:
-			return true
-		case PathPolicyDeny, PathPolicySudo:
-			return false
-		default:
-			panic("missing case")
-		}
-
-	default:
-		panic("missing case")
-	}
+// Capability represents a policy for a path in the namespace
+type PathCapabilities struct {
+	Prefix          string `hcl:",key"`
+	Policy          string
+	Capabilities    []string
+	CapabilitiesMap map[string]bool `hcl:"-"`
+	Glob            bool
 }
 
 // Parse is used to parse the specified ACL rules into an
@@ -79,22 +51,44 @@ func Parse(rules string) (*Policy, error) {
 	}
 
 	// Validate the path policy
-	for _, pp := range p.Paths {
+	for _, pc := range p.Paths {
 		// Strip the glob character if found
-		if strings.HasSuffix(pp.Prefix, "*") {
-			pp.Prefix = strings.TrimSuffix(pp.Prefix, "*")
-			pp.Glob = true
+		if strings.HasSuffix(pc.Prefix, "*") {
+			pc.Prefix = strings.TrimSuffix(pc.Prefix, "*")
+			pc.Glob = true
 		}
 
-		// Check the policy is valid
-		switch pp.Policy {
-		case PathPolicyDeny:
-		case PathPolicyRead:
-		case PathPolicyWrite:
-		case PathPolicySudo:
-		default:
-			return nil, fmt.Errorf("Invalid path policy: %#v", pp)
+		// Map old-style policies into capabilities
+		switch pc.Policy {
+		case OldDenyPathPolicy:
+			pc.Capabilities = append(pc.Capabilities, DenyCapability)
+		case OldReadPathPolicy:
+			pc.Capabilities = append(pc.Capabilities, []string{ReadCapability, ListCapability}...)
+		case OldWritePathPolicy:
+			pc.Capabilities = append(pc.Capabilities, []string{CreateCapability, ReadCapability, UpdateCapability, DeleteCapability, ListCapability}...)
+		case OldSudoPathPolicy:
+			pc.Capabilities = append(pc.Capabilities, []string{CreateCapability, ReadCapability, UpdateCapability, DeleteCapability, ListCapability, SudoCapability}...)
 		}
+
+		// Initialize the map
+		pc.CapabilitiesMap = make(map[string]bool, len(pc.Capabilities))
+		for _, cap := range pc.Capabilities {
+			switch cap {
+			// If it's deny, don't include any other capability
+			case DenyCapability:
+				pc.Capabilities = []string{DenyCapability}
+				pc.CapabilitiesMap = map[string]bool{
+					DenyCapability: true,
+				}
+				goto PathFinished
+			case CreateCapability, ReadCapability, UpdateCapability, DeleteCapability, ListCapability, SudoCapability:
+				pc.CapabilitiesMap[cap] = true
+			default:
+				return nil, fmt.Errorf("Invalid capability: %#v", pc)
+			}
+		}
+
+	PathFinished:
 	}
 	return p, nil
 }

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -1,45 +1,10 @@
 package vault
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
-
-func TestPolicy_TakesPrecedence(t *testing.T) {
-	type tcase struct {
-		a, b       string
-		precedence bool
-	}
-	tests := []tcase{
-		tcase{PathPolicyDeny, PathPolicyDeny, true},
-		tcase{PathPolicyDeny, PathPolicyRead, true},
-		tcase{PathPolicyDeny, PathPolicyWrite, true},
-		tcase{PathPolicyDeny, PathPolicySudo, true},
-
-		tcase{PathPolicyRead, PathPolicyDeny, false},
-		tcase{PathPolicyRead, PathPolicyRead, false},
-		tcase{PathPolicyRead, PathPolicyWrite, false},
-		tcase{PathPolicyRead, PathPolicySudo, false},
-
-		tcase{PathPolicyWrite, PathPolicyDeny, false},
-		tcase{PathPolicyWrite, PathPolicyRead, true},
-		tcase{PathPolicyWrite, PathPolicyWrite, false},
-		tcase{PathPolicyWrite, PathPolicySudo, false},
-
-		tcase{PathPolicySudo, PathPolicyDeny, false},
-		tcase{PathPolicySudo, PathPolicyRead, true},
-		tcase{PathPolicySudo, PathPolicyWrite, true},
-		tcase{PathPolicySudo, PathPolicySudo, false},
-	}
-	for idx, test := range tests {
-		a := &PathPolicy{Policy: test.a}
-		b := &PathPolicy{Policy: test.b}
-		if out := a.TakesPrecedence(b); out != test.precedence {
-			t.Fatalf("bad: idx %d expect: %v out: %v",
-				idx, test.precedence, out)
-		}
-	}
-}
 
 func TestPolicy_Parse(t *testing.T) {
 	p, err := Parse(rawPolicy)
@@ -51,13 +16,64 @@ func TestPolicy_Parse(t *testing.T) {
 		t.Fatalf("bad: %#v", p)
 	}
 
-	expect := []*PathPolicy{
-		&PathPolicy{"", "deny", true},
-		&PathPolicy{"stage/", "sudo", true},
-		&PathPolicy{"prod/version", "read", false},
+	expect := []*PathCapabilities{
+		&PathCapabilities{"", "deny",
+			[]string{
+				"deny",
+			}, map[string]bool{
+				"deny": true,
+			}, true},
+		&PathCapabilities{"stage/", "sudo",
+			[]string{
+				"create",
+				"read",
+				"update",
+				"delete",
+				"list",
+				"sudo",
+			}, map[string]bool{
+				"create": true,
+				"read":   true,
+				"update": true,
+				"delete": true,
+				"list":   true,
+				"sudo":   true,
+			}, true},
+		&PathCapabilities{"prod/version", "read",
+			[]string{
+				"read",
+				"list",
+			}, map[string]bool{
+				"read": true,
+				"list": true,
+			}, false},
+		&PathCapabilities{"foo/bar", "read",
+			[]string{
+				"read",
+				"list",
+			}, map[string]bool{
+				"read": true,
+				"list": true,
+			}, false},
+		&PathCapabilities{"foo/bar", "",
+			[]string{
+				"create",
+				"sudo",
+			}, map[string]bool{
+				"create": true,
+				"sudo":   true,
+			}, false},
 	}
 	if !reflect.DeepEqual(p.Paths, expect) {
-		t.Fatalf("bad: %#v", p)
+		ret := fmt.Sprintf("bad:\nexpected:\n")
+		for _, v := range expect {
+			ret = fmt.Sprintf("%s\n%#v", ret, *v)
+		}
+		ret = fmt.Sprintf("%s\n\ngot:\n", ret)
+		for _, v := range p.Paths {
+			ret = fmt.Sprintf("%s\n%#v", ret, *v)
+		}
+		t.Fatalf("%s\n", ret)
 	}
 }
 
@@ -78,5 +94,16 @@ path "stage/*" {
 # Limited read privilege to production
 path "prod/version" {
 	policy = "read"
+}
+
+# Read access to foobar
+path "foo/bar" {
+	policy = "read"
+}
+
+# Add capabilities for creation and sudo to foobar
+# This will be separate; they are combined when compiled into an ACL
+path "foo/bar" {
+	capabilities = ["create", "sudo"]
 }
 `

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -20,9 +20,7 @@ func TestPolicy_Parse(t *testing.T) {
 		&PathCapabilities{"", "deny",
 			[]string{
 				"deny",
-			}, map[string]bool{
-				"deny": true,
-			}, true},
+			}, DenyCapabilityInt, true},
 		&PathCapabilities{"stage/", "sudo",
 			[]string{
 				"create",
@@ -31,38 +29,23 @@ func TestPolicy_Parse(t *testing.T) {
 				"delete",
 				"list",
 				"sudo",
-			}, map[string]bool{
-				"create": true,
-				"read":   true,
-				"update": true,
-				"delete": true,
-				"list":   true,
-				"sudo":   true,
-			}, true},
+			}, CreateCapabilityInt | ReadCapabilityInt | UpdateCapabilityInt |
+				DeleteCapabilityInt | ListCapabilityInt | SudoCapabilityInt, true},
 		&PathCapabilities{"prod/version", "read",
 			[]string{
 				"read",
 				"list",
-			}, map[string]bool{
-				"read": true,
-				"list": true,
-			}, false},
+			}, ReadCapabilityInt | ListCapabilityInt, false},
 		&PathCapabilities{"foo/bar", "read",
 			[]string{
 				"read",
 				"list",
-			}, map[string]bool{
-				"read": true,
-				"list": true,
-			}, false},
+			}, ReadCapabilityInt | ListCapabilityInt, false},
 		&PathCapabilities{"foo/bar", "",
 			[]string{
 				"create",
 				"sudo",
-			}, map[string]bool{
-				"create": true,
-				"sudo":   true,
-			}, false},
+			}, CreateCapabilityInt | SudoCapabilityInt, false},
 	}
 	if !reflect.DeepEqual(p.Paths, expect) {
 		ret := fmt.Sprintf("bad:\nexpected:\n")

--- a/vault/router_test.go
+++ b/vault/router_test.go
@@ -35,8 +35,8 @@ func (n *NoopBackend) HandleRequest(req *logical.Request) (*logical.Response, er
 	return n.Response, nil
 }
 
-func (n *NoopBackend) HandleExistenceCheck(req *logical.Request) (*bool, error) {
-	return new(bool), nil
+func (n *NoopBackend) HandleExistenceCheck(req *logical.Request) (bool, bool, error) {
+	return false, false, nil
 }
 
 func (n *NoopBackend) SpecialPaths() *logical.Paths {

--- a/vault/router_test.go
+++ b/vault/router_test.go
@@ -35,6 +35,10 @@ func (n *NoopBackend) HandleRequest(req *logical.Request) (*logical.Response, er
 	return n.Response, nil
 }
 
+func (n *NoopBackend) HandleExistenceCheck(req *logical.Request) (*bool, error) {
+	return new(bool), nil
+}
+
 func (n *NoopBackend) SpecialPaths() *logical.Paths {
 	return &logical.Paths{
 		Root:            n.Root,

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -286,8 +286,8 @@ func (n *rawHTTP) HandleRequest(req *logical.Request) (*logical.Response, error)
 	}, nil
 }
 
-func (n *rawHTTP) HandleExistenceCheck(req *logical.Request) (*bool, error) {
-	return new(bool), nil
+func (n *rawHTTP) HandleExistenceCheck(req *logical.Request) (bool, bool, error) {
+	return false, false, nil
 }
 
 func (n *rawHTTP) SpecialPaths() *logical.Paths {

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -286,6 +286,10 @@ func (n *rawHTTP) HandleRequest(req *logical.Request) (*logical.Response, error)
 	}, nil
 }
 
+func (n *rawHTTP) HandleExistenceCheck(req *logical.Request) (*bool, error) {
+	return new(bool), nil
+}
+
 func (n *rawHTTP) SpecialPaths() *logical.Paths {
 	return &logical.Paths{Unauthenticated: []string{"*"}}
 }

--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -28,44 +28,74 @@ path "secret/*" {
 
 path "secret/foo" {
   policy = "read"
+  capabilities = ["create", "sudo"]
 }
 
 path "secret/super-secret" {
-  policy = "deny"
+  capabilities = ["deny"]
 }
 ```
 
 Policies use path based matching to apply rules. A policy may be an exact
-match, or might be a glob pattern which uses a prefix. The default policy
-is always deny so if a path isn't explicitly allowed, Vault will reject access to it.
-This works well due to Vault's architecture of being like a filesystem:
-everything has a path associated with it, including the core configuration
-mechanism under "sys".
+match, or might be a glob pattern which uses a prefix. Vault operates in a
+whitelisting mode, so if a path isn't explicitly allowed, Vault will reject
+access to it.  This works well due to Vault's architecture of being like a
+filesystem: everything has a path associated with it, including the core
+configuration mechanism under "sys".
 
 ~> Policy paths are matched using the most specific defined policy. This may
 be an exact match or the longest-prefix match of a glob. This means if you
 define a policy for `"secret/foo*"`, the policy would also match `"secret/foobar"`.
 The glob character is only supported at the end of the path specification.
 
-## Policies
+## Capabilities and Policies
 
-Allowed policies for a path are:
+Paths have an associated set of capabilities that provide fine-grained control
+over operations. The capabilities are:
 
-  * `deny` - No access allowed. Highest precedence.
+  * `create` - Create a value at a path. (At present, few parts of Vault
+    distinguish between `create` and `update`, so most operations require
+    `update`. Parts of Vault that provide such a distinction, such as
+    the `generic` backend, are noted in documentation.)
 
-  * `sudo` - Read, write, and root access to a path.
+  * `read` - Read the value at a path.
 
-  * `write` - Read, write access to a path.
+  * `update` - Change the value at a path. In most parts of Vault, this also
+    includes the ability to create the initial value at the path.
 
-  * `read` - Read-only access to a path.
+  * `delete` - Delete the value at a path.
 
-The only non-obvious policy is "sudo". Some routes within Vault and mounted
-backends are marked as _root_ paths. Clients aren't allowed to access root
-paths unless they are a root user (have the special policy "root") or
-have access to that path with the "sudo" policy.
+  * `list` - List values at a path.
+
+  * `sudo` - Gain access to paths that are _root-protected_. This is _additive_
+    to other capabilities, so a path that requires `sudo` access will also
+    require `read`, `update`, etc. as appropriate.
+
+  * `deny` - No access allowed. This always takes precedence regardless of any
+    other defined capabilities, including `sudo`.
+
+The only non-obvious capability is `sudo`. Some routes within Vault and mounted
+backends are marked as _root-protected_ paths. Clients aren't allowed to access
+root paths unless they are a root user (have the special policy "root" attached
+to their token) or have access to that path with the `sudo` capability (in
+addition to the other necessary capabilities for performing an operation
+against that path, such as `read` or `delete`).
 
 For example, modifying the audit log backends is done via root paths.
-Only root or "sudo" privilege users are allowed to do this.
+Only root or `sudo` privilege users are allowed to do this.
+
+Prior to Vault 0.5, the `policy` keyword was used per path rather than a set of
+`capabilities`. In Vault 0.5+ these are still supported as shorthand and to
+maintain backwards compatibility, but internally they map to a set of
+capabilities. These mappings are as follows:
+
+  * `deny` - `["deny"]`
+
+  * `sudo` - `["create", "read", "update", "delete", "list", "sudo"]`
+
+  * `write` - `["create", "read", "update", "delete", "list"]`
+
+  * `read` - `["read", "list"]`
 
 ## Root Policy
 
@@ -128,6 +158,6 @@ The merge would previously give the "read" higher precedence. The current
 version of Vault prioritizes the explicit deny, so that the "deny" would
 take precedence.
 
-To make all Vault 0.1 policies compatible with Vault 0.2, the explicit
+To make all Vault 0.1 policies compatible with Vault 0.2+, the explicit
 glob character must be added to all the path prefixes.
 

--- a/website/source/docs/internals/architecture.html.md
+++ b/website/source/docs/internals/architecture.html.md
@@ -119,10 +119,10 @@ used for operators, while applications may use public/private keys or tokens to 
 An authentication request flows through core and into a credential backend, which determines
 if the request is valid and returns a list of associated policies.
 
-Policies are just a named ACL rule. For example, the "root" policy is builtin and
+Policies are just a named ACL rule. For example, the "root" policy is built-in and
 permits access to all resources. You can create any number of named policies with
-fine-grained control over paths. Vault operates exclusively in a blacklist mode, meaning
-unless access is explicitly granted via a policy the action is not allowed.
+fine-grained control over paths. Vault operates exclusively in a whitelist mode, meaning
+that unless access is explicitly granted via a policy, the action is not allowed.
 Since a user may have multiple policies associated, an action is allowed if any policy
 permits it. Policies are stored and managed by an internal policy store. This internal store
 is manipulated through the system backend, which is always mounted at `sys/`.

--- a/website/source/docs/internals/security.html.md
+++ b/website/source/docs/internals/security.html.md
@@ -108,7 +108,7 @@ policies. Vault uses a strict default deny or whitelist enforcement. This means 
 an associated policy allows for a given action, it will be denied. Each policy specifies
 a level of access granted to a path in Vault. When the policies are merged (if multiple
 policies are associated with a client), the highest access level permitted is used.
-For example, if the "engineering" policy permits read/write access to the "eng/" path,
+For example, if the "engineering" policy permits read/update access to the "eng/" path,
 and the "ops" policy permits read access to the "ops/" path, then the user gets the
 union of those. Policy is matched using the most specific defined policy, which may be
 an exact match or the longest-prefix match glob pattern.

--- a/website/source/docs/secrets/generic/index.html.md
+++ b/website/source/docs/secrets/generic/index.html.md
@@ -19,6 +19,9 @@ of these backends at different mount points as you like.
 Writing to a key in the `secret/` backend will replace the old value;
 sub-fields are not merged together.
 
+This backend honors the distinction between the `create` and `update`
+capabilities inside ACL policies.
+
 **Note**: Path and key names are _not_ obfuscated or encrypted; only the values
 set on keys are. You should not store sensitive information as part of a
 secret's path.
@@ -109,7 +112,10 @@ seconds (one hour) as specified.
 <dl class="api">
   <dt>Description</dt>
   <dd>
-    Stores a secret at the specified location.
+    Stores a secret at the specified location. If the value does not yet exist,
+    the calling token must have an ACL policy granting the `create` capability.
+    If the value already exists, the calling token must have an ACL policy
+    granting the `update` capability.
   </dd>
 
   <dt>Method</dt>


### PR DESCRIPTION
* Splits ACLs into granular "capabilities" that can be mixed and matched

* Retains backwards compatibility with "policy" statements by
including the set of capabilities previously defined by them

* Drastically simplifies checking logic, since there is no longer a
concept of hierarchies of "policy" statements -- you either have the
permission in your capability set, or you don't

* Adds ExistenceCheck function capability on backend paths to
enumerate whether an action would be a create or update (to handle
them based on allowed capabilities), and enables this on
logical_passthrough (generic)

* Fixes Seal w.r.t. ExistenceCheck by removing some hackiness around
how Seal was handled, which previously was to not include paths in
logical_system, but put "seal" in RootPaths. Seal now performs the
needed ACL check itself after fetching the ACL via a common function
with checkToken.

* Updates documentation

* Adds capabilities into existing tests in additive ways with
old-style "policy" declarations to ensure that backwards compatibility
is maintained

* Adds new test cases using only capabilities

* Adds test cases around the new Seal logic to ensure that no
permissions hole was opened

Fixes #724 (and others).