### PR TITLE
Suggest workaround when no leader has been found

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -447,7 +447,7 @@ func handleRequestForwarding(core *vault.Core, handler http.Handler) http.Handle
 			return
 		}
 		if leaderAddr == "" {
-			respondError(w, http.StatusInternalServerError, fmt.Errorf("local node not active but active cluster node not found"))
+			respondError(w, http.StatusInternalServerError, fmt.Errorf("local node not active but active cluster node not found\nThis can happen when a leader failed without releasing the lock.\nIf you know the leader will not come back, check in the storage backend and release the lock if needed"))
 			return
 		}
 


### PR DESCRIPTION
When the leader fails without releasing the lock, this can lead to a situation where no other node can acquire it and log the following message: `failed to acquire lock: error="Existing key does not match lock use"`

This change gives more information in the error message so the operator knows how to solve this issue.