### PR TITLE
Adding support for base_url for Okta api

### DIFF
--- a/builtin/credential/okta/path_config.go
+++ b/builtin/credential/okta/path_config.go
@@ -164,7 +164,7 @@ func (b *backend) pathConfigWrite(
 		cfg.BaseURL = baseURL
 	}
 
-	// We only care about the production flag when baseURL is not set. It is
+	// We only care about the production flag when base_url is not set. It is
 	// for compatibility reasons.
 	if cfg.BaseURL == "" {
 		productionRaw, ok := d.GetOk("production")
@@ -172,6 +172,9 @@ func (b *backend) pathConfigWrite(
 			production := productionRaw.(bool)
 			cfg.Production = &production
 		}
+	} else {
+		// clear out old production flag if base_url is set
+		cfg.Production = nil
 	}
 
 	ttl, ok := d.GetOk("ttl")

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -439,10 +439,10 @@
 			"revisionTime": "2017-07-11T19:02:43Z"
 		},
 		{
-			"checksumSHA1": "QZtBo/fc3zeQFxPFgPVMyDiw70M=",
+			"checksumSHA1": "sFjc2R+KS9AeXIPMV4KCw+GwX5I=",
 			"path": "github.com/chrismalek/oktasdk-go/okta",
-			"revision": "7d4ce0a254ec5f9eda3397523f6cf183e1d46c5e",
-			"revisionTime": "2017-02-07T05:01:14Z"
+			"revision": "ae553c909ca06a4c34eb41ee435e83871a7c2496",
+			"revisionTime": "2017-09-11T15:31:29Z"
 		},
 		{
 			"checksumSHA1": "WsB6y1Yd+kDbHGz1Rm7xZ44hyAE=",

--- a/website/source/api/auth/okta/index.html.md
+++ b/website/source/api/auth/okta/index.html.md
@@ -29,7 +29,9 @@ distinction between the `create` and `update` capabilities inside ACL policies.
 
 - `org_name` `(string: <required>)` - Name of the organization to be used in the
   Okta API.
-- `api_token` `(string: <required>)` - Okta API key.
+- `api_token` `(string: "")` - Okta API token. This is required to query Okta 
+  for user group membership. If this is not supplied only locally configured 
+  groups will be enabled. 
 - `base_url` `(string: "okta.com")` -  If set, will be used as the base domain
   for API requests.  Examples are okta.com, oktapreview.com, and okta-emea.com.
 - `ttl` `(string: "")` - Duration after which authentication will be expired.

--- a/website/source/api/auth/okta/index.html.md
+++ b/website/source/api/auth/okta/index.html.md
@@ -32,7 +32,7 @@ distinction between the `create` and `update` capabilities inside ACL policies.
 - `api_token` `(string: "")` - Okta API token. This is required to query Okta 
   for user group membership. If this is not supplied only locally configured 
   groups will be enabled. 
-- `base_url` `(string: "okta.com")` -  If set, will be used as the base domain
+- `base_url` `(string: "")` -  If set, will be used as the base domain
   for API requests.  Examples are okta.com, oktapreview.com, and okta-emea.com.
 - `ttl` `(string: "")` - Duration after which authentication will be expired.
 - `max_ttl` `(string: "")` - Maximum duration after which authentication will 

--- a/website/source/api/auth/okta/index.html.md
+++ b/website/source/api/auth/okta/index.html.md
@@ -30,9 +30,8 @@ distinction between the `create` and `update` capabilities inside ACL policies.
 - `org_name` `(string: <required>)` - Name of the organization to be used in the
   Okta API.
 - `api_token` `(string: <required>)` - Okta API key.
-- `production` `(bool: true)` -  If set, production API URL prefix will be used 
-  to communicate with Okta and if not set, a preview production API URL prefix 
-  will be used. Defaults to true.
+- `base_url` `(string: "okta.com")` -  If set, will be used as the base domain
+  for API requests.  Examples are okta.com, oktapreview.com, and okta-emea.com.
 - `ttl` `(string: "")` - Duration after which authentication will be expired.
 - `max_ttl` `(string: "")` - Maximum duration after which authentication will 
   be expired.
@@ -83,7 +82,7 @@ $ curl \
   "data": {
     "org_name": "example",
     "api_token": "abc123",
-    "production": true,
+    "base_url": "okta.com",
     "ttl": "",
     "max_ttl": ""
   },

--- a/website/source/api/system/mfa-duo.html.md
+++ b/website/source/api/system/mfa-duo.html.md
@@ -22,6 +22,9 @@ This endpoint defines a MFA method of type Duo.
 
 - `username_format` `(string)` - A format string for mapping Identity names to MFA method names. Values to substitute should be placed in `{{}}`. For example, `"{{persona.name}}@example.com"`. If blank, the Persona's Name field will be used as-is. Currently-supported mappings:
   - persona.name: The name returned by the mount configured via the `mount_accessor` parameter
+  - entity.name: The name configured for the Entity
+  - persona.metadata.`<key>`: The value of the Persona's metadata parameter
+  - entity.metadata.`<key>`: The value of the Entity's metadata paramater
 
 - `secret_key` `(string)` - Secret key for Duo.
 

--- a/website/source/api/system/mfa-okta.html.md
+++ b/website/source/api/system/mfa-okta.html.md
@@ -22,6 +22,9 @@ This endpoint defines a MFA method of type Okta.
 
 - `username_format` `(string)` - A format string for mapping Identity names to MFA method names. Values to substitute should be placed in `{{}}`. For example, `"{{persona.name}}@example.com"`. If blank, the Persona's Name field will be used as-is. Currently-supported mappings:
   - persona.name: The name returned by the mount configured via the `mount_accessor` parameter
+  - entity.name: The name configured for the Entity
+  - persona.metadata.`<key>`: The value of the Persona's metadata parameter
+  - entity.metadata.`<key>`: The value of the Entity's metadata paramater
 
 - `org_name` `(string)` - Name of the organization to be used in the Okta API.
 

--- a/website/source/api/system/mfa-okta.html.md
+++ b/website/source/api/system/mfa-okta.html.md
@@ -27,7 +27,7 @@ This endpoint defines a MFA method of type Okta.
 
 - `api_token` `(string)` - Okta API key.
 
-- `production` `(string)` - If set, production API URL prefix will be used to communicate with Okta and if not set, a preview production API URL prefix will be used. Defaults to true.
+- `base_url` `(string)` -  If set, will be used as the base domain for API requests.  Examples are okta.com, oktapreview.com, and okta-emea.com.
 
 ### Sample Payload
 

--- a/website/source/api/system/mfa-pingid.html.md
+++ b/website/source/api/system/mfa-pingid.html.md
@@ -22,6 +22,9 @@ This endpoint defines a MFA method of type PingID.
 
 - `username_format` `(string)` - A format string for mapping Identity names to MFA method names. Values to substitute should be placed in `{{}}`. For example, `"{{persona.name}}@example.com"`. If blank, the Persona's Name field will be used as-is. Currently-supported mappings:
   - persona.name: The name returned by the mount configured via the `mount_accessor` parameter
+  - entity.name: The name configured for the Entity
+  - persona.metadata.`<key>`: The value of the Persona's metadata parameter
+  - entity.metadata.`<key>`: The value of the Entity's metadata paramater
 
 - `settings_file_base64` `(string)` - A base64-encoded third-party settings file retrieved from PingID's configuration page.
 

--- a/website/source/docs/auth/okta.html.md
+++ b/website/source/docs/auth/okta.html.md
@@ -87,8 +87,8 @@ Configuration is written to `auth/okta/config`.
 
 ### Connection parameters
 
-* `organization` (string, required) - The Okta organization.  This will be the first part of the url `https://XXX.okta.com` url.
-* `token` (string, optional) - The Okta API token.  This is required to query Okta for user group membership. If this is not supplied only locally configured groups will be enabled. This can be generated from http://developer.okta.com/docs/api/getting_started/getting_a_token.html
+* `org_name` (string, required) - The Okta organization.  This will be the first part of the url `https://XXX.okta.com` url.
+* `api_token` (string, optional) - The Okta API token.  This is required to query Okta for user group membership. If this is not supplied only locally configured groups will be enabled. This can be generated from http://developer.okta.com/docs/api/getting_started/getting_a_token.html
 * `base_url` (string, optional) - The Okta url. Examples: `oktapreview.com`, The default is `okta.com`
 * `max_ttl` (string, optional) - Maximum duration after which authentication will be expired.
  Either number of seconds or in a format parsable by Go's [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration)
@@ -106,7 +106,7 @@ Use `vault path-help` for more details.
 
 ```
 $ vault write auth/okta/config \
-    organization="XXXTest"
+    org_name="XXXTest"
 ...
 ```
 
@@ -118,8 +118,8 @@ $ vault write auth/okta/config \
 
 ```
 $ vault write auth/okta/config base_url="oktapreview.com" \
-    organization="dev-123456" \
-    token="00KzlTNCqDf0enpQKYSAYUt88KHqXax6dT11xEZz_g" 
+    org_name="dev-123456" \
+    api_token="00KzlTNCqDf0enpQKYSAYUt88KHqXax6dT11xEZz_g" 
 ...
 ```
 


### PR DESCRIPTION
This adds back support for providing the base_url for Okta API requests.  This will allow the backend to support domains such as okta-emea.com.

Fixes #3313 