### PR TITLE
UI - auth form prefer pathed methods 

### DIFF
--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -57,7 +57,10 @@ export default Ember.Component.extend(DEFAULTS, {
     }
     // this is here because we're changing the `with` attr and there's no way to short-circuit rendering,
     // so we'll just nav -> get new attrs -> re-render
-    if (!this.get('selectedAuth') || (this.get('selectedAuth') && !this.get('selectedAuthBackend'))) {
+    if (
+      (this.get('fetchMethods.isIdle') && !this.get('selectedAuth')) ||
+      (this.get('selectedAuth') && !this.get('selectedAuthBackend'))
+    ) {
       this.set('selectedAuth', this.firstMethod());
       this.get('router').replaceWith({
         queryParams: {

--- a/ui/tests/integration/components/auth-form-test.js
+++ b/ui/tests/integration/components/auth-form-test.js
@@ -104,11 +104,21 @@ test('it renders AdapterError style errors', function(assert) {
 });
 
 test('it renders all the supported tabs when no methods are passed', function(assert) {
+  let replaceSpy = sinon.spy(this.get('router'), 'replaceWith');
   this.render(hbs`{{auth-form cluster=cluster}}`);
-  assert.equal(component.tabs.length, BACKENDS.length, 'renders a tab for every backend');
+
+  return wait().then(() => {
+    assert.equal(component.tabs.length, BACKENDS.length, 'renders a tab for every backend');
+    assert.equal(
+      replaceSpy.getCall(0).args[0].queryParams.with,
+      'token',
+      'calls router replaceWith properly'
+    );
+  });
 });
 
 test('it renders all the supported methods and Other tab when methods are present', function(assert) {
+  let replaceSpy = sinon.spy(this.get('router'), 'replaceWith');
   let methods = {
     'foo/': {
       type: 'userpass',
@@ -128,7 +138,9 @@ test('it renders all the supported methods and Other tab when methods are presen
     assert.equal(component.tabs.length, 2, 'renders a tab for userpass and Other');
     assert.equal(component.tabs.objectAt(0).name, 'foo', 'uses the path in the label');
     assert.equal(component.tabs.objectAt(1).name, 'Other', 'second tab is the Other tab');
+    assert.equal(replaceSpy.getCall(0).args[0].queryParams.with, 'foo/', 'calls router replaceWith properly');
     server.shutdown();
+    replaceSpy.restore();
   });
 });
 


### PR DESCRIPTION
Since we moved fetching unauthed methods into the component with the addition of namespaces, the url transition would potentially fire before the ajax request was complete which lead to the UI always defaulting to `?with=token` if you didn't input a query param up front. 

This PR fixes the auth form so that it will do this transition after the ajax request has settled.

Fixes #5274 