### PR TITLE
[WIP] Support custom max Nomad token name length [supersedes https://github.com/hashicorp/vault/pull/4361]

### DIFF
--- a/builtin/logical/nomad/backend.go
+++ b/builtin/logical/nomad/backend.go
@@ -8,10 +8,6 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
-// maxTokenNameLength is the maximum length for the name of a Nomad access
-// token
-const maxTokenNameLength = 256
-
 // Factory returns a Nomad backend that satisfies the logical.Backend interface
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	b := Backend()

--- a/builtin/logical/nomad/backend.go
+++ b/builtin/logical/nomad/backend.go
@@ -8,6 +8,11 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
+// maxTokenNameLength is the maximum length for the name of a Nomad access
+// token
+const maxTokenNameLength = 256
+
+// Factory returns a Nomad backend that satisfies the logical.Backend interface
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	b := Backend()
 	if err := b.Setup(ctx, conf); err != nil {
@@ -16,6 +21,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	return b, nil
 }
 
+// Backend returns the configured Nomad backend
 func Backend() *backend {
 	var b backend
 	b.Backend = &framework.Backend{
@@ -66,5 +72,6 @@ func (b *backend) client(ctx context.Context, s logical.Storage) (*api.Client, e
 	if err != nil {
 		return nil, err
 	}
+
 	return client, nil
 }

--- a/builtin/logical/nomad/backend_test.go
+++ b/builtin/logical/nomad/backend_test.go
@@ -3,29 +3,17 @@ package nomad
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"reflect"
 	"testing"
 	"time"
 
 	nomadapi "github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/vault/helper/testhelpers"
 	"github.com/hashicorp/vault/logical"
 	"github.com/mitchellh/mapstructure"
 	"github.com/ory/dockertest"
 )
-
-// randomWithPrefix is used to generate a unique name with a prefix, for
-// randomizing names in acceptance tests
-func randomWithPrefix(name string) string {
-	reseed()
-	return fmt.Sprintf("%s-%d", name, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
-}
-
-// Seeds random with current timestamp
-func reseed() {
-	rand.Seed(time.Now().UTC().UnixNano())
-}
 
 func prepareTestContainer(t *testing.T) (cleanup func(), retAddress string, nomadToken string) {
 	nomadToken = os.Getenv("NOMAD_TOKEN")
@@ -401,7 +389,7 @@ func TestBackend_max_token_name_length(t *testing.T) {
 			if tc.roleName == "" {
 				tc.roleName = "test"
 			}
-			roleTokenName := randomWithPrefix(tc.roleName)
+			roleTokenName := testhelpers.RandomWithPrefix(tc.roleName)
 
 			confReq.Path = "role/" + roleTokenName
 			confReq.Operation = logical.UpdateOperation

--- a/builtin/logical/nomad/backend_test.go
+++ b/builtin/logical/nomad/backend_test.go
@@ -144,7 +144,7 @@ func TestBackend_config_access(t *testing.T) {
 
 	expected := map[string]interface{}{
 		"address":               connData["address"].(string),
-		"max_token_name_length": maxTokenNameLength,
+		"max_token_name_length": 0,
 	}
 	if !reflect.DeepEqual(expected, resp.Data) {
 		t.Fatalf("bad: expected:%#v\nactual:%#v\n", expected, resp.Data)
@@ -332,8 +332,8 @@ func TestBackend_max_token_name_length(t *testing.T) {
 			tokenLength: 64,
 		},
 		{
-			title:    "ConfigOverride-LongName-notrim",
-			roleName: "testlongerrolenametoexceed64charsdddddddddddddddddddddddd",
+			title:    "Notrim",
+			roleName: "testlongersubrolenametoexceed64charsdddddddddddddddddddddddd",
 		},
 	}
 
@@ -341,20 +341,18 @@ func TestBackend_max_token_name_length(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			// setup config/access
 			connData := map[string]interface{}{
-				"address": connURL,
-				"token":   connToken,
+				"address":               connURL,
+				"token":                 connToken,
+				"max_token_name_length": tc.tokenLength,
 			}
 			expected := map[string]interface{}{
 				"address":               connURL,
-				"max_token_name_length": maxTokenNameLength,
+				"max_token_name_length": tc.tokenLength,
 			}
 
-			expectedTokenNameLength := maxTokenNameLength
-
+			expectedMaxTokenNameLength := maxTokenNameLength
 			if tc.tokenLength != 0 {
-				connData["max_token_name_length"] = tc.tokenLength
-				expected["max_token_name_length"] = tc.tokenLength
-				expectedTokenNameLength = tc.tokenLength
+				expectedMaxTokenNameLength = tc.tokenLength
 			}
 
 			confReq := logical.Request{
@@ -448,8 +446,8 @@ func TestBackend_max_token_name_length(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if len(token.Name) > expectedTokenNameLength {
-				t.Fatalf("token name exceeds max length (%d): %s (%d)", expectedTokenNameLength, token.Name, len(token.Name))
+			if len(token.Name) > expectedMaxTokenNameLength {
+				t.Fatalf("token name exceeds max length (%d): %s (%d)", expectedMaxTokenNameLength, token.Name, len(token.Name))
 			}
 		})
 	}

--- a/builtin/logical/nomad/backend_test.go
+++ b/builtin/logical/nomad/backend_test.go
@@ -367,31 +367,21 @@ func TestBackend_max_token_length(t *testing.T) {
 				"address":          connURL,
 				"max_token_length": maxTokenNameLength,
 			}
+
+			expectedTokenNameLength := maxTokenNameLength
+
 			if tc.tokenLength != 0 {
 				connData["max_token_length"] = tc.tokenLength
 				expected["max_token_length"] = tc.tokenLength
-			} else {
-				// Set tc.tokenLength to default, but don't send to config/access unless
-				// it's been explicitly set
-				// Normally this is handled by the Default specified in the schema
-				tc.tokenLength = maxTokenNameLength
-			}
-			if tc.envLengthString != "" {
-				i, _ := strconv.Atoi(tc.envLengthString)
-				expected["max_token_length"] = i
-			} else {
-				// Set tc.tokenLength to default, but don't send to config/access unless
-				// it's been explicitly set
-				// Normally this is handled by the Default specified in the schema
-				tc.tokenLength = maxTokenNameLength
+				expectedTokenNameLength = tc.tokenLength
 			}
 
 			if tc.envLengthString != "" {
 				os.Setenv("NOMAD_MAX_TOKEN_LENGTH", tc.envLengthString)
 				defer os.Unsetenv("NOMAD_MAX_TOKEN_LENGTH")
 				i, _ := strconv.Atoi(tc.envLengthString)
-				tc.tokenLength = i
 				expected["max_token_length"] = i
+				expectedTokenNameLength = i
 			}
 
 			confReq := logical.Request{
@@ -485,8 +475,8 @@ func TestBackend_max_token_length(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if len(token.Name) > tc.tokenLength {
-				t.Fatalf("token name exceeds max length (%d): %s (%d)", tc.tokenLength, token.Name, len(token.Name))
+			if len(token.Name) > expectedTokenNameLength {
+				t.Fatalf("token name exceeds max length (%d): %s (%d)", expectedTokenNameLength, token.Name, len(token.Name))
 			}
 		})
 	}

--- a/builtin/logical/nomad/backend_test.go
+++ b/builtin/logical/nomad/backend_test.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"os"
 	"reflect"
-	"strconv"
 	"testing"
 	"time"
 
@@ -156,8 +155,8 @@ func TestBackend_config_access(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
-		"address":          connData["address"].(string),
-		"max_token_length": maxTokenNameLength,
+		"address":               connData["address"].(string),
+		"max_token_name_length": maxTokenNameLength,
 	}
 	if !reflect.DeepEqual(expected, resp.Data) {
 		t.Fatalf("bad: expected:%#v\nactual:%#v\n", expected, resp.Data)
@@ -316,7 +315,7 @@ func TestBackend_CredsCreateEnvVar(t *testing.T) {
 	}
 }
 
-func TestBackend_max_token_length(t *testing.T) {
+func TestBackend_max_token_name_length(t *testing.T) {
 	config := logical.TestBackendConfig()
 	config.StorageView = &logical.InmemStorage{}
 	b, err := Factory(context.Background(), config)
@@ -328,10 +327,9 @@ func TestBackend_max_token_length(t *testing.T) {
 	defer cleanup()
 
 	testCases := []struct {
-		title           string
-		roleName        string
-		tokenLength     int
-		envLengthString string
+		title       string
+		roleName    string
+		tokenLength int
 	}{
 		{
 			title: "Default",
@@ -349,11 +347,6 @@ func TestBackend_max_token_length(t *testing.T) {
 			title:    "ConfigOverride-LongName-notrim",
 			roleName: "testlongerrolenametoexceed64charsdddddddddddddddddddddddd",
 		},
-		{
-			title:           "ConfigOverride-LongName-envtrim",
-			roleName:        "testlongerrolenametoexceed64charsdddddddddddddddddddddddd",
-			envLengthString: "16",
-		},
 	}
 
 	for _, tc := range testCases {
@@ -364,24 +357,16 @@ func TestBackend_max_token_length(t *testing.T) {
 				"token":   connToken,
 			}
 			expected := map[string]interface{}{
-				"address":          connURL,
-				"max_token_length": maxTokenNameLength,
+				"address":               connURL,
+				"max_token_name_length": maxTokenNameLength,
 			}
 
 			expectedTokenNameLength := maxTokenNameLength
 
 			if tc.tokenLength != 0 {
-				connData["max_token_length"] = tc.tokenLength
-				expected["max_token_length"] = tc.tokenLength
+				connData["max_token_name_length"] = tc.tokenLength
+				expected["max_token_name_length"] = tc.tokenLength
 				expectedTokenNameLength = tc.tokenLength
-			}
-
-			if tc.envLengthString != "" {
-				os.Setenv("NOMAD_MAX_TOKEN_LENGTH", tc.envLengthString)
-				defer os.Unsetenv("NOMAD_MAX_TOKEN_LENGTH")
-				i, _ := strconv.Atoi(tc.envLengthString)
-				expected["max_token_length"] = i
-				expectedTokenNameLength = i
 			}
 
 			confReq := logical.Request{
@@ -469,7 +454,7 @@ func TestBackend_max_token_length(t *testing.T) {
 			}
 
 			// connect to Nomad and verify the token name does not exceed the
-			// max_token_length
+			// max_token_name_length
 			token, _, err := client.ACLTokens().Self(qOpts)
 			if err != nil {
 				t.Fatal(err)

--- a/builtin/logical/nomad/path_config_access.go
+++ b/builtin/logical/nomad/path_config_access.go
@@ -2,6 +2,9 @@ package nomad
 
 import (
 	"context"
+	"log"
+	"os"
+	"strconv"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/logical"
@@ -22,6 +25,14 @@ func pathConfigAccess(b *backend) *framework.Path {
 			"token": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "Token for API calls",
+			},
+
+			"max_token_length": &framework.FieldSchema{
+				Type:        framework.TypeInt,
+				Description: "Max length for generated Nomad tokens",
+				// Default length is 256 as of
+				// https://github.com/hashicorp/nomad/blob/21682427f3474f92cc589832efe72850a61c83a7/nomad/structs/structs.go#L116
+				Default: maxTokenNameLength,
 			},
 		},
 
@@ -73,7 +84,8 @@ func (b *backend) pathConfigAccessRead(ctx context.Context, req *logical.Request
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"address": conf.Address,
+			"address":          conf.Address,
+			"max_token_length": conf.MaxTokenLength,
 		},
 	}, nil
 }
@@ -96,6 +108,20 @@ func (b *backend) pathConfigAccessWrite(ctx context.Context, req *logical.Reques
 		conf.Token = token.(string)
 	}
 
+	// max_token_length has default of 256
+	conf.MaxTokenLength = data.Get("max_token_length").(int)
+	envMaxTokenLength := os.Getenv("NOMAD_MAX_TOKEN_LENGTH")
+	if envMaxTokenLength != "" {
+		// if we find NOMAD_MAX_max_token_length in the env and can parse it, override
+		// the default length
+		i, err := strconv.Atoi(envMaxTokenLength)
+		if err != nil {
+			log.Printf("[WARN] error parsing NOMAD_MAX_TOKEN_LENGTH, using default 256")
+		} else {
+			conf.MaxTokenLength = i
+		}
+	}
+
 	entry, err := logical.StorageEntryJSON("config/access", conf)
 	if err != nil {
 		return nil, err
@@ -115,6 +141,7 @@ func (b *backend) pathConfigAccessDelete(ctx context.Context, req *logical.Reque
 }
 
 type accessConfig struct {
-	Address string `json:"address"`
-	Token   string `json:"token"`
+	Address        string `json:"address"`
+	Token          string `json:"token"`
+	MaxTokenLength int    `json:"max_token_length"`
 }

--- a/builtin/logical/nomad/path_config_access.go
+++ b/builtin/logical/nomad/path_config_access.go
@@ -83,8 +83,8 @@ func (b *backend) pathConfigAccessRead(ctx context.Context, req *logical.Request
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"address":          conf.Address,
-			"max_token_length": conf.MaxTokenLength,
+			"address":               conf.Address,
+			"max_token_name_length": conf.MaxTokenNameLength,
 		},
 	}, nil
 }

--- a/builtin/logical/nomad/path_config_access.go
+++ b/builtin/logical/nomad/path_config_access.go
@@ -10,10 +10,6 @@ import (
 
 const configAccessKey = "config/access"
 
-// maxTokenNameLength is the maximum length for the name of a Nomad access
-// token
-const maxTokenNameLength = 256
-
 func pathConfigAccess(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "config/access",
@@ -31,7 +27,6 @@ func pathConfigAccess(b *backend) *framework.Path {
 			"max_token_name_length": &framework.FieldSchema{
 				Type:        framework.TypeInt,
 				Description: "Max length for name of generated Nomad tokens",
-				Default:     maxTokenNameLength,
 			},
 		},
 
@@ -107,7 +102,6 @@ func (b *backend) pathConfigAccessWrite(ctx context.Context, req *logical.Reques
 		conf.Token = token.(string)
 	}
 
-	// max_token_name_length has default of 256
 	conf.MaxTokenNameLength = data.Get("max_token_name_length").(int)
 
 	entry, err := logical.StorageEntryJSON("config/access", conf)

--- a/builtin/logical/nomad/path_creds_create.go
+++ b/builtin/logical/nomad/path_creds_create.go
@@ -58,8 +58,9 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 
 	// Handling nomad maximum token length
 	// https://github.com/hashicorp/nomad/blob/d9276e22b3b74674996fb548cdb6bc4c70d5b0e4/nomad/structs/structs.go#L115
-	if len(tokenName) > 64 {
-		tokenName = tokenName[0:63]
+	// size increased in https://github.com/hashicorp/nomad/pull/3888
+	if len(tokenName) > 256 {
+		tokenName = tokenName[0:255]
 	}
 
 	// Create it

--- a/builtin/logical/nomad/path_creds_create.go
+++ b/builtin/logical/nomad/path_creds_create.go
@@ -11,6 +11,10 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
+// maxTokenNameLength is the maximum length for the name of a Nomad access
+// token
+const maxTokenNameLength = 256
+
 func pathCredsCreate(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "creds/" + framework.GenericNameRegex("name"),

--- a/builtin/logical/nomad/path_creds_create.go
+++ b/builtin/logical/nomad/path_creds_create.go
@@ -32,8 +32,8 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 	conf, _ := b.readConfigAccess(ctx, req.Storage)
 	// establish a default
 	tokenNameLength := maxTokenNameLength
-	if conf != nil {
-		tokenNameLength = conf.MaxTokenLength
+	if conf != nil && conf.MaxTokenNameLength > 0 {
+		tokenNameLength = conf.MaxTokenNameLength
 	}
 
 	role, err := b.Role(ctx, req.Storage, name)
@@ -62,13 +62,11 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 	// Generate a name for the token
 	tokenName := fmt.Sprintf("vault-%s-%s-%d", name, req.DisplayName, time.Now().UnixNano())
 
-	// Handling nomad maximum token length
-	// https://github.com/hashicorp/nomad/blob/d9276e22b3b74674996fb548cdb6bc4c70d5b0e4/nomad/structs/structs.go#L115
 	// Note: if the given role name is suffeciently long, the UnixNano() portion
 	// of the pseudo randomized token name is the part that gets trimmed off,
 	// weaking it's randomness.
 	if len(tokenName) > tokenNameLength {
-		tokenName = tokenName[0:tokenNameLength]
+		tokenName = tokenName[:tokenNameLength]
 	}
 
 	// Create it

--- a/builtin/logical/nomad/path_creds_create.go
+++ b/builtin/logical/nomad/path_creds_create.go
@@ -62,9 +62,9 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 	// Generate a name for the token
 	tokenName := fmt.Sprintf("vault-%s-%s-%d", name, req.DisplayName, time.Now().UnixNano())
 
-	// Note: if the given role name is suffeciently long, the UnixNano() portion
+	// Note: if the given role name is sufficiently long, the UnixNano() portion
 	// of the pseudo randomized token name is the part that gets trimmed off,
-	// weaking it's randomness.
+	// weakening it's randomness.
 	if len(tokenName) > tokenNameLength {
 		tokenName = tokenName[:tokenNameLength]
 	}

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"time"
 
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/helper/xor"
@@ -79,4 +80,10 @@ func GenerateRootWithError(t testing.T, cluster *vault.TestCluster, drToken bool
 		return "", err
 	}
 	return token, nil
+}
+
+// RandomWithPrefix is used to generate a unique name with a prefix, for
+// randomizing names in acceptance tests
+func RandomWithPrefix(name string) string {
+	return fmt.Sprintf("%s-%d", name, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
 }

--- a/website/source/api/secret/nomad/index.html.md
+++ b/website/source/api/secret/nomad/index.html.md
@@ -37,12 +37,16 @@ Nomad tokens.
   This value can also be provided on individual calls with the NOMAD_TOKEN 
   environment variable.
 
+- `max_token_name_length` `(int: <optional>)` – Specifies the maximum length to use for
+the name of the Nomad token generated with [Generate Credential](#generate-credential). Default `256`.
+
 ### Sample Payload
 
 ```json
 {
   "address": "http://127.0.0.1:4646",
-  "token": "adha..."
+  "token": "adha...",
+  "max_token_name_length": 256
 }
 ```
 

--- a/website/source/api/secret/nomad/index.html.md
+++ b/website/source/api/secret/nomad/index.html.md
@@ -37,8 +37,12 @@ Nomad tokens.
   This value can also be provided on individual calls with the NOMAD_TOKEN 
   environment variable.
 
-- `max_token_name_length` `(int: <optional>)` – Specifies the maximum length to use for
-the name of the Nomad token generated with [Generate Credential](#generate-credential). Default `256`.
+- `max_token_name_length` `(int: <optional>)` – Specifies the maximum length to
+  use for the name of the Nomad token generated with [Generate
+  Credential](#generate-credential). If omitted, `0` is used and ignored,
+  defaulting to the max value allowed by the Nomad version. For Nomad versions
+  0.8.3 and earlier, the default is `64`. For Nomad version 0.8.4 and later, the default is
+  `256`.
 
 ### Sample Payload
 


### PR DESCRIPTION
Continuing https://github.com/hashicorp/vault/pull/4361 to allow users to supply a custom max length for Nomad credential token names. For Nomad version 0.8.3 and before, the max length for the *name* of the token is 64 characters. With Nomad 0.8.4+, the max length is now 256. 

Here we apply a default max length of 256, but allow users to override that with either the `max_token_length` attribute, or using the `NOMAD_MAX_TOKEN_LENGTH` environment variable. 

NOTE: I've switched the tests to use my fork of the Dockerized Nomad at [catsby/nomad](https://hub.docker.com/r/catsby/nomad/) on docker hub. The current version is 0.8.3 and I needed 0.8.4 to support the new max length. 

Updating the docs now and will push when they are done. Opening this PR now for early review.