### PR TITLE
Add missing link to sidebar menu

### DIFF
--- a/website/source/layouts/api.erb
+++ b/website/source/layouts/api.erb
@@ -29,6 +29,9 @@
               <li<%= sidebar_current("docs-http-secret-databases-cassandra") %>>
                 <a href="/api/secret/databases/cassandra.html">Cassandra</a>
               </li>
+              <li<%= sidebar_current("docs-http-secret-databases-hanadb") %>>
+                <a href="/api/secret/databases/hanadb.html">HanaDB</a>
+              </li>
               <li<%= sidebar_current("docs-http-secret-databases-mongodb") %>>
                 <a href="/api/secret/databases/mongodb.html">MongoDB</a>
               </li>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -189,6 +189,9 @@
               <li<%= sidebar_current("docs-secrets-databases-cassandra") %>>
                 <a href="/docs/secrets/databases/cassandra.html">Cassandra</a>
               </li>
+              <li<%= sidebar_current("docs-secrets-databases-hanadb") %>>
+                <a href="/docs/secrets/databases/hanadb.html">HanaDB</a>
+              </li>
               <li<%= sidebar_current("docs-secrets-databases-mongodb") %>>
                 <a href="/docs/secrets/databases/mongodb.html">MongoDB</a>
               </li>


### PR DESCRIPTION
Silly me, forgot to add the actual sidebar button to go to the hana db docs.

The html files themselves already exist and are reachable