### PR TITLE
Allow returning warnings and other data in 404s in the Go API

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 
@@ -50,6 +51,17 @@ func (c *Logical) Read(path string) (*Secret, error) {
 		defer resp.Body.Close()
 	}
 	if resp != nil && resp.StatusCode == 404 {
+		secret, err := ParseSecret(resp.Body)
+		switch err {
+		case nil:
+		case io.EOF:
+			return nil, nil
+		default:
+			return nil, err
+		}
+		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
+			return secret, nil
+		}
 		return nil, nil
 	}
 	if err != nil {
@@ -70,6 +82,17 @@ func (c *Logical) List(path string) (*Secret, error) {
 		defer resp.Body.Close()
 	}
 	if resp != nil && resp.StatusCode == 404 {
+		secret, err := ParseSecret(resp.Body)
+		switch err {
+		case nil:
+		case io.EOF:
+			return nil, nil
+		default:
+			return nil, err
+		}
+		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
+			return secret, nil
+		}
 		return nil, nil
 	}
 	if err != nil {

--- a/api/logical.go
+++ b/api/logical.go
@@ -112,6 +112,20 @@ func (c *Logical) Write(path string, data map[string]interface{}) (*Secret, erro
 	if resp != nil {
 		defer resp.Body.Close()
 	}
+	if resp != nil && resp.StatusCode == 404 {
+		secret, err := ParseSecret(resp.Body)
+		switch err {
+		case nil:
+		case io.EOF:
+			return nil, nil
+		default:
+			return nil, err
+		}
+		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
+			return secret, nil
+		}
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -128,6 +142,20 @@ func (c *Logical) Delete(path string) (*Secret, error) {
 	resp, err := c.c.RawRequest(r)
 	if resp != nil {
 		defer resp.Body.Close()
+	}
+	if resp != nil && resp.StatusCode == 404 {
+		secret, err := ParseSecret(resp.Body)
+		switch err {
+		case nil:
+		case io.EOF:
+			return nil, nil
+		default:
+			return nil, err
+		}
+		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
+			return secret, nil
+		}
+		return nil, nil
 	}
 	if err != nil {
 		return nil, err

--- a/api/response.go
+++ b/api/response.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/hashicorp/vault/helper/jsonutil"
@@ -33,10 +34,13 @@ func (r *Response) Error() error {
 
 	// We have an error. Let's copy the body into our own buffer first,
 	// so that if we can't decode JSON, we can at least copy it raw.
-	var bodyBuf bytes.Buffer
-	if _, err := io.Copy(&bodyBuf, r.Body); err != nil {
+	bodyBuf := &bytes.Buffer{}
+	if _, err := io.Copy(bodyBuf, r.Body); err != nil {
 		return err
 	}
+
+	r.Body.Close()
+	r.Body = ioutil.NopCloser(bodyBuf)
 
 	// Decode the error response if we can. Note that we wrap the bodyBuf
 	// in a bytes.Reader here so that the JSON decoder doesn't move the

--- a/command/list.go
+++ b/command/list.go
@@ -82,9 +82,14 @@ func (c *ListCommand) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Error listing %s: %s", path, err))
 		return 2
 	}
-	if secret == nil || secret.Data == nil {
+	if secret == nil {
 		c.UI.Error(fmt.Sprintf("No value found at %s", path))
 		return 2
+	}
+	if secret.Data == nil {
+		// If secret wasn't nil, we have warnings, so output them anyways. We
+		// may also have non-keys info.
+		return OutputSecret(c.UI, secret)
 	}
 
 	// If the secret is wrapped, return the wrapped response.

--- a/logical/response_util.go
+++ b/logical/response_util.go
@@ -24,11 +24,21 @@ func RespondErrorCommon(req *Request, resp *Response, err error) (int, error) {
 		// Basically: if we have empty "keys" or no keys at all, 404. This
 		// provides consistency with GET.
 		case req.Operation == ListOperation && resp.WrapInfo == nil:
-			if resp == nil || len(resp.Data) == 0 {
+			if resp == nil {
+				return http.StatusNotFound, nil
+			}
+			if len(resp.Data) == 0 {
+				if len(resp.Warnings) > 0 {
+					return 0, nil
+				}
 				return http.StatusNotFound, nil
 			}
 			keysRaw, ok := resp.Data["keys"]
 			if !ok || keysRaw == nil {
+				// If we don't have keys but have other data, return as-is
+				if len(resp.Data) > 0 || len(resp.Warnings) > 0 {
+					return 0, nil
+				}
 				return http.StatusNotFound, nil
 			}
 


### PR DESCRIPTION
On read it'll output data and/or warnings on a 404 if they exist. On
list, the same behavior; the actual 'vault list' command doesn't change
behavior though in terms of output unless there are no actual keys (so
it doesn't just magically show other data).

This corrects some assumptions in response_util and wrapping.go; it also
corrects a few places in the latter where it could leak a (useless)
token in some error cases.