### PR TITLE
Fix policy website documentation

### DIFF
--- a/website/source/api/system/policy.html.md
+++ b/website/source/api/system/policy.html.md
@@ -70,7 +70,7 @@ updated, it takes effect immediately to all associated users.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `PUT`    | `/sys/policy/:name`          | `204 (empty body)`     |
+| `PUT`    | `/sys/policy/:name`          | `200 application/json  |
 
 ### Parameters
 


### PR DESCRIPTION
Create/update policy in 0.9.x version returns now http 200 instead of 204