### PR TITLE
Direct plugin logs through vault's logger

### DIFF
--- a/builtin/logical/database/dbplugin/client.go
+++ b/builtin/logical/database/dbplugin/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/vault/helper/pluginutil"
+	log "github.com/mgutz/logxi/v1"
 )
 
 // DatabasePluginClient embeds a databasePluginRPCClient and wraps it's Close
@@ -29,13 +30,13 @@ func (dc *DatabasePluginClient) Close() error {
 // newPluginClient returns a databaseRPCClient with a connection to a running
 // plugin. The client is wrapped in a DatabasePluginClient object to ensure the
 // plugin is killed on call of Close().
-func newPluginClient(sys pluginutil.RunnerUtil, pluginRunner *pluginutil.PluginRunner) (Database, error) {
+func newPluginClient(sys pluginutil.RunnerUtil, pluginRunner *pluginutil.PluginRunner, logger log.Logger) (Database, error) {
 	// pluginMap is the map of plugins we can dispense.
 	var pluginMap = map[string]plugin.Plugin{
 		"database": new(DatabasePlugin),
 	}
 
-	client, err := pluginRunner.Run(sys, pluginMap, handshakeConfig, []string{})
+	client, err := pluginRunner.Run(sys, pluginMap, handshakeConfig, []string{}, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/database/dbplugin/plugin.go
+++ b/builtin/logical/database/dbplugin/plugin.go
@@ -62,7 +62,7 @@ func PluginFactory(pluginName string, sys pluginutil.LookRunnerUtil, logger log.
 
 	} else {
 		// create a DatabasePluginClient instance
-		db, err = newPluginClient(sys, pluginRunner)
+		db, err = newPluginClient(sys, pluginRunner, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -30,7 +30,7 @@ func Backend(conf *logical.BackendConfig) (logical.Backend, error) {
 	name := conf.Config["plugin_name"]
 	sys := conf.System
 
-	b, err := bplugin.NewBackend(name, sys)
+	b, err := bplugin.NewBackend(name, sys, conf.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/helper/pluginutil/logger.go
+++ b/helper/pluginutil/logger.go
@@ -1,0 +1,158 @@
+package pluginutil
+
+import (
+	"bytes"
+	"fmt"
+	stdlog "log"
+	"strings"
+
+	hclog "github.com/hashicorp/go-hclog"
+	log "github.com/mgutz/logxi/v1"
+)
+
+// pluginLogFaker is a wrapper on logxi.Logger that
+// implements hclog.Logger
+type hclogFaker struct {
+	logger log.Logger
+
+	name    string
+	implied []interface{}
+}
+
+func (f *hclogFaker) buildLog(msg string, args ...interface{}) (string, []interface{}) {
+	if f.name != "" {
+		msg = fmt.Sprintf("%s: %s", f.name, msg)
+	}
+	args = append(f.implied, args...)
+
+	return msg, args
+}
+
+func (f *hclogFaker) Trace(msg string, args ...interface{}) {
+	msg, args = f.buildLog(msg, args...)
+	f.logger.Trace(msg, args...)
+}
+
+func (f *hclogFaker) Debug(msg string, args ...interface{}) {
+	msg, args = f.buildLog(msg, args...)
+	f.logger.Debug(msg, args...)
+}
+
+func (f *hclogFaker) Info(msg string, args ...interface{}) {
+	msg, args = f.buildLog(msg, args...)
+	f.logger.Info(msg, args...)
+}
+
+func (f *hclogFaker) Warn(msg string, args ...interface{}) {
+	msg, args = f.buildLog(msg, args...)
+	f.logger.Warn(msg, args...)
+}
+
+func (f *hclogFaker) Error(msg string, args ...interface{}) {
+	msg, args = f.buildLog(msg, args...)
+	f.logger.Error(msg, args...)
+}
+
+func (f *hclogFaker) IsTrace() bool {
+	return f.logger.IsTrace()
+}
+
+func (f *hclogFaker) IsDebug() bool {
+	return f.logger.IsDebug()
+}
+
+func (f *hclogFaker) IsInfo() bool {
+	return f.logger.IsInfo()
+}
+
+func (f *hclogFaker) IsWarn() bool {
+	return f.logger.IsWarn()
+}
+
+func (f *hclogFaker) IsError() bool {
+	return !f.logger.IsTrace() && !f.logger.IsDebug() && !f.logger.IsInfo() && !f.IsWarn()
+}
+
+func (f *hclogFaker) With(args ...interface{}) hclog.Logger {
+	var nf = *f
+	nf.implied = append(nf.implied, args...)
+	return f
+}
+
+func (f *hclogFaker) Named(name string) hclog.Logger {
+	var nf = *f
+	if nf.name != "" {
+		nf.name = nf.name + "." + name
+	}
+	return &nf
+}
+
+func (f *hclogFaker) ResetNamed(name string) hclog.Logger {
+	var nf = *f
+	nf.name = name
+	return &nf
+}
+
+func (f *hclogFaker) StandardLogger(opts *hclog.StandardLoggerOptions) *stdlog.Logger {
+	if opts == nil {
+		opts = &hclog.StandardLoggerOptions{}
+	}
+
+	return stdlog.New(&stdlogAdapter{f, opts.InferLevels}, "", 0)
+}
+
+// Provides a io.Writer to shim the data out of *log.Logger
+// and back into our Logger. This is basically the only way to
+// build upon *log.Logger.
+type stdlogAdapter struct {
+	hl          hclog.Logger
+	inferLevels bool
+}
+
+// Take the data, infer the levels if configured, and send it through
+// a regular Logger
+func (s *stdlogAdapter) Write(data []byte) (int, error) {
+	str := string(bytes.TrimRight(data, " \t\n"))
+
+	if s.inferLevels {
+		level, str := s.pickLevel(str)
+		switch level {
+		case hclog.Trace:
+			s.hl.Trace(str)
+		case hclog.Debug:
+			s.hl.Debug(str)
+		case hclog.Info:
+			s.hl.Info(str)
+		case hclog.Warn:
+			s.hl.Warn(str)
+		case hclog.Error:
+			s.hl.Error(str)
+		default:
+			s.hl.Info(str)
+		}
+	} else {
+		s.hl.Info(str)
+	}
+
+	return len(data), nil
+}
+
+// Detect, based on conventions, what log level this is
+func (s *stdlogAdapter) pickLevel(str string) (hclog.Level, string) {
+	switch {
+	case strings.HasPrefix(str, "[DEBUG]"):
+		return hclog.Debug, strings.TrimSpace(str[7:])
+	case strings.HasPrefix(str, "[TRACE]"):
+		return hclog.Trace, strings.TrimSpace(str[7:])
+	case strings.HasPrefix(str, "[INFO]"):
+		return hclog.Info, strings.TrimSpace(str[6:])
+	case strings.HasPrefix(str, "[WARN]"):
+		return hclog.Warn, strings.TrimSpace(str[7:])
+	case strings.HasPrefix(str, "[ERROR]"):
+		return hclog.Error, strings.TrimSpace(str[7:])
+	case strings.HasPrefix(str, "[ERR]"):
+		return hclog.Error, strings.TrimSpace(str[5:])
+	default:
+		return hclog.Info, str
+	}
+}

--- a/helper/pluginutil/runner.go
+++ b/helper/pluginutil/runner.go
@@ -10,6 +10,7 @@ import (
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/wrapping"
+	log "github.com/mgutz/logxi/v1"
 )
 
 // Looker defines the plugin Lookup function that looks into the plugin catalog
@@ -45,7 +46,7 @@ type PluginRunner struct {
 
 // Run takes a wrapper instance, and the go-plugin paramaters and executes a
 // plugin.
-func (r *PluginRunner) Run(wrapper RunnerUtil, pluginMap map[string]plugin.Plugin, hs plugin.HandshakeConfig, env []string) (*plugin.Client, error) {
+func (r *PluginRunner) Run(wrapper RunnerUtil, pluginMap map[string]plugin.Plugin, hs plugin.HandshakeConfig, env []string, logger log.Logger) (*plugin.Client, error) {
 	// Get a CA TLS Certificate
 	certBytes, key, err := generateCert()
 	if err != nil {
@@ -79,12 +80,19 @@ func (r *PluginRunner) Run(wrapper RunnerUtil, pluginMap map[string]plugin.Plugi
 		Hash:     sha256.New(),
 	}
 
+	// Create logger for the plugin client
+	clogger := &hclogFaker{
+		logger: logger,
+	}
+	namedLogger := clogger.ResetNamed("plugin")
+
 	client := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: hs,
 		Plugins:         pluginMap,
 		Cmd:             cmd,
 		TLSConfig:       clientTLSConfig,
 		SecureConfig:    secureConfig,
+		Logger:          namedLogger,
 	})
 
 	return client, nil

--- a/logical/plugin/backend_client.go
+++ b/logical/plugin/backend_client.go
@@ -11,9 +11,8 @@ import (
 // backendPluginClient implements logical.Backend and is the
 // go-plugin client.
 type backendPluginClient struct {
-	broker       *plugin.MuxBroker
-	client       *rpc.Client
-	pluginClient *plugin.Client
+	broker *plugin.MuxBroker
+	client *rpc.Client
 
 	system logical.SystemView
 	logger log.Logger

--- a/logical/plugin/plugin.go
+++ b/logical/plugin/plugin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/vault/helper/pluginutil"
 	"github.com/hashicorp/vault/logical"
+	log "github.com/mgutz/logxi/v1"
 )
 
 // Register these types since we have to serialize and de-serialize tls.ConnectionState
@@ -40,7 +41,7 @@ func (b *BackendPluginClient) Cleanup() {
 // NewBackend will return an instance of an RPC-based client implementation of the backend for
 // external plugins, or a concrete implementation of the backend if it is a builtin backend.
 // The backend is returned as a logical.Backend interface.
-func NewBackend(pluginName string, sys pluginutil.LookRunnerUtil) (logical.Backend, error) {
+func NewBackend(pluginName string, sys pluginutil.LookRunnerUtil, logger log.Logger) (logical.Backend, error) {
 	// Look for plugin in the plugin catalog
 	pluginRunner, err := sys.LookupPlugin(pluginName)
 	if err != nil {
@@ -64,7 +65,7 @@ func NewBackend(pluginName string, sys pluginutil.LookRunnerUtil) (logical.Backe
 
 	} else {
 		// create a backendPluginClient instance
-		backend, err = newPluginClient(sys, pluginRunner)
+		backend, err = newPluginClient(sys, pluginRunner, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -73,12 +74,12 @@ func NewBackend(pluginName string, sys pluginutil.LookRunnerUtil) (logical.Backe
 	return backend, nil
 }
 
-func newPluginClient(sys pluginutil.RunnerUtil, pluginRunner *pluginutil.PluginRunner) (logical.Backend, error) {
+func newPluginClient(sys pluginutil.RunnerUtil, pluginRunner *pluginutil.PluginRunner, logger log.Logger) (logical.Backend, error) {
 	// pluginMap is the map of plugins we can dispense.
 	pluginMap := map[string]plugin.Plugin{
 		"backend": &BackendPlugin{},
 	}
-	client, err := pluginRunner.Run(sys, pluginMap, handshakeConfig, []string{})
+	client, err := pluginRunner.Run(sys, pluginMap, handshakeConfig, []string{}, logger)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Plugin logs now go through core's logger.

```
...
2017/08/10 17:20:10.348312 [INFO ] core: post-unseal setup complete
2017/08/10 17:20:14.839109 [DEBUG] plugin: starting plugin: path=/Users/cleung/code/tmp/vault_plugins/mock-plugin args=[/Users/cleung/code/tmp/vault_plugins/mock-plugin]
2017/08/10 17:20:14.841726 [DEBUG] plugin: waiting for RPC address: path=/Users/cleung/code/tmp/vault_plugins/mock-plugin
2017/08/10 17:20:14.888501 [DEBUG] plugin.mock-plugin: plugin address: address=/var/folders/1x/c_x5s2h90mzdyx4bzz3_dsx80000gn/T/plugin748882765 network=unix
2017/08/10 17:20:14.987489 [INFO ] core: successful mount: path=mock/ type=plugin
^C==> Vault shutdown triggered
2017/08/10 17:20:19.602519 [DEBUG] core: marked as sealed
2017/08/10 17:20:19.602589 [TRACE] core: clearing forwarding clients
2017/08/10 17:20:19.602610 [TRACE] core: done clearing forwarding clients
2017/08/10 17:20:19.602627 [INFO ] core: pre-seal teardown starting
2017/08/10 17:20:19.602643 [INFO ] core: cluster listeners not running
2017/08/10 17:20:19.602679 [INFO ] rollback: stopping rollback manager
2017/08/10 17:20:19.604545 [DEBUG] plugin.mock-plugin: plugin received interrupt signal, ignoring: count=1
2017/08/10 17:20:19.608004 [DEBUG] plugin: plugin process exited: path=/Users/cleung/code/tmp/vault_plugins/mock-plugin
2017/08/10 17:20:19.608212 [INFO ] core: pre-seal teardown complete
2017/08/10 17:20:19.608254 [DEBUG] core: sealing barrier
2017/08/10 17:20:19.608275 [INFO ] core: vault is sealed
```
