### PR TITLE
[Don't Merge Yet] Make single-lease revocation behave like expiration

### DIFF
--- a/builtin/credential/approle/backend.go
+++ b/builtin/credential/approle/backend.go
@@ -157,7 +157,7 @@ func (b *backend) invalidate(_ context.Context, key string) {
 func (b *backend) periodicFunc(ctx context.Context, req *logical.Request) error {
 	// Initiate clean-up of expired SecretID entries
 	if b.System().LocalMount() || !b.System().ReplicationState().HasState(consts.ReplicationPerformanceSecondary) {
-		b.tidySecretID(ctx, req.Storage)
+		b.tidySecretID(ctx, req)
 	}
 	return nil
 }

--- a/builtin/credential/approle/path_tidy_user_id.go
+++ b/builtin/credential/approle/path_tidy_user_id.go
@@ -3,6 +3,7 @@ package approle
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -165,9 +166,7 @@ func (b *backend) tidySecretID(ctx context.Context, s logical.Storage) (*logical
 		}
 	}()
 
-	resp := &logical.Response{}
-	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
-	return resp, nil
+	return logical.RespondWithStatusCode(nil, nil, http.StatusAccepted)
 }
 
 // pathTidySecretIDUpdate is used to delete the expired SecretID entries

--- a/builtin/credential/approle/path_tidy_user_id.go
+++ b/builtin/credential/approle/path_tidy_user_id.go
@@ -27,12 +27,14 @@ func pathTidySecretID(b *backend) *framework.Path {
 }
 
 // tidySecretID is used to delete entries in the whitelist that are expired.
-func (b *backend) tidySecretID(ctx context.Context, s logical.Storage) (*logical.Response, error) {
+func (b *backend) tidySecretID(ctx context.Context, req *logical.Request) (*logical.Response, error) {
 	if !atomic.CompareAndSwapUint32(b.tidySecretIDCASGuard, 0, 1) {
 		resp := &logical.Response{}
 		resp.AddWarning("Tidy operation already in progress.")
 		return resp, nil
 	}
+
+	s := req.Storage
 
 	go func() {
 		defer atomic.StoreUint32(b.tidySecretIDCASGuard, 0)
@@ -166,12 +168,14 @@ func (b *backend) tidySecretID(ctx context.Context, s logical.Storage) (*logical
 		}
 	}()
 
-	return logical.RespondWithStatusCode(nil, nil, http.StatusAccepted)
+	resp := &logical.Response{}
+	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
+	return logical.RespondWithStatusCode(resp, req, http.StatusAccepted)
 }
 
 // pathTidySecretIDUpdate is used to delete the expired SecretID entries
 func (b *backend) pathTidySecretIDUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	return b.tidySecretID(ctx, req.Storage)
+	return b.tidySecretID(ctx, req)
 }
 
 const pathTidySecretIDSyn = "Trigger the clean-up of expired SecretID entries."

--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -165,7 +165,7 @@ func (b *backend) periodicFunc(ctx context.Context, req *logical.Request) error 
 			}
 			// tidy role tags if explicitly not disabled
 			if !skipBlacklistTidy {
-				b.tidyBlacklistRoleTag(ctx, req.Storage, safety_buffer)
+				b.tidyBlacklistRoleTag(ctx, req, safety_buffer)
 			}
 		}
 
@@ -189,7 +189,7 @@ func (b *backend) periodicFunc(ctx context.Context, req *logical.Request) error 
 		}
 		// tidy identities if explicitly not disabled
 		if !skipWhitelistTidy {
-			b.tidyWhitelistIdentity(ctx, req.Storage, safety_buffer)
+			b.tidyWhitelistIdentity(ctx, req, safety_buffer)
 		}
 
 		// Update the time at which to run the tidy functions again.

--- a/builtin/credential/aws/path_tidy_identity_whitelist.go
+++ b/builtin/credential/aws/path_tidy_identity_whitelist.go
@@ -34,12 +34,14 @@ expiration, before it is removed from the backend storage.`,
 }
 
 // tidyWhitelistIdentity is used to delete entries in the whitelist that are expired.
-func (b *backend) tidyWhitelistIdentity(ctx context.Context, s logical.Storage, safetyBuffer int) (*logical.Response, error) {
+func (b *backend) tidyWhitelistIdentity(ctx context.Context, req *logical.Request, safetyBuffer int) (*logical.Response, error) {
 	if !atomic.CompareAndSwapUint32(b.tidyWhitelistCASGuard, 0, 1) {
 		resp := &logical.Response{}
 		resp.AddWarning("Tidy operation already in progress.")
 		return resp, nil
 	}
+
+	s := req.Storage
 
 	go func() {
 		defer atomic.StoreUint32(b.tidyWhitelistCASGuard, 0)
@@ -92,12 +94,14 @@ func (b *backend) tidyWhitelistIdentity(ctx context.Context, s logical.Storage, 
 		}
 	}()
 
-	return logical.RespondWithStatusCode(nil, nil, http.StatusAccepted)
+	resp := &logical.Response{}
+	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
+	return logical.RespondWithStatusCode(resp, req, http.StatusAccepted)
 }
 
 // pathTidyIdentityWhitelistUpdate is used to delete entries in the whitelist that are expired.
 func (b *backend) pathTidyIdentityWhitelistUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	return b.tidyWhitelistIdentity(ctx, req.Storage, data.Get("safety_buffer").(int))
+	return b.tidyWhitelistIdentity(ctx, req, data.Get("safety_buffer").(int))
 }
 
 const pathTidyIdentityWhitelistSyn = `

--- a/builtin/credential/aws/path_tidy_identity_whitelist.go
+++ b/builtin/credential/aws/path_tidy_identity_whitelist.go
@@ -3,6 +3,7 @@ package awsauth
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -91,9 +92,7 @@ func (b *backend) tidyWhitelistIdentity(ctx context.Context, s logical.Storage, 
 		}
 	}()
 
-	resp := &logical.Response{}
-	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
-	return resp, nil
+	return logical.RespondWithStatusCode(nil, nil, http.StatusAccepted)
 }
 
 // pathTidyIdentityWhitelistUpdate is used to delete entries in the whitelist that are expired.

--- a/builtin/credential/aws/path_tidy_roletag_blacklist.go
+++ b/builtin/credential/aws/path_tidy_roletag_blacklist.go
@@ -34,12 +34,14 @@ expiration, before it is removed from the backend storage.`,
 }
 
 // tidyBlacklistRoleTag is used to clean-up the entries in the role tag blacklist.
-func (b *backend) tidyBlacklistRoleTag(ctx context.Context, s logical.Storage, safetyBuffer int) (*logical.Response, error) {
+func (b *backend) tidyBlacklistRoleTag(ctx context.Context, req *logical.Request, safetyBuffer int) (*logical.Response, error) {
 	if !atomic.CompareAndSwapUint32(b.tidyBlacklistCASGuard, 0, 1) {
 		resp := &logical.Response{}
 		resp.AddWarning("Tidy operation already in progress.")
 		return resp, nil
 	}
+
+	s := req.Storage
 
 	go func() {
 		defer atomic.StoreUint32(b.tidyBlacklistCASGuard, 0)
@@ -92,12 +94,14 @@ func (b *backend) tidyBlacklistRoleTag(ctx context.Context, s logical.Storage, s
 		}
 	}()
 
-	return logical.RespondWithStatusCode(nil, nil, http.StatusAccepted)
+	resp := &logical.Response{}
+	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
+	return logical.RespondWithStatusCode(resp, req, http.StatusAccepted)
 }
 
 // pathTidyRoletagBlacklistUpdate is used to clean-up the entries in the role tag blacklist.
 func (b *backend) pathTidyRoletagBlacklistUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	return b.tidyBlacklistRoleTag(ctx, req.Storage, data.Get("safety_buffer").(int))
+	return b.tidyBlacklistRoleTag(ctx, req, data.Get("safety_buffer").(int))
 }
 
 const pathTidyRoletagBlacklistSyn = `

--- a/builtin/credential/aws/path_tidy_roletag_blacklist.go
+++ b/builtin/credential/aws/path_tidy_roletag_blacklist.go
@@ -3,6 +3,7 @@ package awsauth
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -91,9 +92,7 @@ func (b *backend) tidyBlacklistRoleTag(ctx context.Context, s logical.Storage, s
 		}
 	}()
 
-	resp := &logical.Response{}
-	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
-	return resp, nil
+	return logical.RespondWithStatusCode(nil, nil, http.StatusAccepted)
 }
 
 // pathTidyRoletagBlacklistUpdate is used to clean-up the entries in the role tag blacklist.

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -186,9 +187,7 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 		}
 	}()
 
-	resp := &logical.Response{}
-	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
-	return resp, nil
+	return logical.RespondWithStatusCode(nil, req, http.StatusAccepted)
 }
 
 const pathTidyHelpSyn = `

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -187,7 +187,9 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 		}
 	}()
 
-	return logical.RespondWithStatusCode(nil, req, http.StatusAccepted)
+	resp := &logical.Response{}
+	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
+	return logical.RespondWithStatusCode(resp, req, http.StatusAccepted)
 }
 
 const pathTidyHelpSyn = `

--- a/command/server.go
+++ b/command/server.go
@@ -1151,22 +1151,24 @@ func (c *ServerCommand) enableDev(core *vault.Core, coreConfig *vault.CoreConfig
 	}
 
 	// Upgrade the default K/V store
-	req := &logical.Request{
-		Operation:   logical.UpdateOperation,
-		ClientToken: init.RootToken,
-		Path:        "sys/mounts/secret/tune",
-		Data: map[string]interface{}{
-			"options": map[string]string{
-				"version": "2",
+	if !c.flagDevLeasedKV {
+		req := &logical.Request{
+			Operation:   logical.UpdateOperation,
+			ClientToken: init.RootToken,
+			Path:        "sys/mounts/secret/tune",
+			Data: map[string]interface{}{
+				"options": map[string]string{
+					"version": "2",
+				},
 			},
-		},
-	}
-	resp, err := core.HandleRequest(req)
-	if err != nil {
-		return nil, errwrap.Wrapf("error upgrading default K/V store: {{err}}", err)
-	}
-	if resp.IsError() {
-		return nil, errwrap.Wrapf("failed to upgrade default K/V store: {{err}}", resp.Error())
+		}
+		resp, err := core.HandleRequest(req)
+		if err != nil {
+			return nil, errwrap.Wrapf("error upgrading default K/V store: {{err}}", err)
+		}
+		if resp.IsError() {
+			return nil, errwrap.Wrapf("failed to upgrade default K/V store: {{err}}", resp.Error())
+		}
 	}
 
 	return init, nil

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -130,6 +130,31 @@ func TestHandler_CacheControlNoStore(t *testing.T) {
 	}
 }
 
+func TestHandler_Accepted(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+
+	req, err := http.NewRequest("POST", addr+"/v1/auth/token/tidy", nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	req.Header.Set(AuthHeaderName, token)
+
+	client := cleanhttp.DefaultClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	t.Logf("%#v", resp)
+
+	testResponseStatus(t, resp, 202)
+	if resp.Body != http.NoBody {
+		t.Fatal("got non-empty body")
+	}
+}
+
 // We use this test to verify header auth
 func TestSysMounts_headerAuth(t *testing.T) {
 	core, _, token := vault.TestCoreUnsealed(t)

--- a/http/logical.go
+++ b/http/logical.go
@@ -268,8 +268,7 @@ func respondRaw(w http.ResponseWriter, r *http.Request, resp *logical.Response) 
 		// Get the body
 		bodyRaw, ok := resp.Data[logical.HTTPRawBody]
 		if !ok {
-			retErr(w, "no body given")
-			return
+			goto WRITE_RESPONSE
 		}
 
 		switch bodyRaw.(type) {
@@ -290,6 +289,7 @@ func respondRaw(w http.ResponseWriter, r *http.Request, resp *logical.Response) 
 		}
 	}
 
+WRITE_RESPONSE:
 	// Write the response
 	if contentType != "" {
 		w.Header().Set("Content-Type", contentType)

--- a/logical/error.go
+++ b/logical/error.go
@@ -1,5 +1,31 @@
 package logical
 
+import "errors"
+
+var (
+	// ErrUnsupportedOperation is returned if the operation is not supported
+	// by the logical backend.
+	ErrUnsupportedOperation = errors.New("unsupported operation")
+
+	// ErrUnsupportedPath is returned if the path is not supported
+	// by the logical backend.
+	ErrUnsupportedPath = errors.New("unsupported path")
+
+	// ErrInvalidRequest is returned if the request is invalid
+	ErrInvalidRequest = errors.New("invalid request")
+
+	// ErrPermissionDenied is returned if the client is not authorized
+	ErrPermissionDenied = errors.New("permission denied")
+
+	// ErrMultiAuthzPending is returned if the the request needs more
+	// authorizations
+	ErrMultiAuthzPending = errors.New("request needs further approval")
+
+	// ErrAccepted is returned if the request has been accepted but not yet
+	// processed
+	ErrAccepted = errors.New("request successfully accepted")
+)
+
 type HTTPCodedError interface {
 	Error() string
 	Code() int

--- a/logical/error.go
+++ b/logical/error.go
@@ -20,10 +20,6 @@ var (
 	// ErrMultiAuthzPending is returned if the the request needs more
 	// authorizations
 	ErrMultiAuthzPending = errors.New("request needs further approval")
-
-	// ErrAccepted is returned if the request has been accepted but not yet
-	// processed
-	ErrAccepted = errors.New("request successfully accepted")
 )
 
 type HTTPCodedError interface {

--- a/logical/request.go
+++ b/logical/request.go
@@ -1,7 +1,6 @@
 package logical
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -272,24 +271,4 @@ const (
 	RevokeOperation   Operation = "revoke"
 	RenewOperation              = "renew"
 	RollbackOperation           = "rollback"
-)
-
-var (
-	// ErrUnsupportedOperation is returned if the operation is not supported
-	// by the logical backend.
-	ErrUnsupportedOperation = errors.New("unsupported operation")
-
-	// ErrUnsupportedPath is returned if the path is not supported
-	// by the logical backend.
-	ErrUnsupportedPath = errors.New("unsupported path")
-
-	// ErrInvalidRequest is returned if the request is invalid
-	ErrInvalidRequest = errors.New("invalid request")
-
-	// ErrPermissionDenied is returned if the client is not authorized
-	ErrPermissionDenied = errors.New("permission denied")
-
-	// ErrMultiAuthzPending is returned if the the request needs more
-	// authorizations
-	ErrMultiAuthzPending = errors.New("request needs further approval")
 )

--- a/logical/response.go
+++ b/logical/response.go
@@ -141,22 +141,27 @@ func ListResponseWithInfo(keys []string, keyInfo map[string]interface{}) *Respon
 // RespondWithStatusCode takes a response and converts it to a raw response with
 // the provided Status Code.
 func RespondWithStatusCode(resp *Response, req *Request, code int) (*Response, error) {
-	httpResp := LogicalResponseToHTTPResponse(resp)
-	httpResp.RequestID = req.ID
-
-	body, err := json.Marshal(httpResp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Response{
+	ret := &Response{
 		Data: map[string]interface{}{
 			HTTPContentType: "application/json",
-			// We default to string here so that the value is HMAC'd via audit.
-			// Since this function is always marshaling to JSON, this is
-			// appropriate.
-			HTTPRawBody:    string(body),
-			HTTPStatusCode: code,
+			HTTPStatusCode:  code,
 		},
-	}, nil
+	}
+
+	if resp != nil {
+		httpResp := LogicalResponseToHTTPResponse(resp)
+		httpResp.RequestID = req.ID
+
+		body, err := json.Marshal(httpResp)
+		if err != nil {
+			return nil, err
+		}
+
+		// We default to string here so that the value is HMAC'd via audit.
+		// Since this function is always marshaling to JSON, this is
+		// appropriate.
+		ret.Data[HTTPRawBody] = string(body)
+	}
+
+	return ret, nil
 }

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -189,7 +189,7 @@ func (c *Core) disableCredential(ctx context.Context, path string) error {
 
 	if backend != nil {
 		// Revoke credentials from this path
-		if err := c.expiration.RevokePrefix(fullPath); err != nil {
+		if err := c.expiration.RevokePrefix(fullPath, false); err != nil {
 			return err
 		}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -189,7 +189,7 @@ func (c *Core) disableCredential(ctx context.Context, path string) error {
 
 	if backend != nil {
 		// Revoke credentials from this path
-		if err := c.expiration.RevokePrefix(fullPath, false); err != nil {
+		if err := c.expiration.RevokePrefix(fullPath, true); err != nil {
 			return err
 		}
 

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -3,11 +3,13 @@ package vault
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1435,6 +1437,97 @@ func TestExpiration_renewEntry(t *testing.T) {
 	}
 	if !reflect.DeepEqual(req.Data, le.Data) {
 		t.Fatalf("Bad: %v", req)
+	}
+}
+
+func TestExpiration_revokeEntry_rejected(t *testing.T) {
+	core, _, _ := TestCoreUnsealed(t)
+	exp := core.expiration
+
+	rejected := new(uint32)
+
+	noop := &NoopBackend{
+		RequestHandler: func(ctx context.Context, req *logical.Request) (*logical.Response, error) {
+			if req.Operation == logical.RevokeOperation {
+				if atomic.CompareAndSwapUint32(rejected, 0, 1) {
+					t.Logf("denying revocation")
+					return nil, errors.New("nope")
+				}
+				t.Logf("allowing revocation")
+			}
+			return nil, nil
+		},
+	}
+	_, barrier, _ := mockBarrier(t)
+	view := NewBarrierView(barrier, "logical/")
+	meUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = exp.router.Mount(noop, "foo/bar/", &MountEntry{Path: "foo/bar/", Type: "noop", UUID: meUUID, Accessor: "noop-accessor"}, view)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	le := &leaseEntry{
+		LeaseID: "foo/bar/1234",
+		Path:    "foo/bar",
+		Data: map[string]interface{}{
+			"testing": true,
+		},
+		Secret: &logical.Secret{
+			LeaseOptions: logical.LeaseOptions{
+				TTL: time.Minute,
+			},
+		},
+		IssueTime:  time.Now(),
+		ExpireTime: time.Now().Add(time.Minute),
+	}
+
+	err = exp.persistEntry(le)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = exp.Revoke(le.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Give time to let the request be handled
+	time.Sleep(1 * time.Second)
+
+	if atomic.LoadUint32(rejected) != 1 {
+		t.Fatal("unexpected val for rejected")
+	}
+
+	err = exp.Stop()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = core.setupExpiration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp = core.expiration
+
+	for {
+		if !exp.inRestoreMode() {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Now let the revocation actually process
+	time.Sleep(1 * time.Second)
+
+	le, err = exp.FetchLeaseTimes(le.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if le != nil {
+		t.Fatal("ugh")
 	}
 }
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2331,6 +2331,8 @@ func (b *SystemBackend) handleRevoke(ctx context.Context, req *logical.Request, 
 		b.Backend.Logger().Error("lease revocation failed", "lease_id", leaseID, "error", err)
 		return handleErrorNoReadOnlyForward(err)
 	}
+
+	return nil, nil
 }
 
 // handleRevokePrefix is used to revoke a prefix with many LeaseIDs

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1190,9 +1190,7 @@ func (b *SystemBackend) handleTidyLeases(ctx context.Context, req *logical.Reque
 		}
 	}()
 
-	resp := &logical.Response{}
-	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
-	return resp, nil
+	return logical.RespondWithStatusCode(nil, req, http.StatusAccepted)
 }
 
 func (b *SystemBackend) invalidate(ctx context.Context, key string) {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1200,7 +1200,9 @@ func (b *SystemBackend) handleTidyLeases(ctx context.Context, req *logical.Reque
 		}
 	}()
 
-	return logical.RespondWithStatusCode(nil, req, http.StatusAccepted)
+	resp := &logical.Response{}
+	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
+	return logical.RespondWithStatusCode(resp, req, http.StatusAccepted)
 }
 
 func (b *SystemBackend) invalidate(ctx context.Context, key string) {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -408,7 +408,7 @@ func (c *Core) unmountInternal(ctx context.Context, path string) error {
 		}
 
 		// Revoke all the dynamic keys
-		if err := c.expiration.RevokePrefix(path, false); err != nil {
+		if err := c.expiration.RevokePrefix(path, true); err != nil {
 			return err
 		}
 
@@ -555,7 +555,7 @@ func (c *Core) remount(ctx context.Context, src, dst string) error {
 	}
 
 	// Revoke all the dynamic keys
-	if err := c.expiration.RevokePrefix(src, false); err != nil {
+	if err := c.expiration.RevokePrefix(src, true); err != nil {
 		return err
 	}
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -408,7 +408,7 @@ func (c *Core) unmountInternal(ctx context.Context, path string) error {
 		}
 
 		// Revoke all the dynamic keys
-		if err := c.expiration.RevokePrefix(path); err != nil {
+		if err := c.expiration.RevokePrefix(path, false); err != nil {
 			return err
 		}
 
@@ -555,7 +555,7 @@ func (c *Core) remount(ctx context.Context, src, dst string) error {
 	}
 
 	// Revoke all the dynamic keys
-	if err := c.expiration.RevokePrefix(src); err != nil {
+	if err := c.expiration.RevokePrefix(src, false); err != nil {
 		return err
 	}
 

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"sync/atomic"
 
@@ -1505,9 +1506,7 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 		}
 	}()
 
-	resp := &logical.Response{}
-	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
-	return resp, nil
+	return logical.RespondWithStatusCode(nil, req, http.StatusAccepted)
 }
 
 // handleUpdateLookupAccessor handles the auth/token/lookup-accessor path for returning

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1506,7 +1506,9 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 		}
 	}()
 
-	return logical.RespondWithStatusCode(nil, req, http.StatusAccepted)
+	resp := &logical.Response{}
+	resp.AddWarning("Tidy operation successfully started. Any information from the operation will be printed to Vault's server logs.")
+	return logical.RespondWithStatusCode(resp, req, http.StatusAccepted)
 }
 
 // handleUpdateLookupAccessor handles the auth/token/lookup-accessor path for returning


### PR DESCRIPTION
This change makes it so that if a lease is revoked through user action,
we set the expiration time to now and update pending, just as we do with
tokens. This allows the normal retry logic to apply in these cases as
well, instead of just erroring out immediately. The idea being that once
you tell Vault to revoke something it should keep doing its darndest to
actually make that happen.