### PR TITLE
Add SRV record functionality for client side host/port discovery of Vault

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -336,12 +337,23 @@ func (c *Client) Clone() (*Client, error) {
 // configured for this client. This is an advanced method and generally
 // doesn't need to be called externally.
 func (c *Client) NewRequest(method, requestPath string) *Request {
+	// if SRV records exist (see https://tools.ietf.org/html/draft-andrews-http-srv-02), lookup the SRV
+	// record and take the highest match; this is not designed for high-availability, just discovery
+	var host string = c.addr.Host
+	if c.addr.Port() == "" {
+		// Internet Draft specifies that the SRV record is ignored if a port is given
+		_, addrs, err := net.LookupSRV("http", "tcp", c.addr.Hostname())
+		if err == nil {
+			  host = fmt.Sprintf("%s:%d", addrs[0].Target, addrs[0].Port)
+		}
+	}
+
 	req := &Request{
 		Method: method,
 		URL: &url.URL{
 			User:   c.addr.User,
 			Scheme: c.addr.Scheme,
-			Host:   c.addr.Host,
+			Host:   host,
 			Path:   path.Join(c.addr.Path, requestPath),
 		},
 		ClientToken: c.token,

--- a/api/client.go
+++ b/api/client.go
@@ -343,7 +343,7 @@ func (c *Client) NewRequest(method, requestPath string) *Request {
 	if c.addr.Port() == "" {
 		// Internet Draft specifies that the SRV record is ignored if a port is given
 		_, addrs, err := net.LookupSRV("http", "tcp", c.addr.Hostname())
-		if err == nil {
+		if err == nil && len(addrs) > 0 {
 			  host = fmt.Sprintf("%s:%d", addrs[0].Target, addrs[0].Port)
 		}
 	}


### PR DESCRIPTION
This PR is to add SRV functionality to the client API to support port discovery for the HTTP service.

e.g. with a SRV record like:

_http._tcp.vault.mydomain.com. IN SRV 10 1 8200 vaulthost1.primarydc.mydomain.com. 

...and the patch, the client can just connect to 'vault.mydomain.com' without needing to specify the port, avoiding the need to hard-code hosts/ports in client-side configs and allowing administrative flexibility with respect to moving services around in a business continuity or less major incident - for example, the record could be changed to:

_http._tcp.vault.mydomain.com. IN SRV 10 1 8200 vaulthost1.secondarydc.mydomain.com. 

New clients/requests will now hit the new location for the service.

The patch does not attempt to handle retries, reconnect, etc - although it could be further developed.