### PR TITLE
Add API helper for renewing a secret

### DIFF
--- a/api/api_integration_test.go
+++ b/api/api_integration_test.go
@@ -71,7 +71,7 @@ func testVaultServerBackends(t testing.TB, backends map[string]logical.Factory) 
 		t.Fatal(err)
 	}
 	if secret == nil || secret.Data["id"].(string) != rootToken {
-		t.Fatalf("token mismatch: %q vs %q", secret, rootToken)
+		t.Fatalf("token mismatch: %#v vs %q", secret, rootToken)
 	}
 
 	return client, func() {

--- a/api/api_integration_test.go
+++ b/api/api_integration_test.go
@@ -71,7 +71,7 @@ func testVaultServerBackends(t testing.TB, backends map[string]logical.Factory) 
 		t.Fatal(err)
 	}
 	if secret == nil || secret.Data["id"].(string) != rootToken {
-		t.Fatal("token mismatch: %q vs %q", secret, rootToken)
+		t.Fatalf("token mismatch: %q vs %q", secret, rootToken)
 	}
 
 	return client, func() {

--- a/api/api_integration_test.go
+++ b/api/api_integration_test.go
@@ -1,0 +1,117 @@
+package api_test
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/builtin/logical/pki"
+	"github.com/hashicorp/vault/builtin/logical/transit"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/vault"
+
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	vaulthttp "github.com/hashicorp/vault/http"
+	logxi "github.com/mgutz/logxi/v1"
+	dockertest "gopkg.in/ory-am/dockertest.v3"
+)
+
+var testVaultServerDefaultBackends = map[string]logical.Factory{
+	"transit": transit.Factory,
+	"pki":     pki.Factory,
+}
+
+func testVaultServer(t testing.TB) (*api.Client, func()) {
+	return testVaultServerBackends(t, testVaultServerDefaultBackends)
+}
+
+func testVaultServerBackends(t testing.TB, backends map[string]logical.Factory) (*api.Client, func()) {
+	handlers := []http.Handler{
+		http.NewServeMux(),
+		http.NewServeMux(),
+		http.NewServeMux(),
+	}
+
+	coreConfig := &vault.CoreConfig{
+		DisableMlock:    true,
+		DisableCache:    true,
+		Logger:          logxi.NullLog,
+		LogicalBackends: backends,
+	}
+
+	// Chicken-and-egg: Handler needs a core. So we create handlers first, then
+	// add routes chained to a Handler-created handler.
+	cores := vault.TestCluster(t, handlers, coreConfig, true)
+	for i, core := range cores {
+		handlers[i].(*http.ServeMux).Handle("/", vaulthttp.Handler(core.Core))
+	}
+
+	// make it easy to get access to the active
+	core := cores[0].Core
+	vault.TestWaitActive(t, core)
+
+	rootToken := cores[0].Root
+	address := fmt.Sprintf("https://127.0.0.1:%d", cores[1].Listeners[0].Address.Port)
+
+	config := api.DefaultConfig()
+	config.Address = address
+	config.HttpClient = cleanhttp.DefaultClient()
+	config.HttpClient.Transport.(*http.Transport).TLSClientConfig = cores[0].TLSConfig
+	client, err := api.NewClient(config)
+	if err != nil {
+		t.Fatalf("error creating vault cluster: %s", err)
+	}
+	client.SetToken(rootToken)
+
+	// Sanity check
+	secret, err := client.Auth().Token().LookupSelf()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret == nil || secret.Data["id"].(string) != rootToken {
+		t.Fatal("token mismatch: %q vs %q", secret, rootToken)
+	}
+
+	return client, func() {
+		for _, core := range cores {
+			defer core.CloseListeners()
+		}
+	}
+}
+
+// testPostgresDB creates a testing postgres database in a Docker container,
+// returning the connection URL and the associated closer function.
+func testPostgresDB(t testing.TB) (string, func()) {
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Fatalf("postgresdb: failed to connect to docker: %s", err)
+	}
+
+	resource, err := pool.Run("postgres", "latest", []string{
+		"POSTGRES_PASSWORD=secret",
+		"POSTGRES_DB=database",
+	})
+	if err != nil {
+		t.Fatalf("postgresdb: could not start container: %s", err)
+	}
+
+	addr := fmt.Sprintf("postgres://postgres:secret@localhost:%s/database?sslmode=disable", resource.GetPort("5432/tcp"))
+
+	if err := pool.Retry(func() error {
+		db, err := sql.Open("postgres", addr)
+		if err != nil {
+			return err
+		}
+		return db.Ping()
+	}); err != nil {
+		t.Fatalf("postgresdb: could not connect: %s", err)
+	}
+
+	return addr, func() {
+		if err := pool.Purge(resource); err != nil {
+			t.Fatalf("postgresdb: failed to cleanup container: %s", err)
+		}
+	}
+}

--- a/api/api_integration_test.go
+++ b/api/api_integration_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/vault"
 
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	vaulthttp "github.com/hashicorp/vault/http"
 	logxi "github.com/mgutz/logxi/v1"
 	dockertest "gopkg.in/ory-am/dockertest.v3"
@@ -52,17 +51,10 @@ func testVaultServerBackends(t testing.TB, backends map[string]logical.Factory) 
 	core := cores[0].Core
 	vault.TestWaitActive(t, core)
 
+	// Grab the root token
 	rootToken := cores[0].Root
-	address := fmt.Sprintf("https://127.0.0.1:%d", cores[1].Listeners[0].Address.Port)
 
-	config := api.DefaultConfig()
-	config.Address = address
-	config.HttpClient = cleanhttp.DefaultClient()
-	config.HttpClient.Transport.(*http.Transport).TLSClientConfig = cores[0].TLSConfig
-	client, err := api.NewClient(config)
-	if err != nil {
-		t.Fatalf("error creating vault cluster: %s", err)
-	}
+	client := cores[0].Client
 	client.SetToken(rootToken)
 
 	// Sanity check

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,18 +1,10 @@
 package api
 
 import (
-	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
-	"os"
-	"os/exec"
-	"sync/atomic"
 	"testing"
-	"time"
-
-	_ "github.com/lib/pq"
-	dockertest "gopkg.in/ory-am/dockertest.v3"
 
 	"golang.org/x/net/http2"
 )
@@ -36,95 +28,4 @@ func testHTTPServer(
 	config.Address = fmt.Sprintf("http://%s", ln.Addr())
 
 	return config, ln
-}
-
-// nextPort is the next port to use for the API server.
-var nextPort int32 = 28200
-
-// restVaultServer runs an instance of the Vault server in development mode.
-// This requires that the vault binary is installed and in the $PATH.
-func testVaultServer(t *testing.T) (*Client, func()) {
-	bin, err := exec.LookPath("vault")
-	if err != nil || bin == "" {
-		t.Fatal("vault binary not found")
-	}
-
-	// Get the port number
-	port := atomic.AddInt32(&nextPort, 1)
-
-	// Construct the address
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-
-	// Start the server
-	cmd := exec.Command(
-		bin, "server", "-dev",
-		"-dev-listen-address", addr,
-		"-dev-root-token-id", "root",
-	)
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	for i := 0; i < 10; i++ {
-		conn, err := net.DialTimeout("tcp", addr, time.Second)
-		if err != nil {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-		conn.Close()
-
-		config := DefaultConfig()
-		config.Address = fmt.Sprintf("http://%s", addr)
-		client, err := NewClient(config)
-		if err != nil {
-			t.Fatal(err)
-		}
-		client.SetToken("root")
-
-		return client, func() {
-			cmd.Process.Signal(os.Interrupt)
-			cmd.Process.Wait()
-		}
-	}
-
-	t.Fatalf("timeout waiting for vault server")
-	return nil, nil
-}
-
-func testPostgresDatabase(t *testing.T) (string, func()) {
-	if os.Getenv("PG_URL") != "" {
-		return os.Getenv("PG_URL"), func() {}
-	}
-
-	pool, err := dockertest.NewPool("")
-	if err != nil {
-		t.Fatalf("Failed to connect to docker: %s", err)
-	}
-
-	resource, err := pool.Run("postgres", "latest", []string{"POSTGRES_PASSWORD=secret", "POSTGRES_DB=database"})
-	if err != nil {
-		t.Fatalf("Could not start local PostgreSQL docker container: %s", err)
-	}
-
-	cleanup := func() {
-		err := pool.Purge(resource)
-		if err != nil {
-			t.Fatalf("Failed to cleanup local container: %s", err)
-		}
-	}
-
-	pgURL := fmt.Sprintf("postgres://postgres:secret@localhost:%s/database?sslmode=disable", resource.GetPort("5432/tcp"))
-
-	// exponential backoff-retry
-	if err := pool.Retry(func() error {
-		db, err := sql.Open("postgres", pgURL)
-		if err != nil {
-			return err
-		}
-		return db.Ping()
-	}); err != nil {
-		t.Fatalf("Could not connect to PostgreSQL docker container: %s", err)
-	}
-
-	return pgURL, cleanup
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,10 +1,18 @@
 package api
 
 import (
+	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"os/exec"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	dockertest "gopkg.in/ory-am/dockertest.v3"
 
 	"golang.org/x/net/http2"
 )
@@ -28,4 +36,95 @@ func testHTTPServer(
 	config.Address = fmt.Sprintf("http://%s", ln.Addr())
 
 	return config, ln
+}
+
+// nextPort is the next port to use for the API server.
+var nextPort int32 = 28200
+
+// restVaultServer runs an instance of the Vault server in development mode.
+// This requires that the vault binary is installed and in the $PATH.
+func testVaultServer(t *testing.T) (*Client, func()) {
+	bin, err := exec.LookPath("vault")
+	if err != nil || bin == "" {
+		t.Fatal("vault binary not found")
+	}
+
+	// Get the port number
+	port := atomic.AddInt32(&nextPort, 1)
+
+	// Construct the address
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	// Start the server
+	cmd := exec.Command(
+		bin, "server", "-dev",
+		"-dev-listen-address", addr,
+		"-dev-root-token-id", "root",
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err != nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		conn.Close()
+
+		config := DefaultConfig()
+		config.Address = fmt.Sprintf("http://%s", addr)
+		client, err := NewClient(config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		client.SetToken("root")
+
+		return client, func() {
+			cmd.Process.Signal(os.Interrupt)
+			cmd.Process.Wait()
+		}
+	}
+
+	t.Fatalf("timeout waiting for vault server")
+	return nil, nil
+}
+
+func testPostgresDatabase(t *testing.T) (string, func()) {
+	if os.Getenv("PG_URL") != "" {
+		return os.Getenv("PG_URL"), func() {}
+	}
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Fatalf("Failed to connect to docker: %s", err)
+	}
+
+	resource, err := pool.Run("postgres", "latest", []string{"POSTGRES_PASSWORD=secret", "POSTGRES_DB=database"})
+	if err != nil {
+		t.Fatalf("Could not start local PostgreSQL docker container: %s", err)
+	}
+
+	cleanup := func() {
+		err := pool.Purge(resource)
+		if err != nil {
+			t.Fatalf("Failed to cleanup local container: %s", err)
+		}
+	}
+
+	pgURL := fmt.Sprintf("postgres://postgres:secret@localhost:%s/database?sslmode=disable", resource.GetPort("5432/tcp"))
+
+	// exponential backoff-retry
+	if err := pool.Retry(func() error {
+		db, err := sql.Open("postgres", pgURL)
+		if err != nil {
+			return err
+		}
+		return db.Ping()
+	}); err != nil {
+		t.Fatalf("Could not connect to PostgreSQL docker container: %s", err)
+	}
+
+	return pgURL, cleanup
 }

--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -135,9 +135,9 @@ func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
-// RenewSelfAsToken behaves like renew-self, but authenticates using a provided
+// RenewTokenAsSelf behaves like renew-self, but authenticates using a provided
 // token instead of the token attached to the client.
-func (c *TokenAuth) RenewSelfAsToken(token string, increment int) (*Secret, error) {
+func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 	r.ClientToken = token
 

--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -135,6 +135,26 @@ func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
+// RenewSelfAsToken behaves like renew-self, but authenticates using a provided
+// token instead of the token attached to the client.
+func (c *TokenAuth) RenewSelfAsToken(token string, increment int) (*Secret, error) {
+	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
+	r.ClientToken = token
+
+	body := map[string]interface{}{"increment": increment}
+	if err := r.SetJSONBody(body); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.RawRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return ParseSecret(resp.Body)
+}
+
 // RevokeAccessor revokes a token associated with the given accessor
 // along with all the child tokens.
 func (c *TokenAuth) RevokeAccessor(accessor string) error {

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -87,11 +87,11 @@ func (c *Client) NewRenewer(i *RenewerInput) (*Renewer, error) {
 		client: c,
 		secret: secret,
 		grace:  grace,
-		doneCh: make(chan error, 1),
+		doneCh: make(chan error),
 		tickCh: make(chan struct{}, 5),
 
 		stopped: false,
-		stopCh:  make(chan struct{}, 1),
+		stopCh:  make(chan struct{}),
 	}, nil
 }
 

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -1,0 +1,243 @@
+package api
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// RenewerInput is used as input to the renew function.
+type RenewerInput struct {
+	// Secret is the secret to renew
+	Secret *Secret
+
+	// Grace is a minimum renewal (in seconds) before returring so the upstream
+	// client can do a re-read. This can be used to prevent clients from waiting
+	// too long to read a new credential and incur downtime.
+	Grace int
+}
+
+// Renewer is a process for renewing a secret.
+//
+// 	renewer, err := client.NewRenewer(&RenewerInput{
+// 		Secret: mySecret,
+// 	})
+// 	go renewer.Renew()
+// 	defer renewer.Stop()
+//
+// 	for {
+// 		select {
+// 		case err := <-DoneCh():
+// 			if err != nil {
+// 				log.Fatal(err)
+// 			}
+//
+// 			// Renewal is now over
+// 		case <-TickCh():
+// 			log.Println("Successfully renewed")
+// 		default:
+// 		}
+// 	}
+//
+//
+// The `DoneCh` will return if renewal fails or if the remaining lease duration
+// after a renewal is less than or equal to the grace (in number of seconds). In
+// both cases, the caller should attempt a re-read of the secret. Clients should
+// check the return value of the channel to see if renewal was successful.
+type Renewer struct {
+	sync.Mutex
+
+	client *Client
+	secret *Secret
+	grace  int
+	doneCh chan error
+	tickCh chan struct{}
+
+	stopped bool
+	stopCh  chan struct{}
+}
+
+var (
+	ErrRenewerMissingInput  = errors.New("missing input to renewer")
+	ErrRenewerMissingSecret = errors.New("missing secret to renew")
+	ErrRenewerNotRenewable  = errors.New("secret is not renewable")
+	ErrRenewerNoSecretData  = errors.New("returned empty secret data")
+
+	// DefaultRenewerGrace is the default grace period
+	DefaultRenewerGrace = 15
+)
+
+// NewRenewer creates a new renewer from the given input.
+func (c *Client) NewRenewer(i *RenewerInput) (*Renewer, error) {
+	if i == nil {
+		return nil, ErrRenewerMissingInput
+	}
+
+	secret := i.Secret
+	if secret == nil {
+		return nil, ErrRenewerMissingSecret
+	}
+
+	grace := i.Grace
+	if grace == 0 {
+		grace = DefaultRenewerGrace
+	}
+
+	return &Renewer{
+		client: c,
+		secret: secret,
+		grace:  grace,
+		doneCh: make(chan error, 1),
+		tickCh: make(chan struct{}, 5),
+
+		stopped: false,
+		stopCh:  make(chan struct{}, 1),
+	}, nil
+}
+
+// DoneCh returns the channel where the renewer will publish when renewal stops.
+// If there is an error, this will be an error.
+func (r *Renewer) DoneCh() <-chan error {
+	return r.doneCh
+}
+
+// TickCh is a channel that receives a message when a successful renewal takes
+// place.
+func (r *Renewer) TickCh() <-chan struct{} {
+	return r.tickCh
+}
+
+// Stop stops the renewer.
+func (r *Renewer) Stop() {
+	r.Lock()
+	if !r.stopped {
+		close(r.stopCh)
+		r.stopped = true
+	}
+	r.Unlock()
+}
+
+// Renew starts a background process for renewing this secret. When the secret
+// is has auth data, this attempts to renew the auth (token). When the secret
+// has a lease, this attempts to renew the lease.
+//
+// This function will not return if nothing is reading from doneCh (it blocks)
+// on a write to the channel.
+func (r *Renewer) Renew() {
+	if r.secret.Auth != nil {
+		r.doneCh <- r.renewAuth()
+	} else {
+		r.doneCh <- r.renewLease()
+	}
+}
+
+// renewAuth is a helper for renewing authentication.
+func (r *Renewer) renewAuth() error {
+	if !r.secret.Auth.Renewable || r.secret.Auth.ClientToken == "" {
+		return ErrRenewerNotRenewable
+	}
+
+	client, token := r.client, r.secret.Auth.ClientToken
+
+	for {
+		// Check if we are stopped.
+		select {
+		case <-r.stopCh:
+			return nil
+		default:
+		}
+
+		// Renew the auth.
+		renewal, err := client.Auth().Token().RenewSelfAsToken(token, 0)
+		if err != nil {
+			return err
+		}
+
+		// Push a message that a renewal took place.
+		select {
+		case r.tickCh <- struct{}{}:
+		default:
+		}
+
+		// Somehow, sometimes, this happens.
+		if renewal == nil || renewal.Auth == nil {
+			return ErrRenewerNoSecretData
+		}
+
+		// Do nothing if we are not renewable
+		if !renewal.Auth.Renewable {
+			return ErrRenewerNotRenewable
+		}
+
+		// Grab the lease duration - note that we grab the auth lease duration, not
+		// the secret lease duration.
+		leaseDuration := renewal.Auth.LeaseDuration
+
+		// If we are within grace, return now.
+		if leaseDuration <= r.grace {
+			return nil
+		}
+
+		select {
+		case <-r.stopCh:
+			return nil
+		case <-time.After(time.Duration(leaseDuration/2.0) * time.Second):
+			continue
+		}
+	}
+}
+
+// renewLease is a helper for renewing a lease.
+func (r *Renewer) renewLease() error {
+	if !r.secret.Renewable || r.secret.LeaseID == "" {
+		return ErrRenewerNotRenewable
+	}
+
+	client, leaseID := r.client, r.secret.LeaseID
+
+	for {
+		// Check if we are stopped.
+		select {
+		case <-r.stopCh:
+			return nil
+		default:
+		}
+
+		// Renew the lease.
+		renewal, err := client.Sys().Renew(leaseID, 0)
+		if err != nil {
+			return err
+		}
+
+		// Push a message that a renewal took place.
+		select {
+		case r.tickCh <- struct{}{}:
+		default:
+		}
+
+		// Somehow, sometimes, this happens.
+		if renewal == nil {
+			return ErrRenewerNoSecretData
+		}
+
+		// Do nothing if we are not renewable
+		if !renewal.Renewable {
+			return ErrRenewerNotRenewable
+		}
+
+		// Grab the lease duration
+		leaseDuration := renewal.LeaseDuration
+
+		// If we are within grace, return now.
+		if leaseDuration <= r.grace {
+			return nil
+		}
+
+		select {
+		case <-r.stopCh:
+			return nil
+		case <-time.After(time.Duration(leaseDuration/2.0) * time.Second):
+			continue
+		}
+	}
+}

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -6,16 +6,15 @@ import (
 	"time"
 )
 
-// RenewerInput is used as input to the renew function.
-type RenewerInput struct {
-	// Secret is the secret to renew
-	Secret *Secret
+var (
+	ErrRenewerMissingInput  = errors.New("missing input to renewer")
+	ErrRenewerMissingSecret = errors.New("missing secret to renew")
+	ErrRenewerNotRenewable  = errors.New("secret is not renewable")
+	ErrRenewerNoSecretData  = errors.New("returned empty secret data")
 
-	// Grace is a minimum renewal (in seconds) before returring so the upstream
-	// client can do a re-read. This can be used to prevent clients from waiting
-	// too long to read a new credential and incur downtime.
-	Grace time.Duration
-}
+	// DefaultRenewerGrace is the default grace period
+	DefaultRenewerGrace = 15 * time.Second
+)
 
 // Renewer is a process for renewing a secret.
 //
@@ -57,15 +56,16 @@ type Renewer struct {
 	stopCh  chan struct{}
 }
 
-var (
-	ErrRenewerMissingInput  = errors.New("missing input to renewer")
-	ErrRenewerMissingSecret = errors.New("missing secret to renew")
-	ErrRenewerNotRenewable  = errors.New("secret is not renewable")
-	ErrRenewerNoSecretData  = errors.New("returned empty secret data")
+// RenewerInput is used as input to the renew function.
+type RenewerInput struct {
+	// Secret is the secret to renew
+	Secret *Secret
 
-	// DefaultRenewerGrace is the default grace period
-	DefaultRenewerGrace = 15 * time.Second
-)
+	// Grace is a minimum renewal (in seconds) before returring so the upstream
+	// client can do a re-read. This can be used to prevent clients from waiting
+	// too long to read a new credential and incur downtime.
+	Grace time.Duration
+}
 
 // NewRenewer creates a new renewer from the given input.
 func (c *Client) NewRenewer(i *RenewerInput) (*Renewer, error) {

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -7,11 +7,6 @@ import (
 	"time"
 )
 
-func init() {
-	// Seed the random generator
-	rand.Seed(time.Now().Unix())
-}
-
 var (
 	ErrRenewerMissingInput  = errors.New("missing input to renewer")
 	ErrRenewerMissingSecret = errors.New("missing secret to renew")

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -148,7 +148,7 @@ func (r *Renewer) renewAuth() error {
 		}
 
 		// Renew the auth.
-		renewal, err := client.Auth().Token().RenewSelfAsToken(token, 0)
+		renewal, err := client.Auth().Token().RenewTokenAsSelf(token, 0)
 		if err != nil {
 			return err
 		}

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -14,7 +14,7 @@ type RenewerInput struct {
 	// Grace is a minimum renewal (in seconds) before returring so the upstream
 	// client can do a re-read. This can be used to prevent clients from waiting
 	// too long to read a new credential and incur downtime.
-	Grace int
+	Grace time.Duration
 }
 
 // Renewer is a process for renewing a secret.
@@ -49,7 +49,7 @@ type Renewer struct {
 
 	client *Client
 	secret *Secret
-	grace  int
+	grace  time.Duration
 	doneCh chan error
 	tickCh chan struct{}
 
@@ -64,7 +64,7 @@ var (
 	ErrRenewerNoSecretData  = errors.New("returned empty secret data")
 
 	// DefaultRenewerGrace is the default grace period
-	DefaultRenewerGrace = 15
+	DefaultRenewerGrace = 15 * time.Second
 )
 
 // NewRenewer creates a new renewer from the given input.
@@ -171,7 +171,7 @@ func (r *Renewer) renewAuth() error {
 
 		// Grab the lease duration - note that we grab the auth lease duration, not
 		// the secret lease duration.
-		leaseDuration := renewal.Auth.LeaseDuration
+		leaseDuration := time.Duration(renewal.Auth.LeaseDuration) * time.Second
 
 		// If we are within grace, return now.
 		if leaseDuration <= r.grace {
@@ -226,7 +226,7 @@ func (r *Renewer) renewLease() error {
 		}
 
 		// Grab the lease duration
-		leaseDuration := renewal.LeaseDuration
+		leaseDuration := time.Duration(renewal.LeaseDuration) * time.Second
 
 		// If we are within grace, return now.
 		if leaseDuration <= r.grace {

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -2,9 +2,15 @@ package api
 
 import (
 	"errors"
+	"math/rand"
 	"sync"
 	"time"
 )
+
+func init() {
+	// Seed the random generator
+	rand.Seed(time.Now().Unix())
+}
 
 var (
 	ErrRenewerMissingInput  = errors.New("missing input to renewer")

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -149,10 +149,16 @@ func (r *Renewer) Stop() {
 // This function will not return if nothing is reading from doneCh (it blocks)
 // on a write to the channel.
 func (r *Renewer) Renew() {
+	var result error
 	if r.secret.Auth != nil {
-		r.doneCh <- r.renewAuth()
+		result = r.renewAuth()
 	} else {
-		r.doneCh <- r.renewLease()
+		result = r.renewLease()
+	}
+
+	select {
+	case r.doneCh <- result:
+	case <-r.stopCh:
 	}
 }
 

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -125,7 +125,7 @@ func (c *Client) NewRenewer(i *RenewerInput) (*Renewer, error) {
 		secret:  secret,
 		grace:   grace,
 		random:  random,
-		doneCh:  make(chan error),
+		doneCh:  make(chan error, 1),
 		renewCh: make(chan *RenewOutput, renewBuffer),
 
 		stopped: false,
@@ -158,9 +158,6 @@ func (r *Renewer) Stop() {
 // Renew starts a background process for renewing this secret. When the secret
 // is has auth data, this attempts to renew the auth (token). When the secret
 // has a lease, this attempts to renew the lease.
-//
-// This function will not return if nothing is reading from doneCh (it blocks)
-// on a write to the channel.
 func (r *Renewer) Renew() {
 	var result error
 	if r.secret.Auth != nil {

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -45,7 +45,7 @@ var (
 // both cases, the caller should attempt a re-read of the secret. Clients should
 // check the return value of the channel to see if renewal was successful.
 type Renewer struct {
-	sync.Mutex
+	l sync.Mutex
 
 	client  *Client
 	secret  *Secret
@@ -134,12 +134,12 @@ func (r *Renewer) RenewCh() <-chan *RenewOutput {
 
 // Stop stops the renewer.
 func (r *Renewer) Stop() {
-	r.Lock()
+	r.l.Lock()
 	if !r.stopped {
 		close(r.stopCh)
 		r.stopped = true
 	}
-	r.Unlock()
+	r.l.Unlock()
 }
 
 // Renew starts a background process for renewing this secret. When the secret

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -31,15 +31,14 @@ var (
 //
 // 	for {
 // 		select {
-// 		case err := <-DoneCh():
+// 		case err := <-renewer.DoneCh():
 // 			if err != nil {
 // 				log.Fatal(err)
 // 			}
 //
 // 			// Renewal is now over
-// 		case renewal := <-RenewCh():
+// 		case renewal := <-renewer.RenewCh():
 // 			log.Printf("Successfully renewed: %#v", renewal)
-// 		default:
 // 		}
 // 	}
 //

--- a/api/renewer.go
+++ b/api/renewer.go
@@ -66,8 +66,8 @@ type RenewerInput struct {
 	// Secret is the secret to renew
 	Secret *Secret
 
-	// Grace is a minimum renewal (in seconds) before returring so the upstream
-	// client can do a re-read. This can be used to prevent clients from waiting
+	// Grace is a minimum renewal before returning so the upstream client
+	// can do a re-read. This can be used to prevent clients from waiting
 	// too long to read a new credential and incur downtime.
 	Grace time.Duration
 

--- a/api/renewer_integration_test.go
+++ b/api/renewer_integration_test.go
@@ -1,0 +1,228 @@
+package api_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/builtin/logical/database"
+	"github.com/hashicorp/vault/builtin/logical/pki"
+	"github.com/hashicorp/vault/builtin/logical/transit"
+	"github.com/hashicorp/vault/logical"
+)
+
+func TestRenewer_Renew(t *testing.T) {
+	t.Parallel()
+
+	client, vaultDone := testVaultServerBackends(t, map[string]logical.Factory{
+		"database": database.Factory,
+		"pki":      pki.Factory,
+		"transit":  transit.Factory,
+	})
+	defer vaultDone()
+
+	pgURL, pgDone := testPostgresDB(t)
+	defer pgDone()
+
+	t.Run("group", func(t *testing.T) {
+		t.Run("generic", func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := client.Logical().Write("secret/value", map[string]interface{}{
+				"foo": "bar",
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			secret, err := client.Logical().Read("secret/value")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v, err := client.NewRenewer(&api.RenewerInput{
+				Secret: secret,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			go v.Renew()
+			defer v.Stop()
+
+			select {
+			case err := <-v.DoneCh():
+				if err != api.ErrRenewerNotRenewable {
+					t.Fatal(err)
+				}
+			case renew := <-v.RenewCh():
+				t.Error("received renew, but should have been nil: %#v", renew)
+			case <-time.After(500 * time.Millisecond):
+				t.Error("should have been non-renewable")
+			}
+		})
+
+		t.Run("transit", func(t *testing.T) {
+			t.Parallel()
+
+			if err := client.Sys().Mount("transit", &api.MountInput{
+				Type: "transit",
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			secret, err := client.Logical().Write("transit/encrypt/my-app", map[string]interface{}{
+				"plaintext": "Zm9vCg==",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v, err := client.NewRenewer(&api.RenewerInput{
+				Secret: secret,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			go v.Renew()
+			defer v.Stop()
+
+			select {
+			case err := <-v.DoneCh():
+				if err != api.ErrRenewerNotRenewable {
+					t.Fatal(err)
+				}
+			case renew := <-v.RenewCh():
+				t.Error("received renew, but should have been nil: %#v", renew)
+			case <-time.After(500 * time.Millisecond):
+				t.Error("should have been non-renewable")
+			}
+		})
+
+		t.Run("database", func(t *testing.T) {
+			t.Parallel()
+
+			if err := client.Sys().Mount("database", &api.MountInput{
+				Type: "database",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.Logical().Write("database/config/postgresql", map[string]interface{}{
+				"plugin_name":    "postgresql-database-plugin",
+				"connection_url": pgURL,
+				"allowed_roles":  "readonly",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.Logical().Write("database/roles/readonly", map[string]interface{}{
+				"db_name": "postgresql",
+				"creation_statements": `` +
+					`CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';` +
+					`GRANT SELECT ON ALL TABLES IN SCHEMA public TO "{{name}}";`,
+				"default_ttl": "1s",
+				"max_ttl":     "3s",
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			secret, err := client.Logical().Read("database/creds/readonly")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v, err := client.NewRenewer(&api.RenewerInput{
+				Secret: secret,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			go v.Renew()
+			defer v.Stop()
+
+			select {
+			case err := <-v.DoneCh():
+				t.Errorf("should have renewed once before returning: %s", err)
+			case renew := <-v.RenewCh():
+				if renew == nil {
+					t.Fatal("renew is nil")
+				}
+				if !renew.Secret.Renewable {
+					t.Errorf("expected lease to be renewable: %#v", renew)
+				}
+				if renew.Secret.LeaseDuration > 2 {
+					t.Errorf("expected lease to < 2s: %#v", renew)
+				}
+			case <-time.After(3 * time.Second):
+				t.Errorf("no renewal")
+			}
+
+			select {
+			case err := <-v.DoneCh():
+				if err != nil {
+					t.Fatal(err)
+				}
+			case renew := <-v.RenewCh():
+				t.Fatalf("should not have renewed (lease should be up): %#v", renew)
+			case <-time.After(3 * time.Second):
+				t.Errorf("no data")
+			}
+		})
+
+		t.Run("auth", func(t *testing.T) {
+			t.Parallel()
+
+			secret, err := client.Auth().Token().Create(&api.TokenCreateRequest{
+				Policies:       []string{"default"},
+				TTL:            "1s",
+				ExplicitMaxTTL: "3s",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v, err := client.NewRenewer(&api.RenewerInput{
+				Secret: secret,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			go v.Renew()
+			defer v.Stop()
+
+			select {
+			case err := <-v.DoneCh():
+				t.Errorf("should have renewed once before returning: %s", err)
+			case renew := <-v.RenewCh():
+				if renew == nil {
+					t.Fatal("renew is nil")
+				}
+				if renew.Secret.Auth == nil {
+					t.Fatal("renew auth is nil")
+				}
+				if !renew.Secret.Auth.Renewable {
+					t.Errorf("expected lease to be renewable: %#v", renew)
+				}
+				if renew.Secret.Auth.LeaseDuration > 2 {
+					t.Errorf("expected lease to < 2s: %#v", renew)
+				}
+				if renew.Secret.Auth.ClientToken == "" {
+					t.Error("expected a client token")
+				}
+				if renew.Secret.Auth.Accessor == "" {
+					t.Error("expected an accessor")
+				}
+			case <-time.After(3 * time.Second):
+				t.Errorf("no renewal")
+			}
+
+			select {
+			case err := <-v.DoneCh():
+				if err != nil {
+					t.Fatal(err)
+				}
+			case renew := <-v.RenewCh():
+				t.Fatalf("should not have renewed (lease should be up): %#v", renew)
+			case <-time.After(3 * time.Second):
+				t.Errorf("no data")
+			}
+		})
+	})
+}

--- a/api/renewer_integration_test.go
+++ b/api/renewer_integration_test.go
@@ -54,7 +54,7 @@ func TestRenewer_Renew(t *testing.T) {
 					t.Fatal(err)
 				}
 			case renew := <-v.RenewCh():
-				t.Error("received renew, but should have been nil: %#v", renew)
+				t.Errorf("received renew, but should have been nil: %#v", renew)
 			case <-time.After(500 * time.Millisecond):
 				t.Error("should have been non-renewable")
 			}
@@ -91,7 +91,7 @@ func TestRenewer_Renew(t *testing.T) {
 					t.Fatal(err)
 				}
 			case renew := <-v.RenewCh():
-				t.Error("received renew, but should have been nil: %#v", renew)
+				t.Errorf("received renew, but should have been nil: %#v", renew)
 			case <-time.After(500 * time.Millisecond):
 				t.Error("should have been non-renewable")
 			}

--- a/api/renewer_test.go
+++ b/api/renewer_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -50,18 +49,18 @@ func TestRenewer_NewRenewer(t *testing.T) {
 			"custom_grace",
 			&RenewerInput{
 				Secret: &Secret{},
-				Grace:  30,
+				Grace:  30 * time.Second,
 			},
 			&Renewer{
 				secret: &Secret{},
-				grace:  30,
+				grace:  30 * time.Second,
 			},
 			false,
 		},
 	}
 
-	for i, tc := range cases {
-		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			v, err := client.NewRenewer(tc.i)
 			if (err != nil) != tc.err {
 				t.Fatal(err)
@@ -74,7 +73,7 @@ func TestRenewer_NewRenewer(t *testing.T) {
 			// Zero-out channels because reflect
 			v.client = nil
 			v.doneCh = nil
-			v.tickCh = nil
+			v.renewCh = nil
 			v.stopCh = nil
 
 			if !reflect.DeepEqual(tc.e, v) {
@@ -82,170 +81,4 @@ func TestRenewer_NewRenewer(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestRenewer_Renew(t *testing.T) {
-	client, vaultDone := testVaultServer(t)
-	defer vaultDone()
-
-	pgURL, pgDone := testPostgresDatabase(t)
-	defer pgDone()
-
-	// Generic
-	if _, err := client.Logical().Write("secret/value", map[string]interface{}{
-		"foo": "bar",
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Transit
-	if err := client.Sys().Mount("transit", &MountInput{
-		Type: "transit",
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// PostgreSQL
-	if err := client.Sys().Mount("database", &MountInput{
-		Type: "database",
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := client.Logical().Write("database/config/postgresql", map[string]interface{}{
-		"plugin_name":    "postgresql-database-plugin",
-		"connection_url": pgURL,
-		"allowed_roles":  "readonly",
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := client.Logical().Write("database/roles/readonly", map[string]interface{}{
-		"db_name": "postgresql",
-		"creation_statements": `` +
-			`CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';` +
-			`GRANT SELECT ON ALL TABLES IN SCHEMA public TO "{{name}}";`,
-		"default_ttl": "2s",
-		"max_ttl":     "5s",
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Run("generic", func(t *testing.T) {
-		secret, err := client.Logical().Read("secret/value")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		v, err := client.NewRenewer(&RenewerInput{
-			Secret: secret,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		go v.Renew()
-		defer v.Stop()
-
-		select {
-		case err := <-v.DoneCh():
-			if err != ErrRenewerNotRenewable {
-				t.Fatal(err)
-			}
-		}
-	})
-
-	t.Run("transit", func(t *testing.T) {
-		secret, err := client.Logical().Write("transit/encrypt/my-app", map[string]interface{}{
-			"plaintext": "Zm9vCg==",
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		v, err := client.NewRenewer(&RenewerInput{
-			Secret: secret,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		go v.Renew()
-		defer v.Stop()
-
-		select {
-		case err := <-v.DoneCh():
-			if err != ErrRenewerNotRenewable {
-				t.Fatal(err)
-			}
-		}
-	})
-
-	t.Run("dynamic", func(t *testing.T) {
-		secret, err := client.Logical().Read("database/creds/readonly")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		v, err := client.NewRenewer(&RenewerInput{
-			Secret: secret,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		go v.Renew()
-		defer v.Stop()
-
-		select {
-		case err := <-v.DoneCh():
-			t.Errorf("should have renewed once before returning: %s", err)
-		case <-v.TickCh():
-			// Received a renewal
-		case <-time.After(5 * time.Second):
-			t.Errorf("no data in 5s")
-		}
-
-		select {
-		case err := <-v.DoneCh():
-			if err != nil {
-				t.Fatal(err)
-			}
-		case <-time.After(5 * time.Second):
-			t.Errorf("no data in 5s")
-		}
-	})
-
-	t.Run("auth", func(t *testing.T) {
-		secret, err := client.Auth().Token().Create(&TokenCreateRequest{
-			Policies:       []string{"default"},
-			TTL:            "2s",
-			ExplicitMaxTTL: "5s",
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		v, err := client.NewRenewer(&RenewerInput{
-			Secret: secret,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		go v.Renew()
-		defer v.Stop()
-
-		select {
-		case err := <-v.DoneCh():
-			t.Errorf("should have renewed once before returning: %s", err)
-		case <-v.TickCh():
-			// Received a renewal
-		case <-time.After(5 * time.Second):
-			t.Errorf("no data in 5s")
-		}
-
-		select {
-		case err := <-v.DoneCh():
-			if err != nil {
-				t.Fatal(err)
-			}
-		case <-time.After(5 * time.Second):
-			t.Errorf("no data in 5s")
-		}
-	})
 }

--- a/api/renewer_test.go
+++ b/api/renewer_test.go
@@ -1,0 +1,251 @@
+package api
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestRenewer_NewRenewer(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		i    *RenewerInput
+		e    *Renewer
+		err  bool
+	}{
+		{
+			"nil",
+			nil,
+			nil,
+			true,
+		},
+		{
+			"missing_secret",
+			&RenewerInput{
+				Secret: nil,
+			},
+			nil,
+			true,
+		},
+		{
+			"default_grace",
+			&RenewerInput{
+				Secret: &Secret{},
+			},
+			&Renewer{
+				secret: &Secret{},
+				grace:  DefaultRenewerGrace,
+			},
+			false,
+		},
+		{
+			"custom_grace",
+			&RenewerInput{
+				Secret: &Secret{},
+				Grace:  30,
+			},
+			&Renewer{
+				secret: &Secret{},
+				grace:  30,
+			},
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			v, err := client.NewRenewer(tc.i)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+
+			if v == nil {
+				return
+			}
+
+			// Zero-out channels because reflect
+			v.client = nil
+			v.doneCh = nil
+			v.tickCh = nil
+			v.stopCh = nil
+
+			if !reflect.DeepEqual(tc.e, v) {
+				t.Errorf("not equal\nexp: %#v\nact: %#v", tc.e, v)
+			}
+		})
+	}
+}
+
+func TestRenewer_Renew(t *testing.T) {
+	client, vaultDone := testVaultServer(t)
+	defer vaultDone()
+
+	pgURL, pgDone := testPostgresDatabase(t)
+	defer pgDone()
+
+	// Generic
+	if _, err := client.Logical().Write("secret/value", map[string]interface{}{
+		"foo": "bar",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Transit
+	if err := client.Sys().Mount("transit", &MountInput{
+		Type: "transit",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// PostgreSQL
+	if err := client.Sys().Mount("database", &MountInput{
+		Type: "database",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Logical().Write("database/config/postgresql", map[string]interface{}{
+		"plugin_name":    "postgresql-database-plugin",
+		"connection_url": pgURL,
+		"allowed_roles":  "readonly",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Logical().Write("database/roles/readonly", map[string]interface{}{
+		"db_name": "postgresql",
+		"creation_statements": `` +
+			`CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';` +
+			`GRANT SELECT ON ALL TABLES IN SCHEMA public TO "{{name}}";`,
+		"default_ttl": "2s",
+		"max_ttl":     "5s",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("generic", func(t *testing.T) {
+		secret, err := client.Logical().Read("secret/value")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		v, err := client.NewRenewer(&RenewerInput{
+			Secret: secret,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		go v.Renew()
+		defer v.Stop()
+
+		select {
+		case err := <-v.DoneCh():
+			if err != ErrRenewerNotRenewable {
+				t.Fatal(err)
+			}
+		}
+	})
+
+	t.Run("transit", func(t *testing.T) {
+		secret, err := client.Logical().Write("transit/encrypt/my-app", map[string]interface{}{
+			"plaintext": "Zm9vCg==",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		v, err := client.NewRenewer(&RenewerInput{
+			Secret: secret,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		go v.Renew()
+		defer v.Stop()
+
+		select {
+		case err := <-v.DoneCh():
+			if err != ErrRenewerNotRenewable {
+				t.Fatal(err)
+			}
+		}
+	})
+
+	t.Run("dynamic", func(t *testing.T) {
+		secret, err := client.Logical().Read("database/creds/readonly")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		v, err := client.NewRenewer(&RenewerInput{
+			Secret: secret,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		go v.Renew()
+		defer v.Stop()
+
+		select {
+		case err := <-v.DoneCh():
+			t.Errorf("should have renewed once before returning: %s", err)
+		case <-v.TickCh():
+			// Received a renewal
+		case <-time.After(5 * time.Second):
+			t.Errorf("no data in 5s")
+		}
+
+		select {
+		case err := <-v.DoneCh():
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("no data in 5s")
+		}
+	})
+
+	t.Run("auth", func(t *testing.T) {
+		secret, err := client.Auth().Token().Create(&TokenCreateRequest{
+			Policies:       []string{"default"},
+			TTL:            "2s",
+			ExplicitMaxTTL: "5s",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		v, err := client.NewRenewer(&RenewerInput{
+			Secret: secret,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		go v.Renew()
+		defer v.Stop()
+
+		select {
+		case err := <-v.DoneCh():
+			t.Errorf("should have renewed once before returning: %s", err)
+		case <-v.TickCh():
+			// Received a renewal
+		case <-time.After(5 * time.Second):
+			t.Errorf("no data in 5s")
+		}
+
+		select {
+		case err := <-v.DoneCh():
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("no data in 5s")
+		}
+	})
+}

--- a/api/renewer_test.go
+++ b/api/renewer_test.go
@@ -72,6 +72,7 @@ func TestRenewer_NewRenewer(t *testing.T) {
 
 			// Zero-out channels because reflect
 			v.client = nil
+			v.random = nil
 			v.doneCh = nil
 			v.renewCh = nil
 			v.stopCh = nil


### PR DESCRIPTION
This adds a client API helper for renewing a secret with a configurable grace period. I really got sick of writing the same code over and over again, and figured the API client could benefit here. This isn't an end-all-be-all renewal method; clients which want more control should implement this logic themselves. However, for the normal basic cases, it suffices.

~~This is _really_ hard to test. There's no way to spin up a Vault server in the api package because the vault core depends on the API package, creating a circular dependency. I didn't want to do a huge refactor and shuffle things around for this tiny PR.~~

Thanks to @ryanuber, I have a relatively good way to test this! 