### PR TITLE
Support Okta and Duo Push for Okta MFA.

### DIFF
--- a/builtin/credential/okta/backend.go
+++ b/builtin/credential/okta/backend.go
@@ -3,11 +3,19 @@ package okta
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"encoding/json"
+	"errors"
 	"github.com/chrismalek/oktasdk-go/okta"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/vault/helper/mfa"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
+	"github.com/mitchellh/mapstructure"
+	"net/http"
+	"net/url"
+	"strings"
 )
 
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
@@ -55,6 +63,46 @@ type backend struct {
 	*framework.Backend
 }
 
+// halResource is a Hypertext Application Language resource (used throughout the Okta API).
+// See https://tools.ietf.org/html/draft-kelly-json-hal-06
+// Embedding this Go struct helps deserialize dynamic embedded links and objects.
+type halResource struct {
+	Embedded embedded `mapstructure:"_embedded"`
+	Links    links    `mapstructure:"_links"`
+}
+
+// embedded is a HAL "_embedded" object.
+type embedded map[string]interface{}
+
+// Decode decodes the named embedded object or object list.
+// Dest should be a pointer to a struct, or a pointer to a struct slice for list-valued embeds.
+func (m embedded) Decode(name string, dest interface{}) error {
+	return mapstructure.Decode(m[name], dest)
+}
+
+// links is a HAL "_links" object.
+type links map[string]link
+
+// link is a HAL link.
+type link struct {
+	Href string
+}
+
+type authResult struct {
+	halResource  `mapstructure:",squash"`
+	Status       string
+	FactorResult string
+	StateToken   string
+}
+
+func (r *authResult) UnmarshalJSON(data []byte) error {
+	// Use mapstructure for JSON unmarshalling, since it plays better with HAL dynamic
+	// embedded objects than static struct definitions.
+	m := make(map[string]interface{})
+	json.Unmarshal(data, &m)
+	return mapstructure.Decode(m, r)
+}
+
 func (b *backend) Login(ctx context.Context, req *logical.Request, username string, password string) ([]string, *logical.Response, []string, error) {
 	cfg, err := b.Config(ctx, req.Storage)
 	if err != nil {
@@ -66,15 +114,6 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 
 	client := cfg.OktaClient()
 
-	type embeddedResult struct {
-		User okta.User `json:"user"`
-	}
-
-	type authResult struct {
-		Embedded embeddedResult `json:"_embedded"`
-		Status   string         `json:"status"`
-	}
-
 	authReq, err := client.NewRequest("POST", "authn", map[string]interface{}{
 		"username": username,
 		"password": password,
@@ -83,18 +122,18 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 		return nil, nil, nil, err
 	}
 
-	var result authResult
-	rsp, err := client.Do(authReq, &result)
+	result := &authResult{}
+	_, err = client.Do(authReq, result)
 	if err != nil {
 		return nil, logical.ErrorResponse(fmt.Sprintf("Okta auth failed: %v", err)), nil, nil
-	}
-	if rsp == nil {
-		return nil, logical.ErrorResponse("okta auth method unexpected failure"), nil, nil
 	}
 
 	oktaResponse := &logical.Response{
 		Data: map[string]interface{}{},
 	}
+
+	// More about Okta's Auth transation state here:
+	// https://developer.okta.com/docs/api/resources/authn#transaction-state
 
 	// If lockout failures are not configured to be hidden, the status needs to
 	// be inspected for LOCKED_OUT status. Otherwise, it is handled above by an
@@ -105,6 +144,17 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 			b.Logger().Debug("auth/okta: user is locked out", "user", username)
 		}
 		return nil, logical.ErrorResponse("okta authentication failed"), nil, nil
+
+	case "MFA_ENROLL", "MFA_ENROLL_ACTIVATE":
+		if b.Logger().IsDebug() {
+			b.Logger().Debug("auth/okta: user must enroll or complete mfa enrollment", "user", username)
+		}
+		return nil, logical.ErrorResponse("okta authentication failed: you must complete MFA enrollment to continue"), nil, nil
+
+	case "MFA_REQUIRED":
+		if result, err = b.completeMfa(ctx, client, result); err != nil {
+			return nil, logical.ErrorResponse(fmt.Sprintf("Okta auth failed: %v", err)), nil, nil
+		}
 
 	case "PASSWORD_EXPIRED":
 		if b.Logger().IsDebug() {
@@ -147,7 +197,11 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 	var allGroups []string
 	// Only query the Okta API for group membership if we have a token
 	if cfg.Token != "" {
-		oktaGroups, err := b.getOktaGroups(client, &result.Embedded.User)
+		user := &okta.User{}
+		if err = result.Embedded.Decode("user", user); err != nil {
+			return nil, nil, nil, err
+		}
+		oktaGroups, err := b.getOktaGroups(client, user)
 		if err != nil {
 			return nil, logical.ErrorResponse(fmt.Sprintf("okta failure retrieving groups: %v", err)), nil, nil
 		}
@@ -221,6 +275,224 @@ func (b *backend) getOktaGroups(client *okta.Client, user *okta.User) ([]string,
 		b.Logger().Debug("auth/okta: Groups fetched from Okta", "num_groups", len(oktaGroups), "groups", oktaGroups)
 	}
 	return oktaGroups, nil
+}
+
+func (b *backend) completeMfa(ctx context.Context, client *okta.Client, mfaRequiredResult *authResult) (*authResult, error) {
+	var factors []mfaFactor
+	if err := mfaRequiredResult.Embedded.Decode("factors", &factors); err != nil {
+		return nil, err
+	}
+
+	var handler verifyMfaHandler
+	var factorId string
+	for _, v := range factors {
+		if v.Provider == "OKTA" && v.FactorType == "push" {
+			// For Okta push, the only thing we need to do is hit the verify endpoint.
+			handler = doOktaVerify
+			factorId = v.Id
+		} else if v.Provider == "DUO" && v.FactorType == "web" {
+			handler = b.verifyDuoPush
+			factorId = v.Id
+		}
+	}
+	if handler == nil || factorId == "" {
+		return nil, errors.New("Only Okta Push and Duo Push are supported for Okta MFA.")
+	}
+
+	stateToken := mfaRequiredResult.StateToken
+	// Perform our part of the MFA flow.
+	result, err := handler(client, stateToken, factorId)
+
+	if result.FactorResult == "WAITING" {
+		b.Logger().Debug("auth/okta: waiting for Okta MFA result")
+	}
+	for result.FactorResult == "WAITING" {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			// okta has a documented rate limit of ~1tps, so we try to respect that here
+			time.Sleep(500 * time.Millisecond)
+			if result, err = doOktaVerify(client, stateToken, factorId); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	switch result.FactorResult {
+	case "REJECTED", "TIMEOUT", "CANCELLED", "ERROR":
+		// These are known MFA failure cases and we want to communicate them individually.
+		return nil, fmt.Errorf("multi-factor authentication failed: %s", result.FactorResult)
+	case "":
+		// Empty is success.
+		b.Logger().Debug("auth/okta: multi-factor authentication succeeded")
+		return result, nil
+	default:
+		// In the unknown case, let the caller decide based on status.
+		b.Logger().Debug("auth/okta: unhandled factor result", "status", result.Status, "factor_result", result.FactorResult)
+		return result, nil
+	}
+}
+
+type mfaFactor struct {
+	halResource `mapstructure:",squash"`
+	Id          string
+	FactorType  string
+	Provider    string
+	Profile     map[string]string
+}
+
+// verifyMfaHandler verifies a single type of Okta MFA factor.
+type verifyMfaHandler func(oktaClient *okta.Client, stateToken string, factorId string) (*authResult, error)
+
+// doOktaVerify POSTs to the given factor's verification URL. The first call starts verification,
+// and subsequent calls with the same state token get the current status of the verification.
+func doOktaVerify(oktaClient *okta.Client, stateToken string, factorId string) (*authResult, error) {
+	verifyUrl := fmt.Sprintf("authn/factors/%s/verify", factorId)
+	payload := map[string]interface{}{
+		"stateToken": stateToken,
+	}
+	verifyReq, err := oktaClient.NewRequest("POST", verifyUrl, payload)
+	if err != nil {
+		return nil, err
+	}
+	result := &authResult{}
+	_, err = oktaClient.Do(verifyReq, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (b *backend) verifyDuoPush(oktaClient *okta.Client, stateToken string, factorId string) (*authResult, error) {
+	result, err := doOktaVerify(oktaClient, stateToken, factorId)
+	if err != nil {
+		return nil, err
+	}
+	if result.Status != "MFA_CHALLENGE" {
+		return nil, fmt.Errorf("expected auth status MFA_CHALLENGE, got %s", result.Status)
+	}
+
+	// Extract the challenge details.
+	factor := mfaFactor{}
+	if err = result.Embedded.Decode("factor", &factor); err != nil {
+		return nil, err
+	}
+	var verification struct {
+		halResource  `mapstructure:",squash"`
+		Host         string
+		Signature    string
+		FactorResult string
+	}
+	if err = factor.Embedded.Decode("verification", &verification); err != nil {
+		return nil, err
+	}
+	sigParts := strings.Split(verification.Signature, ":")
+	txSig := sigParts[0]
+	appSig := sigParts[1]
+
+	// Kick off Duo verification exchange.
+	parent := &url.URL{
+		Scheme: oktaClient.BaseURL.Scheme,
+		Host:   oktaClient.BaseURL.Host,
+		Path:   "/signin/verify/duo/web",
+	}
+	queryVals := make(url.Values)
+	queryVals.Add("parent", parent.String())
+	queryVals.Add("tx", txSig)
+	queryVals.Add("v", "2.6")
+	reqUrl := &url.URL{
+		Scheme:   "https",
+		Host:     verification.Host,
+		Path:     "/frame/web/v1/auth",
+		RawQuery: queryVals.Encode(),
+	}
+	var promptUrl *url.URL
+	// We don't actually need to load the UI, just to capture the prompt URL.
+	captureRedirectClient := &http.Client{
+		Transport: cleanhttp.DefaultTransport(),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			promptUrl = req.URL
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := captureRedirectClient.PostForm(reqUrl.String(), queryVals)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	// Send Duo verification push.
+	sid := promptUrl.Query().Get("sid")
+	promptUrl.RawQuery = ""
+	promptVals := map[string]string{
+		"sid": sid,
+		// phone1 is the user's default device. phoneN is the Nth phone in the user's device list.
+		"device": "phone1",
+		"factor": "Duo Push",
+	}
+	var duoResponse struct {
+		Response map[string]string `json:"response"`
+		Stat     string            `json:"stat"`
+	}
+	if err = postForm(promptUrl.String(), promptVals, &duoResponse); err != nil {
+		return nil, err
+	}
+	txid := duoResponse.Response["txid"]
+
+	// Long-poll the status endpoint for status updates.
+	statusUrl := &(*promptUrl)
+	statusUrl.Path = "/frame/status"
+	statusVals := map[string]string{
+		"sid":  sid,
+		"txid": txid,
+	}
+	for statusCode := ""; statusCode != "allow"; {
+		if err = postForm(statusUrl.String(), statusVals, &duoResponse); err != nil {
+			return nil, err
+		}
+		statusCode = duoResponse.Response["status_code"]
+		status := duoResponse.Response["status"]
+		switch statusCode {
+		case "allow", "pushed":
+			b.Logger().Debug(
+				"auth/okta: Duo verification", "status_code", statusCode, "status", status)
+		case "timeout":
+			return nil, errors.New("Duo verification push timed out")
+		default:
+			return nil, fmt.Errorf("unknown Duo verification status %s: %s", statusCode, status)
+		}
+	}
+
+	// Report the success back to Okta.
+	completeVals := map[string]string{
+		"id":           factorId,
+		"stateToken":   stateToken,
+		"sig_response": fmt.Sprintf("%s:%s", duoResponse.Response["cookie"], appSig),
+	}
+	if err = postForm(verification.Links["complete"].Href, completeVals, nil); err != nil {
+		return nil, err
+	}
+	b.Logger().Debug("auth/okta: Duo verification: result posted back to Okta")
+
+	// Verify success with Okta.
+	return doOktaVerify(oktaClient, stateToken, factorId)
+}
+
+func postForm(uri string, values map[string]string, dest interface{}) error {
+	urlValues := make(url.Values)
+	for k, v := range values {
+		urlValues.Set(k, v)
+	}
+	resp, err := http.PostForm(uri, urlValues)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if dest == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(dest)
 }
 
 const backendHelp = `

--- a/builtin/credential/okta/backend.go
+++ b/builtin/credential/okta/backend.go
@@ -339,7 +339,6 @@ type mfaFactor struct {
 	Id          string
 	FactorType  string
 	Provider    string
-	Profile     map[string]string
 }
 
 // verifyMfaHandler verifies a single type of Okta MFA factor.


### PR DESCRIPTION
Fixes #3872 by directly performing the Okta MFA workflow inside the Okta
auth backend rather than only performing primary authentication to Okta
and doing Duo MFA separately. This lets us support Okta-Duo MFA without
missing out on the Okta PASSWORD_EXPIRED status, which is only exposed
after Okta MFA completion.

Users whose Okta is configured to require Duo MFA and still have the
old-fashioned separate Duo MFA configured in Vault will get two pushes.

This change is based on broamski's #3908, and also adds support for Okta
Push within the Okta auth backend.

The Okta-Duo integration is intended to be web-based (with an iframe).
This solution emulates that flow within Vault, and long-term should
probably be replaced by some better option we are working to get from
Okta/Duo.