### PR TITLE
UI - fix cubbyhole

### DIFF
--- a/ui/app/routes/vault/cluster/secrets/backend/create.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create.js
@@ -13,6 +13,10 @@ var SecretProxy = Ember.Object.extend(KeyMixin, {
     let backendModel = this.store.peekRecord('secret-engine', backend);
     return this.store.createRecord(backendModel.get('modelTypeForKV'), this.toModel());
   },
+
+  willDestroy() {
+    this.store = null;
+  },
 });
 
 export default EditBase.extend({

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -40,6 +40,7 @@ export default Ember.Route.extend({
       aws: 'role-aws',
       pki: tab === 'certs' ? 'pki-certificate' : 'role-pki',
       // secret or secret-v2
+      cubbyhole: 'secret',
       kv: backendModel.get('modelTypeForKV'),
       generic: backendModel.get('modelTypeForKV'),
     };

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -51,6 +51,7 @@ export default Ember.Route.extend(UnloadModelRoute, {
       ssh: 'role-ssh',
       aws: 'role-aws',
       pki: secret && secret.startsWith('cert/') ? 'pki-certificate' : 'role-pki',
+      cubbyhole: 'secret',
       kv: backendModel.get('modelTypeForKV'),
       generic: backendModel.get('modelTypeForKV'),
     };

--- a/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
@@ -1,0 +1,40 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'vault/tests/helpers/module-for-acceptance';
+import editPage from 'vault/tests/pages/secrets/backend/kv/edit-secret';
+import showPage from 'vault/tests/pages/secrets/backend/kv/show';
+import listPage from 'vault/tests/pages/secrets/backend/list';
+
+import { create } from 'ember-cli-page-object';
+
+import apiStub from 'vault/tests/helpers/noop-all-api-requests';
+
+moduleForAcceptance('Acceptance | secrets/cubbyhole/create', {
+  beforeEach() {
+    this.server = apiStub({ usePassthrough: true });
+    return authLogin();
+  },
+  afterEach() {
+    this.server.shutdown();
+  },
+});
+
+test('it creates and can view a secret with the cubbyhole backend', function(assert) {
+  const kvPath = `cubbyhole-kv-${new Date().getTime()}`;
+  listPage.visitRoot({ backend: 'cubbyhole' });
+  andThen(() => {
+    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list-root', 'navigates to the list page');
+  });
+
+  listPage.create();
+  editPage.createSecret(kvPath, 'foo', 'bar');
+  andThen(() => {
+    let capabilitiesReq = this.server.passthroughRequests.findBy('url', '/v1/sys/capabilities-self');
+    assert.equal(
+      JSON.parse(capabilitiesReq.requestBody).paths,
+      `cubbyhole/${kvPath}`,
+      'calls capabilites with the correct path'
+    );
+    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.ok(showPage.editIsPresent, 'shows the edit button');
+  });
+});

--- a/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/cubbyhole/secret-test.js
@@ -3,9 +3,6 @@ import moduleForAcceptance from 'vault/tests/helpers/module-for-acceptance';
 import editPage from 'vault/tests/pages/secrets/backend/kv/edit-secret';
 import showPage from 'vault/tests/pages/secrets/backend/kv/show';
 import listPage from 'vault/tests/pages/secrets/backend/list';
-
-import { create } from 'ember-cli-page-object';
-
 import apiStub from 'vault/tests/helpers/noop-all-api-requests';
 
 moduleForAcceptance('Acceptance | secrets/cubbyhole/create', {


### PR DESCRIPTION
When fixing generic-upgraded backends, we made the type lookup more explicit (it used to fallback to 'secret'). In doing so, this broke the cubbyhole secret engine in the UI. 

This adds cubbyhole to the lookups, and adds acceptance tests to make sure we don't break it again 😬.