### PR TITLE
Reading consul access configuration in the consul secret backend.

### DIFF
--- a/builtin/logical/consul/backend_test.go
+++ b/builtin/logical/consul/backend_test.go
@@ -43,6 +43,11 @@ func createBackend() *backend {
 }
 
 func TestBackend_config_access(t *testing.T) {
+	if os.Getenv(logicaltest.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", logicaltest.TestEnvVar))
+		return
+	}
+
 	accessConfig, process := testStartConsulServer(t)
 	defer testStopConsulServer(t, process)
 

--- a/builtin/logical/consul/backend_test.go
+++ b/builtin/logical/consul/backend_test.go
@@ -8,15 +8,83 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
 	logicaltest "github.com/hashicorp/vault/logical/testing"
 	"github.com/mitchellh/mapstructure"
 )
+
+func createBackend() *backend {
+	var b backend
+	b.Backend = &framework.Backend{
+		PathsSpecial: &logical.Paths{
+			Root: []string{
+				"config/*",
+			},
+		},
+
+		Paths: []*framework.Path{
+			pathConfigAccess(),
+			pathRoles(),
+			pathToken(&b),
+		},
+
+		Secrets: []*framework.Secret{
+			secretToken(&b),
+		},
+	}
+	return &b
+}
+
+func TestBackend_config_access(t *testing.T) {
+	accessConfig, process := testStartConsulServer(t)
+	defer testStopConsulServer(t, process)
+
+	config := logical.TestBackendConfig()
+	storage := &logical.InmemStorage{}
+	config.StorageView = storage
+
+	b := createBackend()
+	_, err := b.Backend.Setup(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	confReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/access",
+		Storage:   storage,
+		Data:      accessConfig,
+	}
+
+	resp, err := b.HandleRequest(confReq)
+	if err != nil || (resp != nil && resp.IsError()) || resp != nil {
+		t.Fatalf("failed to write configuration: resp:%#v err:%s", resp, err)
+	}
+
+	confReq.Operation = logical.ReadOperation
+	resp, err = b.HandleRequest(confReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("failed to write configuration: resp:%#v err:%s", resp, err)
+	}
+
+	expected := map[string]interface{}{
+		"address": "127.0.0.1:8500",
+		"scheme":  "http",
+	}
+	if !reflect.DeepEqual(expected, resp.Data) {
+		t.Fatalf("bad: expected:%#v\nactual:%#v\n", expected, resp.Data)
+	}
+	if resp.Data["token"] != nil {
+		t.Fatalf("token should not be set in the response")
+	}
+}
 
 func TestBackend_basic(t *testing.T) {
 	if os.Getenv(logicaltest.TestEnvVar) == "" {

--- a/builtin/logical/consul/path_config.go
+++ b/builtin/logical/consul/path_config.go
@@ -1,6 +1,8 @@
 package consul
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -31,9 +33,52 @@ func pathConfigAccess() *framework.Path {
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation:   pathConfigAccessRead,
 			logical.UpdateOperation: pathConfigAccessWrite,
 		},
 	}
+}
+
+func readConfigAccess(storage logical.Storage) (*accessConfig, error, error) {
+	entry, err := storage.Get("config/access")
+	if err != nil {
+		return nil, nil, err
+	}
+	if entry == nil {
+		return nil, fmt.Errorf(
+				"Access credentials for the backend itself haven't been configured. Please configure them at the '/config/access' endpoint"),
+			nil
+	}
+
+	conf := &accessConfig{}
+	if err := entry.DecodeJSON(conf); err != nil {
+		return nil, nil, fmt.Errorf("error reading root configuration: %s", err)
+	}
+
+	return conf, nil, nil
+}
+
+func pathConfigAccessRead(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	conf, userErr, intErr := readConfigAccess(req.Storage)
+	if intErr != nil {
+		return nil, intErr
+	}
+	if userErr != nil {
+		return logical.ErrorResponse(userErr.Error()), nil
+	}
+	if conf == nil {
+		return nil, fmt.Errorf("no user error reported but configuration not found")
+	}
+
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"address": conf.Address,
+			"scheme":  conf.Scheme,
+		},
+	}
+
+	return resp, nil
 }
 
 func pathConfigAccessWrite(

--- a/builtin/logical/consul/path_config.go
+++ b/builtin/logical/consul/path_config.go
@@ -52,7 +52,7 @@ func readConfigAccess(storage logical.Storage) (*accessConfig, error, error) {
 
 	conf := &accessConfig{}
 	if err := entry.DecodeJSON(conf); err != nil {
-		return nil, nil, fmt.Errorf("error reading root configuration: %s", err)
+		return nil, nil, fmt.Errorf("error reading consul access configuration: %s", err)
 	}
 
 	return conf, nil, nil
@@ -68,17 +68,15 @@ func pathConfigAccessRead(
 		return logical.ErrorResponse(userErr.Error()), nil
 	}
 	if conf == nil {
-		return nil, fmt.Errorf("no user error reported but configuration not found")
+		return nil, fmt.Errorf("no user error reported but consul access configuration not found")
 	}
 
-	resp := &logical.Response{
+	return &logical.Response{
 		Data: map[string]interface{}{
 			"address": conf.Address,
 			"scheme":  conf.Scheme,
 		},
-	}
-
-	return resp, nil
+	}, nil
 }
 
 func pathConfigAccessWrite(

--- a/builtin/logical/consul/path_token.go
+++ b/builtin/logical/consul/path_token.go
@@ -47,8 +47,11 @@ func (b *backend) pathTokenRead(
 	}
 
 	// Get the consul client
-	c, err := client(req.Storage)
-	if err != nil {
+	c, userErr, intErr := client(req.Storage)
+	if intErr != nil {
+		return nil, intErr
+	}
+	if userErr != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
 


### PR DESCRIPTION
The `token` will not be sent in the response.