### PR TITLE
Include Go runtime version in version string

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 )
 
 var (
@@ -22,6 +23,7 @@ type VersionInfo struct {
 	Revision          string
 	Version           string
 	VersionPrerelease string
+	RuntimeVersion    string
 }
 
 func GetVersion() *VersionInfo {
@@ -38,6 +40,7 @@ func GetVersion() *VersionInfo {
 		Revision:          GitCommit,
 		Version:           ver,
 		VersionPrerelease: rel,
+		RuntimeVersion:    runtime.Version(),
 	}
 }
 
@@ -68,6 +71,9 @@ func (c *VersionInfo) FullVersionNumber(rev bool) string {
 	}
 	if rev && c.Revision != "" {
 		fmt.Fprintf(&versionString, " (%s)", c.Revision)
+	}
+	if c.RuntimeVersion != "" {
+		fmt.Fprintf(&versionString, " %s", c.RuntimeVersion)
 	}
 
 	return versionString.String()


### PR DESCRIPTION
It is occasionally super useful to know which version of the Go compiler and standard library were used to build a Vault release.  This information is not always published on the Vault [CHANGELOG](https://github.com/hashicorp/vault/blob/master/CHANGELOG.md), and attempts to invoke `strings` over a Go binary do not always bear fruit.

```
% bin/vault -version
Vault v0.6.5 go1.8rc3
```

Counter-argument: This may provide misleading information if a Go fork is used to build Vault, as was the case with the Vault 0.5.0 release.