### PR TITLE
Correct the page title to read `re-wrapping`

### DIFF
--- a/website/source/guides/encryption/transit-rewrap.html.md
+++ b/website/source/guides/encryption/transit-rewrap.html.md
@@ -1,6 +1,6 @@
 ---
 layout: "guides"
-page_title: "Transit Secrets Re-rapping - Guides"
+page_title: "Transit Secrets Re-wrapping - Guides"
 sidebar_current: "guides-encryption-rewrap"
 description: |-
   The goal of this guide is to demonstrate one possible way to re-wrap data after


### PR DESCRIPTION
The title in the metadata used `re-rapping` instead of `re-wrapping`. This one line change fixes the spelling.