### PR TITLE
Fix writing to KVv2 root via `kv put`

### DIFF
--- a/command/kv_destroy.go
+++ b/command/kv_destroy.go
@@ -115,6 +115,9 @@ func (c *KVDestroyCommand) Run(args []string) int {
 	secret, err := client.Logical().Write(path, data)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error writing data to %s: %s", path, err))
+		if secret != nil {
+			OutputSecret(c.UI, secret)
+		}
 		return 2
 	}
 	if secret == nil {

--- a/command/kv_helpers.go
+++ b/command/kv_helpers.go
@@ -99,8 +99,13 @@ func isKVv2(path string, client *api.Client) (string, bool, error) {
 }
 
 func addPrefixToVKVPath(p, mountPath, apiPrefix string) string {
-	p = strings.TrimPrefix(p, mountPath)
-	return path.Join(mountPath, apiPrefix, p)
+	switch {
+	case p == mountPath, p == strings.TrimSuffix(mountPath, "/"):
+		return path.Join(mountPath, apiPrefix)
+	default:
+		p = strings.TrimPrefix(p, mountPath)
+		return path.Join(mountPath, apiPrefix, p)
+	}
 }
 
 func getHeaderForMap(header string, data map[string]interface{}) string {

--- a/command/kv_metadata_delete.go
+++ b/command/kv_metadata_delete.go
@@ -82,8 +82,11 @@ func (c *KVMetadataDeleteCommand) Run(args []string) int {
 	}
 
 	path = addPrefixToVKVPath(path, mountPath, "metadata")
-	if _, err := client.Logical().Delete(path); err != nil {
+	if secret, err := client.Logical().Delete(path); err != nil {
 		c.UI.Error(fmt.Sprintf("Error deleting %s: %s", path, err))
+		if secret != nil {
+			OutputSecret(c.UI, secret)
+		}
 		return 2
 	}
 

--- a/command/kv_metadata_get.go
+++ b/command/kv_metadata_get.go
@@ -105,7 +105,13 @@ func (c *KVMetadataGetCommand) Run(args []string) int {
 		return OutputSecret(c.UI, secret)
 	}
 
-	versions := secret.Data["versions"].(map[string]interface{})
+	versionsRaw, ok := secret.Data["versions"]
+	if !ok || versionsRaw == nil {
+		c.UI.Error(fmt.Sprintf("No value found at %s", path))
+		OutputSecret(c.UI, secret)
+		return 2
+	}
+	versions := versionsRaw.(map[string]interface{})
 
 	delete(secret.Data, "versions")
 

--- a/command/kv_metadata_put.go
+++ b/command/kv_metadata_put.go
@@ -125,6 +125,9 @@ func (c *KVMetadataPutCommand) Run(args []string) int {
 	secret, err := client.Logical().Write(path, data)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error writing data to %s: %s", path, err))
+		if secret != nil {
+			OutputSecret(c.UI, secret)
+		}
 		return 2
 	}
 	if secret == nil {

--- a/command/kv_undelete.go
+++ b/command/kv_undelete.go
@@ -110,6 +110,9 @@ func (c *KVUndeleteCommand) Run(args []string) int {
 	secret, err := client.Logical().Write(path, data)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error writing data to %s: %s", path, err))
+		if secret != nil {
+			OutputSecret(c.UI, secret)
+		}
 		return 2
 	}
 	if secret == nil {


### PR DESCRIPTION
The check that adds the API path wasn't taking into account the root,
e.g. if it's mounted at `kv`, `kv` and `kv/` would end up creating an
extra copy of the mount path in front, leading to paths like
`kv/data/kv`.