### PR TITLE
Replace app-id with approle due to deprecation

### DIFF
--- a/website/source/docs/concepts/auth.html.md
+++ b/website/source/docs/concepts/auth.html.md
@@ -31,7 +31,7 @@ multiple authentication backends to gain access.
 
 This allows you to enable human-friendly as well as machine-friendly
 backends at the same time. For example, for humans you might use the
-"github" auth backend, and for machines you might use the "app-id" backend.
+"github" auth backend, and for machines you might use the "approle" backend.
 
 ## Tokens
 


### PR DESCRIPTION
According to the documentation the App-ID backend is deprecated in favor of the AppRole backend since Vault 0.6.1.