### PR TITLE
use constant where X-Vault-Token was still hardcoded

### DIFF
--- a/api/request.go
+++ b/api/request.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/hashicorp/vault/helper/consts"
+
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
 
@@ -124,7 +126,7 @@ func (r *Request) toRetryableHTTP() (*retryablehttp.Request, error) {
 	}
 
 	if len(r.ClientToken) != 0 {
-		req.Header.Set("X-Vault-Token", r.ClientToken)
+		req.Header.Set(consts.AuthHeaderName, r.ClientToken)
 	}
 
 	if len(r.WrapTTL) != 0 {

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/vault/helper/consts"
 	"github.com/hashicorp/vault/helper/jsonutil"
 )
 
@@ -68,7 +69,7 @@ func testHttpData(t *testing.T, method string, token string, addr string, body i
 	req.Header.Set("Content-Type", "application/json")
 
 	if len(token) != 0 {
-		req.Header.Set("X-Vault-Token", token)
+		req.Header.Set(consts.AuthHeaderName, token)
 	}
 
 	client := cleanhttp.DefaultClient()
@@ -89,8 +90,8 @@ func testHttpData(t *testing.T, method string, token string, addr string, body i
 			return nil
 		}
 		// mutate the subsequent redirect requests with the first Header
-		if token := via[0].Header.Get("X-Vault-Token"); len(token) != 0 {
-			req.Header.Set("X-Vault-Token", token)
+		if token := via[0].Header.Get(consts.AuthHeaderName); len(token) != 0 {
+			req.Header.Set(consts.AuthHeaderName, token)
 		}
 		return nil
 	}

--- a/vault/cluster_test.go
+++ b/vault/cluster_test.go
@@ -345,7 +345,7 @@ func testCluster_ForwardRequests(t *testing.T, c *TestClusterCore, rootToken, re
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Header.Add("X-Vault-Token", rootToken)
+	req.Header.Add(consts.AuthHeaderName, rootToken)
 	req = req.WithContext(context.WithValue(req.Context(), "original_request_path", req.URL.Path))
 
 	statusCode, header, respBytes, err := c.ForwardRequest(req)

--- a/vault/cors.go
+++ b/vault/cors.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/helper/consts"
 	"github.com/hashicorp/vault/helper/strutil"
 	"github.com/hashicorp/vault/logical"
 )
@@ -22,10 +23,10 @@ var StdAllowedHeaders = []string{
 	"X-Vault-AWS-IAM-Server-ID",
 	"X-Vault-MFA",
 	"X-Vault-No-Request-Forwarding",
-	"X-Vault-Token",
 	"X-Vault-Wrap-Format",
 	"X-Vault-Wrap-TTL",
 	"X-Vault-Policy-Override",
+	consts.AuthHeaderName,
 }
 
 // CORSConfig stores the state of the CORS configuration.


### PR DESCRIPTION
This replace the occurences of harcoded "X-Vault-Token" still present in code with the const defined in helper package