### PR TITLE
Ignore go-zookeeper lock children instead of panicking

### DIFF
--- a/physical/zookeeper.go
+++ b/physical/zookeeper.go
@@ -289,8 +289,14 @@ func (c *ZookeeperBackend) List(prefix string) ([]string, error) {
 		// and append the slash which is what Vault depends on
 		// for iteration
 		if stat.DataLength > 0 && stat.NumChildren > 0 {
-			msgFmt := "Node %q is both of data and leaf type ??"
-			panic(fmt.Sprintf(msgFmt, childPath))
+			if childPath == c.nodePath("core/lock") {
+				// go-zookeeper Lock() breaks Vault semantics and creates a directory
+				// under the lock file; just treat it like the file Vault expects
+				children = append(children, key[1:])
+			} else {
+				msgFmt := "Node %q is both of data and leaf type ??"
+				panic(fmt.Sprintf(msgFmt, childPath))
+			}
 		} else if stat.DataLength == 0 {
 			// No, we cannot differentiate here on number of children as node
 			// can have all it leafs remoed, and it still is a node.


### PR DESCRIPTION
Context: I've been working with [vault-migrator](https://github.com/nebtex/vault-migrator) to backup a running Vault cluster to protect against accidental deletions and disasters. Recognizing that hot backups are not without flaw, it is still better than nothing.

Calling `zk.List("core/")` causes Vault to panic because the `lock` node has both data and children. This is a side effect of `go-zookeeper` managing the lock: it creates it's own directory structure underneath the provided path and it doesn't match Vault's semantics of "data or children, but never both". While Vault never actually calls `zk.List("core/")`, this seems like a worthwhile change to remove that sharp edge and enable backups.