### PR TITLE
Debug level logging of socket audit backend config at startup

### DIFF
--- a/vault/audit.go
+++ b/vault/audit.go
@@ -421,6 +421,10 @@ func (c *Core) newAuditBackend(entry *MountEntry, view logical.Storage, conf map
 		})
 
 		c.reloadFuncsLock.Unlock()
+	case "socket":
+		if c.logger.IsDebug() {
+			c.logger.Debug("audit: socket backend options", "path", entry.Path, "address", entry.Options["address"], "socket type", entry.Options["socket_type"])
+		}
 	}
 
 	return be, err

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -411,7 +411,9 @@ func (c *Core) newAuditBackend(entry *MountEntry, view logical.Storage, conf map
 
 		if c.logger.IsDebug() {
 			c.logger.Debug("audit: adding reload function", "path", entry.Path)
-			c.logger.Debug("audit: file backend options", "path", entry.Path, "file_path", entry.Options["file_path"])
+			if entry.Options != nil {
+				c.logger.Debug("audit: file backend options", "path", entry.Path, "file_path", entry.Options["file_path"])
+			}
 		}
 
 		c.reloadFuncs[key] = append(c.reloadFuncs[key], func(map[string]interface{}) error {
@@ -424,11 +426,15 @@ func (c *Core) newAuditBackend(entry *MountEntry, view logical.Storage, conf map
 		c.reloadFuncsLock.Unlock()
 	case "socket":
 		if c.logger.IsDebug() {
-			c.logger.Debug("audit: socket backend options", "path", entry.Path, "address", entry.Options["address"], "socket type", entry.Options["socket_type"])
+			if entry.Options != nil {
+				c.logger.Debug("audit: socket backend options", "path", entry.Path, "address", entry.Options["address"], "socket type", entry.Options["socket_type"])
+			}
 		}
 	case "syslog":
 		if c.logger.IsDebug() {
-			c.logger.Debug("audit: syslog backend options", "path", entry.Path, "facility", entry.Options["facility"], "tag", entry.Options["tag"])
+			if entry.Options != nil {
+				c.logger.Debug("audit: syslog backend options", "path", entry.Path, "facility", entry.Options["facility"], "tag", entry.Options["tag"])
+			}
 		}
 	}
 

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -411,6 +411,7 @@ func (c *Core) newAuditBackend(entry *MountEntry, view logical.Storage, conf map
 
 		if c.logger.IsDebug() {
 			c.logger.Debug("audit: adding reload function", "path", entry.Path)
+			c.logger.Debug("audit: file backend options", "path", entry.Path, "file_path", entry.Options["file_path"])
 		}
 
 		c.reloadFuncs[key] = append(c.reloadFuncs[key], func(map[string]interface{}) error {
@@ -424,6 +425,10 @@ func (c *Core) newAuditBackend(entry *MountEntry, view logical.Storage, conf map
 	case "socket":
 		if c.logger.IsDebug() {
 			c.logger.Debug("audit: socket backend options", "path", entry.Path, "address", entry.Options["address"], "socket type", entry.Options["socket_type"])
+		}
+	case "syslog":
+		if c.logger.IsDebug() {
+			c.logger.Debug("audit: syslog backend options", "path", entry.Path, "facility", entry.Options["facility"], "tag", entry.Options["tag"])
 		}
 	}
 


### PR DESCRIPTION
This provides details about currently enabled socket audit backend configuration at startup via *debug* level logging, which can be helpful if a socket audit backend is blocked, but the operators are not aware of its current configuration to assist with unblocking the socket backend.

In such situations, the Vault server can be restarted with `log-level=debug`, and important configuration details about the backend will be logged like this:

```
2017/11/09 15:29:00.857286 [DEBUG] audit: socket backend options: path=socket/ address=127.0.0.1:9999 socket type=tcp
```

as a reminder of the configured backends so that the suspect blocked backend can be inspected and fixed to restore Vault operations. Currently there is not another way to learn this information if the audit log becomes blocked and Vault stops responding to requests.
