### PR TITLE
sign-verbatim should set use_csr_common_name to true

### DIFF
--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -124,6 +124,7 @@ func (b *backend) pathSignVerbatim(
 		AllowIPSANs:      true,
 		EnforceHostnames: false,
 		KeyType:          "any",
+		UseCSRCommonName: true,
 	}
 
 	return b.pathIssueSignCert(req, data, role, true, true)

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -52,7 +52,7 @@ func pathSign(b *backend) *framework.Path {
 
 func pathSignVerbatim(b *backend) *framework.Path {
 	ret := &framework.Path{
-		Pattern: "sign-verbatim/" + framework.GenericNameRegex("role"),
+		Pattern: "sign-verbatim" + framework.OptionalParamRegex("role"),
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.pathSignVerbatim,


### PR DESCRIPTION
The generated role used by the pki `/sign-verbatim` endpoint should set use_csr_common_name to true.

Fixes a bug where the sign-verbatim endpoint can only be used if a `common_name` field is added to the request even though the field is ignored.

example:
- csr subj:
```
$ openssl req -subject -noout -in vault-test.csr
subject=/C=US/ST=California/L=San Francisco/OU=vault/CN=vault
```

- request without common_name:
```
$ vault write -field=certificate pki/sign-verbatim/foo csr=@vault-test.csr
Error writing data to pki/sign-verbatim: Error making API request.

URL: PUT https://localhost:8201/v1/pki/sign-verbatim
Code: 400. Errors:

* the common_name field is required, or must be provided in a CSR with "use_csr_common_name" set to true
```

- request with dummy common_name:
```
$ vault write -field=certificate pki/sign-verbatim/foo csr=@vault-test.csr common_name="ignored" | openssl x509 -subject -noout
subject=/C=US/ST=California/L=San Francisco/OU=vault/CN=vault
```
