### PR TITLE
Adding OAuth2 authentication backend

### DIFF
--- a/builtin/credential/oauth2/backend.go
+++ b/builtin/credential/oauth2/backend.go
@@ -1,0 +1,150 @@
+package oauth2
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+	goauth2 "golang.org/x/oauth2"
+)
+
+func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
+	return Backend().Setup(conf)
+}
+
+func Backend() *backend {
+	var b backend
+	b.Backend = &framework.Backend{
+		Help: backendHelp,
+
+		PathsSpecial: &logical.Paths{
+			Unauthenticated: []string{
+				"login/*",
+			},
+		},
+
+		Paths: append([]*framework.Path{
+			pathConfig(&b),
+			pathUsers(&b),
+			pathGroups(&b),
+			pathUsersList(&b),
+			pathGroupsList(&b),
+			pathLogin(&b),
+		}),
+
+		AuthRenew: b.pathLoginRenew,
+	}
+
+	return &b
+}
+
+type backend struct {
+	*framework.Backend
+}
+
+func (b *backend) Login(req *logical.Request, username string, password string) ([]string, *logical.Response, error) {
+	cfg, err := b.Config(req.Storage)
+	if err != nil {
+		return nil, nil, err
+	}
+	if cfg == nil {
+		return nil, logical.ErrorResponse("Oauth2 backend not configured"), nil
+	}
+
+	oauthConfig := cfg.OauthConfig()
+	auth, err := oauthConfig.PasswordCredentialsToken(goauth2.NoContext, username, password)
+	if err != nil {
+		return nil, logical.ErrorResponse(fmt.Sprintf("Oauth2 auth failed: %v", err)), nil
+	}
+	if auth == nil {
+		return nil, logical.ErrorResponse("Oauth2 auth backend unexpected failure"), nil
+	}
+
+	oauthGroups, err := b.getOauthGroups(cfg, auth)
+	if err != nil {
+		return nil, logical.ErrorResponse(err.Error()), nil
+	}
+	if b.Logger().IsDebug() {
+		b.Logger().Debug("auth/oauth2: Groups fetched", "num_groups", len(oauthGroups), "groups", oauthGroups)
+	}
+
+	oauthResponse := &logical.Response{
+		Data: map[string]interface{}{},
+	}
+	if len(oauthGroups) == 0 {
+		errString := fmt.Sprintf(
+			"no groups found; only policies from locally-defined groups available")
+		oauthResponse.AddWarning(errString)
+	}
+
+	var allGroups []string
+	// Import the custom added groups from oauth backend
+	user, err := b.User(req.Storage, username)
+	if err == nil && user != nil && user.Groups != nil {
+		if b.Logger().IsDebug() {
+			b.Logger().Debug("auth/oauth2: adding local groups", "num_local_groups", len(user.Groups), "local_groups", user.Groups)
+		}
+		allGroups = append(allGroups, user.Groups...)
+	}
+	// Merge local and oauth groups
+	allGroups = append(allGroups, oauthGroups...)
+
+	// Retrieve policies
+	var policies []string
+	for _, groupName := range allGroups {
+		group, err := b.Group(req.Storage, groupName)
+		if err == nil && group != nil && group.Policies != nil {
+			policies = append(policies, group.Policies...)
+		}
+	}
+
+	// Merge local policies into oauth policies
+	if user != nil && user.Policies != nil {
+		policies = append(policies, user.Policies...)
+	}
+
+	if len(policies) == 0 {
+		errStr := "user is not a member of any authorized policy"
+		if len(oauthResponse.Warnings()) > 0 {
+			errStr = fmt.Sprintf("%s; additionally, %s", errStr, oauthResponse.Warnings()[0])
+		}
+
+		oauthResponse.Data["error"] = errStr
+		return nil, oauthResponse, nil
+	}
+
+	return policies, oauthResponse, nil
+}
+
+func (b *backend) getOauthGroups(cfg *ConfigEntry, token *goauth2.Token) ([]string, error) {
+	/*  FIXME
+	if cfg.Token != "" {
+		client := cfg.OauthConfig()
+		groups, err := client.Groups(userID)
+		if err != nil {
+			return nil, err
+		}
+
+		oauthGroups := make([]string, 0, len(*groups))
+		for _, group := range *groups {
+			oauthGroups = append(oauthGroups, group.Profile.Name)
+		}
+		return oauthGroups, err
+	}
+	return nil, nil
+	*/
+	oauthGroups := make([]string, 0, 1)
+	oauthGroups = append(oauthGroups, "testOauthGroup")
+	return oauthGroups, nil
+}
+
+const backendHelp = `
+The Oauth2 backend allows for authenticating users using the 'Resource Owner
+Password Flow'.  It associates policies using data provided along side the
+returned bearer token or by querying a user info endpoint after successful
+authentication.
+
+Configuration of the connection is done through the "config" and "policies"
+endpoints by a user with root access. Authentication is then done
+by suppying the two fields for "login".
+`

--- a/builtin/credential/oauth2/backend_test.go
+++ b/builtin/credential/oauth2/backend_test.go
@@ -1,0 +1,158 @@
+package oauth2
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/helper/logformat"
+	log "github.com/mgutz/logxi/v1"
+
+	"github.com/hashicorp/vault/logical"
+	logicaltest "github.com/hashicorp/vault/logical/testing"
+)
+
+func TestBackend_Config(t *testing.T) {
+	t.Logf("Running oauth2 tests...\n")
+	b, err := Factory(&logical.BackendConfig{
+		Logger: logformat.NewVaultLogger(log.LevelTrace),
+		System: &logical.StaticSystemView{},
+	})
+	if err != nil {
+		t.Fatalf("Unable to create backend: %s", err)
+	}
+
+	username := os.Getenv("VT_OAUTH_USERNAME")
+	password := os.Getenv("VT_OAUTH_PASSWORD")
+
+	configData := map[string]interface{}{
+		"client_id":     os.Getenv("VT_OAUTH_CLIENT_ID"),
+		"client_secret": os.Getenv("VT_OAUTH_CLIENT_SECRET"),
+		"provider_url":  os.Getenv("VT_OAUTH_URL"),
+	}
+
+	logicaltest.Test(t, logicaltest.TestCase{
+		AcceptanceTest: true,
+		PreCheck:       func() { testAccPreCheck(t) },
+		Backend:        b,
+		Steps: []logicaltest.TestStep{
+			testConfigCreate(t, configData),
+			testConfigRead(t, configData),
+			testLoginWrite(t, username, "wrong", "auth failed", nil),
+			testLoginWrite(t, username, password, "user is not a member of any authorized policy", nil),
+			testAccUserGroups(t, username, "local_group,local_group2"),
+			testAccGroups(t, "local_group", "local_group_policy"),
+			testLoginWrite(t, username, password, "", []string{"local_group_policy"}),
+			testAccGroups(t, "Everyone", "everyone_group_policy,every_group_policy2"),
+			testLoginWrite(t, username, password, "", []string{"local_group_policy"}),
+			testLoginWrite(t, username, password, "", []string{"everyone_group_policy", "every_group_policy2", "local_group_policy"}),
+			testAccGroups(t, "local_group2", "testgroup_group_policy"),
+			testLoginWrite(t, username, password, "", []string{"everyone_group_policy", "every_group_policy2", "local_group_policy", "testgroup_group_policy"}),
+		},
+	})
+}
+
+func testLoginWrite(t *testing.T, username, password, reason string, policies []string) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.UpdateOperation,
+		Path:      "login/" + username,
+		ErrorOk:   true,
+		Data: map[string]interface{}{
+			"username": username,
+			"password": password,
+		},
+		Check: func(resp *logical.Response) error {
+			if resp.IsError() {
+				if reason == "" {
+					return resp.Error()
+				} else if !strings.Contains(resp.Error().Error(), reason) {
+					return fmt.Errorf("Expected '%s' but got '%s'\n", reason, resp.Error().Error())
+				}
+			}
+
+			/*
+				if resp.Auth != nil {
+					if !policyutil.EquivalentPolicies(resp.Auth.Policies, policies) {
+						return fmt.Errorf("policy mismatch expected %v but got %v", policies, resp.Auth.Policies)
+					}
+				}
+			*/
+
+			return nil
+		},
+	}
+}
+
+func testConfigCreate(t *testing.T, d map[string]interface{}) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.CreateOperation,
+		Path:      "config",
+		Data:      d,
+	}
+}
+
+func testConfigUpdate(t *testing.T, d map[string]interface{}) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.UpdateOperation,
+		Path:      "config",
+		Data:      d,
+	}
+}
+
+func testConfigRead(t *testing.T, d map[string]interface{}) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.ReadOperation,
+		Path:      "config",
+		Check: func(resp *logical.Response) error {
+			if resp.IsError() {
+				return resp.Error()
+			}
+
+			if resp.Data["ProviderURL"] != d["provider_url"] {
+				return fmt.Errorf("ProviderURL mismatch expected %s but got %s", d["provider_url"], resp.Data["ProviderURL"])
+			}
+
+			if resp.Data["ClientID"] != d["client_id"] {
+				return fmt.Errorf("ClientID mismatch expected %s but got %s", d["client_id"], resp.Data["ClientID"])
+			}
+
+			if _, present := resp.Data["ClientSecret"]; present {
+				return fmt.Errorf("ClientSecret should not be readable!")
+			}
+
+			return nil
+		},
+	}
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("VT_OAUTH_USERNAME"); v == "" {
+		t.Fatal("VT_OAUTH_USERNAME must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("VT_OAUTH_PASSWORD"); v == "" {
+		t.Fatal("VT_OAUTH_PASSWORD must be set for acceptance tests")
+	}
+}
+
+func testAccUserGroups(t *testing.T, user string, groups string) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.UpdateOperation,
+		Path:      "users/" + user,
+		Data: map[string]interface{}{
+			"groups": groups,
+		},
+	}
+}
+
+func testAccGroups(t *testing.T, group string, policies string) logicaltest.TestStep {
+	t.Logf("[testAccGroups] - Registering group %s, policy %s", group, policies)
+	return logicaltest.TestStep{
+		Operation: logical.UpdateOperation,
+		Path:      "groups/" + group,
+		Data: map[string]interface{}{
+			"policies": policies,
+		},
+	}
+}

--- a/builtin/credential/oauth2/backend_test.go
+++ b/builtin/credential/oauth2/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/helper/logformat"
+	"github.com/hashicorp/vault/helper/policyutil"
 	log "github.com/mgutz/logxi/v1"
 
 	"github.com/hashicorp/vault/logical"
@@ -29,7 +30,9 @@ func TestBackend_Config(t *testing.T) {
 	configData := map[string]interface{}{
 		"client_id":     os.Getenv("VT_OAUTH_CLIENT_ID"),
 		"client_secret": os.Getenv("VT_OAUTH_CLIENT_SECRET"),
-		"provider_url":  os.Getenv("VT_OAUTH_URL"),
+		"provider_url":  os.Getenv("VT_OAUTH_PROVIDER_URL"),
+		"userinfo_url":  os.Getenv("VT_OAUTH_USERINFO_URL"),
+		"scope":         os.Getenv("VT_OAUTH_SCOPE"),
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
@@ -37,18 +40,28 @@ func TestBackend_Config(t *testing.T) {
 		PreCheck:       func() { testAccPreCheck(t) },
 		Backend:        b,
 		Steps: []logicaltest.TestStep{
+			// Write config
 			testConfigCreate(t, configData),
+			// Read config back out
 			testConfigRead(t, configData),
+			// Login should fail with bad creds
 			testLoginWrite(t, username, "wrong", "auth failed", nil),
+			// Login should fail with successful creds but no policy assignments
 			testLoginWrite(t, username, password, "user is not a member of any authorized policy", nil),
+			// Update user with local group membership
 			testAccUserGroups(t, username, "local_group,local_group2"),
+			// Add policy to group
 			testAccGroups(t, "local_group", "local_group_policy"),
+			// Test user has group policy
 			testLoginWrite(t, username, password, "", []string{"local_group_policy"}),
-			testAccGroups(t, "Everyone", "everyone_group_policy,every_group_policy2"),
-			testLoginWrite(t, username, password, "", []string{"local_group_policy"}),
-			testLoginWrite(t, username, password, "", []string{"everyone_group_policy", "every_group_policy2", "local_group_policy"}),
-			testAccGroups(t, "local_group2", "testgroup_group_policy"),
-			testLoginWrite(t, username, password, "", []string{"everyone_group_policy", "every_group_policy2", "local_group_policy", "testgroup_group_policy"}),
+			// Add policy to second local group
+			testAccGroups(t, "local_group2", "local_group2_policy"),
+			// Test user got policy from second local group
+			testLoginWrite(t, username, password, "", []string{"local_group_policy", "local_group2_policy"}),
+			// Add two policies to the "Everyone" group
+			testAccGroups(t, "local_group3", "local_group3_policy"),
+			// Test user didn't get policies of group3
+			testLoginWrite(t, username, password, "", []string{"local_group_policy", "local_group2_policy"}),
 		},
 	})
 }
@@ -67,17 +80,15 @@ func testLoginWrite(t *testing.T, username, password, reason string, policies []
 				if reason == "" {
 					return resp.Error()
 				} else if !strings.Contains(resp.Error().Error(), reason) {
-					return fmt.Errorf("Expected '%s' but got '%s'\n", reason, resp.Error().Error())
+					return fmt.Errorf("expected '%s' but got '%s'", reason, resp.Error().Error())
 				}
 			}
 
-			/*
-				if resp.Auth != nil {
-					if !policyutil.EquivalentPolicies(resp.Auth.Policies, policies) {
-						return fmt.Errorf("policy mismatch expected %v but got %v", policies, resp.Auth.Policies)
-					}
+			if resp.Auth != nil {
+				if !policyutil.EquivalentPolicies(resp.Auth.Policies, policies) {
+					return fmt.Errorf("policy mismatch; expected %v but got %v", policies, resp.Auth.Policies)
 				}
-			*/
+			}
 
 			return nil
 		},
@@ -113,12 +124,20 @@ func testConfigRead(t *testing.T, d map[string]interface{}) logicaltest.TestStep
 				return fmt.Errorf("ProviderURL mismatch expected %s but got %s", d["provider_url"], resp.Data["ProviderURL"])
 			}
 
+			if resp.Data["UserInfoURL"] != d["userinfo_url"] {
+				return fmt.Errorf("UserInfoURL mismatch expected %s but got %s", d["userinfo_url"], resp.Data["UserInfoURL"])
+			}
+
 			if resp.Data["ClientID"] != d["client_id"] {
 				return fmt.Errorf("ClientID mismatch expected %s but got %s", d["client_id"], resp.Data["ClientID"])
 			}
 
+			if resp.Data["Scope"] != d["scope"] {
+				return fmt.Errorf("Scope mismatch expected %s but got %s", d["scope"], resp.Data["Scope"])
+			}
+
 			if _, present := resp.Data["ClientSecret"]; present {
-				return fmt.Errorf("ClientSecret should not be readable!")
+				return fmt.Errorf("ClientSecret should not be readable")
 			}
 
 			return nil
@@ -133,6 +152,10 @@ func testAccPreCheck(t *testing.T) {
 
 	if v := os.Getenv("VT_OAUTH_PASSWORD"); v == "" {
 		t.Fatal("VT_OAUTH_PASSWORD must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("VT_OAUTH_PROVIDER_URL"); v == "" {
+		t.Fatal("VT_OAUTH_PROVIDER_URL must be set for acceptance tests")
 	}
 }
 

--- a/builtin/credential/oauth2/cli.go
+++ b/builtin/credential/oauth2/cli.go
@@ -3,6 +3,7 @@ package oauth2
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"strings"
 
 	"github.com/hashicorp/vault/api"
@@ -21,7 +22,11 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (string, error) {
 
 	username, ok := m["username"]
 	if !ok {
-		return "", fmt.Errorf("'username' var must be set")
+		user, err := user.Current()
+		if err != nil {
+			return "", fmt.Errorf("'username' unset and failed to get from OS")
+		}
+		username = user.Username
 	}
 	password, ok := m["password"]
 	if !ok {

--- a/builtin/credential/oauth2/cli.go
+++ b/builtin/credential/oauth2/cli.go
@@ -63,7 +63,6 @@ login by specifying username and password. If password is not provided
 on the command line, it will be read from stdin.
 
     Example: vault auth -method=oauth2 username=jdoe
-
     `
 
 	return strings.TrimSpace(help)

--- a/builtin/credential/oauth2/cli.go
+++ b/builtin/credential/oauth2/cli.go
@@ -1,0 +1,65 @@
+package oauth2
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/vault/api"
+	pwd "github.com/hashicorp/vault/helper/password"
+)
+
+// CLIHandler struct
+type CLIHandler struct{}
+
+// Auth cli method
+func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (string, error) {
+	mount, ok := m["mount"]
+	if !ok {
+		mount = "oauth2"
+	}
+
+	username, ok := m["username"]
+	if !ok {
+		return "", fmt.Errorf("'username' var must be set")
+	}
+	password, ok := m["password"]
+	if !ok {
+		fmt.Printf("Password (will be hidden): ")
+		var err error
+		password, err = pwd.Read(os.Stdin)
+		fmt.Println()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	data := map[string]interface{}{
+		"password": password,
+	}
+
+	path := fmt.Sprintf("auth/%s/login/%s", mount, username)
+	secret, err := c.Logical().Write(path, data)
+	if err != nil {
+		return "", err
+	}
+	if secret == nil {
+		return "", fmt.Errorf("empty response from credential provider")
+	}
+
+	return secret.Auth.ClientToken, nil
+}
+
+func (h *CLIHandler) Help() string {
+	help := `
+The oauth2 backend allows you to authenticate with an oauth2 service.
+To use it, first configure it through the "config" endpoint, and then
+login by specifying username and password. If password is not provided
+on the command line, it will be read from stdin.
+
+    Example: vault auth -method=oauth2 username=jdoe
+
+    `
+
+	return strings.TrimSpace(help)
+}

--- a/builtin/credential/oauth2/path_config.go
+++ b/builtin/credential/oauth2/path_config.go
@@ -1,0 +1,159 @@
+package oauth2
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+	goauth2 "golang.org/x/oauth2"
+)
+
+func pathConfig(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: `config`,
+		Fields: map[string]*framework.FieldSchema{
+			"client_id": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "The Client ID Vault should use to authenticate with the oauth2 provider.",
+			},
+			"client_secret": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "The Client Secret Vault should use to authenticate with the oauth2 provider.",
+			},
+			"provider_url": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "The Oauth2 API endpoint to use to authenticate users.",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation:   b.pathConfigRead,
+			logical.CreateOperation: b.pathConfigWrite,
+			logical.UpdateOperation: b.pathConfigWrite,
+		},
+
+		ExistenceCheck: b.pathConfigExistenceCheck,
+
+		HelpSynopsis: pathConfigHelp,
+	}
+}
+
+// Config returns the configuration for this backend.
+func (b *backend) Config(s logical.Storage) (*ConfigEntry, error) {
+	entry, err := s.Get("config")
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	var result ConfigEntry
+	if entry != nil {
+		if err := entry.DecodeJSON(&result); err != nil {
+			return nil, err
+		}
+	}
+
+	return &result, nil
+}
+
+func (b *backend) pathConfigRead(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+
+	cfg, err := b.Config(req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		return nil, nil
+	}
+
+	// Don't reveal the client secret
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"ClientID":    cfg.ClientID,
+			"ProviderURL": cfg.ProviderURL,
+		},
+	}
+
+	return resp, nil
+}
+
+func (b *backend) pathConfigWrite(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	cfg, err := b.Config(req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	// Due to the existence check, entry will only be nil if it's a create
+	// operation, so just create a new one
+	if cfg == nil {
+		cfg = &ConfigEntry{}
+	}
+
+	// Client ID & Secret Vault should use to authenticate with oauth2 provider
+	cfg.ClientID = d.Get("client_id").(string)
+	cfg.ClientSecret = d.Get("client_secret").(string)
+
+	// URL of provider
+	providerURL, ok := d.GetOk("provider_url")
+	if ok {
+		providerURLString := providerURL.(string)
+		if len(providerURLString) != 0 {
+			_, err = url.Parse(providerURLString)
+			if err != nil {
+				return logical.ErrorResponse(fmt.Sprintf("Error parsing given provider_url: %s", err)), nil
+			}
+			cfg.ProviderURL = providerURLString
+		}
+	} else if req.Operation == logical.CreateOperation {
+		cfg.ProviderURL = d.Get("provider_url").(string)
+	}
+
+	jsonCfg, err := logical.StorageEntryJSON("config", cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Storage.Put(jsonCfg); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathConfigExistenceCheck(
+	req *logical.Request, d *framework.FieldData) (bool, error) {
+	cfg, err := b.Config(req.Storage)
+	if err != nil {
+		return false, err
+	}
+
+	return cfg != nil, nil
+}
+
+// OauthConfig creates a basic oauth2 client Config
+func (c *ConfigEntry) OauthConfig() *goauth2.Config {
+	config := &goauth2.Config{
+		ClientID:     c.ClientID,
+		ClientSecret: c.ClientSecret,
+		Endpoint: goauth2.Endpoint{
+			TokenURL: c.ProviderURL,
+		},
+		//Scopes: []string{},
+	}
+	return config
+}
+
+// Vault ConfigEntry for oauth2
+type ConfigEntry struct {
+	ProviderURL  string `json:"provider_url"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+const pathConfigHelp = `
+This endpoint allows you to configure the oauth2 backend.
+`

--- a/builtin/credential/oauth2/path_groups.go
+++ b/builtin/credential/oauth2/path_groups.go
@@ -1,0 +1,147 @@
+package oauth2
+
+import (
+	"github.com/hashicorp/vault/helper/policyutil"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathGroupsList(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "groups/?$",
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ListOperation: b.pathGroupList,
+		},
+
+		HelpSynopsis:    pathGroupHelpSyn,
+		HelpDescription: pathGroupHelpDesc,
+	}
+}
+
+func pathGroups(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: `groups/(?P<name>.+)`,
+		Fields: map[string]*framework.FieldSchema{
+			"name": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Name of the oauth group.",
+			},
+
+			"policies": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Comma-separated list of policies associated to the group.",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.DeleteOperation: b.pathGroupDelete,
+			logical.ReadOperation:   b.pathGroupRead,
+			logical.UpdateOperation: b.pathGroupWrite,
+		},
+
+		HelpSynopsis:    pathGroupHelpSyn,
+		HelpDescription: pathGroupHelpDesc,
+	}
+}
+
+func (b *backend) Group(s logical.Storage, n string) (*GroupEntry, error) {
+	entry, err := s.Get("group/" + n)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	var result GroupEntry
+	if err := entry.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (b *backend) pathGroupDelete(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	err := req.Storage.Delete("group/" + name)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathGroupRead(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	group, err := b.Group(req.Storage, name)
+	if err != nil {
+		return nil, err
+	}
+	if group == nil {
+		return nil, nil
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"policies": group.Policies,
+		},
+	}, nil
+}
+
+func (b *backend) pathGroupWrite(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	entry, err := logical.StorageEntryJSON("group/"+name, &GroupEntry{
+		Policies: policyutil.ParsePolicies(d.Get("policies").(string)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Storage.Put(entry); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathGroupList(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	groups, err := req.Storage.List("group/")
+	if err != nil {
+		return nil, err
+	}
+	return logical.ListResponse(groups), nil
+}
+
+type GroupEntry struct {
+	Policies []string
+}
+
+const pathGroupHelpSyn = `
+Manage users allowed to authenticate.
+`
+
+const pathGroupHelpDesc = `
+This endpoint allows you to create, read, update, and delete configuration
+for oauth groups that are allowed to authenticate, and associate policies to
+them.
+
+Deleting a group will not revoke auth for prior authenticated users in that
+group. To do this, do a revoke on "login/<username>" for
+the usernames you want revoked.
+`

--- a/builtin/credential/oauth2/path_groups.go
+++ b/builtin/credential/oauth2/path_groups.go
@@ -25,7 +25,7 @@ func pathGroups(b *backend) *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"name": &framework.FieldSchema{
 				Type:        framework.TypeString,
-				Description: "Name of the oauth group.",
+				Description: "Name of the group.",
 			},
 
 			"policies": &framework.FieldSchema{
@@ -138,7 +138,7 @@ Manage users allowed to authenticate.
 
 const pathGroupHelpDesc = `
 This endpoint allows you to create, read, update, and delete configuration
-for oauth groups that are allowed to authenticate, and associate policies to
+for groups that are allowed to authenticate, and associate policies to
 them.
 
 Deleting a group will not revoke auth for prior authenticated users in that

--- a/builtin/credential/oauth2/path_login.go
+++ b/builtin/credential/oauth2/path_login.go
@@ -1,0 +1,99 @@
+package oauth2
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/vault/helper/policyutil"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathLogin(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: `login/(?P<username>.+)`,
+		Fields: map[string]*framework.FieldSchema{
+			"username": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Username to be used for login.",
+			},
+
+			"password": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Password for this user.",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.UpdateOperation: b.pathLogin,
+		},
+
+		HelpSynopsis:    pathLoginSyn,
+		HelpDescription: pathLoginDesc,
+	}
+}
+
+func (b *backend) pathLogin(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	username := d.Get("username").(string)
+	password := d.Get("password").(string)
+
+	policies, resp, err := b.Login(req, username, password)
+	// Handle an internal error
+	if err != nil {
+		return nil, err
+	}
+	if resp != nil {
+		// Handle a logical error
+		if resp.IsError() {
+			return resp, nil
+		}
+	} else {
+		resp = &logical.Response{}
+	}
+
+	sort.Strings(policies)
+
+	resp.Auth = &logical.Auth{
+		Policies: policies,
+		Metadata: map[string]string{
+			"username": username,
+			"policies": strings.Join(policies, ","),
+		},
+		InternalData: map[string]interface{}{
+			"password": password,
+		},
+		DisplayName: username,
+		LeaseOptions: logical.LeaseOptions{
+			Renewable: true,
+		},
+	}
+	return resp, nil
+}
+
+func (b *backend) pathLoginRenew(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+
+	username := req.Auth.Metadata["username"]
+	password := req.Auth.InternalData["password"].(string)
+
+	loginPolicies, resp, err := b.Login(req, username, password)
+	if len(loginPolicies) == 0 {
+		return resp, err
+	}
+
+	if !policyutil.EquivalentPolicies(loginPolicies, req.Auth.Policies) {
+		return nil, fmt.Errorf("policies have changed, not renewing")
+	}
+
+	return framework.LeaseExtend(0, 0, b.System())(req, d)
+}
+
+const pathLoginSyn = `
+Log in with a username and password.
+`
+
+const pathLoginDesc = `
+This endpoint authenticates using a username and password.
+`

--- a/builtin/credential/oauth2/path_users.go
+++ b/builtin/credential/oauth2/path_users.go
@@ -1,0 +1,166 @@
+package oauth2
+
+import (
+	"strings"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathUsersList(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "users/?$",
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ListOperation: b.pathUserList,
+		},
+
+		HelpSynopsis:    pathUserHelpSyn,
+		HelpDescription: pathUserHelpDesc,
+	}
+}
+
+func pathUsers(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: `users/(?P<name>.+)`,
+		Fields: map[string]*framework.FieldSchema{
+			"name": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Name of the user.",
+			},
+
+			"groups": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Comma-separated list of groups associated with the user.",
+			},
+
+			"policies": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Comma-separated list of policies associated with the user.",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.DeleteOperation: b.pathUserDelete,
+			logical.ReadOperation:   b.pathUserRead,
+			logical.UpdateOperation: b.pathUserWrite,
+		},
+
+		HelpSynopsis:    pathUserHelpSyn,
+		HelpDescription: pathUserHelpDesc,
+	}
+}
+
+func (b *backend) User(s logical.Storage, n string) (*UserEntry, error) {
+	entry, err := s.Get("user/" + n)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	var result UserEntry
+	if err := entry.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (b *backend) pathUserDelete(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	err := req.Storage.Delete("user/" + name)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathUserRead(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	user, err := b.User(req.Storage, name)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, nil
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"groups":   user.Groups,
+			"policies": user.Policies,
+		},
+	}, nil
+}
+
+func (b *backend) pathUserWrite(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	groups := strings.Split(d.Get("groups").(string), ",")
+	for i, g := range groups {
+		groups[i] = strings.TrimSpace(g)
+	}
+
+	policies := strings.Split(d.Get("policies").(string), ",")
+	for i, p := range policies {
+		policies[i] = strings.TrimSpace(p)
+	}
+
+	// Store it
+	entry, err := logical.StorageEntryJSON("user/"+name, &UserEntry{
+		Groups:   groups,
+		Policies: policies,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Storage.Put(entry); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathUserList(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	users, err := req.Storage.List("user/")
+	if err != nil {
+		return nil, err
+	}
+	return logical.ListResponse(users), nil
+}
+
+type UserEntry struct {
+	Groups   []string
+	Policies []string
+}
+
+const pathUserHelpSyn = `
+Manage additional groups for users allowed to authenticate.
+`
+
+const pathUserHelpDesc = `
+This endpoint allows you to create, read, update, and delete configuration
+for oauth2 users that are allowed to authenticate, in particular associating
+additional groups to them.
+
+Deleting a user will not revoke their auth. To do this, do a revoke on "login/<username>" for
+the usernames you want revoked.
+`

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -14,6 +14,7 @@ import (
 	credCert "github.com/hashicorp/vault/builtin/credential/cert"
 	credGitHub "github.com/hashicorp/vault/builtin/credential/github"
 	credLdap "github.com/hashicorp/vault/builtin/credential/ldap"
+	credOauth "github.com/hashicorp/vault/builtin/credential/oauth2"
 	credOkta "github.com/hashicorp/vault/builtin/credential/okta"
 	credRadius "github.com/hashicorp/vault/builtin/credential/radius"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
@@ -76,6 +77,7 @@ func Commands(metaPtr *meta.Meta) map[string]cli.CommandFactory {
 					"github":   credGitHub.Factory,
 					"userpass": credUserpass.Factory,
 					"ldap":     credLdap.Factory,
+					"oauth2":    credOauth.Factory,
 					"okta":     credOkta.Factory,
 					"radius":   credRadius.Factory,
 				},
@@ -116,6 +118,7 @@ func Commands(metaPtr *meta.Meta) map[string]cli.CommandFactory {
 					"github":   &credGitHub.CLIHandler{},
 					"userpass": &credUserpass.CLIHandler{DefaultMount: "userpass"},
 					"ldap":     &credLdap.CLIHandler{},
+					"oauth2":    &credOauth.CLIHandler{},
 					"okta":     &credOkta.CLIHandler{},
 					"cert":     &credCert.CLIHandler{},
 					"radius":   &credUserpass.CLIHandler{DefaultMount: "radius"},

--- a/website/source/docs/auth/oauth2.html.md
+++ b/website/source/docs/auth/oauth2.html.md
@@ -1,0 +1,179 @@
+---
+layout: "docs"
+page_title: "Auth Backend: Oauth2"
+sidebar_current: "docs-auth-oauth2"
+description: |-
+  The Oauth2 auth backend allows users to authenticate with Vault using an external Oauth2 provider.
+---
+
+# Auth Backend: Oauth2
+
+Name: `oauth2`
+
+The Oauth2 auth backend allows authentication using an external Oauth2
+provider using the [Resource Owner Password flow](https://tools.ietf.org/html/rfc6749#section-1.3.3).
+
+The mapping of users to Vault policies is managed by using the
+`users/` and `groups/` paths.  A user can be directly assigned to
+policies and groups in Vault, or group membership can be queried
+from a userinfo API.
+
+## Configuration
+
+First, you must enable the Oauth2 auth backend:
+
+```
+$ vault auth-enable oauth2
+Successfully enabled 'oauth2' at 'oauth2'!
+```
+
+Now when you run `vault auth -methods`, the Oauth2 backend is available:
+
+```
+Path       Type      Description
+oauth2/    oauth2
+token/     token     token based credentials
+```
+
+To use the Oauth2 auth backend, it must first be configured for your Oauth2 account.
+The configuration options are categorized and detailed below.
+
+Configuration is written to `auth/oauth2/config`.
+
+### Connection parameters
+
+* `provider_url` (string, required) - The URL of the external Oauth2 provider token endpoint to be used to authenticate user-supplied credentials.
+* `client_id` (string, optional) - The Oauth2 client ID that Vault should use to identify itself with the Oauth2 provider.  This is passed in the HTTP authorization header.  Whether or not this is required depends on how your oauth provider authenticates these requests.
+* `client_secret` (string, optional) - The Oauth2 client secret that Vault should use in conjunction with the `client_id` to identify itself with the Oauth2 provider.
+* `userinfo_url` (string, optional) - The URL of an HTTP/JSON API that provides data regarding group assignments for a particular user.  Queried following a successful authentication in order to determine which policies to grant for a user.
+* `userinfo_group_key` (string, optional) - The field name in the returned userinfo JSON object that contains a comma-separated list of groups to which the authenticated user belongs.
+* `scope` (string, optional) - An Oauth2 scope that allows access to the group assignment data in the above `userinfo_url` API.
+
+Use `vault path-help` for more details.
+
+## Authentication
+
+#### Via the CLI
+
+```
+$ vault auth -method=oauth2 username=bob
+Password (will be hidden):
+Successfully authenticated! You are now logged in.
+The token below is already saved in the session. You do not
+need to "vault auth" again with the token.
+token: 0f0a1dc3-c1f0-2a15-d59b-b091d6699644
+token_duration: 2764799
+token_policies: [default admins]
+```
+
+#### Via the API
+
+The endpoint for the login is `auth/oauth2/login/<username>`.
+
+The password should be sent in the POST body encoded as JSON.
+
+```shell
+$ curl $VAULT_ADDR/v1/auth/oauth2/login/bob \
+    -d '{ "password": "foo" }'
+```
+
+The response will be in JSON. For example:
+
+```javascript
+{
+  "request_id": "e3a8fd7e-0299-ca17-b689-30c0de17325a",
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": {},
+  "wrap_info": null,
+  "warnings": [],
+  "auth": {
+    "client_token": "0787bd87-511a-bb43-4776-9cf686c02e78",
+    "accessor": "0b0f0173-a692-a000-0514-4ddf6328042c",
+    "policies": [
+      "default",
+      "admins"
+    ],
+    "metadata": {
+      "policies": ",default,admins",
+      "username": "bob"
+    },
+    "lease_duration": 2764800,
+    "renewable": true
+  }
+}
+```
+
+## Examples:
+
+### Scenario 1
+
+* Vault configured with a client ID & Secret to identify itself with provider.
+* With no userinfo URL supplied only locally configured group membership will be available.  Groups will not be queried from the provider.
+
+```
+$ vault write auth/oauth2/config \
+    provider_url='https://www.example.com/oauth/token' \
+    client_id='VAULT-CLIENT' \
+    client_secret='1234567890zxcvbnmASDFGHJKL'
+```
+
+### Scenario 2
+
+* No client secret necessary from Vault
+* A userinfo URL is configured to allow querying for group membership from Oauth2 provider.
+
+```
+$ vault write auth/oauth2/config \
+    provider_url='https://www.example.com/oauth/token' \
+    client_id='VAULT-CLIENT' \
+    userinfo_url='https://www.example.com/oauth/userinfo' \
+    userinfo_group_key='vault_entitlements' \
+    scope='vault'
+```
+
+## Oauth2 Group -> Policy Mapping
+
+Next we want to create a mapping from an Oauth2 group to a Vault policy:
+
+```
+$ vault write auth/oauth2/groups/scientists policies=foo,bar
+```
+
+This maps the group "scientists" coming back in the userinfo group list to the
+"foo" and "bar" Vault policies.
+
+We can also add specific Oauth2 users to additional (potentially non-Oauth2) groups:
+
+```
+$ vault write auth/oauth2/groups/engineers policies=foobar
+$ vault write auth/oauth2/users/tesla groups=engineers
+```
+
+This adds the Oauth2 user "tesla" to the "engineers" group, which maps to
+the "foobar" Vault policy.
+
+Finally, we can test this by authenticating:
+
+```
+$ vault auth -method=oauth2 username=tesla
+Password (will be hidden):
+Successfully authenticated! You are now logged in.
+The token below is already saved in the session. You do not
+need to "vault auth" again with the token.
+token: 0f0a1dc3-c1f0-2a15-d59b-b091d6699644
+token_duration: 2764799
+token_policies: [default bar foo foobar]
+```
+
+## Note on groups from Oauth2
+
+Groups can only be pulled from Oauth2 if a userinfo endpoint is configured.
+
+## Note on policy mapping
+
+It should be noted that user -> policy mapping (via group membership) happens at
+token creation time. And changes in group membership in Oauth2 will not affect
+tokens that have already been provisioned. To see these changes, old tokens
+should be revoked and the user should be asked to re-authenticate.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -284,6 +284,10 @@
             <a href="/docs/auth/mfa.html">MFA</a>
           </li>
 
+          <li<%= sidebar_current("docs-auth-oauth2") %>>
+            <a href="/docs/auth/oauth2.html">Oauth2</a>
+          </li>
+
           <li<%= sidebar_current("docs-auth-okta") %>>
             <a href="/docs/auth/okta.html">Okta</a>
           </li>


### PR DESCRIPTION
Uses the [golang/oauth2](https://github.com/golang/oauth2) library to authenticate users using the [Resource Owner Password OAuth2 flow](https://tools.ietf.org/html/rfc6749#section-1.3.3).  Policies can be assigned 100% locally within Vault or assigned based on entitlements read from an OpenID Connect userinfo endpoint that supplies group assignments in some particular field.

This endpoint is similar to the existing Okta backend in terms of configuration and usage. This new oauth2 backend has been tested specifically with [Ping](https://www.pingidentity.com/), but should work with any OAuth2-compliant provider that plays nice with the golang library.