### PR TITLE
Fix authentication example mentioning vault auth but using vault login

### DIFF
--- a/website/source/docs/concepts/auth.html.md
+++ b/website/source/docs/concepts/auth.html.md
@@ -66,7 +66,7 @@ revoking tokens, and renewing tokens. This is all covered on the
 
 ### Via the CLI
 
-To authenticate with the CLI, `vault auth` is used. This supports many
+To authenticate with the CLI, `vault login` is used. This supports many
 of the built-in auth methods. For example, with GitHub:
 
 ```


### PR DESCRIPTION
When reading the [basic concepts documentation around authentication](https://www.vaultproject.io/docs/concepts/auth.html#authenticating) I noticed that the example used `vault login`, but the description above it still mentioned using `vault auth`.

This PR updates the docs to use `vault login` for both.