### PR TITLE
Change 'rules' parameter for Policies requests

### DIFF
--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -472,7 +472,7 @@ Policies may be created (uploaded) via the CLI or via the API. To create a new
 policy in Vault:
 
 ```sh
-$ vault write sys/policy/my-policy rules=@my-policy.hcl
+$ vault write sys/policy/my-policy policy=@my-policy.hcl
 ```
 
 -> The `@` tells Vault to read from a file on disk. In the example above, Vault
@@ -485,7 +485,7 @@ or via the API:
 $ curl \
   --request POST \
   --header "X-Vault-Token: ..." \
-  --data '{"rules":"path \"...\" {...} "}' \
+  --data '{"policy":"path \"...\" {...} "}' \
   https://vault.hashicorp.rocks/v1/sys/policy/my-policy
 ```
 
@@ -500,7 +500,7 @@ API. To update an existing policy in Vault, follow the same steps as creating a
 policy, but use an existing policy name:
 
 ```sh
-$ vault write sys/policy/my-existing-policy rules=@updated-policy.json
+$ vault write sys/policy/my-existing-policy policy=@updated-policy.json
 ```
 
 or via the API:
@@ -509,7 +509,7 @@ or via the API:
 $ curl \
   --request POST \
   --header "X-Vault-Token: ..." \
-  --data '{"rules":"path \"...\" {...} "}' \
+  --data '{"policy":"path \"...\" {...} "}' \
   https://vault.hashicorp.rocks/v1/sys/policy/my-existing-policy
 ```
 


### PR DESCRIPTION
With Vault Version: 0.9.1, the following is returned when using "rules" for policies operation:
```The following warnings were returned from the Vault server:
* 'rules' is deprecated, please use 'policy' instead```