### PR TITLE
add backtick to fix mysql  database name contain special  characters

### DIFF
--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -69,7 +69,7 @@ func NewMySQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 	if !ok {
 		table = "vault"
 	}
-	dbTable := database + "." + table
+	dbTable := "`" + database + "`" + "." + "`" + table + "`"
 
 	maxIdleConnStr, ok := conf["max_idle_connections"]
 	var maxIdleConnInt int
@@ -153,7 +153,7 @@ func NewMySQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 
 	// Create the required database if it doesn't exists.
 	if !schemaExist {
-		if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS " + database); err != nil {
+		if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS `" + database + "`"); err != nil {
 			return nil, errwrap.Wrapf("failed to create mysql database: {{err}}", err)
 		}
 	}


### PR DESCRIPTION
when use mysql storage, set` database = "dev-dassets-bc"` , create database and create table will throw exceptions as follows:

    Error initializing storage of type mysql: failed to create mysql database: Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-dassets-bc' at line 1
    Error initializing storage of type mysql: failed to create mysql table: Error 1046: No database selected

cause of `-` is  a MySQL  built-in symbol. so add backtick for create database sql\create table sql \dml sqls.