### PR TITLE
fix route name

### DIFF
--- a/ui/app/routes/vault/cluster/replication/mode/secondaries/revoke.js
+++ b/ui/app/routes/vault/cluster/replication/mode/secondaries/revoke.js
@@ -2,7 +2,7 @@ import Base from '../../replication-base';
 
 export default Base.extend({
   model() {
-    return this.modelFor('vault.cluster.replication.secondaries');
+    return this.modelFor('vault.cluster.replication.mode.secondaries');
   },
 
   redirect(model) {


### PR DESCRIPTION
This was trying to get a model for a route that didn't exist so you could never successfully navigate to the revoke route.