### PR TITLE
Add listing of cubbyhole's root to the default policy.

### DIFF
--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -221,6 +221,10 @@ path "auth/token/revoke-self" {
 path "cubbyhole/*" {
     capabilities = ["create", "read", "update", "delete", "list"]
 }
+
+path "cubbyhole" {
+    capabilities = ["list"]
+}
 `)
 	if err != nil {
 		return errwrap.Wrapf("error parsing default policy: {{err}}", err)


### PR DESCRIPTION
This allows `vault list cubbyhole` to behave as expected rather than
requiring `vault list cubbyhole/`. It could be special cased in logic,
but it also serves as a model for the same behavior in e.g. `generic`
mounts where special casing is not possible due to unforeseen mount
paths.