### PR TITLE
fix swallowed errors in pki package tests

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2209,6 +2209,10 @@ func TestBackend_Root_Idempotentcy(t *testing.T) {
 		t.Fatal("expected ca info")
 	}
 	resp, err = client.Logical().Read("pki/cert/ca_chain")
+	if err != nil {
+		t.Fatalf("error reading ca_chain: %v", err)
+	}
+
 	r1Data := resp.Data
 
 	// Try again, make sure it's a 204 and same CA
@@ -2222,6 +2226,9 @@ func TestBackend_Root_Idempotentcy(t *testing.T) {
 		t.Fatal("expected no ca info")
 	}
 	resp, err = client.Logical().Read("pki/cert/ca_chain")
+	if err != nil {
+		t.Fatalf("error reading ca_chain: %v", err)
+	}
 	r2Data := resp.Data
 	if !reflect.DeepEqual(r1Data, r2Data) {
 		t.Fatal("got different ca certs")


### PR DESCRIPTION
Two swallowed errors were recently introduced in the tests for the pki package.