### PR TITLE
docs: kv 2 is used by default in the dev server only

### DIFF
--- a/website/source/docs/secrets/kv/kv-v2.html.md
+++ b/website/source/docs/secrets/kv/kv-v2.html.md
@@ -32,7 +32,7 @@ $ vault secrets enable -version=2 kv
 ```
 
 Additionally, the v2 `kv` secrets engine is enabled by default at the
-path `secret/`. It can be disabled, moved, or enabled multiple times at
+path `secret/` in case of the "Dev" Server. It can be disabled, moved, or enabled multiple times at
 different paths. Each instance of the KV secrets engine is isolated and unique.
 
 ## Upgrading from Version 1

--- a/website/source/docs/secrets/kv/kv-v2.html.md
+++ b/website/source/docs/secrets/kv/kv-v2.html.md
@@ -31,8 +31,8 @@ A v2 `kv` secrets engine can be enabled by:
 $ vault secrets enable -version=2 kv
 ```
 
-Additionally, the v2 `kv` secrets engine is enabled by default at the
-path `secret/` in case of the "Dev" Server. It can be disabled, moved, or enabled multiple times at
+Additionally, when running a dev-mode server, the v2 `kv` secrets engine is enabled by default at the
+path `secret/` (for non-dev serers, it is currently v1). It can be disabled, moved, or enabled multiple times at
 different paths. Each instance of the KV secrets engine is isolated and unique.
 
 ## Upgrading from Version 1


### PR DESCRIPTION
According to this code: https://github.com/hashicorp/vault/blob/4ab9eef57a71b45bbf922c82dc2a8b899c7679d9/vault/mount.go#L979