### PR TITLE
Fix 'vault auth' panic

### DIFF
--- a/command/auth.go
+++ b/command/auth.go
@@ -62,6 +62,10 @@ func (c *AuthCommand) Run(args []string) int {
 	// Deprecation
 	// TODO: remove in 0.9.0
 
+	if len(args) == 0 {
+		return cli.RunResultHelp
+	}
+
 	// Parse the args for our deprecations and defer to the proper areas.
 	for _, arg := range args {
 		switch {


### PR DESCRIPTION
Running 'vault auth' with no parameters was panicking:

```
panic: assignment to entry in nil map
	github.com/hashicorp/vault/command/login.go:255 +0xdee
```

Now it will show help, like other commands with subcommands.