### PR TITLE
Remove Trailing White space in Kubernetes Doc

### DIFF
--- a/website/source/docs/auth/kubernetes.html.md
+++ b/website/source/docs/auth/kubernetes.html.md
@@ -111,7 +111,7 @@ login it first must be configured in a role.
 
 ```
 vault write auth/kubernetes/role/demo \
-    bound_service_account_names=vault-auth \ 
+    bound_service_account_names=vault-auth \
     bound_service_account_namespaces=default \
     policies=default \
     ttl=1h


### PR DESCRIPTION
Removed a trailing white space from which caused `Error loading data: Invalid key/value pair ' ': format must be key=value` if copying the example

```
vault write auth/kubernetes/role/demo \
    bound_service_account_names=vault-auth \
    bound_service_account_namespaces=default \
    policies=default \
    ttl=1h
```