### PR TITLE
Fix audited request header lookup

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1211,7 +1211,7 @@ func (b *SystemBackend) handleAuditedHeaderRead(req *logical.Request, d *framewo
 	}
 
 	headerConfig := b.Core.AuditedHeadersConfig()
-	settings, ok := headerConfig.Headers[header]
+	settings, ok := headerConfig.Headers[strings.ToLower(header)]
 	if !ok {
 		return logical.ErrorResponse("Could not find header in config"), nil
 	}


### PR DESCRIPTION
The headers are stored lowercased but the lookup function wasn't
properly lowercasing when indexing in the header map.

Fixes #3701