### PR TITLE
Check role key type and bits when signing CSR.

### DIFF
--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -123,6 +123,7 @@ func (b *backend) pathSignVerbatim(
 		AllowAnyName:     true,
 		AllowIPSANs:      true,
 		EnforceHostnames: false,
+		KeyType:          "any",
 	}
 
 	return b.pathIssueSignCert(req, data, role, true, true)

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -196,6 +196,7 @@ func (b *backend) pathCASignIntermediate(
 		AllowAnyName:     true,
 		AllowIPSANs:      true,
 		EnforceHostnames: false,
+		KeyType:          "any",
 	}
 
 	if cn := data.Get("common_name").(string); len(cn) == 0 {


### PR DESCRIPTION
Two exceptions: signing an intermediate CA CSR, and signing a CSR via
the 'sign-verbatim' path.