### PR TITLE
Ensure authorized_keys file is readable when uninstalling an ssh key

### DIFF
--- a/builtin/logical/ssh/linux_install_script.go
+++ b/builtin/logical/ssh/linux_install_script.go
@@ -55,8 +55,10 @@ sudo mkdir -p "$SSH_DIR"
 sudo touch "$AUTH_KEYS_FILE"
 
 # Remove the key from authorized_keys file if it is already present.
-# This step is common for both install and uninstall.
-grep -vFf "$PUBLIC_KEY_FILE" "$AUTH_KEYS_FILE" > temp_$PUBLIC_KEY_FILE || true
+# This step is common for both install and uninstall.  Note that grep's
+# return code is ignored, thus if grep fails all keys will be removed
+# rather than none and it fails secure
+sudo grep -vFf "$PUBLIC_KEY_FILE" "$AUTH_KEYS_FILE" > temp_$PUBLIC_KEY_FILE || true
 cat temp_$PUBLIC_KEY_FILE | sudo tee "$AUTH_KEYS_FILE"
 
 # Append the new public key to authorized_keys file


### PR DESCRIPTION
Without this change, if the user running the ssh key install script doesn't
have read access to the authorized_keys file when uninstalling a key, all
keys will be deleted from the authorized_keys file.

Fixes GH #1285