### PR TITLE
On 404 if there is no actual body, return orig err.

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -51,18 +51,18 @@ func (c *Logical) Read(path string) (*Secret, error) {
 		defer resp.Body.Close()
 	}
 	if resp != nil && resp.StatusCode == 404 {
-		secret, err := ParseSecret(resp.Body)
-		switch err {
+		secret, parseErr := ParseSecret(resp.Body)
+		switch parseErr {
 		case nil:
 		case io.EOF:
 			return nil, nil
 		default:
-			return nil, err
+			return nil, parseErr
 		}
 		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
 			return secret, nil
 		}
-		return nil, nil
+		return nil, err
 	}
 	if err != nil {
 		return nil, err
@@ -82,18 +82,18 @@ func (c *Logical) List(path string) (*Secret, error) {
 		defer resp.Body.Close()
 	}
 	if resp != nil && resp.StatusCode == 404 {
-		secret, err := ParseSecret(resp.Body)
-		switch err {
+		secret, parseErr := ParseSecret(resp.Body)
+		switch parseErr {
 		case nil:
 		case io.EOF:
 			return nil, nil
 		default:
-			return nil, err
+			return nil, parseErr
 		}
 		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
 			return secret, nil
 		}
-		return nil, nil
+		return nil, err
 	}
 	if err != nil {
 		return nil, err
@@ -113,18 +113,18 @@ func (c *Logical) Write(path string, data map[string]interface{}) (*Secret, erro
 		defer resp.Body.Close()
 	}
 	if resp != nil && resp.StatusCode == 404 {
-		secret, err := ParseSecret(resp.Body)
-		switch err {
+		secret, parseErr := ParseSecret(resp.Body)
+		switch parseErr {
 		case nil:
 		case io.EOF:
 			return nil, nil
 		default:
-			return nil, err
+			return nil, parseErr
 		}
 		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
 			return secret, nil
 		}
-		return nil, nil
+		return nil, err
 	}
 	if err != nil {
 		return nil, err
@@ -144,18 +144,18 @@ func (c *Logical) Delete(path string) (*Secret, error) {
 		defer resp.Body.Close()
 	}
 	if resp != nil && resp.StatusCode == 404 {
-		secret, err := ParseSecret(resp.Body)
-		switch err {
+		secret, parseErr := ParseSecret(resp.Body)
+		switch parseErr {
 		case nil:
 		case io.EOF:
 			return nil, nil
 		default:
-			return nil, err
+			return nil, parseErr
 		}
 		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
 			return secret, nil
 		}
-		return nil, nil
+		return nil, err
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This keeps better backwards compat; we'll only swallow the original
error if there's actually other data or warnings returned.