### PR TITLE
Docs: Header Type Typo

### DIFF
--- a/website/source/api/secret/transit/index.html.md
+++ b/website/source/api/secret/transit/index.html.md
@@ -173,7 +173,7 @@ $ curl \
     https://vault.rocks/v1/transit/keys/my-key
 ```
 
-#### Update Key Configuration
+## Update Key Configuration
 
 This endpoint allows tuning configuration values for a given key. (These values
 are returned during a read operation on the named key.)


### PR DESCRIPTION
Header 'Update Key Configuration' should be a H2 not a H4.