### PR TITLE
use deep.Equal instead of reflect.DeepEqual in some failing tests

### DIFF
--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -64,7 +64,7 @@ func TestCore_DefaultMountTable(t *testing.T) {
 	}
 
 	if diff := deep.Equal(c.mounts.sortEntriesByPath(), c2.mounts.sortEntriesByPath()); len(diff) > 0 {
-		t.Fatalf("mismatch: %#v %#v", c.mounts, c2.mounts)
+		t.Fatalf("mismatch: %v", diff)
 	}
 }
 
@@ -105,7 +105,7 @@ func TestCore_Mount(t *testing.T) {
 
 	// Verify matching mount tables
 	if diff := deep.Equal(c.mounts.sortEntriesByPath(), c2.mounts.sortEntriesByPath()); len(diff) > 0 {
-		t.Fatalf("mismatch: %#v %#v", c.mounts, c2.mounts)
+		t.Fatalf("mismatch: %v", diff)
 	}
 }
 

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -63,9 +63,8 @@ func TestCore_DefaultMountTable(t *testing.T) {
 		}
 	}
 
-	// Verify matching mount tables
-	if !reflect.DeepEqual(c.mounts.sortEntriesByPath(), c2.mounts.sortEntriesByPath()) {
-		t.Fatalf("mismatch: %v %v", c.mounts, c2.mounts)
+	if diff := deep.Equal(c.mounts.sortEntriesByPath(), c2.mounts.sortEntriesByPath()); len(diff) > 0 {
+		t.Fatalf("mismatch: %#v %#v", c.mounts, c2.mounts)
 	}
 }
 
@@ -105,8 +104,8 @@ func TestCore_Mount(t *testing.T) {
 	}
 
 	// Verify matching mount tables
-	if !reflect.DeepEqual(c.mounts.sortEntriesByPath(), c2.mounts.sortEntriesByPath()) {
-		t.Fatalf("mismatch: %v %v", c.mounts, c2.mounts)
+	if diff := deep.Equal(c.mounts.sortEntriesByPath(), c2.mounts.sortEntriesByPath()); len(diff) > 0 {
+		t.Fatalf("mismatch: %#v %#v", c.mounts, c2.mounts)
 	}
 }
 


### PR DESCRIPTION
Some side effects of using `deep.Equal` instead of `reflect.DeepEqual` seem to be that unexported fields aren't compared. With the proposed changes there is no equality checking for these fields of the `MountEntry` struct
- namespace *namespace.Namespace
- synthesizedConfigCache sync.Map

I _think_ this is OK for these tests.