### PR TITLE
Format array, number and boolean outputs in ui console (Fixes #6054)

### DIFF
--- a/ui/app/lib/console-helpers.js
+++ b/ui/app/lib/console-helpers.js
@@ -106,13 +106,16 @@ export function logFromResponse(response, path, method, flags) {
       if (format && format === 'json') {
         return { type: 'json', content: fieldValue };
       }
-      switch (typeof fieldValue) {
-        case 'string':
-          response = { type: 'text', content: fieldValue };
-          break;
-        default:
-          response = { type: 'object', content: fieldValue };
-          break;
+      if (typeof fieldValue == 'string') {
+        response = { type: 'text', content: fieldValue };
+      } else if (typeof fieldValue == 'number') {
+        response = { type: 'text', content: JSON.stringify(fieldValue) };
+      } else if (typeof fieldValue == 'boolean') {
+        response = { type: 'text', content: JSON.stringify(fieldValue) };
+      } else if (Array.isArray(fieldValue)) {
+        response = { type: 'text', content: JSON.stringify(fieldValue) };
+      } else {
+        response = { type: 'object', content: fieldValue };
       }
     } else {
       response = { type: 'error', content: `Field "${field}" not present in secret` };

--- a/ui/tests/acceptance/console-test.js
+++ b/ui/tests/acceptance/console-test.js
@@ -55,7 +55,7 @@ module('Acceptance | console', function(hooks) {
       let consoleOut = document.querySelector('.console-ui-output>pre').innerText;
 
       assert.notOk(consoleOut.includes('function(){'));
-      assert.equal(consoleOut, '["root"]', 'Unexpected content:' + consoleOut);
+      assert.equal(consoleOut, '["root"]');
     }, 300);
   });
 
@@ -66,7 +66,7 @@ module('Acceptance | console', function(hooks) {
     // have to wrap in a later so that we can wait for the CSS transition to finish
     await later(() => {
       let consoleOut = document.querySelector('.console-ui-output>pre').innerText;
-      assert.ok(consoleOut.match(/^\d+$/).length == 1, 'Non number content: ' + consoleOut);
+      assert.ok(consoleOut.match(/^\d+$/).length == 1);
     }, 300);
   });
 
@@ -77,7 +77,7 @@ module('Acceptance | console', function(hooks) {
     // have to wrap in a later so that we can wait for the CSS transition to finish
     await later(() => {
       let consoleOut = document.querySelector('.console-ui-output>pre').innerText;
-      assert.ok(consoleOut.match(/^(true|false)$/g).length == 1, 'Non boolean content: ' + consoleOut);
+      assert.ok(consoleOut.match(/^(true|false)$/g).length == 1);
     }, 300);
   });
 });

--- a/ui/tests/acceptance/console-test.js
+++ b/ui/tests/acceptance/console-test.js
@@ -45,4 +45,39 @@ module('Acceptance | console', function(hooks) {
       assert.equal(consoleEle.offsetTop, 0, 'fullscreen is aligned to the top of window');
     }, 300);
   });
+
+  test('array output is correctly formatted', async function(assert) {
+    await consoleComponent.toggle();
+    await consoleComponent.runCommands('read -field=policies /auth/token/lookup-self');
+
+    // have to wrap in a later so that we can wait for the CSS transition to finish
+    await later(() => {
+      let consoleOut = document.querySelector('.console-ui-output>pre').innerText;
+
+      assert.notOk(consoleOut.includes('function(){'));
+      assert.equal(consoleOut, '["root"]', 'Unexpected content:' + consoleOut);
+    }, 300);
+  });
+
+  test('number output is correctly formatted', async function(assert) {
+    await consoleComponent.toggle();
+    await consoleComponent.runCommands('read -field=creation_time /auth/token/lookup-self');
+
+    // have to wrap in a later so that we can wait for the CSS transition to finish
+    await later(() => {
+      let consoleOut = document.querySelector('.console-ui-output>pre').innerText;
+      assert.ok(consoleOut.match(/^\d+$/).length == 1, 'Non number content: ' + consoleOut);
+    }, 300);
+  });
+
+  test('boolean output is correctly formatted', async function(assert) {
+    await consoleComponent.toggle();
+    await consoleComponent.runCommands('read -field=orphan /auth/token/lookup-self');
+
+    // have to wrap in a later so that we can wait for the CSS transition to finish
+    await later(() => {
+      let consoleOut = document.querySelector('.console-ui-output>pre').innerText;
+      assert.ok(consoleOut.match(/^(true|false)$/g).length == 1, 'Non boolean content: ' + consoleOut);
+    }, 300);
+  });
 });


### PR DESCRIPTION
Add additional cases when typeof != string, as well as when the output is an array (and so appears as an object). Add basic tests to these outputs.

Ran the automated tests which all seemed to pass, the field=___ parameter now displays clean output for booleans, numbers and arrays.

Fixes #6054 