### PR TITLE
[Discussion required] Prometheus metrics export

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -16,6 +16,10 @@
 			"Rev": "f303b03b91d770a11a39677f1d3b55da4002bbcb"
 		},
 		{
+			"ImportPath": "github.com/armon/go-metrics/prometheus",
+			"Rev": "f303b03b91d770a11a39677f1d3b55da4002bbcb"
+		},
+		{
 			"ImportPath": "github.com/armon/go-radix",
 			"Rev": "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2"
 		},

--- a/command/server.go
+++ b/command/server.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/prometheus"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/logutils"
@@ -587,6 +588,15 @@ func (c *ServerCommand) setupTelemetry(config *server.Config) error {
 	// Configure the statsd sink
 	if telConfig.StatsdAddr != "" {
 		sink, err := metrics.NewStatsdSink(telConfig.StatsdAddr)
+		if err != nil {
+			return err
+		}
+		fanout = append(fanout, sink)
+	}
+
+	// Configure the prometheus sink
+	if telConfig.EnablePrometheus {
+		sink, err := prometheus.NewPrometheusSink()
 		if err != nil {
 			return err
 		}

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -85,8 +85,9 @@ func (b *Backend) GoString() string {
 
 // Telemetry is the telemetry configuration for the server
 type Telemetry struct {
-	StatsiteAddr string `hcl:"statsite_address"`
-	StatsdAddr   string `hcl:"statsd_address"`
+	StatsiteAddr     string `hcl:"statsite_address"`
+	StatsdAddr       string `hcl:"statsd_address"`
+	EnablePrometheus bool   `hcl:"enable_prometheus"`
 
 	DisableHostname bool `hcl:"disable_hostname"`
 }
@@ -459,6 +460,7 @@ func parseTelemetry(result *Config, list *ast.ObjectList) error {
 	valid := []string{
 		"statsite_address",
 		"statsd_address",
+		"enable_prometheus",
 		"disable_hostname",
 	}
 	if err := checkHCLKeys(item.Val, valid); err != nil {

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -85,9 +85,10 @@ func (b *Backend) GoString() string {
 
 // Telemetry is the telemetry configuration for the server
 type Telemetry struct {
-	StatsiteAddr     string `hcl:"statsite_address"`
-	StatsdAddr       string `hcl:"statsd_address"`
-	EnablePrometheus bool   `hcl:"enable_prometheus"`
+	StatsiteAddr       string `hcl:"statsite_address"`
+	StatsdAddr         string `hcl:"statsd_address"`
+	PrometheusEnabled  bool   `hcl:"prometheus_enabled"`
+	PrometheusBindAddr string `hcl:"prometheus_bindaddr"`
 
 	DisableHostname bool `hcl:"disable_hostname"`
 }
@@ -460,7 +461,8 @@ func parseTelemetry(result *Config, list *ast.ObjectList) error {
 	valid := []string{
 		"statsite_address",
 		"statsd_address",
-		"enable_prometheus",
+		"prometheus_enabled",
+		"prometheus_bindaddr",
 		"disable_hostname",
 	}
 	if err := checkHCLKeys(item.Val, valid); err != nil {

--- a/http/handler.go
+++ b/http/handler.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/vault"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // AuthHeaderName is the name of the header containing the token.
@@ -38,6 +40,9 @@ func Handler(core *vault.Core) http.Handler {
 	mux.Handle("/v1/sys/capabilities-self", handleLogical(core, true, sysCapabilitiesSelfCallback))
 	mux.Handle("/v1/sys/", handleLogical(core, true, nil))
 	mux.Handle("/v1/", handleLogical(core, false, nil))
+
+	// This is probably wrong in quite a few ways - unsure how to register it properly? Something like Mounting, maybe?
+	mux.Handle("/metrics", prometheus.Handler())
 
 	// Wrap the handler in another handler to trigger all help paths.
 	handler := handleHelpHandler(mux, core)

--- a/http/handler.go
+++ b/http/handler.go
@@ -11,8 +11,6 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/vault"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // AuthHeaderName is the name of the header containing the token.
@@ -40,9 +38,6 @@ func Handler(core *vault.Core) http.Handler {
 	mux.Handle("/v1/sys/capabilities-self", handleLogical(core, true, sysCapabilitiesSelfCallback))
 	mux.Handle("/v1/sys/", handleLogical(core, true, nil))
 	mux.Handle("/v1/", handleLogical(core, false, nil))
-
-	// This is probably wrong in quite a few ways - unsure how to register it properly? Something like Mounting, maybe?
-	mux.Handle("/metrics", prometheus.Handler())
 
 	// Wrap the handler in another handler to trigger all help paths.
 	handler := handleHelpHandler(mux, core)

--- a/vendor/github.com/armon/go-metrics/prometheus/prometheus.go
+++ b/vendor/github.com/armon/go-metrics/prometheus/prometheus.go
@@ -1,0 +1,88 @@
+// +build go1.3
+package prometheus
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type PrometheusSink struct {
+	mu        sync.Mutex
+	gauges    map[string]prometheus.Gauge
+	summaries map[string]prometheus.Summary
+	counters  map[string]prometheus.Counter
+}
+
+func NewPrometheusSink() (*PrometheusSink, error) {
+	return &PrometheusSink{
+		gauges:    make(map[string]prometheus.Gauge),
+		summaries: make(map[string]prometheus.Summary),
+		counters:  make(map[string]prometheus.Counter),
+	}, nil
+}
+
+func (p *PrometheusSink) flattenKey(parts []string) string {
+	joined := strings.Join(parts, "_")
+	joined = strings.Replace(joined, " ", "_", -1)
+	joined = strings.Replace(joined, ".", "_", -1)
+	joined = strings.Replace(joined, "-", "_", -1)
+	return joined
+}
+
+func (p *PrometheusSink) SetGauge(parts []string, val float32) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	key := p.flattenKey(parts)
+	g, ok := p.gauges[key]
+	if !ok {
+		g = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: key,
+			Help: key,
+		})
+		prometheus.MustRegister(g)
+		p.gauges[key] = g
+	}
+	g.Set(float64(val))
+}
+
+func (p *PrometheusSink) AddSample(parts []string, val float32) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	key := p.flattenKey(parts)
+	g, ok := p.summaries[key]
+	if !ok {
+		g = prometheus.NewSummary(prometheus.SummaryOpts{
+			Name:   key,
+			Help:   key,
+			MaxAge: 10 * time.Second,
+		})
+		prometheus.MustRegister(g)
+		p.summaries[key] = g
+	}
+	g.Observe(float64(val))
+}
+
+// EmitKey is not implemented. Prometheus doesn’t offer a type for which an
+// arbitrary number of values is retained, as Prometheus works with a pull
+// model, rather than a push model.
+func (p *PrometheusSink) EmitKey(key []string, val float32) {
+}
+
+func (p *PrometheusSink) IncrCounter(parts []string, val float32) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	key := p.flattenKey(parts)
+	g, ok := p.counters[key]
+	if !ok {
+		g = prometheus.NewCounter(prometheus.CounterOpts{
+			Name: key,
+			Help: key,
+		})
+		prometheus.MustRegister(g)
+		p.counters[key] = g
+	}
+	g.Add(float64(val))
+}


### PR DESCRIPTION
Related issue: #1230 
This is a first draft of how to expose metrics to Prometheus, using the support built-in in go-metrics. 
The main pain point is likely in how the http endpoint is registered - I'm not sure how to best go about it. It should only be registered if the config option is enabled, for a start, and probably not in the main handler package. Can/should the mount mechanism be used?

Also, I would prefer if it would be possible to set `DisableHostname` when exporting to Prometheus (the hostname will be collected as part of the scrape anyway). However, if some users want to have multiple telemetry options enabled, it shouldn't affect all of them, I think. I don't see an easy way to change it to per-telemetry sink, though. Maybe creating some per-sink option-map? Might be a bit over-doing it?