### PR TITLE
cookies are in fact passed via HTTP headers

### DIFF
--- a/website/source/docs/internals/architecture.html.md
+++ b/website/source/docs/internals/architecture.html.md
@@ -55,7 +55,7 @@ clarify what is being discussed:
 * **Client Token** - A client token is a conceptually similar to a session cookie on a web site.
   Once a user authenticates, Vault returns a client token which is used for future requests.
   The token is used by Vault to verify the identity of the client and to enforce the applicable
-  ACL policies. Unlike a cookie on a web site, this token is passed via HTTP headers.
+  ACL policies. Like a cookie on a web site, this token is passed via HTTP headers.
 
 * **Secret** - A secret is the term for anything returned by Vault which contains confidential
   or cryptographic material. Not everything returned by Vault is a secret, for example


### PR DESCRIPTION
Per [RFC 6265 § 3.1](https://tools.ietf.org/html/rfc6265#section-3.1),  and now-historic RFCs [2965](https://tools.ietf.org/html/rfc2965), and [2109](https://tools.ietf.org/html/rfc2109), cookies on a web site are passed via HTTP headers.