### PR TITLE
Parse and return MountConfigOutput from API

### DIFF
--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -96,18 +96,21 @@ func (c *Sys) TuneMount(path string, config MountConfigInput) error {
 	return err
 }
 
-func (c *Sys) MountConfig(path string) error {
+func (c *Sys) MountConfig(path string) (*MountConfigOutput, error) {
 	if err := c.checkMountPath(path); err != nil {
-		return err
+		return nil, err
 	}
 
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 
 	resp, err := c.c.RawRequest(r)
-	if err == nil {
-		defer resp.Body.Close()
+	if err != nil {
+		return nil, err
 	}
-	return err
+	defer resp.Body.Close()
+	var result MountConfigOutput
+	err = resp.DecodeJSON(&result)
+	return &result, err
 }
 
 func (c *Sys) checkMountPath(path string) error {

--- a/api/sys_mounts_test.go
+++ b/api/sys_mounts_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/vault"
+)
+
+func TestSysMountConfig(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := http.TestServer(t, core)
+	defer ln.Close()
+
+	config := DefaultConfig()
+	config.Address = addr
+
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.SetToken(token)
+
+	// Set up a test mount
+	path, err := testMount(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Sys().Unmount(path)
+
+	// Get config info for this mount
+	mountConfig, err := client.Sys().MountConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDefaultTTL := 2592000
+	if mountConfig.DefaultLeaseTTL != expectedDefaultTTL {
+		t.Fatalf("Expected default lease TTL: %d, got %d",
+			expectedDefaultTTL, mountConfig.DefaultLeaseTTL)
+	}
+
+	expectedMaxTTL := 2592000
+	if mountConfig.MaxLeaseTTL != expectedMaxTTL {
+		t.Fatalf("Expected default lease TTL: %d, got %d",
+			expectedMaxTTL, mountConfig.MaxLeaseTTL)
+	}
+}
+
+// testMount sets up a test mount of a generic backend w/ a random path; caller
+// is responsible for unmounting
+func testMount(client *Client) (string, error) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	randInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	path := fmt.Sprintf("testmount-%d", randInt)
+	err := client.Sys().Mount(path, &MountInput{Type: "generic"})
+	return path, err
+}


### PR DESCRIPTION
When working on the Terraform / Vault integration I came across the fact
that `Sys().MountConfig(...)` didn't seem to return a response struct,
even though it's a `GET` method.

Looks like just a simple oversight to me. This fix does break API BC,
but the method had no use without its return value so I feel like that's
probably a mitigating factor.