### PR TITLE
always show copy token button

### DIFF
--- a/ui/app/templates/components/auth-info.hbs
+++ b/ui/app/templates/components/auth-info.hbs
@@ -34,16 +34,6 @@
                 Revoke token
               {{/confirm-action}}
             </li>
-            <li class="action">
-              <CopyButton
-                @clipboardText={{auth.currentToken}}
-                class="link button"
-                @buttonType="button"
-                @success={{action (set-flash-message 'Token copied!')}}
-              >
-                Copy token
-              </CopyButton>
-            </li>
           {{else}}
             <li class="action text-right">
               {{#confirm-action
@@ -60,18 +50,13 @@
                 Revoke token
               {{/confirm-action}}
             </li>
-            <li class="action">
-              <CopyButton
-                @clipboardText={{auth.currentToken}}
-                class="link button"
-                @buttonType="button"
-                @success={{action (set-flash-message 'Token copied!')}}
-              >
-                Copy token
-              </CopyButton>
-            </li>
           {{/if}}
         {{/if}}
+        <li class="action">
+          <CopyButton @clipboardText={{auth.currentToken}} class="link button" @buttonType="button" @success={{action (set-flash-message 'Token copied!')}}>
+            Copy token
+          </CopyButton>
+        </li>
         <li class="action">
           <button type="button" class="button link" onclick={{action "restartGuide"}}>
             Restart guide


### PR DESCRIPTION
Quick update to https://github.com/hashicorp/vault/pull/6063

Show the copy token even when the current token has expired or when it is the `root` token!