### PR TITLE
Update listing API/CLI to support listing all plugin types

### DIFF
--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -18,8 +18,8 @@ type ListPluginsInput struct {
 
 // ListPluginsResponse is the response from the ListPlugins call.
 type ListPluginsResponse struct {
-	// Types is the list of plugins by type.
-	NamesByType map[consts.PluginType][]string `json:"names"`
+	// PluginsByType is the list of plugins by type.
+	PluginsByType map[consts.PluginType][]string `json:"types"`
 }
 
 // ListPlugins lists all plugins in the catalog and returns their names as a
@@ -54,7 +54,7 @@ func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 	}
 
 	result := &ListPluginsResponse{
-		NamesByType: make(map[consts.PluginType][]string),
+		PluginsByType: make(map[consts.PluginType][]string),
 	}
 	if i.Type == consts.PluginTypeUnknown {
 		for pluginTypeStr, pluginsRaw := range secret.Data {
@@ -76,14 +76,14 @@ func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 				}
 				plugins[i] = name
 			}
-			result.NamesByType[pluginType] = plugins
+			result.PluginsByType[pluginType] = plugins
 		}
 	} else {
 		var respKeys []string
 		if err := mapstructure.Decode(secret.Data["keys"], &respKeys); err != nil {
 			return nil, err
 		}
-		result.NamesByType[i.Type] = respKeys
+		result.PluginsByType[i.Type] = respKeys
 	}
 
 	return result, nil

--- a/command/base_predict.go
+++ b/command/base_predict.go
@@ -353,7 +353,7 @@ func (p *Predict) plugins(pluginTypes ...consts.PluginType) []string {
 		if err != nil {
 			return nil
 		}
-		for _, names := range result.NamesByType {
+		for _, names := range result.PluginsByType {
 			for _, name := range names {
 				if _, ok := pluginsAdded[name]; !ok {
 					plugins = append(plugins, name)

--- a/command/plugin_deregister.go
+++ b/command/plugin_deregister.go
@@ -61,10 +61,10 @@ func (c *PluginDeregisterCommand) Run(args []string) int {
 	args = f.Args()
 	switch {
 	case len(args) < 2:
-		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", len(args)))
 		return 1
 	case len(args) > 2:
-		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", len(args)))
 		return 1
 	}
 

--- a/command/plugin_deregister_test.go
+++ b/command/plugin_deregister_test.go
@@ -119,7 +119,7 @@ func TestPluginDeregisterCommand_Run(t *testing.T) {
 		}
 
 		found := false
-		for _, plugins := range resp.NamesByType {
+		for _, plugins := range resp.PluginsByType {
 			for _, p := range plugins {
 				if p == pluginName {
 					found = true
@@ -127,7 +127,7 @@ func TestPluginDeregisterCommand_Run(t *testing.T) {
 			}
 		}
 		if found {
-			t.Errorf("expected %q to not be in %q", pluginName, resp.NamesByType)
+			t.Errorf("expected %q to not be in %q", pluginName, resp.PluginsByType)
 		}
 	})
 

--- a/command/plugin_list.go
+++ b/command/plugin_list.go
@@ -101,7 +101,7 @@ func (c *PluginListCommand) Run(args []string) int {
 
 func formatListPluginsResponse(resp *api.ListPluginsResponse) map[string]interface{} {
 	res := make(map[string]interface{})
-	for k, v := range resp.NamesByType {
+	for k, v := range resp.PluginsByType {
 		res[k.String()] = v
 	}
 	return res

--- a/command/plugin_register.go
+++ b/command/plugin_register.go
@@ -99,10 +99,10 @@ func (c *PluginRegisterCommand) Run(args []string) int {
 	args = f.Args()
 	switch {
 	case len(args) < 2:
-		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 1, got %d)", len(args)))
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2, got %d)", len(args)))
 		return 1
 	case len(args) > 2:
-		c.UI.Error(fmt.Sprintf("Too many arguments (expected 1, got %d)", len(args)))
+		c.UI.Error(fmt.Sprintf("Too many arguments (expected 2, got %d)", len(args)))
 		return 1
 	case c.flagSHA256 == "":
 		c.UI.Error("SHA256 is required for all plugins, please provide -sha256")

--- a/command/plugin_register_test.go
+++ b/command/plugin_register_test.go
@@ -111,7 +111,7 @@ func TestPluginRegisterCommand_Run(t *testing.T) {
 		}
 
 		found := false
-		for _, plugins := range resp.NamesByType {
+		for _, plugins := range resp.PluginsByType {
 			for _, p := range plugins {
 				if p == pluginName {
 					found = true
@@ -119,7 +119,7 @@ func TestPluginRegisterCommand_Run(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("expected %q to be in %q", pluginName, resp.NamesByType)
+			t.Errorf("expected %q to be in %q", pluginName, resp.PluginsByType)
 		}
 	})
 


### PR DESCRIPTION
```
› vault plugin list
Key         Value
---         -----
auth        [alicloud app-id approle aws azure centrify cert gcp github jwt kubernetes ldap mock-plugin my-mock-plugin mysql-database-plugin okta passthrough-plugin radius totp-plugin userpass vault-auth-plugin-example vault-plugin-auth-gcp vault-secrets-gen-moved]
database    [cassandra-database-plugin hana-database-plugin mock-plugin mongodb-database-plugin mssql-database-plugin my-mock-plugin mysql-aurora-database-plugin mysql-database-plugin mysql-legacy-database-plugin mysql-rds-database-plugin passthrough-plugin postgresql-database-plugin totp-plugin vault-auth-plugin-example vault-plugin-auth-gcp vault-secrets-gen-moved]
secret      [ad alicloud aws azure cassandra consul gcp gcpkms kv mock-plugin mongodb mssql my-mock-plugin mysql mysql-database-plugin nomad passthrough-plugin pki postgresql rabbitmq ssh totp totp-plugin transit vault-auth-plugin-example vault-plugin-auth-gcp vault-secrets-gen-moved]
unknown     [mock-plugin my-mock-plugin mysql-database-plugin passthrough-plugin totp-plugin vault-auth-plugin-example vault-plugin-auth-gcp vault-secrets-gen-moved]
```

```
› vault plugin list -format=json
{
  "auth": [
    "alicloud",
    "app-id",
    "approle",
    "aws",
    "azure",
    "centrify",
    "cert",
    "gcp",
    "github",
    "jwt",
    "kubernetes",
    "ldap",
    "mock-plugin",
    "my-mock-plugin",
    "mysql-database-plugin",
    "okta",
    "passthrough-plugin",
    "radius",
    "totp-plugin",
    "userpass",
    "vault-auth-plugin-example",
    "vault-plugin-auth-gcp",
    "vault-secrets-gen-moved"
  ],
  "database": [
    "cassandra-database-plugin",
    "hana-database-plugin",
    "mock-plugin",
    "mongodb-database-plugin",
    "mssql-database-plugin",
    "my-mock-plugin",
    "mysql-aurora-database-plugin",
    "mysql-database-plugin",
    "mysql-legacy-database-plugin",
    "mysql-rds-database-plugin",
    "passthrough-plugin",
    "postgresql-database-plugin",
    "totp-plugin",
    "vault-auth-plugin-example",
    "vault-plugin-auth-gcp",
    "vault-secrets-gen-moved"
  ],
  "secret": [
    "ad",
    "alicloud",
    "aws",
    "azure",
    "cassandra",
    "consul",
    "gcp",
    "gcpkms",
    "kv",
    "mock-plugin",
    "mongodb",
    "mssql",
    "my-mock-plugin",
    "mysql",
    "mysql-database-plugin",
    "nomad",
    "passthrough-plugin",
    "pki",
    "postgresql",
    "rabbitmq",
    "ssh",
    "totp",
    "totp-plugin",
    "transit",
    "vault-auth-plugin-example",
    "vault-plugin-auth-gcp",
    "vault-secrets-gen-moved"
  ],
  "unknown": [
    "mock-plugin",
    "my-mock-plugin",
    "mysql-database-plugin",
    "passthrough-plugin",
    "totp-plugin",
    "vault-auth-plugin-example",
    "vault-plugin-auth-gcp",
    "vault-secrets-gen-moved"
  ]
}
```