### PR TITLE
Add environment variables for address and token when using the consul backend

### DIFF
--- a/physical/consul.go
+++ b/physical/consul.go
@@ -2,6 +2,7 @@ package physical
 
 import (
 	"fmt"
+	"os"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -152,6 +153,15 @@ func newConsulBackend(conf map[string]string, logger log.Logger) (Backend, error
 			logger.Debug("physical/consul: config address set", "address", addr)
 		}
 	}
+
+	addressEnv := os.Getenv("CONSUL_ADDR")
+	if addressEnv != "" {
+		consulConf.Address = addressEnv
+		if logger.IsDebug() {
+			logger.Debug("physical/consul: config address set via ENV", "address", addressEnv)
+		}
+	}
+
 	if scheme, ok := conf["scheme"]; ok {
 		consulConf.Scheme = scheme
 		if logger.IsDebug() {
@@ -161,6 +171,14 @@ func newConsulBackend(conf map[string]string, logger log.Logger) (Backend, error
 	if token, ok := conf["token"]; ok {
 		consulConf.Token = token
 		logger.Debug("physical/consul: config token set")
+	}
+
+	tokenEnv := os.Getenv("CONSUL_TOKEN")
+	if tokenEnv != "" {
+		consulConf.Token = tokenEnv
+		if logger.IsDebug() {
+			logger.Debug("physical/consul: config token set via ENV")
+		}
 	}
 
 	if consulConf.Scheme == "https" {


### PR DESCRIPTION
Allow the use of environment variables for the consul address and consul token. This adds feature parity with the etcd backend where the address and username/password can be set via environment variables.