### PR TITLE
Corrects description for mode option in ssh command

### DIFF
--- a/command/ssh.go
+++ b/command/ssh.go
@@ -94,7 +94,7 @@ func (c *SSHCommand) Flags() *FlagSets {
 		Default:    "",
 		EnvVar:     "",
 		Completion: complete.PredictSet("ca", "dynamic", "otp"),
-		Usage:      "Name of the role to use to generate the key.",
+		Usage:      "Name of the authentication mode (ca, dynamic, otp).",
 	})
 
 	f.StringVar(&StringVar{

--- a/website/source/docs/auth/kubernetes.html.md
+++ b/website/source/docs/auth/kubernetes.html.md
@@ -104,7 +104,7 @@ list of available configuration options, please see the API documentation.
 This auth method accesses the [Kubernetes TokenReview API][k8s-tokenreview] to
 validate the provided JWT is still valid. Kubernetes should be running with
 `--service-account-lookup`. This is defaulted to true in Kubernetes 1.7, but any
-versions prior should ensure the Kubernetes API server is started with with this
+versions prior should ensure the Kubernetes API server is started with this
 setting. Otherwise deleted tokens in Kubernetes will not be properly revoked and
 will be able to authenticate to this auth method.
 

--- a/website/source/docs/commands/ssh.html.md
+++ b/website/source/docs/commands/ssh.html.md
@@ -65,7 +65,7 @@ flags](/docs/commands/index.html) included on all commands.
 
 ### SSH Options
 
-- `-mode` `(string: "")` - Name of the role to use to generate the key.
+- `-mode` `(string: "")` - Name of the authentication mode (ca, dynamic, otp)."
 
 - `-mount-point` `(string: "ssh/")` - Mount point to the SSH secrets engine.
 


### PR DESCRIPTION
The description for `mode` option in `ssh` command and its documentation is same as description of `role` option. This commit changes it to right one.

Fixes #4375 