### PR TITLE
added error handling for HandleRequest to ensure that error is empty for response

### DIFF
--- a/builtin/logical/ssh/path_config_ca_test.go
+++ b/builtin/logical/ssh/path_config_ca_test.go
@@ -117,7 +117,7 @@ func TestSSH_ConfigCAUpdateDelete(t *testing.T) {
 
 	// Fail to overwrite it
 	resp, err = b.HandleRequest(context.Background(), caReq)
-	if err == nil {
+	if err == nil && resp.Data["error"] == "" {
 		t.Fatalf("expected an error")
 	}
 
@@ -142,7 +142,7 @@ func TestSSH_ConfigCAUpdateDelete(t *testing.T) {
 
 	// Fail to overwrite it
 	resp, err = b.HandleRequest(context.Background(), caReq)
-	if err == nil {
+	if err == nil && resp.Data["error"] == "" {
 		t.Fatalf("expected an error")
 	}
 


### PR DESCRIPTION
* Check for `error` object to be empty in response when running the `TestSSH_ConfigCAUpdateDelete`
* Test locally and works fine. 
