### PR TITLE
Updated the link to the sample app folder which was moved

### DIFF
--- a/website/source/guides/encryption/transit-rewrap.html.md
+++ b/website/source/guides/encryption/transit-rewrap.html.md
@@ -113,7 +113,7 @@ application provided in this guide:
 - [Docker](https://docs.docker.com/install/)
 
 Download the sample application code from
-[vault-guides](https://github.com/hashicorp/vault-guides/tree/master/encryption/vault-transit-rewrap-example)
+[vault-guides](https://github.com/hashicorp/vault-guides/tree/master/encryption/vault-transit-rewrap)
 repository to perform the steps described in this guide.
 
 The `vault-transit-rewrap-example` contains the following:

--- a/website/source/guides/encryption/transit-rewrap.html.md
+++ b/website/source/guides/encryption/transit-rewrap.html.md
@@ -113,7 +113,7 @@ application provided in this guide:
 - [Docker](https://docs.docker.com/install/)
 
 Download the sample application code from
-[vault-guides](https://github.com/hashicorp/vault-guides/tree/master/secrets/transit/vault-transit-rewrap-example)
+[vault-guides](https://github.com/hashicorp/vault-guides/tree/master/encryption/vault-transit-rewrap-example)
 repository to perform the steps described in this guide.
 
 The `vault-transit-rewrap-example` contains the following:


### PR DESCRIPTION
The sample app folder location has been moved from `../secret/transit/vault-transit-rewrap-example` to `../encryption/vault-transit-rewrap-example`. 