### PR TITLE
State in docs that FoundationDB backend is community supported

### DIFF
--- a/website/source/docs/configuration/storage/foundationdb.html.md
+++ b/website/source/docs/configuration/storage/foundationdb.html.md
@@ -21,6 +21,11 @@ accompanying the backend's source in the Vault source tree.
   nodes inside the cluster being properly sychronized; clock skews are
   susceptible to cause contention on the locks.
 
+- **Community Supported** – the FoundationDB storage backend is supported
+  by the community. While it has undergone review by HashiCorp employees,
+  they may not be as knowledgeable about the technology. If you encounter
+  problems with them, you may be referred to the original author.
+
 ```hcl
 storage "foundationdb" {
   api_version  = 510


### PR DESCRIPTION
The new FoundationDB is the only storage backend where it is not stated the kind of support provided.