### PR TITLE
Ability to forward the MFA Challenge

### DIFF
--- a/helper/mfa/duo/duo.go
+++ b/helper/mfa/duo/duo.go
@@ -69,7 +69,13 @@ type duoAuthRequest struct {
 func duoHandler(duoConfig *DuoConfig, duoAuthClient AuthClient, request *duoAuthRequest) (
 	*logical.Response, error) {
 
-	duoUser := fmt.Sprintf(duoConfig.UsernameFormat, request.username)
+	var username string
+	if duoConfig.ValidatorUsername == "" {
+		username = request.username
+	} else {
+		username = duoConfig.ValidatorUsername
+	}
+	duoUser := fmt.Sprintf(duoConfig.UsernameFormat, username)
 
 	preauth, err := duoAuthClient.Preauth(
 		authapi.PreauthUsername(duoUser),

--- a/helper/mfa/duo/path_duo_config.go
+++ b/helper/mfa/duo/path_duo_config.go
@@ -20,6 +20,10 @@ func pathDuoConfig() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Format string given auth backend username as argument to create Duo username (default '%s')",
 			},
+			"validator_username": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Username for the Duo's account that will receive the MFA challenge (default '')",
+			},
 			"push_info": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "A string of URL-encoded key/value pairs that provides additional context about the authentication attempt in the Duo Mobile app",
@@ -61,9 +65,10 @@ func pathDuoConfigWrite(
 		return nil, errors.New("username_format must include username ('%s')")
 	}
 	entry, err := logical.StorageEntryJSON("duo/config", DuoConfig{
-		UsernameFormat: username_format,
-		UserAgent:      d.Get("user_agent").(string),
-		PushInfo:       d.Get("push_info").(string),
+		UsernameFormat:    username_format,
+		ValidatorUsername: d.Get("validator_username").(string),
+		UserAgent:         d.Get("user_agent").(string),
+		PushInfo:          d.Get("push_info").(string),
 	})
 	if err != nil {
 		return nil, err
@@ -89,21 +94,23 @@ func pathDuoConfigRead(
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"username_format": config.UsernameFormat,
-			"user_agent":      config.UserAgent,
-			"push_info":       config.PushInfo,
+			"username_format":    config.UsernameFormat,
+			"validator_username": config.ValidatorUsername,
+			"user_agent":         config.UserAgent,
+			"push_info":          config.PushInfo,
 		},
 	}, nil
 }
 
 type DuoConfig struct {
-	UsernameFormat string `json:"username_format"`
-	UserAgent      string `json:"user_agent"`
-	PushInfo       string `json:"push_info"`
+	UsernameFormat    string `json:"username_format"`
+	ValidatorUsername string `json:"validator_username"`
+	UserAgent         string `json:"user_agent"`
+	PushInfo          string `json:"push_info"`
 }
 
 const pathDuoConfigHelpSyn = `
-Configure Duo second factor behavior. 
+Configure Duo second factor behavior.
 `
 
 const pathDuoConfigHelpDesc = `


### PR DESCRIPTION
Hello there,

I'd like to propose a nuance on the Duo MFA authentication.
We have the following need: in our production environnement, we would like to restrict the access to our nodes, and have every single SSH access, manually validated by a peer / manager.
For the implementation, the idea is too add the ability to add a `validator_username` when configuring the Auth Backend. If this field is empty, we fallback on the username (this ensures backward compatibility):

    vault write auth/userpass/duo/config user_agent="Bastion-vault" validator_username="devops"

With this, the account `devops` will receive the responsability for distributing the OTP or accepting/rejecting the pushes.
Any feedback?
Best,

Ludovic