### PR TITLE
Typo fix

### DIFF
--- a/website/source/guides/identity/policies.html.md
+++ b/website/source/guides/identity/policies.html.md
@@ -594,4 +594,4 @@ requirements. Next, the [AppRole Pull Authentication](/guides/identity/authentic
 guide demonstrates how to associate policies to a role.
 
 To learn about Sentinel policies, refer to the [Sentinel
-Policies](/guides/identity/sentinel.html.md) guide.
+Policies](/guides/identity/sentinel.html) guide.


### PR DESCRIPTION
Removed ".md" from the hyper-link