### PR TITLE
Adding some visual separation for parameters

### DIFF
--- a/website/source/assets/stylesheets/application.scss
+++ b/website/source/assets/stylesheets/application.scss
@@ -35,3 +35,21 @@
 
 // Demo
 @import '_demo';
+
+
+// Docs - visual separation for parameter names and flags
+span.param {
+    font-weight: 800;
+}
+span.param:after {
+    content: ":";
+}
+span.param-flags {
+    font-style: italic;
+}
+span.param-flags:before {
+    content: "(";
+}
+span.param-flags:after {
+    content: ")";
+}


### PR DESCRIPTION
Currently on the Documentation pages when parameters are listed, there is no visual separation between the parameter names, flags, and descriptions. This should make it a bit easier for humans to read.