### PR TITLE
Redo transit locking

### DIFF
--- a/builtin/logical/transit/path_config.go
+++ b/builtin/logical/transit/path_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/vault/helper/keysutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -61,10 +62,10 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, d *
 	name := d.Get("name").(string)
 
 	// Check if the policy already exists before we lock everything
-	p, lock, err := b.lm.GetPolicyExclusive(ctx, req.Storage, name)
-	if lock != nil {
-		defer lock.Unlock()
-	}
+	p, _, err := b.lm.GetPolicy(ctx, keysutil.PolicyRequest{
+		Storage: req.Storage,
+		Name:    name,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -73,6 +74,10 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, d *
 				fmt.Sprintf("no existing key named %s could be found", name)),
 			logical.ErrInvalidRequest
 	}
+	if !b.System().CachingDisabled() {
+		p.Lock(true)
+	}
+	defer p.Unlock()
 
 	resp := &logical.Response{}
 

--- a/builtin/logical/transit/path_config_test.go
+++ b/builtin/logical/transit/path_config_test.go
@@ -10,14 +10,7 @@ import (
 )
 
 func TestTransit_ConfigSettings(t *testing.T) {
-	var b *backend
-	sysView := logical.TestSystemView()
-	storage := &logical.InmemStorage{}
-
-	b = Backend(&logical.BackendConfig{
-		StorageView: storage,
-		System:      sysView,
-	})
+	b, storage := createBackendWithSysView(t)
 
 	doReq := func(req *logical.Request) *logical.Response {
 		resp, err := b.HandleRequest(context.Background(), req)

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"sync"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/errutil"
@@ -128,13 +127,17 @@ to the min_encryption_version configured on the key.`,
 
 func (b *backend) pathEncryptExistenceCheck(ctx context.Context, req *logical.Request, d *framework.FieldData) (bool, error) {
 	name := d.Get("name").(string)
-	p, lock, err := b.lm.GetPolicyShared(ctx, req.Storage, name)
-	if lock != nil {
-		defer lock.RUnlock()
-	}
+	p, _, err := b.lm.GetPolicy(ctx, keysutil.PolicyRequest{
+		Storage: req.Storage,
+		Name:    name,
+	})
 	if err != nil {
 		return false, err
 	}
+	if p != nil && b.System().CachingDisabled() {
+		p.Unlock()
+	}
+
 	return p != nil, nil
 }
 
@@ -207,15 +210,16 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 
 	// Get the policy
 	var p *keysutil.Policy
-	var lock *sync.RWMutex
 	var upserted bool
+	var polReq keysutil.PolicyRequest
 	if req.Operation == logical.CreateOperation {
 		convergent := d.Get("convergent_encryption").(bool)
 		if convergent && !contextSet {
 			return logical.ErrorResponse("convergent encryption requires derivation to be enabled, so context is required"), nil
 		}
 
-		polReq := keysutil.PolicyRequest{
+		polReq = keysutil.PolicyRequest{
+			Upsert:     true,
 			Storage:    req.Storage,
 			Name:       name,
 			Derived:    contextSet,
@@ -233,21 +237,23 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		default:
 			return logical.ErrorResponse(fmt.Sprintf("unknown key type %v", keyType)), logical.ErrInvalidRequest
 		}
-
-		p, lock, upserted, err = b.lm.GetPolicyUpsert(ctx, polReq)
-
 	} else {
-		p, lock, err = b.lm.GetPolicyShared(ctx, req.Storage, name)
+		polReq = keysutil.PolicyRequest{
+			Storage: req.Storage,
+			Name:    name,
+		}
 	}
-	if lock != nil {
-		defer lock.RUnlock()
-	}
+	p, upserted, err = b.lm.GetPolicy(ctx, polReq)
 	if err != nil {
 		return nil, err
 	}
 	if p == nil {
 		return logical.ErrorResponse("encryption key not found"), logical.ErrInvalidRequest
 	}
+	if !b.System().CachingDisabled() {
+		p.Lock(false)
+	}
+	defer p.Unlock()
 
 	// Process batch request items. If encryption of any request
 	// item fails, respectively mark the error in the response

--- a/builtin/logical/transit/path_export_test.go
+++ b/builtin/logical/transit/path_export_test.go
@@ -22,14 +22,7 @@ func TestTransit_Export_KeyVersion_ExportsCorrectVersion(t *testing.T) {
 }
 
 func verifyExportsCorrectVersion(t *testing.T, exportType, keyType string) {
-	var b *backend
-	sysView := logical.TestSystemView()
-	storage := &logical.InmemStorage{}
-
-	b = Backend(&logical.BackendConfig{
-		StorageView: storage,
-		System:      sysView,
-	})
+	b, storage := createBackendWithSysView(t)
 
 	// First create a key, v1
 	req := &logical.Request{
@@ -119,14 +112,7 @@ func verifyExportsCorrectVersion(t *testing.T, exportType, keyType string) {
 }
 
 func TestTransit_Export_ValidVersionsOnly(t *testing.T) {
-	var b *backend
-	sysView := logical.TestSystemView()
-	storage := &logical.InmemStorage{}
-
-	b = Backend(&logical.BackendConfig{
-		StorageView: storage,
-		System:      sysView,
-	})
+	b, storage := createBackendWithSysView(t)
 
 	// First create a key, v1
 	req := &logical.Request{
@@ -226,14 +212,7 @@ func TestTransit_Export_ValidVersionsOnly(t *testing.T) {
 }
 
 func TestTransit_Export_KeysNotMarkedExportable_ReturnsError(t *testing.T) {
-	var b *backend
-	sysView := logical.TestSystemView()
-	storage := &logical.InmemStorage{}
-
-	b = Backend(&logical.BackendConfig{
-		StorageView: storage,
-		System:      sysView,
-	})
+	b, storage := createBackendWithSysView(t)
 
 	req := &logical.Request{
 		Storage:   storage,
@@ -263,14 +242,7 @@ func TestTransit_Export_KeysNotMarkedExportable_ReturnsError(t *testing.T) {
 }
 
 func TestTransit_Export_SigningDoesNotSupportSigning_ReturnsError(t *testing.T) {
-	var b *backend
-	sysView := logical.TestSystemView()
-	storage := &logical.InmemStorage{}
-
-	b = Backend(&logical.BackendConfig{
-		StorageView: storage,
-		System:      sysView,
-	})
+	b, storage := createBackendWithSysView(t)
 
 	req := &logical.Request{
 		Storage:   storage,
@@ -303,14 +275,7 @@ func TestTransit_Export_EncryptionDoesNotSupportEncryption_ReturnsError(t *testi
 }
 
 func testTransit_Export_EncryptionDoesNotSupportEncryption_ReturnsError(t *testing.T, keyType string) {
-	var b *backend
-	sysView := logical.TestSystemView()
-	storage := &logical.InmemStorage{}
-
-	b = Backend(&logical.BackendConfig{
-		StorageView: storage,
-		System:      sysView,
-	})
+	b, storage := createBackendWithSysView(t)
 
 	req := &logical.Request{
 		Storage:   storage,
@@ -338,14 +303,7 @@ func testTransit_Export_EncryptionDoesNotSupportEncryption_ReturnsError(t *testi
 }
 
 func TestTransit_Export_KeysDoesNotExist_ReturnsNotFound(t *testing.T) {
-	var b *backend
-	sysView := logical.TestSystemView()
-	storage := &logical.InmemStorage{}
-
-	b = Backend(&logical.BackendConfig{
-		StorageView: storage,
-		System:      sysView,
-	})
+	b, storage := createBackendWithSysView(t)
 
 	req := &logical.Request{
 		Storage:   storage,
@@ -360,14 +318,7 @@ func TestTransit_Export_KeysDoesNotExist_ReturnsNotFound(t *testing.T) {
 }
 
 func TestTransit_Export_EncryptionKey_DoesNotExportHMACKey(t *testing.T) {
-	var b *backend
-	sysView := logical.TestSystemView()
-	storage := &logical.InmemStorage{}
-
-	b = Backend(&logical.BackendConfig{
-		StorageView: storage,
-		System:      sysView,
-	})
+	b, storage := createBackendWithSysView(t)
 
 	req := &logical.Request{
 		Storage:   storage,

--- a/builtin/logical/transit/path_hash_test.go
+++ b/builtin/logical/transit/path_hash_test.go
@@ -8,14 +8,7 @@ import (
 )
 
 func TestTransit_Hash(t *testing.T) {
-	var b *backend
-	sysView := logical.TestSystemView()
-	storage := &logical.InmemStorage{}
-
-	b = Backend(&logical.BackendConfig{
-		StorageView: storage,
-		System:      sysView,
-	})
+	b, storage := createBackendWithSysView(t)
 
 	req := &logical.Request{
 		Storage:   storage,

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -130,6 +130,7 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 	}
 
 	polReq := keysutil.PolicyRequest{
+		Upsert:               true,
 		Storage:              req.Storage,
 		Name:                 name,
 		Derived:              derived,
@@ -154,15 +155,15 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 		return logical.ErrorResponse(fmt.Sprintf("unknown key type %v", keyType)), logical.ErrInvalidRequest
 	}
 
-	p, lock, upserted, err := b.lm.GetPolicyUpsert(ctx, polReq)
-	if lock != nil {
-		defer lock.RUnlock()
-	}
+	p, upserted, err := b.lm.GetPolicy(ctx, polReq)
 	if err != nil {
 		return nil, err
 	}
 	if p == nil {
 		return nil, fmt.Errorf("error generating key: returned policy was nil")
+	}
+	if b.System().CachingDisabled() {
+		p.Unlock()
 	}
 
 	resp := &logical.Response{}
@@ -183,16 +184,20 @@ type asymKey struct {
 func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
-	p, lock, err := b.lm.GetPolicyShared(ctx, req.Storage, name)
-	if lock != nil {
-		defer lock.RUnlock()
-	}
+	p, _, err := b.lm.GetPolicy(ctx, keysutil.PolicyRequest{
+		Storage: req.Storage,
+		Name:    name,
+	})
 	if err != nil {
 		return nil, err
 	}
 	if p == nil {
 		return nil, nil
 	}
+	if !b.System().CachingDisabled() {
+		p.Lock(false)
+	}
+	defer p.Unlock()
 
 	// Return the response
 	resp := &logical.Response{

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/errutil"
+	"github.com/hashicorp/vault/helper/keysutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 	"github.com/mitchellh/mapstructure"
@@ -114,16 +115,20 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 	}
 
 	// Get the policy
-	p, lock, err := b.lm.GetPolicyShared(ctx, req.Storage, d.Get("name").(string))
-	if lock != nil {
-		defer lock.RUnlock()
-	}
+	p, _, err := b.lm.GetPolicy(ctx, keysutil.PolicyRequest{
+		Storage: req.Storage,
+		Name:    d.Get("name").(string),
+	})
 	if err != nil {
 		return nil, err
 	}
 	if p == nil {
 		return logical.ErrorResponse("encryption key not found"), logical.ErrInvalidRequest
 	}
+	if !b.System().CachingDisabled() {
+		p.Lock(false)
+	}
+	defer p.Unlock()
 
 	for i, item := range batchInputItems {
 		if batchResponseItems[i].Error != "" {

--- a/builtin/logical/transit/path_rotate.go
+++ b/builtin/logical/transit/path_rotate.go
@@ -3,6 +3,7 @@ package transit
 import (
 	"context"
 
+	"github.com/hashicorp/vault/helper/keysutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -30,16 +31,20 @@ func (b *backend) pathRotateWrite(ctx context.Context, req *logical.Request, d *
 	name := d.Get("name").(string)
 
 	// Get the policy
-	p, lock, err := b.lm.GetPolicyExclusive(ctx, req.Storage, name)
-	if lock != nil {
-		defer lock.Unlock()
-	}
+	p, _, err := b.lm.GetPolicy(ctx, keysutil.PolicyRequest{
+		Storage: req.Storage,
+		Name:    name,
+	})
 	if err != nil {
 		return nil, err
 	}
 	if p == nil {
 		return logical.ErrorResponse("key not found"), logical.ErrInvalidRequest
 	}
+	if !b.System().CachingDisabled() {
+		p.Lock(true)
+	}
+	defer p.Unlock()
 
 	// Rotate the policy
 	err = p.Rotate(ctx, req.Storage)

--- a/helper/keysutil/lock_manager.go
+++ b/helper/keysutil/lock_manager.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/jsonutil"
+	"github.com/hashicorp/vault/helper/locksutil"
 	"github.com/hashicorp/vault/logical"
 )
 
@@ -52,177 +54,32 @@ type PolicyRequest struct {
 }
 
 type LockManager struct {
-	// A lock for each named key
-	locks map[string]*sync.RWMutex
-
-	// A mutex for the map itself
-	locksMutex sync.RWMutex
-
+	useCache bool
 	// If caching is enabled, the map of name to in-memory policy cache
-	cache map[string]*Policy
+	cache sync.Map
 
-	// Used for global locking, and as the cache map mutex
-	cacheMutex sync.RWMutex
+	keyLocks []*locksutil.LockEntry
 }
 
 func NewLockManager(cacheDisabled bool) *LockManager {
 	lm := &LockManager{
-		locks: map[string]*sync.RWMutex{},
-	}
-	if !cacheDisabled {
-		lm.cache = map[string]*Policy{}
+		useCache: !cacheDisabled,
+		keyLocks: locksutil.CreateLocks(),
 	}
 	return lm
 }
 
 func (lm *LockManager) CacheActive() bool {
-	return lm.cache != nil
+	return lm.useCache
 }
 
 func (lm *LockManager) InvalidatePolicy(name string) {
-	// Check if it's in our cache. If so, return right away.
-	if lm.CacheActive() {
-		lm.cacheMutex.Lock()
-		defer lm.cacheMutex.Unlock()
-		delete(lm.cache, name)
-	}
-}
-
-func (lm *LockManager) policyLock(name string, lockType bool) *sync.RWMutex {
-	lm.locksMutex.RLock()
-	lock := lm.locks[name]
-	if lock != nil {
-		// We want to give this up before locking the lock, but it's safe --
-		// the only time we ever write to a value in this map is the first time
-		// we access the value, so it won't be changing out from under us
-		lm.locksMutex.RUnlock()
-		if lockType == exclusive {
-			lock.Lock()
-		} else {
-			lock.RLock()
-		}
-		return lock
-	}
-
-	lm.locksMutex.RUnlock()
-	lm.locksMutex.Lock()
-
-	// Don't defer the unlock call because if we get a valid lock below we want
-	// to release the lock mutex right away to avoid the possibility of
-	// deadlock by trying to grab the second lock
-
-	// Check to make sure it hasn't been created since
-	lock = lm.locks[name]
-	if lock != nil {
-		lm.locksMutex.Unlock()
-		if lockType == exclusive {
-			lock.Lock()
-		} else {
-			lock.RLock()
-		}
-		return lock
-	}
-
-	lock = &sync.RWMutex{}
-	lm.locks[name] = lock
-	lm.locksMutex.Unlock()
-	if lockType == exclusive {
-		lock.Lock()
-	} else {
-		lock.RLock()
-	}
-
-	return lock
-}
-
-func (lm *LockManager) UnlockPolicy(lock *sync.RWMutex, lockType bool) {
-	if lockType == exclusive {
-		lock.Unlock()
-	} else {
-		lock.RUnlock()
-	}
-}
-
-func (lm *LockManager) UpdateCache(name string, policy *Policy) {
-	if lm.CacheActive() {
-		lm.cacheMutex.Lock()
-		defer lm.cacheMutex.Unlock()
-		lm.cache[name] = policy
-	}
-}
-
-// Get the policy with a read lock. If we get an error saying an exclusive lock
-// is needed (for instance, for an upgrade/migration), give up the read lock,
-// call again with an exclusive lock, then swap back out for a read lock.
-func (lm *LockManager) GetPolicyShared(ctx context.Context, storage logical.Storage, name string) (*Policy, *sync.RWMutex, error) {
-	p, lock, _, err := lm.getPolicyCommon(ctx, PolicyRequest{
-		Storage: storage,
-		Name:    name,
-	}, shared)
-	if err == nil ||
-		(err != nil && err != errNeedExclusiveLock) {
-		return p, lock, err
-	}
-
-	// Try again while asking for an exclusive lock
-	p, lock, _, err = lm.getPolicyCommon(ctx, PolicyRequest{
-		Storage: storage,
-		Name:    name,
-	}, exclusive)
-	if err != nil || p == nil || lock == nil {
-		return p, lock, err
-	}
-
-	lock.Unlock()
-
-	p, lock, _, err = lm.getPolicyCommon(ctx, PolicyRequest{
-		Storage: storage,
-		Name:    name,
-	}, shared)
-	return p, lock, err
-}
-
-// Get the policy with an exclusive lock
-func (lm *LockManager) GetPolicyExclusive(ctx context.Context, storage logical.Storage, name string) (*Policy, *sync.RWMutex, error) {
-	p, lock, _, err := lm.getPolicyCommon(ctx, PolicyRequest{
-		Storage: storage,
-		Name:    name,
-	}, exclusive)
-	return p, lock, err
-}
-
-// Get the policy with a read lock; if it returns that an exclusive lock is
-// needed, retry. If successful, call one more time to get a read lock and
-// return the value.
-func (lm *LockManager) GetPolicyUpsert(ctx context.Context, req PolicyRequest) (*Policy, *sync.RWMutex, bool, error) {
-	req.Upsert = true
-
-	p, lock, _, err := lm.getPolicyCommon(ctx, req, shared)
-	if err == nil ||
-		(err != nil && err != errNeedExclusiveLock) {
-		return p, lock, false, err
-	}
-
-	// Try again while asking for an exclusive lock
-	p, lock, upserted, err := lm.getPolicyCommon(ctx, req, exclusive)
-	if err != nil || p == nil || lock == nil {
-		return p, lock, upserted, err
-	}
-	lock.Unlock()
-
-	req.Upsert = false
-	// Now get a shared lock for the return, but preserve the value of upserted
-	p, lock, _, err = lm.getPolicyCommon(ctx, req, shared)
-
-	return p, lock, upserted, err
+	lm.cache.Delete(name)
 }
 
 // RestorePolicy acquires an exclusive lock on the policy name and restores the
 // given policy along with the archive.
 func (lm *LockManager) RestorePolicy(ctx context.Context, storage logical.Storage, name, backup string) error {
-	var p *Policy
-	var err error
-
 	backupBytes, err := base64.StdEncoding.DecodeString(backup)
 	if err != nil {
 		return err
@@ -241,38 +98,36 @@ func (lm *LockManager) RestorePolicy(ctx context.Context, storage logical.Storag
 
 	name = keyData.Policy.Name
 
-	// set the policy version cache
-	keyData.Policy.versionPrefixCache = &sync.Map{}
+	// Grab the exclusive lock as we'll be modifying disk
+	lock := locksutil.LockForKey(lm.keyLocks, name)
+	lock.Lock()
+	defer lock.Unlock()
 
-	lockType := exclusive
-	lock := lm.policyLock(name, lockType)
-	defer lm.UnlockPolicy(lock, lockType)
-
-	// If the policy is in cache, error out
-	if lm.CacheActive() {
-		lm.cacheMutex.RLock()
-		p = lm.cache[name]
-		if p != nil {
-			lm.cacheMutex.RUnlock()
-			return fmt.Errorf(fmt.Sprintf("policy %q already exists", name))
-		}
-		lm.cacheMutex.RUnlock()
+	// If the policy is in cache, error out. Anywhere that would put it in the
+	// cache will also be protected by the mutex above, so we don't need to
+	// re-check the cache later.
+	_, ok := lm.cache.Load(name)
+	if ok {
+		return fmt.Errorf(fmt.Sprintf("key %q already exists", name))
 	}
 
 	// If the policy exists in storage, error out
-	p, err = lm.getStoredPolicy(ctx, storage, name)
+	p, err := lm.getPolicyFromStorage(ctx, storage, name)
 	if err != nil {
 		return err
 	}
 	if p != nil {
-		return fmt.Errorf(fmt.Sprintf("policy %q already exists", name))
+		return fmt.Errorf(fmt.Sprintf("key %q already exists", name))
 	}
+
+	// We don't need to grab policy locks as we have ensured it doesn't already
+	// exist, so there will be no races as nothing else has this pointer.
 
 	// Restore the archived keys
 	if keyData.ArchivedKeys != nil {
 		err = keyData.Policy.storeArchive(ctx, storage, keyData.ArchivedKeys)
 		if err != nil {
-			return errwrap.Wrapf(fmt.Sprintf("failed to restore archived keys for policy %q: {{err}}", name), err)
+			return errwrap.Wrapf(fmt.Sprintf("failed to restore archived keys for key %q: {{err}}", name), err)
 		}
 	}
 
@@ -288,22 +143,42 @@ func (lm *LockManager) RestorePolicy(ctx context.Context, storage logical.Storag
 		return errwrap.Wrapf(fmt.Sprintf("failed to restore the policy %q: {{err}}", name), err)
 	}
 
+	keyData.Policy.l = new(sync.RWMutex)
+
 	// Update the cache to contain the restored policy
-	lm.UpdateCache(name, keyData.Policy)
+	lm.cache.Store(name, keyData.Policy)
 
 	return nil
 }
 
 func (lm *LockManager) BackupPolicy(ctx context.Context, storage logical.Storage, name string) (string, error) {
-	p, lock, err := lm.GetPolicyExclusive(ctx, storage, name)
-	if lock != nil {
-		defer lock.Unlock()
+	var p *Policy
+	var err error
+
+	// Backup writes information about when the bacup took place, so we get an
+	// exclusive lock here
+	lock := locksutil.LockForKey(lm.keyLocks, name)
+	lock.Lock()
+	defer lock.Unlock()
+
+	pRaw, ok := lm.cache.Load(name)
+	if ok {
+		p = pRaw.(*Policy)
+		p.l.Lock()
+		defer p.l.Unlock()
+	} else {
+		// If the policy doesn't exit in storage, error out
+		p, err = lm.getPolicyFromStorage(ctx, storage, name)
+		if err != nil {
+			return "", err
+		}
+		if p == nil {
+			return "", fmt.Errorf(fmt.Sprintf("key %q not found", name))
+		}
 	}
-	if err != nil {
-		return "", err
-	}
-	if p == nil {
-		return "", fmt.Errorf("invalid key %q", name)
+
+	if atomic.LoadUint32(&p.deleted) == 1 {
+		return "", fmt.Errorf(fmt.Sprintf("key %q not found", name))
 	}
 
 	backup, err := p.Backup(ctx, storage)
@@ -311,89 +186,101 @@ func (lm *LockManager) BackupPolicy(ctx context.Context, storage logical.Storage
 		return "", err
 	}
 
-	// Update the cache since the policy would now have the backup information
-	lm.UpdateCache(name, p)
-
 	return backup, nil
 }
 
-// When the function returns, a lock will be held on the policy if err == nil.
-// It is the caller's responsibility to unlock.
-func (lm *LockManager) getPolicyCommon(ctx context.Context, req PolicyRequest, lockType bool) (*Policy, *sync.RWMutex, bool, error) {
-	lock := lm.policyLock(req.Name, lockType)
-
+// When the function returns, if caching was disabled, the Policy's lock must
+// be unlocked when the caller is done (and it should not be re-locked).
+func (lm *LockManager) GetPolicy(ctx context.Context, req PolicyRequest) (*Policy, bool, error) {
 	var p *Policy
 	var err error
 
 	// Check if it's in our cache. If so, return right away.
-	if lm.CacheActive() {
-		lm.cacheMutex.RLock()
-		p = lm.cache[req.Name]
-		if p != nil {
-			lm.cacheMutex.RUnlock()
-			return p, lock, false, nil
+	pRaw, ok := lm.cache.Load(req.Name)
+	if ok {
+		p = pRaw.(*Policy)
+		if atomic.LoadUint32(&p.deleted) == 1 {
+			return nil, false, nil
 		}
-		lm.cacheMutex.RUnlock()
+		return p, false, nil
+	}
+
+	// We're not using the cache, or it wasn't found; get an exclusive lock.
+	// This ensures that any other process writing the actual storage will be
+	// finished before we load from storage.
+	lock := locksutil.LockForKey(lm.keyLocks, req.Name)
+	lock.Lock()
+
+	// If we are using the cache, defer the lock unlock; otherwise we will
+	// return from here with the lock still held.
+	if lm.useCache {
+		defer lock.Unlock()
+	}
+
+	// Check the cache again
+	pRaw, ok = lm.cache.Load(req.Name)
+	if ok {
+		p = pRaw.(*Policy)
+		if atomic.LoadUint32(&p.deleted) == 1 {
+			return nil, false, nil
+		}
+		return p, false, nil
 	}
 
 	// Load it from storage
-	p, err = lm.getStoredPolicy(ctx, req.Storage, req.Name)
+	p, err = lm.getPolicyFromStorage(ctx, req.Storage, req.Name)
 	if err != nil {
-		lm.UnlockPolicy(lock, lockType)
-		return nil, nil, false, err
+		return nil, false, err
 	}
+	// We don't need to lock the policy as there would be no other holders of
+	// the pointer
 
 	if p == nil {
 		// This is the only place we upsert a new policy, so if upsert is not
 		// specified, or the lock type is wrong, unlock before returning
 		if !req.Upsert {
-			lm.UnlockPolicy(lock, lockType)
-			return nil, nil, false, nil
+			return nil, false, nil
 		}
 
-		if lockType != exclusive {
-			lm.UnlockPolicy(lock, lockType)
-			return nil, nil, false, errNeedExclusiveLock
-		}
+		// We create the policy here, then at the end we do a LoadOrStore. If
+		// it's been loaded since we last checked the cache, we return an error
+		// to the user to let them know that their request can't be satisfied
+		// because we don't know if the parameters match.
 
 		switch req.KeyType {
 		case KeyType_AES256_GCM96, KeyType_ChaCha20_Poly1305:
 			if req.Convergent && !req.Derived {
-				lm.UnlockPolicy(lock, lockType)
-				return nil, nil, false, fmt.Errorf("convergent encryption requires derivation to be enabled")
+				return nil, false, fmt.Errorf("convergent encryption requires derivation to be enabled")
 			}
 
 		case KeyType_ECDSA_P256:
 			if req.Derived || req.Convergent {
-				lm.UnlockPolicy(lock, lockType)
-				return nil, nil, false, fmt.Errorf("key derivation and convergent encryption not supported for keys of type %v", req.KeyType)
+				return nil, false, fmt.Errorf("key derivation and convergent encryption not supported for keys of type %v", req.KeyType)
 			}
 
 		case KeyType_ED25519:
 			if req.Convergent {
-				lm.UnlockPolicy(lock, lockType)
-				return nil, nil, false, fmt.Errorf("convergent encryption not supported for keys of type %v", req.KeyType)
+				return nil, false, fmt.Errorf("convergent encryption not supported for keys of type %v", req.KeyType)
 			}
 
 		case KeyType_RSA2048, KeyType_RSA4096:
 			if req.Derived || req.Convergent {
-				lm.UnlockPolicy(lock, lockType)
-				return nil, nil, false, fmt.Errorf("key derivation and convergent encryption not supported for keys of type %v", req.KeyType)
+				return nil, false, fmt.Errorf("key derivation and convergent encryption not supported for keys of type %v", req.KeyType)
 			}
 
 		default:
-			lm.UnlockPolicy(lock, lockType)
-			return nil, nil, false, fmt.Errorf("unsupported key type %v", req.KeyType)
+			return nil, false, fmt.Errorf("unsupported key type %v", req.KeyType)
 		}
 
 		p = &Policy{
+			l:                    new(sync.RWMutex),
 			Name:                 req.Name,
 			Type:                 req.KeyType,
 			Derived:              req.Derived,
 			Exportable:           req.Exportable,
 			AllowPlaintextBackup: req.AllowPlaintextBackup,
-			versionPrefixCache:   &sync.Map{},
 		}
+
 		if req.Derived {
 			p.KDF = Kdf_hkdf_sha256
 			if req.Convergent {
@@ -407,107 +294,88 @@ func (lm *LockManager) getPolicyCommon(ctx context.Context, req PolicyRequest, l
 			}
 		}
 
+		// Performs the actual persist and does setup
 		err = p.Rotate(ctx, req.Storage)
 		if err != nil {
-			lm.UnlockPolicy(lock, lockType)
-			return nil, nil, false, err
+			return nil, false, err
 		}
 
-		if lm.CacheActive() {
-			// Since we didn't have the policy in the cache, if there was no
-			// error, write the value in.
-			lm.cacheMutex.Lock()
-			defer lm.cacheMutex.Unlock()
-			// Make sure a policy didn't appear. If so, it will only be set if
-			// there was no error, so assume it's good and return that
-			exp := lm.cache[req.Name]
-			if exp != nil {
-				return exp, lock, false, nil
-			}
-			if err == nil {
-				lm.cache[req.Name] = p
-			}
+		if lm.useCache {
+			lm.cache.Store(req.Name, p)
+		} else {
+			p.l = &lock.RWMutex
+			p.writeLocked = true
 		}
 
 		// We don't need to worry about upgrading since it will be a new policy
-		return p, lock, true, nil
+		return p, true, nil
 	}
 
 	if p.NeedsUpgrade() {
-		if lockType == shared {
-			lm.UnlockPolicy(lock, lockType)
-			return nil, nil, false, errNeedExclusiveLock
-		}
-
-		err = p.Upgrade(ctx, req.Storage)
-		if err != nil {
-			lm.UnlockPolicy(lock, lockType)
-			return nil, nil, false, err
+		if err := p.Upgrade(ctx, req.Storage); err != nil {
+			return nil, false, err
 		}
 	}
 
-	if lm.CacheActive() {
-		// Since we didn't have the policy in the cache, if there was no
-		// error, write the value in.
-		lm.cacheMutex.Lock()
-		defer lm.cacheMutex.Unlock()
-		// Make sure a policy didn't appear. If so, it will only be set if
-		// there was no error, so assume it's good and return that
-		exp := lm.cache[req.Name]
-		if exp != nil {
-			return exp, lock, false, nil
-		}
-		if err == nil {
-			lm.cache[req.Name] = p
-		}
+	if lm.useCache {
+		lm.cache.Store(req.Name, p)
+	} else {
+		p.l = &lock.RWMutex
+		p.writeLocked = true
 	}
 
-	return p, lock, false, nil
+	return p, false, nil
 }
 
 func (lm *LockManager) DeletePolicy(ctx context.Context, storage logical.Storage, name string) error {
-	lm.cacheMutex.Lock()
-	lock := lm.policyLock(name, exclusive)
-	defer lock.Unlock()
-	defer lm.cacheMutex.Unlock()
-
 	var p *Policy
 	var err error
 
-	if lm.CacheActive() {
-		p = lm.cache[name]
+	// We may be writing to disk, so grab an exclusive lock. This prevents bad
+	// behavior when the cache is turned off. We also lock the shared policy
+	// object to make sure no requests are in flight.
+	lock := locksutil.LockForKey(lm.keyLocks, name)
+	lock.Lock()
+	defer lock.Unlock()
+
+	pRaw, ok := lm.cache.Load(name)
+	if ok {
+		p = pRaw.(*Policy)
+		p.l.Lock()
+		defer p.l.Unlock()
 	}
+
 	if p == nil {
-		p, err = lm.getStoredPolicy(ctx, storage, name)
+		p, err = lm.getPolicyFromStorage(ctx, storage, name)
 		if err != nil {
 			return err
 		}
 		if p == nil {
-			return fmt.Errorf("could not delete policy; not found")
+			return fmt.Errorf("could not delete key; not found")
 		}
 	}
 
 	if !p.DeletionAllowed {
-		return fmt.Errorf("deletion is not allowed for this policy")
+		return fmt.Errorf("deletion is not allowed for this key")
 	}
+
+	atomic.StoreUint32(&p.deleted, 1)
+
+	lm.cache.Delete(name)
 
 	err = storage.Delete(ctx, "policy/"+name)
 	if err != nil {
-		return errwrap.Wrapf(fmt.Sprintf("error deleting policy %q: {{err}}", name), err)
+		return errwrap.Wrapf(fmt.Sprintf("error deleting key %q: {{err}}", name), err)
 	}
 
 	err = storage.Delete(ctx, "archive/"+name)
 	if err != nil {
-		return errwrap.Wrapf(fmt.Sprintf("error deleting archive %q: {{err}}", name), err)
-	}
-
-	if lm.CacheActive() {
-		delete(lm.cache, name)
+		return errwrap.Wrapf(fmt.Sprintf("error deleting key %q archive: {{err}}", name), err)
 	}
 
 	return nil
 }
 
-func (lm *LockManager) getStoredPolicy(ctx context.Context, storage logical.Storage, name string) (*Policy, error) {
+func (lm *LockManager) getPolicyFromStorage(ctx context.Context, storage logical.Storage, name string) (*Policy, error) {
 	return LoadPolicy(ctx, storage, "policy/"+name)
 }

--- a/helper/keysutil/policy_test.go
+++ b/helper/keysutil/policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -59,14 +60,12 @@ func testKeyUpgradeCommon(t *testing.T, lm *LockManager) {
 	ctx := context.Background()
 
 	storage := &logical.InmemStorage{}
-	p, lock, upserted, err := lm.GetPolicyUpsert(ctx, PolicyRequest{
+	p, upserted, err := lm.GetPolicy(ctx, PolicyRequest{
+		Upsert:  true,
 		Storage: storage,
 		KeyType: KeyType_AES256_GCM96,
 		Name:    "test",
 	})
-	if lock != nil {
-		defer lock.RUnlock()
-	}
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +107,8 @@ func testArchivingUpgradeCommon(t *testing.T, lm *LockManager) {
 	// zero and latest, respectively
 
 	storage := &logical.InmemStorage{}
-	p, lock, _, err := lm.GetPolicyUpsert(ctx, PolicyRequest{
+	p, _, err := lm.GetPolicy(ctx, PolicyRequest{
+		Upsert:  true,
 		Storage: storage,
 		KeyType: KeyType_AES256_GCM96,
 		Name:    "test",
@@ -116,10 +116,9 @@ func testArchivingUpgradeCommon(t *testing.T, lm *LockManager) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p == nil || lock == nil {
-		t.Fatal("nil policy or lock")
+	if p == nil {
+		t.Fatal("nil policy")
 	}
-	lock.RUnlock()
 
 	// Store the initial key in the archive
 	keysArchive := []KeyEntry{KeyEntry{}, p.Keys["1"]}
@@ -159,27 +158,32 @@ func testArchivingUpgradeCommon(t *testing.T, lm *LockManager) {
 
 	// If we're caching, expire from the cache since we modified it
 	// under-the-hood
-	if lm.CacheActive() {
-		delete(lm.cache, "test")
+	if lm.useCache {
+		lm.cache.Delete("test")
 	}
 
 	// Now get the policy again; the upgrade should happen automatically
-	p, lock, err = lm.GetPolicyShared(ctx, storage, "test")
+	p, _, err = lm.GetPolicy(ctx, PolicyRequest{
+		Storage: storage,
+		Name:    "test",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p == nil || lock == nil {
-		t.Fatal("nil policy or lock")
+	if p == nil {
+		t.Fatal("nil policy")
 	}
-	lock.RUnlock()
 
 	checkKeys(t, ctx, p, storage, keysArchive, "upgrade", 10, 10, 10)
 
 	// Let's check some deletion logic while we're at it
 
 	// The policy should be in there
-	if lm.CacheActive() && lm.cache["test"] == nil {
-		t.Fatal("nil policy in cache")
+	if lm.useCache {
+		_, ok := lm.cache.Load("test")
+		if !ok {
+			t.Fatal("nil policy in cache")
+		}
 	}
 
 	// First we'll do this wrong, by not setting the deletion flag
@@ -189,18 +193,23 @@ func testArchivingUpgradeCommon(t *testing.T, lm *LockManager) {
 	}
 
 	// The policy should still be in there
-	if lm.CacheActive() && lm.cache["test"] == nil {
-		t.Fatal("nil policy in cache")
+	if lm.useCache {
+		_, ok := lm.cache.Load("test")
+		if !ok {
+			t.Fatal("nil policy in cache")
+		}
 	}
 
-	p, lock, err = lm.GetPolicyShared(ctx, storage, "test")
+	p, _, err = lm.GetPolicy(ctx, PolicyRequest{
+		Storage: storage,
+		Name:    "test",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p == nil || lock == nil {
-		t.Fatal("policy or lock nil after bad delete")
+	if p == nil {
+		t.Fatal("policy nil after bad delete")
 	}
-	lock.RUnlock()
 
 	// Now do it properly
 	p.DeletionAllowed = true
@@ -214,16 +223,22 @@ func testArchivingUpgradeCommon(t *testing.T, lm *LockManager) {
 	}
 
 	// The policy should *not* be in there
-	if lm.CacheActive() && lm.cache["test"] != nil {
-		t.Fatal("non-nil policy in cache")
+	if lm.useCache {
+		_, ok := lm.cache.Load("test")
+		if ok {
+			t.Fatal("non-nil policy in cache")
+		}
 	}
 
-	p, lock, err = lm.GetPolicyShared(ctx, storage, "test")
+	p, _, err = lm.GetPolicy(ctx, PolicyRequest{
+		Storage: storage,
+		Name:    "test",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p != nil || lock != nil {
-		t.Fatal("policy or lock not nil after delete")
+	if p != nil {
+		t.Fatal("policy not nil after delete")
 	}
 }
 
@@ -241,7 +256,8 @@ func testArchivingCommon(t *testing.T, lm *LockManager) {
 	// zero and latest, respectively
 
 	storage := &logical.InmemStorage{}
-	p, lock, _, err := lm.GetPolicyUpsert(ctx, PolicyRequest{
+	p, _, err := lm.GetPolicy(ctx, PolicyRequest{
+		Upsert:  true,
 		Storage: storage,
 		KeyType: KeyType_AES256_GCM96,
 		Name:    "test",
@@ -249,10 +265,9 @@ func testArchivingCommon(t *testing.T, lm *LockManager) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p == nil || lock == nil {
-		t.Fatal("nil policy or lock")
+	if p == nil {
+		t.Fatal("nil policy")
 	}
-	lock.RUnlock()
 
 	// Store the initial key in the archive
 	keysArchive := []KeyEntry{KeyEntry{}, p.Keys["1"]}
@@ -393,7 +408,8 @@ func Test_StorageErrorSafety(t *testing.T) {
 	lm := NewLockManager(false)
 
 	storage := &logical.InmemStorage{}
-	p, lock, _, err := lm.GetPolicyUpsert(ctx, PolicyRequest{
+	p, _, err := lm.GetPolicy(ctx, PolicyRequest{
+		Upsert:  true,
 		Storage: storage,
 		KeyType: KeyType_AES256_GCM96,
 		Name:    "test",
@@ -401,10 +417,9 @@ func Test_StorageErrorSafety(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p == nil || lock == nil {
-		t.Fatal("nil policy or lock")
+	if p == nil {
+		t.Fatal("nil policy")
 	}
-	lock.RUnlock()
 
 	// Store the initial key in the archive
 	keysArchive := []KeyEntry{KeyEntry{}, p.Keys["1"]}
@@ -440,7 +455,8 @@ func Test_BadUpgrade(t *testing.T) {
 	ctx := context.Background()
 	lm := NewLockManager(false)
 	storage := &logical.InmemStorage{}
-	p, lock, _, err := lm.GetPolicyUpsert(ctx, PolicyRequest{
+	p, _, err := lm.GetPolicy(ctx, PolicyRequest{
+		Upsert:  true,
 		Storage: storage,
 		KeyType: KeyType_AES256_GCM96,
 		Name:    "test",
@@ -448,10 +464,9 @@ func Test_BadUpgrade(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p == nil || lock == nil {
-		t.Fatal("nil policy or lock")
+	if p == nil {
+		t.Fatal("nil policy")
 	}
-	lock.RUnlock()
 
 	orig, err := copystructure.Copy(p)
 	if err != nil {
@@ -471,7 +486,7 @@ func Test_BadUpgrade(t *testing.T) {
 	k.CreationTime = o.CreationTime
 	k.HMACKey = o.HMACKey
 	p.Keys["1"] = k
-	p.versionPrefixCache = nil
+	p.versionPrefixCache = sync.Map{}
 
 	if !reflect.DeepEqual(orig, p) {
 		t.Fatalf("not equal:\n%#v\n%#v", orig, p)
@@ -504,7 +519,8 @@ func Test_BadArchive(t *testing.T) {
 	ctx := context.Background()
 	lm := NewLockManager(false)
 	storage := &logical.InmemStorage{}
-	p, lock, _, err := lm.GetPolicyUpsert(ctx, PolicyRequest{
+	p, _, err := lm.GetPolicy(ctx, PolicyRequest{
+		Upsert:  true,
 		Storage: storage,
 		KeyType: KeyType_AES256_GCM96,
 		Name:    "test",
@@ -512,10 +528,9 @@ func Test_BadArchive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p == nil || lock == nil {
-		t.Fatal("nil policy or lock")
+	if p == nil {
+		t.Fatal("nil policy")
 	}
-	lock.RUnlock()
 
 	for i := 2; i <= 10; i++ {
 		err = p.Rotate(ctx, storage)


### PR DESCRIPTION
This massively simplifies transit locking behavior by pushing some
locking down to the Policy level, and embedding either a local or global
lock in the Policy depending on whether caching is enabled or not.