### PR TITLE
fix external token helpers

### DIFF
--- a/command/token/helper_external.go
+++ b/command/token/helper_external.go
@@ -30,10 +30,10 @@ func ExternalTokenHelperPath(path string) (string, error) {
 	}
 
 	if _, err := os.Stat(path); err != nil {
-		return path, nil
+		return "", fmt.Errorf("unknown error getting the external helper path")
 	}
 
-	return "", fmt.Errorf("unknown error getting the external helper path")
+	return path, nil
 }
 
 // ExternalTokenHelper is the struct that has all the logic for storing and retrieving


### PR DESCRIPTION
The token helper refactor in hashicorp/vault#853 (reasonably!) added a check for the existence of the helper binary. Unfortunately, the error check is wrong, and external helpers don't work, period. In this patch, I swapped the return statements rather than turn it to `err == nil`, because it's more consistent with the rest of the file. That appears to fix it.