### PR TITLE
Use a pooled HTTP client for the Vault CLI

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -121,7 +121,7 @@ type TLSConfig struct {
 func DefaultConfig() *Config {
 	config := &Config{
 		Address:    "https://127.0.0.1:8200",
-		HttpClient: cleanhttp.DefaultClient(),
+		HttpClient: cleanhttp.DefaultPooledClient(),
 	}
 	config.HttpClient.Timeout = time.Second * 60
 


### PR DESCRIPTION
As the CLI client is initialized with a specific Vault address, is makes
sense to use the pooled HTTP client here. This will prevent setting up
new TCP sessions for each API call that the client needs to make.