### PR TITLE
Add notes about deprecated database backends.

### DIFF
--- a/website/source/api/secret/cassandra/index.html.md
+++ b/website/source/api/secret/cassandra/index.html.md
@@ -8,6 +8,11 @@ description: |-
 
 # Cassandra Secret Backend HTTP API
 
+~> **Deprecation Note:** This backend is deprecated in favor of the
+combined databases backend added in v0.7.1. See the API documentation for
+the new implementation of this backend at
+[Cassandra Database Plugin HTTP API](/api/secret/databases/cassandra.html).
+
 This is the API documentation for the Vault Cassandra secret backend. For
 general information about the usage and operation of the Cassandra backend,
 please see the

--- a/website/source/api/secret/mongodb/index.html.md
+++ b/website/source/api/secret/mongodb/index.html.md
@@ -8,6 +8,11 @@ description: |-
 
 # MongoDB Secret Backend HTTP API
 
+~> **Deprecation Note:** This backend is deprecated in favor of the
+combined databases backend added in v0.7.1. See the API documentation for
+the new implementation of this backend at
+[MongoDB Database Plugin HTTP API](/api/secret/databases/mongodb.html).
+
 This is the API documentation for the Vault MongoDB secret backend. For general
 information about the usage and operation of the MongoDB backend, please see
 the [Vault MongoDB backend documentation](/docs/secrets/mongodb/index.html).

--- a/website/source/api/secret/mssql/index.html.md
+++ b/website/source/api/secret/mssql/index.html.md
@@ -8,6 +8,11 @@ description: |-
 
 # MSSQL Secret Backend HTTP API
 
+~> **Deprecation Note:** This backend is deprecated in favor of the
+combined databases backend added in v0.7.1. See the API documentation for
+the new implementation of this backend at
+[MSSQL Database Plugin HTTP API](/api/secret/databases/mssql.html).
+
 This is the API documentation for the Vault MSSQL secret backend. For general
 information about the usage and operation of the MSSQL backend, please see
 the [Vault MSSQL backend documentation](/docs/secrets/mssql/index.html).

--- a/website/source/api/secret/mysql/index.html.md
+++ b/website/source/api/secret/mysql/index.html.md
@@ -8,6 +8,11 @@ description: |-
 
 # MySQL Secret Backend HTTP API
 
+~> **Deprecation Note:** This backend is deprecated in favor of the
+combined databases backend added in v0.7.1. See the API documentation for
+the new implementation of this backend at
+[MySQL/MariaDB Database Plugin HTTP API](/api/secret/databases/mysql-maria.html).
+
 This is the API documentation for the Vault MySQL secret backend. For general
 information about the usage and operation of the MySQL backend, please see
 the [Vault MySQL backend documentation](/docs/secrets/mysql/index.html).

--- a/website/source/api/secret/postgresql/index.html.md
+++ b/website/source/api/secret/postgresql/index.html.md
@@ -8,6 +8,11 @@ description: |-
 
 # PostgreSQL Secret Backend HTTP API
 
+~> **Deprecation Note:** This backend is deprecated in favor of the
+combined databases backend added in v0.7.1. See the API documentation for
+the new implementation of this backend at
+[PostgreSQL Database Plugin HTTP API](/api/secret/databases/postgresql.html).
+
 This is the API documentation for the Vault PostgreSQL secret backend. For
 general information about the usage and operation of the PostgreSQL backend,
 please see the

--- a/website/source/docs/secrets/cassandra/index.html.md
+++ b/website/source/docs/secrets/cassandra/index.html.md
@@ -10,6 +10,11 @@ description: |-
 
 Name: `cassandra`
 
+~> **Deprecation Note:** This backend is deprecated in favor of the
+combined databases backend added in v0.7.1. See the documentation for
+the new implementation of this backend at
+[Cassandra Database Plugin](/docs/secrets/databases/cassandra.html).
+
 The Cassandra secret backend for Vault generates database credentials
 dynamically based on configured roles. This means that services that need
 to access a database no longer need to hardcode credentials: they can request

--- a/website/source/docs/secrets/mongodb/index.html.md
+++ b/website/source/docs/secrets/mongodb/index.html.md
@@ -10,6 +10,11 @@ description: |-
 
 Name: `mongodb`
 
+~> **Deprecation Note:** This backend is deprecated in favor of the
+combined databases backend added in v0.7.1. See the documentation for
+the new implementation of this backend at
+[MongoDB Database Plugin](/docs/secrets/databases/mongodb.html).
+
 The `mongodb` secret backend for Vault generates MongoDB database credentials
 dynamically based on configured roles. This means that services that need
 to access a MongoDB database no longer need to hard-code credentials: they

--- a/website/source/docs/secrets/mssql/index.html.md
+++ b/website/source/docs/secrets/mssql/index.html.md
@@ -10,6 +10,11 @@ description: |-
 
 Name: `mssql`
 
+~> **Deprecation Note:** This backend is deprecated in favor of the
+combined databases backend added in v0.7.1. See the documentation for
+the new implementation of this backend at
+[MSSQL Database Plugin](/docs/secrets/databases/mssql.html).
+
 The MSSQL secret backend for Vault generates database credentials
 dynamically based on configured roles. This means that services that need
 to access a database no longer need to hardcode credentials: they can request

--- a/website/source/docs/secrets/mysql/index.html.md
+++ b/website/source/docs/secrets/mysql/index.html.md
@@ -10,6 +10,11 @@ description: |-
 
 Name: `mysql`
 
+~> **Deprecation Note:** This backend is deprecated in favor of the
+combined databases backend added in v0.7.1. See the documentation for
+the new implementation of this backend at
+[MySQL/MariaDB Database Plugin](/docs/secrets/databases/mysql-maria.html).
+
 The MySQL secret backend for Vault generates database credentials
 dynamically based on configured roles. This means that services that need
 to access a database no longer need to hardcode credentials: they can request

--- a/website/source/docs/secrets/postgresql/index.html.md
+++ b/website/source/docs/secrets/postgresql/index.html.md
@@ -10,6 +10,11 @@ description: |-
 
 Name: `postgresql`
 
+~> **Deprecation Note:** This backend is deprecated in favor of the
+combined databases backend added in v0.7.1. See the documentation for
+the new implementation of this backend at
+[PostgreSQL Database Plugin](/docs/secrets/databases/postgresql.html).
+
 The PostgreSQL secret backend for Vault generates database credentials
 dynamically based on configured roles. This means that services that need
 to access a database no longer need to hardcode credentials: they can request


### PR DESCRIPTION
Users have been confused by the _(Deprecated)_ note on the database backend. This PR adds a note at the top of the pages of the deprecated backends pointing users to the new implementation's page.