### PR TITLE
Allow empty values in transit backend

### DIFF
--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -2,7 +2,6 @@ package transit
 
 import (
 	"encoding/base64"
-	"fmt"
 
 	"github.com/hashicorp/vault/helper/errutil"
 	"github.com/hashicorp/vault/logical"
@@ -95,10 +94,6 @@ func (b *backend) pathDecryptWrite(
 		default:
 			return nil, err
 		}
-	}
-
-	if plaintext == "" {
-		return nil, fmt.Errorf("empty plaintext returned")
 	}
 
 	// Generate the response

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -64,9 +64,6 @@ func (b *backend) pathEncryptWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 	value := d.Get("plaintext").(string)
-	if len(value) == 0 {
-		return logical.ErrorResponse("missing plaintext to encrypt"), logical.ErrInvalidRequest
-	}
 
 	var err error
 


### PR DESCRIPTION
As pointed out in [a discussion at `vault-rails`](https://github.com/hashicorp/vault-rails/commit/07399786d9fc09c295e93af0df87023eaf26c827#commitcomment-18980307), the fact that a string is empty may itself be sensitive information, so it makes sense to be able to encrypt it.

This patch removes both (encrypt/decrypt) guards against empty values in transit. The only unintended side-effect, as noted in the aforementioned discussion, is that Vault will not be able to tell the difference between requests that don’t specify plaintext at all and requests that specify the empty string. Since this parameter is currently documented as *required*, let me know if that is something worth changing the documentation for, and I will update the patch. IMO, this nuance need not be documented since, as I understand it, it is a quirk of Go, that does not distinguish an absent value from an empty one.

I built a binary with this patch applied on v0.6.1, and I can use it to encrypt/decrypt empty strings in transit, no errors reported.