### PR TITLE
Specify the value of "generated secrets"

### DIFF
--- a/website/source/docs/auth/token.html.md
+++ b/website/source/docs/auth/token.html.md
@@ -580,8 +580,8 @@ of the header should be "X-Vault-Token" and the value should be the token.
   <dt>Description</dt>
   <dd>
     Revokes the token used to call it and all child tokens.
-    When the token is revoked, all secrets generated with
-    it are also revoked.
+    When the token is revoked, all dynamic secrets generated
+    with it are also revoked.
   </dd>
 
   <dt>Method</dt>


### PR DESCRIPTION
This small change is to specify (mostly for new users) that only dynamic secrets are revoked when running revoke-self.