### PR TITLE
Remove unnecessary transit test

### DIFF
--- a/builtin/logical/transit/path_decrypt_test.go
+++ b/builtin/logical/transit/path_decrypt_test.go
@@ -7,51 +7,7 @@ import (
 	"github.com/hashicorp/vault/logical"
 )
 
-// Case1: If batch decryption input is not base64 encoded, it should fail.
-func TestTransit_BatchDecryptionCase1(t *testing.T) {
-	var resp *logical.Response
-	var err error
-
-	b, s := createBackendWithStorage(t)
-
-	batchEncryptionInput := []interface{}{
-		map[string]interface{}{"plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA=="},
-		map[string]interface{}{"plaintext": "Cg=="},
-	}
-
-	batchEncryptionData := map[string]interface{}{
-		"batch_input": batchEncryptionInput,
-	}
-
-	batchEncryptionReq := &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "encrypt/upserted_key",
-		Storage:   s,
-		Data:      batchEncryptionData,
-	}
-	resp, err = b.HandleRequest(context.Background(), batchEncryptionReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%v resp:%#v", err, resp)
-	}
-
-	batchDecryptionData := map[string]interface{}{
-		"batch_input": resp.Data["batch_results"],
-	}
-
-	batchDecryptionReq := &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "decrypt/upserted_key",
-		Storage:   s,
-		Data:      batchDecryptionData,
-	}
-	resp, err = b.HandleRequest(context.Background(), batchDecryptionReq)
-	if err == nil {
-		t.Fatalf("expected an error")
-	}
-}
-
-// Case2: Normal case of batch decryption
-func TestTransit_BatchDecryptionCase2(t *testing.T) {
+func TestTransit_BatchDecryption(t *testing.T) {
 	var resp *logical.Response
 	var err error
 
@@ -107,8 +63,7 @@ func TestTransit_BatchDecryptionCase2(t *testing.T) {
 	}
 }
 
-// Case3: Test batch decryption with a derived key
-func TestTransit_BatchDecryptionCase3(t *testing.T) {
+func TestTransit_BatchDecryption_DerivedKey(t *testing.T) {
 	var resp *logical.Response
 	var err error
 


### PR DESCRIPTION
Previously, the test passed due to expected failure, but for the wrong reason. The newer release of mapstructure now correctly handles the case which is why it passes. The base64 encoded input value for `batch_input` was removed shortly after initial release, but the tests were still checking for this case, see https://github.com/hashicorp/vault/pull/2331.

```
--- PASS: TestTransit_BatchDecryptionCase1 (0.00s)
    path_decrypt_test.go:54: err failed to parse batch input: 2 error(s)decoding:

        * '[0]' expected a map, got 'struct'
        * '[1]' expected a map, got 'struct'
PASS
```