### PR TITLE
Two small items:

### DIFF
--- a/helper/policyutil/policyutil.go
+++ b/helper/policyutil/policyutil.go
@@ -78,11 +78,14 @@ func SanitizePolicies(policies []string, addDefault bool) []string {
 // the "default" policy out of its comparisons as it may be added later by core
 // after a set of policies has been saved by a backend.
 func EquivalentPolicies(a, b []string) bool {
-	if a == nil && b == nil {
+	switch {
+	case a == nil && b == nil:
 		return true
-	}
-
-	if a == nil || b == nil {
+	case a == nil && len(b) == 1 && b[0] == "default":
+		return true
+	case b == nil && len(a) == 1 && a[0] == "default":
+		return true
+	case a == nil || b == nil:
 		return false
 	}
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1399,6 +1399,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		}
 		config.Address = fmt.Sprintf("https://127.0.0.1:%d", port)
 		config.HttpClient = client
+		config.MaxRetries = 0
 		apiClient, err := api.NewClient(config)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
1) Disable MaxRetries in test cluster clients. We generally want to fail
as fast as possible in tests so adding unpredictable timing in doesn't
help things, especially if we're timing sensitive in the test.

2) EquivalentPolicies is supposed to return true if only one set
contains `default` and the other is empty, but if one set was nil
instead of simply a zero length slice it would always return false. This
means that renewing against, say, `userpass` when not actually
specifying any user policies would always fail.