### PR TITLE
Fix incorrect parameter name in docs

### DIFF
--- a/website/source/api/auth/gcp/index.html.md
+++ b/website/source/api/auth/gcp/index.html.md
@@ -374,7 +374,7 @@ $ curl \
       "prod"
     ],
     "project_id": "project-123456",
-    "role": "gce",
+    "type": "gce",
     "ttl": 1800
   }
 }


### PR DESCRIPTION
This pull request corrects https://github.com/hashicorp/vault/pull/5793/files. The type name has been changed errorneously from `role_type` to `role` and only afterwards to `type`. `type` is the currently correct naming (as of https://github.com/hashicorp/vault-plugin-auth-gcp/commit/438b86d4b944867fc9ca0d713280088eb72df744)