### PR TITLE
Return status for rekey/root generation at init time.

### DIFF
--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -13,7 +13,7 @@ func (c *Sys) GenerateRootStatus() (*GenerateRootStatusResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) GenerateRootInit(otp, pgpKey string) error {
+func (c *Sys) GenerateRootInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
 	body := map[string]interface{}{
 		"otp":     otp,
 		"pgp_key": pgpKey,
@@ -21,14 +21,18 @@ func (c *Sys) GenerateRootInit(otp, pgpKey string) error {
 
 	r := c.c.NewRequest("PUT", "/v1/sys/generate-root/attempt")
 	if err := r.SetJSONBody(body); err != nil {
-		return err
+		return nil, err
 	}
 
 	resp, err := c.c.RawRequest(r)
-	if err == nil {
-		defer resp.Body.Close()
+	if err != nil {
+		return nil, err
 	}
-	return err
+	defer resp.Body.Close()
+
+	var result GenerateRootStatusResponse
+	err = resp.DecodeJSON(&result)
+	return &result, err
 }
 
 func (c *Sys) GenerateRootCancel() error {

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -13,17 +13,21 @@ func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) RekeyInit(config *RekeyInitRequest) error {
+func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey/init")
 	if err := r.SetJSONBody(config); err != nil {
-		return err
+		return nil, err
 	}
 
 	resp, err := c.c.RawRequest(r)
-	if err == nil {
-		defer resp.Body.Close()
+	if err != nil {
+		return nil, err
 	}
-	return err
+	defer resp.Body.Close()
+
+	var result RekeyStatusResponse
+	err = resp.DecodeJSON(&result)
+	return &result, err
 }
 
 func (c *Sys) RekeyCancel() error {

--- a/command/generate-root.go
+++ b/command/generate-root.go
@@ -140,14 +140,9 @@ func (c *GenerateRootCommand) Run(args []string) int {
 
 	// Start the root generation process if not started
 	if !rootGenerationStatus.Started {
-		err = client.Sys().GenerateRootInit(otp, pgpKey)
+		rootGenerationStatus, err = client.Sys().GenerateRootInit(otp, pgpKey)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error initializing root generation: %s", err))
-			return 1
-		}
-		rootGenerationStatus, err = client.Sys().GenerateRootStatus()
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error reading root generation status: %s", err))
 			return 1
 		}
 		c.Nonce = rootGenerationStatus.Nonce
@@ -229,14 +224,15 @@ func (c *GenerateRootCommand) decode(encodedVal, otp string) int {
 // initGenerateRoot is used to start the generation process
 func (c *GenerateRootCommand) initGenerateRoot(client *api.Client, otp string, pgpKey string) int {
 	// Start the rekey
-	err := client.Sys().GenerateRootInit(otp, pgpKey)
+	status, err := client.Sys().GenerateRootInit(otp, pgpKey)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error initializing root generation: %s", err))
 		return 1
 	}
 
-	// Provide the current status
-	return c.rootGenerationStatus(client)
+	c.dumpStatus(status)
+
+	return 0
 }
 
 // cancelGenerateRoot is used to abort the generation process

--- a/http/sys_generate_root.go
+++ b/http/sys_generate_root.go
@@ -86,7 +86,8 @@ func handleSysGenerateRootAttemptPut(core *vault.Core, w http.ResponseWriter, r 
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
-	respondOk(w, nil)
+
+	handleSysGenerateRootAttemptGet(core, w, r)
 }
 
 func handleSysGenerateRootAttemptDelete(core *vault.Core, w http.ResponseWriter, r *http.Request) {

--- a/http/sys_generate_root_test.go
+++ b/http/sys_generate_root_test.go
@@ -32,10 +32,10 @@ func TestSysGenerateRootAttempt_Status(t *testing.T) {
 		"complete":           false,
 		"encoded_root_token": "",
 		"pgp_fingerprint":    "",
+		"nonce":              "",
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
-	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
 	}
@@ -69,6 +69,9 @@ func TestSysGenerateRootAttempt_Setup_OTP(t *testing.T) {
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
+	if actual["nonce"].(string) == "" {
+		t.Fatalf("nonce was empty")
+	}
 	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
@@ -87,6 +90,9 @@ func TestSysGenerateRootAttempt_Setup_OTP(t *testing.T) {
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
+	if actual["nonce"].(string) == "" {
+		t.Fatalf("nonce was empty")
+	}
 	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
@@ -117,6 +123,9 @@ func TestSysGenerateRootAttempt_Setup_PGP(t *testing.T) {
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
+	if actual["nonce"].(string) == "" {
+		t.Fatalf("nonce was empty")
+	}
 	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
@@ -150,11 +159,13 @@ func TestSysGenerateRootAttempt_Cancel(t *testing.T) {
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
+	if actual["nonce"].(string) == "" {
+		t.Fatalf("nonce was empty")
+	}
 	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
 	}
-	initialNonce := expected["nonce"].(string)
 
 	resp = testHttpDelete(t, token, addr+"/v1/sys/generate-root/attempt")
 	testResponseStatus(t, resp, 204)
@@ -172,16 +183,12 @@ func TestSysGenerateRootAttempt_Cancel(t *testing.T) {
 		"complete":           false,
 		"encoded_root_token": "",
 		"pgp_fingerprint":    "",
+		"nonce":              "",
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
-	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
-	}
-
-	if expected["nonce"].(string) == initialNonce {
-		t.Fatalf("Same nonce detected across two invocations")
 	}
 }
 

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -100,7 +100,8 @@ func handleSysRekeyInitPut(core *vault.Core, w http.ResponseWriter, r *http.Requ
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
-	respondOk(w, nil)
+
+	handleSysRekeyInitGet(core, w, r)
 }
 
 func handleSysRekeyInitDelete(core *vault.Core, w http.ResponseWriter, r *http.Request) {

--- a/http/sys_rekey_test.go
+++ b/http/sys_rekey_test.go
@@ -29,10 +29,10 @@ func TestSysRekeyInit_Status(t *testing.T) {
 		"required":         float64(1),
 		"pgp_fingerprints": interface{}(nil),
 		"backup":           false,
+		"nonce":            "",
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
-	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
 	}
@@ -62,6 +62,9 @@ func TestSysRekeyInit_Setup(t *testing.T) {
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
+	if actual["nonce"].(string) == "" {
+		t.Fatalf("nonce was empty")
+	}
 	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
@@ -81,6 +84,12 @@ func TestSysRekeyInit_Setup(t *testing.T) {
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
+	if actual["nonce"].(string) == "" {
+		t.Fatalf("nonce was empty")
+	}
+	if actual["nonce"].(string) == "" {
+		t.Fatalf("nonce was empty")
+	}
 	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
@@ -116,10 +125,10 @@ func TestSysRekeyInit_Cancel(t *testing.T) {
 		"required":         float64(1),
 		"pgp_fingerprints": interface{}(nil),
 		"backup":           false,
+		"nonce":            "",
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
-	expected["nonce"] = actual["nonce"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
 	}

--- a/http/sys_rekey_test.go
+++ b/http/sys_rekey_test.go
@@ -48,12 +48,29 @@ func TestSysRekeyInit_Setup(t *testing.T) {
 		"secret_shares":    5,
 		"secret_threshold": 3,
 	})
-	testResponseStatus(t, resp, 204)
-
-	resp = testHttpGet(t, token, addr+"/v1/sys/rekey/init")
+	testResponseStatus(t, resp, 200)
 
 	var actual map[string]interface{}
 	expected := map[string]interface{}{
+		"started":          true,
+		"t":                float64(3),
+		"n":                float64(5),
+		"progress":         float64(0),
+		"required":         float64(1),
+		"pgp_fingerprints": interface{}(nil),
+		"backup":           false,
+	}
+	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+	expected["nonce"] = actual["nonce"]
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
+	}
+
+	resp = testHttpGet(t, token, addr+"/v1/sys/rekey/init")
+
+	actual = map[string]interface{}{}
+	expected = map[string]interface{}{
 		"started":          true,
 		"t":                float64(3),
 		"n":                float64(5),
@@ -80,7 +97,7 @@ func TestSysRekeyInit_Cancel(t *testing.T) {
 		"secret_shares":    5,
 		"secret_threshold": 3,
 	})
-	testResponseStatus(t, resp, 204)
+	testResponseStatus(t, resp, 200)
 
 	resp = testHttpDelete(t, token, addr+"/v1/sys/rekey/init")
 	testResponseStatus(t, resp, 204)
@@ -130,13 +147,6 @@ func TestSysRekey_Update(t *testing.T) {
 		"secret_shares":    5,
 		"secret_threshold": 3,
 	})
-	testResponseStatus(t, resp, 204)
-
-	// We need to get the nonce first before we update
-	resp, err := http.Get(addr + "/v1/sys/rekey/init")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
 	var rekeyStatus map[string]interface{}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &rekeyStatus)
@@ -177,7 +187,7 @@ func TestSysRekey_ReInitUpdate(t *testing.T) {
 		"secret_shares":    5,
 		"secret_threshold": 3,
 	})
-	testResponseStatus(t, resp, 204)
+	testResponseStatus(t, resp, 200)
 
 	resp = testHttpDelete(t, token, addr+"/v1/sys/rekey/init")
 	testResponseStatus(t, resp, 204)
@@ -186,7 +196,7 @@ func TestSysRekey_ReInitUpdate(t *testing.T) {
 		"secret_shares":    5,
 		"secret_threshold": 3,
 	})
-	testResponseStatus(t, resp, 204)
+	testResponseStatus(t, resp, 200)
 
 	resp = testHttpPut(t, token, addr+"/v1/sys/rekey/update", map[string]interface{}{
 		"key": hex.EncodeToString(master),


### PR DESCRIPTION
This mitigates a(very unlikely) potential timing attack between init-ing and fetching status.

Fixes #1054