### PR TITLE
Error when an invalid (as opposed to incorrect) unseal key is given.

### DIFF
--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -118,10 +118,18 @@ func handleSysUnseal(core *vault.Core) http.Handler {
 			if _, err := core.Unseal(key); err != nil {
 				// Ignore ErrInvalidKey because its a user error that we
 				// mask away. We just show them the seal status.
-				if !errwrap.ContainsType(err, new(vault.ErrInvalidKey)) {
+				switch {
+				case errwrap.ContainsType(err, new(vault.ErrInvalidKey)):
+				case errwrap.Contains(err, vault.ErrBarrierInvalidKey.Error()):
+				case errwrap.Contains(err, vault.ErrBarrierNotInit.Error()):
+				case errwrap.Contains(err, vault.ErrBarrierSealed.Error()):
+				case errwrap.Contains(err, vault.ErrStandby.Error()):
+				default:
 					respondError(w, http.StatusInternalServerError, err)
 					return
 				}
+				respondError(w, http.StatusBadRequest, err)
+				return
 			}
 		}
 

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -146,33 +146,7 @@ func TestSysUnseal_badKey(t *testing.T) {
 	resp := testHttpPut(t, "", addr+"/v1/sys/unseal", map[string]interface{}{
 		"key": "0123",
 	})
-
-	var actual map[string]interface{}
-	expected := map[string]interface{}{
-		"sealed":   true,
-		"t":        json.Number("1"),
-		"n":        json.Number("1"),
-		"progress": json.Number("0"),
-	}
-	testResponseStatus(t, resp, 200)
-	testResponseBody(t, resp, &actual)
-	if actual["version"] == nil {
-		t.Fatalf("expected version information")
-	}
-	expected["version"] = actual["version"]
-	if actual["cluster_name"] == nil {
-		delete(expected, "cluster_name")
-	} else {
-		expected["cluster_name"] = actual["cluster_name"]
-	}
-	if actual["cluster_id"] == nil {
-		delete(expected, "cluster_id")
-	} else {
-		expected["cluster_id"] = actual["cluster_id"]
-	}
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: expected: %#v\nactual: %#v", expected, actual)
-	}
+	testResponseStatus(t, resp, 400)
 }
 
 func TestSysUnseal_Reset(t *testing.T) {

--- a/vault/core.go
+++ b/vault/core.go
@@ -103,8 +103,9 @@ func (e *NonFatalError) Error() string {
 	return e.Err.Error()
 }
 
-// ErrInvalidKey is returned if there is an error with a
-// provided unseal key.
+// ErrInvalidKey is returned if there is a user-based error with a provided
+// unseal key. This will be shown to the user, so should not contain
+// information that is sensitive.
 type ErrInvalidKey struct {
 	Reason string
 }


### PR DESCRIPTION
Fixes #1777