### PR TITLE
Properly store iam_server_id_header_value

### DIFF
--- a/builtin/credential/aws/path_config_client_test.go
+++ b/builtin/credential/aws/path_config_client_test.go
@@ -73,4 +73,37 @@ func TestBackend_pathConfigClient(t *testing.T) {
 		t.Fatalf("expected iam_server_id_header_value: '%#v'; returned iam_server_id_header_value: '%#v'",
 			data["iam_server_id_header_value"], resp.Data["iam_server_id_header_value"])
 	}
+
+	data = map[string]interface{}{
+		"iam_server_id_header_value": "vault_server_identification_2718281",
+	}
+	resp, err = b.HandleRequest(&logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/client",
+		Data:      data,
+		Storage:   storage,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && resp.IsError() {
+		t.Fatal("failed to update the client config entry")
+	}
+
+	resp, err = b.HandleRequest(&logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config/client",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.IsError() {
+		t.Fatal("failed to read the client config entry")
+	}
+	if resp.Data["iam_server_id_header_value"] != data["iam_server_id_header_value"] {
+		t.Fatalf("expected iam_server_id_header_value: '%#v'; returned iam_server_id_header_value: '%#v'",
+			data["iam_server_id_header_value"], resp.Data["iam_server_id_header_value"])
+	}
 }


### PR DESCRIPTION
In auth/aws/config/client, when only the iam_server_id_header_value was
being updated on an existing config, it wouldn't get stored because I
was trying to avoid unnecessarily flushing the cache of AWS clients, and
the flag to not flush the cache also meant that the updated entry didn't
get written back to the storage. This now adds a new flag for when
other changes occur that don't require flushing the cache but do require
getting written to the storage. It also adds a test for this explicitly.

Fixes #3004