### PR TITLE
Remove an empty line for /pki/ca_chain

### DIFF
--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -177,7 +177,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 			}
 			certStr = strings.Join([]string{certStr, strings.TrimSpace(string(pem.EncodeToMemory(&block)))}, "\n")
 		}
-		certificate = []byte(certStr)
+		certificate = []byte(strings.TrimSpace(certStr))
 		goto reply
 	}
 


### PR DESCRIPTION
This PR fix #5778.

Easy test case to reproduce the problem:
https://play.golang.org/p/CAMdrOHT7C1

Since `certStr` is empty string during first iteration `strings.Join()`
will merge empty line with first CA cert.

Extra `strings.TrimSpace` call will remove that empty line, before
certificate will be return.