### PR TITLE
Fix swallowed errors in cert test goroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ BUG FIXES:
 
  * core: Policy-related commands would sometimes fail to act case-insensitively
    [GH-3210]
+ * auth/aws: Properly use role-set period values for IAM-derived token renewals
+   [GH-3220]
 
 ## 0.8.1 (August 16th, 2017)
 

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -943,7 +943,13 @@ func (b *backend) pathLoginRenewIam(
 		}
 	}
 
-	return framework.LeaseExtend(roleEntry.TTL, roleEntry.MaxTTL, b.System())(req, data)
+	// If 'Period' is set on the role, then the token should never expire.
+	if roleEntry.Period > time.Duration(0) {
+		req.Auth.TTL = roleEntry.Period
+		return &logical.Response{Auth: req.Auth}, nil
+	} else {
+		return framework.LeaseExtend(roleEntry.TTL, roleEntry.MaxTTL, b.System())(req, data)
+	}
 }
 
 func (b *backend) pathLoginRenewEc2(

--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -80,37 +81,65 @@ func connectionState(serverCAPath, serverCertPath, serverKeyPath, clientCertPath
 	}
 	defer list.Close()
 
+	// Accept connections.
+	serverErrors := make(chan error, 1)
+	connState := make(chan tls.ConnectionState)
+	go func() {
+		defer close(connState)
+		serverConn, err := list.Accept()
+		serverErrors <- err
+		if err != nil {
+			close(serverErrors)
+			return
+		}
+		defer serverConn.Close()
+
+		// Read the ping
+		buf := make([]byte, 4)
+		_, err = serverConn.Read(buf)
+		if (err != nil) && (err != io.EOF) {
+			serverErrors <- err
+			close(serverErrors)
+			return
+		} else {
+			// EOF is a reasonable error condition, so swallow it.
+			serverErrors <- nil
+		}
+		close(serverErrors)
+		connState <- serverConn.(*tls.Conn).ConnectionState()
+	}()
+
 	// Establish a connection from the client side and write a few bytes.
+	clientErrors := make(chan error, 1)
 	go func() {
 		addr := list.Addr().String()
 		conn, err := tls.Dial("tcp", addr, dialConf)
+		clientErrors <- err
 		if err != nil {
-			// FIXME
-			// Disabled, as a t.Fatal in a goroutine is silently dropped
-			// if err != nil {
-			// 		t.Fatalf("err: %v", err)
-			// }
+			close(clientErrors)
+			return
 		}
 		defer conn.Close()
 
 		// Write ping
-		conn.Write([]byte("ping"))
+		_, err = conn.Write([]byte("ping"))
+		clientErrors <- err
+		close(clientErrors)
 	}()
 
-	// Accept the connection on the server side.
-	serverConn, err := list.Accept()
-	if err != nil {
-		return tls.ConnectionState{}, err
+	for err = range clientErrors {
+		if err != nil {
+			return tls.ConnectionState{}, fmt.Errorf("error in client goroutine:%v", err)
+		}
 	}
-	defer serverConn.Close()
 
-	// Read the ping
-	buf := make([]byte, 4)
-	serverConn.Read(buf)
-
+	for err = range serverErrors {
+		if err != nil {
+			return tls.ConnectionState{}, fmt.Errorf("error in server goroutine:%v", err)
+		}
+	}
 	// Grab the current state
-	connState := serverConn.(*tls.Conn).ConnectionState()
-	return connState, nil
+	return <-connState, nil
 }
 
 func TestBackend_NonCAExpiry(t *testing.T) {


### PR DESCRIPTION
This is a bit more ambitious than my usual PRs.

The cert tests currently expect a t.Fatal() called from a goroutine to do something, but Go is silently swallowing these calls.  From the godoc for testing.T:

> A test ends when its Test function returns or calls any of the methods FailNow, Fatal, Fatalf, SkipNow, Skip, or Skipf. Those methods, as well as the Parallel method, must be called only from the goroutine running the Test function. 

My first step in this PR was to move all use of testing.T out of the connectionState() and testConnState() functions, and instead have them return errors.

Next, I changed them to create separate goroutines for both server and client actions. Both communicate their errors back to the main testing goroutine with channels. There is also a channel that communicates the tls.ConnectionState{} from the server goroutine back to the main testing goroutine.