### PR TITLE
allow a TLS server name to be configured for SSH agents

### DIFF
--- a/api/ssh_agent_test.go
+++ b/api/ssh_agent_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"net/http"
 )
 
 func TestSSH_CreateTLSClient(t *testing.T) {
@@ -27,6 +28,29 @@ func TestSSH_CreateTLSClient(t *testing.T) {
 	}
 	if client.config.HttpClient.Transport == nil {
 		panic(fmt.Sprintf("error creating client with TLS transport"))
+	}
+}
+
+func TestSSH_CreateTLSClient_tlsServerName(t *testing.T) {
+	// Ensure that the HTTP client is associated with the configured TLS server name.
+	var tlsServerName = "tls.server.name"
+
+	config, err := ParseSSHHelperConfig(fmt.Sprintf(`
+vault_addr = "1.2.3.4"
+tls_server_name = "%s"
+`, tlsServerName))
+	if err != nil {
+		panic(fmt.Sprintf("error loading config: %s", err))
+	}
+
+	client, err := config.NewClient()
+	if err != nil {
+		panic(fmt.Sprintf("error creating the client: %s", err))
+	}
+
+	actualTLSServerName := client.config.HttpClient.Transport.(*http.Transport).TLSClientConfig.ServerName
+	if actualTLSServerName != tlsServerName {
+		panic(fmt.Sprintf("incorrect TLS server name. expected: %s actual: %s", tlsServerName, actualTLSServerName))
 	}
 }
 
@@ -65,5 +89,22 @@ nope = "bad"
 
 	if !strings.Contains(err.Error(), "ssh_helper: invalid key 'nope' on line 3") {
 		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestParseSSHHelperConfig_tlsServerName(t *testing.T) {
+	var tlsServerName = "tls.server.name"
+
+	config, err := ParseSSHHelperConfig(fmt.Sprintf(`
+vault_addr = "1.2.3.4"
+tls_server_name = "%s"
+`, tlsServerName))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.TLSServerName != tlsServerName {
+		t.Errorf("incorrect TLS server name. expected: %s actual: %s", tlsServerName, config.TLSServerName)
 	}
 }


### PR DESCRIPTION
This pull request adds support for TLS server names in ssh_agent. The end goal is to allow the vault-ssh-helper to be configured with a TLS server name.