### PR TITLE
Fix build script for Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ vet:
 # source files.
 prep:
 	go generate $(go list ./... | grep -v /vendor/)
-	cp -u .hooks/* .git/hooks/
+	cp .hooks/* .git/hooks/
 
 # bootstrap the build by downloading additional tools
 bootstrap:


### PR DESCRIPTION
* Copy the hooks every time, since Darwin does not support `cp -u`.
