### PR TITLE
turbolinks + ember = ❤ 

### DIFF
--- a/website/source/assets/javascripts/app/Init.js
+++ b/website/source/assets/javascripts/app/Init.js
@@ -59,6 +59,8 @@ var Init = {
 
 };
 
-Init.start();
+$(function() {
+  Init.start();
+});
 
 })(window.Sidebar, window.DotLockup);

--- a/website/source/assets/javascripts/application.js
+++ b/website/source/assets/javascripts/application.js
@@ -2,9 +2,6 @@
 //= require jquery
 //= require bootstrap
 //= require jquery.waypoints
-//= require lib/ember-template-compiler
-//= require lib/ember-1-10
-//= require lib/ember-data-1-0
 
 //= require lib/String.substitute
 //= require lib/Function.prototype.bind
@@ -17,6 +14,3 @@
 //= require app/Sidebar
 //= require app/DotLockup
 //= require app/Init
-
-//= require demo
-//= require_tree ./demo

--- a/website/source/assets/javascripts/demo-app.js
+++ b/website/source/assets/javascripts/demo-app.js
@@ -1,0 +1,5 @@
+//= require lib/ember-template-compiler
+//= require lib/ember-1-10
+//= require lib/ember-data-1-0
+//= require demo
+//= require_tree ./demo

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -9,7 +9,7 @@
 
     <div>
       <a class="v-btn blue lrg started" href="/intro">Get Started</a>
-      <a class="v-btn black lrg terminal" href="/#/demo/0">Launch Interactive Tutorial</a>
+      <a class="v-btn black lrg terminal" href="/#/demo/0" data-turbolinks="false">Launch Interactive Tutorial</a>
     </div>
 
     <div id="diagram"></div>
@@ -93,3 +93,8 @@
     </div>
   </div>
 </div>
+
+
+<% content_for(:scripts) do %>
+  <%= javascript_include_tag "demo-app" %>
+<% end %>

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -47,7 +47,7 @@
           <div class="col-xs-12">
             <div class="navbar-header">
               <div class="navbar-brand">
-                <a class="logo" href="/">Vault</a>
+                <a class="logo" href="/" data-turbolinks="false">Vault</a>
               </div>
               <button class="navbar-toggle" type="button">
                 <span class="sr-only">Toggle navigation</span>

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -21,6 +21,7 @@
     <!--[if lt IE 9]>
       <%= javascript_include_tag "ie-compat" %>
     <![endif]-->
+    <%= javascript_include_tag "application" %>
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -134,7 +135,7 @@
     }());
     </script>
 
-    <%= javascript_include_tag "application" %>
+    <%= yield_content :scripts %>
 
     <script type="application/ld+json">
       {


### PR DESCRIPTION
This excludes the homepage from using tubolinks and moves the ember JS files to only load on the home page. /cc @sethvargo 