### PR TITLE
Support external-id with AWS STS:AssumeRole

### DIFF
--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -33,6 +33,10 @@ func pathUser(b *backend) *framework.Path {
 				Description: "Lifetime of the returned credentials in seconds",
 				Default:     3600,
 			},
+			"external_id": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "STS external ID",
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -69,6 +73,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		ttl = int64(d.Get("ttl").(int))
 	}
 	roleArn := d.Get("role_arn").(string)
+	externalId := d.Get("external_id").(string)
 
 	var credentialType string
 	switch {
@@ -114,7 +119,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		case !strutil.StrListContains(role.RoleArns, roleArn):
 			return logical.ErrorResponse(fmt.Sprintf("role_arn %q not in allowed role arns for Vault role %q", roleArn, roleName)), nil
 		}
-		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, ttl)
+		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, externalId, ttl)
 	case federationTokenCred:
 		return b.secretTokenCreate(ctx, req.Storage, req.DisplayName, roleName, role.PolicyDocument, ttl)
 	default:

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -111,7 +111,7 @@ func (b *backend) secretTokenCreate(ctx context.Context, s logical.Storage,
 }
 
 func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
-	displayName, roleName, roleArn, policy string,
+	displayName, roleName, roleArn, policy, externalId string,
 	lifeTimeInSeconds int64) (*logical.Response, error) {
 	stsClient, err := b.clientSTS(ctx, s)
 	if err != nil {
@@ -127,6 +127,10 @@ func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 	}
 	if policy != "" {
 		assumeRoleInput.SetPolicy(policy)
+	}
+
+	if externalId != "" {
+		assumeRoleInput.SetExternalId(externalId)
 	}
 	tokenResp, err := stsClient.AssumeRole(assumeRoleInput)
 


### PR DESCRIPTION
Support external id at sts:assumerole time.

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html

This is a rewrite, taking comments into account, of the larger patch set initialy sent in #5033
(also re-pushed in #5033 over the previous commit, but lost in the previous discussion).

