### PR TITLE
Don't allow non-printable characters in the API client's token

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -98,12 +98,8 @@ func TestClientToken(t *testing.T) {
 
 func TestClientBadToken(t *testing.T) {
 	tokenValue := "foo\u007f"
-	handler := func(w http.ResponseWriter, req *http.Request) {}
 
-	config, ln := testHTTPServer(t, http.HandlerFunc(handler))
-	defer ln.Close()
-
-	client, err := NewClient(config)
+	client, err := NewClient(nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -107,15 +107,13 @@ func TestClientBadToken(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	/*
-		client.SetToken("foo")
-		_, err = client.RawRequest(client.NewRequest("PUT", "/"))
-		if err != nil {
-			t.Fatal(err)
-		}
-	*/
+	client.SetToken("foo")
+	_, err = client.RawRequest(client.NewRequest("PUT", "/"))
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	client.SetToken("foo\u00f7")
+	client.SetToken("foo\u007f")
 	_, err = client.RawRequest(client.NewRequest("PUT", "/"))
 	if err == nil || !strings.Contains(err.Error(), "printable") {
 		t.Fatalf("expected error due to bad token")

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -97,16 +97,25 @@ func TestClientToken(t *testing.T) {
 }
 
 func TestClientBadToken(t *testing.T) {
-	tokenValue := "foo\u007f"
+	handler := func(w http.ResponseWriter, req *http.Request) {}
 
-	client, err := NewClient(nil)
+	config, ln := testHTTPServer(t, http.HandlerFunc(handler))
+	defer ln.Close()
+
+	client, err := NewClient(config)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	client.SetToken(tokenValue)
+	/*
+		client.SetToken("foo")
+		_, err = client.RawRequest(client.NewRequest("PUT", "/"))
+		if err != nil {
+			t.Fatal(err)
+		}
+	*/
 
-	// Do a raw "/" request
+	client.SetToken("foo\u00f7")
 	_, err = client.RawRequest(client.NewRequest("PUT", "/"))
 	if err == nil || !strings.Contains(err.Error(), "printable") {
 		t.Fatalf("expected error due to bad token")


### PR DESCRIPTION
A better place to do this would be SetToken but that would require API
breaks so this is a better solution for now.