### PR TITLE
Enterprise version detection fix

### DIFF
--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -22,7 +22,8 @@ export default Ember.Route.extend(ModelBoundaryRoute, ClusterRoute, {
     const params = this.paramsFor(this.routeName);
     const id = this.getClusterId(params);
     if (id) {
-      return this.get('auth').setCluster(id);
+      this.get('auth').setCluster(id);
+      return this.get('version').fetchFeatures();
     } else {
       return Ember.RSVP.reject({ httpStatus: 404, message: 'not found', path: params.cluster_name });
     }
@@ -31,9 +32,7 @@ export default Ember.Route.extend(ModelBoundaryRoute, ClusterRoute, {
   model(params) {
     const id = this.getClusterId(params);
 
-    return this.get('version').fetchFeatures().then(() => {
       return this.get('store').findRecord('cluster', id);
-    });
   },
 
   stopPoll: Ember.on('deactivate', function() {

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -6,6 +6,7 @@ const POLL_INTERVAL_MS = 10000;
 const { inject } = Ember;
 
 export default Ember.Route.extend(ModelBoundaryRoute, ClusterRoute, {
+  version: inject.service(),
   store: inject.service(),
   auth: inject.service(),
   currentCluster: Ember.inject.service(),
@@ -29,7 +30,10 @@ export default Ember.Route.extend(ModelBoundaryRoute, ClusterRoute, {
 
   model(params) {
     const id = this.getClusterId(params);
-    return this.get('store').findRecord('cluster', id);
+
+    return this.get('version').fetchFeatures().then(() => {
+      return this.get('store').findRecord('cluster', id);
+    });
   },
 
   stopPoll: Ember.on('deactivate', function() {

--- a/ui/app/services/version.js
+++ b/ui/app/services/version.js
@@ -24,7 +24,7 @@ export default Service.extend({
 
   hasSentinel: hasFeature('Sentinel'),
 
-  isEnterprise: computed.match('version', /\+\w+$/),
+  isEnterprise: computed.match('version', /\+.+$/),
 
   isOSS: computed.not('isEnterprise'),
 

--- a/ui/app/styles/components/status-menu.scss
+++ b/ui/app/styles/components/status-menu.scss
@@ -91,9 +91,16 @@
     width: 100%;
     text-align: left;
 
+    .icon {
+      color: $menu-item-hover-background-color;
+    }
     &:hover {
       background-color: $menu-item-hover-background-color;
       color: $menu-item-hover-color;
+      .icon {
+        color: $menu-item-hover-color;
+      }
+
     }
 
     &.is-active {

--- a/ui/app/templates/partials/replication/replication-mode-summary-menu.hbs
+++ b/ui/app/templates/partials/replication/replication-mode-summary-menu.hbs
@@ -1,38 +1,40 @@
-<div class="level-left is-flex-1">
-  <div>
-    {{#if (or replicationUnsupported (and (eq mode 'performance') (not version.hasPerfReplication)))}}
-      <p>
-         Upgrade to Vault Enterprise Premium to use Performance Replication.
-      </p>
-    {{else if replicationEnabled}}
-      <span>
-        {{capitalize modeForUrl}}
-      </span>
-      {{#if secondaryId}}
+<div class="level is-mobile">
+  <div class="level-left is-flex-1">
+    <div>
+      {{#if (or replicationUnsupported (and (eq mode 'performance') (not version.hasPerfReplication)))}}
+        <p>
+           Upgrade to Vault Enterprise Premium to use Performance Replication.
+        </p>
+      {{else if replicationEnabled}}
+        <span>
+          {{capitalize modeForUrl}}
+        </span>
+        {{#if secondaryId}}
+          <span class="tag is-light">
+            <code>
+              {{secondaryId}}
+            </code>
+          </span>
+        {{/if}}
         <span class="tag is-light">
           <code>
-            {{secondaryId}}
+            {{clusterIdDisplay}}
           </code>
         </span>
+      {{else}}
+        Enable
       {{/if}}
-      <span class="tag is-light">
-        <code>
-          {{clusterIdDisplay}}
-        </code>
-      </span>
-    {{else}}
-      Enable
+    </div>
+  </div>
+  <div class="level-right">
+    {{#if replicationEnabled}}
+      {{#if (get cluster (concat mode 'StateGlyph'))}}
+        {{i-con size=14 glyph=(get cluster (concat mode 'StateGlyph'))}}
+      {{else if syncProgress}}
+        <progress value="{{syncProgressPercent}}" max="100" class="progress is-small is-narrow is-info">
+          {{syncProgress.progress}} of {{syncProgress.total}} keys
+        </progress>
+      {{/if}}
     {{/if}}
   </div>
-</div>
-<div class="level-right">
-  {{#if replicationEnabled}}
-    {{#if (get cluster (concat mode 'StateGlyph'))}}
-      {{i-con size=14 glyph=(get cluster (concat mode 'StateGlyph')) class="has-text-info" aria-label=(concat mode 'StateDisplay')}}
-    {{else if syncProgress}}
-      <progress value="{{syncProgressPercent}}" max="100" class="progress is-small is-narrow is-info">
-        {{syncProgress.progress}} of {{syncProgress.total}} keys
-      </progress>
-    {{/if}}
-  {{/if}}
 </div>

--- a/ui/tests/unit/services/version-test.js
+++ b/ui/tests/unit/services/version-test.js
@@ -16,6 +16,13 @@ test('setting version computes isEnterprise properly', function(assert) {
   assert.equal(service.get('isEnterprise'), true);
 });
 
+test('setting version with hsm ending computes isEnterprise properly', function(assert) {
+  let service = this.subject();
+  service.set('version', '0.9.5+prem.hsm');
+  assert.equal(service.get('isOSS'), false);
+  assert.equal(service.get('isEnterprise'), true);
+});
+
 test('hasPerfReplication', function(assert) {
   let service = this.subject();
   assert.equal(service.get('hasPerfReplication'), false);


### PR DESCRIPTION
There was a bug if you were running the HSM build of Enterprise where the UI would parse the version wrong and lock you out of all Enterprise features.

In addition there was a race condition with the replication menu so you'd only see the type of replication you had enabled in the menu and Performance would be an upsell link. Now we fetch features at the cluster route to ensure they're loaded before the application nav renders.

We also fixed a small layout bug in the replication menu.