### PR TITLE
Add the chunk_size optional parameter to gcs storage

### DIFF
--- a/physical/gcs/gcs.go
+++ b/physical/gcs/gcs.go
@@ -21,9 +21,6 @@ import (
 	"google.golang.org/api/option"
 )
 
-// Verify GCSBackend satisfies the correct interfaces
-var _ physical.Backend = (*GCSBackend)(nil)
-
 // GCSBackend is a physical backend that stores data
 // within an Google Cloud Storage bucket.
 type GCSBackend struct {
@@ -32,6 +29,15 @@ type GCSBackend struct {
 	permitPool *physical.PermitPool
 	logger     log.Logger
 }
+
+var (
+	// Verify GCSBackend satisfies the correct interfaces
+	_ physical.Backend = (*GCSBackend)(nil)
+
+	// Number of bytes the writer will attempt to write in a single request.
+	// Defaults to 8Mb, as defined in the gcs library
+	chunkSize = 8 * 1024 * 1024
+)
 
 // NewGCSBackend constructs a Google Cloud Storage backend using a pre-existing
 // bucket. Credentials can be provided to the backend, sourced
@@ -67,6 +73,18 @@ func NewGCSBackend(conf map[string]string, logger log.Logger) (physical.Backend,
 		}
 		if logger.IsDebug() {
 			logger.Debug("physical/gcs: max_parallel set", "max_parallel", maxParInt)
+		}
+	}
+
+	chunkSizeStr, ok := conf["chunk_size"]
+	if ok {
+		chunkSize, err = strconv.Atoi(chunkSizeStr)
+		if err != nil {
+			return nil, errwrap.Wrapf("failed parsing chunk_size parameter: {{err}}", err)
+		}
+		chunkSize *= 1024
+		if logger.IsDebug() {
+			logger.Debug("physical/gcs: chunk_size set", "chunk_size", chunkSize)
 		}
 	}
 
@@ -111,6 +129,7 @@ func (g *GCSBackend) Put(ctx context.Context, entry *physical.Entry) error {
 
 	bucket := g.client.Bucket(g.bucketName)
 	writer := bucket.Object(entry.Key).NewWriter(context.Background())
+	writer.ChunkSize = chunkSize
 
 	g.permitPool.Acquire()
 	defer g.permitPool.Release()

--- a/website/source/docs/configuration/storage/google-cloud.html.md
+++ b/website/source/docs/configuration/storage/google-cloud.html.md
@@ -42,6 +42,13 @@ storage "gcs" {
 - `max_parallel` `(string: "128")` – Specifies the maximum number of concurrent
   requests.
 
+- `chunk_size` `(string: "8192")` – Specifies the maximum kilobytes of each object
+  the gcs writer will attempt to send to the server in a single request.
+  If set to 0, it will attempt to send the whole object at once, but it will
+  not retry any failures either (not recommended). If you are not storing large
+  objects in Vault, it is recommended to set this to a low value (minimum is 256)
+  since it will drastically reduce the amount of memory Vault uses.
+
 ## `gcs` Examples
 
 ### Default Example


### PR DESCRIPTION
While following an issue, where Vault was running [out of memory](https://groups.google.com/forum/#!topic/vault-tool/5VRhuCwdg1U) we found that the issue is the `gcs` library. After opening a [ticket](https://github.com/GoogleCloudPlatform/google-cloud-go/issues/902), it was established that it was a configurable feature of the GCS library. 

Add an optional parameter `chunk_size` to the gcs storage configuration (defaults still to 8Mb, so it behaves as until now for everyone else) to specify the size of the chunks