### PR TITLE
Fixed small typo in RabbitMQ secret backend.

### DIFF
--- a/website/source/api/secret/rabbitmq/index.html.md
+++ b/website/source/api/secret/rabbitmq/index.html.md
@@ -167,7 +167,7 @@ This endpoint deletes the role definition.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `DELETE` | `/rabbitmq/roles/:namer`     | `204 (empty body)`     |
+| `DELETE` | `/rabbitmq/roles/:name`     | `204 (empty body)`     |
 
 ### Parameters
 


### PR DESCRIPTION
Fixed `name` param for the Delete Role API in the RabbitMQ secret backend.