### PR TITLE
physical/dynamodb: Clarify `ha_enabled` type in documentation

### DIFF
--- a/website/source/docs/configuration/storage/dynamodb.html.md
+++ b/website/source/docs/configuration/storage/dynamodb.html.md
@@ -39,9 +39,9 @@ see the [official AWS DynamoDB documentation][dynamodb-rw-capacity].
   endpoint. This can also be provided via the environment variable
   `AWS_DYNAMODB_ENDPOINT`.
 
-- `ha_enabled` `(bool: false)` – Specifies whether this backend should be used
-  to run Vault in high availability mode. This can also be provided via the
-  environment variable `DYNAMODB_HA_ENABLED`.
+- `ha_enabled` `(string: "false")` – Specifies whether this backend should be used
+  to run Vault in high availability mode. Valid values are "true" or "false". This
+  can also be provided via the environment variable `DYNAMODB_HA_ENABLED`.
 
 - `max_parallel` `(string: "128")` – Specifies the maximum number of concurrent
   requests.


### PR DESCRIPTION
The example in the documentation correctly passes a quoted boolean (i.e. true or false as a string) instead of a "real" HCL boolean. This commit corrects the parameter list to document that fact.

While it would be more desirable to change the implementation to accept an unquoted boolean, it seems that the use of `hcl.DecodeObject` for parameters which are not common to all storage back ends would make thisa rather more involved change than this necessarily warrants.