### PR TITLE
Added new configuration option to ldap auth backend - groupfilter

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -1,9 +1,9 @@
 package ldap
 
 import (
+	"bytes"
 	"fmt"
-
-	"strings"
+	"text/template"
 
 	"github.com/go-ldap/ldap"
 	"github.com/hashicorp/vault/helper/mfa"
@@ -100,32 +100,35 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 		return nil, logical.ErrorResponse("invalid connection returned from LDAP dial"), nil
 	}
 
-	bindDN, err := getBindDN(cfg, c, username)
+	bindDN, err := b.getBindDN(cfg, c, username)
 	if err != nil {
 		return nil, logical.ErrorResponse(err.Error()), nil
 	}
 
+	b.Logger().Printf("[DEBUG] auth/ldap: BindDN for %s is %s", username, bindDN)
+
+	// Try to bind as the login user. This is where the actual authentication takes place.
 	if err = c.Bind(bindDN, password); err != nil {
 		return nil, logical.ErrorResponse(fmt.Sprintf("LDAP bind failed: %v", err)), nil
 	}
 
-	userDN, err := getUserDN(cfg, c, bindDN)
+	userDN, err := b.getUserDN(cfg, c, bindDN)
 	if err != nil {
 		return nil, logical.ErrorResponse(err.Error()), nil
 	}
 
-	ldapGroups, err := getLdapGroups(cfg, c, userDN, username)
+	ldapGroups, err := b.getLdapGroups(cfg, c, userDN, username)
 	if err != nil {
 		return nil, logical.ErrorResponse(err.Error()), nil
 	}
+	b.Logger().Printf("[DEBUG] auth/ldap: Server returned %d groups: %v", len(ldapGroups), ldapGroups)
 
 	ldapResponse := &logical.Response{
 		Data: map[string]interface{}{},
 	}
 	if len(ldapGroups) == 0 {
 		errString := fmt.Sprintf(
-			"no LDAP groups found in userDN '%s' or groupDN '%s';only policies from locally-defined groups available",
-			cfg.UserDN,
+			"no LDAP groups found in groupDN '%s'; only policies from locally-defined groups available",
 			cfg.GroupDN)
 		ldapResponse.AddWarning(errString)
 	}
@@ -133,10 +136,11 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 	var allGroups []string
 	// Import the custom added groups from ldap backend
 	user, err := b.User(req.Storage, username)
-	if err == nil && user != nil {
+	if err == nil && user != nil && user.Groups != nil {
+		b.Logger().Printf("[DEBUG] auth/ldap: adding %d local groups: %v\n", len(user.Groups), user.Groups)
 		allGroups = append(allGroups, user.Groups...)
 	}
-	// add the LDAP groups
+	// Merge local and LDAP groups
 	allGroups = append(allGroups, ldapGroups...)
 
 	// Retrieve policies
@@ -161,12 +165,49 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 	return policies, ldapResponse, nil
 }
 
-func getBindDN(cfg *ConfigEntry, c *ldap.Conn, username string) (string, error) {
+/*
+ * Parses a distinguished name and returns the CN portion.
+ * Given a non-conforming string (such as an already-extracted CN),
+ * it will be returned as-is.
+ */
+func (b *backend) getCN(dn string) string {
+	parsedDN, err := ldap.ParseDN(dn)
+	if err != nil || len(parsedDN.RDNs) == 0 {
+		// It was already a CN, return as-is
+		return dn
+	}
+
+	for _, rdn := range parsedDN.RDNs {
+		for _, rdnAttr := range rdn.Attributes {
+			if rdnAttr.Type == "CN" {
+				return rdnAttr.Value
+			}
+		}
+	}
+
+	// Default, return self
+	return dn
+}
+
+/*
+ * Discover and return the bind string for the user attempting to authenticate.
+ * This is handled in one of several ways:
+ *
+ * 1. If DiscoverDN is set, the user object will be searched for using userdn (base search path)
+ *    and userattr (the attribute that maps to the provided username).
+ *    The bind will either be anonymous or use binddn and bindpassword if they were provided.
+ * 2. If upndomain is set, the user dn is constructed as 'username@upndomain'. See https://msdn.microsoft.com/en-us/library/cc223499.aspx
+ *
+ */
+func (b *backend) getBindDN(cfg *ConfigEntry, c *ldap.Conn, username string) (string, error) {
 	bindDN := ""
 	if cfg.DiscoverDN || (cfg.BindDN != "" && cfg.BindPassword != "") {
 		if err := c.Bind(cfg.BindDN, cfg.BindPassword); err != nil {
 			return bindDN, fmt.Errorf("LDAP bind (service) failed: %v", err)
 		}
+
+		filter := fmt.Sprintf("(%s=%s)", cfg.UserAttr, ldap.EscapeFilter(username))
+		b.Logger().Printf("[DEBUG] auth/ldap: Discovering user, BaseDN=%s, Filter=%s", cfg.UserDN, filter)
 		result, err := c.Search(&ldap.SearchRequest{
 			BaseDN: cfg.UserDN,
 			Scope:  2, // subtree
@@ -190,14 +231,19 @@ func getBindDN(cfg *ConfigEntry, c *ldap.Conn, username string) (string, error) 
 	return bindDN, nil
 }
 
-func getUserDN(cfg *ConfigEntry, c *ldap.Conn, bindDN string) (string, error) {
+/*
+ * Returns the DN of the object representing the authenticated user.
+ */
+func (b *backend) getUserDN(cfg *ConfigEntry, c *ldap.Conn, bindDN string) (string, error) {
 	userDN := ""
 	if cfg.UPNDomain != "" {
 		// Find the distinguished name for the user if userPrincipalName used for login
+		filter := fmt.Sprintf("(userPrincipalName=%s)", ldap.EscapeFilter(bindDN))
+		b.Logger().Printf("[DEBUG] auth/ldap: Searching UPN, BaseDN=%s, Filter=%s", cfg.UserDN, filter)
 		result, err := c.Search(&ldap.SearchRequest{
 			BaseDN: cfg.UserDN,
 			Scope:  2, // subtree
-			Filter: fmt.Sprintf("(userPrincipalName=%s)", ldap.EscapeFilter(bindDN)),
+			Filter: filter,
 		})
 		if err != nil {
 			return userDN, fmt.Errorf("LDAP search failed for detecting user: %v", err)
@@ -212,77 +258,100 @@ func getUserDN(cfg *ConfigEntry, c *ldap.Conn, bindDN string) (string, error) {
 	return userDN, nil
 }
 
-func getLdapGroups(cfg *ConfigEntry, c *ldap.Conn, userDN string, username string) ([]string, error) {
+/*
+ * getLdapGroups queries LDAP and returns a slice describing the set of groups the authenticated user is a member of.
+ *
+ * The search query is constructed according to cfg.GroupFilter, and run in context of cfg.GroupDN.
+ * Groups will be resolved from the query results by following the attribute defined in cfg.GroupAttr.
+ *
+ * cfg.GroupFilter is a go template and is compiled with the following context: [UserDN, Username]
+ *    UserDN - The DN of the authenticated user
+ *    Username - The Username of the authenticated user
+ *
+ * Example:
+ *   cfg.GroupFilter = "(&(objectClass=group)(member:1.2.840.113556.1.4.1941:={{.UserDN}}))"
+ *   cfg.GroupDN     = "OU=Groups,DC=myorg,DC=com"
+ *   cfg.GroupAttr   = "cn"
+ *
+ * NOTE - If cfg.GroupFilter is empty, no query is performed and an empty result slice is returned.
+ *
+ */
+func (b *backend) getLdapGroups(cfg *ConfigEntry, c *ldap.Conn, userDN string, username string) ([]string, error) {
 	// retrieve the groups in a string/bool map as a structure to avoid duplicates inside
 	ldapMap := make(map[string]bool)
-	// Fetch the optional memberOf property values on the user object
-	// This is the most common method used in Active Directory setup to retrieve the groups
+
+	if cfg.GroupFilter == "" {
+		b.Logger().Printf("[WARN] auth/ldap: GroupFilter is empty, will not query server")
+		return make([]string, 0), nil
+	}
+
+	if cfg.GroupDN == "" {
+		b.Logger().Printf("[WARN] auth/ldap: GroupDN is empty, will not query server")
+		return make([]string, 0), nil
+	}
+
+	// If groupfilter was defined, resolve it as a Go template and use the query for
+	// returning the user's groups
+	b.Logger().Printf("[DEBUG] auth/ldap: Compiling group filter %s", cfg.GroupFilter)
+
+	// Parse the configuration as a template.
+	// Example template "(&(objectClass=group)(member:1.2.840.113556.1.4.1941:={{.UserDN}}))"
+	t, err := template.New("queryTemplate").Parse(cfg.GroupFilter)
+	if err != nil {
+		return nil, fmt.Errorf("LDAP search failed due to template compilation error: %v", err)
+	}
+
+	// Build context to pass to template - we will be exposing UserDn and Username.
+	context := struct {
+		UserDN   string
+		Username string
+	}{
+		ldap.EscapeFilter(userDN),
+		ldap.EscapeFilter(username),
+	}
+
+	var renderedQuery bytes.Buffer
+	t.Execute(&renderedQuery, context)
+
+	b.Logger().Printf("[DEBUG] auth/ldap: Searching GroupDN=%s, query=%s", cfg.GroupDN, renderedQuery.String())
+
 	result, err := c.Search(&ldap.SearchRequest{
-		BaseDN: userDN,
-		Scope:  0,        // base scope to fetch only the userDN
-		Filter: "(cn=*)", // bogus filter, required to fetch the CN from userDN
+		BaseDN: cfg.GroupDN,
+		Scope:  2, // subtree
+		Filter: renderedQuery.String(),
 		Attributes: []string{
-			"memberOf",
+			cfg.GroupAttr,
 		},
 	})
-	// this check remains in case something happens with the ldap query or connection
 	if err != nil {
-		return nil, fmt.Errorf("LDAP fetch of distinguishedName=%s failed: %v", userDN, err)
+		return nil, fmt.Errorf("LDAP search failed: %v", err)
 	}
-	// if there are more than one entry, we consider the results irrelevant and ignore them
-	if len(result.Entries) == 1 {
-		for _, attr := range result.Entries[0].Attributes {
-			// Find the groups the user is member of from the 'memberOf' attribute extracting the CN
-			if attr.Name == "memberOf" {
-				for _, value := range attr.Values {
-					memberOfDN, err := ldap.ParseDN(value)
-					if err != nil || len(memberOfDN.RDNs) == 0 {
-						continue
-					}
 
-					for _, rdn := range memberOfDN.RDNs {
-						for _, rdnTypeAndValue := range rdn.Attributes {
-							if strings.EqualFold(rdnTypeAndValue.Type, "CN") {
-								ldapMap[rdnTypeAndValue.Value] = true
-							}
-						}
-					}
-				}
+	for _, e := range result.Entries {
+		dn, err := ldap.ParseDN(e.DN)
+		if err != nil || len(dn.RDNs) == 0 {
+			continue
+		}
+
+		// Enumerate attributes of each result, parse out CN and add as group
+		values := e.GetAttributeValues(cfg.GroupAttr)
+		if len(values) > 0 {
+			for _, val := range values {
+				groupCN := b.getCN(val)
+				ldapMap[groupCN] = true
 			}
+		} else {
+			// If groupattr didn't resolve, use self (enumerating group objects)
+			groupCN := b.getCN(e.DN)
+			ldapMap[groupCN] = true
 		}
 	}
 
-	// Find groups by searching in groupDN for any of the memberUid, member or uniqueMember attributes
-	// and retrieving the CN in the DN result
-	if cfg.GroupDN != "" {
-		result, err := c.Search(&ldap.SearchRequest{
-			BaseDN: cfg.GroupDN,
-			Scope:  2, // subtree
-			Filter: fmt.Sprintf("(|(memberUid=%s)(member=%s)(uniqueMember=%s))", ldap.EscapeFilter(username), ldap.EscapeFilter(userDN), ldap.EscapeFilter(userDN)),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("LDAP search failed: %v", err)
-		}
-
-		for _, e := range result.Entries {
-			dn, err := ldap.ParseDN(e.DN)
-			if err != nil || len(dn.RDNs) == 0 {
-				continue
-			}
-			for _, rdn := range dn.RDNs {
-				for _, rdnTypeAndValue := range rdn.Attributes {
-					if strings.EqualFold(rdnTypeAndValue.Type, "CN") {
-						ldapMap[rdnTypeAndValue.Value] = true
-					}
-				}
-			}
-		}
-	}
-
-	ldapGroups := make([]string, len(ldapMap))
+	ldapGroups := make([]string, 0, len(ldapMap))
 	for key, _ := range ldapMap {
 		ldapGroups = append(ldapGroups, key)
 	}
+
 	return ldapGroups, nil
 }
 

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -3,6 +3,7 @@ package ldap
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -11,6 +12,21 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+/*
+ * Acceptance test for LDAP Auth Backend
+ *
+ * The tests here rely on a public LDAP server:
+ * [http://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/]
+ *
+ * ...as well as existence of a person object, `uid=tesla,dc=example,dc=com`,
+ *    which is a member of a group, `ou=scientists,dc=example,dc=com`
+ *
+ * Querying the server from the command line:
+ *   $ ldapsearch -x -H ldap://ldap.forumsys.com -b dc=example,dc=com -s sub \
+ *       '(&(objectClass=groupOfUniqueNames)(uniqueMember=uid=tesla,dc=example,dc=com))'
+ *
+ *   $ ldapsearch -x -H ldap://ldap.forumsys.com -b dc=example,dc=com -s sub uid=tesla
+ */
 func factory(t *testing.T) logical.Backend {
 	defaultLeaseTTLVal := time.Hour * 24
 	maxLeaseTTLVal := time.Hour * 24 * 30
@@ -35,11 +51,22 @@ func TestBackend_basic(t *testing.T) {
 		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfigUrl(t),
-			testAccStepGroup(t, "scientists", "foo"),
+			// Map Scientists group (from LDAP server) with foo policy
+			testAccStepGroup(t, "Scientists", "foo"),
+
+			// Map engineers group (local) with bar policy
 			testAccStepGroup(t, "engineers", "bar"),
+
+			// Map tesla user with local engineers group
 			testAccStepUser(t, "tesla", "engineers"),
+
+			// Authenticate
 			testAccStepLogin(t, "tesla", "password"),
-			testAccStepGroupList(t, []string{"engineers", "scientists"}),
+
+			// Verify both groups mappings can be listed back
+			testAccStepGroupList(t, []string{"engineers", "Scientists"}),
+
+			// Verify user mapping can be listed back
 			testAccStepUserList(t, []string{"tesla"}),
 		},
 	})
@@ -53,7 +80,7 @@ func TestBackend_basic_authbind(t *testing.T) {
 		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfigUrlWithAuthBind(t),
-			testAccStepGroup(t, "scientists", "foo"),
+			testAccStepGroup(t, "Scientists", "foo"),
 			testAccStepGroup(t, "engineers", "bar"),
 			testAccStepUser(t, "tesla", "engineers"),
 			testAccStepLogin(t, "tesla", "password"),
@@ -69,7 +96,7 @@ func TestBackend_basic_discover(t *testing.T) {
 		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfigUrlWithDiscover(t),
-			testAccStepGroup(t, "scientists", "foo"),
+			testAccStepGroup(t, "Scientists", "foo"),
 			testAccStepGroup(t, "engineers", "bar"),
 			testAccStepUser(t, "tesla", "engineers"),
 			testAccStepLogin(t, "tesla", "password"),
@@ -85,7 +112,7 @@ func TestBackend_basic_nogroupdn(t *testing.T) {
 		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfigUrlNoGroupDN(t),
-			testAccStepGroup(t, "scientists", "foo"),
+			testAccStepGroup(t, "Scientists", "foo"),
 			testAccStepGroup(t, "engineers", "bar"),
 			testAccStepUser(t, "tesla", "engineers"),
 			testAccStepLoginNoGroupDN(t, "tesla", "password"),
@@ -101,9 +128,56 @@ func TestBackend_groupCrud(t *testing.T) {
 		Backend:        b,
 		Steps: []logicaltest.TestStep{
 			testAccStepGroup(t, "g1", "foo"),
-			testAccStepReadGroup(t, "g1", "foo"),
+			testAccStepReadGroup(t, "g1", "default,foo"),
 			testAccStepDeleteGroup(t, "g1"),
 			testAccStepReadGroup(t, "g1", ""),
+		},
+	})
+}
+
+/*
+ * Test backend configuration defaults are successfully read.
+ */
+func TestBackend_configDefaultsAfterUpdate(t *testing.T) {
+	b := factory(t)
+
+	logicaltest.Test(t, logicaltest.TestCase{
+		AcceptanceTest: false,
+		Backend:        b,
+		Steps: []logicaltest.TestStep{
+			logicaltest.TestStep{
+				Operation: logical.UpdateOperation,
+				Path:      "config",
+				Data:      map[string]interface{}{},
+			},
+			logicaltest.TestStep{
+				Operation: logical.ReadOperation,
+				Path:      "config",
+				Check: func(resp *logical.Response) error {
+					if resp == nil {
+						return fmt.Errorf("bad: %#v", resp)
+					}
+
+					// Test well-known defaults
+					cfg := resp.Data
+					defaultGroupFilter := "(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))"
+					if cfg["groupfilter"] != defaultGroupFilter {
+						t.Errorf("Default mismatch: groupfilter. Expected: '%s', received :'%s'", defaultGroupFilter, cfg["groupfilter"])
+					}
+
+					defaultGroupAttr := "cn"
+					if cfg["groupattr"] != defaultGroupAttr {
+						t.Errorf("Default mismatch: groupattr. Expected: '%s', received :'%s'", defaultGroupAttr, cfg["groupattr"])
+					}
+
+					defaultUserAttr := "cn"
+					if cfg["userattr"] != defaultUserAttr {
+						t.Errorf("Default mismatch: userattr. Expected: '%s', received :'%s'", defaultUserAttr, cfg["userattr"])
+					}
+
+					return nil
+				},
+			},
 		},
 	})
 }
@@ -172,6 +246,7 @@ func testAccStepConfigUrlNoGroupDN(t *testing.T) logicaltest.TestStep {
 }
 
 func testAccStepGroup(t *testing.T, group string, policies string) logicaltest.TestStep {
+	t.Logf("[testAccStepGroup] - Registering group %s, policy %s", group, policies)
 	return logicaltest.TestStep{
 		Operation: logical.UpdateOperation,
 		Path:      "groups/" + group,
@@ -285,6 +360,7 @@ func testAccStepLogin(t *testing.T, user string, pass string) logicaltest.TestSt
 		},
 		Unauthenticated: true,
 
+		// Verifies user tesla maps to groups via local group (engineers) as well as remote group (Scientiests)
 		Check: logicaltest.TestCheckAuth([]string{"bar", "default", "foo"}),
 	}
 }
@@ -298,6 +374,7 @@ func testAccStepLoginNoGroupDN(t *testing.T, user string, pass string) logicalte
 		},
 		Unauthenticated: true,
 
+		// Verifies a search without defined GroupDN returns a warnting rather than failing
 		Check: func(resp *logical.Response) error {
 			if len(resp.Warnings()) != 1 {
 				return fmt.Errorf("expected a warning due to no group dn, got: %#v", resp.Warnings())
@@ -334,9 +411,16 @@ func testAccStepGroupList(t *testing.T, groups []string) logicaltest.TestStep {
 				return fmt.Errorf("Got error response: %#v", *resp)
 			}
 
-			exp := groups
-			if !reflect.DeepEqual(exp, resp.Data["keys"].([]string)) {
-				return fmt.Errorf("expected:\n%#v\ngot:\n%#v\n", exp, resp.Data["keys"])
+			expected := make([]string, len(groups))
+			copy(expected, groups)
+			sort.Strings(expected)
+
+			sortedResponse := make([]string, len(resp.Data["keys"].([]string)))
+			copy(sortedResponse, resp.Data["keys"].([]string))
+			sort.Strings(sortedResponse)
+
+			if !reflect.DeepEqual(expected, sortedResponse) {
+				return fmt.Errorf("expected:\n%#v\ngot:\n%#v\n", expected, sortedResponse)
 			}
 			return nil
 		},
@@ -352,9 +436,16 @@ func testAccStepUserList(t *testing.T, users []string) logicaltest.TestStep {
 				return fmt.Errorf("Got error response: %#v", *resp)
 			}
 
-			exp := users
-			if !reflect.DeepEqual(exp, resp.Data["keys"].([]string)) {
-				return fmt.Errorf("expected:\n%#v\ngot:\n%#v\n", exp, resp.Data["keys"])
+			expected := make([]string, len(users))
+			copy(expected, users)
+			sort.Strings(expected)
+
+			sortedResponse := make([]string, len(resp.Data["keys"].([]string)))
+			copy(sortedResponse, resp.Data["keys"].([]string))
+			sort.Strings(sortedResponse)
+
+			if !reflect.DeepEqual(expected, sortedResponse) {
+				return fmt.Errorf("expected:\n%#v\ngot:\n%#v\n", expected, sortedResponse)
 			}
 			return nil
 		},


### PR DESCRIPTION
/cc @jefferai @LeonDaniel @steve-jansen @0x9090 - here is what I was thinking of - exposing a new configuration option to define a template allowing full control of the group membership query. This is not ready to merge yet, but I wanted your feedback on the approach. I will look over the code some more - but I believe all the overlapping options can be combined somewhat to simplify this.

I've testing this branch against our Active Directory and can successfully resolve transitive group membership when providing `groupdn=DC=myorg,DC=local` and `groupfilter="(&(objectClass=group)(member:1.2.840.113556.1.4.1941:={{.UserDN}}))"`

Please let me know what you think.