### PR TITLE
  // , Make reference to Consul more explicit

### DIFF
--- a/website/source/intro/vs/consul.html.md
+++ b/website/source/intro/vs/consul.html.md
@@ -13,7 +13,7 @@ and configuration that is distributed and highly available. Consul also
 supports an ACL system to restrict access to keys and service information.
 
 While Consul can be used to store secret information and gate access using
-ACLs, it is not designed for that purpose. As such, data is not encrypted
+ACLs, it is not designed for that purpose. As such, Consul does not encrypt data
 in transit nor at rest, it does not have pluggable authentication mechanisms,
 and there is no per-request auditing mechanism.
 


### PR DESCRIPTION
  // , I propose this as one of our devs, a native, highly experienced coder and native English speaker, while trying to piece together our use case for vault, asked whether this sentence referred to Consul or to Vault. 

I couldn't tell, myself, until I read through it twice. Perhaps this small change would clear it up that Consul doesn't encrypt data in transit?

Does that make sense? 