### PR TITLE
Make -client-cert and -client-key work when the server doesn't know about the CA used to sign the cert.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -177,7 +177,12 @@ func (c *Config) ConfigureTLS(t *TLSConfig) error {
 	}
 
 	if foundClientCert {
-		clientTLSConfig.Certificates = []tls.Certificate{clientCert}
+		// We use this function to ignore the server's preferential list of
+		// CAs, otherwise any CA used for the cert auth backend must be in the
+		// server's CA pool
+		clientTLSConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &clientCert, nil
+		}
 	}
 
 	if t.TLSServerName != "" {

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -95,7 +95,9 @@ func (m *Meta) Client() (*api.Client, error) {
 			TLSServerName: "",
 			Insecure:      m.flagInsecure,
 		}
-		config.ConfigureTLS(t)
+		if err := config.ConfigureTLS(t); err != nil {
+			return nil, err
+		}
 	}
 
 	// Build the client


### PR DESCRIPTION
Stop swallowing an error in meta.

Fixes #2946