### PR TITLE
ConfigureTLS() sets default HttpClient if nil

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -106,7 +106,7 @@ func DefaultConfig() *Config {
 func (c *Config) ConfigureTLS(t *TLSConfig) error {
 
 	if c.HttpClient == nil {
-		return fmt.Errorf("config HTTP Client must be set")
+		c.HttpClient = DefaultConfig().HttpClient
 	}
 
 	var clientCert tls.Certificate


### PR DESCRIPTION
api.NewClient() creates a default HttpClient if one has not yet been
supplied, but ConfigureTLS() did not.

It seems like consistency here is useful: either client code need not
care whether the HttpClient was initialized (in this case, this is the
correct fix), or configuring the HttpClient is part of the contract for
initializing the client and api.NewClient() should also error if it is
not supplied.