### PR TITLE
Add max_parallel parameter to MySQL backend.

### DIFF
--- a/website/source/docs/configuration/storage/mysql.html.md
+++ b/website/source/docs/configuration/storage/mysql.html.md
@@ -42,6 +42,9 @@ storage "mysql" {
 - `tls_ca_file` `(string: "")` – Specifies the path to the CA certificate to
   connect using TLS.
 
+- `max_parallel` `(string: "128")` – Specifies The maximum number of concurrent
+  requests to MySQL.
+
 Additionally, Vault requires the following authentication information.
 
 - `username` `(string: <required>)` – Specifies the MySQL username to connect to

--- a/website/source/docs/configuration/storage/mysql.html.md
+++ b/website/source/docs/configuration/storage/mysql.html.md
@@ -42,7 +42,7 @@ storage "mysql" {
 - `tls_ca_file` `(string: "")` – Specifies the path to the CA certificate to
   connect using TLS.
 
-- `max_parallel` `(string: "128")` – Specifies The maximum number of concurrent
+- `max_parallel` `(string: "128")` – Specifies the maximum number of concurrent
   requests to MySQL.
 
 Additionally, Vault requires the following authentication information.


### PR DESCRIPTION
This limits the number of concurrent connections, so that vault does not die suddenly from "Too many connections".

This can happen when e.g. vault starts up, and tries to load all the existing leases in parallel. At the time of writing this, the value [ExpirationRestoreWorkerCount](https://github.com/hashicorp/vault/blob/v0.7.2/helper/consts/consts.go#L6) is set to 64, meaning that if there are enough leases in the vault's DB, it will generate AT LEAST 64 concurrent connections to MySQL when loading the data during start-up. On certain configurations, e.g. smaller AWS RDS/Aurora instances, this will cause Vault to fail startup.