### PR TITLE
return nil if the entry in storage is nil

### DIFF
--- a/builtin/credential/github/path_config.go
+++ b/builtin/credential/github/path_config.go
@@ -98,14 +98,14 @@ func (b *backend) Config(s logical.Storage) (*config, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	var result config
-	if entry != nil {
-		if err := entry.DecodeJSON(&result); err != nil {
-			return nil, fmt.Errorf("error reading configuration: %s", err)
-		}
+	if entry == nil {
+		return nil, nil
 	}
 
+	var result config
+	if err := entry.DecodeJSON(&result); err != nil {
+		return nil, fmt.Errorf("error reading configuration: %s", err)
+	}
 	return &result, nil
 }
 


### PR DESCRIPTION
When nothing is written to `config` endpoint, storage entry will be nil.
Currently, it returns a valid struct with default values.
This method should return nil if a storage entry is not found.