### PR TITLE
Added link to list of all extensions for the ssh.

### DIFF
--- a/website/source/api/secret/ssh/index.html.md
+++ b/website/source/api/secret/ssh/index.html.md
@@ -164,6 +164,10 @@ This endpoint creates or updates a named role.
 - `allowed_extensions` `(string: "")` – Specifies a comma-separated list of
   extensions that certificates can have when signed. To allow any critical
   options, set this to an empty string. Will default to allowing any extensions.
+  For the list of extensions, take a look at 
+  [sshd manual](https://man.openbsd.org/sshd#AUTHORIZED_KEYS_FILE_FORMAT) 
+  `AUTHORIZED_KEYS FILE FORMAT` part. You should add a `permit-` before the
+  name of extension to allow it.
 
 - `default_critical_options` `(map<string|string>: "")` – Specifies a map of
   critical options certificates should have if none are provided when signing.


### PR DESCRIPTION
Added a link to the OpenSSH extension list, this is not documented anywhere in vault documentation website.