### PR TITLE
Transit: Support batch encryption and decryption

### DIFF
--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -23,6 +23,21 @@ const (
 	testPlaintext = "the quick brown fox"
 )
 
+func createBackendWithStorage(t *testing.T) (*backend, logical.Storage) {
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+
+	b := Backend(config)
+	if b == nil {
+		t.Fatalf("failed to create backend")
+	}
+	_, err := b.Backend.Setup(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b, config.StorageView
+}
+
 func TestBackend_basic(t *testing.T) {
 	decryptData := make(map[string]interface{})
 	logicaltest.Test(t, logicaltest.TestCase{

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -2,11 +2,39 @@ package transit
 
 import (
 	"encoding/base64"
+	"fmt"
 
 	"github.com/hashicorp/vault/helper/errutil"
+	"github.com/hashicorp/vault/helper/jsonutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
+	"github.com/mitchellh/mapstructure"
 )
+
+// BatchDecryptionItemRequest represents an item in the batch decryption
+// request
+type BatchDecryptionItemRequest struct {
+	// Context for key derivation. This is required for derived keys.
+	Context string `json:"context" structs:"context" mapstructure:"context"`
+
+	// Ciphertext for decryption
+	Ciphertext string `json:"ciphertext" structs:"ciphertext" mapstructure:"ciphertext"`
+
+	// Nonce to be used when v1 convergent encryption is used
+	Nonce string `json:"nonce" structs:"nonce" mapstructure:"nonce"`
+}
+
+// BatchDecryptionItemResponse represents an item in the batch decryption
+// response
+type BatchDecryptionItemResponse struct {
+	// Plaintext for the ciphertext present in the corresponsding batch
+	// request item
+	Plaintext string `json:"plaintext" structs:"plaintext" mapstructure:"plaintext"`
+
+	// Error, if set, represents a failure encountered while decrypting a
+	// corresponding batch request item
+	Error string `json:"error" structs:"error" mapstructure:"error"`
+}
 
 func (b *backend) pathDecrypt() *framework.Path {
 	return &framework.Path{
@@ -31,6 +59,25 @@ func (b *backend) pathDecrypt() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Nonce for when convergent encryption is used",
 			},
+
+			"batch": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: `
+Base64 encoded list of items to be decrypted in a single batch. When this
+parameter is set, if the parameters 'ciphertext', 'context' and 'nonce' are
+also set, they will be ignored. JSON format for the input goes like this:
+[
+  {
+    "context": "context1",
+    "ciphertext": "vault:v1:/DupSiSbX/ATkGmKAmhqD0tvukByrx6gmps7dVI="
+  },
+  {
+    "context": "context2",
+    "ciphertext": "vault:v1:XjsPWPjqPrBi1N2Ms2s1QM798YyFWnO4TR4lsFA="
+  },
+  ...
+]`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -44,36 +91,9 @@ func (b *backend) pathDecrypt() *framework.Path {
 
 func (b *backend) pathDecryptWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-	ciphertext := d.Get("ciphertext").(string)
-	if len(ciphertext) == 0 {
-		return logical.ErrorResponse("missing ciphertext to decrypt"), logical.ErrInvalidRequest
-	}
-
-	var err error
-
-	// Decode the context if any
-	contextRaw := d.Get("context").(string)
-	var context []byte
-	if len(contextRaw) != 0 {
-		context, err = base64.StdEncoding.DecodeString(contextRaw)
-		if err != nil {
-			return logical.ErrorResponse("failed to base64-decode context"), logical.ErrInvalidRequest
-		}
-	}
-
-	// Decode the nonce if any
-	nonceRaw := d.Get("nonce").(string)
-	var nonce []byte
-	if len(nonceRaw) != 0 {
-		nonce, err = base64.StdEncoding.DecodeString(nonceRaw)
-		if err != nil {
-			return logical.ErrorResponse("failed to base64-decode nonce"), logical.ErrInvalidRequest
-		}
-	}
 
 	// Get the policy
-	p, lock, err := b.lm.GetPolicyShared(req.Storage, name)
+	p, lock, err := b.lm.GetPolicyShared(req.Storage, d.Get("name").(string))
 	if lock != nil {
 		defer lock.RUnlock()
 	}
@@ -84,24 +104,117 @@ func (b *backend) pathDecryptWrite(
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
 	}
 
-	plaintext, err := p.Decrypt(context, nonce, ciphertext)
-	if err != nil {
-		switch err.(type) {
-		case errutil.UserError:
-			return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
-		case errutil.InternalError:
-			return nil, err
-		default:
-			return nil, err
+	batchInputRaw := d.Get("batch").(string)
+	var batchInput []byte
+	if len(batchInputRaw) != 0 {
+		batchInput, err = base64.StdEncoding.DecodeString(batchInputRaw)
+		if err != nil {
+			return logical.ErrorResponse("failed to base64-decode batch input"), logical.ErrInvalidRequest
+		}
+	} else {
+		ciphertext := d.Get("ciphertext").(string)
+		if len(ciphertext) == 0 {
+			return logical.ErrorResponse("missing ciphertext to decrypt"), logical.ErrInvalidRequest
+		}
+
+		var singleItemBatch []BatchDecryptionItemRequest
+		singleItemBatch = append(singleItemBatch, BatchDecryptionItemRequest{
+			Ciphertext: ciphertext,
+			Context:    d.Get("context").(string),
+			Nonce:      d.Get("nonce").(string),
+		})
+
+		batchInput, err = jsonutil.EncodeJSON(singleItemBatch)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode batch input")
 		}
 	}
 
-	// Generate the response
-	resp := &logical.Response{
-		Data: map[string]interface{}{
-			"plaintext": plaintext,
-		},
+	var batchInputArray []interface{}
+	if err := jsonutil.DecodeJSON([]byte(batchInput), &batchInputArray); err != nil {
+		return nil, fmt.Errorf("invalid input: %v", err)
 	}
+
+	var batchItems []BatchDecryptionItemRequest
+	var batchResponseItems []BatchDecryptionItemResponse
+	for _, batchItem := range batchInputArray {
+		var item BatchDecryptionItemRequest
+		if err := mapstructure.Decode(batchItem, &item); err != nil {
+			return logical.ErrorResponse(fmt.Sprintf("failed to parse the input: %v", err)), logical.ErrInvalidRequest
+		}
+		batchItems = append(batchItems, item)
+
+		if item.Ciphertext == "" {
+			batchResponseItems = append(batchResponseItems, BatchDecryptionItemResponse{
+				Error: "missing ciphertext to decrypt",
+			})
+			continue
+		}
+
+		var itemContext []byte
+		if len(item.Context) != 0 {
+			itemContext, err = base64.StdEncoding.DecodeString(item.Context)
+			if err != nil {
+				batchResponseItems = append(batchResponseItems, BatchDecryptionItemResponse{
+					Error: "failed to base64-decode context",
+				})
+				continue
+			}
+		}
+
+		var itemNonce []byte
+		if len(item.Nonce) != 0 {
+			itemNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
+			if err != nil {
+				batchResponseItems = append(batchResponseItems, BatchDecryptionItemResponse{
+					Error: "failed to base64-decode nonce",
+				})
+			}
+		}
+
+		plaintext, err := p.Decrypt(itemContext, itemNonce, item.Ciphertext)
+		if err != nil {
+			switch err.(type) {
+			case errutil.UserError:
+				return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+			case errutil.InternalError:
+				return nil, err
+			default:
+				return nil, err
+			}
+		}
+
+		batchResponseItems = append(batchResponseItems, BatchDecryptionItemResponse{
+			Plaintext: plaintext,
+		})
+	}
+
+	if len(batchItems) != len(batchResponseItems) {
+		return nil, fmt.Errorf("number of request and the number of response items do not match")
+	}
+
+	if len(batchResponseItems) == 0 {
+		return nil, fmt.Errorf("number of response items cannot be zero")
+	}
+
+	resp := &logical.Response{}
+	if len(batchInputRaw) != 0 {
+		batchResponseJSON, err := jsonutil.EncodeJSON(batchResponseItems)
+		if err != nil {
+			return nil, fmt.Errorf("failed to JSON encode batch response")
+		}
+		resp.Data = map[string]interface{}{
+			"data": string(batchResponseJSON),
+		}
+	} else {
+		if batchResponseItems[0].Error != "" {
+			return nil, fmt.Errorf(batchResponseItems[0].Error)
+		}
+		resp.Data = map[string]interface{}{
+			"plaintext": batchResponseItems[0].Plaintext,
+		}
+	}
+
 	return resp, nil
 }
 

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -46,18 +46,24 @@ func (b *backend) pathDecrypt() *framework.Path {
 			},
 
 			"ciphertext": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Description: "Ciphertext value to decrypt",
+				Type: framework.TypeString,
+				Description: `
+The ciphertext to decrypt, provided as returned by encrypt.`,
 			},
 
 			"context": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Description: "Context for key derivation. Required for derived keys.",
+				Type: framework.TypeString,
+				Description: `
+Base64 encoded context for key derivation. Required if key derivation is
+enabled.`,
 			},
 
 			"nonce": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Description: "Nonce for when convergent encryption is used",
+				Type: framework.TypeString,
+				Description: `
+Base64 encoded nonce value used during encryption. Must be provided if
+convergent encryption is enabled for this key and the key was generated with
+Vault 0.6.1. Not required for keys created in 0.6.2+.`,
 			},
 
 			"batch": &framework.FieldSchema{

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -176,6 +176,7 @@ func (b *backend) pathDecryptWrite(
 					Error: "failed to base64-decode nonce",
 				})
 			}
+			continue
 		}
 
 		plaintext, err := p.Decrypt(itemContext, itemNonce, item.Ciphertext)

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -120,18 +120,14 @@ func (b *backend) pathDecryptWrite(
 		}
 
 		if item.Ciphertext == "" {
-			batchResponseItems[i] = BatchResponseItem{
-				Error: "missing ciphertext to decrypt",
-			}
+			batchResponseItems[i].Error = "missing ciphertext to decrypt"
 			continue
 		}
 
 		if len(item.Context) != 0 {
 			batchInputItems[i].DecodedContext, err = base64.StdEncoding.DecodeString(item.Context)
 			if err != nil {
-				batchResponseItems[i] = BatchResponseItem{
-					Error: "failed to base64-decode context",
-				}
+				batchResponseItems[i].Error = "failed to base64-decode context"
 				continue
 			}
 		}
@@ -139,11 +135,9 @@ func (b *backend) pathDecryptWrite(
 		if len(item.Nonce) != 0 {
 			batchInputItems[i].DecodedNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
 			if err != nil {
-				batchResponseItems[i] = BatchResponseItem{
-					Error: "failed to base64-decode nonce",
-				}
+				batchResponseItems[i].Error = "failed to base64-decode nonce"
+				continue
 			}
-			continue
 		}
 	}
 
@@ -175,9 +169,7 @@ func (b *backend) pathDecryptWrite(
 				return nil, err
 			}
 		}
-		batchResponseItems[i] = BatchResponseItem{
-			Plaintext: plaintext,
-		}
+		batchResponseItems[i].Plaintext = plaintext
 	}
 
 	resp := &logical.Response{}

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -88,7 +88,7 @@ func (b *backend) pathDecryptWrite(
 		}
 
 		if len(batchInputItems) == 0 {
-			return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
+			return logical.ErrorResponse("missing batch input to process"), logical.ErrInvalidRequest
 		}
 	} else {
 		ciphertext := d.Get("ciphertext").(string)

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -136,22 +136,16 @@ func (b *backend) pathDecryptWrite(
 		}
 	}
 
-	if len(batchInputArray) == 0 {
-		return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
-	}
-
 	var contextSet bool
 	switch len(batchInputArray) {
+	case 0:
+		return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
 	case 1:
 		contextSet = batchInputArray[0].Context != ""
 	default:
-		contextSet = true
+		contextSet = batchInputArray[0].Context != ""
 		for _, item := range batchInputArray {
-			if item.Context == "" && contextSet {
-				contextSet = false
-			}
-
-			if item.Context != "" && !contextSet {
+			if (item.Context == "" && contextSet) || (item.Context != "" && !contextSet) {
 				return logical.ErrorResponse("context should be set either in all the request blocks or in none"), logical.ErrInvalidRequest
 			}
 		}

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -140,15 +140,20 @@ func (b *backend) pathDecryptWrite(
 		return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
 	}
 
-	contextSet := true
+	var contextSet bool
+	switch len(batchInputArray) {
+	case 1:
+		contextSet = batchInputArray[0].Context != ""
+	default:
+		contextSet = true
+		for _, item := range batchInputArray {
+			if item.Context == "" && contextSet {
+				contextSet = false
+			}
 
-	for _, item := range batchInputArray {
-		if item.Context == "" && contextSet {
-			contextSet = false
-		}
-
-		if item.Context != "" && !contextSet {
-			return logical.ErrorResponse("context should be set either in all the request blocks or in none"), logical.ErrInvalidRequest
+			if item.Context != "" && !contextSet {
+				return logical.ErrorResponse("context should be set either in all the request blocks or in none"), logical.ErrInvalidRequest
+			}
 		}
 	}
 

--- a/builtin/logical/transit/path_decrypt_test.go
+++ b/builtin/logical/transit/path_decrypt_test.go
@@ -1,0 +1,204 @@
+package transit
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/hashicorp/vault/helper/jsonutil"
+	"github.com/hashicorp/vault/logical"
+	"github.com/mitchellh/mapstructure"
+)
+
+// Case1: If batch decryption input is not base64 encoded, it should fail.
+func TestTransit_BatchDecryptionCase1(t *testing.T) {
+	var resp *logical.Response
+	var err error
+
+	b, s := createBackendWithStorage(t)
+
+	batchEncryptionInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="},{"plaintext":"Cg=="}]`
+	batchEncryptionInputB64 := base64.StdEncoding.EncodeToString([]byte(batchEncryptionInput))
+	batchEncryptionData := map[string]interface{}{
+		"batch": batchEncryptionInputB64,
+	}
+
+	batchEncryptionReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "encrypt/upserted_key",
+		Storage:   s,
+		Data:      batchEncryptionData,
+	}
+	resp, err = b.HandleRequest(batchEncryptionReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	batchDecryptionInput := resp.Data["data"].(string)
+	batchDecryptionData := map[string]interface{}{
+		"batch": batchDecryptionInput,
+	}
+
+	batchDecryptionReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "decrypt/upserted_key",
+		Storage:   s,
+		Data:      batchDecryptionData,
+	}
+	resp, err = b.HandleRequest(batchDecryptionReq)
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+}
+
+// Case2: Normal case of batch decryption
+func TestTransit_BatchDecryptionCase2(t *testing.T) {
+	var resp *logical.Response
+	var err error
+
+	b, s := createBackendWithStorage(t)
+
+	batchEncryptionInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="},{"plaintext":"Cg=="}]`
+	batchEncryptionInputB64 := base64.StdEncoding.EncodeToString([]byte(batchEncryptionInput))
+	batchEncryptionData := map[string]interface{}{
+		"batch": batchEncryptionInputB64,
+	}
+
+	batchEncryptionReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "encrypt/upserted_key",
+		Storage:   s,
+		Data:      batchEncryptionData,
+	}
+	resp, err = b.HandleRequest(batchEncryptionReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	batchDecryptionInput := resp.Data["data"].(string)
+	batchDecryptionInputB64 := base64.StdEncoding.EncodeToString([]byte(batchDecryptionInput))
+	batchDecryptionData := map[string]interface{}{
+		"batch": batchDecryptionInputB64,
+	}
+
+	batchDecryptionReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "decrypt/upserted_key",
+		Storage:   s,
+		Data:      batchDecryptionData,
+	}
+	resp, err = b.HandleRequest(batchDecryptionReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	var batchDecryptionResponseArray []interface{}
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchDecryptionResponseArray); err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext1 := "dGhlIHF1aWNrIGJyb3duIGZveA=="
+	plaintext2 := "Cg=="
+	for _, responseItem := range batchDecryptionResponseArray {
+		var item BatchDecryptionItemResponse
+		if err := mapstructure.Decode(responseItem, &item); err != nil {
+			t.Fatal(err)
+		}
+		if item.Plaintext != plaintext1 && item.Plaintext != plaintext2 {
+			t.Fatalf("bad: plaintext: %q", item.Plaintext)
+		}
+	}
+}
+
+// Case3: Test batch decryption with a derived key
+func TestTransit_BatchDecryptionCase3(t *testing.T) {
+	var resp *logical.Response
+	var err error
+
+	b, s := createBackendWithStorage(t)
+
+	policyData := map[string]interface{}{
+		"derived": true,
+	}
+
+	policyReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "keys/existing_key",
+		Storage:   s,
+		Data:      policyData,
+	}
+
+	resp, err = b.HandleRequest(policyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	batchInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA==",
+"context":"dmlzaGFsCg=="},{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA==",
+"context":"dmlzaGFsCg=="}]`
+
+	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
+	batchData := map[string]interface{}{
+		"batch": batchInputB64,
+	}
+	batchReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "encrypt/existing_key",
+		Storage:   s,
+		Data:      batchData,
+	}
+	resp, err = b.HandleRequest(batchReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	var decryptionRequestItems []BatchDecryptionItemRequest
+	var batchResponseArray []interface{}
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
+		t.Fatal(err)
+	}
+	for _, responseItem := range batchResponseArray {
+		var item BatchDecryptionItemRequest
+		if err := mapstructure.Decode(responseItem, &item); err != nil {
+			t.Fatal(err)
+		}
+		item.Context = "dmlzaGFsCg=="
+		decryptionRequestItems = append(decryptionRequestItems, item)
+	}
+
+	batchDecryptionInput, err := jsonutil.EncodeJSON(decryptionRequestItems)
+	if err != nil {
+		t.Fatalf("failed to encode batch decryption input")
+	}
+
+	batchDecryptionInputB64 := base64.StdEncoding.EncodeToString(batchDecryptionInput)
+	batchDecryptionData := map[string]interface{}{
+		"batch": batchDecryptionInputB64,
+	}
+
+	batchDecryptionReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "decrypt/existing_key",
+		Storage:   s,
+		Data:      batchDecryptionData,
+	}
+	resp, err = b.HandleRequest(batchDecryptionReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	var batchDecryptionResponseArray []interface{}
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchDecryptionResponseArray); err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
+	for _, responseItem := range batchDecryptionResponseArray {
+		var item BatchDecryptionItemResponse
+		if err := mapstructure.Decode(responseItem, &item); err != nil {
+			t.Fatal(err)
+		}
+		if item.Plaintext != plaintext {
+			t.Fatalf("bad: plaintext. Expected: %q, Actual: %q", plaintext, item.Plaintext)
+		}
+	}
+}

--- a/builtin/logical/transit/path_decrypt_test.go
+++ b/builtin/logical/transit/path_decrypt_test.go
@@ -152,7 +152,7 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, item := range batchResponseArray {
-		item.Context = "dmlzaGFsCg=="
+		item.Context = []byte("dmlzaGFsCg==")
 		decryptionRequestItems = append(decryptionRequestItems, item)
 	}
 

--- a/builtin/logical/transit/path_decrypt_test.go
+++ b/builtin/logical/transit/path_decrypt_test.go
@@ -90,7 +90,7 @@ func TestTransit_BatchDecryptionCase2(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var batchDecryptionResponseArray []BatchDecryptionItemResponse
+	var batchDecryptionResponseArray []BatchResponseItem
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchDecryptionResponseArray); err != nil {
 		t.Fatal(err)
 	}
@@ -146,8 +146,8 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var decryptionRequestItems []BatchDecryptionItemRequest
-	var batchResponseArray []BatchDecryptionItemRequest
+	var decryptionRequestItems []BatchRequestItem
+	var batchResponseArray []BatchRequestItem
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var batchDecryptionResponseArray []BatchDecryptionItemResponse
+	var batchDecryptionResponseArray []BatchResponseItem
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchDecryptionResponseArray); err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/transit/path_decrypt_test.go
+++ b/builtin/logical/transit/path_decrypt_test.go
@@ -128,8 +128,8 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 	}
 
 	batchInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA==",
-"context":"dmlzaGFsCg=="},{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA==",
-"context":"dmlzaGFsCg=="}]`
+"context":"dGVzdGNvbnRleHQ="},{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA==",
+"context":"dGVzdGNvbnRleHQ="}]`
 
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
@@ -152,7 +152,7 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, item := range batchResponseArray {
-		item.Context = []byte("dmlzaGFsCg==")
+		item.Context = []byte("testcontext")
 		decryptionRequestItems = append(decryptionRequestItems, item)
 	}
 

--- a/builtin/logical/transit/path_decrypt_test.go
+++ b/builtin/logical/transit/path_decrypt_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/vault/helper/jsonutil"
 	"github.com/hashicorp/vault/logical"
-	"github.com/mitchellh/mapstructure"
 )
 
 // Case1: If batch decryption input is not base64 encoded, it should fail.
@@ -91,18 +90,14 @@ func TestTransit_BatchDecryptionCase2(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var batchDecryptionResponseArray []interface{}
+	var batchDecryptionResponseArray []BatchDecryptionItemResponse
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchDecryptionResponseArray); err != nil {
 		t.Fatal(err)
 	}
 
 	plaintext1 := "dGhlIHF1aWNrIGJyb3duIGZveA=="
 	plaintext2 := "Cg=="
-	for _, responseItem := range batchDecryptionResponseArray {
-		var item BatchDecryptionItemResponse
-		if err := mapstructure.Decode(responseItem, &item); err != nil {
-			t.Fatal(err)
-		}
+	for _, item := range batchDecryptionResponseArray {
 		if item.Plaintext != plaintext1 && item.Plaintext != plaintext2 {
 			t.Fatalf("bad: plaintext: %q", item.Plaintext)
 		}
@@ -152,15 +147,11 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 	}
 
 	var decryptionRequestItems []BatchDecryptionItemRequest
-	var batchResponseArray []interface{}
+	var batchResponseArray []BatchDecryptionItemRequest
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
-	for _, responseItem := range batchResponseArray {
-		var item BatchDecryptionItemRequest
-		if err := mapstructure.Decode(responseItem, &item); err != nil {
-			t.Fatal(err)
-		}
+	for _, item := range batchResponseArray {
 		item.Context = "dmlzaGFsCg=="
 		decryptionRequestItems = append(decryptionRequestItems, item)
 	}
@@ -186,17 +177,13 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var batchDecryptionResponseArray []interface{}
+	var batchDecryptionResponseArray []BatchDecryptionItemResponse
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchDecryptionResponseArray); err != nil {
 		t.Fatal(err)
 	}
 
 	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
-	for _, responseItem := range batchDecryptionResponseArray {
-		var item BatchDecryptionItemResponse
-		if err := mapstructure.Decode(responseItem, &item); err != nil {
-			t.Fatal(err)
-		}
+	for _, item := range batchDecryptionResponseArray {
 		if item.Plaintext != plaintext {
 			t.Fatalf("bad: plaintext. Expected: %q, Actual: %q", plaintext, item.Plaintext)
 		}

--- a/builtin/logical/transit/path_decrypt_test.go
+++ b/builtin/logical/transit/path_decrypt_test.go
@@ -18,7 +18,7 @@ func TestTransit_BatchDecryptionCase1(t *testing.T) {
 	batchEncryptionInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="},{"plaintext":"Cg=="}]`
 	batchEncryptionInputB64 := base64.StdEncoding.EncodeToString([]byte(batchEncryptionInput))
 	batchEncryptionData := map[string]interface{}{
-		"batch": batchEncryptionInputB64,
+		"batch_input": batchEncryptionInputB64,
 	}
 
 	batchEncryptionReq := &logical.Request{
@@ -32,9 +32,9 @@ func TestTransit_BatchDecryptionCase1(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchDecryptionInput := resp.Data["data"].(string)
+	batchDecryptionInput := resp.Data["batch_results"].(string)
 	batchDecryptionData := map[string]interface{}{
-		"batch": batchDecryptionInput,
+		"batch_input": batchDecryptionInput,
 	}
 
 	batchDecryptionReq := &logical.Request{
@@ -59,7 +59,7 @@ func TestTransit_BatchDecryptionCase2(t *testing.T) {
 	batchEncryptionInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="},{"plaintext":"Cg=="}]`
 	batchEncryptionInputB64 := base64.StdEncoding.EncodeToString([]byte(batchEncryptionInput))
 	batchEncryptionData := map[string]interface{}{
-		"batch": batchEncryptionInputB64,
+		"batch_input": batchEncryptionInputB64,
 	}
 
 	batchEncryptionReq := &logical.Request{
@@ -73,10 +73,10 @@ func TestTransit_BatchDecryptionCase2(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchDecryptionInput := resp.Data["data"].(string)
+	batchDecryptionInput := resp.Data["batch_results"].(string)
 	batchDecryptionInputB64 := base64.StdEncoding.EncodeToString([]byte(batchDecryptionInput))
 	batchDecryptionData := map[string]interface{}{
-		"batch": batchDecryptionInputB64,
+		"batch_input": batchDecryptionInputB64,
 	}
 
 	batchDecryptionReq := &logical.Request{
@@ -91,7 +91,7 @@ func TestTransit_BatchDecryptionCase2(t *testing.T) {
 	}
 
 	var batchDecryptionResponseArray []BatchResponseItem
-	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchDecryptionResponseArray); err != nil {
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["batch_results"].(string)), &batchDecryptionResponseArray); err != nil {
 		t.Fatal(err)
 	}
 
@@ -133,7 +133,7 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 	batchReq := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -148,7 +148,7 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 
 	var decryptionRequestItems []BatchRequestItem
 	var batchResponseArray []BatchRequestItem
-	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["batch_results"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
 	for _, item := range batchResponseArray {
@@ -163,7 +163,7 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 
 	batchDecryptionInputB64 := base64.StdEncoding.EncodeToString(batchDecryptionInput)
 	batchDecryptionData := map[string]interface{}{
-		"batch": batchDecryptionInputB64,
+		"batch_input": batchDecryptionInputB64,
 	}
 
 	batchDecryptionReq := &logical.Request{
@@ -178,7 +178,7 @@ func TestTransit_BatchDecryptionCase3(t *testing.T) {
 	}
 
 	var batchDecryptionResponseArray []BatchResponseItem
-	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchDecryptionResponseArray); err != nil {
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["batch_results"].(string)), &batchDecryptionResponseArray); err != nil {
 		t.Fatal(err)
 	}
 

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -6,10 +6,27 @@ import (
 	"sync"
 
 	"github.com/hashicorp/vault/helper/errutil"
+	"github.com/hashicorp/vault/helper/jsonutil"
 	"github.com/hashicorp/vault/helper/keysutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
+	"github.com/mitchellh/mapstructure"
 )
+
+const (
+	MB int = 1048 * 1048
+)
+
+type BatchEncryptionItemRequest struct {
+	Context   string `json:"context" structs:"context" mapstructure:"context"`
+	Plaintext string `json:"plaintext" structs:"plaintext" mapstructure:"plaintext"`
+	Nonce     string `json:"nonce" structs:"nonce" mapstructure:"nonce"`
+}
+
+type BatchEncryptionItemResponse struct {
+	CipherText string `json:"ciphertext" structs:"ciphertext" mapstructure:"ciphertext"`
+	Error      string `json:"error" structs:"error" mapstructure:"error"`
+}
 
 func (b *backend) pathEncrypt() *framework.Path {
 	return &framework.Path{
@@ -27,36 +44,65 @@ func (b *backend) pathEncrypt() *framework.Path {
 
 			"context": &framework.FieldSchema{
 				Type:        framework.TypeString,
-				Description: "Context for key derivation. Required for derived keys.",
+				Description: "Base64 encoded context for key derivation. Required for derived keys.",
 			},
 
 			"nonce": &framework.FieldSchema{
 				Type:        framework.TypeString,
-				Description: "Nonce for when convergent encryption is used",
+				Description: "Base64 encoded nonce for when convergent encryption is used",
 			},
 
 			"type": &framework.FieldSchema{
 				Type:    framework.TypeString,
 				Default: "aes256-gcm96",
-				Description: `When performing an upsert operation, the type of key
-to create. Currently, "aes256-gcm96" (symmetric) is the
-only type supported. Defaults to "aes256-gcm96".`,
+				Description: `
+This parameter is required when encryption key is expected to be created.
+When performing an upsert operation, the type of key to create. Currently,
+"aes256-gcm96" (symmetric) is the only type supported. Defaults to
+"aes256-gcm96".`,
 			},
 
 			"convergent_encryption": &framework.FieldSchema{
 				Type: framework.TypeBool,
-				Description: `Whether to support convergent encryption.
-This is only supported when using a key with
-key derivation enabled and will require all
-requests to carry both a context and 96-bit
-(12-byte) nonce. The given nonce will be used
-in place of a randomly generated nonce. As a
-result, when the same context and nonce are
-supplied, the same ciphertext is generated. It
-is *very important* when using this mode that
-you ensure that all nonces are unique for a
-given context. Failing to do so will severely
-impact the ciphertext's security.`,
+				Description: `
+This parameter will only be used when a key is expected to be created.  Whether
+to support convergent encryption. This is only supported when using a key with
+key derivation enabled and will require all requests to carry both a context
+and 96-bit (12-byte) nonce. The given nonce will be used in place of a randomly
+generated nonce. As a result, when the same context and nonce are supplied, the
+same ciphertext is generated. It is *very important* when using this mode that
+you ensure that all nonces are unique for a given context.  Failing to do so
+will severely impact the ciphertext's security.`,
+			},
+
+			"derived": &framework.FieldSchema{
+				Type: framework.TypeBool,
+				Description: `
+This parameter will only be used when a key is expected to be created.  Enables
+key derivation mode. This allows for per-transaction unique keys for encryption
+operations.`,
+			},
+
+			"batch": &framework.FieldSchema{
+				Type:    framework.TypeString,
+				Default: "",
+				Description: `
+Base64 encoded list of items to be encrypted in a single batch. The size of the
+input is limited to 4MB. When this parameter is set, the parameters
+'plaintext', 'context' and 'nonce' will be ignored. JSON format for the input
+goes like this:
+
+[
+  {
+    "context": "context1",
+    "plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA=="
+  },
+  {
+    "context": "context2",
+    "plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA=="
+  },
+  ...
+]`,
 			},
 		},
 
@@ -88,48 +134,19 @@ func (b *backend) pathEncryptExistenceCheck(
 func (b *backend) pathEncryptWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
-
-	valueRaw, ok := d.GetOk("plaintext")
-	if !ok {
-		return logical.ErrorResponse("missing plaintext to encrypt"), logical.ErrInvalidRequest
-	}
-	value := valueRaw.(string)
-
-	// Decode the context if any
-	contextRaw := d.Get("context").(string)
-	var context []byte
 	var err error
-	if len(contextRaw) != 0 {
-		context, err = base64.StdEncoding.DecodeString(contextRaw)
-		if err != nil {
-			return logical.ErrorResponse("failed to base64-decode context"), logical.ErrInvalidRequest
-		}
-	}
 
-	// Decode the nonce if any
-	nonceRaw := d.Get("nonce").(string)
-	var nonce []byte
-	if len(nonceRaw) != 0 {
-		nonce, err = base64.StdEncoding.DecodeString(nonceRaw)
-		if err != nil {
-			return logical.ErrorResponse("failed to base64-decode nonce"), logical.ErrInvalidRequest
-		}
-	}
+	convergent := d.Get("convergent_encryption").(bool)
 
 	// Get the policy
 	var p *keysutil.Policy
 	var lock *sync.RWMutex
 	var upserted bool
 	if req.Operation == logical.CreateOperation {
-		convergent := d.Get("convergent_encryption").(bool)
-		if convergent && len(context) == 0 {
-			return logical.ErrorResponse("convergent encryption requires derivation to be enabled, so context is required"), nil
-		}
-
 		polReq := keysutil.PolicyRequest{
 			Storage:    req.Storage,
 			Name:       name,
-			Derived:    len(context) != 0,
+			Derived:    d.Get("derived").(bool),
 			Convergent: convergent,
 		}
 
@@ -156,6 +173,145 @@ func (b *backend) pathEncryptWrite(
 	}
 	if p == nil {
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
+	}
+
+	batchInputRaw := d.Get("batch").(string)
+	var batchInput []byte
+	if len(batchInputRaw) != 0 {
+		batchInput, err = base64.StdEncoding.DecodeString(batchInputRaw)
+		if err != nil {
+			return logical.ErrorResponse("failed to base64-decode batch"), logical.ErrInvalidRequest
+		}
+	}
+
+	if len(batchInput) != 0 {
+		// The size of the batch input is limited to 4MB
+		if len(batchInput) > 4*MB {
+			return logical.ErrorResponse("Input for batch encryption should be less than 4MB"), logical.ErrInvalidRequest
+		}
+
+		var batchInputArray []interface{}
+		if err := jsonutil.DecodeJSON([]byte(batchInput), &batchInputArray); err != nil {
+			return nil, err
+		}
+
+		var batchItems []BatchEncryptionItemRequest
+		var batchResponseItems []BatchEncryptionItemResponse
+
+		// Process batch request items. If encryption of any request
+		// item fails, respectively mark the error in the response
+		// collection and continue to process other items.
+		for _, batchItem := range batchInputArray {
+			var item BatchEncryptionItemRequest
+			if err := mapstructure.Decode(batchItem, &item); err != nil {
+				batchResponseItems = append(batchResponseItems, BatchEncryptionItemResponse{
+					Error: fmt.Sprintf("failed to decode the request: %v", err),
+				})
+				continue
+			}
+			batchItems = append(batchItems, item)
+
+			if item.Plaintext == "" {
+				batchResponseItems = append(batchResponseItems, BatchEncryptionItemResponse{
+					Error: "missing plaintext to encrypt",
+				})
+				continue
+			}
+
+			// Decode the context
+			var itemContext []byte
+			if len(item.Context) != 0 {
+				itemContext, err = base64.StdEncoding.DecodeString(item.Context)
+				if err != nil {
+					batchResponseItems = append(batchResponseItems, BatchEncryptionItemResponse{
+						Error: "failed to base64-decode context",
+					})
+					continue
+				}
+			}
+
+			// Decode the nonce
+			var itemNonce []byte
+			if len(item.Nonce) != 0 {
+				itemNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
+				if err != nil {
+					batchResponseItems = append(batchResponseItems, BatchEncryptionItemResponse{
+						Error: "failed to base64-decode nonce",
+					})
+					continue
+				}
+			}
+
+			ciphertext, err := p.Encrypt(itemContext, itemNonce, item.Plaintext)
+			if err != nil {
+				batchResponseItems = append(batchResponseItems, BatchEncryptionItemResponse{
+					Error: fmt.Sprintf("encryption failed: %s", err.Error()),
+				})
+				continue
+			}
+
+			if ciphertext == "" {
+				batchResponseItems = append(batchResponseItems, BatchEncryptionItemResponse{
+					Error: "empty ciphertext returned",
+				})
+				continue
+			}
+
+			batchResponseItems = append(batchResponseItems, BatchEncryptionItemResponse{
+				CipherText: ciphertext,
+			})
+		}
+
+		if len(batchItems) != len(batchResponseItems) {
+			return nil, fmt.Errorf("number of request and the response items does not match")
+		}
+
+		batchResponseJSON, err := jsonutil.EncodeJSON(batchResponseItems)
+		if err != nil {
+			return nil, fmt.Errorf("failed to JSON encode batch response")
+		}
+
+		// Generate the response
+		resp := &logical.Response{
+			Data: map[string]interface{}{
+				"data": batchResponseJSON,
+			},
+		}
+
+		if req.Operation == logical.CreateOperation && !upserted {
+			resp.AddWarning("Attempted creation of the key during the encrypt operation, but it was created beforehand")
+		}
+		return resp, nil
+	}
+
+	valueRaw, ok := d.GetOk("plaintext")
+	if !ok {
+		return logical.ErrorResponse("missing plaintext to encrypt"), logical.ErrInvalidRequest
+	}
+	value := valueRaw.(string)
+
+	// Decode the context if any
+	contextRaw := d.Get("context").(string)
+	var context []byte
+	if len(contextRaw) != 0 {
+		context, err = base64.StdEncoding.DecodeString(contextRaw)
+		if err != nil {
+			return logical.ErrorResponse("failed to base64-decode context"), logical.ErrInvalidRequest
+		}
+	}
+
+	if convergent && len(context) == 0 {
+		return logical.ErrorResponse("convergent encryption requires derivation to be enabled, so context is required"), nil
+	}
+
+	// Decode the nonce if any
+	nonceRaw := d.Get("nonce").(string)
+	var nonce []byte
+	if len(nonceRaw) != 0 {
+		nonce, err = base64.StdEncoding.DecodeString(nonceRaw)
+		if err != nil {
+			return logical.ErrorResponse("failed to base64-decode nonce"), logical.ErrInvalidRequest
+		}
 	}
 
 	ciphertext, err := p.Encrypt(context, nonce, value)

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -249,6 +249,22 @@ func (b *backend) pathEncryptWrite(
 	// item fails, respectively mark the error in the response
 	// collection and continue to process other items.
 	for _, item := range batchItems {
+		// Decode the plaintext
+		if len(item.Plaintext) == 0 {
+			batchResponseItems = append(batchResponseItems, BatchEncryptionItemResponse{
+				Error: "missing plaintext to encrypt",
+			})
+			continue
+		}
+
+		_, err := base64.StdEncoding.DecodeString(item.Plaintext)
+		if err != nil {
+			batchResponseItems = append(batchResponseItems, BatchEncryptionItemResponse{
+				Error: "failed to base64-decode plaintext",
+			})
+			continue
+		}
+
 		// Decode the context
 		var itemContext []byte
 		if len(item.Context) != 0 {

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -319,13 +319,12 @@ func (b *backend) pathEncryptWrite(
 			return nil, fmt.Errorf("failed to JSON encode batch response")
 		}
 		resp.Data = map[string]interface{}{
-			"data": batchResponseJSON,
+			"data": string(batchResponseJSON),
 		}
 	} else {
 		if batchResponseItems[0].Error != "" {
 			return nil, fmt.Errorf(batchResponseItems[0].Error)
 		}
-
 		resp.Data = map[string]interface{}{
 			"ciphertext": batchResponseItems[0].Ciphertext,
 		}

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -14,7 +14,7 @@ import (
 )
 
 // BatchEncryptionItemRequest represents an item in the batch encryption
-// request.
+// request
 type BatchEncryptionItemRequest struct {
 	// Context for key derivation. This is required for derived keys.
 	Context string `json:"context" structs:"context" mapstructure:"context"`
@@ -27,14 +27,14 @@ type BatchEncryptionItemRequest struct {
 }
 
 // BatchEncryptionItemResponse represents an item in the batch encryption
-// response.
+// response
 type BatchEncryptionItemResponse struct {
 	// Ciphertext for the plaintext present in the corresponding batch
-	// request item.
+	// request item
 	Ciphertext string `json:"ciphertext" structs:"ciphertext" mapstructure:"ciphertext"`
 
 	// Error, if set represents a failure encountered which encrypting a
-	// corresponding batch request item.
+	// corresponding batch request item
 	Error string `json:"error" structs:"error" mapstructure:"error"`
 }
 
@@ -92,8 +92,7 @@ will severely impact the ciphertext's security.`,
 			},
 
 			"batch": &framework.FieldSchema{
-				Type:    framework.TypeString,
-				Default: "",
+				Type: framework.TypeString,
 				Description: `
 Base64 encoded list of items to be encrypted in a single batch. When this
 parameter is set, if the parameters 'plaintext', 'context' and 'nonce' are also
@@ -148,7 +147,7 @@ func (b *backend) pathEncryptWrite(
 	if len(batchInputRaw) != 0 {
 		batchInput, err = base64.StdEncoding.DecodeString(batchInputRaw)
 		if err != nil {
-			return logical.ErrorResponse("failed to base64-decode batch"), logical.ErrInvalidRequest
+			return logical.ErrorResponse("failed to base64-decode batch input"), logical.ErrInvalidRequest
 		}
 	} else {
 		valueRaw, ok := d.GetOk("plaintext")
@@ -162,6 +161,7 @@ func (b *backend) pathEncryptWrite(
 			Context:   d.Get("context").(string),
 			Nonce:     d.Get("nonce").(string),
 		})
+
 		batchInput, err = jsonutil.EncodeJSON(singleItemBatch)
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode batch input")
@@ -314,7 +314,7 @@ func (b *backend) pathEncryptWrite(
 	}
 
 	if len(batchItems) != len(batchResponseItems) {
-		return nil, fmt.Errorf("number of request and the response items does not match")
+		return nil, fmt.Errorf("number of request and the number of response items do not match")
 	}
 
 	if len(batchResponseItems) == 0 {

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -13,10 +13,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-const (
-	MB int = 1048 * 1048
-)
-
 type BatchEncryptionItemRequest struct {
 	Context   string `json:"context" structs:"context" mapstructure:"context"`
 	Plaintext string `json:"plaintext" structs:"plaintext" mapstructure:"plaintext"`
@@ -49,7 +45,7 @@ func (b *backend) pathEncrypt() *framework.Path {
 
 			"nonce": &framework.FieldSchema{
 				Type:        framework.TypeString,
-				Description: "Base64 encoded nonce for when convergent encryption is used",
+				Description: "Base64 encoded nonce for when v1 convergent encryption is used",
 			},
 
 			"type": &framework.FieldSchema{
@@ -87,10 +83,9 @@ operations.`,
 				Type:    framework.TypeString,
 				Default: "",
 				Description: `
-Base64 encoded list of items to be encrypted in a single batch. The size of the
-input is limited to 4MB. When this parameter is set, the parameters
-'plaintext', 'context' and 'nonce' will be ignored. JSON format for the input
-goes like this:
+Base64 encoded list of items to be encrypted in a single batch. When this
+parameter is set, if the parameters 'plaintext', 'context' and 'nonce' are also
+set, they will be ignored. JSON format for the input goes like this:
 
 [
   {
@@ -185,11 +180,6 @@ func (b *backend) pathEncryptWrite(
 	}
 
 	if len(batchInput) != 0 {
-		// The size of the batch input is limited to 4MB
-		if len(batchInput) > 4*MB {
-			return logical.ErrorResponse("Input for batch encryption should be less than 4MB"), logical.ErrInvalidRequest
-		}
-
 		var batchInputArray []interface{}
 		if err := jsonutil.DecodeJSON([]byte(batchInput), &batchInputArray); err != nil {
 			return nil, err

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -249,13 +249,6 @@ func (b *backend) pathEncryptWrite(
 	// item fails, respectively mark the error in the response
 	// collection and continue to process other items.
 	for _, item := range batchItems {
-		if item.Plaintext == "" {
-			batchResponseItems = append(batchResponseItems, BatchEncryptionItemResponse{
-				Error: "missing plaintext to encrypt",
-			})
-			continue
-		}
-
 		// Decode the context
 		var itemContext []byte
 		if len(item.Context) != 0 {

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -33,7 +33,7 @@ type BatchEncryptionItemResponse struct {
 	// request item
 	Ciphertext string `json:"ciphertext" structs:"ciphertext" mapstructure:"ciphertext"`
 
-	// Error, if set represents a failure encountered which encrypting a
+	// Error, if set represents a failure encountered while encrypting a
 	// corresponding batch request item
 	Error string `json:"error" structs:"error" mapstructure:"error"`
 }

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -161,7 +161,7 @@ func (b *backend) pathEncryptWrite(
 		}
 
 		if len(batchInputItems) == 0 {
-			return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
+			return logical.ErrorResponse("missing batch input to process"), logical.ErrInvalidRequest
 		}
 	} else {
 		valueRaw, ok := d.GetOk("plaintext")

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -168,26 +168,20 @@ func (b *backend) pathEncryptWrite(
 		}
 	}
 
-	if len(batchInputArray) == 0 {
-		return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
-	}
-
 	var contextSet bool
 	switch len(batchInputArray) {
+	case 0:
+		return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
 	case 1:
 		contextSet = batchInputArray[0].Context != ""
 	default:
-		contextSet = true
+		contextSet = batchInputArray[0].Context != ""
 		// Before processing the batch request items, get the policy. If the
 		// policy is supposed to be upserted, then determine if 'derived' is to
 		// be set or not, based on the presence of 'context' field in all the
 		// input items.
 		for _, item := range batchInputArray {
-			if item.Context == "" && contextSet {
-				contextSet = false
-			}
-
-			if item.Context != "" && !contextSet {
+			if (item.Context == "" && contextSet) || (item.Context != "" && !contextSet) {
 				return logical.ErrorResponse("context should be set either in all the request blocks or in none"), logical.ErrInvalidRequest
 			}
 		}

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -39,15 +39,15 @@ type BatchRequestItem struct {
 type BatchResponseItem struct {
 	// Ciphertext for the plaintext present in the corresponding batch
 	// request item
-	Ciphertext string `json:"omitempty,ciphertext" structs:"ciphertext" mapstructure:"ciphertext"`
+	Ciphertext string `json:"ciphertext,omitempty" structs:"ciphertext" mapstructure:"ciphertext"`
 
 	// Plaintext for the ciphertext present in the corresponsding batch
 	// request item
-	Plaintext string `json:"omitempty,plaintext" structs:"plaintext" mapstructure:"plaintext"`
+	Plaintext string `json:"plaintext,omitempty" structs:"plaintext" mapstructure:"plaintext"`
 
 	// Error, if set represents a failure encountered while encrypting a
 	// corresponding batch request item
-	Error string `json:"omitempty,error" structs:"error" mapstructure:"error"`
+	Error string `json:"error,omitempty" structs:"error" mapstructure:"error"`
 }
 
 func (b *backend) pathEncrypt() *framework.Path {
@@ -205,9 +205,7 @@ func (b *backend) pathEncryptWrite(
 
 		_, err := base64.StdEncoding.DecodeString(item.Plaintext)
 		if err != nil {
-			batchResponseItems[i] = BatchResponseItem{
-				Error: "failed to base64-decode plaintext",
-			}
+			batchResponseItems[i].Error = "failed to base64-decode plaintext"
 			continue
 		}
 
@@ -215,9 +213,7 @@ func (b *backend) pathEncryptWrite(
 		if len(item.Context) != 0 {
 			batchInputItems[i].DecodedContext, err = base64.StdEncoding.DecodeString(item.Context)
 			if err != nil {
-				batchResponseItems[i] = BatchResponseItem{
-					Error: "failed to base64-decode context",
-				}
+				batchResponseItems[i].Error = "failed to base64-decode context"
 				continue
 			}
 		}
@@ -226,9 +222,7 @@ func (b *backend) pathEncryptWrite(
 		if len(item.Nonce) != 0 {
 			batchInputItems[i].DecodedNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
 			if err != nil {
-				batchResponseItems[i] = BatchResponseItem{
-					Error: "failed to base64-decode nonce",
-				}
+				batchResponseItems[i].Error = "failed to base64-decode nonce"
 				continue
 			}
 		}
@@ -297,15 +291,11 @@ func (b *backend) pathEncryptWrite(
 		}
 
 		if ciphertext == "" {
-			batchResponseItems[i] = BatchResponseItem{
-				Error: "empty ciphertext returned",
-			}
+			batchResponseItems[i].Error = "empty ciphertext returned"
 			continue
 		}
 
-		batchResponseItems[i] = BatchResponseItem{
-			Ciphertext: ciphertext,
-		}
+		batchResponseItems[i].Ciphertext = ciphertext
 	}
 
 	resp := &logical.Response{}

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -192,14 +192,6 @@ func (b *backend) pathEncryptWrite(
 			return logical.ErrorResponse("context should be set either in all the request blocks or in none"), logical.ErrInvalidRequest
 		}
 
-		// Decode the plaintext
-		if len(item.Plaintext) == 0 {
-			batchResponseItems[i] = BatchEncryptionItemResponse{
-				Error: "missing plaintext to encrypt",
-			}
-			continue
-		}
-
 		_, err := base64.StdEncoding.DecodeString(item.Plaintext)
 		if err != nil {
 			batchResponseItems[i] = BatchEncryptionItemResponse{

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -274,8 +274,7 @@ func (b *backend) pathEncryptWrite(
 		}
 
 		if ciphertext == "" {
-			batchResponseItems[i].Error = "empty ciphertext returned"
-			continue
+			return nil, fmt.Errorf("empty ciphertext returned for input item %d", i)
 		}
 
 		batchResponseItems[i].Ciphertext = ciphertext

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -1,0 +1,214 @@
+package transit
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/hashicorp/vault/helper/jsonutil"
+	"github.com/hashicorp/vault/logical"
+	"github.com/mitchellh/mapstructure"
+)
+
+// Case1: Ensure that batch encryption did not affect the normal flow of
+// encrypting the plaintext with a pre-existing key.
+func TestTransit_BatchEncryptionCase1(t *testing.T) {
+	var resp *logical.Response
+	var err error
+	b, s := createBackendWithStorage(t)
+
+	// Create the policy
+	policyReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "keys/existing_key",
+		//Data:      policyData,
+		Storage: s,
+	}
+	resp, err = b.HandleRequest(policyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
+
+	encData := map[string]interface{}{
+		"plaintext": plaintext,
+	}
+
+	encReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "encrypt/existing_key",
+		Storage:   s,
+		Data:      encData,
+	}
+	resp, err = b.HandleRequest(encReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	ciphertext := resp.Data["ciphertext"]
+
+	decData := map[string]interface{}{
+		"ciphertext": ciphertext,
+	}
+	decReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "decrypt/existing_key",
+		Storage:   s,
+		Data:      decData,
+	}
+	resp, err = b.HandleRequest(decReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	if resp.Data["plaintext"] != plaintext {
+		t.Fatalf("bad: plaintext. Expected: %q, Actual: %q", plaintext, resp.Data["plaintext"])
+	}
+}
+
+// Case2: Ensure that batch encryption did not affect the normal flow of
+// encrypting the plaintext with the key upserted.
+func TestTransit_BatchEncryptionCase2(t *testing.T) {
+	var resp *logical.Response
+	var err error
+	b, s := createBackendWithStorage(t)
+
+	// Upsert the key and encrypt the data
+	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
+
+	encData := map[string]interface{}{
+		"plaintext": plaintext,
+	}
+
+	encReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "encrypt/upserted_key",
+		Storage:   s,
+		Data:      encData,
+	}
+	resp, err = b.HandleRequest(encReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	ciphertext := resp.Data["ciphertext"]
+	decData := map[string]interface{}{
+		"ciphertext": ciphertext,
+	}
+
+	policyReq := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "keys/upserted_key",
+		Storage:   s,
+	}
+
+	resp, err = b.HandleRequest(policyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	decReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "decrypt/upserted_key",
+		Storage:   s,
+		Data:      decData,
+	}
+	resp, err = b.HandleRequest(decReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	if resp.Data["plaintext"] != plaintext {
+		t.Fatalf("bad: plaintext. Expected: %q, Actual: %q", plaintext, resp.Data["plaintext"])
+	}
+}
+
+// Case3: If batch encryption input is not base64 encoded, it should fail.
+func TestTransit_BatchEncryptionCase3(t *testing.T) {
+	var err error
+
+	b, s := createBackendWithStorage(t)
+
+	batchInput := `[ {"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="}]`
+	batchData := map[string]interface{}{
+		"batch": batchInput,
+	}
+
+	batchReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "encrypt/upserted_key",
+		Storage:   s,
+		Data:      batchData,
+	}
+	_, err = b.HandleRequest(batchReq)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+}
+
+// Case4: Test batch encryption for with an existing key
+func TestTransit_BatchEncryptionCase4(t *testing.T) {
+	var resp *logical.Response
+	var err error
+
+	b, s := createBackendWithStorage(t)
+
+	policyReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "keys/existing_key",
+		Storage:   s,
+	}
+	resp, err = b.HandleRequest(policyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	batchInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="},{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="}]`
+	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
+	batchData := map[string]interface{}{
+		"batch": batchInputB64,
+	}
+	batchReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "encrypt/existing_key",
+		Storage:   s,
+		Data:      batchData,
+	}
+	resp, err = b.HandleRequest(batchReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	var responseItems []BatchEncryptionItemResponse
+	var batchResponseArray []interface{}
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
+		t.Fatal(err)
+	}
+
+	decReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "decrypt/existing_key",
+		Storage:   s,
+	}
+
+	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
+
+	for _, responseItem := range batchResponseArray {
+		var item BatchEncryptionItemResponse
+		if err := mapstructure.Decode(responseItem, &item); err != nil {
+			t.Fatal(err)
+		}
+		responseItems = append(responseItems, item)
+		decReq.Data = map[string]interface{}{
+			"ciphertext": item.Ciphertext,
+		}
+		resp, err = b.HandleRequest(decReq)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%v resp:%#v", err, resp)
+		}
+
+		if resp.Data["plaintext"] != plaintext {
+			t.Fatalf("bad: plaintext. Expected: %q, Actual: %q", plaintext, resp.Data["plaintext"])
+		}
+	}
+}

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -437,8 +437,8 @@ func TestTransit_BatchEncryptionCase8(t *testing.T) {
 		Data:      batchData,
 	}
 	resp, err = b.HandleRequest(batchReq)
-	if err == nil {
-		t.Fatal("expected an error")
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
 	plaintext := "simple plaintext"

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -178,7 +178,6 @@ func TestTransit_BatchEncryptionCase4(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var responseItems []BatchEncryptionItemResponse
 	var batchResponseArray []interface{}
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
@@ -197,7 +196,6 @@ func TestTransit_BatchEncryptionCase4(t *testing.T) {
 		if err := mapstructure.Decode(responseItem, &item); err != nil {
 			t.Fatal(err)
 		}
-		responseItems = append(responseItems, item)
 		decReq.Data = map[string]interface{}{
 			"ciphertext": item.Ciphertext,
 		}
@@ -254,7 +252,6 @@ func TestTransit_BatchEncryptionCase5(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var responseItems []BatchEncryptionItemResponse
 	var batchResponseArray []interface{}
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
@@ -273,7 +270,6 @@ func TestTransit_BatchEncryptionCase5(t *testing.T) {
 		if err := mapstructure.Decode(responseItem, &item); err != nil {
 			t.Fatal(err)
 		}
-		responseItems = append(responseItems, item)
 		decReq.Data = map[string]interface{}{
 			"ciphertext": item.Ciphertext,
 			"context":    "dmlzaGFsCg==",
@@ -312,7 +308,6 @@ func TestTransit_BatchEncryptionCase6(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var responseItems []BatchEncryptionItemResponse
 	var batchResponseArray []interface{}
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
@@ -331,7 +326,6 @@ func TestTransit_BatchEncryptionCase6(t *testing.T) {
 		if err := mapstructure.Decode(responseItem, &item); err != nil {
 			t.Fatal(err)
 		}
-		responseItems = append(responseItems, item)
 		decReq.Data = map[string]interface{}{
 			"ciphertext": item.Ciphertext,
 		}
@@ -372,7 +366,6 @@ func TestTransit_BatchEncryptionCase7(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var responseItems []BatchEncryptionItemResponse
 	var batchResponseArray []interface{}
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
@@ -391,7 +384,6 @@ func TestTransit_BatchEncryptionCase7(t *testing.T) {
 		if err := mapstructure.Decode(responseItem, &item); err != nil {
 			t.Fatal(err)
 		}
-		responseItems = append(responseItems, item)
 		decReq.Data = map[string]interface{}{
 			"ciphertext": item.Ciphertext,
 			"context":    "dmlzaGFsCg==",

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -178,7 +178,7 @@ func TestTransit_BatchEncryptionCase4(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var batchResponseArray []interface{}
+	var batchResponseArray []BatchEncryptionItemResponse
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
@@ -191,11 +191,7 @@ func TestTransit_BatchEncryptionCase4(t *testing.T) {
 
 	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
 
-	for _, responseItem := range batchResponseArray {
-		var item BatchEncryptionItemResponse
-		if err := mapstructure.Decode(responseItem, &item); err != nil {
-			t.Fatal(err)
-		}
+	for _, item := range batchResponseArray {
 		decReq.Data = map[string]interface{}{
 			"ciphertext": item.Ciphertext,
 		}
@@ -252,7 +248,7 @@ func TestTransit_BatchEncryptionCase5(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var batchResponseArray []interface{}
+	var batchResponseArray []BatchEncryptionItemResponse
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
@@ -265,11 +261,7 @@ func TestTransit_BatchEncryptionCase5(t *testing.T) {
 
 	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
 
-	for _, responseItem := range batchResponseArray {
-		var item BatchEncryptionItemResponse
-		if err := mapstructure.Decode(responseItem, &item); err != nil {
-			t.Fatal(err)
-		}
+	for _, item := range batchResponseArray {
 		decReq.Data = map[string]interface{}{
 			"ciphertext": item.Ciphertext,
 			"context":    "dmlzaGFsCg==",
@@ -366,7 +358,7 @@ func TestTransit_BatchEncryptionCase7(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var batchResponseArray []interface{}
+	var batchResponseArray []BatchEncryptionItemResponse
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
@@ -379,11 +371,7 @@ func TestTransit_BatchEncryptionCase7(t *testing.T) {
 
 	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
 
-	for _, responseItem := range batchResponseArray {
-		var item BatchEncryptionItemResponse
-		if err := mapstructure.Decode(responseItem, &item); err != nil {
-			t.Fatal(err)
-		}
+	for _, item := range batchResponseArray {
 		decReq.Data = map[string]interface{}{
 			"ciphertext": item.Ciphertext,
 			"context":    "dmlzaGFsCg==",

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -178,7 +178,7 @@ func TestTransit_BatchEncryptionCase4(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var batchResponseArray []BatchEncryptionItemResponse
+	var batchResponseArray []BatchResponseItem
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +248,7 @@ func TestTransit_BatchEncryptionCase5(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var batchResponseArray []BatchEncryptionItemResponse
+	var batchResponseArray []BatchResponseItem
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +314,7 @@ func TestTransit_BatchEncryptionCase6(t *testing.T) {
 	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
 
 	for _, responseItem := range batchResponseArray {
-		var item BatchEncryptionItemResponse
+		var item BatchResponseItem
 		if err := mapstructure.Decode(responseItem, &item); err != nil {
 			t.Fatal(err)
 		}
@@ -358,7 +358,7 @@ func TestTransit_BatchEncryptionCase7(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	var batchResponseArray []BatchEncryptionItemResponse
+	var batchResponseArray []BatchResponseItem
 	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -498,9 +498,8 @@ func TestTransit_BatchEncryptionCase10(t *testing.T) {
 	}
 }
 
-// Case11: Incorrect inputs for context and nonce should be ignored
+// Case11: Incorrect inputs for context and nonce should not be ignored
 func TestTransit_BatchEncryptionCase11(t *testing.T) {
-	var resp *logical.Response
 	var err error
 
 	b, s := createBackendWithStorage(t)
@@ -519,9 +518,9 @@ func TestTransit_BatchEncryptionCase11(t *testing.T) {
 		Storage:   s,
 		Data:      batchData,
 	}
-	resp, err = b.HandleRequest(batchReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%v resp:%#v", err, resp)
+	_, err = b.HandleRequest(batchReq)
+	if err == nil {
+		t.Fatalf("expected an error")
 	}
 }
 

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -130,7 +130,7 @@ func TestTransit_BatchEncryptionCase3(t *testing.T) {
 
 	batchInput := `[ {"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="}]`
 	batchData := map[string]interface{}{
-		"batch": batchInput,
+		"batch_input": batchInput,
 	}
 
 	batchReq := &logical.Request{
@@ -165,7 +165,7 @@ func TestTransit_BatchEncryptionCase4(t *testing.T) {
 	batchInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="},{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="}]`
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 	batchReq := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -179,7 +179,7 @@ func TestTransit_BatchEncryptionCase4(t *testing.T) {
 	}
 
 	var batchResponseArray []BatchResponseItem
-	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["batch_results"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
 
@@ -235,7 +235,7 @@ func TestTransit_BatchEncryptionCase5(t *testing.T) {
 
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 	batchReq := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -249,7 +249,7 @@ func TestTransit_BatchEncryptionCase5(t *testing.T) {
 	}
 
 	var batchResponseArray []BatchResponseItem
-	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["batch_results"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
 
@@ -287,7 +287,7 @@ func TestTransit_BatchEncryptionCase6(t *testing.T) {
 	batchInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="},{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="}]`
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 	batchReq := &logical.Request{
 		Operation: logical.CreateOperation,
@@ -301,7 +301,7 @@ func TestTransit_BatchEncryptionCase6(t *testing.T) {
 	}
 
 	var batchResponseArray []interface{}
-	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["batch_results"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
 
@@ -345,7 +345,7 @@ func TestTransit_BatchEncryptionCase7(t *testing.T) {
 
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 	batchReq := &logical.Request{
 		Operation: logical.CreateOperation,
@@ -359,7 +359,7 @@ func TestTransit_BatchEncryptionCase7(t *testing.T) {
 	}
 
 	var batchResponseArray []BatchResponseItem
-	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchResponseArray); err != nil {
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["batch_results"].(string)), &batchResponseArray); err != nil {
 		t.Fatal(err)
 	}
 
@@ -408,7 +408,7 @@ func TestTransit_BatchEncryptionCase8(t *testing.T) {
 	batchInput := `[{"plaintext":"simple_plaintext"}]`
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 	batchReq := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -451,8 +451,8 @@ func TestTransit_BatchEncryptionCase9(t *testing.T) {
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
 	batchData := map[string]interface{}{
-		"batch":     batchInputB64,
-		"plaintext": plaintext,
+		"batch_input": batchInputB64,
+		"plaintext":   plaintext,
 	}
 	batchReq := &logical.Request{
 		Operation: logical.CreateOperation,
@@ -483,7 +483,7 @@ func TestTransit_BatchEncryptionCase10(t *testing.T) {
 
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 
 	batchReq := &logical.Request{
@@ -510,7 +510,7 @@ func TestTransit_BatchEncryptionCase11(t *testing.T) {
 
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 	batchReq := &logical.Request{
 		Operation: logical.CreateOperation,
@@ -542,7 +542,7 @@ func TestTransit_BatchEncryptionCase12(t *testing.T) {
 
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 	batchReq := &logical.Request{
 		Operation: logical.CreateOperation,

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -5,9 +5,36 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/vault/helper/errutil"
+	"github.com/hashicorp/vault/helper/jsonutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
+	"github.com/mitchellh/mapstructure"
 )
+
+// BatchRewrapItemRequest represents an item in the batch rewrap
+// request
+type BatchRewrapItemRequest struct {
+	// Context for key derivation. This is required for derived keys.
+	Context string `json:"context" structs:"context" mapstructure:"context"`
+
+	// Ciphertext which needs rewrap
+	Ciphertext string `json:"ciphertext" structs:"ciphertext" mapstructure:"ciphertext"`
+
+	// Nonce to be used when v1 convergent encryption is used
+	Nonce string `json:"nonce" structs:"nonce" mapstructure:"nonce"`
+}
+
+// BatchRewrapItemResponse represents an item in the batch rewrap
+// response
+type BatchRewrapItemResponse struct {
+	// Ciphertext is a rewrapped version of the ciphertext in the corresponding
+	// batch request item
+	Ciphertext string `json:"ciphertext" structs:"ciphertext" mapstructure:"ciphertext"`
+
+	// Error, if set represents a failure encountered while encrypting rewrapping a
+	// corresponding batch request item
+	Error string `json:"error" structs:"error" mapstructure:"error"`
+}
 
 func (b *backend) pathRewrap() *framework.Path {
 	return &framework.Path{
@@ -25,12 +52,31 @@ func (b *backend) pathRewrap() *framework.Path {
 
 			"context": &framework.FieldSchema{
 				Type:        framework.TypeString,
-				Description: "Context for key derivation. Required for derived keys.",
+				Description: "Base64 encoded context for key derivation. Required for derived keys.",
 			},
 
 			"nonce": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "Nonce for when convergent encryption is used",
+			},
+
+			"batch": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: `
+Base64 encoded list of items to be rewrapped in a single batch. When this
+parameter is set, if the parameters 'ciphertext', 'context' and 'nonce' are
+also set, they will be ignored. JSON format for the input goes like this:
+[
+  {
+    "context": "context1",
+    "ciphertext": "vault:v1:/DupSiSbX/ATkGmKAmhqD0tvukByrx6gmps7dVI="
+  },
+  {
+    "context": "context2",
+    "ciphertext": "vault:v1:XjsPWPjqPrBi1N2Ms2s1QM798YyFWnO4TR4lsFA="
+  },
+  ...
+]`,
 			},
 		},
 
@@ -45,87 +91,242 @@ func (b *backend) pathRewrap() *framework.Path {
 
 func (b *backend) pathRewrapWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-
-	value := d.Get("ciphertext").(string)
-	if len(value) == 0 {
-		return logical.ErrorResponse("missing ciphertext to decrypt"), logical.ErrInvalidRequest
-	}
-
-	var err error
-
-	// Decode the context if any
-	contextRaw := d.Get("context").(string)
-	var context []byte
-	if len(contextRaw) != 0 {
-		context, err = base64.StdEncoding.DecodeString(contextRaw)
-		if err != nil {
-			return logical.ErrorResponse("failed to base64-decode context"), logical.ErrInvalidRequest
-		}
-	}
-
-	// Decode the nonce if any
-	nonceRaw := d.Get("nonce").(string)
-	var nonce []byte
-	if len(nonceRaw) != 0 {
-		nonce, err = base64.StdEncoding.DecodeString(nonceRaw)
-		if err != nil {
-			return logical.ErrorResponse("failed to base64-decode nonce"), logical.ErrInvalidRequest
-		}
-	}
 
 	// Get the policy
-	p, lock, err := b.lm.GetPolicyShared(req.Storage, name)
+	p, lock, err := b.lm.GetPolicyShared(req.Storage, d.Get("name").(string))
 	if lock != nil {
 		defer lock.RUnlock()
 	}
 	if err != nil {
 		return nil, err
 	}
-	// Error if invalid policy
 	if p == nil {
 		return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
 	}
 
-	plaintext, err := p.Decrypt(context, nonce, value)
-	if err != nil {
-		switch err.(type) {
-		case errutil.UserError:
-			return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
-		case errutil.InternalError:
-			return nil, err
-		default:
-			return nil, err
+	batchInputRaw := d.Get("batch").(string)
+	var batchInput []byte
+	if len(batchInputRaw) != 0 {
+		batchInput, err = base64.StdEncoding.DecodeString(batchInputRaw)
+		if err != nil {
+			return logical.ErrorResponse("failed to base64-decode batch input"), logical.ErrInvalidRequest
+		}
+	} else {
+		ciphertext := d.Get("ciphertext").(string)
+		if len(ciphertext) == 0 {
+			return logical.ErrorResponse("missing ciphertext to decrypt"), logical.ErrInvalidRequest
+		}
+
+		var singleItemBatch []BatchRewrapItemRequest
+		singleItemBatch = append(singleItemBatch, BatchRewrapItemRequest{
+			Ciphertext: ciphertext,
+			Context:    d.Get("context").(string),
+			Nonce:      d.Get("nonce").(string),
+		})
+
+		batchInput, err = jsonutil.EncodeJSON(singleItemBatch)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode batch input")
 		}
 	}
 
-	if plaintext == "" {
-		return nil, fmt.Errorf("empty plaintext returned during rewrap")
+	var batchInputArray []interface{}
+	if err := jsonutil.DecodeJSON([]byte(batchInput), &batchInputArray); err != nil {
+		return nil, fmt.Errorf("invalid input: %v", err)
 	}
 
-	ciphertext, err := p.Encrypt(context, nonce, plaintext)
-	if err != nil {
-		switch err.(type) {
-		case errutil.UserError:
-			return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
-		case errutil.InternalError:
-			return nil, err
-		default:
-			return nil, err
+	var batchItems []BatchRewrapItemRequest
+	var batchResponseItems []BatchRewrapItemResponse
+	for _, batchItem := range batchInputArray {
+		var item BatchRewrapItemRequest
+		if err := mapstructure.Decode(batchItem, &item); err != nil {
+			return logical.ErrorResponse(fmt.Sprintf("failed to parse the input: %v", err)), logical.ErrInvalidRequest
+		}
+		batchItems = append(batchItems, item)
+
+		if item.Ciphertext == "" {
+			batchResponseItems = append(batchResponseItems, BatchRewrapItemResponse{
+				Error: "missing ciphertext to decrypt",
+			})
+			continue
+		}
+
+		var itemContext []byte
+		if len(item.Context) != 0 {
+			itemContext, err = base64.StdEncoding.DecodeString(item.Context)
+			if err != nil {
+				batchResponseItems = append(batchResponseItems, BatchRewrapItemResponse{
+					Error: "failed to base64-decode context",
+				})
+				continue
+			}
+		}
+
+		var itemNonce []byte
+		if len(item.Nonce) != 0 {
+			itemNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
+			if err != nil {
+				batchResponseItems = append(batchResponseItems, BatchRewrapItemResponse{
+					Error: "failed to base64-decode nonce",
+				})
+			}
+			continue
+		}
+
+		plaintext, err := p.Decrypt(itemContext, itemNonce, item.Ciphertext)
+		if err != nil {
+			switch err.(type) {
+			case errutil.UserError:
+				return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+			case errutil.InternalError:
+				return nil, err
+			default:
+				return nil, err
+			}
+		}
+
+		if plaintext == "" {
+			batchResponseItems = append(batchResponseItems, BatchRewrapItemResponse{
+				Error: "empty plaintext returned during rewrap",
+			})
+			continue
+		}
+
+		ciphertext, err := p.Encrypt(itemContext, itemNonce, plaintext)
+		if err != nil {
+			switch err.(type) {
+			case errutil.UserError:
+				return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+			case errutil.InternalError:
+				return nil, err
+			default:
+				return nil, err
+			}
+		}
+
+		if ciphertext == "" {
+			batchResponseItems = append(batchResponseItems, BatchRewrapItemResponse{
+				Error: "empty ciphertext returned",
+			})
+			continue
+		}
+
+		batchResponseItems = append(batchResponseItems, BatchRewrapItemResponse{
+			Ciphertext: ciphertext,
+		})
+	}
+
+	if len(batchItems) != len(batchResponseItems) {
+		return nil, fmt.Errorf("number of request and the number of response items do not match")
+	}
+
+	if len(batchResponseItems) == 0 {
+		return nil, fmt.Errorf("number of response items cannot be zero")
+	}
+
+	resp := &logical.Response{}
+	if len(batchInputRaw) != 0 {
+		batchResponseJSON, err := jsonutil.EncodeJSON(batchResponseItems)
+		if err != nil {
+			return nil, fmt.Errorf("failed to JSON encode batch response")
+		}
+		resp.Data = map[string]interface{}{
+			"data": string(batchResponseJSON),
+		}
+	} else {
+		if batchResponseItems[0].Error != "" {
+			return nil, fmt.Errorf(batchResponseItems[0].Error)
+		}
+		resp.Data = map[string]interface{}{
+			"ciphertext": batchResponseItems[0].Ciphertext,
 		}
 	}
 
-	if ciphertext == "" {
-		return nil, fmt.Errorf("empty ciphertext returned")
-	}
-
-	// Generate the response
-	resp := &logical.Response{
-		Data: map[string]interface{}{
-			"ciphertext": ciphertext,
-		},
-	}
 	return resp, nil
+
+	/*
+		name := d.Get("name").(string)
+
+		value := d.Get("ciphertext").(string)
+		if len(value) == 0 {
+			return logical.ErrorResponse("missing ciphertext to decrypt"), logical.ErrInvalidRequest
+		}
+
+		var err error
+
+		// Decode the context if any
+		contextRaw := d.Get("context").(string)
+		var context []byte
+		if len(contextRaw) != 0 {
+			context, err = base64.StdEncoding.DecodeString(contextRaw)
+			if err != nil {
+				return logical.ErrorResponse("failed to base64-decode context"), logical.ErrInvalidRequest
+			}
+		}
+
+		// Decode the nonce if any
+		nonceRaw := d.Get("nonce").(string)
+		var nonce []byte
+		if len(nonceRaw) != 0 {
+			nonce, err = base64.StdEncoding.DecodeString(nonceRaw)
+			if err != nil {
+				return logical.ErrorResponse("failed to base64-decode nonce"), logical.ErrInvalidRequest
+			}
+		}
+
+		// Get the policy
+		p, lock, err := b.lm.GetPolicyShared(req.Storage, name)
+		if lock != nil {
+			defer lock.RUnlock()
+		}
+		if err != nil {
+			return nil, err
+		}
+		// Error if invalid policy
+		if p == nil {
+			return logical.ErrorResponse("policy not found"), logical.ErrInvalidRequest
+		}
+
+		plaintext, err := p.Decrypt(context, nonce, value)
+		if err != nil {
+			switch err.(type) {
+			case errutil.UserError:
+				return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+			case errutil.InternalError:
+				return nil, err
+			default:
+				return nil, err
+			}
+		}
+
+		if plaintext == "" {
+			return nil, fmt.Errorf("empty plaintext returned during rewrap")
+		}
+
+		ciphertext, err := p.Encrypt(context, nonce, plaintext)
+		if err != nil {
+			switch err.(type) {
+			case errutil.UserError:
+				return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+			case errutil.InternalError:
+				return nil, err
+			default:
+				return nil, err
+			}
+		}
+
+		if ciphertext == "" {
+			return nil, fmt.Errorf("empty ciphertext returned")
+		}
+
+		// Generate the response
+		resp := &logical.Response{
+			Data: map[string]interface{}{
+				"ciphertext": ciphertext,
+			},
+		}
+		return resp, nil
+	*/
 }
 
 const pathRewrapHelpSyn = `Rewrap ciphertext`

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -344,8 +344,8 @@ func (b *backend) pathRewrapWrite(
 const pathRewrapHelpSyn = `Rewrap ciphertext`
 
 const pathRewrapHelpDesc = `
-After key rotation, this function can be used to rewrap the
-given ciphertext with the latest version of the named key.
-If the given ciphertext is already using the latest version
-of the key, this function is a no-op.
+After key rotation, this function can be used to rewrap the given ciphertext or
+a batch of given ciphertext blocks with the latest version of the named key.
+If the given ciphertext is already using the latest version of the key, this
+function is a no-op.
 `

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -129,22 +129,16 @@ func (b *backend) pathRewrapWrite(
 		}
 	}
 
-	if len(batchInputArray) == 0 {
-		return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
-	}
-
 	var contextSet bool
 	switch len(batchInputArray) {
+	case 0:
+		return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
 	case 1:
 		contextSet = batchInputArray[0].Context != ""
 	default:
-		contextSet = true
+		contextSet = batchInputArray[0].Context != ""
 		for _, item := range batchInputArray {
-			if item.Context == "" && contextSet {
-				contextSet = false
-			}
-
-			if item.Context != "" && !contextSet {
+			if (item.Context == "" && contextSet) || (item.Context != "" && !contextSet) {
 				return logical.ErrorResponse("context should be set either in all the request blocks or in none"), logical.ErrInvalidRequest
 			}
 		}

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -82,7 +82,7 @@ func (b *backend) pathRewrapWrite(
 		}
 
 		if len(batchInputItems) == 0 {
-			return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
+			return logical.ErrorResponse("missing batch input to process"), logical.ErrInvalidRequest
 		}
 	} else {
 		ciphertext := d.Get("ciphertext").(string)

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -111,18 +111,14 @@ func (b *backend) pathRewrapWrite(
 		}
 
 		if item.Ciphertext == "" {
-			batchResponseItems[i] = BatchResponseItem{
-				Error: "missing ciphertext to decrypt",
-			}
+			batchResponseItems[i].Error = "missing ciphertext to decrypt"
 			continue
 		}
 
 		if len(item.Context) != 0 {
 			batchInputItems[i].DecodedContext, err = base64.StdEncoding.DecodeString(item.Context)
 			if err != nil {
-				batchResponseItems[i] = BatchResponseItem{
-					Error: "failed to base64-decode context",
-				}
+				batchResponseItems[i].Error = "failed to base64-decode context"
 				continue
 			}
 		}
@@ -130,11 +126,9 @@ func (b *backend) pathRewrapWrite(
 		if len(item.Nonce) != 0 {
 			batchInputItems[i].DecodedNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
 			if err != nil {
-				batchResponseItems[i] = BatchResponseItem{
-					Error: "failed to base64-decode nonce",
-				}
+				batchResponseItems[i].Error = "failed to base64-decode nonce"
+				continue
 			}
-			continue
 		}
 	}
 
@@ -168,9 +162,7 @@ func (b *backend) pathRewrapWrite(
 		}
 
 		if plaintext == "" {
-			batchResponseItems[i] = BatchResponseItem{
-				Error: "empty plaintext returned during rewrap",
-			}
+			batchResponseItems[i].Error = "empty plaintext returned during rewrap"
 			continue
 		}
 
@@ -187,15 +179,11 @@ func (b *backend) pathRewrapWrite(
 		}
 
 		if ciphertext == "" {
-			batchResponseItems[i] = BatchResponseItem{
-				Error: "empty ciphertext returned",
-			}
+			batchResponseItems[i].Error = "empty ciphertext returned"
 			continue
 		}
 
-		batchResponseItems[i] = BatchResponseItem{
-			Ciphertext: ciphertext,
-		}
+		batchResponseItems[i].Ciphertext = ciphertext
 	}
 
 	resp := &logical.Response{}

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -156,11 +156,6 @@ func (b *backend) pathRewrapWrite(
 			}
 		}
 
-		if plaintext == "" {
-			batchResponseItems[i].Error = "empty plaintext returned during rewrap"
-			continue
-		}
-
 		ciphertext, err := p.Encrypt(item.Context, item.Nonce, plaintext)
 		if err != nil {
 			switch err.(type) {
@@ -175,8 +170,7 @@ func (b *backend) pathRewrapWrite(
 		}
 
 		if ciphertext == "" {
-			batchResponseItems[i].Error = "empty ciphertext returned"
-			continue
+			return nil, fmt.Errorf("empty ciphertext returned for input item %d", i)
 		}
 
 		batchResponseItems[i].Ciphertext = ciphertext

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -165,7 +165,8 @@ func (b *backend) pathRewrapWrite(
 		if err != nil {
 			switch err.(type) {
 			case errutil.UserError:
-				return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+				batchResponseItems[i].Error = err.Error()
+				continue
 			case errutil.InternalError:
 				return nil, err
 			default:

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -133,15 +133,20 @@ func (b *backend) pathRewrapWrite(
 		return logical.ErrorResponse("missing input to process"), logical.ErrInvalidRequest
 	}
 
-	contextSet := true
+	var contextSet bool
+	switch len(batchInputArray) {
+	case 1:
+		contextSet = batchInputArray[0].Context != ""
+	default:
+		contextSet = true
+		for _, item := range batchInputArray {
+			if item.Context == "" && contextSet {
+				contextSet = false
+			}
 
-	for _, item := range batchInputArray {
-		if item.Context == "" && contextSet {
-			contextSet = false
-		}
-
-		if item.Context != "" && !contextSet {
-			return logical.ErrorResponse("context should be set either in all the request blocks or in none"), logical.ErrInvalidRequest
+			if item.Context != "" && !contextSet {
+				return logical.ErrorResponse("context should be set either in all the request blocks or in none"), logical.ErrInvalidRequest
+			}
 		}
 	}
 

--- a/builtin/logical/transit/path_rewrap_test.go
+++ b/builtin/logical/transit/path_rewrap_test.go
@@ -1,0 +1,305 @@
+package transit
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/helper/jsonutil"
+	"github.com/hashicorp/vault/logical"
+	"github.com/mitchellh/mapstructure"
+)
+
+// Check the normal flow of rewrap
+func TestTransit_BatchRewrapCase1(t *testing.T) {
+	var resp *logical.Response
+	var err error
+	b, s := createBackendWithStorage(t)
+
+	// Upsert the key and encrypt the data
+	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
+
+	encData := map[string]interface{}{
+		"plaintext": plaintext,
+	}
+
+	// Create a key and encrypt a plaintext
+	encReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "encrypt/upserted_key",
+		Storage:   s,
+		Data:      encData,
+	}
+	resp, err = b.HandleRequest(encReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	// Cache the ciphertext
+	ciphertext := resp.Data["ciphertext"]
+	if !strings.HasPrefix(ciphertext.(string), "vault:v1") {
+		t.Fatalf("bad: ciphertext version: expected: 'vault:v1', actual: %s", ciphertext)
+	}
+
+	rewrapData := map[string]interface{}{
+		"ciphertext": ciphertext,
+	}
+
+	// Read the policy and check if the latest version is 1
+	policyReq := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "keys/upserted_key",
+		Storage:   s,
+	}
+
+	resp, err = b.HandleRequest(policyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	if resp.Data["latest_version"] != 1 {
+		t.Fatalf("bad: latest_version: expected: 1, actual: %d", resp.Data["latest_version"])
+	}
+
+	rotateReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "keys/upserted_key/rotate",
+		Storage:   s,
+	}
+	resp, err = b.HandleRequest(rotateReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	// Read the policy again and the latest version is 2
+	resp, err = b.HandleRequest(policyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	if resp.Data["latest_version"] != 2 {
+		t.Fatalf("bad: latest_version: expected: 2, actual: %d", resp.Data["latest_version"])
+	}
+
+	// Rewrap the ciphertext and check that they are different
+	rewrapReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rewrap/upserted_key",
+		Storage:   s,
+		Data:      rewrapData,
+	}
+
+	resp, err = b.HandleRequest(rewrapReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	if ciphertext.(string) == resp.Data["ciphertext"].(string) {
+		t.Fatalf("bad: ciphertexts are same before and after rewrap")
+	}
+
+	if !strings.HasPrefix(resp.Data["ciphertext"].(string), "vault:v2") {
+		t.Fatalf("bad: ciphertext version: expected: 'vault:v2', actual: %s", resp.Data["ciphertext"].(string))
+	}
+}
+
+// Check the normal flow of rewrap with upserted key
+func TestTransit_BatchRewrapCase2(t *testing.T) {
+	var resp *logical.Response
+	var err error
+	b, s := createBackendWithStorage(t)
+
+	// Upsert the key and encrypt the data
+	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
+
+	encData := map[string]interface{}{
+		"plaintext": plaintext,
+		"context":   "dmlzaGFsCg==",
+	}
+
+	// Create a key and encrypt a plaintext
+	encReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "encrypt/upserted_key",
+		Storage:   s,
+		Data:      encData,
+	}
+	resp, err = b.HandleRequest(encReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	// Cache the ciphertext
+	ciphertext := resp.Data["ciphertext"]
+	if !strings.HasPrefix(ciphertext.(string), "vault:v1") {
+		t.Fatalf("bad: ciphertext version: expected: 'vault:v1', actual: %s", ciphertext)
+	}
+
+	rewrapData := map[string]interface{}{
+		"ciphertext": ciphertext,
+		"context":    "dmlzaGFsCg==",
+	}
+
+	// Read the policy and check if the latest version is 1
+	policyReq := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "keys/upserted_key",
+		Storage:   s,
+	}
+
+	resp, err = b.HandleRequest(policyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	if resp.Data["latest_version"] != 1 {
+		t.Fatalf("bad: latest_version: expected: 1, actual: %d", resp.Data["latest_version"])
+	}
+
+	rotateReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "keys/upserted_key/rotate",
+		Storage:   s,
+	}
+	resp, err = b.HandleRequest(rotateReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	// Read the policy again and the latest version is 2
+	resp, err = b.HandleRequest(policyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	if resp.Data["latest_version"] != 2 {
+		t.Fatalf("bad: latest_version: expected: 2, actual: %d", resp.Data["latest_version"])
+	}
+
+	// Rewrap the ciphertext and check that they are different
+	rewrapReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rewrap/upserted_key",
+		Storage:   s,
+		Data:      rewrapData,
+	}
+
+	resp, err = b.HandleRequest(rewrapReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	if ciphertext.(string) == resp.Data["ciphertext"].(string) {
+		t.Fatalf("bad: ciphertexts are same before and after rewrap")
+	}
+
+	if !strings.HasPrefix(resp.Data["ciphertext"].(string), "vault:v2") {
+		t.Fatalf("bad: ciphertext version: expected: 'vault:v2', actual: %s", resp.Data["ciphertext"].(string))
+	}
+}
+
+// Batch encrypt plaintexts, rotate the keys and rewrap all the ciphertexts
+func TestTransit_BatchRewrapCase3(t *testing.T) {
+	var resp *logical.Response
+	var err error
+
+	b, s := createBackendWithStorage(t)
+
+	batchInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="},{"plaintext":"dmlzaGFsCg=="}]`
+	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
+	batchData := map[string]interface{}{
+		"batch": batchInputB64,
+	}
+	batchReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "encrypt/upserted_key",
+		Storage:   s,
+		Data:      batchData,
+	}
+	resp, err = b.HandleRequest(batchReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	var batchEncryptionResponseArray []interface{}
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchEncryptionResponseArray); err != nil {
+		t.Fatal(err)
+	}
+
+	batchInputB64 = base64.StdEncoding.EncodeToString([]byte(resp.Data["data"].(string)))
+	rewrapData := map[string]interface{}{
+		"batch": batchInputB64,
+	}
+
+	rotateReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "keys/upserted_key/rotate",
+		Storage:   s,
+	}
+	resp, err = b.HandleRequest(rotateReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	rewrapReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "rewrap/upserted_key",
+		Storage:   s,
+		Data:      rewrapData,
+	}
+
+	resp, err = b.HandleRequest(rewrapReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	var batchRewrapResponseArray []interface{}
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchRewrapResponseArray); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(batchRewrapResponseArray) != len(batchEncryptionResponseArray) {
+		t.Fatalf("bad: length of input and output or rewrap are not matching; expected: %d, actual: %d", len(batchEncryptionResponseArray), len(batchRewrapResponseArray))
+	}
+
+	decReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "decrypt/upserted_key",
+		Storage:   s,
+	}
+
+	for i, responseItem := range batchEncryptionResponseArray {
+		var input BatchRewrapItemRequest
+		if err := mapstructure.Decode(responseItem, &input); err != nil {
+			t.Fatal(err)
+		}
+
+		var output BatchRewrapItemResponse
+		if err := mapstructure.Decode(batchRewrapResponseArray[i], &output); err != nil {
+			t.Fatal(err)
+		}
+
+		if input.Ciphertext == output.Ciphertext {
+			t.Fatalf("bad: rewrap input and output are the same")
+		}
+
+		if !strings.HasPrefix(output.Ciphertext, "vault:v2") {
+			t.Fatalf("bad: invalid version of ciphertext in rewrap response; expected: 'vault:v2', actual: %s", output.Ciphertext)
+		}
+
+		decReq.Data = map[string]interface{}{
+			"ciphertext": output.Ciphertext,
+		}
+
+		resp, err = b.HandleRequest(decReq)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%v resp:%#v", err, resp)
+		}
+
+		plaintext1 := "dGhlIHF1aWNrIGJyb3duIGZveA=="
+		plaintext2 := "dmlzaGFsCg=="
+		if resp.Data["plaintext"] != plaintext1 && resp.Data["plaintext"] != plaintext2 {
+			t.Fatalf("bad: plaintext. Expected: %q or %q, Actual: %q", plaintext1, plaintext2, resp.Data["plaintext"])
+		}
+	}
+}

--- a/builtin/logical/transit/path_rewrap_test.go
+++ b/builtin/logical/transit/path_rewrap_test.go
@@ -269,12 +269,12 @@ func TestTransit_BatchRewrapCase3(t *testing.T) {
 	}
 
 	for i, responseItem := range batchEncryptionResponseArray {
-		var input BatchRewrapItemRequest
+		var input BatchRequestItem
 		if err := mapstructure.Decode(responseItem, &input); err != nil {
 			t.Fatal(err)
 		}
 
-		var output BatchRewrapItemResponse
+		var output BatchResponseItem
 		if err := mapstructure.Decode(batchRewrapResponseArray[i], &output); err != nil {
 			t.Fatal(err)
 		}

--- a/builtin/logical/transit/path_rewrap_test.go
+++ b/builtin/logical/transit/path_rewrap_test.go
@@ -208,7 +208,7 @@ func TestTransit_BatchRewrapCase3(t *testing.T) {
 	batchInput := `[{"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="},{"plaintext":"dmlzaGFsCg=="}]`
 	batchInputB64 := base64.StdEncoding.EncodeToString([]byte(batchInput))
 	batchData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 	batchReq := &logical.Request{
 		Operation: logical.CreateOperation,
@@ -222,13 +222,13 @@ func TestTransit_BatchRewrapCase3(t *testing.T) {
 	}
 
 	var batchEncryptionResponseArray []interface{}
-	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchEncryptionResponseArray); err != nil {
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["batch_results"].(string)), &batchEncryptionResponseArray); err != nil {
 		t.Fatal(err)
 	}
 
-	batchInputB64 = base64.StdEncoding.EncodeToString([]byte(resp.Data["data"].(string)))
+	batchInputB64 = base64.StdEncoding.EncodeToString([]byte(resp.Data["batch_results"].(string)))
 	rewrapData := map[string]interface{}{
-		"batch": batchInputB64,
+		"batch_input": batchInputB64,
 	}
 
 	rotateReq := &logical.Request{
@@ -254,7 +254,7 @@ func TestTransit_BatchRewrapCase3(t *testing.T) {
 	}
 
 	var batchRewrapResponseArray []interface{}
-	if err := jsonutil.DecodeJSON([]byte(resp.Data["data"].(string)), &batchRewrapResponseArray); err != nil {
+	if err := jsonutil.DecodeJSON([]byte(resp.Data["batch_results"].(string)), &batchRewrapResponseArray); err != nil {
 		t.Fatal(err)
 	}
 

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -477,21 +477,21 @@ only encrypt or decrypt using the named keys they need access to.
     </ul>
     <ul>
       <li>
-        <span class="param">batch</span>
+        <span class="param">batch_input</span>
         <span class="param-flags">optional</span>
-        Base64 encoded list of items to be encrypted in a single batch. The size of the
-        input is limited to 4MB. When this parameter is set, the parameters
-        'plaintext', 'context' and 'nonce' will be ignored. JSON format for the input
-        goes like this:
+        Base64 encoded list of items to be encrypted in a single batch. When
+        this parameter is set, if the parameters 'plaintext', 'context' and
+        'nonce' are also set, they will be ignored. JSON format for the input
+        (which should be base64 encoded) goes like this:
 
 ```javascript
 [
   {
-    "context": "context1",
+    "context": "c2FtcGxlY29udGV4dA==",
     "plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA=="
   },
   {
-    "context": "context2",
+    "context": "YW5vdGhlcnNhbXBsZWNvbnRleHQ=",
     "plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA=="
   },
   ...
@@ -580,21 +580,21 @@ only encrypt or decrypt using the named keys they need access to.
     </ul>
     <ul>
       <li>
-        <span class="param">batch</span>
+        <span class="param">batch_input</span>
         <span class="param-flags">optional</span>
-        Base64 encoded list of items to be decrypted in a single batch. When this
-        parameter is set, if the parameters 'ciphertext', 'context' and 'nonce' are
-        also set, they will be ignored. JSON format for the input goes like this:
-
+        Base64 encoded list of items to be decrypted in a single batch. When
+        this parameter is set, if the parameters 'ciphertext', 'context' and
+        'nonce' are also set, they will be ignored. JSON format for the input
+        (which should be base64 encoded) goes like this:
 
 ```javascript
 [
   {
-    "context": "context1",
+    "context": "c2FtcGxlY29udGV4dA==",
     "ciphertext": "vault:v1:/DupSiSbX/ATkGmKAmhqD0tvukByrx6gmps7dVI="
   },
   {
-    "context": "context2",
+    "context": "YW5vdGhlcnNhbXBsZWNvbnRleHQ=",
     "ciphertext": "vault:v1:XjsPWPjqPrBi1N2Ms2s1QM798YyFWnO4TR4lsFA="
   },
   ...
@@ -658,26 +658,26 @@ only encrypt or decrypt using the named keys they need access to.
         0.6.2+.
       </li>
       <li>
-        <span class="param">batch</span>
+        <span class="param">batch_input</span>
         <span class="param-flags">optional</span>
         Base64 encoded list of items to be rewrapped in a single batch. When
         this parameter is set, if the parameters 'ciphertext', 'context' and
         'nonce' are also set, they will be ignored. JSON format for the input
-        goes like this:
+        (which should be bae64 encoded) goes like this:
 
 ```javascript
 [
   {
-    "context": "context1",
+    "context": "c2FtcGxlY29udGV4dA==",
     "ciphertext": "vault:v1:/DupSiSbX/ATkGmKAmhqD0tvukByrx6gmps7dVI="
   },
   {
-    "context": "context2",
+    "context": "YW5vdGhlcnNhbXBsZWNvbnRleHQ=",
     "ciphertext": "vault:v1:XjsPWPjqPrBi1N2Ms2s1QM798YyFWnO4TR4lsFA="
   },
   ...
 ]
-```javascript
+```
 
       </li>
     </ul>

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -455,12 +455,16 @@ only encrypt or decrypt using the named keys they need access to.
         <span class="param-flags">required</span>
         The plaintext to encrypt, provided as a base64-encoded string.
       </li>
+    </ul>
+    <ul>
       <li>
         <span class="param">context</span>
         <span class="param-flags">optional</span>
         The key derivation context, provided as a base64-encoded string.
         Must be provided if derivation is enabled.
       </li>
+    </ul>
+    <ul>
       <li>
         <span class="param">nonce</span>
         <span class="param-flags">optional</span>
@@ -470,6 +474,62 @@ only encrypt or decrypt using the named keys they need access to.
         must be exactly 96 bits (12 bytes) long and the user must ensure that
         for any given context (and thus, any given encryption key) this nonce
         value is **never reused**.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">batch</span>
+        <span class="param-flags">optional</span>
+        Base64 encoded list of items to be encrypted in a single batch. The size of the
+        input is limited to 4MB. When this parameter is set, the parameters
+        'plaintext', 'context' and 'nonce' will be ignored. JSON format for the input
+        goes like this:
+
+```javascript
+[
+  {
+    "context": "context1",
+    "plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA=="
+  },
+  {
+    "context": "context2",
+    "plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA=="
+  },
+  ...
+]
+```
+
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">type</span>
+        <span class="param-flags">optional</span>
+	This parameter is required if encryption key is expected to be created.
+        When performing an upsert operation, the type of key to create.  Currently,
+        "aes256-gcm96" (symmetric) is the only type supported. Defaults to
+        "aes256-gcm96".
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">convergent_encryption</span>
+        <span class="param-flags">optional</span>
+        Whether to support convergent encryption. This is only supported when using a
+        key with key derivation enabled and will require all requests to carry both a
+        context and 96-bit (12-byte) nonce. The given nonce will be used in place of a
+        randomly generated nonce. As a result, when the same context and nonce are
+        supplied, the same ciphertext is generated. It is *very important* when using
+        this mode that you ensure that all nonces are unique for a given context.
+        Failing to do so will severely impact the ciphertext's security.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">derived</span>
+        <span class="param-flags">optional</span>
+        Enables key derivation mode. This allows for per-transaction unique keys for
+        encryption operations.
       </li>
     </ul>
   </dd>

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -579,6 +579,31 @@ only encrypt or decrypt using the named keys they need access to.
         0.6.2+.
       </li>
     </ul>
+    <ul>
+      <li>
+        <span class="param">batch</span>
+        <span class="param-flags">optional</span>
+        Base64 encoded list of items to be decrypted in a single batch. When this
+        parameter is set, if the parameters 'ciphertext', 'context' and 'nonce' are
+        also set, they will be ignored. JSON format for the input goes like this:
+
+
+```javascript
+[
+  {
+    "context": "context1",
+    "ciphertext": "vault:v1:/DupSiSbX/ATkGmKAmhqD0tvukByrx6gmps7dVI="
+  },
+  {
+    "context": "context2",
+    "ciphertext": "vault:v1:XjsPWPjqPrBi1N2Ms2s1QM798YyFWnO4TR4lsFA="
+  },
+  ...
+]
+```
+
+      </li>
+    </ul>
   </dd>
 
   <dt>Returns</dt>

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -453,27 +453,26 @@ only encrypt or decrypt using the named keys they need access to.
       <li>
         <span class="param">plaintext</span>
         <span class="param-flags">required</span>
-        The plaintext to encrypt, provided as a base64-encoded string.
+        Base64 encoded plaintext value to be encrypted.
       </li>
     </ul>
     <ul>
       <li>
         <span class="param">context</span>
         <span class="param-flags">optional</span>
-        The key derivation context, provided as a base64-encoded string.
-        Must be provided if derivation is enabled.
+        Base64 encoded context for key derivation. Required if key derivation
+        is enabled.
       </li>
     </ul>
     <ul>
       <li>
         <span class="param">nonce</span>
         <span class="param-flags">optional</span>
-        The nonce value, provided as base64 encoded. Must be provided if
-        convergent encryption is enabled for this key and the key was generated
-        with Vault 0.6.1. Not required for keys created in 0.6.2+. The value
-        must be exactly 96 bits (12 bytes) long and the user must ensure that
-        for any given context (and thus, any given encryption key) this nonce
-        value is **never reused**.
+        Base64 encoded nonce value. Must be provided if convergent encryption is
+        enabled for this key and the key was generated with Vault 0.6.1. Not required
+        for keys created in 0.6.2+. The value must be exactly 96 bits (12 bytes) long
+        and the user must ensure that for any given context (and thus, any given
+        encryption key) this nonce value is **never reused**.
       </li>
     </ul>
     <ul>
@@ -505,8 +504,8 @@ only encrypt or decrypt using the named keys they need access to.
       <li>
         <span class="param">type</span>
         <span class="param-flags">optional</span>
-	This parameter is required if encryption key is expected to be created.
-        When performing an upsert operation, the type of key to create.  Currently,
+        This parameter is required when encryption key is expected to be created.
+        When performing an upsert operation, the type of key to create. Currently,
         "aes256-gcm96" (symmetric) is the only type supported. Defaults to
         "aes256-gcm96".
       </li>
@@ -515,21 +514,14 @@ only encrypt or decrypt using the named keys they need access to.
       <li>
         <span class="param">convergent_encryption</span>
         <span class="param-flags">optional</span>
-        Whether to support convergent encryption. This is only supported when using a
-        key with key derivation enabled and will require all requests to carry both a
-        context and 96-bit (12-byte) nonce. The given nonce will be used in place of a
-        randomly generated nonce. As a result, when the same context and nonce are
-        supplied, the same ciphertext is generated. It is *very important* when using
-        this mode that you ensure that all nonces are unique for a given context.
-        Failing to do so will severely impact the ciphertext's security.
-      </li>
-    </ul>
-    <ul>
-      <li>
-        <span class="param">derived</span>
-        <span class="param-flags">optional</span>
-        Enables key derivation mode. This allows for per-transaction unique keys for
-        encryption operations.
+        This parameter will only be used when a key is expected to be created.  Whether
+        to support convergent encryption. This is only supported when using a key with
+        key derivation enabled and will require all requests to carry both a context
+        and 96-bit (12-byte) nonce. The given nonce will be used in place of a randomly
+        generated nonce. As a result, when the same context and nonce are supplied, the
+        same ciphertext is generated. It is *very important* when using this mode that
+        you ensure that all nonces are unique for a given context.  Failing to do so
+        will severely impact the ciphertext's security.
       </li>
     </ul>
   </dd>

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -567,16 +567,15 @@ only encrypt or decrypt using the named keys they need access to.
       <li>
         <span class="param">context</span>
         <span class="param-flags">optional</span>
-        The key derivation context, provided as a base64-encoded string.
-        Must be provided if derivation is enabled.
+        Base64 encoded context for key derivation. Required if key derivation is
+        enabled.
       </li>
       <li>
         <span class="param">nonce</span>
         <span class="param-flags">optional</span>
-        The nonce value used during encryption, provided as base64 encoded.
-        Must be provided if convergent encryption is enabled for this key and
-        the key was created with Vault 0.6.1. Not required for keys created in
-        0.6.2+.
+        Base64 encoded nonce value used during encryption. Must be provided if
+        convergent encryption is enabled for this key and the key was generated with
+        Vault 0.6.1. Not required for keys created in 0.6.2+.
       </li>
     </ul>
     <ul>

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -647,8 +647,7 @@ only encrypt or decrypt using the named keys they need access to.
       <li>
         <span class="param">context</span>
         <span class="param-flags">optional</span>
-        The key derivation context, provided as base64-encoded string.
-        Must be provided if derivation is enabled.
+        Base64 encoded context for key derivation. Required for derived keys.
       </li>
       <li>
         <span class="param">nonce</span>
@@ -657,6 +656,29 @@ only encrypt or decrypt using the named keys they need access to.
         Must be provided if convergent encryption is enabled for this key and
         the key was created with Vault 0.6.1. Not required for keys created in
         0.6.2+.
+      </li>
+      <li>
+        <span class="param">batch</span>
+        <span class="param-flags">optional</span>
+        Base64 encoded list of items to be rewrapped in a single batch. When
+        this parameter is set, if the parameters 'ciphertext', 'context' and
+        'nonce' are also set, they will be ignored. JSON format for the input
+        goes like this:
+
+```javascript
+[
+  {
+    "context": "context1",
+    "ciphertext": "vault:v1:/DupSiSbX/ATkGmKAmhqD0tvukByrx6gmps7dVI="
+  },
+  {
+    "context": "context2",
+    "ciphertext": "vault:v1:XjsPWPjqPrBi1N2Ms2s1QM798YyFWnO4TR4lsFA="
+  },
+  ...
+]
+```javascript
+
       </li>
     </ul>
   </dd>


### PR DESCRIPTION
Fixes #2107 

Both encryption and decryption requests can be performed in batches now. Both batch encryption and decryption requests should always be base64 encoded. During encryption, the encryption key can be upserted. If the upserted key is supposed to be a `derived` key, then all the input items should have a non-empty `context` field.

The response of the batch encryption can be base64 encoded and round-tripped back for decryption for non-derived keys. For derived keys, the `context` field should be populated explicitly.

Tests are in place.

Batch request processing for other transit endpoints are not performed right now. Based on the need, we can revisit those functionalities in future.