### PR TITLE
AWS API Gateway Reverse Proxy Support

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -33,6 +33,7 @@ const EnvVaultWrapTTL = "VAULT_WRAP_TTL"
 const EnvVaultMaxRetries = "VAULT_MAX_RETRIES"
 const EnvVaultToken = "VAULT_TOKEN"
 const EnvVaultMFA = "VAULT_MFA"
+const EnvAWSApiGatewaySignature = "VAULT_AWS_APIGATEWAY_SIGNATURE"
 
 // WrappingLookupFunc is a function that, given an HTTP verb and a path,
 // returns an optional string duration to be used for response wrapping (e.g.
@@ -68,6 +69,8 @@ type Config struct {
 	// If there is an error when creating the configuration, this will be the
 	// error
 	Error error
+
+	AWSApiGatewaySignature bool
 }
 
 // TLSConfig contains the parameters needed to configure TLS on the HTTP client
@@ -204,6 +207,7 @@ func (c *Config) ReadEnvironment() error {
 	var envInsecure bool
 	var envTLSServerName string
 	var envMaxRetries *uint64
+	var envAWSApiGatewaySignature bool
 
 	// Parse the environment variables
 	if v := os.Getenv(EnvVaultAddress); v != "" {
@@ -244,6 +248,17 @@ func (c *Config) ReadEnvironment() error {
 	}
 	if v := os.Getenv(EnvVaultTLSServerName); v != "" {
 		envTLSServerName = v
+	}
+
+	if v := os.Getenv(EnvAWSApiGatewaySignature); v != "" {
+		var err error
+		envAWSApiGatewaySignature, err = strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("Could not parse VAULT_AWS_APIGATEWAY_SIGNATURE")
+		}
+		if envAWSApiGatewaySignature {
+			c.AWSApiGatewaySignature = true
+		}
 	}
 
 	// Configure the HTTP clients TLS configuration.
@@ -518,6 +533,10 @@ func (c *Client) NewRequest(method, requestPath string) *Request {
 		req.Headers = c.headers
 	}
 
+	if c.config.AWSApiGatewaySignature {
+		req.AWSApiGatewaySignature = true
+	}
+
 	req.PolicyOverride = c.policyOverride
 
 	return req
@@ -534,6 +553,7 @@ func (c *Client) RawRequest(r *Request) (*Response, error) {
 
 	redirectCount := 0
 START:
+	r.AWSApiGatewaySignature = c.config.AWSApiGatewaySignature
 	req, err := r.ToHTTP()
 	if err != nil {
 		return nil, err

--- a/command/base.go
+++ b/command/base.go
@@ -31,14 +31,15 @@ type BaseCommand struct {
 	flags     *FlagSets
 	flagsOnce sync.Once
 
-	flagAddress       string
-	flagCACert        string
-	flagCAPath        string
-	flagClientCert    string
-	flagClientKey     string
-	flagTLSServerName string
-	flagTLSSkipVerify bool
-	flagWrapTTL       time.Duration
+	flagAddress                string
+	flagCACert                 string
+	flagCAPath                 string
+	flagClientCert             string
+	flagClientKey              string
+	flagTLSServerName          string
+	flagTLSSkipVerify          bool
+	flagAWSApiGatewaySignature bool
+	flagWrapTTL                time.Duration
 
 	flagFormat string
 	flagField  string
@@ -65,6 +66,10 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 
 	if c.flagAddress != "" {
 		config.Address = c.flagAddress
+	}
+
+	if c.flagAWSApiGatewaySignature {
+		config.AWSApiGatewaySignature = true
 	}
 
 	// If we need custom TLS configuration, then set it
@@ -223,6 +228,17 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 				Usage: "Disable verification of TLS certificates. Using this option " +
 					"is highly discouraged and decreases the security of data " +
 					"transmissions to and from the Vault server.",
+			})
+
+			f.BoolVar(&BoolVar{
+				Name:    "aws-apigateway-signature",
+				Target:  &c.flagAWSApiGatewaySignature,
+				Default: false,
+				EnvVar:  "VAULT_AWS_APIGATEWAY_SIGNATURE",
+				Usage: "Sign all client requests with AWS v4 Signatures for use " +
+					"with AWS API Gateway being used as a reverse proxy." +
+					"The signer will use the default credential provider chain for " +
+					"signing requests.",
 			})
 
 			f.DurationVar(&DurationVar{


### PR DESCRIPTION
Adds support to sign requests using AWS v4 Signatures against `execute-api`
which corresponds to AWS API Gateway.

This allows Vault to be made publicly available with an IAM authentication
firewall for all requests.

The VAULT_AWS_APIGATEWAY_SIGNATURE environment variable and
-aws-apigateway-signature option enable this behaviour.

---

I'm not sure if this is the best way to implement this, or if it should be even accepted.
I couldn't seen an appropriate way to abstract a request signer, and this is more of a quick
proof of concept than a final product. Am looking for comments or suggestions as to 
whether or not to improve it, and how best to proceed.