### PR TITLE
add an auth-config adapter for jwt so that configs can be saved properly

### DIFF
--- a/ui/app/adapters/auth-config/jwt.js
+++ b/ui/app/adapters/auth-config/jwt.js
@@ -1,0 +1,2 @@
+import AuthConfig from './_base';
+export default AuthConfig.extend();

--- a/ui/tests/integration/components/mount-backend-form-test.js
+++ b/ui/tests/integration/components/mount-backend-form-test.js
@@ -56,7 +56,7 @@ module('Integration | Component | mount backend form', function(hooks) {
   });
 
   test('it calls mount success', async function(assert) {
-    this.server.post('/v1/sys/auth/foo', request => {
+    this.server.post('/v1/sys/auth/foo', () => {
       return [204, { 'Content-Type': 'application/json' }];
     });
     const spy = sinon.spy();
@@ -73,11 +73,11 @@ module('Integration | Component | mount backend form', function(hooks) {
   });
 
   test('it calls the correct jwt config', async function(assert) {
-    this.server.post('/v1/sys/auth/jwt', request => {
+    this.server.post('/v1/sys/auth/jwt', () => {
       return [204, { 'Content-Type': 'application/json' }];
     });
 
-    this.server.post('/v1/auth/jwt/config', request => {
+    this.server.post('/v1/auth/jwt/config', () => {
       return [
         400,
         { 'Content-Type': 'application/json' },
@@ -98,10 +98,10 @@ module('Integration | Component | mount backend form', function(hooks) {
   });
 
   test('it calls mount config error', async function(assert) {
-    this.server.post('/v1/sys/auth/bar', request => {
+    this.server.post('/v1/sys/auth/bar', () => {
       return [204, { 'Content-Type': 'application/json' }];
     });
-    this.server.post('/v1/auth/bar/config', request => {
+    this.server.post('/v1/auth/bar/config', () => {
       return [
         400,
         { 'Content-Type': 'application/json' },

--- a/ui/tests/integration/components/mount-backend-form-test.js
+++ b/ui/tests/integration/components/mount-backend-form-test.js
@@ -1,5 +1,5 @@
 import { later, run } from '@ember/runloop';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import apiStub from 'vault/tests/helpers/noop-all-api-requests';
@@ -18,7 +18,7 @@ module('Integration | Component | mount backend form', function(hooks) {
   hooks.beforeEach(function() {
     component.setContext(this);
     this.owner.lookup('service:flash-messages').registerTypes(['success', 'danger']);
-    this.server = apiStub({ usePassthrough: true });
+    this.server = apiStub();
   });
 
   hooks.afterEach(function() {
@@ -55,17 +55,59 @@ module('Integration | Component | mount backend form', function(hooks) {
     assert.equal(component.pathValue, 'newpath', 'updates to the value of the type');
   });
 
-  skip('it calls mount success', async function(assert) {
+  test('it calls mount success', async function(assert) {
+    this.server.post('/v1/sys/auth/foo', request => {
+      return [204, { 'Content-Type': 'application/json' }];
+    });
     const spy = sinon.spy();
     this.set('onMountSuccess', spy);
     await render(hbs`{{mount-backend-form onMountSuccess=onMountSuccess}}`);
 
     await component.mount('approle', 'foo');
-    assert.equal(this.server.db.authMethods.length, 1, 'it enables an auth method');
+
+    later(() => run.cancelTimers(), 50);
+    await settled();
+    let enableRequest = this.server.handledRequests.findBy('url', '/v1/sys/auth/foo');
+    assert.ok(enableRequest, 'it calls enable on an auth method');
     assert.ok(spy.calledOnce, 'calls the passed success method');
   });
 
-  skip('it calls mount config error', async function(assert) {
+  test('it calls the correct jwt config', async function(assert) {
+    this.server.post('/v1/sys/auth/jwt', request => {
+      return [204, { 'Content-Type': 'application/json' }];
+    });
+
+    this.server.post('/v1/auth/jwt/config', request => {
+      return [
+        400,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({ errors: ['there was an error'] }),
+      ];
+    });
+    await render(hbs`<MountBackendForm />`);
+
+    await component.selectType('jwt');
+    await component.next();
+    await component.fillIn('oidcDiscoveryUrl', 'host');
+    component.submit();
+
+    later(() => run.cancelTimers(), 50);
+    await settled();
+    let configRequest = this.server.handledRequests.findBy('url', '/v1/auth/jwt/config');
+    assert.ok(configRequest, 'it calls the config url');
+  });
+
+  test('it calls mount config error', async function(assert) {
+    this.server.post('/v1/sys/auth/bar', request => {
+      return [204, { 'Content-Type': 'application/json' }];
+    });
+    this.server.post('/v1/auth/bar/config', request => {
+      return [
+        400,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({ errors: ['there was an error'] }),
+      ];
+    });
     const spy = sinon.spy();
     const spy2 = sinon.spy();
     this.set('onMountSuccess', spy);
@@ -79,7 +121,8 @@ module('Integration | Component | mount backend form', function(hooks) {
     component.submit();
     later(() => run.cancelTimers(), 50);
     await settled();
-    assert.equal(this.server.db.authMethods.length, 1, 'it still enables an auth method');
+    let enableRequest = this.server.handledRequests.findBy('url', '/v1/sys/auth/bar');
+    assert.ok(enableRequest, 'it calls enable on an auth method');
     assert.equal(spy.callCount, 0, 'does not call the success method');
     assert.ok(spy2.calledOnce, 'calls the passed error method');
   });


### PR DESCRIPTION
We missed this when we added the JWT method to the ui - the default looks for `jwts/` as the url instead of `jwt/` - this fixes that.