### PR TITLE
Update AWS auth backend iam_request_headers to be TypeHeader

### DIFF
--- a/builtin/credential/aws/backend_test.go
+++ b/builtin/credential/aws/backend_test.go
@@ -20,6 +20,10 @@ import (
 	logicaltest "github.com/hashicorp/vault/logical/testing"
 )
 
+const testVaultHeaderValue = "VaultAcceptanceTesting"
+const testValidRoleName = "valid-role"
+const testInvalidRoleName = "invalid-role"
+
 func TestBackend_CreateParseVerifyRoleTag(t *testing.T) {
 	// create a backend
 	config := logical.TestBackendConfig()
@@ -1510,9 +1514,6 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	//    it allows us to login to our role
 	// 6. Pass in a request that has a validly signed request, asking for
 	//    the other role, ensure it fails
-	const testVaultHeaderValue = "VaultAcceptanceTesting"
-	const testValidRoleName = "valid-role"
-	const testInvalidRoleName = "invalid-role"
 
 	clientConfigData := map[string]interface{}{
 		"iam_server_id_header_value": testVaultHeaderValue,

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -1147,8 +1147,8 @@ func (b *backend) pathLoginUpdateIam(ctx context.Context, req *logical.Request, 
 	}
 	body := string(bodyRaw)
 
-	header := data.Get("iam_request_headers").(http.Header)
-	if len(header) == 0 {
+	headers := data.Get("iam_request_headers").(http.Header)
+	if len(headers) == 0 {
 		return logical.ErrorResponse("missing iam_request_headers"), nil
 	}
 
@@ -1161,7 +1161,7 @@ func (b *backend) pathLoginUpdateIam(ctx context.Context, req *logical.Request, 
 
 	if config != nil {
 		if config.IAMServerIdHeaderValue != "" {
-			err = validateVaultHeaderValue(header, parsedUrl, config.IAMServerIdHeaderValue)
+			err = validateVaultHeaderValue(headers, parsedUrl, config.IAMServerIdHeaderValue)
 			if err != nil {
 				return logical.ErrorResponse(fmt.Sprintf("error validating %s header: %v", iamServerIdHeader, err)), nil
 			}
@@ -1171,7 +1171,7 @@ func (b *backend) pathLoginUpdateIam(ctx context.Context, req *logical.Request, 
 		}
 	}
 
-	callerID, err := submitCallerIdentityRequest(method, endpoint, parsedUrl, body, header)
+	callerID, err := submitCallerIdentityRequest(method, endpoint, parsedUrl, body, headers)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf("error making upstream request: %v", err)), nil
 	}

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -88,9 +88,10 @@ This must match the request body included in the signature.`,
 			},
 			"iam_request_headers": {
 				Type: framework.TypeHeader,
-				Description: `Base64-encoded JSON representation of the request headers when auth_type is
-iam. This must at a minimum include the headers over
-which AWS has included a signature.`,
+				Description: `Key/value pairs of headers for use in the
+sts:GetCallerIdentity HTTP requests headers when auth_typeis iam. Can be either 
+a Base64-encoded, JSON-serialized string, or a JSON object of key/value pairs. 
+This must at a minimum include the headers over which AWS has included a  signature.`,
 			},
 			"identity": {
 				Type: framework.TypeString,

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -89,7 +89,7 @@ This must match the request body included in the signature.`,
 			"iam_request_headers": {
 				Type: framework.TypeHeader,
 				Description: `Key/value pairs of headers for use in the
-sts:GetCallerIdentity HTTP requests headers when auth_typeis iam. Can be either 
+sts:GetCallerIdentity HTTP requests headers when auth_type is iam. Can be either 
 a Base64-encoded, JSON-serialized string, or a JSON object of key/value pairs. 
 This must at a minimum include the headers over which AWS has included a  signature.`,
 			},
@@ -201,7 +201,7 @@ func validateMetadata(clientNonce, pendingTime string, storedIdentity *whitelist
 	}
 
 	// If reauthentication is disabled or if the nonce supplied matches a
-	// predefied nonce which indicates reauthentication to be disabled,
+	// predefined nonce which indicates reauthentication to be disabled,
 	// authentication will not succeed.
 	if storedIdentity.DisallowReauthentication ||
 		subtle.ConstantTimeCompare([]byte(reauthenticationDisabledNonce), []byte(clientNonce)) == 1 {

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -232,8 +232,8 @@ func TestBackend_pathLogin_IAMHeaders(t *testing.T) {
 	parsingErr := errors.New("error making upstream request: error parsing STS response")
 
 	testCases := []struct {
-		Header    interface{}
 		Name      string
+		Header    interface{}
 		ExpectErr error
 	}{
 		{

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -348,8 +348,6 @@ func defaultLoginData() (map[string]interface{}, error) {
 // use the AWS SDK), which receieves the mocked response responseFromUser
 // containing user information matching the role.
 func setupIAMTestServer() *httptest.Server {
-	base64Complete()
-
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		responseString := `<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <GetCallerIdentityResult>

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -385,14 +385,21 @@ func setupIAMTestServer() *httptest.Server {
 	}))
 }
 
+// base64Complete returns a base64 encoded auth header as expected
 func base64Complete() string {
 	min := `{"Authorization":["AWS4-HMAC-SHA256 Credential=AKIAJPQ466AIIQW4LPSQ/20180907/us-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-vault-aws-iam-server-id, Signature=97086b0531854844099fc52733fa2c88a2bfb54b2689600c6e249358a8353b52"],"Content-Length":["43"],"Content-Type":["application/x-www-form-urlencoded; charset=utf-8"],"User-Agent":["aws-sdk-go/1.14.24 (go1.11; darwin; amd64)"],"X-Amz-Date":["20180907T222145Z"],"X-Vault-Aws-Iam-Server-Id":["VaultAcceptanceTesting"]}`
 	return min
 }
+
+// base64MissingVaultID returns a base64 encoded auth header, that omits the
+// Vault ID header
 func base64MissingVaultID() string {
 	min := `{"Authorization":["AWS4-HMAC-SHA256 Credential=AKIAJPQ466AIIQW4LPSQ/20180907/us-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-vault-aws-iam-server-id, Signature=97086b0531854844099fc52733fa2c88a2bfb54b2689600c6e249358a8353b52"],"Content-Length":["43"],"Content-Type":["application/x-www-form-urlencoded; charset=utf-8"],"User-Agent":["aws-sdk-go/1.14.24 (go1.11; darwin; amd64)"],"X-Amz-Date":["20180907T222145Z"]}`
 	return min
 }
+
+// base64MissingAuthField returns a base64 encoded Auth header, that omits the
+// "Signature" part
 func base64MissingAuthField() string {
 	min := `{"Authorization":["AWS4-HMAC-SHA256 Credential=AKIAJPQ466AIIQW4LPSQ/20180907/us-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-vault-aws-iam-server-id"],"Content-Length":["43"],"Content-Type":["application/x-www-form-urlencoded; charset=utf-8"],"User-Agent":["aws-sdk-go/1.14.24 (go1.11; darwin; amd64)"],"X-Amz-Date":["20180907T222145Z"],"X-Vault-Aws-Iam-Server-Id":["VaultAcceptanceTesting"]}`
 	return min

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -285,39 +285,17 @@ func TestBackend_pathLogin_IAMHeaders(t *testing.T) {
 			ExpectErr: parsingErr,
 		},
 		{
-			Name: "Base64-complete",
-			Header: `eyJBdXRob3JpemF0aW9uIjpbIkFXUzQtSE1BQy1TSEEyNTYgQ3Jl
-ZGVudGlhbD1BS0lBSlBRNDY2QUlJUVc0TFBTUS8yMDE4MDkxMC91cy1lYXN0LTEvc3RzL2F3czRfcmVx
-dWVzdCwgU2lnbmVkSGVhZGVycz1jb250ZW50LWxlbmd0aDtjb250ZW50LXR5cGU7aG9zdDt4LWFtei1k
-YXRlO3gtdmF1bHQtYXdzLWlhbS1zZXJ2ZXItaWQsIFNpZ25hdHVyZT0xZDQ2YWRiMGQxODFhODVlMDRh
-YjAyODFjZjI5OTQ1MTljM2E0ZGIzZGQ4MTVmM2RiZDNiNDBhMjM0OGYyODc1Il0sIkNvbnRlbnQtTGVu
-Z3RoIjpbIjQzIl0sIkNvbnRlbnQtVHlwZSI6WyJhcHBsaWNhdGlvbi94LXd3dy1mb3JtLXVybGVuY29k
-ZWQ7IGNoYXJzZXQ9dXRmLTgiXSwiVXNlci1BZ2VudCI6WyJhd3Mtc2RrLWdvLzEuMTQuMjQgKGdvMS4x
-MTsgZGFyd2luOyBhbWQ2NCkiXSwiWC1BbXotRGF0ZSI6WyIyMDE4MDkxMFQyMDA5MzNaIl0sIlgtVmF1
-bHQtQXdzLUlhbS1TZXJ2ZXItSWQiOlsiVmF1bHRBY2NlcHRhbmNlVGVzdGluZyJdfQ==`,
+			Name:   "Base64-complete",
+			Header: base64Complete(),
 		},
 		{
-			Name: "Base64-incomplete-missing-header",
-			Header: `eyJBdXRob3JpemF0aW9uIjogWyJBV1M0LUhNQUMtU0hBMjU2IENyZWRlbnRpYWw9Q
-UtJQUpQUTQ2NkFJSVFXNExQU1EvMjAxODA5MDcvdXMtZWFzdC0xL3N0cy9hd3M0X3JlcXVlc3QsIFNpZ
-25lZEhlYWRlcnM9Y29udGVudC1sZW5ndGg7Y29udGVudC10eXBlO2hvc3Q7eC1hbXotZGF0ZTt4LXZhd
-Wx0LWF3cy1pYW0tc2VydmVyLWlkLCBTaWduYXR1cmU9OTcwODZiMDUzMTg1NDg0NDA5OWZjNTI3MzNmY
-TJjODhhMmJmYjU0YjI2ODk2MDBjNmUyNDkzNThhODM1M2I1MiJdLCJDb250ZW50LUxlbmd0aCI6IFsiN
-DMiXSwiQ29udGVudC1UeXBlIjogWyJhcHBsaWNhdGlvbi94LXd3dy1mb3JtLXVybGVuY29kZWQ7IGNoY
-XJzZXQ9dXRmLTgiXSwiVXNlci1BZ2VudCI6IFsiYXdzLXNkay1nby8xLjE0LjI0IChnbzEuMTE7IGRhc
-ndpbjsgYW1kNjQpIl0sIlgtQW16LURhdGUiOiBbIjIwMTgwOTA3VDIyMjE0NVoiXX0=`,
+			Name:      "Base64-incomplete-missing-header",
+			Header:    base64MissingVaultID(),
 			ExpectErr: missingHeaderErr,
 		},
 		{
-			Name: "Base64-incomplete-missing-auth-sig",
-			Header: `eyJBdXRob3JpemF0aW9uIjogWyJBV1M0LUhNQUMtU0hBMjU2IENyZWRlbnRpYWw9Q
-UtJQUpQUTQ2NkFJSVFXNExQU1EvMjAxODA5MDcvdXMtZWFzdC0xL3N0cy9hd3M0X3JlcXVlc3QsIFNpZ
-25lZEhlYWRlcnM9Y29udGVudC1sZW5ndGg7Y29udGVudC10eXBlO2hvc3Q7eC1hbXotZGF0ZTt4LXZhd
-Wx0LWF3cy1pYW0tc2VydmVyLWlkIl0sIkNvbnRlbnQtTGVuZ3RoIjogWyI0MyJdLCJDb250ZW50LVR5c
-GUiOiBbImFwcGxpY2F0aW9uL3gtd3d3LWZvcm0tdXJsZW5jb2RlZDsgY2hhcnNldD11dGYtOCJdLCJVc
-2VyLUFnZW50IjogWyJhd3Mtc2RrLWdvLzEuMTQuMjQgKGdvMS4xMTsgZGFyd2luOyBhbWQ2NCkiXSwiW
-C1BbXotRGF0ZSI6IFsiMjAxODA5MDdUMjIyMTQ1WiJdLCJYLVZhdWx0LUF3cy1JYW0tU2VydmVyLUlkI
-jogWyJWYXVsdEFjY2VwdGFuY2VUZXN0aW5nIl19`,
+			Name:      "Base64-incomplete-missing-auth-sig",
+			Header:    base64MissingAuthField(),
 			ExpectErr: parsingErr,
 		},
 	}
@@ -370,6 +348,8 @@ func defaultLoginData() (map[string]interface{}, error) {
 // use the AWS SDK), which receieves the mocked response responseFromUser
 // containing user information matching the role.
 func setupIAMTestServer() *httptest.Server {
+	base64Complete()
+
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		responseString := `<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <GetCallerIdentityResult>
@@ -403,4 +383,17 @@ func setupIAMTestServer() *httptest.Server {
 		}
 		fmt.Fprintln(w, responseString)
 	}))
+}
+
+func base64Complete() string {
+	min := `{"Authorization":["AWS4-HMAC-SHA256 Credential=AKIAJPQ466AIIQW4LPSQ/20180907/us-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-vault-aws-iam-server-id, Signature=97086b0531854844099fc52733fa2c88a2bfb54b2689600c6e249358a8353b52"],"Content-Length":["43"],"Content-Type":["application/x-www-form-urlencoded; charset=utf-8"],"User-Agent":["aws-sdk-go/1.14.24 (go1.11; darwin; amd64)"],"X-Amz-Date":["20180907T222145Z"],"X-Vault-Aws-Iam-Server-Id":["VaultAcceptanceTesting"]}`
+	return min
+}
+func base64MissingVaultID() string {
+	min := `{"Authorization":["AWS4-HMAC-SHA256 Credential=AKIAJPQ466AIIQW4LPSQ/20180907/us-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-vault-aws-iam-server-id, Signature=97086b0531854844099fc52733fa2c88a2bfb54b2689600c6e249358a8353b52"],"Content-Length":["43"],"Content-Type":["application/x-www-form-urlencoded; charset=utf-8"],"User-Agent":["aws-sdk-go/1.14.24 (go1.11; darwin; amd64)"],"X-Amz-Date":["20180907T222145Z"]}`
+	return min
+}
+func base64MissingAuthField() string {
+	min := `{"Authorization":["AWS4-HMAC-SHA256 Credential=AKIAJPQ466AIIQW4LPSQ/20180907/us-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-vault-aws-iam-server-id"],"Content-Length":["43"],"Content-Type":["application/x-www-form-urlencoded; charset=utf-8"],"User-Agent":["aws-sdk-go/1.14.24 (go1.11; darwin; amd64)"],"X-Amz-Date":["20180907T222145Z"],"X-Vault-Aws-Iam-Server-Id":["VaultAcceptanceTesting"]}`
+	return min
 }

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -2,14 +2,11 @@ package awsauth
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -173,46 +170,6 @@ func TestBackend_validateVaultHeaderValue(t *testing.T) {
 	err = validateVaultHeaderValue(postHeadersSplit, requestURL, canaryHeaderValue)
 	if err != nil {
 		t.Errorf("did NOT validate valid POST request with split Authorization header: %v", err)
-	}
-}
-
-func TestBackend_pathLogin_parseIamRequestHeaders(t *testing.T) {
-	testIamParser := func(headers interface{}, expectedHeaders http.Header) error {
-		headersJSON, err := json.Marshal(headers)
-		if err != nil {
-			return fmt.Errorf("unable to JSON encode headers: %v", err)
-		}
-		headersB64 := base64.StdEncoding.EncodeToString(headersJSON)
-
-		parsedHeaders, err := parseIamRequestHeaders(headersB64)
-		if err != nil {
-			return fmt.Errorf("error parsing encoded headers: %v", err)
-		}
-		if parsedHeaders == nil {
-			return fmt.Errorf("nil result from parsing headers")
-		}
-		if !reflect.DeepEqual(parsedHeaders, expectedHeaders) {
-			return fmt.Errorf("parsed headers not equal to input headers")
-		}
-		return nil
-	}
-
-	headersGoStyle := http.Header{
-		"Header1": []string{"Value1"},
-		"Header2": []string{"Value2"},
-	}
-	headersMixedType := map[string]interface{}{
-		"Header1": "Value1",
-		"Header2": []string{"Value2"},
-	}
-
-	err := testIamParser(headersGoStyle, headersGoStyle)
-	if err != nil {
-		t.Errorf("error parsing go-style headers: %v", err)
-	}
-	err = testIamParser(headersMixedType, headersGoStyle)
-	if err != nil {
-		t.Errorf("error parsing mixed-style headers: %v", err)
 	}
 }
 

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -39,16 +39,16 @@ func TestBackend_pathLogin_getCallerIdentityResponse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if parsed_arn := parsedUserResponse.GetCallerIdentityResult[0].Arn; parsed_arn != expectedUserArn {
-		t.Errorf("expected to parse arn %#v, got %#v", expectedUserArn, parsed_arn)
+	if parsedArn := parsedUserResponse.GetCallerIdentityResult[0].Arn; parsedArn != expectedUserArn {
+		t.Errorf("expected to parse arn %#v, got %#v", expectedUserArn, parsedArn)
 	}
 
 	parsedRoleResponse, err := parseGetCallerIdentityResponse(responseFromAssumedRole)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if parsed_arn := parsedRoleResponse.GetCallerIdentityResult[0].Arn; parsed_arn != expectedRoleArn {
-		t.Errorf("expected to parn arn %#v; got %#v", expectedRoleArn, parsed_arn)
+	if parsedArn := parsedRoleResponse.GetCallerIdentityResult[0].Arn; parsedArn != expectedRoleArn {
+		t.Errorf("expected to parn arn %#v; got %#v", expectedRoleArn, parsedArn)
 	}
 
 	_, err = parseGetCallerIdentityResponse("SomeRandomGibberish")
@@ -113,7 +113,7 @@ func TestBackend_pathLogin_parseIamArn(t *testing.T) {
 
 func TestBackend_validateVaultHeaderValue(t *testing.T) {
 	const canaryHeaderValue = "Vault-Server"
-	requestUrl, err := url.Parse("https://sts.amazonaws.com/")
+	requestURL, err := url.Parse("https://sts.amazonaws.com/")
 	if err != nil {
 		t.Fatalf("error parsing test URL: %v", err)
 	}
@@ -143,27 +143,27 @@ func TestBackend_validateVaultHeaderValue(t *testing.T) {
 		"Authorization":   []string{"AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request", "SignedHeaders=content-type;host;x-amz-date;x-vault-aws-iam-server-id, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7"},
 	}
 
-	err = validateVaultHeaderValue(postHeadersMissing, requestUrl, canaryHeaderValue)
+	err = validateVaultHeaderValue(postHeadersMissing, requestURL, canaryHeaderValue)
 	if err == nil {
 		t.Error("validated POST request with missing Vault header")
 	}
 
-	err = validateVaultHeaderValue(postHeadersInvalid, requestUrl, canaryHeaderValue)
+	err = validateVaultHeaderValue(postHeadersInvalid, requestURL, canaryHeaderValue)
 	if err == nil {
 		t.Error("validated POST request with invalid Vault header value")
 	}
 
-	err = validateVaultHeaderValue(postHeadersUnsigned, requestUrl, canaryHeaderValue)
+	err = validateVaultHeaderValue(postHeadersUnsigned, requestURL, canaryHeaderValue)
 	if err == nil {
 		t.Error("validated POST request with unsigned Vault header")
 	}
 
-	err = validateVaultHeaderValue(postHeadersValid, requestUrl, canaryHeaderValue)
+	err = validateVaultHeaderValue(postHeadersValid, requestURL, canaryHeaderValue)
 	if err != nil {
 		t.Errorf("did NOT validate valid POST request: %v", err)
 	}
 
-	err = validateVaultHeaderValue(postHeadersSplit, requestUrl, canaryHeaderValue)
+	err = validateVaultHeaderValue(postHeadersSplit, requestURL, canaryHeaderValue)
 	if err != nil {
 		t.Errorf("did NOT validate valid POST request with split Authorization header: %v", err)
 	}
@@ -171,11 +171,11 @@ func TestBackend_validateVaultHeaderValue(t *testing.T) {
 
 func TestBackend_pathLogin_parseIamRequestHeaders(t *testing.T) {
 	testIamParser := func(headers interface{}, expectedHeaders http.Header) error {
-		headersJson, err := json.Marshal(headers)
+		headersJSON, err := json.Marshal(headers)
 		if err != nil {
 			return fmt.Errorf("unable to JSON encode headers: %v", err)
 		}
-		headersB64 := base64.StdEncoding.EncodeToString(headersJson)
+		headersB64 := base64.StdEncoding.EncodeToString(headersJSON)
 
 		parsedHeaders, err := parseIamRequestHeaders(headersB64)
 		if err != nil {

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -15,19 +15,6 @@ import (
 	"github.com/hashicorp/vault/logical"
 )
 
-// base 64 encoded representation of valid headers, read from dummy data and
-// extracted for re-use. It's the value from the "Default" test case that's
-// built by buildCallerIdentityLoginData above
-const headersBase64Encoded = `eyJBdXRob3JpemF0aW9uIjpbIkFXUzQtSE1BQy1TSEEyNTYgQ3Jl
-ZGVudGlhbD1BS0lBSlBRNDY2QUlJUVc0TFBTUS8yMDE4MDkxMC91cy1lYXN0LTEvc3RzL2F3czRfcmVx
-dWVzdCwgU2lnbmVkSGVhZGVycz1jb250ZW50LWxlbmd0aDtjb250ZW50LXR5cGU7aG9zdDt4LWFtei1k
-YXRlO3gtdmF1bHQtYXdzLWlhbS1zZXJ2ZXItaWQsIFNpZ25hdHVyZT0xZDQ2YWRiMGQxODFhODVlMDRh
-YjAyODFjZjI5OTQ1MTljM2E0ZGIzZGQ4MTVmM2RiZDNiNDBhMjM0OGYyODc1Il0sIkNvbnRlbnQtTGVu
-Z3RoIjpbIjQzIl0sIkNvbnRlbnQtVHlwZSI6WyJhcHBsaWNhdGlvbi94LXd3dy1mb3JtLXVybGVuY29k
-ZWQ7IGNoYXJzZXQ9dXRmLTgiXSwiVXNlci1BZ2VudCI6WyJhd3Mtc2RrLWdvLzEuMTQuMjQgKGdvMS4x
-MTsgZGFyd2luOyBhbWQ2NCkiXSwiWC1BbXotRGF0ZSI6WyIyMDE4MDkxMFQyMDA5MzNaIl0sIlgtVmF1
-bHQtQXdzLUlhbS1TZXJ2ZXItSWQiOlsiVmF1bHRBY2NlcHRhbmNlVGVzdGluZyJdfQ==`
-
 func TestBackend_pathLogin_getCallerIdentityResponse(t *testing.T) {
 	responseFromUser := `<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <GetCallerIdentityResult>
@@ -298,8 +285,16 @@ func TestBackend_pathLogin_IAMHeaders(t *testing.T) {
 			ExpectErr: parsingErr,
 		},
 		{
-			Name:   "Base64-complete",
-			Header: headersBase64Encoded,
+			Name: "Base64-complete",
+			Header: `eyJBdXRob3JpemF0aW9uIjpbIkFXUzQtSE1BQy1TSEEyNTYgQ3Jl
+ZGVudGlhbD1BS0lBSlBRNDY2QUlJUVc0TFBTUS8yMDE4MDkxMC91cy1lYXN0LTEvc3RzL2F3czRfcmVx
+dWVzdCwgU2lnbmVkSGVhZGVycz1jb250ZW50LWxlbmd0aDtjb250ZW50LXR5cGU7aG9zdDt4LWFtei1k
+YXRlO3gtdmF1bHQtYXdzLWlhbS1zZXJ2ZXItaWQsIFNpZ25hdHVyZT0xZDQ2YWRiMGQxODFhODVlMDRh
+YjAyODFjZjI5OTQ1MTljM2E0ZGIzZGQ4MTVmM2RiZDNiNDBhMjM0OGYyODc1Il0sIkNvbnRlbnQtTGVu
+Z3RoIjpbIjQzIl0sIkNvbnRlbnQtVHlwZSI6WyJhcHBsaWNhdGlvbi94LXd3dy1mb3JtLXVybGVuY29k
+ZWQ7IGNoYXJzZXQ9dXRmLTgiXSwiVXNlci1BZ2VudCI6WyJhd3Mtc2RrLWdvLzEuMTQuMjQgKGdvMS4x
+MTsgZGFyd2luOyBhbWQ2NCkiXSwiWC1BbXotRGF0ZSI6WyIyMDE4MDkxMFQyMDA5MzNaIl0sIlgtVmF1
+bHQtQXdzLUlhbS1TZXJ2ZXItSWQiOlsiVmF1bHRBY2NlcHRhbmNlVGVzdGluZyJdfQ==`,
 		},
 		{
 			Name: "Base64-incomplete-missing-header",

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -369,6 +369,8 @@ func setupIAMTestServer() *httptest.Server {
 			key := strings.Split(s, "=")
 			parts[i] = key[0]
 		}
+
+		// verify the "Authorization" header contains all the expected parts
 		expectedAuthParts := []string{"AWS4-HMAC-SHA256 Credential", "SignedHeaders", "Signature"}
 		var matchingCount int
 		for _, v := range parts {

--- a/website/source/api/auth/aws/index.html.md
+++ b/website/source/api/auth/aws/index.html.md
@@ -923,15 +923,15 @@ along with its RSA digest can be supplied to this endpoint.
   `QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNQ==` which is the
   base64 encoding of `Action=GetCallerIdentity&Version=2011-06-15`. This is
   required when using the iam auth method.
-- `iam_request_headers` `(string: <required-iam>)` - Base64-encoded,
-  JSON-serialized representation of the sts:GetCallerIdentity HTTP request
-  headers. The JSON serialization assumes that each header key maps to either a
-  string value or an array of string values (though the length of that array
-  will probably only be one). If the `iam_server_id_header_value` is configured
-  in Vault for the aws auth mount, then the headers must include the
-  X-Vault-AWS-IAM-Server-ID header, its value must match the value configured,
-  and the header must be included in the signed headers.  This is required when
-  using the iam auth method.
+- `iam_request_headers` `(string: <required-iam>)` - Key/value pairs of headers
+  for use in the `sts:GetCallerIdentity` HTTP requests headers. Can be either a
+  Base64-encoded, JSON-serialized string, or a JSON object of key/value pairs. The
+  JSON serialization assumes that each header key maps to either a string value or
+  an array of string values (though the length of that array will probably only be
+  one). If the `iam_server_id_header_value` is configured in Vault for the aws
+  auth mount, then the headers must include the X-Vault-AWS-IAM-Server-ID header,
+  its value must match the value configured, and the header must be included in
+  the signed headers.  This is required when using the iam auth method.
 
 
 ### Sample Payload


### PR DESCRIPTION
Use `TypeHeader` introduced in https://github.com/hashicorp/vault/pull/4993 for the AWS auth backend's `iam_request_headers` input. The current behavior only allows base64 encoded strings. This PR updates that to support base64 strings as well as JSON headers as mentioned in #4993