### PR TITLE
Fix audit docs

### DIFF
--- a/website/source/docs/audit/file.html.md
+++ b/website/source/docs/audit/file.html.md
@@ -34,55 +34,40 @@ device:
 $ vault audit enable -path="vault_audit_1" file file_path=/home/user/vault_audit.log
 ```
 
+Enable logs on stdout. This is useful when running in a container:
+
+```text
+$ vault audit enable file file_path=stdout
+```
+
 ## Configuration
 
 Note the difference between `audit enable` command options and the `file` backend
 configuration options. Use `vault audit enable -help` to see the command options.
 Following are the configuration options available for the backend.
 
-<dl class="api">
-  <dt>Backend configuration options</dt>
-  <dd>
-    <ul>
-      <li>
-        <span class="param">file_path</span>
-        <span class="param-flags">required</span>
-            The path to where the audit log will be written. If this
-            path exists, the audit backend will append to it. Specify `"stdout"` to write audit log to standard output; specify `"discard"` to discard output (useful in testing scenarios).
-      </li>
-      <li>
-        <span class="param">log_raw</span>
-        <span class="param-flags">optional</span>
-            A string containing a boolean value ('true'/'false'), if set, logs
-            the security sensitive information without hashing, in the raw
-            format. Defaults to `false`.
-      </li>
-      <li>
-        <span class="param">hmac_accessor</span>
-        <span class="param-flags">optional</span>
-            A string containing a boolean value ('true'/'false'), if set,
-            enables the hashing of token accessor. Defaults
-            to `true`. This option is useful only when `log_raw` is `false`.
-      </li>
-      <li>
-        <span class="param">mode</span>
-        <span class="param-flags">optional</span>
-            A string containing an octal number representing the bit pattern
-            for the file mode, similar to `chmod`. This option defaults to
-            `0600`. Specifying mode of `0000` will disable Vault's setting any mode on the file.
-      </li>
-      <li>
-        <span class="param">format</span>
-        <span class="param-flags">optional</span>
-            Allows selecting the output format. Valid values are `json` (the
-            default) and `jsonx`, which formats the normal log entries as XML.
-      </li>
-      <li>
-        <span class="param">prefix</span>
-        <span class="param-flags">optional</span>
-            Allows a customizable string prefix to write before the actual log
-            line. Defaults to an empty string.
-      </li>
-    </ul>
-  </dd>
-</dl>
+## Configuration
+
+- `file_path` `(string: <required>)` - The path to where the audit log will be
+  written. If a file already exists at the given path, the audit backend will
+  append to it. There are some special keywords:
+
+  - `stdout` writes the audit log to standard output
+
+  - `discard` writes output (useful in testing scenarios)
+
+- `log_raw` `(bool: false)` - If enabled, logs the security sensitive
+  information without hashing, in the raw format.
+
+- `hmac_accessor` `(bool: true)` - If enabled, enables the hashing of token
+  accessor.
+
+- `mode` `(string: "0600")` - A string containing an octal number representing
+  the bit pattern for the file mode, similar to `chmod`. Set to `"0000"` to
+  prevent Vault from modifying the file mode.
+
+- `format` `(string: "json")` - Allows selecting the output format. Valid values
+  are `"json"` and `"jsonx"`, which formats the normal log entries as XML.
+
+- `prefix` `(string: "")` - A customizable string prefix to write before the
+  actual log line.


### PR DESCRIPTION
These appear to have been converted to (bad) HTML. This returns them to their original markdown format.

![screen shot 2019-01-04 at 1 46 32 pm](https://user-images.githubusercontent.com/408570/50704951-290d0980-1027-11e9-8ea6-408cf7ac40f1.png)
