### PR TITLE
Added "Domain" configuration parameter to Swift provider to enable V3 authentication

### DIFF
--- a/physical/swift.go
+++ b/physical/swift.go
@@ -58,18 +58,26 @@ func newSwiftBackend(conf map[string]string, logger log.Logger) (Backend, error)
 			return nil, fmt.Errorf("missing container")
 		}
 	}
-	tenant := os.Getenv("OS_TENANT_NAME")
-	if tenant == "" {
-		tenant = conf["tenant"]
+	project := os.Getenv("OS_PROJECT_NAME")
+	if project == "" {
+		project = conf["project"]
+
+		if project == "" {
+			// Check for KeyStone naming prior to V3
+			project := os.Getenv("OS_TENANT_NAME")
+			if project == "" {
+				project = conf["tenant"]
+			}
+		}
 	}
 
 	domain := os.Getenv("OS_USER_DOMAIN_NAME")
 	if domain == "" {
 		domain = conf["domain"]
 	}
-	tenantDomain := os.Getenv("OS_PROJECT_DOMAIN_NAME")
-	if tenantDomain == "" {
-		tenantDomain = conf["tenant-domain"]
+	projectDomain := os.Getenv("OS_PROJECT_DOMAIN_NAME")
+	if projectDomain == "" {
+		projectDomain = conf["project-domain"]
 	}
 
 	c := swift.Connection{
@@ -77,8 +85,8 @@ func newSwiftBackend(conf map[string]string, logger log.Logger) (Backend, error)
 		UserName:     username,
 		ApiKey:       password,
 		AuthUrl:      authUrl,
-		Tenant:       tenant,
-		TenantDomain: tenantDomain,
+		Tenant:       project,
+		TenantDomain: projectDomain,
 		Transport:    cleanhttp.DefaultPooledTransport(),
 	}
 

--- a/physical/swift.go
+++ b/physical/swift.go
@@ -63,12 +63,23 @@ func newSwiftBackend(conf map[string]string, logger log.Logger) (Backend, error)
 		tenant = conf["tenant"]
 	}
 
+	domain := os.Getenv("OS_USER_DOMAIN_NAME")
+	if domain == "" {
+		domain = conf["domain"]
+	}
+	tenantDomain := os.Getenv("OS_PROJECT_DOMAIN_NAME")
+	if tenantDomain == "" {
+		tenantDomain = conf["tenant-domain"]
+	}
+
 	c := swift.Connection{
-		UserName:  username,
-		ApiKey:    password,
-		AuthUrl:   authUrl,
-		Tenant:    tenant,
-		Transport: cleanhttp.DefaultPooledTransport(),
+		Domain:       domain,
+		UserName:     username,
+		ApiKey:       password,
+		AuthUrl:      authUrl,
+		Tenant:       tenant,
+		TenantDomain: tenantDomain,
+		Transport:    cleanhttp.DefaultPooledTransport(),
 	}
 
 	err := c.Authenticate()

--- a/physical/swift_test.go
+++ b/physical/swift_test.go
@@ -21,9 +21,9 @@ func TestSwiftBackend(t *testing.T) {
 	username := os.Getenv("OS_USERNAME")
 	password := os.Getenv("OS_PASSWORD")
 	authUrl := os.Getenv("OS_AUTH_URL")
-	tenant := os.Getenv("OS_TENANT_NAME")
+	project := os.Getenv("OS_PROJECT_NAME")
 	domain := os.Getenv("OS_USER_DOMAIN_NAME")
-	tenantDomain := os.Getenv("OS_PROJECT_DOMAIN_NAME")
+	projectDomain := os.Getenv("OS_PROJECT_DOMAIN_NAME")
 
 	ts := time.Now().UnixNano()
 	container := fmt.Sprintf("vault-test-%d", ts)
@@ -33,8 +33,8 @@ func TestSwiftBackend(t *testing.T) {
 		UserName:     username,
 		ApiKey:       password,
 		AuthUrl:      authUrl,
-		Tenant:       tenant,
-		TenantDomain: tenantDomain,
+		Tenant:       project,
+		TenantDomain: projectDomain,
 		Transport:    cleanhttp.DefaultPooledTransport(),
 	}
 
@@ -67,13 +67,13 @@ func TestSwiftBackend(t *testing.T) {
 	logger := logformat.NewVaultLogger(log.LevelTrace)
 
 	b, err := NewBackend("swift", logger, map[string]string{
-		"username":      username,
-		"password":      password,
-		"container":     container,
-		"auth_url":      authUrl,
-		"tenant":        tenant,
-		"domain":        domain,
-		"tenant-domain": tenantDomain,
+		"username":       username,
+		"password":       password,
+		"container":      container,
+		"auth_url":       authUrl,
+		"project":        project,
+		"domain":         domain,
+		"project-domain": projectDomain,
 	})
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/physical/swift_test.go
+++ b/physical/swift_test.go
@@ -22,16 +22,20 @@ func TestSwiftBackend(t *testing.T) {
 	password := os.Getenv("OS_PASSWORD")
 	authUrl := os.Getenv("OS_AUTH_URL")
 	tenant := os.Getenv("OS_TENANT_NAME")
+	domain := os.Getenv("OS_USER_DOMAIN_NAME")
+	tenantDomain := os.Getenv("OS_PROJECT_DOMAIN_NAME")
 
 	ts := time.Now().UnixNano()
 	container := fmt.Sprintf("vault-test-%d", ts)
 
 	cleaner := swift.Connection{
-		UserName:  username,
-		ApiKey:    password,
-		AuthUrl:   authUrl,
-		Tenant:    tenant,
-		Transport: cleanhttp.DefaultPooledTransport(),
+		Domain:       domain,
+		UserName:     username,
+		ApiKey:       password,
+		AuthUrl:      authUrl,
+		Tenant:       tenant,
+		TenantDomain: tenantDomain,
+		Transport:    cleanhttp.DefaultPooledTransport(),
 	}
 
 	err := cleaner.Authenticate()
@@ -63,11 +67,13 @@ func TestSwiftBackend(t *testing.T) {
 	logger := logformat.NewVaultLogger(log.LevelTrace)
 
 	b, err := NewBackend("swift", logger, map[string]string{
-		"username":  username,
-		"password":  password,
-		"container": container,
-		"auth_url":  authUrl,
-		"tenant":    tenant,
+		"username":      username,
+		"password":      password,
+		"container":     container,
+		"auth_url":      authUrl,
+		"tenant":        tenant,
+		"domain":        domain,
+		"tenant-domain": tenantDomain,
 	})
 	if err != nil {
 		t.Fatalf("err: %s", err)


### PR DESCRIPTION
This pull request adds the ability to pass in the Keystone user and project domains which is required by OpenStack environments configured with v3 auth.