### PR TITLE
Add Sprintf capability to logical.ErrorResponse

### DIFF
--- a/logical/response.go
+++ b/logical/response.go
@@ -3,6 +3,7 @@ package logical
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/hashicorp/vault/helper/wrapping"
 )
@@ -100,7 +101,10 @@ func HelpResponse(text string, seeAlso []string, oapiDoc interface{}) *Response 
 }
 
 // ErrorResponse is used to format an error response
-func ErrorResponse(text string) *Response {
+func ErrorResponse(text string, vargs ...interface{}) *Response {
+	if len(vargs) > 0 {
+		text = fmt.Sprintf(text, vargs...)
+	}
 	return &Response{
 		Data: map[string]interface{}{
 			"error": text,


### PR DESCRIPTION
Roughly 25% of calls to logical.ErrorResponse() include an inner fmt.Sprintf() call.
This PR would simplify these cases:

`return logical.ErrorResponse(fmt.Sprintf("unable to read role '%s'", role))`

  could become

`return logical.ErrorResponse("unable to read role '%s'", role)`

With only a single parameter passed in, behavior is unchanged.

A dedicated function for this purpose (e.g. ErrorResponseFmt) is also reasonable.