### PR TITLE
Fix zeroaddress config example

### DIFF
--- a/website/source/api/secret/ssh/index.html.md
+++ b/website/source/api/secret/ssh/index.html.md
@@ -400,7 +400,7 @@ This endpoint configures zero-address roles.
 
 ```json
 {
-  "roles": ["otp_key_role"]
+  "roles": "otp_key_role"
 }
 ```
 


### PR DESCRIPTION
Parameter expects comma separated string but the example is a list