### PR TITLE
Make "ttl" reflect the actual TTL of the token in lookup calls.

### DIFF
--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -126,6 +126,7 @@ func TestLogical_StandbyRedirect(t *testing.T) {
 			"orphan":       true,
 			"id":           root,
 			"ttl":          float64(0),
+			"creation_ttl": float64(0),
 		},
 		"warnings": nilWarnings,
 		"auth":     nil,

--- a/http/sys_generate_root_test.go
+++ b/http/sys_generate_root_test.go
@@ -262,6 +262,7 @@ func TestSysGenerateRoot_Update_OTP(t *testing.T) {
 		"num_uses":     float64(0),
 		"policies":     []interface{}{"root"},
 		"orphan":       true,
+		"creation_ttl": float64(0),
 		"ttl":          float64(0),
 		"path":         "auth/token/root",
 	}
@@ -341,6 +342,7 @@ func TestSysGenerateRoot_Update_PGP(t *testing.T) {
 		"num_uses":     float64(0),
 		"policies":     []interface{}{"root"},
 		"orphan":       true,
+		"creation_ttl": float64(0),
 		"ttl":          float64(0),
 		"path":         "auth/token/root",
 	}

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -837,6 +837,7 @@ func TestTokenStore_HandleRequest_Lookup(t *testing.T) {
 		"display_name": "root",
 		"orphan":       true,
 		"num_uses":     0,
+		"creation_ttl": int64(0),
 		"ttl":          int64(0),
 	}
 
@@ -868,6 +869,7 @@ func TestTokenStore_HandleRequest_Lookup(t *testing.T) {
 		"display_name": "token",
 		"orphan":       false,
 		"num_uses":     0,
+		"creation_ttl": int64(3600),
 		"ttl":          int64(3600),
 	}
 
@@ -875,6 +877,11 @@ func TestTokenStore_HandleRequest_Lookup(t *testing.T) {
 		t.Fatalf("creation time was zero")
 	}
 	delete(resp.Data, "creation_time")
+
+	// Depending on timing of the test this may have ticked down, so accept 3599
+	if resp.Data["ttl"].(int64) == 3599 {
+		resp.Data["ttl"] = int64(3600)
+	}
 
 	if !reflect.DeepEqual(resp.Data, exp) {
 		t.Fatalf("bad:\n%#v\nexp:\n%#v\n", resp.Data, exp)
@@ -964,6 +971,7 @@ func TestTokenStore_HandleRequest_LookupSelf(t *testing.T) {
 		"display_name": "root",
 		"orphan":       true,
 		"num_uses":     0,
+		"creation_ttl": int64(0),
 		"ttl":          int64(0),
 	}
 


### PR DESCRIPTION
Add a new value "creation_ttl" which holds the value at creation time.

Fixes #986