### PR TITLE
Rename Google Container Engine to Google Kubernetes Engine

### DIFF
--- a/website/source/docs/configuration/seal/gcpckms.html.md
+++ b/website/source/docs/configuration/seal/gcpckms.html.md
@@ -42,7 +42,7 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
 - `credentials` `(string: <required>)`: The path to the credentials JSON file
   to use. May be also specified by the `GOOGLE_CREDENTIALS` or
   `GOOGLE_APPLICATION_CREDENTIALS` environment variable or set automatically if
-  running under Google App Engine, Google Compute Engine or Google Container
+  running under Google App Engine, Google Compute Engine or Google Kubernetes
   Engine.
 
 - `project` `(string: <required>)`: The GCP project ID to use. May also be


### PR DESCRIPTION
Hi,

Google Cloud Renamed GKE (formerly known as Google Container Engine) to Google Kubernetes Engine (see https://cloudplatform.googleblog.com/2017/11/introducing-Certified-Kubernetes-and-Google-Kubernetes-Engine.html)

This fix the documentation accordingly