### PR TITLE
Fix TestLogical_RequestSizeLimit failure

### DIFF
--- a/http/logical.go
+++ b/http/logical.go
@@ -26,11 +26,6 @@ func buildLogicalRequest(core *vault.Core, w http.ResponseWriter, r *http.Reques
 		return nil, http.StatusNotFound, nil
 	}
 
-	// Verify the content length does not exceed the maximum size
-	if r.ContentLength >= MaxRequestSize {
-		return nil, http.StatusRequestEntityTooLarge, nil
-	}
-
 	// Determine the operation
 	var op logical.Operation
 	switch r.Method {
@@ -61,7 +56,7 @@ func buildLogicalRequest(core *vault.Core, w http.ResponseWriter, r *http.Reques
 	// Parse the request if we can
 	var data map[string]interface{}
 	if op == logical.UpdateOperation {
-		err := parseRequest(r, &data)
+		err := parseRequest(r, w, &data)
 		if err == io.EOF {
 			data = nil
 			err = nil

--- a/http/sys_generate_root.go
+++ b/http/sys_generate_root.go
@@ -80,7 +80,7 @@ func handleSysGenerateRootAttemptGet(core *vault.Core, w http.ResponseWriter, r 
 func handleSysGenerateRootAttemptPut(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 	// Parse the request
 	var req GenerateRootInitRequest
-	if err := parseRequest(r, &req); err != nil {
+	if err := parseRequest(r, w, &req); err != nil {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
@@ -113,7 +113,7 @@ func handleSysGenerateRootUpdate(core *vault.Core) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse the request
 		var req GenerateRootUpdateRequest
-		if err := parseRequest(r, &req); err != nil {
+		if err := parseRequest(r, w, &req); err != nil {
 			respondError(w, http.StatusBadRequest, err)
 			return
 		}

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -38,7 +38,7 @@ func handleSysInitGet(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 	// Parse the request
 	var req InitRequest
-	if err := parseRequest(r, &req); err != nil {
+	if err := parseRequest(r, w, &req); err != nil {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -95,7 +95,7 @@ func handleSysRekeyInitGet(core *vault.Core, recovery bool, w http.ResponseWrite
 func handleSysRekeyInitPut(core *vault.Core, recovery bool, w http.ResponseWriter, r *http.Request) {
 	// Parse the request
 	var req RekeyRequest
-	if err := parseRequest(r, &req); err != nil {
+	if err := parseRequest(r, w, &req); err != nil {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
@@ -148,7 +148,7 @@ func handleSysRekeyUpdate(core *vault.Core, recovery bool) http.Handler {
 
 		// Parse the request
 		var req RekeyUpdateRequest
-		if err := parseRequest(r, &req); err != nil {
+		if err := parseRequest(r, w, &req); err != nil {
 			respondError(w, http.StatusBadRequest, err)
 			return
 		}

--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -80,7 +80,7 @@ func handleSysUnseal(core *vault.Core) http.Handler {
 
 		// Parse the request
 		var req UnsealRequest
-		if err := parseRequest(r, &req); err != nil {
+		if err := parseRequest(r, w, &req); err != nil {
 			respondError(w, http.StatusBadRequest, err)
 			return
 		}


### PR DESCRIPTION
#2108 breaks unit tests with:

```
--- FAIL: TestLogical_RequestSizeLimit (0.19s)
	http_test.go:76: err: Put http://127.0.0.1:48199/v1/secret/foo: write tcp 127.0.0.1:34320->127.0.0.1:48199: write: connection reset by peer
```

Use `http.MaxBytesReader` to limit request size and avoid `connection reset by peer`