### PR TITLE
add allowed_names to cert-responses (cli and API)

### DIFF
--- a/builtin/credential/cert/path_certs.go
+++ b/builtin/credential/cert/path_certs.go
@@ -131,10 +131,11 @@ func (b *backend) pathCertRead(
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"certificate":  cert.Certificate,
-			"display_name": cert.DisplayName,
-			"policies":     cert.Policies,
-			"ttl":          duration / time.Second,
+			"certificate":   cert.Certificate,
+			"display_name":  cert.DisplayName,
+			"policies":      cert.Policies,
+			"ttl":           duration / time.Second,
+			"allowed_names": cert.AllowedNames,
 		},
 	}, nil
 }


### PR DESCRIPTION
While working with the vault API I noticed that the "allowed_names" parameter as mentioned [here](https://www.vaultproject.io/api/auth/cert/index.html) never gets returned. Neither with the cli nor the API. 

Unfortunately I actually need exactly this functionality to figure out who's allowed to connect to vault (and with which policies).

Note: I don't have any experience with go - I tested my change locally and had no problems. Would be nice when someone more experienced takes a second look at this :)