### PR TITLE
[WIP] PKI base64 encode the storage paths containing serial numbers

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"net"
@@ -181,25 +182,46 @@ func fetchCAInfo(req *logical.Request) (*caInfoBundle, error) {
 func fetchCertBySerial(req *logical.Request, prefix, serial string) (*logical.StorageEntry, error) {
 	var path string
 
+	serial = strings.Replace(strings.ToLower(serial), "-", ":", -1)
+
 	switch {
 	// Revoked goes first as otherwise ca/crl get hardcoded paths which fail if
 	// we actually want revocation info
 	case strings.HasPrefix(prefix, "revoked/"):
-		path = "revoked/" + strings.Replace(strings.ToLower(serial), "-", ":", -1)
+		path = "revoked/" + base64.URLEncoding.EncodeToString([]byte(serial))
 	case serial == "ca":
 		path = "ca"
 	case serial == "crl":
 		path = "crl"
 	default:
-		path = "certs/" + strings.Replace(strings.ToLower(serial), "-", ":", -1)
+		path = "certs/" + base64.URLEncoding.EncodeToString([]byte(serial))
 	}
 
 	certEntry, err := req.Storage.Get(path)
 	if err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching certificate %s: %s", serial, err)}
 	}
+
 	if certEntry == nil {
-		return nil, nil
+		// If storage entry was not found, then attempt to check for
+		// entries that have base64 URL encoded serials in the paths
+		if serial != "" && serial != "ca" && serial != "crl" {
+			switch {
+			case strings.HasPrefix(prefix, "revoked/"):
+				path = "revoked/" + base64.URLEncoding.EncodeToString([]byte(serial))
+			default:
+				path = "certs/" + base64.URLEncoding.EncodeToString([]byte(serial))
+			}
+		}
+
+		certEntry, err = req.Storage.Get(path)
+		if err != nil {
+			return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching certificate %s: %s", serial, err)}
+		}
+
+		if certEntry == nil {
+			return nil, nil
+		}
 	}
 
 	if certEntry.Value == nil || len(certEntry.Value) == 0 {

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -86,7 +87,7 @@ func revokeCert(b *backend, req *logical.Request, serial string, fromLease bool)
 		revInfo.RevocationTime = currTime.Unix()
 		revInfo.RevocationTimeUTC = currTime.UTC()
 
-		revEntry, err = logical.StorageEntryJSON("revoked/"+serial, revInfo)
+		revEntry, err = logical.StorageEntryJSON("revoked/"+base64.URLEncoding.EncodeToString([]byte(serial)), revInfo)
 		if err != nil {
 			return nil, fmt.Errorf("Error creating revocation entry")
 		}

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -196,11 +196,11 @@ func (b *backend) pathSetSignedIntermediate(
 		return nil, err
 	}
 
-	entry.Key = "certs/" + cb.SerialNumber
+	entry.Key = "certs/" + base64.URLEncoding.EncodeToString([]byte(cb.SerialNumber))
 	entry.Value = inputBundle.CertificateBytes
 	err = req.Storage.Put(entry)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Unable to store certificate locally: %v", err)
 	}
 
 	// For ease of later use, also store just the certificate at a known

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -225,7 +225,7 @@ func (b *backend) pathIssueSignCert(
 	resp.Secret.TTL = parsedBundle.Certificate.NotAfter.Sub(time.Now())
 
 	err = req.Storage.Put(&logical.StorageEntry{
-		Key:   "certs/" + cb.SerialNumber,
+		Key:   "certs/" + base64.URLEncoding.EncodeToString([]byte(cb.SerialNumber)),
 		Value: parsedBundle.CertificateBytes,
 	})
 	if err != nil {

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -145,7 +145,7 @@ func (b *backend) pathCAGenerateRoot(
 	// Also store it as just the certificate identified by serial number, so it
 	// can be revoked
 	err = req.Storage.Put(&logical.StorageEntry{
-		Key:   "certs/" + cb.SerialNumber,
+		Key:   "certs/" + base64.URLEncoding.EncodeToString([]byte(cb.SerialNumber)),
 		Value: parsedBundle.CertificateBytes,
 	})
 	if err != nil {
@@ -277,7 +277,7 @@ func (b *backend) pathCASignIntermediate(
 	}
 
 	err = req.Storage.Put(&logical.StorageEntry{
-		Key:   "certs/" + cb.SerialNumber,
+		Key:   "certs/" + base64.URLEncoding.EncodeToString([]byte(cb.SerialNumber)),
 		Value: parsedBundle.CertificateBytes,
 	})
 	if err != nil {

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -61,6 +61,11 @@ func (b *backend) pathTidyWrite(
 		}
 
 		for _, serial := range serials {
+			//
+			// Newer serials will be base64 encoded. For tidying
+			// purposes, it does not matter if serial is encoded or
+			// not.
+			//
 			certEntry, err := req.Storage.Get("certs/" + serial)
 			if err != nil {
 				return nil, fmt.Errorf("error fetching certificate %s: %s", serial, err)
@@ -100,6 +105,11 @@ func (b *backend) pathTidyWrite(
 
 		var revInfo revocationInfo
 		for _, serial := range revokedSerials {
+			//
+			// Newer serials will be base64 encoded. For tidying
+			// purposes, it does not matter if serial is encoded or
+			// not.
+			//
 			revokedEntry, err := req.Storage.Get("revoked/" + serial)
 			if err != nil {
 				return nil, fmt.Errorf("unable to fetch revoked cert with serial %s: %s", serial, err)


### PR DESCRIPTION
Fixes https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/vault-tool/D2GStAl1f1k/AoURH_uUEAAJ

Manually tested on Windows to ensure that the issue is resolved.

Pending tests.

This PR base64 URL encodes the serial numbers when they are used as part of storage entry paths. This will enable the storage entry paths to be compatible with Windows.

The list operation will return the decoded serials.