### PR TITLE
Adding option to set custom vault client timeout using env variable VAULT_CLIENT_TIMEOUT

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -24,6 +24,7 @@ const EnvVaultCACert = "VAULT_CACERT"
 const EnvVaultCAPath = "VAULT_CAPATH"
 const EnvVaultClientCert = "VAULT_CLIENT_CERT"
 const EnvVaultClientKey = "VAULT_CLIENT_KEY"
+const EnvVaultClientTimeout = "VAULT_CLIENT_TIMEOUT"
 const EnvVaultInsecure = "VAULT_SKIP_VERIFY"
 const EnvVaultTLSServerName = "VAULT_TLS_SERVER_NAME"
 const EnvVaultWrapTTL = "VAULT_WRAP_TTL"
@@ -183,6 +184,13 @@ func (c *Config) ReadEnvironment() error {
 	if v := os.Getenv(EnvVaultClientKey); v != "" {
 		envClientKey = v
 	}
+	if t := os.Getenv(EnvVaultClientTimeout); t != "" {
+		clientTimeout, err := strconv.ParseUint(t, 10, 32)
+		if err != nil {
+			return err
+		}
+		c.HttpClient.Timeout = time.Second * time.Duration(clientTimeout)
+	}
 	if v := os.Getenv(EnvVaultInsecure); v != "" {
 		var err error
 		envInsecure, err = strconv.ParseBool(v)
@@ -302,6 +310,11 @@ func (c *Client) Address() string {
 // SetMaxRetries sets the number of retries that will be used in the case of certain errors
 func (c *Client) SetMaxRetries(retries int) {
 	c.config.MaxRetries = retries
+}
+
+// SetClientTimeout sets the client request timeout
+func (c *Client) SetClientTimeout(timeout time.Duration) {
+	c.config.HttpClient.Timeout = timeout
 }
 
 // SetWrappingLookupFunc sets a lookup function that returns desired wrap TTLs

--- a/api/client.go
+++ b/api/client.go
@@ -228,7 +228,7 @@ func (c *Config) ReadEnvironment() error {
 		c.MaxRetries = int(*envMaxRetries) + 1
 	}
 
-	if envClientTimeout != time.Second*0 {
+	if envClientTimeout != 0 {
 		c.Timeout = envClientTimeout
 	}
 
@@ -384,7 +384,7 @@ func (c *Client) NewRequest(method, requestPath string) *Request {
 	} else {
 		req.WrapTTL = DefaultWrappingLookupFunc(method, lookupPath)
 	}
-	if c.config.Timeout != time.Second*0 {
+	if c.config.Timeout != 0 {
 		c.config.HttpClient.Timeout = c.config.Timeout
 	}
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 )
 
 func init() {
@@ -158,5 +159,22 @@ func TestClientEnvSettings(t *testing.T) {
 	}
 	if tlsConfig.InsecureSkipVerify != true {
 		t.Fatalf("bad: %v", tlsConfig.InsecureSkipVerify)
+	}
+}
+
+func TestClientTimeout(t *testing.T) {
+	oldClientTimeout := os.Getenv(EnvVaultClientTimeout)
+	os.Setenv(EnvVaultClientTimeout, "10")
+	defer os.Setenv(EnvVaultClientTimeout, oldClientTimeout)
+	config := DefaultConfig()
+	config.ReadEnvironment()
+
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if client.config.HttpClient.Timeout != time.Second*10 {
+		t.Fatalf("error setting client timeout")
 	}
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -162,19 +162,26 @@ func TestClientEnvSettings(t *testing.T) {
 	}
 }
 
-func TestClientTimeout(t *testing.T) {
+func TestClientTimeoutSetting(t *testing.T) {
 	oldClientTimeout := os.Getenv(EnvVaultClientTimeout)
 	os.Setenv(EnvVaultClientTimeout, "10")
 	defer os.Setenv(EnvVaultClientTimeout, oldClientTimeout)
 	config := DefaultConfig()
 	config.ReadEnvironment()
-
 	client, err := NewClient(config)
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	_ = client.NewRequest("PUT", "/")
 	if client.config.HttpClient.Timeout != time.Second*10 {
-		t.Fatalf("error setting client timeout")
+		t.Fatalf("error setting client timeout using env variable")
 	}
+
+	// Setting custom client timeout for a new request
+	client.SetClientTimeout(time.Second * 20)
+	_ = client.NewRequest("PUT", "/")
+	if client.config.HttpClient.Timeout != time.Second*20 {
+		t.Fatalf("error setting client timeout using SetClientTimeout")
+	}
+
 }

--- a/website/source/docs/commands/environment.html.md
+++ b/website/source/docs/commands/environment.html.md
@@ -44,6 +44,10 @@ The following table describes them:
     <td>Path to an unencrypted PEM-encoded private key matching the client certificate.</td>
   </tr>
   <tr>
+    <td><tt>VAULT_CLIENT_TIMEOUT</tt></td>
+    <td>Timeout variable for the vault client. Default value is 60 seconds.</td>
+  </tr>
+  <tr>
     <td><tt>VAULT_CLUSTER_ADDR</tt></td>
     <td>The address that should be used for other cluster members to connect to this node when in High Availability mode.</td>
   </tr>


### PR DESCRIPTION
Fixes #2956 

Option to set the vault client timeout using env var VAULT_CLIENT_TIMEOUT has been added.
Added a new function SetClientTimeout which can set the client timeout through api config.