### PR TITLE
website: update sidebar_title in front matter to use <code>

### DIFF
--- a/website/source/api/system/audit-hash.html.md
+++ b/website/source/api/system/audit-hash.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/audit-hash - HTTP API"
-sidebar_title: "<tt>/sys/audit-hash</tt>"
+sidebar_title: "<code>/sys/audit-hash</code>"
 sidebar_current: "api-http-system-audit-hash"
 description: |-
   The `/sys/audit-hash` endpoint is used to hash data using an audit device's

--- a/website/source/api/system/audit.html.md
+++ b/website/source/api/system/audit.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/audit - HTTP API"
-sidebar_title: "<tt>/sys/audit</tt>"
+sidebar_title: "<code>/sys/audit</code>"
 sidebar_current: "api-http-system-audit/"
 description: |-
   The `/sys/audit` endpoint is used to enable and disable audit devices.

--- a/website/source/api/system/auth.html.md
+++ b/website/source/api/system/auth.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/auth - HTTP API"
-sidebar_title: "<tt>/sys/auth</tt>"
+sidebar_title: "<code>/sys/auth</code>"
 sidebar_current: "api-http-system-auth"
 description: |-
   The `/sys/auth` endpoint is used to manage auth methods in Vault.

--- a/website/source/api/system/capabilities-accessor.html.md
+++ b/website/source/api/system/capabilities-accessor.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/capabilities-accessor - HTTP API"
-sidebar_title: "<tt>/sys/capabilities-accessor</tt>"
+sidebar_title: "<code>/sys/capabilities-accessor</code>"
 sidebar_current: "api-http-system-capabilities-accessor"
 description: |-
   The `/sys/capabilities-accessor` endpoint is used to fetch the capabilities of

--- a/website/source/api/system/capabilities-self.html.md
+++ b/website/source/api/system/capabilities-self.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/capabilities-self - HTTP API"
-sidebar_title: "<tt>/sys/capabilities-self</tt>"
+sidebar_title: "<code>/sys/capabilities-self</code>"
 sidebar_current: "api-http-system-capabilities-self"
 description: |-
   The `/sys/capabilities-self` endpoint is used to fetch the capabilities of

--- a/website/source/api/system/capabilities.html.md
+++ b/website/source/api/system/capabilities.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/capabilities - HTTP API"
-sidebar_title: "<tt>/sys/capabilities</tt>"
+sidebar_title: "<code>/sys/capabilities</code>"
 sidebar_current: "api-http-system-capabilities/"
 description: |-
   The `/sys/capabilities` endpoint is used to fetch the capabilities of a token

--- a/website/source/api/system/config-auditing.html.md
+++ b/website/source/api/system/config-auditing.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/config/auditing - HTTP API"
-sidebar_title: "<tt>/sys/config/auditing</tt>"
+sidebar_title: "<code>/sys/config/auditing</code>"
 sidebar_current: "api-http-system-config-auditing"
 description: |-
   The `/sys/config/auditing` endpoint is used to configure auditing settings.

--- a/website/source/api/system/config-control-group.html.md
+++ b/website/source/api/system/config-control-group.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/config/control-group - HTTP API"
-sidebar_title: "<tt>/sys/config/control-group</tt>"
+sidebar_title: "<code>/sys/config/control-group</code>"
 sidebar_current: "api-http-system-config-control-group"
 description: |-
   The '/sys/config/control-group' endpoint configures control groups.

--- a/website/source/api/system/config-cors.html.md
+++ b/website/source/api/system/config-cors.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/config/cors - HTTP API"
-sidebar_title: "<tt>/sys/config/cors</tt>"
+sidebar_title: "<code>/sys/config/cors</code>"
 sidebar_current: "api-http-system-config-cors"
 description: |-
   The '/sys/config/cors' endpoint configures how the Vault server responds to cross-origin requests.

--- a/website/source/api/system/config-ui.html.md
+++ b/website/source/api/system/config-ui.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/config/ui - HTTP API"
-sidebar_title: "<tt>/sys/config/ui</tt>"
+sidebar_title: "<code>/sys/config/ui</code>"
 sidebar_current: "api-http-system-config-ui"
 description: |-
   The '/sys/config/ui' endpoint configures the UI.

--- a/website/source/api/system/control-group.html.md
+++ b/website/source/api/system/control-group.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/control-group - HTTP API"
-sidebar_title: "<tt>/sys/control-group</tt>"
+sidebar_title: "<code>/sys/control-group</code>"
 sidebar_current: "api-http-system-control-group"
 description: |-
   The '/sys/control-group' endpoint handles the Control Group workflow.

--- a/website/source/api/system/generate-root.html.md
+++ b/website/source/api/system/generate-root.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/generate-root - HTTP API"
-sidebar_title: "<tt>/sys/generate-root</tt>"
+sidebar_title: "<code>/sys/generate-root</code>"
 sidebar_current: "api-http-system-generate-root"
 description: |-
   The `/sys/generate-root/` endpoints are used to create a new root key for

--- a/website/source/api/system/health.html.md
+++ b/website/source/api/system/health.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/health - HTTP API"
-sidebar_title: "<tt>/sys/health</tt>"
+sidebar_title: "<code>/sys/health</code>"
 sidebar_current: "api-http-system-health"
 description: |-
   The `/sys/health` endpoint is used to check the health status of Vault.

--- a/website/source/api/system/init.html.md
+++ b/website/source/api/system/init.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/init - HTTP API"
-sidebar_title: "<tt>/sys/init</tt>"
+sidebar_title: "<code>/sys/init</code>"
 sidebar_current: "api-http-system-init"
 description: |-
   The `/sys/init` endpoint is used to initialize a new Vault.

--- a/website/source/api/system/internal-ui-mounts.html.md
+++ b/website/source/api/system/internal-ui-mounts.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/internal/ui/mounts - HTTP API"
-sidebar_title: "<tt>/sys/internal/ui/mounts</tt>"
+sidebar_title: "<code>/sys/internal/ui/mounts</code>"
 sidebar_current: "api-http-system-internal-ui-mounts"
 description: |-
   The `/sys/internal/ui/mounts` endpoint is used to manage mount listing visibility.

--- a/website/source/api/system/key-status.html.md
+++ b/website/source/api/system/key-status.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/key-status - HTTP API"
-sidebar_title: "<tt>/sys/key-status</tt>"
+sidebar_title: "<code>/sys/key-status</code>"
 sidebar_current: "api-http-system-key-status"
 description: |-
   The `/sys/key-status` endpoint is used to query info about the current

--- a/website/source/api/system/leader.html.md
+++ b/website/source/api/system/leader.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/leader - HTTP API"
-sidebar_title: "<tt>/sys/leader</tt>"
+sidebar_title: "<code>/sys/leader</code>"
 sidebar_current: "api-http-system-leader"
 description: |-
   The `/sys/leader` endpoint is used to check the high availability status and

--- a/website/source/api/system/leases.html.md
+++ b/website/source/api/system/leases.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/leases - HTTP API"
-sidebar_title: "<tt>/sys/leases</tt>"
+sidebar_title: "<code>/sys/leases</code>"
 sidebar_current: "api-http-system-leases"
 description: |-
   The `/sys/leases` endpoints are used to view and manage leases.

--- a/website/source/api/system/license.html.md
+++ b/website/source/api/system/license.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/license - HTTP API"
-sidebar_title: "<tt>/sys/license</tt>"
+sidebar_title: "<code>/sys/license</code>"
 sidebar_current: "api-http-system-license"
 description: |-
   The `/sys/license` endpoint is used to view and update the license used in 

--- a/website/source/api/system/mfa/index.html.md
+++ b/website/source/api/system/mfa/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/mfa - HTTP API"
-sidebar_title: "<tt>/sys/mfa</tt>"
+sidebar_title: "<code>/sys/mfa</code>"
 sidebar_current: "api-http-system-mfa"
 description: |-
   The '/sys/mfa' endpoint focuses on managing MFA behaviors in Vault Enterprise MFA.

--- a/website/source/api/system/mfa/mfa-duo.html.md
+++ b/website/source/api/system/mfa/mfa-duo.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/mfa/method/duo - HTTP API"
-sidebar_title: "<tt>/sys/mfa/method/duo</tt>"
+sidebar_title: "<code>/sys/mfa/method/duo</code>"
 sidebar_current: "api-http-system-mfa-duo"
 description: |-
   The '/sys/mfa/method/duo' endpoint focuses on managing Duo MFA behaviors in Vault Enterprise.

--- a/website/source/api/system/mfa/mfa-okta.html.md
+++ b/website/source/api/system/mfa/mfa-okta.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/mfa/method/okta - HTTP API"
-sidebar_title: "<tt>/sys/mfa/method/okta</tt>"
+sidebar_title: "<code>/sys/mfa/method/okta</code>"
 sidebar_current: "api-http-system-mfa-okta"
 description: |-
   The '/sys/mfa/method/okta' endpoint focuses on managing Okta MFA behaviors in Vault Enterprise.

--- a/website/source/api/system/mfa/mfa-pingid.html.md
+++ b/website/source/api/system/mfa/mfa-pingid.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/mfa/method/pingid - HTTP API"
-sidebar_title: "<tt>/sys/mfa/method/pingid</tt>"
+sidebar_title: "<code>/sys/mfa/method/pingid</code>"
 sidebar_current: "api-http-system-mfa-pingid"
 description: |-
   The '/sys/mfa/method/pingid' endpoint focuses on managing PingID MFA behaviors in Vault Enterprise.

--- a/website/source/api/system/mfa/mfa-totp.html.md
+++ b/website/source/api/system/mfa/mfa-totp.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/mfa/method/totp - HTTP API"
-sidebar_title: "<tt>/sys/mfa/method/totp</tt>"
+sidebar_title: "<code>/sys/mfa/method/totp</code>"
 sidebar_current: "api-http-system-mfa-totp"
 description: |-
   The '/sys/mfa/method/totp' endpoint focuses on managing TOTP MFA behaviors in Vault Enterprise.

--- a/website/source/api/system/mounts.html.md
+++ b/website/source/api/system/mounts.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/mounts - HTTP API"
-sidebar_title: "<tt>/sys/mounts</tt>"
+sidebar_title: "<code>/sys/mounts</code>"
 sidebar_current: "api-http-system-mounts"
 description: |-
   The `/sys/mounts` endpoint is used manage secrets engines in Vault.

--- a/website/source/api/system/namespaces.html.md
+++ b/website/source/api/system/namespaces.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/namespaces - HTTP API"
-sidebar_title: "<tt>/sys/namespaces</tt>"
+sidebar_title: "<code>/sys/namespaces</code>"
 sidebar_current: "api-http-system-namespaces"
 description: |-
   The `/sys/namespaces` endpoint is used manage namespaces in Vault.

--- a/website/source/api/system/plugins-catalog.html.md
+++ b/website/source/api/system/plugins-catalog.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/plugins/catalog - HTTP API"
-sidebar_title: "<tt>/sys/plugins/catalog</tt>"
+sidebar_title: "<code>/sys/plugins/catalog</code>"
 sidebar_current: "api-http-system-plugins-catalog"
 description: |-
   The `/sys/plugins/catalog` endpoint is used to manage plugins.

--- a/website/source/api/system/plugins-reload-backend.html.md
+++ b/website/source/api/system/plugins-reload-backend.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/plugins/reload/backend - HTTP API"
-sidebar_title: "<tt>/sys/plugins/reload/backend</tt>"
+sidebar_title: "<code>/sys/plugins/reload/backend</code>"
 sidebar_current: "api-http-system-plugins-reload-backend"
 description: |-
   The `/sys/plugins/reload/backend` endpoint is used to reload plugin backends.

--- a/website/source/api/system/policies.html.md
+++ b/website/source/api/system/policies.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/policies/ - HTTP API"
-sidebar_title: "<tt>/sys/policies</tt>"
+sidebar_title: "<code>/sys/policies</code>"
 sidebar_current: "api-http-system-policies"
 description: |-
   The `/sys/policies/` endpoints are used to manage ACL, RGP, and EGP policies in Vault.

--- a/website/source/api/system/policy.html.md
+++ b/website/source/api/system/policy.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/policy - HTTP API"
-sidebar_title: "<tt>/sys/policy</tt>"
+sidebar_title: "<code>/sys/policy</code>"
 sidebar_current: "api-http-system-policy"
 description: |-
   The `/sys/policy` endpoint is used to manage ACL policies in Vault.

--- a/website/source/api/system/raw.html.md
+++ b/website/source/api/system/raw.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/raw - HTTP API"
-sidebar_title: "<tt>/sys/raw</tt>"
+sidebar_title: "<code>/sys/raw</code>"
 sidebar_current: "api-http-system-raw"
 description: |-
   The `/sys/raw` endpoint is used to access the raw underlying store in Vault.

--- a/website/source/api/system/rekey-recovery-key.html.md
+++ b/website/source/api/system/rekey-recovery-key.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/rekey-recovery-key - HTTP API"
-sidebar_title: "<tt>/sys/rekey-recovery-key</tt>"
+sidebar_title: "<code>/sys/rekey-recovery-key</code>"
 sidebar_current: "api-http-system-rekey-recovery-key"
 description: |-
   The `/sys/rekey-recovery-key` endpoints are used to rekey the recovery keys for Vault.

--- a/website/source/api/system/rekey.html.md
+++ b/website/source/api/system/rekey.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/rekey - HTTP API"
-sidebar_title: "<tt>/sys/rekey</tt>"
+sidebar_title: "<code>/sys/rekey</code>"
 sidebar_current: "api-http-system-rekey"
 description: |-
   The `/sys/rekey` endpoints are used to rekey the unseal keys for Vault.

--- a/website/source/api/system/remount.html.md
+++ b/website/source/api/system/remount.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/remount - HTTP API"
-sidebar_title: "<tt>/sys/remount</tt>"
+sidebar_title: "<code>/sys/remount</code>"
 sidebar_current: "api-http-system-remount"
 description: |-
   The '/sys/remount' endpoint is used remount a mounted backend to a new endpoint.

--- a/website/source/api/system/replication/index.html.md
+++ b/website/source/api/system/replication/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/replication - HTTP API"
-sidebar_title: "<tt>/sys/replication</tt>"
+sidebar_title: "<code>/sys/replication</code>"
 sidebar_current: "api-http-system-replication"
 description: |-
   The '/sys/replication' endpoint focuses on managing general operations in Vault Enterprise replication

--- a/website/source/api/system/replication/replication-dr.html.md
+++ b/website/source/api/system/replication/replication-dr.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/replication - HTTP API"
-sidebar_title: "<tt>/sys/replication/dr</tt>"
+sidebar_title: "<code>/sys/replication/dr</code>"
 sidebar_current: "api-http-system-replication-dr"
 description: |-
   The '/sys/replication/dr' endpoint focuses on managing general operations in Vault Enterprise Disaster Recovery replication

--- a/website/source/api/system/replication/replication-performance.html.md
+++ b/website/source/api/system/replication/replication-performance.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/replication - HTTP API"
-sidebar_title: "<tt>/sys/replication/performance</tt>"
+sidebar_title: "<code>/sys/replication/performance</code>"
 sidebar_current: "api-http-system-replication-performance"
 description: |-
   The '/sys/replication/performance' endpoint focuses on managing general operations in Vault Enterprise Performance Replication

--- a/website/source/api/system/rotate.html.md
+++ b/website/source/api/system/rotate.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/rotate - HTTP API"
-sidebar_title: "<tt>/sys/rotate</tt>"
+sidebar_title: "<code>/sys/rotate</code>"
 sidebar_current: "api-http-system-rotate"
 description: |-
   The `/sys/rotate` endpoint is used to rotate the encryption key.

--- a/website/source/api/system/seal-status.html.md
+++ b/website/source/api/system/seal-status.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/seal-status - HTTP API"
-sidebar_title: "<tt>/sys/seal-status</tt>"
+sidebar_title: "<code>/sys/seal-status</code>"
 sidebar_current: "api-http-system-seal-status"
 description: |-
   The `/sys/seal-status` endpoint is used to check the seal status of a Vault.

--- a/website/source/api/system/seal.html.md
+++ b/website/source/api/system/seal.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/seal - HTTP API"
-sidebar_title: "<tt>/sys/seal</tt>"
+sidebar_title: "<code>/sys/seal</code>"
 sidebar_current: "api-http-system-seal/"
 description: |-
   The `/sys/seal` endpoint seals the Vault.

--- a/website/source/api/system/step-down.html.md
+++ b/website/source/api/system/step-down.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/step-down - HTTP API"
-sidebar_title: "<tt>/sys/step-down</tt>"
+sidebar_title: "<code>/sys/step-down</code>"
 sidebar_current: "api-http-system-step-down"
 description: |-
   The `/sys/step-down` endpoint causes the node to give up active status.

--- a/website/source/api/system/tools.html.md
+++ b/website/source/api/system/tools.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/tools - HTTP API"
-sidebar_title: "<tt>/sys/tools</tt>"
+sidebar_title: "<code>/sys/tools</code>"
 sidebar_current: "api-http-system-tools"
 description: |-
   This is the API documentation for a general set of crypto  tools.

--- a/website/source/api/system/unseal.html.md
+++ b/website/source/api/system/unseal.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/unseal - HTTP API"
-sidebar_title: "<tt>/sys/unseal</tt>"
+sidebar_title: "<code>/sys/unseal</code>"
 sidebar_current: "api-http-system-unseal"
 description: |-
   The `/sys/unseal` endpoint is used to unseal the Vault.

--- a/website/source/api/system/wrapping-lookup.html.md
+++ b/website/source/api/system/wrapping-lookup.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/wrapping/lookup - HTTP API"
-sidebar_title: "<tt>/sys/wrapping/lookup</tt>"
+sidebar_title: "<code>/sys/wrapping/lookup</code>"
 sidebar_current: "api-http-system-wrapping-lookup"
 description: |-
   The `/sys/wrapping/lookup` endpoint returns wrapping token properties.

--- a/website/source/api/system/wrapping-rewrap.html.md
+++ b/website/source/api/system/wrapping-rewrap.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/wrapping/rewrap - HTTP API"
-sidebar_title: "<tt>/sys/wrapping/rewrap</tt>"
+sidebar_title: "<code>/sys/wrapping/rewrap</code>"
 sidebar_current: "api-http-system-wrapping-rewrap"
 description: |-
   The `/sys/wrapping/rewrap` endpoint can be used to rotate a wrapping token and refresh its TTL.

--- a/website/source/api/system/wrapping-unwrap.html.md
+++ b/website/source/api/system/wrapping-unwrap.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/wrapping/unwrap - HTTP API"
-sidebar_title: "<tt>/sys/wrapping/unwrap</tt>"
+sidebar_title: "<code>/sys/wrapping/unwrap</code>"
 sidebar_current: "api-http-system-wrapping-unwrap"
 description: |-
   The `/sys/wrapping/unwrap` endpoint unwraps a wrapped response.

--- a/website/source/api/system/wrapping-wrap.html.md
+++ b/website/source/api/system/wrapping-wrap.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "api"
 page_title: "/sys/wrapping/wrap - HTTP API"
-sidebar_title: "<tt>/sys/wrapping/wrap</tt>"
+sidebar_title: "<code>/sys/wrapping/wrap</code>"
 sidebar_current: "api-http-system-wrapping-wrap"
 description: |-
   The `/sys/wrapping/wrap` endpoint wraps the given values in a

--- a/website/source/docs/commands/agent.html.md
+++ b/website/source/docs/commands/agent.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "agent - Command"
-sidebar_title: "agent"
+sidebar_title: "<code>agent</code>"
 sidebar_current: "docs-commands-agent"
 description: |-
   The "agent" command is used to start Vault Agent

--- a/website/source/docs/commands/audit/disable.html.md
+++ b/website/source/docs/commands/audit/disable.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "audit disable - Command"
-sidebar_title: "disable"
+sidebar_title: "<code>disable</code>"
 sidebar_current: "docs-commands-audit-disable"
 description: |-
   The "audit disable" command disables an audit device at a given path, if one

--- a/website/source/docs/commands/audit/enable.html.md
+++ b/website/source/docs/commands/audit/enable.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "audit enable - Command"
-sidebar_title: "enable"
+sidebar_title: "<code>enable</code>"
 sidebar_current: "docs-commands-audit-enable"
 description: |-
   The "audit enable" command enables an audit device at a given path.

--- a/website/source/docs/commands/audit/index.html.md
+++ b/website/source/docs/commands/audit/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "audit - Command"
-sidebar_title: "audit"
+sidebar_title: "<code>audit</code>"
 sidebar_current: "docs-commands-audit"
 description: |-
   The "audit" command groups subcommands for interacting with Vault's audit

--- a/website/source/docs/commands/audit/list.html.md
+++ b/website/source/docs/commands/audit/list.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "audit list - Command"
-sidebar_title: "list"
+sidebar_title: "<code>list</code>"
 sidebar_current: "docs-commands-audit-list"
 description: |-
   The "audit list" command lists the audit devices enabled. The output lists the

--- a/website/source/docs/commands/auth/disable.html.md
+++ b/website/source/docs/commands/auth/disable.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "auth disable - Command"
-sidebar_title: "disable"
+sidebar_title: "<code>disable</code>"
 sidebar_current: "docs-commands-auth-disable"
 description: |-
   The "auth disable" command disables an auth method at a given path, if one

--- a/website/source/docs/commands/auth/enable.html.md
+++ b/website/source/docs/commands/auth/enable.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "auth enable - Command"
-sidebar_title: "enable"
+sidebar_title: "<code>enable</code>"
 sidebar_current: "docs-commands-auth-enable"
 description: |-
   The "auth enable" command enables an auth method at a given path. If an auth

--- a/website/source/docs/commands/auth/help.html.md
+++ b/website/source/docs/commands/auth/help.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "auth help - Command"
-sidebar_title: "help"
+sidebar_title: "<code>help</code>"
 sidebar_current: "docs-commands-auth-help"
 description: |-
   The "auth help" command prints usage and help for an auth method.

--- a/website/source/docs/commands/auth/index.html.md
+++ b/website/source/docs/commands/auth/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "auth - Command"
-sidebar_title: "auth"
+sidebar_title: "<code>auth</code>"
 sidebar_current: "docs-commands-auth"
 description: |-
   The "auth" command groups subcommands for interacting with Vault's auth

--- a/website/source/docs/commands/auth/list.html.md
+++ b/website/source/docs/commands/auth/list.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "auth list - Command"
-sidebar_title: "list"
+sidebar_title: "<code>list</code>"
 sidebar_current: "docs-commands-auth-list"
 description: |-
   The "auth list" command lists the auth methods enabled. The output lists the

--- a/website/source/docs/commands/auth/tune.html.md
+++ b/website/source/docs/commands/auth/tune.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "auth tune - Command"
-sidebar_title: "tune"
+sidebar_title: "<code>tune</code>"
 sidebar_current: "docs-commands-auth-tune"
 description: |-
   The "auth tune" command tunes the configuration options for the auth method at

--- a/website/source/docs/commands/delete.html.md
+++ b/website/source/docs/commands/delete.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "delete - Command"
-sidebar_title: "delete"
+sidebar_title: "<code>delete</code>"
 sidebar_current: "docs-commands-delete"
 description: |-
   The "delete" command deletes secrets and configuration from Vault at the given

--- a/website/source/docs/commands/help.html.md
+++ b/website/source/docs/commands/help.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Path Help"
-sidebar_title: "path-help"
+sidebar_title: "<code>path-help</code>"
 sidebar_current: "docs-commands-path-help"
 description: |-
   The Vault CLI has a built-in help system that can be used to get help for not only the CLI itself, but also any paths that the CLI can be used with within Vault.

--- a/website/source/docs/commands/lease.html.md
+++ b/website/source/docs/commands/lease.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "lease - Command"
-sidebar_title: "lease"
+sidebar_title: "<code>lease</code>"
 sidebar_current: "docs-commands-lease"
 description: |-
   The "lease" command groups subcommands for interacting with leases attached to

--- a/website/source/docs/commands/lease/index.html.md
+++ b/website/source/docs/commands/lease/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "lease - Command"
-sidebar_title: "lease"
+sidebar_title: "<code>lease</code>"
 sidebar_current: "docs-commands-lease"
 description: |-
   The "lease" command groups subcommands for interacting with leases attached to

--- a/website/source/docs/commands/lease/renew.html.md
+++ b/website/source/docs/commands/lease/renew.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "lease renew - Command"
-sidebar_title: "renew"
+sidebar_title: "<code>renew</code>"
 sidebar_current: "docs-commands-lease-renew"
 description: |-
   The "lease renew" command renews the lease on a secret, extending the time

--- a/website/source/docs/commands/lease/revoke.html.md
+++ b/website/source/docs/commands/lease/revoke.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "lease revoke - Command"
-sidebar_title: "revoke"
+sidebar_title: "<code>revoke</code>"
 sidebar_current: "docs-commands-lease-revoke"
 description: |-
   The "lease revoke" command revokes the lease on a secret, invalidating the

--- a/website/source/docs/commands/list.html.md
+++ b/website/source/docs/commands/list.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "list - Command"
-sidebar_title: "list"
+sidebar_title: "<code>list</code>"
 sidebar_current: "docs-commands-list"
 description: |-
   The "list" command lists data from Vault at the given path. This can be used

--- a/website/source/docs/commands/login.html.md
+++ b/website/source/docs/commands/login.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "login - Command"
-sidebar_title: "login"
+sidebar_title: "<code>login</code>"
 sidebar_current: "docs-commands-login"
 description: |-
   The "login" command authenticates users or machines to Vault using the

--- a/website/source/docs/commands/namespace.html.md
+++ b/website/source/docs/commands/namespace.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "namespace - Command"
-sidebar_title: "namespace"
+sidebar_title: "<code>namespace</code>"
 sidebar_current: "docs-commands-namespace"
 description: |-
   The "namespace" command groups subcommands for interacting with namespaces.

--- a/website/source/docs/commands/operator/generate-root.html.md
+++ b/website/source/docs/commands/operator/generate-root.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "operator generate-root - Command"
-sidebar_title: "generate-root"
+sidebar_title: "<code>generate-root</code>"
 sidebar_current: "docs-commands-operator-generate-root"
 description: |-
   The "operator generate-root" command generates a new root token by combining a

--- a/website/source/docs/commands/operator/index.html.md
+++ b/website/source/docs/commands/operator/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "operator - Command"
-sidebar_title: "operator"
+sidebar_title: "<code>operator</code>"
 sidebar_current: "docs-commands-operator"
 description: |-
   The "operator" command groups subcommands for operators interacting with

--- a/website/source/docs/commands/operator/init.html.md
+++ b/website/source/docs/commands/operator/init.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "operator init - Command"
-sidebar_title: "init"
+sidebar_title: "<code>init</code>"
 sidebar_current: "docs-commands-operator-init"
 description: |-
   The "operator init" command initializes a Vault server. Initialization is the

--- a/website/source/docs/commands/operator/key-status.html.md
+++ b/website/source/docs/commands/operator/key-status.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "operator key-status - Command"
-sidebar_title: "key-status"
+sidebar_title: "<code>key-status</code>"
 sidebar_current: "docs-commands-operator-key-status"
 description: |-
   The "operator key-status" provides information about the active encryption

--- a/website/source/docs/commands/operator/migrate.html.md
+++ b/website/source/docs/commands/operator/migrate.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "operator migrate - Command"
-sidebar_title: "migrate"
+sidebar_title: "<code>migrate</code>"
 sidebar_current: "docs-commands-operator-migrate"
 description: |-
   The "operator migrate" command copies data between storage backends to facilitate

--- a/website/source/docs/commands/operator/rekey.html.md
+++ b/website/source/docs/commands/operator/rekey.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "operator rekey - Command"
-sidebar_title: "rekey"
+sidebar_title: "<code>rekey</code>"
 sidebar_current: "docs-commands-operator-rekey"
 description: |-
   The "operator rekey" command generates a new set of unseal keys. This can

--- a/website/source/docs/commands/operator/rotate.html.md
+++ b/website/source/docs/commands/operator/rotate.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "operator rotate - Command"
-sidebar_title: "rotate"
+sidebar_title: "<code>rotate</code>"
 sidebar_current: "docs-commands-operator-rotate"
 description: |-
   The "operator rotate" rotates the underlying encryption key which is used to

--- a/website/source/docs/commands/operator/seal.html.md
+++ b/website/source/docs/commands/operator/seal.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "operator seal - Command"
-sidebar_title: "seal"
+sidebar_title: "<code>seal</code>"
 sidebar_current: "docs-commands-operator-seal"
 description: |-
   The "operator seal" command seals the Vault server. Sealing tells the Vault server to

--- a/website/source/docs/commands/operator/step-down.html.md
+++ b/website/source/docs/commands/operator/step-down.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "operator step-down - Command"
-sidebar_title: "step-down"
+sidebar_title: "<code>step-down</code>"
 sidebar_current: "docs-commands-operator-step-down"
 description: |-
   The "operator step-down" forces the Vault server at the given address to step

--- a/website/source/docs/commands/operator/unseal.html.md
+++ b/website/source/docs/commands/operator/unseal.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "operator unseal - Command"
-sidebar_title: "unseal"
+sidebar_title: "<code>unseal</code>"
 sidebar_current: "docs-commands-operator-unseal"
 description: |-
   The "operator unseal" allows the user to provide a portion of the master key

--- a/website/source/docs/commands/path-help.html.md
+++ b/website/source/docs/commands/path-help.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "path-help - Command"
-sidebar_title: "path-help"
+sidebar_title: "<code>path-help</code>"
 sidebar_current: "docs-commands-path-help"
 description: |-
   The "path-help" command retrieves API help for paths. All endpoints in Vault

--- a/website/source/docs/commands/plugin/deregister.html.md
+++ b/website/source/docs/commands/plugin/deregister.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "plugin deregister - Command"
-sidebar_title: "deregister"
+sidebar_title: "<code>deregister</code>"
 sidebar_current: "docs-commands-plugin-deregister"
 description: |-
   The "plugin deregister" command deregisters a new plugin in Vault's plugin

--- a/website/source/docs/commands/plugin/index.html.md
+++ b/website/source/docs/commands/plugin/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "plugin - Command"
-sidebar_title: "plugin"
+sidebar_title: "<code>plugin</code>"
 sidebar_current: "docs-commands-plugin"
 description: |-
   The "plugin" command groups subcommands for interacting with

--- a/website/source/docs/commands/plugin/info.html.md
+++ b/website/source/docs/commands/plugin/info.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "plugin info - Command"
-sidebar_title: "info"
+sidebar_title: "<code>info</code>"
 sidebar_current: "docs-commands-plugin-info"
 description: |-
   The "plugin info" command displays information about a plugin in the catalog.

--- a/website/source/docs/commands/plugin/list.html.md
+++ b/website/source/docs/commands/plugin/list.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "plugin list - Command"
-sidebar_title: "list"
+sidebar_title: "<code>list</code>"
 sidebar_current: "docs-commands-plugin-list"
 description: |-
   The "plugin list" command lists all available plugins in the plugin catalog.

--- a/website/source/docs/commands/plugin/register.html.md
+++ b/website/source/docs/commands/plugin/register.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "plugin register - Command"
-sidebar_title: "register"
+sidebar_title: "<code>register</code>"
 sidebar_current: "docs-commands-plugin-register"
 description: |-
   The "plugin register" command registers a new plugin in Vault's plugin

--- a/website/source/docs/commands/policy/delete.html.md
+++ b/website/source/docs/commands/policy/delete.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "policy delete - Command"
-sidebar_title: "delete"
+sidebar_title: "<code>delete</code>"
 sidebar_current: "docs-commands-policy-delete"
 description: |-
   The "policy delete" command deletes the policy named NAME in the Vault server.

--- a/website/source/docs/commands/policy/fmt.html.md
+++ b/website/source/docs/commands/policy/fmt.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "policy fmt - Command"
-sidebar_title: "fmt"
+sidebar_title: "<code>fmt</code>"
 sidebar_current: "docs-commands-policy-fmt"
 description: |-
   The "policy fmt" formats a local policy file to the policy specification. This

--- a/website/source/docs/commands/policy/index.html.md
+++ b/website/source/docs/commands/policy/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "policy - Command"
-sidebar_title: "policy"
+sidebar_title: "<code>policy</code>"
 sidebar_current: "docs-commands-policy"
 description: |-
   The "policy" command groups subcommands for interacting with policies. Users

--- a/website/source/docs/commands/policy/list.html.md
+++ b/website/source/docs/commands/policy/list.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "policy list - Command"
-sidebar_title: "list"
+sidebar_title: "<code>list</code>"
 sidebar_current: "docs-commands-policy-list"
 description: |-
   The "policy list" command Lists the names of the policies that are installed

--- a/website/source/docs/commands/policy/read.html.md
+++ b/website/source/docs/commands/policy/read.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "policy read - Command"
-sidebar_title: "read"
+sidebar_title: "<code>read</code>"
 sidebar_current: "docs-commands-policy-read"
 description: |-
   The "policy read" command prints the contents and metadata of the Vault policy

--- a/website/source/docs/commands/policy/write.html.md
+++ b/website/source/docs/commands/policy/write.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "policy write - Command"
-sidebar_title: "write"
+sidebar_title: "<code>write</code>"
 sidebar_current: "docs-commands-policy-write"
 description: |-
   The "policy write" command uploads a policy with name NAME from the contents

--- a/website/source/docs/commands/read.html.md
+++ b/website/source/docs/commands/read.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "read - Command"
-sidebar_title: "read"
+sidebar_title: "<code>read</code>"
 sidebar_current: "docs-commands-read"
 description: |-
   The "read" command reads data from Vault at the given path. This can be used

--- a/website/source/docs/commands/secrets/disable.html.md
+++ b/website/source/docs/commands/secrets/disable.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "secrets disable - Command"
-sidebar_title: "disable"
+sidebar_title: "<code>disable</code>"
 sidebar_current: "docs-commands-secrets-disable"
 description: |-
   The "secrets disable" command disables an secrets engine at a given PATH. The

--- a/website/source/docs/commands/secrets/enable.html.md
+++ b/website/source/docs/commands/secrets/enable.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "secrets enable - Command"
-sidebar_title: "enable"
+sidebar_title: "<code>enable</code>"
 sidebar_current: "docs-commands-secrets-enable"
 description: |-
   The "secrets enable" command enables an secrets engine at a given path. If an

--- a/website/source/docs/commands/secrets/index.html.md
+++ b/website/source/docs/commands/secrets/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "secrets - Command"
-sidebar_title: "secrets"
+sidebar_title: "<code>secrets</code>"
 sidebar_current: "docs-commands-secrets"
 description: |-
   The "secrets" command groups subcommands for interacting with Vault's secrets

--- a/website/source/docs/commands/secrets/list.html.md
+++ b/website/source/docs/commands/secrets/list.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "secrets list - Command"
-sidebar_title: "list"
+sidebar_title: "<code>list</code>"
 sidebar_current: "docs-commands-secrets-list"
 description: |-
   The "secrets list" command lists the enabled secrets engines on the Vault

--- a/website/source/docs/commands/secrets/move.html.md
+++ b/website/source/docs/commands/secrets/move.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "secrets move - Command"
-sidebar_title: "move"
+sidebar_title: "<code>move</code>"
 sidebar_current: "docs-commands-secrets-move"
 description: |-
   The "secrets move" command moves an existing secrets engine to a new path. Any

--- a/website/source/docs/commands/secrets/tune.html.md
+++ b/website/source/docs/commands/secrets/tune.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "secrets tune - Command"
-sidebar_title: "tune"
+sidebar_title: "<code>tune</code>"
 sidebar_current: "docs-commands-secrets-tune"
 description: |-
   The "secrets tune" command tunes the configuration options for the secrets

--- a/website/source/docs/commands/server.html.md
+++ b/website/source/docs/commands/server.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "server - Command"
-sidebar_title: "server"
+sidebar_title: "<code>server</code>"
 sidebar_current: "docs-commands-server"
 description: |-
   The "server" command starts a Vault server that responds to API requests. By

--- a/website/source/docs/commands/ssh.html.md
+++ b/website/source/docs/commands/ssh.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "ssh - Command"
-sidebar_title: "ssh"
+sidebar_title: "<code>ssh</code>"
 sidebar_current: "docs-commands-ssh"
 description: |-
   The "ssh" command establishes an SSH connection with the target machine using

--- a/website/source/docs/commands/status.html.md
+++ b/website/source/docs/commands/status.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "status - Command"
-sidebar_title: "status"
+sidebar_title: "<code>status</code>"
 sidebar_current: "docs-commands-status"
 description: |-
   The "status" command prints the current state of Vault including whether it is

--- a/website/source/docs/commands/token/capabilities.html.md
+++ b/website/source/docs/commands/token/capabilities.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "token capabilities - Command"
-sidebar_title: "capabilities"
+sidebar_title: "<code>capabilities</code>"
 sidebar_current: "docs-commands-token-capabilities"
 description: |-
   The "token capabilities" command fetches the capabilities of a token for a

--- a/website/source/docs/commands/token/create.html.md
+++ b/website/source/docs/commands/token/create.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "token create - Command"
-sidebar_title: "create"
+sidebar_title: "<code>create</code>"
 sidebar_current: "docs-commands-token-create"
 description: |-
   The "token create" command creates a new token that can be used for

--- a/website/source/docs/commands/token/index.html.md
+++ b/website/source/docs/commands/token/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "token - Command"
-sidebar_title: "token"
+sidebar_title: "<code>token</code>"
 sidebar_current: "docs-commands-token"
 description: |-
   The "token" command groups subcommands for interacting with tokens. Users can

--- a/website/source/docs/commands/token/lookup.html.md
+++ b/website/source/docs/commands/token/lookup.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "token lookup - Command"
-sidebar_title: "lookup"
+sidebar_title: "<code>lookup</code>"
 sidebar_current: "docs-commands-token-lookup"
 description: |-
   The "token lookup" displays information about a token or accessor. If a TOKEN

--- a/website/source/docs/commands/token/renew.html.md
+++ b/website/source/docs/commands/token/renew.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "token renew - Command"
-sidebar_title: "renew"
+sidebar_title: "<code>renew</code>"
 sidebar_current: "docs-commands-token-renew"
 description: |-
   The "token renew" renews a token's lease, extending the amount of time it can

--- a/website/source/docs/commands/token/revoke.html.md
+++ b/website/source/docs/commands/token/revoke.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "token revoke - Command"
-sidebar_title: "revoke"
+sidebar_title: "<code>revoke</code>"
 sidebar_current: "docs-commands-token-revoke"
 description: |-
   The "token revoke" revokes authentication tokens and their children. If a

--- a/website/source/docs/commands/unwrap.html.md
+++ b/website/source/docs/commands/unwrap.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "unwrap - Command"
-sidebar_title: "unwrap"
+sidebar_title: "<code>unwrap</code>"
 sidebar_current: "docs-commands-unwrap"
 description: |-
   The "unwrap" command unwraps a wrapped secret from Vault by the given token.

--- a/website/source/docs/commands/write.html.md
+++ b/website/source/docs/commands/write.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "write - Command"
-sidebar_title: "write"
+sidebar_title: "<code>write</code>"
 sidebar_current: "docs-commands-write"
 description: |-
   The "write" command writes data to Vault at the given path. The data can be

--- a/website/source/docs/configuration/listener/index.html.md
+++ b/website/source/docs/configuration/listener/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Listeners - Configuration"
-sidebar_title: "<tt>listener</tt>"
+sidebar_title: "<code>listener</code>"
 sidebar_current: "docs-configuration-listener"
 description: |-
   The listener stanza configures the addresses and ports on which Vault will

--- a/website/source/docs/configuration/seal/index.html.md
+++ b/website/source/docs/configuration/seal/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Seals - Configuration"
-sidebar_title: "<tt>seal</tt>"
+sidebar_title: "<code>seal</code>"
 sidebar_current: "docs-configuration-seal"
 description: |-
   The seal stanza configures the seal type to use for additional data protection.

--- a/website/source/docs/configuration/storage/index.html.md
+++ b/website/source/docs/configuration/storage/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Storage Backends - Configuration"
-sidebar_title: "<tt>storage</tt>"
+sidebar_title: "<code>storage</code>"
 sidebar_current: "docs-configuration-storage"
 description: |-
   The storage stanza configures the storage backend, which represents the

--- a/website/source/docs/configuration/telemetry.html.md
+++ b/website/source/docs/configuration/telemetry.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Telemetry - Configuration"
-sidebar_title: "<tt>telemetry</tt>"
+sidebar_title: "<code>telemetry</code>"
 sidebar_current: "docs-configuration-telemetry"
 description: |-
   The telemetry stanza specifies various configurations for Vault to publish

--- a/website/source/docs/configuration/ui/index.html.md
+++ b/website/source/docs/configuration/ui/index.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "UI - Configuration"
-sidebar_title: "<tt>ui</tt>"
+sidebar_title: "<code>ui</code>"
 sidebar_current: "docs-configuration-ui"
 description: |-
   Vault features a user interface (web interface) for interacting with Vault.


### PR DESCRIPTION
This PR does two things:

1. This will go through all markdown front matter and remove any `<tt>` tags that are being used in `sidebar_title`, replacing them with `<code>` since the use of `<tt>` is obsolete and discouraged (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt).

1. (@mitchellh - hoping to get your eyes and approval on this to be sure this is something we want and that you're ok with this update).  Based on design feedback, navigation items in the "Commands (CLI)" category should be in monospace font.  Commit 702647c will add `<code>` around `sidebar_title` front matter on pages in the commands category, which will display these page titles as monospace in the `docs-sidenav` and `docs-sitemap` components.  You can see this in action below:

![screen shot 2018-10-29 at 10 52 17 am](https://user-images.githubusercontent.com/5368111/47668382-e550dc00-db6d-11e8-9f5f-d83992181b79.png)

![screen shot 2018-10-25 at 2 30 47 pm](https://user-images.githubusercontent.com/5368111/47668395-ed108080-db6d-11e8-8599-42f3f46c7b36.png)

If we don't want to change the Commands pages, we can remove that commit from this PR and move forward with removing the `<tt>` tags.