### PR TITLE
Update example payload and response for pem_keys field

### DIFF
--- a/website/source/api/auth/kubernetes/index.html.md
+++ b/website/source/api/auth/kubernetes/index.html.md
@@ -46,7 +46,7 @@ access the Kubernetes API.
 {
   "kubernetes_host": "https://192.168.99.100:8443",
   "kubernetes_ca_cert": "-----BEGIN CERTIFICATE-----.....-----END CERTIFICATE-----",
-  "pem_keys": "-----BEGIN CERTIFICATE-----.....-----END CERTIFICATE-----"
+  "pem_keys": "-----BEGIN CERTIFICATE-----\n.....\n-----END CERTIFICATE-----"
 }
 ```
 
@@ -83,7 +83,9 @@ $ curl \
   "data":{
       "kubernetes_host": "https://192.168.99.100:8443",
       "kubernetes_ca_cert": "-----BEGIN CERTIFICATE-----.....-----END CERTIFICATE-----",
-      "pem_keys": "-----BEGIN CERTIFICATE-----.....-----END CERTIFICATE-----"
+      "pem_keys": "-----BEGIN CERTIFICATE-----
+      .....
+      -----END CERTIFICATE-----"
   },
   ...
 }


### PR DESCRIPTION
Update example payload and response for `/auth/kubernetes/config` `pem_keys` field. This field needs `\n` after header and before footer in order to be accepted as a valid RSA or ECDSA public key. 

Without `\n`, you get error "data does not contain any valid RSA or ECDSA public keys".