### PR TITLE
UI identity lists

### DIFF
--- a/ui/app/helpers/tabs-for-identity-show.js
+++ b/ui/app/helpers/tabs-for-identity-show.js
@@ -4,9 +4,9 @@ export const TABS = {
   entity: ['details', 'aliases', 'policies', 'groups', 'metadata'],
   'entity-alias': ['details', 'metadata'],
   //group will be used in the model hook of the route
-  group: ['details', 'aliases', 'policies', 'members', 'metadata'],
-  'group-internal': ['details', 'policies', 'members', 'metadata'],
-  'group-external': ['details', 'aliases', 'policies', 'members', 'metadata'],
+  group: ['details', 'aliases', 'policies', 'members', 'parent-groups', 'metadata'],
+  'group-internal': ['details', 'policies', 'members', 'parent-groups', 'metadata'],
+  'group-external': ['details', 'aliases', 'policies', 'members', 'parent-groups', 'metadata'],
   'group-alias': ['details'],
 };
 

--- a/ui/app/models/identity/group.js
+++ b/ui/app/models/identity/group.js
@@ -26,6 +26,12 @@ export default IdentityModel.extend({
   lastUpdateTime: attr('string', {
     readOnly: true,
   }),
+  numMemberEntities: attr('number', {
+    readOnly: true
+  }),
+  numParentGroups: attr('number', {
+    readOnly: true
+  }),
   metadata: attr('object', {
     editType: 'kv',
   }),
@@ -34,6 +40,10 @@ export default IdentityModel.extend({
   }),
   memberGroupIds: attr({
     label: 'Member Group IDs',
+    editType: 'stringArray',
+  }),
+  parentGroupIds: attr({
+    label: 'Parent Group IDs',
     editType: 'stringArray',
   }),
   memberEntityIds: attr({

--- a/ui/app/serializers/identity/_base.js
+++ b/ui/app/serializers/identity/_base.js
@@ -1,0 +1,26 @@
+import ApplicationSerializer from '../application';
+
+export default ApplicationSerializer.extend({
+  normalizeItems(payload) {
+    if (payload.data.keys && Array.isArray(payload.data.keys)) {
+      return payload.data.keys;
+    }
+    Ember.assign(payload, payload.data);
+    delete payload.data;
+    return payload;
+  },
+
+  extractLazyPaginatedData(payload) {
+    let list;
+    list = payload.data.keys.map(key => {
+      let model = payload.data.key_info[key];
+      model.id = key;
+      return model;
+    });
+    delete payload.data.key_info;
+    return list.sort((a,b) => {
+      return a.name.localeCompare(b.name);
+    });
+  },
+
+});

--- a/ui/app/serializers/identity/_base.js
+++ b/ui/app/serializers/identity/_base.js
@@ -1,4 +1,5 @@
 import ApplicationSerializer from '../application';
+import Ember from 'ember';
 
 export default ApplicationSerializer.extend({
   normalizeItems(payload) {

--- a/ui/app/serializers/identity/entity-alias.js
+++ b/ui/app/serializers/identity/entity-alias.js
@@ -1,0 +1,2 @@
+import IdentitySerializer from './_base';
+export default IdentitySerializer.extend();

--- a/ui/app/serializers/identity/entity.js
+++ b/ui/app/serializers/identity/entity.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
-import ApplicationSerializer from '../application';
+import IdentitySerializer from './_base';
 
-export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
+export default IdentitySerializer.extend(DS.EmbeddedRecordsMixin, {
   attrs: {
     aliases: { embedded: 'always' },
   },

--- a/ui/app/serializers/identity/group-alias.js
+++ b/ui/app/serializers/identity/group-alias.js
@@ -1,0 +1,2 @@
+import IdentitySerializer from './_base';
+export default IdentitySerializer.extend();

--- a/ui/app/serializers/identity/group.js
+++ b/ui/app/serializers/identity/group.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
-import ApplicationSerializer from '../application';
+import IdentitySerializer from './_base';
 
-export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
+export default IdentitySerializer.extend(DS.EmbeddedRecordsMixin, {
   attrs: {
     alias: { embedded: 'always' },
   },

--- a/ui/app/styles/components/sub-nav.scss
+++ b/ui/app/styles/components/sub-nav.scss
@@ -23,8 +23,8 @@
       color: $grey-dark;
       font-weight: $font-weight-semibold;
       text-decoration: none;
-      padding: $size-6 $size-8 $size-8;
-      margin: 0 $size-5;
+      padding: $size-6 0;
+      margin: 0 $size-4;
       border-bottom: 2px solid transparent;
       transition: border-color $speed;
 

--- a/ui/app/styles/components/sub-nav.scss
+++ b/ui/app/styles/components/sub-nav.scss
@@ -14,6 +14,9 @@
         border-color: $blue;
         color: $blue;
       }
+      &:first-child a {
+        margin-left: $size-5;
+      }
     }
 
     a {
@@ -21,6 +24,7 @@
       font-weight: $font-weight-semibold;
       text-decoration: none;
       padding: $size-6 $size-8 $size-8;
+      margin: 0 $size-5;
       border-bottom: 2px solid transparent;
       transition: border-color $speed;
 

--- a/ui/app/templates/components/identity/item-aliases.hbs
+++ b/ui/app/templates/components/identity/item-aliases.hbs
@@ -13,9 +13,14 @@
             glyph='role'
             size=14
             class="has-text-grey-light"
-            }}{{item.name}}</a>
-        <span class="tag">{{item.mountType}}</span>
-        <code class="has-text-grey is-size-8">{{item.mountAccessor}}</code>
+            }}<span class="has-text-weight-semibold">{{item.name}}</span></a>
+        <div class="has-text-grey">
+          {{item.id}}
+        </div>
+        <span class="tag"> {{item.mountType}} </span>
+        <span class="has-text-grey is-size-8">
+          {{item.mountAccessor}}
+        </span>
       </div>
       <div class="column has-text-right">
         {{identity/popup-alias params=(array item)}}

--- a/ui/app/templates/components/identity/item-parent-groups.hbs
+++ b/ui/app/templates/components/identity/item-parent-groups.hbs
@@ -1,0 +1,37 @@
+{{#if model.parentGroupIds.length}}
+  {{#each model.parentGroupIds as |gid|}}
+    {{#linked-block
+      "vault.cluster.access.identity.show"
+      "groups"
+      gid
+      details
+      class="box is-sideless is-marginless"
+    }}
+      <div class="columns is-mobile">
+        <div class="column is-10">
+          <a href={{href-to "vault.cluster.access.identity.show" "groups" gid "details" }}
+            class="is-block has-text-black has-text-weight-semibold"
+            >{{i-con
+              glyph='folder'
+              size=14
+              class="has-text-grey-light"
+              }}{{gid}}</a>
+        </div>
+        <div class="column has-text-right">
+        </div>
+      </div>
+    {{/linked-block}}
+  {{/each}}
+{{else}}
+  <div class="box is-bottomless has-background-white-bis">
+    <div class="columns is-centered">
+      <div class="column is-half has-text-centered">
+        <div class="box is-shadowless has-background-white-bis">
+          <p class="has-text-grey">
+            This group has no parent groups.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+{{/if}}

--- a/ui/app/templates/vault/cluster/access/identity/aliases/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/index.hbs
@@ -21,7 +21,14 @@
               glyph="role"
               size=14
               class="has-text-grey-light"
-            }}<span class="has-text-weight-semibold">{{item.id}}</span></a>
+            }}<span class="has-text-weight-semibold">{{item.name}}</span></a>
+          <div class="has-text-grey">
+            {{item.id}}
+          </div>
+          <span class="tag"> {{item.mountType}} </span> 
+          <span class="has-text-grey is-size-8">
+            {{item.mountAccessor}}
+          </span>
         </div>
         <div class="column has-text-right">
           {{identity/popup-alias params=(array item) onSuccess=(action "onDelete")}}

--- a/ui/app/templates/vault/cluster/access/identity/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/index.hbs
@@ -9,7 +9,7 @@
       data-test-identity-row=true
       }}
       <div class="columns is-mobile">
-        <div class="column is-10">
+        <div class="column is-7-tablet is-10-mobile">
           <a href={{href-to
             "vault.cluster.access.identity.show"
             item.id
@@ -21,7 +21,18 @@
               glyph="role"
               size=14
               class="has-text-grey-light"
-            }}<span class="has-text-weight-semibold">{{item.id}}</span></a>
+            }}<span class="has-text-weight-semibold">{{item.name}}</span></a>
+          <div class="has-text-grey is-size-8">
+            {{item.id}}
+          </div>
+        </div>
+        <div class="column is-3 is-hidden-mobile">
+          {{#if (eq item.identityType "entity")}}
+            {{#if item.aliases.length}}
+              {{pluralize item.aliases.length "alias"}}
+            {{/if}}
+          {{else}}
+          {{/if}}
         </div>
         <div class="column has-text-right">
           {{#popup-menu name="identity-item" onOpen=(action "reloadRecord" item)}}

--- a/ui/app/templates/vault/cluster/access/identity/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/show.hbs
@@ -35,7 +35,7 @@
       {{#each (tabs-for-identity-show model.identityType model.type) as |tab|}}
         {{#link-to "vault.cluster.access.identity.show" model.id tab tagName="li"}}
           <a href={{href-to "vault.cluster.access.identity.show" (pluralize model.identityType) model.id tab }}>
-            {{capitalize tab}}
+            {{capitalize (humanize tab)}}
           </a>
         {{/link-to}}
       {{/each}}

--- a/ui/tests/acceptance/access/identity/_shared-alias-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-alias-tests.js
@@ -38,11 +38,11 @@ export const testAliasCRUD = (name, itemType, assert) => {
   aliasIndexPage.visit({ item_type: itemType });
   andThen(() => {
     assert.equal(
-      aliasIndexPage.items.filterBy('id', aliasID).length,
+      aliasIndexPage.items.filterBy('name', name).length,
       1,
       `${itemType}: lists the entity in the entity list`
     );
-    aliasIndexPage.items.filterBy('id', aliasID)[0].menu();
+    aliasIndexPage.items.filterBy('name', name)[0].menu();
   });
   aliasIndexPage.delete().confirmDelete();
 

--- a/ui/tests/acceptance/access/identity/_shared-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-tests.js
@@ -3,12 +3,9 @@ import showPage from 'vault/tests/pages/access/identity/show';
 import indexPage from 'vault/tests/pages/access/identity/index';
 
 export const testCRUD = (name, itemType, assert) => {
-  let id;
   page.visit({ item_type: itemType });
   page.editForm.name(name).submit();
   andThen(() => {
-    let idRow = showPage.rows.filterBy('hasLabel').filterBy('rowLabel', 'ID')[0];
-    id = idRow.rowValue;
     assert.equal(
       currentRouteName(),
       'vault.cluster.access.identity.show',
@@ -26,16 +23,16 @@ export const testCRUD = (name, itemType, assert) => {
   indexPage.visit({ item_type: itemType });
   andThen(() => {
     assert.equal(
-      indexPage.items.filterBy('id', id).length,
+      indexPage.items.filterBy('name', name).length,
       1,
       `${itemType}: lists the entity in the entity list`
     );
-    indexPage.items.filterBy('id', id)[0].menu();
+    indexPage.items.filterBy('name', name)[0].menu();
   });
   indexPage.delete().confirmDelete();
 
   andThen(() => {
-    assert.equal(indexPage.items.filterBy('id', id).length, 0, `${itemType}: the row is deleted`);
+    assert.equal(indexPage.items.filterBy('name', name).length, 0, `${itemType}: the row is deleted`);
     indexPage.flashMessage.latestMessage.startsWith(
       'Successfully deleted',
       `${itemType}: shows flash message`
@@ -44,12 +41,8 @@ export const testCRUD = (name, itemType, assert) => {
 };
 
 export const testDeleteFromForm = (name, itemType, assert) => {
-  let id;
   page.visit({ item_type: itemType });
   page.editForm.name(name).submit();
-  andThen(() => {
-    id = showPage.rows.filterBy('hasLabel').filterBy('rowLabel', 'ID')[0].rowValue;
-  });
   showPage.edit();
   andThen(() => {
     assert.equal(
@@ -66,7 +59,7 @@ export const testDeleteFromForm = (name, itemType, assert) => {
       `${itemType}: navigates to list page on delete`
     );
     assert.equal(
-      indexPage.items.filterBy('id', id).length,
+      indexPage.items.filterBy('name', name).length,
       0,
       `${itemType}: the row does not show in the list`
     );

--- a/ui/tests/pages/access/identity/aliases/index.js
+++ b/ui/tests/pages/access/identity/aliases/index.js
@@ -6,7 +6,7 @@ export default create({
   flashMessage,
   items: collection('[data-test-identity-row]', {
     menu: clickable('[data-test-popup-menu-trigger]'),
-    id: text('[data-test-identity-link]'),
+    name: text('[data-test-identity-link]'),
   }),
   delete: clickable('[data-test-item-delete] [data-test-confirm-action-trigger]'),
   confirmDelete: clickable('[data-test-item-delete] [data-test-confirm-button]'),

--- a/ui/tests/pages/access/identity/index.js
+++ b/ui/tests/pages/access/identity/index.js
@@ -6,7 +6,7 @@ export default create({
   flashMessage,
   items: collection('[data-test-identity-row]', {
     menu: clickable('[data-test-popup-menu-trigger]'),
-    id: text('[data-test-identity-link]'),
+    name: text('[data-test-identity-link]'),
   }),
   delete: clickable('[data-test-item-delete] [data-test-confirm-action-trigger]'),
   confirmDelete: clickable('[data-test-item-delete] [data-test-confirm-button]'),


### PR DESCRIPTION
This uses the new `key_info` block on identity list endpoints to make the Identity UI (Access > Entities and Access > Groups) nicer to navigate and reason about. Groups now also show a "Parent Groups" tab that lists the groups a group is a member of.

![screen shot 2018-05-29 at 9 19 43 pm](https://user-images.githubusercontent.com/39469/40695423-d36844ba-6386-11e8-8e1f-f64b0a702a46.png)
![screen shot 2018-05-29 at 9 20 21 pm](https://user-images.githubusercontent.com/39469/40695424-d3776a62-6386-11e8-9a5e-fec878c1f9ad.png)
![screen shot 2018-05-29 at 9 20 29 pm](https://user-images.githubusercontent.com/39469/40695425-d384f0e2-6386-11e8-80be-6cd33f01a0d7.png)
![screen shot 2018-05-29 at 9 21 07 pm](https://user-images.githubusercontent.com/39469/40695426-d393c220-6386-11e8-9037-323d93a481ab.png)



Also makes a visual adjustment to the tabs subnav to be closer to the designs.