### PR TITLE
Update aws.html.md

### DIFF
--- a/website/source/docs/auth/aws.html.md
+++ b/website/source/docs/auth/aws.html.md
@@ -507,7 +507,7 @@ $ vault write auth/aws/config/client secret_key=vCtSM8ZUEQ3mOFVlYPBQkf2sO6F/W7a5
 #### Configure the policies on the role.
 
 ```
-$ vault write auth/aws/role/dev-role bound_ami_id=ami-fce3c696 policies=prod,dev max_ttl=500h
+$ vault write auth/aws/role/dev-role auth_type=ec2 bound_ami_id=ami-fce3c696 policies=prod,dev max_ttl=500h
 
 $ vault write auth/aws/role/dev-role-iam auth_type=iam \
               bound_iam_principal_arn=arn:aws:iam::123456789012:role/MyRole policies=prod,dev max_ttl=500h


### PR DESCRIPTION
Is this now required argument?

I was getting following:
```sh
 # vault write auth/aws/role/my-role max_ttl=500h bound_account_id=12345 role_tag=VaultAccess policies=production
Error writing data to auth/aws/role/my-role: Error making API request.

URL: PUT https://127.0.0.1:8200/v1/auth/aws/role/my-role
Code: 400. Errors:

* specified bound_account_id but not allowing ec2 auth_type or inferring ec2_instance
```