### PR TITLE
Undo make fmt

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -897,8 +897,8 @@ func (b *backend) handleRoleTagLogin(ctx context.Context, s logical.Storage, rol
 	}
 
 	return &roleTagLoginResponse{
-		Policies: rTag.Policies,
-		MaxTTL:   rTag.MaxTTL,
+		Policies:                 rTag.Policies,
+		MaxTTL:                   rTag.MaxTTL,
 		DisallowReauthentication: rTag.DisallowReauthentication,
 	}, nil
 }

--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -860,11 +860,11 @@ func (r *awsRoleEntry) ToResponseData() map[string]interface{} {
 		"resolve_aws_unique_ids":         r.ResolveAWSUniqueIDs,
 		"role_tag":                       r.RoleTag,
 		"allow_instance_migration":       r.AllowInstanceMigration,
-		"ttl":                       r.TTL / time.Second,
-		"max_ttl":                   r.MaxTTL / time.Second,
-		"policies":                  r.Policies,
-		"disallow_reauthentication": r.DisallowReauthentication,
-		"period":                    r.Period / time.Second,
+		"ttl":                            r.TTL / time.Second,
+		"max_ttl":                        r.MaxTTL / time.Second,
+		"policies":                       r.Policies,
+		"disallow_reauthentication":      r.DisallowReauthentication,
+		"period":                         r.Period / time.Second,
 	}
 
 	convertNilToEmptySlice := func(data map[string]interface{}, field string) {

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -574,12 +574,12 @@ func TestAwsEc2_RoleCrud(t *testing.T) {
 		"role_tag":                       "testtag",
 		"resolve_aws_unique_ids":         false,
 		"allow_instance_migration":       true,
-		"ttl":                       "10m",
-		"max_ttl":                   "20m",
-		"policies":                  "testpolicy1,testpolicy2",
-		"disallow_reauthentication": false,
-		"hmac_key":                  "testhmackey",
-		"period":                    "1m",
+		"ttl":                            "10m",
+		"max_ttl":                        "20m",
+		"policies":                       "testpolicy1,testpolicy2",
+		"disallow_reauthentication":      false,
+		"hmac_key":                       "testhmackey",
+		"period":                         "1m",
 	}
 
 	roleReq.Path = "role/testrole"
@@ -613,11 +613,11 @@ func TestAwsEc2_RoleCrud(t *testing.T) {
 		"resolve_aws_unique_ids":         false,
 		"role_tag":                       "testtag",
 		"allow_instance_migration":       true,
-		"ttl":                       time.Duration(600),
-		"max_ttl":                   time.Duration(1200),
-		"policies":                  []string{"testpolicy1", "testpolicy2"},
-		"disallow_reauthentication": false,
-		"period":                    time.Duration(60),
+		"ttl":                            time.Duration(600),
+		"max_ttl":                        time.Duration(1200),
+		"policies":                       []string{"testpolicy1", "testpolicy2"},
+		"disallow_reauthentication":      false,
+		"period":                         time.Duration(60),
 	}
 
 	if !reflect.DeepEqual(expected, resp.Data) {
@@ -676,9 +676,9 @@ func TestAwsEc2_RoleDurationSeconds(t *testing.T) {
 		"auth_type":                      "ec2",
 		"bound_iam_instance_profile_arn": "arn:aws:iam::123456789012:instance-profile/test-profile-name",
 		"resolve_aws_unique_ids":         false,
-		"ttl":     "10s",
-		"max_ttl": "20s",
-		"period":  "30s",
+		"ttl":                            "10s",
+		"max_ttl":                        "20s",
+		"period":                         "30s",
 	}
 
 	roleReq := &logical.Request{

--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -220,7 +220,7 @@ func TestBackend_PermittedDNSDomainsIntermediateCA(t *testing.T) {
 	// Sign the intermediate CSR using /pki
 	secret, err = client.Logical().Write("pki/root/sign-intermediate", map[string]interface{}{
 		"permitted_dns_domains": ".myvault.com",
-		"csr": intermediateCSR,
+		"csr":                   intermediateCSR,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/builtin/credential/radius/path_config.go
+++ b/builtin/credential/radius/path_config.go
@@ -104,8 +104,8 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, d *f
 
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"host": cfg.Host,
-			"port": cfg.Port,
+			"host":                       cfg.Host,
+			"port":                       cfg.Port,
 			"unregistered_user_policies": cfg.UnregisteredUserPolicies,
 			"dial_timeout":               cfg.DialTimeout,
 			"read_timeout":               cfg.ReadTimeout,

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1961,8 +1961,8 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 		Subject: pkix.Name{
 			CommonName: "foo.bar.com",
 		},
-		SerialNumber: big.NewInt(1234),
-		IsCA:         false,
+		SerialNumber:          big.NewInt(1234),
+		IsCA:                  false,
 		BasicConstraintsValid: true,
 	}
 
@@ -1992,8 +1992,8 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 		Subject: pkix.Name{
 			CommonName: "bar.foo.com",
 		},
-		SerialNumber: big.NewInt(2345),
-		IsCA:         true,
+		SerialNumber:          big.NewInt(2345),
+		IsCA:                  true,
 		BasicConstraintsValid: true,
 	}
 	ss, ssCert := getSelfSigned(template, issuer)
@@ -2576,7 +2576,7 @@ func setCerts() {
 		NotBefore:             time.Now().Add(-30 * time.Second),
 		NotAfter:              time.Now().Add(262980 * time.Hour),
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 	caBytes, err := x509.CreateCertificate(rand.Reader, caCertTemplate, caCertTemplate, cak.Public(), cak)
 	if err != nil {

--- a/builtin/logical/pki/ca_test.go
+++ b/builtin/logical/pki/ca_test.go
@@ -82,7 +82,7 @@ func TestBackend_CA_Steps(t *testing.T) {
 			NotBefore:             time.Now().Add(-30 * time.Second),
 			NotAfter:              time.Now().Add(262980 * time.Hour),
 			BasicConstraintsValid: true,
-			IsCA: true,
+			IsCA:                  true,
 		}
 		caBytes, err := x509.CreateCertificate(rand.Reader, caCertTemplate, caCertTemplate, cak.Public(), cak)
 		if err != nil {

--- a/helper/certutil/certutil_test.go
+++ b/helper/certutil/certutil_test.go
@@ -506,7 +506,7 @@ func setCerts() {
 		NotBefore:             time.Now().Add(-30 * time.Second),
 		NotAfter:              time.Now().Add(262980 * time.Hour),
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 	caBytes, err := x509.CreateCertificate(rand.Reader, caCertTemplate, caCertTemplate, caKey.Public(), caKey)
 	if err != nil {
@@ -541,7 +541,7 @@ func setCerts() {
 		NotBefore:             time.Now().Add(-30 * time.Second),
 		NotAfter:              time.Now().Add(262980 * time.Hour),
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 	intBytes, err := x509.CreateCertificate(rand.Reader, intCertTemplate, caCert, intKey.Public(), caKey)
 	if err != nil {

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -82,7 +82,7 @@ func TestHandler_cors(t *testing.T) {
 		"Access-Control-Allow-Origin":  addr,
 		"Access-Control-Allow-Headers": strings.Join(vault.StdAllowedHeaders, ","),
 		"Access-Control-Max-Age":       "300",
-		"Vary": "Origin",
+		"Vary":                         "Origin",
 	}
 
 	for expHeader, expected := range expHeaders {

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -73,9 +73,9 @@ type AESGCMBarrier struct {
 // the provided physical backend for storage.
 func NewAESGCMBarrier(physical physical.Backend) (*AESGCMBarrier, error) {
 	b := &AESGCMBarrier{
-		backend: physical,
-		sealed:  true,
-		cache:   make(map[uint32]cipher.AEAD),
+		backend:                  physical,
+		sealed:                   true,
+		cache:                    make(map[uint32]cipher.AEAD),
 		currentAESGCMVersionByte: byte(AESGCMVersion2),
 	}
 	return b, nil

--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -240,7 +240,7 @@ func (c *Core) setupCluster(ctx context.Context) error {
 				// 30 years of single-active uptime ought to be enough for anybody
 				NotAfter:              time.Now().Add(262980 * time.Hour),
 				BasicConstraintsValid: true,
-				IsCA: true,
+				IsCA:                  true,
 			}
 
 			certBytes, err := x509.CreateCertificate(rand.Reader, template, template, c.localClusterPrivateKey.Load().(*ecdsa.PrivateKey).Public(), c.localClusterPrivateKey.Load().(*ecdsa.PrivateKey))

--- a/vault/identity_store_entities_test.go
+++ b/vault/identity_store_entities_test.go
@@ -151,8 +151,8 @@ func TestIdentityStore_EntityCreateUpdate(t *testing.T) {
 
 func TestIdentityStore_CloneImmutability(t *testing.T) {
 	alias := &identity.Alias{
-		ID:   "testaliasid",
-		Name: "testaliasname",
+		ID:                     "testaliasid",
+		Name:                   "testaliasname",
 		MergedFromCanonicalIDs: []string{"entityid1"},
 	}
 

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -311,9 +311,9 @@ func (c *Core) refreshRequestForwardingConnection(ctx context.Context, clusterAd
 	c.rpcClientConnCancelFunc = cancelFunc
 	c.rpcForwardingClient = &forwardingClient{
 		RequestForwardingClient: NewRequestForwardingClient(c.rpcClientConn),
-		core:        c,
-		echoTicker:  time.NewTicker(HeartbeatInterval),
-		echoContext: dctx,
+		core:                    c,
+		echoTicker:              time.NewTicker(HeartbeatInterval),
+		echoContext:             dctx,
 	}
 	c.rpcForwardingClient.startHeartbeat()
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -952,7 +952,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 			NotBefore:             time.Now().Add(-30 * time.Second),
 			NotAfter:              time.Now().Add(262980 * time.Hour),
 			BasicConstraintsValid: true,
-			IsCA: true,
+			IsCA:                  true,
 		}
 		caBytes, err = x509.CreateCertificate(rand.Reader, caCertTemplate, caCertTemplate, caKey.Public(), caKey)
 		if err != nil {


### PR DESCRIPTION
I had merged a PR running `make fmt`, but the differences I was seeing were due to being on version 1.10 of Go vs. 1.11. I've now updated and this PR essentially reverts those changes.