### PR TITLE
Fix docs for Transit API

### DIFF
--- a/website/source/api/secret/transit/index.html.md
+++ b/website/source/api/secret/transit/index.html.md
@@ -792,7 +792,7 @@ supports signing.
    Required if key derivation is enabled; currently only available with ed25519
    keys.
 
- - `prehashed` `(bool: false)` - Set to `true` when the input is already
+- `prehashed` `(bool: false)` - Set to `true` when the input is already
    hashed. If the key type is `rsa-2048` or `rsa-4096`, then the algorithm used
    to hash the input should be indicated by the `algorithm` parameter.
 
@@ -857,11 +857,11 @@ data.
   `/transit/hmac` function. Either this must be supplied or `signature` must be
   supplied.
 
- - `context` `(string: "")` - Base64 encoded context for key derivation.
+- `context` `(string: "")` - Base64 encoded context for key derivation.
    Required if key derivation is enabled; currently only available with ed25519
    keys.
 
- - `prehashed` `(bool: false)` - Set to `true` when the input is already
+- `prehashed` `(bool: false)` - Set to `true` when the input is already
    hashed. If the key type is `rsa-2048` or `rsa-4096`, then the algorithm used
    to hash the input should be indicated by the `algorithm` parameter.
 


### PR DESCRIPTION
prehash and context parameters are marked up incorrectly and
appear to be subparams of other parameters in the API call.