### PR TITLE
Make sys/wrapping/lookup unauthenticated.

### DIFF
--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -25,9 +25,7 @@ const (
 	responseWrappingPolicyName = "response-wrapping"
 
 	// responseWrappingPolicy is the policy that ensures cubbyhole response
-	// wrapping can always succeed. Note that sys/wrapping/lookup isn't
-	// contained here because using it would revoke the token anyways, so there
-	// isn't much point.
+	// wrapping can always succeed.
 	responseWrappingPolicy = `
 path "cubbyhole/response" {
     capabilities = ["create", "read"]


### PR DESCRIPTION
We still perform validation on the token, so if the call makes it
through to this endpoint it's got a valid token (either explicitly
specified in data or as the request token). But this allows
introspection for sanity/safety checking without revoking the token in
the process.