### PR TITLE
Corrects description for mode option in ssh command

### DIFF
--- a/command/ssh.go
+++ b/command/ssh.go
@@ -94,7 +94,7 @@ func (c *SSHCommand) Flags() *FlagSets {
 		Default:    "",
 		EnvVar:     "",
 		Completion: complete.PredictSet("ca", "dynamic", "otp"),
-		Usage:      "Name of the role to use to generate the key.",
+		Usage:      "Name of the authentication mode (ca, dynamic, otp).",
 	})
 
 	f.StringVar(&StringVar{

--- a/website/source/docs/commands/ssh.html.md
+++ b/website/source/docs/commands/ssh.html.md
@@ -65,7 +65,7 @@ flags](/docs/commands/index.html) included on all commands.
 
 ### SSH Options
 
-- `-mode` `(string: "")` - Name of the role to use to generate the key.
+- `-mode` `(string: "")` - Name of the authentication mode (ca, dynamic, otp)."
 
 - `-mount-point` `(string: "ssh/")` - Mount point to the SSH secrets engine.
 


### PR DESCRIPTION
The description for `mode` option in `ssh` command and its documentation is same as description of `role` option. This commit changes it to right one.

Fixes #4375 