### PR TITLE
Re-add mount plugin name for backwards compatibility

### DIFF
--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -164,6 +164,7 @@ type MountConfigOutput struct {
 	DefaultLeaseTTL           int      `json:"default_lease_ttl" mapstructure:"default_lease_ttl"`
 	MaxLeaseTTL               int      `json:"max_lease_ttl" mapstructure:"max_lease_ttl"`
 	ForceNoCache              bool     `json:"force_no_cache" mapstructure:"force_no_cache"`
+	DeprecatedPluginName      string   `json:"plugin_name,omitempty" mapstructure:"plugin_name"`
 	AuditNonHMACRequestKeys   []string `json:"audit_non_hmac_request_keys,omitempty" mapstructure:"audit_non_hmac_request_keys"`
 	AuditNonHMACResponseKeys  []string `json:"audit_non_hmac_response_keys,omitempty" mapstructure:"audit_non_hmac_response_keys"`
 	ListingVisibility         string   `json:"listing_visibility,omitempty" mapstructure:"listing_visibility"`

--- a/command/auth_list.go
+++ b/command/auth_list.go
@@ -155,10 +155,11 @@ func (c *AuthListCommand) detailedMounts(auths map[string]*api.AuthMount) []stri
 			replication = "local"
 		}
 
-		out = append(out, fmt.Sprintf("%s | %s | %s | %s | %s | %s | %s | %t | %v | %s",
+		out = append(out, fmt.Sprintf("%s | %s | %s | %s | %s | %s | %s | %s | %t | %v | %s ",
 			path,
 			mount.Type,
 			mount.Accessor,
+			mount.Config.DeprecatedPluginName,
 			defaultTTL,
 			maxTTL,
 			mount.Config.TokenType,

--- a/command/secrets_list.go
+++ b/command/secrets_list.go
@@ -155,10 +155,11 @@ func (c *SecretsListCommand) detailedMounts(mounts map[string]*api.MountOutput) 
 			replication = "local"
 		}
 
-		out = append(out, fmt.Sprintf("%s | %s | %s | %s | %s | %t | %s | %t | %v | %s",
+		out = append(out, fmt.Sprintf("%s | %s | %s | %s | %s | %s | %t | %s | %t | %v | %s",
 			path,
 			mount.Type,
 			mount.Accessor,
+			mount.Config.DeprecatedPluginName,
 			defaultTTL,
 			maxTTL,
 			mount.Config.ForceNoCache,


### PR DESCRIPTION
This PR re-adds the `PluginName` field on the `MountConfig` in case it comes back to the current Vault client from an older Vault server.