### PR TITLE
Ensure there's a newline between each warning

### DIFF
--- a/command/format.go
+++ b/command/format.go
@@ -182,8 +182,8 @@ func (t TableFormatter) printWarnings(ui cli.Ui, secret *api.Secret) {
 		ui.Warn("WARNING! The following warnings were returned from Vault:\n")
 		for _, warning := range secret.Warnings {
 			ui.Warn(wrapAtLengthWithPadding(fmt.Sprintf("* %s", warning), 2))
+			ui.Warn("")
 		}
-		ui.Warn("")
 	}
 }
 


### PR DESCRIPTION
It's really hard to see where one stops and another starts given multiple warnings.