### PR TITLE
UI - kv v2 models

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
   },
   rules: {
     'no-unused-vars': ['error', { ignoreRestSiblings: true }],
-    'eol-last': 'never',
   },
   globals: {
     TextEncoderLite: true,

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
   },
   rules: {
     'no-unused-vars': ['error', { ignoreRestSiblings: true }],
+    'eol-last': 'never',
   },
   globals: {
     TextEncoderLite: true,

--- a/ui/app/adapters/secret-v2-version.js
+++ b/ui/app/adapters/secret-v2-version.js
@@ -1,10 +1,11 @@
+/* eslint-disable */
 import { isEmpty } from '@ember/utils';
 import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
   namespace: 'v1',
-  _url(backend, id) {
-    let url = `${this.buildURL()}/${backend}/data/`;
+  _url(backend, id, infix = 'data') {
+    let url = `${this.buildURL()}/${backend}/${infix}/`;
     if (!isEmpty(id)) {
       url = url + id;
     }
@@ -16,8 +17,37 @@ export default ApplicationAdapter.extend({
     return this._url(backend, path) + `?version=${version}`;
   },
 
+  urlForCreateRecord(modelName, snapshot) {
+    let backend = snapshot.belongsTo('secret').belongsTo('engine').id;
+    let path = snapshot.attr('path');
+    return this._url(backend, path);
+  },
+
+  createRecord(store, modelName, snapshot) {
+    let backend = snapshot.belongsTo('secret').belongsTo('engine').id;
+    let path = snapshot.attr('path');
+    return this._super(...arguments).then(resp => {
+      resp.id = JSON.stringify([backend, path, resp.version]);
+      return resp;
+    });
+  },
+
+  urlForUpdateRecord(id) {
+    let [backend, path] = JSON.parse(id);
+    return this._url(backend, path);
+  },
+
   deleteRecord(store, type, snapshot) {
     // use adapterOptions to determine if it's delete or destroy for the version
+    // deleteType should be 'delete', 'destroy', 'undelete'
+    let infix = snapshot.adapterOptions.deleteType;
+    let [backend, path, version] = JSON.parse(snapshot.id);
+
+    return this.ajax(this._url(backend, path, infix), 'POST', { data: { versions: [version] } });
+  },
+
+  handleResponse(/*status, headers, payload, requestData*/) {
+    // the body of the 404 will have some relevant information
     return this._super(...arguments);
   },
 });

--- a/ui/app/adapters/secret-v2-version.js
+++ b/ui/app/adapters/secret-v2-version.js
@@ -1,0 +1,23 @@
+import { isEmpty } from '@ember/utils';
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+  namespace: 'v1',
+  _url(backend, id) {
+    let url = `${this.buildURL()}/${backend}/data/`;
+    if (!isEmpty(id)) {
+      url = url + id;
+    }
+    return url;
+  },
+
+  urlForFindRecord(id) {
+    let [backend, path, version] = JSON.parse(id);
+    return this._url(backend, path) + `?version=${version}`;
+  },
+
+  deleteRecord(store, type, snapshot) {
+    // use adapterOptions to determine if it's delete or destroy for the version
+    return this._super(...arguments);
+  },
+});

--- a/ui/app/adapters/secret-v2.js
+++ b/ui/app/adapters/secret-v2.js
@@ -16,26 +16,35 @@ export default ApplicationAdapter.extend({
   // concerns and we only want to send "list" to the server
   query(store, type, query) {
     let { backend, id } = query;
-    return this.ajax(this._url(backend, id), 'GET', { data: { list: true } });
+    return this.ajax(this._url(backend, id), 'GET', { data: { list: true } }).then(resp => {
+      resp.id = id;
+      return resp;
+    });
   },
 
   urlForQueryRecord(query) {
     let { id, backend } = query;
-    return this._url(backend) + id;
+    return this._url(backend, id);
   },
 
   queryRecord(store, type, query) {
     let { backend, id } = query;
-    return this._super(...arguments).then(resp => {
+    return this.ajax(this._url(backend, id), 'GET').then(resp => {
       resp.id = id;
       resp.backend = backend;
       return resp;
     });
   },
 
-  urlForDeleteRecord(store, type, snapshot) {
-    let backend = snapshot.belongsTo('secret-engine', { id: true });
+  urlForUpdateRecord(store, type, snapshot) {
+    let backend = snapshot.belongsTo('engine', { id: true });
     let { id } = snapshot;
-    return this.urlForQueryRecord({ id, backend });
+    return this._url(backend, id);
+  },
+
+  urlForDeleteRecord(store, type, snapshot) {
+    let backend = snapshot.belongsTo('engine', { id: true });
+    let { id } = snapshot;
+    return this._url(backend, id);
   },
 });

--- a/ui/app/components/navigate-input.js
+++ b/ui/app/components/navigate-input.js
@@ -170,7 +170,6 @@ export default Component.extend(FocusOnInsertMixin, {
 
     setFilterFocused: function(isFocused) {
       this.get('filterFocusDidChange')(isFocused);
-      console.log(isFocused);
     },
 
     handleKeyPress: function(event) {

--- a/ui/app/components/navigate-input.js
+++ b/ui/app/components/navigate-input.js
@@ -163,24 +163,25 @@ export default Component.extend(FocusOnInsertMixin, {
   },
 
   actions: {
-    handleInput: function(event) {
-      var filter = event.target.value;
+    handleInput: function(filter) {
       this.get('filterDidChange')(filter);
       debounce(this, 'filterUpdated', filter, 200);
     },
 
     setFilterFocused: function(isFocused) {
       this.get('filterFocusDidChange')(isFocused);
+      console.log(isFocused);
     },
 
-    handleKeyPress: function(val, event) {
+    handleKeyPress: function(event) {
       if (event.keyCode === keys.TAB) {
         this.onTab(event);
       }
     },
 
-    handleKeyUp: function(val, event) {
+    handleKeyUp: function(event) {
       var keyCode = event.keyCode;
+      let val = event.target.value;
       if (keyCode === keys.ENTER) {
         this.onEnter(val);
       }

--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -2,7 +2,7 @@ import { or } from '@ember/object/computed';
 import { isBlank, isNone } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { computed, get } from '@ember/object';
+import { computed } from '@ember/object';
 import { task, waitForEvent } from 'ember-concurrency';
 import FocusOnInsertMixin from 'vault/mixins/focus-on-insert';
 import keys from 'vault/lib/keycodes';
@@ -74,7 +74,7 @@ export default Component.extend(FocusOnInsertMixin, {
   willDestroyElement() {
     this._super(...arguments);
     if (this.model.isError && !this.model.isDestroyed) {
-      model.rollbackAttributes();
+      this.model.rollbackAttributes();
     }
   },
 
@@ -172,7 +172,6 @@ export default Component.extend(FocusOnInsertMixin, {
         return;
       }
       let $form = this.element.querySelector('form');
-      console.log('form is: ', $form);
       if ($form.length) {
         $form.submit();
       }

--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -61,9 +61,9 @@ export default Component.extend(FocusOnInsertMixin, {
       this.set('preferAdvancedEdit', true);
     }
     this.checkRows();
-    if (this.get('wizard.featureState') === 'details' && this.get('mode') === 'create') {
-      let engine = this.get('model').backend.includes('kv') ? 'kv' : this.get('model').backend;
-      this.get('wizard').transitionFeatureMachine('details', 'CONTINUE', engine);
+    if (this.wizard.featureState === 'details' && this.mode === 'create') {
+      let engine = this.model.backend.includes('kv') ? 'kv' : this.model.backend;
+      this.wizard.transitionFeatureMachine('details', 'CONTINUE', engine);
     }
 
     if (this.mode === 'edit') {
@@ -88,7 +88,7 @@ export default Component.extend(FocusOnInsertMixin, {
     .cancelOn('willDestroyElement'),
 
   partialName: computed('mode', function() {
-    return `partials/secret-form-${this.get('mode')}`;
+    return `partials/secret-form-${this.mode}`;
   }),
 
   requestInFlight: or('model.isLoading', 'model.isReloading', 'model.isSaving'),

--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -1,9 +1,9 @@
 import { or } from '@ember/object/computed';
 import { isBlank, isNone } from '@ember/utils';
-import $ from 'jquery';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
+import { task, waitForEvent } from 'ember-concurrency';
 import FocusOnInsertMixin from 'vault/mixins/focus-on-insert';
 import keys from 'vault/lib/keycodes';
 import KVObject from 'vault/lib/kv-object';
@@ -18,6 +18,7 @@ export default Component.extend(FocusOnInsertMixin, {
 
   // a key model
   key: null,
+  model: null,
 
   // a value to pre-fill the key input - this is populated by the corresponding
   // 'initialKey' queryParam
@@ -44,10 +45,15 @@ export default Component.extend(FocusOnInsertMixin, {
   codemirrorString: null,
 
   hasLintError: false,
+  isV2: false,
 
   init() {
     this._super(...arguments);
-    const secrets = this.get('key.secretData');
+    let secrets = this.model.secretData;
+    if (!secrets && this.model.selectedVersion) {
+      this.set('isV2', true);
+      secrets = this.model.belongsTo('selectedVersion').value().secretData;
+    }
     const data = KVObject.create({ content: [] }).fromJSON(secrets);
     this.set('secretData', data);
     this.set('codemirrorString', data.toJSONString());
@@ -56,81 +62,75 @@ export default Component.extend(FocusOnInsertMixin, {
     }
     this.checkRows();
     if (this.get('wizard.featureState') === 'details' && this.get('mode') === 'create') {
-      let engine = this.get('key').backend.includes('kv') ? 'kv' : this.get('key').backend;
+      let engine = this.get('model').backend.includes('kv') ? 'kv' : this.get('model').backend;
       this.get('wizard').transitionFeatureMachine('details', 'CONTINUE', engine);
     }
 
-    if (this.get('mode') === 'edit') {
+    if (this.mode === 'edit') {
       this.send('addRow');
     }
   },
 
-  didInsertElement() {
-    this._super(...arguments);
-    $(document).on('keyup.keyEdit', this.onEscape.bind(this));
-  },
-
   willDestroyElement() {
     this._super(...arguments);
-    const key = this.get('key');
-    if (get(key, 'isError') && !key.isDestroyed) {
-      key.rollbackAttributes();
+    if (this.model.isError && !this.model.isDestroyed) {
+      model.rollbackAttributes();
     }
-    $(document).off('keyup.keyEdit');
   },
+
+  waitForKeyUp: task(function*() {
+    while (true) {
+      let event = yield waitForEvent(document.body, 'keyup');
+      this.onEscape(event);
+    }
+  })
+    .on('didInsertElement')
+    .cancelOn('willDestroyElement'),
 
   partialName: computed('mode', function() {
     return `partials/secret-form-${this.get('mode')}`;
   }),
 
-  showPrefix: or('key.initialParentKey', 'key.parentKey'),
-
-  requestInFlight: or('key.isLoading', 'key.isReloading', 'key.isSaving'),
+  requestInFlight: or('model.isLoading', 'model.isReloading', 'model.isSaving'),
 
   buttonDisabled: or(
     'requestInFlight',
-    'key.isFolder',
-    'key.isError',
-    'key.flagsIsInvalid',
+    'model.isFolder',
+    'model.isError',
+    'model.flagsIsInvalid',
     'hasLintError',
     'error'
   ),
 
+  modelForData: computed('isV2', 'model', function() {
+    return this.isV2 ? this.model.belongsTo('selectedVersion').value() : this.model;
+  }),
+
   basicModeDisabled: computed('secretDataIsAdvanced', 'showAdvancedMode', function() {
-    return this.get('secretDataIsAdvanced') || this.get('showAdvancedMode') === false;
+    return this.secretDataIsAdvanced || this.showAdvancedMode === false;
   }),
 
   secretDataAsJSON: computed('secretData', 'secretData.[]', function() {
-    return this.get('secretData').toJSON();
+    return this.secretData.toJSON();
   }),
 
   secretDataIsAdvanced: computed('secretData', 'secretData.[]', function() {
-    return this.get('secretData').isAdvanced();
+    return this.secretData.isAdvanced();
   }),
 
-  hasDataChanges() {
-    const keyDataString = this.get('key.dataAsJSONString');
-    const sameData = this.get('secretData').toJSONString() === keyDataString;
-    if (sameData === false) {
-      this.set('lastChange', Date.now());
-    }
-
-    this.get('onDataChange')(!sameData);
-  },
-
   showAdvancedMode: computed('preferAdvancedEdit', 'secretDataIsAdvanced', 'lastChange', function() {
-    return this.get('secretDataIsAdvanced') || this.get('preferAdvancedEdit');
+    return this.secretDataIsAdvanced || this.preferAdvancedEdit;
   }),
 
   transitionToRoute() {
-    this.get('router').transitionTo(...arguments);
+    this.router.transitionTo(...arguments);
   },
 
   onEscape(e) {
-    if (e.keyCode !== keys.ESC || this.get('mode') !== 'show') {
+    if (e.keyCode !== keys.ESC || this.mode !== 'show') {
       return;
     }
-    const parentKey = this.get('key.parentKey');
+    const parentKey = this.model.parentKey;
     if (parentKey) {
       this.transitionToRoute(LIST_ROUTE, parentKey);
     } else {
@@ -139,25 +139,19 @@ export default Component.extend(FocusOnInsertMixin, {
   },
 
   // successCallback is called in the context of the component
-  persistKey(method, successCallback, isCreate) {
-    let model = this.get('key');
-    let key = model.get('id');
+  persistKey(successCallback) {
+    let model = this.modelForData;
+    let key = model.get('path') || model.id;
 
     if (key.startsWith('/')) {
       key = key.replace(/^\/+/g, '');
-      model.set('id', key);
+      model.set(model.pathAttr, key);
     }
 
-    if (isCreate && typeof model.createRecord === 'function') {
-      // create an ember data model from the proxy
-      model = model.createRecord(model.get('backend'));
-      this.set('key', model);
-    }
-
-    return model[method]().then(() => {
-      if (!get(model, 'isError')) {
-        if (this.get('wizard.featureState') === 'secret') {
-          this.get('wizard').transitionFeatureMachine('secret', 'CONTINUE');
+    return model.save().then(() => {
+      if (!model.isError) {
+        if (this.wizard.featureState === 'secret') {
+          this.wizard.transitionFeatureMachine('secret', 'CONTINUE');
         }
         successCallback(key);
       }
@@ -165,85 +159,78 @@ export default Component.extend(FocusOnInsertMixin, {
   },
 
   checkRows() {
-    if (this.get('secretData').get('length') === 0) {
+    if (this.secretData.length === 0) {
       this.send('addRow');
     }
   },
 
   actions: {
+    //submit on shift + enter
     handleKeyDown(e) {
       e.stopPropagation();
       if (!(e.keyCode === keys.ENTER && e.metaKey)) {
         return;
       }
-      let $form = this.$('form');
+      let $form = this.element.querySelector('form');
+      console.log('form is: ', $form);
       if ($form.length) {
         $form.submit();
       }
-      $form = null;
     },
 
     handleChange() {
-      this.set('codemirrorString', this.get('secretData').toJSONString(true));
-      this.hasDataChanges();
+      this.set('codemirrorString', this.secretData.toJSONString(true));
     },
 
     createOrUpdateKey(type, event) {
       event.preventDefault();
-      const newData = this.get('secretData').toJSON();
-      this.get('key').set('secretData', newData);
+      const newData = this.secretData.toJSON();
+      let model = this.modelForData;
+      model.set('secretData', newData);
 
       // prevent from submitting if there's no key
       // maybe do something fancier later
-      if (type === 'create' && isBlank(this.get('key.id'))) {
+      if (type === 'create' && isBlank(model.get('path') || model.id)) {
         return;
       }
 
-      this.persistKey(
-        'save',
-        key => {
-          this.hasDataChanges();
-          this.transitionToRoute(SHOW_ROUTE, key);
-        },
-        type === 'create'
-      );
+      this.persistKey(key => {
+        this.transitionToRoute(SHOW_ROUTE, key);
+      });
     },
 
     deleteKey() {
-      this.persistKey('destroyRecord', () => {
+      this.model.destroyRecord().then(() => {
         this.transitionToRoute(LIST_ROOT_ROUTE);
       });
     },
 
     refresh() {
-      this.get('onRefresh')();
+      this.onRefresh();
     },
 
     addRow() {
-      const data = this.get('secretData');
+      const data = this.secretData;
       if (isNone(data.findBy('name', ''))) {
         data.pushObject({ name: '', value: '' });
         this.set('codemirrorString', data.toJSONString(true));
       }
       this.checkRows();
-      this.hasDataChanges();
     },
 
     deleteRow(name) {
-      const data = this.get('secretData');
+      const data = this.secretData;
       const item = data.findBy('name', name);
       if (isBlank(item.name)) {
         return;
       }
       data.removeObject(item);
       this.checkRows();
-      this.hasDataChanges();
       this.set('codemirrorString', data.toJSONString(true));
-      this.rerender();
     },
 
     toggleAdvanced(bool) {
-      this.get('onToggleAdvancedEdit')(bool);
+      this.onToggleAdvancedEdit(bool);
     },
 
     codemirrorUpdated(val, codemirror) {
@@ -252,7 +239,7 @@ export default Component.extend(FocusOnInsertMixin, {
       const noErrors = codemirror.state.lint.marked.length === 0;
       if (noErrors) {
         try {
-          this.get('secretData').fromJSONString(val);
+          this.secretData.fromJSONString(val);
         } catch (e) {
           this.set('error', e.message);
         }
@@ -262,7 +249,7 @@ export default Component.extend(FocusOnInsertMixin, {
     },
 
     formatJSON() {
-      this.set('codemirrorString', this.get('secretData').toJSONString(true));
+      this.set('codemirrorString', this.secretData.toJSONString(true));
     },
   },
 });

--- a/ui/app/models/key-mixin.js
+++ b/ui/app/models/key-mixin.js
@@ -3,6 +3,9 @@ import Mixin from '@ember/object/mixin';
 import utils from '../lib/key-utils';
 
 export default Mixin.create({
+  // what attribute has the path for the key
+  // will.be 'path' for v2 or 'id' v1
+  pathAttr: 'id',
   flags: null,
 
   initialParentKey: null,
@@ -11,33 +14,39 @@ export default Mixin.create({
     return this.get('initialParentKey') != null;
   }),
 
-  isFolder: computed('id', function() {
-    return utils.keyIsFolder(this.get('id'));
+  pathVal() {
+    return this.get(this.pathAttr);
+  },
+
+  // rather than using defineProperty for all of these,
+  // we're just going to hardcode the known keys for the path ('id' and 'path')
+  isFolder: computed('id', 'path', function() {
+    return utils.keyIsFolder(this.pathVal());
   }),
 
-  keyParts: computed('id', function() {
-    return utils.keyPartsForKey(this.get('id'));
+  keyParts: computed('id', 'path', function() {
+    return utils.keyPartsForKey(this.pathVal());
   }),
 
-  parentKey: computed('id', 'isCreating', {
+  parentKey: computed('id', 'path', 'isCreating', {
     get: function() {
-      return this.get('isCreating') ? this.get('initialParentKey') : utils.parentKeyForKey(this.get('id'));
+      return this.isCreating ? this.initialParentKey : utils.parentKeyForKey(this.pathVal());
     },
     set: function(_, value) {
       return value;
     },
   }),
 
-  keyWithoutParent: computed('id', 'parentKey', {
+  keyWithoutParent: computed('id', 'path', 'parentKey', {
     get: function() {
-      var key = this.get('id');
-      return key ? key.replace(this.get('parentKey'), '') : null;
+      var key = this.pathVal();
+      return key ? key.replace(this.parentKey, '') : null;
     },
     set: function(_, value) {
       if (value && value.trim()) {
-        this.set('id', this.get('parentKey') + value);
+        this.set(this.pathAttr, this.parentKey + value);
       } else {
-        this.set('id', null);
+        this.set(this.pathAttr, null);
       }
       return value;
     },

--- a/ui/app/models/secret-v2-version.js
+++ b/ui/app/models/secret-v2-version.js
@@ -1,8 +1,12 @@
 import Secret from './secret';
 import DS from 'ember-data';
 
-const { attr } = DS;
+const { attr, belongsTo } = DS;
 
 export default Secret.extend({
+  pathAttr: 'path',
   version: attr('number'),
+  secret: belongsTo('secret-v2'),
+  path: attr('string'),
+  currentVersion: attr('number'),
 });

--- a/ui/app/models/secret-v2-version.js
+++ b/ui/app/models/secret-v2-version.js
@@ -1,0 +1,8 @@
+import Secret from './secret';
+import DS from 'ember-data';
+
+const { attr } = DS;
+
+export default Secret.extend({
+  version: attr('number'),
+});

--- a/ui/app/models/secret-v2.js
+++ b/ui/app/models/secret-v2.js
@@ -1,15 +1,17 @@
-import Secret from './secret';
 import DS from 'ember-data';
+import { match } from '@ember/object/computed';
 
 const { attr, hasMany, belongsTo, Model } = DS;
 
 export default Model.extend({
   engine: belongsTo('secret-engine'),
-  versions: hasMany('secret-v2-version', { async: false }),
+  versions: hasMany('secret-v2-version', { async: false, inverse: null }),
+  selectedVersion: belongsTo('secret-v2-version', { inverse: 'secret' }),
   createdTime: attr(),
   updatedTime: attr(),
   currentVersion: attr('number'),
   oldestVersion: attr('number'),
   maxVersions: attr('number'),
   casRequired: attr('boolean'),
+  isFolder: match('id', /\/$/),
 });

--- a/ui/app/models/secret-v2.js
+++ b/ui/app/models/secret-v2.js
@@ -1,3 +1,15 @@
 import Secret from './secret';
+import DS from 'ember-data';
 
-export default Secret.extend();
+const { attr, hasMany, belongsTo, Model } = DS;
+
+export default Model.extend({
+  engine: belongsTo('secret-engine'),
+  versions: hasMany('secret-v2-version', { async: false }),
+  createdTime: attr(),
+  updatedTime: attr(),
+  currentVersion: attr('number'),
+  oldestVersion: attr('number'),
+  maxVersions: attr('number'),
+  casRequired: attr('boolean'),
+});

--- a/ui/app/routes/vault/cluster/secrets/backend.js
+++ b/ui/app/routes/vault/cluster/secrets/backend.js
@@ -16,16 +16,8 @@ export default Route.extend({
   },
 
   afterModel(model, transition) {
-    let target = transition.targetName;
     let path = model && model.get('path');
-    let type = model && model.get('type');
-    if (type === 'kv' && model.get('options.version') === 2) {
-      this.get('flashMessages').stickyInfo(
-        `"${path}" is a newer version of the KV backend. The Vault UI does not currently support the additional versioning features. All actions taken through the UI in this engine will operate on the most recent version of a secret.`
-      );
-    }
-
-    if (target === this.routeName) {
+    if (transition.targetName === this.routeName) {
       return this.replaceWith('vault.cluster.secrets.backend.list-root', path);
     }
   },

--- a/ui/app/routes/vault/cluster/secrets/backend/create-root.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create-root.js
@@ -1,1 +1,45 @@
-export { default } from './create';
+import { hash } from 'rsvp';
+import { inject as service } from '@ember/service';
+import EditBase from './secret-edit';
+
+let secretModel = (store, backend, key) => {
+  let backendModel = store.peekRecord('secret-engine', backend);
+  let modelType = backendModel.get('modelTypeForKV');
+  if (modelType !== 'secret-v2') {
+    return store.createRecord(modelType, {
+      id: key,
+    });
+  }
+  let secret = store.createRecord(modelType);
+  secret.set('engine', backendModel);
+  let version = store.createRecord('secret-v2-version', {
+    path: key,
+  });
+  secret.set('selectedVersion', version);
+  return secret;
+};
+
+export default EditBase.extend({
+  wizard: service(),
+  createModel(transition) {
+    const { backend } = this.paramsFor('vault.cluster.secrets.backend');
+    const modelType = this.modelType(backend);
+    if (modelType === 'role-ssh') {
+      return this.store.createRecord(modelType, { keyType: 'ca' });
+    }
+    if (modelType !== 'secret' && modelType !== 'secret-v2') {
+      if (this.get('wizard.featureState') === 'details' && this.get('wizard.componentState') === 'transit') {
+        this.get('wizard').transitionFeatureMachine('details', 'CONTINUE', 'transit');
+      }
+      return this.store.createRecord(modelType);
+    }
+    return secretModel(this.store, backend, transition.queryParams.initialKey);
+  },
+
+  model(params, transition) {
+    return hash({
+      secret: this.createModel(transition),
+      capabilities: {},
+    });
+  },
+});

--- a/ui/app/routes/vault/cluster/secrets/backend/create.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create.js
@@ -1,59 +1,10 @@
-import { hash } from 'rsvp';
-import { inject as service } from '@ember/service';
-import EmberObject from '@ember/object';
-import EditBase from './secret-edit';
-import KeyMixin from 'vault/models/key-mixin';
+import Route from '@ember/routing/route';
 
-var SecretProxy = EmberObject.extend(KeyMixin, {
-  store: null,
-
-  toModel() {
-    return this.getProperties('id', 'secretData', 'backend');
-  },
-
-  createRecord(backend) {
-    let backendModel = this.store.peekRecord('secret-engine', backend);
-    return this.store.createRecord(backendModel.get('modelTypeForKV'), this.toModel());
-  },
-
-  willDestroy() {
-    this.store = null;
-  },
-});
-
-export default EditBase.extend({
-  wizard: service(),
-  createModel(transition, parentKey) {
-    const { backend } = this.paramsFor('vault.cluster.secrets.backend');
-    const modelType = this.modelType(backend);
-    if (modelType === 'role-ssh') {
-      return this.store.createRecord(modelType, { keyType: 'ca' });
-    }
-    if (modelType !== 'secret' && modelType !== 'secret-v2') {
-      if (this.get('wizard.featureState') === 'details' && this.get('wizard.componentState') === 'transit') {
-        this.get('wizard').transitionFeatureMachine('details', 'CONTINUE', 'transit');
-      }
-      return this.store.createRecord(modelType);
-    }
-    const key = transition.queryParams.initialKey || '';
-    const model = SecretProxy.create({
-      initialParentKey: parentKey,
-      store: this.store,
-    });
-
-    if (key) {
-      // have to set this after so that it will be
-      // computed properly in the template (it's dependent on `initialParentKey`)
-      model.set('keyWithoutParent', key);
-    }
-    return model;
-  },
-
-  model(params, transition) {
-    const parentKey = params.secret ? params.secret : '';
-    return hash({
-      secret: this.createModel(transition, parentKey),
-      capabilities: {},
+export default Route.extend({
+  beforeModel(transition) {
+    let { secret } = this.paramsFor(this.routeName);
+    return this.transitionTo('vault.cluster.secrets.backend.create-root', {
+      queryParams: { initialKey: secret },
     });
   },
 });

--- a/ui/app/routes/vault/cluster/secrets/backend/create.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-  beforeModel(transition) {
+  beforeModel() {
     let { secret } = this.paramsFor(this.routeName);
     return this.transitionTo('vault.cluster.secrets.backend.create-root', {
       queryParams: { initialKey: secret },

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -72,7 +72,14 @@ export default Route.extend(UnloadModelRoute, {
       secret = secret.replace('cert/', '');
     }
     return hash({
-      secret: this.store.queryRecord(modelType, { id: secret, backend }),
+      secret: this.store.queryRecord(modelType, { id: secret, backend }).then(resp => {
+        if (modelType === 'secret-v2') {
+          // TODO, find by query param to enable viewing versions
+          let version = resp.versions.findBy('version', resp.currentVersion);
+          version.reload();
+        }
+        return resp;
+      }),
       capabilities: this.capabilities(secret),
     });
   },

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -76,7 +76,10 @@ export default Route.extend(UnloadModelRoute, {
         if (modelType === 'secret-v2') {
           // TODO, find by query param to enable viewing versions
           let version = resp.versions.findBy('version', resp.currentVersion);
-          version.reload();
+          return version.reload().then(() => {
+            resp.set('selectedVersion', version);
+            return resp;
+          });
         }
         return resp;
       }),
@@ -127,6 +130,8 @@ export default Route.extend(UnloadModelRoute, {
     },
 
     willTransition(transition) {
+      console.log(this.hasChanges);
+      console.log(this.controller.model.hasDirtyAttributes);
       if (this.get('hasChanges')) {
         if (
           window.confirm(

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -130,8 +130,6 @@ export default Route.extend(UnloadModelRoute, {
     },
 
     willTransition(transition) {
-      console.log(this.hasChanges);
-      console.log(this.controller.model.hasDirtyAttributes);
       if (this.get('hasChanges')) {
         if (
           window.confirm(

--- a/ui/app/serializers/secret-v2-version.js
+++ b/ui/app/serializers/secret-v2-version.js
@@ -1,0 +1,25 @@
+import { get } from '@ember/object';
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  secretDataPath: 'data.data',
+  normalizeItems(payload, requestType) {
+    let path = this.secretDataPath;
+    // move response that is the contents of the secret from the dataPath
+    // to `secret_data` so it will be `secretData` in the model
+    payload.secret_data = get(payload, path);
+    payload = Object.assign({}, payload, payload.data.metadata);
+    delete payload.data;
+    // return the payload if it's expecting a single object or wrap
+    // it as an array if not
+    return payload;
+  },
+  serialize(snapshot) {
+    return {
+      data: snapshot.attr('secretData'),
+      options: {
+        cas: snapshot.attr('currentVerion'),
+      },
+    };
+  },
+});

--- a/ui/app/serializers/secret-v2-version.js
+++ b/ui/app/serializers/secret-v2-version.js
@@ -3,23 +3,28 @@ import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
   secretDataPath: 'data.data',
-  normalizeItems(payload, requestType) {
+  normalizeItems(payload) {
     let path = this.secretDataPath;
     // move response that is the contents of the secret from the dataPath
     // to `secret_data` so it will be `secretData` in the model
     payload.secret_data = get(payload, path);
     payload = Object.assign({}, payload, payload.data.metadata);
     delete payload.data;
+    payload.path = payload.id;
     // return the payload if it's expecting a single object or wrap
     // it as an array if not
     return payload;
   },
   serialize(snapshot) {
-    return {
+    let data = {
       data: snapshot.attr('secretData'),
-      options: {
-        cas: snapshot.attr('currentVerion'),
-      },
     };
+    if (snapshot.attr('currentVersion')) {
+      data.options = {
+        cas: snapshot.attr('currentVerion'),
+      };
+    }
+
+    return data;
   },
 });

--- a/ui/app/serializers/secret-v2.js
+++ b/ui/app/serializers/secret-v2.js
@@ -1,5 +1,40 @@
-import SecretSerializer from './secret';
+import ApplicationSerializer from './application';
+import DS from 'ember-data';
 
-export default SecretSerializer.extend({
-  secretDataPath: 'data.data',
+export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
+  attrs: {
+    versions: { embedded: 'always' },
+  },
+  secretDataPath: 'data',
+  normalizeItems(payload, requestType) {
+    if (payload.data.keys && Array.isArray(payload.data.keys)) {
+      // if we have data.keys, it's a list of ids, so we map over that
+      // and create objects with id's
+      return payload.data.keys.map(secret => {
+        // secrets don't have an id in the response, so we need to concat the full
+        // path of the secret here - the id in the payload is added
+        // in the adapter after making the request
+        let fullSecretPath = payload.id ? payload.id + secret : secret;
+
+        // if there is no path, it's a "top level" secret, so add
+        // a unicode space for the id
+        // https://github.com/hashicorp/vault/issues/3348
+        if (!fullSecretPath) {
+          fullSecretPath = '\u0020';
+        }
+        return { id: fullSecretPath };
+      });
+    }
+    if (payload.data.versions) {
+      payload.data.versions = Object.keys(payload.data.versions).map(version => {
+        let body = payload.data.versions[version];
+        body.version = version;
+        body.id = JSON.stringify([payload.backend, payload.id, version]);
+        return body;
+      });
+      console.log(payload);
+    }
+    payload.data.id = payload.id;
+    return requestType === 'queryRecord' ? payload.data : [payload.data];
+  },
 });

--- a/ui/app/serializers/secret-v2.js
+++ b/ui/app/serializers/secret-v2.js
@@ -25,14 +25,15 @@ export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
         return { id: fullSecretPath };
       });
     }
+    // transform versions to an array with composite IDs
     if (payload.data.versions) {
       payload.data.versions = Object.keys(payload.data.versions).map(version => {
         let body = payload.data.versions[version];
         body.version = version;
+        body.path = payload.id;
         body.id = JSON.stringify([payload.backend, payload.id, version]);
         return body;
       });
-      console.log(payload);
     }
     payload.data.id = payload.id;
     return requestType === 'queryRecord' ? payload.data : [payload.data];

--- a/ui/app/services/csp-event.js
+++ b/ui/app/services/csp-event.js
@@ -12,19 +12,19 @@ export default Service.extend({
   connectionViolations: filterBy('events', 'violatedDirective', 'connect-src'),
 
   attach() {
-    this.get('monitor').perform();
+    this.monitor.perform();
   },
 
   remove() {
-    this.get('monitor').cancelAll();
+    this.monitor.cancelAll();
   },
 
   monitor: task(function*() {
-    this.get('events').clear();
+    this.events.clear();
 
     while (true) {
       let event = yield waitForEvent(window.document, 'securitypolicyviolation');
-      this.get('events').addObject(event);
+      this.events.addObject(event);
     }
   }),
 });

--- a/ui/app/templates/components/navigate-input.hbs
+++ b/ui/app/templates/components/navigate-input.hbs
@@ -1,16 +1,17 @@
 <div class="field">
   <p class="control has-icons-left has-icons-right">
-  {{input
-    value=filter
-    placeholder=(or placeholder "Filter keys")
+  <input
     class="filter input"
-    disabled=disabled
-    key-up=(action "handleKeyUp")
-    key-down=(action "handleKeyPress")
-    input=(action "handleInput")
-    focus-in=(action "setFilterFocused" true)
-    focus-out=(action "setFilterFocused" false)
-    }}
+    disabled={{disabled}}
+    value={{@filter}}
+    placeholder={{ or @placeholder "Filter keys" }}
+
+    oninput={{action "handleInput" value="target.value"}}
+    onkeyup={{action "handleKeyUp" }}
+    onkeydown={{action "handleKeyPress"}} 
+    onfocus={{action "setFilterFocused" true}}
+    onblur={{action "setFilterFocused" false}}
+   /> 
 
     {{i-con glyph="ios-search-strong" class="is-left has-text-grey" size=18}}
   </p>

--- a/ui/app/templates/components/secret-list-header.hbs
+++ b/ui/app/templates/components/secret-list-header.hbs
@@ -32,8 +32,8 @@
           <div class="control">
             {{#secret-link
               mode="create"
-              secret=(or baseKey.id '')
-              queryParams=(query-params initialKey='')
+              secret=''
+              queryParams=(query-params initialKey=baseKey.id)
               class="button has-icon-right is-ghost is-compact"
               data-test-secret-create=true
             }}

--- a/ui/app/templates/partials/secret-edit-display.hbs
+++ b/ui/app/templates/partials/secret-edit-display.hbs
@@ -1,4 +1,3 @@
-{{#unless key.isFolder}}
   {{#if showAdvancedMode}}
     {{json-editor
       value=codemirrorString
@@ -45,4 +44,3 @@
       </div>
     {{/each}}
   {{/if}}
-{{/unless}}

--- a/ui/app/templates/partials/secret-form-create.hbs
+++ b/ui/app/templates/partials/secret-form-create.hbs
@@ -1,30 +1,12 @@
-<form class="{{if showAdvancedMode 'advanced-edit' 'simple-edit'}}" onsubmit={{action "createOrUpdateKey" "create"}} onchange={{action "handleChange"}}>
+<form class="{{if showAdvancedMode 'advanced-edit' 'simple-edit'}}" onsubmit={{action "createOrUpdateKey" "create"}}>
   <div class="field box is-fullwidth is-sideless is-marginless">
     <NamespaceReminder @mode="create" @noun="secret" />
-    {{message-error model=key errorMessage=error}}
+    <MessageError @model={{model}} @errorMessage={{error}} />
     <label class="label is-font-weight-normal" for="kv-key">Path for this secret</label>
-    <div class="field has-addons">
-      {{#if (not-eq key.initialParentKey '') }}
-        {{! need this to prevent a shift in the layout before we transition when saving }}
-        {{#if key.isCreating}}
-          <p class="control is-no-flex-grow">
-            <button type="button" class="button is-static has-background-grey-lighter has-text-grey has-default-border">
-              {{key.initialParentKey}}
-            </button>
-          </p>
-        {{else}}
-          <p class="control is-no-flex-grow">
-            <button type="button" class="button is-static">
-              {{key.parentKey}}
-            </button>
-          </p>
-        {{/if}}
-      {{/if}}
-      <p class="control is-expanded">
-        {{input data-test-secret-path=true id="kv-key" class="input" value=key.keyWithoutParent}}
-      </p>
-    </div>
-    {{#if key.isFolder}}
+    <p class="control is-expanded">
+      {{input data-test-secret-path=true id="kv-key" class="input" value=(get modelForData modelForData.pathAttr)}}
+    </p>
+    {{#if modelForData.isFolder}}
       <p class="help is-danger">
       The secret path may not end in <code>/</code>
       </p>
@@ -47,7 +29,7 @@
     <div class="control">
       {{#secret-link
         mode="list"
-        secret=key.initialParentKey
+        secret=model.parentKey
         class="button"
       }}
         Cancel

--- a/ui/app/templates/partials/secret-form-show.hbs
+++ b/ui/app/templates/partials/secret-form-show.hbs
@@ -1,6 +1,6 @@
 {{#if showAdvancedMode}}
   {{json-editor
-    value=key.dataAsJSONString
+    value=modelForData.dataAsJSONString
     options=(hash
       readOnly=true
     )
@@ -16,7 +16,7 @@
       </div>
     </div>
   </div>
-  {{#each-in key.secretData as |key value|}}
+  {{#each-in modelForData.secretData as |key value|}}
     {{#info-table-row label=key value=value alwaysRender=true}}
       {{masked-input value=value displayOnly=true}}
     {{/info-table-row}}

--- a/ui/tests/unit/adapters/secret-v2-test.js
+++ b/ui/tests/unit/adapters/secret-v2-test.js
@@ -1,26 +1,70 @@
-import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import apiStub from 'vault/tests/helpers/noop-all-api-requests';
 
 module('Unit | Adapter | secret-v2', function(hooks) {
   setupTest(hooks);
 
-  test('secret api urls', function(assert) {
-    let url, method, options;
-    let adapter = this.owner.factoryFor('adapter:secret-v2').create({
-      ajax: (...args) => {
-        [url, method, options] = args;
-        return resolve({});
+  hooks.beforeEach(function() {
+    this.server = apiStub();
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  });
+
+  [
+    ['query', null, {}, { id: '', backend: 'secret' }, 'GET', '/v1/secret/metadata/?list=true'],
+    ['queryRecord', null, {}, { id: 'foo', backend: 'secret' }, 'GET', '/v1/secret/metadata/foo'],
+    [
+      'updateRecord',
+      {
+        serializerFor() {
+          return {
+            serializeIntoHash() {},
+          };
+        },
       },
+      {},
+      {
+        id: 'foo',
+        belongsTo() {
+          return 'secret';
+        },
+      },
+      'PUT',
+      '/v1/secret/metadata/foo',
+    ],
+    [
+      'deleteRecord',
+      {
+        serializerFor() {
+          return {
+            serializeIntoHash() {},
+          };
+        },
+      },
+      {},
+      {
+        id: 'foo',
+        belongsTo() {
+          return 'secret';
+        },
+      },
+      'DELETE',
+      '/v1/secret/metadata/foo',
+    ],
+  ].forEach(([adapterMethod, store, type, queryOrSnapshot, expectedHttpVerb, expectedURL]) => {
+    test(`secret-v2: ${adapterMethod}`, function(assert) {
+      let adapter = this.owner.lookup('adapter:secret-v2');
+      adapter[adapterMethod](store, type, queryOrSnapshot);
+      let { url, method } = this.server.handledRequests[0];
+      assert.equal(url, expectedURL, `${adapterMethod} calls the correct url: ${expectedURL}`);
+      assert.equal(
+        method,
+        expectedHttpVerb,
+        `${adapterMethod} uses the correct http verb: ${expectedHttpVerb}`
+      );
     });
-
-    adapter.query({}, 'secret', { id: '', backend: 'secret' });
-    assert.equal(url, '/v1/secret/metadata/', 'query generic url OK');
-    assert.equal('GET', method, 'query generic method OK');
-    assert.deepEqual(options, { data: { list: true } }, 'query generic url OK');
-
-    adapter.queryRecord({}, 'secret', { id: 'foo', backend: 'secret' });
-    assert.equal(url, '/v1/secret/data/foo', 'queryRecord generic url OK');
-    assert.equal('GET', method, 'queryRecord generic method OK');
   });
 });

--- a/ui/tests/unit/adapters/secret-v2-version-test.js
+++ b/ui/tests/unit/adapters/secret-v2-version-test.js
@@ -1,0 +1,79 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import apiStub from 'vault/tests/helpers/noop-all-api-requests';
+
+module('Unit | Adapter | secret-v2-version', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.server = apiStub();
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  });
+
+  [
+    [
+      'findRecord with version',
+      'findRecord',
+      [null, {}, JSON.stringify(['secret', 'foo', '2']), {}],
+      'GET',
+      '/v1/secret/data/foo?version=2',
+    ],
+    [
+      'deleteRecord with delete',
+      'deleteRecord',
+      [null, {}, { id: JSON.stringify(['secret', 'foo', '2']), adapterOptions: { deleteType: 'delete' } }],
+      'POST',
+      '/v1/secret/delete/foo',
+      { versions: ['2'] },
+    ],
+    [
+      'deleteRecord with destroy',
+      'deleteRecord',
+      [null, {}, { id: JSON.stringify(['secret', 'foo', '2']), adapterOptions: { deleteType: 'destroy' } }],
+      'POST',
+      '/v1/secret/destroy/foo',
+      { versions: ['2'] },
+    ],
+    [
+      'deleteRecord with destroy',
+      'deleteRecord',
+      [null, {}, { id: JSON.stringify(['secret', 'foo', '2']), adapterOptions: { deleteType: 'undelete' } }],
+      'POST',
+      '/v1/secret/undelete/foo',
+      { versions: ['2'] },
+    ],
+    [
+      'updateRecord makes calls to correct url',
+      'updateRecord',
+      [
+        {
+          serializerFor() {
+            return { serializeIntoHash() {} };
+          },
+        },
+        {},
+        { id: JSON.stringify(['secret', 'foo', '2']) },
+      ],
+      'PUT',
+      '/v1/secret/data/foo',
+    ],
+  ].forEach(([testName, adapterMethod, args, expectedHttpVerb, expectedURL, exptectedRequestBody]) => {
+    test(`secret-v2: ${testName}`, function(assert) {
+      let adapter = this.owner.lookup('adapter:secret-v2-version');
+      adapter[adapterMethod](...args);
+      let { url, method, requestBody } = this.server.handledRequests[0];
+      assert.equal(url, expectedURL, `${adapterMethod} calls the correct url: ${expectedURL}`);
+      assert.equal(
+        method,
+        expectedHttpVerb,
+        `${adapterMethod} uses the correct http verb: ${expectedHttpVerb}`
+      );
+      if (exptectedRequestBody) {
+        assert.deepEqual(JSON.parse(requestBody), exptectedRequestBody);
+      }
+    });
+  });
+});


### PR DESCRIPTION
This is the first step to supporting kv-v2 secret engine in the ui. We've expanded the v2-specific models so that there's a secret, and a secret-version. The secret-edit component was updated to work with these new models, and changed to be more modern (no more jQuery, using `model` instead of `key` to reference the ember model, adjustments to change tracking). Fixes for the navigate input have gone in - it seems this may have been broken by the recent 3.4 update - I've added a todo to add more test coverage in that area. And lastly, secret creation has changed: in the route structure, it has moved so it's always at the top level, and we pre-fill the input for you, and we now always create a model instead of the proxy object approach we were using before.