### PR TITLE
[etcd] fix the deafult prefix in website

### DIFF
--- a/website/source/docs/configuration/storage/etcd.html.md
+++ b/website/source/docs/configuration/storage/etcd.html.md
@@ -49,7 +49,7 @@ storage "etcd" {
   enabled. This can also be provided via the environment variable
   `ETCD_HA_ENABLED`.
 
-- `path` `(string: "vault/")` – Specifies the path in Etcd where Vault data will
+- `path` `(string: "/vault/")` – Specifies the path in Etcd where Vault data will
   be stored.
 
 - `sync` `(string: "true")` – Specifies whether to sync the list of available


### PR DESCRIPTION
etcd storage stores all Vault data under a prefix.
The default prefix is "/vault/" according to source codes.

* https://github.com/ymmt2005/vault/blob/master/physical/etcd/etcd2.go#L68
* https://github.com/ymmt2005/vault/blob/master/physical/etcd/etcd3.go#L55

However, the default prefix shown in the website is "vault/".
If the access to etcd is restricted to this wrong prefix, vault
cannot use etcd.