### PR TITLE
Don't use time.Time in responses.

### DIFF
--- a/audit/format.go
+++ b/audit/format.go
@@ -225,7 +225,7 @@ func (f *AuditFormatter) FormatResponse(
 		respWrapInfo = &AuditWrapInfo{
 			TTL:             int(resp.WrapInfo.TTL / time.Second),
 			Token:           resp.WrapInfo.Token,
-			CreationTime:    resp.WrapInfo.CreationTime,
+			CreationTime:    resp.WrapInfo.CreationTime.Format(time.RFC3339Nano),
 			WrappedAccessor: resp.WrapInfo.WrappedAccessor,
 		}
 	}
@@ -316,10 +316,10 @@ type AuditSecret struct {
 }
 
 type AuditWrapInfo struct {
-	TTL             int       `json:"ttl"`
-	Token           string    `json:"token"`
-	CreationTime    time.Time `json:"creation_time"`
-	WrappedAccessor string    `json:"wrapped_accessor,omitempty"`
+	TTL             int    `json:"ttl"`
+	Token           string `json:"token"`
+	CreationTime    string `json:"creation_time"`
+	WrappedAccessor string `json:"wrapped_accessor,omitempty"`
 }
 
 // getRemoteAddr safely gets the remote address avoiding a nil pointer

--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -867,9 +867,9 @@ func (b *backend) secretIDCommon(s logical.Storage, entryIndex, secretIDHMAC str
 	// Map() from 'structs' package formats time in RFC3339Nano.
 	// In order to not break the API due to a modification in the
 	// third party package, converting the time values again.
-	d["creation_time"] = (d["creation_time"].(time.Time)).Format(time.RFC3339Nano)
-	d["expiration_time"] = (d["expiration_time"].(time.Time)).Format(time.RFC3339Nano)
-	d["last_updated_time"] = (d["last_updated_time"].(time.Time)).Format(time.RFC3339Nano)
+	d["creation_time"] = result.CreationTime.Format(time.RFC3339Nano)
+	d["expiration_time"] = result.ExpirationTime.Format(time.RFC3339Nano)
+	d["last_updated_time"] = result.LastUpdatedTime.Format(time.RFC3339Nano)
 
 	return &logical.Response{
 		Data: d,

--- a/builtin/credential/aws-ec2/path_identity_whitelist.go
+++ b/builtin/credential/aws-ec2/path_identity_whitelist.go
@@ -111,9 +111,14 @@ func (b *backend) pathIdentityWhitelistRead(
 		return nil, nil
 	}
 
-	return &logical.Response{
+	resp := &logical.Response{
 		Data: structs.New(entry).Map(),
-	}, nil
+	}
+	resp.Data["creation_time"] = entry.CreationTime.Format(time.RFC3339Nano)
+	resp.Data["expiration_time"] = entry.ExpirationTime.Format(time.RFC3339Nano)
+	resp.Data["last_updated_time"] = entry.LastUpdatedTime.Format(time.RFC3339Nano)
+
+	return resp, nil
 }
 
 // Struct to represent each item in the identity whitelist.

--- a/builtin/credential/aws-ec2/path_roletag_blacklist.go
+++ b/builtin/credential/aws-ec2/path_roletag_blacklist.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"time"
 
-	"github.com/fatih/structs"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -128,7 +127,10 @@ func (b *backend) pathRoletagBlacklistRead(
 	}
 
 	return &logical.Response{
-		Data: structs.New(entry).Map(),
+		Data: map[string]interface{}{
+			"creation_time":   entry.CreationTime.Format(time.RFC3339Nano),
+			"expiration_time": entry.ExpirationTime.Format(time.RFC3339Nano),
+		},
 	}, nil
 }
 

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -118,7 +118,7 @@ func revokeCert(b *backend, req *logical.Request, serial string, fromLease bool)
 		},
 	}
 	if !revInfo.RevocationTimeUTC.IsZero() {
-		resp.Data["revocation_time_rfc3339"] = revInfo.RevocationTimeUTC
+		resp.Data["revocation_time_rfc3339"] = revInfo.RevocationTimeUTC.Format(time.RFC3339Nano)
 	}
 	return resp, nil
 }

--- a/http/logical.go
+++ b/http/logical.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-uuid"
@@ -169,7 +170,7 @@ func respondLogical(w http.ResponseWriter, r *http.Request, req *logical.Request
 				WrapInfo: &logical.HTTPWrapInfo{
 					Token:           resp.WrapInfo.Token,
 					TTL:             int(resp.WrapInfo.TTL.Seconds()),
-					CreationTime:    resp.WrapInfo.CreationTime,
+					CreationTime:    resp.WrapInfo.CreationTime.Format(time.RFC3339Nano),
 					WrappedAccessor: resp.WrapInfo.WrappedAccessor,
 				},
 			}

--- a/logical/sanitize.go
+++ b/logical/sanitize.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"time"
 )
 
 // This logic was pulled from the http package so that it can be used for
@@ -60,10 +59,10 @@ type HTTPAuth struct {
 }
 
 type HTTPWrapInfo struct {
-	Token           string    `json:"token"`
-	TTL             int       `json:"ttl"`
-	CreationTime    time.Time `json:"creation_time"`
-	WrappedAccessor string    `json:"wrapped_accessor,omitempty"`
+	Token           string `json:"token"`
+	TTL             int    `json:"ttl"`
+	CreationTime    string `json:"creation_time"`
+	WrappedAccessor string `json:"wrapped_accessor,omitempty"`
 }
 
 type HTTPSysInjector struct {


### PR DESCRIPTION
This fixes #1911 but not directly; it doesn't address the cause of the
panic. However, it turns out that this is the correct fix anyways,
because it ensures that the value being logged is RFC3339 format, which
is what the time turns into in JSON but not the normal time string
value, so what we audit log (and HMAC) matches what we are returning.