### PR TITLE
Fixed HTTP method names for Token authentication functions

### DIFF
--- a/website/source/api/auth/token/index.html.md
+++ b/website/source/api/auth/token/index.html.md
@@ -301,7 +301,7 @@ if there is a lease associated with it.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `POST`   | `/auth/token/renew`          | `200 application/json` |
-| `POST`   | `/auth/token/renew/:token`   | `200 application/json` |
+| `GET`    | `/auth/token/renew/:token`   | `200 application/json` |
 
 ### Parameters
 
@@ -490,7 +490,7 @@ endpoint.
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `POST`   | `/auth/token/revoke-orphan`          | `204 (empty body)` |
-| `POST`   | `/auth/token/revoke-orphan/:token`   | `204 (empty body)` |
+| `GET`    | `/auth/token/revoke-orphan/:token`   | `204 (empty body)` |
 
 ### Parameters
 


### PR DESCRIPTION
The `Renew Token` and `Revoke Token and Orphan Children` functions have two POST methods with one taking a token as a param. This param-based function should be a GET HTTP method.