### PR TITLE
Base64 encode the file names in the 'file' physical backend

### DIFF
--- a/physical/file.go
+++ b/physical/file.go
@@ -167,8 +167,8 @@ func (b *FileBackend) Put(entry *Entry) error {
 	// base64 URL encode the file name to make all the characters compatible by
 	// the host OS (specially Windows). However, the basePath can contain
 	// disallowed characters.  Encoding all the directory names and the file
-	// name is an over kill, and encoding all at once will flatten the file
-	// system, which *may* not be desire.
+	// name is an over kill, and encoding the fullPath will flatten the
+	// storage, which *may* not be desired.
 	fullPath = filepath.Join(basePath, "_"+base64.URLEncoding.EncodeToString([]byte(fileName)))
 
 	// JSON encode the entry and write it

--- a/physical/file.go
+++ b/physical/file.go
@@ -145,7 +145,8 @@ func (b *FileBackend) Put(entry *Entry) error {
 	// file with a non-encoded file name exists, it indicates that this is an
 	// update operation. To avoid duplication of storage entries, delete the
 	// old entry in the defer function.
-	if _, err := os.Stat(fullPathPrefixedFileName); !os.IsNotExist(err) {
+	info, err := os.Stat(fullPathPrefixedFileName)
+	if err == nil && info != nil {
 		defer func() {
 			err := os.Remove(fullPathPrefixedFileName)
 			if err != nil && !os.IsNotExist(err) {

--- a/physical/file.go
+++ b/physical/file.go
@@ -59,7 +59,7 @@ func (b *FileBackend) Delete(path string) error {
 	}
 
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("Failed to remove %q: %v", fullPathPrefixedFileName, err)
+		return fmt.Errorf("Failed to remove %q: %v", path, err)
 	}
 
 	err = b.cleanupLogicalPath(path)

--- a/physical/file_test.go
+++ b/physical/file_test.go
@@ -1,13 +1,135 @@
 package physical
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/vault/helper/logformat"
 	log "github.com/mgutz/logxi/v1"
 )
+
+func TestFileBackend_Base64URLEncoding(t *testing.T) {
+	backendPath, err := ioutil.TempDir("", "vault")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.RemoveAll(backendPath)
+
+	logger := logformat.NewVaultLogger(log.LevelTrace)
+
+	b, err := NewBackend("file", logger, map[string]string{
+		"path": backendPath,
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// List the entries. Length should be zero.
+	keys, err := b.List("")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("bad: len(keys): expected: 0, actual: %d", len(keys))
+	}
+
+	// Create a storage entry without base64 encoding the file name
+	rawFullPath := filepath.Join(backendPath, "_foo")
+	e := &Entry{Key: "foo", Value: []byte("test")}
+	f, err := os.OpenFile(
+		rawFullPath,
+		os.O_CREATE|os.O_TRUNC|os.O_WRONLY,
+		0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	json.NewEncoder(f).Encode(e)
+	f.Close()
+
+	// Get should work
+	out, err := b.Get("foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(out, e) {
+		t.Fatalf("bad: %v expected: %v", out, e)
+	}
+
+	// List the entries. There should be one entry.
+	keys, err = b.List("")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("bad: len(keys): expected: 1, actual: %d", len(keys))
+	}
+
+	err = b.Put(e)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// List the entries again. There should still be one entry.
+	keys, err = b.List("")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("bad: len(keys): expected: 1, actual: %d", len(keys))
+	}
+
+	// Get should work
+	out, err = b.Get("foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !reflect.DeepEqual(out, e) {
+		t.Fatalf("bad: %v expected: %v", out, e)
+	}
+
+	err = b.Delete("foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	out, err = b.Get("foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("bad: entry: expected: nil, actual: %#v", e)
+	}
+
+	keys, err = b.List("")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("bad: len(keys): expected: 0, actual: %d", len(keys))
+	}
+
+	f, err = os.OpenFile(
+		rawFullPath,
+		os.O_CREATE|os.O_TRUNC|os.O_WRONLY,
+		0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	json.NewEncoder(f).Encode(e)
+	f.Close()
+
+	keys, err = b.List("")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("bad: len(keys): expected: 1, actual: %d", len(keys))
+	}
+}
 
 func TestFileBackend(t *testing.T) {
 	dir, err := ioutil.TempDir("", "vault")


### PR DESCRIPTION
Fixes https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/vault-tool/D2GStAl1f1k/AoURH_uUEAAJ in a generic manner.

This will deprecate #2198.

This PR will base64 URL encodes the file name part for all the paths stored at the `file` backend and decodes when appropriate with backwards compatibility. This will ensure that file names are compatible with Windows platform.

*Note*: However, if Windows disallowed characters are present as part of the `basePath`, then it will not work. If we choose to encode the entire path, the directory hierarchy will flatten, which *may* not be desired.

Tested on Windows manually to verify the reported bug in PKI.