### PR TITLE
Add `-mode otp` to the two examples under "Automate it!" section

### DIFF
--- a/website/source/docs/secrets/ssh/one-time-ssh-passwords.html.md
+++ b/website/source/docs/secrets/ssh/one-time-ssh-passwords.html.md
@@ -92,7 +92,7 @@ A single CLI command can be used to create a new OTP and invoke SSH with the
 correct parameters to connect to the host.
 
 ```text
-$ vault ssh -role otp_key_role username@x.x.x.x
+$ vault ssh -role otp_key_role -mode otp username@x.x.x.x
 OTP for the session is `b4d47e1b-4879-5f4e-ce5c-7988d7986f37`
 [Note: Install `sshpass` to automate typing in OTP]
 Password: <Enter OTP>
@@ -101,7 +101,7 @@ Password: <Enter OTP>
 The OTP will be entered automatically using `sshpass` if it is installed.
 
 ```text
-$ vault ssh -role otp_key_role -strict-host-key-checking=no username@x.x.x.x
+$ vault ssh -role otp_key_role -mode otp -strict-host-key-checking=no username@x.x.x.x
 username@<IP of remote host>:~$
 ```
 


### PR DESCRIPTION
Without `-mode otp`, you get a warning when running those examples:

```
$ vault ssh -role otp_key_role -strict-host-key-checking=no username@172.20.20.10

WARNING: No -mode specified. Use -mode to tell Vault which ssh authentication
mode to use. In the future, you will need to tell Vault which mode to use.
For now, Vault will attempt to guess based on the API response. This guess
involves creating a temporary credential, reading its type, and then revoking
it. To reduce the number of API calls and surface area, specify -mode
directly. This will be removed in Vault 0.11 (or later).
```