### PR TITLE
Fix typo in AppRole guide

### DIFF
--- a/website/source/guides/identity/approle-trusted-entities.html.md
+++ b/website/source/guides/identity/approle-trusted-entities.html.md
@@ -326,7 +326,7 @@ $ curl --silent \
        --location \
        --header "X-Vault-Token: $VAULT_TOKEN" \
        --request PUT \
-       --data @app-1-secret-read.hcl \
+       --data @app-1-secret-read.json \
        $VAULT_ADDR/v1/sys/policy/app-1-secret-read
 ```
 


### PR DESCRIPTION
Guide uses .hcl everywhere, so the other way is also possible