### PR TITLE
Use auth-saved cert name during renewals to avoid a panic.

### DIFF
--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -156,7 +156,12 @@ func (b *backend) verifyCredentials(req *logical.Request, d *framework.FieldData
 	clientCert := connState.PeerCertificates[0]
 
 	// Allow constraining the login request to a single CertEntry
-	certName := d.Get("name").(string)
+	var string certName
+	if req.Auth != nil { // It's a renewal, use the saved certName
+		certName = req.Auth.Metadata["cert_name"]
+	} else {
+		certName = d.Get("name").(string)
+	}
 
 	// Load the trusted certificates
 	roots, trusted, trustedNonCAs := b.loadTrustedCerts(req.Storage, certName)

--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -156,7 +156,7 @@ func (b *backend) verifyCredentials(req *logical.Request, d *framework.FieldData
 	clientCert := connState.PeerCertificates[0]
 
 	// Allow constraining the login request to a single CertEntry
-	var string certName
+	var certName string
 	if req.Auth != nil { // It's a renewal, use the saved certName
 		certName = req.Auth.Metadata["cert_name"]
 	} else {


### PR DESCRIPTION
Fixes #2749