### PR TITLE
pki: add ext_key_usage to mirror key_usage and add to sign-verbatim

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -941,23 +941,6 @@ func generateCreationBundle(b *backend, data *dataBundle) error {
 		}
 	}
 
-	// Build up usages
-	var extUsage certExtKeyUsage
-	{
-		if data.role.ServerFlag {
-			extUsage |= serverAuthExtKeyUsage
-		}
-		if data.role.ClientFlag {
-			extUsage |= clientAuthExtKeyUsage
-		}
-		if data.role.CodeSigningFlag {
-			extUsage |= codeSigningExtKeyUsage
-		}
-		if data.role.EmailProtectionFlag {
-			extUsage |= emailProtectionExtKeyUsage
-		}
-	}
-
 	data.params = &creationParameters{
 		Subject:                       subject,
 		DNSNames:                      dnsNames,
@@ -968,7 +951,7 @@ func generateCreationBundle(b *backend, data *dataBundle) error {
 		KeyBits:                       data.role.KeyBits,
 		NotAfter:                      notAfter,
 		KeyUsage:                      x509.KeyUsage(parseKeyUsages(data.role.KeyUsage)),
-		ExtKeyUsage:                   extUsage | parseExtKeyUsages(data.role.ExtKeyUsage),
+		ExtKeyUsage:                   parseExtKeyUsages(data.role),
 		ExtKeyUsageOIDs:               data.role.ExtKeyUsageOIDs,
 		PolicyIdentifiers:             data.role.PolicyIdentifiers,
 		BasicConstraintsValidForNonCA: data.role.BasicConstraintsValidForNonCA,

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -74,6 +74,32 @@ taken verbatim from the CSR, except for
 basic constraints.`,
 	}
 
+	ret.Fields["key_usage"] = &framework.FieldSchema{
+		Type:    framework.TypeCommaStringSlice,
+		Default: []string{"DigitalSignature", "KeyAgreement", "KeyEncipherment"},
+		Description: `A comma-separated string or list of key usages (not extended
+key usages). Valid values can be found at
+https://golang.org/pkg/crypto/x509/#KeyUsage
+-- simply drop the "KeyUsage" part of the name.
+To remove all key usages from being set, set
+this value to an empty list.`,
+	}
+
+	ret.Fields["ext_key_usage"] = &framework.FieldSchema{
+		Type:    framework.TypeCommaStringSlice,
+		Default: []string{},
+		Description: `A comma-separated string or list of extended key usages. Valid values can be found at
+https://golang.org/pkg/crypto/x509/#ExtKeyUsage
+-- simply drop the "ExtKeyUsage" part of the name.
+To remove all key usages from being set, set
+this value to an empty list.`,
+	}
+
+	ret.Fields["ext_key_usage_oids"] = &framework.FieldSchema{
+		Type:        framework.TypeCommaStringSlice,
+		Description: `A comma-separated string or list of extended key usage oids.`,
+	}
+
 	return ret
 }
 
@@ -139,6 +165,9 @@ func (b *backend) pathSignVerbatim(ctx context.Context, req *logical.Request, da
 		UseCSRSANs:           true,
 		AllowedSerialNumbers: []string{"*"},
 		GenerateLease:        new(bool),
+		KeyUsage:             data.Get("key_usage").([]string),
+		ExtKeyUsage:          data.Get("ext_key_usage").([]string),
+		ExtKeyUsageOIDs:      data.Get("ext_key_usage_oids").([]string),
 	}
 
 	*entry.GenerateLease = false

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -171,6 +171,16 @@ To remove all key usages from being set, set
 this value to an empty list.`,
 			},
 
+			"ext_key_usage": &framework.FieldSchema{
+				Type:    framework.TypeCommaStringSlice,
+				Default: []string{},
+				Description: `A comma-separated string or list of extended key usages. Valid values can be found at
+https://golang.org/pkg/crypto/x509/#ExtKeyUsage
+-- simply drop the "ExtKeyUsage" part of the name.
+To remove all key usages from being set, set
+this value to an empty list.`,
+			},
+
 			"ext_key_usage_oids": &framework.FieldSchema{
 				Type:        framework.TypeCommaStringSlice,
 				Description: `A comma-separated string or list of extended key usage oids.`,
@@ -461,6 +471,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		UseCSRCommonName:              data.Get("use_csr_common_name").(bool),
 		UseCSRSANs:                    data.Get("use_csr_sans").(bool),
 		KeyUsage:                      data.Get("key_usage").([]string),
+		ExtKeyUsage:                   data.Get("ext_key_usage").([]string),
 		ExtKeyUsageOIDs:               data.Get("ext_key_usage_oids").([]string),
 		OU:                            data.Get("ou").([]string),
 		Organization:                  data.Get("organization").([]string),
@@ -565,6 +576,41 @@ func parseKeyUsages(input []string) int {
 	return int(parsedKeyUsages)
 }
 
+func parseExtKeyUsages(input []string) certExtKeyUsage {
+	var parsedKeyUsages certExtKeyUsage
+
+	for _, k := range input {
+		switch strings.ToLower(strings.TrimSpace(k)) {
+		case "any":
+			parsedKeyUsages |= anyExtKeyUsage
+		case "serverauth":
+			parsedKeyUsages |= serverAuthExtKeyUsage
+		case "clientauth":
+			parsedKeyUsages |= clientAuthExtKeyUsage
+		case "codesigning":
+			parsedKeyUsages |= codeSigningExtKeyUsage
+		case "emailprotection":
+			parsedKeyUsages |= emailProtectionExtKeyUsage
+		case "ipsecendsystem":
+			parsedKeyUsages |= ipsecEndSystemExtKeyUsage
+		case "ipsectunnel":
+			parsedKeyUsages |= ipsecTunnelExtKeyUsage
+		case "ipsecuser":
+			parsedKeyUsages |= ipsecUserExtKeyUsage
+		case "timestamping":
+			parsedKeyUsages |= timeStampingExtKeyUsage
+		case "ocspsigning":
+			parsedKeyUsages |= ocspSigningExtKeyUsage
+		case "microsoftservergatedcrypto":
+			parsedKeyUsages |= microsoftServerGatedCryptoExtKeyUsage
+		case "netscapeservergatedcrypto":
+			parsedKeyUsages |= netscapeServerGatedCryptoExtKeyUsage
+		}
+	}
+
+	return parsedKeyUsages
+}
+
 type roleEntry struct {
 	LeaseMax                      string        `json:"lease_max"`
 	Lease                         string        `json:"lease"`
@@ -595,6 +641,7 @@ type roleEntry struct {
 	MaxPathLength                 *int          `json:",omitempty" mapstructure:"max_path_length"`
 	KeyUsageOld                   string        `json:"key_usage,omitempty"`
 	KeyUsage                      []string      `json:"key_usage_list" mapstructure:"key_usage"`
+	ExtKeyUsage                   []string      `json:"extended_key_usage_list" mapstructure:"extended_key_usage"`
 	OUOld                         string        `json:"ou,omitempty"`
 	OU                            []string      `json:"ou_list" mapstructure:"ou"`
 	OrganizationOld               string        `json:"organization,omitempty"`
@@ -639,6 +686,7 @@ func (r *roleEntry) ToResponseData() map[string]interface{} {
 		"key_type":                           r.KeyType,
 		"key_bits":                           r.KeyBits,
 		"key_usage":                          r.KeyUsage,
+		"ext_key_usage":                      r.ExtKeyUsage,
 		"ext_key_usage_oids":                 r.ExtKeyUsageOIDs,
 		"ou":                                 r.OU,
 		"organization":                       r.Organization,

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -576,10 +576,26 @@ func parseKeyUsages(input []string) int {
 	return int(parsedKeyUsages)
 }
 
-func parseExtKeyUsages(input []string) certExtKeyUsage {
+func parseExtKeyUsages(role *roleEntry) certExtKeyUsage {
 	var parsedKeyUsages certExtKeyUsage
 
-	for _, k := range input {
+	if role.ServerFlag {
+		parsedKeyUsages |= serverAuthExtKeyUsage
+	}
+
+	if role.ClientFlag {
+		parsedKeyUsages |= clientAuthExtKeyUsage
+	}
+
+	if role.CodeSigningFlag {
+		parsedKeyUsages |= codeSigningExtKeyUsage
+	}
+
+	if role.EmailProtectionFlag {
+		parsedKeyUsages |= emailProtectionExtKeyUsage
+	}
+
+	for _, k := range role.ExtKeyUsage {
 		switch strings.ToLower(strings.TrimSpace(k)) {
 		case "any":
 			parsedKeyUsages |= anyExtKeyUsage

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -796,6 +796,12 @@ request is denied.
   drop the `KeyUsage` part of the value. Values are not case-sensitive. To 
   specify no key usage constraints, set this to an empty list.
 
+- `ext_key_usage` `(list: [])` –
+  Specifies the allowed extended key usage constraint on issued certificates. Valid 
+  values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply 
+  drop the `ExtKeyUsage` part of the value. Values are not case-sensitive. To 
+  specify no key usage constraints, set this to an empty list.
+
 - `use_csr_common_name` `(bool: true)` – When used with the CSR signing
   endpoint, the common name in the CSR will be used instead of taken from the
   JSON data. This does `not` include any requested SANs in the CSR; use
@@ -1428,6 +1434,18 @@ have access.**
   `no_store`.
 
 - `csr` `(string: <required>)` – Specifies the PEM-encoded CSR.
+
+- `key_usage` `(list: ["DigitalSignature", "KeyAgreement", "KeyEncipherment"])` –
+  Specifies the allowed key usage constraint on issued certificates. Valid 
+  values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply 
+  drop the `KeyUsage` part of the value. Values are not case-sensitive. To 
+  specify no key usage constraints, set this to an empty list.
+
+- `ext_key_usage` `(list: [])` –
+  Specifies the allowed extended key usage constraint on issued certificates. Valid 
+  values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply 
+  drop the `ExtKeyUsage` part of the value. Values are not case-sensitive. To 
+  specify no key usage constraints, set this to an empty list.
 
 - `ttl` `(string: "")` – Specifies the requested Time To Live. Cannot be greater
   than the engine's `max_ttl` value. If not provided, the engine's `ttl` value


### PR DESCRIPTION
I recently was looking at using the vault pki backend to sign CSRs verbatim and found that you could not set the key usage or extended key usage.

This PR adds that ability to sign-verbatim as well as adding the field ext_key_usage to mirror key_usage (and supporting more extended key usages in the process).