### PR TITLE
serve robots.txt from the root when the UI is enabled

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -123,6 +123,7 @@ func Handler(props *vault.HandlerProperties) http.Handler {
 	if core.UIEnabled() == true {
 		if uiBuiltIn {
 			mux.Handle("/ui/", http.StripPrefix("/ui/", gziphandler.GzipHandler(handleUIHeaders(core, handleUI(http.FileServer(&UIAssetWrapper{FileSystem: assetFS()}))))))
+			mux.Handle("/robots.txt", gziphandler.GzipHandler(handleUIHeaders(core, handleUI(http.FileServer(&UIAssetWrapper{FileSystem: assetFS()})))))
 		} else {
 			mux.Handle("/ui/", handleUIHeaders(core, handleUIStub()))
 		}
@@ -182,7 +183,7 @@ func wrapGenericHandler(core *vault.Core, h http.Handler, maxRequestSize int64, 
 			}
 			r = newR
 
-		case strings.HasPrefix(r.URL.Path, "/ui"), r.URL.Path == "/":
+		case strings.HasPrefix(r.URL.Path, "/ui"), r.URL.Path == "/robots.txt", r.URL.Path == "/":
 		default:
 			respondError(w, http.StatusNotFound, nil)
 			cancelFunc()


### PR DESCRIPTION
Currently if the UI is enabled, the `robots.txt` file is in the wrong place. It is not recommended to run Vault exposed to the internet, but in the event that it happens, this will prevent Vault's UI page from being crawled by search engine spiders.

Fixes https://github.com/hashicorp/vault/issues/5585