### PR TITLE
Add creation time to returned wrapped token info

### DIFF
--- a/api/secret.go
+++ b/api/secret.go
@@ -32,8 +32,9 @@ type Secret struct {
 
 // SecretWrapInfo contains wrapping information if we have it.
 type SecretWrapInfo struct {
-	Token string `json:"token"`
-	TTL   int    `json:"ttl"`
+	Token        string `json:"token"`
+	TTL          int    `json:"ttl"`
+	CreationTime int64  `json:"creation_time"`
 }
 
 // SecretAuth is the structure containing auth information if we have it.

--- a/api/secret.go
+++ b/api/secret.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"io"
+	"time"
 )
 
 // Secret is the structure returned for every secret within Vault.
@@ -32,9 +33,9 @@ type Secret struct {
 
 // SecretWrapInfo contains wrapping information if we have it.
 type SecretWrapInfo struct {
-	Token        string `json:"token"`
-	TTL          int    `json:"ttl"`
-	CreationTime int64  `json:"creation_time"`
+	Token        string    `json:"token"`
+	TTL          int       `json:"ttl"`
+	CreationTime time.Time `json:"creation_time"`
 }
 
 // SecretAuth is the structure containing auth information if we have it.

--- a/api/secret_test.go
+++ b/api/secret_test.go
@@ -20,7 +20,8 @@ func TestParseSecret(t *testing.T) {
 	],
 	"wrap_info": {
 		"token": "token",
-		"ttl": 60
+		"ttl": 60,
+		"creation_time": 100000
 	}
 }`)
 
@@ -40,8 +41,9 @@ func TestParseSecret(t *testing.T) {
 			"a warning!",
 		},
 		WrapInfo: &SecretWrapInfo{
-			Token: "token",
-			TTL:   60,
+			Token:        "token",
+			TTL:          60,
+			CreationTime: int64(100000),
 		},
 	}
 	if !reflect.DeepEqual(secret, expected) {

--- a/api/secret_test.go
+++ b/api/secret_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseSecret(t *testing.T) {
@@ -21,9 +22,11 @@ func TestParseSecret(t *testing.T) {
 	"wrap_info": {
 		"token": "token",
 		"ttl": 60,
-		"creation_time": 100000
+		"creation_time": "2016-06-07T15:52:10-04:00"
 	}
 }`)
+
+	rawTime, _ := time.Parse(time.RFC3339, "2016-06-07T15:52:10-04:00")
 
 	secret, err := ParseSecret(strings.NewReader(raw))
 	if err != nil {
@@ -43,10 +46,10 @@ func TestParseSecret(t *testing.T) {
 		WrapInfo: &SecretWrapInfo{
 			Token:        "token",
 			TTL:          60,
-			CreationTime: int64(100000),
+			CreationTime: rawTime,
 		},
 	}
 	if !reflect.DeepEqual(secret, expected) {
-		t.Fatalf("bad: %#v %#v", secret, expected)
+		t.Fatalf("bad:\ngot\n%#v\nexpected\n%#v\n", secret, expected)
 	}
 }

--- a/audit/format_json.go
+++ b/audit/format_json.go
@@ -46,7 +46,7 @@ func (f *FormatJSON) FormatRequest(
 			Path:        req.Path,
 			Data:        req.Data,
 			RemoteAddr:  getRemoteAddr(req),
-			WrapTTL:     int64(req.WrapTTL / time.Second),
+			WrapTTL:     int(req.WrapTTL / time.Second),
 		},
 	})
 }
@@ -90,8 +90,9 @@ func (f *FormatJSON) FormatResponse(
 	var respWrapInfo *JSONWrapInfo
 	if resp.WrapInfo != nil {
 		respWrapInfo = &JSONWrapInfo{
-			TTL:   int64(resp.WrapInfo.TTL / time.Second),
-			Token: resp.WrapInfo.Token,
+			TTL:          int(resp.WrapInfo.TTL / time.Second),
+			Token:        resp.WrapInfo.Token,
+			CreationTime: resp.WrapInfo.CreationTime,
 		}
 	}
 
@@ -113,7 +114,7 @@ func (f *FormatJSON) FormatResponse(
 			Path:       req.Path,
 			Data:       req.Data,
 			RemoteAddr: getRemoteAddr(req),
-			WrapTTL:    int64(req.WrapTTL / time.Second),
+			WrapTTL:    int(req.WrapTTL / time.Second),
 		},
 
 		Response: JSONResponse{
@@ -151,7 +152,7 @@ type JSONRequest struct {
 	Path        string                 `json:"path"`
 	Data        map[string]interface{} `json:"data"`
 	RemoteAddr  string                 `json:"remote_address"`
-	WrapTTL     int64                  `json:"wrap_ttl"`
+	WrapTTL     int                    `json:"wrap_ttl"`
 }
 
 type JSONResponse struct {
@@ -175,8 +176,9 @@ type JSONSecret struct {
 }
 
 type JSONWrapInfo struct {
-	TTL   int64  `json:"ttl"`
-	Token string `json:"token"`
+	TTL          int    `json:"ttl"`
+	Token        string `json:"token"`
+	CreationTime int64  `json:"creation_time"`
 }
 
 // getRemoteAddr safely gets the remote address avoiding a nil pointer

--- a/audit/format_json.go
+++ b/audit/format_json.go
@@ -176,9 +176,9 @@ type JSONSecret struct {
 }
 
 type JSONWrapInfo struct {
-	TTL          int    `json:"ttl"`
-	Token        string `json:"token"`
-	CreationTime int64  `json:"creation_time"`
+	TTL          int       `json:"ttl"`
+	Token        string    `json:"token"`
+	CreationTime time.Time `json:"creation_time"`
 }
 
 // getRemoteAddr safely gets the remote address avoiding a nil pointer

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -68,8 +68,9 @@ func TestCopy_response(t *testing.T) {
 			"foo": "bar",
 		},
 		WrapInfo: &logical.WrapInfo{
-			TTL:   60,
-			Token: "foo",
+			TTL:          60,
+			Token:        "foo",
+			CreationTime: 100000,
 		},
 	}
 	arg := expected
@@ -137,8 +138,9 @@ func TestHash(t *testing.T) {
 					"foo": "bar",
 				},
 				WrapInfo: &logical.WrapInfo{
-					TTL:   60,
-					Token: "bar",
+					TTL:          60,
+					Token:        "bar",
+					CreationTime: 100000,
 				},
 			},
 			&logical.Response{
@@ -146,8 +148,9 @@ func TestHash(t *testing.T) {
 					"foo": "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
 				},
 				WrapInfo: &logical.WrapInfo{
-					TTL:   60,
-					Token: "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
+					TTL:          60,
+					Token:        "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
+					CreationTime: 100000,
 				},
 			},
 		},

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -70,7 +70,7 @@ func TestCopy_response(t *testing.T) {
 		WrapInfo: &logical.WrapInfo{
 			TTL:          60,
 			Token:        "foo",
-			CreationTime: 100000,
+			CreationTime: time.Now(),
 		},
 	}
 	arg := expected
@@ -140,7 +140,7 @@ func TestHash(t *testing.T) {
 				WrapInfo: &logical.WrapInfo{
 					TTL:          60,
 					Token:        "bar",
-					CreationTime: 100000,
+					CreationTime: now,
 				},
 			},
 			&logical.Response{
@@ -150,7 +150,7 @@ func TestHash(t *testing.T) {
 				WrapInfo: &logical.WrapInfo{
 					TTL:          60,
 					Token:        "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
-					CreationTime: 100000,
+					CreationTime: now,
 				},
 			},
 		},

--- a/command/format.go
+++ b/command/format.go
@@ -160,6 +160,7 @@ func (t TableFormatter) OutputSecret(ui cli.Ui, secret, s *api.Secret) error {
 	if s.WrapInfo != nil {
 		input = append(input, fmt.Sprintf("wrapping_token: %s %s", config.Delim, s.WrapInfo.Token))
 		input = append(input, fmt.Sprintf("wrapping_token_ttl: %s %d", config.Delim, s.WrapInfo.TTL))
+		input = append(input, fmt.Sprintf("wrapping_token_creation_time: %s %d", config.Delim, s.WrapInfo.CreationTime))
 	}
 
 	keys := make([]string, 0, len(s.Data))

--- a/command/format.go
+++ b/command/format.go
@@ -160,7 +160,7 @@ func (t TableFormatter) OutputSecret(ui cli.Ui, secret, s *api.Secret) error {
 	if s.WrapInfo != nil {
 		input = append(input, fmt.Sprintf("wrapping_token: %s %s", config.Delim, s.WrapInfo.Token))
 		input = append(input, fmt.Sprintf("wrapping_token_ttl: %s %d", config.Delim, s.WrapInfo.TTL))
-		input = append(input, fmt.Sprintf("wrapping_token_creation_time: %s %d", config.Delim, s.WrapInfo.CreationTime))
+		input = append(input, fmt.Sprintf("wrapping_token_creation_time: %s %s", config.Delim, s.WrapInfo.CreationTime.String()))
 	}
 
 	keys := make([]string, 0, len(s.Data))

--- a/command/util.go
+++ b/command/util.go
@@ -42,7 +42,7 @@ func PrintRawField(ui cli.Ui, secret *api.Secret, field string) int {
 		}
 	case "wrapping_token_creation_time":
 		if secret.WrapInfo != nil {
-			val = secret.WrapInfo.CreationTime
+			val = secret.WrapInfo.CreationTime.String()
 		}
 	case "refresh_interval":
 		val = secret.LeaseDuration

--- a/command/util.go
+++ b/command/util.go
@@ -40,6 +40,10 @@ func PrintRawField(ui cli.Ui, secret *api.Secret, field string) int {
 		if secret.WrapInfo != nil {
 			val = secret.WrapInfo.TTL
 		}
+	case "wrapping_token_creation_time":
+		if secret.WrapInfo != nil {
+			val = secret.WrapInfo.CreationTime
+		}
 	case "refresh_interval":
 		val = secret.LeaseDuration
 	default:

--- a/http/handler.go
+++ b/http/handler.go
@@ -185,6 +185,9 @@ func requestWrapTTL(r *http.Request, req *logical.Request) (*logical.Request, er
 		}
 		req.WrapTTL = time.Duration(seconds) * time.Second
 	}
+	if int64(req.WrapTTL) < 0 {
+		return req, fmt.Errorf("requested wrap ttl cannot be negative")
+	}
 
 	return req, nil
 }

--- a/http/logical.go
+++ b/http/logical.go
@@ -163,8 +163,9 @@ func respondLogical(w http.ResponseWriter, r *http.Request, path string, dataOnl
 		if resp.WrapInfo != nil && resp.WrapInfo.Token != "" {
 			httpResp = logical.HTTPResponse{
 				WrapInfo: &logical.HTTPWrapInfo{
-					Token: resp.WrapInfo.Token,
-					TTL:   int(resp.WrapInfo.TTL.Seconds()),
+					Token:        resp.WrapInfo.Token,
+					TTL:          int(resp.WrapInfo.TTL.Seconds()),
+					CreationTime: resp.WrapInfo.CreationTime,
 				},
 			}
 		} else {

--- a/logical/response.go
+++ b/logical/response.go
@@ -35,9 +35,9 @@ type WrapInfo struct {
 	// The token containing the wrapped response
 	Token string
 
-	// The creation time in seconds since Unix epoch. This can be used with the
-	// TTL to figure out an expected expiration.
-	CreationTime int64
+	// The creation time. This can be used with the TTL to figure out an
+	// expected expiration.
+	CreationTime time.Time
 }
 
 // Response is a struct that stores the response of a request.

--- a/logical/response.go
+++ b/logical/response.go
@@ -34,6 +34,10 @@ type WrapInfo struct {
 
 	// The token containing the wrapped response
 	Token string
+
+	// The creation time in seconds since Unix epoch. This can be used with the
+	// TTL to figure out an expected expiration.
+	CreationTime int64
 }
 
 // Response is a struct that stores the response of a request.

--- a/logical/sanitize.go
+++ b/logical/sanitize.go
@@ -1,5 +1,7 @@
 package logical
 
+import "time"
+
 // This logic was pulled from the http package so that it can be used for
 // encoding wrapped responses as well. It simply translates the logical request
 // to an http response, with the values we want and omitting the values we
@@ -52,7 +54,7 @@ type HTTPAuth struct {
 }
 
 type HTTPWrapInfo struct {
-	Token        string `json:"token"`
-	TTL          int    `json:"ttl"`
-	CreationTime int64  `json:"creation_time"`
+	Token        string    `json:"token"`
+	TTL          int       `json:"ttl"`
+	CreationTime time.Time `json:"creation_time"`
 }

--- a/logical/sanitize.go
+++ b/logical/sanitize.go
@@ -52,6 +52,7 @@ type HTTPAuth struct {
 }
 
 type HTTPWrapInfo struct {
-	Token string `json:"token"`
-	TTL   int    `json:"ttl"`
+	Token        string `json:"token"`
+	TTL          int    `json:"ttl"`
+	CreationTime int64  `json:"creation_time"`
 }

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -376,11 +376,12 @@ func (c *Core) wrapInCubbyhole(req *logical.Request, resp *logical.Response) (*l
 	// wrapping token ID in the audit logs, so that it can be determined from
 	// the audit logs whether the token was ever actually used.
 	te := TokenEntry{
-		Path:         req.Path,
-		Policies:     []string{"cubbyhole-response-wrapping"},
-		CreationTime: time.Now().Unix(),
-		TTL:          resp.WrapInfo.TTL,
-		NumUses:      1,
+		Path:           req.Path,
+		Policies:       []string{"cubbyhole-response-wrapping"},
+		CreationTime:   time.Now().Unix(),
+		TTL:            resp.WrapInfo.TTL,
+		NumUses:        1,
+		ExplicitMaxTTL: resp.WrapInfo.TTL,
 	}
 
 	if err := c.tokenStore.create(&te); err != nil {
@@ -389,6 +390,7 @@ func (c *Core) wrapInCubbyhole(req *logical.Request, resp *logical.Response) (*l
 	}
 
 	resp.WrapInfo.Token = te.ID
+	resp.WrapInfo.CreationTime = te.CreationTime
 
 	httpResponse := logical.SanitizeResponse(resp)
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -375,10 +375,11 @@ func (c *Core) wrapInCubbyhole(req *logical.Request, resp *logical.Response) (*l
 	// before auditing so that resp.WrapInfo.Token can contain the HMAC'd
 	// wrapping token ID in the audit logs, so that it can be determined from
 	// the audit logs whether the token was ever actually used.
+	creationTime := time.Now()
 	te := TokenEntry{
 		Path:           req.Path,
 		Policies:       []string{"cubbyhole-response-wrapping"},
-		CreationTime:   time.Now().Unix(),
+		CreationTime:   creationTime.Unix(),
 		TTL:            resp.WrapInfo.TTL,
 		NumUses:        1,
 		ExplicitMaxTTL: resp.WrapInfo.TTL,
@@ -390,7 +391,7 @@ func (c *Core) wrapInCubbyhole(req *logical.Request, resp *logical.Response) (*l
 	}
 
 	resp.WrapInfo.Token = te.ID
-	resp.WrapInfo.CreationTime = te.CreationTime
+	resp.WrapInfo.CreationTime = creationTime
 
 	httpResponse := logical.SanitizeResponse(resp)
 


### PR DESCRIPTION
This makes it easier to understand the expected lifetime without a
lookup call that uses the single use left on the token.

This also adds a couple of safety checks and for JSON uses int, rather
than int64, for the TTL for the wrapped token.