### PR TITLE
Call wg.Add outside of goroutine

### DIFF
--- a/builtin/credential/approle/path_tidy_user_id_test.go
+++ b/builtin/credential/approle/path_tidy_user_id_test.go
@@ -124,8 +124,8 @@ func TestAppRole_TidyDanglingAccessors_RaceTest(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
+		wg.Add(1)
 		go func() {
-			wg.Add(1)
 			defer wg.Done()
 			roleSecretIDReq := &logical.Request{
 				Operation: logical.UpdateOperation,


### PR DESCRIPTION
Fixes potential data races like these: https://travis-ci.org/hashicorp/vault/jobs/451486838

As suggested here, we should call `wg.Add(1)` outside of the goroutine: https://github.com/golang/go/issues/23842