### PR TITLE
Fix broken 0.6 upgrade link in nav bar.

### DIFF
--- a/website/source/layouts/install.erb
+++ b/website/source/layouts/install.erb
@@ -26,7 +26,7 @@
 							<a href="/docs/install/upgrade-to-0.5.1.html">Upgrade to 0.5.1</a>
 						</li>
 						<li<%= sidebar_current("docs-install-upgrade-to-0.6.0") %>>
-							<a href="/docs/install/upgrade-to-0.6.0.html">Upgrade to 0.6.0</a>
+							<a href="/docs/install/upgrade-to-0.6.html">Upgrade to 0.6</a>
 						</li>
 					</ul>
 				</li>


### PR DESCRIPTION
File is 0.6.html, not 0.6.0.html.  Changed the text of the link to to match 0.5 link style as well.