### PR TITLE
Sealing vault in standby mode

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1183,6 +1183,10 @@ func (c *Core) Seal(token string) (retErr error) {
 		}
 	}
 	if err != nil {
+		if c.standby {
+			c.logger.Printf("[ERR] core: cannot seal the vault in standby mode")
+			return errors.New("Vault cannot be sealed in standby mode")
+		}
 		return err
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -1183,9 +1183,14 @@ func (c *Core) Seal(token string) (retErr error) {
 		}
 	}
 	if err != nil {
+		// Since there is no token store in standby nodes, sealing cannot
+		// be done. Ideally, the request has to be forwarded to leader node
+		// for validation and the operation should be performed. But for now,
+		// just returning with an error and recommending a vault restart, which
+		// essentially does the same thing.
 		if c.standby {
-			c.logger.Printf("[ERR] core: cannot seal the vault in standby mode")
-			return errors.New("Vault cannot be sealed in standby mode")
+			c.logger.Printf("[ERR] core: vault cannot be sealed when in standby mode; please restart instead")
+			return errors.New("vault cannot be sealed when in standby mode; please restart instead")
 		}
 		return err
 	}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1105,6 +1106,114 @@ func TestCore_LimitedUseToken(t *testing.T) {
 	_, err = c.HandleRequest(req)
 	if err != logical.ErrPermissionDenied {
 		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestCore_Standby_Seal(t *testing.T) {
+	// Create the first core and initialize it
+	inm := physical.NewInmem()
+	inmha := physical.NewInmemHA()
+	advertiseOriginal := "http://127.0.0.1:8200"
+	core, err := NewCore(&CoreConfig{
+		Physical:      inm,
+		HAPhysical:    inmha,
+		AdvertiseAddr: advertiseOriginal,
+		DisableMlock:  true,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	key, root := TestCoreInit(t, core)
+	if _, err := core.Unseal(TestKeyCopy(key)); err != nil {
+		t.Fatalf("unseal err: %s", err)
+	}
+
+	// Verify unsealed
+	sealed, err := core.Sealed()
+	if err != nil {
+		t.Fatalf("err checking seal status: %s", err)
+	}
+	if sealed {
+		t.Fatal("should not be sealed")
+	}
+
+	// Wait for core to become active
+	testWaitActive(t, core)
+
+	// Ensure that the original clean function has stopped running
+	time.Sleep(2 * time.Second)
+
+	// Check the leader is local
+	isLeader, advertise, err := core.Leader()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !isLeader {
+		t.Fatalf("should be leader")
+	}
+	if advertise != advertiseOriginal {
+		t.Fatalf("Bad advertise: %v", advertise)
+	}
+
+	// Create the second core and initialize it
+	advertiseOriginal2 := "http://127.0.0.1:8500"
+	core2, err := NewCore(&CoreConfig{
+		Physical:      inm,
+		HAPhysical:    inmha,
+		AdvertiseAddr: advertiseOriginal2,
+		DisableMlock:  true,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, err := core2.Unseal(TestKeyCopy(key)); err != nil {
+		t.Fatalf("unseal err: %s", err)
+	}
+
+	// Verify unsealed
+	sealed, err = core2.Sealed()
+	if err != nil {
+		t.Fatalf("err checking seal status: %s", err)
+	}
+	if sealed {
+		t.Fatal("should not be sealed")
+	}
+
+	// Core2 should be in standby
+	standby, err := core2.Standby()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !standby {
+		t.Fatalf("should be standby")
+	}
+
+	// Check the leader is not local
+	isLeader, advertise, err = core2.Leader()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if isLeader {
+		t.Fatalf("should not be leader")
+	}
+	if advertise != advertiseOriginal {
+		t.Fatalf("Bad advertise: %v", advertise)
+	}
+
+	// Seal the standby core with the correct token. Shouldn't go down
+	err = core2.Seal(root)
+	if err != nil && !strings.Contains(err.Error(), "vault cannot be sealed when in standby mode; please restart instead") {
+		t.Fatalf("should not be sealed in standby mode")
+	}
+
+	keyUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Seal the standby core with an invalid token. Shouldn't go down
+	err = core2.Seal(keyUUID)
+	if err != nil && !strings.Contains(err.Error(), "vault cannot be sealed when in standby mode; please restart instead") {
+		t.Fatalf("should not be sealed in standby mode")
 	}
 }
 

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -2,7 +2,6 @@ package vault
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -1202,8 +1201,8 @@ func TestCore_Standby_Seal(t *testing.T) {
 
 	// Seal the standby core with the correct token. Shouldn't go down
 	err = core2.Seal(root)
-	if err != nil && !strings.Contains(err.Error(), "vault cannot be sealed when in standby mode; please restart instead") {
-		t.Fatalf("should not be sealed in standby mode")
+	if err == nil {
+		t.Fatal("should not be sealed")
 	}
 
 	keyUUID, err := uuid.GenerateUUID()
@@ -1212,8 +1211,8 @@ func TestCore_Standby_Seal(t *testing.T) {
 	}
 	// Seal the standby core with an invalid token. Shouldn't go down
 	err = core2.Seal(keyUUID)
-	if err != nil && !strings.Contains(err.Error(), "vault cannot be sealed when in standby mode; please restart instead") {
-		t.Fatalf("should not be sealed in standby mode")
+	if err == nil {
+		t.Fatal("should not be sealed")
 	}
 }
 

--- a/website/source/docs/http/sys-seal.html.md
+++ b/website/source/docs/http/sys-seal.html.md
@@ -11,7 +11,7 @@ description: |-
 <dl>
   <dt>Description</dt>
   <dd>
-    Seals the Vault.
+    Seals the Vault. In HA mode, only an active node can be sealed. Standby nodes should be restarted to get the same effect.
   </dd>
 
   <dt>Method</dt>


### PR DESCRIPTION
Introduced a check to see if seal operation is performed on a standby node.
If yes, an error is thrown indicating that it is not allowed and a restart of vault is recommended instead.
Fixes #1006 