### PR TITLE
Add support for x.509 Name Serial Number attribute in subject of certificates

### DIFF
--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -29,20 +29,21 @@ func (b *backend) getGenerationParams(
 	}
 
 	role = &roleEntry{
-		TTL:              time.Duration(data.Get("ttl").(int)) * time.Second,
-		KeyType:          data.Get("key_type").(string),
-		KeyBits:          data.Get("key_bits").(int),
-		AllowLocalhost:   true,
-		AllowAnyName:     true,
-		AllowIPSANs:      true,
-		EnforceHostnames: false,
-		OU:               data.Get("ou").([]string),
-		Organization:     data.Get("organization").([]string),
-		Country:          data.Get("country").([]string),
-		Locality:         data.Get("locality").([]string),
-		Province:         data.Get("province").([]string),
-		StreetAddress:    data.Get("street_address").([]string),
-		PostalCode:       data.Get("postal_code").([]string),
+		TTL:                  time.Duration(data.Get("ttl").(int)) * time.Second,
+		KeyType:              data.Get("key_type").(string),
+		KeyBits:              data.Get("key_bits").(int),
+		AllowLocalhost:       true,
+		AllowAnyName:         true,
+		AllowIPSANs:          true,
+		EnforceHostnames:     false,
+		AllowedSerialNumbers: []string{"*"},
+		OU:                   data.Get("ou").([]string),
+		Organization:         data.Get("organization").([]string),
+		Country:              data.Get("country").([]string),
+		Locality:             data.Get("locality").([]string),
+		Province:             data.Get("province").([]string),
+		StreetAddress:        data.Get("street_address").([]string),
+		PostalCode:           data.Get("postal_code").([]string),
 	}
 
 	if role.KeyType == "rsa" && role.KeyBits < 2048 {

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -724,7 +724,6 @@ func generateCreationBundle(b *backend, data *dataBundle) error {
 	{
 		if data.csr != nil && data.role.UseCSRCommonName {
 			cn = data.csr.Subject.CommonName
-			ridSerialNumber = data.csr.Subject.SerialNumber
 		}
 		if cn == "" {
 			cn = data.apiData.Get("common_name").(string)
@@ -732,11 +731,12 @@ func generateCreationBundle(b *backend, data *dataBundle) error {
 				return errutil.UserError{Err: `the common_name field is required, or must be provided in a CSR with "use_csr_common_name" set to true, unless "require_cn" is set to false`}
 			}
 		}
+
+		if data.csr != nil && len(data.role.AllowedSerialNumbers) > 0 {
+			ridSerialNumber = data.csr.Subject.SerialNumber
+		}
 		if ridSerialNumber == "" {
-			ridSerialNumberRaw, ok := data.apiData.GetOk("serial_number")
-			if ok {
-				ridSerialNumber = ridSerialNumberRaw.(string)
-			}
+			ridSerialNumber = data.apiData.Get("serial_number").(string)
 		}
 
 		if data.csr != nil && data.role.UseCSRSANs {

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -732,11 +732,11 @@ func generateCreationBundle(b *backend, data *dataBundle) error {
 			}
 		}
 
-		if data.csr != nil && len(data.role.AllowedSerialNumbers) > 0 {
+		ridSerialNumber = data.apiData.Get("serial_number").(string)
+
+		// only take serial number from CSR if one was not supplied via API
+		if ridSerialNumber == "" && data.csr != nil {
 			ridSerialNumber = data.csr.Subject.SerialNumber
-		}
-		if ridSerialNumber == "" {
-			ridSerialNumber = data.apiData.Get("serial_number").(string)
 		}
 
 		if data.csr != nil && data.role.UseCSRSANs {

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -169,6 +169,13 @@ this value.`,
 this value.`,
 	}
 
+	fields["serial_number"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `The requested serial number, if any. If you want
+more than one, specify alternative names in
+the alt_names map using OID 2.5.4.5.`,
+	}
+
 	return fields
 }
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -75,6 +75,13 @@ is enabled for the role, this may contain
 email addresses.`,
 	}
 
+	fields["serial_number"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `The requested serial number, if any. If you want
+more than one, specify alternative names in
+the alt_names map using OID 2.5.4.5.`,
+	}
+
 	fields["ttl"] = &framework.FieldSchema{
 		Type: framework.TypeDurationSecond,
 		Description: `The requested Time To Live for the certificate;

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -128,16 +128,17 @@ func (b *backend) pathSignVerbatim(ctx context.Context, req *logical.Request, da
 	}
 
 	entry := &roleEntry{
-		TTL:              b.System().DefaultLeaseTTL(),
-		MaxTTL:           b.System().MaxLeaseTTL(),
-		AllowLocalhost:   true,
-		AllowAnyName:     true,
-		AllowIPSANs:      true,
-		EnforceHostnames: false,
-		KeyType:          "any",
-		UseCSRCommonName: true,
-		UseCSRSANs:       true,
-		GenerateLease:    new(bool),
+		TTL:                  b.System().DefaultLeaseTTL(),
+		MaxTTL:               b.System().MaxLeaseTTL(),
+		AllowLocalhost:       true,
+		AllowAnyName:         true,
+		AllowIPSANs:          true,
+		EnforceHostnames:     false,
+		KeyType:              "any",
+		UseCSRCommonName:     true,
+		UseCSRSANs:           true,
+		AllowedSerialNumbers: []string{"*"},
+		GenerateLease:        new(bool),
 	}
 
 	*entry.GenerateLease = false

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -114,6 +114,11 @@ Any valid IP is accepted.`,
 				Description: `If set, an array of allowed other names to put in SANs. These values support globbing.`,
 			},
 
+			"allowed_serial_numbers": &framework.FieldSchema{
+				Type:        framework.TypeCommaStringSlice,
+				Description: `If set, an array of allowed serial numbers to put in Subject. These values support globbing.`,
+			},
+
 			"server_flag": &framework.FieldSchema{
 				Type:    framework.TypeBool,
 				Default: true,
@@ -467,6 +472,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		GenerateLease:                 new(bool),
 		NoStore:                       data.Get("no_store").(bool),
 		RequireCN:                     data.Get("require_cn").(bool),
+		AllowedSerialNumbers:          data.Get("allowed_serial_numbers").([]string),
 		PolicyIdentifiers:             data.Get("policy_identifiers").([]string),
 		BasicConstraintsValidForNonCA: data.Get("basic_constraints_valid_for_non_ca").(bool),
 	}
@@ -602,6 +608,7 @@ type roleEntry struct {
 	NoStore                       bool          `json:"no_store" mapstructure:"no_store"`
 	RequireCN                     bool          `json:"require_cn" mapstructure:"require_cn"`
 	AllowedOtherSANs              []string      `json:"allowed_other_sans" mapstructure:"allowed_other_sans"`
+	AllowedSerialNumbers          []string      `json:"allowed_serial_numbers" mapstructure:"allowed_serial_numbers"`
 	PolicyIdentifiers             []string      `json:"policy_identifiers" mapstructure:"policy_identifiers"`
 	ExtKeyUsageOIDs               []string      `json:"ext_key_usage_oids" mapstructure:"ext_key_usage_oids"`
 	BasicConstraintsValidForNonCA bool          `json:"basic_constraints_valid_for_non_ca" mapstructure:"basic_constraints_valid_for_non_ca"`
@@ -642,6 +649,7 @@ func (r *roleEntry) ToResponseData() map[string]interface{} {
 		"postal_code":                        r.PostalCode,
 		"no_store":                           r.NoStore,
 		"allowed_other_sans":                 r.AllowedOtherSANs,
+		"allowed_serial_numbers":             r.AllowedSerialNumbers,
 		"require_cn":                         r.RequireCN,
 		"policy_identifiers":                 r.PolicyIdentifiers,
 		"basic_constraints_valid_for_non_ca": r.BasicConstraintsValidForNonCA,

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -268,6 +268,7 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 		AllowIPSANs:           true,
 		EnforceHostnames:      false,
 		KeyType:               "any",
+		AllowedSerialNumbers:  []string{"*"},
 		AllowExpirationPastCA: true,
 	}
 


### PR DESCRIPTION
This PR adds support for specifying X.509 Name serialNumber attributes in subjects. It is possible to already to do this using a custom OID (2.5.4.5) with `allowed_other_sans="2.5.4.5;utf8:*" in the role configuration, however this field is not regularly parsed by various applications. It's also possible to issue certificates by passing a CSR to the sign-verbatim endpoint, but as the documents suggest it is a highly trusted and potentially dangerous endpoint. However, the sign-verbatim endpoint does not respect role specific requirements (such as EKU restrictions) and submitted CSR's may override/bypass them.

Discussion here: https://github.com/hashicorp/vault/issues/4562#issuecomment-393907646