### PR TITLE
DOCS: ttl specified on sign-intermediate cannot extend beyond expiry of signing CA

### DIFF
--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -1162,7 +1162,7 @@ verbatim.
 
 - `ttl` `(string: "")` – Specifies the requested Time To Live (after which the
   certificate will be expired). This cannot be larger than the engine's max (or,
-  if not set, the system max). However, this can be after the expiration of the
+  if not set, the system max) and cannot be after the expiration of the
   signing CA.
 
 - `format` `(string: "pem")` – Specifies the format for returned data. Can be


### PR DESCRIPTION
Hey, this part of the docs @ https://www.vaultproject.io/api/secret/pki/index.html#sign-intermediate doesn't seem to match Vault's behaviour:

```
 - `ttl` `(string: "")` – Specifies the requested Time To Live (after which the
   certificate will be expired). This cannot be larger than the engine's max (or,
-  if not set, the system max). However, this can be after the expiration of the
   signing CA.
```

Attempting to sign an intermediate with a ttl that extends beyond the expiry of the signing CA produces an error `cannot satisfy request, as TTL is beyond the expiration of the CA certificate`
