### PR TITLE
Fix server command test

### DIFF
--- a/command/server_test.go
+++ b/command/server_test.go
@@ -20,10 +20,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/physical"
+	physInmem "github.com/hashicorp/vault/physical/inmem"
 	"github.com/mitchellh/cli"
-
-	physConsul "github.com/hashicorp/vault/physical/consul"
-	physFile "github.com/hashicorp/vault/physical/file"
 )
 
 func testRandomPort(tb testing.TB) int {
@@ -56,31 +54,23 @@ func testBaseHCL(tb testing.TB) string {
 }
 
 const (
-	consulHCL = `
-backend "consul" {
-  prefix               = "foo/"
+	inmemHCL = `
+backend "inmem_ha" {
   advertise_addr       = "http://127.0.0.1:8200"
-  disable_registration = "true"
 }
 `
-	haConsulHCL = `
-ha_backend "consul" {
-  prefix               = "bar/"
+	haInmemHCL = `
+ha_backend "inmem_ha" {
   redirect_addr        = "http://127.0.0.1:8200"
-  disable_registration = "true"
 }
 `
 
-	badHAConsulHCL = `
-ha_backend "file" {
-  path = "/dev/null"
-}
+	badHAInmemHCL = `
+ha_backend "inmem" {}
 `
 
 	reloadHCL = `
-backend "file" {
-  path = "/dev/null"
-}
+backend "inmem" {}
 disable_mlock = true
 listener "tcp" {
   address       = "127.0.0.1:8203"
@@ -101,8 +91,8 @@ func testServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
 		ShutdownCh: MakeShutdownCh(),
 		SighupCh:   MakeSighupCh(),
 		PhysicalBackends: map[string]physical.Factory{
-			"file":   physFile.NewFileBackend,
-			"consul": physConsul.NewConsulBackend,
+			"inmem":    physInmem.NewInmem,
+			"inmem_ha": physInmem.NewInmemHA,
 		},
 
 		// These prevent us from random sleep guessing...
@@ -216,19 +206,19 @@ func TestServer(t *testing.T) {
 	}{
 		{
 			"common_ha",
-			testBaseHCL(t) + consulHCL,
+			testBaseHCL(t) + inmemHCL,
 			"(HA available)",
 			0,
 		},
 		{
 			"separate_ha",
-			testBaseHCL(t) + consulHCL + haConsulHCL,
+			testBaseHCL(t) + inmemHCL + haInmemHCL,
 			"HA Storage:",
 			0,
 		},
 		{
 			"bad_separate_ha",
-			testBaseHCL(t) + consulHCL + badHAConsulHCL,
+			testBaseHCL(t) + inmemHCL + badHAInmemHCL,
 			"Specified HA storage does not support HA",
 			1,
 		},


### PR DESCRIPTION
The addition of CheckMigration to the server startup process means
that physical backends in this test need to be able to respond to Get() without error.