### PR TITLE
doc: change data type from boolean to string

### DIFF
--- a/website/source/docs/audit/file.html.md
+++ b/website/source/docs/audit/file.html.md
@@ -61,13 +61,13 @@ Following are the configuration options available for the backend.
       <li>
         <span class="param">log_raw</span>
         <span class="param-flags">optional</span>
-            A boolean, if set, logs the security sensitive information without
+            A string containing a boolean value ('true'/'false'), if set, logs the security sensitive information without
             hashing, in the raw format. Defaults to `false`.
       </li>
       <li>
         <span class="param">hmac_accessor</span>
         <span class="param-flags">optional</span>
-            A boolean, if set, enables the hashing of token accessor. Defaults
+            A string containing a boolean value ('true'/'false'), if set, enables the hashing of token accessor. Defaults
             to `true`. This option is useful only when `log_raw` is `false`.
       </li>
 	  <li>


### PR DESCRIPTION
the api doesn't accept the boolean value. it needs a string containing a boolean value.

p.s. if this is changing in 0.6.3 source code, please ignore this PR.