### PR TITLE
Use transaction object for query

### DIFF
--- a/builtin/logical/mssql/path_creds_create.go
+++ b/builtin/logical/mssql/path_creds_create.go
@@ -64,7 +64,7 @@ func (b *backend) pathCredsCreateRead(
 		return nil, err
 	}
 
-	// Get our connection
+	// Get our handle
 	db, err := b.DB(req.Storage)
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func (b *backend) pathCredsCreateRead(
 
 	// Execute each query
 	for _, query := range SplitSQL(roleSQL) {
-		stmt, err := db.Prepare(Query(query, map[string]string{
+		stmt, err := tx.Prepare(Query(query, map[string]string{
 			"name":     username,
 			"password": password,
 		}))

--- a/builtin/logical/mssql/path_creds_create.go
+++ b/builtin/logical/mssql/path_creds_create.go
@@ -90,6 +90,7 @@ func (b *backend) pathCredsCreateRead(
 		if err != nil {
 			return nil, err
 		}
+		defer stmt.Close()
 		if _, err := stmt.Exec(); err != nil {
 			return nil, err
 		}

--- a/builtin/logical/mssql/secret_creds.go
+++ b/builtin/logical/mssql/secret_creds.go
@@ -133,6 +133,7 @@ func (b *backend) secretCredsRevoke(
 			lastStmtError = err
 			continue
 		}
+		defer stmt.Close()
 		_, err = stmt.Exec()
 		if err != nil {
 			lastStmtError = err

--- a/builtin/logical/mysql/path_role_create.go
+++ b/builtin/logical/mysql/path_role_create.go
@@ -68,7 +68,7 @@ func (b *backend) pathRoleCreateRead(
 		return nil, err
 	}
 
-	// Get our connection
+	// Get our handle
 	db, err := b.DB(req.Storage)
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func (b *backend) pathRoleCreateRead(
 
 	// Execute each query
 	for _, query := range SplitSQL(role.SQL) {
-		stmt, err := db.Prepare(Query(query, map[string]string{
+		stmt, err := tx.Prepare(Query(query, map[string]string{
 			"name":     username,
 			"password": password,
 		}))

--- a/builtin/logical/mysql/path_role_create.go
+++ b/builtin/logical/mysql/path_role_create.go
@@ -90,6 +90,7 @@ func (b *backend) pathRoleCreateRead(
 		if err != nil {
 			return nil, err
 		}
+		defer stmt.Close()
 		if _, err := stmt.Exec(); err != nil {
 			return nil, err
 		}

--- a/builtin/logical/postgresql/backend.go
+++ b/builtin/logical/postgresql/backend.go
@@ -3,6 +3,7 @@ package postgresql
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -11,10 +12,10 @@ import (
 )
 
 func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
-	return Backend().Setup(conf)
+	return Backend(conf).Setup(conf)
 }
 
-func Backend() *backend {
+func Backend(conf *logical.BackendConfig) *backend {
 	var b backend
 	b.Backend = &framework.Backend{
 		Help: strings.TrimSpace(backendHelp),
@@ -34,6 +35,7 @@ func Backend() *backend {
 		Clean: b.ResetDB,
 	}
 
+	b.logger = conf.Logger
 	return &b
 }
 
@@ -42,10 +44,14 @@ type backend struct {
 
 	db   *sql.DB
 	lock sync.Mutex
+
+	logger *log.Logger
 }
 
 // DB returns the database connection.
 func (b *backend) DB(s logical.Storage) (*sql.DB, error) {
+	b.logger.Println("[WARN] postgres/db: enter")
+	defer b.logger.Println("[WARN] postgres/db: exit")
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -100,6 +106,9 @@ func (b *backend) DB(s logical.Storage) (*sql.DB, error) {
 
 // ResetDB forces a connection next time DB() is called.
 func (b *backend) ResetDB() {
+	b.logger.Println("[WARN] postgres/resetdb: enter")
+	defer b.logger.Println("[WARN] postgres/resetdb: exit")
+
 	b.lock.Lock()
 	defer b.lock.Unlock()
 

--- a/builtin/logical/postgresql/backend_test.go
+++ b/builtin/logical/postgresql/backend_test.go
@@ -101,7 +101,7 @@ func TestBackend_roleCrud(t *testing.T) {
 }
 
 func TestBackend_configConnection(t *testing.T) {
-	b := Backend()
+	b, _ := Factory(logical.TestBackendConfig())
 	d1 := map[string]interface{}{
 		"value": os.Getenv("PG_URL"),
 	}

--- a/builtin/logical/postgresql/path_role_create.go
+++ b/builtin/logical/postgresql/path_role_create.go
@@ -101,7 +101,6 @@ func (b *backend) pathRoleCreateRead(
 
 	// Execute each query
 	for _, query := range SplitSQL(role.SQL) {
-
 		b.logger.Println("[WARN] postgres/pathRoleCreateRead: preparing statement")
 		stmt, err := tx.Prepare(Query(query, map[string]string{
 			"name":       username,
@@ -111,7 +110,7 @@ func (b *backend) pathRoleCreateRead(
 		if err != nil {
 			return nil, err
 		}
-
+		defer stmt.Close()
 		b.logger.Println("[WARN] postgres/pathRoleCreateRead: executing statement")
 		if _, err := stmt.Exec(); err != nil {
 			return nil, err

--- a/builtin/logical/postgresql/path_role_create.go
+++ b/builtin/logical/postgresql/path_role_create.go
@@ -31,6 +31,8 @@ func pathRoleCreate(b *backend) *framework.Path {
 
 func (b *backend) pathRoleCreateRead(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	b.logger.Println("[WARN] postgres/pathRoleCreateRead: enter")
+	defer b.logger.Println("[WARN] postgres/pathRoleCreateRead: exit")
 	name := data.Get("name").(string)
 
 	// Get the role

--- a/builtin/logical/postgresql/path_role_create.go
+++ b/builtin/logical/postgresql/path_role_create.go
@@ -36,7 +36,6 @@ func (b *backend) pathRoleCreateRead(
 	name := data.Get("name").(string)
 
 	// Get the role
-
 	b.logger.Println("[WARN] postgres/pathRoleCreateRead: getting role")
 	role, err := b.Role(req.Storage, name)
 	if err != nil {
@@ -82,8 +81,7 @@ func (b *backend) pathRoleCreateRead(
 		Add(lease.Lease).
 		Format("2006-01-02 15:04:05-0700")
 
-	// Get our connection
-
+	// Get our handle
 	b.logger.Println("[WARN] postgres/pathRoleCreateRead: getting database")
 	db, err := b.DB(req.Storage)
 	if err != nil {
@@ -105,7 +103,7 @@ func (b *backend) pathRoleCreateRead(
 	for _, query := range SplitSQL(role.SQL) {
 
 		b.logger.Println("[WARN] postgres/pathRoleCreateRead: preparing statement")
-		stmt, err := db.Prepare(Query(query, map[string]string{
+		stmt, err := tx.Prepare(Query(query, map[string]string{
 			"name":       username,
 			"password":   password,
 			"expiration": expiration,

--- a/builtin/logical/postgresql/path_role_create.go
+++ b/builtin/logical/postgresql/path_role_create.go
@@ -36,6 +36,8 @@ func (b *backend) pathRoleCreateRead(
 	name := data.Get("name").(string)
 
 	// Get the role
+
+	b.logger.Println("[WARN] postgres/pathRoleCreateRead: getting role")
 	role, err := b.Role(req.Storage, name)
 	if err != nil {
 		return nil, err
@@ -45,6 +47,7 @@ func (b *backend) pathRoleCreateRead(
 	}
 
 	// Determine if we have a lease
+	b.logger.Println("[WARN] postgres/pathRoleCreateRead: getting lease")
 	lease, err := b.Lease(req.Storage)
 	if err != nil {
 		return nil, err
@@ -80,20 +83,28 @@ func (b *backend) pathRoleCreateRead(
 		Format("2006-01-02 15:04:05-0700")
 
 	// Get our connection
+
+	b.logger.Println("[WARN] postgres/pathRoleCreateRead: getting database")
 	db, err := b.DB(req.Storage)
 	if err != nil {
 		return nil, err
 	}
 
 	// Start a transaction
+	b.logger.Println("[WARN] postgres/pathRoleCreateRead: starting transaction")
 	tx, err := db.Begin()
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback()
+	defer func() {
+		b.logger.Println("[WARN] postgres/pathRoleCreateRead: rolling back transaction")
+		tx.Rollback()
+	}()
 
 	// Execute each query
 	for _, query := range SplitSQL(role.SQL) {
+
+		b.logger.Println("[WARN] postgres/pathRoleCreateRead: preparing statement")
 		stmt, err := db.Prepare(Query(query, map[string]string{
 			"name":       username,
 			"password":   password,
@@ -102,17 +113,23 @@ func (b *backend) pathRoleCreateRead(
 		if err != nil {
 			return nil, err
 		}
+
+		b.logger.Println("[WARN] postgres/pathRoleCreateRead: executing statement")
 		if _, err := stmt.Exec(); err != nil {
 			return nil, err
 		}
 	}
 
 	// Commit the transaction
+
+	b.logger.Println("[WARN] postgres/pathRoleCreateRead: committing transaction")
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 
 	// Return the secret
+
+	b.logger.Println("[WARN] postgres/pathRoleCreateRead: generating secret")
 	resp := b.Secret(SecretCredsType).Response(map[string]interface{}{
 		"username": username,
 		"password": password,

--- a/builtin/logical/postgresql/path_role_create.go
+++ b/builtin/logical/postgresql/path_role_create.go
@@ -31,12 +31,12 @@ func pathRoleCreate(b *backend) *framework.Path {
 
 func (b *backend) pathRoleCreateRead(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	b.logger.Println("[WARN] postgres/pathRoleCreateRead: enter")
-	defer b.logger.Println("[WARN] postgres/pathRoleCreateRead: exit")
+	b.logger.Println("[TRACE] postgres/pathRoleCreateRead: enter")
+	defer b.logger.Println("[TRACE] postgres/pathRoleCreateRead: exit")
 	name := data.Get("name").(string)
 
 	// Get the role
-	b.logger.Println("[WARN] postgres/pathRoleCreateRead: getting role")
+	b.logger.Println("[TRACE] postgres/pathRoleCreateRead: getting role")
 	role, err := b.Role(req.Storage, name)
 	if err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func (b *backend) pathRoleCreateRead(
 	}
 
 	// Determine if we have a lease
-	b.logger.Println("[WARN] postgres/pathRoleCreateRead: getting lease")
+	b.logger.Println("[TRACE] postgres/pathRoleCreateRead: getting lease")
 	lease, err := b.Lease(req.Storage)
 	if err != nil {
 		return nil, err
@@ -82,26 +82,26 @@ func (b *backend) pathRoleCreateRead(
 		Format("2006-01-02 15:04:05-0700")
 
 	// Get our handle
-	b.logger.Println("[WARN] postgres/pathRoleCreateRead: getting database")
+	b.logger.Println("[TRACE] postgres/pathRoleCreateRead: getting database handle")
 	db, err := b.DB(req.Storage)
 	if err != nil {
 		return nil, err
 	}
 
 	// Start a transaction
-	b.logger.Println("[WARN] postgres/pathRoleCreateRead: starting transaction")
+	b.logger.Println("[TRACE] postgres/pathRoleCreateRead: starting transaction")
 	tx, err := db.Begin()
 	if err != nil {
 		return nil, err
 	}
 	defer func() {
-		b.logger.Println("[WARN] postgres/pathRoleCreateRead: rolling back transaction")
+		b.logger.Println("[TRACE] postgres/pathRoleCreateRead: rolling back transaction")
 		tx.Rollback()
 	}()
 
 	// Execute each query
 	for _, query := range SplitSQL(role.SQL) {
-		b.logger.Println("[WARN] postgres/pathRoleCreateRead: preparing statement")
+		b.logger.Println("[TRACE] postgres/pathRoleCreateRead: preparing statement")
 		stmt, err := tx.Prepare(Query(query, map[string]string{
 			"name":       username,
 			"password":   password,
@@ -111,7 +111,7 @@ func (b *backend) pathRoleCreateRead(
 			return nil, err
 		}
 		defer stmt.Close()
-		b.logger.Println("[WARN] postgres/pathRoleCreateRead: executing statement")
+		b.logger.Println("[TRACE] postgres/pathRoleCreateRead: executing statement")
 		if _, err := stmt.Exec(); err != nil {
 			return nil, err
 		}
@@ -119,14 +119,14 @@ func (b *backend) pathRoleCreateRead(
 
 	// Commit the transaction
 
-	b.logger.Println("[WARN] postgres/pathRoleCreateRead: committing transaction")
+	b.logger.Println("[TRACE] postgres/pathRoleCreateRead: committing transaction")
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 
 	// Return the secret
 
-	b.logger.Println("[WARN] postgres/pathRoleCreateRead: generating secret")
+	b.logger.Println("[TRACE] postgres/pathRoleCreateRead: generating secret")
 	resp := b.Secret(SecretCredsType).Response(map[string]interface{}{
 		"username": username,
 		"password": password,

--- a/builtin/logical/postgresql/secret_creds.go
+++ b/builtin/logical/postgresql/secret_creds.go
@@ -163,6 +163,7 @@ func (b *backend) secretCredsRevoke(
 			lastStmtError = err
 			continue
 		}
+		defer stmt.Close()
 		_, err = stmt.Exec()
 		if err != nil {
 			lastStmtError = err


### PR DESCRIPTION
Current code in pg/my/ms sql backends creates a transaction and then ignores it for the query, consuming multiple database connections under the hood, which can lead to contention/exhaustion of these.

This also fixes some statements lacking Close calls.