### PR TITLE
Clarify auth token life expectancy - #1079

### DIFF
--- a/website/source/docs/auth/token.html.md
+++ b/website/source/docs/auth/token.html.md
@@ -24,6 +24,10 @@ operations on tokens such as renewal and revocation.
 Please see the [token concepts](/docs/concepts/tokens.html) page dedicated
 to tokens.
 
+-> **NOTE:** Non-root Auth Backend tokens have a maximum TTL of 30 days, this cannot
+be changed.  Non-root Auth tokens can exist longer than 30 days, regardless
+of renewal attempts.
+
 ## Authentication
 
 #### Via the CLI


### PR DESCRIPTION
Please consider this documentation clarification.  I believe that most everyone assumes that "renewable means that you can renew forever, like DNS TTL and DHCP lease times.  I am staill unclear on whether this "maximium lifetime TTL" applies to all objects, or only to Auth Backend tokens.