### PR TITLE
Check if there's a bound iam arn when renewing

### DIFF
--- a/website/source/docs/auth/aws.html.md
+++ b/website/source/docs/auth/aws.html.md
@@ -1413,7 +1413,9 @@ The response will be in JSON. For example:
         When set, instructs Vault to turn on inferencing. The only current valid
         value is "ec2_instance" instructing Vault to infer that the role comes
         from an EC2 instance in an IAM instance profile. This only applies to
-        the iam auth method.
+        the iam auth method. If you set this on an existing role where it had
+        not previously been set, tokens that had been created prior will not be
+        renewable; clients will need to get a new token.
       </li>
     </ul>
     <ul>


### PR DESCRIPTION
Previously, the renew method would ALWAYS check to ensure the
authenticated IAM principal ARN matched the bound ARN.  However, there
is a valid use case in which no bound_iam_principal_arn is specified and
all bindings are done through inferencing. When a role is configured
like this, clients won't be able to renew their token because of the
check.

This now checks to ensure that the bound_iam_principal_arn is not empty
before requriing that it match the originally authenticated client.

Fixes #2781