### PR TITLE
Allow globbing dis/allowed_policies in token roles (with caveat)

### DIFF
--- a/helper/strutil/strutil.go
+++ b/helper/strutil/strutil.go
@@ -32,6 +32,17 @@ func StrListContains(haystack []string, needle string) bool {
 	return false
 }
 
+// StrListSubsetGlob checks if a given list is a subset of
+// another set, allowing for globs.
+func StrListSubsetGlob(super, sub []string) bool {
+	for _, item := range sub {
+		if !StrListContainsGlob(super, item) {
+			return false
+		}
+	}
+	return true
+}
+
 // StrListSubset checks if a given list is a subset
 // of another set
 func StrListSubset(super, sub []string) bool {
@@ -237,6 +248,18 @@ func RemoveDuplicates(items []string, lowercase bool) []string {
 	}
 	sort.Strings(items)
 	return items
+}
+
+// RemoveGlobs removes any elements containing globs from a slice of strings.
+func RemoveGlobs(items []string) []string {
+	ret := make([]string, 0, len(items))
+	for _, item := range items {
+		// glob.GLOB is "*"; ignore items containing that
+		if !strings.Contains(item, glob.GLOB) {
+			ret = append(ret, item)
+		}
+	}
+	return ret
 }
 
 // EquivalentSlices checks whether the given string sets are equivalent, as in,

--- a/helper/strutil/strutil_test.go
+++ b/helper/strutil/strutil_test.go
@@ -104,6 +104,43 @@ func TestStrutil_ListContains(t *testing.T) {
 	}
 }
 
+func TestStrutil_ListSubsetGlob(t *testing.T) {
+	parent := []string{
+		"dev",
+		"ops*",
+		"root/*",
+		"*-dev",
+		"_*_",
+	}
+	if StrListSubsetGlob(parent, []string{"tubez", "dev", "root/admin"}) {
+		t.Fatalf("Bad")
+	}
+	if StrListSubsetGlob(parent, []string{"devops", "ops-dev"}) {
+		t.Fatalf("Bad")
+	}
+	if StrListSubsetGlob(nil, parent) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, []string{"root/test", "dev", "_test_"}) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, []string{"ops_test", "ops", "devops-dev"}) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, []string{"ops"}) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, []string{"test-dev"}) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, []string{"_test_"}) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, nil) {
+		t.Fatalf("Bad")
+	}
+}
+
 func TestStrutil_ListSubset(t *testing.T) {
 	parent := []string{
 		"dev",
@@ -417,6 +454,28 @@ func TestStrUtil_RemoveDuplicates(t *testing.T) {
 
 	for _, tc := range tCases {
 		actual := RemoveDuplicates(tc.input, tc.lowercase)
+
+		if !reflect.DeepEqual(actual, tc.expect) {
+			t.Fatalf("Bad testcase %#v, expected %v, got %v", tc, tc.expect, actual)
+		}
+	}
+}
+
+func TestStrUtil_RemoveGlobs(t *testing.T) {
+	type tCase struct {
+		input  []string
+		expect []string
+	}
+
+	tCases := []tCase{
+		tCase{[]string{}, []string{}},
+		tCase{[]string{"hello"}, []string{"hello"}},
+		tCase{[]string{"h*i"}, []string{}},
+		tCase{[]string{"one", "two*", "*three", "f*our", "five"}, []string{"one", "five"}},
+	}
+
+	for _, tc := range tCases {
+		actual := RemoveGlobs(tc.input)
 
 		if !reflect.DeepEqual(actual, tc.expect) {
 			t.Fatalf("Bad testcase %#v, expected %v, got %v", tc, tc.expect, actual)


### PR DESCRIPTION
This patch will allow for using `*` in token role `allowed_policies` and `disallowed_policies` attributes to meet the use case described in #3756. For example, I'd like to create a role to allow nomad to create tokens for jobs, but rather than maintaining a long list of allowed policies, I would like to just match against a prefix, eg `nomad-job-*`.

HOWEVER, while I was writing the tests I discovered a rather large caveat to the very idea of this patch: Currently `*` is a legal character in policy names in Vault. So it's possible to have a policy named literally `nomad-job-*` or `*hello*` etc.

Since it's possible, I assume such policies do exist. And so, I don't think this patch is safe to merge as-is. But since I did the work, I'm going to go ahead and submit it as an artifact.