### PR TITLE
Do not revoke signed SSH key

### DIFF
--- a/command/ssh.go
+++ b/command/ssh.go
@@ -321,10 +321,7 @@ func (c *SSHCommand) handleTypeCA() error {
 		return errors.Wrap(err, "failed to run ssh command")
 	}
 
-	// Revoke the key if it's longer than expected
-	if err := c.client.Sys().Revoke(secret.LeaseID); err != nil {
-		return errors.Wrap(err, "failed to revoke key")
-	}
+	// There is no secret to revoke, since it's a certificate signing
 
 	return nil
 }


### PR DESCRIPTION
There is no secret to revoke - this produces an error on the CLI

I was running tests and never noticed the error. The "secret" that comes back from a key signing operation does not have an associated lease.

/cc @vishalnayak 