### PR TITLE
WIP: Update UI to Support Explicit AWS Credential Types

### DIFF
--- a/ui/app/components/role-aws-edit.js
+++ b/ui/app/components/role-aws-edit.js
@@ -32,6 +32,11 @@ export default RoleEdit.extend({
         set(this, 'model.policy_arns', []);
       }
 
+      var policy_document = get(this, 'model.policy_document');
+      if (policy_document == '{}') {
+        set(this, 'model.policy_document', '');
+      }
+
       this.persist('save', () => {
         this.hasDataChanges();
         this.transitionToRoute(SHOW_ROUTE, modelId);

--- a/ui/app/components/role-aws-edit.js
+++ b/ui/app/components/role-aws-edit.js
@@ -5,13 +5,8 @@ const { get, set } = Ember;
 const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
 
 export default RoleEdit.extend({
-  useARN: false,
   init() {
     this._super(...arguments);
-    const arn = get(this, 'model.arn');
-    if (arn) {
-      set(this, 'useARN', true);
-    }
   },
 
   actions: {
@@ -24,11 +19,17 @@ export default RoleEdit.extend({
       if (type === 'create' && Ember.isBlank(modelId)) {
         return;
       }
-      // clear the policy or arn before save depending on "useARN"
-      if (get(this, 'useARN')) {
-        set(this, 'model.policy', '');
-      } else {
-        set(this, 'model.arn', '');
+
+      var credential_type = get(this, 'model.credential_type');
+      if (credential_type == "iam_user") {
+        set(this, 'model.role_arns', []);
+      }
+      if (credential_type == "assumed_role") {
+        set(this, 'model.policy_arns', []);
+      }
+      if (credential_type == "federation_token") {
+        set(this, 'model.role_arns', []);
+        set(this, 'model.policy_arns', []);
       }
 
       this.persist('save', () => {

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -6,7 +6,7 @@ import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 const { attr } = DS;
 const { computed } = Ember;
 
-const CREATE_FIELDS = ['name', 'policy', 'arn'];
+const CREATE_FIELDS = ['name', 'credential_type', 'role_arns', 'policy_arns', 'policy_document'];
 export default DS.Model.extend({
   backend: attr('string', {
     readOnly: true,
@@ -16,13 +16,26 @@ export default DS.Model.extend({
     fieldValue: 'id',
     readOnly: true,
   }),
-  arn: attr('string', {
+  credential_type: attr('string', {
+    defaultValue: "iam_user",
+  }),
+  role_arns: attr({
+    editType: 'stringArray',
+    label: 'Role ARNs',
+  }),
+  policy_arns: attr({
+    editType: 'stringArray',
+  }),
+  policy_document: attr('string', {
+    widget: 'json',
+  }),
+  /*arn: attr('string', {
     helpText: '',
   }),
   policy: attr('string', {
     helpText: '',
     widget: 'json',
-  }),
+  }),*/
   attrs: computed(function() {
     let keys = CREATE_FIELDS.slice(0);
     return expandAttributeMeta(this, keys);

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -6,7 +6,7 @@ import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 const { attr } = DS;
 const { computed } = Ember;
 
-const CREATE_FIELDS = ['name', 'credential_type', 'role_arns', 'policy_arns', 'policy_document'];
+const CREATE_FIELDS = ['name', 'credential_type', 'credential_types', 'role_arns', 'policy_arns', 'policy_document'];
 export default DS.Model.extend({
   backend: attr('string', {
     readOnly: true,
@@ -18,6 +18,10 @@ export default DS.Model.extend({
   }),
   credential_type: attr('string', {
     defaultValue: "iam_user",
+  }),
+  credential_types: attr({
+    label: 'Credential Types',
+    readOnly: true,
   }),
   role_arns: attr({
     editType: 'stringArray',

--- a/ui/app/templates/partials/role-aws/form.hbs
+++ b/ui/app/templates/partials/role-aws/form.hbs
@@ -13,42 +13,59 @@
       </div>
     {{/if}}
     <div class="field">
-      <div class="level">
-        <div class="level-left">
-          {{#if useARN}}
-            <label for="arn" class="is-label">
-              ARN
-            </label>
-          {{else}}
-            <label for="policy" class="is-label">
-              Policy
-            </label>
-          {{/if}}
-        </div>
-        <div class="level-right">
-          <div class="control is-flex">
-            {{input
-              data-test-aws-toggle-use-arn=true
-              id="use-arn"
-              type="checkbox"
-              name="use-arn"
-              class="switch is-rounded is-success is-small"
-              checked=useARN
-            }}
-            <label for="use-arn">Use Amazon Resource Name</label>
-          </div>
+      <label for="credential-type" class="is-label">
+        Credential Type
+      </label>
+      <div class="control is-expanded">
+        <div class="select is-fullwidth">
+          <select
+             name="credential-type"
+             id="credential-type"
+             onchange={{action (mut model.credential_type) value="target.value"}}
+          >
+            <option selected={{eq model.credential_type "iam_user"}} value="iam_user">
+              IAM User
+            </option>
+            <option selected={{eq model.credential_type "assumed_role"}} value="assumed_role">
+              Assumed Role
+            </option>
+            <option selected={{eq model.credential_type "federation_token"}} value="federation_token">
+              Federation Token
+            </option>
+          </select>
         </div>
       </div>
-      <div class="control">
-        {{#if useARN}}
-          {{input id="arn" value=model.arn class="input" data-test-input="arn"}}
-        {{else}}
+    </div>
+    {{#if (eq model.credential_type "assumed_role") }}
+      <div class="field">
+        <label for="role_arns" class="is-label">
+          Role ARNs
+        </label>
+        <div class="control">
+          {{input id="role_arns" value=model.role_arns class="input" data-test-input="role_arns"}}
+        </div>
+      </div>
+    {{/if}}
+    {{#if (eq model.credential_type "iam_user") }}
+      <div class="field">
+        <label for="policy_arns" class="is-label">
+          Policy ARNs
+        </label>
+        <div class="control">
+          {{input id="policy_arns" value=model.policy_arns class="input" data-test-input="policy_arns"}}
+        </div>
+      </div>
+    {{/if}}
+  </div>
+  <div class="field">
+    <label for="policy_document" class="is-label">
+      Policy
+    </label>
+    <div class="control">
           {{json-editor
-            value=(if model.policy (stringify (jsonify model.policy)) emptyData)
-            valueUpdated=(action "codemirrorUpdated" "policy")
-          }}
-        {{/if}}
-      </div>
+            value=(if model.policy_document (stringify (jsonify model.policy_document)) emptyData)
+            valueUpdated=(action "codemirrorUpdated" "policy_document")
+            }}
     </div>
   </div>
   <div class="field is-grouped-split box is-fullwidth is-bottomless">

--- a/ui/app/templates/partials/role-aws/form.hbs
+++ b/ui/app/templates/partials/role-aws/form.hbs
@@ -23,13 +23,13 @@
              id="credential-type"
              onchange={{action (mut model.credential_type) value="target.value"}}
           >
-            <option selected={{eq model.credential_type "iam_user"}} value="iam_user">
+            <option selected={{eq model.credential_types "iam_user"}} value="iam_user">
               IAM User
             </option>
-            <option selected={{eq model.credential_type "assumed_role"}} value="assumed_role">
+            <option selected={{eq model.credential_types "assumed_role"}} value="assumed_role">
               Assumed Role
             </option>
-            <option selected={{eq model.credential_type "federation_token"}} value="federation_token">
+            <option selected={{eq model.credential_types "federation_token"}} value="federation_token">
               Federation Token
             </option>
           </select>
@@ -37,14 +37,11 @@
       </div>
     </div>
     {{#if (eq model.credential_type "assumed_role") }}
-      <div class="field">
-        <label for="role_arns" class="is-label">
-          Role ARNs
-        </label>
-        <div class="control">
-          {{input id="role_arns" value=model.role_arns class="input" data-test-input="role_arns"}}
-        </div>
-      </div>
+      {{string-list
+        label="Role ARNs"
+	inputValue=model.role_arns
+	attr=model.role_arns
+      }}
     {{/if}}
     {{#if (eq model.credential_type "iam_user") }}
       <div class="field">

--- a/ui/app/templates/partials/role-aws/show.hbs
+++ b/ui/app/templates/partials/role-aws/show.hbs
@@ -1,11 +1,13 @@
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#each model.attrs as |attr|}}
-    {{#if (eq attr.name "policy")}}
+    {{#if (eq attr.name "policy_document")}}
       {{#info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=model.policy}}
       <pre><code class="is-paddingless">{{stringify (jsonify model.policy)}}</code></pre>
       {{/info-table-row}}
     {{else}}
-      {{info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=(get model attr.name)}}
+      {{#unless (eq attr.name "credential_type")}}
+        {{info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=(get model attr.name)}}
+      {{/unless}}
     {{/if}}
   {{/each}}
 </div>


### PR DESCRIPTION
UI support for #4360 -- because it contains some backwards incompatibilities in reading role data, the UI no longer works to manage roles. It can be used for creating roles and generating credentials, but not viewing role details, and editing the role looks ugly as well.

Definitely need some help if I'm going to finish the swing on this, UI work isn't my forte (I'm  much more comfortable digging around the [nitty gritty details](https://github.com/hashicorp/vault/pull/4183) of crypto code...).

I'm sure there's a lot I'm going wrong, but the current list of bugs I'm aware of are:

* [ ] When editing an existing role, the existing `credential_type` doesn't get recognized. That's because `credential_type` is a bit weird. It gets set as a singular value, but read out as a list, as `credential_types` for backwards compatibility reasons (see the discussion starting at https://github.com/hashicorp/vault/issues/4229#issuecomment-380316788 for more details on the why). I'm not sure how to make a Handlebars helper in an Ember app to implement some sort of ArrayContains method).
* [ ] `role_arns` items don't get saved when I try to update them.
* [ ] `policy_arns` is entered as a comma-separated value, but it should be a real list. Waiting to figure out the previous item before tackling this one.
* [ ] When setting an empty policy document, the UI prompts about
       discarding changes. This doesn't seem like the right behavior.
* [ ] Eliminate distinction between generate IAM creds and STS creds, though might not be able to fully for legacy roles.]
* [ ] Add/Update UI tests