### PR TITLE
AWS permissions documentation fixes

### DIFF
--- a/website/source/docs/secrets/aws/index.html.md
+++ b/website/source/docs/secrets/aws/index.html.md
@@ -154,17 +154,19 @@ The root credentials need permission to perform various IAM actions. These are t
     {
       "Effect": "Allow",
       "Action": [
+        "iam:AttachUserPolicy",
         "iam:CreateAccessKey",
         "iam:CreateUser",
         "iam:DeleteAccessKey",
-        "iam:DeleteUser"
+        "iam:DeleteUser",
         "iam:DeleteUserPolicy",
+        "iam:DetachUserPolicy",
         "iam:ListAccessKeys",
         "iam:ListAttachedUserPolicies",
         "iam:ListGroupsForUser",
         "iam:ListUserPolicies",
         "iam:PutUserPolicy",
-        "iam:RemoveUserFromGroup",
+        "iam:RemoveUserFromGroup"
       ],
       "Resource": [
         "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:user/vault-*"


### PR DESCRIPTION
* Add missing permission needed to attach managed policies to IAM users
* Add missing comma
* Remove extraneous comma