### PR TITLE
UI - console refresh

### DIFF
--- a/ui/app/components/console/command-input.js
+++ b/ui/app/components/console/command-input.js
@@ -11,9 +11,6 @@ export default Ember.Component.extend({
   value: null,
   isFullscreen: null,
 
-  didRender() {
-    this.element.scrollIntoView();
-  },
   actions: {
     handleKeyUp(event) {
       const keyCode = event.keyCode;

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -19,6 +19,20 @@ export default Ember.Component.extend({
   inputValue: null,
   log: computed.alias('console.log'),
 
+  didReceiveAttrs() {
+    let val = this.get('inputValue');
+    let oldVal = this.get('oldInputValue');
+    this.set('valChanged', val !== oldVal);
+    this.set('oldInputValue', val);
+  },
+
+  didRender() {
+    if (this.get('valChanged')) {
+      // make sure we're scrolled to the bottom;
+     this.scrollToBottom();
+    }
+  },
+
   logAndOutput(command, logContent) {
     this.set('inputValue', '');
     this.get('console').logAndOutput(command, logContent);
@@ -84,6 +98,10 @@ export default Ember.Component.extend({
     this.get('console').shiftCommandIndex(keyCode, val => {
       this.set('inputValue', val);
     });
+  },
+
+  scrollToBottom() {
+    this.element.scrollTop = this.element.scrollHeight;
   },
 
   actions: {

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -30,7 +30,7 @@ export default Ember.Component.extend({
   didRender() {
     if (this.get('valChanged')) {
       // make sure we're scrolled to the bottom;
-     this.scrollToBottom();
+      this.scrollToBottom();
     }
   },
 
@@ -78,7 +78,6 @@ export default Ember.Component.extend({
       this.logAndOutput(command, inputError);
       return;
     }
-    let serviceFn = service[method];
     this.get('runner').perform(
       () => service[method].call(service, path, data, flags.wrapTTL),
       resp => this.logAndOutput(command, logFromResponse(resp, path, method, flags)),
@@ -93,8 +92,12 @@ export default Ember.Component.extend({
 
     this.get('runner').perform(
       () => route.refresh(),
-      () => this.logAndOutput(null, {type: 'success', content: 'The current screen has been refreshed!'}),
-      () => this.logAndOutput(null, {type: 'error', content: 'The was a problem refreshing the current screen.'}),
+      () => this.logAndOutput(null, { type: 'success', content: 'The current screen has been refreshed!' }),
+      () =>
+        this.logAndOutput(null, {
+          type: 'error',
+          content: 'The was a problem refreshing the current screen.',
+        })
     );
   },
 

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -9,7 +9,7 @@ import {
   executeUICommand,
 } from 'vault/lib/console-helpers';
 
-const { inject, computed, getOwner } = Ember;
+const { inject, computed, getOwner, run } = Ember;
 
 export default Ember.Component.extend({
   classNames: 'console-ui-panel-scroller',
@@ -36,6 +36,7 @@ export default Ember.Component.extend({
 
   logAndOutput(command, logContent) {
     this.get('console').logAndOutput(command, logContent);
+    run.next(()=> this.scrollToBottom());
   },
 
   executeCommand(command, shouldThrow = false) {

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -21,6 +21,7 @@ export default Ember.Component.extend({
   log: computed.alias('console.log'),
 
   didRender() {
+    this._super(...arguments);
     this.scrollToBottom();
   },
 

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -8,13 +8,14 @@ import {
   executeUICommand,
 } from 'vault/lib/console-helpers';
 
-const { inject, computed } = Ember;
+const { inject, computed, getOwner } = Ember;
 
 export default Ember.Component.extend({
   classNames: 'console-ui-panel-scroller',
   classNameBindings: ['isFullscreen:fullscreen'],
   isFullscreen: false,
   console: inject.service(),
+  router: inject.service(),
   inputValue: null,
   log: computed.alias('console.log'),
 
@@ -32,7 +33,8 @@ export default Ember.Component.extend({
         command,
         args => this.logAndOutput(args),
         args => service.clearLog(args),
-        () => this.toggleProperty('isFullscreen')
+        () => this.toggleProperty('isFullscreen'),
+        () => this.refreshRoute()
       )
     ) {
       return;
@@ -70,6 +72,12 @@ export default Ember.Component.extend({
       .catch(error => {
         this.logAndOutput(command, logFromError(error, path, method));
       });
+  },
+
+  refreshRoute() {
+    let owner = getOwner(this);
+    let routeName = this.get('router.currentRouteName');
+    owner.lookup(`route:${routeName}`).refresh();
   },
 
   shiftCommandIndex(keyCode) {

--- a/ui/app/lib/console-helpers.js
+++ b/ui/app/lib/console-helpers.js
@@ -2,7 +2,7 @@ import keys from 'vault/lib/keycodes';
 import argTokenizer from 'yargs-parser-tokenizer';
 
 const supportedCommands = ['read', 'write', 'list', 'delete'];
-const uiCommands = ['clearall', 'clear', 'fullscreen'];
+const uiCommands = ['clearall', 'clear', 'fullscreen', 'refresh'];
 
 export function extractDataAndFlags(data, flags) {
   return data.concat(flags).reduce((accumulator, val) => {
@@ -29,7 +29,7 @@ export function extractDataAndFlags(data, flags) {
   }, { data: {}, flags: {} });
 }
 
-export function executeUICommand(command, logAndOutput, clearLog, toggleFullscreen) {
+export function executeUICommand(command, logAndOutput, clearLog, toggleFullscreen, refreshFn) {
   const isUICommand = uiCommands.includes(command);
   if (isUICommand) {
     logAndOutput(command);
@@ -43,6 +43,9 @@ export function executeUICommand(command, logAndOutput, clearLog, toggleFullscre
       break;
     case 'fullscreen':
       toggleFullscreen();
+      break;
+    case 'refresh':
+      refreshFn();
       break;
   }
 

--- a/ui/app/models/identity/group.js
+++ b/ui/app/models/identity/group.js
@@ -27,10 +27,10 @@ export default IdentityModel.extend({
     readOnly: true,
   }),
   numMemberEntities: attr('number', {
-    readOnly: true
+    readOnly: true,
   }),
   numParentGroups: attr('number', {
-    readOnly: true
+    readOnly: true,
   }),
   metadata: attr('object', {
     editType: 'kv',

--- a/ui/app/serializers/identity/_base.js
+++ b/ui/app/serializers/identity/_base.js
@@ -19,9 +19,8 @@ export default ApplicationSerializer.extend({
       return model;
     });
     delete payload.data.key_info;
-    return list.sort((a,b) => {
+    return list.sort((a, b) => {
       return a.name.localeCompare(b.name);
     });
   },
-
 });

--- a/ui/app/services/console.js
+++ b/ui/app/services/console.js
@@ -61,8 +61,10 @@ export default Service.extend({
 
   logAndOutput(command, logContent) {
     let log = this.get('log');
-    log.pushObject({ type: 'command', content: command });
-    this.set('commandIndex', null);
+    if (command) {
+      log.pushObject({ type: 'command', content: command });
+      this.set('commandIndex', null);
+    }
     if (logContent) {
       log.pushObject(logContent);
     }

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -151,3 +151,18 @@ header .navbar-sections {
   transform: translate3d(0, 0, 0);
   will-change: transform;
 }
+
+.console-spinner.control {
+  height: 21px;
+  width: 21px;
+  transform: scale(.75);
+  transform-origin: center;
+  &:after {
+    height: auto;
+    width: auto;
+    right: .25rem;
+    left: .25rem;
+    top: .25rem;
+    bottom: .25rem;
+  }
+}

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -62,7 +62,6 @@
   align-items: center;
   display: flex;
 
-
   input {
     background-color: rgba($black, 0.5);
     border: 0;

--- a/ui/app/styles/components/console-ui-panel.scss
+++ b/ui/app/styles/components/console-ui-panel.scss
@@ -157,7 +157,7 @@ header .navbar-sections {
   width: 21px;
   transform: scale(.75);
   transform-origin: center;
-  &:after {
+  &::after {
     height: auto;
     width: auto;
     right: .25rem;

--- a/ui/app/templates/application.hbs
+++ b/ui/app/templates/application.hbs
@@ -9,7 +9,7 @@
         </div>
         <div class="navbar-end is-divider-list is-flex">
           <div class="navbar-item">
-            <button type="button" class="button is-transparent" {{action 'toggleConsole'}}>
+            <button type="button" class="button is-transparent" {{action 'toggleConsole'}} data-test-console-toggle>
               {{#if consoleOpen}}
                 {{i-con glyph="console-active" size=24}}
                 {{i-con glyph="chevron-up" aria-hidden="true" size=8 class="has-text-white auto-width is-status-chevron"}}

--- a/ui/app/templates/components/console/command-input.hbs
+++ b/ui/app/templates/components/console/command-input.hbs
@@ -1,4 +1,8 @@
-{{i-con glyph="chevron-right" size=12}}
+{{#if isRunning}}
+  <div class="control console-spinner is-loading"></div>
+{{else}}
+  {{i-con glyph="chevron-right" size=12 }}
+{{/if}}
 <input onkeyup={{action 'handleKeyUp'}} value={{value}} autocomplete="off" spellcheck="false" />
 {{#tool-tip horizontalPosition="auto-right" verticalPosition=(if isFullscreen "above" "below") as |d|}}
   {{#d.trigger tagName="button" type="button" class=(concat "button is-compact" (if isFullscreen " active")) click=(action "fullscreen") data-test-tool-tip-trigger=true}}

--- a/ui/app/templates/components/console/log-help.hbs
+++ b/ui/app/templates/components/console/log-help.hbs
@@ -12,5 +12,6 @@ Web CLI Commands:
   fullscreen  Toggle fullscreen display
   clear       Clear output from the log
   clearall    Clear output and command history
+  refresh     Refresh the data on the current screen under the CLI window
 </pre>
 </div>

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -7,6 +7,7 @@
   {{console/output-log log=log}}
   {{console/command-input
     isFullscreen=isFullscreen
+    isRunning=runner.isRunning
     value=inputValue
     onValueUpdate=(action (mut inputValue))
     onFullscreen=(action 'toggleFullscreen')

--- a/ui/app/templates/components/console/ui-panel.hbs
+++ b/ui/app/templates/components/console/ui-panel.hbs
@@ -7,7 +7,7 @@
   {{console/output-log log=log}}
   {{console/command-input
     isFullscreen=isFullscreen
-    isRunning=runner.isRunning
+    isRunning=isRunning
     value=inputValue
     onValueUpdate=(action (mut inputValue))
     onFullscreen=(action 'toggleFullscreen')

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,6 +42,7 @@
     "bulma": "^0.5.2",
     "bulma-switch": "^0.0.1",
     "codemirror": "5.15.2",
+    "columnify": "^1.5.4",
     "cool-checkboxes-for-bulma.io": "^1.1.0",
     "ember-ajax": "^3.0.0",
     "ember-api-actions": "^0.1.8",
@@ -83,6 +84,7 @@
     "ember-qunit-assert-helpers": "^0.1.3",
     "ember-radio-button": "^1.1.1",
     "ember-resolver": "^4.0.0",
+    "ember-router-service-polyfill": "^1.0.2",
     "ember-sinon": "^1.0.1",
     "ember-source": "~2.14.0",
     "ember-test-selectors": "^0.3.6",
@@ -96,7 +98,6 @@
     "qunit-dom": "^0.6.2",
     "string.prototype.startswith": "mathiasbynens/String.prototype.startsWith",
     "text-encoder-lite": "1.0.0",
-    "columnify": "^1.5.4",
     "yargs-parser": "^10.0.0"
   },
   "engines": {

--- a/ui/tests/acceptance/console-test.js
+++ b/ui/tests/acceptance/console-test.js
@@ -1,0 +1,32 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'vault/tests/helpers/module-for-acceptance';
+import enginesPage from 'vault/tests/pages/secrets/backends';
+
+moduleForAcceptance('Acceptance | console', {
+  beforeEach() {
+    return authLogin();
+  },
+});
+
+
+test('refresh reloads the current route\'s data', function(assert) {
+  let numEngines;
+  enginesPage.visit();
+  andThen(() => {
+    numEngines = enginesPage.rows().count;
+    enginesPage.consoleToggle();
+    let now = Date.now();
+    [1, 2, 3].forEach(num => {
+      let inputString = `write sys/mounts/${now+num} type=kv`;
+      enginesPage.console.consoleInput(inputString);
+      enginesPage.console.enter();
+    });
+  });
+  andThen(() => {
+    enginesPage.console.consoleInput('refresh');
+    enginesPage.console.enter();
+  });
+  andThen(() => {
+    assert.equal(enginesPage.rows().count, numEngines + 3, 'new engines were added to the page');
+  });
+});

--- a/ui/tests/pages/secrets/backends.js
+++ b/ui/tests/pages/secrets/backends.js
@@ -1,6 +1,9 @@
 import { create, visitable, collection, clickable, text } from 'ember-cli-page-object';
+import uiPanel from 'vault/tests/pages/components/console/ui-panel';
 
 export default create({
+  console: uiPanel,
+  consoleToggle: clickable('[data-test-console-toggle]'),
   visit: visitable('/vault/secrets'),
   rows: collection({
     itemScope: '[data-test-secret-backend-row]',

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3451,6 +3451,12 @@ ember-router-generator@^1.0.0:
   dependencies:
     recast "^0.11.3"
 
+ember-router-service-polyfill@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ember-router-service-polyfill/-/ember-router-service-polyfill-1.0.2.tgz#6e5565f196fa7045cbe06a6fab861f9e766fe62a"
+  dependencies:
+    ember-cli-babel "^6.8.2"
+
 ember-runtime-enumerable-includes-polyfill@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-1.0.4.tgz#16a7612e347a2edf07da8b2f2f09dbfee70deba0"


### PR DESCRIPTION
For the new console, it is possible to change the state of the current screen you're on (for example, enabling or disabling new engines when you're on the engines page) and since we don't poll or have any way to know to update the UI, this could lead to confusion as the UI would not reflect the current state of the Vault server. In order to get around this, we added a `refresh` command that will look up the current route and re-run the data hooks (it calls Ember Route's `refresh` method).

As an added bonus, ember-concurrency was added so now if you're on a slow network or type really fast, you can run commands concurrently and their output will end up in the log when they finish. A spinner next to the input in the console indicates if there's currently any asynchronous tasks running.

In addition to that, the scrolling behavior changed to be more user friendly - the previous use of `element.scrollIntoView` could be very abrupt and scroll the rest of the console off of the page if the outer page was scrollable.

![console-refresh](https://user-images.githubusercontent.com/39469/40853789-efd73362-6594-11e8-885f-1e3975518a19.gif)

