### PR TITLE
Non-recursive BFS for revoking token trees.

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -67,19 +67,19 @@ oOyBJU/HMVvBfv4g+OVFLVgSwwm6owwsouZ0+D/LasbuHqYyqYqdyPJQYzWA2Y+F
 )
 
 // TestCore returns a pure in-memory, uninitialized core for testing.
-func TestCore(t *testing.T) *Core {
+func TestCore(t testing.TB) *Core {
 	return TestCoreWithSeal(t, nil)
 }
 
 // TestCoreNewSeal returns an in-memory, ininitialized core with the new seal
 // configuration.
-func TestCoreNewSeal(t *testing.T) *Core {
+func TestCoreNewSeal(t testing.TB) *Core {
 	return TestCoreWithSeal(t, &TestSeal{})
 }
 
 // TestCoreWithSeal returns a pure in-memory, uninitialized core with the
 // specified seal for testing.
-func TestCoreWithSeal(t *testing.T, testSeal Seal) *Core {
+func TestCoreWithSeal(t testing.TB, testSeal Seal) *Core {
 	noopAudits := map[string]audit.Factory{
 		"noop": func(config *audit.BackendConfig) (audit.Backend, error) {
 			view := &logical.InmemStorage{}
@@ -143,11 +143,11 @@ func TestCoreWithSeal(t *testing.T, testSeal Seal) *Core {
 
 // TestCoreInit initializes the core with a single key, and returns
 // the key that must be used to unseal the core and a root token.
-func TestCoreInit(t *testing.T, core *Core) ([][]byte, string) {
+func TestCoreInit(t testing.TB, core *Core) ([][]byte, string) {
 	return TestCoreInitClusterWrapperSetup(t, core, nil, func() (http.Handler, http.Handler) { return nil, nil })
 }
 
-func TestCoreInitClusterWrapperSetup(t *testing.T, core *Core, clusterAddrs []*net.TCPAddr, handlerSetupFunc func() (http.Handler, http.Handler)) ([][]byte, string) {
+func TestCoreInitClusterWrapperSetup(t testing.TB, core *Core, clusterAddrs []*net.TCPAddr, handlerSetupFunc func() (http.Handler, http.Handler)) ([][]byte, string) {
 	core.SetClusterListenerAddrs(clusterAddrs)
 	core.SetClusterSetupFuncs(handlerSetupFunc)
 	result, err := core.Initialize(&InitParams{
@@ -170,7 +170,7 @@ func TestCoreUnseal(core *Core, key []byte) (bool, error) {
 
 // TestCoreUnsealed returns a pure in-memory core that is already
 // initialized and unsealed.
-func TestCoreUnsealed(t *testing.T) (*Core, [][]byte, string) {
+func TestCoreUnsealed(t testing.TB) (*Core, [][]byte, string) {
 	core := TestCore(t)
 	keys, token := TestCoreInit(t, core)
 	for _, key := range keys {
@@ -192,7 +192,7 @@ func TestCoreUnsealed(t *testing.T) (*Core, [][]byte, string) {
 
 // TestCoreWithTokenStore returns an in-memory core that has a token store
 // mounted, so that logical token functions can be used
-func TestCoreWithTokenStore(t *testing.T) (*Core, *TokenStore, [][]byte, string) {
+func TestCoreWithTokenStore(t testing.TB) (*Core, *TokenStore, [][]byte, string) {
 	c, keys, root := TestCoreUnsealed(t)
 
 	me := &MountEntry{

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -672,40 +672,28 @@ func TestTokenStore_Revoke_Orphan(t *testing.T) {
 }
 
 func TestTokenStore_RevokeTree(t *testing.T) {
+	testTokenStore_RevokeTree_Impl(t, 2)
+}
+
+// testTokenStore_RevokeTree_Impl takes a tree depth, creates a binary tree of
+// tokens and tests that tokens are revoked properly.
+func testTokenStore_RevokeTree_Impl(t testing.TB, depth uint64) {
 	_, ts, _, _ := TestCoreWithTokenStore(t)
 
-	ent1 := &TokenEntry{}
-	if err := ts.create(ent1); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	ent2 := &TokenEntry{Parent: ent1.ID}
-	if err := ts.create(ent2); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	ent3 := &TokenEntry{Parent: ent2.ID}
-	if err := ts.create(ent3); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	ent4 := &TokenEntry{Parent: ent2.ID}
-	if err := ts.create(ent4); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	root, children := buildTokenTree(t, ts, depth)
 
 	err := ts.RevokeTree("")
 	if err.Error() != "cannot revoke blank token" {
 		t.Fatalf("err: %v", err)
 	}
-	err = ts.RevokeTree(ent1.ID)
+	err = ts.RevokeTree(root.ID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	lookup := []string{ent1.ID, ent2.ID, ent3.ID, ent4.ID}
-	for _, id := range lookup {
-		out, err := ts.Lookup(id)
+	children = append(children, root)
+	for _, entry := range children {
+		out, err := ts.Lookup(entry.ID)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -713,6 +701,49 @@ func TestTokenStore_RevokeTree(t *testing.T) {
 			t.Fatalf("bad: %#v", out)
 		}
 	}
+}
+
+func BenchmarkTokenStore_RevokeTree(b *testing.B) {
+	//benchmarks := []uint64{0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}
+	benchmarks := []uint64{20}
+	for _, depth := range benchmarks {
+		b.Run(fmt.Sprintf("Tree of Depth %d", depth), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				testTokenStore_RevokeTree_Impl(b, depth)
+			}
+		})
+	}
+}
+
+func buildTokenTree(t testing.TB, ts *TokenStore, depth uint64) (root *TokenEntry, children []*TokenEntry) {
+	root = &TokenEntry{}
+	if err := ts.create(root); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	frontier := []*TokenEntry{root}
+	current := uint64(0)
+	for current < depth {
+		next := make([]*TokenEntry, 0, 2*len(frontier))
+		for _, node := range frontier {
+			left := &TokenEntry{Parent: node.ID}
+			if err := ts.create(left); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			right := &TokenEntry{Parent: node.ID}
+			if err := ts.create(right); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			children = append(children, left, right)
+			next = append(next, left, right)
+		}
+		frontier = next
+		current++
+	}
+
+	return root, children
 }
 
 func TestTokenStore_RevokeSelf(t *testing.T) {

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -704,8 +704,7 @@ func testTokenStore_RevokeTree_Impl(t testing.TB, depth uint64) {
 }
 
 func BenchmarkTokenStore_RevokeTree(b *testing.B) {
-	//benchmarks := []uint64{0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}
-	benchmarks := []uint64{20}
+	benchmarks := []uint64{0, 1, 2, 4, 8, 16, 20}
 	for _, depth := range benchmarks {
 		b.Run(fmt.Sprintf("Tree of Depth %d", depth), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This PR updates token revocation to use a non-recursive approach. On
very large trees this avoids stack overflows.

Fixes https://github.com/hashicorp/vault/issues/2348

@jefferai 