### PR TITLE
Auth tune endpoints and config settings output from CLI

### DIFF
--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -51,6 +51,12 @@ func (c *Sys) DisableAuth(path string) error {
 // documentation. Please refer to that documentation for more details.
 
 type AuthMount struct {
-	Type        string
-	Description string
+	Type        string           `json:"type" structs:"type" mapstructure:"type"`
+	Description string           `json:"description" structs:"description" mapstructure:"description"`
+	Config      AuthConfigOutput `json:"config" structs:"config" mapstructure:"config"`
+}
+
+type AuthConfigOutput struct {
+	DefaultLeaseTTL int `json:"default_lease_ttl" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"`
+	MaxLeaseTTL     int `json:"max_lease_ttl" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`
 }

--- a/command/auth.go
+++ b/command/auth.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/vault/api"
@@ -266,11 +267,19 @@ func (c *AuthCommand) listMethods() int {
 	}
 	sort.Strings(paths)
 
-	columns := []string{"Path | Type | Description"}
-	for _, k := range paths {
-		a := auth[k]
+	columns := []string{"Path | Type | Default TTL | Max TTL | Description"}
+	for _, path := range paths {
+		auth := auth[path]
+		defTTL := "system"
+		if auth.Config.DefaultLeaseTTL != 0 {
+			defTTL = strconv.Itoa(auth.Config.DefaultLeaseTTL)
+		}
+		maxTTL := "system"
+		if auth.Config.MaxLeaseTTL != 0 {
+			maxTTL = strconv.Itoa(auth.Config.MaxLeaseTTL)
+		}
 		columns = append(columns, fmt.Sprintf(
-			"%s | %s | %s", k, a.Type, a.Description))
+			"%s | %s | %s | %s | %s", path, auth.Type, defTTL, maxTTL, auth.Description))
 	}
 
 	c.Ui.Output(columnize.SimpleFormat(columns))

--- a/http/sys_auth_test.go
+++ b/http/sys_auth_test.go
@@ -20,12 +20,16 @@ func TestSysAuth(t *testing.T) {
 		"token/": map[string]interface{}{
 			"description": "token based credentials",
 			"type":        "token",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
+		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
 	}
 }
 
@@ -48,16 +52,24 @@ func TestSysEnableAuth(t *testing.T) {
 		"foo/": map[string]interface{}{
 			"description": "foo",
 			"type":        "noop",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 		"token/": map[string]interface{}{
 			"description": "token based credentials",
 			"type":        "token",
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 		},
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
+		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
 	}
 }
 
@@ -81,6 +93,10 @@ func TestSysDisableAuth(t *testing.T) {
 	var actual map[string]interface{}
 	expected := map[string]interface{}{
 		"token/": map[string]interface{}{
+			"config": map[string]interface{}{
+				"default_lease_ttl": float64(0),
+				"max_lease_ttl":     float64(0),
+			},
 			"description": "token based credentials",
 			"type":        "token",
 		},
@@ -88,6 +104,6 @@ func TestSysDisableAuth(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
+		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
 	}
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -661,8 +661,8 @@ func (b *SystemBackend) handleMountTable(
 			"type":        entry.Type,
 			"description": entry.Description,
 			"config": map[string]interface{}{
-				"default_lease_ttl": int(entry.Config.DefaultLeaseTTL.Seconds()),
-				"max_lease_ttl":     int(entry.Config.MaxLeaseTTL.Seconds()),
+				"default_lease_ttl": int64(entry.Config.DefaultLeaseTTL.Seconds()),
+				"max_lease_ttl":     int64(entry.Config.MaxLeaseTTL.Seconds()),
 			},
 		}
 
@@ -1041,8 +1041,8 @@ func (b *SystemBackend) handleAuthTable(
 			"type":        entry.Type,
 			"description": entry.Description,
 			"config": map[string]interface{}{
-				"default_lease_ttl": int(entry.Config.DefaultLeaseTTL.Seconds()),
-				"max_lease_ttl":     int(entry.Config.MaxLeaseTTL.Seconds()),
+				"default_lease_ttl": int64(entry.Config.DefaultLeaseTTL.Seconds()),
+				"max_lease_ttl":     int64(entry.Config.MaxLeaseTTL.Seconds()),
 			},
 		}
 		resp.Data[entry.Path] = info

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -525,9 +525,13 @@ func TestSystemBackend_authTable(t *testing.T) {
 	}
 
 	exp := map[string]interface{}{
-		"token/": map[string]string{
+		"token/": map[string]interface{}{
 			"type":        "token",
 			"description": "token based credentials",
+			"config": map[string]interface{}{
+				"default_lease_ttl": int(0),
+				"max_lease_ttl":     int(0),
+			},
 		},
 	}
 	if !reflect.DeepEqual(resp.Data, exp) {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -46,24 +46,24 @@ func TestSystemBackend_mounts(t *testing.T) {
 			"type":        "generic",
 			"description": "generic secret storage",
 			"config": map[string]interface{}{
-				"default_lease_ttl": resp.Data["secret/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(int),
-				"max_lease_ttl":     resp.Data["secret/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(int),
+				"default_lease_ttl": resp.Data["secret/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(int64),
+				"max_lease_ttl":     resp.Data["secret/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(int64),
 			},
 		},
 		"sys/": map[string]interface{}{
 			"type":        "system",
 			"description": "system endpoints used for control, policy and debugging",
 			"config": map[string]interface{}{
-				"default_lease_ttl": resp.Data["sys/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(int),
-				"max_lease_ttl":     resp.Data["sys/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(int),
+				"default_lease_ttl": resp.Data["sys/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(int64),
+				"max_lease_ttl":     resp.Data["sys/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(int64),
 			},
 		},
 		"cubbyhole/": map[string]interface{}{
 			"description": "per-token private secret storage",
 			"type":        "cubbyhole",
 			"config": map[string]interface{}{
-				"default_lease_ttl": resp.Data["cubbyhole/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(int),
-				"max_lease_ttl":     resp.Data["cubbyhole/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(int),
+				"default_lease_ttl": resp.Data["cubbyhole/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(int64),
+				"max_lease_ttl":     resp.Data["cubbyhole/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(int64),
 			},
 		},
 	}
@@ -529,8 +529,8 @@ func TestSystemBackend_authTable(t *testing.T) {
 			"type":        "token",
 			"description": "token based credentials",
 			"config": map[string]interface{}{
-				"default_lease_ttl": int(0),
-				"max_lease_ttl":     int(0),
+				"default_lease_ttl": int64(0),
+				"max_lease_ttl":     int64(0),
 			},
 		},
 	}

--- a/website/source/docs/http/sys-auth.html.md
+++ b/website/source/docs/http/sys-auth.html.md
@@ -45,8 +45,8 @@ description: |-
   <dt>Description</dt>
   <dd>
     Enable a new auth backend. The auth backend can be accessed
-    and configured via the mount point specified in the URL. This
-    mount point will be exposed under the `auth` prefix. For example,
+    and configured via the auth path specified in the URL. This
+    auth path will be exposed under the `auth` prefix. For example,
     enabling with the `/sys/auth/foo` URL will make the backend
     available at `/auth/foo`.
   </dd>
@@ -55,7 +55,7 @@ description: |-
   <dd>POST</dd>
 
   <dt>URL</dt>
-  <dd>`/sys/auth/<mount point>`</dd>
+  <dd>`/sys/auth/<auth_path>`</dd>
 
   <dt>Parameters</dt>
   <dd>
@@ -83,17 +83,92 @@ description: |-
 <dl>
   <dt>Description</dt>
   <dd>
-    Disable the auth backend at the given mount point.
+    Disable the auth backend at the given auth path.
   </dd>
 
   <dt>Method</dt>
   <dd>DELETE</dd>
 
   <dt>URL</dt>
-  <dd>`/sys/auth/<mount point>`</dd>
+  <dd>`/sys/auth/<auth_path>`</dd>
 
   <dt>Parameters</dt>
   <dd>None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+# /sys/auth/<auth_path>/tune
+
+## GET
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Read the given auth path's configuration. Returns the current time
+    in seconds for each TTL, which may be the system default or a
+    auth path specific value.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/auth/<auth_path>/tune`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+      "default_lease_ttl": 3600,
+      "max_lease_ttl": 7200
+    }
+    ```
+
+  </dd>
+</dl>
+
+## POST
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Tune configuration parameters for a given auth path.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>POST</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/auth/<auth_path>/tune`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">default_lease_ttl</span>
+        <span class="param-flags">optional</span>
+        The default time-to-live. If set on a specific auth path,
+        overrides the global default. A value of "system" or "0"
+        are equivalent and set to the system default TTL.
+      </li>
+      <li>
+        <span class="param">max_lease_ttl</span>
+        <span class="param-flags">optional</span>
+        The maximum time-to-live. If set on a specific auth path,
+        overrides the global default. A value of "system" or "0"
+        are equivalent and set to the system max TTL.
+      </li>
+    </ul>
   </dd>
 
   <dt>Returns</dt>

--- a/website/source/docs/http/sys-mounts.html.md
+++ b/website/source/docs/http/sys-mounts.html.md
@@ -57,38 +57,6 @@ description: |-
   </dd>
 </dl>
 
-<dl>
-  <dt>Description</dt>
-  <dd>
-    List the given mount's configuration. Unlike the `mounts`
-    endpoint, this will return the current time in seconds for each
-    TTL, which may be the system default or a mount-specific value.
-  </dd>
-
-  <dt>Method</dt>
-  <dd>GET</dd>
-
-  <dt>URL</dt>
-  <dd>`/sys/mounts/<mount point>/tune`</dd>
-
-  <dt>Parameters</dt>
-  <dd>
-    None
-  </dd>
-
-  <dt>Returns</dt>
-  <dd>
-
-    ```javascript
-    {
-      "default_lease_ttl": 3600,
-      "max_lease_ttl": 7200
-    }
-    ```
-
-  </dd>
-</dl>
-
 ## POST
 
 <dl>
@@ -134,6 +102,67 @@ description: |-
   </dd>
 </dl>
 
+## DELETE
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Unmount the mount point specified in the URL.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>DELETE</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/mounts/<mount point>`</dd>
+
+  <dt>Parameters</dt>
+  <dd>None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+# /sys/mounts/<mount point>/tune
+
+## GET
+
+<dl>
+  <dt>Description</dt>
+  <dd>
+    Read the given mount's configuration. Unlike the `mounts`
+    endpoint, this will return the current time in seconds for each
+    TTL, which may be the system default or a mount-specific value.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/sys/mounts/<mount point>/tune`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+      "default_lease_ttl": 3600,
+      "max_lease_ttl": 7200
+    }
+    ```
+
+  </dd>
+</dl>
+
+## POST
+
 <dl>
   <dt>Description</dt>
   <dd>
@@ -164,29 +193,6 @@ description: |-
         are equivalent and set to the system max TTL.
       </li>
     </ul>
-  </dd>
-
-  <dt>Returns</dt>
-  <dd>`204` response code.
-  </dd>
-</dl>
-
-## DELETE
-
-<dl>
-  <dt>Description</dt>
-  <dd>
-    Unmount the mount point specified in the URL.
-  </dd>
-
-  <dt>Method</dt>
-  <dd>DELETE</dd>
-
-  <dt>URL</dt>
-  <dd>`/sys/mounts/<mount point>`</dd>
-
-  <dt>Parameters</dt>
-  <dd>None
   </dd>
 
   <dt>Returns</dt>


### PR DESCRIPTION
Displaying 'Default TTL' and 'Max TTL' in the output of 'vault auth -methods'

Fixes #1269 