### PR TITLE
Fix typo

### DIFF
--- a/website/source/docs/vault-enterprise/replication/index.html.md
+++ b/website/source/docs/vault-enterprise/replication/index.html.md
@@ -24,7 +24,7 @@ scalability, and highly-available disaster recovery.
 
 ## Architecture
 
-The core unit of Vault replication is a **cluster**, which is comprised of a 
+The core unit of Vault replication is a **cluster**, which is composed of a 
 collection of Vault nodes (an active and its corresponding HA nodes). Multiple Vault 
 clusters communicate in a one-to-many near real-time flow.
 


### PR DESCRIPTION
Justification: "Comprise" is a synonym of "include"

Correct usage examples:
* A book includes pages and a cover
* A book comprises pages and a cover
* A book is composed of pages, a binding, and a cover ("is composed of" implies exhaustivity)

Incorrect usage examples
* A book is included of pages and a cover
* A book is comprised of pages and a cover