### PR TITLE
Create and persist human-friendly-ish mount accessors

### DIFF
--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -90,6 +90,7 @@ type EnableAuthOptions struct {
 type AuthMount struct {
 	Type        string           `json:"type" structs:"type" mapstructure:"type"`
 	Description string           `json:"description" structs:"description" mapstructure:"description"`
+	Accessor    string           `json:"accessor" structs:"accessor" mapstructure:"accessor"`
 	Config      AuthConfigOutput `json:"config" structs:"config" mapstructure:"config"`
 	Local       bool             `json:"local" structs:"local" mapstructure:"local"`
 }

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -135,6 +135,7 @@ type MountConfigInput struct {
 type MountOutput struct {
 	Type        string            `json:"type" structs:"type"`
 	Description string            `json:"description" structs:"description"`
+	Accessor    string            `json:"accessor" structs:"accessor"`
 	Config      MountConfigOutput `json:"config" structs:"config"`
 	Local       bool              `json:"local" structs:"local"`
 }

--- a/command/auth.go
+++ b/command/auth.go
@@ -332,7 +332,7 @@ func (c *AuthCommand) listMethods() int {
 			replicatedBehavior = "local"
 		}
 		columns = append(columns, fmt.Sprintf(
-			"%s | %s | %s | %s | %s | %s", path, auth.Type, defTTL, maxTTL, replicatedBehavior, auth.Description))
+			"%s | %s | %s | %s | %s | %s | %s", path, auth.Type, auth.Accessor, defTTL, maxTTL, replicatedBehavior, auth.Description))
 	}
 
 	c.Ui.Output(columnize.SimpleFormat(columns))

--- a/command/auth.go
+++ b/command/auth.go
@@ -316,7 +316,7 @@ func (c *AuthCommand) listMethods() int {
 	}
 	sort.Strings(paths)
 
-	columns := []string{"Path | Type | Default TTL | Max TTL | Replication Behavior | Description"}
+	columns := []string{"Path | Type | Accessor | Default TTL | Max TTL | Replication Behavior | Description"}
 	for _, path := range paths {
 		auth := auth[path]
 		defTTL := "system"

--- a/command/mounts.go
+++ b/command/mounts.go
@@ -42,7 +42,7 @@ func (c *MountsCommand) Run(args []string) int {
 	}
 	sort.Strings(paths)
 
-	columns := []string{"Path | Type | Default TTL | Max TTL | Force No Cache | Replication Behavior | Description"}
+	columns := []string{"Path | Type | Accessor | Default TTL | Max TTL | Force No Cache | Replication Behavior | Description"}
 	for _, path := range paths {
 		mount := mounts[path]
 		defTTL := "system"
@@ -68,7 +68,7 @@ func (c *MountsCommand) Run(args []string) int {
 			replicatedBehavior = "local"
 		}
 		columns = append(columns, fmt.Sprintf(
-			"%s | %s | %s | %s | %v | %s | %s", path, mount.Type, defTTL, maxTTL,
+			"%s | %s | %s | %s | %s | %v | %s | %s", path, mount.Type, mount.Accessor, defTTL, maxTTL,
 			mount.Config.ForceNoCache, replicatedBehavior, mount.Description))
 	}
 

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -221,6 +221,13 @@ func TestSysMounts_headerAuth(t *testing.T) {
 	testResponseBody(t, resp, &actual)
 
 	expected["request_id"] = actual["request_id"]
+	for k, v := range actual["data"].(map[string]interface{}) {
+		if v.(map[string]interface{})["accessor"] == "" {
+			t.Fatalf("no accessor from %s", k)
+		}
+		expected[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+		expected["data"].(map[string]interface{})[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+	}
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad:\nExpected: %#v\nActual: %#v\n", expected, actual)

--- a/http/sys_auth_test.go
+++ b/http/sys_auth_test.go
@@ -49,6 +49,13 @@ func TestSysAuth(t *testing.T) {
 	testResponseBody(t, resp, &actual)
 
 	expected["request_id"] = actual["request_id"]
+	for k, v := range actual["data"].(map[string]interface{}) {
+		if v.(map[string]interface{})["accessor"] == "" {
+			t.Fatalf("no accessor from %s", k)
+		}
+		expected[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+		expected["data"].(map[string]interface{})[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+	}
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
@@ -120,6 +127,13 @@ func TestSysEnableAuth(t *testing.T) {
 	testResponseBody(t, resp, &actual)
 
 	expected["request_id"] = actual["request_id"]
+	for k, v := range actual["data"].(map[string]interface{}) {
+		if v.(map[string]interface{})["accessor"] == "" {
+			t.Fatalf("no accessor from %s", k)
+		}
+		expected[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+		expected["data"].(map[string]interface{})[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+	}
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)
@@ -176,6 +190,13 @@ func TestSysDisableAuth(t *testing.T) {
 	testResponseBody(t, resp, &actual)
 
 	expected["request_id"] = actual["request_id"]
+	for k, v := range actual["data"].(map[string]interface{}) {
+		if v.(map[string]interface{})["accessor"] == "" {
+			t.Fatalf("no accessor from %s", k)
+		}
+		expected[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+		expected["data"].(map[string]interface{})[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+	}
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: expected:%#v\nactual:%#v", expected, actual)

--- a/http/sys_mount_test.go
+++ b/http/sys_mount_test.go
@@ -91,6 +91,14 @@ func TestSysMounts(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	expected["request_id"] = actual["request_id"]
+	for k, v := range actual["data"].(map[string]interface{}) {
+		if v.(map[string]interface{})["accessor"] == "" {
+			t.Fatalf("no accessor from %s", k)
+		}
+		expected[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+		expected["data"].(map[string]interface{})[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+	}
+
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
@@ -204,6 +212,14 @@ func TestSysMount(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	expected["request_id"] = actual["request_id"]
+	for k, v := range actual["data"].(map[string]interface{}) {
+		if v.(map[string]interface{})["accessor"] == "" {
+			t.Fatalf("no accessor from %s", k)
+		}
+		expected[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+		expected["data"].(map[string]interface{})[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+	}
+
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
@@ -339,6 +355,14 @@ func TestSysRemount(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	expected["request_id"] = actual["request_id"]
+	for k, v := range actual["data"].(map[string]interface{}) {
+		if v.(map[string]interface{})["accessor"] == "" {
+			t.Fatalf("no accessor from %s", k)
+		}
+		expected[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+		expected["data"].(map[string]interface{})[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+	}
+
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
@@ -435,6 +459,14 @@ func TestSysUnmount(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	expected["request_id"] = actual["request_id"]
+	for k, v := range actual["data"].(map[string]interface{}) {
+		if v.(map[string]interface{})["accessor"] == "" {
+			t.Fatalf("no accessor from %s", k)
+		}
+		expected[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+		expected["data"].(map[string]interface{})[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+	}
+
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
@@ -548,6 +580,14 @@ func TestSysTuneMount(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	expected["request_id"] = actual["request_id"]
+	for k, v := range actual["data"].(map[string]interface{}) {
+		if v.(map[string]interface{})["accessor"] == "" {
+			t.Fatalf("no accessor from %s", k)
+		}
+		expected[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+		expected["data"].(map[string]interface{})[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+	}
+
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad: %#v", actual)
 	}
@@ -683,6 +723,14 @@ func TestSysTuneMount(t *testing.T) {
 	testResponseStatus(t, resp, 200)
 	testResponseBody(t, resp, &actual)
 	expected["request_id"] = actual["request_id"]
+	for k, v := range actual["data"].(map[string]interface{}) {
+		if v.(map[string]interface{})["accessor"] == "" {
+			t.Fatalf("no accessor from %s", k)
+		}
+		expected[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+		expected["data"].(map[string]interface{})[k].(map[string]interface{})["accessor"] = v.(map[string]interface{})["accessor"]
+	}
+
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("bad:\nExpected: %#v\nActual:%#v", expected, actual)
 	}

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -80,7 +80,7 @@ func (c *Core) enableAudit(entry *MountEntry) error {
 		entry.UUID = entryUUID
 	}
 	if entry.Accessor == "" {
-		accessor, err := generateMountAccessor(entry.Type)
+		accessor, err := c.generateMountAccessor("audit_" + entry.Type)
 		if err != nil {
 			return err
 		}
@@ -209,7 +209,7 @@ func (c *Core) loadAudits() error {
 				needPersist = true
 			}
 			if entry.Accessor == "" {
-				accessor, err := generateMountAccessor(entry.Type)
+				accessor, err := c.generateMountAccessor("audit_" + entry.Type)
 				if err != nil {
 					return err
 				}

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -79,6 +79,13 @@ func (c *Core) enableAudit(entry *MountEntry) error {
 		}
 		entry.UUID = entryUUID
 	}
+	if entry.Accessor == "" {
+		accessor, err := generateMountAccessor(entry.Type)
+		if err != nil {
+			return err
+		}
+		entry.Accessor = accessor
+	}
 	viewPath := auditBarrierPrefix + entry.UUID + "/"
 	view := NewBarrierView(c.barrier, viewPath)
 
@@ -199,6 +206,14 @@ func (c *Core) loadAudits() error {
 		for _, entry := range c.audit.Entries {
 			if entry.Table == "" {
 				entry.Table = c.audit.Type
+				needPersist = true
+			}
+			if entry.Accessor == "" {
+				accessor, err := generateMountAccessor(entry.Type)
+				if err != nil {
+					return err
+				}
+				entry.Accessor = accessor
 				needPersist = true
 			}
 		}

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -220,16 +220,18 @@ func TestCore_EnableAudit_Local(t *testing.T) {
 		Type: auditTableType,
 		Entries: []*MountEntry{
 			&MountEntry{
-				Table: auditTableType,
-				Path:  "noop/",
-				Type:  "noop",
-				UUID:  "abcd",
+				Table:    auditTableType,
+				Path:     "noop/",
+				Type:     "noop",
+				UUID:     "abcd",
+				Accessor: "noop-abcd",
 			},
 			&MountEntry{
-				Table: auditTableType,
-				Path:  "noop2/",
-				Type:  "noop",
-				UUID:  "bcde",
+				Table:    auditTableType,
+				Path:     "noop2/",
+				Type:     "noop",
+				UUID:     "bcde",
+				Accessor: "noop-bcde",
 			},
 		},
 	}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -86,7 +86,7 @@ func (c *Core) enableCredential(entry *MountEntry) error {
 		entry.UUID = entryUUID
 	}
 	if entry.Accessor == "" {
-		accessor, err := generateMountAccessor(entry.Type)
+		accessor, err := c.generateMountAccessor("auth_" + entry.Type)
 		if err != nil {
 			return err
 		}
@@ -290,7 +290,7 @@ func (c *Core) loadCredentials() error {
 				needPersist = true
 			}
 			if entry.Accessor == "" {
-				accessor, err := generateMountAccessor(entry.Type)
+				accessor, err := c.generateMountAccessor("auth_" + entry.Type)
 				if err != nil {
 					return err
 				}
@@ -303,7 +303,7 @@ func (c *Core) loadCredentials() error {
 			return nil
 		}
 	} else {
-		c.auth = defaultAuthTable()
+		c.auth = c.defaultAuthTable()
 	}
 
 	if err := c.persistAuth(c.auth, false); err != nil {
@@ -499,7 +499,7 @@ func (c *Core) newCredentialBackend(
 }
 
 // defaultAuthTable creates a default auth table
-func defaultAuthTable() *MountTable {
+func (c *Core) defaultAuthTable() *MountTable {
 	table := &MountTable{
 		Type: credentialTableType,
 	}
@@ -507,7 +507,7 @@ func defaultAuthTable() *MountTable {
 	if err != nil {
 		panic(fmt.Sprintf("could not generate UUID for default auth table token entry: %v", err))
 	}
-	tokenAccessor, err := generateMountAccessor("token")
+	tokenAccessor, err := c.generateMountAccessor("auth_token")
 	if err != nil {
 		panic(fmt.Sprintf("could not generate accessor for default auth table token entry: %v", err))
 	}

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -99,16 +99,18 @@ func TestCore_EnableCredential_Local(t *testing.T) {
 		Type: credentialTableType,
 		Entries: []*MountEntry{
 			&MountEntry{
-				Table: credentialTableType,
-				Path:  "noop/",
-				Type:  "noop",
-				UUID:  "abcd",
+				Table:    credentialTableType,
+				Path:     "noop/",
+				Type:     "noop",
+				UUID:     "abcd",
+				Accessor: "noop-abcd",
 			},
 			&MountEntry{
-				Table: credentialTableType,
-				Path:  "noop2/",
-				Type:  "noop",
-				UUID:  "bcde",
+				Table:    credentialTableType,
+				Path:     "noop2/",
+				Type:     "noop",
+				UUID:     "bcde",
+				Accessor: "noop-bcde",
 			},
 		},
 	}

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -349,7 +349,8 @@ func TestCore_DisableCredential_Cleanup(t *testing.T) {
 }
 
 func TestDefaultAuthTable(t *testing.T) {
-	table := defaultAuthTable()
+	c, _, _ := TestCoreUnsealed(t)
+	table := c.defaultAuthTable()
 	verifyDefaultAuthTable(t, table)
 }
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1160,6 +1160,7 @@ func (b *SystemBackend) handleMountTable(
 		info := map[string]interface{}{
 			"type":        entry.Type,
 			"description": entry.Description,
+			"accessor":    entry.Accessor,
 			"config": map[string]interface{}{
 				"default_lease_ttl": int64(entry.Config.DefaultLeaseTTL.Seconds()),
 				"max_lease_ttl":     int64(entry.Config.MaxLeaseTTL.Seconds()),

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1657,6 +1657,7 @@ func (b *SystemBackend) handleAuthTable(
 		info := map[string]interface{}{
 			"type":        entry.Type,
 			"description": entry.Description,
+			"accessor":    entry.Accessor,
 			"config": map[string]interface{}{
 				"default_lease_ttl": int64(entry.Config.DefaultLeaseTTL.Seconds()),
 				"max_lease_ttl":     int64(entry.Config.MaxLeaseTTL.Seconds()),

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -115,6 +115,7 @@ func TestSystemBackend_mounts(t *testing.T) {
 		"secret/": map[string]interface{}{
 			"type":        "generic",
 			"description": "generic secret storage",
+			"accessor":    resp.Data["secret/"].(map[string]interface{})["accessor"],
 			"config": map[string]interface{}{
 				"default_lease_ttl": resp.Data["secret/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(int64),
 				"max_lease_ttl":     resp.Data["secret/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(int64),
@@ -125,6 +126,7 @@ func TestSystemBackend_mounts(t *testing.T) {
 		"sys/": map[string]interface{}{
 			"type":        "system",
 			"description": "system endpoints used for control, policy and debugging",
+			"accessor":    resp.Data["sys/"].(map[string]interface{})["accessor"],
 			"config": map[string]interface{}{
 				"default_lease_ttl": resp.Data["sys/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(int64),
 				"max_lease_ttl":     resp.Data["sys/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(int64),
@@ -135,6 +137,7 @@ func TestSystemBackend_mounts(t *testing.T) {
 		"cubbyhole/": map[string]interface{}{
 			"description": "per-token private secret storage",
 			"type":        "cubbyhole",
+			"accessor":    resp.Data["cubbyhole/"].(map[string]interface{})["accessor"],
 			"config": map[string]interface{}{
 				"default_lease_ttl": resp.Data["cubbyhole/"].(map[string]interface{})["config"].(map[string]interface{})["default_lease_ttl"].(int64),
 				"max_lease_ttl":     resp.Data["cubbyhole/"].(map[string]interface{})["config"].(map[string]interface{})["max_lease_ttl"].(int64),
@@ -1113,6 +1116,7 @@ func TestSystemBackend_authTable(t *testing.T) {
 		"token/": map[string]interface{}{
 			"type":        "token",
 			"description": "token based credentials",
+			"accessor":    resp.Data["token/"].(map[string]interface{})["accessor"],
 			"config": map[string]interface{}{
 				"default_lease_ttl": int64(0),
 				"max_lease_ttl":     int64(0),

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -93,16 +93,18 @@ func TestCore_Mount_Local(t *testing.T) {
 		Type: mountTableType,
 		Entries: []*MountEntry{
 			&MountEntry{
-				Table: mountTableType,
-				Path:  "noop/",
-				Type:  "generic",
-				UUID:  "abcd",
+				Table:    mountTableType,
+				Path:     "noop/",
+				Type:     "generic",
+				UUID:     "abcd",
+				Accessor: "generic-abcd",
 			},
 			&MountEntry{
-				Table: mountTableType,
-				Path:  "noop2/",
-				Type:  "generic",
-				UUID:  "bcde",
+				Table:    mountTableType,
+				Path:     "noop2/",
+				Type:     "generic",
+				UUID:     "bcde",
+				Accessor: "generic-bcde",
 			},
 		},
 	}

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -428,7 +428,8 @@ func TestCore_Remount_Protected(t *testing.T) {
 }
 
 func TestDefaultMountTable(t *testing.T) {
-	table := defaultMountTable()
+	c, _, _ := TestCoreUnsealed(t)
+	table := c.defaultMountTable()
 	verifyDefaultTable(t, table)
 }
 

--- a/vault/router.go
+++ b/vault/router.go
@@ -14,10 +14,11 @@ import (
 
 // Router is used to do prefix based routing of a request to a logical backend
 type Router struct {
-	l              sync.RWMutex
-	root           *radix.Tree
-	mountUUIDCache *radix.Tree
-	tokenStoreSalt *salt.Salt
+	l                  sync.RWMutex
+	root               *radix.Tree
+	mountUUIDCache     *radix.Tree
+	mountAccessorCache *radix.Tree
+	tokenStoreSalt     *salt.Salt
 
 	// storagePrefix maps the prefix used for storage (ala the BarrierView)
 	// to the backend. This is used to map a key back into the backend that owns it.
@@ -28,9 +29,10 @@ type Router struct {
 // NewRouter returns a new router
 func NewRouter() *Router {
 	r := &Router{
-		root:           radix.New(),
-		storagePrefix:  radix.New(),
-		mountUUIDCache: radix.New(),
+		root:               radix.New(),
+		storagePrefix:      radix.New(),
+		mountUUIDCache:     radix.New(),
+		mountAccessorCache: radix.New(),
 	}
 	return r
 }
@@ -80,6 +82,7 @@ func (r *Router) Mount(backend logical.Backend, prefix string, mountEntry *Mount
 	r.root.Insert(prefix, re)
 	r.storagePrefix.Insert(storageView.prefix, re)
 	r.mountUUIDCache.Insert(re.mountEntry.UUID, re.mountEntry)
+	r.mountAccessorCache.Insert(re.mountEntry.Accessor, re.mountEntry)
 
 	return nil
 }
@@ -103,6 +106,7 @@ func (r *Router) Unmount(prefix string) error {
 	r.root.Delete(prefix)
 	r.storagePrefix.Delete(re.storageView.prefix)
 	r.mountUUIDCache.Delete(re.mountEntry.UUID)
+	r.mountAccessorCache.Delete(re.mountEntry.Accessor)
 
 	return nil
 }
@@ -156,6 +160,22 @@ func (r *Router) MatchingMountByUUID(mountID string) *MountEntry {
 	defer r.l.RUnlock()
 
 	_, raw, ok := r.mountUUIDCache.LongestPrefix(mountID)
+	if !ok {
+		return nil
+	}
+
+	return raw.(*MountEntry)
+}
+
+func (r *Router) MatchingMountByAccessor(mountAccessor string) *MountEntry {
+	if mountAccessor == "" {
+		return nil
+	}
+
+	r.l.RLock()
+	defer r.l.RUnlock()
+
+	_, raw, ok := r.mountAccessorCache.LongestPrefix(mountAccessor)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
These are nicer than using mount UUIDs for identity, and do not expose anything considered sensitive.

A couple of open questions:

1) I used base32 with the smallest length that would avoid padding. The reason I didn't use base64 is to avoid + and / characters which may make using this complicated elsewhere. Anything wrong with this approach?

2) Should audit tables have exposed accessors? I didn't see a point at the moment as users can't use them for anything.

3) Should auth/audit accessors be prefixed? e.g. right now `aws` will be the beginning of the accessor for both the secret mount and credential mount. So should it be `auth-aws` to avoid any confusion and make it easier to understand at a glance what it's applicable to?