### PR TITLE
Revert "Add the ability to use root credentials for AWS IAM authentication. (#3181)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ IMPROVEMENTS:
 
  * auth/approle: Allow array input for policies in addition to comma-delimited
    strings [GH-3163]
- * auth/aws: Allow using root credentials for IAM authentication [GH-3181]
  * plugins: Send logs through Vault's logger rather than stdout [GH-3142]
  * secret/pki: Add `pki/root` delete operation [GH-3165]
  * secret/pki: Don't overwrite an existing root cert/key when calling generate

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -1279,10 +1279,8 @@ func parseIamArn(iamArn string) (*iamEntity, error) {
 	// fullParts[5] would now be something like user/<UserName> or assumed-role/<RoleName>/<RoleSessionName>
 	parts := strings.Split(fullParts[5], "/")
 	entity.Type = parts[0]
-	if len(parts) > 1 {
-		entity.Path = strings.Join(parts[1:len(parts)-1], "/")
-		entity.FriendlyName = parts[len(parts)-1]
-	}
+	entity.Path = strings.Join(parts[1:len(parts)-1], "/")
+	entity.FriendlyName = parts[len(parts)-1]
 	// now, entity.FriendlyName should either be <UserName> or <RoleName>
 	switch entity.Type {
 	case "assumed-role":
@@ -1294,7 +1292,6 @@ func parseIamArn(iamArn string) (*iamEntity, error) {
 	case "user":
 	case "role":
 	case "instance-profile":
-	case "root":
 	default:
 		return &iamEntity{}, fmt.Errorf("unrecognized principal type: %q", entity.Type)
 	}
@@ -1516,11 +1513,7 @@ func (e *iamEntity) canonicalArn() string {
 	// make an AWS API call to look up the role by FriendlyName, which introduces more complexity to
 	// code and test, and it also breaks backwards compatibility in an area where we would really want
 	// it
-	ret := fmt.Sprintf("arn:%s:iam::%s:%s", e.Partition, e.AccountNumber, entityType)
-	if e.FriendlyName != "" {
-		ret = fmt.Sprintf("%s/%s", ret, e.FriendlyName)
-	}
-	return ret
+	return fmt.Sprintf("arn:%s:iam::%s:%s/%s", e.Partition, e.AccountNumber, entityType, e.FriendlyName)
 }
 
 const iamServerIdHeader = "X-Vault-AWS-IAM-Server-ID"

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -88,9 +88,6 @@ func TestBackend_pathLogin_parseIamArn(t *testing.T) {
 		"",
 		iamEntity{Partition: "aws", AccountNumber: "123456789012", Type: "instance-profile", Path: "profilePath", FriendlyName: "InstanceProfileName"},
 	)
-	testParser("arn:aws:iam::123456789012:root", "arn:aws:iam::123456789012:root",
-		iamEntity{Partition: "aws", AccountNumber: "123456789012", Type: "root"},
-	)
 }
 
 func TestBackend_validateVaultHeaderValue(t *testing.T) {


### PR DESCRIPTION
This reverts commit e99a2cd87726986cb0896fdc445a3d5f3c11a66d.

Fixes #3198

See discussion in #3198 for context.