### PR TITLE
Move LDAP field and parsing logic

### DIFF
--- a/builtin/credential/ldap/path_config.go
+++ b/builtin/credential/ldap/path_config.go
@@ -2,16 +2,9 @@ package ldap
 
 import (
 	"context"
-	"crypto/x509"
-	"encoding/pem"
-	"fmt"
-	"strings"
-	"text/template"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/consts"
 	"github.com/hashicorp/vault/helper/ldaputil"
-	"github.com/hashicorp/vault/helper/tlsutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -19,105 +12,7 @@ import (
 func pathConfig(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: `config`,
-		Fields: map[string]*framework.FieldSchema{
-			"url": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Default:     "ldap://127.0.0.1",
-				Description: "LDAP URL to connect to (default: ldap://127.0.0.1). Multiple URLs can be specified by concatenating them with commas; they will be tried in-order.",
-			},
-
-			"userdn": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Description: "LDAP domain to use for users (eg: ou=People,dc=example,dc=org)",
-			},
-
-			"binddn": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Description: "LDAP DN for searching for the user DN (optional)",
-			},
-
-			"bindpass": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Description: "LDAP password for searching for the user DN (optional)",
-			},
-
-			"groupdn": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Description: "LDAP search base to use for group membership search (eg: ou=Groups,dc=example,dc=org)",
-			},
-
-			"groupfilter": &framework.FieldSchema{
-				Type:    framework.TypeString,
-				Default: "(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))",
-				Description: `Go template for querying group membership of user (optional)
-The template can access the following context variables: UserDN, Username
-Example: (&(objectClass=group)(member:1.2.840.113556.1.4.1941:={{.UserDN}}))
-Default: (|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))`,
-			},
-
-			"groupattr": &framework.FieldSchema{
-				Type:    framework.TypeString,
-				Default: "cn",
-				Description: `LDAP attribute to follow on objects returned by <groupfilter>
-in order to enumerate user group membership.
-Examples: "cn" or "memberOf", etc.
-Default: cn`,
-			},
-
-			"upndomain": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Description: "Enables userPrincipalDomain login with [username]@UPNDomain (optional)",
-			},
-
-			"userattr": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Default:     "cn",
-				Description: "Attribute used for users (default: cn)",
-			},
-
-			"certificate": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Description: "CA certificate to use when verifying LDAP server certificate, must be x509 PEM encoded (optional)",
-			},
-
-			"discoverdn": &framework.FieldSchema{
-				Type:        framework.TypeBool,
-				Description: "Use anonymous bind to discover the bind DN of a user (optional)",
-			},
-
-			"insecure_tls": &framework.FieldSchema{
-				Type:        framework.TypeBool,
-				Description: "Skip LDAP server SSL Certificate verification - VERY insecure (optional)",
-			},
-
-			"starttls": &framework.FieldSchema{
-				Type:        framework.TypeBool,
-				Description: "Issue a StartTLS command after establishing unencrypted connection (optional)",
-			},
-
-			"tls_min_version": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Default:     "tls12",
-				Description: "Minimum TLS version to use. Accepted values are 'tls10', 'tls11' or 'tls12'. Defaults to 'tls12'",
-			},
-
-			"tls_max_version": &framework.FieldSchema{
-				Type:        framework.TypeString,
-				Default:     "tls12",
-				Description: "Maximum TLS version to use. Accepted values are 'tls10', 'tls11' or 'tls12'. Defaults to 'tls12'",
-			},
-
-			"deny_null_bind": &framework.FieldSchema{
-				Type:        framework.TypeBool,
-				Default:     true,
-				Description: "Denies an unauthenticated LDAP bind request if the user's password is empty; defaults to true",
-			},
-
-			"case_sensitive_names": &framework.FieldSchema{
-				Type:        framework.TypeBool,
-				Description: "If true, case sensitivity will be used when comparing usernames and groups for matching policies.",
-			},
-		},
+		Fields:  ldaputil.ConfigFields(),
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.ReadOperation:   b.pathConfigRead,
@@ -140,7 +35,7 @@ func (b *backend) Config(ctx context.Context, req *logical.Request) (*ldaputil.C
 	}
 
 	// Create a new ConfigEntry, filling in defaults where appropriate
-	result, err := b.newConfigEntry(fd)
+	result, err := ldaputil.NewConfigEntry(fd)
 	if err != nil {
 		return nil, err
 	}
@@ -195,147 +90,14 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, d *f
 	}
 
 	resp := &logical.Response{
-		Data: map[string]interface{}{
-			"url":                  cfg.Url,
-			"userdn":               cfg.UserDN,
-			"groupdn":              cfg.GroupDN,
-			"groupfilter":          cfg.GroupFilter,
-			"groupattr":            cfg.GroupAttr,
-			"upndomain":            cfg.UPNDomain,
-			"userattr":             cfg.UserAttr,
-			"certificate":          cfg.Certificate,
-			"insecure_tls":         cfg.InsecureTLS,
-			"starttls":             cfg.StartTLS,
-			"binddn":               cfg.BindDN,
-			"deny_null_bind":       cfg.DenyNullBind,
-			"discoverdn":           cfg.DiscoverDN,
-			"tls_min_version":      cfg.TLSMinVersion,
-			"tls_max_version":      cfg.TLSMaxVersion,
-			"case_sensitive_names": *cfg.CaseSensitiveNames,
-		},
+		Data: cfg.PasswordlessMap(),
 	}
 	return resp, nil
 }
 
-/*
- * Creates and initializes a ConfigEntry object with its default values,
- * as specified by the passed schema.
- */
-func (b *backend) newConfigEntry(d *framework.FieldData) (*ldaputil.ConfigEntry, error) {
-	cfg := new(ldaputil.ConfigEntry)
-
-	url := d.Get("url").(string)
-	if url != "" {
-		cfg.Url = strings.ToLower(url)
-	}
-	userattr := d.Get("userattr").(string)
-	if userattr != "" {
-		cfg.UserAttr = strings.ToLower(userattr)
-	}
-	userdn := d.Get("userdn").(string)
-	if userdn != "" {
-		cfg.UserDN = userdn
-	}
-	groupdn := d.Get("groupdn").(string)
-	if groupdn != "" {
-		cfg.GroupDN = groupdn
-	}
-	groupfilter := d.Get("groupfilter").(string)
-	if groupfilter != "" {
-		// Validate the template before proceeding
-		_, err := template.New("queryTemplate").Parse(groupfilter)
-		if err != nil {
-			return nil, errwrap.Wrapf("invalid groupfilter: {{err}}", err)
-		}
-
-		cfg.GroupFilter = groupfilter
-	}
-	groupattr := d.Get("groupattr").(string)
-	if groupattr != "" {
-		cfg.GroupAttr = groupattr
-	}
-	upndomain := d.Get("upndomain").(string)
-	if upndomain != "" {
-		cfg.UPNDomain = upndomain
-	}
-	certificate := d.Get("certificate").(string)
-	if certificate != "" {
-		block, _ := pem.Decode([]byte(certificate))
-
-		if block == nil || block.Type != "CERTIFICATE" {
-			return nil, fmt.Errorf("failed to decode PEM block in the certificate")
-		}
-		_, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return nil, errwrap.Wrapf("failed to parse certificate: {{err}}", err)
-		}
-		cfg.Certificate = certificate
-	}
-	insecureTLS := d.Get("insecure_tls").(bool)
-	if insecureTLS {
-		cfg.InsecureTLS = insecureTLS
-	}
-	cfg.TLSMinVersion = d.Get("tls_min_version").(string)
-	if cfg.TLSMinVersion == "" {
-		return nil, fmt.Errorf("failed to get 'tls_min_version' value")
-	}
-
-	var ok bool
-	_, ok = tlsutil.TLSLookup[cfg.TLSMinVersion]
-	if !ok {
-		return nil, fmt.Errorf("invalid 'tls_min_version'")
-	}
-
-	cfg.TLSMaxVersion = d.Get("tls_max_version").(string)
-	if cfg.TLSMaxVersion == "" {
-		return nil, fmt.Errorf("failed to get 'tls_max_version' value")
-	}
-
-	_, ok = tlsutil.TLSLookup[cfg.TLSMaxVersion]
-	if !ok {
-		return nil, fmt.Errorf("invalid 'tls_max_version'")
-	}
-	if cfg.TLSMaxVersion < cfg.TLSMinVersion {
-		return nil, fmt.Errorf("'tls_max_version' must be greater than or equal to 'tls_min_version'")
-	}
-
-	startTLS := d.Get("starttls").(bool)
-	if startTLS {
-		cfg.StartTLS = startTLS
-	}
-
-	bindDN := d.Get("binddn").(string)
-	if bindDN != "" {
-		cfg.BindDN = bindDN
-	}
-
-	bindPass := d.Get("bindpass").(string)
-	if bindPass != "" {
-		cfg.BindPassword = bindPass
-	}
-
-	denyNullBind := d.Get("deny_null_bind").(bool)
-	if denyNullBind {
-		cfg.DenyNullBind = denyNullBind
-	}
-
-	discoverDN := d.Get("discoverdn").(bool)
-	if discoverDN {
-		cfg.DiscoverDN = discoverDN
-	}
-
-	caseSensitiveNames, ok := d.GetOk("case_sensitive_names")
-	if ok {
-		cfg.CaseSensitiveNames = new(bool)
-		*cfg.CaseSensitiveNames = caseSensitiveNames.(bool)
-	}
-
-	return cfg, nil
-}
-
 func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	// Build a ConfigEntry struct out of the supplied FieldData
-	cfg, err := b.newConfigEntry(d)
+	cfg, err := ldaputil.NewConfigEntry(d)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}

--- a/helper/ldaputil/config.go
+++ b/helper/ldaputil/config.go
@@ -5,9 +5,234 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"strings"
+	"text/template"
 
 	"github.com/hashicorp/vault/helper/tlsutil"
+	"github.com/hashicorp/vault/logical/framework"
+
+	"github.com/hashicorp/errwrap"
 )
+
+// ConfigFields returns all the config fields that can potentially be used by the LDAP client.
+// Not all fields will be used by every integration.
+func ConfigFields() map[string]*framework.FieldSchema {
+	return map[string]*framework.FieldSchema{
+		"url": {
+			Type:        framework.TypeString,
+			Default:     "ldap://127.0.0.1",
+			Description: "LDAP URL to connect to (default: ldap://127.0.0.1). Multiple URLs can be specified by concatenating them with commas; they will be tried in-order.",
+		},
+
+		"userdn": {
+			Type:        framework.TypeString,
+			Description: "LDAP domain to use for users (eg: ou=People,dc=example,dc=org)",
+		},
+
+		"binddn": {
+			Type:        framework.TypeString,
+			Description: "LDAP DN for searching for the user DN (optional)",
+		},
+
+		"bindpass": {
+			Type:        framework.TypeString,
+			Description: "LDAP password for searching for the user DN (optional)",
+		},
+
+		"groupdn": {
+			Type:        framework.TypeString,
+			Description: "LDAP search base to use for group membership search (eg: ou=Groups,dc=example,dc=org)",
+		},
+
+		"groupfilter": {
+			Type:    framework.TypeString,
+			Default: "(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))",
+			Description: `Go template for querying group membership of user (optional)
+The template can access the following context variables: UserDN, Username
+Example: (&(objectClass=group)(member:1.2.840.113556.1.4.1941:={{.UserDN}}))
+Default: (|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))`,
+		},
+
+		"groupattr": {
+			Type:    framework.TypeString,
+			Default: "cn",
+			Description: `LDAP attribute to follow on objects returned by <groupfilter>
+in order to enumerate user group membership.
+Examples: "cn" or "memberOf", etc.
+Default: cn`,
+		},
+
+		"upndomain": {
+			Type:        framework.TypeString,
+			Description: "Enables userPrincipalDomain login with [username]@UPNDomain (optional)",
+		},
+
+		"userattr": {
+			Type:        framework.TypeString,
+			Default:     "cn",
+			Description: "Attribute used for users (default: cn)",
+		},
+
+		"certificate": {
+			Type:        framework.TypeString,
+			Description: "CA certificate to use when verifying LDAP server certificate, must be x509 PEM encoded (optional)",
+		},
+
+		"discoverdn": {
+			Type:        framework.TypeBool,
+			Description: "Use anonymous bind to discover the bind DN of a user (optional)",
+		},
+
+		"insecure_tls": {
+			Type:        framework.TypeBool,
+			Description: "Skip LDAP server SSL Certificate verification - VERY insecure (optional)",
+		},
+
+		"starttls": {
+			Type:        framework.TypeBool,
+			Description: "Issue a StartTLS command after establishing unencrypted connection (optional)",
+		},
+
+		"tls_min_version": {
+			Type:        framework.TypeString,
+			Default:     "tls12",
+			Description: "Minimum TLS version to use. Accepted values are 'tls10', 'tls11' or 'tls12'. Defaults to 'tls12'",
+		},
+
+		"tls_max_version": {
+			Type:        framework.TypeString,
+			Default:     "tls12",
+			Description: "Maximum TLS version to use. Accepted values are 'tls10', 'tls11' or 'tls12'. Defaults to 'tls12'",
+		},
+
+		"deny_null_bind": {
+			Type:        framework.TypeBool,
+			Default:     true,
+			Description: "Denies an unauthenticated LDAP bind request if the user's password is empty; defaults to true",
+		},
+
+		"case_sensitive_names": {
+			Type:        framework.TypeBool,
+			Description: "If true, case sensitivity will be used when comparing usernames and groups for matching policies.",
+		},
+	}
+}
+
+/*
+ * Creates and initializes a ConfigEntry object with its default values,
+ * as specified by the passed schema.
+ */
+func NewConfigEntry(d *framework.FieldData) (*ConfigEntry, error) {
+	cfg := new(ConfigEntry)
+
+	url := d.Get("url").(string)
+	if url != "" {
+		cfg.Url = strings.ToLower(url)
+	}
+	userattr := d.Get("userattr").(string)
+	if userattr != "" {
+		cfg.UserAttr = strings.ToLower(userattr)
+	}
+	userdn := d.Get("userdn").(string)
+	if userdn != "" {
+		cfg.UserDN = userdn
+	}
+	groupdn := d.Get("groupdn").(string)
+	if groupdn != "" {
+		cfg.GroupDN = groupdn
+	}
+	groupfilter := d.Get("groupfilter").(string)
+	if groupfilter != "" {
+		// Validate the template before proceeding
+		_, err := template.New("queryTemplate").Parse(groupfilter)
+		if err != nil {
+			return nil, errwrap.Wrapf("invalid groupfilter: {{err}}", err)
+		}
+
+		cfg.GroupFilter = groupfilter
+	}
+	groupattr := d.Get("groupattr").(string)
+	if groupattr != "" {
+		cfg.GroupAttr = groupattr
+	}
+	upndomain := d.Get("upndomain").(string)
+	if upndomain != "" {
+		cfg.UPNDomain = upndomain
+	}
+	certificate := d.Get("certificate").(string)
+	if certificate != "" {
+		block, _ := pem.Decode([]byte(certificate))
+
+		if block == nil || block.Type != "CERTIFICATE" {
+			return nil, fmt.Errorf("failed to decode PEM block in the certificate")
+		}
+		_, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, errwrap.Wrapf("failed to parse certificate: {{err}}", err)
+		}
+		cfg.Certificate = certificate
+	}
+	insecureTLS := d.Get("insecure_tls").(bool)
+	if insecureTLS {
+		cfg.InsecureTLS = insecureTLS
+	}
+	cfg.TLSMinVersion = d.Get("tls_min_version").(string)
+	if cfg.TLSMinVersion == "" {
+		return nil, fmt.Errorf("failed to get 'tls_min_version' value")
+	}
+
+	var ok bool
+	_, ok = tlsutil.TLSLookup[cfg.TLSMinVersion]
+	if !ok {
+		return nil, fmt.Errorf("invalid 'tls_min_version'")
+	}
+
+	cfg.TLSMaxVersion = d.Get("tls_max_version").(string)
+	if cfg.TLSMaxVersion == "" {
+		return nil, fmt.Errorf("failed to get 'tls_max_version' value")
+	}
+
+	_, ok = tlsutil.TLSLookup[cfg.TLSMaxVersion]
+	if !ok {
+		return nil, fmt.Errorf("invalid 'tls_max_version'")
+	}
+	if cfg.TLSMaxVersion < cfg.TLSMinVersion {
+		return nil, fmt.Errorf("'tls_max_version' must be greater than or equal to 'tls_min_version'")
+	}
+
+	startTLS := d.Get("starttls").(bool)
+	if startTLS {
+		cfg.StartTLS = startTLS
+	}
+
+	bindDN := d.Get("binddn").(string)
+	if bindDN != "" {
+		cfg.BindDN = bindDN
+	}
+
+	bindPass := d.Get("bindpass").(string)
+	if bindPass != "" {
+		cfg.BindPassword = bindPass
+	}
+
+	denyNullBind := d.Get("deny_null_bind").(bool)
+	if denyNullBind {
+		cfg.DenyNullBind = denyNullBind
+	}
+
+	discoverDN := d.Get("discoverdn").(bool)
+	if discoverDN {
+		cfg.DiscoverDN = discoverDN
+	}
+
+	caseSensitiveNames, ok := d.GetOk("case_sensitive_names")
+	if ok {
+		cfg.CaseSensitiveNames = new(bool)
+		*cfg.CaseSensitiveNames = caseSensitiveNames.(bool)
+	}
+
+	return cfg, nil
+}
 
 type ConfigEntry struct {
 	Url           string `json:"url"`
@@ -32,6 +257,33 @@ type ConfigEntry struct {
 	// To continue reading in users' previously stored values,
 	// we chose to carry that forward.
 	CaseSensitiveNames *bool `json:"CaseSensitiveNames,omitempty"`
+}
+
+func (c *ConfigEntry) Map() map[string]interface{} {
+	m := c.PasswordlessMap()
+	m["bindpass"] = c.BindPassword
+	return m
+}
+
+func (c *ConfigEntry) PasswordlessMap() map[string]interface{} {
+	return map[string]interface{}{
+		"url":                  c.Url,
+		"userdn":               c.UserDN,
+		"groupdn":              c.GroupDN,
+		"groupfilter":          c.GroupFilter,
+		"groupattr":            c.GroupAttr,
+		"upndomain":            c.UPNDomain,
+		"userattr":             c.UserAttr,
+		"certificate":          c.Certificate,
+		"insecure_tls":         c.InsecureTLS,
+		"starttls":             c.StartTLS,
+		"binddn":               c.BindDN,
+		"deny_null_bind":       c.DenyNullBind,
+		"discoverdn":           c.DiscoverDN,
+		"tls_min_version":      c.TLSMinVersion,
+		"tls_max_version":      c.TLSMaxVersion,
+		"case_sensitive_names": *c.CaseSensitiveNames,
+	}
 }
 
 func (c *ConfigEntry) Validate() error {


### PR DESCRIPTION
- Moves the schema field map into `ldaputil` so it can be reused
- Moves parsing the ldap config fields into `ldaputil` so it can be reused
- Creates a `Map` and `PasswordlessMap` method for reuse

**All logic is simply moved, none is edited.**