### PR TITLE
Use the oauth2 context ability to specify a clean http client.

### DIFF
--- a/builtin/credential/github/backend.go
+++ b/builtin/credential/github/backend.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"context"
+
 	"github.com/google/go-github/github"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/vault/logical"
@@ -63,7 +65,8 @@ type backend struct {
 func (b *backend) Client(token string) (*github.Client, error) {
 	tc := cleanhttp.DefaultClient()
 	if token != "" {
-		tc = oauth2.NewClient(oauth2.NoContext, &tokenSource{Value: token})
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, tc)
+		tc = oauth2.NewClient(ctx, &tokenSource{Value: token})
 	}
 
 	return github.NewClient(tc), nil

--- a/builtin/credential/github/backend_test.go
+++ b/builtin/credential/github/backend_test.go
@@ -48,9 +48,8 @@ func TestBackend_Config(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		AcceptanceTest: true,
-		PreCheck:       func() { testAccPreCheck(t) },
-		Backend:        b,
+		PreCheck: func() { testAccPreCheck(t) },
+		Backend:  b,
 		Steps: []logicaltest.TestStep{
 			testConfigWrite(t, config_data1),
 			testLoginWrite(t, login_data, expectedTTL1.Nanoseconds(), false),
@@ -105,9 +104,8 @@ func TestBackend_basic(t *testing.T) {
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{
-		AcceptanceTest: true,
-		PreCheck:       func() { testAccPreCheck(t) },
-		Backend:        b,
+		PreCheck: func() { testAccPreCheck(t) },
+		Backend:  b,
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t, false),
 			testAccMap(t, "default", "fakepol"),
@@ -131,15 +129,15 @@ func TestBackend_basic(t *testing.T) {
 
 func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("GITHUB_TOKEN"); v == "" {
-		t.Fatal("GITHUB_TOKEN must be set for acceptance tests")
+		t.Skip("GITHUB_TOKEN must be set for acceptance tests")
 	}
 
 	if v := os.Getenv("GITHUB_ORG"); v == "" {
-		t.Fatal("GITHUB_ORG must be set for acceptance tests")
+		t.Skip("GITHUB_ORG must be set for acceptance tests")
 	}
 
 	if v := os.Getenv("GITHUB_BASEURL"); v == "" {
-		t.Fatal("GITHUB_BASEURL must be set for acceptance tests (use 'https://api.github.com' if you don't know what you're doing)")
+		t.Skip("GITHUB_BASEURL must be set for acceptance tests (use 'https://api.github.com' if you don't know what you're doing)")
 	}
 }
 


### PR DESCRIPTION
Hopefully fixes #2793