### PR TITLE
UI - Fix secret creation when cas_required=true

### DIFF
--- a/ui/app/serializers/secret-v2-version.js
+++ b/ui/app/serializers/secret-v2-version.js
@@ -16,11 +16,8 @@ export default ApplicationSerializer.extend({
     return payload;
   },
   serialize(snapshot) {
-    let version = 0;
     let secret = snapshot.belongsTo('secret');
-    if (secret) {
-      version = secret.attr('currentVersion');
-    }
+    let version = secret.attr('currentVersion') || 0;
     return {
       data: snapshot.attr('secretData'),
       options: {


### PR DESCRIPTION
Previously we were using the currentVersion from the secret metadata to set the `cas` param when saving in KV V2. This failed when `cas_required` was true on the mount config because when you created a new version, there wasn't any metadata to read from yet. 

Now instead of checking for the secret which would never fail because ember-data would always return a snapshot, we fall back to using 0.

Fixes #5801