### PR TITLE
Docs: update policy read API output to address #5298

### DIFF
--- a/website/source/api/system/policy.html.md
+++ b/website/source/api/system/policy.html.md
@@ -59,7 +59,8 @@ $ curl \
 
 ```json
 {
-  "policy": "path \"secret/foo\" {..."
+  "name": "my-policy",
+  "rules": "path \"secret/*\"...
 }
 ```
 


### PR DESCRIPTION
This updates the output of the [Read Policy](https://www.vaultproject.io/api/system/policy.html#read-policy) example to be inline with => v0.11.x and resolves #5298.