### PR TITLE
Input validation for router mount

### DIFF
--- a/vault/router.go
+++ b/vault/router.go
@@ -79,6 +79,17 @@ func (r *Router) Mount(backend logical.Backend, prefix string, mountEntry *Mount
 		loginPaths:  pathsToRadix(paths.Unauthenticated),
 	}
 
+	switch {
+	case prefix == "":
+		return fmt.Errorf("missing prefix to be used for router entry")
+	case storageView.prefix == "":
+		return fmt.Errorf("missing storage view prefix")
+	case re.mountEntry.UUID == "":
+		return fmt.Errorf("missing mount identifier")
+	case re.mountEntry.Accessor == "":
+		return fmt.Errorf("missing mount accessor")
+	}
+
 	r.root.Insert(prefix, re)
 	r.storagePrefix.Insert(storageView.prefix, re)
 	r.mountUUIDCache.Insert(re.mountEntry.UUID, re.mountEntry)

--- a/vault/router.go
+++ b/vault/router.go
@@ -81,13 +81,13 @@ func (r *Router) Mount(backend logical.Backend, prefix string, mountEntry *Mount
 
 	switch {
 	case prefix == "":
-		return fmt.Errorf("missing prefix to be used for router entry")
+		return fmt.Errorf("missing prefix to be used for router entry; mount_path: %q, mount_type: %q", re.mountEntry.Path, re.mountEntry.Type)
 	case storageView.prefix == "":
-		return fmt.Errorf("missing storage view prefix")
+		return fmt.Errorf("missing storage view prefix; mount_path: %q, mount_type: %q", re.mountEntry.Path, re.mountEntry.Type)
 	case re.mountEntry.UUID == "":
-		return fmt.Errorf("missing mount identifier")
+		return fmt.Errorf("missing mount identifier; mount_path: %q, mount_type: %q", re.mountEntry.Path, re.mountEntry.Type)
 	case re.mountEntry.Accessor == "":
-		return fmt.Errorf("missing mount accessor")
+		return fmt.Errorf("missing mount accessor; mount_path: %q, mount_type: %q", re.mountEntry.Path, re.mountEntry.Type)
 	}
 
 	r.root.Insert(prefix, re)


### PR DESCRIPTION
This ensures that we don't insert any invalid item to caches maintained by router. If an entry is inserted into the router's cache with an empty index, then LongestPrefix query on that cache will return this very same entry on *any* input.