### PR TITLE
Fix read/write typos in AWS backend docs

### DIFF
--- a/website/source/docs/secrets/aws/index.html.md
+++ b/website/source/docs/secrets/aws/index.html.md
@@ -252,11 +252,11 @@ that overrides the allow.)
 }
 ```
 
-To generate a new set of STS federation token credentials, we simply write to
-the role using the aws/sts endpoint:
+To generate a new set of STS federation token credentials, we simply read from
+the role using the aws/sts (or aws/creds) endpoint:
 
 ```text
-$ vault write aws/sts/ec2_admin ttl=60m
+$ vault read aws/sts/ec2_admin ttl=60m
 Key            	Value
 lease_id       	aws/sts/ec2_admin/31d771a6-fb39-f46b-fdc5-945109106422
 lease_duration 	60m0s
@@ -342,11 +342,11 @@ $ vault write aws/roles/deploy \
     credential_type=assumed_role
 ```
 
-To generate a new set of STS assumed role credentials, we again write to
-the role using the aws/sts endpoint:
+To generate a new set of STS assumed role credentials, we again read from
+the role using the aws/sts (or aws/creds) endpoint:
 
 ```text
-$ vault write aws/sts/deploy ttl=60m
+$ vault read aws/sts/deploy ttl=60m
 Key            	Value
 lease_id       	aws/sts/deploy/31d771a6-fb39-f46b-fdc5-945109106422
 lease_duration 	60m0s


### PR DESCRIPTION
This fixes two instances of the same typo in the AWS backend documentation.