### PR TITLE
Update help output (spaces instead of tabs)

### DIFF
--- a/command/ssh.go
+++ b/command/ssh.go
@@ -303,38 +303,38 @@ General Options:
 ` + meta.GeneralOptionsUsage() + `
 SSH Options:
 
-	-role				Role to be used to create the key.
-					Each IP is associated with a role. To see the associated
-					roles with IP, use "lookup" endpoint. If you are certain
-					that there is only one role associated with the IP, you can
-					skip mentioning the role. It will be chosen by default.  If
-					there are no roles associated with the IP, register the
-					CIDR block of that IP using the "roles/" endpoint.
+  -role            Role to be used to create the key. Each IP is associated with
+                   a role. To see the associated roles with IP, use "lookup"
+                   endpoint. If you are certain that there is only one role
+                   associated with the IP, you can skip mentioning the role. It
+                   will be chosen by default. If there are no roles associated
+                   with the IP, register the CIDR block of that IP using the
+                   "roles/" endpoint.
 
-	-no-exec			Shows the credentials but does not establish connection.
+  -no-exec         Shows the credentials but does not establish connection.
 
-	-mount-point			Mount point of SSH backend. If the backend is mounted at
-					'ssh', which is the default as well, this parameter can be
-					skipped.
+  -mount-point     Mount point of SSH backend. If the backend is mounted at
+                   "ssh" (default), this parameter can be skipped.
 
-	-format				If no-exec option is enabled, then the credentials will be
-					printed out and SSH connection will not be established. The
-					format of the output can be 'json' or 'table'. JSON output
-					is useful when writing scripts. Default is 'table'.
+  -format          If the "no-exec" option is enabled, the credentials will be
+                   printed out and SSH connection will not be established. The
+                   format of the output can be "json" or "table" (default).
 
-	-strict-host-key-checking	This option corresponds to StrictHostKeyChecking of SSH configuration.
-					If 'sshpass' is employed to enable automated login, then if host key
-					is not "known" to the client, 'vault ssh' command will fail. Set this
-					option to "no" to bypass the host key checking. Defaults to "ask".
-					Can also be specified with VAULT_SSH_STRICT_HOST_KEY_CHECKING environment
-					variable.
+  -strict-host-key-checking   This option corresponds to "StrictHostKeyChecking"
+                   of SSH configuration. If "sshpass" is employed to enable
+                   automated login, then if host key is not "known" to the
+                   client, "vault ssh" command will fail. Set this option to
+                   "no" to bypass the host key checking. Defaults to "ask".
+                   Can also be specified with the
+                   "VAULT_SSH_STRICT_HOST_KEY_CHECKING" environment variable.
 
-	-user-known-hosts-file		This option corresponds to UserKnownHostsFile of SSH configuration.
-					Assigns the file to use for storing the host keys. If this option is
-					set to "/dev/null" along with "-strict-host-key-checking=no", both
-					warnings and host key checking can be avoided while establishing the
-					connection. Defaults to "~/.ssh/known_hosts". Can also be specified
-					with VAULT_SSH_USER_KNOWN_HOSTS_FILE environment variable.
+  -user-known-hosts-file   This option corresponds to "UserKnownHostsFile" of
+                   SSH configuration. Assigns the file to use for storing the
+                   host keys. If this option is set to "/dev/null" along with
+                   "-strict-host-key-checking=no", both warnings and host key
+                   checking can be avoided while establishing the connection.
+                   Defaults to "~/.ssh/known_hosts". Can also be specified with
+                   "VAULT_SSH_USER_KNOWN_HOSTS_FILE" environment variable.
 `
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
I'm going to take a bigger pass at all the CLI help output separately, but this one really stuck out against the other help options:

<img width="468" alt="screen shot 2017-08-15 at 7 45 51 pm" src="https://user-images.githubusercontent.com/408570/29341448-5b3fdbae-81f2-11e7-9926-42d1aec444e4.png">
