### PR TITLE
Set c.standby true in non-HA context.

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1088,6 +1088,8 @@ func (c *Core) sealInternal() error {
 
 	// Do pre-seal teardown if HA is not enabled
 	if c.ha == nil {
+		// Even in a non-HA context we key off of this for some things
+		c.standby = true
 		if err := c.preSeal(); err != nil {
 			c.logger.Error("core: pre-seal teardown failed", "error", err)
 			return fmt.Errorf("internal error")


### PR DESCRIPTION
This value is the key for some checks in core logic. In a non-HA
environment, if the core was sealed it would never be set back to true.