### PR TITLE
Explicitly check go version in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - docker
 
 go:
-  - 1.9
+  - 1.9.1
 
 matrix:
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ EXTERNAL_TOOLS=\
 BUILD_TAGS?=vault
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
+# NOTE: This does NOT support specifying versions more granular than x.y
+# E.g., if you specify 1.9, it'll properly check that the build environment
+# is at least 1.9, but if you specify 1.9.1, it will still happily accept
+# a 1.9 build environment.
+GO_VERSION_MIN=1.9
+
 default: dev
 
 # bin generates the releaseable binaries for Vault
@@ -60,6 +66,7 @@ vet:
 # prep runs `go generate` to build the dynamically generated
 # source files.
 prep:
+	@sh -c "'$(CURDIR)/scripts/goversioncheck.sh' '$(GO_VERSION_MIN)'"
 	go generate $(go list ./... | grep -v /vendor/)
 	cp .hooks/* .git/hooks/
 

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,7 @@ EXTERNAL_TOOLS=\
 BUILD_TAGS?=vault
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
-# NOTE: This does NOT support specifying versions more granular than x.y
-# E.g., if you specify 1.9, it'll properly check that the build environment
-# is at least 1.9, but if you specify 1.9.1, it will still happily accept
-# a 1.9 build environment.
-GO_VERSION_MIN=1.9
+GO_VERSION_MIN=1.9.1
 
 default: dev
 

--- a/scripts/goversioncheck.sh
+++ b/scripts/goversioncheck.sh
@@ -3,13 +3,17 @@
 GO_VERSION_MIN=$1
 echo "==> Checking that build is using go version >= $1..."
 
-GO_VERSION=$(go version | grep -o 'go[0-9]\+\.[0-9]\+' | tr -d 'go')
+GO_VERSION=$(go version | grep -o 'go[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?' | tr -d 'go')
 
 
 IFS="." read -r -a GO_VERSION_ARR <<< "$GO_VERSION"
 IFS="." read -r -a GO_VERSION_REQ <<< "$GO_VERSION_MIN"
 
-if [[ ${GO_VERSION_ARR[0]} -lt ${GO_VERSION_REQ[0]} || ( ${GO_VERSION_ARR[0]} -eq ${GO_VERSION_REQ[0]} && ${GO_VERSION_ARR[1]} -lt ${GO_VERSION_REQ[1]} ) ]]; then
+if [[ ${GO_VERSION_ARR[0]} -lt ${GO_VERSION_REQ[0]} ||
+    ( ${GO_VERSION_ARR[0]} -eq ${GO_VERSION_REQ[0]} &&
+      ( ${GO_VERSION_ARR[1]} -lt ${GO_VERSION_REQ[1]} ||
+        ( ${GO_VERSION_ARR[1]} -eq ${GO_VERSION_REQ[1]} && ${GO_VERSION_ARR[2]} -lt ${GO_VERSION_REQ[2]} )))
+    ]]; then
     echo "Vault requires go $GO_VERSION_MIN to build; found $GO_VERSION."
     exit 1
 fi

--- a/scripts/goversioncheck.sh
+++ b/scripts/goversioncheck.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+GO_VERSION_MIN=$1
+echo "==> Checking that build is using go version >= $1..."
+
+GO_VERSION=$(go version | grep -o 'go[0-9]\+\.[0-9]\+' | tr -d 'go')
+
+
+IFS="." read -r -a GO_VERSION_ARR <<< "$GO_VERSION"
+IFS="." read -r -a GO_VERSION_REQ <<< "$GO_VERSION_MIN"
+
+if [[ ${GO_VERSION_ARR[0]} -lt ${GO_VERSION_REQ[0]} || ( ${GO_VERSION_ARR[0]} -eq ${GO_VERSION_REQ[0]} && ${GO_VERSION_ARR[1]} -lt ${GO_VERSION_REQ[1]} ) ]]; then
+    echo "Vault requires go $GO_VERSION_MIN to build; found $GO_VERSION."
+    exit 1
+fi


### PR DESCRIPTION
Several GH issues have been opened by people trying to use an older
version of Go to build Vault (e.g., #3307 is the most recent). This adds
an explicit check to the build to hopefully make it more clear to users
in the future.