### PR TITLE
Create audit failure metrics unconditionally

### DIFF
--- a/vault/audit.go
+++ b/vault/audit.go
@@ -525,7 +525,7 @@ func (a *AuditBroker) LogRequest(ctx context.Context, auth *logical.Auth, req *l
 		}
 
 		ret = retErr.ErrorOrNil()
-		failure := 0.0
+		failure := float32(0.0)
 		if ret != nil {
 			failure = 1.0
 		}
@@ -589,7 +589,7 @@ func (a *AuditBroker) LogResponse(ctx context.Context, auth *logical.Auth, req *
 
 		ret = retErr.ErrorOrNil()
 
-		failure := 0.0
+		failure := float32(0.0)
 		if ret != nil {
 			failure = 1.0
 		}

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -525,10 +525,11 @@ func (a *AuditBroker) LogRequest(ctx context.Context, auth *logical.Auth, req *l
 		}
 
 		ret = retErr.ErrorOrNil()
-
+		failure := 0.0
 		if ret != nil {
-			metrics.IncrCounter([]string{"audit", "log_request_failure"}, 1.0)
+			failure = 1.0
 		}
+		metrics.IncrCounter([]string{"audit", "log_request_failure"}, failure)
 	}()
 
 	// All logged requests must have an identifier
@@ -588,9 +589,11 @@ func (a *AuditBroker) LogResponse(ctx context.Context, auth *logical.Auth, req *
 
 		ret = retErr.ErrorOrNil()
 
+		failure := 0.0
 		if ret != nil {
-			metrics.IncrCounter([]string{"audit", "log_response_failure"}, 1.0)
+			failure = 1.0
 		}
+		metrics.IncrCounter([]string{"audit", "log_response_failure"}, failure)
 	}()
 
 	headers := req.Headers


### PR DESCRIPTION
It seems inconvenient/dangerous to me that the stats related to audit failures will not be created until a failure is encountered. This means dashboards / alerts will appear blank in the steady state which makes it hard to tell if there is no data because Vault is auditing correctly or if there is no data because the monitoring is not configured correctly.

In my opinion, it would be ideal for all timeseries metrics exported to be given this treatment, but the auditing related stats seem to be both important and rare-to-fail which was my motivation here.