### PR TITLE
Fix minor struct tag issues

### DIFF
--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -368,29 +368,29 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, d *
 }
 
 type ConfigEntry struct {
-	logger             log.Logger
-	Url                string `json:"url"`
-	UserDN             string `json:"userdn"`
-	GroupDN            string `json:"groupdn"`
-	GroupFilter        string `json:"groupfilter"`
-	GroupAttr          string `json:"groupattr"`
-	UPNDomain          string `json:"upndomain"`
-	UserAttr           string `json:"userattr"`
-	Certificate        string `json:"certificate"`
-	InsecureTLS        bool   `json:"insecure_tls"`
-	StartTLS           bool   `json:"starttls"`
-	BindDN             string `json:"binddn"`
-	BindPassword       string `json:"bindpass"`
-	DenyNullBind       bool   `json:"deny_null_bind"`
-	DiscoverDN         bool   `json:"discoverdn"`
-	TLSMinVersion      string `json:"tls_min_version"`
-	TLSMaxVersion      string `json:"tls_max_version"`
+	logger        log.Logger
+	Url           string `json:"url"`
+	UserDN        string `json:"userdn"`
+	GroupDN       string `json:"groupdn"`
+	GroupFilter   string `json:"groupfilter"`
+	GroupAttr     string `json:"groupattr"`
+	UPNDomain     string `json:"upndomain"`
+	UserAttr      string `json:"userattr"`
+	Certificate   string `json:"certificate"`
+	InsecureTLS   bool   `json:"insecure_tls"`
+	StartTLS      bool   `json:"starttls"`
+	BindDN        string `json:"binddn"`
+	BindPassword  string `json:"bindpass"`
+	DenyNullBind  bool   `json:"deny_null_bind"`
+	DiscoverDN    bool   `json:"discoverdn"`
+	TLSMinVersion string `json:"tls_min_version"`
+	TLSMaxVersion string `json:"tls_max_version"`
 
 	// This json tag deviates from snake case because there was a past issue
 	// where the tag was being ignored, causing it to be jsonified as "CaseSensitiveNames".
 	// To continue reading in users' previously stored values,
 	// we chose to carry that forward.
-	CaseSensitiveNames *bool  `json:"CaseSensitiveNames,omitempty"`
+	CaseSensitiveNames *bool `json:"CaseSensitiveNames,omitempty"`
 }
 
 func (c *ConfigEntry) GetTLSConfig(host string) (*tls.Config, error) {

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -385,7 +385,7 @@ type ConfigEntry struct {
 	DiscoverDN         bool   `json:"discoverdn"`
 	TLSMinVersion      string `json:"tls_min_version"`
 	TLSMaxVersion      string `json:"tls_max_version"`
-	CaseSensitiveNames *bool  `json:"case_sensitive_names,omitempty`
+	CaseSensitiveNames *bool  `json:"case_sensitive_names,omitempty"`
 }
 
 func (c *ConfigEntry) GetTLSConfig(host string) (*tls.Config, error) {

--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -385,7 +385,12 @@ type ConfigEntry struct {
 	DiscoverDN         bool   `json:"discoverdn"`
 	TLSMinVersion      string `json:"tls_min_version"`
 	TLSMaxVersion      string `json:"tls_max_version"`
-	CaseSensitiveNames *bool  `json:"case_sensitive_names,omitempty"`
+
+	// This json tag deviates from snake case because there was a past issue
+	// where the tag was being ignored, causing it to be jsonified as "CaseSensitiveNames".
+	// To continue reading in users' previously stored values,
+	// we chose to carry that forward.
+	CaseSensitiveNames *bool  `json:"CaseSensitiveNames,omitempty"`
 }
 
 func (c *ConfigEntry) GetTLSConfig(host string) (*tls.Config, error) {

--- a/logical/request.go
+++ b/logical/request.go
@@ -143,7 +143,7 @@ type Request struct {
 
 	// For replication, contains the last WAL on the remote side after handling
 	// the request, used for best-effort avoidance of stale read-after-write
-	lastRemoteWAL uint64 `sentinel:""`
+	lastRemoteWAL uint64
 }
 
 // Get returns a data field and guards for nil Data


### PR DESCRIPTION
Noticed these two small struct tag issues.

For `CaseSensitiveNames`, the lack of a closing quotation would have caused the setting to still be marshalled and unmarshalled correctly, but under a json key of `"CaseSensitiveNames"`. Adding the missing quotation may cause previous configs stored under that key to no longer be read in properly, so it will always return `false`. How should we handle that?

For `lastRemoteWAL`, since the `sentinal:""` tag seems insignificant and it wasn't getting picked up anyway, simply strips it.