### PR TITLE
upgrade ldap api docs to refrect 0.8.3 change to returned json of policies

### DIFF
--- a/website/source/api/auth/ldap/index.html.md
+++ b/website/source/api/auth/ldap/index.html.md
@@ -208,7 +208,10 @@ $ curl \
 ```json
 {
   "data": {
-    "policies": "admin,default"
+    "policies": [
+      "admin",
+      "default"
+    ]
   },
   "renewable": false,
   "lease_id": ""
@@ -332,7 +335,10 @@ $ curl \
 ```json
 {
   "data": {
-    "policies": "admin,default",
+    "policies": [
+      "admin",
+      "default"
+    ],
     "groups": ""
   },
   "renewable": false,


### PR DESCRIPTION
Just a tiny fix to the docs reflecting the 0.8.3 change to the json response regarding policies.