### PR TITLE
Update jitter logic and add tests

### DIFF
--- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
+++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
@@ -204,7 +204,14 @@ func LinearJitterBackoff(min, max time.Duration, attemptNum int, resp *http.Resp
 	// Pick a random number that lies somewhere between the min and max and
 	// multiply by the attemptNum. attemptNum starts at zero so we always
 	// increment here.
-	return (min + time.Duration(int64(rand.Int63())%int64(max-min))) * time.Duration(attemptNum+1)
+	rawWait := (min + time.Duration(int64(rand.Int63())%int64(max-min))) * time.Duration(attemptNum+1)
+	if rawWait < min {
+		return min
+	}
+	if rawWait > max {
+		return max
+	}
+	return rawWait
 }
 
 // PassthroughErrorHandler is an ErrorHandler that directly passes through the

--- a/vendor/github.com/hashicorp/go-retryablehttp/client_test.go
+++ b/vendor/github.com/hashicorp/go-retryablehttp/client_test.go
@@ -1,0 +1,21 @@
+package retryablehttp
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestLinearJitterBackoff(t *testing.T) {
+	min := time.Duration(1000) * time.Second
+	max := time.Duration(2000) * time.Second
+	for i := 0; i < 20; i++ {
+		result := LinearJitterBackoff(min, max, i, nil).Seconds()
+		if result < min.Seconds() {
+			t.Fatal(fmt.Sprintf("result too low, got %f", result))
+		}
+		if result > max.Seconds() {
+			t.Fatal(fmt.Sprintf("result too high, got %f", result))
+		}
+	}
+}


### PR DESCRIPTION
Sample output:
```
1000
1149.442481565
1251.075917443
1376.790722445
1418.401247737
1516.758442941
1649.536682011
1726.061209069
1899.562988961
1889.904646638
1976.973755796
2000
2000
2000
2000
2000
2000
2000
2000
2000
```