### PR TITLE
Fixes a reference to deprecated init command

### DIFF
--- a/website/source/intro/getting-started/deploy.html.md
+++ b/website/source/intro/getting-started/deploy.html.md
@@ -111,7 +111,7 @@ server_.
 
 During initialization, the encryption keys are generated, unseal keys are
 created, and the initial root token is setup. To initialize Vault use `vault
-init`. This is an _unauthenticated_ request, but it only works on brand new
+operator init`. This is an _unauthenticated_ request, but it only works on brand new
 Vaults with no data:
 
 ```text


### PR DESCRIPTION
Replace "vault init" with "vault operator init" in initialising the vault section.