### PR TITLE
logical/framework: Fix field_data_tests

### DIFF
--- a/logical/framework/field_data.go
+++ b/logical/framework/field_data.go
@@ -248,12 +248,18 @@ func (d *FieldData) getPrimitive(k string, schema *FieldSchema) (interface{}, bo
 		if err := decoder.Decode(raw); err != nil {
 			return nil, true, err
 		}
+		if result == nil {
+			result = []int{}
+		}
 		return result, true, nil
 
 	case TypeSlice:
 		var result []interface{}
 		if err := mapstructure.WeakDecode(raw, &result); err != nil {
 			return nil, true, err
+		}
+		if result == nil {
+			result = []interface{}{}
 		}
 		return result, true, nil
 


### PR DESCRIPTION
mapstructure was updated in #5454 which now returns nil rather than an
empty slice when the slice is empty (see
mitchellh/mapstructure@713b9f9e12fcd509e7fdec567f64d3e43a3cfc21). That
broke field_data_tests which expected an empty slice and instead got a
nil slice. This restores field_data's old behavior by returning an empty
slice when nil is returned by mapstructure.

Changing the tests' expected behavior is also relatively straightforward; there's only three tests that fail. Happy to switch to that approach if you feel it's right, but this should be the safest.