### PR TITLE
simplify a case of strings.Index with strings.Contains

### DIFF
--- a/helper/identity/templating.go
+++ b/helper/identity/templating.go
@@ -36,7 +36,7 @@ func PopulateString(p *PopulateStringInput) (bool, string, error) {
 	splitStr := strings.Split(p.String, "{{")
 
 	if len(splitStr) >= 1 {
-		if strings.Index(splitStr[0], "}}") != -1 {
+		if strings.Contains(splitStr[0], "}}") {
 			return false, "", ErrUnbalancedTemplatingCharacter
 		}
 		if len(splitStr) == 1 {


### PR DESCRIPTION
Simplifes a case of strings.Index with strings.Contains. Inspired by https://staticcheck.io/docs/gosimple#S1003