### PR TITLE
 Continuously attempt to unseal if sealed keys are supported

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -741,7 +741,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 	// Initialize the core
 	core, newCoreError := vault.NewCore(coreConfig)
 	if newCoreError != nil {
-		if !errwrap.ContainsType(newCoreError, new(vault.NonFatalError)) {
+		if vault.IsFatalError(newCoreError) {
 			c.UI.Error(fmt.Sprintf("Error initializing core: %s", newCoreError))
 			return 1
 		}
@@ -938,7 +938,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 	}
 
 	if err := core.UnsealWithStoredKeys(context.Background()); err != nil {
-		if !errwrap.ContainsType(err, new(vault.NonFatalError)) {
+		if vault.IsFatalError(err) {
 			c.UI.Error(fmt.Sprintf("Error initializing core: %s", err))
 			return 1
 		}

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/vault"
 )
 
@@ -104,7 +103,7 @@ func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 
 	result, initErr := core.Initialize(ctx, initParams)
 	if initErr != nil {
-		if !errwrap.ContainsType(initErr, new(vault.NonFatalError)) {
+		if vault.IsFatalError(initErr) {
 			respondError(w, http.StatusBadRequest, initErr)
 			return
 		} else {

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -135,7 +135,10 @@ func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	core.UnsealWithStoredKeys(ctx)
+	if err := core.UnsealWithStoredKeys(ctx); err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
 
 	respondOk(w, resp)
 }

--- a/vault/core.go
+++ b/vault/core.go
@@ -396,6 +396,10 @@ type Core struct {
 	// Stores the sealunwrapper for downgrade needs
 	sealUnwrapper physical.Backend
 
+	// unsealwithStoredKeysLock is a mutex that prevents multiple processes from
+	// unsealing with stored keys are the same time.
+	unsealWithStoredKeysLock sync.Mutex
+
 	// Stores any funcs that should be run on successful postUnseal
 	postUnsealFuncs []func()
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -107,6 +107,16 @@ func (e *NonFatalError) Error() string {
 	return e.Err.Error()
 }
 
+// NewNonFatalError returns a new non-fatal error.
+func NewNonFatalError(err error) *NonFatalError {
+	return &NonFatalError{Err: err}
+}
+
+// IsFatalError returns true if the given error is a non-fatal error.
+func IsFatalError(err error) bool {
+	return !errwrap.ContainsType(err, new(NonFatalError))
+}
+
 // ErrInvalidKey is returned if there is a user-based error with a provided
 // unseal key. This will be shown to the user, so should not contain
 // information that is sensitive.

--- a/vault/init.go
+++ b/vault/init.go
@@ -281,7 +281,7 @@ func (c *Core) UnsealWithStoredKeys(ctx context.Context) error {
 	defer c.unsealWithStoredKeysLock.Unlock()
 
 	if !c.seal.StoredKeysSupported() {
-		return errors.New("stored keys are not supported")
+		return nil
 	}
 
 	// Disallow auto-unsealing when migrating

--- a/vault/init.go
+++ b/vault/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/errwrap"
@@ -270,53 +271,62 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 	return results, nil
 }
 
-// UnsealWithStoredKeys performs auto-unseal using stored keys.
+// UnsealWithStoredKeys performs auto-unseal using stored keys. An error
+// return value of "nil" implies the Vault instance is unsealed.
+//
+// Callers should attempt to retry any NOnFatalErrors. Callers should
+// not re-attempt fatal errors.
 func (c *Core) UnsealWithStoredKeys(ctx context.Context) error {
+	c.unsealWithStoredKeysLock.Lock()
+	defer c.unsealWithStoredKeysLock.Unlock()
+
 	if !c.seal.StoredKeysSupported() {
-		return nil
+		return errors.New("stored keys are not supported")
 	}
 
 	// Disallow auto-unsealing when migrating
 	if c.IsInSealMigration() {
-		return nil
+		return NewNonFatalError(errors.New("cannot auto-unseal during seal migration"))
 	}
 
 	sealed := c.Sealed()
 	if !sealed {
+		c.Logger().Warn("attempted unseal with stored keys, but vault is already unsealed")
 		return nil
 	}
 
-	c.logger.Info("stored unseal keys supported, attempting fetch")
+	c.Logger().Info("stored unseal keys supported, attempting fetch")
 	keys, err := c.seal.GetStoredKeys(ctx)
 	if err != nil {
-		c.logger.Error("fetching stored unseal keys failed", "error", err)
-		return &NonFatalError{Err: errwrap.Wrapf("fetching stored unseal keys failed: {{err}}", err)}
+		return NewNonFatalError(errwrap.Wrapf("fetching stored unseal keys failed: {{err}}", err))
 	}
+
+	// This usually happens when auto-unseal is configured, but the servers have
+	// not been initialized yet.
 	if len(keys) == 0 {
-		c.logger.Warn("stored unseal key(s) supported but none found")
+		return NewNonFatalError(errors.New("stored unseal keys are supported, but none were found"))
+	}
+
+	unsealed := false
+	keysUsed := 0
+	for _, key := range keys {
+		unsealed, err = c.Unseal(key)
+		if err != nil {
+			return NewNonFatalError(errwrap.Wrapf("unseal with stored key failed: {{err}}", err))
+		}
+		keysUsed++
+		if unsealed {
+			break
+		}
+	}
+
+	if !unsealed {
+		// This most likely means that the user configured Vault to only store a
+		// subset of the required threshold of keys. We still consider this a
+		// "success", since trying again would yield the same result.
+		c.Logger().Warn("vault still sealed after using stored unseal keys", "stored_keys_used", keysUsed)
 	} else {
-		unsealed := false
-		keysUsed := 0
-		for _, key := range keys {
-			unsealed, err = c.Unseal(key)
-			if err != nil {
-				c.logger.Error("unseal with stored unseal key failed", "error", err)
-				return &NonFatalError{Err: errwrap.Wrapf("unseal with stored key failed: {{err}}", err)}
-			}
-			keysUsed += 1
-			if unsealed {
-				break
-			}
-		}
-		if !unsealed {
-			if c.logger.IsWarn() {
-				c.logger.Warn("stored unseal key(s) used but Vault not unsealed yet", "stored_keys_used", keysUsed)
-			}
-		} else {
-			if c.logger.IsInfo() {
-				c.logger.Info("successfully unsealed with stored key(s)", "stored_keys_used", keysUsed)
-			}
-		}
+		c.Logger().Info("unsealed with stored keys", "stored_keys_used", keysUsed)
 	}
 
 	return nil


### PR DESCRIPTION
This fixes a bug / adds a missing feature that occurs on bootstrapping an initial cluster. Given a collection of Vault nodes and an initialized storage backend, they will all go into standby waiting for initialization. After one node is initialized, the other nodes had no mechanism by which they "re-check" to see if unseal keys are present. This adds a goroutine to the server command which continually waits for unseal keys to exist. It exits in the following conditions:

- the node is unsealed
- the node does not support stored keys
- a fatal error occurs (as defined by Vault)
- the server is shutting down

In all other situations, the routine wakes up at the specified interval and attempts to unseal with the stored keys.

## Why is this important?

When running on a scheduler for the first time with auto-unseal configured, Vault will start all the pods/services, but then the vault nodes all immediately enter a "deadlock" mode in which they are waiting for unseal keys (because the config says they are supported), but no keys exist because the storage backend is uninitialized. Without this change, upon initializing the storage backend, the only way to get the pods to unseal themselves is to fully restart the pod. This isn't a great experience and is incredibly difficult to automate.

## Other things considered

#### Have a sidecar container that runs `vault init ...`
This works great in theory, but Vault's storage backends don't support CAS operations. If multiple Vault servers start at the same time (as they would when scheduled by something like Kubernetes or Nomad), the sidecar container would run `vault init...` on each of them. Depending on the storage backend, there's a race condition where one init process will overwrite another between the time of the init call and the time of the data persistence. This sounds rare, but in practice I've been able to reproduce it reliably 88% of the time. See also https://github.com/hashicorp/vault/pull/5356.


#### Add / update API
I considered adding a new API  like `sys/unseal-check` and considered updating the existing `sys/unseal` endpoint to not require a `key` parameter and instead try to unseal with stored keys. I lied, I didn't consider it, I actually wrote it first. It worked. I deployed and tested it. It just didn't "feel" correct. It's difficult to orchestrate an API call to all the Vault nodes after their deployment, and it honestly felt like an unnecessary extra step. I kept asking why Vault wouldn't just do this for me since it's already pointed at the shared storage backend. I'm not opposed to going back this route, but it felt wrong.

#### Check on HUP
This is probably the simplest option in terms of code changes. We simply update the reload handlers to attempt an auto-unseal. The drawbacks, however, are not as simple. Just like the new API endpoint, it's difficult to orchestrate sending signals across multiple pods. Additionally, it creates a weird edge case where someone manually sealed a Vault node, but another process was able to HUP it, effectively unsealing it. It felt a little priv-esc to me, and I think there's probably a security hole there if you look hard enough.

#### Do nothing
This is my least favorite option, as it pushes far too much orchestration back onto the user.