### PR TITLE
auth/cert: Remove looped DNSName checking as Go 1.10 covers it already

### DIFF
--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -439,28 +439,12 @@ func validateConnState(roots *x509.CertPool, cs *tls.ConnectionState) ([][]*x509
 		}
 	}
 
-	var chains [][]*x509.Certificate
-	var err error
-	switch {
-	case len(certs[0].DNSNames) > 0:
-		for _, dnsName := range certs[0].DNSNames {
-			opts.DNSName = dnsName
-			chains, err = certs[0].Verify(opts)
-			if err != nil {
-				if _, ok := err.(x509.UnknownAuthorityError); ok {
-					return nil, nil
-				}
-				return nil, errors.New("failed to verify client's certificate: " + err.Error())
-			}
+	chains, err := certs[0].Verify(opts)
+	if err != nil {
+		if _, ok := err.(x509.UnknownAuthorityError); ok {
+			return nil, nil
 		}
-	default:
-		chains, err = certs[0].Verify(opts)
-		if err != nil {
-			if _, ok := err.(x509.UnknownAuthorityError); ok {
-				return nil, nil
-			}
-			return nil, errors.New("failed to verify client's certificate: " + err.Error())
-		}
+		return nil, errors.New("failed to verify client's certificate: " + err.Error())
 	}
 
 	return chains, nil


### PR DESCRIPTION
TestBackend_PermittedDNSDomainsIntermediateCA passes even without looping.