### PR TITLE
use an array to lookup capabilities paths so that commas aren't an issue

### DIFF
--- a/ui/app/adapters/capabilities.js
+++ b/ui/app/adapters/capabilities.js
@@ -8,7 +8,7 @@ export default ApplicationAdapter.extend({
   },
 
   findRecord(store, type, id) {
-    return this.ajax(this.buildURL(type), 'POST', { data: { path: id } }).catch(e => {
+    return this.ajax(this.buildURL(type), 'POST', { data: { paths: [id] } }).catch(e => {
       if (e instanceof DS.AdapterError) {
         Ember.set(e, 'policyPath', 'sys/capabilities-self');
       }

--- a/ui/tests/acceptance/policies-acl-old-test.js
+++ b/ui/tests/acceptance/policies-acl-old-test.js
@@ -71,3 +71,20 @@ test('policies', function(assert) {
     );
   });
 });
+
+test('it properly fetches policies when the name ends in a ,', function(assert) {
+  const policyString = 'path "*" { capabilities = ["update"]}';
+  const policyName = `symbol,.`;
+
+  page.visit({ type: 'acl' });
+  // new policy creation
+  click('[data-test-policy-create-link]');
+  fillIn('[data-test-policy-input="name"]', policyName);
+  andThen(() => {
+    find('.CodeMirror').get(0).CodeMirror.setValue(policyString);
+  });
+  click('[data-test-policy-save]');
+  andThen(() => {
+    assert.equal(find('[data-test-policy-edit-toggle]').length, 1, 'shows the edit toggle');
+  });
+});

--- a/ui/tests/unit/adapters/capabilities-test.js
+++ b/ui/tests/unit/adapters/capabilities-test.js
@@ -16,6 +16,6 @@ test('calls the correct url', function(assert) {
 
   adapter.findRecord(null, 'capabilities', 'foo');
   assert.equal('/v1/sys/capabilities-self', url, 'calls the correct URL');
-  assert.deepEqual({ path: 'foo' }, options.data, 'data params OK');
+  assert.deepEqual({ paths: ['foo'] }, options.data, 'data params OK');
   assert.equal('POST', method, 'method OK');
 });


### PR DESCRIPTION
This issue here was that the vault server accepts comma-separated strings or an array for capabilities checks. When the path had a comma in it, the server assumed it was a comma-separated string and spit it causing the UI to error out. Now, the UI passes an array so all is right in the world ✨.

Fixes https://github.com/hashicorp/vault/issues/4395