### PR TITLE
Remove need for PUT in rekey. We've decided that POST and PUT are to

### DIFF
--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -114,11 +114,6 @@ func handleSysRekeyInitDelete(core *vault.Core, w http.ResponseWriter, r *http.R
 
 func handleSysRekeyUpdate(core *vault.Core) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "PUT" {
-			respondError(w, http.StatusMethodNotAllowed, nil)
-			return
-		}
-
 		// Parse the request
 		var req RekeyUpdateRequest
 		if err := parseRequest(r, &req); err != nil {


### PR DESCRIPTION
stay as synonyms for writes, so there's no reason to limit it for this
operation.