### PR TITLE
UI unauthenticated auth method login

### DIFF
--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -8,6 +8,7 @@ const DEFAULTS = {
   token: null,
   username: null,
   password: null,
+  customPath: null,
 };
 
 export default Ember.Component.extend(DEFAULTS, {
@@ -75,10 +76,14 @@ export default Ember.Component.extend(DEFAULTS, {
     'selectedAuth',
     'selectedAuthIsPath',
     function() {
-      let methods = this.get('allSupportedMethods');
+      let methods = this.get('methods');
+      let selectedAuth = this.get('selectedAuth');
       let keyIsPath = this.get('selectedAuthIsPath');
-      let findKey = keyIsPath ? 'path' : 'type';
-      return methods.findBy(findKey, this.get('selectedAuth'));
+      if (keyIsPath) {
+        return methods.findBy('path', selectedAuth);
+      } else {
+        return BACKENDS.findBy('type', selectedAuth);
+      }
     }
   ),
 
@@ -143,15 +148,14 @@ export default Ember.Component.extend(DEFAULTS, {
       });
       let targetRoute = this.get('redirectTo') || 'vault.cluster';
       let backend = this.get('selectedAuthBackend') || {};
-      let path = get(backend, 'path') || this.get('customPath');
       let backendMeta = BACKENDS.find(
         b => get(b, 'type').toLowerCase() === get(backend, 'type').toLowerCase()
       );
       let attributes = get(backendMeta, 'formAttributes');
 
       data = Ember.assign(data, this.getProperties(...attributes));
-      if (get(backend, 'path') || (this.get('useCustomPath') && path)) {
-        data.path = path;
+      if (this.get('customPath') || get(backend, 'id')) {
+        data.path = this.get('customPath') || get(backend, 'id');
       }
       const clusterId = this.get('cluster.id');
       this.get('auth').authenticate({ clusterId, backend: get(backend, 'type'), data }).then(

--- a/ui/app/routes/vault/cluster/auth.js
+++ b/ui/app/routes/vault/cluster/auth.js
@@ -5,7 +5,8 @@ const { RSVP } = Ember;
 
 export default ClusterRouteBase.extend({
   beforeModel() {
-    return this.store.unloadAll('auth-method');
+    this.store.unloadAll('auth-method');
+    return this._super();
   },
   model() {
     let cluster = this._super(...arguments);

--- a/ui/app/routes/vault/cluster/auth.js
+++ b/ui/app/routes/vault/cluster/auth.js
@@ -1,9 +1,11 @@
 import ClusterRouteBase from './cluster-route-base';
 import Ember from 'ember';
+import config from 'vault/config/environment';
 
-const { RSVP } = Ember;
+const { RSVP, inject } = Ember;
 
 export default ClusterRouteBase.extend({
+  flashMessages: inject.service(),
   beforeModel() {
     this.store.unloadAll('auth-method');
     return this._super();
@@ -26,5 +28,11 @@ export default ClusterRouteBase.extend({
   resetController(controller) {
     controller.set('wrappedToken', '');
     controller.set('authMethod', '');
+  },
+
+  afterModel() {
+    if (config.welcomeMessage) {
+      this.get('flashMessages').stickyInfo(config.welcomeMessage);
+    }
   },
 });

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -66,6 +66,7 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
   }
+  ENV.welcomeMessage = process.env.UI_AUTH_WELCOME;
 
   return ENV;
 };

--- a/ui/tests/integration/components/auth-form-test.js
+++ b/ui/tests/integration/components/auth-form-test.js
@@ -128,6 +128,31 @@ test('it renders all the supported methods and Other tab when methods are presen
   assert.equal(component.tabs.objectAt(1).name, 'Other', 'second tab is the Other tab');
 });
 
+test('it calls authorize with the correct path', function(assert) {
+  this.register('service:auth', workingAuthService);
+  this.inject.service('auth');
+  let authSpy = sinon.spy(this.get('auth'), 'authenticate');
+  let methods = [
+    {
+      type: 'userpass',
+      id: 'foo',
+      path: 'foo/',
+    },
+  ];
+  this.set('methods', methods);
+  this.set('selectedAuth', 'foo/');
+
+  this.render(hbs`{{auth-form cluster=cluster methods=methods selectedAuth=selectedAuth}}`);
+  component.login();
+
+  return wait().then(() => {
+    assert.ok(authSpy.calledOnce, 'a call to authenticate was made');
+    let { data } = authSpy.getCall(0).args[0];
+    assert.equal(data.path, methods[0].id, 'uses the id for the path');
+    authSpy.restore();
+  });
+});
+
 test('it renders all the supported methods when no supported methods are present in passed methods', function(
   assert
 ) {


### PR DESCRIPTION
Uses the id so that we don't get a 301 with double `/` in the URL, makes sure we disambiguate built-in and auth-tuned unauthenicated logins, and uses the customPath if it's filled in.

Additionally, specifying `UI_AUTH_WELCOME` on build will show an info flash message with the content of that Env var.