### PR TITLE
Remove agent reauthentication on new credentials.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## Next
+## 1.0.0-beta2 (Unreleased)
+
+CHANGES:
+
+ * Agent no longer automatically reauthenticates when new credentials are
+   detected. It's not strictly necessary and in some cases was causing
+   reauthentication much more often than intended.
 
 BUG FIXES:
   * cli: Fix panic that could occur if parameters were not provided. [GH-5603]

--- a/command/agent.go
+++ b/command/agent.go
@@ -323,9 +323,10 @@ func (c *AgentCommand) Run(args []string) int {
 	})
 
 	ah := auth.NewAuthHandler(&auth.AuthHandlerConfig{
-		Logger:  c.logger.Named("auth.handler"),
-		Client:  c.client,
-		WrapTTL: config.AutoAuth.Method.WrapTTL,
+		Logger:                       c.logger.Named("auth.handler"),
+		Client:                       c.client,
+		WrapTTL:                      config.AutoAuth.Method.WrapTTL,
+		EnableReauthOnNewCredentials: config.AutoAuth.EnableReauthOnNewCredentials,
 	})
 
 	// Start things running

--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -27,18 +27,20 @@ type AuthConfig struct {
 // AuthHandler is responsible for keeping a token alive and renewed and passing
 // new tokens to the sink server
 type AuthHandler struct {
-	DoneCh   chan struct{}
-	OutputCh chan string
-	logger   hclog.Logger
-	client   *api.Client
-	random   *rand.Rand
-	wrapTTL  time.Duration
+	DoneCh                       chan struct{}
+	OutputCh                     chan string
+	logger                       hclog.Logger
+	client                       *api.Client
+	random                       *rand.Rand
+	wrapTTL                      time.Duration
+	enableReauthOnNewCredentials bool
 }
 
 type AuthHandlerConfig struct {
-	Logger  hclog.Logger
-	Client  *api.Client
-	WrapTTL time.Duration
+	Logger                       hclog.Logger
+	Client                       *api.Client
+	WrapTTL                      time.Duration
+	EnableReauthOnNewCredentials bool
 }
 
 func NewAuthHandler(conf *AuthHandlerConfig) *AuthHandler {
@@ -46,11 +48,12 @@ func NewAuthHandler(conf *AuthHandlerConfig) *AuthHandler {
 		DoneCh: make(chan struct{}),
 		// This is buffered so that if we try to output after the sink server
 		// has been shut down, during agent shutdown, we won't block
-		OutputCh: make(chan string, 1),
-		logger:   conf.Logger,
-		client:   conf.Client,
-		random:   rand.New(rand.NewSource(int64(time.Now().Nanosecond()))),
-		wrapTTL:  conf.WrapTTL,
+		OutputCh:                     make(chan string, 1),
+		logger:                       conf.Logger,
+		client:                       conf.Client,
+		random:                       rand.New(rand.NewSource(int64(time.Now().Nanosecond()))),
+		wrapTTL:                      conf.WrapTTL,
+		enableReauthOnNewCredentials: conf.EnableReauthOnNewCredentials,
 	}
 
 	return ah
@@ -77,6 +80,21 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) {
 	}()
 
 	credCh := am.NewCreds()
+	if !ah.enableReauthOnNewCredentials {
+		realCredCh := credCh
+		credCh = nil
+		if realCredCh != nil {
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-realCredCh:
+					}
+				}
+			}()
+		}
+	}
 	if credCh == nil {
 		credCh = make(chan struct{})
 	}

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -27,6 +27,10 @@ type Config struct {
 type AutoAuth struct {
 	Method *Method `hcl:"-"`
 	Sinks  []*Sink `hcl:"sinks"`
+
+	// NOTE: This is unsupported outside of testing and may disappear at any
+	// time.
+	EnableReauthOnNewCredentials bool `hcl:"enable_reauth_on_new_credentials"`
 }
 
 type Method struct {

--- a/command/agent/jwt_end_to_end_test.go
+++ b/command/agent/jwt_end_to_end_test.go
@@ -139,8 +139,9 @@ func testJWTEndToEnd(t *testing.T, ahWrapping bool) {
 	}
 
 	ahConfig := &auth.AuthHandlerConfig{
-		Logger: logger.Named("auth.handler"),
-		Client: client,
+		Logger:                       logger.Named("auth.handler"),
+		Client:                       client,
+		EnableReauthOnNewCredentials: true,
 	}
 	if ahWrapping {
 		ahConfig.WrapTTL = 10 * time.Second


### PR DESCRIPTION
Functionality is left in for use in testing (where it is indeed quite
useful).

Fixes #5522