### PR TITLE
Fix ssh command in example

### DIFF
--- a/website/source/docs/secrets/ssh/one-time-ssh-passwords.html.md
+++ b/website/source/docs/secrets/ssh/one-time-ssh-passwords.html.md
@@ -81,9 +81,9 @@ key_type       	otp
 ### Establish an SSH session
 
 ```text
-$ ssh username@localhost
+$ ssh username@x.x.x.x
 Password: <Enter OTP>
-username@ip:~$
+username@x.x.x.x:~$
 ```
 
 ### Automate it!


### PR DESCRIPTION
- SSH host name should be IP of remote server instead of `localhost`
- All other example code snippets use `x.x.x.x` as placeholder for IP address instead of `ip`