### PR TITLE
Docs: clarify max_ttl in Database Secrets Create

### DIFF
--- a/website/source/api/secret/databases/index.html.md
+++ b/website/source/api/secret/databases/index.html.md
@@ -230,7 +230,7 @@ This endpoint creates or updates a role definition.
 
 - `max_ttl` `(string/int: 0)` - Specifies the maximum TTL for the leases
   associated with this role. Accepts time suffixed strings ("1h") or an integer
-  number of seconds. Defaults to system/engine default TTL time.
+  number of seconds. Defaults to system/mount default TTL time; this value is allowed to be less than the mount max TTL (or, if not set, the system max TTL), but it is not allowed to be longer. See also [The TTL General Gase](https://www.vaultproject.io/docs/concepts/tokens.html#the-general-case).
 
 - `creation_statements` `(list: <required>)` – Specifies the database
   statements executed to create and configure a user. See the plugin's API page


### PR DESCRIPTION
- Clarify max_ttl on Database Secrets Create API
- Crosslink to TTL general case docs