### PR TITLE
Document /sys/health?perfstandbyok

### DIFF
--- a/website/source/api/system/health.html.md
+++ b/website/source/api/system/health.html.md
@@ -36,7 +36,12 @@ The default status codes are:
 - `standbyok` `(bool: false)` – Specifies if being a standby should still return
   the active status code instead of the standby status code. This is useful when
   Vault is behind a non-configurable load balance that just wants a 200-level
-  response.
+  response. This will not apply if the node is a performance standby.
+  
+- `perfstandbyok` `(bool: false)` – Specifies if being a performance standby should
+  still return the active status code instead of the standby status code. This is
+  useful when Vault is behind a non-configurable load balance that just wants a
+  200-level response.
 
 - `activecode` `(int: 200)` – Specifies the status code that should be returned
   for an active node.

--- a/website/source/api/system/health.html.md
+++ b/website/source/api/system/health.html.md
@@ -39,9 +39,9 @@ The default status codes are:
   response. This will not apply if the node is a performance standby.
   
 - `perfstandbyok` `(bool: false)` – Specifies if being a performance standby should
-  still return the active status code instead of the standby status code. This is
-  useful when Vault is behind a non-configurable load balance that just wants a
-  200-level response.
+  still return the active status code instead of the performance standby status code.
+  This is useful when Vault is behind a non-configurable load balance that just wants
+  a 200-level response.
 
 - `activecode` `(int: 200)` – Specifies the status code that should be returned
   for an active node.


### PR DESCRIPTION
I discovered in my testing of Vault Enterprise 0.11.5, that `/sys/health?standbyok` returns a 473 status for performance standby nodes, compared to a 200 for standard standby nodes.

Turns out that `standbyok` does not apply to a Performance Standby node, only to standby nodes that have had that feature disabled.

There was an additional `perfstandbyok` option added in https://github.com/hashicorp/vault/commit/e5aaf80764941d130e6a439f801502bfbc4ee565, which this PR aims to document