### PR TITLE
Use hostname instead of the IP when running the actual ssh command with vault ssh

### DIFF
--- a/command/ssh.go
+++ b/command/ssh.go
@@ -331,7 +331,7 @@ func (c *SSHCommand) Run(args []string) int {
 	case ssh.KeyTypeCA:
 		return c.handleTypeCA(username, hostname, ip, sshArgs)
 	case ssh.KeyTypeOTP:
-		return c.handleTypeOTP(username, ip, sshArgs)
+		return c.handleTypeOTP(username, hostname, ip, sshArgs)
 	case ssh.KeyTypeDynamic:
 		return c.handleTypeDynamic(username, ip, sshArgs)
 	default:
@@ -482,7 +482,7 @@ func (c *SSHCommand) handleTypeCA(username, hostname, ip string, sshArgs []strin
 }
 
 // handleTypeOTP is used to handle SSH logins using the "otp" key type.
-func (c *SSHCommand) handleTypeOTP(username, ip string, sshArgs []string) int {
+func (c *SSHCommand) handleTypeOTP(username, hostname string, ip string, sshArgs []string) int {
 	secret, cred, err := c.generateCredential(username, ip)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("failed to generate credential: %s", err))
@@ -515,7 +515,7 @@ func (c *SSHCommand) handleTypeOTP(username, ip string, sshArgs []string) int {
 			"-o UserKnownHostsFile=" + c.flagUserKnownHostsFile,
 			"-o StrictHostKeyChecking=" + c.flagStrictHostKeyChecking,
 			"-p", cred.Port,
-			username + "@" + ip,
+			username + "@" + hostname,
 		}, sshArgs...)
 		cmd = exec.Command("ssh", args...)
 	} else {
@@ -525,7 +525,7 @@ func (c *SSHCommand) handleTypeOTP(username, ip string, sshArgs []string) int {
 			"-o UserKnownHostsFile=" + c.flagUserKnownHostsFile,
 			"-o StrictHostKeyChecking=" + c.flagStrictHostKeyChecking,
 			"-p", cred.Port,
-			username + "@" + ip,
+			username + "@" + hostname,
 		}, sshArgs...)
 		cmd = exec.Command(sshpassPath, args...)
 		env := os.Environ()


### PR DESCRIPTION
This is implementing the same fix that was added for the CA mode for vault
ssh in https://github.com/hashicorp/vault/pull/3922
Using the IP address caused `Host` entries in the ssh_config to not match anymore meaning you would need to hardcode all of your IP addresses in your ssh config instead of using DNS to connect to hosts. 

I was originally going to open an issue for this to discuss if it made sense to connect using the hostname instead of IP however I found that this issue already existed and was resolved for the CA backend in https://github.com/hashicorp/vault/issues/3920 so I decided to just go ahead and commit the code already since this seems to be the way forward. 