### PR TITLE
Add support for passing args via `vault read`

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 
 	"github.com/hashicorp/errwrap"
@@ -46,7 +47,25 @@ func (c *Client) Logical() *Logical {
 }
 
 func (c *Logical) Read(path string) (*Secret, error) {
+	return c.ReadWithData(path, nil)
+}
+
+func (c *Logical) ReadWithData(path string, data map[string][]string) (*Secret, error) {
 	r := c.c.NewRequest("GET", "/v1/"+path)
+
+	var values url.Values
+	for k, v := range data {
+		if values == nil {
+			values = make(url.Values)
+		}
+		for _, val := range v {
+			values.Add(k, val)
+		}
+	}
+
+	if values != nil {
+		r.Params = values
+	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()

--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -152,6 +152,22 @@ func parseArgsDataString(stdin io.Reader, args []string) (map[string]string, err
 	return result, nil
 }
 
+// parseArgsDataStringLists parses the args data and returns the values as
+// string lists. If the values cannot be represented as strings, an error is
+// returned.
+func parseArgsDataStringLists(stdin io.Reader, args []string) (map[string][]string, error) {
+	raw, err := parseArgsData(stdin, args)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string][]string
+	if err := mapstructure.WeakDecode(raw, &result); err != nil {
+		return nil, errors.Wrap(err, "failed to convert values to strings")
+	}
+	return result, nil
+}
+
 // truncateToSeconds truncates the given duration to the number of seconds. If
 // the duration is less than 1s, it is returned as 0. The integer represents
 // the whole number unit of seconds for the duration.


### PR DESCRIPTION
We support this in the API as of 0.10.2 so read should support it too.

Trivially tested with some log info:

`core: data: data="map[string]interface {}{"zip":[]string{"zap", "zap2"}}"`