### PR TITLE
Added Vault version information to the 'status' command

### DIFF
--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -49,9 +49,11 @@ func sealStatusRequest(c *Sys, r *Request) (*SealStatusResponse, error) {
 }
 
 type SealStatusResponse struct {
-	Sealed   bool
-	T        int
-	N        int
-	Progress int
-	Version  string
+	Sealed      bool   `json:"sealed"`
+	T           int    `json:"t"`
+	N           int    `json:"n"`
+	Progress    int    `json:"progress"`
+	Version     string `json:"version"`
+	ClusterName string `json:"cluster_name,omitempty"`
+	ClusterID   string `json:"cluster_id,omitempty"`
 }

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -53,4 +53,5 @@ type SealStatusResponse struct {
 	T        int
 	N        int
 	Progress int
+	Version  string
 }

--- a/command/status.go
+++ b/command/status.go
@@ -38,11 +38,13 @@ func (c *StatusCommand) Run(args []string) int {
 		"Sealed: %v\n"+
 			"Key Shares: %d\n"+
 			"Key Threshold: %d\n"+
-			"Unseal Progress: %d",
+			"Unseal Progress: %d\n"+
+			"Version: %s",
 		sealStatus.Sealed,
 		sealStatus.N,
 		sealStatus.T,
-		sealStatus.Progress))
+		sealStatus.Progress,
+		sealStatus.Version))
 
 	// Mask the 'Vault is sealed' error, since this means HA is enabled,
 	// but that we cannot query for the leader since we are sealed.

--- a/command/status.go
+++ b/command/status.go
@@ -34,7 +34,8 @@ func (c *StatusCommand) Run(args []string) int {
 			"Error checking seal status: %s", err))
 		return 1
 	}
-	c.Ui.Output(fmt.Sprintf(
+
+	outStr := fmt.Sprintf(
 		"Sealed: %v\n"+
 			"Key Shares: %d\n"+
 			"Key Threshold: %d\n"+
@@ -44,7 +45,13 @@ func (c *StatusCommand) Run(args []string) int {
 		sealStatus.N,
 		sealStatus.T,
 		sealStatus.Progress,
-		sealStatus.Version))
+		sealStatus.Version)
+
+	if sealStatus.ClusterName != "" && sealStatus.ClusterID != "" {
+		outStr = fmt.Sprintf("%s\nCluster Name: %s\nCluster ID: %s", outStr, sealStatus.ClusterName, sealStatus.ClusterID)
+	}
+
+	c.Ui.Output(outStr)
 
 	// Mask the 'Vault is sealed' error, since this means HA is enabled,
 	// but that we cannot query for the leader since we are sealed.

--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/version"
 )
 
 func handleSysSeal(core *vault.Core) http.Handler {
@@ -155,14 +156,16 @@ func handleSysSealStatusRaw(core *vault.Core, w http.ResponseWriter, r *http.Req
 		T:        sealConfig.SecretThreshold,
 		N:        sealConfig.SecretShares,
 		Progress: core.SecretProgress(),
+		Version:  version.GetVersion().String(),
 	})
 }
 
 type SealStatusResponse struct {
-	Sealed   bool `json:"sealed"`
-	T        int  `json:"t"`
-	N        int  `json:"n"`
-	Progress int  `json:"progress"`
+	Sealed   bool   `json:"sealed"`
+	T        int    `json:"t"`
+	N        int    `json:"n"`
+	Progress int    `json:"progress"`
+	Version  string `json:"version"`
 }
 
 type UnsealRequest struct {

--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -156,7 +156,7 @@ func handleSysSealStatusRaw(core *vault.Core, w http.ResponseWriter, r *http.Req
 	if !sealed {
 		cluster, err := core.Cluster()
 
-		// Don't set the cluster details in the health status when Vault is sealed
+		// Don't set the cluster details in the status when Vault is sealed
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err)
 			return

--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -151,21 +151,43 @@ func handleSysSealStatusRaw(core *vault.Core, w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Fetch the local cluster name and identifier
+	var clusterName, clusterID string
+	if !sealed {
+		cluster, err := core.Cluster()
+
+		// Don't set the cluster details in the health status when Vault is sealed
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, err)
+			return
+		}
+		if cluster == nil {
+			respondError(w, http.StatusInternalServerError, nil)
+			return
+		}
+		clusterName = cluster.Name
+		clusterID = cluster.ID
+	}
+
 	respondOk(w, &SealStatusResponse{
-		Sealed:   sealed,
-		T:        sealConfig.SecretThreshold,
-		N:        sealConfig.SecretShares,
-		Progress: core.SecretProgress(),
-		Version:  version.GetVersion().String(),
+		Sealed:      sealed,
+		T:           sealConfig.SecretThreshold,
+		N:           sealConfig.SecretShares,
+		Progress:    core.SecretProgress(),
+		Version:     version.GetVersion().String(),
+		ClusterName: clusterName,
+		ClusterID:   clusterID,
 	})
 }
 
 type SealStatusResponse struct {
-	Sealed   bool   `json:"sealed"`
-	T        int    `json:"t"`
-	N        int    `json:"n"`
-	Progress int    `json:"progress"`
-	Version  string `json:"version"`
+	Sealed      bool   `json:"sealed"`
+	T           int    `json:"t"`
+	N           int    `json:"n"`
+	Progress    int    `json:"progress"`
+	Version     string `json:"version"`
+	ClusterName string `json:"cluster_name,omitempty"`
+	ClusterID   string `json:"cluster_id,omitempty"`
 }
 
 type UnsealRequest struct {

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -36,8 +36,23 @@ func TestSysSealStatus(t *testing.T) {
 		t.Fatalf("expected version information")
 	}
 	expected["version"] = actual["version"]
+	if actual["cluster_name"] == nil {
+		delete(expected, "cluster_name")
+	} else {
+		expected["cluster_name"] = actual["cluster_name"]
+	}
+	if actual["cluster_id"] == nil {
+		delete(expected, "cluster_id")
+	} else {
+		expected["cluster_id"] = actual["cluster_id"]
+	}
+	if actual["cluster_id"] == nil {
+		delete(expected, "cluster_id")
+	} else {
+		expected["cluster_id"] = actual["cluster_id"]
+	}
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
+		t.Fatalf("bad: expected: %#v\nactual: %#v", expected, actual)
 	}
 }
 
@@ -112,8 +127,18 @@ func TestSysUnseal(t *testing.T) {
 		t.Fatalf("expected version information")
 	}
 	expected["version"] = actual["version"]
+	if actual["cluster_name"] == nil {
+		delete(expected, "cluster_name")
+	} else {
+		expected["cluster_name"] = actual["cluster_name"]
+	}
+	if actual["cluster_id"] == nil {
+		delete(expected, "cluster_id")
+	} else {
+		expected["cluster_id"] = actual["cluster_id"]
+	}
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
+		t.Fatalf("bad: expected: %#v\nactual: %#v", expected, actual)
 	}
 }
 
@@ -140,8 +165,18 @@ func TestSysUnseal_badKey(t *testing.T) {
 		t.Fatalf("expected version information")
 	}
 	expected["version"] = actual["version"]
+	if actual["cluster_name"] == nil {
+		delete(expected, "cluster_name")
+	} else {
+		expected["cluster_name"] = actual["cluster_name"]
+	}
+	if actual["cluster_id"] == nil {
+		delete(expected, "cluster_id")
+	} else {
+		expected["cluster_id"] = actual["cluster_id"]
+	}
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
+		t.Fatalf("bad: expected: %#v\nactual: %#v", expected, actual)
 	}
 }
 
@@ -185,6 +220,16 @@ func TestSysUnseal_Reset(t *testing.T) {
 			t.Fatalf("expected version information")
 		}
 		expected["version"] = actual["version"]
+		if actual["cluster_name"] == nil {
+			delete(expected, "cluster_name")
+		} else {
+			expected["cluster_name"] = actual["cluster_name"]
+		}
+		if actual["cluster_id"] == nil {
+			delete(expected, "cluster_id")
+		} else {
+			expected["cluster_id"] = actual["cluster_id"]
+		}
 		if !reflect.DeepEqual(actual, expected) {
 			t.Fatalf("\nexpected:\n%#v\nactual:\n%#v\n", expected, actual)
 		}
@@ -207,6 +252,16 @@ func TestSysUnseal_Reset(t *testing.T) {
 		t.Fatalf("expected version information")
 	}
 	expected["version"] = actual["version"]
+	if actual["cluster_name"] == nil {
+		delete(expected, "cluster_name")
+	} else {
+		expected["cluster_name"] = actual["cluster_name"]
+	}
+	if actual["cluster_id"] == nil {
+		delete(expected, "cluster_id")
+	} else {
+		expected["cluster_id"] = actual["cluster_id"]
+	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected:\n%#v\nactual:\n%#v\n", expected, actual)
 	}

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -32,6 +32,10 @@ func TestSysSealStatus(t *testing.T) {
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
+	if actual["version"] == nil {
+		t.Fatalf("expected version information")
+	}
+	expected["version"] = actual["version"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
@@ -104,6 +108,10 @@ func TestSysUnseal(t *testing.T) {
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
+	if actual["version"] == nil {
+		t.Fatalf("expected version information")
+	}
+	expected["version"] = actual["version"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
@@ -128,6 +136,10 @@ func TestSysUnseal_badKey(t *testing.T) {
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
+	if actual["version"] == nil {
+		t.Fatalf("expected version information")
+	}
+	expected["version"] = actual["version"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
@@ -169,6 +181,10 @@ func TestSysUnseal_Reset(t *testing.T) {
 		}
 		testResponseStatus(t, resp, 200)
 		testResponseBody(t, resp, &actual)
+		if actual["version"] == nil {
+			t.Fatalf("expected version information")
+		}
+		expected["version"] = actual["version"]
 		if !reflect.DeepEqual(actual, expected) {
 			t.Fatalf("\nexpected:\n%#v\nactual:\n%#v\n", expected, actual)
 		}
@@ -187,6 +203,10 @@ func TestSysUnseal_Reset(t *testing.T) {
 	}
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
+	if actual["version"] == nil {
+		t.Fatalf("expected version information")
+	}
+	expected["version"] = actual["version"]
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected:\n%#v\nactual:\n%#v\n", expected, actual)
 	}

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -46,11 +46,6 @@ func TestSysSealStatus(t *testing.T) {
 	} else {
 		expected["cluster_id"] = actual["cluster_id"]
 	}
-	if actual["cluster_id"] == nil {
-		delete(expected, "cluster_id")
-	} else {
-		expected["cluster_id"] = actual["cluster_id"]
-	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: expected: %#v\nactual: %#v", expected, actual)
 	}


### PR DESCRIPTION
Fixes #1668 

Did not add the version in the `unseal` command's output.