### PR TITLE
ui kv routing fix

### DIFF
--- a/ui/app/components/navigate-input.js
+++ b/ui/app/components/navigate-input.js
@@ -61,7 +61,7 @@ export default Component.extend(FocusOnInsertMixin, {
     return `cert/${key}`;
   },
   onEnter: function(val) {
-    let { filter, baseKey, mode } = this;
+    let { baseKey, mode } = this;
     let extraParams = this.get('extraNavParams');
     if (mode.startsWith('secrets') && (!val || val === baseKey)) {
       return;

--- a/ui/app/components/navigate-input.js
+++ b/ui/app/components/navigate-input.js
@@ -61,8 +61,7 @@ export default Component.extend(FocusOnInsertMixin, {
     return `cert/${key}`;
   },
   onEnter: function(val) {
-    let baseKey = this.get('baseKey');
-    let mode = this.get('mode');
+    let { filter, baseKey, mode } = this;
     let extraParams = this.get('extraNavParams');
     if (mode.startsWith('secrets') && (!val || val === baseKey)) {
       return;
@@ -78,7 +77,7 @@ export default Component.extend(FocusOnInsertMixin, {
       if (baseKey) {
         this.transitionToRoute(route, this.keyForNav(baseKey), {
           queryParams: {
-            initialKey: val.replace(this.keyForNav(baseKey), ''),
+            initialKey: val,
           },
         });
       } else {

--- a/ui/app/routes/vault/cluster/secrets/backend/create.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create.js
@@ -2,9 +2,10 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   beforeModel() {
-    let { secret } = this.paramsFor(this.routeName);
+    let { secret, initialKey } = this.paramsFor(this.routeName);
+    let qp = initialKey || secret;
     return this.transitionTo('vault.cluster.secrets.backend.create-root', {
-      queryParams: { initialKey: secret },
+      queryParams: { initialKey: qp },
     });
   },
 });

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -70,9 +70,11 @@ export default Route.extend({
           return model;
         })
         .catch(err => {
+          // if we're at the root we don't want to throw
           if (backendModel && err.httpStatus === 404 && secret === '') {
             return [];
           } else {
+            // else we're throwing and dealing with this in the error action
             throw err;
           }
         }),
@@ -153,9 +155,9 @@ export default Route.extend({
       if (hasModel && error.httpStatus === 404) {
         this.set('has404', true);
         transition.abort();
-      } else {
-        return true;
+        return false;
       }
+      return true;
     },
 
     willTransition(transition) {

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -111,6 +111,11 @@ export default Route.extend({
     let { backend } = this.paramsFor('vault.cluster.secrets.backend');
     let backendModel = this.store.peekRecord('secret-engine', backend);
     let has404 = this.get('has404');
+    // only clear store cache if this is a new model
+    if (secret !== controller.get('baseKey.id')) {
+      this.store.clearAllDatasets();
+    }
+
     controller.set('hasModel', true);
     controller.setProperties({
       model,

--- a/ui/app/services/router.js
+++ b/ui/app/services/router.js
@@ -1,6 +1,43 @@
 import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
+export function extractRouteArgs(args) {
+  args = args.slice();
+  let possibleQueryParams = args[args.length - 1];
+
+  let queryParams;
+  if (possibleQueryParams && possibleQueryParams.hasOwnProperty('queryParams')) {
+    queryParams = args.pop().queryParams;
+  } else {
+    queryParams = {};
+  }
+
+  let routeName = args.shift();
+
+  return { routeName, models: args, queryParams };
+}
+//https://github.com/emberjs/ember.js/blob/abf753a3d494830dc9e95b1337b3654b671b11be/packages/ember-routing/lib/utils.js#L210
+export function shallowEqual(a, b) {
+  let k;
+  let aCount = 0;
+  let bCount = 0;
+  for (k in a) {
+    if (a.hasOwnProperty(k)) {
+      if (a[k] !== b[k]) {
+        return false;
+      }
+      aCount++;
+    }
+  }
+
+  for (k in b) {
+    if (b.hasOwnProperty(k)) {
+      bCount++;
+    }
+  }
+
+  return aCount === bCount;
+}
 
 export default Service.extend({
   routing: service('-routing'),
@@ -20,4 +57,24 @@ export default Service.extend({
   currentURL: alias('router.currentURL'),
   currentRouteName: alias('router.currentRouteName'),
   rootURL: alias('router.rootURL'),
+  location: alias('router.location'),
+
+  //adapted from:
+  // https://github.com/emberjs/ember.js/blob/abf753a3d494830dc9e95b1337b3654b671b11be/packages/ember-routing/lib/services/router.js#L220
+  isActive(...args) {
+    let { routeName, models, queryParams } = extractRouteArgs(args);
+    let routerMicrolib = this.router._routerMicrolib;
+
+    if (!routerMicrolib.isActiveIntent(routeName, models, null)) {
+      return false;
+    }
+    let hasQueryParams = Object.keys(queryParams).length > 0;
+
+    if (hasQueryParams) {
+      this.router._prepareQueryParams(routeName, models, queryParams, true /* fromRouterService */);
+      return shallowEqual(queryParams, routerMicrolib.state.queryParams);
+    }
+
+    return true;
+  },
 });

--- a/ui/app/services/router.js
+++ b/ui/app/services/router.js
@@ -1,0 +1,23 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import { alias } from '@ember/object/computed';
+
+export default Service.extend({
+  routing: service('-routing'),
+  router: alias('routing.router'),
+  transitionTo() {
+    let r = this.router;
+    return r.transitionTo.call(r, ...arguments);
+  },
+  replaceWith() {
+    let r = this.router;
+    return r.replaceWith.call(r, ...arguments);
+  },
+  urlFor() {
+    let r = this.router;
+    return r.generate.call(r, ...arguments);
+  },
+  currentURL: alias('router.currentURL'),
+  currentRouteName: alias('router.currentRouteName'),
+  rootURL: alias('router.rootURL'),
+});

--- a/ui/app/templates/components/navigate-input.hbs
+++ b/ui/app/templates/components/navigate-input.hbs
@@ -5,6 +5,7 @@
     disabled={{disabled}}
     value={{@filter}}
     placeholder={{ or @placeholder "Filter keys" }}
+    type="text"
 
     oninput={{action "handleInput" value="target.value"}}
     onkeyup={{action "handleKeyUp" }}

--- a/ui/app/templates/components/secret-list-header.hbs
+++ b/ui/app/templates/components/secret-list-header.hbs
@@ -31,7 +31,7 @@
             {{#secret-link
               mode="create"
               secret=''
-              queryParams=(query-params initialKey=baseKey.id)
+              queryParams=(query-params initialKey=(or filter baseKey.id))
               class="button has-icon-right is-ghost is-compact"
               data-test-secret-create=true
             }}

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -1,4 +1,4 @@
-{{secret-list-header isCertTab=(eq tab "certs") model=backendModel baseKey=baseKey backendCrumb=backendCrumb}}
+{{secret-list-header isCertTab=(eq tab "certs") model=backendModel baseKey=baseKey backendCrumb=backendCrumb filter=filter}}
 
 {{#with (options-for-backend backendType tab) as |options|}}
   <div class="box is-sideless has-background-grey-lighter has-short-padding is-marginless">


### PR DESCRIPTION
Creating a new secret from the nav input on a secrets list page had a few issues:

1 -  it didn't take into account the partial filter if there was one (this is because we moved all secret creation to the root route instead of doing nested creates). 

2 - The input didn't focus on route change so using it became trickier - if you navigated by typing in a key with a slash, you had to manually re-focus the input

3 - Sometimes you'd get the default query params for all of the routes showing up in the URL when you navigated - this is apparently the desired behavior of the new router service in ember, but the way to opt out has not been implemented - (see https://github.com/emberjs/ember.js/issues/16973)

4 - The router service also causes more than the current model hook to re-fire so more of the template was re-rendering, sometimes causing uncaught errors (see https://github.com/emberjs/ember.js/issues/16349 and https://github.com/emberjs/ember.js/issues/15801)

Because of 3 and 4, this PR introduces a new router service that calls methods on the private `-routing` service that does not have these bugs (this is what we were doing pre 2.15 when the public router service was introduced). This is done in a way that once these bugs are worked out in the public router service, deleting `service/router.js` will again use the public routing service and we won't need to change the usage of that service throughout the application. Some of it is copied verbatim from the routing service, some of it just proxies to the existing private service.