### PR TITLE
updated json format for policy rules

### DIFF
--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -60,11 +60,11 @@ func (c *Sys) GetPolicy(name string) (string, error) {
 		return "", errors.New("data from server response is empty")
 	}
 
-	if policyRaw, ok := secret.Data["policy"]; ok {
+	if policyRaw, ok := secret.Data["rules"]; ok {
 		return policyRaw.(string), nil
 	}
 
-	return "", fmt.Errorf("no policy found in response")
+	return "", fmt.Errorf("no rules found in response")
 }
 
 func (c *Sys) PutPolicy(name, rules string) error {


### PR DESCRIPTION
discovered when using terraform with vault_policy provider, against the latest changes of vault where GetPolicy now returns the capabilities wrapped in "data.rules" rather than "data.policy".