### PR TITLE
Keep the expiration manager from keeping old token entries.

### DIFF
--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -375,7 +375,10 @@ func TestExpiration_RevokeByToken(t *testing.T) {
 	}
 
 	// Should nuke all the keys
-	if err := exp.RevokeByToken("foobarbaz"); err != nil {
+	te := &TokenEntry{
+		ID: "foobarbaz",
+	}
+	if err := exp.RevokeByToken(te); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -653,7 +653,7 @@ func (ts *TokenStore) revokeSalted(saltedId string) error {
 
 	// Revoke all secrets under this token
 	if entry != nil {
-		if err := ts.expiration.RevokeByToken(entry.ID); err != nil {
+		if err := ts.expiration.RevokeByToken(entry); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The expiration manager would never be poked to remove token entries upon
token revocation, if that revocation was initiated in the token store
itself. It might have been to avoid deadlock, since during revocation of
tokens the expiration manager is called, which then calls back into the
token store, and so on.

This adds a way to skip that last call back into the token store if we
know that we're on the revocation path because we're in the middle of
revoking a token. That way the lease is cleaned up. This both prevents
log entries appearing for already-revoked tokens, and it also releases
timer/memory resources since we're not keeping the leases around.