### PR TITLE
Updated policy format to use capabilities keyword

### DIFF
--- a/website/source/intro/getting-started/policies.html.md
+++ b/website/source/intro/getting-started/policies.html.md
@@ -31,15 +31,15 @@ policy is shown below:
 
 ```javascript
 path "secret/*" {
-  policy = "write"
+  capabilities = ["write"]
 }
 
 path "secret/foo" {
-  policy = "read"
+  capabilities = ["read"]
 }
 
 path "auth/token/lookup-self" {
-  policy = "read"
+  capabilities = ["read"]
 }
 ```
 


### PR DESCRIPTION
The `policy` key name is deprecated and has been replaced with `capabilities`.