### PR TITLE
aws-ec2 auth: Remove the sanity check which is not proving to be useful

### DIFF
--- a/builtin/credential/aws-ec2/path_role.go
+++ b/builtin/credential/aws-ec2/path_role.go
@@ -207,11 +207,6 @@ func (b *backend) nonLockedAWSRole(s logical.Storage, roleName string) (*awsRole
 
 	// Check if the value held by role ARN field is actually an instance profile ARN
 	if result.BoundIamRoleARN != "" && strings.Contains(result.BoundIamRoleARN, ":instance-profile/") {
-		// For sanity
-		if result.BoundIamInstanceProfileARN != "" {
-			return nil, fmt.Errorf("bound_iam_role_arn contains instance profile ARN and bound_iam_instance_profile_arn is non empty")
-		}
-
 		// If yes, move it to the correct field
 		result.BoundIamInstanceProfileARN = result.BoundIamRoleARN
 


### PR DESCRIPTION
Fixes the problem mentioned in the original post here: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/vault-tool/Q-m20j8WF3w/TgR76hn5BwAJ