### PR TITLE
Fix redirect_addr HA examples

### DIFF
--- a/website/source/docs/configuration/storage/dynamodb.html.md
+++ b/website/source/docs/configuration/storage/dynamodb.html.md
@@ -116,7 +116,7 @@ This example show enabling high availability for the DynamoDB storage backend.
 ```hcl
 storage "dynamodb" {
   ha_enabled    = "true"
-  redirect_addr = "vault-leader.my-company.internal"
+  redirect_addr = "https://vault-leader.my-company.internal"
 }
 ```
 

--- a/website/source/docs/configuration/storage/etcd.html.md
+++ b/website/source/docs/configuration/storage/etcd.html.md
@@ -133,7 +133,7 @@ This example show enabling high availability for the Etcd storage backend.
 ```hcl
 storage "etcd" {
   ha_enabled    = true
-  redirect_addr = "vault-leader.my-company.internal"
+  redirect_addr = "https://vault-leader.my-company.internal"
 }
 ```
 


### PR DESCRIPTION
As we can see in the other docs (https://www.vaultproject.io/docs/concepts/ha.html): `In both cases, the redirect_addr should be a full URL including scheme (http/https), not simply an IP address and port.`

Also, Vault really doesn't really start with an value on `redirect_addr` that lacks the scheme: 
`Error parsing synthesized cluster address vault.example.com: parse vault.example.com: invalid URI for request`.  