### PR TITLE
Add code for writing and reading request counters to storage.

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1607,9 +1607,7 @@ func stopReplicationImpl(c *Core) error {
 // emitMetrics is used to periodically expose metrics while running
 func (c *Core) emitMetrics(stopCh chan struct{}) {
 	emitTimer := time.Tick(time.Second)
-	// TODO set writeTimer to a longer interval (5m?) once feature is complete.
-	// The current setting is helpful for debuging.
-	writeTimer := time.Tick(10 * time.Second)
+	writeTimer := time.Tick(1 * time.Minute)
 
 	for {
 		select {

--- a/vault/core.go
+++ b/vault/core.go
@@ -144,19 +144,6 @@ type unlockInformation struct {
 	Nonce string
 }
 
-type counters struct {
-	// activePath is set at startup to the path we primed the requests counter from,
-	// or empty string if there wasn't a relevant path - either because this is the first
-	// time Vault starts with the feature enabled, or because Vault hadn't written
-	// out the request counter this month yet.
-	// Whenever we write out the counters, we update activePath if it's no longer
-	// accurate.  This coincides with a reset of the counters.
-	// There's no lock because the only reader/writer of activePath is the goroutine
-	// doing background syncs.
-	activePath string
-	requests   uint64
-}
-
 // Core is used as the central manager of Vault activity. It is the primary point of
 // interface for API handlers and is responsible for managing the logical and physical
 // backends, router, security barrier, and audit trails.
@@ -166,8 +153,6 @@ type Core struct {
 	// The registry of builtin plugins is passed in here as an interface because
 	// if it's used directly, it results in import cycles.
 	builtinRegistry BuiltinRegistry
-
-	counters counters
 
 	// N.B.: This is used to populate a dev token down replication, as
 	// otherwise, after replication is started, a dev would have to go through
@@ -433,6 +418,9 @@ type Core struct {
 
 	// Telemetry objects
 	metricsHelper *metricsutil.MetricsHelper
+
+	// Stores request counters
+	counters counters
 }
 
 // CoreConfig is used to parameterize a core
@@ -610,6 +598,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		neverBecomeActive:            new(uint32),
 		clusterLeaderParams:          new(atomic.Value),
 		metricsHelper:                conf.MetricsHelper,
+		counters:                     counters{requests: new(uint64)},
 	}
 
 	atomic.StoreUint32(c.sealed, 1)

--- a/vault/core.go
+++ b/vault/core.go
@@ -1630,7 +1630,7 @@ func (c *Core) emitMetrics(stopCh chan struct{}) {
 			c.metricsMutex.Unlock()
 
 		case <-writeTimer:
-			if couldForward(c) {
+			if c.perfStandby {
 				syncCounter(c)
 			} else {
 				err := c.saveCurrentRequestCounters(context.Background(), time.Now())

--- a/vault/core.go
+++ b/vault/core.go
@@ -144,6 +144,19 @@ type unlockInformation struct {
 	Nonce string
 }
 
+type counters struct {
+	// activePath is set at startup to the path we primed the requests counter from,
+	// or empty string if there wasn't a relevant path - either because this is the first
+	// time Vault starts with the feature enabled, or because Vault hadn't written
+	// out the request counter this month yet.
+	// Whenever we write out the counters, we update activePath if it's no longer
+	// accurate.  This coincides with a reset of the counters.
+	// There's no lock because the only reader/writer of activePath is the goroutine
+	// doing background syncs.
+	activePath string
+	requests   uint64
+}
+
 // Core is used as the central manager of Vault activity. It is the primary point of
 // interface for API handlers and is responsible for managing the logical and physical
 // backends, router, security barrier, and audit trails.
@@ -153,6 +166,8 @@ type Core struct {
 	// The registry of builtin plugins is passed in here as an interface because
 	// if it's used directly, it results in import cycles.
 	builtinRegistry BuiltinRegistry
+
+	counters counters
 
 	// N.B.: This is used to populate a dev token down replication, as
 	// otherwise, after replication is started, a dev would have to go through
@@ -1427,6 +1442,9 @@ func (s standardUnsealStrategy) unseal(ctx context.Context, logger log.Logger, c
 	if err := c.loadCORSConfig(ctx); err != nil {
 		return err
 	}
+	if err := c.loadCurrentRequestCounters(ctx, time.Now()); err != nil {
+		return err
+	}
 	if err := c.loadCredentials(ctx); err != nil {
 		return err
 	}
@@ -1599,14 +1617,26 @@ func stopReplicationImpl(c *Core) error {
 
 // emitMetrics is used to periodically expose metrics while running
 func (c *Core) emitMetrics(stopCh chan struct{}) {
+	emitTimer := time.Tick(time.Second)
+	// TODO set writeTimer to a longer interval (5m?) once feature is complete.
+	// The current setting is helpful for debuging.
+	writeTimer := time.Tick(10 * time.Second)
+
 	for {
 		select {
-		case <-time.After(time.Second):
+		case <-emitTimer:
 			c.metricsMutex.Lock()
 			if c.expiration != nil {
 				c.expiration.emitMetrics()
 			}
 			c.metricsMutex.Unlock()
+
+		case <-writeTimer:
+			err := c.saveCurrentRequestCounters(context.Background(), time.Now())
+			if err != nil {
+				c.logger.Error("writing request counters to barrier", "err", err)
+			}
+
 		case <-stopCh:
 			return
 		}

--- a/vault/counters.go
+++ b/vault/counters.go
@@ -1,0 +1,152 @@
+package vault
+
+import (
+	"context"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/logical"
+)
+
+const requestCounterDatePathFormat = "2006/01"
+
+// RequestCounter stores the state of request counters for a single unspecified period.
+type RequestCounter struct {
+	// Total holds the sum total of all requests seen during the period.
+	// "All" does not include requests excluded by design, e.g. health checks and UI
+	// asset requests.
+	Total *uint64 `json:"total"`
+}
+
+// DatedRequestCounter holds request counters from a single period of time.
+type DatedRequestCounter struct {
+	// StartTime is when the period starts.
+	StartTime time.Time `json:"start_time"`
+	// RequestCounter counts requests.
+	RequestCounter
+}
+
+// AllRequestCounters contains all request counters from the dawn of time.
+type AllRequestCounters struct {
+	// Dated holds the request counters dating back to when the feature was first
+	// introduced in this instance, ordered by time (oldest first).
+	Dated []DatedRequestCounter
+}
+
+// loadAllRequestCounters returns all request counters found in storage.
+func (c *Core) loadAllRequestCounters(ctx context.Context) (*AllRequestCounters, error) {
+	view := c.systemBarrierView.SubView("counters/requests/")
+
+	datepaths, err := view.List(ctx, "")
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to read request counters: {{err}}", err)
+	}
+	if datepaths == nil {
+		return nil, nil
+	}
+
+	var all AllRequestCounters
+	sort.Strings(datepaths)
+	for _, datepath := range datepaths {
+		datesubpaths, err := view.List(ctx, datepath)
+		if err != nil {
+			return nil, errwrap.Wrapf("failed to read request counters: {{err}}", err)
+		}
+		for _, datesubpath := range datesubpaths {
+			fullpath := datepath + datesubpath
+			counter, err := c.loadRequestCounters(ctx, fullpath)
+			if err != nil {
+				return nil, err
+			}
+
+			t, err := time.Parse(requestCounterDatePathFormat, fullpath)
+			if err != nil {
+				return nil, err
+			}
+
+			all.Dated = append(all.Dated, DatedRequestCounter{StartTime: t, RequestCounter: *counter})
+		}
+	}
+
+	return &all, nil
+}
+
+// loadCurrentRequestCounters reads the current RequestCounter out of storage.
+// The in-memory current request counter is populated with the value read, if any.
+// now should be the current time; it is a parameter to facilitate testing.
+func (c *Core) loadCurrentRequestCounters(ctx context.Context, now time.Time) error {
+	datepath := now.Format(requestCounterDatePathFormat)
+	counter, err := c.loadRequestCounters(ctx, datepath)
+	if err != nil {
+		return err
+	}
+	if counter != nil {
+		c.counters.activePath = datepath
+		atomic.StoreUint64(&c.counters.requests, *counter.Total)
+	}
+	return nil
+}
+
+// loadRequestCounters reads a RequestCounter out of storage at location datepath.
+// If nothing is found at that path, that isn't an error: a reference to a zero
+// RequestCounter is returned.
+func (c *Core) loadRequestCounters(ctx context.Context, datepath string) (*RequestCounter, error) {
+	view := c.systemBarrierView.SubView("counters/requests/")
+
+	out, err := view.Get(ctx, datepath)
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to read request counters: {{err}}", err)
+	}
+	if out == nil {
+		return nil, nil
+	}
+
+	newCounters := &RequestCounter{}
+	err = out.DecodeJSON(newCounters)
+	if err != nil {
+		return nil, err
+	}
+
+	return newCounters, nil
+}
+
+// saveCurrentRequestCounters writes the current RequestCounter to storage.
+// The in-memory current request counter is reset to zero after writing if
+// we've entered a new month.
+// now should be the current time; it is a parameter to facilitate testing.
+func (c *Core) saveCurrentRequestCounters(ctx context.Context, now time.Time) error {
+	view := c.systemBarrierView.SubView("counters/requests/")
+	datepath := now.Format(requestCounterDatePathFormat)
+
+	var requests uint64
+	if c.counters.activePath == "" || c.counters.activePath == datepath {
+		// We leave requests at 0 in the case where the month has just changed; we don't
+		// want to write the current count of requests (from last month) to the new month
+		// datepath.  This means we discard any requests counted since the last time
+		// we wrote, but since we write frequently that's okay.
+		requests = atomic.LoadUint64(&c.counters.requests)
+	}
+
+	localCounters := &RequestCounter{
+		Total: &requests,
+	}
+	entry, err := logical.StorageEntryJSON(datepath, localCounters)
+	if err != nil {
+		return errwrap.Wrapf("failed to create request counters entry: {{err}}", err)
+	}
+
+	if err := view.Put(ctx, entry); err != nil {
+		return errwrap.Wrapf("failed to save request counters: {{err}}", err)
+	}
+
+	if datepath != c.counters.activePath {
+		if c.counters.activePath != "" {
+			atomic.StoreUint64(&c.counters.requests, 0)
+		}
+		c.counters.activePath = datepath
+	}
+
+	return nil
+}

--- a/vault/counters.go
+++ b/vault/counters.go
@@ -61,6 +61,7 @@ func (c *Core) loadAllRequestCounters(ctx context.Context, now time.Time) ([]Dat
 		if err != nil {
 			return nil, errwrap.Wrapf("failed to read request counters: {{err}}", err)
 		}
+		sort.Strings(datesubpaths)
 		for _, datesubpath := range datesubpaths {
 			fullpath := datepath + datesubpath
 			counter, err := c.loadRequestCounters(ctx, fullpath)

--- a/vault/counters_test.go
+++ b/vault/counters_test.go
@@ -1,0 +1,120 @@
+package vault
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-test/deep"
+)
+
+func testParseTime(t *testing.T, format, timeval string) time.Time {
+	t.Helper()
+	tm, err := time.Parse(format, timeval)
+	if err != nil {
+		t.Fatalf("Error parsing time '%s': %v", timeval, err)
+	}
+	return tm
+}
+
+// TestRequestCounterLoadCurrent exercises the code that primes the in-mem
+// request counters from persistent storage.
+func TestRequestCounterLoadCurrent(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	december2018 := testParseTime(t, time.RFC3339, "2018-12-05T09:44:12-05:00")
+	decemberRequests := uint64(555)
+
+	// It's December, and we got some requests.  Persist the counter.
+	atomic.StoreUint64(&c.counters.requests, decemberRequests)
+	err := c.saveCurrentRequestCounters(context.Background(), december2018)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// It's still December, simulate being restarted.  At startup the counter is
+	// zero initially, until we read the counter from storage post-unseal via
+	// loadCurrentRequestCounters.
+	atomic.StoreUint64(&c.counters.requests, 0)
+	err = c.loadCurrentRequestCounters(context.Background(), december2018)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadUint64(&c.counters.requests); got != decemberRequests {
+		t.Fatalf("expected=%d, got=%d", decemberRequests, got)
+	}
+
+	// Now simulate being restarted in January. We never wrote anything out during
+	// January, so the in-mem counter should remain zero.
+	january2019 := testParseTime(t, time.RFC3339, "2019-01-02T08:21:11-05:00")
+	atomic.StoreUint64(&c.counters.requests, 0)
+	err = c.loadCurrentRequestCounters(context.Background(), january2019)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadUint64(&c.counters.requests); got != 0 {
+		t.Fatalf("expected=%d, got=%d", 0, got)
+	}
+}
+
+// TestRequestCounterSaveCurrent exercises the code that saves the in-mem
+// request counters to persistent storage.
+func TestRequestCounterSaveCurrent(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+
+	// storeSaveLoad stores newValue in the in-mem counter, saves it to storage,
+	// then verifies in-mem counter has value expectedPostLoad.
+	storeSaveLoad := func(newValue, expectedPostLoad uint64, now time.Time) {
+		atomic.StoreUint64(&c.counters.requests, newValue)
+		err := c.saveCurrentRequestCounters(context.Background(), now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := atomic.LoadUint64(&c.counters.requests); got != expectedPostLoad {
+			t.Fatalf("expected=%d, got=%d", expectedPostLoad, got)
+		}
+	}
+
+	// Start in December. The first write ever should persist the current in-mem value.
+	december2018 := testParseTime(t, time.RFC3339, "2018-12-05T09:44:12-05:00")
+	decemberRequests := uint64(555)
+	storeSaveLoad(decemberRequests, decemberRequests, december2018)
+
+	// Update request count.
+	decemberRequests++
+	storeSaveLoad(decemberRequests, decemberRequests, december2018)
+
+	decemberStartTime := testParseTime(t, requestCounterDatePathFormat, december2018.Format(requestCounterDatePathFormat))
+	expected2018 := AllRequestCounters{
+		Dated: []DatedRequestCounter{
+			DatedRequestCounter{decemberStartTime, RequestCounter{Total: &decemberRequests}},
+		},
+	}
+	all, err := c.loadAllRequestCounters(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := deep.Equal(*all, expected2018); len(diff) != 0 {
+		t.Errorf("Expected=%v, got=%v, diff=%v", expected2018, *all, diff)
+	}
+
+	// Now it's January. Saving after transition to new month should reset in-mem
+	// counter to zero, and also write zero to storage for the new month.
+	january2019 := testParseTime(t, time.RFC3339, "2019-01-02T08:21:11-05:00")
+	januaryRequests := decemberRequests
+	storeSaveLoad(januaryRequests, 0, january2019)
+
+	all, err = c.loadAllRequestCounters(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	januaryStartTime := testParseTime(t, requestCounterDatePathFormat, january2019.Format(requestCounterDatePathFormat))
+	var expectedJanuary uint64
+	expected2019 := expected2018
+	expected2019.Dated = append(expected2019.Dated,
+		DatedRequestCounter{januaryStartTime, RequestCounter{&expectedJanuary}})
+	if diff := deep.Equal(*all, expected2019); len(diff) != 0 {
+		t.Errorf("Expected=%v, got=%v, diff=%v", expected2019, *all, diff)
+	}
+}

--- a/vault/counters_test.go
+++ b/vault/counters_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-test/deep"
 )
 
+//noinspection SpellCheckingInspection
 func testParseTime(t *testing.T, format, timeval string) time.Time {
 	t.Helper()
 	tm, err := time.Parse(format, timeval)
@@ -87,9 +88,9 @@ func TestRequestCounterSaveCurrent(t *testing.T) {
 
 	decemberStartTime := testParseTime(t, requestCounterDatePathFormat, december2018.Format(requestCounterDatePathFormat))
 	expected2018 := []DatedRequestCounter{
-		DatedRequestCounter{decemberStartTime, RequestCounter{Total: &decemberRequests}},
+		{StartTime: decemberStartTime, RequestCounter: RequestCounter{Total: &decemberRequests}},
 	}
-	all, err := c.loadAllRequestCounters(context.Background())
+	all, err := c.loadAllRequestCounters(context.Background(), december2018)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +107,7 @@ func TestRequestCounterSaveCurrent(t *testing.T) {
 	januaryRequests := uint64(333)
 	storeSaveLoad(januaryRequests, januaryRequests, january2019)
 
-	all, err = c.loadAllRequestCounters(context.Background())
+	all, err = c.loadAllRequestCounters(context.Background(), january2019)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2984,6 +2984,28 @@ func (b *SystemBackend) pathInternalUIMountRead(ctx context.Context, req *logica
 	return resp, nil
 }
 
+func (b *SystemBackend) pathInternalCountersRequests(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	counters, err := b.Core.loadAllRequestCounters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	buf, err := json.Marshal(counters.Dated)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			logical.HTTPStatusCode:  200,
+			logical.HTTPRawBody:     buf,
+			logical.HTTPContentType: "application/json",
+		},
+	}
+
+	return resp, nil
+}
+
 func (b *SystemBackend) pathInternalUIResultantACL(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	if req.ClientToken == "" {
 		// 204 -- no ACL
@@ -3897,5 +3919,9 @@ This path responds to the following HTTP methods.
 	"metrics": {
 		"Export the metrics aggregated for telemetry purpose.",
 		"",
+	},
+	"internal-counters-requests": {
+		"Count of requests seen by this Vault cluster over time.",
+		"Count of requests seen by this Vault cluster over time. Not included in count: health checks, UI asset requests, requests forwarded from another cluster.",
 	},
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2985,7 +2985,7 @@ func (b *SystemBackend) pathInternalUIMountRead(ctx context.Context, req *logica
 }
 
 func (b *SystemBackend) pathInternalCountersRequests(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	counters, err := b.Core.loadAllRequestCounters(ctx)
+	counters, err := b.Core.loadAllRequestCounters(ctx, time.Now())
 	if err != nil {
 		return nil, err
 	}

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2990,16 +2990,9 @@ func (b *SystemBackend) pathInternalCountersRequests(ctx context.Context, req *l
 		return nil, err
 	}
 
-	buf, err := json.Marshal(counters.Dated)
-	if err != nil {
-		return nil, err
-	}
-
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			logical.HTTPStatusCode:  200,
-			logical.HTTPRawBody:     buf,
-			logical.HTTPContentType: "application/json",
+			"counters": counters,
 		},
 	}
 

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -824,6 +824,17 @@ func (b *SystemBackend) internalPaths() []*framework.Path {
 			HelpSynopsis:    strings.TrimSpace(sysHelp["internal-ui-resultant-acl"][0]),
 			HelpDescription: strings.TrimSpace(sysHelp["internal-ui-resultant-acl"][1]),
 		},
+		{
+			Pattern: "internal/counters/requests",
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.pathInternalCountersRequests,
+					Unpublished: true,
+				},
+			},
+			HelpSynopsis:    strings.TrimSpace(sysHelp["internal-counters-requests"][0]),
+			HelpDescription: strings.TrimSpace(sysHelp["internal-counters-requests"][1]),
+		},
 	}
 }
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
@@ -537,6 +538,7 @@ func (c *Core) doRouting(ctx context.Context, req *logical.Request) (*logical.Re
 			return forward(ctx, c, req)
 		}
 	}
+	atomic.AddUint64(c.counters.requests, 1)
 	return resp, err
 }
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -538,7 +538,6 @@ func (c *Core) doRouting(ctx context.Context, req *logical.Request) (*logical.Re
 			return forward(ctx, c, req)
 		}
 	}
-	c.logger.Info("requests counter incremented", "path", req.Path, "newvalue", atomic.AddUint64(c.counters.requests, 1))
 	return resp, err
 }
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -538,7 +538,7 @@ func (c *Core) doRouting(ctx context.Context, req *logical.Request) (*logical.Re
 			return forward(ctx, c, req)
 		}
 	}
-	c.logger.Info("requests counter incremented", "path", req.Path, "newvalue", atomic.AddUint64(&c.counters.requests, 1))
+	c.logger.Info("requests counter incremented", "path", req.Path, "newvalue", atomic.AddUint64(c.counters.requests, 1))
 	return resp, err
 }
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	metrics "github.com/armon/go-metrics"

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
@@ -529,6 +530,18 @@ func isControlGroupRun(req *logical.Request) bool {
 	return req.ControlGroup != nil
 }
 
+func (c *Core) doRouting(ctx context.Context, req *logical.Request) (*logical.Response, error) {
+	// If we're replicating and we get a read-only error from a backend, need to forward to primary
+	resp, err := c.router.Route(ctx, req)
+	if err != nil {
+		if shouldForward(c, err) {
+			return forward(ctx, c, req)
+		}
+	}
+	c.logger.Info("requests counter incremented", "path", req.Path, "newvalue", atomic.AddUint64(&c.counters.requests, 1))
+	return resp, err
+}
+
 func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp *logical.Response, retAuth *logical.Auth, retErr error) {
 	defer metrics.MeasureSince([]string{"core", "handle_request"}, time.Now())
 
@@ -662,12 +675,9 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 	}
 
 	// Route the request
-	resp, routeErr := c.router.Route(ctx, req)
-	// If we're replicating and we get a read-only error from a backend, need to forward to primary
-	if routeErr != nil {
-		resp, routeErr = possiblyForward(ctx, c, req, resp, routeErr)
-	}
+	resp, routeErr := c.doRouting(ctx, req)
 	if resp != nil {
+
 		// If wrapping is used, use the shortest between the request and response
 		var wrapTTL time.Duration
 		var wrapFormat, creationPath string
@@ -943,11 +953,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 	}
 
 	// Route the request
-	resp, routeErr := c.router.Route(ctx, req)
-	// If we're replicating and we get a read-only error from a backend, need to forward to primary
-	if routeErr != nil {
-		resp, routeErr = possiblyForward(ctx, c, req, resp, routeErr)
-	}
+	resp, routeErr := c.doRouting(ctx, req)
 	if resp != nil {
 		// If wrapping is used, use the shortest between the request and response
 		var wrapTTL time.Duration

--- a/vault/request_handling_util.go
+++ b/vault/request_handling_util.go
@@ -15,8 +15,12 @@ func checkNeedsCG(context.Context, *Core, *logical.Request, *logical.Auth, error
 	return nil, nil, nil, nil
 }
 
-func possiblyForward(ctx context.Context, c *Core, req *logical.Request, resp *logical.Response, routeErr error) (*logical.Response, error) {
-	return resp, routeErr
+func shouldForward(c *Core, routeErr error) bool {
+	return false
+}
+
+func forward(ctx context.Context, c *Core, req *logical.Request) (*logical.Response, error) {
+	panic("forward called in OSS Vault")
 }
 
 func getLeaseRegisterFunc(c *Core) (func(context.Context, *logical.Request, *logical.Response) (string, error), error) {

--- a/vault/request_handling_util.go
+++ b/vault/request_handling_util.go
@@ -19,6 +19,13 @@ func shouldForward(c *Core, routeErr error) bool {
 	return false
 }
 
+func syncCounter(c *Core) {
+}
+
+func couldForward(c *Core) bool {
+	return false
+}
+
 func forward(ctx context.Context, c *Core, req *logical.Request) (*logical.Response, error) {
 	panic("forward called in OSS Vault")
 }

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1291,6 +1291,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		coreConfig.DisableCache = base.DisableCache
 
 		coreConfig.DevToken = base.DevToken
+		coreConfig.CounterSyncInterval = base.CounterSyncInterval
 	}
 
 	if coreConfig.Physical == nil {


### PR DESCRIPTION
Add some basic request handling counting and load/store of the counters
to core.  This part is still WIP, mostly to show how the storage routines
will be used.

I'm not actually looking to merge this yet, but I welcome early feedback to see if I'm on the right track.