### PR TITLE
ISSUE-4295 - make dev-ui dependencies management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ bin: prep
 # into ./bin/ as well as $GOPATH/bin
 dev: prep
 	@CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS)' VAULT_DEV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
-dev-ui: prep
+dev-ui: static-dist prep 
 	@CGO_ENABLED=$(CGO_ENABLED) BUILD_TAGS='$(BUILD_TAGS) ui' VAULT_DEV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 dev-dynamic: prep
 	@CGO_ENABLED=1 BUILD_TAGS='$(BUILD_TAGS)' VAULT_DEV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
@@ -118,6 +118,7 @@ update-plugins:
 
 static-assets:
 	@echo "--> Generating static assets"
+	@mkdir -p pkg/web_ui/
 	@go-bindata-assetfs -o bindata_assetfs.go -pkg http -prefix pkg -modtime 1480000000 -tags ui ./pkg/web_ui/...
 	@mv bindata_assetfs.go http
 	@$(MAKE) -f $(THIS_FILE) fmt

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ $ make bootstrap
 ...
 ```
 
-To compile a development version of Vault, run `make` or `make dev`. This will
-put the Vault binary in the `bin` and `$GOPATH/bin` folders:
+To compile a development version of Vault, storing the resulting Vault binary
+in the `bin` and `$GOPATH/bin` folders:
 
 ```sh
 $ make dev
@@ -82,11 +82,12 @@ $ bin/vault
 ...
 ```
 
-To compile a development version of Vault with the UI, run `make static-dist dev-ui`. This will
-put the Vault binary in the `bin` and `$GOPATH/bin` folders:
+After installing [yarn](https://yarnpkg.com/lang/en/docs/install) and npm in your system,
+in order to compile a development version of Vault with the UI, storing the
+resulting Vault binary in the `bin` and `$GOPATH/bin` folders:
 
 ```sh
-$ make static-dist dev-ui
+$ make dev-ui
 ...
 $ bin/vault
 ...


### PR DESCRIPTION
Hi!

  minor potential contribution, given I was unable to compile dev-ui just following the instructions in the README... so just trying to make the process as clean as possible for the next ones that may find themselves in the same situation. Actually there's a bug that was closed on this:
https://github.com/hashicorp/vault/issues/4295

 Suggested changes:
* Rather than requiring multiple make targets, just declaring the dependency of dev-ui in the Makefile and creating the required directory automatically. 
* Updating README:
    * with the effects of the previous Makefile change
    * declaring extra environment requirements (npm and yarn) for this specific build targe
    * and removing some duplication (easy to forget about updating make commands in the example and inline)