### PR TITLE
Handle multierr when altering response codes

### DIFF
--- a/logical/error.go
+++ b/logical/error.go
@@ -12,6 +12,8 @@ func CodedError(status int, msg string) HTTPCodedError {
 	}
 }
 
+var _ HTTPCodedError = (*codedError)(nil)
+
 type codedError struct {
 	Status  int
 	Message string

--- a/logical/response_util.go
+++ b/logical/response_util.go
@@ -119,6 +119,13 @@ func RespondErrorCommon(req *Request, resp *Response, err error) (int, error) {
 // conditions in a way that can be shared across http's respondError and other
 // locations.
 func AdjustErrorStatusCode(status *int, err error) {
+	// Handle nested errors
+	if t, ok := err.(*multierror.Error); ok {
+		for _, e := range t.Errors {
+			AdjustErrorStatusCode(status, e)
+		}
+	}
+
 	// Adjust status code when sealed
 	if errwrap.Contains(err, consts.ErrSealed.Error()) {
 		*status = http.StatusServiceUnavailable


### PR DESCRIPTION
At some point, the interface for plugins changed such that all values returned are now multierrors. I didn't want to trace that back, since I'm sure it had good intentions, but it broke the ability for plugins to send custom response codes (everything would be converted to a 500 error). This is problematic because:

- Clients may rely on different status codes for different logic
- The Vault CLI client tries 3x on a 5xx status, which can elongate the interaction with plugins on error

/cc @jefferai @chrishoffman 