### PR TITLE
AliCloud auto-unseal bug fix and acceptance test

### DIFF
--- a/vault/seal/alicloudkms/alicloudkms_test.go
+++ b/vault/seal/alicloudkms/alicloudkms_test.go
@@ -74,6 +74,39 @@ func TestAliCloudKMSSeal_Lifecycle(t *testing.T) {
 	}
 }
 
+// This test executes real calls. The calls themselves should be free,
+// but the KMS key used is generally not free. Alibaba doesn't publish
+// the price but it can be assumed to be around $1/month because that's
+// what AWS charges for the same.
+//
+// To run this test, the following env variables need to be set:
+//   - VAULT_ALICLOUDKMS_SEAL_KEY_ID
+//   - ALICLOUD_REGION
+//   - ALICLOUD_ACCESS_KEY
+//   - ALICLOUD_SECRET_KEY
+func TestAccAliCloudKMSSeal_Lifecycle(t *testing.T) {
+	if os.Getenv(EnvAliCloudKMSSealKeyID) == "" {
+		t.SkipNow()
+	}
+
+	s := NewSeal(logging.NewVaultLogger(log.Trace))
+	s.SetConfig(nil)
+	input := []byte("foo")
+	swi, err := s.Encrypt(context.Background(), input)
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+
+	pt, err := s.Decrypt(context.Background(), swi)
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+
+	if !reflect.DeepEqual(input, pt) {
+		t.Fatalf("expected %s, got %s", input, pt)
+	}
+}
+
 type mockAliCloudKMSSealClient struct {
 	keyID string
 }


### PR DESCRIPTION
- Fixes a bug where the AliCloud API failed to properly encode and decode strings because they weren't base64
- Adds an acceptance test
- Slightly simplifies the code