### PR TITLE
website: fix product-subnav broken links

### DIFF
--- a/website/source/api/index.html.erb
+++ b/website/source/api/index.html.erb
@@ -6,12 +6,9 @@ description: |-
 
 <% @meganav_title = 'API Docs' %>
 
-<hashi-product-subnav _data="<%= encode({
-  current_path: current_page.path,
-  dark: false,
+<hashi-product-subnav project_site="true" current_path="<%= current_page.path %>" _data="<%= encode({
   products: dato.enterprise_products.map(&:to_hash),
-  subnav: dato.vault_product_page.subnav.to_hash,
-  project_site: true
+  subnav: dato.vault_product_page.subnav.to_hash
 }) %>"></hashi-product-subnav>
 
 <div class='g-section-block'>

--- a/website/source/docs/index.html.erb
+++ b/website/source/docs/index.html.erb
@@ -6,12 +6,9 @@ description: |-
 
 <% @meganav_title = 'Docs' %>
 
-<hashi-product-subnav _data="<%= encode({
-  current_path: current_page.path,
-  dark: false,
+<hashi-product-subnav project_site="true" current_path="<%= current_page.path %>" _data="<%= encode({
   products: dato.enterprise_products.map(&:to_hash),
-  subnav: dato.vault_product_page.subnav.to_hash,
-  project_site: true
+  subnav: dato.vault_product_page.subnav.to_hash
 }) %>"></hashi-product-subnav>
 
 <div class='g-section-block'>

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -4,12 +4,9 @@ description: "Vault secures, stores, and tightly controls access to tokens, pass
 
 <% page = dato.vault_oss_page %>
 
-<hashi-product-subnav _data="<%= encode({
-  current_path: current_page.path,
-  dark: false,
+<hashi-product-subnav project_site="true" current_path="<%= current_page.path %>" _data="<%= encode({
   products: dato.enterprise_products.map(&:to_hash),
-  subnav: dato.vault_product_page.subnav.to_hash,
-  project_site: true
+  subnav: dato.vault_product_page.subnav.to_hash
 }) %>"></hashi-product-subnav>
 
 <hashi-hero _data="<%= encode(page.hero) %>"></hashi-hero>

--- a/website/source/layouts/inner.erb
+++ b/website/source/layouts/inner.erb
@@ -1,10 +1,7 @@
 <% wrap_layout :layout do %>
-	<hashi-product-subnav _data="<%= encode({
-		current_path: current_page.path,
-		dark: false,
-		products: dato.enterprise_products.map(&:to_hash),
-		subnav: dato.vault_product_page.subnav.to_hash,
-		project_site: true
+	<hashi-product-subnav project_site="true" current_path="<%= current_page.path %>" _data="<%= encode({
+	products: dato.enterprise_products.map(&:to_hash),
+	subnav: dato.vault_product_page.subnav.to_hash
 	}) %>"></hashi-product-subnav>
 
 	<div class="content-wrap g-container">


### PR DESCRIPTION
This is a bug fix to repair the broken links in the product dropdown of the product subnav component.  It simply moves some of the needed data out of the encoded `_data` prop and into their own separate props.