### PR TITLE
Error message typo fix

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -606,7 +606,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 		// Force https as we'll always be TLS-secured
 		u, err := url.ParseRequestURI(coreConfig.ClusterAddr)
 		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error parsing cluster address %s: %v", coreConfig.RedirectAddr, err))
+			c.UI.Error(fmt.Sprintf("Error parsing cluster address %s: %v", coreConfig.ClusterAddr, err))
 			return 11
 		}
 		u.Scheme = "https"


### PR DESCRIPTION
While reading the code i have noticed there shold be `ClusterAddr` instead of `RedirectAddr`