### PR TITLE
audit: hash time.Time values in map fields

### DIFF
--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -1,8 +1,10 @@
 package audit
 
 import (
+	"errors"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/vault/helper/salt"
 	"github.com/hashicorp/vault/helper/wrapping"
@@ -141,6 +143,12 @@ type hashWalker struct {
 	unknownKeys []string
 }
 
+// hashTimeType stores a pre-computed reflect.Type for a time.Time so
+// we can quickly compare in hashWalker.Struct. We create an empty/invalid
+// time.Time{} so we don't need to incur any additional startup cost vs.
+// Now() or Unix().
+var hashTimeType = reflect.TypeOf(time.Time{})
+
 func (w *hashWalker) Enter(loc reflectwalk.Location) error {
 	w.loc = loc
 	return nil
@@ -185,6 +193,41 @@ func (w *hashWalker) Slice(s reflect.Value) error {
 func (w *hashWalker) SliceElem(i int, elem reflect.Value) error {
 	w.csKey = append(w.csKey, reflect.ValueOf(i))
 	w.sliceIndex = i
+	return nil
+}
+
+func (w *hashWalker) Struct(v reflect.Value) error {
+	// We are looking for time values. If it isn't one, ignore it.
+	if v.Type() != hashTimeType {
+		return nil
+	}
+
+	// If we aren't in a map value, return an error to prevent a panic
+	if v.Interface() != w.lastValue.Interface() {
+		return errors.New("time.Time value in a non map key cannot be hashed for audits")
+	}
+
+	// Override location to be a MapValue. loc is set to None since we
+	// already "entered" the struct. We could do better here by keeping
+	// a stack of locations and checking the last entry.
+	w.loc = reflectwalk.MapValue
+
+	// Create a string value of the time. IMPORTANT: this must never change
+	// across Vault versions or the hash value of equivalent time.Time will
+	// change.
+	strVal := v.Interface().(time.Time).UTC().Format(time.RFC3339Nano)
+
+	// Walk it as if it were a primitive value with the string value.
+	// This will replace the currenty map value (which is a time.Time).
+	if err := w.Primitive(reflect.ValueOf(strVal)); err != nil {
+		return err
+	}
+
+	// Skip this entry so that we don't walk the struct.
+	return reflectwalk.SkipEntry
+}
+
+func (w *hashWalker) StructField(reflect.StructField, reflect.Value) error {
 	return nil
 }
 

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -140,6 +140,10 @@ func TestHash(t *testing.T) {
 			&logical.Response{
 				Data: map[string]interface{}{
 					"foo": "bar",
+
+					// Responses can contain time values, so test that with
+					// a known fixed value.
+					"bar": time.Unix(1494264707, 0),
 				},
 				WrapInfo: &wrapping.ResponseWrapInfo{
 					TTL:             60,
@@ -151,6 +155,7 @@ func TestHash(t *testing.T) {
 			&logical.Response{
 				Data: map[string]interface{}{
 					"foo": "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317",
+					"bar": "hmac-sha256:b09b815a7d1c3bbcf702f9c9a50ef6408d0935bea0154383a128ca8743eb06fc",
 				},
 				WrapInfo: &wrapping.ResponseWrapInfo{
 					TTL:             60,

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1129,10 +1129,10 @@
 			"revisionTime": "2017-03-07T20:11:23Z"
 		},
 		{
-			"checksumSHA1": "67Y6z6rHipvOvFwCZZXqKH+TWao=",
+			"checksumSHA1": "KqsMqI+Y+3EFYPhyzafpIneaVCM=",
 			"path": "github.com/mitchellh/reflectwalk",
-			"revision": "417edcfd99a4d472c262e58f22b4bfe97580f03e",
-			"revisionTime": "2017-01-10T16:52:07Z"
+			"revision": "8d802ff4ae93611b807597f639c19f76074df5c6",
+			"revisionTime": "2017-05-08T17:38:06Z"
 		},
 		{
 			"checksumSHA1": "BxxkAJ/Nm61PybCXvQIZJwyTj3Y=",


### PR DESCRIPTION
This enables audit.Hash to hash time.Time values that may exist as
direct fields in the map. This will error (instead of panic) for any
time.Time values that don't occur within map values. For example, this
does not support a time.Time within a slice. If that needs to be
supported then modifications will need to be made.

This also requires an update to reflectwalk (included in this PR). This
is a minimal change that allows SkipEntry to signal to skip an entire
struct. We do this because we don't want to walk any of time.Time since
we handle it directly.

Fixes #2687