### PR TITLE
docs: Clarify the utility of DynamoDB capacities

### DIFF
--- a/website/source/docs/configuration/storage/dynamodb.html.md
+++ b/website/source/docs/configuration/storage/dynamodb.html.md
@@ -51,8 +51,9 @@ see the [official AWS DynamoDB documentation][dynamodb-rw-capacity].
   provided via the environment variable `AWS_DEFAULT_REGION`.
 
 - `read_capacity` `(int: 5)` – Specifies the maximum number of reads consumed
-  per second on the table. This can also be provided via the environment
-  variable `AWS_DYNAMODB_READ_CAPACITY`.
+  per second on the table, for use if Vault creates the DynamoDB table. This has
+  no effect if the `table` already exists. This can also be provided via the
+  environment variable `AWS_DYNAMODB_READ_CAPACITY`.
 
 - `table` `(string: "vault-dynamodb-backend")` – Specifies the name of the
   DynamoDB table in which to store Vault data. If the specified table does not
@@ -61,8 +62,9 @@ see the [official AWS DynamoDB documentation][dynamodb-rw-capacity].
   information on the table schema below.
 
 - `write_capacity` `(int: 5)` – Specifies the maximum number of writes performed
-  per second on the table. This can also be provided via the environment
-  variable `AWS_DYNAMODB_WRITE_CAPACITY`.
+  per second on the table, for use if Vault creates the DynamoDB table. This value
+  has no effect if the `table` already exists. This can also be provided via the
+  environment variable `AWS_DYNAMODB_WRITE_CAPACITY`.
 
 The following settings are used for authenticating to AWS. If you are
 running your Vault server on an EC2 instance, you can also make use of the EC2
@@ -145,6 +147,14 @@ resource "aws_dynamodb_table" "dynamodb-table" {
   }
 }
 ```
+
+If a table with the configured name already exists, Vault will not modify it -
+and the Vault configuration values of `read_capacity` and `write_capacity` have
+no effect.
+
+If the table does not already exist, Vault will try to create it, with read and
+write capacities set to the values of `read_capacity` and `write_capacity`
+respectively.
 
 ## DynamoDB Examples of Vault Configuration
 


### PR DESCRIPTION
When configuring the DynamoDB physical back end, the read and write capacities configured only have any effect if the table does not exist. As per the [comment in the code][1], the configuration of an existing table is never modified. This was not previously reflected in the documentation - this pull request rectifies that.

[1]: https://github.com/hashicorp/vault/blob/master/physical/dynamodb/dynamodb.go#L743-L745