### PR TITLE
Fix indentation of code block in Consul Secrets Engine docs

### DIFF
--- a/website/source/docs/secrets/consul/index.html.md
+++ b/website/source/docs/secrets/consul/index.html.md
@@ -84,7 +84,7 @@ lease_id           consul/creds/my-role/b2469121-f55f-53c5-89af-a3ba52b1d6d8
 lease_duration     768h
 lease_renewable    true
 token              642783bf-1540-526f-d4de-fe1ac1aed6f0
-    ```
+```
 
 ## API
 


### PR DESCRIPTION
The indentation of the code block in the Consul Secrets Engine doc was removed in #4224, but the closing backticks remained indented one level, resulting in the block swallowing all text after it. Removing the indentation from the closing backticks fixes this.