### PR TITLE
Example "List" command missing a forward slash

### DIFF
--- a/website/source/docs/http/index.html.md
+++ b/website/source/docs/http/index.html.md
@@ -84,7 +84,7 @@ given directory:
 $ curl \
     -H "X-Vault-Token: f3b09679-3001-009d-2b80-9c306ab81aa6" \
     -X GET \
-    http://127.0.0.1:8200/v1/secret?list=true
+    http://127.0.0.1:8200/v1/secret/?list=true
 ```
 
 To write a secret, issue a POST on the following URL:


### PR DESCRIPTION
The List command example is missing a forward slash before the query parameter.