### PR TITLE
Update docs to reflect ability to load cold CA certs to output full c…

### DIFF
--- a/helper/certutil/helpers.go
+++ b/helper/certutil/helpers.go
@@ -102,8 +102,8 @@ func ParsePKIJSON(input []byte) (*ParsedCertBundle, error) {
 
 // ParsePEMBundle takes a string of concatenated PEM-format certificate
 // and private key values and decodes/parses them, checking validity along
-// the way. There must be at max two certificates (a certificate and its
-// issuing certificate) and one private key.
+// the way. The first certificate must be the subject certificate and issuing
+// certificates may follow.  There must be at most one private key.
 func ParsePEMBundle(pemBundle string) (*ParsedCertBundle, error) {
 	if len(pemBundle) == 0 {
 		return nil, errutil.UserError{"empty pem bundle"}

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -175,9 +175,14 @@ $ curl \
 ## Submit CA Information
 
 This endpoint allows submitting the CA information for the backend via a PEM
-file containing the CA certificate and its private key, concatenated. Not needed
-if you are generating a self-signed root certificate, and not used if you have a
-signed intermediate CA certificate with a generated key (use the
+file containing the CA certificate and its private key, concatenated.
+
+May optionally append additional CA certificates.  Useful when creating an
+intermediate CA to ensure a full chain is returned when signing or generating
+certificates.
+
+Not needed if you are generating a self-signed root certificate, and not used
+if you have a signed intermediate CA certificate with a generated key (use the
 `/pki/intermediate/set-signed` endpoint for that). _If you have already set a
 certificate and key, they will be overridden._
 


### PR DESCRIPTION
I went through the code hoping to find a way to make sure our full cold CA chain ended up output to clients of sign and generate.  It turns out this is already functioning -- but that it isn't documented clearly as being possible.

This is a quick pass at making the documentation expose this functionality, let me know if I can improve it.  Thanks.