### PR TITLE
Adding support for SSE in the S3 storage backend.

### DIFF
--- a/physical/s3/s3_test.go
+++ b/physical/s3/s3_test.go
@@ -18,18 +18,22 @@ import (
 )
 
 func TestDefaultS3Backend(t *testing.T) {
-	DoS3BackendTest(t, "")
+	DoS3BackendTest(t, "", "")
 }
 
 func TestS3BackendSseAes256(t *testing.T) {
-	DoS3BackendTest(t, "AES256")
+	DoS3BackendTest(t, "AES256", "")
 }
 
 func TestS3BackendSseKms(t *testing.T) {
-	DoS3BackendTest(t, "aws:kms")
+	DoS3BackendTest(t, "aws:kms", "")
 }
 
-func DoS3BackendTest(t *testing.T, sse string) {
+func TestS3BackendSseKmsWithAliasedKey(t *testing.T) {
+	DoS3BackendTest(t, "aws:kms", "alias/aws/s3")
+}
+
+func DoS3BackendTest(t *testing.T, sse string, kmsKeyId string) {
 	credsConfig := &awsutil.CredentialsConfig{}
 
 	credsChain, err := credsConfig.GenerateCredentialChain()
@@ -95,8 +99,9 @@ func DoS3BackendTest(t *testing.T, sse string) {
 
 	// This uses the same logic to find the AWS credentials as we did at the beginning of the test
 	b, err := NewS3Backend(map[string]string{
-		"bucket": bucket,
-		"sse":    sse,
+		"bucket":   bucket,
+		"sse":      sse,
+		"kmsKeyId": kmsKeyId,
 	}, logger)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/physical/s3/s3_test.go
+++ b/physical/s3/s3_test.go
@@ -17,7 +17,19 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-func TestS3Backend(t *testing.T) {
+func TestDefaultS3Backend(t *testing.T) {
+	DoS3BackendTest(t, "")
+}
+
+func TestS3BackendSseAes256(t *testing.T) {
+	DoS3BackendTest(t, "AES256")
+}
+
+func TestS3BackendSseKms(t *testing.T) {
+	DoS3BackendTest(t, "aws:kms")
+}
+
+func DoS3BackendTest(t *testing.T, sse string) {
 	credsConfig := &awsutil.CredentialsConfig{}
 
 	credsChain, err := credsConfig.GenerateCredentialChain()
@@ -84,6 +96,7 @@ func TestS3Backend(t *testing.T) {
 	// This uses the same logic to find the AWS credentials as we did at the beginning of the test
 	b, err := NewS3Backend(map[string]string{
 		"bucket": bucket,
+		"sse":    sse,
 	}, logger)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/physical/s3/s3_test.go
+++ b/physical/s3/s3_test.go
@@ -21,19 +21,11 @@ func TestDefaultS3Backend(t *testing.T) {
 	DoS3BackendTest(t, "", "")
 }
 
-func TestS3BackendSseAes256(t *testing.T) {
-	DoS3BackendTest(t, "AES256", "")
-}
-
 func TestS3BackendSseKms(t *testing.T) {
-	DoS3BackendTest(t, "aws:kms", "")
-}
-
-func TestS3BackendSseKmsWithAliasedKey(t *testing.T) {
 	DoS3BackendTest(t, "aws:kms", "alias/aws/s3")
 }
 
-func DoS3BackendTest(t *testing.T, sse string, kmsKeyId string) {
+func DoS3BackendTest(t *testing.T, kmsKeyId string) {
 	credsConfig := &awsutil.CredentialsConfig{}
 
 	credsChain, err := credsConfig.GenerateCredentialChain()
@@ -100,7 +92,6 @@ func DoS3BackendTest(t *testing.T, sse string, kmsKeyId string) {
 	// This uses the same logic to find the AWS credentials as we did at the beginning of the test
 	b, err := NewS3Backend(map[string]string{
 		"bucket":   bucket,
-		"sse":      sse,
 		"kmsKeyId": kmsKeyId,
 	}, logger)
 	if err != nil {

--- a/physical/s3/s3_test.go
+++ b/physical/s3/s3_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 func TestDefaultS3Backend(t *testing.T) {
-	DoS3BackendTest(t, "", "")
+	DoS3BackendTest(t, "")
 }
 
 func TestS3BackendSseKms(t *testing.T) {
-	DoS3BackendTest(t, "aws:kms", "alias/aws/s3")
+	DoS3BackendTest(t, "alias/aws/s3")
 }
 
 func DoS3BackendTest(t *testing.T, kmsKeyId string) {

--- a/website/source/docs/configuration/storage/s3.html.md
+++ b/website/source/docs/configuration/storage/s3.html.md
@@ -68,13 +68,10 @@ cause Vault to attempt to retrieve credentials from the AWS metadata service.
 - `disable_ssl` `(string: "false")` - Specifies if SSL should be used for the
   endpoint connection (highly recommended not to disable for production).
 
-- `sse` `(string: "")` - Specifies if S3 server side encryption should be enabled.
-  Valid values are `AES256` or `aws:kms`. Server side encryption is disabled if
-  this option is not specified.
-  
 - `kms_key_id` `(string: "")` - Specifies the ID or Alias of the KMS key used to
   encrypt data in the S3 backend. Vault must have `kms:Encrypt` and `kms:Decrypt`
-  permissions for this key. If specified, `sse` must be set to `aws:kms`.
+  permissions for this key. You can use `alias/aws/s3` to specify the default
+  key for the account.
   
 ## `s3` Examples
 
@@ -90,21 +87,7 @@ storage "s3" {
 }
 ```
 
-### S3 Server Side Encryption (AES256)
-
-This example shows using Amazon S3 as a storage backend with AES256 server side
-encryption enabled.
-
-```hcl
-storage "s3" {
-  access_key = "abcd1234"
-  secret_key = "defg5678"
-  bucket     = "my-bucket"
-  sse        = "AES256"
-}
-```
-
-### S3 Server Side Encryption (KMS)
+### S3 KMS Encryption with Default Key
 
 This example shows using Amazon S3 as a storage backend using KMS
 encryption with the default S3 KMS key for the account.
@@ -114,11 +97,11 @@ storage "s3" {
   access_key = "abcd1234"
   secret_key = "defg5678"
   bucket     = "my-bucket"
-  sse        = "aws:kms"
+  kms_key_id = "alias/aws/s3"
 }
 ```
 
-### S3 Server Side Encryption (Custom KMS Key)
+### S3 KMS Encryption with Custom Key
 
 This example shows using Amazon S3 as a storage backend using KMS
 encryption with a customer managed KMS key.
@@ -128,23 +111,7 @@ storage "s3" {
   access_key = "abcd1234"
   secret_key = "defg5678"
   bucket     = "my-bucket"
-  sse        = "aws:kms"
   kms_key_id = "001234ac-72d3-9902-a3fc-0123456789ab"
-}
-```
-
-### S3 Server Side Encryption (Aliased KMS Key)
-
-This example shows using Amazon S3 as a storage backend using KMS
-encryption with an aliased customer managed KMS key.
-
-```hcl
-storage "s3" {
-  access_key = "abcd1234"
-  secret_key = "defg5678"
-  bucket     = "my-bucket"
-  sse        = "aws:kms"
-  kms_key_id = "alias/MyVaultKey"
 }
 ```
 

--- a/website/source/docs/configuration/storage/s3.html.md
+++ b/website/source/docs/configuration/storage/s3.html.md
@@ -68,6 +68,14 @@ cause Vault to attempt to retrieve credentials from the AWS metadata service.
 - `disable_ssl` `(string: "false")` - Specifies if SSL should be used for the
   endpoint connection (highly recommended not to disable for production).
 
+- `sse` `(string: "")` - Specifies if S3 server side encryption should be enabled.
+  Valid values are `AES256` or `aws:kms`. Server side encryption is disabled if
+  this option is not specified.
+  
+- `kms_key_id` `(string: "")` - Specifies the ID or Alias of the KMS key used to
+  encrypt data in the S3 backend. Vault must have `kms:Encrypt` and `kms:Decrypt`
+  permissions for this key. If specified, `sse` must be set to `aws:kms`.
+  
 ## `s3` Examples
 
 ### Default Example
@@ -79,6 +87,64 @@ storage "s3" {
   access_key = "abcd1234"
   secret_key = "defg5678"
   bucket     = "my-bucket"
+}
+```
+
+### S3 Server Side Encryption (AES256)
+
+This example shows using Amazon S3 as a storage backend with AES256 server side
+encryption enabled.
+
+```hcl
+storage "s3" {
+  access_key = "abcd1234"
+  secret_key = "defg5678"
+  bucket     = "my-bucket"
+  sse        = "AES256"
+}
+```
+
+### S3 Server Side Encryption (KMS)
+
+This example shows using Amazon S3 as a storage backend using KMS
+encryption with the default S3 KMS key for the account.
+
+```hcl
+storage "s3" {
+  access_key = "abcd1234"
+  secret_key = "defg5678"
+  bucket     = "my-bucket"
+  sse        = "aws:kms"
+}
+```
+
+### S3 Server Side Encryption (Custom KMS Key)
+
+This example shows using Amazon S3 as a storage backend using KMS
+encryption with a customer managed KMS key.
+
+```hcl
+storage "s3" {
+  access_key = "abcd1234"
+  secret_key = "defg5678"
+  bucket     = "my-bucket"
+  sse        = "aws:kms"
+  kms_key_id = "001234ac-72d3-9902-a3fc-0123456789ab"
+}
+```
+
+### S3 Server Side Encryption (Aliased KMS Key)
+
+This example shows using Amazon S3 as a storage backend using KMS
+encryption with an aliased customer managed KMS key.
+
+```hcl
+storage "s3" {
+  access_key = "abcd1234"
+  secret_key = "defg5678"
+  bucket     = "my-bucket"
+  sse        = "aws:kms"
+  kms_key_id = "alias/MyVaultKey"
 }
 ```
 


### PR DESCRIPTION
This adds the ability to enable SSE for the S3 storage backend, including the option to use a customer managed KMS key.

Fixes #2673