### PR TITLE
Add a check to prevent panics

### DIFF
--- a/helper/ldaputil/client.go
+++ b/helper/ldaputil/client.go
@@ -377,6 +377,10 @@ func (c *Client) GetLdapGroups(cfg *ConfigEntry, conn Connection, userDN string,
 
 // EscapeLDAPValue is exported because a plugin uses it outside this package.
 func EscapeLDAPValue(input string) string {
+	if input == "" {
+		return ""
+	}
+
 	// RFC4514 forbids un-escaped:
 	// - leading space or hash
 	// - trailing space

--- a/helper/ldaputil/client_test.go
+++ b/helper/ldaputil/client_test.go
@@ -11,6 +11,7 @@ func TestLDAPEscape(t *testing.T) {
 		"test,hel+lo": "test\\,hel\\+lo",
 		"test\\hello": "test\\\\hello",
 		"  test  ":    "\\  test \\ ",
+		"":            "",
 	}
 
 	for test, answer := range testcases {


### PR DESCRIPTION
Solves a panic with `EscapeLDAPValue` if its input was an empty string.