### PR TITLE
Add SSL support for PostgreSQL in the Database secrets engine

### DIFF
--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -200,6 +200,7 @@ func (b *databaseBackend) connectionReadHandler() framework.OperationFunc {
 		}
 
 		delete(config.ConnectionDetails, "password")
+		delete(config.ConnectionDetails, "client_secret_key")
 
 		return &logical.Response{
 			Data: structs.New(config).Map(),

--- a/builtin/logical/postgresql/path_config_connection.go
+++ b/builtin/logical/postgresql/path_config_connection.go
@@ -46,6 +46,21 @@ and a negative value disables idle connections.
 If larger than max_open_connections it will be
 reduced to the same size.`,
 			},
+
+			"ca_cert": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: "Public CA sertificate of the database",
+			},
+
+			"client_public_key": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: "Public key for the client",
+			},
+
+			"client_secret_key": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: "Private key for the client",
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{

--- a/plugins/helper/database/connutil/sql.go
+++ b/plugins/helper/database/connutil/sql.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/vault/helper/parseutil"
 	"github.com/hashicorp/vault/plugins/helper/database/dbutil"
 	"github.com/mitchellh/mapstructure"
+	"net/url"
 )
 
 var _ ConnectionProducer = &SQLConnectionProducer{}
@@ -24,6 +25,9 @@ type SQLConnectionProducer struct {
 	MaxConnectionLifetimeRaw interface{} `json:"max_connection_lifetime" mapstructure:"max_connection_lifetime" structs:"max_connection_lifetime"`
 	Username                 string      `json:"username" mapstructure:"username" structs:"username"`
 	Password                 string      `json:"password" mapstructure:"password" structs:"password"`
+	CaCert                   string      `json:"ca_cert" mapstructure:"ca_cert" structs:"ca_cert"`
+	ClientPublicKey          string      `json:"client_public_key" mapstructure:"client_public_key" structs:"client_public_key"`
+	ClientPrivateKey         string      `json:"client_private_key" mapstructure:"client_private_key" structs:"client_private_key"`
 
 	Type                  string
 	RawConfig             map[string]interface{}
@@ -56,6 +60,9 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 	c.ConnectionURL = dbutil.QueryHelper(c.ConnectionURL, map[string]string{
 		"username": c.Username,
 		"password": c.Password,
+		"ca_cert": url.QueryEscape(c.CaCert),
+		"client_public_key": url.QueryEscape(c.ClientPublicKey),
+		"client_private_key": url.QueryEscape(c.ClientPrivateKey),
 	})
 
 	if c.MaxOpenConnections == 0 {

--- a/website/source/api/secret/databases/postgresql.html.md
+++ b/website/source/api/secret/databases/postgresql.html.md
@@ -44,6 +44,12 @@ has a number of parameters to further configure a connection.
 
 - `password` `(string: "")` - The root credential password used in the connection URL. 
 
+- `ca_cert` `(string: "")` - The server's root CA certificate, if SSL encryption is used
+
+- `client_public_key` `(string: "")` - The client's public key, if SSL encryption is used
+
+- `client_private_key` `(string: "")` - The client's private key, if SSL encryption is used
+
 ### Sample Payload
 
 ```json
@@ -55,6 +61,23 @@ has a number of parameters to further configure a connection.
   "max_connection_lifetime": "5s",
   "username": "username",
   "password": "password"
+}
+```
+
+### Sample Payload, SSL Encryption
+
+```json
+{
+  "plugin_name": "postgresql-database-plugin",
+  "allowed_roles": "readonly",
+  "connection_url": "postgresql://{{username}}:{{password}}@localhost:5432/postgres?sslmode=verify-ca&sslinline=true&sslrootcert={{ca_cert}}&sslcert={{client_public_key}}&sslkey={{client_private_key}}",
+  "max_open_connections": 5,
+  "max_connection_lifetime": "5s",
+  "username": "username",
+  "password": "password",
+  "ca_cert": "-----BEGIN CERTIFICATE-----\nMIIDI...",
+  "client_public_key": "-----BEGIN CERTIFICATE-----\nMIIDLT...",
+  "client_private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBA..."
 }
 ```
 


### PR DESCRIPTION
Related to #3191.

This is an attempt at adding support for providing a custom server CA and client public/private key pair, for encrypted communication between Vault and PostgreSQL.

This PR is dependent on a patch to the Go client library for PostgreSQL https://github.com/lib/pq/pull/818 to be merged.

What do you think about this solution?