### PR TITLE
Fix possible nil pointer on mapping method

### DIFF
--- a/helper/ldaputil/config.go
+++ b/helper/ldaputil/config.go
@@ -266,24 +266,27 @@ func (c *ConfigEntry) Map() map[string]interface{} {
 }
 
 func (c *ConfigEntry) PasswordlessMap() map[string]interface{} {
-	return map[string]interface{}{
-		"url":                  c.Url,
-		"userdn":               c.UserDN,
-		"groupdn":              c.GroupDN,
-		"groupfilter":          c.GroupFilter,
-		"groupattr":            c.GroupAttr,
-		"upndomain":            c.UPNDomain,
-		"userattr":             c.UserAttr,
-		"certificate":          c.Certificate,
-		"insecure_tls":         c.InsecureTLS,
-		"starttls":             c.StartTLS,
-		"binddn":               c.BindDN,
-		"deny_null_bind":       c.DenyNullBind,
-		"discoverdn":           c.DiscoverDN,
-		"tls_min_version":      c.TLSMinVersion,
-		"tls_max_version":      c.TLSMaxVersion,
-		"case_sensitive_names": *c.CaseSensitiveNames,
+	m := map[string]interface{}{
+		"url":             c.Url,
+		"userdn":          c.UserDN,
+		"groupdn":         c.GroupDN,
+		"groupfilter":     c.GroupFilter,
+		"groupattr":       c.GroupAttr,
+		"upndomain":       c.UPNDomain,
+		"userattr":        c.UserAttr,
+		"certificate":     c.Certificate,
+		"insecure_tls":    c.InsecureTLS,
+		"starttls":        c.StartTLS,
+		"binddn":          c.BindDN,
+		"deny_null_bind":  c.DenyNullBind,
+		"discoverdn":      c.DiscoverDN,
+		"tls_min_version": c.TLSMinVersion,
+		"tls_max_version": c.TLSMaxVersion,
 	}
+	if c.CaseSensitiveNames != nil {
+		m["case_sensitive_names"] = *c.CaseSensitiveNames
+	}
+	return m
 }
 
 func (c *ConfigEntry) Validate() error {

--- a/helper/ldaputil/config.go
+++ b/helper/ldaputil/config.go
@@ -283,7 +283,7 @@ func (c *ConfigEntry) PasswordlessMap() map[string]interface{} {
 		"tls_min_version": c.TLSMinVersion,
 		"tls_max_version": c.TLSMaxVersion,
 	}
-	if c.CaseSensitiveNames != nil {
+	if *c.CaseSensitiveNames != nil {
 		m["case_sensitive_names"] = *c.CaseSensitiveNames
 	}
 	return m

--- a/helper/ldaputil/config.go
+++ b/helper/ldaputil/config.go
@@ -283,7 +283,7 @@ func (c *ConfigEntry) PasswordlessMap() map[string]interface{} {
 		"tls_min_version": c.TLSMinVersion,
 		"tls_max_version": c.TLSMaxVersion,
 	}
-	if *c.CaseSensitiveNames != nil {
+	if c.CaseSensitiveNames != nil {
 		m["case_sensitive_names"] = *c.CaseSensitiveNames
 	}
 	return m


### PR DESCRIPTION
If `c.CaseSensitiveNames` is nil to flag that it's unset, a panic will be caused on line 285 of the code shown in red. 

This PR eliminates the possible panic by only adding that field to the map if it's not nil.