### PR TITLE
Fix vet warnings.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -689,7 +689,9 @@ START:
 	}
 
 	if timeout != 0 {
-		ctx, _ = context.WithTimeout(ctx, timeout)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
 	}
 	req.Request = req.Request.WithContext(ctx)
 

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -885,7 +885,7 @@ func testDerivedKeyUpgrade(t *testing.T, keyType keysutil.KeyType) {
 	p.Upgrade(context.Background(), storage) // Need to run the upgrade code to make the migration stick
 
 	if p.KDF != keysutil.Kdf_hmac_sha256_counter {
-		t.Fatalf("bad KDF value by default; counter val is %d, KDF val is %d, policy is %#v", keysutil.Kdf_hmac_sha256_counter, p.KDF, *p)
+		t.Fatalf("bad KDF value by default; counter val is %d, KDF val is %d, policy is %#v", keysutil.Kdf_hmac_sha256_counter, p.KDF, p)
 	}
 
 	derBytesOld, err := p.DeriveKey(keyContext, 1, 0)

--- a/command/agent.go
+++ b/command/agent.go
@@ -251,6 +251,7 @@ func (c *AgentCommand) Run(args []string) int {
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
 
 	var sinks []*sink.SinkConfig
 	for _, sc := range config.AutoAuth.Sinks {

--- a/command/agent/auth/auth_test.go
+++ b/command/agent/auth/auth_test.go
@@ -71,6 +71,7 @@ func TestAuthHandler(t *testing.T) {
 	client := cluster.Cores[0].Client
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
 
 	ah := NewAuthHandler(&AuthHandlerConfig{
 		Logger: logger.Named("auth.handler"),

--- a/helper/cidrutil/cidr_test.go
+++ b/helper/cidrutil/cidr_test.go
@@ -205,7 +205,7 @@ func TestCIDRUtil_RemoteAddrIsOk_NegativeTest(t *testing.T) {
 		t.Fatal(err)
 	}
 	boundCIDRs := []*sockaddr.SockAddrMarshaler{
-		{addr},
+		{SockAddr: addr},
 	}
 	if RemoteAddrIsOk("123.0.0.1", boundCIDRs) {
 		t.Fatal("remote address of 123.0.0.1/2 should not be allowed for 127.0.0.1/8")
@@ -218,7 +218,7 @@ func TestCIDRUtil_RemoteAddrIsOk_PositiveTest(t *testing.T) {
 		t.Fatal(err)
 	}
 	boundCIDRs := []*sockaddr.SockAddrMarshaler{
-		{addr},
+		{SockAddr: addr},
 	}
 	if !RemoteAddrIsOk("127.0.0.1", boundCIDRs) {
 		t.Fatal("remote address of 127.0.0.1 should be allowed for 127.0.0.1/8")

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3070,7 +3070,7 @@ func (ts *TokenStore) tokenStoreRoleCreateUpdate(ctx context.Context, req *logic
 				if err != nil {
 					return logical.ErrorResponse(errwrap.Wrapf(fmt.Sprintf("invalid value %q when parsing bound cidrs: {{err}}", v), err).Error()), nil
 				}
-				parsedCIDRs = append(parsedCIDRs, &sockaddr.SockAddrMarshaler{parsedCIDR})
+				parsedCIDRs = append(parsedCIDRs, &sockaddr.SockAddrMarshaler{SockAddr: parsedCIDR})
 			}
 			entry.BoundCIDRs = parsedCIDRs
 		}

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -42,7 +42,7 @@ func TestTokenStore_Salting(t *testing.T) {
 		t.Fatalf("expected sha2-256 hmac; got sha1 hash")
 	}
 
-	nsCtx := namespace.ContextWithNamespace(context.Background(), &namespace.Namespace{"testid", "ns1"})
+	nsCtx := namespace.ContextWithNamespace(context.Background(), &namespace.Namespace{ID: "testid", Path: "ns1"})
 	saltedID, err = ts.SaltID(nsCtx, "foo")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
After this change `make vet` no longer generates output.