### PR TITLE
Fix the output format when warnings are present

### DIFF
--- a/command/format.go
+++ b/command/format.go
@@ -176,14 +176,21 @@ func (t TableFormatter) OutputSecret(ui cli.Ui, secret, s *api.Secret) error {
 		input = append(input, fmt.Sprintf("%s %s %v", k, config.Delim, s.Data[k]))
 	}
 
+	ui.Output(columnize.Format(input, config))
+
+	// Print the warning separately because the length of first
+	// column in the output will be increased by the length of
+	// the longest warning string making the output look bad.
+	warningsInput := make([]string, 0, 5)
 	if len(s.Warnings) != 0 {
-		input = append(input, "")
-		input = append(input, "The following warnings were returned from the Vault server:")
+		warningsInput = append(warningsInput, "")
+		warningsInput = append(warningsInput, "The following warnings were returned from the Vault server:")
 		for _, warning := range s.Warnings {
-			input = append(input, fmt.Sprintf("* %s", warning))
+			warningsInput = append(warningsInput, fmt.Sprintf("* %s", warning))
 		}
 	}
 
-	ui.Output(columnize.Format(input, config))
+	ui.Output(columnize.Format(warningsInput, config))
+
 	return nil
 }

--- a/command/format.go
+++ b/command/format.go
@@ -176,7 +176,7 @@ func (t TableFormatter) OutputSecret(ui cli.Ui, secret, s *api.Secret) error {
 		input = append(input, fmt.Sprintf("%s %s %v", k, config.Delim, s.Data[k]))
 	}
 
-	ui.Output(columnize.Format(input, config))
+	tableOutputStr := columnize.Format(input, config)
 
 	// Print the warning separately because the length of first
 	// column in the output will be increased by the length of
@@ -190,7 +190,9 @@ func (t TableFormatter) OutputSecret(ui cli.Ui, secret, s *api.Secret) error {
 		}
 	}
 
-	ui.Output(columnize.Format(warningsInput, config))
+	warningsOutputStr := columnize.Format(warningsInput, config)
+
+	ui.Output(fmt.Sprintf("%s\n%s", tableOutputStr, warningsOutputStr))
 
 	return nil
 }

--- a/command/format_test.go
+++ b/command/format_test.go
@@ -77,6 +77,6 @@ func TestTableFormatter(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(output, "something") {
-		t.Fatal("did not find something")
+		t.Fatal("did not find 'something'")
 	}
 }


### PR DESCRIPTION
Display before the fix and after the fix.

<img width="959" alt="formatoutput" src="https://cloud.githubusercontent.com/assets/3053672/16097585/85dd8e36-331c-11e6-9b40-3c388bbaebe4.png">
