### PR TITLE
Add ability to override temp dir in dev cluster

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -293,7 +293,7 @@ func (c *ServerCommand) Run(args []string) int {
 	}
 
 	if devThreeNode {
-		return c.enableThreeNodeDevCluster(coreConfig, info, infoKeys, devListenAddress)
+		return c.enableThreeNodeDevCluster(coreConfig, info, infoKeys, devListenAddress, os.Getenv("VAULT_DEV_TEMP_DIR"))
 	}
 
 	var disableClustering bool
@@ -857,11 +857,12 @@ func (c *ServerCommand) enableDev(core *vault.Core, coreConfig *vault.CoreConfig
 	return init, nil
 }
 
-func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info map[string]string, infoKeys []string, devListenAddress string) int {
+func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info map[string]string, infoKeys []string, devListenAddress, tempDir string) int {
 	testCluster := vault.NewTestCluster(&testing.RuntimeT{}, base, &vault.TestClusterOptions{
 		HandlerFunc:       vaulthttp.Handler,
 		BaseListenAddress: devListenAddress,
 		RawLogger:         c.logger,
+		TempDir:           tempDir,
 	})
 	defer c.cleanupGuard.Do(testCluster.Cleanup)
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -813,6 +813,7 @@ type TestClusterOptions struct {
 	NumCores           int
 	SealFunc           func() Seal
 	RawLogger          interface{}
+	TempDir            string
 }
 
 var DefaultNumCores = 3
@@ -856,11 +857,20 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 	}
 
 	var testCluster TestCluster
-	tempDir, err := ioutil.TempDir("", "vault-test-cluster-")
-	if err != nil {
-		t.Fatal(err)
+	if opts != nil && opts.TempDir != "" {
+		if _, err := os.Stat(opts.TempDir); os.IsNotExist(err) {
+			if err := os.MkdirAll(opts.TempDir, 0700); err != nil {
+				t.Fatal(err)
+			}
+		}
+		testCluster.TempDir = opts.TempDir
+	} else {
+		tempDir, err := ioutil.TempDir("", "vault-test-cluster-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		testCluster.TempDir = tempDir
 	}
-	testCluster.TempDir = tempDir
 
 	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {


### PR DESCRIPTION
This will allow the temp dir to be a fixed directory which can be helpful when creating docker images where we can mount the volume to a fixed location.