### PR TITLE
Fix a couple of instances where we are using LIST verb

### DIFF
--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -42,6 +42,12 @@ func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 	}
 
 	req := c.c.NewRequest(method, path)
+	if method == "LIST" {
+		// Set this for broader compatibility, but we use LIST above to be able to
+		// handle the wrapping lookup function
+		req.Method = "GET"
+		req.Params.Set("list", "true")
+	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
@@ -56,8 +62,8 @@ func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 
 	// We received an Unsupported Operation response from Vault, indicating
 	// Vault of an older version that doesn't support the READ method yet.
-	if resp.StatusCode == 405 && req.Method == "GET" {
-		req.Method = "LIST"
+	if resp.StatusCode == 405 && method == "GET" {
+		req.Params.Set("list", "true")
 		resp, err := c.c.RawRequestWithContext(ctx, req)
 		if err != nil {
 			return nil, err

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -43,8 +43,8 @@ func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 
 	req := c.c.NewRequest(method, path)
 	if method == "LIST" {
-		// Set this for broader compatibility, but we use LIST above to be able to
-		// handle the wrapping lookup function
+		// Set this for broader compatibility, but we use LIST above to be able
+		// to handle the wrapping lookup function
 		req.Method = "GET"
 		req.Params.Set("list", "true")
 	}

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -61,8 +61,9 @@ func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 	defer resp.Body.Close()
 
 	// We received an Unsupported Operation response from Vault, indicating
-	// Vault of an older version that doesn't support the READ method yet.
-	if resp.StatusCode == 405 && method == "GET" {
+	// Vault of an older version that doesn't support the GET method yet;
+	// switch it to a LIST.
+	if resp.StatusCode == 405 {
 		req.Params.Set("list", "true")
 		resp, err := c.c.RawRequestWithContext(ctx, req)
 		if err != nil {

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -10,6 +10,10 @@ import (
 
 func (c *Sys) ListPolicies() ([]string, error) {
 	r := c.c.NewRequest("LIST", "/v1/sys/policies/acl")
+	// Set this for broader compatibility, but we use LIST above to be able to
+	// handle the wrapping lookup function
+	r.Method = "GET"
+	r.Params.Set("list", "true")
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()


### PR DESCRIPTION
We specify it for the wrapping lookup function but for broader
compatibility with proxies and such we want to filter it to a GET. In a
couple of places we weren't doing that, so this updates those locations.