### PR TITLE
Allow configuration of dynamodb storage to specify the max retries of aws sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ BUG FIXES:
 
  * auth/aws: Fix honoring `max_ttl` when a corresponding role `ttl` is not also
    set [GH-4107]
+ * auth/token: If a periodic token being issued has a period greater than the
+   max_lease_ttl configured on the token store mount, truncate it. This matches
+   renewal behavior; before it was inconsistent between issuance and renewal.
+   [GH-4112]
  * cli: Improve error messages around `vault auth help` when there is no CLI
    helper for a particular method [GH-4056]
  * cli: Fix autocomplete installation when using Fish as the shell [GH-4094]

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -186,13 +186,14 @@ func NewDynamoDBBackend(conf map[string]string, logger log.Logger) (physical.Bac
 	dynamodbMaxRetryString := os.Getenv("AWS_DYNAMODB_MAX_RETRIES")
 	if dynamodbMaxRetryString == "" {
 		dynamodbMaxRetryString = conf["dynamodb_max_retries"]
-		if dynamodbMaxRetryString == "" {
-			dynamodbMaxRetryString = "-1"
-		}
 	}
-	dynamodbMaxRetry, err := strconv.Atoi(dynamodbMaxRetryString)
-	if err != nil {
-		return nil, fmt.Errorf("invalid max retry: %s", dynamodbMaxRetryString)
+	var dynamodbMaxRetry int = aws.UseServiceDefaultRetries
+	if dynamodbMaxRetryString != "" {
+		var err error
+		dynamodbMaxRetry, err = strconv.Atoi(dynamodbMaxRetryString)
+		if err != nil {
+			return nil, fmt.Errorf("invalid max retry: %s", dynamodbMaxRetryString)
+		}
 	}
 
 	credsConfig := &awsutil.CredentialsConfig{

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -187,7 +187,7 @@ func NewDynamoDBBackend(conf map[string]string, logger log.Logger) (physical.Bac
 	if dynamodbMaxRetryString == "" {
 		dynamodbMaxRetryString = conf["dynamodb_max_retries"]
 		if dynamodbMaxRetryString == "" {
-			dynamodbMaxRetryString = "0"
+			dynamodbMaxRetryString = "-1"
 		}
 	}
 	dynamodbMaxRetry, err := strconv.Atoi(dynamodbMaxRetryString)


### PR DESCRIPTION
This was an issue if you are wanting errors to manifest themselves in vault as the errors weren't being shown. By setting the variable to 0 you are able to get error messages from the sdk calls if it fails once and then the clients can handle the retry logic.