### PR TITLE
Use Consul API client's DefaultNonPooledTransport.

### DIFF
--- a/builtin/logical/consul/client.go
+++ b/builtin/logical/consul/client.go
@@ -23,7 +23,7 @@ func client(s logical.Storage) (*api.Client, error) {
 		return nil, fmt.Errorf("error reading root configuration: %s", err)
 	}
 
-	consulConf := api.DefaultConfig()
+	consulConf := api.DefaultNonPooledConfig()
 	consulConf.Address = conf.Address
 	consulConf.Scheme = conf.Scheme
 	consulConf.Token = conf.Token


### PR DESCRIPTION
What we should probably do is create a client with a mutex and
invalidate it when parameters change rather than creating a client over
and over...that can be a TODO for later but for now this fix suffices.

Fixes #1428