### PR TITLE
Add useragent helper

### DIFF
--- a/helper/useragent/useragent.go
+++ b/helper/useragent/useragent.go
@@ -1,0 +1,29 @@
+package useragent
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/hashicorp/vault/version"
+)
+
+var (
+	// projectURL is the project URL.
+	projectURL = "https://www.vaultproject.io/"
+
+	// rt is the runtime - variable for tests.
+	rt = runtime.Version()
+
+	// versionFunc is the func that returns the current version. This is a
+	// function to take into account the different build processes and distinguish
+	// between enterprise and oss builds.
+	versionFunc = func() string {
+		return version.GetVersion().VersionNumber()
+	}
+)
+
+// String returns the consistent user-agent string for Vault.
+func String() string {
+	return fmt.Sprintf("Vault/%s (+%s; %s)",
+		versionFunc(), projectURL, rt)
+}

--- a/helper/useragent/useragent_test.go
+++ b/helper/useragent/useragent_test.go
@@ -1,0 +1,18 @@
+package useragent
+
+import (
+	"testing"
+)
+
+func TestUserAgent(t *testing.T) {
+	projectURL = "https://vault-test.com"
+	rt = "go5.0"
+	versionFunc = func() string { return "1.2.3" }
+
+	act := String()
+
+	exp := "Vault/1.2.3 (+https://vault-test.com; go5.0)"
+	if exp != act {
+		t.Errorf("expected %q to be %q", act, exp)
+	}
+}

--- a/physical/gcs/gcs.go
+++ b/physical/gcs/gcs.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/helper/useragent"
 	"github.com/hashicorp/vault/physical"
 	log "github.com/mgutz/logxi/v1"
 
@@ -84,8 +85,8 @@ func newGCSClient(ctx context.Context, conf map[string]string, logger log.Logger
 	// else use application default credentials
 	credentialsFile, ok := conf["credentials_file"]
 	if ok {
-		client, err := storage.NewClient(
-			ctx,
+		client, err := storage.NewClient(ctx,
+			option.WithUserAgent(useragent.String()),
 			option.WithServiceAccountFile(credentialsFile),
 		)
 
@@ -95,7 +96,9 @@ func newGCSClient(ctx context.Context, conf map[string]string, logger log.Logger
 		return client, nil
 	}
 
-	client, err := storage.NewClient(ctx)
+	client, err := storage.NewClient(ctx,
+		option.WithUserAgent(useragent.String()),
+	)
 	if err != nil {
 		return nil, errwrap.Wrapf("error with application default credentials: {{err}}", err)
 	}

--- a/physical/spanner/spanner.go
+++ b/physical/spanner/spanner.go
@@ -11,9 +11,11 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/strutil"
+	"github.com/hashicorp/vault/helper/useragent"
 	"github.com/hashicorp/vault/physical"
 	log "github.com/mgutz/logxi/v1"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 
 	"cloud.google.com/go/spanner"
@@ -151,7 +153,9 @@ func NewBackend(c map[string]string, logger log.Logger) (physical.Backend, error
 	logger.Debug("physical/spanner: creating client")
 
 	ctx := context.Background()
-	client, err := spanner.NewClient(ctx, database)
+	client, err := spanner.NewClient(ctx, database,
+		option.WithUserAgent(useragent.String()),
+	)
 	if err != nil {
 		return nil, errwrap.Wrapf("failed to create spanner client: {{err}}", err)
 	}


### PR DESCRIPTION
This adds a user-agent header helper and adds support for sending that user agent in the spanner and gcs storage backends.