### PR TITLE
Avoid panic at login when external group has a nil alias

### DIFF
--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -1868,7 +1868,7 @@ func (i *IdentityStore) refreshExternalGroupMembershipsByEntityID(entityID strin
 
 		// If the external group is from a different mount, don't remove the
 		// entity ID from it.
-		if mountAccessor != "" && group.Alias.MountAccessor != mountAccessor {
+		if mountAccessor != "" && group.Alias != nil && group.Alias.MountAccessor != mountAccessor {
 			continue
 		}
 


### PR DESCRIPTION
Fixes #6229 

Check for the presence of alias in refreshExternalGroupMembershipByEntityID

Group membership get deleted in case the group contains no alias
This will avoid panic when a user in an external group with no alias tries to login