### PR TITLE
[api] Add 'Credentials' as an option for 'api.MountConfigInput' type

### DIFF
--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -149,6 +149,7 @@ type MountConfigInput struct {
 	AuditNonHMACResponseKeys  []string          `json:"audit_non_hmac_response_keys,omitempty" mapstructure:"audit_non_hmac_response_keys"`
 	ListingVisibility         string            `json:"listing_visibility,omitempty" mapstructure:"listing_visibility"`
 	PassthroughRequestHeaders []string          `json:"passthrough_request_headers,omitempty" mapstructure:"passthrough_request_headers"`
+	Credentials               string            `json:"credentials,omitempty" mapstructure:"credentials"`
 }
 
 type MountOutput struct {


### PR DESCRIPTION
This is required for https://github.com/terraform-providers/terraform-provider-vault/pull/212