### PR TITLE
Allow overriding of the displayname when creating mysql users.

### DIFF
--- a/builtin/logical/mysql/path_role_create.go
+++ b/builtin/logical/mysql/path_role_create.go
@@ -30,6 +30,7 @@ func pathRoleCreate(b *backend) *framework.Path {
 
 func (b *backend) pathRoleCreateRead(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	var displayName string;
 	name := data.Get("name").(string)
 
 	// Get the role
@@ -50,8 +51,15 @@ func (b *backend) pathRoleCreateRead(
 		lease = &configLease{}
 	}
 
-	// Generate our username and password. MySQL limits user to 16 characters
-	displayName := req.DisplayName
+	// Generate our username and password. MySQL limits user to 16 characters.
+	// If a `displayname` attribute is set, use that; otherwise
+	// default to the displayname of the requestor.
+	dn, ok := data.GetOk("displayname")
+	if ok == true {
+	        displayName = dn.(string)
+	} else {
+	        displayName = req.DisplayName
+	}
 	if len(displayName) > 10 {
 		displayName = displayName[:10]
 	}

--- a/builtin/logical/mysql/path_roles.go
+++ b/builtin/logical/mysql/path_roles.go
@@ -34,6 +34,11 @@ func pathRoles(b *backend) *framework.Path {
 				Type:        framework.TypeString,
 				Description: "SQL string to create a user. See help for more info.",
 			},
+
+			"displayname": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Displayname to prepend to the generated username. Optional.",
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -105,6 +110,7 @@ func (b *backend) pathRoleCreate(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	name := data.Get("name").(string)
 	sql := data.Get("sql").(string)
+	displayname := data.Get("displayname").(string)
 
 	// Get our connection
 	db, err := b.DB(req.Storage)
@@ -128,6 +134,7 @@ func (b *backend) pathRoleCreate(
 	// Store it
 	entry, err := logical.StorageEntryJSON("role/"+name, &roleEntry{
 		SQL: sql,
+		DISPLAYNAME: displayname,
 	})
 	if err != nil {
 		return nil, err
@@ -139,7 +146,8 @@ func (b *backend) pathRoleCreate(
 }
 
 type roleEntry struct {
-	SQL string `json:"sql"`
+	SQL         string `json:"sql"`
+	DISPLAYNAME string `json:"displayname"`
 }
 
 const pathRoleHelpSyn = `
@@ -165,4 +173,9 @@ Example of a decent SQL query to use:
 
 Note the above user would be able to access anything in db1. Please see the MySQL
 manual on the GRANT command to learn how to do more fine grained access.
+
+The optional "displayname" parameter customizes the construction of the DB user
+inserted into the {{name}} variable: by default the displayname associated
+with the requestor is used, but if the displayname parameter is set in this
+path, that is used preferentially.
 `

--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -84,6 +84,17 @@ to tables in the database. More complex `GRANT` queries can be used to
 customize the privileges of the role. See the [MySQL manual](https://dev.mysql.com/doc/refman/5.7/en/grant.html)
 for more information.
 
+By default, the `{{name}}` variable is prepended with the displayname of
+the user creating role.  To override this, provide a `displayname` parameter
+when creating it:
+
+```
+$ vault write mysql/roles/readonly \
+    sql="CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';GRANT SELECT ON *.* TO '{{name}}'@'%';" \
+    displayname="rouser"
+Success! Data written to: mysql/roles/readonly
+```
+
 To generate a new set of credentials, we simply read from that role:
 
 ```
@@ -234,6 +245,12 @@ allowed to read.
         Must be semi-colon separated. The '{{name}}' and '{{password}}'
         values will be substituted.
       </li>
+      <li>
+        <span class="param">displayname</span>
+        <span class="param-flags">optional</span>
+        Manually specify the displayname that will be used to generate
+        the '{{name}}' value when the SQL statement is interpolated.
+      </li>
     </ul>
   </dd>
 
@@ -268,7 +285,8 @@ allowed to read.
     ```javascript
     {
       "data": {
-        "sql": "CREATE USER..."
+        "sql": "CREATE USER...",
+        "displayname": "USERNAME"
       }
     }
     ```


### PR DESCRIPTION
Tests pass:
`$ make test TEST=./vault
go generate
CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -tags='vault' ./vault  -timeout=120s -parallel=4
ok  	github.com/hashicorp/vault/vault	37.757s`