### PR TITLE
Add globbing support to the PKI backend's allowed_domains list

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1549,6 +1549,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		Wildcard             bool `structs:"*.example.com"`
 		SubSubdomain         bool `structs:"foo.bar.example.com"`
 		SubSubdomainWildcard bool `structs:"*.bar.example.com"`
+		GlobDomain           bool `structs:"fooexample.com"`
 		NonHostname          bool `structs:"daɪˈɛrɨsɨs"`
 		AnyHost              bool `structs:"porkslap.beer"`
 	}
@@ -1753,6 +1754,11 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		commonNames.SecondDomain = true
 		roleVals.AllowBareDomains = true
 		commonNames.BareDomain = true
+		addCnTests()
+
+		roleVals.AllowedDomains = "foobar.com,*example.com"
+		roleVals.AllowGlobDomains = true
+		commonNames.GlobDomain = true
 		addCnTests()
 
 		roleVals.AllowAnyName = true

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -331,8 +331,8 @@ func validateNames(req *logical.Request, names []string, role *roleEntry) string
 					}
 				}
 
-				if glob.Glob("*."+req.DisplayName, sanitizedName) ||
-					(isWildcard && glob.Glob(req.DisplayName, sanitizedName)) {
+				if strings.HasSuffix(sanitizedName, "."+req.DisplayName) ||
+					(isWildcard && sanitizedName == req.DisplayName) {
 					continue
 				}
 			}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/vault/helper/strutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
+	"github.com/ryanuber/go-glob"
 )
 
 type certExtKeyUsage int
@@ -323,15 +324,15 @@ func validateNames(req *logical.Request, names []string, role *roleEntry) string
 							// Compare the sanitized name against the hostname
 							// portion of the email address in the roken
 							// display name
-							if strings.HasSuffix(sanitizedName, "."+splitDisplay[1]) {
+							if glob.Glob("*."+splitDisplay[1], sanitizedName) {
 								continue
 							}
 						}
 					}
 				}
 
-				if strings.HasSuffix(sanitizedName, "."+req.DisplayName) ||
-					(isWildcard && sanitizedName == req.DisplayName) {
+				if glob.Glob("*."+req.DisplayName, sanitizedName) ||
+					(isWildcard && glob.Glob(req.DisplayName, sanitizedName)) {
 					continue
 				}
 			}
@@ -348,15 +349,15 @@ func validateNames(req *logical.Request, names []string, role *roleEntry) string
 				// First, allow an exact match of the base domain if that role flag
 				// is enabled
 				if role.AllowBareDomains &&
-					(name == currDomain ||
-						(isEmail && emailDomain == currDomain)) {
+					(glob.Glob(currDomain, name) ||
+						(isEmail && glob.Glob(currDomain, emailDomain))) {
 					valid = true
 					break
 				}
 
 				if role.AllowSubdomains {
-					if strings.HasSuffix(sanitizedName, "."+currDomain) ||
-						(isWildcard && sanitizedName == currDomain) {
+					if glob.Glob("*."+currDomain, sanitizedName) ||
+						(isWildcard && glob.Glob(currDomain, sanitizedName)) {
 						valid = true
 						break
 					}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -363,9 +363,8 @@ func validateNames(req *logical.Request, names []string, role *roleEntry) string
 					}
 				}
 
-				// Domain globbing support additionally requires bare domains to be enabled
 				if role.AllowGlobDomains &&
-					role.AllowBareDomains &&
+					strings.Contains(currDomain, "*") &&
 					glob.Glob(currDomain, name) {
 					valid = true
 					break

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -324,7 +324,7 @@ func validateNames(req *logical.Request, names []string, role *roleEntry) string
 							// Compare the sanitized name against the hostname
 							// portion of the email address in the roken
 							// display name
-							if glob.Glob("*."+splitDisplay[1], sanitizedName) {
+							if strings.HasSuffix(sanitizedName, "."+splitDisplay[1]) {
 								continue
 							}
 						}
@@ -350,7 +350,7 @@ func validateNames(req *logical.Request, names []string, role *roleEntry) string
 				// is enabled
 				if role.AllowBareDomains &&
 					(glob.Glob(currDomain, name) ||
-						(isEmail && glob.Glob(currDomain, emailDomain))) {
+						(isEmail && emailDomain == currDomain)) {
 					valid = true
 					break
 				}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -349,18 +349,26 @@ func validateNames(req *logical.Request, names []string, role *roleEntry) string
 				// First, allow an exact match of the base domain if that role flag
 				// is enabled
 				if role.AllowBareDomains &&
-					(glob.Glob(currDomain, name) ||
+					(name == currDomain ||
 						(isEmail && emailDomain == currDomain)) {
 					valid = true
 					break
 				}
 
 				if role.AllowSubdomains {
-					if glob.Glob("*."+currDomain, sanitizedName) ||
-						(isWildcard && glob.Glob(currDomain, sanitizedName)) {
+					if strings.HasSuffix(sanitizedName, "."+currDomain) ||
+						(isWildcard && sanitizedName == currDomain) {
 						valid = true
 						break
 					}
+				}
+
+				// Domain globbing support additionally requires bare domains to be enabled
+				if role.AllowGlobDomains &&
+					role.AllowBareDomains &&
+					glob.Glob(currDomain, name) {
+					valid = true
+					break
 				}
 			}
 			if valid {

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -84,6 +84,15 @@ including wildcard subdomains. See the documentation for
 more information.`,
 			},
 
+			"allow_glob_domains": &framework.FieldSchema{
+				Type:    framework.TypeBool,
+				Default: false,
+				Description: `If set, domains specified in "allowed_domains"
+can include glob patterns, e.g. "ftp*.example.com". This
+option requires "allow_bare_domains" to be set as well.
+See the documentation for more information.`,
+			},
+
 			"allow_any_name": &framework.FieldSchema{
 				Type:    framework.TypeBool,
 				Default: false,
@@ -369,6 +378,7 @@ func (b *backend) pathRoleCreate(
 		AllowedDomains:      data.Get("allowed_domains").(string),
 		AllowBareDomains:    data.Get("allow_bare_domains").(bool),
 		AllowSubdomains:     data.Get("allow_subdomains").(bool),
+		AllowGlobDomains:    data.Get("allow_glob_domains").(bool),
 		AllowAnyName:        data.Get("allow_any_name").(bool),
 		EnforceHostnames:    data.Get("enforce_hostnames").(bool),
 		AllowIPSANs:         data.Get("allow_ip_sans").(bool),
@@ -488,6 +498,7 @@ type roleEntry struct {
 	AllowBareDomains      bool   `json:"allow_bare_domains" structs:"allow_bare_domains" mapstructure:"allow_bare_domains"`
 	AllowTokenDisplayName bool   `json:"allow_token_displayname" structs:"allow_token_displayname" mapstructure:"allow_token_displayname"`
 	AllowSubdomains       bool   `json:"allow_subdomains" structs:"allow_subdomains" mapstructure:"allow_subdomains"`
+	AllowGlobDomains      bool   `json:"allow_glob_domains" structs:"allow_glob_domains" mapstructure:"allow_glob_domains"`
 	AllowAnyName          bool   `json:"allow_any_name" structs:"allow_any_name" mapstructure:"allow_any_name"`
 	EnforceHostnames      bool   `json:"enforce_hostnames" structs:"enforce_hostnames" mapstructure:"enforce_hostnames"`
 	AllowIPSANs           bool   `json:"allow_ip_sans" structs:"allow_ip_sans" mapstructure:"allow_ip_sans"`

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -88,9 +88,8 @@ more information.`,
 				Type:    framework.TypeBool,
 				Default: false,
 				Description: `If set, domains specified in "allowed_domains"
-can include glob patterns, e.g. "ftp*.example.com". This
-option requires "allow_bare_domains" to be set as well.
-See the documentation for more information.`,
+can include glob patterns, e.g. "ftp*.example.com". See
+the documentation for more information.`,
 			},
 
 			"allow_any_name": &framework.FieldSchema{

--- a/vendor/github.com/ryanuber/go-glob/LICENSE
+++ b/vendor/github.com/ryanuber/go-glob/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Ryan Uber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/ryanuber/go-glob/README.md
+++ b/vendor/github.com/ryanuber/go-glob/README.md
@@ -1,0 +1,29 @@
+# String globbing in golang [![Build Status](https://travis-ci.org/ryanuber/go-glob.svg)](https://travis-ci.org/ryanuber/go-glob)
+
+`go-glob` is a single-function library implementing basic string glob support.
+
+Globs are an extremely user-friendly way of supporting string matching without
+requiring knowledge of regular expressions or Go's particular regex engine. Most
+people understand that if you put a `*` character somewhere in a string, it is
+treated as a wildcard. Surprisingly, this functionality isn't found in Go's
+standard library, except for `path.Match`, which is intended to be used while
+comparing paths (not arbitrary strings), and contains specialized logic for this
+use case. A better solution might be a POSIX basic (non-ERE) regular expression
+engine for Go, which doesn't exist currently.
+
+Example
+=======
+
+```
+package main
+
+import "github.com/ryanuber/go-glob"
+
+func main() {
+    glob.Glob("*World!", "Hello, World!") // true
+    glob.Glob("Hello,*", "Hello, World!") // true
+    glob.Glob("*ello,*", "Hello, World!") // true
+    glob.Glob("World!", "Hello, World!")  // false
+    glob.Glob("/home/*", "/home/ryanuber/.bashrc") // true
+}
+```

--- a/vendor/github.com/ryanuber/go-glob/glob.go
+++ b/vendor/github.com/ryanuber/go-glob/glob.go
@@ -1,0 +1,56 @@
+package glob
+
+import "strings"
+
+// The character which is treated like a glob
+const GLOB = "*"
+
+// Glob will test a string pattern, potentially containing globs, against a
+// subject string. The result is a simple true/false, determining whether or
+// not the glob pattern matched the subject text.
+func Glob(pattern, subj string) bool {
+	// Empty pattern can only match empty subject
+	if pattern == "" {
+		return subj == pattern
+	}
+
+	// If the pattern _is_ a glob, it matches everything
+	if pattern == GLOB {
+		return true
+	}
+
+	parts := strings.Split(pattern, GLOB)
+
+	if len(parts) == 1 {
+		// No globs in pattern, so test for equality
+		return subj == pattern
+	}
+
+	leadingGlob := strings.HasPrefix(pattern, GLOB)
+	trailingGlob := strings.HasSuffix(pattern, GLOB)
+	end := len(parts) - 1
+
+	// Go over the leading parts and ensure they match.
+	for i := 0; i < end; i++ {
+		idx := strings.Index(subj, parts[i])
+
+		switch i {
+		case 0:
+			// Check the first section. Requires special handling.
+			if !leadingGlob && idx != 0 {
+				return false
+			}
+		default:
+			// Check that the middle parts match.
+			if idx < 0 {
+				return false
+			}
+		}
+
+		// Trim evaluated text from subj as we loop over the pattern.
+		subj = subj[idx+len(parts[i]):]
+	}
+
+	// Reached the last section. Requires special handling.
+	return trailingGlob || strings.HasSuffix(subj, parts[end])
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1117,6 +1117,12 @@
 			"revisionTime": "2017-02-08T17:17:27Z"
 		},
 		{
+			"checksumSHA1": "6JP37UqrI0H80Gpk0Y2P+KXgn5M=",
+			"path": "github.com/ryanuber/go-glob",
+			"revision": "256dc444b735e061061cf46c809487313d5b0065",
+			"revisionTime": "2017-01-28T01:21:29Z"
+		},
+		{
 			"checksumSHA1": "5SYLEhADhdBVZAGPVHWggQl7H8k=",
 			"path": "github.com/samuel/go-zookeeper/zk",
 			"revision": "1d7be4effb13d2d908342d349d71a284a7542693",

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -663,9 +663,7 @@ request is denied.
 - `allow_glob_domains` `(bool: false)` - Allows names specified in
   `allowed_domains` to contain glob patterns (e.g. `ftp*.example.com`). Clients
   will be allowed to request certificates with names matching the glob
-  patterns. _Please note_ that setting this option requires
-  `allow_bare_domains` to be set as well, since a glob match against a
-  non-glob pattern would result in an implicit bare domain match.
+  patterns.
 
 - `allow_any_name` `(bool: false)` – Specifies if clients can request any CN.
   Useful in some circumstances, but make sure you understand whether it is

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -613,12 +613,13 @@ $ curl \
 
 ## Create/Update Role
 
-This endpoint ceates or updates the role definition. Note that the
-`allowed_domains`, `allow_subdomains`, and `allow_any_name` attributes are
-additive; between them nearly and across multiple roles nearly any issuing
-policy can be accommodated. `server_flag`, `client_flag`, and
-`code_signing_flag` are additive as well. If a client requests a certificate
-that is not allowed by the CN policy in the role, the request is denied.
+This endpoint creates or updates the role definition. Note that the
+`allowed_domains`, `allow_subdomains`, `allow_glob_domains`, and
+`allow_any_name` attributes are additive; between them nearly and across
+multiple roles nearly any issuing policy can be accommodated. `server_flag`,
+`client_flag`, and `code_signing_flag` are additive as well. If a client
+requests a certificate that is not allowed by the CN policy in the role, the
+request is denied.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
@@ -658,6 +659,13 @@ that is not allowed by the CN policy in the role, the request is denied.
   `allowed_domains` value of `example.com` with this option set to true will
   allow `foo.example.com` and `bar.example.com` as well as `*.example.com`. This
   is redundant when using the `allow_any_name` option.
+
+- `allow_glob_domains` `(bool: false)` - Allows names specified in
+  `allowed_domains` to contain glob patterns (e.g. `ftp*.example.com`). Clients
+  will be allowed to request certificates with names matching the glob
+  patterns. _Please note_ that setting this option requires
+  `allow_bare_domains` to be set as well, since a glob match against a
+  non-glob pattern would result in an implicit bare domain match.
 
 - `allow_any_name` `(bool: false)` – Specifies if clients can request any CN.
   Useful in some circumstances, but make sure you understand whether it is


### PR DESCRIPTION
This change adds simple glob support to the "allowed_domains" list in the PKI backend. This is useful if you would like role policies to allow more flexible name patterns without allowing any name or any subdomain.

It uses an asterisk as the glob character, which I think works for this use case because an asterisk cannot be used in a DNS domain name and in a certificate the wildcard can only be in one specific place (a single wildcard can be present in the left-most name position, and it must be the only component of the dot boundary). A PKI policy of "\*.domain.com" will still allow the explicit name "\*.domain.com". It will also allow anything ending in ".domain.com", however this is consistent with threat modeling around the DNS hierarchy.