### PR TITLE
Typo fix in vault enterprise/replication docs.

### DIFF
--- a/website/source/docs/vault-enterprise/replication/index.html.md
+++ b/website/source/docs/vault-enterprise/replication/index.html.md
@@ -31,7 +31,7 @@ centers.
 
 Multiple Vault clusters communicate in a one-to-many near real-time flow.
 
-The primary cluster acts as the system or record and asynchronously replicates
+The primary cluster acts as the system of record and asynchronously replicates
 most Vault data to a series of remote clusters, known as secondary clusters or
 secondaries.
 


### PR DESCRIPTION
Minor verbiage typo fix in replication documentation.