### PR TITLE
Fix project resource name in documentation

### DIFF
--- a/website/source/api/secret/gcp/index.html.md
+++ b/website/source/api/secret/gcp/index.html.md
@@ -125,7 +125,7 @@ generated under this roleset.**
 See [bindings format docs](/docs/secrets/gcp/index.html#roleset-bindings) for more information.
 
 ```hcl
-resource "//cloudresourcemanager.googleapis.com/project/mygcpproject" {
+resource "//cloudresourcemanager.googleapis.com/projects/mygcpproject" {
   roles = [
     "roles/viewer"
   ],


### PR DESCRIPTION
The resource name when referring to a GCP project needs to have a "s". This PR adds the missing letter in the documentation.