### PR TITLE
Enable `allow_token_displayname` configuration option for PKI backends

### DIFF
--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -73,6 +73,12 @@ This is a separate option as in some cases this can
 be considered a security threat.`,
 			},
 
+			"allow_token_displayname": &framework.FieldSchema{
+				Type: framework.TypeBool,
+				Description: `If set, clients can request certificates for
+a CN matching the display name of the requesting token.`,
+			},
+
 			"allow_subdomains": &framework.FieldSchema{
 				Type: framework.TypeBool,
 				Description: `If set, clients can request certificates for
@@ -437,6 +443,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		AllowLocalhost:                data.Get("allow_localhost").(bool),
 		AllowedDomains:                data.Get("allowed_domains").([]string),
 		AllowBareDomains:              data.Get("allow_bare_domains").(bool),
+		AllowTokenDisplayName:         data.Get("allow_token_displayname").(bool),
 		AllowSubdomains:               data.Get("allow_subdomains").(bool),
 		AllowGlobDomains:              data.Get("allow_glob_domains").(bool),
 		AllowAnyName:                  data.Get("allow_any_name").(bool),


### PR DESCRIPTION
The logic for this configuration option was already in place, but it was not being handled during role creation. This simple change will allow the use of this option; to verify, execute the following:

  1. Build the binary and start a dev server
```
make
./bin/vault server --dev
```
  2. Enable the PKI backend and configure the CA and a test role
```
export VAULT_ADDR=http://localhost:8200
./bin/vault secrets enable pki
./bin/vault write pki/config/ca pem_bundle=@/path/to/bundle
./bin/vault write pki/roles/test allow_token_displayname=true
```
  3. You can now generate a certificate using a common name matching the display name of the token (in this case, it's `root`)
```
$ ./bin/vault write pki/issue/test common_name=any
Error writing data to pki/issue/test: Error making API request.

URL: PUT http://localhost:8200/v1/pki/issue/test
Code: 400. Errors:

* common name any not allowed by this role

$ ./bin/vault write pki/issue/test common_name=root
Key                 Value
---                 -----
certificate          -----BEGIN CERTIFICATE-----
```