### PR TITLE
do not panic when Client.Transport is not *http.Transport

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -271,9 +271,10 @@ func NewClient(c *Config) (*Client, error) {
 		c.HttpClient.Transport = cleanhttp.DefaultTransport()
 	}
 
-	tp := c.HttpClient.Transport.(*http.Transport)
-	if err := http2.ConfigureTransport(tp); err != nil {
-		return nil, err
+	if tp, ok := c.HttpClient.Transport.(*http.Transport); ok {
+		if err := http2.ConfigureTransport(tp); err != nil {
+			return nil, err
+		}
 	}
 
 	redirFunc := func() {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -194,3 +194,22 @@ func TestClientTimeoutSetting(t *testing.T) {
 	}
 
 }
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (rt roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt(r)
+}
+
+func TestClientNonTransportRoundTripper(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripperFunc(http.DefaultTransport.RoundTrip),
+	}
+
+	_, err := NewClient(&Config{
+		HttpClient: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Only attempt to configure the client transport for http/2 if it is a `*http.Transport`.

Fixes #3439