### PR TITLE
Add new aws-iam authentication backend

### DIFF
--- a/builtin/credential/aws-iam/backend.go
+++ b/builtin/credential/aws-iam/backend.go
@@ -1,0 +1,55 @@
+package awsiam
+
+import (
+	"sync"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
+	return Backend().Setup(conf)
+}
+
+func Backend() *backend {
+	var b backend
+
+	b.Backend = &framework.Backend{
+		Help: backendHelp,
+		PathsSpecial: &logical.Paths{
+			Root: []string{},
+			Unauthenticated: []string{
+				"login",
+			},
+		},
+		Paths: []*framework.Path{
+			pathLogin(&b),
+			pathConfigClient(&b),
+			pathRole(&b),
+			pathListRole(&b),
+		},
+		AuthRenew: b.pathLoginRenew,
+	}
+
+	return &b
+}
+
+type backend struct {
+	*framework.Backend
+
+	// Lock to make changes to the client config
+	configMutex sync.RWMutex
+
+	// Lock to make changes to the roles
+	roleMutex sync.RWMutex
+}
+
+const backendHelp = `
+The aws-iam auth backend provides a secure introduction mechanism for AWS IAM
+principals. This allows you to reduce the problem of securely introducing a
+Vault token to the problem of securely introducing AWS IAM credentials, which
+AWS has already solved in a number of use cases, such as via EC2 Instance
+Profiles and IAM roles attached to Lambda functions. It also allows you to have
+a consistent workflow between developers working on a local laptop with tools
+such as Hologram.
+`

--- a/builtin/credential/aws-iam/backend_test.go
+++ b/builtin/credential/aws-iam/backend_test.go
@@ -1,0 +1,215 @@
+package awsiam
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/hashicorp/vault/logical"
+	logicaltest "github.com/hashicorp/vault/logical/testing"
+)
+
+func buildLoginData(request *http.Request, roleName string) (map[string]interface{}, error) {
+	headersJson, err := json.Marshal(transformHeaders(request.Header))
+	if err != nil {
+		return nil, err
+	}
+	requestBody, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"method":  request.Method,
+		"url":     request.URL.String(),
+		"headers": base64.StdEncoding.EncodeToString(headersJson),
+		"body":    base64.StdEncoding.EncodeToString(requestBody),
+		"role":    roleName,
+	}, nil
+}
+
+// This is an acceptance test.
+// If the test is NOT being run on an AWS EC2 instance in an instance profile,
+// it requires the following environment variables to be set:
+// TEST_AWS_ACCESS_KEY_ID
+// TEST_AWS_SECRET_ACCESS_KEY
+// TEST_AWS_SECURITY_TOKEN (optional, if you are using short-lived creds)
+// These are intentionally NOT the "standard" variables to prevent accidentally
+// using prod creds in acceptance tests
+func TestBackendAcc_Login(t *testing.T) {
+	// This test case should be run only when certain env vars are set and
+	// executed as an acceptance test.
+	if os.Getenv(logicaltest.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", logicaltest.TestEnvVar))
+		return
+	}
+
+	storage := &logical.InmemStorage{}
+	config := logical.TestBackendConfig()
+	config.StorageView = storage
+	b := Backend()
+	_, err := b.Setup(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Override the default AWS env vars (if set) with our test creds
+	// so that the credential provider chain will pick them up
+	// NOTE that I'm not bothing to override the shared config file location,
+	// so if creds are specified there, they will be used before IAM
+	// instance profile creds
+	// This doesn't provide perfect leakage protection (e.g., it will still
+	// potentially pick up credentials from the ~/.config files), but probably
+	// good enough rather than having to muck around in the low-level details
+	for _, envvar := range []string{
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SECURITY_TOKEN"} {
+		os.Setenv("TEST_"+envvar, os.Getenv(envvar))
+	}
+	awsSession, err := session.NewSession()
+	if err != nil {
+		fmt.Println("failed to create session,", err)
+		return
+	}
+
+	stsService := sts.New(awsSession)
+	var stsInputParams *sts.GetCallerIdentityInput
+
+	testIdentity, err := stsService.GetCallerIdentity(stsInputParams)
+	if err != nil {
+		t.Fatalf("Received error retrieving identity: %s", err)
+	}
+	testIdentityArn, _, err := parseIamArn(*testIdentity.Arn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test setup largely done
+	// At this point, we're going to:
+	// 1. Configure the client to require our test header value
+	// 2. Configure two different roles:
+	//    a. One bound to our test user
+	//    b. One bound to a garbage ARN
+	// 3. Pass in a request that doesn't have the signed header, ensure
+	//    we're not allowed to login
+	// 4. Passin a request that has a validly signed header, but the wrong
+	//    value, ensure it doesn't allow login
+	// 5. Pass in a request that has a validly signed request, ensure
+	//    it allows us to login to our role
+	// 6. Pass in a request that has a validly signed request, asking for
+	//    the other role, ensure it fails
+	const testVaultHeaderValue = "VaultAcceptanceTesting"
+	const testValidRoleName = "valid-role"
+	const testInvalidRoleName = "invalid-role"
+
+	clientConfigData := map[string]interface{}{
+		"vault_header_value": testVaultHeaderValue,
+	}
+	clientRequest := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/client",
+		Storage:   storage,
+		Data:      clientConfigData,
+	}
+	_, err = b.HandleRequest(clientRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// configuring the valid role we'll be able to login to
+	roleData := map[string]interface{}{
+		"bound_iam_principal": testIdentityArn,
+		"policies":            "root",
+	}
+	roleRequest := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "role/" + testValidRoleName,
+		Storage:   storage,
+		Data:      roleData,
+	}
+	resp, err := b.HandleRequest(roleRequest)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: failed to create role: resp:%#v\nerr:%v", resp, err)
+	}
+
+	// now we're creating the invalid role we won't be able to login to
+	roleData["bound_iam_principal"] = "arn:aws:iam::123456789012:role/FakeRole"
+	roleRequest.Path = "role/" + testInvalidRoleName
+	resp, err = b.HandleRequest(roleRequest)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: failed to create role: resp:%#v\nerr:%v", resp, err)
+	}
+
+	// now, create the request without the signed header
+	stsRequestNoHeader, _ := stsService.GetCallerIdentityRequest(stsInputParams)
+	stsRequestNoHeader.Sign()
+	loginData, err := buildLoginData(stsRequestNoHeader.HTTPRequest, testValidRoleName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loginRequest := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "login",
+		Storage:   storage,
+		Data:      loginData,
+	}
+	resp, err = b.HandleRequest(loginRequest)
+	if err != nil || resp == nil || !resp.IsError() {
+		t.Errorf("bad: expected failed login due to missing header: resp:%#v\nerr:%v", resp, err)
+	}
+
+	// create the request with the invalid header value
+
+	// Not reusing stsRequestNoHeader because the process of signing the request
+	// and reading the body modifies the underlying request, so it's just cleaner
+	// to get new requests.
+	stsRequestInvalidHeader, _ := stsService.GetCallerIdentityRequest(stsInputParams)
+	stsRequestInvalidHeader.HTTPRequest.Header.Add(magicVaultHeader, "InvalidValue")
+	stsRequestInvalidHeader.Sign()
+	loginData, err = buildLoginData(stsRequestInvalidHeader.HTTPRequest, testValidRoleName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loginRequest = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "login",
+		Storage:   storage,
+		Data:      loginData,
+	}
+	resp, err = b.HandleRequest(loginRequest)
+	if err != nil || resp == nil || !resp.IsError() {
+		t.Errorf("bad: expected failed login due to invalid header: resp:%#v\nerr:%v", resp, err)
+	}
+
+	// Now, valid request against invalid role
+	stsRequestValid, _ := stsService.GetCallerIdentityRequest(stsInputParams)
+	stsRequestValid.HTTPRequest.Header.Add(magicVaultHeader, testVaultHeaderValue)
+	stsRequestValid.Sign()
+	loginData, err = buildLoginData(stsRequestValid.HTTPRequest, testInvalidRoleName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loginRequest = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "login",
+		Storage:   storage,
+		Data:      loginData,
+	}
+	resp, err = b.HandleRequest(loginRequest)
+	if err != nil || resp == nil || !resp.IsError() {
+		t.Errorf("bad: expected failed login due to invalid role: resp:%#v\nerr:%v", resp, err)
+	}
+
+	loginData["role"] = testValidRoleName
+	resp, err = b.HandleRequest(loginRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.Auth == nil || resp.IsError() {
+		t.Errorf("bad: expected valid login: resp:%#v", resp)
+	}
+}

--- a/builtin/credential/aws-iam/backend_test.go
+++ b/builtin/credential/aws-iam/backend_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func buildLoginData(request *http.Request, roleName string) (map[string]interface{}, error) {
-	headersJson, err := json.Marshal(transformHeaders(request.Header))
+	headersJson, err := json.Marshal(request.Header)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/credential/aws-iam/cli.go
+++ b/builtin/credential/aws-iam/cli.go
@@ -16,14 +16,6 @@ import (
 
 type CLIHandler struct{}
 
-func transformHeaders(input map[string][]string) map[string]string {
-	retval := map[string]string{}
-	for k, v := range input {
-		retval[k] = v[0]
-	}
-	return retval
-}
-
 func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (string, error) {
 	mount, ok := m["mount"]
 	if !ok {
@@ -67,7 +59,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (string, error) {
 		stsRequest.HTTPRequest.Header.Add(magicVaultHeader, headerValue)
 	}
 	stsRequest.Sign()
-	headersJson, err := json.Marshal(transformHeaders(stsRequest.HTTPRequest.Header))
+	headersJson, err := json.Marshal(stsRequest.HTTPRequest.Header)
 	if err != nil {
 		return "", err
 	}

--- a/builtin/credential/aws-iam/cli.go
+++ b/builtin/credential/aws-iam/cli.go
@@ -1,0 +1,137 @@
+package awsiam
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/hashicorp/vault/api"
+)
+
+type CLIHandler struct{}
+
+func transformHeaders(input map[string][]string) map[string]string {
+	retval := map[string]string{}
+	for k, v := range input {
+		retval[k] = v[0]
+	}
+	return retval
+}
+
+func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (string, error) {
+	mount, ok := m["mount"]
+	if !ok {
+		mount = "aws-iam"
+	}
+
+	role, ok := m["role"]
+	if !ok {
+		role = ""
+	}
+
+	headerValue, ok := m["header_value"]
+	if !ok {
+		headerValue = ""
+	}
+
+	var stsSession *session.Session
+	var err error
+
+	access_key, ok := m["aws_access_key_id"]
+	if ok {
+		secret_key, ok := m["aws_secret_access_key"]
+		if !ok {
+			return "", fmt.Errorf("Explicitly specified aws_access_key_id but not aws_secret_access_key. Please specify them both.")
+		}
+		token, ok := m["aws_security_token"]
+		if !ok {
+			token = ""
+		}
+		staticCreds := credentials.NewStaticCredentials(access_key, secret_key, token)
+		stsSession, err = session.NewSessionWithOptions(session.Options{
+			Config: aws.Config{Credentials: staticCreds},
+		})
+		if err != nil {
+			return "", err
+		}
+	} else {
+		stsSession, err = session.NewSession()
+		if err != nil {
+			return "", err
+		}
+	}
+	var params *sts.GetCallerIdentityInput
+	svc := sts.New(stsSession)
+	stsRequest, _ := svc.GetCallerIdentityRequest(params)
+	if headerValue != "" {
+		stsRequest.HTTPRequest.Header.Add("X-Vault-Server", headerValue)
+	}
+	stsRequest.Sign()
+	headersJson, err := json.Marshal(transformHeaders(stsRequest.HTTPRequest.Header))
+	if err != nil {
+		return "", err
+	}
+	requestBody, err := ioutil.ReadAll(stsRequest.HTTPRequest.Body)
+	if err != nil {
+		return "", err
+	}
+	method := stsRequest.HTTPRequest.Method
+	targetUrl := stsRequest.HTTPRequest.URL.String()
+	headers := base64.StdEncoding.EncodeToString(headersJson)
+	body := base64.StdEncoding.EncodeToString(requestBody)
+
+	path := fmt.Sprintf("auth/%s/login", mount)
+	secret, err := c.Logical().Write(path, map[string]interface{}{
+		"method":  method,
+		"url":     targetUrl,
+		"headers": headers,
+		"body":    body,
+		"role":    role,
+	})
+
+	if err != nil {
+		return "", err
+	}
+	if secret == nil {
+		return "", fmt.Errorf("empty response from credential provider")
+	}
+
+	return secret.Auth.ClientToken, nil
+
+	return "", nil
+}
+
+func (h *CLIHandler) Help() string {
+	help := `
+The AWS-IAM credentaial provider allows you to authenticate with
+AWS IAM credentials. To use it, you specify valid AWS IAM credentials
+in one of a number of ways. They can be specified explicitly on the
+command line (which in general you should not do), via the standard AWS
+environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and
+AWS_SECURITY_TOKEN), via the ~/.aws/credentials file, or via an EC2
+instance profile (in that order).
+
+  Example: vault auth -method=aws-iam
+
+If you need to explicitly pass in credentials, you would do it like this:
+  Example: vault auth -method=aws-iam aws_access_key_id=<access key> aws_secret_access_key=<secret key> aws_security_token=<token>
+
+Key/Value Pairs:
+
+  mount=aws-iam                       The mountpoint for the AWS-IAM credential provider.
+                                      Defaults to "aws-iam"
+  aws_access_key_id=<access key>      Explicitly specified AWS access key
+  aws_secret_access_key=<secret key>  Explicitly specified AWS secret key
+  aws_security_token=<token>          Security token for temporary credentials
+  header_value                        The Value of the X-Vault-Server header.
+  role                                The name of the role you're requesting a token for
+  `
+
+	return strings.TrimSpace(help)
+}

--- a/builtin/credential/aws-iam/path_config_client.go
+++ b/builtin/credential/aws-iam/path_config_client.go
@@ -1,0 +1,150 @@
+package awsiam
+
+import (
+	"github.com/fatih/structs"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathConfigClient(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "config/client$",
+		Fields: map[string]*framework.FieldSchema{
+			"endpoint": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Default:     "",
+				Description: "API endpoint to submit GetCallerIdentity requests to",
+			},
+			"vault_header_value": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Default:     "",
+				Description: "Value to require in the X-Vault-Server request header",
+			},
+		},
+
+		ExistenceCheck: b.pathConfigClientExistenceCheck,
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.CreateOperation: b.pathConfigClientCreateUpdate,
+			logical.UpdateOperation: b.pathConfigClientCreateUpdate,
+			logical.DeleteOperation: b.pathConfigClientDelete,
+			logical.ReadOperation:   b.pathConfigClientRead,
+		},
+
+		HelpSynopsis:    pathConfigClientHelpSyn,
+		HelpDescription: pathConfigClientHelpDesc,
+	}
+}
+
+func (b *backend) lockedClientConfigEntry(s logical.Storage) (*clientConfig, error) {
+	b.configMutex.RLock()
+	defer b.configMutex.RUnlock()
+
+	return b.nonLockedClientConfigEntry(s)
+}
+
+func (b *backend) nonLockedClientConfigEntry(s logical.Storage) (*clientConfig, error) {
+	entry, err := s.Get("config/client")
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	var result clientConfig
+	if err := entry.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+
+}
+
+func (b *backend) pathConfigClientExistenceCheck(
+	req *logical.Request, data *framework.FieldData) (bool, error) {
+
+	entry, err := b.lockedClientConfigEntry(req.Storage)
+	if err != nil {
+		return false, err
+	}
+	return entry != nil, nil
+}
+
+func (b *backend) pathConfigClientRead(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+
+	clientConfig, err := b.lockedClientConfigEntry(req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	if clientConfig == nil {
+		return nil, nil
+	}
+
+	return &logical.Response{
+		Data: structs.New(clientConfig).Map(),
+	}, nil
+}
+
+func (b *backend) pathConfigClientCreateUpdate(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+
+	b.configMutex.Lock()
+	defer b.configMutex.Unlock()
+
+	configEntry, err := b.nonLockedClientConfigEntry(req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if configEntry == nil {
+		configEntry = &clientConfig{}
+	}
+
+	endpointStr := data.Get("endpoint").(string)
+	if endpointStr != "" {
+		configEntry.Endpoint = endpointStr
+	}
+
+	headerValueStr := data.Get("vault_header_value").(string)
+	if headerValueStr != "" {
+		configEntry.HeaderValue = headerValueStr
+	}
+
+	entry, err := logical.StorageEntryJSON("config/client", configEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := req.Storage.Put(entry); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathConfigClientDelete(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+
+	b.configMutex.Lock()
+	defer b.configMutex.Unlock()
+
+	return nil, req.Storage.Delete("config/client")
+}
+
+type clientConfig struct {
+	Endpoint    string `json:"endpoint" structs:"endpoint" mapstructure:"endpoint"`
+	HeaderValue string `json:"vault_header_value" structs:"vault_header_value" mapstructure:"vault_header_value"`
+}
+
+const pathConfigClientHelpSyn = `
+Configures the STS client used to validate requests.
+`
+
+const pathConfigClientHelpDesc = `
+aws-iam auth backend validates signed GetCallerIdentity requests to determine
+the AWS IAM principal making the requests. The endpoint allows you to specify
+which STS endpoint to forward the signed query along to, while the
+vault_header_value allows you to specify a required value to be included in the
+signed headers to mitigate certain types of attacks.
+`

--- a/builtin/credential/aws-iam/path_config_client.go
+++ b/builtin/credential/aws-iam/path_config_client.go
@@ -18,7 +18,7 @@ func pathConfigClient(b *backend) *framework.Path {
 			"vault_header_value": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Default:     "",
-				Description: "Value to require in the X-Vault-Server request header",
+				Description: "Value to require in the X-Vault-AWSIAM-Server-ID request header",
 			},
 		},
 
@@ -101,14 +101,18 @@ func (b *backend) pathConfigClientCreateUpdate(
 		configEntry = &clientConfig{}
 	}
 
-	endpointStr := data.Get("endpoint").(string)
-	if endpointStr != "" {
-		configEntry.Endpoint = endpointStr
+	endpointStr, ok := data.GetOk("endpoint")
+	if ok {
+		configEntry.Endpoint = endpointStr.(string)
+	} else if req.Operation == logical.CreateOperation {
+		configEntry.Endpoint = data.Get("endpoint").(string)
 	}
 
-	headerValueStr := data.Get("vault_header_value").(string)
-	if headerValueStr != "" {
-		configEntry.HeaderValue = headerValueStr
+	headerValueStr, ok := data.GetOk("vault_header_value")
+	if ok {
+		configEntry.HeaderValue = headerValueStr.(string)
+	} else if req.Operation == logical.CreateOperation {
+		configEntry.HeaderValue = data.Get("vault_header_value").(string)
 	}
 
 	entry, err := logical.StorageEntryJSON("config/client", configEntry)

--- a/builtin/credential/aws-iam/path_config_client_test.go
+++ b/builtin/credential/aws-iam/path_config_client_test.go
@@ -1,0 +1,73 @@
+package awsiam
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/logical"
+)
+
+func TestBackend_pathConfigClient(t *testing.T) {
+	config := logical.TestBackendConfig()
+	storage := &logical.InmemStorage{}
+	config.StorageView = storage
+
+	b := Backend()
+	_, err := b.Setup(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure we start with empty roles, which gives us confidence that the read later
+	// actually is the two roles we created
+	resp, err := b.HandleRequest(&logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config/client",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// at this point, resp == nil is valid as no client config exists
+	// if resp != nil, then resp.Data must have EndPoint and HeaderValue as nil
+	if resp != nil {
+		if resp.IsError() {
+			t.Fatalf("failed to read client config entry")
+		} else if resp.Data["endpoint"] != nil || resp.Data["vault_header_value"] != nil {
+			t.Fatalf("Returned endpoint or vault_header_value non-nil")
+		}
+	}
+
+	data := map[string]interface{}{
+		"endpoint":           "https://my-custom-sts-endpoint.example.com",
+		"vault_header_value": "vault_server_identification_314159",
+	}
+	resp, err = b.HandleRequest(&logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "config/client",
+		Data:      data,
+		Storage:   storage,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && resp.IsError() {
+		t.Fatal("failed to create the client config entry")
+	}
+
+	resp, err = b.HandleRequest(&logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config/client",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.IsError() {
+		t.Fatal("failed to read the client config entry")
+	}
+	if resp.Data["vault_header_value"] != data["vault_header_value"] {
+		t.Fatalf("Expected vault_header_value: '%#v'; returned vault_header_value: '%#v'",
+			data["vault_header_value"], resp.Data["vault_header_value"])
+	}
+}

--- a/builtin/credential/aws-iam/path_config_client_test.go
+++ b/builtin/credential/aws-iam/path_config_client_test.go
@@ -33,7 +33,7 @@ func TestBackend_pathConfigClient(t *testing.T) {
 		if resp.IsError() {
 			t.Fatalf("failed to read client config entry")
 		} else if resp.Data["endpoint"] != nil || resp.Data["vault_header_value"] != nil {
-			t.Fatalf("Returned endpoint or vault_header_value non-nil")
+			t.Fatalf("returned endpoint or vault_header_value non-nil")
 		}
 	}
 
@@ -67,7 +67,7 @@ func TestBackend_pathConfigClient(t *testing.T) {
 		t.Fatal("failed to read the client config entry")
 	}
 	if resp.Data["vault_header_value"] != data["vault_header_value"] {
-		t.Fatalf("Expected vault_header_value: '%#v'; returned vault_header_value: '%#v'",
+		t.Fatalf("expected vault_header_value: '%#v'; returned vault_header_value: '%#v'",
 			data["vault_header_value"], resp.Data["vault_header_value"])
 	}
 }

--- a/builtin/credential/aws-iam/path_login.go
+++ b/builtin/credential/aws-iam/path_login.go
@@ -1,0 +1,376 @@
+package awsiam
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	//"github.com/hashicorp/vault/helper/policyutil"
+	"github.com/hashicorp/vault/helper/jsonutil"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathLogin(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "login$",
+		Fields: map[string]*framework.FieldSchema{
+			"role": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: `Name of the role against which the login is being attempted.
+If 'role' is not specified, then the login endpoint looks for a role
+bearing the name of the IAM principal that is trying to login in.
+If a matching role is not found, the login fails.`,
+			},
+			"method": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: `HTTP method to use for the AWS request. This must match what
+has been signed in the presigned request. Currently, POST is the only supported value`,
+			},
+			"url": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: `Full URL against which to make the AWS request. If using a POST
+request with the action specified in the body, this should just be
+"/".`,
+			},
+			"body": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: `Base64-encoded request body. This must match the request
+body included in the signature.`,
+			},
+			"headers": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: `Base64-encoded JSON representation of the request headers.
+This must at a minimum include the headers over which AWS has included a
+signature.`,
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.UpdateOperation: b.pathLoginUpdate,
+		},
+
+		HelpSynopsis:    pathLoginSyn,
+		HelpDescription: pathLoginDesc,
+	}
+}
+
+func (b *backend) pathLoginUpdate(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+
+	// BEGIN boring data parsing
+	method := data.Get("method").(string)
+	if method == "" {
+		return logical.ErrorResponse("missing method"), nil
+	}
+
+	// In the future, might consider supporting GET
+	if method != "POST" {
+		return logical.ErrorResponse("Invalid method; currently only 'POST' is supported"), nil
+	}
+
+	rawUrl := data.Get("url").(string)
+	if rawUrl == "" {
+		return logical.ErrorResponse("missing url"), nil
+	}
+	parsedUrl, err := url.Parse(rawUrl)
+	if err != nil {
+		return logical.ErrorResponse("error parsing url"), nil
+	}
+
+	// TODO: There are two potentially valid cases we're not yet supporting that would
+	// necessitate this check being changed. First, if we support GET requests.
+	// Second if we support presigned POST requests
+	bodyB64 := data.Get("body").(string)
+	if bodyB64 == "" {
+		return logical.ErrorResponse("missing body"), nil
+	}
+	bodyRaw, err := base64.StdEncoding.DecodeString(bodyB64)
+	if err != nil {
+		return logical.ErrorResponse("body is invalid base64"), nil
+	}
+	body := string(bodyRaw)
+
+	headersB64 := data.Get("headers").(string)
+	if headersB64 == "" {
+		return logical.ErrorResponse("missing headers"), nil
+	}
+	headersJson, err := base64.StdEncoding.DecodeString(headersB64)
+	if err != nil {
+		return logical.ErrorResponse("headers is invalid base64"), nil
+	}
+	var headers map[string]string
+	err = jsonutil.DecodeJSON(headersJson, &headers)
+	if err != nil {
+		return logical.ErrorResponse(fmt.Sprintf("headers '%s' is invalid JSON: %s", headersJson, err)), nil
+	}
+	// END boring data parsing
+
+	config, err := b.lockedClientConfigEntry(req.Storage)
+	if err != nil {
+		return logical.ErrorResponse("Error getting configuration"), nil
+	}
+
+	if config.HeaderValue != "" {
+		ok, msg := ensureVaultHeaderValue(headers, parsedUrl, config.HeaderValue)
+		if !ok {
+			return logical.ErrorResponse(fmt.Sprintf("Error validating %s header: %s", magicVaultHeader, msg)), nil
+		}
+	}
+
+	endpoint := config.Endpoint
+	if endpoint == "" {
+		endpoint = "https://sts.amazonaws.com"
+	}
+
+	clientArn, err := submitCallerIdentityRequest(method, endpoint, parsedUrl, body, headers)
+	if err != nil {
+		return logical.ErrorResponse(fmt.Sprintf("Error making upstream request: %s", err)), nil
+	}
+	canonicalArn, principalName, err := parseIamArn(clientArn)
+	if err != nil {
+		return logical.ErrorResponse("Unrecognized IAM principal type"), nil
+	}
+
+	roleName := data.Get("role").(string)
+	if roleName == "" {
+		roleName = principalName
+	}
+
+	roleEntry, err := b.lockedAWSRole(req.Storage, roleName)
+	if err != nil {
+		return nil, err
+	}
+	if roleEntry == nil {
+		return logical.ErrorResponse(fmt.Sprintf("entry for role %s not found", roleName)), nil
+	}
+
+	if roleEntry.BoundIamPrincipal != canonicalArn {
+		return logical.ErrorResponse(fmt.Sprintf("IAM Principal '%s' does not belong to the role '%s'", clientArn, roleName)), nil
+	}
+
+	resp := &logical.Response{
+		Auth: &logical.Auth{
+			Policies: roleEntry.Policies,
+			Metadata: map[string]string{
+				"client_arn":    clientArn,
+				"canonical_arn": canonicalArn,
+			},
+			InternalData: map[string]interface{}{
+				"role_name": roleName,
+			},
+			DisplayName: principalName,
+			LeaseOptions: logical.LeaseOptions{
+				Renewable: true,
+				TTL:       roleEntry.TTL,
+			},
+		},
+	}
+
+	shortestTTL := b.System().DefaultLeaseTTL()
+	if roleEntry.TTL > time.Duration(0) && roleEntry.TTL < shortestTTL {
+		shortestTTL = roleEntry.TTL
+	}
+
+	maxTTL := b.System().MaxLeaseTTL()
+	if roleEntry.MaxTTL > time.Duration(0) && roleEntry.MaxTTL < maxTTL {
+		maxTTL = roleEntry.MaxTTL
+	}
+
+	if shortestTTL > maxTTL {
+		resp.AddWarning(fmt.Sprintf("Effective TTL of %q exceeded the effective max_ttl of %q; TTL value is capped accordingly", (shortestTTL / time.Second).String(), (maxTTL / time.Second).String()))
+		shortestTTL = maxTTL
+	}
+
+	resp.Auth.TTL = shortestTTL
+
+	return resp, nil
+}
+
+func (b *backend) pathLoginRenew(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	canonicalArn := req.Auth.Metadata["canonical_arn"]
+	if canonicalArn == "" {
+		return nil, fmt.Errorf("unable to retrieve canonical ARN from metadata during renewal")
+	}
+
+	roleName := req.Auth.InternalData["role_name"].(string)
+	if roleName == "" {
+		return nil, fmt.Errorf("Error retrieving role_name during renewal")
+	}
+	roleEntry, err := b.lockedAWSRole(req.Storage, roleName)
+	if err != nil {
+		return nil, err
+	}
+	if roleEntry == nil {
+		return nil, fmt.Errorf("role entry not found")
+	}
+
+	if roleEntry.BoundIamPrincipal != canonicalArn {
+		return nil, fmt.Errorf("Role no longer bound to arn '%s'", canonicalArn)
+	}
+
+	return framework.LeaseExtend(roleEntry.TTL, roleEntry.MaxTTL, b.System())(req, data)
+
+}
+
+// takes in ARNs like either arn:aws:iam::123456789012:user/MyUserName or
+// arn:aws:sts::123456789012:assumed-role/RoleName/SessionName
+// returns two strings
+// The first is the ARN transformed into a canonical form, i.e.,
+// the latter example transformed into arn:aws:iam::123456789012:role/RoleName
+// The second is the "principal" name, i.e., either "MyUserName" or "RoleName"
+func parseIamArn(iamArn string) (string, string, error) {
+	fullParts := strings.Split(iamArn, ":")
+	principalFullName := fullParts[5]
+	parts := strings.Split(principalFullName, "/")
+	principalName := parts[1]
+	transformedArn := iamArn
+	if parts[0] == "assumed-role" {
+		transformedArn = fmt.Sprintf("arn:aws:iam::%s:role/%s", fullParts[4], principalName)
+	} else if parts[0] != "user" {
+		return "", "", fmt.Errorf("Unrecognized principal type: '%s'", parts[0])
+	}
+	return transformedArn, principalName, nil
+}
+
+func ensureVaultHeaderValue(headers map[string]string, requestUrl *url.URL, requiredHeaderValue string) (bool, string) {
+	providedValue, ok := headers[magicVaultHeader]
+	if !ok {
+		return false, fmt.Sprintf("Didn't find %s", magicVaultHeader)
+	}
+
+	// NOT doing a constant time compare here since the value is NOT intended to be secret
+	if providedValue != requiredHeaderValue {
+		return false, fmt.Sprintf("Expected %s but got %s", requiredHeaderValue, providedValue)
+	}
+
+	if authzHeader, ok := headers["Authorization"]; ok {
+		// authzHeader looks like AWS4-HMAC-SHA256 Credential=AKI..., SignedHeaders=host;x-amz-date;x-vault-server, Signature=...
+		// We need to extract out the SignedHeaders
+		re := regexp.MustCompile(".*SignedHeaders=([^,]+)")
+		signedHeaders := string(re.FindSubmatch([]byte(authzHeader))[1])
+		return ensureHeaderIsSigned(signedHeaders, magicVaultHeader)
+	}
+	// TODO: If we support GET requests, then we need to parse the X-Amz-SignedHeaders
+	// argument out of the query string and search in there for the header value
+	return false, "Missing Authorization header"
+}
+
+func buildHttpRequest(method, endpoint string, parsedUrl *url.URL, body string, headers map[string]string) *http.Request {
+	// This is all a bit complicated because the AWS signature algorithm requires that
+	// the Host header be included in the signed headers. See
+	// http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+	// The use cases we want to support, in order of increasing complexity, are:
+	// 1. All defaults (client assumes sts.amazonaws.com and server has no override)
+	// 2. Alternate STS regions: client wants to go to a specific region, in which case
+	//    Vault must be confiugred with that endpoint as well. The client's signed request
+	//    will include a signature over what the client expects the Host header to be,
+	//    so we cannot change that and must match.
+	// 3. Alternate STS regions with a proxy that is transparent to Vault's clients.
+	//    In this case, Vault is aware of the proxy, as the proxy is configured as the
+	//    endpoint, but the clients should NOT be aware of the proxy (because STS will
+	//    not be aware of the proxy)
+	// It's also annoying because:
+	// 1. The AWS Sigv4 algorithm requires the Host header to be defined
+	// 2. Some of the official SDKs (at least botocore and aws-sdk-go) don't actually
+	//    incude an explicit Host header in the HTTP requests they generate, relying on
+	//    the underlying HTTP library to do that for them.
+	// 3. To get a validly signed request, the SDKs check if a Host header has been set
+	//    and, if not, add an inferred host header (based on the URI) to the internal
+	//    data structure used for calculating the signature, but never actually expose
+	//    that to clients. So then they just "hope" that the underlying library actually
+	//    adds the right Host header which was included in the signature calculation.
+	// We could either explicity require all Vault clients to explicitly add the Host header
+	// in the encoded request, or we could also implicitly infer it from the URI.
+	// We choose to support both -- allow you to explicitly set a Host header, but if not,
+	// infer one from the URI.
+	// HOWEVER, we have to preserve the request URI portion of the client's
+	// URL because the GetCallerIdentity Action can be encoded in either the body
+	// or the URL. So, we need to rebuild the URL sent to the http library to have the
+	// custom, Vault-specified endpoint with the client-side request parameters.
+	targetUrl := fmt.Sprintf("%s/%s", endpoint, parsedUrl.RequestURI())
+	request, err := http.NewRequest(method, targetUrl, strings.NewReader(body))
+	if err != nil {
+		return nil
+	}
+	request.Host = parsedUrl.Host
+	for k, v := range headers {
+		request.Header.Add(k, v)
+	}
+	return request
+}
+
+func ensureHeaderIsSigned(signedHeaders, headerToSign string) (bool, string) {
+	for _, header := range strings.Split(signedHeaders, ";") {
+		if header == strings.ToLower(headerToSign) {
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf("Vault header wasn't signed")
+}
+
+func parseGetCallerIdentityResponse(response string) (GetCallerIdentityResponse, error) {
+	decoder := xml.NewDecoder(strings.NewReader(response))
+	result := GetCallerIdentityResponse{}
+	err := decoder.Decode(&result)
+	return result, err
+}
+
+func submitCallerIdentityRequest(method, endpoint string, parsedUrl *url.URL, body string, headers map[string]string) (string, error) {
+	// TODO: Some validation to ensure we're calling STS, instead of acting as an unintended network proxy
+	request := buildHttpRequest(method, endpoint, parsedUrl, body, headers)
+	client := &http.Client{}
+	response, err := client.Do(request)
+	defer response.Body.Close()
+	if err != nil {
+		return "", fmt.Errorf("Error making request: %s", err)
+	}
+	// we check for status code afterwards to also print out response body
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if response.StatusCode != 200 {
+		return "", fmt.Errorf("Received error code %s from STS: %s", response.StatusCode, string(responseBody))
+	}
+	callerIdentityResponse, err := parseGetCallerIdentityResponse(string(responseBody))
+	if err != nil {
+		return "", fmt.Errorf("Error parsing STS response")
+	}
+	clientArn := callerIdentityResponse.GetCallerIdentityResult[0].Arn
+	if clientArn == "" {
+		return "", fmt.Errorf("No ARN validated")
+	}
+	return clientArn, nil
+}
+
+type GetCallerIdentityResponse struct {
+	XMLName                 xml.Name                  `xml:"GetCallerIdentityResponse"`
+	GetCallerIdentityResult []GetCallerIdentityResult `xml:"GetCallerIdentityResult"`
+	ResponseMetadata        []ResponseMetadata        `xml:"ResponseMetadata"`
+}
+
+type GetCallerIdentityResult struct {
+	Arn     string `xml:"Arn"`
+	UserId  string `xml:"UserId"`
+	Account string `xml:"Account"`
+}
+
+type ResponseMetadata struct {
+	RequestId string `xml:"RequestId"`
+}
+
+const pathLoginSyn = `
+Authenticates an AWS IAM principal with Vault.
+`
+
+const pathLoginDesc = `
+An AWS IAM principal is authenticated using the AWS STS GetCallerIdentity API method.
+
+`
+
+const magicVaultHeader = "X-Vault-Server"

--- a/builtin/credential/aws-iam/path_login_test.go
+++ b/builtin/credential/aws-iam/path_login_test.go
@@ -32,17 +32,17 @@ func TestBackend_pathLogin_getCallerIdentityResponse(t *testing.T) {
 
 	parsedUserResponse, err := parseGetCallerIdentityResponse(responseFromUser)
 	if parsed_arn := parsedUserResponse.GetCallerIdentityResult[0].Arn; parsed_arn != expectedUserArn {
-		t.Errorf("Expected to parse arn %#v, got %#v", expectedUserArn, parsed_arn)
+		t.Errorf("expected to parse arn %#v, got %#v", expectedUserArn, parsed_arn)
 	}
 
 	parsedRoleResponse, err := parseGetCallerIdentityResponse(responseFromAssumedRole)
 	if parsed_arn := parsedRoleResponse.GetCallerIdentityResult[0].Arn; parsed_arn != expectedRoleArn {
-		t.Errorf("Expected to parn arn %#v; got %#v", expectedRoleArn, parsed_arn)
+		t.Errorf("expected to parn arn %#v; got %#v", expectedRoleArn, parsed_arn)
 	}
 
 	_, err = parseGetCallerIdentityResponse("SomeRandomGibberish")
 	if err == nil {
-		t.Errorf("Expected to NOT parse random giberish, but didn't get an error")
+		t.Errorf("expected to NOT parse random giberish, but didn't get an error")
 	}
 }
 
@@ -56,10 +56,10 @@ func TestBackend_pathLogin_parseIamArn(t *testing.T) {
 		t.Fatal(err)
 	}
 	if xformedUser != userArn {
-		t.Fatalf("Expected to transform ARN %#v into %#v but got %#v instead", userArn, userArn, xformedUser)
+		t.Fatalf("expected to transform ARN %#v into %#v but got %#v instead", userArn, userArn, xformedUser)
 	}
 	if sessionName != "MyUserName" {
-		t.Fatalf("Expected to extract MyUserName from ARN %#v but got %#v instead", userArn, sessionName)
+		t.Fatalf("expected to extract MyUserName from ARN %#v but got %#v instead", userArn, sessionName)
 	}
 
 	xformedRole, sessionName, err := parseIamArn(assumedRoleArn)
@@ -67,10 +67,10 @@ func TestBackend_pathLogin_parseIamArn(t *testing.T) {
 		t.Fatal(err)
 	}
 	if xformedRole != baseRoleArn {
-		t.Fatalf("Expected to transform ARN %#v into %#v but got %#v instead", assumedRoleArn, baseRoleArn, xformedRole)
+		t.Fatalf("expected to transform ARN %#v into %#v but got %#v instead", assumedRoleArn, baseRoleArn, xformedRole)
 	}
 	if sessionName != "RoleName" {
-		t.Fatalf("Expected to extract principal name of RoleName from ARN %#v but got %#v instead", assumedRoleArn, sessionName)
+		t.Fatalf("expected to extract principal name of RoleName from ARN %#v but got %#v instead", assumedRoleArn, sessionName)
 	}
 }
 
@@ -78,16 +78,16 @@ func TestBackend_ensureVaultHeaderValue(t *testing.T) {
 	const canaryHeaderValue = "Vault-Server"
 	requestUrl, err := url.Parse("https://sts.amazonaws.com/")
 	if err != nil {
-		t.Fatalf("Error parsing test URL: %s", err)
+		t.Fatalf("error parsing test URL: %s", err)
 	}
 	postHeadersMissing := map[string]string{
 		"Host":          "Foo",
-		"Authorization": "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-vault-server, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7",
+		"Authorization": "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-vault-awsiam-server-id, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7",
 	}
 	postHeadersInvalid := map[string]string{
 		"Host":           "Foo",
 		magicVaultHeader: "InvalidValue",
-		"Authorization":  "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-vault-server, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7",
+		"Authorization":  "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-vault-awsiam-server-id, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7",
 	}
 	postHeadersUnsigned := map[string]string{
 		"Host":           "Foo",
@@ -97,26 +97,26 @@ func TestBackend_ensureVaultHeaderValue(t *testing.T) {
 	postHeadersValid := map[string]string{
 		"Host":           "Foo",
 		magicVaultHeader: canaryHeaderValue,
-		"Authorization":  "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-vault-server, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7",
+		"Authorization":  "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-vault-awsiam-server-id, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7",
 	}
 
 	found, errMsg := ensureVaultHeaderValue(postHeadersMissing, requestUrl, canaryHeaderValue)
 	if found {
-		t.Error("Validated POST request with missing Vault header")
+		t.Error("validated POST request with missing Vault header")
 	}
 
 	found, errMsg = ensureVaultHeaderValue(postHeadersInvalid, requestUrl, canaryHeaderValue)
 	if found {
-		t.Error("Validated POST request with invalid Vault header value")
+		t.Error("validated POST request with invalid Vault header value")
 	}
 
 	found, errMsg = ensureVaultHeaderValue(postHeadersUnsigned, requestUrl, canaryHeaderValue)
 	if found {
-		t.Error("Validated POST request with unsigned Vault header")
+		t.Error("validated POST request with unsigned Vault header")
 	}
 
 	found, errMsg = ensureVaultHeaderValue(postHeadersValid, requestUrl, canaryHeaderValue)
 	if !found {
-		t.Errorf("Did NOT validate valid POST request: %s", errMsg)
+		t.Errorf("did NOT validate valid POST request: %s", errMsg)
 	}
 }

--- a/builtin/credential/aws-iam/path_role.go
+++ b/builtin/credential/aws-iam/path_role.go
@@ -1,0 +1,260 @@
+package awsiam
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fatih/structs"
+	"github.com/hashicorp/vault/helper/policyutil"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathRole(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "role/" + framework.GenericNameRegex("role"),
+		Fields: map[string]*framework.FieldSchema{
+			"role": {
+				Type:        framework.TypeString,
+				Description: "Name of the role.",
+			},
+			"bound_iam_principal": {
+				Type:        framework.TypeString,
+				Description: "ARN of the IAM principal to bind to this role.",
+			},
+			"ttl": {
+				Type:    framework.TypeDurationSecond,
+				Default: 0,
+				Description: `Duration in seconds after which the issued token should expire. Defaults
+to 0, in whcih case the value will fall back to the system/mount defaults.`,
+			},
+			"max_ttl": {
+				Type:        framework.TypeDurationSecond,
+				Default:     0,
+				Description: "The maximum allowed lifetime of tokens issued using this role",
+			},
+			"policies": {
+				Type:        framework.TypeString,
+				Default:     "default",
+				Description: "Policies to be set on tokens issued using this role.",
+			},
+		},
+
+		ExistenceCheck: b.pathRoleExistenceCheck,
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.CreateOperation: b.pathRoleCreateUpdate,
+			logical.UpdateOperation: b.pathRoleCreateUpdate,
+			logical.ReadOperation:   b.pathRoleRead,
+			logical.DeleteOperation: b.pathRoleDelete,
+		},
+
+		HelpSynopsis:    pathRoleSyn,
+		HelpDescription: pathRoleDesc,
+	}
+}
+
+func pathListRole(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "roles?/?",
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ListOperation: b.pathRoleList,
+		},
+
+		HelpSynopsis:    pathListRolesHelpSyn,
+		HelpDescription: pathListRolesHelpDesc,
+	}
+}
+
+type awsRoleEntry struct {
+	TTL               time.Duration `json:"ttl" structs:"ttl" mapstructure:"ttl"`
+	MaxTTL            time.Duration `json:"max_ttl" structs:"max_ttl" mapstructure:"max_ttl"`
+	BoundIamPrincipal string        `json:"bound_iam_principal" structs:"bound_iam_principal" mapstructure:"bound_iam_principal"`
+	Policies          []string      `json:"policies" structs:"policies" mapstructure:"policies"`
+}
+
+func (b *backend) lockedAWSRole(s logical.Storage, role string) (*awsRoleEntry, error) {
+	b.roleMutex.RLock()
+	defer b.roleMutex.RUnlock()
+
+	return b.nonLockedAWSRole(s, role)
+}
+
+func (b *backend) nonLockedAWSRole(s logical.Storage, role string) (*awsRoleEntry, error) {
+	entry, err := s.Get("role/" + strings.ToLower(role))
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	var result awsRoleEntry
+	if err := entry.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (b *backend) pathRoleExistenceCheck(req *logical.Request, data *framework.FieldData) (bool, error) {
+	entry, err := b.lockedAWSRole(req.Storage, strings.ToLower(data.Get("role").(string)))
+	if err != nil {
+		return false, err
+	}
+	return entry != nil, nil
+}
+
+func (b *backend) pathRoleCreateUpdate(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+
+	roleName := strings.ToLower(data.Get("role").(string))
+	if roleName == "" {
+		return logical.ErrorResponse("missing role"), nil
+	}
+
+	b.roleMutex.Lock()
+	defer b.roleMutex.Unlock()
+
+	roleEntry, err := b.nonLockedAWSRole(req.Storage, roleName)
+	if err != nil {
+		return nil, err
+	}
+	if roleEntry == nil {
+		roleEntry = &awsRoleEntry{}
+	}
+
+	if boundIamPrincipal, ok := data.GetOk("bound_iam_principal"); ok {
+		roleEntry.BoundIamPrincipal = boundIamPrincipal.(string)
+	}
+
+	// We do this here to permit updating an existing role
+	if roleEntry.BoundIamPrincipal == "" {
+		return logical.ErrorResponse("Must bind to an IAM Principal"), nil
+	}
+
+	policiesStr, ok := data.GetOk("policies")
+	if ok {
+		roleEntry.Policies = policyutil.ParsePolicies(policiesStr.(string))
+	} else if req.Operation == logical.CreateOperation {
+		roleEntry.Policies = []string{"default"}
+	}
+
+	var resp logical.Response
+
+	ttlRaw, ok := data.GetOk("ttl")
+	if ok {
+		ttl := time.Duration(ttlRaw.(int)) * time.Second
+		defaultLeaseTTL := b.System().DefaultLeaseTTL()
+		if ttl > defaultLeaseTTL {
+			resp.AddWarning(fmt.Sprintf("Given ttl of %d seconds greater than current mount/system default of %d seconds; ttl will be capped at login time", ttl/time.Second, defaultLeaseTTL/time.Second))
+		}
+		roleEntry.TTL = ttl
+	} else if req.Operation == logical.CreateOperation {
+		roleEntry.TTL = time.Duration(data.Get("ttl").(int)) * time.Second
+	}
+
+	maxTTLInt, ok := data.GetOk("max_ttl")
+	if ok {
+		maxTTL := time.Duration(maxTTLInt.(int)) * time.Second
+		systemMaxTTL := b.System().MaxLeaseTTL()
+		if maxTTL > systemMaxTTL {
+			resp.AddWarning(fmt.Sprintf("Given max_ttl of %d seconds greater than current mount/system default of %d seconds; max_ttl will be capped at login time", maxTTL/time.Second, systemMaxTTL/time.Second))
+		}
+
+		if maxTTL < time.Duration(0) {
+			return logical.ErrorResponse("max_ttl cannot be negative"), nil
+		}
+
+		roleEntry.MaxTTL = maxTTL
+	} else if req.Operation == logical.CreateOperation {
+		roleEntry.MaxTTL = time.Duration(data.Get("max_ttl").(int)) * time.Second
+	}
+
+	entry, err := logical.StorageEntryJSON("role/"+roleName, roleEntry)
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Storage.Put(entry); err != nil {
+		return nil, err
+	}
+
+	if len(resp.Warnings()) == 0 {
+		return nil, nil
+	}
+
+	return &resp, nil
+}
+
+func (b *backend) pathRoleRead(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+
+	roleEntry, err := b.lockedAWSRole(req.Storage, strings.ToLower(data.Get("role").(string)))
+	if err != nil {
+		return nil, err
+	}
+
+	if roleEntry == nil {
+		return nil, nil
+	}
+
+	respData := structs.New(roleEntry).Map()
+	respData["ttl"] = roleEntry.TTL / time.Second
+	respData["max_ttl"] = roleEntry.MaxTTL / time.Second
+
+	return &logical.Response{
+		Data: respData,
+	}, nil
+}
+
+func (b *backend) pathRoleDelete(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+
+	roleName := data.Get("role").(string)
+	if roleName == "" {
+		return logical.ErrorResponse("missing role"), nil
+	}
+
+	b.roleMutex.Lock()
+	defer b.roleMutex.Unlock()
+
+	return nil, req.Storage.Delete("role/" + strings.ToLower(roleName))
+}
+
+func (b *backend) pathRoleList(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+
+	b.roleMutex.RLock()
+	defer b.roleMutex.RUnlock()
+
+	roles, err := req.Storage.List("role/")
+	if err != nil {
+		return nil, err
+	}
+	return logical.ListResponse(roles), nil
+}
+
+const pathRoleSyn = `
+Create a role and associate policies to it.
+`
+
+const pathRoleDesc = `
+The login endpoint takes in the role name which the client
+would like to access. After the client is authenticated, the
+authorization for the client is determined by the policies that
+are associated for the role.
+
+Also, a 'max_ttl' can be configured in this endpoint that determines
+the maximum duration for which a login can be renewed. Note that the
+'max_ttl' has an upper limit of the 'max_ttl' value on the backend's
+mount.
+`
+
+const pathListRolesHelpSyn = `
+List all roles that are registered with Vault.
+`
+
+const pathListRolesHelpDesc = `
+Roles will be listed by their respective role names.
+`

--- a/builtin/credential/aws-iam/path_role.go
+++ b/builtin/credential/aws-iam/path_role.go
@@ -36,7 +36,6 @@ to 0, in whcih case the value will fall back to the system/mount defaults.`,
 			},
 			"policies": {
 				Type:        framework.TypeString,
-				Default:     "default",
 				Description: "Policies to be set on tokens issued using this role.",
 			},
 		},
@@ -83,6 +82,10 @@ func (b *backend) lockedAWSRole(s logical.Storage, role string) (*awsRoleEntry, 
 }
 
 func (b *backend) nonLockedAWSRole(s logical.Storage, role string) (*awsRoleEntry, error) {
+	if role == "" {
+		return nil, fmt.Errorf("missing role name")
+	}
+
 	entry, err := s.Get("role/" + strings.ToLower(role))
 	if err != nil {
 		return nil, err
@@ -131,7 +134,7 @@ func (b *backend) pathRoleCreateUpdate(
 
 	// We do this here to permit updating an existing role
 	if roleEntry.BoundIamPrincipal == "" {
-		return logical.ErrorResponse("Must bind to an IAM Principal"), nil
+		return logical.ErrorResponse("must bind to an IAM Principal"), nil
 	}
 
 	policiesStr, ok := data.GetOk("policies")

--- a/builtin/credential/aws-iam/path_role_test.go
+++ b/builtin/credential/aws-iam/path_role_test.go
@@ -1,0 +1,123 @@
+package awsiam
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/helper/policyutil"
+	"github.com/hashicorp/vault/logical"
+)
+
+func TestBackend_pathRole(t *testing.T) {
+	config := logical.TestBackendConfig()
+	storage := &logical.InmemStorage{}
+	config.StorageView = storage
+
+	b := Backend()
+	_, err := b.Setup(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure we start with empty roles, which gives us confidence that the read later
+	// actually is the two roles we created
+	resp, err := b.HandleRequest(&logical.Request{
+		Operation: logical.ListOperation,
+		Path:      "roles",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.Data == nil || resp.IsError() {
+		t.Fatalf("failed to list role entries")
+	}
+	if resp.Data["keys"] != nil {
+		t.Fatalf("Received roles when expected none")
+	}
+
+	data := map[string]interface{}{
+		"policies":            "p,q,r,s",
+		"max_ttl":             "2h",
+		"bound_iam_principal": "n:aws:iam::123456789012:user/MyUserName",
+	}
+	resp, err = b.HandleRequest(&logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "role/MyRoleName",
+		Data:      data,
+		Storage:   storage,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && resp.IsError() {
+		t.Fatal("failed to create the role entry")
+	}
+
+	resp, err = b.HandleRequest(&logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "role/MyRoleName",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.IsError() {
+		t.Fatal("failed to read the role entry")
+	}
+	if !policyutil.EquivalentPolicies(strings.Split(data["policies"].(string), ","), resp.Data["policies"].([]string)) {
+		t.Fatalf("bad: policies: expected %#v\ngot: %#v\n", data, resp.Data)
+	}
+
+	// generate a second role, ensure we're able to list both
+	resp, err = b.HandleRequest(&logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "role/MyOtherRoleName",
+		Data:      data,
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to create additional role")
+	}
+
+	resp, err = b.HandleRequest(&logical.Request{
+		Operation: logical.ListOperation,
+		Path:      "roles",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.Data == nil || resp.IsError() {
+		t.Fatalf("failed to list role entries")
+	}
+	keys := resp.Data["keys"].([]string)
+	if len(keys) != 2 {
+		t.Fatalf("bad: keys %#v\n", keys)
+	}
+
+	resp, err = b.HandleRequest(&logical.Request{
+		Operation: logical.DeleteOperation,
+		Path:      "role/MyOtherRoleName",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err = b.HandleRequest(&logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "role/MyOtherRoleName",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Fatalf("bad: response: expected: nil actual:%3v\n", resp)
+	}
+}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -10,6 +10,7 @@ import (
 	credAppId "github.com/hashicorp/vault/builtin/credential/app-id"
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
 	credAwsEc2 "github.com/hashicorp/vault/builtin/credential/aws-ec2"
+	credAwsIam "github.com/hashicorp/vault/builtin/credential/aws-iam"
 	credCert "github.com/hashicorp/vault/builtin/credential/cert"
 	credGitHub "github.com/hashicorp/vault/builtin/credential/github"
 	credLdap "github.com/hashicorp/vault/builtin/credential/ldap"
@@ -68,6 +69,7 @@ func Commands(metaPtr *meta.Meta) map[string]cli.CommandFactory {
 					"approle":  credAppRole.Factory,
 					"cert":     credCert.Factory,
 					"aws-ec2":  credAwsEc2.Factory,
+					"aws-iam":  credAwsIam.Factory,
 					"app-id":   credAppId.Factory,
 					"github":   credGitHub.Factory,
 					"userpass": credUserpass.Factory,
@@ -111,6 +113,7 @@ func Commands(metaPtr *meta.Meta) map[string]cli.CommandFactory {
 					"userpass": &credUserpass.CLIHandler{},
 					"ldap":     &credLdap.CLIHandler{},
 					"cert":     &credCert.CLIHandler{},
+					"aws-iam":  &credAwsIam.CLIHandler{},
 				},
 			}, nil
 		},

--- a/website/source/docs/auth/aws-iam.html.md
+++ b/website/source/docs/auth/aws-iam.html.md
@@ -1,0 +1,606 @@
+---
+layout: "docs"
+page_title: "Auth Backend: AWS-IAM"
+sidebar_current: "docs-auth-aws-iam"
+description: |-
+  The aws-iam backend allows automated authentication AWS IAM principals.
+---
+
+# Auth Backend: aws-iam
+
+The aws-iam auth backend provides a secure introduction mechanism for AWS IAM
+principals. This allows you to reduce the problem of securely introducing a
+Vault token to the problem of securely introducing AWS IAM credentials, which
+AWS has already solved in a number of use cases, such as via EC2 Instance
+Profiles and IAM roles attached to Lambda functions. It also allows you to have
+a consistent workflow between developers working on a local laptop with tools
+such as Hologram.
+
+## Comparison with AWS-EC2 Authentication Backend
+
+The AWS-IAM and AWS-EC2 authentication backends serve similar purposes. Both
+look to authenticate some type of AWS entity to Vault. However, in many ways,
+the similarity ends there. The following is a comparison of the two entities:
+
+* What type of entity is authenticated:
+  * The AWS-EC2 backend authenticates AWS EC2 instances only.
+  * The AWS-IAM backend authenticates AWS IAM principals. This can include
+    IAM users, IAM roles assumed from other accounts, AWS Lambdas that are
+    launched in an IAM role, or even EC2 instances that are launched in an
+    EC2 instance profile.
+* How the entities are authenticated
+  * The AWS-EC2 backend authenticates instances by making use of the EC2 instance
+    identity document, which is a cryptographically signed document containing
+    metadata about the instance. This document changes relatively infrequently,
+    so Vault adds a number of other constructs to mitigate against replay
+    attacks, such as client nonces, role tags, instance migrations, etc.
+  * The AWS-IAM backend authenticates by having clients provide a specially
+    signed AWS API request which the backend then passes on to AWS to validate
+    the signature and tell Vault who created it. The actual secret (i.e.,
+    the AWS secret access key) is never transmitted over the wire, and the
+    AWS signature algorithm automatically expires requests after 15 minutes,
+    providing simple and robust protection against replay attacks.
+* Specific use cases
+  * If you have a long-lived EC2 instance which you are unable to relaunch into
+    an IAM instance profile, then the AWS-EC2 backend is probably the best
+    solution for you. (While you could store long-lived AWS IAM user
+    credentials on disk and use those to authenticate to Vault, that would not
+    be recommended.)
+  * If you have non-EC2 instance entities, such as IAM users, Lambdas in IAM
+    roles, or developer laptops using [AdRoll's Hologram](https://github.com/AdRoll/hologram)
+    then you would need to use the AWS-IAM backend.
+  * If you have EC2 instances which are already in an IAM instance profile, then
+    you could use either backend.
+
+## Authentication Workflow
+
+AWS has introduced the [`sts:GetCallerIdentity`](http://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html)
+API method to allow you to validate the identity of a caller. The client signs
+a `GetCallerIdentity` query using the [AWS Signature v4
+algorithm](http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html) and
+submits that signed query to the Vault server. The Vault server then forwards
+it on to the AWS STS service and validates the result back. Clients don't even
+need network-level access to talk to the AWS STS API endpoint; they merely need
+to sign the credentials. However, it means that the Vault server DOES need
+network-level access to send requests to the STS endpoint.
+
+Each signed AWS request includes the current timestamp to mitigate the risk of
+replay attacks. In addition, Vault allows you to require an additional header,
+`X-Vault-Server`, to be present to mitigate against different types of replay
+attacks (such as a signed `GetCallerIdentity` request stolen from a dev Vault
+instance and used to authenticate to a prod Vault instance). Vault further
+requires that this header be one of the headers included in the AWS signature
+and relies upon AWS to authenticate that signature.
+
+While the AWS API endpoints support both signed GET and POST requests, for
+simplicity, the aws-iam backend supports only POST requests.
+
+## Authorization Workflow
+
+Roles are mapped from AWS IAM principals back to Vault roles. At present, two
+types of principals are supported: AWS IAM Users and AWS IAM roles. For users,
+you simply bind the full ARN of the user, e.g., `arn:aws:iam::123456789012:user/MyUserName`
+(where `123456789012` is your AWS account number nad `MyUserName` is your IAM
+username). Assumed roles are a little tricky: when authenticating with IAM roles,
+you are simultaneously _two_ different principals: `arn:aws:iam::123456789012:role/MyRoleName`
+*and* `arn:aws:sts::123456789012:assumed-role/MyRoleName/RoleSessionName`. In
+this case, you should bind the former ARN to your Vault roles.
+
+## Authentication
+
+### Via the CLI
+
+#### Enable AWS IAM authentication in Vault.
+
+```
+$ vault auth-enable aws-iam
+```
+
+#### Configure the policies on the role.
+
+```
+$ vault write auth/aws-iam/role/dev-role bound_iam_principal=arn:aws:iam::123456789012:role/my_role policies=prod,dev max_ttl=500h
+```
+
+#### Configure a required X-Vault-Server Header (recommended)
+
+```
+$ vault write auth/aws-iam/client/config vault_header_vaule=vault.example.xom
+```
+
+#### Perform the login operation
+
+Generating the signed request is a non-standard operation. The Vault cli supports generating this for you:
+
+```
+$ vault auth -method=aws-iam header_value=vault.example.com role=dev-role
+```
+
+This assumes you have AWS credentials configured in the standard locations AWS SDKs search for credentials
+(environment variables, ~/.aws/credentials, EC2 instance profile in that order). If you do not have
+IAM credentials available at any of these locations, you can explicitly pass them in on the command line
+(though this is not recommended):
+```
+$ vault auth -method aws-iam header_value=vault.example.com role=dev-role \
+        aws_access_key_id=<access_key> \
+        aws_secret_access_key=<secret_key> \
+        aws_security_token=<security_token>
+```
+
+For reference, the following Go program also demonstrates how to generate the
+required parameters (assuming you are using a default AWS credential provider):
+
+```
+package main
+
+import (
+        "encoding/base64"
+        "encoding/json"
+        "fmt"
+        "io/ioutil"
+
+        "github.com/aws/aws-sdk-go/aws/session"
+        "github.com/aws/aws-sdk-go/service/sts"
+)
+
+func transformHeaders(input map[string][]string) map[string]string {
+        retval := map[string]string{}
+        for k, v := range input {
+                retval[k] = v[0]
+        }
+        return retval
+}
+
+func main() {
+        sess, err := session.NewSession()
+        if err != nil {
+                fmt.Println("failed to create session,", err)
+                return
+        }
+
+        svc := sts.New(sess)
+        var params *sts.GetCallerIdentityInput
+        stsRequest, _ := svc.GetCallerIdentityRequest(params)
+        stsRequest.HTTPRequest.Header.Add("X-Vault-Server", "vault.example.com")
+        stsRequest.Sign()
+
+        headersJson, err := json.Marshal(transformHeaders(stsRequest.HTTPRequest.Header))
+        if err != nil {
+                fmt.Println(fmt.Errorf("Error:", err))
+                return
+        }
+        requestBody, err := ioutil.ReadAll(stsRequest.HTTPRequest.Body)
+        if err != nil {
+                fmt.Println(fmt.Errorf("Error:", err))
+                return
+        }
+        fmt.Println("method=" + stsRequest.HTTPRequest.Method)
+        fmt.Println("url=" + stsRequest.HTTPRequest.URL.String())
+        fmt.Println("headers=" + base64.StdEncoding.EncodeToString(headersJson))
+        fmt.Println("body=" + base64.StdEncoding.EncodeToString(requestBody))
+}
+```
+Using this, we can get the values to pass in to the `vault write` operation:
+
+```
+$ vault write auth/aws-iam/login role=dev method=POST url=https://sts.amazonaws.com/ headers=eyJBdXRob3JpemF0aW9uIjoiQVdTNC1ITUFDLVNIQTI1NiBDcmVkZW50aWFsPWZvby8yMDE2MDkzMC91cy1lYXN0LTEvc3RzL2F3czRfcmVxdWVzdCwgU2lnbmVkSGVhZGVycz1jb250ZW50LWxlbmd0aDtjb250ZW50LXR5cGU7aG9zdDt4LWFtei1kYXRlO3gtdmF1bHQtc2VydmVyLCBTaWduYXR1cmU9YTY5ZmQ3NTBhMzQ0NWM0ZTU1M2UxYjNlNzlkM2RhOTBlZWY1NDA0N2YxZWI0ZWZlOGZmYmM5YzQyOGMyNjU1YiIsIkNvbnRlbnQtTGVuZ3RoIjoiNDMiLCJDb250ZW50LVR5cGUiOiJhcHBsaWNhdGlvbi94LXd3dy1mb3JtLXVybGVuY29kZWQ7IGNoYXJzZXQ9dXRmLTgiLCJVc2VyLUFnZW50IjoiYXdzLXNkay1nby8xLjQuMTIgKGdvMS43LjE7IGxpbnV4OyBhbWQ2NCkiLCJYLUFtei1EYXRlIjoiMjAxNjA5MzBUMDQzMTIxWiIsIlgtVmF1bHQtU2VydmVyIjoidmF1bHQuZGV2Lmp0aG9tcHNvbi5pbyJ9 body=QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNQ==
+```
+
+### Via the API
+
+#### Enable AWS IAM authentication in Vault.
+
+```
+curl -X POST -H "x-vault-token:123" "http://127.0.0.1:8200/v1/sys/auth/aws-iam" -d '{"type":"aws-iam"}'
+```
+
+#### Configure the policies on the role.
+
+```
+curl -X POST -H "x-vault-token:123" "http://127.0.0.1:8200/v1/auth/aws-iam/role/dev-role -d '{"bound_iam_principal":"arn:aws:iam::123456789012:role/my_role","policies":"prod,dev","max_ttl":"500h"}'
+```
+
+#### Perform the login operation
+
+```
+curl -X POST "http://127.0.0.1:8200/v1/auth/aws-iam/login" -d '{"role":"dev", "method": "POST", "url": "https://sts.amazonaws.com/", "body": "QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNQ==", "headers": "eyJBdXRob3JpemF0aW9uIjoiQVdTNC1ITUFDLVNIQTI1NiBDcmVkZW50aWFsPWZvby8yMDE2MDkzMC91cy1lYXN0LTEvc3RzL2F3czRfcmVxdWVzdCwgU2lnbmVkSGVhZGVycz1jb250ZW50LWxlbmd0aDtjb250ZW50LXR5cGU7aG9zdDt4LWFtei1kYXRlO3gtdmF1bHQtc2VydmVyLCBTaWduYXR1cmU9YTY5ZmQ3NTBhMzQ0NWM0ZTU1M2UxYjNlNzlkM2RhOTBlZWY1NDA0N2YxZWI0ZWZlOGZmYmM5YzQyOGMyNjU1YiIsIkNvbnRlbnQtTGVuZ3RoIjoiNDMiLCJDb250ZW50LVR5cGUiOiJhcHBsaWNhdGlvbi94LXd3dy1mb3JtLXVybGVuY29kZWQ7IGNoYXJzZXQ9dXRmLTgiLCJVc2VyLUFnZW50IjoiYXdzLXNkay1nby8xLjQuMTIgKGdvMS43LjE7IGxpbnV4OyBhbWQ2NCkiLCJYLUFtei1EYXRlIjoiMjAxNjA5MzBUMDQzMTIxWiIsIlgtVmF1bHQtU2VydmVyIjoidmF1bHQuZGV2Lmp0aG9tcHNvbi5pbyJ9" }'
+```
+
+
+The response will be in JSON. For example:
+
+```javascript
+{
+    "auth": {
+        "accessor": "52033390-a416-9aaf-e8d9-68b45947ce59",
+        "client_token": "8b1d634a-6d02-7452-e2b9-9cec9e12cbf7",
+        "lease_duration": 2592000,
+        "metadata": {
+            "canonical_arn": "arn:aws:iam::123456789012:role/MyRole",
+            "client_arn": "arn:aws:sts::123456789012:assumed-role/MyRole/RoleSessionName"
+        },
+        "policies": [
+            "default"
+        ],
+        "renewable": true
+    },
+    "data": null,
+    "lease_duration": 0,
+    "lease_id": "",
+    "renewable": false,
+    "request_id": "84915669-8386-5c99-2d7b-131cac038d52",
+    "warnings": null,
+    "wrap_info": null
+}
+```
+
+## API
+### /auth/aws-iam/config/client
+#### POST
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Configures the behavior of Vault's STS client. 
+  </dd>
+
+  <dt>Method</dt>
+  <dd>POST</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-iam/config/client`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">endpoint</span>
+        <span class="param-flags">optional</span>
+        URL to override the default generated endpoint for making AWS STS API calls.
+        This is useful if you want to use STS in a [region other than
+us-east-1](http://docs.aws.amazon.com/general/latest/gr/rande.html#sts_region).
+      </li>
+      <li>
+        <span class="param">vault_header_value</span>
+        <span class="param-flags">optional</span>
+        Value to require be present in the X-Vault-Server header. If not set, then
+        no value is required or validated. If set, clients must include an X-VaultServer
+        header in the headers of login requests, and further the X-VaultServer must be
+        among the signed headers validated by AWS. This is to protect against different types
+        of replay attacks, for example a signed request sent to a dev server being
+        resent to a production server. Consider setting this to the Vault server's DNS name.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+#### GET
+<dl class="api">
+  <dt>Description</dt>
+    Returns the previously configured AWS STS client.
+  <dd>
+
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-iam/config/client`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+```
+{
+  "auth": null,
+  "warnings": null,
+  "data": {
+    "endpoint": "",
+    "vault_header_value": "vault.example.com"
+  },
+  "lease_duration": 0,
+  "renewable": false,
+  "lease_id": ""
+}
+```
+
+  </dd>
+</dl>
+
+
+#### DELETE
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Deletes the previously configured AWS STS client configuration.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>DELETE</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-iam/config/client`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+
+
+### /auth/aws-iam/role/[role]
+#### POST
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Registers a role in the backend. Only those IAM principals which have been
+mapped to a role will be able to perform the login operation.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>POST</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-iam/role/<role>`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">role</span>
+        <span class="param-flags">required</span>
+        Name of the role.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">bound_iam_principal</span>
+        <span class="param-flags">required</span>
+        Defines the ARN of the IAM principal to map to the role.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">ttl</span>
+        <span class="param-flags">optional</span>
+        The TTL period of tokens issued using this role, provided as "1h", where hour is
+        the largest suffix.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">max_ttl</span>
+        <span class="param-flags">optional</span>
+        The maximum allowed lifetime of tokens issued using this role.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">policies</span>
+        <span class="param-flags">optional</span>
+        Policies to be set on tokens issued using this role.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+
+#### GET
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Returns the previously registered role configuration.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-iam/role/<role>`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+```javascript
+{
+  "auth": null,
+  "warnings": null,
+  "data": {
+    "bound_iam_principal": "arn:aws:iam::123456789012:role/my_role"
+    "policies": [
+      "default",
+      "dev",
+      "prod"
+    ],
+    "max_ttl": 1800000
+  },
+  "lease_duration": 0,
+  "renewable": false,
+  "lease_id": ""
+}
+```
+
+  </dd>
+</dl>
+
+
+#### LIST
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Lists all the roles that are registered with the backend.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-iam/roles?list=true`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+```javascript
+{
+  "auth": null,
+  "warnings": null,
+  "data": {
+    "keys": [
+      "dev-role",
+      "prod-role"
+    ]
+  },
+  "lease_duration": 0,
+  "renewable": false,
+  "lease_id": ""
+}
+```
+
+  </dd>
+</dl>
+
+
+#### DELETE
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Deletes the previously registered role.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>DELETE</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-iam/role/<role>`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+
+
+### /auth/aws-iam/login
+#### POST
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+   Fetch a token. This endpoint verifies the query signature with AWS and
+ensure the query was signed by a valid IAM principal. Note that the HTTP request
+mentioned in the parameter descriptions below refers to the signed GetCallerIdentity
+STS request that is embedded in the request to the Vault server, NOT the request to
+the Vault server itself.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>POST</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-iam/login`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">role</span>
+        <span class="param-flags">optional</span>
+        Name of the Vault role against which the login is being attempted.
+        If `role` is not specified, then the login endpoint looks for a role
+        bearing the name of the AMI ID of the EC2 instance that is trying to login.
+        If a matching role is not found, login fails.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">method</span>
+        <span class="param-flags">required</span>
+        HTTP method used in the signed request. Currently only POST is supported, but
+        other methods may be supported in the future.
+      </li>
+      <li>
+        <span class="param">url</span>
+        <span class="param-flags">required</span>
+        HTTP URL used in the signed request. Most likely just https://sts.amazonaws.com/
+        as most requests will probably use POST with an empty URI.
+      </li>
+      <li>
+        <span class="param">body</span>
+        <span class="param-flags">required</span>
+        Base64-encoded body of the signed request. Most likely
+        <em>QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNQ==</em>
+        which is the base64 encoding of <em>Action=GetCallerIdentity&Version=2011-06-15</em>
+      </li>
+      <li>
+        <span class="param">headers</span>
+        <span class="param-flags">required</span>
+        Base64-encoded, JSON-serialized representation of the HTTP request headers. The JSON
+        serialization assumes that each header key only has a single string value. While the
+        HTTP spec allows for a given header to have multiple values, that is extremely unlikely
+        to occur with any request sent to STS.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+```javascript
+{
+    "auth": {
+        "accessor": "52033390-a416-9aaf-e8d9-68b45947ce59",
+        "client_token": "8b1d634a-6d02-7452-e2b9-9cec9e12cbf7",
+        "lease_duration": 2592000,
+        "metadata": {
+            "canonical_arn": "arn:aws:iam::854766835649:user/joelt49",
+            "client_arn": "arn:aws:iam::854766835649:user/joelt49"
+        },
+        "policies": [
+            "default"
+        ],
+        "renewable": true
+    },
+    "data": null,
+    "lease_duration": 0,
+    "lease_id": "",
+    "renewable": false,
+    "request_id": "84915669-8386-5c99-2d7b-131cac038d52",
+    "warnings": null,
+    "wrap_info": null
+}
+```
+
+  </dd>
+</dl>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -184,7 +184,7 @@
 
 						<li<%= sidebar_current("docs-auth-aws-iam") %>>
 							<a href="/docs/auth/aws-iam.html">AWS IAM</a>
-            </li>
+						</li>
 
 						<li<%= sidebar_current("docs-auth-github") %>>
 							<a href="/docs/auth/github.html">GitHub</a>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -182,6 +182,10 @@
 							<a href="/docs/auth/aws-ec2.html">AWS EC2</a>
 						</li>
 
+						<li<%= sidebar_current("docs-auth-aws-iam") %>>
+							<a href="/docs/auth/aws-iam.html">AWS IAM</a>
+            </li>
+
 						<li<%= sidebar_current("docs-auth-github") %>>
 							<a href="/docs/auth/github.html">GitHub</a>
 						</li>


### PR DESCRIPTION
The aws-iam authentication backend is able to validate arbitrary
AWS IAM principals against AWS. It does this by receiving a signed AWS
STS GetCallerIdentity request and forwarding that on to AWS. AWS will
validate the request and return the principal, which allows Vault to
then map the caller to a set of policies.

Many thanks to @copumpkin for his feedback in reviewing this thus far!
