### PR TITLE
Add metrics to Transit Secrets Engine

### DIFF
--- a/builtin/logical/transit/path_backup.go
+++ b/builtin/logical/transit/path_backup.go
@@ -2,7 +2,9 @@ package transit
 
 import (
 	"context"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -27,6 +29,8 @@ func (b *backend) pathBackup() *framework.Path {
 }
 
 func (b *backend) pathBackupRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "backup_key"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "backup_key"}, 1)
 	backup, err := b.lm.BackupPolicy(ctx, req.Storage, d.Get("name").(string))
 	if err != nil {
 		return nil, err

--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -5,7 +5,9 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/helper/errutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
@@ -62,6 +64,8 @@ min_encryption_version configured on the key.`,
 }
 
 func (b *backend) pathDatakeyWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "data_key_encrypt"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "data_key_encrypt"}, 1)
 	name := d.Get("name").(string)
 	ver := d.Get("key_version").(int)
 

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/helper/errutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
@@ -52,6 +54,8 @@ Vault 0.6.1. Not required for keys created in 0.6.2+.`,
 }
 
 func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "decrypt"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "decrypt"}, 1)
 	batchInputRaw := d.Raw["batch_input"]
 	var batchInputItems []BatchRequestItem
 	var err error

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -5,7 +5,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"sync"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/helper/errutil"
 	"github.com/hashicorp/vault/helper/keysutil"
 	"github.com/hashicorp/vault/logical"
@@ -138,6 +140,8 @@ func (b *backend) pathEncryptExistenceCheck(ctx context.Context, req *logical.Re
 }
 
 func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "encrypt"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "encrypt"}, 1)
 	name := d.Get("name").(string)
 	var err error
 

--- a/builtin/logical/transit/path_export.go
+++ b/builtin/logical/transit/path_export.go
@@ -12,7 +12,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/helper/keysutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
@@ -52,6 +54,8 @@ func (b *backend) pathExportKeys() *framework.Path {
 }
 
 func (b *backend) pathPolicyExportRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "export"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "export"}, 1)
 	exportType := d.Get("type").(string)
 	name := d.Get("name").(string)
 	version := d.Get("version").(string)

--- a/builtin/logical/transit/path_hash.go
+++ b/builtin/logical/transit/path_hash.go
@@ -8,7 +8,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"hash"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -57,6 +59,8 @@ Defaults to "sha2-256".`,
 }
 
 func (b *backend) pathHashWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "hash_data"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "hash_data"}, 1)
 	inputB64 := d.Get("input").(string)
 	format := d.Get("format").(string)
 	algorithm := d.Get("urlalgorithm").(string)

--- a/builtin/logical/transit/path_hmac.go
+++ b/builtin/logical/transit/path_hmac.go
@@ -10,7 +10,9 @@ import (
 	"hash"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -65,6 +67,8 @@ to the min_encryption_version configured on the key.`,
 }
 
 func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "generate_hmac"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "generate_hmac"}, 1)
 	name := d.Get("name").(string)
 	ver := d.Get("key_version").(int)
 	inputB64 := d.Get("input").(string)
@@ -138,6 +142,8 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 }
 
 func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *framework.FieldData, verificationHMAC string) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "hmac_verify"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "hmac_verify"}, 1)
 	name := d.Get("name").(string)
 	inputB64 := d.Get("input").(string)
 	algorithm := d.Get("urlalgorithm").(string)

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -12,6 +12,7 @@ import (
 
 	"golang.org/x/crypto/ed25519"
 
+	"github.com/armon/go-metrics"
 	"github.com/fatih/structs"
 	"github.com/hashicorp/vault/helper/keysutil"
 	"github.com/hashicorp/vault/logical"
@@ -108,6 +109,8 @@ return the public key for the given context.`,
 }
 
 func (b *backend) pathKeysList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "list_keys"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "list_keys"}, 1)
 	entries, err := req.Storage.List(ctx, "policy/")
 	if err != nil {
 		return nil, err
@@ -117,6 +120,8 @@ func (b *backend) pathKeysList(ctx context.Context, req *logical.Request, d *fra
 }
 
 func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "policy_write"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "policy_write"}, 1)
 	name := d.Get("name").(string)
 	derived := d.Get("derived").(bool)
 	convergent := d.Get("convergent_encryption").(bool)
@@ -180,6 +185,8 @@ type asymKey struct {
 }
 
 func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "policy_read"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "policy_read"}, 1)
 	name := d.Get("name").(string)
 
 	p, lock, err := b.lm.GetPolicyShared(ctx, req.Storage, name)
@@ -320,6 +327,8 @@ func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *f
 }
 
 func (b *backend) pathPolicyDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "policy_delete"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "policy_delete"}, 1)
 	name := d.Get("name").(string)
 
 	// Delete does its own locking

--- a/builtin/logical/transit/path_random.go
+++ b/builtin/logical/transit/path_random.go
@@ -6,7 +6,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"time"
 
+	"github.com/armon/go-metrics"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
@@ -44,6 +46,8 @@ func (b *backend) pathRandom() *framework.Path {
 }
 
 func (b *backend) pathRandomWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "random_bytes"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "random_bytes"}, 1)
 	bytes := 0
 	var err error
 	strBytes := d.Get("urlbytes").(string)

--- a/builtin/logical/transit/path_restore.go
+++ b/builtin/logical/transit/path_restore.go
@@ -2,7 +2,9 @@ package transit
 
 import (
 	"context"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -31,6 +33,8 @@ func (b *backend) pathRestore() *framework.Path {
 }
 
 func (b *backend) pathRestoreUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "restore_key"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "restore_key"}, 1)
 	backupB64 := d.Get("backup").(string)
 	if backupB64 == "" {
 		return logical.ErrorResponse("'backup' must be supplied"), nil

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/helper/errutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
@@ -53,6 +55,8 @@ to the min_encryption_version configured on the key.`,
 }
 
 func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "rewrap_data"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "rewrap_data"}, 1)
 	batchInputRaw := d.Raw["batch_input"]
 	var batchInputItems []BatchRequestItem
 	var err error

--- a/builtin/logical/transit/path_rotate.go
+++ b/builtin/logical/transit/path_rotate.go
@@ -2,7 +2,9 @@ package transit
 
 import (
 	"context"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -27,6 +29,8 @@ func (b *backend) pathRotate() *framework.Path {
 }
 
 func (b *backend) pathRotateWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "rotate_key"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "rotate_key"}, 1)
 	name := d.Get("name").(string)
 
 	// Get the policy

--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -7,7 +7,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"hash"
+	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/helper/errutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
@@ -138,6 +140,8 @@ Defaults to "sha2-256". Not valid for all key types.`,
 }
 
 func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "sign_data"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "sign_data"}, 1)
 	name := d.Get("name").(string)
 	ver := d.Get("key_version").(int)
 	inputB64 := d.Get("input").(string)
@@ -218,6 +222,8 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 }
 
 func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	defer metrics.MeasureSince([]string{"transit", "verify_write"}, time.Now())
+	metrics.IncrCounter([]string{"transit", "verify_write"}, 1)
 
 	sig := d.Get("signature").(string)
 	hmac := d.Get("hmac").(string)


### PR DESCRIPTION
This adds timers and counters to path operations for the Transit Secrets Engine.

If it is acceptable to carry on in this way and we want to incorporate these kinds of metrics in all secrets engines, I'll go ahead and add them and submit as one PR per secrets engine for the other secrets engines as well.