### PR TITLE
ZooKeeper Backend: Authnetication and Authorization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.1 (Unreleased)
+
+BUG FIXES:
+
+ * logical/postgresql: Add extra revocation statements to better handle more
+   permission scenarios [GH-1053]
+
 ## 0.5.0 (February 10, 2016)
 
 SECURITY:

--- a/physical/zookeeper.go
+++ b/physical/zookeeper.go
@@ -71,7 +71,7 @@ func newZookeeperBackend(conf map[string]string) (Backend, error) {
 
 			// znode_owner is in config and structured correctly - but does it make any sense?
 			// Either 'owner' or 'schema' was set but not both - this seems like a failed attempt
-			// (e.g. ':MyUser' which omit the schema, or ':' omiting both)
+			// (e.g. ':MyUser' which omit the schema, or ':' omitting both)
 			if owner == "" || schema == "" {
 				return nil, fmt.Errorf("znode_owner expected format is 'schema:auth'")
 			}
@@ -94,7 +94,7 @@ func newZookeeperBackend(conf map[string]string) (Backend, error) {
 
 			// auth_info is in config and structured correctly - but does it make any sense?
 			// Either 'owner' or 'schema' was set but not both - this seems like a failed attempt
-			// (e.g. ':MyUser' which omit the schema, or ':' omiting both)
+			// (e.g. ':MyUser' which omit the schema, or ':' omitting both)
 			if owner == "" || schema == "" {
 				return nil, fmt.Errorf("auth_info expected format is 'schema:auth'")
 			}

--- a/physical/zookeeper.go
+++ b/physical/zookeeper.go
@@ -119,7 +119,6 @@ func newZookeeperBackend(conf map[string]string) (Backend, error) {
 // an error during an operation
 func (c *ZookeeperBackend) ensurePath(path string, value []byte) error {
 	nodes := strings.Split(path, "/")
-	//acl := zk.WorldACL(zk.PermAll)
 	fullPath := ""
 	for index, node := range nodes {
 		if strings.TrimSpace(node) != "" {
@@ -304,8 +303,7 @@ func (i *ZookeeperHALock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) 
 
 func (i *ZookeeperHALock) attemptLock(lockpath string, didLock chan struct{}, failLock chan error, releaseCh chan bool) {
 	// Wait to acquire the lock in ZK
-	acl := zk.WorldACL(zk.PermAll)
-	lock := zk.NewLock(i.in.client, lockpath, acl)
+	lock := zk.NewLock(i.in.client, lockpath, i.in.acl)
 	err := lock.Lock()
 	if err != nil {
 		failLock <- err

--- a/physical/zookeeper.go
+++ b/physical/zookeeper.go
@@ -26,7 +26,7 @@ const (
 type ZookeeperBackend struct {
 	path   string
 	client *zk.Conn
-    acl     []zk.ACL
+	acl    []zk.ACL
 }
 
 // newZookeeperBackend constructs a Zookeeper backend using the given API client
@@ -53,43 +53,41 @@ func newZookeeperBackend(conf map[string]string) (Backend, error) {
 		machines = "localhost:2181"
 	}
 
-    // zNode owner and schema.
-    var owner string
-    var schema string
-    var schemaAndOwner string
-    schemaAndOwner, ok = conf["znode_owner"]
-    if !ok {
-        owner = "anyone"
-        schema = "world"
-    } else {
-        parsedSchemaAndOwner := strings.SplitN(schemaAndOwner, ":", 2)
-        if !(len(parsedSchemaAndOwner)==2) {
-            return nil, fmt.Errorf("znode_owner expected format is 'schema:owner'")
-        } else {
-            schema = parsedSchemaAndOwner[0]
-            owner = parsedSchemaAndOwner[1]
-        }
-    }
+	// zNode owner and schema.
+	var owner string
+	var schema string
+	var schemaAndOwner string
+	schemaAndOwner, ok = conf["znode_owner"]
+	if !ok {
+		owner = "anyone"
+		schema = "world"
+	} else {
+		parsedSchemaAndOwner := strings.SplitN(schemaAndOwner, ":", 2)
+		if len(parsedSchemaAndOwner) != 2 {
+			return nil, fmt.Errorf("znode_owner expected format is 'schema:owner'")
+		} else {
+			schema = parsedSchemaAndOwner[0]
+			owner = parsedSchemaAndOwner[1]
+		}
+	}
 
-    acl := []zk.ACL{{zk.PermAll, schema, owner}} 
+	acl := []zk.ACL{{zk.PermAll, schema, owner}}
 
-
-    // Authnetication info
-    var schemaAndUser string
-    schemaAndUser, ok = conf["auth_info"]
-    if !ok {
-        owner = ""
-        schema = ""
-    } else {
-        parsedSchemaAndUser := strings.SplitN(schemaAndUser, ":", 2)
-        if !(len(parsedSchemaAndUser)==2) {
-            return nil, fmt.Errorf("auth_info expected format is 'schema:auth'")
-        } else {
-            schema = parsedSchemaAndUser[0]
-            owner = parsedSchemaAndUser[1]
-        }
-    }   
-
+	// Authnetication info
+	var schemaAndUser string
+	schemaAndUser, ok = conf["auth_info"]
+	if !ok {
+		owner = ""
+		schema = ""
+	} else {
+		parsedSchemaAndUser := strings.SplitN(schemaAndUser, ":", 2)
+		if len(parsedSchemaAndUser) != 2 {
+			return nil, fmt.Errorf("auth_info expected format is 'schema:auth'")
+		} else {
+			schema = parsedSchemaAndUser[0]
+			owner = parsedSchemaAndUser[1]
+		}
+	}
 
 	// Attempt to create the ZK client
 	client, _, err := zk.Connect(strings.Split(machines, ","), time.Second)
@@ -97,19 +95,19 @@ func newZookeeperBackend(conf map[string]string) (Backend, error) {
 		return nil, fmt.Errorf("client setup failed: %v", err)
 	}
 
-    // If auth_info provided - attempt to authenticate 
-    if owner != "" {
-        err = client.AddAuth(schema, []byte(owner))
-        if err != nil {
-            return nil, fmt.Errorf("Zookeeper rejected authentication information provided at auth_info")
-        }
-    }
+	// If auth_info provided - attempt to authenticate
+	if owner != "" {
+		err = client.AddAuth(schema, []byte(owner))
+		if err != nil {
+			return nil, fmt.Errorf("Zookeeper rejected authentication information provided at auth_info: %v", err)
+		}
+	}
 
 	// Setup the backend
 	c := &ZookeeperBackend{
 		path:   path,
 		client: client,
-        acl:    acl,
+		acl:    acl,
 	}
 	return c, nil
 }


### PR DESCRIPTION
Provide a fix to issue #1058. 
With that fix users can set Zookeeper AddAuth string and ACLs. If none is provided the existing default (OPEN_ACL_UNSAFE) is kept. 

The PR also updates the relevant documentation. 