### PR TITLE
Don't use activeContext for standby/leader cancelation

### DIFF
--- a/vault/ha.go
+++ b/vault/ha.go
@@ -773,7 +773,7 @@ func (c *Core) cleanLeaderPrefix(ctx context.Context, uuid string, leaderLostCh 
 // clearLeader is used to clear our leadership entry
 func (c *Core) clearLeader(uuid string) error {
 	key := coreLeaderPrefix + uuid
-	err := c.barrier.Delete(c.activeContext, key)
+	err := c.barrier.Delete(context.Background(), key)
 
 	// Advertise ourselves as a standby
 	sd, ok := c.ha.(physical.ServiceDiscovery)


### PR DESCRIPTION
Move cancelation to after cleanup. This is my _guess_ as to what's happening here, but I could be totally off base. 

It looks like we call cancelation on `activeContext`, but then pass that context to the function. I moved the cancelation to after cleanup, and made context a local param to reduce the chance of a race if another func modifies c.activeContext

/cc @briankassouf @jefferai 

Fixes GH-4915