### PR TITLE
Add ha_enabled for mysql backend

### DIFF
--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -45,6 +45,7 @@ type MySQLBackend struct {
 	conf         map[string]string
 	redirectHost string
 	redirectPort int64
+	haEnabled    bool
 }
 
 // NewMySQLBackend constructs a MySQL backend using the given API client and
@@ -116,6 +117,16 @@ func NewMySQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		}
 	}
 
+	// Default value for ha_enabled
+	haEnabledStr, ok := conf["ha_enabled"]
+	if !ok {
+		haEnabledStr = "false"
+	}
+	haEnabled, err := strconv.ParseBool(haEnabledStr)
+	if err != nil {
+		return nil, fmt.Errorf("value [%v] of 'ha_enabled' could not be understood", haEnabledStr)
+	}
+
 	locktable, ok := conf["lock_table"]
 	if !ok {
 		locktable = table + "_lock"
@@ -123,22 +134,25 @@ func NewMySQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 
 	dbLockTable := "`" + database + "`.`" + locktable + "`"
 
-	// Check table exists
-	var lockTableExist bool
-	lockTableRows, err := db.Query("SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ?", locktable, database)
+	// Only create lock table if ha_enabled is true
+	if haEnabled {
+		// Check table exists
+		var lockTableExist bool
+		lockTableRows, err := db.Query("SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ?", locktable, database)
 
-	if err != nil {
-		return nil, errwrap.Wrapf("failed to check mysql table exist: {{err}}", err)
-	}
-	defer lockTableRows.Close()
-	lockTableExist = lockTableRows.Next()
+		if err != nil {
+			return nil, errwrap.Wrapf("failed to check mysql table exist: {{err}}", err)
+		}
+		defer lockTableRows.Close()
+		lockTableExist = lockTableRows.Next()
 
-	// Create the required table if it doesn't exists.
-	if !lockTableExist {
-		create_query := "CREATE TABLE IF NOT EXISTS " + dbLockTable +
-			" (node_job varchar(512), current_leader varchar(512), PRIMARY KEY (node_job))"
-		if _, err := db.Exec(create_query); err != nil {
-			return nil, errwrap.Wrapf("failed to create mysql table: {{err}}", err)
+		// Create the required table if it doesn't exists.
+		if !lockTableExist {
+			create_query := "CREATE TABLE IF NOT EXISTS " + dbLockTable +
+				" (node_job varchar(512), current_leader varchar(512), PRIMARY KEY (node_job))"
+			if _, err := db.Exec(create_query); err != nil {
+				return nil, errwrap.Wrapf("failed to create mysql table: {{err}}", err)
+			}
 		}
 	}
 
@@ -151,18 +165,24 @@ func NewMySQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		logger:      logger,
 		permitPool:  physical.NewPermitPool(maxParInt),
 		conf:        conf,
+		haEnabled:   haEnabled,
 	}
 
 	// Prepare all the statements required
 	statements := map[string]string{
 		"put": "INSERT INTO " + dbTable +
 			" VALUES( ?, ? ) ON DUPLICATE KEY UPDATE vault_value=VALUES(vault_value)",
-		"get":       "SELECT vault_value FROM " + dbTable + " WHERE vault_key = ?",
-		"delete":    "DELETE FROM " + dbTable + " WHERE vault_key = ?",
-		"list":      "SELECT vault_key FROM " + dbTable + " WHERE vault_key LIKE ?",
-		"get_lock":  "SELECT current_leader FROM " + dbLockTable + " WHERE node_job = ?",
-		"used_lock": "SELECT IS_USED_LOCK(?)",
+		"get":    "SELECT vault_value FROM " + dbTable + " WHERE vault_key = ?",
+		"delete": "DELETE FROM " + dbTable + " WHERE vault_key = ?",
+		"list":   "SELECT vault_key FROM " + dbTable + " WHERE vault_key LIKE ?",
 	}
+
+	// Only prepare ha-related statements if we need them
+	if haEnabled {
+		statements["get_lock"] = "SELECT current_leader FROM " + dbLockTable + " WHERE node_job = ?"
+		statements["used_lock"] = "SELECT IS_USED_LOCK(?)"
+	}
+
 	for name, query := range statements {
 		if err := m.prepare(name, query); err != nil {
 			return nil, err
@@ -366,7 +386,7 @@ func (m *MySQLBackend) LockWith(key, value string) (physical.Lock, error) {
 }
 
 func (m *MySQLBackend) HAEnabled() bool {
-	return true
+	return m.haEnabled
 }
 
 // MySQLHALock is a MySQL Lock implementation for the HABackend

--- a/physical/mysql/mysql_test.go
+++ b/physical/mysql/mysql_test.go
@@ -47,7 +47,7 @@ func TestMySQLBackend(t *testing.T) {
 
 	defer func() {
 		mysql := b.(*MySQLBackend)
-		_, err := mysql.client.Exec("DROP TABLE " + mysql.dbTable)
+		_, err := mysql.client.Exec("DROP TABLE IF EXISTS " + mysql.dbTable + " ," + mysql.dbLockTable)
 		if err != nil {
 			t.Fatalf("Failed to drop table: %v", err)
 		}
@@ -93,7 +93,7 @@ func TestMySQLHABackend(t *testing.T) {
 
 	defer func() {
 		mysql := b.(*MySQLBackend)
-		_, err := mysql.client.Exec("DROP TABLE " + mysql.dbTable)
+		_, err := mysql.client.Exec("DROP TABLE IF EXISTS " + mysql.dbTable + " ," + mysql.dbLockTable)
 		if err != nil {
 			t.Fatalf("Failed to drop table: %v", err)
 		}

--- a/physical/mysql/mysql_test.go
+++ b/physical/mysql/mysql_test.go
@@ -80,11 +80,12 @@ func TestMySQLHABackend(t *testing.T) {
 	logger := logging.NewVaultLogger(log.Debug)
 
 	b, err := NewMySQLBackend(map[string]string{
-		"address":  address,
-		"database": database,
-		"table":    table,
-		"username": username,
-		"password": password,
+		"address":    address,
+		"database":   database,
+		"table":      table,
+		"username":   username,
+		"password":   password,
+		"ha_enabled": "true",
 	}, logger)
 
 	if err != nil {

--- a/website/source/docs/configuration/storage/mysql.html.md
+++ b/website/source/docs/configuration/storage/mysql.html.md
@@ -56,6 +56,13 @@ Additionally, Vault requires the following authentication information.
 - `password` `(string: <required)` – Specifies the MySQL password to connect to
   the database.
 
+### High Availability Parameters
+
+- `lock_table` `(string: "vault_lock")` – Specifies the name of the table to
+  use for storing high availability information. By default, this is the name
+  of the `table` suffixed with `_lock`. If the table does not exist, Vault will
+  attempt to create it.
+
 ## `mysql` Examples
 
 ### Custom Database and Table

--- a/website/source/docs/configuration/storage/mysql.html.md
+++ b/website/source/docs/configuration/storage/mysql.html.md
@@ -58,6 +58,10 @@ Additionally, Vault requires the following authentication information.
 
 ### High Availability Parameters
 
+- `ha_enabled` `(string: "true")` -  Specifies if high availability mode is
+  enabled. This is a boolean value, but it is specified as a string like "true"
+  or "false".
+
 - `lock_table` `(string: "vault_lock")` – Specifies the name of the table to
   use for storing high availability information. By default, this is the name
   of the `table` suffixed with `_lock`. If the table does not exist, Vault will


### PR DESCRIPTION
Really excited to see the ball start rolling for getting HA support for the mysql backend (#4686).

This pull request adds the `ha_enabled` variable to the configuration options, and defaults it to false.  This functionality should be opt-in, because it requires [additional configuration](https://www.vaultproject.io/docs/configuration/index.html#high-availability-parameters).

If the lock table name isn't explicitly specified, it will default to the regular table name suffixed by "_lock" (similar to how the Spanner backend does things).

I added backticks around a few places that mysql might be tripped up by weird characters, like in #5054

Finally, I condensed some duplicate code for figuring out the name of the lock table by centralising it under the MySQLBackend struct