### PR TITLE
Added documentation to consul and listener pages explaining how to conntrol Consul's DNS resolution with multiple listeners

### DIFF
--- a/website/source/docs/configuration/listener/tcp.html.md
+++ b/website/source/docs/configuration/listener/tcp.html.md
@@ -17,6 +17,11 @@ listener "tcp" {
 }
 ```
 
+The `listener` stanza may be specified more than once to make Vault listen on
+multiple interfaces. If you configure multiple listeners you also need to
+specify [`api_addr`][api-addr] and [`cluster_addr`][cluster-addr] so Vault will
+advertise the correct address to other nodes.
+
 ## `tcp` Listener Parameters
 
 - `address` `(string: "127.0.0.1:8200")` – Specifies the address to bind to for
@@ -30,19 +35,19 @@ listener "tcp" {
   talk.
 
 - `proxy_protocol_behavior` `(string: "") – When specified, turns on the PROXY
-  protocol for the listener.  
+  protocol for the listener.
   Accepted Values:
-  - *use_always* - The client's IP address will always be used.  
-  - *allow_authorized* - If the source IP address is in the 
+  - *use_always* - The client's IP address will always be used.
+  - *allow_authorized* - If the source IP address is in the
   `proxy_protocol_authorized_addrs` list, the client's IP address will be used.
-  If the source IP is not in the list, the source IP address will be used.  
+  If the source IP is not in the list, the source IP address will be used.
   - *deny_unauthorized* - The traffic will be rejected if the source IP
   address is not in the `proxy_protocol_authorized_addrs` list.
 
-- `proxy_protocol_authorized_addrs` `(string: <required-if-enabled> or array: <required-if-enabled> )` – 
+- `proxy_protocol_authorized_addrs` `(string: <required-if-enabled> or array: <required-if-enabled> )` –
   Specifies the list of allowed source IP addresses to be used with the PROXY protocol.
-  Not required if `proxy_protocol_behavior` is set to `use_always`. Source IPs should 
-  be comma-delimited if provided as a string. At least one source IP must be provided, 
+  Not required if `proxy_protocol_behavior` is set to `use_always`. Source IPs should
+  be comma-delimited if provided as a string. At least one source IP must be provided,
   `proxy_protocol_authorized_addrs` cannot be an empty array or string.
 
 - `tls_disable` `(string: "false")` – Specifies if TLS will be disabled. Vault
@@ -120,4 +125,24 @@ listener "tcp" {
 }
 ```
 
+### Listening on Multiple Interfaces
+
+This example shows Vault listening on a private interface, as well as localhost.
+
+```hcl
+listener "tcp" {
+  address = "127.0.0.1:8200"
+}
+
+listener "tcp" {
+  address = "10.0.0.5:8200"
+}
+
+# Advertise the non-loopback interface
+api_addr = "https://10.0.0.5:8200"
+cluster_addr = "https://10.0.0.5:8201"
+```
+
 [golang-tls]: https://golang.org/src/crypto/tls/cipher_suites.go
+[api-addr]: /docs/configuration/index.html#api_addr
+[cluster-addr]: /docs/configuration/index.html#cluster_addr

--- a/website/source/docs/configuration/storage/consul.html.md
+++ b/website/source/docs/configuration/storage/consul.html.md
@@ -50,6 +50,9 @@ vault.service.consul
 Sealed Vault instances will mark themselves as unhealthy to avoid being returned
 at Consul's service discovery layer.
 
+Note that if you have configured multiple listeners for Vault, you must specify
+which one Consul should advertise to the cluster using [`api_addr`][api-addr]
+and [`cluster_addr`][cluster-addr] ([example][listener-example]).
 
 ## `consul` Parameters
 
@@ -236,3 +239,6 @@ storage "consul" {
 [consul-encryption]: https://www.consul.io/docs/agent/encryption.html "Consul Encryption"
 [consul-translate-wan-addrs]: https://www.consul.io/docs/agent/options.html#translate_wan_addrs "Consul Configuration"
 [consul-session-ttl]: https://www.consul.io/docs/agent/options.html#session_ttl_min "Consul Configuration"
+[api-addr]: /docs/configuration/index.html#api_addr
+[cluster-addr]: /docs/configuration/index.html#cluster_addr
+[listener-example]: /docs/configuration/listener/tcp.html#listening-on-multiple-interfaces


### PR DESCRIPTION
Closes #4859 

There are whitespace changes because my editor stripped trailing whitespace on save. To view the diff without use https://github.com/hashicorp/vault/pull/4862/files?w=1