### PR TITLE
If you pass an empty password to authenticate to vault using LDAP, an…

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -111,7 +111,7 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 	}
 
 	if cfg.DenyNullBind && len(password) == 0 {
-		return nil, logical.ErrorResponse("Password cannot be of zero length when passwordless binds are being denied"), nil
+		return nil, logical.ErrorResponse("password cannot be of zero length when passwordless binds are being denied"), nil
 	}
 
 	// Try to bind as the login user. This is where the actual authentication takes place.

--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -110,6 +110,10 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 		b.Logger().Debug("auth/ldap: BindDN fetched", "username", username, "binddn", bindDN)
 	}
 
+	if cfg.DenyNullBind && len(password) == 0 {
+		return nil, logical.ErrorResponse("Password cannot be of zero length when passwordless binds are being denied"), nil
+	}
+
 	// Try to bind as the login user. This is where the actual authentication takes place.
 	if err = c.Bind(bindDN, password); err != nil {
 		return nil, logical.ErrorResponse(fmt.Sprintf("LDAP bind failed: %v", err)), nil

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -175,7 +175,7 @@ func TestBackend_configDefaultsAfterUpdate(t *testing.T) {
 						t.Errorf("Default mismatch: userattr. Expected: '%s', received :'%s'", defaultUserAttr, cfg["userattr"])
 					}
 
-					defaultDenyNullBind := false
+					defaultDenyNullBind := true
 					if cfg["deny_null_bind"] != defaultDenyNullBind {
 						t.Errorf("Default mismatch: deny_null_bind. Expected: '%s', received :'%s'", defaultDenyNullBind, cfg["deny_null_bind"])
 					}

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -175,6 +175,11 @@ func TestBackend_configDefaultsAfterUpdate(t *testing.T) {
 						t.Errorf("Default mismatch: userattr. Expected: '%s', received :'%s'", defaultUserAttr, cfg["userattr"])
 					}
 
+					defaultDenyNullBind := false
+					if cfg["denynullbind"] != defaultDenyNullBind {
+						t.Errorf("Default mismatch: denynullbind. Expected: '%s', received :'%s'", defaultDenyNullBind, cfg["denynullbind"])
+					}
+
 					return nil
 				},
 			},
@@ -364,6 +369,7 @@ func testAccStepLogin(t *testing.T, user string, pass string) logicaltest.TestSt
 		Check: logicaltest.TestCheckAuth([]string{"bar", "default", "foo"}),
 	}
 }
+
 
 func testAccStepLoginNoGroupDN(t *testing.T, user string, pass string) logicaltest.TestStep {
 	return logicaltest.TestStep{

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -176,8 +176,8 @@ func TestBackend_configDefaultsAfterUpdate(t *testing.T) {
 					}
 
 					defaultDenyNullBind := false
-					if cfg["denynullbind"] != defaultDenyNullBind {
-						t.Errorf("Default mismatch: denynullbind. Expected: '%s', received :'%s'", defaultDenyNullBind, cfg["denynullbind"])
+					if cfg["deny_null_bind"] != defaultDenyNullBind {
+						t.Errorf("Default mismatch: deny_null_bind. Expected: '%s', received :'%s'", defaultDenyNullBind, cfg["deny_null_bind"])
 					}
 
 					return nil

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -106,7 +106,7 @@ Default: cn`,
 				Default:     "tls12",
 				Description: "Maximum TLS version to use. Accepted values are 'tls10', 'tls11' or 'tls12'. Defaults to 'tls12'",
 			},
-			"denynullbind": &framework.FieldSchema{
+			"deny_null_bind": &framework.FieldSchema{
 				Type:		 framework.TypeBool,
 				Default:	 false,
 				Description:  "Denies an unauthenticated LDAP bind request if the user's password is empty",
@@ -261,7 +261,7 @@ func (b *backend) newConfigEntry(d *framework.FieldData) (*ConfigEntry, error) {
 	if bindPass != "" {
 		cfg.BindPassword = bindPass
 	}
-	denyNullBind := d.Get("denynullbind").(bool)
+	denyNullBind := d.Get("deny_null_bind").(bool)
 	if denyNullBind {
 		cfg.DenyNullBind = denyNullBind
 	}
@@ -306,7 +306,7 @@ type ConfigEntry struct {
 	StartTLS      bool   `json:"starttls" structs:"starttls" mapstructure:"starttls"`
 	BindDN        string `json:"binddn" structs:"binddn" mapstructure:"binddn"`
 	BindPassword  string `json:"bindpass" structs:"bindpass" mapstructure:"bindpass"`
-	DenyNullBind  bool   `json:"denynullbind" structs:"denynullbind" mapstructure:"denynullbind"`
+	DenyNullBind  bool   `json:"deny_null_bind" structs:"deny_null_bind" mapstructure:"deny_null_bind"`
 	DiscoverDN    bool   `json:"discoverdn" structs:"discoverdn" mapstructure:"discoverdn"`
 	TLSMinVersion string `json:"tls_min_version" structs:"tls_min_version" mapstructure:"tls_min_version"`
 	TLSMaxVersion string `json:"tls_max_version" structs:"tls_max_version" mapstructure:"tls_max_version"`

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -106,6 +106,11 @@ Default: cn`,
 				Default:     "tls12",
 				Description: "Maximum TLS version to use. Accepted values are 'tls10', 'tls11' or 'tls12'. Defaults to 'tls12'",
 			},
+			"denynullbind": &framework.FieldSchema{
+				Type:		 framework.TypeBool,
+				Default:	 false,
+				Description:  "Denies an unauthenticated LDAP bind request if the user's password is empty",
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -256,6 +261,10 @@ func (b *backend) newConfigEntry(d *framework.FieldData) (*ConfigEntry, error) {
 	if bindPass != "" {
 		cfg.BindPassword = bindPass
 	}
+	denyNullBind := d.Get("denynullbind").(bool)
+	if denyNullBind {
+		cfg.DenyNullBind = denyNullBind
+	}
 	discoverDN := d.Get("discoverdn").(bool)
 	if discoverDN {
 		cfg.DiscoverDN = discoverDN
@@ -297,6 +306,7 @@ type ConfigEntry struct {
 	StartTLS      bool   `json:"starttls" structs:"starttls" mapstructure:"starttls"`
 	BindDN        string `json:"binddn" structs:"binddn" mapstructure:"binddn"`
 	BindPassword  string `json:"bindpass" structs:"bindpass" mapstructure:"bindpass"`
+	DenyNullBind  bool   `json:"denynullbind" structs:"denynullbind" mapstructure:"denynullbind"`
 	DiscoverDN    bool   `json:"discoverdn" structs:"discoverdn" mapstructure:"discoverdn"`
 	TLSMinVersion string `json:"tls_min_version" structs:"tls_min_version" mapstructure:"tls_min_version"`
 	TLSMaxVersion string `json:"tls_max_version" structs:"tls_max_version" mapstructure:"tls_max_version"`

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -108,8 +108,8 @@ Default: cn`,
 			},
 			"deny_null_bind": &framework.FieldSchema{
 				Type:		 framework.TypeBool,
-				Default:	 false,
-				Description:  "Denies an unauthenticated LDAP bind request if the user's password is empty",
+				Default:	 true,
+				Description: "Denies an unauthenticated LDAP bind request if the user's password is empty",
 			},
 		},
 

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -109,7 +109,7 @@ Default: cn`,
 			"deny_null_bind": &framework.FieldSchema{
 				Type:		 framework.TypeBool,
 				Default:	 true,
-				Description: "Denies an unauthenticated LDAP bind request if the user's password is empty",
+				Description: "Denies an unauthenticated LDAP bind request if the user's password is empty; defaults to true",
 			},
 		},
 

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -132,7 +132,7 @@ There are two alternate methods of resolving the user object used to authenticat
 * `discoverdn` (bool, optional) - If true, use anonymous bind to discover the bind DN of a user
 * `userdn` (string, optional) - Base DN under which to perform user search. Example: `ou=Users,dc=example,dc=com`
 * `userattr` (string, optional) - Attribute on user attribute object matching the username passed when authenticating. Examples: `sAMAccountName`, `cn`, `uid`
-* `deny_null_bind` (bool, optional) - If true, this option allows null binds for searching, but prevents users from bypassing authentication when providing a blank password. The default is `false`.
+* `deny_null_bind` (bool, optional) - This option prevents users from bypassing authentication when providing an empty password. The default is `true`.
 
 #### Binding - User Principal Name (AD)
 

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -132,7 +132,7 @@ There are two alternate methods of resolving the user object used to authenticat
 * `discoverdn` (bool, optional) - If true, use anonymous bind to discover the bind DN of a user
 * `userdn` (string, optional) - Base DN under which to perform user search. Example: `ou=Users,dc=example,dc=com`
 * `userattr` (string, optional) - Attribute on user attribute object matching the username passed when authenticating. Examples: `sAMAccountName`, `cn`, `uid`
-* `denynullbind` (bool, optional) - If true, this option allows null binds for searching, but prevents users from bypassing authentication when providing a blank password. The default is `false`.
+* `deny_null_bind` (bool, optional) - If true, this option allows null binds for searching, but prevents users from bypassing authentication when providing a blank password. The default is `false`.
 
 #### Binding - User Principal Name (AD)
 

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -132,6 +132,7 @@ There are two alternate methods of resolving the user object used to authenticat
 * `discoverdn` (bool, optional) - If true, use anonymous bind to discover the bind DN of a user
 * `userdn` (string, optional) - Base DN under which to perform user search. Example: `ou=Users,dc=example,dc=com`
 * `userattr` (string, optional) - Attribute on user attribute object matching the username passed when authenticating. Examples: `sAMAccountName`, `cn`, `uid`
+* `denynullbind` (bool, optional) - If true, this option allows null binds for searching, but prevents users from bypassing authentication when providing a blank password. The default is `false`.
 
 #### Binding - User Principal Name (AD)
 

--- a/website/source/docs/install/upgrade-to-0.6.3.html.md
+++ b/website/source/docs/install/upgrade-to-0.6.3.html.md
@@ -1,0 +1,19 @@
+---
+layout: "install"
+page_title: "Upgrading to Vault 0.6.3"
+sidebar_current: "docs-install-upgrade-to-0.6.3"
+description: |-
+  Learn how to upgrade to Vault 0.63.
+---
+
+# Overview
+
+This page contains the list of deprecations and important or breaking changes
+for Vault 0.6.3. Please read it carefully.
+
+## LDAP Null Binds Disabled By Default
+
+When using the LDAP Auth Backend, `deny_null_bind` has a default value of
+`true`, preventing a successful user authentication when an empty password
+is provided. If you utilize passwordless LDAP binds, `deny_null_bind` must
+be set to `false`.

--- a/website/source/docs/install/upgrade-to-0.6.3.html.md
+++ b/website/source/docs/install/upgrade-to-0.6.3.html.md
@@ -16,4 +16,6 @@ for Vault 0.6.3. Please read it carefully.
 When using the LDAP Auth Backend, `deny_null_bind` has a default value of
 `true`, preventing a successful user authentication when an empty password
 is provided. If you utilize passwordless LDAP binds, `deny_null_bind` must
-be set to `false`.
+be set to `false`. Upgrades will keep previous behavior until the LDAP
+configuration information is rewritten, at which point the new behavior
+will be utilized.


### PR DESCRIPTION
…d the LDAP server is configured to accept null bindings, the authentication will succeed without knowing the user's password. This provides an option, `denynullbind`, that allows null binds for searching, but requires that end users provide a password for authentication.

Fixes #2086