### PR TITLE
Removed unused parameter from docs

### DIFF
--- a/website/source/api/secret/transit/index.html.md
+++ b/website/source/api/secret/transit/index.html.md
@@ -840,9 +840,6 @@ data.
 
 - `input` `(string: <required>)` – Specifies the **base64 encoded** input data.
 
-- `format` `(string: "hex")` – Specifies the output encoding. This can be either
-  `hex` or `base64`.
-
 - `signature` `(string: "")` – Specifies the signature output from the
   `/transit/sign` function. Either this must be supplied or `hmac` must be
   supplied.


### PR DESCRIPTION
According to #3116, it seems like this parameter isn't used. I couldn't trigger any differences by playing around with transit signing function, and could not find anything in the source code that actually parses this param. Presumably, it is unused?