### PR TITLE
Website: Use H3 for Parameters To Match Existing Pattern in Identity API Docs

### DIFF
--- a/website/source/api/secret/identity/entity.html.md
+++ b/website/source/api/secret/identity/entity.html.md
@@ -170,7 +170,7 @@ This endpoint deletes an entity and all its associated aliases.
 | :--------- | :-------------------------- | :----------------------|
 | `DELETE`   | `/identity/entity/id/:id`   | `204 (empty body)`     |
 
-## Parameters
+### Parameters
 
 - `id` `(string: <required>)` – Identifier of the entity.
 
@@ -327,7 +327,7 @@ entity name.
 | :--------- | :------------------------------ | :----------------------|
 | `DELETE`   | `/identity/entity/name/:name`   | `204 (empty body)`     |
 
-## Parameters
+### Parameters
 
 - `name` `(string: <required>)` – Name of the entity.
 


### PR DESCRIPTION
The website source Markdown files seemingly use a H3 markdown format for the "Parameters" section across the board. This PR updates the "entity" page for the identity secret engine to match that expectation.