### PR TITLE
docs: Alphabetize CLI commands

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -308,6 +308,9 @@
           <li<%= sidebar_current("docs-commands-ssh") %>>
             <a href="/docs/commands/ssh.html">ssh</a>
           </li>
+          <li<%= sidebar_current("docs-commands-status") %>>
+            <a href="/docs/commands/status.html">status</a>
+          </li>
           <li<%= sidebar_current("docs-commands-token") %>>
             <a href="/docs/commands/token.html">token</a>
             <ul class="nav">
@@ -327,9 +330,6 @@
                 <a href="/docs/commands/token/revoke.html">revoke</a>
               </li>
             </ul>
-          </li>
-          <li<%= sidebar_current("docs-commands-status") %>>
-            <a href="/docs/commands/status.html">status</a>
           </li>
           <li<%= sidebar_current("docs-commands-unwrap") %>>
             <a href="/docs/commands/unwrap.html">unwrap</a>


### PR DESCRIPTION
status was appearing after token when it should be before