### PR TITLE
Website add meganav

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.12"
+gem "middleman-hashicorp", "0.3.13"

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.12)
+    middleman-hashicorp (0.3.13)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -151,7 +151,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.12)
+  middleman-hashicorp (= 0.3.13)
 
 BUNDLED WITH
    1.14.6

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.12"
+VERSION?="0.3.13"
 
 website:
 	@echo "==> Starting website in Docker..."

--- a/website/packer.json
+++ b/website/packer.json
@@ -8,7 +8,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "hashicorp/middleman-hashicorp:0.3.12",
+      "image": "hashicorp/middleman-hashicorp:0.3.13",
       "discard": "true",
       "run_command": ["-d", "-i", "-t", "{{ .Image }}", "/bin/sh"]
     }

--- a/website/source/assets/javascripts/application.js
+++ b/website/source/assets/javascripts/application.js
@@ -12,6 +12,8 @@
 //= require lib/Chainable
 //= require lib/dbg
 
+//= require hashicorp/mega-nav
+
 //= require app/Sidebar
 //= require app/DotLockup
 //= require app/Init

--- a/website/source/assets/stylesheets/application.scss
+++ b/website/source/assets/stylesheets/application.scss
@@ -1,14 +1,16 @@
 @import 'bootstrap-sprockets';
 @import 'bootstrap';
 
-// Remote fonts
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600');
+@import url("//fonts.googleapis.com/css?family=Open+Sans:300,400,700|Open+Sans:300,600,400|Ubuntu+Mono");
 
 // Core variables and mixins
 @import '_variables';
 
 //Global Site
 @import '_global';
+
+//Mega Nav
+@import 'hashicorp/mega-nav';
 
 // Hashicorp Shared Project Styles
 @import 'hashicorp-shared/_hashicorp-utility';

--- a/website/source/layouts/inner.erb
+++ b/website/source/layouts/inner.erb
@@ -1,7 +1,7 @@
 <% wrap_layout :layout do %>
 <div class="container">
 	<div class="row">
-		<div class="col-sm-3 col-md-offset-1 col-md-3 col-xs-12">
+		<div class="col-sm-3 col-md-3 col-xs-12">
 			<%= yield_content :sidebar %>
 		</div>
 

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -43,7 +43,7 @@
     <div id="header" class="navigation navbar-static-top hidden-print">
       <div class="container">
         <div class="row">
-          <div class="col-md-offset-1 col-md-10 col-xs-12">
+          <div class="col-xs-12">
             <div class="navbar-header">
               <div class="navbar-brand">
                 <a class="logo" href="/">Vault</a>

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -88,7 +88,7 @@
     <div id="footer" class="navigation hidden-print">
       <div class="container">
         <div class="row">
-          <div class="col-md-offset-1 col-md-10 col-xs-12">
+          <div class="col-xs-12">
             <% if current_page.url != '/' && current_page.url != '/index.html' %>
               <div class="edit-page-link"><a href="<%= github_url :current_page %>">Edit this page</a></div>
             <% end %>

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -37,24 +37,8 @@
   </head>
 
   <body id="<%= body_id_for(current_page) %>" class="<%= body_classes_for(current_page) %>">
-    <div id="announcement-bnr" class="hidden-print">
-      <div class="container">
-        <div class="row">
-          <div class="col-md-offset-1 col-md-10 col-xs-12">
-            <p>
-              Announcing
-              <a class="enterprise-logo" href="https://www.hashicorp.com/vault.html?utm_source=oss&utm_medium=top-banner&utm_campaign=vault">
-                <%= partial "layouts/svg/svg-enterprise" %>
-              </a>
-              <span class="tagline">Secure Infrastructure Automation.</span>
-              <a class="link-blue" href="https://www.hashicorp.com/vault.html?utm_source=oss&utm_medium=top-banner&utm_campaign=vault">
-                Find out more <span class="hcaret"></span>
-              </a>
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
+
+   <%= mega_nav :vault %>
 
     <div id="header" class="navigation navbar-static-top hidden-print">
       <div class="container">
@@ -63,7 +47,6 @@
             <div class="navbar-header">
               <div class="navbar-brand">
                 <a class="logo" href="/">Vault</a>
-                <a class="by-hashicorp" href="https://hashicorp.com/"><span class="svg-wrap">by</span><%= partial "layouts/svg/svg-by-hashicorp" %><%= partial "layouts/svg/svg-hashicorp-logo" %>Hashicorp</a>
               </div>
               <button class="navbar-toggle" type="button">
                 <span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
🚧 WIP. Don't merge until final 👍 

HashiCorp is adding a high-level element to provide navigation and visibility to OSS project sites. We like to call it Mega Nav :zap:. Mega Nav is pulled in from [middleman-hashicorp](https://github.com/hashicorp/middleman-hashicorp) and is positioned above the local nav in the site. It looks like this: 

### Desktop Inactive
<img width="1431" alt="screen shot 2017-03-08 at 3 20 26 pm" src="https://cloud.githubusercontent.com/assets/416727/23728705/200c7c7a-0413-11e7-805a-1a23cd50ea1b.png">

### Desktop Active
<img width="1433" alt="screen shot 2017-03-08 at 3 20 41 pm" src="https://cloud.githubusercontent.com/assets/416727/23728713/28a3e062-0413-11e7-9669-0c877d854fc7.png">

### Mobile Inactive
<img width="400" alt="screen shot 2017-03-08 at 3 21 02 pm" src="https://cloud.githubusercontent.com/assets/416727/23728718/2e6c129e-0413-11e7-8146-2f9e29c4e909.png">

### Mobile Active
<img width="397" alt="screen shot 2017-03-08 at 3 21 11 pm" src="https://cloud.githubusercontent.com/assets/416727/23728725/3400452c-0413-11e7-9bc7-c08af3c93c5c.png">

It's worth noting the layout has been updated. The offset is removed and the container on the site as wide as the other HashiCorp OSS sites. 

cc/ @pearkes @hashicorp/design 