### PR TITLE
DynamoDB: Check for children more efficiently

### DIFF
--- a/physical/dynamodb.go
+++ b/physical/dynamodb.go
@@ -317,11 +317,11 @@ func (d *DynamoDBBackend) Delete(key string) error {
 	prefixes := prefixes(key)
 	sort.Sort(sort.Reverse(sort.StringSlice(prefixes)))
 	for _, prefix := range prefixes {
-		items, err := d.List(prefix)
+		hasChildren, err := d.hasChildren(prefix)
 		if err != nil {
 			return err
 		}
-		if len(items) == 1 {
+		if !hasChildren {
 			requests = append(requests, &dynamodb.WriteRequest{
 				DeleteRequest: &dynamodb.DeleteRequest{
 					Key: map[string]*dynamodb.AttributeValue{
@@ -376,6 +376,39 @@ func (d *DynamoDBBackend) List(prefix string) ([]string, error) {
 	}
 
 	return keys, nil
+}
+
+// hasChildren returns true if there exist items below a certain path prefix.
+// To do so, the method fetches such items from DynamoDB. If there are more than one item (which is the "directory"
+// item), there are children.
+func (d *DynamoDBBackend) hasChildren(prefix string) (bool, error) {
+	prefix = strings.TrimSuffix(prefix, "/")
+	prefix = escapeEmptyPath(prefix)
+
+	queryInput := &dynamodb.QueryInput{
+		TableName:      aws.String(d.table),
+		ConsistentRead: aws.Bool(true),
+		KeyConditions: map[string]*dynamodb.Condition{
+			"Path": {
+				ComparisonOperator: aws.String("EQ"),
+				AttributeValueList: []*dynamodb.AttributeValue{{
+					S: aws.String(prefix),
+				}},
+			},
+		},
+		// Avoid fetching too many items from DynamoDB for performance reasons.
+		// We need at least two because one is the directory item, all others are children.
+		Limit: aws.Int64(2),
+	}
+
+	d.permitPool.Acquire()
+	defer d.permitPool.Release()
+
+	out, err := d.client.Query(queryInput)
+	if err != nil {
+		return false, err
+	}
+	return len(out.Items) > 1, nil
 }
 
 // LockWith is used for mutual exclusion based on the given key.

--- a/physical/dynamodb.go
+++ b/physical/dynamodb.go
@@ -379,8 +379,8 @@ func (d *DynamoDBBackend) List(prefix string) ([]string, error) {
 }
 
 // hasChildren returns true if there exist items below a certain path prefix.
-// To do so, the method fetches such items from DynamoDB. If there are more than one item (which is the "directory"
-// item), there are children.
+// To do so, the method fetches such items from DynamoDB. If there are more
+// than one item (which is the "directory" item), there are children.
 func (d *DynamoDBBackend) hasChildren(prefix string) (bool, error) {
 	prefix = strings.TrimSuffix(prefix, "/")
 	prefix = escapeEmptyPath(prefix)
@@ -397,7 +397,8 @@ func (d *DynamoDBBackend) hasChildren(prefix string) (bool, error) {
 			},
 		},
 		// Avoid fetching too many items from DynamoDB for performance reasons.
-		// We need at least two because one is the directory item, all others are children.
+		// We need at least two because one is the directory item, all others
+		// are children.
 		Limit: aws.Int64(2),
 	}
 


### PR DESCRIPTION
When deleting items from Vault, the DynamoDB backend checks whether there are any more items in the same path and cleans it up if not. This works pretty well for nodes with only a few children. In our infrastructure however, we experience issues with the revocation of leases that reside in `auth/github/login/`.

Below this node, there are so many items, that [listing them](https://github.com/hashicorp/vault/blob/9de6563abec3e667950614203d280f5ab2d2ee3c/physical/dynamodb.go#L320-L324) consumes **a lot** DynamoDB read capacity units. Because leases are revoked all the time in our setup, we run into throttled DynamoDB requests (in spikes) a lot. 

To work around this, we figured that there must be an easier way to count items. Sadly this is pretty hard in DynamoDB. However what we can do is only fetch 2 items (which only consumes 1 or 2 "read capacity units" in DynamoDB). If there are no children, only one item is returned for this query - the "directory" node itself. If there are two items, we know that there are children.

We tested this in our production cluster where we previously (with v0.7.2) had the throttling issues. Everything works well and we don't see any throttled requests anymore. 🎉 