### PR TITLE
Fix incorrect parameter name in docs

### DIFF
--- a/website/source/api/auth/gcp/index.html.md
+++ b/website/source/api/auth/gcp/index.html.md
@@ -374,7 +374,7 @@ $ curl \
       "prod"
     ],
     "project_id": "project-123456",
-    "role_type": "gce",
+    "role": "gce",
     "ttl": 1800
   }
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault-plugin-auth-gcp/issues/56