### PR TITLE
vault token capabilities with multiple paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ IMPROVEMENTS:
  * core/seal (enterprise): Lazily rewrap data when seal keys are rotated
  * expiration: Allow revoke-prefix and revoke-force to work on single leases as
    well as prefixes [GH-4450]
+ * cli: Display all capabilities when running `vault token capabilities` with
+   multiple paths [GH-4554]
 
 BUG FIXES:
 

--- a/api/sys_capabilities.go
+++ b/api/sys_capabilities.go
@@ -2,11 +2,72 @@ package api
 
 import "fmt"
 
+// CapabilitiesSelf returns the capabilities of the client token against a given path
+// For compatibility, this is only valid when specifying a single path
 func (c *Sys) CapabilitiesSelf(path string) ([]string, error) {
 	return c.Capabilities(c.c.Token(), path)
 }
 
+// CapabilitiesSelfMultiple returns the capabilities of the client token against given paths
+func (c *Sys) CapabilitiesSelfMultiple(path string) (map[string][]string, error) {
+	return c.CapabilitiesMultiple(c.c.Token(), path)
+}
+
+// Capabilities returns the capabilities of a specified token against a given path
+// For compatibility, this is only valid when specifying a single path
 func (c *Sys) Capabilities(token, path string) ([]string, error) {
+
+	result, err := c.capabilitiesRequest(token, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if result["capabilities"] == nil {
+		return nil, nil
+	}
+
+	var capabilities []string
+	capabilitiesRaw, ok := result["capabilities"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("error interpreting returned capabilities")
+	}
+	for _, capability := range capabilitiesRaw {
+		capabilities = append(capabilities, capability.(string))
+	}
+	return capabilities, nil
+}
+
+// CapabilitiesMultiple returns the capabilities of a specified token against given paths
+func (c *Sys) CapabilitiesMultiple(token, path string) (map[string][]string, error) {
+
+	result, err := c.capabilitiesRequest(token, path)
+	if err != nil {
+		return nil, err
+	}
+
+	data, ok := result["data"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("error interpreting returned capabilities")
+	}
+
+	capabilities := make(map[string][]string)
+
+	for path, pathCapabilities := range data {
+		capabilities[path] = []string{}
+
+		pathCapabilitiesRaw := pathCapabilities.([]interface{})
+
+		for _, capability := range pathCapabilitiesRaw {
+			capabilities[path] = append(capabilities[path], capability.(string))
+		}
+	}
+
+	return capabilities, nil
+}
+
+// capabilitiesRequest handles the common functionality between Capabilities
+// and CapabilitiesMultiple
+func (c *Sys) capabilitiesRequest(token, path string) (map[string]interface{}, error) {
 	body := map[string]string{
 		"token": token,
 		"path":  path,
@@ -34,16 +95,5 @@ func (c *Sys) Capabilities(token, path string) ([]string, error) {
 		return nil, err
 	}
 
-	if result["capabilities"] == nil {
-		return nil, nil
-	}
-	var capabilities []string
-	capabilitiesRaw, ok := result["capabilities"].([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("error interpreting returned capabilities")
-	}
-	for _, capability := range capabilitiesRaw {
-		capabilities = append(capabilities, capability.(string))
-	}
-	return capabilities, nil
+	return result, nil
 }


### PR DESCRIPTION
Originally a fix for https://github.com/hashicorp/vault/issues/4552

With a single path, previous behaviour is preserved:

```
$ go run main.go token capabilities secret/foo
create, delete, list, read, update

$ go run main.go token capabilities -format=json secret/foo
[
  "create",
  "delete",
  "list",
  "read",
  "update"
]
```

With multiple paths:

```
$ go run main.go token capabilities secret/foo,secret/bar
Path           Capabilities
----           ------------
secret/foo     create, delete, list, read, update
secret/bar     create, delete, list, read, update

$ go run main.go token capabilities -format=json secret/foo,secret/bar
{
  "secret/bar": [
    "create",
    "delete",
    "list",
    "read",
    "update"
  ],
  "secret/foo": [
    "create",
    "delete",
    "list",
    "read",
    "update"
  ]
}
```

This corresponds to what we get when using the `sys/capabilities(-self)` endpoints directly

```
$ vault write sys/capabilities-self path=secret/foo
Key             Value
---             -----
capabilities    [create delete list read update]
secret/foo      [create delete list read update]

$ vault write sys/capabilities-self path=secret/foo,secret/bar
Key           Value
---           -----
secret/bar    [create delete list read update]
secret/foo    [create delete list read update]
```

For compatibility, the existing Sys Capabilities(Self) methods remain unchanged.