### PR TITLE
Add transaction-like behavior for Transit persists.

### DIFF
--- a/helper/keysutil/policy.go
+++ b/helper/keysutil/policy.go
@@ -32,7 +32,6 @@ import (
 	"github.com/hashicorp/vault/helper/jsonutil"
 	"github.com/hashicorp/vault/helper/kdf"
 	"github.com/hashicorp/vault/logical"
-	"github.com/mitchellh/copystructure"
 )
 
 // Careful with iota; don't put anything before it in this const block because
@@ -456,9 +455,13 @@ func (p *Policy) Upgrade(ctx context.Context, storage logical.Storage) (retErr e
 	priorLatestVersion := p.LatestVersion
 	priorMinDecryptionVersion := p.MinDecryptionVersion
 	priorConvergentVersion := p.ConvergentVersion
-	priorKeys, err := copystructure.Copy(p.Keys)
-	if err != nil {
-		return err
+	priorKeys := keyEntryMap(nil)
+
+	if p.Keys != nil {
+		priorKeys = keyEntryMap{}
+		for k, v := range p.Keys {
+			priorKeys[k] = v
+		}
 	}
 
 	defer func() {
@@ -467,7 +470,7 @@ func (p *Policy) Upgrade(ctx context.Context, storage logical.Storage) (retErr e
 			p.LatestVersion = priorLatestVersion
 			p.MinDecryptionVersion = priorMinDecryptionVersion
 			p.ConvergentVersion = priorConvergentVersion
-			p.Keys = priorKeys.(keyEntryMap)
+			p.Keys = priorKeys
 		}
 	}()
 

--- a/helper/keysutil/policy.go
+++ b/helper/keysutil/policy.go
@@ -372,7 +372,7 @@ func (p *Policy) Persist(ctx context.Context, storage logical.Storage) (retErr e
 	// roll back keys, but better safe than sorry and this doesn't happen
 	// enough to worry about the speed tradeoff.
 	priorArchiveVersion := p.ArchiveVersion
-	priorKeys := keyEntryMap(nil)
+	var priorKeys keyEntryMap
 
 	if p.Keys != nil {
 		priorKeys = keyEntryMap{}
@@ -455,7 +455,7 @@ func (p *Policy) Upgrade(ctx context.Context, storage logical.Storage) (retErr e
 	priorLatestVersion := p.LatestVersion
 	priorMinDecryptionVersion := p.MinDecryptionVersion
 	priorConvergentVersion := p.ConvergentVersion
-	priorKeys := keyEntryMap(nil)
+	var priorKeys keyEntryMap
 
 	if p.Keys != nil {
 		priorKeys = keyEntryMap{}
@@ -1002,7 +1002,7 @@ func (p *Policy) VerifySignature(context, input []byte, sig, algorithm string) (
 func (p *Policy) Rotate(ctx context.Context, storage logical.Storage) (retErr error) {
 	priorLatestVersion := p.LatestVersion
 	priorMinDecryptionVersion := p.MinDecryptionVersion
-	priorKeys := keyEntryMap(nil)
+	var priorKeys keyEntryMap
 
 	if p.Keys != nil {
 		priorKeys = keyEntryMap{}

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -29,6 +29,25 @@ bit length be returned to them, encrypted with the named key. Normally this will
 also return the key in plaintext to allow for immediate use, but this can be
 disabled to accommodate auditing requirements.
 
+## Working Set Management
+
+This secrets engine does not currently delete keys. Keys that are out of the
+working set (earlier than a key's specified `min_decryption_version` are
+instead archived. This is a performance consideration to keep key loading fast,
+as well as a security consideration: by disallowing decryption of old versions
+of keys, found ciphertext corresponding to obsolete (but sensitive) data can
+not be decrypted by most users, but in an emergency the
+`min_decryption_version` can be moved back to allow for legitimate decryption.
+
+Currently this archive is stored in a single storage entry. With some storage
+backends, notably those using Raft or Paxos for HA capabilities, frequent
+rotation may lead to a storage entry size for the archive that is larger than
+the storage backend can handle. For frequent rotation needs, using named keys
+that correspond to time bounds (e.g. five-minute periods floored to the closest
+multiple of five) may provide a good alternative, allowing for several keys to
+be live at once and a deterministic way to decide which key to use at any given
+time.
+
 ## Setup
 
 Most secrets engines must be configured in advance before they can perform their


### PR DESCRIPTION
This ensures that in-memory policy matches the state of on-disk policy
if a storage error occurs.

Ref: #2705 