### PR TITLE
missing hyphen in docs for vault auth-enable

### DIFF
--- a/website/source/docs/auth/approle.html.md
+++ b/website/source/docs/auth/approle.html.md
@@ -85,7 +85,7 @@ management tool.
 1. Enable the AppRole auth method:
 
     ```text
-    $ vault auth enable approle
+    $ vault auth-enable approle
     ```
 
 1. Create a named role:

--- a/website/source/guides/identity/authentication.html.md
+++ b/website/source/guides/identity/authentication.html.md
@@ -162,7 +162,7 @@ Like many other auth backends, AppRole must be enabled before it can be used.
 Enable `approle` auth backend by executing the following command:
 
 ```shell
-$ vault auth enable approle
+$ vault auth-enable approle
 ```
 
 #### API call using cURL


### PR DESCRIPTION
Just added a hyphen to docs, as what was documented didn't work for me.