### PR TITLE
Use inclusive range on cert role diff comparison

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -984,7 +984,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 			actualDiff := time.Now().Sub(cert.NotBefore)
 			certRoleDiff := (role.NotBeforeDuration - actualDiff).Truncate(time.Second)
 			// These times get truncated, so give a 1 second buffer on each side
-			if certRoleDiff > -1*time.Second && certRoleDiff < 1*time.Second {
+			if certRoleDiff >= -1*time.Second && certRoleDiff <= 1*time.Second {
 				return nil
 			}
 			return fmt.Errorf("validity period out of range diff: %v", certRoleDiff)


### PR DESCRIPTION
Makes `Truncate` useful and tests to pass on cases like `-1.01` -> `-1`. Third time's a charm :)