### PR TITLE
UI - wrapping lookup path

### DIFF
--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -2,13 +2,14 @@
   background: linear-gradient(to right, #191A1C, #1B212D);
   height: 0;
   left: 0;
-  min-height: 400px;
   overflow: auto;
-  position: fixed;
+  position: absolute;
+  min-height: 0;
   right: 0;
   transform: translate3d(0, -400px, 0);
   transition: min-height $speed ease-out, transform $speed ease-in;
   will-change: transform, min-height;
+  -webkit-overflow-scrolling: touch;
   z-index: 199;
 }
 
@@ -69,7 +70,7 @@
     color: $white;
     flex: 1;
     font-family: $family-monospace;
-    font-size: $body-size;
+    font-size: 16px;
     font-weight: $font-weight-bold;
     margin-left: -$size-10;
     outline: none;
@@ -119,11 +120,13 @@
 .panel-open .console-ui-panel-scroller  {
   box-shadow: $box-shadow-highest;
   transform: translate3d(0, 0, 0);
+  min-height: 400px;
 }
 
 .panel-open .console-ui-panel-scroller.fullscreen  {
   bottom: 0;
   top: 0;
+  position: fixed;
   min-height: 100%;
 }
 
@@ -146,7 +149,6 @@
 header .navbar,
 header .navbar-sections {
   z-index: 200;
-  position: relative;
   transform: translate3d(0, 0, 0);
   will-change: transform;
 }

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -146,6 +146,7 @@
 header .navbar,
 header .navbar-sections {
   z-index: 200;
+  position: relative;
   transform: translate3d(0, 0, 0);
   will-change: transform;
 }

--- a/ui/app/styles/components/global-flash.scss
+++ b/ui/app/styles/components/global-flash.scss
@@ -1,14 +1,7 @@
 .global-flash {
   position: fixed;
-  @include until($desktop) {
-    position: -webkit-sticky;
-    position: sticky;
-    top: 0;
-    bottom: auto;
-    margin: 0 auto;
-    width: 95%;
-  }
-  width: 450px;
+  max-width: 450px;
+  width: 95%;
   bottom: 0;
   left: 0;
   margin: 10px;

--- a/ui/app/styles/core/tabs.scss
+++ b/ui/app/styles/core/tabs.scss
@@ -5,6 +5,7 @@
   padding: $size-10 $size-10;
 
   @include until($tablet) {
+    position:relative;
     background-color: $grey;
     flex: 0 0 100%;
     height: 3rem;

--- a/ui/app/templates/components/console/command-input.hbs
+++ b/ui/app/templates/components/console/command-input.hbs
@@ -1,5 +1,5 @@
 {{i-con glyph="chevron-right" size=12}}
-<input onkeyup={{action 'handleKeyUp'}} value={{value}} />
+<input onkeyup={{action 'handleKeyUp'}} value={{value}} autocomplete="off" spellcheck="false" />
 {{#tool-tip horizontalPosition="auto-right" verticalPosition=(if isFullscreen "above" "below") as |d|}}
   {{#d.trigger tagName="button" type="button" class=(concat "button is-compact" (if isFullscreen " active")) click=(action "fullscreen") data-test-tool-tip-trigger=true}}
     {{i-con glyph=(if isFullscreen "fullscreen-close" "fullscreen-open") aria-hidden="true" size=16}}

--- a/ui/app/templates/partials/tools/lookup.hbs
+++ b/ui/app/templates/partials/tools/lookup.hbs
@@ -10,6 +10,7 @@
 
 {{#if (or creation_time creation_ttl)}}
   <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
+    {{info-table-row label="Creation path" value=creation_path data-test-tools="token-lookup-row"}}
     {{info-table-row label="Creation time" value=creation_time data-test-tools="token-lookup-row"}}
     {{info-table-row label="Creation TTL" value=creation_ttl data-test-tools="token-lookup-row"}}
     {{#if expirationDate}}


### PR DESCRIPTION
Adds path to the wrapping lookup output: 
<img width="494" alt="screen shot 2018-05-26 at 8 59 39 pm" src="https://user-images.githubusercontent.com/39469/40635655-b6e3cc04-62c0-11e8-9064-07e3ba360f17.png">

Also fixes some layout weirdness with the new console and smaller viewports:

Before:
<img width="496" alt="screen shot 2018-05-26 at 8 59 24 pm" src="https://user-images.githubusercontent.com/39469/40635652-b6c1813a-62c0-11e8-8e9f-30610cb5c595.png">

After:
<img width="496" alt="screen shot 2018-05-26 at 8 59 33 pm" src="https://user-images.githubusercontent.com/39469/40635654-b6d575aa-62c0-11e8-882c-853736935aff.png">


And finally - makes it so all of the flash messages are position:fixed instead of the viewport changing we were doing before.