### PR TITLE
Fix Google Cloud races

### DIFF
--- a/physical/gcs/gcs_ha.go
+++ b/physical/gcs/gcs_ha.go
@@ -274,20 +274,26 @@ func (l *Lock) watchLock() {
 	retries := 0
 	ticker := time.NewTicker(l.watchRetryInterval)
 
+OUTER:
 	for {
 		// Check if the channel is already closed
 		select {
 		case <-l.stopCh:
+			break OUTER
 		default:
 		}
 
 		// Check if we've exceeded retries
 		if retries >= l.watchRetryMax-1 {
-			break
+			break OUTER
 		}
 
 		// Wait for the timer
-		<-ticker.C
+		select {
+		case <-ticker.C:
+		case <-l.stopCh:
+			break OUTER
+		}
 
 		// Attempt to read the key
 		r, err := l.get(context.Background())
@@ -298,7 +304,7 @@ func (l *Lock) watchLock() {
 
 		// Verify the identity is the same
 		if r == nil || r.Identity != l.identity {
-			break
+			break OUTER
 		}
 	}
 

--- a/physical/gcs/gcs_ha.go
+++ b/physical/gcs/gcs_ha.go
@@ -180,10 +180,30 @@ func (l *Lock) Unlock() error {
 	}
 	l.stopLock.Unlock()
 
-	// Delete
+	// Read the record value before deleting. This needs to be a CAS operation or
+	// else we might be deleting someone else's lock.
 	ctx := context.Background()
-	if err := l.backend.Delete(ctx, l.key); err != nil {
-		return err
+	r, err := l.get(ctx)
+	if err != nil {
+		return errwrap.Wrapf("failed to read lock for deletion: {{err}}", err)
+	}
+	if r != nil && r.Identity == l.identity {
+		ctx := context.Background()
+		conds := storage.Conditions{
+			GenerationMatch:     r.attrs.Generation,
+			MetagenerationMatch: r.attrs.Metageneration,
+		}
+
+		obj := l.backend.client.Bucket(l.backend.bucket).Object(l.key)
+		if err := obj.If(conds).Delete(ctx); err != nil {
+			// If the pre-condition failed, it means that someone else has already
+			// acquired the lock and we don't want to delete it.
+			if terr, ok := err.(*googleapi.Error); ok && terr.Code == 412 {
+				l.backend.logger.Debug("unlock: preconditions failed (lock already taken by someone else?)")
+			} else {
+				return errwrap.Wrapf("failed to delete lock: {{err}}", err)
+			}
+		}
 	}
 
 	// We are no longer holding the lock


### PR DESCRIPTION
While debugging #4915, I was able to get the backend into a weird state. I thought it was un-reproducible, but I finally figured out how to reproduce it and found the sources of the bug.

First, a silly Golang mistake on my part - I was breaking out of a `select`, not the outer `for` loop. This wasn't the root cause of the bug, but it meant that it took longer for a leader to step down properly.

The real issue is that GCS is a real-life race condition. Let's say vault-0 is the current leader, but voluntarily steps down. If it's stepping down at the same time that vault-1 is trying to acquire leadership, the lockfile may reach the max ttl. vault-1 writes its own lockfile, but vault-0 is shutting down and deletes said lockfile as part of its shutdown. Then lock contention arises.

This PR uses GCS's metadata generation attributes to perform a check-and-delete operation to make sure that we only delete the lockfile when it's truly _our_ lockfile.

/cc @emilymye @briankassouf 