### PR TITLE
Use %q in output for better visibility

### DIFF
--- a/command/format.go
+++ b/command/format.go
@@ -218,9 +218,9 @@ func (t TableFormatter) OutputSecret(ui cli.Ui, secret *api.Secret) error {
 			out = append(out, fmt.Sprintf("token_duration %s %s", hopeDelim, humanDurationInt(secret.Auth.LeaseDuration)))
 		}
 		out = append(out, fmt.Sprintf("token_renewable %s %t", hopeDelim, secret.Auth.Renewable))
-		out = append(out, fmt.Sprintf("token_policies %s %v", hopeDelim, secret.Auth.TokenPolicies))
-		out = append(out, fmt.Sprintf("identity_policies %s %v", hopeDelim, secret.Auth.IdentityPolicies))
-		out = append(out, fmt.Sprintf("policies %s %v", hopeDelim, secret.Auth.Policies))
+		out = append(out, fmt.Sprintf("token_policies %s %q", hopeDelim, secret.Auth.TokenPolicies))
+		out = append(out, fmt.Sprintf("identity_policies %s %q", hopeDelim, secret.Auth.IdentityPolicies))
+		out = append(out, fmt.Sprintf("policies %s %q", hopeDelim, secret.Auth.Policies))
 		for k, v := range secret.Auth.Metadata {
 			out = append(out, fmt.Sprintf("token_meta_%s %s %v", k, hopeDelim, v))
 		}

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1751,7 +1751,7 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 				finalPolicies = sanitizedRolePolicies
 			} else {
 				if !strutil.StrListSubset(sanitizedRolePolicies, finalPolicies) {
-					return logical.ErrorResponse(fmt.Sprintf("token policies (%v) must be subset of the role's allowed policies (%v)", finalPolicies, sanitizedRolePolicies)), logical.ErrInvalidRequest
+					return logical.ErrorResponse(fmt.Sprintf("token policies (%q) must be subset of the role's allowed policies (%q)", finalPolicies, sanitizedRolePolicies)), logical.ErrInvalidRequest
 				}
 			}
 		} else {


### PR DESCRIPTION
Was debugging a nomad <=> vault problem and got this error message in nomad from vault:
`token policies ([default policy1]) must be subset of the role's allowed policies ([default policy1 policy2 policy3])` which didn't make any sense.

After debugging I found that we added the policy "default policy1 policy2" instead of 3 different policies.

This patch fixes this for the error and will show
`token policies (["default" "policy1"]) must be subset of the role's allowed policies (["default policy1 policy2 policy3"])` which makes it easier to spot.

Found 3 other instances where it would benefit of using %q too.
