### PR TITLE
Remove panicking and added usage

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -425,6 +425,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"print": func() (cli.Command, error) {
+			return &PrintCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"print token": func() (cli.Command, error) {
 			return &PrintTokenCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/print.go
+++ b/command/print.go
@@ -1,0 +1,43 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+var _ cli.Command = (*PrintCommand)(nil)
+var _ cli.CommandAutocomplete = (*PrintCommand)(nil)
+
+type PrintCommand struct {
+	*BaseCommand
+}
+
+func (c *PrintCommand) Synopsis() string {
+	return "Prints runtime configurations"
+}
+
+func (c *PrintCommand) Help() string {
+	helpText := `
+Usage: vault print <subcommand>
+
+	This command groups subcommands for interacting with Vault's runtime values.
+
+Subcommands:
+	token    Token currently in use
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *PrintCommand) AutocompleteArgs() complete.Predictor {
+	return nil
+}
+
+func (c *PrintCommand) AutocompleteFlags() complete.Flags {
+	return nil
+}
+
+func (c *PrintCommand) Run(args []string) int {
+	return cli.RunResultHelp
+}

--- a/command/print_token.go
+++ b/command/print_token.go
@@ -15,7 +15,7 @@ type PrintTokenCommand struct {
 }
 
 func (c *PrintTokenCommand) Synopsis() string {
-	return "Prints the contents of a policy"
+	return "Prints the vault token currenty in use"
 }
 
 func (c *PrintTokenCommand) Help() string {
@@ -27,13 +27,8 @@ Usage: vault print token
 
       $ vault print token
 
-` + c.Flags().Help()
-
+`
 	return strings.TrimSpace(helpText)
-}
-
-func (c *PrintTokenCommand) Flags() *FlagSets {
-	return nil
 }
 
 func (c *PrintTokenCommand) AutocompleteArgs() complete.Predictor {


### PR DESCRIPTION
When running `vault print` or `vault print token blabla` vault would panic and there was usage guide for just the `vault print` command.

I know my text is not the best