### PR TITLE
audit: support a configurable prefix string to write before each message

### DIFF
--- a/audit/format_json.go
+++ b/audit/format_json.go
@@ -8,11 +8,20 @@ import (
 
 // JSONFormatWriter is an AuditFormatWriter implementation that structures data into
 // a JSON format.
-type JSONFormatWriter struct{}
+type JSONFormatWriter struct {
+	Prefix string
+}
 
 func (f *JSONFormatWriter) WriteRequest(w io.Writer, req *AuditRequestEntry) error {
 	if req == nil {
 		return fmt.Errorf("request entry was nil, cannot encode")
+	}
+
+	if len(f.Prefix) > 0 {
+		_, err := w.Write([]byte(f.Prefix))
+		if err != nil {
+			return err
+		}
 	}
 
 	enc := json.NewEncoder(w)
@@ -22,6 +31,13 @@ func (f *JSONFormatWriter) WriteRequest(w io.Writer, req *AuditRequestEntry) err
 func (f *JSONFormatWriter) WriteResponse(w io.Writer, resp *AuditResponseEntry) error {
 	if resp == nil {
 		return fmt.Errorf("response entry was nil, cannot encode")
+	}
+
+	if len(f.Prefix) > 0 {
+		_, err := w.Write([]byte(f.Prefix))
+		if err != nil {
+			return err
+		}
 	}
 
 	enc := json.NewEncoder(w)

--- a/audit/format_jsonx.go
+++ b/audit/format_jsonx.go
@@ -10,11 +10,20 @@ import (
 
 // JSONxFormatWriter is an AuditFormatWriter implementation that structures data into
 // a XML format.
-type JSONxFormatWriter struct{}
+type JSONxFormatWriter struct {
+	Prefix string
+}
 
 func (f *JSONxFormatWriter) WriteRequest(w io.Writer, req *AuditRequestEntry) error {
 	if req == nil {
 		return fmt.Errorf("request entry was nil, cannot encode")
+	}
+
+	if len(f.Prefix) > 0 {
+		_, err := w.Write([]byte(f.Prefix))
+		if err != nil {
+			return err
+		}
 	}
 
 	jsonBytes, err := json.Marshal(req)
@@ -34,6 +43,13 @@ func (f *JSONxFormatWriter) WriteRequest(w io.Writer, req *AuditRequestEntry) er
 func (f *JSONxFormatWriter) WriteResponse(w io.Writer, resp *AuditResponseEntry) error {
 	if resp == nil {
 		return fmt.Errorf("response entry was nil, cannot encode")
+	}
+
+	if len(f.Prefix) > 0 {
+		_, err := w.Write([]byte(f.Prefix))
+		if err != nil {
+			return err
+		}
 	}
 
 	jsonBytes, err := json.Marshal(resp)

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -76,9 +76,13 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 
 	switch format {
 	case "json":
-		b.formatter.AuditFormatWriter = &audit.JSONFormatWriter{}
+		b.formatter.AuditFormatWriter = &audit.JSONFormatWriter{
+			Prefix: conf.Config["prefix"],
+		}
 	case "jsonx":
-		b.formatter.AuditFormatWriter = &audit.JSONxFormatWriter{}
+		b.formatter.AuditFormatWriter = &audit.JSONxFormatWriter{
+			Prefix: conf.Config["prefix"],
+		}
 	}
 
 	// Ensure that the file can be successfully opened for writing;

--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -87,9 +87,13 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 
 	switch format {
 	case "json":
-		b.formatter.AuditFormatWriter = &audit.JSONFormatWriter{}
+		b.formatter.AuditFormatWriter = &audit.JSONFormatWriter{
+			Prefix: conf.Config["prefix"],
+		}
 	case "jsonx":
-		b.formatter.AuditFormatWriter = &audit.JSONxFormatWriter{}
+		b.formatter.AuditFormatWriter = &audit.JSONxFormatWriter{
+			Prefix: conf.Config["prefix"],
+		}
 	}
 
 	return b, nil

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -74,9 +74,13 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 
 	switch format {
 	case "json":
-		b.formatter.AuditFormatWriter = &audit.JSONFormatWriter{}
+		b.formatter.AuditFormatWriter = &audit.JSONFormatWriter{
+			Prefix: conf.Config["prefix"],
+		}
 	case "jsonx":
-		b.formatter.AuditFormatWriter = &audit.JSONxFormatWriter{}
+		b.formatter.AuditFormatWriter = &audit.JSONxFormatWriter{
+			Prefix: conf.Config["prefix"],
+		}
 	}
 
 	return b, nil

--- a/website/source/docs/audit/file.html.md
+++ b/website/source/docs/audit/file.html.md
@@ -85,6 +85,12 @@ Following are the configuration options available for the backend.
             Allows selecting the output format. Valid values are `json` (the
             default) and `jsonx`, which formats the normal log entries as XML.
       </li>
+      <li>
+        <span class="param">prefix</span>
+        <span class="param-flags">optional</span>
+            Allows a customizable string prefix to write before the actual log
+            line. Defaults to an empty string.
+      </li>
     </ul>
   </dd>
 </dl>

--- a/website/source/docs/audit/socket.html.md
+++ b/website/source/docs/audit/socket.html.md
@@ -74,6 +74,12 @@ Following are the configuration options available for the backend.
         <span class="param-flags">optional</span>
             Sets the timeout for writes to the socket. Defaults to "2s" (2 seconds).
         </li>
+      <li>
+        <span class="param">prefix</span>
+        <span class="param-flags">optional</span>
+            Allows a customizable string prefix to write before the actual log
+            line. Defaults to an empty string.
+      </li>
     </ul>
   </dd>
 </dl>

--- a/website/source/docs/audit/syslog.html.md
+++ b/website/source/docs/audit/syslog.html.md
@@ -71,6 +71,12 @@ Following are the configuration options available for the backend.
             Allows selecting the output format. Valid values are `json` (the
             default) and `jsonx`, which formats the normal log entries as XML.
       </li>
+      <li>
+        <span class="param">prefix</span>
+        <span class="param-flags">optional</span>
+            Allows a customizable string prefix to write before the actual log
+            line. Defaults to an empty string.
+      </li>
     </ul>
   </dd>
 </dl>


### PR DESCRIPTION
This is a second attempt at a previously rejected PR: https://github.com/hashicorp/vault/pull/2067

Configured through:

```
$ vault audit-enable file file_path="foobar.txt" prefix="\@cee: "
```

Will produce logs like:

```
@cee: {"time":"2017-02-09T19:53:46Z","type":"request","auth":{ ...
```

A static token at the beginning of a log line can help systems parse
logs better. For example, rsyslog and syslog-ng will recognize the
'@cee: ' prefix and will parse the rest of the line as a valid json message.
This is useful in environments where there is a mix of structured and
unstructured logs.