### PR TITLE
check for failure on that query

### DIFF
--- a/physical/mysql.go
+++ b/physical/mysql.go
@@ -172,6 +172,9 @@ func (m *MySQLBackend) List(prefix string) ([]string, error) {
 	// Add the % wildcard to the prefix to do the prefix search
 	likePrefix := prefix + "%"
 	rows, err := m.statements["list"].Query(likePrefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute statement: %v", err)
+	}
 
 	var keys []string
 	for rows.Next() {


### PR DESCRIPTION
That query used to have a check for err, but it was removed in 46ba8d10a555.
The caller, expireID in vault/expiration.go:565, retries after 1 second, and
there's other failures in this method that return nil,err so this approach
looks valid.

We were seeing these panics/crashes since our vault is lightly used and the connection goes stale:

    [mysql] 2016/11/03 21:39:01 packets.go:33: unexpected EOF
    [mysql] 2016/11/03 21:39:01 packets.go:124: write tcp x.x.x.x:xxxxx->x.x.x.x:xxxxx: write: broken pipe
    [mysql] 2016/11/03 21:39:01 statement.go:27: invalid connection
    [mysql] 2016/11/03 21:39:01 packets.go:33: unexpected EOF
    [mysql] 2016/11/03 21:39:01 statement.go:27: invalid connection
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal 0xb code=0x1 addr=0x20 pc=0x9a42a2]

    goroutine 422144 [running]:
    panic(0x148b560, 0xc8200100b0)
    /goroot/src/runtime/panic.go:481
    database/sql.(*Rows).Next(0x0, 0xc8207cf818)
    /goroot/src/database/sql/sql.go:1751
    github.com/hashicorp/vault/physical.(*MySQLBackend).List(0xc820162420, 0xc820a269c0, 0x3a, 0x0, 0x0, 0x0, 0x0, 0x0)
    physical/mysql.go:177
    physical/cache.go:83
    vault/barrier_aes_gcm.go:678
    vault/barrier_view.go:44
    vault/token_store.go:786
    vault/token_store.go:775
    vault/expiration.go:581
    vault/expiration.go:197
    vault/expiration.go:177
    vault/expiration.go:565
    vault/expiration.go:538
    created by time.goFunc
    /goroot/src/time/sleep.go:129 +0x3a

This addresses https://github.com/hashicorp/vault/issues/2063