### PR TITLE
Correction: DR Replication API documentation

### DIFF
--- a/website/source/api/system/replication-dr.html.md
+++ b/website/source/api/system/replication-dr.html.md
@@ -142,7 +142,7 @@ identifier can later be used to revoke a DR secondary's access.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `GET`    | `/sys/replication/dr/primary/secondary-token` | `200 application/json` |
+| `POST`    | `/sys/replication/dr/primary/secondary-token` | `200 application/json` |
 
 ### Parameters
 


### PR DESCRIPTION
Updated https://www.vaultproject.io/api/system/replication-dr.html#generate-dr-secondary-token to be a POST rather than GET. I confirmed that this should be a logical.UpdateOperation rather than ReadOperation (https://github.com/hashicorp/vault-enterprise/blob/24f2b961fdb300e7cfcaaa94e708509513bb54f3/vault/replication_api.go#L121).