### PR TITLE
Fix race

### DIFF
--- a/http/forwarded_for_test.go
+++ b/http/forwarded_for_test.go
@@ -44,7 +44,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		client := cluster.Cores[0].Client
 
 		req := client.NewRequest("GET", "/")
-		_, err = client.RawRequest(req)
+		_, err := client.RawRequest(req)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -128,7 +128,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		req := client.NewRequest("GET", "/")
 		req.Headers = make(http.Header)
 		req.Headers.Set("x-forwarded-for", "5.6.7.8")
-		_, err = client.RawRequest(req)
+		_, err := client.RawRequest(req)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -162,7 +162,7 @@ func TestHandler_XForwardedFor(t *testing.T) {
 		req := client.NewRequest("GET", "/")
 		req.Headers = make(http.Header)
 		req.Headers.Set("x-forwarded-for", "2.3.4.5,3.4.5.6")
-		_, err = client.RawRequest(req)
+		_, err := client.RawRequest(req)
 		if err == nil {
 			t.Fatal("expected error")
 		}


### PR DESCRIPTION
It turned out this test was failing sometimes due to a race because of the `err` being reused on multiple goroutines.