### PR TITLE
[etcd] use clientv3 forcibly if user requested

### DIFF
--- a/physical/etcd/etcd.go
+++ b/physical/etcd/etcd.go
@@ -71,9 +71,6 @@ func NewEtcdBackend(conf map[string]string, logger log.Logger) (physical.Backend
 	case "2", "etcd2", "v2":
 		return newEtcd2Backend(conf, logger)
 	case "3", "etcd3", "v3":
-		if remoteAPIVersion == "2" {
-			return nil, errors.New("etcd3 is required: etcd2 is running")
-		}
 		return newEtcd3Backend(conf, logger)
 	default:
 		return nil, EtcdVersionUnknown


### PR DESCRIPTION
etcd storage auto detects cluster version.  Unfortunately though,
the auto detection sometimes detect v3 cluster as v2  (I will open
another issue for this problem; edit #5129).

Worse, even if a user specifies the cluster version in HCL as:

    storage "etcd" {
        etcd_api = "v3"
        ...
    }

vault denies to start with this error message:

> etcd3 is required: etcd2 is running

This commit eliminates this version check to work around the
auto detection problem because the check is in fact unnecessary
as the user explicitly requested to connect with v3 protocol.