### PR TITLE
Token store deleted parent

### DIFF
--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1170,7 +1170,13 @@ func (ts *TokenStore) revokeSalted(ctx context.Context, saltedId string) (ret er
 	}
 
 	// Mark all children token as orphan by removing
-	// their parent index, and clear the parent entry
+	// their parent index, and clear the parent entry.
+	//
+	// Marking the token as orphan is the correct behavior in here since
+	// revokeTreeSalted will ensure that they are deleted anyways if it's not an
+	// explicit call to orphan the child tokens (the delete occurs at the leaf
+	// node and uses parent prefix, not entry.Parent, to build the tree for
+	// traversal).
 	parentPath := parentPrefix + saltedId + "/"
 	children, err := ts.view.List(ctx, parentPath)
 	if err != nil {

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1413,17 +1413,10 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 		}
 		// Add current children deleted count to the total count
 		deletedCountParentList += deletedChildrenCount
-		// If we deleted all the children, then add that to our deleted parent entries count
+		// N.B.: We don't call delete on the parent prefix since physical.Backend.Delete
+		// implementations should be in charge of deleting empty prefixes.
+		// If we deleted all the children, then add that to our deleted parent entries count.
 		if originalChildrenCount == deletedChildrenCount {
-			// Make sure that we only delete if parent doesn't exist.
-			// N.B.: This is a no-op for the consul storage backend since the delete doesn't support
-			// recursive deletes, and delete on a path is a no-op.
-			if exists == nil {
-				err := ts.view.Delete(ctx, parentPrefix+parent)
-				if err != nil {
-					tidyErrors = multierror.Append(tidyErrors, fmt.Errorf("failed to delete parent prefix entry: %v", err))
-				}
-			}
 			deletedCountParentEntries++
 		}
 	}

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1169,7 +1169,7 @@ func (ts *TokenStore) revokeSalted(ctx context.Context, saltedId string) (ret er
 		}
 	}
 
-	// Clear the parent index
+	// Clear the parent entry
 	parentPath := parentPrefix + saltedId + "/"
 	if err = logical.ClearView(ctx, ts.view.SubView(parentPath)); err != nil {
 		return fmt.Errorf("failed to delete entry: %v", err)
@@ -1342,8 +1342,9 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 			continue
 		}
 
-		// First check if the salt ID of the parent exists, and if not delete this
-		// entry and continue to the next one.
+		// First check if the salt ID of the parent exists, and if not mark this so
+		// that deletion of children later with this loop below applies to all
+		// children
 		originalChildrenCount := int64(len(children))
 		exists, _ := ts.lookupSalted(ctx, strings.TrimSuffix(parent, "/"), true)
 		if exists == nil {
@@ -1473,8 +1474,8 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 		}
 	}
 
-	ts.logger.Debug("token: number of entries scanned in parent index", "count", countParentEntries)
-	ts.logger.Debug("token: number of entries deleted in parent index", "count", deletedCountParentEntries)
+	ts.logger.Debug("token: number of entries scanned in parent prefix", "count", countParentEntries)
+	ts.logger.Debug("token: number of entries deleted in parent prefix", "count", deletedCountParentEntries)
 	ts.logger.Debug("token: number of tokens scanned in parent index list", "count", countParentList)
 	ts.logger.Debug("token: number of tokens revoked in parent index list", "count", deletedCountParentList)
 	ts.logger.Debug("token: number of accessors scanned", "count", countAccessorList)

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -3527,8 +3527,10 @@ func TestTokenStore_HandleTidyCase1(t *testing.T) {
 	}
 }
 
-// Create a token, delete the token entry while leaking accessors, invoke tidy
-// and check if the dangling accessor entry is getting removed
+// Create a set of tokens along with a child token for each of them, delete the
+// token entry while leaking accessors, invoke tidy and check if the dangling
+// accessor entry is getting removed and check if child tokens are still present
+// and turned into orphan tokens.
 func TestTokenStore_HandleTidy_parentCleanup(t *testing.T) {
 	var resp *logical.Response
 	var err error

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -758,6 +758,10 @@ func TestTokenStore_Revoke_Orphan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+
+	// Unset the expected token parent's ID
+	ent2.Parent = ""
+
 	if !reflect.DeepEqual(out, ent2) {
 		t.Fatalf("bad: expected:%#v\nactual:%#v", ent2, out)
 	}

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -3545,7 +3545,7 @@ func TestTokenStore_HandleTidy_parentCleanup(t *testing.T) {
 	// present, the list operation should return only one key.
 	accessorListReq := &logical.Request{
 		Operation:   logical.ListOperation,
-		Path:        "accessors",
+		Path:        "accessors/",
 		ClientToken: root,
 	}
 	resp, err = ts.HandleRequest(context.Background(), accessorListReq)


### PR DESCRIPTION
Addresses the following:
 - Revoke-orphan and tidy now removes the parent prefix entry if the token entry doesn't exist
 - Revoke-orphan and tidy now converts/marks all child tokens as orphan tokens as it's cleaning up the parent prefix entry.