### PR TITLE
Add cookbook section, with root vault generate-root technique

### DIFF
--- a/website/source/docs/concepts/tokens.html.md
+++ b/website/source/docs/concepts/tokens.html.md
@@ -54,8 +54,8 @@ of version 0.6.1, there are only three ways to create root tokens:
    expiration
 2. By using another root token; a root token with an expiration cannot create a
    root token that never expires
-3. By using `vault generate-root` with the permission of a quorum of unseal key
-   holders
+3. By using `vault generate-root` ([example](../cookbook/index.html#generate-a-root-token-when-none-exists))
+   with the permission of a quorum of unseal key holders
 
 Root tokens are useful in development but should be extremely carefully guarded
 in production. In fact, the Vault team recommends that root tokens are only

--- a/website/source/docs/cookbook/index.html.md
+++ b/website/source/docs/cookbook/index.html.md
@@ -1,0 +1,20 @@
+---
+layout: "docs"
+page_title: "Vault Cookbook"
+sidebar_current: "docs-cookbook"
+description: |-
+  Vault server how-to cookbook.
+---
+
+# Day-to-day tasks with Vault
+
+## Generate a root token (when none exists)
+
+It's considered [best practice](../concepts/tokens.html#root-tokens) not to keep root tokens around, as they are all-powerful. Instead, if one is absolutely needed, create it using vault's generate-root command:
+
+1. Unseal the vault. You do not need to be authenticated (you do not need an existing root token).
+2. Generate a one-time password with `vault generate-root -genotp`
+3. Get the encoded root token: `vault generate-root -otp <generated_otp>` (Requires a quorum of unseal keys again, so needs to be done \<quorum\> times.)
+4. Decode the encoded root token with `vault generate-root -otp <generated_otp> -decode=<encoded_root_token> `
+
+(See `vault generate-root -h` for information on the alternate technique using a PGP key.)

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -220,6 +220,11 @@
 						</li>
 					</ul>
 				</li>
+
+				<li<%= sidebar_current("docs-cookbook") %>>
+					<a href="/docs/cookbook/index.html">Cookbook</a>
+				</li>
+
 			</ul>
 		</div>
 	<% end %>


### PR DESCRIPTION
There are many things in vault that are documented at a high level or at the very low level (like help on the vault command). But sometimes it takes some work to actually put them to use. 

* This PR adds a "cookbook" section to the manual.
* The first item in the cookbook is how to generate a root token with `vault generate-root`

Mostly, I just wanted to add the specifics on vault generate-root and couldn't find an appropriate place for it that wouldn't interrupt to flow. So here's my attempt :) Any other place is fine.