### PR TITLE
only run cassandra RotateRootCreds test when in Travis

### DIFF
--- a/plugins/database/cassandra/cassandra_test.go
+++ b/plugins/database/cassandra/cassandra_test.go
@@ -253,6 +253,9 @@ func TestCassandra_RevokeUser(t *testing.T) {
 }
 
 func TestCassandra_RotateRootCredentials(t *testing.T) {
+	if os.Getenv("TRAVIS") != "true" {
+		t.SkipNow()
+	}
 	cleanup, address, port := prepareCassandraTestContainer(t)
 	defer cleanup()
 


### PR DESCRIPTION
according to a commit from @jefferai on tests, cassandra tests should only run if triggered by Travis
This fixes it
Also it (on our workstation, not sure if affecting everyone) make local modification to the test fixture, making the local directory dirty