### PR TITLE
VAULT_ADDR needs to be set to HTTP

### DIFF
--- a/website/source/docs/install/index.html.md
+++ b/website/source/docs/install/index.html.md
@@ -30,7 +30,11 @@ inside is all that is necessary to run Vault (or `vault.exe` for Windows). Any
 additional files, if any, aren't required to run Vault.
 
 Copy the binary to anywhere on your system. If you intend to access it from the
-command-line, make sure to place it somewhere on your `PATH`.
+command-line, make sure to place it somewhere on your `PATH`. Vault out of the 
+runs over SSL (API calls would be made over HTTPS). If you dont have an SSL cert
+installed on your local system please export the following environment variable.
+VAULT_ADDR=http://127.0.0.1:8200
+This will run Vault over HTTP.
 
 ## Compiling from Source
 


### PR DESCRIPTION
VAULT_ADDR variable needs to be set to "http" - for vault binary to start a server and then call APIs over http. 
export VAULT_ADDR=http://127.0.0.1:8200
If this variable is not set, then vault calls HTTPS API, and throws the following error,
Error checking seal status: Get https://127.0.0.1:8200/v1/sys/seal-status: http: server gave HTTP response to HTTPS client

I fixed it while trying out vault by exporting that env variable on my ubuntu box.