### PR TITLE
use S3's native encryption because why not

### DIFF
--- a/physical/s3.go
+++ b/physical/s3.go
@@ -98,9 +98,10 @@ func (s *S3Backend) Put(entry *Entry) error {
 	defer metrics.MeasureSince([]string{"s3", "put"}, time.Now())
 
 	_, err := s.client.PutObject(&s3.PutObjectInput{
-		Bucket: aws.String(s.bucket),
-		Key:    aws.String(entry.Key),
-		Body:   bytes.NewReader(entry.Value),
+		Bucket:               aws.String(s.bucket),
+		Key:                  aws.String(entry.Key),
+		Body:                 bytes.NewReader(entry.Value),
+		ServerSideEncryption: aws.String("AES256"),
 	})
 
 	if err != nil {


### PR DESCRIPTION
It seems silly not to enable S3's AES256 encryption, which is entirely transparent to the user and satisfies all sorts of "Is your data encrypted at rest?"-type questions.
