### PR TITLE
Add libvault to the list of elixir libraries

### DIFF
--- a/website/source/api/libraries.html.md
+++ b/website/source/api/libraries.html.md
@@ -65,6 +65,7 @@ $ Install-Package Vault
 
 ### Elixir
 
+* [libvault](https://hex.pm/packages/libvault)
 * [vaultex](https://hex.pm/packages/vaultex)
 
 ### Go


### PR DESCRIPTION
One of my users suggested that I add my elixir vault library to the official client list. https://github.com/matthewoden/libvault/issues/6#issue-406002741

If there's a review process for client libraries, I'm happy to start that process too.