### PR TITLE
Terraform changes for quick start on vault server

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,26 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -63,7 +63,7 @@ resource "aws_security_group_rule" "vault-http-api" {
     from_port = 8200
     to_port = 8200
     protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    source_security_group_id = "${aws_security_group.elb.id}"
 }
 
 resource "aws_security_group_rule" "vault-egress" {
@@ -140,14 +140,6 @@ resource "aws_security_group_rule" "vault-elb-egress" {
     protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
 }
-
-
-
-
-
-
-
-
 
 
 # automatic lookup based on   #https://aws.amazon.com/amazon-linux-ami/

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -19,10 +19,7 @@ resource "aws_autoscaling_group" "vault" {
     health_check_grace_period = 15
     health_check_type = "EC2"
     vpc_zone_identifier = ["${split(",", var.subnets)}"]
-    /*
-    load_balancers = ["${aws_lb.vault.id}"]
-    */
-    
+
     tag {
         key = "Name"
         value = "vault"
@@ -93,18 +90,8 @@ resource "aws_lb" "vault" {
   security_groups    = ["${aws_security_group.elb.id}"]
   subnets            = ["${split(",", var.subnets)}"]
 
-  enable_deletion_protection = true
-/*
-  access_logs {
-    bucket  = "${aws_s3_bucket.lb_logs.bucket}"
-    prefix  = "test-lb"
-    enabled = true
-  }
+  enable_deletion_protection = false
 
-  tags {
-    Environment = "production"
-  }
-*/
 }
 
 resource "aws_lb_target_group" "vault-lb-tgt-group" {
@@ -220,7 +207,6 @@ resource "aws_security_group_rule" "vault-elb-egress" {
 
 # automatic lookup based on   #https://aws.amazon.com/amazon-linux-ami/
 # aws ec2 describe-images --owners 099720109477 --filters 'Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-????????' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'
-
 data "aws_ami" "latest_ubuntu_image" {
   most_recent = true
 
@@ -230,5 +216,4 @@ data "aws_ami" "latest_ubuntu_image" {
     name   = "name"
     values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
   }
-
 }

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,13 +1,17 @@
+
 output "address" {
-    value = "${aws_elb.vault.dns_name}"
+    value = "${aws_lb.vault.dns_name}"
+}
+
+output "vault_profile" {
+    value = <<EOF
+    
+    export VAULT_ADDR=\"https://${aws_lb.vault.dns_name}\""
+    vault status -tls-skip-verify
+EOF
 }
 
 // Can be used to add additional SG rules to Vault instances.
 output "vault_security_group" {
     value = "${aws_security_group.vault.id}"
-}
-
-// Can be used to add additional SG rules to the Vault ELB.
-output "elb_security_group" {
-    value = "${aws_security_group.elb.id}"
 }

--- a/terraform/aws/scripts/install.sh.tpl
+++ b/terraform/aws/scripts/install.sh.tpl
@@ -30,15 +30,15 @@ cat <<EOF >/tmp/vault.service
 Description=vault service
 Requires=network-online.target
 After=network-online.target
-ConditionFileNotEmpty=/etc/vault/config.json
+ConditionFileNotEmpty=/usr/local/etc/vault-config.json
  
 [Service]
 EnvironmentFile=-/etc/sysconfig/vault
 Environment=GOMAXPROCS=2
 Restart=on-failure
-ExecStart=/usr/bin/vault server -config=/usr/local/etc/vault-config.json
-StandardOutput=/logs/vault/output.log
-StandardError=/logs/vault/error.log
+ExecStart=/usr/local/bin/vault server -config=/usr/local/etc/vault-config.json
+StandardOutput=/var/log/vault/output.log
+StandardError=/var/log/vault/error.log
 LimitMEMLOCK=infinity
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -60,8 +60,8 @@ variable "vpc-id" {
 
 variable "source-networks" {
     type = "list"
-    #not secure by default 
-    #default = ["0.0.0.0/0"]
-    default = ["108.92.149.99/32"]
+    #not secure by default, get your IP from checkip.amazonaws.com and set to something like:
+    #default = ["108.92.149.99/32","34.222.225.77/32","18.237.144.183/32"]
+    default = ["0.0.0.0/0"]
     description = "List of source networks from which to allow access"
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -58,10 +58,9 @@ variable "vpc-id" {
     description = "VPC ID"
 }
 
+#Note: not secure by default, highly recommended to override.
 variable "source-networks" {
     type = "list"
-    #not secure by default, get your IP from checkip.amazonaws.com and set to something like:
-    #default = ["108.92.149.99/32","34.222.225.77/32","18.237.144.183/32"]
     default = ["0.0.0.0/0"]
     description = "List of source networks from which to allow access"
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -58,9 +58,8 @@ variable "vpc-id" {
     description = "VPC ID"
 }
 
-#Note: not secure by default, highly recommended to override.
 variable "source-networks" {
     type = "list"
     default = ["0.0.0.0/0"]
-    description = "List of source networks from which to allow access"
+    description = "List of source networks from which to allow access Note: not secure by default, highly recommended to override."
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -57,3 +57,10 @@ variable "subnets" {
 variable "vpc-id" {
     description = "VPC ID"
 }
+
+variable "source-networks" {
+    type = "list"
+    #not secure by default 
+    default = ["0.0.0.0/0"]
+    description = "List of source networks from which to allow access"
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -61,6 +61,7 @@ variable "vpc-id" {
 variable "source-networks" {
     type = "list"
     #not secure by default 
-    default = ["0.0.0.0/0"]
+    #default = ["0.0.0.0/0"]
+    default = ["108.92.149.99/32"]
     description = "List of source networks from which to allow access"
 }


### PR DESCRIPTION
I was looking for a quick start to testing some ideas with vault server, but ran into some problems with the terraform code supporting this; So, hopefully these changes will help others.  Looking for any feedback to help others bring vault server up fast.  These are the fixes I added:

1. Hard coded AMI no longer valid, changed to use a dynamic AMI to pull latest ubuntu image.

2. Seems ubuntu has moved away from upstart, created service file from: https://devopscube.com/setup-hashicorp-vault-beginners-guide/ and  https://www.hashicorp.com/resources/hashicorp-vault-administrative-guide

3. ELB classics are headed out the door, changed to use an ALB and setup support certificates to support a "secure" connection; though this is still self signed, it is better than cleartext over the internet.  I'm hoping it's a good enough point for quick starters to start iterating from.

4. Changed Vault security group to force use of the LB, removing direct access around.  I debate with myself in a quick start situation, but most people will not "remove" this excessive access; better they add this if they are troubleshooting startup/connectivity problems.

5. Added a variable to support a list of inbound networks. 0.0.0.0/0 is a bad practice.

I would like to add more clarity to the README to give some examples and links of what could be put into terraform.tfvars to help support a secure quick start lab.

Thank you for the feedback and consideration.