### PR TITLE
Armor PGP keys (rather than hex encoding their binary form)

### DIFF
--- a/command/rekey.go
+++ b/command/rekey.go
@@ -160,7 +160,7 @@ func (c *RekeyCommand) Run(args []string) int {
 	// Provide the keys
 	for i, key := range result.Keys {
 		if len(result.PGPFingerprints) > 0 {
-			c.Ui.Output(fmt.Sprintf("Key %d fingerprint: %s; value: %s", i+1, result.PGPFingerprints[i], key))
+			c.Ui.Output(fmt.Sprintf("Key %d fingerprint: %s:\n%s", i+1, result.PGPFingerprints[i], key))
 		} else {
 			c.Ui.Output(fmt.Sprintf("Key %d: %s", i+1, key))
 		}

--- a/http/sys_health_test.go
+++ b/http/sys_health_test.go
@@ -113,7 +113,7 @@ func TestSysHealth_head(t *testing.T) {
 	ln, addr := TestServer(t, core)
 	defer ln.Close()
 
-	testData := []struct{
+	testData := []struct {
 		uri  string
 		code int
 	}{

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -167,11 +167,15 @@ func handleSysRekeyUpdate(core *vault.Core, recovery bool) http.Handler {
 		if result != nil {
 			resp.Complete = true
 			resp.Nonce = req.Nonce
-
 			// Encode the keys
 			keys := make([]string, 0, len(result.SecretShares))
 			for _, k := range result.SecretShares {
-				keys = append(keys, hex.EncodeToString(k))
+				if result.PGPFingerprints == nil {
+					keys = append(keys, hex.EncodeToString(k))
+				} else {
+					// PGP encoded keys are armored, so just use the plain string.
+					keys = append(keys, string(k))
+				}
 			}
 			resp.Keys = keys
 


### PR DESCRIPTION
I got annoyed by the output of the rekey operation when using PGP, so I decided to fix it. It now outputs armored PGP messages rather than a hex encoding of the binary format.