### PR TITLE
Remove a lot of deferred functions in the request path.

### DIFF
--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -142,14 +142,15 @@ func (b *AESGCMBarrier) Initialize(ctx context.Context, key []byte) error {
 func (b *AESGCMBarrier) persistKeyring(ctx context.Context, keyring *Keyring) error {
 	// Create the keyring entry
 	keyringBuf, err := keyring.Serialize()
-	defer memzero(keyringBuf)
 	if err != nil {
+		memzero(keyringBuf)
 		return errwrap.Wrapf("failed to serialize keyring: {{err}}", err)
 	}
 
 	// Create the AES-GCM
 	gcm, err := b.aeadFromKey(keyring.MasterKey())
 	if err != nil {
+		memzero(keyringBuf)
 		return err
 	}
 
@@ -162,6 +163,7 @@ func (b *AESGCMBarrier) persistKeyring(ctx context.Context, keyring *Keyring) er
 		Value: value,
 	}
 	if err := b.backend.Put(ctx, pe); err != nil {
+		memzero(keyringBuf)
 		return errwrap.Wrapf("failed to persist keyring: {{err}}", err)
 	}
 
@@ -172,8 +174,9 @@ func (b *AESGCMBarrier) persistKeyring(ctx context.Context, keyring *Keyring) er
 		Value:   keyring.MasterKey(),
 	}
 	keyBuf, err := key.Serialize()
-	defer memzero(keyBuf)
 	if err != nil {
+		memzero(keyringBuf)
+		memzero(keyBuf)
 		return errwrap.Wrapf("failed to serialize master key: {{err}}", err)
 	}
 
@@ -181,6 +184,8 @@ func (b *AESGCMBarrier) persistKeyring(ctx context.Context, keyring *Keyring) er
 	activeKey := keyring.ActiveKey()
 	aead, err := b.aeadFromKey(activeKey.Value)
 	if err != nil {
+		memzero(keyringBuf)
+		memzero(keyBuf)
 		return err
 	}
 	value = b.encrypt(masterKeyPath, activeKey.Term, aead, keyBuf)
@@ -191,8 +196,13 @@ func (b *AESGCMBarrier) persistKeyring(ctx context.Context, keyring *Keyring) er
 		Value: value,
 	}
 	if err := b.backend.Put(ctx, pe); err != nil {
+		memzero(keyringBuf)
+		memzero(keyBuf)
 		return errwrap.Wrapf("failed to persist master key: {{err}}", err)
 	}
+
+	memzero(keyringBuf)
+	memzero(keyBuf)
 	return nil
 }
 
@@ -213,20 +223,23 @@ func (b *AESGCMBarrier) KeyLength() (int, int) {
 // is not expected to be able to perform any CRUD until it is unsealed.
 func (b *AESGCMBarrier) Sealed() (bool, error) {
 	b.l.RLock()
-	defer b.l.RUnlock()
-	return b.sealed, nil
+	sealed := b.sealed
+	b.l.RUnlock()
+	return sealed, nil
 }
 
 // VerifyMaster is used to check if the given key matches the master key
 func (b *AESGCMBarrier) VerifyMaster(key []byte) error {
 	b.l.RLock()
-	defer b.l.RUnlock()
 	if b.sealed {
+		b.l.RUnlock()
 		return ErrBarrierSealed
 	}
 	if subtle.ConstantTimeCompare(key, b.keyring.MasterKey()) != 1 {
+		b.l.RUnlock()
 		return ErrBarrierInvalidKey
 	}
+	b.l.RUnlock()
 	return nil
 }
 
@@ -235,44 +248,53 @@ func (b *AESGCMBarrier) VerifyMaster(key []byte) error {
 // is present in the leader.
 func (b *AESGCMBarrier) ReloadKeyring(ctx context.Context) error {
 	b.l.Lock()
-	defer b.l.Unlock()
 
 	// Create the AES-GCM
 	gcm, err := b.aeadFromKey(b.keyring.MasterKey())
 	if err != nil {
+		b.l.Unlock()
 		return err
 	}
 
 	// Read in the keyring
 	out, err := b.backend.Get(ctx, keyringPath)
 	if err != nil {
+		b.l.Unlock()
 		return errwrap.Wrapf("failed to check for keyring: {{err}}", err)
 	}
 
 	// Ensure that the keyring exists. This should never happen,
 	// and indicates something really bad has happened.
 	if out == nil {
+		b.l.Unlock()
 		return fmt.Errorf("keyring unexpectedly missing")
 	}
 
 	// Decrypt the barrier init key
 	plain, err := b.decrypt(keyringPath, gcm, out.Value)
-	defer memzero(plain)
 	if err != nil {
 		if strings.Contains(err.Error(), "message authentication failed") {
+			b.l.Unlock()
+			memzero(plain)
 			return ErrBarrierInvalidKey
 		}
+		b.l.Unlock()
+		memzero(plain)
 		return err
 	}
 
 	// Recover the keyring
 	keyring, err := DeserializeKeyring(plain)
 	if err != nil {
+		b.l.Unlock()
+		memzero(plain)
 		return errwrap.Wrapf("keyring deserialization failed: {{err}}", err)
 	}
 
 	// Setup the keyring and finish
 	b.keyring = keyring
+	b.l.Unlock()
+	memzero(plain)
 	return nil
 }
 
@@ -293,19 +315,19 @@ func (b *AESGCMBarrier) ReloadMasterKey(ctx context.Context) error {
 		return nil
 	}
 
-	defer memzero(out.Value)
-
 	// Deserialize the master key
 	key, err := DeserializeKey(out.Value)
 	if err != nil {
+		memzero(out.Value)
 		return errwrap.Wrapf("failed to deserialize key: {{err}}", err)
 	}
 
 	b.l.Lock()
-	defer b.l.Unlock()
 
 	// Check if the master key is the same
 	if subtle.ConstantTimeCompare(b.keyring.MasterKey(), key.Value) == 1 {
+		b.l.Unlock()
+		memzero(out.Value)
 		return nil
 	}
 
@@ -313,6 +335,8 @@ func (b *AESGCMBarrier) ReloadMasterKey(ctx context.Context) error {
 	oldKeyring := b.keyring
 	b.keyring = b.keyring.SetMasterKey(key.Value)
 	oldKeyring.Zeroize(false)
+	b.l.Unlock()
+	memzero(out.Value)
 	return nil
 }
 
@@ -320,53 +344,62 @@ func (b *AESGCMBarrier) ReloadMasterKey(ctx context.Context) error {
 // to be unsealed. If the key is not correct, the barrier remains sealed.
 func (b *AESGCMBarrier) Unseal(ctx context.Context, key []byte) error {
 	b.l.Lock()
-	defer b.l.Unlock()
 
 	// Do nothing if already unsealed
 	if !b.sealed {
+		b.l.Unlock()
 		return nil
 	}
 
 	// Create the AES-GCM
 	gcm, err := b.aeadFromKey(key)
 	if err != nil {
+		b.l.Unlock()
 		return err
 	}
 
 	// Read in the keyring
 	out, err := b.backend.Get(ctx, keyringPath)
 	if err != nil {
+		b.l.Unlock()
 		return errwrap.Wrapf("failed to check for keyring: {{err}}", err)
 	}
 	if out != nil {
 		// Decrypt the barrier init key
 		plain, err := b.decrypt(keyringPath, gcm, out.Value)
-		defer memzero(plain)
 		if err != nil {
 			if strings.Contains(err.Error(), "message authentication failed") {
+				b.l.Unlock()
+				memzero(plain)
 				return ErrBarrierInvalidKey
 			}
+			b.l.Unlock()
+			memzero(plain)
 			return err
 		}
 
 		// Recover the keyring
 		keyring, err := DeserializeKeyring(plain)
 		if err != nil {
+			b.l.Unlock()
 			return errwrap.Wrapf("keyring deserialization failed: {{err}}", err)
 		}
 
 		// Setup the keyring and finish
 		b.keyring = keyring
 		b.sealed = false
+		b.l.Unlock()
 		return nil
 	}
 
 	// Read the barrier initialization key
 	out, err = b.backend.Get(ctx, barrierInitPath)
 	if err != nil {
+		b.l.Unlock()
 		return errwrap.Wrapf("failed to check for initialization: {{err}}", err)
 	}
 	if out == nil {
+		b.l.Unlock()
 		return ErrBarrierNotInit
 	}
 
@@ -374,15 +407,18 @@ func (b *AESGCMBarrier) Unseal(ctx context.Context, key []byte) error {
 	plain, err := b.decrypt(barrierInitPath, gcm, out.Value)
 	if err != nil {
 		if strings.Contains(err.Error(), "message authentication failed") {
+			b.l.Unlock()
 			return ErrBarrierInvalidKey
 		}
+		b.l.Unlock()
 		return err
 	}
-	defer memzero(plain)
 
 	// Unmarshal the barrier init
 	var init barrierInit
 	if err := jsonutil.DecodeJSON(plain, &init); err != nil {
+		b.l.Unlock()
+		memzero(plain)
 		return fmt.Errorf("failed to unmarshal barrier init file")
 	}
 
@@ -391,28 +427,38 @@ func (b *AESGCMBarrier) Unseal(ctx context.Context, key []byte) error {
 	keyring := keyringNew.SetMasterKey(key)
 
 	// AddKey reuses the master, so we are only zeroizing after this call
-	defer keyringNew.Zeroize(false)
-
 	keyring, err = keyring.AddKey(&Key{
 		Term:    1,
 		Version: 1,
 		Value:   init.Key,
 	})
 	if err != nil {
+		b.l.Unlock()
+		keyringNew.Zeroize(false)
+		memzero(plain)
 		return errwrap.Wrapf("failed to create keyring: {{err}}", err)
 	}
 	if err := b.persistKeyring(ctx, keyring); err != nil {
+		b.l.Unlock()
+		keyringNew.Zeroize(false)
+		memzero(plain)
 		return err
 	}
 
 	// Delete the old barrier entry
 	if err := b.backend.Delete(ctx, barrierInitPath); err != nil {
+		b.l.Unlock()
+		keyringNew.Zeroize(false)
+		memzero(plain)
 		return errwrap.Wrapf("failed to delete barrier init file: {{err}}", err)
 	}
 
 	// Set the vault as unsealed
 	b.keyring = keyring
 	b.sealed = false
+	b.l.Unlock()
+	keyringNew.Zeroize(false)
+	memzero(plain)
 	return nil
 }
 
@@ -420,13 +466,14 @@ func (b *AESGCMBarrier) Unseal(ctx context.Context, key []byte) error {
 // be unsealed again to perform any further operations.
 func (b *AESGCMBarrier) Seal() error {
 	b.l.Lock()
-	defer b.l.Unlock()
 
 	// Remove the primary key, and seal the vault
 	b.cache = make(map[uint32]cipher.AEAD)
 	b.keyring.Zeroize(true)
 	b.keyring = nil
 	b.sealed = true
+
+	b.l.Unlock()
 	return nil
 }
 
@@ -434,14 +481,15 @@ func (b *AESGCMBarrier) Seal() error {
 // should use the new key, while old values should still be decryptable.
 func (b *AESGCMBarrier) Rotate(ctx context.Context) (uint32, error) {
 	b.l.Lock()
-	defer b.l.Unlock()
 	if b.sealed {
+		b.l.Unlock()
 		return 0, ErrBarrierSealed
 	}
 
 	// Generate a new key
 	encrypt, err := b.GenerateKey()
 	if err != nil {
+		b.l.Unlock()
 		return 0, errwrap.Wrapf("failed to generate encryption key: {{err}}", err)
 	}
 
@@ -456,32 +504,36 @@ func (b *AESGCMBarrier) Rotate(ctx context.Context) (uint32, error) {
 		Value:   encrypt,
 	})
 	if err != nil {
+		b.l.Unlock()
 		return 0, errwrap.Wrapf("failed to add new encryption key: {{err}}", err)
 	}
 
 	// Persist the new keyring
 	if err := b.persistKeyring(ctx, newKeyring); err != nil {
+		b.l.Unlock()
 		return 0, err
 	}
 
 	// Swap the keyrings
 	b.keyring = newKeyring
+	b.l.Unlock()
 	return newTerm, nil
 }
 
 // CreateUpgrade creates an upgrade path key to the given term from the previous term
 func (b *AESGCMBarrier) CreateUpgrade(ctx context.Context, term uint32) error {
 	b.l.RLock()
-	defer b.l.RUnlock()
 	if b.sealed {
+		b.l.RUnlock()
 		return ErrBarrierSealed
 	}
 
 	// Get the key for this term
 	termKey := b.keyring.TermKey(term)
 	buf, err := termKey.Serialize()
-	defer memzero(buf)
 	if err != nil {
+		b.l.RUnlock()
+		memzero(buf)
 		return err
 	}
 
@@ -489,6 +541,8 @@ func (b *AESGCMBarrier) CreateUpgrade(ctx context.Context, term uint32) error {
 	prevTerm := term - 1
 	primary, err := b.aeadForTerm(prevTerm)
 	if err != nil {
+		b.l.RUnlock()
+		memzero(buf)
 		return err
 	}
 
@@ -499,6 +553,8 @@ func (b *AESGCMBarrier) CreateUpgrade(ctx context.Context, term uint32) error {
 		Key:   key,
 		Value: value,
 	}
+	b.l.RUnlock()
+	memzero(buf)
 	return b.backend.Put(ctx, pe)
 }
 
@@ -511,8 +567,8 @@ func (b *AESGCMBarrier) DestroyUpgrade(ctx context.Context, term uint32) error {
 // CheckUpgrade looks for an upgrade to the current term and installs it
 func (b *AESGCMBarrier) CheckUpgrade(ctx context.Context) (bool, uint32, error) {
 	b.l.RLock()
-	defer b.l.RUnlock()
 	if b.sealed {
+		b.l.RUnlock()
 		return false, 0, ErrBarrierSealed
 	}
 
@@ -523,44 +579,49 @@ func (b *AESGCMBarrier) CheckUpgrade(ctx context.Context) (bool, uint32, error) 
 	upgrade := fmt.Sprintf("%s%d", keyringUpgradePrefix, activeTerm)
 	entry, err := b.Get(ctx, upgrade)
 	if err != nil {
+		b.l.RUnlock()
 		return false, 0, err
 	}
 
 	// Nothing to do if no upgrade
 	if entry == nil {
+		b.l.RUnlock()
 		return false, 0, nil
 	}
-
-	defer memzero(entry.Value)
 
 	// Deserialize the key
 	key, err := DeserializeKey(entry.Value)
 	if err != nil {
+		b.l.RUnlock()
+		memzero(entry.Value)
 		return false, 0, err
 	}
 
 	// Upgrade from read lock to write lock
 	b.l.RUnlock()
-	defer b.l.RLock()
 	b.l.Lock()
-	defer b.l.Unlock()
 
 	// Update the keyring
 	newKeyring, err := b.keyring.AddKey(key)
 	if err != nil {
+		b.l.Unlock()
+		memzero(entry.Value)
 		return false, 0, errwrap.Wrapf("failed to add new encryption key: {{err}}", err)
 	}
 	b.keyring = newKeyring
 
 	// Done!
+	b.l.Unlock()
+	memzero(entry.Value)
 	return true, key.Term, nil
 }
 
 // ActiveKeyInfo is used to inform details about the active key
 func (b *AESGCMBarrier) ActiveKeyInfo() (*KeyInfo, error) {
 	b.l.RLock()
-	defer b.l.RUnlock()
+
 	if b.sealed {
+		b.l.RUnlock()
 		return nil, ErrBarrierSealed
 	}
 
@@ -573,21 +634,23 @@ func (b *AESGCMBarrier) ActiveKeyInfo() (*KeyInfo, error) {
 		Term:        int(term),
 		InstallTime: key.InstallTime,
 	}
+	b.l.RUnlock()
 	return info, nil
 }
 
 // Rekey is used to change the master key used to protect the keyring
 func (b *AESGCMBarrier) Rekey(ctx context.Context, key []byte) error {
 	b.l.Lock()
-	defer b.l.Unlock()
 
 	newKeyring, err := b.updateMasterKeyCommon(key)
 	if err != nil {
+		b.l.Unlock()
 		return err
 	}
 
 	// Persist the new keyring
 	if err := b.persistKeyring(ctx, newKeyring); err != nil {
+		b.l.Unlock()
 		return err
 	}
 
@@ -595,6 +658,7 @@ func (b *AESGCMBarrier) Rekey(ctx context.Context, key []byte) error {
 	oldKeyring := b.keyring
 	b.keyring = newKeyring
 	oldKeyring.Zeroize(false)
+	b.l.Unlock()
 	return nil
 }
 
@@ -602,10 +666,10 @@ func (b *AESGCMBarrier) Rekey(ctx context.Context, key []byte) error {
 // anything to storage
 func (b *AESGCMBarrier) SetMasterKey(key []byte) error {
 	b.l.Lock()
-	defer b.l.Unlock()
 
 	newKeyring, err := b.updateMasterKeyCommon(key)
 	if err != nil {
+		b.l.Unlock()
 		return err
 	}
 
@@ -613,6 +677,7 @@ func (b *AESGCMBarrier) SetMasterKey(key []byte) error {
 	oldKeyring := b.keyring
 	b.keyring = newKeyring
 	oldKeyring.Zeroize(false)
+	b.l.Unlock()
 	return nil
 }
 
@@ -636,14 +701,16 @@ func (b *AESGCMBarrier) updateMasterKeyCommon(key []byte) (*Keyring, error) {
 func (b *AESGCMBarrier) Put(ctx context.Context, entry *Entry) error {
 	defer metrics.MeasureSince([]string{"barrier", "put"}, time.Now())
 	b.l.RLock()
-	defer b.l.RUnlock()
+
 	if b.sealed {
+		b.l.RUnlock()
 		return ErrBarrierSealed
 	}
 
 	term := b.keyring.ActiveTerm()
 	primary, err := b.aeadForTerm(term)
 	if err != nil {
+		b.l.RUnlock()
 		return err
 	}
 
@@ -652,6 +719,7 @@ func (b *AESGCMBarrier) Put(ctx context.Context, entry *Entry) error {
 		Value:    b.encrypt(entry.Key, term, primary, entry.Value),
 		SealWrap: entry.SealWrap,
 	}
+	b.l.RUnlock()
 	return b.backend.Put(ctx, pe)
 }
 
@@ -659,22 +727,26 @@ func (b *AESGCMBarrier) Put(ctx context.Context, entry *Entry) error {
 func (b *AESGCMBarrier) Get(ctx context.Context, key string) (*Entry, error) {
 	defer metrics.MeasureSince([]string{"barrier", "get"}, time.Now())
 	b.l.RLock()
-	defer b.l.RUnlock()
+
 	if b.sealed {
+		b.l.RUnlock()
 		return nil, ErrBarrierSealed
 	}
 
 	// Read the key from the backend
 	pe, err := b.backend.Get(ctx, key)
 	if err != nil {
+		b.l.RUnlock()
 		return nil, err
 	} else if pe == nil {
+		b.l.RUnlock()
 		return nil, nil
 	}
 
 	// Decrypt the ciphertext
 	plain, err := b.decryptKeyring(key, pe.Value)
 	if err != nil {
+		b.l.RUnlock()
 		return nil, errwrap.Wrapf("decryption failed: {{err}}", err)
 	}
 
@@ -684,15 +756,20 @@ func (b *AESGCMBarrier) Get(ctx context.Context, key string) (*Entry, error) {
 		Value:    plain,
 		SealWrap: pe.SealWrap,
 	}
+
+	b.l.RUnlock()
 	return entry, nil
 }
 
 // Delete is used to permanently delete an entry
 func (b *AESGCMBarrier) Delete(ctx context.Context, key string) error {
 	defer metrics.MeasureSince([]string{"barrier", "delete"}, time.Now())
+
 	b.l.RLock()
-	defer b.l.RUnlock()
-	if b.sealed {
+	sealed := b.sealed
+	b.l.RUnlock()
+
+	if sealed {
 		return ErrBarrierSealed
 	}
 
@@ -703,9 +780,12 @@ func (b *AESGCMBarrier) Delete(ctx context.Context, key string) error {
 // prefix, up to the next prefix.
 func (b *AESGCMBarrier) List(ctx context.Context, prefix string) ([]string, error) {
 	defer metrics.MeasureSince([]string{"barrier", "list"}, time.Now())
+
 	b.l.RLock()
-	defer b.l.RUnlock()
-	if b.sealed {
+	sealed := b.sealed
+	b.l.RUnlock()
+
+	if sealed {
 		return nil, ErrBarrierSealed
 	}
 
@@ -852,43 +932,53 @@ func (b *AESGCMBarrier) decryptKeyring(path string, cipher []byte) ([]byte, erro
 // Encrypt is used to encrypt in-memory for the BarrierEncryptor interface
 func (b *AESGCMBarrier) Encrypt(ctx context.Context, key string, plaintext []byte) ([]byte, error) {
 	b.l.RLock()
-	defer b.l.RUnlock()
+
 	if b.sealed {
+		b.l.RUnlock()
 		return nil, ErrBarrierSealed
 	}
 
 	term := b.keyring.ActiveTerm()
 	primary, err := b.aeadForTerm(term)
 	if err != nil {
+		b.l.RUnlock()
 		return nil, err
 	}
 
 	ciphertext := b.encrypt(key, term, primary, plaintext)
+
+	b.l.RUnlock()
 	return ciphertext, nil
 }
 
 // Decrypt is used to decrypt in-memory for the BarrierEncryptor interface
 func (b *AESGCMBarrier) Decrypt(ctx context.Context, key string, ciphertext []byte) ([]byte, error) {
 	b.l.RLock()
-	defer b.l.RUnlock()
+
 	if b.sealed {
+		b.l.RUnlock()
 		return nil, ErrBarrierSealed
 	}
 
 	// Decrypt the ciphertext
 	plain, err := b.decryptKeyring(key, ciphertext)
 	if err != nil {
+		b.l.RUnlock()
 		return nil, errwrap.Wrapf("decryption failed: {{err}}", err)
 	}
+
+	b.l.RUnlock()
 	return plain, nil
 }
 
 func (b *AESGCMBarrier) Keyring() (*Keyring, error) {
 	b.l.RLock()
-	defer b.l.RUnlock()
+
 	if b.sealed {
+		b.l.RUnlock()
 		return nil, ErrBarrierSealed
 	}
 
+	b.l.RUnlock()
 	return b.keyring.Clone(), nil
 }

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -252,16 +252,17 @@ func (c *Core) checkToken(ctx context.Context, req *logical.Request, unauth bool
 // HandleRequest is used to handle a new incoming request
 func (c *Core) HandleRequest(req *logical.Request) (resp *logical.Response, err error) {
 	c.stateLock.RLock()
-	defer c.stateLock.RUnlock()
+
 	if c.sealed {
+		c.stateLock.RUnlock()
 		return nil, consts.ErrSealed
 	}
 	if c.standby {
+		c.stateLock.RUnlock()
 		return nil, consts.ErrStandby
 	}
 
 	ctx, cancel := context.WithCancel(c.activeContext)
-	defer cancel()
 
 	// Allowing writing to a path ending in / makes it extremely difficult to
 	// understand user intent for the filesystem-like backends (kv,
@@ -272,6 +273,8 @@ func (c *Core) HandleRequest(req *logical.Request) (resp *logical.Response, err 
 	if strings.HasSuffix(req.Path, "/") &&
 		(req.Operation == logical.UpdateOperation ||
 			req.Operation == logical.CreateOperation) {
+		cancel()
+		c.stateLock.RUnlock()
 		return logical.ErrorResponse("cannot write to a path ending in '/'"), nil
 	}
 
@@ -338,6 +341,8 @@ func (c *Core) HandleRequest(req *logical.Request) (resp *logical.Response, err 
 			err := jsonutil.DecodeJSON(resp.Data[logical.HTTPRawBody].([]byte), httpResp)
 			if err != nil {
 				c.logger.Error("failed to unmarshal wrapped HTTP response for audit logging", "error", err)
+				cancel()
+				c.stateLock.RUnlock()
 				return nil, ErrInternalError
 			}
 
@@ -373,9 +378,13 @@ func (c *Core) HandleRequest(req *logical.Request) (resp *logical.Response, err 
 	}
 	if auditErr := c.auditBroker.LogResponse(ctx, logInput, c.auditedHeaders); auditErr != nil {
 		c.logger.Error("failed to audit response", "request_path", req.Path, "error", auditErr)
+		cancel()
+		c.stateLock.RUnlock()
 		return nil, ErrInternalError
 	}
 
+	cancel()
+	c.stateLock.RUnlock()
 	return
 }
 

--- a/vault/router.go
+++ b/vault/router.go
@@ -209,9 +209,9 @@ func (r *Router) MatchingMountByUUID(mountID string) *MountEntry {
 	}
 
 	r.l.RLock()
-	defer r.l.RUnlock()
-
 	_, raw, ok := r.mountUUIDCache.LongestPrefix(mountID)
+	r.l.RUnlock()
+
 	if !ok {
 		return nil
 	}
@@ -226,9 +226,9 @@ func (r *Router) MatchingMountByAccessor(mountAccessor string) *MountEntry {
 	}
 
 	r.l.RLock()
-	defer r.l.RUnlock()
-
 	_, raw, ok := r.mountAccessorCache.LongestPrefix(mountAccessor)
+	r.l.RUnlock()
+
 	if !ok {
 		return nil
 	}
@@ -239,8 +239,8 @@ func (r *Router) MatchingMountByAccessor(mountAccessor string) *MountEntry {
 // MatchingMount returns the mount prefix that would be used for a path
 func (r *Router) MatchingMount(path string) string {
 	r.l.RLock()
-	defer r.l.RUnlock()
-	var mount = r.matchingMountInternal(path)
+	mount := r.matchingMountInternal(path)
+	r.l.RUnlock()
 	return mount
 }
 
@@ -406,10 +406,10 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 	// Grab a read lock on the route entry, this protects against the backend
 	// being reloaded during a request.
 	re.l.RLock()
-	defer re.l.RUnlock()
 
 	// Filtered mounts will have a nil backend
 	if re.backend == nil {
+		re.l.RUnlock()
 		return logical.ErrorResponse(fmt.Sprintf("no handler for route '%s'", req.Path)), false, false, logical.ErrUnsupportedPath
 	}
 
@@ -419,6 +419,7 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 		switch req.Operation {
 		case logical.RevokeOperation, logical.RollbackOperation:
 		default:
+			re.l.RUnlock()
 			return logical.ErrorResponse(fmt.Sprintf("no handler for route '%s'", req.Path)), false, false, logical.ErrUnsupportedPath
 		}
 	}
@@ -448,6 +449,7 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 		// salted ID, so we double-salt what's going to the cubbyhole backend
 		salt, err := r.tokenStoreSaltFunc(ctx)
 		if err != nil {
+			re.l.RUnlock()
 			return nil, false, false, err
 		}
 		req.ClientToken = re.SaltID(salt.SaltID(req.ClientToken))
@@ -489,7 +491,7 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 	req.SetTokenEntry(nil)
 
 	// Reset the request before returning
-	defer func() {
+	resetFunc := func() {
 		req.Path = originalPath
 		req.MountPoint = mount
 		req.MountType = re.mountEntry.Type
@@ -511,11 +513,13 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 		req.EntityID = originalEntityID
 
 		req.SetTokenEntry(reqTokenEntry)
-	}()
+	}
 
 	// Invoke the backend
 	if existenceCheck {
 		ok, exists, err := re.backend.HandleExistenceCheck(ctx, req)
+		resetFunc()
+		re.l.RUnlock()
 		return nil, ok, exists, err
 	} else {
 		resp, err := re.backend.HandleRequest(ctx, req)
@@ -540,6 +544,8 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 				alias.MountAccessor = re.mountEntry.Accessor
 			}
 		}
+		resetFunc()
+		re.l.RUnlock()
 		return resp, false, false, err
 	}
 }


### PR DESCRIPTION
There is an interesting benchmark at https://www.reddit.com/r/golang/comments/3h21nk/simple_micro_benchmark_to_measure_the_overhead_of/

It shows that defer actually adds quite a lot of overhead -- maybe 100ns
per call but we defer a *lot* of functions in the request path. So this
removes some of the ones in request handling, ha, barrier, router, and
physical cache.

One meta-note: nearly every metrics function is in a defer which means
every metrics call we add could add a non-trivial amount of time, e.g.
for every 10 extra metrics statements we add 1ms to a request. I don't
know how to solve this right now without doing what I did in some of
these cases and putting that call into a simple function call that then
goes before each return.