### PR TITLE
Update AWS CloudHSM comparison.

### DIFF
--- a/website/source/intro/vs/hsm.html.md
+++ b/website/source/intro/vs/hsm.html.md
@@ -14,8 +14,8 @@ device that is meant to secure various secrets using protections against access
 and tampering at both the software and hardware layers.
 
 The primary issue with HSMs is that they are expensive and not very cloud
-friendly. Amazon provides CloudHSM, but the minimum price point to even begin
-using CloudHSM is in the thousands of US dollars.
+friendly. Amazon released an update to its CloudHSM product recently that
+lowers the price of an HSM somewhat, but running one is still not cheap.
 
 Once an HSM is up and running, configuring it is generally very tedious, and
 the API to request secrets is also difficult to use. Example: CloudHSM requires

--- a/website/source/intro/vs/hsm.html.md
+++ b/website/source/intro/vs/hsm.html.md
@@ -15,7 +15,8 @@ and tampering at both the software and hardware layers.
 
 The primary issue with HSMs is that they are expensive and not very cloud
 friendly. An exception to the latter is Amazon's CloudHSM service, which is
-friendly for AWS users but still costs more than $14k per year per instance.
+friendly for AWS users but still costs more than $14k per year per instance,
+and not as useful for heterogenous cloud architectures.
 
 Once an HSM is up and running, configuring it is generally very tedious, and
 the API to request secrets is also difficult to use. Example: CloudHSM requires

--- a/website/source/intro/vs/hsm.html.md
+++ b/website/source/intro/vs/hsm.html.md
@@ -14,8 +14,8 @@ device that is meant to secure various secrets using protections against access
 and tampering at both the software and hardware layers.
 
 The primary issue with HSMs is that they are expensive and not very cloud
-friendly. Amazon released an update to its CloudHSM product recently that
-lowers the price of an HSM somewhat, but running one is still not cheap.
+friendly. An exception to the latter is Amazon's CloudHSM service, which is
+friendly for AWS users but still costs more than $14k per year per instance.
 
 Once an HSM is up and running, configuring it is generally very tedious, and
 the API to request secrets is also difficult to use. Example: CloudHSM requires


### PR DESCRIPTION
Very minor fix to comparison docs, to reflect AWS's update to CloudHSM.