### PR TITLE
Fix a few quirks in the GCP auth backend's docs.

### DIFF
--- a/website/source/api/auth/gcp/index.html.md
+++ b/website/source/api/auth/gcp/index.html.md
@@ -146,7 +146,7 @@ entities attempting to login.
 
 - `service_accounts` `(array: [])` - Required for `iam` roles.
   A comma-separated list of service account emails or ids.
-  Defines the service accounts that login is restricted to. If set to `\*`, all
+  Defines the service accounts that login is restricted to. If set to `*`, all
   service accounts are allowed (role will still be bound by project).
 
 ### Sample Payload

--- a/website/source/docs/auth/gcp.html.md
+++ b/website/source/docs/auth/gcp.html.md
@@ -75,7 +75,7 @@ curl -H "Authorization: Bearer $OAUTH_TOKEN" \
 
 **Golang Example**
 
-We use the Go OAuth2 libraries, GCP IAM API, and Vault API.
+We use the Go OAuth2 libraries, GCP IAM API, and Vault API. The example generates a token valid for the `dev-role` role (as indicated by the `aud` field of `jwtPayload`).
 
 ```go
 // Abbreviated imports to show libraries.
@@ -117,7 +117,7 @@ func main() {
 	// 1. Generate signed JWT using IAM.
 	resourceName := fmt.Sprintf("projects/%s/serviceAccounts/%s", project, serviceAccount)
 	jwtPayload := map[string]interface{}{
-		"aud": "auth/gcp/login",
+		"aud": "vault/dev-role",
 		"sub": serviceAccount,
 		"exp": time.Now().Add(time.Minute * 10).Unix(),
 	}


### PR DESCRIPTION
This should have been included in #3317 but I somehow forgot them—sorry for that.

* I could only get the desired result with `*`, so I believe the backward slash is a typo.
* The plugin requires `vault/<role-name>` as the value of the `aud` field in the JWT payload, but `auth/gcp/login` was being specified.