### PR TITLE
Add -self flag to token-revoke

### DIFF
--- a/command/token_revoke.go
+++ b/command/token_revoke.go
@@ -15,8 +15,11 @@ type TokenRevokeCommand struct {
 func (c *TokenRevokeCommand) Run(args []string) int {
 	var mode string
 	var accessor bool
+	var self bool
+	var token string
 	flags := c.Meta.FlagSet("token-revoke", meta.FlagSetDefault)
 	flags.BoolVar(&accessor, "accessor", false, "")
+	flags.BoolVar(&self, "self", false, "")
 	flags.StringVar(&mode, "mode", "", "")
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := flags.Parse(args); err != nil {
@@ -24,14 +27,20 @@ func (c *TokenRevokeCommand) Run(args []string) int {
 	}
 
 	args = flags.Args()
-	if len(args) != 1 {
+	switch {
+	case len(args) == 1 && !self:
+		token = args[0]
+	case len(args) != 0 && self:
 		flags.Usage()
 		c.Ui.Error(fmt.Sprintf(
-			"\ntoken-revoke expects one argument"))
+			"\ntoken-revoke expects no arguments when revoking self"))
+		return 1
+	case len(args) != 1 && !self:
+		flags.Usage()
+		c.Ui.Error(fmt.Sprintf(
+			"\ntoken-revoke expects one argument or the 'self' flag"))
 		return 1
 	}
-
-	token := args[0]
 
 	client, err := c.Client()
 	if err != nil {
@@ -43,14 +52,22 @@ func (c *TokenRevokeCommand) Run(args []string) int {
 	var fn func(string) error
 	// Handle all 6 possible combinations
 	switch {
-	case !accessor && mode == "":
+	case !accessor && self && mode == "":
+		fn = client.Auth().Token().RevokeSelf
+	case !accessor && !self && mode == "":
 		fn = client.Auth().Token().RevokeTree
-	case !accessor && mode == "orphan":
+	case !accessor && !self && mode == "orphan":
 		fn = client.Auth().Token().RevokeOrphan
-	case !accessor && mode == "path":
+	case !accessor && !self && mode == "path":
 		fn = client.Sys().RevokePrefix
-	case accessor && mode == "":
+	case accessor && !self && mode == "":
 		fn = client.Auth().Token().RevokeAccessor
+	case accessor && self:
+		c.Ui.Error("token-revoke cannot be run on self when 'accessor' flag is set")
+		return 1
+	case self && mode != "":
+		c.Ui.Error("token-revoke cannot be run on self when 'mode' flag is set")
+		return 1
 	case accessor && mode == "orphan":
 		c.Ui.Error("token-revoke cannot be run for 'orphan' mode when 'accessor' flag is set")
 		return 1
@@ -110,6 +127,8 @@ Token Options:
                           via '/auth/token/lookup-accessor/<accessor>' endpoint.
                           Accessor is used when there is no access to token ID.
 
+  -self                   A boolean flag, if set, the operation is performed on the currently
+                          authenticated token i.e. lookup-self.
 
   -mode=value             The type of revocation to do. See the documentation
                           above for more information.


### PR DESCRIPTION
Fixes #2493.

Adds a `-self` flag to token-revoke.