### PR TITLE
Update Consul to use the role's configured lease on renew.

### DIFF
--- a/builtin/logical/consul/backend_test.go
+++ b/builtin/logical/consul/backend_test.go
@@ -433,12 +433,8 @@ func testAccStepReadPolicy(t *testing.T, name string, policy string, lease time.
 				return fmt.Errorf("mismatch: %s %s", out, policy)
 			}
 
-			leaseRaw := resp.Data["lease"].(string)
-			l, err := time.ParseDuration(leaseRaw)
-			if err != nil {
-				return err
-			}
-			if l != lease {
+			l := resp.Data["lease"].(int64)
+			if lease != time.Second*time.Duration(l) {
 				return fmt.Errorf("mismatch: %v %v", l, lease)
 			}
 			return nil

--- a/builtin/logical/consul/path_roles.go
+++ b/builtin/logical/consul/path_roles.go
@@ -44,7 +44,7 @@ Defaults to 'client'.`,
 			},
 
 			"lease": &framework.FieldSchema{
-				Type:        framework.TypeString,
+				Type:        framework.TypeDurationSecond,
 				Description: "Lease time of the role.",
 			},
 		},
@@ -91,7 +91,7 @@ func pathRolesRead(
 	// Generate the response
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"lease":      result.Lease.String(),
+			"lease":      int64(result.Lease.Seconds()),
 			"token_type": result.TokenType,
 		},
 	}
@@ -130,13 +130,9 @@ func pathRolesWrite(
 	}
 
 	var lease time.Duration
-	leaseParam := d.Get("lease").(string)
-	if leaseParam != "" {
-		lease, err = time.ParseDuration(leaseParam)
-		if err != nil {
-			return logical.ErrorResponse(fmt.Sprintf(
-				"error parsing given lease of %s: %s", leaseParam, err)), nil
-		}
+	leaseParamRaw, ok := d.GetOk("lease")
+	if ok {
+		lease = time.Second * time.Duration(leaseParamRaw.(int))
 	}
 
 	entry, err := logical.StorageEntryJSON("policy/"+name, roleConfig{


### PR DESCRIPTION
Fixes #3679 

Note: I didn't modify backend tests to check this as it's actually major surgery to do so, but I did test manually:

```
$ vault read consul/creds/readonly
Key            	Value
---            	-----
lease_id       	consul/creds/readonly/c121b65f-089a-f189-a6e7-a393743fc037
lease_duration 	2h0m0s
lease_renewable	true
token          	782601dc-76db-785c-62c6-4fea8f9d7f7a

$ vault renew consul/creds/readonly/c121b65f-089a-f189-a6e7-a393743fc037
Key            	Value
---            	-----
lease_id       	consul/creds/readonly/c121b65f-089a-f189-a6e7-a393743fc037
lease_duration 	2h0m0s
lease_renewable	true
```