### PR TITLE
prevent binding 0.0.0.0 -> ::0

### DIFF
--- a/command/server/listener_tcp.go
+++ b/command/server/listener_tcp.go
@@ -3,6 +3,7 @@ package server
 import (
 	"io"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/vault"
@@ -15,7 +16,9 @@ func tcpListenerFactory(config map[string]string, _ io.Writer) (net.Listener, ma
 		addr = "127.0.0.1:8200"
 	}
 
-	if addr == "0.0.0.0" {
+	// If they've passed 0.0.0.0, we only want to bind on IPv4
+	// rather than golang's dual stack default
+	if strings.HasPrefix(addr, "0.0.0.0:") {
 		bind_proto = "tcp4"
 	}
 

--- a/command/server/listener_tcp.go
+++ b/command/server/listener_tcp.go
@@ -9,12 +9,17 @@ import (
 )
 
 func tcpListenerFactory(config map[string]string, _ io.Writer) (net.Listener, map[string]string, vault.ReloadFunc, error) {
+	bind_proto := "tcp"
 	addr, ok := config["address"]
 	if !ok {
 		addr = "127.0.0.1:8200"
 	}
 
-	ln, err := net.Listen("tcp", addr)
+	if addr == "0.0.0.0" {
+		bind_proto = "tcp4"
+	}
+
+	ln, err := net.Listen(bind_proto, addr)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
As an operator, it was surprising to see the
ipv6 bind address when configuring the ipv4 address.

This adds a special case for 0.0.0.0 to bind on tcp4
rather than the generic tcp. This more closely follows the
behavior seen in nginx and mysql.

The golang default of mapping 0.0.0.0 to ::0 makes sense as the
*default* case, we want to lean towards the *secure* case.

If an operating passes 0.0.0.0, we should honor it.
If they want dual stack, they can pass ::0.

Config file:
```
{
  "backend": {
    "consul": {
      "address": "127.0.0.1:8500", 
      "path": "vault"
    }
  }, 
  "disable_mlock": true, 
  "listener": {
    "tcp": {
      "address": "0.0.0.0:8200", 
      "tls_disable": 1
    }
  }
}
```

Old behavior:
```
$ netstat -plant | grep vault
tcp6       0      0 :::8200                 :::*                    LISTEN      3238/vault  
```

New behavior:
```
# netstat -plant | grep vault
tcp        0      0 0.0.0.0:8200            0.0.0.0:*               LISTEN      6222/vault      
```