### PR TITLE
auth/aws: Fix error with empty bound_iam_principal_arn

### DIFF
--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -500,7 +500,7 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 		// This allows the user to sumbit an update with the same ARN to force Vault
 		// to re-resolve the ARN to the unique ID, in case an entity was deleted and
 		// recreated
-		if roleEntry.ResolveAWSUniqueIDs && !strings.HasSuffix(roleEntry.BoundIamPrincipalARN, "*") {
+		if roleEntry.ResolveAWSUniqueIDs && roleEntry.BoundIamPrincipalARN != "" && !strings.HasSuffix(roleEntry.BoundIamPrincipalARN, "*") {
 			principalID, err := b.resolveArnToUniqueIDFunc(ctx, req.Storage, principalARN)
 			if err != nil {
 				return logical.ErrorResponse(fmt.Sprintf("failed updating the unique ID of ARN %#v: %#v", principalARN, err)), nil

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -118,6 +118,20 @@ func TestBackend_pathRoleEc2(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	data["bound_iam_principal_arn"] = ""
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "role/ami-abcd456",
+		Data:      data,
+		Storage:   storage,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && resp.IsError() {
+		t.Fatalf("failed to update role with empty bound_iam_principal_arn: %s", resp.Data["error"])
+	}
+
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.ListOperation,
 		Path:      "roles",
@@ -154,6 +168,7 @@ func TestBackend_pathRoleEc2(t *testing.T) {
 	if resp != nil {
 		t.Fatalf("bad: response: expected:nil actual:%#v\n", resp)
 	}
+
 }
 
 func Test_enableIamIDResolution(t *testing.T) {

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -168,7 +168,6 @@ func TestBackend_pathRoleEc2(t *testing.T) {
 	if resp != nil {
 		t.Fatalf("bad: response: expected:nil actual:%#v\n", resp)
 	}
-
 }
 
 func Test_enableIamIDResolution(t *testing.T) {


### PR DESCRIPTION
In cases where there doesn't need to be a bound_iam_principal_arn, i.e.,
either auth_type is ec2 or there are other bindings with the iam
auth_type, but it is specified explicitly anyway, Vault tried to parse
it to resolve to internal unique IDs. This now checks to ensure that
bound_iam_principal_arn is non-empty before attempting to resolve it.

Fixes #3837