### PR TITLE
Adds RPM packages and SELinux policy

### DIFF
--- a/rpm/vault.config
+++ b/rpm/vault.config
@@ -1,0 +1,8 @@
+backend "file" {
+  path = "/var/lib/vault/"
+}
+
+listener "tcp" {
+  address = "127.0.0.1:8200"
+  tls_disable = 1
+}

--- a/rpm/vault.fc
+++ b/rpm/vault.fc
@@ -1,0 +1,5 @@
+/usr/bin/vault		--	gen_context(system_u:object_r:vault_exec_t,s0)
+
+/usr/lib/systemd/system/vault.service		--	gen_context(system_u:object_r:vault_unit_file_t,s0)
+
+/var/lib/vault(/.*)?		gen_context(system_u:object_r:vault_var_lib_t,s0)

--- a/rpm/vault.if
+++ b/rpm/vault.if
@@ -1,0 +1,223 @@
+
+## <summary>policy for vault</summary>
+
+########################################
+## <summary>
+##	Execute vault_exec_t in the vault domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`vault_domtrans',`
+	gen_require(`
+		type vault_t, vault_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, vault_exec_t, vault_t)
+')
+
+######################################
+## <summary>
+##	Execute vault in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`vault_exec',`
+	gen_require(`
+		type vault_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, vault_exec_t)
+')
+
+########################################
+## <summary>
+##	Search vault lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`vault_search_lib',`
+	gen_require(`
+		type vault_var_lib_t;
+	')
+
+	allow $1 vault_var_lib_t:dir search_dir_perms;
+	files_search_var_lib($1)
+')
+
+########################################
+## <summary>
+##	Read vault lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`vault_read_lib_files',`
+	gen_require(`
+		type vault_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	read_files_pattern($1, vault_var_lib_t, vault_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage vault lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`vault_manage_lib_files',`
+	gen_require(`
+		type vault_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_files_pattern($1, vault_var_lib_t, vault_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage vault lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`vault_manage_lib_dirs',`
+	gen_require(`
+		type vault_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_dirs_pattern($1, vault_var_lib_t, vault_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Execute vault server in the vault domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`vault_systemctl',`
+	gen_require(`
+		type vault_t;
+		type vault_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+        systemd_read_fifo_file_passwd_run($1)
+	allow $1 vault_unit_file_t:file read_file_perms;
+	allow $1 vault_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, vault_t)
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an vault environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`vault_admin',`
+	gen_require(`
+		type vault_t;
+		type vault_var_lib_t;
+	type vault_unit_file_t;
+	')
+
+	allow $1 vault_t:process { signal_perms };
+	ps_process_pattern($1, vault_t)
+
+    tunable_policy(`deny_ptrace',`',`
+        allow $1 vault_t:process ptrace;
+    ')
+
+	files_search_var_lib($1)
+	admin_pattern($1, vault_var_lib_t)
+
+	vault_systemctl($1)
+	admin_pattern($1, vault_unit_file_t)
+	allow $1 vault_unit_file_t:service all_service_perms;
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')
+
+########################################
+## <summary>
+##      Make a TCP connection to the vault port.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`vault_connect',`
+        gen_require(`
+                type vault_port_t;
+        ')
+
+        allow $1 vault_port_t:tcp_socket name_connect;
+	corenet_tcp_connect_trivnet1_port($1)
+')
+
+########################################
+## <summary>
+##      Bind TCP sockets to the vault port.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <infoflow type="none"/>
+#
+interface(`vault_tcp_bind_vault_port',`
+        gen_require(`
+                type vault_port_t;
+        ')
+
+        allow $1 vault_port_t:tcp_socket name_bind;
+
+')

--- a/rpm/vault.service
+++ b/rpm/vault.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Vault secret management tool
+After=syslog.target network.target local-fs.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=simple
+User=vault
+Group=vault
+ExecStart=/usr/bin/vault server -config=/etc/vault/vault.config
+ExecReload=/bin/kill -s HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/rpm/vault.spec
+++ b/rpm/vault.spec
@@ -1,0 +1,176 @@
+%global provider        github
+%global provider_tld    com
+%global project         hashicorp
+%global repo            vault
+%global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
+%global import_path     %{provider_prefix}
+%if 0%{?_commit:1}
+# rpmbuild -ba --define "_commit 409b441c31f83279af0db289123eb4b0b14809a6" *.spec
+%global commit          %{_commit}
+%else
+%global commit          15982cfa072fc6898f56d8320a460b5bafb7606b
+%endif
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
+%if ! 0%{?gobuild:1}
+%define gobuild(o:) go build -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n')" -a -v -x %{?**};
+%endif
+
+%if ! 0%{?gotest:1}
+%define gotest() go test -ldflags "${LDFLAGS:-}" %{?**}
+%endif
+
+Name:           vault
+Version:        0.9.3
+Release:        2.git%{shortcommit}%{?dist}
+Summary:        Vault is a tool for securely accessing secrets
+License:        MPLv2.0
+URL:            https://www.vaultproject.io
+Source0:        https://%{provider_prefix}/archive/%{commit}/%{repo}-%{shortcommit}.tar.gz
+Source1:        %{name}.config
+Source2:        %{name}.service
+
+# e.g. el6 has ppc64 arch without gcc-go, so EA tag is required
+ExclusiveArch:  %{?go_arches:%{go_arches}}%{!?go_arches:%{ix86} x86_64 %{arm}}
+# If go_compiler is not set to 1, there is no virtual provide. Use golang instead.
+BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang} >= 1.9
+BuildRequires:  systemd
+BuildRequires:  git
+
+Requires(pre):          shadow-utils
+Requires(post):         systemd libcap
+Requires(preun):        systemd
+Requires(postun):       systemd
+
+%description
+Vault secures, stores, and tightly controls access to tokens, passwords,
+certificates, API keys, and other secrets in modern computing. Vault handles
+leasing, key revocation, key rolling, and auditing. Through a unified API, users
+can access an encrypted Key/Value store and network encryption-as-a-service, or
+generate AWS IAM/STS credentials, SQL/NoSQL databases, X.509 certificates, SSH
+credentials, and more.
+
+%package selinux
+Source3:        	%{name}.te
+Source4:        	%{name}.fc
+Source5:        	%{name}.if
+
+BuildRequires:  	selinux-policy selinux-policy-devel
+Requires:       	policycoreutils, libselinux-utils
+
+Requires(post):         policycoreutils, policycoreutils-python 
+Requires(postun):       policycoreutils
+
+Summary: SELinux policy for %{name}
+
+%prep
+%setup -q -n %{name}-%{commit}
+
+mkdir -p selinux
+cd selinux
+cp %{SOURCE3} %{SOURCE4} %{SOURCE5} .
+cd -
+
+%build
+mkdir -p src/%{provider}.%{provider_tld}/%{project}
+ln -s ../../../ src/%{provider}.%{provider_tld}/%{project}/%{repo}
+
+ls -lhA
+ls -lhA src/%{provider}.%{provider_tld}/%{project}/%{repo}
+
+%if ! 0%{?with_bundled}
+export GOPATH=$(pwd):%{gopath}
+%else
+export GOPATH=$(pwd):$(pwd)/Godeps/_workspace:%{gopath}
+%endif
+
+%gobuild -o bin/%{name} %{import_path} || exit 1
+
+cd selinux
+make -f /usr/share/selinux/devel/Makefile %{name}.pp || exit
+cd -
+
+%install
+mkdir -p %{buildroot}%{_bindir}/
+cp -p bin/%{name} %{buildroot}%{_bindir}/
+
+mkdir -p %{buildroot}%{_sysconfdir}/%{name}
+cp -p %{SOURCE1} %{buildroot}%{_sysconfdir}/%{name}/%{name}.config
+
+mkdir -p %{buildroot}%{_sharedstatedir}/%{name}
+
+mkdir -p %{buildroot}%{_unitdir}
+cp -p %{SOURCE2} %{buildroot}%{_unitdir}
+
+install -d %{buildroot}%{_datadir}/selinux/packages
+install -m 0600 selinux/%{name}.pp %{buildroot}%{_datadir}/selinux/packages
+install -d %{buildroot}%{_datadir}/selinux/devel/include/contrib
+install -m 0644 selinux/%{name}.if %{buildroot}%{_datadir}/selinux/devel/include/contrib/
+
+%clean
+rm -rf %{buildroot}
+rm -rf %{_builddir}/*
+
+%files
+%{_bindir}/%{name}
+%dir %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/%{name}.config
+%attr(0750,%{name},%{name}) %dir %{_sharedstatedir}/%{name}
+%{_unitdir}/%{name}.service
+
+%doc CHANGELOG.md README.md LICENSE CHANGELOG.md
+
+%pre
+getent group %{name} > /dev/null || groupadd -r %{name}
+getent passwd %{name} > /dev/null || \
+    useradd -r -d %{_sharedstatedir}/%{name} -g %{name} \
+    -s /sbin/nologin -c "Vault secret management tool" %{name}
+exit 0
+
+%post
+/sbin/setcap cap_ipc_lock=+ep %{_bindir}/%{name}
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
+%description selinux
+SELinux policy for %{name}
+
+%files selinux
+%{_datadir}/selinux/packages/%{name}.pp
+%{_datadir}/selinux/devel/include/contrib/%{name}.if
+
+%post selinux
+semodule -n -i %{_datadir}/selinux/packages/%{name}.pp
+if /usr/sbin/selinuxenabled ; then
+    /usr/sbin/load_policy
+    %relabel_files
+fi;
+semanage port -a -t %{name}_port_t -p tcp "8201,8202"
+semanage port -a -t %{name}_port_t -p udp "8201,8202"
+exit 0
+
+%postun selinux
+if [ $1 -eq 0 ]; then
+    semanage port -d -t %{name}_port_t -p tcp "8201,8202"
+    semanage port -d -t %{name}_port_t -p udp "8201,8202"
+
+    semodule -n -r %{name}
+    if /usr/sbin/selinuxenabled ; then
+       /usr/sbin/load_policy
+       %relabel_files
+    fi;
+fi;
+exit 0
+
+%changelog
+* Thu Feb 01 2018 fuero <fuerob@gmail.com> - 0.9.3-2.git15982cf
+- splits selinux policy to extra package
+
+* Wed Jan 31 2018 fuero <fuerob@gmail.com> - 0.9.3-1.git15982cf
+- initial package
+

--- a/rpm/vault.te
+++ b/rpm/vault.te
@@ -1,0 +1,84 @@
+policy_module(vault, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type vault_t;
+type vault_exec_t;
+init_daemon_domain(vault_t, vault_exec_t)
+
+type vault_var_lib_t;
+files_type(vault_var_lib_t)
+
+type vault_unit_file_t;
+systemd_unit_file(vault_unit_file_t)
+
+type vault_port_t;
+corenet_port(vault_port_t)
+
+allow vault_t self:fifo_file rw_fifo_file_perms;
+allow vault_t self:unix_stream_socket create_stream_socket_perms;
+
+manage_dirs_pattern(vault_t, vault_var_lib_t, vault_var_lib_t)
+manage_files_pattern(vault_t, vault_var_lib_t, vault_var_lib_t)
+manage_lnk_files_pattern(vault_t, vault_var_lib_t, vault_var_lib_t)
+files_var_lib_filetrans(vault_t, vault_var_lib_t, { dir file lnk_file })
+
+domain_use_interactive_fds(vault_t)
+
+files_read_etc_files(vault_t)
+
+miscfiles_read_localization(vault_t)
+
+allow vault_t self:capability ipc_lock;
+allow vault_t self:netlink_route_socket { bind create getattr nlmsg_read };
+allow vault_t self:tcp_socket { accept bind create getattr listen setopt connect getopt };
+allow vault_t self:udp_socket { connect create getattr setopt };
+
+corenet_tcp_bind_generic_node(vault_t)
+# Vault default port
+corenet_tcp_bind_trivnet1_port(vault_t)
+kernel_read_net_sysctls(vault_t)
+kernel_search_network_sysctl(vault_t)
+
+kernel_read_net_sysctls(vault_t)
+kernel_search_network_sysctl(vault_t)
+miscfiles_read_generic_certs(vault_t)
+sysnet_read_config(vault_t)
+
+# semanage port -a -t vault_port_t -p tcp '8201,8202'
+vault_tcp_bind_vault_port(vault_t)
+
+gen_tunable(vault_ldap_connect, false)
+tunable_policy(`vault_ldap_connect',`
+corenet_tcp_connect_ldap_port(vault_t)
+')
+
+gen_tunable(vault_mysqld_connect, false)
+tunable_policy(`vault_mysqld_connect',`
+corenet_tcp_connect_mysqld_port(vault_t)
+')
+
+gen_tunable(vault_postgresql_connect, false)
+tunable_policy(`vault_postgresql_connect',`
+corenet_tcp_connect_postgresql_port(vault_t)
+')
+
+gen_tunable(vault_zookeeper_connect, false)
+tunable_policy(`vault_zookeeper_connect',`
+corenet_tcp_connect_zookeeper_client_port(vault_t)
+')
+
+gen_tunable(vault_couchdb_connect, false)
+tunable_policy(`vault_couchdb_connect',`
+corenet_tcp_connect_couchdb_port(vault_t)
+')
+
+gen_tunable(vault_http_connect, false)
+tunable_policy(`vault_http_connect',`
+corenet_tcp_connect_http_cache_port(vault_t)
+corenet_tcp_connect_http_port(vault_t)
+corenet_tcp_connect_squid_port(vault_t)
+')


### PR DESCRIPTION
As there's no official RPM package for vault that I am aware of, I've created a 
RPM package and SELinux policy I will be using at work for Vault.

Tested on CentOS Linux release 7.4.1708 (Core), built with Google's Golang RPM packages for EL.

Perhaps you'd like to offer RPMs compatible to EPEL for vault using this.
