### PR TITLE
UI: Search select trigger styles

### DIFF
--- a/ui/app/styles/components/search-select.scss
+++ b/ui/app/styles/components/search-select.scss
@@ -12,6 +12,11 @@
   border: 0;
   border-radius: $radius;
   padding-right: 0;
+
+  &--active {
+    outline-width: 3px;
+    outline-offset: -2px;
+  }
 }
 
 .ember-power-select-trigger:focus,

--- a/ui/app/styles/components/search-select.scss
+++ b/ui/app/styles/components/search-select.scss
@@ -24,15 +24,31 @@
 }
 
 .ember-power-select-search {
+  left: 0;
+  padding: 0;
   position: absolute;
-  left: $spacing-l;
   top: 0;
   right: 0;
   transform: translateY(-100%);
+  z-index: -1;
+
+  &::after {
+    background: $white;
+    bottom: 0;
+    content: '';
+    left: $spacing-xxs + $spacing-l;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: -1;
+  }
 }
 
 .ember-power-select-search-input {
+  background: transparent;
   border: 0;
+  padding: $spacing-xxs $spacing-s;
+  padding-left: $spacing-xxs + $spacing-l;
 }
 
 .ember-power-select-options {

--- a/ui/app/styles/components/search-select.scss
+++ b/ui/app/styles/components/search-select.scss
@@ -34,12 +34,12 @@
 
   &::after {
     background: $white;
-    bottom: 0;
+    bottom: $spacing-xxs;
     content: '';
     left: $spacing-xxs + $spacing-l;
     position: absolute;
-    right: 0;
-    top: 0;
+    right: $spacing-xxs;
+    top: $spacing-xxs;
     z-index: -1;
   }
 }
@@ -108,4 +108,12 @@
 .search-select-list-key {
   color: $grey;
   font-size: $size-8;
+}
+
+.ember-power-select-dropdown.ember-basic-dropdown-content {
+  animation: none;
+
+  .ember-power-select-options {
+    animation: drop-fade-above 0.15s;
+  }
 }

--- a/ui/app/templates/components/search-select.hbs
+++ b/ui/app/templates/components/search-select.hbs
@@ -8,7 +8,7 @@
     helpText=helpText
   }}
 {{else}}
-  <label for="{{name}}" class="is-label">
+  <label for="{{name}}" class="title is-4">
     {{label}}
     {{#if helpText}}
       {{#info-tooltip}}{{helpText}}{{/info-tooltip}}


### PR DESCRIPTION
- Makes the search select input lay over trigger better, masking the placeholder with a pseudo-element
- Animate only the popover, not the input too
- Better outline for the trigger so you can tell when you've focused the input

![vault-search-select-styles-2](https://user-images.githubusercontent.com/111194/49119077-19e6af00-f264-11e8-8971-46387e52995f.gif)
