### PR TITLE
Add SHA1 signing/verification support to transit engine

### DIFF
--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -36,6 +36,7 @@ derivation is enabled; currently only available with ed25519 keys.`,
 				Default: "sha2-256",
 				Description: `Hash algorithm to use (POST body parameter). Valid values are:
 
+* sha1
 * sha2-224
 * sha2-256
 * sha2-384
@@ -130,6 +131,7 @@ derivation is enabled; currently only available with ed25519 keys.`,
 				Default: "sha2-256",
 				Description: `Hash algorithm to use (POST body parameter). Valid values are:
 
+* sha1
 * sha2-224
 * sha2-256
 * sha2-384

--- a/helper/keysutil/consts.go
+++ b/helper/keysutil/consts.go
@@ -1,6 +1,7 @@
 package keysutil
 
 import (
+	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
 	"hash"
@@ -9,8 +10,9 @@ import (
 type HashType uint32
 
 const (
-	_                        = iota
-	HashTypeSHA2224 HashType = iota
+	_                     = iota
+	HashTypeSHA1 HashType = iota
+	HashTypeSHA2224
 	HashTypeSHA2256
 	HashTypeSHA2384
 	HashTypeSHA2512
@@ -26,6 +28,7 @@ const (
 
 var (
 	HashTypeMap = map[string]HashType{
+		"sha1":     HashTypeSHA1,
 		"sha2-224": HashTypeSHA2224,
 		"sha2-256": HashTypeSHA2256,
 		"sha2-384": HashTypeSHA2384,
@@ -33,6 +36,7 @@ var (
 	}
 
 	HashFuncMap = map[HashType]func() hash.Hash{
+		HashTypeSHA1:    sha1.New,
 		HashTypeSHA2224: sha256.New224,
 		HashTypeSHA2256: sha256.New,
 		HashTypeSHA2384: sha512.New384,

--- a/helper/keysutil/policy.go
+++ b/helper/keysutil/policy.go
@@ -1142,6 +1142,8 @@ func (p *Policy) Sign(ver int, context, input []byte, hashAlgorithm HashType, si
 
 		var algo crypto.Hash
 		switch hashAlgorithm {
+		case HashTypeSHA1:
+			algo = crypto.SHA1
 		case HashTypeSHA2224:
 			algo = crypto.SHA224
 		case HashTypeSHA2256:
@@ -1293,6 +1295,8 @@ func (p *Policy) VerifySignature(context, input []byte, hashAlgorithm HashType, 
 
 		var algo crypto.Hash
 		switch hashAlgorithm {
+		case HashTypeSHA1:
+			algo = crypto.SHA1
 		case HashTypeSHA2224:
 			algo = crypto.SHA224
 		case HashTypeSHA2256:

--- a/website/source/api/secret/transit/index.html.md
+++ b/website/source/api/secret/transit/index.html.md
@@ -799,6 +799,7 @@ supports signing.
   own hash algorithm). This can also be specified as part of the URL.
   Currently-supported algorithms are:
 
+    - `sha1`
     - `sha2-224`
     - `sha2-256`
     - `sha2-384`
@@ -877,6 +878,7 @@ data.
 - `hash_algorithm` `(string: "sha2-256")` – Specifies the hash algorithm to use. This
   can also be specified as part of the URL. Currently-supported algorithms are:
 
+    - `sha1`
     - `sha2-224`
     - `sha2-256`
     - `sha2-384`


### PR DESCRIPTION
This adds support for the SHA1 hash algorithm in the transit engine. While identified as a having weaknesses, this allows several legacy systems to now leverage vault as where they were previously unable to do so.