### PR TITLE
docs: Should these names not reference Vault?

### DIFF
--- a/website/source/docs/configuration/listener/tcp.html.md
+++ b/website/source/docs/configuration/listener/tcp.html.md
@@ -86,8 +86,8 @@ This example shows enabling a TLS listener.
 
 ```hcl
 listener "tcp" {
-  tls_cert_file = "/etc/certs/nomad.crt"
-  tls_key_file  = "/etc/certs/nomad.key"
+  tls_cert_file = "/etc/certs/vault.crt"
+  tls_key_file  = "/etc/certs/vault.key"
 }
 ```
 


### PR DESCRIPTION
Since we are in the Vault docs, should these names not reference Vault instead of Nomad?