### PR TITLE
Makefile: static-assets depends on ember-dist* target (ambiguous)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ test-ember:
 	@echo "--> Running ember tests"
 	@cd ui && yarn run test-oss
 
-ember-dist:
+ember-dist: static-assets
 	@echo "--> Installing JavaScript assets"
 	@cd ui && yarn --ignore-optional
 	@cd ui && npm rebuild node-sass
@@ -136,15 +136,15 @@ ember-dist:
 	@cd ui && yarn run build
 	@rm -rf ui/if-you-need-to-delete-this-open-an-issue-async-disk-cache
 
-ember-dist-dev:
+ember-dist-dev: static-assets
 	@echo "--> Installing JavaScript assets"
 	@cd ui && yarn --ignore-optional
 	@cd ui && npm rebuild node-sass
 	@echo "--> Building Ember application"
 	@cd ui && yarn run build-dev
 
-static-dist: ember-dist static-assets
-static-dist-dev: ember-dist-dev static-assets
+static-dist: ember-dist
+static-dist-dev: ember-dist-dev
 
 proto:
 	protoc vault/*.proto --go_out=plugins=grpc:../../..


### PR DESCRIPTION
The static-assets target has a dependency on *either* ember-dist or
ember-dist-dev, so these targets must not execute in parallel. Since
this is an either/or dependency, it cannot be expressed as a regular
dependency unless the targets are refactored somehow.

Fixes: 7a312d7c37bb ("Add Makefile/Dockerfile UI bits")

@jefferai, PTAL