### PR TITLE
Check allowed/denied/required params on read calls.

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -334,7 +334,7 @@ CHECK:
 
 	// Only check parameter permissions for operations that can modify
 	// parameters.
-	if op == logical.UpdateOperation || op == logical.CreateOperation {
+	if op == logical.ReadOperation || op == logical.UpdateOperation || op == logical.CreateOperation {
 		for _, parameter := range permissions.RequiredParameters {
 			if _, ok := req.Data[strings.ToLower(parameter)]; !ok {
 				return


### PR DESCRIPTION
We added support a bit ago for some read operations to take in
parameters, so we should now apply these checks against them.