### PR TITLE
Fix panic() in test suite

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -625,10 +625,9 @@ func TestCluster(t *testing.T, handlers []http.Handler, base *CoreConfig, unseal
 				coreConfig.AuditBackends[k] = v
 			}
 		}
-	}
-
-	if base.Logger != nil {
-		coreConfig.Logger = base.Logger
+		if base.Logger != nil {
+			coreConfig.Logger = base.Logger
+		}
 	}
 
 	c1, err := NewCore(coreConfig)


### PR DESCRIPTION
`TestCluster_ListenForRequests` fails with

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x4f62fc]
```

As `base` could be nil, move check in `if base != nil`