### PR TITLE
Restore is-word-break class in masked input template

### DIFF
--- a/ui/app/templates/components/masked-input.hbs
+++ b/ui/app/templates/components/masked-input.hbs
@@ -1,6 +1,6 @@
 <div class="masked-input {{if shouldObscure "masked"}} {{if displayOnly "display-only"}}" data-test-masked-input>
 	{{#if displayOnly}}
-		<pre class="masked-value display-only">{{displayValue}}</pre>
+		<pre class="masked-value display-only is-word-break">{{displayValue}}</pre>
 	{{else}}
   <textarea
     class="input masked-value"


### PR DESCRIPTION
Fixes #4811 by restoring `is-word-break` class in masked input template. Tested on newest Chrome, Firefox and Safari.