### PR TITLE
fix PostgreSQL sample code

### DIFF
--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -490,7 +490,7 @@ The PostgreSQL backend has the following options:
 
     Examples:
 
-    * postgres://username:password@localhost:5432/database?sslmode=disabled
+    * postgres://username:password@localhost:5432/database?sslmode=disable
 
     * postgres://username:password@localhost:5432/database?sslmode=verify-full
 


### PR DESCRIPTION
The current sample configuration line fails with `Error initializing backend of type postgresql: failed to check for native upsert: pq: unsupported sslmode "disabled"; only "require" (default), "verify-full", "verify-ca", and "disable" supported`.