### PR TITLE
Use ldaps in docs

### DIFF
--- a/website/source/api/secret/ad/index.html.md
+++ b/website/source/api/secret/ad/index.html.md
@@ -33,7 +33,7 @@ text that fulfills those requirements. `{{PASSWORD}}` must appear exactly once a
 
 ### Connection parameters
 
-* `url` (string, required) - The LDAP server to connect to. Examples: `ldap://ldap.myorg.com`, `ldaps://ldap.myorg.com:636`. This can also be a comma-delineated list of URLs, e.g. `ldap://ldap.myorg.com,ldaps://ldap.myorg.com:636`, in which case the servers will be tried in-order if there are errors during the connection process.
+* `url` (string, required) - The LDAP server to connect to. Examples: `ldaps://ldap.myorg.com`, `ldaps://ldap.myorg.com:636`. This can also be a comma-delineated list of URLs, e.g. `ldaps://ldap.myorg.com,ldaps://ldap.myorg.com:636`, in which case the servers will be tried in-order if there are errors during the connection process.
 * `starttls` (bool, optional) - If true, issues a `StartTLS` command after establishing an unencrypted connection.
 * `insecure_tls` - (bool, optional) - If true, skips LDAP server SSL certificate verification - insecure, use with caution!
 * `certificate` - (string, optional) - CA certificate to use when verifying LDAP server certificate, must be x509 PEM encoded.
@@ -72,7 +72,7 @@ $ curl \
 {
   "binddn": "domain-admin",
   "bindpass": "pa$$w0rd",
-  "url": "ldap://127.0.0.11",
+  "url": "ldaps://127.0.0.11",
   "userdn": "dc=example,dc=com"
 }
 ```
@@ -91,7 +91,7 @@ $ curl \
   "tls_min_version": "tls12",
   "ttl": 2764800,
   "upndomain": "",
-  "url": "ldap://127.0.0.11",
+  "url": "ldaps://127.0.0.11",
   "userdn": "dc=example,dc=com"
 }
 

--- a/website/source/docs/secrets/ad/index.html.md
+++ b/website/source/docs/secrets/ad/index.html.md
@@ -84,7 +84,7 @@ to generate passwords:
     $ vault write ad/config \
         binddn=$USERNAME \
         bindpass=$PASSWORD \
-        url=ldap://138.91.247.105 \
+        url=ldaps://138.91.247.105 \
         userdn='dc=example,dc=com'
     ```
 


### PR DESCRIPTION
Active directory won't perform password rotation unless using an `ldaps` connection, so steer users in the right direction.