### PR TITLE
Update examples to use sha256

### DIFF
--- a/website/source/api/system/plugins-catalog.html.md
+++ b/website/source/api/system/plugins-catalog.html.md
@@ -81,7 +81,7 @@ supplied name.
 
 ```json
 {
-  "sha_256": "d130b9a0fbfddef9709d8ff92e5e6053ccd246b78632fc03b8548457026961e9",
+  "sha256": "d130b9a0fbfddef9709d8ff92e5e6053ccd246b78632fc03b8548457026961e9",
   "command": "mysql-database-plugin"
 }
 ```

--- a/website/source/docs/auth/azure.html.md
+++ b/website/source/docs/auth/azure.html.md
@@ -178,7 +178,7 @@ for your server at `path/to/plugins`:
     ```text
     $ vault write sys/plugins/catalog/azure-auth \
         command="vault-plugin-auth-azure" \
-        sha_256="..."
+        sha256="..."
     ```
 
 1. Enable the azure auth method as a plugin:

--- a/website/source/docs/internals/plugins.html.md
+++ b/website/source/docs/internals/plugins.html.md
@@ -73,7 +73,7 @@ An example plugin submission looks like:
 
 ```
 $ vault write sys/plugins/catalog/myplugin-database-plugin \
-    sha_256=<expected SHA256 Hex value of the plugin binary> \
+    sha256=<expected SHA256 Hex value of the plugin binary> \
     command="myplugin"
 Success! Data written to: sys/plugins/catalog/myplugin-database-plugin
 ```

--- a/website/source/docs/secrets/databases/custom.html.md
+++ b/website/source/docs/secrets/databases/custom.html.md
@@ -102,7 +102,7 @@ this your token will need sudo permissions.
 
 ```text
 $ vault write sys/plugins/catalog/myplugin-database-plugin \
-    sha_256="..." \
+    sha256="..." \
     command="myplugin"
 Success! Data written to: sys/plugins/catalog/myplugin-database-plugin
 ```

--- a/website/source/docs/secrets/databases/oracle.html.md
+++ b/website/source/docs/secrets/databases/oracle.html.md
@@ -49,7 +49,7 @@ you will need to enable ipc_lock capabilities for the plugin binary.
 
     ```text
     $ vault write sys/plugins/catalog/oracle-database-plugin \
-        sha_256="..." \
+        sha256="..." \
         command=vault-plugin-database-oracle
     ```
 

--- a/website/source/guides/operations/plugin-backends.html.md
+++ b/website/source/guides/operations/plugin-backends.html.md
@@ -70,7 +70,7 @@ $ shasum -a 256 /etc/vault/vault_plugins/my-mock-plugin
 2c071aafa1b30897e60b79643e77592cb9d1e8f803025d44a7f9bbfa4779d615  /etc/vault/vault_plugins/my-mock-plugin
 
 $ vault write sys/plugins/catalog/my-mock-plugin \
-    sha_256=2c071aafa1b30897e60b79643e77592cb9d1e8f803025d44a7f9bbfa4779d615 \
+    sha256=2c071aafa1b30897e60b79643e77592cb9d1e8f803025d44a7f9bbfa4779d615 \
     command=my-mock-plugin
 Success! Data written to: sys/plugins/catalog/my-mock-plugin
 ```


### PR DESCRIPTION
sha_256 is supported but not referenced in our API docs.