### PR TITLE
Some atomic cleanup

### DIFF
--- a/builtin/credential/approle/backend.go
+++ b/builtin/credential/approle/backend.go
@@ -30,7 +30,7 @@ type backend struct {
 	view logical.Storage
 
 	// Guard to clean-up the expired SecretID entries
-	tidySecretIDCASGuard uint32
+	tidySecretIDCASGuard *uint32
 
 	// Locks to make changes to role entries. These will be initialized to a
 	// predefined number of locks when the backend is created, and will be
@@ -85,6 +85,8 @@ func Backend(conf *logical.BackendConfig) (*backend, error) {
 
 		// Create locks to modify the generated SecretIDAccessors
 		secretIDAccessorLocks: locksutil.CreateLocks(),
+
+		tidySecretIDCASGuard: new(uint32),
 	}
 
 	// Attach the paths and secrets that are to be handled by the backend

--- a/builtin/credential/approle/path_tidy_user_id.go
+++ b/builtin/credential/approle/path_tidy_user_id.go
@@ -27,9 +27,9 @@ func pathTidySecretID(b *backend) *framework.Path {
 
 // tidySecretID is used to delete entries in the whitelist that are expired.
 func (b *backend) tidySecretID(ctx context.Context, s logical.Storage) error {
-	grabbed := atomic.CompareAndSwapUint32(&b.tidySecretIDCASGuard, 0, 1)
+	grabbed := atomic.CompareAndSwapUint32(b.tidySecretIDCASGuard, 0, 1)
 	if grabbed {
-		defer atomic.StoreUint32(&b.tidySecretIDCASGuard, 0)
+		defer atomic.StoreUint32(b.tidySecretIDCASGuard, 0)
 	} else {
 		return fmt.Errorf("SecretID tidy operation already running")
 	}

--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -39,8 +39,8 @@ type backend struct {
 	blacklistMutex sync.RWMutex
 
 	// Guards the blacklist/whitelist tidy functions
-	tidyBlacklistCASGuard uint32
-	tidyWhitelistCASGuard uint32
+	tidyBlacklistCASGuard *uint32
+	tidyWhitelistCASGuard *uint32
 
 	// Duration after which the periodic function of the backend needs to
 	// tidy the blacklist and whitelist entries.
@@ -82,10 +82,12 @@ func Backend(conf *logical.BackendConfig) (*backend, error) {
 	b := &backend{
 		// Setting the periodic func to be run once in an hour.
 		// If there is a real need, this can be made configurable.
-		tidyCooldownPeriod:  time.Hour,
-		EC2ClientsMap:       make(map[string]map[string]*ec2.EC2),
-		IAMClientsMap:       make(map[string]map[string]*iam.IAM),
-		iamUserIdToArnCache: cache.New(7*24*time.Hour, 24*time.Hour),
+		tidyCooldownPeriod:    time.Hour,
+		EC2ClientsMap:         make(map[string]map[string]*ec2.EC2),
+		IAMClientsMap:         make(map[string]map[string]*iam.IAM),
+		iamUserIdToArnCache:   cache.New(7*24*time.Hour, 24*time.Hour),
+		tidyBlacklistCASGuard: new(uint32),
+		tidyWhitelistCASGuard: new(uint32),
 	}
 
 	b.resolveArnToUniqueIDFunc = b.resolveArnToRealUniqueId

--- a/builtin/credential/aws/path_tidy_identity_whitelist.go
+++ b/builtin/credential/aws/path_tidy_identity_whitelist.go
@@ -34,9 +34,9 @@ expiration, before it is removed from the backend storage.`,
 
 // tidyWhitelistIdentity is used to delete entries in the whitelist that are expired.
 func (b *backend) tidyWhitelistIdentity(ctx context.Context, s logical.Storage, safety_buffer int) error {
-	grabbed := atomic.CompareAndSwapUint32(&b.tidyWhitelistCASGuard, 0, 1)
+	grabbed := atomic.CompareAndSwapUint32(b.tidyWhitelistCASGuard, 0, 1)
 	if grabbed {
-		defer atomic.StoreUint32(&b.tidyWhitelistCASGuard, 0)
+		defer atomic.StoreUint32(b.tidyWhitelistCASGuard, 0)
 	} else {
 		return fmt.Errorf("identity whitelist tidy operation already running")
 	}

--- a/builtin/credential/aws/path_tidy_roletag_blacklist.go
+++ b/builtin/credential/aws/path_tidy_roletag_blacklist.go
@@ -34,9 +34,9 @@ expiration, before it is removed from the backend storage.`,
 
 // tidyBlacklistRoleTag is used to clean-up the entries in the role tag blacklist.
 func (b *backend) tidyBlacklistRoleTag(ctx context.Context, s logical.Storage, safety_buffer int) error {
-	grabbed := atomic.CompareAndSwapUint32(&b.tidyBlacklistCASGuard, 0, 1)
+	grabbed := atomic.CompareAndSwapUint32(b.tidyBlacklistCASGuard, 0, 1)
 	if grabbed {
-		defer atomic.StoreUint32(&b.tidyBlacklistCASGuard, 0)
+		defer atomic.StoreUint32(b.tidyBlacklistCASGuard, 0)
 	} else {
 		return fmt.Errorf("roletag blacklist tidy operation already running")
 	}

--- a/logical/framework/backend_test.go
+++ b/logical/framework/backend_test.go
@@ -203,9 +203,9 @@ func TestBackendHandleRequest_renewAuth(t *testing.T) {
 }
 
 func TestBackendHandleRequest_renewAuthCallback(t *testing.T) {
-	var called uint32
+	called := new(uint32)
 	callback := func(context.Context, *logical.Request, *FieldData) (*logical.Response, error) {
-		atomic.AddUint32(&called, 1)
+		atomic.AddUint32(called, 1)
 		return nil, nil
 	}
 
@@ -217,14 +217,14 @@ func TestBackendHandleRequest_renewAuthCallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if v := atomic.LoadUint32(&called); v != 1 {
+	if v := atomic.LoadUint32(called); v != 1 {
 		t.Fatalf("bad: %#v", v)
 	}
 }
 func TestBackendHandleRequest_renew(t *testing.T) {
-	var called uint32
+	called := new(uint32)
 	callback := func(context.Context, *logical.Request, *FieldData) (*logical.Response, error) {
-		atomic.AddUint32(&called, 1)
+		atomic.AddUint32(called, 1)
 		return nil, nil
 	}
 
@@ -240,15 +240,15 @@ func TestBackendHandleRequest_renew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if v := atomic.LoadUint32(&called); v != 1 {
+	if v := atomic.LoadUint32(called); v != 1 {
 		t.Fatalf("bad: %#v", v)
 	}
 }
 
 func TestBackendHandleRequest_revoke(t *testing.T) {
-	var called uint32
+	called := new(uint32)
 	callback := func(context.Context, *logical.Request, *FieldData) (*logical.Response, error) {
-		atomic.AddUint32(&called, 1)
+		atomic.AddUint32(called, 1)
 		return nil, nil
 	}
 
@@ -264,16 +264,16 @@ func TestBackendHandleRequest_revoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if v := atomic.LoadUint32(&called); v != 1 {
+	if v := atomic.LoadUint32(called); v != 1 {
 		t.Fatalf("bad: %#v", v)
 	}
 }
 
 func TestBackendHandleRequest_rollback(t *testing.T) {
-	var called uint32
+	called := new(uint32)
 	callback := func(_ context.Context, req *logical.Request, kind string, data interface{}) error {
 		if data == "foo" {
-			atomic.AddUint32(&called, 1)
+			atomic.AddUint32(called, 1)
 		}
 		return nil
 	}
@@ -298,16 +298,16 @@ func TestBackendHandleRequest_rollback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if v := atomic.LoadUint32(&called); v != 1 {
+	if v := atomic.LoadUint32(called); v != 1 {
 		t.Fatalf("bad: %#v", v)
 	}
 }
 
 func TestBackendHandleRequest_rollbackMinAge(t *testing.T) {
-	var called uint32
+	called := new(uint32)
 	callback := func(_ context.Context, req *logical.Request, kind string, data interface{}) error {
 		if data == "foo" {
-			atomic.AddUint32(&called, 1)
+			atomic.AddUint32(called, 1)
 		}
 		return nil
 	}
@@ -330,7 +330,7 @@ func TestBackendHandleRequest_rollbackMinAge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if v := atomic.LoadUint32(&called); v != 0 {
+	if v := atomic.LoadUint32(called); v != 0 {
 		t.Fatalf("bad: %#v", v)
 	}
 }

--- a/physical/inmem/inmem.go
+++ b/physical/inmem/inmem.go
@@ -36,10 +36,10 @@ type InmemBackend struct {
 	root       *radix.Tree
 	permitPool *physical.PermitPool
 	logger     log.Logger
-	failGet    uint32
-	failPut    uint32
-	failDelete uint32
-	failList   uint32
+	failGet    *uint32
+	failPut    *uint32
+	failDelete *uint32
+	failList   *uint32
 }
 
 type TransactionalInmemBackend struct {
@@ -52,6 +52,10 @@ func NewInmem(_ map[string]string, logger log.Logger) (physical.Backend, error) 
 		root:       radix.New(),
 		permitPool: physical.NewPermitPool(physical.DefaultParallelOperations),
 		logger:     logger,
+		failGet:    new(uint32),
+		failPut:    new(uint32),
+		failDelete: new(uint32),
+		failList:   new(uint32),
 	}
 	return in, nil
 }
@@ -81,7 +85,7 @@ func (i *InmemBackend) Put(ctx context.Context, entry *physical.Entry) error {
 }
 
 func (i *InmemBackend) PutInternal(ctx context.Context, entry *physical.Entry) error {
-	if atomic.LoadUint32(&i.failPut) != 0 {
+	if atomic.LoadUint32(i.failPut) != 0 {
 		return PutDisabledError
 	}
 
@@ -94,7 +98,7 @@ func (i *InmemBackend) FailPut(fail bool) {
 	if fail {
 		val = 1
 	}
-	atomic.StoreUint32(&i.failPut, val)
+	atomic.StoreUint32(i.failPut, val)
 }
 
 // Get is used to fetch an entry
@@ -109,7 +113,7 @@ func (i *InmemBackend) Get(ctx context.Context, key string) (*physical.Entry, er
 }
 
 func (i *InmemBackend) GetInternal(ctx context.Context, key string) (*physical.Entry, error) {
-	if atomic.LoadUint32(&i.failGet) != 0 {
+	if atomic.LoadUint32(i.failGet) != 0 {
 		return nil, GetDisabledError
 	}
 
@@ -127,7 +131,7 @@ func (i *InmemBackend) FailGet(fail bool) {
 	if fail {
 		val = 1
 	}
-	atomic.StoreUint32(&i.failGet, val)
+	atomic.StoreUint32(i.failGet, val)
 }
 
 // Delete is used to permanently delete an entry
@@ -142,7 +146,7 @@ func (i *InmemBackend) Delete(ctx context.Context, key string) error {
 }
 
 func (i *InmemBackend) DeleteInternal(ctx context.Context, key string) error {
-	if atomic.LoadUint32(&i.failDelete) != 0 {
+	if atomic.LoadUint32(i.failDelete) != 0 {
 		return DeleteDisabledError
 	}
 
@@ -155,7 +159,7 @@ func (i *InmemBackend) FailDelete(fail bool) {
 	if fail {
 		val = 1
 	}
-	atomic.StoreUint32(&i.failDelete, val)
+	atomic.StoreUint32(i.failDelete, val)
 }
 
 // List is used ot list all the keys under a given
@@ -171,7 +175,7 @@ func (i *InmemBackend) List(ctx context.Context, prefix string) ([]string, error
 }
 
 func (i *InmemBackend) ListInternal(prefix string) ([]string, error) {
-	if atomic.LoadUint32(&i.failList) != 0 {
+	if atomic.LoadUint32(i.failList) != 0 {
 		return nil, ListDisabledError
 	}
 
@@ -201,7 +205,7 @@ func (i *InmemBackend) FailList(fail bool) {
 	if fail {
 		val = 1
 	}
-	atomic.StoreUint32(&i.failList, val)
+	atomic.StoreUint32(i.failList, val)
 }
 
 // Implements the transaction interface

--- a/vault/cors.go
+++ b/vault/cors.go
@@ -32,7 +32,7 @@ var StdAllowedHeaders = []string{
 type CORSConfig struct {
 	sync.RWMutex   `json:"-"`
 	core           *Core
-	Enabled        uint32   `json:"enabled"`
+	Enabled        *uint32  `json:"enabled"`
 	AllowedOrigins []string `json:"allowed_origins,omitempty"`
 	AllowedHeaders []string `json:"allowed_headers,omitempty"`
 }
@@ -40,8 +40,9 @@ type CORSConfig struct {
 func (c *Core) saveCORSConfig(ctx context.Context) error {
 	view := c.systemBarrierView.SubView("config/")
 
+	enabled := atomic.LoadUint32(c.corsConfig.Enabled)
 	localConfig := &CORSConfig{
-		Enabled: atomic.LoadUint32(&c.corsConfig.Enabled),
+		Enabled: &enabled,
 	}
 	c.corsConfig.RLock()
 	localConfig.AllowedOrigins = c.corsConfig.AllowedOrigins
@@ -109,19 +110,19 @@ func (c *CORSConfig) Enable(ctx context.Context, urls []string, headers []string
 	}
 	c.Unlock()
 
-	atomic.StoreUint32(&c.Enabled, CORSEnabled)
+	atomic.StoreUint32(c.Enabled, CORSEnabled)
 
 	return c.core.saveCORSConfig(ctx)
 }
 
 // IsEnabled returns the value of CORSConfig.isEnabled
 func (c *CORSConfig) IsEnabled() bool {
-	return atomic.LoadUint32(&c.Enabled) == CORSEnabled
+	return atomic.LoadUint32(c.Enabled) == CORSEnabled
 }
 
 // Disable sets CORS to disabled and clears the allowed origins & headers.
 func (c *CORSConfig) Disable(ctx context.Context) error {
-	atomic.StoreUint32(&c.Enabled, CORSDisabled)
+	atomic.StoreUint32(c.Enabled, CORSDisabled)
 	c.Lock()
 
 	c.AllowedOrigins = nil

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -29,17 +29,18 @@ func (c *Core) Standby() (bool, error) {
 
 // Leader is used to get the current active leader
 func (c *Core) Leader() (isLeader bool, leaderAddr, clusterAddr string, err error) {
+	// Check if HA enabled. We don't need the lock for this check as it's set
+	// on startup and never modified
+	if c.ha == nil {
+		return false, "", "", ErrHANotEnabled
+	}
+
 	c.stateLock.RLock()
 	defer c.stateLock.RUnlock()
 
 	// Check if sealed
 	if c.sealed {
 		return false, "", "", consts.ErrSealed
-	}
-
-	// Check if HA enabled
-	if c.ha == nil {
-		return false, "", "", ErrHANotEnabled
 	}
 
 	// Check if we are the leader
@@ -419,7 +420,7 @@ func (c *Core) runStandby(doneCh, manualStepDownCh, stopCh chan struct{}) {
 		case <-stopCh:
 			// This case comes from sealInternal; we will already be having the
 			// state lock held so we do toggle grabStateLock to false
-			if atomic.LoadUint32(&c.keepHALockOnStepDown) == 1 {
+			if atomic.LoadUint32(c.keepHALockOnStepDown) == 1 {
 				releaseHALock = false
 			}
 			grabStateLock = false
@@ -466,13 +467,13 @@ func (c *Core) runStandby(doneCh, manualStepDownCh, stopCh chan struct{}) {
 // the result.
 func (c *Core) periodicLeaderRefresh(doneCh, stopCh chan struct{}) {
 	defer close(doneCh)
-	var opCount int32
+	opCount := new(int32)
 	for {
 		select {
 		case <-time.After(leaderCheckInterval):
-			count := atomic.AddInt32(&opCount, 1)
+			count := atomic.AddInt32(opCount, 1)
 			if count > 1 {
-				atomic.AddInt32(&opCount, -1)
+				atomic.AddInt32(opCount, -1)
 				continue
 			}
 			// We do this in a goroutine because otherwise if this refresh is
@@ -480,7 +481,7 @@ func (c *Core) periodicLeaderRefresh(doneCh, stopCh chan struct{}) {
 			// deadlock, which then means stopCh can never been seen and we can
 			// block shutdown
 			go func() {
-				defer atomic.AddInt32(&opCount, -1)
+				defer atomic.AddInt32(opCount, -1)
 				c.Leader()
 			}()
 		case <-stopCh:
@@ -492,18 +493,18 @@ func (c *Core) periodicLeaderRefresh(doneCh, stopCh chan struct{}) {
 // periodicCheckKeyUpgrade is used to watch for key rotation events as a standby
 func (c *Core) periodicCheckKeyUpgrade(ctx context.Context, doneCh, stopCh chan struct{}) {
 	defer close(doneCh)
-	var opCount int32
+	opCount := new(int32)
 	for {
 		select {
 		case <-time.After(keyRotateCheckInterval):
-			count := atomic.AddInt32(&opCount, 1)
+			count := atomic.AddInt32(opCount, 1)
 			if count > 1 {
-				atomic.AddInt32(&opCount, -1)
+				atomic.AddInt32(opCount, -1)
 				continue
 			}
 
 			go func() {
-				defer atomic.AddInt32(&opCount, -1)
+				defer atomic.AddInt32(opCount, -1)
 				// Only check if we are a standby
 				c.stateLock.RLock()
 				standby := c.standby

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -79,7 +79,7 @@ func (c *Core) startForwarding(ctx context.Context) error {
 	fws := &http2.Server{}
 
 	// Shutdown coordination logic
-	var shutdown uint32
+	shutdown := new(uint32)
 	shutdownWg := &sync.WaitGroup{}
 
 	for _, addr := range c.clusterListenerAddrs {
@@ -120,7 +120,7 @@ func (c *Core) startForwarding(ctx context.Context) error {
 			}
 
 			for {
-				if atomic.LoadUint32(&shutdown) > 0 {
+				if atomic.LoadUint32(shutdown) > 0 {
 					return
 				}
 
@@ -213,7 +213,7 @@ func (c *Core) startForwarding(ctx context.Context) error {
 
 		// Set the shutdown flag. This will cause the listeners to shut down
 		// within the deadline in clusterListenerAcceptDeadline
-		atomic.StoreUint32(&shutdown, 1)
+		atomic.StoreUint32(shutdown, 1)
 		c.logger.Info("forwarding rpc listeners stopped")
 
 		// Wait for them all to shut down

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -733,7 +733,7 @@ func TestTokenStore_CreateLookup_ExpirationInRestoreMode(t *testing.T) {
 
 	// Reset expiration manager to restore mode
 	ts.expiration.restoreModeLock.Lock()
-	atomic.StoreInt32(&ts.expiration.restoreMode, 1)
+	atomic.StoreInt32(ts.expiration.restoreMode, 1)
 	ts.expiration.restoreLocks = locksutil.CreateLocks()
 	ts.expiration.restoreModeLock.Unlock()
 


### PR DESCRIPTION
Taking inspiration from
https://github.com/golang/go/issues/17604#issuecomment-256384471
suggests that taking the address of a stack variable for use in atomics
works (at least, the race detector doesn't complain) but is doing it
wrong.

The only other change is a change in Leader() detecting if HA is enabled
to fast-path out. This value never changes after NewCore, so we don't
need to grab the read lock to check it.