### PR TITLE
Rename ParseDedupAndSortStrings to ParseDedupLowercaseAndSortStrings

### DIFF
--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -1895,7 +1895,7 @@ func (b *backend) handleRoleSecretIDCommon(req *logical.Request, data *framework
 	}
 
 	// Parse the CIDR blocks into a slice
-	secretIDCIDRs := strutil.ParseDedupAndSortStrings(cidrList, ",")
+	secretIDCIDRs := strutil.ParseDedupLowercaseAndSortStrings(cidrList, ",")
 
 	// Ensure that the CIDRs on the secret ID are a subset of that of role's
 	if err := verifyCIDRRoleSecretIDSubset(secretIDCIDRs, role.BoundCIDRList); err != nil {

--- a/builtin/credential/approle/validation.go
+++ b/builtin/credential/approle/validation.go
@@ -273,7 +273,7 @@ func (b *backend) validateBindSecretID(req *logical.Request, roleName, secretID,
 func verifyCIDRRoleSecretIDSubset(secretIDCIDRs []string, roleBoundCIDRList string) error {
 	if len(secretIDCIDRs) != 0 {
 		// Parse the CIDRs on role as a slice
-		roleCIDRs := strutil.ParseDedupAndSortStrings(roleBoundCIDRList, ",")
+		roleCIDRs := strutil.ParseDedupLowercaseAndSortStrings(roleBoundCIDRList, ",")
 
 		// If there are no CIDR blocks on the role, then the subset
 		// requirement would be satisfied

--- a/builtin/credential/ldap/path_users.go
+++ b/builtin/credential/ldap/path_users.go
@@ -101,7 +101,7 @@ func (b *backend) pathUserRead(
 func (b *backend) pathUserWrite(
 	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
-	groups := strutil.ParseDedupAndSortStrings(d.Get("groups").(string), ",")
+	groups := strutil.ParseDedupLowercaseAndSortStrings(d.Get("groups").(string), ",")
 	policies := policyutil.ParsePolicies(d.Get("policies").(string))
 	for i, g := range groups {
 		groups[i] = strings.TrimSpace(g)

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1471,7 +1471,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 			}
 			cert := parsedCertBundle.Certificate
 
-			expected := strutil.ParseDedupAndSortStrings(role.OU, ",")
+			expected := strutil.ParseDedupLowercaseAndSortStrings(role.OU, ",")
 			if !reflect.DeepEqual(cert.Subject.OrganizationalUnit, expected) {
 				return fmt.Errorf("Error: returned certificate has OU of %s but %s was specified in the role.", cert.Subject.OrganizationalUnit, expected)
 			}
@@ -1492,7 +1492,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 			}
 			cert := parsedCertBundle.Certificate
 
-			expected := strutil.ParseDedupAndSortStrings(role.Organization, ",")
+			expected := strutil.ParseDedupLowercaseAndSortStrings(role.Organization, ",")
 			if !reflect.DeepEqual(cert.Subject.Organization, expected) {
 				return fmt.Errorf("Error: returned certificate has Organization of %s but %s was specified in the role.", cert.Subject.Organization, expected)
 			}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -597,7 +597,7 @@ func generateCreationBundle(b *backend,
 		if csr == nil || !role.UseCSRSANs {
 			cnAltRaw, ok := data.GetOk("alt_names")
 			if ok {
-				cnAlt := strutil.ParseDedupAndSortStrings(cnAltRaw.(string), ",")
+				cnAlt := strutil.ParseDedupLowercaseAndSortStrings(cnAltRaw.(string), ",")
 				for _, v := range cnAlt {
 					if strings.Contains(v, "@") {
 						emailAddresses = append(emailAddresses, v)

--- a/helper/cidrutil/cidr.go
+++ b/helper/cidrutil/cidr.go
@@ -52,7 +52,7 @@ func IPBelongsToCIDRBlocksString(ipAddr string, cidrList, separator string) (boo
 		return false, fmt.Errorf("invalid IP address")
 	}
 
-	return IPBelongsToCIDRBlocksSlice(ipAddr, strutil.ParseDedupAndSortStrings(cidrList, separator))
+	return IPBelongsToCIDRBlocksSlice(ipAddr, strutil.ParseDedupLowercaseAndSortStrings(cidrList, separator))
 }
 
 // IPBelongsToCIDRBlocksSlice checks if the given IP is encompassed by any of the given
@@ -95,7 +95,7 @@ func ValidateCIDRListString(cidrList string, separator string) (bool, error) {
 		return false, fmt.Errorf("missing separator")
 	}
 
-	return ValidateCIDRListSlice(strutil.ParseDedupAndSortStrings(cidrList, separator))
+	return ValidateCIDRListSlice(strutil.ParseDedupLowercaseAndSortStrings(cidrList, separator))
 }
 
 // ValidateCIDRListSlice checks if the given list of CIDR blocks are valid

--- a/helper/strutil/strutil.go
+++ b/helper/strutil/strutil.go
@@ -32,7 +32,7 @@ func StrListSubset(super, sub []string) bool {
 // Parses a comma separated list of strings into a slice of strings.
 // The return slice will be sorted and will not contain duplicate or
 // empty items. The values will be converted to lower case.
-func ParseDedupAndSortStrings(input string, sep string) []string {
+func ParseDedupLowercaseAndSortStrings(input string, sep string) []string {
 	input = strings.TrimSpace(input)
 	parsed := []string{}
 	if input == "" {
@@ -49,7 +49,7 @@ func ParseKeyValues(input string, out map[string]string, sep string) error {
 		return fmt.Errorf("'out is nil")
 	}
 
-	keyValues := ParseDedupAndSortStrings(input, sep)
+	keyValues := ParseDedupLowercaseAndSortStrings(input, sep)
 	if len(keyValues) == 0 {
 		return nil
 	}

--- a/physical/consul.go
+++ b/physical/consul.go
@@ -233,7 +233,7 @@ func newConsulBackend(conf map[string]string, logger log.Logger) (Backend, error
 		kv:                  client.KV(),
 		permitPool:          NewPermitPool(maxParInt),
 		serviceName:         service,
-		serviceTags:         strutil.ParseDedupAndSortStrings(tags, ","),
+		serviceTags:         strutil.ParseDedupLowercaseAndSortStrings(tags, ","),
 		checkTimeout:        checkTimeout,
 		disableRegistration: disableRegistration,
 		consistencyMode:     consistencyMode,

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -2202,9 +2202,9 @@ func (ts *TokenStore) tokenStoreRoleCreateUpdate(
 
 	disallowedPoliciesStr, ok := data.GetOk("disallowed_policies")
 	if ok {
-		entry.DisallowedPolicies = strutil.ParseDedupAndSortStrings(disallowedPoliciesStr.(string), ",")
+		entry.DisallowedPolicies = strutil.ParseDedupLowercaseAndSortStrings(disallowedPoliciesStr.(string), ",")
 	} else if req.Operation == logical.CreateOperation {
-		entry.DisallowedPolicies = strutil.ParseDedupAndSortStrings(data.Get("disallowed_policies").(string), ",")
+		entry.DisallowedPolicies = strutil.ParseDedupLowercaseAndSortStrings(data.Get("disallowed_policies").(string), ",")
 	}
 
 	// Store it


### PR DESCRIPTION
Make the function name more explicit to prevent confusion on what this method does.