### PR TITLE
Handling nomad maximum token name limit 

### DIFF
--- a/builtin/logical/nomad/path_creds_create.go
+++ b/builtin/logical/nomad/path_creds_create.go
@@ -56,6 +56,12 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 	// Generate a name for the token
 	tokenName := fmt.Sprintf("vault-%s-%s-%d", name, req.DisplayName, time.Now().UnixNano())
 
+	// Handling nomad maximum token lenght
+	// https://github.com/hashicorp/nomad/blob/d9276e22b3b74674996fb548cdb6bc4c70d5b0e4/nomad/structs/structs.go#L115
+	if len(tokenName) > 64 {
+		tokenName = tokenName[0:63]
+	}
+
 	// Create it
 	token, _, err := c.ACLTokens().Create(&api.ACLToken{
 		Name:     tokenName,


### PR DESCRIPTION
Nomad maximum token name is limited to 64 characters:
https://github.com/hashicorp/nomad/blob/d9276e22b3b74674996fb548cdb6bc4c70d5b0e4/nomad/structs/structs.go#L115

We ran in issue when generating tokens from nomad that runs a job that should do nomad dispatch.
Display name that nomad passes is `token-job-uuid-task_name` with adding all the prependers and timestamp it exceeds 64 characters.

PR just trims the token name if it's longer than 64 chars.

Hope it's OK from naming point of view @ncorrare
