### PR TITLE
Add the ability to use root credentials for AWS IAM authentication.

### DIFF
--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -88,6 +88,9 @@ func TestBackend_pathLogin_parseIamArn(t *testing.T) {
 		"",
 		iamEntity{Partition: "aws", AccountNumber: "123456789012", Type: "instance-profile", Path: "profilePath", FriendlyName: "InstanceProfileName"},
 	)
+	testParser("arn:aws:iam::123456789012:root", "arn:aws:iam::123456789012:root",
+		iamEntity{Partition: "aws", AccountNumber: "123456789012", Type: "root"},
+	)
 }
 
 func TestBackend_validateVaultHeaderValue(t *testing.T) {


### PR DESCRIPTION
Partial fix for #3179