### PR TITLE
Document upper limit on Transit encryption size

### DIFF
--- a/website/source/api/secret/transit/index.html.md
+++ b/website/source/api/secret/transit/index.html.md
@@ -385,6 +385,12 @@ will be returned.
 }
 ```
 
+!> Vault HTTP API imposes a maximum request size of 32MB to prevent a denial
+of service attack. This can be tuned per [`listener`
+block](/docs/configuration/listener/tcp.html) in the Vault server
+configuration.
+
+
 ### Sample Request
 
 ```
@@ -966,7 +972,7 @@ input to this endpoint should be the output of `/backup` endpoint.
  ~> For safety, by default the backend will refuse to restore to an existing
  key. If you want to reuse a key name, it is recommended you delete the key
  before restoring. It is a good idea to attempt restoring to a different key
- name first to verify that the operation successfully completes. 
+ name first to verify that the operation successfully completes.
 
 | Method   | Path                        | Produces               |
 | :------- | :-------------------------- | :--------------------- |

--- a/website/source/docs/secrets/transit/index.html.md
+++ b/website/source/docs/secrets/transit/index.html.md
@@ -63,7 +63,7 @@ types also generate separate HMAC keys):
 * `ecdsa-p256`: ECDSA using curve P256; supports signing and signature
   verification
 * `rsa-2048`: 2048-bit RSA key; supports encryption, decryption, signing, and
-  signature verification 
+  signature verification
 * `rsa-4096`: 4096-bit RSA key; supports encryption, decryption, signing, and
   signature verification
 
@@ -143,6 +143,11 @@ the proper permission, it can use this secrets engine.
     Note that Vault does not _store_ any of this data. The caller is responsible
     for storing the encrypted ciphertext. When the caller wants the plaintext,
     it must provide the ciphertext back to Vault to decrypt the value.
+
+    !> Vault HTTP API imposes a maximum request size of 32MB to prevent a denial
+    of service attack. This can be tuned per [`listener`
+    block](/docs/configuration/listener/tcp.html) in the Vault server
+    configuration.
 
 1. Decrypt a piece of data using the `/decrypt` endpoint with a named key:
 


### PR DESCRIPTION
This is to resolve the [Asana task](https://app.asana.com/0/112957393038545/806004910285237/f). 

I was tempted to simply add a link to the [doc](https://www.vaultproject.io/api/overview.html#limits) but decided to spell out the default max HTTP request size.  