### PR TITLE
Fix bug with vault cli when reading an individual field containing a Printf formatting verb

### DIFF
--- a/command/util.go
+++ b/command/util.go
@@ -79,7 +79,7 @@ func PrintRawField(ui cli.Ui, secret *api.Secret, field string) int {
 		// directly print the message. If mitchellh/cli exposes method
 		// to print without CR, this check needs to be removed.
 		if reflect.TypeOf(ui).String() == "*cli.BasicUi" {
-			fmt.Fprintf(os.Stdout, fmt.Sprintf("%v", val))
+			fmt.Fprintf(os.Stdout, "%v", val)
 		} else {
 			ui.Output(fmt.Sprintf("%v", val))
 		}


### PR DESCRIPTION
There appears to be an interesting bug with the Vault CLI tool with the `-field` option. If the selected field's value contains a formatting verb, e.g.: `%s`, the output of the CLI tool will contain the familiar `%!s(MISSING)` in the middle of the value.

~~The fix is simply printing with `Fprint` instead of `Fprintf` (which appears to be unnecessary anyway).~~

Edit: Simplified this even further. The Sprintf seems superfluous. Eliminating it and passing the format string to Fprintf fixes this.

Steps to reproduce, if interested:

```shell
$ vault write secret/foo password=bar%sbaz
Success! Data written to: secret/foo
$
$ vault read -field=password secret/foo
bar%!s(MISSING)baz
```