### PR TITLE
concat role name and token displayname to form mysql username

### DIFF
--- a/builtin/logical/mysql/path_role_create.go
+++ b/builtin/logical/mysql/path_role_create.go
@@ -31,6 +31,7 @@ func pathRoleCreate(b *backend) *framework.Path {
 func (b *backend) pathRoleCreateRead(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	name := data.Get("name").(string)
+	var usernameLength int
 
 	// Get the role
 	role, err := b.Role(req.Storage, name)
@@ -52,8 +53,14 @@ func (b *backend) pathRoleCreateRead(
 
 	// Generate our username and password. MySQL limits user to 16 characters
 	displayName := name
-	if len(displayName) > 10 {
-		displayName = displayName[:10]
+	ul, ok := data.GetOk("username_length")
+	if ok == true {
+		usernameLength = ul.(int)
+	} else {
+		usernameLength = 10
+	}
+	if len(displayName) > usernameLength {
+		displayName = displayName[:usernameLength]
 	}
 	userUUID, err := uuid.GenerateUUID()
 	if err != nil {

--- a/builtin/logical/mysql/path_role_create.go
+++ b/builtin/logical/mysql/path_role_create.go
@@ -51,7 +51,7 @@ func (b *backend) pathRoleCreateRead(
 	}
 
 	// Generate our username and password. MySQL limits user to 16 characters
-	displayName := req.DisplayName
+	displayName := name
 	if len(displayName) > 10 {
 		displayName = displayName[:10]
 	}

--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -245,18 +245,25 @@ the default on versions prior to that.
         values will be substituted.
       </li>
       <li>
-        <span class="param">displayname_length</span>
+        <span class="param">rolename_length</span>
         <span class="param-flags">optional</span>
         Determines how many characters from the role name will be used
         to form the mysql username interpolated into the '{{name}}' field
-        of the sql parameter.
+        of the sql parameter.  The default is 4.
+      </li>
+      <li>
+        <span class="param">displayname_length</span>
+        <span class="param-flags">optional</span>
+        Determines how many characters from the token display name will be used
+        to form the mysql username interpolated into the '{{name}}' field
+        of the sql parameter.  The default is 4.
       </li>
       <li>
         <span class="param">username_length</span>
         <span class="param-flags">optional</span>
         Determines the maximum total length in characters of the
         mysql username interpolated into the '{{name}}' field
-        of the sql parameter.
+        of the sql parameter.  The default is 16.
       </li>
     </ul>
   </dd>
@@ -389,7 +396,7 @@ the default on versions prior to that.
     ```javascript
     {
       "data": {
-        "username": "rolename-aefa635a-18",
+        "username": "user-role-aefa63",
         "password": "132ae3ef-5a64-7499-351e-bfe59f3a2a21"
       }
     }

--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -105,6 +105,13 @@ that trusted operators can manage the role definitions, and both
 users and applications are restricted in the credentials they are
 allowed to read.
 
+Optionally, you may configure the number of character from the role
+name that are truncated to form the mysql usernamed interpolated into
+the `{{name}}` field: the default is 10.  Note that versions of
+mysql prior to 5.8 have a 16 character total limit on user names, so
+it is probably not safe to increase this above the default on versions
+prior to that.
+
 ## API
 
 ### /mysql/config/connection
@@ -233,6 +240,13 @@ allowed to read.
         The SQL statements executed to create and configure the role.
         Must be semi-colon separated. The '{{name}}' and '{{password}}'
         values will be substituted.
+      </li>
+      <li>
+        <span class="param">username_length</span>
+        <span class="param-flags">optional</span>
+        Determines how many characters from the role name will be used
+        to form the mysql username interpolated into the '{{name}}' field
+        of the sql parameter.
       </li>
     </ul>
   </dd>

--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -92,7 +92,7 @@ Key           	Value
 lease_id      	mysql/creds/readonly/bd404e98-0f35-b378-269a-b7770ef01897
 lease_duration	3600
 password      	132ae3ef-5a64-7499-351e-bfe59f3a2a21
-username      	root-aefa635a-18
+username      	readonly-aefa635a-18
 ```
 
 By reading from the `creds/readonly` path, Vault has generated a new
@@ -105,12 +105,15 @@ that trusted operators can manage the role definitions, and both
 users and applications are restricted in the credentials they are
 allowed to read.
 
-Optionally, you may configure the number of character from the role
-name that are truncated to form the mysql usernamed interpolated into
-the `{{name}}` field: the default is 10.  Note that versions of
-mysql prior to 5.8 have a 16 character total limit on user names, so
-it is probably not safe to increase this above the default on versions
-prior to that.
+Optionally, you may configure both the number of characters from the role name
+that are truncated to form the display name portion of the mysql username
+interpolated into the `{{name}}` field: the default is 10. 
+
+You may also configure the total number of characters allowed in the entire
+generated username (the sum of the display name and uuid poritions); the
+default is 16. Note that versions of MySQL prior to 5.8 have a 16 character
+total limit on user names, so it is probably not safe to increase this above
+the default on versions prior to that.
 
 ## API
 
@@ -242,10 +245,17 @@ prior to that.
         values will be substituted.
       </li>
       <li>
-        <span class="param">username_length</span>
+        <span class="param">displayname_length</span>
         <span class="param-flags">optional</span>
         Determines how many characters from the role name will be used
         to form the mysql username interpolated into the '{{name}}' field
+        of the sql parameter.
+      </li>
+      <li>
+        <span class="param">username_length</span>
+        <span class="param-flags">optional</span>
+        Determines the maximum total length in characters of the
+        mysql username interpolated into the '{{name}}' field
         of the sql parameter.
       </li>
     </ul>
@@ -379,7 +389,7 @@ prior to that.
     ```javascript
     {
       "data": {
-        "username": "root-aefa635a-18",
+        "username": "rolename-aefa635a-18",
         "password": "132ae3ef-5a64-7499-351e-bfe59f3a2a21"
       }
     }


### PR DESCRIPTION
If a single token generates multiple myself roles, the generated mysql
username was previously prepended with the displayname of the vault
user; this makes the output of `show processlist` in mysql potentially
difficult to correlate with the roles actually in use without cross-
checking against the vault audit log.

See https://github.com/hashicorp/vault/pull/1603 for further discussion.