### PR TITLE
Support connect_timeout for Cassandra and align timeout.

### DIFF
--- a/builtin/logical/cassandra/backend.go
+++ b/builtin/logical/cassandra/backend.go
@@ -55,6 +55,7 @@ type sessionConfig struct {
 	PrivateKey      string `json:"private_key" structs:"private_key"`
 	IssuingCA       string `json:"issuing_ca" structs:"issuing_ca"`
 	ProtocolVersion int    `json:"protocol_version" structs:"protocol_version"`
+	ConnectTimeout  string `json:"connect_timeout" structs:"connect_timeout"`
 }
 
 // DB returns the database connection.
@@ -81,7 +82,7 @@ func (b *backend) DB(s logical.Storage) (*gocql.Session, error) {
 		return nil, err
 	}
 
-	return createSession(config, s)
+	return createSession(config, s, b.Logger())
 }
 
 // ResetDB forces a connection next time DB() is called.

--- a/builtin/logical/cassandra/backend.go
+++ b/builtin/logical/cassandra/backend.go
@@ -55,7 +55,7 @@ type sessionConfig struct {
 	PrivateKey      string `json:"private_key" structs:"private_key"`
 	IssuingCA       string `json:"issuing_ca" structs:"issuing_ca"`
 	ProtocolVersion int    `json:"protocol_version" structs:"protocol_version"`
-	ConnectTimeout  string `json:"connect_timeout" structs:"connect_timeout"`
+	ConnectTimeout  int    `json:"connect_timeout" structs:"connect_timeout"`
 }
 
 // DB returns the database connection.
@@ -82,7 +82,7 @@ func (b *backend) DB(s logical.Storage) (*gocql.Session, error) {
 		return nil, err
 	}
 
-	return createSession(config, s, b.Logger())
+	return createSession(config, s)
 }
 
 // ResetDB forces a connection next time DB() is called.

--- a/builtin/logical/cassandra/path_config_connection.go
+++ b/builtin/logical/cassandra/path_config_connection.go
@@ -62,8 +62,9 @@ take precedence.`,
 			},
 
 			"connect_timeout": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Description: `The connection timeout to use. Defaults to 5s.`,
+				Type:        framework.TypeDurationSecond,
+				Default:     5,
+				Description: `The connection timeout to use. Defaults to 5.`,
 			},
 		},
 
@@ -124,7 +125,7 @@ func (b *backend) pathConnectionWrite(
 		TLS:             data.Get("tls").(bool),
 		InsecureTLS:     data.Get("insecure_tls").(bool),
 		ProtocolVersion: data.Get("protocol_version").(int),
-		ConnectTimeout:  data.Get("connect_timeout").(string),
+		ConnectTimeout:  data.Get("connect_timeout").(int),
 	}
 
 	if config.InsecureTLS {
@@ -168,7 +169,7 @@ func (b *backend) pathConnectionWrite(
 		config.TLS = true
 	}
 
-	session, err := createSession(config, req.Storage, b.Logger())
+	session, err := createSession(config, req.Storage)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}

--- a/builtin/logical/cassandra/path_config_connection.go
+++ b/builtin/logical/cassandra/path_config_connection.go
@@ -60,6 +60,11 @@ take precedence.`,
 				Type:        framework.TypeInt,
 				Description: `The protocol version to use. Defaults to 2.`,
 			},
+
+			"connect_timeout": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: `The connection timeout to use. Defaults to 5s.`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -119,6 +124,7 @@ func (b *backend) pathConnectionWrite(
 		TLS:             data.Get("tls").(bool),
 		InsecureTLS:     data.Get("insecure_tls").(bool),
 		ProtocolVersion: data.Get("protocol_version").(int),
+		ConnectTimeout:  data.Get("connect_timeout").(string),
 	}
 
 	if config.InsecureTLS {
@@ -162,7 +168,7 @@ func (b *backend) pathConnectionWrite(
 		config.TLS = true
 	}
 
-	session, err := createSession(config, req.Storage)
+	session, err := createSession(config, req.Storage, b.Logger())
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}

--- a/builtin/logical/cassandra/util.go
+++ b/builtin/logical/cassandra/util.go
@@ -3,7 +3,9 @@ package cassandra
 import (
 	"crypto/tls"
 	"fmt"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/gocql/gocql"
 	"github.com/hashicorp/vault/helper/certutil"
@@ -32,7 +34,7 @@ func substQuery(tpl string, data map[string]string) string {
 	return tpl
 }
 
-func createSession(cfg *sessionConfig, s logical.Storage) (*gocql.Session, error) {
+func createSession(cfg *sessionConfig, s logical.Storage, logger *log.Logger) (*gocql.Session, error) {
 	clusterConfig := gocql.NewCluster(strings.Split(cfg.Hosts, ",")...)
 	clusterConfig.Authenticator = gocql.PasswordAuthenticator{
 		Username: cfg.Username,
@@ -42,6 +44,22 @@ func createSession(cfg *sessionConfig, s logical.Storage) (*gocql.Session, error
 	clusterConfig.ProtoVersion = cfg.ProtocolVersion
 	if clusterConfig.ProtoVersion == 0 {
 		clusterConfig.ProtoVersion = 2
+	}
+
+	if len(cfg.ConnectTimeout) != 0 {
+		d, err := time.ParseDuration(cfg.ConnectTimeout)
+		if err != nil {
+			return nil, err
+		}
+
+		if d < 1 {
+			return nil, fmt.Errorf("Cassandra connect_timeout must be greater than 0")
+		}
+
+		clusterConfig.Timeout = d
+		logger.Printf("[DEBUG]: cassandra: config connect_timeout set to %v", d)
+	} else {
+		clusterConfig.Timeout = 5 * time.Second
 	}
 
 	if cfg.TLS {

--- a/website/source/docs/secrets/cassandra/index.html.md
+++ b/website/source/docs/secrets/cassandra/index.html.md
@@ -182,6 +182,11 @@ subpath for interactive help output.
         <span class="param-flags">optional</span>
         The CQL protocol version to use. Defaults to 2.
       </li>
+      <li>
+        <span class="param">connect_timeout</span>
+        <span class="param-flags">optional</span>
+        The connection timeout to use. Defaults to 5s.
+      </li>
     </ul>
   </dd>
 

--- a/website/source/docs/secrets/cassandra/index.html.md
+++ b/website/source/docs/secrets/cassandra/index.html.md
@@ -185,7 +185,7 @@ subpath for interactive help output.
       <li>
         <span class="param">connect_timeout</span>
         <span class="param-flags">optional</span>
-        The connection timeout to use. Defaults to 5s.
+        The connection timeout to use. Defaults to 5 seconds.
       </li>
     </ul>
   </dd>


### PR DESCRIPTION
The cassandra backend now supports a configurable connect timeout. The timeout is configured using the connect_timeout parameter in the session configuration.  Also align the timeout to 5 seconds which is the default for the Python and Java drivers.

Fixes #1538