### PR TITLE
Use locks in a slice rather than a map

### DIFF
--- a/builtin/credential/approle/backend.go
+++ b/builtin/credential/approle/backend.go
@@ -1,7 +1,6 @@
 package approle
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/hashicorp/vault/helper/locksutil"
@@ -23,28 +22,26 @@ type backend struct {
 	// Guard to clean-up the expired SecretID entries
 	tidySecretIDCASGuard uint32
 
-	// Map of locks to make changes to role entries. These will be
-	// initialized to a predefined number of locks when the backend is
-	// created, and will be indexed based on salted role names.
-	roleLocksMap map[string]*sync.RWMutex
-
-	// Map of locks to make changes to the storage entries of RoleIDs
-	// generated. These will be initialized to a predefined number of locks
-	// when the backend is created, and will be indexed based on the salted
-	// RoleIDs.
-	roleIDLocksMap map[string]*sync.RWMutex
-
-	// Map of locks to make changes to the storage entries of SecretIDs
-	// generated. These will be initialized to a predefined number of locks
-	// when the backend is created, and will be indexed based on the HMAC-ed
-	// SecretIDs.
-	secretIDLocksMap map[string]*sync.RWMutex
-
-	// Map of locks to make changes to the storage entries of
-	// SecretIDAccessors generated. These will be initialized to a
+	// Locks to make changes to role entries. These will be initialized to a
 	// predefined number of locks when the backend is created, and will be
-	// indexed based on the SecretIDAccessors itself.
-	secretIDAccessorLocksMap map[string]*sync.RWMutex
+	// indexed based on salted role names.
+	roleLocks []*locksutil.LockEntry
+
+	// Locks to make changes to the storage entries of RoleIDs generated. These
+	// will be initialized to a predefined number of locks when the backend is
+	// created, and will be indexed based on the salted RoleIDs.
+	roleIDLocks []*locksutil.LockEntry
+
+	// Locks to make changes to the storage entries of SecretIDs generated.
+	// These will be initialized to a predefined number of locks when the
+	// backend is created, and will be indexed based on the HMAC-ed SecretIDs.
+	secretIDLocks []*locksutil.LockEntry
+
+	// Locks to make changes to the storage entries of SecretIDAccessors
+	// generated. These will be initialized to a predefined number of locks
+	// when the backend is created, and will be indexed based on the
+	// SecretIDAccessors itself.
+	secretIDAccessorLocks []*locksutil.LockEntry
 
 	// secretIDListingLock is a dedicated lock for listing SecretIDAccessors
 	// for all the SecretIDs issued against an approle
@@ -64,48 +61,18 @@ func Backend(conf *logical.BackendConfig) (*backend, error) {
 	b := &backend{
 		view: conf.StorageView,
 
-		// Create the map of locks to modify the registered roles
-		roleLocksMap: make(map[string]*sync.RWMutex, 257),
+		// Create locks to modify the registered roles
+		roleLocks: locksutil.CreateLocks(),
 
-		// Create the map of locks to modify the generated RoleIDs
-		roleIDLocksMap: make(map[string]*sync.RWMutex, 257),
+		// Create locks to modify the generated RoleIDs
+		roleIDLocks: locksutil.CreateLocks(),
 
-		// Create the map of locks to modify the generated SecretIDs
-		secretIDLocksMap: make(map[string]*sync.RWMutex, 257),
+		// Create locks to modify the generated SecretIDs
+		secretIDLocks: locksutil.CreateLocks(),
 
-		// Create the map of locks to modify the generated SecretIDAccessors
-		secretIDAccessorLocksMap: make(map[string]*sync.RWMutex, 257),
+		// Create locks to modify the generated SecretIDAccessors
+		secretIDAccessorLocks: locksutil.CreateLocks(),
 	}
-
-	var err error
-
-	// Create 256 locks each for managing RoleID and SecretIDs. This will avoid
-	// a superfluous number of locks directly proportional to the number of RoleID
-	// and SecretIDs. These locks can be accessed by indexing based on the first two
-	// characters of a randomly generated UUID.
-	if err = locksutil.CreateLocks(b.roleLocksMap, 256); err != nil {
-		return nil, fmt.Errorf("failed to create role locks: %v", err)
-	}
-
-	if err = locksutil.CreateLocks(b.roleIDLocksMap, 256); err != nil {
-		return nil, fmt.Errorf("failed to create role ID locks: %v", err)
-	}
-
-	if err = locksutil.CreateLocks(b.secretIDLocksMap, 256); err != nil {
-		return nil, fmt.Errorf("failed to create secret ID locks: %v", err)
-	}
-
-	if err = locksutil.CreateLocks(b.secretIDAccessorLocksMap, 256); err != nil {
-		return nil, fmt.Errorf("failed to create secret ID accessor locks: %v", err)
-	}
-
-	// Have an extra lock to use in case the indexing does not result in a lock.
-	// This happens if the indexing value is not beginning with hex characters.
-	// These locks can be used for listing purposes as well.
-	b.roleLocksMap["custom"] = &sync.RWMutex{}
-	b.roleIDLocksMap["custom"] = &sync.RWMutex{}
-	b.secretIDLocksMap["custom"] = &sync.RWMutex{}
-	b.secretIDAccessorLocksMap["custom"] = &sync.RWMutex{}
 
 	// Attach the paths and secrets that are to be handled by the backend
 	b.Backend = &framework.Backend{

--- a/helper/locksutil/locks_test.go
+++ b/helper/locksutil/locks_test.go
@@ -1,47 +1,10 @@
 package locksutil
 
-import (
-	"sync"
-	"testing"
-)
+import "testing"
 
 func Test_CreateLocks(t *testing.T) {
-	locks := map[string]*sync.RWMutex{}
-
-	// Invalid argument
-	if err := CreateLocks(locks, -1); err == nil {
-		t.Fatal("expected an error")
-	}
-
-	// Invalid argument
-	if err := CreateLocks(locks, 0); err == nil {
-		t.Fatal("expected an error")
-	}
-
-	// Invalid argument
-	if err := CreateLocks(locks, 300); err == nil {
-		t.Fatal("expected an error")
-	}
-
-	// Maximum number of locks
-	if err := CreateLocks(locks, 256); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	locks := CreateLocks()
 	if len(locks) != 256 {
 		t.Fatalf("bad: len(locks): expected:256 actual:%d", len(locks))
 	}
-
-	// Clear out the locks for testing the next case
-	for k, _ := range locks {
-		delete(locks, k)
-	}
-
-	// General case
-	if err := CreateLocks(locks, 10); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if len(locks) != 10 {
-		t.Fatalf("bad: len(locks): expected:10 actual:%d", len(locks))
-	}
-
 }


### PR DESCRIPTION
It's faster and makes things cleaner; we can standardize on the size and the method of lookup. We also don't need a "custom" lock as an empty string will always still return a lock.