### PR TITLE
Update jq path for "excited" in JSON output example

### DIFF
--- a/website/source/intro/getting-started/first-secret.html.md
+++ b/website/source/intro/getting-started/first-secret.html.md
@@ -84,7 +84,7 @@ Optional JSON output is very useful for scripts. For example below we use the
 `jq` tool to extract the value of the `excited` secret:
 
 ```text
-$ vault kv get -format=json secret/hello | jq -r .data.excited
+$ vault kv get -format=json secret/hello | jq -r .data.data.excited
 yes
 ```
 


### PR DESCRIPTION
Current documentation specifies the path to the "excited" secret's contents as `.data.excited`. As I follow the tutorial I find that the full path is `.data.data.excited` (extra `.data`). I'm new to the `jq` tool, so perhaps this is something that changed there and requires an update to this documentation.