### PR TITLE
Add Duo pushinfo capabilities

### DIFF
--- a/helper/mfa/duo/duo.go
+++ b/helper/mfa/duo/duo.go
@@ -111,6 +111,11 @@ func duoHandler(duoConfig *DuoConfig, duoAuthClient AuthClient, request *duoAuth
 	if request.method == "" {
 		request.method = "auto"
 	}
+	if request.method == "auto" || request.method == "push" {
+		if duoConfig.PushInfo != "" {
+			options = append(options, authapi.AuthPushinfo(duoConfig.PushInfo))
+		}
+	}
 	if request.passcode != "" {
 		request.method = "passcode"
 		options = append(options, authapi.AuthPasscode(request.passcode))

--- a/helper/mfa/duo/path_duo_config.go
+++ b/helper/mfa/duo/path_duo_config.go
@@ -62,6 +62,7 @@ func pathDuoConfigWrite(
 	}
 	entry, err := logical.StorageEntryJSON("duo/config", DuoConfig{
 		UsernameFormat: username_format,
+		UserAgent:      d.Get("user_agent").(string),
 		PushInfo:       d.Get("push_info").(string),
 	})
 	if err != nil {
@@ -89,6 +90,7 @@ func pathDuoConfigRead(
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"username_format": config.UsernameFormat,
+			"user_agent":      config.UserAgent,
 			"push_info":       config.PushInfo,
 		},
 	}, nil

--- a/helper/mfa/duo/path_duo_config.go
+++ b/helper/mfa/duo/path_duo_config.go
@@ -20,6 +20,10 @@ func pathDuoConfig() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Format string given auth backend username as argument to create Duo username (default '%s')",
 			},
+			"push_info": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "A string of URL-encoded key/value pairs that provides additional context about the authentication attemmpt in the Duo Mobile app",
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -50,11 +54,15 @@ func GetDuoConfig(req *logical.Request) (*DuoConfig, error) {
 func pathDuoConfigWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	username_format := d.Get("username_format").(string)
+	if username_format == "" {
+		username_format = "%s"
+	}
 	if !strings.Contains(username_format, "%s") {
 		return nil, errors.New("username_format must include username ('%s')")
 	}
 	entry, err := logical.StorageEntryJSON("duo/config", DuoConfig{
 		UsernameFormat: username_format,
+		PushInfo:       d.Get("push_info").(string),
 	})
 	if err != nil {
 		return nil, err
@@ -81,6 +89,7 @@ func pathDuoConfigRead(
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"username_format": config.UsernameFormat,
+			"push_info":       config.PushInfo,
 		},
 	}, nil
 }
@@ -88,6 +97,7 @@ func pathDuoConfigRead(
 type DuoConfig struct {
 	UsernameFormat string `json:"username_format"`
 	UserAgent      string `json:"user_agent"`
+	PushInfo       string `json:"push_info"`
 }
 
 const pathDuoConfigHelpSyn = `

--- a/website/source/docs/auth/mfa.html.md
+++ b/website/source/docs/auth/mfa.html.md
@@ -89,4 +89,7 @@ that is passed the original username as its first argument and outputs
 the new username. For example "%s@example.com" would append "@example.com"
 to the provided username before connecting to Duo.
 
+`push_info` is a string of URL-encoded key/value pairs that provides additional
+context about the authentication attemmpt in the Duo Mobile application.
+
 More information can be found through the CLI `path-help` command.


### PR DESCRIPTION
Add the option to provide additional context to Duo push requests (via `push_info`) when using Duo as an MFA provider.

https://duo.com/docs/authapi#/auth