### PR TITLE
Docs: Clarify that revoking token revokes dynamic secrets

### DIFF
--- a/website/source/api/auth/token/index.html.md
+++ b/website/source/api/auth/token/index.html.md
@@ -428,7 +428,7 @@ $ curl \
 
 ## Revoke a Token
 
-Revokes a token and all child tokens. When the token is revoked, all secrets
+Revokes a token and all child tokens. When the token is revoked, all dynamic secrets
 generated with it are also revoked.
 
 | Method   | Path                         | Produces               |


### PR DESCRIPTION
This PR updates the API document for tokens. I have added a clarification that revoking a token revokes all *dynamic* secrets generated with it.

I used the same terminology as https://github.com/hashicorp/vault/pull/2066 which made this same update in the auth backend document.