### PR TITLE
Fix typo in rekey documentation

### DIFF
--- a/website/source/guides/rekeying-and-rotating.html.md
+++ b/website/source/guides/rekeying-and-rotating.html.md
@@ -17,7 +17,7 @@ daily Vault use.
 ## Background
 
 In order to prevent no one person from having complete access to the system,
-Vault implores [Shamir's Secret Sharing Algorithm][shamir]. Under this process,
+Vault employs [Shamir's Secret Sharing Algorithm][shamir]. Under this process,
 a secret is divided into a subset of parts such that a subset of those parts are
 needed to reconstruct the original secret. Vault makes heavy use of this
 algorithm as part of the [unsealing process](/docs/concepts/seal.html).


### PR DESCRIPTION
There is a minor typo in the documentation for rekeying Vault. The word "implores" should be changed to "employs".