### PR TITLE
Use UseNumber() on json.Decoder to have numbers be json.Number objects

### DIFF
--- a/api/response.go
+++ b/api/response.go
@@ -18,6 +18,7 @@ type Response struct {
 // still be called.
 func (r *Response) DecodeJSON(out interface{}) error {
 	dec := json.NewDecoder(r.Body)
+	dec.UseNumber()
 	return dec.Decode(out)
 }
 
@@ -42,6 +43,7 @@ func (r *Response) Error() error {
 	// read pointer for the original buffer.
 	var resp ErrorResponse
 	dec := json.NewDecoder(bytes.NewReader(bodyBuf.Bytes()))
+	dec.UseNumber()
 	if err := dec.Decode(&resp); err != nil {
 		// Ignore the decoding error and just drop the raw response
 		return fmt.Errorf(

--- a/api/secret.go
+++ b/api/secret.go
@@ -41,6 +41,7 @@ func ParseSecret(r io.Reader) (*Secret, error) {
 	// First decode the JSON into a map[string]interface{}
 	var secret Secret
 	dec := json.NewDecoder(r)
+	dec.UseNumber()
 	if err := dec.Decode(&secret); err != nil {
 		return nil, err
 	}

--- a/command/auth.go
+++ b/command/auth.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -229,7 +230,7 @@ func (c *AuthCommand) Run(args []string) int {
 
 	output := "Successfully authenticated!"
 	output += fmt.Sprintf("\ntoken: %s", secret.Data["id"])
-	output += fmt.Sprintf("\ntoken_duration: %d", int(secret.Data["ttl"].(float64)))
+	output += fmt.Sprintf("\ntoken_duration: %s", secret.Data["ttl"].(json.Number).String())
 	if len(policies) > 0 {
 		output += fmt.Sprintf("\ntoken_policies: [%s]", strings.Join(policies, ", "))
 	}

--- a/website/source/docs/install/upgrade-to-0.6.html.md
+++ b/website/source/docs/install/upgrade-to-0.6.html.md
@@ -11,7 +11,9 @@ description: |-
 This page contains the list of breaking changes for Vault 0.6. Please read it
 carefully.
 
-Please note that this includes the full list of breaking changes _since Vault 0.5_. Some of these changes were introduced in later releases in the Vault 0.5.x series.
+Please note that this includes the full list of breaking changes __since Vault
+0.5__. Some of these changes were introduced in later releases in the Vault
+0.5.x series.
 
 ## PKI Backend Disallows RSA Keys < 2048 Bits
 
@@ -65,3 +67,12 @@ You can use the new `cert/config` endpoint to disable this behavior.
 As part of addressing a minor security issue, this endpoint has been removed in
 favor of using `sys/revoke-prefix` for prefix-based revocation of both tokens
 and secrets leases.
+
+## Go API Uses `json.Number` For Decoding
+
+When using the Go API, it now calls `UseNumber()` on the decoder object. As a
+result, rather than always decode as a `float64`, numbers are returned as a
+`json.Number`, where they can be converted, with proper error checking, to
+`int64`, `float64`, or simply used as a `string` value. This fixes some display
+errors where numbers were being decoded as `float64` and printed in scientific
+notation.


### PR DESCRIPTION
instead of float64. This fixes some display bugs.