### PR TITLE
Make the plugin catalog endpoint roundtrip so we can use terraform to manage them.

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1105,6 +1105,9 @@ func (b *SystemBackend) handlePluginCatalogUpdate(ctx context.Context, req *logi
 	args := d.Get("args").([]string)
 	// For backwards compatibility, also accept args as part of command.
 	parts := strings.Split(command, " ")
+	if len(parts) <= 0 {
+		return logical.ErrorResponse("missing command value"), nil
+	}
 	args = append(parts[1:], args...)
 
 	sha256Bytes, err := hex.DecodeString(sha256)

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -85,7 +85,7 @@ func (c *PluginCatalog) Get(name string) (*pluginutil.PluginRunner, error) {
 
 // Set registers a new external plugin with the catalog, or updates an existing
 // external plugin. It takes the name, command and SHA256 of the plugin.
-func (c *PluginCatalog) Set(name, command string, sha256 []byte) error {
+func (c *PluginCatalog) Set(name, command string, args []string, sha256 []byte) error {
 	if c.directory == "" {
 		return ErrDirectoryNotConfigured
 	}
@@ -100,11 +100,9 @@ func (c *PluginCatalog) Set(name, command string, sha256 []byte) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	parts := strings.Split(command, " ")
-
 	// Best effort check to make sure the command isn't breaking out of the
 	// configured plugin directory.
-	commandFull := filepath.Join(c.directory, parts[0])
+	commandFull := filepath.Join(c.directory, command)
 	sym, err := filepath.EvalSymlinks(commandFull)
 	if err != nil {
 		return fmt.Errorf("error while validating the command path: %v", err)
@@ -120,8 +118,8 @@ func (c *PluginCatalog) Set(name, command string, sha256 []byte) error {
 
 	entry := &pluginutil.PluginRunner{
 		Name:    name,
-		Command: parts[0],
-		Args:    parts[1:],
+		Command: command,
+		Args:    args,
 		Sha256:  sha256,
 		Builtin: false,
 	}

--- a/vault/plugin_catalog_test.go
+++ b/vault/plugin_catalog_test.go
@@ -50,8 +50,8 @@ func TestPluginCatalog_CRUD(t *testing.T) {
 	}
 	defer file.Close()
 
-	command := fmt.Sprintf("%s --test", filepath.Base(file.Name()))
-	err = core.pluginCatalog.Set("mysql-database-plugin", command, []byte{'1'})
+	command := fmt.Sprintf("%s", filepath.Base(file.Name()))
+	err = core.pluginCatalog.Set("mysql-database-plugin", command, []string{"--test"}, []byte{'1'})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,14 +139,14 @@ func TestPluginCatalog_List(t *testing.T) {
 	}
 	defer file.Close()
 
-	command := fmt.Sprintf("%s --test", filepath.Base(file.Name()))
-	err = core.pluginCatalog.Set("mysql-database-plugin", command, []byte{'1'})
+	command := filepath.Base(file.Name())
+	err = core.pluginCatalog.Set("mysql-database-plugin", command, []string{"--test"}, []byte{'1'})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Set another plugin
-	err = core.pluginCatalog.Set("aaaaaaa", command, []byte{'1'})
+	err = core.pluginCatalog.Set("aaaaaaa", command, []string{"--test"}, []byte{'1'})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -409,8 +409,9 @@ func TestAddTestPlugin(t testing.T, c *Core, name, testFunc string) {
 	c.pluginDirectory = directoryPath
 	c.pluginCatalog.directory = directoryPath
 
-	command := fmt.Sprintf("%s --test.run=%s", filepath.Base(os.Args[0]), testFunc)
-	err = c.pluginCatalog.Set(name, command, sum)
+	command := fmt.Sprintf("%s", filepath.Base(os.Args[0]))
+	args := []string{fmt.Sprintf("--test.run=%s", testFunc)}
+	err = c.pluginCatalog.Set(name, command, args, sum)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,8 +473,9 @@ func TestAddTestPluginTempDir(t testing.T, c *Core, name, testFunc, tempDir stri
 	c.pluginDirectory = fullPath
 	c.pluginCatalog.directory = fullPath
 
-	command := fmt.Sprintf("%s --test.run=%s", filepath.Base(os.Args[0]), testFunc)
-	err = c.pluginCatalog.Set(name, command, sum)
+	command := fmt.Sprintf("%s", filepath.Base(os.Args[0]))
+	args := []string{fmt.Sprintf("--test.run=%s", testFunc)}
+	err = c.pluginCatalog.Set(name, command, args, sum)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #3776 

You can now do:

```
$ cat plugin.json 
{
  "args": [
    "--ca-cert=/etc/vault/ca.pem",
    "--client-cert=/etc/vault/cert.pem",
    "--client-key=/etc/vault/key.pem"
  ],
  "command": "google-auth-vault-plugin",
  "name": "google-auth-vault-plugin",
  "sha256": "989845e5a0171d9e1b1c6d9ca13393dd031fd9068c200c52ec723737ed450d4d"
}
$ vault  write sys/plugins/catalog/google-auth-vault-plugin @plugin.json
Success! Data written to: sys/plugins/catalog/google-auth-vault-plugin
$ vault read --format json sys/plugins/catalog/google-auth-vault-plugin
{
	"request_id": "d61b86d4-f5c6-7334-3848-be4c8730f0b1",
	"lease_id": "",
	"lease_duration": 0,
	"renewable": false,
	"data": {
		"args": [
			"--ca-cert=/etc/vault/ca.pem",
			"--client-cert=/etc/vault/cert.pem",
			"--client-key=/etc/vault/key.pem"
		],
		"command": "google-auth-vault-plugin",
		"name": "google-auth-vault-plugin",
		"sha256": "989845e5a0171d9e1b1c6d9ca13393dd031fd9068c200c52ec723737ed450d4d"
	},
	"warnings": null
}
```

Which should be enough to allow terraform to manage plugins.
