### PR TITLE
Fix sidebar typo

### DIFF
--- a/website/source/layouts/intro.erb
+++ b/website/source/layouts/intro.erb
@@ -82,7 +82,7 @@
 							<a href="/intro/getting-started/deploy.html">Deploy Vault</a>
 						</li>
 
-						<li<%= sidebar_current("getting-started-apis") %>>
+						<li<%= sidebar_current("gettingstarted-apis") %>>
 							<a href="/intro/getting-started/apis.html">HTTP API</a>
 						</li>
 


### PR DESCRIPTION
Fix typo in sidebar layout that prevented sidebar item 'getting started apis' from correctly rendering when 'getting started apis' page was active.