### PR TITLE
Docs: fix typo in libtool ltdl name

### DIFF
--- a/website/source/docs/configuration/seal/pkcs11.html.md
+++ b/website/source/docs/configuration/seal/pkcs11.html.md
@@ -31,7 +31,7 @@ the key are listed at the end of this document.
 The following software packages are required for Vault Enterprise HSM:
 
 - PKCS#11 compatible HSM integration library
-- `libtldl` library
+- The [GNU libltdl library](https://www.gnu.org/software/libtool/manual/html_node/Using-libltdl.html) — ensure that it is installed for the correct architecture of your servers
 
 ## `pkcs11` Example
 


### PR DESCRIPTION
- Correct the name (it's **libltdl** not *libtldl*)
- Link to relevant page so folks have an idea of what libltdl even is
- Mention that it needs to be installed for the right arch as apparently Amazon Linux will install only the 686 package on x86_64 or something like that
