### PR TITLE
PKI Tidy Revocation List optionally Tidy Revoked Certs that are Unexp…

### DIFF
--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -31,6 +31,14 @@ the revocation list`,
 				Default: false,
 			},
 
+			"tidy_revoked_certs": &framework.FieldSchema{
+				Type: framework.TypeBool,
+				Description: `Set to true to expire all revoked
+certificates, even if their duration has not yet passed. This will cause these
+certificates to be removed from the CRL the next time the CRL is generated.`,
+				Default: false,
+			},
+
 			"safety_buffer": &framework.FieldSchema{
 				Type: framework.TypeDurationSecond,
 				Description: `The amount of extra time that must have passed
@@ -54,6 +62,7 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 	safetyBuffer := d.Get("safety_buffer").(int)
 	tidyCertStore := d.Get("tidy_cert_store").(bool)
 	tidyRevocationList := d.Get("tidy_revocation_list").(bool)
+	tidyRevokedCerts := d.Get("tidy_revoked_certs").(bool)
 
 	if safetyBuffer < 1 {
 		return logical.ErrorResponse("safety_buffer must be greater than zero"), nil
@@ -163,7 +172,7 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 						return errwrap.Wrapf(fmt.Sprintf("unable to parse stored revoked certificate with serial %q: {{err}}", serial), err)
 					}
 
-					if time.Now().After(revokedCert.NotAfter.Add(bufferDuration)) {
+					if tidyRevokedCerts || time.Now().After(revokedCert.NotAfter.Add(bufferDuration)) {
 						if err := req.Storage.Delete(ctx, "revoked/"+serial); err != nil {
 							return errwrap.Wrapf(fmt.Sprintf("error deleting serial %q from revoked list: {{err}}", serial), err)
 						}

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -1532,6 +1532,10 @@ expiration time.
 - `tidy_revocation_list` `(bool: false)` Specifies whether to tidy up the
   revocation list (CRL).
 
+- `tidy_revoked_certs` `(bool: false)` Set to true to expire all revoked
+  certificates, even if their duration has not yet passed. This will cause these
+  certificates to be removed from the CRL the next time the CRL is generated.
+
 - `safety_buffer` `(string: "")` Specifies  A duration (given as an integer
   number of seconds or a string; defaults to `72h`) used as a safety buffer to
   ensure certificates are not expunged prematurely; as an example, this can keep


### PR DESCRIPTION
Tested with:

```
$ curl \
  --request POST \
  --header "X-Vault-Token: root" \
  --data '{"serial_number":"3e:13:f8:0c:c5:b3:85:99:e8:7e:a3:3c:09:58:60:91:4d:b3:b
b:79"}' \
  http://127.0.0.1:8200/v1/pki/aws-us-west-2/revoke | jq .

{
  "request_id": "b611faa5-8c18-14c9-c1bd-9ef9ec4c4aa3",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 0,
  "data": {
    "revocation_time": 1531419682,
    "revocation_time_rfc3339": "2018-07-12T18:21:22.954519735Z"
  },
  "wrap_info": null,
  "warnings": null,
  "auth": null
}

$ curl \
  --header "X-Vault-Token: root" \
  http://127.0.0.1:8200/v1/pki/aws-us-west-2/crl/pem > teststate/vault-1-crls.pem

$ openssl crl -inform PEM -in teststate/vault-1-crls.pem  -text                                                            

Certificate Revocation List (CRL):
        Version 2 (0x1)
    Signature Algorithm: ecdsa-with-SHA384
        Issuer: /CN=ICA aws-us-west-2
        Last Update: Jul 12 18:21:26 2018 GMT
        Next Update: Jul 15 18:21:26 2018 GMT
        CRL extensions:
            X509v3 Authority Key Identifier:
                keyid:51:00:F6:D7:24:E8:3F:B4:AF:5B:30:A5:AE:D5:3E:86:BC:CB:9D:D3

Revoked Certificates:
    Serial Number: 3E13F80CC5B38599E87EA33C095860914DB3BB79
        Revocation Date: Jul 12 18:21:22 2018 GMT
    Signature Algorithm: ecdsa-with-SHA384
         30:66:02:31:00:be:cb:c8:b4:fd:56:91:ba:09:47:54:5e:36:
         25:6b:36:f4:75:7c:0a:e0:c0:c5:8a:7a:85:f2:aa:19:94:b6:
         f1:53:73:e3:54:48:81:1f:58:36:9a:ea:0b:f9:f1:0c:72:02:
         31:00:d2:8d:2b:35:43:61:fe:4c:ca:4e:90:85:c6:08:2d:b5:
         da:53:60:23:21:32:ec:c3:93:a4:54:b4:49:09:a3:9d:a9:05:
         61:3f:cd:04:d5:50:7d:db:13:4c:a2:44:e2:9d
-----BEGIN X509 CRL-----
....

$ VAULT_ADDR=http://127.0.0.1:8200 \
   VAULT_TOKEN=root \
   /vagrant_data/go/src/github.com/hashicorp/vault/bin/vault write pki/aws-us-west-2/
tidy tidy_revocation_list=true tidy_revoked_certs=true

WARNING! The following warnings were returned from Vault:

  * Tidy operation successfully started. Any information from the operation
  will be printed to Vault's server logs.

$ curl --header "X-Vault-Token: root" http://127.0.0.1:8200/v1/pki/aws-us-west-2/crl/pem > teststate/vault-1-crls.pem

$ openssl crl -inform PEM -in teststate/vault-1-crls.pem  -text                                                               
Certificate Revocation List (CRL):
        Version 2 (0x1)
    Signature Algorithm: ecdsa-with-SHA384
        Issuer: /CN=ICA aws-us-west-2
        Last Update: Jul 12 18:22:38 2018 GMT
        Next Update: Jul 15 18:22:38 2018 GMT
        CRL extensions:
            X509v3 Authority Key Identifier:
                keyid:51:00:F6:D7:24:E8:3F:B4:AF:5B:30:A5:AE:D5:3E:86:BC:CB:9D:D3

No Revoked Certificates.
    Signature Algorithm: ecdsa-with-SHA384
         30:64:02:30:72:70:06:15:83:39:7a:ed:d4:c7:e5:7c:7d:98:
         af:47:f8:52:dc:69:83:5c:d2:b4:fd:b7:0b:9f:a1:4d:01:82:
         65:d6:6a:14:0f:34:3a:d4:5b:7c:d3:15:8a:99:3e:bc:02:30:
         20:ac:4e:06:84:b8:86:94:0b:1e:01:24:b8:48:1a:5e:c0:a2:
         14:c5:6b:c9:fe:fe:11:aa:7b:2b:e6:6e:ac:21:83:4d:75:29:
         33:e4:ac:47:bd:a7:75:2d:e2:6f:cf:7e
-----BEGIN X509 CRL-----
...
```
