### PR TITLE
return correct format of random data generator

### DIFF
--- a/ui/app/components/tool-actions-form.js
+++ b/ui/app/components/tool-actions-form.js
@@ -106,7 +106,7 @@ export default Component.extend(DEFAULTS, {
         : JSON.parse(get(this, 'data'));
     }
     if (action === 'random') {
-      return this.getProperties('bytes');
+      return this.getProperties('bytes', 'format');
     }
 
     if (action === 'hash') {


### PR DESCRIPTION
This PR fixes an issue where the random data generator on the Random Tools page always returned base64 even if hex output was selected. It was caused by the format not being included in the request params.

<img width="1072" alt="screen shot 2018-12-12 at 10 58 14 am" src="https://user-images.githubusercontent.com/903288/49892042-dad86200-fdfc-11e8-8ec8-8a8a78e040bc.png">
