### PR TITLE
Add support for token passed Authorization Bearer header

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -576,14 +576,11 @@ func getTokenFromReq(r *http.Request) (string, error) {
 	if v := r.Header.Get("Authorization"); v != "" {
 		// Reference for Authorization header format: https://tools.ietf.org/html/rfc7236#section-3
 
-		if !strings.HasPrefix(v, "Bearer") {
-			return "", fmt.Errorf("the Authorization header scheme should be Bearer")
+		// If string does not start by Bearer, or contains any space after it. It is a formatting error
+		if !strings.HasPrefix(v, "Bearer ") || strings.LastIndexByte(v, ' ') > 7 {
+			return "", fmt.Errorf("the Authorization header provided is wrongly formatted. Please use \"Bearer <token>\"")
 		}
-		vals := strings.Split(strings.TrimSpace(strings.TrimPrefix(v, "Bearer")), " ")
-		if len(vals) < 1 {
-			return "", fmt.Errorf("the Authorization header provided is wrongly formatted")
-		}
-		return vals[0], nil
+		return v[7:], nil
 	}
 	return "", nil
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -567,18 +567,41 @@ func respondStandby(core *vault.Core, w http.ResponseWriter, reqURL *url.URL) {
 	w.WriteHeader(307)
 }
 
+// getTokenFromReq parse headers of the incoming request to extract token if present
+// it accepts Authorization Bearer (RFC6750) and X-Vault-Token header
+func getTokenFromReq(r *http.Request) (string, error) {
+	if token := r.Header.Get(consts.AuthHeaderName); token != "" {
+		return token, nil
+	}
+	if v := r.Header.Get("Authorization"); v != "" {
+		// Reference for Authorization header format: https://tools.ietf.org/html/rfc7236#section-3
+
+		if !strings.HasPrefix(v, "Bearer") {
+			return "", fmt.Errorf("the Authorization header scheme should be Bearer")
+		}
+		vals := strings.Split(strings.TrimSpace(strings.TrimPrefix(v, "Bearer")), " ")
+		if len(vals) < 1 {
+			return "", fmt.Errorf("the Authorization header provided is wrongly formatted")
+		}
+		return vals[0], nil
+	}
+	return "", nil
+}
+
 // requestAuth adds the token to the logical.Request if it exists.
 func requestAuth(core *vault.Core, r *http.Request, req *logical.Request) (*logical.Request, error) {
 	// Attach the header value if we have it
-	if v := r.Header.Get(consts.AuthHeaderName); v != "" {
-		req.ClientToken = v
+	if token, err := getTokenFromReq(r); err != nil {
+		return req, err
+	} else if token != "" {
+		req.ClientToken = token
 
 		// Also attach the accessor if we have it. This doesn't fail if it
 		// doesn't exist because the request may be to an unauthenticated
 		// endpoint/login endpoint where a bad current token doesn't matter, or
 		// a token from a Vault version pre-accessors.
-		te, err := core.LookupToken(r.Context(), v)
-		if err != nil && strings.Count(v, ".") != 2 {
+		te, err := core.LookupToken(r.Context(), token)
+		if err != nil && strings.Count(token, ".") != 2 {
 			return req, err
 		}
 		if err == nil && te != nil {

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -534,16 +534,16 @@ func TestHandler_requestAuth(t *testing.T) {
 	}
 
 	rWithAuthorization, err := http.NewRequest("GET", "v1/test/path", nil)
-	rWithAuthorization.Header.Set("Authorization", "Bearer "+token)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	rWithAuthorization.Header.Set("Authorization", "Bearer "+token)
 
 	rWithVault, err := http.NewRequest("GET", "v1/test/path", nil)
-	rWithVault.Header.Set(consts.AuthHeaderName, token)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	rWithVault.Header.Set(consts.AuthHeaderName, token)
 
 	for _, r := range []*http.Request{rWithVault, rWithAuthorization} {
 		req := logical.TestRequest(t, logical.ReadOperation, "test/path")
@@ -568,11 +568,11 @@ func TestHandler_requestAuth(t *testing.T) {
 	}
 
 	rInvalidScheme, err := http.NewRequest("GET", "v1/test/path", nil)
-	rInvalidScheme.Header.Set("Authorization", "invalid_scheme something")
-	req := logical.TestRequest(t, logical.ReadOperation, "test/path")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	rInvalidScheme.Header.Set("Authorization", "invalid_scheme something")
+	req := logical.TestRequest(t, logical.ReadOperation, "test/path")
 
 	_, err = requestAuth(core, rInvalidScheme, req)
 	if err == nil {
@@ -593,6 +593,18 @@ func TestHandler_requestAuth(t *testing.T) {
 		t.Fatalf("client token should not be filled, got %s", req.ClientToken)
 	}
 
+	rFragmentedHeader, err := http.NewRequest("GET", "v1/test/path", nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	rFragmentedHeader.Header.Set("Authorization", "Bearer something somewhat")
+	req = logical.TestRequest(t, logical.ReadOperation, "test/path")
+
+	_, err = requestAuth(core, rFragmentedHeader, req)
+	if err == nil {
+		t.Fatalf("expected an error, got none")
+	}
+
 }
 
 func TestHandler_getTokenFromReq(t *testing.T) {
@@ -605,10 +617,10 @@ func TestHandler_getTokenFromReq(t *testing.T) {
 	}
 
 	r.Header.Set("Authorization", "Bearer TOKEN NOT_GOOD_TOKEN")
-	if tok, err := getTokenFromReq(&r); err != nil {
-		t.Fatalf("expected no error, got %s", err)
-	} else if tok != "TOKEN" {
-		t.Fatalf("expected 'TOKEN' as result, got '%s'", tok)
+	if tok, err := getTokenFromReq(&r); err == nil {
+		t.Fatalf("expected an error, got none")
+	} else if tok != "" {
+		t.Fatalf("expected '' as result, got '%s'", tok)
 	}
 
 	r.Header.Set(consts.AuthHeaderName, "NEWTOKEN")

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -540,7 +540,7 @@ func TestHandler_requestAuth(t *testing.T) {
 	}
 
 	rWithVault, err := http.NewRequest("GET", "v1/test/path", nil)
-	rWithVault.Header.Set("X-Vault-Token", token)
+	rWithVault.Header.Set(consts.AuthHeaderName, token)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -611,11 +611,11 @@ func TestHandler_getTokenFromReq(t *testing.T) {
 		t.Fatalf("expected 'TOKEN' as result, got '%s'", tok)
 	}
 
-	r.Header.Set("X-Vault-Token", "NEWTOKEN")
+	r.Header.Set(consts.AuthHeaderName, "NEWTOKEN")
 	if tok, err := getTokenFromReq(&r); err != nil {
 		t.Fatalf("expected no error, got %s", err)
 	} else if tok == "TOKEN" {
-		t.Fatalf("X-Vault-Token header should be prioritized")
+		t.Fatalf("%s header should be prioritized", consts.AuthHeaderName)
 	} else if tok != "NEWTOKEN" {
 		t.Fatalf("expected 'NEWTOKEN' as result, got '%s'", tok)
 	}

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -580,10 +580,10 @@ func TestHandler_requestAuth(t *testing.T) {
 	}
 
 	rNothing, err := http.NewRequest("GET", "v1/test/path", nil)
-	req = logical.TestRequest(t, logical.ReadOperation, "test/path")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	req = logical.TestRequest(t, logical.ReadOperation, "test/path")
 
 	req, err = requestAuth(core, rNothing, req)
 	if err != nil {

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/hashicorp/vault/helper/namespace"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/vault/helper/consts"
 	"github.com/hashicorp/vault/logical"
@@ -532,7 +530,7 @@ func TestHandler_requestAuth(t *testing.T) {
 	te, err := core.LookupToken(rootCtx, token)
 
 	if err != nil {
-		t.Fatalf("err: %s, te: %s", err, spew.Sdump(te))
+		t.Fatalf("err: %s", err)
 	}
 
 	rWithAuthorization, err := http.NewRequest("GET", "v1/test/path", nil)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -101,7 +101,6 @@ func testHttpData(t *testing.T, method string, token string, addr string, body i
 		t.Fatalf("err: %s", err)
 	}
 
-	return resp
 }
 
 func testResponseStatus(t *testing.T, resp *http.Response, code int) {

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -101,6 +101,7 @@ func testHttpData(t *testing.T, method string, token string, addr string, body i
 		t.Fatalf("err: %s", err)
 	}
 
+	return resp
 }
 
 func testResponseStatus(t *testing.T, resp *http.Response, code int) {

--- a/vault/cors.go
+++ b/vault/cors.go
@@ -26,6 +26,7 @@ var StdAllowedHeaders = []string{
 	"X-Vault-Wrap-Format",
 	"X-Vault-Wrap-TTL",
 	"X-Vault-Policy-Override",
+	"Authorization",
 	consts.AuthHeaderName,
 }
 


### PR DESCRIPTION
Fixes: #5396

Similar to what has been done in https://github.com/hashicorp/consul/pull/4502
Most credits go to @mbag for the consul PR

This let users pass their token as an Authorization: Bearer XXX header [RFC-6750](https://tools.ietf.org/html/rfc6750), which is an Oauth standard.

Some software only can be configured to use Authorization headers, and don't let users specify arbitrary (i.e X-Vault-Token) header names. 

Doc will be further updated by this week in the PR