### PR TITLE
Fix auth tune API to accept token type

### DIFF
--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1142,6 +1142,10 @@ func (b *SystemBackend) authPaths() []*framework.Path {
 					Type:        framework.TypeCommaStringSlice,
 					Description: strings.TrimSpace(sysHelp["passthrough_request_headers"][0]),
 				},
+				"token_type": &framework.FieldSchema{
+					Type:        framework.TypeString,
+					Description: strings.TrimSpace(sysHelp["token_type"][0]),
+				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ReadOperation: &framework.PathOperation{


### PR DESCRIPTION
Mount tuning for `token_type` was only working when using `sys/mounts/auth/:path/tune` and not when using `sys/auth/:path/tune` API.