### PR TITLE
Update the S3 storage backend docs to reflect capabilities.

### DIFF
--- a/website/source/docs/configuration/storage/s3.html.md
+++ b/website/source/docs/configuration/storage/s3.html.md
@@ -46,11 +46,13 @@ instance profile service to provide the credentials Vault will use to make
 S3 API calls. Leaving the `access_key` and `secret_key` fields empty will
 cause Vault to attempt to retrieve credentials from the AWS metadata service.
 
-- `access_key` `(string: <required>)` – Specifies the AWS access key. This can
-  also be provided via the environment variable `AWS_ACCESS_KEY_ID`.
+- `access_key` – Specifies the AWS access key. This can also be provided via
+  the environment variable `AWS_ACCESS_KEY_ID`, AWS credential files, or by
+  IAM role.
 
-- `secret_key` `(string: <required>)` – Specifies the AWS secret key. This can
-  also be provided via the environment variable `AWS_SECRET_ACCESS_KEY`.
+- `secret_key` – Specifies the AWS secret key. This can also be provided via
+  the environment variable `AWS_SECRET_ACCESS_KEY`, AWS credential files, or
+  by IAM role.
 
 - `session_token` `(string: "")` – Specifies the AWS session token. This can
   also be provided via the environment variable `AWS_SESSION_TOKEN`.


### PR DESCRIPTION
Update S3 storage backend docs to remove `required` designation from AWS creds, highlight that IAM role support is implemented.