### PR TITLE
fix nav-to-nearest mixin when there are no ancestors

### DIFF
--- a/ui/app/mixins/with-nav-to-nearest-ancestor.js
+++ b/ui/app/mixins/with-nav-to-nearest-ancestor.js
@@ -15,7 +15,7 @@ export default Mixin.create({
   navToNearestAncestor: task(function*(key) {
     let ancestors = utils.ancestorKeysForKey(key);
     let errored = false;
-    let nearest = ancestors.pop();
+    let nearest = ancestors && ancestors.pop();
     while (nearest) {
       try {
         let transition = this.transitionToRoute('vault.cluster.secrets.backend.list', nearest);

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -137,6 +137,29 @@ module('Acceptance | secrets/secret/create', function(hooks) {
       'navigates to the ancestor created earlier'
     );
   });
+  test('first level secrets redirect properly upon deletion', async function(assert) {
+    let enginePath = `kv-${new Date().getTime()}`;
+    let secretPath = 'test';
+    // mount version 1 engine
+    await mountSecrets.visit();
+    await mountSecrets.selectType('kv');
+    await withFlash(
+      mountSecrets
+        .next()
+        .path(enginePath)
+        .version(1)
+        .submit()
+    );
+
+    await listPage.create();
+    await editPage.createSecret(secretPath, 'foo', 'bar');
+    await showPage.deleteSecret();
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.list-root',
+      'redirected to the list page on delete'
+    );
+  });
 
   // https://github.com/hashicorp/vault/issues/5994
   test('version 1: key named keys', async function(assert) {

--- a/ui/tests/pages/secrets/backend/kv/show.js
+++ b/ui/tests/pages/secrets/backend/kv/show.js
@@ -4,6 +4,8 @@ import { code } from 'vault/tests/pages/helpers/codemirror';
 
 export default create({
   ...Base,
+  deleteBtn: clickable('[data-test-secret-delete] button'),
+  confirmBtn: clickable('[data-test-confirm-button]'),
   rows: collection('data-test-row-label'),
   toggleJSON: clickable('[data-test-secret-json-toggle]'),
   toggleIsPresent: isPresent('[data-test-secret-json-toggle]'),
@@ -11,5 +13,8 @@ export default create({
   editIsPresent: isPresent('[data-test-secret-edit]'),
   editor: {
     content: code('[data-test-component="json-editor"]'),
+  },
+  deleteSecret() {
+    return this.deleteBtn().confirmBtn();
   },
 });


### PR DESCRIPTION
The mixin that was added to navigate to the nearest existing secret when you deleted a secret didn't properly handle the case when a secret was at the top level. 

In practice this means that a secret at `secrets/foo`, when deleted via the UI, would be deleted, but the redirection would result in an uncaught error and it would look like nothing happened when you tried to delete the secret.

This fixes the issue with the redirect erroring.
Fixes #6197