### PR TITLE
Fix typo in recommended vault auth iam policy

### DIFF
--- a/website/source/docs/auth/aws.html.md
+++ b/website/source/docs/auth/aws.html.md
@@ -304,7 +304,7 @@ method.
       "Effect": "Allow",
       "Action": ["sts:AssumeRole"],
       "Resource": [
-        "arn:aws:iam:<AccountId>:role/<VaultRole>"
+        "arn:aws:iam::<AccountId>:role/<VaultRole>"
       ]
     }
   ]


### PR DESCRIPTION
The resource arn for the `sts:AssumeRole` action is missing a `:` for the region and therefore invalid.