### PR TITLE
UI - kv save error

### DIFF
--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -134,14 +134,7 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
 
   requestInFlight: or('model.isLoading', 'model.isReloading', 'model.isSaving'),
 
-  buttonDisabled: or(
-    'requestInFlight',
-    'model.isFolder',
-    'model.isError',
-    'model.flagsIsInvalid',
-    'hasLintError',
-    'error'
-  ),
+  buttonDisabled: or('requestInFlight', 'model.isFolder', 'model.flagsIsInvalid', 'hasLintError', 'error'),
 
   modelForData: computed('isV2', 'model', function() {
     return this.isV2 ? this.model.belongsTo('selectedVersion').value() : this.model;

--- a/ui/tests/integration/components/secret-edit-test.js
+++ b/ui/tests/integration/components/secret-edit-test.js
@@ -69,6 +69,20 @@ module('Integration | Component | secret edit', function(hooks) {
     assert.dom('[data-test-error]').includesText('Vault expects data to be formatted as an JSON object');
   });
 
+  test('it allows saving when the model isError', async function(assert) {
+    this.set('mode', 'create');
+    this.set('model', {
+      isError: true,
+      secretData: {
+        int: '2',
+        null: 'null',
+        float: '1.234',
+      },
+    });
+    await render(hbs`<SecretEdit @mode={{mode}} @model={{model}} />`);
+    assert.dom('[data-test-secret-save]').isNotDisabled();
+  });
+
   test('it shows an error when editing and the data is not an object', async function(assert) {
     this.set('mode', 'edit');
     capabilities = {


### PR DESCRIPTION
Previously if we got an error when saving the model on kv edit or create, the form would be disabled. This fixes that.