### PR TITLE
Add support for "sovereign" Azure cloud environments

### DIFF
--- a/physical/azure/azure.go
+++ b/physical/azure/azure.go
@@ -67,21 +67,21 @@ func NewAzureBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		}
 	}
 
-	cloudEnvironmentName := os.Getenv("AZURE_ENVIRONMENT")
-	if cloudEnvironmentName == "" {
-		cloudEnvironmentName = conf["cloudEnvironment"]
-		if cloudEnvironmentName == "" {
-			cloudEnvironmentName = "AzurePublicCloud"
+	environmentName := os.Getenv("AZURE_ENVIRONMENT")
+	if environmentName == "" {
+		environmentName = conf["environment"]
+		if environmentName == "" {
+			environmentName = "AzurePublicCloud"
 		}
 	}
-	cloudEnvironment, err := azure.EnvironmentFromName(cloudEnvironmentName)
+	environment, err := azure.EnvironmentFromName(environmentName)
 	if err != nil {
 		errorMsg := fmt.Sprintf("failed to look up Azure environment descriptor for name %q: {{err}}",
-			cloudEnvironmentName)
+			environmentName)
 		return nil, errwrap.Wrapf(errorMsg, err)
 	}
 
-	client, err := storage.NewBasicClientOnSovereignCloud(accountName, accountKey, cloudEnvironment)
+	client, err := storage.NewBasicClientOnSovereignCloud(accountName, accountKey, environment)
 	if err != nil {
 		return nil, errwrap.Wrapf("failed to create Azure client: {{err}}", err)
 	}

--- a/physical/azure/azure.go
+++ b/physical/azure/azure.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	storage "github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
@@ -66,7 +67,21 @@ func NewAzureBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		}
 	}
 
-	client, err := storage.NewBasicClient(accountName, accountKey)
+	cloudEnvironmentName := os.Getenv("AZURE_ENVIRONMENT")
+	if cloudEnvironmentName == "" {
+		cloudEnvironmentName = conf["cloudEnvironment"]
+		if cloudEnvironmentName == "" {
+			cloudEnvironmentName = "AzurePublicCloud"
+		}
+	}
+	cloudEnvironment, err := azure.EnvironmentFromName(cloudEnvironmentName)
+	if err != nil {
+		errorMsg := fmt.Sprintf("failed to look up Azure environment descriptor for name %q: {{err}}",
+			cloudEnvironmentName)
+		return nil, errwrap.Wrapf(errorMsg, err)
+	}
+
+	client, err := storage.NewBasicClientOnSovereignCloud(accountName, accountKey, cloudEnvironment)
 	if err != nil {
 		return nil, errwrap.Wrapf("failed to create Azure client: {{err}}", err)
 	}

--- a/physical/azure/azure_test.go
+++ b/physical/azure/azure_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/vault/physical"
 )
 
-func cloudEnvironmentForCleanupClient(name string) (azure.Environment, error) {
+func environmentForCleanupClient(name string) (azure.Environment, error) {
 	if name == "" {
 		return azure.EnvironmentFromName("AzurePublicCloud")
 	}
@@ -31,25 +31,25 @@ func TestAzureBackend(t *testing.T) {
 
 	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
 	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
-	cloudEnvironmentName := os.Getenv("AZURE_ENVIRONMENT")
+	environmentName := os.Getenv("AZURE_ENVIRONMENT")
 
 	ts := time.Now().UnixNano()
 	name := fmt.Sprintf("vault-test-%d", ts)
 
-	cleanupCloudEnvironment, err := cloudEnvironmentForCleanupClient(cloudEnvironmentName)
+	cleanupEnvironment, err := environmentForCleanupClient(environmentName)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	cleanupClient, _ := storage.NewBasicClientOnSovereignCloud(accountName, accountKey, cleanupCloudEnvironment)
+	cleanupClient, _ := storage.NewBasicClientOnSovereignCloud(accountName, accountKey, cleanupEnvironment)
 	cleanupClient.HTTPClient = cleanhttp.DefaultPooledClient()
 
 	logger := logging.NewVaultLogger(log.Debug)
 
 	backend, err := NewAzureBackend(map[string]string{
-		"container":        name,
-		"accountName":      accountName,
-		"accountKey":       accountKey,
-		"cloudEnvironment": cloudEnvironmentName,
+		"container":   name,
+		"accountName": accountName,
+		"accountKey":  accountKey,
+		"environment": environmentName,
 	}, logger)
 
 	defer func() {
@@ -74,25 +74,25 @@ func TestAzureBackend_ListPaging(t *testing.T) {
 
 	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
 	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
-	cloudEnvironmentName := os.Getenv("AZURE_ENVIRONMENT")
+	environmentName := os.Getenv("AZURE_ENVIRONMENT")
 
 	ts := time.Now().UnixNano()
 	name := fmt.Sprintf("vault-test-%d", ts)
 
-	cleanupCloudEnvironment, err := cloudEnvironmentForCleanupClient(cloudEnvironmentName)
+	cleanupEnvironment, err := environmentForCleanupClient(environmentName)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	cleanupClient, _ := storage.NewBasicClientOnSovereignCloud(accountName, accountKey, cleanupCloudEnvironment)
+	cleanupClient, _ := storage.NewBasicClientOnSovereignCloud(accountName, accountKey, cleanupEnvironment)
 	cleanupClient.HTTPClient = cleanhttp.DefaultPooledClient()
 
 	logger := logging.NewVaultLogger(log.Debug)
 
 	backend, err := NewAzureBackend(map[string]string{
-		"container":        name,
-		"accountName":      accountName,
-		"accountKey":       accountKey,
-		"cloudEnvironment": cloudEnvironmentName,
+		"container":   name,
+		"accountName": accountName,
+		"accountKey":  accountKey,
+		"environment": environmentName,
 	}, logger)
 
 	defer func() {

--- a/website/source/docs/configuration/storage/azure.html.md
+++ b/website/source/docs/configuration/storage/azure.html.md
@@ -28,6 +28,7 @@ storage "azure" {
   accountName = "my-storage-account"
   accountKey  = "abcd1234"
   container   = "container-efgh5678"
+  cloudEnvironment = "AzurePublicCloud"
 }
 ```
 
@@ -42,6 +43,10 @@ The current implementation is limited to a maximum of 4 megabytes per blob.
 
 - `container` `(string: <required>)` – Specifies the Azure Storage Blob
   container name.
+
+- `cloudEnvironment` `(string: "AzurePublicCloud")` - Specifies the cloud
+   environment the storage account belongs to by way of the case-insensitive
+   name defined in the [Azure Go SDK][azure-environment].
 
 - `max_parallel` `(string: "128")` – Specifies The maximum number of concurrent
   requests to Azure.
@@ -61,3 +66,4 @@ storage "azure" {
 ```
 
 [azure-storage]: https://azure.microsoft.com/en-us/services/storage/
+[azure-environment]: https://godoc.org/github.com/Azure/go-autorest/autorest/azure#pkg-variables

--- a/website/source/docs/configuration/storage/azure.html.md
+++ b/website/source/docs/configuration/storage/azure.html.md
@@ -28,7 +28,7 @@ storage "azure" {
   accountName = "my-storage-account"
   accountKey  = "abcd1234"
   container   = "container-efgh5678"
-  cloudEnvironment = "AzurePublicCloud"
+  environment = "AzurePublicCloud"
 }
 ```
 
@@ -44,7 +44,7 @@ The current implementation is limited to a maximum of 4 megabytes per blob.
 - `container` `(string: <required>)` – Specifies the Azure Storage Blob
   container name.
 
-- `cloudEnvironment` `(string: "AzurePublicCloud")` - Specifies the cloud
+- `environment` `(string: "AzurePublicCloud")` - Specifies the cloud
    environment the storage account belongs to by way of the case-insensitive
    name defined in the [Azure Go SDK][azure-environment].
 


### PR DESCRIPTION
The implementation of the Azure physical storage backend in vault 0.10.4 creates the storage client by means of the Azure storage SDK's function `NewBasicClient(accountName, accountKey)`. This function unconditionally assumes the storage account belongs to the Azure "public" cloud. It therefore is not possible to make vault 0.10.4 use a blob storage created in one of the "sovereign" Azure clouds (like Azure Germany) as its backend.

This PR adds the parameter `cloudEnvironment` to the configuration of the Azure physical storage backend.  It also obtains the Azure storage client by calling `NewBasicClientOnSovereignCloud(accountName, accountKey, cloudEnvironment)`. Since the config parameter `cloudEnvironment` defaults to `"AzurePublicCloud"`, the change is backwards compatible. Users of one of the sovereign cloud environments have now the option to specify a storage account in their respective environment, though.