### PR TITLE
reverting client changes in #2856

### DIFF
--- a/api/sys_lease.go
+++ b/api/sys_lease.go
@@ -1,7 +1,7 @@
 package api
 
 func (c *Sys) Renew(id string, increment int) (*Secret, error) {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/renew")
+	r := c.c.NewRequest("PUT", "/v1/sys/renew")
 
 	body := map[string]interface{}{
 		"increment": increment,
@@ -21,7 +21,7 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 }
 
 func (c *Sys) Revoke(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke/"+id)
+	r := c.c.NewRequest("PUT", "/v1/sys/revoke/"+id)
 	resp, err := c.c.RawRequest(r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -30,7 +30,7 @@ func (c *Sys) Revoke(id string) error {
 }
 
 func (c *Sys) RevokePrefix(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-prefix/"+id)
+	r := c.c.NewRequest("PUT", "/v1/sys/revoke-prefix/"+id)
 	resp, err := c.c.RawRequest(r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -39,7 +39,7 @@ func (c *Sys) RevokePrefix(id string) error {
 }
 
 func (c *Sys) RevokeForce(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-force/"+id)
+	r := c.c.NewRequest("PUT", "/v1/sys/revoke-force/"+id)
 	resp, err := c.c.RawRequest(r)
 	if err == nil {
 		defer resp.Body.Close()


### PR DESCRIPTION
The CLI/client version may be different than the server version.  In order to maintain backwards compatibility with the CLI, hold off on making this client change.  Reverting #2856.