### PR TITLE
Allow more complex errors from plugins

### DIFF
--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -320,7 +320,7 @@ func TestHandler_error(t *testing.T) {
 	// The code inside of the error should override
 	// the argument to respondError
 	w2 := httptest.NewRecorder()
-	e := logical.CodedError(403, "error text")
+	e := logical.NewCodedError(403, "error text")
 
 	respondError(w2, 500, e)
 

--- a/logical/error.go
+++ b/logical/error.go
@@ -1,25 +1,30 @@
 package logical
 
-type HTTPCodedError interface {
-	Error() string
-	Code() int
+// CodedError is an error which includes an HTTP status code. Various places in
+// Vault will "unwrap" this error to return the correct response to the user.
+type CodedError struct {
+	Status  int
+	Message string
 }
 
-func CodedError(c int, s string) HTTPCodedError {
-	return &codedError{s, c}
+// Error implements the standard error interface and returns the given message.
+func (e *CodedError) Error() string {
+	return e.Message
 }
 
-type codedError struct {
-	s    string
-	code int
+// Code returns the HTTP status code of this error. This exists for backwards
+// compatability. New implementations should use .Status directly.
+func (e *CodedError) Code() int {
+	return e.Status
 }
 
-func (e *codedError) Error() string {
-	return e.s
-}
-
-func (e *codedError) Code() int {
-	return e.code
+// NewCodedError creates a new HTTP CodedError from the given status and
+// message.
+func NewCodedError(status int, message string) *CodedError {
+	return &CodedError{
+		Status:  status,
+		Message: message,
+	}
 }
 
 // Struct to identify user input errors.  This is helpful in responding the
@@ -34,9 +39,9 @@ func (s *StatusBadRequest) Error() string {
 }
 
 // This is a new type declared to not cause potential compatibility problems if
-// the logic around the HTTPCodedError interface changes; in particular for
-// logical request paths it is basically ignored, and changing that behavior
-// might cause unforseen issues.
+// the logic around the CodedError changes; in particular for logical request
+// paths it is basically ignored, and changing that behavior might cause
+// unforseen issues.
 type ReplicationCodedError struct {
 	Msg  string
 	Code int

--- a/logical/plugin/backend_client.go
+++ b/logical/plugin/backend_client.go
@@ -33,7 +33,7 @@ type HandleRequestArgs struct {
 // HandleRequestReply is the reply for HandleRequest method.
 type HandleRequestReply struct {
 	Response *logical.Response
-	Error    *plugin.BasicError
+	Error    error
 }
 
 // SpecialPathsReply is the reply for SpecialPaths method.
@@ -44,7 +44,7 @@ type SpecialPathsReply struct {
 // SystemReply is the reply for System method.
 type SystemReply struct {
 	SystemView logical.SystemView
-	Error      *plugin.BasicError
+	Error      error
 }
 
 // HandleExistenceCheckArgs is the args for HandleExistenceCheck method.
@@ -57,7 +57,7 @@ type HandleExistenceCheckArgs struct {
 type HandleExistenceCheckReply struct {
 	CheckFound bool
 	Exists     bool
-	Error      *plugin.BasicError
+	Error      error
 }
 
 // SetupArgs is the args for Setup method.
@@ -70,7 +70,7 @@ type SetupArgs struct {
 
 // SetupReply is the reply for Setup method.
 type SetupReply struct {
-	Error *plugin.BasicError
+	Error error
 }
 
 // TypeReply is the reply for the Type method.
@@ -85,7 +85,7 @@ type RegisterLicenseArgs struct {
 
 // RegisterLicenseReply is the reply for the RegisterLicense method.
 type RegisterLicenseReply struct {
-	Error *plugin.BasicError
+	Error error
 }
 
 func (b *backendPluginClient) HandleRequest(req *logical.Request) (*logical.Response, error) {

--- a/logical/plugin/backend_server.go
+++ b/logical/plugin/backend_server.go
@@ -41,7 +41,7 @@ func (b *backendPluginServer) HandleRequest(args *HandleRequestArgs, reply *Hand
 	resp, err := b.backend.HandleRequest(args.Request)
 	*reply = HandleRequestReply{
 		Response: resp,
-		Error:    plugin.NewBasicError(err),
+		Error:    wrapError(err),
 	}
 
 	return nil
@@ -66,7 +66,7 @@ func (b *backendPluginServer) HandleExistenceCheck(args *HandleExistenceCheckArg
 	*reply = HandleExistenceCheckReply{
 		CheckFound: checkFound,
 		Exists:     exists,
-		Error:      plugin.NewBasicError(err),
+		Error:      wrapError(err),
 	}
 
 	return nil
@@ -108,7 +108,7 @@ func (b *backendPluginServer) Setup(args *SetupArgs, reply *SetupReply) error {
 	storageConn, err := b.broker.Dial(args.StorageID)
 	if err != nil {
 		*reply = SetupReply{
-			Error: plugin.NewBasicError(err),
+			Error: wrapError(err),
 		}
 		return nil
 	}
@@ -121,7 +121,7 @@ func (b *backendPluginServer) Setup(args *SetupArgs, reply *SetupReply) error {
 	loggerConn, err := b.broker.Dial(args.LoggerID)
 	if err != nil {
 		*reply = SetupReply{
-			Error: plugin.NewBasicError(err),
+			Error: wrapError(err),
 		}
 		return nil
 	}
@@ -134,7 +134,7 @@ func (b *backendPluginServer) Setup(args *SetupArgs, reply *SetupReply) error {
 	sysViewConn, err := b.broker.Dial(args.SysViewID)
 	if err != nil {
 		*reply = SetupReply{
-			Error: plugin.NewBasicError(err),
+			Error: wrapError(err),
 		}
 		return nil
 	}
@@ -155,7 +155,7 @@ func (b *backendPluginServer) Setup(args *SetupArgs, reply *SetupReply) error {
 	backend, err := b.factory(config)
 	if err != nil {
 		*reply = SetupReply{
-			Error: plugin.NewBasicError(err),
+			Error: wrapError(err),
 		}
 	}
 	b.backend = backend
@@ -179,7 +179,7 @@ func (b *backendPluginServer) RegisterLicense(args *RegisterLicenseArgs, reply *
 	err := b.backend.RegisterLicense(args.License)
 	if err != nil {
 		*reply = RegisterLicenseReply{
-			Error: plugin.NewBasicError(err),
+			Error: wrapError(err),
 		}
 	}
 

--- a/logical/plugin/logger.go
+++ b/logical/plugin/logger.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"net/rpc"
 
-	plugin "github.com/hashicorp/go-plugin"
 	log "github.com/mgutz/logxi/v1"
 )
 
@@ -131,7 +130,7 @@ func (l *LoggerServer) Warn(args *LoggerArgs, reply *LoggerReply) error {
 	err := l.logger.Warn(args.Msg, args.Args...)
 	if err != nil {
 		*reply = LoggerReply{
-			Error: plugin.NewBasicError(err),
+			Error: wrapError(err),
 		}
 		return nil
 	}
@@ -142,7 +141,7 @@ func (l *LoggerServer) Error(args *LoggerArgs, reply *LoggerReply) error {
 	err := l.logger.Error(args.Msg, args.Args...)
 	if err != nil {
 		*reply = LoggerReply{
-			Error: plugin.NewBasicError(err),
+			Error: wrapError(err),
 		}
 		return nil
 	}
@@ -201,5 +200,5 @@ type LoggerArgs struct {
 // for a particular RPC call.
 type LoggerReply struct {
 	IsTrue bool
-	Error  *plugin.BasicError
+	Error  error
 }

--- a/logical/plugin/plugin.go
+++ b/logical/plugin/plugin.go
@@ -15,8 +15,8 @@ import (
 	log "github.com/mgutz/logxi/v1"
 )
 
-// Register these types since we have to serialize and de-serialize tls.ConnectionState
-// over the wire as part of logical.Request.Connection.
+// init registers basic structs with gob which will be used to transport complex
+// types through the plugin server and client.
 func init() {
 	// Common basic structs
 	gob.Register([]interface{}{})
@@ -24,10 +24,18 @@ func init() {
 	gob.Register(map[string]string{})
 	gob.Register(map[string]int{})
 
-	// tls.ConnectionState structs
+	// Register these types since we have to serialize and de-serialize
+	// tls.ConnectionState over the wire as part of logical.Request.Connection.
 	gob.Register(rsa.PublicKey{})
 	gob.Register(ecdsa.PublicKey{})
 	gob.Register(time.Duration(0))
+
+	// Custom common error types for requests. If you add something here, you must
+	// also add it to the switch statement in `wrapError`!
+	gob.Register(&plugin.BasicError{})
+	gob.Register(&logical.CodedError{})
+	gob.Register(&logical.StatusBadRequest{})
+	gob.Register(&logical.ReplicationCodedError{})
 }
 
 // BackendPluginClient is a wrapper around backendPluginClient
@@ -123,4 +131,24 @@ func newPluginClient(sys pluginutil.RunnerUtil, pluginRunner *pluginutil.PluginR
 		client:              client,
 		backendPluginClient: backendRPC,
 	}, nil
+}
+
+// wrapError takes a generic error type and makes it usable with the plugin
+// interface. Only errors which have exported fields and have been registered
+// with gob can be unwrapped and transported. This checks error types and, if
+// none match, wrap the error in a plugin.BasicError.
+func wrapError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch err.(type) {
+	case *plugin.BasicError,
+		*logical.CodedError,
+		*logical.StatusBadRequest,
+		*logical.ReplicationCodedError:
+		return err
+	}
+
+	return plugin.NewBasicError(err)
 }

--- a/logical/plugin/storage.go
+++ b/logical/plugin/storage.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"net/rpc"
 
-	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/vault/logical"
 )
 
@@ -70,7 +69,7 @@ func (s *StorageServer) List(prefix string, reply *StorageListReply) error {
 	keys, err := s.impl.List(prefix)
 	*reply = StorageListReply{
 		Keys:  keys,
-		Error: plugin.NewBasicError(err),
+		Error: wrapError(err),
 	}
 	return nil
 }
@@ -79,7 +78,7 @@ func (s *StorageServer) Get(key string, reply *StorageGetReply) error {
 	storageEntry, err := s.impl.Get(key)
 	*reply = StorageGetReply{
 		StorageEntry: storageEntry,
-		Error:        plugin.NewBasicError(err),
+		Error:        wrapError(err),
 	}
 	return nil
 }
@@ -87,7 +86,7 @@ func (s *StorageServer) Get(key string, reply *StorageGetReply) error {
 func (s *StorageServer) Put(entry *logical.StorageEntry, reply *StoragePutReply) error {
 	err := s.impl.Put(entry)
 	*reply = StoragePutReply{
-		Error: plugin.NewBasicError(err),
+		Error: wrapError(err),
 	}
 	return nil
 }
@@ -95,27 +94,27 @@ func (s *StorageServer) Put(entry *logical.StorageEntry, reply *StoragePutReply)
 func (s *StorageServer) Delete(key string, reply *StorageDeleteReply) error {
 	err := s.impl.Delete(key)
 	*reply = StorageDeleteReply{
-		Error: plugin.NewBasicError(err),
+		Error: wrapError(err),
 	}
 	return nil
 }
 
 type StorageListReply struct {
 	Keys  []string
-	Error *plugin.BasicError
+	Error error
 }
 
 type StorageGetReply struct {
 	StorageEntry *logical.StorageEntry
-	Error        *plugin.BasicError
+	Error        error
 }
 
 type StoragePutReply struct {
-	Error *plugin.BasicError
+	Error error
 }
 
 type StorageDeleteReply struct {
-	Error *plugin.BasicError
+	Error error
 }
 
 // NOOPStorage is used to deny access to the storage interface while running a

--- a/logical/plugin/system.go
+++ b/logical/plugin/system.go
@@ -6,7 +6,6 @@ import (
 
 	"fmt"
 
-	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/vault/helper/consts"
 	"github.com/hashicorp/vault/helper/pluginutil"
 	"github.com/hashicorp/vault/helper/wrapping"
@@ -182,7 +181,7 @@ func (s *SystemViewServer) ResponseWrapData(args *ResponseWrapDataArgs, reply *R
 	info, err := s.impl.ResponseWrapData(args.Data, args.TTL, false)
 	if err != nil {
 		*reply = ResponseWrapDataReply{
-			Error: plugin.NewBasicError(err),
+			Error: wrapError(err),
 		}
 		return nil
 	}
@@ -239,7 +238,7 @@ type ResponseWrapDataArgs struct {
 
 type ResponseWrapDataReply struct {
 	ResponseWrapInfo *wrapping.ResponseWrapInfo
-	Error            *plugin.BasicError
+	Error            error
 }
 
 type MlockEnabledReply struct {

--- a/logical/response_util.go
+++ b/logical/response_util.go
@@ -105,7 +105,7 @@ func AdjustErrorStatusCode(status *int, err error) {
 	}
 
 	// Allow HTTPCoded error passthrough to specify a code
-	if t, ok := err.(HTTPCodedError); ok {
-		*status = t.Code()
+	if t, ok := err.(*CodedError); ok {
+		*status = t.Status
 	}
 }

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -65,7 +65,7 @@ func (c *Core) enableCredential(entry *MountEntry) error {
 		case strings.HasPrefix(ent.Path, entry.Path):
 			fallthrough
 		case strings.HasPrefix(entry.Path, ent.Path):
-			return logical.CodedError(409, "path is already in use")
+			return logical.NewCodedError(409, "path is already in use")
 		}
 	}
 
@@ -75,7 +75,7 @@ func (c *Core) enableCredential(entry *MountEntry) error {
 	}
 
 	if match := c.router.MatchingMount(credentialRoutePrefix + entry.Path); match != "" {
-		return logical.CodedError(409, fmt.Sprintf("existing mount at %s", match))
+		return logical.NewCodedError(409, fmt.Sprintf("existing mount at %s", match))
 	}
 
 	// Generate a new UUID and view
@@ -213,7 +213,7 @@ func (c *Core) removeCredEntry(path string) error {
 	entry := newTable.remove(path)
 	if entry == nil {
 		c.logger.Error("core: nil entry found removing entry in auth table", "path", path)
-		return logical.CodedError(500, "failed to remove entry in auth table")
+		return logical.NewCodedError(500, "failed to remove entry in auth table")
 	}
 
 	// Update the auth table

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -189,8 +189,8 @@ func TestCore_EnableCredential_twice_409(t *testing.T) {
 	// 2nd should be a 409 error
 	err2 := c.enableCredential(me)
 	switch err2.(type) {
-	case logical.HTTPCodedError:
-		if err2.(logical.HTTPCodedError).Code() != 409 {
+	case *logical.CodedError:
+		if err2.(*logical.CodedError).Status != 409 {
 			t.Fatalf("invalid code given")
 		}
 	default:

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2639,7 +2639,7 @@ and is unaffected by replication.`,
 	},
 
 	"mount_plugin_name": {
-		`Name of the plugin to mount based from the name registered 
+		`Name of the plugin to mount based from the name registered
 in the plugin catalog.`,
 	},
 
@@ -2989,7 +2989,7 @@ This path responds to the following HTTP methods.
 		"",
 	},
 	"plugin-catalog_sha-256": {
-		`The SHA256 sum of the executable used in the 
+		`The SHA256 sum of the executable used in the
 command field. This should be HEX encoded.`,
 		"",
 	},

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1374,11 +1374,11 @@ func (b *SystemBackend) handleMount(
 	return nil, nil
 }
 
-// used to intercept an HTTPCodedError so it goes back to callee
+// Intercept a CodedError so the correct status code is returned.
 func handleError(
 	err error) (*logical.Response, error) {
 	switch err.(type) {
-	case logical.HTTPCodedError:
+	case *logical.CodedError:
 		return logical.ErrorResponse(err.Error()), err
 	default:
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -193,14 +193,14 @@ func (c *Core) mount(entry *MountEntry) error {
 	// Prevent protected paths from being mounted
 	for _, p := range protectedMounts {
 		if strings.HasPrefix(entry.Path, p) {
-			return logical.CodedError(403, fmt.Sprintf("cannot mount '%s'", entry.Path))
+			return logical.NewCodedError(403, fmt.Sprintf("cannot mount '%s'", entry.Path))
 		}
 	}
 
 	// Do not allow more than one instance of a singleton mount
 	for _, p := range singletonMounts {
 		if entry.Type == p {
-			return logical.CodedError(403, fmt.Sprintf("Cannot mount more than one instance of '%s'", entry.Type))
+			return logical.NewCodedError(403, fmt.Sprintf("Cannot mount more than one instance of '%s'", entry.Type))
 		}
 	}
 
@@ -209,7 +209,7 @@ func (c *Core) mount(entry *MountEntry) error {
 
 	// Verify there is no conflicting mount
 	if match := c.router.MatchingMount(entry.Path); match != "" {
-		return logical.CodedError(409, fmt.Sprintf("existing mount at %s", match))
+		return logical.NewCodedError(409, fmt.Sprintf("existing mount at %s", match))
 	}
 
 	// Generate a new UUID and view
@@ -259,7 +259,7 @@ func (c *Core) mount(entry *MountEntry) error {
 	newTable.Entries = append(newTable.Entries, entry)
 	if err := c.persistMounts(newTable, entry.Local); err != nil {
 		c.logger.Error("core: failed to update mount table", "error", err)
-		return logical.CodedError(500, "failed to update mount table")
+		return logical.NewCodedError(500, "failed to update mount table")
 	}
 	c.mounts = newTable
 
@@ -354,7 +354,7 @@ func (c *Core) removeMountEntry(path string) error {
 	entry := newTable.remove(path)
 	if entry == nil {
 		c.logger.Error("core: nil entry found removing entry in mounts table", "path", path)
-		return logical.CodedError(500, "failed to remove entry in mounts table")
+		return logical.NewCodedError(500, "failed to remove entry in mounts table")
 	}
 
 	// When unmounting all entries the JSON code will load back up from storage
@@ -366,7 +366,7 @@ func (c *Core) removeMountEntry(path string) error {
 	// Update the mount table
 	if err := c.persistMounts(newTable, entry.Local); err != nil {
 		c.logger.Error("core: failed to remove entry from mounts table", "error", err)
-		return logical.CodedError(500, "failed to remove entry from mounts table")
+		return logical.NewCodedError(500, "failed to remove entry from mounts table")
 	}
 
 	c.mounts = newTable
@@ -383,13 +383,13 @@ func (c *Core) taintMountEntry(path string) error {
 	entry := c.mounts.setTaint(path, true)
 	if entry == nil {
 		c.logger.Error("core: nil entry found tainting entry in mounts table", "path", path)
-		return logical.CodedError(500, "failed to taint entry in mounts table")
+		return logical.NewCodedError(500, "failed to taint entry in mounts table")
 	}
 
 	// Update the mount table
 	if err := c.persistMounts(c.mounts, entry.Local); err != nil {
 		c.logger.Error("core: failed to taint entry in mounts table", "error", err)
-		return logical.CodedError(500, "failed to taint entry in mounts table")
+		return logical.NewCodedError(500, "failed to taint entry in mounts table")
 	}
 
 	return nil
@@ -454,7 +454,7 @@ func (c *Core) remount(src, dst string) error {
 
 	if ent == nil {
 		c.logger.Error("core: failed to find entry in mounts table")
-		return logical.CodedError(500, "failed to find entry in mounts table")
+		return logical.NewCodedError(500, "failed to find entry in mounts table")
 	}
 
 	// Update the mount table
@@ -463,7 +463,7 @@ func (c *Core) remount(src, dst string) error {
 		ent.Tainted = true
 		c.mountsLock.Unlock()
 		c.logger.Error("core: failed to update mounts table", "error", err)
-		return logical.CodedError(500, "failed to update mounts table")
+		return logical.NewCodedError(500, "failed to update mounts table")
 	}
 	c.mountsLock.Unlock()
 


### PR DESCRIPTION
This enables more complex types to be registered and returned from plugins.

This PR also converts `HTTPCodedError` from an interface to a concrete struct. I looked, and there does not seem to be a place where the interface was actually being used where a straight type-check couldn't have been used instead.

I also opened GH-3444, which keeps the interface as-is.