### PR TITLE
Correctly document response code for auth/token/revoke endpoint

### DIFF
--- a/website/source/docs/auth/token.html.md
+++ b/website/source/docs/auth/token.html.md
@@ -501,7 +501,8 @@ of the header should be "X-Vault-Token" and the value should be the token.
   </dd>
 
   <dt>Returns</dt>
-  <dd>`204` response code.
+  <dd>`204` response code when the token is in the request body.<br />
+      `200` response code when the token is in the URL <em>(not recommended)</em>.
   </dd>
 </dl>
 


### PR DESCRIPTION
The response code depends on whether the token is placed in the URL
(HTTP 200 with warning in response body) or in the request body
(HTTP 204).

Fixes #2248 