### PR TITLE
Added URI Subject Alternative Names to secrets/pki

### DIFF
--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -34,13 +34,13 @@ pkcs8 instead. Defaults to "der".`,
 	}
 
 	fields["ip_sans"] = &framework.FieldSchema{
-		Type: framework.TypeString,
+		Type: framework.TypeCommaStringSlice,
 		Description: `The requested IP SANs, if any, in a
 comma-delimited list`,
 	}
 
 	fields["uri_sans"] = &framework.FieldSchema{
-		Type: framework.TypeString,
+		Type: framework.TypeCommaStringSlice,
 		Description: `The requested URI SANs, if any, in a
 comma-delimited list.`,
 	}

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -42,7 +42,7 @@ comma-delimited list`,
 	fields["uri_sans"] = &framework.FieldSchema{
 		Type: framework.TypeString,
 		Description: `The requested URI SANs, if any, in a
-comma-delimited list`,
+comma-delimited list.`,
 	}
 
 	fields["other_sans"] = &framework.FieldSchema{

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -39,6 +39,12 @@ pkcs8 instead. Defaults to "der".`,
 comma-delimited list`,
 	}
 
+	fields["uri_sans"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `The requested URI SANs, if any, in a
+comma-delimited list`,
+	}
+
 	fields["other_sans"] = &framework.FieldSchema{
 		Type: framework.TypeCommaStringSlice,
 		Description: `Requested other SANs, in an array with the format

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -109,6 +109,13 @@ CN and SANs. Defaults to true.`,
 Any valid IP is accepted.`,
 			},
 
+			"allow_uri_sans": &framework.FieldSchema{
+				Type:    framework.TypeBool,
+				Default: true,
+				Description: `If set, URI Subject Alternative Names are allowed.
+Any valid URI is accepted.`,
+			},
+
 			"allowed_other_sans": &framework.FieldSchema{
 				Type:        framework.TypeCommaStringSlice,
 				Description: `If set, an array of allowed other names to put in SANs. These values support globbing.`,
@@ -452,6 +459,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		AllowAnyName:                  data.Get("allow_any_name").(bool),
 		EnforceHostnames:              data.Get("enforce_hostnames").(bool),
 		AllowIPSANs:                   data.Get("allow_ip_sans").(bool),
+		AllowURISANs:                  data.Get("allow_uri_sans").(bool),
 		ServerFlag:                    data.Get("server_flag").(bool),
 		ClientFlag:                    data.Get("client_flag").(bool),
 		CodeSigningFlag:               data.Get("code_signing_flag").(bool),
@@ -584,6 +592,7 @@ type roleEntry struct {
 	AllowAnyName                  bool          `json:"allow_any_name" mapstructure:"allow_any_name"`
 	EnforceHostnames              bool          `json:"enforce_hostnames" mapstructure:"enforce_hostnames"`
 	AllowIPSANs                   bool          `json:"allow_ip_sans" mapstructure:"allow_ip_sans"`
+	AllowURISANs                  bool          `json:"allow_uri_sans" mapstructure:"allow_uri_sans"`
 	ServerFlag                    bool          `json:"server_flag" mapstructure:"server_flag"`
 	ClientFlag                    bool          `json:"client_flag" mapstructure:"client_flag"`
 	CodeSigningFlag               bool          `json:"code_signing_flag" mapstructure:"code_signing_flag"`
@@ -630,6 +639,7 @@ func (r *roleEntry) ToResponseData() map[string]interface{} {
 		"allow_any_name":                     r.AllowAnyName,
 		"enforce_hostnames":                  r.EnforceHostnames,
 		"allow_ip_sans":                      r.AllowIPSANs,
+		"allow_uri_sans":                     r.AllowURISANs,
 		"server_flag":                        r.ServerFlag,
 		"client_flag":                        r.ClientFlag,
 		"code_signing_flag":                  r.CodeSigningFlag,

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -109,11 +109,10 @@ CN and SANs. Defaults to true.`,
 Any valid IP is accepted.`,
 			},
 
-			"allow_uri_sans": &framework.FieldSchema{
-				Type:    framework.TypeBool,
-				Default: true,
-				Description: `If set, URI Subject Alternative Names are allowed.
-Any valid URI is accepted.`,
+			"allowed_uri_sans": &framework.FieldSchema{
+				Type: framework.TypeCommaStringSlice,
+				Description: `If set, an array of allowed URIs to put in the URI Subject Alternative Names.
+Any valid URI is accepted, these values support globbing.`,
 			},
 
 			"allowed_other_sans": &framework.FieldSchema{
@@ -459,7 +458,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		AllowAnyName:                  data.Get("allow_any_name").(bool),
 		EnforceHostnames:              data.Get("enforce_hostnames").(bool),
 		AllowIPSANs:                   data.Get("allow_ip_sans").(bool),
-		AllowURISANs:                  data.Get("allow_uri_sans").(bool),
+		AllowedURISANs:                data.Get("allowed_uri_sans").([]string),
 		ServerFlag:                    data.Get("server_flag").(bool),
 		ClientFlag:                    data.Get("client_flag").(bool),
 		CodeSigningFlag:               data.Get("code_signing_flag").(bool),
@@ -592,7 +591,6 @@ type roleEntry struct {
 	AllowAnyName                  bool          `json:"allow_any_name" mapstructure:"allow_any_name"`
 	EnforceHostnames              bool          `json:"enforce_hostnames" mapstructure:"enforce_hostnames"`
 	AllowIPSANs                   bool          `json:"allow_ip_sans" mapstructure:"allow_ip_sans"`
-	AllowURISANs                  bool          `json:"allow_uri_sans" mapstructure:"allow_uri_sans"`
 	ServerFlag                    bool          `json:"server_flag" mapstructure:"server_flag"`
 	ClientFlag                    bool          `json:"client_flag" mapstructure:"client_flag"`
 	CodeSigningFlag               bool          `json:"code_signing_flag" mapstructure:"code_signing_flag"`
@@ -618,6 +616,7 @@ type roleEntry struct {
 	RequireCN                     bool          `json:"require_cn" mapstructure:"require_cn"`
 	AllowedOtherSANs              []string      `json:"allowed_other_sans" mapstructure:"allowed_other_sans"`
 	AllowedSerialNumbers          []string      `json:"allowed_serial_numbers" mapstructure:"allowed_serial_numbers"`
+	AllowedURISANs                []string      `json:"allowed_uri_sans" mapstructure:"allowed_uri_sans"`
 	PolicyIdentifiers             []string      `json:"policy_identifiers" mapstructure:"policy_identifiers"`
 	ExtKeyUsageOIDs               []string      `json:"ext_key_usage_oids" mapstructure:"ext_key_usage_oids"`
 	BasicConstraintsValidForNonCA bool          `json:"basic_constraints_valid_for_non_ca" mapstructure:"basic_constraints_valid_for_non_ca"`
@@ -639,7 +638,6 @@ func (r *roleEntry) ToResponseData() map[string]interface{} {
 		"allow_any_name":                     r.AllowAnyName,
 		"enforce_hostnames":                  r.EnforceHostnames,
 		"allow_ip_sans":                      r.AllowIPSANs,
-		"allow_uri_sans":                     r.AllowURISANs,
 		"server_flag":                        r.ServerFlag,
 		"client_flag":                        r.ClientFlag,
 		"code_signing_flag":                  r.CodeSigningFlag,
@@ -660,6 +658,7 @@ func (r *roleEntry) ToResponseData() map[string]interface{} {
 		"no_store":                           r.NoStore,
 		"allowed_other_sans":                 r.AllowedOtherSANs,
 		"allowed_serial_numbers":             r.AllowedSerialNumbers,
+		"allowed_uri_sans":                   r.AllowedURISANs,
 		"require_cn":                         r.RequireCN,
 		"policy_identifiers":                 r.PolicyIdentifiers,
 		"basic_constraints_valid_for_non_ca": r.BasicConstraintsValidForNonCA,

--- a/builtin/logical/pki/path_roles_test.go
+++ b/builtin/logical/pki/path_roles_test.go
@@ -426,6 +426,40 @@ func TestPki_RoleAllowedDomains(t *testing.T) {
 	}
 }
 
+func TestPki_RoleAllowedURISANs(t *testing.T) {
+	var resp *logical.Response
+	var err error
+	b, storage := createBackendWithStorage(t)
+
+	roleData := map[string]interface{}{
+		"allowed_uri_sans": []string{"http://foobar.com", "spiffe://*"},
+		"ttl":              "5h",
+	}
+
+	roleReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "roles/testrole",
+		Storage:   storage,
+		Data:      roleData,
+	}
+
+	resp, err = b.HandleRequest(context.Background(), roleReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: err: %v resp: %#v", err, resp)
+	}
+
+	roleReq.Operation = logical.ReadOperation
+	resp, err = b.HandleRequest(context.Background(), roleReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: err: %v resp: %#v", err, resp)
+	}
+
+	allowedURISANs := resp.Data["allowed_uri_sans"].([]string)
+	if len(allowedURISANs) != 2 {
+		t.Fatalf("allowed_uri_sans should have 2 values")
+	}
+}
+
 func TestPki_RolePkixFields(t *testing.T) {
 	var resp *logical.Response
 	var err error

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -768,9 +768,11 @@ request is denied.
   Alternative Names. No authorization checking is performed except to verify
   that the given values are valid IP addresses.
 
-- `allow_uri_sans` `(bool: true)` - Specifies if clients can request URI Subject
+- `allowed_uri_sans` `(string: "")` - Defines allowed URI Subject
   Alternative Names. No authorization checking is performed except to verify
-  that the given values are valid URIs.
+  that the given values are valid URIs. This can be a comma-delimited list or
+  a JSON string slice. Values can contain glob patterns (e.g. 
+  `spiffe://hostname/*`).
 
 - `allowed_other_sans` `(string: "")` – Defines allowed custom OID/UTF8-string
   SANs. This field supports globbing. The format is the same as OpenSSL:

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -920,10 +920,10 @@ $ curl \
   "data": {
     "allow_any_name": false,
     "allow_ip_sans": true,
-    "allow_uri_sans": true,
     "allow_localhost": true,
     "allow_subdomains": false,
     "allowed_domains": ["example.com", "foobar.com"],
+    "allow_uri_sans": ["example.com","spiffe://*"],
     "client_flag": true,
     "code_signing_flag": false,
     "key_bits": 2048,
@@ -1385,8 +1385,8 @@ root CA need be in a client's trust store.
   is the default).
 
 - `uri_sans` `(string: "")` – Specifies the requested URI Subject Alternative
-  Names, in a comma-delimited list. Only valid if the role allows URI SANs (which
-  is the default).
+  Names, in a comma-delimited list. If any requested URIs do not match role policy, 
+  the entire request will be denied.
 
 - `ttl` `(string: "")` – Specifies the requested Time To Live. Cannot be greater
   than the role's `max_ttl` value. If not provided, the role's `ttl` value will

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -435,6 +435,9 @@ can be set in a CSR are supported.
 - `ip_sans` `(string: "")` – Specifies the requested IP Subject Alternative
   Names, in a comma-delimited list.
 
+- `uri_sans` `(string: "")` – Specifies the requested URI Subject Alternative
+  Names, in a comma-delimited list.
+
 - `other_sans` `(string: "")` – Specifies custom OID/UTF8-string SANs. These
   must match values specified on the role in `allowed_other_sans` (globbing
   allowed). The format is the same as OpenSSL: `<oid>;<type>:<value>` where the
@@ -588,6 +591,9 @@ need to request a new certificate.**
 - `ip_sans` `(string: "")` – Specifies requested IP Subject Alternative Names,
   in a comma-delimited list. Only valid if the role allows IP SANs (which is the
   default).
+
+- `uri_sans` `(string: "")` – Specifies the requested URI Subject Alternative
+  Names, in a comma-delimited list.
 
 - `other_sans` `(string: "")` – Specifies custom OID/UTF8-string SANs. These
   must match values specified on the role in `allowed_other_sans` (globbing
@@ -762,6 +768,10 @@ request is denied.
   Alternative Names. No authorization checking is performed except to verify
   that the given values are valid IP addresses.
 
+- `allow_uri_sans` `(bool: true)` - Specifies if clients can request URI Subject
+  Alternative Names. No authorization checking is performed except to verify
+  that the given values are valid URIs.
+
 - `allowed_other_sans` `(string: "")` – Defines allowed custom OID/UTF8-string
   SANs. This field supports globbing. The format is the same as OpenSSL:
   `<oid>;<type>:<value>` where the only current valid type is `UTF8`. This can
@@ -908,6 +918,7 @@ $ curl \
   "data": {
     "allow_any_name": false,
     "allow_ip_sans": true,
+    "allow_uri_sans": true,
     "allow_localhost": true,
     "allow_subdomains": false,
     "allowed_domains": ["example.com", "foobar.com"],
@@ -1012,6 +1023,9 @@ existing cert/key with new values.
   they will be parsed into their respective fields.
 
 - `ip_sans` `(string: "")` – Specifies the requested IP Subject Alternative
+  Names, in a comma-delimited list.
+
+- `uri_sans` `(string: "")` – Specifies the requested URI Subject Alternative
   Names, in a comma-delimited list.
 
 - `other_sans` `(string: "")` – Specifies custom OID/UTF8-string SANs. These
@@ -1164,6 +1178,9 @@ verbatim.
   they will be parsed into their respective fields.
 
 - `ip_sans` `(string: "")` – Specifies the requested IP Subject Alternative
+  Names, in a comma-delimited list.
+
+- `uri_sans` `(string: "")` – Specifies the requested URI Subject Alternative
   Names, in a comma-delimited list.
 
 - `other_sans` `(string: "")` – Specifies custom OID/UTF8-string SANs. These
@@ -1363,6 +1380,10 @@ root CA need be in a client's trust store.
 
 - `ip_sans` `(string: "")` – Specifies the requested IP Subject Alternative
   Names, in a comma-delimited list. Only valid if the role allows IP SANs (which
+  is the default).
+
+- `uri_sans` `(string: "")` – Specifies the requested URI Subject Alternative
+  Names, in a comma-delimited list. Only valid if the role allows URI SANs (which
   is the default).
 
 - `ttl` `(string: "")` – Specifies the requested Time To Live. Cannot be greater


### PR DESCRIPTION
Added new parameter `uri_sans` when generating x.509 certificates  
Added new parameter `allow_uri_sans` to role
Updated documentation

@jefferai I am not sure which test to modify to validate this change (have tested manually for now), `ip_sans` testing seems to be in the OID test however I think I should probably create a separate test for this?

In addition to this, should I also modify the UI to add the new parameter?