### PR TITLE
physical/zk: Ignore ErrNoNode when deleting znodes

### DIFF
--- a/physical/zookeeper.go
+++ b/physical/zookeeper.go
@@ -182,7 +182,7 @@ func (c *ZookeeperBackend) cleanupLogicalPath(path string) error {
 			return nil
 		} else {
 			// Empty node, lets clean it up!
-			if err := c.client.Delete(fullPath, -1); err != nil {
+			if err := c.client.Delete(fullPath, -1); err != nil && err != zk.ErrNoNode {
 				msgFmt := "Removal of node `%s` failed: `%v`"
 				return fmt.Errorf(msgFmt, fullPath, err)
 			}


### PR DESCRIPTION
This change ignores when znodes don't exist that we are trying to delete. It seems to have shown up as part of https://github.com/hashicorp/vault/pull/1964. We ran into this during tear down of our internal tests we remove the auth backends we created in earlier steps. 