### PR TITLE
Add newline on non-ttl output

### DIFF
--- a/command/main.go
+++ b/command/main.go
@@ -23,7 +23,9 @@ func (u *VaultUI) Output(m string) {
 	if u.isTerminal {
 		u.Ui.Output(m)
 	} else {
-		getWriterFromUI(u.Ui).Write([]byte(m))
+		writer := getWriterFromUI(u.Ui)
+		writer.Write([]byte(m))
+		writer.Write([]byte("\n"))
 	}
 }
 


### PR DESCRIPTION
Output is formatted with newlines in mind, so without this those get
lost and things get funky due to multiple outputs running together.