### PR TITLE
the values need to be raw strings, not arrays

### DIFF
--- a/website/source/docs/secrets/pki/index.html.md
+++ b/website/source/docs/secrets/pki/index.html.md
@@ -602,17 +602,17 @@ subpath for interactive help output.
       <li>
         <span class="param">issuing_certificates</span>
         <span class="param-flags">optional</span>
-        The URL values for the Issuing Certificate field.
+        The URL values for the Issuing Certificate field. This needs to be a delimited string value. (not a JSON array)
       </li>
       <li>
         <span class="param">crl_distribution_points</span>
         <span class="param-flags">optional</span>
-        The URL values for the CRL Distribution Points field.
+        The URL values for the CRL Distribution Points field. This needs to be a delimited string value. (not a JSON array)
       </li>
       <li>
         <span class="param">ocsp_servers</span>
         <span class="param-flags">optional</span>
-        The URL values for the OCSP Servers field.
+        The URL values for the OCSP Servers field. This needs to be a delimited string value. (not a JSON array)
       </li>
     </ul>
   </dd>


### PR DESCRIPTION
clarifying since, during the GET, the API returns it as JSON arrays.
but while POSTING, we need to write it as raw strings, not arrays.