### PR TITLE
Add query parameters to `/sys/health` to specify return codes.

### DIFF
--- a/http/sys_health_test.go
+++ b/http/sys_health_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 )
 
 func TestSysHealth_get(t *testing.T) {
-	core, _, _ := vault.TestCoreUnsealed(t)
+	core, _, root := vault.TestCoreUnsealed(t)
 	ln, addr := TestServer(t, core)
 	defer ln.Close()
 
@@ -25,6 +26,79 @@ func TestSysHealth_get(t *testing.T) {
 		"standby":     false,
 	}
 	testResponseStatus(t, resp, 200)
+	testResponseBody(t, resp, &actual)
+	expected["server_time_utc"] = actual["server_time_utc"]
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+
+	core.Seal(root)
+
+	resp, err = http.Get(addr + "/v1/sys/health")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual = map[string]interface{}{}
+	expected = map[string]interface{}{
+		"initialized": true,
+		"sealed":      true,
+		"standby":     false,
+	}
+	testResponseStatus(t, resp, 500)
+	testResponseBody(t, resp, &actual)
+	expected["server_time_utc"] = actual["server_time_utc"]
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestSysHealth_customcodes(t *testing.T) {
+	core, _, root := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+
+	queryurl, err := url.Parse(addr + "/v1/sys/health?sealedcode=503&activecode=202")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	resp, err := http.Get(queryurl.String())
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	var actual map[string]interface{}
+	expected := map[string]interface{}{
+		"initialized": true,
+		"sealed":      false,
+		"standby":     false,
+	}
+	testResponseStatus(t, resp, 202)
+	testResponseBody(t, resp, &actual)
+
+	expected["server_time_utc"] = actual["server_time_utc"]
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+
+	core.Seal(root)
+
+	queryurl, err = url.Parse(addr + "/v1/sys/health?sealedcode=503&activecode=202")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	resp, err = http.Get(queryurl.String())
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual = map[string]interface{}{}
+	expected = map[string]interface{}{
+		"initialized": true,
+		"sealed":      true,
+		"standby":     false,
+	}
+	testResponseStatus(t, resp, 503)
 	testResponseBody(t, resp, &actual)
 	expected["server_time_utc"] = actual["server_time_utc"]
 	if !reflect.DeepEqual(actual, expected) {

--- a/website/source/docs/http/sys-health.html.md
+++ b/website/source/docs/http/sys-health.html.md
@@ -11,8 +11,9 @@ description: |-
 <dl>
 	<dt>Description</dt>
 	<dd>
-		Returns the health status of Vault. This matches the semantics of a Consul HTTP health
-        check and provides a simple way to monitor the health of a Vault instance.
+        Returns the health status of Vault. This matches the semantics of a
+        Consul HTTP health check and provides a simple way to monitor the
+        health of a Vault instance.
 	</dd>
 
 	<dt>Method</dt>
@@ -25,7 +26,25 @@ description: |-
             <span class="param">standbyok</span>
             <span class="param-flags">optional</span>
             A query parameter provided to indicate that being a standby should
-            still return a 200 status code instead of the standard 429 status code.
+            still return the active status code instead of the standby code
+          </li>
+          <li>
+            <span class="param">activecode</span>
+            <span class="param-flags">optional</span>
+            A query parameter provided to indicate the status code that should
+            be returned for an active node instead of the default of `200`
+          </li>
+          <li>
+            <span class="param">standbycode</span>
+            <span class="param-flags">optional</span>
+            A query parameter provided to indicate the status code that should
+            be returned for a standby node instead of the default of `429`
+          </li>
+          <li>
+            <span class="param">sealedcode</span>
+            <span class="param-flags">optional</span>
+            A query parameter provided to indicate the status code that should
+            be returned for a sealed node instead of the default of `500`
           </li>
         </ul>
 	</dd>
@@ -41,10 +60,10 @@ description: |-
     }
     ```
 
-    Status Codes:
+    Default Status Codes:
 
- * `200` if initialized, unsealed and active.
+ * `200` if initialized, unsealed, and active.
  * `429` if unsealed and standby.
- * `500` if not initialized or sealed.
+ * `500` if sealed, or if not initialized.
 	</dd>
 </dl>


### PR DESCRIPTION
Fixes #1199