### PR TITLE
Made the auth step clearer

### DIFF
--- a/website/source/intro/getting-started/dev-server.html.md
+++ b/website/source/intro/getting-started/dev-server.html.md
@@ -79,7 +79,7 @@ With the dev server running, do the following three things before anything else:
   3. Save the unseal key somewhere. Don't worry about _how_ to save this
      securely. For now, just save it anywhere.
 
-  4. Do the same as step 3, but with the root token. We'll use this later.
+  4. Run `vault auth` and use the `Root Token` that was displayed to authenticate.
 
 ## Verify the Server is Running
 


### PR DESCRIPTION
I had missed this step, so on the next page when it came time to write to the vault, I was greeted with `missing client token` errors.

On my local install, it said:

```
The only step you need to take is to set the following
environment variables:
    export VAULT_ADDR='http://0.0.0.0:8200'
```

So I must have skimmed over these steps, believing that that step was indeed the only step I needed to finish setup.

Here is the full getting started experience:

1. Use Kitematic to create a container from the vault image
2. Use Kitematic to open a shell into the container using the exec button
3. Follow the getting started guide

```
/ # vault
usage: vault [-version] [-help] <command> [args]

Common commands:
    delete           Delete operation on secrets in Vault
    path-help        Look up the help for a path
    read             Read data or secrets from Vault
    renew            Renew the lease of a secret
    revoke           Revoke a secret.
    server           Start a Vault server
    status           Outputs status of whether Vault is sealed and if HA mode is enabled
    unwrap           Unwrap a wrapped secret
    write            Write secrets or configuration into Vault

All other commands:
    audit-disable    Disable an audit backend
    audit-enable     Enable an audit backend
    audit-list       Lists enabled audit backends in Vault
    auth             Prints information about how to authenticate with Vault
    auth-disable     Disable an auth provider
    auth-enable      Enable a new auth provider
    capabilities     Fetch the capabilities of a token on a given path
    generate-root    Generates a new root token
    init             Initialize a new Vault server
    key-status       Provides information about the active encryption key
    list             List data or secrets in Vault
    mount            Mount a logical backend
    mount-tune       Tune mount configuration parameters
    mounts           Lists mounted backends in Vault
    policies         List the policies on the server
    policy-delete    Delete a policy from the server
    policy-write     Write a policy to the server
    rekey            Rekeys Vault to generate new unseal keys
    remount          Remount a secret backend to a new path
    rotate           Rotates the backend encryption key used to persist data
    seal             Seals the Vault server
    ssh              Initiate an SSH session
    step-down        Force the Vault node to give up active duty
    token-create     Create a new auth token
    token-lookup     Display information about the specified token
    token-renew      Renew an auth token if there is an associated lease
    token-revoke     Revoke one or more auth tokens
    unmount          Unmount a secret backend
    unseal           Unseals the Vault server
    version          Prints the Vault version

/ # vault status
Error checking seal status: Get https://127.0.0.1:8200/v1/sys/seal-status: http: server gave HTTP response to HTTPS client
/ # export VAULT_ADDR='http://0.0.0.0:8200'
/ # vault status
Seal Type: shamir
Sealed: false
Key Shares: 1
Key Threshold: 1
Unseal Progress: 0
Unseal Nonce: 
Version: 0.9.1
Cluster Name: [REMOVED]
Cluster ID: [REMOVED]

High-Availability Enabled: false
/ # vault write secret/hello value=world
Error writing data to secret/hello: Error making API request.

URL: PUT http://0.0.0.0:8200/v1/secret/hello
Code: 400. Errors:

* missing client token
/ # vault auth
Token (will be hidden): 
Successfully authenticated! You are now logged in.
token: [REMOVED]
token_duration: 0
token_policies: [root]
/ # vault write secret/hello value=world
Success! Data written to: secret/hello
/ # vault write secret/hello value=world excited=yes
Success! Data written to: secret/hello
```