### PR TITLE
Ensure user input with ending whitespace for kv_list is respected

### DIFF
--- a/command/kv_list.go
+++ b/command/kv_list.go
@@ -73,7 +73,7 @@ func (c *KVListCommand) Run(args []string) int {
 		return 2
 	}
 
-	path := ensureTrailingSlash(sanitizePath(args[0]))
+	path := ensureTrailingSlash(ensureNoLeadingSlash(args[0]))
 	mountPath, v2, err := isKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())


### PR DESCRIPTION
#6213

Ending whitespace was getting trimmed, causing secrets with ending whitespace to be unreachable by the CLI.