### PR TITLE
Documentation correction - update list identity whitelist sample request

### DIFF
--- a/website/source/api/auth/aws/index.html.md
+++ b/website/source/api/auth/aws/index.html.md
@@ -1163,7 +1163,7 @@ $ curl \
 $ curl \
     --header "X-Vault-Token: ..." \
     --request LIST \
-    http://127.0.0.1:8200/v1/auth/aws/roletag-blacklist
+    http://127.0.0.1:8200/v1/auth/aws/identity-whitelist
 ```
 
 ### Sample Response


### PR DESCRIPTION
Path was incorrectly referencing the roletag-blacklist

Updated the sample to match the correct path