### PR TITLE
Update page content with a generic noun

### DIFF
--- a/website/source/api/index.html.md
+++ b/website/source/api/index.html.md
@@ -33,7 +33,7 @@ to have to do both depending on user settings.
 ## Authentication
 
 Once Vault is unsealed, almost every other operation requires a _client token_.
-A user may have a client token sent to her.  The client token must be sent as
+A user may have a client token sent to them.  The client token must be sent as
 the `X-Vault-Token` HTTP header.
 
 Otherwise, a client token can be retrieved via [authentication


### PR DESCRIPTION
This might be a typo, It says `A user may have a client token sent to her` instead it should say `A user may have a client token sent to them`