### PR TITLE
Fix two problems with entity alias updating

### DIFF
--- a/vault/identity_store_aliases.go
+++ b/vault/identity_store_aliases.go
@@ -217,7 +217,6 @@ func (i *IdentityStore) handleAliasUpdateCommon() framework.OperationFunc {
 				// If entity is nil, we didn't find a previous alias from factors,
 				// so append to this entity
 				entity = canonicalEntity
-				i.logger.Warn("entity was nil, appending alias to this entity")
 				entity.Aliases = append(entity.Aliases, alias)
 			} else if entity.ID != canonicalEntity.ID {
 				// In this case we found an entity from alias factors or given
@@ -227,15 +226,12 @@ func (i *IdentityStore) handleAliasUpdateCommon() framework.OperationFunc {
 
 				for aliasIndex, item := range previousEntity.Aliases {
 					if item.ID == alias.ID {
-						i.logger.Warn("eliding entity", "previous", previousEntity.Aliases)
 						previousEntity.Aliases = append(previousEntity.Aliases[:aliasIndex], previousEntity.Aliases[aliasIndex+1:]...)
-						i.logger.Warn("eliding entity", "after", previousEntity.Aliases)
 						break
 					}
 				}
 
 				entity.Aliases = append(entity.Aliases, alias)
-				i.logger.Warn("entity was found, appending alias to this entity")
 				resp.AddWarning(fmt.Sprintf("alias is being transferred from entity %q to %q", previousEntity.ID, entity.ID))
 			}
 		}


### PR DESCRIPTION
See
https://github.com/hashicorp/vault/issues/5729#issuecomment-436882254
for details

Fixes #5729 

TODO:
-- Remove comments [Done]
-- Fix tests [No test errors]
-- Does group handling suffer from the same problem? [No]
-- Merging behavior -- should we merge or simply error out? See discussion in the related ticket. [Discussion deferred]
-- We really should ensure that no upsert function ever does a query, or does so _very carefully_, it will likely always be against stale data [Noted]