### PR TITLE
Fix sink server error when multiple 'wrap_ttl' fields in Agent config file

### DIFF
--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -207,7 +207,7 @@ func parseSinks(result *Config, list *ast.ObjectList) error {
 
 		if s.WrapTTLRaw != nil {
 			if result.AutoAuth.Method.WrapTTL > 0 {
-				return multierror.Prefix(errors.New("'wrap_ttl' must be in either the 'method' or 'sink' block, but not in both"), fmt.Sprintf("sink.%s", s.Type))
+				return multierror.Prefix(errors.New("'wrap_ttl' may be in either the 'method' or 'sink' block, but not in both"), fmt.Sprintf("sink.%s", s.Type))
 			}
 
 			var err error

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -206,6 +206,10 @@ func parseSinks(result *Config, list *ast.ObjectList) error {
 		}
 
 		if s.WrapTTLRaw != nil {
+			if result.AutoAuth.Method.WrapTTL > 0 {
+				return multierror.Prefix(errors.New("'wrap_ttl' must be in either the 'method' or 'sink' block, but not in both"), fmt.Sprintf("sink.%s", s.Type))
+			}
+
 			var err error
 			if s.WrapTTL, err = parseutil.ParseDurationSecond(s.WrapTTLRaw); err != nil {
 				return multierror.Prefix(err, fmt.Sprintf("sink.%s", s.Type))

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -16,56 +17,103 @@ func TestLoadConfigFile(t *testing.T) {
 	os.Setenv("TEST_AAD_ENV", "aad")
 	defer os.Unsetenv("TEST_AAD_ENV")
 
-	config, err := LoadConfig("./test-fixtures/config.hcl", logger)
-	if err != nil {
-		t.Fatalf("err: %s", err)
+	testLoadConfig := func(file string, expectedConfig *Config, expectedError error) {
+		config, err := LoadConfig(file, logger)
+		if expectedError != nil {
+			if err == nil {
+				t.Fatal("expected a non-nil error")
+			}
+			if err.Error() != expectedError.Error() {
+				t.Fatalf("Errors differ. Got:\n\t%v\nExpected:\n\t%v", err, expectedError)
+			}
+			return
+		}
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if diff := deep.Equal(config, expectedConfig); diff != nil {
+			t.Fatal(diff)
+		}
 	}
 
-	expected := &Config{
-		AutoAuth: &AutoAuth{
-			Method: &Method{
-				Type:      "aws",
-				WrapTTL:   300 * time.Second,
-				MountPath: "auth/aws",
-				Config: map[string]interface{}{
-					"role": "foobar",
-				},
-			},
-			Sinks: []*Sink{
-				&Sink{
-					Type:   "file",
-					DHType: "curve25519",
-					DHPath: "/tmp/file-foo-dhpath",
-					AAD:    "foobar",
+	t.Run("non-embedded-type", func(t *testing.T) {
+		expected := &Config{
+			AutoAuth: &AutoAuth{
+				Method: &Method{
+					Type:      "aws",
+					WrapTTL:   300 * time.Second,
+					MountPath: "auth/aws",
 					Config: map[string]interface{}{
-						"path": "/tmp/file-foo",
+						"role": "foobar",
 					},
 				},
-				&Sink{
-					Type:    "file",
-					WrapTTL: 5 * time.Minute,
-					DHType:  "curve25519",
-					DHPath:  "/tmp/file-foo-dhpath2",
-					AAD:     "aad",
-					Config: map[string]interface{}{
-						"path": "/tmp/file-bar",
+				Sinks: []*Sink{
+					&Sink{
+						Type:   "file",
+						DHType: "curve25519",
+						DHPath: "/tmp/file-foo-dhpath",
+						AAD:    "foobar",
+						Config: map[string]interface{}{
+							"path": "/tmp/file-foo",
+						},
+					},
+					&Sink{
+						Type:    "file",
+						DHType:  "curve25519",
+						DHPath:  "/tmp/file-foo-dhpath2",
+						AAD:     "aad",
+						Config: map[string]interface{}{
+							"path": "/tmp/file-bar",
+						},
 					},
 				},
 			},
-		},
-		PidFile: "./pidfile",
-	}
+			PidFile: "./pidfile",
+		}
 
-	if diff := deep.Equal(config, expected); diff != nil {
-		t.Fatal(diff)
-	}
+		testLoadConfig("./test-fixtures/config.hcl", expected, nil)
+	})
 
-	config, err = LoadConfig("./test-fixtures/config-embedded-type.hcl", logger)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	t.Run("embedded-type", func(t *testing.T) {
+		expected := &Config{
+			AutoAuth: &AutoAuth{
+				Method: &Method{
+					Type:      "aws",
+					WrapTTL:   300 * time.Second,
+					MountPath: "auth/aws",
+					Config: map[string]interface{}{
+						"role": "foobar",
+					},
+				},
+				Sinks: []*Sink{
+					&Sink{
+						Type:   "file",
+						DHType: "curve25519",
+						DHPath: "/tmp/file-foo-dhpath",
+						AAD:    "foobar",
+						Config: map[string]interface{}{
+							"path": "/tmp/file-foo",
+						},
+					},
+					&Sink{
+						Type:    "file",
+						DHType:  "curve25519",
+						DHPath:  "/tmp/file-foo-dhpath2",
+						AAD:     "aad",
+						Config: map[string]interface{}{
+							"path": "/tmp/file-bar",
+						},
+					},
+				},
+			},
+			PidFile: "./pidfile",
+		}
 
-	if diff := deep.Equal(config, expected); diff != nil {
-		t.Fatal(diff)
-	}
+		testLoadConfig("./test-fixtures/config-embedded-type.hcl", expected, nil)
+	})
+
+	t.Run("multiple-wrap-ttls", func(t *testing.T) {
+		err := errors.New("error parsing 'auto_auth': error parsing 'sink' stanzas: sink.file 'wrap_ttl' must be in either the 'method' or 'sink' block, but not in both")
+		testLoadConfig("./test-fixtures/config-multiple-wrap-ttls.hcl", nil, err)
+	})
 }

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -113,7 +113,7 @@ func TestLoadConfigFile(t *testing.T) {
 	})
 
 	t.Run("multiple-wrap-ttls", func(t *testing.T) {
-		err := errors.New("error parsing 'auto_auth': error parsing 'sink' stanzas: sink.file 'wrap_ttl' must be in either the 'method' or 'sink' block, but not in both")
+		err := errors.New("error parsing 'auto_auth': error parsing 'sink' stanzas: sink.file 'wrap_ttl' may be in either the 'method' or 'sink' block, but not in both")
 		testLoadConfig("./test-fixtures/config-multiple-wrap-ttls.hcl", nil, err)
 	})
 }

--- a/command/agent/config/test-fixtures/config-multiple-wrap-ttls.hcl
+++ b/command/agent/config/test-fixtures/config-multiple-wrap-ttls.hcl
@@ -16,14 +16,6 @@ auto_auth {
 		aad = "foobar"
 		dh_type = "curve25519"
 		dh_path = "/tmp/file-foo-dhpath"
-	}
-
-	sink "file" {
-		aad_env_var = "TEST_AAD_ENV"
-		dh_type = "curve25519"
-		dh_path = "/tmp/file-foo-dhpath2"
-		config = {
-			path = "/tmp/file-bar"
-		}
+    wrap_ttl = 300
 	}
 }

--- a/command/agent/config/test-fixtures/config-multiple-wrap-ttls.hcl
+++ b/command/agent/config/test-fixtures/config-multiple-wrap-ttls.hcl
@@ -16,6 +16,6 @@ auto_auth {
 		aad = "foobar"
 		dh_type = "curve25519"
 		dh_path = "/tmp/file-foo-dhpath"
-    wrap_ttl = 300
+		wrap_ttl = 300
 	}
 }

--- a/command/agent/config/test-fixtures/config.hcl
+++ b/command/agent/config/test-fixtures/config.hcl
@@ -21,7 +21,6 @@ auto_auth {
 
 	sink {
 		type = "file"
-		wrap_ttl = "5m" 
 		aad_env_var = "TEST_AAD_ENV"
 		dh_type = "curve25519"
 		dh_path = "/tmp/file-foo-dhpath2"


### PR DESCRIPTION
I noticed that when I run the Vault Agent with the following configuration file:
```hcl
auto_auth {
        method "aws" {
                mount_path = "auth/aws"
                wrap_ttl = "5m"
                config = {
                        role = "dev-role-iam"
                        type = "iam"
                }
        }

        sink "file" {
                wrap_ttl = "5m"
                config = {
                        path = "/tmp/foo"
                }
        }
}

pid_file = "./pidfile"
```
the agent logs the following error:
```
==> Vault agent configuration:

                     Cgo: disabled
               Log Level: info
                 Version: Vault v1.0.1
             Version Sha: 08df121c8b9adcc2b8fd55fc8506c3f9714c7e61

==> Vault server started! Log data will stream in below:

2019-01-11T22:18:56.206-0500 [INFO]  sink.file: creating file sink
2019-01-11T22:18:56.206-0500 [INFO]  sink.file: file sink configured: path=/tmp/foo
2019-01-11T22:18:56.206-0500 [INFO]  sink.server: starting sink server
2019-01-11T22:18:56.206-0500 [INFO]  auth.handler: starting auth handler
2019-01-11T22:18:56.206-0500 [INFO]  auth.handler: authenticating
2019-01-11T22:18:56.316-0500 [INFO]  auth.handler: authentication successful, sending wrapped token to sinks and pausing
2019-01-11T22:18:56.316-0500 [ERROR] sink.server: error returned by sink function, retrying: error="error wrapping token, not writing out to sink: configured Vault token contains non-printable characters and cannot be used)" backoff=2.80807845s
```
This appears to be because there is a `wrap_ttl` field in both the `method` and `sink` blocks of the configuration file. It appears that upon successful authentication, the agent's auth handler will [receive a TTL-wrapped token, JSON-encode the `WrapInfo` field of the secret, and pass this JSON string to the sink handler](https://github.com/hashicorp/vault/blob/master/command/agent/auth/auth.go#L124-L164). If a sink also has a WrapTTL value, however, the sink handler, expecting to receive simply a token, will [attempt to wrap this JSON string](https://github.com/hashicorp/vault/blob/master/command/agent/sink/sink.go#L110-L111), resulting in the error shown above.  I think that rather than allowing a user to start the agent with such a configuration the preferable behavior would be for [`config.LoadConfig()`](https://github.com/hashicorp/vault/blob/master/command/agent/config/config.go#L57) to return an error and exit. This PR implements this behavior. I also included a unit test for it.