### PR TITLE
Fixed typo (newtwork -> network)

### DIFF
--- a/website/source/docs/internals/high-availability.html.md
+++ b/website/source/docs/internals/high-availability.html.md
@@ -65,5 +65,5 @@ the request will be forwarded onto the active server. If the request is
 read-only the request will be serviced locally on the Performance Standby.
 
 Just like traditional HA standbys if the active node is sealed, fails, or loses
-newtwork connectivity then a performance standby can take over and become the
+network connectivity then a performance standby can take over and become the
 active instance.


### PR DESCRIPTION
Fixed typo in documentation.