### PR TITLE
agent: kubernetes: add missing slash in token path

### DIFF
--- a/command/agent/auth/kubernetes/kubernetes.go
+++ b/command/agent/auth/kubernetes/kubernetes.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	serviceAccountFile = "var/run/secrets/kubernetes.io/serviceaccount/token"
+	serviceAccountFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 type kubernetesMethod struct {


### PR DESCRIPTION
When running the agent with the kubernetes method, it fails to load the service account token:

Example"
```
2018-07-29 19:15:37.627608 I | open var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory
```
This adds a leading slash to the path to ensure the token is loaded properly