### PR TITLE
Add allowed_roles to ssh-helper-config and return role name from verify call

### DIFF
--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -41,13 +41,16 @@ type SSHHelper struct {
 type SSHVerifyResponse struct {
 	// Usually empty. If the request OTP is echo request message, this will
 	// be set to the corresponding echo response message.
-	Message string `mapstructure:"message"`
+	Message string `json:"message" structs:"message" mapstructure:"message"`
 
 	// Username associated with the OTP
-	Username string `mapstructure:"username"`
+	Username string `json:"username" structs:"username" mapstructure:"username"`
 
 	// IP associated with the OTP
-	IP string `mapstructure:"ip"`
+	IP string `json:"ip" structs:"ip" mapstructure:"ip"`
+
+	// Name of the role against which the OTP was issued
+	RoleName string `json:"role_name" structs:"role_name" mapstructure:"role_name"`
 }
 
 // SSHHelperConfig is a structure which represents the entries from the vault-ssh-helper's configuration file.
@@ -57,6 +60,7 @@ type SSHHelperConfig struct {
 	CACert          string `hcl:"ca_cert"`
 	CAPath          string `hcl:"ca_path"`
 	AllowedCidrList string `hcl:"allowed_cidr_list"`
+	AllowedRoles    string `hcl:"allowed_roles"`
 	TLSSkipVerify   bool   `hcl:"tls_skip_verify"`
 }
 
@@ -139,6 +143,7 @@ func ParseSSHHelperConfig(contents string) (*SSHHelperConfig, error) {
 		"ca_cert",
 		"ca_path",
 		"allowed_cidr_list",
+		"allowed_roles",
 		"tls_skip_verify",
 	}
 	if err := checkHCLKeys(list, valid); err != nil {

--- a/builtin/logical/ssh/linux_install_script.go
+++ b/builtin/logical/ssh/linux_install_script.go
@@ -10,7 +10,7 @@ const (
 # authoried_keys file in a typical linux machine. 
 # 
 # If the platform differs or if the binaries used in this script are not available
-# in targer machine, use the 'install_script' parameter with 'roles/' endpoint to
+# in target machine, use the 'install_script' parameter with 'roles/' endpoint to
 # register a custom script (applicable for Dynamic type only).
 #
 # Vault server runs this script on the target machine with the following params:

--- a/builtin/logical/ssh/path_verify.go
+++ b/builtin/logical/ssh/path_verify.go
@@ -77,8 +77,9 @@ func (b *backend) pathVerifyWrite(req *logical.Request, d *framework.FieldData) 
 	// Return username and IP only if there were no problems uptill this point.
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"username": otpEntry.Username,
-			"ip":       otpEntry.IP,
+			"username":  otpEntry.Username,
+			"ip":        otpEntry.IP,
+			"role_name": otpEntry.RoleName,
 		},
 	}, nil
 }


### PR DESCRIPTION
Adding `allowed_roles` to vault-ssh-helper configuration.