### PR TITLE
Touch up getting started doc

### DIFF
--- a/website/source/intro/getting-started/first-secret.html.md
+++ b/website/source/intro/getting-started/first-secret.html.md
@@ -46,7 +46,7 @@ $ vault kv put secret/hello foo=world excited=yes
 Success! Data written to: secret/hello
 ```
 
-`vault write` is a very powerful command. In addition to writing data
+`vault kv put` is a very powerful command. In addition to writing data
 directly from the command-line, it can read values and key pairs from
 `STDIN` as well as files. For more information, see the
 [command documentation](/docs/commands/index.html).


### PR DESCRIPTION
The example uses `vault kv put` but the the commentary references `vault write`.  Make them consistent (this commit) or explain the equivalence.