### PR TITLE
Fix #5973 on windows by disregarding errors when querying legacy cert path

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -262,11 +262,11 @@ func fetchCertBySerial(ctx context.Context, req *logical.Request, prefix, serial
 		return nil, nil
 	}
 
-	// Retrieve the old-style path
-	certEntry, err = req.Storage.Get(ctx, legacyPath)
-	if err != nil {
-		return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching certificate %s: %s", serial, err)}
-	}
+	// Retrieve the old-style path.  We disregard errors here because they
+	// always manifest on windows, and thus the initial check for a revoked
+	// cert fails would return an error when the cert isn't revoked, preventing
+	// the happy path from working.
+	certEntry, _ = req.Storage.Get(ctx, legacyPath)
 	if certEntry == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
@jefferai suggested either disregarding the error here or skipping the legacy query when on windows; I chose to do the former as it seemed a smaller change.