### PR TITLE
all: test: Fix govet warnings

### DIFF
--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -374,7 +374,7 @@ func TestAppRole_RoleSecretIDReadDelete(t *testing.T) {
 
 	resp, err = b.HandleRequest(secretIDReq)
 	if resp != nil && resp.IsError() {
-		t.Fatalf("error response:%#v", err, resp)
+		t.Fatalf("error response:%#v", resp)
 	}
 	if err != nil {
 		t.Fatal(err)

--- a/builtin/credential/aws-ec2/backend_test.go
+++ b/builtin/credential/aws-ec2/backend_test.go
@@ -628,7 +628,7 @@ vSeDCOUMYQR7R9LINYwouHIziqQYMAkGByqGSM44BAMDLwAwLAIUWXBlk40xTwSw
 -----END CERTIFICATE-----
 `
 	if resp.Data["aws_public_cert"].(string) != expectedCert {
-		t.Fatal("bad: expected:%s\n got:%s\n", expectedCert, resp.Data["aws_public_cert"].(string))
+		t.Fatalf("bad: expected:%s\n got:%s\n", expectedCert, resp.Data["aws_public_cert"].(string))
 	}
 
 	certReq.Operation = logical.CreateOperation

--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -697,7 +697,7 @@ func Test_Renew(t *testing.T) {
 		StorageView: storage,
 	})
 	if err != nil {
-		t.Fatal("error: %s", err)
+		t.Fatalf("error: %s", err)
 	}
 
 	b := lb.(*backend)
@@ -779,7 +779,7 @@ func Test_Renew(t *testing.T) {
 		t.Fatal("got nil response from renew")
 	}
 	if resp.IsError() {
-		t.Fatal("got error: %#v", *resp)
+		t.Fatalf("got error: %#v", *resp)
 	}
 
 	// Delete CA, make sure we can't renew

--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -163,7 +163,7 @@ func createRole(t *testing.T) {
 	_, err := svc.CreateRole(params)
 
 	if err != nil {
-		t.Fatal("AWS CreateRole failed: %v", err)
+		t.Fatalf("AWS CreateRole failed: %v", err)
 	}
 
 	attachment := &iam.AttachRolePolicyInput{
@@ -173,7 +173,7 @@ func createRole(t *testing.T) {
 	_, err = svc.AttachRolePolicy(attachment)
 
 	if err != nil {
-		t.Fatal("AWS CreateRole failed: %v", err)
+		t.Fatalf("AWS CreateRole failed: %v", err)
 	}
 
 	// Sleep sometime because AWS is eventually consistent

--- a/builtin/logical/rabbitmq/backend_test.go
+++ b/builtin/logical/rabbitmq/backend_test.go
@@ -64,13 +64,13 @@ const (
 
 func testAccPreCheck(t *testing.T) {
 	if uri := os.Getenv(envRabbitMQConnectionURI); uri == "" {
-		t.Fatal(fmt.Sprintf("%s must be set for acceptance tests", envRabbitMQConnectionURI))
+		t.Fatalf(fmt.Sprintf("%s must be set for acceptance tests", envRabbitMQConnectionURI))
 	}
 	if username := os.Getenv(envRabbitMQUsername); username == "" {
-		t.Fatal(fmt.Sprintf("%s must be set for acceptance tests", envRabbitMQUsername))
+		t.Fatalf(fmt.Sprintf("%s must be set for acceptance tests", envRabbitMQUsername))
 	}
 	if password := os.Getenv(envRabbitMQPassword); password == "" {
-		t.Fatal(fmt.Sprintf("%s must be set for acceptance tests", envRabbitMQPassword))
+		t.Fatalf(fmt.Sprintf("%s must be set for acceptance tests", envRabbitMQPassword))
 	}
 }
 

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -124,7 +124,7 @@ func TestServer_ReloadListener(t *testing.T) {
 	checkFinished := func() {
 		finishedMutex.Lock()
 		if finished {
-			t.Fatal(fmt.Sprintf("finished early; relhcl was\n%s\nstdout was\n%s\nstderr was\n%s\n", relhcl, ui.OutputWriter.String(), ui.ErrorWriter.String()))
+			t.Fatalf(fmt.Sprintf("finished early; relhcl was\n%s\nstdout was\n%s\nstderr was\n%s\n", relhcl, ui.OutputWriter.String(), ui.ErrorWriter.String()))
 		}
 		finishedMutex.Unlock()
 	}

--- a/command/unwrap_test.go
+++ b/command/unwrap_test.go
@@ -61,7 +61,7 @@ func TestUnwrap(t *testing.T) {
 		t.Fatal("outer response was nil")
 	}
 	if outer.WrapInfo == nil {
-		t.Fatal("outer wrapinfo was nil, response was %#v", *outer)
+		t.Fatalf("outer wrapinfo was nil, response was %#v", *outer)
 	}
 
 	args = append(args, outer.WrapInfo.Token)
@@ -88,7 +88,7 @@ func TestUnwrap(t *testing.T) {
 		t.Fatal("outer response was nil")
 	}
 	if outer.WrapInfo == nil {
-		t.Fatal("outer wrapinfo was nil, response was %#v", *outer)
+		t.Fatalf("outer wrapinfo was nil, response was %#v", *outer)
 	}
 
 	args = []string{

--- a/helper/cidrutil/cidr_test.go
+++ b/helper/cidrutil/cidr_test.go
@@ -105,7 +105,7 @@ func TestCIDRUtil_ValidateCIDRListString(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !valid {
-		t.Fatalf("expected CIDR list %q to be valid")
+		t.Fatalf("expected CIDR list %q to be valid", cidrList)
 	}
 
 	cidrList = "172.169.100.200,192.168.0.0/16,10.10.20.20/24"
@@ -129,7 +129,7 @@ func TestCIDRUtil_ValidateCIDRListSlice(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !valid {
-		t.Fatalf("expected CIDR list %q to be valid")
+		t.Fatalf("expected CIDR list %q to be valid", cidrList)
 	}
 
 	cidrList = []string{"172.169.100.200", "192.168.0.0/16", "10.10.20.20/24"}
@@ -190,7 +190,7 @@ func TestCIDRUtil_Subset(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !subset {
-		t.Fatal("expected CIDR %q to be a subset of CIDR %q", cidr1, cidr2)
+		t.Fatalf("expected CIDR %q to be a subset of CIDR %q", cidr1, cidr2)
 	}
 }
 

--- a/helper/compressutil/compress_test.go
+++ b/helper/compressutil/compress_test.go
@@ -43,7 +43,7 @@ func TestCompressUtil_CompressDecompress(t *testing.T) {
 	}
 	// Check the presense of the canary
 	if compressedJSONBytes[0] != CompressionCanaryLzw {
-		t.Fatal("bad: compression canary: expected: %d actual: %d", CompressionCanaryLzw, compressedJSONBytes[0])
+		t.Fatalf("bad: compression canary: expected: %d actual: %d", CompressionCanaryLzw, compressedJSONBytes[0])
 	}
 
 	// Decompress the input and check the output
@@ -74,7 +74,7 @@ func TestCompressUtil_CompressDecompress(t *testing.T) {
 	}
 	// Check the presense of the canary
 	if compressedJSONBytes[0] != CompressionCanaryGzip {
-		t.Fatal("bad: compression canary: expected: %d actual: %d", CompressionCanaryGzip, compressedJSONBytes[0])
+		t.Fatalf("bad: compression canary: expected: %d actual: %d", CompressionCanaryGzip, compressedJSONBytes[0])
 	}
 
 	// Decompress the input and check the output
@@ -106,7 +106,7 @@ func TestCompressUtil_CompressDecompress(t *testing.T) {
 	}
 	// Check the presense of the canary
 	if compressedJSONBytes[0] != CompressionCanaryGzip {
-		t.Fatal("bad: compression canary: expected: %d actual: %d", CompressionCanaryGzip, compressedJSONBytes[0])
+		t.Fatalf("bad: compression canary: expected: %d actual: %d", CompressionCanaryGzip, compressedJSONBytes[0])
 	}
 
 	// Decompress the input and check the output
@@ -138,7 +138,7 @@ func TestCompressUtil_CompressDecompress(t *testing.T) {
 	}
 	// Check the presense of the canary
 	if compressedJSONBytes[0] != CompressionCanaryGzip {
-		t.Fatal("bad: compression canary: expected: %d actual: %d", CompressionCanaryGzip, compressedJSONBytes[0])
+		t.Fatalf("bad: compression canary: expected: %d actual: %d", CompressionCanaryGzip, compressedJSONBytes[0])
 	}
 
 	// Decompress the input and check the output
@@ -170,7 +170,7 @@ func TestCompressUtil_CompressDecompress(t *testing.T) {
 	}
 	// Check the presense of the canary
 	if compressedJSONBytes[0] != CompressionCanaryGzip {
-		t.Fatal("bad: compression canary: expected: %d actual: %d",
+		t.Fatalf("bad: compression canary: expected: %d actual: %d",
 			CompressionCanaryGzip, compressedJSONBytes[0])
 	}
 

--- a/helper/jsonutil/json_test.go
+++ b/helper/jsonutil/json_test.go
@@ -98,7 +98,7 @@ func TestJSONUtil_EncodeJSON(t *testing.T) {
 	expected := `{"test":"data","validation":"process"}`
 
 	if actual != expected {
-		t.Fatal("bad: encoded JSON: expected:%s\nactual:%s\n", expected, string(actualBytes))
+		t.Fatalf("bad: encoded JSON: expected:%s\nactual:%s\n", expected, string(actualBytes))
 	}
 }
 
@@ -117,7 +117,7 @@ func TestJSONUtil_DecodeJSON(t *testing.T) {
 		"validation": "process",
 	}
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatal("bad: expected:%#v\nactual:%#v", expected, actual)
+		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
 	}
 }
 
@@ -136,6 +136,6 @@ func TestJSONUtil_DecodeJSONFromReader(t *testing.T) {
 		"validation": "process",
 	}
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatal("bad: expected:%#v\nactual:%#v", expected, actual)
+		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
 	}
 }

--- a/helper/locksutil/locks_test.go
+++ b/helper/locksutil/locks_test.go
@@ -25,10 +25,10 @@ func Test_CreateLocks(t *testing.T) {
 
 	// Maximum number of locks
 	if err := CreateLocks(locks, 256); err != nil {
-		t.Fatal("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	if len(locks) != 256 {
-		t.Fatal("bad: len(locks): expected:256 actual:%d", len(locks))
+		t.Fatalf("bad: len(locks): expected:256 actual:%d", len(locks))
 	}
 
 	// Clear out the locks for testing the next case
@@ -38,10 +38,10 @@ func Test_CreateLocks(t *testing.T) {
 
 	// General case
 	if err := CreateLocks(locks, 10); err != nil {
-		t.Fatal("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	if len(locks) != 10 {
-		t.Fatal("bad: len(locks): expected:10 actual:%d", len(locks))
+		t.Fatalf("bad: len(locks): expected:10 actual:%d", len(locks))
 	}
 
 }

--- a/helper/policyutil/policyutil_test.go
+++ b/helper/policyutil/policyutil_test.go
@@ -6,14 +6,14 @@ func TestSanitizePolicies(t *testing.T) {
 	expected := []string{"foo", "bar"}
 	actual := SanitizePolicies([]string{"foo", "bar"}, false)
 	if !EquivalentPolicies(expected, actual) {
-		t.Fatal("bad: expected:%s\ngot:%s\n", expected, actual)
+		t.Fatalf("bad: expected:%s\ngot:%s\n", expected, actual)
 	}
 
 	// If 'default' is already added, do not remove it.
 	expected = []string{"foo", "bar", "default"}
 	actual = SanitizePolicies([]string{"foo", "bar", "default"}, false)
 	if !EquivalentPolicies(expected, actual) {
-		t.Fatal("bad: expected:%s\ngot:%s\n", expected, actual)
+		t.Fatalf("bad: expected:%s\ngot:%s\n", expected, actual)
 	}
 }
 
@@ -22,33 +22,33 @@ func TestParsePolicies(t *testing.T) {
 	actual := ParsePolicies("foo,bar")
 	// add default if not present.
 	if !EquivalentPolicies(expected, actual) {
-		t.Fatal("bad: expected:%s\ngot:%s\n", expected, actual)
+		t.Fatalf("bad: expected:%s\ngot:%s\n", expected, actual)
 	}
 
 	// do not add default more than once.
 	actual = ParsePolicies("foo,bar,default")
 	if !EquivalentPolicies(expected, actual) {
-		t.Fatal("bad: expected:%s\ngot:%s\n", expected, actual)
+		t.Fatalf("bad: expected:%s\ngot:%s\n", expected, actual)
 	}
 
 	// handle spaces and tabs.
 	actual = ParsePolicies(" foo ,	bar	,   default")
 	if !EquivalentPolicies(expected, actual) {
-		t.Fatal("bad: expected:%s\ngot:%s\n", expected, actual)
+		t.Fatalf("bad: expected:%s\ngot:%s\n", expected, actual)
 	}
 
 	// ignore all others if root is present.
 	expected = []string{"root"}
 	actual = ParsePolicies("foo,bar,root")
 	if !EquivalentPolicies(expected, actual) {
-		t.Fatal("bad: expected:%s\ngot:%s\n", expected, actual)
+		t.Fatalf("bad: expected:%s\ngot:%s\n", expected, actual)
 	}
 
 	// with spaces and tabs.
 	expected = []string{"root"}
 	actual = ParsePolicies("foo ,bar, root		")
 	if !EquivalentPolicies(expected, actual) {
-		t.Fatal("bad: expected:%s\ngot:%s\n", expected, actual)
+		t.Fatalf("bad: expected:%s\ngot:%s\n", expected, actual)
 	}
 }
 

--- a/helper/strutil/strutil_test.go
+++ b/helper/strutil/strutil_test.go
@@ -35,7 +35,7 @@ func TestStrUtil_StrListDelete(t *testing.T) {
 
 	output = StrListDelete(output, "random")
 	if len(output) != 1 {
-		t.Fatal("bad: expected: 1, actual: %d", len(output))
+		t.Fatalf("bad: expected: 1, actual: %d", len(output))
 	}
 
 	output = StrListDelete(output, "item3")

--- a/http/sys_wrapping_test.go
+++ b/http/sys_wrapping_test.go
@@ -301,7 +301,7 @@ func TestHTTP_Wrapping(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(data, secret.Data) {
-		t.Fatal("custom wrap did not match expected: %#v", secret.Data)
+		t.Fatalf("custom wrap did not match expected: %#v", secret.Data)
 	}
 
 	//

--- a/vault/cluster_test.go
+++ b/vault/cluster_test.go
@@ -110,7 +110,7 @@ func TestCluster_ListenForRequests(t *testing.T) {
 		for _, ln := range cores[0].Listeners {
 			tcpAddr, ok := ln.Addr().(*net.TCPAddr)
 			if !ok {
-				t.Fatal("%s not a TCP port", tcpAddr.String())
+				t.Fatalf("%s not a TCP port", tcpAddr.String())
 			}
 
 			conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", tcpAddr.IP.String(), tcpAddr.Port+10), tlsConfig)

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -2190,7 +2190,7 @@ func TestTokenStore_RolePeriod(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatal(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -2347,7 +2347,7 @@ func TestTokenStore_RoleExplicitMaxTTL(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatal(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -2475,7 +2475,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatal(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -2535,7 +2535,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatal(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -2596,7 +2596,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatal(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)
@@ -2663,7 +2663,7 @@ func TestTokenStore_Periodic(t *testing.T) {
 			t.Fatal("response was nil")
 		}
 		if resp.Auth == nil {
-			t.Fatal(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
+			t.Fatalf(fmt.Sprintf("response auth was nil, resp is %#v", *resp))
 		}
 		if resp.Auth.ClientToken == "" {
 			t.Fatalf("bad: %#v", resp)


### PR DESCRIPTION
This is janitorial

Fix calls to t.Fatal() with formatting.
Fixed some calls to Fatalf() with wrong formatting