### PR TITLE
Fixing the response sample for reading a plugin

### DIFF
--- a/website/source/api/system/plugins-catalog.html.md
+++ b/website/source/api/system/plugins-catalog.html.md
@@ -120,13 +120,11 @@ $ curl \
 ```javascript
 {
 	"data": {
-		"plugin": {
-			"args": [],
-			"builtin": false,
-			"command": "/tmp/vault-plugins/mysql-database-plugin",
-			"name": "example-plugin",
-			"sha256": "0TC5oPv93vlwnY/5Ll5gU8zSRreGMvwDuFSEVwJpYek="
-		}
+		"args": [],
+		"builtin": false,
+		"command": "/tmp/vault-plugins/mysql-database-plugin",
+		"name": "example-plugin",
+		"sha256": "0TC5oPv93vlwnY/5Ll5gU8zSRreGMvwDuFSEVwJpYek="
 	}
 }
 ```


### PR DESCRIPTION
The plugin config data properties are returned immediately within the response's `data` object.