### PR TITLE
Don't build mlock for NetBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ IMPROVEMENTS:
    fails to authenticate the provided token [GH-1233]
  * command/write: `-format` and `-field` can now be used with the `write`
    command [GH-1228]
- * core: Add `mlock` support for FreeBSD, OpenBSD, NetBSD, and Darwin [GH-1297]
+ * core: Add `mlock` support for FreeBSD, OpenBSD, and Darwin [GH-1297]
  * core: Don't keep lease timers around when tokens are revoked [GH-1277]
  * core: If using the `disable_cache` option, caches for the policy store and
    the `transit` backend are now disabled as well [GH-1346]

--- a/helper/mlock/mlock_unavail.go
+++ b/helper/mlock/mlock_unavail.go
@@ -1,4 +1,4 @@
-// +build android nacl plan9 windows
+// +build android nacl netbsd plan9 windows
 
 package mlock
 

--- a/helper/mlock/mlock_unix.go
+++ b/helper/mlock/mlock_unix.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+// +build darwin dragonfly freebsd linux openbsd solaris
 
 package mlock
 


### PR DESCRIPTION
NetBSD doesn't have the right symbols defined in Go for mlockall support.  The OS supports it just fine, but the definitions aren't present in Go.  If someone wanted to they could add support XOR the values from `sys/mman.h` for `MCL_CURRENT | MCL_FUTURE` which is almost certainly `0x01 | 0x02` but we're not going to do that in code due to the maintenance of a one-off just for NetBSD.  PR's welcome.