### PR TITLE
Configurable Consul Service Address

### DIFF
--- a/physical/consul/consul.go
+++ b/physical/consul/consul.go
@@ -731,7 +731,7 @@ func (c *ConsulBackend) reconcileConsul(registeredServiceID string, activeFunc p
 		Name:              c.serviceName,
 		Tags:              tags,
 		Port:              int(c.redirectPort),
-		Address:           c.redirectHost,
+		Address:           "",
 		EnableTagOverride: false,
 	}
 

--- a/physical/consul/consul.go
+++ b/physical/consul/consul.go
@@ -160,8 +160,6 @@ func NewConsulBackend(conf map[string]string, logger log.Logger) (physical.Backe
 	serviceAddrStr, ok := conf["service_address"]
 	if ok {
 		serviceAddr = &serviceAddrStr
-	} else {
-		serviceAddr = nil
 	}
 	if logger.IsDebug() {
 		logger.Debug("physical/consul: config service_address set", "service_address", serviceAddr)

--- a/physical/consul/consul_test.go
+++ b/physical/consul/consul_test.go
@@ -117,6 +117,51 @@ func TestConsul_ServiceTags(t *testing.T) {
 	}
 }
 
+func TestConsul_ServiceAddress(t *testing.T) {
+	tests := []struct {
+		consulConfig   map[string]string
+		serviceAddrNil bool
+	}{
+		{
+			consulConfig: map[string]string{
+				"service_address": "",
+			},
+		},
+		{
+			consulConfig: map[string]string{
+				"service_address": "vault.example.com",
+			},
+		},
+		{
+			serviceAddrNil: true,
+		},
+	}
+
+	for _, test := range tests {
+		logger := logformat.NewVaultLogger(log.LevelTrace)
+
+		be, err := NewConsulBackend(test.consulConfig, logger)
+		if err != nil {
+			t.Fatalf("expected Consul to initialize: %v", err)
+		}
+
+		c, ok := be.(*ConsulBackend)
+		if !ok {
+			t.Fatalf("Expected ConsulBackend")
+		}
+
+		if test.serviceAddrNil {
+			if c.serviceAddress != nil {
+				t.Fatalf("expected service address to be nil")
+			}
+		} else {
+			if c.serviceAddress == nil {
+				t.Fatalf("did not expect service address to be nil")
+			}
+		}
+	}
+}
+
 func TestConsul_newConsulBackend(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/website/source/docs/configuration/storage/consul.html.md
+++ b/website/source/docs/configuration/storage/consul.html.md
@@ -86,6 +86,14 @@ at Consul's service discovery layer.
 - `service_tags` `(string: "")` – Specifies a comma-separated list of tags to
   attach to the service registration in Consul.
 
+- `service_address` `(string: nil)` – Specifies a service-specific address to
+  set on the service registration in Consul. If unset, Vault will use what it
+  knows to be the HA redirect address - which is usually desirable. Setting
+  this parameter to `""` will tell Consul to leverage the configuration of the
+  node the service is registered on dynamically. This could be beneficial if
+  you intend to leverage Consul's
+  [`translate_wan_addrs`](consul-translate-wan-addrs) parameter.
+
 - `token` `(string: "")` – Specifies the [Consul ACL token][consul-acl] with
   permission to read and write from the `path` in Consul's key-value store.
   This is **not** a Vault token. See the ACL section below for help.
@@ -216,3 +224,4 @@ storage "consul" {
 [consul-acl]: https://www.consul.io/docs/guides/acl.html "Consul ACLs"
 [consul-consistency]: https://www.consul.io/api/index.html#consistency-modes "Consul Consistency Modes"
 [consul-encryption]: https://www.consul.io/docs/agent/encryption.html "Consul Encryption"
+[consul-translate-wan-addrs]: https://www.consul.io/docs/agent/options.html#translate_wan_addrs "Consul Configuration"


### PR DESCRIPTION
Setting an explicit service address makes Consul ignore the [`translate_wan_addrs`](https://www.consul.io/docs/agent/options.html#translate_wan_addrs) setting. When set, Consul nodes will return their WAN address on queries from foreign datacenters. This seems to me to be a nice option to have instead of defining the `redirectHost` as the service-specific address.

This behavior is mentioned here: https://github.com/hashicorp/consul/issues/2390#issuecomment-252077332.