### PR TITLE
Specify allowed headers explicitly instead of using a wildcard

### DIFF
--- a/http/cors.go
+++ b/http/cors.go
@@ -10,7 +10,7 @@ import (
 )
 
 var preflightHeaders = map[string]string{
-	"Access-Control-Allow-Headers": "*",
+	"Access-Control-Allow-Headers": "X-Vault-Token",
 	"Access-Control-Max-Age":       "300",
 }
 

--- a/http/cors.go
+++ b/http/cors.go
@@ -10,7 +10,7 @@ import (
 )
 
 var preflightHeaders = map[string]string{
-	"Access-Control-Allow-Headers": "X-Vault-Token",
+	"Access-Control-Allow-Headers": "Content-Type, X-Requested-With, X-Vault-Token",
 	"Access-Control-Max-Age":       "300",
 }
 

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -78,7 +78,7 @@ func TestHandler_cors(t *testing.T) {
 	//
 	expHeaders := map[string]string{
 		"Access-Control-Allow-Origin":  addr,
-		"Access-Control-Allow-Headers": "X-Vault-Token",
+		"Access-Control-Allow-Headers": "Content-Type, X-Requested-With, X-Vault-Token",
 		"Access-Control-Max-Age":       "300",
 		"Vary": "Origin",
 	}

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -78,7 +78,7 @@ func TestHandler_cors(t *testing.T) {
 	//
 	expHeaders := map[string]string{
 		"Access-Control-Allow-Origin":  addr,
-		"Access-Control-Allow-Headers": "*",
+		"Access-Control-Allow-Headers": "X-Vault-Token",
 		"Access-Control-Max-Age":       "300",
 		"Vary": "Origin",
 	}


### PR DESCRIPTION
While testing out the recently merged CORS support I faced this error in both Chrome and Firefox:

```
XMLHttpRequest cannot load http://127.0.0.1:8200/v1/secret/path. Request header field X-Vault-Token is not allowed by Access-Control-Allow-Headers in preflight response.
```

Vault sets the value of `Access-Control-Allow-Headers` to `*`. This, it turns out, is still an open spec issue and has not yet been merged in either Chrome or Firefox: https://github.com/whatwg/fetch/issues/548

The fix is to explicitly specify the list of headers that should be allowed e.g. `Content-Type`, `X-Vault-Token`, etc. The changes here fix that.