### PR TITLE
Docs: Note about automatic unseal behavior with HSM in HA configuration

### DIFF
--- a/website/source/docs/vault-enterprise/hsm/behavior.html.md
+++ b/website/source/docs/vault-enterprise/hsm/behavior.html.md
@@ -43,6 +43,9 @@ encryption key that the master key protects via the
 [`/sys/rotate`](/api/system/rotate.html) API
 endpoint.
 
+Note that in high availability configurations the HSM automatically unseals
+the barrier for only the active instance.
+
 ## Recovery Key
 
 When Vault is initialized while using an HSM, rather than unseal keys being


### PR DESCRIPTION
Clarifying that only the active instance is automatically unsealed in HA with HSM.