### PR TITLE
mysql: provide allow_verification option to disable connection_url check

### DIFF
--- a/builtin/logical/mysql/backend.go
+++ b/builtin/logical/mysql/backend.go
@@ -74,7 +74,7 @@ func (b *backend) DB(s logical.Storage) (*sql.DB, error) {
 		return nil, err
 	}
 
-	conn := connConfig.ConnectionString
+	conn := connConfig.ConnectionURL
 	if len(conn) == 0 {
 		conn = connConfig.ConnectionURL
 	}

--- a/builtin/logical/mysql/backend.go
+++ b/builtin/logical/mysql/backend.go
@@ -74,7 +74,7 @@ func (b *backend) DB(s logical.Storage) (*sql.DB, error) {
 		return nil, err
 	}
 
-	conn := connConfig.ConnectionURL
+	conn := connConfig.ConnectionString
 	if len(conn) == 0 {
 		conn = connConfig.ConnectionURL
 	}

--- a/builtin/logical/mysql/backend_test.go
+++ b/builtin/logical/mysql/backend_test.go
@@ -14,25 +14,55 @@ import (
 func TestBackend_basic(t *testing.T) {
 	b, _ := Factory(logical.TestBackendConfig())
 
+	d := map[string]interface{}{
+		"connection_url": os.Getenv("MYSQL_DSN"),
+	}
 	logicaltest.Test(t, logicaltest.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Backend:  b,
 		Steps: []logicaltest.TestStep{
-			testAccStepConfig(t),
+			testAccStepConfig(t, d, false),
 			testAccStepRole(t),
 			testAccStepReadCreds(t, "web"),
 		},
 	})
 }
-
-func TestBackend_roleCrud(t *testing.T) {
+func TestBackend_configConnection(t *testing.T) {
 	b := Backend()
+	d1 := map[string]interface{}{
+		"value": os.Getenv("MYSQL_DSN"),
+	}
+	d2 := map[string]interface{}{
+		"connection_url": os.Getenv("MYSQL_DSN"),
+	}
+	d3 := map[string]interface{}{
+		"value":          os.Getenv("MYSQL_DSN"),
+		"connection_url": os.Getenv("MYSQL_DSN"),
+	}
+	d4 := map[string]interface{}{}
 
 	logicaltest.Test(t, logicaltest.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Backend:  b,
 		Steps: []logicaltest.TestStep{
-			testAccStepConfig(t),
+			testAccStepConfig(t, d1, false),
+			testAccStepConfig(t, d2, false),
+			testAccStepConfig(t, d3, false),
+			testAccStepConfig(t, d4, true),
+		},
+	})
+}
+func TestBackend_roleCrud(t *testing.T) {
+	b := Backend()
+
+	d := map[string]interface{}{
+		"connection_url": os.Getenv("MYSQL_DSN"),
+	}
+	logicaltest.Test(t, logicaltest.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Backend:  b,
+		Steps: []logicaltest.TestStep{
+			testAccStepConfig(t, d, false),
 			testAccStepRole(t),
 			testAccStepReadRole(t, "web", testRole),
 			testAccStepDeleteRole(t, "web"),
@@ -43,12 +73,15 @@ func TestBackend_roleCrud(t *testing.T) {
 
 func TestBackend_leaseWriteRead(t *testing.T) {
 	b := Backend()
+	d := map[string]interface{}{
+		"connection_url": os.Getenv("MYSQL_DSN"),
+	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Backend:  b,
 		Steps: []logicaltest.TestStep{
-			testAccStepConfig(t),
+			testAccStepConfig(t, d, false),
 			testAccStepWriteLease(t),
 			testAccStepReadLease(t),
 		},
@@ -62,12 +95,32 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccStepConfig(t *testing.T) logicaltest.TestStep {
+func testAccStepConfig(t *testing.T, d map[string]interface{}, expectError bool) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.UpdateOperation,
 		Path:      "config/connection",
-		Data: map[string]interface{}{
-			"value": os.Getenv("MYSQL_DSN"),
+		Data:      d,
+		ErrorOk:   true,
+		Check: func(resp *logical.Response) error {
+			log.Printf("vishal: testAccStepConfig: resp: %#v\n", resp)
+			if expectError {
+				if resp.Data == nil {
+					return fmt.Errorf("data is nil")
+				}
+				var e struct {
+					Error string `mapstructure:"error"`
+				}
+				if err := mapstructure.Decode(resp.Data, &e); err != nil {
+					return err
+				}
+				if len(e.Error) == 0 {
+					return fmt.Errorf("expected error, but write succeeded.")
+				}
+				return nil
+			} else if resp != nil {
+				return fmt.Errorf("response should be nil")
+			}
+			return nil
 		},
 	}
 }

--- a/builtin/logical/mysql/backend_test.go
+++ b/builtin/logical/mysql/backend_test.go
@@ -14,14 +14,20 @@ import (
 func TestBackend_basic(t *testing.T) {
 	b, _ := Factory(logical.TestBackendConfig())
 
-	d := map[string]interface{}{
+	d1 := map[string]interface{}{
 		"connection_url": os.Getenv("MYSQL_DSN"),
+	}
+	d2 := map[string]interface{}{
+		"value": os.Getenv("MYSQL_DSN"),
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Backend:  b,
 		Steps: []logicaltest.TestStep{
-			testAccStepConfig(t, d, false),
+			testAccStepConfig(t, d1, false),
+			testAccStepRole(t),
+			testAccStepReadCreds(t, "web"),
+			testAccStepConfig(t, d2, false),
 			testAccStepRole(t),
 			testAccStepReadCreds(t, "web"),
 		},

--- a/builtin/logical/mysql/path_config_connection.go
+++ b/builtin/logical/mysql/path_config_connection.go
@@ -79,7 +79,6 @@ func (b *backend) pathConnectionWrite(
 
 	// Store it
 	entry, err := logical.StorageEntryJSON("config/connection", connectionConfig{
-		ConnectionString:   connURL,
 		ConnectionURL:      connURL,
 		MaxOpenConnections: maxOpenConns,
 	})
@@ -96,9 +95,7 @@ func (b *backend) pathConnectionWrite(
 }
 
 type connectionConfig struct {
-	ConnectionURL string `json:"connection_url"`
-	// Deprecate "value" in coming releases
-	ConnectionString   string `json:"value"`
+	ConnectionURL      string `json:"connection_url"`
 	MaxOpenConnections int    `json:"max_open_connections"`
 }
 

--- a/builtin/logical/mysql/path_config_connection.go
+++ b/builtin/logical/mysql/path_config_connection.go
@@ -49,7 +49,7 @@ func (b *backend) pathConnectionWrite(
 	connURL := data.Get("connection_url").(string)
 	if connURL == "" {
 		if connValue == "" {
-			return logical.ErrorResponse("provide the connection_url"), nil
+			return logical.ErrorResponse("the connection_url parameter must be supplied"), nil
 		} else {
 			connURL = connValue
 		}

--- a/builtin/logical/mysql/path_config_connection.go
+++ b/builtin/logical/mysql/path_config_connection.go
@@ -95,7 +95,9 @@ func (b *backend) pathConnectionWrite(
 }
 
 type connectionConfig struct {
-	ConnectionURL      string `json:"connection_url"`
+	ConnectionURL string `json:"connection_url"`
+	// Deprecate "value" in coming releases
+	ConnectionString   string `json:"value"`
 	MaxOpenConnections int    `json:"max_open_connections"`
 }
 

--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -41,7 +41,7 @@ instance. This is done by providing a DSN (Data Source Name):
 
 ```
 $ vault write mysql/config/connection \
-    value="root:root@tcp(192.168.33.10:3306)/"
+    connection_url="root:root@tcp(192.168.33.10:3306)/"
 Success! Data written to: mysql/config/connection
 ```
 
@@ -127,9 +127,18 @@ allowed to read.
   <dd>
     <ul>
       <li>
-        <span class="param">value</span>
+        <span class="param">connection_url</span>
         <span class="param-flags">required</span>
         The MySQL DSN
+      </li>
+    </ul>
+  </dd>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">value</span>
+        <span class="param-flags">optionsl</span>
+        DEPRECATED; use "connection_url" instead
       </li>
     </ul>
   </dd>
@@ -140,6 +149,16 @@ allowed to read.
         <span class="param-flags">optional</span>
         Maximum number of open connections to the database.
 	Defaults to 2.
+      </li>
+    </ul>
+  </dd>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">allow_verification</span>
+        <span class="param-flags">optional</span>
+	If set, connection_url is verified by actually connecting to the database
+	Defaults to true.
       </li>
     </ul>
   </dd>

--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -138,7 +138,6 @@ allowed to read.
       <li>
         <span class="param">value</span>
         <span class="param-flags">optionsl</span>
-        DEPRECATED; use "connection_url" instead
       </li>
     </ul>
   </dd>


### PR DESCRIPTION
Fixes #1076 

An option "allow_verification" is added to mysql backend, which can be used to disable the checking of connection_url while configuring.

Also, "connection_url" field gets stored as a config instead of "value".

Acceptance tests also test for "connection_url" by default now.
At least one of these two has to be provided while configuring the connection.

All the acceptance tests are passing.