### PR TITLE
Reuse Cassandra session for create creds

### DIFF
--- a/builtin/logical/cassandra/backend.go
+++ b/builtin/logical/cassandra/backend.go
@@ -83,7 +83,12 @@ func (b *backend) DB(s logical.Storage) (*gocql.Session, error) {
 		return nil, err
 	}
 
-	return createSession(config, s)
+	session, err := createSession(config, s)
+	//  Store the session in backend for reuse
+	b.session = session
+
+	return session, err
+
 }
 
 // ResetDB forces a connection next time DB() is called.


### PR DESCRIPTION
Added couple of lines of code to store the Cassandra session object in the backend for reuse. The existing implementation creates a new session for every creds read request thereby opening multiple new connections to the C* node each time.

Fixes #1801

Thanks
Navin Anandaraj