### PR TITLE
Two PKI improvements:

### DIFF
--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -1,0 +1,124 @@
+package pki
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/vault"
+)
+
+func TestBackend_CRL_EnableDisable(t *testing.T) {
+	coreConfig := &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"pki": Factory,
+		},
+	}
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	client := cluster.Cores[0].Client
+	var err error
+	err = client.Sys().Mount("pki", &api.MountInput{
+		Type: "pki",
+		Config: api.MountConfigInput{
+			DefaultLeaseTTL: "16h",
+			MaxLeaseTTL:     "60h",
+		},
+	})
+
+	resp, err := client.Logical().Write("pki/root/generate/internal", map[string]interface{}{
+		"ttl":         "40h",
+		"common_name": "myvault.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	caSerial := resp.Data["serial_number"]
+
+	_, err = client.Logical().Write("pki/roles/test", map[string]interface{}{
+		"allow_bare_domains": true,
+		"allow_subdomains":   true,
+		"allowed_domains":    "foobar.com",
+		"generate_lease":     true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var serials = make(map[int]string)
+	for i := 0; i < 6; i++ {
+		resp, err := client.Logical().Write("pki/issue/test", map[string]interface{}{
+			"common_name": "test.foobar.com",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		serials[i] = resp.Data["serial_number"].(string)
+	}
+
+	test := func(num int) {
+		resp, err := client.Logical().Read("pki/cert/crl")
+		if err != nil {
+			t.Fatal(err)
+		}
+		crlPem := resp.Data["certificate"].(string)
+		certList, err := x509.ParseCRL([]byte(crlPem))
+		if err != nil {
+			t.Fatal(err)
+		}
+		lenList := len(certList.TBSCertList.RevokedCertificates)
+		if lenList != num {
+			t.Fatalf("expected %d, found %d", num, lenList)
+		}
+	}
+
+	revoke := func(num int) {
+		resp, err = client.Logical().Write("pki/revoke", map[string]interface{}{
+			"serial_number": serials[num],
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resp, err = client.Logical().Write("pki/revoke", map[string]interface{}{
+			"serial_number": caSerial,
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	}
+
+	toggle := func(disabled bool) {
+		_, err = client.Logical().Write("pki/config/crl", map[string]interface{}{
+			"disable": disabled,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	test(0)
+	revoke(0)
+	revoke(1)
+	test(2)
+	toggle(true)
+	test(0)
+	revoke(2)
+	revoke(3)
+	test(0)
+	toggle(false)
+	test(4)
+	revoke(4)
+	revoke(5)
+	test(6)
+	toggle(true)
+	test(0)
+	toggle(false)
+	test(6)
+}

--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -83,7 +83,7 @@ func (b *backend) pathCAWrite(ctx context.Context, req *logical.Request, data *f
 		return nil, err
 	}
 
-	err = buildCRL(ctx, b, req)
+	err = buildCRL(ctx, b, req, true)
 
 	return nil, err
 }

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -232,7 +232,7 @@ func (b *backend) pathSetSignedIntermediate(ctx context.Context, req *logical.Re
 	}
 
 	// Build a fresh CRL
-	err = buildCRL(ctx, b, req)
+	err = buildCRL(ctx, b, req, true)
 
 	return nil, err
 }

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -64,7 +64,7 @@ func (b *backend) pathRotateCRLRead(ctx context.Context, req *logical.Request, d
 	b.revokeStorageLock.RLock()
 	defer b.revokeStorageLock.RUnlock()
 
-	crlErr := buildCRL(ctx, b, req)
+	crlErr := buildCRL(ctx, b, req, false)
 	switch crlErr.(type) {
 	case errutil.UserError:
 		return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -232,7 +232,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	}
 
 	// Build a fresh CRL
-	err = buildCRL(ctx, b, req)
+	err = buildCRL(ctx, b, req, true)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -178,7 +178,7 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 				}
 
 				if tidiedRevoked {
-					if err := buildCRL(ctx, b, req); err != nil {
+					if err := buildCRL(ctx, b, req, false); err != nil {
 						return err
 					}
 				}

--- a/helper/certutil/types.go
+++ b/helper/certutil/types.go
@@ -17,7 +17,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"math/big"
 	"strings"
 
 	"github.com/hashicorp/errwrap"
@@ -98,7 +97,6 @@ type ParsedCertBundle struct {
 	CertificateBytes []byte
 	Certificate      *x509.Certificate
 	CAChain          []*CertBlock
-	SerialNumber     *big.Int
 }
 
 // CSRBundle contains a key type, a PEM-encoded private key,
@@ -223,8 +221,6 @@ func (c *CertBundle) ToParsedCertBundle() (*ParsedCertBundle, error) {
 		if err != nil {
 			return nil, errutil.UserError{Err: fmt.Sprintf("Error encountered parsing certificate bytes from raw bundle via issuing CA: %v", err)}
 		}
-
-		result.SerialNumber = result.Certificate.SerialNumber
 
 		certBlock := &CertBlock{
 			Bytes:       pemBlock.Bytes,

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -236,6 +236,7 @@ $ curl \
   "renewable": false,
   "lease_duration": 0,
   "data": {
+      "disable": false,
       "expiry": "72h"
     },
   "auth": null
@@ -245,7 +246,15 @@ $ curl \
 ## Set CRL Configuration
 
 This endpoint allows setting the duration for which the generated CRL should be
-marked valid.
+marked valid. If the CRL is disabled, it will return a signed but zero-length
+CRL for any request. If enabled, it will re-build the CRL.
+
+  ~> Note: Disabling the CRL does not affect whether revoked certificates are
+  stored internally. Certificates that have been revoked when a role's
+  certificate storage is enabled will continue to be marked and stored as
+  revoked until `tidy` has been run with the desired safety buffer. Re-enabling
+  CRL generation will then result in all such certificates becoming a part of
+  the CRL.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
@@ -254,6 +263,7 @@ marked valid.
 ### Parameters
 
 - `expiry` `(string: "72h")` – Specifies the time until expiration.
+- `disable` `(bool: false)` – Disables or enables CRL building.
 
 ### Sample Payload
 


### PR DESCRIPTION
* Disallow adding CA's serial to revocation list
* Allow disabling revocation list generation. This returns an empty (but
signed) list, but does not affect tracking of revocations so turning it
back on will populate the list properly.