### PR TITLE
Move colorable statements to fix Windows support.

### DIFF
--- a/command/main.go
+++ b/command/main.go
@@ -10,6 +10,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/hashicorp/vault/command/token"
+	colorable "github.com/mattn/go-colorable"
 	"github.com/mitchellh/cli"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -99,10 +100,10 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 		runOpts = &RunOptions{}
 	}
 	if runOpts.Stdout == nil {
-		runOpts.Stdout = os.Stdout
+		runOpts.Stdout = colorable.NewColorable(os.Stdout)
 	}
 	if runOpts.Stderr == nil {
-		runOpts.Stderr = os.Stderr
+		runOpts.Stderr = colorable.NewColorable(os.Stderr)
 	}
 
 	args = setupEnv(args)

--- a/command/server.go
+++ b/command/server.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	colorable "github.com/mattn/go-colorable"
 	"github.com/mitchellh/cli"
 	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/posener/complete"
@@ -285,7 +284,7 @@ func (c *ServerCommand) Run(args []string) int {
 
 	// Create a logger. We wrap it in a gated writer so that it doesn't
 	// start logging too early.
-	c.logGate = &gatedwriter.Writer{Writer: colorable.NewColorable(os.Stderr)}
+	c.logGate = &gatedwriter.Writer{Writer: os.Stderr}
 	var level log.Level
 	c.flagLogLevel = strings.ToLower(strings.TrimSpace(c.flagLogLevel))
 	switch c.flagLogLevel {


### PR DESCRIPTION
This puts it in the main command level.

Fixes #4070