### PR TITLE
UI/gate wizard

### DIFF
--- a/ui/app/components/wizard/features-selection.js
+++ b/ui/app/components/wizard/features-selection.js
@@ -26,35 +26,33 @@ export default Component.extend({
   },
 
   hasSecretsPermission: computed(function() {
-    return this.permissions.hasPermission('sys/mounts/example', 'update');
+    return this.permissions.hasPermission('sys/mounts/example', ['update']);
   }),
 
   hasAuthenticationPermission: computed(function() {
-    const canRead = this.permissions.hasPermission('sys/auth', 'read');
+    const canRead = this.permissions.hasPermission('sys/auth', ['read']);
 
     const capabilities = ['update', 'sudo'];
-    const canUpdateOrCreate = capabilities.every(capability => {
-      return this.permissions.hasPermission('sys/auth/example', capability);
-    });
+    const canUpdateOrCreate = this.permissions.hasPermission('sys/auth/example', capabilities);
 
     return canRead && canUpdateOrCreate;
   }),
 
   hasPoliciesPermission: computed(function() {
-    return this.permissions.hasPermission('sys/policies/acl', 'list');
+    return this.permissions.hasPermission('sys/policies/acl', ['list']);
   }),
 
   hasReplicationPermission: computed(function() {
     const PATHS = ['sys/replication/performance/primary/enable', 'sys/replication/dr/primary/enable'];
     return PATHS.every(path => {
-      return this.permissions.hasPermission(path, 'update');
+      return this.permissions.hasPermission(path, ['update']);
     });
   }),
 
   hasToolsPermission: computed(function() {
     const PATHS = ['sys/wrapping/wrap', 'sys/wrapping/lookup', 'sys/wrapping/unwrap', 'sys/wrapping/rewrap'];
     return PATHS.every(path => {
-      return this.permissions.hasPermission(path, 'update');
+      return this.permissions.hasPermission(path, ['update']);
     });
   }),
 

--- a/ui/app/components/wizard/features-selection.js
+++ b/ui/app/components/wizard/features-selection.js
@@ -16,7 +16,7 @@ export default Component.extend({
   maybeHideFeatures() {
     let features = this.get('allFeatures');
     features.forEach(feat => {
-      feat.disabled = !this.get(`has${feat.name}Permission`);
+      feat.disabled = this.doesNotHavePermission(feat.requiredPermissions);
     });
 
     if (this.get('showReplication') === false) {
@@ -25,36 +25,13 @@ export default Component.extend({
     }
   },
 
-  hasSecretsPermission: computed(function() {
-    return this.permissions.hasPermission('sys/mounts/example', ['update']);
-  }),
-
-  hasAuthenticationPermission: computed(function() {
-    const canRead = this.permissions.hasPermission('sys/auth', ['read']);
-
-    const capabilities = ['update', 'sudo'];
-    const canUpdateOrCreate = this.permissions.hasPermission('sys/auth/example', capabilities);
-
-    return canRead && canUpdateOrCreate;
-  }),
-
-  hasPoliciesPermission: computed(function() {
-    return this.permissions.hasPermission('sys/policies/acl', ['list']);
-  }),
-
-  hasReplicationPermission: computed(function() {
-    const PATHS = ['sys/replication/performance/primary/enable', 'sys/replication/dr/primary/enable'];
-    return PATHS.every(path => {
-      return this.permissions.hasPermission(path, ['update']);
+  doesNotHavePermission(requiredPermissions) {
+    return !Object.keys(requiredPermissions).every(path => {
+      return requiredPermissions[path].every(capability => {
+        return this.permissions.hasPermission(path, [capability]);
+      });
     });
-  }),
-
-  hasToolsPermission: computed(function() {
-    const PATHS = ['sys/wrapping/wrap', 'sys/wrapping/lookup', 'sys/wrapping/unwrap', 'sys/wrapping/rewrap'];
-    return PATHS.every(path => {
-      return this.permissions.hasPermission(path, ['update']);
-    });
-  }),
+  },
 
   estimatedTime: computed('selectedFeatures', function() {
     let time = 0;
@@ -83,6 +60,9 @@ export default Component.extend({
         selected: false,
         show: true,
         disabled: false,
+        requiredPermissions: {
+          'sys/mounts/example': ['update'],
+        },
       },
       {
         key: 'authentication',
@@ -91,6 +71,10 @@ export default Component.extend({
         selected: false,
         show: true,
         disabled: false,
+        requiredPermissions: {
+          'sys/auth': ['read'],
+          'sys/auth/foo': ['update', 'sudo'],
+        },
       },
       {
         key: 'policies',
@@ -104,6 +88,9 @@ export default Component.extend({
         selected: false,
         show: true,
         disabled: false,
+        requiredPermissions: {
+          'sys/policies/acl': ['list'],
+        },
       },
       {
         key: 'replication',
@@ -112,6 +99,10 @@ export default Component.extend({
         selected: false,
         show: true,
         disabled: false,
+        requiredPermissions: {
+          'sys/replication/performance/primary/enable': ['update'],
+          'sys/replication/dr/primary/enable': ['update'],
+        },
       },
       {
         key: 'tools',
@@ -120,6 +111,12 @@ export default Component.extend({
         selected: false,
         show: true,
         disabled: false,
+        requiredPermissions: {
+          'sys/wrapping/wrap': ['update'],
+          'sys/wrapping/lookup': ['update'],
+          'sys/wrapping/unwrap': ['update'],
+          'sys/wrapping/rewrap': ['update'],
+        },
       },
     ];
   }),

--- a/ui/app/components/wizard/features-selection.js
+++ b/ui/app/components/wizard/features-selection.js
@@ -26,10 +26,14 @@ export default Component.extend({
   },
 
   doesNotHavePermission(requiredPermissions) {
+    // requiredPermissions is an object of paths and capabilities defined within allFeatures.
+    // the expected shape is:
+    // {
+    //   'example/path': ['capability'],
+    //   'second/example/path': ['update', 'sudo'],
+    // }
     return !Object.keys(requiredPermissions).every(path => {
-      return requiredPermissions[path].every(capability => {
-        return this.permissions.hasPermission(path, [capability]);
-      });
+      return this.permissions.hasPermission(path, requiredPermissions[path]);
     });
   },
 

--- a/ui/app/helpers/has-permission.js
+++ b/ui/app/helpers/has-permission.js
@@ -3,8 +3,8 @@ import { inject as service } from '@ember/service';
 
 export default Helper.extend({
   permissions: service(),
-  compute([navItem], { routeParams }) {
+  compute([route], { routeParams, capability }) {
     let permissions = this.permissions;
-    return permissions.hasNavPermission(navItem, routeParams);
+    return permissions.hasNavPermission(route, routeParams, capability);
   },
 });

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -108,17 +108,23 @@ export default Service.extend({
     }
   },
 
-  hasPermission(pathName, capability) {
+  hasPermission(pathName, capabilities = []) {
     const path = this.pathNameWithNamespace(pathName);
 
-    if (
-      this.canViewAll ||
-      this.hasMatchingExactPath(path, capability) ||
-      this.hasMatchingGlobPath(path, capability)
-    ) {
+    if (this.canViewAll) {
       return true;
     }
-    return false;
+
+    if (capabilities.length) {
+      return capabilities.every(capability => {
+        if (this.hasMatchingExactPath(path, capability) || this.hasMatchingGlobPath(path, capability)) {
+          return true;
+        }
+        return false;
+      });
+    }
+
+    return this.hasMatchingExactPath(path) || this.hasMatchingGlobPath(path);
   },
 
   hasMatchingExactPath(pathName, capability) {

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -108,23 +108,16 @@ export default Service.extend({
     }
   },
 
-  hasPermission(pathName, capabilities = []) {
+  hasPermission(pathName, capabilities = [null]) {
     const path = this.pathNameWithNamespace(pathName);
 
     if (this.canViewAll) {
       return true;
     }
 
-    if (capabilities.length) {
-      return capabilities.every(capability => {
-        if (this.hasMatchingExactPath(path, capability) || this.hasMatchingGlobPath(path, capability)) {
-          return true;
-        }
-        return false;
-      });
-    }
-
-    return this.hasMatchingExactPath(path) || this.hasMatchingGlobPath(path);
+    return capabilities.every(
+      capability => this.hasMatchingExactPath(path, capability) || this.hasMatchingGlobPath(path, capability)
+    );
   },
 
   hasMatchingExactPath(pathName, capability) {

--- a/ui/app/styles/components/features-selection.scss
+++ b/ui/app/styles/components/features-selection.scss
@@ -19,6 +19,11 @@
   &.is-active {
     box-shadow: 0 0 0 1px $grey-light;
   }
+
+  &.is-disabled {
+    background-color: $ui-gray-010;
+    color: $ui-gray-300;
+  }
 }
 
 .feature-box label {

--- a/ui/app/templates/components/wizard/features-selection.hbs
+++ b/ui/app/templates/components/wizard/features-selection.hbs
@@ -12,8 +12,9 @@
   <h3 class="feature-header">Walk me through setting up:</h3>
   <form id="features-form" class="feature-selection" {{action "saveFeatures" on="submit"}}>
     {{#each allFeatures as |feature|}}
-    {{#if (and feature.show (has-permission feature.permission))}}
-    <div class="feature-box {{if feature.selected 'is-active'}}">
+    {{#if feature.show}}
+    <div class="feature-box {{if feature.selected 'is-active'}} {{if feature.disabled 'is-disabled'}}"
+        data-test-select-input={{true}}>
       <div class="b-checkbox">
         <input
           id="feature-{{feature.key}}"
@@ -21,6 +22,8 @@
           class="styled"
           checked={{feature.selected}}
           onchange={{action (mut feature.selected) value="target.checked"}}
+          disabled={{feature.disabled}}
+          data-test-checkbox={{feature.name}}
          />
         <label for="feature-{{feature.key}}">{{feature.name}}</label>
         <button type="button" class="button is-ghost icon is-pulled-right" onclick={{action (toggle (concat feature.key "-isOpen") this)}}>
@@ -29,6 +32,11 @@
             @class="has-text-grey auto-width is-paddingless is-flex-column"
           />
         </button>
+        {{#if feature.disabled}}
+          <Info-Tooltip data-test-tooltip>
+              You do not have permissions to tour some parts of this feature
+          </Info-Tooltip>
+        {{/if}}
       </div>
       {{#if (get this (concat feature.key "-isOpen"))}}
         <ul class="feature-steps">
@@ -41,7 +49,14 @@
     {{/if}}
     {{/each}}
     <span class="selection-summary">
-      <button type="submit" class="button is-primary">Start</button>
+      <button
+        type="submit"
+        class="button is-primary"
+        disabled={{cannotStartWizard}}
+        data-test-start-button
+        >
+        Start
+      </button>
       {{#if selectedFeatures}}
         <span class="time-estimate"><ICon @glyph="stopwatch" @class="has-text-grey auto-width is-paddingless is-flex-column"/>About {{estimatedTime}} minutes</span>
       {{/if}}

--- a/ui/tests/integration/components/features-selection-test.js
+++ b/ui/tests/integration/components/features-selection-test.js
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { create } from 'ember-cli-page-object';
+import featuresSelection from 'vault/tests/pages/components/wizard/features-selection';
+import hbs from 'htmlbars-inline-precompile';
+
+const component = create(featuresSelection);
+
+module('Integration | Component | features-selection', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    component.setContext(this);
+  });
+
+  hooks.afterEach(function() {
+    component.removeContext();
+  });
+
+  test('it disables and enables wizard items according to user permissions', async function(assert) {
+    const enabled = { Secrets: true, Authentication: false, Policies: true, Tools: false };
+    await render(
+      hbs`{{wizard/features-selection hasSecretsPermission=true hasAuthenticationPermission=false hasPoliciesPermission=true}}`
+    );
+
+    component.wizardItems.forEach(i => {
+      assert.equal(
+        i.hasDisabledTooltip,
+        !enabled[i.text],
+        'shows a tooltip only when the wizard item is not enabled'
+      );
+    });
+  });
+
+  test('it disables the start button if no wizard items are checked', async function(assert) {
+    await render(hbs`{{wizard/features-selection}}`);
+    assert.equal(component.hasDisabledStartButton, true);
+  });
+
+  test('it enables the start button when user has permission and wizard items are checked', async function(assert) {
+    await render(hbs`{{wizard/features-selection hasSecretsPermission=true}}`);
+    await component.selectSecrets();
+
+    assert.equal(component.hasDisabledStartButton, false);
+  });
+});

--- a/ui/tests/integration/components/features-selection-test.js
+++ b/ui/tests/integration/components/features-selection-test.js
@@ -20,9 +20,7 @@ module('Integration | Component | features-selection', function(hooks) {
 
   test('it disables and enables wizard items according to user permissions', async function(assert) {
     const enabled = { Secrets: true, Authentication: false, Policies: true, Tools: false };
-    await render(
-      hbs`{{wizard/features-selection hasSecretsPermission=true hasAuthenticationPermission=false hasPoliciesPermission=true}}`
-    );
+    await render(hbs`{{wizard/features-selection allFeatures=}}`);
 
     component.wizardItems.forEach(i => {
       assert.equal(

--- a/ui/tests/integration/components/features-selection-test.js
+++ b/ui/tests/integration/components/features-selection-test.js
@@ -23,12 +23,7 @@ module('Integration | Component | features-selection', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
-    component.setContext(this);
     this.owner.register('service:permissions', permissionsService);
-  });
-
-  hooks.afterEach(function() {
-    component.removeContext();
   });
 
   test('it disables and enables wizard items according to user permissions', async function(assert) {

--- a/ui/tests/pages/components/wizard/features-selection.js
+++ b/ui/tests/pages/components/wizard/features-selection.js
@@ -1,0 +1,9 @@
+import { collection, isPresent, property, clickable } from 'ember-cli-page-object';
+
+export default {
+  wizardItems: collection('[data-test-select-input]', {
+    hasDisabledTooltip: isPresent('[data-test-tooltip]'),
+  }),
+  hasDisabledStartButton: property('disabled', '[data-test-start-button]'),
+  selectSecrets: clickable('[data-test-checkbox=Secrets]'),
+};

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -93,6 +93,22 @@ module('Unit | Service | permissions', function(hooks) {
     assert.equal(service.hasPermission('hi'), true);
   });
 
+  test('it returns true if a policy has the specified capabilities on a path', function(assert) {
+    let service = this.owner.lookup('service:permissions');
+    service.set('exactPaths', PERMISSIONS_RESPONSE.data.exact_paths);
+    service.set('globPaths', PERMISSIONS_RESPONSE.data.glob_paths);
+    assert.equal(service.hasPermission('bar/bee', 'create'), true);
+    assert.equal(service.hasPermission('baz/biz', 'read'), true);
+  });
+
+  test('it returns false if a policy does not have the specified capabilities on a path', function(assert) {
+    let service = this.owner.lookup('service:permissions');
+    service.set('exactPaths', PERMISSIONS_RESPONSE.data.exact_paths);
+    service.set('globPaths', PERMISSIONS_RESPONSE.data.glob_paths);
+    assert.equal(service.hasPermission('bar/bee', 'delete'), false);
+    assert.equal(service.hasPermission('foo', 'create'), false);
+  });
+
   test('defaults to show all items when policy cannot be found', async function(assert) {
     let service = this.owner.lookup('service:permissions');
     this.server.get('/v1/sys/internal/ui/resultant-acl', () => {

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -97,16 +97,16 @@ module('Unit | Service | permissions', function(hooks) {
     let service = this.owner.lookup('service:permissions');
     service.set('exactPaths', PERMISSIONS_RESPONSE.data.exact_paths);
     service.set('globPaths', PERMISSIONS_RESPONSE.data.glob_paths);
-    assert.equal(service.hasPermission('bar/bee', 'create'), true);
-    assert.equal(service.hasPermission('baz/biz', 'read'), true);
+    assert.equal(service.hasPermission('bar/bee', ['create']), true);
+    assert.equal(service.hasPermission('baz/biz', ['read']), true);
   });
 
   test('it returns false if a policy does not have the specified capabilities on a path', function(assert) {
     let service = this.owner.lookup('service:permissions');
     service.set('exactPaths', PERMISSIONS_RESPONSE.data.exact_paths);
     service.set('globPaths', PERMISSIONS_RESPONSE.data.glob_paths);
-    assert.equal(service.hasPermission('bar/bee', 'delete'), false);
-    assert.equal(service.hasPermission('foo', 'create'), false);
+    assert.equal(service.hasPermission('bar/bee', ['delete']), false);
+    assert.equal(service.hasPermission('foo', ['create']), false);
   });
 
   test('defaults to show all items when policy cannot be found', async function(assert) {

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -10,7 +10,7 @@ const PERMISSIONS_RESPONSE = {
         capabilities: ['read'],
       },
       'bar/bee': {
-        capabilities: ['create'],
+        capabilities: ['create', 'list'],
       },
       boo: {
         capabilities: ['deny'],
@@ -97,7 +97,7 @@ module('Unit | Service | permissions', function(hooks) {
     let service = this.owner.lookup('service:permissions');
     service.set('exactPaths', PERMISSIONS_RESPONSE.data.exact_paths);
     service.set('globPaths', PERMISSIONS_RESPONSE.data.glob_paths);
-    assert.equal(service.hasPermission('bar/bee', ['create']), true);
+    assert.equal(service.hasPermission('bar/bee', ['create', 'list']), true);
     assert.equal(service.hasPermission('baz/biz', ['read']), true);
   });
 
@@ -105,7 +105,7 @@ module('Unit | Service | permissions', function(hooks) {
     let service = this.owner.lookup('service:permissions');
     service.set('exactPaths', PERMISSIONS_RESPONSE.data.exact_paths);
     service.set('globPaths', PERMISSIONS_RESPONSE.data.glob_paths);
-    assert.equal(service.hasPermission('bar/bee', ['delete']), false);
+    assert.equal(service.hasPermission('bar/bee', ['create', 'delete']), false);
     assert.equal(service.hasPermission('foo', ['create']), false);
   });
 


### PR DESCRIPTION
## Only display onboarding wizard sections that the user has access to
- Only allow users to begin the wizard when they have selected at least 1 item
- Note: a user must have ALL capabilities for a given section for it to be enabled. For instance, if a user can create, edit, but not delete a policy, then they cannot progress through the 'Policies' section of the onboarding wizard.

### Testing
If a user has full capabilities but has not selected anything, all sections should be enabled but the start button should be disabled.
<img width="1192" alt="screen shot 2019-01-23 at 4 11 02 pm" src="https://user-images.githubusercontent.com/903288/51645696-48160180-1f2a-11e9-8034-1e9e2c860b63.png">

Once they select something, the start button should be enabled.
<img width="1192" alt="screen shot 2019-01-23 at 4 11 15 pm" src="https://user-images.githubusercontent.com/903288/51645685-41878a00-1f2a-11e9-8537-50a005d0ceef.png">

If a user has no capabilities, all sections should be disabled with a tooltip on hover.
<img width="1012" alt="screen shot 2019-01-23 at 4 11 55 pm" src="https://user-images.githubusercontent.com/903288/51645680-3cc2d600-1f2a-11e9-8171-c0271fa3ae64.png">
