### PR TITLE
Adding interface methods to logical.Backend for parity

### DIFF
--- a/logical/logical.go
+++ b/logical/logical.go
@@ -38,6 +38,11 @@ type Backend interface {
 	// Cleanup is invoked during an unmount of a backend to allow it to
 	// handle any cleanup like connection closing or releasing of file handles.
 	Cleanup()
+
+	// InvalidateKey may be invoked when an object is modified that belongs
+	// to the backend. The backend can use this to clear any caches or reset
+	// internal state as needed.
+	InvalidateKey(key string)
 }
 
 // BackendConfig is provided to the factory to initialize the backend

--- a/logical/logical.go
+++ b/logical/logical.go
@@ -35,6 +35,8 @@ type Backend interface {
 	// existence check function was found, the item exists or not.
 	HandleExistenceCheck(*Request) (bool, bool, error)
 
+	// Cleanup is invoked during an unmount of a backend to allow it to
+	// handle any cleanup like connection closing or releasing of file handles.
 	Cleanup()
 }
 

--- a/logical/storage.go
+++ b/logical/storage.go
@@ -1,11 +1,17 @@
 package logical
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/hashicorp/vault/helper/jsonutil"
 )
+
+// ErrReadOnly is returned when a backend does not support
+// writing. This can be caused by a read-only replica or secondary
+// cluster operation.
+var ErrReadOnly = errors.New("Cannot write to readonly storage")
 
 // Storage is the way that logical backends are able read/write data.
 type Storage interface {

--- a/logical/system_view.go
+++ b/logical/system_view.go
@@ -30,6 +30,11 @@ type SystemView interface {
 	// Returns true if caching is disabled. If true, no caches should be used,
 	// despite known slowdowns.
 	CachingDisabled() bool
+
+	// IsPrimary checks if this is a primary Vault instance. This
+	// can be used to avoid writes on secondaries and to avoid doing
+	// lazy upgrades which may cause writes.
+	IsPrimary() bool
 }
 
 type StaticSystemView struct {
@@ -38,6 +43,7 @@ type StaticSystemView struct {
 	SudoPrivilegeVal   bool
 	TaintedVal         bool
 	CachingDisabledVal bool
+	Primary            bool
 }
 
 func (d StaticSystemView) DefaultLeaseTTL() time.Duration {
@@ -58,4 +64,8 @@ func (d StaticSystemView) Tainted() bool {
 
 func (d StaticSystemView) CachingDisabled() bool {
 	return d.CachingDisabledVal
+}
+
+func (d StaticSystemView) IsPrimary() bool {
+	return d.Primary
 }

--- a/vault/barrier_view.go
+++ b/vault/barrier_view.go
@@ -15,8 +15,9 @@ import (
 // BarrierView implements logical.Storage so it can be passed in as the
 // durable storage mechanism for logical views.
 type BarrierView struct {
-	barrier BarrierStorage
-	prefix  string
+	barrier  BarrierStorage
+	prefix   string
+	readonly bool
 }
 
 // NewBarrierView takes an underlying security barrier and returns
@@ -95,7 +96,7 @@ func (v *BarrierView) Delete(key string) error {
 // SubView constructs a nested sub-view using the given prefix
 func (v *BarrierView) SubView(prefix string) *BarrierView {
 	sub := v.expandKey(prefix)
-	return &BarrierView{barrier: v.barrier, prefix: sub}
+	return &BarrierView{barrier: v.barrier, prefix: sub, readonly: v.readonly}
 }
 
 // expandKey is used to expand to the full key path with the prefix

--- a/vault/barrier_view.go
+++ b/vault/barrier_view.go
@@ -68,6 +68,9 @@ func (v *BarrierView) Get(key string) (*logical.StorageEntry, error) {
 
 // logical.Storage impl.
 func (v *BarrierView) Put(entry *logical.StorageEntry) error {
+	if v.readonly {
+		return logical.ErrReadOnly
+	}
 	if err := v.sanityCheck(entry.Key); err != nil {
 		return err
 	}
@@ -80,6 +83,9 @@ func (v *BarrierView) Put(entry *logical.StorageEntry) error {
 
 // logical.Storage impl.
 func (v *BarrierView) Delete(key string) error {
+	if v.readonly {
+		return logical.ErrReadOnly
+	}
 	if err := v.sanityCheck(key); err != nil {
 		return err
 	}

--- a/vault/barrier_view_test.go
+++ b/vault/barrier_view_test.go
@@ -282,3 +282,35 @@ func TestBarrierView_ClearView(t *testing.T) {
 		t.Fatalf("have keys: %#v", out)
 	}
 }
+func TestBarrierView_Readonly(t *testing.T) {
+	_, barrier, _ := mockBarrier(t)
+	view := NewBarrierView(barrier, "foo/")
+
+	// Add a key before enabling read-only
+	entry := &Entry{Key: "test", Value: []byte("test")}
+	if err := view.Put(entry.Logical()); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Enable read only mode
+	view.readonly = true
+
+	// Put should fail in readonly mode
+	if err := view.Put(entry.Logical()); err != logical.ErrReadOnly {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Delete nested
+	if err := view.Delete("test"); err != logical.ErrReadOnly {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check the non-nested key
+	e, err := view.Get("test")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if e == nil {
+		t.Fatalf("key test missing")
+	}
+}

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -74,8 +74,3 @@ func (d dynamicSystemView) Tainted() bool {
 func (d dynamicSystemView) CachingDisabled() bool {
 	return d.core.cachingDisabled
 }
-
-// IsPrimary checks if this is a primary Vault instance.
-func (d dynamicSystemView) IsPrimary() bool {
-	return true
-}

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -74,3 +74,8 @@ func (d dynamicSystemView) Tainted() bool {
 func (d dynamicSystemView) CachingDisabled() bool {
 	return d.core.cachingDisabled
 }
+
+// IsPrimary checks if this is a primary Vault instance.
+func (d dynamicSystemView) IsPrimary() bool {
+	return true
+}

--- a/vault/dynamic_system_view_ext.go
+++ b/vault/dynamic_system_view_ext.go
@@ -1,0 +1,8 @@
+// +build vault
+
+package vault
+
+// IsPrimary checks if this is a primary Vault instance.
+func (d dynamicSystemView) IsPrimary() bool {
+	return true
+}

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -17,6 +17,9 @@ func mockRollback(t *testing.T) (*RollbackManager, *NoopBackend) {
 	mounts := new(MountTable)
 	router := NewRouter()
 
+	_, barrier, _ := mockBarrier(t)
+	view := NewBarrierView(barrier, "logical/")
+
 	mounts.Entries = []*MountEntry{
 		&MountEntry{
 			Path: "foo",
@@ -26,7 +29,7 @@ func mockRollback(t *testing.T) (*RollbackManager, *NoopBackend) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := router.Mount(backend, "foo", &MountEntry{UUID: meUUID}, nil); err != nil {
+	if err := router.Mount(backend, "foo", &MountEntry{UUID: meUUID}, view); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/vault/router_test.go
+++ b/vault/router_test.go
@@ -57,6 +57,10 @@ func (n *NoopBackend) Cleanup() {
 	// noop
 }
 
+func (n *NoopBackend) InvalidateKey(string) {
+	// noop
+}
+
 func TestRouter_Mount(t *testing.T) {
 	r := NewRouter()
 	_, barrier, _ := mockBarrier(t)

--- a/vault/router_test.go
+++ b/vault/router_test.go
@@ -67,7 +67,7 @@ func TestRouter_Mount(t *testing.T) {
 		t.Fatal(err)
 	}
 	n := &NoopBackend{}
-	err = r.Mount(n, "prod/aws/", &MountEntry{UUID: meUUID}, view)
+	err = r.Mount(n, "prod/aws/", &MountEntry{Path: "prod/aws/", UUID: meUUID}, view)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -97,6 +97,14 @@ func TestRouter_Mount(t *testing.T) {
 		t.Fatalf("bad: %s", v)
 	}
 
+	mount, prefix, ok := r.MatchingStoragePrefix("logical/foo")
+	if !ok {
+		t.Fatalf("missing storage prefix")
+	}
+	if mount != "prod/aws/" || prefix != "logical/" {
+		t.Fatalf("Bad: %v - %v", mount, prefix)
+	}
+
 	req := &logical.Request{
 		Path: "prod/aws/foo",
 	}
@@ -124,7 +132,7 @@ func TestRouter_Unmount(t *testing.T) {
 		t.Fatal(err)
 	}
 	n := &NoopBackend{}
-	err = r.Mount(n, "prod/aws/", &MountEntry{UUID: meUUID}, view)
+	err = r.Mount(n, "prod/aws/", &MountEntry{Path: "prod/aws/", UUID: meUUID}, view)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -141,6 +149,10 @@ func TestRouter_Unmount(t *testing.T) {
 	if !strings.Contains(err.Error(), "unsupported path") {
 		t.Fatalf("err: %v", err)
 	}
+
+	if _, _, ok := r.MatchingStoragePrefix("logical/foo"); ok {
+		t.Fatalf("should not have matching storage prefix")
+	}
 }
 
 func TestRouter_Remount(t *testing.T) {
@@ -153,11 +165,13 @@ func TestRouter_Remount(t *testing.T) {
 		t.Fatal(err)
 	}
 	n := &NoopBackend{}
-	err = r.Mount(n, "prod/aws/", &MountEntry{UUID: meUUID}, view)
+	me := &MountEntry{Path: "prod/aws/", UUID: meUUID}
+	err = r.Mount(n, "prod/aws/", me, view)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
+	me.Path = "stage/aws/"
 	err = r.Remount("prod/aws/", "stage/aws/")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -187,6 +201,15 @@ func TestRouter_Remount(t *testing.T) {
 	// Verify the path
 	if len(n.Paths) != 1 || n.Paths[0] != "foo" {
 		t.Fatalf("bad: %v", n.Paths)
+	}
+
+	// Check the resolve from storage still works
+	mount, prefix, _ := r.MatchingStoragePrefix("logical/foobar")
+	if mount != "stage/aws/" {
+		t.Fatalf("bad mount: %s", mount)
+	}
+	if prefix != "logical/" {
+		t.Fatalf("Bad prefix: %s", prefix)
 	}
 }
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -381,6 +381,10 @@ func (n *rawHTTP) Cleanup() {
 	// noop
 }
 
+func (n *rawHTTP) InvalidateKey(string) {
+	// noop
+}
+
 func GenerateRandBytes(length int) ([]byte, error) {
 	if length < 0 {
 		return nil, fmt.Errorf("length must be >= 0")

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -593,11 +593,13 @@ func TestTokenStore_Revoke(t *testing.T) {
 }
 
 func TestTokenStore_Revoke_Leases(t *testing.T) {
-	_, ts, _, _ := TestCoreWithTokenStore(t)
+	c, ts, _, _ := TestCoreWithTokenStore(t)
+
+	view := NewBarrierView(c.barrier, "noop/")
 
 	// Mount a noop backend
 	noop := &NoopBackend{}
-	ts.expiration.router.Mount(noop, "", &MountEntry{UUID: ""}, nil)
+	ts.expiration.router.Mount(noop, "", &MountEntry{UUID: ""}, view)
 
 	ent := &TokenEntry{Path: "test", Policies: []string{"dev", "ops"}}
 	if err := ts.create(ent); err != nil {


### PR DESCRIPTION
This PR adds some additional methods to the logical backend and system view for parity with the enterprise version. 