### PR TITLE
Fix SIGINT handling.

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -666,15 +666,16 @@ General Options:
 
 // MakeShutdownCh returns a channel that can be used for shutdown
 // notifications for commands. This channel will send a message for every
-// interrupt or SIGTERM received.
+// SIGINT or SIGTERM received.
 func MakeShutdownCh() chan struct{} {
 	resultCh := make(chan struct{})
 
-	signalCh := make(chan os.Signal, 4)
-	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+	shutdownCh := make(chan os.Signal, 4)
+	signal.Notify(shutdownCh, os.Interrupt, syscall.SIGINT)
+	signal.Notify(shutdownCh, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		for {
-			<-signalCh
+			<-shutdownCh
 			resultCh <- struct{}{}
 		}
 	}()


### PR DESCRIPTION
No signal handler was setup to receive SIGINT.  I didn't investigate to
see if signal(2) mask was setup (ala `SIG_IGN`) or if sigprocmask(2) is
being used, but in either case, the correct behavior is to capture and
treat SIGINT the same as SIGTERM.  At some point in the future these two
signals may affect the running process differently, but we will clarify
that difference in the future.