### PR TITLE
Fix deadlock in root credential rotation

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -249,7 +249,7 @@ func (b *databaseBackend) CloseIfShutdown(db *dbPluginInstance, err error) {
 	case rpc.ErrShutdown, dbplugin.ErrPluginShutdown:
 		// Put this in a goroutine so that requests can run with the read or write lock
 		// and simply defer the unlock.  Since we are attaching the instance and matching
-		// the id in the conneciton map, we can safely do this.
+		// the id in the connection map, we can safely do this.
 		go func() {
 			b.Lock()
 			defer b.Unlock()

--- a/plugins/database/cassandra/test-fixtures/cassandra.yaml
+++ b/plugins/database/cassandra/test-fixtures/cassandra.yaml
@@ -572,7 +572,7 @@ ssl_storage_port: 7001
 #
 # Setting listen_address to 0.0.0.0 is always wrong.
 #
-listen_address: 172.17.0.2
+listen_address: 172.17.0.6
 
 # Set listen_address OR listen_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.


### PR DESCRIPTION
The individual plugins were tested but the current rotate deadlocks when going through the database backend.  This also updates the operation from `GET` to `PUT` for rotation.