### PR TITLE
Ping the mongo session when the connection is retrieved.

### DIFF
--- a/plugins/database/cassandra/connection_producer.go
+++ b/plugins/database/cassandra/connection_producer.go
@@ -116,12 +116,15 @@ func (c *cassandraConnectionProducer) Initialize(ctx context.Context, conf map[s
 }
 
 func (c *cassandraConnectionProducer) Connection(_ context.Context) (interface{}, error) {
+	c.Lock()
+	defer c.Unlock()
+
 	if !c.Initialized {
 		return nil, connutil.ErrNotInitialized
 	}
 
 	// If we already have a DB, return it
-	if c.session != nil {
+	if c.session != nil && !c.session.Closed() {
 		return c.session, nil
 	}
 


### PR DESCRIPTION
This was in the deprecated backend where it fixed a similar issue a long
time ago but for some reason didn't make it over. Additionally the
function wasn't being locked properly.

Hopefully fixes #2973