### PR TITLE
Add SSH CLI CA type authentication

### DIFF
--- a/api/ssh.go
+++ b/api/ssh.go
@@ -36,3 +36,20 @@ func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, err
 
 	return ParseSecret(resp.Body)
 }
+
+// SignKey signs the given public key and returns a signed public key to pass
+// along with the SSH request.
+func (c *SSH) SignKey(role string, data map[string]interface{}) (*Secret, error) {
+	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/sign/%s", c.MountPoint, role))
+	if err := r.SetJSONBody(data); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.RawRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return ParseSecret(resp.Body)
+}


### PR DESCRIPTION
1. The current implementation of the SSH command is heavily tied to the assumptions of OTP/dynamic key types. The SSH CA backend is fundamentally a different approach to login and authentication. As a result, there was some restructuring of existing methods to share more code and state.

2. Each authentication method (ca, otp, dynamic) are now fully-contained in their own handle* function.

3. -mode and -role are going to be required for SSH CA, and I don't think the magical UX (and overhead) of guessing them is a good UX. It's confusing as to which role and how Vault guesses. We can reduce 66% of the API calls and add more declaration to the CLI by making -mode and -role required. This commit adds warnings for that deprecation, but these values are both required for CA type authentication.

4. The principal and extensions are currently fixed, and I personally believe that's good enough for the first pass at this. Until we understand what configuration options users will want, I think we should ship with all the local extensions enabled. Users who don't want that can generate the key themselves directly (current behavior) or submit PRs to make the map of extensions customizable.

5. Host key checking for the CA backend is not currently implemented. It's not strictly required at setup, so I need to think about whether it belongs here.

This is not ready for merge, but it's ready for early review.

**Questions**

- The key is saved to disk (in a temp location). Is there a good way to clean it up? I have a defer, but we don't know if they just close the terminal and never exit back to go. Is there a way we can safely delete that file which doesn't cause a race condition?

/cc @armon @vishalnayak @jefferai 

- [x] Basic functionality
- [x] Support arbitrary args
- [x] Optional Host key verification
- [ ] Documentation updates
- [ ] Regression tested against OTP and dynamic
