### PR TITLE
Correct documentation for Kubernetes Auth Plugin

### DIFF
--- a/website/source/api/auth/kubernetes/index.html.md
+++ b/website/source/api/auth/kubernetes/index.html.md
@@ -191,8 +191,8 @@ Lists all the roles that are registered with the backend.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `LIST`   | `/auth/kubernetes/roles`            | `200 application/json` |
-| `GET`   | `/auth/kubernetes/roles?list=true`   | `200 application/json` |
+| `LIST`   | `/auth/kubernetes/role`            | `200 application/json` |
+| `GET`   | `/auth/kubernetes/role?list=true`   | `200 application/json` |
 
 ### Sample Request
 
@@ -200,7 +200,7 @@ Lists all the roles that are registered with the backend.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request LIST \
-    https://vault.rocks/v1/auth/kubernetes/roles
+    https://vault.rocks/v1/auth/kubernetes/role
 ```
 
 ### Sample Response


### PR DESCRIPTION
`auth/kubernetes/roles` URL does not exist.

As documented (404):

```shell
$ kubectl exec -n vault $POD_NAME -c consul -- \
  curl --silent --show-error --fail \
  --cacert $CA_CERT \
  --header "X-Vault-Token: $VAULT_TOKEN" \
  https://$POD_IP:8200/v1/auth/kubernetes/roles?list=true | jq '.'
curl: (22) The requested URL returned error: 404 Not Found
command terminated with exit code 22
```

Actual behavior of plugin:

```shell
$ kubectl exec -n vault $POD_NAME -c consul -- \
  curl --silent --show-error --fail \
  --cacert $CA_CERT \
  --header "X-Vault-Token: $VAULT_TOKEN" \
  https://$POD_IP:8200/v1/auth/kubernetes/role?list=true | jq '.'
{
  "request_id": "deadbeef-dead-beef-dead-beefdeadbeef",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 0,
  "data": {
    "keys": [
      "default-default",
      "my-role"
    ]
  },
  "wrap_info": null,
  "warnings": null,
  "auth": null
}
```