### PR TITLE
UI control groups - detect control group

### DIFF
--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -79,8 +79,10 @@ export default Ember.Component.extend({
       this.logAndOutput(command, logFromResponse(resp, path, method, flags));
     } catch(error) {
       if (error instanceof ControlGroupError) {
-        this.logAndOutput(command, {type: 'error', content: `Control Group encountered at ${error.creation_path}. Close the console for more details.`});
-        return this.get('controlGroup').handleError(error);
+        return this.logAndOutput(
+          command,
+          this.get('controlGroup').logFromError(error)
+        );
       }
       this.logAndOutput(command, logFromError(error, path, method));
     }

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
+import ControlGroupError from 'vault/lib/control-group-error';
 import {
   parseCommand,
   extractDataAndFlags,
@@ -12,11 +13,12 @@ import {
 const { inject, computed, getOwner, run } = Ember;
 
 export default Ember.Component.extend({
+  console: inject.service(),
+  router: inject.service(),
+  controlGroup: inject.service(),
   classNames: 'console-ui-panel-scroller',
   classNameBindings: ['isFullscreen:fullscreen'],
   isFullscreen: false,
-  console: inject.service(),
-  router: inject.service(),
   inputValue: null,
   log: computed.alias('console.log'),
 
@@ -76,6 +78,10 @@ export default Ember.Component.extend({
       let resp = yield service[method].call(service, path, data, flags.wrapTTL);
       this.logAndOutput(command, logFromResponse(resp, path, method, flags));
     } catch(error) {
+      if (error instanceof ControlGroupError) {
+        this.logAndOutput(command, {type: 'error', content: `Control Group encountered at ${error.creation_path}. Close the console for more details.`});
+        return this.get('controlGroup').handleError(error);
+      }
       this.logAndOutput(command, logFromError(error, path, method));
     }
   }),

--- a/ui/app/lib/control-group-error.js
+++ b/ui/app/lib/control-group-error.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default class ControlGroupError extends Ember.Error {
+  constructor() {
+    super();
+    this.message = 'Control Group encountered';
+  }
+}

--- a/ui/app/lib/control-group-error.js
+++ b/ui/app/lib/control-group-error.js
@@ -1,8 +1,16 @@
 import Ember from 'ember';
 
 export default class ControlGroupError extends Ember.Error {
-  constructor() {
+  constructor(wrapInfo) {
+    let {accessor, creation_path, creation_time, token, ttl} = wrapInfo;
     super();
     this.message = 'Control Group encountered';
+
+    // add items from the wrapInfo object to the error
+    this.token = token;
+    this.accessor = accessor;
+    this.creation_path = creation_path;
+    this.creation_time = creation_time;
+    this.ttl = ttl;
   }
 }

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -67,7 +67,7 @@ Router.map(function() {
           });
         });
         this.route('control-groups');
-        this.route('control-group-accessor', '/control-groups/:accessor');
+        this.route('control-group-accessor', {path: '/control-groups/:accessor'});
       });
       this.route('secrets', function() {
         this.route('backends', { path: '/' });

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -1,9 +1,15 @@
 import Ember from 'ember';
 
+const { inject } = Ember;
 export default Ember.Route.extend({
+  controlGroup: inject.service(),
+
   actions: {
     willTransition() {
       window.scrollTo(0, 0);
     },
+    error(err, transition) {
+      this.get('controlGroup').handleError(err, transition);
+    }
   },
 });

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import ControlGroupError from 'vault/lib/control-group-error';
 
 const { inject } = Ember;
 export default Ember.Route.extend({
@@ -9,7 +10,10 @@ export default Ember.Route.extend({
       window.scrollTo(0, 0);
     },
     error(err, transition) {
-      this.get('controlGroup').handleError(err, transition);
+      if (err instanceof ControlGroupError) {
+        return this.get('controlGroup').handleError(err, transition);
+      }
+      throw err;
     }
   },
 });

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -13,7 +13,7 @@ export default Ember.Route.extend({
       if (err instanceof ControlGroupError) {
         return this.get('controlGroup').handleError(err, transition);
       }
-      throw err;
+      return true;
     }
   },
 });

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import ControlGroupError from 'vault/lib/control-group-error';
 
-const { Service, assign, inject, RSVP } = Ember;
+const { Service, inject, RSVP } = Ember;
 
 // list of endpoints that return wrapped responses
 // without `wrap-ttl`
@@ -23,12 +23,11 @@ export default Service.extend({
       wasWrapTTLRequested ||
       !response ||
       (creationPath && WRAPPED_RESPONSE_PATHS.includes(creationPath)) ||
-      (response && !response.wrap_info)
+      !response.wrap_info
     ) {
       return RSVP.resolve(...callbackArgs);
     }
-    let error = new ControlGroupError();
-    error = assign(error, response.wrap_info);
+    let error = new ControlGroupError(response.wrap_info);
     return RSVP.reject(error);
   },
 

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+import ControlGroupError from 'vault/lib/control-group-error';
+
+const { Service, assign, inject, RSVP } = Ember;
+
+export default Service.extend({
+  version: inject.service(),
+  router: inject.service(),
+
+  checkForControlGroup(callbackArgs, response, wasWrapTTLRequested) {
+    if (this.get('version.isOSS') || wasWrapTTLRequested || !response.wrap_info) {
+      return RSVP.resolve(...callbackArgs);
+    }
+    let error = new ControlGroupError();
+    error = assign(error, response.wrap_info);
+    return RSVP.reject(error);
+  },
+
+  handleError(error, transition) {
+
+    //console requests won't have a transition
+    if (transition) {}
+    debugger;
+  }
+
+});

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -16,11 +16,9 @@ export default Service.extend({
     return RSVP.reject(error);
   },
 
-  handleError(error, transition) {
+  handleError(error) {
     let {accessor} = error;
-    if (transition) {
-      transition.intent
-    }
+
     return this.get('router')
       .transitionTo('vault.cluster.access.control-group-accessor', accessor);
   },

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -17,10 +17,27 @@ export default Service.extend({
   },
 
   handleError(error, transition) {
+    let {accessor} = error;
+    if (transition) {
+      transition.intent
+    }
+    return this.get('router')
+      .transitionTo('vault.cluster.access.control-group-accessor', accessor);
+  },
 
-    //console requests won't have a transition
-    if (transition) {}
-    debugger;
+  logFromError(error) {
+    let {accessor} = error;
+    let href = this.get('router').urlFor('vault.cluster.access.control-group-accessor', accessor);
+    let lines = [
+      `A Control Group was encountered at ${error.creation_path}.`,
+      `The Control Group Token is ${error.token}.`,
+      `The Accessor is ${error.accessor}.`,
+      `Visit <a href='${href}'>${href}</a> for more details.`
+    ];
+    return {
+      type: 'error-with-html',
+      content: lines.join('\n')
+    };
   }
 
 });

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -8,7 +8,7 @@ export default Service.extend({
   router: inject.service(),
 
   checkForControlGroup(callbackArgs, response, wasWrapTTLRequested) {
-    if (this.get('version.isOSS') || wasWrapTTLRequested || !response.wrap_info) {
+    if (this.get('version.isOSS') || wasWrapTTLRequested || !response || (response && !response.wrap_info)) {
       return RSVP.resolve(...callbackArgs);
     }
     let error = new ControlGroupError();

--- a/ui/app/templates/components/console/log-error-with-html.hbs
+++ b/ui/app/templates/components/console/log-error-with-html.hbs
@@ -1,0 +1,4 @@
+<div class="console-ui-alert has-text-danger">
+  {{i-con glyph="close-circled" aria-hidden="true" size=12}}
+  <pre>{{{content}}}</pre>
+</div>

--- a/ui/tests/acceptance/enterprise-control-groups-test.js
+++ b/ui/tests/acceptance/enterprise-control-groups-test.js
@@ -1,0 +1,54 @@
+import { test } from 'qunit';
+import { create } from 'ember-cli-page-object';
+
+import moduleForAcceptance from 'vault/tests/helpers/module-for-acceptance';
+import console from 'vault/tests/pages/components/console/ui-panel';
+
+const consoleComponent = create(console);
+
+moduleForAcceptance('Acceptance | Enterprise | control groups', {
+  beforeEach() {
+    authLogin();
+  },
+});
+const POLICY = `path "kv/foo" {
+    capabilities = ["create", "read", "update", "delete", "list"]
+    control_group = {
+        max_ttl = "24h"
+        factor "ops_manager" {
+            identity {
+                group_names = ["managers"]
+                approvals = 2
+            }
+        }
+        factor "superman" {
+            identity {
+                group_names = ["superman"]
+                approvals = 1
+            }
+        }
+    }
+}`;
+
+test('it creates a thing', function(assert) {
+  visit('/vault/secrets');
+  let token;
+  andThen(() => {
+    consoleComponent.runCommands([
+      'write sys/mounts/kv type=kv',
+      'write kv/foo bar=baz',
+      'write sys/auth/userpass type=userpass',
+      `write sys/policies/acl/kv-control-group policy='${POLICY}'`,
+      'write -field=client_token auth/token/create policies=kv-control-group'
+    ]);
+  });
+  andThen(() => {
+    token = consoleComponent.lastLogOutput;
+    authLogout();
+    return authLogin(token);
+  });
+  visit('/vault/secrets/kv/show/foo');
+  andThen(() => {
+    debugger;
+  });
+})

--- a/ui/tests/acceptance/enterprise-control-groups-test.js
+++ b/ui/tests/acceptance/enterprise-control-groups-test.js
@@ -14,7 +14,7 @@ moduleForAcceptance('Acceptance | Enterprise | control groups', {
     return authLogout();
   }
 });
-const POLICY = `path "kv/foo" {
+const POLICY = `'path "kv/foo" {
     capabilities = ["create", "read", "update", "delete", "list"]
     control_group = {
         max_ttl = "24h"
@@ -31,7 +31,7 @@ const POLICY = `path "kv/foo" {
             }
         }
     }
-}`;
+}'`;
 
 const setupControlGroup = () => {
   let token;
@@ -41,7 +41,7 @@ const setupControlGroup = () => {
       'write sys/mounts/kv type=kv',
       'write kv/foo bar=baz',
       'write sys/auth/userpass type=userpass',
-      `write sys/policies/acl/kv-control-group policy='${POLICY}'`,
+      `write sys/policies/acl/kv-control-group policy=${POLICY}`,
       'write -field=client_token auth/token/create policies=kv-control-group'
     ]);
   });

--- a/ui/tests/acceptance/tools-test.js
+++ b/ui/tests/acceptance/tools-test.js
@@ -7,6 +7,9 @@ moduleForAcceptance('Acceptance | tools', {
   beforeEach() {
     return authLogin();
   },
+  afterEach() {
+    return authLogout();
+  }
 });
 
 const DATA_TO_WRAP = JSON.stringify({ tools: 'tests' });

--- a/ui/tests/acceptance/tools-test.js
+++ b/ui/tests/acceptance/tools-test.js
@@ -7,9 +7,6 @@ moduleForAcceptance('Acceptance | tools', {
   beforeEach() {
     return authLogin();
   },
-  afterEach() {
-    return authLogout();
-  },
 });
 
 const DATA_TO_WRAP = JSON.stringify({ tools: 'tests' });

--- a/ui/tests/helpers/auth-login.js
+++ b/ui/tests/helpers/auth-login.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Test.registerAsyncHelper('authLogin', function() {
+export default Ember.Test.registerAsyncHelper('authLogin', function(app, token) {
   visit('/vault/auth?with=token');
-  fillIn('[data-test-token]', 'root');
+  fillIn('[data-test-token]', token || 'root');
   click('[data-test-auth-submit]');
   // get rid of the root warning flash
   if (find('[data-test-flash-message-body]').length) {

--- a/ui/tests/pages/components/console/ui-panel.js
+++ b/ui/tests/pages/components/console/ui-panel.js
@@ -1,10 +1,20 @@
-import { text, triggerable, fillable, value, isPresent } from 'ember-cli-page-object';
+import { text, triggerable, collection, fillable, value, isPresent } from 'ember-cli-page-object';
+import { getter } from 'ember-cli-page-object/macros';
+
 import keys from 'vault/lib/keycodes';
 
 export default {
   consoleInput: fillable('[data-test-component="console/command-input"] input'),
   consoleInputValue: value('[data-test-component="console/command-input"] input'),
   logOutput: text('[data-test-component="console/output-log"]'),
+  logOutputItems: collection('[data-test-component="console/output-log"] > div', {
+    text: text(),
+  }),
+  lastLogOutput: getter(function() {
+    let count = this.logOutputItems.length;
+    return this.logOutputItems.objectAt(count - 1).text;
+  }),
+
   up: triggerable('keyup', '[data-test-component="console/command-input"] input', {
     eventProperties: { keyCode: keys.UP },
   }),
@@ -15,4 +25,11 @@ export default {
     eventProperties: { keyCode: keys.ENTER },
   }),
   hasInput: isPresent('[data-test-component="console/command-input"] input'),
+  runCommands(commands) {
+    let toExecute = Array.isArray(commands) ? commands : [commands];
+    return toExecute.forEach(command => {
+      this.consoleInput(command);
+      this.enter();
+    });
+  }
 };

--- a/ui/tests/pages/components/console/ui-panel.js
+++ b/ui/tests/pages/components/console/ui-panel.js
@@ -1,9 +1,10 @@
-import { text, triggerable, collection, fillable, value, isPresent } from 'ember-cli-page-object';
+import { text, triggerable, clickable, collection, fillable, value, isPresent } from 'ember-cli-page-object';
 import { getter } from 'ember-cli-page-object/macros';
 
 import keys from 'vault/lib/keycodes';
 
 export default {
+  toggle: clickable('[data-test-console-toggle]'),
   consoleInput: fillable('[data-test-component="console/command-input"] input'),
   consoleInputValue: value('[data-test-component="console/command-input"] input'),
   logOutput: text('[data-test-component="console/output-log"]'),

--- a/ui/tests/unit/adapters/capabilities-test.js
+++ b/ui/tests/unit/adapters/capabilities-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
 moduleFor('adapter:capabilities', 'Unit | Adapter | capabilities', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
 });
 
 test('calls the correct url', function(assert) {

--- a/ui/tests/unit/adapters/cluster-test.js
+++ b/ui/tests/unit/adapters/cluster-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
 moduleFor('adapter:cluster', 'Unit | Adapter | cluster', {
-  needs: ['service:auth', 'service:flash-messages', 'service:version'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
 });
 
 test('cluster api urls', function(assert) {

--- a/ui/tests/unit/adapters/console-test.js
+++ b/ui/tests/unit/adapters/console-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('adapter:console', 'Unit | Adapter | console', {
-  needs: ['service:auth', 'service:flash-messages', 'service:version'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
 });
 
 test('it builds the correct URL', function(assert) {

--- a/ui/tests/unit/adapters/identity/entity-alias-test.js
+++ b/ui/tests/unit/adapters/identity/entity-alias-test.js
@@ -3,7 +3,7 @@ import testCases from './_test-cases';
 import apiStub from 'vault/tests/helpers/noop-all-api-requests';
 
 moduleFor('adapter:identity/entity-alias', 'Unit | Adapter | identity/entity-alias', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
   beforeEach() {
     this.server = apiStub();
   },

--- a/ui/tests/unit/adapters/identity/entity-merge-test.js
+++ b/ui/tests/unit/adapters/identity/entity-merge-test.js
@@ -3,7 +3,7 @@ import { moduleFor, test } from 'ember-qunit';
 import { storeMVP } from './_test-cases';
 
 moduleFor('adapter:identity/entity-merge', 'Unit | Adapter | identity/entity-merge', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
   beforeEach() {
     this.server = new Pretender(function() {
       this.post('/v1/**', response => {

--- a/ui/tests/unit/adapters/identity/entity-test.js
+++ b/ui/tests/unit/adapters/identity/entity-test.js
@@ -3,7 +3,7 @@ import testCases from './_test-cases';
 import apiStub from 'vault/tests/helpers/noop-all-api-requests';
 
 moduleFor('adapter:identity/entity', 'Unit | Adapter | identity/entity', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
   beforeEach() {
     this.server = apiStub();
   },

--- a/ui/tests/unit/adapters/identity/group-alias-test.js
+++ b/ui/tests/unit/adapters/identity/group-alias-test.js
@@ -3,7 +3,7 @@ import testCases from './_test-cases';
 import apiStub from 'vault/tests/helpers/noop-all-api-requests';
 
 moduleFor('adapter:identity/group-alias', 'Unit | Adapter | identity/group-alias', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
   beforeEach() {
     this.server = apiStub();
   },

--- a/ui/tests/unit/adapters/identity/group-test.js
+++ b/ui/tests/unit/adapters/identity/group-test.js
@@ -3,7 +3,7 @@ import testCases from './_test-cases';
 import apiStub from 'vault/tests/helpers/noop-all-api-requests';
 
 moduleFor('adapter:identity/group', 'Unit | Adapter | identity/group', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
   beforeEach() {
     this.server = apiStub();
   },

--- a/ui/tests/unit/adapters/secret-engine-test.js
+++ b/ui/tests/unit/adapters/secret-engine-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 import apiStub from 'vault/tests/helpers/noop-all-api-requests';
 
 moduleFor('adapter:secret-engine', 'Unit | Adapter | secret engine', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
   beforeEach() {
     this.server = apiStub();
   },

--- a/ui/tests/unit/adapters/secret-test.js
+++ b/ui/tests/unit/adapters/secret-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
 moduleFor('adapter:secret', 'Unit | Adapter | secret', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
 });
 
 test('secret api urls', function(assert) {

--- a/ui/tests/unit/adapters/secret-v2-test.js
+++ b/ui/tests/unit/adapters/secret-v2-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
 moduleFor('adapter:secret-v2', 'Unit | Adapter | secret-v2', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
 });
 
 test('secret api urls', function(assert) {

--- a/ui/tests/unit/adapters/tools-test.js
+++ b/ui/tests/unit/adapters/tools-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
 moduleFor('adapter:tools', 'Unit | Adapter | tools', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
 });
 
 test('wrapping api urls', function(assert) {

--- a/ui/tests/unit/adapters/transit-key-test.js
+++ b/ui/tests/unit/adapters/transit-key-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
 moduleFor('adapter:transit-key', 'Unit | Adapter | transit key', {
-  needs: ['service:auth', 'service:flash-messages'],
+  needs: ['service:auth', 'service:flash-messages', 'service:control-group', 'service:version'],
 });
 
 test('transit api urls', function(assert) {

--- a/ui/tests/unit/services/auth-test.js
+++ b/ui/tests/unit/services/auth-test.js
@@ -118,7 +118,7 @@ let GITHUB_RESPONSE = {
 };
 
 moduleFor('service:auth', 'Unit | Service | auth', {
-  needs: ['service:flash-messages', 'adapter:cluster', 'service:version'],
+  needs: ['service:flash-messages', 'adapter:cluster', 'service:version', 'service:control-group'],
   beforeEach: function() {
     Ember.getOwner(this).lookup('service:flash-messages').registerTypes(['warning']);
     this.store = storage();

--- a/ui/tests/unit/services/control-group-test.js
+++ b/ui/tests/unit/services/control-group-test.js
@@ -1,0 +1,79 @@
+import { moduleFor, test } from 'ember-qunit';
+import { sanitizePath, ensureTrailingSlash } from 'vault/services/console';
+import sinon from 'sinon';
+
+import Ember from 'ember';
+
+let versionStub = Ember.Service.extend();
+let routerStub = Ember.Service.extend({
+  transitionTo: sinon.stub(),
+  urlFor: sinon.stub(),
+});
+
+moduleFor('service:control-group', 'Unit | Service | control group', {
+  beforeEach() {
+    this.register('service:version', versionStub);
+    this.inject.service('version', { as: 'version' });
+    this.register('service:router', routerStub);
+    this.inject.service('router', { as: 'router' });
+  },
+  afterEach() {},
+});
+
+let isOSS = (context) => Ember.set(context, 'version.isOSS', true);
+let isEnt = (context) => Ember.set(context, 'version.isOSS', false);
+let resolvesArgs = (assert, result, expectedArgs) => {
+  return result.then((...args) => {
+    return assert.deepEqual(args, expectedArgs, 'resolves with the passed args');
+  });
+};
+
+[
+  [
+    'it resolves isOSS:true, wrapTTL: true, response: has wrap_info',
+    isOSS,
+    [[{'one': 'two', 'three': 'four'}], {wrap_info: {token: 'foo', accessor: 'bar'}}, true],
+    (assert, result) => resolvesArgs(assert, result, [{'one': 'two', 'three': 'four'}])
+  ],
+  [
+    'it resolves isOSS:true, wrapTTL: false, response: has no wrap_info',
+    isOSS,
+    [[{'one': 'two', 'three': 'four'}], {wrap_info: null}, false],
+    (assert, result) => resolvesArgs(assert, result, [{'one': 'two', 'three': 'four'}])
+  ],
+  [
+    'it resolves isOSS: false and wrapTTL:true response: has wrap_info',
+    isEnt,
+    [[{'one': 'two', 'three': 'four'}], {wrap_info: {token: 'foo', accessor: 'bar'}}, true],
+    (assert, result) => resolvesArgs(assert, result, [{'one': 'two', 'three': 'four'}])
+  ],
+  [
+    'it resolves isOSS: false and wrapTTL:false response: has no wrap_info',
+    isEnt,
+    [[{'one': 'two', 'three': 'four'}], {wrap_info: null}, false],
+    (assert, result) => resolvesArgs(assert, result, [{'one': 'two', 'three': 'four'}])
+  ],
+ [
+    'it rejects isOSS: false, wrapTTL:false, response: has wrap_info',
+    isEnt,
+    [[{'one': 'two', 'three': 'four'}], {foo: 'bar', wrap_info: {token: 'secret', accessor: 'lookup'}}, false],
+    (assert, result) => {
+      return result.then(
+        () => {},
+        (err) => {
+          assert.equal(err.token, 'secret')
+          assert.equal(err.accessor, 'lookup')
+        });
+    }
+  ],
+
+].forEach(function([name, setup, args, expectation]) {
+  test(`checkForControlGroup: ${name}`, function(assert) {
+    if (setup) {
+      setup(this);
+    }
+    let service = this.subject();
+    let result = service.checkForControlGroup(...args);
+    return expectation(assert, result);
+  });
+});

--- a/ui/tests/unit/services/control-group-test.js
+++ b/ui/tests/unit/services/control-group-test.js
@@ -1,5 +1,4 @@
 import { moduleFor, test } from 'ember-qunit';
-import { sanitizePath, ensureTrailingSlash } from 'vault/services/console';
 import sinon from 'sinon';
 
 import Ember from 'ember';
@@ -77,3 +76,19 @@ let resolvesArgs = (assert, result, expectedArgs) => {
     return expectation(assert, result);
   });
 });
+
+test(`handleError: transitions to accessor when there is no transition passed in`, function(assert) {
+  let service = this.subject();
+  service.handleError({ accessor: '12345'});
+  assert.ok(this.router.transitionTo.calledWith('vault.cluster.access.control-group-accessor', '12345'));
+});
+
+test(`logFromError: returns correct content string`, function(assert) {
+  let service = this.subject();
+  let contentString = service.logFromError({ accessor: '12345', creation_path: '/this/path/', token: 'asdf'});
+  assert.ok(this.router.urlFor.calledWith('vault.cluster.access.control-group-accessor', '12345'), 'calls urlFor with accessor');
+  assert.ok(contentString.content.includes('12345'), 'contains accessor');
+  assert.ok(contentString.content.includes('/this/path/'), 'contains creation path');
+  assert.ok(contentString.content.includes('asdf'), 'contains token');
+});
+

--- a/ui/tests/unit/services/control-group-test.js
+++ b/ui/tests/unit/services/control-group-test.js
@@ -57,6 +57,9 @@ let resolvesArgs = (assert, result, expectedArgs) => {
     isEnt,
     [[{'one': 'two', 'three': 'four'}], {foo: 'bar', wrap_info: {token: 'secret', accessor: 'lookup'}}, false],
     (assert, result) => {
+      // ensure failure if we ever don't reject
+      assert.expect(2);
+
       return result.then(
         () => {},
         (err) => {


### PR DESCRIPTION
This is the first step in supporting Control Groups (in Enterprise) in the UI. You can read more about Control Groups here: https://www.vaultproject.io/docs/enterprise/control-groups/index.html. 

At a high level you can gate access to any paths and specify a number of authorizations required, and what Identity Groups they're required from. This is done via a new block in ACL policies or via Sentinel with an EGP or RGP policy. If a user encounters a Control Group gated request, it will be a response wrapped token instead of the data returned from the path. 

In the UI we detect this via the global request path in the application adapter. If it's determined that the response _is_ a Control Group token, then we redirect to a new route where we'll instruct the user what they need to do and what the status of their token is. If you're using the console and request a control grouped path, we show an error in the console and link them to the route mentioned above.

The mechanism for this works as follows: 
There is a new control group service that contains the logic for detecting if a response is a control group. If a control group is not detected the method resolves the params to the adapter's ajax method. If it does detect one, the method rejects with the token information merged onto the error object so that Ember Data does not try to push the token data into the store. Where we make requests (the application adapter, and the console) then catch the error and either redirect or print an error.

Enterprise specific tests don't run in Travis, but the new test do all pass locally:

<img width="827" alt="screen shot 2018-06-08 at 10 01 55 am" src="https://user-images.githubusercontent.com/39469/41165834-474ba0f0-6b04-11e8-9945-36812c6956e9.png">
