### PR TITLE
remove scrollbars from auth form

### DIFF
--- a/ui/app/styles/components/auth-form.scss
+++ b/ui/app/styles/components/auth-form.scss
@@ -3,6 +3,7 @@
   @extend .is-bottomless;
   padding: 0;
   position: relative;
+  overflow: hidden;
 }
 
 .auth-form .vault-loader {


### PR DESCRIPTION
This PR fixes https://github.com/hashicorp/vault/issues/5771, in which unnecessary scroll bars appeared on the auth loading screen.