### PR TITLE
AllowedBaseDomain never migrates.

### DIFF
--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -216,9 +216,9 @@ func (b *backend) getRole(s logical.Storage, n string) (*roleEntry, error) {
 			} else {
 				result.AllowedDomains += "," + result.AllowedBaseDomain
 			}
-			result.AllowedBaseDomain = ""
-			modified = true
 		}
+		result.AllowedBaseDomain = ""
+		modified = true
 	}
 
 	if modified {


### PR DESCRIPTION
While reading through the source, I noticed that AllowedBaseDomain may actually never migrate - it can be stuck in a cycle of always correcting itself, but not updating the other fields like the other older options.

It is only zero-ed out if the domain is not found in the (new) AllowedDomains configuration setting. If the domain is found, AllowedBaseDomain is not emptied and this code will be run every single time.

In the interested of being honest - I never actually ran and tested the code.