### PR TITLE
Fix a logic bug in the respondRaw function

### DIFF
--- a/http/logical.go
+++ b/http/logical.go
@@ -212,7 +212,7 @@ func respondRaw(w http.ResponseWriter, r *http.Request, resp *logical.Response) 
 
 	// Get the content type header; don't require it if the body is empty
 	contentTypeRaw, ok := resp.Data[logical.HTTPContentType]
-	if !ok && !nonEmpty {
+	if !ok && nonEmpty {
 		retErr(w, "no content type given")
 		return
 	}


### PR DESCRIPTION
This bug was causing errors on raw responses that set the status to 204 (no content) and do not set a content type. 