### PR TITLE
SHA2-256 salting for AppID

### DIFF
--- a/builtin/credential/app-id/backend_test.go
+++ b/builtin/credential/app-id/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/vault/helper/salt"
 	"github.com/hashicorp/vault/logical"
 	logicaltest "github.com/hashicorp/vault/logical/testing"
 )
@@ -53,11 +54,11 @@ func TestBackend_basic(t *testing.T) {
 	if len(keys) != 1 {
 		t.Fatalf("expected 1 key, got %d", len(keys))
 	}
-	salt, err := b.Salt()
+	bSalt, err := b.Salt()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if keys[0] != salt.SaltID("foo") {
+	if keys[0] != "s"+bSalt.SaltIDHashFunc("foo", salt.SHA256Hash) {
 		t.Fatal("value was improperly salted")
 	}
 }

--- a/command/path_map_upgrade_api_test.go
+++ b/command/path_map_upgrade_api_test.go
@@ -1,0 +1,93 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/vault"
+	logxi "github.com/mgutz/logxi/v1"
+
+	credAppId "github.com/hashicorp/vault/builtin/credential/app-id"
+)
+
+func TestPathMap_Upgrade_API(t *testing.T) {
+	var err error
+	coreConfig := &vault.CoreConfig{
+		DisableMlock: true,
+		DisableCache: true,
+		Logger:       logxi.NullLog,
+		CredentialBackends: map[string]logical.Factory{
+			"app-id": credAppId.Factory,
+		},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+
+	vault.TestWaitActive(t, cores[0].Core)
+
+	client := cores[0].Client
+
+	// Enable the app-id method
+	err = client.Sys().EnableAuthWithOptions("app-id", &api.EnableAuthOptions{
+		Type: "app-id",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an app-id
+	_, err = client.Logical().Write("auth/app-id/map/app-id/test-app-id", map[string]interface{}{
+		"policy": "test-policy",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a user-id
+	_, err = client.Logical().Write("auth/app-id/map/user-id/test-user-id", map[string]interface{}{
+		"value": "test-app-id",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Perform a login. It should succeed.
+	_, err = client.Logical().Write("auth/app-id/login", map[string]interface{}{
+		"app_id":  "test-app-id",
+		"user_id": "test-user-id",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// List the hashed app-ids in the storage
+	secret, err := client.Logical().List("auth/app-id/map/app-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashedAppID := secret.Data["keys"].([]interface{})[0].(string)
+
+	// Try reading it. This used to cause an issue which is fixed in [GH-3806].
+	_, err = client.Logical().Read("auth/app-id/map/app-id/" + hashedAppID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure that there was no issue by performing another login
+	_, err = client.Logical().Write("auth/app-id/login", map[string]interface{}{
+		"app_id":  "test-app-id",
+		"user_id": "test-user-id",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/helper/salt/salt.go
+++ b/helper/salt/salt.go
@@ -139,6 +139,12 @@ func (s *Salt) DidGenerate() bool {
 	return s.generated
 }
 
+// SaltIDHashFunc uses the supplied hash function instead of the configured
+// hash func in the salt.
+func (s *Salt) SaltIDHashFunc(id, hashType, delim string, hashFunc HashFunc) string {
+	return hashType + delim + SaltID(s.salt, id, hashFunc)
+}
+
 // SaltID is used to apply a salt and hash function to an ID to make sure
 // it is not reversible
 func SaltID(salt, id string, hash HashFunc) string {

--- a/helper/salt/salt.go
+++ b/helper/salt/salt.go
@@ -141,8 +141,8 @@ func (s *Salt) DidGenerate() bool {
 
 // SaltIDHashFunc uses the supplied hash function instead of the configured
 // hash func in the salt.
-func (s *Salt) SaltIDHashFunc(id, hashType, delim string, hashFunc HashFunc) string {
-	return hashType + delim + SaltID(s.salt, id, hashFunc)
+func (s *Salt) SaltIDHashFunc(id string, hashFunc HashFunc) string {
+	return SaltID(s.salt, id, hashFunc)
 }
 
 // SaltID is used to apply a salt and hash function to an ID to make sure

--- a/helper/salt/salt_test.go
+++ b/helper/salt/salt_test.go
@@ -3,11 +3,27 @@ package salt
 import (
 	"crypto/sha1"
 	"crypto/sha256"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/logical"
 )
+
+func TestSaltIDHashFunc(t *testing.T) {
+	inm := &logical.InmemStorage{}
+	conf := &Config{}
+
+	salt, err := NewSalt(inm, conf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	saltedID := salt.SaltIDHashFunc("sampletext", "sha2-256", "-", SHA256Hash)
+	if !strings.HasPrefix(saltedID, "sha2-256-") {
+		t.Fatalf("bad prefix; expected a prefix of %q; actual value: %#v", "sha2-256-", saltedID)
+	}
+}
 
 func TestSalt(t *testing.T) {
 	inm := &logical.InmemStorage{}

--- a/helper/salt/salt_test.go
+++ b/helper/salt/salt_test.go
@@ -3,27 +3,11 @@ package salt
 import (
 	"crypto/sha1"
 	"crypto/sha256"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/logical"
 )
-
-func TestSaltIDHashFunc(t *testing.T) {
-	inm := &logical.InmemStorage{}
-	conf := &Config{}
-
-	salt, err := NewSalt(inm, conf)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	saltedID := salt.SaltIDHashFunc("sampletext", "sha2-256", "-", SHA256Hash)
-	if !strings.HasPrefix(saltedID, "sha2-256-") {
-		t.Fatalf("bad prefix; expected a prefix of %q; actual value: %#v", "sha2-256-", saltedID)
-	}
-}
 
 func TestSalt(t *testing.T) {
 	inm := &logical.InmemStorage{}

--- a/logical/framework/path_map.go
+++ b/logical/framework/path_map.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/vault/helper/salt"
+	saltpkg "github.com/hashicorp/vault/helper/salt"
 	"github.com/hashicorp/vault/logical"
 )
 
@@ -21,8 +21,8 @@ type PathMap struct {
 	Name          string
 	Schema        map[string]*FieldSchema
 	CaseSensitive bool
-	Salt          *salt.Salt
-	SaltFunc      func() (*salt.Salt, error)
+	Salt          *saltpkg.Salt
+	SaltFunc      func() (*saltpkg.Salt, error)
 
 	once sync.Once
 }
@@ -64,7 +64,7 @@ func (p *PathMap) pathStruct(s logical.Storage, k string) (*PathStruct, error) {
 		}
 	}
 	if salt != nil {
-		k = salt.SaltID(k)
+		k = salt.SaltIDHashFunc(k, "sha2-256", "-", saltpkg.SHA256Hash)
 	}
 
 	finalName := fmt.Sprintf("map/%s/%s", p.Name, k)
@@ -73,17 +73,22 @@ func (p *PathMap) pathStruct(s logical.Storage, k string) (*PathStruct, error) {
 		Schema: p.Schema,
 	}
 
-	// Check for unsalted version and upgrade if so
-	if k != origKey {
-		// Generate the unsalted name
-		unsaltedName := fmt.Sprintf("map/%s/%s", p.Name, origKey)
-		// Set the path struct to use the unsalted name
-		ps.Name = unsaltedName
+	if !strings.HasPrefix(origKey, "sha2-256-") && k != origKey {
 		// Ensure that no matter what happens what is returned is the final
 		// path
 		defer func() {
 			ps.Name = finalName
 		}()
+
+		//
+		// Check for unsalted version and upgrade if so
+		//
+
+		// Generate the unsalted name
+		unsaltedName := fmt.Sprintf("map/%s/%s", p.Name, origKey)
+		// Set the path struct to use the unsalted name
+		ps.Name = unsaltedName
+
 		val, err := ps.Get(s)
 		if err != nil {
 			return nil, err
@@ -98,6 +103,38 @@ func (p *PathMap) pathStruct(s logical.Storage, k string) (*PathStruct, error) {
 			}
 			// Set it back to the old path and delete
 			ps.Name = unsaltedName
+			err = ps.Delete(s)
+			if err != nil {
+				return nil, err
+			}
+			// We'll set this in the deferred function but doesn't hurt here
+			ps.Name = finalName
+		}
+
+		//
+		// Check for SHA1 hashed version and upgrade if so
+		//
+
+		// Generate the SHA1 hash suffixed path name
+		sha1SuffixedName := fmt.Sprintf("map/%s/%s", p.Name, salt.SaltID(origKey))
+
+		// Set the path struct to use the SHA1 hash suffixed path name
+		ps.Name = sha1SuffixedName
+
+		val, err = ps.Get(s)
+		if err != nil {
+			return nil, err
+		}
+		// If not nil, we have an SHA1 hash suffixed entry -- upgrade it
+		if val != nil {
+			// Set the path struct to use the desired final name
+			ps.Name = finalName
+			err = ps.Put(s, val)
+			if err != nil {
+				return nil, err
+			}
+			// Set it back to the old path and delete
+			ps.Name = sha1SuffixedName
 			err = ps.Delete(s)
 			if err != nil {
 				return nil, err

--- a/logical/framework/path_map.go
+++ b/logical/framework/path_map.go
@@ -64,7 +64,7 @@ func (p *PathMap) pathStruct(s logical.Storage, k string) (*PathStruct, error) {
 		}
 	}
 	if salt != nil {
-		k = salt.SaltIDHashFunc(k, "sha2-256", "-", saltpkg.SHA256Hash)
+		k = "s" + salt.SaltIDHashFunc(k, saltpkg.SHA256Hash)
 	}
 
 	finalName := fmt.Sprintf("map/%s/%s", p.Name, k)
@@ -73,7 +73,7 @@ func (p *PathMap) pathStruct(s logical.Storage, k string) (*PathStruct, error) {
 		Schema: p.Schema,
 	}
 
-	if !strings.HasPrefix(origKey, "sha2-256-") && k != origKey {
+	if !strings.HasPrefix(origKey, "s") && k != origKey {
 		// Ensure that no matter what happens what is returned is the final
 		// path
 		defer func() {

--- a/logical/framework/path_map_test.go
+++ b/logical/framework/path_map_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/vault/helper/salt"
+	saltpkg "github.com/hashicorp/vault/helper/salt"
 	"github.com/hashicorp/vault/logical"
 )
 
@@ -140,14 +140,20 @@ func TestPathMap_routes(t *testing.T) {
 
 func TestPathMap_Salted(t *testing.T) {
 	storage := new(logical.InmemStorage)
-	salt, err := salt.NewSalt(storage, &salt.Config{
-		HashFunc: salt.SHA1Hash,
+
+	salt, err := saltpkg.NewSalt(storage, &saltpkg.Config{
+		HashFunc: saltpkg.SHA1Hash,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	p := &PathMap{Name: "foo", Salt: salt}
+
+	testSalting(t, storage, salt, &PathMap{Name: "foo", Salt: salt})
+}
+
+func testSalting(t *testing.T, storage logical.Storage, salt *saltpkg.Salt, p *PathMap) {
 	var b logical.Backend = &Backend{Paths: p.Paths()}
+	var err error
 
 	// Write via HTTP
 	_, err = b.HandleRequest(context.Background(), &logical.Request{
@@ -172,7 +178,7 @@ func TestPathMap_Salted(t *testing.T) {
 	}
 
 	// Ensure the path is salted
-	expect := salt.SaltID("a")
+	expect := salt.SaltIDHashFunc("a", "sha2-256", "-", saltpkg.SHA256Hash)
 	out, err = storage.Get("struct/map/foo/" + expect)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -280,7 +286,41 @@ func TestPathMap_Salted(t *testing.T) {
 	}
 	found := false
 	for _, v := range list {
-		if v == salt.SaltID("b") {
+		if v == salt.SaltIDHashFunc("b", "sha2-256", "-", saltpkg.SHA256Hash) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("did not find upgraded value")
+	}
+
+	// Put in a SHA1 salted version and make sure that after reading its been
+	// upgraded
+	err = storage.Put(&logical.StorageEntry{
+		Key:   "struct/map/foo/" + salt.SaltID("b"),
+		Value: []byte(`{"foo": "bar"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A read should transparently upgrade
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "map/foo/b",
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, _ = storage.List("struct/map/foo/")
+	if len(list) != 1 {
+		t.Fatalf("unexpected number of entries left after upgrade; expected 1, got %d", len(list))
+	}
+	found = false
+	for _, v := range list {
+		if v == salt.SaltIDHashFunc("b", "sha2-256", "-", saltpkg.SHA256Hash) {
 			found = true
 			break
 		}
@@ -292,155 +332,17 @@ func TestPathMap_Salted(t *testing.T) {
 
 func TestPathMap_SaltFunc(t *testing.T) {
 	storage := new(logical.InmemStorage)
-	locSalt, err := salt.NewSalt(storage, &salt.Config{
-		HashFunc: salt.SHA1Hash,
+
+	salt, err := saltpkg.NewSalt(storage, &saltpkg.Config{
+		HashFunc: saltpkg.SHA1Hash,
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	saltFunc := func() (*salt.Salt, error) {
-		return locSalt, nil
-	}
-	p := &PathMap{Name: "foo", SaltFunc: saltFunc}
-	var b logical.Backend = &Backend{Paths: p.Paths()}
 
-	// Write via HTTP
-	_, err = b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "map/foo/a",
-		Data: map[string]interface{}{
-			"value": "bar",
-		},
-		Storage: storage,
-	})
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
+	saltFunc := func() (*saltpkg.Salt, error) {
+		return salt, nil
 	}
 
-	// Non-salted version should not be there
-	out, err := storage.Get("struct/map/foo/a")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out != nil {
-		t.Fatalf("non-salted key found")
-	}
-
-	// Ensure the path is salted
-	expect := locSalt.SaltID("a")
-	out, err = storage.Get("struct/map/foo/" + expect)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if out == nil {
-		t.Fatalf("missing salted key")
-	}
-
-	// Read via HTTP
-	resp, err := b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "map/foo/a",
-		Storage:   storage,
-	})
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
-	if resp.Data["value"] != "bar" {
-		t.Fatalf("bad: %#v", resp)
-	}
-
-	// Read via API
-	v, err := p.Get(storage, "a")
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
-	if v["value"] != "bar" {
-		t.Fatalf("bad: %#v", v)
-	}
-
-	// Read via API with other casing
-	v, err = p.Get(storage, "A")
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
-	if v["value"] != "bar" {
-		t.Fatalf("bad: %#v", v)
-	}
-
-	// Verify List
-	keys, err := p.List(storage, "")
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
-	if len(keys) != 1 || keys[0] != expect {
-		t.Fatalf("bad: %#v", keys)
-	}
-
-	// Delete via HTTP
-	resp, err = b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.DeleteOperation,
-		Path:      "map/foo/a",
-		Storage:   storage,
-	})
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
-	if resp != nil {
-		t.Fatalf("bad: %#v", resp)
-	}
-
-	// Re-read via HTTP
-	resp, err = b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "map/foo/a",
-		Storage:   storage,
-	})
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
-	if _, ok := resp.Data["value"]; ok {
-		t.Fatalf("bad: %#v", resp)
-	}
-
-	// Re-read via API
-	v, err = p.Get(storage, "a")
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
-	if v != nil {
-		t.Fatalf("bad: %#v", v)
-	}
-
-	// Put in a non-salted version and make sure that after reading it's been
-	// upgraded
-	err = storage.Put(&logical.StorageEntry{
-		Key:   "struct/map/foo/b",
-		Value: []byte(`{"foo": "bar"}`),
-	})
-	if err != nil {
-		t.Fatal("err: %v", err)
-	}
-	// A read should transparently upgrade
-	resp, err = b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "map/foo/b",
-		Storage:   storage,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	list, _ := storage.List("struct/map/foo/")
-	if len(list) != 1 {
-		t.Fatalf("unexpected number of entries left after upgrade; expected 1, got %d", len(list))
-	}
-	found := false
-	for _, v := range list {
-		if v == locSalt.SaltID("b") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatal("did not find upgraded value")
-	}
+	testSalting(t, storage, salt, &PathMap{Name: "foo", SaltFunc: saltFunc})
 }

--- a/logical/framework/path_map_test.go
+++ b/logical/framework/path_map_test.go
@@ -178,7 +178,7 @@ func testSalting(t *testing.T, storage logical.Storage, salt *saltpkg.Salt, p *P
 	}
 
 	// Ensure the path is salted
-	expect := salt.SaltIDHashFunc("a", "sha2-256", "-", saltpkg.SHA256Hash)
+	expect := "s" + salt.SaltIDHashFunc("a", saltpkg.SHA256Hash)
 	out, err = storage.Get("struct/map/foo/" + expect)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -286,7 +286,7 @@ func testSalting(t *testing.T, storage logical.Storage, salt *saltpkg.Salt, p *P
 	}
 	found := false
 	for _, v := range list {
-		if v == salt.SaltIDHashFunc("b", "sha2-256", "-", saltpkg.SHA256Hash) {
+		if v == "s"+salt.SaltIDHashFunc("b", saltpkg.SHA256Hash) {
 			found = true
 			break
 		}
@@ -320,7 +320,7 @@ func testSalting(t *testing.T, storage logical.Storage, salt *saltpkg.Salt, p *P
 	}
 	found = false
 	for _, v := range list {
-		if v == salt.SaltIDHashFunc("b", "sha2-256", "-", saltpkg.SHA256Hash) {
+		if v == "s"+salt.SaltIDHashFunc("b", saltpkg.SHA256Hash) {
 			found = true
 			break
 		}


### PR DESCRIPTION
This PR replaces the usage of SHA1 salting in PathMap (which is used by AppID) by SHA2-256 hashing.

A hash identifier prefix is added to the salted value in the storage to indicate that an upgrade has already been made. This is used to avoid double salting of the already upgraded values.

Fixes https://mail.google.com/mail/u/0/?zx=ntve45vxrq9j#inbox/15fe5fb68bf5048d