### PR TITLE
Adds note on GH-1102 fix to secret/aws doc

### DIFF
--- a/website/source/docs/secrets/aws/index.html.md
+++ b/website/source/docs/secrets/aws/index.html.md
@@ -195,6 +195,9 @@ If either of those conditions are not met, a "403 not-authorized" error will be 
 
 See http://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html for more details.
 
+Vault 0.5.1 or later is recommended when using STS tokens to avoid validation errors for exceeding
+the AWS limit of 32 characters on STS token names.
+
 ## A Note on Consistency
 
 Unfortunately, IAM credentials are eventually consistent with respect to other


### PR DESCRIPTION
Add note related to #1102, which leads to a non-obvious AWS error message on 0.5.0 or earlier.