### PR TITLE
Follow Vault convention on `DELETE` being idempotent

### DIFF
--- a/command/audit_disable.go
+++ b/command/audit_disable.go
@@ -43,7 +43,8 @@ func (c *AuditDisableCommand) Run(args []string) int {
 	}
 
 	c.Ui.Output(fmt.Sprintf(
-		"Successfully disabled audit backend '%s'!", id))
+		"Successfully disabled audit backend '%s' if it was enabled", id))
+
 	return 0
 }
 

--- a/command/auth_disable.go
+++ b/command/auth_disable.go
@@ -43,7 +43,7 @@ func (c *AuthDisableCommand) Run(args []string) int {
 	}
 
 	c.Ui.Output(fmt.Sprintf(
-		"Disabled auth provider at path '%s'!", path))
+		"Disabled auth provider at path '%s' if it was enabled", path))
 
 	return 0
 }

--- a/command/unmount.go
+++ b/command/unmount.go
@@ -43,7 +43,7 @@ func (c *UnmountCommand) Run(args []string) int {
 	}
 
 	c.Ui.Output(fmt.Sprintf(
-		"Successfully unmounted '%s'!", path))
+		"Successfully unmounted '%s' if it was mounted", path))
 
 	return 0
 }

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -99,7 +99,7 @@ func (c *Core) enableAudit(entry *MountEntry) error {
 }
 
 // disableAudit is used to disable an existing audit backend
-func (c *Core) disableAudit(path string) error {
+func (c *Core) disableAudit(path string) (bool, error) {
 	// Ensure we end the path in a slash
 	if !strings.HasSuffix(path, "/") {
 		path += "/"
@@ -114,12 +114,12 @@ func (c *Core) disableAudit(path string) error {
 
 	// Ensure there was a match
 	if !found {
-		return fmt.Errorf("no matching backend")
+		return false, fmt.Errorf("no matching backend")
 	}
 
 	// Update the audit table
 	if err := c.persistAudit(newTable); err != nil {
-		return errors.New("failed to update audit table")
+		return true, errors.New("failed to update audit table")
 	}
 
 	c.audit = newTable
@@ -129,7 +129,7 @@ func (c *Core) disableAudit(path string) error {
 	if c.logger.IsInfo() {
 		c.logger.Info("core: disabled audit backend", "path", path)
 	}
-	return nil
+	return true, nil
 }
 
 // loadAudits is invoked as part of postUnseal to load the audit table

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -112,9 +112,9 @@ func TestCore_DisableAudit(t *testing.T) {
 		}, nil
 	}
 
-	err := c.disableAudit("foo")
-	if err.Error() != "no matching backend" {
-		t.Fatalf("err: %v", err)
+	existed, err := c.disableAudit("foo")
+	if existed && err != nil {
+		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
 
 	me := &MountEntry{
@@ -127,9 +127,9 @@ func TestCore_DisableAudit(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = c.disableAudit("foo")
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	existed, err = c.disableAudit("foo")
+	if !existed || err != nil {
+		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
 
 	// Check for registration

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -127,9 +127,9 @@ func TestCore_DisableCredential(t *testing.T) {
 		return &NoopBackend{}, nil
 	}
 
-	err := c.disableCredential("foo")
-	if err.Error() != "no matching backend" {
-		t.Fatalf("err: %v", err)
+	existed, err := c.disableCredential("foo")
+	if existed || err.Error() != "no matching backend" {
+		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
 
 	me := &MountEntry{
@@ -142,9 +142,9 @@ func TestCore_DisableCredential(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = c.disableCredential("foo")
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	existed, err = c.disableCredential("foo")
+	if !existed || err != nil {
+		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
 
 	match := c.router.MatchingMount("auth/foo/bar")
@@ -176,9 +176,9 @@ func TestCore_DisableCredential(t *testing.T) {
 
 func TestCore_DisableCredential_Protected(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	err := c.disableCredential("token")
-	if err.Error() != "token credential backend cannot be disabled" {
-		t.Fatalf("err: %v", err)
+	existed, err := c.disableCredential("token")
+	if !existed || err.Error() != "token credential backend cannot be disabled" {
+		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
 }
 
@@ -232,9 +232,9 @@ func TestCore_DisableCredential_Cleanup(t *testing.T) {
 	}
 
 	// Disable should cleanup
-	err = c.disableCredential("foo")
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	existed, err := c.disableCredential("foo")
+	if !existed || err != nil {
+		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
 
 	// Token should be revoked

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -806,7 +806,7 @@ func (b *SystemBackend) handleUnmount(
 	suffix = sanitizeMountPath(suffix)
 
 	// Attempt unmount
-	if err := b.Core.unmount(suffix); err != nil {
+	if existed, err := b.Core.unmount(suffix); existed && err != nil {
 		b.Backend.Logger().Error("sys: unmount failed", "path", suffix, "error", err)
 		return handleError(err)
 	}
@@ -1117,7 +1117,7 @@ func (b *SystemBackend) handleDisableAuth(
 	suffix = sanitizeMountPath(suffix)
 
 	// Attempt disable
-	if err := b.Core.disableCredential(suffix); err != nil {
+	if existed, err := b.Core.disableCredential(suffix); existed && err != nil {
 		b.Backend.Logger().Error("sys: disable auth mount failed", "path", suffix, "error", err)
 		return handleError(err)
 	}
@@ -1282,7 +1282,7 @@ func (b *SystemBackend) handleDisableAudit(
 	path := data.Get("path").(string)
 
 	// Attempt disable
-	if err := b.Core.disableAudit(path); err != nil {
+	if existed, err := b.Core.disableAudit(path); existed && err != nil {
 		b.Backend.Logger().Error("sys: disable audit mount failed", "path", path, "error", err)
 		return handleError(err)
 	}

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -233,19 +233,6 @@ func TestSystemBackend_CapabilitiesAccessor(t *testing.T) {
 	}
 }
 
-func TestSystemBackend_unmount_invalid(t *testing.T) {
-	b := testSystemBackend(t)
-
-	req := logical.TestRequest(t, logical.DeleteOperation, "mounts/foo/")
-	resp, err := b.HandleRequest(req)
-	if err != logical.ErrInvalidRequest {
-		t.Fatalf("err: %v", err)
-	}
-	if resp.Data["error"] != "no matching mount" {
-		t.Fatalf("bad: %v", resp)
-	}
-}
-
 func TestSystemBackend_remount(t *testing.T) {
 	b := testSystemBackend(t)
 
@@ -648,19 +635,6 @@ func TestSystemBackend_disableAuth(t *testing.T) {
 	}
 }
 
-func TestSystemBackend_disableAuth_invalid(t *testing.T) {
-	b := testSystemBackend(t)
-
-	req := logical.TestRequest(t, logical.DeleteOperation, "auth/foo")
-	resp, err := b.HandleRequest(req)
-	if err != logical.ErrInvalidRequest {
-		t.Fatalf("err: %v", err)
-	}
-	if resp.Data["error"] != "no matching backend" {
-		t.Fatalf("bad: %v", resp)
-	}
-}
-
 func TestSystemBackend_policyList(t *testing.T) {
 	b := testSystemBackend(t)
 	req := logical.TestRequest(t, logical.ReadOperation, "policy")
@@ -910,19 +884,6 @@ func TestSystemBackend_disableAudit(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if resp != nil {
-		t.Fatalf("bad: %v", resp)
-	}
-}
-
-func TestSystemBackend_disableAudit_invalid(t *testing.T) {
-	b := testSystemBackend(t)
-
-	req := logical.TestRequest(t, logical.DeleteOperation, "audit/foo")
-	resp, err := b.HandleRequest(req)
-	if err != logical.ErrInvalidRequest {
-		t.Fatalf("err: %v", err)
-	}
-	if resp.Data["error"] != "no matching backend" {
 		t.Fatalf("bad: %v", resp)
 	}
 }

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -80,9 +80,9 @@ func TestCore_Mount(t *testing.T) {
 
 func TestCore_Unmount(t *testing.T) {
 	c, key, _ := TestCoreUnsealed(t)
-	err := c.unmount("secret")
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	existed, err := c.unmount("secret")
+	if !existed || err != nil {
+		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
 
 	match := c.router.MatchingMount("secret/foo")
@@ -169,8 +169,8 @@ func TestCore_Unmount_Cleanup(t *testing.T) {
 	}
 
 	// Unmount, this should cleanup
-	if err := c.unmount("test/"); err != nil {
-		t.Fatalf("err: %v", err)
+	if existed, err := c.unmount("test/"); !existed || err != nil {
+		t.Fatalf("existed: %v; err: %v", existed, err)
 	}
 
 	// Rollback should be invoked


### PR DESCRIPTION
with audit/auth/mounts deletes (a.k.a. disabling/unmounting).