### PR TITLE
Allow user to provide no sinks to Agent

### DIFF
--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -126,11 +126,8 @@ func parseAutoAuth(result *Config, list *ast.ObjectList) error {
 		return errwrap.Wrapf("error parsing 'sink' stanzas: {{err}}", err)
 	}
 
-	switch {
-	case a.Method == nil:
+	if a.Method == nil {
 		return fmt.Errorf("no 'method' block found")
-	case len(a.Sinks) == 0:
-		return fmt.Errorf("at least one 'sink' block must be provided")
 	}
 
 	return nil
@@ -185,7 +182,7 @@ func parseSinks(result *Config, list *ast.ObjectList) error {
 
 	sinkList := list.Filter(name)
 	if len(sinkList.Items) < 1 {
-		return fmt.Errorf("at least one %q block is required", name)
+		return nil
 	}
 
 	var ts []*Sink

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -16,56 +16,110 @@ func TestLoadConfigFile(t *testing.T) {
 	os.Setenv("TEST_AAD_ENV", "aad")
 	defer os.Unsetenv("TEST_AAD_ENV")
 
-	config, err := LoadConfig("./test-fixtures/config.hcl", logger)
-	if err != nil {
-		t.Fatalf("err: %s", err)
+	testLoadConfig := func(file string, expected *Config) {
+		config, err := LoadConfig(file, logger)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if diff := deep.Equal(config, expected); diff != nil {
+			t.Fatal(diff)
+		}
 	}
 
-	expected := &Config{
-		AutoAuth: &AutoAuth{
-			Method: &Method{
-				Type:      "aws",
-				WrapTTL:   300 * time.Second,
-				MountPath: "auth/aws",
-				Config: map[string]interface{}{
-					"role": "foobar",
-				},
-			},
-			Sinks: []*Sink{
-				&Sink{
-					Type:   "file",
-					DHType: "curve25519",
-					DHPath: "/tmp/file-foo-dhpath",
-					AAD:    "foobar",
+	t.Run("non-embedded type", func(t *testing.T) {
+		expected := &Config{
+			AutoAuth: &AutoAuth{
+				Method: &Method{
+					Type:      "aws",
+					WrapTTL:   300 * time.Second,
+					MountPath: "auth/aws",
 					Config: map[string]interface{}{
-						"path": "/tmp/file-foo",
+						"role": "foobar",
 					},
 				},
-				&Sink{
-					Type:    "file",
-					WrapTTL: 5 * time.Minute,
-					DHType:  "curve25519",
-					DHPath:  "/tmp/file-foo-dhpath2",
-					AAD:     "aad",
-					Config: map[string]interface{}{
-						"path": "/tmp/file-bar",
+				Sinks: []*Sink{
+					&Sink{
+						Type:   "file",
+						DHType: "curve25519",
+						DHPath: "/tmp/file-foo-dhpath",
+						AAD:    "foobar",
+						Config: map[string]interface{}{
+							"path": "/tmp/file-foo",
+						},
+					},
+					&Sink{
+						Type:    "file",
+						WrapTTL: 5 * time.Minute,
+						DHType:  "curve25519",
+						DHPath:  "/tmp/file-foo-dhpath2",
+						AAD:     "aad",
+						Config: map[string]interface{}{
+							"path": "/tmp/file-bar",
+						},
 					},
 				},
 			},
-		},
-		PidFile: "./pidfile",
-	}
+			PidFile: "./pidfile",
+		}
 
-	if diff := deep.Equal(config, expected); diff != nil {
-		t.Fatal(diff)
-	}
+		testLoadConfig("./test-fixtures/config.hcl", expected)
+	})
 
-	config, err = LoadConfig("./test-fixtures/config-embedded-type.hcl", logger)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	t.Run("embedded-type", func(t *testing.T) {
+		expected := &Config{
+			AutoAuth: &AutoAuth{
+				Method: &Method{
+					Type:      "aws",
+					WrapTTL:   300 * time.Second,
+					MountPath: "auth/aws",
+					Config: map[string]interface{}{
+						"role": "foobar",
+					},
+				},
+				Sinks: []*Sink{
+					&Sink{
+						Type:   "file",
+						DHType: "curve25519",
+						DHPath: "/tmp/file-foo-dhpath",
+						AAD:    "foobar",
+						Config: map[string]interface{}{
+							"path": "/tmp/file-foo",
+						},
+					},
+					&Sink{
+						Type:    "file",
+						WrapTTL: 5 * time.Minute,
+						DHType:  "curve25519",
+						DHPath:  "/tmp/file-foo-dhpath2",
+						AAD:     "aad",
+						Config: map[string]interface{}{
+							"path": "/tmp/file-bar",
+						},
+					},
+				},
+			},
+			PidFile: "./pidfile",
+		}
 
-	if diff := deep.Equal(config, expected); diff != nil {
-		t.Fatal(diff)
-	}
+		testLoadConfig("./test-fixtures/config-embedded-type.hcl", expected)
+	})
+
+	t.Run("no-sinks", func(t *testing.T) {
+		expected := &Config{
+			AutoAuth: &AutoAuth{
+				Method: &Method{
+					Type:      "aws",
+					WrapTTL:   300 * time.Second,
+					MountPath: "auth/aws",
+					Config: map[string]interface{}{
+						"role": "foobar",
+					},
+				},
+			},
+			PidFile: "./pidfile",
+		}
+
+		testLoadConfig("./test-fixtures/config-no-sinks.hcl", expected)
+	})
 }

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -27,7 +27,7 @@ func TestLoadConfigFile(t *testing.T) {
 		}
 	}
 
-	t.Run("non-embedded type", func(t *testing.T) {
+	t.Run("non-embedded-type", func(t *testing.T) {
 		expected := &Config{
 			AutoAuth: &AutoAuth{
 				Method: &Method{

--- a/command/agent/config/test-fixtures/config-no-sinks.hcl
+++ b/command/agent/config/test-fixtures/config-no-sinks.hcl
@@ -1,0 +1,11 @@
+pid_file = "./pidfile"
+
+auto_auth {
+	method "aws" {
+		mount_path = "auth/aws"
+		wrap_ttl = 300
+		config = {
+			role = "foobar"
+		}
+	}
+}

--- a/command/agent/sink/sink.go
+++ b/command/agent/sink/sink.go
@@ -78,7 +78,7 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 	}()
 
 	latestToken := new(string)
-	sinkCh := make(chan func() error, len(sinks))
+	sinkCh := make(chan func() error, len(sinks) + 1)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
I noticed that the Vault Agent errors when the config file contains no [sinks](https://www.vaultproject.io/docs/agent/autoauth/index.html#configuration-sinks-). I believe it would be good to give users the option to provide no sinks at all. I am sure there will be cases when users don't want to store a token on disk, so providing that option would be helpful in such cases. This PR provides just such a solution.