### PR TITLE
UI - fix kv object so that falsey values don't get coerced to empty strings

### DIFF
--- a/ui/app/lib/kv-object.js
+++ b/ui/app/lib/kv-object.js
@@ -33,7 +33,8 @@ export default Ember.ArrayProxy.extend({
       if (!includeBlanks && item.value === '' && item.name === '') {
         return obj;
       }
-      obj[item.name || ''] = item.value || '';
+      let val = typeof item.value === 'undefined' ? '' : item.value;
+      obj[item.name || ''] = val;
       return obj;
     }, {});
   },

--- a/ui/tests/unit/lib/kv-object-test.js
+++ b/ui/tests/unit/lib/kv-object-test.js
@@ -1,0 +1,91 @@
+import { module, test } from 'qunit';
+import KVObject from 'vault/lib/kv-object';
+
+module('lib/kv-object', 'Unit | Lib | kv object');
+
+let fromJSONTests = [
+  [
+    'types',
+    { string: 'string', false: false, zero: 0, number: 1, null: null, true: true, object: { one: 'two' } },
+    [
+      { name: 'false', value: false },
+      { name: 'null', value: null },
+      { name: 'number', value: 1 },
+      { name: 'object', value: { one: 'two' } },
+      { name: 'string', value: 'string' },
+      { name: 'true', value: true },
+      { name: 'zero', value: 0 },
+    ],
+  ],
+  [
+    'ordering',
+    { b: 'b', '1': '1', z: 'z', A: 'A', a: 'a' },
+    [
+      { name: '1', value: '1' },
+      { name: 'a', value: 'a' },
+      { name: 'A', value: 'A' },
+      { name: 'b', value: 'b' },
+      { name: 'z', value: 'z' },
+    ],
+  ],
+];
+
+fromJSONTests.forEach(function([name, input, content]) {
+  test(`fromJSON: ${name}`, function(assert) {
+    let data = KVObject.create({ content: [] }).fromJSON(input);
+    assert.deepEqual(data.get('content'), content, 'has expected content');
+  });
+});
+
+fromJSONTests.forEach(function([name, input, content]) {
+  test(`fromJSONString: ${name}`, function(assert) {
+    let inputString = JSON.stringify(input, null, 2);
+    let data = KVObject.create({ content: [] }).fromJSONString(inputString);
+    assert.deepEqual(data.get('content'), content, 'has expected content');
+  });
+});
+
+let toJSONTests = [
+  [
+    'types',
+    false,
+    { string: 'string', false: false, zero: 0, number: 1, null: null, true: true, object: { one: 'two' } },
+    { false: false, null: null, number: 1, object: { one: 'two' }, string: 'string', true: true, zero: 0 },
+  ],
+  ['include blanks = true', true, { string: 'string', '': '' }, { string: 'string', '': '' }],
+  ['include blanks = false', false, { string: 'string', '': '' }, { string: 'string' }],
+];
+
+toJSONTests.forEach(function([name, includeBlanks, input, output]) {
+  test(`toJSON: ${name}`, function(assert) {
+    let data = KVObject.create({ content: [] }).fromJSON(input);
+    let result = data.toJSON(includeBlanks);
+    assert.deepEqual(result, output, 'has expected output');
+  });
+});
+
+toJSONTests.forEach(function([name, includeBlanks, input, output]) {
+  test(`toJSONString: ${name}`, function(assert) {
+    let expected = JSON.stringify(output, null, 2);
+    let data = KVObject.create({ content: [] }).fromJSON(input);
+    let result = data.toJSONString(includeBlanks);
+    assert.deepEqual(result, expected, 'has expected output string');
+  });
+});
+
+let isAdvancedTests = [
+  [
+    'advanced',
+    { string: 'string', false: false, zero: 0, number: 1, null: null, true: true, object: { one: 'two' } },
+    true,
+  ],
+  ['string-only', { string: 'string', one: 'two' }, false],
+];
+
+isAdvancedTests.forEach(function([name, input, expected]) {
+  test(`isAdvanced: ${name}`, function(assert) {
+    let data = KVObject.create({ content: [] }).fromJSON(input);
+
+    assert.equal(data.isAdvanced(), expected, 'calculates isAdvanced correctly');
+  });
+});

--- a/ui/tests/unit/lib/kv-object-test.js
+++ b/ui/tests/unit/lib/kv-object-test.js
@@ -69,7 +69,7 @@ toJSONTests.forEach(function([name, includeBlanks, input, output]) {
     let expected = JSON.stringify(output, null, 2);
     let data = KVObject.create({ content: [] }).fromJSON(input);
     let result = data.toJSONString(includeBlanks);
-    assert.deepEqual(result, expected, 'has expected output string');
+    assert.equal(result, expected, 'has expected output string');
   });
 });
 


### PR DESCRIPTION
Currently on master, if you 

1) have an "advanced" (anything with non-string values) data structure for the kv backend
2) any of those values are 0, false, or null,
3) enter edit mode in the UI

You'll see that your false-y values get coerced to empty strings. This PR changes the kv object array proxy to check for existence of the value instead of checking its false-y-ness.

