### PR TITLE
EA validation of material against Vault 0.11

### DIFF
--- a/website/source/guides/operations/deployment-guide.html.md
+++ b/website/source/guides/operations/deployment-guide.html.md
@@ -6,6 +6,7 @@ description: |-
   This deployment guide covers the steps required to install and
   configure a single HashiCorp Vault cluster as defined in the
   Vault Reference Architecture
+product_version: 0.11
 ---
 
 # Vault Deployment Guide

--- a/website/source/guides/operations/reference-architecture.html.md
+++ b/website/source/guides/operations/reference-architecture.html.md
@@ -5,6 +5,7 @@ sidebar_current: "guides-operations-reference-architecture"
 description: |-
   This guide provides guidance in the best practices of Vault
   implementations through use of a reference architecture.
+product_version: 0.11
 ---
 
 # Vault Reference Architecture


### PR DESCRIPTION
The Reference Architecture and Deployment Guide have both been validated for accuracy against Vault 0.11. No changes were required from Vault 0.10.

This change adds a `product_version` variable where we can track validation even if no document updates are required.