### PR TITLE
UI namespace additions

### DIFF
--- a/ui/app/components/list-item.js
+++ b/ui/app/components/list-item.js
@@ -9,11 +9,12 @@ export default Ember.Component.extend({
   componentName: null,
   hasMenu: false,
 
-  callMethod: task(function*(method, model, successMessage, failureMessage) {
+  callMethod: task(function*(method, model, successMessage, failureMessage, successCallback = () => {}) {
     let flash = this.get('flashMessages');
     try {
       yield model[method]();
       flash.success(successMessage);
+      successCallback();
     } catch (e) {
       let errString = e.errors.join(' ');
       flash.danger(failureMessage + errString);

--- a/ui/app/controllers/vault/cluster/access/namespaces/index.js
+++ b/ui/app/controllers/vault/cluster/access/namespaces/index.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+const { computed, inject, Controller } = Ember;
+export default Controller.extend({
+  namespaceService: inject.service('namespace'),
+  accessibleNamespaces: computed.alias('namespaceService.accessibleNamespaces'),
+  currentNamespace: computed.alias('namespaceService.path'),
+});

--- a/ui/app/controllers/vault/cluster/access/namespaces/index.js
+++ b/ui/app/controllers/vault/cluster/access/namespaces/index.js
@@ -5,4 +5,10 @@ export default Controller.extend({
   namespaceService: inject.service('namespace'),
   accessibleNamespaces: computed.alias('namespaceService.accessibleNamespaces'),
   currentNamespace: computed.alias('namespaceService.path'),
+  actions: {
+    refreshNamespaceList() {
+      // fetch new namespaces for the namespace picker
+      this.get('namespaceService.findNamespacesForUser').perform();
+    },
+  },
 });

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -28,14 +28,28 @@ export default Service.extend({
     // want to keep track of these separately
     let store = this.get('store');
     let adapter = store.adapterFor('namespace');
+    let userRoot = this.get('auth.authData.userRootNamespace');
     try {
       let ns = yield adapter.findAll(store, 'namespace', null, {
         adapterOptions: {
           forUser: true,
-          namespace: this.get('userRootNamespace'),
+          namespace: userRoot,
         },
       });
-      this.set('accessibleNamespaces', ns.data.keys.map(n => n.replace(/\/$/, '')));
+      this.set(
+        'accessibleNamespaces',
+        ns.data.keys.map(n => {
+          let fullNS = n;
+          // if the user's root isn't '', then we need to construct
+          // the paths so they connect to the user root to the list
+          // otherwise using the current ns to grab the correct leaf
+          // node in the graph doesn't work
+          if (userRoot) {
+            fullNS = `${userRoot}/${n}`;
+          }
+          return fullNS.replace(/\/$/, '');
+        })
+      );
     } catch (e) {
       //do nothing here
     }

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
+import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 const { Service, computed, inject } = Ember;
 const ROOT_NAMESPACE = '';
@@ -18,6 +19,8 @@ export default Service.extend({
   setNamespace(path) {
     this.set('path', path);
   },
+  listPath: lazyCapabilities(apiPath`sys/namespaces`, 'path'),
+  canList: computed.alias('listPath.canList'),
 
   findNamespacesForUser: task(function*() {
     // uses the adapter and the raw response here since

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -19,7 +19,7 @@ export default Service.extend({
   setNamespace(path) {
     this.set('path', path);
   },
-  listPath: lazyCapabilities(apiPath`sys/namespaces`, 'path'),
+  listPath: lazyCapabilities(apiPath`sys/namespaces/`, 'path'),
   canList: computed.alias('listPath.canList'),
 
   findNamespacesForUser: task(function*() {

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -33,10 +33,11 @@
             {{/if}}
           </div>
           <div class="level-right">
-            {{namespaceService.canList}}
-            {{#link-to "vault.cluster.access.namespaces" class="namespace-manage-link"}}
-              Manage
-            {{/link-to}}
+            {{#if namespaceService.canList}}
+              {{#link-to "vault.cluster.access.namespaces" class="namespace-manage-link"}}
+                Manage
+              {{/link-to}}
+            {{/if}}
           </div>
         </div>
         <header class="current-namespace">

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -33,6 +33,7 @@
             {{/if}}
           </div>
           <div class="level-right">
+            {{namespaceService.canList}}
             {{#link-to "vault.cluster.access.namespaces" class="namespace-manage-link"}}
               Manage
             {{/link-to}}

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -43,7 +43,7 @@
         <header class="current-namespace">
           <h5 class="namespace-header">Current namespace</h5>
           <div class="level is-mobile namespace-link">
-            <span class="level-left">{{or namespacePath "root"}}</span>
+            <span class="level-left">{{if namespacePath (concat namespacePath "/") "root"}}</span>
             <ICon @glyph="checkmark-circled-outline" @size="16" @class="has-text-success level-right" />
           </div>
         </header>

--- a/ui/app/templates/components/namespace-reminder.hbs
+++ b/ui/app/templates/components/namespace-reminder.hbs
@@ -1,5 +1,5 @@
 {{#if showMessage}}
   <p class="namespace-reminder">
-    This {{noun}} will be {{modeVerb}} in the <span class="tag">{{namespace.path}}</span>namespace.
+  This {{noun}} will be {{modeVerb}} in the <span class="tag">{{namespace.path}}/</span>namespace.
   </p>
 {{/if}}

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -32,7 +32,16 @@
             @confirmButtonClasses="button is-primary"
             @confirmButtonText="Remove"
             @buttonClasses="link is-destroy"
-            @onConfirmAction={{action (perform Item.callMethod "destroyRecord" list.item (concat "Successfully deleted namespace: " list.item.id) "There was an error deleting this namespace: ") }}
+            @onConfirmAction={{action
+              (perform
+                Item.callMethod
+                "destroyRecord"
+                list.item
+                (concat "Successfully deleted namespace: " list.item.id)
+                "There was an error deleting this namespace: "
+                (action "refreshNamespaceList")
+              )
+            }}
             @confirmMessage={{concat "Are you sure you want to delete " list.item.id "?"}}
             @showConfirm={{get this (concat "shouldDelete-" list.item.id)}}
             @class={{if (get this (concat "shouldDelete-" list.item.id)) "message is-block is-warning is-outline"}}

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -18,6 +18,15 @@
         {{list.item.id}}
       </Item.content>
       <Item.menu>
+        {{#with (concat currentNamespace (if currentNamespace "/") list.item.id) as |targetNamespace|}}
+          {{#if (contains targetNamespace accessibleNamespaces)}}
+            <li class="action">
+              {{#link-to "vault.cluster.secrets" (query-params namespace=targetNamespace) class="is-block"}}
+                Switch to this namespace
+              {{/link-to}}
+            </li>
+          {{/if}}
+        {{/with}}
         <li class="action">
           <ConfirmAction
             @confirmButtonClasses="button is-primary"

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -22,7 +22,7 @@
           {{#if (contains targetNamespace accessibleNamespaces)}}
             <li class="action">
               {{#link-to "vault.cluster.secrets" (query-params namespace=targetNamespace) class="is-block"}}
-                Switch to this namespace
+                Switch to namespace
               {{/link-to}}
             </li>
           {{/if}}


### PR DESCRIPTION
Adds a few things in the UI:
Switch to the namespace from the context menu
![screen shot 2018-08-21 at 2 28 21 pm](https://user-images.githubusercontent.com/39469/44424500-e3a3e000-a54e-11e8-861e-9cfb2a870d4b.png)

Refresh the namespace picker when you delete an item
Fixes a bug where the token only has access to namespaces below it's home namespace - the picker wouldn't render the tree properly.