### PR TITLE
Fix policy website documentation

### DIFF
--- a/website/source/api/system/policy.html.md
+++ b/website/source/api/system/policy.html.md
@@ -70,7 +70,7 @@ updated, it takes effect immediately to all associated users.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `PUT`    | `/sys/policy/:name`          | `204 (empty body)`     |
+| `PUT`    | `/sys/policy/:name`          | `204 (empty body)`<br />`200 (deprecated fields warnings)`  |
 
 ### Parameters
 
@@ -119,3 +119,4 @@ $ curl \
     --request DELETE \
     https://vault.rocks/v1/sys/policy/my-policy
 ```
+


### PR DESCRIPTION
Create/update policy in 0.9.x version could return now http 200 instead of 204.

In your tests you've changed the asserting response to 200, but also 204 could be returned!

Maybe is interesting to update the documentation with both return codes.