### PR TITLE
Period tokens do expire unless explicitly renewed

### DIFF
--- a/website/source/docs/commands/token/create.html.md
+++ b/website/source/docs/commands/token/create.html.md
@@ -97,9 +97,10 @@ flags](/docs/commands/index.html) included on all commands.
   value requires sudo permissions.
 
 - `-period` `(duration: "")` - If specified, every renewal will use the given
-  period. Periodic tokens do not expire (unless `-explicit-max-ttl` is also
-  provided). Setting this value requires sudo permissions. This is specified as
-  a numeric string with suffix like "30s" or "5m".
+  period. Periodic tokens do not expire as long as they are actively being
+  renewed (unless `-explicit-max-ttl` is also provided). Setting this value 
+  requires sudo permissions. This is specified as a numeric string with suffix 
+  like "30s" or "5m".
 
 - `-policy` `(string: "")` - Name of a policy to associate with this token. This
   can be specified multiple times to attach multiple policies.


### PR DESCRIPTION
Had a customer mislead by the `--periodic` documentation. If you create a periodic token and then never renew it, it will expire at the end of its TTL. Trying to be more clear here.