### PR TITLE
Plumbing request context through to expiration manager

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -189,7 +189,7 @@ func (c *Core) disableCredential(ctx context.Context, path string) error {
 
 	if backend != nil {
 		// Revoke credentials from this path
-		if err := c.expiration.RevokePrefix(fullPath, true); err != nil {
+		if err := c.expiration.RevokePrefix(ctx, fullPath, true); err != nil {
 			return err
 		}
 

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -189,7 +189,7 @@ func (c *Core) disableCredential(ctx context.Context, path string) error {
 
 	if backend != nil {
 		// Revoke credentials from this path
-		if err := c.expiration.RevokePrefix(ctx, fullPath, true); err != nil {
+		if err := c.expiration.RevokePrefix(c.activeContext, fullPath, true); err != nil {
 			return err
 		}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -1080,7 +1080,7 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 		// we won't have a token store after sealing.
 		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
 		if err == nil {
-			err = c.expiration.Revoke(ctx, leaseID)
+			err = c.expiration.Revoke(c.activeContext, leaseID)
 		}
 		if err != nil {
 			c.logger.Error("token needed revocation before seal but failed to revoke", "error", err)

--- a/vault/core.go
+++ b/vault/core.go
@@ -1078,7 +1078,7 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 	if te != nil && te.NumUses == tokenRevocationPending {
 		// Token needs to be revoked. We do this immediately here because
 		// we won't have a token store after sealing.
-		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(te)
+		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
 		if err == nil {
 			err = c.expiration.Revoke(ctx, leaseID)
 		}

--- a/vault/core.go
+++ b/vault/core.go
@@ -1078,7 +1078,7 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 	if te != nil && te.NumUses == tokenRevocationPending {
 		// Token needs to be revoked. We do this immediately here because
 		// we won't have a token store after sealing.
-		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
+		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(c.activeContext, te)
 		if err == nil {
 			err = c.expiration.Revoke(c.activeContext, leaseID)
 		}

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -490,9 +490,6 @@ func (m *ExpirationManager) Stop() error {
 func (m *ExpirationManager) Revoke(ctx context.Context, leaseID string) error {
 	defer metrics.MeasureSince([]string{"expire", "revoke"}, time.Now())
 
-	// Setting context to the running active context
-	ctx = m.quitContext
-
 	return m.revokeCommon(ctx, leaseID, false, false)
 }
 
@@ -589,9 +586,6 @@ func (m *ExpirationManager) revokeCommon(ctx context.Context, leaseID string, fo
 func (m *ExpirationManager) RevokeForce(ctx context.Context, prefix string) error {
 	defer metrics.MeasureSince([]string{"expire", "revoke-force"}, time.Now())
 
-	// Setting context to the running active context
-	ctx = m.quitContext
-
 	return m.revokePrefixCommon(ctx, prefix, true, true)
 }
 
@@ -600,9 +594,6 @@ func (m *ExpirationManager) RevokeForce(ctx context.Context, prefix string) erro
 // to reason about.
 func (m *ExpirationManager) RevokePrefix(ctx context.Context, prefix string, sync bool) error {
 	defer metrics.MeasureSince([]string{"expire", "revoke-prefix"}, time.Now())
-
-	// Setting context to the running active context
-	ctx = m.quitContext
 
 	return m.revokePrefixCommon(ctx, prefix, false, sync)
 }
@@ -613,9 +604,6 @@ func (m *ExpirationManager) RevokePrefix(ctx context.Context, prefix string, syn
 // token store's revokeSalted function.
 func (m *ExpirationManager) RevokeByToken(ctx context.Context, te *logical.TokenEntry) error {
 	defer metrics.MeasureSince([]string{"expire", "revoke-by-token"}, time.Now())
-
-	// Setting context to the running active context
-	ctx = m.quitContext
 
 	// Lookup the leases
 	existing, err := m.lookupLeasesByToken(ctx, te.ID)

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -502,9 +502,6 @@ func (m *ExpirationManager) Revoke(ctx context.Context, leaseID string) error {
 func (m *ExpirationManager) LazyRevoke(ctx context.Context, leaseID string) error {
 	defer metrics.MeasureSince([]string{"expire", "lazy-revoke"}, time.Now())
 
-	// Setting context to the running active context
-	ctx = m.quitContext
-
 	// Load the entry
 	le, err := m.loadEntry(ctx, leaseID)
 	if err != nil {

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -900,7 +900,7 @@ func (m *ExpirationManager) Register(ctx context.Context, req *logical.Request, 
 		// want to revoke a generated secret (since an error means we may not
 		// be successfully tracking it), remove indexes, and delete the entry.
 		if retErr != nil {
-			revResp, err := m.router.Route(ctx, logical.RevokeRequest(req.Path, resp.Secret, resp.Data))
+			revResp, err := m.router.Route(m.quitContext, logical.RevokeRequest(req.Path, resp.Secret, resp.Data))
 			if err != nil {
 				retErr = multierror.Append(retErr, errwrap.Wrapf("an additional internal error was encountered revoking the newly-generated secret: {{err}}", err))
 			} else if revResp != nil && revResp.IsError() {
@@ -1143,7 +1143,7 @@ func (m *ExpirationManager) revokeEntry(ctx context.Context, le *leaseEntry) err
 	}
 
 	// Handle standard revocation via backends
-	resp, err := m.router.Route(ctx, logical.RevokeRequest(le.Path, le.Secret, le.Data))
+	resp, err := m.router.Route(m.quitContext, logical.RevokeRequest(le.Path, le.Secret, le.Data))
 	if err != nil || (resp != nil && resp.IsError()) {
 		return errwrap.Wrapf(fmt.Sprintf("failed to revoke entry: resp: %#v err: {{err}}", resp), err)
 	}

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -79,7 +79,7 @@ func TestExpiration_Tidy(t *testing.T) {
 	}
 
 	// Persist the invalid lease entry
-	if err = exp.persistEntry(le); err != nil {
+	if err = exp.persistEntry(context.Background(), le); err != nil {
 		t.Fatalf("error persisting entry: %v", err)
 	}
 
@@ -114,7 +114,7 @@ func TestExpiration_Tidy(t *testing.T) {
 	le.ClientToken = "invalidtoken"
 
 	// Persist the invalid lease entry
-	if err = exp.persistEntry(le); err != nil {
+	if err = exp.persistEntry(context.Background(), le); err != nil {
 		t.Fatalf("error persisting entry: %v", err)
 	}
 
@@ -146,12 +146,12 @@ func TestExpiration_Tidy(t *testing.T) {
 	}
 
 	// Attach an invalid token with 2 leases
-	if err = exp.persistEntry(le); err != nil {
+	if err = exp.persistEntry(context.Background(), le); err != nil {
 		t.Fatalf("error persisting entry: %v", err)
 	}
 
 	le.LeaseID = "another/invalid/lease"
-	if err = exp.persistEntry(le); err != nil {
+	if err = exp.persistEntry(context.Background(), le); err != nil {
 		t.Fatalf("error persisting entry: %v", err)
 	}
 
@@ -187,7 +187,7 @@ func TestExpiration_Tidy(t *testing.T) {
 				"test_key": "test_value",
 			},
 		}
-		_, err := exp.Register(req, resp)
+		_, err := exp.Register(context.Background(), req, resp)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -240,7 +240,7 @@ func TestExpiration_Tidy(t *testing.T) {
 	le.ClientToken = root.ID
 
 	// Attach a valid token with the leases
-	if err = exp.persistEntry(le); err != nil {
+	if err = exp.persistEntry(context.Background(), le); err != nil {
 		t.Fatalf("error persisting entry: %v", err)
 	}
 
@@ -345,7 +345,7 @@ func benchmarkExpirationBackend(b *testing.B, physicalBackend physical.Backend, 
 				"secret_key": "abcd",
 			},
 		}
-		_, err = exp.Register(req, resp)
+		_, err = exp.Register(context.Background(), req, resp)
 		if err != nil {
 			b.Fatalf("err: %v", err)
 		}
@@ -404,7 +404,7 @@ func TestExpiration_Restore(t *testing.T) {
 				"secret_key": "abcd",
 			},
 		}
-		_, err := exp.Register(req, resp)
+		_, err := exp.Register(context.Background(), req, resp)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -461,7 +461,7 @@ func TestExpiration_Register(t *testing.T) {
 		},
 	}
 
-	id, err := exp.Register(req, resp)
+	id, err := exp.Register(context.Background(), req, resp)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -489,12 +489,12 @@ func TestExpiration_RegisterAuth(t *testing.T) {
 		},
 	}
 
-	err = exp.RegisterAuth("auth/github/login", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/github/login", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = exp.RegisterAuth("auth/github/../login", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/github/../login", auth)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -511,13 +511,13 @@ func TestExpiration_RegisterAuth_NoLease(t *testing.T) {
 		ClientToken: root.ID,
 	}
 
-	err = exp.RegisterAuth("auth/github/login", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/github/login", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Should not be able to renew, no expiration
-	resp, err := exp.RenewToken(&logical.Request{}, "auth/github/login", root.ID, 0)
+	resp, err := exp.RenewToken(context.Background(), &logical.Request{}, "auth/github/login", root.ID, 0)
 	if err != nil && (err != logical.ErrInvalidRequest || (resp != nil && resp.IsError() && resp.Error().Error() != "lease not found or lease is not renewable")) {
 		t.Fatalf("bad: err:%v resp:%#v", err, resp)
 	}
@@ -569,7 +569,7 @@ func TestExpiration_Revoke(t *testing.T) {
 		},
 	}
 
-	id, err := exp.Register(req, resp)
+	id, err := exp.Register(context.Background(), req, resp)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -615,7 +615,7 @@ func TestExpiration_RevokeOnExpire(t *testing.T) {
 		},
 	}
 
-	_, err = exp.Register(req, resp)
+	_, err = exp.Register(context.Background(), req, resp)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -677,14 +677,14 @@ func TestExpiration_RevokePrefix(t *testing.T) {
 				"secret_key": "abcd",
 			},
 		}
-		_, err := exp.Register(req, resp)
+		_, err := exp.Register(context.Background(), req, resp)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	}
 
 	// Should nuke all the keys
-	if err := exp.RevokePrefix("prod/aws/", true); err != nil {
+	if err := exp.RevokePrefix(context.Background(), "prod/aws/", true); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -745,7 +745,7 @@ func TestExpiration_RevokeByToken(t *testing.T) {
 				"secret_key": "abcd",
 			},
 		}
-		_, err := exp.Register(req, resp)
+		_, err := exp.Register(context.Background(), req, resp)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -755,7 +755,7 @@ func TestExpiration_RevokeByToken(t *testing.T) {
 	te := &logical.TokenEntry{
 		ID: "foobarbaz",
 	}
-	if err := exp.RevokeByToken(te); err != nil {
+	if err := exp.RevokeByToken(context.Background(), te); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -832,7 +832,7 @@ func TestExpiration_RevokeByToken_Blocking(t *testing.T) {
 				"secret_key": "abcd",
 			},
 		}
-		_, err := exp.Register(req, resp)
+		_, err := exp.Register(context.Background(), req, resp)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -842,7 +842,7 @@ func TestExpiration_RevokeByToken_Blocking(t *testing.T) {
 	te := &logical.TokenEntry{
 		ID: "foobarbaz",
 	}
-	if err := exp.RevokeByToken(te); err != nil {
+	if err := exp.RevokeByToken(context.Background(), te); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -897,13 +897,13 @@ func TestExpiration_RenewToken(t *testing.T) {
 			Renewable: true,
 		},
 	}
-	err = exp.RegisterAuth("auth/token/login", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/token/login", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Renew the token
-	out, err := exp.RenewToken(&logical.Request{}, "auth/token/login", root.ID, 0)
+	out, err := exp.RenewToken(context.Background(), &logical.Request{}, "auth/token/login", root.ID, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -935,13 +935,13 @@ func TestExpiration_RenewToken_period(t *testing.T) {
 		},
 		Period: time.Minute,
 	}
-	err := exp.RegisterAuth("auth/token/login", auth)
+	err := exp.RegisterAuth(context.Background(), "auth/token/login", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Renew the token
-	out, err := exp.RenewToken(&logical.Request{}, "auth/token/login", root.ID, 0)
+	out, err := exp.RenewToken(context.Background(), &logical.Request{}, "auth/token/login", root.ID, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -998,14 +998,14 @@ func TestExpiration_RenewToken_period_backend(t *testing.T) {
 		Period: 5 * time.Second,
 	}
 
-	err = exp.RegisterAuth("auth/foo/login", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/foo/login", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Wait 3 seconds
 	time.Sleep(3 * time.Second)
-	resp, err := exp.RenewToken(&logical.Request{}, "auth/foo/login", root.ID, 0)
+	resp, err := exp.RenewToken(context.Background(), &logical.Request{}, "auth/foo/login", root.ID, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1018,7 +1018,7 @@ func TestExpiration_RenewToken_period_backend(t *testing.T) {
 
 	// Wait another 3 seconds. If period works correctly, this should not fail
 	time.Sleep(3 * time.Second)
-	resp, err = exp.RenewToken(&logical.Request{}, "auth/foo/login", root.ID, 0)
+	resp, err = exp.RenewToken(context.Background(), &logical.Request{}, "auth/foo/login", root.ID, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1045,13 +1045,13 @@ func TestExpiration_RenewToken_NotRenewable(t *testing.T) {
 			Renewable: false,
 		},
 	}
-	err = exp.RegisterAuth("auth/github/login", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/github/login", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Attempt to renew the token
-	resp, err := exp.RenewToken(&logical.Request{}, "auth/github/login", root.ID, 0)
+	resp, err := exp.RenewToken(context.Background(), &logical.Request{}, "auth/github/login", root.ID, 0)
 	if err != nil && (err != logical.ErrInvalidRequest || (resp != nil && resp.IsError() && resp.Error().Error() != "lease is not renewable")) {
 		t.Fatalf("bad: err:%v resp:%#v", err, resp)
 	}
@@ -1093,7 +1093,7 @@ func TestExpiration_Renew(t *testing.T) {
 		},
 	}
 
-	id, err := exp.Register(req, resp)
+	id, err := exp.Register(context.Background(), req, resp)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1110,7 +1110,7 @@ func TestExpiration_Renew(t *testing.T) {
 		},
 	}
 
-	out, err := exp.Renew(id, 0)
+	out, err := exp.Renew(context.Background(), id, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1163,12 +1163,12 @@ func TestExpiration_Renew_NotRenewable(t *testing.T) {
 		},
 	}
 
-	id, err := exp.Register(req, resp)
+	id, err := exp.Register(context.Background(), req, resp)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	_, err = exp.Renew(id, 0)
+	_, err = exp.Renew(context.Background(), id, 0)
 	if err.Error() != "lease is not renewable" {
 		t.Fatalf("err: %v", err)
 	}
@@ -1213,7 +1213,7 @@ func TestExpiration_Renew_RevokeOnExpire(t *testing.T) {
 		},
 	}
 
-	id, err := exp.Register(req, resp)
+	id, err := exp.Register(context.Background(), req, resp)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1230,7 +1230,7 @@ func TestExpiration_Renew_RevokeOnExpire(t *testing.T) {
 		},
 	}
 
-	_, err = exp.Renew(id, 0)
+	_, err = exp.Renew(context.Background(), id, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1337,7 +1337,7 @@ func TestExpiration_revokeEntry_token(t *testing.T) {
 		ExpireTime:  time.Now(),
 	}
 
-	if err := exp.persistEntry(le); err != nil {
+	if err := exp.persistEntry(context.Background(), le); err != nil {
 		t.Fatalf("error persisting entry: %v", err)
 	}
 	if err := exp.createIndexByToken(le.ClientToken, le.LeaseID); err != nil {
@@ -1484,12 +1484,12 @@ func TestExpiration_revokeEntry_rejected(t *testing.T) {
 		ExpireTime: time.Now().Add(time.Minute),
 	}
 
-	err = exp.persistEntry(le)
+	err = exp.persistEntry(context.Background(), le)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = exp.LazyRevoke(le.LeaseID)
+	err = exp.LazyRevoke(context.Background(), le.LeaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1522,7 +1522,7 @@ func TestExpiration_revokeEntry_rejected(t *testing.T) {
 	// Now let the revocation actually process
 	time.Sleep(1 * time.Second)
 
-	le, err = exp.FetchLeaseTimes(le.LeaseID)
+	le, err = exp.FetchLeaseTimes(context.Background(), le.LeaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1613,11 +1613,11 @@ func TestExpiration_PersistLoadDelete(t *testing.T) {
 		ExpireTime:      lastTime,
 		LastRenewalTime: lastTime,
 	}
-	if err := exp.persistEntry(le); err != nil {
+	if err := exp.persistEntry(context.Background(), le); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	out, err := exp.loadEntry("foo/bar/1234")
+	out, err := exp.loadEntry(context.Background(), "foo/bar/1234")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1633,12 +1633,12 @@ func TestExpiration_PersistLoadDelete(t *testing.T) {
 		t.Fatalf("bad: expected:\n%#v\nactual:\n%#v", le, out)
 	}
 
-	err = exp.deleteEntry("foo/bar/1234")
+	err = exp.deleteEntry(context.Background(), "foo/bar/1234")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	out, err = exp.loadEntry("foo/bar/1234")
+	out, err = exp.loadEntry(context.Background(), "foo/bar/1234")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -1286,7 +1286,7 @@ func TestExpiration_revokeEntry(t *testing.T) {
 		ExpireTime: time.Now(),
 	}
 
-	err = exp.revokeEntry(le)
+	err = exp.revokeEntry(context.Background(), le)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1340,12 +1340,12 @@ func TestExpiration_revokeEntry_token(t *testing.T) {
 	if err := exp.persistEntry(context.Background(), le); err != nil {
 		t.Fatalf("error persisting entry: %v", err)
 	}
-	if err := exp.createIndexByToken(le.ClientToken, le.LeaseID); err != nil {
+	if err := exp.createIndexByToken(context.Background(), le.ClientToken, le.LeaseID); err != nil {
 		t.Fatalf("error creating secondary index: %v", err)
 	}
 	exp.updatePending(le, le.Secret.LeaseTotal())
 
-	indexEntry, err := exp.indexByToken(le.ClientToken, le.LeaseID)
+	indexEntry, err := exp.indexByToken(context.Background(), le.ClientToken, le.LeaseID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1353,7 +1353,7 @@ func TestExpiration_revokeEntry_token(t *testing.T) {
 		t.Fatalf("err: should have found a secondary index entry")
 	}
 
-	err = exp.revokeEntry(le)
+	err = exp.revokeEntry(context.Background(), le)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1368,7 +1368,7 @@ func TestExpiration_revokeEntry_token(t *testing.T) {
 		t.Fatalf("bad: %v", out)
 	}
 
-	indexEntry, err = exp.indexByToken(le.ClientToken, le.LeaseID)
+	indexEntry, err = exp.indexByToken(context.Background(), le.ClientToken, le.LeaseID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1419,7 +1419,7 @@ func TestExpiration_renewEntry(t *testing.T) {
 		ExpireTime: time.Now(),
 	}
 
-	resp, err := exp.renewEntry(le, 0)
+	resp, err := exp.renewEntry(context.Background(), le, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1571,7 +1571,7 @@ func TestExpiration_renewAuthEntry(t *testing.T) {
 		ExpireTime: time.Now().Add(time.Minute),
 	}
 
-	resp, err := exp.renewAuthEntry(&logical.Request{}, le, 0)
+	resp, err := exp.renewAuthEntry(context.Background(), &logical.Request{}, le, 0)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -247,7 +247,7 @@ func (c *Core) StepDown(httpCtx context.Context, req *logical.Request) (retErr e
 		// we won't have a token store after sealing.
 		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
 		if err == nil {
-			err = c.expiration.Revoke(ctx, leaseID)
+			err = c.expiration.Revoke(c.activeContext, leaseID)
 		}
 		if err != nil {
 			c.logger.Error("token needed revocation before step-down but failed to revoke", "error", err)

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -245,7 +245,7 @@ func (c *Core) StepDown(httpCtx context.Context, req *logical.Request) (retErr e
 	if te != nil && te.NumUses == tokenRevocationPending {
 		// Token needs to be revoked. We do this immediately here because
 		// we won't have a token store after sealing.
-		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(te)
+		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
 		if err == nil {
 			err = c.expiration.Revoke(ctx, leaseID)
 		}

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -245,7 +245,7 @@ func (c *Core) StepDown(httpCtx context.Context, req *logical.Request) (retErr e
 	if te != nil && te.NumUses == tokenRevocationPending {
 		// Token needs to be revoked. We do this immediately here because
 		// we won't have a token store after sealing.
-		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
+		leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(c.activeContext, te)
 		if err == nil {
 			err = c.expiration.Revoke(c.activeContext, leaseID)
 		}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2319,7 +2319,7 @@ func (b *SystemBackend) handleRevoke(ctx context.Context, req *logical.Request, 
 
 	if data.Get("sync").(bool) {
 		// Invoke the expiration manager directly
-		if err := b.Core.expiration.Revoke(ctx, leaseID); err != nil {
+		if err := b.Core.expiration.Revoke(b.Core.activeContext, leaseID); err != nil {
 			b.Backend.Logger().Error("lease revocation failed", "lease_id", leaseID, "error", err)
 			return handleErrorNoReadOnlyForward(err)
 		}
@@ -2327,7 +2327,7 @@ func (b *SystemBackend) handleRevoke(ctx context.Context, req *logical.Request, 
 		return nil, nil
 	}
 
-	if err := b.Core.expiration.LazyRevoke(ctx, leaseID); err != nil {
+	if err := b.Core.expiration.LazyRevoke(b.Core.activeContext, leaseID); err != nil {
 		b.Backend.Logger().Error("lease revocation failed", "lease_id", leaseID, "error", err)
 		return handleErrorNoReadOnlyForward(err)
 	}
@@ -2354,9 +2354,9 @@ func (b *SystemBackend) handleRevokePrefixCommon(ctx context.Context,
 	// Invoke the expiration manager directly
 	var err error
 	if force {
-		err = b.Core.expiration.RevokeForce(ctx, prefix)
+		err = b.Core.expiration.RevokeForce(b.Core.activeContext, prefix)
 	} else {
-		err = b.Core.expiration.RevokePrefix(ctx, prefix, sync)
+		err = b.Core.expiration.RevokePrefix(b.Core.activeContext, prefix, sync)
 	}
 	if err != nil {
 		b.Backend.Logger().Error("revoke prefix failed", "prefix", prefix, "error", err)

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -1305,7 +1305,7 @@ func TestSystemBackend_revokePrefixAuth_newUrl(t *testing.T) {
 			TTL: time.Hour,
 		},
 	}
-	err = exp.RegisterAuth(te.Path, auth)
+	err = exp.RegisterAuth(context.Background(), te.Path, auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1368,7 +1368,7 @@ func TestSystemBackend_revokePrefixAuth_origUrl(t *testing.T) {
 			TTL: time.Hour,
 		},
 	}
-	err = exp.RegisterAuth(te.Path, auth)
+	err = exp.RegisterAuth(context.Background(), te.Path, auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -408,7 +408,7 @@ func (c *Core) unmountInternal(ctx context.Context, path string) error {
 		}
 
 		// Revoke all the dynamic keys
-		if err := c.expiration.RevokePrefix(ctx, path, true); err != nil {
+		if err := c.expiration.RevokePrefix(c.activeContext, path, true); err != nil {
 			return err
 		}
 
@@ -555,7 +555,7 @@ func (c *Core) remount(ctx context.Context, src, dst string) error {
 	}
 
 	// Revoke all the dynamic keys
-	if err := c.expiration.RevokePrefix(ctx, src, true); err != nil {
+	if err := c.expiration.RevokePrefix(c.activeContext, src, true); err != nil {
 		return err
 	}
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -408,7 +408,7 @@ func (c *Core) unmountInternal(ctx context.Context, path string) error {
 		}
 
 		// Revoke all the dynamic keys
-		if err := c.expiration.RevokePrefix(path, true); err != nil {
+		if err := c.expiration.RevokePrefix(ctx, path, true); err != nil {
 			return err
 		}
 
@@ -555,7 +555,7 @@ func (c *Core) remount(ctx context.Context, src, dst string) error {
 	}
 
 	// Revoke all the dynamic keys
-	if err := c.expiration.RevokePrefix(src, true); err != nil {
+	if err := c.expiration.RevokePrefix(ctx, src, true); err != nil {
 		return err
 	}
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -445,7 +445,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 			// valid request (this is the token's final use). We pass the ID in
 			// directly just to be safe in case something else modifies te later.
 			defer func(id string) {
-				leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
+				leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(c.activeContext, te)
 				if err == nil {
 					err = c.expiration.LazyRevoke(ctx, leaseID)
 				}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -447,7 +447,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 			defer func(id string) {
 				leaseID, err := c.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
 				if err == nil {
-					err = c.expiration.Revoke(ctx, leaseID)
+					err = c.expiration.LazyRevoke(ctx, leaseID)
 				}
 				if err != nil {
 					c.logger.Error("failed to revoke token", "error", err)

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -656,7 +656,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 		}
 
 		resp.Auth.TokenPolicies = policyutil.SanitizePolicies(resp.Auth.Policies, policyutil.DoNotAddDefaultPolicy)
-		if err := c.expiration.RegisterAuth(context.Background(), resp.Auth.CreationPath, resp.Auth); err != nil {
+		if err := c.expiration.RegisterAuth(ctx, resp.Auth.CreationPath, resp.Auth); err != nil {
 			c.tokenStore.revokeOrphan(ctx, te.ID)
 			c.logger.Error("failed to register token lease", "request_path", req.Path, "error", err)
 			retErr = multierror.Append(retErr, ErrInternalError)
@@ -882,7 +882,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 		auth.TTL = te.TTL
 
 		// Register with the expiration manager
-		if err := c.expiration.RegisterAuth(context.Background(), te.Path, auth); err != nil {
+		if err := c.expiration.RegisterAuth(ctx, te.Path, auth); err != nil {
 			c.tokenStore.revokeOrphan(ctx, te.ID)
 			c.logger.Error("failed to register token lease", "request_path", req.Path, "error", err)
 			return nil, auth, ErrInternalError

--- a/vault/rollback_test.go
+++ b/vault/rollback_test.go
@@ -17,6 +17,7 @@ func mockRollback(t *testing.T) (*RollbackManager, *NoopBackend) {
 	backend := new(NoopBackend)
 	mounts := new(MountTable)
 	router := NewRouter()
+	core, _, _ := TestCoreUnsealed(t)
 
 	_, barrier, _ := mockBarrier(t)
 	view := NewBarrierView(barrier, "logical/")
@@ -40,7 +41,7 @@ func mockRollback(t *testing.T) (*RollbackManager, *NoopBackend) {
 
 	logger := logging.NewVaultLogger(log.Trace)
 
-	rb := NewRollbackManager(logger, mountsFunc, router, context.Background())
+	rb := NewRollbackManager(context.Background(), logger, mountsFunc, router, core)
 	rb.period = 10 * time.Millisecond
 	return rb, backend
 }

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1306,7 +1306,7 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 		defer atomic.StoreUint32(ts.tidyLock, 0)
 
 		// Don't cancel when the original client request goes away
-		ctx = context.Background()
+		ctx = ts.quitContext
 
 		logger := ts.logger.Named("tidy")
 

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -976,7 +976,7 @@ func (ts *TokenStore) lookupSalted(ctx context.Context, saltedID string, tainted
 	if ts.expiration == nil {
 		return nil, errors.New("expiration manager is nil on tokenstore")
 	}
-	le, err := ts.expiration.FetchLeaseTimesByToken(entry.Path, entry.ID)
+	le, err := ts.expiration.FetchLeaseTimesByToken(ctx, entry.Path, entry.ID)
 	if err != nil {
 		return nil, errwrap.Wrapf("failed to fetch lease times: {{err}}", err)
 	}
@@ -986,7 +986,7 @@ func (ts *TokenStore) lookupSalted(ctx context.Context, saltedID string, tainted
 	switch {
 	// It's any kind of expiring token with no lease, immediately delete it
 	case le == nil:
-		leaseID, err := ts.expiration.CreateOrFetchRevocationLeaseByToken(entry)
+		leaseID, err := ts.expiration.CreateOrFetchRevocationLeaseByToken(ctx, entry)
 		if err != nil {
 			return nil, err
 		}
@@ -1096,7 +1096,7 @@ func (ts *TokenStore) revokeSalted(ctx context.Context, saltedID string, skipOrp
 
 	// Revoke all secrets under this token. This should go first as it's a
 	// security-sensitive item.
-	if err := ts.expiration.RevokeByToken(entry); err != nil {
+	if err := ts.expiration.RevokeByToken(ctx, entry); err != nil {
 		return err
 	}
 
@@ -1468,7 +1468,7 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 
 					// Attempt to revoke the token. This will also revoke
 					// the leases associated with the token.
-					err := ts.expiration.RevokeByToken(tokenEntry)
+					err := ts.expiration.RevokeByToken(ctx, tokenEntry)
 					if err != nil {
 						tidyErrors = multierror.Append(tidyErrors, errwrap.Wrapf("failed to revoke leases of expired token: {{err}}", err))
 						continue
@@ -1594,7 +1594,7 @@ func (ts *TokenStore) handleUpdateRevokeAccessor(ctx context.Context, req *logic
 		return logical.ErrorResponse("token not found"), logical.ErrInvalidRequest
 	}
 
-	leaseID, err := ts.expiration.CreateOrFetchRevocationLeaseByToken(te)
+	leaseID, err := ts.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
 	if err != nil {
 		return nil, err
 	}
@@ -2049,7 +2049,7 @@ func (ts *TokenStore) handleRevokeSelf(ctx context.Context, req *logical.Request
 		return logical.ErrorResponse("token not found"), logical.ErrInvalidRequest
 	}
 
-	leaseID, err := ts.expiration.CreateOrFetchRevocationLeaseByToken(te)
+	leaseID, err := ts.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
 	if err != nil {
 		return nil, err
 	}
@@ -2085,7 +2085,7 @@ func (ts *TokenStore) handleRevokeTree(ctx context.Context, req *logical.Request
 		return logical.ErrorResponse("token not found"), logical.ErrInvalidRequest
 	}
 
-	leaseID, err := ts.expiration.CreateOrFetchRevocationLeaseByToken(te)
+	leaseID, err := ts.expiration.CreateOrFetchRevocationLeaseByToken(ctx, te)
 	if err != nil {
 		return nil, err
 	}
@@ -2228,7 +2228,7 @@ func (ts *TokenStore) handleLookup(ctx context.Context, req *logical.Request, da
 	}
 
 	// Fetch the last renewal time
-	leaseTimes, err := ts.expiration.FetchLeaseTimesByToken(out.Path, out.ID)
+	leaseTimes, err := ts.expiration.FetchLeaseTimesByToken(ctx, out.Path, out.ID)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
@@ -2297,7 +2297,7 @@ func (ts *TokenStore) handleRenew(ctx context.Context, req *logical.Request, dat
 	}
 
 	// Renew the token and its children
-	resp, err := ts.expiration.RenewToken(req, te.Path, te.ID, increment)
+	resp, err := ts.expiration.RenewToken(ctx, req, te.Path, te.ID, increment)
 
 	if urltoken {
 		resp.AddWarning(`Using a token in the path is unsafe as the token can be logged in many places. Please use POST or PUT with the token passed in via the "token" parameter.`)

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -86,7 +86,7 @@ func TestTokenStore_TokenEntryUpgrade(t *testing.T) {
 		},
 		ClientToken: entry.ID,
 	}
-	if err := ts.expiration.RegisterAuth(entry.Path, auth); err != nil {
+	if err := ts.expiration.RegisterAuth(context.Background(), entry.Path, auth); err != nil {
 		t.Fatal(err)
 	}
 
@@ -130,7 +130,7 @@ func TestTokenStore_TokenEntryUpgrade(t *testing.T) {
 		},
 		ClientToken: ent.ID,
 	}
-	if err := ts.expiration.RegisterAuth(ent.Path, auth); err != nil {
+	if err := ts.expiration.RegisterAuth(context.Background(), ent.Path, auth); err != nil {
 		t.Fatal(err)
 	}
 
@@ -174,7 +174,7 @@ func TestTokenStore_TokenEntryUpgrade(t *testing.T) {
 		},
 		ClientToken: ent.ID,
 	}
-	if err := ts.expiration.RegisterAuth(ent.Path, auth); err != nil {
+	if err := ts.expiration.RegisterAuth(context.Background(), ent.Path, auth); err != nil {
 		t.Fatal(err)
 	}
 
@@ -215,7 +215,7 @@ func TestTokenStore_TokenEntryUpgrade(t *testing.T) {
 		},
 		ClientToken: ent.ID,
 	}
-	if err := ts.expiration.RegisterAuth(ent.Path, auth); err != nil {
+	if err := ts.expiration.RegisterAuth(context.Background(), ent.Path, auth); err != nil {
 		t.Fatal(err)
 	}
 
@@ -248,7 +248,7 @@ func TestTokenStore_TokenEntryUpgrade(t *testing.T) {
 		},
 		ClientToken: ent.ID,
 	}
-	if err := ts.expiration.RegisterAuth(ent.Path, auth); err != nil {
+	if err := ts.expiration.RegisterAuth(context.Background(), ent.Path, auth); err != nil {
 		t.Fatal(err)
 	}
 
@@ -294,7 +294,7 @@ func testMakeTokenViaRequest(t testing.TB, ts *TokenStore, req *logical.Request)
 		t.Fatalf("got nil token from create call")
 	}
 
-	if err := ts.expiration.RegisterAuth(resp.Auth.CreationPath, resp.Auth); err != nil {
+	if err := ts.expiration.RegisterAuth(context.Background(), resp.Auth.CreationPath, resp.Auth); err != nil {
 		t.Fatal(err)
 	}
 
@@ -321,7 +321,7 @@ func testMakeTokenDirectly(t testing.TB, ts *TokenStore, te *logical.TokenEntry)
 		ExplicitMaxTTL: te.ExplicitMaxTTL,
 		CreationPath:   te.Path,
 	}
-	if err := ts.expiration.RegisterAuth(te.Path, auth); err != nil {
+	if err := ts.expiration.RegisterAuth(context.Background(), te.Path, auth); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -512,7 +512,7 @@ func TestTokenStore_HandleRequest_RevokeAccessor(t *testing.T) {
 			Renewable: true,
 		},
 	}
-	err = exp.RegisterAuth("auth/token/create", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/token/create", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -708,7 +708,7 @@ func TestTokenStore_CreateLookup_ExpirationInRestoreMode(t *testing.T) {
 		IssueTime:   time.Now(),
 		ExpireTime:  time.Now().Add(1 * time.Hour),
 	}
-	if err := ts.expiration.persistEntry(le); err != nil {
+	if err := ts.expiration.persistEntry(context.Background(), le); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -722,7 +722,7 @@ func TestTokenStore_CreateLookup_ExpirationInRestoreMode(t *testing.T) {
 
 	// Set to expired lease time
 	le.ExpireTime = time.Now().Add(-1 * time.Hour)
-	if err := ts.expiration.persistEntry(le); err != nil {
+	if err := ts.expiration.persistEntry(context.Background(), le); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -893,7 +893,7 @@ func TestTokenStore_Revoke_Leases(t *testing.T) {
 			"secret_key": "abcd",
 		},
 	}
-	leaseID, err := ts.expiration.Register(req, resp)
+	leaseID, err := ts.expiration.Register(context.Background(), req, resp)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -907,7 +907,7 @@ func TestTokenStore_Revoke_Leases(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Verify the lease is gone
-	out, err := ts.expiration.loadEntry(leaseID)
+	out, err := ts.expiration.loadEntry(context.Background(), leaseID)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1584,7 +1584,7 @@ func TestTokenStore_HandleRequest_Revoke(t *testing.T) {
 			Renewable: true,
 		},
 	}
-	err = exp.RegisterAuth("auth/token/create", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/token/create", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1598,7 +1598,7 @@ func TestTokenStore_HandleRequest_Revoke(t *testing.T) {
 			Renewable: true,
 		},
 	}
-	err = exp.RegisterAuth("auth/token/create", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/token/create", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2003,7 +2003,7 @@ func TestTokenStore_HandleRequest_Renew(t *testing.T) {
 			Renewable: true,
 		},
 	}
-	err = exp.RegisterAuth("auth/token/root", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/token/root", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -2052,7 +2052,7 @@ func TestTokenStore_HandleRequest_RenewSelf(t *testing.T) {
 			Renewable: true,
 		},
 	}
-	err = exp.RegisterAuth("auth/token/root", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/token/root", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3989,7 +3989,7 @@ func TestTokenStore_TidyLeaseRevocation(t *testing.T) {
 			Renewable: true,
 		},
 	}
-	err = exp.RegisterAuth("auth/token/create", auth)
+	err = exp.RegisterAuth(context.Background(), "auth/token/create", auth)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4011,7 +4011,7 @@ func TestTokenStore_TidyLeaseRevocation(t *testing.T) {
 	leases := []string{}
 
 	for i := 0; i < 10; i++ {
-		leaseID, err := exp.Register(req, resp)
+		leaseID, err := exp.Register(context.Background(), req, resp)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -4020,7 +4020,7 @@ func TestTokenStore_TidyLeaseRevocation(t *testing.T) {
 
 	sort.Strings(leases)
 
-	storedLeases, err := exp.lookupLeasesByToken(tut)
+	storedLeases, err := exp.lookupLeasesByToken(context.Background(), tut)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4056,7 +4056,7 @@ func TestTokenStore_TidyLeaseRevocation(t *testing.T) {
 	}
 
 	// Verify leases still exist
-	storedLeases, err = exp.lookupLeasesByToken(tut)
+	storedLeases, err = exp.lookupLeasesByToken(context.Background(), tut)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4071,7 +4071,7 @@ func TestTokenStore_TidyLeaseRevocation(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Verify leases are gone
-	storedLeases, err = exp.lookupLeasesByToken(tut)
+	storedLeases, err = exp.lookupLeasesByToken(context.Background(), tut)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -259,7 +259,7 @@ DONELISTHANDLING:
 	}
 
 	// Register the wrapped token with the expiration manager
-	if err := c.expiration.RegisterAuth(te.Path, wAuth); err != nil {
+	if err := c.expiration.RegisterAuth(ctx, te.Path, wAuth); err != nil {
 		// Revoke since it's not yet being tracked for expiration
 		c.tokenStore.revokeOrphan(ctx, te.ID)
 		c.logger.Error("failed to register cubbyhole wrapping token lease", "request_path", req.Path, "error", err)


### PR DESCRIPTION
Looking for feedback on where we should use the active context in expiration manager instead of the request context.  