### PR TITLE
Makefile: do not execute static-assets in parallel with deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,3 +193,5 @@ mongodb-database-plugin:
 	@CGO_ENABLED=0 go build -o bin/mongodb-database-plugin ./plugins/database/mongodb/mongodb-database-plugin
 
 .PHONY: bin default prep test vet bootstrap fmt fmtcheck mysql-database-plugin mysql-legacy-database-plugin cassandra-database-plugin postgresql-database-plugin mssql-database-plugin hana-database-plugin mongodb-database-plugin static-assets ember-dist ember-dist-dev static-dist static-dist-dev
+
+.NOTPARALLEL: ember-dist ember-dist-dev static-assets


### PR DESCRIPTION
The static-assets target has a dependency on *either* ember-dist or
ember-dist-dev, so these targets must not execute in parallel. Since
this is an either/or dependency, it cannot be expressed as a regular
dependency unless the targets are refactored somehow.

Fixes: 7a312d7c37bb ("Add Makefile/Dockerfile UI bits")

@jefferai, PTAL