### PR TITLE
Fix for writing config attribute 'max_retries' for aws auth method

### DIFF
--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -235,6 +235,7 @@ func (b *backend) pathConfigClientCreateUpdate(ctx context.Context, req *logical
 	maxRetriesInt, ok := data.GetOk("max_retries")
 	if ok {
 		configEntry.MaxRetries = maxRetriesInt.(int)
+		changedOtherConfig = true
 	} else if req.Operation == logical.CreateOperation {
 		configEntry.MaxRetries = data.Get("max_retries").(int)
 	}


### PR DESCRIPTION
After a client config is created for the AWS auth method, we can't change `max_retries` without first deleting the client config. Because, for existing configs `max_retries` the config is not pushed to backend storage:

```
$ vault write auth/team7/aws/k8s/node/config/client max_retries=20
Success! Data written to: auth/team7/aws/k8s/node/config/client
$ vault read auth/team7/aws/k8s/node/config/client
Key                           Value
---                           -----
access_key                    n/a
endpoint                      n/a
iam_endpoint                  n/a
iam_server_id_header_value    n/a
max_retries                   10
sts_endpoint                  n/a
```

Please merge this fix so we can delete our workaround.