### PR TITLE
UI - fix perf standby feature display

### DIFF
--- a/ui/app/components/license-info.js
+++ b/ui/app/components/license-info.js
@@ -7,18 +7,25 @@ export default Component.extend({
   startTime: '',
   licenseId: '',
   features: null,
+  model: null,
   text: '',
   showForm: false,
   isTemporary: computed('licenseId', function() {
     return this.licenseId === 'temporary';
   }),
-  featuresInfo: computed('features', function() {
-    let info = [];
-    allFeatures().forEach(feature => {
+  featuresInfo: computed('model', 'features', function() {
+    return allFeatures().map(feature => {
       let active = this.features.includes(feature) ? true : false;
-      info.push({ name: feature, active: active });
+      if (active && feature === 'Performance Standby') {
+        let count = this.model.performanceStandbyCount;
+        return {
+          name: feature,
+          active: count ? active : false,
+          count,
+        };
+      }
+      return { name: feature, active };
     });
-    return info;
   }),
   saveModel() {},
   actions: {

--- a/ui/app/components/license-info.js
+++ b/ui/app/components/license-info.js
@@ -15,7 +15,7 @@ export default Component.extend({
   }),
   featuresInfo: computed('model', 'features', function() {
     return allFeatures().map(feature => {
-      let active = this.features.includes(feature) ? true : false;
+      let active = this.features.includes(feature);
       if (active && feature === 'Performance Standby') {
         let count = this.model.performanceStandbyCount;
         return {

--- a/ui/app/models/license.js
+++ b/ui/app/models/license.js
@@ -26,4 +26,5 @@ export default DS.Model.extend({
   licenseId: attr('string'),
   startTime: attr('string'),
   text: attr('string'),
+  performanceStandbyCount: attr('number'),
 });

--- a/ui/app/templates/components/license-info.hbs
+++ b/ui/app/templates/components/license-info.hbs
@@ -71,7 +71,8 @@
     {{#each featuresInfo as |info|}}
       {{#info-table-row label=info.name value=(if info.active "Active" "Not Active") data-test-feature-row="data-test-feature-row"}}
         {{#if info.active}}
-          <ICon @size=28 @glyph="true" /> <span data-test-feature-status>Active</span>
+        <ICon @size=28 @glyph="true" /> <span data-test-feature-status>Active {{#if info.count}}&mdash;
+          count: {{info.count}}{{/if}}</span>
         {{else}}
           <ICon @size=28 @glyph="false" /> <span data-test-feature-status>Not Active</span>
         {{/if}}

--- a/ui/app/templates/components/license-info.hbs
+++ b/ui/app/templates/components/license-info.hbs
@@ -72,7 +72,7 @@
       {{#info-table-row label=info.name value=(if info.active "Active" "Not Active") data-test-feature-row="data-test-feature-row"}}
         {{#if info.active}}
         <ICon @size=28 @glyph="true" /> <span data-test-feature-status>Active {{#if info.count}}&mdash;
-         {{info.count}} standby nodes connected{{/if}}</span>
+         {{info.count}} standby nodes allotted{{/if}}</span>
         {{else}}
           <ICon @size=28 @glyph="false" /> <span data-test-feature-status>Not Active</span>
         {{/if}}

--- a/ui/app/templates/components/license-info.hbs
+++ b/ui/app/templates/components/license-info.hbs
@@ -72,7 +72,7 @@
       {{#info-table-row label=info.name value=(if info.active "Active" "Not Active") data-test-feature-row="data-test-feature-row"}}
         {{#if info.active}}
         <ICon @size=28 @glyph="true" /> <span data-test-feature-status>Active {{#if info.count}}&mdash;
-          count: {{info.count}}{{/if}}</span>
+         {{info.count}} standby nodes connected{{/if}}</span>
         {{else}}
           <ICon @size=28 @glyph="false" /> <span data-test-feature-status>Not Active</span>
         {{/if}}

--- a/ui/tests/integration/components/license-info-test.js
+++ b/ui/tests/integration/components/license-info-test.js
@@ -15,14 +15,6 @@ const component = create(license);
 module('Integration | Component | license info', function(hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function() {
-    component.setContext(this);
-  });
-
-  hooks.afterEach(function() {
-    component.removeContext();
-  });
-
   const LICENSE_WARNING_TEXT = `Warning Your temporary license expires in 30 minutes and your vault will seal. Please enter a valid license below.`;
 
   test('it renders properly for temporary license', async function(assert) {
@@ -113,5 +105,37 @@ module('Integration | Component | license info', function(hooks) {
     await component.text('ABCDE12345');
     await component.saveButton();
     assert.ok(this.get('saveModel').calledOnce);
+  });
+
+  test('it renders Performance Standby as inactive if count is 0', async function(assert) {
+    const now = Date.now();
+    this.set('licenseId', 'temporary');
+    this.set('expirationTime', addMinutes(now, 30));
+    this.set('startTime', now);
+    this.set('model', { performanceStandbyCount: 0 });
+    this.set('features', ['Performance Standby', 'Namespaces']);
+
+    await render(
+      hbs`<LicenseInfo @licenseId={{this.licenseId}} @expirationTime={{this.expirationTime}} @startTime={{this.startTime}} @features={{this.features}} @model={{this.model}}/>`
+    );
+
+    let row = component.featureRows.filterBy('featureName', 'Performance Standby')[0];
+    assert.equal(row.featureStatus, 'Not Active', 'renders feature as inactive because when count is 0');
+  });
+
+  test('it renders Performance Standby as active and shows count', async function(assert) {
+    const now = Date.now();
+    this.set('licenseId', 'temporary');
+    this.set('expirationTime', addMinutes(now, 30));
+    this.set('startTime', now);
+    this.set('model', { performanceStandbyCount: 4 });
+    this.set('features', ['Performance Standby', 'Namespaces']);
+
+    await render(
+      hbs`<LicenseInfo @licenseId={{this.licenseId}} @expirationTime={{this.expirationTime}} @startTime={{this.startTime}} @features={{this.features}} @model={{this.model}}/>`
+    );
+
+    let row = component.featureRows.filterBy('featureName', 'Performance Standby')[0];
+    assert.equal(row.featureStatus, 'Active — count: 4', 'renders active and displays count');
   });
 });

--- a/ui/tests/integration/components/license-info-test.js
+++ b/ui/tests/integration/components/license-info-test.js
@@ -136,6 +136,6 @@ module('Integration | Component | license info', function(hooks) {
     );
 
     let row = component.featureRows.filterBy('featureName', 'Performance Standby')[0];
-    assert.equal(row.featureStatus, 'Active — count: 4', 'renders active and displays count');
+    assert.equal(row.featureStatus, 'Active — 4 standby nodes allotted', 'renders active and displays count');
   });
 });


### PR DESCRIPTION
Perf standbys are always in the features list (in pro and prem), but there's also `performance_standby_count` which is 0 in pro and 2 in prem. This PR changes the license component to display count if there is one, and to show Performance Standby as Not Active if the count is 0.

<img width="535" alt="screen shot 2018-12-18 at 10 04 41 am" src="https://user-images.githubusercontent.com/39469/50166865-7cecc400-02ad-11e9-9631-bab921fc32fe.png">
<img width="551" alt="screen shot 2018-12-18 at 10 09 51 am" src="https://user-images.githubusercontent.com/39469/50166870-7f4f1e00-02ad-11e9-96e7-33cef39dd0f0.png">
