### PR TITLE
Make credential plugin to work that is modified before vault startup

### DIFF
--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -124,5 +124,12 @@ func (c *Core) reloadPluginCommon(ctx context.Context, entry *MountEntry, isAuth
 	// Set the backend back
 	re.backend = backend
 
+	// Set paths as well
+	paths := backend.SpecialPaths()
+	if paths != nil {
+		re.rootPaths.Store(pathsToRadix(paths.Root))
+		re.loginPaths.Store(pathsToRadix(paths.Unauthenticated))
+	}
+
 	return nil
 }


### PR DESCRIPTION
If I start vault server with old checksum of my credential plugin and update plugin catalog later, then there is no chance to make the plugin work correctly. Vault core recognizes it as a normal logical backend, not a credential plugin even after reload.

Reproducing steps
- Modify the credential plugin already registered and build it (checksum changed)
- Start vault server with old checksum value
- Update plugin catalog with new checksum value
- Reload the credential plugin

This PR fixes the issue by refreshing `routeEntry.rootPaths`, `routeEntry.loginPaths` after reload.
I've changed the types of these fields to `atomic.Value` because they can be replaced on runtime.