### PR TITLE
Stop Vault Package Tests From Swallowing Errors

### DIFF
--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -275,6 +275,9 @@ func TestAESGCMBarrier_MoveIntegrityV1(t *testing.T) {
 	pe, _ := inm.Get("test")
 	pe.Key = "moved"
 	err = inm.Put(pe)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Read from the barrier
 	_, err = b.Get("moved")

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -317,6 +317,9 @@ func TestAESGCMBarrier_MoveIntegrityV2(t *testing.T) {
 	pe, _ := inm.Get("test")
 	pe.Key = "moved"
 	err = inm.Put(pe)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Read from the barrier
 	_, err = b.Get("moved")

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -214,6 +214,9 @@ func TestExpiration_Tidy(t *testing.T) {
 	}
 
 	root, err := exp.tokenStore.rootToken()
+	if err != nil {
+		t.Fatal(err)
+	}
 	le.ClientToken = root.ID
 
 	// Attach a valid token with the leases

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -1232,6 +1232,10 @@ func TestSystemBackend_policyCRUD(t *testing.T) {
 	// Read, and make sure that case has been normalized
 	req = logical.TestRequest(t, logical.ReadOperation, "policy/Foo")
 	resp, err = b.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
 	if resp != nil {
 		t.Fatalf("err: expected nil response, got %#v", *resp)
 	}


### PR DESCRIPTION
I found some places in the tests for the vault package where errors were being ignored.