### PR TITLE
Fixed bug where OpenStack project name could only be provided via the 'project' attribute

### DIFF
--- a/physical/swift.go
+++ b/physical/swift.go
@@ -30,6 +30,8 @@ type SwiftBackend struct {
 // from the environment.
 func newSwiftBackend(conf map[string]string, logger log.Logger) (Backend, error) {
 
+	var ok bool
+
 	username := os.Getenv("OS_USERNAME")
 	if username == "" {
 		username = conf["username"]
@@ -60,11 +62,9 @@ func newSwiftBackend(conf map[string]string, logger log.Logger) (Backend, error)
 	}
 	project := os.Getenv("OS_PROJECT_NAME")
 	if project == "" {
-		project = conf["project"]
-
-		if project == "" {
+		if project, ok = conf["project"]; !ok {
 			// Check for KeyStone naming prior to V3
-			project := os.Getenv("OS_TENANT_NAME")
+			project = os.Getenv("OS_TENANT_NAME")
 			if project == "" {
 				project = conf["tenant"]
 			}


### PR DESCRIPTION
To enable Keystone v3 legacy naming it was decided to add logic to read OS environment variables using the old naming. The logic to fall back to the old names was broken. This pull request is to fix it.