### PR TITLE
Strip checking cidrs on renewals

### DIFF
--- a/builtin/credential/cert/path_login.go
+++ b/builtin/credential/cert/path_login.go
@@ -159,10 +159,6 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 		return nil, nil
 	}
 
-	if err := b.checkCIDR(cert, req); err != nil {
-		return nil, err
-	}
-
 	if !policyutil.EquivalentPolicies(cert.Policies, req.Auth.Policies) {
 		return nil, fmt.Errorf("policies have changed, not renewing")
 	}
@@ -171,7 +167,6 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 	resp.Auth.TTL = cert.TTL
 	resp.Auth.MaxTTL = cert.MaxTTL
 	resp.Auth.Period = cert.Period
-	resp.Auth.BoundCIDRs = cert.BoundCIDRs
 	return resp, nil
 }
 

--- a/builtin/credential/userpass/path_login.go
+++ b/builtin/credential/userpass/path_login.go
@@ -3,7 +3,6 @@ package userpass
 import (
 	"context"
 	"crypto/subtle"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -124,15 +123,9 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 		return nil, fmt.Errorf("policies have changed, not renewing")
 	}
 
-	// Check for a CIDR match.
-	if !cidrutil.RemoteAddrIsOk(req.Connection.RemoteAddr, user.BoundCIDRs) {
-		return nil, errors.New("renewal request originated from invalid CIDR")
-	}
-
 	resp := &logical.Response{Auth: req.Auth}
 	resp.Auth.TTL = user.TTL
 	resp.Auth.MaxTTL = user.MaxTTL
-	resp.Auth.BoundCIDRs = user.BoundCIDRs
 	return resp, nil
 }
 


### PR DESCRIPTION
On a separate PR, Jeff pointed out:

>CIDRs are bound on the token; we don't actually have a way to update them currently (and may never). You can leave this code in but maybe mark it as for the future.

This strips code that makes it look like CIDRs are being possibly updated when they're not.