### PR TITLE
docs: quote dynamodb ha_enabled property

### DIFF
--- a/website/source/docs/configuration/storage/dynamodb.html.md
+++ b/website/source/docs/configuration/storage/dynamodb.html.md
@@ -24,7 +24,7 @@ The DynamoDB storage backend is used to persist Vault's data in
 
 ```hcl
 storage "dynamodb" {
-  ha_enabled = true
+  ha_enabled = "true"
   region     = "us-west-2"
   table      = "vault-data"
 }
@@ -115,7 +115,7 @@ This example show enabling high availability for the DynamoDB storage backend.
 
 ```hcl
 storage "dynamodb" {
-  ha_enabled    = true
+  ha_enabled    = "true"
   redirect_addr = "vault-leader.my-company.internal"
 }
 ```


### PR DESCRIPTION
With `ha_enabled = true` vault crashes with the following error: 

```
error parsing 'storage': storage.dynamodb: At 17:16: root.ha_enabled: unknown type for string *ast.LiteralType
```

This seems related to https://github.com/hashicorp/vault/issues/1559