### PR TITLE
Continue on plugin registration error in dev mode

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -987,6 +987,10 @@ CLUSTER_SYNTHESIS_COMPLETE:
 				path := filepath.Join(f.Name(), name)
 				if err := c.addPlugin(path, init.RootToken, core); err != nil {
 					pluginsNotLoaded = append(pluginsNotLoaded, name)
+					fmt.Println("===========", err)
+					if errwrap.Contains(err, vault.ErrPluginBadType.Error()) {
+						fmt.Println("----------- got here")
+					}
 					continue
 				}
 				plugins = append(plugins, name)

--- a/command/server.go
+++ b/command/server.go
@@ -986,11 +986,10 @@ CLUSTER_SYNTHESIS_COMPLETE:
 			for _, name := range list {
 				path := filepath.Join(f.Name(), name)
 				if err := c.addPlugin(path, init.RootToken, core); err != nil {
-					pluginsNotLoaded = append(pluginsNotLoaded, name)
-					fmt.Println("===========", err)
-					if errwrap.Contains(err, vault.ErrPluginBadType.Error()) {
-						fmt.Println("----------- got here")
+					if !errwrap.Contains(err, vault.ErrPluginBadType.Error()) {
+						return 1
 					}
+					pluginsNotLoaded = append(pluginsNotLoaded, name)
 					continue
 				}
 				plugins = append(plugins, name)
@@ -1051,7 +1050,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 		if len(pluginsNotLoaded) > 0 {
 			c.UI.Warn("")
 			c.UI.Warn(wrapAtLength(
-				"The following dev plugins FAILED to be registered in the catalog:"))
+				"The following dev plugins FAILED to be registered in the catalog due to unknown type:"))
 			for _, p := range pluginsNotLoaded {
 				c.UI.Warn(fmt.Sprintf("    - %s", p))
 			}

--- a/command/server.go
+++ b/command/server.go
@@ -967,7 +967,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 			return 1
 		}
 
-		var plugins []string
+		var plugins, pluginsNotLoaded []string
 		if c.flagDevPluginDir != "" && c.flagDevPluginInit {
 
 			f, err := os.Open(c.flagDevPluginDir)
@@ -986,8 +986,8 @@ CLUSTER_SYNTHESIS_COMPLETE:
 			for _, name := range list {
 				path := filepath.Join(f.Name(), name)
 				if err := c.addPlugin(path, init.RootToken, core); err != nil {
-					c.UI.Error(fmt.Sprintf("Error enabling plugin %s: %s", name, err))
-					return 1
+					pluginsNotLoaded = append(pluginsNotLoaded, name)
+					continue
 				}
 				plugins = append(plugins, name)
 			}
@@ -1040,6 +1040,15 @@ CLUSTER_SYNTHESIS_COMPLETE:
 			c.UI.Warn(wrapAtLength(
 				"The following dev plugins are registered in the catalog:"))
 			for _, p := range plugins {
+				c.UI.Warn(fmt.Sprintf("    - %s", p))
+			}
+		}
+
+		if len(pluginsNotLoaded) > 0 {
+			c.UI.Warn("")
+			c.UI.Warn(wrapAtLength(
+				"The following dev plugins FAILED to be registered in the catalog:"))
+			for _, p := range pluginsNotLoaded {
 				c.UI.Warn(fmt.Sprintf("    - %s", p))
 			}
 		}

--- a/command/server.go
+++ b/command/server.go
@@ -987,6 +987,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 				path := filepath.Join(f.Name(), name)
 				if err := c.addPlugin(path, init.RootToken, core); err != nil {
 					if !errwrap.Contains(err, vault.ErrPluginBadType.Error()) {
+						c.UI.Error(fmt.Sprintf("Error enabling plugin %s: %s", name, err))
 						return 1
 					}
 					pluginsNotLoaded = append(pluginsNotLoaded, name)

--- a/vault/plugin_catalog.go
+++ b/vault/plugin_catalog.go
@@ -26,6 +26,7 @@ var (
 	pluginCatalogPath         = "core/plugin-catalog/"
 	ErrDirectoryNotConfigured = errors.New("could not set plugin, plugin directory is not configured")
 	ErrPluginNotFound         = errors.New("plugin not found in the catalog")
+	ErrPluginBadType          = errors.New("unable to determine plugin type")
 )
 
 // PluginCatalog keeps a record of plugins known to vault. External plugins need
@@ -270,7 +271,7 @@ func (c *PluginCatalog) setInternal(ctx context.Context, name string, pluginType
 
 		pluginType, err = c.getPluginTypeFromUnknown(ctx, entryTmp)
 		if err != nil || pluginType == consts.PluginTypeUnknown {
-			return errors.New("unable to determine plugin type")
+			return ErrPluginBadType
 		}
 	}
 


### PR DESCRIPTION
```
==> Vault server configuration:

             Api Address: http://127.0.0.1:8200
                     Cgo: disabled
         Cluster Address: https://127.0.0.1:8201
              Listener 1: tcp (addr: "127.0.0.1:8200", cluster address: "127.0.0.1:8201", max_request_duration: "1m30s", max_request_size: "33554432", tls: "disabled")
               Log Level: trace
                   Mlock: supported: false, enabled: false
                 Storage: consul (HA available)
                 Version: Vault v1.0.0-beta2
             Version Sha: 9b88852bc7f19c785879ecca8b135b2070a60a5a+CHANGES

WARNING! dev mode is enabled! In this mode, Vault runs entirely in-memory
and starts unsealed with a single unseal key. The root token is already
authenticated to the CLI, so you can immediately begin using Vault.

You may need to set the following environment variable:

    $ export VAULT_ADDR='http://127.0.0.1:8200'

The unseal key and root token are displayed below in case you want to
seal/unseal the Vault or re-authenticate.

Unseal Key: q5BV3gdoUgTpiB1B5i3xZ7rxgQhlyU2XZlh26YmwXHE=
Root Token: root

The following dev plugins are registered in the catalog:
    - mock-plugin
    - my-mock-plugin
    - vault-auth-plugin-example
    - vault-secrets-gen

The following dev plugins FAILED to be registered in the catalog:
    - totp-plugin

Development mode should NOT be used in production installations!

==> Vault server started! Log data will stream in below:

...
```