### PR TITLE
Add to the PKIX name: Country, State/Province, Locality, Street Addre…

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -41,6 +41,11 @@ type creationBundle struct {
 	CommonName     string
 	OU             []string
 	Organization   []string
+	Country        []string
+	Province       []string
+	Locality       []string
+	StreetAddress  []string
+	PostalCode     []string
 	DNSNames       []string
 	EmailAddresses []string
 	IPAddresses    []net.IP
@@ -730,6 +735,46 @@ func generateCreationBundle(b *backend,
 		}
 	}
 
+	// Set C (country) values if specified in the role
+	country := []string{}
+	{
+		if role.Country != "" {
+			country = strutil.RemoveDuplicates(strutil.ParseStringSlice(role.Country, ","), false)
+		}
+	}
+
+	// Set ST (state, province) values if specified in the role
+	province := []string{}
+	{
+		if role.Province != "" {
+			province = strutil.RemoveDuplicates(strutil.ParseStringSlice(role.Province, ","), false)
+		}
+	}
+
+	// Set L (locality) values if specified in the role
+	locality := []string{}
+	{
+		if role.Locality != "" {
+			locality = strutil.RemoveDuplicates(strutil.ParseStringSlice(role.Locality, ","), false)
+		}
+	}
+
+	// Set streetAddress values if specified in the role
+	streetAddress := []string{}
+	{
+		if role.StreetAddress != "" {
+			streetAddress = strutil.RemoveDuplicates(strutil.ParseStringSlice(role.StreetAddress, ","), false)
+		}
+	}
+
+	// Set postalCode values if specified in the role
+	postalCode := []string{}
+	{
+		if role.PostalCode != "" {
+			postalCode = strutil.RemoveDuplicates(strutil.ParseStringSlice(role.PostalCode, ","), false)
+		}
+	}
+
 	// Get the TTL and verify it against the max allowed
 	var ttl time.Duration
 	var maxTTL time.Duration
@@ -798,6 +843,11 @@ func generateCreationBundle(b *backend,
 		CommonName:     cn,
 		OU:             ou,
 		Organization:   organization,
+		Country:        country,
+		Province:       province,
+		Locality:       locality,
+		StreetAddress:  streetAddress,
+		PostalCode:     postalCode,
 		DNSNames:       dnsNames,
 		EmailAddresses: emailAddresses,
 		IPAddresses:    ipAddresses,
@@ -891,6 +941,11 @@ func createCertificate(creationInfo *creationBundle) (*certutil.ParsedCertBundle
 		CommonName:         creationInfo.CommonName,
 		OrganizationalUnit: creationInfo.OU,
 		Organization:       creationInfo.Organization,
+		Country:            creationInfo.Country,
+		Province:           creationInfo.Province,
+		Locality:           creationInfo.Locality,
+		StreetAddress:      creationInfo.StreetAddress,
+		PostalCode:         creationInfo.PostalCode,
 	}
 
 	certTemplate := &x509.Certificate{

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -191,10 +191,45 @@ include the Common Name (cn). Defaults to true.`,
 this value in certificates issued by this role.`,
 			},
 
+			"country": &framework.FieldSchema{
+				Type:    framework.TypeString,
+				Default: "",
+				Description: `If set, the C (Country) will be set to
+this value in certificates issued by this role.`,
+			},
+
+			"province": &framework.FieldSchema{
+				Type:    framework.TypeString,
+				Default: "",
+				Description: `If set, the ST (Province) will be set to
+this value in certificates issued by this role.`,
+			},
+
+			"locality": &framework.FieldSchema{
+				Type:    framework.TypeString,
+				Default: "",
+				Description: `If set, the L (Locality) will be set to
+this value in certificates issued by this role.`,
+			},
+
 			"organization": &framework.FieldSchema{
 				Type:    framework.TypeString,
 				Default: "",
 				Description: `If set, the O (Organization) will be set to
+this value in certificates issued by this role.`,
+			},
+
+			"street_address": &framework.FieldSchema{
+				Type:    framework.TypeString,
+				Default: "",
+				Description: `If set, the streetAddress will be set to
+this value in certificates issued by this role.`,
+			},
+
+			"postal_code": &framework.FieldSchema{
+				Type:    framework.TypeString,
+				Default: "",
+				Description: `If set, the postalCode will be set to
 this value in certificates issued by this role.`,
 			},
 
@@ -398,6 +433,11 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		Organization:        data.Get("organization").(string),
 		GenerateLease:       new(bool),
 		NoStore:             data.Get("no_store").(bool),
+		Country:             data.Get("country").(string),
+		Province:            data.Get("province").(string),
+		Locality:            data.Get("locality").(string),
+		StreetAddress:       data.Get("street_address").(string),
+		PostalCode:          data.Get("postal_code").(string),
 	}
 
 	// no_store implies generate_lease := false
@@ -526,6 +566,11 @@ type roleEntry struct {
 	Organization          string   `json:"organization" mapstructure:"organization"`
 	GenerateLease         *bool    `json:"generate_lease,omitempty"`
 	NoStore               bool     `json:"no_store" mapstructure:"no_store"`
+	Country               string   `json:"country" mapstructure:"country"`
+	Province              string   `json:"province" mapstructure:"province"`
+	Locality              string   `json:"locality" mapstructure:"locality"`
+	StreetAddress         string   `json:"street_address" mapstructure:"street_address"`
+	PostalCode            string   `json:"postal_address" mapstructure:"postal_code"`
 
 	// Used internally for signing intermediates
 	AllowExpirationPastCA bool


### PR DESCRIPTION
I started to use the Vault PKI Secret backend to generate certs and found that it didn't support the Country, State/Province and Locality fields. 

I added those, and thought of adding Street Address and Postal Code as well since they are supported by the Go crypto.x509.pkix.Name.

Fixes #3777