### PR TITLE
Hint that you don't need to run auth twice

### DIFF
--- a/command/auth.go
+++ b/command/auth.go
@@ -227,7 +227,11 @@ func (c *AuthCommand) Run(args []string) int {
 		policies = append(policies, v.(string))
 	}
 
-	output := "Successfully authenticated!"
+	output := "Successfully authenticated! You are now logged in."
+	if method != "" {
+		output += "\nThe token below is already saved in the session. You do not"
+		output += "\nneed to \"vault auth\" again with the token."
+	}
 	output += fmt.Sprintf("\ntoken: %s", secret.Data["id"])
 	output += fmt.Sprintf("\ntoken_duration: %d", int(secret.Data["ttl"].(float64)))
 	if len(policies) > 0 {


### PR DESCRIPTION
This came up twice, in two different training courses. The UX is a
little confusing here on the CLI. Users are used to running:

    $ vault auth abcd-1234...

So when they auth using a method, the output leads them to believe the
need to "re-auth" as the generated token:

    $ vault auth -method=userpass username=foo password=bar
    Successfully authenticated!
    token: defg-5678...

A number of users then run:

    $ vault auth defg-5678

I've added some helpful text to hint this is not required if the method
is not "token".