### PR TITLE
Docs: mlock() notes, fixes #3605

### DIFF
--- a/website/source/docs/configuration/index.html.md
+++ b/website/source/docs/configuration/index.html.md
@@ -88,6 +88,8 @@ to specify where the configuration is.
     sudo setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
     ```
 
+    If you use a Linux distribution with systemd, you can also add the above `setcap` command as an [ExecStartPre](https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStartPre=) additional command in your Vault unit file to ensure that `mlock()` capability is added to the `vault` binary before executing.
+
 - `plugin_directory` `(string: "")` – A directory from which plugins are
   allowed to be loaded. Vault must have permission to read files in this
   directory to successfully load plugins.

--- a/website/source/guides/upgrading/index.html.md
+++ b/website/source/guides/upgrading/index.html.md
@@ -63,7 +63,7 @@ active duty. To do this:
    If you kill Vault without letting it release the lock, a standby node will
    not be able to take over until the lock's timeout period has expired. This
    is backend-specific but could be ten seconds or more.
-2. Replace the Vault binary with the new version
+2. Replace the Vault binary with the new version; ensure that `mlock()` capability is added to the new binary with [setcap](https://www.vaultproject.io/docs/configuration/index.html#disable_mlock)
 3. Start the node
 4. Unseal the node (it will now be a standby)
 


### PR DESCRIPTION
- Add note in upgrading section about ensuring that `mlock()` is on the new binary
- Add systemd `ExecStartPre` note to configuration section
