### PR TITLE
Append trailing slash to folder listing in etcd3 backend

### DIFF
--- a/physical/etcd/etcd3.go
+++ b/physical/etcd/etcd3.go
@@ -200,7 +200,7 @@ func (c *EtcdBackend) List(prefix string) ([]string, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), etcd3RequestTimeout)
 	defer cancel()
-	prefix = path.Join(c.path, prefix)
+	prefix = path.Join(c.path, prefix) + "/"
 	resp, err := c.etcd.Get(ctx, prefix, clientv3.WithPrefix())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes an issue with etcd3 where listing keys in Vault can result in things that aren't children of the requested path being returned as if they were.

If you have a key `secret/foo/bar`, and a key `secret/foobar/baz`, and ask for a list of `secret/foo`, etcd3's non-hierarchical setup will return *secret/foo*/bar -> `bar`, and *secret/foo*bar/baz -> `bar/`. Appending a slash causes `secret/foobar/baz` to no longer match, so the expected results are returned.

To show the issue;
```
vault write secret/foo/bar value=123
vault write secret/foobar/baz value=123

vault list secret/foo
vault list secret/fo
```

With etcd2:
```
$ vault list secret/foo
Keys
----
bar
$ vault list secret/fo
No value found at secret/fo/
```

With etcd3, before this PR:
```
$ vault list secret/foo
Keys
----
bar
bar/
$ vault list secret/fo
Keys
----
o/
obar/
```

With etcd3, after this PR:
```
$ vault list secret/foo
Keys
----
bar
$ vault list secret/fo/
No value found at secret/fo/
```