### PR TITLE
Always use a local test server

### DIFF
--- a/command/auth_disable_test.go
+++ b/command/auth_disable_test.go
@@ -50,7 +50,11 @@ func TestAuthDisableCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testAuthDisableCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {

--- a/command/auth_help_test.go
+++ b/command/auth_help_test.go
@@ -54,7 +54,11 @@ func TestAuthHelpCommand_Run(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			client, closer := testVaultServer(t)
+			defer closer()
+
 			ui, cmd := testAuthHelpCommand(t)
+			cmd.client = client
 
 			code := cmd.Run(tc.args)
 			if code != tc.code {

--- a/command/auth_tune_test.go
+++ b/command/auth_tune_test.go
@@ -51,7 +51,11 @@ func TestAuthTuneCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testAuthTuneCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {

--- a/command/delete_test.go
+++ b/command/delete_test.go
@@ -50,7 +50,11 @@ func TestDeleteCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testDeleteCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {

--- a/command/operator_generate_root_test.go
+++ b/command/operator_generate_root_test.go
@@ -91,7 +91,11 @@ func TestOperatorGenerateRootCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testOperatorGenerateRootCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {
@@ -109,7 +113,11 @@ func TestOperatorGenerateRootCommand_Run(t *testing.T) {
 	t.Run("generate_otp", func(t *testing.T) {
 		t.Parallel()
 
+		client, closer := testVaultServer(t)
+		defer closer()
+
 		ui, cmd := testOperatorGenerateRootCommand(t)
+		cmd.client = client
 
 		code := cmd.Run([]string{
 			"-generate-otp",
@@ -130,7 +138,11 @@ func TestOperatorGenerateRootCommand_Run(t *testing.T) {
 		encoded := "L9MaZ/4mQanpOV6QeWd84g=="
 		otp := "dIeeezkjpDUv3fy7MYPOLQ=="
 
+		client, closer := testVaultServer(t)
+		defer closer()
+
 		ui, cmd := testOperatorGenerateRootCommand(t)
+		cmd.client = client
 
 		// Simulate piped output to print raw output
 		old := os.Stdout

--- a/command/operator_key_status_test.go
+++ b/command/operator_key_status_test.go
@@ -44,7 +44,11 @@ func TestOperatorKeyStatusCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testOperatorKeyStatusCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {

--- a/command/operator_unseal_test.go
+++ b/command/operator_unseal_test.go
@@ -27,7 +27,11 @@ func TestOperatorUnsealCommand_Run(t *testing.T) {
 	t.Run("error_non_terminal", func(t *testing.T) {
 		t.Parallel()
 
+		client, closer := testVaultServer(t)
+		defer closer()
+
 		ui, cmd := testOperatorUnsealCommand(t)
+		cmd.client = client
 		cmd.testOutput = ioutil.Discard
 
 		code := cmd.Run(nil)

--- a/command/policy_delete_test.go
+++ b/command/policy_delete_test.go
@@ -51,7 +51,11 @@ func TestPolicyDeleteCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testPolicyDeleteCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {

--- a/command/policy_fmt_test.go
+++ b/command/policy_fmt_test.go
@@ -52,7 +52,11 @@ func TestPolicyFmtCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testPolicyFmtCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {
@@ -87,7 +91,11 @@ path "secret" {
 		}
 		f.Close()
 
+		client, closer := testVaultServer(t)
+		defer closer()
+
 		_, cmd := testPolicyFmtCommand(t)
+		cmd.client = client
 
 		code := cmd.Run([]string{
 			f.Name(),
@@ -126,7 +134,11 @@ path "secret" {
 		}
 		f.Close()
 
+		client, closer := testVaultServer(t)
+		defer closer()
+
 		ui, cmd := testPolicyFmtCommand(t)
+		cmd.client = client
 
 		code := cmd.Run([]string{
 			f.Name(),
@@ -157,7 +169,11 @@ path "secret" {
 		}
 		f.Close()
 
+		client, closer := testVaultServer(t)
+		defer closer()
+
 		ui, cmd := testPolicyFmtCommand(t)
+		cmd.client = client
 
 		code := cmd.Run([]string{
 			f.Name(),
@@ -188,7 +204,11 @@ path "secret" {
 		}
 		f.Close()
 
+		client, closer := testVaultServer(t)
+		defer closer()
+
 		ui, cmd := testPolicyFmtCommand(t)
+		cmd.client = client
 
 		code := cmd.Run([]string{
 			f.Name(),

--- a/command/rotate_test.go
+++ b/command/rotate_test.go
@@ -44,7 +44,11 @@ func TestOperatorRotateCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testOperatorRotateCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {

--- a/command/secrets_move_test.go
+++ b/command/secrets_move_test.go
@@ -56,7 +56,11 @@ func TestSecretsMoveCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testSecretsMoveCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {

--- a/command/secrets_tune_test.go
+++ b/command/secrets_tune_test.go
@@ -51,7 +51,11 @@ func TestSecretsTuneCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testSecretsTuneCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {

--- a/command/token_capabilities_test.go
+++ b/command/token_capabilities_test.go
@@ -42,7 +42,11 @@ func TestTokenCapabilitiesCommand_Run(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			client, closer := testVaultServer(t)
+			defer closer()
+
 			ui, cmd := testTokenCapabilitiesCommand(t)
+			cmd.client = client
 
 			code := cmd.Run(tc.args)
 			if code != tc.code {

--- a/command/token_revoke_test.go
+++ b/command/token_revoke_test.go
@@ -86,7 +86,11 @@ func TestTokenRevokeCommand_Run(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
+				client, closer := testVaultServer(t)
+				defer closer()
+
 				ui, cmd := testTokenRevokeCommand(t)
+				cmd.client = client
 
 				code := cmd.Run(tc.args)
 				if code != tc.code {

--- a/command/version_test.go
+++ b/command/version_test.go
@@ -26,7 +26,12 @@ func TestVersionCommand_Run(t *testing.T) {
 	t.Run("output", func(t *testing.T) {
 		t.Parallel()
 
+		client, closer := testVaultServer(t)
+		defer closer()
+
 		ui, cmd := testVersionCommand(t)
+		cmd.client = client
+
 		code := cmd.Run(nil)
 		if exp := 0; code != exp {
 			t.Errorf("expected %d to be %d", code, exp)


### PR DESCRIPTION
Some commands didn't setup a local test server since they didn't need it. Other commands didn't setup a local test server because Seth forgot.

Long story short, I kept seeing weird requests to my Vault server when I ran tests, and that should never happen. This ensures all test requests will go to a test Vault instance.

Benchmarks show this adds 0.4s to the command test suite.