### PR TITLE
Ensure we don't use a token entry period of 0 in role comparisons.

### DIFF
--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -1967,7 +1967,7 @@ func TestTokenStore_RolePeriod(t *testing.T) {
 		}
 
 		// Let the TTL go down a bit to 3 seconds
-		time.Sleep(2 * time.Second)
+		time.Sleep(3 * time.Second)
 
 		req.Operation = logical.UpdateOperation
 		req.Path = "auth/token/renew-self"


### PR DESCRIPTION
When we added support for generating periodic tokens for root/sudo in
auth/token/create we used the token entry's period value to store the
shortest period found to eventually populate the TTL. The problem was
that we then assumed later that this value would be populated for
periodic tokens, when it wouldn't have been in the upgrade case.

Instead, use a temp var to store the proper value to use; populate
te.Period only if actually given; and check that it's not zero before
comparing against role value during renew.