### PR TITLE
Adding path roles test coverage for storing PKIX fields

### DIFF
--- a/builtin/logical/pki/path_roles_test.go
+++ b/builtin/logical/pki/path_roles_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/vault/helper/strutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/mitchellh/mapstructure"
 )
@@ -401,6 +402,97 @@ func TestPki_RoleAllowedDomains(t *testing.T) {
 	}
 	if len(result.AllowedDomains) != 2 {
 		t.Fatal("allowed_domains should have 2 values")
+	}
+}
+
+func TestPki_RolePkixFields(t *testing.T) {
+	var resp *logical.Response
+	var err error
+	b, storage := createBackendWithStorage(t)
+
+	roleData := map[string]interface{}{
+		"ttl":            "5h",
+		"country":        []string{"c1", "c2"},
+		"ou":             []string{"abc", "123"},
+		"organization":   []string{"org1", "org2"},
+		"locality":       []string{"foocity", "bartown"},
+		"province":       []string{"bar", "foo"},
+		"street_address": []string{"123 foo street", "789 bar avenue"},
+		"postal_code":    []string{"f00", "b4r"},
+	}
+
+	roleReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "roles/testrole_pkixfields",
+		Storage:   storage,
+		Data:      roleData,
+	}
+
+	resp, err = b.HandleRequest(context.Background(), roleReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: err: %v resp: %#v", err, resp)
+	}
+
+	roleReq.Operation = logical.ReadOperation
+	resp, err = b.HandleRequest(context.Background(), roleReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: err: %v resp: %#v", err, resp)
+	}
+
+	origCountry := roleData["country"].([]string)
+	respCountry := resp.Data["country"].([]string)
+	if !strutil.StrListSubset(origCountry, respCountry) {
+		t.Fatalf("country did not match values set in role")
+	} else if len(origCountry) != len(respCountry) {
+		t.Fatalf("country did not have same number of values set in role")
+	}
+
+	origOU := roleData["ou"].([]string)
+	respOU := resp.Data["ou"].([]string)
+	if !strutil.StrListSubset(origOU, respOU) {
+		t.Fatalf("ou did not match values set in role")
+	} else if len(origOU) != len(respOU) {
+		t.Fatalf("ou did not have same number of values set in role")
+	}
+
+	origOrganization := roleData["organization"].([]string)
+	respOrganization := resp.Data["organization"].([]string)
+	if !strutil.StrListSubset(origOrganization, respOrganization) {
+		t.Fatalf("organization did not match values set in role")
+	} else if len(origOrganization) != len(respOrganization) {
+		t.Fatalf("organization did not have same number of values set in role")
+	}
+
+	origLocality := roleData["locality"].([]string)
+	respLocality := resp.Data["locality"].([]string)
+	if !strutil.StrListSubset(origLocality, respLocality) {
+		t.Fatalf("locality did not match values set in role")
+	} else if len(origLocality) != len(respLocality) {
+		t.Fatalf("locality did not have same number of values set in role: ")
+	}
+
+	origProvince := roleData["province"].([]string)
+	respProvince := resp.Data["province"].([]string)
+	if !strutil.StrListSubset(origProvince, respProvince) {
+		t.Fatalf("province did not match values set in role")
+	} else if len(origProvince) != len(respProvince) {
+		t.Fatalf("province did not have same number of values set in role")
+	}
+
+	origStreetAddress := roleData["street_address"].([]string)
+	respStreetAddress := resp.Data["street_address"].([]string)
+	if !strutil.StrListSubset(origStreetAddress, respStreetAddress) {
+		t.Fatalf("street_address did not match values set in role")
+	} else if len(origStreetAddress) != len(respStreetAddress) {
+		t.Fatalf("street_address did not have same number of values set in role")
+	}
+
+	origPostalCode := roleData["postal_code"].([]string)
+	respPostalCode := resp.Data["postal_code"].([]string)
+	if !strutil.StrListSubset(origPostalCode, respPostalCode) {
+		t.Fatalf("postal_code did not match values set in role")
+	} else if len(origPostalCode) != len(respPostalCode) {
+		t.Fatalf("postal_code did not have same number of values set in role")
 	}
 }
 


### PR DESCRIPTION
This should cover testing the storage & retrieval of newly-added PKIX fields via the `/pki/roles` endpoint.