### PR TITLE
fixed read-entity-by-name code

### DIFF
--- a/website/source/api/secret/identity/entity.html.md
+++ b/website/source/api/secret/identity/entity.html.md
@@ -287,7 +287,7 @@ This endpoint queries the entity by its name.
 ```
 $ curl \
     --header "X-Vault-Token: ..." \
-    http://127.0.0.1:8200/v1/identity/entity/id/testentityname
+    http://127.0.0.1:8200/v1/identity/entity/name/testentityname
 ```
 
 ### Sample Response


### PR DESCRIPTION
Not 100% this is the way it should be - check https://github.com/hashicorp/vault/issues/5421 as i couldnt get the `read entity by name` command to work