### PR TITLE
Allow vault http requests for secrets to just return the data

### DIFF
--- a/http/logical.go
+++ b/http/logical.go
@@ -26,6 +26,8 @@ func handleLogical(core *vault.Core, dataOnly bool, prepareRequestCallback Prepa
 			return
 		}
 
+	
+
 		// Determine the operation
 		var op logical.Operation
 		switch r.Method {
@@ -43,6 +45,13 @@ func handleLogical(core *vault.Core, dataOnly bool, prepareRequestCallback Prepa
 				}
 				if list {
 					op = logical.ListOperation
+				}
+			}
+			dataStr :=  queryVals.Get("data")
+			if dataStr != "" {
+				dataOnly, err := strconv.ParseBool(dataStr)
+				if err != nil {
+					respondError(w, http.StatusBadRequest, nil)
 				}
 			}
 		case "POST", "PUT":


### PR DESCRIPTION
This allows for vault to just return the data of a secret. This makes it easier to use vault for tools that just want an endpoint and a token. They don't have to know that the data is in the 'data' field of JSON document