### PR TITLE
docs: transit parameter is actually deletion_allowed

### DIFF
--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -338,7 +338,7 @@ only encrypt or decrypt using the named keys they need access to.
         Defaults to 0.
       </li>
       <li>
-        <span class="param">allow_deletion</span>
+        <span class="param">deletion_allowed</span>
         <span class="param-flags">optional</span>
         When set, the key is allowed to be deleted. Defaults to false.
       </li>


### PR DESCRIPTION
Attempts to configure `allow_deletion=true` on a transit key return a success, but does not actually let you delete the key:

```
# vault read transit/test/keys/tommytest
Key                   	Value
---                   	-----
deletion_allowed      	false
derived               	false
keys                  	map[1:1485962685]
latest_version        	1
min_decryption_version	1
name                  	tommytest
type                  	aes256-gcm96

# vault write transit/test/keys/tommytest/config allow_deletion=true
Success! Data written to: transit/test/keys/tommytest/config
# vault read transit/test/keys/tommytest
Key                   	Value
---                   	-----
deletion_allowed      	false
derived               	false
keys                  	map[1:1485962685]
latest_version        	1
min_decryption_version	1
name                  	tommytest
type                  	aes256-gcm96
```