### PR TITLE
Added documentation for working with MySQL wildcards in GRANT statements.

### DIFF
--- a/website/source/docs/secrets/databases/mysql-maria.html.md
+++ b/website/source/docs/secrets/databases/mysql-maria.html.md
@@ -67,3 +67,31 @@ plugin API](/api/secret/databases/mysql-maria.html) page.
 For more information on the Database secret backend's HTTP API please see the [Database secret
 backend API](/api/secret/databases/index.html) page.
 
+## Examples
+
+### Using wildcards in grant statements
+
+MySQL supports using wildcards in grant statements. These are sometimes needed
+by applications which expect access to a large number of databases inside MySQL.
+This can be realized by using a wildcard in the grant statement. For example if
+you want the user created by Vault to have access to all databases starting with
+`fooapp_` you could use the following creation statement:
+
+```
+CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}'; GRANT SELECT ON `fooapp\_%`.* TO '{{name}}'@'%';
+```
+
+MySQL expects the part in which the wildcards are to be placed inside backticks.
+If you want to add this creation statement to Vault via the Vault CLI you cannot
+simply paste the above statement on the CLI because the shell will interpret the
+text between the backticks as something that must be executed. The easiest way to
+get around this is to encode the creation statement as Base64 and feed this to Vault.
+For example:
+
+```
+$ vault write database/roles/readonly \
+    db_name=mysql \
+    creation_statements="Q1JFQVRFIFVTRVIgJ3t7bmFtZX19J0AnJScgSURFTlRJRklFRCBCWSAne3twYXNzd29yZH19JzsgR1JBTlQgU0VMRUNUIE9OIGBmb29hcHBcXyVgLiogVE8gJ3t7bmFtZX19J0AnJSc7" \
+    default_ttl="1h" \
+    max_ttl="24h"
+```


### PR DESCRIPTION
As discussed in #2940 this pull request adds documentation for using wildcards in creation statements in MySQL. Something that is somewhat common in MySQL and is something that is not super intuitive (hoping to save people some time with this pull request ;-) ).

Due to docker not liking our proxy I wasn't able to test if the documentation came out alright. I was however super-careful and don't see any reason why it shouldn't work so I was hoping you guys could do a quick check if it builds correctly.