### PR TITLE
Allow Okta auth backend to specify TTL and max TTL values

### DIFF
--- a/builtin/credential/okta/backend_test.go
+++ b/builtin/credential/okta/backend_test.go
@@ -54,19 +54,19 @@ func TestBackend_Config(t *testing.T) {
 			testLoginWrite(t, username, password, "user is not a member of any authorized policy", 0, nil),
 			testAccUserGroups(t, username, "local_group,local_group2"),
 			testAccGroups(t, "local_group", "local_group_policy"),
-			testLoginWrite(t, username, password, "", defaultLeaseTTLVal.Nanoseconds(), []string{"local_group_policy"}),
+			testLoginWrite(t, username, password, "", defaultLeaseTTLVal, []string{"local_group_policy"}),
 			testAccGroups(t, "Everyone", "everyone_group_policy,every_group_policy2"),
-			testLoginWrite(t, username, password, "", defaultLeaseTTLVal.Nanoseconds(), []string{"local_group_policy"}),
+			testLoginWrite(t, username, password, "", defaultLeaseTTLVal, []string{"local_group_policy"}),
 			testConfigUpdate(t, configDataToken),
 			testConfigRead(t, token, configData),
-			testLoginWrite(t, username, password, "", updatedDuration.Nanoseconds(), []string{"everyone_group_policy", "every_group_policy2", "local_group_policy"}),
+			testLoginWrite(t, username, password, "", updatedDuration, []string{"everyone_group_policy", "every_group_policy2", "local_group_policy"}),
 			testAccGroups(t, "local_group2", "testgroup_group_policy"),
-			testLoginWrite(t, username, password, "", updatedDuration.Nanoseconds(), []string{"everyone_group_policy", "every_group_policy2", "local_group_policy", "testgroup_group_policy"}),
+			testLoginWrite(t, username, password, "", updatedDuration, []string{"everyone_group_policy", "every_group_policy2", "local_group_policy", "testgroup_group_policy"}),
 		},
 	})
 }
 
-func testLoginWrite(t *testing.T, username, password, reason string, expectedTTL int64, policies []string) logicaltest.TestStep {
+func testLoginWrite(t *testing.T, username, password, reason string, expectedTTL time.Duration, policies []string) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.UpdateOperation,
 		Path:      "login/" + username,
@@ -86,7 +86,7 @@ func testLoginWrite(t *testing.T, username, password, reason string, expectedTTL
 					return fmt.Errorf("policy mismatch expected %v but got %v", policies, resp.Auth.Policies)
 				}
 
-				actualTTL := resp.Auth.LeaseOptions.TTL.Nanoseconds()
+				actualTTL := resp.Auth.LeaseOptions.TTL
 				if actualTTL != expectedTTL {
 					return fmt.Errorf("TTL mismatch expected %v but got %v", expectedTTL, actualTTL)
 				}

--- a/website/source/docs/auth/okta.html.md
+++ b/website/source/docs/auth/okta.html.md
@@ -91,9 +91,9 @@ Configuration is written to `auth/okta/config`.
 * `token` (string, optional) - The Okta API token.  This is required to query Okta for user group membership. If this is not supplied only locally configured groups will be enabled. This can be generated from http://developer.okta.com/docs/api/getting_started/getting_a_token.html
 * `base_url` (string, optional) - The Okta url. Examples: `oktapreview.com`, The default is `okta.com`
 * `max_ttl` (string, optional) - Maximum duration after which authentication will be expired.
- This must be a string in a format parsable by Go's [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration)
+ Either number of seconds or in a format parsable by Go's [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration)
 * `ttl` (string, optional) - Duration after which authentication will be expired.
- This must be a string in a format parsable by Go's [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration)
+ Either number of seconds or in a format parsable by Go's [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration)
 
 Use `vault path-help` for more details.
 

--- a/website/source/docs/auth/okta.html.md
+++ b/website/source/docs/auth/okta.html.md
@@ -90,6 +90,10 @@ Configuration is written to `auth/okta/config`.
 * `organization` (string, required) - The Okta organization.  This will be the first part of the url `https://XXX.okta.com` url.
 * `token` (string, optional) - The Okta API token.  This is required to query Okta for user group membership. If this is not supplied only locally configured groups will be enabled. This can be generated from http://developer.okta.com/docs/api/getting_started/getting_a_token.html
 * `base_url` (string, optional) - The Okta url. Examples: `oktapreview.com`, The default is `okta.com`
+* `max_ttl` (string, optional) - Maximum duration after which authentication will be expired.
+ This must be a string in a format parsable by Go's [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration)
+* `ttl` (string, optional) - Duration after which authentication will be expired.
+ This must be a string in a format parsable by Go's [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration)
 
 Use `vault path-help` for more details.
 


### PR DESCRIPTION
Allow Okta auth backend to have a TTL different to the system max TTL.

The TTL value is configurable per-backend rather than per-group as when logging in one user may match against multiple groups.