### PR TITLE
Provide base64 keys in addition to hex encoded.

### DIFF
--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -45,7 +45,9 @@ type InitStatusResponse struct {
 }
 
 type InitResponse struct {
-	Keys         []string `json:"keys"`
-	RecoveryKeys []string `json:"recovery_keys"`
-	RootToken    string   `json:"root_token"`
+	Keys            []string `json:"keys"`
+	KeysB64         []string `json:"keys_base64"`
+	RecoveryKeys    []string `json:"recovery_keys"`
+	RecoveryKeysB64 []string `json:"recovery_keys_base64"`
+	RootToken       string   `json:"root_token"`
 }

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -190,11 +190,13 @@ type RekeyUpdateResponse struct {
 	Nonce           string
 	Complete        bool
 	Keys            []string
+	KeysB64         []string `json:"keys_base64"`
 	PGPFingerprints []string `json:"pgp_fingerprints"`
 	Backup          bool
 }
 
 type RekeyRetrieveResponse struct {
-	Nonce string
-	Keys  map[string][]string
+	Nonce   string
+	Keys    map[string][]string
+	KeysB64 map[string][]string `json:"keys_base64"`
 }

--- a/command/init.go
+++ b/command/init.go
@@ -192,10 +192,20 @@ func (c *InitCommand) runInit(check bool, initRequest *api.InitRequest) int {
 	}
 
 	for i, key := range resp.Keys {
-		c.Ui.Output(fmt.Sprintf("Unseal Key %d: %s", i+1, key))
+		if resp.KeysB64 != nil && len(resp.KeysB64) == len(resp.Keys) {
+			c.Ui.Output(fmt.Sprintf("Unseal Key %d (hex)   : %s", i+1, key))
+			c.Ui.Output(fmt.Sprintf("Unseal Key %d (base64): %s", i+1, resp.KeysB64[i]))
+		} else {
+			c.Ui.Output(fmt.Sprintf("Unseal Key %d: %s", i+1, key))
+		}
 	}
 	for i, key := range resp.RecoveryKeys {
-		c.Ui.Output(fmt.Sprintf("Recovery Key %d: %s", i+1, key))
+		if resp.RecoveryKeysB64 != nil && len(resp.RecoveryKeysB64) == len(resp.RecoveryKeys) {
+			c.Ui.Output(fmt.Sprintf("Recovery Key %d (hex)   : %s", i+1, key))
+			c.Ui.Output(fmt.Sprintf("Recovery Key %d (base64): %s", i+1, resp.RecoveryKeysB64[i]))
+		} else {
+			c.Ui.Output(fmt.Sprintf("Recovery Key %d: %s", i+1, key))
+		}
 	}
 
 	c.Ui.Output(fmt.Sprintf("Initial Root Token: %s", resp.RootToken))

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -244,5 +244,5 @@ func TestInit_PGP(t *testing.T) {
 
 	rootToken := matches[0][1]
 
-	parseDecryptAndTestUnsealKeys(t, ui.OutputWriter.String(), rootToken, false, nil, core)
+	parseDecryptAndTestUnsealKeys(t, ui.OutputWriter.String(), rootToken, false, nil, nil, core)
 }

--- a/command/rekey.go
+++ b/command/rekey.go
@@ -93,12 +93,14 @@ func (c *RekeyCommand) Run(args []string) int {
 				SecretShares:    shares,
 				SecretThreshold: threshold,
 				PGPKeys:         pgpKeys,
+				Backup:          backup,
 			})
 		} else {
 			rekeyStatus, err = client.Sys().RekeyInit(&api.RekeyInitRequest{
 				SecretShares:    shares,
 				SecretThreshold: threshold,
 				PGPKeys:         pgpKeys,
+				Backup:          backup,
 			})
 		}
 		if err != nil {
@@ -158,11 +160,25 @@ func (c *RekeyCommand) Run(args []string) int {
 	// Space between the key prompt, if any, and the output
 	c.Ui.Output("\n")
 	// Provide the keys
+	var haveB64 bool
+	if result.KeysB64 != nil && len(result.KeysB64) == len(result.Keys) {
+		haveB64 = true
+	}
 	for i, key := range result.Keys {
 		if len(result.PGPFingerprints) > 0 {
-			c.Ui.Output(fmt.Sprintf("Key %d fingerprint: %s; value: %s", i+1, result.PGPFingerprints[i], key))
+			if haveB64 {
+				c.Ui.Output(fmt.Sprintf("Key %d fingerprint: %s; value (hex)   : %s", i+1, result.PGPFingerprints[i], key))
+				c.Ui.Output(fmt.Sprintf("Key %d fingerprint: %s; value (base64): %s", i+1, result.PGPFingerprints[i], result.KeysB64[i]))
+			} else {
+				c.Ui.Output(fmt.Sprintf("Key %d fingerprint: %s; value: %s", i+1, result.PGPFingerprints[i], key))
+			}
 		} else {
-			c.Ui.Output(fmt.Sprintf("Key %d: %s", i+1, key))
+			if haveB64 {
+				c.Ui.Output(fmt.Sprintf("Key %d (hex)   : %s", i+1, key))
+				c.Ui.Output(fmt.Sprintf("Key %d (base64): %s", i+1, result.KeysB64[i]))
+			} else {
+				c.Ui.Output(fmt.Sprintf("Key %d: %s", i+1, key))
+			}
 		}
 	}
 

--- a/command/rekey_test.go
+++ b/command/rekey_test.go
@@ -227,7 +227,8 @@ func TestRekey_init_pgp(t *testing.T) {
 	}
 
 	type backupStruct struct {
-		Keys map[string][]string
+		Keys    map[string][]string
+		KeysB64 map[string][]string
 	}
 	backupVals := &backupStruct{}
 
@@ -247,6 +248,7 @@ func TestRekey_init_pgp(t *testing.T) {
 	}
 
 	backupVals.Keys = resp.Data["keys"].(map[string][]string)
+	backupVals.KeysB64 = resp.Data["keys_base64"].(map[string][]string)
 
 	// Now delete and try again; the values should be inaccessible
 	req = logical.TestRequest(t, logical.DeleteOperation, "rekey/backup")
@@ -269,7 +271,8 @@ func TestRekey_init_pgp(t *testing.T) {
 	// Sort, because it'll be tested with DeepEqual later
 	for k, _ := range backupVals.Keys {
 		sort.Strings(backupVals.Keys[k])
+		sort.Strings(backupVals.KeysB64[k])
 	}
 
-	parseDecryptAndTestUnsealKeys(t, ui.OutputWriter.String(), token, true, backupVals.Keys, core)
+	parseDecryptAndTestUnsealKeys(t, ui.OutputWriter.String(), token, true, backupVals.Keys, backupVals.KeysB64, core)
 }

--- a/command/server.go
+++ b/command/server.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -489,8 +490,9 @@ func (c *ServerCommand) Run(args []string) int {
 				"    "+export+" VAULT_ADDR="+quote+"http://"+config.Listeners[0].Config["address"]+quote+"\n\n"+
 				"The unseal key and root token are reproduced below in case you\n"+
 				"want to seal/unseal the Vault or play with authentication.\n\n"+
-				"Unseal Key: %s\nRoot Token: %s\n",
+				"Unseal Key (hex)   : %s\nUnseal Key (base64): %s\nRoot Token: %s\n",
 			hex.EncodeToString(init.SecretShares[0]),
+			base64.StdEncoding.EncodeToString(init.SecretShares[0]),
 			init.RootToken,
 		))
 	}

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -97,7 +97,7 @@ func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 	keysB64 := make([]string, 0, len(result.SecretShares))
 	for _, k := range result.SecretShares {
 		keys = append(keys, hex.EncodeToString(k))
-		keysB64 = append(keys, base64.StdEncoding.EncodeToString(k))
+		keysB64 = append(keysB64, base64.StdEncoding.EncodeToString(k))
 	}
 
 	resp := &InitResponse{
@@ -111,7 +111,7 @@ func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 		resp.RecoveryKeysB64 = make([]string, 0, len(result.RecoveryShares))
 		for _, k := range result.RecoveryShares {
 			resp.RecoveryKeys = append(resp.RecoveryKeys, hex.EncodeToString(k))
-			resp.RecoveryKeysB64 = append(resp.RecoveryKeys, base64.StdEncoding.EncodeToString(k))
+			resp.RecoveryKeysB64 = append(resp.RecoveryKeysB64, base64.StdEncoding.EncodeToString(k))
 		}
 	}
 

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -93,19 +94,24 @@ func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 
 	// Encode the keys
 	keys := make([]string, 0, len(result.SecretShares))
+	keysB64 := make([]string, 0, len(result.SecretShares))
 	for _, k := range result.SecretShares {
 		keys = append(keys, hex.EncodeToString(k))
+		keysB64 = append(keys, base64.StdEncoding.EncodeToString(k))
 	}
 
 	resp := &InitResponse{
 		Keys:      keys,
+		KeysB64:   keysB64,
 		RootToken: result.RootToken,
 	}
 
 	if len(result.RecoveryShares) > 0 {
 		resp.RecoveryKeys = make([]string, 0, len(result.RecoveryShares))
+		resp.RecoveryKeysB64 = make([]string, 0, len(result.RecoveryShares))
 		for _, k := range result.RecoveryShares {
 			resp.RecoveryKeys = append(resp.RecoveryKeys, hex.EncodeToString(k))
+			resp.RecoveryKeysB64 = append(resp.RecoveryKeys, base64.StdEncoding.EncodeToString(k))
 		}
 	}
 
@@ -125,9 +131,11 @@ type InitRequest struct {
 }
 
 type InitResponse struct {
-	Keys         []string `json:"keys"`
-	RecoveryKeys []string `json:"recovery_keys,omitempty"`
-	RootToken    string   `json:"root_token"`
+	Keys            []string `json:"keys"`
+	KeysB64         []string `json:"keys_base64"`
+	RecoveryKeys    []string `json:"recovery_keys,omitempty"`
+	RecoveryKeysB64 []string `json:"recovery_keys_base64,omitempty"`
+	RootToken       string   `json:"root_token"`
 }
 
 type InitStatusResponse struct {

--- a/http/sys_rekey_test.go
+++ b/http/sys_rekey_test.go
@@ -180,8 +180,13 @@ func TestSysRekey_Update(t *testing.T) {
 	if len(keys) != 5 {
 		t.Fatalf("bad: %#v", keys)
 	}
+	keysB64 := actual["keys_base64"].([]interface{})
+	if len(keysB64) != 5 {
+		t.Fatalf("bad: %#v", keysB64)
+	}
 
 	delete(actual, "keys")
+	delete(actual, "keys_base64")
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("\nexpected: %#v\nactual: %#v", expected, actual)
 	}

--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -97,13 +98,20 @@ func handleSysUnseal(core *vault.Core) http.Handler {
 			}
 			core.ResetUnsealProcess()
 		} else {
-			// Decode the key, which is hex encoded
+			// Decode the key, which is base64 or hex encoded
+			min, max := core.BarrierKeyLength()
 			key, err := hex.DecodeString(req.Key)
-			if err != nil {
-				respondError(
-					w, http.StatusBadRequest,
-					errors.New("'key' must be a valid hex-string"))
-				return
+			// We check min and max here to ensure that a string that is base64
+			// encoded but also valid hex will not be valid and we instead base64
+			// decode it
+			if err != nil || len(key) < min || len(key) > max {
+				key, err = base64.StdEncoding.DecodeString(req.Key)
+				if err != nil {
+					respondError(
+						w, http.StatusBadRequest,
+						errors.New("'key' must be a valid hex or base64 string"))
+					return
+				}
 			}
 
 			// Attempt the unseal

--- a/vault/core.go
+++ b/vault/core.go
@@ -1490,3 +1490,9 @@ func (c *Core) SealAccess() *SealAccess {
 func (c *Core) Logger() *log.Logger {
 	return c.logger
 }
+
+func (c *Core) BarrierKeyLength() (min, max int) {
+	min, max = c.barrier.KeyLength()
+	max += shamir.ShareOverhead
+	return
+}


### PR DESCRIPTION
Accept these at unseal/rekey time.

Also fix a bug where backup would not be honored when doing a rekey with
no operation currently ongoing.