### PR TITLE
Update dynamic-secrets.html.md

### DIFF
--- a/website/source/intro/getting-started/dynamic-secrets.html.md
+++ b/website/source/intro/getting-started/dynamic-secrets.html.md
@@ -77,14 +77,9 @@ is okay - just use this one for now.
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "Stmt1426528957000",
       "Effect": "Allow",
-      "Action": [
-        "ec2:*"
-      ],
-      "Resource": [
-        "*"
-      ]
+      "Action": "ec2:*",
+      "Resource": "*"
     }
   ]
 }
@@ -94,19 +89,16 @@ As mentioned above, we need to map this policy document to a named role. To do
 that, write to `aws/roles/:name`:
 
 ```text
-$ vault write aws/roles/my-role policy=-<<EOF
+$ vault write aws/roles/my-role \
+    credential_type=iam_user \
+    policy_document=-<<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "Stmt1426528957000",
       "Effect": "Allow",
-      "Action": [
-        "ec2:*"
-      ],
-      "Resource": [
-        "*"
-      ]
+      "Action": "ec2:*",
+      "Resource": "*"
     }
   ]
 }
@@ -153,7 +145,7 @@ Vault will automatically revoke this credential after 768 hours (see
 `lease_duration` in the output), but perhaps we want to revoke it early. Once
 the secret is revoked, the access keys are no longer valid.
 
-To revoke the secret, use `vault revoke` with the lease ID that was outputted
+To revoke the secret, use `vault lease revoke` with the lease ID that was outputted
 from `vault read` when you ran it:
 
 ```text


### PR DESCRIPTION
# Version

`Vault v0.11.3 ('fb601237bfbe4bc16ff679f642248ee8a86e627b')`

## 1. Remove Warning

Using the current tutorial will return a warning after creating the role "my-role:

```bash
WARNING! The following warnings were returned from Vault:

  * Detected use of legacy role or policy parameter. Please upgrade to use the
  new parameters.
```

To fix this we need to update the command and the policy. Correct entries can be found in documentation for the [AWS Engine](https://www.vaultproject.io/docs/secrets/aws/index.html).

## 2. Fix step description

`vault revoke` to `vault lease revoke`. The command bellow is updated, but the text above it was not.