### PR TITLE
Simplify a lot of the mount tuning code

### DIFF
--- a/http/sys_mount_test.go
+++ b/http/sys_mount_test.go
@@ -602,7 +602,7 @@ func TestSysTuneMount(t *testing.T) {
 	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{
 		"default_lease_ttl": "72000h",
 	})
-	testResponseStatus(t, resp, 400)
+	testResponseStatus(t, resp, 204)
 
 	// Longer than system default
 	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/foo/tune", map[string]interface{}{

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1561,7 +1561,7 @@ func (b *SystemBackend) handleTuneWriteCommon(
 		b.Backend.Logger().Error("sys: tune failed: no mount entry found", "path", path)
 		return handleError(fmt.Errorf("sys: tune of path '%s' failed: no mount entry found", path))
 	}
-	if mountEntry != nil && !mountEntry.Local && repState == consts.ReplicationSecondary {
+	if mountEntry != nil && !mountEntry.Local && repState.HasState(consts.ReplicationPerformanceSecondary) {
 		return logical.ErrorResponse("cannot tune a non-local mount on a replication secondary"), nil
 	}
 
@@ -1606,8 +1606,6 @@ func (b *SystemBackend) handleTuneWriteCommon(
 		}
 	}
 
-	var resp *logical.Response
-
 	description := data.Get("description").(string)
 	if description != "" {
 		oldDesc := mountEntry.Description
@@ -1630,7 +1628,7 @@ func (b *SystemBackend) handleTuneWriteCommon(
 		}
 	}
 
-	return resp, nil
+	return nil, nil
 }
 
 // handleLease is use to view the metadata for a given LeaseID

--- a/vault/logical_system_helpers.go
+++ b/vault/logical_system_helpers.go
@@ -7,61 +7,31 @@ import (
 )
 
 // tuneMount is used to set config on a mount point
-func (b *SystemBackend) tuneMountTTLs(path string, me *MountEntry, newDefault, newMax *time.Duration) error {
-	meConfig := &me.Config
+func (b *SystemBackend) tuneMountTTLs(path string, me *MountEntry, newDefault, newMax time.Duration) error {
+	zero := time.Duration(0)
 
-	if newDefault == nil && newMax == nil {
-		return nil
-	}
-	if newDefault == nil && newMax != nil &&
-		*newMax == meConfig.MaxLeaseTTL {
-		return nil
-	}
-	if newMax == nil && newDefault != nil &&
-		*newDefault == meConfig.DefaultLeaseTTL {
-		return nil
-	}
-	if newMax != nil && newDefault != nil &&
-		*newDefault == meConfig.DefaultLeaseTTL &&
-		*newMax == meConfig.MaxLeaseTTL {
-		return nil
-	}
+	switch {
+	case newDefault == zero && newMax == zero:
+		// No checks needed
 
-	if newMax != nil && newDefault != nil && *newMax < *newDefault {
-		return fmt.Errorf("new backend max lease TTL of %d less than new backend default lease TTL of %d",
-			int(newMax.Seconds()), int(newDefault.Seconds()))
-	}
+	case newDefault == zero && newMax != zero:
+		// No default/max conflict, no checks needed
 
-	if newMax != nil && newDefault == nil {
-		if meConfig.DefaultLeaseTTL != 0 && *newMax < meConfig.DefaultLeaseTTL {
-			return fmt.Errorf("new backend max lease TTL of %d less than backend default lease TTL of %d",
-				int(newMax.Seconds()), int(meConfig.DefaultLeaseTTL.Seconds()))
+	case newDefault != zero && newMax == zero:
+		// No default/max conflict, no checks needed
+
+	case newDefault != zero && newMax != zero:
+		if newMax < newDefault {
+			return fmt.Errorf("backend max lease TTL of %d would be less than backend default lease TTL of %d",
+				int(newMax.Seconds()), int(newDefault.Seconds()))
 		}
 	}
 
-	if newDefault != nil {
-		if meConfig.MaxLeaseTTL == 0 {
-			if newMax == nil && *newDefault > b.Core.maxLeaseTTL {
-				return fmt.Errorf("new backend default lease TTL of %d greater than system max lease TTL of %d",
-					int(newDefault.Seconds()), int(b.Core.maxLeaseTTL.Seconds()))
-			}
-		} else {
-			if newMax == nil && *newDefault > meConfig.MaxLeaseTTL {
-				return fmt.Errorf("new backend default lease TTL of %d greater than backend max lease TTL of %d",
-					int(newDefault.Seconds()), int(meConfig.MaxLeaseTTL.Seconds()))
-			}
-		}
-	}
+	origMax := me.Config.MaxLeaseTTL
+	origDefault := me.Config.DefaultLeaseTTL
 
-	origMax := meConfig.MaxLeaseTTL
-	origDefault := meConfig.DefaultLeaseTTL
-
-	if newMax != nil {
-		meConfig.MaxLeaseTTL = *newMax
-	}
-	if newDefault != nil {
-		meConfig.DefaultLeaseTTL = *newDefault
-	}
+	me.Config.MaxLeaseTTL = newMax
+	me.Config.DefaultLeaseTTL = newDefault
 
 	// Update the mount table
 	var err error
@@ -72,13 +42,12 @@ func (b *SystemBackend) tuneMountTTLs(path string, me *MountEntry, newDefault, n
 		err = b.Core.persistMounts(b.Core.mounts, me.Local)
 	}
 	if err != nil {
-		meConfig.MaxLeaseTTL = origMax
-		meConfig.DefaultLeaseTTL = origDefault
+		me.Config.MaxLeaseTTL = origMax
+		me.Config.DefaultLeaseTTL = origDefault
 		return fmt.Errorf("failed to update mount table, rolling back TTL changes")
 	}
-
 	if b.Core.logger.IsInfo() {
-		b.Core.logger.Info("core: mount tuning successful", "path", path)
+		b.Core.logger.Info("core: mount tuning of leases successful", "path", path)
 	}
 
 	return nil


### PR DESCRIPTION
Make leases much simpler by not trying to compare against system
default/max -- a bit of a fool's errand since a change to config files
can flip whether it's even valid.

For extra credit, add the ability to tune description; closes #2645