### PR TITLE
Bug fix - ui context menu

### DIFF
--- a/ui/app/helpers/dot-to-dash.js
+++ b/ui/app/helpers/dot-to-dash.js
@@ -1,0 +1,7 @@
+import { helper as buildHelper } from '@ember/component/helper';
+
+export function dotToDash([string]) {
+  return string.replace(/\./gi, '-');
+}
+
+export default buildHelper(dotToDash);

--- a/ui/app/templates/components/identity/popup-alias.hbs
+++ b/ui/app/templates/components/identity/popup-alias.hbs
@@ -29,8 +29,8 @@
               buttonClasses="link is-destroy"
               onConfirmAction=(action "performTransaction" item)
               confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-              showConfirm=(get this (concat "shouldDelete-" item.id))
-              class=(if (get this (concat "shouldDelete-" item.id)) "message is-block is-warning is-outline")
+              showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
+              class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
               containerClasses="message-body is-block"
               messageClasses="is-block"
             }}

--- a/ui/app/templates/components/identity/popup-members.hbs
+++ b/ui/app/templates/components/identity/popup-members.hbs
@@ -8,8 +8,8 @@
           buttonClasses="link is-destroy"
           onConfirmAction=(action "performTransaction" model groupArray memberId)
           confirmMessage=(concat "Are you sure you want to remove " memberId "?")
-          showConfirm=(get this (concat "shouldDelete-" memberId))
-          class=(if (get this (concat "shouldDelete-" memberId)) "message is-block is-warning is-outline")
+          showConfirm=(get this (concat "shouldDelete-" (dot-to-dash memberId)))
+          class=(if (get this (concat "shouldDelete-" (dot-to-dash memberId))) "message is-block is-warning is-outline")
           containerClasses="message-body is-block"
           messageClasses="is-block"
         }}

--- a/ui/app/templates/components/identity/popup-policy.hbs
+++ b/ui/app/templates/components/identity/popup-policy.hbs
@@ -18,8 +18,8 @@
           buttonClasses="link is-destroy"
           onConfirmAction=(action "performTransaction" model policyName)
           confirmMessage=(concat "Are you sure you want to remove " policyName "?")
-          showConfirm=(get this (concat "shouldDelete-" policyName))
-          class=(if (get this (concat "shouldDelete-" policyName)) "message is-block is-warning is-outline")
+          showConfirm=(get this (concat "shouldDelete-" (dot-to-dash policyName)))
+          class=(if (get this (concat "shouldDelete-" (dot-to-dash policyName))) "message is-block is-warning is-outline")
           containerClasses="message-body is-block"
           messageClasses="is-block"
         }}

--- a/ui/app/templates/components/pki-cert-popup.hbs
+++ b/ui/app/templates/components/pki-cert-popup.hbs
@@ -13,8 +13,8 @@
             buttonClasses="link is-destroy"
             onConfirmAction=(action "delete" item)
             confirmMessage=(concat "Are you sure you want to revoke " item.id "?")
-            showConfirm=(get this (concat "shouldDelete-" item.id))
-            class=(if (get this (concat "shouldDelete-" item.id)) "message is-block is-warning is-outline")
+            showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
+            class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
             containerClasses="message-body is-block"
             messageClasses="is-block"
             confirmButtonText="Revoke"

--- a/ui/app/templates/partials/role-aws/popup-menu.hbs
+++ b/ui/app/templates/partials/role-aws/popup-menu.hbs
@@ -47,8 +47,8 @@
               buttonClasses="link is-destroy"
               onConfirmAction=(action "delete" item)
               confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-              showConfirm=(get this (concat "shouldDelete-" item.id))
-              class=(if (get this (concat "shouldDelete-" item.id)) "message is-block is-warning is-outline")
+              showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
+              class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
               containerClasses="message-body is-block"
               messageClasses="is-block"
               data-test-aws-role-delete=item.id

--- a/ui/app/templates/partials/role-pki/popup-menu.hbs
+++ b/ui/app/templates/partials/role-pki/popup-menu.hbs
@@ -60,8 +60,8 @@
               buttonClasses="link is-destroy"
               onConfirmAction=(action "delete" item)
               confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-              showConfirm=(get this (concat "shouldDelete-" item.id))
-              class=(if (get this (concat "shouldDelete-" item.id)) "message is-block is-warning is-outline")
+              showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
+              class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
               containerClasses="message-body is-block"
               messageClasses="is-block"
               data-test-aws-role-delete=item.id

--- a/ui/app/templates/partials/role-ssh/popup-menu.hbs
+++ b/ui/app/templates/partials/role-ssh/popup-menu.hbs
@@ -63,8 +63,8 @@
               buttonClasses="link is-destroy"
               onConfirmAction=(action "delete" item)
               confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-              showConfirm=(get this (concat "shouldDelete-" item.id))
-              class=(if (get this (concat "shouldDelete-" item.id)) "message is-block is-warning is-outline")
+              showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
+              class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
               containerClasses="message-body is-block"
               messageClasses="is-block"
               data-test-ssh-role-delete=item.id

--- a/ui/app/templates/partials/secret-list/item.hbs
+++ b/ui/app/templates/partials/secret-list/item.hbs
@@ -14,7 +14,7 @@
         @mode={{if item.isFolder "list" "show" }}
         @secret={{item.id}}
         @class="has-text-black has-text-weight-semibold"
-      > 
+      >
         <ICon
           @glyph={{if item.isFolder 'folder' 'file' }}
           @size="14"
@@ -31,7 +31,7 @@
                 @mode="list"
                 @secret={{item.id}}
                 @class="has-text-black has-text-weight-semibold"
-              > 
+              >
                 Contents
               </SecretLink>
             {{else}}
@@ -48,7 +48,7 @@
                       @mode="show"
                       @secret={{item.id}}
                       @class="has-text-black has-text-weight-semibold"
-                    > 
+                    >
                       Details
                     </SecretLink>
                   </li>
@@ -58,7 +58,7 @@
                         @mode="versions"
                         @secret={{item.id}}
                         @class="has-text-black has-text-weight-semibold"
-                      > 
+                      >
                         View version history
                       </SecretLink>
                     </li>
@@ -70,7 +70,7 @@
                       @mode="edit"
                       @secret={{item.id}}
                       @class="has-text-black has-text-weight-semibold"
-                    > 
+                    >
                       {{if backendModel.isV2KV
                         "Create New Version"
                         "Edit"
@@ -85,8 +85,8 @@
                       buttonClasses="link is-destroy"
                       onConfirmAction=(action "delete" item "secret")
                       confirmMessage=(concat "Are you sure you want to permanently delete " item.id " and all its versions?")
-                      showConfirm=(get this (concat "shouldDelete-" item.id))
-                      class=(if (get this (concat "shouldDelete-" item.id)) "message is-block is-warning is-outline")
+                      showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
+                      class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
                       containerClasses="message-body is-block"
                       messageClasses="is-block"
                       data-test-v2-kv-delete=item.id

--- a/ui/app/templates/vault/cluster/access/identity/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/index.hbs
@@ -64,8 +64,8 @@
                           buttonClasses="link"
                           onConfirmAction=(action "toggleDisabled" item)
                           confirmMessage=(concat "Are you sure you want to disable " item.id "?")
-                          showConfirm=(get this (concat "shouldDisable-" item.id))
-                          class=(if (get this (concat "shouldDisable-" item.id)) "message is-block is-warning is-outline")
+                          showConfirm=(get this (concat "shouldDisable-" (dot-to-dash item.id)))
+                          class=(if (get this (concat "shouldDisable-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
                           containerClasses="message-body is-block"
                           messageClasses="is-block"
                         }}
@@ -89,8 +89,8 @@
                         buttonClasses="link"
                         onConfirmAction=(action "delete" item)
                         confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-                        showConfirm=(get this (concat "shouldDelete-" item.id))
-                        class=(if (get this (concat "shouldDelete-" item.id)) "message is-block is-warning is-outline")
+                        showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
+                        class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
                         containerClasses="message-body is-block"
                         messageClasses="is-block"
                       }}

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -64,8 +64,8 @@
                       buttonClasses="link is-destroy"
                       onConfirmAction=(perform disableMethod method)
                       confirmMessage=(concat "Are you sure you want to disable the " method.id " auth method at " method.path "?")
-                      showConfirm=(get this (concat "shouldDelete-" method.id))
-                      class=(if (get this (concat "shouldDelete-" method.id)) "message is-block is-warning is-outline")
+                      showConfirm=(get this (concat "shouldDelete-" (dot-to-dash method.id)))
+                      class=(if (get this (concat "shouldDelete-" (dot-to-dash method.id))) "message is-block is-warning is-outline")
                       containerClasses="message-body is-block"
                       messageClasses="is-block"
                       confirmButtonText="Disable"

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -43,8 +43,8 @@
               )
             }}
             @confirmMessage={{concat "Are you sure you want to delete " list.item.id "?"}}
-            @showConfirm={{get this (concat "shouldDelete-" list.item.id)}}
-            @class={{if (get this (concat "shouldDelete-" list.item.id)) "message is-block is-warning is-outline"}}
+            @showConfirm={{get this (concat "shouldDelete-" (dot-to-dash list.item.id))}}
+            @class={{if (get this (concat "shouldDelete-" (dot-to-dash list.item.id))) "message is-block is-warning is-outline"}}
             @containerClasses="message-body is-block"
             @messageClasses="is-block"
           >

--- a/ui/app/templates/vault/cluster/policies/index.hbs
+++ b/ui/app/templates/vault/cluster/policies/index.hbs
@@ -121,8 +121,8 @@
                             buttonClasses="link is-destroy"
                             onConfirmAction=(action "deletePolicy" item)
                             confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-                            showConfirm=(get this (concat "shouldDelete-" item.id))
-                            class=(if (get this (concat "shouldDelete-" item.id)) "message is-block is-warning is-outline")
+                            showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
+                            class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
                             containerClasses="message-body is-block"
                             messageClasses="is-block"
                             data-test-policy-delete=item.id

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -66,8 +66,8 @@
                       @buttonClasses="link is-destroy"
                       @onConfirmAction={{perform disableEngine backend}}
                       @confirmMessage={{concat "Are you sure you want to disable the " backend.engineType " secrets engine at " backend.path "?"}}
-                      @showConfirm={{get this (concat "shouldDelete-" backend.id)}}
-                      @class={{if (get this (concat "shouldDelete-" backend.id)) "message is-block is-warning is-outline"}}
+                      @showConfirm={{get this (concat "shouldDelete-" (dot-to-dash backend.id))}}
+                      @class={{if (get this (concat "shouldDelete-" (dot-to-dash backend.id))) "message is-block is-warning is-outline"}}
                       @containerClasses="message-body is-block"
                       @messageClasses="is-block"
                       @confirmButtonText="Disable"
@@ -128,8 +128,8 @@
                      @buttonClasses="link is-destroy"
                      @onConfirmAction={{perform disableEngine backend}}
                      @confirmMessage={{concat "Are you sure you want to disable the " backend.engineType " secrets engine at " backend.path "?"}}
-                     @showConfirm={{get this (concat "shouldDelete-" backend.id)}}
-                     @class={{if (get this (concat "shouldDelete-" backend.id)) "message is-block is-warning is-outline"}}
+                     @showConfirm={{get this (concat "shouldDelete-" (dot-to-dash backend.id))}}
+                     @class={{if (get this (concat "shouldDelete-" (dot-to-dash backend.id))) "message is-block is-warning is-outline"}}
                      @containerClasses="message-body is-block"
                      @messageClasses="is-block"
                      @confirmButtonText="Disable"

--- a/ui/tests/acceptance/policies/index-test.js
+++ b/ui/tests/acceptance/policies/index-test.js
@@ -31,11 +31,11 @@ module('Acceptance | policies/acl', function(hooks) {
   });
 
   test('it allows deletion of policies with dots in names', async function(assert) {
-    const POLICY = `path "*" { capabilities = ["list"]}`;
+    const POLICY = 'path "*" { capabilities = ["list"]}';
     let policyName = 'list.policy';
-    await consoleComponent.runCommands(`write sys/policies/acl/${policyName} policy=${POLICY}`);
+    await consoleComponent.runCommands([`write sys/policies/acl/${policyName} policy='${POLICY}'`]);
     await page.visit({ type: 'acl' });
-    let policy = page.findPolicyByName(policyName);
+    let policy = page.row.filterBy('name', policyName)[0];
     assert.ok(policy, 'policy is shown in the list');
     await policy.menu();
     await page.delete().confirmDelete();

--- a/ui/tests/acceptance/policies/index-test.js
+++ b/ui/tests/acceptance/policies/index-test.js
@@ -1,8 +1,13 @@
 import { currentURL, currentRouteName } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
+import { create } from 'ember-cli-page-object';
+
 import page from 'vault/tests/pages/policies/index';
 import authPage from 'vault/tests/pages/auth';
+import consoleClass from 'vault/tests/pages/components/console/ui-panel';
+
+const consoleComponent = create(consoleClass);
 
 module('Acceptance | policies/acl', function(hooks) {
   setupApplicationTest(hooks);
@@ -23,5 +28,17 @@ module('Acceptance | policies/acl', function(hooks) {
     await page.findPolicyByName('default').click();
     assert.equal(currentRouteName(), 'vault.cluster.policy.show');
     assert.equal(currentURL(), '/vault/policy/acl/default');
+  });
+
+  test('it allows deletion of policies with dots in names', async function(assert) {
+    const POLICY = `path "*" { capabilities = ["list"]}`;
+    let policyName = 'list.policy';
+    await consoleComponent.runCommands(`write sys/policies/acl/${policyName} policy=${POLICY}`);
+    await page.visit({ type: 'acl' });
+    let policy = page.findPolicyByName(policyName);
+    assert.ok(policy, 'policy is shown in the list');
+    await policy.menu();
+    await page.delete().confirmDelete();
+    assert.notOk(page.findPolicyByName(policyName), 'policy is deleted successfully');
   });
 });

--- a/ui/tests/pages/policies/index.js
+++ b/ui/tests/pages/policies/index.js
@@ -1,10 +1,19 @@
-import { text, create, collection, visitable } from 'ember-cli-page-object';
+import { text, create, collection, clickable, visitable } from 'ember-cli-page-object';
 export default create({
   visit: visitable('/vault/policies/:type'),
   policies: collection('[data-test-policy-item]', {
     name: text('[data-test-policy-name]'),
+    menu: clickable('[data-test-popup-menu-trigger]'),
   }),
   findPolicyByName(name) {
     return this.policies.filterBy('name', name)[0];
   },
+  delete: clickable('[data-test-confirm-action-trigger]', {
+    scope: '[data-test-item-delete]',
+    testContainer: '#ember-testing',
+  }),
+  confirmDelete: clickable('[data-test-confirm-button]', {
+    scope: '[data-test-item-delete]',
+    testContainer: '#ember-testing',
+  }),
 });

--- a/ui/tests/pages/policies/index.js
+++ b/ui/tests/pages/policies/index.js
@@ -3,17 +3,18 @@ export default create({
   visit: visitable('/vault/policies/:type'),
   policies: collection('[data-test-policy-item]', {
     name: text('[data-test-policy-name]'),
+  }),
+  row: collection('[data-test-policy-link]', {
+    name: text(),
     menu: clickable('[data-test-popup-menu-trigger]'),
   }),
   findPolicyByName(name) {
     return this.policies.filterBy('name', name)[0];
   },
   delete: clickable('[data-test-confirm-action-trigger]', {
-    scope: '[data-test-item-delete]',
     testContainer: '#ember-testing',
   }),
   confirmDelete: clickable('[data-test-confirm-button]', {
-    scope: '[data-test-item-delete]',
     testContainer: '#ember-testing',
   }),
 });

--- a/ui/tests/unit/helpers/dot-to-dash-test.js
+++ b/ui/tests/unit/helpers/dot-to-dash-test.js
@@ -1,0 +1,22 @@
+import { dotToDash } from 'vault/helpers/dot-to-dash';
+import { module, test } from 'qunit';
+
+module('Unit | Helpers | dot-to-dash', function() {
+  test('it returns a string unchanged if there are not .s', function(assert) {
+    let string = 'foo';
+    let result = dotToDash([string]);
+    assert.equal(string, result);
+  });
+
+  test('it replaces a single . with -', function(assert) {
+    let string = 'foo.bar';
+    let result = dotToDash([string]);
+    assert.equal(result, 'foo-bar');
+  });
+
+  test('it replaces multiple . with -', function(assert) {
+    let string = 'foo.bar.baz';
+    let result = dotToDash([string]);
+    assert.equal(result, 'foo-bar-baz');
+  });
+});


### PR DESCRIPTION
Because Ember's `get` helper uses dot-separated strings as paths on an object, if an id contained a dot, the helper would try to find a value at a non-existant path, causing an error. Here we introduced a template helper that subs dashes for dots so this no longer happens.

Fixes #5915