### PR TITLE
Fix small typo on policy command page

### DIFF
--- a/website/source/docs/commands/policy/index.html.md
+++ b/website/source/docs/commands/policy/index.html.md
@@ -5,13 +5,13 @@ sidebar_title: "<code>policy</code>"
 sidebar_current: "docs-commands-policy"
 description: |-
   The "policy" command groups subcommands for interacting with policies. Users
-  can Users can write, read, and list policies in Vault.
+  can write, read, and list policies in Vault.
 ---
 
 # policy
 
 The `policy` command groups subcommands for interacting with policies. Users can
-Users can write, read, and list policies in Vault.
+write, read, and list policies in Vault.
 
 For more information, please see the [policy
 documentation](/docs/concepts/policies.html).


### PR DESCRIPTION
This removes a duplicate "Users can" typo I spotted while reading through the [policy command overview page](https://www.vaultproject.io/docs/commands/policy/index.html). 