### PR TITLE
enable alicloud in the ui

### DIFF
--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -8,6 +8,12 @@ const MOUNTABLE_SECRET_ENGINES = [
     category: 'cloud',
   },
   {
+    displayName: 'AliCloud',
+    value: 'alicloud',
+    type: 'alicloud',
+    category: 'cloud',
+  },
+  {
     displayName: 'AWS',
     value: 'aws',
     type: 'aws',

--- a/ui/app/templates/components/wizard/alicloud-engine.hbs
+++ b/ui/app/templates/components/wizard/alicloud-engine.hbs
@@ -1,0 +1,10 @@
+<WizardSection
+  @headerText="AliCloud"
+  @headerIcon="enable/alicloud"
+  @docText="Docs: Google Cloud Secrets"
+  @docPath="/docs/secrets/alicloud/index.html"
+>
+  <p>
+    The AliCloud secrets engine dynamically generates AliCloud access tokens based on RAM policies, or AliCloud STS credentials based on RAM roles. This generally makes working with AliCloud easier, since it does not involve clicking in the web UI. The AliCloud access tokens are time-based and are automatically revoked when the Vault lease expires. STS credentials are short-lived, non-renewable, and expire on their own.
+  </p>
+</WizardSection>

--- a/ui/tests/acceptance/secrets/backend/alicloud/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/alicloud/secret-test.js
@@ -1,0 +1,31 @@
+import { currentRouteName } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
+import backendsPage from 'vault/tests/pages/secrets/backends';
+import authPage from 'vault/tests/pages/auth';
+import withFlash from 'vault/tests/helpers/with-flash';
+
+module('Acceptance | alicloud/enable', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    return authPage.login();
+  });
+
+  test('enable alicloud', async function(assert) {
+    let enginePath = `alicloud-${new Date().getTime()}`;
+    await mountSecrets.visit();
+    await mountSecrets.selectType('alicloud');
+    await withFlash(
+      mountSecrets
+        .next()
+        .path(enginePath)
+        .submit()
+    );
+
+    assert.equal(currentRouteName(), 'vault.cluster.secrets.backends', 'redirects to the backends page');
+
+    assert.ok(backendsPage.rows.filterBy('path', `${enginePath}/`)[0], 'shows the alicloud engine');
+  });
+});


### PR DESCRIPTION
This PR adds the ability to enable the AliCloud secrets engine in the Vault UI. Users will still need to manually configure the engine via the cli using the instructions in the [docs](https://www.vaultproject.io/docs/secrets/alicloud/index.html).
[JIRA ticket](https://hashicorp.atlassian.net/browse/VAULT-270)

### Testing instructions
- Verify you can enable AliCloud
<img width="617" alt="screen shot 2018-10-29 at 3 45 55 pm" src="https://user-images.githubusercontent.com/903288/47684894-c6644100-db91-11e8-96f2-a29682c6588f.png">