### PR TITLE
Disable redirects on the http client that calls AWS STS api

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -1505,6 +1505,9 @@ func submitCallerIdentityRequest(method, endpoint string, parsedUrl *url.URL, bo
 	// the endpoint to talk to alternate web addresses
 	request := buildHttpRequest(method, endpoint, parsedUrl, body, headers)
 	client := cleanhttp.DefaultClient()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 	response, err := client.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("error making request: %v", err)


### PR DESCRIPTION
This client is used in the AWS IAM auth method. If an invalid payload is sent to the STS endpoint, the request is redirected to a non-https AWS endpoint, which would can potentially introduce a MITM scenario.

Co-authored-by: Max Justicz <max@justi.cz>