### PR TITLE
Correct typo in Kubernetes auth backend docs

### DIFF
--- a/website/source/docs/auth/kubernetes.html.md
+++ b/website/source/docs/auth/kubernetes.html.md
@@ -104,7 +104,7 @@ list of available configuration options, please see the API documentation.
 This auth method accesses the [Kubernetes TokenReview API][k8s-tokenreview] to
 validate the provided JWT is still valid. Kubernetes should be running with
 `--service-account-lookup`. This is defaulted to true in Kubernetes 1.7, but any
-versions prior should ensure the Kubernetes API server is started with with this
+versions prior should ensure the Kubernetes API server is started with this
 setting. Otherwise deleted tokens in Kubernetes will not be properly revoked and
 will be able to authenticate to this auth method.
 


### PR DESCRIPTION
Resolve small typo in [Configuring Kubernetes](https://github.com/hashicorp/vault/blob/04708d554cb082d9df0753e48d6ae824c5f25e97/website/source/docs/auth/kubernetes.html.md#configuring-kubernetes) section in [Kubernetes Auth Backend](https://github.com/hashicorp/vault/blob/04708d554cb082d9df0753e48d6ae824c5f25e97/website/source/docs/auth/kubernetes.html.md)
documentation.

Fixes #4417