### PR TITLE
Update policies.html.md

### DIFF
--- a/website/source/intro/getting-started/policies.html.md
+++ b/website/source/intro/getting-started/policies.html.md
@@ -31,7 +31,7 @@ policy is shown below:
 
 ```javascript
 path "secret/*" {
-  capabilities = ["write"]
+  capabilities = ["create"]
 }
 
 path "secret/foo" {


### PR DESCRIPTION
Using the latest vault release - Vault v0.8.0 ('af63d879130d2ee292f09257571d371100a513eb'), I was getting the following error when the policy used `write`:

Error: Error making API request.

URL: PUT http://0.0.0.0:8200/v1/sys/policy/secret
Code: 400. Errors:

* Failed to parse policy: path "secret/*": invalid capability 'write'

I think `create` is the correct new Capability.