### PR TITLE
Update the AliCloud auth agent to match the AWS one

### DIFF
--- a/command/agent/alicloud_end_to_end_test.go
+++ b/command/agent/alicloud_end_to_end_test.go
@@ -91,9 +91,9 @@ func TestAliCloudEndToEnd(t *testing.T) {
 		Logger:    logger.Named("auth.alicloud"),
 		MountPath: "auth/alicloud",
 		Config: map[string]interface{}{
-			"role":                    "test",
-			"region":                  "us-west-1",
-			"cred_check_freq_seconds": 1,
+			"role":                     "test",
+			"region":                   "us-west-1",
+			"credential_poll_interval": 1,
 		},
 	})
 	if err != nil {

--- a/command/agent/auth/alicloud/alicloud.go
+++ b/command/agent/auth/alicloud/alicloud.go
@@ -60,9 +60,11 @@ func NewAliCloudAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 
 	// Check for an optional custom frequency at which we should poll for creds.
 	credCheckFreqSec := defaultCredCheckFreqSeconds
-	if checkFreqRaw, ok := conf.Config["cred_check_freq_seconds"]; ok {
+	if checkFreqRaw, ok := conf.Config["credential_poll_interval"]; ok {
 		if credFreq, ok := checkFreqRaw.(int); ok {
 			credCheckFreqSec = credFreq
+		} else {
+			return nil, errors.New("could not convert 'credential_poll_interval' config value to int")
 		}
 	}
 

--- a/website/source/docs/agent/autoauth/methods/alicloud.html.md
+++ b/website/source/docs/agent/autoauth/methods/alicloud.html.md
@@ -15,13 +15,13 @@ method](https://www.vaultproject.io/docs/auth/alicloud.html).
 
 The Vault agent will use the first credential it can successfully obtain in the following order:
 
-1. [Env variables](https://github.com/aliyun/alibaba-cloud-sdk-go/blob/master/sdk/auth/credentials/providers/env.go)
+1. [Environment variables](https://github.com/aliyun/alibaba-cloud-sdk-go/blob/master/sdk/auth/credentials/providers/env.go)
 2. A static credential configuration
 3. Instance metadata (recommended)
 
 Wherever possible, we recommend using instance metadata for credentials. These rotate every hour
 and require no effort on your part to provision, making instance metadata the most secure of the three methods. If 
-using instance metadata _and_ a custom `cred_check_freq_seconds`, be sure the frequency is set for 
+using instance metadata _and_ a custom `credential_poll_interval`, be sure the frequency is set for 
 less than an hour, because instance metadata credentials expire every hour.
 
 Environment variables are given first precedence to provide the ability to quickly override your
@@ -35,7 +35,7 @@ configuration.
 
 - `region` `(string: required)` - The AliCloud region in which the Vault agent resides. Example: "us-west-1".
 
-- `cred_check_freq_seconds` `(integer: optional)` - In seconds, how frequently the Vault agent should check for new credentials.
+- `credential_poll_interval` `(integer: optional)` - In seconds, how frequently the Vault agent should check for new credentials.
 
 ### Optional Static Credential Configuration (Not Preferred)
 


### PR DESCRIPTION
The AWS and AliCloud auth agents are extremely similar. Some valuable pointers came out of #5300 that apply here too, so this PR incorporates that feedback into the AliCloud agent as well.