### PR TITLE
Fix typo in test name

### DIFF
--- a/command/seal_migration_test.go
+++ b/command/seal_migration_test.go
@@ -108,7 +108,7 @@ func TestSealMigration(t *testing.T) {
 
 		core := cluster.Cores[0].Core
 
-		newSeal := vault.NewAutoSeal(seal.NeweTestSeal(logger))
+		newSeal := vault.NewAutoSeal(seal.NewTestSeal(logger))
 		newSeal.SetCore(core)
 		autoSeal = newSeal
 		if err := adjustCoreForSealMigration(context.Background(), core, coreConfig, newSeal, &server.Config{


### PR DESCRIPTION
This was causing some tests not to build.