### PR TITLE
Expose error so warning about not decoding accessors is more useful

### DIFF
--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -688,7 +688,7 @@ func (ts *TokenStore) tokenStoreAccessorList(ctx context.Context, req *logical.R
 	for _, entry := range entries {
 		aEntry, err := ts.lookupByAccessor(ctx, entry, true, false)
 		if err != nil {
-			resp.AddWarning("Found an accessor entry that could not be successfully decoded")
+			resp.AddWarning(fmt.Sprintf("Found an accessor entry that could not be successfully decoded; associated error is %q", err.Error()))
 			continue
 		}
 


### PR DESCRIPTION
Based on https://groups.google.com/d/msgid/vault-tool/cf2d1723-69ed-49d2-9998-1b7006a1a1a1%40googlegroups.com

Another approach would be to put the error in the logs; one creates a potentially very spammy response with a couple hundred thousand entries (but those already exist, this just adds detail), the other creates a couple hundred thousand log lines. Unsure which is worse.

I don't think there's a reason not to expose the error, but all ears if someone disagrees.