### PR TITLE
If no clusterAddr is given but we have a single synthesized cluster a…

### DIFF
--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -462,6 +462,9 @@ func (c *Core) ClusterTLSConfig() (*tls.Config, error) {
 
 func (c *Core) SetClusterListenerAddrs(addrs []*net.TCPAddr) {
 	c.clusterListenerAddrs = addrs
+	if c.clusterAddr == "" && len(addrs) == 1 {
+		c.clusterAddr = addrs[0].String()
+	}
 }
 
 func (c *Core) SetClusterHandler(handler http.Handler) {


### PR DESCRIPTION
…ddresses, automatically use it.