### PR TITLE
Fix wrong file name in service definition

### DIFF
--- a/website/source/guides/operations/vault-ha-consul.html.md
+++ b/website/source/guides/operations/vault-ha-consul.html.md
@@ -230,7 +230,7 @@ PermissionsStartOnly=true
 ExecStartPre=-/bin/mkdir -p /var/run/consul
 ExecStartPre=/bin/chown -R consul:consul /var/run/consul
 ExecStart=/usr/local/bin/consul agent \
-    -config-file=/usr/local/etc/consul/server_agent.json \
+    -config-file=/usr/local/etc/consul/client_agent.json \
     -pid-file=/var/run/consul/consul.pid
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
@@ -268,7 +268,7 @@ system and verify the status:
        Memory: 13.6M
           CPU: 0m 52.784s
        CGroup: /system.slice/consul.service
-               └─2068 /usr/local/bin/consul agent -config-file=/usr/local/etc/consul/server_agent.json -pid-file=/var/run/consul/consul.pid
+               └─2068 /usr/local/bin/consul agent -config-file=/usr/local/etc/consul/client_agent.json -pid-file=/var/run/consul/consul.pid
 
 After starting all Consul server agents, let’s check the Consul cluster status:
 


### PR DESCRIPTION
Changed a file name in the "Consul Server `systemd` Unit file" to match the naming of the file earlier in the tutorial (`/usr/local/etc/consul/server_agent.json` -> `/usr/local/etc/consul/client_agent.json`). `server_agent.json` seems to be the incorrect name given that all the other Consul configuration files in the example are named `client_agent.json`.