### PR TITLE
Fix default TTL for AWS secrets

### DIFF
--- a/ui/app/models/aws-credential.js
+++ b/ui/app/models/aws-credential.js
@@ -20,6 +20,7 @@ export default DS.Model.extend({
   }),
   ttl: attr({
     editType: 'ttl',
+    defaultValue: '3600s',
     label: 'TTL',
     helpText:
       'Specifies the TTL for the use of the STS token. Valid only when credential_type is assumed_role or federation_token.',


### PR DESCRIPTION
The default TTL was being offered as 30 minutes, and when unchanged, the
UI wouldn't send the TTL back to the backend, causing it to use the
default of 60m. Fix the TTL to default back to 1 hour.