### PR TITLE
Implement locking in the transit backend.

### DIFF
--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -38,7 +38,7 @@ func Backend() *backend {
 		Secrets: []*framework.Secret{},
 	}
 
-	b.policies = &policyCache{
+	b.policies = policyCache{
 		cache: map[string]*lockingPolicy{},
 	}
 
@@ -47,5 +47,5 @@ func Backend() *backend {
 
 type backend struct {
 	*framework.Backend
-	policies *policyCache
+	policies policyCache
 }

--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -6,36 +6,46 @@ import (
 )
 
 func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
-	return Backend().Setup(conf)
+	b := Backend()
+	be, err := b.Backend.Setup(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	err = b.policies.loadStoredPolicies(conf.StorageView)
+	if err != nil {
+		return nil, err
+	}
+
+	return be, nil
 }
 
-func Backend() *framework.Backend {
+func Backend() *backend {
 	var b backend
 	b.Backend = &framework.Backend{
-		PathsSpecial: &logical.Paths{
-			Root: []string{
-				"keys/*",
-			},
-		},
-
 		Paths: []*framework.Path{
 			// Rotate/Config needs to come before Keys
 			// as the handler is greedy
-			pathConfig(),
-			pathRotate(),
-			pathRewrap(),
-			pathKeys(),
-			pathEncrypt(),
-			pathDecrypt(),
-			pathDatakey(),
+			b.pathConfig(),
+			b.pathRotate(),
+			b.pathRewrap(),
+			b.pathKeys(),
+			b.pathEncrypt(),
+			b.pathDecrypt(),
+			b.pathDatakey(),
 		},
 
 		Secrets: []*framework.Secret{},
 	}
 
-	return b.Backend
+	b.policies = &policyCache{
+		cache: map[string]*lockingPolicy{},
+	}
+
+	return &b
 }
 
 type backend struct {
 	*framework.Backend
+	policies *policyCache
 }

--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -12,11 +12,6 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 		return nil, err
 	}
 
-	err = b.policies.loadStoredPolicies(conf.StorageView)
-	if err != nil {
-		return nil, err
-	}
-
 	return be, nil
 }
 

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -19,7 +19,7 @@ const (
 func TestBackend_basic(t *testing.T) {
 	decryptData := make(map[string]interface{})
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: Backend(),
+		Factory: Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepWritePolicy(t, "test", false),
 			testAccStepReadPolicy(t, "test", false, false),
@@ -42,7 +42,7 @@ func TestBackend_basic(t *testing.T) {
 func TestBackend_datakey(t *testing.T) {
 	dataKeyInfo := make(map[string]interface{})
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: Backend(),
+		Factory: Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepWritePolicy(t, "test", false),
 			testAccStepReadPolicy(t, "test", false, false),
@@ -57,7 +57,7 @@ func TestBackend_rotation(t *testing.T) {
 	decryptData := make(map[string]interface{})
 	encryptHistory := make(map[int]map[string]interface{})
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: Backend(),
+		Factory: Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepWritePolicy(t, "test", false),
 			testAccStepEncryptVX(t, "test", testPlaintext, decryptData, 0, encryptHistory),
@@ -111,26 +111,10 @@ func TestBackend_rotation(t *testing.T) {
 	})
 }
 
-func TestBackend_upsert(t *testing.T) {
-	decryptData := make(map[string]interface{})
-	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: Backend(),
-		Steps: []logicaltest.TestStep{
-			testAccStepReadPolicy(t, "test", true, false),
-			testAccStepEncrypt(t, "test", testPlaintext, decryptData),
-			testAccStepReadPolicy(t, "test", false, false),
-			testAccStepDecrypt(t, "test", testPlaintext, decryptData),
-			testAccStepEnableDeletion(t, "test"),
-			testAccStepDeletePolicy(t, "test"),
-			testAccStepReadPolicy(t, "test", true, false),
-		},
-	})
-}
-
 func TestBackend_basic_derived(t *testing.T) {
 	decryptData := make(map[string]interface{})
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: Backend(),
+		Factory: Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepWritePolicy(t, "test", true),
 			testAccStepReadPolicy(t, "test", false, true),

--- a/builtin/logical/transit/path_config.go
+++ b/builtin/logical/transit/path_config.go
@@ -52,12 +52,12 @@ func (b *backend) pathConfigWrite(
 			logical.ErrInvalidRequest
 	}
 
-	lp.lock.Lock()
-	defer lp.lock.Unlock()
+	lp.Lock()
+	defer lp.Unlock()
 
 	// Verify if wasn't deleted before we grabbed the lock
 	if lp.policy == nil {
-		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
+		return nil, fmt.Errorf("no existing role named %s could be found", name)
 	}
 
 	resp := &logical.Response{}

--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -83,12 +83,12 @@ func (b *backend) pathDatakeyWrite(
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
 	}
 
-	lp.lock.RLock()
-	defer lp.lock.RUnlock()
+	lp.RLock()
+	defer lp.RUnlock()
 
 	// Verify if wasn't deleted before we grabbed the lock
 	if lp.policy == nil {
-		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
+		return nil, fmt.Errorf("no existing policy named %s could be found", name)
 	}
 
 	newKey := make([]byte, 32)

--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
-func pathDatakey() *framework.Path {
+func (b *backend) pathDatakey() *framework.Path {
 	return &framework.Path{
 		Pattern: "datakey/" + framework.GenericNameRegex("plaintext") + "/" + framework.GenericNameRegex("name"),
 		Fields: map[string]*framework.FieldSchema{
@@ -39,7 +39,7 @@ and 512 bits are supported. Defaults to 256.`,
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: pathDatakeyWrite,
+			logical.UpdateOperation: b.pathDatakeyWrite,
 		},
 
 		HelpSynopsis:    pathDatakeyHelpSyn,
@@ -47,7 +47,7 @@ and 512 bits are supported. Defaults to 256.`,
 	}
 }
 
-func pathDatakeyWrite(
+func (b *backend) pathDatakeyWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
@@ -73,14 +73,22 @@ func pathDatakeyWrite(
 	}
 
 	// Get the policy
-	p, err := getPolicy(req, name)
+	lp, err := b.policies.getPolicy(req, name)
 	if err != nil {
 		return nil, err
 	}
 
 	// Error if invalid policy
-	if p == nil {
+	if lp == nil {
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
+	}
+
+	lp.lock.RLock()
+	defer lp.lock.RUnlock()
+
+	// Verify if wasn't deleted before we grabbed the lock
+	if lp.policy == nil {
+		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
 	}
 
 	newKey := make([]byte, 32)
@@ -99,7 +107,7 @@ func pathDatakeyWrite(
 		return nil, err
 	}
 
-	ciphertext, err := p.Encrypt(context, base64.StdEncoding.EncodeToString(newKey))
+	ciphertext, err := lp.policy.Encrypt(context, base64.StdEncoding.EncodeToString(newKey))
 	if err != nil {
 		switch err.(type) {
 		case certutil.UserError:

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -68,12 +68,12 @@ func (b *backend) pathDecryptWrite(
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
 	}
 
-	lp.lock.RLock()
-	defer lp.lock.RUnlock()
+	lp.RLock()
+	defer lp.RUnlock()
 
 	// Verify if wasn't deleted before we grabbed the lock
 	if lp.policy == nil {
-		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
+		return nil, fmt.Errorf("no existing policy named %s could be found", name)
 	}
 
 	plaintext, err := lp.policy.Decrypt(context, ciphertext)

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
-func pathDecrypt() *framework.Path {
+func (b *backend) pathDecrypt() *framework.Path {
 	return &framework.Path{
 		Pattern: "decrypt/" + framework.GenericNameRegex("name"),
 		Fields: map[string]*framework.FieldSchema{
@@ -30,7 +30,7 @@ func pathDecrypt() *framework.Path {
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: pathDecryptWrite,
+			logical.UpdateOperation: b.pathDecryptWrite,
 		},
 
 		HelpSynopsis:    pathDecryptHelpSyn,
@@ -38,7 +38,7 @@ func pathDecrypt() *framework.Path {
 	}
 }
 
-func pathDecryptWrite(
+func (b *backend) pathDecryptWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 	ciphertext := d.Get("ciphertext").(string)
@@ -58,17 +58,25 @@ func pathDecryptWrite(
 	}
 
 	// Get the policy
-	p, err := getPolicy(req, name)
+	lp, err := b.policies.getPolicy(req, name)
 	if err != nil {
 		return nil, err
 	}
 
 	// Error if invalid policy
-	if p == nil {
+	if lp == nil {
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
 	}
 
-	plaintext, err := p.Decrypt(context, ciphertext)
+	lp.lock.RLock()
+	defer lp.lock.RUnlock()
+
+	// Verify if wasn't deleted before we grabbed the lock
+	if lp.policy == nil {
+		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
+	}
+
+	plaintext, err := lp.policy.Decrypt(context, ciphertext)
 	if err != nil {
 		switch err.(type) {
 		case certutil.UserError:

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -68,12 +68,12 @@ func (b *backend) pathEncryptWrite(
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
 	}
 
-	lp.lock.RLock()
-	defer lp.lock.RUnlock()
+	lp.RLock()
+	defer lp.RUnlock()
 
 	// Verify if wasn't deleted before we grabbed the lock
 	if lp.policy == nil {
-		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
+		return nil, fmt.Errorf("no existing policy named %s could be found", name)
 	}
 
 	ciphertext, err := lp.policy.Encrypt(context, value)

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -70,7 +70,7 @@ func (b *backend) pathPolicyRead(
 
 	// Verify if wasn't deleted before we grabbed the lock
 	if lp.policy == nil {
-		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
+		return nil, fmt.Errorf("no existing policy named %s could be found", name)
 	}
 
 	// Return the response

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
-func pathKeys() *framework.Path {
+func (b *backend) pathKeys() *framework.Path {
 	return &framework.Path{
 		Pattern: "keys/" + framework.GenericNameRegex("name"),
 		Fields: map[string]*framework.FieldSchema{
@@ -24,9 +24,9 @@ func pathKeys() *framework.Path {
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: pathPolicyWrite,
-			logical.DeleteOperation: pathPolicyDelete,
-			logical.ReadOperation:   pathPolicyRead,
+			logical.UpdateOperation: b.pathPolicyWrite,
+			logical.DeleteOperation: b.pathPolicyDelete,
+			logical.ReadOperation:   b.pathPolicyRead,
 		},
 
 		HelpSynopsis:    pathPolicyHelpSyn,
@@ -34,13 +34,13 @@ func pathKeys() *framework.Path {
 	}
 }
 
-func pathPolicyWrite(
+func (b *backend) pathPolicyWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 	derived := d.Get("derived").(bool)
 
 	// Check if the policy already exists
-	existing, err := getPolicy(req, name)
+	existing, err := b.policies.getPolicy(req, name)
 	if err != nil {
 		return nil, err
 	}
@@ -49,39 +49,47 @@ func pathPolicyWrite(
 	}
 
 	// Generate the policy
-	_, err = generatePolicy(req.Storage, name, derived)
+	_, err = b.policies.generatePolicy(req.Storage, name, derived)
 	return nil, err
 }
 
-func pathPolicyRead(
+func (b *backend) pathPolicyRead(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
-	p, err := getPolicy(req, name)
+	lp, err := b.policies.getPolicy(req, name)
 	if err != nil {
 		return nil, err
 	}
-	if p == nil {
+	if lp == nil {
 		return nil, nil
+	}
+
+	lp.lock.RLock()
+	defer lp.lock.RUnlock()
+
+	// Verify if wasn't deleted before we grabbed the lock
+	if lp.policy == nil {
+		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
 	}
 
 	// Return the response
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"name":                   p.Name,
-			"cipher_mode":            p.CipherMode,
-			"derived":                p.Derived,
-			"deletion_allowed":       p.DeletionAllowed,
-			"min_decryption_version": p.MinDecryptionVersion,
-			"latest_version":         p.LatestVersion,
+			"name":                   lp.policy.Name,
+			"cipher_mode":            lp.policy.CipherMode,
+			"derived":                lp.policy.Derived,
+			"deletion_allowed":       lp.policy.DeletionAllowed,
+			"min_decryption_version": lp.policy.MinDecryptionVersion,
+			"latest_version":         lp.policy.LatestVersion,
 		},
 	}
-	if p.Derived {
-		resp.Data["kdf_mode"] = p.KDFMode
+	if lp.policy.Derived {
+		resp.Data["kdf_mode"] = lp.policy.KDFMode
 	}
 
 	retKeys := map[string]int64{}
-	for k, v := range p.Keys {
+	for k, v := range lp.policy.Keys {
 		retKeys[strconv.Itoa(k)] = v.CreationTime
 	}
 	resp.Data["keys"] = retKeys
@@ -89,30 +97,38 @@ func pathPolicyRead(
 	return resp, nil
 }
 
-func pathPolicyDelete(
+func (b *backend) pathPolicyDelete(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
-	p, err := getPolicy(req, name)
+	lp, err := b.policies.getPolicy(req, name)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf("error looking up policy %s, error is %s", name, err)), err
 	}
-	if p == nil {
+	if lp == nil {
 		return logical.ErrorResponse(fmt.Sprintf("no such key %s", name)), logical.ErrInvalidRequest
 	}
 
-	if !p.DeletionAllowed {
+	// We don't defer here because deletePolicy also needs to grab the lock
+	lp.lock.RLock()
+
+	// Verify if wasn't deleted before we grabbed the lock
+	if lp.policy == nil {
+		lp.lock.RUnlock()
+		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
+	}
+
+	if !lp.policy.DeletionAllowed {
+		lp.lock.RUnlock()
 		return logical.ErrorResponse(fmt.Sprintf("'allow_deletion' config value is not set")), logical.ErrInvalidRequest
 	}
 
-	err = req.Storage.Delete("policy/" + name)
+	// Let deletePolicy grab the lock
+	lp.lock.RUnlock()
+
+	err = b.policies.deletePolicy(req.Storage, name)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf("error deleting policy %s: %s", name, err)), err
-	}
-
-	err = req.Storage.Delete("archive/" + name)
-	if err != nil {
-		return logical.ErrorResponse(fmt.Sprintf("error deleting archive %s: %s", name, err)), err
 	}
 
 	return nil, nil

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -74,7 +74,7 @@ func (b *backend) pathRewrapWrite(
 
 	// Verify if wasn't deleted before we grabbed the lock
 	if lp.policy == nil {
-		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
+		return nil, fmt.Errorf("no existing policy named %s could be found", name)
 	}
 
 	plaintext, err := lp.policy.Decrypt(context, value)

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
-func pathRewrap() *framework.Path {
+func (b *backend) pathRewrap() *framework.Path {
 	return &framework.Path{
 		Pattern: "rewrap/" + framework.GenericNameRegex("name"),
 		Fields: map[string]*framework.FieldSchema{
@@ -30,7 +30,7 @@ func pathRewrap() *framework.Path {
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: pathRewrapWrite,
+			logical.UpdateOperation: b.pathRewrapWrite,
 		},
 
 		HelpSynopsis:    pathRewrapHelpSyn,
@@ -38,7 +38,7 @@ func pathRewrap() *framework.Path {
 	}
 }
 
-func pathRewrapWrite(
+func (b *backend) pathRewrapWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
@@ -59,17 +59,25 @@ func pathRewrapWrite(
 	}
 
 	// Get the policy
-	p, err := getPolicy(req, name)
+	lp, err := b.policies.getPolicy(req, name)
 	if err != nil {
 		return nil, err
 	}
 
 	// Error if invalid policy
-	if p == nil {
+	if lp == nil {
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
 	}
 
-	plaintext, err := p.Decrypt(context, value)
+	lp.lock.RLock()
+	defer lp.lock.RUnlock()
+
+	// Verify if wasn't deleted before we grabbed the lock
+	if lp.policy == nil {
+		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
+	}
+
+	plaintext, err := lp.policy.Decrypt(context, value)
 	if err != nil {
 		switch err.(type) {
 		case certutil.UserError:
@@ -85,7 +93,7 @@ func pathRewrapWrite(
 		return nil, fmt.Errorf("empty plaintext returned during rewrap")
 	}
 
-	ciphertext, err := p.Encrypt(context, plaintext)
+	ciphertext, err := lp.policy.Encrypt(context, plaintext)
 	if err != nil {
 		switch err.(type) {
 		case certutil.UserError:

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -69,8 +69,8 @@ func (b *backend) pathRewrapWrite(
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
 	}
 
-	lp.lock.RLock()
-	defer lp.lock.RUnlock()
+	lp.RLock()
+	defer lp.RUnlock()
 
 	// Verify if wasn't deleted before we grabbed the lock
 	if lp.policy == nil {

--- a/builtin/logical/transit/path_rotate.go
+++ b/builtin/logical/transit/path_rotate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
-func pathRotate() *framework.Path {
+func (b *backend) pathRotate() *framework.Path {
 	return &framework.Path{
 		Pattern: "keys/" + framework.GenericNameRegex("name") + "/rotate",
 		Fields: map[string]*framework.FieldSchema{
@@ -18,7 +18,7 @@ func pathRotate() *framework.Path {
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: pathRotateWrite,
+			logical.UpdateOperation: b.pathRotateWrite,
 		},
 
 		HelpSynopsis:    pathRotateHelpSyn,
@@ -26,23 +26,31 @@ func pathRotate() *framework.Path {
 	}
 }
 
-func pathRotateWrite(
+func (b *backend) pathRotateWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
-	// Check if the policy already exists
-	policy, err := getPolicy(req, name)
+	// Get the policy
+	lp, err := b.policies.getPolicy(req, name)
 	if err != nil {
 		return nil, err
 	}
-	if policy == nil {
-		return logical.ErrorResponse(
-				fmt.Sprintf("no existing role named %s could be found", name)),
-			logical.ErrInvalidRequest
+
+	// Error if invalid policy
+	if lp == nil {
+		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
+	}
+
+	lp.lock.RLock()
+	defer lp.lock.RUnlock()
+
+	// Verify if wasn't deleted before we grabbed the lock
+	if lp.policy == nil {
+		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
 	}
 
 	// Generate the policy
-	err = policy.rotate(req.Storage)
+	err = lp.policy.rotate(req.Storage)
 
 	return nil, err
 }

--- a/builtin/logical/transit/path_rotate.go
+++ b/builtin/logical/transit/path_rotate.go
@@ -41,8 +41,8 @@ func (b *backend) pathRotateWrite(
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
 	}
 
-	lp.lock.RLock()
-	defer lp.lock.RUnlock()
+	lp.Lock()
+	defer lp.Unlock()
 
 	// Verify if wasn't deleted before we grabbed the lock
 	if lp.policy == nil {

--- a/builtin/logical/transit/path_rotate.go
+++ b/builtin/logical/transit/path_rotate.go
@@ -46,7 +46,7 @@ func (b *backend) pathRotateWrite(
 
 	// Verify if wasn't deleted before we grabbed the lock
 	if lp.policy == nil {
-		return nil, fmt.Errorf("policy %s found in cache but no longer valid after lock", name)
+		return nil, fmt.Errorf("no existing policy named %s could be found", name)
 	}
 
 	// Generate the policy

--- a/builtin/logical/transit/policy.go
+++ b/builtin/logical/transit/policy.go
@@ -28,33 +28,6 @@ type policyCache struct {
 	lock  sync.RWMutex
 }
 
-// loadStoredPolicies loads stored policies into the cache. This should only be
-// run at backend initialization time.
-func (p *policyCache) loadStoredPolicies(storage logical.Storage) error {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	policyNames, err := storage.List("policy/")
-	if err != nil {
-		return err
-	}
-
-	// getPolicy will populate the cache
-	for _, name := range policyNames {
-		lp, err := p.getPolicy(&logical.Request{
-			Storage: storage,
-		}, name)
-		if err != nil {
-			return err
-		}
-		if lp == nil {
-			return fmt.Errorf("policy %s key was found but value was nil")
-		}
-	}
-
-	return nil
-}
-
 // getPolicy loads a policy into the cache or returns one already in the cache
 func (p *policyCache) getPolicy(req *logical.Request, name string) (*lockingPolicy, error) {
 	// We don't defer this since we may need to give it up and get a write lock


### PR DESCRIPTION
This ensures that we can safely rotate and modify configuration
parameters with multiple requests in flight.

As a side effect we also get a cache, which should provide a nice
speedup since we don't need to decrypt/deserialize constantly, which
would happen even with the physical LRU.