### PR TITLE
RFC: Filter cubbyhole responses based on cidr_block

### DIFF
--- a/vault/logical_cubbyhole.go
+++ b/vault/logical_cubbyhole.go
@@ -126,6 +126,8 @@ func (b *CubbyholeBackend) handleRead(
 
 func (b *CubbyholeBackend) handleWrite(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	var resp *logical.Response = nil
+
 	if req.ClientToken == "" {
 		return nil, fmt.Errorf("[ERR] cubbyhole write: Client token empty")
 	}
@@ -141,6 +143,9 @@ func (b *CubbyholeBackend) handleWrite(
 		}
 
 		req.Data["cidr_block"] = cidr.String()
+
+		resp = &logical.Response{}
+		resp.AddWarning("cidr_block is specified, but may be unreliable. See warning in cubbyhole docs")
 	}
 
 	// JSON encode the data
@@ -158,7 +163,7 @@ func (b *CubbyholeBackend) handleWrite(
 		return nil, fmt.Errorf("failed to write: %v", err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (b *CubbyholeBackend) handleDelete(

--- a/vault/logical_cubbyhole_test.go
+++ b/vault/logical_cubbyhole_test.go
@@ -131,8 +131,16 @@ func TestCubbyholeBackend_CIDRWrite(t *testing.T) {
 	}
 	req.ClientToken = clientToken
 
-	if _, err := b.HandleRequest(req); err != nil {
+	resp, err := b.HandleRequest(req)
+
+	if err != nil {
 		t.Fatalf("err: %v", err)
+	}
+
+	expected_warnings := []string{"cidr_block is specified, but may be unreliable. See warning in cubbyhole docs"}
+	warnings := resp.Warnings()
+	if !reflect.DeepEqual(expected_warnings, warnings) {
+		t.Fatalf("bad response.\n\nexpected: %#v\n\nGot: %#v", expected_warnings, warnings)
 	}
 
 	req = logical.TestRequest(t, logical.ReadOperation, "foo")
@@ -140,7 +148,7 @@ func TestCubbyholeBackend_CIDRWrite(t *testing.T) {
 	req.Storage = storage
 	req.ClientToken = clientToken
 
-	resp, err := b.HandleRequest(req)
+	resp, err = b.HandleRequest(req)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/website/source/docs/secrets/cubbyhole/index.html.md
+++ b/website/source/docs/secrets/cubbyhole/index.html.md
@@ -51,6 +51,22 @@ zip           	zap
 
 As expected, the value previously set is returned to us.
 
+## Restricting by IP
+
+Keys named `cidr_block` are treated specially. The value in the `cidr_block`
+key will restrict which client IP subnets are allowed to later read the value.
+
+```
+$ vault write cubbyhole/foo bar=baz cidr_block="192.168.1.0/24"
+```
+
+In the above example, a client within 192.168.1.0/24 would be allowed to read
+`cubbyhole/foo`, but reads from outside that subnet would be denied.
+
+WARNING: Vault has no way to verify the authenticity of client IPs connecting
+to it. For this feature to work for you, you MUST trust the network that your
+Vault servers are part of.
+
 ## API
 
 #### GET

--- a/website/source/docs/secrets/cubbyhole/index.html.md
+++ b/website/source/docs/secrets/cubbyhole/index.html.md
@@ -51,7 +51,7 @@ zip           	zap
 
 As expected, the value previously set is returned to us.
 
-## Restricting by IP
+## Restricting by client address
 
 Keys named `cidr_block` are treated specially. The value in the `cidr_block`
 key will restrict which client IP subnets are allowed to later read the value.


### PR DESCRIPTION
The cubbyhole is designed (in part) for entities to securely exchange secrets, by sharing a token that they use to PUT data in and GET data from the cubbyhole. This change enhances cubbyhole security by allowing the entity which writes into the cubbyhole to specify cidr blocks of clients that are allowed to read a given path. The idea is that the writer, knowing the IP address to which it will send its cubbyhole token, will choose cidr blocks such that only is intended recipient can then read the value out of the cubbyhole.

By doing this, we supplement the cubbyhole security model. Currently, an eavesdropper must use the cubbyhole before its intended recipient, within the lease duration, and prevent any monitoring from noticing that the cubbyhole has been used by an attacker. This change makes it so that an eavesdropper must also be able to spoof packets coming from the intended recipient in order to use the Cubbyhole.

The code in this diff is taken nearly verbatim from the app-id backend.

cc @EvanKrall