### PR TITLE
add script defer to the demo app tag as well

### DIFF
--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -125,5 +125,5 @@ description: |-
 
 
 <% content_for(:scripts) do %>
-  <%= javascript_include_tag "demo-app" %>
+  <%= javascript_include_tag "demo-app", defer: true %>
 <% end %>


### PR DESCRIPTION
Fixes #4487 

#4400 added `defer: true` to the application JS script tag, but not to the demo app tag, so demo-app would load first and throw an error about unknown jQuery. Adding `defer` to the demo app include fixes the issue.

