### PR TITLE
Allow force restore for Transit Key Restores

### DIFF
--- a/builtin/logical/transit/path_restore.go
+++ b/builtin/logical/transit/path_restore.go
@@ -19,6 +19,11 @@ func (b *backend) pathRestore() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "If set, this will be the name of the restored key.",
 			},
+			"force": &framework.FieldSchema{
+				Type:        framework.TypeBool,
+				Description: "If set and a key by the given name exists, force the restore operation and override the key.",
+				Default:     false,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -32,11 +37,12 @@ func (b *backend) pathRestore() *framework.Path {
 
 func (b *backend) pathRestoreUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	backupB64 := d.Get("backup").(string)
+	force := d.Get("force").(bool)
 	if backupB64 == "" {
 		return logical.ErrorResponse("'backup' must be supplied"), nil
 	}
 
-	return nil, b.lm.RestorePolicy(ctx, req.Storage, d.Get("name").(string), backupB64)
+	return nil, b.lm.RestorePolicy(ctx, req.Storage, d.Get("name").(string), backupB64, force)
 }
 
 const pathRestoreHelpSyn = `Restore the named key`

--- a/builtin/logical/transit/path_restore_test.go
+++ b/builtin/logical/transit/path_restore_test.go
@@ -129,6 +129,7 @@ func TestTransit_Restore(t *testing.T) {
 			ExpectedErr: keyExitsError,
 		},
 	}
+
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			var resp *logical.Response
@@ -176,7 +177,6 @@ func TestTransit_Restore(t *testing.T) {
 			if err != nil && tc.ExpectedErr == nil {
 				t.Fatalf("unexpected error:%s", err)
 			}
-			// TODO Check errors match
 
 			if err != nil && tc.ExpectedErr != nil {
 				if err.Error() != tc.ExpectedErr.Error() {

--- a/builtin/logical/transit/path_restore_test.go
+++ b/builtin/logical/transit/path_restore_test.go
@@ -78,9 +78,12 @@ func TestTransit_Restore(t *testing.T) {
 		t.Fatalf("resp: %#v\nerr: %v", resp, err)
 	}
 
+	// helper func to get a pointer value for a boolean
 	boolPtr := func(b bool) *bool {
 		return &b
 	}
+
+	keyExitsError := fmt.Errorf("key \"%s\" already exists", keyName)
 
 	testCases := []struct {
 		Name string
@@ -100,7 +103,7 @@ func TestTransit_Restore(t *testing.T) {
 			// key already exists
 			Name:        "Restore-without-force",
 			Seed:        true,
-			ExpectedErr: fmt.Errorf("key \"%s\" already exists", keyName),
+			ExpectedErr: keyExitsError,
 		},
 		{
 			// key already exists, use force to force a restore
@@ -112,6 +115,18 @@ func TestTransit_Restore(t *testing.T) {
 			// using force shouldn't matter if the key doesn't exist
 			Name:  "Restore-with-force-no-seed",
 			Force: boolPtr(true),
+		},
+		{
+			// using force shouldn't matter if the key doesn't exist
+			Name:  "Restore-force-false",
+			Force: boolPtr(false),
+		},
+		{
+			// using false force should still error
+			Name:        "Restore-force-false",
+			Seed:        true,
+			Force:       boolPtr(false),
+			ExpectedErr: keyExitsError,
 		},
 	}
 	for _, tc := range testCases {

--- a/builtin/logical/transit/path_restore_test.go
+++ b/builtin/logical/transit/path_restore_test.go
@@ -1,0 +1,241 @@
+package transit
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/vault/helper/testhelpers"
+	"github.com/hashicorp/vault/logical"
+	"github.com/y0ssar1an/q"
+)
+
+func TestTransit_Restore(t *testing.T) {
+	// Test setup:
+	// - Create a key
+	// - Configure it to be exportable, allowing deletion, and backups
+	// - Capture backup
+	// - Delete key
+	// - Run test cases
+
+	keyType := "aes256-gcm96"
+	b, s := createBackendWithStorage(t)
+	keyName := testhelpers.RandomWithPrefix("my-key")
+	var backupKey string
+
+	// Create a key
+	keyReq := &logical.Request{
+		Path:      "keys/" + keyName,
+		Operation: logical.UpdateOperation,
+		Storage:   s,
+		Data: map[string]interface{}{
+			"type":       keyType,
+			"exportable": true,
+		},
+	}
+	resp, err := b.HandleRequest(context.Background(), keyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("resp: %#v\nerr: %v", resp, err)
+	}
+
+	// Configure the key to allow its deletion and backup
+	configReq := &logical.Request{
+		Path:      fmt.Sprintf("keys/%s/config", keyName),
+		Operation: logical.UpdateOperation,
+		Storage:   s,
+		Data: map[string]interface{}{
+			"deletion_allowed":       true,
+			"allow_plaintext_backup": true,
+		},
+	}
+	resp, err = b.HandleRequest(context.Background(), configReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("resp: %#v\nerr: %v", resp, err)
+	}
+
+	// Take a backup of the key
+	backupReq := &logical.Request{
+		Path:      "backup/" + keyName,
+		Operation: logical.ReadOperation,
+		Storage:   s,
+	}
+	resp, err = b.HandleRequest(context.Background(), backupReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("resp: %#v\nerr: %v", resp, err)
+	}
+
+	// may need to be interface
+	backupKey = resp.Data["backup"].(string)
+	if backupKey == "" {
+		t.Fatal("failed to get a backup")
+	}
+
+	// Delete the key
+	keyReq.Operation = logical.DeleteOperation
+	resp, err = b.HandleRequest(context.Background(), keyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("resp: %#v\nerr: %v", resp, err)
+	}
+
+	boolPtr := func(b bool) *bool {
+		return &b
+	}
+
+	testCases := []struct {
+		Name string
+		// Seed dermines if we start the test by restoring the initial backup we
+		// took, to test a restore operation based on the key existing or not
+		Seed bool
+		// Force is a pointer to differenciate between default false and given false
+		Force       *bool
+		ExpectedErr error
+	}{
+		{
+			// key does not already exist
+			Name: "Default restore",
+		},
+		{
+			// key already exists
+			Name:        "Restore-without-force",
+			Seed:        true,
+			ExpectedErr: fmt.Errorf("key \"%s\" already exists", keyName),
+		},
+		{
+			// key already exists, use force to force a restore
+			Name:  "Restore-with-force",
+			Seed:  true,
+			Force: boolPtr(true),
+		},
+		{
+			// using force shouldn't matter if the key doesn't exist
+			Name:  "Restore-with-force-no-seed",
+			Force: boolPtr(true),
+		},
+	}
+
+	// Each test case should start with no key present. If the 'key' parameter is in
+	// the struct, we'll start by restoring it (without force) to run that test as
+	// if the key already existed
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var resp *logical.Response
+			var err error
+			// // setup a defered function to optionally clean up after this test.
+			// // Example would be if we expect the test to 'end' with a key in
+			// // existance. We want to make sure we clear it for the next run
+			// cleanupFunc := func(t *testing.T) {
+			// 	q.Q("no cleanup specified for=", tc.Name)
+			// }
+			// defer func() { cleanupFunc(t) }()
+			if tc.Seed {
+				// restore our key to test a pre-existing key
+				seedRestoreReq := &logical.Request{
+					Path:      "restore",
+					Operation: logical.UpdateOperation,
+					Storage:   s,
+					Data: map[string]interface{}{
+						"backup": backupKey,
+					},
+				}
+
+				resp, err := b.HandleRequest(context.Background(), seedRestoreReq)
+				if resp != nil && resp.IsError() {
+					t.Fatalf("resp: %#v\nerr: %v", resp, err)
+				}
+				if err != nil && tc.ExpectedErr == nil {
+					t.Fatalf("did not expect an error in SeedKey restore: %s", err)
+				}
+
+				// cleanupFunc = func(t *testing.T) {
+				// 	// Delete the key
+				// 	keyReq.Operation = logical.DeleteOperation
+				// 	resp, err = b.HandleRequest(context.Background(), keyReq)
+				// 	if err != nil || (resp != nil && resp.IsError()) {
+				// 		t.Fatalf("resp: %#v\nerr: %v", resp, err)
+				// 	}
+				// 	q.Q("cleaned up=", tc.Name)
+				// }
+			}
+
+			restoreReq := &logical.Request{
+				Path:      "restore",
+				Operation: logical.UpdateOperation,
+				Storage:   s,
+				Data: map[string]interface{}{
+					"backup": backupKey,
+				},
+			}
+
+			if tc.Force != nil {
+				restoreReq.Data["force"] = *tc.Force
+			}
+
+			resp, err = b.HandleRequest(context.Background(), restoreReq)
+			q.Q("test resp=", resp)
+			q.Q("test err=", err)
+			if resp != nil && resp.IsError() {
+				t.Fatalf("resp: %#v\nerr: %v", resp, err)
+			}
+			if err == nil && tc.ExpectedErr != nil {
+				t.Fatalf("expected an error, but got none")
+			}
+			if err != nil && tc.ExpectedErr == nil {
+				t.Fatalf("unexpected error:%s", err)
+			}
+			// TODO Check errors match
+
+			// cleanup
+			keyReq.Operation = logical.DeleteOperation
+			resp, err = b.HandleRequest(context.Background(), keyReq)
+			if err != nil || (resp != nil && resp.IsError()) {
+				t.Fatalf("resp: %#v\nerr: %v", resp, err)
+			}
+			q.Q("cleaned up=", tc.Name)
+		})
+	}
+
+	// restoreReq := &logical.Request{
+	// 	Path:      "restore",
+	// 	Operation: logical.UpdateOperation,
+	// 	Storage:   s,
+	// 	Data: map[string]interface{}{
+	// 		"backup": backup,
+	// 	},
+	// }
+	// resp, err = b.HandleRequest(context.Background(), restoreReq)
+	// if resp != nil && resp.IsError() {
+	// 	t.Fatalf("resp: %#v\nerr: %v", resp, err)
+	// }
+	// if err == nil {
+	// 	t.Fatalf("expected an error")
+	// }
+
+	// // Try to restore the key using force
+	// restoreReq.Data = map[string]interface{}{
+	// 	"backup": backup,
+	// 	"force":  true,
+	// }
+	// resp, err = b.HandleRequest(context.Background(), restoreReq)
+	// if err != nil {
+	// 	t.Fatalf("expected 'force' to work, got error: %s", err)
+	// }
+	// if resp != nil && resp.IsError() {
+	// 	t.Fatalf("resp: %#v\nerr: %v", resp, err)
+	// }
+	// if resp != nil && err != nil {
+	// 	t.Fatalf("expected both err and resp to be nil. err (%s) resp (%#v)", err, resp)
+	// }
+
+	// // Read the key
+	// keyReq = &logical.Request{
+	// 	Path:      "keys/" + keyName,
+	// 	Operation: logical.ReadOperation,
+	// 	Storage:   s,
+	// }
+	// resp, err = b.HandleRequest(context.Background(), keyReq)
+	// if err != nil || (resp != nil && resp.IsError()) {
+	// 	t.Fatalf("resp: %#v\nerr: %v", resp, err)
+	// }
+	// q.Q("read resp=", resp)
+
+}

--- a/helper/keysutil/lock_manager.go
+++ b/helper/keysutil/lock_manager.go
@@ -108,7 +108,7 @@ func (lm *LockManager) RestorePolicy(ctx context.Context, storage logical.Storag
 	// so we don't need to re-check the cache later.
 	pRaw, ok := lm.cache.Load(name)
 	if ok && !force {
-		return fmt.Errorf(fmt.Sprintf("key %q already exists", name))
+		return fmt.Errorf("key %q already exists", name)
 	}
 
 	// Conditionally look up the policy from storage, depending on the use of
@@ -129,7 +129,7 @@ func (lm *LockManager) RestorePolicy(ctx context.Context, storage logical.Storag
 			return err
 		}
 		if p != nil && !force {
-			return fmt.Errorf(fmt.Sprintf("key %q already exists", name))
+			return fmt.Errorf("key %q already exists", name)
 		}
 	}
 
@@ -142,9 +142,7 @@ func (lm *LockManager) RestorePolicy(ctx context.Context, storage logical.Storag
 	}
 	if p != nil {
 		p.l.Lock()
-		defer func() {
-			p.l.Unlock()
-		}()
+		defer p.l.Unlock()
 	}
 
 	// Restore the archived keys

--- a/website/source/api/secret/transit/index.html.md
+++ b/website/source/api/secret/transit/index.html.md
@@ -962,10 +962,10 @@ This endpoint restores the backup as a named key. This will restore the key
 configurations and all the versions of the named key along with HMAC keys. The
 input to this endpoint should be the output of `/backup` endpoint.
 
- ~> For safety, the backend will refuse to restore to an existing key. If you
- want to reuse a key name, you must delete the key before restoring. It is a
- good idea to attempt restoring to a different key name first to verify that
- the operation successfully completes.
+ ~> For safety, by default the backend will refuse to restore to an existing
+ key. If you want to reuse a key name, it is recommended you delete the key
+ before restoring. It is a good idea to attempt restoring to a different key
+ name first to verify that the operation successfully completes. 
 
 | Method   | Path                        | Produces               |
 | :------- | :-------------------------- | :--------------------- |
@@ -978,6 +978,9 @@ input to this endpoint should be the output of `/backup` endpoint.
 
  - `name` `(string: <optional>)` - If set, this will be the name of the
    restored key.
+
+ - `force` `(bool: false)` - If set, force the restore to proceed even if a key
+   by this name already exists.
 
 ### Sample Payload
 


### PR DESCRIPTION
Adds an optional parameter `force` to the `Restore` operation of Transit keys, allowing a user to force the restoration even a key by the same name already exists. The default is false, and the current behavior remains unchanged. 

Implements https://github.com/hashicorp/vault/issues/5156