### PR TITLE
Revert some of commit 050ab805a7565c5b0cadb0176023031ee5f0d17b

### DIFF
--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -637,16 +637,14 @@ func (b *AESGCMBarrier) updateMasterKeyCommon(key []byte) (*Keyring, error) {
 func (b *AESGCMBarrier) Put(ctx context.Context, entry *Entry) error {
 	defer metrics.MeasureSince([]string{"barrier", "put"}, time.Now())
 	b.l.RLock()
-
+	defer b.l.RUnlock()
 	if b.sealed {
-		b.l.RUnlock()
 		return ErrBarrierSealed
 	}
 
 	term := b.keyring.ActiveTerm()
 	primary, err := b.aeadForTerm(term)
 	if err != nil {
-		b.l.RUnlock()
 		return err
 	}
 
@@ -655,37 +653,29 @@ func (b *AESGCMBarrier) Put(ctx context.Context, entry *Entry) error {
 		Value:    b.encrypt(entry.Key, term, primary, entry.Value),
 		SealWrap: entry.SealWrap,
 	}
-
-	err = b.backend.Put(ctx, pe)
-
-	b.l.RUnlock()
-	return err
+	return b.backend.Put(ctx, pe)
 }
 
 // Get is used to fetch an entry
 func (b *AESGCMBarrier) Get(ctx context.Context, key string) (*Entry, error) {
 	defer metrics.MeasureSince([]string{"barrier", "get"}, time.Now())
 	b.l.RLock()
-
+	defer b.l.RUnlock()
 	if b.sealed {
-		b.l.RUnlock()
 		return nil, ErrBarrierSealed
 	}
 
 	// Read the key from the backend
 	pe, err := b.backend.Get(ctx, key)
 	if err != nil {
-		b.l.RUnlock()
 		return nil, err
 	} else if pe == nil {
-		b.l.RUnlock()
 		return nil, nil
 	}
 
 	// Decrypt the ciphertext
 	plain, err := b.decryptKeyring(key, pe.Value)
 	if err != nil {
-		b.l.RUnlock()
 		return nil, errwrap.Wrapf("decryption failed: {{err}}", err)
 	}
 
@@ -695,8 +685,6 @@ func (b *AESGCMBarrier) Get(ctx context.Context, key string) (*Entry, error) {
 		Value:    plain,
 		SealWrap: pe.SealWrap,
 	}
-
-	b.l.RUnlock()
 	return entry, nil
 }
 
@@ -704,16 +692,12 @@ func (b *AESGCMBarrier) Get(ctx context.Context, key string) (*Entry, error) {
 func (b *AESGCMBarrier) Delete(ctx context.Context, key string) error {
 	defer metrics.MeasureSince([]string{"barrier", "delete"}, time.Now())
 	b.l.RLock()
-
+	defer b.l.RUnlock()
 	if b.sealed {
-		b.l.RUnlock()
 		return ErrBarrierSealed
 	}
 
-	err := b.backend.Delete(ctx, key)
-
-	b.l.RUnlock()
-	return err
+	return b.backend.Delete(ctx, key)
 }
 
 // List is used ot list all the keys under a given
@@ -721,16 +705,12 @@ func (b *AESGCMBarrier) Delete(ctx context.Context, key string) error {
 func (b *AESGCMBarrier) List(ctx context.Context, prefix string) ([]string, error) {
 	defer metrics.MeasureSince([]string{"barrier", "list"}, time.Now())
 	b.l.RLock()
-
+	defer b.l.RUnlock()
 	if b.sealed {
-		b.l.RUnlock()
 		return nil, ErrBarrierSealed
 	}
 
-	keys, err := b.backend.List(ctx, prefix)
-
-	b.l.RUnlock()
-	return keys, err
+	return b.backend.List(ctx, prefix)
 }
 
 // aeadForTerm returns the AES-GCM AEAD for the given term
@@ -873,7 +853,6 @@ func (b *AESGCMBarrier) decryptKeyring(path string, cipher []byte) ([]byte, erro
 // Encrypt is used to encrypt in-memory for the BarrierEncryptor interface
 func (b *AESGCMBarrier) Encrypt(ctx context.Context, key string, plaintext []byte) ([]byte, error) {
 	b.l.RLock()
-
 	if b.sealed {
 		b.l.RUnlock()
 		return nil, ErrBarrierSealed
@@ -887,7 +866,6 @@ func (b *AESGCMBarrier) Encrypt(ctx context.Context, key string, plaintext []byt
 	}
 
 	ciphertext := b.encrypt(key, term, primary, plaintext)
-
 	b.l.RUnlock()
 	return ciphertext, nil
 }
@@ -895,7 +873,6 @@ func (b *AESGCMBarrier) Encrypt(ctx context.Context, key string, plaintext []byt
 // Decrypt is used to decrypt in-memory for the BarrierEncryptor interface
 func (b *AESGCMBarrier) Decrypt(ctx context.Context, key string, ciphertext []byte) ([]byte, error) {
 	b.l.RLock()
-
 	if b.sealed {
 		b.l.RUnlock()
 		return nil, ErrBarrierSealed

--- a/vault/router.go
+++ b/vault/router.go
@@ -209,13 +209,14 @@ func (r *Router) MatchingMountByUUID(mountID string) *MountEntry {
 	}
 
 	r.l.RLock()
-	_, raw, ok := r.mountUUIDCache.LongestPrefix(mountID)
-	r.l.RUnlock()
 
+	_, raw, ok := r.mountUUIDCache.LongestPrefix(mountID)
 	if !ok {
+		r.l.RUnlock()
 		return nil
 	}
 
+	r.l.RUnlock()
 	return raw.(*MountEntry)
 }
 
@@ -226,13 +227,14 @@ func (r *Router) MatchingMountByAccessor(mountAccessor string) *MountEntry {
 	}
 
 	r.l.RLock()
-	_, raw, ok := r.mountAccessorCache.LongestPrefix(mountAccessor)
-	r.l.RUnlock()
 
+	_, raw, ok := r.mountAccessorCache.LongestPrefix(mountAccessor)
 	if !ok {
+		r.l.RUnlock()
 		return nil
 	}
 
+	r.l.RUnlock()
 	return raw.(*MountEntry)
 }
 
@@ -406,10 +408,10 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 	// Grab a read lock on the route entry, this protects against the backend
 	// being reloaded during a request.
 	re.l.RLock()
+	defer re.l.RUnlock()
 
 	// Filtered mounts will have a nil backend
 	if re.backend == nil {
-		re.l.RUnlock()
 		return logical.ErrorResponse(fmt.Sprintf("no handler for route '%s'", req.Path)), false, false, logical.ErrUnsupportedPath
 	}
 
@@ -419,7 +421,6 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 		switch req.Operation {
 		case logical.RevokeOperation, logical.RollbackOperation:
 		default:
-			re.l.RUnlock()
 			return logical.ErrorResponse(fmt.Sprintf("no handler for route '%s'", req.Path)), false, false, logical.ErrUnsupportedPath
 		}
 	}
@@ -449,7 +450,6 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 		// salted ID, so we double-salt what's going to the cubbyhole backend
 		salt, err := r.tokenStoreSaltFunc(ctx)
 		if err != nil {
-			re.l.RUnlock()
 			return nil, false, false, err
 		}
 		req.ClientToken = re.SaltID(salt.SaltID(req.ClientToken))
@@ -491,7 +491,7 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 	req.SetTokenEntry(nil)
 
 	// Reset the request before returning
-	resetFunc := func() {
+	defer func() {
 		req.Path = originalPath
 		req.MountPoint = mount
 		req.MountType = re.mountEntry.Type
@@ -513,13 +513,11 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 		req.EntityID = originalEntityID
 
 		req.SetTokenEntry(reqTokenEntry)
-	}
+	}()
 
 	// Invoke the backend
 	if existenceCheck {
 		ok, exists, err := re.backend.HandleExistenceCheck(ctx, req)
-		resetFunc()
-		re.l.RUnlock()
 		return nil, ok, exists, err
 	} else {
 		resp, err := re.backend.HandleRequest(ctx, req)
@@ -544,8 +542,6 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 				alias.MountAccessor = re.mountEntry.Accessor
 			}
 		}
-		resetFunc()
-		re.l.RUnlock()
 		return resp, false, false, err
 	}
 }


### PR DESCRIPTION
If we have a panic defer functions are run but unlocks aren't. Since we
can't really trust plugins and storage, this backs out the changes for
those parts of the request path.