### PR TITLE
Enable audit-logging of seal and step-down commands.

### DIFF
--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -13,19 +13,21 @@ import (
 
 func handleSysSeal(core *vault.Core) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case "PUT":
-		case "POST":
+		req, statusCode, err := buildLogicalRequest(w, r)
+		if err != nil || statusCode != 0 {
+			respondError(w, statusCode, err)
+			return
+		}
+
+		switch req.Operation {
+		case logical.UpdateOperation:
 		default:
 			respondError(w, http.StatusMethodNotAllowed, nil)
 			return
 		}
 
-		// Get the auth for the request so we can access the token directly
-		req := requestAuth(r, &logical.Request{})
-
 		// Seal with the token above
-		if err := core.Seal(req.ClientToken); err != nil {
+		if err := core.SealWithRequest(req); err != nil {
 			respondError(w, http.StatusInternalServerError, err)
 			return
 		}
@@ -36,19 +38,21 @@ func handleSysSeal(core *vault.Core) http.Handler {
 
 func handleSysStepDown(core *vault.Core) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case "PUT":
-		case "POST":
+		req, statusCode, err := buildLogicalRequest(w, r)
+		if err != nil || statusCode != 0 {
+			respondError(w, statusCode, err)
+			return
+		}
+
+		switch req.Operation {
+		case logical.UpdateOperation:
 		default:
 			respondError(w, http.StatusMethodNotAllowed, nil)
 			return
 		}
 
-		// Get the auth for the request so we can access the token directly
-		req := requestAuth(r, &logical.Request{})
-
 		// Seal with the token above
-		if err := core.StepDown(req.ClientToken); err != nil {
+		if err := core.StepDown(req); err != nil {
 			respondError(w, http.StatusInternalServerError, err)
 			return
 		}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -1148,8 +1148,13 @@ func TestCore_StepDown(t *testing.T) {
 		t.Fatalf("Bad advertise: %v", advertise)
 	}
 
+	req := &logical.Request{
+		ClientToken: root,
+		Path:        "sys/step-down",
+	}
+
 	// Step down core
-	err = core.StepDown(root)
+	err = core.StepDown(req)
 	if err != nil {
 		t.Fatal("error stepping down core 1")
 	}
@@ -1191,7 +1196,7 @@ func TestCore_StepDown(t *testing.T) {
 	}
 
 	// Step down core2
-	err = core2.StepDown(root)
+	err = core2.StepDown(req)
 	if err != nil {
 		t.Fatal("error stepping down core 1")
 	}


### PR DESCRIPTION
This pulls the logical request building code into its own function so
that it's accessible from other HTTP handlers, then uses that with some
added logic to the Seal() and StepDown() commands to have meaningful
audit log entries.