### PR TITLE
Split SanitizeTTL method to support time.Duration parameters as well

### DIFF
--- a/builtin/credential/github/path_login.go
+++ b/builtin/credential/github/path_login.go
@@ -46,7 +46,7 @@ func (b *backend) pathLogin(
 		return nil, err
 	}
 
-	ttl, _, err := b.SanitizeTTL(config.TTL.String(), config.MaxTTL.String())
+	ttl, _, err := b.SanitizeTTLStr(config.TTL.String(), config.MaxTTL.String())
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf("[ERR]:%s", err)), nil
 	}

--- a/builtin/credential/userpass/path_users.go
+++ b/builtin/credential/userpass/path_users.go
@@ -176,7 +176,7 @@ func (b *backend) userCreateUpdate(req *logical.Request, d *framework.FieldData)
 		maxTTLStr = maxTTLStrRaw.(string)
 	}
 
-	userEntry.TTL, userEntry.MaxTTL, err = b.SanitizeTTL(ttlStr, maxTTLStr)
+	userEntry.TTL, userEntry.MaxTTL, err = b.SanitizeTTLStr(ttlStr, maxTTLStr)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf("err: %s", err)), nil
 	}


### PR DESCRIPTION
`ttl` and `max_ttl` values are increasingly being parsed as `int` instead of a `string`.
SanitizeTTL was receiving string arguments and hence was not useful when the values were parsed as integers. Splitting that into two different methods now.