### PR TITLE
Add GET variant on LIST endpoints to API documentation

### DIFF
--- a/website/source/api/auth/approle/index.html.md
+++ b/website/source/api/auth/approle/index.html.md
@@ -23,6 +23,7 @@ This endpoint returns a list the existing AppRoles in the backend.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/approle/role`          | `200 application/json` |
+| `GET`   | `/auth/approle/role?list=true` | `200 application/json` |
 
 ### Sample Request
 
@@ -334,6 +335,7 @@ This includes the accessors for "custom" SecretIDs as well.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/approle/role/:role_name/secret-id` | `200 application/json` |
+| `GET`   | `/auth/approle/role/:role_name/secret-id?list=true` | `200 application/json` |
 
 ### Parameters
 

--- a/website/source/api/auth/aws/index.html.md
+++ b/website/source/api/auth/aws/index.html.md
@@ -217,6 +217,7 @@ Lists all the AWS public certificates that are registered with the backend.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/aws/config/certificates` | `200 application/json` |
+| `GET`   | `/auth/aws/config/certificates?list=true` | `200 application/json` |
 
 ### Sample Request
 
@@ -327,6 +328,7 @@ Lists all the AWS Account IDs for which an STS role is registered.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/aws/config/sts`       | `200 application/json` |
+| `GET`   | `/auth/aws/config/sts?list=true`       | `200 application/json` |
 
 ### Sample Request
 
@@ -746,6 +748,7 @@ Lists all the roles that are registered with the backend.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/aws/roles`       | `200 application/json` |
+| `GET`   | `/auth/aws/roles?list=true`       | `200 application/json` |
 
 ### Sample Request
 
@@ -1054,6 +1057,7 @@ Lists all the role tags that are blacklisted.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/aws/roletag-blacklist`       | `200 application/json` |
+| `GET`   | `/auth/aws/roletag-blacklist?list=true`       | `200 application/json` |
 
 ### Sample Request
 
@@ -1179,6 +1183,7 @@ $ curl \
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/aws/identity-whitelist`       | `200 application/json` |
+| `GET`   | `/auth/aws/identity-whitelist?list=true`       | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/auth/cert/index.html.md
+++ b/website/source/api/auth/cert/index.html.md
@@ -107,6 +107,7 @@ Lists configured certificate names.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/cert/certs`           | `200 application/json` |
+| `GET`   | `/auth/cert/certs?list=true`  | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/auth/gcp/index.html.md
+++ b/website/source/api/auth/gcp/index.html.md
@@ -279,6 +279,7 @@ Lists all the roles that are registered with the plugin.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/gcp/roles`            | `200 application/json` |
+| `GET`   | `/auth/gcp/roles?list=true`   | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/auth/ldap/index.html.md
+++ b/website/source/api/auth/ldap/index.html.md
@@ -153,6 +153,7 @@ This endpoint returns a list of existing groups in the backend.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/ldap/groups`          | `200 application/json` |
+| `GET`   | `/auth/ldap/groups?list=true` | `200 application/json` |
 
 ### Sample Request
 
@@ -276,6 +277,7 @@ This endpoint returns a list of existing users in the backend.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/ldap/users`          | `200 application/json` |
+| `GET`   | `/auth/ldap/users?list=true`          | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/auth/okta/index.html.md
+++ b/website/source/api/auth/okta/index.html.md
@@ -97,6 +97,7 @@ List the users configurated in the Okta backend.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/okta/users`           | `200 application/json` |
+| `GET`   | `/auth/okta/users?list=true`  | `200 application/json` |
 
 ### Sample Request
 
@@ -222,6 +223,7 @@ List the groups configurated in the Okta backend.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/okta/groups`           | `200 application/json` |
+| `GET`   | `/auth/okta/groups?list=true`  | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/auth/radius/index.html.md
+++ b/website/source/api/auth/radius/index.html.md
@@ -155,6 +155,7 @@ List the users registered with the backend.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/radius/users`         | `200 application/json` |
+| `GET`   | `/auth/radius/users?list=true` | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/auth/token/index.html.md
+++ b/website/source/api/auth/token/index.html.md
@@ -21,6 +21,7 @@ large numbers of tokens and their associated leases at once.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/token/accessors`      | `200 application/json` |
+| `GEt`    | `/auth/token/accessors?list=true` | `200 application/json` |
 
 ### Sample Request
 
@@ -565,6 +566,7 @@ List available token roles.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/token/roles`          | `200 application/json` |
+| `GET`    | `/auth/token/roles?list=true` | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/auth/userpass/index.html.md
+++ b/website/source/api/auth/userpass/index.html.md
@@ -177,6 +177,7 @@ List available userpass users.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/auth/userpass/users`          | `200 application/json` |
+| `GEt`    | `/auth/userpass/users?list=true` | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/aws/index.html.md
+++ b/website/source/api/secret/aws/index.html.md
@@ -236,6 +236,7 @@ This endpoint lists all existing roles in the backend.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/aws/roles`                 | `200 application/json` |
+| `GEt`    | `/aws/roles?list=true`       | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/consul/index.html.md
+++ b/website/source/api/secret/consul/index.html.md
@@ -152,6 +152,7 @@ This endpoint lists all existing roles in the backend.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`    | `/consul/roles`             | `200 application/json` |
+| `GET`     | `/consul/roles?list=true`   | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/cubbyhole/index.html.md
+++ b/website/source/api/secret/cubbyhole/index.html.md
@@ -60,7 +60,8 @@ not return a value. The values themselves are not accessible via this command.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `List`   | `/cubbyhole/:path`           | `200 application/json` |
+| `LIST`   | `/cubbyhole/:path`           | `200 application/json` |
+| `GET`    | `/cubbyhole/:path?list=true` | `200 application/json` |
 
 ### Parameters
 

--- a/website/source/api/secret/databases/index.html.md
+++ b/website/source/api/secret/databases/index.html.md
@@ -256,6 +256,7 @@ returned, not any values.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/database/roles`          | `200 application/json` |
+| `GET`   | `/database/roles?list=true` | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/generic/index.html.md
+++ b/website/source/api/secret/generic/index.html.md
@@ -68,6 +68,7 @@ this command.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/secret/:path`              | `200 application/json` |
+| `GEt`    | `/secret/:path?list=true`    | `200 application/json` |
 
 ### Parameters
 

--- a/website/source/api/secret/identity/index.html.md
+++ b/website/source/api/secret/identity/index.html.md
@@ -180,6 +180,7 @@ This endpoint returns a list of available entities by their identifiers.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/identity/entity/id`        | `200 application/json` |
+| `GET`   | `/identity/entity/id?list=true` | `200 application/json` |
 
 ### Sample Request
 
@@ -391,6 +392,7 @@ This endpoint returns a list of available personas by their identifiers.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/identity/persona/id`       | `200 application/json` |
+| `GET`    | `/identity/persona/id?list=true` | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/mssql/index.html.md
+++ b/website/source/api/secret/mssql/index.html.md
@@ -169,6 +169,7 @@ returned, not any values.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/mssql/roles`               | `200 application/json` |
+| `GET`   | `/mssql/roles?list=true`      | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/mysql/index.html.md
+++ b/website/source/api/secret/mysql/index.html.md
@@ -190,6 +190,7 @@ returned, not any values.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/mysql/roles`               | `200 application/json` |
+| `GET`    | `/mysql/roles?list=true`     | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -140,6 +140,7 @@ This endpoint returns a list of the current certificates by serial number only.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/pki/certs`                 | `200 application/json` |
+| `GET`    | `/pki/certs?list=true`       | `200 application/json` |
 
 
 ### Sample Request
@@ -833,6 +834,7 @@ returned, not any values.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/pki/roles`                 | `200 application/json` |
+| `GET`    | `/pki/roles?list=true`       | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/postgresql/index.html.md
+++ b/website/source/api/secret/postgresql/index.html.md
@@ -184,6 +184,7 @@ returned, not any values.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/postgresql/roles`          | `200 application/json` |
+| `GET`    | `/postgresql/roles?list=true` | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/ssh/index.html.md
+++ b/website/source/api/secret/ssh/index.html.md
@@ -293,6 +293,7 @@ returned, not any values.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/ssh/roles`                 | `200 application/json` |
+| `GET`   | `/ssh/roles?list=true`        | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/totp/index.html.md
+++ b/website/source/api/secret/totp/index.html.md
@@ -150,6 +150,7 @@ returned, not any values.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/totp/keys`                 | `200 application/json` |
+| `GET`    | `/totp/keys?list=true`       | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/secret/transit/index.html.md
+++ b/website/source/api/secret/transit/index.html.md
@@ -128,6 +128,7 @@ actual keys themselves).
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/transit/keys`              | `200 application/json` |
+| `GET`    | `/transit/keys?list=true`    | `200 application/json` |
 
 ### Sample Request
 

--- a/website/source/api/system/leases.html.md
+++ b/website/source/api/system/leases.html.md
@@ -62,6 +62,7 @@ This endpoint returns a list of lease ids.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `LIST`   | `/sys/leases/lookup/:prefix` | `200 application/json` |
+| `GET`   | `/sys/leases/lookup/:prefix?list=true` | `200 application/json` |
 
 
 ### Sample Request

--- a/website/source/api/system/plugins-catalog.html.md
+++ b/website/source/api/system/plugins-catalog.html.md
@@ -18,7 +18,8 @@ This endpoint lists the plugins in the catalog.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `LIST`   | `/sys/plugins/catalog/`      | `200 application/json` |
+| `LIST`   | `/sys/plugins/catalog`      | `200 application/json` |
+| `GET`   | `/sys/plugins/catalog?list=true`      | `200 application/json` |
 
 ### Sample Request
 


### PR DESCRIPTION
Adding `GET` with `?list=true` parameter to all LIST endpoints in API docs.