### PR TITLE
Update the readme with information on how to compile the dev version of vault with UI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ $ bin/vault
 ...
 ```
 
+To compile a development version of Vault with the UI, run `make static-dist dev-ui`. This will
+put the Vault binary in the `bin` and `$GOPATH/bin` folders:
+
+```sh
+$ make static-dist dev-ui
+...
+$ bin/vault
+...
+```
+
 To run tests, type `make test`. Note: this requires Docker to be installed. If
 this exits with exit status 0, then everything is working!
 


### PR DESCRIPTION
Executing `make dev-ui` resulted in an error: `http/handler.go:125:147: undefined: assetFS`. So, `static-dist` also needs to be executed.