### PR TITLE
KV-V2 migration includes outdated docs

### DIFF
--- a/website/source/api/secret/kv/kv-v2.html.md
+++ b/website/source/api/secret/kv/kv-v2.html.md
@@ -110,7 +110,7 @@ have an ACL policy granting the `update` capability.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
-| `POST`   | `/secret/data/:path`         | `204 (empty body)`     |
+| `POST`   | `/secret/data/:path`         | `200 application/json` |
 
 ### Parameters
 


### PR DESCRIPTION
Creating/Updating a secret in KV-V2 produces a status code `200` with a response body of `application/json`, whereas the previous documentation notated a `204 (empty body)` expected response code.

I haven't been able to expand testing to other CRUD operations to validate the expected response code per the docs against the latest source, but as this is pivotal to some guides out there for new Vault users, I figure I'd save someone else a possible headache from the KV-V1/2 migration.