### PR TITLE
Support for Cross-Account AWS Auth

### DIFF
--- a/builtin/credential/aws-ec2/backend.go
+++ b/builtin/credential/aws-ec2/backend.go
@@ -49,7 +49,7 @@ type backend struct {
 	// overhead of creating a client object for every login request. When
 	// the credentials are modified or deleted, all the cached client objects
 	// will be flushed.
-	EC2ClientsMap map[string]*ec2.EC2
+	EC2ClientsMap map[string]map[string]*ec2.EC2
 
 	// Map to hold the IAM client objects indexed by region. This avoids
 	// the overhead of creating a client object for every login request.
@@ -71,7 +71,7 @@ func Backend(conf *logical.BackendConfig) (*backend, error) {
 		// If there is a real need, this can be made configurable.
 		tidyCooldownPeriod: time.Hour,
 		Salt:               salt,
-		EC2ClientsMap:      make(map[string]*ec2.EC2),
+		EC2ClientsMap:      make(map[string]map[string]*ec2.EC2),
 		IAMClientsMap:      make(map[string]*iam.IAM),
 	}
 
@@ -92,6 +92,8 @@ func Backend(conf *logical.BackendConfig) (*backend, error) {
 			pathRoleTag(b),
 			pathConfigClient(b),
 			pathConfigCertificate(b),
+			pathConfigSts(b),
+			pathListSts(b),
 			pathConfigTidyRoletagBlacklist(b),
 			pathConfigTidyIdentityWhitelist(b),
 			pathListCertificates(b),

--- a/builtin/credential/aws-ec2/backend.go
+++ b/builtin/credential/aws-ec2/backend.go
@@ -45,17 +45,17 @@ type backend struct {
 	// of tidyCooldownPeriod.
 	nextTidyTime time.Time
 
-	// Map to hold the EC2 client objects indexed by region. This avoids the
-	// overhead of creating a client object for every login request. When
-	// the credentials are modified or deleted, all the cached client objects
-	// will be flushed.
+	// Map to hold the EC2 client objects indexed by region and STS role.
+	// This avoids the overhead of creating a client object for every login request.
+	// When the credentials are modified or deleted, all the cached client objects
+	// will be flushed. The empty STS role signifies the master account
 	EC2ClientsMap map[string]map[string]*ec2.EC2
 
-	// Map to hold the IAM client objects indexed by region. This avoids
-	// the overhead of creating a client object for every login request.
-	// When the credentials are modified or deleted, all the cached client
-	// objects will be flushed.
-	IAMClientsMap map[string]*iam.IAM
+	// Map to hold the IAM client objects indexed by region and STS role.
+	// This avoids the overhead of creating a client object for every login request.
+	// When the credentials are modified or deleted, all the cached client objects
+	// will be flushed. The empty STS role signifies the master account
+	IAMClientsMap map[string]map[string]*iam.IAM
 }
 
 func Backend(conf *logical.BackendConfig) (*backend, error) {
@@ -72,7 +72,7 @@ func Backend(conf *logical.BackendConfig) (*backend, error) {
 		tidyCooldownPeriod: time.Hour,
 		Salt:               salt,
 		EC2ClientsMap:      make(map[string]map[string]*ec2.EC2),
-		IAMClientsMap:      make(map[string]*iam.IAM),
+		IAMClientsMap:      make(map[string]map[string]*iam.IAM),
 	}
 
 	b.Backend = &framework.Backend{

--- a/builtin/credential/aws-ec2/backend_test.go
+++ b/builtin/credential/aws-ec2/backend_test.go
@@ -1342,8 +1342,8 @@ func TestBackend_pathStsConfig(t *testing.T) {
 	stsReq.Path = "config/sts/account2"
 	stsReq.Data = data
 	// create another entry to test the list operation
-	_, err = b.HandleRequest(stsReq)
-	if err != nil {
+	resp, err = b.HandleRequest(stsReq)
+	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatal(err)
 	}
 
@@ -1364,14 +1364,14 @@ func TestBackend_pathStsConfig(t *testing.T) {
 
 	stsReq.Operation = logical.DeleteOperation
 	stsReq.Path = "config/sts/account1"
-	_, err = b.HandleRequest(stsReq)
-	if err != nil {
+	resp, err = b.HandleRequest(stsReq)
+	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatal(err)
 	}
 
 	stsReq.Path = "config/sts/account2"
-	_, err = b.HandleRequest(stsReq)
-	if err != nil {
+	resp, err = b.HandleRequest(stsReq)
+	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatal(err)
 	}
 

--- a/builtin/credential/aws-ec2/backend_test.go
+++ b/builtin/credential/aws-ec2/backend_test.go
@@ -1307,8 +1307,7 @@ func TestBackend_pathStsConfig(t *testing.T) {
 	}
 
 	data := map[string]interface{}{
-		"account_id": "123456789098",
-		"sts_role":   "arn:aws:iam:123456789098:role/myRole",
+		"sts_role": "arn:aws:iam:account1:role/myRole",
 	}
 
 	stsReq.Data = data
@@ -1334,14 +1333,13 @@ func TestBackend_pathStsConfig(t *testing.T) {
 	stsReq.Operation = logical.ReadOperation
 	// test read operation
 	resp, err = b.HandleRequest(stsReq)
-	expectedStsRole := "arn:aws:iam:123456789098:role/myRole"
+	expectedStsRole := "arn:aws:iam:account1:role/myRole"
 	if resp.Data["sts_role"].(string) != expectedStsRole {
 		t.Fatalf("bad: expected:%s\n got:%s\n", expectedStsRole, resp.Data["sts_role"].(string))
 	}
 
 	stsReq.Operation = logical.CreateOperation
 	stsReq.Path = "config/sts/account2"
-	data["account_id"] = "098765432123"
 	stsReq.Data = data
 	// create another entry to test the list operation
 	_, err = b.HandleRequest(stsReq)

--- a/builtin/credential/aws-ec2/backend_test.go
+++ b/builtin/credential/aws-ec2/backend_test.go
@@ -1275,3 +1275,119 @@ func TestBackendAcc_LoginAndWhitelistIdentity(t *testing.T) {
 		t.Fatalf("login attempt failed")
 	}
 }
+
+func TestBackend_pathStsConfig(t *testing.T) {
+	config := logical.TestBackendConfig()
+	storage := &logical.InmemStorage{}
+	config.StorageView = storage
+
+	b, err := Backend(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = b.Setup(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stsReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Storage:   storage,
+		Path:      "config/sts/account1",
+	}
+	checkFound, exists, err := b.HandleExistenceCheck(stsReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !checkFound {
+		t.Fatal("existence check not found for path 'config/sts/account1'")
+	}
+	if exists {
+		t.Fatal("existence check should have returned 'false' for 'config/sts/account1'")
+	}
+
+	data := map[string]interface{}{
+		"account_id": "123456789098",
+		"sts_role":   "arn:aws:iam:123456789098:role/myRole",
+	}
+
+	stsReq.Data = data
+	// test create operation
+	resp, err := b.HandleRequest(stsReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("resp: %#v, err: %v", resp, err)
+	}
+
+	stsReq.Data = nil
+	// test existence check
+	checkFound, exists, err = b.HandleExistenceCheck(stsReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !checkFound {
+		t.Fatal("existence check not found for path 'config/sts/account1'")
+	}
+	if !exists {
+		t.Fatal("existence check should have returned 'true' for 'config/sts/account1'")
+	}
+
+	stsReq.Operation = logical.ReadOperation
+	// test read operation
+	resp, err = b.HandleRequest(stsReq)
+	expectedStsRole := "arn:aws:iam:123456789098:role/myRole"
+	if resp.Data["sts_role"].(string) != expectedStsRole {
+		t.Fatalf("bad: expected:%s\n got:%s\n", expectedStsRole, resp.Data["sts_role"].(string))
+	}
+
+	stsReq.Operation = logical.CreateOperation
+	stsReq.Path = "config/sts/account2"
+	data["account_id"] = "098765432123"
+	stsReq.Data = data
+	// create another entry to test the list operation
+	_, err = b.HandleRequest(stsReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stsReq.Operation = logical.ListOperation
+	stsReq.Path = "config/sts"
+	// test list operation
+	resp, err = b.HandleRequest(stsReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.IsError() {
+		t.Fatalf("failed to list config/sts")
+	}
+	keys := resp.Data["keys"].([]string)
+	if len(keys) != 2 {
+		t.Fatalf("invalid keys listed: %#v\n", keys)
+	}
+
+	stsReq.Operation = logical.DeleteOperation
+	stsReq.Path = "config/sts/account1"
+	_, err = b.HandleRequest(stsReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stsReq.Path = "config/sts/account2"
+	_, err = b.HandleRequest(stsReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stsReq.Operation = logical.ListOperation
+	stsReq.Path = "config/sts"
+	// test list operation
+	resp, err = b.HandleRequest(stsReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.IsError() {
+		t.Fatalf("failed to list config/sts")
+	}
+	if resp.Data["keys"] != nil {
+		t.Fatalf("no entries should be present")
+	}
+}

--- a/builtin/credential/aws-ec2/client.go
+++ b/builtin/credential/aws-ec2/client.go
@@ -149,7 +149,7 @@ func (b *backend) clientEC2(s logical.Storage, region string, stsRole string) (*
 // clientIAM creates a client to interact with AWS IAM API
 func (b *backend) clientIAM(s logical.Storage, region string, stsRole string) (*iam.IAM, error) {
 	b.configMutex.RLock()
-	if b.IAMClientsMap[region][stsRole] != nil {
+	if b.IAMClientsMap[region] != nil && b.IAMClientsMap[region][stsRole] != nil {
 		defer b.configMutex.RUnlock()
 		// If the client object was already created, return it
 		return b.IAMClientsMap[region][stsRole], nil
@@ -161,7 +161,7 @@ func (b *backend) clientIAM(s logical.Storage, region string, stsRole string) (*
 	defer b.configMutex.Unlock()
 
 	// If the client gets created while switching the locks, return it
-	if b.IAMClientsMap[region][stsRole] != nil {
+	if b.IAMClientsMap[region] != nil && b.IAMClientsMap[region][stsRole] != nil {
 		return b.IAMClientsMap[region][stsRole], nil
 	}
 

--- a/builtin/credential/aws-ec2/client.go
+++ b/builtin/credential/aws-ec2/client.go
@@ -179,7 +179,7 @@ func (b *backend) clientIAM(s logical.Storage, region string, stsRole string) (*
 	}
 
 	// Create a new IAM client object, cache it and return the same
-	if _, ok := b.EC2ClientsMap[region]; !ok {
+	if _, ok := b.IAMClientsMap[region]; !ok {
 		b.IAMClientsMap[region] = map[string]*iam.IAM{stsRole: iam.New(session.New(awsConfig))}
 	} else {
 		b.IAMClientsMap[region][stsRole] = iam.New(session.New(awsConfig))

--- a/builtin/credential/aws-ec2/client.go
+++ b/builtin/credential/aws-ec2/client.go
@@ -62,8 +62,9 @@ func (b *backend) getClientConfig(s logical.Storage, region string) (*aws.Config
 }
 
 // getStsClientConfig returns an aws-sdk-go config, with assumed credentials
-// It uses getClientConfig to obtain config for the master account, which is
-// then used to obtain a set of assumed credentials.
+// It uses getClientConfig to obtain config for the runtime environemnt, which is
+// then used to obtain a set of assumed credentials. The credentials will expire
+// after 15 minutes but will auto-refresh.
 func (b *backend) getStsClientConfig(s logical.Storage, region string, stsRole string) (*aws.Config, error) {
 	config, err := b.getClientConfig(s, region)
 	if err != nil {

--- a/builtin/credential/aws-ec2/client.go
+++ b/builtin/credential/aws-ec2/client.go
@@ -106,7 +106,7 @@ func (b *backend) flushCachedIAMClients() {
 // clientEC2 creates a client to interact with AWS EC2 API
 func (b *backend) clientEC2(s logical.Storage, region string, stsRole string) (*ec2.EC2, error) {
 	b.configMutex.RLock()
-	if b.EC2ClientsMap[region][stsRole] != nil {
+	if b.EC2ClientsMap[region] != nil && b.EC2ClientsMap[region][stsRole] != nil {
 		defer b.configMutex.RUnlock()
 		// If the client object was already created, return it
 		return b.EC2ClientsMap[region][stsRole], nil
@@ -118,7 +118,7 @@ func (b *backend) clientEC2(s logical.Storage, region string, stsRole string) (*
 	defer b.configMutex.Unlock()
 
 	// If the client gets created while switching the locks, return it
-	if b.EC2ClientsMap[region][stsRole] != nil {
+	if b.EC2ClientsMap[region] != nil && b.EC2ClientsMap[region][stsRole] != nil {
 		return b.EC2ClientsMap[region][stsRole], nil
 	}
 

--- a/builtin/credential/aws-ec2/path_config_sts.go
+++ b/builtin/credential/aws-ec2/path_config_sts.go
@@ -1,0 +1,191 @@
+package awsec2
+
+import (
+	"fmt"
+
+	"github.com/fatih/structs"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+type awsStsEntry struct {
+	StsRole string `json:"sts_role" structs:"sts_role" mapstructure:"sts_role"`
+}
+
+func pathListSts(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "config/sts/?",
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ListOperation: b.pathStsList,
+		},
+	}
+}
+
+func pathConfigSts(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "config/sts/" + framework.GenericNameRegex("account_id"),
+		Fields: map[string]*framework.FieldSchema{
+			"account_id": {
+				Type:        framework.TypeString,
+				Description: "AWS account ID for account for which STS role will be assumed",
+			},
+			"sts_role": {
+				Type:        framework.TypeString,
+				Description: "AWS ARN for STS role to be assumed",
+			},
+		},
+
+		ExistenceCheck: b.pathConfigStsExistenceCheck,
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.CreateOperation: b.pathConfigStsCreateUpdate,
+			logical.UpdateOperation: b.pathConfigStsCreateUpdate,
+			logical.ReadOperation:   b.pathConfigStsRead,
+		},
+	}
+}
+
+// Establishes dichotomy of request operation between CreateOperation and UpdateOperation.
+// Returning 'true' forces an UpdateOperation, CreateOperation otherwise.
+func (b *backend) pathConfigStsExistenceCheck(req *logical.Request, data *framework.FieldData) (bool, error) {
+	accountId := data.Get("account_id").(string)
+	if accountId == "" {
+		return false, fmt.Errorf("missing account_id")
+	}
+
+	entry, err := b.lockedAwsStsEntry(req.Storage, accountId)
+	if err != nil {
+		return false, err
+	}
+
+	return entry != nil, nil
+}
+
+// pathStsList is used to list all the AWS STS role configurations
+func (b *backend) pathStsList(
+	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	b.configMutex.RLock()
+	defer b.configMutex.RUnlock()
+	sts, err := req.Storage.List("config/sts/")
+	if err != nil {
+		return nil, err
+	}
+	return logical.ListResponse(sts), nil
+}
+
+func (b *backend) nonLockedSetAwsStsEntry(s logical.Storage, accountID string, stsEntry *awsStsEntry) error {
+	if accountID == "" {
+		return fmt.Errorf("missing AWS account ID")
+	}
+
+	if stsEntry == nil {
+		return fmt.Errorf("missing AWS STS Role ARN")
+	}
+
+	entry, err := logical.StorageEntryJSON("config/sts/"+accountID, stsEntry)
+	if err != nil {
+		return err
+	}
+
+	if entry == nil {
+		return fmt.Errorf("failed to create storage entry for AWS STS configuration")
+	}
+
+	return s.Put(entry)
+}
+
+func (b *backend) lockedSetAwsStsEntry(s logical.Storage, accountID string, stsEntry *awsStsEntry) error {
+	if accountID == "" {
+		return fmt.Errorf("missing AWS account ID")
+	}
+
+	if stsEntry == nil {
+		return fmt.Errorf("missing AWS STS Role ARN")
+	}
+
+	b.configMutex.Lock()
+	defer b.configMutex.Unlock()
+
+	return b.nonLockedSetAwsStsEntry(s, accountID, stsEntry)
+}
+
+func (b *backend) nonLockedAwsStsEntry(s logical.Storage, accountID string) (*awsStsEntry, error) {
+	entry, err := s.Get("config/sts/" + accountID)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	var stsEntry awsStsEntry
+	if err := entry.DecodeJSON(&stsEntry); err != nil {
+		return nil, err
+	}
+
+	return &stsEntry, nil
+}
+
+func (b *backend) lockedAwsStsEntry(s logical.Storage, accountID string) (*awsStsEntry, error) {
+	b.configMutex.RLock()
+	defer b.configMutex.RUnlock()
+
+	return b.nonLockedAwsStsEntry(s, accountID)
+}
+
+func (b *backend) pathConfigStsRead(req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	accountId := data.Get("account_id").(string)
+	if accountId == "" {
+		return logical.ErrorResponse("missing account id"), nil
+	}
+
+	stsEntry, err := b.lockedAwsStsEntry(req.Storage, accountId)
+	if err != nil {
+		return nil, err
+	}
+	if stsEntry == nil {
+		return nil, nil
+	}
+
+	return &logical.Response{
+		Data: structs.New(stsEntry).Map(),
+	}, nil
+}
+
+func (b *backend) pathConfigStsCreateUpdate(req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	accountId := data.Get("account_id").(string)
+	if accountId == "" {
+		return logical.ErrorResponse("missing AWS account ID"), nil
+	}
+
+	b.configMutex.Lock()
+	defer b.configMutex.Unlock()
+
+	// Check if an STS role is already registered
+	stsEntry, err := b.nonLockedAwsStsEntry(req.Storage, accountId)
+	if err != nil {
+		return nil, err
+	}
+	if stsEntry == nil {
+		stsEntry = &awsStsEntry{}
+	}
+
+	// Check that an STS role has actually been provided
+	stsRole, ok := data.GetOk("sts_role")
+	if ok {
+		if stsRole != "" {
+			stsEntry.StsRole = stsRole.(string)
+		} else {
+			return logical.ErrorResponse("missing sts role"), nil
+		}
+	} else {
+		return logical.ErrorResponse("missing sts role"), nil
+	}
+
+	// save the provided STS role
+	if err := b.nonLockedSetAwsStsEntry(req.Storage, accountId, stsEntry); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}

--- a/builtin/credential/aws-ec2/path_login.go
+++ b/builtin/credential/aws-ec2/path_login.go
@@ -645,6 +645,7 @@ func (b *backend) pathLoginUpdate(
 			Metadata: map[string]string{
 				"instance_id":      identityDocParsed.InstanceID,
 				"region":           identityDocParsed.Region,
+				"account_id":       identityDocParsed.AccountID,
 				"role_tag_max_ttl": rTagMaxTTL.String(),
 				"role":             roleName,
 				"ami_id":           identityDocParsed.AmiID,
@@ -768,9 +769,12 @@ func (b *backend) pathLoginRenew(
 		return nil, fmt.Errorf("unable to fetch region from metadata during renewal")
 	}
 
-	accountID := req.Auth.Metadata["account_id"]
-	if accountID == "" {
-		return nil, fmt.Errorf("unable to fetch account_id from metadata during renewal")
+	// Ensure backwards compatibility for older clients without account_id saved in metadata
+	var accountID string
+	if accountID, ok := req.Auth.Metadata["account_id"]; ok {
+		if accountID == "" {
+			return nil, fmt.Errorf("unable to fetch account_id from metadata during renewal")
+		}
 	}
 
 	// Cross check that the instance is still in 'running' state

--- a/builtin/credential/aws-ec2/path_login.go
+++ b/builtin/credential/aws-ec2/path_login.go
@@ -770,8 +770,8 @@ func (b *backend) pathLoginRenew(
 	}
 
 	// Ensure backwards compatibility for older clients without account_id saved in metadata
-	var accountID string
-	if accountID, ok := req.Auth.Metadata["account_id"]; ok {
+	accountID, ok := req.Auth.Metadata["account_id"]
+	if ok {
 		if accountID == "" {
 			return nil, fmt.Errorf("unable to fetch account_id from metadata during renewal")
 		}

--- a/website/source/docs/auth/aws-ec2.html.md
+++ b/website/source/docs/auth/aws-ec2.html.md
@@ -262,6 +262,20 @@ will not be aware of such events. The token issued will still be valid, until
 it expires. The token will likely be expired sooner than its lifetime when the
 instance fails to renew the token on time.
 
+### Cross Account Access
+
+To allow Vault to authenticate EC2 instances running in other accounts, AWS STS (Security
+Token Service) can be used to retrieve temporary credentials by assuming an IAM Role
+in those accounts.
+
+The account in which Vault is running (i.e. the master account) must be listed as
+a trusted entity in the IAM Role being assumed on the remote account. The Role itself
+must allow the `ec2:DescribeInstances` action, and `iam:GetInstanceProfile` if IAM Role
+binding is used (see below).
+
+Furthermore, in the master account, Vault must be granted the action `sts:AssumeRole`
+for the IAM Role to be assumed.
+
 ## Authentication
 
 ### Via the CLI

--- a/website/source/docs/auth/aws-ec2.html.md
+++ b/website/source/docs/auth/aws-ec2.html.md
@@ -623,6 +623,150 @@ The response will be in JSON. For example:
   </dd>
 </dl>
 
+
+### /auth/aws-ec2/config/sts/<account_id>
+#### POST
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Allows the explicit association of STS roles to satellite AWS accounts (i.e. those
+    which are not the account in which the Vault server is running.) Login attempts from
+    EC2 instances running in these accounts will be verified using credentials obtained
+    by assumption of these STS roles.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>POST</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-ec2/config/certificate/<account_id>`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">account_id</span>
+        <span class="param-flags">required</span>
+        AWS account ID to be associated with STS role. If set,
+        Vault will use assumed credentials to verify any login attempts from EC2
+        instances in this account.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">sts_role</span>
+        <span class="param-flags">required</span>
+        AWS ARN for STS role to be assumed when interacting with the account specified.
+        The Vault server must have permissions to assume this role.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+#### GET
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Returns the previously configured STS role. 
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-ec2/config/sts/<account_id>`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+```javascript
+{
+  "auth": null,
+  "warnings": null,
+  "data": {
+    "sts_role ": "arn:aws:iam:<account_id>:role/myRole"
+  },
+  "lease_duration": 0,
+  "renewable": false,
+  "lease_id": ""
+}
+```
+
+  </dd>
+</dl>
+
+#### LIST
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Lists all the AWS Account IDs for which an STS role is registered 
+  </dd>
+
+  <dt>Method</dt>
+  <dd>LIST/GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-ec2/config/sts` (LIST) or `/auth/aws-ec2/config/sts?list=true` (GET)</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+```javascript
+{
+  "auth": null,
+  "warnings": null,
+  "data": {
+    "keys": [
+      "<account_id_1>",
+      "<account_id_2>"
+    ]
+  },
+  "lease_duration": 0,
+  "renewable": false,
+  "lease_id": ""
+}
+```
+
+  </dd>
+</dl>
+
+#### DELETE
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+    Deletes a previously configured AWS account/STS role association  
+  </dd>
+
+  <dt>Method</dt>
+  <dd>DELETE</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/aws-ec2/config/sts/<account_id>`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
 ### /auth/aws-ec2/config/tidy/identity-whitelist
 ##### POST
 <dl class="api">


### PR DESCRIPTION
Hi Guys,

The current AWS-EC2 auth backend (whilst excellent, thanks!) allows only for authentication from EC2 instances in the same account as the Vault server. It is quite a common practice to have separate AWS accounts for different concerns in an organisation (e.g. for separation of billing or security reasons). The headache of managing a separate Vault installation per account may be a barrier to adoption.

This change adds support for assumption of AWS Roles in remote accounts through STS. We are able to add an STS configuration like this:

```
vault write auth/aws-ec2/config/sts/123456789098 sts_role=arn:aws:iam::123456789098:role/Vault
```

And then any instances which advertise themselves as belonging to account 123456789098 will be authenticated using temporary credentials obtained through assumption of the role.

It adds a new layer to the cache of EC2 (and IAM) clients such that they are indexed by region and STS Role. The empty STS Role signifies the 'master' account. Credentials are auto-refreshed when required (this happens intrinsically with the AWS SDK, when Get() is called)

Includes tests and doc updates, but happy to add more if required.

Thanks
Louis


