### PR TITLE
UI - allow kv secret with "keys" key

### DIFF
--- a/ui/app/serializers/secret.js
+++ b/ui/app/serializers/secret.js
@@ -4,7 +4,7 @@ import ApplicationSerializer from './application';
 export default ApplicationSerializer.extend({
   secretDataPath: 'data',
   normalizeItems(payload, requestType) {
-    if (payload.data.keys && Array.isArray(payload.data.keys)) {
+    if (requestType !== 'queryRecord' && payload.data.keys && Array.isArray(payload.data.keys)) {
       // if we have data.keys, it's a list of ids, so we map over that
       // and create objects with id's
       return payload.data.keys.map(secret => {

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -138,6 +138,17 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     );
   });
 
+  // https://github.com/hashicorp/vault/issues/5994
+  test('version 1: key named keys', async function(assert) {
+    await consoleComponent.runCommands([
+      'vault write sys/mounts/test type=kv',
+      'refresh',
+      'vault write test/a keys=a keys=b',
+    ]);
+    await showPage.visit({ backend: 'test', id: 'a' });
+    assert.ok(showPage.editIsPresent, 'renders the page properly');
+  });
+
   test('it redirects to the path ending in / for list pages', async function(assert) {
     const path = `foo/bar/kv-path-${new Date().getTime()}`;
     await listPage.visitRoot({ backend: 'secret' });


### PR DESCRIPTION
We were looking for `data.keys` to determine serialization behavior between lists and single records. Now we only look for `data.keys` if it's not a call for a single record.

Fixes #5994