### PR TITLE
Docs: Add Auto Unseal Rekey example

### DIFF
--- a/website/source/docs/commands/operator/rekey.html.md
+++ b/website/source/docs/commands/operator/rekey.html.md
@@ -47,7 +47,7 @@ $ vault operator rekey \
     -pgp-keys="keybase:hashicorp,keybase:jefferai,keybase:sethvargo"
 ```
 
-Rekey KMS recovery keys and encrypt the resulting keys with PGP:
+Rekey an Auto Unseal vault and encrypt the resulting recovery keys with PGP:
 
 ```text
 $ vault operator rekey \

--- a/website/source/docs/commands/operator/rekey.html.md
+++ b/website/source/docs/commands/operator/rekey.html.md
@@ -47,6 +47,17 @@ $ vault operator rekey \
     -pgp-keys="keybase:hashicorp,keybase:jefferai,keybase:sethvargo"
 ```
 
+Rekey KMS recovery keys and encrypt the resulting keys with PGP:
+
+```text
+$ vault operator rekey \
+    -target=recovery \
+    -init \
+    -pgp-keys=keybase:grahamhashicorp 
+    -key-shares=1 
+    -key-threshold=1
+```
+
 Store encrypted PGP keys in Vault's core:
 
 ```text


### PR DESCRIPTION
I've had customers looking for AWS KMS rekeying examples today - when using pgp keys.
This example would have clarified what they needed to do.