### PR TITLE
Store client token in endpoint-specific file

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -289,6 +289,15 @@ func (c *Client) SetAddress(addr string) error {
 	return nil
 }
 
+// Address returns the Vault address used by this client. It will
+// return the empty string if there is no address set.
+func (c *Client) Address() string {
+	if c.addr == nil {
+		return ""
+	}
+	return c.addr.String()
+}
+
 // SetWrappingLookupFunc sets a lookup function that returns desired wrap TTLs
 // for a given operation and path
 func (c *Client) SetWrappingLookupFunc(lookupFunc WrappingLookupFunc) {

--- a/command/auth.go
+++ b/command/auth.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/vault/api"
+	tokenAPI "github.com/hashicorp/vault/command/token"
 	"github.com/hashicorp/vault/helper/kv-builder"
 	"github.com/hashicorp/vault/helper/password"
 	"github.com/hashicorp/vault/meta"
@@ -157,6 +158,11 @@ func (c *AuthCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf(
 			"Error initializing client to auth: %s", err))
 		return 1
+	}
+
+	switch tokenHelper := tokenHelper.(type) {
+	case *tokenAPI.InternalTokenHelper:
+		tokenHelper.SetVaultAddress(client.Address())
 	}
 
 	if authPath != "" {

--- a/command/auth_test.go
+++ b/command/auth_test.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/api"
+	tokenAPI "github.com/hashicorp/vault/command/token"
 	"github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/meta"
 	"github.com/hashicorp/vault/vault"
 	"github.com/mitchellh/cli"
+	"github.com/mitchellh/go-homedir"
 )
 
 func TestAuth_methods(t *testing.T) {
@@ -72,6 +74,11 @@ func TestAuth_token(t *testing.T) {
 	helper, err := c.TokenHelper()
 	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+
+	switch h := helper.(type) {
+	case *tokenAPI.InternalTokenHelper:
+		h.SetVaultAddress(addr)
 	}
 
 	actual, err := helper.Get()
@@ -171,6 +178,11 @@ func TestAuth_method(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
+	switch h := helper.(type) {
+	case *tokenAPI.InternalTokenHelper:
+		h.SetVaultAddress(addr)
+	}
+
 	actual, err := helper.Get()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -182,6 +194,9 @@ func TestAuth_method(t *testing.T) {
 }
 
 func testAuthInit(t *testing.T) {
+	// InternalTokenHelper evaluates the user's homedir, which changes for each test case
+	homedir.DisableCache = true
+
 	td, err := ioutil.TempDir("", "vault")
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/command/token/helper_internal.go
+++ b/command/token/helper_internal.go
@@ -2,10 +2,13 @@ package token
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+
+	"net/url"
 
 	"github.com/mitchellh/go-homedir"
 )
@@ -13,32 +16,70 @@ import (
 // InternalTokenHelper fulfills the TokenHelper interface when no external
 // token-helper is configured, and avoids shelling out
 type InternalTokenHelper struct {
-	tokenPath string
+	defaultTokenPath string
+	hashedTokenPath  string
+	addr             string
 }
 
-// populateTokenPath figures out the token path using homedir to get the user's
+func (i *InternalTokenHelper) hashAddress() (string, error) {
+	// Ignore the protocol field; just use the address and port
+	u, err := url.Parse(i.addr)
+	if err != nil {
+		return "", err
+	}
+	hashedAddr := sha256.Sum256([]byte(u.Host))
+	asciiHashedAddr := fmt.Sprintf("%x", hashedAddr)
+	return asciiHashedAddr, nil
+}
+
+// populateTokenPaths figures out the token paths using homedir to get the user's
 // home directory
-func (i *InternalTokenHelper) populateTokenPath() {
+func (i *InternalTokenHelper) populateTokenPaths() error {
 	homePath, err := homedir.Dir()
 	if err != nil {
 		panic(fmt.Errorf("error getting user's home directory: %v", err))
 	}
-	i.tokenPath = homePath + "/.vault-token"
+	i.defaultTokenPath = homePath + "/.vault-token"
+	if len(i.addr) > 0 {
+		asciiHashedAddr, err := i.hashAddress()
+		if err != nil {
+			return err
+		}
+		i.hashedTokenPath = i.defaultTokenPath + "-" + asciiHashedAddr[0:8]
+	}
+	return nil
 }
 
 func (i *InternalTokenHelper) Path() string {
-	return i.tokenPath
+	return i.hashedTokenPath
+}
+
+// SetVaultAddress sets the Vault address in use.  This is used to determine the token path.
+func (i *InternalTokenHelper) SetVaultAddress(addr string) {
+	i.addr = addr
 }
 
 // Get gets the value of the stored token, if any
 func (i *InternalTokenHelper) Get() (string, error) {
-	i.populateTokenPath()
-	f, err := os.Open(i.tokenPath)
-	if os.IsNotExist(err) {
-		return "", nil
-	}
-	if err != nil {
+	var f *os.File
+	var err error
+	if err = i.populateTokenPaths(); err != nil {
 		return "", err
+	}
+	if len(i.hashedTokenPath) > 0 {
+		f, err = os.Open(i.hashedTokenPath)
+		if err != nil && !os.IsNotExist(err) {
+			return "", err
+		}
+	}
+	if f == nil { // No token exists at hashed path
+		f, err = os.Open(i.defaultTokenPath)
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		if err != nil {
+			return "", err
+		}
 	}
 	defer f.Close()
 
@@ -46,14 +87,21 @@ func (i *InternalTokenHelper) Get() (string, error) {
 	if _, err := io.Copy(buf, f); err != nil {
 		return "", err
 	}
-
 	return strings.TrimSpace(buf.String()), nil
 }
 
 // Store stores the value of the token to the file
 func (i *InternalTokenHelper) Store(input string) error {
-	i.populateTokenPath()
-	f, err := os.OpenFile(i.tokenPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	if err := i.populateTokenPaths(); err != nil {
+		return err
+	}
+	var path string
+	if len(i.hashedTokenPath) > 0 {
+		path = i.hashedTokenPath
+	} else {
+		path = i.defaultTokenPath
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}
@@ -69,8 +117,13 @@ func (i *InternalTokenHelper) Store(input string) error {
 
 // Erase erases the value of the token
 func (i *InternalTokenHelper) Erase() error {
-	i.populateTokenPath()
-	if err := os.Remove(i.tokenPath); err != nil && !os.IsNotExist(err) {
+	i.populateTokenPaths()
+	if len(i.hashedTokenPath) > 0 {
+		if err := os.Remove(i.hashedTokenPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if err := os.Remove(i.defaultTokenPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 

--- a/command/token/helper_internal_test.go
+++ b/command/token/helper_internal_test.go
@@ -1,11 +1,55 @@
 package token
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 // TestCommand re-uses the existing Test function to ensure proper behavior of
 // the internal token helper
 func TestCommand(t *testing.T) {
 	Test(t, &InternalTokenHelper{})
+}
+
+func TestInternalTokenHelper(t *testing.T) {
+	testHashedStorage(t, "http://127.0.0.1:8200", "0769a29d")
+	testHashedStorage(t, "https://127.0.0.1:8200", "0769a29d")
+}
+
+func testHashedStorage(t *testing.T, addr string, extension string) {
+	// InternalTokenHelper evaluates the user's homedir, which changes for each test case
+	homedir.DisableCache = true
+
+	var tkn = "not a valid token"
+
+	td, err := ioutil.TempDir("", "vault")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	os.Setenv("HOME", td)
+	homePath, err := homedir.Dir()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	h := &InternalTokenHelper{}
+	h.SetVaultAddress(addr)
+	h.Store(tkn)
+
+	_, err = os.Stat(homePath + "/.vault-token-" + extension)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual, err := h.Get()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if actual != tkn {
+		t.Fatalf("bad: expected %s, received %s", tkn, actual)
+	}
 }

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/command/token"
+	tokenAPI "github.com/hashicorp/vault/command/token"
 	"github.com/mitchellh/cli"
 )
 
@@ -15,7 +15,7 @@ import (
 // default FlagSet returned by Meta.FlagSet.
 type FlagSetFlags uint
 
-type TokenHelperFunc func() (token.TokenHelper, error)
+type TokenHelperFunc func() (tokenAPI.TokenHelper, error)
 
 const (
 	FlagSetNone    FlagSetFlags = 0
@@ -105,6 +105,10 @@ func (m *Meta) Client() (*api.Client, error) {
 			tokenHelper, err := m.TokenHelper()
 			if err != nil {
 				return nil, err
+			}
+			switch tokenHelper := tokenHelper.(type) {
+			case *tokenAPI.InternalTokenHelper:
+				tokenHelper.SetVaultAddress(client.Address())
 			}
 			token, err = tokenHelper.Get()
 			if err != nil {

--- a/website/source/docs/commands/environment.html.md
+++ b/website/source/docs/commands/environment.html.md
@@ -21,7 +21,12 @@ The following table describes them:
   </tr>
   <tr>
     <td><tt>VAULT_TOKEN</tt></td>
-    <td>The Vault authentication token.  If not specified, the token located in <tt>$HOME/.vault-token</tt> will be used if it exists.</td>
+    <td>The Vault authentication token.  If not specified, the token will be searched for in one of the following locations:
+        <ul>
+          <li><tt>$HOME/.vault-token-SUFFIX</tt>, where SUFFIX is a hash of the hostname and port of the Vault server</li>
+          <li><tt>$HOME/.vault-token</tt></li>
+        </ul>
+    </td>
   </tr>
   <tr>
     <td><tt>VAULT_ADDR</tt></td>


### PR DESCRIPTION
Where possible, store the user's token in `~/.vault-token-SUFFIX`
for safekeeping, where `SUFFIX` is the first 8 hex digits of the SHA-256
hash of `host:port`.  If that can't be found, fall back to the
historical `~/.vault-token` location.

Fixes #2092