### PR TITLE
Update kv v2 documentation with more detail on upgrade from v1

### DIFF
--- a/website/source/docs/secrets/kv/kv-v2.html.md
+++ b/website/source/docs/secrets/kv/kv-v2.html.md
@@ -37,8 +37,11 @@ different paths. Each instance of the KV secrets engine is isolated and unique.
 
 ## Upgrading from Version 1
 
-An existing version 1 kv can be easily upgraded to a version 2 KV store with the
-CLI command:
+An existing version 1 kv store can be upgraded to a version 2 kv store via the CLI or API, as shown below. This will start an upgrade process to upgrade the existing key/value data to a versioned format. The mount will be inaccessible during this process. This process could take a long time, so plan accordingly.  
+
+Once upgraded to version 2, the former paths at which the data was accessible will no longer suffice. You will need to adjust user policies to add access to the version 2 paths as detailed in the [ACL Rules section below](/docs/secrets/kv/kv-v2.html#acl-rules). Similarly, users/applications will need to update the paths at which they interact with the kv data once it has been upgraded to version 2.
+
+An existing version 1 kv can be upgraded to a version 2 KV store with the CLI command:
 
 ```
 $ vault kv enable-versioning secret/
@@ -61,10 +64,6 @@ $ curl \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/mounts/secret/tune
 ```
-
-This will start an upgrade process to upgrade the existing key/value data to
-a versioned format. The mount will be inaccessible during this process. This
-process could take a long time, so plan accordingly.  
 
 ## ACL Rules
 


### PR DESCRIPTION
Update kv v2 documentation to better warn and elaborate on changes needed when upgrading a mount from version 1 to version 2 (customer request)