### PR TITLE
Improve documentation around token TTLs.

### DIFF
--- a/website/source/docs/auth/token.html.md
+++ b/website/source/docs/auth/token.html.md
@@ -286,8 +286,10 @@ of the header should be "X-Vault-Token" and the value should be the token.
       <li>
         <span class="param">increment</span>
         <span class="param-flags">optional</span>
-            An optional requested lease increment can be provided. This
-            increment may be ignored.
+            An optional requested lease increment (measured in seconds) can be provided.
+            If changing the token's TTL to current time + `increment` seconds would
+            cause the TTL to exceed the token's Max Lease TTL then [this increment will be
+            ignored and the TTL will capped at the Max Lease TTL](/docs/concepts/tokens.html#ttls-and-leases).
       </li>
     </ul>
   </dd>
@@ -342,8 +344,10 @@ of the header should be "X-Vault-Token" and the value should be the token.
       <li>
         <span class="param">increment</span>
         <span class="param-flags">optional</span>
-            An optional requested lease increment can be provided. This
-            increment may be ignored.
+            An optional requested lease increment (measured in seconds) can be provided.
+            If changing the token's TTL to current time + `increment` seconds would
+            cause the TTL to exceed the token's Max Lease TTL then [this increment will be
+            ignored and the TTL will capped at the Max Lease TTL](/docs/concepts/tokens.html#ttls-and-leases).
       </li>
     </ul>
   </dd>

--- a/website/source/docs/auth/token.html.md
+++ b/website/source/docs/auth/token.html.md
@@ -287,9 +287,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
         <span class="param">increment</span>
         <span class="param-flags">optional</span>
             An optional requested lease increment (measured in seconds) can be provided.
-            If changing the token's TTL to current time + `increment` seconds would
-            cause the TTL to exceed the token's Max Lease TTL then [this increment will be
-            ignored and the TTL will capped at the Max Lease TTL](/docs/concepts/tokens.html#ttls-and-leases).
+            This increment may be ignored. See "[token concepts](/docs/concepts/tokens.html#ttls-and-leases)" for more info.
       </li>
     </ul>
   </dd>
@@ -345,9 +343,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
         <span class="param">increment</span>
         <span class="param-flags">optional</span>
             An optional requested lease increment (measured in seconds) can be provided.
-            If changing the token's TTL to current time + `increment` seconds would
-            cause the TTL to exceed the token's Max Lease TTL then [this increment will be
-            ignored and the TTL will capped at the Max Lease TTL](/docs/concepts/tokens.html#ttls-and-leases).
+            This increment may be ignored. See "[token concepts](/docs/concepts/tokens.html#ttls-and-leases)" for more info.
       </li>
     </ul>
   </dd>
@@ -465,7 +461,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
 
 ### /auth/token/roles/[role_name]
 
-#### DELETE 
+#### DELETE
 
 <dl class="api">
   <dt>Description</dt>
@@ -490,7 +486,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
   </dd>
 </dl>
 
-#### GET 
+#### GET
 
 <dl class="api">
   <dt>Description</dt>
@@ -526,7 +522,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
   </dd>
 </dl>
 
-#### LIST 
+#### LIST
 
 <dl class="api">
   <dt>Description</dt>
@@ -724,4 +720,3 @@ of the header should be "X-Vault-Token" and the value should be the token.
   <dd>`204` response code.
   </dd>
 </dl>
-

--- a/website/source/docs/concepts/auth.html.md
+++ b/website/source/docs/concepts/auth.html.md
@@ -97,3 +97,5 @@ how leasing is implemented.
 And just like secrets, identities can be renewed without having to
 completely reauthenticate. Just use `vault token-renew <token>` with the
 leased token associated with your identity to renew it.
+See the [tokens concepts](/docs/concepts/tokens.html#ttls-and-leases) page
+for more information.

--- a/website/source/docs/concepts/tokens.html.md
+++ b/website/source/docs/concepts/tokens.html.md
@@ -46,39 +46,50 @@ with the token. Learn more about policies on the
 ## Token Time-To-Live and Leases
 
 Every non-root token has a time-to-live (TTL) associated with it, which is
-the number of seconds the token is valid for, _measured from the moment it is
-created_. After the TTL is up, the token will no longer function, and
-Vault will revoke it. You can find how much of a token's TTL is remaining
-by calling `vault token-lookup`.
+the number of seconds the token is valid for from this moment in time.
+The TTL is constantly decreasing, and Vault will revoke the token when the TTL hits 0.
+You can find out how much of a token's TTL remains using the `vault token-lookup` command.
 
-When a token is revoked, any leases associated with the token will be revoked
-as well, even if the TTLs on the individual leases are not yet up. For example,
-if a user requests AWS access keys, after the token expires the AWS access keys
-will also be revoked.
+When a token is revoked, any leases associated with the token will also be revoked,
+even if the TTLs on the individual leases are not yet up. For example,
+if a developer uses a token to generate AWS access keys, the AWS access keys
+will be revoked when the token is revoked. The developer will then need to
+create a new token, and use it to request a new set of AWS access keys.
 
-To prevent your token being revoked, you should call the `vault
+To stop your token being revoked, you should call the `vault
 token-renew` command periodically, which will attempt to extend the token's TTL.
 You can specify _the new TTL_ using the `increment` argument. If this is
 not specified, then Vault will use the default TTL specified by the
 `auth/token` mount, or the global [`default_lease_ttl`](/docs/config/index.html#default_lease_ttl).
 
-**NOTE:** Vault enforces a cap on the maximum lifetime of non-root tokens.
-This cap is called the "Max Lease TTL", and is measured in seconds
-from the moment the token was created. If renewing a token would cause
-its TTL to exceed this value, then Vault will cap the TTL at the Max Lease TTL.
+**NOTE:** Vault enforces an upper bound on how long non-root tokens can exist.
+This bound is called the "max lease TTL", and is measured from
+the moment the token was created. Vault will not allow a token to be renewed
+beyond this point. If you attempt to do so, Vault will cap the TTL at a value
+that will not cause the token to exist beyond the max lease TTL.
 
-For example, suppose the system's Max Lease TTL has been set to 12 hours,
-and you have a token that was created 7 hours ago.
-If you were to renew this token with an `increment` of 6 hours,
-that would cause the token's TTL to exceed the max of 12 hours (7 + 6 = 13),
-so Vault will cap the TTL at 12 hours.
+You can detect if the token has hit the max lease TTL by comparing the token's
+TTL after renewal to the `increment` you provided when renewing it. If the TTL
+is less than half of the requested `increment` then you should generate a new token.
 
-You can configure this cap by changing the system's 
+As an example, suppose Vault's "max lease TTL" has been set to 10 hours,
+and you have a token that was created 6 hours ago.
+If you were to renew this token with an `increment` of 9 hours,
+that would cause the token to exist for longer than the "max lease TTL" of
+10 hours (`6 + 9 = 15`), so instead Vault will ignore `increment` and
+cap the TTL at 4 hours (`10 - 6 = 4`). 4 hours is less than half of the requested
+`increment`, so you should generate a new token and prepare for the fact that
+Vault will soon be revoking the old one.
+
+You can configure this cap by changing the system's
 [`max_lease_ttl`](/docs/config/index.html#max_lease_ttl) (which will affect
 all backends, such as AWS, PKI etc.), but the preferred method is to tune
-the `auth/token` mount itself:
+the `auth/token` mount itself. Configuration options set on the `auth/token`
+backend will take precedence over values set in the server config.
+Here's an example:
 
 ```console
+# We don't specify a TTL, so Vault uses the configured `default_lease_ttl`
 $ vault token-create -policy=default
 Key             Value
 token           db7b286c-30b6-9e3f-ca2e-30d46aeedbcd
@@ -87,6 +98,10 @@ token_renewable true
 
 $ vault mount-tune -max-lease-ttl="2h" auth/token
 
+# Vault tries to renew the token with an increment equal to the default
+# lease TTL, but the `auth/token` backend is now restricting the overall lifetime of
+# tokens to 2 hours (7200 seconds), so the TTL is restricted
+# accordingly.
 $ vault token-renew db7b286c-30b6-9e3f-ca2e-30d46aeedbcd
 Key             Value
 token           db7b286c-30b6-9e3f-ca2e-30d46aeedbcd

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -65,8 +65,10 @@ sending a SIGHUP to the server process. These are denoted below.
   for tokens and secrets. This is a string value using a suffix, e.g. "720h".
   Default value is 30 days. This value cannot be larger than `max_lease_ttl`.
 
-* `max_lease_ttl` (optional) - Configures the maximum possible
-  lease duration for tokens and secrets. This is a string value using a suffix,
+* `max_lease_ttl` (optional) - Configures the maximum length of time that
+  tokens and secrets can be used before Vault revokes them.
+  This period is measured from the moment the token/secret is created.
+  This is a string value; use a suffix of `h` to specify in hours, or `m` for minutes.
   e.g. "720h". Default value is 30 days.
 
 In production it is a risk to run Vault on systems where `mlock` is


### PR DESCRIPTION
This change is sparked by a discussion[0] about vault not appearing to
respect the `increment` passed to `vault token-renew`. It turns out
this is expected behaviour if the token's new TTL would exceed the
Backend/System's Max Lease TTL.

[0]: https://github.com/hashicorp/vault/issues/1079