### PR TITLE
UI: File API compat for IE

### DIFF
--- a/ui/app/components/download-button.js
+++ b/ui/app/components/download-button.js
@@ -12,16 +12,36 @@ export default Ember.Component.extend({
     return `${this.get('filename')}-${new Date().toISOString()}.${this.get('extension')}`;
   }),
 
-  href: computed('data', 'mime', 'stringify', function() {
+  fileLike: computed('data', 'mime', 'strigify', 'download', function() {
+    let file;
     let data = this.get('data');
-    const mime = this.get('mime');
+    let filename = this.get('download');
+    let mime = this.get('mime');
     if (this.get('stringify')) {
       data = JSON.stringify(data, null, 2);
     }
-
-    const file = new File([data], { type: mime });
-    return window.URL.createObjectURL(file);
+    if (window.navigator.msSaveOrOpenBlob) {
+      file = new Blob([data], { type: mime });
+      file.name = filename;
+    } else {
+      file = new File([data], filename, { type: mime });
+    }
+    return file;
   }),
+
+  href: computed('fileLike', function() {
+    return window.URL.createObjectURL(this.get('fileLike'));
+  }),
+
+  click(event) {
+    if (!window.navigator.msSaveOrOpenBlob) {
+      return;
+    }
+    event.preventDefault();
+    let file = this.get('fileLike');
+    //lol whyyyy
+    window.navigator.msSaveOrOpenBlob(file, file.name);
+  },
 
   actionText: 'Download',
   data: null,


### PR DESCRIPTION
IE11 / Edge both don't seem to have a `File` constructor, so this detects the MS-specific API for saving Blobs, and will use it instead of using the File constructor to add download links to the UI.

Before: it'd error out the rendering on the Show page leaving a blank textarea.

After: 
![screen shot 2018-04-16 at 9 54 38 pm](https://user-images.githubusercontent.com/39469/38846223-eb42a2fc-41c0-11e8-845e-d88c6be37fb4.png)

Manually tested in IE11 Win7 (Note: we need to get cross-browser testing set up and getting the UI tests up and running in CI in general).