### PR TITLE
RenewPeriodic for tokens

### DIFF
--- a/api/sys_lease.go
+++ b/api/sys_lease.go
@@ -1,5 +1,9 @@
 package api
 
+import (
+	"time"
+)
+
 func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/renew")
 
@@ -18,6 +22,19 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 	defer resp.Body.Close()
 
 	return ParseSecret(resp.Body)
+}
+
+func (c *Sys) RenewPeriodic(id string, increment int, doneCh chan struct{}) error {
+    for {
+    	select {
+    	case <-time.After(time.Second * increment / 2):
+    		if _, err := c.Renew(id, increment); err != nil {
+    			return err
+    		}
+    	case <-doneCh:
+    		return nil
+    	}
+    }
 }
 
 func (c *Sys) Revoke(id string) error {


### PR DESCRIPTION
It would be cool if we had a renewPeriodic function for tokens, like the session API in Consul.

However, I have a couple of reservations about the implementation in this pull request:

1. Not all tokens are renewable. Should we check if the token is renewable at the start of the function call?

2. I'm renewing the token with an interval of `increment/2` which might not be what the user expects if the token is close to expiration at the time of invoking renewPeriodic. We could attempt to renew before entering the select block.

3. In the session API renewPeriodic implementation for Consul it keeps track of errors but does not return until the time since no error is greater than the session TTL. Should we do something similar with token TTLs? 