### PR TITLE
go vet cleanup 

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -131,6 +131,6 @@ func TestClientEnvSettings(t *testing.T) {
 		t.Fatalf("bad: expected client tls config to have a client certificate")
 	}
 	if tlsConfig.InsecureSkipVerify != true {
-		t.Fatalf("bad: %s", tlsConfig.InsecureSkipVerify)
+		t.Fatalf("bad: %v", tlsConfig.InsecureSkipVerify)
 	}
 }

--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -24,7 +24,7 @@ func testFactory(t *testing.T) logical.Backend {
 		StorageView: &logical.InmemStorage{},
 	})
 	if err != nil {
-		t.Fatal("error: %s", err)
+		t.Fatalf("error: %s", err)
 	}
 	return b
 }

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1762,7 +1762,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 			}
 
 			if keys[0] != "test" {
-				return fmt.Errorf("unexpected key value of %d", keys[0])
+				return fmt.Errorf("unexpected key value of %s", keys[0])
 			}
 
 			return nil

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -528,7 +528,7 @@ func testAccStepDecryptDatakey(t *testing.T, name string,
 			}
 
 			if d.Plaintext != dataKeyInfo["plaintext"].(string) {
-				return fmt.Errorf("plaintext mismatch: got '%s', expected '%s', decryptData was %#v", d.Plaintext, dataKeyInfo["plaintext"].(string))
+				return fmt.Errorf("plaintext mismatch: got '%s', expected '%s', decryptData was %#v", d.Plaintext, dataKeyInfo["plaintext"].(string), resp.Data)
 			}
 			return nil
 		},

--- a/helper/certutil/helpers.go
+++ b/helper/certutil/helpers.go
@@ -295,6 +295,4 @@ func ComparePublicKeys(key1Iface, key2Iface crypto.PublicKey) (bool, error) {
 	default:
 		return false, fmt.Errorf("cannot compare key with type %T", key1Iface)
 	}
-
-	return false, fmt.Errorf("undefined error comparing public keys")
 }

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -722,7 +722,7 @@ func TestExpiration_revokeEntry_token(t *testing.T) {
 
 	indexEntry, err := exp.indexByToken(le.ClientToken, le.LeaseID)
 	if err != nil {
-		t.Fatalf("err: %v")
+		t.Fatalf("err: %v", err)
 	}
 	if indexEntry == nil {
 		t.Fatalf("err: should have found a secondary index entry")
@@ -743,7 +743,7 @@ func TestExpiration_revokeEntry_token(t *testing.T) {
 
 	indexEntry, err = exp.indexByToken(le.ClientToken, le.LeaseID)
 	if err != nil {
-		t.Fatalf("err: %v")
+		t.Fatalf("err: %v", err)
 	}
 	if indexEntry != nil {
 		t.Fatalf("err: should not have found a secondary index entry")

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -739,7 +739,7 @@ func TestSystemBackend_auditHash(t *testing.T) {
 			HMACType: "hmac-sha256",
 		})
 		if err != nil {
-			t.Fatal("error getting new salt: %v", err)
+			t.Fatalf("error getting new salt: %v", err)
 		}
 		return &NoopAudit{
 			Config: config,

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -75,7 +75,7 @@ func TestCore(t *testing.T) *Core {
 				HMACType: "hmac-sha256",
 			})
 			if err != nil {
-				t.Fatal("error getting new salt: %v", err)
+				t.Fatalf("error getting new salt: %v", err)
 			}
 			return &noopAudit{
 				Config: config,


### PR DESCRIPTION
Calling format methods (instead of their non-interpolating friends) and correcting interpolation flags. 