### PR TITLE
ui/add disable secret engine button

### DIFF
--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -115,9 +115,10 @@ export default Component.extend({
       // err will display via model state
       return;
     }
-    this.get('flashMessages').success(
-      `Successfully mounted ${type} ${this.get('mountType')} method at ${path}.`
-    );
+
+    let mountType = this.get('mountType');
+    mountType = mountType === 'secret' ? `${mountType}s engine` : `${mountType} method`;
+    this.get('flashMessages').success(`Successfully mounted the ${type} ${mountType} at ${path}.`);
     if (this.get('mountType') === 'secret') {
       yield this.get('onMountSuccess')(type, path);
       return;

--- a/ui/app/controllers/vault/cluster/secrets/backends.js
+++ b/ui/app/controllers/vault/cluster/secrets/backends.js
@@ -1,6 +1,7 @@
 import { filterBy } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Controller from '@ember/controller';
+import { task } from 'ember-concurrency';
 import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
 const LINKED_BACKENDS = supportedSecretBackends();
 
@@ -25,4 +26,16 @@ export default Controller.extend({
         .sortBy('id');
     }
   ),
+
+  disableEngine: task(function*(engine) {
+    const { engineType, path } = engine;
+    try {
+      yield engine.destroyRecord();
+      this.get('flashMessages').success(`The ${engineType} secrets engine at ${path} has been disabled.`);
+    } catch (err) {
+      this.get('flashMessages').danger(
+        `There was an error disabling the ${engineType} secrets engine at ${path}: ${err.errors.join(' ')}.`
+      );
+    }
+  }).drop(),
 });

--- a/ui/app/templates/components/identity/popup-alias.hbs
+++ b/ui/app/templates/components/identity/popup-alias.hbs
@@ -9,7 +9,7 @@
       </li>
       {{#if item.updatePath.isPending}}
         <li class="action">
-          <button disabled=true type="button" class="link button is-loading is-transparent">
+          <button disabled type="button" class="link button is-loading is-transparent">
             loading
           </button>
         </li>

--- a/ui/app/templates/components/secret-version-menu.hbs
+++ b/ui/app/templates/components/secret-version-menu.hbs
@@ -31,7 +31,7 @@
             {{else}}
               {{#if isFetchingVersionCapabilities}}
                 <li class="action">
-                  <button disabled=true type="button" class="link button is-loading is-transparent">
+                  <button disabled type="button" class="link button is-loading is-transparent">
                     loading
                   </button>
                 </li>

--- a/ui/app/templates/partials/role-aws/popup-menu.hbs
+++ b/ui/app/templates/partials/role-aws/popup-menu.hbs
@@ -3,7 +3,7 @@
     <ul class="menu-list">
       {{#if item.generatePath.isPending}}
         <li class="action">
-          <button disabled=true type="button" class="link button is-loading is-transparent">
+          <button disabled type="button" class="link button is-loading is-transparent">
             loading
           </button>
         </li>
@@ -16,12 +16,12 @@
       {{/if}}
       {{#if item.updatePath.isPending}}
         <li class="action">
-          <button disabled=true type="button" class="link button is-loading is-transparent">
+          <button disabled type="button" class="link button is-loading is-transparent">
             loading
           </button>
         </li>
         <li class="action">
-          <button disabled=true type="button" class="link button is-loading is-transparent">
+          <button disabled type="button" class="link button is-loading is-transparent">
             loading
           </button>
         </li>

--- a/ui/app/templates/partials/role-pki/popup-menu.hbs
+++ b/ui/app/templates/partials/role-pki/popup-menu.hbs
@@ -3,7 +3,7 @@
     {{#if (or item.generatePath.isPending item.signPath.isPending)}}
       <ul class="menu-list">
         <li class="action">
-          <button disabled=true type="button" class="link button is-loading is-transparent">
+          <button disabled type="button" class="link button is-loading is-transparent">
             loading
           </button>
         </li>
@@ -29,12 +29,12 @@
     <ul class="menu-list">
       {{#if item.updatePath.isPending}}
         <li class="action">
-          <button disabled=true type="button" class="link button is-loading is-transparent">
+          <button disabled type="button" class="link button is-loading is-transparent">
             loading
           </button>
         </li>
         <li class="action">
-          <button disabled=true type="button" class="link button is-loading is-transparent">
+          <button disabled type="button" class="link button is-loading is-transparent">
             loading
           </button>
         </li>

--- a/ui/app/templates/partials/role-ssh/popup-menu.hbs
+++ b/ui/app/templates/partials/role-ssh/popup-menu.hbs
@@ -4,7 +4,7 @@
       {{#if (eq item.keyType 'otp')}}
         {{#if item.generatePath.isPending}}
           <li class="action">
-            <button disabled=true type="button" class="link button is-loading is-transparent">
+            <button disabled type="button" class="link button is-loading is-transparent">
               loading
             </button>
           </li>
@@ -18,7 +18,7 @@
       {{else if (eq item.keyType 'ca')}}
         {{#if item.signPath.isPending}}
           <li class="action">
-            <button disabled=true type="button" class="link button is-loading is-transparent">
+            <button disabled type="button" class="link button is-loading is-transparent">
               loading
             </button>
           </li>
@@ -32,12 +32,12 @@
       {{/if}}
       {{#if item.updatePath.isPending}}
         <li class="action">
-          <button disabled=true type="button" class="link button is-loading is-transparent">
+          <button disabled type="button" class="link button is-loading is-transparent">
             loading
           </button>
         </li>
         <li class="action">
-          <button disabled=true type="button" class="link button is-loading is-transparent">
+          <button disabled type="button" class="link button is-loading is-transparent">
             loading
           </button>
         </li>

--- a/ui/app/templates/partials/secret-list/item.hbs
+++ b/ui/app/templates/partials/secret-list/item.hbs
@@ -37,7 +37,7 @@
             {{else}}
               {{#if (or item.versionPath.isLoading item.secretPath.isLoading)}}
                 <li class="action">
-                  <button disabled=true type="button" class="link button is-loading is-transparent">
+                  <button disabled type="button" class="link button is-loading is-transparent">
                     loading
                   </button>
                 </li>

--- a/ui/app/templates/vault/cluster/access/identity/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/index.hbs
@@ -41,7 +41,7 @@
                 </li>
                 {{#if (or item.isReloading item.updatePath.isPending item.aliasPath.isPending)}}
                   <li class="action">
-                    <button disabled=true type="button" class="link button is-loading is-transparent">
+                    <button disabled type="button" class="link button is-loading is-transparent">
                       loading
                     </button>
                   </li>

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -63,7 +63,7 @@
                       confirmButtonClasses="button is-primary"
                       buttonClasses="link is-destroy"
                       onConfirmAction=(perform disableMethod method)
-                      confirmMessage=(concat "Are you sure you want to disable auth via " method.id "?")
+                      confirmMessage=(concat "Are you sure you want to disable the " method.id " auth method at " method.path "?")
                       showConfirm=(get this (concat "shouldDelete-" method.id))
                       class=(if (get this (concat "shouldDelete-" method.id)) "message is-block is-warning is-outline")
                       containerClasses="message-body is-block"

--- a/ui/app/templates/vault/cluster/policies/index.hbs
+++ b/ui/app/templates/vault/cluster/policies/index.hbs
@@ -90,12 +90,12 @@
                   <ul class="menu-list">
                     {{#if item.updatePath.isPending}}
                       <li class="action">
-                        <button disabled=true type="button" class="link button is-loading is-transparent">
+                        <button disabled type="button" class="link button is-loading is-transparent">
                           loading
                         </button>
                       </li>
                       <li class="action">
-                        <button disabled=true type="button" class="link button is-loading is-transparent">
+                        <button disabled type="button" class="link button is-loading is-transparent">
                           loading
                         </button>
                       </li>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -78,7 +78,7 @@
                    {{/unless}}
                  {{#if item.updatePath.isPending}}
                    <li class="action">
-                     <button disabled=true type="button" class="link button is-loading is-transparent"></button>
+                     <button disabled type="button" class="link button is-loading is-transparent"></button>
                     </li>
                  {{/if}}
               </ul>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -59,6 +59,23 @@
                      View Configuration
                    {{/link-to}}
                   </li>
+                  {{#unless (eq backend.type "cubbyhole")}}
+                  <li class="action">
+                    <ConfirmAction
+                      @confirmButtonClasses="button is-primary"
+                      @buttonClasses="link is-destroy"
+                      @onConfirmAction={{perform disableEngine backend}}
+                      @confirmMessage={{concat "Are you sure you want to disable the " backend.engineType " secrets engine at " backend.path "?"}}
+                      @showConfirm={{get this (concat "shouldDelete-" backend.id)}}
+                      @class={{if (get this (concat "shouldDelete-" backend.id)) "message is-block is-warning is-outline"}}
+                      @containerClasses="message-body is-block"
+                      @messageClasses="is-block"
+                      @confirmButtonText="Disable"
+                      data-test-engine-disable>
+                      Disable
+                    </ConfirmAction>
+                   </li>
+                   {{/unless}}
                  {{#if item.updatePath.isPending}}
                    <li class="action">
                      <button disabled=true type="button" class="link button is-loading is-transparent"></button>
@@ -104,6 +121,22 @@
                    {{#link-to "vault.cluster.secrets.backend.configuration" backend.id data-test-engine-config}}
                      View Configuration
                    {{/link-to}}
+                 </li>
+                 <li>
+                   <ConfirmAction
+                     @confirmButtonClasses="button is-primary"
+                     @buttonClasses="link is-destroy"
+                     @onConfirmAction={{perform disableEngine backend}}
+                     @confirmMessage={{concat "Are you sure you want to disable the " backend.engineType " secrets engine at " backend.path "?"}}
+                     @showConfirm={{get this (concat "shouldDelete-" backend.id)}}
+                     @class={{if (get this (concat "shouldDelete-" backend.id)) "message is-block is-warning is-outline"}}
+                     @containerClasses="message-body is-block"
+                     @messageClasses="is-block"
+                     @confirmButtonText="Disable"
+                     data-test-engine-disable
+                     >
+                     Disable
+                   </ConfirmAction>
                  </li>
                </ul>
             </nav>

--- a/ui/tests/acceptance/secrets/backend/engines-test.js
+++ b/ui/tests/acceptance/secrets/backend/engines-test.js
@@ -1,0 +1,36 @@
+import { currentRouteName } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
+import backendsPage from 'vault/tests/pages/secrets/backends';
+import authPage from 'vault/tests/pages/auth';
+
+module('Acceptance | engine/disable', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    return authPage.login();
+  });
+
+  test('disable engine', async function(assert) {
+    // first mount an engine so we can disable it.
+    let enginePath = `alicloud-${new Date().getTime()}`;
+    await mountSecrets.enable('alicloud', enginePath);
+
+    assert.ok(backendsPage.rows.filterBy('path', `${enginePath}/`)[0], 'shows the mounted engine');
+
+    await backendsPage.visit();
+    let row = backendsPage.rows.filterBy('path', `${enginePath}/`)[0];
+    await row.menu();
+    await backendsPage.disableButton();
+    await backendsPage.confirmDisable();
+
+    assert.equal(currentRouteName(), 'vault.cluster.secrets.backends', 'redirects to the backends page');
+
+    assert.equal(
+      backendsPage.rows.filterBy('path', `${enginePath}/`).length,
+      0,
+      'does not show the disabled engine'
+    );
+  });
+});

--- a/ui/tests/acceptance/settings/auth/enable-test.js
+++ b/ui/tests/acceptance/settings/auth/enable-test.js
@@ -22,7 +22,7 @@ module('Acceptance | settings/auth/enable', function(hooks) {
     await withFlash(page.enable(type, path), () => {
       assert.equal(
         page.flash.latestMessage,
-        `Successfully mounted ${type} auth method at ${path}.`,
+        `Successfully mounted the ${type} auth method at ${path}.`,
         'success flash shows'
       );
     });

--- a/ui/tests/pages/secrets/backends.js
+++ b/ui/tests/pages/secrets/backends.js
@@ -12,4 +12,10 @@ export default create({
   configLink: clickable('[data-test-engine-config]', {
     testContainer: '#ember-testing',
   }),
+  disableButton: clickable('[data-test-confirm-action-trigger]', {
+    testContainer: '#ember-testing',
+  }),
+  confirmDisable: clickable('[data-test-confirm-button]', {
+    testContainer: '#ember-testing',
+  }),
 });


### PR DESCRIPTION
Allow users to disable a secrets engine from the list page. All engines except cubbyhole should be able to be disabled.

+ Updated the messaging around enabling/disabling auth methods so it's consistent with secrets engines 💅 

![screen shot 2018-11-08 at 4 01 36 pm](https://user-images.githubusercontent.com/903288/48234718-9aa24180-e36f-11e8-911f-d81f075015cc.png)


