### PR TITLE
#1486 : Fixed sealed and leader checks for consul backend

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -301,14 +301,14 @@ func (c *ServerCommand) Run(args []string) int {
 		sd, ok := coreConfig.HAPhysical.(physical.ServiceDiscovery)
 		if ok {
 			activeFunc := func() bool {
-				if isLeader, _, err := core.Leader(); err != nil {
+				if isLeader, _, err := core.Leader(); err == nil {
 					return isLeader
 				}
 				return false
 			}
 
 			sealedFunc := func() bool {
-				if sealed, err := core.Sealed(); err != nil {
+				if sealed, err := core.Sealed(); err == nil {
 					return sealed
 				}
 				return true


### PR DESCRIPTION
The changes in consul.go were supplied by @sean- which simplify reasoning about the return value of sealedFunc(), but the real issue was that the activeFunc and sealedFunc closures mistakenly always return false and true respectively if there is **_not_** an error when looking up that state.

Looks like there are no tests for these functions, but I'm not familiar enough with the codebase to know where a good spot to add some would be.

(As reported in #1486)