### PR TITLE
Adding prefixed view of a physical backend

### DIFF
--- a/physical/physical_view.go
+++ b/physical/physical_view.go
@@ -1,0 +1,90 @@
+package physical
+
+import (
+	"fmt"
+	"strings"
+)
+
+// View represents a prefixed view of a physical backend
+type View struct {
+	backend Backend
+	prefix  string
+}
+
+// NewView takes an underlying physical backend and returns
+// a view of it that can only operate with the given prefix.
+func NewView(backend Backend, prefix string) *View {
+	return &View{
+		backend: backend,
+		prefix:  prefix,
+	}
+}
+
+// List the contents of the prefixed view
+func (v *View) List(prefix string) ([]string, error) {
+	if err := v.sanityCheck(prefix); err != nil {
+		return nil, err
+	}
+	return v.backend.List(v.expandKey(prefix))
+}
+
+// Get the key of the prefixed view
+func (v *View) Get(key string) (*Entry, error) {
+	if err := v.sanityCheck(key); err != nil {
+		return nil, err
+	}
+	entry, err := v.backend.Get(v.expandKey(key))
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+	if entry != nil {
+		entry.Key = v.truncateKey(entry.Key)
+	}
+
+	return &Entry{
+		Key:   entry.Key,
+		Value: entry.Value,
+	}, nil
+}
+
+// Put the entry into the prefix view
+func (v *View) Put(entry *Entry) error {
+	if err := v.sanityCheck(entry.Key); err != nil {
+		return err
+	}
+
+	nested := &Entry{
+		Key:   v.expandKey(entry.Key),
+		Value: entry.Value,
+	}
+	return v.backend.Put(nested)
+}
+
+// Delete the entry from the prefix view
+func (v *View) Delete(key string) error {
+	if err := v.sanityCheck(key); err != nil {
+		return err
+	}
+	return v.backend.Delete(v.expandKey(key))
+}
+
+// sanityCheck is used to perform a sanity check on a key
+func (v *View) sanityCheck(key string) error {
+	if strings.Contains(key, "..") {
+		return fmt.Errorf("key cannot be relative path")
+	}
+	return nil
+}
+
+// expandKey is used to expand to the full key path with the prefix
+func (v *View) expandKey(suffix string) string {
+	return v.prefix + suffix
+}
+
+// truncateKey is used to remove the prefix of the key
+func (v *View) truncateKey(full string) string {
+	return strings.TrimPrefix(full, v.prefix)
+}

--- a/physical/physical_view_test.go
+++ b/physical/physical_view_test.go
@@ -1,0 +1,112 @@
+package physical
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/helper/logformat"
+	log "github.com/mgutz/logxi/v1"
+)
+
+func TestPhysicalView_impl(t *testing.T) {
+	var _ Backend = new(View)
+}
+
+func newInmemTestBackend() *InmemBackend {
+	logger := logformat.NewVaultLogger(log.LevelTrace)
+	return NewInmem(logger)
+}
+
+func TestPhysicalView_BadKeysKeys(t *testing.T) {
+	backend := newInmemTestBackend()
+	view := NewView(backend, "foo/")
+
+	_, err := view.List("../")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	_, err = view.Get("../")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	err = view.Delete("../foo")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	le := &Entry{
+		Key:   "../foo",
+		Value: []byte("test"),
+	}
+	err = view.Put(le)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestPhysicalView(t *testing.T) {
+	backend := newInmemTestBackend()
+	view := NewView(backend, "foo/")
+
+	// Write a key outside of foo/
+	entry := &Entry{Key: "test", Value: []byte("test")}
+	if err := backend.Put(entry); err != nil {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// List should have no visibility
+	keys, err := view.List("")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("bad: %v", err)
+	}
+
+	// Get should have no visibility
+	out, err := view.Get("test")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("bad: %v", out)
+	}
+
+	// Try to put the same entry via the view
+	if err := view.Put(entry); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check it is nested
+	entry, err = backend.Get("foo/test")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if entry == nil {
+		t.Fatalf("missing nested foo/test")
+	}
+
+	// Delete nested
+	if err := view.Delete("test"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check the nested key
+	entry, err = backend.Get("foo/test")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if entry != nil {
+		t.Fatalf("nested foo/test should be gone")
+	}
+
+	// Check the non-nested key
+	entry, err = backend.Get("test")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if entry == nil {
+		t.Fatalf("root test missing")
+	}
+}


### PR DESCRIPTION
This view implements the ClearableView interface to all for clearing out subsets of physical entries from the backend.