### PR TITLE
website: update docs to clearly link to enterprise version

### DIFF
--- a/website/source/docs/vault-enterprise/index.html.md
+++ b/website/source/docs/vault-enterprise/index.html.md
@@ -15,3 +15,5 @@ specific workflows. These include:
 - [Replication](/docs/vault-enterprise/replication)
 - [Secure Introduction Client](/docs/vault-enterprise/vsi)
 - [HSM Key Wrapping and Auto-Unsealing](/docs/vault-enterprise/hsm)
+
+These features are part of [Vault Enterprise](https://www.hashicorp.com/vault.html?utm_source=oss&utm_medium=docs&utm_campaign=vault&_ga=1.201793489.1956619674.1489356624).


### PR DESCRIPTION
This just makes it more obvious if you land on this page.