### PR TITLE
Vault Init Message For Single Key

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -244,11 +244,11 @@ func (c *InitCommand) runInit(check bool, initRequest *api.InitRequest) int {
 	if initRequest.StoredShares < 1 {
 		c.Ui.Output(fmt.Sprintf(
 			"\n"+
-				"Vault initialized with %d keys and a key threshold of %d. Please\n"+
-				"securely distribute the above keys. When the Vault is re-sealed,\n"+
-				"restarted, or stopped, you must provide at least %d of these keys\n"+
+			"Vault initialized with %d key(s) and a key threshold of %d. Please\n"+
+			"securely distribute the above key(s). When the Vault is re-sealed,\n"+
+			"restarted, or stopped, you must provide at least %d of these key(s)\n"+
 				"to unseal it again.\n\n"+
-				"Vault does not store the master key. Without at least %d keys,\n"+
+			"Vault does not store the master key. Without at least %d key(s),\n"+
 				"your Vault will remain permanently sealed.",
 			initRequest.SecretShares,
 			initRequest.SecretThreshold,

--- a/command/init.go
+++ b/command/init.go
@@ -242,18 +242,26 @@ func (c *InitCommand) runInit(check bool, initRequest *api.InitRequest) int {
 	c.Ui.Output(fmt.Sprintf("Initial Root Token: %s", resp.RootToken))
 
 	if initRequest.StoredShares < 1 {
+		keyMsg := "key"
+		unsealMsg := "this key"
+		if initRequest.SecretShares > 1 {
+			keyMsg = "keys"
+			unsealMsg = fmt.Sprintf("at least %d of these keys",initRequest.SecretThreshold)
+		}
 		c.Ui.Output(fmt.Sprintf(
 			"\n"+
-			"Vault initialized with %d key(s) and a key threshold of %d. Please\n"+
-			"securely distribute the above key(s). When the Vault is re-sealed,\n"+
-			"restarted, or stopped, you must provide at least %d of these key(s)\n"+
+			"Vault initialized with %d %s and a key threshold of %d. Please\n"+
+			"securely distribute the above %s. When the Vault is re-sealed,\n"+
+			"restarted, or stopped, you must provide %s\n"+
 				"to unseal it again.\n\n"+
-			"Vault does not store the master key. Without at least %d key(s),\n"+
+			"Vault does not store the master key. Without %s,\n"+
 				"your Vault will remain permanently sealed.",
 			initRequest.SecretShares,
+			keyMsg,
 			initRequest.SecretThreshold,
-			initRequest.SecretThreshold,
-			initRequest.SecretThreshold,
+			keyMsg,
+			unsealMsg,
+			unsealMsg,
 		))
 	} else {
 		c.Ui.Output(


### PR DESCRIPTION
The current output looks like the following.  
```
You can find the vault keys at /var/vault/config/init.keys
Unseal Key 1: xxxxxxxxxxxxxxxxxxxxx
Initial Root Token: xxxxxxxxxxxxxxxxxxxxxx

Vault initialized with 1 keys and a key threshold of 1. Please
securely distribute the above keys. When the Vault is re-sealed,
restarted, or stopped, you must provide at least 1 of these keys
to unseal it again.

Vault does not store the master key. Without at least 1 keys,
your Vault will remain permanently sealed.
```
This PR fixes the minor grammatical improvement needed when there is only one key.