### PR TITLE
Rename helper 'duration' to 'parseutil'.

### DIFF
--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -10,7 +10,7 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/audit"
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/logical"
 )
 
@@ -33,7 +33,7 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 	if !ok {
 		writeDeadline = "2s"
 	}
-	writeDuration, err := duration.ParseDurationSecond(writeDeadline)
+	writeDuration, err := parseutil.ParseDurationSecond(writeDeadline)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/fatih/structs"
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -388,7 +388,7 @@ func (b *backend) pathRoleCreate(
 	if len(entry.MaxTTL) == 0 {
 		maxTTL = maxSystemTTL
 	} else {
-		maxTTL, err = duration.ParseDurationSecond(entry.MaxTTL)
+		maxTTL, err = parseutil.ParseDurationSecond(entry.MaxTTL)
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf(
 				"Invalid max ttl: %s", err)), nil
@@ -400,7 +400,7 @@ func (b *backend) pathRoleCreate(
 
 	ttl := b.System().DefaultLeaseTTL()
 	if len(entry.TTL) != 0 {
-		ttl, err = duration.ParseDurationSecond(entry.TTL)
+		ttl, err = parseutil.ParseDurationSecond(entry.TTL)
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf(
 				"Invalid ttl: %s", err)), nil

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/helper/cidrutil"
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -432,7 +432,7 @@ func (b *backend) createCARole(allowedUsers, defaultUser string, data *framework
 		maxTTL = maxSystemTTL
 	} else {
 		var err error
-		maxTTL, err = duration.ParseDurationSecond(role.MaxTTL)
+		maxTTL, err = parseutil.ParseDurationSecond(role.MaxTTL)
 		if err != nil {
 			return nil, logical.ErrorResponse(fmt.Sprintf(
 				"Invalid max ttl: %s", err))
@@ -445,7 +445,7 @@ func (b *backend) createCARole(allowedUsers, defaultUser string, data *framework
 	ttl := b.System().DefaultLeaseTTL()
 	if len(role.TTL) != 0 {
 		var err error
-		ttl, err = duration.ParseDurationSecond(role.TTL)
+		ttl, err = parseutil.ParseDurationSecond(role.TTL)
 		if err != nil {
 			return nil, logical.ErrorResponse(fmt.Sprintf(
 				"Invalid ttl: %s", err))

--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/helper/certutil"
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/helper/errutil"
 	"github.com/hashicorp/vault/helper/strutil"
 	"github.com/hashicorp/vault/logical"
@@ -332,7 +332,7 @@ func (b *backend) calculateTTL(data *framework.FieldData, role *sshRole) (time.D
 		ttl = b.System().DefaultLeaseTTL()
 	} else {
 		var err error
-		ttl, err = duration.ParseDurationSecond(ttlField)
+		ttl, err = parseutil.ParseDurationSecond(ttlField)
 		if err != nil {
 			return 0, fmt.Errorf("invalid requested ttl: %s", err)
 		}
@@ -342,7 +342,7 @@ func (b *backend) calculateTTL(data *framework.FieldData, role *sshRole) (time.D
 		maxTTL = b.System().MaxLeaseTTL()
 	} else {
 		var err error
-		maxTTL, err = duration.ParseDurationSecond(role.MaxTTL)
+		maxTTL, err = parseutil.ParseDurationSecond(role.MaxTTL)
 		if err != nil {
 			return 0, fmt.Errorf("invalid requested max ttl: %s", err)
 		}

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -60,9 +60,12 @@ func TestLoadConfigFile(t *testing.T) {
 			DisableHostname: false,
 		},
 
-		DisableCache: true,
-		DisableMlock: true,
-		EnableUI:     true,
+		DisableCache:    true,
+		DisableCacheRaw: true,
+		DisableMlock:    true,
+		DisableMlockRaw: true,
+		EnableUI:        true,
+		EnableUIRaw:     true,
 
 		MaxLeaseTTL:        10 * time.Hour,
 		MaxLeaseTTLRaw:     "10h",
@@ -134,7 +137,10 @@ func TestLoadConfigFile_json(t *testing.T) {
 		DefaultLeaseTTL:    10 * time.Hour,
 		DefaultLeaseTTLRaw: "10h",
 		ClusterName:        "testcluster",
+		DisableCacheRaw:    interface{}(nil),
+		DisableMlockRaw:    interface{}(nil),
 		EnableUI:           true,
+		EnableUIRaw:        true,
 	}
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config, expected)

--- a/command/token_renew.go
+++ b/command/token_renew.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/meta"
 )
 
@@ -44,7 +44,7 @@ func (c *TokenRenewCommand) Run(args []string) int {
 		increment = args[1]
 	}
 	if increment != "" {
-		dur, err := duration.ParseDurationSecond(increment)
+		dur, err := parseutil.ParseDurationSecond(increment)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Invalid increment: %s", err))
 			return 1

--- a/helper/parseutil/parseutil.go
+++ b/helper/parseutil/parseutil.go
@@ -1,4 +1,4 @@
-package duration
+package parseutil
 
 import (
 	"encoding/json"
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 func ParseDurationSecond(in interface{}) (time.Duration, error) {
@@ -49,4 +51,12 @@ func ParseDurationSecond(in interface{}) (time.Duration, error) {
 	}
 
 	return dur, nil
+}
+
+func ParseBool(in interface{}) (bool, error) {
+	var result bool
+	if err := mapstructure.WeakDecode(in, &result); err != nil {
+		return false, err
+	}
+	return result, nil
 }

--- a/helper/parseutil/parseutil_test.go
+++ b/helper/parseutil/parseutil_test.go
@@ -1,4 +1,4 @@
-package duration
+package parseutil
 
 import (
 	"encoding/json"
@@ -27,5 +27,29 @@ func Test_ParseDurationSecond(t *testing.T) {
 	}
 	if outp != time.Duration(4352)*time.Second {
 		t.Fatal("not equivalent")
+	}
+}
+
+func Test_ParseBool(t *testing.T) {
+	outp, err := ParseBool("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outp {
+		t.Fatal("wrong output")
+	}
+	outp, err = ParseBool(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outp {
+		t.Fatal("wrong output")
+	}
+	outp, err = ParseBool(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outp {
+		t.Fatal("wrong output")
 	}
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/consts"
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/helper/jsonutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/vault"
@@ -289,7 +289,7 @@ func requestWrapInfo(r *http.Request, req *logical.Request) (*logical.Request, e
 	}
 
 	// If it has an allowed suffix parse as a duration string
-	dur, err := duration.ParseDurationSecond(wrapTTL)
+	dur, err := parseutil.ParseDurationSecond(wrapTTL)
 	if err != nil {
 		return req, err
 	}

--- a/logical/framework/backend.go
+++ b/logical/framework/backend.go
@@ -13,7 +13,7 @@ import (
 	log "github.com/mgutz/logxi/v1"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/helper/errutil"
 	"github.com/hashicorp/vault/helper/logformat"
 	"github.com/hashicorp/vault/logical"
@@ -551,7 +551,7 @@ func (s *FieldSchema) DefaultOrZero() interface{} {
 			case float64:
 				result = int(inp)
 			case string:
-				dur, err := duration.ParseDurationSecond(inp)
+				dur, err := parseutil.ParseDurationSecond(inp)
 				if err != nil {
 					return s.Type.Zero()
 				}

--- a/logical/framework/field_data.go
+++ b/logical/framework/field_data.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -161,7 +161,7 @@ func (d *FieldData) getPrimitive(
 		case float64:
 			result = int(inp)
 		case string:
-			dur, err := duration.ParseDurationSecond(inp)
+			dur, err := parseutil.ParseDurationSecond(inp)
 			if err != nil {
 				return nil, true, err
 			}

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/helper/jsonutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
@@ -133,7 +133,7 @@ func (b *PassthroughBackend) handleRead(
 	}
 	ttlDuration := b.System().DefaultLeaseTTL()
 	if len(ttl) != 0 {
-		dur, err := duration.ParseDurationSecond(ttl)
+		dur, err := parseutil.ParseDurationSecond(ttl)
 		if err == nil {
 			ttlDuration = dur
 		}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/helper/consts"
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 	"github.com/mitchellh/mapstructure"
@@ -973,7 +973,7 @@ func (b *SystemBackend) handleMount(
 	case "":
 	case "system":
 	default:
-		tmpDef, err := duration.ParseDurationSecond(apiConfig.DefaultLeaseTTL)
+		tmpDef, err := parseutil.ParseDurationSecond(apiConfig.DefaultLeaseTTL)
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf(
 					"unable to parse default TTL of %s: %s", apiConfig.DefaultLeaseTTL, err)),
@@ -986,7 +986,7 @@ func (b *SystemBackend) handleMount(
 	case "":
 	case "system":
 	default:
-		tmpMax, err := duration.ParseDurationSecond(apiConfig.MaxLeaseTTL)
+		tmpMax, err := parseutil.ParseDurationSecond(apiConfig.MaxLeaseTTL)
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf(
 					"unable to parse max TTL of %s: %s", apiConfig.MaxLeaseTTL, err)),
@@ -1221,7 +1221,7 @@ func (b *SystemBackend) handleTuneWriteCommon(
 			tmpDef := time.Duration(0)
 			newDefault = &tmpDef
 		default:
-			tmpDef, err := duration.ParseDurationSecond(defTTL)
+			tmpDef, err := parseutil.ParseDurationSecond(defTTL)
 			if err != nil {
 				return handleError(err)
 			}
@@ -1235,7 +1235,7 @@ func (b *SystemBackend) handleTuneWriteCommon(
 			tmpMax := time.Duration(0)
 			newMax = &tmpMax
 		default:
-			tmpMax, err := duration.ParseDurationSecond(maxTTL)
+			tmpMax, err := parseutil.ParseDurationSecond(maxTTL)
 			if err != nil {
 				return handleError(err)
 			}

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 )
 
 const (
@@ -211,14 +211,14 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			}
 		}
 		if pc.MinWrappingTTLHCL != nil {
-			dur, err := duration.ParseDurationSecond(pc.MinWrappingTTLHCL)
+			dur, err := parseutil.ParseDurationSecond(pc.MinWrappingTTLHCL)
 			if err != nil {
 				return errwrap.Wrapf("error parsing min_wrapping_ttl: {{err}}", err)
 			}
 			pc.Permissions.MinWrappingTTL = dur
 		}
 		if pc.MaxWrappingTTLHCL != nil {
-			dur, err := duration.ParseDurationSecond(pc.MaxWrappingTTLHCL)
+			dur, err := parseutil.ParseDurationSecond(pc.MaxWrappingTTLHCL)
 			if err != nil {
 				return errwrap.Wrapf("error parsing max_wrapping_ttl: {{err}}", err)
 			}

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -11,7 +11,7 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/vault/helper/duration"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/helper/jsonutil"
 	"github.com/hashicorp/vault/helper/locksutil"
 	"github.com/hashicorp/vault/helper/policyutil"
@@ -1582,7 +1582,7 @@ func (ts *TokenStore) handleCreateCommon(
 	}
 
 	if data.ExplicitMaxTTL != "" {
-		dur, err := duration.ParseDurationSecond(data.ExplicitMaxTTL)
+		dur, err := parseutil.ParseDurationSecond(data.ExplicitMaxTTL)
 		if err != nil {
 			return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 		}
@@ -1598,7 +1598,7 @@ func (ts *TokenStore) handleCreateCommon(
 			return logical.ErrorResponse("root or sudo privileges required to create periodic token"),
 				logical.ErrInvalidRequest
 		}
-		dur, err := duration.ParseDurationSecond(data.Period)
+		dur, err := parseutil.ParseDurationSecond(data.Period)
 		if err != nil {
 			return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 		}
@@ -1611,7 +1611,7 @@ func (ts *TokenStore) handleCreateCommon(
 
 	// Parse the TTL/lease if any
 	if data.TTL != "" {
-		dur, err := duration.ParseDurationSecond(data.TTL)
+		dur, err := parseutil.ParseDurationSecond(data.TTL)
 		if err != nil {
 			return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 		}


### PR DESCRIPTION
Add a ParseBool function that accepts various kinds of ways of
specifying booleans.

Have config use ParseBool for UI and disabling mlock/cache.

We should probably start opportunistically switching bool handling (in non-`framework` contexts) to use this as the current situation of sometimes-bool-sometimes-string is pretty confusing for users.