### PR TITLE
Fix listing of deep paths in PostgreSQL backend

### DIFF
--- a/physical/postgresql.go
+++ b/physical/postgresql.go
@@ -71,7 +71,8 @@ func newPostgreSQLBackend(conf map[string]string, logger log.Logger) (Backend, e
 		get_query:    "SELECT value FROM " + quoted_table + " WHERE path = $1 AND key = $2",
 		delete_query: "DELETE FROM " + quoted_table + " WHERE path = $1 AND key = $2",
 		list_query: "SELECT key FROM " + quoted_table + " WHERE path = $1" +
-			"UNION SELECT substr(path, length($1)+1) FROM " + quoted_table + "WHERE parent_path = $1",
+			"UNION SELECT DISTINCT substring(substr(path, length($1)+1) from '^.*?/') FROM " +
+			quoted_table + " WHERE parent_path LIKE concat($1, '%')",
 		logger: logger,
 	}
 


### PR DESCRIPTION
This change addresses an issue where deep paths would not be enumerated if parent paths did not contain a key.

Given the keys `shallow` and `deep` at the following paths...
```
secret/path1/shallow
secret/path2/path3/deep
```

... a `LIST` request against `/v1/secret` would produce only one result, `path1/`.  With this change, the same list request will now list `path1/` and `path2/`.