### PR TITLE
Advertise the cluster_(id|name) in the Scada handshake

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -371,6 +371,19 @@ func (c *ServerCommand) Run(args []string) int {
 	// Initialize the listeners
 	lns := make([]net.Listener, 0, len(config.Listeners))
 	for i, lnConfig := range config.Listeners {
+		if lnConfig.Type == "atlas" {
+			cluster, err := core.Cluster()
+			if err != nil {
+				c.Ui.Error(fmt.Sprintf(
+					"Error initializing listener of type %s: %s",
+					lnConfig.Type, err))
+				return 1
+			}
+
+			lnConfig.Config["cluster_id"] = cluster.ID
+			lnConfig.Config["cluster_name"] = cluster.Name
+		}
+
 		ln, props, reloadFunc, err := server.NewListener(lnConfig.Type, lnConfig.Config, logGate)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf(

--- a/command/server.go
+++ b/command/server.go
@@ -372,16 +372,12 @@ func (c *ServerCommand) Run(args []string) int {
 	lns := make([]net.Listener, 0, len(config.Listeners))
 	for i, lnConfig := range config.Listeners {
 		if lnConfig.Type == "atlas" {
-			cluster, err := core.Cluster()
-			if err != nil {
-				c.Ui.Error(fmt.Sprintf(
-					"Error initializing listener of type %s: %s",
-					lnConfig.Type, err))
+			if config.ClusterName == "" {
+				c.Ui.Error("cluster_name is not set in the config and is a required value")
 				return 1
 			}
 
-			lnConfig.Config["cluster_id"] = cluster.ID
-			lnConfig.Config["cluster_name"] = cluster.Name
+			lnConfig.Config["cluster_name"] = config.ClusterName
 		}
 
 		ln, props, reloadFunc, err := server.NewListener(lnConfig.Type, lnConfig.Config, logGate)

--- a/command/server/listener_atlas.go
+++ b/command/server/listener_atlas.go
@@ -33,7 +33,6 @@ func atlasListenerFactory(config map[string]string, logger io.Writer) (net.Liste
 		ResourceType: "vault-cluster",
 		Meta: map[string]string{
 			"node_id":      config["node_id"],
-			"cluster_id":   config["cluster_id"],
 			"cluster_name": config["cluster_name"],
 		},
 		Atlas: scada.AtlasConfig{

--- a/command/server/listener_atlas.go
+++ b/command/server/listener_atlas.go
@@ -32,7 +32,9 @@ func atlasListenerFactory(config map[string]string, logger io.Writer) (net.Liste
 		Version:      version.GetVersion().VersionNumber(),
 		ResourceType: "vault-cluster",
 		Meta: map[string]string{
-			"node_id": config["node_id"],
+			"node_id":      config["node_id"],
+			"cluster_id":   config["cluster_id"],
+			"cluster_name": config["cluster_name"],
 		},
 		Atlas: scada.AtlasConfig{
 			Endpoint:       config["endpoint"],


### PR DESCRIPTION
This improves connection times by not requiring the scada endpoint to turn around and query `/sys/health` to find out the cluster grouping info (which is critical for scada operations)