### PR TITLE
Add docker-credential-vault-login to Third-Party Tools

### DIFF
--- a/website/source/api/relatedtools.html.md
+++ b/website/source/api/relatedtools.html.md
@@ -31,6 +31,6 @@ The following list of tools is maintained by the community of Vault users; Hashi
 * [Cryptr](https://github.com/adobe/cryptr) - a desktop Vault UI for Mac, Windows and Linux
 * [sequelize-vault](https://github.com/linyows/sequelize-vault) - A Sequelize plugin for easily integrating Vault secrets.
 * [ansible-modules-hashivault](https://github.com/TerryHowe/ansible-modules-hashivault) - An Ansible module for configuring most things in Vault including secrets, backends and policies.
-* [Docker credential helper](https://github.com/morningconsult/docker-credential-vault-login) - A program that automatically reads Docker credentials from your Vault server and passes them to the Docker daemon to authenticate to your Docker registry pulling an image
+* [Docker credential helper](https://github.com/morningconsult/docker-credential-vault-login) - A program that automatically reads Docker credentials from your Vault server and passes them to the Docker daemon to authenticate to your Docker registry when pulling an image
 
 Want to add your own project, or one that you use? Additions are welcome via [pull requests](https://github.com/hashicorp/vault/blob/master/website/source/api/relatedtools.html.md).

--- a/website/source/api/relatedtools.html.md
+++ b/website/source/api/relatedtools.html.md
@@ -31,5 +31,6 @@ The following list of tools is maintained by the community of Vault users; Hashi
 * [Cryptr](https://github.com/adobe/cryptr) - a desktop Vault UI for Mac, Windows and Linux
 * [sequelize-vault](https://github.com/linyows/sequelize-vault) - A Sequelize plugin for easily integrating Vault secrets.
 * [ansible-modules-hashivault](https://github.com/TerryHowe/ansible-modules-hashivault) - An Ansible module for configuring most things in Vault including secrets, backends and policies.
+* [Docker credential helper](https://github.com/morningconsult/docker-credential-vault-login) - A program that automatically reads Docker credentials from your Vault server and passes them to the Docker daemon to authenticate to your Docker registry pulling an image
 
 Want to add your own project, or one that you use? Additions are welcome via [pull requests](https://github.com/hashicorp/vault/blob/master/website/source/api/relatedtools.html.md).


### PR DESCRIPTION
This program is a [Docker credential helper which](https://github.com/docker/docker-credential-helpers) automatically authenticates to your Docker registry when your Docker credentials are stored in Vault. Specifically, it avoids the need to call `docker login`. If you keep your Docker credentials in Vault, when you run `docker pull` this program will automatically authenticate to your Vault instance via any of the methods supported by the Vault agent (e.g. `aws`, `gcp`, `approle`, etc.) to obtain a client token, use that client token to read the secret where your Docker credentials are kept, and pass those credentials to the Docker daemon. 