### PR TITLE
Update Replication Guide 

### DIFF
--- a/website/source/guides/operations/replication.html.md
+++ b/website/source/guides/operations/replication.html.md
@@ -77,7 +77,16 @@ remove it from rotation (e.g. if using Consul for service discovery), but if a
 standby does not attempt taking over it will throw errors. We hope to make this
 workflow better in a future update.
 
-### Dev-Mode Root Tokens
+### Secondary Tokens
+
+On a production system, after a secondary is activated, the enabled
+auth methods should be used to get tokens with appropriate policies,
+as policies and auth method configuration are replicated.
+
+The generate-root command can also be used to generate a root token local to
+the secondary cluster. After the secondary is activated, it will need to use the unseal or recovery keys from the Primary when generating a new root token or performing other commands that require unseal or recovery keys.
+
+#### Dev-Mode Root Tokens
 
 To ease development and testing, when both the primary and secondary are
 running in development mode, the initial root token created by the primary
@@ -85,13 +94,6 @@ running in development mode, the initial root token created by the primary
 populated into the secondary upon activation. This allows a developer to keep a
 consistent `~/.vault-token` file or `VAULT_TOKEN` environment variable when
 working with both clusters.
-
-On a production system, after a secondary is activated, the enabled
-auth methods should be used to get tokens with appropriate policies,
-as policies and auth method configuration are replicated.
-
-The generate-root command can also be used to generate a root token local to
-the secondary cluster.
 
 ## Managing Vault Performance Replication
 


### PR DESCRIPTION
Update Replication Guide to clarify how to get a token on a newly activated Secondary replica, including need to use unseal/recovery keys from Primary if doing generate-root.