### PR TITLE
Add support for context and add more documentation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,51 @@
+// Package api is the official Golang API client for HashiCorp Vault. Vault's
+// own internal core consumes this API.
+//
+// To get started, create a new API client:
+//
+//     client, err := api.NewClient(api.DefaultClient())
+//     if err != nil {
+//         log.Fatal(err)
+//     }
+//
+// Chaining
+//
+// The library is designed to work in a "chained" fashion. For example, basic
+// CRUD operations are available via the Logical() chain:
+//
+//     // Read a secret
+//     secret, err := client.Logical().Read("secret/foo")
+//
+//     // Write a secret
+//     secret, err := client.Logical().Write("secret/foo", map[string]interface{}{
+//         "hello": "world"
+//     })
+//
+//     // List secrets
+//     secrets, err := client.Logical().List("secret/")
+//
+//     // Delete a secret
+//     err := client.Logical().Delete("secret/foo")
+//
+// Similarly, the system backend is available via the Sys() chain:
+//
+//     // Check seal status
+//     status, err := client.Sys().SealStatus()
+//
+// Context Support
+//
+// Most methods in this library support Go's standard context pattern by passing
+// a context as the first argument to a method. All functions which support
+// context are suffixed with "WithContext" like "MyFunctionWithContext".
+//
+//     // Read a secret with context
+//     ctx, cancel := context.WithTimeout(context.Background(), 5 *time.Second)
+//     defer cancel()
+//     secret, err := client.Logical().ReadWithContext(ctx, "secret/foo")
+//
+//     // Check seal status with context
+//     ctx, cancel := context.WithCancel(context.Background)
+//     defer cancel()
+//     status, err := client.Sys().SealStatusWithContext(ctx)
+//
+package api

--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -1,5 +1,10 @@
 package api
 
+import (
+	"context"
+	"net/http"
+)
+
 // TokenAuth is used to perform token backend operations on Vault
 type TokenAuth struct {
 	c *Client
@@ -10,13 +15,22 @@ func (a *Auth) Token() *TokenAuth {
 	return &TokenAuth{c: a.c}
 }
 
+// Create makes a new Vault token with the given options.
 func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
-	r := c.c.NewRequest("POST", "/v1/auth/token/create")
-	if err := r.SetJSONBody(opts); err != nil {
+	return c.CreateWithContext(context.Background(), opts)
+}
+
+// CreateWithContext makes a new Vault token with the given options, with a
+// context.
+func (c *TokenAuth) CreateWithContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
+	req := c.c.NewRequest(http.MethodPost, "/v1/auth/token/create")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -25,13 +39,21 @@ func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
+// CreateOrphan creates an orphan token.
 func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
-	r := c.c.NewRequest("POST", "/v1/auth/token/create-orphan")
-	if err := r.SetJSONBody(opts); err != nil {
+	return c.CreateOrphanWithContext(context.Background(), opts)
+}
+
+// CreateOrphanWithContext creates an orphan token, with a context.
+func (c *TokenAuth) CreateOrphanWithContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
+	req := c.c.NewRequest(http.MethodPost, "/v1/auth/token/create-orphan")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -40,13 +62,22 @@ func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
+// CreateWithRole creates a token with the given role.
 func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*Secret, error) {
-	r := c.c.NewRequest("POST", "/v1/auth/token/create/"+roleName)
-	if err := r.SetJSONBody(opts); err != nil {
+	return c.CreateWithRoleWithContext(context.Background(), opts, roleName)
+}
+
+// CreateWithRoleWithContext creates a token with the given role, with a
+// context.
+func (c *TokenAuth) CreateWithRoleWithContext(ctx context.Context, opts *TokenCreateRequest, roleName string) (*Secret, error) {
+	req := c.c.NewRequest(http.MethodPost, "/v1/auth/token/create/"+roleName)
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -55,15 +86,23 @@ func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*
 	return ParseSecret(resp.Body)
 }
 
+// Lookup gets information about the given token.
 func (c *TokenAuth) Lookup(token string) (*Secret, error) {
-	r := c.c.NewRequest("POST", "/v1/auth/token/lookup")
-	if err := r.SetJSONBody(map[string]interface{}{
+	return c.LookupWithContext(context.Background(), token)
+}
+
+// LookupWithContext gets information about the given token, with a context.
+func (c *TokenAuth) LookupWithContext(ctx context.Context, token string) (*Secret, error) {
+	req := c.c.NewRequest(http.MethodPost, "/v1/auth/token/lookup")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(map[string]interface{}{
 		"token": token,
 	}); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -72,14 +111,23 @@ func (c *TokenAuth) Lookup(token string) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
+// LookupAccessor looks up information about the token with the given accessor.
 func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
-	r := c.c.NewRequest("POST", "/v1/auth/token/lookup-accessor")
-	if err := r.SetJSONBody(map[string]interface{}{
+	return c.LookupAccessorWithContext(context.Background(), accessor)
+}
+
+// LookupAccessorWithContext looks up information about the token with the given
+// accessor, with a context.
+func (c *TokenAuth) LookupAccessorWithContext(ctx context.Context, accessor string) (*Secret, error) {
+	req := c.c.NewRequest(http.MethodPost, "/v1/auth/token/lookup-accessor")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
 	}); err != nil {
 		return nil, err
 	}
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -88,10 +136,17 @@ func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
+// LookupSelf looks up the current token.
 func (c *TokenAuth) LookupSelf() (*Secret, error) {
-	r := c.c.NewRequest("GET", "/v1/auth/token/lookup-self")
+	return c.LookupSelfWithContext(context.Background())
+}
 
-	resp, err := c.c.RawRequest(r)
+// LookupSelfWithContext looks up the current token, with a context.
+func (c *TokenAuth) LookupSelfWithContext(ctx context.Context) (*Secret, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/auth/token/lookup-self")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -100,16 +155,25 @@ func (c *TokenAuth) LookupSelf() (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
+// Renew renews the given token with the requested increment.
 func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
-	r := c.c.NewRequest("PUT", "/v1/auth/token/renew")
-	if err := r.SetJSONBody(map[string]interface{}{
+	return c.RenewWithContext(context.Background(), token, increment)
+}
+
+// RenewWithContext renews the given token with the requested increment, with a
+// context.
+func (c *TokenAuth) RenewWithContext(ctx context.Context, token string, increment int) (*Secret, error) {
+	req := c.c.NewRequest(http.MethodPut, "/v1/auth/token/renew")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(map[string]interface{}{
 		"token":     token,
 		"increment": increment,
 	}); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,15 +182,23 @@ func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
+// RenewSelf renews the token on the client with the requested increment.
 func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
-	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
+	return c.RenewSelfWithContext(context.Background(), increment)
+}
+
+// RenewSelfWithContext renews the token on the client with the requested
+// increment, with a context.
+func (c *TokenAuth) RenewSelfWithContext(ctx context.Context, increment int) (*Secret, error) {
+	req := c.c.NewRequest(http.MethodPut, "/v1/auth/token/renew-self")
+	req = req.WithContext(ctx)
 
 	body := map[string]interface{}{"increment": increment}
-	if err := r.SetJSONBody(body); err != nil {
+	if err := req.SetJSONBody(body); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -138,15 +210,22 @@ func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 // RenewTokenAsSelf behaves like renew-self, but authenticates using a provided
 // token instead of the token attached to the client.
 func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, error) {
-	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
-	r.ClientToken = token
+	return c.RenewTokenAsSelfWithContext(context.Background(), token, increment)
+}
+
+// RenewTokenAsSelfWithConext behaves like renew-self, but authenticates using a
+// provided token instead of the token attached to the client, with a context.
+func (c *TokenAuth) RenewTokenAsSelfWithContext(ctx context.Context, token string, increment int) (*Secret, error) {
+	req := c.c.NewRequest(http.MethodPut, "/v1/auth/token/renew-self")
+	req = req.WithContext(ctx)
+	req.ClientToken = token
 
 	body := map[string]interface{}{"increment": increment}
-	if err := r.SetJSONBody(body); err != nil {
+	if err := req.SetJSONBody(body); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -155,16 +234,24 @@ func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, erro
 	return ParseSecret(resp.Body)
 }
 
-// RevokeAccessor revokes a token associated with the given accessor
-// along with all the child tokens.
+// RevokeAccessor revokes a token associated with the given accessor along with
+// all the child tokens.
 func (c *TokenAuth) RevokeAccessor(accessor string) error {
-	r := c.c.NewRequest("POST", "/v1/auth/token/revoke-accessor")
-	if err := r.SetJSONBody(map[string]interface{}{
+	return c.RevokeAccessorWithContext(context.Background(), accessor)
+}
+
+// RevokeAccessorWithContext revokes a token associated with the given accessor
+// along with all the child tokens, with a context.
+func (c *TokenAuth) RevokeAccessorWithContext(ctx context.Context, accessor string) error {
+	req := c.c.NewRequest(http.MethodPost, "/v1/auth/token/revoke-accessor")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
 	}); err != nil {
 		return err
 	}
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return err
 	}
@@ -174,16 +261,24 @@ func (c *TokenAuth) RevokeAccessor(accessor string) error {
 }
 
 // RevokeOrphan revokes a token without revoking the tree underneath it (so
-// child tokens are orphaned rather than revoked)
+// child tokens are orphaned rather than revoked).
 func (c *TokenAuth) RevokeOrphan(token string) error {
-	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-orphan")
-	if err := r.SetJSONBody(map[string]interface{}{
+	return c.RevokeOrphanWithContext(context.Background(), token)
+}
+
+// RevokeOrphanWithContext revokes a token without revoking the tree underneath
+// it (so child tokens are orphaned rather than revoked), with a context.
+func (c *TokenAuth) RevokeOrphanWithContext(ctx context.Context, token string) error {
+	req := c.c.NewRequest(http.MethodPut, "/v1/auth/token/revoke-orphan")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(map[string]interface{}{
 		"token": token,
 	}); err != nil {
 		return err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return err
 	}
@@ -196,8 +291,15 @@ func (c *TokenAuth) RevokeOrphan(token string) error {
 // for backwards compatibility but is ignored; only the client's set token has
 // an effect.
 func (c *TokenAuth) RevokeSelf(token string) error {
-	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-self")
-	resp, err := c.c.RawRequest(r)
+	return c.RevokeSelfWithContext(context.Background())
+}
+
+// RevokeSelfWithContext revokes the token making the call, with a context.
+func (c *TokenAuth) RevokeSelfWithContext(ctx context.Context) error {
+	req := c.c.NewRequest(http.MethodPut, "/v1/auth/token/revoke-self")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return err
 	}
@@ -210,14 +312,23 @@ func (c *TokenAuth) RevokeSelf(token string) error {
 // the entire tree underneath -- all of its child tokens, their child tokens,
 // etc.
 func (c *TokenAuth) RevokeTree(token string) error {
-	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke")
-	if err := r.SetJSONBody(map[string]interface{}{
+	return c.RevokeTreeWithContext(context.Background(), token)
+}
+
+// RevokeTreeWithContext is the "normal" revoke operation that revokes the given token and
+// the entire tree underneath -- all of its child tokens, their child tokens,
+// etc, with a context.
+func (c *TokenAuth) RevokeTreeWithContext(ctx context.Context, token string) error {
+	req := c.c.NewRequest(http.MethodPut, "/v1/auth/token/revoke")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(map[string]interface{}{
 		"token": token,
 	}); err != nil {
 		return err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return err
 	}
@@ -228,16 +339,44 @@ func (c *TokenAuth) RevokeTree(token string) error {
 
 // TokenCreateRequest is the options structure for creating a token.
 type TokenCreateRequest struct {
-	ID              string            `json:"id,omitempty"`
-	Policies        []string          `json:"policies,omitempty"`
-	Metadata        map[string]string `json:"meta,omitempty"`
-	Lease           string            `json:"lease,omitempty"`
-	TTL             string            `json:"ttl,omitempty"`
-	ExplicitMaxTTL  string            `json:"explicit_max_ttl,omitempty"`
-	Period          string            `json:"period,omitempty"`
-	NoParent        bool              `json:"no_parent,omitempty"`
-	NoDefaultPolicy bool              `json:"no_default_policy,omitempty"`
-	DisplayName     string            `json:"display_name"`
-	NumUses         int               `json:"num_uses"`
-	Renewable       *bool             `json:"renewable,omitempty"`
+	// ID is the token - only root tokens can request a token with a specified ID.
+	ID string `json:"id,omitempty"`
+
+	// Policies is the list of policies to attach to the token.
+	Policies []string `json:"policies,omitempty"`
+
+	// Metadata is arbitrary key-value metadata for the token.
+	Metadata map[string]string `json:"meta,omitempty"`
+
+	// Lease is the lease.
+	//
+	// Deprecated: Lease is deprecated. Use TTL instead.
+	Lease string `json:"lease,omitempty"`
+
+	// TTL is the minimum TTL for the token.
+	TTL string `json:"ttl,omitempty"`
+
+	// ExplicitMaxTTL is the maximum TTL for the token.
+	ExplicitMaxTTL string `json:"explicit_max_ttl,omitempty"`
+
+	// Period is period for the token, if a periodic token. Only root tokens can
+	// create periodic tokens.
+	Period string `json:"period,omitempty"`
+
+	// NoParent detaches the token from its parent. Only root tokens can create
+	// orphan tokens.
+	NoParent bool `json:"no_parent,omitempty"`
+
+	// NoDefaultPolicy removes the default policy from the token.
+	NoDefaultPolicy bool `json:"no_default_policy,omitempty"`
+
+	// DisplayName is the human name of the token.
+	DisplayName string `json:"display_name"`
+
+	// NumUses is the number of uses before the token expires, regardless of
+	// remaining TTLs.
+	NumUses int `json:"num_uses"`
+
+	// Renewable is a pointer to a bool indicating whether the token is renewable.
+	Renewable *bool `json:"renewable,omitempty"`
 }

--- a/api/client.go
+++ b/api/client.go
@@ -21,18 +21,22 @@ import (
 	"golang.org/x/net/http2"
 )
 
-const EnvVaultAddress = "VAULT_ADDR"
-const EnvVaultCACert = "VAULT_CACERT"
-const EnvVaultCAPath = "VAULT_CAPATH"
-const EnvVaultClientCert = "VAULT_CLIENT_CERT"
-const EnvVaultClientKey = "VAULT_CLIENT_KEY"
-const EnvVaultClientTimeout = "VAULT_CLIENT_TIMEOUT"
-const EnvVaultInsecure = "VAULT_SKIP_VERIFY"
-const EnvVaultTLSServerName = "VAULT_TLS_SERVER_NAME"
-const EnvVaultWrapTTL = "VAULT_WRAP_TTL"
-const EnvVaultMaxRetries = "VAULT_MAX_RETRIES"
-const EnvVaultToken = "VAULT_TOKEN"
-const EnvVaultMFA = "VAULT_MFA"
+// These are the names of the environment variables consumed by the Vault API
+// client to get some of its configuration.
+const (
+	EnvVaultAddress       = "VAULT_ADDR"
+	EnvVaultCACert        = "VAULT_CACERT"
+	EnvVaultCAPath        = "VAULT_CAPATH"
+	EnvVaultClientCert    = "VAULT_CLIENT_CERT"
+	EnvVaultClientKey     = "VAULT_CLIENT_KEY"
+	EnvVaultClientTimeout = "VAULT_CLIENT_TIMEOUT"
+	EnvVaultInsecure      = "VAULT_SKIP_VERIFY"
+	EnvVaultTLSServerName = "VAULT_TLS_SERVER_NAME"
+	EnvVaultWrapTTL       = "VAULT_WRAP_TTL"
+	EnvVaultMaxRetries    = "VAULT_MAX_RETRIES"
+	EnvVaultToken         = "VAULT_TOKEN"
+	EnvVaultMFA           = "VAULT_MFA"
+)
 
 // WrappingLookupFunc is a function that, given an HTTP verb and a path,
 // returns an optional string duration to be used for response wrapping (e.g.

--- a/api/help.go
+++ b/api/help.go
@@ -1,14 +1,24 @@
 package api
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 )
 
-// Help reads the help information for the given path.
+// Help returns help information about the given path.
 func (c *Client) Help(path string) (*Help, error) {
-	r := c.NewRequest("GET", fmt.Sprintf("/v1/%s", path))
-	r.Params.Add("help", "1")
-	resp, err := c.RawRequest(r)
+	return c.HelpWithContext(context.Background(), path)
+}
+
+// HelpWithContext returns help information about the given path, with a context.
+func (c *Client) HelpWithContext(ctx context.Context, path string) (*Help, error) {
+	req := c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/%s", path))
+	req = req.WithContext(ctx)
+
+	req.Params.Add("help", "1")
+
+	resp, err := c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -19,7 +29,11 @@ func (c *Client) Help(path string) (*Help, error) {
 	return &result, err
 }
 
+// Help is the response from a help request.
 type Help struct {
-	Help    string   `json:"help"`
+	// Help is the raw help.
+	Help string `json:"help"`
+
+	// SeeAlso is a list of other methods to see for help.
 	SeeAlso []string `json:"see_also"`
 }

--- a/api/secret.go
+++ b/api/secret.go
@@ -12,9 +12,14 @@ type Secret struct {
 	// The request ID that generated this response
 	RequestID string `json:"request_id"`
 
-	LeaseID       string `json:"lease_id"`
-	LeaseDuration int    `json:"lease_duration"`
-	Renewable     bool   `json:"renewable"`
+	// LeaseID is the ID of the lease, if one exists.
+	LeaseID string `json:"lease_id"`
+
+	// LeaseDuration is the remaining lease duration, if one exists.
+	LeaseDuration int `json:"lease_duration"`
+
+	// Renewable indicates if this secret is renewable.
+	Renewable bool `json:"renewable"`
 
 	// Data is the actual contents of the secret. The format of the data
 	// is arbitrary and up to the secret backend.

--- a/api/sys_audit.go
+++ b/api/sys_audit.go
@@ -9,10 +9,13 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// AuditHash calculates the audit hash for the given input.
 func (c *Sys) AuditHash(path string, input string) (string, error) {
 	return c.AuditHashWithContext(context.Background(), path, input)
 }
 
+// AuditHashWithContext calculates the audit hash for the given input, with a
+// context.
 func (c *Sys) AuditHashWithContext(ctx context.Context, path string, input string) (string, error) {
 	req := c.c.NewRequest(http.MethodPut, fmt.Sprintf("/v1/sys/audit-hash/%s", path))
 	req = req.WithContext(ctx)
@@ -46,10 +49,12 @@ func (c *Sys) ListAudit() (map[string]*Audit, error) {
 	return c.ListAuditsWithContext(context.Background())
 }
 
+// ListAudits returns all enabled audit backends.
 func (c *Sys) ListAudits() (map[string]*Audit, error) {
 	return c.ListAuditsWithContext(context.Background())
 }
 
+// ListAuditsWithContext returns all enabled audit backends, with a context.
 func (c *Sys) ListAuditsWithContext(ctx context.Context) (map[string]*Audit, error) {
 	req := c.c.NewRequest(http.MethodGet, "/v1/sys/audit")
 	req = req.WithContext(ctx)

--- a/api/sys_audit.go
+++ b/api/sys_audit.go
@@ -1,33 +1,36 @@
 package api
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/fatih/structs"
 	"github.com/mitchellh/mapstructure"
 )
 
 func (c *Sys) AuditHash(path string, input string) (string, error) {
+	return c.AuditHashWithContext(context.Background(), path, input)
+}
+
+func (c *Sys) AuditHashWithContext(ctx context.Context, path string, input string) (string, error) {
+	req := c.c.NewRequest(http.MethodPut, fmt.Sprintf("/v1/sys/audit-hash/%s", path))
+	req = req.WithContext(ctx)
+
 	body := map[string]interface{}{
 		"input": input,
 	}
-
-	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/sys/audit-hash/%s", path))
-	if err := r.SetJSONBody(body); err != nil {
+	if err := req.SetJSONBody(body); err != nil {
 		return "", err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
 
-	type d struct {
-		Hash string `json:"hash"`
-	}
-
-	var result d
+	var result hashResp
 	err = resp.DecodeJSON(&result)
 	if err != nil {
 		return "", err
@@ -36,9 +39,22 @@ func (c *Sys) AuditHash(path string, input string) (string, error) {
 	return result.Hash, err
 }
 
+// ListAudit lists audit backends.
+//
+// Deprecated: ListAudit is deprecated. Use ListAudits instead.
 func (c *Sys) ListAudit() (map[string]*Audit, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/audit")
-	resp, err := c.c.RawRequest(r)
+	return c.ListAuditsWithContext(context.Background())
+}
+
+func (c *Sys) ListAudits() (map[string]*Audit, error) {
+	return c.ListAuditsWithContext(context.Background())
+}
+
+func (c *Sys) ListAuditsWithContext(ctx context.Context) (map[string]*Audit, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/audit")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -72,9 +88,11 @@ func (c *Sys) ListAudit() (map[string]*Audit, error) {
 	return mounts, nil
 }
 
-// DEPRECATED: Use EnableAuditWithOptions instead
-func (c *Sys) EnableAudit(
-	path string, auditType string, desc string, opts map[string]string) error {
+// EnableAudit enables an audit backend at the given path, with the given type
+// and description.
+//
+// Deprecated: EnableAudit is deprecated. Use EnableAuditWithOptions instead.
+func (c *Sys) EnableAudit(path string, auditType string, desc string, opts map[string]string) error {
 	return c.EnableAuditWithOptions(path, &EnableAuditOptions{
 		Type:        auditType,
 		Description: desc,
@@ -82,15 +100,24 @@ func (c *Sys) EnableAudit(
 	})
 }
 
-func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) error {
-	body := structs.Map(options)
+// EnableAuditWithOptions enables the given audit backend with the provided
+// options.
+func (c *Sys) EnableAuditWithOptions(path string, opts *EnableAuditOptions) error {
+	return c.EnableAuditWithOptionsWithContext(context.Background(), path, opts)
+}
 
-	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/sys/audit/%s", path))
-	if err := r.SetJSONBody(body); err != nil {
+// EnableAuditWithOptionsWithContext enables the given audit backend with the
+// provided options, with a context.
+func (c *Sys) EnableAuditWithOptionsWithContext(ctx context.Context, path string, opts *EnableAuditOptions) error {
+	req := c.c.NewRequest(http.MethodPut, fmt.Sprintf("/v1/sys/audit/%s", path))
+	req = req.WithContext(ctx)
+
+	body := structs.Map(opts)
+	if err := req.SetJSONBody(body); err != nil {
 		return err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return err
 	}
@@ -99,30 +126,56 @@ func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) e
 	return nil
 }
 
+// DisableAudit disables the audit at the given path.
 func (c *Sys) DisableAudit(path string) error {
-	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/audit/%s", path))
-	resp, err := c.c.RawRequest(r)
+	return c.DisableAuditWithContext(context.Background(), path)
+}
+
+// DisableAuditWithContext disables the audit at the given path, with a context.
+func (c *Sys) DisableAuditWithContext(ctx context.Context, path string) error {
+	req := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/audit/%s", path))
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
 	return err
 }
 
-// Structures for the requests/resposne are all down here. They aren't
-// individually documented because the map almost directly to the raw HTTP API
-// documentation. Please refer to that documentation for more details.
-
+// EnableAuditOptions is used as input to the EnableAuditWithOptions function.
 type EnableAuditOptions struct {
-	Type        string            `json:"type" structs:"type"`
-	Description string            `json:"description" structs:"description"`
-	Options     map[string]string `json:"options" structs:"options"`
-	Local       bool              `json:"local" structs:"local"`
+	// Type is the type of audit backend to enable.
+	Type string `json:"type" structs:"type"`
+
+	// Description is a human-friendly description of the audit backend.
+	Description string `json:"description" structs:"description"`
+
+	// Options is a list of options to pass directly to the audit backend.
+	Options map[string]string `json:"options" structs:"options"`
+
+	// Local is a boolean indicating the audit backend should not be replicated.
+	Local bool `json:"local" structs:"local"`
 }
 
+// Audit is information about an audit backend.
 type Audit struct {
-	Path        string
-	Type        string
+	// Path is the path where the audit backend is mounted.
+	Path string
+
+	// Type is the type of audit backend.
+	Type string
+
+	// Description is the human-friendly description of the audit backend.
 	Description string
-	Options     map[string]string
-	Local       bool
+
+	// Options are the list of configurations for the audit backend.
+	Options map[string]string
+
+	// Local is a boolean indicating the audit backend is not be replicated.
+	Local bool
+}
+
+type hashResp struct {
+	Hash string `json:"hash"`
 }

--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -1,15 +1,32 @@
 package api
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/fatih/structs"
 	"github.com/mitchellh/mapstructure"
 )
 
+// ListAuth lists auth methods.
+//
+// Deprecated: ListAuth is deprecated. Use ListAuths instead.
 func (c *Sys) ListAuth() (map[string]*AuthMount, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/auth")
-	resp, err := c.c.RawRequest(r)
+	return c.ListAuthsWithContext(context.Background())
+}
+
+// ListAuths lists the enabled auth methods.
+func (c *Sys) ListAuths() (map[string]*AuthMount, error) {
+	return c.ListAuthsWithContext(context.Background())
+}
+
+// ListAuthsWithContext lists the enabled auth methods, with a context.
+func (c *Sys) ListAuthsWithContext(ctx context.Context) (map[string]*AuthMount, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/auth")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +60,10 @@ func (c *Sys) ListAuth() (map[string]*AuthMount, error) {
 	return mounts, nil
 }
 
-// DEPRECATED: Use EnableAuthWithOptions instead
+// EnableAuth enables an authentication at the given path, with the given type
+// and description.
+//
+// Deprecated: EnableAuth is deprecated. Use EnableAuthWithOptions instead.
 func (c *Sys) EnableAuth(path, authType, desc string) error {
 	return c.EnableAuthWithOptions(path, &EnableAuthOptions{
 		Type:        authType,
@@ -51,15 +71,24 @@ func (c *Sys) EnableAuth(path, authType, desc string) error {
 	})
 }
 
-func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) error {
-	body := structs.Map(options)
+// EnableAuthWithOptions enables an authentication at the given path with the
+// given options.
+func (c *Sys) EnableAuthWithOptions(path string, opts *EnableAuthOptions) error {
+	return c.EnableAuthWithOptionsWithContext(context.Background(), path, opts)
+}
 
-	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/auth/%s", path))
-	if err := r.SetJSONBody(body); err != nil {
+// EnableAuthWithOptionsWithContext enables an authentication at the given path
+// with the given options, with a context.
+func (c *Sys) EnableAuthWithOptionsWithContext(ctx context.Context, path string, opts *EnableAuthOptions) error {
+	req := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/auth/%s", path))
+	req = req.WithContext(ctx)
+
+	body := structs.Map(opts)
+	if err := req.SetJSONBody(body); err != nil {
 		return err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return err
 	}
@@ -68,41 +97,73 @@ func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) err
 	return nil
 }
 
+// DisableAuth disables an auth at the given path.
 func (c *Sys) DisableAuth(path string) error {
-	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/auth/%s", path))
-	resp, err := c.c.RawRequest(r)
+	return c.DisableAuthWithContext(context.Background(), path)
+}
+
+// DisableAuthWithContext disables an auth at the given path, with a context.
+func (c *Sys) DisableAuthWithContext(ctx context.Context, path string) error {
+	req := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/auth/%s", path))
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
 	return err
 }
 
-// Structures for the requests/resposne are all down here. They aren't
-// individually documentd because the map almost directly to the raw HTTP API
-// documentation. Please refer to that documentation for more details.
-
+// EnableAuthOptions is used as input to the EnableAuthWithOptions function.
 type EnableAuthOptions struct {
-	Type        string          `json:"type" structs:"type"`
-	Description string          `json:"description" structs:"description"`
-	Config      AuthConfigInput `json:"config" structs:"config"`
-	Local       bool            `json:"local" structs:"local"`
-	PluginName  string          `json:"plugin_name,omitempty" structs:"plugin_name,omitempty"`
+	// Type is the type of auth method to enable.
+	Type string `json:"type" structs:"type"`
+
+	// Description is a human-friendly description of the auth method.
+	Description string `json:"description" structs:"description"`
+
+	// Config is configuration about the auth method.
+	Config AuthConfigInput `json:"config" structs:"config"`
+
+	// Local is a boolean indicating the auth method should not be replicated.
+	Local bool `json:"local" structs:"local"`
+
+	// PluginName is the name of the plugin (if Type == "plugin").
+	PluginName string `json:"plugin_name,omitempty" structs:"plugin_name,omitempty"`
 }
 
+// AuthConfigInput is the input auth config.
 type AuthConfigInput struct {
+	// PluginName is the name of the plugin (if Type == "plugin").
 	PluginName string `json:"plugin_name,omitempty" structs:"plugin_name,omitempty" mapstructure:"plugin_name"`
 }
 
+// AuthMount is information about an auth mount.
 type AuthMount struct {
-	Type        string           `json:"type" structs:"type" mapstructure:"type"`
-	Description string           `json:"description" structs:"description" mapstructure:"description"`
-	Accessor    string           `json:"accessor" structs:"accessor" mapstructure:"accessor"`
-	Config      AuthConfigOutput `json:"config" structs:"config" mapstructure:"config"`
-	Local       bool             `json:"local" structs:"local" mapstructure:"local"`
+	// Type is the type of auth method.
+	Type string `json:"type" structs:"type" mapstructure:"type"`
+
+	// Description is a human-friendly description of the auth method.
+	Description string `json:"description" structs:"description" mapstructure:"description"`
+
+	// Accessor is the accessor of the auth method.
+	Accessor string `json:"accessor" structs:"accessor" mapstructure:"accessor"`
+
+	// Config is configuration about the auth method.
+	Config AuthConfigOutput `json:"config" structs:"config" mapstructure:"config"`
+
+	// Local is a boolean indicating the auth method should not be replicated.
+	Local bool `json:"local" structs:"local" mapstructure:"local"`
 }
 
+// AuthConfigOutput is output auth config.
 type AuthConfigOutput struct {
-	DefaultLeaseTTL int    `json:"default_lease_ttl" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"`
-	MaxLeaseTTL     int    `json:"max_lease_ttl" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`
-	PluginName      string `json:"plugin_name,omitempty" structs:"plugin_name,omitempty" mapstructure:"plugin_name"`
+	// DefaultLeaseTTL is the default minimum lease.
+	DefaultLeaseTTL int `json:"default_lease_ttl" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"`
+
+	// MaxLeaseTTL is the maximum lease.
+	MaxLeaseTTL int `json:"max_lease_ttl" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`
+
+	// PluginName is the name of the plugin (if Type == "plugin")
+	PluginName string `json:"plugin_name,omitempty" structs:"plugin_name,omitempty" mapstructure:"plugin_name"`
 }

--- a/api/sys_capabilities.go
+++ b/api/sys_capabilities.go
@@ -1,28 +1,49 @@
 package api
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
 
+// CapabilitiesSelf returns the list of capabilities for the current token on
+// the given path.
 func (c *Sys) CapabilitiesSelf(path string) ([]string, error) {
-	return c.Capabilities(c.c.Token(), path)
+	return c.CapabilitiesSelfWithContext(context.Background(), path)
 }
 
-func (c *Sys) Capabilities(token, path string) ([]string, error) {
-	body := map[string]string{
-		"token": token,
-		"path":  path,
-	}
+// CapabilitiesSelfWithContext returns the list of capabilities for the current
+// token on the given path, with a context.
+func (c *Sys) CapabilitiesSelfWithContext(ctx context.Context, path string) ([]string, error) {
+	return c.CapabilitiesWithContext(ctx, c.c.Token(), path)
+}
 
+// Capabilities returns the list of capabilities for the given token on the
+// given path.
+func (c *Sys) Capabilities(token, path string) ([]string, error) {
+	return c.CapabilitiesWithContext(context.Background(), token, path)
+}
+
+// CapabilitiesWithContext returns the list of capabilities for the given token
+// on the given path, with a context.
+func (c *Sys) CapabilitiesWithContext(ctx context.Context, token, path string) ([]string, error) {
 	reqPath := "/v1/sys/capabilities"
 	if token == c.c.Token() {
 		reqPath = fmt.Sprintf("%s-self", reqPath)
 	}
 
-	r := c.c.NewRequest("POST", reqPath)
-	if err := r.SetJSONBody(body); err != nil {
+	req := c.c.NewRequest(http.MethodPost, reqPath)
+	req = req.WithContext(ctx)
+
+	body := map[string]string{
+		"token": token,
+		"path":  path,
+	}
+	if err := req.SetJSONBody(body); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -1,8 +1,21 @@
 package api
 
+import (
+	"context"
+	"net/http"
+)
+
+// CORSStatus returns the current CORS configuration.
 func (c *Sys) CORSStatus() (*CORSResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/config/cors")
-	resp, err := c.c.RawRequest(r)
+	return c.CORSStatusWithContext(context.Background())
+}
+
+// CORSStatusWithContext returns the current CORS configuration, with a context.
+func (c *Sys) CORSStatusWithContext(ctx context.Context) (*CORSResponse, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/config/cors")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -13,13 +26,21 @@ func (c *Sys) CORSStatus() (*CORSResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) ConfigureCORS(req *CORSRequest) (*CORSResponse, error) {
-	r := c.c.NewRequest("PUT", "/v1/sys/config/cors")
-	if err := r.SetJSONBody(req); err != nil {
+// ConfigureCORS updates the CORS configuration.
+func (c *Sys) ConfigureCORS(r *CORSRequest) (*CORSResponse, error) {
+	return c.ConfigureCORSWithContext(context.Background(), r)
+}
+
+// ConfigureCORSWithContext updates the CORS configuration, with a context.
+func (c *Sys) ConfigureCORSWithContext(ctx context.Context, r *CORSRequest) (*CORSResponse, error) {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/config/cors")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(r); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -30,10 +51,17 @@ func (c *Sys) ConfigureCORS(req *CORSRequest) (*CORSResponse, error) {
 	return &result, err
 }
 
+// DisableCORS disables CORS.
 func (c *Sys) DisableCORS() (*CORSResponse, error) {
-	r := c.c.NewRequest("DELETE", "/v1/sys/config/cors")
+	return c.DisableCORSWithContext(context.Background())
+}
 
-	resp, err := c.c.RawRequest(r)
+// DisableCORSWithContext disables CORS, with a context.
+func (c *Sys) DisableCORSWithContext(ctx context.Context) (*CORSResponse, error) {
+	req := c.c.NewRequest(http.MethodDelete, "/v1/sys/config/cors")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -45,12 +73,20 @@ func (c *Sys) DisableCORS() (*CORSResponse, error) {
 
 }
 
+// CORSRequest is used as input to enable CORS.
 type CORSRequest struct {
+	// AllowOrigins is a comma-separated list of allowed origins.
 	AllowedOrigins string `json:"allowed_origins"`
-	Enabled        bool   `json:"enabled"`
+
+	// Enabled is a boolean indicating whether CORS should be enabled.
+	Enabled bool `json:"enabled"`
 }
 
+// CORSResponse is the result of a CORS request.
 type CORSResponse struct {
+	// AllowOrigins is a comma-separated list of allowed origins.
 	AllowedOrigins string `json:"allowed_origins"`
-	Enabled        bool   `json:"enabled"`
+
+	// Enabled is a boolean indicating whether CORS is enabled.
+	Enabled bool `json:"enabled"`
 }

--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -1,16 +1,38 @@
 package api
 
+import (
+	"context"
+	"net/http"
+)
+
+// GenerateRootStatus gets the current root generation status.
 func (c *Sys) GenerateRootStatus() (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommon("/v1/sys/generate-root/attempt")
+	return c.GenerateRootStatusWithContext(context.Background())
 }
 
+// GenerateRootStatusWithContext gets the current root generation status, with a
+// context.
+func (c *Sys) GenerateRootStatusWithContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommon(ctx, "/v1/sys/generate-root/attempt")
+}
+
+// GenerateDROperationTokenStatus gets the current DR root token generation
+// status.
 func (c *Sys) GenerateDROperationTokenStatus() (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+	return c.GenerateDROperationTokenStatusWithContext(context.Background())
 }
 
-func (c *Sys) generateRootStatusCommon(path string) (*GenerateRootStatusResponse, error) {
-	r := c.c.NewRequest("GET", path)
-	resp, err := c.c.RawRequest(r)
+// GenerateDROperationTokenStatusWithContext gets the current DR root token generation
+// status, with a context.
+func (c *Sys) GenerateDROperationTokenStatusWithContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommon(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+}
+
+func (c *Sys) generateRootStatusCommon(ctx context.Context, path string) (*GenerateRootStatusResponse, error) {
+	req := c.c.NewRequest(http.MethodGet, path)
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -21,26 +43,41 @@ func (c *Sys) generateRootStatusCommon(path string) (*GenerateRootStatusResponse
 	return &result, err
 }
 
+// GenerateRootInit initializes a new root token generation.
 func (c *Sys) GenerateRootInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommon("/v1/sys/generate-root/attempt", otp, pgpKey)
+	return c.GenerateRootInitWithContext(context.Background(), otp, pgpKey)
 }
 
+// GenerateRootInitWithContext initializes a new root token generation, with a
+// context.
+func (c *Sys) GenerateRootInitWithContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommon(ctx, "/v1/sys/generate-root/attempt", otp, pgpKey)
+}
+
+// GenerateDROperationTokenInit initializes a new DR root token generation.
 func (c *Sys) GenerateDROperationTokenInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt", otp, pgpKey)
+	return c.GenerateDROperationTokenInitWithContext(context.Background(), otp, pgpKey)
 }
 
-func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+// GenerateDROperationTokenInitWithContext initializes a new DR root token
+// generation, with a context.
+func (c *Sys) GenerateDROperationTokenInitWithContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommon(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt", otp, pgpKey)
+}
+
+func (c *Sys) generateRootInitCommon(ctx context.Context, path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	req := c.c.NewRequest(http.MethodPut, path)
+	req = req.WithContext(ctx)
+
 	body := map[string]interface{}{
 		"otp":     otp,
 		"pgp_key": pgpKey,
 	}
-
-	r := c.c.NewRequest("PUT", path)
-	if err := r.SetJSONBody(body); err != nil {
+	if err := req.SetJSONBody(body); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -51,43 +88,75 @@ func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootSta
 	return &result, err
 }
 
+// GenerateRootCancel cancels an existing root generation.
 func (c *Sys) GenerateRootCancel() error {
-	return c.generateRootCancelCommon("/v1/sys/generate-root/attempt")
+	return c.GenerateRootCancelWithContext(context.Background())
 }
 
+// GenerateRootCancelWithContext cancels an existing root generation, with a
+// context.
+func (c *Sys) GenerateRootCancelWithContext(ctx context.Context) error {
+	return c.generateRootCancelCommon(ctx, "/v1/sys/generate-root/attempt")
+}
+
+// GenerateDROperationTokenCancel cancles an existing DR root generation.
 func (c *Sys) GenerateDROperationTokenCancel() error {
-	return c.generateRootCancelCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+	return c.GenerateDROperationTokenCancelWithContext(context.Background())
 }
 
-func (c *Sys) generateRootCancelCommon(path string) error {
-	r := c.c.NewRequest("DELETE", path)
-	resp, err := c.c.RawRequest(r)
+// GenerateDROperationTokenCancelWithContext cancles an existing DR root
+// generation, with a context.
+func (c *Sys) GenerateDROperationTokenCancelWithContext(ctx context.Context) error {
+	return c.generateRootCancelCommon(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+}
+
+func (c *Sys) generateRootCancelCommon(ctx context.Context, path string) error {
+	req := c.c.NewRequest(http.MethodDelete, path)
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
 	return err
 }
 
+// GenerateRootUpdate submits a shard to the root generation process.
 func (c *Sys) GenerateRootUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommon("/v1/sys/generate-root/update", shard, nonce)
+	return c.GenerateRootUpdateWithContext(context.Background(), shard, nonce)
 }
 
+// GenerateRootUpdateWithContext submits a shard to the root generation process,
+// with a context.
+func (c *Sys) GenerateRootUpdateWithContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommon(ctx, "/v1/sys/generate-root/update", shard, nonce)
+}
+
+// GenerateDROperationTokenUpdate submits a shard to the DR token generation
+// process.
 func (c *Sys) GenerateDROperationTokenUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommon("/v1/sys/replication/dr/secondary/generate-operation-token/update", shard, nonce)
+	return c.GenerateDROperationTokenUpdateWithContext(context.Background(), shard, nonce)
 }
 
-func (c *Sys) generateRootUpdateCommon(path, shard, nonce string) (*GenerateRootStatusResponse, error) {
+// GenerateDROperationTokenUpdateWithContext submits a shard to the DR token
+// generation process, with a context.
+func (c *Sys) GenerateDROperationTokenUpdateWithContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommon(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/update", shard, nonce)
+}
+
+func (c *Sys) generateRootUpdateCommon(ctx context.Context, path, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	req := c.c.NewRequest(http.MethodPut, path)
+	req = req.WithContext(ctx)
+
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
 	}
-
-	r := c.c.NewRequest("PUT", path)
-	if err := r.SetJSONBody(body); err != nil {
+	if err := req.SetJSONBody(body); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -98,13 +167,29 @@ func (c *Sys) generateRootUpdateCommon(path, shard, nonce string) (*GenerateRoot
 	return &result, err
 }
 
+// GenerateRootStatusResponse is the response from the generate root operation.
 type GenerateRootStatusResponse struct {
-	Nonce            string
-	Started          bool
-	Progress         int
-	Required         int
-	Complete         bool
-	EncodedToken     string `json:"encoded_token"`
+	// Nonce is the operation nonce.
+	Nonce string
+
+	// Started is a boolean indicating whether the operation is started.
+	Started bool
+
+	// Progress is the current root token generation progress.
+	Progress int
+
+	// Required is the number of required keys.
+	Required int
+
+	// Complete is a boolean indicating whether the operation is complete.
+	Complete bool
+
+	// EncodedToken is the encoded token.
+	EncodedToken string `json:"encoded_token"`
+
+	// EncodedRootToken is the encoded root token.
 	EncodedRootToken string `json:"encoded_root_token"`
-	PGPFingerprint   string `json:"pgp_fingerprint"`
+
+	// PGPFingerprint is the PGP fingerprint, if given.
+	PGPFingerprint string `json:"pgp_fingerprint"`
 }

--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -1,13 +1,26 @@
 package api
 
+import (
+	"context"
+	"net/http"
+)
+
+// Health gets the current health of the cluster.
 func (c *Sys) Health() (*HealthResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/health")
+	return c.HealthWithContext(context.Background())
+}
+
+// HealthWithContext gets the current health of the cluster, with a context.
+func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/health")
+	req = req.WithContext(ctx)
+
 	// If the code is 400 or above it will automatically turn into an error,
 	// but the sys/health API defaults to returning 5xx when not sealed or
 	// inited, so we force this code to be something else so we parse correctly
-	r.Params.Add("sealedcode", "299")
-	r.Params.Add("uninitcode", "299")
-	resp, err := c.c.RawRequest(r)
+	req.Params.Add("sealedcode", "299")
+	req.Params.Add("uninitcode", "299")
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -18,12 +31,27 @@ func (c *Sys) Health() (*HealthResponse, error) {
 	return &result, err
 }
 
+// HealthResponse is the result of the health query.
 type HealthResponse struct {
-	Initialized   bool   `json:"initialized"`
-	Sealed        bool   `json:"sealed"`
-	Standby       bool   `json:"standby"`
-	ServerTimeUTC int64  `json:"server_time_utc"`
-	Version       string `json:"version"`
-	ClusterName   string `json:"cluster_name,omitempty"`
-	ClusterID     string `json:"cluster_id,omitempty"`
+	// Initialized returns true if the Vault is currently initialized.
+	Initialized bool `json:"initialized"`
+
+	// Sealed returns true if the Vault is currently sealed.
+	Sealed bool `json:"sealed"`
+
+	// Standby returns true if the Vault is currently in standby (if running in HA
+	// mode).
+	Standby bool `json:"standby"`
+
+	// ServerTimeUTC is the current time of the server in UTC>
+	ServerTimeUTC int64 `json:"server_time_utc"`
+
+	// Version is the Vault version.
+	Version string `json:"version"`
+
+	// ClusterName is the user-supplied or auto-generated cluster name.
+	ClusterName string `json:"cluster_name,omitempty"`
+
+	// ClusterID is the ID of the cluster.
+	ClusterID string `json:"cluster_id,omitempty"`
 }

--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -1,8 +1,22 @@
 package api
 
+import (
+	"context"
+	"net/http"
+)
+
+// InitStatus gets the current status of initialization.
 func (c *Sys) InitStatus() (bool, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/init")
-	resp, err := c.c.RawRequest(r)
+	return c.InitStatusWithContext(context.Background())
+}
+
+// InitStatusWithContext gets the current status of initialization, with a
+// context.
+func (c *Sys) InitStatusWithContext(ctx context.Context) (bool, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/init")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return false, err
 	}
@@ -13,13 +27,20 @@ func (c *Sys) InitStatus() (bool, error) {
 	return result.Initialized, err
 }
 
+// Init initializes the Vault.
 func (c *Sys) Init(opts *InitRequest) (*InitResponse, error) {
-	r := c.c.NewRequest("PUT", "/v1/sys/init")
-	if err := r.SetJSONBody(opts); err != nil {
+	return c.InitWithContext(context.Background(), opts)
+}
+
+// Init initializes the Vault, with a context.
+func (c *Sys) InitWithContext(ctx context.Context, opts *InitRequest) (*InitResponse, error) {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/init")
+	req = req.WithContext(ctx)
+	if err := req.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -30,25 +51,62 @@ func (c *Sys) Init(opts *InitRequest) (*InitResponse, error) {
 	return &result, err
 }
 
+// InitRequest is used as input to the Init and InitWithContext functions.
 type InitRequest struct {
-	SecretShares      int      `json:"secret_shares"`
-	SecretThreshold   int      `json:"secret_threshold"`
-	StoredShares      int      `json:"stored_shares"`
-	PGPKeys           []string `json:"pgp_keys"`
-	RecoveryShares    int      `json:"recovery_shares"`
-	RecoveryThreshold int      `json:"recovery_threshold"`
-	RecoveryPGPKeys   []string `json:"recovery_pgp_keys"`
-	RootTokenPGPKey   string   `json:"root_token_pgp_key"`
+	// SecretShares is the number of keys to generate.
+	SecretShares int `json:"secret_shares"`
+
+	// SecretThreshold is the number of keys that must be supplied to re-generate
+	// the master key. This must be <= SecretShares.
+	SecretThreshold int `json:"secret_threshold"`
+
+	// StoredShares is the number of shares that should be stored on the HSM.
+	// Vault Enterprise only.
+	StoredShares int `json:"stored_shares"`
+
+	// PGPKeys is a list of PGP public keys or keybase usernames to encrypt the
+	// generated key shares with. This must be equal to the number of shares.
+	PGPKeys []string `json:"pgp_keys"`
+
+	// RecoveryShares is the number of recovery shares to generate.
+	RecoveryShares int `json:"recovery_shares"`
+
+	// RecoveryThreshold is the number of keys that must be supplied to
+	// re-generate the recovery key. This must be <= RecoveryShares.
+	RecoveryThreshold int `json:"recovery_threshold"`
+
+	// RecoveryPGPKeys is a list of PGP public keys or keybase usernames to
+	// encrypt the generated key shares with. This must be equal to the number of
+	// recovery shares.
+	RecoveryPGPKeys []string `json:"recovery_pgp_keys"`
+
+	// RootTokenPGPKey is the PGP public key or keybase username to encrypt the
+	// initial root token with.
+	RootTokenPGPKey string `json:"root_token_pgp_key"`
 }
 
+// InitStatusResponse is the response for an init status request.
 type InitStatusResponse struct {
+	// Initialized will be true if the Vault is currently initialized.
 	Initialized bool
 }
 
+// InitResponse is the response for the init request. If any PGP options were
+// given to the init request, the results will be encrypted with the associated
+// PGP key.
 type InitResponse struct {
-	Keys            []string `json:"keys"`
-	KeysB64         []string `json:"keys_base64"`
-	RecoveryKeys    []string `json:"recovery_keys"`
+	// Keys is the list of keys hex-encoded.
+	Keys []string `json:"keys"`
+
+	// KeysB64 is the list of keys base64-encoded.
+	KeysB64 []string `json:"keys_base64"`
+
+	// RecoveryKeys is the list of recovery keys hex-encoded.
+	RecoveryKeys []string `json:"recovery_keys"`
+
+	// RecoveryKeysB64 is the list of recovery keys base64-encoded.
 	RecoveryKeysB64 []string `json:"recovery_keys_base64"`
-	RootToken       string   `json:"root_token"`
+
+	// RootToken is the initial root token.
+	RootToken string `json:"root_token"`
 }

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -1,8 +1,22 @@
 package api
 
+import (
+	"context"
+	"net/http"
+)
+
+// Leader returns information about the current leader.
 func (c *Sys) Leader() (*LeaderResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/leader")
-	resp, err := c.c.RawRequest(r)
+	return c.LeaderWithContext(context.Background())
+}
+
+// LeaderWithContext returns information about the current leader, with a
+// context.
+func (c *Sys) LeaderWithContext(ctx context.Context) (*LeaderResponse, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/leader")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -13,9 +27,19 @@ func (c *Sys) Leader() (*LeaderResponse, error) {
 	return &result, err
 }
 
+// LeaderResponse is the response from a request for leader information.
 type LeaderResponse struct {
-	HAEnabled            bool   `json:"ha_enabled"`
-	IsSelf               bool   `json:"is_self"`
-	LeaderAddress        string `json:"leader_address"`
+	// HAEnabled indicates whether high-availability is enabled.
+	HAEnabled bool `json:"ha_enabled"`
+
+	// IsSelf is a boolean which will be true if the leader is the Vault server
+	// which was queried.
+	IsSelf bool `json:"is_self"`
+
+	// LeaderAddress is the address of the current cluster leader.
+	LeaderAddress string `json:"leader_address"`
+
+	// LeaderClusterAddress is the address to use when addressing the entire
+	// cluster.
 	LeaderClusterAddress string `json:"leader_cluster_address"`
 }

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -1,17 +1,33 @@
 package api
 
+import (
+	"context"
+	"net/http"
+)
+
+// Renew renews the given lease id. The optional increment parameter can be used
+// to request additional time on the lease. Vault does not have to honor this
+// request.
 func (c *Sys) Renew(id string, increment int) (*Secret, error) {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/renew")
+	return c.RenewWithContext(context.Background(), id, increment)
+}
+
+// RenewWithContext renews the given lease id with a context. The optional increment
+// parameter can be used to request additional time on the lease. Vault does not
+// have to honor this request.
+func (c *Sys) RenewWithContext(ctx context.Context, id string, increment int) (*Secret, error) {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/leases/renew")
+	req = req.WithContext(ctx)
 
 	body := map[string]interface{}{
 		"increment": increment,
 		"lease_id":  id,
 	}
-	if err := r.SetJSONBody(body); err != nil {
+	if err := req.SetJSONBody(body); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -20,27 +36,52 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 	return ParseSecret(resp.Body)
 }
 
+// Revoke revokes the given lease id.
 func (c *Sys) Revoke(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke/"+id)
-	resp, err := c.c.RawRequest(r)
+	return c.RevokeWithContext(context.Background(), id)
+}
+
+// RevokeWithContext revokes the given lease id.
+func (c *Sys) RevokeWithContext(ctx context.Context, id string) error {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/leases/revoke/"+id)
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
 	return err
 }
 
+// RevokePrefix revokes all leases which begin with the given prefix.
 func (c *Sys) RevokePrefix(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-prefix/"+id)
-	resp, err := c.c.RawRequest(r)
+	return c.RevokePrefixWithContext(context.Background(), id)
+}
+
+// RevokePrefixWithContext revokes all leases which begin with the given prefix,
+// with a context.
+func (c *Sys) RevokePrefixWithContext(ctx context.Context, id string) error {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/leases/revoke-prefix/"+id)
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
 	return err
 }
 
+// RevokeForce force revokes the given leases.
 func (c *Sys) RevokeForce(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-force/"+id)
-	resp, err := c.c.RawRequest(r)
+	return c.RevokeForceWithContext(context.Background(), id)
+}
+
+// RevokeForceWithContext force revokes the given leases, with a context.
+func (c *Sys) RevokeForceWithContext(ctx context.Context, id string) error {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/leases/revoke-force/"+id)
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -1,15 +1,25 @@
 package api
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/fatih/structs"
 	"github.com/mitchellh/mapstructure"
 )
 
+// ListMounts lists all available mounts.
 func (c *Sys) ListMounts() (map[string]*MountOutput, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/mounts")
-	resp, err := c.c.RawRequest(r)
+	return c.ListMountsWithContext(context.Background())
+}
+
+// ListMountsWithContext lists all available mounts, with a context.
+func (c *Sys) ListMountsWithContext(ctx context.Context) (map[string]*MountOutput, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/mounts")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -43,15 +53,22 @@ func (c *Sys) ListMounts() (map[string]*MountOutput, error) {
 	return mounts, nil
 }
 
+// Mount mounts a new backend at the given path.
 func (c *Sys) Mount(path string, mountInfo *MountInput) error {
-	body := structs.Map(mountInfo)
+	return c.MountWithContext(context.Background(), path, mountInfo)
+}
 
-	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s", path))
-	if err := r.SetJSONBody(body); err != nil {
+// MountWithContext mounts a new backend at the given path, with a context.
+func (c *Sys) MountWithContext(ctx context.Context, path string, mountInfo *MountInput) error {
+	req := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/mounts/%s", path))
+	req = req.WithContext(ctx)
+
+	body := structs.Map(mountInfo)
+	if err := req.SetJSONBody(body); err != nil {
 		return err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return err
 	}
@@ -60,51 +77,85 @@ func (c *Sys) Mount(path string, mountInfo *MountInput) error {
 	return nil
 }
 
+// Unmount unmounts the backend at the given path, if it exits.
 func (c *Sys) Unmount(path string) error {
-	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/mounts/%s", path))
-	resp, err := c.c.RawRequest(r)
+	return c.UnmountWithContext(context.Background(), path)
+}
+
+// UnmountWithContext unmounts the backend at the given path, if it exits, with
+// a context.
+func (c *Sys) UnmountWithContext(ctx context.Context, path string) error {
+	req := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/mounts/%s", path))
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
 	return err
 }
 
+// Remount moves the backend at the "from" to the "to" path.
 func (c *Sys) Remount(from, to string) error {
+	return c.RemountWithContext(context.Background(), from, to)
+}
+
+// RemountWithContext moves the backend at the "from" to the "to" path, with a
+// context.
+func (c *Sys) RemountWithContext(ctx context.Context, from, to string) error {
+	req := c.c.NewRequest(http.MethodPost, "/v1/sys/remount")
+	req = req.WithContext(ctx)
+
 	body := map[string]interface{}{
 		"from": from,
 		"to":   to,
 	}
-
-	r := c.c.NewRequest("POST", "/v1/sys/remount")
-	if err := r.SetJSONBody(body); err != nil {
+	if err := req.SetJSONBody(body); err != nil {
 		return err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
 	return err
 }
 
+// TuneMount tunes the backend mounted at the given path.
 func (c *Sys) TuneMount(path string, config MountConfigInput) error {
+	return c.TuneMountWithContext(context.Background(), path, config)
+}
+
+// TuneMountWithContext tunes the backend mounted at the given path, with a
+// context.
+func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config MountConfigInput) error {
+	req := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
+	req = req.WithContext(ctx)
+
 	body := structs.Map(config)
-	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
-	if err := r.SetJSONBody(body); err != nil {
+	if err := req.SetJSONBody(body); err != nil {
 		return err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
 	return err
 }
 
+// MountConfig returns the configuration for the mount at the given path.
 func (c *Sys) MountConfig(path string) (*MountConfigOutput, error) {
-	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
+	return c.MountConfigWithContext(context.Background(), path)
+}
 
-	resp, err := c.c.RawRequest(r)
+// MountConfigWithContext returns the configuration for the mount at the given
+// path, with a context.
+func (c *Sys) MountConfigWithContext(ctx context.Context, path string) (*MountConfigOutput, error) {
+	req := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -119,34 +170,80 @@ func (c *Sys) MountConfig(path string) (*MountConfigOutput, error) {
 	return &result, err
 }
 
+// MountInput is used as input to the mount function for mounting a new backend.
 type MountInput struct {
-	Type        string           `json:"type" structs:"type"`
-	Description string           `json:"description" structs:"description"`
-	Config      MountConfigInput `json:"config" structs:"config"`
-	Local       bool             `json:"local" structs:"local"`
-	PluginName  string           `json:"plugin_name,omitempty" structs:"plugin_name"`
-	SealWrap    bool             `json:"seal_wrap" structs:"seal_wrap" mapstructure:"seal_wrap"`
+	// Type is the type of backend to mount.
+	Type string `json:"type" structs:"type"`
+
+	// Description is an optional human-friendly description of the backend.
+	Description string `json:"description" structs:"description"`
+
+	// Config is configuration information such as the default leases and
+	// replication behavior.
+	Config MountConfigInput `json:"config" structs:"config"`
+
+	// Local is a boolean representing that this mount is local-only (should not
+	// replicate).
+	Local bool `json:"local" structs:"local"`
+
+	// PluginName is the name of the plugin to use for this mount (if type ==
+	// "plugin").
+	PluginName string `json:"plugin_name,omitempty" structs:"plugin_name"`
+
+	// SealWrap is a boolean indicating whether to use a seal wrap.
+	SealWrap bool `json:"seal_wrap" structs:"seal_wrap" mapstructure:"seal_wrap"`
 }
 
+// MountConfigInput is used as input about the mount configuration.
 type MountConfigInput struct {
+	// DefaultLeaseTTL is the default minimum lease.
 	DefaultLeaseTTL string `json:"default_lease_ttl" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"`
-	MaxLeaseTTL     string `json:"max_lease_ttl" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`
-	ForceNoCache    bool   `json:"force_no_cache" structs:"force_no_cache" mapstructure:"force_no_cache"`
-	PluginName      string `json:"plugin_name,omitempty" structs:"plugin_name,omitempty" mapstructure:"plugin_name"`
+
+	// MaxLeaseTTL is the default maximum lease.
+	MaxLeaseTTL string `json:"max_lease_ttl" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`
+
+	// ForceNoCache forces the mount to not use caching.
+	ForceNoCache bool `json:"force_no_cache" structs:"force_no_cache" mapstructure:"force_no_cache"`
+
+	// PluginName is the name of the plugin to use for the mount (if type ==
+	// "plugin").
+	PluginName string `json:"plugin_name,omitempty" structs:"plugin_name,omitempty" mapstructure:"plugin_name"`
 }
 
+// MountOutput is specific output about a mount.
 type MountOutput struct {
-	Type        string            `json:"type" structs:"type"`
-	Description string            `json:"description" structs:"description"`
-	Accessor    string            `json:"accessor" structs:"accessor"`
-	Config      MountConfigOutput `json:"config" structs:"config"`
-	Local       bool              `json:"local" structs:"local"`
-	SealWrap    bool              `json:"seal_wrap" structs:"seal_wrap" mapstructure:"seal_wrap"`
+	// Type is the type of mount.
+	Type string `json:"type" structs:"type"`
+
+	// Description is the human-friendly description of the mount, if one was
+	// given.
+	Description string `json:"description" structs:"description"`
+
+	// Accessor is the mount accessor.
+	Accessor string `json:"accessor" structs:"accessor"`
+
+	// Config is the configuration information for the mount.
+	Config MountConfigOutput `json:"config" structs:"config"`
+
+	// Local is a boolean representing whether this mount is replicated.
+	Local bool `json:"local" structs:"local"`
+
+	// SealWrap is a boolean indicating whether this mount has a seal wrap.
+	SealWrap bool `json:"seal_wrap" structs:"seal_wrap" mapstructure:"seal_wrap"`
 }
 
+// MountConfigOutput is the mount configuration.
 type MountConfigOutput struct {
-	DefaultLeaseTTL int    `json:"default_lease_ttl" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"`
-	MaxLeaseTTL     int    `json:"max_lease_ttl" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`
-	ForceNoCache    bool   `json:"force_no_cache" structs:"force_no_cache" mapstructure:"force_no_cache"`
-	PluginName      string `json:"plugin_name,omitempty" structs:"plugin_name,omitempty" mapstructure:"plugin_name"`
+	// DefaultLeaseTTL is the default minimum lease.
+	DefaultLeaseTTL int `json:"default_lease_ttl" structs:"default_lease_ttl" mapstructure:"default_lease_ttl"`
+
+	// MaxLeaseTTL is the default maximum lease.
+	MaxLeaseTTL int `json:"max_lease_ttl" structs:"max_lease_ttl" mapstructure:"max_lease_ttl"`
+
+	// ForceNoCache forces the mount to not use caching.
+	ForceNoCache bool `json:"force_no_cache" structs:"force_no_cache" mapstructure:"force_no_cache"`
+
+	// PluginName is the name of the plugin to use for the mount (if type ==
+	// "plugin").
+	PluginName string `json:"plugin_name,omitempty" structs:"plugin_name,omitempty" mapstructure:"plugin_name"`
 }

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -1,10 +1,23 @@
 package api
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
 
+// ListPolicies returns a string list of all policies.
 func (c *Sys) ListPolicies() ([]string, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/policy")
-	resp, err := c.c.RawRequest(r)
+	return c.ListPoliciesWithContext(context.Background())
+}
+
+// ListPoliciesWithContext returns a string list of all policies, with a
+// context.
+func (c *Sys) ListPoliciesWithContext(ctx context.Context) ([]string, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/policy")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -31,9 +44,18 @@ func (c *Sys) ListPolicies() ([]string, error) {
 	return policies, err
 }
 
+// GetPolicy retrieves the contents of the given policy by name.
 func (c *Sys) GetPolicy(name string) (string, error) {
-	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/policy/%s", name))
-	resp, err := c.c.RawRequest(r)
+	return c.GetPolicyWithContext(context.Background(), name)
+}
+
+// GetPolicyWithContext retrieves the contents of the given policy by name, with
+// a context.
+func (c *Sys) GetPolicyWithContext(ctx context.Context, name string) (string, error) {
+	req := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/policy/%s", name))
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if resp != nil {
 		defer resp.Body.Close()
 		if resp.StatusCode == 404 {
@@ -60,17 +82,25 @@ func (c *Sys) GetPolicy(name string) (string, error) {
 	return "", fmt.Errorf("no policy found in response")
 }
 
+// PutPolicy creates a new or updates an existing policy.
 func (c *Sys) PutPolicy(name, rules string) error {
+	return c.PutPolicyWithContext(context.Background(), name, rules)
+}
+
+// PutPolicyWithContext creates a new or updates an existing policy, with a
+// context.
+func (c *Sys) PutPolicyWithContext(ctx context.Context, name, rules string) error {
 	body := map[string]string{
 		"rules": rules,
 	}
 
-	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/sys/policy/%s", name))
-	if err := r.SetJSONBody(body); err != nil {
+	req := c.c.NewRequest(http.MethodPut, fmt.Sprintf("/v1/sys/policy/%s", name))
+	req = req.WithContext(ctx)
+	if err := req.SetJSONBody(body); err != nil {
 		return err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return err
 	}
@@ -79,9 +109,18 @@ func (c *Sys) PutPolicy(name, rules string) error {
 	return nil
 }
 
+// DeletePolicy deletes the policy by the given name, if it exists.
 func (c *Sys) DeletePolicy(name string) error {
-	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/policy/%s", name))
-	resp, err := c.c.RawRequest(r)
+	return c.DeletePolicyWithContext(context.Background(), name)
+}
+
+// DeletePolicyWithContext deletes the policy by the given name, if it exists,
+// with a context.
+func (c *Sys) DeletePolicyWithContext(ctx context.Context, name string) error {
+	req := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/policy/%s", name))
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -1,8 +1,19 @@
 package api
 
+import (
+	"context"
+	"net/http"
+)
+
 func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/init")
-	resp, err := c.c.RawRequest(r)
+	return c.RekeyStatusWithContext(context.Background())
+}
+
+func (c *Sys) RekeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/rekey/init")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -14,8 +25,14 @@ func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
 }
 
 func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/init")
-	resp, err := c.c.RawRequest(r)
+	return c.RekeyRecoveryKeyStatusWithContext(context.Background())
+}
+
+func (c *Sys) RekeyRecoveryKeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/rekey-recovery-key/init")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -27,12 +44,18 @@ func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
 }
 
 func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
-	r := c.c.NewRequest("PUT", "/v1/sys/rekey/init")
-	if err := r.SetJSONBody(config); err != nil {
+	return c.RekeyInitWithContext(context.Background(), config)
+}
+
+func (c *Sys) RekeyInitWithContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/rekey/init")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(config); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -44,12 +67,18 @@ func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) 
 }
 
 func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
-	r := c.c.NewRequest("PUT", "/v1/sys/rekey-recovery-key/init")
-	if err := r.SetJSONBody(config); err != nil {
+	return c.RekeyRecoveryKeyInitWithContext(context.Background(), config)
+}
+
+func (c *Sys) RekeyRecoveryKeyInitWithContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/rekey-recovery-key/init")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(config); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +90,14 @@ func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusRespon
 }
 
 func (c *Sys) RekeyCancel() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/init")
-	resp, err := c.c.RawRequest(r)
+	return c.RekeyCancelWithContext(context.Background())
+}
+
+func (c *Sys) RekeyCancelWithContext(ctx context.Context) error {
+	req := c.c.NewRequest(http.MethodDelete, "/v1/sys/rekey/init")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -70,8 +105,14 @@ func (c *Sys) RekeyCancel() error {
 }
 
 func (c *Sys) RekeyRecoveryKeyCancel() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/init")
-	resp, err := c.c.RawRequest(r)
+	return c.RekeyRecoveryKeyCancelWithContext(context.Background())
+}
+
+func (c *Sys) RekeyRecoveryKeyCancelWithContext(ctx context.Context) error {
+	req := c.c.NewRequest(http.MethodDelete, "/v1/sys/rekey-recovery-key/init")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -79,17 +120,23 @@ func (c *Sys) RekeyRecoveryKeyCancel() error {
 }
 
 func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
+	return c.RekeyUpdateWithContext(context.Background(), shard, nonce)
+}
+
+func (c *Sys) RekeyUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
 	}
 
-	r := c.c.NewRequest("PUT", "/v1/sys/rekey/update")
-	if err := r.SetJSONBody(body); err != nil {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/rekey/update")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(body); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -101,17 +148,23 @@ func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
 }
 
 func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
+	return c.RekeyRecoveryKeyUpdateWithContext(context.Background(), shard, nonce)
+}
+
+func (c *Sys) RekeyRecoveryKeyUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
 	}
 
-	r := c.c.NewRequest("PUT", "/v1/sys/rekey-recovery-key/update")
-	if err := r.SetJSONBody(body); err != nil {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/rekey-recovery-key/update")
+	req = req.WithContext(ctx)
+
+	if err := req.SetJSONBody(body); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequest(r)
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -123,8 +176,14 @@ func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse,
 }
 
 func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/backup")
-	resp, err := c.c.RawRequest(r)
+	return c.RekeyRetrieveBackupWithContext(context.Background())
+}
+
+func (c *Sys) RekeyRetrieveBackupWithContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/rekey/backup")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -136,8 +195,14 @@ func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
 }
 
 func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/recovery-backup")
-	resp, err := c.c.RawRequest(r)
+	return c.RekeyRetrieveRecoveryBackupWithContext(context.Background())
+}
+
+func (c *Sys) RekeyRetrieveRecoveryBackupWithContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/rekey/recovery-backup")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -149,8 +214,14 @@ func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
 }
 
 func (c *Sys) RekeyDeleteBackup() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/backup")
-	resp, err := c.c.RawRequest(r)
+	return c.RekeyDeleteBackupWithContext(context.Background())
+}
+
+func (c *Sys) RekeyDeleteBackupWithContext(ctx context.Context) error {
+	req := c.c.NewRequest(http.MethodDelete, "/v1/sys/rekey/backup")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -159,8 +230,14 @@ func (c *Sys) RekeyDeleteBackup() error {
 }
 
 func (c *Sys) RekeyDeleteRecoveryBackup() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/recovery-backup")
-	resp, err := c.c.RawRequest(r)
+	return c.RekeyDeleteRecoveryBackupWithContext(context.Background())
+}
+
+func (c *Sys) RekeyDeleteRecoveryBackupWithContext(ctx context.Context) error {
+	req := c.c.NewRequest(http.MethodDelete, "/v1/sys/rekey/recovery-backup")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -168,36 +245,78 @@ func (c *Sys) RekeyDeleteRecoveryBackup() error {
 	return err
 }
 
+// RekeyInitRequest is used as input to the rekey request.
 type RekeyInitRequest struct {
-	SecretShares    int      `json:"secret_shares"`
-	SecretThreshold int      `json:"secret_threshold"`
-	StoredShares    int      `json:"stored_shares"`
-	PGPKeys         []string `json:"pgp_keys"`
-	Backup          bool
+	// SecretShares is the new number of secret shares to use.
+	SecretShares int `json:"secret_shares"`
+
+	// SecretThreshold is the new number of secret threshold to use/
+	SecretThreshold int `json:"secret_threshold"`
+
+	// StoredShares is the new number of shares to store on the HSM.
+	StoredShares int `json:"stored_shares"`
+
+	// PGPKeys is the list of PGP keys to encrypt the new keys.
+	PGPKeys []string `json:"pgp_keys"`
+
+	// Backup is a boolean indicating if Vault should backup the current keys in
+	// case of rekeying failure.
+	Backup bool
 }
 
+// RekeyStatusResponse is the response from a rekey operation.
 type RekeyStatusResponse struct {
-	Nonce           string
-	Started         bool
-	T               int
-	N               int
-	Progress        int
-	Required        int
+	// Nonce is the operation nonce.
+	Nonce string
+
+	// Started is a boolean indicating if the rekeying operation is started.
+	Started bool
+
+	// T is the new threshold.
+	T int
+
+	// N is the new number of shares.
+	N int
+
+	// Progress is the current rekey progress, if any.
+	Progress int
+
+	// Required is the number of required shards to complete the rekey.
+	Required int
+
+	// PGPFingerprints is the list of PGP fingerprints, if given.
 	PGPFingerprints []string `json:"pgp_fingerprints"`
-	Backup          bool
+
+	// Backup is a bool indicating whether the rekey operation is backed up.
+	Backup bool
 }
 
+// RekeyUpdateResponse is the response when a user submits an unseal key.
 type RekeyUpdateResponse struct {
-	Nonce           string
-	Complete        bool
-	Keys            []string
-	KeysB64         []string `json:"keys_base64"`
+	// Nonce is the operation nonce.
+	Nonce string
+
+	// Complete is a boolean indicating if the rekey is complete.
+	Complete bool
+
+	// Keys is the list of unseal keys hex-encoded.
+	Keys []string
+
+	// KeysB64 is the list of unseal keys base64-encoded.
+	KeysB64 []string `json:"keys_base64"`
+
+	// PGPFingerprints is the list of PGP fingerprints, if given.
 	PGPFingerprints []string `json:"pgp_fingerprints"`
-	Backup          bool
+
+	// Backup is a bool indicating whether the rekey operation is backed up.
+	Backup bool
 }
 
+// RekeyRetrieveResponse is the response for getting the backup.
 type RekeyRetrieveResponse struct {
-	Nonce   string
+	// Nonce is the operation nonce.
+	Nonce string
+
 	Keys    map[string][]string
 	KeysB64 map[string][]string `json:"keys_base64"`
 }

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -1,19 +1,40 @@
 package api
 
-import "time"
+import (
+	"context"
+	"net/http"
+	"time"
+)
 
+// Rotate triggers a rotation of Vault's underlying encryption key.
 func (c *Sys) Rotate() error {
-	r := c.c.NewRequest("POST", "/v1/sys/rotate")
-	resp, err := c.c.RawRequest(r)
+	return c.RotateWithContext(context.Background())
+}
+
+// RotateWithContext triggers a rotation of Vault's underlying encryption key,
+// with a context.
+func (c *Sys) RotateWithContext(ctx context.Context) error {
+	req := c.c.NewRequest(http.MethodPost, "/v1/sys/rotate")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
 	return err
 }
 
+// KeyStatus returns the current key status of Vault.
 func (c *Sys) KeyStatus() (*KeyStatus, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/key-status")
-	resp, err := c.c.RawRequest(r)
+	return c.KeyStatusWithContext(context.Background())
+}
+
+// KeyStatusWithContext returns the current key status of Vault, with a context.
+func (c *Sys) KeyStatusWithContext(ctx context.Context) (*KeyStatus, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/key-status")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -24,7 +45,11 @@ func (c *Sys) KeyStatus() (*KeyStatus, error) {
 	return result, err
 }
 
+// KeyStatus is the result of a key status query.
 type KeyStatus struct {
-	Term        int       `json:"term"`
+	// Term is the current key term.
+	Term int `json:"term"`
+
+	// InstallTime is the time where the key was installed.
 	InstallTime time.Time `json:"install_time"`
 }

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -1,39 +1,78 @@
 package api
 
+import (
+	"context"
+	"net/http"
+)
+
+// SealStatus returns the seal status for the Vault server the client is
+// pointing to.
 func (c *Sys) SealStatus() (*SealStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/seal-status")
-	return sealStatusRequest(c, r)
+	return c.SealStatusWithContext(context.Background())
 }
 
+// SealStatusWithContext returns the seal status for the Vault server the client
+// is pointing to, with a context.
+func (c *Sys) SealStatusWithContext(ctx context.Context) (*SealStatusResponse, error) {
+	req := c.c.NewRequest(http.MethodGet, "/v1/sys/seal-status")
+	req = req.WithContext(ctx)
+	return sealStatusRequest(c, req)
+}
+
+// Seal seals the Vault server.
 func (c *Sys) Seal() error {
-	r := c.c.NewRequest("PUT", "/v1/sys/seal")
-	resp, err := c.c.RawRequest(r)
+	return c.SealWithContext(context.Background())
+}
+
+// SealWithContext seals the Vault server, with a context.
+func (c *Sys) SealWithContext(ctx context.Context) error {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/seal")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
 	return err
 }
 
+// ResetUnsealProcess resets an unseal process back to zero, discarding any
+// entered shares.
 func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
-	body := map[string]interface{}{"reset": true}
-
-	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
-	if err := r.SetJSONBody(body); err != nil {
-		return nil, err
-	}
-
-	return sealStatusRequest(c, r)
+	return c.ResetUnsealProcessWithContext(context.Background())
 }
 
-func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
-	body := map[string]interface{}{"key": shard}
+// ResetUnsealProcessWithContext resets an unseal process back to zero,
+// discarding any entered shares, with a context.
+func (c *Sys) ResetUnsealProcessWithContext(ctx context.Context) (*SealStatusResponse, error) {
+	body := map[string]interface{}{"reset": true}
 
-	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
-	if err := r.SetJSONBody(body); err != nil {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/unseal")
+	req = req.WithContext(ctx)
+	if err := req.SetJSONBody(body); err != nil {
 		return nil, err
 	}
 
-	return sealStatusRequest(c, r)
+	return sealStatusRequest(c, req)
+}
+
+// Unseal is used to supply one piece of the unseal key.
+func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
+	return c.UnsealWithContext(context.Background(), shard)
+}
+
+// UnsealWithContext is used to supply one piece of the unseal key, with a
+// context.
+func (c *Sys) UnsealWithContext(ctx context.Context, shard string) (*SealStatusResponse, error) {
+	body := map[string]interface{}{"key": shard}
+
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/unseal")
+	req = req.WithContext(ctx)
+	if err := req.SetJSONBody(body); err != nil {
+		return nil, err
+	}
+
+	return sealStatusRequest(c, req)
 }
 
 func sealStatusRequest(c *Sys, r *Request) (*SealStatusResponse, error) {
@@ -48,14 +87,32 @@ func sealStatusRequest(c *Sys, r *Request) (*SealStatusResponse, error) {
 	return &result, err
 }
 
+// SealStatusResponse is the response returned from a seal status request.
 type SealStatusResponse struct {
-	Type        string `json:"type"`
-	Sealed      bool   `json:"sealed"`
-	T           int    `json:"t"`
-	N           int    `json:"n"`
-	Progress    int    `json:"progress"`
-	Nonce       string `json:"nonce"`
-	Version     string `json:"version"`
+	// Type is the type of seal implored.
+	Type string `json:"type"`
+
+	// Sealed indicates if the Vault is sealed.
+	Sealed bool `json:"sealed"`
+
+	// T is the threshold of shares.
+	T int `json:"t"`
+
+	// N is the total number of shares.
+	N int `json:"n"`
+
+	// Progress is the current unseal progress, if any.
+	Progress int `json:"progress"`
+
+	// None is the current nonce operation.
+	Nonce string `json:"nonce"`
+
+	// Version is the Vault version.
+	Version string `json:"version"`
+
+	// ClusterName is the user-supplied or auto-generated cluster name.
 	ClusterName string `json:"cluster_name,omitempty"`
-	ClusterID   string `json:"cluster_id,omitempty"`
+
+	// ClusterID is the ID of the cluster.
+	ClusterID string `json:"cluster_id,omitempty"`
 }

--- a/api/sys_stepdown.go
+++ b/api/sys_stepdown.go
@@ -1,8 +1,22 @@
 package api
 
+import (
+	"context"
+	"net/http"
+)
+
+// StepDown sends an API call to the client to inform it to give up leadership.
 func (c *Sys) StepDown() error {
-	r := c.c.NewRequest("PUT", "/v1/sys/step-down")
-	resp, err := c.c.RawRequest(r)
+	return c.StepDownWithContext(context.Background())
+}
+
+// StepDown sends an API call to the client to inform it to give up leadership,
+// with a context.
+func (c *Sys) StepDownWithContext(ctx context.Context) error {
+	req := c.c.NewRequest(http.MethodPut, "/v1/sys/step-down")
+	req = req.WithContext(ctx)
+
+	resp, err := c.c.RawRequest(req)
 	if err == nil {
 		defer resp.Body.Close()
 	}


### PR DESCRIPTION
This PR adds support for Golang's [context.Context](https://golang.org/pkg/context) in the `api` package and also improves the API package documentation.