### PR TITLE
Extending generateCreationBundle to allow for specifying PKIX subject…

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1555,6 +1555,27 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		ret = append(ret, issueTestStep)
 	}
 
+	getCountryCheck := func(role roleEntry) logicaltest.TestCheckFunc {
+		var certBundle certutil.CertBundle
+		return func(resp *logical.Response) error {
+			err := mapstructure.Decode(resp.Data, &certBundle)
+			if err != nil {
+				return err
+			}
+			parsedCertBundle, err := certBundle.ToParsedCertBundle()
+			if err != nil {
+				return fmt.Errorf("Error checking generated certificate: %s", err)
+			}
+			cert := parsedCertBundle.Certificate
+
+			expected := strutil.RemoveDuplicates(role.Country, false)
+			if !reflect.DeepEqual(cert.Subject.Country, expected) {
+				return fmt.Errorf("Error: returned certificate has Country of %s but %s was specified in the role.", cert.Subject.Country, expected)
+			}
+			return nil
+		}
+	}
+
 	getOuCheck := func(role roleEntry) logicaltest.TestCheckFunc {
 		var certBundle certutil.CertBundle
 		return func(resp *logical.Response) error {
@@ -1568,7 +1589,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 			}
 			cert := parsedCertBundle.Certificate
 
-			expected := strutil.RemoveDuplicates(role.OU, true)
+			expected := strutil.RemoveDuplicates(role.OU, false)
 			if !reflect.DeepEqual(cert.Subject.OrganizationalUnit, expected) {
 				return fmt.Errorf("Error: returned certificate has OU of %s but %s was specified in the role.", cert.Subject.OrganizationalUnit, expected)
 			}
@@ -1589,9 +1610,93 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 			}
 			cert := parsedCertBundle.Certificate
 
-			expected := strutil.RemoveDuplicates(role.Organization, true)
+			expected := strutil.RemoveDuplicates(role.Organization, false)
 			if !reflect.DeepEqual(cert.Subject.Organization, expected) {
 				return fmt.Errorf("Error: returned certificate has Organization of %s but %s was specified in the role.", cert.Subject.Organization, expected)
+			}
+			return nil
+		}
+	}
+
+	getLocalityCheck := func(role roleEntry) logicaltest.TestCheckFunc {
+		var certBundle certutil.CertBundle
+		return func(resp *logical.Response) error {
+			err := mapstructure.Decode(resp.Data, &certBundle)
+			if err != nil {
+				return err
+			}
+			parsedCertBundle, err := certBundle.ToParsedCertBundle()
+			if err != nil {
+				return fmt.Errorf("Error checking generated certificate: %s", err)
+			}
+			cert := parsedCertBundle.Certificate
+
+			expected := strutil.RemoveDuplicates(role.Locality, false)
+			if !reflect.DeepEqual(cert.Subject.Locality, expected) {
+				return fmt.Errorf("Error: returned certificate has Locality of %s but %s was specified in the role.", cert.Subject.Locality, expected)
+			}
+			return nil
+		}
+	}
+
+	getProvinceCheck := func(role roleEntry) logicaltest.TestCheckFunc {
+		var certBundle certutil.CertBundle
+		return func(resp *logical.Response) error {
+			err := mapstructure.Decode(resp.Data, &certBundle)
+			if err != nil {
+				return err
+			}
+			parsedCertBundle, err := certBundle.ToParsedCertBundle()
+			if err != nil {
+				return fmt.Errorf("Error checking generated certificate: %s", err)
+			}
+			cert := parsedCertBundle.Certificate
+
+			expected := strutil.RemoveDuplicates(role.Province, false)
+			if !reflect.DeepEqual(cert.Subject.Province, expected) {
+				return fmt.Errorf("Error: returned certificate has Province of %s but %s was specified in the role.", cert.Subject.Province, expected)
+			}
+			return nil
+		}
+	}
+
+	getStreetAddressCheck := func(role roleEntry) logicaltest.TestCheckFunc {
+		var certBundle certutil.CertBundle
+		return func(resp *logical.Response) error {
+			err := mapstructure.Decode(resp.Data, &certBundle)
+			if err != nil {
+				return err
+			}
+			parsedCertBundle, err := certBundle.ToParsedCertBundle()
+			if err != nil {
+				return fmt.Errorf("Error checking generated certificate: %s", err)
+			}
+			cert := parsedCertBundle.Certificate
+
+			expected := strutil.RemoveDuplicates(role.StreetAddress, false)
+			if !reflect.DeepEqual(cert.Subject.StreetAddress, expected) {
+				return fmt.Errorf("Error: returned certificate has Street Address of %s but %s was specified in the role.", cert.Subject.StreetAddress, expected)
+			}
+			return nil
+		}
+	}
+
+	getPostalCodeCheck := func(role roleEntry) logicaltest.TestCheckFunc {
+		var certBundle certutil.CertBundle
+		return func(resp *logical.Response) error {
+			err := mapstructure.Decode(resp.Data, &certBundle)
+			if err != nil {
+				return err
+			}
+			parsedCertBundle, err := certBundle.ToParsedCertBundle()
+			if err != nil {
+				return fmt.Errorf("Error checking generated certificate: %s", err)
+			}
+			cert := parsedCertBundle.Certificate
+
+			expected := strutil.RemoveDuplicates(role.PostalCode, false)
+			if !reflect.DeepEqual(cert.Subject.PostalCode, expected) {
+				return fmt.Errorf("Error: returned certificate has Postal Code of %s but %s was specified in the role.", cert.Subject.PostalCode, expected)
 			}
 			return nil
 		}
@@ -1883,6 +1988,14 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		keybitSizeRandOff = true
 		addCnTests()
 	}
+	// Country tests
+	{
+		roleVals.Country = []string{"foo"}
+		addTests(getCountryCheck(roleVals))
+
+		roleVals.Country = []string{"foo", "bar"}
+		addTests(getCountryCheck(roleVals))
+	}
 	// OU tests
 	{
 		roleVals.OU = []string{"foo"}
@@ -1898,6 +2011,38 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 
 		roleVals.Organization = []string{"foo", "bar"}
 		addTests(getOrganizationCheck(roleVals))
+	}
+	// Locality tests
+	{
+		roleVals.Locality = []string{"foo"}
+		addTests(getLocalityCheck(roleVals))
+
+		roleVals.Locality = []string{"foo", "bar"}
+		addTests(getLocalityCheck(roleVals))
+	}
+	// Province tests
+	{
+		roleVals.Province = []string{"foo"}
+		addTests(getProvinceCheck(roleVals))
+
+		roleVals.Province = []string{"foo", "bar"}
+		addTests(getProvinceCheck(roleVals))
+	}
+	// StreetAddress tests
+	{
+		roleVals.StreetAddress = []string{"123 Foo Street"}
+		addTests(getStreetAddressCheck(roleVals))
+
+		roleVals.StreetAddress = []string{"123 Foo Street", "789 Bar Street"}
+		addTests(getStreetAddressCheck(roleVals))
+	}
+	// PostalCode tests
+	{
+		roleVals.PostalCode = []string{"F00"}
+		addTests(getPostalCodeCheck(roleVals))
+
+		roleVals.PostalCode = []string{"F00", "B4R"}
+		addTests(getPostalCodeCheck(roleVals))
 	}
 	// IP SAN tests
 	{

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -841,14 +841,115 @@ func generateCreationBundle(b *backend, data *dataBundle) error {
 		}
 	}
 
+	country := strutil.RemoveDuplicates(data.role.Country, false)
+	organization := strutil.RemoveDuplicates(data.role.Organization, false)
+	ou := strutil.RemoveDuplicates(data.role.OU, false)
+	locality := strutil.RemoveDuplicates(data.role.Locality, false)
+	province := strutil.RemoveDuplicates(data.role.Province, false)
+	streetAddress := strutil.RemoveDuplicates(data.role.StreetAddress, false)
+	postalCode := strutil.RemoveDuplicates(data.role.PostalCode, false)
+
+	var result interface{}
+	// Set C (countryName) values if specified in data and not already set by role
+	result, ok = data.apiData.GetOk("country")
+	if ok && len(result.([]string)) > 0 {
+		if len(country) == 0 {
+			country = strutil.RemoveDuplicates(result.([]string), false)
+		} else if strutil.StrListSubset(country, result.([]string)) {
+			country = strutil.RemoveDuplicates(result.([]string), false)
+		} else {
+			return errutil.UserError{Err: fmt.Sprintf(
+				"Country has been specified for this role (%s), but was provided %s", country, result.([]string))}
+		}
+	}
+
+	// Set O (organizationName) values if specified in data and not already set by role
+	result, ok = data.apiData.GetOk("organization")
+	if ok && len(result.([]string)) > 0 {
+		if len(organization) == 0 {
+			organization = strutil.RemoveDuplicates(result.([]string), false)
+		} else if strutil.StrListSubset(organization, result.([]string)) {
+			organization = strutil.RemoveDuplicates(result.([]string), false)
+		} else {
+			return errutil.UserError{Err: fmt.Sprintf(
+				"Organization has been specified for this role (%s), but was provided %s", organization, result.([]string))}
+		}
+	}
+
+	// Set OU (organizationalUnit) values if specified in data and not already set by role
+	result, ok = data.apiData.GetOk("ou")
+	if ok && len(result.([]string)) > 0 {
+		if len(ou) == 0 {
+			ou = strutil.RemoveDuplicates(result.([]string), false)
+		} else if strutil.StrListSubset(ou, result.([]string)) {
+			ou = strutil.RemoveDuplicates(result.([]string), false)
+		} else {
+			return errutil.UserError{Err: fmt.Sprintf(
+				"Organizational Unit has been specified for this role (%s), but was provided %s", ou, result.([]string))}
+		}
+	}
+
+	// Set L (locality) values if specified in data and not already set by role
+	result, ok = data.apiData.GetOk("locality")
+	if ok && len(result.([]string)) > 0 {
+		if len(locality) == 0 {
+			locality = strutil.RemoveDuplicates(result.([]string), false)
+		} else if strutil.StrListSubset(locality, result.([]string)) {
+			locality = strutil.RemoveDuplicates(result.([]string), false)
+		} else {
+			return errutil.UserError{Err: fmt.Sprintf(
+				"Locality has been specified for this role (%s), but was provided %s", locality, result.([]string))}
+		}
+	}
+
+	// Set ST (stateOrProvince) values if specified in data and not already set by role
+	result, ok = data.apiData.GetOk("province")
+	if ok && len(result.([]string)) > 0 {
+		if len(province) == 0 {
+			province = strutil.RemoveDuplicates(result.([]string), false)
+		} else if strutil.StrListSubset(province, result.([]string)) {
+			province = strutil.RemoveDuplicates(result.([]string), false)
+		} else {
+			return errutil.UserError{Err: fmt.Sprintf(
+				"State or Province has been specified for this role (%s), but was provided %s", province, result.([]string))}
+		}
+	}
+
+	// Set STREET (streetAddress) values if specified in data and not already set by role
+	result, ok = data.apiData.GetOk("street_address")
+	if ok && len(result.([]string)) > 0 {
+		if len(streetAddress) == 0 {
+			streetAddress = strutil.RemoveDuplicates(result.([]string), false)
+		} else if strutil.StrListSubset(streetAddress, result.([]string)) {
+			streetAddress = strutil.RemoveDuplicates(result.([]string), false)
+		} else {
+			return errutil.UserError{Err: fmt.Sprintf(
+				"Street Address has been specified for this role (%s), but was provided %s", streetAddress, result.([]string))}
+		}
+	}
+
+	// Set postalCode values if specified in data and not already set by role
+	result, ok = data.apiData.GetOk("postal_code")
+	if ok && len(result.([]string)) > 0 {
+		if len(postalCode) == 0 {
+			postalCode = strutil.RemoveDuplicates(result.([]string), false)
+		} else if strutil.StrListSubset(postalCode, result.([]string)) {
+			postalCode = strutil.RemoveDuplicates(result.([]string), false)
+		} else {
+			return errutil.UserError{Err: fmt.Sprintf(
+				"Postal Code has been specified for this role (%s), but was provided %s", postalCode, result.([]string))}
+		}
+	}
+
 	subject := pkix.Name{
-		Country:            strutil.RemoveDuplicates(data.role.Country, false),
-		Organization:       strutil.RemoveDuplicates(data.role.Organization, false),
-		OrganizationalUnit: strutil.RemoveDuplicates(data.role.OU, false),
-		Locality:           strutil.RemoveDuplicates(data.role.Locality, false),
-		Province:           strutil.RemoveDuplicates(data.role.Province, false),
-		StreetAddress:      strutil.RemoveDuplicates(data.role.StreetAddress, false),
-		PostalCode:         strutil.RemoveDuplicates(data.role.PostalCode, false),
+		CommonName:         cn,
+		Country:            country,
+		Organization:       organization,
+		OrganizationalUnit: ou,
+		Locality:           locality,
+		Province:           province,
+		StreetAddress:      streetAddress,
+		PostalCode:         postalCode,
 	}
 
 	// Get the TTL and verify it against the max allowed

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -84,6 +84,48 @@ default TTL is used, in that order. Cannot
 be later than the role max TTL.`,
 	}
 
+	fields["ou"] = &framework.FieldSchema{
+		Type: framework.TypeCommaStringSlice,
+		Description: `If set, OU (OrganizationalUnit) will be set to
+this value.`,
+	}
+
+	fields["organization"] = &framework.FieldSchema{
+		Type: framework.TypeCommaStringSlice,
+		Description: `If set, O (Organization) will be set to
+this value.`,
+	}
+
+	fields["country"] = &framework.FieldSchema{
+		Type: framework.TypeCommaStringSlice,
+		Description: `If set, Country will be set to
+this value.`,
+	}
+
+	fields["locality"] = &framework.FieldSchema{
+		Type: framework.TypeCommaStringSlice,
+		Description: `If set, Locality will be set to
+this value.`,
+	}
+
+	fields["province"] = &framework.FieldSchema{
+		Type: framework.TypeCommaStringSlice,
+		Description: `If set, Province will be set to
+this value.`,
+	}
+
+	fields["street_address"] = &framework.FieldSchema{
+		Type: framework.TypeCommaStringSlice,
+		Description: `If set, Street Address will be set to
+this value.`,
+	}
+
+	fields["postal_code"] = &framework.FieldSchema{
+		Type: framework.TypeCommaStringSlice,
+		Description: `If set, Postal Code will be set to
+this value.`,
+	}
+
 	return fields
 }
 


### PR DESCRIPTION
… data in CSR/issuance requests, and verifying that data against configured role data, if present.

The use case is to allow users to specify PKIX data when making a request, but if their role has PKIX fields pre-configured, then test to see if the request data is a subset of the role data. I believe that this has utility beyond my particular needs; would love to receive feedback.