### PR TITLE
UI access sidebar

### DIFF
--- a/ui/app/components/token-expire-warning.js
+++ b/ui/app/components/token-expire-warning.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  classNames: 'token-expire-warning',
   auth: Ember.inject.service(),
 
   routing: Ember.inject.service('-routing'),

--- a/ui/app/styles/components/token-expire-warning.scss
+++ b/ui/app/styles/components/token-expire-warning.scss
@@ -1,0 +1,19 @@
+.token-expire-warning {
+  position: absolute;
+  z-index: 200;
+  display: flex;
+  justify-content: center;
+  box-shadow: $box-shadow-highest;
+  top: 1rem;
+  left: 1rem;
+  right: 1rem;
+}
+.token-expire-warning .content p {
+  padding-right: $size-6;
+}
+.token-expire-warning .message-in-page {
+  margin: 0;
+}
+.token-expire-warning .message {
+  width: 100%;
+}

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -65,6 +65,7 @@
 @import "./components/sidebar";
 @import "./components/status-menu";
 @import "./components/sub-nav";
+@import "./components/token-expire-warning";
 @import "./components/tool-tip";
 @import "./components/upgrade-overlay";
 @import "./components/vault-loading";

--- a/ui/app/templates/components/identity/item-aliases.hbs
+++ b/ui/app/templates/components/identity/item-aliases.hbs
@@ -17,7 +17,7 @@
         <div class="has-text-grey">
           {{item.id}}
         </div>
-        <span class="tag"> {{item.mountType}} </span>
+        <span class="tag">{{item.mountType}}</span>
         <span class="has-text-grey is-size-8">
           {{item.mountAccessor}}
         </span>

--- a/ui/app/templates/components/token-expire-warning.hbs
+++ b/ui/app/templates/components/token-expire-warning.hbs
@@ -3,7 +3,7 @@
     {{#message-in-page type="danger"}}
       <div class="content">
         <p>
-        Your auth token expired at {{moment-format auth.tokenExpirationDate 'YYYY-MM-DD HH:mm:ss'}}.
+        Your auth token expired on {{moment-format auth.tokenExpirationDate 'MMMM Do YYYY, h:mm:ss a'}}. You will need to re-authenticate.
         </p>
       </div>
       <button type="button" class="button" {{action "reauthenticate"}}>
@@ -14,9 +14,9 @@
     {{#message-in-page type="warning"}}
       <div class="content">
         <p>
-          We've determined you are inactive, and have stopped auto-renewing your current auth token.
-          Your token will expire in {{moment-from-now auth.tokenExpirationDate interval=1000 hideSuffix=true}} at
-          {{moment-format auth.tokenExpirationDate 'YYYY-MM-DD HH:mm:ss'}}
+          We've stopped auto-renewing your current auth token due to inactivity.
+          Your token will expire in {{moment-from-now auth.tokenExpirationDate interval=1000 hideSuffix=true}} on
+          {{moment-format auth.tokenExpirationDate 'MMMM Do YYYY, h:mm:ss a'}}
         </p>
         <button type="button" class="button" {{action "renewToken"}}>Resume auto-renewal</button>
       </div>

--- a/ui/app/templates/vault/cluster/access/error.hbs
+++ b/ui/app/templates/vault/cluster/access/error.hbs
@@ -1,0 +1,25 @@
+    {{#if (eq model.httpStatus 404)}}
+      {{not-found model=model}}
+    {{else}}
+      <header class="page-header">
+        <div class="level">
+          <div class="level-left">
+            <h1 class="title is-3 has-text-grey">
+              {{#if (eq model.httpStatus 403)}}
+                Not authorized
+              {{else}}
+                Error
+              {{/if}}
+            </h1>
+          </div>
+        </div>
+      </header>
+      <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered">
+        {{#if model.message}}
+          <p>{{model.message}}</p>
+        {{/if}}
+        {{#each model.errors as |error|}}
+          <p>{{error}}</p>
+        {{/each}}
+      </div>
+    {{/if}}

--- a/ui/app/templates/vault/cluster/access/identity/aliases/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/index.hbs
@@ -25,7 +25,7 @@
           <div class="has-text-grey">
             {{item.id}}
           </div>
-          <span class="tag"> {{item.mountType}} </span> 
+          <span class="tag">{{item.mountType}}</span>
           <span class="has-text-grey is-size-8">
             {{item.mountAccessor}}
           </span>

--- a/ui/app/templates/vault/cluster/access/identity/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/index.hbs
@@ -27,11 +27,8 @@
           </div>
         </div>
         <div class="column is-3 is-hidden-mobile">
-          {{#if (eq item.identityType "entity")}}
-            {{#if item.aliases.length}}
-              {{pluralize item.aliases.length "alias"}}
-            {{/if}}
-          {{else}}
+          {{#if item.aliases.length}}
+            {{pluralize item.aliases.length "alias"}}
           {{/if}}
         </div>
         <div class="column has-text-right">


### PR DESCRIPTION
Previously, a 403 on that auth list endpoint would render an error in the cluster template, meaning the sidebar for the Access section wouldn't show. Adding an error.hbs template in the /access folder means we'll now render the error in the access template and the sidebar will still be visible even in the case of an error.

![screen shot 2018-05-30 at 11 40 40 am](https://user-images.githubusercontent.com/39469/40734613-8bea641a-63fe-11e8-9a6b-201f2b0a8235.png)

While looking at this, we also took the opportunity to style the token expiry warning and tweak the message on it: 

![screen shot 2018-05-30 at 11 01 42 am](https://user-images.githubusercontent.com/39469/40734651-a730665c-63fe-11e8-9b8e-1b7c53459952.png)
![screen shot 2018-05-30 at 11 12 38 am](https://user-images.githubusercontent.com/39469/40734652-a73fe820-63fe-11e8-89e6-fd63d68aaec4.png)
