### PR TITLE
Added a 'read' for github config

### DIFF
--- a/builtin/credential/github/path_config.go
+++ b/builtin/credential/github/path_config.go
@@ -77,10 +77,10 @@ func (b *backend) pathConfigWrite(
 	}
 
 	entry, err := logical.StorageEntryJSON("config", config{
-		Org:     organization,
-		BaseURL: baseURL,
-		TTL:     ttl,
-		MaxTTL:  maxTTL,
+		Organization:	organization,
+		BaseURL: 	baseURL,
+		TTL:     	ttl,
+		MaxTTL:  	maxTTL,
 	})
 
 	if err != nil {
@@ -99,6 +99,11 @@ func (b *backend) pathConfigRead(req *logical.Request, data *framework.FieldData
 	if err != nil {
 		return nil, err
 	}
+
+	if config == nil {
+		return nil, fmt.Errorf("configuration object not found")
+	}
+
 	config.TTL /= time.Second
 	config.MaxTTL /= time.Second
 
@@ -126,8 +131,8 @@ func (b *backend) Config(s logical.Storage) (*config, error) {
 }
 
 type config struct {
-	Org     string        `json:"organization" structs:"organization" mapstructure:"organization"`
-	BaseURL string        `json:"base_url" structs:"base_url" mapstructure:"base_url"`
-	TTL     time.Duration `json:"ttl" structs:"ttl" mapstructure:"ttl"`
-	MaxTTL  time.Duration `json:"max_ttl" structs:"max_ttl" mapstructure:"max_ttl"`
+	Organization string        `json:"organization" structs:"organization" mapstructure:"organization"`
+	BaseURL      string        `json:"base_url" structs:"base_url" mapstructure:"base_url"`
+	TTL          time.Duration `json:"ttl" structs:"ttl" mapstructure:"ttl"`
+	MaxTTL       time.Duration `json:"max_ttl" structs:"max_ttl" mapstructure:"max_ttl"`
 }

--- a/builtin/credential/github/path_login.go
+++ b/builtin/credential/github/path_login.go
@@ -107,7 +107,7 @@ func (b *backend) verifyCredentials(req *logical.Request, token string) (*verify
 	if err != nil {
 		return nil, nil, err
 	}
-	if config.Org == "" {
+	if config.Organization == "" {
 		return nil, logical.ErrorResponse(
 			"configure the github credential backend first"), nil
 	}
@@ -152,7 +152,7 @@ func (b *backend) verifyCredentials(req *logical.Request, token string) (*verify
 	}
 
 	for _, o := range allOrgs {
-		if strings.ToLower(*o.Login) == strings.ToLower(config.Org) {
+		if strings.ToLower(*o.Login) == strings.ToLower(config.Organization) {
 			org = o
 			break
 		}


### PR DESCRIPTION
While working on https://github.com/hashicorp/vault/issues/2239, I also thought it'd be good to support reading the current config.

#2239 is still in progress, this is just "inspired" by it.  

I wasn't sure if the struct needed both `structs` and `mapstructure` added, but I figured it doesn't hurt to do both.