### PR TITLE
Don't allow root from authentication backends either.

### DIFF
--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -261,7 +261,7 @@ func (c *Core) handleRequest(req *logical.Request) (retResp *logical.Response, r
 
 // handleLoginRequest is used to handle a login request, which is an
 // unauthenticated request to the backend.
-func (c *Core) handleLoginRequest(req *logical.Request) (retResp *logical.Response, retAuth *logical.Auth, retErr error) {
+func (c *Core) handleLoginRequest(req *logical.Request) (*logical.Response, *logical.Auth, error) {
 	defer metrics.MeasureSince([]string{"core", "handle_login_request"}, time.Now())
 
 	// Create an audit trail of the request, auth is not available on login requests
@@ -277,8 +277,7 @@ func (c *Core) handleLoginRequest(req *logical.Request) (retResp *logical.Respon
 		c.logger.Printf(
 			"[ERR] core: unexpected login request for token backend "+
 				"(request path: %s)", req.Path)
-		retErr = multierror.Append(retErr, ErrInternalError)
-		return nil, nil, retErr
+		return nil, nil, ErrInternalError
 	}
 
 	// Route the request

--- a/website/source/docs/auth/app-id.html.md
+++ b/website/source/docs/auth/app-id.html.md
@@ -101,21 +101,21 @@ the set of App IDs, user IDs, and the mapping between them. An
 example is shown below, use `vault path-help` for more details.
 
 ```
-$ vault write auth/app-id/map/app-id/foo value=root display_name=foo
+$ vault write auth/app-id/map/app-id/foo value=admins display_name=foo
 ...
 
 $ vault write auth/app-id/map/user-id/bar value=foo cidr_block=10.0.0.0/16
 ...
 ```
 
-The above creates an App ID "foo" that associates with the policy "root".
+The above creates an App ID "foo" that associates with the policy "admins".
 The `display_name` sets the display name for audit logs and secrets.
 Next, we configure the user ID "bar" and say that the user ID bar
 can be paired with "foo" but only if the client is in the "10.0.0.0/16" CIDR block.
 The `cidr_block` configuration is optional.
 
 This means that if a client authenticates and provide both "foo" and "bar",
-then the app ID will authenticate that client with the policy "root".
+then the app ID will authenticate that client with the policy "admins".
 
 In practice, both the user and app ID are likely hard-to-guess UUID-like values.
 

--- a/website/source/docs/auth/github.html.md
+++ b/website/source/docs/auth/github.html.md
@@ -50,7 +50,7 @@ The response will be in JSON. For example:
   "auth": {
     "client_token": "c4f280f6-fdb2-18eb-89d3-589e2e834cdb",
     "policies": [
-      "root"
+      "admins"
     ],
     "metadata": {
       "org": "test_org",
@@ -109,12 +109,11 @@ you will need to include it as: `some-amazing-team`.
 Example:
 
 ```
-$ vault write auth/github/map/teams/admins value=root
+$ vault write auth/github/map/teams/admins value=admins
 Success! Data written to: auth/github/map/teams/admins
 ```
 
-The above would make anyone in the "admins" team a root user in Vault
-(not recommended).
+The above would make anyone in the "admins" team receive tokens with the policy `admins`.
 
 You can then auth with a user that is a member of the "admins" team using a Personal Access Token with the `read:org` scope.
 
@@ -125,6 +124,6 @@ $ vault auth -method=github token=000000905b381e723b3d6a7d52f148a5d43c4b45
 Successfully authenticated! The policies that are associated
 with this token are listed below:
 
-root
+admins
 ```
 

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -49,7 +49,7 @@ Password (will be hidden):
 Successfully authenticated! The policies that are associated
 with this token are listed below:
 
-root
+admins
 ```
 
 #### Via the API
@@ -74,7 +74,7 @@ The response will be in JSON. For example:
   "auth": {
     "client_token": "c4f280f6-fdb2-18eb-89d3-589e2e834cdb",
     "policies": [
-      "root"
+      "admins"
     ],
     "metadata": {
       "username": "mitchellh"

--- a/website/source/docs/auth/userpass.html.md
+++ b/website/source/docs/auth/userpass.html.md
@@ -49,7 +49,7 @@ The response will be in JSON. For example:
   "auth": {
     "client_token": "c4f280f6-fdb2-18eb-89d3-589e2e834cdb",
     "policies": [
-      "root"
+      "admins"
     ],
     "metadata": {
       "username": "mitchellh"
@@ -85,12 +85,12 @@ Use `vault path-help` for more details.
 ```
 $ vault write auth/userpass/users/mitchellh \
     password=foo \
-    policies=root
+    policies=admins
 ...
 ```
 
 The above creates a new user "mitchellh" with the password "foo" that
-will be associated with the "root" policy. This is the only configuration
+will be associated with the "admins" policy. This is the only configuration
 necessary.
 
 ## API


### PR DESCRIPTION
We've disabled this in the token store, but it makes no sense to have
that disabled but have it enabled elsewhere. It's the same issue across
all, so simply remove the ability altogether.