### PR TITLE
Protect against version downgrade in `secrets tune` command

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -63,6 +63,7 @@ func systemBackendMemDBSchema() *memdb.DBSchema {
 	return systemSchema
 }
 
+// NewSystemBackend makes a new sys backend
 func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 	db, _ := memdb.NewMemDB(systemBackendMemDBSchema())
 
@@ -1341,6 +1342,16 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 			if meVersion < optVersion {
 				resp = &logical.Response{}
 				resp.AddWarning(fmt.Sprintf("Upgrading mount from version %d to version %d. This mount will be unavailable for a brief period and will resume service shortly.", meVersion, optVersion))
+			}
+		} else {
+			// if version is not included in the
+			// options, and is present in the current
+			// mountEntry's options, copy it's value
+			// to the new options map to protect
+			// against accidental version downgrades
+			if vers, ok := mountEntry.Options["version"]; ok {
+				options["version"] = vers
+				numBuiltIn++
 			}
 		}
 		if options != nil {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1344,11 +1344,9 @@ func (b *SystemBackend) handleTuneWriteCommon(ctx context.Context, path string, 
 				resp.AddWarning(fmt.Sprintf("Upgrading mount from version %d to version %d. This mount will be unavailable for a brief period and will resume service shortly.", meVersion, optVersion))
 			}
 		} else {
-			// if version is not included in the
-			// options, and is present in the current
-			// mountEntry's options, copy it's value
-			// to the new options map to protect
-			// against accidental version downgrades
+			// if version is not included in the options, and is present in the
+			// current mountEntry's options, copy it's value to the new options map to
+			// protect against accidental version downgrades
 			if vers, ok := mountEntry.Options["version"]; ok {
 				options["version"] = vers
 				numBuiltIn++


### PR DESCRIPTION
Fixed https://github.com/hashicorp/vault/issues/5237 by guarding against removing the `version` option in secrets backends. 

I'm not 100% confident in the placement of the test, I struggled constructing one in `logical_system_test.go` where maybe it makes more sense to be. 

The test is currently in `command/secrets_tune_test.go`, I was able to construct a test that reproduces the regression and verifies it's fixed by 27f008b . 