### PR TITLE
Change list users to list all for session validation

### DIFF
--- a/plugins/database/cassandra/connection_producer.go
+++ b/plugins/database/cassandra/connection_producer.go
@@ -228,7 +228,7 @@ func (c *cassandraConnectionProducer) createSession() (*gocql.Session, error) {
 	}
 
 	// Verify the info
-	err = session.Query(`LIST USERS`).Exec()
+	err = session.Query(`LIST ALL`).Exec()
 	if err != nil {
 		return nil, fmt.Errorf("error validating connection info: %s", err)
 	}


### PR DESCRIPTION

List Users and List Roles always use Quorum as the default consistency level. Changing to List All which provides a list of users (works for all C* versions) and uses the consistency level set for the session