### PR TITLE
Clarify backup data that is being stored

### DIFF
--- a/website/source/api/system/rekey.html.md
+++ b/website/source/api/system/rekey.html.md
@@ -74,9 +74,9 @@ and starting a new rekey, which will also provide a new nonce.
   array must be the same as `secret_shares`.
 
 - `backup` `(bool: false)` – Specifies if using PGP-encrypted keys, whether
-  Vault should also back them up to `core/unseal-keys-backup` in the physical
-  storage backend. These can then be retrieved and removed via the
-  `sys/rekey/backup` endpoint.
+  Vault should also store a plaintext backup of the PGP-encrypted keys at
+  `core/unseal-keys-backup` in the physical storage backend. These can then
+  be retrieved and removed via the `sys/rekey/backup` endpoint.
 
 ### Sample Payload
 


### PR DESCRIPTION
> Specifies if using PGP-encrypted keys, whether Vault should also back them up ...

The wording sounded like "them" referred to the public PGP keys, and not the plaintext PGP-encrypted keys, so this rewording clarifies the description and puts it closer to the description on the help command.