### PR TITLE
Converting key_usage and allowed_domains in PKI to CommaStringSlice

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1594,38 +1594,38 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 			roleVals.CodeSigningFlag = false
 			roleVals.EmailProtectionFlag = false
 
-			var usage string
+			var usage []string
 			if mathRand.Int()%2 == 1 {
-				usage = usage + ",DigitalSignature"
+				usage = append(usage, "DigitalSignature")
 			}
 			if mathRand.Int()%2 == 1 {
-				usage = usage + ",ContentCoMmitment"
+				usage = append(usage, "ContentCoMmitment")
 			}
 			if mathRand.Int()%2 == 1 {
-				usage = usage + ",KeyEncipherment"
+				usage = append(usage, "KeyEncipherment")
 			}
 			if mathRand.Int()%2 == 1 {
-				usage = usage + ",DataEncipherment"
+				usage = append(usage, "DataEncipherment")
 			}
 			if mathRand.Int()%2 == 1 {
-				usage = usage + ",KeyAgreemEnt"
+				usage = append(usage, "KeyAgreemEnt")
 			}
 			if mathRand.Int()%2 == 1 {
-				usage = usage + ",CertSign"
+				usage = append(usage, "CertSign")
 			}
 			if mathRand.Int()%2 == 1 {
-				usage = usage + ",CRLSign"
+				usage = append(usage, "CRLSign")
 			}
 			if mathRand.Int()%2 == 1 {
-				usage = usage + ",EncipherOnly"
+				usage = append(usage, "EncipherOnly")
 			}
 			if mathRand.Int()%2 == 1 {
-				usage = usage + ",DecipherOnly"
+				usage = append(usage, "DecipherOnly")
 			}
 
 			roleVals.KeyUsage = usage
 			parsedKeyUsage := parseKeyUsages(roleVals.KeyUsage)
-			if parsedKeyUsage == 0 && usage != "" {
+			if parsedKeyUsage == 0 && len(usage) != 0 {
 				panic("parsed key usages was zero")
 			}
 			parsedKeyUsageUnderTest = parsedKeyUsage

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1463,7 +1463,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		//t.Logf("test step %d\nrole vals: %#v\n", stepCount, roleVals)
 		stepCount++
 		//t.Logf("test step %d\nissue vals: %#v\n", stepCount, issueTestStep)
-		roleTestStep.Data = structs.New(roleVals).Map()
+		roleTestStep.Data = roleVals.ToResponseData()
 		roleTestStep.Data["generate_lease"] = false
 		ret = append(ret, roleTestStep)
 		issueTestStep.Data = structs.New(issueVals).Map()

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1759,10 +1759,10 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		commonNames.Localhost = true
 		addCnTests()
 
-		roleVals.AllowedDomains = "foobar.com"
+		roleVals.AllowedDomains = []string{"foobar.com"}
 		addCnTests()
 
-		roleVals.AllowedDomains = "example.com"
+		roleVals.AllowedDomains = []string{"example.com"}
 		roleVals.AllowSubdomains = true
 		commonNames.SubDomain = true
 		commonNames.Wildcard = true
@@ -1770,13 +1770,13 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		commonNames.SubSubdomainWildcard = true
 		addCnTests()
 
-		roleVals.AllowedDomains = "foobar.com,example.com"
+		roleVals.AllowedDomains = []string{"foobar.com", "example.com"}
 		commonNames.SecondDomain = true
 		roleVals.AllowBareDomains = true
 		commonNames.BareDomain = true
 		addCnTests()
 
-		roleVals.AllowedDomains = "foobar.com,*example.com"
+		roleVals.AllowedDomains = []string{"foobar.com", "*example.com"}
 		roleVals.AllowGlobDomains = true
 		commonNames.GlobDomain = true
 		addCnTests()

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -375,9 +375,9 @@ func validateNames(req *logical.Request, names []string, role *roleEntry) string
 			}
 		}
 
-		if role.AllowedDomains != "" {
+		if len(role.AllowedDomains) > 0 {
 			valid := false
-			for _, currDomain := range strings.Split(role.AllowedDomains, ",") {
+			for _, currDomain := range role.AllowedDomains {
 				// If there is, say, a trailing comma, ignore it
 				if currDomain == "" {
 					continue

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -159,7 +159,7 @@ the key_type.`,
 			"key_usage": &framework.FieldSchema{
 				Type:    framework.TypeCommaStringSlice,
 				Default: []string{"DigitalSignature", "KeyAgreement", "KeyEncipherment"},
-				Description: `A comma-separate string or list of key usages (not extended
+				Description: `A comma-separated string or list of key usages (not extended
 key usages). Valid values can be found at
 https://golang.org/pkg/crypto/x509/#KeyUsage
 -- simply drop the "KeyUsage" part of the name.

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/structs"
 	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
@@ -358,22 +357,8 @@ func (b *backend) pathRoleRead(
 	}
 
 	resp := &logical.Response{
-		Data: structs.New(role).Map(),
+		Data: role.ToResponseData(),
 	}
-
-	if resp.Data == nil {
-		return nil, fmt.Errorf("error converting role data to response")
-	}
-
-	// These values are deprecated and the entries are migrated on read
-	delete(resp.Data, "lease")
-	delete(resp.Data, "lease_max")
-	delete(resp.Data, "allowed_base_domain")
-	delete(resp.Data, "allow_base_domain")
-	delete(resp.Data, "AllowExpirationPastCA")
-	delete(resp.Data, "key_usage_old")
-	delete(resp.Data, "allowed_domains_old")
-
 	return resp, nil
 }
 
@@ -513,40 +498,75 @@ func parseKeyUsages(input []string) int {
 }
 
 type roleEntry struct {
-	LeaseMax              string   `json:"lease_max" structs:"lease_max" mapstructure:"lease_max"`
-	Lease                 string   `json:"lease" structs:"lease" mapstructure:"lease"`
-	MaxTTL                string   `json:"max_ttl" structs:"max_ttl" mapstructure:"max_ttl"`
-	TTL                   string   `json:"ttl" structs:"ttl" mapstructure:"ttl"`
-	AllowLocalhost        bool     `json:"allow_localhost" structs:"allow_localhost" mapstructure:"allow_localhost"`
-	AllowedBaseDomain     string   `json:"allowed_base_domain" structs:"allowed_base_domain" mapstructure:"allowed_base_domain"`
-	AllowedDomainsOld     string   `json:"allowed_domains,omit_empty" structs:"allowed_domains_old" mapstructure:"allowed_domains_old"`
-	AllowedDomains        []string `json:"allowed_domains_list" structs:"allowed_domains" mapstructure:"allowed_domains"`
-	AllowBaseDomain       bool     `json:"allow_base_domain" structs:"allow_base_domain" mapstructure:"allow_base_domain"`
-	AllowBareDomains      bool     `json:"allow_bare_domains" structs:"allow_bare_domains" mapstructure:"allow_bare_domains"`
-	AllowTokenDisplayName bool     `json:"allow_token_displayname" structs:"allow_token_displayname" mapstructure:"allow_token_displayname"`
-	AllowSubdomains       bool     `json:"allow_subdomains" structs:"allow_subdomains" mapstructure:"allow_subdomains"`
-	AllowGlobDomains      bool     `json:"allow_glob_domains" structs:"allow_glob_domains" mapstructure:"allow_glob_domains"`
-	AllowAnyName          bool     `json:"allow_any_name" structs:"allow_any_name" mapstructure:"allow_any_name"`
-	EnforceHostnames      bool     `json:"enforce_hostnames" structs:"enforce_hostnames" mapstructure:"enforce_hostnames"`
-	AllowIPSANs           bool     `json:"allow_ip_sans" structs:"allow_ip_sans" mapstructure:"allow_ip_sans"`
-	ServerFlag            bool     `json:"server_flag" structs:"server_flag" mapstructure:"server_flag"`
-	ClientFlag            bool     `json:"client_flag" structs:"client_flag" mapstructure:"client_flag"`
-	CodeSigningFlag       bool     `json:"code_signing_flag" structs:"code_signing_flag" mapstructure:"code_signing_flag"`
-	EmailProtectionFlag   bool     `json:"email_protection_flag" structs:"email_protection_flag" mapstructure:"email_protection_flag"`
-	UseCSRCommonName      bool     `json:"use_csr_common_name" structs:"use_csr_common_name" mapstructure:"use_csr_common_name"`
-	UseCSRSANs            bool     `json:"use_csr_sans" structs:"use_csr_sans" mapstructure:"use_csr_sans"`
-	KeyType               string   `json:"key_type" structs:"key_type" mapstructure:"key_type"`
-	KeyBits               int      `json:"key_bits" structs:"key_bits" mapstructure:"key_bits"`
-	MaxPathLength         *int     `json:",omitempty" structs:"max_path_length,omitempty" mapstructure:"max_path_length"`
-	KeyUsageOld           string   `json:"key_usage,omitempty" structs:"key_usage_old" mapstructure:"key_usage_old"`
-	KeyUsage              []string `json:"key_usage_list" structs:"key_usage" mapstructure:"key_usage"`
-	OU                    string   `json:"ou" structs:"ou" mapstructure:"ou"`
-	Organization          string   `json:"organization" structs:"organization" mapstructure:"organization"`
-	GenerateLease         *bool    `json:"generate_lease,omitempty" structs:"generate_lease,omitempty"`
-	NoStore               bool     `json:"no_store" structs:"no_store" mapstructure:"no_store"`
+	LeaseMax              string   `json:"lease_max"`
+	Lease                 string   `json:"lease"`
+	MaxTTL                string   `json:"max_ttl" mapstructure:"max_ttl"`
+	TTL                   string   `json:"ttl" mapstructure:"ttl"`
+	AllowLocalhost        bool     `json:"allow_localhost" mapstructure:"allow_localhost"`
+	AllowedBaseDomain     string   `json:"allowed_base_domain" mapstructure:"allowed_base_domain"`
+	AllowedDomainsOld     string   `json:"allowed_domains,omit_empty"`
+	AllowedDomains        []string `json:"allowed_domains_list" mapstructure:"allowed_domains"`
+	AllowBaseDomain       bool     `json:"allow_base_domain"`
+	AllowBareDomains      bool     `json:"allow_bare_domains" mapstructure:"allow_bare_domains"`
+	AllowTokenDisplayName bool     `json:"allow_token_displayname" mapstructure:"allow_token_displayname"`
+	AllowSubdomains       bool     `json:"allow_subdomains" mapstructure:"allow_subdomains"`
+	AllowGlobDomains      bool     `json:"allow_glob_domains" mapstructure:"allow_glob_domains"`
+	AllowAnyName          bool     `json:"allow_any_name" mapstructure:"allow_any_name"`
+	EnforceHostnames      bool     `json:"enforce_hostnames" mapstructure:"enforce_hostnames"`
+	AllowIPSANs           bool     `json:"allow_ip_sans" mapstructure:"allow_ip_sans"`
+	ServerFlag            bool     `json:"server_flag" mapstructure:"server_flag"`
+	ClientFlag            bool     `json:"client_flag" mapstructure:"client_flag"`
+	CodeSigningFlag       bool     `json:"code_signing_flag" mapstructure:"code_signing_flag"`
+	EmailProtectionFlag   bool     `json:"email_protection_flag" mapstructure:"email_protection_flag"`
+	UseCSRCommonName      bool     `json:"use_csr_common_name" mapstructure:"use_csr_common_name"`
+	UseCSRSANs            bool     `json:"use_csr_sans" mapstructure:"use_csr_sans"`
+	KeyType               string   `json:"key_type" mapstructure:"key_type"`
+	KeyBits               int      `json:"key_bits" mapstructure:"key_bits"`
+	MaxPathLength         *int     `json:",omitempty" mapstructure:"max_path_length"`
+	KeyUsageOld           string   `json:"key_usage,omitempty"`
+	KeyUsage              []string `json:"key_usage_list" mapstructure:"key_usage"`
+	OU                    string   `json:"ou" mapstructure:"ou"`
+	Organization          string   `json:"organization" mapstructure:"organization"`
+	GenerateLease         *bool    `json:"generate_lease,omitempty"`
+	NoStore               bool     `json:"no_store" mapstructure:"no_store"`
 
 	// Used internally for signing intermediates
 	AllowExpirationPastCA bool
+}
+
+func (r *roleEntry) ToResponseData() map[string]interface{} {
+	responseData := map[string]interface{}{
+		"ttl":                     r.TTL,
+		"max_ttl":                 r.MaxTTL,
+		"allow_localhost":         r.AllowLocalhost,
+		"allowed_domains":         r.AllowedDomains,
+		"allow_bare_domains":      r.AllowBareDomains,
+		"allow_token_displayname": r.AllowTokenDisplayName,
+		"allow_subdomains":        r.AllowSubdomains,
+		"allow_glob_domains":      r.AllowGlobDomains,
+		"allow_any_name":          r.AllowAnyName,
+		"enforce_hostnames":       r.EnforceHostnames,
+		"allow_ip_sans":           r.AllowIPSANs,
+		"server_flag":             r.ServerFlag,
+		"client_flag":             r.ClientFlag,
+		"code_signing_flag":       r.CodeSigningFlag,
+		"email_protection_flag":   r.EmailProtectionFlag,
+		"use_csr_common_name":     r.UseCSRCommonName,
+		"use_csr_sans":            r.UseCSRSANs,
+		"key_type":                r.KeyType,
+		"key_bits":                r.KeyBits,
+		"key_usage":               r.KeyUsage,
+		"ou":                      r.OU,
+		"organization":            r.Organization,
+		"no_store":                r.NoStore,
+	}
+	if r.MaxPathLength != nil {
+		responseData["max_path_length"] = r.MaxPathLength
+	}
+	if r.GenerateLease != nil {
+		responseData["generate_lease"] = r.GenerateLease
+	}
+	return responseData
 }
 
 const pathListRolesHelpSyn = `List the existing roles in this backend`

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -310,7 +310,7 @@ func (b *backend) getRole(s logical.Storage, n string) (*roleEntry, error) {
 		}
 		if err := s.Put(jsonEntry); err != nil {
 			// Only perform upgrades on replication primary
-			if !errwrap.Contains(err, logical.ErrReadOnly) {
+			if !strings.Contains(err.Error(), logical.ErrReadOnly.Error()) {
 				return nil, err
 			}
 		}

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -61,7 +61,8 @@ name in a request`,
 				Description: `If set, clients can request certificates for
 subdomains directly beneath these domains, including
 the wildcard subdomains. See the documentation for more
-information.`,
+information. This parameter accepts a comma-separated 
+string or list of domains.`,
 			},
 
 			"allow_bare_domains": &framework.FieldSchema{
@@ -158,7 +159,7 @@ the key_type.`,
 			"key_usage": &framework.FieldSchema{
 				Type:    framework.TypeCommaStringSlice,
 				Default: []string{"DigitalSignature", "KeyAgreement", "KeyEncipherment"},
-				Description: `A list of key usages (not extended
+				Description: `A comma-separate string or list of key usages (not extended
 key usages). Valid values can be found at
 https://golang.org/pkg/crypto/x509/#KeyUsage
 -- simply drop the "KeyUsage" part of the name.
@@ -308,7 +309,10 @@ func (b *backend) getRole(s logical.Storage, n string) (*roleEntry, error) {
 			return nil, err
 		}
 		if err := s.Put(jsonEntry); err != nil {
-			return nil, err
+			// Only perform upgrades on replication primary
+			if err != logical.ErrReadOnly {
+				return nil, err
+			}
 		}
 	}
 

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -61,8 +61,7 @@ name in a request`,
 				Description: `If set, clients can request certificates for
 subdomains directly beneath these domains, including
 the wildcard subdomains. See the documentation for more
-information. This parameter accepts a comma-separated list
-of domains.`,
+information.`,
 			},
 
 			"allow_bare_domains": &framework.FieldSchema{

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -310,7 +310,7 @@ func (b *backend) getRole(s logical.Storage, n string) (*roleEntry, error) {
 		}
 		if err := s.Put(jsonEntry); err != nil {
 			// Only perform upgrades on replication primary
-			if err != logical.ErrReadOnly {
+			if !errwrap.Contains(err, logical.ErrReadOnly) {
 				return nil, err
 			}
 		}

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -684,9 +684,8 @@ request is denied.
   certificates for `localhost` as one of the requested common names. This is
   useful for testing and to allow clients on a single host to talk securely.
 
-- `allowed_domains` `(string: "")` – Specifies the domains of the role, provided
-  as a comma-separated list. This is used with the `allow_bare_domains` and
-  `allow_subdomains` options.
+- `allowed_domains` `(list: [])` – Specifies the domains of the role. This is 
+  used with the `allow_bare_domains` and `allow_subdomains` options.
 
 - `allow_bare_domains` `(bool: false)` – Specifies if clients can request
   certificates matching the value of the actual domains themselves; e.g. if a
@@ -738,12 +737,11 @@ request is denied.
   https://golang.org/pkg/crypto/elliptic/#Curve for an overview of allowed bit
   lengths for `ec`.
 
-- `key_usage` `(string: "DigitalSignature,KeyAgreement,KeyEncipherment")` –
-  Specifies the allowed key usage constraint on issued certificates. This is a
-  comma-separated string; valid values can be found at
-  https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the `KeyUsage` part
-  of the value. Values are not case-sensitive. To specify no key usage
-  constraints, set this to an empty string.
+- `key_usage` `(list: ["DigitalSignature", "KeyAgreement", "KeyEncipherment"])` –
+  Specifies the allowed key usage constraint on issued certificates. Valid 
+  values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply 
+  drop the `KeyUsage` part of the value. Values are not case-sensitive. To 
+  specify no key usage constraints, set this to an empty list.
 
 - `use_csr_common_name` `(bool: true)` – When used with the CSR signing
   endpoint, the common name in the CSR will be used instead of taken from the
@@ -782,7 +780,7 @@ short-lived. This option implies a value of `false` for `generate_lease`.
 
 ```json
 {
-  "allowed_domains": "example.com",
+  "allowed_domains": ["example.com"],
   "allow_subdomains": true
 }
 ```
@@ -827,7 +825,7 @@ $ curl \
     "allow_ip_sans": true,
     "allow_localhost": true,
     "allow_subdomains": false,
-    "allowed_domains": "example.com,foobar.com",
+    "allowed_domains": ["example.com", "foobar.com"],
     "client_flag": true,
     "code_signing_flag": false,
     "key_bits": 2048,


### PR DESCRIPTION
This introduces a slight backwards incompatibility on the PKI role response.  key_usage and allowed_domains will be returned as a list instead of a comma-separated string.