### PR TITLE
Adding LDAP API reference to documentation

### DIFF
--- a/website/source/docs/auth/approle.html.md
+++ b/website/source/docs/auth/approle.html.md
@@ -241,23 +241,23 @@ $ curl -X POST \
   <dt>Returns</dt>
   <dd>
 
-```javascript
-{
-  "auth": null,
-  "warnings": null,
-  "wrap_info": null,
-  "data": {
-    "keys": [
-      "dev",
-      "prod",
-      "test"
-    ]
-  },
-  "lease_duration": 0,
-  "renewable": false,
-  "lease_id": ""
-}
-```
+    ```javascript
+    {
+      "auth": null,
+      "warnings": null,
+      "wrap_info": null,
+      "data": {
+        "keys": [
+          "dev",
+          "prod",
+          "test"
+        ]
+      },
+      "lease_duration": 0,
+      "renewable": false,
+      "lease_id": ""
+    }
+    ```
 
   </dd>
 </dl>
@@ -386,28 +386,28 @@ $ curl -X POST \
   <dt>Returns</dt>
   <dd>
 
-```javascript
-{
-  "auth": null,
-  "warnings": null,
-  "wrap_info": null,
-  "data": {
-    "token_ttl": 1200,
-    "token_max_ttl": 1800,
-    "secret_id_ttl": 600,
-    "secret_id_num_uses": 40,
-    "policies": [
-      "default"
-    ],
-    "period": 0,
-    "bind_secret_id": true,
-    "bound_cidr_list": ""
-  },
-  "lease_duration": 0,
-  "renewable": false,
-  "lease_id": ""
-}
-```
+    ```javascript
+    {
+      "auth": null,
+      "warnings": null,
+      "wrap_info": null,
+      "data": {
+        "token_ttl": 1200,
+        "token_max_ttl": 1800,
+        "secret_id_ttl": 600,
+        "secret_id_num_uses": 40,
+        "policies": [
+          "default"
+        ],
+        "period": 0,
+        "bind_secret_id": true,
+        "bound_cidr_list": ""
+      },
+      "lease_duration": 0,
+      "renewable": false,
+      "lease_id": ""
+    }
+    ```
 
   </dd>
 </dl>
@@ -458,19 +458,19 @@ $ curl -X POST \
   <dt>Returns</dt>
   <dd>
 
-```javascript
-{
-  "auth": null,
-  "warnings": null,
-  "wrap_info": null,
-  "data": {
-    "role_id": "e5a7b66e-5d08-da9c-7075-71984634b882"
-  },
-  "lease_duration": 0,
-  "renewable": false,
-  "lease_id": ""
-}
-```
+    ```javascript
+    {
+      "auth": null,
+      "warnings": null,
+      "wrap_info": null,
+      "data": {
+        "role_id": "e5a7b66e-5d08-da9c-7075-71984634b882"
+      },
+      "lease_duration": 0,
+      "renewable": false,
+      "lease_id": ""
+    }
+    ```
 
   </dd>
 </dl>
@@ -551,20 +551,20 @@ the role.
   <dt>Returns</dt>
   <dd>
 
-```javascript
-{
-  "auth": null,
-  "warnings": null,
-  "wrap_info": null,
-  "data": {
-    "secret_id_accessor": "84896a0c-1347-aa90-a4f6-aca8b7558780",
-    "secret_id": "841771dc-11c9-bbc7-bcac-6a3945a69cd9"
-  },
-  "lease_duration": 0,
-  "renewable": false,
-  "lease_id": ""
-}
-```
+    ```javascript
+    {
+      "auth": null,
+      "warnings": null,
+      "wrap_info": null,
+      "data": {
+        "secret_id_accessor": "84896a0c-1347-aa90-a4f6-aca8b7558780",
+        "secret_id": "841771dc-11c9-bbc7-bcac-6a3945a69cd9"
+      },
+      "lease_duration": 0,
+      "renewable": false,
+      "lease_id": ""
+    }
+    ```
 
   </dd>
 </dl>
@@ -591,25 +591,25 @@ the role.
   <dt>Returns</dt>
   <dd>
 
-```javascript
-{
-  "auth": null,
-  "warnings": null,
-  "wrap_info": null,
-  "data": {
-    "keys": [
-      "ce102d2a-8253-c437-bf9a-aceed4241491",
-      "a1c8dee4-b869-e68d-3520-2040c1a0849a",
-      "be83b7e2-044c-7244-07e1-47560ca1c787",
-      "84896a0c-1347-aa90-a4f6-aca8b7558780",
-      "239b1328-6523-15e7-403a-a48038cdc45a"
-    ]
-  },
-  "lease_duration": 0,
-  "renewable": false,
-  "lease_id": ""
-}
-```
+    ```javascript
+    {
+      "auth": null,
+      "warnings": null,
+      "wrap_info": null,
+      "data": {
+        "keys": [
+          "ce102d2a-8253-c437-bf9a-aceed4241491",
+          "a1c8dee4-b869-e68d-3520-2040c1a0849a",
+          "be83b7e2-044c-7244-07e1-47560ca1c787",
+          "84896a0c-1347-aa90-a4f6-aca8b7558780",
+          "239b1328-6523-15e7-403a-a48038cdc45a"
+        ]
+      },
+      "lease_duration": 0,
+      "renewable": false,
+      "lease_id": ""
+    }
+    ```
 
   </dd>
 </dl>
@@ -642,24 +642,25 @@ Secret ID attached to the role
   <dt>Returns</dt>
   <dd>
 
-```javascript
-{
-        "request_id": "0d25d8ec-0d16-2842-1dda-c28c25aefd4b",
-        "lease_id": "",
-        "lease_duration": 0,
-        "renewable": false,
-        "data": {
-                "cidr_list": null,
-                "creation_time": "2016-09-28T21:00:46.760570318-04:00",
-                "expiration_time": "0001-01-01T00:00:00Z",
-                "last_updated_time": "2016-09-28T21:00:46.760570318-04:00",
-                "metadata": {},
-                "secret_id_accessor": "b4bea6b2-0214-9f7f-33cf-e732155feadb",
-                "secret_id_num_uses": 10,
-                "secret_id_ttl": 0
-        },
-}
-```
+    ```javascript
+    {
+      "request_id": "0d25d8ec-0d16-2842-1dda-c28c25aefd4b",
+      "lease_id": "",
+      "lease_duration": 0,
+      "renewable": false,
+      "data": {
+        "cidr_list": null,
+        "creation_time": "2016-09-28T21:00:46.760570318-04:00",
+        "expiration_time": "0001-01-01T00:00:00Z",
+        "last_updated_time": "2016-09-28T21:00:46.760570318-04:00",
+        "metadata": {},
+        "secret_id_accessor": "b4bea6b2-0214-9f7f-33cf-e732155feadb",
+        "secret_id_num_uses": 10,
+        "secret_id_ttl": 0
+      }
+    }
+    ```
+
   </dd>
 </dl>
 
@@ -723,24 +724,24 @@ Accessor of the secret ID
   <dt>Returns</dt>
   <dd>
 
-```javascript
-{
-        "request_id": "2132237e-d1b6-d298-6117-b54a2d938d00",
-        "lease_id": "",
-        "lease_duration": 0,
-        "renewable": false,
-        "data": {
-                "cidr_list": null,
-                "creation_time": "2016-09-28T22:09:02.834238344-04:00",
-                "expiration_time": "0001-01-01T00:00:00Z",
-                "last_updated_time": "2016-09-28T22:09:02.834238344-04:00",
-                "metadata": {},
-                "secret_id_accessor": "54ba219d-b539-ac4f-e3cf-763c02f351fb",
-                "secret_id_num_uses": 10,
-                "secret_id_ttl": 0
-        },
-}
-```
+    ```javascript
+    {
+      "request_id": "2132237e-d1b6-d298-6117-b54a2d938d00",
+      "lease_id": "",
+      "lease_duration": 0,
+      "renewable": false,
+      "data": {
+        "cidr_list": null,
+        "creation_time": "2016-09-28T22:09:02.834238344-04:00",
+        "expiration_time": "0001-01-01T00:00:00Z",
+        "last_updated_time": "2016-09-28T22:09:02.834238344-04:00",
+        "metadata": {},
+        "secret_id_accessor": "54ba219d-b539-ac4f-e3cf-763c02f351fb",
+        "secret_id_num_uses": 10,
+        "secret_id_ttl": 0
+      }
+    }
+    ```
 
   </dd>
 </dl>
@@ -826,20 +827,20 @@ the role.
   <dt>Returns</dt>
   <dd>
 
-```javascript
-{
-  "auth": null,
-  "warnings": null,
-  "wrap_info": null,
-  "data": {
-    "secret_id_accessor": "a109dc4a-1fd3-6df6-feda-0ca28b2d4a81",
-    "secret_id": "testsecretid"
-  },
-  "lease_duration": 0,
-  "renewable": false,
-  "lease_id": ""
-}
-```
+    ```javascript
+    {
+      "auth": null,
+      "warnings": null,
+      "wrap_info": null,
+      "data": {
+        "secret_id_accessor": "a109dc4a-1fd3-6df6-feda-0ca28b2d4a81",
+        "secret_id": "testsecretid"
+      },
+      "lease_duration": 0,
+      "renewable": false,
+      "lease_id": ""
+    }
+    ```
 
   </dd>
 </dl>
@@ -883,26 +884,26 @@ the role.
   <dt>Returns</dt>
   <dd>
 
-```javascript
-{
-  "auth": {
-    "renewable": true,
-    "lease_duration": 1200,
-    "metadata": null,
-    "policies": [
-      "default"
-    ],
-    "accessor": "fd6c9a00-d2dc-3b11-0be5-af7ae0e1d374",
-    "client_token": "5b1a0318-679c-9c45-e5c6-d1b9a9035d49"
-  },
-  "warnings": null,
-  "wrap_info": null,
-  "data": null,
-  "lease_duration": 0,
-  "renewable": false,
-  "lease_id": ""
-}
-```
+    ```javascript
+    {
+      "auth": {
+        "renewable": true,
+        "lease_duration": 1200,
+        "metadata": null,
+        "policies": [
+          "default"
+        ],
+        "accessor": "fd6c9a00-d2dc-3b11-0be5-af7ae0e1d374",
+        "client_token": "5b1a0318-679c-9c45-e5c6-d1b9a9035d49"
+      },
+      "warnings": null,
+      "wrap_info": null,
+      "data": null,
+      "lease_duration": 0,
+      "renewable": false,
+      "lease_id": ""
+    }
+    ```
 
   </dd>
 </dl>

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -257,3 +257,528 @@ default, foobar, zoobar
 ## Note on policy mapping
 
 It should be noted that user -> policy mapping happens at token creation time. And changes in group membership on the LDAP server will not affect tokens that have already been provisioned. To see these changes, old tokens should be revoked and the user should be asked to reauthenticate.
+
+## API
+### /auth/ldap/config
+#### POST
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Configures the LDAP authentication backend.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>POST</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/config`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">rurl</span>
+        <span class="param-flags">required</span>
+        The LDAP server to connect to. Examples: `ldap://ldap.myorg.com`,
+        `ldaps://ldap.myorg.com:636`
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">starttls</span>
+        <span class="param-flags">optional</span>
+        If true, issues a `StartTLS` command after establishing an unencrypted
+        connection. Defaults to `false`.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">tls_in_version</span>
+        <span class="param-flags">optional</span>
+        Minimum TLS version to use. Accepted values are `tls10`, `tls11` or
+        `tls12`. Defaults to `tls12`.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">tls_max_version</span>
+        <span class="param-flags">optional</span>
+        Maximum TLS version to use. Accepted values are `tls10`, `tls11` or
+        `tls12`. Defaults to `tls12`.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">insecure_tls</span>
+        <span class="param-flags">optional</span>
+        If true, skips LDAP server SSL certificate verification - insecure, use
+        with caution! Defaults to `false`.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">certificate</span>
+        <span class="param-flags">optional</span>
+        CA certificate to use when verifying LDAP server certificate, must be
+        x509 PEM encoded.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">binddn</span>
+        <span class="param-flags">optional</span>
+        Distinguished name of object to bind when performing user search.
+        Example: `cn=vault,ou=Users,dc=example,dc=com`
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">bindpass</span>
+        <span class="param-flags">optional</span>
+        Password to use along with `binddn` when performing user search.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">userdn</span>
+        <span class="param-flags">optional</span>
+        Base DN under which to perform user search. Example:
+        `ou=Users,dc=example,dc=com`
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">userattr</span>
+        <span class="param-flags">optional</span>
+        Attribute on user attribute object matching the username passed when
+        authenticating. Examples: `sAMAccountName`, `cn`, `uid`
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">discoverdn</span>
+        <span class="param-flags">optional</span>
+        Use anonymous bind to discover the bind DN of a user. Defaults to
+        `false`.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">deny_null_bind</span>
+        <span class="param-flags">optional</span>
+        This option prevents users from bypassing authentication when providing
+        an empty password. Defaults to `true`.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">upndomain</span>
+        <span class="param-flags">optional</span>
+        userPrincipalDomain used to construct the UPN string for the
+        authenticating user. The constructed UPN will appear as
+        `[username]@UPNDomain`. Example: `example.com`, which will cause
+        vault to bind as `username@example.com`.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">groupfilter</span>
+        <span class="param-flags">optional</span>
+        Go template used when constructing the group membership query. The
+        template can access the following context variables:
+        \[`UserDN`, `Username`\]. The default is `(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))`,
+        which is compatible with several common directory schemas. To support
+        nested group resolution for Active Directory, instead use the following
+        query: `(&(objectClass=group)(member:1.2.840.113556.1.4.1941:={{.UserDN}}))`.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">groupdn</span>
+        <span class="param-flags">optional</span>
+        LDAP search base to use for group membership search. This can be the
+        root containing either groups or users.
+        Example: `ou=Groups,dc=example,dc=com`
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">groupattr</span>
+        <span class="param-flags">optional</span>
+        LDAP attribute to follow on objects returned by `groupfilter` in order
+        to enumerate user group membership. Examples: for groupfilter queries
+        returning _group_ objects, use: `cn`. For queries returning _user_
+        objects, use: `memberOf`. The default is `cn`.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+
+### /auth/ldap/config
+#### GET
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Retrieves the LDAP configuration.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/config`</dd>
+
+  <dt>Parameters</dt>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+      "auth": null,
+      "warnings": null,
+      "wrap_info": null,
+      "data": {
+        "binddn": "cn=vault,ou=Users,dc=example,dc=com",
+        "bindpass": "",
+        "certificate": "",
+        "deny_null_bind": true,
+        "discoverdn": false,
+        "groupattr": "cn",
+        "groupdn": "ou=Groups,dc=example,dc=com",
+        "groupfilter": "(\u0026(objectClass=group)(member:1.2.840.113556.1.4.1941:={{.UserDN}}))",
+        "insecure_tls": false,
+        "starttls": false,
+        "tls_max_version": "tls12",
+        "tls_min_version": "tls12",
+        "upndomain": "",
+        "url": "ldaps://ldap.myorg.com:636",
+        "userattr": "samaccountname",
+        "userdn": "ou=Users,dc=example,dc=com"
+      },
+      "lease_duration": 0,
+      "renewable": false,
+      "lease_id": ""
+    }
+    ```
+
+  </dd>
+</dl>
+
+### /auth/ldap/groups
+#### LIST/GET
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Lists the existing groups in the backend
+  </dd>
+
+  <dt>Method</dt>
+  <dd>LIST/GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/groups` (LIST) or `/auth/ldap/groups?list=true` (GET)</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+  None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+      "auth": null,
+      "warnings": null,
+      "wrap_info": null,
+      "data": {
+        "keys": [
+          "scientists",
+          "engineers"
+        ]
+      },
+      "lease_duration": 0,
+      "renewable": false,
+      "lease_id": ""
+    }
+    ```
+
+  </dd>
+</dl>
+
+### /auth/ldap/groups/[group_name]
+#### POST
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Creates and updates the LDAP group policy associations.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/groups/[group_name]`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">policies</span>
+        <span class="param-flags">required</span>
+        Comma-separated list of policies associated to the group.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+#### GET
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Reads the LDAP group policy mappings.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/groups/[group_name]`</dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+      "data": {
+        "policies": "admin,default"
+      },
+      "renewable": false,
+      "lease_id": ""
+      "lease_duration": 0,
+      "warnings": null
+    }
+    ```
+
+  </dd>
+</dl>
+
+#### DELETE
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Deletes an LDAP group.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>DELETE</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/groups/[group_name]`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+### /auth/ldap/users
+#### LIST/GET
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Lists the existing users in the backend.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>LIST/GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/users` (LIST) or `/auth/ldap/users?list=true` (GET)</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+  None
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+      "auth": null,
+      "warnings": null,
+      "wrap_info": null,
+      "data": {
+        "keys": [
+          "tesla"
+        ]
+      },
+      "lease_duration": 0,
+      "renewable": false,
+      "lease_id": ""
+    }
+    ```
+
+  </dd>
+</dl>
+
+### /auth/ldap/users/[username]
+#### POST
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Creates and updates the LDAP user group and policy mappings.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/users/[username]`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">groups</span>
+        <span class="param-flags">optional</span>
+        Comma-separated list of groups associated to the user.
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <span class="param">policies</span>
+        <span class="param-flags">optional</span>
+        Comma-separated list of policies associated to the user.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+#### GET
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Reads the LDAP user.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/users/[username]`</dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+      "data": {
+        "policies": "admins,default",
+        "groups": ""
+      },
+      "renewable": false,
+      "lease_id": ""
+      "lease_duration": 0,
+      "warnings": null
+    }
+    ```
+
+  </dd>
+</dl>
+
+#### DELETE
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Deletes an LDAP user.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>DELETE</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/users/[username]`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    None.
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>`204` response code.
+  </dd>
+</dl>
+
+### /auth/ldap/login/[username]
+#### POST
+<dl class="api">
+  <dt>Description</dt>
+  <dd>
+  Creates and updates the LDAP user group and policy associations.
+  </dd>
+
+  <dt>Method</dt>
+  <dd>GET</dd>
+
+  <dt>URL</dt>
+  <dd>`/auth/ldap/login/[username]`</dd>
+
+  <dt>Parameters</dt>
+  <dd>
+    <ul>
+      <li>
+        <span class="param">password</span>
+        <span class="param-flags">required</span>
+        Password for the user.
+      </li>
+    </ul>
+  </dd>
+
+  <dt>Returns</dt>
+  <dd>
+
+    ```javascript
+    {
+      "lease_id": "",
+      "renewable": false,
+      "lease_duration": 0,
+      "data": null,
+      "auth": {
+        "client_token": "c4f280f6-fdb2-18eb-89d3-589e2e834cdb",
+        "policies": [
+          "admins",
+          "default"
+        ],
+        "metadata": {
+          "username": "mitchellh"
+        },
+        "lease_duration": 0,
+        "renewable": false
+      }
+    }
+    ```
+
+  </dd>
+</dl>

--- a/website/source/docs/auth/ldap.html.md
+++ b/website/source/docs/auth/ldap.html.md
@@ -277,7 +277,7 @@ It should be noted that user -> policy mapping happens at token creation time. A
   <dd>
     <ul>
       <li>
-        <span class="param">rurl</span>
+        <span class="param">url</span>
         <span class="param-flags">required</span>
         The LDAP server to connect to. Examples: `ldap://ldap.myorg.com`,
         `ldaps://ldap.myorg.com:636`
@@ -418,8 +418,6 @@ It should be noted that user -> policy mapping happens at token creation time. A
   </dd>
 </dl>
 
-
-### /auth/ldap/config
 #### GET
 <dl class="api">
   <dt>Description</dt>
@@ -473,11 +471,11 @@ It should be noted that user -> policy mapping happens at token creation time. A
 </dl>
 
 ### /auth/ldap/groups
-#### LIST/GET
+#### LIST
 <dl class="api">
   <dt>Description</dt>
   <dd>
-  Lists the existing groups in the backend
+  Lists the existing groups in the backend.
   </dd>
 
   <dt>Method</dt>
@@ -523,7 +521,7 @@ It should be noted that user -> policy mapping happens at token creation time. A
   </dd>
 
   <dt>Method</dt>
-  <dd>GET</dd>
+  <dd>POST</dd>
 
   <dt>URL</dt>
   <dd>`/auth/ldap/groups/[group_name]`</dd>
@@ -599,7 +597,7 @@ It should be noted that user -> policy mapping happens at token creation time. A
 </dl>
 
 ### /auth/ldap/users
-#### LIST/GET
+#### LIST
 <dl class="api">
   <dt>Description</dt>
   <dd>
@@ -648,7 +646,7 @@ It should be noted that user -> policy mapping happens at token creation time. A
   </dd>
 
   <dt>Method</dt>
-  <dd>GET</dd>
+  <dd>POST</dd>
 
   <dt>URL</dt>
   <dd>`/auth/ldap/users/[username]`</dd>
@@ -740,7 +738,7 @@ It should be noted that user -> policy mapping happens at token creation time. A
   </dd>
 
   <dt>Method</dt>
-  <dd>GET</dd>
+  <dd>POST</dd>
 
   <dt>URL</dt>
   <dd>`/auth/ldap/login/[username]`</dd>

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -381,9 +381,9 @@ only encrypt or decrypt using the named keys they need access to.
   </dd>
 </dl>
 
-### /transit/export/encryption-key/<name>(/<version>)
-### /transit/export/signing-key/<name>(/<version>)
-### /transit/export/hmac-key/<name>(/<version>)
+### /transit/export/encryption-key/\<name\>(/\<version\>)
+### /transit/export/signing-key/\<name\>(/\<version\>)
+### /transit/export/hmac-key/\<name\>(/\<version\>)
 #### GET
 
 <dl class="api">


### PR DESCRIPTION
 When working with the LDAP backend, it was sometimes hard to find exactly what endpoints, operations, parameters, and return objects were available.  All the information was in the guide but the API reference is great for quick reference.  There is quite a bit of duplication between the guide and the API reference for configuration parameters so let me know if you want to see any tweaks.

I also fixed a few other formatting issues in the transit and approle documentation.