### PR TITLE
Update Azure VM sizes in Reference Architecture

### DIFF
--- a/website/source/guides/operations/reference-architecture.html.md
+++ b/website/source/guides/operations/reference-architecture.html.md
@@ -79,7 +79,7 @@ CPU" in AWS terms, such as T-series instances.
 | Size  | CPU      | Memory          | Disk      | Typical Cloud Instance Types               |
 |-------|----------|-----------------|-----------|--------------------------------------------|
 | Small | 2 core   | 4-8 GB RAM      | 25 GB     | **AWS:** m5.large                          |
-|       |          |                 |           | **Azure:** Standard_A2_v2, Standard_A4_v2  |
+|       |          |                 |           | **Azure:** Standard_D2_v3                  |
 |       |          |                 |           | **GCE:** n1-standard-2, n1-standard-4      |
 | Large | 4-8 core | 16-32 GB RAM    | 50 GB     | **AWS:** m5.xlarge, m5.2xlarge             |
 |       |          |                 |           | **Azure:** Standard_D4_v3, Standard_D8_v3  |
@@ -90,10 +90,10 @@ CPU" in AWS terms, such as T-series instances.
 | Size  | CPU      | Memory          | Disk      | Typical Cloud Instance Types               |
 |-------|----------|-----------------|-----------|--------------------------------------------|
 | Small | 2 core   | 8-16 GB RAM     | 50 GB     | **AWS:** m5.large, m5.xlarge               |
-|       |          |                 |           | **Azure:** Standard_A4_v2, Standard_A8_v2  |
+|       |          |                 |           | **Azure:** Standard_D2_v3, Standard_D4_v3  |
 |       |          |                 |           | **GCE:** n1-standard-4, n1-standard-8      |
 | Large | 4-8 core | 32-64+ GB RAM   | 100 GB    | **AWS:** m5.2xlarge, m5.4xlarge            |
-|       |          |                 |           | **Azure:** Standard_D4_v3, Standard_D5_v3  |
+|       |          |                 |           | **Azure:** Standard_D4_v3, Standard_D8_v3  |
 |       |          |                 |           | **GCE:** n1-standard-16, n1-standard-32    |
 
 ### Hardware Considerations


### PR DESCRIPTION
To me, based on performance and pricing comparisons, it makes sense to use D series for everything instead of A series. A series works out lower performance and higher cost compared to the D (v3) series.