### PR TITLE
put modal over the nav

### DIFF
--- a/ui/app/styles/components/upgrade-overlay.scss
+++ b/ui/app/styles/components/upgrade-overlay.scss
@@ -4,6 +4,7 @@
   text-align: left;
   transition: opacity $speed-slow;
   will-change: opacity;
+  z-index: 300;
 
   &.is-animated {
     opacity: 1;


### PR DESCRIPTION
Fixes an issue where the upgrade modal would be under the top nav so you'd never be able to close it.