### PR TITLE
audit: add cee log formatter

### DIFF
--- a/audit/format_cee.go
+++ b/audit/format_cee.go
@@ -1,0 +1,38 @@
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// CEEFormatWriter is an AuditFormatWriter implementation that structures data into
+// a JSON format.
+type CEEFormatWriter struct{}
+
+const ceePrefix = "@cee:"
+
+func (f *CEEFormatWriter) WriteRequest(w io.Writer, req *AuditRequestEntry) error {
+	if req == nil {
+		return fmt.Errorf("request entry was nil, cannot encode")
+	}
+	_, err := w.Write([]byte(ceePrefix))
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(w)
+	return enc.Encode(req)
+}
+
+func (f *CEEFormatWriter) WriteResponse(w io.Writer, resp *AuditResponseEntry) error {
+	if resp == nil {
+		return fmt.Errorf("response entry was nil, cannot encode")
+	}
+	_, err := w.Write([]byte(ceePrefix))
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(w)
+	return enc.Encode(resp)
+}

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -29,7 +29,7 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 		format = "json"
 	}
 	switch format {
-	case "json", "jsonx":
+	case "cee", "json", "jsonx":
 	default:
 		return nil, fmt.Errorf("unknown format type %s", format)
 	}
@@ -75,6 +75,8 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 	}
 
 	switch format {
+	case "cee":
+		b.formatter.AuditFormatWriter = &audit.CEEFormatWriter{}
 	case "json":
 		b.formatter.AuditFormatWriter = &audit.JSONFormatWriter{}
 	case "jsonx":

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -32,7 +32,7 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 		format = "json"
 	}
 	switch format {
-	case "json", "jsonx":
+	case "cee", "json", "jsonx":
 	default:
 		return nil, fmt.Errorf("unknown format type %s", format)
 	}
@@ -73,6 +73,8 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 	}
 
 	switch format {
+	case "cee":
+		b.formatter.AuditFormatWriter = &audit.CEEFormatWriter{}
 	case "json":
 		b.formatter.AuditFormatWriter = &audit.JSONFormatWriter{}
 	case "jsonx":


### PR DESCRIPTION
The audit logs were not parsed correctly due to a lack of the `@cee:` prefix. 

This could be fixed by adding parsing rules on the log infrastructure side, but some other customers may run into the same issue.

http://cee.mitre.org/language/1.0-beta1/clt.html