### PR TITLE
return code is 403 not 400

### DIFF
--- a/website/source/intro/getting-started/acl.html.md
+++ b/website/source/intro/getting-started/acl.html.md
@@ -102,7 +102,7 @@ $ vault write secret/foo value=yes
 Error writing data to secret/foo: Error making API request.
 
 URL: PUT http://127.0.0.1:8200/v1/secret/foo
-Code: 400. Errors:
+Code: 403. Errors:
 
 * permission denied
 ```


### PR DESCRIPTION
I noticed this while going through the docs.
Not sure if it's something that was like that before or just a typo, but that's vault v0.6.2 returns now..