### PR TITLE
Adding allow_user_key_ids field to SSH role config

### DIFF
--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -44,6 +44,7 @@ type sshRole struct {
 	AllowHostCertificates  bool              `mapstructure:"allow_host_certificates" json:"allow_host_certificates"`
 	AllowBareDomains       bool              `mapstructure:"allow_bare_domains" json:"allow_bare_domains"`
 	AllowSubdomains        bool              `mapstructure:"allow_subdomains" json:"allow_subdomains"`
+	AllowUserKeyIDs        bool              `mapstructure:"allow_user_key_ids" json:"allow_user_key_ids"`
 }
 
 func pathListRoles(b *backend) *framework.Path {
@@ -254,6 +255,16 @@ func pathRoles(b *backend) *framework.Path {
 				If set, host certificates that are requested are allowed to use subdomains of those listed in "allowed_domains".
 				`,
 			},
+			"allow_user_key_ids": &framework.FieldSchema{
+				Type: framework.TypeBool,
+				Default: true,
+				Description: `
+				[Not applicable for Dynamic type] [Not applicable for OTP type] [Optional for CA type]
+				If true, users can override the key ID for a signed certificate with the "key_id" field.
+				When false, the key ID will always be the token display name.
+				The key ID is logged by the SSH server and can be useful for auditing.
+				`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -423,6 +434,7 @@ func (b *backend) createCARole(allowedUsers, defaultUser string, data *framework
 		DefaultUser:            defaultUser,
 		AllowBareDomains:       data.Get("allow_bare_domains").(bool),
 		AllowSubdomains:        data.Get("allow_subdomains").(bool),
+		AllowUserKeyIDs:        data.Get("allow_user_key_ids").(bool),
 		KeyType:                KeyTypeCA,
 	}
 
@@ -536,6 +548,7 @@ func (b *backend) pathRoleRead(req *logical.Request, d *framework.FieldData) (*l
 				"allow_host_certificates":  role.AllowHostCertificates,
 				"allow_bare_domains":       role.AllowBareDomains,
 				"allow_subdomains":         role.AllowSubdomains,
+				"allow_user_key_ids":       role.AllowUserKeyIDs,
 				"key_type":                 role.KeyType,
 				"default_critical_options": role.DefaultCriticalOptions,
 				"default_extensions":       role.DefaultExtensions,

--- a/website/source/docs/secrets/ssh/index.html.md
+++ b/website/source/docs/secrets/ssh/index.html.md
@@ -619,6 +619,14 @@ username@<IP of remote host>:~$
         subdomains of those listed in "allowed_users". Defaults
         to false.
       </li>
+      <li>
+        <span class="param">allow_user_key_ids</span>
+        <span class="param-flags">N/A for Dynamic Key type, N/A for OTP type,
+        optional for CA type</span>
+        If true, users can override the key ID for a signed certificate with the "key_id" field.
+        When false, the key ID will always be the token display name.
+        The key ID is logged by the SSH server and can be useful for auditing.
+      </li>
     </ul>
   </dd>
 
@@ -678,6 +686,7 @@ username@<IP of remote host>:~$
   "allow_bare_domains": false,
   "allow_host_certificates": true,
   "allow_subdomains": false,
+  "allow_user_key_ids": false,
   "allow_user_certificates": true,
   "allowed_critical_options": "",
   "allowed_extensions": "",


### PR DESCRIPTION
Adding a boolean field that determines whether users will be allowed to
set the ID of the signed SSH key or whether it will always be the token
display name.  Preventing users from changing the ID and always using
the token name is useful for auditing who actually used a key to access
a remote host since sshd logs key IDs.