### PR TITLE
Update AWS secrets engine documentation 

### DIFF
--- a/website/source/api/secret/aws/index.html.md
+++ b/website/source/api/secret/aws/index.html.md
@@ -325,39 +325,19 @@ $ curl \
     http://127.0.0.1:8200/v1/aws/roles/example-role
 ```
 
-## Generate Credentials
+## Generate IAM Credentials
 
-This endpoint generates credentials based on the named role. This role must be
+This endpoint generates IAM credentials based on the named role. This role must be
 created before queried.
 
 | Method   | Path                         | Produces               |
 | :------- | :--------------------------- | :--------------------- |
 | `GET`    | `/aws/creds/:name`           | `200 application/json` |
-| `GET`    | `/aws/sts/:name`             | `200 application/json` |
-
-The `/aws/creds` and `/aws/sts` endpoints are almost identical. The exception is
-when retrieving credentials for a role that was specified with the legacy `arn`
-or `policy` parameter. In this case, credentials retrieved through `/aws/sts`
-must be of either the `assumed_role` or `federation_token` types, and
-credentials retrieved through `/aws/creds` must be of the `iam_user` type.
 
 ### Parameters
 
 - `name` `(string: <required>)` – Specifies the name of the role to generate
   credentials against. This is part of the request URL.
-- `role_arn` `(string)` – The ARN of the role to assume if `credential_type` on
-  the Vault role is `assumed_role`. Must match one of the allowed role ARNs in
-  the Vault role. Optional if the Vault role only allows a single AWS role ARN;
-  required otherwise.
-- `ttl` `(string: "3600s")` – Specifies the TTL for the use of the STS token.
-  This is specified as a string with a duration suffix. Valid only when
-  `credential_type` is `assumed_role` or `federation_token`. AWS places limits
-  on the maximum TTL allowed. See the AWS documentation on the `DurationSeconds`
-  parameter for
-  [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
-  (for `assumed_role` credential types) and
-  [GetFederationToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html)
-  (for `federation_token` credential types) for more details.
 
 ### Sample Request
 
@@ -378,3 +358,63 @@ $ curl \
   }
 }
 ```
+
+## Generate IAM Credentials with STS
+
+This endpoint generates IAM credentials with an STS token based on the named role. This role must be
+created before queried.
+
+| Method   | Path                         | Produces               |
+| :------- | :--------------------------- | :--------------------- |
+| `POST`    | `/aws/creds/:name`           | `200 application/json` |
+| `POST`    | `/aws/sts/:name`             | `200 application/json` |
+
+The `/aws/sts` endpoint is deprecated but available for backwards compatibility with roles that were specified with the legacy `arn` or `policy` parameters. 
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name of the role to generate
+  credentials against. This is part of the request URL.
+- `role_arn` `(string)` – The ARN of the role to assume if `credential_type` on
+  the Vault role is `assumed_role`. Must match one of the allowed role ARNs in
+  the Vault role. Optional if the Vault role only allows a single AWS role ARN;
+  required otherwise.
+- `ttl` `(string: "3600s")` – Specifies the TTL for the use of the STS token.
+  This is specified as a string with a duration suffix. AWS places limits
+  on the maximum TTL allowed. See the AWS documentation on the `DurationSeconds`
+  parameter for
+  [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
+  (for `assumed_role` credential types) and
+  [GetFederationToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html)
+  (for `federation_token` credential types) for more details.
+
+### Sample Payload
+
+```json
+{
+  "ttl": "900s"
+}
+```
+
+### Sample Request
+
+```
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/aws/creds/example-role
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "access_key": "AKIA...",
+    "secret_key": "xlCs...",
+    "security_token": "429255"
+  }
+}
+```
+

--- a/website/source/docs/secrets/aws/index.html.md
+++ b/website/source/docs/secrets/aws/index.html.md
@@ -252,12 +252,12 @@ that overrides the allow.)
 ```
 
 To generate a new set of STS federation token credentials, we simply write to
-the role using the aws/sts endpoint:
+the role using the aws/creds endpoint:
 
 ```text
-$ vault write aws/sts/ec2_admin ttl=60m
+$ vault write aws/creds/ec2_admin ttl=60m
 Key            	Value
-lease_id       	aws/sts/ec2_admin/31d771a6-fb39-f46b-fdc5-945109106422
+lease_id       	aws/creds/ec2_admin/31d771a6-fb39-f46b-fdc5-945109106422
 lease_duration 	60m0s
 lease_renewable	true
 access_key     	ASIAJYYYY2AA5K4WIXXX
@@ -342,12 +342,12 @@ $ vault write aws/roles/deploy \
 ```
 
 To generate a new set of STS assumed role credentials, we again write to
-the role using the aws/sts endpoint:
+the role using the aws/creds endpoint:
 
 ```text
-$ vault write aws/sts/deploy ttl=60m
+$ vault write aws/creds/deploy ttl=60m
 Key            	Value
-lease_id       	aws/sts/deploy/31d771a6-fb39-f46b-fdc5-945109106422
+lease_id       	aws/creds/deploy/31d771a6-fb39-f46b-fdc5-945109106422
 lease_duration 	60m0s
 lease_renewable	true
 access_key     	ASIAJYYYY2AA5K4WIXXX


### PR DESCRIPTION
Updated AWS Secrets API docs to clarify:
1. aws/creds is a GET for IAM and a POST for sts 
2. Add clarification that aws/sts is deprecated & available for backwards compatibility
3. Add example payload for aws/creds for sts

I did this by separating the aws/creds into two sections, to make it clearer for users. Happy to edit this if it should be two subsections under one header instead. 

Updated AWS Secrets Engine docs to use aws/creds rather than aws/sts in examples for STS tokens.