### PR TITLE
Renaming ttl_max -> max_ttl in mssql backend

### DIFF
--- a/builtin/logical/mssql/backend_test.go
+++ b/builtin/logical/mssql/backend_test.go
@@ -186,7 +186,7 @@ func testAccStepWriteLease(t *testing.T) logicaltest.TestStep {
 		Path:      "config/lease",
 		Data: map[string]interface{}{
 			"ttl":     "1h5m",
-			"ttl_max": "24h",
+			"max_ttl": "24h",
 		},
 	}
 }
@@ -196,7 +196,7 @@ func testAccStepReadLease(t *testing.T) logicaltest.TestStep {
 		Operation: logical.ReadOperation,
 		Path:      "config/lease",
 		Check: func(resp *logical.Response) error {
-			if resp.Data["ttl"] != "1h5m0s" || resp.Data["ttl_max"] != "24h0m0s" {
+			if resp.Data["ttl"] != "1h5m0s" || resp.Data["max_ttl"] != "24h0m0s" {
 				return fmt.Errorf("bad: %#v", resp)
 			}
 

--- a/builtin/logical/mssql/path_config_lease.go
+++ b/builtin/logical/mssql/path_config_lease.go
@@ -84,12 +84,16 @@ func (b *backend) pathConfigLeaseRead(
 		return nil, nil
 	}
 
-	return &logical.Response{
+	resp := &logical.Response{
 		Data: map[string]interface{}{
 			"ttl":     leaseConfig.TTL.String(),
+			"ttl_max": leaseConfig.TTLMax.String(),
 			"max_ttl": leaseConfig.TTLMax.String(),
 		},
-	}, nil
+	}
+	resp.AddWarning("The field ttl_max is deprecated and will be removed in a future release. Use max_ttl instead.")
+
+	return resp, nil
 }
 
 type configLease struct {

--- a/builtin/logical/mssql/path_config_lease.go
+++ b/builtin/logical/mssql/path_config_lease.go
@@ -18,6 +18,12 @@ func pathConfigLease(b *backend) *framework.Path {
 			},
 
 			"ttl_max": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: `Deprecated: use "max_ttl" instead.  Maximum
+time a credential is valid for.`,
+			},
+
+			"max_ttl": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "Maximum time a credential is valid for.",
 			},
@@ -36,7 +42,10 @@ func pathConfigLease(b *backend) *framework.Path {
 func (b *backend) pathConfigLeaseWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	ttlRaw := d.Get("ttl").(string)
-	ttlMaxRaw := d.Get("ttl_max").(string)
+	ttlMaxRaw := d.Get("max_ttl").(string)
+	if len(ttlMaxRaw) == 0 {
+		ttlMaxRaw = d.Get("ttl_max").(string)
+	}
 
 	ttl, err := time.ParseDuration(ttlRaw)
 	if err != nil {
@@ -46,7 +55,7 @@ func (b *backend) pathConfigLeaseWrite(
 	ttlMax, err := time.ParseDuration(ttlMaxRaw)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf(
-			"Invalid ttl_max: %s", err)), nil
+			"Invalid max_ttl: %s", err)), nil
 	}
 
 	// Store it
@@ -78,7 +87,7 @@ func (b *backend) pathConfigLeaseRead(
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"ttl":     leaseConfig.TTL.String(),
-			"ttl_max": leaseConfig.TTLMax.String(),
+			"max_ttl": leaseConfig.TTLMax.String(),
 		},
 	}, nil
 }

--- a/website/source/docs/secrets/mssql/index.html.md
+++ b/website/source/docs/secrets/mssql/index.html.md
@@ -60,7 +60,7 @@ by Vault. This is done by writing to the `config/lease` key:
 ```
 $ vault write mssql/config/lease \
     ttl=1h \
-    ttl_max=24h
+    max_ttl=24h
 Success! Data written to: mssql/config/lease
 ```
 
@@ -187,7 +187,7 @@ allowed to read.
         with time suffix. Hour is the largest suffix.
       </li>
       <li>
-        <span class="param">ttl_max</span>
+        <span class="param">max_ttl</span>
         <span class="param-flags">required</span>
         The maximum ttl value provided as a string duration
         with time suffix. Hour is the largest suffix.
@@ -226,7 +226,7 @@ allowed to read.
         '{{name}}' and '{{password}}' values will be substituted. Must be a
         semicolon-separated string, a base64-encoded semicolon-separated
         string, a serialized JSON string array, or a base64-encoded serialized
-        JSON string array. 
+        JSON string array.
       </li>
     </ul>
   </dd>


### PR DESCRIPTION
This will bring this backends parameters in line with the other secret backends.