### PR TITLE
Disable the `sys/raw` endpoint by default

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -260,6 +260,7 @@ func (c *ServerCommand) Run(args []string) int {
 		ClusterName:        config.ClusterName,
 		CacheSize:          config.CacheSize,
 		PluginDirectory:    config.PluginDirectory,
+		EnableRaw:          config.EnableRawEndpoint,
 	}
 	if dev {
 		coreConfig.DevToken = devRootTokenID

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -46,13 +46,17 @@ type Config struct {
 	ClusterCipherSuites string `hcl:"cluster_cipher_suites"`
 
 	PluginDirectory string `hcl:"plugin_directory"`
+
+	EnableRawEndpoint    bool        `hcl:"-"`
+	EnableRawEndpointRaw interface{} `hcl:"raw"`
 }
 
 // DevConfig is a Config that is used for dev mode of Vault.
 func DevConfig(ha, transactional bool) *Config {
 	ret := &Config{
-		DisableCache: false,
-		DisableMlock: true,
+		DisableCache:      false,
+		DisableMlock:      true,
+		EnableRawEndpoint: true,
 
 		Storage: &Storage{
 			Type: "inmem",
@@ -288,6 +292,11 @@ func (c *Config) Merge(c2 *Config) *Config {
 		result.EnableUI = c2.EnableUI
 	}
 
+	result.EnableRawEndpoint = c.EnableRawEndpoint
+	if c2.EnableRawEndpoint {
+		result.EnableRawEndpoint = c2.EnableRawEndpoint
+	}
+
 	result.PluginDirectory = c.PluginDirectory
 	if c2.PluginDirectory != "" {
 		result.PluginDirectory = c2.PluginDirectory
@@ -306,9 +315,8 @@ func LoadConfig(path string, logger log.Logger) (*Config, error) {
 
 	if fi.IsDir() {
 		return LoadConfigDir(path, logger)
-	} else {
-		return LoadConfigFile(path, logger)
 	}
+	return LoadConfigFile(path, logger)
 }
 
 // LoadConfigFile loads the configuration from the given file.
@@ -363,6 +371,12 @@ func ParseConfig(d string, logger log.Logger) (*Config, error) {
 		}
 	}
 
+	if result.EnableRawEndpointRaw != nil {
+		if result.EnableRawEndpoint, err = parseutil.ParseBool(result.EnableRawEndpointRaw); err != nil {
+			return nil, err
+		}
+	}
+
 	list, ok := obj.Node.(*ast.ObjectList)
 	if !ok {
 		return nil, fmt.Errorf("error parsing: file doesn't contain a root object")
@@ -385,6 +399,7 @@ func ParseConfig(d string, logger log.Logger) (*Config, error) {
 		"cluster_name",
 		"cluster_cipher_suites",
 		"plugin_directory",
+		"raw",
 	}
 	if err := checkHCLKeys(list, valid); err != nil {
 		return nil, err

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	PluginDirectory string `hcl:"plugin_directory"`
 
 	EnableRawEndpoint    bool        `hcl:"-"`
-	EnableRawEndpointRaw interface{} `hcl:"raw"`
+	EnableRawEndpointRaw interface{} `hcl:"raw_storage_endpoint"`
 }
 
 // DevConfig is a Config that is used for dev mode of Vault.
@@ -399,7 +399,7 @@ func ParseConfig(d string, logger log.Logger) (*Config, error) {
 		"cluster_name",
 		"cluster_cipher_suites",
 		"plugin_directory",
-		"raw",
+		"raw_storage_endpoint",
 	}
 	if err := checkHCLKeys(list, valid); err != nil {
 		return nil, err

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -62,6 +62,9 @@ func TestLoadConfigFile(t *testing.T) {
 		EnableUI:        true,
 		EnableUIRaw:     true,
 
+		EnableRawEndpoint:    true,
+		EnableRawEndpointRaw: true,
+
 		MaxLeaseTTL:        10 * time.Hour,
 		MaxLeaseTTLRaw:     "10h",
 		DefaultLeaseTTL:    10 * time.Hour,
@@ -129,6 +132,9 @@ func TestLoadConfigFile_json(t *testing.T) {
 		DisableMlockRaw:    interface{}(nil),
 		EnableUI:           true,
 		EnableUIRaw:        true,
+
+		EnableRawEndpoint:    true,
+		EnableRawEndpointRaw: true,
 	}
 	if !reflect.DeepEqual(config, expected) {
 		t.Fatalf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config, expected)
@@ -177,6 +183,8 @@ func TestLoadConfigFile_json2(t *testing.T) {
 		CacheSize: 45678,
 
 		EnableUI: true,
+
+		EnableRawEndpoint: true,
 
 		Telemetry: &Telemetry{
 			StatsiteAddr:                       "foo",
@@ -231,6 +239,8 @@ func TestLoadConfigDir(t *testing.T) {
 		},
 
 		EnableUI: true,
+
+		EnableRawEndpoint: true,
 
 		Telemetry: &Telemetry{
 			StatsiteAddr:    "qux",

--- a/command/server/test-fixtures/config-dir/baz.hcl
+++ b/command/server/test-fixtures/config-dir/baz.hcl
@@ -4,6 +4,6 @@ telemetry {
     disable_hostname = true
 }
 ui=true
-raw=true
+raw_storage_endpoint=true
 default_lease_ttl = "10h"
 cluster_name = "testcluster"

--- a/command/server/test-fixtures/config-dir/baz.hcl
+++ b/command/server/test-fixtures/config-dir/baz.hcl
@@ -4,5 +4,6 @@ telemetry {
     disable_hostname = true
 }
 ui=true
+raw=true
 default_lease_ttl = "10h"
 cluster_name = "testcluster"

--- a/command/server/test-fixtures/config.hcl
+++ b/command/server/test-fixtures/config.hcl
@@ -28,4 +28,4 @@ telemetry {
 max_lease_ttl = "10h"
 default_lease_ttl = "10h"
 cluster_name = "testcluster"
-raw = true
+raw_storage_endpoint = true

--- a/command/server/test-fixtures/config.hcl
+++ b/command/server/test-fixtures/config.hcl
@@ -28,3 +28,4 @@ telemetry {
 max_lease_ttl = "10h"
 default_lease_ttl = "10h"
 cluster_name = "testcluster"
+raw = true

--- a/command/server/test-fixtures/config.hcl.json
+++ b/command/server/test-fixtures/config.hcl.json
@@ -17,5 +17,6 @@
 	"max_lease_ttl": "10h",
 	"default_lease_ttl": "10h",
 	"cluster_name":"testcluster",
-	"ui":true
+	"ui":true,
+	"raw":true
 }

--- a/command/server/test-fixtures/config.hcl.json
+++ b/command/server/test-fixtures/config.hcl.json
@@ -18,5 +18,5 @@
 	"default_lease_ttl": "10h",
 	"cluster_name":"testcluster",
 	"ui":true,
-	"raw":true
+	"raw_storage_endpoint":true
 }

--- a/command/server/test-fixtures/config2.hcl.json
+++ b/command/server/test-fixtures/config2.hcl.json
@@ -1,5 +1,6 @@
 {
   "ui":true,
+  "raw":true,
   "listener":[
     {
       "tcp":{

--- a/command/server/test-fixtures/config2.hcl.json
+++ b/command/server/test-fixtures/config2.hcl.json
@@ -1,6 +1,6 @@
 {
   "ui":true,
-  "raw":true,
+  "raw_storage_endpoint":true,
   "listener":[
     {
       "tcp":{

--- a/vault/core.go
+++ b/vault/core.go
@@ -344,6 +344,9 @@ type Core struct {
 	// uiEnabled indicates whether Vault Web UI is enabled or not
 	uiEnabled bool
 
+	// rawEnabled indicates whether the Raw endpoint is enabled
+	rawEnabled bool
+
 	// pluginDirectory is the location vault will look for plugin binaries
 	pluginDirectory string
 
@@ -401,6 +404,9 @@ type CoreConfig struct {
 	ClusterCipherSuites string `json:"cluster_cipher_suites" structs:"cluster_cipher_suites" mapstructure:"cluster_cipher_suites"`
 
 	EnableUI bool `json:"ui" structs:"ui" mapstructure:"ui"`
+
+	// Enable the raw endpoint
+	EnableRaw bool `json:"enable_raw" structs:"enable_raw" mapstructure:"enable_raw"`
 
 	PluginDirectory string `json:"plugin_directory" structs:"plugin_directory" mapstructure:"plugin_directory"`
 
@@ -462,6 +468,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		clusterListenerShutdownSuccessCh: make(chan struct{}),
 		clusterPeerClusterAddrsCache:     cache.New(3*heartbeatInterval, time.Second),
 		enableMlock:                      !conf.DisableMlock,
+		rawEnabled:                       conf.EnableRaw,
 	}
 
 	if conf.ClusterCipherSuites != "" {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -59,6 +59,7 @@ func NewSystemBackend(core *Core) *SystemBackend {
 				"remount",
 				"audit",
 				"audit/*",
+				"raw",
 				"raw/*",
 				"replication/primary/secondary-token",
 				"replication/reindex",

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -27,6 +27,7 @@ func TestSystemBackend_RootPaths(t *testing.T) {
 		"remount",
 		"audit",
 		"audit/*",
+		"raw",
 		"raw/*",
 		"replication/primary/secondary-token",
 		"replication/reindex",

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -1447,7 +1447,7 @@ func TestSystemBackend_disableAudit(t *testing.T) {
 }
 
 func TestSystemBackend_rawRead_Protected(t *testing.T) {
-	b := testSystemBackend(t)
+	b := testSystemBackendRaw(t)
 
 	req := logical.TestRequest(t, logical.ReadOperation, "raw/"+keyringPath)
 	_, err := b.HandleRequest(req)
@@ -1457,7 +1457,7 @@ func TestSystemBackend_rawRead_Protected(t *testing.T) {
 }
 
 func TestSystemBackend_rawWrite_Protected(t *testing.T) {
-	b := testSystemBackend(t)
+	b := testSystemBackendRaw(t)
 
 	req := logical.TestRequest(t, logical.UpdateOperation, "raw/"+keyringPath)
 	_, err := b.HandleRequest(req)
@@ -1467,7 +1467,7 @@ func TestSystemBackend_rawWrite_Protected(t *testing.T) {
 }
 
 func TestSystemBackend_rawReadWrite(t *testing.T) {
-	c, b, _ := testCoreSystemBackend(t)
+	c, b, _ := testCoreSystemBackendRaw(t)
 
 	req := logical.TestRequest(t, logical.UpdateOperation, "raw/sys/policy/test")
 	req.Data["value"] = `path "secret/" { policy = "read" }`
@@ -1503,7 +1503,7 @@ func TestSystemBackend_rawReadWrite(t *testing.T) {
 }
 
 func TestSystemBackend_rawDelete_Protected(t *testing.T) {
-	b := testSystemBackend(t)
+	b := testSystemBackendRaw(t)
 
 	req := logical.TestRequest(t, logical.DeleteOperation, "raw/"+keyringPath)
 	_, err := b.HandleRequest(req)
@@ -1513,7 +1513,7 @@ func TestSystemBackend_rawDelete_Protected(t *testing.T) {
 }
 
 func TestSystemBackend_rawDelete(t *testing.T) {
-	c, b, _ := testCoreSystemBackend(t)
+	c, b, _ := testCoreSystemBackendRaw(t)
 
 	// set the policy!
 	p := &Policy{Name: "test"}
@@ -1589,6 +1589,25 @@ func TestSystemBackend_rotate(t *testing.T) {
 
 func testSystemBackend(t *testing.T) logical.Backend {
 	c, _, _ := TestCoreUnsealed(t)
+	return testSystemBackendInternal(t, c)
+}
+
+func testSystemBackendRaw(t *testing.T) logical.Backend {
+	c, _, _ := TestCoreUnsealedRaw(t)
+	return testSystemBackendInternal(t, c)
+}
+
+func testCoreSystemBackend(t *testing.T) (*Core, logical.Backend, string) {
+	c, _, root := TestCoreUnsealed(t)
+	return c, testSystemBackendInternal(t, c), root
+}
+
+func testCoreSystemBackendRaw(t *testing.T) (*Core, logical.Backend, string) {
+	c, _, root := TestCoreUnsealedRaw(t)
+	return c, testSystemBackendInternal(t, c), root
+}
+
+func testSystemBackendInternal(t *testing.T, c *Core) logical.Backend {
 	bc := &logical.BackendConfig{
 		Logger: c.logger,
 		System: logical.StaticSystemView{
@@ -1604,24 +1623,6 @@ func testSystemBackend(t *testing.T) logical.Backend {
 	}
 
 	return b
-}
-
-func testCoreSystemBackend(t *testing.T) (*Core, logical.Backend, string) {
-	c, _, root := TestCoreUnsealed(t)
-	bc := &logical.BackendConfig{
-		Logger: c.logger,
-		System: logical.StaticSystemView{
-			DefaultLeaseTTLVal: time.Hour * 24,
-			MaxLeaseTTLVal:     time.Hour * 24 * 32,
-		},
-	}
-
-	b := NewSystemBackend(c)
-	err := b.Backend.Setup(bc)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return c, b, root
 }
 
 func TestSystemBackend_PluginCatalog_CRUD(t *testing.T) {

--- a/vault/seal_testing.go
+++ b/vault/seal_testing.go
@@ -107,7 +107,7 @@ func (d *TestSeal) SetRecoveryKey(key []byte) error {
 
 func testCoreUnsealedWithConfigs(t *testing.T, barrierConf, recoveryConf *SealConfig) (*Core, [][]byte, [][]byte, string) {
 	seal := &TestSeal{}
-	core := TestCoreWithSeal(t, seal)
+	core := TestCoreWithSeal(t, seal, false)
 	result, err := core.Initialize(&InitParams{
 		BarrierConfig:  barrierConf,
 		RecoveryConfig: recoveryConf,

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -85,18 +85,24 @@ oOyBJU/HMVvBfv4g+OVFLVgSwwm6owwsouZ0+D/LasbuHqYyqYqdyPJQYzWA2Y+F
 
 // TestCore returns a pure in-memory, uninitialized core for testing.
 func TestCore(t testing.T) *Core {
-	return TestCoreWithSeal(t, nil)
+	return TestCoreWithSeal(t, nil, false)
+}
+
+// TestCoreRaw returns a pure in-memory, uninitialized core for testing. The raw
+// storage endpoints are enabled with this core.
+func TestCoreRaw(t testing.T) *Core {
+	return TestCoreWithSeal(t, nil, true)
 }
 
 // TestCoreNewSeal returns a pure in-memory, uninitialized core with
 // the new seal configuration.
 func TestCoreNewSeal(t testing.T) *Core {
-	return TestCoreWithSeal(t, &TestSeal{})
+	return TestCoreWithSeal(t, &TestSeal{}, false)
 }
 
 // TestCoreWithSeal returns a pure in-memory, uninitialized core with the
 // specified seal for testing.
-func TestCoreWithSeal(t testing.T, testSeal Seal) *Core {
+func TestCoreWithSeal(t testing.T, testSeal Seal, enableRaw bool) *Core {
 	logger := logformat.NewVaultLogger(log.LevelTrace)
 	physicalBackend, err := physInmem.NewInmem(nil, logger)
 	if err != nil {
@@ -104,6 +110,10 @@ func TestCoreWithSeal(t testing.T, testSeal Seal) *Core {
 	}
 
 	conf := testCoreConfig(t, physicalBackend, logger)
+
+	if enableRaw {
+		conf.EnableRaw = true
+	}
 
 	if testSeal != nil {
 		conf.Seal = testSeal
@@ -198,6 +208,17 @@ func TestCoreUnseal(core *Core, key []byte) (bool, error) {
 // initialized and unsealed.
 func TestCoreUnsealed(t testing.T) (*Core, [][]byte, string) {
 	core := TestCore(t)
+	return testCoreUnsealed(t, core)
+}
+
+// TestCoreUnsealedRaw returns a pure in-memory core that is already
+// initialized, unsealed, and with raw endpoints enabled.
+func TestCoreUnsealedRaw(t testing.T) (*Core, [][]byte, string) {
+	core := TestCoreRaw(t)
+	return testCoreUnsealed(t, core)
+}
+
+func testCoreUnsealed(t testing.T, core *Core) (*Core, [][]byte, string) {
 	keys, token := TestCoreInit(t, core)
 	for _, key := range keys {
 		if _, err := TestCoreUnseal(core, TestKeyCopy(key)); err != nil {

--- a/website/source/api/system/raw.html.md
+++ b/website/source/api/system/raw.html.md
@@ -10,6 +10,10 @@ description: |-
 
 The `/sys/raw` endpoint is access the raw underlying store in Vault.
 
+This endpont is off by default.  See the 
+[Vault configuration documentation](/docs/configuration/index.html) to
+enable.
+
 ## Read Raw
 
 This endpoint reads the value of the key at the given path. This is the raw path

--- a/website/source/api/system/raw.html.md
+++ b/website/source/api/system/raw.html.md
@@ -80,6 +80,41 @@ $ curl \
     https://vault.rocks/v1/sys/raw/secret/foo
 ```
 
+## List Raw
+
+This endpoint returns a list keys for a given path prefix.
+
+**This endpoint requires 'sudo' capability.**
+
+| Method   | Path                         | Produces               |
+| :------- | :--------------------------- | :--------------------- |
+| `LIST`   | `/sys/raw/:prefix` | `200 application/json` |
+| `GET`   | `/sys/raw/:prefix?list=true` | `200 application/json` |
+
+
+### Sample Request
+
+```
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request LIST \
+    https://vault.rocks/v1/sys/raw/logical
+```
+
+### Sample Response
+
+```json
+{
+  "data":{
+    "keys":[
+      "abcd-1234...",
+      "efgh-1234...",
+      "ijkl-1234..."
+    ]
+  }
+}
+```
+
 ## Delete Raw
 
 This endpoint deletes the key with given path. This is the raw path in the

--- a/website/source/docs/configuration/index.html.md
+++ b/website/source/docs/configuration/index.html.md
@@ -100,9 +100,9 @@ to specify where the configuration is.
   duration for tokens and secrets. This is specified using a label
   suffix like `"30s"` or `"1h"`.
 
-- `raw` `(bool: false)` – Enables the `sys/raw` endpoint which allows the
-  decryption/encryption of raw data into and out of the security barrier. This 
-  is a highly priveleged endpoint. 
+- `raw_storage_endpoint` `(bool: false)` – Enables the `sys/raw` endpoint which 
+  allows the decryption/encryption of raw data into and out of the security 
+  barrier. This is a highly priveleged endpoint. 
 
 - `ui` `(bool: false, Enterprise-only)` – Enables the built-in web UI, which is
   available on all listeners (address + port) at the `/ui` path. Browsers accessing

--- a/website/source/docs/configuration/index.html.md
+++ b/website/source/docs/configuration/index.html.md
@@ -100,6 +100,10 @@ to specify where the configuration is.
   duration for tokens and secrets. This is specified using a label
   suffix like `"30s"` or `"1h"`.
 
+- `raw` `(bool: false)` – Enables the `sys/raw` endpoint which allows the
+  decryption/encryption of raw data into and out of the security barrier. This 
+  is a highly priveleged endpoint. 
+
 - `ui` `(bool: false, Enterprise-only)` – Enables the built-in web UI, which is
   available on all listeners (address + port) at the `/ui` path. Browsers accessing
   the standard Vault API address will automatically redirect there. This can also


### PR DESCRIPTION
Considering the highly sensitive nature of this endpoint and the infrequent usage, disable this endpoint by default and add a config option to enable it.