### PR TITLE
Receiving a SIGUSR2 makes Vault log the running goroutines' stacks.

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -971,7 +971,7 @@ func MakeSighupCh() chan struct{} {
 
 // MakeSigUSR2Ch returns a channel that can be used for SIGUSR2
 // goroutine logging. This channel will send a message for every
-// SIGHUP received.
+// SIGUSR2 received.
 func MakeSigUSR2Ch() chan struct{} {
 	resultCh := make(chan struct{})
 

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -90,6 +90,7 @@ func testServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
 		},
 		ShutdownCh: MakeShutdownCh(),
 		SighupCh:   MakeSighupCh(),
+		SigUSR2Ch:  MakeSigUSR2Ch(),
 		PhysicalBackends: map[string]physical.Factory{
 			"inmem":    physInmem.NewInmem,
 			"inmem_ha": physInmem.NewInmemHA,


### PR DESCRIPTION
Fixes #6180.