### PR TITLE
Added AcceptanceTest boolean to logical.TestCase

### DIFF
--- a/builtin/credential/app-id/backend_test.go
+++ b/builtin/credential/app-id/backend_test.go
@@ -10,7 +10,8 @@ import (
 
 func TestBackend_basic(t *testing.T) {
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: Factory,
+		AcceptanceTest: true,
+		Factory:        Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepMapAppId(t),
 			testAccStepMapUserId(t),
@@ -25,7 +26,8 @@ func TestBackend_basic(t *testing.T) {
 
 func TestBackend_cidr(t *testing.T) {
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: Factory,
+		AcceptanceTest: true,
+		Factory:        Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepMapAppIdDisplayName(t),
 			testAccStepMapUserIdCidr(t, "192.168.1.0/16"),
@@ -38,7 +40,8 @@ func TestBackend_cidr(t *testing.T) {
 
 func TestBackend_displayName(t *testing.T) {
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: Factory,
+		AcceptanceTest: true,
+		Factory:        Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepMapAppIdDisplayName(t),
 			testAccStepMapUserId(t),

--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -48,7 +48,8 @@ func TestBackend_CertWrites(t *testing.T) {
 	}
 
 	tc := logicaltest.TestCase{
-		Backend: testFactory(t),
+		AcceptanceTest: true,
+		Backend:        testFactory(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepCert(t, "aaa", ca1, "foo", false),
 			testAccStepCert(t, "bbb", ca2, "foo", false),
@@ -68,7 +69,8 @@ func TestBackend_basic_CA(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: testFactory(t),
+		AcceptanceTest: true,
+		Backend:        testFactory(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepCert(t, "web", ca, "foo", false),
 			testAccStepLogin(t, connState),
@@ -94,7 +96,8 @@ func TestBackend_CRLs(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: testFactory(t),
+		AcceptanceTest: true,
+		Backend:        testFactory(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepCertNoLease(t, "web", ca, "foo"),
 			testAccStepLoginDefaultLease(t, connState),
@@ -116,7 +119,8 @@ func TestBackend_basic_singleCert(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: testFactory(t),
+		AcceptanceTest: true,
+		Backend:        testFactory(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepCert(t, "web", ca, "foo", false),
 			testAccStepLogin(t, connState),
@@ -129,7 +133,8 @@ func TestBackend_untrusted(t *testing.T) {
 	connState := testConnState(t, "test-fixtures/keys/cert.pem",
 		"test-fixtures/keys/key.pem", "test-fixtures/root/rootcacert.pem")
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: testFactory(t),
+		AcceptanceTest: true,
+		Backend:        testFactory(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepLoginInvalid(t, connState),
 		},

--- a/builtin/credential/github/backend_test.go
+++ b/builtin/credential/github/backend_test.go
@@ -47,8 +47,9 @@ func TestBackend_Config(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testConfigWrite(t, config_data1),
 			testLoginWrite(t, login_data, expectedTTL1.Nanoseconds(), false),
@@ -103,8 +104,9 @@ func TestBackend_basic(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccMap(t, "default", "root"),

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -30,7 +30,8 @@ func TestBackend_basic(t *testing.T) {
 	b := factory(t)
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfigUrl(t),
 			testAccStepGroup(t, "scientists", "foo"),
@@ -45,7 +46,8 @@ func TestBackend_basic_authbind(t *testing.T) {
 	b := factory(t)
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfigUrlWithAuthBind(t),
 			testAccStepGroup(t, "scientists", "foo"),
@@ -60,7 +62,8 @@ func TestBackend_basic_discover(t *testing.T) {
 	b := factory(t)
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfigUrlWithDiscover(t),
 			testAccStepGroup(t, "scientists", "foo"),
@@ -75,7 +78,8 @@ func TestBackend_basic_nogroupdn(t *testing.T) {
 	b := factory(t)
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfigUrlNoGroupDN(t),
 			testAccStepGroup(t, "scientists", "foo"),
@@ -90,7 +94,8 @@ func TestBackend_groupCrud(t *testing.T) {
 	b := factory(t)
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepGroup(t, "g1", "foo"),
 			testAccStepReadGroup(t, "g1", "foo"),
@@ -212,7 +217,8 @@ func TestBackend_userCrud(t *testing.T) {
 	b := Backend()
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepUser(t, "g1", "bar"),
 			testAccStepReadUser(t, "g1", "bar"),

--- a/builtin/credential/userpass/backend_test.go
+++ b/builtin/credential/userpass/backend_test.go
@@ -54,7 +54,8 @@ func TestBackend_TTLDurations(t *testing.T) {
 		t.Fatalf("Unable to create backend: %s", err)
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testUsersWrite(t, "test", data1, true),
 			testUsersWrite(t, "test", data2, true),
@@ -78,7 +79,8 @@ func TestBackend_basic(t *testing.T) {
 		t.Fatalf("Unable to create backend: %s", err)
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepUser(t, "web", "password", "foo"),
 			testAccStepLogin(t, "web", "password", []string{"default", "foo"}),
@@ -99,7 +101,8 @@ func TestBackend_userCrud(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepUser(t, "web", "password", "foo"),
 			testAccStepReadUser(t, "web", "foo"),
@@ -122,7 +125,8 @@ func TestBackend_userCreateOperation(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testUserCreateOperation(t, "web", "password", "foo"),
 			testAccStepLogin(t, "web", "password", []string{"default", "foo"}),
@@ -143,7 +147,8 @@ func TestBackend_passwordUpdate(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepUser(t, "web", "password", "foo"),
 			testAccStepReadUser(t, "web", "foo"),
@@ -168,7 +173,8 @@ func TestBackend_policiesUpdate(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepUser(t, "web", "password", "foo"),
 			testAccStepReadUser(t, "web", "foo"),

--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -26,8 +26,9 @@ func getBackend(t *testing.T) logical.Backend {
 
 func TestBackend_basic(t *testing.T) {
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  getBackend(t),
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        getBackend(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccStepWritePolicy(t, "test", testPolicy),
@@ -38,8 +39,9 @@ func TestBackend_basic(t *testing.T) {
 
 func TestBackend_basicSTS(t *testing.T) {
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  getBackend(t),
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        getBackend(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccStepWritePolicy(t, "test", testPolicy),
@@ -57,7 +59,8 @@ func TestBackend_policyCrud(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: getBackend(t),
+		AcceptanceTest: true,
+		Backend:        getBackend(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccStepWritePolicy(t, "test", testPolicy),
@@ -261,8 +264,9 @@ func testAccStepWriteArnPolicyRef(t *testing.T, name string, arn string) logical
 
 func TestBackend_basicPolicyArnRef(t *testing.T) {
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  getBackend(t),
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        getBackend(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccStepWriteArnPolicyRef(t, "test", testPolicyArn),
@@ -273,7 +277,8 @@ func TestBackend_basicPolicyArnRef(t *testing.T) {
 
 func TestBackend_policyArnCrud(t *testing.T) {
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: getBackend(t),
+		AcceptanceTest: true,
+		Backend:        getBackend(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccStepWriteArnPolicyRef(t, "test", testPolicyArn),

--- a/builtin/logical/cassandra/backend_test.go
+++ b/builtin/logical/cassandra/backend_test.go
@@ -15,8 +15,9 @@ func TestBackend_basic(t *testing.T) {
 	b := Backend()
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccStepRole(t),
@@ -29,8 +30,9 @@ func TestBackend_roleCrud(t *testing.T) {
 	b := Backend()
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccStepRole(t),

--- a/builtin/logical/consul/backend_test.go
+++ b/builtin/logical/consul/backend_test.go
@@ -28,8 +28,9 @@ func TestBackend_basic(t *testing.T) {
 
 	b, _ := Factory(logical.TestBackendConfig())
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t, config),
 			testAccStepWritePolicy(t, "test", testPolicy, ""),
@@ -48,8 +49,9 @@ func TestBackend_management(t *testing.T) {
 
 	b, _ := Factory(logical.TestBackendConfig())
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t, config),
 			testAccStepWriteManagementPolicy(t, "test", ""),
@@ -68,8 +70,9 @@ func TestBackend_crud(t *testing.T) {
 
 	b, _ := Factory(logical.TestBackendConfig())
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepWritePolicy(t, "test", testPolicy, ""),
 			testAccStepReadPolicy(t, "test", testPolicy, 0),
@@ -88,8 +91,9 @@ func TestBackend_role_lease(t *testing.T) {
 
 	b, _ := Factory(logical.TestBackendConfig())
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepWritePolicy(t, "test", testPolicy, "6h"),
 			testAccStepReadPolicy(t, "test", testPolicy, 6*time.Hour),

--- a/builtin/logical/mssql/backend_test.go
+++ b/builtin/logical/mssql/backend_test.go
@@ -15,8 +15,9 @@ func TestBackend_basic(t *testing.T) {
 	b, _ := Factory(logical.TestBackendConfig())
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccStepRole(t),
@@ -29,8 +30,9 @@ func TestBackend_roleCrud(t *testing.T) {
 	b := Backend()
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccStepRole(t),
@@ -45,8 +47,9 @@ func TestBackend_leaseWriteRead(t *testing.T) {
 	b := Backend()
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
 			testAccStepWriteLease(t),

--- a/builtin/logical/mysql/backend_test.go
+++ b/builtin/logical/mysql/backend_test.go
@@ -21,8 +21,9 @@ func TestBackend_basic(t *testing.T) {
 		"value": os.Getenv("MYSQL_DSN"),
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t, d1, false),
 			testAccStepRole(t),
@@ -49,8 +50,9 @@ func TestBackend_configConnection(t *testing.T) {
 	d4 := map[string]interface{}{}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t, d1, false),
 			testAccStepConfig(t, d2, false),
@@ -67,8 +69,9 @@ func TestBackend_roleCrud(t *testing.T) {
 		"connection_url": os.Getenv("MYSQL_DSN"),
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t, d, false),
 			testAccStepRole(t),
@@ -86,8 +89,9 @@ func TestBackend_leaseWriteRead(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t, d, false),
 			testAccStepWriteLease(t),

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -54,8 +54,9 @@ func TestBackend_RSAKey(t *testing.T) {
 	}
 
 	testCase := logicaltest.TestCase{
-		Backend: b,
-		Steps:   []logicaltest.TestStep{},
+		AcceptanceTest: true,
+		Backend:        b,
+		Steps:          []logicaltest.TestStep{},
 	}
 
 	stepCount = len(testCase.Steps)
@@ -88,8 +89,9 @@ func TestBackend_ECKey(t *testing.T) {
 	}
 
 	testCase := logicaltest.TestCase{
-		Backend: b,
-		Steps:   []logicaltest.TestStep{},
+		AcceptanceTest: true,
+		Backend:        b,
+		Steps:          []logicaltest.TestStep{},
 	}
 
 	stepCount = len(testCase.Steps)
@@ -120,8 +122,9 @@ func TestBackend_CSRValues(t *testing.T) {
 	}
 
 	testCase := logicaltest.TestCase{
-		Backend: b,
-		Steps:   []logicaltest.TestStep{},
+		AcceptanceTest: true,
+		Backend:        b,
+		Steps:          []logicaltest.TestStep{},
 	}
 
 	stepCount = len(testCase.Steps)
@@ -152,8 +155,9 @@ func TestBackend_URLsCRUD(t *testing.T) {
 	}
 
 	testCase := logicaltest.TestCase{
-		Backend: b,
-		Steps:   []logicaltest.TestStep{},
+		AcceptanceTest: true,
+		Backend:        b,
+		Steps:          []logicaltest.TestStep{},
 	}
 
 	stepCount = len(testCase.Steps)
@@ -187,7 +191,8 @@ func TestBackend_RSARoles(t *testing.T) {
 	}
 
 	testCase := logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			logicaltest.TestStep{
 				Operation: logical.UpdateOperation,
@@ -233,7 +238,8 @@ func TestBackend_RSARoles_CSR(t *testing.T) {
 	}
 
 	testCase := logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			logicaltest.TestStep{
 				Operation: logical.UpdateOperation,
@@ -279,7 +285,8 @@ func TestBackend_ECRoles(t *testing.T) {
 	}
 
 	testCase := logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			logicaltest.TestStep{
 				Operation: logical.UpdateOperation,
@@ -325,7 +332,8 @@ func TestBackend_ECRoles_CSR(t *testing.T) {
 	}
 
 	testCase := logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			logicaltest.TestStep{
 				Operation: logical.UpdateOperation,

--- a/builtin/logical/postgresql/backend_test.go
+++ b/builtin/logical/postgresql/backend_test.go
@@ -24,8 +24,9 @@ func TestBackend_basic(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t, d1, false),
 			testAccStepRole(t),
@@ -45,8 +46,9 @@ func TestBackend_roleCrud(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t, d, false),
 			testAccStepRole(t),
@@ -72,8 +74,9 @@ func TestBackend_configConnection(t *testing.T) {
 	d4 := map[string]interface{}{}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Backend:  b,
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t, d1, false),
 			testAccStepConfig(t, d2, false),

--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -99,7 +99,8 @@ func TestSSHBackend_Lookup(t *testing.T) {
 	resp3 := []string{testDynamicRoleName, testOTPRoleName}
 	resp4 := []string{testDynamicRoleName}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: testingFactory,
+		AcceptanceTest: true,
+		Factory:        testingFactory,
 		Steps: []logicaltest.TestStep{
 			testLookupRead(t, data, resp1),
 			testRoleWrite(t, testOTPRoleName, testOTPRoleData),
@@ -128,7 +129,8 @@ func TestSSHBackend_DynamicKeyCreate(t *testing.T) {
 		"ip":       testIP,
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: testingFactory,
+		AcceptanceTest: true,
+		Factory:        testingFactory,
 		Steps: []logicaltest.TestStep{
 			testNamedKeysWrite(t, testKeyName, testSharedPrivateKey),
 			testRoleWrite(t, testDynamicRoleName, testDynamicRoleData),
@@ -150,7 +152,8 @@ func TestSSHBackend_OTPRoleCrud(t *testing.T) {
 		"cidr_list":    testCIDRList,
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: testingFactory,
+		AcceptanceTest: true,
+		Factory:        testingFactory,
 		Steps: []logicaltest.TestStep{
 			testRoleWrite(t, testOTPRoleName, testOTPRoleData),
 			testRoleRead(t, testOTPRoleName, respOTPRoleData),
@@ -179,7 +182,8 @@ func TestSSHBackend_DynamicRoleCrud(t *testing.T) {
 		"key_type":       testDynamicKeyType,
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: testingFactory,
+		AcceptanceTest: true,
+		Factory:        testingFactory,
 		Steps: []logicaltest.TestStep{
 			testNamedKeysWrite(t, testKeyName, testSharedPrivateKey),
 			testRoleWrite(t, testDynamicRoleName, testDynamicRoleData),
@@ -192,7 +196,8 @@ func TestSSHBackend_DynamicRoleCrud(t *testing.T) {
 
 func TestSSHBackend_NamedKeysCrud(t *testing.T) {
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: testingFactory,
+		AcceptanceTest: true,
+		Factory:        testingFactory,
 		Steps: []logicaltest.TestStep{
 			testNamedKeysWrite(t, testKeyName, testSharedPrivateKey),
 			testNamedKeysDelete(t),
@@ -211,7 +216,8 @@ func TestSSHBackend_OTPCreate(t *testing.T) {
 		"ip":       testIP,
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: testingFactory,
+		AcceptanceTest: true,
+		Factory:        testingFactory,
 		Steps: []logicaltest.TestStep{
 			testRoleWrite(t, testOTPRoleName, testOTPRoleData),
 			testCredsWrite(t, testOTPRoleName, data, false),
@@ -227,7 +233,8 @@ func TestSSHBackend_VerifyEcho(t *testing.T) {
 		"message": api.VerifyEchoResponse,
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: testingFactory,
+		AcceptanceTest: true,
+		Factory:        testingFactory,
 		Steps: []logicaltest.TestStep{
 			testVerifyWrite(t, verifyData, expectedData),
 		},
@@ -264,7 +271,8 @@ func TestSSHBackend_ConfigZeroAddressCRUD(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: testingFactory,
+		AcceptanceTest: true,
+		Factory:        testingFactory,
 		Steps: []logicaltest.TestStep{
 			testRoleWrite(t, testOTPRoleName, testOTPRoleData),
 			testConfigZeroAddressWrite(t, req1),
@@ -304,7 +312,8 @@ func TestSSHBackend_CredsForZeroAddressRoles(t *testing.T) {
 		"roles": fmt.Sprintf("%s,%s", testOTPRoleName, testDynamicRoleName),
 	}
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: testingFactory,
+		AcceptanceTest: true,
+		Factory:        testingFactory,
 		Steps: []logicaltest.TestStep{
 			testRoleWrite(t, testOTPRoleName, otpRoleData),
 			testCredsWrite(t, testOTPRoleName, data, true),

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -24,7 +24,8 @@ const (
 func TestBackend_basic(t *testing.T) {
 	decryptData := make(map[string]interface{})
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: Factory,
+		AcceptanceTest: true,
+		Factory:        Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepWritePolicy(t, "test", false),
 			testAccStepReadPolicy(t, "test", false, false),
@@ -47,7 +48,8 @@ func TestBackend_basic(t *testing.T) {
 func TestBackend_upsert(t *testing.T) {
 	decryptData := make(map[string]interface{})
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: Factory,
+		AcceptanceTest: true,
+		Factory:        Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepReadPolicy(t, "test", true, false),
 			testAccStepEncryptUpsert(t, "test", testPlaintext, decryptData),
@@ -60,7 +62,8 @@ func TestBackend_upsert(t *testing.T) {
 func TestBackend_datakey(t *testing.T) {
 	dataKeyInfo := make(map[string]interface{})
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: Factory,
+		AcceptanceTest: true,
+		Factory:        Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepWritePolicy(t, "test", false),
 			testAccStepReadPolicy(t, "test", false, false),
@@ -75,7 +78,8 @@ func TestBackend_rotation(t *testing.T) {
 	decryptData := make(map[string]interface{})
 	encryptHistory := make(map[int]map[string]interface{})
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: Factory,
+		AcceptanceTest: true,
+		Factory:        Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepWritePolicy(t, "test", false),
 			testAccStepEncryptVX(t, "test", testPlaintext, decryptData, 0, encryptHistory),
@@ -132,7 +136,8 @@ func TestBackend_rotation(t *testing.T) {
 func TestBackend_basic_derived(t *testing.T) {
 	decryptData := make(map[string]interface{})
 	logicaltest.Test(t, logicaltest.TestCase{
-		Factory: Factory,
+		AcceptanceTest: true,
+		Factory:        Factory,
 		Steps: []logicaltest.TestStep{
 			testAccStepWritePolicy(t, "test", true),
 			testAccStepReadPolicy(t, "test", false, true),

--- a/helper/mfa/mfa_test.go
+++ b/helper/mfa/mfa_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/logical"
-	logicaltest "github.com/hashicorp/vault/logical/testing"
 	"github.com/hashicorp/vault/logical/framework"
+	logicaltest "github.com/hashicorp/vault/logical/testing"
 )
 
 // MakeTestBackend creates a simple MFA enabled backend.
@@ -28,12 +28,12 @@ func MakeTestBackend() *framework.Backend {
 	return b
 }
 
-func testPathLogin() *framework.Path { 
+func testPathLogin() *framework.Path {
 	return &framework.Path{
 		Pattern: `login`,
 		Fields: map[string]*framework.FieldSchema{
 			"username": &framework.FieldSchema{
-				Type:        framework.TypeString,
+				Type: framework.TypeString,
 			},
 		},
 
@@ -70,7 +70,8 @@ func TestMFALogin(t *testing.T) {
 	b := MakeTestBackend()
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepEnableMFA(t),
 			testAccStepLogin(t, "user"),
@@ -82,7 +83,8 @@ func TestMFALoginDenied(t *testing.T) {
 	b := MakeTestBackend()
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		Backend: b,
+		AcceptanceTest: true,
+		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepEnableMFA(t),
 			testAccStepLoginDenied(t, "user"),
@@ -93,7 +95,7 @@ func TestMFALoginDenied(t *testing.T) {
 func testAccStepEnableMFA(t *testing.T) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.UpdateOperation,
-		Path: "mfa_config",
+		Path:      "mfa_config",
 		Data: map[string]interface{}{
 			"type": "test",
 		},
@@ -103,25 +105,25 @@ func testAccStepEnableMFA(t *testing.T) logicaltest.TestStep {
 func testAccStepLogin(t *testing.T, username string) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.UpdateOperation,
-		Path: "login",
+		Path:      "login",
 		Data: map[string]interface{}{
-			"method": "accept",
+			"method":   "accept",
 			"username": username,
 		},
 		Unauthenticated: true,
-		Check: logicaltest.TestCheckAuth([]string{"foo"}),
+		Check:           logicaltest.TestCheckAuth([]string{"foo"}),
 	}
 }
 
 func testAccStepLoginDenied(t *testing.T, username string) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.UpdateOperation,
-		Path: "login",
+		Path:      "login",
 		Data: map[string]interface{}{
-			"method": "deny",
+			"method":   "deny",
 			"username": username,
 		},
 		Unauthenticated: true,
-		Check: logicaltest.TestCheckError(),
+		Check:           logicaltest.TestCheckError(),
 	}
 }

--- a/logical/testing/testing.go
+++ b/logical/testing/testing.go
@@ -43,6 +43,11 @@ type TestCase struct {
 	// in the case that the test can't guarantee all resources were
 	// properly cleaned up.
 	Teardown TestTeardownFunc
+
+	// AcceptanceTest, if set, the test case will be run only if
+	// the environment variable TF_ACC is set. If not this test case
+	// will be run as a unit test.
+	AcceptanceTest bool
 }
 
 // TestStep is a single step within a TestCase.


### PR DESCRIPTION
Setting AcceptanceTest to `true` for all the existing references of logicaltest.Test() method.
The newer tests that use logicaltest.Test() can choose to be unit tests.