### PR TITLE
Ui babel polyfill

### DIFF
--- a/ui/app/templates/partials/tools/hash.hbs
+++ b/ui/app/templates/partials/tools/hash.hbs
@@ -88,7 +88,7 @@
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">
       <button
-         type="sumbit"
+         type="submit"
          class="button is-primary"
          data-test-tools-submit="true"
          >

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -3,7 +3,7 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-module.exports = function (defaults) {
+module.exports = function(defaults) {
   var config = defaults.project.config(EmberApp.env());
   var app = new EmberApp(defaults, {
     favicons: {

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -3,7 +3,7 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-module.exports = function(defaults) {
+module.exports = function (defaults) {
   var config = defaults.project.config(EmberApp.env());
   var app = new EmberApp(defaults, {
     favicons: {
@@ -31,6 +31,9 @@ module.exports = function(defaults) {
     },
     babel: {
       plugins: ['transform-object-rest-spread'],
+    },
+    'ember-cli-babel': {
+      includePolyfill: true,
     },
     autoprefixer: {
       grid: true,


### PR DESCRIPTION
IE 11 now need the babel polyfill, so this adds it!

Also: the hash tool had a typo in the HTML that meant IE 11 wouldn't submit the form, or throw an error, or do anything. Now it's a `<button type="submit" />` instead of `<button type="sumbit" />` and all browsers are happier.