### PR TITLE
Kerberos/GSSAPI backend feature request

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -336,12 +337,23 @@ func (c *Client) Clone() (*Client, error) {
 // configured for this client. This is an advanced method and generally
 // doesn't need to be called externally.
 func (c *Client) NewRequest(method, requestPath string) *Request {
+	// if SRV records exist (see https://tools.ietf.org/html/draft-andrews-http-srv-02), lookup the SRV
+	// record and take the highest match; this is not designed for high-availability, just discovery
+	var host string = c.addr.Host
+	if c.addr.Port() == "" {
+		// Internet Draft specifies that the SRV record is ignored if a port is given
+		_, addrs, err := net.LookupSRV("http", "tcp", c.addr.Hostname())
+		if err == nil {
+			host = fmt.Sprintf("%s:%d", addrs[0].Target, addrs[0].Port)
+		}
+	}
+
 	req := &Request{
 		Method: method,
 		URL: &url.URL{
 			User:   c.addr.User,
 			Scheme: c.addr.Scheme,
-			Host:   c.addr.Host,
+			Host:   host,
 			Path:   path.Join(c.addr.Path, requestPath),
 		},
 		ClientToken: c.token,

--- a/api/client.go
+++ b/api/client.go
@@ -3,7 +3,6 @@ package api
 import (
 	"crypto/tls"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -337,23 +336,12 @@ func (c *Client) Clone() (*Client, error) {
 // configured for this client. This is an advanced method and generally
 // doesn't need to be called externally.
 func (c *Client) NewRequest(method, requestPath string) *Request {
-	// if SRV records exist (see https://tools.ietf.org/html/draft-andrews-http-srv-02), lookup the SRV
-	// record and take the highest match; this is not designed for high-availability, just discovery
-	var host string = c.addr.Host
-	if c.addr.Port() == "" {
-		// Internet Draft specifies that the SRV record is ignored if a port is given
-		_, addrs, err := net.LookupSRV("http", "tcp", c.addr.Hostname())
-		if err == nil {
-			host = fmt.Sprintf("%s:%d", addrs[0].Target, addrs[0].Port)
-		}
-	}
-
 	req := &Request{
 		Method: method,
 		URL: &url.URL{
 			User:   c.addr.User,
 			Scheme: c.addr.Scheme,
-			Host:   host,
+			Host:   c.addr.Host,
 			Path:   path.Join(c.addr.Path, requestPath),
 		},
 		ClientToken: c.token,

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -13,6 +13,7 @@ import (
 	credAws "github.com/hashicorp/vault/builtin/credential/aws"
 	credCert "github.com/hashicorp/vault/builtin/credential/cert"
 	credGitHub "github.com/hashicorp/vault/builtin/credential/github"
+	credKerberos "github.com/hashicorp/vault/builtin/credential/kerberos"
 	credLdap "github.com/hashicorp/vault/builtin/credential/ldap"
 	credOkta "github.com/hashicorp/vault/builtin/credential/okta"
 	credRadius "github.com/hashicorp/vault/builtin/credential/radius"
@@ -79,6 +80,7 @@ func Commands(metaPtr *meta.Meta) map[string]cli.CommandFactory {
 					"ldap":     credLdap.Factory,
 					"okta":     credOkta.Factory,
 					"radius":   credRadius.Factory,
+					"kerberos": credKerberos.Factory,
 				},
 				LogicalBackends: map[string]logical.Factory{
 					"aws":        aws.Factory,
@@ -123,6 +125,7 @@ func Commands(metaPtr *meta.Meta) map[string]cli.CommandFactory {
 					"cert":     &credCert.CLIHandler{},
 					"aws":      &credAws.CLIHandler{},
 					"radius":   &credUserpass.CLIHandler{DefaultMount: "radius"},
+					"kerberos": &credKerberos.CLIHandler{DefaultMount: "kerberos"},
 				},
 			}, nil
 		},

--- a/http/logical.go
+++ b/http/logical.go
@@ -223,6 +223,26 @@ func respondRaw(w http.ResponseWriter, r *http.Request, resp *logical.Response) 
 		}
 	}
 
+	// get any returned headers
+	headersRaw, ok := resp.Data[logical.HTTPHeaders]
+	if !ok {
+		retErr(w, "no headers given")
+		return
+	} else {
+		headers, ok := headersRaw.(map[string]string)
+		if !ok {
+			retErr(w, "returned headers are not a map")
+			return
+		} else {
+			for header, value := range headers {
+				w.Header().Set(header, value)
+			}
+
+			// some headers set now, so response is no longer empty
+			nonEmpty = false
+		}
+	}
+
 	if nonEmpty {
 		// Get the body
 		bodyRaw, ok := resp.Data[logical.HTTPRawBody]

--- a/logical/response.go
+++ b/logical/response.go
@@ -23,6 +23,11 @@ const (
 	// This can only be specified for non-secrets, and should should be similarly
 	// avoided like the HTTPContentType. The value must be an integer.
 	HTTPStatusCode = "http_status_code"
+
+	// HTTPHeaders is a mechanism to support returning HTTP headers with the response.
+	// This can only be specified for non-secrets, and should should be similarly
+	// avoided like the HTTPContentType. The value must be a map of string to string.
+	HTTPHeaders = "http_headers"
 )
 
 // Response is a struct that stores the response of a request.

--- a/vault/router.go
+++ b/vault/router.go
@@ -347,9 +347,15 @@ func (r *Router) routeCommon(req *logical.Request, existenceCheck bool) (*logica
 	originalClientTokenRemainingUses := req.ClientTokenRemainingUses
 	req.ClientTokenRemainingUses = 0
 
-	// Cache the headers and hide them from backends
+	// Cache the headers and hide all but a small, standard set of them from backends
 	headers := req.Headers
-	req.Headers = nil
+	for header := range headers {
+		switch header {
+		case "Authorization":
+		default:
+			delete(req.Headers, header)
+		}
+	}
 
 	// Cache the wrap info of the request
 	var wrapInfo *logical.RequestWrapInfo

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -187,6 +187,12 @@
 			"revisionTime": "2017-06-08T22:14:41Z"
 		},
 		{
+			"checksumSHA1": "m1aIIVtZXprQLTHexJ7e0fBZ/fc=",
+			"path": "github.com/apcera/gssapi",
+			"revision": "5fb4217df13b8e6878046fe1e5c10e560e1b86dc",
+			"revisionTime": "2016-10-10T21:59:02Z"
+		},
+		{
 			"checksumSHA1": "M+ZeYktTT2wak9ZvQ0OZBbIHAGo=",
 			"path": "github.com/armon/go-metrics",
 			"revision": "f036747b9d0e8590f175a5d654a2194a7d9df4b5",


### PR DESCRIPTION
This ER is to request GSSAPI / SPNEGO / Kerberos support in Vault:

Motivation:
Many corporate environments use Kerberos heavily (a variety of flavours) for authentication between users, services, etc. It would be useful for Vault to be able to handle this style of authentication to avoid needing to use yet another form of authentication for getting tokens (i.e. non-SSO) or some kind of gateway to convert between the two.

Requirements:

Authentication process should be possible via two methods
a. Vault client API in the usual manner, using SPNEGO (base64 encoded) strings in the metadata passed to the back-end
b. HTTP browser based auth (where the browser responds to a 401 / WWW-Authenticate: Negotiate request with an SPNEGO token automatically)
Auth backend should use the regular system GSSAPI libraries, via dynamic loading (static compilation doesn't work with glibc) and cgo
Client and service should mutually authenticate, and there should be some client-side verification of the service to ensure it's the service that it's expecting to talk to
Notes:

There's an implied need for a client-side plugin to handle this authentication style, as there are additional token handling requirements for SPNEGO, as well as doing the mutual authentication check.
Go does not have native support for the GSSAPI functions. An incomplete but working wrapper library is at https://github.com/apcera/gssapi; this is the library that was used for the PoC. This will need to be brought in as a dependency to make this functionality work.
POC:
Proof of concept code has been built which incorporates a number of items:

Kerberos auth backend
Patches to the header handling code so that selected headers as passed back and forward
Patches to the client side code to handle the backend communication