### PR TITLE
Don't check parsability of a `ttl` key on write.

### DIFF
--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -34,12 +34,6 @@ func LeaseSwitchedPassthroughBackend(conf *logical.BackendConfig, leases bool) (
 		Paths: []*framework.Path{
 			&framework.Path{
 				Pattern: ".*",
-				Fields: map[string]*framework.FieldSchema{
-					"ttl": &framework.FieldSchema{
-						Type:        framework.TypeString,
-						Description: "TTL time for this key when read. Ex: 1h",
-					},
-				},
 
 				Callbacks: map[logical.Operation]framework.OperationFunc{
 					logical.ReadOperation:   b.handleRead,


### PR DESCRIPTION
On read we already ignore bad values, so we shouldn't be restricting
this on write; doing so alters expected data-in-data-out behavior. In
addition, don't issue a warning if a given `ttl` value can't be parsed,
as this can quickly get annoying if it's on purpose.

The documentation has been updated/clarified to make it clear that this
is optional behavior that doesn't affect the status of the key as POD
and the `lease_duration` returned will otherwise default to the
system/mount defaults.

Fixes #1505