### PR TITLE
Multi value test seal

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Developing Vault
 
 If you wish to work on Vault itself or any of its built-in systems,
 you'll first need [Go](https://www.golang.org) installed on your
-machine (version 1.7+ is *required*).
+machine (version 1.8+ is *required*).
 
 For local dev first make sure Go is properly installed, including setting up a
 [GOPATH](https://golang.org/doc/code.html#GOPATH). Next, clone this repository

--- a/command/generate-root_test.go
+++ b/command/generate-root_test.go
@@ -202,13 +202,12 @@ func TestGenerateRoot_OTP(t *testing.T) {
 }
 
 func TestGenerateRoot_PGP(t *testing.T) {
-	core, ts, key, _ := vault.TestCoreWithTokenStore(t)
+	core, ts, keys, _ := vault.TestCoreWithTokenStore(t)
 	ln, addr := http.TestServer(t, core)
 	defer ln.Close()
 
 	ui := new(cli.MockUi)
 	c := &GenerateRootCommand{
-		Key: hex.EncodeToString(key),
 		Meta: meta.Meta{
 			Ui: ui,
 		},
@@ -235,14 +234,23 @@ func TestGenerateRoot_PGP(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	c.Nonce = config.Nonce
+	for _, key := range keys {
+		c = &GenerateRootCommand{
+			Key: hex.EncodeToString(key),
+			Meta: meta.Meta{
+				Ui: ui,
+			},
+		}
 
-	// Provide the key
-	args = []string{
-		"-address", addr,
-	}
-	if code := c.Run(args); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+		c.Nonce = config.Nonce
+
+		// Provide the key
+		args = []string{
+			"-address", addr,
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+		}
 	}
 
 	beforeNAfter := strings.Split(ui.OutputWriter.String(), "Encoded root token: ")

--- a/command/generate-root_test.go
+++ b/command/generate-root_test.go
@@ -18,13 +18,12 @@ import (
 )
 
 func TestGenerateRoot_Cancel(t *testing.T) {
-	core, key, _ := vault.TestCoreUnsealed(t)
+	core, _, _ := vault.TestCoreUnsealed(t)
 	ln, addr := http.TestServer(t, core)
 	defer ln.Close()
 
 	ui := new(cli.MockUi)
 	c := &GenerateRootCommand{
-		Key: hex.EncodeToString(key),
 		Meta: meta.Meta{
 			Ui: ui,
 		},
@@ -56,13 +55,12 @@ func TestGenerateRoot_Cancel(t *testing.T) {
 }
 
 func TestGenerateRoot_status(t *testing.T) {
-	core, key, _ := vault.TestCoreUnsealed(t)
+	core, _, _ := vault.TestCoreUnsealed(t)
 	ln, addr := http.TestServer(t, core)
 	defer ln.Close()
 
 	ui := new(cli.MockUi)
 	c := &GenerateRootCommand{
-		Key: hex.EncodeToString(key),
 		Meta: meta.Meta{
 			Ui: ui,
 		},
@@ -90,13 +88,12 @@ func TestGenerateRoot_status(t *testing.T) {
 }
 
 func TestGenerateRoot_OTP(t *testing.T) {
-	core, ts, key, _ := vault.TestCoreWithTokenStore(t)
+	core, ts, keys, _ := vault.TestCoreWithTokenStore(t)
 	ln, addr := http.TestServer(t, core)
 	defer ln.Close()
 
 	ui := new(cli.MockUi)
 	c := &GenerateRootCommand{
-		Key: hex.EncodeToString(key),
 		Meta: meta.Meta{
 			Ui: ui,
 		},
@@ -124,14 +121,24 @@ func TestGenerateRoot_OTP(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	c.Nonce = config.Nonce
+	for _, key := range keys {
+		ui = new(cli.MockUi)
+		c = &GenerateRootCommand{
+			Key: hex.EncodeToString(key),
+			Meta: meta.Meta{
+				Ui: ui,
+			},
+		}
 
-	// Provide the key
-	args = []string{
-		"-address", addr,
-	}
-	if code := c.Run(args); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+		c.Nonce = config.Nonce
+
+		// Provide the key
+		args = []string{
+			"-address", addr,
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+		}
 	}
 
 	beforeNAfter := strings.Split(ui.OutputWriter.String(), "Encoded root token: ")

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -27,8 +27,10 @@ func TestStatus(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 
-	if _, err := core.Unseal(key); err != nil {
-		t.Fatalf("err: %s", err)
+	for _, key := range keys {
+		if _, err := core.Unseal(key); err != nil {
+			t.Fatalf("err: %s", err)
+		}
 	}
 
 	if code := c.Run(args); code != 0 {

--- a/command/status_test.go
+++ b/command/status_test.go
@@ -18,7 +18,7 @@ func TestStatus(t *testing.T) {
 	}
 
 	core := vault.TestCore(t)
-	key, _ := vault.TestCoreInit(t, core)
+	keys, _ := vault.TestCoreInit(t, core)
 	ln, addr := http.TestServer(t, core)
 	defer ln.Close()
 

--- a/command/unseal_test.go
+++ b/command/unseal_test.go
@@ -12,21 +12,23 @@ import (
 
 func TestUnseal(t *testing.T) {
 	core := vault.TestCore(t)
-	key, _ := vault.TestCoreInit(t, core)
+	keys, _ := vault.TestCoreInit(t, core)
 	ln, addr := http.TestServer(t, core)
 	defer ln.Close()
 
-	ui := new(cli.MockUi)
-	c := &UnsealCommand{
-		Key: hex.EncodeToString(key),
-		Meta: meta.Meta{
-			Ui: ui,
-		},
-	}
+	for _, key := range keys {
+		ui := new(cli.MockUi)
+		c := &UnsealCommand{
+			Key: hex.EncodeToString(key),
+			Meta: meta.Meta{
+				Ui: ui,
+			},
+		}
 
-	args := []string{"-address", addr}
-	if code := c.Run(args); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+		args := []string{"-address", addr}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+		}
 	}
 
 	sealed, err := core.Sealed()
@@ -40,20 +42,22 @@ func TestUnseal(t *testing.T) {
 
 func TestUnseal_arg(t *testing.T) {
 	core := vault.TestCore(t)
-	key, _ := vault.TestCoreInit(t, core)
+	keys, _ := vault.TestCoreInit(t, core)
 	ln, addr := http.TestServer(t, core)
 	defer ln.Close()
 
-	ui := new(cli.MockUi)
-	c := &UnsealCommand{
-		Meta: meta.Meta{
-			Ui: ui,
-		},
-	}
+	for _, key := range keys {
+		ui := new(cli.MockUi)
+		c := &UnsealCommand{
+			Meta: meta.Meta{
+				Ui: ui,
+			},
+		}
 
-	args := []string{"-address", addr, hex.EncodeToString(key)}
-	if code := c.Run(args); code != 0 {
-		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+		args := []string{"-address", addr, hex.EncodeToString(key)}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+		}
 	}
 
 	sealed, err := core.Sealed()

--- a/command/unseal_test.go
+++ b/command/unseal_test.go
@@ -16,8 +16,9 @@ func TestUnseal(t *testing.T) {
 	ln, addr := http.TestServer(t, core)
 	defer ln.Close()
 
+	ui := new(cli.MockUi)
+
 	for _, key := range keys {
-		ui := new(cli.MockUi)
 		c := &UnsealCommand{
 			Key: hex.EncodeToString(key),
 			Meta: meta.Meta{
@@ -46,8 +47,9 @@ func TestUnseal_arg(t *testing.T) {
 	ln, addr := http.TestServer(t, core)
 	defer ln.Close()
 
+	ui := new(cli.MockUi)
+
 	for _, key := range keys {
-		ui := new(cli.MockUi)
 		c := &UnsealCommand{
 			Meta: meta.Meta{
 				Ui: ui,

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -125,10 +125,12 @@ func TestLogical_StandbyRedirect(t *testing.T) {
 	TestServerAuth(t, addr1, root)
 
 	// WRITE to STANDBY
-	resp := testHttpPut(t, root, addr2+"/v1/secret/foo", map[string]interface{}{
+	resp := testHttpPutDisableRedirect(t, root, addr2+"/v1/secret/foo", map[string]interface{}{
 		"data": "bar",
 	})
+	logger.Trace("307 test one starting")
 	testResponseStatus(t, resp, 307)
+	logger.Trace("307 test one stopping")
 
 	//// READ to standby
 	resp = testHttpGet(t, root, addr2+"/v1/auth/token/lookup-self")
@@ -167,8 +169,10 @@ func TestLogical_StandbyRedirect(t *testing.T) {
 	}
 
 	//// DELETE to standby
-	resp = testHttpDelete(t, root, addr2+"/v1/secret/foo")
+	resp = testHttpDeleteDisableRedirect(t, root, addr2+"/v1/secret/foo")
+	logger.Trace("307 test two starting")
 	testResponseStatus(t, resp, 307)
+	logger.Trace("307 test two stopping")
 }
 
 func TestLogical_CreateToken(t *testing.T) {

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -92,9 +92,11 @@ func TestLogical_StandbyRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	key, root := vault.TestCoreInit(t, core1)
-	if _, err := core1.Unseal(vault.TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	keys, root := vault.TestCoreInit(t, core1)
+	for _, key := range keys {
+		if _, err := core1.Unseal(vault.TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Attempt to fix raciness in this test by giving the first core a chance
@@ -112,8 +114,10 @@ func TestLogical_StandbyRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, err := core2.Unseal(vault.TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	for _, key := range keys {
+		if _, err := core2.Unseal(vault.TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	TestServerWithListener(t, ln1, addr1, core1)

--- a/http/sys_generate_root_test.go
+++ b/http/sys_generate_root_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
@@ -29,7 +30,7 @@ func TestSysGenerateRootAttempt_Status(t *testing.T) {
 	expected := map[string]interface{}{
 		"started":            false,
 		"progress":           json.Number("0"),
-		"required":           json.Number("1"),
+		"required":           json.Number("3"),
 		"complete":           false,
 		"encoded_root_token": "",
 		"pgp_fingerprint":    "",
@@ -63,7 +64,7 @@ func TestSysGenerateRootAttempt_Setup_OTP(t *testing.T) {
 	expected := map[string]interface{}{
 		"started":            true,
 		"progress":           json.Number("0"),
-		"required":           json.Number("1"),
+		"required":           json.Number("3"),
 		"complete":           false,
 		"encoded_root_token": "",
 		"pgp_fingerprint":    "",
@@ -84,7 +85,7 @@ func TestSysGenerateRootAttempt_Setup_OTP(t *testing.T) {
 	expected = map[string]interface{}{
 		"started":            true,
 		"progress":           json.Number("0"),
-		"required":           json.Number("1"),
+		"required":           json.Number("3"),
 		"complete":           false,
 		"encoded_root_token": "",
 		"pgp_fingerprint":    "",
@@ -117,7 +118,7 @@ func TestSysGenerateRootAttempt_Setup_PGP(t *testing.T) {
 	expected := map[string]interface{}{
 		"started":            true,
 		"progress":           json.Number("0"),
-		"required":           json.Number("1"),
+		"required":           json.Number("3"),
 		"complete":           false,
 		"encoded_root_token": "",
 		"pgp_fingerprint":    "816938b8a29146fbe245dd29e7cbaf8e011db793",
@@ -153,7 +154,7 @@ func TestSysGenerateRootAttempt_Cancel(t *testing.T) {
 	expected := map[string]interface{}{
 		"started":            true,
 		"progress":           json.Number("0"),
-		"required":           json.Number("1"),
+		"required":           json.Number("3"),
 		"complete":           false,
 		"encoded_root_token": "",
 		"pgp_fingerprint":    "",
@@ -180,7 +181,7 @@ func TestSysGenerateRootAttempt_Cancel(t *testing.T) {
 	expected = map[string]interface{}{
 		"started":            false,
 		"progress":           json.Number("0"),
-		"required":           json.Number("1"),
+		"required":           json.Number("3"),
 		"complete":           false,
 		"encoded_root_token": "",
 		"pgp_fingerprint":    "",
@@ -269,8 +270,8 @@ func TestSysGenerateRoot_Update_OTP(t *testing.T) {
 		expected = map[string]interface{}{
 			"complete":        false,
 			"nonce":           rootGenerationStatus["nonce"].(string),
-			"progress":        json.Number(i + 1),
-			"required":        json.Number(len(keys)),
+			"progress":        json.Number(fmt.Sprintf("%d", i+1)),
+			"required":        json.Number(fmt.Sprintf("%d", len(keys))),
 			"started":         true,
 			"pgp_fingerprint": "",
 		}
@@ -357,8 +358,8 @@ func TestSysGenerateRoot_Update_PGP(t *testing.T) {
 		expected = map[string]interface{}{
 			"complete":        false,
 			"nonce":           rootGenerationStatus["nonce"].(string),
-			"progress":        json.Number(i + 1),
-			"required":        json.Number(len(keys)),
+			"progress":        json.Number(fmt.Sprintf("%d", i+1)),
+			"required":        json.Number(fmt.Sprintf("%d", len(keys))),
 			"started":         true,
 			"pgp_fingerprint": "816938b8a29146fbe245dd29e7cbaf8e011db793",
 		}

--- a/http/sys_health_test.go
+++ b/http/sys_health_test.go
@@ -45,7 +45,7 @@ func TestSysHealth_get(t *testing.T) {
 		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
 	}
 
-	key, _ := vault.TestCoreInit(t, core)
+	keys, _ := vault.TestCoreInit(t, core)
 	resp, err = http.Get(addr + "/v1/sys/health")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -75,8 +75,10 @@ func TestSysHealth_get(t *testing.T) {
 		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
 	}
 
-	if _, err := vault.TestCoreUnseal(core, vault.TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	for _, key := range keys {
+		if _, err := vault.TestCoreUnseal(core, vault.TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 	resp, err = http.Get(addr + "/v1/sys/health")
 	if err != nil {
@@ -148,7 +150,7 @@ func TestSysHealth_customcodes(t *testing.T) {
 		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
 	}
 
-	key, _ := vault.TestCoreInit(t, core)
+	keys, _ := vault.TestCoreInit(t, core)
 	resp, err = http.Get(queryurl.String())
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -179,8 +181,10 @@ func TestSysHealth_customcodes(t *testing.T) {
 		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
 	}
 
-	if _, err := vault.TestCoreUnseal(core, vault.TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	for _, key := range keys {
+		if _, err := vault.TestCoreUnseal(core, vault.TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 	resp, err = http.Get(queryurl.String())
 	if err != nil {

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -204,8 +204,10 @@ func handleSysRekeyUpdate(core *vault.Core, recovery bool) http.Handler {
 			}
 			resp.Keys = keys
 			resp.KeysB64 = keysB64
+			respondOk(w, resp)
+		} else {
+			handleSysRekeyInitGet(core, recovery, w, r)
 		}
-		respondOk(w, resp)
 	})
 }
 

--- a/http/sys_rekey_test.go
+++ b/http/sys_rekey_test.go
@@ -43,7 +43,7 @@ func TestSysRekeyInit_Status(t *testing.T) {
 		"t":                json.Number("0"),
 		"n":                json.Number("0"),
 		"progress":         json.Number("0"),
-		"required":         json.Number("1"),
+		"required":         json.Number("3"),
 		"pgp_fingerprints": interface{}(nil),
 		"backup":           false,
 		"nonce":            "",
@@ -73,7 +73,7 @@ func TestSysRekeyInit_Setup(t *testing.T) {
 		"t":                json.Number("3"),
 		"n":                json.Number("5"),
 		"progress":         json.Number("0"),
-		"required":         json.Number("1"),
+		"required":         json.Number("3"),
 		"pgp_fingerprints": interface{}(nil),
 		"backup":           false,
 	}
@@ -95,7 +95,7 @@ func TestSysRekeyInit_Setup(t *testing.T) {
 		"t":                json.Number("3"),
 		"n":                json.Number("5"),
 		"progress":         json.Number("0"),
-		"required":         json.Number("1"),
+		"required":         json.Number("3"),
 		"pgp_fingerprints": interface{}(nil),
 		"backup":           false,
 	}
@@ -139,7 +139,7 @@ func TestSysRekeyInit_Cancel(t *testing.T) {
 		"t":                json.Number("0"),
 		"n":                json.Number("0"),
 		"progress":         json.Number("0"),
-		"required":         json.Number("1"),
+		"required":         json.Number("3"),
 		"pgp_fingerprints": interface{}(nil),
 		"backup":           false,
 		"nonce":            "",
@@ -196,7 +196,7 @@ func TestSysRekey_Update(t *testing.T) {
 		if i+1 == len(keys) {
 			expected["complete"] = true
 		}
-		testResponseStatus(t, resp, 20)
+		testResponseStatus(t, resp, 200)
 		testResponseBody(t, resp, &actual)
 	}
 

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -26,8 +27,8 @@ func TestSysSealStatus(t *testing.T) {
 	var actual map[string]interface{}
 	expected := map[string]interface{}{
 		"sealed":   true,
-		"t":        json.Number("1"),
-		"n":        json.Number("1"),
+		"t":        json.Number("3"),
+		"n":        json.Number("3"),
 		"progress": json.Number("0"),
 	}
 	testResponseStatus(t, resp, 200)
@@ -114,8 +115,8 @@ func TestSysUnseal(t *testing.T) {
 		expected := map[string]interface{}{
 			"sealed":   true,
 			"t":        json.Number("3"),
-			"n":        json.Number("5"),
-			"progress": json.Number(i + 1),
+			"n":        json.Number("3"),
+			"progress": json.Number(fmt.Sprintf("%d", i+1)),
 		}
 		if i == len(keys)-1 {
 			expected["sealed"] = false

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -120,6 +120,7 @@ func TestSysUnseal(t *testing.T) {
 		}
 		if i == len(keys)-1 {
 			expected["sealed"] = false
+			expected["progress"] = 0
 		}
 		testResponseStatus(t, resp, 200)
 		testResponseBody(t, resp, &actual)

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -54,7 +54,7 @@ func (n *NoopAudit) Reload() error {
 }
 
 func TestCore_EnableAudit(t *testing.T) {
-	c, key, _ := TestCoreUnsealed(t)
+	c, keys, _ := TestCoreUnsealed(t)
 	c.auditBackends["noop"] = func(config *audit.BackendConfig) (audit.Backend, error) {
 		return &NoopAudit{
 			Config: config,
@@ -89,12 +89,14 @@ func TestCore_EnableAudit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	unseal, err := TestCoreUnseal(c2, key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !unseal {
-		t.Fatalf("should be unsealed")
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c2, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("should be unsealed")
+		}
 	}
 
 	// Verify matching audit tables
@@ -160,7 +162,7 @@ func TestCore_EnableAudit_MixedFailures(t *testing.T) {
 }
 
 func TestCore_DisableAudit(t *testing.T) {
-	c, key, _ := TestCoreUnsealed(t)
+	c, keys, _ := TestCoreUnsealed(t)
 	c.auditBackends["noop"] = func(config *audit.BackendConfig) (audit.Backend, error) {
 		return &NoopAudit{
 			Config: config,
@@ -200,12 +202,14 @@ func TestCore_DisableAudit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	unseal, err := TestCoreUnseal(c2, key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !unseal {
-		t.Fatalf("should be unsealed")
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c2, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("should be unsealed")
+		}
 	}
 
 	// Verify matching mount tables
@@ -215,7 +219,7 @@ func TestCore_DisableAudit(t *testing.T) {
 }
 
 func TestCore_DefaultAuditTable(t *testing.T) {
-	c, key, _ := TestCoreUnsealed(t)
+	c, keys, _ := TestCoreUnsealed(t)
 	verifyDefaultAuditTable(t, c.audit)
 
 	// Verify we have an audit broker
@@ -232,12 +236,14 @@ func TestCore_DefaultAuditTable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	unseal, err := TestCoreUnseal(c2, key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !unseal {
-		t.Fatalf("should be unsealed")
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c2, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("should be unsealed")
+		}
 	}
 
 	// Verify matching mount tables

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCore_DefaultAuthTable(t *testing.T) {
-	c, key, _ := TestCoreUnsealed(t)
+	c, keys, _ := TestCoreUnsealed(t)
 	verifyDefaultAuthTable(t, c.auth)
 
 	// Start a second core with same physical
@@ -20,12 +20,14 @@ func TestCore_DefaultAuthTable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	unseal, err := TestCoreUnseal(c2, key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !unseal {
-		t.Fatalf("should be unsealed")
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c2, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("should be unsealed")
+		}
 	}
 
 	// Verify matching mount tables
@@ -35,7 +37,7 @@ func TestCore_DefaultAuthTable(t *testing.T) {
 }
 
 func TestCore_EnableCredential(t *testing.T) {
-	c, key, _ := TestCoreUnsealed(t)
+	c, keys, _ := TestCoreUnsealed(t)
 	c.credentialBackends["noop"] = func(*logical.BackendConfig) (logical.Backend, error) {
 		return &NoopBackend{}, nil
 	}
@@ -66,12 +68,14 @@ func TestCore_EnableCredential(t *testing.T) {
 	c2.credentialBackends["noop"] = func(*logical.BackendConfig) (logical.Backend, error) {
 		return &NoopBackend{}, nil
 	}
-	unseal, err := TestCoreUnseal(c2, key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !unseal {
-		t.Fatalf("should be unsealed")
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c2, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("should be unsealed")
+		}
 	}
 
 	// Verify matching auth tables
@@ -122,7 +126,7 @@ func TestCore_EnableCredential_Token(t *testing.T) {
 }
 
 func TestCore_DisableCredential(t *testing.T) {
-	c, key, _ := TestCoreUnsealed(t)
+	c, keys, _ := TestCoreUnsealed(t)
 	c.credentialBackends["noop"] = func(*logical.BackendConfig) (logical.Backend, error) {
 		return &NoopBackend{}, nil
 	}
@@ -160,12 +164,14 @@ func TestCore_DisableCredential(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	unseal, err := TestCoreUnseal(c2, key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !unseal {
-		t.Fatalf("should be unsealed")
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c2, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("should be unsealed")
+		}
 	}
 
 	// Verify matching mount tables

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -1,7 +1,6 @@
 package vault
 
 import (
-	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -300,7 +299,7 @@ func (b *AESGCMBarrier) ReloadMasterKey() error {
 	defer b.l.Unlock()
 
 	// Check if the master key is the same
-	if bytes.Equal(b.keyring.MasterKey(), key.Value) {
+	if subtle.ConstantTimeCompare(b.keyring.MasterKey(), key.Value) == 1 {
 		return nil
 	}
 

--- a/vault/cluster_test.go
+++ b/vault/cluster_test.go
@@ -52,9 +52,11 @@ func TestClusterHAFetching(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	key, _ := TestCoreInit(t, c)
-	if _, err := TestCoreUnseal(c, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	keys, _ := TestCoreInit(t, c)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(c, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Verify unsealed

--- a/vault/core.go
+++ b/vault/core.go
@@ -1146,6 +1146,13 @@ func (c *Core) postUnseal() (retErr error) {
 	}
 	// HA mode requires us to handle keyring rotation and rekeying
 	if c.ha != nil {
+		// We want to reload these from disk so that in case of a rekey we're
+		// not using cached values
+		c.seal.SetBarrierConfig(nil)
+		if c.seal.RecoveryKeySupported() {
+			c.seal.SetRecoveryConfig(nil)
+		}
+
 		if err := c.checkKeyUpgrades(); err != nil {
 			return err
 		}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -228,12 +228,18 @@ func TestCore_Route_Sealed(t *testing.T) {
 
 // Attempt to unseal after doing a first seal
 func TestCore_SealUnseal(t *testing.T) {
-	c, key, root := TestCoreUnsealed(t)
+	c, keys, root := TestCoreUnsealed(t)
 	if err := c.Seal(root); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if unseal, err := TestCoreUnseal(c, key); err != nil || !unseal {
-		t.Fatalf("err: %v", err)
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("err: should be unsealed")
+		}
 	}
 }
 
@@ -979,9 +985,11 @@ func TestCore_Standby_Seal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	key, root := TestCoreInit(t, core)
-	if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	keys, root := TestCoreInit(t, core)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Verify unsealed
@@ -1019,8 +1027,10 @@ func TestCore_Standby_Seal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Verify unsealed
@@ -1086,9 +1096,11 @@ func TestCore_StepDown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	key, root := TestCoreInit(t, core)
-	if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	keys, root := TestCoreInit(t, core)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Verify unsealed
@@ -1126,8 +1138,10 @@ func TestCore_StepDown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Verify unsealed
@@ -1273,9 +1287,11 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	key, root := TestCoreInit(t, core)
-	if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	keys, root := TestCoreInit(t, core)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Verify unsealed
@@ -1340,8 +1356,10 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Verify unsealed
@@ -1441,9 +1459,11 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	key, root := TestCoreInit(t, core)
-	if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	keys, root := TestCoreInit(t, core)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Verify unsealed
@@ -1495,8 +1515,10 @@ func testCore_Standby_Common(t *testing.T, inm physical.Backend, inmha physical.
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Verify unsealed
@@ -1988,9 +2010,11 @@ func TestCore_Standby_Rotate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	key, root := TestCoreInit(t, core)
-	if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	keys, root := TestCoreInit(t, core)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Wait for core to become active
@@ -2007,8 +2031,10 @@ func TestCore_Standby_Rotate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Rotate the encryption key

--- a/vault/generate_root_test.go
+++ b/vault/generate_root_test.go
@@ -10,10 +10,12 @@ import (
 )
 
 func TestCore_GenerateRoot_Lifecycle(t *testing.T) {
-	c, master, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Lifecycle_Common(t, c, [][]byte{master})
-
 	bc, rc := TestSealDefConfigs()
+	c, masterKeys, _, _ := TestCoreUnsealedWithConfigs(t, bc, rc)
+	c.seal.(*TestSeal).recoveryKeysDisabled = true
+	testCore_GenerateRoot_Lifecycle_Common(t, c, masterKeys)
+
+	bc, rc = TestSealDefConfigs()
 	c, _, recoveryKeys, _ := TestCoreUnsealedWithConfigs(t, bc, rc)
 	testCore_GenerateRoot_Lifecycle_Common(t, c, recoveryKeys)
 }
@@ -109,12 +111,17 @@ func testCore_GenerateRoot_Init_Common(t *testing.T, c *Core) {
 }
 
 func TestCore_GenerateRoot_InvalidMasterNonce(t *testing.T) {
-	c, master, _ := TestCoreUnsealed(t)
-	// Make the master invalid
-	master[0]++
-	testCore_GenerateRoot_InvalidMasterNonce_Common(t, c, [][]byte{master})
-
 	bc, rc := TestSealDefConfigs()
+	bc.SecretShares = 1
+	bc.SecretThreshold = 1
+	bc.StoredShares = 0
+	c, masterKeys, _, _ := TestCoreUnsealedWithConfigs(t, bc, rc)
+	c.seal.(*TestSeal).recoveryKeysDisabled = true
+	// Make the master invalid
+	masterKeys[0][0]++
+	testCore_GenerateRoot_InvalidMasterNonce_Common(t, c, masterKeys)
+
+	bc, rc = TestSealDefConfigs()
 	// For ease of use let's make the threshold the same as the shares and also
 	// no stored shares so we get an error after the full set
 	bc.StoredShares = 0
@@ -123,7 +130,7 @@ func TestCore_GenerateRoot_InvalidMasterNonce(t *testing.T) {
 	rc.SecretShares = 5
 	rc.SecretThreshold = 5
 	// In this case, pass in master keys instead as they'll be invalid
-	c, masterKeys, _, _ := TestCoreUnsealedWithConfigs(t, bc, rc)
+	c, masterKeys, _, _ = TestCoreUnsealedWithConfigs(t, bc, rc)
 	testCore_GenerateRoot_InvalidMasterNonce_Common(t, c, masterKeys)
 }
 
@@ -163,10 +170,12 @@ func testCore_GenerateRoot_InvalidMasterNonce_Common(t *testing.T, c *Core, keys
 }
 
 func TestCore_GenerateRoot_Update_OTP(t *testing.T) {
-	c, master, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Update_OTP_Common(t, c, [][]byte{master})
-
 	bc, rc := TestSealDefConfigs()
+	c, masterKeys, _, _ := TestCoreUnsealedWithConfigs(t, bc, rc)
+	c.seal.(*TestSeal).recoveryKeysDisabled = true
+	testCore_GenerateRoot_Update_OTP_Common(t, c, masterKeys[0:bc.SecretThreshold])
+
+	bc, rc = TestSealDefConfigs()
 	c, _, recoveryKeys, _ := TestCoreUnsealedWithConfigs(t, bc, rc)
 	testCore_GenerateRoot_Update_OTP_Common(t, c, recoveryKeys[0:rc.SecretThreshold])
 }
@@ -249,10 +258,12 @@ func testCore_GenerateRoot_Update_OTP_Common(t *testing.T, c *Core, keys [][]byt
 }
 
 func TestCore_GenerateRoot_Update_PGP(t *testing.T) {
-	c, master, _ := TestCoreUnsealed(t)
-	testCore_GenerateRoot_Update_PGP_Common(t, c, [][]byte{master})
-
 	bc, rc := TestSealDefConfigs()
+	c, masterKeys, _, _ := TestCoreUnsealedWithConfigs(t, bc, rc)
+	c.seal.(*TestSeal).recoveryKeysDisabled = true
+	testCore_GenerateRoot_Update_PGP_Common(t, c, masterKeys[0:bc.SecretThreshold])
+
+	bc, rc = TestSealDefConfigs()
 	c, _, recoveryKeys, _ := TestCoreUnsealedWithConfigs(t, bc, rc)
 	testCore_GenerateRoot_Update_PGP_Common(t, c, recoveryKeys[0:rc.SecretThreshold])
 }

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestCore_DefaultMountTable(t *testing.T) {
-	c, key, _ := TestCoreUnsealed(t)
+	c, keys, _ := TestCoreUnsealed(t)
 	verifyDefaultTable(t, c.mounts)
 
 	// Start a second core with same physical
@@ -25,12 +25,14 @@ func TestCore_DefaultMountTable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	unseal, err := TestCoreUnseal(c2, key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !unseal {
-		t.Fatalf("should be unsealed")
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c2, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("should be unsealed")
+		}
 	}
 
 	// Verify matching mount tables
@@ -40,7 +42,7 @@ func TestCore_DefaultMountTable(t *testing.T) {
 }
 
 func TestCore_Mount(t *testing.T) {
-	c, key, _ := TestCoreUnsealed(t)
+	c, keys, _ := TestCoreUnsealed(t)
 	me := &MountEntry{
 		Table: mountTableType,
 		Path:  "foo",
@@ -64,12 +66,14 @@ func TestCore_Mount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	unseal, err := TestCoreUnseal(c2, key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !unseal {
-		t.Fatalf("should be unsealed")
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c2, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("should be unsealed")
+		}
 	}
 
 	// Verify matching mount tables
@@ -79,7 +83,7 @@ func TestCore_Mount(t *testing.T) {
 }
 
 func TestCore_Unmount(t *testing.T) {
-	c, key, _ := TestCoreUnsealed(t)
+	c, keys, _ := TestCoreUnsealed(t)
 	existed, err := c.unmount("secret")
 	if !existed || err != nil {
 		t.Fatalf("existed: %v; err: %v", existed, err)
@@ -98,12 +102,14 @@ func TestCore_Unmount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	unseal, err := TestCoreUnseal(c2, key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !unseal {
-		t.Fatalf("should be unsealed")
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c2, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("should be unsealed")
+		}
 	}
 
 	// Verify matching mount tables
@@ -197,7 +203,7 @@ func TestCore_Unmount_Cleanup(t *testing.T) {
 }
 
 func TestCore_Remount(t *testing.T) {
-	c, key, _ := TestCoreUnsealed(t)
+	c, keys, _ := TestCoreUnsealed(t)
 	err := c.remount("secret", "foo")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -216,12 +222,14 @@ func TestCore_Remount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	unseal, err := TestCoreUnseal(c2, key)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if !unseal {
-		t.Fatalf("should be unsealed")
+	for i, key := range keys {
+		unseal, err := TestCoreUnseal(c2, key)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if i+1 == len(keys) && !unseal {
+			t.Fatalf("should be unsealed")
+		}
 	}
 
 	// Verify matching mount tables

--- a/vault/rekey_test.go
+++ b/vault/rekey_test.go
@@ -12,11 +12,18 @@ import (
 )
 
 func TestCore_Rekey_Lifecycle(t *testing.T) {
-	c, master, _ := TestCoreUnsealed(t)
-	testCore_Rekey_Lifecycle_Common(t, c, [][]byte{master}, false)
-
 	bc, rc := TestSealDefConfigs()
+	bc.SecretShares = 1
+	bc.SecretThreshold = 1
+	bc.StoredShares = 0
 	c, masterKeys, recoveryKeys, _ := TestCoreUnsealedWithConfigs(t, bc, rc)
+	if len(masterKeys) != 1 {
+		t.Fatalf("expected %d keys, got %d", bc.SecretShares-bc.StoredShares, len(masterKeys))
+	}
+	testCore_Rekey_Lifecycle_Common(t, c, masterKeys, false)
+
+	bc, rc = TestSealDefConfigs()
+	c, masterKeys, recoveryKeys, _ = TestCoreUnsealedWithConfigs(t, bc, rc)
 	if len(masterKeys) != 3 {
 		t.Fatalf("expected %d keys, got %d", bc.SecretShares-bc.StoredShares, len(masterKeys))
 	}
@@ -129,10 +136,14 @@ func testCore_Rekey_Init_Common(t *testing.T, c *Core, recovery bool) {
 }
 
 func TestCore_Rekey_Update(t *testing.T) {
-	c, master, root := TestCoreUnsealed(t)
-	testCore_Rekey_Update_Common(t, c, [][]byte{master}, root, false)
-
 	bc, rc := TestSealDefConfigs()
+	bc.SecretShares = 1
+	bc.SecretThreshold = 1
+	bc.StoredShares = 0
+	c, masterKeys, _, root := TestCoreUnsealedWithConfigs(t, bc, rc)
+	testCore_Rekey_Update_Common(t, c, masterKeys, root, false)
+
+	bc, rc = TestSealDefConfigs()
 	bc.StoredShares = 0
 	c, masterKeys, recoveryKeys, root := TestCoreUnsealedWithConfigs(t, bc, rc)
 	testCore_Rekey_Update_Common(t, c, masterKeys, root, false)
@@ -178,7 +189,7 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 			break
 		}
 	}
-	if result == nil || len(result.SecretShares) != 5 {
+	if result == nil || len(result.SecretShares) != newConf.SecretShares {
 		t.Fatalf("Bad: %#v", result)
 	}
 
@@ -309,9 +320,6 @@ func testCore_Rekey_Update_Common(t *testing.T, c *Core, keys [][]byte, root str
 }
 
 func TestCore_Rekey_Invalid(t *testing.T) {
-	c, master, _ := TestCoreUnsealed(t)
-	testCore_Rekey_Invalid_Common(t, c, [][]byte{master}, false)
-
 	bc, rc := TestSealDefConfigs()
 	bc.StoredShares = 0
 	bc.SecretShares = 1
@@ -372,13 +380,16 @@ func TestCore_Standby_Rekey(t *testing.T) {
 		HAPhysical:   inmha,
 		RedirectAddr: redirectOriginal,
 		DisableMlock: true,
+		DisableCache: true,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	key, root := TestCoreInit(t, core)
-	if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	keys, root := TestCoreInit(t, core)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Wait for core to become active
@@ -391,12 +402,15 @@ func TestCore_Standby_Rekey(t *testing.T) {
 		HAPhysical:   inmha,
 		RedirectAddr: redirectOriginal2,
 		DisableMlock: true,
+		DisableCache: true,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
-		t.Fatalf("unseal err: %s", err)
+	for _, key := range keys {
+		if _, err := TestCoreUnseal(core2, TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
 	}
 
 	// Rekey the master key
@@ -416,11 +430,14 @@ func TestCore_Standby_Rekey(t *testing.T) {
 	if rkconf == nil {
 		t.Fatalf("bad: no rekey config received")
 	}
-	result, err := core.RekeyUpdate(key, rkconf.Nonce, false)
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	var rekeyResult *RekeyResult
+	for _, key := range keys {
+		rekeyResult, err = core.RekeyUpdate(key, rkconf.Nonce, false)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
 	}
-	if result == nil {
+	if rekeyResult == nil {
 		t.Fatalf("rekey failed")
 	}
 
@@ -446,11 +463,21 @@ func TestCore_Standby_Rekey(t *testing.T) {
 	if rkconf == nil {
 		t.Fatalf("bad: no rekey config received")
 	}
-	result, err = core2.RekeyUpdate(result.SecretShares[0], rkconf.Nonce, false)
+	var rekeyResult2 *RekeyResult
+	for _, key := range rekeyResult.SecretShares {
+		rekeyResult2, err = core2.RekeyUpdate(key, rkconf.Nonce, false)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+	if rekeyResult2 == nil {
+		t.Fatalf("rekey failed")
+	}
+
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if result == nil {
+	if rekeyResult2 == nil {
 		t.Fatalf("rekey failed")
 	}
 }

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -160,6 +160,13 @@ func (d *DefaultSeal) SetBarrierConfig(config *SealConfig) error {
 		return err
 	}
 
+	// Provide a way to wipe out the cached value (also prevents actually
+	// saving a nil config)
+	if config == nil {
+		d.config = nil
+		return nil
+	}
+
 	config.Type = d.BarrierType()
 
 	// Encode the seal configuration

--- a/vault/seal_testing.go
+++ b/vault/seal_testing.go
@@ -7,10 +7,12 @@ import (
 )
 
 type TestSeal struct {
-	defseal        *DefaultSeal
-	barrierKeys    [][]byte
-	recoveryKey    []byte
-	recoveryConfig *SealConfig
+	defseal              *DefaultSeal
+	barrierKeys          [][]byte
+	recoveryKey          []byte
+	recoveryConfig       *SealConfig
+	storedKeysDisabled   bool
+	recoveryKeysDisabled bool
 }
 
 func newTestSeal(t *testing.T) Seal {
@@ -43,11 +45,11 @@ func (d *TestSeal) BarrierType() string {
 }
 
 func (d *TestSeal) StoredKeysSupported() bool {
-	return true
+	return !d.storedKeysDisabled
 }
 
 func (d *TestSeal) RecoveryKeySupported() bool {
-	return true
+	return !d.recoveryKeysDisabled
 }
 
 func (d *TestSeal) SetStoredKeys(keys [][]byte) error {
@@ -110,8 +112,7 @@ func TestCoreUnsealedWithConfigs(t *testing.T, barrierConf, recoveryConf *SealCo
 	}
 	if sealed, _ := core.Sealed(); sealed {
 		for _, key := range result.SecretShares {
-			if _, err := core.Unseal(key); err != nil {
-
+			if _, err := core.Unseal(TestKeyCopy(key)); err != nil {
 				t.Fatalf("unseal err: %s", err)
 			}
 		}


### PR DESCRIPTION
This uses a multi-value test seal for tests. This exercises the Shamir code in nearly every test instead of only a subset.

No particular bug for this, just due diligence.

This also makes two non-test changes:

* nils out seal config on HA takeover, to ensure that if a rekey happened that changed the threshold we pick it up
* changes sys/rekey/update to return status rather than nil