### PR TITLE
Add field type TypeNameString

### DIFF
--- a/logical/framework/field_data_test.go
+++ b/logical/framework/field_data_test.go
@@ -301,7 +301,7 @@ func TestFieldDataGet_Error(t *testing.T) {
 		Raw    map[string]interface{}
 		Key    string
 	}{
-		"name string type, valid value with invalid characters": {
+		"name string type, invalid value with invalid characters": {
 			map[string]*FieldSchema{
 				"foo": &FieldSchema{Type: TypeNameString},
 			},
@@ -310,7 +310,7 @@ func TestFieldDataGet_Error(t *testing.T) {
 			},
 			"foo",
 		},
-		"name string type, valid value with special characters at beginning": {
+		"name string type, invalid value with special characters at beginning": {
 			map[string]*FieldSchema{
 				"foo": &FieldSchema{Type: TypeNameString},
 			},
@@ -319,12 +319,21 @@ func TestFieldDataGet_Error(t *testing.T) {
 			},
 			"foo",
 		},
-		"name string type, valid value with special characters at end": {
+		"name string type, invalid value with special characters at end": {
 			map[string]*FieldSchema{
 				"foo": &FieldSchema{Type: TypeNameString},
 			},
 			map[string]interface{}{
 				"foo": "barbaz-",
+			},
+			"foo",
+		},
+		"name string type, empty string": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeNameString},
+			},
+			map[string]interface{}{
+				"foo": "",
 			},
 			"foo",
 		},

--- a/logical/framework/field_data_test.go
+++ b/logical/framework/field_data_test.go
@@ -256,6 +256,28 @@ func TestFieldDataGet(t *testing.T) {
 			"foo",
 			[]string{},
 		},
+
+		"name string type, valid string": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeNameString},
+			},
+			map[string]interface{}{
+				"foo": "bar",
+			},
+			"foo",
+			"bar",
+		},
+
+		"name string type, valid value with special characters": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeNameString},
+			},
+			map[string]interface{}{
+				"foo": "bar.baz-bay123",
+			},
+			"foo",
+			"bar.baz-bay123",
+		},
 	}
 
 	for name, tc := range cases {
@@ -269,6 +291,54 @@ func TestFieldDataGet(t *testing.T) {
 			t.Fatalf(
 				"bad: %s\n\nExpected: %#v\nGot: %#v",
 				name, tc.Value, actual)
+		}
+	}
+}
+
+func TestFieldDataGet_Error(t *testing.T) {
+	cases := map[string]struct {
+		Schema map[string]*FieldSchema
+		Raw    map[string]interface{}
+		Key    string
+	}{
+		"name string type, valid value with invalid characters": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeNameString},
+			},
+			map[string]interface{}{
+				"foo": "bar baz",
+			},
+			"foo",
+		},
+		"name string type, valid value with special characters at beginning": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeNameString},
+			},
+			map[string]interface{}{
+				"foo": ".barbaz",
+			},
+			"foo",
+		},
+		"name string type, valid value with special characters at end": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeNameString},
+			},
+			map[string]interface{}{
+				"foo": "barbaz-",
+			},
+			"foo",
+		},
+	}
+
+	for _, tc := range cases {
+		data := &FieldData{
+			Raw:    tc.Raw,
+			Schema: tc.Schema,
+		}
+
+		_, _, err := data.GetOkErr(tc.Key)
+		if err == nil {
+			t.Fatalf("error expected, none received")
 		}
 	}
 }

--- a/logical/framework/field_type.go
+++ b/logical/framework/field_type.go
@@ -23,12 +23,19 @@ const (
 	// slice of strings and also supports parsing a comma-separated list in
 	// a string field
 	TypeCommaStringSlice
+
+	// TypeNameString represents a name that is URI safe and follows specific
+	// rules.  These rules include start and end with an alphanumeric
+	// character and characters in the middle can be alphanumeric or . or -.
+	TypeNameString
 )
 
 func (t FieldType) String() string {
 	switch t {
 	case TypeString:
 		return "string"
+	case TypeNameString:
+		return "name string"
 	case TypeInt:
 		return "int"
 	case TypeBool:


### PR DESCRIPTION
This field is used for parameters that may be used in URIs.  The regular expression used is the same as in `framework.GenericNameRegex`. 