### PR TITLE
Redirect old /intro/index.html to /index.html

### DIFF
--- a/website/redirects.txt
+++ b/website/redirects.txt
@@ -97,6 +97,7 @@
 /docs/secrets/generic/index.html       /docs/secrets/kv/index.html
 /intro/getting-started/acl.html        /intro/getting-started/policies.html
 /intro/getting-started/secret-backends.html   /intro/getting-started/secrets-engines.html
+/intro/index.html                             /index.html
 
 /guides/configuration/policies.html                /guides/identity/policies.html
 /guides/configuration/authentication.html          /guides/identity/authentication.html


### PR DESCRIPTION
An old location was not redirected. I believe old page has been broken up now, with some of the content over on [learn.hashicorp.com/vault/](https://learn.hashicorp.com/vault/) now, so at this time we'll just redirect to the [`/index.html`](https://www.vaultproject.io/). Alternatively we could redirect to [`/docs/`](https://www.vaultproject.io/docs/).

Fixes https://github.com/hashicorp/vault/issues/5681

cc https://github.com/kelseyhightower/vault-on-google-kubernetes-engine/pull/10