### PR TITLE
etcdbackend: support version auto discovery

### DIFF
--- a/physical/etcd.go
+++ b/physical/etcd.go
@@ -1,9 +1,12 @@
 package physical
 
 import (
+	"context"
 	"errors"
 	"os"
 
+	"github.com/coreos/etcd/client"
+	"github.com/coreos/go-semver/semver"
 	log "github.com/mgutz/logxi/v1"
 )
 
@@ -25,22 +28,67 @@ func newEtcdBackend(conf map[string]string, logger log.Logger) (Backend, error) 
 		ok         bool
 	)
 
+	// v2 client can talk to both etcd2 and etcd3 thought API v2
+	c, err := newEtcdV2Client(conf)
+	if err != nil {
+		return nil, errors.New("failed to create etcd client: " + err.Error())
+	}
+
+	remoteAPIVersion, err := getEtcdAPIVersion(c)
+	if err != nil {
+		return nil, errors.New("failed to get etcd API version: " + err.Error())
+	}
+
 	if apiVersion, ok = conf["etcd_api"]; !ok {
 		apiVersion = os.Getenv("ETCD_API")
 	}
-	if apiVersion == "" {
-		// TODO: auto discover latest version
-		apiVersion = "2"
-	}
 
-	// TODO: check etcd server version. Fail if there is a version mismatch
+	if apiVersion == "" {
+		path, ok := conf["path"]
+		if !ok {
+			path = "/vault"
+		}
+		kAPI := client.NewKeysAPI(c)
+
+		// keep using v2 if vault data exists in v2 and user does not explicitly
+		// ask for v3.
+		_, err := kAPI.Get(context.Background(), path, &client.GetOptions{})
+		if errorIsMissingKey(err) {
+			apiVersion = remoteAPIVersion
+		} else if err == nil {
+			apiVersion = "2"
+		} else {
+			return nil, errors.New("failed to check etcd status: " + err.Error())
+		}
+	}
 
 	switch apiVersion {
 	case "2", "etcd2", "v2":
 		return newEtcd2Backend(conf, logger)
 	case "3", "etcd3", "v3":
+		if remoteAPIVersion == "2" {
+			return nil, errors.New("etcd3 is required: etcd2 is running")
+		}
 		return newEtcd3Backend(conf, logger)
 	default:
 		return nil, EtcdVersionUnknow
 	}
+}
+
+func getEtcdAPIVersion(c client.Client) (string, error) {
+	v, err := c.GetVersion(context.Background())
+	if err != nil {
+		return "", err
+	}
+
+	sv, err := semver.NewVersion(v.Cluster)
+	if err != nil {
+		return "", nil
+	}
+
+	if sv.LessThan(*semver.Must(semver.NewVersion("3.1.0"))) {
+		return "2", nil
+	}
+
+	return "3", nil
 }

--- a/physical/etcd.go
+++ b/physical/etcd.go
@@ -75,6 +75,9 @@ func newEtcdBackend(conf map[string]string, logger log.Logger) (Backend, error) 
 	}
 }
 
+// getEtcdAPIVersion gets the latest supported API version.
+// If etcd cluster version >= 3.1, "3" will be returned.
+// Otherwise, "2" will be returned.
 func getEtcdAPIVersion(c client.Client) (string, error) {
 	v, err := c.GetVersion(context.Background())
 	if err != nil {

--- a/physical/etcd2.go
+++ b/physical/etcd2.go
@@ -76,7 +76,13 @@ func newEtcd2Backend(conf map[string]string, logger log.Logger) (Backend, error)
 	if haEnabled == "" {
 		haEnabled = conf["ha_enabled"]
 	}
-	haEnabledBool, _ := strconv.ParseBool(haEnabled)
+	if haEnabled == "" {
+		haEnabled = "false"
+	}
+	haEnabledBool, err := strconv.ParseBool(haEnabled)
+	if err != nil {
+		return nil, fmt.Errorf("value [%v] of 'ha_enabled' could not be understood", haEnabled)
+	}
 
 	// Should we sync the cluster state? There are three available options
 	// for our client library: don't sync (required for some proxies), sync

--- a/physical/etcd2.go
+++ b/physical/etcd2.go
@@ -67,6 +67,51 @@ func newEtcd2Backend(conf map[string]string, logger log.Logger) (Backend, error)
 		path = "/" + path
 	}
 
+	c, err := newEtcdV2Client(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	haEnabled := os.Getenv("ETCD_HA_ENABLED")
+	if haEnabled == "" {
+		haEnabled = conf["ha_enabled"]
+	}
+	haEnabledBool, _ := strconv.ParseBool(haEnabled)
+
+	// Should we sync the cluster state? There are three available options
+	// for our client library: don't sync (required for some proxies), sync
+	// once, or sync periodically with AutoSync.  We currently support the
+	// first two.
+	sync, ok := conf["sync"]
+	if !ok {
+		sync = "yes"
+	}
+	switch sync {
+	case "yes", "true", "y", "1":
+		ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
+		syncErr := c.Sync(ctx)
+		cancel()
+		if syncErr != nil {
+			return nil, fmt.Errorf("%s: %s", EtcdSyncClusterError, syncErr)
+		}
+	case "no", "false", "n", "0":
+	default:
+		return nil, fmt.Errorf("value of 'sync' could not be understood")
+	}
+
+	kAPI := client.NewKeysAPI(c)
+
+	// Setup the backend.
+	return &Etcd2Backend{
+		path:       path,
+		kAPI:       kAPI,
+		permitPool: NewPermitPool(DefaultParallelOperations),
+		logger:     logger,
+		haEnabled:  haEnabledBool,
+	}, nil
+}
+
+func newEtcdV2Client(conf map[string]string) (client.Client, error) {
 	// Set a default machines list and check for an overriding address value.
 	machines := "http://127.0.0.1:2379"
 	if address, ok := conf["address"]; ok {
@@ -85,12 +130,6 @@ func newEtcd2Backend(conf map[string]string, logger log.Logger) (Backend, error)
 			return nil, EtcdAddressError
 		}
 	}
-
-	haEnabled := os.Getenv("ETCD_HA_ENABLED")
-	if haEnabled == "" {
-		haEnabled = conf["ha_enabled"]
-	}
-	haEnabledBool, _ := strconv.ParseBool(haEnabled)
 
 	// Create a new client from the supplied address and attempt to sync with the
 	// cluster.
@@ -135,42 +174,7 @@ func newEtcd2Backend(conf map[string]string, logger log.Logger) (Backend, error)
 		cfg.Password = password
 	}
 
-	c, err := client.New(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	// Should we sync the cluster state? There are three available options
-	// for our client library: don't sync (required for some proxies), sync
-	// once, or sync periodically with AutoSync.  We currently support the
-	// first two.
-	sync, ok := conf["sync"]
-	if !ok {
-		sync = "yes"
-	}
-	switch sync {
-	case "yes", "true", "y", "1":
-		ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
-		syncErr := c.Sync(ctx)
-		cancel()
-		if syncErr != nil {
-			return nil, fmt.Errorf("%s: %s", EtcdSyncClusterError, syncErr)
-		}
-	case "no", "false", "n", "0":
-	default:
-		return nil, fmt.Errorf("value of 'sync' could not be understood")
-	}
-
-	kAPI := client.NewKeysAPI(c)
-
-	// Setup the backend.
-	return &Etcd2Backend{
-		path:       path,
-		kAPI:       kAPI,
-		permitPool: NewPermitPool(DefaultParallelOperations),
-		logger:     logger,
-		haEnabled:  haEnabledBool,
-	}, nil
+	return client.New(cfg)
 }
 
 // Put is used to insert or update an entry.

--- a/physical/etcd3.go
+++ b/physical/etcd3.go
@@ -59,7 +59,13 @@ func newEtcd3Backend(conf map[string]string, logger log.Logger) (Backend, error)
 	if haEnabled == "" {
 		haEnabled = conf["ha_enabled"]
 	}
-	haEnabledBool, _ := strconv.ParseBool(haEnabled)
+	if haEnabled == "" {
+		haEnabled = "false"
+	}
+	haEnabledBool, err := strconv.ParseBool(haEnabled)
+	if err != nil {
+		return nil, fmt.Errorf("value [%v] of 'ha_enabled' could not be understood", haEnabled)
+	}
 
 	cert, hasCert := conf["tls_cert_file"]
 	key, hasKey := conf["tls_key_file"]

--- a/vendor/github.com/coreos/etcd/client/client.go
+++ b/vendor/github.com/coreos/etcd/client/client.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -26,6 +27,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/coreos/etcd/version"
 
 	"golang.org/x/net/context"
 )
@@ -200,6 +203,9 @@ type Client interface {
 	// HTTP requests. If the given endpoints are not valid, an error will be
 	// returned
 	SetEndpoints(eps []string) error
+
+	// GetVersion retrieves the current etcd server and cluster version
+	GetVersion(ctx context.Context) (*version.Versions, error)
 
 	httpClient
 }
@@ -474,6 +480,33 @@ func (c *httpClusterClient) AutoSync(ctx context.Context, interval time.Duration
 			return ctx.Err()
 		case <-ticker.C:
 		}
+	}
+}
+
+func (c *httpClusterClient) GetVersion(ctx context.Context) (*version.Versions, error) {
+	act := &getAction{Prefix: "/version"}
+
+	resp, body, err := c.Do(ctx, act)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		if len(body) == 0 {
+			return nil, ErrEmptyBody
+		}
+		var vresp version.Versions
+		if err := json.Unmarshal(body, &vresp); err != nil {
+			return nil, ErrInvalidJSON
+		}
+		return &vresp, nil
+	default:
+		var etcdErr Error
+		if err := json.Unmarshal(body, &etcdErr); err != nil {
+			return nil, ErrInvalidJSON
+		}
+		return nil, etcdErr
 	}
 }
 

--- a/vendor/github.com/coreos/etcd/version/version.go
+++ b/vendor/github.com/coreos/etcd/version/version.go
@@ -1,0 +1,56 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package version implements etcd version parsing and contains latest version
+// information.
+package version
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+var (
+	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
+	MinClusterVersion = "3.0.0"
+	Version           = "3.2.0+git"
+	APIVersion        = "unknown"
+
+	// Git SHA Value will be set during build
+	GitSHA = "Not provided (use ./build instead of go build)"
+)
+
+func init() {
+	ver, err := semver.NewVersion(Version)
+	if err == nil {
+		APIVersion = fmt.Sprintf("%d.%d", ver.Major, ver.Minor)
+	}
+}
+
+type Versions struct {
+	Server  string `json:"etcdserver"`
+	Cluster string `json:"etcdcluster"`
+	// TODO: raft state machine version
+}
+
+// Cluster only keeps the major.minor.
+func Cluster(v string) string {
+	vs := strings.Split(v, ".")
+	if len(vs) <= 2 {
+		return v
+	}
+	return fmt.Sprintf("%s.%s", vs[0], vs[1])
+}

--- a/vendor/github.com/coreos/go-semver/LICENSE
+++ b/vendor/github.com/coreos/go-semver/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/coreos/go-semver/semver/semver.go
+++ b/vendor/github.com/coreos/go-semver/semver/semver.go
@@ -1,0 +1,209 @@
+package semver
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major      int64
+	Minor      int64
+	Patch      int64
+	PreRelease PreRelease
+	Metadata   string
+}
+
+type PreRelease string
+
+func splitOff(input *string, delim string) (val string) {
+	parts := strings.SplitN(*input, delim, 2)
+
+	if len(parts) == 2 {
+		*input = parts[0]
+		val = parts[1]
+	}
+
+	return val
+}
+
+func NewVersion(version string) (*Version, error) {
+	v := Version{}
+
+	dotParts := strings.SplitN(version, ".", 3)
+
+	if len(dotParts) != 3 {
+		return nil, errors.New(fmt.Sprintf("%s is not in dotted-tri format", version))
+	}
+
+	v.Metadata = splitOff(&dotParts[2], "+")
+	v.PreRelease = PreRelease(splitOff(&dotParts[2], "-"))
+
+	parsed := make([]int64, 3, 3)
+
+	for i, v := range dotParts[:3] {
+		val, err := strconv.ParseInt(v, 10, 64)
+		parsed[i] = val
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	v.Major = parsed[0]
+	v.Minor = parsed[1]
+	v.Patch = parsed[2]
+
+	return &v, nil
+}
+
+func Must(v *Version, err error) *Version {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func (v *Version) String() string {
+	var buffer bytes.Buffer
+
+	base := fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+	buffer.WriteString(base)
+
+	if v.PreRelease != "" {
+		buffer.WriteString(fmt.Sprintf("-%s", v.PreRelease))
+	}
+
+	if v.Metadata != "" {
+		buffer.WriteString(fmt.Sprintf("+%s", v.Metadata))
+	}
+
+	return buffer.String()
+}
+
+func (v *Version) LessThan(versionB Version) bool {
+	versionA := *v
+	cmp := recursiveCompare(versionA.Slice(), versionB.Slice())
+
+	if cmp == 0 {
+		cmp = preReleaseCompare(versionA, versionB)
+	}
+
+	if cmp == -1 {
+		return true
+	}
+
+	return false
+}
+
+/* Slice converts the comparable parts of the semver into a slice of strings */
+func (v *Version) Slice() []int64 {
+	return []int64{v.Major, v.Minor, v.Patch}
+}
+
+func (p *PreRelease) Slice() []string {
+	preRelease := string(*p)
+	return strings.Split(preRelease, ".")
+}
+
+func preReleaseCompare(versionA Version, versionB Version) int {
+	a := versionA.PreRelease
+	b := versionB.PreRelease
+
+	/* Handle the case where if two versions are otherwise equal it is the
+	 * one without a PreRelease that is greater */
+	if len(a) == 0 && (len(b) > 0) {
+		return 1
+	} else if len(b) == 0 && (len(a) > 0) {
+		return -1
+	}
+
+	// If there is a prelease, check and compare each part.
+	return recursivePreReleaseCompare(a.Slice(), b.Slice())
+}
+
+func recursiveCompare(versionA []int64, versionB []int64) int {
+	if len(versionA) == 0 {
+		return 0
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursiveCompare(versionA[1:], versionB[1:])
+}
+
+func recursivePreReleaseCompare(versionA []string, versionB []string) int {
+	// Handle slice length disparity.
+	if len(versionA) == 0 {
+		// Nothing to compare too, so we return 0
+		return 0
+	} else if len(versionB) == 0 {
+		// We're longer than versionB so return 1.
+		return 1
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	aInt := false; bInt := false
+
+	aI, err := strconv.Atoi(versionA[0])
+	if err == nil {
+		aInt = true
+	}
+
+	bI, err := strconv.Atoi(versionB[0])
+	if err == nil {
+		bInt = true
+	}
+
+	// Handle Integer Comparison
+	if aInt && bInt {
+		if aI > bI {
+			return 1
+		} else if aI < bI {
+			return -1
+		}
+	}
+
+	// Handle String Comparison
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursivePreReleaseCompare(versionA[1:], versionB[1:])
+}
+
+// BumpMajor increments the Major field by 1 and resets all other fields to their default values
+func (v *Version) BumpMajor() {
+	v.Major += 1
+	v.Minor = 0
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpMinor increments the Minor field by 1 and resets all other fields to their default values
+func (v *Version) BumpMinor() {
+	v.Minor += 1
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpPatch increments the Patch field by 1 and resets all other fields to their default values
+func (v *Version) BumpPatch() {
+	v.Patch += 1
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}

--- a/vendor/github.com/coreos/go-semver/semver/sort.go
+++ b/vendor/github.com/coreos/go-semver/semver/sort.go
@@ -1,0 +1,24 @@
+package semver
+
+import (
+	"sort"
+)
+
+type Versions []*Version
+
+func (s Versions) Len() int {
+	return len(s)
+}
+
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Versions) Less(i, j int) bool {
+	return s[i].LessThan(*s[j])
+}
+
+// Sort sorts the given slice of Version
+func Sort(versions []*Version) {
+	sort.Sort(Versions(versions))
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -355,10 +355,10 @@
 			"revisionTime": "2017-01-13T02:57:25Z"
 		},
 		{
-			"checksumSHA1": "7UA5xypGCK2rsrcAf3udKkwOkJM=",
+			"checksumSHA1": "Zgqp9pp3G4cSZbepa6tzhNeHZOI=",
 			"path": "github.com/coreos/etcd/client",
-			"revision": "c89eae790d072ef89f8583030ac2116f6e3d0df0",
-			"revisionTime": "2017-01-13T02:57:25Z"
+			"revision": "b9bbfda874f0add91c300042078c1b1bb904e9c5",
+			"revisionTime": "2017-01-24T15:53:15Z"
 		},
 		{
 			"checksumSHA1": "oW3dk6tgLaS8q1dj9pj4+3kiIog=",
@@ -419,6 +419,18 @@
 			"path": "github.com/coreos/etcd/pkg/types",
 			"revision": "c89eae790d072ef89f8583030ac2116f6e3d0df0",
 			"revisionTime": "2017-01-13T02:57:25Z"
+		},
+		{
+			"checksumSHA1": "sp2FkEyaIGiQFOEZCTDkBZgyHOs=",
+			"path": "github.com/coreos/etcd/version",
+			"revision": "b9bbfda874f0add91c300042078c1b1bb904e9c5",
+			"revisionTime": "2017-01-24T15:53:15Z"
+		},
+		{
+			"checksumSHA1": "bkO2CG/UwwIs8k0x/iXKpkyg7pU=",
+			"path": "github.com/coreos/go-semver/semver",
+			"revision": "568e959cd89871e61434c1143528d9162da89ef2",
+			"revisionTime": "2015-03-04T02:01:26Z"
 		},
 		{
 			"checksumSHA1": "d50/+u/LFlXvEV10HiEoXB9OsGg=",


### PR DESCRIPTION
Rule:

when api version is not defined by user:

1. use api 2 if server only supports api 2
2. use api 2 if previous vault data exists in api 2
3. use api 3 if server supports api3 and no user data exists in api 2

when api version is provided by user, always trust user.

Manually tested.
