### PR TITLE
Allow vault ssh to work with single ssh args like -v

### DIFF
--- a/command/ssh_test.go
+++ b/command/ssh_test.go
@@ -133,6 +133,31 @@ func TestParseSSHCommand(t *testing.T) {
 			"",
 			nil,
 		},
+		{
+			"Allow single args which don't have a value",
+			[]string{
+				"-v",
+				"hostname",
+			},
+			"hostname",
+			"",
+			"",
+			nil,
+		},
+		{
+			"Allow single args before and after the hostname and command",
+			[]string{
+				"-v",
+				"hostname",
+				"-v",
+				"command",
+				"-v",
+			},
+			"hostname",
+			"",
+			"",
+			nil,
+		},
 	}
 
 	for _, test := range tests {
@@ -150,6 +175,42 @@ func TestParseSSHCommand(t *testing.T) {
 			}
 			if port != test.port {
 				t.Errorf("got port: %q want %q", port, test.port)
+			}
+		})
+	}
+}
+
+func TestIsSingleSSHArg(t *testing.T) {
+	t.Parallel()
+
+	_, cmd := testSSHCommand(t)
+	var tests = []struct {
+		name string
+		arg  string
+		want bool
+	}{
+		{
+			"-v is a single ssh arg",
+			"-v",
+			true,
+		},
+		{
+			"-o is NOT a single ssh arg",
+			"-o",
+			false,
+		},
+		{
+			"Repeated args like -vvv is still a single ssh arg",
+			"-vvv",
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := cmd.isSingleSSHArg(test.arg)
+			if got != test.want {
+				t.Errorf("arg %q got %v want %v", test.arg, got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
My changes in #4710 did not take into account single ssh arguments like `-v` for verbosity. When running a command with one of these arguments it would then attempt to parse the next argument as the value. 

A simple example of where this failed.

```
$ vault ssh -role bastion -mode otp -- -v hostname /bin/sh -c 'command'
Error resolving the ssh hostname: "failed to resolve IP address: lookup /bin/sh: no such host"
```

In this case it hit `-v` and decided that the next value would be the value for this arg. Since `-v` isn't interesting for vault it skipped it and continued parsing the ssh command. Then the next bare argument was taken to be the hostname when it was actually supposed to be the command. 


I really wish there was a clean solution to this which didn't involve the hardcoded list of single ssh args. The [ssh client code](https://github.com/openssh/openssh-portable/blob/28013759f09ed3ebf7e8335e83a62936bd7a7f47/ssh.c#L664-L1037) for parsing the args is around 500 lines long and I can't see a way to programatically parse the hostname without knowing which args have values and which don't. 

One potential solution for the future would be to move all ssh parsing logic out of vault and into a separate library. Right now I feel it is important to fix the current bug however this might be a good answer to solving this cleanly. 