### PR TITLE
Make travis file compatible with forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ services:
 go:
   - "1.10.2"
 
+go_import_path: github.com/hashicorp/vault
+
 matrix:
   allow_failures:
     - go: tip


### PR DESCRIPTION
Add the go-import-path key in travis.yml file so the project can be builded on any fork by travis

Without it, it would fail as the github.com/whatever/vault is not referenced in the source