### PR TITLE
Update generate-root output

### DIFF
--- a/command/operator_generate_root.go
+++ b/command/operator_generate_root.go
@@ -395,7 +395,7 @@ func (c *OperatorGenerateRootCommand) provide(client *api.Client, key string, dr
 		nonce = status.Nonce
 
 		w := getWriterFromUI(c.UI)
-		fmt.Fprintf(w, "Root generation operation nonce: %s\n", nonce)
+		fmt.Fprintf(w, "Operation nonce: %s\n", nonce)
 		fmt.Fprintf(w, "Unseal Key (will be hidden): ")
 		key, err = password.Read(os.Stdin)
 		fmt.Fprintf(w, "\n")
@@ -489,10 +489,10 @@ func (c *OperatorGenerateRootCommand) printStatus(status *api.GenerateRootStatus
 		out = append(out, fmt.Sprintf("PGP Fingerprint | %s", status.PGPFingerprint))
 	}
 	switch {
-	case status.EncodedRootToken != "":
-		out = append(out, fmt.Sprintf("Root Token | %s", status.EncodedRootToken))
 	case status.EncodedToken != "":
-		out = append(out, fmt.Sprintf("Root Token | %s", status.EncodedToken))
+		out = append(out, fmt.Sprintf("Encoded Token | %s", status.EncodedToken))
+	case status.EncodedRootToken != "":
+		out = append(out, fmt.Sprintf("Encoded Root Token | %s", status.EncodedRootToken))
 	}
 
 	output := columnOutput(out, nil)

--- a/command/operator_generate_root_test.go
+++ b/command/operator_generate_root_test.go
@@ -346,7 +346,7 @@ func TestOperatorGenerateRootCommand_Run(t *testing.T) {
 			t.Errorf("expected %d to be %d", code, exp)
 		}
 
-		reToken := regexp.MustCompile(`Root Token\s+(.+)`)
+		reToken := regexp.MustCompile(`Encoded Token\s+(.+)`)
 		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
 		match := reToken.FindAllStringSubmatch(combined, -1)
 		if len(match) < 1 || len(match[0]) < 2 {
@@ -421,7 +421,7 @@ func TestOperatorGenerateRootCommand_Run(t *testing.T) {
 			t.Errorf("expected %d to be %d", code, exp)
 		}
 
-		reToken := regexp.MustCompile(`Root Token\s+(.+)`)
+		reToken := regexp.MustCompile(`Encoded Token\s+(.+)`)
 		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
 		match := reToken.FindAllStringSubmatch(combined, -1)
 		if len(match) < 1 || len(match[0]) < 2 {


### PR DESCRIPTION
In current Vault server EncodedToken will always be populated regardless
of type (root, DR), so prioritize that, and properly refer to it as
Encoded Token instead of Root Token.

Additionally refer to the nonce as the Operation nonce instead of the
Root generation operation nonce since it's used for both strategies.