### PR TITLE
Auth token role names now support slash characters.

### DIFF
--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -110,7 +110,7 @@ func NewTokenStore(c *Core, config *logical.BackendConfig) (*TokenStore, error) 
 			},
 
 			&framework.Path{
-				Pattern: "roles/" + framework.GenericNameRegex("role_name"),
+				Pattern: "roles/(?P<role_name>.+)",
 				Fields: map[string]*framework.FieldSchema{
 					"role_name": &framework.FieldSchema{
 						Type:        framework.TypeString,
@@ -167,7 +167,7 @@ func NewTokenStore(c *Core, config *logical.BackendConfig) (*TokenStore, error) 
 			},
 
 			&framework.Path{
-				Pattern: "create/" + framework.GenericNameRegex("role_name"),
+				Pattern: "create/(?P<role_name>.+)",
 
 				Fields: map[string]*framework.FieldSchema{
 					"role_name": &framework.FieldSchema{
@@ -1301,17 +1301,13 @@ func (ts *TokenStore) tokenStoreRole(name string) (*tsRoleEntry, error) {
 
 func (ts *TokenStore) tokenStoreRoleList(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	entries, err := ts.view.List(rolesPrefix)
+	rolesView := ts.view.SubView(rolesPrefix)
+	entries, err := CollectKeys(rolesView)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make([]string, len(entries))
-	for i, entry := range entries {
-		ret[i] = strings.TrimPrefix(entry, rolesPrefix)
-	}
-
-	return logical.ListResponse(ret), nil
+	return logical.ListResponse(entries), nil
 }
 
 func (ts *TokenStore) tokenStoreRoleDelete(

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -1207,15 +1207,24 @@ func TestTokenStore_HandleRequest_RenewSelf(t *testing.T) {
 	}
 }
 
-func TestTokenStore_RoleCRUD(t *testing.T) {
+func TestTokenStore_RoleCRUD_All(t *testing.T) {
+	roles := []string{"test", "foo/bar", "test/multiple/levels"}
+
+	// Test different role names
+	for _, role := range roles {
+		testTokenStore_RoleCRUD(t, role)
+	}
+}
+
+func testTokenStore_RoleCRUD(t *testing.T, roleName string) {
 	core, _, _, root := TestCoreWithTokenStore(t)
 
-	req := logical.TestRequest(t, logical.ReadOperation, "auth/token/roles/test")
+	req := logical.TestRequest(t, logical.ReadOperation, "auth/token/roles/"+roleName)
 	req.ClientToken = root
 
 	resp, err := core.HandleRequest(req)
 	if err != nil {
-		t.Fatalf("err: %v %v", err, resp)
+		t.Fatalf("err reading role %s: %v %v", roleName, err, resp)
 	}
 	if resp != nil {
 		t.Fatalf("should not see a role")
@@ -1232,7 +1241,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 
 	resp, err = core.HandleRequest(req)
 	if err != nil {
-		t.Fatalf("err: %v %v", err, resp)
+		t.Fatalf("err creating role %s: %v %v", roleName, err, resp)
 	}
 	if resp != nil {
 		t.Fatalf("expected a nil response")
@@ -1243,14 +1252,14 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 
 	resp, err = core.HandleRequest(req)
 	if err != nil {
-		t.Fatalf("err: %v %v", err, resp)
+		t.Fatalf("err reading role %s: %v %v", roleName, err, resp)
 	}
 	if resp == nil {
 		t.Fatalf("got a nil response")
 	}
 
 	expected := map[string]interface{}{
-		"name":             "test",
+		"name":             roleName,
 		"orphan":           true,
 		"period":           float64(259200),
 		"allowed_policies": []string{"test1", "test2"},
@@ -1272,7 +1281,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 
 	resp, err = core.HandleRequest(req)
 	if err != nil {
-		t.Fatalf("err: %v %v", err, resp)
+		t.Fatalf("err updating role %s: %v %v", roleName, err, resp)
 	}
 	if resp != nil {
 		t.Fatalf("expected a nil response")
@@ -1283,14 +1292,14 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 
 	resp, err = core.HandleRequest(req)
 	if err != nil {
-		t.Fatalf("err: %v %v", err, resp)
+		t.Fatalf("err reading role %s: %v %v", roleName, err, resp)
 	}
 	if resp == nil {
 		t.Fatalf("got a nil response")
 	}
 
 	expected = map[string]interface{}{
-		"name":             "test",
+		"name":             roleName,
 		"orphan":           true,
 		"period":           float64(284400),
 		"allowed_policies": []string{"test3"},
@@ -1306,7 +1315,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 	req.Data = map[string]interface{}{}
 	resp, err = core.HandleRequest(req)
 	if err != nil {
-		t.Fatalf("err: %v %v", err, resp)
+		t.Fatalf("err listing roles: %v %v", err, resp)
 	}
 	if resp == nil {
 		t.Fatalf("got a nil response")
@@ -1322,15 +1331,15 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 	if len(keys) != 1 {
 		t.Fatalf("unexpected number of keys: %d", len(keys))
 	}
-	if keys[0] != "test" {
-		t.Fatalf("expected \"test\", got \"%s\"", keys[0])
+	if keys[0] != roleName {
+		t.Fatalf("expected \"%s\", got \"%s\"", roleName, keys[0])
 	}
 
 	req.Operation = logical.DeleteOperation
-	req.Path = "auth/token/roles/test"
+	req.Path = "auth/token/roles/" + roleName
 	resp, err = core.HandleRequest(req)
 	if err != nil {
-		t.Fatalf("err: %v %v", err, resp)
+		t.Fatalf("err deleting role %s: %v %v", roleName, err, resp)
 	}
 	if resp != nil {
 		t.Fatalf("expected a nil response")
@@ -1339,7 +1348,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 	req.Operation = logical.ReadOperation
 	resp, err = core.HandleRequest(req)
 	if err != nil {
-		t.Fatalf("err: %v %v", err, resp)
+		t.Fatalf("err reading role %s: %v %v", roleName, err, resp)
 	}
 	if resp != nil {
 		t.Fatalf("expected a nil response")


### PR DESCRIPTION
Previously, auth token roles did not support names/with/slashes. This change add support for these to more closely align with legal policy names.

```
# This was previously rejected
vault write auth/token/roles/foo/bar allowed_policies=default
vault token-create -role=foo/bar
```