### PR TITLE
Log auth info on permission denied due to ACL

### DIFF
--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -23,11 +23,15 @@ func TestFormatJSON_formatRequest(t *testing.T) {
 	saltFunc := func() (*salt.Salt, error) {
 		return salter, nil
 	}
+
+	expectedResultStr := fmt.Sprintf(testFormatJSONReqBasicStrFmt, salter.GetIdentifiedHMAC("foo"))
+
 	cases := map[string]struct {
-		Auth   *logical.Auth
-		Req    *logical.Request
-		Err    error
-		Prefix string
+		Auth        *logical.Auth
+		Req         *logical.Request
+		Err         error
+		Prefix      string
+		ExpectedStr string
 	}{
 		"auth, request": {
 			&logical.Auth{ClientToken: "foo", Accessor: "bar", DisplayName: "testtoken", Policies: []string{"root"}},
@@ -46,6 +50,7 @@ func TestFormatJSON_formatRequest(t *testing.T) {
 			},
 			errors.New("this is an error"),
 			"",
+			expectedResultStr,
 		},
 		"auth, request with prefix": {
 			&logical.Auth{ClientToken: "foo", Accessor: "bar", DisplayName: "testtoken", Policies: []string{"root"}},
@@ -64,6 +69,7 @@ func TestFormatJSON_formatRequest(t *testing.T) {
 			},
 			errors.New("this is an error"),
 			"@cee: ",
+			expectedResultStr,
 		},
 	}
 
@@ -81,9 +87,6 @@ func TestFormatJSON_formatRequest(t *testing.T) {
 		if err := formatter.FormatRequest(&buf, config, tc.Auth, tc.Req, tc.Err); err != nil {
 			t.Fatalf("bad: %s\nerr: %s", name, err)
 		}
-
-		// must regenerate each run since we use a different salter each time
-		var expectedResultStr = fmt.Sprintf(testFormatJSONReqBasicStrFmt, salter.GetIdentifiedHMAC("foo"))
 
 		if !strings.HasPrefix(buf.String(), tc.Prefix) {
 			t.Fatalf("no prefix: %s \n log: %s\nprefix: %s", name, expectedResultStr, tc.Prefix)

--- a/audit/format_jsonx_test.go
+++ b/audit/format_jsonx_test.go
@@ -8,6 +8,7 @@ import (
 
 	"errors"
 
+	"fmt"
 	"github.com/hashicorp/vault/helper/salt"
 	"github.com/hashicorp/vault/logical"
 )
@@ -21,15 +22,15 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 		return salter, nil
 	}
 	cases := map[string]struct {
-		Auth     *logical.Auth
-		Req      *logical.Request
-		Err      error
-		Prefix   string
-		Result   string
-		Expected string
+		Auth        *logical.Auth
+		Req         *logical.Request
+		Err         error
+		Prefix      string
+		Result      string
+		ExpectedFmt string
 	}{
 		"auth, request": {
-			&logical.Auth{ClientToken: "foo", Policies: []string{"root"}},
+			&logical.Auth{ClientToken: "foo", Accessor: "bar", DisplayName: "testtoken", Policies: []string{"root"}},
 			&logical.Request{
 				Operation: logical.UpdateOperation,
 				Path:      "/foo",
@@ -46,10 +47,10 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 			errors.New("this is an error"),
 			"",
 			"",
-			`<json:object name="auth"><json:string name="accessor"></json:string><json:string name="client_token"></json:string><json:string name="display_name"></json:string><json:null name="metadata" /><json:array name="policies"><json:string>root</json:string></json:array></json:object><json:string name="error">this is an error</json:string><json:object name="request"><json:string name="client_token"></json:string><json:string name="client_token_accessor"></json:string><json:null name="data" /><json:object name="headers"><json:array name="foo"><json:string>bar</json:string></json:array></json:object><json:string name="id"></json:string><json:string name="operation">update</json:string><json:string name="path">/foo</json:string><json:string name="remote_address">127.0.0.1</json:string><json:number name="wrap_ttl">60</json:number></json:object><json:string name="type">request</json:string>`,
+			`<json:object name="auth"><json:string name="accessor">bar</json:string><json:string name="client_token">%s</json:string><json:string name="display_name">testtoken</json:string><json:null name="metadata" /><json:array name="policies"><json:string>root</json:string></json:array></json:object><json:string name="error">this is an error</json:string><json:object name="request"><json:string name="client_token"></json:string><json:string name="client_token_accessor"></json:string><json:null name="data" /><json:object name="headers"><json:array name="foo"><json:string>bar</json:string></json:array></json:object><json:string name="id"></json:string><json:string name="operation">update</json:string><json:string name="path">/foo</json:string><json:string name="remote_address">127.0.0.1</json:string><json:number name="wrap_ttl">60</json:number></json:object><json:string name="type">request</json:string>`,
 		},
 		"auth, request with prefix": {
-			&logical.Auth{ClientToken: "foo", Policies: []string{"root"}},
+			&logical.Auth{ClientToken: "foo", Accessor: "bar", DisplayName: "testtoken", Policies: []string{"root"}},
 			&logical.Request{
 				Operation: logical.UpdateOperation,
 				Path:      "/foo",
@@ -66,7 +67,7 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 			errors.New("this is an error"),
 			"",
 			"@cee: ",
-			`<json:object name="auth"><json:string name="accessor"></json:string><json:string name="client_token"></json:string><json:string name="display_name"></json:string><json:null name="metadata" /><json:array name="policies"><json:string>root</json:string></json:array></json:object><json:string name="error">this is an error</json:string><json:object name="request"><json:string name="client_token"></json:string><json:string name="client_token_accessor"></json:string><json:null name="data" /><json:object name="headers"><json:array name="foo"><json:string>bar</json:string></json:array></json:object><json:string name="id"></json:string><json:string name="operation">update</json:string><json:string name="path">/foo</json:string><json:string name="remote_address">127.0.0.1</json:string><json:number name="wrap_ttl">60</json:number></json:object><json:string name="type">request</json:string>`,
+			`<json:object name="auth"><json:string name="accessor">bar</json:string><json:string name="client_token">%s</json:string><json:string name="display_name">testtoken</json:string><json:null name="metadata" /><json:array name="policies"><json:string>root</json:string></json:array></json:object><json:string name="error">this is an error</json:string><json:object name="request"><json:string name="client_token"></json:string><json:string name="client_token_accessor"></json:string><json:null name="data" /><json:object name="headers"><json:array name="foo"><json:string>bar</json:string></json:array></json:object><json:string name="id"></json:string><json:string name="operation">update</json:string><json:string name="path">/foo</json:string><json:string name="remote_address">127.0.0.1</json:string><json:number name="wrap_ttl">60</json:number></json:object><json:string name="type">request</json:string>`,
 		},
 	}
 
@@ -79,7 +80,8 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 			},
 		}
 		config := FormatterConfig{
-			OmitTime: true,
+			OmitTime:     true,
+			HMACAccessor: false,
 		}
 		if err := formatter.FormatRequest(&buf, config, tc.Auth, tc.Req, tc.Err); err != nil {
 			t.Fatalf("bad: %s\nerr: %s", name, err)
@@ -89,10 +91,13 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 			t.Fatalf("no prefix: %s \n log: %s\nprefix: %s", name, tc.Result, tc.Prefix)
 		}
 
-		if !strings.HasSuffix(strings.TrimSpace(buf.String()), string(tc.Expected)) {
+		// must regenerate each run since we use a different salter each time
+		var expectedResultStr = fmt.Sprintf(tc.ExpectedFmt, salter.GetIdentifiedHMAC("foo"))
+
+		if !strings.HasSuffix(strings.TrimSpace(buf.String()), string(expectedResultStr)) {
 			t.Fatalf(
 				"bad: %s\nResult:\n\n'%s'\n\nExpected:\n\n'%s'",
-				name, strings.TrimSpace(buf.String()), string(tc.Expected))
+				name, strings.TrimSpace(buf.String()), string(expectedResultStr))
 		}
 	}
 }

--- a/audit/format_jsonx_test.go
+++ b/audit/format_jsonx_test.go
@@ -21,13 +21,16 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 	saltFunc := func() (*salt.Salt, error) {
 		return salter, nil
 	}
+
+	fooSalted := salter.GetIdentifiedHMAC("foo")
+
 	cases := map[string]struct {
 		Auth        *logical.Auth
 		Req         *logical.Request
 		Err         error
 		Prefix      string
 		Result      string
-		ExpectedFmt string
+		ExpectedStr string
 	}{
 		"auth, request": {
 			&logical.Auth{ClientToken: "foo", Accessor: "bar", DisplayName: "testtoken", Policies: []string{"root"}},
@@ -47,7 +50,8 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 			errors.New("this is an error"),
 			"",
 			"",
-			`<json:object name="auth"><json:string name="accessor">bar</json:string><json:string name="client_token">%s</json:string><json:string name="display_name">testtoken</json:string><json:null name="metadata" /><json:array name="policies"><json:string>root</json:string></json:array></json:object><json:string name="error">this is an error</json:string><json:object name="request"><json:string name="client_token"></json:string><json:string name="client_token_accessor"></json:string><json:null name="data" /><json:object name="headers"><json:array name="foo"><json:string>bar</json:string></json:array></json:object><json:string name="id"></json:string><json:string name="operation">update</json:string><json:string name="path">/foo</json:string><json:string name="remote_address">127.0.0.1</json:string><json:number name="wrap_ttl">60</json:number></json:object><json:string name="type">request</json:string>`,
+			fmt.Sprintf(`<json:object name="auth"><json:string name="accessor">bar</json:string><json:string name="client_token">%s</json:string><json:string name="display_name">testtoken</json:string><json:null name="metadata" /><json:array name="policies"><json:string>root</json:string></json:array></json:object><json:string name="error">this is an error</json:string><json:object name="request"><json:string name="client_token"></json:string><json:string name="client_token_accessor"></json:string><json:null name="data" /><json:object name="headers"><json:array name="foo"><json:string>bar</json:string></json:array></json:object><json:string name="id"></json:string><json:string name="operation">update</json:string><json:string name="path">/foo</json:string><json:string name="remote_address">127.0.0.1</json:string><json:number name="wrap_ttl">60</json:number></json:object><json:string name="type">request</json:string>`,
+				fooSalted),
 		},
 		"auth, request with prefix": {
 			&logical.Auth{ClientToken: "foo", Accessor: "bar", DisplayName: "testtoken", Policies: []string{"root"}},
@@ -67,7 +71,8 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 			errors.New("this is an error"),
 			"",
 			"@cee: ",
-			`<json:object name="auth"><json:string name="accessor">bar</json:string><json:string name="client_token">%s</json:string><json:string name="display_name">testtoken</json:string><json:null name="metadata" /><json:array name="policies"><json:string>root</json:string></json:array></json:object><json:string name="error">this is an error</json:string><json:object name="request"><json:string name="client_token"></json:string><json:string name="client_token_accessor"></json:string><json:null name="data" /><json:object name="headers"><json:array name="foo"><json:string>bar</json:string></json:array></json:object><json:string name="id"></json:string><json:string name="operation">update</json:string><json:string name="path">/foo</json:string><json:string name="remote_address">127.0.0.1</json:string><json:number name="wrap_ttl">60</json:number></json:object><json:string name="type">request</json:string>`,
+			fmt.Sprintf(`<json:object name="auth"><json:string name="accessor">bar</json:string><json:string name="client_token">%s</json:string><json:string name="display_name">testtoken</json:string><json:null name="metadata" /><json:array name="policies"><json:string>root</json:string></json:array></json:object><json:string name="error">this is an error</json:string><json:object name="request"><json:string name="client_token"></json:string><json:string name="client_token_accessor"></json:string><json:null name="data" /><json:object name="headers"><json:array name="foo"><json:string>bar</json:string></json:array></json:object><json:string name="id"></json:string><json:string name="operation">update</json:string><json:string name="path">/foo</json:string><json:string name="remote_address">127.0.0.1</json:string><json:number name="wrap_ttl">60</json:number></json:object><json:string name="type">request</json:string>`,
+				fooSalted),
 		},
 	}
 
@@ -91,13 +96,10 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 			t.Fatalf("no prefix: %s \n log: %s\nprefix: %s", name, tc.Result, tc.Prefix)
 		}
 
-		// must regenerate each run since we use a different salter each time
-		var expectedResultStr = fmt.Sprintf(tc.ExpectedFmt, salter.GetIdentifiedHMAC("foo"))
-
-		if !strings.HasSuffix(strings.TrimSpace(buf.String()), string(expectedResultStr)) {
+		if !strings.HasSuffix(strings.TrimSpace(buf.String()), string(tc.ExpectedStr)) {
 			t.Fatalf(
 				"bad: %s\nResult:\n\n'%s'\n\nExpected:\n\n'%s'",
-				name, strings.TrimSpace(buf.String()), string(expectedResultStr))
+				name, strings.TrimSpace(buf.String()), string(tc.ExpectedStr))
 		}
 	}
 }

--- a/vault/core.go
+++ b/vault/core.go
@@ -664,16 +664,6 @@ func (c *Core) checkToken(req *logical.Request) (*logical.Auth, *TokenEntry, err
 		}
 	}
 
-	// Check the standard non-root ACLs. Return the token entry if it's not
-	// allowed so we can decrement the use count.
-	allowed, rootPrivs := acl.AllowOperation(req)
-	if !allowed {
-		return nil, te, logical.ErrPermissionDenied
-	}
-	if rootPath && !rootPrivs {
-		return nil, te, logical.ErrPermissionDenied
-	}
-
 	// Create the auth response
 	auth := &logical.Auth{
 		ClientToken: req.ClientToken,
@@ -681,6 +671,17 @@ func (c *Core) checkToken(req *logical.Request) (*logical.Auth, *TokenEntry, err
 		Metadata:    te.Meta,
 		DisplayName: te.DisplayName,
 	}
+
+	// Check the standard non-root ACLs. Return the token entry if it's not
+	// allowed so we can decrement the use count.
+	allowed, rootPrivs := acl.AllowOperation(req)
+	if !allowed {
+		return auth, te, logical.ErrPermissionDenied
+	}
+	if rootPath && !rootPrivs {
+		return auth, te, logical.ErrPermissionDenied
+	}
+
 	return auth, te, nil
 }
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -663,10 +663,10 @@ func (c *Core) checkToken(req *logical.Request) (*logical.Auth, *TokenEntry, err
 			panic("unreachable code")
 		}
 	}
-
 	// Create the auth response
 	auth := &logical.Auth{
 		ClientToken: req.ClientToken,
+		Accessor:    req.ClientTokenAccessor,
 		Policies:    te.Policies,
 		Metadata:    te.Meta,
 		DisplayName: te.DisplayName,
@@ -676,9 +676,11 @@ func (c *Core) checkToken(req *logical.Request) (*logical.Auth, *TokenEntry, err
 	// allowed so we can decrement the use count.
 	allowed, rootPrivs := acl.AllowOperation(req)
 	if !allowed {
+		// Return auth for audit logging even if not allowed
 		return auth, te, logical.ErrPermissionDenied
 	}
 	if rootPath && !rootPrivs {
+		// Return auth for audit logging even if not allowed
 		return auth, te, logical.ErrPermissionDenied
 	}
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -171,7 +171,7 @@ func (c *Core) handleRequest(req *logical.Request) (retResp *logical.Response, r
 		if errType != nil {
 			retErr = multierror.Append(retErr, errType)
 		}
-		return logical.ErrorResponse(ctErr.Error()), nil, retErr
+		return logical.ErrorResponse(ctErr.Error()), auth, retErr
 	}
 
 	// Attach the display name


### PR DESCRIPTION
Fixes #2741.

Test case (depends on jq for ease of reading, remove if you want):
```rm /tmp/vault.log
bin/vault server -dev &
export VAULT_ADDR='http://127.0.0.1:8200'
vault audit-enable file file_path=/tmp/vault.log
vault write auth/token/roles/testrole allowed_policies=default
vault write /secret/test key=data
vault read /secret/test
vault write -field=token auth/token/create/testrole display_name=testuser > ~/.vault-token2 ; mv ~/.vault-token2 ~/.vault-token
vault read /secret/test
grep '"path":"secret/test"' /tmp/vault.log | grep '"operation":"read"' | jq
```

Result:
```
{
  "time": "2017-05-23T00:06:40Z",
  "type": "request",
  "auth": {
    "client_token": "",
    "accessor": "",
    "display_name": "root",
    "policies": [
      "root"
    ],
    "metadata": null
  },
  "request": {
    "id": "74c4ab04-cdc3-5856-3889-f0ae90f57870",
    "operation": "read",
    "client_token": "hmac-sha256:19621e2de54a9dcddc73bf2234dd46f4b642b26bf49cacbfbd08bdd3631f9e83",
    "client_token_accessor": "hmac-sha256:bef588d30ac2304f4cf9c95f0f5898eff8ad49de1fed86cec28b7027630ca9ab",
    "path": "secret/test",
    "data": null,
    "remote_address": "127.0.0.1",
    "wrap_ttl": 0,
    "headers": {}
  },
  "error": ""
}
{
  "time": "2017-05-23T00:06:40Z",
  "type": "response",
  "auth": {
    "client_token": "",
    "accessor": "",
    "display_name": "root",
    "policies": [
      "root"
    ],
    "metadata": null
  },
  "request": {
    "id": "74c4ab04-cdc3-5856-3889-f0ae90f57870",
    "operation": "read",
    "client_token": "hmac-sha256:19621e2de54a9dcddc73bf2234dd46f4b642b26bf49cacbfbd08bdd3631f9e83",
    "client_token_accessor": "hmac-sha256:bef588d30ac2304f4cf9c95f0f5898eff8ad49de1fed86cec28b7027630ca9ab",
    "path": "secret/test",
    "data": null,
    "remote_address": "127.0.0.1",
    "wrap_ttl": 0,
    "headers": {}
  },
  "response": {
    "secret": {
      "lease_id": ""
    },
    "data": {
      "key": "hmac-sha256:10f49bdcee36ad5411c601fce92429087a0ca10573f8d0e20b777a04c2b5377b"
    }
  },
  "error": ""
}
{
  "time": "2017-05-23T00:06:40Z",
  "type": "request",
  "auth": {
    "client_token": "",
    "accessor": "",
    "display_name": "token-testuser",
    "policies": [
      "default"
    ],
    "metadata": null
  },
  "request": {
    "id": "b9cfc344-22b1-d5b5-b55e-8fdd904275ca",
    "operation": "read",
    "client_token": "hmac-sha256:74cf7d28b98f8d09d7e4afad6d10d325a0861aa783db90ede7c7ec549733357d",
    "client_token_accessor": "hmac-sha256:40eb83f5c0fac9a9c5f85a9c8d9fc50a2b22a797636d528c0dadf5b83ad61e99",
    "path": "secret/test",
    "data": null,
    "remote_address": "127.0.0.1",
    "wrap_ttl": 0,
    "headers": {}
  },
  "error": "permission denied"
}
{
  "time": "2017-05-23T00:06:40Z",
  "type": "response",
  "auth": {
    "client_token": "",
    "accessor": "",
    "display_name": "token-testuser",
    "policies": [
      "default"
    ],
    "metadata": null
  },
  "request": {
    "id": "b9cfc344-22b1-d5b5-b55e-8fdd904275ca",
    "operation": "read",
    "client_token": "hmac-sha256:74cf7d28b98f8d09d7e4afad6d10d325a0861aa783db90ede7c7ec549733357d",
    "client_token_accessor": "hmac-sha256:40eb83f5c0fac9a9c5f85a9c8d9fc50a2b22a797636d528c0dadf5b83ad61e99",
    "path": "secret/test",
    "data": null,
    "remote_address": "127.0.0.1",
    "wrap_ttl": 0,
    "headers": {}
  },
  "response": {
    "data": {
      "error": "hmac-sha256:9893d3283db38b32de175ce1432b355002f17429c735005e6cd6137dbd30f681"
    }
  },
  "error": "1 error occurred:\n\n* permission denied"
}
```

Without this PR, the `auth` object for the second pair of req/resp would be missing info such as display name and policies that are important for determining who was denied access and why.