### PR TITLE
Load-balanced etcd support

### DIFF
--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -221,6 +221,12 @@ For etcd, the following options are supported:
       Can be comma separated list (protocol://host:port) of many etcd instances.
       Defaults to "http://localhost:2379" if not specified.
 
+  * `username` (optional) - Username to use when authenticating with the etcd
+      server.  May also be specified via the ETCD_USERNAME environment variable.
+
+  * `password` (optional) - Password to use when authenticating with the etcd
+      server.  May also be specified via the ETCD_PASSWORD environment variable.
+
   * `tls_ca_file` (optional) - The path to the CA certificate used for etcd communication.
       Defaults to system bundle if not specified.
 

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -221,6 +221,12 @@ For etcd, the following options are supported:
       Can be comma separated list (protocol://host:port) of many etcd instances.
       Defaults to "http://localhost:2379" if not specified.
 
+  * `sync` (optional) - Should we synchronize the list of available etcd
+      servers on startup?  This will parse as a boolean value, and can be set
+      to "0", "no", "false", "1", "yes", or "true".  Defaults to true.  Set
+      to false if your etcd cluster is behind a proxy server and syncing
+      causes Vault to fail.
+
   * `username` (optional) - Username to use when authenticating with the etcd
       server.  May also be specified via the ETCD_USERNAME environment variable.
 


### PR DESCRIPTION
Some etcd configurations (such as that provided by compose.io) place the etcd cluster behind multiple load balancers or proxies.  In this configuration, calling Sync (or AutoSync) on the etcd client will replace the load balancer addresses with the underlying etcd server address.

This will cause the etcd client to bypass the load balancers, and may cause the connection to fail completely if the etcd servers are protected by a firewall.

This PR provides a "sync" option for the etcd backend, which defaults to the current behavior, but which can be used to turn off of sync. This corresponds to `etcdctl`'s `--no-sync` option.

This PR also documents the existing "username" and "password" options.