### PR TITLE
Fix wrong link in PKI menu-list

### DIFF
--- a/ui/app/templates/partials/role-pki/popup-menu.hbs
+++ b/ui/app/templates/partials/role-pki/popup-menu.hbs
@@ -12,7 +12,7 @@
       <ul class="menu-list">
         {{#if item.canGenerate}}
           <li class="action">
-            {{#link-to "vault.cluster.secrets.backend.credentials" item.id (query-params action="sign") data-test-role-pki-link="generate-certificate"}}
+            {{#link-to "vault.cluster.secrets.backend.credentials" item.id (query-params action="issue") data-test-role-pki-link="generate-certificate"}}
               Generate Certificate
             {{/link-to}}
           </li>


### PR DESCRIPTION
"Generate Certificate" button was linking to "sign" endpoint instead of "issue"