### PR TITLE
Improve EC2 describe instances performance

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -170,13 +170,8 @@ func (b *backend) validateInstance(s logical.Storage, instanceID, region, accoun
 	}
 
 	status, err := ec2Client.DescribeInstances(&ec2.DescribeInstancesInput{
-		Filters: []*ec2.Filter{
-			&ec2.Filter{
-				Name: aws.String("instance-id"),
-				Values: []*string{
-					aws.String(instanceID),
-				},
-			},
+		InstanceIds: []*string{
+			aws.String(instanceID),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Query the EC2 API for the instance ID rather than filter the results of
all instances.