### PR TITLE
Fix FOSSA tests

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2071,6 +2071,18 @@
 			"revisionTime": "2018-02-02T13:35:31Z"
 		},
 		{
+			"checksumSHA1": "Mr4ur60bgQJnQFfJY0dGtwWwMPE=",
+			"path": "golang.org/x/text/encoding",
+			"revision": "5cec4b58c438bd98288aeb248bab2c1840713d21",
+			"revisionTime": "2018-05-20T16:02:21Z"
+		},
+		{
+			"checksumSHA1": "IV4MN7KGBSocu/5NR3le3sxup4Y=",
+			"path": "golang.org/x/text/runes",
+			"revision": "5cec4b58c438bd98288aeb248bab2c1840713d21",
+			"revisionTime": "2018-05-20T16:02:21Z"
+		},
+		{
 			"checksumSHA1": "CbpjEkkOeh0fdM/V8xKDdI0AA88=",
 			"path": "golang.org/x/text/secure/bidirule",
 			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",


### PR DESCRIPTION
@alvin-huang informed me that our FOSSA tests were failing because `govendor` was missing these dependencies added by AD plugin.