### PR TITLE
Updating revoke/renew to prefer PUT payload

### DIFF
--- a/website/source/api/system/renew.html.md
+++ b/website/source/api/system/renew.html.md
@@ -16,7 +16,7 @@ This endpoint renews a secret, requesting to extend the lease.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `PUT`    | `/sys/renew/(:lease_id)`     | `200 application/json` |
+| `PUT`    | `/sys/renew`                 | `200 application/json` |
 
 ### Parameters
 
@@ -30,22 +30,12 @@ This endpoint renews a secret, requesting to extend the lease.
 
 ```json
 {
-  "lease_id": "postgresql/creds/readonly/abcd-1234...",
+  "lease_id": "aws/creds/deploy/abcd-1234...",
   "increment": 1800
 }
 ```
 
 ### Sample Request
-
-With the `lease_id` as part of the URL:
-
-```
-$ curl \
-    --header "X-Vault-Token: ..." \
-    --request PUT \
-    --data @payload.json \
-    https://vault.rocks/v1/sys/renew/postgresql/creds/readonly/abcd-1234
-```
 
 With the `lease_id` in the request body:
 
@@ -61,7 +51,7 @@ $ curl \
 
 ```json
 {
-  "lease_id": "aws/creds/deploy/e31b1145-ff27-e62c-cba2-934e9f0d1dbc",
+  "lease_id": "aws/creds/deploy/abcd-1234...",
   "renewable": true,
   "lease_duration": 2764790
 }

--- a/website/source/api/system/revoke.html.md
+++ b/website/source/api/system/revoke.html.md
@@ -16,11 +16,19 @@ This endpoint revokes a secret immediately.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `PUT`    | `/sys/revoke/:lease_id`      | `204 (empty body)`     |
+| `PUT`    | `/sys/revoke`                | `204 (empty body)`     |
 
 ### Parameters
 
 - `lease_id` `(string: <required>)` – Specifies the ID of the lease to revoke.
+
+### Sample Payload
+
+```json
+{
+  "lease_id": "postgresql/creds/readonly/abcd-1234..."
+}
+```
 
 ### Sample Request
 
@@ -28,5 +36,6 @@ This endpoint revokes a secret immediately.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request PUT \
-    https://vault.rocks/v1/sys/revoke/aws/creds/readonly-acbd1234
+    --data @payload.json \
+    https://vault.rocks/v1/sys/revoke
 ```


### PR DESCRIPTION
Updating revoke/renew to still support URLs for revoking and renewing leases but preferring to receive lease_id in the PUT payloads.  I updated the documentation to only show the preferred method but backwards compatibility will be maintained.