### PR TITLE
Fix minor typo in word "certificate"

### DIFF
--- a/website/source/api/auth/cert/index.html.md
+++ b/website/source/api/auth/cert/index.html.md
@@ -296,7 +296,7 @@ $ curl \
     https://vault.rocks/v1/auth/cert/certs/cert1
 ```
 
-## Login with TLS Certiicate Method
+## Login with TLS Certificate Method
 
 Log in and fetch a token. If there is a valid chain to a CA configured in the
 method and all role constraints are matched, a token will be issued.


### PR DESCRIPTION
Noticed a typo in the documentation for TLS authentication.