### PR TITLE
auth/aws: Add support for bound_cidr

### DIFF
--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -311,6 +311,10 @@ func TestBackend_pathLogin_IAMHeaders(t *testing.T) {
 				Path:      "login",
 				Storage:   storage,
 				Data:      loginData,
+				Connection:  &logical.Connection{
+					RemoteAddr: "127.0.0.1",
+				},
+
 			}
 
 			resp, err := b.HandleRequest(context.Background(), loginRequest)

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-sockaddr"
 	"github.com/hashicorp/vault/helper/policyutil"
 	"github.com/hashicorp/vault/helper/strutil"
 	"github.com/hashicorp/vault/logical"
@@ -600,6 +601,7 @@ func TestAwsEc2_RoleCrud(t *testing.T) {
 		"auth_type":                      ec2AuthType,
 		"bound_ami_id":                   []string{"testamiid"},
 		"bound_account_id":               []string{"testaccountid"},
+		"bound_cidr":			  []*sockaddr.SockAddrMarshaler(nil),
 		"bound_region":                   []string{"testregion"},
 		"bound_ec2_instance_id":          []string{"i-12345678901234567", "i-76543210987654321"},
 		"bound_iam_principal_arn":        []string{},

--- a/website/source/api/auth/aws/index.html.md
+++ b/website/source/api/auth/aws/index.html.md
@@ -684,6 +684,9 @@ list in order to satisfy that constraint.
   the iam auth method. Wildcards are supported at the end of the ARN, e.g.,
   "arn:aws:iam::123456789012:role/\*" will match all roles in the AWS account.
   This is a comma-separated string or JSON array.
+- `bound_cidr` `(string: "", or list: [])` – If set, restricts usage of the
+  login and token to client IPs falling within the range of the specified
+  CIDR(s).
 - `inferred_entity_type` `(string: "")` -  When set, instructs Vault to turn on
   inferencing. The only current valid value is "ec2\_instance" instructing Vault
   to infer that the role comes from an EC2 instance in an IAM instance profile.


### PR DESCRIPTION
This adds support for specifying a bound_cidr parameter on AWS auth role
entries. The singular name of "bound_cidr" is chosen instead of the
plural "bound_cidrs" as the other bindings in AWS auth roles are all
singularly named but many of them take multiple values as well, so this
maintains that consistency.

Fixes #5946