### PR TITLE
Conditionally set file audit log mode

### DIFF
--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -249,13 +249,15 @@ func (b *Backend) open() error {
 	}
 
 	// Change the file mode in case the log file already existed. We special
-	// case /dev/null since we can't chmod it
+	// case /dev/null since we can't chmod it and bypass if the mode is zero
 	switch b.path {
 	case "/dev/null":
 	default:
-		err = os.Chmod(b.path, b.mode)
-		if err != nil {
-			return err
+		if b.mode != 0 {
+			err = os.Chmod(b.path, b.mode)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -75,7 +75,9 @@ func Factory(conf *audit.BackendConfig) (audit.Backend, error) {
 		if err != nil {
 			return nil, err
 		}
-		mode = os.FileMode(m)
+		if m != 0 {
+			mode = os.FileMode(m)
+		}
 	}
 
 	b := &Backend{

--- a/website/source/docs/audit/file.html.md
+++ b/website/source/docs/audit/file.html.md
@@ -77,7 +77,7 @@ Following are the configuration options available for the backend.
         <span class="param-flags">optional</span>
             A string containing an octal number representing the bit pattern
             for the file mode, similar to `chmod`. This option defaults to
-            `0600`.
+            `0600`. Specifying mode of `0000` will disable Vault's setting any mode on the file.
       </li>
       <li>
         <span class="param">format</span>


### PR DESCRIPTION
This is to address #3639 - is it enough to have this check for a zero mode for short circuiting the chmod? I also updated the docs for `mode` too if so. If not, please let me know that too!
