### PR TITLE
Remove prepared stmnts from pgsql physical backend

### DIFF
--- a/physical/postgresql_test.go
+++ b/physical/postgresql_test.go
@@ -32,7 +32,7 @@ func TestPostgreSQLBackend(t *testing.T) {
 
 	defer func() {
 		pg := b.(*PostgreSQLBackend)
-		_, err := pg.client.Exec("DROP TABLE " + pg.table)
+		_, err := pg.client.Exec("TRUNCATE TABLE " + pg.table)
 		if err != nil {
 			t.Fatalf("Failed to drop table: %v", err)
 		}


### PR DESCRIPTION
Prepared statements prevent the use of connection multiplexing software
such as PGBouncer. Even when PGBouncer is configured for [session mode][1]
there's a possibility that a connection to PostgreSQL can be re-used by
different clients.  This leads to errors when clients use session based
features (like prepared statements).

This change removes prepared statements from the PostgreSQL physical
backend. This will allow vault to successfully work in infrastructures
that employ the use of PGBouncer or other connection multiplexing
software.

(This configuration is currently live in one of our integration environments
without issues.)

[1]: https://pgbouncer.github.io/config.html#poolmode