### PR TITLE
UPDATE write.html.md, write.go - remove ambiguous wording and tablify prependable chars

### DIFF
--- a/command/write.go
+++ b/command/write.go
@@ -31,8 +31,9 @@ func (c *WriteCommand) Help() string {
 Usage: vault write [options] PATH [DATA K=V...]
 
   Writes data to Vault at the given path. The data can be credentials, secrets,
-  configuration, or arbitrary data. The specific behavior of this command is
-  determined at the thing mounted at the path.
+  configuration, or arbitrary data. The specific behavior of this command
+  differs depending on the character prepended to the "value" of the relevant 
+  "key=value" pair. These characters are explained below.
 
   Data is specified as "key=value" pairs. If the value begins with an "@", then
   it is loaded from a file. If the value is "-", Vault will read the value from

--- a/website/source/docs/commands/write.html.md
+++ b/website/source/docs/commands/write.html.md
@@ -21,9 +21,14 @@ command via the `DATA` argument. For example:
   
 The available prepend-characters are explained below.
 
-Data is specified as "key=value" pairs. If the value begins with an "@", then it
-is loaded from a file. If the value is "-", Vault will read the value from
-stdin.
+Data is specified as "key=value" pairs. 
+
+There are currently two available prepend-characters, `@` and `-`:
+
+| Prepend Character | Explanation |
+|-------------------|-------------|
+| @ | If the value is prepended with "@", then it is loaded from a file. |
+| - | If the value is prepended with "-", Vault will read the value from stdin. |
 
 For a full list of examples and paths, please see the documentation that
 corresponds to the secrets engines in use.

--- a/website/source/docs/commands/write.html.md
+++ b/website/source/docs/commands/write.html.md
@@ -5,14 +5,21 @@ sidebar_current: "docs-commands-write"
 description: |-
   The "write" command writes data to Vault at the given path. The data can be
   credentials, secrets, configuration, or arbitrary data. The specific behavior
-  of this command is determined at the thing mounted at the path.
+  of this command differs depending on the character prepended to the "value" 
+  of the relevant "key=value" pair. These characters are explained below.
 ---
 
 # write
 
 The `write` command writes data to Vault at the given path. The data can be
-credentials, secrets, configuration, or arbitrary data. The specific behavior of
-this command is determined at the thing mounted at the path.
+credentials, secrets, configuration, or arbitrary data. The specific behavior
+of this command differs depending on the character prepended to the "value"
+of the relevant "key=value" pair. This "key=value" pair is passed to the 
+command via the `DATA` argument. For example:
+
+    Usage: vault write [options] PATH [DATA K=V...]
+  
+The available prepend-characters are explained below.
 
 Data is specified as "key=value" pairs. If the value begins with an "@", then it
 is loaded from a file. If the value is "-", Vault will read the value from


### PR DESCRIPTION
Attempted to remove some ambiguous wording: 
"The specific behavior of this command is determined at the thing mounted at the path." 
Which didn't succinctly explain the behaviour of the command.

I think I could probably touch up more of this file, including separating out the specific prepend-able values into dotpoints to clarify that there are two magic-chars available for use, but didn't want the original fix to be polluted by overall formatting touch-ups. 