### PR TITLE
pki: Include private_key_type on DER-formatted responses from /pki/issue/

### DIFF
--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -220,6 +220,7 @@ func (b *backend) pathIssueSignCert(
 
 		if !useCSR {
 			resp.Data["private_key"] = base64.StdEncoding.EncodeToString(parsedBundle.PrivateKeyBytes)
+			resp.Data["private_key_type"] = cb.PrivateKeyType
 		}
 	}
 

--- a/helper/certutil/types.go
+++ b/helper/certutil/types.go
@@ -3,7 +3,9 @@
 // includes helpers for converting a certificate/private key bundle
 // between DER and PEM, printing certificate serial numbers, and more.
 //
-// Functionality specific to the PKI backend includes some types // and helper methods to make requesting certificates from the // backend easy.
+// Functionality specific to the PKI backend includes some types
+// and helper methods to make requesting certificates from the
+// backend easy.
 package certutil
 
 import (


### PR DESCRIPTION
`private_key` can contain a DER-encoded RSA _or_ EC key.   There is currently insufficient information in the response to correctly parse the key (without guessing its type).