### PR TITLE
Fixing a few typos in the docs

### DIFF
--- a/website/source/docs/auth/mfa.html.md
+++ b/website/source/docs/auth/mfa.html.md
@@ -90,6 +90,6 @@ the new username. For example "%s@example.com" would append "@example.com"
 to the provided username before connecting to Duo.
 
 `push_info` is a string of URL-encoded key/value pairs that provides additional
-context about the authentication attemmpt in the Duo Mobile application.
+context about the authentication attempt in the Duo Mobile application.
 
 More information can be found through the CLI `path-help` command.

--- a/website/source/docs/config/index.html.md
+++ b/website/source/docs/config/index.html.md
@@ -379,7 +379,7 @@ backend "consul" {
   scheme = "http"
 
   // token is a Consul ACL Token that has write privileges to the path
-  // specified below.  Use of a Consul ACL Token is a best pracitce.
+  // specified below.  Use of a Consul ACL Token is a best practice.
   token = "[redacted]" // Vault's Consul ACL Token
 
   // path must be writable by the Consul ACL Token

--- a/website/source/docs/secrets/aws/index.html.md
+++ b/website/source/docs/secrets/aws/index.html.md
@@ -226,7 +226,7 @@ $ vault write aws/roles/deploy \
 
 The policy.json file would contain an inline policy with similar permissions,
 less the `sts:GetFederationToken` permission.  (We could grant `sts` permissions,
-but STS would attach an implict deny on `sts` that overides the allow.)
+but STS would attach an implicit deny on `sts` that overrides the allow.)
 
 ```javascript
 {
@@ -267,7 +267,7 @@ AssumeRole adds a few benefits over federation tokens:
 
 1. Assumed roles can invoke IAM and STS operations, if granted by the role's
    IAM policies.
-2. Assumed roles support cross-account authenication
+2. Assumed roles support cross-account authentication
 
 The `aws/config/root` credentials must have an IAM policy that allows `sts:AssumeRole`
 against the target role:

--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -112,7 +112,7 @@ that are truncated to form the display name portion of the mysql username
 interpolated into the `{{name}}` field: the default is 10. 
 
 You may also configure the total number of characters allowed in the entire
-generated username (the sum of the display name and uuid poritions); the
+generated username (the sum of the display name and uuid portions); the
 default is 16. Note that versions of MySQL prior to 5.8 have a 16 character
 total limit on user names, so it is probably not safe to increase this above
 the default on versions prior to that.

--- a/website/source/docs/secrets/pki/index.html.md
+++ b/website/source/docs/secrets/pki/index.html.md
@@ -409,7 +409,7 @@ subpath for interactive help output.
   <dd>
 
     ```
-    <binary DER-encoded certficiate>
+    <binary DER-encoded certificate>
     ```
 
   </dd>
@@ -441,7 +441,7 @@ subpath for interactive help output.
   <dd>
 
     ```
-    <PEM-encoded certficiate chain>
+    <PEM-encoded certificate chain>
     ```
 
   </dd>
@@ -1227,7 +1227,7 @@ subpath for interactive help output.
         <span class="param">ou</span>
         <span class="param-flags">optional</span>
         This sets the OU (OrganizationalUnit) values in the subject field of
-        issued certiicates. This is a comma-separated string.
+        issued certificates. This is a comma-separated string.
       </li>
     </ul>
   </dd>


### PR DESCRIPTION
This fixes up a few typos in the otherwise stellar documentation.