### PR TITLE
Remove UTC call from SQL creds helper

### DIFF
--- a/plugins/helper/database/credsutil/sql.go
+++ b/plugins/helper/database/credsutil/sql.go
@@ -50,7 +50,7 @@ func (scp *SQLCredentialsProducer) GenerateUsername(config dbplugin.UsernameConf
 	}
 
 	username = fmt.Sprintf("%s%s%s", username, scp.Separator, userUUID)
-	username = fmt.Sprintf("%s%s%s", username, scp.Separator, fmt.Sprint(time.Now().UTC().Unix()))
+	username = fmt.Sprintf("%s%s%s", username, scp.Separator, fmt.Sprint(time.Now().Unix()))
 	if scp.UsernameLen > 0 && len(username) > scp.UsernameLen {
 		username = username[:scp.UsernameLen]
 	}


### PR DESCRIPTION
Unix() by definition is always number of seconds since Unix epoch UTC.