### PR TITLE
UI - fix bug in policy creation from files 

### DIFF
--- a/ui/app/utils/trim-right.js
+++ b/ui/app/utils/trim-right.js
@@ -2,9 +2,7 @@
 // if isExtension is true, the first char of that string will be escaped
 // in the regex
 export default function(str, endings = [], isExtension = true) {
-  let trimRegex = new RegExp(endings.map(ext => `${ext}$`).join('|'));
-  if (isExtension) {
-    trimRegex = new RegExp(endings.map(ext => `\\${ext}$`).join('|'));
-  }
+  let prefix = isExtension ? '\\' : '';
+  let trimRegex = new RegExp(endings.map(ext => `${prefix}${ext}$`).join('|'));
   return str.replace(trimRegex, '');
 }

--- a/ui/app/utils/trim-right.js
+++ b/ui/app/utils/trim-right.js
@@ -1,4 +1,10 @@
-export default function(fileName, toTrimArray = []) {
-  const extension = new RegExp(toTrimArray.join('$|'));
-  return fileName.replace(extension, '');
+// will trim a given set of endings from the end of a string
+// if isExtension is true, the first char of that string will be escaped
+// in the regex
+export default function(str, endings = [], isExtension = true) {
+  let trimRegex = new RegExp(endings.map(ext => `${ext}$`).join('|'));
+  if (isExtension) {
+    trimRegex = new RegExp(endings.map(ext => `\\${ext}$`).join('|'));
+  }
+  return str.replace(trimRegex, '');
 }

--- a/ui/tests/unit/utils/trim-right-test.js
+++ b/ui/tests/unit/utils/trim-right-test.js
@@ -25,4 +25,23 @@ module('Unit | Util | trim right', function() {
 
     assert.equal(trimmedName, 'my-file-name-is-cool.json');
   });
+
+  test('it allows the last extension to also be part of the file name', function(assert) {
+    const trimmedName = trimRight('my-policy.hcl', ['.json', '.txt', '.hcl', '.policy']);
+
+    assert.equal(trimmedName, 'my-policy');
+  });
+
+  test('it allows the last extension to also be part of the file name and the extenstion', function(assert) {
+    const trimmedName = trimRight('my-policy.policy', ['.json', '.txt', '.hcl', '.policy']);
+
+    assert.equal(trimmedName, 'my-policy');
+  });
+
+  test('it passes endings into the regex unescaped when passing false as the third arg', function(assert) {
+    const trimmedName = trimRight('my-policypolicy', ['.json', '.txt', '.hcl', '.policy'], false);
+
+    // the . gets interpreted as regex wildcard so it also trims the y character
+    assert.equal(trimmedName, 'my-polic');
+  });
 });


### PR DESCRIPTION
Previously, the generated regex we were using to trim wouldn't bind the last element to the end of the string - this would result in a file named `my-policy.hcl` would end up as `my.hcl`. 

This fixes it so that `my-policy.hcl` will now be `my-policy`.