### PR TITLE
Remove documenting that the token to revoke can be part of the URL as

### DIFF
--- a/website/source/docs/auth/token.html.md
+++ b/website/source/docs/auth/token.html.md
@@ -473,7 +473,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
   </dd>
 </dl>
 
-### /auth/token/revoke[/token]
+### /auth/token/revoke
 #### POST
 
 <dl class="api">
@@ -487,7 +487,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
   <dd>POST</dd>
 
   <dt>URL</dt>
-  <dd>`/auth/token/revoke</token>`</dd>
+  <dd>`/auth/token/revoke`</dd>
 
   <dt>Parameters</dt>
   <dd>
@@ -495,7 +495,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
       <li>
         <span class="param">token</span>
         <span class="param-flags">required</span>
-            Token to revoke. This can be part of the URL or the body.
+            Token to revoke.
       </li>
     </ul>
   </dd>
@@ -505,7 +505,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
   </dd>
 </dl>
 
-### /auth/token/revoke-accessor[/accessor]
+### /auth/token/revoke-accessor
 #### POST
 
 <dl class="api">
@@ -520,7 +520,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
   <dd>POST</dd>
 
   <dt>URL</dt>
-  <dd>`/auth/token/revoke-accessor</accessor>`</dd>
+  <dd>`/auth/token/revoke-accessor`</dd>
 
   <dt>Parameters</dt>
   <dd>
@@ -528,7 +528,7 @@ of the header should be "X-Vault-Token" and the value should be the token.
       <li>
         <span class="param">accessor</span>
         <span class="param-flags">required</span>
-            Accessor of the token. This can be part of the URL or the body.
+            Accessor of the token.
       </li>
     </ul>
   </dd>


### PR DESCRIPTION
this should never be used and only remains for backwards compat.

Fixes #2248