### PR TITLE
fixing an incorrect json response field name

### DIFF
--- a/website/source/docs/secrets/cassandra/index.html.md
+++ b/website/source/docs/secrets/cassandra/index.html.md
@@ -262,7 +262,7 @@ subpath for interactive help output.
     {
       "data": {
         "creation_cql": "CREATE USER...",
-        "revocation_cql": "DROP USER...",
+        "rollback_cql": "DROP USER...",
         "lease": "12h",
         "lease_grace_period": "1h"
       }


### PR DESCRIPTION
changed a read-role api response field from 'revocation_cql' to 'rollback_cql'
didn't verify it using a real cassandra server test, but looked at the source code json schema definition here: 

https://github.com/hashicorp/vault/blob/master/builtin/logical/cassandra/path_roles.go
func pathRoles(b *backend) *framework.Path 

please feel free to discard the PR, if i am looking at the wrong source location or something.