### PR TITLE
Added support for individual user policy mapping in github auth backend.

### DIFF
--- a/builtin/credential/github/backend.go
+++ b/builtin/credential/github/backend.go
@@ -14,12 +14,22 @@ func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
 
 func Backend() *backend {
 	var b backend
-	b.Map = &framework.PolicyMap{
+	b.TeamMap = &framework.PolicyMap{
 		PathMap: framework.PathMap{
 			Name: "teams",
 		},
 		DefaultKey: "default",
 	}
+
+	b.UserMap = &framework.PolicyMap{
+		PathMap: framework.PathMap{
+			Name: "users",
+		},
+		DefaultKey: "default",
+	}
+
+	allPaths := append(b.TeamMap.Paths(), b.UserMap.Paths()...)
+
 	b.Backend = &framework.Backend{
 		Help: backendHelp,
 
@@ -32,7 +42,7 @@ func Backend() *backend {
 		Paths: append([]*framework.Path{
 			pathConfig(&b),
 			pathLogin(&b),
-		}, b.Map.Paths()...),
+		}, allPaths...),
 
 		AuthRenew: b.pathLoginRenew,
 	}
@@ -43,7 +53,9 @@ func Backend() *backend {
 type backend struct {
 	*framework.Backend
 
-	Map *framework.PolicyMap
+	TeamMap *framework.PolicyMap
+
+	UserMap *framework.PolicyMap
 }
 
 // Client returns the GitHub client to communicate to GitHub via the

--- a/builtin/credential/github/backend_test.go
+++ b/builtin/credential/github/backend_test.go
@@ -112,15 +112,19 @@ func TestBackend_basic(t *testing.T) {
 			testAccStepConfig(t, false),
 			testAccMap(t, "default", "fakepol"),
 			testAccMap(t, "oWnErs", "fakepol"),
-			testAccLogin(t, []string{"fakepol"}),
+			testAccLogin(t, []string{"default", "fakepol"}),
 			testAccStepConfig(t, true),
 			testAccMap(t, "default", "fakepol"),
 			testAccMap(t, "oWnErs", "fakepol"),
-			testAccLogin(t, []string{"fakepol"}),
+			testAccLogin(t, []string{"default", "fakepol"}),
 			testAccStepConfigWithBaseURL(t),
 			testAccMap(t, "default", "fakepol"),
 			testAccMap(t, "oWnErs", "fakepol"),
-			testAccLogin(t, []string{"fakepol"}),
+			testAccLogin(t, []string{"default", "fakepol"}),
+			testAccMap(t, "default", "fakepol"),
+			testAccStepConfig(t, true),
+			mapUserToPolicy(t, os.Getenv("GITHUB_USER"), "userpolicy"),
+			testAccLogin(t, []string{"default", "fakepol", "userpolicy"}),
 		},
 	})
 }
@@ -174,7 +178,17 @@ func testAccMap(t *testing.T, k string, v string) logicaltest.TestStep {
 	}
 }
 
-func testAccLogin(t *testing.T, keys []string) logicaltest.TestStep {
+func mapUserToPolicy(t *testing.T, k string, v string) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.UpdateOperation,
+		Path:      "map/users/" + k,
+		Data: map[string]interface{}{
+			"value": v,
+		},
+	}
+}
+
+func testAccLogin(t *testing.T, policies []string) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.UpdateOperation,
 		Path:      "login",
@@ -183,6 +197,6 @@ func testAccLogin(t *testing.T, keys []string) logicaltest.TestStep {
 		},
 		Unauthenticated: true,
 
-		Check: logicaltest.TestCheckAuth([]string{"default", "fakepol"}),
+		Check: logicaltest.TestCheckAuth(policies),
 	}
 }

--- a/builtin/credential/github/path_login.go
+++ b/builtin/credential/github/path_login.go
@@ -194,14 +194,22 @@ func (b *backend) verifyCredentials(req *logical.Request, token string) (*verify
 		}
 	}
 
-	policiesList, err := b.Map.Policies(req.Storage, teamNames...)
+	groupPoliciesList, err := b.TeamMap.Policies(req.Storage, teamNames...)
+
 	if err != nil {
 		return nil, nil, err
 	}
+
+	userPoliciesList, err := b.UserMap.Policies(req.Storage, []string{*user.Login}...)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return &verifyCredentialsResp{
 		User:     user,
 		Org:      org,
-		Policies: policiesList,
+		Policies: append(groupPoliciesList, userPoliciesList...),
 	}, nil, nil
 }
 


### PR DESCRIPTION
Here is a patch that allows you to create a policy mapping at auth/github/map/users/USERNAME to a policy. On login, that policy will be assigned to the token in addition to the group mappings.

If you accept the patch, I'll submit a PR for documentation.