### PR TITLE
Removed documentation typo

### DIFF
--- a/website/source/api/secret/nomad/index.html.md
+++ b/website/source/api/secret/nomad/index.html.md
@@ -185,7 +185,6 @@ updated attributes.
 - `policies` `(string: "")` – Comma separated list of Nomad policies the token is going to be created against. These need to be created beforehand in Nomad.
 
 - `global` `(bool: "false")` – Specifies if the token should be global, as defined in the [Nomad Documentation](https://www.nomadproject.io/guides/acl.html#acl-tokens).
-ma
 
 - `type` `(string: "client")` - Specifies the type of token to create when
   using this role. Valid values are `"client"` or `"management"`.


### PR DESCRIPTION
Found a minor typo in the documentation. 