### PR TITLE
Respect the configured address's path in the client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"path"
 
 	"golang.org/x/net/http2"
 
@@ -336,7 +337,7 @@ func (c *Client) NewRequest(method, path string) *Request {
 			User:   c.addr.User,
 			Scheme: c.addr.Scheme,
 			Host:   c.addr.Host,
-			Path:   strings.TrimSuffix(c.addr.Path, "/") + path,
+			Path:   path.Join(c.addr.Path, path),
 		},
 		ClientToken: c.token,
 		Params:      make(map[string][]string),

--- a/api/client.go
+++ b/api/client.go
@@ -330,14 +330,14 @@ func (c *Client) ClearToken() {
 // NewRequest creates a new raw request object to query the Vault server
 // configured for this client. This is an advanced method and generally
 // doesn't need to be called externally.
-func (c *Client) NewRequest(method, path string) *Request {
+func (c *Client) NewRequest(method, requestPath string) *Request {
 	req := &Request{
 		Method: method,
 		URL: &url.URL{
 			User:   c.addr.User,
 			Scheme: c.addr.Scheme,
 			Host:   c.addr.Host,
-			Path:   path.Join(c.addr.Path, path),
+			Path:   path.Join(c.addr.Path, requestPath),
 		},
 		ClientToken: c.token,
 		Params:      make(map[string][]string),
@@ -345,12 +345,12 @@ func (c *Client) NewRequest(method, path string) *Request {
 
 	var lookupPath string
 	switch {
-	case strings.HasPrefix(path, "/v1/"):
-		lookupPath = strings.TrimPrefix(path, "/v1/")
-	case strings.HasPrefix(path, "v1/"):
-		lookupPath = strings.TrimPrefix(path, "v1/")
+	case strings.HasPrefix(requestPath, "/v1/"):
+		lookupPath = strings.TrimPrefix(requestPath, "/v1/")
+	case strings.HasPrefix(requestPath, "v1/"):
+		lookupPath = strings.TrimPrefix(requestPath, "v1/")
 	default:
-		lookupPath = path
+		lookupPath = requestPath
 	}
 	if c.wrappingLookupFunc != nil {
 		req.WrapTTL = c.wrappingLookupFunc(method, lookupPath)

--- a/api/client.go
+++ b/api/client.go
@@ -336,7 +336,7 @@ func (c *Client) NewRequest(method, path string) *Request {
 			User:   c.addr.User,
 			Scheme: c.addr.Scheme,
 			Host:   c.addr.Host,
-			Path:   path,
+      Path:   strings.TrimSuffix(c.addr.Path, "/") + path,
 		},
 		ClientToken: c.token,
 		Params:      make(map[string][]string),

--- a/api/client.go
+++ b/api/client.go
@@ -336,7 +336,7 @@ func (c *Client) NewRequest(method, path string) *Request {
 			User:   c.addr.User,
 			Scheme: c.addr.Scheme,
 			Host:   c.addr.Host,
-      Path:   strings.TrimSuffix(c.addr.Path, "/") + path,
+			Path:   strings.TrimSuffix(c.addr.Path, "/") + path,
 		},
 		ClientToken: c.token,
 		Params:      make(map[string][]string),


### PR DESCRIPTION
This is necessary if you have vault sitting behind a reverse-proxy like
nginx under a context path and you need to talk to vault at:
https://hostname.com/vault