### PR TITLE
Add autocomplete for kv v2

### DIFF
--- a/command/delete.go
+++ b/command/delete.go
@@ -51,7 +51,7 @@ func (c *DeleteCommand) Flags() *FlagSets {
 }
 
 func (c *DeleteCommand) AutocompleteArgs() complete.Predictor {
-	return c.PredictVaultFiles()
+	return c.PredictVaultFiles(mountFilterExceptKV2())
 }
 
 func (c *DeleteCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_delete.go
+++ b/command/kv_delete.go
@@ -30,7 +30,7 @@ Usage: vault kv delete [options] PATH
   versioned data will not be fully removed, but marked as deleted and will no
   longer be returned in normal get requests.
 
-  To delete the latest version of the key "foo": 
+  To delete the latest version of the key "foo":
 
       $ vault kv delete secret/foo
 
@@ -63,7 +63,7 @@ func (c *KVDeleteCommand) Flags() *FlagSets {
 }
 
 func (c *KVDeleteCommand) AutocompleteArgs() complete.Predictor {
-	return c.PredictVaultFiles()
+	return c.PredictVaultFiles(mountFilterOnlyKV())
 }
 
 func (c *KVDeleteCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_destroy.go
+++ b/command/kv_destroy.go
@@ -55,7 +55,7 @@ func (c *KVDestroyCommand) Flags() *FlagSets {
 }
 
 func (c *KVDestroyCommand) AutocompleteArgs() complete.Predictor {
-	return nil
+	return c.PredictVaultFiles(mountFilterOnlyKV())
 }
 
 func (c *KVDestroyCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_enable_versioning.go
+++ b/command/kv_enable_versioning.go
@@ -41,7 +41,7 @@ func (c *KVEnableVersioningCommand) Flags() *FlagSets {
 }
 
 func (c *KVEnableVersioningCommand) AutocompleteArgs() complete.Predictor {
-	return nil
+	return c.PredictVaultMounts(mountFilterOnlyKV())
 }
 
 func (c *KVEnableVersioningCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -59,7 +59,7 @@ func (c *KVGetCommand) Flags() *FlagSets {
 }
 
 func (c *KVGetCommand) AutocompleteArgs() complete.Predictor {
-	return nil
+	return c.PredictVaultFiles(mountFilterOnlyKV())
 }
 
 func (c *KVGetCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_list.go
+++ b/command/kv_list.go
@@ -42,7 +42,7 @@ func (c *KVListCommand) Flags() *FlagSets {
 }
 
 func (c *KVListCommand) AutocompleteArgs() complete.Predictor {
-	return c.PredictVaultFolders()
+	return c.PredictVaultFolders(mountFilterOnlyKV())
 }
 
 func (c *KVListCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_metadata_delete.go
+++ b/command/kv_metadata_delete.go
@@ -23,7 +23,7 @@ func (c *KVMetadataDeleteCommand) Help() string {
 	helpText := `
 Usage: vault kv metadata delete [options] PATH
 
-  Deletes all versions and metadata for the provided key. 
+  Deletes all versions and metadata for the provided key.
 
       $ vault kv metadata delete secret/foo
 
@@ -39,7 +39,7 @@ func (c *KVMetadataDeleteCommand) Flags() *FlagSets {
 }
 
 func (c *KVMetadataDeleteCommand) AutocompleteArgs() complete.Predictor {
-	return c.PredictVaultFiles()
+	return c.PredictVaultFiles(mountFilterOnlyKV())
 }
 
 func (c *KVMetadataDeleteCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_metadata_get.go
+++ b/command/kv_metadata_get.go
@@ -43,7 +43,7 @@ func (c *KVMetadataGetCommand) Flags() *FlagSets {
 }
 
 func (c *KVMetadataGetCommand) AutocompleteArgs() complete.Predictor {
-	return nil
+	return c.PredictVaultFiles(mountFilterOnlyKV())
 }
 
 func (c *KVMetadataGetCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_metadata_put.go
+++ b/command/kv_metadata_put.go
@@ -30,16 +30,16 @@ Usage: vault metadata kv put [options] KEY [DATA]
 
   This command can be used to create a blank key in the key-value store or to
   update key configuration for a specified key.
-  
-  Create a key in the key-value store with no data: 
+
+  Create a key in the key-value store with no data:
 
       $ vault kv metadata put secret/foo
 
-  Set a max versions setting on the key: 
+  Set a max versions setting on the key:
 
       $ vault kv metadata put -max-versions=5 secret/foo
 
-  Require Check-and-Set for this key: 
+  Require Check-and-Set for this key:
 
       $ vault kv metadata put -require-cas secret/foo
 
@@ -73,7 +73,7 @@ func (c *KVMetadataPutCommand) Flags() *FlagSets {
 }
 
 func (c *KVMetadataPutCommand) AutocompleteArgs() complete.Predictor {
-	return nil
+	return c.PredictVaultFiles(mountFilterOnlyKV())
 }
 
 func (c *KVMetadataPutCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -56,7 +56,7 @@ func (c *KVPatchCommand) Flags() *FlagSets {
 }
 
 func (c *KVPatchCommand) AutocompleteArgs() complete.Predictor {
-	return nil
+	return c.PredictVaultFiles(mountFilterOnlyKV())
 }
 
 func (c *KVPatchCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -75,7 +75,7 @@ func (c *KVPutCommand) Flags() *FlagSets {
 }
 
 func (c *KVPutCommand) AutocompleteArgs() complete.Predictor {
-	return nil
+	return c.PredictVaultFiles(mountFilterOnlyKV())
 }
 
 func (c *KVPutCommand) AutocompleteFlags() complete.Flags {

--- a/command/kv_undelete.go
+++ b/command/kv_undelete.go
@@ -29,7 +29,7 @@ Usage: vault kv undelete [options] KEY
   This restores the data, allowing it to be returned on get requests.
 
   To undelete version 3 of key "foo":
-  
+
       $ vault kv undelete -versions=3 secret/foo
 
   Additional flags and more advanced use cases are detailed below.
@@ -55,7 +55,7 @@ func (c *KVUndeleteCommand) Flags() *FlagSets {
 }
 
 func (c *KVUndeleteCommand) AutocompleteArgs() complete.Predictor {
-	return nil
+	return c.PredictVaultFiles(mountFilterOnlyKV())
 }
 
 func (c *KVUndeleteCommand) AutocompleteFlags() complete.Flags {

--- a/command/list.go
+++ b/command/list.go
@@ -44,7 +44,7 @@ func (c *ListCommand) Flags() *FlagSets {
 }
 
 func (c *ListCommand) AutocompleteArgs() complete.Predictor {
-	return c.PredictVaultFolders()
+	return c.PredictVaultFolders(mountFilterExceptKV2())
 }
 
 func (c *ListCommand) AutocompleteFlags() complete.Flags {

--- a/command/read.go
+++ b/command/read.go
@@ -43,7 +43,7 @@ func (c *ReadCommand) Flags() *FlagSets {
 }
 
 func (c *ReadCommand) AutocompleteArgs() complete.Predictor {
-	return c.PredictVaultFiles()
+	return c.PredictVaultFiles(mountFilterExceptKV2())
 }
 
 func (c *ReadCommand) AutocompleteFlags() complete.Flags {

--- a/command/write.go
+++ b/command/write.go
@@ -81,9 +81,7 @@ func (c *WriteCommand) Flags() *FlagSets {
 }
 
 func (c *WriteCommand) AutocompleteArgs() complete.Predictor {
-	// Return an anything predictor here. Without a way to access help
-	// information, we don't know what paths we could write to.
-	return complete.PredictAnything
+	return c.PredictVaultFiles(mountFilterExceptKV2())
 }
 
 func (c *WriteCommand) AutocompleteFlags() complete.Flags {


### PR DESCRIPTION
This one was a bit tricky to implement because when I wrote the autocompleter I made the assumption that Vault would never have such a subcommand :).

The behavior is:

- `vault kv <cmd>` completes all mounts of _only_ type "kv" (v1 and v2)
- `vault <cmd>` completes all mounts _except_ type "kv" v2

This is technically a breaking change, but it doesn't make sense to complete kv2 paths for generic Vault commands since they will fail.