### PR TITLE
Restrict userpass logins & tokens by CIDR

### DIFF
--- a/builtin/credential/userpass/backend_test.go
+++ b/builtin/credential/userpass/backend_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"crypto/tls"
+
 	"github.com/hashicorp/vault/helper/policyutil"
 	"github.com/hashicorp/vault/logical"
 	logicaltest "github.com/hashicorp/vault/logical/testing"
@@ -225,36 +227,6 @@ func testUpdatePolicies(t *testing.T, user, policies string) logicaltest.TestSte
 	}
 }
 
-func testUsersWrite(t *testing.T, user string, data map[string]interface{}, expectError bool) logicaltest.TestStep {
-	return logicaltest.TestStep{
-		Operation: logical.UpdateOperation,
-		Path:      "users/" + user,
-		Data:      data,
-		ErrorOk:   true,
-		Check: func(resp *logical.Response) error {
-			if resp == nil && expectError {
-				return fmt.Errorf("expected error but received nil")
-			}
-			return nil
-		},
-	}
-}
-
-func testLoginWrite(t *testing.T, user string, data map[string]interface{}, expectError bool) logicaltest.TestStep {
-	return logicaltest.TestStep{
-		Operation: logical.UpdateOperation,
-		Path:      "login/" + user,
-		Data:      data,
-		ErrorOk:   true,
-		Check: func(resp *logical.Response) error {
-			if resp == nil && expectError {
-				return fmt.Errorf("expected error but received nil")
-			}
-			return nil
-		},
-	}
-}
-
 func testAccStepList(t *testing.T, users []string) logicaltest.TestStep {
 	return logicaltest.TestStep{
 		Operation: logical.ListOperation,
@@ -282,7 +254,8 @@ func testAccStepLogin(t *testing.T, user string, pass string, policies []string)
 		},
 		Unauthenticated: true,
 
-		Check: logicaltest.TestCheckAuth(policies),
+		Check:     logicaltest.TestCheckAuth(policies),
+		ConnState: &tls.ConnectionState{},
 	}
 }
 

--- a/builtin/credential/userpass/path_users.go
+++ b/builtin/credential/userpass/path_users.go
@@ -143,10 +143,10 @@ func (b *backend) pathUserRead(ctx context.Context, req *logical.Request, d *fra
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"policies":   user.Policies,
-			"ttl":        user.TTL.Seconds(),
-			"max_ttl":    user.MaxTTL.Seconds(),
-			"bound_cidr": user.BoundCIDRs,
+			"policies":    user.Policies,
+			"ttl":         user.TTL.Seconds(),
+			"max_ttl":     user.MaxTTL.Seconds(),
+			"bound_cidrs": user.BoundCIDRs,
 		},
 	}, nil
 }
@@ -186,11 +186,11 @@ func (b *backend) userCreateUpdate(ctx context.Context, req *logical.Request, d 
 		userEntry.MaxTTL = time.Duration(maxTTL.(int)) * time.Second
 	}
 
-	parsedCIDRs, err := parseutil.ParseAddrs(d.Get("bound_cidrs"))
+	boundCIDRs, err := parseutil.ParseAddrs(d.Get("bound_cidrs"))
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
-	userEntry.BoundCIDRs = parsedCIDRs
+	userEntry.BoundCIDRs = boundCIDRs
 
 	return nil, b.setUser(ctx, req.Storage, username, userEntry)
 }

--- a/vault/request_handling_test.go
+++ b/vault/request_handling_test.go
@@ -80,6 +80,7 @@ func TestRequestHandling_LoginWrapping(t *testing.T) {
 		Data: map[string]interface{}{
 			"type": "userpass",
 		},
+		Connection: &logical.Connection{},
 	}
 	resp, err := core.HandleRequest(req)
 	if err != nil {
@@ -108,6 +109,7 @@ func TestRequestHandling_LoginWrapping(t *testing.T) {
 		Data: map[string]interface{}{
 			"password": "foo",
 		},
+		Connection: &logical.Connection{},
 	}
 	resp, err = core.HandleRequest(req)
 	if err != nil {
@@ -129,6 +131,7 @@ func TestRequestHandling_LoginWrapping(t *testing.T) {
 		Data: map[string]interface{}{
 			"password": "foo",
 		},
+		Connection: &logical.Connection{},
 	}
 	resp, err = core.HandleRequest(req)
 	if err != nil {


### PR DESCRIPTION
Related issue: #1175 

This PR will add the ability to restrict a user's login by CIDR. It also strips two methods I happened across that weren't in use.

I still need to test this further IRL before I'm ready to submit this for review. Also need to update associated docs.