### PR TITLE
Ldapbind

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -99,7 +99,7 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 		return nil, logical.ErrorResponse(err.Error()), nil
 	}
 	binddn := ""
-	if cfg.BindDN != "" && cfg.BindPassword != "" {
+	if cfg.DiscoverDN || (cfg.BindDN != "" && cfg.BindPassword != "") {
 		if err = c.Bind(cfg.BindDN, cfg.BindPassword); err != nil {
 			return nil, logical.ErrorResponse(fmt.Sprintf("LDAP bind (service) failed: %v", err)), nil
 		}

--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -100,7 +100,7 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 	}
 	binddn := ""
 	if cfg.BindDN != "" && cfg.BindPassword != "" {
-		if err = c.Bind(binddn, password); err != nil {
+		if err = c.Bind(cfg.BindDN, cfg.BindPassword); err != nil {
 			return nil, logical.ErrorResponse(fmt.Sprintf("LDAP bind (service) failed: %v", err)), nil
 		}
 		sresult, err := c.Search(&ldap.SearchRequest{

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -27,11 +27,11 @@ func pathConfig(b *backend) *framework.Path {
 			},
 			"binddn": &framework.FieldSchema{
 				Type:        framework.TypeString,
-				Description: "LDAP DN for searching for the user DN",
+				Description: "LDAP DN for searching for the user DN (optional)",
 			},
 			"bindpass": &framework.FieldSchema{
 				Type:        framework.TypeString,
-				Description: "LDAP password for searching for the user DN",
+				Description: "LDAP password for searching for the user DN (optional)",
 			},
 			"groupdn": &framework.FieldSchema{
 				Type:        framework.TypeString,
@@ -48,6 +48,10 @@ func pathConfig(b *backend) *framework.Path {
 			"certificate": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "CA certificate to use when verifying LDAP server certificate, must be x509 PEM encoded (optional)",
+			},
+			"discoverdn": &framework.FieldSchema{
+				Type:        framework.TypeBool,
+				Description: "Use anonymous bind to discover the bind DN of a user (optional)",
 			},
 			"insecure_tls": &framework.FieldSchema{
 				Type:        framework.TypeBool,
@@ -108,6 +112,7 @@ func (b *backend) pathConfigRead(
 			"starttls":     cfg.StartTLS,
 			"binddn":       cfg.BindDN,
 			"bindpass":     cfg.BindPassword,
+			"discoverdn":   cfg.DiscoverDN,
 		},
 	}, nil
 }
@@ -156,6 +161,10 @@ func (b *backend) pathConfigWrite(
 	if bindPass != "" {
 		cfg.BindPassword = bindPass
 	}
+	discoverDN := d.Get("discoverdn").(bool)
+	if discoverDN {
+		cfg.DiscoverDN = discoverDN
+	}
 
 	// Try to connect to the LDAP server, to validate the URL configuration
 	// We can also check the URL at this stage, as anything else would probably
@@ -188,6 +197,7 @@ type ConfigEntry struct {
 	StartTLS     bool
 	BindDN       string
 	BindPassword string
+	DiscoverDN   bool
 }
 
 func (c *ConfigEntry) GetTLSConfig(host string) (*tls.Config, error) {

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -25,6 +25,14 @@ func pathConfig(b *backend) *framework.Path {
 				Type:        framework.TypeString,
 				Description: "LDAP domain to use for users (eg: ou=People,dc=example,dc=org)",
 			},
+			"binddn": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "LDAP DN for searching for the user DN",
+			},
+			"bindpass": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "LDAP password for searching for the user DN",
+			},
 			"groupdn": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "LDAP domain to use for groups (eg: ou=Groups,dc=example,dc=org)",
@@ -52,7 +60,7 @@ func pathConfig(b *backend) *framework.Path {
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation:  b.pathConfigRead,
+			logical.ReadOperation:   b.pathConfigRead,
 			logical.UpdateOperation: b.pathConfigWrite,
 		},
 
@@ -98,6 +106,8 @@ func (b *backend) pathConfigRead(
 			"certificate":  cfg.Certificate,
 			"insecure_tls": cfg.InsecureTLS,
 			"starttls":     cfg.StartTLS,
+			"binddn":       cfg.BindDN,
+			"bindpass":     cfg.BindPassword,
 		},
 	}, nil
 }
@@ -138,6 +148,14 @@ func (b *backend) pathConfigWrite(
 	if startTLS {
 		cfg.StartTLS = startTLS
 	}
+	bindDN := d.Get("binddn").(string)
+	if bindDN != "" {
+		cfg.BindDN = bindDN
+	}
+	bindPass := d.Get("bindpass").(string)
+	if bindPass != "" {
+		cfg.BindPassword = bindPass
+	}
 
 	// Try to connect to the LDAP server, to validate the URL configuration
 	// We can also check the URL at this stage, as anything else would probably
@@ -160,14 +178,16 @@ func (b *backend) pathConfigWrite(
 }
 
 type ConfigEntry struct {
-	Url         string
-	UserDN      string
-	GroupDN     string
-	UPNDomain   string
-	UserAttr    string
-	Certificate string
-	InsecureTLS bool
-	StartTLS    bool
+	Url          string
+	UserDN       string
+	GroupDN      string
+	UPNDomain    string
+	UserAttr     string
+	Certificate  string
+	InsecureTLS  bool
+	StartTLS     bool
+	BindDN       string
+	BindPassword string
 }
 
 func (c *ConfigEntry) GetTLSConfig(host string) (*tls.Config, error) {

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -122,6 +122,8 @@ $ vault write auth/ldap/config url="ldap://ldap.forumsys.com" \
     starttls=true
 ...
 ```
+To discover the bind dn for a user with an anonymous bind, use the `discoverdn=true`
+parameter and leave the `binddn` / `bindpass` empty.
 
 Next we want to create a mapping from an LDAP group to a Vault policy:
 

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -100,6 +100,15 @@ $ vault write auth/ldap/config url="ldap://ldap.forumsys.com" \
 The above configures the target LDAP server, along with the parameters
 specifying how users and groups should be queried from the LDAP server.
 
+If your users are not located directly below the "userdn", e.g. in several
+OUs like
+```
+    ou=users,dc=example,dc=com
+ou=people    ou=external     ou=robots
+```
+you can also specify a `binddn` and `bindpass` for vault to search for the DN
+of a user.
+
 Next we want to create a mapping from an LDAP group to a Vault policy:
 
 ```

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -107,7 +107,21 @@ OUs like
 ou=people    ou=external     ou=robots
 ```
 you can also specify a `binddn` and `bindpass` for vault to search for the DN
-of a user.
+of a user. This also works for the AD where a typical setup is to have user
+DNs in the form `cn=Firstname Lastname,ou=Users,dc=example,dc=com` but you
+want to login users using the `sAMAccountName` attribute. For that specify
+```
+$ vault write auth/ldap/config url="ldap://ldap.forumsys.com" \
+    userattr=sAMAccountName \
+    userdn="ou=users,dc=example,dc=com" \
+    groupdn="dc=example,dc=com" \
+    binddn="cn=vault,ou=users,dc=example,dc=com" \
+    bindpass='My$ecrt3tP4ss' \
+    certificate=@ldap_ca_cert.pem \
+    insecure_tls=false \
+    starttls=true
+...
+```
 
 Next we want to create a mapping from an LDAP group to a Vault policy:
 


### PR DESCRIPTION
The bind dn and bind password are used by vault to determine the binddn of the user logging in. This is needed when the users tree has several sub OUs like
```
           ou=users,dc=example,dc=com
    ou=robots         ou=employees    ou=external
```
The user's bind dn is searched with a filter of
```go
fmt.Sprintf("(%s=%s)", cfg.UserAttr, EscapeLDAPValue(username))
``` 