### PR TITLE
Fix goroutine error handling in vault tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ dev-dynamic: prep
 
 # test runs the unit tests and vets the code
 test: fmtcheck prep
-	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -timeout=20m -parallel=4
+	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -timeout=40m -parallel=4
 
 testcompile: fmtcheck prep
 	@for pkg in $(TEST) ; do \

--- a/plugins/database/cassandra/cassandra-database-plugin/main.go
+++ b/plugins/database/cassandra/cassandra-database-plugin/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	apiClientMeta := &pluginutil.APIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args)
+	flags.Parse(os.Args[1:])
 
 	err := cassandra.Run(apiClientMeta.GetTLSConfig())
 	if err != nil {

--- a/plugins/database/hana/hana-database-plugin/main.go
+++ b/plugins/database/hana/hana-database-plugin/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	apiClientMeta := &pluginutil.APIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args)
+	flags.Parse(os.Args[1:])
 
 	err := hana.Run(apiClientMeta.GetTLSConfig())
 	if err != nil {

--- a/plugins/database/mongodb/mongodb-database-plugin/main.go
+++ b/plugins/database/mongodb/mongodb-database-plugin/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	apiClientMeta := &pluginutil.APIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args)
+	flags.Parse(os.Args[1:])
 
 	err := mongodb.Run(apiClientMeta.GetTLSConfig())
 	if err != nil {

--- a/plugins/database/mssql/mssql-database-plugin/main.go
+++ b/plugins/database/mssql/mssql-database-plugin/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	apiClientMeta := &pluginutil.APIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args)
+	flags.Parse(os.Args[1:])
 
 	err := mssql.Run(apiClientMeta.GetTLSConfig())
 	if err != nil {

--- a/plugins/database/mysql/mysql-database-plugin/main.go
+++ b/plugins/database/mysql/mysql-database-plugin/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	apiClientMeta := &pluginutil.APIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args)
+	flags.Parse(os.Args[1:])
 
 	err := mysql.Run(apiClientMeta.GetTLSConfig())
 	if err != nil {

--- a/plugins/database/mysql/mysql-legacy-database-plugin/main.go
+++ b/plugins/database/mysql/mysql-legacy-database-plugin/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	apiClientMeta := &pluginutil.APIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args)
+	flags.Parse(os.Args[1:])
 
 	err := mysql.RunLegacy(apiClientMeta.GetTLSConfig())
 	if err != nil {

--- a/plugins/database/postgresql/postgresql-database-plugin/main.go
+++ b/plugins/database/postgresql/postgresql-database-plugin/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	apiClientMeta := &pluginutil.APIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args)
+	flags.Parse(os.Args[1:])
 
 	err := postgresql.Run(apiClientMeta.GetTLSConfig())
 	if err != nil {

--- a/vault/cluster_test.go
+++ b/vault/cluster_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	clusterTestPausePeriod = 2 * time.Second
+	clusterTestPausePeriod = 4 * time.Second
 )
 
 func TestClusterFetching(t *testing.T) {

--- a/vault/cluster_test.go
+++ b/vault/cluster_test.go
@@ -92,7 +92,7 @@ func TestClusterHAFetching(t *testing.T) {
 
 func TestCluster_ListenForRequests(t *testing.T) {
 	// Make this nicer for tests
-	manualStepDownSleepPeriod = 5 * time.Second
+	manualStepDownSleepPeriod = 10 * time.Second
 
 	cluster := NewTestCluster(t, nil, &TestClusterOptions{
 		KeepStandbysSealed: true,
@@ -130,7 +130,7 @@ func TestCluster_ListenForRequests(t *testing.T) {
 					t.Logf("testing %s:%d unsuccessful as expected", tcpAddr.IP.String(), tcpAddr.Port+105)
 					continue
 				}
-				t.Fatalf("error: %v\nlisteners are\n%#v\n%#v\n", err, cores[0].Listeners[0], cores[0].Listeners[1])
+				t.Fatalf("error: %v\nlisteners are\n%#v\n", err, cores[0].Listeners)
 			}
 			if expectFail {
 				t.Fatalf("testing %s:%d not unsuccessful as expected", tcpAddr.IP.String(), tcpAddr.Port+105)

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -1451,7 +1451,7 @@ func TestCore_CleanLeaderPrefix(t *testing.T) {
 	}
 
 	// Give time for the entries to clear out; it is conservative at 1/second
-	time.Sleep(10 * leaderPrefixCleanDelay)
+	time.Sleep(20 * leaderPrefixCleanDelay)
 
 	entries, err = core2.barrier.List(coreLeaderPrefix)
 	if err != nil {

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -3297,6 +3297,7 @@ func TestTokenStore_RevokeUseCountToken(t *testing.T) {
 		if err == nil {
 			errCh <- fmt.Errorf("expected an error from revokeSalted, got nil")
 		}
+		close(readyCh)
 		close(errCh)
 	}()
 

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -3287,17 +3287,21 @@ func TestTokenStore_RevokeUseCountToken(t *testing.T) {
 	}
 	cubbyFuncLock.Unlock()
 
+	errCh := make(chan error)
+	readyCh := make(chan struct{})
 	go func() {
 		cubbyFuncLock.RLock()
+		readyCh <- struct{}{}
 		err := ts.revokeSalted(saltTut)
 		cubbyFuncLock.RUnlock()
 		if err == nil {
-			t.Fatalf("expected error")
+			errCh <- fmt.Errorf("expected an error from revokeSalted, got nil")
 		}
+		close(errCh)
 	}()
 
-	// Give time for the function to start and grab locks
-	time.Sleep(200 * time.Millisecond)
+	// Wait for goroutine to start and grab locks
+	_ = <-readyCh
 	te, err = ts.lookupSalted(saltTut, true)
 	if err != nil {
 		t.Fatal(err)
@@ -3309,8 +3313,11 @@ func TestTokenStore_RevokeUseCountToken(t *testing.T) {
 		t.Fatalf("bad: %d", te.NumUses)
 	}
 
-	// Let things catch up
-	time.Sleep(2 * time.Second)
+	// Check the error channel from the revokeSalted in goroutine
+	err = <-errCh
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Put back to normal
 	cubbyFuncLock.Lock()

--- a/vendor/github.com/docker/docker/pkg/archive/archive_unix.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive_unix.go
@@ -50,8 +50,8 @@ func setHeaderForSpecialDevice(hdr *tar.Header, name string, stat interface{}) (
 		// Currently go does not fill in the major/minors
 		if s.Mode&unix.S_IFBLK != 0 ||
 			s.Mode&unix.S_IFCHR != 0 {
-			hdr.Devmajor = int64(major(s.Rdev))
-			hdr.Devminor = int64(minor(s.Rdev))
+			hdr.Devmajor = int64(major(uint64(s.Rdev))) // nolint: unconvert
+			hdr.Devminor = int64(minor(uint64(s.Rdev))) // nolint: unconvert
 		}
 	}
 

--- a/vendor/github.com/docker/docker/pkg/archive/example_changes.go
+++ b/vendor/github.com/docker/docker/pkg/archive/example_changes.go
@@ -1,0 +1,97 @@
+// +build ignore
+
+// Simple tool to create an archive stream from an old and new directory
+//
+// By default it will stream the comparison of two temporary directories with junk files
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/docker/docker/pkg/archive"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	flDebug  = flag.Bool("D", false, "debugging output")
+	flNewDir = flag.String("newdir", "", "")
+	flOldDir = flag.String("olddir", "", "")
+	log      = logrus.New()
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Println("Produce a tar from comparing two directory paths. By default a demo tar is created of around 200 files (including hardlinks)")
+		fmt.Printf("%s [OPTIONS]\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	log.Out = os.Stderr
+	if (len(os.Getenv("DEBUG")) > 0) || *flDebug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	var newDir, oldDir string
+
+	if len(*flNewDir) == 0 {
+		var err error
+		newDir, err = ioutil.TempDir("", "docker-test-newDir")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer os.RemoveAll(newDir)
+		if _, err := prepareUntarSourceDirectory(100, newDir, true); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		newDir = *flNewDir
+	}
+
+	if len(*flOldDir) == 0 {
+		oldDir, err := ioutil.TempDir("", "docker-test-oldDir")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer os.RemoveAll(oldDir)
+	} else {
+		oldDir = *flOldDir
+	}
+
+	changes, err := archive.ChangesDirs(newDir, oldDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	a, err := archive.ExportChanges(newDir, changes)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer a.Close()
+
+	i, err := io.Copy(os.Stdout, a)
+	if err != nil && err != io.EOF {
+		log.Fatal(err)
+	}
+	fmt.Fprintf(os.Stderr, "wrote archive of %d bytes", i)
+}
+
+func prepareUntarSourceDirectory(numberOfFiles int, targetPath string, makeLinks bool) (int, error) {
+	fileData := []byte("fooo")
+	for n := 0; n < numberOfFiles; n++ {
+		fileName := fmt.Sprintf("file-%d", n)
+		if err := ioutil.WriteFile(path.Join(targetPath, fileName), fileData, 0700); err != nil {
+			return 0, err
+		}
+		if makeLinks {
+			if err := os.Link(path.Join(targetPath, fileName), path.Join(targetPath, fileName+"-link")); err != nil {
+				return 0, err
+			}
+		}
+	}
+	totalSize := numberOfFiles * len(fileData)
+	return totalSize, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -579,164 +579,164 @@
 		{
 			"checksumSHA1": "DmVjBB1a8uZzckWdWIu7pXWVTUc=",
 			"path": "github.com/docker/docker/api/types",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "jVJDbe0IcyjoKc2xbohwzQr+FF0=",
 			"path": "github.com/docker/docker/api/types/blkiodev",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "wyg5aht8yEIRsgW/PzDvy9yIF7U=",
 			"path": "github.com/docker/docker/api/types/container",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "mb6vka286bT0hXMbz09yOZMSuxg=",
 			"path": "github.com/docker/docker/api/types/filters",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "uJeLBKpHZXP+bWhXP4HhpyUTWYI=",
 			"path": "github.com/docker/docker/api/types/mount",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "Gskp+nvbVe8Gk1xPLHylZvNmqTg=",
 			"path": "github.com/docker/docker/api/types/network",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "r2vWq7Uc3ExKzMqYgH0b4AKjLKY=",
 			"path": "github.com/docker/docker/api/types/registry",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "VTxWyFud/RedrpllGdQonVtGM/A=",
 			"path": "github.com/docker/docker/api/types/strslice",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "WNhyKx+2cJ5Gx3jdCeDr0J43F3Y=",
 			"path": "github.com/docker/docker/api/types/swarm",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "mi8EDCDjtrZEONRXPG7VHJosDwY=",
 			"path": "github.com/docker/docker/api/types/swarm/runtime",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "uDPQ3nHsrvGQc9tg/J9OSC4N5dQ=",
 			"path": "github.com/docker/docker/api/types/versions",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "mZ6S+W3VaotYJZnuJim6PNV04C8=",
 			"path": "github.com/docker/docker/opts",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
-			"checksumSHA1": "LH5HB7YeZLHCjEDyQEvZkXFQoSY=",
+			"checksumSHA1": "rArmPXgt/O8HOb/0/ni4dUpLvX4=",
 			"path": "github.com/docker/docker/pkg/archive",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "/rhDgzb51QH29Dn6v9lr/NQrLbs=",
 			"path": "github.com/docker/docker/pkg/fileutils",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "OSFbrnYeBqJzNJ5CsHzQpfCzpR0=",
 			"path": "github.com/docker/docker/pkg/homedir",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "5UI7YJZQYPQhSj3HTUT6h5j7SeE=",
 			"path": "github.com/docker/docker/pkg/idtools",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "jsjQr20W2W6Gewf8Un3D8IKu2I8=",
 			"path": "github.com/docker/docker/pkg/ioutils",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "kp20bhjkvJ06uW6DRfVIZbCj8SY=",
 			"path": "github.com/docker/docker/pkg/jsonlog",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "d7KXgDaJPBbQ8LFKwdwNU2yZz3k=",
 			"path": "github.com/docker/docker/pkg/jsonmessage",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "ndnAFCfsGC3upNQ6jAEwzxcurww=",
 			"path": "github.com/docker/docker/pkg/longpath",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "w8pyOX/u8XwXRmPWlpKpBBwwYUg=",
 			"path": "github.com/docker/docker/pkg/mount",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "cS0+jrjme0j9GX8LLcioQ7ZOBsQ=",
 			"path": "github.com/docker/docker/pkg/pools",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "txf3EORYff4hO6PEvwBm2lyh1MU=",
 			"path": "github.com/docker/docker/pkg/promise",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "H1rrbVmeE1z2TnkF7tSrfh+qUOY=",
 			"path": "github.com/docker/docker/pkg/stdcopy",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "VULoWaiGaUMvB1LCKO5WNqU1xi8=",
 			"path": "github.com/docker/docker/pkg/system",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "dLlr8QsbOA1BkgdKXNWdqrYsx3E=",
 			"path": "github.com/docker/docker/pkg/term",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "NcljihOPc95QOyQAdufyy3eqKSU=",
 			"path": "github.com/docker/docker/pkg/term/windows",
-			"revision": "d7b4c7e0eac223eda54940adbb4c44bf71ec039c",
-			"revisionTime": "2017-09-05T20:35:07Z"
+			"revision": "a68ee8c8950b1923c3a92b9cec0d9a723897111d",
+			"revisionTime": "2017-09-07T12:52:18Z"
 		},
 		{
 			"checksumSHA1": "JbiWTzH699Sqz25XmDlsARpMN9w=",

--- a/website/source/api/auth/cert/index.html.md
+++ b/website/source/api/auth/cert/index.html.md
@@ -228,9 +228,9 @@ $ curl \
 }
 ```
 
-## Delete Certificate Role
+## Delete CRL
 
-Deletes the named role and CA cert from the backend mount.
+Deletes the named CRL from the backend mount.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |

--- a/website/source/api/secret/rabbitmq/index.html.md
+++ b/website/source/api/secret/rabbitmq/index.html.md
@@ -167,7 +167,7 @@ This endpoint deletes the role definition.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `DELETE` | `/rabbitmq/roles/:namer`     | `204 (empty body)`     |
+| `DELETE` | `/rabbitmq/roles/:name`     | `204 (empty body)`     |
 
 ### Parameters
 

--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -42,7 +42,7 @@ preference and saved to disk.
 1. The policy's contents are uploaded and store in Vault and referenced by name.
 You can think of the policy's name as a pointer or symlink to its set of rules.
 
-1. Most importantly, the security team maps data in the authentication back to a
+1. Most importantly, the security team maps data in the authentication backend to a
 policy. For example, the security team might create mappings like:
 
     > Members of the OU group "dev" map to the Vault policy named "readonly-dev".


### PR DESCRIPTION
The tests for the vault package use goroutines in a few places. Test failures that happen inside a goroutine are swallowed, so this PR introduces some channels that communicate errors to the main goroutine where they can be acted upon.

The previous submission of this PR failed on what looks to have been a flake: https://github.com/hashicorp/vault/pull/3297

