### PR TITLE
Add forced revocation.

### DIFF
--- a/api/sys_lease.go
+++ b/api/sys_lease.go
@@ -34,3 +34,12 @@ func (c *Sys) RevokePrefix(id string) error {
 	}
 	return err
 }
+
+func (c *Sys) RevokeForce(id string) error {
+	r := c.c.NewRequest("PUT", "/v1/sys/revoke-force/"+id)
+	resp, err := c.c.RawRequest(r)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	return err
+}

--- a/command/revoke.go
+++ b/command/revoke.go
@@ -11,9 +11,10 @@ type RevokeCommand struct {
 }
 
 func (c *RevokeCommand) Run(args []string) int {
-	var prefix bool
+	var prefix, force bool
 	flags := c.Meta.FlagSet("revoke", FlagSetDefault)
 	flags.BoolVar(&prefix, "prefix", false, "")
+	flags.BoolVar(&force, "force", false, "")
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -35,9 +36,16 @@ func (c *RevokeCommand) Run(args []string) int {
 		return 2
 	}
 
-	if prefix {
+	switch {
+	case force && !prefix:
+		c.Ui.Error(fmt.Sprintf(
+			"-force requires -prefix"))
+		return 1
+	case force && prefix:
+		err = client.Sys().RevokeForce(leaseId)
+	case prefix:
 		err = client.Sys().RevokePrefix(leaseId)
-	} else {
+	default:
 		err = client.Sys().Revoke(leaseId)
 	}
 	if err != nil {
@@ -60,12 +68,16 @@ Usage: vault revoke [options] id
 
   Revoke a secret by its lease ID.
 
-  This command revokes a secret by its lease ID that was returned
-  with it. Once the key is revoked, it is no longer valid.
+  This command revokes a secret by its lease ID that was returned with it. Once
+  the key is revoked, it is no longer valid.
 
-  With the -prefix flag, the revoke is done by prefix: any secret prefixed
-  with the given partial ID is revoked. Lease IDs are structured in such
-  a way to make revocation of prefixes useful.
+  With the -prefix flag, the revoke is done by prefix: any secret prefixed with
+  the given partial ID is revoked. Lease IDs are structured in such a way to
+  make revocation of prefixes useful.
+
+  With the -force flag, the lease is removed from Vault even if the revocation
+  fails. This is meant for certain recovery scenarios and should not be used
+  lightly. This option requires -prefix.
 
 General Options:
 
@@ -76,6 +88,8 @@ Revoke Options:
   -prefix=true            Revoke all secrets with the matching prefix. This
                           defaults to false: an exact revocation.
 
+  -force=true             Delete the lease even if the actual revocation
+                          operation fails.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -193,8 +193,12 @@ func (m *ExpirationManager) revokeCommon(leaseID string, force bool) error {
 	}
 
 	// Revoke the entry
-	if err := m.revokeEntry(le); err != nil && !force {
-		return err
+	if err := m.revokeEntry(le); err != nil {
+		if !force {
+			return err
+		} else {
+			m.logger.Printf("[WARN]: revocation from the backend failed, but in force mode so ignoring; error was: %s", err)
+		}
 	}
 
 	// Delete the entry

--- a/website/source/docs/http/sys-revoke-force.html.md
+++ b/website/source/docs/http/sys-revoke-force.html.md
@@ -1,0 +1,36 @@
+---
+layout: "http"
+page_title: "HTTP API: /sys/revoke-force"
+sidebar_current: "docs-http-lease-revoke-force"
+description: |-
+  The `/sys/revoke-force` endpoint is used to revoke secrets based on prefix while ignoring backend errors.
+---
+
+# /sys/revoke-force
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Revoke all secrets generated under a given prefix immediately. Unlike
+    `/sys/revoke-prefix`, this path ignores backend errors encountered during
+    revocation. This is <i>potentially very dangerous</i> and should only be
+    used in specific emergency situations where errors in the backend or the
+    connected backend service prevent normal revocation. <i>By ignoring these
+    errors, Vault abdicates responsibility for ensuring that the issued
+    credentials or secrets are properly revoked and/or cleaned up. Access to
+    this endpoint should be tightly controlled.</i>
+  </dd>
+
+  <dt>Method</dt>
+  <dd>PUT</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/revoke-force/<path prefix>`</dd>
+
+  <dt>Parameters</dt>
+  <dd>None</dd>
+
+  <dt>Returns</dt>
+  <dd>A `204` response code.
+  </dd>
+</dl>

--- a/website/source/layouts/http.erb
+++ b/website/source/layouts/http.erb
@@ -98,6 +98,10 @@
 						<li<%= sidebar_current("docs-http-lease-revoke-prefix") %>>
 							<a href="/docs/http/sys-revoke-prefix.html">/sys/revoke-prefix</a>
 						</li>
+
+						<li<%= sidebar_current("docs-http-lease-revoke-force") %>>
+							<a href="/docs/http/sys-revoke-force.html">/sys/revoke-force</a>
+						</li>
 					</ul>
                 </li>
 


### PR DESCRIPTION
In some situations, it can be impossible to revoke leases (for instance,
if someone has gone and manually removed users created by Vault). This
can not only cause Vault to cycle trying to revoke them, but it also
prevents mounts from being unmounted, leaving them in a tainted state
where the only operations allowed are to revoke (or rollback), which
will never successfully complete.

This adds a new endpoint that works similarly to `revoke-prefix` but
ignores errors coming from a backend upon revocation (it does not ignore
errors coming from within the expiration manager, such as errors
accessing the data store). This can be used to force Vault to abandon
leases.

Like `revoke-prefix`, this is a very sensitive operation and requires
`sudo`. It is implemented as a separate endpoint, rather than an
argument to `revoke-prefix`, to ensure that control can be delegated
appropriately, as even most administrators should not normally have
this privilege.

Fixes #1135