### PR TITLE
Added socket keep alive option (SO_KEEPALIVE) to Cassandra plugin

### DIFF
--- a/plugins/database/cassandra/connection_producer.go
+++ b/plugins/database/cassandra/connection_producer.go
@@ -22,24 +22,26 @@ import (
 // cassandraConnectionProducer implements ConnectionProducer and provides an
 // interface for cassandra databases to make connections.
 type cassandraConnectionProducer struct {
-	Hosts             string      `json:"hosts" structs:"hosts" mapstructure:"hosts"`
-	Port              int         `json:"port" structs:"port" mapstructure:"port"`
-	Username          string      `json:"username" structs:"username" mapstructure:"username"`
-	Password          string      `json:"password" structs:"password" mapstructure:"password"`
-	TLS               bool        `json:"tls" structs:"tls" mapstructure:"tls"`
-	InsecureTLS       bool        `json:"insecure_tls" structs:"insecure_tls" mapstructure:"insecure_tls"`
-	ProtocolVersion   int         `json:"protocol_version" structs:"protocol_version" mapstructure:"protocol_version"`
-	ConnectTimeoutRaw interface{} `json:"connect_timeout" structs:"connect_timeout" mapstructure:"connect_timeout"`
-	TLSMinVersion     string      `json:"tls_min_version" structs:"tls_min_version" mapstructure:"tls_min_version"`
-	Consistency       string      `json:"consistency" structs:"consistency" mapstructure:"consistency"`
-	PemBundle         string      `json:"pem_bundle" structs:"pem_bundle" mapstructure:"pem_bundle"`
-	PemJSON           string      `json:"pem_json" structs:"pem_json" mapstructure:"pem_json"`
+	Hosts              string      `json:"hosts" structs:"hosts" mapstructure:"hosts"`
+	Port               int         `json:"port" structs:"port" mapstructure:"port"`
+	Username           string      `json:"username" structs:"username" mapstructure:"username"`
+	Password           string      `json:"password" structs:"password" mapstructure:"password"`
+	TLS                bool        `json:"tls" structs:"tls" mapstructure:"tls"`
+	InsecureTLS        bool        `json:"insecure_tls" structs:"insecure_tls" mapstructure:"insecure_tls"`
+	ProtocolVersion    int         `json:"protocol_version" structs:"protocol_version" mapstructure:"protocol_version"`
+	ConnectTimeoutRaw  interface{} `json:"connect_timeout" structs:"connect_timeout" mapstructure:"connect_timeout"`
+	SocketKeepAliveRaw interface{} `json:"socket_keep_alive" structs:"socket_keep_alive" mapstructure:"socket_keep_alive"`
+	TLSMinVersion      string      `json:"tls_min_version" structs:"tls_min_version" mapstructure:"tls_min_version"`
+	Consistency        string      `json:"consistency" structs:"consistency" mapstructure:"consistency"`
+	PemBundle          string      `json:"pem_bundle" structs:"pem_bundle" mapstructure:"pem_bundle"`
+	PemJSON            string      `json:"pem_json" structs:"pem_json" mapstructure:"pem_json"`
 
-	connectTimeout time.Duration
-	certificate    string
-	privateKey     string
-	issuingCA      string
-	rawConfig      map[string]interface{}
+	connectTimeout  time.Duration
+	socketKeepAlive time.Duration
+	certificate     string
+	privateKey      string
+	issuingCA       string
+	rawConfig       map[string]interface{}
 
 	Initialized bool
 	Type        string
@@ -69,6 +71,14 @@ func (c *cassandraConnectionProducer) Init(ctx context.Context, conf map[string]
 	c.connectTimeout, err = parseutil.ParseDurationSecond(c.ConnectTimeoutRaw)
 	if err != nil {
 		return nil, errwrap.Wrapf("invalid connect_timeout: {{err}}", err)
+	}
+
+	if c.SocketKeepAliveRaw == nil {
+		c.SocketKeepAliveRaw = "0s"
+	}
+	c.socketKeepAlive, err = parseutil.ParseDurationSecond(c.SocketKeepAliveRaw)
+	if err != nil {
+		return nil, errwrap.Wrapf("invalid socket_keep_alive: {{err}}", err)
 	}
 
 	switch {
@@ -178,6 +188,7 @@ func (c *cassandraConnectionProducer) createSession() (*gocql.Session, error) {
 	}
 
 	clusterConfig.Timeout = c.connectTimeout
+	clusterConfig.SocketKeepalive = c.socketKeepAlive
 	if c.TLS {
 		var tlsConfig *tls.Config
 		if len(c.certificate) > 0 || len(c.issuingCA) > 0 {

--- a/website/source/api/secret/databases/cassandra.html.md
+++ b/website/source/api/secret/databases/cassandra.html.md
@@ -56,6 +56,9 @@ has a number of parameters to further configure a connection.
 
 - `connect_timeout` `(string: "5s")` – Specifies the connection timeout to use.
 
+- `socket_keep_alive` `(string: "0s")` – the keep-alive period for an active
+	network connection. If zero, keep-alives are not enabled.
+
 TLS works as follows:
 
 - If `tls` is set to true, the connection will use TLS; this happens


### PR DESCRIPTION
 Firewalls configured with an idle connection timeout can close connections between Vault and Cassandra nodes. This results in stale connection at the Vault side, because it never receives a TCP FIN packet, and regards the connection as healthy. Such stale connections cause timeouts when a Vault client reads the role for issuing new Cassandra credentials, resulting in a broken Cassandra secret engine. The SO_KEEPALIVE socket option prevents such firewalls to close connections, because the kernel at Vault side will send duplicate ACK messages every interval.

This pull request adds the `socket_keep_alive` duration option to the Cassandra plugin and solves the above issue.