### PR TITLE
#3850 Fixed documentation for aws/sts ttl

### DIFF
--- a/website/source/docs/secrets/aws/index.html.md
+++ b/website/source/docs/secrets/aws/index.html.md
@@ -218,10 +218,10 @@ To generate a new set of STS federation token credentials, we simply write to
 the role using the aws/sts endpoint:
 
 ```text
-$vault write aws/sts/deploy -ttl=60m
+$vault write aws/sts/deploy ttl=60m
 Key            	Value
 lease_id       	aws/sts/deploy/31d771a6-fb39-f46b-fdc5-945109106422
-lease_duration 	3600
+lease_duration 	60m0s
 lease_renewable	true
 access_key     	ASIAJYYYY2AA5K4WIXXX
 secret_key     	HSs0DYYYYYY9W81DXtI0K7X84H+OVZXK5BXXXX
@@ -287,10 +287,10 @@ To generate a new set of STS assumed role credentials, we again write to
 the role using the aws/sts endpoint:
 
 ```text
-$vault write aws/sts/deploy -ttl=60m
+$vault write aws/sts/deploy ttl=60m
 Key            	Value
 lease_id       	aws/sts/deploy/31d771a6-fb39-f46b-fdc5-945109106422
-lease_duration 	3600
+lease_duration 	60m0s
 lease_renewable	true
 access_key     	ASIAJYYYY2AA5K4WIXXX
 secret_key     	HSs0DYYYYYY9W81DXtI0K7X84H+OVZXK5BXXXX


### PR DESCRIPTION
Updated the `vault write aws/sts` parameter to remove the dash.  It fails to set the TTL otherwise.  Also fixed the output format of the `lease_duration`.

Fixes #3850