### PR TITLE
api: Remove explicit http2 dependency

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/go-rootcerts"
 	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/sethgrid/pester"
-	"golang.org/x/net/http2"
 )
 
 const EnvVaultAddress = "VAULT_ADDR"
@@ -113,10 +112,6 @@ func DefaultConfig() *Config {
 	transport.TLSHandshakeTimeout = 10 * time.Second
 	transport.TLSClientConfig = &tls.Config{
 		MinVersion: tls.VersionTLS12,
-	}
-	if err := http2.ConfigureTransport(transport); err != nil {
-		config.Error = err
-		return config
 	}
 
 	if err := config.ReadEnvironment(); err != nil {


### PR DESCRIPTION
Hi! It seems like the `http2` dependency that @jefferai introduced in 41568317e02262985bdf0a84e09cc5bf3fe19c40 is no longer required. This simple change removes the dependency on that package, which is a bit of a nightmare to add as a dependency to any project that uses `vault/api`.

I've tested this internally in it doesn't seem to introduce any regressions or changes in behavior.

Commit message as follows:

```
Commit 4156831 introduced an explicit dependency on `x/net/http2`, as it
there seemed to be an incompatibility between the builtin HTTP2 support
in the Go standard library and the external package.

This incompatibility is now seemingly fixed, and the explicit call to
`ConfigureTransport` is no longer required to enable HTTP2 upgrades in
the HTTP client.

By removing this explicit dependency on the `api` package, we greatly
simplify the vendoring story for other Go projects that depend on
`vault/api` to access Vault secrets. These projects will no longer need
to bring in all the `x/net/http2` package, which is a particularly heavy
dependency.
```