### PR TITLE
correct Jenkins policy and mysql secret path when kv put in authentication guide

### DIFF
--- a/website/source/guides/identity/authentication.html.md
+++ b/website/source/guides/identity/authentication.html.md
@@ -210,9 +210,10 @@ path "auth/approle/login" {
 }
 
 # Read test data
-path "secret/mysql/*" {
+path "secret/data/mysql/*" {
   capabilities = [ "read" ]
 }
+
 ```
 
 #### CLI command
@@ -551,7 +552,7 @@ found" message.
 `secret/mysql/webapp` path.
 
 ```shell
-$ vault kv put secret/dev/config/mongodb @mysqldb.txt
+$ vault kv put secret/mysql/webapp @mysqldb.txt
 
 $ cat mysqldb.txt
 {

--- a/website/source/guides/identity/authentication.html.md
+++ b/website/source/guides/identity/authentication.html.md
@@ -118,6 +118,7 @@ path "sys/policy/*" {
 }
 
 # Write test data
+# Set the path to "secret/data/mysql/*" if you are running `kv-v2`
 path "secret/mysql/*" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
@@ -210,7 +211,8 @@ path "auth/approle/login" {
 }
 
 # Read test data
-path "secret/data/mysql/*" {
+# Set the path to "secret/data/mysql/*" if you are running `kv-v2`
+path "secret/mysql/*" {
   capabilities = [ "read" ]
 }
 


### PR DESCRIPTION
old jenkins policy:
```
# Login with AppRole
path "auth/approle/login" {
  capabilities = [ "create", "read" ]
}

# Read test data
path "secret/mysql/*" {
  capabilities = [ "read" ]
}
path "secret/mysql/*" {
  capabilities = [ "read" ]
}

```

result of `VAULT_TOKEN=d9b048f7-09ae-99d3-e8ee-87b41b4fa561 vault kv get secret/mysql/webapp`:
```
Error reading secret/data/mysql/webapp: Error making API request.

URL: GET http://127.0.0.1:8200/v1/secret/data/mysql/webapp
Code: 403. Errors:

* permission denied
```

updated jenkins policy:
```
# Login with AppRole
path "auth/approle/login" {
  capabilities = [ "create", "read" ]
}

# Read test data
path "secret/mysql/*" {
  capabilities = [ "read" ]
}
path "secret/data/mysql/*" {
  capabilities = [ "read" ]
}

```

result of `VAULT_TOKEN=d9b048f7-09ae-99d3-e8ee-87b41b4fa561 vault kv get secret/mysql/webapp`:
```
====== Metadata ======
Key              Value
---              -----
created_time     2018-08-01T09:10:49.98566701Z
deletion_time    n/a
destroyed        false
version          1

====== Data ======
Key         Value
---         -----
db_name     users
password    pa$$w0rd
url         foo.example.com:35533
username    admin
```