### PR TITLE
Adding & to avoid errors.

### DIFF
--- a/website/source/intro/getting-started/dev-server.html.md
+++ b/website/source/intro/getting-started/dev-server.html.md
@@ -28,7 +28,7 @@ started guide we'll configure and start a real server.
 To start the Vault dev server, run `vault server -dev`:
 
 ```
-$ vault server -dev
+$ vault server -dev &
 WARNING: Dev mode is enabled!
 
 In this mode, Vault is completely in-memory and unsealed.


### PR DESCRIPTION
I started a dev server. I stopped it and re-ran with &. Then I got errors and had to reinstall from scratch. This gave me some guidance so I thought I'd suggest that to prevent people from getting that error right off the bat by doing what I did in following the instructions verbatim.
If the output looks different, especially if the numbers are different
or the Vault is sealed, then restart the dev server and try again. The
only reason these would ever be different is if you're running a dev
server from going through this guide previously.