### PR TITLE
Provide an API for listing available secrets engines, auth methods, etc

### DIFF
--- a/vault/available.go
+++ b/vault/available.go
@@ -1,0 +1,45 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+const (
+	listAvailableAuditsKey = "audits"
+	listAvailableAuthsKey  = "auths"
+	listAvailableMountsKey = "mounts"
+)
+
+// listAvailable returns the list of installed type by name. This can list
+// the installed audits devices, auth methods, secrets engines, etc.
+func (c *Core) listAvailable(_ context.Context, typ string) ([]string, error) {
+	var rv reflect.Value
+
+	typ = strings.TrimSuffix(typ, "/")
+	switch typ {
+	case listAvailableAuditsKey:
+		rv = reflect.ValueOf(c.auditBackends)
+	case listAvailableAuthsKey:
+		rv = reflect.ValueOf(c.credentialBackends)
+	case listAvailableMountsKey:
+		rv = reflect.ValueOf(c.logicalBackends)
+	default:
+		return nil, fmt.Errorf("unknown type: %s", typ)
+	}
+
+	// This should never happen
+	if rv.Kind() != reflect.Map || rv.Type().Key().Kind() != reflect.String {
+		return nil, fmt.Errorf("not a string-keyed map: %s", typ)
+	}
+
+	names := make([]string, len(rv.MapKeys()))
+	for i, v := range rv.MapKeys() {
+		names[i] = v.String()
+	}
+	sort.Strings(names)
+	return names, nil
+}


### PR DESCRIPTION
This is for super early feedback. The end goals are:

- Provide an API to programatically list available (not enabled, available) secrets engines, auth methods, and audit devices
- Enable shell completion for said API (`vault secrets enable <tab>`, right now this is hard coded and must be maintained as a separate list)

Things I would like comments/feedback on:

1. The path design:

    The current architecture introduces a new `sys/available/<thing>` endpoint so `sys/available/secrets`, `sys/available/auths`, etc. Is this the best place? Should this be under `internal/`?

2. The permission model:

    Should this be a path that anyone in Vault can read? Is there a security vector in knowing what secrets engines are available, for example?

    If this should be a path that is authenticated, should it be in the default policy to have a better UX?

3. The way to get the data. Currently I'm using reflection, since that's the easiest way to key string keys from a map type where the map values are not the same (some are backend.Factory, some are audit.Factory). I'm happy to drop reflect, but it was easier than writing the same `for` loop 3 times.

Again, this is more for feedback and design. This is not the final PR. I'll likely close this one and open another one with the code once it's ready for review.

/cc @jefferai @vishalnayak @briankassouf 