### PR TITLE
Update usage section for kv-v1 docs

### DIFF
--- a/website/source/docs/secrets/kv/kv-v1.html.md
+++ b/website/source/docs/secrets/kv/kv-v1.html.md
@@ -17,7 +17,7 @@ not merged together.
 Key names must always be strings. If you write non-string values directly via
 the CLI, they will be converted into strings. However, you can preserve
 non-string values by writing the key/value pairs to Vault from a JSON file or
-using the HTTP API. 
+using the HTTP API.
 
 This secrets engine honors the distinction between the `create` and `update`
 capabilities inside ACL policies.
@@ -60,7 +60,7 @@ allows for writing keys with arbitrary values.
 1. List the keys:
 
     ```text
-    $ vault kv list kv/my-secret
+    $ vault kv list kv/
     Keys
     ----
     my-secret

--- a/website/source/docs/secrets/kv/kv-v1.html.md
+++ b/website/source/docs/secrets/kv/kv-v1.html.md
@@ -88,7 +88,7 @@ $ vault kv put kv/my-secret ttl=30m my-value=s3cr3t
 Success! Data written to: kv/my-secret
 ```
 
-Even will a `ttl` set, the secrets engine _never_ removes data on its own. The
+Even with a `ttl` set, the secrets engine _never_ removes data on its own. The
 `ttl` key is merely advisory.
 
 When reading a value with a `ttl`, both the `ttl` key _and_ the refresh interval


### PR DESCRIPTION
While following along with the usage section in the kv-v1 docs I noticed this error.
Running the given command gives:

```text
$ vault kv list kv/my-secret
No value found at kv/my-secret/
```

Running `vault kv list kv/` gives the desired output. 

Also, I removed some trailing whitespace.