### PR TITLE
Remove false statement from docs.

### DIFF
--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -871,10 +871,7 @@ request is denied.
   added to the CRL by `vault revoke <lease_id>` when certificates are associated
   with leases.  It can also be done using the `pki/revoke` endpoint. However,
   when lease generation is disabled, invoking `pki/revoke` would be the only way
-  to add the certificates to the CRL. When large number of certificates are
-  generated with long lifetimes, it is recommended that lease generation be
-  disabled, as large amount of leases adversely affect the startup time of
-  Vault.
+  to add the certificates to the CRL.
 
 - `no_store` `(bool: false)` – If set, certificates issued/signed against this
   role will not be stored in the storage backend. This can improve performance


### PR DESCRIPTION
According to [changelog - Lazy Lease Loading](https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#082-september-5th-2017), and @jefferai [comment](https://github.com/hashicorp/consul-template/pull/1106#issuecomment-392270648) this statement is no longer true since Vault version 0.8.2.