### PR TITLE
Allow non-strings to be used to set `ttl` field in generic.

### DIFF
--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/helper/jsonutil"
+	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -126,14 +126,13 @@ func (b *PassthroughBackend) handleRead(
 	}
 
 	// Check if there is a ttl key
-	var ttl string
-	ttl, _ = rawData["ttl"].(string)
-	if len(ttl) == 0 {
-		ttl, _ = rawData["lease"].(string)
-	}
 	ttlDuration := b.System().DefaultLeaseTTL()
-	if len(ttl) != 0 {
-		dur, err := parseutil.ParseDurationSecond(ttl)
+	ttlInt, ok := rawData["ttl"]
+	if !ok {
+		ttlInt, ok = rawData["lease"]
+	}
+	if ok {
+		dur, err := parseutil.ParseDurationSecond(ttlInt)
 		if err == nil {
 			ttlDuration = dur
 		}

--- a/vault/logical_passthrough.go
+++ b/vault/logical_passthrough.go
@@ -127,12 +127,12 @@ func (b *PassthroughBackend) handleRead(
 
 	// Check if there is a ttl key
 	ttlDuration := b.System().DefaultLeaseTTL()
-	ttlInt, ok := rawData["ttl"]
+	ttlRaw, ok := rawData["ttl"]
 	if !ok {
-		ttlInt, ok = rawData["lease"]
+		ttlRaw, ok = rawData["lease"]
 	}
 	if ok {
-		dur, err := parseutil.ParseDurationSecond(ttlInt)
+		dur, err := parseutil.ParseDurationSecond(ttlRaw)
 		if err == nil {
 			ttlDuration = dur
 		}


### PR DESCRIPTION
Fixes #2697