### PR TITLE
Log 'marked as sealed' at INFO instead

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1114,7 +1114,7 @@ func (c *Core) sealInternalWithOptions(grabStateLock, keepHALock bool) error {
 		return nil
 	}
 
-	c.logger.Debug("marked as sealed")
+	c.logger.Info("marked as sealed")
 
 	// Clear forwarding clients
 	c.requestForwardingConnectionLock.Lock()


### PR DESCRIPTION
This PR proposes to emit the current log message:

```
2018-09-04T17:59:16.244Z [DEBUG] core: marked as sealed
```

at **INFO** level instead:

```
2018-09-04T17:59:16.244Z [INFO] core: marked as sealed
```

The rationale is a bit better supportability since this initial indication of Vault sealing can be handy to know about in certain situations, but the majority of users log at INFO in production, which produces a much less helpful log output like the following when Vault is sealed:

```
2018-09-04T18:03:23.142Z [INFO ] core: pre-seal teardown starting
```

Doesn't quite have the same ring to it as "marked as sealed" with respect to making it clear what's going on. Can we please expose this more operator friendly line as INFO instead?