### PR TITLE
Switch reading from S3 to io.Copy from io.ReadFull

### DIFF
--- a/physical/s3/s3.go
+++ b/physical/s3/s3.go
@@ -191,7 +191,10 @@ func (s *S3Backend) Get(ctx context.Context, key string) (*physical.Entry, error
 	defer resp.Body.Close()
 
 	data := bytes.NewBuffer(nil)
-	_, err = io.Copy(data, bytes.NewBuffer(resp.Body))
+	if resp.ContentLength != nil {
+		data = bytes.NewBuffer(make([]byte, 0, *resp.ContentLength))
+	}
+	_, err = io.Copy(data, resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/physical/s3/s3.go
+++ b/physical/s3/s3.go
@@ -188,16 +188,17 @@ func (s *S3Backend) Get(ctx context.Context, key string) (*physical.Entry, error
 	if resp == nil {
 		return nil, fmt.Errorf("got nil response from S3 but no error")
 	}
+	defer resp.Body.Close()
 
-	data := make([]byte, *resp.ContentLength)
-	_, err = io.ReadFull(resp.Body, data)
+	data := bytes.NewBuffer(nil)
+	_, err = io.Copy(data, bytes.NewBuffer(resp.Body))
 	if err != nil {
 		return nil, err
 	}
 
 	ent := &physical.Entry{
 		Key:   key,
-		Value: data,
+		Value: data.Bytes(),
 	}
 
 	return ent, nil


### PR DESCRIPTION
If the Content-Length header wasn't being sent back, the current
behavior could panic. It's unclear when it will not be sent; it appears
to be CORS dependent. But this works around it by not trying to
preallocate a buffer of a specific size and instead just read until EOF.

In addition I noticed that Close wasn't being called.
https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#GetObjectOutput
specifies that Body is an io.ReadCloser so I added a call to Close.

Fixes #4222