### PR TITLE
Re-add lost stored-shares parameter to operator rekey command.

### DIFF
--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -213,10 +213,11 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 		Usage:   "",
 	})
 
+	// Kept to keep scripts passing the flag working, but not used
 	f.IntVar(&IntVar{
 		Name:    "stored-shares",
 		Target:  &c.flagStoredShares,
-		Default: 0, // No default, because we need to check if was supplied
+		Default: 0,
 		Hidden:  true,
 		Usage:   "",
 	})

--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -196,15 +196,6 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 			"is only used in HSM mode.",
 	})
 
-	f.IntVar(&IntVar{
-		Name:       "stored-shares",
-		Target:     &c.flagStoredShares,
-		Default:    0, // No default, because we need to check if was supplied
-		Completion: complete.PredictAnything,
-		Usage: "Number of unseal keys to store on an HSM. This must be equal to " +
-			"-key-shares. This is only used in HSM mode.",
-	})
-
 	// Deprecations
 	// TODO: remove in 0.9.0
 	f.BoolVar(&BoolVar{
@@ -218,6 +209,14 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 		Name:    "auto", // prefer -consul-auto
 		Target:  &c.flagAuto,
 		Default: false,
+		Hidden:  true,
+		Usage:   "",
+	})
+
+	f.IntVar(&IntVar{
+		Name:    "stored-shares",
+		Target:  &c.flagStoredShares,
+		Default: 0, // No default, because we need to check if was supplied
 		Hidden:  true,
 		Usage:   "",
 	})
@@ -456,7 +455,7 @@ func (c *OperatorInitCommand) init(client *api.Client, req *api.InitRequest) int
 	c.UI.Output("")
 	c.UI.Output(fmt.Sprintf("Initial Root Token: %s", resp.RootToken))
 
-	if req.StoredShares < 1 {
+	if len(resp.Keys) > 0 {
 		c.UI.Output("")
 		c.UI.Output(wrapAtLength(fmt.Sprintf(
 			"Vault initialized with %d key shares and a key threshold of %d. Please "+

--- a/command/operator_rekey.go
+++ b/command/operator_rekey.go
@@ -232,6 +232,7 @@ func (c *OperatorRekeyCommand) Flags() *FlagSets {
 		Usage:   "",
 	})
 
+	// Kept to keep scripts passing the flag working, but not used
 	f.IntVar(&IntVar{
 		Name:    "stored-shares",
 		Target:  &c.flagStoredShares,

--- a/command/operator_rekey.go
+++ b/command/operator_rekey.go
@@ -37,9 +37,10 @@ type OperatorRekeyCommand struct {
 
 	// Deprecations
 	// TODO: remove in 0.9.0
-	flagDelete      bool
-	flagRecoveryKey bool
-	flagRetrieve    bool
+	flagDelete       bool
+	flagRecoveryKey  bool
+	flagRetrieve     bool
+	flagStoredShares int
 
 	testStdin io.Reader // for tests
 }
@@ -231,6 +232,14 @@ func (c *OperatorRekeyCommand) Flags() *FlagSets {
 		Usage:   "",
 	})
 
+	f.IntVar(&IntVar{
+		Name:    "stored-shares",
+		Target:  &c.flagStoredShares,
+		Default: 0,
+		Hidden:  true,
+		Usage:   "",
+	})
+
 	return set
 }
 
@@ -323,6 +332,7 @@ func (c *OperatorRekeyCommand) init(client *api.Client) int {
 	status, err := fn(&api.RekeyInitRequest{
 		SecretShares:    c.flagKeyShares,
 		SecretThreshold: c.flagKeyThreshold,
+		StoredShares:    c.flagStoredShares,
 		PGPKeys:         c.flagPGPKeys,
 		Backup:          c.flagBackup,
 	})


### PR DESCRIPTION
Also change the rekey and init APIs to not require explicitly setting values to 1.

Fixes #3969