### PR TITLE
Set request token entry within fetchACLTokenEntryAndEntity

### DIFF
--- a/command/seal_migration_test.go
+++ b/command/seal_migration_test.go
@@ -1,3 +1,5 @@
+// +build !enterprise
+
 package command
 
 import (

--- a/vault/core.go
+++ b/vault/core.go
@@ -1146,8 +1146,6 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 		return retErr
 	}
 
-	req.SetTokenEntry(te)
-
 	// Audit-log the request before going any further
 	auth := &logical.Auth{
 		ClientToken: req.ClientToken,

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -136,6 +136,8 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 			c.logger.Error("failed to lookup token", "error", err)
 			return nil, nil, nil, nil, ErrInternalError
 		}
+		// Set the token entry here since it has not been cached yet
+		req.SetTokenEntry(te)
 	default:
 		te = req.TokenEntry()
 	}


### PR DESCRIPTION
Within `fetchACLTokenEntryAndEntity`, this change sets the request's token entry to the one returned by `Lookup` for the case where the token entry was not yet cached.