### PR TITLE
website: add note about the 0.9.2+ CLI changes to reduce confusion

### DIFF
--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -11,6 +11,10 @@ description: |-
 
 # Vault Commands (CLI)
 
+~> **Note:** The Vault CLI interface was changed substantially in 0.9.2+ and may cause
+confusion while using older versions of Vault with this documentation. Read our
+[upgrade guide](/guides/upgrading/upgrade-to-0.9.2.html#backwards-compatible-cli-changes) for more information.
+
 In addition to a verbose [HTTP API](/api/index.html), Vault features a
 command-line interface that wraps common functionality and formats output. The
 Vault CLI is a single static binary. It is a thin wrapper around the HTTP API.

--- a/website/source/guides/upgrading/upgrade-to-0.9.2.html.md
+++ b/website/source/guides/upgrading/upgrade-to-0.9.2.html.md
@@ -12,6 +12,21 @@ description: |-
 This page contains the list of deprecations and important or breaking changes
 for Vault 0.9.2 compared to 0.9.1. Please read it carefully.
 
+### Backwards Compatible CLI Changes
+
+This upgrade guide is typically reserved for breaking changes, however it
+is worth calling out that the CLI interface to Vault has been completely
+revamped while maintaining backwards compatbitility. This could lead to
+potential confusion  while browsing the latest version of the Vault
+documentation on vaultproject.io.
+
+All previous CLI commands should continue to work and are backwards
+compatible in almost all cases.
+
+Documentation for previous versions of Vault can be accessed using
+the GitHub interface by browsing tags (eg [0.9.1 website tree](https://github.com/hashicorp/vault/tree/v0.9.1/website)) or by
+[building the Vault website locally](https://github.com/hashicorp/vault/tree/v0.9.1/website#running-the-site-locally).
+
 ### `sys/health` DR Secondary Reporting
 
 The `replication_dr_secondary` bool returned by `sys/health` could be

--- a/website/source/guides/upgrading/upgrade-to-0.9.3.html.md
+++ b/website/source/guides/upgrading/upgrade-to-0.9.3.html.md
@@ -1,0 +1,14 @@
+---
+layout: "guides"
+page_title: "Upgrading to Vault 0.9.2 - Guides"
+sidebar_current: "guides-upgrading-to-0.9.2"
+description: |-
+  This page contains the list of deprecations and important or breaking changes
+  for Vault 0.9.3. Please read it carefully.
+---
+
+Due to a rapid release following 0.9.2, there are no version-specific upgrade
+instructions although any for 0.9.2 apply if you are coming from a previous version.
+
+Please see the [0.9.2 upgrade guide](/guides/upgrading/upgrade-to-0.9.2.html) for notes on upgrading to 0.9.3.
+

--- a/website/source/guides/upgrading/upgrade-to-0.9.3.html.md
+++ b/website/source/guides/upgrading/upgrade-to-0.9.3.html.md
@@ -7,6 +7,8 @@ description: |-
   for Vault 0.9.3. Please read it carefully.
 ---
 
+# Overview
+
 Due to a rapid release following 0.9.2, there are no version-specific upgrade
 instructions although any upgrade notices for 0.9.2 apply if you are coming
 from a previous version.

--- a/website/source/guides/upgrading/upgrade-to-0.9.3.html.md
+++ b/website/source/guides/upgrading/upgrade-to-0.9.3.html.md
@@ -1,14 +1,15 @@
 ---
 layout: "guides"
-page_title: "Upgrading to Vault 0.9.2 - Guides"
-sidebar_current: "guides-upgrading-to-0.9.2"
+page_title: "Upgrading to Vault 0.9.3 - Guides"
+sidebar_current: "guides-upgrading-to-0.9.3"
 description: |-
   This page contains the list of deprecations and important or breaking changes
   for Vault 0.9.3. Please read it carefully.
 ---
 
 Due to a rapid release following 0.9.2, there are no version-specific upgrade
-instructions although any for 0.9.2 apply if you are coming from a previous version.
+instructions although any upgrade notices for 0.9.2 apply if you are coming
+from a previous version.
 
 Please see the [0.9.2 upgrade guide](/guides/upgrading/upgrade-to-0.9.2.html) for notes on upgrading to 0.9.3.
 

--- a/website/source/layouts/guides.erb
+++ b/website/source/layouts/guides.erb
@@ -62,6 +62,9 @@
           <li<%= sidebar_current("guides-upgrading-to-0.9.2") %>>
             <a href="/guides/upgrading/upgrade-to-0.9.2.html">Upgrade to 0.9.2</a>
           </li>
+          <li<%= sidebar_current("guides-upgrading-to-0.9.3") %>>
+            <a href="/guides/upgrading/upgrade-to-0.9.3.html">Upgrade to 0.9.3</a>
+          </li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
There has been some confusion about the revamped CLI in 0.9.2+. Though deprecation notices and backwards compatibility exist for almost all commands in the previous version, the website documentation at [vaultproject.io](https://www.vaultproject.io) shows only the latest version. When browsing documentation as an older user of Vault, this can cause significant confusion.

This adds a notice to the top of the CLI index page in the docs:

![image](https://user-images.githubusercontent.com/846194/35581456-a9c6d35e-05a0-11e8-9903-0b07aedfb38f.png)

And a note about the changes in the upgrade guide:

![image](https://user-images.githubusercontent.com/846194/35581503-d1682610-05a0-11e8-8245-3c6d4baad19f.png)

The latter note should point people to GitHub for easy browsing of markdown or the more complex but polished option of building an older version of the Vault website. I also added a 0.9.3 specific upgrade guide pointing to the 0.9.2 guide due to the [rapid follow-on release of 0.9.3](https://groups.google.com/forum/#!topic/vault-tool/fvVfGlFmXCY).