### PR TITLE
secret/kv: Sort keys during list operation

### DIFF
--- a/helper/keysutil/encrypted_key_storage.go
+++ b/helper/keysutil/encrypted_key_storage.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"math/big"
 	paths "path"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/golang-lru"
@@ -205,6 +206,7 @@ func (s *encryptedKeyStorage) List(ctx context.Context, prefix string) ([]string
 		decryptedKeys[i] = plaintext
 	}
 
+	sort.Strings(decryptedKeys)
 	return decryptedKeys, nil
 }
 

--- a/helper/keysutil/encrypted_key_storage_test.go
+++ b/helper/keysutil/encrypted_key_storage_test.go
@@ -203,7 +203,7 @@ func TestEncryptedKeysStorage_List(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(keys) != 2 || !strutil.StrListContains(keys, "foo1/") || !strutil.StrListContains(keys, "foo") {
+	if len(keys) != 2 || keys[1] != "foo1/" || keys[0] != "foo" {
 		t.Fatalf("bad keys: %#v", keys)
 	}
 
@@ -211,7 +211,7 @@ func TestEncryptedKeysStorage_List(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(keys) != 2 || !strutil.StrListContains(keys, "test") || !strutil.StrListContains(keys, "test/") {
+	if len(keys) != 2 || keys[0] != "test" || keys[1] != "test/" {
 		t.Fatalf("bad keys: %#v", keys)
 	}
 


### PR DESCRIPTION
Because in the keys are encrypted in the data store they were coming back in a seemingly random order. This PR ensures they are sorted as expected. 