### PR TITLE
fix issue where unwrapping a response with an auth block wouldn't work

### DIFF
--- a/ui/app/components/tool-actions-form.js
+++ b/ui/app/components/tool-actions-form.js
@@ -71,10 +71,11 @@ export default Ember.Component.extend(DEFAULTS, {
 
   handleSuccess(resp, action) {
     let props = {};
-    if (resp && resp.data && action === 'unwrap') {
-      props = Ember.assign({}, props, { unwrap_data: resp.data });
+    let secret = resp && resp.data || resp.auth;
+    if (secret && action === 'unwrap') {
+      props = Ember.assign({}, props, { unwrap_data: secret });
     }
-    props = Ember.assign({}, props, resp.data);
+    props = Ember.assign({}, props, secret);
 
     if (resp && resp.wrap_info) {
       const keyName = action === 'rewrap' ? 'rewrap_token' : 'token';


### PR DESCRIPTION
Previously if you tried to unwrap an auth response via the UI, it would make the API call, but fail to display the data. This fixes that 🎉

<img width="1356" alt="screen shot 2018-05-22 at 3 08 39 pm" src="https://user-images.githubusercontent.com/39469/40387404-48eef7ac-5dd2-11e8-94a4-7d398483fe8c.png">