### PR TITLE
Implement signing of pre-hashed data

### DIFF
--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -37,6 +37,7 @@ derivation is enabled; currently only available with ed25519 keys.`,
 				Default: "sha2-256",
 				Description: `Hash algorithm to use (POST body parameter). Valid values are:
 
+* none
 * sha2-224
 * sha2-256
 * sha2-384
@@ -108,6 +109,7 @@ derivation is enabled; currently only available with ed25519 keys.`,
 				Default: "sha2-256",
 				Description: `Hash algorithm to use (POST body parameter). Valid values are:
 
+* none
 * sha2-224
 * sha2-256
 * sha2-384
@@ -166,7 +168,7 @@ func (b *backend) pathSignWrite(
 		}
 	}
 
-	if p.Type.HashSignatureInput() {
+	if p.Type.HashSignatureInput() && algorithm != "none" {
 		var hf hash.Hash
 		switch algorithm {
 		case "sha2-224":
@@ -259,7 +261,7 @@ func (b *backend) pathVerifyWrite(
 		}
 	}
 
-	if p.Type.HashSignatureInput() {
+	if p.Type.HashSignatureInput() && algorithm != "none" {
 		var hf hash.Hash
 		switch algorithm {
 		case "sha2-224":

--- a/builtin/logical/transit/path_sign_verify_test.go
+++ b/builtin/logical/transit/path_sign_verify_test.go
@@ -164,6 +164,10 @@ func TestTransit_SignVerify_P256(t *testing.T) {
 	sig = signRequest(req, false, "")
 	verifyRequest(req, false, "", sig)
 
+	req.Data["algorithm"] = "none"
+	sig = signRequest(req, false, "")
+	verifyRequest(req, false, "", sig)
+
 	// Test 512 and save sig for later to ensure we can't validate once min
 	// decryption version is set
 	req.Data["algorithm"] = "sha2-512"

--- a/website/source/api/secret/transit/index.html.md
+++ b/website/source/api/secret/transit/index.html.md
@@ -779,6 +779,7 @@ supports signing.
   own hash algorithm). This can also be specified as part of the URL.
   Currently-supported algorithms are:
 
+    - `none`
     - `sha2-224`
     - `sha2-256`
     - `sha2-384`
@@ -831,6 +832,7 @@ data.
 - `algorithm` `(string: "sha2-256")` – Specifies the hash algorithm to use. This
   can also be specified as part of the URL. Currently-supported algorithms are:
 
+    - `none`
     - `sha2-224`
     - `sha2-256`
     - `sha2-384`


### PR DESCRIPTION
This PR implements `algorithm=none` for the transit backend's `/sign/<name>` and `/verify/<name>` paths. This allows Vault clients to prehash data before requesting a signature, potentially reducing bandwidth while delegating key management to Vault. `algorithm=none` is supported for ECDSA-P256 keys.