### PR TITLE
etcd3: remove wrong keys checking for prefix request

### DIFF
--- a/physical/etcd3.go
+++ b/physical/etcd3.go
@@ -287,9 +287,6 @@ func (c *EtcdLock) Value() (bool, string, error) {
 	if len(resp.Kvs) == 0 {
 		return false, "", nil
 	}
-	if len(resp.Kvs) > 1 {
-		return false, "", errors.New("unexpected number of keys from a get request")
-	}
 
 	return true, string(resp.Kvs[0].Value), nil
 }


### PR DESCRIPTION
/cc @jefferai 

I tried to run e2e testing by modifying /vault/testing.go to use etcd3 all over the place.

Everything passes expect:

`TestExpiration_RevokePrefix`.

I looked into that test, it seems to use noopBackend. So the failure is unrelated to etcd3 backend?

What eles should I do to make sure etcd3 work well for vault?