### PR TITLE
UI - fix PKI context menu

### DIFF
--- a/ui/app/serializers/role.js
+++ b/ui/app/serializers/role.js
@@ -3,13 +3,25 @@ import ApplicationSerializer from './application';
 export default ApplicationSerializer.extend({
   extractLazyPaginatedData(payload) {
     let ret;
+
     if (payload.zero_address_roles) {
       payload.zero_address_roles.forEach(role => {
         // mutate key_info object to add zero_address info
         payload.data.key_info[role].zero_address = true;
       });
     }
-    if (!payload.data.key_info) return payload.data.keys;
+    if (!payload.data.key_info) {
+      return payload.data.keys.map(key => {
+        let model = {
+          id: key,
+        };
+        if (payload.backend) {
+          model.backend = payload.backend;
+        }
+        return model;
+      });
+    }
+
     ret = payload.data.keys.map(key => {
       let model = {
         id: key,

--- a/ui/tests/acceptance/secrets/backend/pki/role-test.js
+++ b/ui/tests/acceptance/secrets/backend/pki/role-test.js
@@ -47,6 +47,9 @@ module('Acceptance | secrets/pki/create', function(hooks) {
 
     await listPage.visitRoot({ backend: path });
     assert.equal(listPage.secrets.length, 1, 'shows role in the list');
+    let secret = listPage.secrets.objectAt(0);
+    await secret.menuToggle();
+    assert.ok(listPage.menuItems.length > 0, 'shows links in the menu');
   });
 
   test('it deletes a role', async function(assert) {

--- a/ui/tests/pages/secrets/backend/list.js
+++ b/ui/tests/pages/secrets/backend/list.js
@@ -10,7 +10,12 @@ export default create({
   configureIsPresent: isPresent('[data-test-secret-backend-configure]'),
 
   tabs: collection('[data-test-tab]'),
-  secrets: collection('[data-test-secret-link]'),
+  secrets: collection('[data-test-secret-link]', {
+    menuToggle: clickable('[data-test-popup-menu-trigger]'),
+  }),
+  menuItems: collection('.ember-basic-dropdown-content li', {
+    testContainer: '#ember-testing',
+  }),
 
   backendIsEmpty: getter(function() {
     return this.secrets.length === 0;


### PR DESCRIPTION
An update to the PKI serializer meant that it was returning early without the `backend` attribute. This also meant that the capabilities fetch we use for showing items in the context menus weren't firing at all because `backend` was `undefined`.

This PR fixes the serializer and adds an assertion in the acceptance test to verify that items get rendered in the menu.
![image](https://user-images.githubusercontent.com/39469/48735080-f771e780-ec0c-11e8-8675-d0e5e5ea0b44.png)

Fixes #5817 
