### PR TITLE
Update Website PGP Docs 

### DIFF
--- a/website/source/docs/concepts/pgp-gpg-keybase.html.md
+++ b/website/source/docs/concepts/pgp-gpg-keybase.html.md
@@ -155,7 +155,7 @@ plain-text unseal key, you must decrypt the value given to you by the
 initializer. To get the plain-text value, run the following command:
 
 ```
-$ echo "wcBMA37..." | base64 -d | keybase pgp decrypt
+$ echo "wcBMA37..." | base64 -d | gpg -dq 
 ```
 
 And replace `wcBMA37...` with the encrypted key. 


### PR DESCRIPTION
This addresses #2046 .

The GPG based section of the website documentation uses the keybase binary in the shell example to decrypt a PGP encrypted seal key. The section is intended to utilize the `gpg` binary making this example inconsistent. 

This update replaces the binary with gpg utilizing the `d` decrypt flag as well as the `q` flag to prevent gpg from printing related key information. 