### PR TITLE
Construct token path from request to fix displaying TTLs when using

### DIFF
--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -844,8 +844,13 @@ func (ts *TokenStore) handleCreateCommon(
 
 	// Setup the token entry
 	te := TokenEntry{
-		Parent:       req.ClientToken,
-		Path:         "auth/token/create",
+		Parent: req.ClientToken,
+
+		// The mount point is always the same since we have only one token
+		// store; using req.MountPoint causes trouble in tests since they don't
+		// have an official mount
+		Path: fmt.Sprintf("auth/token/%s", req.Path),
+
 		Meta:         data.Metadata,
 		DisplayName:  "token",
 		NumUses:      data.NumUses,
@@ -860,7 +865,6 @@ func (ts *TokenStore) handleCreateCommon(
 	if role != nil {
 		te.Role = role.Name
 
-		te.Path = fmt.Sprintf("%s/%s", te.Path, role.Name)
 		if role.PathSuffix != "" {
 			te.Path = fmt.Sprintf("%s/%s", te.Path, role.PathSuffix)
 		}

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -518,7 +518,7 @@ func TestTokenStore_HandleRequest_CreateToken_DisplayName(t *testing.T) {
 	}
 	expected.CreationTime = out.CreationTime
 	if !reflect.DeepEqual(out, expected) {
-		t.Fatalf("bad: %#v", out)
+		t.Fatalf("bad:\ngot:\n%#v\nexpected:\n%#v\n", out, expected)
 	}
 }
 


### PR DESCRIPTION
create-orphan.