### PR TITLE
Adds HUP support for audit log files to close and reopen.

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -26,6 +26,9 @@ type Backend interface {
 	// so that a caller can determine if a value in the audit log matches
 	// an expected plaintext value
 	GetHash(string) string
+
+	// Reload is called on SIGHUP for supporting backends.
+	Reload() error
 }
 
 type BackendConfig struct {

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -116,3 +116,7 @@ func (b *Backend) LogResponse(auth *logical.Auth, req *logical.Request,
 	_, err = b.logger.Write(buf.Bytes())
 	return err
 }
+
+func (b *Backend) Reload() error {
+	return nil
+}

--- a/command/server.go
+++ b/command/server.go
@@ -871,6 +871,7 @@ func (c *ServerCommand) Reload(configPath []string) error {
 		for _, relFunc := range (*c.reloadFuncs)["listener|"+lnConfig.Type] {
 			if err := relFunc(lnConfig.Config); err != nil {
 				reloadErrors = multierror.Append(reloadErrors, fmt.Errorf("Error encountered reloading configuration: %s", err))
+				goto audit
 			}
 		}
 	}

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -49,6 +49,10 @@ func (n *NoopAudit) GetHash(data string) string {
 	return n.Config.Salt.GetIdentifiedHMAC(data)
 }
 
+func (n *NoopAudit) Reload() err {
+	return nil
+}
+
 func TestCore_EnableAudit(t *testing.T) {
 	c, key, _ := TestCoreUnsealed(t)
 	c.auditBackends["noop"] = func(config *audit.BackendConfig) (audit.Backend, error) {

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -49,7 +49,7 @@ func (n *NoopAudit) GetHash(data string) string {
 	return n.Config.Salt.GetIdentifiedHMAC(data)
 }
 
-func (n *NoopAudit) Reload() err {
+func (n *NoopAudit) Reload() error {
 	return nil
 }
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -101,17 +101,18 @@ func (t *MountTable) setTaint(path string, value bool) bool {
 	return false
 }
 
-// remove is used to remove a given path entry
-func (t *MountTable) remove(path string) bool {
+// remove is used to remove a given path entry; returns the entry that was
+// removed
+func (t *MountTable) remove(path string) *MountEntry {
 	n := len(t.Entries)
 	for i := 0; i < n; i++ {
-		if t.Entries[i].Path == path {
+		if entry := t.Entries[i]; entry.Path == path {
 			t.Entries[i], t.Entries[n-1] = t.Entries[n-1], nil
 			t.Entries = t.Entries[:n-1]
-			return true
+			return entry
 		}
 	}
-	return false
+	return nil
 }
 
 // MountEntry is used to represent a mount table entry

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -346,6 +346,10 @@ func (n *noopAudit) LogResponse(a *logical.Auth, r *logical.Request, re *logical
 	return nil
 }
 
+func (n *noopAudit) Reload() error {
+	return nil
+}
+
 type rawHTTP struct{}
 
 func (n *rawHTTP) HandleRequest(req *logical.Request) (*logical.Response, error) {


### PR DESCRIPTION
This makes it much easier to deal with normal log rotation methods.

As part of testing this I noticed that HUP and other items that come out
of command/server.go are going to stderr, which is where our normal log
lines go. This isn't so much problematic with our normal output but as
we officially move to supporting other formats this can cause
interleaving issues, so I moved those to stdout instead.

Fixes #1949 