### PR TITLE
Update '/auth/token/revoke-self' endpoint documentation to reflect th…

### DIFF
--- a/website/source/api/auth/token/index.html.md
+++ b/website/source/api/auth/token/index.html.md
@@ -437,7 +437,7 @@ revoked, all dynamic secrets generated with it are also revoked.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `POST`   | `/auth/token/revoke-self`     | `200 application/json` |
+| `POST`   | `/auth/token/revoke-self`     | `204 (empty body)` |
 
 ### Sample Request
 


### PR DESCRIPTION
…e proper response code

Below is an example from the latest version, running locally in development mode.

```sh
$ ./vault version
Vault v0.9.1 ('87b6919dea55da61d7cd444b2442cabb8ede8ab1')

$ curl -v -X POST -H "X-Vault-Token: XXXXXX" http://127.0.0.1:8200/v1/auth/token/revoke-self
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8200 (#0)
> POST /v1/auth/token/revoke-self HTTP/1.1
> Host: 127.0.0.1:8200
> User-Agent: curl/7.54.0
> Accept: */*
> X-Vault-Token: XXXXXXX
>
< HTTP/1.1 204 No Content
< Cache-Control: no-store
< Content-Type: application/json
< Date: Tue, 26 Dec 2017 20:01:55 GMT
<
* Connection #0 to host 127.0.0.1 left intact
```