### PR TITLE
fix changelog for a bug fix timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -719,7 +719,6 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
- * api: Correct the HTTP verb used in the LookupSelf method [GH-887]
  * api: Fix the output of `Sys().MountConfig(...)` to return proper values
    [GH-1017]
  * command/read: Fix panic when an empty argument was given [GH-923]
@@ -767,8 +766,12 @@ SECURITY:
     Go 1.5. For more information, please see
     https://groups.google.com/forum/#!topic/golang-dev/MEATuOi_ei4
 
-This is a security-only release; other than the version number and building
-against Go 1.5.3, there are no changes from 0.4.0.
+This is majorly a security-only release; other than the version number and building
+against Go 1.5.3 and a bug fix given below, there are no changes from 0.4.0.
+
+BUG FIXES:
+
+ * api: Correct the HTTP verb used in the LookupSelf method [GH-887]
 
 ## 0.4.0 (December 10, 2015)
 


### PR DESCRIPTION
it looks like the bug fix for 'token lookup-self' api's http verb from POST to GET was done for 0.4.1 [GH-884]
my C#.NET client (Jan 20) was based off Vault's 0.4.1 and i was already using GET without any issues. 
it means this fix got in for 0.4.1 (the security build) and not 0.5.0.

again, please feel free to close the PR, if i am missing something.