### PR TITLE
Plugins need setcap too for syscall mlock

### DIFF
--- a/website/source/docs/configuration/index.html.md
+++ b/website/source/docs/configuration/index.html.md
@@ -89,6 +89,8 @@ to specify where the configuration is.
     sudo setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
     ```
 
+    Note: Since each plugin runs as a separate process, you need to do the same for each plugin in your [plugins directory](https://www.vaultproject.io/docs/internals/plugins.html#plugin-directory).
+
     If you use a Linux distribution with a modern version of systemd, you can add
     the following directive to the "[Service]" configuration section:
 

--- a/website/source/docs/internals/plugins.html.md
+++ b/website/source/docs/internals/plugins.html.md
@@ -15,7 +15,7 @@ and require no additional operator intervention to run. Builtin plugins are
 just like any other backend code inside vault. External plugins, on the other
 hand, are not shipped with the vault binary and must be registered to vault by
 a privileged vault user. This section of the documentation will describe the
-architecture and security of external plugins. 
+architecture and security of external plugins.
 
 # Plugin Architecture
 Vault's plugins are completely separate, standalone applications that Vault
@@ -72,7 +72,7 @@ docs](/api/system/plugins-catalog.html).
 An example plugin submission looks like:
 
 ```
-$ vault write sys/plugins/catalog/myplugin-database-plugin \ 
+$ vault write sys/plugins/catalog/myplugin-database-plugin \
     sha_256=<expected SHA256 Hex value of the plugin binary> \
     command="myplugin"
 Success! Data written to: sys/plugins/catalog/myplugin-database-plugin
@@ -83,7 +83,7 @@ When a backend wants to run a plugin, it first looks up the plugin, by name, in
 the catalog. It then checks the executable's SHA256 sum against the one
 configured in the plugin catalog. Finally vault runs the command configured in
 the catalog, sending along the JWT formatted response wrapping token and mlock
-settings (like Vault, plugins support the use of mlock when available).
+settings (like Vault, plugins support [the use of mlock when available](https://www.vaultproject.io/docs/configuration/index.html#disable_mlock)).
 
 # Plugin Development
 
@@ -114,7 +114,7 @@ package main
 
 import (
 	"os"
-	
+
 	"github.com/hashicorp/vault/helper/pluginutil"
 	"github.com/hashicorp/vault/plugins"
 )
@@ -123,7 +123,7 @@ func main() {
 	apiClientMeta := &pluginutil.APIClientMeta{}
 	flags := apiClientMeta.FlagSet()
 	flags.Parse(os.Args)
-	
+
 	plugins.Serve(New().(MyPlugin), apiClientMeta.GetTLSConfig())
 }
 ```


### PR DESCRIPTION
Adding a little detail to the documentation to avoid headaches.