### PR TITLE
Add callouts for deprecations and beta

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -207,10 +207,6 @@
             <a href="/docs/secrets/aws/index.html">AWS</a>
           </li>
 
-          <li<%= sidebar_current("docs-secrets-cassandra") %>>
-            <a href="/docs/secrets/cassandra/index.html">Cassandra (Deprecated)</a>
-          </li>
-
           <li<%= sidebar_current("docs-secrets-consul") %>>
             <a href="/docs/secrets/consul/index.html">Consul</a>
           </li>
@@ -220,7 +216,7 @@
           </li>
 
           <li<%= sidebar_current("docs-secrets-databases") %>>
-            <a href="/docs/secrets/databases/index.html">Databases (Beta)</a>
+            <a href="/docs/secrets/databases/index.html">Databases <sup>BETA</sup></a>
             <ul class="nav">
               <li<%= sidebar_current("docs-secrets-databases-cassandra") %>>
                 <a href="/docs/secrets/databases/cassandra.html">Cassandra</a>
@@ -247,24 +243,8 @@
             <a href="/docs/secrets/generic/index.html">Generic</a>
           </li>
 
-          <li<%= sidebar_current("docs-secrets-mongodb") %>>
-            <a href="/docs/secrets/mongodb/index.html">MongoDB (Deprecated)</a>
-          </li>
-
-          <li<%= sidebar_current("docs-secrets-mssql") %>>
-            <a href="/docs/secrets/mssql/index.html">MSSQL (Deprecated)</a>
-          </li>
-
-          <li<%= sidebar_current("docs-secrets-mysql") %>>
-            <a href="/docs/secrets/mysql/index.html">MySQL (Deprecated)</a>
-          </li>
-
           <li<%= sidebar_current("docs-secrets-pki") %>>
             <a href="/docs/secrets/pki/index.html">PKI (Certificates)</a>
-          </li>
-
-          <li<%= sidebar_current("docs-secrets-postgresql") %>>
-            <a href="/docs/secrets/postgresql/index.html">PostgreSQL (Deprecated)</a>
           </li>
 
           <li<%= sidebar_current("docs-secrets-rabbitmq") %>>
@@ -285,6 +265,28 @@
 
           <li<%= sidebar_current("docs-secrets-custom") %>>
             <a href="/docs/secrets/custom.html">Custom</a>
+          </li>
+
+          <hr>
+
+          <li<%= sidebar_current("docs-secrets-cassandra") %>>
+            <a href="/docs/secrets/cassandra/index.html">Cassandra <sup>DEPRECATED</sup></a>
+          </li>
+
+          <li<%= sidebar_current("docs-secrets-mongodb") %>>
+            <a href="/docs/secrets/mongodb/index.html">MongoDB <sup>DEPRECATED</sup></a>
+          </li>
+
+          <li<%= sidebar_current("docs-secrets-mssql") %>>
+            <a href="/docs/secrets/mssql/index.html">MSSQL <sup>DEPRECATED</sup></a>
+          </li>
+
+          <li<%= sidebar_current("docs-secrets-mysql") %>>
+            <a href="/docs/secrets/mysql/index.html">MySQL <sup>DEPRECATED</sup></a>
+          </li>
+
+          <li<%= sidebar_current("docs-secrets-postgresql") %>>
+            <a href="/docs/secrets/postgresql/index.html">PostgreSQL <sup>DEPRECATED</sup></a>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
This makes the sidebar emphasize the deprecated database backends more.

<img width="247" alt="screen shot 2017-06-14 at 7 56 00 am" src="https://user-images.githubusercontent.com/408570/27130985-ca777d30-50d6-11e7-8415-1f9aa6106bad.png">
