### PR TITLE
Fix panic on deleting the AppRole which doesn't exist

### DIFF
--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -718,6 +718,9 @@ func (b *backend) pathRoleDelete(req *logical.Request, data *framework.FieldData
 	if err != nil {
 		return nil, err
 	}
+	if role == nil {
+		return nil, nil
+	}
 
 	// Acquire the lock before deleting the secrets.
 	b.roleLock.Lock()


### PR DESCRIPTION
`pathRoleDelete` should return silently if the specified AppRole doesn't exist.
Fixes GH-1919