### PR TITLE
doc: remove duplicate aws-ec2 menu item

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -179,7 +179,7 @@
 						</li>
 
 						<li<%= sidebar_current("docs-auth-aws-ec2") %>>
-							<a href="/docs/auth/aws-ec2.html">AWS EC2 Auth</a>
+							<a href="/docs/auth/aws-ec2.html">AWS EC2</a>
 						</li>
 
 						<li<%= sidebar_current("docs-auth-github") %>>
@@ -204,10 +204,6 @@
 
 						<li<%= sidebar_current("docs-auth-userpass") %>>
 							<a href="/docs/auth/userpass.html">Username &amp; Password</a>
-						</li>
-
-						<li<%= sidebar_current("docs-auth-aws-ec2") %>>
-							<a href="/docs/auth/aws-ec2.html">AWS EC2</a>
 						</li>
 					</ul>
 				</li>


### PR DESCRIPTION
documentation fix

the auth backends menu had a duplicate menu item entry for aws-ec2 auth.
removed the dup one.