### PR TITLE
auth/aws: Fix panics when malformed ARNs are passed in

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -1318,6 +1318,9 @@ func parseIamArn(iamArn string) (*iamEntity, error) {
 	// most people would expect, which is arn:aws:iam::<account_id>:role/<RoleName>
 	var entity iamEntity
 	fullParts := strings.Split(iamArn, ":")
+	if len(fullParts) != 6 {
+		return nil, fmt.Errorf("unrecognized arn: contains %d colon-separated parts, expected 6", len(fullParts))
+	}
 	if fullParts[0] != "arn" {
 		return nil, fmt.Errorf("unrecognized arn: does not begin with arn:")
 	}
@@ -1330,6 +1333,9 @@ func parseIamArn(iamArn string) (*iamEntity, error) {
 	entity.AccountNumber = fullParts[4]
 	// fullParts[5] would now be something like user/<UserName> or assumed-role/<RoleName>/<RoleSessionName>
 	parts := strings.Split(fullParts[5], "/")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("unrecognized arn: %q contains fewer than 2 slash-separated parts", fullParts[5])
+	}
 	entity.Type = parts[0]
 	entity.Path = strings.Join(parts[1:len(parts)-1], "/")
 	entity.FriendlyName = parts[len(parts)-1]

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -88,6 +88,27 @@ func TestBackend_pathLogin_parseIamArn(t *testing.T) {
 		"",
 		iamEntity{Partition: "aws", AccountNumber: "123456789012", Type: "instance-profile", Path: "profilePath", FriendlyName: "InstanceProfileName"},
 	)
+
+	// Test that it properly handles pathological inputs...
+	_, err := parseIamArn("")
+	if err == nil {
+		t.Error("expected error from empty input string")
+	}
+
+	_, err = parseIamArn("arn:aws:iam::123456789012:role")
+	if err == nil {
+		t.Error("expected error from malformed ARN without a role name")
+	}
+
+	_, err = parseIamArn("arn:aws:iam")
+	if err == nil {
+		t.Error("expected error from incomplete ARN (arn:aws:iam)")
+	}
+
+	_, err = parseIamArn("arn:aws:iam::1234556789012:/")
+	if err == nil {
+		t.Error("expected error from empty principal type and no principal name (arn:aws:iam::1234556789012:/)")
+	}
 }
 
 func TestBackend_validateVaultHeaderValue(t *testing.T) {


### PR DESCRIPTION
The parseIamArn method was making assumptions about the input arn being
properly formatted and of a certain type. If users tried to pass a
bound_iam_principal_arn that was malformed (or was the ARN of the root
user), it would cause a panic. parseIamArn now explicitly checks the
assumptions it's making and tests are added to ensure it properly errors
out (rather than panic'ing) on malformed input.

#3179 first reported the panic on the root ARN being passed in. #3181 fixed the
panic, but when it was reverted in #3212 it reintroduced the issue of Vault
panic'ing when the root arn was passed in. Vault should fail gracefully in these
scenarios :)