### PR TITLE
Support HEAD requests to /v1/sys/health

### DIFF
--- a/http/sys_health_test.go
+++ b/http/sys_health_test.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"io/ioutil"
+
 	"net/http"
 	"net/url"
 	"reflect"
@@ -103,5 +105,43 @@ func TestSysHealth_customcodes(t *testing.T) {
 	expected["server_time_utc"] = actual["server_time_utc"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestSysHealth_head(t *testing.T) {
+	core, _, _ := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+
+	testData := []struct{
+		uri  string
+		code int
+	}{
+		{"", 200},
+		{"?activecode=503", 503},
+		{"?activecode=notacode", 400},
+	}
+
+	for _, tt := range testData {
+		queryurl, err := url.Parse(addr + "/v1/sys/health" + tt.uri)
+		if err != nil {
+			t.Fatalf("err on %v: %s", queryurl, err)
+		}
+		resp, err := http.Head(queryurl.String())
+		if err != nil {
+			t.Fatalf("err on %v: %s", queryurl, err)
+		}
+
+		if resp.StatusCode != tt.code {
+			t.Fatalf("HEAD %v expected code %d, got %d.", queryurl, tt.code, resp.StatusCode)
+		}
+
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("err on %v: %s", queryurl, err)
+		}
+		if len(data) > 0 {
+			t.Fatalf("HEAD %v expected no body, received \"%v\".", queryurl, data)
+		}
 	}
 }


### PR DESCRIPTION
Some load balancers send HTTP HEAD requests to extract the status code.