### PR TITLE
Config to skip TLS cert verification for etcd

### DIFF
--- a/physical/etcd/etcd3.go
+++ b/physical/etcd/etcd3.go
@@ -84,13 +84,22 @@ func newEtcd3Backend(conf map[string]string, logger log.Logger) (physical.Backen
 	cert, hasCert := conf["tls_cert_file"]
 	key, hasKey := conf["tls_key_file"]
 	ca, hasCa := conf["tls_ca_file"]
+	sskip, hasSkip := conf["tls_insecure_skip_verify"]
 	if (hasCert && hasKey) || hasCa {
 		tls := transport.TLSInfo{
 			TrustedCAFile: ca,
 			CertFile:      cert,
 			KeyFile:       key,
 		}
-
+		if hasSkip {
+			skip, err := strconv.ParseBool(sskip)
+			if err != nil {
+				return nil, errwrap.Wrapf(fmt.Sprintf("value of 'tls_insecure_skip_verify' (%v) could not be understood: {{err}}", sskip), err)
+			}
+			tls.InsecureSkipVerify = skip
+		} else {
+			tls.InsecureSkipVerify = false
+		}
 		tlscfg, err := tls.ClientConfig()
 		if err != nil {
 			return nil, err

--- a/website/source/docs/configuration/storage/etcd.html.md
+++ b/website/source/docs/configuration/storage/etcd.html.md
@@ -74,6 +74,11 @@ storage "etcd" {
 - `tls_key_file` `(string: "")` – Specifies the path to the private key for Etcd
   communication.
 
+- `tls_insecure_skip_verify` `(string: "false")` – Specifies whether verification
+  of the etcd TLS certificates can be skipped. Only applies to etcd v3 api. This
+  option should be used with caution as it makes vault vunerable to man-in-the-middle
+  attacks when communicating with etcd.
+
 ## `etcd` Examples
 
 ### DNS Discovery of cluster members


### PR DESCRIPTION
This change adds a new configuration option to the etcd backend
section. tls_insecure_skip_verify allows the user to instruct
vault to skip the verification of the certificates presented by
etcd. Setting tls_insecure_skip_verify to 'true' is a work around
to issue #4961. If a user sets tls_insecure_skip_verify to 'true'
then vault is vunerable to man-in-the-middle attacks when
communicating with etcd.

I am proposing the change as its the work-around I'm currently
using for the bug and I thought it might be useful to others. However,
given the security implications of enabling the option I understand if
you choose not to land it.