### PR TITLE
Skip-fast on acceptance cases on non-acceptance tests

### DIFF
--- a/builtin/logical/mssql/backend_test.go
+++ b/builtin/logical/mssql/backend_test.go
@@ -103,6 +103,10 @@ func TestBackend_config_connection(t *testing.T) {
 }
 
 func TestBackend_basic(t *testing.T) {
+	if os.Getenv(logicaltest.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", logicaltest.TestEnvVar))
+	}
+
 	b, _ := Factory(context.Background(), logical.TestBackendConfig())
 
 	cleanup, connURL := prepareMSSQLTestContainer(t)
@@ -121,6 +125,10 @@ func TestBackend_basic(t *testing.T) {
 }
 
 func TestBackend_roleCrud(t *testing.T) {
+	if os.Getenv(logicaltest.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", logicaltest.TestEnvVar))
+	}
+
 	b := Backend()
 
 	cleanup, connURL := prepareMSSQLTestContainer(t)
@@ -141,6 +149,10 @@ func TestBackend_roleCrud(t *testing.T) {
 }
 
 func TestBackend_leaseWriteRead(t *testing.T) {
+	if os.Getenv(logicaltest.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", logicaltest.TestEnvVar))
+	}
+
 	b := Backend()
 
 	cleanup, connURL := prepareMSSQLTestContainer(t)

--- a/logical/testing/testing.go
+++ b/logical/testing/testing.go
@@ -128,6 +128,11 @@ func Test(tt TestT, c TestCase) {
 		c.PreCheck()
 	}
 
+	// Defer on the teardown, regardless of pass/fail at this point
+	if c.Teardown != nil {
+		defer c.Teardown()
+	}
+
 	// Check that something is provided
 	if c.Backend == nil && c.Factory == nil {
 		tt.Fatal("Must provide either Backend or Factory")
@@ -333,11 +338,6 @@ func Test(tt TestT, c TestCase) {
 					"still exist. Please verify:\n\n%#v",
 				s))
 		}
-	}
-
-	// Cleanup
-	if c.Teardown != nil {
-		c.Teardown()
 	}
 }
 


### PR DESCRIPTION
This PR adds an explicit check to skip acceptance test early on for mssql backend tests. It prevents containers from spinning up if we aren't running acceptance tests, which should quick should speed things up.

The `Teardown()` call in `logical/testing.Test` is also moved up so that the call is deferred, but invoked earlier.