### PR TITLE
Update backend config docs - addresses #3718

### DIFF
--- a/website/source/docs/configuration/storage/consul.html.md
+++ b/website/source/docs/configuration/storage/consul.html.md
@@ -66,7 +66,7 @@ at Consul's service discovery layer.
   [consistency mode][consul-consistency]. Possible values are `"default"` or
   `"strong"`.
 
-- `disable_registration` `(bool: false)` – Specifies whether Vault should
+- `disable_registration` `(string: "false")` – Specifies whether Vault should
   register itself with Consul.
 
 - `max_parallel` `(string: "128")` – Specifies the maximum number of concurrent

--- a/website/source/docs/configuration/storage/etcd.html.md
+++ b/website/source/docs/configuration/storage/etcd.html.md
@@ -45,7 +45,7 @@ storage "etcd" {
   version is 3.1+ and there has been no data written using the v2 API, the
   auto-detected default is v3.
 
-- `ha_enabled` `(bool: false)` – Specifies if high availability should be
+- `ha_enabled` `(string: "false")` – Specifies if high availability should be
   enabled. This can also be provided via the environment variable
   `ETCD_HA_ENABLED`.
 


### PR DESCRIPTION
Updated documentation for string values which were documented as boolean values in the configuration for Consul and etcd backends.