### PR TITLE
Added renewal capability to app-id backend

### DIFF
--- a/builtin/credential/app-id/backend.go
+++ b/builtin/credential/app-id/backend.go
@@ -78,8 +78,7 @@ func Backend(conf *logical.BackendConfig) (*framework.Backend, error) {
 			b.MapUserId.Paths(),
 		),
 
-		// Not enabled until we add verification logic to the renewal function
-		//		AuthRenew: b.pathLoginRenew,
+		AuthRenew: b.pathLoginRenew,
 	}
 
 	// Since the salt is new in 0.2, we need to handle this by migrating
@@ -213,7 +212,11 @@ The user ID can be any value (just like the app ID), however it is
 generally a value unique to a machine, such as a MAC address or instance ID,
 or a value hashed from these unique values.
 
-(Note that it is also possible to authorize multiple app IDs with each
+It is possible to authorize multiple app IDs with each
 user ID by writing them as comma-separated values to the map/user-id/<user-id>
-path.)
+path.
+
+It is also possible to renew the auth tokens with 'vault token-renew <token>' command.
+Before the token is renewed, the validity of app ID, user ID and the associated
+policies are checked again.
 `

--- a/builtin/credential/app-id/backend_test.go
+++ b/builtin/credential/app-id/backend_test.go
@@ -1,6 +1,7 @@
 package appId
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/vault/logical"
@@ -158,6 +159,12 @@ func testAccStepMapUserIdCidr(t *testing.T, cidr string) logicaltest.TestStep {
 }
 
 func testAccLogin(t *testing.T, display string) logicaltest.TestStep {
+	checkTTL := func(resp *logical.Response) error {
+		if resp.Auth.LeaseOptions.TTL.String() != "720h0m0s" {
+			return fmt.Errorf("invalid TTL")
+		}
+		return nil
+	}
 	return logicaltest.TestStep{
 		Operation: logical.UpdateOperation,
 		Path:      "login",
@@ -170,6 +177,7 @@ func testAccLogin(t *testing.T, display string) logicaltest.TestStep {
 		Check: logicaltest.TestCheckMulti(
 			logicaltest.TestCheckAuth([]string{"bar", "foo"}),
 			logicaltest.TestCheckAuthDisplayName(display),
+			checkTTL,
 		),
 	}
 }

--- a/builtin/credential/app-id/path_login.go
+++ b/builtin/credential/app-id/path_login.go
@@ -44,7 +44,7 @@ func (b *backend) pathLogin(
 	userId := data.Get("user_id").(string)
 
 	var displayName string
-	if dispName, resp, err := b.verifyCredentials(req, appId, userId, true); err != nil {
+	if dispName, resp, err := b.verifyCredentials(req, appId, userId); err != nil {
 		return nil, err
 	} else if resp != nil {
 		return resp, nil
@@ -89,7 +89,7 @@ func (b *backend) pathLoginRenew(
 
 	// Skipping CIDR verification to enable renewal from machines other than
 	// the ones encompassed by CIDR block.
-	if _, resp, err := b.verifyCredentials(req, appId, userId, false); err != nil {
+	if _, resp, err := b.verifyCredentials(req, appId, userId); err != nil {
 		return nil, err
 	} else if resp != nil {
 		return resp, nil
@@ -108,7 +108,7 @@ func (b *backend) pathLoginRenew(
 	return framework.LeaseExtend(0, 0, b.System())(req, d)
 }
 
-func (b *backend) verifyCredentials(req *logical.Request, appId, userId string, verifyCIDR bool) (string, *logical.Response, error) {
+func (b *backend) verifyCredentials(req *logical.Request, appId, userId string) (string, *logical.Response, error) {
 	// Ensure both appId and userId are provided
 	if appId == "" || userId == "" {
 		return "", logical.ErrorResponse("missing 'app_id' or 'user_id'"), nil
@@ -124,7 +124,7 @@ func (b *backend) verifyCredentials(req *logical.Request, appId, userId string, 
 	}
 
 	// If there is a CIDR block restriction, check that
-	if raw, ok := appsMap["cidr_block"]; ok && verifyCIDR {
+	if raw, ok := appsMap["cidr_block"]; ok {
 		_, cidr, err := net.ParseCIDR(raw.(string))
 		if err != nil {
 			return "", nil, fmt.Errorf("invalid restriction cidr: %s", err)


### PR DESCRIPTION
Added renewal capability to app-id backend.
1) System default TTL is set for the returned Auth object.
2) In renewal function: app-id, user-id and the policy verification is made before extending the lease.

Fixes #539 