### PR TITLE
Allow giving connection_details object to postgresql config

### DIFF
--- a/builtin/logical/postgresql/path_config_connection.go
+++ b/builtin/logical/postgresql/path_config_connection.go
@@ -81,12 +81,27 @@ func (b *backend) pathConnectionWrite(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	connValue := data.Get("value").(string)
 	connURL := data.Get("connection_url").(string)
+
+	// Try "value" string
 	if connURL == "" {
-		if connValue == "" {
-			return logical.ErrorResponse("connection_url parameter must be supplied"), nil
-		} else {
-			connURL = connValue
+		connURL = connValue
+	}
+
+	// Try "connection_details" object
+	if connURL == "" {
+		connDetailsGeneric, ok := data.GetOk("connection_details")
+
+		if ok {
+			connURLGeneric, ok := connDetailsGeneric.(map[string]interface{})["connection_url"]
+
+			if ok {
+				connURL = connURLGeneric.(string)
+			}
 		}
+	}
+
+	if connURL == "" {
+		return logical.ErrorResponse("connection_url parameter must be supplied"), nil
 	}
 
 	maxOpenConns := data.Get("max_open_connections").(int)

--- a/plugins/database/postgresql/postgresql_test.go
+++ b/plugins/database/postgresql/postgresql_test.go
@@ -86,6 +86,37 @@ func TestPostgreSQL_Initialize(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
+	// Test connection_deatils object
+	connectionDetails = map[string]interface{}{
+		"connection_details": map[string]interface{}{
+			"connection_url": connURL,
+		},
+		"max_open_connections": 5,
+	}
+
+	dbRaw, _ = New()
+	db = dbRaw.(*PostgreSQL)
+
+	connProducer = db.ConnectionProducer.(*connutil.SQLConnectionProducer)
+
+	err = db.Initialize(connectionDetails, true)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !connProducer.Initialized {
+		t.Fatal("Database should be initalized")
+	}
+
+	if connProducer.ConnectionURL != connURL {
+		t.Fatal("Connection URL should match the one passed in")
+	}
+
+	err = db.Close()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
 	// Test decoding a string value for max_open_connections
 	connectionDetails = map[string]interface{}{
 		"connection_url":       connURL,

--- a/plugins/helper/database/connutil/sql.go
+++ b/plugins/helper/database/connutil/sql.go
@@ -39,6 +39,18 @@ func (c *SQLConnectionProducer) Initialize(conf map[string]interface{}, verifyCo
 	}
 
 	if len(c.ConnectionURL) == 0 {
+		connDetailsGeneric, ok := conf["connection_details"]
+
+		if ok {
+			connURLGeneric, ok := connDetailsGeneric.(map[string]interface{})["connection_url"]
+
+			if ok {
+				c.ConnectionURL = connURLGeneric.(string)
+			}
+		}
+	}
+
+	if len(c.ConnectionURL) == 0 {
 		return fmt.Errorf("connection_url cannot be empty")
 	}
 


### PR DESCRIPTION
Fixes #2962 

Opening super early to get some feedback, since I haven't worked much at all with go before.

~It seems like I might have looked in the wrong place for actually implementing this, any pointers would be very appreciated...~

~Think that I have found it~

🤔 hmm, now it instead creates an `connection_details: { connection_details: { connection_url: "..." } }` structure when reading the value back...
