### PR TITLE
Fixing auth-enable help text

### DIFF
--- a/command/auth_enable.go
+++ b/command/auth_enable.go
@@ -76,7 +76,7 @@ General Options:
 Auth Enable Options:
 
   -description=<desc>     Human-friendly description of the purpose for the
-                          auth provider. This shows up in the auth-list command.
+                          auth provider. This shows up in the auth -methods command.
 
   -path=<path>            Mount point for the auth provider. This defaults
                           to the type of the mount. This will make the auth


### PR DESCRIPTION
`auth-enable` command help in the "Auth Enable Options" is suggesting the usage of a non-existing command called 'auth-list' instead of the correct one `auth -methods`:

```bash
pi@raspberrypi ~/vault $ vault --version
Vault v0.5.0

# auth-enable help

pi@raspberrypi ~/vault $ vault auth-enable
Usage: vault auth-enable [options] type

  Enable a new auth prov...

Auth Enable Options:

  -description=<desc>     Human-friendly description of the purpose for the
                          auth provider. This shows up in the auth-list command.
....

auth-enable expects one argument: the type to enable.

# auth-list doesn't exist

pi@raspberrypi ~/vault $ vault auth-list
usage: vault [-version] [-help] <command> [args...

# auth -methods

pi@raspberrypi ~/vault $ vault auth -methods
Path       Type      Description
token/     token     token based credentials
userpass/  userpass
```