### PR TITLE
Fix PKI logical backend email alt_names

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -573,7 +573,7 @@ func generateCreationBundle(b *backend,
 			if len(cnAlt) != 0 {
 				for _, v := range strings.Split(cnAlt, ",") {
 					if strings.Contains(v, "@") {
-						emailAddresses = append(emailAddresses, cn)
+						emailAddresses = append(emailAddresses, v)
 					} else {
 						dnsNames = append(dnsNames, v)
 					}


### PR DESCRIPTION
Hi,

This PR fixes email addresses list generation when using Subject Alt Names.

Executing the command `vault write foo_intermediate/issue/client common_name=first.last alt_names=first.last@example.net ttl=8760h format=pem` doesn't handle the certificate generation properly.

Before:
```
X509v3 Subject Alternative Name:
    DNS:first.last, email:first.last
```

After:
```
X509v3 Subject Alternative Name:
    DNS:first.last, email:first.last@example.net
```

Please let me know if this change suits to you.

Regards,
Vincent