### PR TITLE
change github example team to admins

### DIFF
--- a/website/source/docs/auth/github.html.md
+++ b/website/source/docs/auth/github.html.md
@@ -113,7 +113,7 @@ Success! Data written to: auth/github/map/teams/admins
 The above would make anyone in the "admins" team a root user in Vault
 (not recommended).
 
-You can then auth with a user that is a member of the "admin" team using a Personal Access Token with the `read:org` scope.
+You can then auth with a user that is a member of the "admins" team using a Personal Access Token with the `read:org` scope.
 
 ```
 $ vault auth -method=github token=000000905b381e723b3d6a7d52f148a5d43c4b45

--- a/website/source/docs/auth/github.html.md
+++ b/website/source/docs/auth/github.html.md
@@ -106,14 +106,14 @@ policies within Vault. Use the `map/teams/<team>` endpoints to do that.
 Example:
 
 ```
-$ vault write auth/github/map/teams/owners value=root
-Success! Data written to: auth/github/map/teams/owners
+$ vault write auth/github/map/teams/admins value=root
+Success! Data written to: auth/github/map/teams/admins
 ```
 
-The above would make anyone in the "owners" team a root user in Vault
+The above would make anyone in the "admins" team a root user in Vault
 (not recommended).
 
-You can then auth with a user that is a member of the "owners" team using a Personal Access Token with the `read:org` scope.
+You can then auth with a user that is a member of the "admin" team using a Personal Access Token with the `read:org` scope.
 
 ```
 $ vault auth -method=github token=000000905b381e723b3d6a7d52f148a5d43c4b45


### PR DESCRIPTION
somewhat recently github has gone away from the previous model of an "owners" team 
https://help.github.com/articles/converting-your-previous-owners-team-to-the-improved-organization-permissions/

you can be an "Owner" of the org still but this does not map to vault as one *might* expect given these docs