### PR TITLE
Fix description of parameter value globbing

### DIFF
--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -331,6 +331,9 @@ options are:
         }
         ```
 
+    * If any parameters are specified, all non-specified parameters are allowed,
+      unless `allowed_parameters` is also set, in which case normal rules apply.
+
 Parameter values also support prefix/suffix globbing. Globbing is enabled by
 prepending or appending or prepending a splat (`*`) to the value:
 
@@ -343,6 +346,9 @@ path "secret/foo" {
   }
 }
 ```
+
+Note: the only value that can be used with the `*` parameter is `[]`.
+
 
 ### Required Response Wrapping TTLs
 

--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -269,7 +269,7 @@ options are:
         ```
 
     * If any keys are specified, all non-specified parameters will be denied
-      unless there the parameter `"*"` is set to an empty array, which will
+      unless the parameter `"*"` is set to an empty array, which will
       allow all other parameters to be modified. Parameters with specific values
       will still be restricted to those values.
 

--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -331,18 +331,15 @@ options are:
         }
         ```
 
-    * If any parameters are specified, all non-specified parameters are allowed,
-      unless `allowed_parameters` is also set, in which case normal rules apply.
-
 Parameter values also support prefix/suffix globbing. Globbing is enabled by
 prepending or appending or prepending a splat (`*`) to the value:
 
 ```ruby
-# Allow any parameter as long as the value starts with "foo-*".
+# Only allow a parameter named "bar" with a value starting with "foo-*".
 path "secret/foo" {
   capabilities = ["create"]
   allowed_parameters = {
-    "*" = ["foo-*"]
+    "bar" = ["foo-*"]
   }
 }
 ```


### PR DESCRIPTION
I believe this is the revision we discussed.

I also removed the preceding bullet, which seems to directly contradict https://github.com/hashicorp/vault/commit/372ce4fd390efc15d52b0c94f428f7e0fe55154e#diff-6c0a914f80c2583079f101c63646ff0eL271 ?