### PR TITLE
Change deprecation warnings from 0.11 or later to 0.12.

### DIFF
--- a/command/auth.go
+++ b/command/auth.go
@@ -70,7 +70,7 @@ func (c *AuthCommand) Run(args []string) int {
 				c.UI.Warn(wrapAtLength(
 					"WARNING! The -methods flag is deprecated. Please use "+
 						"\"vault auth list\" instead. This flag will be removed in "+
-						"Vault 0.11 (or later).") + "\n")
+						"Vault 0.12.") + "\n")
 			}
 			return (&AuthListCommand{
 				BaseCommand: &BaseCommand{
@@ -83,7 +83,7 @@ func (c *AuthCommand) Run(args []string) int {
 				c.UI.Warn(wrapAtLength(
 					"WARNING! The -method-help flag is deprecated. Please use "+
 						"\"vault auth help\" instead. This flag will be removed in "+
-						"Vault 0.11 (or later).") + "\n")
+						"Vault 0.12.") + "\n")
 			}
 			// Parse the args to pull out the method, suppressing any errors because
 			// there could be other flags that we don't care about.
@@ -110,7 +110,7 @@ func (c *AuthCommand) Run(args []string) int {
 			"WARNING! The \"vault auth ARG\" command is deprecated and is now a "+
 				"subcommand for interacting with auth methods. To authenticate "+
 				"locally to Vault, use \"vault login\" instead. This backwards "+
-				"compatibility will be removed in Vault 0.11 (or later).") + "\n")
+				"compatibility will be removed in Vault 0.12.") + "\n")
 	}
 	return (&LoginCommand{
 		BaseCommand: &BaseCommand{

--- a/command/commands.go
+++ b/command/commands.go
@@ -198,7 +198,7 @@ func (c *DeprecatedCommand) Run(args []string) int {
 func (c *DeprecatedCommand) warn() {
 	c.UI.Warn(wrapAtLength(fmt.Sprintf(
 		"WARNING! The \"vault %s\" command is deprecated. Please use \"vault %s\" "+
-			"instead. This command will be removed in Vault 0.11 (or later).",
+			"instead. This command will be removed in Vault 0.12.",
 		c.Old,
 		c.New)))
 	c.UI.Warn("")

--- a/command/lease_renew.go
+++ b/command/lease_renew.go
@@ -91,22 +91,6 @@ func (c *LeaseRenewCommand) Run(args []string) int {
 		return 1
 	case 1:
 		leaseID = strings.TrimSpace(args[0])
-	case 2:
-		// Deprecation
-		// TODO: remove in 0.9.0
-		if Format(c.UI) == "table" {
-			c.UI.Warn(wrapAtLength(
-				"WARNING! Specifying INCREMENT as a second argument is deprecated. " +
-					"Please use -increment instead. This will be removed in the next " +
-					"major release of Vault."))
-		}
-		leaseID = strings.TrimSpace(args[0])
-		parsed, err := time.ParseDuration(appendDurationSuffix(args[1]))
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Invalid increment: %s", err))
-			return 1
-		}
-		increment = parsed
 	default:
 		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1-2, got %d)", len(args)))
 		return 1

--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -246,15 +246,14 @@ func (c *OperatorInitCommand) Run(args []string) int {
 	if c.flagAuto {
 		if Format(c.UI) == "table" {
 			c.UI.Warn(wrapAtLength("WARNING! -auto is deprecated. Please use " +
-				"-consul-auto instead. This will be removed in Vault 0.11 " +
-				"(or later)."))
+				"-consul-auto instead. This will be removed in Vault 0.12."))
 		}
 		c.flagConsulAuto = true
 	}
 	if c.flagCheck {
 		if Format(c.UI) == "table" {
 			c.UI.Warn(wrapAtLength("WARNING! -check is deprecated. Please use " +
-				"-status instead. This will be removed in Vault 0.11 (or later)."))
+				"-status instead. This will be removed in Vault 0.12."))
 		}
 		c.flagStatus = true
 	}

--- a/command/operator_rekey.go
+++ b/command/operator_rekey.go
@@ -282,7 +282,7 @@ func (c *OperatorRekeyCommand) Run(args []string) int {
 		if Format(c.UI) == "table" {
 			c.UI.Warn(wrapAtLength(
 				"WARNING! The -delete flag is deprecated. Please use -backup-delete " +
-					"instead. This flag will be removed in Vault 0.11 (or later)."))
+					"instead. This flag will be removed in Vault 0.12."))
 		}
 		c.flagBackupDelete = true
 	}
@@ -290,7 +290,7 @@ func (c *OperatorRekeyCommand) Run(args []string) int {
 		if Format(c.UI) == "table" {
 			c.UI.Warn(wrapAtLength(
 				"WARNING! The -retrieve flag is deprecated. Please use -backup-retrieve " +
-					"instead. This flag will be removed in Vault 0.11 (or later)."))
+					"instead. This flag will be removed in Vault 0.12."))
 		}
 		c.flagBackupRetrieve = true
 	}
@@ -298,7 +298,7 @@ func (c *OperatorRekeyCommand) Run(args []string) int {
 		if Format(c.UI) == "table" {
 			c.UI.Warn(wrapAtLength(
 				"WARNING! The -recovery-key flag is deprecated. Please use -target=recovery " +
-					"instead. This flag will be removed in Vault 0.11 (or later)."))
+					"instead. This flag will be removed in Vault 0.12."))
 		}
 		c.flagTarget = "recovery"
 	}

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -294,8 +294,7 @@ func (c *SSHCommand) Run(args []string) int {
 			"WARNING: No -role specified. Use -role to tell Vault which ssh role " +
 				"to use for authentication. In the future, you will need to tell " +
 				"Vault which role to use. For now, Vault will attempt to guess based " +
-				"on the API response. This will be removed in the Vault 0.11 (or " +
-				"later."))
+				"on the API response. This will be removed in the Vault 0.12."))
 
 		role, err := c.defaultRole(c.flagMountPoint, ip)
 		if err != nil {
@@ -322,7 +321,7 @@ func (c *SSHCommand) Run(args []string) int {
 				"on the API response. This guess involves creating a temporary " +
 				"credential, reading its type, and then revoking it. To reduce the " +
 				"number of API calls and surface area, specify -mode directly. This " +
-				"will be removed in Vault 0.11 (or later)."))
+				"will be removed in Vault 0.12."))
 		secret, cred, err := c.generateCredential(username, ip)
 		if err != nil {
 			// This is _very_ hacky, but is the only sane backwards-compatible way


### PR DESCRIPTION
Also remove a deprecated parameter that we warned would be removed since
0.8.