### PR TITLE
Adds metadata handling to entity-alias.

### DIFF
--- a/vault/identity_store_aliases.go
+++ b/vault/identity_store_aliases.go
@@ -45,6 +45,14 @@ This field is deprecated, use canonical_id.`,
 					Type:        framework.TypeString,
 					Description: "Name of the alias; unused for a modify",
 				},
+				"metadata": {
+					Type: framework.TypeKVPairs,
+					Description: `Metadata to be associated with the alias.
+In CLI, this parameter can be repeated multiple times, and it all gets merged together.
+For example:
+vault <command> <path> metadata=key1=value1 metadata=key2=value2
+					`,
+				},
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.UpdateOperation: i.handleAliasUpdateCommon(),
@@ -77,6 +85,14 @@ This field is deprecated, use canonical_id.`,
 				"name": {
 					Type:        framework.TypeString,
 					Description: "(Unused)",
+				},
+				"metadata": {
+					Type: framework.TypeKVPairs,
+					Description: `Metadata to be associated with the entity alias.
+In CLI, this parameter can be repeated multiple times, and it all gets merged together.
+For example:
+vault <command> <path> metadata=key1=value1 metadata=key2=value2
+					`,
 				},
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -141,6 +157,15 @@ func (i *IdentityStore) handleAliasUpdateCommon() framework.OperationFunc {
 			alias.Name = aliasName
 		}
 
+		// Get entity metadata
+		metadata, ok, err := d.GetOkErr("metadata")
+		if err != nil {
+			return logical.ErrorResponse(fmt.Sprintf("failed to parse metadata: %v", err)), nil
+		}
+		if ok {
+			alias.Metadata = metadata.(map[string]string)
+		}
+
 		// Get mount accessor
 		if mountAccessor := d.Get("mount_accessor").(string); mountAccessor == "" {
 			if alias.MountAccessor == "" {
@@ -183,14 +208,20 @@ func (i *IdentityStore) handleAliasUpdateCommon() framework.OperationFunc {
 				return nil, fmt.Errorf("existing alias is not associated with an entity")
 			}
 			if canonicalID == "" || entity.ID == canonicalID {
-				// Nothing to do
+				// Update the alias in the entity.
+				for aliasIndex, item := range entity.Aliases {
+					if item.ID == alias.ID {
+						entity.Aliases[aliasIndex] = alias
+						break
+					}
+				}
 				return nil, nil
 			}
 		}
 
 		resp := &logical.Response{}
 
-		// If we found an exisitng alias we won't hit this condition because
+		// If we found an existing alias we won't hit this condition because
 		// canonicalID being empty will result in nil being returned in the block
 		// above, so in this case we know that creating a new entity is the right
 		// thing.


### PR DESCRIPTION
Entity alias had no documentation for the metadata field and no support for writing or updating the metadata field. This adds the required code. The code to read the metadata field already existed and
is unchanged.

This closes #5248. Group aliases will still need to be fixed but I thought it would get some feedback first.