### PR TITLE
UI: change backends template so that the icon shows in a namespace

### DIFF
--- a/ui/app/templates/components/secret-list-header.hbs
+++ b/ui/app/templates/components/secret-list-header.hbs
@@ -16,7 +16,7 @@
     </p.top>
     <p.levelLeft>
       <h1 class="title is-3">
-        {{i-con glyph=(or (concat "enable/" model.type) "enable/secrets") size=24 class="has-text-grey-light"}}
+        {{i-con glyph=(or (concat "enable/" model.engineType) "enable/secrets") size=24 class="has-text-grey-light"}}
         {{model.id}}
         {{#if (eq model.options.version 2)}}
           <span class="tag">

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -22,7 +22,7 @@
         <div>
           <ToolTip @horizontalPosition="left" as |T|>
             <T.trigger>
-              <ICon @glyph={{concat "enable/" (or method.type "auth")}} @size=24 @class="has-text-grey-light"/>
+              <ICon @glyph={{concat "enable/" (or method.methodType "auth")}} @size=24 @class="has-text-grey-light"/>
             </T.trigger>
             <T.content @class="tool-tip">
               <div class="box">
@@ -34,11 +34,6 @@
             {{method.path}}
           </span>
           <br />
-          {{#if (eq method.methodType 'plugin')}}
-            <span class="tag">
-              {{method.methodType}}: {{method.config.plugin_name}}
-            </span>
-          {{/if}}
           <code class="has-text-grey is-size-8">
             {{method.accessor}}
           </code>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -24,11 +24,11 @@
         <div>
           <ToolTip @horizontalPosition="left" as |T|>
             <T.trigger>
-              <ICon @glyph={{concat "enable/" (or backend.type "secrets")}} @size=24 @class="has-text-grey-light"/>
+              <ICon @glyph={{concat "enable/" (or backend.engineType "secrets")}} @size="24" @class="has-text-grey-light" />
             </T.trigger>
             <T.content @class="tool-tip">
               <div class="box">
-                {{backend.type}}
+                {{backend.engineType}}
               </div>
             </T.content>
           </ToolTip>
@@ -39,11 +39,6 @@
             {{backend.path}}
           {{/link-to}}
           <br />
-          {{#if (eq backend.type 'plugin')}}
-            <span class="tag">
-              {{backend.type}}: {{backend.config.plugin_name}}
-            </span>
-          {{/if}}
           <code class="has-text-grey is-size-8">
           {{#if (eq backend.options.version 2)}}
             v2
@@ -85,21 +80,16 @@
           <div data-test-secret-path class="has-text-weight-semibold has-text-grey">
             <ToolTip @horizontalPosition="left" as |T|>
               <T.trigger>
-                <ICon @glyph={{concat "enable/" (or backend.type "secrets")}} @size=24 @class="has-text-grey-light"/>
+                <ICon @glyph={{concat "enable/" (or backend.engineType "secrets")}} @size=24 @class="has-text-grey-light"/>
               </T.trigger>
               <T.content @class="tool-tip">
                 <div class="box">
-                  {{backend.type}}
+                  {{backend.engineType}}
                 </div>
               </T.content>
             </ToolTip>
             {{backend.path}}
           </div>
-          {{#if (eq backend.type 'plugin')}}
-            <span class="tag">
-              {{backend.type}}: {{backend.config.plugin_name}}
-            </span>
-          {{/if}}
           <code class="has-text-grey is-size-8">
             {{backend.accessor}}
           </code>


### PR DESCRIPTION
Some of the templates needed `engineType` and `methodType` instead of `type` so that they weren't prefixed with `ns_` when you're in namespace.

This also removes the plugin block from those templates as they will be unnecessary after https://github.com/hashicorp/vault/pull/5536 lands. 


![screen shot 2018-11-05 at 4 31 47 pm](https://user-images.githubusercontent.com/39469/48032065-d775fa80-e11b-11e8-9e3f-36e8e41f3541.png)
![screen shot 2018-11-05 at 4 54 13 pm](https://user-images.githubusercontent.com/39469/48032066-d775fa80-e11b-11e8-9385-e42b835f3754.png)
![screen shot 2018-11-05 at 4 54 21 pm](https://user-images.githubusercontent.com/39469/48032067-d775fa80-e11b-11e8-98ad-f19cbbdb01f4.png)
