### PR TITLE
UI - don't re-throw error when fetching features

### DIFF
--- a/ui/app/services/version.js
+++ b/ui/app/services/version.js
@@ -57,7 +57,7 @@ export default Service.extend({
       this.setFeatures(response);
       return;
     } catch (err) {
-      throw err;
+      // if we fail here, we're likely in DR Secondary mode and don't need to worry about it
     }
   }).keepLatest(),
 

--- a/ui/tests/acceptance/enterprise-replication-test.js
+++ b/ui/tests/acceptance/enterprise-replication-test.js
@@ -103,12 +103,11 @@ test('replication', function(assert) {
       `/vault/replication/performance/secondaries`,
       'redirects to the secondaries page'
     );
-    assert
-      .dom('[data-test-flash-message-body]:contains(The performance mount filter)')
-      .hasText(
-        `The performance mount filter config for the secondary ${secondaryName} was successfully deleted.`,
-        'renders success flash upon deletion'
-      );
+    assert.equal(
+      find('[data-test-flash-message-body]:contains(The performance mount filter)').text().trim(),
+      `The performance mount filter config for the secondary ${secondaryName} was successfully deleted.`,
+      'renders success flash upon deletion'
+    );
     click('[data-test-flash-message-body]:contains(The performance mount filter)');
   });
 


### PR DESCRIPTION
When in DR Secondary mode, the features fetch will 400 - this previously wasn't a problem, but we moved the fetch higher in the route structure (https://github.com/hashicorp/vault/pull/4547) in order to fix a race condition so now we fetch on the DR Secondary route as well. 

For now I think there's no harm in just ignoring the error so that this mode can be used.