### PR TITLE
WIP: PKI-related API calls

### DIFF
--- a/api/pki.go
+++ b/api/pki.go
@@ -15,18 +15,6 @@ type Pki struct {
 	path string
 }
 
-type certList struct {
-	pki           *Pki
-	serialNumbers []SerialNumber
-}
-
-type CertLister interface {
-	Count() int
-	Next() (*x509.Certificate, error)
-	All(threads int) ([]*x509.Certificate, error)
-	SerialNumbers() []SerialNumber
-}
-
 // Pki is used to return the client for PKI-related API calls.
 func (c *Client) Pki(mountPoint string) *Pki {
 	return &Pki{c: c, path: mountPoint}
@@ -78,36 +66,4 @@ func (pki *Pki) Cert(serial SerialNumber) (*x509.Certificate, error) {
 		return &x509.Certificate{}, err
 	}
 	return cert, nil
-}
-
-func (pki *Pki) List() (CertLister, error) {
-	path := fmt.Sprintf("/v1/%s/certs", pki.path)
-	r := pki.c.NewRequest("LIST", path)
-	resp, err := pki.c.RawRequest(r)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	secret, err := ParseSecret(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	keyInterfaces := secret.Data["keys"].([]interface{})
-	serials := make([]SerialNumber, len(keyInterfaces))
-	for i, v := range keyInterfaces {
-		s := v.(string)
-		serials[i] = SerialNumber(s)
-	}
-
-	return &certList{pki, serials}, nil
-}
-
-func (cl *certList) Count() int {
-	return len(cl.serialNumbers)
-}
-
-func (cl *certList) SerialNumbers() []SerialNumber {
-	return cl.serialNumbers
 }

--- a/api/pki.go
+++ b/api/pki.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+)
+
+type SerialNumber string
+
+// Pki is used to perform PKI-related operations on Vault.
+type Pki struct {
+	c    *Client
+	path string
+}
+
+// Pki is used to return the client for PKI-related API calls.
+func (c *Client) Pki(mountPoint string) *Pki {
+	return &Pki{c: c, path: mountPoint}
+}
+
+func (pki *Pki) Ca() (*x509.Certificate, error) {
+	r := pki.c.NewRequest("GET", fmt.Sprintf("/v1/%s/ca", pki.path))
+	resp, err := pki.c.RawRequest(r)
+	if err != nil {
+		return &x509.Certificate{}, err
+	}
+	defer resp.Body.Close()
+
+	certBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return &x509.Certificate{}, err
+	}
+
+	cert, err := x509.ParseCertificate(certBody)
+	if err != nil {
+		return &x509.Certificate{}, err
+	}
+	return cert, nil
+}
+
+func (pki *Pki) Cert(serial SerialNumber) (*x509.Certificate, error) {
+	path := fmt.Sprintf("/v1/%s/cert/%s", pki.path, serial)
+	r := pki.c.NewRequest("GET", path)
+	resp, err := pki.c.RawRequest(r)
+	if err != nil {
+		return &x509.Certificate{}, err
+	}
+	defer resp.Body.Close()
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return &x509.Certificate{}, err
+	}
+	certPem := secret.Data["certificate"]
+	certString := certPem.(string)
+	certBytes := []byte(certString)
+
+	// We don't need "rest" here because the response contains only one Cert.
+	// Also there is no need to check for block.Type, because it will always
+	// be a pem "CERTIFICATE" type
+	block, _ := pem.Decode(certBytes)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return &x509.Certificate{}, err
+	}
+	return cert, nil
+}

--- a/api/pki.go
+++ b/api/pki.go
@@ -23,9 +23,7 @@ type certList struct {
 type CertLister interface {
 	Count() int
 	Next() (*x509.Certificate, error)
-	All() ([]*x509.Certificate, error)
-	AllParallel(threads int) ([]*x509.Certificate, error)
-	Channel() (chan *x509.Certificate, error)
+	All(threads int) ([]*x509.Certificate, error)
 	SerialNumbers() []SerialNumber
 }
 
@@ -109,6 +107,7 @@ func (pki *Pki) List() (CertLister, error) {
 func (cl *certList) Count() int {
 	return len(cl.serialNumbers)
 }
+
 func (cl *certList) SerialNumbers() []SerialNumber {
 	return cl.serialNumbers
 }

--- a/api/pki_list.go
+++ b/api/pki_list.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"crypto/x509"
+	"fmt"
+)
+
+type certList struct {
+	pki           *Pki
+	serialNumbers []SerialNumber
+}
+
+type CertLister interface {
+	Count() int
+	Next() (*x509.Certificate, error)
+	All(threads int) ([]*x509.Certificate, error)
+	SerialNumbers() []SerialNumber
+}
+
+func (pki *Pki) List() (CertLister, error) {
+	path := fmt.Sprintf("/v1/%s/certs", pki.path)
+	r := pki.c.NewRequest("LIST", path)
+	resp, err := pki.c.RawRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	keyInterfaces := secret.Data["keys"].([]interface{})
+	serials := make([]SerialNumber, len(keyInterfaces))
+	for i, v := range keyInterfaces {
+		s := v.(string)
+		serials[i] = SerialNumber(s)
+	}
+
+	return &certList{pki, serials}, nil
+}
+
+func (cl *certList) Count() int {
+	return len(cl.serialNumbers)
+}
+
+func (cl *certList) SerialNumbers() []SerialNumber {
+	return cl.serialNumbers
+}


### PR DESCRIPTION
Hi!

This is a work in progress, I just wanted to let you guys know I will implement this.
I was thinking about the right way to contribute, I decided I make a pull request early on, so you can comment on my progress or fix if I do something stupid 😄  or you can tell me if you won't merge when it's ready or if you would like a different direction or something. I will often rebase, amend and stuff like that, so the commits themselves will change.
I will consider this feature complete when I implemented every single [pki related API call](https://www.vaultproject.io/api/secret/pki/index.html) and made the `/cert/` endpoint capable of serving certificates in DER format to make the client efficient (that way, it don't have to parse the PEM).
This might take me months or more because I don't have much time, but feel free to commit and comment!

The first design decision: do we need the `revocation_time` field? I implemented the client in a way that it only deals with the certificate and gives back stdlib `x509.Certificate`. When I implement DER format, this field will not be available, or the client have to make another request, which makes DER formatting pointless, or we can give back in a header along with the binary data.