### PR TITLE
Add socket audit backend

### DIFF
--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -1,0 +1,116 @@
+package socket
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/hashicorp/vault/audit"
+	"github.com/hashicorp/vault/logical"
+)
+
+func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
+	if conf.Salt == nil {
+		return nil, fmt.Errorf("nil salt passed in")
+	}
+
+	address, ok := conf.Config["address"]
+	if !ok {
+		return nil, fmt.Errorf("address is required")
+	}
+
+	socket_type, ok := conf.Config["socket_type"]
+	if !ok {
+		socket_type = "tcp"
+	}
+
+	format, ok := conf.Config["format"]
+	if !ok {
+		format = "json"
+	}
+	switch format {
+	case "json", "jsonx":
+	default:
+		return nil, fmt.Errorf("unknown format type %s", format)
+	}
+
+	// Check if hashing of accessor is disabled
+	hmacAccessor := true
+	if hmacAccessorRaw, ok := conf.Config["hmac_accessor"]; ok {
+		value, err := strconv.ParseBool(hmacAccessorRaw)
+		if err != nil {
+			return nil, err
+		}
+		hmacAccessor = value
+	}
+
+	// Check if raw logging is enabled
+	logRaw := false
+	if raw, ok := conf.Config["log_raw"]; ok {
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, err
+		}
+		logRaw = b
+	}
+
+	conn, err := net.Dial(socket_type, address)
+	if err != nil {
+		return nil, err
+	}
+
+	b := &Backend{
+		connection: conn,
+		formatConfig: audit.FormatterConfig{
+			Raw:          logRaw,
+			Salt:         conf.Salt,
+			HMACAccessor: hmacAccessor,
+		},
+	}
+
+	switch format {
+	case "json":
+		b.formatter.AuditFormatWriter = &audit.JSONFormatWriter{}
+	case "jsonx":
+		b.formatter.AuditFormatWriter = &audit.JSONxFormatWriter{}
+	}
+
+	return b, nil
+}
+
+// Backend is the audit backend for the socket audit transport.
+type Backend struct {
+	connection net.Conn
+
+	formatter    audit.AuditFormatter
+	formatConfig audit.FormatterConfig
+}
+
+func (b *Backend) GetHash(data string) string {
+	return audit.HashString(b.formatConfig.Salt, data)
+}
+
+func (b *Backend) LogRequest(auth *logical.Auth, req *logical.Request, outerErr error) error {
+	var buf bytes.Buffer
+	if err := b.formatter.FormatRequest(&buf, b.formatConfig, auth, req, outerErr); err != nil {
+		return err
+	}
+
+	b.connection.Write(buf.Bytes())
+	return nil
+}
+
+func (b *Backend) LogResponse(auth *logical.Auth, req *logical.Request,
+	resp *logical.Response, err error) error {
+	var buf bytes.Buffer
+	if err := b.formatter.FormatResponse(&buf, b.formatConfig, auth, req, resp, err); err != nil {
+		return err
+	}
+	b.connection.Write(buf.Bytes())
+	return nil
+}
+
+func (b *Backend) Reload() error {
+	return nil
+}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	auditFile "github.com/hashicorp/vault/builtin/audit/file"
+	auditSocket "github.com/hashicorp/vault/builtin/audit/socket"
 	auditSyslog "github.com/hashicorp/vault/builtin/audit/syslog"
 	"github.com/hashicorp/vault/version"
 
@@ -63,6 +64,7 @@ func Commands(metaPtr *meta.Meta) map[string]cli.CommandFactory {
 				AuditBackends: map[string]audit.Factory{
 					"file":   auditFile.Factory,
 					"syslog": auditSyslog.Factory,
+					"socket": auditSocket.Factory,
 				},
 				CredentialBackends: map[string]logical.Factory{
 					"approle":  credAppRole.Factory,

--- a/website/source/docs/audit/index.html.md
+++ b/website/source/docs/audit/index.html.md
@@ -100,7 +100,7 @@ block.
         <span class="param">options</span>
         <span class="param-flags">optional</span>
            Configuration options of the backend in JSON format.
-           Refer to `syslog` and `file` audit backend options.
+           Refer to `syslog`, `file` and `socket` audit backend options.
       </li>
     </ul>
   </dd>

--- a/website/source/docs/audit/socket.html.md
+++ b/website/source/docs/audit/socket.html.md
@@ -1,0 +1,72 @@
+---
+layout: "docs"
+page_title: "Audit Backend: Socket"
+sidebar_current: "docs-audit-socket"
+description: |-
+  The "socket" audit backend writes audit writes to a TCP or UDP socket.
+---
+
+# Audit Backend: Socket
+
+The `socket` audit backend writes to a TCP or UDP socket.
+
+## Format
+
+Each line in the audit log is a JSON object. The `type` field specifies what type of
+object it is. Currently, only two types exist: `request` and `response`. The line contains
+all of the information for any given request and response. By default, all the sensitive
+information is first hashed before logging in the audit logs.
+
+## Enabling
+
+#### Via the CLI
+
+Audit `socket` backend can be enabled by the following command.
+
+```
+$ vault audit-enable socket
+```
+
+Backend configuration options can also be provided from command-line.
+
+```
+$ vault audit-enable socket address="127.0.0.1:9090" socket_type="tcp"
+```
+
+Following are the configuration options available for the backend.
+
+<dl class="api">
+  <dt>Backend configuration options</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">address</span>
+        <span class="param-flags">required</span>
+            The socket server address to use. Example `127.0.0.1:9090`.
+      </li>
+      <li>
+        <span class="param">socket_type</span>
+        <span class="param-flags">optional</span>
+            The socket type to use, any type compatible with <a href="https://golang.org/pkg/net/#Dial">net.Dial</a> is acceptable. Defaults to `tcp`.
+      </li>
+      <li>
+        <span class="param">log_raw</span>
+        <span class="param-flags">optional</span>
+            A string containing a boolean value ('true'/'false'), if set, logs the security sensitive information without
+            hashing, in the raw format. Defaults to `false`.
+      </li>
+      <li>
+        <span class="param">hmac_accessor</span>
+        <span class="param-flags">optional</span>
+            A string containing a boolean value ('true'/'false'), if set, enables the hashing of token accessor. Defaults
+            to `true`. This option is useful only when `log_raw` is `false`.
+      </li>
+      <li>
+        <span class="param">format</span>
+        <span class="param-flags">optional</span>
+            Allows selecting the output format. Valid values are `json` (the
+            default) and `jsonx`, which formats the normal log entries as XML.
+      </li>
+    </ul>
+  </dd>
+</dl>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -218,6 +218,10 @@
 						<li<%= sidebar_current("docs-audit-syslog") %>>
 							<a href="/docs/audit/syslog.html">Syslog</a>
 						</li>
+
+						<li<%= sidebar_current("docs-audit-socket") %>>
+							<a href="/docs/audit/socket.html">Socket</a>
+						</li>
 					</ul>
 				</li>
 			</ul>


### PR DESCRIPTION
We're looking to use `Vault` at Buffer and need this backend to collect the audit information in our infrastructure. I think I've got all the docs updated along with the code. I tested this against a small python server that prints out the audit logs:

```python
#!/usr/bin/env python 

""" 
A simple echo server 
""" 

import socket 

host = '' 
port = 9090
backlog = 5 
size = 1024
s = socket.socket(socket.AF_INET, socket.SOCK_STREAM) 
s.bind((host,port)) 
s.listen(backlog) 
while 1: 
    client, address = s.accept() 
    data = client.recv(size) 
    if data: 
        print data
```

Thanks for making `Vault` open source, its a wonderful project 👍 