### PR TITLE
Close ldap connection to avoid leak

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -101,6 +101,9 @@ func (b *backend) Login(req *logical.Request, username string, password string) 
 		return nil, logical.ErrorResponse("invalid connection returned from LDAP dial"), nil
 	}
 
+	// Clean connection
+	defer c.Close()
+
 	bindDN, err := b.getBindDN(cfg, c, username)
 	if err != nil {
 		return nil, logical.ErrorResponse(err.Error()), nil


### PR DESCRIPTION
Vault doesn't close (and leaks) connections to the ldap server.

Seems to be introduced by https://github.com/hashicorp/vault/commit/005cb3e042fedae78d38ae70684fb0724567ea0d#diff-05500c6cd4e9778b2eda4f607092739cL196