### PR TITLE
Payload key should be dr_operation_token

### DIFF
--- a/website/source/api/system/replication-dr.html.md
+++ b/website/source/api/system/replication-dr.html.md
@@ -295,7 +295,7 @@ result in data loss!
 
 ```json
 {
-  "key": "ijH8tphEHaBtgx+IvPfxDsSi2LV4j9k+Lad6eqT5cJw="
+  "dr_operation_token": "ijH8tphEHaBtgx+IvPfxDsSi2LV4j9k+Lad6eqT5cJw="
 }
 ```
 


### PR DESCRIPTION
Using `key` results in error:

curl -X POST -d '{"key":"92724478-9137-fa48-13ae-1a77159e3c8b"}' -H "X-Vault-Token: root" $VAULT_ADDR/v1/sys/replication/dr/secondary/promote

{"errors":["DR operation token was not provided"]}