### PR TITLE
Return 'key_bits' value when reading a SSH CA Role

### DIFF
--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -530,6 +530,7 @@ func (b *backend) parseRole(role *sshRole) (map[string]interface{}, error) {
 			"allow_user_key_ids":       role.AllowUserKeyIDs,
 			"key_id_format":            role.KeyIDFormat,
 			"key_type":                 role.KeyType,
+			"key_bits":                 role.KeyBits,
 			"default_critical_options": role.DefaultCriticalOptions,
 			"default_extensions":       role.DefaultExtensions,
 		}


### PR DESCRIPTION
`parseRole` does not return the `key_bits` value, but should be available when reading. 