### PR TITLE
vault: canonicalize some log output

### DIFF
--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -96,19 +96,19 @@ func (c *Core) loadClusterTLS(adv activeAdvertisement) error {
 		return nil
 
 	case adv.ClusterKeyParams == nil:
-		c.logger.Error("core: failed to load cluster TLS: no key params found")
+		c.logger.Error("core.cluster.: failed to load cluster TLS: no key params found")
 		return fmt.Errorf("no local cluster key params found")
 
 	case adv.ClusterKeyParams.X == nil, adv.ClusterKeyParams.Y == nil, adv.ClusterKeyParams.D == nil:
-		c.logger.Error("core: failed to load cluster TLS: failed to parse local cluster key due to missing params")
+		c.logger.Error("core.cluster: failed to load cluster TLS: failed to parse local cluster key due to missing params")
 		return fmt.Errorf("failed to parse local cluster key")
 
 	case adv.ClusterKeyParams.Type != corePrivateKeyTypeP521:
-		c.logger.Error("core: failed to load cluster TLS: unknown local cluster key type", "key_type", adv.ClusterKeyParams.Type)
+		c.logger.Error("core.cluster: failed to load cluster TLS: unknown local cluster key type", "key_type", adv.ClusterKeyParams.Type)
 		return fmt.Errorf("failed to find valid local cluster key type")
 
 	case adv.ClusterCert == nil || len(adv.ClusterCert) == 0:
-		c.logger.Error("core: failed to load cluster TLS: no local cluster cert found")
+		c.logger.Error("core.cluster: failed to load cluster TLS: no local cluster cert found")
 		return fmt.Errorf("no local cluster cert found")
 	}
 
@@ -129,7 +129,7 @@ func (c *Core) loadClusterTLS(adv activeAdvertisement) error {
 
 	cert, err := x509.ParseCertificate(c.localClusterCert)
 	if err != nil {
-		c.logger.Error("core: failed to load cluster TLS: failed parsing local cluster certificate", "error", err)
+		c.logger.Error("core.cluster: failed to load cluster TLS: failed parsing local cluster certificate", "error", err)
 		return fmt.Errorf("error parsing local cluster certificate: %v", err)
 	}
 
@@ -145,7 +145,7 @@ func (c *Core) setupCluster() error {
 	// Check if storage index is already present or not
 	cluster, err := c.Cluster()
 	if err != nil {
-		c.logger.Error("core: failed to get cluster details", "error", err)
+		c.logger.Error("core.cluster: failed to get cluster details", "error", err)
 		return err
 	}
 
@@ -158,33 +158,26 @@ func (c *Core) setupCluster() error {
 	if cluster.Name == "" {
 		// If cluster name is not supplied, generate one
 		if c.clusterName == "" {
-			c.logger.Trace("core: cluster name not found/set, generating new")
+			c.logger.Trace("core.cluster: cluster name not found or set, generating new")
 			clusterNameBytes, err := uuid.GenerateRandomBytes(4)
 			if err != nil {
-				c.logger.Error("core: failed to generate cluster name", "error", err)
+				c.logger.Error("core.cluster: failed to generate cluster name", "error", err)
 				return err
 			}
-
 			c.clusterName = fmt.Sprintf("vault-cluster-%08x", clusterNameBytes)
 		}
 
 		cluster.Name = c.clusterName
-		if c.logger.IsDebug() {
-			c.logger.Debug("core: cluster name set", "name", cluster.Name)
-		}
 		modified = true
 	}
 
 	if cluster.ID == "" {
-		c.logger.Trace("core: cluster ID not found, generating new")
+		c.logger.Trace("core.cluster: cluster ID not found, generating new")
 		// Generate a clusterID
 		cluster.ID, err = uuid.GenerateUUID()
 		if err != nil {
-			c.logger.Error("core: failed to generate cluster identifier", "error", err)
+			c.logger.Error("core.cluster: failed to generate cluster identifier", "error", err)
 			return err
-		}
-		if c.logger.IsDebug() {
-			c.logger.Debug("core: cluster ID set", "id", cluster.ID)
 		}
 		modified = true
 	}
@@ -197,10 +190,10 @@ func (c *Core) setupCluster() error {
 
 		// Create a private key
 		{
-			c.logger.Trace("core: generating cluster private key")
+			c.logger.Trace("core.cluster: generating cluster private key")
 			key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 			if err != nil {
-				c.logger.Error("core: failed to generate local cluster key", "error", err)
+				c.logger.Error("core.cluster: failed to generate local cluster key", "error", err)
 				return err
 			}
 
@@ -209,7 +202,7 @@ func (c *Core) setupCluster() error {
 
 		// Create a certificate
 		{
-			c.logger.Trace("core: generating local cluster certificate")
+			c.logger.Trace("core.cluster: generating local cluster certificate")
 
 			host, err := uuid.GenerateUUID()
 			if err != nil {
@@ -236,13 +229,13 @@ func (c *Core) setupCluster() error {
 
 			certBytes, err := x509.CreateCertificate(rand.Reader, template, template, c.localClusterPrivateKey.Public(), c.localClusterPrivateKey)
 			if err != nil {
-				c.logger.Error("core: error generating self-signed cert", "error", err)
+				c.logger.Error("core.cluster: error generating self-signed cert", "error", err)
 				return fmt.Errorf("unable to generate local cluster certificate: %v", err)
 			}
 
 			_, err = x509.ParseCertificate(certBytes)
 			if err != nil {
-				c.logger.Error("core: error parsing self-signed cert", "error", err)
+				c.logger.Error("core.cluster: error parsing self-signed cert", "error", err)
 				return fmt.Errorf("error parsing generated certificate: %v", err)
 			}
 
@@ -254,7 +247,7 @@ func (c *Core) setupCluster() error {
 		// Encode the cluster information into as a JSON string
 		rawCluster, err := json.Marshal(cluster)
 		if err != nil {
-			c.logger.Error("core: failed to encode cluster details", "error", err)
+			c.logger.Error("core.cluster: failed to encode cluster details", "error", err)
 			return err
 		}
 
@@ -264,11 +257,13 @@ func (c *Core) setupCluster() error {
 			Value: rawCluster,
 		})
 		if err != nil {
-			c.logger.Error("core: failed to store cluster details", "error", err)
+			c.logger.Error("core.cluster: failed to store cluster details", "error", err)
 			return err
 		}
 	}
 
+	// Provide the cluster name and ID as they are potentially new
+	c.logger.Debug("core.cluster: setup complete", "name", cluster.Name, "id", cluster.ID)
 	return nil
 }
 
@@ -283,21 +278,21 @@ func (c *Core) SetClusterSetupFuncs(handler func() (http.Handler, http.Handler))
 // be built in the same mechanism or started independently.
 func (c *Core) startClusterListener() error {
 	if c.clusterHandlerSetupFunc == nil {
-		c.logger.Error("core: cluster handler setup function has not been set")
+		c.logger.Error("core.cluster: handler setup function has not been set")
 		return fmt.Errorf("cluster handler setup function has not been set")
 	}
 
 	if c.clusterAddr == "" {
-		c.logger.Info("core: clustering disabled, not starting listeners")
+		c.logger.Info("core.cluster: clustering disabled, not starting listeners")
 		return nil
 	}
 
 	if c.clusterListenerAddrs == nil || len(c.clusterListenerAddrs) == 0 {
-		c.logger.Warn("core: clustering not disabled but no addresses to listen on")
+		c.logger.Warn("core.cluster: clustering not disabled but no addresses to listen on")
 		return fmt.Errorf("cluster addresses not found")
 	}
 
-	c.logger.Trace("core: starting cluster listeners")
+	c.logger.Trace("core.cluster: starting cluster listeners")
 	err := c.startForwarding()
 	if err != nil {
 		return err
@@ -309,11 +304,11 @@ func (c *Core) startClusterListener() error {
 // assumed that the state lock is held while this is run.
 func (c *Core) stopClusterListener() {
 	if c.clusterAddr == "" {
-		c.logger.Trace("core: clustering disabled, nothing to do")
+		c.logger.Trace("core.cluster: clustering disabled, nothing to do")
 		return
 	}
 
-	c.logger.Trace("core: stopping cluster listeners")
+	c.logger.Trace("core.cluster: stopping cluster listeners")
 
 	// Tell the goroutine managing the listeners to perform the shutdown
 	// process
@@ -322,9 +317,9 @@ func (c *Core) stopClusterListener() {
 	// The reason for this loop-de-loop is that we may be unsealing again
 	// quickly, and if the listeners are not yet closed, we will get socket
 	// bind errors. This ensures proper ordering.
-	c.logger.Trace("core: waiting for cluster listener shutdown")
+	c.logger.Trace("core.cluster: waiting for cluster listener shutdown")
 	<-c.clusterListenerShutdownSuccessCh
-	c.logger.Info("core: successfully stopped cluster listeners")
+	c.logger.Info("core.cluster: successfully stopped cluster listeners")
 }
 
 // ClusterTLSConfig generates a TLS configuration based on the local cluster

--- a/vault/cluster_test.go
+++ b/vault/cluster_test.go
@@ -115,7 +115,7 @@ func TestCluster_ListenForRequests(t *testing.T) {
 					t.Logf("testing %s:%d unsuccessful as expected", tcpAddr.IP.String(), tcpAddr.Port+1)
 					continue
 				}
-				t.Fatalf("error: %v\nlisteners are\n%#v\n%#v\n", err, cores[0].Listeners[0], cores[0].Listeners[1])
+				t.Fatalf("error: %v\nlisteners are\n%s\n%s\n", err, cores[0].Listeners[0], cores[0].Listeners[1])
 			}
 			if expectFail {
 				t.Fatalf("testing %s:%d not unsuccessful as expected", tcpAddr.IP.String(), tcpAddr.Port+1)

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -34,7 +34,7 @@ func (c *Core) startForwarding() error {
 	// Get our TLS config
 	tlsConfig, err := c.ClusterTLSConfig()
 	if err != nil {
-		c.logger.Error("core: failed to load cluster TLS: failed to get tls configuration", "error", err)
+		c.logger.Error("core.cluster: failed to load cluster TLS: failed to get tls configuration", "error", err)
 		return err
 	}
 
@@ -67,22 +67,19 @@ func (c *Core) startForwarding() error {
 		// Start our listening loop
 		go func() {
 			defer shutdownWg.Done()
-			c.logger.Info("core: starting cluster listener")
+			c.logger.Info("core.cluster: starting cluster listener")
 
 			// Create a TCP listener. We do this separately and specifically
 			// with TCP so that we can set deadlines.
 			tcpLn, err := net.ListenTCP("tcp", laddr)
 			if err != nil {
-				c.logger.Error("core: error starting cluster listener", "error", err)
+				c.logger.Error("core.cluster: error starting cluster listener", "error", err)
 				return
 			}
 
 			// Wrap the listener with TLS
 			tlsLn := tls.NewListener(tcpLn, tlsConfig)
-
-			if c.logger.IsInfo() {
-				c.logger.Info("core: serving cluster requests", "cluster_listen_address", tlsLn.Addr())
-			}
+			c.logger.Info("core.cluster: serving cluster requests", "cluster_listen_address", tlsLn.Addr())
 
 			for {
 				if atomic.LoadUint32(&shutdown) > 0 {
@@ -110,7 +107,7 @@ func (c *Core) startForwarding() error {
 				err = tlsConn.Handshake()
 				if err != nil {
 					if c.logger.IsDebug() {
-						c.logger.Debug("core: failed TLS handshake for cluster request", "error", err)
+						c.logger.Debug("core.cluster: failed TLS handshake for cluster request", "error", err)
 					}
 					if conn != nil {
 						conn.Close()
@@ -120,19 +117,19 @@ func (c *Core) startForwarding() error {
 
 				switch tlsConn.ConnectionState().NegotiatedProtocol {
 				case "h2":
-					c.logger.Trace("core: got h2 cluster connection")
+					c.logger.Trace("core.cluster: got h2 cluster connection")
 					go fws.ServeConn(conn, &http2.ServeConnOpts{
 						Handler: wrappedHandler,
 					})
 
 				case "req_fw_sb-act_v1":
-					c.logger.Trace("core: got req_fw_sb-act_v1 cluster connection")
+					c.logger.Trace("core.cluster: got req_fw_sb-act_v1 cluster connection")
 					go fws.ServeConn(conn, &http2.ServeConnOpts{
 						Handler: c.rpcServer,
 					})
 
 				default:
-					c.logger.Warn("core: unknown negotiated cluster protocol", "protocol",
+					c.logger.Warn("core.cluster: unknown negotiated cluster protocol", "protocol",
 						tlsConn.ConnectionState().NegotiatedProtocol)
 					conn.Close()
 					continue
@@ -149,7 +146,7 @@ func (c *Core) startForwarding() error {
 
 		// Stop the RPC server
 		c.rpcServer.Stop()
-		c.logger.Debug("core: shutting down cluster listeners")
+		c.logger.Debug("core.cluster: shutting down cluster listeners")
 
 		// Set the shutdown flag. This will cause the listeners to shut down
 		// within the deadline in clusterListenerAcceptDeadline
@@ -157,7 +154,7 @@ func (c *Core) startForwarding() error {
 
 		// Wait for them all to shut down
 		shutdownWg.Wait()
-		c.logger.Info("core: cluster listeners successfully shut down")
+		c.logger.Info("core.cluster: cluster listeners successfully shut down")
 
 		// Tell the main thread that shutdown is done.
 		c.clusterListenerShutdownSuccessCh <- struct{}{}
@@ -192,7 +189,7 @@ func (c *Core) refreshRequestForwardingConnection(clusterAddr string) error {
 
 	clusterURL, err := url.Parse(clusterAddr)
 	if err != nil {
-		c.logger.Error("core: error parsing cluster address", "error", err, "address", clusterAddr)
+		c.logger.Error("core.cluster: error parsing cluster address", "error", err, "address", clusterAddr)
 		return err
 	}
 
@@ -201,7 +198,7 @@ func (c *Core) refreshRequestForwardingConnection(clusterAddr string) error {
 		// Set up normal HTTP forwarding handling
 		tlsConfig, err := c.ClusterTLSConfig()
 		if err != nil {
-			c.logger.Error("core: error fetching cluster tls configuration", "error", err)
+			c.logger.Error("core.cluster: error fetching cluster tls configuration", "error", err)
 			return err
 		}
 		tp := &http2.Transport{
@@ -221,7 +218,7 @@ func (c *Core) refreshRequestForwardingConnection(clusterAddr string) error {
 		c.rpcClientConnCancelFunc = cancelFunc
 		c.rpcClientConn, err = grpc.DialContext(ctx, clusterURL.Host, grpc.WithDialer(c.getGRPCDialer()), grpc.WithInsecure())
 		if err != nil {
-			c.logger.Error("core: err setting up cluster rpc client", "error", err)
+			c.logger.Error("core.cluster: err setting up cluster rpc client", "error", err)
 			return err
 		}
 		c.rpcForwardingClient = NewRequestForwardingClient(c.rpcClientConn)
@@ -267,7 +264,7 @@ func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, erro
 
 		freq, err := forwarding.GenerateForwardedHTTPRequest(req, c.requestForwardingConnection.clusterAddr+"/cluster/local/forwarded-request")
 		if err != nil {
-			c.logger.Error("core: error creating forwarded request", "error", err)
+			c.logger.Error("core.cluster: error creating forwarded request", "error", err)
 			return 0, nil, nil, fmt.Errorf("error creating forwarding request")
 		}
 
@@ -294,16 +291,16 @@ func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, erro
 
 		freq, err := forwarding.GenerateForwardedRequest(req)
 		if err != nil {
-			c.logger.Error("core: error creating forwarding RPC request", "error", err)
+			c.logger.Error("core.cluster: error creating forwarding RPC request", "error", err)
 			return 0, nil, nil, fmt.Errorf("error creating forwarding RPC request")
 		}
 		if freq == nil {
-			c.logger.Error("core: got nil forwarding RPC request")
+			c.logger.Error("core.cluster: got nil forwarding RPC request")
 			return 0, nil, nil, fmt.Errorf("got nil forwarding RPC request")
 		}
 		resp, err := c.rpcForwardingClient.HandleRequest(context.Background(), freq, grpc.FailFast(true))
 		if err != nil {
-			c.logger.Error("core: error during forwarded RPC request", "error", err)
+			c.logger.Error("core.cluster: error during forwarded RPC request", "error", err)
 			return 0, nil, nil, fmt.Errorf("error during forwarding RPC request")
 		}
 
@@ -328,7 +325,7 @@ func (c *Core) getGRPCDialer() func(string, time.Duration) (net.Conn, error) {
 	return func(addr string, timeout time.Duration) (net.Conn, error) {
 		tlsConfig, err := c.ClusterTLSConfig()
 		if err != nil {
-			c.logger.Error("core: failed to get cluster tls configuration", "error", err)
+			c.logger.Error("core.cluster: failed to get cluster tls configuration", "error", err)
 			return nil, err
 		}
 		tlsConfig.NextProtos = []string{"req_fw_sb-act_v1"}

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -115,22 +115,22 @@ func (c *Core) startForwarding() error {
 					continue
 				}
 
-				switch tlsConn.ConnectionState().NegotiatedProtocol {
+				proto := tlsConn.ConnectionState().NegotiatedProtocol
+				switch proto {
 				case "h2":
-					c.logger.Trace("core.cluster: got h2 cluster connection")
+					c.logger.Trace("core.cluster: negotiated cluster connection", "protocol", proto)
 					go fws.ServeConn(conn, &http2.ServeConnOpts{
 						Handler: wrappedHandler,
 					})
 
 				case "req_fw_sb-act_v1":
-					c.logger.Trace("core.cluster: got req_fw_sb-act_v1 cluster connection")
+					c.logger.Trace("core.cluster: negotiated cluster connection", "protocol", proto)
 					go fws.ServeConn(conn, &http2.ServeConnOpts{
 						Handler: c.rpcServer,
 					})
 
 				default:
-					c.logger.Warn("core.cluster: unknown negotiated cluster protocol", "protocol",
-						tlsConn.ConnectionState().NegotiatedProtocol)
+					c.logger.Warn("core.cluster: unknown cluster connection protocol negotiated", "protocol", proto)
 					conn.Close()
 					continue
 				}

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -34,7 +34,7 @@ func (c *Core) startForwarding() error {
 	// Get our TLS config
 	tlsConfig, err := c.ClusterTLSConfig()
 	if err != nil {
-		c.logger.Error("core/startClusterListener: failed to get tls configuration", "error", err)
+		c.logger.Error("core: failed to load cluster TLS: failed to get tls configuration", "error", err)
 		return err
 	}
 
@@ -67,14 +67,13 @@ func (c *Core) startForwarding() error {
 		// Start our listening loop
 		go func() {
 			defer shutdownWg.Done()
-
-			c.logger.Info("core/startClusterListener: starting listener")
+			c.logger.Info("core: starting cluster listener")
 
 			// Create a TCP listener. We do this separately and specifically
 			// with TCP so that we can set deadlines.
 			tcpLn, err := net.ListenTCP("tcp", laddr)
 			if err != nil {
-				c.logger.Error("core/startClusterListener: error starting listener", "error", err)
+				c.logger.Error("core: error starting cluster listener", "error", err)
 				return
 			}
 
@@ -82,7 +81,7 @@ func (c *Core) startForwarding() error {
 			tlsLn := tls.NewListener(tcpLn, tlsConfig)
 
 			if c.logger.IsInfo() {
-				c.logger.Info("core/startClusterListener: serving cluster requests", "cluster_listen_address", tlsLn.Addr())
+				c.logger.Info("core: serving cluster requests", "cluster_listen_address", tlsLn.Addr())
 			}
 
 			for {
@@ -111,7 +110,7 @@ func (c *Core) startForwarding() error {
 				err = tlsConn.Handshake()
 				if err != nil {
 					if c.logger.IsDebug() {
-						c.logger.Debug("core/startClusterListener/Accept: error handshaking", "error", err)
+						c.logger.Debug("core: failed TLS handshake for cluster request", "error", err)
 					}
 					if conn != nil {
 						conn.Close()
@@ -121,19 +120,20 @@ func (c *Core) startForwarding() error {
 
 				switch tlsConn.ConnectionState().NegotiatedProtocol {
 				case "h2":
-					c.logger.Debug("core/startClusterListener/Accept: got h2 connection")
+					c.logger.Trace("core: got h2 cluster connection")
 					go fws.ServeConn(conn, &http2.ServeConnOpts{
 						Handler: wrappedHandler,
 					})
 
 				case "req_fw_sb-act_v1":
-					c.logger.Debug("core/startClusterListener/Accept: got req_fw_sb-act_v1 connection")
+					c.logger.Trace("core: got req_fw_sb-act_v1 cluster connection")
 					go fws.ServeConn(conn, &http2.ServeConnOpts{
 						Handler: c.rpcServer,
 					})
 
 				default:
-					c.logger.Debug("core/startClusterListener/Accept: unknown negotiated protocol")
+					c.logger.Warn("core: unknown negotiated cluster protocol", "protocol",
+						tlsConn.ConnectionState().NegotiatedProtocol)
 					conn.Close()
 					continue
 				}
@@ -149,7 +149,7 @@ func (c *Core) startForwarding() error {
 
 		// Stop the RPC server
 		c.rpcServer.Stop()
-		c.logger.Info("core/startClusterListener: shutting down listeners")
+		c.logger.Debug("core: shutting down cluster listeners")
 
 		// Set the shutdown flag. This will cause the listeners to shut down
 		// within the deadline in clusterListenerAcceptDeadline
@@ -157,7 +157,7 @@ func (c *Core) startForwarding() error {
 
 		// Wait for them all to shut down
 		shutdownWg.Wait()
-		c.logger.Info("core/startClusterListener: listeners successfully shut down")
+		c.logger.Info("core: cluster listeners successfully shut down")
 
 		// Tell the main thread that shutdown is done.
 		c.clusterListenerShutdownSuccessCh <- struct{}{}
@@ -192,7 +192,7 @@ func (c *Core) refreshRequestForwardingConnection(clusterAddr string) error {
 
 	clusterURL, err := url.Parse(clusterAddr)
 	if err != nil {
-		c.logger.Error("core/refreshRequestForwardingConnection: error parsing cluster address", "error", err)
+		c.logger.Error("core: error parsing cluster address", "error", err, "address", clusterAddr)
 		return err
 	}
 
@@ -201,7 +201,7 @@ func (c *Core) refreshRequestForwardingConnection(clusterAddr string) error {
 		// Set up normal HTTP forwarding handling
 		tlsConfig, err := c.ClusterTLSConfig()
 		if err != nil {
-			c.logger.Error("core/refreshRequestForwardingConnection: error fetching cluster tls configuration", "error", err)
+			c.logger.Error("core: error fetching cluster tls configuration", "error", err)
 			return err
 		}
 		tp := &http2.Transport{
@@ -221,7 +221,7 @@ func (c *Core) refreshRequestForwardingConnection(clusterAddr string) error {
 		c.rpcClientConnCancelFunc = cancelFunc
 		c.rpcClientConn, err = grpc.DialContext(ctx, clusterURL.Host, grpc.WithDialer(c.getGRPCDialer()), grpc.WithInsecure())
 		if err != nil {
-			c.logger.Error("core/refreshRequestForwardingConnection: err setting up rpc client", "error", err)
+			c.logger.Error("core: err setting up cluster rpc client", "error", err)
 			return err
 		}
 		c.rpcForwardingClient = NewRequestForwardingClient(c.rpcClientConn)
@@ -267,7 +267,7 @@ func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, erro
 
 		freq, err := forwarding.GenerateForwardedHTTPRequest(req, c.requestForwardingConnection.clusterAddr+"/cluster/local/forwarded-request")
 		if err != nil {
-			c.logger.Error("core/ForwardRequest: error creating forwarded request", "error", err)
+			c.logger.Error("core: error creating forwarded request", "error", err)
 			return 0, nil, nil, fmt.Errorf("error creating forwarding request")
 		}
 
@@ -294,16 +294,16 @@ func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, erro
 
 		freq, err := forwarding.GenerateForwardedRequest(req)
 		if err != nil {
-			c.logger.Error("core/ForwardRequest: error creating forwarding RPC request", "error", err)
+			c.logger.Error("core: error creating forwarding RPC request", "error", err)
 			return 0, nil, nil, fmt.Errorf("error creating forwarding RPC request")
 		}
 		if freq == nil {
-			c.logger.Error("core/ForwardRequest: got nil forwarding RPC request")
+			c.logger.Error("core: got nil forwarding RPC request")
 			return 0, nil, nil, fmt.Errorf("got nil forwarding RPC request")
 		}
 		resp, err := c.rpcForwardingClient.HandleRequest(context.Background(), freq, grpc.FailFast(true))
 		if err != nil {
-			c.logger.Error("core/ForwardRequest: error during forwarded RPC request", "error", err)
+			c.logger.Error("core: error during forwarded RPC request", "error", err)
 			return 0, nil, nil, fmt.Errorf("error during forwarding RPC request")
 		}
 
@@ -328,7 +328,7 @@ func (c *Core) getGRPCDialer() func(string, time.Duration) (net.Conn, error) {
 	return func(addr string, timeout time.Duration) (net.Conn, error) {
 		tlsConfig, err := c.ClusterTLSConfig()
 		if err != nil {
-			c.logger.Error("core/getGRPCDialer: failed to get tls configuration", "error", err)
+			c.logger.Error("core: failed to get cluster tls configuration", "error", err)
 			return nil, err
 		}
 		tlsConfig.NextProtos = []string{"req_fw_sb-act_v1"}


### PR DESCRIPTION
This PR canonicalized some of the log outputs related to clustering and request forwarding to be like the other log lines.