### PR TITLE
Vault status formatting

### DIFF
--- a/command/format.go
+++ b/command/format.go
@@ -325,7 +325,7 @@ func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusRespo
 
 			// This is down here just to keep ordering consistent
 			if showLeaderAddr {
-				out = append(out, fmt.Sprintf("Active Node Address: | %s", leaderStatus.LeaderAddress))
+				out = append(out, fmt.Sprintf("Active Node Address | %s", leaderStatus.LeaderAddress))
 			}
 		}
 	}


### PR DESCRIPTION
Example output from `vault status`:
```
:~# vault status
Key                     Value
---                     -----
Seal Type               shamir
Sealed                  false
Total Shares            8
Threshold               2
Version                 0.9.5
Cluster Name            vault-cluster-8c85f1aa
Cluster ID              aaaaaaaa-1111-2222-3333-444444444444
HA Enabled              true
HA Cluster              https://10.0.0.1:8201
HA Mode                 standby
Active Node Address:    https://10.0.0.1:8200
```

`Active Node Address:` - is the only one with a colon at the end.

This PR fix that output style issue.