### PR TITLE
Various PKI updates

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1658,7 +1658,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		SubSubdomain         bool `structs:"foo.bar.example.com"`
 		SubSubdomainWildcard bool `structs:"*.bar.example.com"`
 		GlobDomain           bool `structs:"fooexample.com"`
-		NonHostname          bool `structs:"daɪˈɛrɨsɨs"`
+		IDN                  bool `structs:"daɪˈɛrɨsɨs"`
 		AnyHost              bool `structs:"porkslap.beer"`
 	}
 
@@ -1872,10 +1872,10 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		roleVals.AllowAnyName = true
 		roleVals.EnforceHostnames = true
 		commonNames.AnyHost = true
+		commonNames.IDN = true
 		addCnTests()
 
 		roleVals.EnforceHostnames = false
-		commonNames.NonHostname = true
 		addCnTests()
 
 		// Ensure that we end up with acceptable key sizes since they won't be

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1632,7 +1632,11 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 			}
 			if retName != name {
 				// Check IDNA
-				converted, err := idna.Lookup.ToUnicode(retName)
+				p := idna.New(
+					idna.StrictDomainName(true),
+					idna.VerifyDNSLength(true),
+				)
+				converted, err := p.ToUnicode(retName)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -643,21 +643,17 @@ func generateCreationBundle(b *backend,
 				// used for the purpose for which they are presented
 				emailAddresses = append(emailAddresses, cn)
 			} else {
-				// Only add to dnsNames if it's actually a DNS name but convert idn first
-				wildcard := false
-				lcn := cn
-				if strings.HasPrefix(cn, "*.") {
-					wildcard = true
-					lcn = strings.TrimPrefix(cn, "*.")
-				}
-				converted, err := idna.Lookup.ToASCII(lcn)
+				// Only add to dnsNames if it's actually a DNS name but convert
+				// idn first
+				p := idna.New(
+					idna.StrictDomainName(true),
+					idna.VerifyDNSLength(true),
+				)
+				converted, err := p.ToASCII(cn)
 				if err != nil {
 					return nil, errutil.UserError{Err: err.Error()}
 				}
 				if hostnameRegex.MatchString(converted) {
-					if wildcard {
-						converted = "*." + converted
-					}
 					dnsNames = append(dnsNames, converted)
 				}
 			}
@@ -671,20 +667,17 @@ func generateCreationBundle(b *backend,
 					if strings.Contains(v, "@") {
 						emailAddresses = append(emailAddresses, v)
 					} else {
-						// Only add to dnsNames if it's actually a DNS name but convert idn first
-						wildcard := false
-						if strings.HasPrefix(v, "*.") {
-							wildcard = true
-							v = strings.TrimPrefix(v, "*.")
-						}
-						converted, err := idna.Lookup.ToASCII(v)
+						// Only add to dnsNames if it's actually a DNS name but
+						// convert idn first
+						p := idna.New(
+							idna.StrictDomainName(true),
+							idna.VerifyDNSLength(true),
+						)
+						converted, err := p.ToASCII(v)
 						if err != nil {
 							return nil, errutil.UserError{Err: err.Error()}
 						}
 						if hostnameRegex.MatchString(converted) {
-							if wildcard {
-								converted = "*." + converted
-							}
 							dnsNames = append(dnsNames, converted)
 						}
 					}

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -417,7 +417,6 @@ func validateNames(req *logical.Request, names []string, role *roleEntry) string
 			}
 		}
 
-		//panic(fmt.Sprintf("\nName is %s\nRole is\n%#v\n", name, role))
 		return name
 	}
 

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -92,7 +92,7 @@ func (b *caInfoBundle) GetCAChain() []*certutil.CertBlock {
 }
 
 var (
-	hostnameRegex                = regexp.MustCompile(`^(\*\.)?(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])$`)
+	hostnameRegex                = regexp.MustCompile(`^(\*\.)?(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
 	oidExtensionBasicConstraints = []int{2, 5, 29, 19}
 )
 

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -300,7 +300,7 @@ func validateNames(req *logical.Request, names []string, role *roleEntry) string
 				idna.StrictDomainName(true),
 				idna.VerifyDNSLength(true),
 			)
-			converted, err := p.ToASCII(sanitizedName)
+			_, err := p.ToASCII(sanitizedName)
 			if err != nil {
 				return name
 			}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1647,8 +1647,8 @@
 		{
 			"checksumSHA1": "RcrB7tgYS/GMW4QrwVdMOTNqIU8=",
 			"path": "golang.org/x/net/idna",
-			"revision": "0ed95abb35c445290478a5348a7b38bb154135fd",
-			"revisionTime": "2018-01-24T06:08:02Z"
+			"revision": "f5dfe339be1d06f81b22525fe34671ee7d2c8904",
+			"revisionTime": "2018-02-04T03:50:36Z"
 		},
 		{
 			"checksumSHA1": "5JWn/wMC+EWNDKI/AYE4JifQF54=",


### PR DESCRIPTION
* Update hostname regex in cert util to handle wildcard
* Convert a DNS name, if needed, to IDN equivalent before adding to DNS
SANs (wildcard handled separately since it is not a valid part of an
IDNA conversion)
* Change SAN DNS value in tests to be host names since Go 1.10 will be
more strict about this