### PR TITLE
Small fixes to docs and indexes for InfluxDB plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,9 @@ mysql-legacy-database-plugin:
 cassandra-database-plugin:
 	@CGO_ENABLED=0 go build -o bin/cassandra-database-plugin ./plugins/database/cassandra/cassandra-database-plugin
 
+influxdb-database-plugin:
+	@CGO_ENABLED=0 go build -o bin/influxdb-database-plugin ./plugins/database/influxdb/influxdb-database-plugin
+
 postgresql-database-plugin:
 	@CGO_ENABLED=0 go build -o bin/postgresql-database-plugin ./plugins/database/postgresql/postgresql-database-plugin
 
@@ -192,6 +195,6 @@ hana-database-plugin:
 mongodb-database-plugin:
 	@CGO_ENABLED=0 go build -o bin/mongodb-database-plugin ./plugins/database/mongodb/mongodb-database-plugin
 
-.PHONY: bin default prep test vet bootstrap fmt fmtcheck mysql-database-plugin mysql-legacy-database-plugin cassandra-database-plugin postgresql-database-plugin mssql-database-plugin hana-database-plugin mongodb-database-plugin static-assets ember-dist ember-dist-dev static-dist static-dist-dev
+.PHONY: bin default prep test vet bootstrap fmt fmtcheck mysql-database-plugin mysql-legacy-database-plugin cassandra-database-plugin influxdb-database-plugin postgresql-database-plugin mssql-database-plugin hana-database-plugin mongodb-database-plugin static-assets ember-dist ember-dist-dev static-dist static-dist-dev
 
 .NOTPARALLEL: ember-dist ember-dist-dev static-assets

--- a/website/source/docs/secrets/databases/influxdb.html.md
+++ b/website/source/docs/secrets/databases/influxdb.html.md
@@ -47,8 +47,8 @@ create the database credential:
     ```text
     $ vault write database/roles/my-role \
         db_name=my-influxdb-database \
-        creation_statements=CREATE USER "{{username}}" WITH PASSWORD '{{password}}'; \
-             GRANT ALL ON "vault" TO "{{username}}";" \
+        creation_statements="CREATE USER \"{{username}}\" WITH PASSWORD '{{password}}'; \
+             GRANT ALL ON \"vault\" TO \"{{username}}\";" \
         default_ttl="1h" \
         max_ttl="24h"
     Success! Data written to: database/roles/my-role

--- a/website/source/layouts/api.erb
+++ b/website/source/layouts/api.erb
@@ -25,6 +25,7 @@
                 category: 'databases',
                 content: [
                   'cassandra',
+                  'influxdb',
                   'hanadb',
                   'mongodb',
                   'mssql',

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -207,6 +207,7 @@
                 category: 'databases',
                 content: [
                   'cassandra',
+                  'influxdb',
                   'hanadb',
                   'mongodb',
                   'mssql',


### PR DESCRIPTION
I forgot to add the indexes entries for influx docs and api so the pages are there but the menu doesn't show them