### PR TITLE
Support custom renewal statements in Postgres

### DIFF
--- a/plugins/database/postgresql/postgresql_test.go
+++ b/plugins/database/postgresql/postgresql_test.go
@@ -170,6 +170,28 @@ func TestPostgreSQL_RenewUser(t *testing.T) {
 	if err = testCredsExist(t, connURL, username, password); err != nil {
 		t.Fatalf("Could not connect with new credentials: %s", err)
 	}
+	statements.RenewStatements = defaultPostgresRenewSQL
+	username, password, err = db.CreateUser(statements, "test", time.Now().Add(2*time.Second))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err = testCredsExist(t, connURL, username, password); err != nil {
+		t.Fatalf("Could not connect with new credentials: %s", err)
+	}
+
+	err = db.RenewUser(statements, username, time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Sleep longer than the inital expiration time
+	time.Sleep(2 * time.Second)
+
+	if err = testCredsExist(t, connURL, username, password); err != nil {
+		t.Fatalf("Could not connect with new credentials: %s", err)
+	}
+
 }
 
 func TestPostgreSQL_RevokeUser(t *testing.T) {
@@ -310,4 +332,8 @@ REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM "{{name}}";
 REVOKE USAGE ON SCHEMA public FROM "{{name}}";
 
 DROP ROLE IF EXISTS "{{name}}";
+`
+
+const defaultPostgresRenewSQL = `
+ALTER ROLE "{{name}}" VALID UNTIL '{{expiration}}';
 `

--- a/plugins/database/postgresql/postgresql_test.go
+++ b/plugins/database/postgresql/postgresql_test.go
@@ -333,7 +333,3 @@ REVOKE USAGE ON SCHEMA public FROM "{{name}}";
 
 DROP ROLE IF EXISTS "{{name}}";
 `
-
-const defaultPostgresRenewSQL = `
-ALTER ROLE "{{name}}" VALID UNTIL '{{expiration}}';
-`


### PR DESCRIPTION
This is to support a quirk of Redshift that prevents the standard ALTER ROLE from working correctly.

(Related: I want to add the option of adding caps to the generated passwords to meet Redshift's password requirements; but not immediately obvious where to make that configurable)