### PR TITLE
Extended info message regarding VAULT_ADDR env variable for Windows when running `server -dev`

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1008,13 +1008,6 @@ CLUSTER_SYNTHESIS_COMPLETE:
 			sort.Strings(plugins)
 		}
 
-		export := "export"
-		quote := "'"
-		if runtime.GOOS == "windows" {
-			export = "set"
-			quote = ""
-		}
-
 		// Print the big dev mode warning!
 		c.UI.Warn(wrapAtLength(
 			"WARNING! dev mode is enabled! In this mode, Vault runs entirely " +
@@ -1024,8 +1017,15 @@ CLUSTER_SYNTHESIS_COMPLETE:
 		c.UI.Warn("")
 		c.UI.Warn("You may need to set the following environment variable:")
 		c.UI.Warn("")
-		c.UI.Warn(fmt.Sprintf("    $ %s VAULT_ADDR=%s%s%s",
-			export, quote, "http://"+config.Listeners[0].Config["address"].(string), quote))
+
+		endpointURL := "http://"+config.Listeners[0].Config["address"].(string)
+		if runtime.GOOS == "windows" {
+			c.UI.Warn(fmt.Sprintf("    $env:VAULT_ADDR=\"%s\" (PowerShell)", endpointURL))
+			c.UI.Warn("OR")
+			c.UI.Warn(fmt.Sprintf("    set VAULT_ADDR=%s (cmd.exe)", endpointURL))
+		} else {
+			c.UI.Warn(fmt.Sprintf("    $ export VAULT_ADDR='%s'", endpointURL))
+		}
 
 		// Unseal key is not returned if stored shares is supported
 		if len(init.SecretShares) > 0 {


### PR DESCRIPTION
Improvement regarding issues:
https://github.com/hashicorp/vault/issues/5964 and
https://github.com/hashicorp/vault/issues/3405

When running `vault server -dev` under Windows, the following output is printed:
```
You may need to set the following environment variable:
    $env:VAULT_ADDR="http://127.0.0.1:8200" (Powershell)
OR
    set VAULT_ADDR=http://127.0.0.1:8200 (cmd)
```

For other OSes the out is the same as before.
