### PR TITLE
Add slack on NotBefore value for generated certs.

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -299,8 +299,12 @@ func checkCertsAndPrivateKey(keyType string, key crypto.Signer, usage certUsage,
 		}
 	}
 
-	if math.Abs(float64(time.Now().Unix()-cert.NotBefore.Unix())) > 10 {
+	// 40 seconds since we add 30 second slack for clock skew
+	if math.Abs(float64(time.Now().Unix()-cert.NotBefore.Unix())) > 40 {
 		return nil, fmt.Errorf("Validity period starts out of range")
+	}
+	if !cert.NotBefore.Before(time.Now().Add(-10 * time.Second)) {
+		return nil, fmt.Errorf("Validity period not far enough in the past")
 	}
 
 	if math.Abs(float64(time.Now().Add(validity).Unix()-cert.NotAfter.Unix())) > 10 {

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -717,7 +717,7 @@ func createCertificate(creationInfo *creationBundle) (*certutil.ParsedCertBundle
 	certTemplate := &x509.Certificate{
 		SerialNumber:   serialNumber,
 		Subject:        subject,
-		NotBefore:      time.Now(),
+		NotBefore:      time.Now().Add(-30 * time.Second),
 		NotAfter:       time.Now().Add(creationInfo.TTL),
 		IsCA:           false,
 		SubjectKeyId:   subjKeyID,
@@ -873,7 +873,7 @@ func signCertificate(creationInfo *creationBundle,
 	certTemplate := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject:      subject,
-		NotBefore:    time.Now(),
+		NotBefore:    time.Now().Add(-30 * time.Second),
 		NotAfter:     time.Now().Add(creationInfo.TTL),
 		SubjectKeyId: subjKeyID[:],
 	}


### PR DESCRIPTION
This fixes an issue where, due to clock skew, one system can get a cert
and try to use it before it thinks it's actually valid. The tolerance of
30 seconds should be high enough for pretty much any set of systems
using NTP.

Fixes #1035