### PR TITLE
Update section-header usage for vaultproject.io

### DIFF
--- a/website/assets/css/_inner.css
+++ b/website/assets/css/_inner.css
@@ -26,6 +26,10 @@
     margin-top: 0;
   }
 
+  & .g-section-header {
+    margin-bottom: 100px;
+  }
+
   /* TODO: this should be applied in global styles, temporary override here */
   & pre,
   & code {


### PR DESCRIPTION
This change is to support a change to the `hashi-section-header` component which will be removing the `margin-bottom: 100px` per https://github.com/hashicorp/web-components/pull/468

This effects the https://www.vaultproject.io/community page.

Deploy Prevew: https://5bede455f6d5ea4a41b23b40--vault-www.netlify.com/

  Urls to review:
- [ ] https://www.vaultproject.io/ (no changes needed)
  preview: https://5bede455f6d5ea4a41b23b40--vault-www.netlify.com/
- [ ] https://www.vaultproject.io/api/ (no changes needed)
  preview: https://5bede455f6d5ea4a41b23b40--vault-www.netlify.com/api/
- [ ] https://www.vaultproject.io/community (changes for #inner)
  preview: https://5bede455f6d5ea4a41b23b40--vault-www.netlify.com/community
- [ ] https://www.vaultproject.io/docs/ (no changes needed)
  preview: https://5bede455f6d5ea4a41b23b40--vault-www.netlify.com/docs/
