### PR TITLE
DynamoDB Deprecation Fixes

### DIFF
--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -703,8 +703,8 @@ func ensureTableExists(client *dynamodb.DynamoDB, table string, readCapacity, wr
 	_, err := client.DescribeTable(&dynamodb.DescribeTableInput{
 		TableName: aws.String(table),
 	})
-	if awserr, ok := err.(awserr.Error); ok {
-		if awserr.Code() == "ResourceNotFoundException" {
+	if awsError, ok := err.(awserr.Error); ok {
+		if awsError.Code() == "ResourceNotFoundException" {
 			_, err = client.CreateTable(&dynamodb.CreateTableInput{
 				TableName: aws.String(table),
 				ProvisionedThroughput: &dynamodb.ProvisionedThroughput{

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -259,7 +259,7 @@ func (d *DynamoDBBackend) Put(ctx context.Context, entry *physical.Entry) error 
 		Key:   recordKeyForVaultKey(entry.Key),
 		Value: entry.Value,
 	}
-	item, err := dynamodbattribute.ConvertToMap(record)
+	item, err := dynamodbattribute.MarshalMap(record)
 	if err != nil {
 		return errwrap.Wrapf("could not convert prefix record to DynamoDB item: {{err}}", err)
 	}
@@ -274,7 +274,7 @@ func (d *DynamoDBBackend) Put(ctx context.Context, entry *physical.Entry) error 
 			Path: recordPathForVaultKey(prefix),
 			Key:  fmt.Sprintf("%s/", recordKeyForVaultKey(prefix)),
 		}
-		item, err := dynamodbattribute.ConvertToMap(record)
+		item, err := dynamodbattribute.MarshalMap(record)
 		if err != nil {
 			return errwrap.Wrapf("could not convert prefix record to DynamoDB item: {{err}}", err)
 		}

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -311,7 +311,7 @@ func (d *DynamoDBBackend) Get(ctx context.Context, key string) (*physical.Entry,
 	}
 
 	record := &DynamoDBRecord{}
-	if err := dynamodbattribute.ConvertFromMap(resp.Item, record); err != nil {
+	if err := dynamodbattribute.UnmarshalMap(resp.Item, record); err != nil {
 		return nil, err
 	}
 
@@ -385,7 +385,7 @@ func (d *DynamoDBBackend) List(ctx context.Context, prefix string) ([]string, er
 	err := d.client.QueryPages(queryInput, func(out *dynamodb.QueryOutput, lastPage bool) bool {
 		var record DynamoDBRecord
 		for _, item := range out.Items {
-			dynamodbattribute.ConvertFromMap(item, &record)
+			dynamodbattribute.UnmarshalMap(item, &record)
 			if !strings.HasPrefix(record.Key, DynamoDBLockPrefix) {
 				keys = append(keys, record.Key)
 			}

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -217,7 +217,13 @@ func NewDynamoDBBackend(conf map[string]string, logger log.Logger) (physical.Bac
 			Transport: pooledTransport,
 		}).
 		WithMaxRetries(dynamodbMaxRetry)
-	client := dynamodb.New(session.New(awsConf))
+
+	awsSession, err := session.NewSession(awsConf)
+	if err != nil {
+		return nil, errwrap.Wrapf("Could not establish AWS session: {{err}}", err)
+	}
+
+	client := dynamodb.New(awsSession)
 
 	if err := ensureTableExists(client, table, readCapacity, writeCapacity); err != nil {
 		return nil, err

--- a/physical/dynamodb/dynamodb_test.go
+++ b/physical/dynamodb/dynamodb_test.go
@@ -33,11 +33,16 @@ func TestDynamoDBBackend(t *testing.T) {
 		region = "us-east-1"
 	}
 
-	conn := dynamodb.New(session.New(&aws.Config{
+	awsSession, err := session.NewSession(&aws.Config{
 		Credentials: credsProvider,
 		Endpoint:    aws.String(endpoint),
 		Region:      aws.String(region),
-	}))
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	conn := dynamodb.New(awsSession)
 
 	var randInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	table := fmt.Sprintf("vault-dynamodb-testacc-%d", randInt)
@@ -80,11 +85,16 @@ func TestDynamoDBHABackend(t *testing.T) {
 		region = "us-east-1"
 	}
 
-	conn := dynamodb.New(session.New(&aws.Config{
+	awsSession, err := session.NewSession(&aws.Config{
 		Credentials: credsProvider,
 		Endpoint:    aws.String(endpoint),
 		Region:      aws.String(region),
-	}))
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	conn := dynamodb.New(awsSession)
 
 	var randInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	table := fmt.Sprintf("vault-dynamodb-testacc-%d", randInt)


### PR DESCRIPTION
Howdy. While investigating some other issues with the DynamoDB backend (I'll open an issue or PR soon once things are more organized) I noticed that some of the methods being used have been deprecated in the AWS SDK, and a variable name was colliding with an imported package. 

This is a quick PR to address those issues.