### PR TITLE
Add mount-level TTL helper

### DIFF
--- a/helper/ttl/validation.go
+++ b/helper/ttl/validation.go
@@ -1,0 +1,83 @@
+package ttl
+
+import (
+	"errors"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/vault/logical"
+)
+
+type MountHandler struct {
+	// ConfigTTL is the TTL being set at a mount's config level.
+	// For example, if your plugin were the Azure secrets engine,
+	// and you had a path for an overall config like <mount>/config,
+	// this would be the TTL at that level.
+	// Optional, can be unset.
+	ConfigTTL time.Duration
+
+	// ConfigMaxTTL is the MaxTTL being set at a mount's config level.
+	// For example, if your plugin were the Azure secrets engine,
+	// and you had a path for an overall config like <mount>/config,
+	// this would be the MaxTTL at that level.
+	// Optional, can be unset.
+	ConfigMaxTTL time.Duration
+
+	// RoleTTL is the TTL being set at a role level, which is a lower
+	// and more specific level than the config level.
+	// Optional, can be unset.
+	RoleTTL time.Duration
+
+	// RoleMaxTTL is the MaxTTL being set at a role level, which is a lower
+	// and more specific level than the config level.
+	// Optional, can be unset.
+	RoleMaxTTL time.Duration
+}
+
+func (h *MountHandler) Validate(system logical.SystemView) error {
+
+	merr := &multierror.Error{}
+
+	// Verify the config-level TTL's alone.
+	if h.ConfigTTL < 0 {
+		merr = multierror.Append(merr, errors.New("config ttl < 0"))
+	}
+	if h.ConfigMaxTTL < 0 {
+		merr = multierror.Append(merr, errors.New("config max_ttl < 0"))
+	}
+	if h.ConfigTTL > system.DefaultLeaseTTL() {
+		merr = multierror.Append(merr, errors.New("config ttl > system defined TTL"))
+	}
+	if h.ConfigMaxTTL > system.MaxLeaseTTL() {
+		merr = multierror.Append(merr, errors.New("config max_ttl > system defined max TTL"))
+	}
+	if h.ConfigMaxTTL != 0 && h.ConfigTTL > h.ConfigMaxTTL {
+		merr = multierror.Append(merr, errors.New("config ttl > config max_ttl"))
+	}
+
+	// Verify the role-level TTL's alone.
+	if h.RoleTTL < 0 {
+		merr = multierror.Append(merr, errors.New("role ttl < 0"))
+	}
+	if h.RoleMaxTTL < 0 {
+		merr = multierror.Append(merr, errors.New("role max_ttl < 0"))
+	}
+	if h.RoleTTL > system.DefaultLeaseTTL() {
+		merr = multierror.Append(merr, errors.New("role ttl > system defined TTL"))
+	}
+	if h.RoleMaxTTL > system.MaxLeaseTTL() {
+		merr = multierror.Append(merr, errors.New("role max_ttl > system defined max TTL"))
+	}
+	if h.RoleMaxTTL != 0 && h.RoleTTL > h.RoleMaxTTL {
+		merr = multierror.Append(merr, errors.New("role ttl > role max_ttl"))
+	}
+
+	// Verify the config and role TTL's in relation to each other.
+	if h.ConfigTTL != 0 && h.RoleTTL > h.ConfigTTL {
+		merr = multierror.Append(merr, errors.New("role ttl > config ttl"))
+	}
+	if h.ConfigMaxTTL != 0 && h.RoleMaxTTL > h.ConfigMaxTTL {
+		merr = multierror.Append(merr, errors.New("role max_ttl > config max_ttl"))
+	}
+	return merr.ErrorOrNil()
+}

--- a/helper/ttl/validation_test.go
+++ b/helper/ttl/validation_test.go
@@ -1,0 +1,102 @@
+package ttl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/logical"
+)
+
+var system = &logical.StaticSystemView{
+	DefaultLeaseTTLVal: time.Hour,
+	MaxLeaseTTLVal:     time.Hour,
+}
+
+func TestNegativeTTLsThrowErrors(t *testing.T) {
+	h := &MountHandler{
+		ConfigTTL: -1,
+	}
+	if err := h.Validate(system); err == nil {
+		t.Fatal("should have received error due to negative TTL")
+	}
+
+	h = &MountHandler{
+		ConfigMaxTTL: -1,
+	}
+	if err := h.Validate(system); err == nil {
+		t.Fatal("should have received error due to negative TTL")
+	}
+
+	h = &MountHandler{
+		RoleTTL: -1,
+	}
+	if err := h.Validate(system); err == nil {
+		t.Fatal("should have received error due to negative TTL")
+	}
+
+	h = &MountHandler{
+		RoleMaxTTL: -1,
+	}
+	if err := h.Validate(system); err == nil {
+		t.Fatal("should have received error due to negative TTL")
+	}
+}
+
+func TestZeroTTLsAreOK(t *testing.T) {
+	h := &MountHandler{}
+	if err := h.Validate(system); err != nil {
+		t.Fatal("having zeros for everything is OK")
+	}
+}
+
+func TestConfigTTLsButNoRoleTTLs(t *testing.T) {
+	h := &MountHandler{
+		ConfigTTL:    1,
+		ConfigMaxTTL: 1,
+	}
+	if err := h.Validate(system); err != nil {
+		t.Fatal("having zeros for the role is OK")
+	}
+}
+
+func TestRoleTTLsButNoConfigTTLs(t *testing.T) {
+	h := &MountHandler{
+		RoleTTL:    1,
+		RoleMaxTTL: 1,
+	}
+	if err := h.Validate(system); err != nil {
+		t.Fatal("having zeros for the config is OK")
+	}
+}
+
+func TestRoleTTLsHigherThanConfigTTLs(t *testing.T) {
+	h := &MountHandler{
+		ConfigTTL:    1,
+		ConfigMaxTTL: 1,
+		RoleTTL:      2,
+		RoleMaxTTL:   2,
+	}
+	if err := h.Validate(system); err == nil {
+		t.Fatal("we should error when role TTLs are higher than config TTLs")
+	}
+}
+
+func TestRoleTTLsHigherThanSystemTTLs(t *testing.T) {
+	h := &MountHandler{
+		RoleTTL:    2 * time.Hour,
+		RoleMaxTTL: 2 * time.Hour,
+	}
+	if err := h.Validate(system); err == nil {
+		t.Fatal("we should error when role TTLs are higher than system TTLs")
+	}
+}
+
+func TestConfigTTLsHigherThanSystemTTLs(t *testing.T) {
+	h := &MountHandler{
+		ConfigTTL:    2 * time.Hour,
+		ConfigMaxTTL: 2 * time.Hour,
+	}
+	if err := h.Validate(system); err == nil {
+		t.Fatal("we should error when config TTLs are higher than system TTLs")
+	}
+}


### PR DESCRIPTION
Auth TTL's can be set at the system level, the mount config level, and at the role level for later use. While the system will do the right thing at login time, for instance defaulting to the lowest TTL of those given, if TTLs have been misconfigured it's too late to correct the problem.

This PR adds a helper that will be used by the Alibaba plugin and ideally by other plugins as well. This helper will initially just provide TTL validation, and is intended to be used at paths that configure mounts and roles. However, if we need to add more functionality later, we can.

This will allow the logic to all be in one place, rather than copied across backends, and if it needs to be updated then the updates will automatically propagate. Also, this provides more test coverage to harden the logic.