### PR TITLE
Don't renew cert-based tokens if the policies have changed.

### DIFF
--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/vault/helper/certutil"
@@ -58,12 +59,16 @@ func (b *backend) pathLogin(
 	skid := base64.StdEncoding.EncodeToString(clientCerts[0].SubjectKeyId)
 	akid := base64.StdEncoding.EncodeToString(clientCerts[0].AuthorityKeyId)
 
+	// We want to sort here so we can check properly during renewal)
+	sort.Strings(matched.Entry.Policies)
+
 	// Generate a response
 	resp := &logical.Response{
 		Auth: &logical.Auth{
 			InternalData: map[string]interface{}{
 				"subject_key_id":   skid,
 				"authority_key_id": akid,
+				"policies":         strings.Join(matched.Entry.Policies, ","),
 			},
 			Policies:    matched.Entry.Policies,
 			DisplayName: matched.Entry.DisplayName,
@@ -125,6 +130,12 @@ func (b *backend) pathLoginRenew(
 	if cert == nil {
 		// User no longer exists, do not renew
 		return nil, nil
+	}
+
+	policies := cert.Policies
+	sort.Strings(policies)
+	if strings.Join(policies, ",") != req.Auth.InternalData["policies"] {
+		return logical.ErrorResponse("policies have changed, not renewing"), nil
 	}
 
 	return framework.LeaseExtend(cert.TTL, 0, b.System())(req, d)


### PR DESCRIPTION
Also, add cert renewal testing.

Fixes #477