### PR TITLE
Fix link to mongodb database plugin docs

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -226,7 +226,7 @@
                 <a href="/docs/secrets/databases/cassandra.html">Cassandra</a>
               </li>
               <li<%= sidebar_current("docs-secrets-databases-mongodb") %>>
-                <a href="/docs/secrets/databases/mysql-maria.html">MongoDB</a>
+                <a href="/docs/secrets/databases/mongodb.html">MongoDB</a>
               </li>
               <li<%= sidebar_current("docs-secrets-databases-mssql") %>>
                 <a href="/docs/secrets/databases/mssql.html">MSSQL</a>


### PR DESCRIPTION
Fixing a bad link for the new MongoDB database plugin docs. 