### PR TITLE
Add 'Period' support to AWS IAM token renewal

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -943,7 +943,13 @@ func (b *backend) pathLoginRenewIam(
 		}
 	}
 
-	return framework.LeaseExtend(roleEntry.TTL, roleEntry.MaxTTL, b.System())(req, data)
+	// If 'Period' is set on the role, then the token should never expire.
+	if roleEntry.Period > time.Duration(0) {
+		req.Auth.TTL = roleEntry.Period
+		return &logical.Response{Auth: req.Auth}, nil
+	} else {
+		return framework.LeaseExtend(roleEntry.TTL, roleEntry.MaxTTL, b.System())(req, data)
+	}
 }
 
 func (b *backend) pathLoginRenewEc2(


### PR DESCRIPTION
Period does not appear to be used when renewing a token created against an AWS role with an auth_type of "IAM".

This PR adds the support.

Note that I did not modify the default behaviour if Period is not set, though I suspect it may need to be updated to match what is done in for the EC2 auth_type (for shortest/longestTTL determination).