### PR TITLE
Add scala vault library to list of client libs

### DIFF
--- a/website/source/docs/http/libraries.html.md
+++ b/website/source/docs/http/libraries.html.md
@@ -59,3 +59,6 @@ These libraries are provided by the community.
 
 * [HVAC](https://github.com/ianunruh/hvac)
   * `pip install hvac`
+
+### Scala
+ * [scala-vault](https://github.com/janstenpickle/scala-vault)


### PR DESCRIPTION
I've created a [Scala library](https://github.com/janstenpickle/scala-vault) for working with Vault and was wondering if it could be included in the vault docs.

Thanks for all the great work BTW 😃 