### PR TITLE
Restricts ACL templating to paths but allows failures

### DIFF
--- a/helper/identity/templating.go
+++ b/helper/identity/templating.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -162,7 +163,7 @@ func performTemplating(input string, entity *Entity, groups []*Group) (string, e
 		}
 
 		if found == nil {
-			return "", errors.New("group not found")
+			return "", fmt.Errorf("entity is not a member of group %q", accessorSplit[0])
 		}
 
 		trimmed = accessorSplit[1]

--- a/helper/identity/templating_test.go
+++ b/helper/identity/templating_test.go
@@ -125,7 +125,7 @@ func TestPopulate_Basic(t *testing.T) {
 			input:      "path \"{{identity.groups.ids.hroupID.name}}\" {\n\tval = {{identity.entity.name}}\n}",
 			entityName: "entityName",
 			groupName:  "groupName",
-			err:        errors.New("group not found"),
+			err:        errors.New("entity is not a member of group \"hroupID\""),
 		},
 		{
 			name:       "group_id",
@@ -139,7 +139,7 @@ func TestPopulate_Basic(t *testing.T) {
 			input:      "path \"{{identity.groups.names.hroupName.id}}\" {\n\tval = {{identity.entity.name}}\n}",
 			entityName: "entityName",
 			groupName:  "groupName",
-			err:        errors.New("group not found"),
+			err:        errors.New("entity is not a member of group \"hroupName\""),
 		},
 	}
 

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -154,13 +154,25 @@ func (p *ACLPermissions) Clone() (*ACLPermissions, error) {
 // intermediary set of policies, before being compiled into
 // the ACL
 func ParseACLPolicy(rules string) (*Policy, error) {
+	return parseACLPolicyWithTemplating(rules, false, nil, nil)
+}
+
+// parseACLPolicyWithTemplating performs the actual work and checks whether we
+// should perform substitutions. If performTemplating is true we know that it
+// is templated so we don't check again, otherwise we check to see if it's a
+// templated policy.
+func parseACLPolicyWithTemplating(rules string, performTemplating bool, entity *identity.Entity, groups []*identity.Group) (*Policy, error) {
 	// Check for templating
-	hasTemplating, _, err := identity.PopulateString(&identity.PopulateStringInput{
-		ValidityCheckOnly: true,
-		String:            rules,
-	})
-	if err != nil {
-		return nil, errwrap.Wrapf("failed to validate policy templating: {{err}}", err)
+	var hasTemplating bool
+	var err error
+	if !performTemplating {
+		hasTemplating, _, err = identity.PopulateString(&identity.PopulateStringInput{
+			ValidityCheckOnly: true,
+			String:            rules,
+		})
+		if err != nil {
+			return nil, errwrap.Wrapf("failed to validate policy templating: {{err}}", err)
+		}
 	}
 
 	// Parse the rules
@@ -188,13 +200,13 @@ func ParseACLPolicy(rules string) (*Policy, error) {
 	var p Policy
 	p.Raw = rules
 	p.Type = PolicyTypeACL
-	p.Templated = hasTemplating
+	p.Templated = hasTemplating || performTemplating
 	if err := hcl.DecodeObject(&p, list); err != nil {
 		return nil, errwrap.Wrapf("failed to parse policy: {{err}}", err)
 	}
 
 	if o := list.Filter("path"); len(o.Items) > 0 {
-		if err := parsePaths(&p, o); err != nil {
+		if err := parsePaths(&p, o, performTemplating, entity, groups); err != nil {
 			return nil, errwrap.Wrapf("failed to parse policy: {{err}}", err)
 		}
 	}
@@ -202,13 +214,27 @@ func ParseACLPolicy(rules string) (*Policy, error) {
 	return &p, nil
 }
 
-func parsePaths(result *Policy, list *ast.ObjectList) error {
+func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, entity *identity.Entity, groups []*identity.Group) error {
 	paths := make([]*PathRules, 0, len(list.Items))
 	for _, item := range list.Items {
 		key := "path"
 		if len(item.Keys) > 0 {
 			key = item.Keys[0].Token.Value().(string)
 		}
+
+		// Check the path
+		if performTemplating {
+			_, templated, err := identity.PopulateString(&identity.PopulateStringInput{
+				String: key,
+				Entity: entity,
+				Groups: groups,
+			})
+			if err != nil {
+				continue
+			}
+			key = templated
+		}
+
 		valid := []string{
 			"policy",
 			"capabilities",
@@ -228,6 +254,7 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 		pc.Permissions = new(ACLPermissions)
 
 		pc.Prefix = key
+
 		if err := hcl.DecodeObject(&pc, item.Val); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("path %q:", key))
 		}

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -516,18 +516,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, names .
 					groups = append(directGroups, inheritedGroups...)
 				}
 			}
-			subst, templated, err := identity.PopulateString(&identity.PopulateStringInput{
-				String: policy.Raw,
-				Entity: entity,
-				Groups: groups,
-			})
-			if err != nil {
-				return nil, &TemplateError{Err: errwrap.Wrapf(fmt.Sprintf("error performing templating on policy %q: {{err}}", policy.Name), err)}
-			}
-			if !subst {
-				ps.logger.Warn("found templated policy that reported no substitutions", "policy", policy.Name)
-			}
-			p, err := ParseACLPolicy(templated)
+			p, err := parseACLPolicyWithTemplating(policy.Raw, true, entity, groups)
 			if err != nil {
 				return nil, errwrap.Wrapf(fmt.Sprintf("error parsing templated policy %q: {{err}}", policy.Name), err)
 			}

--- a/website/source/docs/concepts/policies.html.md
+++ b/website/source/docs/concepts/policies.html.md
@@ -227,9 +227,9 @@ credentials, the policy would grant `read` access on the appropriate path.
 
 ## Templated Policies
 
-The policy syntax allows for doing variable replacement in the policy strings
+The policy syntax allows for doing variable replacement in some policy strings
 with values available to the token. Currently `identity` information can be
-injected into policies.
+injected, and currently the `path` keys in policies allow injection.
 
 ### Parameters
 
@@ -243,6 +243,8 @@ injected into policies.
 | `identity.entity.aliases.<<mount accessor>>.metadata.<<metadata key>>` | Metadata associated with the alias for the given mount and metadata key      |
 | `identity.groups.ids.<<group id>>.name`                                | The group name for the given group ID                                        |
 | `identity.groups.names.<<group name>>.id`                              | The group ID for the given group name                                        |
+| `identity.groups.names.<<group id>>.metadata.<<metadata key>>`         | Metadata associated with the group for the given key                                        |
+| `identity.groups.names.<<group name>>.metadata.<<metadata key>>`       | Metadata associated with the group for the given key                                        |
 
 ### Examples
 
@@ -272,9 +274,10 @@ path "secret/metadata/groups/{{identity.groups.ids.fb036ebc-2f62-4124-9503-42aa7
 }
 ```
 
-~> When developing templated policies, use IDs wherever possible.  Each ID is unique to the user and names can change over
-time. This ensures that if a given user or group name is changed, the policy will be mapped to the intended entity
-or group.
+ ~> When developing templated policies, use IDs wherever possible. Each ID is
+ unique to the user, whereas names can change over time and can be reused. This
+ ensures that if a given user or group name is changed, the policy will be
+ mapped to the intended entity or group.
 
 ## Fine-Grained Control
 


### PR DESCRIPTION
When a templating failure happens, we now simply ignore that path,
rather than fail all access to all policies