### PR TITLE
Fix cassandra plugin documentation re substitutions.  

### DIFF
--- a/website/source/api/secret/databases/cassandra.html.md
+++ b/website/source/api/secret/databases/cassandra.html.md
@@ -115,19 +115,19 @@ list the plugin does not support that statement type.
   statements executed to create and configure a user. Must be a
   semicolon-separated string, a base64-encoded semicolon-separated string, a
   serialized JSON string array, or a base64-encoded serialized JSON string
-  array. The '{{name}}' and '{{password}}' values will be substituted. If not
+  array. The '{{username}}' and '{{password}}' values will be substituted. If not
   provided, defaults to a generic create user statements that creates a
   non-superuser.
 
 - `revocation_statements` `(list: [])` – Specifies the database statements to
   be executed to revoke a user. Must be a semicolon-separated string, a
   base64-encoded semicolon-separated string, a serialized JSON string array, or
-  a base64-encoded serialized JSON string array. The '{{name}}' value will be
+  a base64-encoded serialized JSON string array. The '{{username}}' value will be
   substituted. If not provided defaults to a generic drop user statement.
 
 - `rollback_statements` `(list: [])` – Specifies the database statements to be
   executed to rollback a create operation in the event of an error. Must be a
   semicolon-separated string, a base64-encoded semicolon-separated string, a
   serialized JSON string array, or a base64-encoded serialized JSON string
-  array. The '{{name}}' value will be substituted. If not provided, defaults to
+  array. The '{{username}}' value will be substituted. If not provided, defaults to
   a generic drop user statement


### PR DESCRIPTION
It appears this was broken from day one.  See defaults in [cassandra.go]( https://github.com/hashicorp/vault/blob/d686d3f77fa874c5b88138a87d2faee123f10ba1/plugins/database/cassandra/cassandra.go#L19).