### PR TITLE
Progress should not be reset to 0 on unseal

### DIFF
--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -188,6 +188,13 @@ func handleSysSealStatusRaw(core *vault.Core, w http.ResponseWriter, r *http.Req
 	}
 
 	progress, nonce := core.SecretProgress()
+	// When the vault is unsealed, it makes more sense for progress to be
+	// set to the value of SecretThreshold as a value of 0 would imply a
+	// sealed state. Achieving this behaviour in SecretProgress() is quite
+	// a bit harder, so we are doing it here.
+	if !sealed {
+		progress = sealConfig.SecretThreshold
+	}
 
 	respondOk(w, &SealStatusResponse{
 		Sealed:      sealed,

--- a/http/sys_seal_test.go
+++ b/http/sys_seal_test.go
@@ -122,7 +122,7 @@ func TestSysUnseal(t *testing.T) {
 		}
 		if i == len(keys)-1 {
 			expected["sealed"] = false
-			expected["progress"] = json.Number("0")
+			expected["progress"] = json.Number("3")
 		}
 		testResponseStatus(t, resp, 200)
 		testResponseBody(t, resp, &actual)

--- a/website/source/api/system/unseal.html.md
+++ b/website/source/api/system/unseal.html.md
@@ -70,7 +70,7 @@ Sample response when Vault is unsealed.
   "sealed": false,
   "t": 3,
   "n": 5,
-  "progress": 0,
+  "progress": 3,
   "version": "0.6.2",
   "cluster_name": "vault-cluster-d6ec3c7f",
   "cluster_id": "3e8b3fec-3749-e056-ba41-b62a63b997e8"


### PR DESCRIPTION
* When a vault is unsealed, SealStatusResponse.Progress should
  reflect reaching the threshold instead of having a value of 0.
* A progress of 0 suggests a sealed state.

I get this is a bit of nitpicking, and that the authoritative indicator of "sealedness" is the `Sealed` flag. But the first time I read the [documentation on this](https://www.vaultproject.io/api/system/seal-status.html), I came away quite confused. So much that I went and read the code.