### PR TITLE
Remove people from community section

### DIFF
--- a/website/packer.json
+++ b/website/packer.json
@@ -10,15 +10,12 @@
       "type": "docker",
       "image": "hashicorp/middleman-hashicorp:0.3.28",
       "discard": "true",
-      "run_command": ["-d", "-i", "-t", "{{ .Image }}", "/bin/bash"]
+      "volumes": {
+        "{{ pwd }}": "/website"
+      }
     }
   ],
   "provisioners": [
-    {
-      "type": "file",
-      "source": ".",
-      "destination": "/website"
-    },
     {
       "type": "shell",
       "environment_vars": [

--- a/website/source/community.html.erb
+++ b/website/source/community.html.erb
@@ -8,117 +8,28 @@ description: |-
 <h1>Community</h1>
 
 <p>
-Vault is an open source project with a growing community. There are
-active, dedicated users willing to help you through various mediums.
+  Vault is an open source project with a growing community. There are active,
+  dedicated users willing to help you through various mediums.
 </p>
 <p>
-<strong>IRC:</strong> <code>#vault-tool</code> on Freenode
+  <strong>IRC:</strong> <code>#vault-tool</code> on Freenode
 </p>
 <p>
-<strong>Announcement list:</strong>
-<a href="https://groups.google.com/group/hashicorp-announce">HashiCorp Announcement Google Group</a>
+  <strong>Announcement list:</strong>
+  <a href="https://groups.google.com/group/hashicorp-announce">HashiCorp Announcement Google Group</a>
 </p>
 <p>
-<strong>Discussion list:</strong>
-<a href="https://groups.google.com/group/vault-tool">Vault Google Group</a>
+  <strong>Discussion list:</strong>
+  <a href="https://groups.google.com/group/vault-tool">Vault Google Group</a>
 </p>
 <p>
-<strong>Bug Tracker:</strong>
-<a href="https://github.com/hashicorp/vault/issues">Issue tracker
+  <strong>Bug Tracker:</strong>
+  <a href="https://github.com/hashicorp/vault/issues">Issue tracker
 	on GitHub</a>. Please only use this for reporting bugs. Do not ask
-for general help here. Use IRC or the mailing list for that.
+  for general help here. Use IRC or the mailing list for that.
 </p>
 <p>
-<strong>Training:</strong>
-Paid <a href="https://www.hashicorp.com/training.html">HashiCorp training courses</a>
-are also available in a city near you. Private training courses are also available.
+  <strong>Training:</strong>
+  Paid <a href="https://www.hashicorp.com/training.html">HashiCorp training courses</a>
+  are also available in a city near you. Private training courses are also available.
 </p>
-
-<h1>People</h1>
-<p>
-The following people are some of the faces behind Vault. They each
-contribute to Vault in some core way. Over time, faces may appear and
-disappear from this list as contributors come and go. In addition to
-the faces below, Vault is a project by
-<a href="https://www.hashicorp.com">HashiCorp</a>, so many HashiCorp
-employees actively contribute to Vault.
-</p>
-<div class="people">
-	<div class="person">
-		<img class="pull-left" src="https://www.gravatar.com/avatar/54079122b67de9677c1f93933ce8b63a.png?s=125">
-		<div class="bio">
-			<h3>Mitchell Hashimoto (<a href="https://github.com/mitchellh">@mitchellh</a>)</h3>
-			<p>
-			Mitchell Hashimoto is the creator of Vault and works on all
-			layers of Vault from the core to backends. In addition to Vault,
-			Mitchell is the creator of
-			<a href="https://www.vagrantup.com">Vagrant</a>,
-			<a href="https://www.packer.io">Packer</a>,
-			<a href="https://www.consul.io">Consul</a>, and
-			<a href="https://www.terraform.io">Terraform</a>.
-			</p>
-		</div>
-	</div>
-
-	<div class="person">
-		<img class="pull-left" src="https://www.gravatar.com/avatar/11ba9630c9136eef9a70d26473d355d5.png?s=125">
-		<div class="bio">
-			<h3>Armon Dadgar (<a href="https://github.com/armon">@armon</a>)</h3>
-			<p>
-			Armon Dadgar is a creator of Vault. He works on all aspects of Vault,
-			focusing on core architecture and security. Armon is also the creator of
-			<a href="https://www.consul.io">Consul</a>,
-			<a href="https://www.serf.io">Serf</a>,
-			<a href="https://www.terraform.io">Terraform</a>,
-			<a href="https://github.com/armon/statsite">Statsite</a>, and
-			<a href="https://github.com/armon/bloomd">Bloomd</a>.
-			</p>
-		</div>
-	</div>
-
-	<div class="person">
-		<img class="pull-left" src="https://s.gravatar.com/avatar/b32bf8e58ce1929d2d676a353c88f539.png?s=125">
-		<div class="bio">
-			<h3>Jeff Mitchell (<a href="https://github.com/jefferai">@jefferai</a>)</h3>
-			<p>
-			Jeff Mitchell is a core contributor to Vault. He works on all layers of
-			Vault, from the core to backends. Jeff is an employee of HashiCorp and
-			has also contributed to
-			<a href="https://www.consul.io">Consul</a> and
-			<a href="https://www.terraform.io">Terraform</a>,
-			as well as many other open-source projects.
-			</p>
-		</div>
-	</div>
-
-	<div class="person">
-		<img class="pull-left" src="https://s.gravatar.com/avatar/9121c42d73c133a3d1e5201ec00dc938.png?s=125">
-		<div class="bio">
-			<h3>Vishal Nayak (<a href="https://github.com/vishalnayak">@vishalnayak</a>)</h3>
-			<p>
-			Vishal Nayak is a core contributor to Vault. He works on all layers
-			of Vault, from the core to backends. Vishal is an employee of
-			HashiCorp.
-			</p>
-		</div>
-	</div>
-
-	<div class="person">
-		<img class="pull-left" src="https://www.gravatar.com/avatar/2acc31dd6370a54b18f6755cd0710ce6.png?s=125">
-		<div class="bio">
-			<h3>Jack Pearkes (<a href="https://github.com/pearkes">@pearkes</a>)</h3>
-			<p>
-			Jack Pearkes is the creator of the online interactive demo of Vault.
-			He maintains this demo as well as the design and interaction of the
-			Vault website. Jack is an employee of HashiCorp and a primary engineer
-			behind <a href="https://atlas.hashicorp.com">Atlas</a>.
-			He is also a core committer to
-			<a href="https://www.packer.io">Packer</a>,
-			<a href="https://www.consul.io">Consul</a>, and
-			<a href="https://www.terraform.io">Terraform</a>.
-			</p>
-		</div>
-	</div>
-
-	<div class="clearfix"></div>
-</div>


### PR DESCRIPTION
Remove people from community section This is going to be replaced with dynamic content from our CMS in the future, but we agreed to remove it in the interim. 

This also updates the deploy process and brings project-side redirects (if you did not have them already).