### PR TITLE
Clarify that Swift only supports v1.0 auth

### DIFF
--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -619,7 +619,7 @@ The current implementation is limited to a maximum of 4 MBytes per blob/file.
 
 #### Backend Reference: Swift (Community-Supported)
 
-For Swift, the following options are supported:
+For Swift, the following options are supported for v1.0 auth endpoints:
 
   * `container` (required) - The name of the Swift container to use. It must be provided, but it can also be sourced from the `OS_CONTAINER` environment variable.
 

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -619,7 +619,7 @@ The current implementation is limited to a maximum of 4 MBytes per blob/file.
 
 #### Backend Reference: Swift (Community-Supported)
 
-For Swift, the following options are supported for v1.0 auth endpoints:
+For Swift, the following options are valid; only v1.0 auth endpoints are supported:
 
   * `container` (required) - The name of the Swift container to use. It must be provided, but it can also be sourced from the `OS_CONTAINER` environment variable.
 


### PR DESCRIPTION
Re: https://github.com/hashicorp/vault/issues/2069