### PR TITLE
UI - Correct the DR token command

### DIFF
--- a/ui/app/components/status-menu.js
+++ b/ui/app/components/status-menu.js
@@ -9,6 +9,7 @@ export default Component.extend({
   auth: service(),
   store: service(),
   media: service(),
+  version: service(),
   type: 'cluster',
   itemTag: null,
   partialName: computed('type', function() {

--- a/ui/app/templates/components/shamir-flow.hbs
+++ b/ui/app/templates/components/shamir-flow.hbs
@@ -25,7 +25,7 @@
       </div>
       <div class="message is-list has-copy-button" tabindex="-1">
         {{#let
-            (concat 'vault operator generate-root -otp="' otp '" -decode="' encoded_token '"')
+            (concat 'vault operator generate-root -dr-token -otp="' otp '" -decode="' encoded_token '"')
         as |cmd|}}
           <HoverCopyButton @copyValue={{cmd}} />
           <div class="message-body">

--- a/ui/app/templates/partials/status/cluster.hbs
+++ b/ui/app/templates/partials/status/cluster.hbs
@@ -43,7 +43,7 @@
                 }}
               {{/if}}
             </li>
-          {{else if activeCluster.version.isOSS}}
+          {{else if version.isOSS}}
             <li>
               {{#link-to "vault.cluster.replication"}}
                 <div class="level is-mobile">
@@ -68,7 +68,7 @@
       </nav>
       <hr/>
     {{/if}}
-    {{#unless isOSS}}
+    {{#unless version.isOSS}}
       <nav class="menu">
         <div class="menu-label">
           License


### PR DESCRIPTION
This adds `-dr-token` to the `generate-root` command at the end of the DR Operation Token workflow:
<img width="604" alt="screen shot 2018-11-27 at 2 33 18 pm" src="https://user-images.githubusercontent.com/39469/49111416-b05fa400-f255-11e8-8385-d91836be525a.png">


And it hides the license link in the status menu for OSS builds:
<img width="250" alt="screen shot 2018-11-27 at 2 53 55 pm" src="https://user-images.githubusercontent.com/39469/49111424-b5bcee80-f255-11e8-87aa-b9e2b58b830a.png">
