### PR TITLE
Fix DB role statement update

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -902,10 +902,12 @@ func TestBackend_roleCrud(t *testing.T) {
 	// Test role modification
 	{
 		data = map[string]interface{}{
-			"name":                "plugin-role-test",
-			"rollback_statements": testRole,
-			"renew_statements":    defaultRevocationSQL,
-			"max_ttl":             "7m",
+			"name":                  "plugin-role-test",
+			"creation_statements":   []string{testRole, testRole},
+			"revocation_statements": []string{defaultRevocationSQL, defaultRevocationSQL},
+			"rollback_statements":   testRole,
+			"renew_statements":      defaultRevocationSQL,
+			"max_ttl":               "7m",
 		}
 		req = &logical.Request{
 			Operation: logical.UpdateOperation,
@@ -943,9 +945,9 @@ func TestBackend_roleCrud(t *testing.T) {
 		}
 
 		expected := dbplugin.Statements{
-			Creation:   []string{strings.TrimSpace(testRole)},
+			Creation:   []string{strings.TrimSpace(testRole), strings.TrimSpace(testRole)},
 			Rollback:   []string{strings.TrimSpace(testRole)},
-			Revocation: []string{strings.TrimSpace(defaultRevocationSQL)},
+			Revocation: []string{strings.TrimSpace(defaultRevocationSQL), strings.TrimSpace(defaultRevocationSQL)},
 			Renewal:    []string{strings.TrimSpace(defaultRevocationSQL)},
 		}
 

--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -210,6 +210,12 @@ func (b *databaseBackend) pathRoleCreateUpdate() framework.OperationFunc {
 			} else if req.Operation == logical.CreateOperation {
 				role.Statements.Renewal = data.Get("renew_statements").([]string)
 			}
+
+			// Do not persist deprecated statements that are populated on role read
+			role.Statements.CreationStatements = ""
+			role.Statements.RevocationStatements = ""
+			role.Statements.RenewStatements = ""
+			role.Statements.RollbackStatements = ""
 		}
 
 		// Store it


### PR DESCRIPTION
The backwards compatibility logic was preventing updates to role
statements from taking effect. This change removes persistence of
deprecated statement fields.