### PR TITLE
DynamoDB: fix log typo

### DIFF
--- a/physical/dynamodb.go
+++ b/physical/dynamodb.go
@@ -195,7 +195,7 @@ func newDynamoDBBackend(conf map[string]string, logger log.Logger) (Backend, err
 			return nil, errwrap.Wrapf("failed parsing max_parallel parameter: {{err}}", err)
 		}
 		if logger.IsDebug() {
-			logger.Debug("physical/consul: max_parallel set", "max_parallel", maxParInt)
+			logger.Debug("physical/dynamodb: max_parallel set", "max_parallel", maxParInt)
 		}
 	}
 


### PR DESCRIPTION
In 565b45d, some logging code was added to the DynamoDB file that
appears to have been copied from the Consul support, and the name was
never updated.  It now references the correct backend.