### PR TITLE
Backend() functions should return 'backend' objects.

### DIFF
--- a/builtin/credential/github/backend.go
+++ b/builtin/credential/github/backend.go
@@ -12,7 +12,7 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 	return Backend().Setup(conf)
 }
 
-func Backend() *framework.Backend {
+func Backend() *backend {
 	var b backend
 	b.Map = &framework.PolicyMap{
 		PathMap: framework.PathMap{
@@ -37,7 +37,7 @@ func Backend() *framework.Backend {
 		AuthRenew: b.pathLoginRenew,
 	}
 
-	return b.Backend
+	return &b
 }
 
 type backend struct {

--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -15,7 +15,7 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 	return Backend().Setup(conf)
 }
 
-func Backend() *framework.Backend {
+func Backend() *backend {
 	var b backend
 	b.Backend = &framework.Backend{
 		Help: backendHelp,
@@ -41,7 +41,7 @@ func Backend() *framework.Backend {
 		AuthRenew: b.pathLoginRenew,
 	}
 
-	return b.Backend
+	return &b
 }
 
 type backend struct {

--- a/builtin/credential/userpass/backend.go
+++ b/builtin/credential/userpass/backend.go
@@ -10,7 +10,7 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 	return Backend().Setup(conf)
 }
 
-func Backend() *framework.Backend {
+func Backend() *backend {
 	var b backend
 	b.Backend = &framework.Backend{
 		Help: backendHelp,
@@ -35,7 +35,7 @@ func Backend() *framework.Backend {
 		AuthRenew: b.pathLoginRenew,
 	}
 
-	return b.Backend
+	return &b
 }
 
 type backend struct {

--- a/builtin/logical/aws/backend.go
+++ b/builtin/logical/aws/backend.go
@@ -12,7 +12,7 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 	return Backend().Setup(conf)
 }
 
-func Backend() *framework.Backend {
+func Backend() *backend {
 	var b backend
 	b.Backend = &framework.Backend{
 		Help: strings.TrimSpace(backendHelp),
@@ -33,7 +33,7 @@ func Backend() *framework.Backend {
 		WALRollbackMinAge: 5 * time.Minute,
 	}
 
-	return b.Backend
+	return &b
 }
 
 type backend struct {

--- a/builtin/logical/cassandra/backend.go
+++ b/builtin/logical/cassandra/backend.go
@@ -16,7 +16,7 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 }
 
 // Backend contains the base information for the backend's functionality
-func Backend() *framework.Backend {
+func Backend() *backend {
 	var b backend
 	b.Backend = &framework.Backend{
 		Help: strings.TrimSpace(backendHelp),
@@ -32,7 +32,7 @@ func Backend() *framework.Backend {
 		},
 	}
 
-	return b.Backend
+	return &b
 }
 
 type backend struct {

--- a/builtin/logical/mssql/backend.go
+++ b/builtin/logical/mssql/backend.go
@@ -15,7 +15,7 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 	return Backend().Setup(conf)
 }
 
-func Backend() *framework.Backend {
+func Backend() *backend {
 	var b backend
 	b.Backend = &framework.Backend{
 		Help: strings.TrimSpace(backendHelp),
@@ -33,7 +33,7 @@ func Backend() *framework.Backend {
 		},
 	}
 
-	return b.Backend
+	return &b
 }
 
 type backend struct {

--- a/builtin/logical/mysql/backend.go
+++ b/builtin/logical/mysql/backend.go
@@ -15,7 +15,7 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 	return Backend().Setup(conf)
 }
 
-func Backend() *framework.Backend {
+func Backend() *backend {
 	var b backend
 	b.Backend = &framework.Backend{
 		Help: strings.TrimSpace(backendHelp),
@@ -33,7 +33,7 @@ func Backend() *framework.Backend {
 		},
 	}
 
-	return b.Backend
+	return &b
 }
 
 type backend struct {

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -15,7 +15,7 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 }
 
 // Backend returns a new Backend framework struct
-func Backend() *framework.Backend {
+func Backend() *backend {
 	var b backend
 	b.Backend = &framework.Backend{
 		Help: strings.TrimSpace(backendHelp),
@@ -60,7 +60,7 @@ func Backend() *framework.Backend {
 
 	b.crlLifetime = time.Hour * 72
 
-	return b.Backend
+	return &b
 }
 
 type backend struct {

--- a/builtin/logical/postgresql/backend.go
+++ b/builtin/logical/postgresql/backend.go
@@ -14,7 +14,7 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 	return Backend().Setup(conf)
 }
 
-func Backend() *framework.Backend {
+func Backend() *backend {
 	var b backend
 	b.Backend = &framework.Backend{
 		Help: strings.TrimSpace(backendHelp),
@@ -34,7 +34,7 @@ func Backend() *framework.Backend {
 		Clean: b.ResetDB,
 	}
 
-	return b.Backend
+	return &b
 }
 
 type backend struct {


### PR DESCRIPTION
If they return pointers to 'framework.Backend' objects, the receiver functions can't be tested.