### PR TITLE
Adding IAM Role ARN as a constraint for EC2 authentication

### DIFF
--- a/builtin/credential/aws-ec2/path_login.go
+++ b/builtin/credential/aws-ec2/path_login.go
@@ -252,12 +252,12 @@ func (b *backend) pathLoginUpdate(
 	}
 
 	// Check if the IAM Role ARN of the instance trying to login matches the
-  // IAM Role ARN specified as a constraint on the role.
-  iamRoleArn := ""
-  iamRoleArn = *instanceDesc.Reservations[0].Instances[0].IamInstanceProfile.Arn
-  if roleEntry.BoundIamARN != "" && iamRoleArn != roleEntry.BoundIamARN {
-  	return logical.ErrorResponse(fmt.Sprintf("IAM Role ARN %s does not belong to role %s", iamRoleArn, roleName)), nil
-  }
+	// IAM Role ARN specified as a constraint on the role.
+	iamRoleArn := ""
+	iamRoleArn = *instanceDesc.Reservations[0].Instances[0].IamInstanceProfile.Arn
+	if roleEntry.BoundIamARN != "" && iamRoleArn != roleEntry.BoundIamARN {
+		return logical.ErrorResponse(fmt.Sprintf("IAM Role ARN %s does not belong to role %s", iamRoleArn, roleName)), nil
+	}
 
 	// Get the entry from the identity whitelist, if there is one.
 	storedIdentity, err := whitelistIdentityEntry(req.Storage, identityDoc.InstanceID)

--- a/builtin/credential/aws-ec2/path_login.go
+++ b/builtin/credential/aws-ec2/path_login.go
@@ -253,10 +253,18 @@ func (b *backend) pathLoginUpdate(
 
 	// Check if the IAM Role ARN of the instance trying to login matches the
 	// IAM Role ARN specified as a constraint on the role.
-	iamRoleArn := ""
-	iamRoleArn = *instanceDesc.Reservations[0].Instances[0].IamInstanceProfile.Arn
-	if roleEntry.BoundIamARN != "" && iamRoleArn != roleEntry.BoundIamARN {
-		return logical.ErrorResponse(fmt.Sprintf("IAM Role ARN %s does not belong to role %s", iamRoleArn, roleName)), nil
+	if roleEntry.BoundIamARN != "" {
+		if instanceDesc.Reservations[0].Instances[0].IamInstanceProfile == nil {
+			return nil, fmt.Errorf("Iam instance profile in instance description is nil")
+		}
+		if instanceDesc.Reservations[0].Instances[0].IamInstanceProfile.Arn == nil {
+			return nil, fmt.Errorf("ARN in instance description is nil")
+		}
+		iamRoleArn := ""
+		iamRoleArn = *instanceDesc.Reservations[0].Instances[0].IamInstanceProfile.Arn
+		if iamRoleArn != roleEntry.BoundIamARN {
+			return logical.ErrorResponse(fmt.Sprintf("IAM Role ARN %s does not belong to role %s", iamRoleArn, roleName)), nil
+		}
 	}
 
 	// Get the entry from the identity whitelist, if there is one.

--- a/website/source/docs/auth/aws-ec2.html.md
+++ b/website/source/docs/auth/aws-ec2.html.md
@@ -92,7 +92,7 @@ Subsequent authentication attempts by the client require the nonce to match;
 since only the original client knows the nonce, only the original client is
 allowed to reauthenticate. (This is the reason that this is a whitelist rather
 than a blacklist; by default, it's keeping track of clients allowed to
-reauthenticate, rather than those that are not.) 
+reauthenticate, rather than those that are not.)
 
 It is up to the client to behave correctly with respect to the nonce; if the
 client stores the nonce on disk it can survive reboots, but could also give
@@ -405,7 +405,7 @@ The response will be in JSON. For example:
   <dt>Description</dt>
     Returns the previously configured AWS access credentials.
   <dd>
-    
+
   </dd>
 
   <dt>Method</dt>
@@ -817,6 +817,11 @@ The response will be in JSON. For example:
         <span class="param">bound_ami_id</span>
         <span class="param-flags">required</span>
         If set, defines a constraint on the EC2 instances that they should be using the AMI ID specified by this parameter.
+      </li>
+      <li>
+        <span class="param">bound_iam_role_arn</span>
+        <span class="param-flags">optional</span>
+        If set, defines a constraint on the EC2 instances that they should be using the IAM Role ARN specified by this parameter.
       </li>
     </ul>
     <ul>


### PR DESCRIPTION
In the latest build 0.6.0 AMI ID was added as the first constraint to authenticate from an EC2 instance. This is really helpful for a lot of organizations that use different AWS AMI per application. Role tags was also added to allow organizations that use a base AMI to tag their instances for different role access in conjunction with an AMI ID. 

However our organization works a little bit different (or a mix of both). While we do have one base AMI this AMI is constantly changing (with security updates or added technologies) and will make it really hard to keep the Vault roles definitions in sync with the fast phased deployment cycles and AMI updates (think about tens of microservices, different apps, different technologies, each within a different autoscaling group, etc etc). After going back and forward with out DevOps and Security team we identified the IAM Role as the most effective way to achieve a secure identification and constraint for authentication. We assign those roles per application and is part of the autoscaling group and deployment process.

This adds IAM Role ARN as a constraint for authenticating against vault and obtaining a token for a given role. This can be used instead of the AMI ID but keeps both features (AMI ID has precedence if both are defined in the role definition).

To define a vault role with and IAM Role ARN as the constraint you can do the following:

<code>
vault write auth/aws-ec2/role/dev-role bound_iam_role_arn=arn:aws:iam::3233223121:instance-profile/vault-ec2 policies=prod,dev max_ttl=500h
</code>

Note we used the instance profile since this is what gets assigned to the EC2 instances. You can find this value for your role on the AWS console on IAM -> Roles

When you send the instance PKCS7 all the checks for the instance status will be the same and if the bound_iam_role_arn is set then it will verify that it matches the instance IAM Role ARN.

This will have the added benefit to work on Lambda functions since an AMI ID is not present but an IAM Role ARN is always set. 

Role tags will continue to work just the same as they work on AMI ID constraints. 

Thank you
-Ivan
