### PR TITLE
change ui url so that it includes the trailing slash

### DIFF
--- a/website/source/docs/configuration/ui/index.html.md
+++ b/website/source/docs/configuration/ui/index.html.md
@@ -53,14 +53,14 @@ In this case, the UI is accessible the following URL from any machine on the
 subnet (provided no network firewalls are in place):
 
 ```text
-https://10.0.1.35:8200/ui
+https://10.0.1.35:8200/ui/
 ```
 
 It is also accessible at any DNS entry that resolves to that IP address, such as
 the Consul service address (if using Consul):
 
 ```text
-https://vault.service.consul:8200/ui
+https://vault.service.consul:8200/ui/
 ```
 
 ### Note on TLS


### PR DESCRIPTION
This was pointed out on the mailing list. Older versions of Vault don't have a redirect from /ui to /ui/, so this may end up showing errors for them. This is also the address in the handler, so it's nicer to have parity there.