### PR TITLE
Pass user/pass for HTTP Basic Authentication in URL parameters

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -333,6 +333,7 @@ func (c *Client) NewRequest(method, path string) *Request {
 	req := &Request{
 		Method: method,
 		URL: &url.URL{
+			User:   c.addr.User,
 			Scheme: c.addr.Scheme,
 			Host:   c.addr.Host,
 			Path:   path,

--- a/api/request.go
+++ b/api/request.go
@@ -55,6 +55,7 @@ func (r *Request) ToHTTP() (*http.Request, error) {
 		return nil, err
 	}
 
+	req.URL.User = r.URL.User
 	req.URL.Scheme = r.URL.Scheme
 	req.URL.Host = r.URL.Host
 	req.Host = r.URL.Host


### PR DESCRIPTION
Scenario: Vault sits behind reverse proxy which has basicauth configured.