### PR TITLE
Add a "null" formatter

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -302,7 +302,7 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 					EnvVar:     EnvVaultFormat,
 					Completion: complete.PredictSet("table", "json", "yaml"),
 					Usage: "Print the output in the given format. Valid formats " +
-						"are \"table\", \"json\", or \"yaml\".",
+						"are \"table\", \"json\", \"yaml\", or \"none\".",
 				})
 			}
 		}

--- a/command/format.go
+++ b/command/format.go
@@ -67,6 +67,8 @@ var Formatters = map[string]Formatter{
 	"table": TableFormatter{},
 	"yaml":  YamlFormatter{},
 	"yml":   YamlFormatter{},
+	"none":  NullFormatter{},
+	"null":  NullFormatter{},
 }
 
 func Format(ui cli.Ui) string {
@@ -81,6 +83,17 @@ func Format(ui cli.Ui) string {
 	}
 
 	return format
+}
+
+// NullFormatter is a formatter that doens't print anything.
+type NullFormatter struct{}
+
+func (f NullFormatter) Format(_ interface{}) ([]byte, error) {
+	return nil, nil
+}
+
+func (f NullFormatter) Output(_ cli.Ui, _ *api.Secret, _ interface{}) error {
+	return nil
 }
 
 // An output formatter for json output of an object

--- a/website/source/docs/commands/audit/list.html.md
+++ b/website/source/docs/commands/audit/list.html.md
@@ -40,7 +40,7 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options

--- a/website/source/docs/commands/auth/list.html.md
+++ b/website/source/docs/commands/auth/list.html.md
@@ -42,7 +42,7 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options

--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -218,18 +218,18 @@ If provided, Vault output will not include ANSI color escape sequence characters
 
 ### `VAULT_RATE_LIMIT`
 
-This enviroment variable will limit the rate at which the `vault` command
+This environment variable will limit the rate at which the `vault` command
 sends requests to Vault.
 
-This enviroment variable has the format `rate[:burst]` (where items in `[]` are
-optional). If not specified, the burst value defaults to rate. Both rate and 
+This environment variable has the format `rate[:burst]` (where items in `[]` are
+optional). If not specified, the burst value defaults to rate. Both rate and
 burst are specified in "operations per second". If the environment variable is
-not specified, then the rate and burst will be unlimited *i.e.* rate 
+not specified, then the rate and burst will be unlimited *i.e.* rate
 limiting is off by default.
 
 *Note:* The rate is limited for each invocation of the `vault` CLI. Since
 each invocation of the `vault` CLI typically only makes a few requests,
-this enviroment variable is most useful when using the Go 
+this environment variable is most useful when using the Go
 [Vault client API](https://www.vaultproject.io/api/libraries.html#go).
 
 ### `VAULT_MFA`

--- a/website/source/docs/commands/login.html.md
+++ b/website/source/docs/commands/login.html.md
@@ -92,7 +92,7 @@ flags](/docs/commands/index.html) included on all commands.
   will not have a trailing newline making it ideal for piping to other processes.
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options

--- a/website/source/docs/commands/operator/generate-root.html.md
+++ b/website/source/docs/commands/operator/generate-root.html.md
@@ -58,7 +58,7 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options

--- a/website/source/docs/commands/operator/init.html.md
+++ b/website/source/docs/commands/operator/init.html.md
@@ -57,7 +57,7 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "")` - Print the output in the given format. Valid formats
-  are "table", "json", or "yaml". The default is table. This can also be
+  are "table", "json", "yaml", or "none". The default is table. This can also be
   specified via the `VAULT_FORMAT` environment variable.
 
 ### Common Options

--- a/website/source/docs/commands/operator/key-status.html.md
+++ b/website/source/docs/commands/operator/key-status.html.md
@@ -30,5 +30,5 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.

--- a/website/source/docs/commands/operator/rekey.html.md
+++ b/website/source/docs/commands/operator/rekey.html.md
@@ -75,7 +75,7 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options

--- a/website/source/docs/commands/operator/rotate.html.md
+++ b/website/source/docs/commands/operator/rotate.html.md
@@ -38,5 +38,5 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.

--- a/website/source/docs/commands/operator/unseal.html.md
+++ b/website/source/docs/commands/operator/unseal.html.md
@@ -53,7 +53,7 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options

--- a/website/source/docs/commands/policy/list.html.md
+++ b/website/source/docs/commands/policy/list.html.md
@@ -30,6 +30,6 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 

--- a/website/source/docs/commands/policy/read.html.md
+++ b/website/source/docs/commands/policy/read.html.md
@@ -28,5 +28,5 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.

--- a/website/source/docs/commands/read.html.md
+++ b/website/source/docs/commands/read.html.md
@@ -40,5 +40,5 @@ flags](/docs/commands/index.html) included on all commands.
   will not have a trailing newline making it ideal for piping to other processes.
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.

--- a/website/source/docs/commands/secrets/list.html.md
+++ b/website/source/docs/commands/secrets/list.html.md
@@ -48,7 +48,7 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options

--- a/website/source/docs/commands/ssh.html.md
+++ b/website/source/docs/commands/ssh.html.md
@@ -60,7 +60,7 @@ flags](/docs/commands/index.html) included on all commands.
   will not have a trailing newline making it ideal for piping to other processes.
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### SSH Options

--- a/website/source/docs/commands/status.html.md
+++ b/website/source/docs/commands/status.html.md
@@ -46,5 +46,5 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.

--- a/website/source/docs/commands/token/capabilities.html.md
+++ b/website/source/docs/commands/token/capabilities.html.md
@@ -41,5 +41,5 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.

--- a/website/source/docs/commands/token/create.html.md
+++ b/website/source/docs/commands/token/create.html.md
@@ -67,7 +67,7 @@ flags](/docs/commands/index.html) included on all commands.
   will not have a trailing newline making it ideal for piping to other processes.
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options

--- a/website/source/docs/commands/token/lookup.html.md
+++ b/website/source/docs/commands/token/lookup.html.md
@@ -42,7 +42,7 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(default: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options

--- a/website/source/docs/commands/token/renew.html.md
+++ b/website/source/docs/commands/token/renew.html.md
@@ -45,7 +45,7 @@ flags](/docs/commands/index.html) included on all commands.
 ### Output Options
 
 - `-format` `(default: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options

--- a/website/source/docs/commands/unwrap.html.md
+++ b/website/source/docs/commands/unwrap.html.md
@@ -42,5 +42,5 @@ flags](/docs/commands/index.html) included on all commands.
   will not have a trailing newline making it ideal for piping to other processes.
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.

--- a/website/source/docs/commands/write.html.md
+++ b/website/source/docs/commands/write.html.md
@@ -59,7 +59,7 @@ flags](/docs/commands/index.html) included on all commands.
   will not have a trailing newline making it ideal for piping to other processes.
 
 - `-format` `(string: "table")` - Print the output in the given format. Valid
-  formats are "table", "json", or "yaml". This can also be specified via the
+  formats are "table", "json", "yaml", or "none". This can also be specified via the
   `VAULT_FORMAT` environment variable.
 
 ### Command Options


### PR DESCRIPTION
Sometimes you really don't want Vault to print anything. This adds a formatter that does just that. I could be convinced that this should be a dedicated flag like `-silent`, but I thought `-format=none` read nicely.