### PR TITLE
Remove check for using CSR values with non-CA certificate.

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -512,10 +512,6 @@ func signCert(b *backend,
 		return nil, err
 	}
 
-	if useCSRValues && !isCA {
-		return nil, certutil.UserError{Err: "cannot use CSR values with a non-CA certificate"}
-	}
-
 	creationBundle.IsCA = isCA
 	creationBundle.UseCSRValues = useCSRValues
 


### PR DESCRIPTION
The endpoint enforces whether the certificate is a CA or not anyways, so
this ends up not actually providing benefit and causing a bug.

Fixes #1250