### PR TITLE
Tip to override VAULT_ADDR in getting started guide

### DIFF
--- a/website/source/intro/getting-started/deploy.html.md
+++ b/website/source/intro/getting-started/deploy.html.md
@@ -43,7 +43,8 @@ Within the configuration file, there are two primary configurations:
 
   * `listener` - One or more listeners determine how Vault listens for
     API requests. In the example above we're listening on localhost port
-    8200 without TLS.
+    8200 without TLS. In your environment set `VAULT_ADDR=http://127.0.0.1:8200`
+    so the Vault client will connect without TLS. 
 
 For now, copy and paste the configuration above to `example.hcl`. It will
 configure Vault to expect an instance of Consul running locally.


### PR DESCRIPTION
Avoids the `http: server gave HTTP response to HTTPS client` error that you will run into if following the guide verbatim.