### PR TITLE
Prefer -ca-path to -ca-cert.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -117,10 +117,10 @@ func (c *Config) ReadEnvironment() error {
 	// If we need custom TLS configuration, then set it
 	if envCACert != "" || envCAPath != "" || envClientCert != "" || envClientKey != "" || envInsecure {
 		var err error
-		if envCACert != "" {
-			newCertPool, err = LoadCACert(envCACert)
-		} else if envCAPath != "" {
+		if envCAPath != "" {
 			newCertPool, err = LoadCAPath(envCAPath)
+		} else if envCACert != "" {
+			newCertPool, err = LoadCACert(envCACert)
 		}
 		if err != nil {
 			return fmt.Errorf("Error setting up CA path: %s", err)


### PR DESCRIPTION
The [help text](https://github.com/hashicorp/vault/blob/master/meta/meta.go#L258) when running the vault client mentions that "If both `-ca-cert` and `-ca-path` are specified, `-ca-path` is used.", however the client actually prefers to use `-ca-cert`.

This PR fixes the code to match what is documented.