### PR TITLE
Small change: Fix permission vault requires.

### DIFF
--- a/website/source/docs/auth/aws-ec2.html.md
+++ b/website/source/docs/auth/aws-ec2.html.md
@@ -272,7 +272,7 @@ $ vault auth-enable aws-ec2
 #### Configure the credentials required to make AWS API calls
 
 Note: the client uses the official AWS SDK and will use environment variable or
-IAM role-provided credentials if available. The AWS credentials used require the IAM action `ec2:DescribeInstance` to be allowed.
+IAM role-provided credentials if available. The AWS credentials used require the IAM action `ec2:DescribeInstances` to be allowed.
 
 ```
 $ vault write auth/aws-ec2/config/client secret_key=vCtSM8ZUEQ3mOFVlYPBQkf2sO6F/W7a5TVzrl3Oj access_key=VKIAJBRHKH6EVTTNXDHA


### PR DESCRIPTION
Vault requires ec2:DescribeInstances, not ec2:DescribeInstance. (the
non-plural form doesn't exist)

This updates the documentation so that it matches reality.

Thanks!