### PR TITLE
stdout support for file backend via logger

### DIFF
--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -93,7 +93,7 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 	}
 
 	switch path {
-	case "STDOUT":
+	case "stdout":
 		// no need to test opening file if outputting to stdout
 	default:
 		// Ensure that the file can be successfully opened for writing;
@@ -160,7 +160,7 @@ func (b *Backend) LogRequest(auth *logical.Auth, req *logical.Request, outerErr 
 	b.fileLock.Lock()
 	defer b.fileLock.Unlock()
 
-	if b.path == "STDOUT" {
+	if b.path == "stdout" {
 		return b.formatter.FormatRequest(os.Stdout, b.formatConfig, auth, req, outerErr)
 	}
 
@@ -192,7 +192,7 @@ func (b *Backend) LogResponse(
 	b.fileLock.Lock()
 	defer b.fileLock.Unlock()
 
-	if b.path == "STDOUT" {
+	if b.path == "stdout" {
 		return b.formatter.FormatResponse(os.Stdout, b.formatConfig, auth, req, resp, err)
 	}
 
@@ -245,7 +245,7 @@ func (b *Backend) open() error {
 }
 
 func (b *Backend) Reload() error {
-	if b.path == "STDOUT" {
+	if b.path == "stdout" {
 		return nil
 	}
 

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/vault/audit"
@@ -26,6 +27,11 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 		if !ok {
 			return nil, fmt.Errorf("file_path is required")
 		}
+	}
+
+	// normalize path if configured for stdout
+	if strings.ToLower(path) == "stdout" {
+		path = "stdout"
 	}
 
 	format, ok := conf.Config["format"]

--- a/website/source/docs/audit/file.html.md
+++ b/website/source/docs/audit/file.html.md
@@ -56,7 +56,7 @@ Following are the configuration options available for the backend.
         <span class="param">file_path</span>
         <span class="param-flags">required</span>
             The path to where the audit log will be written. If this
-            path exists, the audit backend will append to it. Specify `"STDOUT"` to write audit log to **stdout**.
+            path exists, the audit backend will append to it. Specify `"stdout"` to write audit log to **stdout**.
       </li>
       <li>
         <span class="param">log_raw</span>

--- a/website/source/docs/audit/file.html.md
+++ b/website/source/docs/audit/file.html.md
@@ -56,7 +56,7 @@ Following are the configuration options available for the backend.
         <span class="param">file_path</span>
         <span class="param-flags">required</span>
             The path to where the audit log will be written. If this
-            path exists, the audit backend will append to it.
+            path exists, the audit backend will append to it. Specify `"STDOUT"` to write audit log to **stdout**.
       </li>
       <li>
         <span class="param">log_raw</span>


### PR DESCRIPTION
Here is a working request based on @jefferai's input on #2195. For this one I just took the file backend and forked behavior if file_path is STDOUT. 

What I did:
- passed the logger into the audit backend
- made a special log level LevelRaw (-2) that will dynamically select `formatRaw`.
- fork audit file backend when `file_path == "STDOUT"`, I first tried `-` like @jefferai suggested, but this behaved weirdly in the CLI-- even in quotes I think it must get interpreted as a flag, wasn't sure how to escape it properly. `STDOUT` is easier-- no escaping

Questions:
- Should it be it's own backend?
- Is there any better way to do raw logging? It seems like it would be cleaner to make a special logger just for raw logging, but then the semaphore wouldn't be shared w/ the main logger
- Can my amateurish go code be improved anywhere?
- Is -2 an ok log-level? Since you have to mount it as an audit backend, I think it shouldn't ever be silenced by less verbose log-levels.

Still to be done:
- I need to update the docs, just figured I'd wait to get feedback first