### PR TITLE
bump middleman-hashicorp container to 0.3.32

### DIFF
--- a/website/packer.json
+++ b/website/packer.json
@@ -8,7 +8,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "hashicorp/middleman-hashicorp:0.3.29",
+      "image": "hashicorp/middleman-hashicorp:0.3.32",
       "discard": "true",
       "volumes": {
         "{{ pwd }}": "/website"


### PR DESCRIPTION
Bumping the middleman-hashicorp container to use the latest version. 