### PR TITLE
Create a new command/config subpackage.

### DIFF
--- a/command/config.go
+++ b/command/config.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/vault/command/config"
 )
 
 const (
@@ -33,7 +33,8 @@ type DefaultConfig struct {
 // Config just calls into config.Config for backwards compatibility purposes.
 // Use config.Config instead.
 func Config() (*DefaultConfig, error) {
-	return config.Config()
+	conf, err := config.Config()
+	return (*DefaultConfig)(conf), err
 }
 
 // LoadConfig reads the configuration from the given path. If path is
@@ -43,7 +44,8 @@ func Config() (*DefaultConfig, error) {
 // LoadConfig just calls into config.LoadConfig for backwards compatibility
 // purposes. Use config.LoadConfig instead.
 func LoadConfig(path string) (*DefaultConfig, error) {
-	return config.LoadConfig(path)
+	conf, err := config.LoadConfig(path)
+	return (*DefaultConfig)(conf), err
 }
 
 // ParseConfig parses the given configuration as a string.
@@ -51,7 +53,8 @@ func LoadConfig(path string) (*DefaultConfig, error) {
 // ParseConfig just calls into config.ParseConfig for backwards compatibility
 // purposes. Use config.ParseConfig instead.
 func ParseConfig(contents string) (*DefaultConfig, error) {
-	return config.ParseConfig(contents)
+	conf, err := config.ParseConfig(contents)
+	return (*DefaultConfig)(conf), err
 }
 
 func checkHCLKeys(node ast.Node, valid []string) error {

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -1,11 +1,14 @@
-package command
+package config
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/terraform/config"
+	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -29,29 +32,66 @@ type DefaultConfig struct {
 
 // Config loads the configuration and returns it. If the configuration
 // is already loaded, it is returned.
-//
-// Config just calls into config.Config for backwards compatibility purposes.
-// Use config.Config instead.
 func Config() (*DefaultConfig, error) {
-	return config.Config()
+	var err error
+	config, err := LoadConfig("")
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
 }
 
 // LoadConfig reads the configuration from the given path. If path is
 // empty, then the default path will be used, or the environment variable
 // if set.
-//
-// LoadConfig just calls into config.LoadConfig for backwards compatibility
-// purposes. Use config.LoadConfig instead.
 func LoadConfig(path string) (*DefaultConfig, error) {
-	return config.LoadConfig(path)
+	if path == "" {
+		path = DefaultConfigPath
+	}
+	if v := os.Getenv(ConfigPathEnv); v != "" {
+		path = v
+	}
+
+	// NOTE: requires HOME env var to be set
+	path, err := homedir.Expand(path)
+	if err != nil {
+		return nil, fmt.Errorf("Error expanding config path %s: %s", path, err)
+	}
+
+	contents, err := ioutil.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	return ParseConfig(string(contents))
 }
 
 // ParseConfig parses the given configuration as a string.
-//
-// ParseConfig just calls into config.ParseConfig for backwards compatibility
-// purposes. Use config.ParseConfig instead.
 func ParseConfig(contents string) (*DefaultConfig, error) {
-	return config.ParseConfig(contents)
+	root, err := hcl.Parse(contents)
+	if err != nil {
+		return nil, err
+	}
+
+	// Top-level item should be the object list
+	list, ok := root.Node.(*ast.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("Failed to parse config: does not contain a root object")
+	}
+
+	valid := []string{
+		"token_helper",
+	}
+	if err := checkHCLKeys(list, valid); err != nil {
+		return nil, err
+	}
+
+	var c DefaultConfig
+	if err := hcl.DecodeObject(&c, list); err != nil {
+		return nil, err
+	}
+	return &c, nil
 }
 
 func checkHCLKeys(node ast.Node, valid []string) error {

--- a/command/config/config_test.go
+++ b/command/config/config_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const FixturePath = "./test-fixtures"
+
+func TestLoadConfig(t *testing.T) {
+	config, err := LoadConfig(filepath.Join(FixturePath, "config.hcl"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := &DefaultConfig{
+		TokenHelper: "foo",
+	}
+	if !reflect.DeepEqual(expected, config) {
+		t.Fatalf("bad: %#v", config)
+	}
+}
+
+func TestLoadConfig_noExist(t *testing.T) {
+	config, err := LoadConfig("nope/not-once/.never")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.TokenHelper != "" {
+		t.Errorf("expected %q to be %q", config.TokenHelper, "")
+	}
+}
+
+func TestParseConfig_badKeys(t *testing.T) {
+	_, err := ParseConfig(`
+token_helper = "/token"
+nope = "true"
+`)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "invalid key 'nope' on line 3") {
+		t.Errorf("bad error: %s", err.Error())
+	}
+}

--- a/command/config/config_test.go
+++ b/command/config/config_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-const FixturePath = "./test-fixtures"
+const FixturePath = "../test-fixtures"
 
 func TestLoadConfig(t *testing.T) {
 	config, err := LoadConfig(filepath.Join(FixturePath, "config.hcl"))

--- a/command/config/util.go
+++ b/command/config/util.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"github.com/hashicorp/vault/command/token"
+)
+
+// DefaultTokenHelper returns the token helper that is configured for Vault.
+func DefaultTokenHelper() (token.TokenHelper, error) {
+	config, err := LoadConfig("")
+	if err != nil {
+		return nil, err
+	}
+
+	path := config.TokenHelper
+	if path == "" {
+		return &token.InternalTokenHelper{}, nil
+	}
+
+	path, err = token.ExternalTokenHelperPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return &token.ExternalTokenHelper{BinaryPath: path}, nil
+}

--- a/command/util.go
+++ b/command/util.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/command/config"
 	"github.com/hashicorp/vault/command/token"
 	"github.com/mitchellh/cli"
 )

--- a/command/util.go
+++ b/command/util.go
@@ -15,21 +15,7 @@ import (
 
 // DefaultTokenHelper returns the token helper that is configured for Vault.
 func DefaultTokenHelper() (token.TokenHelper, error) {
-	config, err := LoadConfig("")
-	if err != nil {
-		return nil, err
-	}
-
-	path := config.TokenHelper
-	if path == "" {
-		return &token.InternalTokenHelper{}, nil
-	}
-
-	path, err = token.ExternalTokenHelperPath(path)
-	if err != nil {
-		return nil, err
-	}
-	return &token.ExternalTokenHelper{BinaryPath: path}, nil
+	return config.DefaultTokenHelper()
 }
 
 // RawField extracts the raw field from the given data and returns it as a


### PR DESCRIPTION
This PR extracts the functions associated with loading and parsing
configs, and the DefaultTokenHelper, into a command/config subpackage,
just like TokenHelpers are in the command/token subpackage. The goal is
to allow other clients (in this case, the Vault and Nomad Terraform
providers, but in theory any client that wants to lean on Vault's
default behaviour) to reuse this logic and not drift from Vault, without
vendoring the entirety of Vault.

To retain backwards compatibility, I didn't remove any functions from
the command package; I just copied them into the command/config package,
and update the functions in the command package to call through to the
config package.