### PR TITLE
Fix FOUT issue

### DIFF
--- a/website/source/assets/stylesheets/_global.scss
+++ b/website/source/assets/stylesheets/_global.scss
@@ -19,7 +19,7 @@ body {
 h1, h2, h3, h4, h5 {
   font-family: $font-family-klavika;
   -webkit-font-smoothing: antialiased;
-  
+
   code, tt {
     font-size: inherit !important;
   }
@@ -27,13 +27,4 @@ h1, h2, h3, h4, h5 {
 
 h1 {
   margin-bottom: 24px;
-}
-
-// Avoid FOUT
-.wf-loading {
-  visibility: hidden;
-}
-
-.wf-active, .wf-inactive {
-  visibility: visible;
 }


### PR DESCRIPTION
We recently switched typekit embed methods to directly adding a stylesheet rather than using the js snippet - this resolves an issue that causes a slightly flash of the content when the page loads uncached.