### PR TITLE
Fixed the hyperlink

### DIFF
--- a/website/source/guides/identity/authentication.html.md
+++ b/website/source/guides/identity/authentication.html.md
@@ -668,7 +668,7 @@ b07d7a47-1d0d-741d-20b4-ae0de7c6d964
 
 ## Next steps
 
-Watch the video recording of the [Delivering Secret Zero: Vault AppRole with Terraform and Chef](Docs.google.com/document/d/1CCbAQ-ZEeSpxQqvo40hM0Y5oe3tBCxM1qYrk7_Wyvww/edit?ts=5a865277#heading=h.i52qa2wbjcsk)
+Watch the video recording of the [Delivering Secret Zero: Vault AppRole with Terraform and Chef](https://www.hashicorp.com/resources/delivering-secret-zero-vault-approle-terraform-chef)
 webinar which talks about the usage of AppRole with Terraform and Chef as its trusted entities.
 
 To learn more about response wrapping, go to the [Cubbyhole Response


### PR DESCRIPTION
Fixing the hyperlink for HashiCorp webinar referenced in the "AppRole Pull Authentication" guide.