### PR TITLE
Add correct output to unmount documentation

### DIFF
--- a/website/source/intro/getting-started/secret-backends.html.md
+++ b/website/source/intro/getting-started/secret-backends.html.md
@@ -79,7 +79,7 @@ remains mounted.
 
 ```
 $ vault unmount generic/
-Successfully unmounted 'generic/'!
+Successfully unmounted 'generic/' if it was mounted
 ```
 
 In addition to unmounting, you can remount a backend. Remounting a


### PR DESCRIPTION
Simply adding the actual output of: 'vault unmount generic/'