### PR TITLE
More cleanup of TTL handling in PKI

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2401,7 +2401,7 @@ func TestBackend_SignVerbatim(t *testing.T) {
 	}
 	cert := certs[0]
 	if math.Abs(float64(time.Now().Add(12*time.Hour).Unix()-cert.NotAfter.Unix())) < 10 {
-		t.Fatalf("sign-verbatim did not properly cap validiaty period on signed CSR")
+		t.Fatalf("sign-verbatim did not properly cap validity period on signed CSR")
 	}
 
 	// now check that if we set generate-lease it takes it from the role and the TTLs match


### PR DESCRIPTION
* Max role's max_ttl parameter a TypeDurationString like ttl
* Don't clamp values at write time in favor of evaluating at issue time,
as is the current best practice
* Lots of general cleanup of logic to fix missing cases