### PR TITLE
WIP: Add listener option to block unauthenticated paths

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -671,6 +671,7 @@ func parseListeners(result *Config, list *ast.ObjectList) error {
 			"tls_prefer_server_cipher_suites",
 			"tls_require_and_verify_client_cert",
 			"token",
+			"unauthenticated_paths",
 		}
 		if err := checkHCLKeys(item.Val, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("listeners.%s:", key))

--- a/command/server/listener.go
+++ b/command/server/listener.go
@@ -106,7 +106,13 @@ func listenerWrapTLS(
 			tlsConf.ClientAuth = tls.RequireAndVerifyClientCert
 		}
 	}
-
+	if v, ok := config["unauthenticated_paths"]; ok {
+		_, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("invalid value for 'unauthenticated_paths': %v", err)
+		}
+		props["unauthenticated_paths"] = v
+	}
 	ln = tls.NewListener(ln, tlsConf)
 	props["tls"] = "enabled"
 	return ln, props, cg.reload, nil

--- a/http/handler.go
+++ b/http/handler.go
@@ -83,6 +83,7 @@ func wrapGenericHandler(h http.Handler) http.Handler {
 		// Set the Cache-Control header for all the responses returned
 		// by Vault
 		w.Header().Set("Cache-Control", "no-store")
+		fmt.Printf("Local Addr: %v\n", r.Context().Value(http.LocalAddrContextKey))
 		h.ServeHTTP(w, r)
 		return
 	})


### PR DESCRIPTION
Add unauthenticated_paths option to listener configuration.
This will be true by default, allowing access to unauthenticated paths
but can be set to false to prevent access to any unauthenticated paths
using this listener.

This enables vault to be configured to only allow invocation of any
unauthenticated paths via an internal networks. Controlling access to
unauthenticated paths offers some protection against denial of
service attacks.