### PR TITLE
Add golang api method for creating orphan tokens

### DIFF
--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -25,6 +25,21 @@ func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
+func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
+	r := c.c.NewRequest("POST", "/v1/auth/token/create-orphan")
+	if err := r.SetJSONBody(opts); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.RawRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return ParseSecret(resp.Body)
+}
+
 func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create/"+roleName)
 	if err := r.SetJSONBody(opts); err != nil {


### PR DESCRIPTION
It looks like the auth/token/create-orphan endpoint is missing in the golang api. I've added it here.
I didn't add tests because it's basically a copy of Create, as is CreateWithRole, which also doesn't have dedicated tests.

Let me know if you need anything else.