### PR TITLE
update littleendian.go to fix issue #3089

### DIFF
--- a/vendor/github.com/SAP/go-hdb/internal/protocol/littleendian.go
+++ b/vendor/github.com/SAP/go-hdb/internal/protocol/littleendian.go
@@ -1,4 +1,4 @@
-// +build amd64 386 arm arm64
+// +build amd64 386 arm arm64 ppc64le
 
 /*
 Copyright 2014 SAP SE


### PR DESCRIPTION
Build fails on ppc64le (#3089), add platform to vendor/github.com/SAP/go-hdb/internal/protocol/littleendian.go to fix this 