### PR TITLE
Bump minimum go version to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
   - docker
 
 go:
-  - "1.10.3"
+  - "1.11"
 
 go_import_path: github.com/hashicorp/vault
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ EXTERNAL_TOOLS=\
 	github.com/client9/misspell/cmd/misspell
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
-GO_VERSION_MIN=1.10
+GO_VERSION_MIN=1.11
 
 CGO_ENABLED=0
 ifneq ($(FDB_ENABLED), )


### PR DESCRIPTION
Otherwise, we'll run into gofmt reversions that undo what was done in #5233