### PR TITLE
ui/app/adapters/pki.js: fix typo in assert() message

### DIFF
--- a/ui/app/adapters/pki.js
+++ b/ui/app/adapters/pki.js
@@ -5,7 +5,7 @@ export default ApplicationAdapter.extend({
   namespace: 'v1',
 
   url(/*role*/) {
-    assert('Override the `url` method to extend the SSH adapter', false);
+    assert('Override the `url` method to extend the PKI adapter', false);
   },
 
   createRecord(store, type, snapshot, requestType) {


### PR DESCRIPTION
Love Hashicorp Vault- long time user who finally started plowing through the source. Found an innocuous typo in an ```assert()``` invocation in the ui pki adapter. Super easy/safe fix so took the couple minutes necessary to open this pull request. Thanks Hashicorp team and community- keep up the great work!

---

ui/app/adapters/pki.js: fix typo in assert() message

Update the assertion to indicate, in order to override the PKI adapter
url() method, one should extend the PKI adapter; not the SSH adapter.

Signed-off-by: Chris Dituri <csdituri@gmail.com>