### PR TITLE
Recover from panics during request forwarding

### DIFF
--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -389,6 +389,16 @@ func (b *backend) calculateTTL(data *framework.FieldData, role *sshRole) (time.D
 }
 
 func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			errMsg, ok := r.(string)
+			if ok {
+				retCert = nil
+				retErr = errors.New(errMsg)
+			}
+		}
+	}()
+
 	serialNumber, err := certutil.GenerateSerialNumber()
 	if err != nil {
 		return nil, err

--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -389,16 +389,6 @@ func (b *backend) calculateTTL(data *framework.FieldData, role *sshRole) (time.D
 }
 
 func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err, ok := r.(error)
-			if ok {
-				retCert = nil
-				retErr = err
-			}
-		}
-	}()
-
 	serialNumber, err := certutil.GenerateSerialNumber()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When request forwarding, if we have a panic, the entire connection gets killed. Instead, log an error with the panic information.

Fixes #2877 

Note: fix is currently incomplete for the full issue.