### PR TITLE
Case-Insensitive handling of AppRole role names

### DIFF
--- a/builtin/credential/approle/validation.go
+++ b/builtin/credential/approle/validation.go
@@ -125,6 +125,10 @@ func (b *backend) validateCredentials(req *logical.Request, data *framework.Fiel
 			return nil, "", metadata, "", fmt.Errorf("missing secret_id")
 		}
 
+		if role.LowerCaseRoleName {
+			roleName = strings.ToLower(roleName)
+		}
+
 		// Check if the SecretID supplied is valid. If use limit was specified
 		// on the SecretID, it will be decremented in this call.
 		var valid bool


### PR DESCRIPTION
Fixes #3643 

This PR ensures that the new approles that get created behave in a case-insensitive manner. It does not attempt to upgrade the secret IDs of existing approles. 