### PR TITLE
Add unofficial client library written in Kotlin

### DIFF
--- a/website/source/docs/http/libraries.html.md
+++ b/website/source/docs/http/libraries.html.md
@@ -39,6 +39,10 @@ These libraries are provided by the community.
 * [vault-java](https://github.com/jhaals/vault-java)
 * [vault-java-driver](https://github.com/BetterCloud/vault-java-driver)
 
+### Kotlin
+
+* [vault-kotlin](https://github.com/kunickiaj/vault-kotlin)
+
 ### Node.js
 
 * [node-vault](https://github.com/kr1sp1n/node-vault)


### PR DESCRIPTION
I've been working on a Vault client written in Kotlin. Still a work in progress but will soon be on-par with the official Ruby client.