### PR TITLE
Fix cipher preferred order

### DIFF
--- a/helper/tlsutil/tls.go
+++ b/helper/tlsutil/tls.go
@@ -3,7 +3,6 @@ package tlsutil
 import (
 	"crypto/tls"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/vault/helper/strutil"
 )
@@ -18,7 +17,7 @@ var TLSLookup = map[string]uint16{
 // ParseCiphers parse ciphersuites from the comma-separated string into recognized slice
 func ParseCiphers(cipherStr string) ([]uint16, error) {
 	suites := []uint16{}
-	ciphers := strutil.ParseDedupAndSortStrings(cipherStr, ",")
+	ciphers := strutil.ParseStringSlice(cipherStr, ",")
 	cipherMap := map[string]uint16{
 		"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
 		"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
@@ -39,7 +38,7 @@ func ParseCiphers(cipherStr string) ([]uint16, error) {
 		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	}
 	for _, cipher := range ciphers {
-		if v, ok := cipherMap[strings.ToUpper(cipher)]; ok {
+		if v, ok := cipherMap[cipher]; ok {
 			suites = append(suites, v)
 		} else {
 			return suites, fmt.Errorf("unsupported cipher %q", cipher)

--- a/helper/tlsutil/tlsutil_test.go
+++ b/helper/tlsutil/tlsutil_test.go
@@ -1,14 +1,30 @@
 package tlsutil
 
-import "testing"
+import (
+	"crypto/tls"
+	"reflect"
+	"testing"
+)
 
 func TestParseCiphers(t *testing.T) {
 	testOk := "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384"
-	if _, err := ParseCiphers(testOk); err != nil {
+	v, err := ParseCiphers(testOk)
+	if err != nil {
 		t.Fatal(err)
 	}
+	if len(v) != 12 {
+		t.Fatal("missed ciphers after parse")
+	}
+
 	testBad := "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,cipherX"
 	if _, err := ParseCiphers(testBad); err == nil {
-		t.Fatal("should fail")
+		t.Fatal("should fail on unsupported cipherX")
+	}
+
+	testOrder := "TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
+	v, _ = ParseCiphers(testOrder)
+	expected := []uint16{tls.TLS_RSA_WITH_AES_256_GCM_SHA384, tls.TLS_RSA_WITH_AES_128_GCM_SHA256}
+	if !reflect.DeepEqual(expected, v) {
+		t.Fatal("cipher order is not preserved")
 	}
 }


### PR DESCRIPTION
Follow-up for https://github.com/hashicorp/vault/pull/2293

It appears that earlier suggested function `strutil.ParseDedupAndSortStrings()` neglects the preferred order of ciphersuites specified in `tls_cipher_suites`. The order should be preserved when `tls_prefer_server_cipher_suites = "true"`.

@jefferai 