### PR TITLE
Change split on instance profile name

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -472,7 +472,7 @@ func (b *backend) verifyInstanceMeetsRoleRequirements(
 
 		// Extract out the instance profile name from the instance
 		// profile ARN
-		iamInstanceProfileARNSlice := strings.SplitAfter(iamInstanceProfileARN, ":instance-profile/")
+		iamInstanceProfileARNSlice := strings.SplitAfter(iamInstanceProfileARN, "/")
 		iamInstanceProfileName := iamInstanceProfileARNSlice[len(iamInstanceProfileARNSlice)-1]
 
 		if iamInstanceProfileName == "" {


### PR DESCRIPTION
Previously this would split on the Instance profile ARN on :instance_profile/
This changed the split to /, so that the line below the change, can pull only the short name of the Instance Profile instead of the instance profile name with path.

e.g. for the ARN:  arn:aws:iam::111111111111:instance-profile/some/name

Previously:
iam:GetInstanceProfile would be sent "some/name"

Now:

iam:GetInstanceProfile is sent "name".

relates to #2729 