### PR TITLE
Fixed docs to reflect correct HTTP method for /sys/config/auditing en…

### DIFF
--- a/website/source/api/system/config-auditing.html.md
+++ b/website/source/api/system/config-auditing.html.md
@@ -50,7 +50,7 @@ This endpoint lists the information for the given request header.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `POST`   | `/sys/config/auditing/request-headers/:name` | `200 application/json` |
+| `GET`    | `/sys/config/auditing/request-headers/:name` | `200 application/json` |
 
 ### Parameters
 


### PR DESCRIPTION
Updated documentation to reflect "Read Single Audit Request Header" endpoint is GET-based.