### PR TITLE
Adding latency injector option to -dev mode for storage operations

### DIFF
--- a/physical/latency.go
+++ b/physical/latency.go
@@ -1,7 +1,6 @@
 package physical
 
 import (
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -57,7 +56,6 @@ func (l *LatencyInjector) addLatency() {
 	max := 100 + l.jitterPercent
 	percent := float64(l.random.Intn(max-min)+min) / 100
 	latencyDuration := time.Duration(int64(float64(l.latency/time.Millisecond)*percent)) * time.Millisecond
-	fmt.Printf("%v\n", latencyDuration)
 	time.Sleep(latencyDuration)
 }
 

--- a/physical/latency.go
+++ b/physical/latency.go
@@ -51,11 +51,11 @@ func NewTransactionalLatencyInjector(b Backend, latency time.Duration, jitter in
 }
 
 func (l *LatencyInjector) addLatency() {
-	// Calculate a value between -1 and 1
+	// Calculate a value between 1 +- jitter%
 	min := 100 - l.jitterPercent
 	max := 100 + l.jitterPercent
-	percent := float64(l.random.Intn(max-min)+min) / 100
-	latencyDuration := time.Duration(int64(float64(l.latency/time.Millisecond)*percent)) * time.Millisecond
+	percent := l.random.Intn(max-min) + min
+	latencyDuration := time.Duration(int(l.latency) * percent / 100)
 	time.Sleep(latencyDuration)
 }
 

--- a/physical/latency.go
+++ b/physical/latency.go
@@ -1,0 +1,92 @@
+package physical
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	log "github.com/mgutz/logxi/v1"
+)
+
+const (
+	// DefaultJitterPercent is used if no cache size is specified for NewCache
+	DefaultJitterPercent = 20
+)
+
+// LatencyInjector is used to add latency into underlying physical requests
+type LatencyInjector struct {
+	backend       Backend
+	latency       time.Duration
+	jitterPercent int
+	random        *rand.Rand
+}
+
+// TransactionalLatencyInjector is the transactional version of the latency
+// injector
+type TransactionalLatencyInjector struct {
+	*LatencyInjector
+	Transactional
+}
+
+// NewLatencyInjector returns a wrapped physical backend to simulate latency
+func NewLatencyInjector(b Backend, latency time.Duration, jitter int, logger log.Logger) *LatencyInjector {
+	if jitter < 0 || jitter > 100 {
+		jitter = DefaultJitterPercent
+	}
+	logger.Info("physical/latency: creating latency injector")
+
+	return &LatencyInjector{
+		backend:       b,
+		latency:       latency,
+		jitterPercent: jitter,
+		random:        rand.New(rand.NewSource(int64(time.Now().Nanosecond()))),
+	}
+}
+
+// NewTransactionalLatencyInjector creates a new transactional LatencyInjector
+func NewTransactionalLatencyInjector(b Backend, latency time.Duration, jitter int, logger log.Logger) *TransactionalLatencyInjector {
+	return &TransactionalLatencyInjector{
+		LatencyInjector: NewLatencyInjector(b, latency, jitter, logger),
+		Transactional:   b.(Transactional),
+	}
+}
+
+func (l *LatencyInjector) addLatency() {
+	// Calculate a value between -1 and 1
+	min := 100 - l.jitterPercent
+	max := 100 + l.jitterPercent
+	percent := float64(l.random.Intn(max-min)+min) / 100
+	latencyDuration := time.Duration(int64(float64(l.latency/time.Millisecond)*percent)) * time.Millisecond
+	fmt.Printf("%v\n", latencyDuration)
+	time.Sleep(latencyDuration)
+}
+
+// Put is a latent put request
+func (l *LatencyInjector) Put(entry *Entry) error {
+	l.addLatency()
+	return l.backend.Put(entry)
+}
+
+// Get is a latent get request
+func (l *LatencyInjector) Get(key string) (*Entry, error) {
+	l.addLatency()
+	return l.backend.Get(key)
+}
+
+// Delete is a latent delete request
+func (l *LatencyInjector) Delete(key string) error {
+	l.addLatency()
+	return l.backend.Delete(key)
+}
+
+// List is a latent list request
+func (l *LatencyInjector) List(prefix string) ([]string, error) {
+	l.addLatency()
+	return l.backend.List(prefix)
+}
+
+// Transaction is a latent transaction request
+func (l *TransactionalLatencyInjector) Transaction(txns []TxnEntry) error {
+	l.addLatency()
+	return l.Transactional.Transaction(txns)
+}

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -119,7 +119,7 @@ func (c *Core) setupExpiration() error {
 			c.logger.Error("expiration: error shutting down core: %v", err)
 		}
 	}
-	go c.expiration.Restore(errorFunc, 0)
+	go c.expiration.Restore(errorFunc)
 
 	return nil
 }
@@ -270,7 +270,7 @@ func (m *ExpirationManager) Tidy() error {
 
 // Restore is used to recover the lease states when starting.
 // This is used after starting the vault.
-func (m *ExpirationManager) Restore(errorFunc func(), loadDelay time.Duration) (retErr error) {
+func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
 	defer func() {
 		// Turn off restore mode. We can do this safely without the lock because
 		// if restore mode finished successfully, restore mode was already
@@ -324,7 +324,7 @@ func (m *ExpirationManager) Restore(errorFunc func(), loadDelay time.Duration) (
 						return
 					}
 
-					err := m.processRestore(leaseID, loadDelay)
+					err := m.processRestore(leaseID)
 					if err != nil {
 						errs <- err
 						continue
@@ -400,7 +400,7 @@ func (m *ExpirationManager) Restore(errorFunc func(), loadDelay time.Duration) (
 
 // processRestore takes a lease and restores it in the expiration manager if it has
 // not already been seen
-func (m *ExpirationManager) processRestore(leaseID string, loadDelay time.Duration) error {
+func (m *ExpirationManager) processRestore(leaseID string) error {
 	m.restoreRequestLock.RLock()
 	defer m.restoreRequestLock.RUnlock()
 
@@ -415,11 +415,6 @@ func (m *ExpirationManager) processRestore(leaseID string, loadDelay time.Durati
 	// Check again with the lease locked
 	if _, ok := m.restoreLoaded.Load(leaseID); ok {
 		return nil
-	}
-
-	// Useful for testing to add latency to all load requests
-	if loadDelay > 0 {
-		time.Sleep(loadDelay)
 	}
 
 	// Load lease and restore expiration timer

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -37,7 +37,7 @@ func TestExpiration_Tidy(t *testing.T) {
 	var err error
 
 	exp := mockExpiration(t)
-	if err := exp.Restore(nil, 0); err != nil {
+	if err := exp.Restore(nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -341,7 +341,7 @@ func benchmarkExpirationBackend(b *testing.B, physicalBackend physical.Backend, 
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err = exp.Restore(nil, 0)
+		err = exp.Restore(nil)
 		// Restore
 		if err != nil {
 			b.Fatalf("err: %v", err)
@@ -399,7 +399,7 @@ func TestExpiration_Restore(t *testing.T) {
 	}
 
 	// Restore
-	err = exp.Restore(nil, 0)
+	err = exp.Restore(nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
Adding a general latency injector that can be enabled in dev mode to simulate storage latency while still using the in-memory backend.