### PR TITLE
UI - ent fixes

### DIFF
--- a/ui/app/adapters/cluster.js
+++ b/ui/app/adapters/cluster.js
@@ -58,7 +58,13 @@ export default ApplicationAdapter.extend({
 
   health() {
     return this.ajax(this.urlFor('health'), 'GET', {
-      data: { standbycode: 200, sealedcode: 200, uninitcode: 200, drsecondarycode: 200 },
+      data: {
+        standbycode: 200,
+        sealedcode: 200,
+        uninitcode: 200,
+        drsecondarycode: 200,
+        performancestandbycode: 200,
+      },
       unauthenticated: true,
     });
   },

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -145,7 +145,7 @@ export default Component.extend(DEFAULTS, {
           unauthenticated: true,
         },
       });
-      this.set('methods', methods.map(m => m.toJSON()));
+      this.set('methods', methods.map(m => m.serialize({ includeId: true })));
       run.next(() => {
         store.unloadAll('auth-method');
       });

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -1,3 +1,4 @@
+import { run } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { match, alias, or } from '@ember/object/computed';
 import { assign } from '@ember/polyfills';
@@ -144,9 +145,10 @@ export default Component.extend(DEFAULTS, {
           unauthenticated: true,
         },
       });
-      this.set('methods', null);
-      store.unloadAll('auth-method');
-      this.set('methods', methods);
+      this.set('methods', methods.map(m => m.toJSON()));
+      run.next(() => {
+        store.unloadAll('auth-method');
+      });
     } catch (e) {
       this.set('error', `There was an error fetching auth methods: ${e.errors[0]}`);
     }

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -138,14 +138,14 @@ export default Component.extend(DEFAULTS, {
 
   fetchMethods: task(function*() {
     let store = this.get('store');
-    this.set('methods', null);
-    store.unloadAll('auth-method');
     try {
       let methods = yield store.findAll('auth-method', {
         adapterOptions: {
           unauthenticated: true,
         },
       });
+      this.set('methods', null);
+      store.unloadAll('auth-method');
       this.set('methods', methods);
     } catch (e) {
       this.set('error', `There was an error fetching auth methods: ${e.errors[0]}`);

--- a/ui/app/components/namespace-picker.js
+++ b/ui/app/components/namespace-picker.js
@@ -14,7 +14,10 @@ export default Component.extend({
   tagName: '',
   namespaceService: service('namespace'),
   auth: service(),
+  store: service(),
   namespace: null,
+  listCapability: null,
+  canList: alias('listCapability.canList'),
 
   init() {
     this._super(...arguments);
@@ -28,10 +31,22 @@ export default Component.extend({
     let oldNS = this.get('oldNamespace');
     if (!oldNS || ns !== oldNS) {
       this.get('setForAnimation').perform();
+      this.get('fetchListCapability').perform();
     }
     this.set('oldNamespace', ns);
   },
 
+  fetchListCapability: task(function*() {
+    try {
+      if (this.listCapability) {
+        this.listCapability.unloadRecord();
+      }
+      let capability = yield this.store.findRecord('capabilities', 'sys/namespaces/');
+      this.set('listCapability', capability);
+    } catch (e) {
+      //do nothing here
+    }
+  }),
   setForAnimation: task(function*() {
     let leaves = this.get('menuLeaves');
     let lastLeaves = this.get('lastMenuLeaves');

--- a/ui/app/controllers/vault/cluster/auth.js
+++ b/ui/app/controllers/vault/cluster/auth.js
@@ -14,7 +14,7 @@ export default Controller.extend({
   redirectTo: null,
 
   updateNamespace: task(function*(value) {
-    yield timeout(200);
+    yield timeout(400);
     this.get('namespaceService').setNamespace(value, true);
     this.set('namespaceQueryParam', value);
   }).restartable(),

--- a/ui/app/controllers/vault/cluster/auth.js
+++ b/ui/app/controllers/vault/cluster/auth.js
@@ -14,7 +14,8 @@ export default Controller.extend({
   redirectTo: null,
 
   updateNamespace: task(function*(value) {
-    yield timeout(400);
+    // debounce
+    yield timeout(500);
     this.get('namespaceService').setNamespace(value, true);
     this.set('namespaceQueryParam', value);
   }).restartable(),

--- a/ui/app/controllers/vault/cluster/init.js
+++ b/ui/app/controllers/vault/cluster/init.js
@@ -21,6 +21,7 @@ export default Controller.extend(DEFAULTS, {
   initSuccess(resp) {
     this.set('loading', false);
     this.set('keyData', resp);
+    this.model.reload();
     this.get('wizard').set('initEvent', 'SAVE');
     this.get('wizard').transitionTutorialMachine(this.get('wizard.currentState'), 'TOSAVE');
   },

--- a/ui/app/models/cluster.js
+++ b/ui/app/models/cluster.js
@@ -14,7 +14,7 @@ export default DS.Model.extend({
   standby: attr('boolean'),
   type: attr('string'),
 
-  needsInit: computed('nodes', 'nodes.[]', function() {
+  needsInit: computed('nodes', 'nodes.@each.initialized', function() {
     // needs init if no nodes are initialized
     return this.get('nodes').isEvery('initialized', false);
   }),

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -70,9 +70,12 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
   },
 
   poll: task(function*() {
-    // when testing, the polling loop causes promises to never settle so acceptance tests hang
-    // to get around that, we just disable the poll in tests
-    do {
+    while (true) {
+      // when testing, the polling loop causes promises to never settle so acceptance tests hang
+      // to get around that, we just disable the poll in tests
+      if (Ember.testing) {
+        return;
+      }
       yield timeout(POLL_INTERVAL_MS);
       try {
         yield this.controller.model.reload();
@@ -80,7 +83,7 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
       } catch (e) {
         // we want to keep polling here
       }
-    } while (!Ember.testing);
+    }
   })
     .cancelOn('deactivate')
     .keepLatest(),

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -1,7 +1,6 @@
 import { alias, equal } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 const ROOT_NAMESPACE = '';
 export default Service.extend({
@@ -19,8 +18,6 @@ export default Service.extend({
   setNamespace(path) {
     this.set('path', path);
   },
-  listPath: lazyCapabilities(apiPath`sys/namespaces/`, 'path'),
-  canList: alias('listPath.canList'),
 
   findNamespacesForUser: task(function*() {
     // uses the adapter and the raw response here since

--- a/ui/app/templates/components/namespace-picker.hbs
+++ b/ui/app/templates/components/namespace-picker.hbs
@@ -33,7 +33,7 @@
             {{/if}}
           </div>
           <div class="level-right">
-            {{#if namespaceService.canList}}
+            {{#if canList}}
               {{#link-to "vault.cluster.access.namespaces" class="namespace-manage-link"}}
                 Manage
               {{/link-to}}

--- a/ui/tests/integration/components/auth-form-test.js
+++ b/ui/tests/integration/components/auth-form-test.js
@@ -155,7 +155,7 @@ module('Integration | Component | auth form', function(hooks) {
     server.shutdown();
   });
 
-  test('it calls authorize with the correct path', async function(assert) {
+  test('it calls authenticate with the correct path', async function(assert) {
     this.owner.register('service:auth', workingAuthService);
     this.auth = this.owner.lookup('service:auth');
     let authSpy = sinon.spy(this.get('auth'), 'authenticate');

--- a/ui/tests/pages/auth.js
+++ b/ui/tests/pages/auth.js
@@ -1,5 +1,4 @@
 import { create, visitable, fillable, clickable } from 'ember-cli-page-object';
-import withFlash from 'vault/tests/helpers/with-flash';
 
 export default create({
   visit: visitable('/vault/auth'),
@@ -11,6 +10,6 @@ export default create({
       return this.tokenInput(token).submit();
     }
 
-    return withFlash(this.tokenInput('root').submit());
+    return this.tokenInput('root').submit();
   },
 });

--- a/ui/tests/unit/adapters/cluster-test.js
+++ b/ui/tests/unit/adapters/cluster-test.js
@@ -16,7 +16,13 @@ module('Unit | Adapter | cluster', function(hooks) {
     adapter.health();
     assert.equal('/v1/sys/health', url, 'health url OK');
     assert.deepEqual(
-      { standbycode: 200, sealedcode: 200, uninitcode: 200, drsecondarycode: 200 },
+      {
+        standbycode: 200,
+        sealedcode: 200,
+        uninitcode: 200,
+        drsecondarycode: 200,
+        performancestandbycode: 200,
+      },
       options.data,
       'health data params OK'
     );


### PR DESCRIPTION
This is a variety of enterprise tweaks to smooth over the user experience and one bug I found related to the 3.4 update. 

Included are:
1 - adding `performancestandbycode` to the heath call
2 - stopping the auth page from jumping around as much if you type in other namespaces
3 - re-fetching the cluster model immediately after initilializing 

And the bug was that proxy cleanup bug from using `lazyCapabilities` in conjunction with things that get unloaded - I moved the fetching code into the namespace picker directly and stopped using the macro and the error stopped happening.