### PR TITLE
Fix arrows on select inputs

### DIFF
--- a/ui/app/styles/core/forms.scss
+++ b/ui/app/styles/core/forms.scss
@@ -184,16 +184,16 @@ label {
   }
 }
 
-.select:not(.is-multiple)::after,
-.select:not(.is-multiple)::before {
+.select:not(.is-multiple)::after {
   border-color: $black;
   border-width: 2px;
   margin-top: 0;
-  transform: translateY(25%) rotate(-45deg);
+  transform: translateY(30%) rotate(-45deg);
 }
 
 .select:not(.is-multiple)::before {
-  transform: translateY(-75%) rotate(135deg);
+  @extend .select:not(.is-multiple)::after;
+  transform: translateY(-70%) rotate(135deg);
   z-index: 5;
 }
 


### PR DESCRIPTION
At some point in preparing for v0.11, one of the arrows on the select inputs disappeared. Luckily the broken version is still completely usable, which is probably why we didn't notice.

Before:
![image](https://user-images.githubusercontent.com/111194/45122590-80ef3e80-b121-11e8-8647-2f068a2408d1.png)

---

After:
![image](https://user-images.githubusercontent.com/111194/45122554-5dc48f00-b121-11e8-8a58-029f90754054.png)
