### PR TITLE
operator migrate use path as Entry key

### DIFF
--- a/command/operator_migrate.go
+++ b/command/operator_migrate.go
@@ -211,7 +211,10 @@ func (c *OperatorMigrateCommand) migrateAll(ctx context.Context, from physical.B
 			return nil
 		}
 
-		if err := to.Put(ctx, entry); err != nil {
+		if err := to.Put(ctx, &physical.Entry{
+			Key:   path,
+			Value: entry.Value,
+		}); err != nil {
 			return errwrap.Wrapf("error writing entry: {{err}}", err)
 		}
 		c.logger.Info("copied key", "path", path)


### PR DESCRIPTION
use path as Entry key to prevent a situation where migration results with the inconsistent state on dst



