### PR TITLE
Set minimum TLS version in all tls.Config objects

### DIFF
--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -124,6 +124,7 @@ func (b *backend) pathConfigRead(
 	// Convert the integer representing the TLS version into string of
 	// the form 'tls10', 'tls11' or 'tls12'
 	data["tls_min_version"] = tlsutil.TLSReverseLookup[data["tls_min_version"].(uint16)]
+
 	return &logical.Response{
 		Data: data,
 	}, nil
@@ -162,13 +163,16 @@ func (b *backend) pathConfigWrite(
 		cfg.InsecureTLS = insecureTLS
 	}
 	tlsMinVersion := d.Get("tls_min_version").(string)
-	if tlsMinVersion != "" {
-		var ok bool
-		cfg.TLSMinVersion, ok = tlsutil.TLSLookup[tlsMinVersion]
-		if !ok {
-			return logical.ErrorResponse("failed to set 'tls_min_version'"), nil
-		}
+	if tlsMinVersion == "" {
+		return logical.ErrorResponse("failed to get 'tls_min_version' value"), nil
 	}
+
+	var ok bool
+	cfg.TLSMinVersion, ok = tlsutil.TLSLookup[tlsMinVersion]
+	if !ok {
+		return logical.ErrorResponse("invalid 'tls_min_version'"), nil
+	}
+
 	startTLS := d.Get("starttls").(bool)
 	if startTLS {
 		cfg.StartTLS = startTLS

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -222,15 +222,18 @@ type ConfigEntry struct {
 }
 
 func (c *ConfigEntry) GetTLSConfig(host string) (*tls.Config, error) {
-	tlsMinVersion, ok := tlsutil.TLSLookup[c.TLSMinVersion]
-	if !ok {
-		return nil, fmt.Errorf("invalid 'tls_min_version' in config")
-	}
-
 	tlsConfig := &tls.Config{
-		MinVersion: tlsMinVersion,
 		ServerName: host,
 	}
+
+	if c.TLSMinVersion != "" {
+		tlsMinVersion, ok := tlsutil.TLSLookup[c.TLSMinVersion]
+		if !ok {
+			return nil, fmt.Errorf("invalid 'tls_min_version' in config")
+		}
+		tlsConfig.MinVersion = tlsMinVersion
+	}
+
 	if c.InsecureTLS {
 		tlsConfig.InsecureSkipVerify = true
 	}

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -215,6 +215,7 @@ type ConfigEntry struct {
 
 func (c *ConfigEntry) GetTLSConfig(host string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
+		MinVersion: VersionTLS12,
 		ServerName: host,
 	}
 	if c.InsecureTLS {

--- a/builtin/logical/cassandra/backend.go
+++ b/builtin/logical/cassandra/backend.go
@@ -46,16 +46,17 @@ type backend struct {
 }
 
 type sessionConfig struct {
-	Hosts           string `json:"hosts" structs:"hosts"`
-	Username        string `json:"username" structs:"username"`
-	Password        string `json:"password" structs:"password"`
-	TLS             bool   `json:"tls" structs:"tls"`
-	InsecureTLS     bool   `json:"insecure_tls" structs:"insecure_tls"`
-	Certificate     string `json:"certificate" structs:"certificate"`
-	PrivateKey      string `json:"private_key" structs:"private_key"`
-	IssuingCA       string `json:"issuing_ca" structs:"issuing_ca"`
-	ProtocolVersion int    `json:"protocol_version" structs:"protocol_version"`
-	ConnectTimeout  int    `json:"connect_timeout" structs:"connect_timeout"`
+	Hosts           string `json:"hosts" structs:"hosts" mapstructure:"hosts"`
+	Username        string `json:"username" structs:"username" mapstructure:"username"`
+	Password        string `json:"password" structs:"password" mapstructure:"password"`
+	TLS             bool   `json:"tls" structs:"tls" mapstructure:"tls"`
+	InsecureTLS     bool   `json:"insecure_tls" structs:"insecure_tls" mapstructure:"insecure_tls"`
+	Certificate     string `json:"certificate" structs:"certificate" mapstructure:"certificate"`
+	PrivateKey      string `json:"private_key" structs:"private_key" mapstructure:"private_key"`
+	IssuingCA       string `json:"issuing_ca" structs:"issuing_ca" mapstructure:"issuing_ca"`
+	ProtocolVersion int    `json:"protocol_version" structs:"protocol_version" mapstructure:"protocol_version"`
+	ConnectTimeout  int    `json:"connect_timeout" structs:"connect_timeout" mapstructure:"connect_timeout"`
+	TLSMinVersion   uint16 `json:"tls_min_version" structs:"tls_min_version" mapstructure:"tls_min_version"`
 }
 
 // DB returns the database connection.

--- a/builtin/logical/cassandra/backend.go
+++ b/builtin/logical/cassandra/backend.go
@@ -56,7 +56,7 @@ type sessionConfig struct {
 	IssuingCA       string `json:"issuing_ca" structs:"issuing_ca" mapstructure:"issuing_ca"`
 	ProtocolVersion int    `json:"protocol_version" structs:"protocol_version" mapstructure:"protocol_version"`
 	ConnectTimeout  int    `json:"connect_timeout" structs:"connect_timeout" mapstructure:"connect_timeout"`
-	TLSMinVersion   uint16 `json:"tls_min_version" structs:"tls_min_version" mapstructure:"tls_min_version"`
+	TLSMinVersion   string `json:"tls_min_version" structs:"tls_min_version" mapstructure:"tls_min_version"`
 }
 
 // DB returns the database connection.

--- a/builtin/logical/cassandra/path_config_connection.go
+++ b/builtin/logical/cassandra/path_config_connection.go
@@ -105,15 +105,8 @@ func (b *backend) pathConnectionRead(
 		config.PrivateKey = "**********"
 	}
 
-	// Convert the struct into a map
-	d := structs.New(config).Map()
-
-	// Convert the integer representing the TLS version into string of
-	// the form 'tls10', 'tls11' or 'tls12'
-	d["tls_min_version"] = tlsutil.TLSReverseLookup[d["tls_min_version"].(uint16)]
-
 	return &logical.Response{
-		Data: d,
+		Data: structs.New(config).Map(),
 	}, nil
 }
 
@@ -142,13 +135,13 @@ func (b *backend) pathConnectionWrite(
 		ConnectTimeout:  data.Get("connect_timeout").(int),
 	}
 
-	tlsMinVersion := data.Get("tls_min_version").(string)
-	if tlsMinVersion == "" {
+	config.TLSMinVersion = data.Get("tls_min_version").(string)
+	if config.TLSMinVersion == "" {
 		return logical.ErrorResponse("failed to get 'tls_min_version' value"), nil
 	}
 
 	var ok bool
-	config.TLSMinVersion, ok = tlsutil.TLSLookup[tlsMinVersion]
+	_, ok = tlsutil.TLSLookup[config.TLSMinVersion]
 	if !ok {
 		return logical.ErrorResponse("invalid 'tls_min_version'"), nil
 	}

--- a/builtin/logical/cassandra/util.go
+++ b/builtin/logical/cassandra/util.go
@@ -75,12 +75,17 @@ func createSession(cfg *sessionConfig, s logical.Storage) (*gocql.Session, error
 			}
 			tlsConfig.InsecureSkipVerify = cfg.InsecureTLS
 
-			var ok bool
-			tlsConfig.MinVersion, ok = tlsutil.TLSLookup[cfg.TLSMinVersion]
-			if !ok {
-				return nil, fmt.Errorf("invalid 'tls_min_version' in config")
+			if cfg.TLSMinVersion != "" {
+				var ok bool
+				tlsConfig.MinVersion, ok = tlsutil.TLSLookup[cfg.TLSMinVersion]
+				if !ok {
+					return nil, fmt.Errorf("invalid 'tls_min_version' in config")
+				}
+			} else {
+				// MinVersion was not being set earlier. Reset it to
+				// zero to gracefully handle upgrades.
+				tlsConfig.MinVersion = 0
 			}
-
 		}
 
 		clusterConfig.SslOpts = &gocql.SslOptions{

--- a/builtin/logical/cassandra/util.go
+++ b/builtin/logical/cassandra/util.go
@@ -48,11 +48,7 @@ func createSession(cfg *sessionConfig, s logical.Storage) (*gocql.Session, error
 	clusterConfig.Timeout = time.Duration(cfg.ConnectTimeout) * time.Second
 
 	if cfg.TLS {
-		tlsConfig := &tls.Config{
-			InsecureSkipVerify: cfg.InsecureTLS,
-			MinVersion:         VersionTLS12,
-		}
-
+		var tlsConfig *tls.Config
 		if len(cfg.Certificate) > 0 || len(cfg.IssuingCA) > 0 {
 			if len(cfg.Certificate) > 0 && len(cfg.PrivateKey) == 0 {
 				return nil, fmt.Errorf("Found certificate for TLS authentication but no private key")
@@ -65,18 +61,19 @@ func createSession(cfg *sessionConfig, s logical.Storage) (*gocql.Session, error
 			}
 			if len(cfg.IssuingCA) > 0 {
 				certBundle.IssuingCA = cfg.IssuingCA
-				tlsConfig.InsecureSkipVerify = false
 			}
 
 			parsedCertBundle, err := certBundle.ToParsedCertBundle()
 			if err != nil {
-				return nil, fmt.Errorf("Error parsing certificate bundle: %s", err)
+				return nil, fmt.Errorf("failed to parse certificate bundle: %s", err)
 			}
 
 			tlsConfig, err = parsedCertBundle.GetTLSConfig(certutil.TLSClient)
 			if err != nil {
-				return nil, fmt.Errorf("Error getting TLS configuration: %s", err)
+				return nil, fmt.Errorf("failed to get TLS configuration: %s", err)
 			}
+			tlsConfig.InsecureSkipVerify = cfg.InsecureTLS
+			tlsConfig.MinVersion = cfg.TLSMinVersion
 		}
 
 		clusterConfig.SslOpts = &gocql.SslOptions{

--- a/builtin/logical/cassandra/util.go
+++ b/builtin/logical/cassandra/util.go
@@ -50,6 +50,7 @@ func createSession(cfg *sessionConfig, s logical.Storage) (*gocql.Session, error
 	if cfg.TLS {
 		tlsConfig := &tls.Config{
 			InsecureSkipVerify: cfg.InsecureTLS,
+			MinVersion:         VersionTLS12,
 		}
 
 		if len(cfg.Certificate) > 0 || len(cfg.IssuingCA) > 0 {

--- a/command/server/listener.go
+++ b/command/server/listener.go
@@ -10,6 +10,8 @@ import (
 	"net"
 	"strconv"
 	"sync"
+
+	"github.com/hashicorp/vault/helper/tlsutil"
 )
 
 // ListenerFactory is the factory function to create a listener.
@@ -19,13 +21,6 @@ type ListenerFactory func(map[string]string, io.Writer) (net.Listener, map[strin
 var BuiltinListeners = map[string]ListenerFactory{
 	"tcp":   tcpListenerFactory,
 	"atlas": atlasListenerFactory,
-}
-
-// tlsLookup maps the tls_min_version configuration to the internal value
-var tlsLookup = map[string]uint16{
-	"tls10": tls.VersionTLS10,
-	"tls11": tls.VersionTLS11,
-	"tls12": tls.VersionTLS12,
 }
 
 // NewListener creates a new listener of the given type with the given
@@ -81,7 +76,7 @@ func listenerWrapTLS(
 	tlsConf := &tls.Config{}
 	tlsConf.GetCertificate = cg.getCertificate
 	tlsConf.NextProtos = []string{"http/1.1"}
-	tlsConf.MinVersion, ok = tlsLookup[tlsvers]
+	tlsConf.MinVersion, ok = tlsutil.TLSLookup[tlsvers]
 	if !ok {
 		return nil, nil, nil, fmt.Errorf("'tls_min_version' value %s not supported, please specify one of [tls10,tls11,tls12]", tlsvers)
 	}

--- a/helper/certutil/types.go
+++ b/helper/certutil/types.go
@@ -438,6 +438,7 @@ func (p *ParsedCertBundle) GetTLSConfig(usage TLSUsage) (*tls.Config, error) {
 
 	tlsConfig := &tls.Config{
 		NextProtos: []string{"http/1.1"},
+		MinVersion: VersionTLS12,
 	}
 
 	if p.Certificate != nil {

--- a/helper/certutil/types.go
+++ b/helper/certutil/types.go
@@ -438,7 +438,7 @@ func (p *ParsedCertBundle) GetTLSConfig(usage TLSUsage) (*tls.Config, error) {
 
 	tlsConfig := &tls.Config{
 		NextProtos: []string{"http/1.1"},
-		MinVersion: VersionTLS12,
+		MinVersion: tls.VersionTLS12,
 	}
 
 	if p.Certificate != nil {

--- a/helper/tlsutil/tls.go
+++ b/helper/tlsutil/tls.go
@@ -8,9 +8,3 @@ var TLSLookup = map[string]uint16{
 	"tls11": tls.VersionTLS11,
 	"tls12": tls.VersionTLS12,
 }
-
-var TLSReverseLookup = map[uint16]string{
-	tls.VersionTLS10: "tls10",
-	tls.VersionTLS11: "tls11",
-	tls.VersionTLS12: "tls12",
-}

--- a/helper/tlsutil/tls.go
+++ b/helper/tlsutil/tls.go
@@ -1,0 +1,16 @@
+package tlsutil
+
+import "crypto/tls"
+
+// TLSLookup maps the tls_min_version configuration to the internal value
+var TLSLookup = map[string]uint16{
+	"tls10": tls.VersionTLS10,
+	"tls11": tls.VersionTLS11,
+	"tls12": tls.VersionTLS12,
+}
+
+var TLSReverseLookup = map[uint16]string{
+	tls.VersionTLS10: "tls10",
+	tls.VersionTLS11: "tls11",
+	tls.VersionTLS12: "tls12",
+}

--- a/physical/consul.go
+++ b/physical/consul.go
@@ -191,7 +191,7 @@ func setupTLSConfig(conf map[string]string) (*tls.Config, error) {
 	}
 
 	tlsClientConfig := &tls.Config{
-		MinVersion:         VersionTLS12,
+		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: insecureSkipVerify,
 		ServerName:         serverName[0],
 	}

--- a/physical/consul.go
+++ b/physical/consul.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/vault/helper/tlsutil"
 )
 
 const (
@@ -190,8 +191,19 @@ func setupTLSConfig(conf map[string]string) (*tls.Config, error) {
 		insecureSkipVerify = true
 	}
 
+	tlsMinVersionStr, ok := conf["tls_min_version"]
+	if !ok {
+		// Set the default value
+		tlsMinVersionStr = "tls12"
+	}
+
+	tlsMinVersion, ok := tlsutil.TLSLookup[tlsMinVersionStr]
+	if !ok {
+		return nil, fmt.Errorf("invalid 'tls_min_version'")
+	}
+
 	tlsClientConfig := &tls.Config{
-		MinVersion:         tls.VersionTLS12,
+		MinVersion:         tlsMinVersion,
 		InsecureSkipVerify: insecureSkipVerify,
 		ServerName:         serverName[0],
 	}

--- a/physical/consul.go
+++ b/physical/consul.go
@@ -191,6 +191,7 @@ func setupTLSConfig(conf map[string]string) (*tls.Config, error) {
 	}
 
 	tlsClientConfig := &tls.Config{
+		MinVersion:         VersionTLS12,
 		InsecureSkipVerify: insecureSkipVerify,
 		ServerName:         serverName[0],
 	}

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -223,6 +223,9 @@ For Consul, the following options are supported:
   * `tls_skip_verify` (optional) - If non-empty, then TLS host verification
     will be disabled for Consul communication.  Defaults to false.
 
+  * `tls_min_version` (optional) - Minimum TLS version to use. Accepted values
+    are 'tls10', 'tls11' or 'tls12'. Defaults to 'tls12'.
+
 The following settings should be set according to your [Consul encryption
 settings](https://www.consul.io/docs/agent/encryption.html):
 


### PR DESCRIPTION
This also fixes the `tlsConfig` getting overwritten in cassandra backend.