### PR TITLE
Explicitly use 5.7 and below to test mysql backends

### DIFF
--- a/plugins/database/mysql/mysql_test.go
+++ b/plugins/database/mysql/mysql_test.go
@@ -15,7 +15,7 @@ import (
 	dockertest "gopkg.in/ory-am/dockertest.v3"
 )
 
-func prepareMySQLTestContainer(t *testing.T) (cleanup func(), retURL string) {
+func prepareMySQLTestContainer(t *testing.T, legacy bool) (cleanup func(), retURL string) {
 	if os.Getenv("MYSQL_URL") != "" {
 		return func() {}, os.Getenv("MYSQL_URL")
 	}
@@ -25,7 +25,12 @@ func prepareMySQLTestContainer(t *testing.T) (cleanup func(), retURL string) {
 		t.Fatalf("Failed to connect to docker: %s", err)
 	}
 
-	resource, err := pool.Run("mysql", "latest", []string{"MYSQL_ROOT_PASSWORD=secret"})
+	imageVersion := "5.7"
+	if legacy {
+		imageVersion = "5.6"
+	}
+
+	resource, err := pool.Run("mysql", imageVersion, []string{"MYSQL_ROOT_PASSWORD=secret"})
 	if err != nil {
 		t.Fatalf("Could not start local MySQL docker container: %s", err)
 	}
@@ -49,47 +54,7 @@ func prepareMySQLTestContainer(t *testing.T) (cleanup func(), retURL string) {
 		}
 		return db.Ping()
 	}); err != nil {
-		t.Fatalf("Could not connect to MySQL docker container: %s", err)
-	}
-
-	return
-}
-
-func prepareMySQLLegacyTestContainer(t *testing.T) (cleanup func(), retURL string) {
-	if os.Getenv("MYSQL_URL") != "" {
-		return func() {}, os.Getenv("MYSQL_URL")
-	}
-
-	pool, err := dockertest.NewPool("")
-	if err != nil {
-		t.Fatalf("Failed to connect to docker: %s", err)
-	}
-
-	// Mysql 5.6 is the last MySQL version to limit usernames to 16 characters.
-	resource, err := pool.Run("mysql", "5.6", []string{"MYSQL_ROOT_PASSWORD=secret"})
-	if err != nil {
-		t.Fatalf("Could not start local MySQL docker container: %s", err)
-	}
-
-	cleanup = func() {
-		err := pool.Purge(resource)
-		if err != nil {
-			t.Fatalf("Failed to cleanup local container: %s", err)
-		}
-	}
-
-	retURL = fmt.Sprintf("root:secret@(localhost:%s)/mysql?parseTime=true", resource.GetPort("3306/tcp"))
-
-	// exponential backoff-retry
-	if err = pool.Retry(func() error {
-		var err error
-		var db *sql.DB
-		db, err = sql.Open("mysql", retURL)
-		if err != nil {
-			return err
-		}
-		return db.Ping()
-	}); err != nil {
+		cleanup()
 		t.Fatalf("Could not connect to MySQL docker container: %s", err)
 	}
 
@@ -97,7 +62,7 @@ func prepareMySQLLegacyTestContainer(t *testing.T) (cleanup func(), retURL strin
 }
 
 func TestMySQL_Initialize(t *testing.T) {
-	cleanup, connURL := prepareMySQLTestContainer(t)
+	cleanup, connURL := prepareMySQLTestContainer(t, false)
 	defer cleanup()
 
 	connectionDetails := map[string]interface{}{
@@ -132,7 +97,7 @@ func TestMySQL_Initialize(t *testing.T) {
 }
 
 func TestMySQL_CreateUser(t *testing.T) {
-	cleanup, connURL := prepareMySQLTestContainer(t)
+	cleanup, connURL := prepareMySQLTestContainer(t, false)
 	defer cleanup()
 
 	connectionDetails := map[string]interface{}{
@@ -194,7 +159,7 @@ func TestMySQL_CreateUser(t *testing.T) {
 }
 
 func TestMySQL_CreateUser_Legacy(t *testing.T) {
-	cleanup, connURL := prepareMySQLLegacyTestContainer(t)
+	cleanup, connURL := prepareMySQLTestContainer(t, true)
 	defer cleanup()
 
 	connectionDetails := map[string]interface{}{
@@ -243,7 +208,7 @@ func TestMySQL_CreateUser_Legacy(t *testing.T) {
 }
 
 func TestMySQL_RotateRootCredentials(t *testing.T) {
-	cleanup, connURL := prepareMySQLTestContainer(t)
+	cleanup, connURL := prepareMySQLTestContainer(t, false)
 	defer cleanup()
 
 	connURL = strings.Replace(connURL, "root:secret", `{{username}}:{{password}}`, -1)
@@ -279,7 +244,7 @@ func TestMySQL_RotateRootCredentials(t *testing.T) {
 }
 
 func TestMySQL_RevokeUser(t *testing.T) {
-	cleanup, connURL := prepareMySQLTestContainer(t)
+	cleanup, connURL := prepareMySQLTestContainer(t, false)
 	defer cleanup()
 
 	connectionDetails := map[string]interface{}{


### PR DESCRIPTION
The mysql docker image recently defaulted the "latest" tag to 8.0 since it came out of GA. This had a breaking change in defaults for authentication behavior which the sql driver currently doesn't support unless some hacking/workaround work is done. Changing the tag to 5.7 seems to be the best option for now until the image or the driver is updated to properly support sane defaults. Also updated the legacy mysql tests to use dockertest.v3 since I initially thought that was the issue.
