### PR TITLE
Docs EA update 1.0

### DIFF
--- a/website/source/guides/operations/deployment-guide.html.md
+++ b/website/source/guides/operations/deployment-guide.html.md
@@ -5,8 +5,8 @@ sidebar_current: "guides-operations-deployment-guide"
 description: |-
   This deployment guide covers the steps required to install and
   configure a single HashiCorp Vault cluster as defined in the
-  Vault Reference Architecture
-product_version: 1.0
+  Vault Reference Architecture.
+ea_version: 1.0
 ---
 
 # Vault Deployment Guide

--- a/website/source/guides/operations/reference-architecture.html.md
+++ b/website/source/guides/operations/reference-architecture.html.md
@@ -6,7 +6,7 @@ sidebar_current: "guides-operations-reference-architecture"
 description: |-
   This guide provides guidance in the best practices of Vault
   implementations through use of a reference architecture.
-product_version: 0.11
+ea_version: 1.0
 ---
 
 # Vault Reference Architecture


### PR DESCRIPTION
Manual testing of Vault 1.0 version using the existing Reference Architecture and Deployment Guide. This change adds frontmatter to identify the version of Vault these documents are verified against. To avoid confusion the frontmatter has been changed from `product_version` to `ea_version` as this is a verification carried out by the EA team.