### PR TITLE
add input for AWS assume role session-name to refresh sessions before expiry

### DIFF
--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -33,11 +33,11 @@ func pathUser(b *backend) *framework.Path {
 				Description: "Lifetime of the returned credentials in seconds",
 				Default:     3600,
 			},
-                        "role_session_name": &framework.FieldSchema{
-                                Type:        framework.TypeString,
-                                Description: "Session name of role to assume when credential_type is " + assumedRoleCred,
-                                Default:     "",
-                        },
+			"role_session_name": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Session name of role to assume when credential_type is " + assumedRoleCred,
+				Default:     "",
+			},
 		},
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.ReadOperation:   b.pathCredsRead,
@@ -86,7 +86,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 
 	roleArn := d.Get("role_arn").(string)
 
-        roleSessionName := d.Get("role_session_name").(string)
+	roleSessionName := d.Get("role_session_name").(string)
 
 	var credentialType string
 	switch {

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -125,9 +125,9 @@ func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 		RoleArn:         aws.String(roleArn),
 		DurationSeconds: &lifeTimeInSeconds,
 	}
-        if roleSessionName != "" {
-                assumeRoleInput.SetRoleSessionName(roleSessionName)
-        }
+	if roleSessionName != "" {
+		assumeRoleInput.SetRoleSessionName(roleSessionName)
+	}
 	if policy != "" {
 		assumeRoleInput.SetPolicy(policy)
 	}

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -112,7 +112,7 @@ func (b *backend) secretTokenCreate(ctx context.Context, s logical.Storage,
 
 func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 	displayName, roleName, roleArn, policy string,
-	lifeTimeInSeconds int64) (*logical.Response, error) {
+	lifeTimeInSeconds int64, roleSessionName string) (*logical.Response, error) {
 	stsClient, err := b.clientSTS(ctx, s)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil
@@ -125,6 +125,9 @@ func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 		RoleArn:         aws.String(roleArn),
 		DurationSeconds: &lifeTimeInSeconds,
 	}
+        if roleSessionName != "" {
+                assumeRoleInput.SetRoleSessionName(roleSessionName)
+        }
 	if policy != "" {
 		assumeRoleInput.SetPolicy(policy)
 	}

--- a/website/source/api/secret/aws/index.html.md
+++ b/website/source/api/secret/aws/index.html.md
@@ -411,9 +411,12 @@ credentials retrieved through `/aws/creds` must be of the `iam_user` type.
   (for `assumed_role` credential types) and
   [GetFederationToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html)
   (for `federation_token` credential types) for more details.
+- `role_session_name` `(string: "")` – Specifies the RoleSessionName when `credential_type` is `assumed_role`.
+  When not specified, `role_session_name` defaults to empty string, and Vault will dynamically generate a username for the RoleSessionName parameter.  See the AWS documentation on the RoleSessionName parameter for
+  [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
 
 ### Sample Request
-
+### Sample Request
 ```
 $ curl \
     --header "X-Vault-Token: ..." \

--- a/website/source/api/secret/aws/index.html.md
+++ b/website/source/api/secret/aws/index.html.md
@@ -412,7 +412,7 @@ credentials retrieved through `/aws/creds` must be of the `iam_user` type.
   [GetFederationToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html)
   (for `federation_token` credential types) for more details.
 - `role_session_name` `(string: "")` – Specifies the RoleSessionName when `credential_type` is `assumed_role`.
-  When not specified, `role_session_name` defaults to empty string, and Vault will dynamically generate a username for the RoleSessionName parameter.  See the AWS documentation on the RoleSessionName parameter for
+  When not specified, `role_session_name` defaults to an empty string, and Vault will dynamically generate a username for the RoleSessionName parameter.  See the AWS documentation on the RoleSessionName parameter for
   [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
 
 ### Sample Request

--- a/website/source/docs/secrets/aws/index.html.md
+++ b/website/source/docs/secrets/aws/index.html.md
@@ -356,6 +356,21 @@ secret_key     	HSs0DYYYYYY9W81DXtI0K7X84H+OVZXK5BXXXX
 security_token 	AQoDYXdzEEwasAKwQyZUtZaCjVNDiXXXXXXXXgUgBBVUUbSyujLjsw6jYzboOQ89vUVIehUw/9MreAifXFmfdbjTr3g6zc0me9M+dB95DyhetFItX5QThw0lEsVQWSiIeIotGmg7mjT1//e7CJc4LpxbW707loFX1TYD1ilNnblEsIBKGlRNXZ+QJdguY4VkzXxv2urxIH0Sl14xtqsRPboV7eYruSEZlAuP3FLmqFbmA0AFPCT37cLf/vUHinSbvw49C4c9WQLH7CeFPhDub7/rub/QU/lCjjJ43IqIRo9jYgcEvvdRkQSt70zO8moGCc7pFvmL7XGhISegQpEzudErTE/PdhjlGpAKGR3d5qKrHpPYK/k480wk1Ai/t1dTa/8/3jUYTUeIkaJpNBnupQt7qoaXXXXXXXXXX
 ```
 
+When `role_session_name` is specified, then Vault will use the specified value
+for the RoleSessionName parameter to the [sts:AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
+API call; otherwise, Vault will generate a new value for RoleSessionName on each call:
+
+```text
+$ vault write aws/sts/deploy role_session_name="foobar" ttl=60m
+Key             Value
+lease_id        aws/sts/deploy/31d771a6-fb39-f46b-fdc5-945109106422
+lease_duration  60m0s
+lease_renewable true
+access_key      ASIAJYYYY2AA5K4WIXXX
+secret_key      HSs0DYYYYYY9W81DXtI0K7X84H+OVZXK5BXXXX
+security_token  AQoDYXdzEEwasAKwQyZUtZaCjVNDiXXXXXXXXgUgBBVUUbSyujLjsw6jYzboOQ89vUVIehUw/9MreAifXFmfdbjTr3g6zc0me9M+dB95DyhetFItX5QThw0lEsVQWSiIeIotGmg7mjT1//e7CJc4LpxbW707loFX1TYD1ilNnblEsIBKGlRNXZ+QJdguY4VkzXxv2urxIH0Sl14xtqsRPboV7eYruSEZlAuP3FLmqFbmA0AFPCT37cLf/vUHinSbvw49C4c9WQLH7CeFPhDub7/rub/QU/lCjjJ43IqIRo9jYgcEvvdRkQSt70zO8moGCc7pFvmL7XGhISegQpEzudErTE/PdhjlGpAKGR3d5qKrHpPYK/k480wk1Ai/t1dTa/8/3jUYTUeIkaJpNBnupQt7qoaXXXXXXXXXX
+```
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
To refresh credentials for AWS assume role sessions (extend sessions), Add option to use custom assume role session name:

1) Getting a 15 min. assumed_role credential with custom session name
```
$ vault read -format=json aws/assumed-role/creds/role-test role_session_name="foobar" ttl="15m"
```

2) Before  above session expires, refresh the credential, while maintaining the same session:
```
$ vault read -format=json aws/assumed-role/creds/role-test role_session_name="foobar" ttl="15m"
```
with curl:
```
$ curl -Ss --header "X-Vault-Token: $VAULT_TOKEN" --request POST http://127.0.0.1:8200/v1/aws/assumed-role/creds/role-test -d '{"role_session_name": "foobar", "ttl" : "15m"}'
```
This stretches the idea of temporary credentials..., but there are times where you need to maintain a session for longer than current AWS assume role session limit (12 hours).
