### PR TITLE
Check for prefix match instead of exact match for IAM bound parameters

### DIFF
--- a/builtin/credential/aws-ec2/path_login.go
+++ b/builtin/credential/aws-ec2/path_login.go
@@ -327,7 +327,7 @@ func (b *backend) pathLoginUpdate(
 			return nil, fmt.Errorf("IAM instance profile ARN in the instance description is nil")
 		}
 		iamInstanceProfileARN := *instanceDesc.Reservations[0].Instances[0].IamInstanceProfile.Arn
-		if iamInstanceProfileARN != roleEntry.BoundIamInstanceProfileARN {
+		if !strings.HasPrefix(iamInstanceProfileARN, roleEntry.BoundIamInstanceProfileARN) {
 			return logical.ErrorResponse(fmt.Sprintf("IAM instance profile ARN %q does not satisfy the constraint role %q", iamInstanceProfileARN, roleName)), nil
 		}
 	}
@@ -367,7 +367,7 @@ func (b *backend) pathLoginUpdate(
 			return nil, fmt.Errorf("IAM role ARN could not be fetched")
 		}
 
-		if iamRoleARN != roleEntry.BoundIamRoleARN {
+		if !strings.HasPrefix(iamRoleARN, roleEntry.BoundIamRoleARN) {
 			return logical.ErrorResponse(fmt.Sprintf("IAM role ARN %q does not satisfy the constraint role %q", iamRoleARN, roleName)), nil
 		}
 	}

--- a/builtin/credential/aws-ec2/path_role.go
+++ b/builtin/credential/aws-ec2/path_role.go
@@ -32,13 +32,15 @@ in its identity document to match the one specified by this parameter.`,
 			},
 			"bound_iam_role_arn": {
 				Type: framework.TypeString,
-				Description: `If set, defines a constraint on the EC2 instances that they should be using the
-IAM role ARN specified by this parameter.`,
+				Description: `If set, defines a constraint on the EC2 instances to be associated with an IAM
+role ARN which has a prefix that matches the value specified by this
+parameter. Note that an exact match is also a prefix.`,
 			},
 			"bound_iam_instance_profile_arn": {
 				Type: framework.TypeString,
-				Description: `If set, defines a constraint on the EC2 instances that they should be using the
-IAM instance profile ARN specified by this parameter.`,
+				Description: `If set, defines a constraint on the EC2 instances to be associated with an IAM
+instance profile ARN which has a prefix that matches the value specified by this
+parameter. Note that an exact match is also a prefix.`,
 			},
 			"role_tag": {
 				Type:        framework.TypeString,

--- a/website/source/docs/auth/aws-ec2.html.md
+++ b/website/source/docs/auth/aws-ec2.html.md
@@ -843,16 +843,18 @@ in its identity document to match the one specified by this parameter.
       <li>
         <span class="param">bound_iam_role_arn</span>
         <span class="param-flags">optional</span>
-        If set, defines a constraint on the EC2 instances that they should be
-using the IAM role ARN specified by this parameter.
+If set, defines a constraint on the EC2 instances to be associated with an IAM
+role ARN which has a prefix that matches the value specified by this
+parameter. Note that an exact match is also a prefix.
       </li>
     </ul>
-    <ul>
+j   <ul>
       <li>
         <span class="param">bound_iam_instance_profile_arn</span>
         <span class="param-flags">optional</span>
-        If set, defines a constraint on the EC2 instances that they should be
-using the IAM instance profile ARN specified by this parameter.
+If set, defines a constraint on the EC2 instances to be associated with an IAM
+instance profile ARN which has a prefix that matches the value specified by
+this parameter. Note that an exact match is also a prefix.
       </li>
     </ul>
     <ul>


### PR DESCRIPTION
Fixes #1941 