### PR TITLE
Let ctx handle matching mount entry

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1041,14 +1041,8 @@ func (b *SystemBackend) handleAuthTuneWrite(ctx context.Context, req *logical.Re
 	if path == "" {
 		return logical.ErrorResponse("missing path"), nil
 	}
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
-	path = ns.Path + namespace.Canonicalize("auth/"+path)
-
-	return b.handleTuneWriteCommon(ctx, path, data)
+	return b.handleTuneWriteCommon(ctx, "auth/"+path, data)
 }
 
 // handleMountTuneWrite is used to set config settings on a backend


### PR DESCRIPTION
Removes old logic around building the path using the namespace (which was not correct in the first place). It should be handled directly within the funcs themselves already (e.g. `MatchingMountEntry`).

```
› vault write -ns=ns1 sys/auth/userpass/tune description=hello
Error writing data to sys/auth/userpass/tune: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/auth/userpass/tune
Code: 400. Errors:

* tune of path "ns1/auth/userpass/" failed: no mount entry found
```