### PR TITLE
Update section-header to 4.0.0

### DIFF
--- a/website/assets/package.json
+++ b/website/assets/package.json
@@ -24,7 +24,7 @@
     "@hashicorp/hashi-newsletter-signup-form": "1.1.1",
     "@hashicorp/hashi-product-downloader": "^0.6.1",
     "@hashicorp/hashi-product-subnav": "^0.5.3",
-    "@hashicorp/hashi-section-header": "^3.0.0",
+    "@hashicorp/hashi-section-header": "^4.0.0",
     "@hashicorp/hashi-split-cta": "^0.1.4",
     "@hashicorp/hashi-vertical-text-block-list": "^0.1.1",
     "@hashicorp/js-utils": "^1.0.0",


### PR DESCRIPTION
Updates `@hashicorp/hashi-section-header` to `^4.0.0` for the website.
This update removes the bottom margin from the `section-header` so that the spacing can be handled in the layout that it is used in.
Previously the Vault website was updated to prepare for this section-header change with https://github.com/hashicorp/vault/pull/5799 which added css rules to account for the removal of the bottom margin from the section-header.