### PR TITLE
Enhancements to `setupTLSConfig`

### DIFF
--- a/website/source/docs/configuration/storage/consul.html.md
+++ b/website/source/docs/configuration/storage/consul.html.md
@@ -100,6 +100,13 @@ connection. You can read more about encrypting Consul connections on the
   [`ca_file`](https://www.consul.io/docs/agent/options.html#ca_file) setting in
   Consul.
 
+- `tls_ca_path` `(string: "")` – Specifies the path to a directory of
+  certificate authority files for Consul communication.  Is an alternative to
+  `tls_ca_file`.  This defaults to the system bundle if not specified.
+  This should be set according to the
+  [`ca_path`](https://www.consul.io/docs/agent/options.html#ca_path) setting in
+  Consul.
+
 - `tls_cert_file` `(string: "")` (optional) – Specifies the path to the
   certificate for Consul communication. This should be set according to the
   [`cert_file`](https://www.consul.io/docs/agent/options.html#cert_file) setting
@@ -109,6 +116,13 @@ connection. You can read more about encrypting Consul connections on the
   Consul communication. This should be set according to the
   [`key_file`](https://www.consul.io/docs/agent/options.html#key_file) setting
   in Consul.
+
+- `tls_server_name` `(string: "")` (optional) – Specifies the server name to
+  use as the SNI host for Consul communication via TLS.  This defaults to the
+  server name portion of `address`.
+  This should be set according to the
+  [`server_name`](https://www.consul.io/docs/agent/options.html#server_name)
+  setting in Consul.
 
 - `tls_min_version` `(string: "tls12")` – Specifies the minimum TLS version to
   use. Accepted values are `"tls10"`, `"tls11"` or `"tls12"`.


### PR DESCRIPTION
The function `setupTLSConfig` is now implemented in terms of the
function `SetupTLSConfig` in `consul/api`.

The function also respects two additional configuration properties.
- `tls_server_name` (optional) which sets the server name to use as
  the SNI host when connecting via TLS (for when it differs from the
  server name in `address`). Has the same behavior as the environment
  variable `CONSUL_TLS_SERVER_NAME`.
- `tls_ca_path` (optional) which sets the path to a directory of CA
  certificates to use for Consul communication. Has the same behavior
  as the environment variable `CONSUL_CAPATH`.

The function also now logs:
- a debug message containing the values used to create the `Config`
  from the `crypto/tls` package.
- a warning message when only one of `tls_key_file` or `tls_cert_file`
  are provided in the `conf` map.