### PR TITLE
Add link to vault-client vc written in go

### DIFF
--- a/website/source/docs/http/libraries.html.md
+++ b/website/source/docs/http/libraries.html.md
@@ -49,6 +49,10 @@ These libraries are provided by the community.
 
 * [vaultex](https://hex.pm/packages/vaultex)
 
+### Go
+
+* [vc](https://github.com/adfinis-sygroup/vault-client)
+
 ### Haskell
 
 * [vault-tool](https://hackage.haskell.org/package/vault-tool)


### PR DESCRIPTION
vc is a new client written in Go and inspired by pass (kudos to @winpat).