### PR TITLE
Add OIDC auth backend with tests

### DIFF
--- a/builtin/credential/oidc/backend.go
+++ b/builtin/credential/oidc/backend.go
@@ -1,0 +1,48 @@
+package oidc
+
+import (
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func Factory(conf *logical.BackendConfig) (logical.Backend, error) {
+	return Backend().Setup(conf)
+}
+
+func Backend() *backend {
+	var b backend
+	b.Backend = &framework.Backend{
+		Help: backendHelp,
+
+		PathsSpecial: &logical.Paths{
+			Unauthenticated: []string{
+				"login",
+			},
+		},
+
+		Paths: append([]*framework.Path{
+			pathConfig(&b),
+			pathUsers(&b),
+			pathGroups(&b),
+			pathUsersList(&b),
+			pathGroupsList(&b),
+			pathLogin(&b),
+		}),
+
+		AuthRenew: nil, // explicitly don't support renewal.
+	}
+
+	return &b
+}
+
+type backend struct {
+	*framework.Backend
+}
+
+const backendHelp = `
+The OpenID Connect provider allows Vault to issue Tokens for
+holders of OpenID Connect identity tokens, which are self validating.
+
+Only users that have an explicit mapping of username or group to a policy
+will be granted Tokens.
+`

--- a/builtin/credential/oidc/backend_test.go
+++ b/builtin/credential/oidc/backend_test.go
@@ -1,0 +1,172 @@
+package oidc
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http/httptest"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/jose"
+	oidcutil "github.com/coreos/go-oidc/oidc"
+	"github.com/hashicorp/vault/builtin/credential/oidc/oidctesting"
+	"github.com/hashicorp/vault/helper/logformat"
+	"github.com/hashicorp/vault/logical"
+	logicaltest "github.com/hashicorp/vault/logical/testing"
+	log "github.com/mgutz/logxi/v1"
+)
+
+var (
+	goodClientId       = "myGoodClientId"
+	goodSubjectId      = "DEADBEEF"
+	usernameClaim      = "test_user_claim"
+	groupClaim         = "test_group_claim"
+	defaultLeaseTTLVal = time.Hour * 24
+	maxLeaseTTLVal     = time.Hour * 24 * 32
+)
+
+// oidcProviderHarness starts a small httptest-based OIDC provider for the purpose of tests.
+type oidcProviderHarness struct {
+	tempDir  string
+	provider *oidctesting.OIDCProvider
+	server   *httptest.Server
+}
+
+func NewOidcProviderHarness(t *testing.T) *oidcProviderHarness {
+	var err error
+	h := &oidcProviderHarness{}
+	h.tempDir = os.TempDir()
+	oidctesting.GenerateSelfSignedCert(t, "127.0.0.1", path.Join(h.tempDir, "cert-1"), path.Join(h.tempDir, h.tempDir, "key-1"))
+	h.provider = oidctesting.NewOIDCProvider(t, "")
+	h.server, err = h.provider.ServeTLSWithKeyPair(path.Join(h.tempDir, "cert-1"), path.Join(h.tempDir, h.tempDir, "key-1"))
+	if err != nil {
+		t.Fatalf("failed starting oidc test harness: %v", err)
+	}
+	return h
+}
+
+func (h *oidcProviderHarness) issuerUrl(t *testing.T) string {
+	return h.server.URL
+}
+
+func (h *oidcProviderHarness) genIdentityToken(t *testing.T, username string, groups []string, iat time.Time, exp time.Time) string {
+	claims := oidcutil.NewClaims(h.issuerUrl(t), goodSubjectId, goodClientId, iat, exp)
+	claims.Add(usernameClaim, username)
+	if len(groups) > 0 {
+		claims.Add(groupClaim, groups)
+	}
+	signer := h.provider.PrivKey.Signer()
+	jwt, err := jose.NewSignedJWT(claims, signer)
+	if err != nil {
+		t.Fatalf("Cannot generate token: %v", err)
+	}
+	return jwt.Encode()
+}
+
+func (h *oidcProviderHarness) getCaCertBundle(t *testing.T) string {
+	data, err := ioutil.ReadFile(path.Join(h.tempDir, "cert-1"))
+	if err != nil {
+		t.Fatalf("failed opening CA cert from testdir of harness %v", err)
+	}
+	return string(data)
+}
+
+func (h *oidcProviderHarness) Close() error {
+	h.server.Close()
+	os.RemoveAll(h.tempDir)
+	return nil
+}
+
+func TestBackend_HappyPath_WithGroupName(t *testing.T) {
+	h := NewOidcProviderHarness(t)
+	defer h.Close()
+
+	b, err := Factory(&logical.BackendConfig{
+		Logger: logformat.NewVaultLogger(log.LevelTrace),
+		System: &logical.StaticSystemView{
+			DefaultLeaseTTLVal: defaultLeaseTTLVal,
+			MaxLeaseTTLVal:     maxLeaseTTLVal,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Unable to create backend: %s", err)
+	}
+
+	config_data_good := map[string]interface{}{
+		"issuer_url":       h.issuerUrl(t),
+		"client_ids":       []string{goodClientId},
+		"username_claim":   usernameClaim,
+		"groups_claim":     groupClaim,
+		"issuer_verify_ca": h.getCaCertBundle(t),
+	}
+
+	goodUserName := "myuser@example.com"
+	goodGroupName := "myGroup"
+	goodToken := h.genIdentityToken(t, goodUserName, []string{goodGroupName}, time.Now().Add(-1*time.Hour), time.Now().Add(1*time.Hour))
+	t.Logf("show token: %v", goodToken)
+	//expiredToken := h.genIdentityToken(t, goodUserName, []string{goodGroupName}, time.Now().Add(-1 * time.Hour), time.Now().Add(1 * time.Hour))
+
+	logicaltest.Test(t, logicaltest.TestCase{
+		AcceptanceTest: false,
+		Backend:        b,
+		Steps: []logicaltest.TestStep{
+			testConfigWrite(t, config_data_good),
+			testAccGroups(t, goodGroupName, "somepolicy"),
+			//testLoginWrite(t, "dummytoken", 0, true),
+			testLoginWrite(t, goodToken, 2*time.Hour, false),
+			//testLoginWrite(t, login_data, expectedTTL1.Nanoseconds(), false),
+			//testConfigWrite(t, config_data2),
+			//testLoginWrite(t, login_data, expectedTTL2.Nanoseconds(), false),
+			//testConfigWrite(t, config_data3),
+			//testLoginWrite(t, login_data, 0, true),
+		},
+	})
+}
+
+func testLoginWrite(t *testing.T, token string, expectedTTL time.Duration, expectFail bool) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.UpdateOperation,
+		Path:      "login",
+		ErrorOk:   true,
+		Data:      map[string]interface{}{"token": token},
+		Check: func(resp *logical.Response) error {
+			if resp.IsError() && expectFail {
+				return nil
+			} else if expectFail {
+				return fmt.Errorf("expected failiure")
+			} else if resp.IsError() {
+				return fmt.Errorf("expected to succeed but got %v", resp.Error())
+			}
+			t.Logf("resp.Auth %v", resp.Auth)
+
+			actualTTL := resp.Auth.LeaseOptions.TTL
+			ttlDiff := expectedTTL - actualTTL
+			t.Logf("actualTtl %v expectedTtl %v ttldiff %v", actualTTL, expectedTTL, ttlDiff)
+			if -5*time.Second < ttlDiff && ttlDiff < 5*time.Second { // 5s grace period
+				return fmt.Errorf("TTL mismatched. Expected: %d Actual: %d", expectedTTL, resp.Auth.LeaseOptions.TTL.Nanoseconds())
+			}
+			return nil
+		},
+	}
+}
+
+func testConfigWrite(t *testing.T, d map[string]interface{}) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: logical.UpdateOperation,
+		Path:      "config",
+		Data:      d,
+	}
+}
+
+func testAccGroups(t *testing.T, group string, policies string) logicaltest.TestStep {
+	t.Logf("[testAccGroups] - Registering group %s, policy %s", group, policies)
+	return logicaltest.TestStep{
+		Operation: logical.UpdateOperation,
+		Path:      "groups/" + group,
+		Data: map[string]interface{}{
+			"policies": policies,
+		},
+	}
+}

--- a/builtin/credential/oidc/cli.go
+++ b/builtin/credential/oidc/cli.go
@@ -1,0 +1,58 @@
+package oidc
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/vault/api"
+)
+
+type CLIHandler struct{}
+
+func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (string, error) {
+	mount, ok := m["mount"]
+	if !ok {
+		mount = "oidc"
+	}
+
+	token, ok := m["token"]
+	if !ok {
+		if token = os.Getenv("VAULT_AUTH_OIDC_TOKEN"); token == "" {
+			return "", fmt.Errorf("OpenID Connect (OIDC) token should be provided either as 'value' for 'token' key,\nor via an env var VAULT_AUTH_OIDC_TOKEN")
+		}
+	}
+
+	path := fmt.Sprintf("auth/%s/login", mount)
+	secret, err := c.Logical().Write(path, map[string]interface{}{
+		"token": token,
+	})
+	if err != nil {
+		return "", err
+	}
+	if secret == nil {
+		return "", fmt.Errorf("empty response from credential provider")
+	}
+
+	return secret.Auth.ClientToken, nil
+}
+
+func (h *CLIHandler) Help() string {
+	help := `
+The OpenID Connect credential provider allows you to authenticate with OIDC providers.
+To use it, specify the "token" parameter. The value should be the user's identity
+token for the OIDC provider. Usually you should get a new OIDC identity token with a third
+party CLI tool.
+
+    Example: vault auth -method=oidc token=<token>
+
+Key/Value Pairs:
+
+    mount=oidc      The mountpoint for the OIDC credential provider.
+                      Defaults to "oidc"
+
+    token=<token>     The OIDC identity token for authentication.
+	`
+
+	return strings.TrimSpace(help)
+}

--- a/builtin/credential/oidc/oidctesting/provider.go
+++ b/builtin/credential/oidc/oidctesting/provider.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidctesting
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/jose"
+	"github.com/coreos/go-oidc/key"
+	"github.com/coreos/go-oidc/oidc"
+)
+
+// NewOIDCProvider provides a bare minimum OIDC IdP Server useful for testing.
+func NewOIDCProvider(t *testing.T, issuerPath string) *OIDCProvider {
+	privKey, err := key.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("Cannot create OIDC Provider: %v", err)
+		return nil
+	}
+
+	op := &OIDCProvider{
+		Mux:        http.NewServeMux(),
+		PrivKey:    privKey,
+		issuerPath: issuerPath,
+	}
+
+	op.Mux.HandleFunc(path.Join(issuerPath, "/.well-known/openid-configuration"), op.handleConfig)
+	op.Mux.HandleFunc(path.Join(issuerPath, "/keys"), op.handleKeys)
+
+	return op
+}
+
+type OIDCProvider struct {
+	Mux        *http.ServeMux
+	PCFG       oidc.ProviderConfig
+	PrivKey    *key.PrivateKey
+	issuerPath string
+}
+
+func (op *OIDCProvider) ServeTLSWithKeyPair(cert, key string) (*httptest.Server, error) {
+	srv := httptest.NewUnstartedServer(op.Mux)
+
+	srv.TLS = &tls.Config{Certificates: make([]tls.Certificate, 1)}
+	var err error
+	srv.TLS.Certificates[0], err = tls.LoadX509KeyPair(cert, key)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot load cert/key pair: %v", err)
+	}
+	srv.StartTLS()
+
+	// The issuer's URL is extended by an optional path. This ensures that the plugin can
+	// handle issuers that use a non-root path for discovery (see kubernetes/kubernetes#29749).
+	srv.URL = srv.URL + op.issuerPath
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		return nil, err
+	}
+	pathFor := func(p string) *url.URL {
+		u2 := *u // Shallow copy.
+		u2.Path = path.Join(u2.Path, p)
+		return &u2
+	}
+
+	op.PCFG = oidc.ProviderConfig{
+		Issuer:                  u,
+		AuthEndpoint:            pathFor("/auth"),
+		TokenEndpoint:           pathFor("/token"),
+		KeysEndpoint:            pathFor("/keys"),
+		ResponseTypesSupported:  []string{"code"},
+		SubjectTypesSupported:   []string{"public"},
+		IDTokenSigningAlgValues: []string{"RS256"},
+	}
+	return srv, nil
+}
+
+func (op *OIDCProvider) handleConfig(w http.ResponseWriter, req *http.Request) {
+	b, err := json.Marshal(&op.PCFG)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(b)
+}
+
+func (op *OIDCProvider) handleKeys(w http.ResponseWriter, req *http.Request) {
+	keys := struct {
+		Keys []jose.JWK `json:"keys"`
+	}{
+		Keys: []jose.JWK{op.PrivKey.JWK()},
+	}
+
+	b, err := json.Marshal(keys)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(time.Hour.Seconds())))
+	w.Header().Set("Expires", time.Now().Add(time.Hour).Format(time.RFC1123))
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(b)
+}
+
+// generateSelfSignedCert generates a self-signed cert/key pairs and writes to the certPath/keyPath.
+// This method is mostly identical to crypto.GenerateSelfSignedCert except for the 'IsCA' and 'KeyUsage'
+// in the certificate template. (Maybe we can merge these two methods).
+func GenerateSelfSignedCert(t *testing.T, host, certPath, keyPath string) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("%s@%d", host, time.Now().Unix()),
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24 * 365),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA: true,
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		template.IPAddresses = append(template.IPAddresses, ip)
+	} else {
+		template.DNSNames = append(template.DNSNames, host)
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate cert
+	certBuffer := bytes.Buffer{}
+	if err := pem.Encode(&certBuffer, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate key
+	keyBuffer := bytes.Buffer{}
+	if err := pem.Encode(&keyBuffer, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write cert
+	if err := os.MkdirAll(filepath.Dir(certPath), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(certPath, certBuffer.Bytes(), os.FileMode(0644)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write key
+	if err := os.MkdirAll(filepath.Dir(keyPath), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(keyPath, keyBuffer.Bytes(), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/builtin/credential/oidc/path_config.go
+++ b/builtin/credential/oidc/path_config.go
@@ -1,0 +1,275 @@
+package oidc
+
+import (
+	"fmt"
+	"net/url"
+
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"github.com/coreos/go-oidc"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+	"net/http"
+)
+
+const (
+	defaultUsernameClaim = "sub"
+)
+
+func pathConfig(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: `config`,
+		Fields: map[string]*framework.FieldSchema{
+			"issuer_url": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "OIDC issuer URL. This is typically the base URL (no path) to the discovery URL of the provider.",
+			},
+			"issuer_verify_ca": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "OIDC issuer verification CA. If set, it is a PEM-encoded CA bundle to verify the TLS connections to the OIDC provider. If not provided, system certificates are used.",
+			},
+			"client_ids": &framework.FieldSchema{
+				Type:        framework.TypeCommaStringSlice,
+				Description: "OIDC client IDs that are permittable in identity token's `aud` claims.",
+			},
+			"username_claim": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "The OIDC claim inside the identity token that identifies the username. Defaults to `sub`.",
+				Default:     defaultUsernameClaim,
+			},
+			"groups_claim": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "The OIDC claim inside the identity token that identifies the groups the token is for. This claim must be a list of strings. If unset, no groups mapping will be used.",
+				Default:     "",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation:   b.pathConfigRead,
+			logical.CreateOperation: b.pathConfigWrite,
+			logical.UpdateOperation: b.pathConfigWrite,
+		},
+
+		ExistenceCheck: b.pathConfigExistenceCheck,
+
+		HelpSynopsis: pathConfigHelp,
+	}
+}
+
+// Config returns the configuration for this backend.
+func (b *backend) Config(s logical.Storage) (*ConfigEntry, error) {
+	entry, err := s.Get("config")
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	var result ConfigEntry
+	if entry != nil {
+		if err := entry.DecodeJSON(&result); err != nil {
+			return nil, err
+		}
+	}
+
+	return &result, nil
+}
+
+func (b *backend) pathConfigRead(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+
+	cfg, err := b.Config(req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		return nil, nil
+	}
+
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"issuer_url":       cfg.IssuerUrl,
+			"issuer_verify_ca": cfg.IssuerCABundle,
+			"client_ids":       cfg.ClientIDs,
+			"username_claim":   cfg.UsernameClaim,
+			"groups_claim":     cfg.GroupsClaim,
+		},
+	}
+
+	return resp, nil
+}
+
+func (b *backend) pathConfigWrite(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	cfg, err := b.Config(req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	// Due to the existence check, entry will only be nil if it's a create
+	// operation, so just create a new one
+	if cfg == nil {
+		cfg = &ConfigEntry{}
+	}
+
+	// Parse issuer_url, required.
+	issuerUrlRaw, ok, err := d.GetOkErr("issuer_url")
+	if ok {
+		_, err = url.Parse(issuerUrlRaw.(string))
+		if err != nil {
+			return logical.ErrorResponse(fmt.Sprintf("Error parsing given issuer_url: %s", err)), nil
+		}
+		cfg.IssuerUrl = issuerUrlRaw.(string)
+	} else if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	} else {
+		return logical.ErrorResponse("auth/oidc: missing required config value issuer_url"), nil
+	}
+	// Parse issuer_verify_ca.
+	issuerVerifyCaRaw, ok, err := d.GetOkErr("issuer_verify_ca")
+	if ok {
+		_, err := certPoolFromString(issuerVerifyCaRaw.(string))
+		if err != nil {
+			return logical.ErrorResponse("auth/oidc: failed parsing PEM of issuer_verify_ca: " + err.Error()), nil
+		}
+		cfg.IssuerCABundle = issuerVerifyCaRaw.(string)
+	} else if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+	// Parse client ids, required.
+	clientIdsRaw, ok, err := d.GetOkErr("client_ids")
+	if ok {
+		cfg.ClientIDs = clientIdsRaw.([]string)
+	} else if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	} else if !ok {
+		return logical.ErrorResponse("auth/oidc: missing required config value client_ids"), nil
+	}
+	// Read defaults for claim configs.
+	cfg.UsernameClaim = d.Get("username_claim").(string)
+	cfg.GroupsClaim = d.Get("groups_claim").(string)
+
+	jsonCfg, err := logical.StorageEntryJSON("config", cfg)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+	if err := req.Storage.Put(jsonCfg); err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathConfigExistenceCheck(
+	req *logical.Request, d *framework.FieldData) (bool, error) {
+	cfg, err := b.Config(req.Storage)
+	if err != nil {
+		return false, err
+	}
+
+	return cfg != nil, nil
+}
+
+func (b *backend) oidcProviderForConfig(conf *ConfigEntry) (*oidc.Provider, error) {
+	// TODO(mwitkow): This creates a new Provider each time, making a request to the Discovery URL of the provider. Add caching per config "hash".
+	ctx := context.TODO()
+	if conf.IssuerCABundle != "" {
+		bundles, err := certPoolFromString(conf.IssuerCABundle)
+		if err != nil {
+			return nil, err
+		}
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: bundles,
+			},
+		}
+		httpClient := &http.Client{
+			Transport: transport,
+		}
+		ctx = oidc.ClientContext(ctx, httpClient)
+	}
+
+	return oidc.NewProvider(ctx, conf.IssuerUrl)
+}
+
+func (b *backend) validateAndExtractClaims(cfg *ConfigEntry, rawToken string) (userName string, groups []string, token *oidc.IDToken, err error) {
+	provider, err := b.oidcProviderForConfig(cfg)
+	if err != nil {
+		return "", []string{}, nil, err
+	}
+	if provider == nil {
+		return "", []string{}, nil, errors.New("OIDC provider not configured")
+	}
+	verifier := provider.Verifier(&oidc.Config{SkipClientIDCheck: true}) // note we verify the audience ourselves.
+	idToken, err := verifier.Verify(context.TODO(), rawToken)
+	if err != nil {
+		return "", []string{}, nil, errors.New("OIDC identity token error: " + err.Error())
+	}
+	if !containsAny(idToken.Audience, cfg.ClientIDs) {
+		b.Logger().Info("OIDC token has bad 'aud': %v", idToken.Audience)
+		return "", []string{}, nil, errors.New("OIDC identity token issued for unsupported client ID.")
+	}
+	claims := make(map[string]interface{})
+	if err := idToken.Claims(&claims); err != nil {
+		b.Logger().Warn("OIDC token claims parsing error: %v", err)
+		return "", []string{}, nil, errors.New("OIDC identity token claim parsing error.")
+	}
+	b.Logger().Debug("OIDC claims %v", claims) // TODO(mwitkow): Remove.
+
+	userNameClaim, ok := claims[cfg.UsernameClaim].(string)
+	if !ok {
+		b.Logger().Warn("OIDC token doesn't have username under expected claim. Claims: %v", claims)
+		return "", []string{}, nil, errors.New("OIDC identity token user claim parsing error.")
+	}
+	userName = userNameClaim
+	if cfg.GroupsClaim != "" {
+		groupNameClaim, ok := claims[cfg.GroupsClaim].([]interface{})
+		if !ok {
+			b.Logger().Warn("OIDC token doesn't have group name under expected claim.", "claimName", cfg.GroupsClaim, "allClaims", claims)
+			return "", []string{}, nil, errors.New("OIDC identity token group claim parsing error.")
+		}
+		for _, gInt := range groupNameClaim {
+			g, ok := gInt.(string)
+			if ok {
+				groups = append(groups, g)
+			}
+		}
+	}
+	return userName, groups, idToken, nil
+}
+
+func containsAny(existingValues []string, checkedValues []string) bool {
+	for _, s := range existingValues {
+		for _, c := range checkedValues {
+			if s == c {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func certPoolFromString(caBundle string) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	ok := pool.AppendCertsFromPEM([]byte(caBundle))
+	if !ok {
+		return nil, errors.New("failed parsing CA bundle")
+	}
+	return pool, nil
+}
+
+// ConfigEntry for OIDC configuration.
+type ConfigEntry struct {
+	IssuerUrl      string   `json:"issuer_url"`
+	IssuerCABundle string   `json:"issuer_verify_ca"`
+	ClientIDs      []string `json:"client_ids"`
+	UsernameClaim  string   `json:"username_claim"`
+	GroupsClaim    string   `json:"group_claim"`
+}
+
+// TODO(mwitkow): Update this.
+const pathConfigHelp = `
+This endpoint allows you to configure the OpenID Connect provider.
+`

--- a/builtin/credential/oidc/path_groups.go
+++ b/builtin/credential/oidc/path_groups.go
@@ -1,0 +1,142 @@
+package oidc
+
+import (
+	"github.com/hashicorp/vault/helper/policyutil"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathGroupsList(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "groups/?$",
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ListOperation: b.pathGroupList,
+		},
+
+		HelpSynopsis:    pathGroupHelpSyn,
+		HelpDescription: pathGroupHelpDesc,
+	}
+}
+
+func pathGroups(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: `groups/(?P<name>.+)`,
+		Fields: map[string]*framework.FieldSchema{
+			"name": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Name of the group inside the group claim.",
+			},
+			"policies": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Comma-separated list of policies associated to the group.",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.DeleteOperation: b.pathGroupDelete,
+			logical.ReadOperation:   b.pathGroupRead,
+			logical.UpdateOperation: b.pathGroupWrite,
+		},
+
+		HelpSynopsis:    pathGroupHelpSyn,
+		HelpDescription: pathGroupHelpDesc,
+	}
+}
+
+func (b *backend) Group(s logical.Storage, n string) (*GroupEntry, error) {
+	entry, err := s.Get("group/" + n)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	var result GroupEntry
+	if err := entry.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (b *backend) pathGroupDelete(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	err := req.Storage.Delete("group/" + name)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathGroupRead(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	group, err := b.Group(req.Storage, name)
+	if err != nil {
+		return nil, err
+	}
+	if group == nil {
+		return nil, nil
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"policies": group.Policies,
+		},
+	}, nil
+}
+
+func (b *backend) pathGroupWrite(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	entry, err := logical.StorageEntryJSON("group/"+name, &GroupEntry{
+		Policies: policyutil.ParsePolicies(d.Get("policies").(string)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Storage.Put(entry); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathGroupList(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	groups, err := req.Storage.List("group/")
+	if err != nil {
+		return nil, err
+	}
+	return logical.ListResponse(groups), nil
+}
+
+type GroupEntry struct {
+	Policies []string
+}
+
+const pathGroupHelpSyn = `
+Manage users allowed to authenticate.
+`
+
+const pathGroupHelpDesc = `
+This endpoint allows you to create, read, update, and delete configuration
+for OpenID group claims that are allowed to authenticate, and associate policies to
+them.
+`

--- a/builtin/credential/oidc/path_login.go
+++ b/builtin/credential/oidc/path_login.go
@@ -1,0 +1,124 @@
+package oidc
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+	"time"
+)
+
+func pathLogin(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: `login`,
+		Fields: map[string]*framework.FieldSchema{
+			"token": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "OIDC Identity Token to be used for login.",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.UpdateOperation: b.pathLogin,
+		},
+
+		HelpSynopsis:    pathLoginSyn,
+		HelpDescription: pathLoginDesc,
+	}
+}
+
+func (b *backend) pathLogin(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	token := d.Get("token").(string)
+
+	config, err := b.Config(req.Storage)
+	if err != nil {
+		return logical.ErrorResponse("OIDC backend not configured"), nil
+	}
+
+	tokenUsername, tokenGroups, tokenStruct, err := b.validateAndExtractClaims(config, token)
+	if err != nil {
+		b.Logger().Info("auth/oidc: IdToken verification failed", "error", err)
+		return logical.ErrorResponse("OIDC backend bad token"), nil
+	}
+	if b.Logger().IsDebug() {
+		b.Logger().Debug("auth/oidc: IdToken verified", "tokenUsername", tokenUsername, "tokenGroups", tokenGroups)
+	}
+
+	loginResponse := &logical.Response{
+		Data: map[string]interface{}{},
+	}
+	if len(tokenGroups) == 0 {
+		errString := fmt.Sprintf(
+			"no identity token groups found; only policies from user-defined groups available")
+		loginResponse.AddWarning(errString)
+	}
+
+	var allGroups []string
+	// Import the custom added tokenGroups from okta backend
+	user, err := b.User(req.Storage, tokenUsername)
+	if err == nil && user != nil && user.Groups != nil {
+		if b.Logger().IsDebug() {
+			b.Logger().Debug("auth/oidc: adding local user groups", "userGroups", user.Groups)
+		}
+		allGroups = append(allGroups, user.Groups...)
+	}
+	// Merge local and Okta tokenGroups
+	allGroups = append(allGroups, tokenGroups...)
+
+	// Retrieve policies
+	var policies []string
+	for _, groupName := range allGroups {
+		group, err := b.Group(req.Storage, groupName)
+		if err == nil && group != nil && group.Policies != nil {
+			policies = append(policies, group.Policies...)
+		}
+	}
+	// Merge local Policies into Okta Policies
+	if user != nil && user.Policies != nil {
+		policies = append(policies, user.Policies...)
+	}
+
+	if len(policies) == 0 {
+		errStr := "user is not a member of any authorized policy"
+		if len(loginResponse.Warnings()) > 0 {
+			errStr = fmt.Sprintf("%s; additionally, %s", errStr, loginResponse.Warnings()[0])
+		}
+
+		loginResponse.Data["error"] = errStr
+		return loginResponse, nil
+	}
+	// TODO(mwitkow): Copy pasted from okta, don't think it is correct
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(policies)
+	loginResponse.Auth = &logical.Auth{
+		Policies: policies,
+		Metadata: map[string]string{
+			"username":        tokenUsername,
+			"token_nonce":     tokenStruct.Nonce,
+			"token_issuer":    tokenStruct.Issuer,
+			"token_issued_at": fmt.Sprintf("%v", tokenStruct.IssuedAt),
+			"policies":        strings.Join(policies, ","),
+		},
+		DisplayName: tokenUsername,
+		LeaseOptions: logical.LeaseOptions{
+			TTL:       tokenStruct.Expiry.Sub(time.Now()),
+			Renewable: false,
+		},
+	}
+	b.Logger().Debug("Returning login response", "ttl_set", loginResponse.Auth.LeaseOptions.TTL)
+	return loginResponse, nil
+}
+
+const pathLoginSyn = `
+Log in with an OIDC identity token.
+`
+
+const pathLoginDesc = `
+This endpoint authenticates a user with an OIDC identity token.
+`

--- a/builtin/credential/oidc/path_users.go
+++ b/builtin/credential/oidc/path_users.go
@@ -1,0 +1,168 @@
+package oidc
+
+import (
+	"strings"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func pathUsersList(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "users/?$",
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ListOperation: b.pathUserList,
+		},
+
+		HelpSynopsis:    pathUserHelpSyn,
+		HelpDescription: pathUserHelpDesc,
+	}
+}
+
+func pathUsers(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: `users/(?P<name>.+)`,
+		Fields: map[string]*framework.FieldSchema{
+			"name": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Name of the user according to the user group name.",
+			},
+
+			"groups": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Comma-separated list of groups associated with the user.",
+			},
+
+			"policies": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Comma-separated list of policies associated with the user.",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.DeleteOperation: b.pathUserDelete,
+			logical.ReadOperation:   b.pathUserRead,
+			logical.UpdateOperation: b.pathUserWrite,
+		},
+
+		HelpSynopsis:    pathUserHelpSyn,
+		HelpDescription: pathUserHelpDesc,
+	}
+}
+
+func (b *backend) User(s logical.Storage, n string) (*UserEntry, error) {
+	entry, err := s.Get("user/" + n)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	var result UserEntry
+	if err := entry.DecodeJSON(&result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (b *backend) pathUserDelete(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	err := req.Storage.Delete("user/" + name)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathUserRead(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	user, err := b.User(req.Storage, name)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, nil
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"groups":   user.Groups,
+			"policies": user.Policies,
+		},
+	}, nil
+}
+
+func (b *backend) pathUserWrite(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+	if len(name) == 0 {
+		return logical.ErrorResponse("Error empty name"), nil
+	}
+
+	groups := strings.Split(d.Get("groups").(string), ",")
+	for i, g := range groups {
+		groups[i] = strings.TrimSpace(g)
+	}
+
+	policies := strings.Split(d.Get("policies").(string), ",")
+	for i, p := range policies {
+		policies[i] = strings.TrimSpace(p)
+	}
+
+	// Store it
+	entry, err := logical.StorageEntryJSON("user/"+name, &UserEntry{
+		Groups:   groups,
+		Policies: policies,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Storage.Put(entry); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathUserList(
+	req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	users, err := req.Storage.List("user/")
+	if err != nil {
+		return nil, err
+	}
+	return logical.ListResponse(users), nil
+}
+
+type UserEntry struct {
+	Groups   []string
+	Policies []string
+}
+
+// TODO(mwitkow): Fix up the names.
+const pathUserHelpSyn = `
+Manage optional groups for individual users allowed to authenticate.
+`
+
+const pathUserHelpDesc = `
+This endpoint allows you to create, read, update, and delete additional
+configuration for OIDC users that are allowed to authenticate, in
+particular associating additional groups to them.
+
+By default, all users (identified by the username_claim) with valid OIDC
+identity tokens can log in, as long as there is a policy assigned to them
+directly, or to groups they're a member of.
+`


### PR DESCRIPTION
This PR adds support for a generic OIDC backend along the lines of the original [design document](https://docs.google.com/document/d/1saxtZMuh3OYilpa0BvP5_Ien_6U5bqdqOUj5AATdTtc/edit?usp=sharing) discussed in https://github.com/hashicorp/vault/issues/2525.

The code relies heavily on [go-oidc](https://github.com/coreos/go-oidc), the same OIDC client library used in Kubernetes. However, it copies the "test provider" from Kubernetes, something that needs to be addressed in https://github.com/coreos/go-oidc/issues/150 before this can be merged.

The code has been verified to work against [CoreOS Dex  ](https://github.com/coreos/dex) and Google OIDC endpoints (with manual policies).

The PR has rundimentary tests, but as this is the first time I'm trying to wrap my head around Vault test harness, I'm probably doing something wrong.

Still todo before this can be merged:
 [ ] use upstream "test provider" https://github.com/coreos/go-oidc/issues/150
 [ ] add tests for expired tokens and bad CA certs
 [ ] add README.md docs

@ericchiang for OpenID security review
@jefferai as a follow up from discussions in #2525