### PR TITLE
Clarify policies note

### DIFF
--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -158,8 +158,7 @@ capabilities, which controls a token's access to credentials in Vault.
 an exact match or the longest-prefix match of a glob. This means if you define a
 policy for `"secret/foo*"`, the policy would also match `"secret/foobar"`.
 
-!> The glob character is only supported as the **last character of the path**,
-and **is not a regular expression**!
+!> The glob character referred to in this documentation is the asterisk (`*`). It *is not a regular expression*, and is only supported **as the last character of the path**!
 
 When providing `list` capability, it is important to note that since listing
 always operates on a prefix, policies must operate on a prefix because Vault


### PR DESCRIPTION
- Make it even clearer that "*" is the glob character referred to