### PR TITLE
Clarify delete operation

### DIFF
--- a/command/delete.go
+++ b/command/delete.go
@@ -41,7 +41,7 @@ func (c *DeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.Ui.Output(fmt.Sprintf("Success! Deleted '%s'", path))
+	c.Ui.Output(fmt.Sprintf("Success! Deleted '%s' if it existed", path))
 	return 0
 }
 

--- a/website/source/intro/getting-started/first-secret.html.md
+++ b/website/source/intro/getting-started/first-secret.html.md
@@ -110,7 +110,7 @@ and delete it. We can do this with `vault delete`:
 
 ```
 $ vault delete secret/hello
-Success! Deleted 'secret/hello'
+Success! Deleted 'secret/hello' if it existed
 ```
 
 ## Next


### PR DESCRIPTION
One thing that has been a point of confusion for users is Vault's
response when deleting a key that does not actually exist in the system.
For example, consider:

    $ vault delete secret/foo
    Success! Deleted 'secret/foo'

This message is misleading if the secret does not exist, especially if
the same command is run twice in a row.

Obviously the reason for this is clear - returning an error if a secret
does not exist would reveal the existence of a secret (the same reason
everything on S3 is a 403 or why GitHub repos 404 instead of 403 if you
do not have permission to view them).

I think we can make the UX a little bit better by adding just a few
words to the output:

    $ vault delete secret/foo
    Success! Deleted 'secret/foo' if it existed

This makes it clear that the operation was only performed if the secret
existed, but it does not reveal any more information.