### PR TITLE
Add UI docs

### DIFF
--- a/website/source/docs/configuration/index.html.md
+++ b/website/source/docs/configuration/index.html.md
@@ -74,7 +74,7 @@ to specify where the configuration is.
 
     Disabling `mlock` is not recommended unless the systems running Vault only
     use encrypted swap or do not use swap at all. Vault only supports memory
-    locking on UNIX-like systems that support the mlock() syscall (Linux, FreeBSD, etc). 
+    locking on UNIX-like systems that support the mlock() syscall (Linux, FreeBSD, etc).
     Non UNIX-like systems (e.g. Windows, NaCL, Android) lack the primitives to keep a
     process's entire memory address space from spilling to disk and is therefore
     automatically disabled on unsupported platforms.
@@ -99,6 +99,7 @@ to specify where the configuration is.
 
 - `ui` `(bool: false, Enterprise-only)` – Enables the built-in web UI. Once
   enabled, the UI will be available to browsers at the standard Vault address.
+  This UI will be available on all listeners (address + port) at the `/ui` path.
   This can also be provided via the environment variable `VAULT_UI`.
 
 [storage-backend]: /docs/configuration/storage/index.html

--- a/website/source/docs/configuration/index.html.md
+++ b/website/source/docs/configuration/index.html.md
@@ -97,10 +97,10 @@ to specify where the configuration is.
   duration for tokens and secrets. This is specified using a label
   suffix like `"30s"` or `"1h"`.
 
-- `ui` `(bool: false, Enterprise-only)` – Enables the built-in web UI. Once
-  enabled, the UI will be available to browsers at the standard Vault address.
-  This UI will be available on all listeners (address + port) at the `/ui` path.
-  This can also be provided via the environment variable `VAULT_UI`.
+- `ui` `(bool: false, Enterprise-only)` – Enables the built-in web UI, which is
+  available on all listeners (address + port) at the `/ui` path. Browsers accessing
+  the standard Vault API address will automatically redirect there. This can also
+  be provided via the environment variable `VAULT_UI`.
 
 [storage-backend]: /docs/configuration/storage/index.html
 [listener]: /docs/configuration/listener/index.html

--- a/website/source/docs/vault-enterprise/ui/index.html.md
+++ b/website/source/docs/vault-enterprise/ui/index.html.md
@@ -1,0 +1,78 @@
+---
+layout: "docs"
+page_title: "Vault Enterprise UI"
+sidebar_current: "docs-vault-enterprise-ui"
+description: |-
+  Vault Enterprise features a user interface for interacting with Vault. Easily
+  create, read, update, and delete secrets, authenticate, unseal, and more with
+  the Vault Enterprise UI.
+---
+
+# Vault UI
+
+Vault Enterprise features a user interface for interacting with Vault. Easily
+create, read, update, and delete secrets, authenticate, unseal, and more with
+the Vault Enterprise UI.
+
+To use the UI, you must have an active or trial Vault Enterprise or Vault Pro
+trial. To start a trial, contact [HashiCorp sales](mailto:sales@hashicorp.com).
+
+## Activating the Vault UI
+
+The Vault Enterprise UI is not activated by default. To activate the UI, set the
+`ui` configuration option in the Vault server configuration. Vault clients do
+not need to set this option, since they will not be serving the UI.
+
+```hcl
+ui = true
+
+listener "tcp" {
+  address = "10.0.1.35:8200"
+}
+
+storage "consul" {
+  # ...
+}
+```
+
+For more information, please see the
+[Vault configuration options](/docs/configuration/index.html).
+
+## Accessing the Vault UI
+
+The UI runs on the same port as the Vault listener. As such, you must configure
+at least one `listener` stanza in order to access the UI.
+
+```hcl
+listener "tcp" {
+  address = "10.0.1.35:8200"
+
+  # If bound to localhost, the Vault UI is only
+  # accessible from the local machine!
+  # address = "127.0.0.1:8200"
+}
+```
+
+In this case, the UI is accessible the following URL from any machine on the
+subnet (provided no network firewalls are in place):
+
+```text
+https://10.0.1.35:8200/ui
+```
+
+It is also accessible at any DNS entry that resolves to that IP address, such as
+the Consul service address (if using Consul):
+
+```text
+https://vault.service.consul:8200/ui
+```
+
+### Note on TLS
+
+When using TLS (recommended), the certificate must be valid for all DNS entries
+you will be accessing the Vault UI on, and any IP addresses on the SAN. If you
+are running Vault with a self-signed certificate, any browsers that access the
+Vault UI will need to have the root CA installed. Failure to do so may result in
+the browser displaying a warning that the site is "untrusted". It is highly
+recommended that client browsers accessing the Vault UI install the proper CA
+root for validation to reduce the chance of a MITM attack.

--- a/website/source/docs/vault-enterprise/ui/index.html.md
+++ b/website/source/docs/vault-enterprise/ui/index.html.md
@@ -14,7 +14,7 @@ Vault Enterprise features a user interface for interacting with Vault. Easily
 create, read, update, and delete secrets, authenticate, unseal, and more with
 the Vault Enterprise UI.
 
-To use the UI, you must have an active or trial license for  Vault Enterprise or
+To use the UI, you must have an active or trial license for Vault Enterprise or
 Vault Pro. To start a trial, contact [HashiCorp sales](mailto:sales@hashicorp.com).
 
 ## Activating the Vault UI

--- a/website/source/docs/vault-enterprise/ui/index.html.md
+++ b/website/source/docs/vault-enterprise/ui/index.html.md
@@ -14,8 +14,8 @@ Vault Enterprise features a user interface for interacting with Vault. Easily
 create, read, update, and delete secrets, authenticate, unseal, and more with
 the Vault Enterprise UI.
 
-To use the UI, you must have an active or trial Vault Enterprise or Vault Pro
-trial. To start a trial, contact [HashiCorp sales](mailto:sales@hashicorp.com).
+To use the UI, you must have an active or trial license for  Vault Enterprise or
+Vault Pro. To start a trial, contact [HashiCorp sales](mailto:sales@hashicorp.com).
 
 ## Activating the Vault UI
 

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -356,6 +356,9 @@
               </li>
             </ul>
           </li>
+          <li<%= sidebar_current("docs-vault-enterprise-ui") %>>
+            <a href="/docs/vault-enterprise/ui/index.html">UI (Web Interface)</a>
+          </li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
This commit adds a section about the Vault Enterprise UI setup and access.

I couldn't figure out what port the UI ran on, until I realized that it didn't by searching the source. I think adding a UI section to the docs is a good idea, and it gives us a path to add more documentation about the UI (including screenshots) in the future. I tried to keep this as minimal but informative as possible. Please check for correctness.