### PR TITLE
added AWS enpoint handling

### DIFF
--- a/builtin/logical/aws/client.go
+++ b/builtin/logical/aws/client.go
@@ -29,6 +29,7 @@ func getRootConfig(s logical.Storage) (*aws.Config, error) {
 		credsConfig.AccessKey = config.AccessKey
 		credsConfig.SecretKey = config.SecretKey
 		credsConfig.Region = config.Region
+		credsConfig.Endpoint = config.Endpoint
 	}
 
 	if credsConfig.Region == "" {
@@ -51,6 +52,7 @@ func getRootConfig(s logical.Storage) (*aws.Config, error) {
 	return &aws.Config{
 		Credentials: creds,
 		Region:      aws.String(credsConfig.Region),
+		Endpoint:    aws.String(credsConfig.Endpoint),
 		HTTPClient:  cleanhttp.DefaultClient(),
 	}, nil
 }
@@ -60,7 +62,13 @@ func clientIAM(s logical.Storage) (*iam.IAM, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	client := iam.New(session.New(awsConfig))
+
+	if *awsConfig.Endpoint != "none" {
+		client = iam.New(session.New(awsConfig.WithEndpoint(*awsConfig.Endpoint)))
+	}
+
 	if client == nil {
 		return nil, fmt.Errorf("could not obtain iam client")
 	}
@@ -73,6 +81,9 @@ func clientSTS(s logical.Storage) (*sts.STS, error) {
 		return nil, err
 	}
 	client := sts.New(session.New(awsConfig))
+	if *awsConfig.Endpoint != "none" {
+		client = sts.New(session.New(awsConfig.WithEndpoint(*awsConfig.Endpoint)))
+	}
 	if client == nil {
 		return nil, fmt.Errorf("could not obtain sts client")
 	}

--- a/builtin/logical/aws/client.go
+++ b/builtin/logical/aws/client.go
@@ -29,7 +29,8 @@ func getRootConfig(s logical.Storage) (*aws.Config, error) {
 		credsConfig.AccessKey = config.AccessKey
 		credsConfig.SecretKey = config.SecretKey
 		credsConfig.Region = config.Region
-		credsConfig.Endpoint = config.Endpoint
+		credsConfig.IAMEndpoint = config.IAMEndpoint
+		credsConfig.STSEndpoint = config.STSEndpoint
 	}
 
 	if credsConfig.Region == "" {
@@ -52,7 +53,8 @@ func getRootConfig(s logical.Storage) (*aws.Config, error) {
 	return &aws.Config{
 		Credentials: creds,
 		Region:      aws.String(credsConfig.Region),
-		Endpoint:    aws.String(credsConfig.Endpoint),
+		IAMEndpoint: aws.String(credsConfig.IAMEndpoint),
+		STSEndpoint: aws.String(credsConfig.STSEndpoint),
 		HTTPClient:  cleanhttp.DefaultClient(),
 	}, nil
 }
@@ -65,8 +67,8 @@ func clientIAM(s logical.Storage) (*iam.IAM, error) {
 
 	client := iam.New(session.New(awsConfig))
 
-	if *awsConfig.Endpoint != "none" {
-		client = iam.New(session.New(awsConfig.WithEndpoint(*awsConfig.Endpoint)))
+	if *awsConfig.IAMEndpoint != "" {
+		client = iam.New(session.New(awsConfig.WithEndpoint(*awsConfig.IAMEndpoint)))
 	}
 
 	if client == nil {
@@ -81,8 +83,8 @@ func clientSTS(s logical.Storage) (*sts.STS, error) {
 		return nil, err
 	}
 	client := sts.New(session.New(awsConfig))
-	if *awsConfig.Endpoint != "none" {
-		client = sts.New(session.New(awsConfig.WithEndpoint(*awsConfig.Endpoint)))
+	if *awsConfig.STSEndpoint != "" {
+		client = sts.New(session.New(awsConfig.WithEndpoint(*awsConfig.STSEndpoint)))
 	}
 	if client == nil {
 		return nil, fmt.Errorf("could not obtain sts client")

--- a/builtin/logical/aws/client.go
+++ b/builtin/logical/aws/client.go
@@ -13,8 +13,9 @@ import (
 	"github.com/hashicorp/vault/logical"
 )
 
-func getRootConfig(s logical.Storage) (*aws.Config, error) {
+func getRootConfig(s logical.Storage, clientType string) (*aws.Config, error) {
 	credsConfig := &awsutil.CredentialsConfig{}
+	var endpoint string
 
 	entry, err := s.Get("config/root")
 	if err != nil {
@@ -29,8 +30,12 @@ func getRootConfig(s logical.Storage) (*aws.Config, error) {
 		credsConfig.AccessKey = config.AccessKey
 		credsConfig.SecretKey = config.SecretKey
 		credsConfig.Region = config.Region
-		credsConfig.IAMEndpoint = config.IAMEndpoint
-		credsConfig.STSEndpoint = config.STSEndpoint
+		switch {
+		case clientType == "iam" && config.IAMEndpoint != "":
+			endpoint = *aws.String(config.IAMEndpoint)
+		case clientType == "sts" && config.STSEndpoint != "":
+			endpoint = *aws.String(config.STSEndpoint)
+		}
 	}
 
 	if credsConfig.Region == "" {
@@ -53,23 +58,18 @@ func getRootConfig(s logical.Storage) (*aws.Config, error) {
 	return &aws.Config{
 		Credentials: creds,
 		Region:      aws.String(credsConfig.Region),
-		IAMEndpoint: aws.String(credsConfig.IAMEndpoint),
-		STSEndpoint: aws.String(credsConfig.STSEndpoint),
+		Endpoint:    &endpoint,
 		HTTPClient:  cleanhttp.DefaultClient(),
 	}, nil
 }
 
 func clientIAM(s logical.Storage) (*iam.IAM, error) {
-	awsConfig, err := getRootConfig(s)
+	awsConfig, err := getRootConfig(s, "iam")
 	if err != nil {
 		return nil, err
 	}
 
 	client := iam.New(session.New(awsConfig))
-
-	if *awsConfig.IAMEndpoint != "" {
-		client = iam.New(session.New(awsConfig.WithEndpoint(*awsConfig.IAMEndpoint)))
-	}
 
 	if client == nil {
 		return nil, fmt.Errorf("could not obtain iam client")
@@ -78,14 +78,12 @@ func clientIAM(s logical.Storage) (*iam.IAM, error) {
 }
 
 func clientSTS(s logical.Storage) (*sts.STS, error) {
-	awsConfig, err := getRootConfig(s)
+	awsConfig, err := getRootConfig(s, "sts")
 	if err != nil {
 		return nil, err
 	}
 	client := sts.New(session.New(awsConfig))
-	if *awsConfig.STSEndpoint != "" {
-		client = sts.New(session.New(awsConfig.WithEndpoint(*awsConfig.STSEndpoint)))
-	}
+
 	if client == nil {
 		return nil, fmt.Errorf("could not obtain sts client")
 	}

--- a/builtin/logical/aws/path_config_root.go
+++ b/builtin/logical/aws/path_config_root.go
@@ -23,9 +23,13 @@ func pathConfigRoot() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Region for API calls.",
 			},
-			"endpoint": &framework.FieldSchema{
+			"iamendpoint": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "Endpoint to custom IAM server URL",
+			},
+			"stsendpoint": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Endpoint to custom STS server URL",
 			},
 		},
 
@@ -41,17 +45,15 @@ func pathConfigRoot() *framework.Path {
 func pathConfigRootWrite(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	region := data.Get("region").(string)
-	endpoint := data.Get("endpoint").(string)
-
-	if endpoint == "" {
-		endpoint = "none"
-	}
+	iamendpoint := data.Get("iamendpoint").(string)
+	stsendpoint := data.Get("stsendpoint").(string)
 
 	entry, err := logical.StorageEntryJSON("config/root", rootConfig{
-		AccessKey: data.Get("access_key").(string),
-		SecretKey: data.Get("secret_key").(string),
-		Endpoint:  endpoint,
-		Region:    region,
+		AccessKey:   data.Get("access_key").(string),
+		SecretKey:   data.Get("secret_key").(string),
+		IAMEndpoint: iamendpoint,
+		STSEndpoint: stsendpoint,
+		Region:      region,
 	})
 	if err != nil {
 		return nil, err
@@ -65,10 +67,11 @@ func pathConfigRootWrite(
 }
 
 type rootConfig struct {
-	AccessKey string `json:"access_key"`
-	SecretKey string `json:"secret_key"`
-	Endpoint  string `json:"endpoint"`
-	Region    string `json:"region"`
+	AccessKey   string `json:"access_key"`
+	SecretKey   string `json:"secret_key"`
+	IAMEndpoint string `json:"iamendpoint"`
+	STSEndpoint string `json:"stsendpoint"`
+	Region      string `json:"region"`
 }
 
 const pathConfigRootHelpSyn = `

--- a/builtin/logical/aws/path_config_root.go
+++ b/builtin/logical/aws/path_config_root.go
@@ -23,6 +23,10 @@ func pathConfigRoot() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Region for API calls.",
 			},
+			"endpoint": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Endpoint to custom IAM server URL",
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -37,10 +41,16 @@ func pathConfigRoot() *framework.Path {
 func pathConfigRootWrite(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	region := data.Get("region").(string)
+	endpoint := data.Get("endpoint").(string)
+
+	if endpoint == "" {
+		endpoint = "none"
+	}
 
 	entry, err := logical.StorageEntryJSON("config/root", rootConfig{
 		AccessKey: data.Get("access_key").(string),
 		SecretKey: data.Get("secret_key").(string),
+		Endpoint:  endpoint,
 		Region:    region,
 	})
 	if err != nil {
@@ -57,6 +67,7 @@ func pathConfigRootWrite(
 type rootConfig struct {
 	AccessKey string `json:"access_key"`
 	SecretKey string `json:"secret_key"`
+	Endpoint  string `json:"endpoint"`
 	Region    string `json:"region"`
 }
 

--- a/builtin/logical/aws/path_config_root.go
+++ b/builtin/logical/aws/path_config_root.go
@@ -23,11 +23,11 @@ func pathConfigRoot() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Region for API calls.",
 			},
-			"iamendpoint": &framework.FieldSchema{
+			"iam_endpoint": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "Endpoint to custom IAM server URL",
 			},
-			"stsendpoint": &framework.FieldSchema{
+			"sts_endpoint": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "Endpoint to custom STS server URL",
 			},
@@ -45,8 +45,8 @@ func pathConfigRoot() *framework.Path {
 func pathConfigRootWrite(
 	req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	region := data.Get("region").(string)
-	iamendpoint := data.Get("iamendpoint").(string)
-	stsendpoint := data.Get("stsendpoint").(string)
+	iamendpoint := data.Get("iam_endpoint").(string)
+	stsendpoint := data.Get("sts_endpoint").(string)
 
 	entry, err := logical.StorageEntryJSON("config/root", rootConfig{
 		AccessKey:   data.Get("access_key").(string),
@@ -69,8 +69,8 @@ func pathConfigRootWrite(
 type rootConfig struct {
 	AccessKey   string `json:"access_key"`
 	SecretKey   string `json:"secret_key"`
-	IAMEndpoint string `json:"iamendpoint"`
-	STSEndpoint string `json:"stsendpoint"`
+	IAMEndpoint string `json:"iam_endpoint"`
+	STSEndpoint string `json:"sts_endpoint"`
 	Region      string `json:"region"`
 }
 

--- a/helper/awsutil/generate_credentials.go
+++ b/helper/awsutil/generate_credentials.go
@@ -25,7 +25,10 @@ type CredentialsConfig struct {
 	Region string
 
 	//Endpoint to custom IAM server URL
-	Endpoint string
+	IAMEndpoint string
+
+	//Endpoint to custom STS server URL
+	STSEndpoint string
 
 	// The filename for the shared credentials provider, if being used
 	Filename string

--- a/helper/awsutil/generate_credentials.go
+++ b/helper/awsutil/generate_credentials.go
@@ -24,12 +24,6 @@ type CredentialsConfig struct {
 	// the client elsewhere.
 	Region string
 
-	//Endpoint to custom IAM server URL
-	IAMEndpoint string
-
-	//Endpoint to custom STS server URL
-	STSEndpoint string
-
 	// The filename for the shared credentials provider, if being used
 	Filename string
 

--- a/helper/awsutil/generate_credentials.go
+++ b/helper/awsutil/generate_credentials.go
@@ -24,6 +24,9 @@ type CredentialsConfig struct {
 	// the client elsewhere.
 	Region string
 
+	//Endpoint to custom IAM server URL
+	Endpoint string
+
 	// The filename for the shared credentials provider, if being used
 	Filename string
 

--- a/website/source/api/secret/aws/index.html.md
+++ b/website/source/api/secret/aws/index.html.md
@@ -52,6 +52,10 @@ valid AWS credentials with proper permissions.
   will use the `AWS_REGION` env var, `AWS_DEFAULT_REGION` env var, or
   `us-east-1` in that order.
 
+- `iam_endpoint` `(string: <optional>)` – Specifies a custom HTTP IAM endpoint to use.
+
+- `sts_endpoint` `(string: <optional>)` – Specifies a custom HTTP STS endpoint to use.
+
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
In AWS, IAM endpoint(API you actually talk to get users) is determined by the region.

There is a number of AWS clones out there, like Eucalyptus. IAM works in very similar way, but endpoints are not standardized. The only way to make clones work with Vault is to provide optional endpoint parameter. 
