### PR TITLE
Fixed rabbitmq documentation

### DIFF
--- a/website/source/docs/secrets/rabbitmq/index.html.md
+++ b/website/source/docs/secrets/rabbitmq/index.html.md
@@ -74,7 +74,7 @@ For example, lets create a "readwrite" virtual host role:
 ```text
 $ vault write rabbitmq/roles/readwrite \
     vhosts='{"/":{"write": ".*", "read": ".*"}}'
-Success! Data written to: rabbitmq/roles/readonly
+Success! Data written to: rabbitmq/roles/readwrite
 ```
 
 By writing to the `roles/readwrite` path we are defining the `readwrite` role.


### PR DESCRIPTION
The docs were inconsistent between readwrite and readonly, the policy
itself evaluates to a readwrite policy, so the inconsistency is solved
by changing the odd occurrence of readonly.