### PR TITLE
Logger objects for all the physical backends

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -150,7 +150,7 @@ func (c *ServerCommand) Run(args []string) int {
 
 	// Initialize the backend
 	backend, err := physical.NewBackend(
-		config.Backend.Type, config.Backend.Config)
+		config.Backend.Type, logger, config.Backend.Config)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(
 			"Error initializing backend of type %s: %s",
@@ -182,7 +182,7 @@ func (c *ServerCommand) Run(args []string) int {
 	var ok bool
 	if config.HABackend != nil {
 		habackend, err := physical.NewBackend(
-			config.HABackend.Type, config.HABackend.Config)
+			config.HABackend.Type, logger, config.HABackend.Config)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf(
 				"Error initializing backend of type %s: %s",

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -3,12 +3,18 @@ package http
 import (
 	"bytes"
 	"io"
+	"log"
+	"os"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/vault/physical"
 	"github.com/hashicorp/vault/vault"
+)
+
+var (
+	logger = log.New(os.Stderr, "", log.LstdFlags)
 )
 
 func TestLogical(t *testing.T) {
@@ -69,7 +75,7 @@ func TestLogical_StandbyRedirect(t *testing.T) {
 	defer ln2.Close()
 
 	// Create an HA Vault
-	inmha := physical.NewInmemHA()
+	inmha := physical.NewInmemHA(logger)
 	conf := &vault.CoreConfig{
 		Physical:      inmha,
 		HAPhysical:    inmha,

--- a/logical/testing/testing.go
+++ b/logical/testing/testing.go
@@ -16,6 +16,10 @@ import (
 	"github.com/hashicorp/vault/vault"
 )
 
+var (
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+)
+
 // TestEnvVar must be set to a non-empty value for acceptance tests to run.
 const TestEnvVar = "VAULT_ACC"
 
@@ -131,7 +135,7 @@ func Test(t TestT, c TestCase) {
 
 	// Create an in-memory Vault core
 	core, err := vault.NewCore(&vault.CoreConfig{
-		Physical: physical.NewInmem(),
+		Physical: physical.NewInmem(logger),
 		LogicalBackends: map[string]logical.Factory{
 			"test": func(conf *logical.BackendConfig) (logical.Backend, error) {
 				if c.Backend != nil {

--- a/physical/azure.go
+++ b/physical/azure.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -21,12 +22,13 @@ var MaxBlobSize = 1024 * 1024 * 4
 type AzureBackend struct {
 	container string
 	client    storage.BlobStorageClient
+	logger    *log.Logger
 }
 
 // newAzureBackend constructs an Azure backend using a pre-existing
 // bucket. Credentials can be provided to the backend, sourced
 // from the environment, AWS credential files or by IAM role.
-func newAzureBackend(conf map[string]string) (Backend, error) {
+func newAzureBackend(conf map[string]string, logger *log.Logger) (Backend, error) {
 
 	container := os.Getenv("AZURE_BLOB_CONTAINER")
 	if container == "" {
@@ -63,6 +65,7 @@ func newAzureBackend(conf map[string]string) (Backend, error) {
 	a := &AzureBackend{
 		container: container,
 		client:    client.GetBlobService(),
+		logger:    logger,
 	}
 	return a, nil
 }

--- a/physical/azure_test.go
+++ b/physical/azure_test.go
@@ -2,10 +2,12 @@ package physical
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/storage"
+	"log"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
 )
 
 func TestAzureBackend(t *testing.T) {
@@ -22,7 +24,8 @@ func TestAzureBackend(t *testing.T) {
 
 	cleanupClient, _ := storage.NewBasicClient(accountName, accountKey)
 
-	backend, err := NewBackend("azure", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	backend, err := NewBackend("azure", logger, map[string]string{
 		"container":   container,
 		"accountName": accountName,
 		"accountKey":  accountKey,

--- a/physical/cache_test.go
+++ b/physical/cache_test.go
@@ -1,16 +1,22 @@
 package physical
 
-import "testing"
+import (
+	"log"
+	"os"
+	"testing"
+)
 
 func TestCache(t *testing.T) {
-	inm := NewInmem()
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	inm := NewInmem(logger)
 	cache := NewCache(inm, 0)
 	testBackend(t, cache)
 	testBackend_ListPrefix(t, cache)
 }
 
 func TestCache_Purge(t *testing.T) {
-	inm := NewInmem()
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	inm := NewInmem(logger)
 	cache := NewCache(inm, 0)
 
 	ent := &Entry{

--- a/physical/consul.go
+++ b/physical/consul.go
@@ -3,6 +3,7 @@ package physical
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/url"
 	"strconv"
@@ -50,6 +51,7 @@ const (
 // it allows Vault to run on multiple machines in a highly-available manner.
 type ConsulBackend struct {
 	path                string
+	logger              *log.Logger
 	client              *api.Client
 	kv                  *api.KV
 	permitPool          *PermitPool
@@ -71,7 +73,7 @@ type ConsulBackend struct {
 
 // newConsulBackend constructs a Consul backend using the given API client
 // and the prefix in the KV store.
-func newConsulBackend(conf map[string]string) (Backend, error) {
+func newConsulBackend(conf map[string]string, logger *log.Logger) (Backend, error) {
 	// Get the path in Consul
 	path, ok := conf["path"]
 	if !ok {
@@ -161,6 +163,7 @@ func newConsulBackend(conf map[string]string) (Backend, error) {
 	// Setup the backend
 	c := &ConsulBackend{
 		path:                path,
+		logger:              logger,
 		client:              client,
 		kv:                  client.KV(),
 		permitPool:          NewPermitPool(maxParInt),

--- a/physical/consul_test.go
+++ b/physical/consul_test.go
@@ -2,6 +2,7 @@ package physical
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"reflect"
 	"testing"
@@ -27,7 +28,8 @@ func testConsulBackend(t *testing.T) *ConsulBackend {
 }
 
 func testConsulBackendConfig(t *testing.T, conf *consulConf) *ConsulBackend {
-	be, err := newConsulBackend(*conf)
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	be, err := newConsulBackend(*conf, logger)
 	if err != nil {
 		t.Fatalf("Expected Consul to initialize: %v", err)
 	}
@@ -145,7 +147,8 @@ func TestConsul_newConsulBackend(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		be, err := newConsulBackend(test.consulConfig)
+		logger := log.New(os.Stderr, "", log.LstdFlags)
+		be, err := newConsulBackend(test.consulConfig, logger)
 		if test.fail {
 			if err == nil {
 				t.Fatalf(`Expected config "%s" to fail`, test.name)
@@ -435,7 +438,8 @@ func TestConsulBackend(t *testing.T) {
 		client.KV().DeleteTree(randPath, nil)
 	}()
 
-	b, err := NewBackend("consul", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("consul", logger, map[string]string{
 		"address":      addr,
 		"path":         randPath,
 		"max_parallel": "256",
@@ -466,7 +470,8 @@ func TestConsulHABackend(t *testing.T) {
 		client.KV().DeleteTree(randPath, nil)
 	}()
 
-	b, err := NewBackend("consul", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("consul", logger, map[string]string{
 		"address":      addr,
 		"path":         randPath,
 		"max_parallel": "-1",

--- a/physical/dynamodb.go
+++ b/physical/dynamodb.go
@@ -2,6 +2,7 @@ package physical
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -63,6 +64,7 @@ type DynamoDBBackend struct {
 	table    string
 	client   *dynamodb.DynamoDB
 	recovery bool
+	logger   *log.Logger
 }
 
 // DynamoDBRecord is the representation of a vault entry in
@@ -85,7 +87,7 @@ type DynamoDBLock struct {
 
 // newDynamoDBBackend constructs a DynamoDB backend. If the
 // configured DynamoDB table does not exist, it creates it.
-func newDynamoDBBackend(conf map[string]string) (Backend, error) {
+func newDynamoDBBackend(conf map[string]string, logger *log.Logger) (Backend, error) {
 	table := os.Getenv("AWS_DYNAMODB_TABLE")
 	if table == "" {
 		table = conf["table"]
@@ -178,6 +180,7 @@ func newDynamoDBBackend(conf map[string]string) (Backend, error) {
 		table:    table,
 		client:   client,
 		recovery: recoveryMode == "1",
+		logger:   logger,
 	}, nil
 }
 

--- a/physical/dynamodb_test.go
+++ b/physical/dynamodb_test.go
@@ -2,6 +2,7 @@ package physical
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"testing"
@@ -47,7 +48,8 @@ func TestDynamoDBBackend(t *testing.T) {
 		})
 	}()
 
-	b, err := NewBackend("dynamodb", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("dynamodb", logger, map[string]string{
 		"access_key":    creds.AccessKeyID,
 		"secret_key":    creds.SecretAccessKey,
 		"session_token": creds.SessionToken,
@@ -95,7 +97,8 @@ func TestDynamoDBHABackend(t *testing.T) {
 		})
 	}()
 
-	b, err := NewBackend("dynamodb", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("dynamodb", logger, map[string]string{
 		"access_key":    creds.AccessKeyID,
 		"secret_key":    creds.SecretAccessKey,
 		"session_token": creds.SessionToken,

--- a/physical/etcd.go
+++ b/physical/etcd.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -67,10 +68,11 @@ type EtcdBackend struct {
 	path       string
 	kAPI       client.KeysAPI
 	permitPool *PermitPool
+	logger     *log.Logger
 }
 
 // newEtcdBackend constructs a etcd backend using a given machine address.
-func newEtcdBackend(conf map[string]string) (Backend, error) {
+func newEtcdBackend(conf map[string]string, logger *log.Logger) (Backend, error) {
 	// Get the etcd path form the configuration.
 	path, ok := conf["path"]
 	if !ok {
@@ -173,6 +175,7 @@ func newEtcdBackend(conf map[string]string) (Backend, error) {
 		path:       path,
 		kAPI:       kAPI,
 		permitPool: NewPermitPool(DefaultParallelOperations),
+		logger:     logger,
 	}, nil
 }
 

--- a/physical/etcd_test.go
+++ b/physical/etcd_test.go
@@ -2,6 +2,7 @@ package physical
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"testing"
 	"time"
@@ -45,7 +46,8 @@ func TestEtcdBackend(t *testing.T) {
 		}
 	}()
 
-	b, err := NewBackend("etcd", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("etcd", logger, map[string]string{
 		"address": addr,
 		"path":    randPath,
 	})

--- a/physical/file.go
+++ b/physical/file.go
@@ -3,6 +3,7 @@ package physical
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -16,19 +17,22 @@ import (
 // and non-performant. It is meant mostly for local testing and development.
 // It can be improved in the future.
 type FileBackend struct {
-	Path string
-
-	l sync.Mutex
+	Path   string
+	l      sync.Mutex
+	logger *log.Logger
 }
 
 // newFileBackend constructs a Filebackend using the given directory
-func newFileBackend(conf map[string]string) (Backend, error) {
+func newFileBackend(conf map[string]string, logger *log.Logger) (Backend, error) {
 	path, ok := conf["path"]
 	if !ok {
 		return nil, fmt.Errorf("'path' must be set")
 	}
 
-	return &FileBackend{Path: path}, nil
+	return &FileBackend{
+		Path:   path,
+		logger: logger,
+	}, nil
 }
 
 func (b *FileBackend) Delete(k string) error {

--- a/physical/file_test.go
+++ b/physical/file_test.go
@@ -2,6 +2,7 @@ package physical
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"testing"
 )
@@ -13,7 +14,8 @@ func TestFileBackend(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	b, err := NewBackend("file", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("file", logger, map[string]string{
 		"path": dir,
 	})
 	if err != nil {

--- a/physical/inmem.go
+++ b/physical/inmem.go
@@ -1,6 +1,7 @@
 package physical
 
 import (
+	"log"
 	"strings"
 	"sync"
 
@@ -14,10 +15,11 @@ type InmemBackend struct {
 	root       *radix.Tree
 	l          sync.RWMutex
 	permitPool *PermitPool
+	logger     *log.Logger
 }
 
 // NewInmem constructs a new in-memory backend
-func NewInmem() *InmemBackend {
+func NewInmem(logger *log.Logger) *InmemBackend {
 	in := &InmemBackend{
 		root:       radix.New(),
 		permitPool: NewPermitPool(DefaultParallelOperations),

--- a/physical/inmem_ha.go
+++ b/physical/inmem_ha.go
@@ -2,21 +2,24 @@ package physical
 
 import (
 	"fmt"
+	"log"
 	"sync"
 )
 
 type InmemHABackend struct {
 	InmemBackend
-	locks map[string]string
-	l     sync.Mutex
-	cond  *sync.Cond
+	locks  map[string]string
+	l      sync.Mutex
+	cond   *sync.Cond
+	logger *log.Logger
 }
 
 // NewInmemHA constructs a new in-memory HA backend. This is only for testing.
-func NewInmemHA() *InmemHABackend {
+func NewInmemHA(logger *log.Logger) *InmemHABackend {
 	in := &InmemHABackend{
-		InmemBackend: *NewInmem(),
+		InmemBackend: *NewInmem(logger),
 		locks:        make(map[string]string),
+		logger:       logger,
 	}
 	in.cond = sync.NewCond(&in.l)
 	return in

--- a/physical/inmem_ha_test.go
+++ b/physical/inmem_ha_test.go
@@ -1,8 +1,13 @@
 package physical
 
-import "testing"
+import (
+	"log"
+	"os"
+	"testing"
+)
 
 func TestInmemHA(t *testing.T) {
-	inm := NewInmemHA()
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	inm := NewInmemHA(logger)
 	testHABackend(t, inm, inm)
 }

--- a/physical/inmem_test.go
+++ b/physical/inmem_test.go
@@ -1,9 +1,14 @@
 package physical
 
-import "testing"
+import (
+	"log"
+	"os"
+	"testing"
+)
 
 func TestInmem(t *testing.T) {
-	inm := NewInmem()
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	inm := NewInmem(logger)
 	testBackend(t, inm)
 	testBackend_ListPrefix(t, inm)
 }

--- a/physical/mysql.go
+++ b/physical/mysql.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/url"
 	"sort"
 	"strings"
@@ -25,11 +26,12 @@ type MySQLBackend struct {
 	dbTable    string
 	client     *sql.DB
 	statements map[string]*sql.Stmt
+	logger     *log.Logger
 }
 
 // newMySQLBackend constructs a MySQL backend using the given API client and
 // server address and credential for accessing mysql database.
-func newMySQLBackend(conf map[string]string) (Backend, error) {
+func newMySQLBackend(conf map[string]string, logger *log.Logger) (Backend, error) {
 	// Get the MySQL credentials to perform read/write operations.
 	username, ok := conf["username"]
 	if !ok || username == "" {
@@ -91,6 +93,7 @@ func newMySQLBackend(conf map[string]string) (Backend, error) {
 		dbTable:    dbTable,
 		client:     db,
 		statements: make(map[string]*sql.Stmt),
+		logger:     logger,
 	}
 
 	// Prepare all the statements required

--- a/physical/mysql_test.go
+++ b/physical/mysql_test.go
@@ -1,6 +1,7 @@
 package physical
 
 import (
+	"log"
 	"os"
 	"testing"
 
@@ -27,7 +28,8 @@ func TestMySQLBackend(t *testing.T) {
 	password := os.Getenv("MYSQL_PASSWORD")
 
 	// Run vault tests
-	b, err := NewBackend("mysql", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("mysql", logger, map[string]string{
 		"address":  address,
 		"database": database,
 		"table":    table,

--- a/physical/physical.go
+++ b/physical/physical.go
@@ -1,6 +1,9 @@
 package physical
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+)
 
 const DefaultParallelOperations = 128
 
@@ -83,23 +86,23 @@ type Entry struct {
 }
 
 // Factory is the factory function to create a physical backend.
-type Factory func(map[string]string) (Backend, error)
+type Factory func(config map[string]string, logger *log.Logger) (Backend, error)
 
 // NewBackend returns a new backend with the given type and configuration.
 // The backend is looked up in the builtinBackends variable.
-func NewBackend(t string, conf map[string]string) (Backend, error) {
+func NewBackend(t string, logger *log.Logger, conf map[string]string) (Backend, error) {
 	f, ok := builtinBackends[t]
 	if !ok {
 		return nil, fmt.Errorf("unknown physical backend type: %s", t)
 	}
-	return f(conf)
+	return f(conf, logger)
 }
 
 // BuiltinBackends is the list of built-in physical backends that can
 // be used with NewBackend.
 var builtinBackends = map[string]Factory{
-	"inmem": func(map[string]string) (Backend, error) {
-		return NewInmem(), nil
+	"inmem": func(_ map[string]string, logger *log.Logger) (Backend, error) {
+		return NewInmem(logger), nil
 	},
 	"consul":     newConsulBackend,
 	"zookeeper":  newZookeeperBackend,

--- a/physical/physical_test.go
+++ b/physical/physical_test.go
@@ -1,6 +1,8 @@
 package physical
 
 import (
+	"log"
+	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -8,12 +10,13 @@ import (
 )
 
 func testNewBackend(t *testing.T) {
-	_, err := NewBackend("foobar", nil)
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	_, err := NewBackend("foobar", logger, nil)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
 
-	b, err := NewBackend("inmem", nil)
+	b, err := NewBackend("inmem", logger, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/physical/postgresql.go
+++ b/physical/postgresql.go
@@ -3,6 +3,7 @@ package physical
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -16,11 +17,12 @@ type PostgreSQLBackend struct {
 	table      string
 	client     *sql.DB
 	statements map[string]*sql.Stmt
+	logger     *log.Logger
 }
 
 // newPostgreSQLBackend constructs a PostgreSQL backend using the given
 // API client, server address, credentials, and database.
-func newPostgreSQLBackend(conf map[string]string) (Backend, error) {
+func newPostgreSQLBackend(conf map[string]string, logger *log.Logger) (Backend, error) {
 	// Get the PostgreSQL credentials to perform read/write operations.
 	connURL, ok := conf["connection_url"]
 	if !ok || connURL == "" {
@@ -62,6 +64,7 @@ func newPostgreSQLBackend(conf map[string]string) (Backend, error) {
 		table:      quoted_table,
 		client:     db,
 		statements: make(map[string]*sql.Stmt),
+		logger:     logger,
 	}
 
 	// Prepare all the statements required

--- a/physical/postgresql_test.go
+++ b/physical/postgresql_test.go
@@ -1,6 +1,7 @@
 package physical
 
 import (
+	"log"
 	"os"
 	"testing"
 
@@ -19,7 +20,8 @@ func TestPostgreSQLBackend(t *testing.T) {
 	}
 
 	// Run vault tests
-	b, err := NewBackend("postgresql", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("postgresql", logger, map[string]string{
 		"connection_url": connURL,
 		"table":          table,
 	})

--- a/physical/s3.go
+++ b/physical/s3.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -24,12 +25,13 @@ import (
 type S3Backend struct {
 	bucket string
 	client *s3.S3
+	logger *log.Logger
 }
 
 // newS3Backend constructs a S3 backend using a pre-existing
 // bucket. Credentials can be provided to the backend, sourced
 // from the environment, AWS credential files or by IAM role.
-func newS3Backend(conf map[string]string) (Backend, error) {
+func newS3Backend(conf map[string]string, logger *log.Logger) (Backend, error) {
 
 	bucket := os.Getenv("AWS_S3_BUCKET")
 	if bucket == "" {
@@ -88,6 +90,7 @@ func newS3Backend(conf map[string]string) (Backend, error) {
 	s := &S3Backend{
 		client: s3conn,
 		bucket: bucket,
+		logger: logger,
 	}
 	return s, nil
 }

--- a/physical/s3_test.go
+++ b/physical/s3_test.go
@@ -2,6 +2,7 @@ package physical
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"testing"
@@ -72,7 +73,8 @@ func TestS3Backend(t *testing.T) {
 		}
 	}()
 
-	b, err := NewBackend("s3", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("s3", logger, map[string]string{
 		"access_key":    creds.AccessKeyID,
 		"secret_key":    creds.SecretAccessKey,
 		"session_token": creds.SessionToken,

--- a/physical/zookeeper.go
+++ b/physical/zookeeper.go
@@ -2,6 +2,7 @@ package physical
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -27,11 +28,12 @@ type ZookeeperBackend struct {
 	path   string
 	client *zk.Conn
 	acl    []zk.ACL
+	logger *log.Logger
 }
 
 // newZookeeperBackend constructs a Zookeeper backend using the given API client
 // and the prefix in the KV store.
-func newZookeeperBackend(conf map[string]string) (Backend, error) {
+func newZookeeperBackend(conf map[string]string, logger *log.Logger) (Backend, error) {
 	// Get the path in Zookeeper
 	path, ok := conf["path"]
 	if !ok {
@@ -120,6 +122,7 @@ func newZookeeperBackend(conf map[string]string) (Backend, error) {
 		path:   path,
 		client: client,
 		acl:    acl,
+		logger: logger,
 	}
 	return c, nil
 }

--- a/physical/zookeeper_test.go
+++ b/physical/zookeeper_test.go
@@ -2,6 +2,7 @@ package physical
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"testing"
 	"time"
@@ -37,7 +38,8 @@ func TestZookeeperBackend(t *testing.T) {
 		client.Close()
 	}()
 
-	b, err := NewBackend("zookeeper", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("zookeeper", logger, map[string]string{
 		"address": addr + "," + addr,
 		"path":    randPath,
 	})
@@ -75,7 +77,8 @@ func TestZookeeperHABackend(t *testing.T) {
 		client.Close()
 	}()
 
-	b, err := NewBackend("zookeeper", map[string]string{
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	b, err := NewBackend("zookeeper", logger, map[string]string{
 		"address": addr + "," + addr,
 		"path":    randPath,
 	})

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -3,14 +3,20 @@ package vault
 import (
 	"bytes"
 	"encoding/json"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/vault/physical"
 )
 
+var (
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+)
+
 // mockBarrier returns a physical backend, security barrier, and master key
 func mockBarrier(t *testing.T) (physical.Backend, SecurityBarrier, []byte) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -24,7 +30,7 @@ func mockBarrier(t *testing.T) (physical.Backend, SecurityBarrier, []byte) {
 }
 
 func TestAESGCMBarrier_Basic(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -33,7 +39,7 @@ func TestAESGCMBarrier_Basic(t *testing.T) {
 }
 
 func TestAESGCMBarrier_Rotate(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -42,7 +48,7 @@ func TestAESGCMBarrier_Rotate(t *testing.T) {
 }
 
 func TestAESGCMBarrier_Upgrade(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b1, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -55,7 +61,7 @@ func TestAESGCMBarrier_Upgrade(t *testing.T) {
 }
 
 func TestAESGCMBarrier_Upgrade_Rekey(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b1, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -68,7 +74,7 @@ func TestAESGCMBarrier_Upgrade_Rekey(t *testing.T) {
 }
 
 func TestAESGCMBarrier_Rekey(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -79,7 +85,7 @@ func TestAESGCMBarrier_Rekey(t *testing.T) {
 // Test an upgrade from the old (0.1) barrier/init to the new
 // core/keyring style
 func TestAESGCMBarrier_BackwardsCompatible(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -158,7 +164,7 @@ func TestAESGCMBarrier_BackwardsCompatible(t *testing.T) {
 
 // Verify data sent through is encrypted
 func TestAESGCMBarrier_Confidential(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -195,7 +201,7 @@ func TestAESGCMBarrier_Confidential(t *testing.T) {
 
 // Verify data sent through cannot be tampered with
 func TestAESGCMBarrier_Integrity(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -230,7 +236,7 @@ func TestAESGCMBarrier_Integrity(t *testing.T) {
 
 // Verify data sent through cannot be moved
 func TestAESGCMBarrier_MoveIntegrityV1(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -268,7 +274,7 @@ func TestAESGCMBarrier_MoveIntegrityV1(t *testing.T) {
 }
 
 func TestAESGCMBarrier_MoveIntegrityV2(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -306,7 +312,7 @@ func TestAESGCMBarrier_MoveIntegrityV2(t *testing.T) {
 }
 
 func TestAESGCMBarrier_UpgradeV1toV2(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -358,7 +364,7 @@ func TestAESGCMBarrier_UpgradeV1toV2(t *testing.T) {
 }
 
 func TestEncrypt_Unique(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -385,7 +391,7 @@ func TestEncrypt_Unique(t *testing.T) {
 }
 
 func TestInitialize_KeyLength(t *testing.T) {
-	inm := physical.NewInmem()
+	inm := physical.NewInmem(logger)
 	b, err := NewAESGCMBarrier(inm)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -1,6 +1,8 @@
 package vault
 
 import (
+	"log"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -17,9 +19,10 @@ var (
 )
 
 func TestNewCore_badAdvertiseAddr(t *testing.T) {
+	logger = log.New(os.Stderr, "", log.LstdFlags)
 	conf := &CoreConfig{
 		AdvertiseAddr: "127.0.0.1:8200",
-		Physical:      physical.NewInmem(),
+		Physical:      physical.NewInmem(logger),
 		DisableMlock:  true,
 	}
 	_, err := NewCore(conf)
@@ -951,8 +954,9 @@ func TestCore_LimitedUseToken(t *testing.T) {
 
 func TestCore_Standby_Seal(t *testing.T) {
 	// Create the first core and initialize it
-	inm := physical.NewInmem()
-	inmha := physical.NewInmemHA()
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+	inm := physical.NewInmem(logger)
+	inmha := physical.NewInmemHA(logger)
 	advertiseOriginal := "http://127.0.0.1:8200"
 	core, err := NewCore(&CoreConfig{
 		Physical:      inm,
@@ -1056,8 +1060,9 @@ func TestCore_Standby_Seal(t *testing.T) {
 
 func TestCore_StepDown(t *testing.T) {
 	// Create the first core and initialize it
-	inm := physical.NewInmem()
-	inmha := physical.NewInmemHA()
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+	inm := physical.NewInmem(logger)
+	inmha := physical.NewInmemHA(logger)
 	advertiseOriginal := "http://127.0.0.1:8200"
 	core, err := NewCore(&CoreConfig{
 		Physical:      inm,
@@ -1230,8 +1235,9 @@ func TestCore_StepDown(t *testing.T) {
 
 func TestCore_CleanLeaderPrefix(t *testing.T) {
 	// Create the first core and initialize it
-	inm := physical.NewInmem()
-	inmha := physical.NewInmemHA()
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+	inm := physical.NewInmem(logger)
+	inmha := physical.NewInmemHA(logger)
 	advertiseOriginal := "http://127.0.0.1:8200"
 	core, err := NewCore(&CoreConfig{
 		Physical:      inm,
@@ -1386,12 +1392,14 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 }
 
 func TestCore_Standby(t *testing.T) {
-	inmha := physical.NewInmemHA()
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+	inmha := physical.NewInmemHA(logger)
 	testCore_Standby_Common(t, inmha, inmha)
 }
 
 func TestCore_Standby_SeparateHA(t *testing.T) {
-	testCore_Standby_Common(t, physical.NewInmemHA(), physical.NewInmemHA())
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+	testCore_Standby_Common(t, physical.NewInmemHA(logger), physical.NewInmemHA(logger))
 }
 
 func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.HABackend) {
@@ -1925,8 +1933,9 @@ func testWaitActive(t *testing.T, core *Core) {
 
 func TestCore_Standby_Rotate(t *testing.T) {
 	// Create the first core and initialize it
-	inm := physical.NewInmem()
-	inmha := physical.NewInmemHA()
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+	inm := physical.NewInmem(logger)
+	inmha := physical.NewInmemHA(logger)
 	advertiseOriginal := "http://127.0.0.1:8200"
 	core, err := NewCore(&CoreConfig{
 		Physical:      inm,

--- a/vault/init_test.go
+++ b/vault/init_test.go
@@ -1,6 +1,8 @@
 package vault
 
 import (
+	"log"
+	"os"
 	"reflect"
 	"testing"
 
@@ -20,7 +22,8 @@ func TestCore_Init(t *testing.T) {
 }
 
 func testCore_NewTestCore(t *testing.T, seal Seal) (*Core, *CoreConfig) {
-	inm := physical.NewInmem()
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	inm := physical.NewInmem(logger)
 	conf := &CoreConfig{
 		Physical:     inm,
 		DisableMlock: true,

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -2,6 +2,8 @@ package vault
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"reflect"
 	"testing"
 
@@ -352,8 +354,9 @@ func testCore_Rekey_Invalid_Common(t *testing.T, c *Core, keys [][]byte, recover
 
 func TestCore_Standby_Rekey(t *testing.T) {
 	// Create the first core and initialize it
-	inm := physical.NewInmem()
-	inmha := physical.NewInmemHA()
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	inm := physical.NewInmem(logger)
+	inmha := physical.NewInmemHA(logger)
 	advertiseOriginal := "http://127.0.0.1:8200"
 	core, err := NewCore(&CoreConfig{
 		Physical:      inm,

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -106,13 +106,15 @@ func TestCoreWithSeal(t *testing.T, testSeal Seal) *Core {
 		logicalBackends[backendName] = backendFactory
 	}
 
-	physicalBackend := physical.NewInmem()
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	physicalBackend := physical.NewInmem(logger)
 	conf := &CoreConfig{
 		Physical:           physicalBackend,
 		AuditBackends:      noopAudits,
 		LogicalBackends:    logicalBackends,
 		CredentialBackends: noopBackends,
 		DisableMlock:       true,
+		Logger:             logger,
 	}
 	if testSeal != nil {
 		conf.Seal = testSeal


### PR DESCRIPTION
Only the Consul backend is using this atm, however the `logger` attribute has been added to all backends.