### PR TITLE
Fix bug with vault cli when reading an individual field containing a Printf formatting verb

### DIFF
--- a/command/util.go
+++ b/command/util.go
@@ -128,7 +128,7 @@ func PrintRaw(ui cli.Ui, str string) int {
 		// The cli.Ui prints a CR, which is not wanted since the user probably wants
 		// just the raw value.
 		w := getWriterFromUI(ui)
-		fmt.Fprintf(w, str)
+		fmt.Fprint(w, str)
 	}
 	return 0
 }


### PR DESCRIPTION
This PR is closely related to this one: https://github.com/hashicorp/vault/pull/2109

Printf formatting verbs are working as expected when calling the cli regularly, but when calling it from a subshell they are expanded and declared missing.

Steps to reproduce, if interested:
`
$ vault read -field=password secret/foo
bar%sbaz
$
$ echo $(vault read -field=password secret/foo) 
bar%!s(MISSING)baz
`