### PR TITLE
Return 404 error instead of (nil, nil)

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -31,6 +32,9 @@ var (
 
 		return ""
 	}
+
+	// Err404 is the error returned when the server receives a 404 response
+	Err404 = errors.New("status code 404 received from server")
 )
 
 // Logical is used to perform logical backend operations on Vault.
@@ -50,7 +54,7 @@ func (c *Logical) Read(path string) (*Secret, error) {
 		defer resp.Body.Close()
 	}
 	if resp != nil && resp.StatusCode == 404 {
-		return nil, nil
+		return nil, Err404
 	}
 	if err != nil {
 		return nil, err
@@ -70,7 +74,7 @@ func (c *Logical) List(path string) (*Secret, error) {
 		defer resp.Body.Close()
 	}
 	if resp != nil && resp.StatusCode == 404 {
-		return nil, nil
+		return nil, Err404
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Expected Behavior:
When the API client encounters a 404 error, it should return an error.

# Observed Behavior: 
It does not return an error, returning `(nil, nil)` instead.

# Why We Should Make This Change:
The current behavior violates the principal of least astonishment. Since the request failed, an error should be produced instead of a silent failure. Also, at present users have no way to tell that the reason they received (nil, nil) is that there was a 404. They would have to look into the source code to see why they received what they did.

# Other Notes
There are other places in the source where `(nil, nil)` is returned, but those are operations which are expected to be stateful (`Delete`, for example) and it is only returned on success.

Additionally, I can't get the tests to pass locally (prior to this PR) so I can't add a test for this change.