### PR TITLE
Add POC for discussion around CAS method on backends

### DIFF
--- a/physical/physical.go
+++ b/physical/physical.go
@@ -56,6 +56,10 @@ type HABackend interface {
 	HAEnabled() bool
 }
 
+type CASBackend interface {
+	PutCAS(ctx context.Context, entry *Entry) error
+}
+
 // ToggleablePurgemonster is an interface for backends that can toggle on or
 // off special functionality and/or support purging. This is only used for the
 // cache, don't use it for other things.


### PR DESCRIPTION
This is more of a POC than a PR, but I find it easiest to discuss in code.

One of the challenges with initialization currently is that if two Vault servers simultaneously try to initialize the same storage backend, there's a race and they might both initialize, overwriting the other one. Then you have Vault servers with in-memory keys that they think are correct, but have actually been overwritten by another Vault server that tried to initialize at the same time.

As such, I propose added a `PutCAS` method on physical.Backend (in the form of an optionally implemented interface). If implemented, operations like init would use this CAS operation instead of the regular put operation. This would prevent overwriting and would at least return an error (that we could retry on). 

While the init function does first check if the backend is initialized before proceeding, it's possible that another backend initializes between that check and when the actual initialization call is made a few lines down. Adding a CAS method that backends could implement would make some backends safer to start a collection of Vault servers in parallel.

/cc @jefferai @chrishoffman 