### PR TITLE
website: remove deleted markdown reference from docs sidenav .yml

### DIFF
--- a/website/data/docs_detailed_categories.yml
+++ b/website/data/docs_detailed_categories.yml
@@ -122,7 +122,6 @@
   title: "Plugin Backends"
   docs:
     - docs/plugin/index.html
-    - docs/plugin/partnerships.html
 -
   title: "Vault Enterprise"
   docs:


### PR DESCRIPTION
This removes the `docs/plugin/partnerships.html` reference from the docs sidenav .yml file.  The referenced file was removed with e10783d1402dd4a31f200300657d45e2deeb4024, which has broken the build.  This should fix that.