### PR TITLE
Initial CLI autocomplete support

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -36,9 +36,11 @@ func RunCustom(args []string, commands map[string]cli.CommandFactory) int {
 	}
 
 	cli := &cli.CLI{
-		Args:     args,
-		Commands: commands,
-		HelpFunc: cli.FilteredHelpFunc(commandsInclude, HelpFunc),
+		Args:         args,
+		Commands:     commands,
+		Name:         "vault",
+		Autocomplete: true,
+		HelpFunc:     cli.FilteredHelpFunc(commandsInclude, HelpFunc),
 	}
 
 	exitCode, err := cli.Run()

--- a/vendor/github.com/mitchellh/cli/cli.go
+++ b/vendor/github.com/mitchellh/cli/cli.go
@@ -85,13 +85,17 @@ type CLI struct {
 	// for the flag name. These default to `autocomplete-install` and
 	// `autocomplete-uninstall` respectively.
 	//
+	// AutocompleteNoDefaultFlags is a boolean which controls if the default auto-
+	// complete flags like -help and -version are added to the output.
+	//
 	// AutocompleteGlobalFlags are a mapping of global flags for
 	// autocompletion. The help and version flags are automatically added.
-	Autocomplete            bool
-	AutocompleteInstall     string
-	AutocompleteUninstall   string
-	AutocompleteGlobalFlags complete.Flags
-	autocompleteInstaller   autocompleteInstaller // For tests
+	Autocomplete               bool
+	AutocompleteInstall        string
+	AutocompleteUninstall      string
+	AutocompleteNoDefaultFlags bool
+	AutocompleteGlobalFlags    complete.Flags
+	autocompleteInstaller      autocompleteInstaller // For tests
 
 	// HelpFunc and HelpWriter are used to output help information, if
 	// requested.
@@ -153,6 +157,14 @@ func (c *CLI) IsVersion() bool {
 func (c *CLI) Run() (int, error) {
 	c.once.Do(c.init)
 
+	// If this is a autocompletion request, satisfy it. This must be called
+	// first before anything else since its possible to be autocompleting
+	// -help or -version or other flags and we want to show completions
+	// and not actually write the help or version.
+	if c.Autocomplete && c.autocomplete.Complete() {
+		return 0, nil
+	}
+
 	// Just show the version and exit if instructed.
 	if c.IsVersion() && c.Version != "" {
 		c.HelpWriter.Write([]byte(c.Version + "\n"))
@@ -195,11 +207,6 @@ func (c *CLI) Run() (int, error) {
 				return 1, err
 			}
 
-			return 0, nil
-		}
-
-		// If this is a autocompletion request, satisfy it
-		if c.autocomplete.Complete() {
 			return 0, nil
 		}
 	}
@@ -372,11 +379,13 @@ func (c *CLI) initAutocomplete() {
 
 	// For the root, we add the global flags to the "Flags". This way
 	// they don't show up on every command.
-	cmd.Flags = map[string]complete.Predictor{
-		"-" + c.AutocompleteInstall:   complete.PredictNothing,
-		"-" + c.AutocompleteUninstall: complete.PredictNothing,
-		"-help":    complete.PredictNothing,
-		"-version": complete.PredictNothing,
+	if !c.AutocompleteNoDefaultFlags {
+		cmd.Flags = map[string]complete.Predictor{
+			"-" + c.AutocompleteInstall:   complete.PredictNothing,
+			"-" + c.AutocompleteUninstall: complete.PredictNothing,
+			"-help":    complete.PredictNothing,
+			"-version": complete.PredictNothing,
+		}
 	}
 	cmd.GlobalFlags = c.AutocompleteGlobalFlags
 

--- a/vendor/github.com/mitchellh/cli/ui_mock.go
+++ b/vendor/github.com/mitchellh/cli/ui_mock.go
@@ -100,8 +100,12 @@ func (b *syncBuffer) Reset() {
 }
 
 func (b *syncBuffer) String() string {
+	return string(b.Bytes())
+}
+
+func (b *syncBuffer) Bytes() []byte {
 	b.RLock()
 	data := b.b.Bytes()
 	b.RUnlock()
-	return string(data)
+	return data
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1185,10 +1185,10 @@
 			"revisionTime": "2017-07-10T09:56:15Z"
 		},
 		{
-			"checksumSHA1": "az4cLSQCZTxkknjFm6b+iHBbf6A=",
+			"checksumSHA1": "KXrCoifaKi3Wy4zbCfXTtM/FO48=",
 			"path": "github.com/mitchellh/cli",
-			"revision": "d10eaaaf78c45b8e959311791db9fae4530a61bf",
-			"revisionTime": "2017-07-17T22:17:35Z"
+			"revision": "b633c78680fa6fb27ac81694f38c28f79602ebd9",
+			"revisionTime": "2017-08-14T15:07:37Z"
 		},
 		{
 			"checksumSHA1": "+p4JY4wmFQAppCdlrJ8Kxybmht8=",

--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -24,3 +24,19 @@ with the `-h` argument.
 The help output is very comprehensive, so we defer you to that for documentation.
 We've included some guides to the left of common interactions with the
 CLI.
+
+## Autocompletion
+
+The `vault` command features opt-in subcommand autocompletion that you can
+enable for your shell with `consul -autocomplete-install`. After doing so,
+you can invoke a new shell and use the feature.
+
+For example, assume a tab is typed at the end of each prompt line:
+
+```
+$ vault au
+audit-disable  audit-enable  audit-list  auth  auth-disable  auth-enable
+
+$ vault s
+seal  server  ssh  status  step-down
+```


### PR DESCRIPTION
This enables the initial for-free sub-command autocompletion feature from [mitchellh/cli](https://github.com/mitchellh/cli). More details are in the [feature commit message](https://github.com/mitchellh/cli/pull/58).

I vendored the latest CLI, built `vault`, and verified that `consul -autocomplete-install` and basic sub-command completion was occurring for me in `zsh` with the changes! 🎉

Also added [Name:](https://github.com/mitchellh/cli/blob/master/cli.go#L64-L65) as well because Autocomplete errors without it:

```
./bin/vault
Error executing CLI: internal error: CLI.Name must be specified for autocomplete to work
```

As I understand it, there needs to be additional work done for completion on specific CLI flags and so on to make things more feature complete, but the basics are there as a starting point if we want to use it.