### PR TITLE
Document that AWS STS lease revocation is a no-op

### DIFF
--- a/builtin/logical/aws/path_sts.go
+++ b/builtin/logical/aws/path_sts.go
@@ -87,6 +87,6 @@ then "aws/sts/deploy" would generate access keys for the "deploy" role.
 
 Note, these credentials are instantiated using the AWS STS backend.
 
-The access keys will have a lease associated with them. The access keys
-can be revoked by using the lease ID.
+The access keys will have a lease associated with them, but revoking the lease
+does not revoke the access keys.
 `


### PR DESCRIPTION
Vault says ["The access keys can be revoked by using the lease ID"](https://github.com/hashicorp/vault/blob/v0.9.1/builtin/logical/aws/path_sts.go#L90-L91), but revoking STS-generated credentials [is a no-op](https://github.com/hashicorp/vault/blob/v0.9.1/builtin/logical/aws/secret_access_keys.go#L278-L290). This commit updates the documentation at `vault path-help aws/sts/role` to reflect the current behavior.

This fixes #3736, for a limited definition of "fix".