### PR TITLE
Added capability to execute remote commands in SSH

### DIFF
--- a/command/ssh.go
+++ b/command/ssh.go
@@ -32,6 +32,7 @@ type SSHCredentialResp struct {
 
 func (c *SSHCommand) Run(args []string) int {
 	var role, mountPoint, format, userKnownHostsFile, strictHostKeyChecking string
+	var commands string
 	var noExec bool
 	var sshCmdArgs []string
 	var sshDynamicKeyFileName string
@@ -42,6 +43,7 @@ func (c *SSHCommand) Run(args []string) int {
 	flags.StringVar(&role, "role", "", "")
 	flags.StringVar(&mountPoint, "mount-point", "ssh", "")
 	flags.BoolVar(&noExec, "no-exec", false, "")
+	flags.StringVar(&commands, "commands", "", "")
 
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := flags.Parse(args); err != nil {
@@ -173,7 +175,7 @@ func (c *SSHCommand) Run(args []string) int {
 		// Feel free to try and remove this dependency.
 		sshpassPath, err := exec.LookPath("sshpass")
 		if err == nil {
-			sshCmdArgs = append(sshCmdArgs, []string{"-p", string(resp.Key), "ssh", "-o UserKnownHostsFile=" + userKnownHostsFile, "-o StrictHostKeyChecking=" + strictHostKeyChecking, "-p", resp.Port, username + "@" + ip.String()}...)
+			sshCmdArgs = append(sshCmdArgs, []string{"-p", string(resp.Key), "ssh", "-o UserKnownHostsFile=" + userKnownHostsFile, "-o StrictHostKeyChecking=" + strictHostKeyChecking, "-p", resp.Port, username + "@" + ip.String(), commands}...)
 			sshCmd := exec.Command(sshpassPath, sshCmdArgs...)
 			sshCmd.Stdin = os.Stdin
 			sshCmd.Stdout = os.Stdout
@@ -186,7 +188,7 @@ func (c *SSHCommand) Run(args []string) int {
 		c.Ui.Output("OTP for the session is " + resp.Key)
 		c.Ui.Output("[Note: Install 'sshpass' to automate typing in OTP]")
 	}
-	sshCmdArgs = append(sshCmdArgs, []string{"-o UserKnownHostsFile=" + userKnownHostsFile, "-o StrictHostKeyChecking=" + strictHostKeyChecking, "-p", resp.Port, username + "@" + ip.String()}...)
+	sshCmdArgs = append(sshCmdArgs, []string{"-o UserKnownHostsFile=" + userKnownHostsFile, "-o StrictHostKeyChecking=" + strictHostKeyChecking, "-p", resp.Port, username + "@" + ip.String(), commands}...)
 
 	sshCmd := exec.Command("ssh", sshCmdArgs...)
 	sshCmd.Stdin = os.Stdin


### PR DESCRIPTION
Added capability to execute remote commands with "vault ssh", instead of only being presented with a login shell. This is done by using "-commands=<commands>" option with "vault ssh". For example: `/usr/local/bin/vault ssh -mount-point=CHANGEME -role=CHANGEME -commands='hostname; id' user@ip`

It would be great to have this functionality. Right now, "vault ssh" only gives me a login shell. Many times, I want to execute a remote command automatically instead of using the login shell to execute a command.

I added "-commands" as an option because it was the easiest to implement as such. A more natural way to implement this functionality might be through specifying any commands after the ip address (like in the OpenSSH client). However, the parsing logic of "user@ip" would have to be carefully changed to take into account any optional commands. 

This is my first pull request with the project (and my first time doing anything with Go) so please bear with me!