### PR TITLE
[Do Not Merge] Add VAULT_BEARER_TOKEN env var and set it as an Authorization header

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -38,6 +38,7 @@ const EnvVaultMaxRetries = "VAULT_MAX_RETRIES"
 const EnvVaultToken = "VAULT_TOKEN"
 const EnvVaultMFA = "VAULT_MFA"
 const EnvRateLimit = "VAULT_RATE_LIMIT"
+const EnvVaultBearerToken = "VAULT_BEARER_TOKEN"
 
 // WrappingLookupFunc is a function that, given an HTTP verb and a path,
 // returns an optional string duration to be used for response wrapping (e.g.
@@ -377,6 +378,14 @@ func NewClient(c *Config) (*Client, error) {
 
 	if token := os.Getenv(EnvVaultToken); token != "" {
 		client.token = token
+	}
+
+	if v := os.Getenv(EnvVaultBearerToken); v != "" {
+		if client.headers == nil {
+			client.headers = make(http.Header)
+		}
+		header := "Bearer " + v
+		client.headers.Set("Authorization", header)
 	}
 
 	return client, nil


### PR DESCRIPTION
Resolves issue #4982 

Happy to refactor/abandon/tweak, but this worked for me locally.

Very useful if you want to put vault behind https://cloud.google.com/iap/ and use the CLI with bearer tokens to prove identity to the load balancer.