### PR TITLE
Fixed wording from "SQL" to "MongoDB" for clarity

### DIFF
--- a/website/source/docs/secrets/databases/mongodb.html.md
+++ b/website/source/docs/secrets/databases/mongodb.html.md
@@ -41,8 +41,8 @@ more information about setting up the database secrets engine.
         password="Password!"
     ```
 
-1. Configure a role that maps a name in Vault to an SQL statement to execute to
-create the database credential:
+1. Configure a role that maps a name in Vault to a MongoDB command that executes and
+creates the database credential:
 
     ```text
     $ vault write database/roles/my-role \


### PR DESCRIPTION
The original wording made it appear as if SQL statements were being executed against a MongoDB backend, which is incorrect and confusing.  Fixed to better reflect what is actually occurring.