### PR TITLE
Fixed the broken link

### DIFF
--- a/website/source/netlify-redirects
+++ b/website/source/netlify-redirects
@@ -132,7 +132,7 @@
 /guides/identity/policy-templating.html         https://learn.hashicorp.com/vault/identity-access-management/policy-templating
 /guides/identity/authentication.html            https://learn.hashicorp.com/vault/identity-access-management/iam-authentication
 /guides/identity/approle-trusted-entities.html  https://learn.hashicorp.com/vault/identity-access-management/iam-approle-trusted-entities
-/guides/identity/lease.html                     https://learn.hashicorp.com/vault/secrets-management/sm-lease
+/guides/identity/lease.html                     https://learn.hashicorp.com/vault/secrets-management/tokens
 /guides/identity/identity.html                  https://learn.hashicorp.com/vault/identity-access-management/iam-identity
 /guides/identity/sentinel.html                  https://learn.hashicorp.com/vault/identity-access-management/iam-sentinel
 /guides/identity/control-groups.html            https://learn.hashicorp.com/vault/identity-access-management/iam-control-groups

--- a/website/source/netlify-redirects
+++ b/website/source/netlify-redirects
@@ -132,10 +132,13 @@
 /guides/identity/policy-templating.html         https://learn.hashicorp.com/vault/identity-access-management/policy-templating
 /guides/identity/authentication.html            https://learn.hashicorp.com/vault/identity-access-management/iam-authentication
 /guides/identity/approle-trusted-entities.html  https://learn.hashicorp.com/vault/identity-access-management/iam-approle-trusted-entities
-/guides/identity/lease.html                     https://learn.hashicorp.com/vault/secrets-management/tokens
+/guides/identity/lease.html                     https://learn.hashicorp.com/vault/secrets-management/sm-lease
 /guides/identity/identity.html                  https://learn.hashicorp.com/vault/identity-access-management/iam-identity
 /guides/identity/sentinel.html                  https://learn.hashicorp.com/vault/identity-access-management/iam-sentinel
 /guides/identity/control-groups.html            https://learn.hashicorp.com/vault/identity-access-management/iam-control-groups
+
+# Learn
+https://learn.hashicorp.com/vault/secrets-management/sm-lease                     https://learn.hashicorp.com/vault/secrets-management/tokens
 
 # Secret management
 /guides/secret-mgmt/index.html                  https://learn.hashicorp.com/vault/?track=secrets-management#secrets-management

--- a/website/source/netlify-redirects
+++ b/website/source/netlify-redirects
@@ -132,13 +132,10 @@
 /guides/identity/policy-templating.html         https://learn.hashicorp.com/vault/identity-access-management/policy-templating
 /guides/identity/authentication.html            https://learn.hashicorp.com/vault/identity-access-management/iam-authentication
 /guides/identity/approle-trusted-entities.html  https://learn.hashicorp.com/vault/identity-access-management/iam-approle-trusted-entities
-/guides/identity/lease.html                     https://learn.hashicorp.com/vault/secrets-management/sm-lease
+/guides/identity/lease.html                     https://learn.hashicorp.com/vault/secrets-management/tokens
 /guides/identity/identity.html                  https://learn.hashicorp.com/vault/identity-access-management/iam-identity
 /guides/identity/sentinel.html                  https://learn.hashicorp.com/vault/identity-access-management/iam-sentinel
 /guides/identity/control-groups.html            https://learn.hashicorp.com/vault/identity-access-management/iam-control-groups
-
-# Learn
-https://learn.hashicorp.com/vault/secrets-management/sm-lease                     https://learn.hashicorp.com/vault/secrets-management/tokens
 
 # Secret management
 /guides/secret-mgmt/index.html                  https://learn.hashicorp.com/vault/?track=secrets-management#secrets-management


### PR DESCRIPTION
Re-directing the `/guides/identity/lease.html` link to `https://learn.hashicorp.com/vault/secrets-management/tokens`

With the introduction of batch token in 1.0.0, this guide was re-designed and renamed.