### PR TITLE
fix spellings errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ IMPROVEMENTS:
  * auth/aws: Allow wildcards in `bound_iam_principal_id` [GH-3213]
  * auth/okta: Compare groups case-insensitively since Okta is only
    case-preserving [GH-3240]
- * auth/okta: Standarize Okta configuration APIs across backends [GH-3245]
+ * auth/okta: Standardize Okta configuration APIs across backends [GH-3245]
  * cli: Add subcommand autocompletion that can be enabled with 
    `vault -autocomplete-install` [GH-3223]
  * cli: Add ability to handle wrapped responses when using `vault auth`. What

--- a/vendor/github.com/hashicorp/vault-plugin-auth-kubernetes/README.md
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-kubernetes/README.md
@@ -7,7 +7,7 @@ This plugin allows for Kubernets Service Accounts to authenticate with Vault.
 
 ## Quick Links
     - Vault Website: https://www.vaultproject.io
-    - Kunernetes Auth Docs: https://www.vaultproject.io/docs/auth/kubernetes.html
+    - Kubernetes Auth Docs: https://www.vaultproject.io/docs/auth/kubernetes.html
     - Main Project Github: https://www.github.com/hashicorp/vault
 
 

--- a/website/source/docs/auth/kubernetes.html.md
+++ b/website/source/docs/auth/kubernetes.html.md
@@ -4,7 +4,7 @@ page_title: "Auth Plugin Backend: Kubernetes"
 sidebar_current: "docs-auth-kubernetes"
 description: |-
   The Kubernetes auth backend allows automated authentication of Kubernetes
-  Service Accouts.
+  Service Accounts.
 ---
 
 # Auth Backend: Kubernetes


### PR DESCRIPTION
Noticed a typo for _Service Accounts_ while unfurling `https://www.vaultproject.io/docs/auth/kubernetes.html`. Hopefully this is a first... 🤞