### PR TITLE
Fixed re-registrations and health-check flatenning issue

### DIFF
--- a/physical/consul.go
+++ b/physical/consul.go
@@ -513,7 +513,13 @@ shutdown:
 // checkID returns the ID used for a Consul Check.  Assume at least a read
 // lock is held.
 func (c *ConsulBackend) checkID() string {
-	return "vault-sealed-check"
+	return fmt.Sprintf("vault-sealed-check:%s:%d", c.advertiseHost, c.advertisePort)
+}
+
+// serviceID returns the Vault ServiceID for use in Consul.  Assume at least
+// a read lock is held.
+func (c *ConsulBackend) serviceID() string {
+	return fmt.Sprintf("%s:%s:%d", c.serviceName, c.advertiseHost, c.advertisePort)
 }
 
 // reconcileConsul queries the state of Vault Core and Consul and fixes up
@@ -527,16 +533,21 @@ func (c *ConsulBackend) reconcileConsul(registeredServiceID string, activeFunc a
 	sealed := sealedFunc()
 
 	agent := c.client.Agent()
+	catalog := c.client.Catalog()
+
+	serviceID = c.serviceID()
 
 	// Get the current state of Vault from Consul
-	var currentVaultService *api.AgentService
-	if services, err := agent.Services(); err == nil {
-		if service, ok := services[c.serviceName]; ok {
-			currentVaultService = service
+	var currentVaultService *api.CatalogService
+	if services, _, err := catalog.Service("vault", "", nil); err == nil {
+		for _, service := range services {
+			if serviceID == service.ServiceID {
+				currentVaultService = service
+				break
+			}
 		}
 	}
 
-	serviceID = c.serviceID()
 	tags := serviceTags(active)
 
 	var reregister bool
@@ -546,14 +557,16 @@ func (c *ConsulBackend) reconcileConsul(registeredServiceID string, activeFunc a
 		reregister = true
 	default:
 		switch {
-		case len(currentVaultService.Tags) != 1,
-			currentVaultService.Tags[0] != tags[0]:
+		case len(currentVaultService.ServiceTags) != 1,
+			currentVaultService.ServiceTags[0] != tags[0]:
 			reregister = true
 		}
 	}
 
 	if !reregister {
-		return "", nil
+		// When re-registration is not required, return a valid serviceID
+		// to avoid registration in the next cycle.
+		return serviceID, nil
 	}
 
 	service := &api.AgentServiceRegistration{
@@ -601,12 +614,6 @@ func (c *ConsulBackend) runCheck(sealed bool) error {
 	} else {
 		return agent.FailTTL(c.checkID(), "Vault Sealed")
 	}
-}
-
-// serviceID returns the Vault ServiceID for use in Consul.  Assume at least
-// a read lock is held.
-func (c *ConsulBackend) serviceID() string {
-	return fmt.Sprintf("%s:%s:%d", c.serviceName, c.advertiseHost, c.advertisePort)
 }
 
 // serviceTags returns all of the relevant tags for Consul.

--- a/physical/consul.go
+++ b/physical/consul.go
@@ -513,7 +513,7 @@ shutdown:
 // checkID returns the ID used for a Consul Check.  Assume at least a read
 // lock is held.
 func (c *ConsulBackend) checkID() string {
-	return fmt.Sprintf("vault-sealed-check:%s:%d", c.advertiseHost, c.advertisePort)
+	return fmt.Sprintf("%s:vault-sealed-check", c.serviceID())
 }
 
 // serviceID returns the Vault ServiceID for use in Consul.  Assume at least

--- a/physical/consul.go
+++ b/physical/consul.go
@@ -539,7 +539,7 @@ func (c *ConsulBackend) reconcileConsul(registeredServiceID string, activeFunc a
 
 	// Get the current state of Vault from Consul
 	var currentVaultService *api.CatalogService
-	if services, _, err := catalog.Service("vault", "", nil); err == nil {
+	if services, _, err := catalog.Service(c.serviceName, "", &api.QueryOptions{AllowStale: true}); err == nil {
 		for _, service := range services {
 			if serviceID == service.ServiceID {
 				currentVaultService = service

--- a/physical/consul_test.go
+++ b/physical/consul_test.go
@@ -295,13 +295,6 @@ func TestConsul_NotifySealedStateChange(t *testing.T) {
 	}
 }
 
-func TestConsul_checkID(t *testing.T) {
-	c := testConsulBackend(t)
-	if c.checkID() != "vault-sealed-check" {
-		t.Errorf("bad")
-	}
-}
-
 func TestConsul_serviceID(t *testing.T) {
 	passingTests := []struct {
 		name          string


### PR DESCRIPTION
All the nodes of a Vault cluster are resulting in different checks for each.
Initializing the Vault and unsealing a node results in the corresponding check marked to 'passing', while all other nodes are still 'critical'.
Unsealing each one of the standby nodes resulting in it's check being marked as 'passing'