### PR TITLE
Add support for renewing cached policy

### DIFF
--- a/builtin/logical/transit/lock_manager.go
+++ b/builtin/logical/transit/lock_manager.go
@@ -307,6 +307,19 @@ func (lm *lockManager) DeletePolicy(storage logical.Storage, name string) error 
 	return nil
 }
 
+func (lm *lockManager) DeletePolicyFromCache(storage logical.Storage, name string) error {
+	lm.cacheMutex.Lock()
+	defer lm.cacheMutex.Unlock()
+
+	if !lm.CacheActive() {
+		return nil
+	}
+
+	delete(lm.cache, name)
+
+	return nil
+}
+
 func (lm *lockManager) getStoredPolicy(storage logical.Storage, name string) (*Policy, error) {
 	// Check if the policy already exists
 	raw, err := storage.Get("policy/" + name)

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -58,6 +58,20 @@ func (b *backend) pathDecryptWrite(
 	}
 
 	// Get the policy
+	resp, err := b.pathDecryptWriteHelper(name, context, ciphertext, req, d)
+	if err != nil && err.Error() == "invalid ciphertext: version is too new" {
+		err = b.lm.DeletePolicyFromCache(req.Storage, name)
+		if err != nil {
+			return nil, err
+		}
+		resp, err = b.pathDecryptWriteHelper(name, context, ciphertext, req, d)
+	}
+	return resp, err
+}
+
+func (b *backend) pathDecryptWriteHelper(name string, context []byte, ciphertext string,
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+
 	p, lock, err := b.lm.GetPolicyShared(req.Storage, name)
 	if lock != nil {
 		defer lock.RUnlock()


### PR DESCRIPTION
Wondering what you all would think of doing something like this to deal with transit key caching issues. When running with a database backend without HA, a failover to another standalone node uses cached values and key versions can fall behind. Rather than an error when the latest version is behind the requested version, a refresh of the policy could allow the decryption with the correct key version.

This is just a rough draft and untested, so just looking for some discussion/feedback here.
