### PR TITLE
Set sane DialTimeout for etcd3 client

### DIFF
--- a/physical/etcd/etcd3.go
+++ b/physical/etcd/etcd3.go
@@ -66,7 +66,8 @@ func newEtcd3Backend(conf map[string]string, logger log.Logger) (physical.Backen
 	}
 
 	cfg := clientv3.Config{
-		Endpoints: endpoints,
+		Endpoints:   endpoints,
+		DialTimeout: 5 * time.Second,
 	}
 
 	haEnabled := os.Getenv("ETCD_HA_ENABLED")


### PR DESCRIPTION
Ensure that a sane DialTimeout is configured when addressing
etcd3 clusters, avoiding issues when the first member of the
target addresses list is down.