### PR TITLE
Don't swallow logical.Unwrap error

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -138,10 +138,11 @@ func (c *Logical) Unwrap(wrappingToken string) (*Secret, error) {
 	if resp != nil {
 		defer resp.Body.Close()
 	}
-	if err != nil {
-		if resp != nil && resp.StatusCode != 404 {
-			return nil, err
-		}
+
+	// Return all errors except those that are from a 404 as we handle the not
+	// found error as a special case.
+	if err != nil && (resp == nil || resp.StatusCode != 404) {
+		return nil, err
 	}
 	if resp == nil {
 		return nil, nil


### PR DESCRIPTION
This PR fixes the error handling in the api packages logical.Unwrap
method. Previously if there was an error making the request to Vault,
the error was only returned if there was an HTTP response and the status
code was not a 404.

The new code returns all errors but does special case handling if the
response code is a 404.