### PR TITLE
Allow fallback to non /-suffixed path for list acling

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -218,6 +218,14 @@ func (a *ACL) Capabilities(path string) (pathCapabilities []string) {
 		capabilities = perm.CapabilitiesBitmap
 		goto CHECK
 	}
+	if op == logical.ListOperation {
+		raw, ok = a.exactRules.Get(strings.TrimSuffix(path, "/"))
+		if ok {
+			permissions = raw.(*ACLPermissions)
+			capabilities = permissions.CapabilitiesBitmap
+			goto CHECK
+		}
+	}
 
 	// Find a glob rule, default deny if no match
 	_, raw, ok = a.globRules.LongestPrefix(path)
@@ -285,6 +293,14 @@ func (a *ACL) AllowOperation(req *logical.Request) (ret *ACLResults) {
 		permissions = raw.(*ACLPermissions)
 		capabilities = permissions.CapabilitiesBitmap
 		goto CHECK
+	}
+	if op == logical.ListOperation {
+		raw, ok = a.exactRules.Get(strings.TrimSuffix(path, "/"))
+		if ok {
+			permissions = raw.(*ACLPermissions)
+			capabilities = permissions.CapabilitiesBitmap
+			goto CHECK
+		}
 	}
 
 	// Find a glob rule, default deny if no match


### PR DESCRIPTION
This works around a very, very common error where people write policies
to affect listing but forget the slash at the end. If there is no exact
rule with a slash at the end when doing a list, we look to see if there
is a rule without it, and if so, use those capabilities.

Fixes #mass-user-confusion