### PR TITLE
Fix docs for Certificate authentication

### DIFF
--- a/website/source/api/auth/cert/index.html.md
+++ b/website/source/api/auth/cert/index.html.md
@@ -228,9 +228,9 @@ $ curl \
 }
 ```
 
-## Delete Certificate Role
+## Delete CRL
 
-Deletes the named role and CA cert from the backend mount.
+Deletes the named CRL from the backend mount.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |


### PR DESCRIPTION
Fix discrepancies in the documentation for TLS Certificate authentication. The Delete CRL method has a misleading title and description.