### PR TITLE
Better error messages using ListObjects than using HeadBucket. Might …

### DIFF
--- a/physical/s3.go
+++ b/physical/s3.go
@@ -92,9 +92,9 @@ func newS3Backend(conf map[string]string, logger log.Logger) (Backend, error) {
 		Region:   aws.String(region),
 	}))
 
-	_, err = s3conn.HeadBucket(&s3.HeadBucketInput{Bucket: &bucket})
+	_, err = s3conn.ListObjects(&s3.ListObjectsInput{Bucket: &bucket})
 	if err != nil {
-		return nil, fmt.Errorf("unable to access bucket '%s': %v", bucket, err)
+		return nil, fmt.Errorf("unable to access bucket '%s' in region %s: %v", bucket, region, err)
 	}
 
 	maxParStr, ok := conf["max_parallel"]


### PR DESCRIPTION
…be a bigger request but messages are better than BadRequest, how this changes effect the messages:
**Before:**
If you put some random bucket name that does not exist it gives you 'NotFound'.
But if it does exist but you put the wrong region it gives you 'BadRequest'.
**After:**
If the bucket dose not exist we get:
`Error initializing storage of type s3: unable to access bucket 'my-vault-secrets2' in region us-east-1: NoSuchBucket: The specified bucket does not exist status code: 404`
If it is the wrong region we get:
`Error initializing storage of type s3: unable to access bucket 'my-vault-secrets' in region us-east-1: AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-west-1' status code: 400`

Using `ListObjects` not only tells you that it can't access the bucket but it tells you what region it is expecting.