### PR TITLE
Decompress data before sending it via sys/raw

### DIFF
--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -1589,6 +1589,19 @@ func TestSystemBackend_disableAudit(t *testing.T) {
 	}
 }
 
+func TestSystemBackend_rawRead_Compressed(t *testing.T) {
+	b := testSystemBackendRaw(t)
+
+	req := logical.TestRequest(t, logical.ReadOperation, "raw/core/mounts")
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.HasPrefix(resp.Data["value"].(string), "{\"type\":\"mounts\"") {
+		t.Fatalf("bad: %v", resp)
+	}
+}
+
 func TestSystemBackend_rawRead_Protected(t *testing.T) {
 	b := testSystemBackendRaw(t)
 


### PR DESCRIPTION
This pull request updates the `sys/raw` GET endpoint to decompress values before sending them, for those values that are stored compressed on the server. There's no change for values that aren't stored compressed on the server.

The updated code provides a more consistent experience to the end-user, as now the end-user doesn't have to worry about handling decompression for items like `core/mounts`. In addition, this works around the [encoding problems for compressed data sent through the API](https://github.com/hashicorp/vault/issues/3952).

```
$ vault read sys/raw/core/mounts
Key      Value
---      -----
value    {"type":"mounts","entries":[{"table":"mounts","path":"secret/","type":"kv","description":"key/value secret storage","uuid":"4eba7773-a37b-e01e-4ce1-1cb95b4c645c","accessor":"kv_802e66a3","config":{"default_lease_ttl":0,"max_lease_ttl":0,"force_no_cache":false},"options":null,"local":false,"seal_wrap":false},{"table":"mounts","path":"sys/","type":"system","description":"system endpoints used for control, policy and debugging","uuid":"6d6fc9e4-ec0c-36cb-7526-865b3a355042","accessor":"system_bf4000cb","config":{"default_lease_ttl":0,"max_lease_ttl":0,"force_no_cache":false},"options":null,"local":false,"seal_wrap":false},{"table":"mounts","path":"identity/","type":"identity","description":"identity store","uuid":"71596ae3-bef4-c5ee-9cf8-d0dec4256a59","accessor":"identity_3e0544d7","config":{"default_lease_ttl":0,"max_lease_ttl":0,"force_no_cache":false},"options":null,"local":false,"seal_wrap":false}]}

$ vault write secret/_known kittens=awesome
Success! Data written to: secret/_known

$ vault read sys/raw/logical/4eba7773-a37b-e01e-4ce1-1cb95b4c645c/_known
Key      Value
---      -----
value    {"kittens":"awesome"}
```

Fixes https://github.com/hashicorp/vault/issues/3952.