### PR TITLE
Fix state change notification channels

### DIFF
--- a/physical/consul.go
+++ b/physical/consul.go
@@ -237,6 +237,8 @@ func newConsulBackend(conf map[string]string, logger log.Logger) (Backend, error
 		checkTimeout:        checkTimeout,
 		disableRegistration: disableRegistration,
 		consistencyMode:     consistencyMode,
+		notifyActiveCh:      make(chan notifyEvent),
+		notifySealedCh:      make(chan notifyEvent),
 	}
 	return c, nil
 }


### PR DESCRIPTION
Channels were not initialized correctly, so state change notification never got through (which was helpfully logged as a "Concurrent state change notify dropped" warning).

In my setup this fix decreases the time for Vault master change to propagate through Consul from 30-60 seconds to ~1 second.