### PR TITLE
accept LIST on sys/plugins/catalog$ pattern

### DIFF
--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -639,6 +639,7 @@ func (b *SystemBackend) pluginsCatalogListPaths() []*framework.Path {
 			Pattern: "plugins/catalog/?$",
 
 			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.ReadOperation: b.handlePluginCatalogUntypedList,
 				logical.ListOperation: b.handlePluginCatalogUntypedList,
 			},
 

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -639,7 +639,7 @@ func (b *SystemBackend) pluginsCatalogListPaths() []*framework.Path {
 			Pattern: "plugins/catalog/?$",
 
 			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.ReadOperation: b.handlePluginCatalogUntypedList,
+				logical.ListOperation: b.handlePluginCatalogUntypedList,
 			},
 
 			HelpSynopsis:    strings.TrimSpace(sysHelp["plugin-catalog-list-all"][0]),


### PR DESCRIPTION
Fixes #5769 

Add support for LIST operations

It prefixes the plugins with their type except in the case of database plugin which are already aptly named