### PR TITLE
Use TypeDurationSecond for TTL values in PKI.

### DIFF
--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -1,6 +1,8 @@
 package pki
 
 import (
+	"time"
+
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -27,7 +29,7 @@ func (b *backend) getGenerationParams(
 	}
 
 	role = &roleEntry{
-		TTL:              data.Get("ttl").(string),
+		TTL:              (time.Duration(data.Get("ttl").(int)) * time.Second).String(),
 		KeyType:          data.Get("key_type").(string),
 		KeyBits:          data.Get("key_bits").(int),
 		AllowLocalhost:   true,

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -739,7 +739,7 @@ func generateCreationBundle(b *backend,
 				ttl, err = parseutil.ParseDurationSecond(role.TTL)
 				if err != nil {
 					return nil, errutil.UserError{Err: fmt.Sprintf(
-						"invalid requested ttl: %s", err)}
+						"invalid role ttl: %s", err)}
 				}
 			}
 		}
@@ -748,7 +748,7 @@ func generateCreationBundle(b *backend,
 			maxTTL, err = parseutil.ParseDurationSecond(role.MaxTTL)
 			if err != nil {
 				return nil, errutil.UserError{Err: fmt.Sprintf(
-					"invalid ttl: %s", err)}
+					"invalid role max_ttl: %s", err)}
 			}
 		}
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -59,7 +59,7 @@ email addresses.`,
 	}
 
 	fields["ttl"] = &framework.FieldSchema{
-		Type: framework.TypeString,
+		Type: framework.TypeDurationSecond,
 		Description: `The requested Time To Live for the certificate;
 sets the expiration date. If not specified
 the role default, backend default, or system
@@ -92,7 +92,7 @@ must still be specified in alt_names or ip_sans.`,
 	}
 
 	fields["ttl"] = &framework.FieldSchema{
-		Type: framework.TypeString,
+		Type: framework.TypeDurationSecond,
 		Description: `The requested Time To Live for the certificate;
 sets the expiration date. If not specified
 the role default, backend default, or system

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -35,7 +35,7 @@ func pathRoles(b *backend) *framework.Path {
 			},
 
 			"ttl": &framework.FieldSchema{
-				Type:    framework.TypeString,
+				Type:    framework.TypeDurationSecond,
 				Default: "",
 				Description: `The lease duration if no specific lease duration is
 requested. The lease duration controls the expiration
@@ -383,7 +383,7 @@ func (b *backend) pathRoleCreate(
 
 	entry := &roleEntry{
 		MaxTTL:              data.Get("max_ttl").(string),
-		TTL:                 data.Get("ttl").(string),
+		TTL:                 (time.Duration(data.Get("ttl").(int)) * time.Second).String(),
 		AllowLocalhost:      data.Get("allow_localhost").(bool),
 		AllowedDomains:      data.Get("allowed_domains").(string),
 		AllowBareDomains:    data.Get("allow_bare_domains").(bool),

--- a/helper/parseutil/parseutil.go
+++ b/helper/parseutil/parseutil.go
@@ -19,6 +19,9 @@ func ParseDurationSecond(in interface{}) (time.Duration, error) {
 	switch in.(type) {
 	case string:
 		inp := in.(string)
+		if inp == "" {
+			return time.Duration(0), nil
+		}
 		var err error
 		// Look for a suffix otherwise its a plain second value
 		if strings.HasSuffix(inp, "s") || strings.HasSuffix(inp, "m") || strings.HasSuffix(inp, "h") {


### PR DESCRIPTION
This has the side effect of simplifying logic quite a bit.

This also fixes/changes parseutil.ParseDurationSecond to return a
duration of 0 if the input is a string but empty.