### PR TITLE
Strip leading paths in policies.

### DIFF
--- a/vault/policy.go
+++ b/vault/policy.go
@@ -74,6 +74,12 @@ func Parse(rules string) (*Policy, error) {
 
 	// Validate the path policy
 	for _, pc := range p.Paths {
+		// Strip a leading '/' as paths in Vault start after the / in the API
+		// path
+		if len(pc.Prefix) > 0 && pc.Prefix[0] == '/' {
+			pc.Prefix = pc.Prefix[1:]
+		}
+
 		// Strip the glob character if found
 		if strings.HasSuffix(pc.Prefix, "*") {
 			pc.Prefix = strings.TrimSuffix(pc.Prefix, "*")

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -80,7 +80,8 @@ path "prod/version" {
 }
 
 # Read access to foobar
-path "foo/bar" {
+# Also tests stripping of leading slash
+path "/foo/bar" {
 	policy = "read"
 }
 


### PR DESCRIPTION
It appears to be a common mistake, but they won't ever match.

Fixes #1167