### PR TITLE
Adding the CLI flag placement info

### DIFF
--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -41,8 +41,8 @@ $ vault <subcommand> -h
 
 ## CLI Command Structure
 
-There are a number of command options available: HTTP options, output options,
-and command specific options.
+There are a number of command and subcommand options available: HTTP options,
+output options, and command specific options.
 
 Construct your Vault CLI command such that the command options precede its path
 and arguments if any:
@@ -51,26 +51,34 @@ and arguments if any:
 vault <command> [options] [path] [args]
 ```
 
-- `options` - CLI flags to specify additional settings (e.g. display the output
-  in JSON format)    
-- `args` - Input parameters specific to the command operation you are invoking
+- `options` - CLI flags to specify additional settings
+- `args` - API arguments specific to the operation
 
-For example, the following `write` command passes the `-address` option flag to
-specify the Vault server address which precedes the path
-(`auth/userpass/users/bob`) and its command argument
+  -> **NOTE:** Run `vault path-help <path>` to see the list of args (parameters).
+
+#### Examples:
+
+The following `write` command creates a new user (`bob`) in the userpass auth
+method. It passes the `-address` flag to specify the Vault server address which
+precedes the path (`auth/userpass/users/bob`) and its
+[argument](/api/auth/userpass/index.html#create-update-user)
 (`password="long-password"`) at last.
 
 ```text
 $ vault write -address="http://127.0.0.1:8200" auth/userpass/users/bob password="long-password"
 ```
 
-If multiple options (`-address` and `-namespace`) and arguments (`password`
-and `policies`) are specified, the command would look like:
+If multiple options (`-address` and `-namespace`) and
+[arguments](/api/auth/userpass/index.html#create-update-user) (`password` and
+`policies`) are specified, the command would look like:
 
 ```text
 $ vault write -address="http://127.0.0.1:8200" -namespace="my-organization" \
         auth/userpass/users/bob password="long-password" policies="admin"
 ```
+
+The options (CLI flags) come after the command (or subcommand) preceding the
+path, and the args always follow the path to set API parameter values.
 
 ## Exit Codes
 

--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -51,10 +51,9 @@ and arguments if any:
 vault <command> [options] [path] [args]
 ```
 
-- `options` - CLI flags to specify additional settings (e.g. display the command
-  output in JSON format)    
-- `args` - Request parameters specific to the command operation (equivalent
-  to the parameters you set when invoking Vault API)
+- `options` - CLI flags to specify additional settings (e.g. display the output
+  in JSON format)    
+- `args` - Input parameters specific to the command operation you are invoking
 
 For example, the following `write` command passes the `-address` option flag to
 specify the Vault server address which precedes the path

--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -39,6 +39,35 @@ To get help for a subcommand, run:
 $ vault <subcommand> -h
 ```
 
+## CLI Command Structure
+
+There are a number of command options available: HTTP options, output options,
+and command specific options.
+
+Construct your Vault CLI command such that the command options precede its path
+and arguments if any:
+
+```text
+vault <command> [options] [path] [args]
+```
+
+For example, the following `write` command passes the `-address` option flag to
+specify the Vault server address which precedes the path
+(`auth/userpass/users/bob`) and its command argument
+(`password="long-password"`) at last.
+
+```text
+$ vault write -address="http://127.0.0.1:8200" auth/userpass/users/bob password="long-password"
+```
+
+If multiple options (`-address` and `-namespace`) and arguments (`password`
+and `policies`) are specified, the command would look like:
+
+```text
+$ vault write -address="http://127.0.0.1:8200" -namespace="my-organization" \
+        auth/userpass/users/bob password="long-password" policies="admin"
+```
+
 ## Exit Codes
 
 The Vault CLI aims to be consistent and well-behaved unless documented
@@ -234,14 +263,14 @@ This enviroment variable will limit the rate at which the `vault` command
 sends requests to Vault.
 
 This enviroment variable has the format `rate[:burst]` (where items in `[]` are
-optional). If not specified, the burst value defaults to rate. Both rate and 
+optional). If not specified, the burst value defaults to rate. Both rate and
 burst are specified in "operations per second". If the environment variable is
-not specified, then the rate and burst will be unlimited *i.e.* rate 
+not specified, then the rate and burst will be unlimited *i.e.* rate
 limiting is off by default.
 
 *Note:* The rate is limited for each invocation of the `vault` CLI. Since
 each invocation of the `vault` CLI typically only makes a few requests,
-this enviroment variable is most useful when using the Go 
+this enviroment variable is most useful when using the Go
 [Vault client API](https://www.vaultproject.io/api/libraries.html#go).
 
 ### `VAULT_NAMESPACE`

--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -51,7 +51,7 @@ and arguments if any:
 vault <command> [options] [path] [args]
 ```
 
-- `options` - CLI flags to specify additional settings
+- `options` - [Flags](/docs/commands/index.html#flags) to specify additional settings
 - `args` - API arguments specific to the operation
 
   -> **NOTE:** Run `vault path-help <path>` to see the list of args (parameters).
@@ -77,8 +77,8 @@ $ vault write -address="http://127.0.0.1:8200" -namespace="my-organization" \
         auth/userpass/users/bob password="long-password" policies="admin"
 ```
 
-The options (CLI flags) come after the command (or subcommand) preceding the
-path, and the args always follow the path to set API parameter values.
+The options (flags) come after the command (or subcommand) preceding the path,
+and the args always follow the path to set API parameter values.
 
 ## Exit Codes
 

--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -51,6 +51,11 @@ and arguments if any:
 vault <command> [options] [path] [args]
 ```
 
+- `options` - CLI flags to specify additional settings (e.g. display the command
+  output in JSON format)    
+- `args` - Request parameters specific to the command operation (equivalent
+  to the parameters you set when invoking Vault API)
+
 For example, the following `write` command passes the `-address` option flag to
 specify the Vault server address which precedes the path
 (`auth/userpass/users/bob`) and its command argument

--- a/website/source/docs/commands/login.html.md
+++ b/website/source/docs/commands/login.html.md
@@ -40,15 +40,20 @@ the returned token is automatically unwrapped unless:
 By default, login uses a "token" method:
 
 ```text
-$ vault login 10862232-fd55-701c-9013-d764b5bc3953
-Success! You are now authenticated. The token information below is already
-stored in the token helper. You do NOT need to run "vault login" again. Future
-requests will use this token automatically.
+$ vault login s.3jnbMAKl1i4YS3QoKdbHzGXq
+Success! You are now authenticated. The token information displayed below
+is already stored in the token helper. You do NOT need to run "vault login"
+again. Future Vault requests will automatically use this token.
 
-token: 10862232-fd55-701c-9013-d764b5bc3953
-accessor: 121533e1-20e7-0b4e-04d6-a8c18b8566d5
-renewable: true
-policies: [my-policy]
+Key                  Value
+---                  -----
+token                s.3jnbMAKl1i4YS3QoKdbHzGXq
+token_accessor       7Uod1Rm0ejUAz77Oh7SxpAM0
+token_duration       767h59m49s
+token_renewable      true
+token_policies       ["admin" "default"]
+identity_policies    []
+policies             ["admin" "default"]
 ```
 
 To login with a different method, use `-method`:
@@ -60,12 +65,20 @@ Success! You are now authenticated. The token information below is already
 stored in the token helper. You do NOT need to run "vault login" again. Future
 requests will use this token automatically.
 
-token: a700ded8-28ed-907d-abf4-23514b783d52
-accessor: e0857619-3912-9981-4e03-8d6c4b2f6c56
-duration: 768h
-renewable: true
-policies: [default]
+Key                    Value
+---                    -----
+token                  s.2y4SU3Sk46dK3p2Y8q2jSBwL
+token_accessor         8J125x9SZyB76MI9uF2jSJZf
+token_duration         768h
+token_renewable        true
+token_policies         ["default"]
+identity_policies      []
+policies               ["default"]
+token_meta_username    my-username
 ```
+
+~> Notice that the command option (`-method=userpass`) precedes the command
+argument (`username=my-username`).
 
 If a github auth method was enabled at the path "github-ent":
 
@@ -75,10 +88,17 @@ Success! You are now authenticated. The token information below is already
 stored in the token helper. You do NOT need to run "vault login" again. Future
 requests will use this token automatically.
 
-token: 7eab2aba-b476-af57-e0af-dfcab7c541f6
-accessor: 2ae9b1cd-6d17-3428-bd44-986e97f6d2f3
-renewable: 22bc4d76-aa3b-1c53-4349-b230b459b56b
-policies: [root]
+Key                    Value
+---                    -----
+token                  s.2f3c5L1MHtnqbuNCbx90utmC
+token_accessor         JLUIXJ6ltUftTt2UYRl2lTAC
+token_duration         768h
+token_renewable        true
+token_policies         ["default"]
+identity_policies      []
+policies               ["default"]
+token_meta_org         hashicorp
+token_meta_username    my-username
 ```
 
 ## Usage


### PR DESCRIPTION
This is to resolve the [Asana task](https://app.asana.com/0/157256879238414/959593948077948/f). 

I added the following in the [Vault Commands (CLI)](https://www.vaultproject.io/docs/commands/index.html) doc: 

![screenshot](https://s3-us-west-1.amazonaws.com/education-yh/screenshots/CLI.png)

The help text already describes the command usage, but it wouldn't hurt to re-emphasize the order. As far as I know, there is nothing special about the `-namespace` and `-path` flags, so I didn't explicitly call out the two.  

I updated the login doc a little, but again, its help text already explains the command usage. 

@lauradiane @amanoske  Would this be good enough, or is there anything I missed?


