### PR TITLE
Don't create multiple system backends since core only holds a reference

### DIFF
--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -121,6 +121,12 @@ func (d dynamicSystemView) ResponseWrapData(data map[string]interface{}, ttl tim
 // LookupPlugin looks for a plugin with the given name in the plugin catalog. It
 // returns a PluginRunner or an error if no plugin was found.
 func (d dynamicSystemView) LookupPlugin(name string) (*pluginutil.PluginRunner, error) {
+	if d.core == nil {
+		return nil, fmt.Errorf("system view core is nil")
+	}
+	if d.core.pluginCatalog == nil {
+		return nil, fmt.Errorf("system view core plugin catalog is nil")
+	}
 	r, err := d.core.pluginCatalog.Get(name)
 	if err != nil {
 		return nil, err

--- a/vault/logical_system_integ_test.go
+++ b/vault/logical_system_integ_test.go
@@ -4,31 +4,28 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/vault/builtin/plugin"
-	"github.com/hashicorp/vault/helper/logformat"
 	"github.com/hashicorp/vault/helper/pluginutil"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/logical"
 	lplugin "github.com/hashicorp/vault/logical/plugin"
 	"github.com/hashicorp/vault/logical/plugin/mock"
 	"github.com/hashicorp/vault/vault"
-	log "github.com/mgutz/logxi/v1"
 )
 
 func TestSystemBackend_Plugin_secret(t *testing.T) {
-	cluster, _ := testSystemBackendMock(t, 1, logical.TypeLogical)
+	cluster := testSystemBackendMock(t, 1, logical.TypeLogical)
 	defer cluster.Cleanup()
 }
 
 func TestSystemBackend_Plugin_auth(t *testing.T) {
-	cluster, _ := testSystemBackendMock(t, 1, logical.TypeCredential)
+	cluster := testSystemBackendMock(t, 1, logical.TypeCredential)
 	defer cluster.Cleanup()
 }
 
 func TestSystemBackend_Plugin_autoReload(t *testing.T) {
-	cluster, _ := testSystemBackendMock(t, 1, logical.TypeLogical)
+	cluster := testSystemBackendMock(t, 1, logical.TypeLogical)
 	defer cluster.Cleanup()
 
 	core := cluster.Cores[0]
@@ -81,17 +78,17 @@ func TestSystemBackend_Plugin_reload(t *testing.T) {
 }
 
 func testSystemBackend_PluginReload(t *testing.T, reqData map[string]interface{}) {
-	cluster, b := testSystemBackendMock(t, 2, logical.TypeLogical)
+	cluster := testSystemBackendMock(t, 2, logical.TypeLogical)
 	defer cluster.Cleanup()
 
 	core := cluster.Cores[0]
+	client := core.Client
 
 	for i := 0; i < 2; i++ {
 		// Update internal value in the backend
-		req := logical.TestRequest(t, logical.UpdateOperation, fmt.Sprintf("mock-%d/internal", i))
-		req.ClientToken = core.Client.Token()
-		req.Data["value"] = "baz"
-		resp, err := core.HandleRequest(req)
+		resp, err := client.Logical().Write(fmt.Sprintf("mock-%d/internal", i), map[string]interface{}{
+			"value": "baz",
+		})
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -101,10 +98,7 @@ func testSystemBackend_PluginReload(t *testing.T, reqData map[string]interface{}
 	}
 
 	// Perform plugin reload
-	req := logical.TestRequest(t, logical.UpdateOperation, "plugins/backend/reload")
-	req.ClientToken = core.Client.Token()
-	req.Data = reqData
-	resp, err := b.HandleRequest(req)
+	resp, err := client.Logical().Write("sys/plugins/backend/reload", reqData)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -114,9 +108,7 @@ func testSystemBackend_PluginReload(t *testing.T, reqData map[string]interface{}
 
 	for i := 0; i < 2; i++ {
 		// Ensure internal backed value is reset
-		req := logical.TestRequest(t, logical.ReadOperation, fmt.Sprintf("mock-%d/internal", i))
-		req.ClientToken = core.Client.Token()
-		resp, err := core.HandleRequest(req)
+		resp, err := client.Logical().Read(fmt.Sprintf("mock-%d/internal", i))
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -131,7 +123,7 @@ func testSystemBackend_PluginReload(t *testing.T, reqData map[string]interface{}
 
 // testSystemBackendMock returns a systemBackend with the desired number
 // of mounted mock plugin backends
-func testSystemBackendMock(t *testing.T, numMounts int, backendType logical.BackendType) (*vault.TestCluster, *vault.SystemBackend) {
+func testSystemBackendMock(t *testing.T, numMounts int, backendType logical.BackendType) *vault.TestCluster {
 	coreConfig := &vault.CoreConfig{
 		LogicalBackends: map[string]logical.Factory{
 			"plugin": plugin.Factory,
@@ -146,37 +138,22 @@ func testSystemBackendMock(t *testing.T, numMounts int, backendType logical.Back
 	})
 	cluster.Start()
 
-	core := cluster.Cores[0].Core
-	vault.TestWaitActive(t, core)
-
-	b := vault.NewSystemBackend(core)
-	logger := logformat.NewVaultLogger(log.LevelTrace)
-	bc := &logical.BackendConfig{
-		Logger: logger,
-		System: logical.StaticSystemView{
-			DefaultLeaseTTLVal: time.Hour * 24,
-			MaxLeaseTTLVal:     time.Hour * 24 * 32,
-		},
-	}
-
-	err := b.Backend.Setup(bc)
-	if err != nil {
-		t.Fatal(err)
-	}
+	core := cluster.Cores[0]
+	vault.TestWaitActive(t, core.Core)
+	client := core.Client
 
 	os.Setenv(pluginutil.PluginCACertPEMEnv, cluster.CACertPEMFile)
 
 	switch backendType {
 	case logical.TypeLogical:
-		vault.TestAddTestPlugin(t, core, "mock-plugin", "TestBackend_PluginMainLogical")
+		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", "TestBackend_PluginMainLogical")
 		for i := 0; i < numMounts; i++ {
-			req := logical.TestRequest(t, logical.UpdateOperation, fmt.Sprintf("mounts/mock-%d/", i))
-			req.Data["type"] = "plugin"
-			req.Data["config"] = map[string]interface{}{
-				"plugin_name": "mock-plugin",
-			}
-
-			resp, err := b.HandleRequest(req)
+			resp, err := client.Logical().Write(fmt.Sprintf("sys/mounts/mock-%d", i), map[string]interface{}{
+				"type": "plugin",
+				"config": map[string]interface{}{
+					"plugin_name": "mock-plugin",
+				},
+			})
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -185,13 +162,12 @@ func testSystemBackendMock(t *testing.T, numMounts int, backendType logical.Back
 			}
 		}
 	case logical.TypeCredential:
-		vault.TestAddTestPlugin(t, core, "mock-plugin", "TestBackend_PluginMainCredentials")
+		vault.TestAddTestPlugin(t, core.Core, "mock-plugin", "TestBackend_PluginMainCredentials")
 		for i := 0; i < numMounts; i++ {
-			req := logical.TestRequest(t, logical.UpdateOperation, fmt.Sprintf("auth/mock-%d", i))
-			req.Data["type"] = "plugin"
-			req.Data["plugin_name"] = "mock-plugin"
-
-			resp, err := b.HandleRequest(req)
+			resp, err := client.Logical().Write(fmt.Sprintf("sys/auth/mock-%d", i), map[string]interface{}{
+				"type":        "plugin",
+				"plugin_name": "mock-plugin",
+			})
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -203,7 +179,7 @@ func testSystemBackendMock(t *testing.T, numMounts int, backendType logical.Back
 		t.Fatal("unknown backend type provided")
 	}
 
-	return cluster, b
+	return cluster
 }
 
 func TestBackend_PluginMainLogical(t *testing.T) {


### PR DESCRIPTION
to one.