### PR TITLE
Consider whole response when missing auth,data,wrap_info in UI Console

### DIFF
--- a/ui/app/lib/console-helpers.js
+++ b/ui/app/lib/console-helpers.js
@@ -91,12 +91,13 @@ export function logFromResponse(response, path, method, flags) {
   let { format, field } = flags;
   let secret = response && (response.auth || response.data || response.wrap_info);
   if (!secret) {
-    let message =
-      method === 'write'
-        ? `Success! Data written to: ${path}`
-        : `Success! Data deleted (if it existed) at: ${path}`;
-
-    return { type: 'success', content: message };
+    if (method === 'write') {
+      return { type: 'success', content: `Success! Data written to: ${path}` };
+    } else if (method === 'delete') {
+      return { type: 'success', content: `Success! Data deleted (if it existed) at: ${path}` };
+    } else {
+      secret = response;
+    }
   }
 
   if (field) {

--- a/ui/tests/unit/lib/console-helpers-test.js
+++ b/ui/tests/unit/lib/console-helpers-test.js
@@ -125,6 +125,30 @@ module('Unit | Lib | console helpers', function() {
       },
     },
     {
+      name: 'read, no data, auth, wrap_info',
+      args: [{ foo: 'bar', one: 'two' }, 'foo/bar', 'read', {}],
+      expectedData: {
+        type: 'object',
+        content: { foo: 'bar', one: 'two' },
+      },
+    },
+    {
+      name: 'read with -format=json flag, no data, auth, wrap_info',
+      args: [{ foo: 'bar', one: 'two' }, 'foo/bar', 'read', { format: 'json' }],
+      expectedData: {
+        type: 'json',
+        content: { foo: 'bar', one: 'two' },
+      },
+    },
+    {
+      name: 'read with -field flag, no data, auth, wrap_info',
+      args: [{ foo: 'bar', one: 'two' }, 'foo/bar', 'read', { field: 'one' }],
+      expectedData: {
+        type: 'text',
+        content: 'two',
+      },
+    },
+    {
       name: 'write, with content',
       args: [{ data: { one: 'two' } }, 'foo/bar', 'write', {}],
       expectedData: {


### PR DESCRIPTION
This may have some ramifications that I don't yet know, but essentially instead of assuming a response lacking one of those fields (auth, data or wrap_info) is a write or delete, this checks if it is one. If it is neither, it passes the whole response along, so fields can be extracted, it can be formatted as json, etc.

Technically this will allow fields to be displayed that couldn't before, but as far as I can tell, it wont be able to display anything curl couldn't with the same request.

This fixes #6072 