### PR TITLE
docs: Added text to clarify that `root` does not refer to AWS root creds

### DIFF
--- a/website/source/docs/secrets/aws/index.html.md
+++ b/website/source/docs/secrets/aws/index.html.md
@@ -28,7 +28,7 @@ $ vault mount aws
 Successfully mounted 'aws' at 'aws'!
 ```
 
-Next, we must configure the root credentials that are used to manage IAM credentials:
+Next, we must configure the credentials that are used to manage IAM credentials:
 
 ```text
 $ vault write aws/config/root \
@@ -36,6 +36,10 @@ $ vault write aws/config/root \
     secret_key=R4nm063hgMVo4BTT5xOs5nHLeLXA6lar7ZJ3Nt0i \
     region=us-east-1
 ```
+
+*Note that `root` does not mean it needs to be your AWS account's root credentials, and it 
+probably should not be.  Create an IAM user with permissions to manage IAM and STS.  
+See below for the specific actions required.*
 
 The following parameters are required:
 
@@ -128,7 +132,8 @@ The [Quick Start](#quick-start) describes how to setup the `aws/creds` endpoint.
 
 ## Root Credentials for Dynamic IAM users
 
-The `aws/config/root` credentials need permission to manage dynamic IAM users.
+The `aws/config/root` credentials need permission to manage dynamic IAM users.  
+This does not mean it needs to be your AWS account's root credentials, and we would not suggest using them.
 Here is an example IAM policy that would grant these permissions:
 
 ```javascript


### PR DESCRIPTION
I had a co-worker read the docs for the AWS secret backend and interpret the `aws/config/root` path to mean that Vault needs/wants the AWS account's root access key/secret to be used.  I understand that's not the case, but I can somewhat see the confusion.  Here's some suggested text to clarify that not only do you not need to use AWS root credentials but it's recommended not to.

Not married to this text at all, it's just a suggestion. But I think it'd be good to make clear one way or another.