### PR TITLE
doc: remove unused 429 code from docs to avoid confusion

### DIFF
--- a/website/source/docs/http/index.html.md
+++ b/website/source/docs/http/index.html.md
@@ -161,8 +161,6 @@ The following HTTP status codes are used throughout the API.
 - `404` - Invalid path. This can both mean that the path truly
    doesn't exist or that you don't have permission to view a
    specific path. We use 404 in some cases to avoid state leakage.
-- `429` - Rate limit exceeded. Try again after waiting some period
-   of time.
 - `500` - Internal server error. An internal error has occurred,
    try again later. If the error persists, report a bug.
 - `503` - Vault is down for maintenance or is currently sealed.


### PR DESCRIPTION
Fixes #336 