### PR TITLE
s/aws_region/region/

### DIFF
--- a/website/source/docs/enterprise/auto-unseal/index.html.md
+++ b/website/source/docs/enterprise/auto-unseal/index.html.md
@@ -21,7 +21,7 @@ specify the `seal` stanza in your Vault configuration file:
 
 ```hcl
 seal "awskms" {
-  aws_region = "us-east-1"
+  region = "us-east-1"
   access_key = "..."
   secret_key = "..."
   kms_key_id = "..."


### PR DESCRIPTION
The correct key name is 'region' as opposed to 'aws_region'.