### PR TITLE
Document allowed characters in paths

### DIFF
--- a/website/source/api/system/auth.html.md
+++ b/website/source/api/system/auth.html.md
@@ -69,6 +69,8 @@ For example, enable the "foo" auth method will make it accessible at
 - `path` `(string: <required>)` – Specifies the path in which to enable the auth
   method. This is part of the request URL.
 
+    !> **NOTE:** Use ASCII printable characters to specify the desired path.
+
 - `description` `(string: "")` – Specifies a human-friendly description of the
   auth method.
 

--- a/website/source/api/system/mounts.html.md
+++ b/website/source/api/system/mounts.html.md
@@ -70,6 +70,8 @@ This endpoint enables a new secrets engine at the given path.
 - `path` `(string: <required>)` – Specifies the path where the secrets engine
   will be mounted. This is specified as part of the URL.
 
+    !> **NOTE:** Use ASCII printable characters to specify the desired path.
+
 - `type` `(string: <required>)` – Specifies the type of the backend, such as
   "aws".
 
@@ -110,8 +112,8 @@ This endpoint enables a new secrets engine at the given path.
     `pki` backends. This is only available in Vault Enterprise.
 
 - `options` `(map<string|string>: nil)` - Specifies mount type specific options
-  that are passed to the backend. 
-  
+  that are passed to the backend.
+
     *Key/Value (KV)*  
     - `version` `(string: "1")` - The version of the KV to mount. Set to "2" for mount
       KV v2.


### PR DESCRIPTION
This is for the [Asana task](https://app.asana.com/0/112957393038545/891804286044398/f). 

I used the term, "ASCII printable characters"  rather than "alphanumeric characters" since special characters (e.g. @, &, #) are also supported.  