### PR TITLE
Turn off retries on CLI

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -86,6 +87,11 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 	client, err := api.NewClient(config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create client")
+	}
+
+	// Turn off retries on the CLI
+	if os.Getenv(api.EnvVaultMaxRetries) == "" {
+		client.SetMaxRetries(0)
 	}
 
 	// Set the wrapping function

--- a/command/base_predict.go
+++ b/command/base_predict.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -33,6 +34,11 @@ func (p *Predict) Client() *api.Client {
 					return
 				}
 				client.SetToken(token)
+			}
+
+			// Turn off retries for prediction
+			if os.Getenv(api.EnvVaultMaxRetries) == "" {
+				client.SetMaxRetries(0)
 			}
 
 			p.client = client


### PR DESCRIPTION
For the CLI it just ends up confusing people as to why it's "hanging"
before returning a 500. This can still be overridden with
VAULT_MAX_RETRIES.