### PR TITLE
Add debug flag to dump requests and responses on the CLI

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -14,11 +14,15 @@ func init() {
 	// Ensure our special envvars are not present
 	os.Setenv("VAULT_ADDR", "")
 	os.Setenv("VAULT_TOKEN", "")
+	os.Setenv("VAULT_CLIENT_DEBUG", "")
 }
 
 func TestDefaultConfig_envvar(t *testing.T) {
 	os.Setenv("VAULT_ADDR", "https://vault.mycompany.com")
 	defer os.Setenv("VAULT_ADDR", "")
+
+	os.Setenv("VAULT_CLIENT_DEBUG", "true")
+	defer os.Setenv("VAULT_CLIENT_TOKEN", "")
 
 	config := DefaultConfig()
 	if config.Address != "https://vault.mycompany.com" {
@@ -33,6 +37,9 @@ func TestDefaultConfig_envvar(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
+	if debug := client.config.Debug; debug != true {
+		t.Fatalf("bad: %t", debug)
+	}
 	if token := client.Token(); token != "testing" {
 		t.Fatalf("bad: %s", token)
 	}

--- a/command/base.go
+++ b/command/base.go
@@ -38,6 +38,7 @@ type BaseCommand struct {
 	flagClientKey     string
 	flagTLSServerName string
 	flagTLSSkipVerify bool
+	flagDebug         bool
 	flagWrapTTL       time.Duration
 
 	flagFormat string
@@ -79,6 +80,8 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 		}
 		config.ConfigureTLS(t)
 	}
+
+	config.Debug = c.flagDebug
 
 	// Build the client
 	client, err := api.NewClient(config)
@@ -256,6 +259,14 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 					"TTL. The response is available via the \"vault unwrap\" command. " +
 					"The TTL is specified as a numeric string with suffix like \"30s\" " +
 					"or \"5m\".",
+			})
+
+			f.BoolVar(&BoolVar{
+				Name:    "debug",
+				Target:  &c.flagDebug,
+				Default: false,
+				EnvVar:  "VAULT_CLIENT_DEBUG",
+				Usage:   "Debug HTTP requests made to Vault API.",
 			})
 		}
 


### PR DESCRIPTION
Adding debug flag and environment variable to output API debug information using the `httputil` library to print the request and response information to the command line.