### PR TITLE
Two items:

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -590,7 +590,7 @@ func (c *Core) handleRequest(req *logical.Request) (retResp *logical.Response, r
 	// Only the token store is allowed to return an auth block, for any
 	// other request this is an internal error. We exclude renewal of a token,
 	// since it does not need to be re-registered
-	if resp != nil && resp.Auth != nil && !strings.HasPrefix(req.Path, "auth/token/renew/") {
+	if resp != nil && resp.Auth != nil && !strings.HasPrefix(req.Path, "auth/token/renew") {
 		if !strings.HasPrefix(req.Path, "auth/token/") {
 			c.logger.Printf(
 				"[ERR] core: unexpected Auth response for non-token backend "+

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -902,9 +902,9 @@ func (ts *TokenStore) handleCreateCommon(
 	}
 
 	switch {
-	// If we have a role, we don't even consider parent policies; the role
-	// allowed policies trumps all
-	case role != nil:
+	// If we have a role, and the role defines policies, we don't even consider
+	// parent policies; the role allowed policies trumps all
+	case role != nil && len(role.AllowedPolicies) > 0:
 		if len(data.Policies) == 0 {
 			data.Policies = role.AllowedPolicies
 		} else {


### PR DESCRIPTION
1: Fix path check in core to handle renew paths from the token store
that aren't simply renew/
2: Use token policy logic if token store role policies are empty