### PR TITLE
Replace special hyphen that renders as: â

### DIFF
--- a/website/source/guides/operations/deployment-guide.html.md
+++ b/website/source/guides/operations/deployment-guide.html.md
@@ -210,7 +210,7 @@ listener "tcp" {
 
 The following parameters are set for the `tcp` listener stanza:
 
-- [`address`](/docs/configuration/listener/tcp.html#address) `(string: "127.0.0.1:8200")` – Changing from the loopback address to allow external access to the Vault UI
+- [`address`](/docs/configuration/listener/tcp.html#address) `(string: "127.0.0.1:8200")` - Changing from the loopback address to allow external access to the Vault UI
 - [`tls_cert_file`](/docs/configuration/listener/tcp.html#tls_cert_file) `(string: <required-if-enabled>, reloads-on-SIGHUP)` - Must be set when using TLS
 - [`tls_key_file`](/docs/configuration/listener/tcp.html#tls_key_file) `(string: <required-if-enabled>, reloads-on-SIGHUP)` - Must be set when using TLS
 


### PR DESCRIPTION
Fixed special hyphen in documentation that [renders as the character â](https://learn.hashicorp.com/vault/operations/ops-deployment-guide#listener-stanza) (`CTRL + F` for `Changing from the loopback` to find it).