### PR TITLE
UI - code cleanup

### DIFF
--- a/ui/app/models/iam-credential.js
+++ b/ui/app/models/iam-credential.js
@@ -1,7 +1,8 @@
 import DS from 'ember-data';
 import Ember from 'ember';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 const { attr } = DS;
-const { computed, get } = Ember;
+const { computed } = Ember;
 const CREATE_FIELDS = ['ttl'];
 
 const DISPLAY_FIELDS = ['accessKey', 'secretKey', 'securityToken', 'leaseId', 'renewable', 'leaseDuration'];
@@ -27,18 +28,7 @@ export default DS.Model.extend({
 
   attrs: computed('accessKey', function() {
     let keys = this.get('accessKey') ? DISPLAY_FIELDS.slice(0) : CREATE_FIELDS.slice(0);
-    get(this.constructor, 'attributes').forEach((meta, name) => {
-      const index = keys.indexOf(name);
-      if (index === -1) {
-        return;
-      }
-      keys.replace(index, 1, {
-        type: meta.type,
-        name,
-        options: meta.options,
-      });
-    });
-    return keys;
+    return expandAttributeMeta(this, keys);
   }),
 
   toCreds: computed('accessKey', 'secretKey', 'securityToken', 'leaseId', function() {

--- a/ui/app/models/pki-ca-certificate.js
+++ b/ui/app/models/pki-ca-certificate.js
@@ -1,7 +1,7 @@
 import Certificate from './pki-certificate';
 import Ember from 'ember';
 import DS from 'ember-data';
-import { queryRecord } from 'ember-computed-query';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 const { computed } = Ember;
 const { attr } = DS;
@@ -146,15 +146,6 @@ export default Certificate.extend({
   }),
   expiration: attr(),
 
-  deletePath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend } = context.getProperties('backend');
-      return {
-        id: `${backend}/root`,
-      };
-    },
-    'backend'
-  ),
+  deletePath: lazyCapabilities( apiPath`${'backend'}/root`, 'backend'),
   canDeleteRoot: computed.and('deletePath.canDelete', 'deletePath.canSudo'),
 });

--- a/ui/app/models/pki-certificate.js
+++ b/ui/app/models/pki-certificate.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import { queryRecord } from 'ember-computed-query';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 const { computed, get } = Ember;
 const { attr } = DS;
@@ -145,15 +145,6 @@ export default DS.Model.extend({
     }
   ),
 
-  revokePath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend } = context.getProperties('backend');
-      return {
-        id: `${backend}/revoke`,
-      };
-    },
-    'backend'
-  ),
+  revokePath: lazyCapabilities(apiPath`${'backend'}/revoke`, 'backend'),
   canRevoke: computed.alias('revokePath.canUpdate'),
 });

--- a/ui/app/models/pki-certificate.js
+++ b/ui/app/models/pki-certificate.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
+import fieldToAttrs, { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
-const { computed, get } = Ember;
+const { computed } = Ember;
 const { attr } = DS;
 
 export default DS.Model.extend({
@@ -74,20 +75,7 @@ export default DS.Model.extend({
   serialNumber: attr('string'),
 
   fieldsToAttrs(fieldGroups) {
-    const attrMap = get(this.constructor, 'attributes');
-    return fieldGroups.map(group => {
-      const groupKey = Object.keys(group)[0];
-      const groupMembers = group[groupKey];
-      const fields = groupMembers.map(field => {
-        var meta = attrMap.get(field);
-        return {
-          type: meta.type,
-          name: meta.name,
-          options: meta.options,
-        };
-      });
-      return { [groupKey]: fields };
-    });
+    return fieldToAttrs(this, fieldGroups);
   },
 
   fieldDefinition: computed(function() {
@@ -104,16 +92,7 @@ export default DS.Model.extend({
 
   attrs: computed('certificate', 'csr', function() {
     let keys = this.get('certificate') || this.get('csr') ? this.DISPLAY_FIELDS.slice(0) : [];
-    const attrMap = get(this.constructor, 'attributes');
-    keys = keys.map(key => {
-      let meta = attrMap.get(key);
-      return {
-        type: meta.type,
-        name: meta.name,
-        options: meta.options,
-      };
-    });
-    return keys;
+    return expandAttributeMeta(this, keys);
   }),
 
   toCreds: computed(

--- a/ui/app/models/pki-config.js
+++ b/ui/app/models/pki-config.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import DS from 'ember-data';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
 const { attr } = DS;
-const { computed, get } = Ember;
+const { computed } = Ember;
 
 export default DS.Model.extend({
   backend: attr('string'),
@@ -10,16 +11,7 @@ export default DS.Model.extend({
   pem: attr('string'),
   caChain: attr('string'),
   attrList(keys) {
-    const attrMap = get(this.constructor, 'attributes');
-    keys = keys.map(key => {
-      let meta = attrMap.get(key);
-      return {
-        type: meta.type,
-        name: meta.name,
-        options: meta.options,
-      };
-    });
-    return keys;
+    return expandAttributeMeta(this, keys);
   },
 
   //urls

--- a/ui/app/models/policy.js
+++ b/ui/app/models/policy.js
@@ -1,6 +1,6 @@
 import DS from 'ember-data';
 import Ember from 'ember';
-import { queryRecord } from 'ember-computed-query';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 let { attr } = DS;
 let { computed } = Ember;
@@ -12,20 +12,7 @@ export default DS.Model.extend({
     return this.constructor.modelName.split('/')[1];
   }),
 
-  updatePath: queryRecord(
-    'capabilities',
-    context => {
-      const { policyType, id } = context.getProperties('policyType', 'id');
-      if (!policyType && id) {
-        return;
-      }
-      return {
-        id: `sys/policies/${policyType}/${id}`,
-      };
-    },
-    'id',
-    'policyType'
-  ),
+  updatePath: lazyCapabilities(apiPath`sys/policies/${'policyType'}/${'id'}`, 'id', 'policyType'),
   canDelete: computed.alias('updatePath.canDelete'),
   canEdit: computed.alias('updatePath.canUpdate'),
   canRead: computed.alias('updatePath.canRead'),

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import { queryRecord } from 'ember-computed-query';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 const { attr } = DS;
 const { computed, get } = Ember;
@@ -38,44 +38,14 @@ export default DS.Model.extend({
     return keys;
   }),
 
-  updatePath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      return {
-        id: `${backend}/roles/${id}`,
-      };
-    },
-    'id',
-    'backend'
-  ),
+  updatePath: lazyCapabilities(apiPath`${'backend'}/roles/${'id'}`, 'backend', 'id'),
   canDelete: computed.alias('updatePath.canDelete'),
   canEdit: computed.alias('updatePath.canUpdate'),
   canRead: computed.alias('updatePath.canRead'),
 
-  generatePath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      return {
-        id: `${backend}/creds/${id}`,
-      };
-    },
-    'id',
-    'backend'
-  ),
+  generatePath: lazyCapabilities(apiPath`${'backend'}/creds/${'id'}`, 'backend', 'id'),
   canGenerate: computed.alias('generatePath.canUpdate'),
 
-  stsPath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      return {
-        id: `${backend}/sts/${id}`,
-      };
-    },
-    'id',
-    'backend'
-  ),
+  stsPath: lazyCapabilities(apiPath`${'backend'}/sts/${'id'}`, 'backend', 'id'),
   canGenerateSTS: computed.alias('stsPath.canUpdate'),
 });

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
 const { attr } = DS;
-const { computed, get } = Ember;
+const { computed } = Ember;
 
 const CREATE_FIELDS = ['name', 'policy', 'arn'];
 export default DS.Model.extend({
@@ -24,18 +25,7 @@ export default DS.Model.extend({
   }),
   attrs: computed(function() {
     let keys = CREATE_FIELDS.slice(0);
-    get(this.constructor, 'attributes').forEach((meta, name) => {
-      const index = keys.indexOf(name);
-      if (index === -1) {
-        return;
-      }
-      keys.replace(index, 1, {
-        type: meta.type,
-        name,
-        options: meta.options,
-      });
-    });
-    return keys;
+    return expandAttributeMeta(this, keys);
   }),
 
   updatePath: lazyCapabilities(apiPath`${'backend'}/roles/${'id'}`, 'backend', 'id'),

--- a/ui/app/models/role-pki.js
+++ b/ui/app/models/role-pki.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import { queryRecord } from 'ember-computed-query';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 const { attr } = DS;
 const { computed, get } = Ember;
@@ -104,58 +104,18 @@ export default DS.Model.extend({
     label: 'Mark Basic Constraints valid when issuing non-CA certificates.',
   }),
 
-  updatePath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      return {
-        id: `${backend}/roles/${id}`,
-      };
-    },
-    'id',
-    'backend'
-  ),
+  updatePath: lazyCapabilities(apiPath`${'backend'}/roles/${'id'}`, 'backend', 'id'),
   canDelete: computed.alias('updatePath.canDelete'),
   canEdit: computed.alias('updatePath.canUpdate'),
   canRead: computed.alias('updatePath.canRead'),
 
-  generatePath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      return {
-        id: `${backend}/issue/${id}`,
-      };
-    },
-    'id',
-    'backend'
-  ),
+  generatePath: lazyCapabilities(apiPath`${'backend'}/issue/${'id'}`, 'backend', 'id'),
   canGenerate: computed.alias('generatePath.canUpdate'),
 
-  signPath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      return {
-        id: `${backend}/sign/${id}`,
-      };
-    },
-    'id',
-    'backend'
-  ),
+  signPath: lazyCapabilities(apiPath`${'backend'}/sign/${'id'}`, 'backend', 'id'),
   canSign: computed.alias('signPath.canUpdate'),
 
-  signVerbatimPath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      return {
-        id: `${backend}/sign-verbatim/${id}`,
-      };
-    },
-    'id',
-    'backend'
-  ),
+  signVerbatimPath: lazyCapabilities(apiPath`${'backend'}/sign-verbatim/${'id'}`, 'backend', 'id'),
   canSignVerbatim: computed.alias('signVerbatimPath.canUpdate'),
 
   /*

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import { queryRecord } from 'ember-computed-query';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 const { attr } = DS;
 const { computed, get } = Ember;
@@ -138,56 +138,17 @@ export default DS.Model.extend({
     return keys;
   }),
 
-  updatePath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      return {
-        id: `${backend}/roles/${id}`,
-      };
-    },
-    'id',
-    'backend'
-  ),
+  updatePath: lazyCapabilities(apiPath`${'backend'}/roles/${'id'}`, 'backend', 'id'),
   canDelete: computed.alias('updatePath.canDelete'),
   canEdit: computed.alias('updatePath.canUpdate'),
   canRead: computed.alias('updatePath.canRead'),
 
-  generatePath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      return {
-        id: `${backend}/creds/${id}`,
-      };
-    },
-    'id',
-    'backend'
-  ),
+  generatePath: lazyCapabilities(apiPath`${'backend'}/creds/${'id'}`, 'backend', 'id'),
   canGenerate: computed.alias('generatePath.canUpdate'),
 
-  signPath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      return {
-        id: `${backend}/sign/${id}`,
-      };
-    },
-    'id',
-    'backend'
-  ),
+  signPath: lazyCapabilities(apiPath`${'backend'}/sign/${'id'}`, 'backend', 'id'),
   canSign: computed.alias('signPath.canUpdate'),
 
-  zeroAddressPath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend } = context.getProperties('backend');
-      return {
-        id: `${backend}/config/zeroaddress`,
-      };
-    },
-    'backend'
-  ),
+  zeroAddressPath: lazyCapabilities(apiPath`${'backend'}/config/zeroaddress`, 'backend'),
   canEditZeroAddress: computed.alias('zeroAddressPath.canUpdate'),
 });

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
 const { attr } = DS;
-const { computed, get } = Ember;
+const { computed } = Ember;
 
 // these arrays define the order in which the fields will be displayed
 // see
@@ -124,18 +125,7 @@ export default DS.Model.extend({
   attrsForKeyType: computed('keyType', function() {
     const keyType = this.get('keyType');
     let keys = keyType === 'ca' ? CA_FIELDS.slice(0) : OTP_FIELDS.slice(0);
-    get(this.constructor, 'attributes').forEach((meta, name) => {
-      const index = keys.indexOf(name);
-      if (index === -1) {
-        return;
-      }
-      keys.replace(index, 1, {
-        type: meta.type,
-        name,
-        options: meta.options,
-      });
-    });
-    return keys;
+    return expandAttributeMeta(this, keys);
   }),
 
   updatePath: lazyCapabilities(apiPath`${'backend'}/roles/${'id'}`, 'backend', 'id'),

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import { queryRecord } from 'ember-computed-query';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { fragment } from 'ember-data-model-fragments/attributes';
 
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
@@ -81,16 +81,7 @@ export default DS.Model.extend({
     });
   },
 
-  zeroAddressPath: queryRecord(
-    'capabilities',
-    context => {
-      const { id } = context.getProperties('backend', 'id');
-      return {
-        id: `${id}/config/zeroaddress`,
-      };
-    },
-    'id'
-  ),
+  zeroAddressPath: lazyCapabilities(apiPath`${'id'}/config/zeroaddress`, 'id'),
   canEditZeroAddress: computed.alias('zeroAddressPath.canUpdate'),
 
   // aws backend attrs

--- a/ui/app/models/ssh-otp-credential.js
+++ b/ui/app/models/ssh-otp-credential.js
@@ -1,7 +1,8 @@
 import DS from 'ember-data';
 import Ember from 'ember';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 const { attr } = DS;
-const { computed, get } = Ember;
+const { computed } = Ember;
 const CREATE_FIELDS = ['username', 'ip'];
 
 const DISPLAY_FIELDS = ['username', 'ip', 'key', 'keyType', 'port'];
@@ -18,18 +19,7 @@ export default DS.Model.extend({
   port: attr('number'),
   attrs: computed('key', function() {
     let keys = this.get('key') ? DISPLAY_FIELDS.slice(0) : CREATE_FIELDS.slice(0);
-    get(this.constructor, 'attributes').forEach((meta, name) => {
-      const index = keys.indexOf(name);
-      if (index === -1) {
-        return;
-      }
-      keys.replace(index, 1, {
-        type: meta.type,
-        name,
-        options: meta.options,
-      });
-    });
-    return keys;
+    return expandAttributeMeta(this, keys);
   }),
   toCreds: computed('key', function() {
     // todo: would this be better copied as an SSH command?

--- a/ui/app/models/ssh-sign.js
+++ b/ui/app/models/ssh-sign.js
@@ -1,7 +1,8 @@
 import DS from 'ember-data';
 import Ember from 'ember';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 const { attr } = DS;
-const { computed, get } = Ember;
+const { computed } = Ember;
 const CREATE_FIELDS = [
   'publicKey',
   'keyId',
@@ -45,17 +46,6 @@ export default DS.Model.extend({
 
   attrs: computed('signedKey', function() {
     let keys = this.get('signedKey') ? DISPLAY_FIELDS.slice(0) : CREATE_FIELDS.slice(0);
-    get(this.constructor, 'attributes').forEach((meta, name) => {
-      const index = keys.indexOf(name);
-      if (index === -1) {
-        return;
-      }
-      keys.replace(index, 1, {
-        type: meta.type,
-        name,
-        options: meta.options,
-      });
-    });
-    return keys;
+    return expandAttributeMeta(this, keys);
   }),
 });

--- a/ui/app/models/transit-key.js
+++ b/ui/app/models/transit-key.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import clamp from 'vault/utils/clamp';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 import { queryRecord } from 'ember-computed-query';
 
 const { attr } = DS;
@@ -120,20 +121,6 @@ export default DS.Model.extend({
     readOnly: true,
   }),
 
-  rotatePath: queryRecord(
-    'capabilities',
-    context => {
-      const { backend, id } = context.getProperties('backend', 'id');
-      if (!backend && id) {
-        return;
-      }
-      return {
-        id: `${backend}/keys/${id}/rotate`,
-      };
-    },
-    'id',
-    'backend'
-  ),
-
+  rotatePath: lazyCapabilities(apiPath`${'backend'}/keys/${'id'}/rotate`, 'backend', 'id'),
   canRotate: computed.alias('rotatePath.canUpdate'),
 });

--- a/ui/app/models/transit-key.js
+++ b/ui/app/models/transit-key.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import clamp from 'vault/utils/clamp';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
-import { queryRecord } from 'ember-computed-query';
 
 const { attr } = DS;
 const { computed, get, set } = Ember;

--- a/ui/app/templates/components/generate-credentials.hbs
+++ b/ui/app/templates/components/generate-credentials.hbs
@@ -1,34 +1,34 @@
-<header class="page-header">
-  <nav class="breadcrumb">
-    <ul>
-      <li>
-        <span class="sep">&#x0002f;</span>
-        <a href={{href-to "vault.cluster.secrets.backend" backend.id}} data-test-link="role-list">
-          {{backend.id}}
-        </a>
-      </li>
-      <li class="is-active">
-        <span class="sep">&#x0002f;</span>
-        <a href={{href-to "vault.cluster.secrets.backend" backend.id}}>
-          creds
-        </a>
-      </li>
-      <li>
-        <span class="sep">&#x0002f;</span>
-        <a href={{href-to "vault.cluster.secrets.backend.show" model.role.name}}>
-          {{model.role.name}}
-        </a>
-      </li>
-    </ul>
-  </nav>
-  <div class="level">
-    <div class="level-left">
-      <h1 data-test-title class="title is-3">
-        {{options.title}}
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.top>
+    <nav class="breadcrumb">
+      <ul>
+        <li>
+          <span class="sep">&#x0002f;</span>
+          <a href={{href-to "vault.cluster.secrets.backend" backend.id}} data-test-link="role-list">
+            {{backend.id}}
+          </a>
+        </li>
+        <li class="is-active">
+          <span class="sep">&#x0002f;</span>
+          <a href={{href-to "vault.cluster.secrets.backend" backend.id}}>
+            creds
+          </a>
+        </li>
+        <li>
+          <span class="sep">&#x0002f;</span>
+          <a href={{href-to "vault.cluster.secrets.backend.show" model.role.name}}>
+            {{model.role.name}}
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </p.top>
+  <p.levelLeft>
+    <h1 data-test-title class="title is-3">
+      {{options.title}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{#if (or options.generateWithoutInput (get model options.generatedAttr))}}
   {{#if loading}}

--- a/ui/app/templates/components/identity/entity-nav.hbs
+++ b/ui/app/templates/components/identity/entity-nav.hbs
@@ -1,24 +1,22 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        {{capitalize (pluralize identityType)}}
-      </h1>
-    </div>
-    <div class="level-right">
-      {{#if (eq identityType "entity")}}
-        <a href="{{href-to 'vault.cluster.access.identity.merge' (pluralize identityType)}}" class="button has-icon-right is-ghost is-compact" data-test-entity-merge-link=true>
-          Merge {{pluralize identityType}}
-          {{i-con glyph="chevron-right" size=11}}
-        </a>
-      {{/if}}
-      <a href="{{href-to 'vault.cluster.access.identity.create' (pluralize identityType)}}" class="button has-icon-right is-ghost is-compact" data-test-entity-create-link=true>
-        Create {{identityType}}
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{capitalize (pluralize identityType)}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    {{#if (eq identityType "entity")}}
+      <a href="{{href-to 'vault.cluster.access.identity.merge' (pluralize identityType)}}" class="button has-icon-right is-ghost is-compact" data-test-entity-merge-link=true>
+        Merge {{pluralize identityType}}
         {{i-con glyph="chevron-right" size=11}}
       </a>
-    </div>
-  </div>
-</header>
+    {{/if}}
+    <a href="{{href-to 'vault.cluster.access.identity.create' (pluralize identityType)}}" class="button has-icon-right is-ghost is-compact" data-test-entity-create-link=true>
+      Create {{identityType}}
+      {{i-con glyph="chevron-right" size=11}}
+    </a>
+  </p.levelRight>
+</PageHeader>
 <div class="box is-sideless is-fullwidth is-paddingless is-marginless">
   <nav class="tabs sub-nav">
     <ul>

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -1,14 +1,14 @@
-<header class="page-header">
-  <div class="level">
-<h1 class="title is-3" data-test-mount-form-header=true>
-  {{#if (eq mountType "auth")}}
-    Enable an authentication method
-  {{else}}
-    Enable a secrets engine
-  {{/if}}
-</h1>
-</div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-mount-form-header=true>
+      {{#if (eq mountType "auth")}}
+        Enable an authentication method
+      {{else}}
+        Enable a secrets engine
+      {{/if}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 <form {{action (perform mountBackend) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">
     {{message-error model=mountModel}}

--- a/ui/app/templates/components/not-found.hbs
+++ b/ui/app/templates/components/not-found.hbs
@@ -1,13 +1,11 @@
 <div class="box is-shadowless" data-test-not-found>
-  <header class="page-header">
-    <div class="level">
-      <div class="level-left">
-        <h1 class="title is-3 has-text-grey">
-          404 Not Found
-        </h1>
-      </div>
-    </div>
-  </header>
+  <PageHeader as |p|>
+    <p.levelLeft>
+      <h1 class="title is-3 has-text-grey">
+        404 Not Found
+      </h1>
+    </p.levelLeft>
+  </PageHeader>
   <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered">
     <p>Sorry, we were unable to find any content at <code>{{or model.path path}}</code>.</p>
     <p>Double check the url or go back {{home-link text="home"}}.</p>

--- a/ui/app/templates/components/pki-cert-show.hbs
+++ b/ui/app/templates/components/pki-cert-show.hbs
@@ -1,19 +1,19 @@
-<header class="page-header">
-  {{key-value-header
-    baseKey=(hash display=model.id id=model.idForNav)
-    path="vault.cluster.secrets.backend.list"
-    mode=mode
-    root=root
-    showCurrent=true
-  }}
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3" data-test-secret-header="true">
-        PKI Certificate
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.top>
+    {{key-value-header
+      baseKey=(hash display=model.id id=model.idForNav)
+      path="vault.cluster.secrets.backend.list"
+      mode=mode
+      root=root
+      showCurrent=true
+    }}
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-secret-header="true">
+      PKI Certificate
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   {{message-error model=model}}

--- a/ui/app/templates/components/role-aws-edit.hbs
+++ b/ui/app/templates/components/role-aws-edit.hbs
@@ -1,71 +1,71 @@
-<header class="page-header">
-  {{key-value-header
-    baseKey=model
-    path="vault.cluster.secrets.backend.list"
-    mode=mode
-    root=root
-    showCurrent=true
-  }}
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3" data-test-secret-header="true">
-        {{#if (eq mode "create") }}
-          Create an AWS Role
-        {{else if (eq mode 'edit')}}
-          Edit AWS Role
-        {{else}}
-          AWS Role <code>{{model.id}}</code>
-        {{/if}}
-      </h1>
-    </div>
-    <div class="level-right">
-      <div class="field is-grouped">
-        {{#if (eq mode "show") }}
-          {{#if (or model.canUpdate model.canDelete)}}
-            <div class="control">
-              {{#secret-link
-                secret=model.id
-                mode="edit"
-                replace=true
-                class="button has-icon-right is-ghost is-compact"
-                }}
-                Edit role
-                {{i-con glyph="chevron-right" size=11}}
-              {{/secret-link}}
-            </div>
-          {{/if}}
-          {{#if model.canGenerate}}
-            <div class="control">
-              {{#secret-link
-                mode="credentials"
-                secret=model.id
-                class="button has-icon-right is-ghost is-compact"
-                data-test-backend-credentials="iam"
+<PageHeader as |p|>
+  <p.top>
+    {{key-value-header
+      baseKey=model
+      path="vault.cluster.secrets.backend.list"
+      mode=mode
+      root=root
+      showCurrent=true
+    }}
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-secret-header="true">
+      {{#if (eq mode "create") }}
+        Create an AWS Role
+      {{else if (eq mode 'edit')}}
+        Edit AWS Role
+      {{else}}
+        AWS Role <code>{{model.id}}</code>
+      {{/if}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    <div class="field is-grouped">
+      {{#if (eq mode "show") }}
+        {{#if (or model.canUpdate model.canDelete)}}
+          <div class="control">
+            {{#secret-link
+              secret=model.id
+              mode="edit"
+              replace=true
+              class="button has-icon-right is-ghost is-compact"
               }}
-               Generate IAM
-               {{i-con glyph="chevron-right" size=11}}
-              {{/secret-link}}
-            </div>
-          {{/if}}
-          {{#if model.canGenerateSTS}}
-            <div class="control">
-              {{#secret-link
-                mode="credentials"
-                secret=model.id
-                queryParams=(query-params action="sts")
-                class="button has-icon-right is-ghost is-compact"
-                data-test-backend-credentials="sts"
-              }}
-                Generate IAM with STS
-                {{i-con glyph="chevron-right" size=11}}
-              {{/secret-link}}
-            </div>
-          {{/if}}
+              Edit role
+              {{i-con glyph="chevron-right" size=11}}
+            {{/secret-link}}
+          </div>
         {{/if}}
-      </div>
+        {{#if model.canGenerate}}
+          <div class="control">
+            {{#secret-link
+              mode="credentials"
+              secret=model.id
+              class="button has-icon-right is-ghost is-compact"
+              data-test-backend-credentials="iam"
+            }}
+             Generate IAM
+             {{i-con glyph="chevron-right" size=11}}
+            {{/secret-link}}
+          </div>
+        {{/if}}
+        {{#if model.canGenerateSTS}}
+          <div class="control">
+            {{#secret-link
+              mode="credentials"
+              secret=model.id
+              queryParams=(query-params action="sts")
+              class="button has-icon-right is-ghost is-compact"
+              data-test-backend-credentials="sts"
+            }}
+              Generate IAM with STS
+              {{i-con glyph="chevron-right" size=11}}
+            {{/secret-link}}
+          </div>
+        {{/if}}
+      {{/if}}
     </div>
-  </div>
-</header>
+  </p.levelRight>
+</PageHeader>
 
 {{#if (or (eq mode 'edit') (eq mode 'create'))}}
   {{partial 'partials/role-aws/form'}}

--- a/ui/app/templates/components/role-pki-edit.hbs
+++ b/ui/app/templates/components/role-pki-edit.hbs
@@ -1,73 +1,73 @@
-<header class="page-header">
-  {{key-value-header
-    baseKey=model
-    path="vault.cluster.secrets.backend.list"
-    mode=mode
-    root=root
-    showCurrent=true
-  }}
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3" data-test-secret-header="true">
-        {{#if (eq mode "create") }}
-          Create a PKI Role
-        {{else if (eq mode 'edit')}}
-          Edit PKI Role
-        {{else}}
-          PKI Role <code>{{model.id}}</code>
-        {{/if}}
-      </h1>
-    </div>
-    <div class="level-right">
-      <div class="field is-grouped">
-        {{#if (eq mode "show") }}
-          {{#if (or model.canUpdate model.canDelete)}}
-            <div class="control">
-              {{#secret-link
-                secret=model.id
-                mode="edit"
-                replace=true
-                class="button has-icon-right is-ghost is-compact"
-                data-test-edit-link=true
-                }}
-                Edit role
-                {{i-con glyph="chevron-right" size=11}}
-              {{/secret-link}}
-            </div>
-          {{/if}}
-            {{#if model.canGenerate}}
+<PageHeader as |p|>
+  <p.top>
+    {{key-value-header
+      baseKey=model
+      path="vault.cluster.secrets.backend.list"
+      mode=mode
+      root=root
+      showCurrent=true
+    }}
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-secret-header="true">
+      {{#if (eq mode "create") }}
+        Create a PKI Role
+      {{else if (eq mode 'edit')}}
+        Edit PKI Role
+      {{else}}
+        PKI Role <code>{{model.id}}</code>
+      {{/if}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    <div class="field is-grouped">
+      {{#if (eq mode "show") }}
+        {{#if (or model.canUpdate model.canDelete)}}
           <div class="control">
-              {{#secret-link
-                mode="credentials"
-                secret=model.id
-                queryParams=(query-params action="issue")
-                class="button has-icon-right is-ghost is-compact"
-                data-test-credentials-link=true
+            {{#secret-link
+              secret=model.id
+              mode="edit"
+              replace=true
+              class="button has-icon-right is-ghost is-compact"
+              data-test-edit-link=true
               }}
-               Generate Certificate
-               {{i-con glyph="chevron-right" size=11}}
-              {{/secret-link}}
+              Edit role
+              {{i-con glyph="chevron-right" size=11}}
+            {{/secret-link}}
           </div>
-            {{/if}}
-            {{#if model.canSign}}
-          <div class="control">
-              {{#secret-link
-                mode="credentials"
-                secret=model.id
-                queryParams=(query-params action="sign")
-                class="button has-icon-right is-ghost is-compact"
-                data-test-sign-link=true
-              }}
-                Sign Certificate
-                {{i-con glyph="chevron-right" size=11}}
-              {{/secret-link}}
-          </div>
-            {{/if}}
         {{/if}}
-      </div>
+        {{#if model.canGenerate}}
+          <div class="control">
+            {{#secret-link
+              mode="credentials"
+              secret=model.id
+              queryParams=(query-params action="issue")
+              class="button has-icon-right is-ghost is-compact"
+              data-test-credentials-link=true
+              }}
+              Generate Certificate
+              {{i-con glyph="chevron-right" size=11}}
+            {{/secret-link}}
+          </div>
+        {{/if}}
+        {{#if model.canSign}}
+          <div class="control">
+            {{#secret-link
+              mode="credentials"
+              secret=model.id
+              queryParams=(query-params action="sign")
+              class="button has-icon-right is-ghost is-compact"
+              data-test-sign-link=true
+              }}
+              Sign Certificate
+              {{i-con glyph="chevron-right" size=11}}
+            {{/secret-link}}
+          </div>
+        {{/if}}
+      {{/if}}
     </div>
-  </div>
-</header>
+  </p.levelRight>
+</PageHeader>
 
 {{#if (or (eq mode 'edit') (eq mode 'create'))}}
   {{partial 'partials/role-pki/form'}}

--- a/ui/app/templates/components/role-ssh-edit.hbs
+++ b/ui/app/templates/components/role-ssh-edit.hbs
@@ -1,12 +1,12 @@
 <PageHeader as |p|>
   <p.top>
-  {{key-value-header
-    baseKey=model
-    path="vault.cluster.secrets.backend.list"
-    mode=mode
-    root=root
-    showCurrent=true
-  }}
+    {{key-value-header
+      baseKey=model
+      path="vault.cluster.secrets.backend.list"
+      mode=mode
+      root=root
+      showCurrent=true
+    }}
   </p.top>
   <p.levelLeft>
     <h1 class="title is-3" data-test-secret-header="true">

--- a/ui/app/templates/components/role-ssh-edit.hbs
+++ b/ui/app/templates/components/role-ssh-edit.hbs
@@ -1,4 +1,5 @@
-<header class="page-header">
+<PageHeader as |p|>
+  <p.top>
   {{key-value-header
     baseKey=model
     path="vault.cluster.secrets.backend.list"
@@ -6,62 +7,61 @@
     root=root
     showCurrent=true
   }}
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3" data-test-secret-header="true">
-        {{#if (eq mode "create") }}
-          Create an SSH Role
-        {{else if (eq mode 'edit')}}
-          Edit SSH Role
-        {{else}}
-          SSH Role <code>{{model.id}}</code>
-        {{/if}}
-      </h1>
-    </div>
-    <div class="level-right">
-      <div class="field is-grouped">
-        {{#if (eq mode "show") }}
-          {{#if (or model.canUpdate model.canDelete)}}
-            <div class="control">
-              {{#secret-link
-                secret=model.id
-                mode="edit"
-                replace=true
-                class="button has-icon-right is-ghost is-compact"
-                }}
-                Edit role
-                {{i-con glyph="chevron-right" size=11}}
-              {{/secret-link}}
-            </div>
-          {{/if}}
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-secret-header="true">
+      {{#if (eq mode "create") }}
+        Create an SSH Role
+      {{else if (eq mode 'edit')}}
+        Edit SSH Role
+      {{else}}
+        SSH Role <code>{{model.id}}</code>
+      {{/if}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    <div class="field is-grouped">
+      {{#if (eq mode "show") }}
+        {{#if (or model.canUpdate model.canDelete)}}
           <div class="control">
-            {{#if (eq model.keyType "otp")}}
-              {{#secret-link
-                mode="credentials"
-                secret=model.id
-                class="button has-icon-right is-ghost is-compact"
-                data-test-backend-credentials=true
+            {{#secret-link
+              secret=model.id
+              mode="edit"
+              replace=true
+              class="button has-icon-right is-ghost is-compact"
               }}
-               Generate Credentials
-               {{i-con glyph="chevron-right" size=11}}
-              {{/secret-link}}
-            {{else}}
-              {{#secret-link
-                mode="sign"
-                secret=model.id
-                class="button has-icon-right is-ghost is-compact"
-                data-test-backend-credentials=true
-              }}
-                Sign Keys
-                {{i-con glyph="chevron-right" size=11}}
-              {{/secret-link}}
-            {{/if}}
+              Edit role
+              {{i-con glyph="chevron-right" size=11}}
+            {{/secret-link}}
           </div>
         {{/if}}
-      </div>
+        <div class="control">
+          {{#if (eq model.keyType "otp")}}
+            {{#secret-link
+              mode="credentials"
+              secret=model.id
+              class="button has-icon-right is-ghost is-compact"
+              data-test-backend-credentials=true
+            }}
+             Generate Credentials
+             {{i-con glyph="chevron-right" size=11}}
+            {{/secret-link}}
+          {{else}}
+            {{#secret-link
+              mode="sign"
+              secret=model.id
+              class="button has-icon-right is-ghost is-compact"
+              data-test-backend-credentials=true
+            }}
+              Sign Keys
+              {{i-con glyph="chevron-right" size=11}}
+            {{/secret-link}}
+          {{/if}}
+        </div>
+      {{/if}}
     </div>
-  </div>
-</header>
+  </p.levelRight>
+</PageHeader>
 
 {{#if (or (eq mode 'edit') (eq mode 'create'))}}
   {{partial 'partials/role-ssh/form'}}

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -1,12 +1,14 @@
-<header class="page-header">
-  {{key-value-header
-    baseKey=baseKey
-    path="vault.cluster.secrets.backend.list"
-    mode=mode
-    root=root
-    showCurrent=true
-  }}
-  <div class="level">
+<PageHeader as |p|>
+  <p.top>
+    {{key-value-header
+      baseKey=baseKey
+      path="vault.cluster.secrets.backend.list"
+      mode=mode
+      root=root
+      showCurrent=true
+    }}
+  </p.top>
+  <p.levelLeft>
     <h1 class="title is-3">
       {{#if (eq mode "create") }}
         Create Secret
@@ -16,8 +18,8 @@
         {{key.id}}
       {{/if}}
     </h1>
-  </div>
-</header>
+  </p.levelLeft>
+</PageHeader>
 <div class="box is-sideless has-background-grey-lighter has-slim-padding is-marginless">
   <div class="level">
     <div class="level-left">

--- a/ui/app/templates/components/secret-list-header.hbs
+++ b/ui/app/templates/components/secret-list-header.hbs
@@ -1,6 +1,6 @@
 {{#with (options-for-backend model.type) as |options|}}
-  {{#page-header as |p|}}
-    {{#p.top}}
+  <PageHeader as |p|>
+    <p.top>
       {{#key-value-header
         baseKey=baseKey
         path="vault.cluster.secrets.backend.list"
@@ -13,8 +13,8 @@
           </a>
         </li>
       {{/key-value-header}}
-    {{/p.top}}
-    {{#p.levelLeft}}
+    </p.top>
+    <p.levelLeft>
       <h1 class="title is-3">
         {{model.id}}
         <span class="tag is-outlined is-inverted has-text-grey-dark is-font-mono">
@@ -26,8 +26,8 @@
           </span>
         {{/if}}
       </h1>
-    {{/p.levelLeft}}
-    {{#p.levelRight}}
+    </p.levelLeft>
+    <p.levelRight>
        {{#unless (or isCertTab isConfigure)}}
           <div class="control">
             {{#secret-link
@@ -55,8 +55,8 @@
           </a>
         </div>
       {{/if}}
-    {{/p.levelRight}}
-  {{/page-header}}
+    </p.levelRight>
+  </PageHeader>
   {{#if options.tabs}}
     <div class="box is-bottomless is-marginless is-fullwidth is-paddingless">
       <nav class="tabs sub-nav">

--- a/ui/app/templates/components/transit-edit.hbs
+++ b/ui/app/templates/components/transit-edit.hbs
@@ -1,54 +1,54 @@
-<header class="page-header">
-  {{key-value-header
-    baseKey=key
-    path="vault.cluster.secrets.backend.list"
-    mode=mode
-    root=root
-    showCurrent=true
-  }}
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        {{#if (eq mode "create") }}
-          Create Encryption Key
-        {{else if (eq mode "edit") }}
-          Edit Encryption Key
-        {{else}}
-          Encryption Key <code>{{key.id}}</code>
-        {{/if}}
-      </h1>
-    </div>
-    <div class="level-right">
-      <div class="field is-grouped">
-        {{#if (eq mode "show") }}
-          {{#if (or capabilities.canUpdate capabilities.canDelete)}}
-            <div class="control">
-              {{#secret-link
-                secret=key.id
-                mode="edit"
-                replace=true
-                class="button has-icon-right is-ghost is-compact"
-                }}
-                Edit encryption key
-                {{i-con glyph="chevron-right" size=11}}
-              {{/secret-link}}
-            </div>
-          {{/if}}
+<PageHeader as |p|>
+  <p.top>
+    {{key-value-header
+      baseKey=key
+      path="vault.cluster.secrets.backend.list"
+      mode=mode
+      root=root
+      showCurrent=true
+    }}
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{#if (eq mode "create") }}
+        Create Encryption Key
+      {{else if (eq mode "edit") }}
+        Edit Encryption Key
+      {{else}}
+        Encryption Key <code>{{key.id}}</code>
+      {{/if}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    <div class="field is-grouped">
+      {{#if (eq mode "show") }}
+        {{#if (or capabilities.canUpdate capabilities.canDelete)}}
           <div class="control">
             {{#secret-link
-              mode="actions"
               secret=key.id
+              mode="edit"
+              replace=true
               class="button has-icon-right is-ghost is-compact"
-              data-test-transit-key-actions-link=true
-            }}
-              Key actions
+              }}
+              Edit encryption key
               {{i-con glyph="chevron-right" size=11}}
             {{/secret-link}}
           </div>
         {{/if}}
-      </div>
+        <div class="control">
+          {{#secret-link
+            mode="actions"
+            secret=key.id
+            class="button has-icon-right is-ghost is-compact"
+            data-test-transit-key-actions-link=true
+          }}
+            Key actions
+            {{i-con glyph="chevron-right" size=11}}
+          {{/secret-link}}
+        </div>
+      {{/if}}
     </div>
-  </div>
-</header>
+  </p.levelRight>
+</PageHeader>
 
 {{partial (concat 'partials/transit-form-' mode)}}

--- a/ui/app/templates/components/upgrade-page.hbs
+++ b/ui/app/templates/components/upgrade-page.hbs
@@ -1,8 +1,10 @@
-<header class="page-header">
-  <h1 class="title is-3">
-    {{title}}
-  </h1>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{title}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 <div class="box is-sideless is-bottomless has-text-centered has-background-white-bis">
   <p class="has-text-grey-dark">

--- a/ui/app/templates/partials/replication/enable.hbs
+++ b/ui/app/templates/partials/replication/enable.hbs
@@ -1,20 +1,18 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        {{#if initialReplicationMode}}
-          {{#if (eq initialReplicationMode 'dr')}}
-            Enable Disaster Recovery Replication
-          {{else if (eq initialReplicationMode 'performance')}}
-            Enable Performance Replication
-          {{/if}}
-        {{else}}
-          Enable Replication
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{#if initialReplicationMode}}
+        {{#if (eq initialReplicationMode 'dr')}}
+          Enable Disaster Recovery Replication
+        {{else if (eq initialReplicationMode 'performance')}}
+          Enable Performance Replication
         {{/if}}
-      </h1>
-    </div>
-  </div>
-</header>
+      {{else}}
+        Enable Replication
+      {{/if}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 <form
   onsubmit={{

--- a/ui/app/templates/partials/replication/mode-summary.hbs
+++ b/ui/app/templates/partials/replication/mode-summary.hbs
@@ -1,13 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Replication
-      </h1>
-    </div>
-  </div>
-</header>
-
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Replication
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 <div class="box is-sideless is-fullwidth is-marginless">
   <h3 class="title is-flex-center is-5 is-marginless">
     {{i-con class="has-text-grey is-medium" glyph="replication" size=20}}

--- a/ui/app/templates/partials/tools/hash.hbs
+++ b/ui/app/templates/partials/tools/hash.hbs
@@ -1,12 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h3 class="title is-3">
-        Hash Data
-      </h3>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Hash Data
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{#if sum}}
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/partials/tools/lookup.hbs
+++ b/ui/app/templates/partials/tools/lookup.hbs
@@ -1,12 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h3 class="title is-3">
-        Lookup Token
-      </h3>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Lookup Token
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{#if (or creation_time creation_ttl)}}
   <div class="box is-fullwidth is-sideless is-paddingless is-marginless">

--- a/ui/app/templates/partials/tools/random.hbs
+++ b/ui/app/templates/partials/tools/random.hbs
@@ -1,12 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h3 class="title is-3">
-        Random Bytes
-      </h3>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Random Bytes
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{#if random_bytes}}
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/partials/tools/rewrap.hbs
+++ b/ui/app/templates/partials/tools/rewrap.hbs
@@ -1,12 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h3 class="title is-3">
-        Rewrap Token
-      </h3>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Rewrap Token
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{#if rewrap_token}}
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/partials/tools/unwrap.hbs
+++ b/ui/app/templates/partials/tools/unwrap.hbs
@@ -1,12 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h3 class="title is-3">
-        Unwrap Data
-      </h3>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Unwrap Data
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{#if unwrap_data}}
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/partials/tools/wrap.hbs
+++ b/ui/app/templates/partials/tools/wrap.hbs
@@ -1,12 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h3 class="title is-3">
-        Wrap Data
-      </h3>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Wrap Data
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{#if token}}
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/vault/cluster/access/error.hbs
+++ b/ui/app/templates/vault/cluster/access/error.hbs
@@ -1,19 +1,17 @@
     {{#if (eq model.httpStatus 404)}}
       {{not-found model=model}}
     {{else}}
-      <header class="page-header">
-        <div class="level">
-          <div class="level-left">
-            <h1 class="title is-3 has-text-grey">
-              {{#if (eq model.httpStatus 403)}}
-                Not authorized
-              {{else}}
-                Error
-              {{/if}}
-            </h1>
-          </div>
-        </div>
-      </header>
+      <PageHeader as |p|>
+        <p.levelLeft>
+          <h1 class="title is-3 has-text-grey">
+            {{#if (eq model.httpStatus 403)}}
+              Not authorized
+            {{else}}
+              Error
+            {{/if}}
+          </h1>
+        </p.levelLeft>
+      </PageHeader>
       <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered">
         {{#if model.message}}
           <p>{{model.message}}</p>

--- a/ui/app/templates/vault/cluster/access/identity/aliases/add.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/add.hbs
@@ -1,11 +1,9 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Add {{lowercase (humanize model.identityType)}} for {{model.canonicalId}}
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Add {{lowercase (humanize model.identityType)}} for {{model.canonicalId}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{identity/edit-form model=model onSave=(perform navAfterSave)}}

--- a/ui/app/templates/vault/cluster/access/identity/aliases/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/edit.hbs
@@ -1,11 +1,9 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Edit {{model.name}}
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Edit {{model.name}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{identity/edit-form mode="edit" model=model onSave=(perform navAfterSave)}}

--- a/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/aliases/show.hbs
@@ -1,28 +1,28 @@
-<header class="page-header">
-  <nav class="breadcrumb">
-    <ul>
-      <li>
-        <span class="sep">&#x0002f;</span>
-        <a href={{href-to "vault.cluster.access.identity.aliases"}}>
-          {{pluralize (humanize model.identityType)}}
-        </a>
-      </li>
-    </ul>
-  </nav>
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        {{model.name}}
-      </h1>
-    </div>
-    <div class="level-right">
-      <a href="{{href-to 'vault.cluster.access.identity.aliases.edit' model.id}}" class="button has-icon-right is-ghost is-compact" data-test-alias-edit-link=true>
-        Edit {{lowercase (humanize model.identityType)}}
-        {{i-con glyph="chevron-right" size=11}}
-      </a>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.top>
+    <nav class="breadcrumb">
+      <ul>
+        <li>
+          <span class="sep">&#x0002f;</span>
+          <a href={{href-to "vault.cluster.access.identity.aliases"}}>
+            {{pluralize (humanize model.identityType)}}
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{model.name}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    <a href="{{href-to 'vault.cluster.access.identity.aliases.edit' model.id}}" class="button has-icon-right is-ghost is-compact" data-test-alias-edit-link=true>
+      Edit {{lowercase (humanize model.identityType)}}
+      {{i-con glyph="chevron-right" size=11}}
+    </a>
+  </p.levelRight>
+</PageHeader>
 <div class="box is-sideless is-fullwidth is-paddingless is-marginless">
   <nav class="tabs sub-nav">
     <ul>

--- a/ui/app/templates/vault/cluster/access/identity/create.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/create.hbs
@@ -1,11 +1,9 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Add {{model.identityType}}
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Add {{model.identityType}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{identity/edit-form model=model onSave=(perform navAfterSave)}}

--- a/ui/app/templates/vault/cluster/access/identity/edit.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/edit.hbs
@@ -1,11 +1,9 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Edit {{model.name}}
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Edit {{model.name}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{identity/edit-form mode="edit" model=model onSave=(perform navAfterSave)}}

--- a/ui/app/templates/vault/cluster/access/identity/merge.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/merge.hbs
@@ -1,11 +1,9 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Merge entities
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Merge entities
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{identity/edit-form mode="merge" model=model onSave=(perform navAfterSave)}}

--- a/ui/app/templates/vault/cluster/access/identity/show.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/show.hbs
@@ -1,34 +1,34 @@
-<header class="page-header">
-  <nav class="breadcrumb">
-    <ul>
-      <li>
-        <span class="sep">&#x0002f;</span>
-        <a href={{href-to "vault.cluster.access.identity.index"}}>
-          {{capitalize (pluralize model.identityType)}}
-        </a>
-      </li>
-    </ul>
-  </nav>
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        {{model.name}}
-      </h1>
-    </div>
-    <div class="level-right">
-      {{#unless (or (and (eq model.identityType "group") (eq model.type "internal")) model.alias)}}
-        <a href="{{href-to 'vault.cluster.access.identity.aliases.add' (pluralize model.identityType) model.id}}" class="button has-icon-right is-ghost is-compact" data-test-entity-create-link=true>
-          Add alias
-          {{i-con glyph="chevron-right" size=11}}
-        </a>
-      {{/unless}}
-      <a href="{{href-to 'vault.cluster.access.identity.edit' (pluralize model.identityType) model.id}}" class="button has-icon-right is-ghost is-compact" data-test-entity-edit-link=true>
-        Edit {{model.identityType}}
+<PageHeader as |p|>
+  <p.top>
+    <nav class="breadcrumb">
+      <ul>
+        <li>
+          <span class="sep">&#x0002f;</span>
+          <a href={{href-to "vault.cluster.access.identity.index"}}>
+            {{capitalize (pluralize model.identityType)}}
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{model.name}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    {{#unless (or (and (eq model.identityType "group") (eq model.type "internal")) model.alias)}}
+      <a href="{{href-to 'vault.cluster.access.identity.aliases.add' (pluralize model.identityType) model.id}}" class="button has-icon-right is-ghost is-compact" data-test-entity-create-link=true>
+        Add alias
         {{i-con glyph="chevron-right" size=11}}
       </a>
-    </div>
-  </div>
-</header>
+    {{/unless}}
+    <a href="{{href-to 'vault.cluster.access.identity.edit' (pluralize model.identityType) model.id}}" class="button has-icon-right is-ghost is-compact" data-test-entity-edit-link=true>
+      Edit {{model.identityType}}
+      {{i-con glyph="chevron-right" size=11}}
+    </a>
+  </p.levelRight>
+</PageHeader>
 <div class="box is-sideless is-fullwidth is-paddingless is-marginless">
   <nav class="tabs sub-nav">
     <ul>

--- a/ui/app/templates/vault/cluster/access/leases/error.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/error.hbs
@@ -1,12 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        {{#link-to "vault.cluster.access.leases"}}Leases{{/link-to}}
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{#link-to "vault.cluster.access.leases"}}Leases{{/link-to}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{#unless (or (eq model.httpStatus 400) (eq model.httpStatus 404))}}
   {{model.message}}

--- a/ui/app/templates/vault/cluster/access/leases/index.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/index.hbs
@@ -1,12 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Lookup a Lease
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Lookup a Lease
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 <form {{action "lookupLease" leaseId on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/vault/cluster/access/leases/list.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/list.hbs
@@ -1,64 +1,64 @@
-<header class="page-header">
-  {{key-value-header
-    baseKey=baseKey
-    path="vault.cluster.access.leases.list"
-    model=clusterController.model.name
-    root=backendCrumb
-    showCurrent=true
-  }}
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        {{#link-to "vault.cluster.access.leases.list-root"}}
-          Leases
-        {{/link-to}}
-      </h1>
-    </div>
-    <div class="level-right">
-      <div class="field is-grouped">
-        {{#if (not-eq baseKey.id '')}}
-          <div class="control">
-            {{#if (and capabilities.forceRevokePrefix.canUpdate (not confirmingRevoke))}}
-              {{#confirm-action
-                buttonClasses="button is-ghost is-compact"
-                onConfirmAction=(action "revokePrefix" baseKey.id true)
-                confirmMessage= (concat
-                  "Confirming removes all leases under "
-                  baseKey.id
-                  " and disregards any errors encountered."
-                )
-                confirmButtonText=(concat "Revoke " baseKey.id)
-                confirmButtonClasses="button is-danger is-outlined is-compact"
-                cancelButtonText="Cancel"
-                cancelButtonClasses="button is-outlined is-compact"
-                showConfirm=confirmingForceRevoke
+<PageHeader as |p|>
+  <p.top>
+    {{key-value-header
+      baseKey=baseKey
+      path="vault.cluster.access.leases.list"
+      model=clusterController.model.name
+      root=backendCrumb
+      showCurrent=true
+    }}
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{#link-to "vault.cluster.access.leases.list-root"}}
+        Leases
+      {{/link-to}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    <div class="field is-grouped">
+      {{#if (not-eq baseKey.id '')}}
+        <div class="control">
+          {{#if (and capabilities.forceRevokePrefix.canUpdate (not confirmingRevoke))}}
+            {{#confirm-action
+              buttonClasses="button is-ghost is-compact"
+              onConfirmAction=(action "revokePrefix" baseKey.id true)
+              confirmMessage= (concat
+              "Confirming removes all leases under "
+              baseKey.id
+              " and disregards any errors encountered."
+              )
+              confirmButtonText=(concat "Revoke " baseKey.id)
+              confirmButtonClasses="button is-danger is-outlined is-compact"
+              cancelButtonText="Cancel"
+              cancelButtonClasses="button is-outlined is-compact"
+              showConfirm=confirmingForceRevoke
               }}
-                Force revoke prefix
-              {{/confirm-action}}
-            {{/if}}
-          </div>
-          <div class="control">
-            {{#if (and capabilities.revokePrefix.canUpdate (not confirmingForceRevoke))}}
-              {{#confirm-action
-                buttonClasses="button is-ghost is-compact"
-                onConfirmAction=(action "revokePrefix" baseKey.id)
-                confirmMessage= (concat "Confirming will remove all leases under " baseKey.id)
-                confirmButtonText=(concat "Revoke " baseKey.id)
-                confirmButtonClasses="button is-danger is-outlined is-compact"
-                cancelButtonText="Cancel"
-                cancelButtonClasses="button is-outlined is-compact"
-                showConfirm=confirmingRevoke
-                data-test-lease-revoke-prefix=true
+              Force revoke prefix
+            {{/confirm-action}}
+          {{/if}}
+        </div>
+        <div class="control">
+          {{#if (and capabilities.revokePrefix.canUpdate (not confirmingForceRevoke))}}
+            {{#confirm-action
+              buttonClasses="button is-ghost is-compact"
+              onConfirmAction=(action "revokePrefix" baseKey.id)
+              confirmMessage= (concat "Confirming will remove all leases under " baseKey.id)
+              confirmButtonText=(concat "Revoke " baseKey.id)
+              confirmButtonClasses="button is-danger is-outlined is-compact"
+              cancelButtonText="Cancel"
+              cancelButtonClasses="button is-outlined is-compact"
+              showConfirm=confirmingRevoke
+              data-test-lease-revoke-prefix=true
               }}
-                Revoke prefix
-              {{/confirm-action}}
-            {{/if}}
-          </div>
-        {{/if}}
-      </div>
+              Revoke prefix
+            {{/confirm-action}}
+          {{/if}}
+        </div>
+      {{/if}}
     </div>
-  </div>
-</header>
+  </p.levelRight>
+</PageHeader>
 <div class="box is-sideless has-background-grey-lighter has-short-padding is-marginless">
   <div class="level">
     <div class="level-left">

--- a/ui/app/templates/vault/cluster/access/leases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/show.hbs
@@ -1,21 +1,21 @@
-<header class="page-header">
-  {{key-value-header
-    baseKey=baseKey
-    path="vault.cluster.access.leases.list"
-    root=backendCrumb
-    showCurrent=true
-    linkToPaths=capabilities.leases.canList
-  }}
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        {{#link-to "vault.cluster.access.leases" }}
-          Leases
-        {{/link-to}}
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.top>
+    {{key-value-header
+      baseKey=baseKey
+      path="vault.cluster.access.leases.list"
+      root=backendCrumb
+      showCurrent=true
+      linkToPaths=capabilities.leases.canList
+    }}
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{#link-to "vault.cluster.access.leases" }}
+        Leases
+      {{/link-to}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 <div class="field box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#info-table-row label="Issue time" value=model.issueTime}}
     {{moment-format model.issueTime 'MMM DD, YYYY hh:mm:ss A'}}

--- a/ui/app/templates/vault/cluster/access/method/section.hbs
+++ b/ui/app/templates/vault/cluster/access/method/section.hbs
@@ -1,35 +1,35 @@
-<header class="page-header">
-  {{key-value-header
-    baseKey=model
-    path="vault.cluster.access.method"
-    root=root
-    showCurrent=true
-  }}
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        {{capitalize model.type}}
-      </h1>
-    </div>
-    <div class="level-right">
-      {{#if (eq section "configuration")}}
-        <div class="field is-grouped">
-          <div class="control">
-            {{#link-to
-              "vault.cluster.settings.auth.configure"
-              model.id
-              class="button is-ghost has-icon-right is-compact"
-              data-test-configure-link=true
-            }}
-              Configure
-              {{i-con glyph="chevron-right" size=11}}
-            {{/link-to}}
-          </div>
+<PageHeader as |p|>
+  <p.top>
+    {{key-value-header
+      baseKey=model
+      path="vault.cluster.access.method"
+      root=root
+      showCurrent=true
+    }}
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{capitalize model.type}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    {{#if (eq section "configuration")}}
+      <div class="field is-grouped">
+        <div class="control">
+          {{#link-to
+            "vault.cluster.settings.auth.configure"
+            model.id
+            class="button is-ghost has-icon-right is-compact"
+            data-test-configure-link=true
+          }}
+            Configure
+            {{i-con glyph="chevron-right" size=11}}
+          {{/link-to}}
         </div>
-      {{/if}}
-    </div>
-  </div>
-</header>
+      </div>
+    {{/if}}
+  </p.levelRight>
+</PageHeader>
 
 {{section-tabs model 'authShow'}}
 {{component (concat "auth-method/" section) model=model}}

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -1,18 +1,16 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Authentication Methods
-      </h1>
-    </div>
-    <div class="level-right">
-      {{#link-to 'vault.cluster.settings.auth.enable' class="button has-icon-right is-ghost is-compact"}}
-        Enable new method
-        {{i-con glyph="chevron-right" size=11}}
-      {{/link-to}}
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Authentication Methods
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    {{#link-to 'vault.cluster.settings.auth.enable' class="button has-icon-right is-ghost is-compact"}}
+      Enable new method
+      {{i-con glyph="chevron-right" size=11}}
+    {{/link-to}}
+  </p.levelRight>
+</PageHeader>
 
 {{#each (sort-by "path" model) as |method|}}
   {{#linked-block

--- a/ui/app/templates/vault/cluster/error.hbs
+++ b/ui/app/templates/vault/cluster/error.hbs
@@ -1,19 +1,17 @@
 {{#if (eq model.httpStatus 404)}}
   {{not-found model=model}}
 {{else}}
-  <header class="page-header">
-    <div class="level">
-      <div class="level-left">
-        <h1 class="title is-3 has-text-grey">
-          {{#if (eq model.httpStatus 403)}}
-            Not authorized
-          {{else}}
-            Error
-          {{/if}}
-        </h1>
-      </div>
-    </div>
-  </header>
+  <PageHeader as |p|>
+    <p.levelLeft>
+      <h1 class="title is-3 has-text-grey">
+        {{#if (eq model.httpStatus 403)}}
+          Not authorized
+        {{else}}
+          Error
+        {{/if}}
+      </h1>
+    </p.levelLeft>
+  </PageHeader>
   <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered">
     {{#if (and
       (eq model.httpStatus 403)

--- a/ui/app/templates/vault/cluster/policies/create.hbs
+++ b/ui/app/templates/vault/cluster/policies/create.hbs
@@ -1,19 +1,18 @@
-<header class="page-header">
-  <div class="breadcrumb">
-    <a href="{{href-to 'vault.cluster.policies' policyType}}" data-test-policy-list-link=true>
-      <span class="sep">&#x0002f;</span>
-      {{uppercase policyType}} Policies
-    </a>
-  </div>
-
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Add {{uppercase policyType}} policy
-      </h1>
+<PageHeader as |p|>
+  <p.top>
+    <div class="breadcrumb">
+      <a href="{{href-to 'vault.cluster.policies' policyType}}" data-test-policy-list-link=true>
+        <span class="sep">&#x0002f;</span>
+        {{uppercase policyType}} Policies
+      </a>
     </div>
-  </div>
-</header>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Add {{uppercase policyType}} policy
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 <form {{ action "savePolicy" model on="submit"}}>
   <div class="box is-bottomless is-fullwidth is-marginless">

--- a/ui/app/templates/vault/cluster/policies/index.hbs
+++ b/ui/app/templates/vault/cluster/policies/index.hbs
@@ -1,24 +1,22 @@
 {{#if (or (eq policyType "acl") (has-feature "Sentinel"))}}
-  <header class="page-header">
-    <div class="level">
-      <div class="level-left">
-        <h1 class="title is-3">
-          {{uppercase policyType}} Policies
-          {{#unless (eq policyType "acl")}}
-            <span class="tag" aria-label="Enforcement level: {{model.enforcementLevel}}">
-              Sentinel
-            </span>
-          {{/unless}}
-        </h1>
-      </div>
-      <div class="level-right">
-        <a href="{{href-to 'vault.cluster.policies.create'}}" class="button has-icon-right is-ghost is-compact" data-test-policy-create-link=true>
-          Create {{uppercase policyType}} policy
-          {{i-con glyph="chevron-right" size=11}}
-        </a>
-      </div>
-    </div>
-  </header>
+  <PageHeader as |p|>
+    <p.levelLeft>
+      <h1 class="title is-3">
+        {{uppercase policyType}} Policies
+        {{#unless (eq policyType "acl")}}
+          <span class="tag" aria-label="Enforcement level: {{model.enforcementLevel}}">
+            Sentinel
+          </span>
+        {{/unless}}
+      </h1>
+    </p.levelLeft>
+    <p.levelRight>
+      <a href="{{href-to 'vault.cluster.policies.create'}}" class="button has-icon-right is-ghost is-compact" data-test-policy-create-link=true>
+        Create {{uppercase policyType}} policy
+        {{i-con glyph="chevron-right" size=11}}
+      </a>
+    </p.levelRight>
+  </PageHeader>
   <div class="box is-sideless has-background-grey-lighter has-short-padding is-marginless">
     <div class="level">
       <div class="level-left">

--- a/ui/app/templates/vault/cluster/policy/edit.hbs
+++ b/ui/app/templates/vault/cluster/policy/edit.hbs
@@ -1,23 +1,23 @@
-<header class="page-header">
-  <div class="breadcrumb">
-    <a href="{{href-to 'vault.cluster.policies' policyType}}" data-test-policy-list-link=true>
-      <span class="sep">&#x0002f;</span>
-      {{uppercase policyType}} Policies
-    </a>
-  </div>
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        {{model.id}}
-        {{#if model.enforcementLevel}}
-          <span class="tag is-medium" aria-label="Enforcement level: {{model.enforcementLevel}}">
-            {{model.enforcementLevel}}
-          </span>
-        {{/if}}
-      </h1>
+<PageHeader as |p|>
+  <p.top>
+    <div class="breadcrumb">
+      <a href="{{href-to 'vault.cluster.policies' policyType}}" data-test-policy-list-link=true>
+        <span class="sep">&#x0002f;</span>
+        {{uppercase policyType}} Policies
+      </a>
     </div>
-  </div>
-</header>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      {{model.id}}
+      {{#if model.enforcementLevel}}
+        <span class="tag is-medium" aria-label="Enforcement level: {{model.enforcementLevel}}">
+          {{model.enforcementLevel}}
+        </span>
+      {{/if}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 <form {{action "savePolicy" model on="submit"}}>
   <div class="box is-bottomless is-fullwidth is-marginless">

--- a/ui/app/templates/vault/cluster/policy/error.hbs
+++ b/ui/app/templates/vault/cluster/policy/error.hbs
@@ -1,19 +1,17 @@
     {{#if (eq model.httpStatus 404)}}
       {{not-found model=model}}
     {{else}}
-      <header class="page-header">
-        <div class="level">
-          <div class="level-left">
-            <h1 class="title is-3 has-text-grey">
-              {{#if (eq model.httpStatus 403)}}
-                Not authorized
-              {{else}}
-                Error
-              {{/if}}
-            </h1>
-          </div>
-        </div>
-      </header>
+      <PageHeader as |p|>
+        <p.levelLeft>
+          <h1 class="title is-3 has-text-grey">
+            {{#if (eq model.httpStatus 403)}}
+              Not authorized
+            {{else}}
+              Error
+            {{/if}}
+          </h1>
+        </p.levelLeft>
+      </PageHeader>
       <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered">
         {{#if model.message}}
           <p>{{model.message}}</p>

--- a/ui/app/templates/vault/cluster/policy/show.hbs
+++ b/ui/app/templates/vault/cluster/policy/show.hbs
@@ -1,25 +1,25 @@
-<header class="page-header">
-  <nav class="breadcrumb">
-    <li>
-      <a href="{{href-to 'vault.cluster.policies'}}" data-test-policy-list-link=true>
-        <span class="sep">&#x0002f;</span>
-        {{uppercase policyType}} Policies
-      </a>
-    </li>
-  </nav>
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3" data-test-policy-name="true">
-        {{model.id}}
-        {{#if model.enforcementLevel}}
-          <span class="tag" aria-label="Enforcement level: {{model.enforcementLevel}}">
-            {{model.enforcementLevel}}
-          </span>
-        {{/if}}
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.top>
+    <nav class="breadcrumb">
+      <li>
+        <a href="{{href-to 'vault.cluster.policies'}}" data-test-policy-list-link=true>
+          <span class="sep">&#x0002f;</span>
+          {{uppercase policyType}} Policies
+        </a>
+      </li>
+    </nav>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-policy-name="true">
+      {{model.id}}
+      {{#if model.enforcementLevel}}
+        <span class="tag" aria-label="Enforcement level: {{model.enforcementLevel}}">
+          {{model.enforcementLevel}}
+        </span>
+      {{/if}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 <div class="box is-bottomless is-fullwidth is-marginless">
   <div class="level is-mobile">
     <div class="level-left">

--- a/ui/app/templates/vault/cluster/replication/index.hbs
+++ b/ui/app/templates/vault/cluster/replication/index.hbs
@@ -1,13 +1,11 @@
 {{#if (eq model.mode 'unsupported')}}
-   <header class="page-header">
-    <div class="level">
-      <div class="level-left">
-        <h1 class="title is-3 has-text-grey">
-          Replication unsupported
-        </h1>
-      </div>
-    </div>
-  </header>
+  <PageHeader as |p|>
+    <p.levelLeft>
+      <h1 class="title is-3 has-text-grey">
+        Replication unsupported
+      </h1>
+    </p.levelLeft>
+  </PageHeader>
   <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered">
     <p>
       The current cluster configuration does not support replication.

--- a/ui/app/templates/vault/cluster/replication/mode.hbs
+++ b/ui/app/templates/vault/cluster/replication/mode.hbs
@@ -1,33 +1,30 @@
 {{#if model.replicationAttrs.replicationEnabled}}
-  <header class="page-header">
-    <div class="level">
-      <div class="level-left">
-        <h1 class="title is-3" data-test-replication-title=true>
-          {{#if (eq replicationMode 'dr')}}
-            Disaster Recovery
-          {{else if (eq replicationMode 'performance')}}
-            Performance
-          {{/if}}
-          <span class="tag is-light has-text-grey-dark" data-test-replication-mode-display=true>
-              {{model.replicationAttrs.modeForUrl}}
-          </span>
-          {{#if secondaryId}}
-            <span class="tag is-light has-text-grey-dark">
-              <code>
-                {{model.replicationAttrs.secondaryId}}
-              </code>
-            </span>
-          {{/if}}
-          <span class="tag is-light">
-            <code class="has-text-grey-dark">
-              {{model.replicationAttrs.clusterIdDisplay}}
+  <PageHeader as |p|>
+    <p.levelLeft>
+      <h1 class="title is-3" data-test-replication-title=true>
+        {{#if (eq replicationMode 'dr')}}
+          Disaster Recovery
+        {{else if (eq replicationMode 'performance')}}
+          Performance
+        {{/if}}
+        <span class="tag is-light has-text-grey-dark" data-test-replication-mode-display=true>
+            {{model.replicationAttrs.modeForUrl}}
+        </span>
+        {{#if secondaryId}}
+          <span class="tag is-light has-text-grey-dark">
+            <code>
+              {{model.replicationAttrs.secondaryId}}
             </code>
           </span>
-        </h1>
-      </div>
-    </div>
-  </header>
-
+        {{/if}}
+        <span class="tag is-light">
+          <code class="has-text-grey-dark">
+            {{model.replicationAttrs.clusterIdDisplay}}
+          </code>
+        </span>
+      </h1>
+    </p.levelLeft>
+  </PageHeader>
   <div class="box is-bottomless is-fullwidth is-paddingless is-marginless">
     <nav class="tabs sub-nav">
       <ul>

--- a/ui/app/templates/vault/cluster/secrets/backend/error.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/error.hbs
@@ -1,31 +1,31 @@
 <div class="box is-shadowless">
-  <header class="page-header">
-    <nav class="breadcrumb">
-      <li>
-        <a href={{href-to  params=(if model.backend
-            (array "vault.cluster.secrets.backend.list-root")
-            (array "vault.cluster.secrets")
-          )
-        }}>
-          <span class="sep">&#x0002f;</span>
-          {{if model.backend model.backend 'secrets'}}
-        </a>
-      </li>
-    </nav>
-    <div class="level">
-      <div class="level-left">
-        <h1 class="title is-3 has-text-grey">
-          {{#if (eq model.httpStatus 404)}}
-            404 Not Found
-          {{else if (eq model.httpStatus 403)}}
-            Not Authorized
-          {{else}}
-            Error
-          {{/if}}
-        </h1>
-      </div>
-    </div>
-  </header>
+  <PageHeader as |p|>
+    <p.top>
+      <nav class="breadcrumb">
+        <li>
+          <a href={{href-to  params=(if model.backend
+              (array "vault.cluster.secrets.backend.list-root")
+              (array "vault.cluster.secrets")
+            )
+          }}>
+            <span class="sep">&#x0002f;</span>
+            {{if model.backend model.backend 'secrets'}}
+          </a>
+        </li>
+      </nav>
+    </p.top>
+    <p.levelLeft>
+      <h1 class="title is-3 has-text-grey">
+        {{#if (eq model.httpStatus 404)}}
+          404 Not Found
+        {{else if (eq model.httpStatus 403)}}
+          Not Authorized
+        {{else}}
+          Error
+        {{/if}}
+      </h1>
+    </p.levelLeft>
+  </PageHeader>
   <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered">
     {{#if (eq model.httpStatus 404)}}
       <p data-test-secret-not-found>

--- a/ui/app/templates/vault/cluster/secrets/backend/sign.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/sign.hbs
@@ -1,34 +1,34 @@
-<header class="page-header">
-  <nav class="breadcrumb">
-    <ul>
-      <li>
-        <span class="sep">&#x0002f;</span>
-        <a href={{href-to "vault.cluster.secrets.backend" backend.id}}>
-          ssh
-        </a>
-      </li>
-      <li class="is-active">
-        <span class="sep">&#x0002f;</span>
-        <a href={{href-to "vault.cluster.secrets.backend" backend.id}}>
-          sign
-        </a>
-      </li>
-      <li>
-        <span class="sep">&#x0002f;</span>
-        <a href={{href-to "vault.cluster.secrets.backend.show" model.role.name}}>
-          {{model.role.name}}
-        </a>
-      </li>
-    </ul>
-  </nav>
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3 ">
-        Sign SSH Key
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.top>
+    <nav class="breadcrumb">
+      <ul>
+        <li>
+          <span class="sep">&#x0002f;</span>
+          <a href={{href-to "vault.cluster.secrets.backend" backend.id}}>
+            ssh
+          </a>
+        </li>
+        <li class="is-active">
+          <span class="sep">&#x0002f;</span>
+          <a href={{href-to "vault.cluster.secrets.backend" backend.id}}>
+            sign
+          </a>
+        </li>
+        <li>
+          <span class="sep">&#x0002f;</span>
+          <a href={{href-to "vault.cluster.secrets.backend.show" model.role.name}}>
+            {{model.role.name}}
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3 ">
+      Sign SSH Key
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{#if model.signedKey}}
   <div class="box is-fullwidth is-sideless is-paddingless is-marginless">

--- a/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/transit-actions-layout.hbs
@@ -15,37 +15,37 @@
     {{/each}}
   {{/menu-sidebar}}
   <div class="column is-10">
-    <header class="page-header">
-      {{key-value-header
-        baseKey=model
-        path="vault.cluster.secrets.backend.list"
-        mode=mode
-        root=backendCrumb
-        showCurrent=true
-      }}
-      <div class="level">
-        <div class="level-left">
-          <h1 class="title is-3">
-            {{model.id}}
-          </h1>
-        </div>
-        <div class="level-right">
-          {{#secret-link
-            mode="show"
-            secret=model.id
-            class="button has-icon-right is-ghost is-compact"
-          }}
-            Details
-            {{i-con glyph="chevron-right" size=11}}
-          {{/secret-link}}
-        </div>
-      </div>
-      {{transit-key-actions
-        selectedAction=selectedAction
-        backend=backend
-        key=model
-        capabilities=capabilities
-      }}
-    </header>
+    <PageHeader as |p|>
+      <p.top>
+        {{key-value-header
+          baseKey=model
+          path="vault.cluster.secrets.backend.list"
+          mode=mode
+          root=backendCrumb
+          showCurrent=true
+        }}
+      </p.top>
+      <p.levelLeft>
+        <h1 class="title is-3">
+          {{model.id}}
+        </h1>
+      </p.levelLeft>
+      <p.levelRight>
+        {{#secret-link
+          mode="show"
+          secret=model.id
+          class="button has-icon-right is-ghost is-compact"
+        }}
+          Details
+          {{i-con glyph="chevron-right" size=11}}
+        {{/secret-link}}
+      </p.levelRight>
+    </PageHeader>
+    {{transit-key-actions
+      selectedAction=selectedAction
+      backend=backend
+      key=model
+      capabilities=capabilities
+    }}
   </div>
 </div>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -1,18 +1,16 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Secrets Engines
-      </h1>
-    </div>
-    <div class="level-right">
-      {{#link-to 'vault.cluster.settings.mount-secret-backend' class="button has-icon-right is-ghost is-compact"}}
-        Enable new engine
-        {{i-con glyph="chevron-right" size=11}}
-      {{/link-to}}
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Secrets Engines
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    {{#link-to 'vault.cluster.settings.mount-secret-backend' class="button has-icon-right is-ghost is-compact"}}
+      Enable new engine
+      {{i-con glyph="chevron-right" size=11}}
+    {{/link-to}}
+  </p.levelRight>
+</PageHeader>
 
 {{#each supportedBackends as |backend|}}
   {{#linked-block

--- a/ui/app/templates/vault/cluster/settings/auth/configure.hbs
+++ b/ui/app/templates/vault/cluster/settings/auth/configure.hbs
@@ -1,33 +1,33 @@
-<header class="page-header">
-  {{key-value-header
-    baseKey=model
-    path="vault.cluster.access.method"
-    root=root
-    showCurrent=true
-  }}
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Configure {{get (find-by "type" model.type (mountable-auth-methods)) "displayName"}}
-      </h1>
-    </div>
-    <div class="level-right">
-      <div class="field is-grouped">
-        <div class="control">
-          {{#link-to
-            "vault.cluster.access.method"
-            model.id
-            class="button is-ghost has-icon-right is-compact"
-            data-test-backend-view-link=true
-          }}
-            View method
-            {{i-con glyph="chevron-right" size=11}}
-          {{/link-to}}
-        </div>
+<PageHeader as |p|>
+  <p.top>
+    {{key-value-header
+      baseKey=model
+      path="vault.cluster.access.method"
+      root=root
+      showCurrent=true
+    }}
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Configure {{get (find-by "type" model.type (mountable-auth-methods)) "displayName"}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    <div class="field is-grouped">
+      <div class="control">
+        {{#link-to
+          "vault.cluster.access.method"
+          model.id
+          class="button is-ghost has-icon-right is-compact"
+          data-test-backend-view-link=true
+        }}
+          View method
+          {{i-con glyph="chevron-right" size=11}}
+        {{/link-to}}
       </div>
     </div>
-  </div>
-</header>
+  </p.levelRight>
+</PageHeader>
 
 {{section-tabs model}}
 {{outlet}}

--- a/ui/app/templates/vault/cluster/settings/configure-secret-backend.hbs
+++ b/ui/app/templates/vault/cluster/settings/configure-secret-backend.hbs
@@ -1,33 +1,33 @@
-<header class="page-header">
-  {{key-value-header
-    baseKey=model
-    path="vault.cluster.secrets.backend"
-    root=root
-    showCurrent=true
-  }}
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Configure {{get (options-for-backend model.type) "displayName"}}
-      </h1>
-    </div>
-    <div class="level-right">
-      <div class="field is-grouped">
-        <div class="control">
-          {{#link-to
-            "vault.cluster.secrets.backend"
-            model.id
-            class="button has-icon-right is-ghost is-compact"
-            data-test-backend-view-link=true
-          }}
-            View backend
-            {{i-con glyph="chevron-right" size=11}}
-          {{/link-to}}
-        </div>
+<PageHeader as |p|>
+  <p.top>
+    {{key-value-header
+      baseKey=model
+      path="vault.cluster.secrets.backend"
+      root=root
+      showCurrent=true
+    }}
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Configure {{get (options-for-backend model.type) "displayName"}}
+    </h1>
+  </p.levelLeft>
+  <p.levelRight>
+    <div class="field is-grouped">
+      <div class="control">
+        {{#link-to
+          "vault.cluster.secrets.backend"
+          model.id
+          class="button has-icon-right is-ghost is-compact"
+          data-test-backend-view-link=true
+        }}
+          View backend
+          {{i-con glyph="chevron-right" size=11}}
+        {{/link-to}}
       </div>
     </div>
-  </div>
-</header>
+  </p.levelRight>
+</PageHeader>
 
 {{partial (concat "partials/secret-backend-settings/" model.type)}}
 {{outlet}}

--- a/ui/app/templates/vault/cluster/settings/mount-secret-backend.hbs
+++ b/ui/app/templates/vault/cluster/settings/mount-secret-backend.hbs
@@ -1,12 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Enable a secrets engine
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Enable a secrets engine
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 <form {{action "mountBackend" on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">
     {{message-error model=model}}

--- a/ui/app/templates/vault/cluster/settings/seal.hbs
+++ b/ui/app/templates/vault/cluster/settings/seal.hbs
@@ -1,12 +1,10 @@
-<header class="page-header">
-  <div class="level">
-    <div class="level-left">
-      <h1 class="title is-3">
-        Seal this vault
-      </h1>
-    </div>
-  </div>
-</header>
+<PageHeader as |p|>
+  <p.levelLeft>
+    <h1 class="title is-3">
+      Seal this vault
+    </h1>
+  </p.levelLeft>
+</PageHeader>
 
 {{#if model.seal.canUpdate}}
   <div class="box is-sideless is-fullwidth is-marginless">

--- a/ui/app/templates/vault/error.hbs
+++ b/ui/app/templates/vault/error.hbs
@@ -12,19 +12,17 @@
     {{#if (eq model.httpStatus 404)}}
       {{not-found model=model}}
     {{else}}
-      <header class="page-header">
-        <div class="level">
-          <div class="level-left">
-            <h1 class="title is-3 has-text-grey">
-              {{#if (eq model.httpStatus 403)}}
-                Not authorized
-              {{else}}
-                Error
-              {{/if}}
-            </h1>
-          </div>
-        </div>
-      </header>
+      <PageHeader as |p|>
+        <p.levelLeft>
+          <h1 class="title is-3 has-text-grey">
+            {{#if (eq model.httpStatus 403)}}
+              Not authorized
+            {{else}}
+              Error
+            {{/if}}
+          </h1>
+        </p.levelLeft>
+      </PageHeader>
       <div class="box is-sideless has-background-white-bis has-text-grey has-text-centered">
         {{#if model.message}}
           <p>{{model.message}}</p>

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,6 +44,7 @@
     "columnify": "^1.5.4",
     "cool-checkboxes-for-bulma.io": "^1.1.0",
     "ember-ajax": "^3.0.0",
+    "ember-angle-bracket-invocation-polyfill": "^1.0.2",
     "ember-api-actions": "^0.1.8",
     "ember-basic-dropdown": "^0.33.5",
     "ember-basic-dropdown-hover": "^0.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,13 +20,12 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "gitDir": "../",
     "linters": {
-      "ui/{app,tests,config,lib,mirage}/**/*.js": [
-        "prettier-eslint --single-quote --trailing-comma es5 --print-width 110 --write",
+      "*.js": [
+        "prettier-eslint --single-quote --no-use-tabs --trailing-comma es5 --print-width 110 --write",
         "git add"
       ],
-      "ui/app/styles/**/*.*": [
+      "*.scss": [
         "prettier --write",
         "git add"
       ]

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2722,6 +2722,13 @@ ember-ajax@^3.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
+ember-angle-bracket-invocation-polyfill@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-1.0.2.tgz#b8e43e91161c0da1b442c995e1f270b64c7d8d00"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-cli-version-checker "^2.1.2"
+
 ember-api-actions@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/ember-api-actions/-/ember-api-actions-0.1.8.tgz#651031b9d61a320c221dd75b20f7e8f783e6393d"
@@ -3167,6 +3174,13 @@ ember-cli-version-checker@^2.0.0:
 ember-cli-version-checker@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz#fc79a56032f3717cf844ada7cbdec1a06fedb604"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
+ember-cli-version-checker@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz#305ce102390c66e4e0f1432dea9dc5c7c19fed98"
   dependencies:
     resolve "^1.3.3"
     semver "^5.3.0"


### PR DESCRIPTION
This is some code cleanup and spreading use of abstractions that we've built so that we're using them consistently across the codebase. The changes include:

- Use `lazyCapabilities` macro anywhere we were doing `queryRecord` in models.
- Moves to using `expandAttributeMeta` and `fieldToAttrs` where we were duplicating code in models.
- Pulls in the polyfill for the new angle-bracket component invocation for Ember components and then use that for `<PageHeader>` contextual component (which we previously only had in one place).