### PR TITLE
Fix RabbitMQ documentation.

### DIFF
--- a/website/source/docs/secrets/rabbitmq/index.html.md
+++ b/website/source/docs/secrets/rabbitmq/index.html.md
@@ -44,7 +44,7 @@ and the user's password.
 
 ```text
 $ vault write rabbitmq/config/connection \
-    uri="http://localhost:15672" \
+    connection_uri="http://localhost:15672" \
     username="admin" \
     password="password"
 ```


### PR DESCRIPTION
Change parameter `uri` to `connection_uri` in code example.