### PR TITLE
Embed Google Analytics only in production

### DIFF
--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -34,12 +34,14 @@
     <![endif]-->
     <%= javascript_include_tag "application" %>
 
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-NR2SD7C');</script>
+    <% if config[:environment] == :build %>
+      <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-NR2SD7C');</script>
+    <% end %>
 
     <!-- Typekit script to import Klavika font -->
     <script src="https://use.typekit.net/wxf7mfi.js"></script>
@@ -123,16 +125,18 @@
       </div>
     </div>
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    <% if config[:environment] == :build %>
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-62364009-1', 'vaultproject.io');
-      ga('require', 'linkid');
-      ga('send', 'pageview', location.pathname);
-    </script>
+        ga('create', 'UA-62364009-1', 'vaultproject.io');
+        ga('require', 'linkid');
+        ga('send', 'pageview', location.pathname);
+      </script>
+    <% end %>
 
     <%= yield_content :scripts %>
 


### PR DESCRIPTION
This will clean up analytics which currently show non-published pages
and an incorrect number of pageviews due to the Google Analytics script being run in
development as well as production.