### PR TITLE
A simple copy-paste fix

### DIFF
--- a/physical/mysql/mysql_test.go
+++ b/physical/mysql/mysql_test.go
@@ -102,7 +102,7 @@ func TestMySQLHABackend(t *testing.T) {
 
 	ha, ok := b.(physical.HABackend)
 	if !ok {
-		t.Fatalf("zookeeper does not implement HABackend")
+		t.Fatalf("MySQL does not implement HABackend")
 	}
 	physical.ExerciseHABackend(t, ha, ha)
 }


### PR DESCRIPTION
The test for MySQL HA backend seems to have been based on the Zookeeper one and the error message in it did not get updated to be MySQL-specific.