### PR TITLE
Order list responses

### DIFF
--- a/logical/response.go
+++ b/logical/response.go
@@ -3,6 +3,7 @@ package logical
 import (
 	"encoding/json"
 	"errors"
+	"sort"
 
 	"github.com/hashicorp/vault/helper/wrapping"
 )
@@ -113,6 +114,7 @@ func ListResponse(keys []string) *Response {
 		Data: map[string]interface{}{},
 	}
 	if len(keys) != 0 {
+		sort.Strings(keys)
 		resp.Data["keys"] = keys
 	}
 	return resp


### PR DESCRIPTION
We do this already in the CLI, but because we do it there the UI doesn't
have ordered responses.

We could put it in the UI, but it seems like we might as well just make
it nice for all API users.

Fixes #5141