### PR TITLE
Set allowed OIDs to any value when generaing a CA.

### DIFF
--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -37,6 +37,7 @@ func (b *backend) getGenerationParams(
 		AllowIPSANs:          true,
 		EnforceHostnames:     false,
 		AllowedURISANs:       []string{"*"},
+		AllowedOtherSANs:     []string{"*"},
 		AllowedSerialNumbers: []string{"*"},
 		OU:                   data.Get("ou").([]string),
 		Organization:         data.Get("organization").([]string),

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -465,6 +465,12 @@ func validateNames(data *dataBundle, names []string) string {
 // allowed, it will be returned as the second string. Empty strings + error
 // means everything is okay.
 func validateOtherSANs(data *dataBundle, requested map[string][]string) (string, string, error) {
+	for _, val := range data.role.AllowedOtherSANs {
+		if val == "*" {
+			// Anything is allowed
+			return "", "", nil
+		}
+	}
 	allowed, err := parseOtherSANs(data.role.AllowedOtherSANs)
 	if err != nil {
 		return "", "", errwrap.Wrapf("error parsing role's allowed SANs: {{err}}", err)
@@ -504,7 +510,10 @@ func parseOtherSANs(others []string) (map[string][]string, error) {
 		if len(splitType) != 2 {
 			return nil, fmt.Errorf("expected a colon in other SAN %q", other)
 		}
-		if !strings.EqualFold(splitType[0], "utf8") {
+		switch {
+		case strings.EqualFold(splitType[0], "utf8"):
+		case strings.EqualFold(splitType[0], "utf-8"):
+		default:
 			return nil, fmt.Errorf("only utf8 other SANs are supported; found non-supported type in other SAN %q", other)
 		}
 		result[splitOther[0]] = append(result[splitOther[0]], splitType[1])

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -117,7 +117,7 @@ Any valid URI is accepted, these values support globbing.`,
 
 			"allowed_other_sans": &framework.FieldSchema{
 				Type:        framework.TypeCommaStringSlice,
-				Description: `If set, an array of allowed other names to put in SANs. These values support globbing.`,
+				Description: `If set, an array of allowed other names to put in SANs. These values support globbing and must be in the format <oid>;<type>:<value>. Currently only "utf8" is a valid type. All values, including globbing values, must use this syntax, with the exception being a single "*" which allows any OID and any value (but type must still be utf8).`,
 			},
 
 			"allowed_serial_numbers": &framework.FieldSchema{

--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -786,8 +786,11 @@ request is denied.
 
 - `allowed_other_sans` `(string: "")` – Defines allowed custom OID/UTF8-string
   SANs. This field supports globbing. The format is the same as OpenSSL:
-  `<oid>;<type>:<value>` where the only current valid type is `UTF8`. This can
-  be a comma-delimited list or a JSON string slice.
+  `<oid>;<type>:<value>` where the only current valid type is `UTF8` (or
+  `UTF-8`). This can be a comma-delimited list or a JSON string slice. All
+  values, including globbing values, must use the correct syntax, with the
+  exception being a single `*` which allows any OID and any value (but type
+  must still be UTF8).
 
 - `server_flag` `(bool: true)` – Specifies if certificates are flagged for
   server use.


### PR DESCRIPTION
Also, allow utf-8 in addition to utf8 as the OID type specifier, and
allow `*` to specify any OID of a supported type.

Fixes #5459 