### PR TITLE
Changed DR docs page to fix generating secondary DR token

### DIFF
--- a/website/source/api/system/replication-dr.html.md
+++ b/website/source/api/system/replication-dr.html.md
@@ -151,12 +151,22 @@ identifier can later be used to revoke a DR secondary's access.
 - `ttl` `(string: "30m")` – Specifies the TTL for the secondary activation
   token.
 
+### Sample Payload
+
+```json
+{
+  "id": "us-east-1"
+}
+```
+
 ### Sample Request
 
 ```
 $ curl \
     --header "X-Vault-Token: ..." \
-    http://127.0.0.1:8200/v1/sys/replication/dr/primary/secondary-token?id=us-east-1
+    --request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/sys/replication/dr/primary/secondary-token
 ```
 
 ### Sample Response


### PR DESCRIPTION
The docs for how to create secondary DR tokens were incorrect, which caused issues at a customer. I fixed the documentation with the proper syntax and formatting, which I copied from the perf replication docs (after changing endpoints). Can someone take a quick look for me?