### PR TITLE
Token identity support

### DIFF
--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -272,4 +272,5 @@ type TokenCreateRequest struct {
 	NumUses         int               `json:"num_uses"`
 	Renewable       *bool             `json:"renewable,omitempty"`
 	Type            string            `json:"type"`
+	EntityAlias     string            `json:"entity_alias"`
 }

--- a/command/token_create.go
+++ b/command/token_create.go
@@ -29,6 +29,7 @@ type TokenCreateCommand struct {
 	flagType            string
 	flagMetadata        map[string]string
 	flagPolicies        []string
+	flagEntityAlias     string
 }
 
 func (c *TokenCreateCommand) Synopsis() string {
@@ -176,6 +177,16 @@ func (c *TokenCreateCommand) Flags() *FlagSets {
 			"specified multiple times to attach multiple policies.",
 	})
 
+	f.StringVar(&StringVar{
+		Name:    "entity-alias",
+		Target:  &c.flagEntityAlias,
+		Default: "",
+		Usage: "Name of the entity alias to associate with during token creation. " +
+			"Only works in combination with -role argument and used entity alias " +
+			"must be listed in allowed entity aliases. If this has been specified, " +
+			"the entity will not be inherited from the parent.",
+	})
+
 	return set
 }
 
@@ -224,6 +235,7 @@ func (c *TokenCreateCommand) Run(args []string) int {
 		ExplicitMaxTTL:  c.flagExplicitMaxTTL.String(),
 		Period:          c.flagPeriod.String(),
 		Type:            c.flagType,
+		EntityAlias:     c.flagEntityAlias,
 	}
 
 	var secret *api.Secret

--- a/command/token_create.go
+++ b/command/token_create.go
@@ -183,7 +183,7 @@ func (c *TokenCreateCommand) Flags() *FlagSets {
 		Default: "",
 		Usage: "Name of the entity alias to associate with during token creation. " +
 			"Only works in combination with -role argument and used entity alias " +
-			"must be listed in allowed entity aliases. If this has been specified, " +
+			"must be listed in allowed_entity_aliases. If this has been specified, " +
 			"the entity will not be inherited from the parent.",
 	})
 

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3244,8 +3244,6 @@ func (ts *TokenStore) tokenStoreRoleCreateUpdate(ctx context.Context, req *logic
 	allowedEntityAliasesRaw, ok := data.GetOk("allowed_entity_aliases")
 	if ok {
 		entry.AllowedEntityAliases = strutil.RemoveDuplicates(allowedEntityAliasesRaw.([]string), true)
-	} else if req.Operation == logical.CreateOperation {
-		entry.AllowedEntityAliases = strutil.RemoveDuplicates(data.Get("allowed_entity_aliases").([]string), true)
 	}
 
 	ns, err := namespace.FromContext(ctx)

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -2233,14 +2233,27 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 				continue
 			}
 
-			// Remove asterisk
-			allowedAlias = strings.ReplaceAll(allowedAlias, "*", "")
+			// Split by asterisk to get prefix and suffix
+			split := strings.Split(allowedAlias, "*")
 
-			// Check if it matches
-			if strings.HasPrefix(strings.ToLower(data.EntityAlias), strings.ToLower(allowedAlias)) {
-				match = true
-				break
+			// Multiple asterisks are not allowed. Skip this invalid glob pattern.
+			if len(split) != 2 {
+				continue
 			}
+
+			// Check if prefix matches
+			if !strings.HasPrefix(data.EntityAlias, split[0]) {
+				continue
+			}
+
+			// Check if suffix matches
+			if !strings.HasSuffix(data.EntityAlias, split[1]) {
+				continue
+			}
+
+			// Found a match
+			match = true
+			break
 		}
 
 		// Throw an error if it does not match

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -17,10 +17,10 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-sockaddr"
+	sockaddr "github.com/hashicorp/go-sockaddr"
 
-	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-multierror"
+	metrics "github.com/armon/go-metrics"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -1827,11 +1827,11 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 			}
 
 			var countAccessorList,
-			countCubbyholeKeys,
-			deletedCountAccessorEmptyToken,
-			deletedCountAccessorInvalidToken,
-			deletedCountInvalidTokenInAccessor,
-			deletedCountInvalidCubbyholeKey int64
+				countCubbyholeKeys,
+				deletedCountAccessorEmptyToken,
+				deletedCountAccessorInvalidToken,
+				deletedCountInvalidTokenInAccessor,
+				deletedCountInvalidCubbyholeKey int64
 
 			validCubbyholeKeys := make(map[string]bool)
 
@@ -2219,6 +2219,11 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 			return logical.ErrorResponse("'entity_alias' is only allowed in combination with token role"), logical.ErrInvalidRequest
 		}
 
+		// Check if provided entity alias name is in the allowed entity aliases list
+		if !strutil.StrListContains(role.AllowedEntityAliases, data.EntityAlias) {
+			return logical.ErrorResponse("invalid 'entity_alias' value"), logical.ErrInvalidRequest
+		}
+
 		// Get mount accessor which is required to lookup entity alias
 		mountValidationResp := ts.core.router.MatchingMountByAccessor(req.MountAccessor)
 		if mountValidationResp == nil {
@@ -2252,11 +2257,6 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 			// Set new entity id
 			overwriteEntityID = newEntity.ID
 		default:
-			// Check if provided entity alias name is in the allowed entity aliases list
-			if !strutil.StrListContains(role.AllowedEntityAliases, data.EntityAlias) {
-				return logical.ErrorResponse("invalid 'entity_alias' value"), logical.ErrInvalidRequest
-			}
-
 			// Lookup entity
 			entity, err := ts.core.identityStore.CreateOrFetchEntity(ctx, alias)
 			if err != nil {

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -2220,7 +2220,7 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 		// Check if there is a concrete match
 		if !strutil.StrListContains(role.AllowedEntityAliases, data.EntityAlias) &&
 			!strutil.StrListContainsGlob(role.AllowedEntityAliases, data.EntityAlias) {
-			return logical.ErrorResponse("invalid 'entity_alias' value"), logical.ErrPermissionDenied
+			return logical.ErrorResponse("invalid 'entity_alias' value"), logical.ErrInvalidRequest
 		}
 
 		// Get mount accessor which is required to lookup entity alias

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3047,6 +3047,7 @@ func (ts *TokenStore) tokenStoreRoleRead(ctx context.Context, req *logical.Reque
 			"path_suffix":            role.PathSuffix,
 			"renewable":              role.Renewable,
 			"token_type":             role.TokenType.String(),
+			"allowed_entity_aliases": role.AllowedEntityAliases,
 		},
 	}
 

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -2614,6 +2614,249 @@ func TestTokenStore_HandleRequest_Renew(t *testing.T) {
 	}
 }
 
+func TestTokenStore_HandleRequest_CreateToken_ExistingEntityAlias(t *testing.T) {
+	core, _, root := TestCoreUnsealed(t)
+	i := core.identityStore
+	ctx := namespace.RootContext(nil)
+	testPolicyName := "testpolicy"
+	entityAliasName := "testentityalias"
+	testRoleName := "test"
+
+	// Create manually an entity
+	resp, err := i.HandleRequest(ctx, &logical.Request{
+		Path:      "entity",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name":     "testentity",
+			"policies": []string{testPolicyName},
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err: %v\nresp: %#v", err, resp)
+	}
+	entityID := resp.Data["id"].(string)
+
+	// Find mount accessor
+	resp, err = core.systemBackend.HandleRequest(namespace.RootContext(nil), &logical.Request{
+		Path:      "auth",
+		Operation: logical.ReadOperation,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
+	}
+	tokenMountAccessor := resp.Data["token/"].(map[string]interface{})["accessor"].(string)
+
+	// Create manually an entity alias
+	resp, err = i.HandleRequest(ctx, &logical.Request{
+		Path:      "entity-alias",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name":           entityAliasName,
+			"canonical_id":   entityID,
+			"mount_accessor": tokenMountAccessor,
+		},
+	})
+
+	// Create token role
+	resp, err = core.HandleRequest(ctx, &logical.Request{
+		Path:      "auth/token/roles/" + testRoleName,
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"orphan":      true,
+			"period":      "72h",
+			"path_suffix": "happenin",
+			"bound_cidrs": []string{"0.0.0.0/0"},
+			"allowed_entity_aliases": []string{"test1", "test2", entityAliasName},
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err: %v\nresp: %#v", err, resp)
+	}
+
+	resp, err = core.HandleRequest(ctx, &logical.Request{
+		Path:        "auth/token/create",
+		Operation:   logical.UpdateOperation,
+		ClientToken: root,
+		Data: map[string]interface{}{
+			"role_name":    testRoleName,
+			"entity_alias": entityAliasName,
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
+	}
+	if resp == nil {
+		t.Fatal("expected a response")
+	}
+	if resp.Auth.EntityID != entityID {
+		t.Fatalf("expected '%s' got '%s'", entityID, resp.Auth.EntityID)
+	}
+
+	policyFound := false
+	for _, policy := range resp.Auth.IdentityPolicies {
+		if policy == testPolicyName {
+			policyFound = true
+		}
+	}
+	if !policyFound {
+		t.Fatalf("Policy '%s' not derived by entity but should be. Auth %#v", testPolicyName, resp.Auth)
+	}
+}
+
+func TestTokenStore_HandleRequest_CreateToken_NonExistingEntityAlias(t *testing.T) {
+	core, _, root := TestCoreUnsealed(t)
+	i := core.identityStore
+	ctx := namespace.RootContext(nil)
+	entityAliasName := "testentityalias"
+	testRoleName := "test"
+
+	// Create token role
+	resp, err := core.HandleRequest(ctx, &logical.Request{
+		Path:      "auth/token/roles/" + testRoleName,
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"period":      "72h",
+			"path_suffix": "happenin",
+			"bound_cidrs": []string{"0.0.0.0/0"},
+			"allowed_entity_aliases": []string{"test1", "test2"},
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err: %v\nresp: %#v", err, resp)
+	}
+
+	// Create token with non existing entity alias
+	resp, err = core.HandleRequest(ctx, &logical.Request{
+		Path:        "auth/token/create",
+		Operation:   logical.UpdateOperation,
+		ClientToken: root,
+		Data: map[string]interface{}{
+			"role_name":    testRoleName,
+			"entity_alias": entityAliasName,
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
+	}
+	if resp == nil {
+		t.Fatal("expected a response")
+	}
+
+	// Read the new entity
+	resp, err = i.HandleRequest(ctx, &logical.Request{
+		Path:      "entity/id/" + resp.Auth.EntityID,
+		Operation: logical.ReadOperation,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
+	}
+
+	// Get the attached alias information
+	aliases, ok := resp.Data["aliases"].([]identity.Alias)
+	if !ok {
+		t.Fatalf("failed to parse attached aliases. Resp: %#v", resp.Data)
+	}
+	if len(aliases) != 1 {
+		t.Fatalf("expected one attached alias but got %d", len(aliases))
+	}
+	if aliases[0].Name != entityAliasName {
+		t.Fatalf("alias name should be '%s' but is '%s'", entityAliasName, aliases[0].Name)
+	}
+}
+
+func TestTokenStore_HandleRequest_CreateToken_NotAllowedEntityAlias(t *testing.T) {
+	core, _, root := TestCoreUnsealed(t)
+	i := core.identityStore
+	ctx := namespace.RootContext(nil)
+	testPolicyName := "testpolicy"
+	entityAliasName := "testentityalias"
+	testRoleName := "test"
+
+	// Create manually an entity
+	resp, err := i.HandleRequest(ctx, &logical.Request{
+		Path:      "entity",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name":     "testentity",
+			"policies": []string{testPolicyName},
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err: %v\nresp: %#v", err, resp)
+	}
+	entityID := resp.Data["id"].(string)
+
+	// Find mount accessor
+	resp, err = core.systemBackend.HandleRequest(namespace.RootContext(nil), &logical.Request{
+		Path:      "auth",
+		Operation: logical.ReadOperation,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
+	}
+	tokenMountAccessor := resp.Data["token/"].(map[string]interface{})["accessor"].(string)
+
+	// Create manually an entity alias
+	resp, err = i.HandleRequest(ctx, &logical.Request{
+		Path:      "entity-alias",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name":           entityAliasName,
+			"canonical_id":   entityID,
+			"mount_accessor": tokenMountAccessor,
+		},
+	})
+
+	// Create token role
+	resp, err = core.HandleRequest(ctx, &logical.Request{
+		Path:      "auth/token/roles/" + testRoleName,
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"period": "72h",
+			"allowed_entity_aliases": []string{"test1", "test2", "testentityaliasn"},
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err: %v\nresp: %#v", err, resp)
+	}
+
+	resp, _ = core.HandleRequest(ctx, &logical.Request{
+		Path:        "auth/token/create",
+		Operation:   logical.UpdateOperation,
+		ClientToken: root,
+		Data: map[string]interface{}{
+			"entity_alias": entityAliasName,
+		},
+	})
+	if resp == nil || resp.Data == nil {
+		t.Fatal("expected a response")
+	}
+	if resp.Data["error"] != "invalid 'entity_alias' value" {
+		t.Fatalf("wrong error returned. Err: %s", resp.Data["error"])
+	}
+}
+
+func TestTokenStore_HandleRequest_CreateToken_NoRoleEntityAlias(t *testing.T) {
+	core, _, root := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+	entityAliasName := "testentityalias"
+
+	resp, _ := core.HandleRequest(ctx, &logical.Request{
+		Path:        "auth/token/create",
+		Operation:   logical.UpdateOperation,
+		ClientToken: root,
+		Data: map[string]interface{}{
+			"entity_alias": entityAliasName,
+		},
+	})
+	if resp == nil || resp.Data == nil {
+		t.Fatal("expected a response")
+	}
+	if resp.Data["error"] != "'entity_alias' is only allowed in combination with token role" {
+		t.Fatalf("wrong error returned. Err: %s", resp.Data["error"])
+	}
+}
+
 func TestTokenStore_HandleRequest_RenewSelf(t *testing.T) {
 	exp := mockExpiration(t)
 	ts := exp.tokenStore

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -2772,7 +2772,7 @@ func TestTokenStore_HandleRequest_CreateToken_GlobPatternEntityAlias(t *testing.
 	core, _, root := TestCoreUnsealed(t)
 	i := core.identityStore
 	ctx := namespace.RootContext(nil)
-	entityAliaGlobPattern := "testentity*"
+	entityAliasGlobPattern := "testentity*"
 	entityAliasName := "testentity12345"
 	testRoleName := "test"
 
@@ -2785,7 +2785,72 @@ func TestTokenStore_HandleRequest_CreateToken_GlobPatternEntityAlias(t *testing.
 			"period":                 "72h",
 			"path_suffix":            "happening",
 			"bound_cidrs":            []string{"0.0.0.0/0"},
-			"allowed_entity_aliases": []string{"test1", "test2", entityAliaGlobPattern},
+			"allowed_entity_aliases": []string{"test1", "test2", entityAliasGlobPattern},
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err: %v\nresp: %#v", err, resp)
+	}
+
+	// Create token with non existing entity alias
+	resp, err = core.HandleRequest(ctx, &logical.Request{
+		Path:        "auth/token/create/" + testRoleName,
+		Operation:   logical.UpdateOperation,
+		ClientToken: root,
+		Data: map[string]interface{}{
+			"entity_alias": entityAliasName,
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
+	}
+	if resp == nil {
+		t.Fatal("expected a response")
+	}
+
+	// Read the new entity
+	resp, err = i.HandleRequest(ctx, &logical.Request{
+		Path:      "entity/id/" + resp.Auth.EntityID,
+		Operation: logical.ReadOperation,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: resp: %#v\nerr: %v", resp, err)
+	}
+
+	// Get the attached alias information
+	aliases := resp.Data["aliases"].([]interface{})
+	if len(aliases) != 1 {
+		t.Fatalf("expected only one alias but got %d; Aliases: %#v", len(aliases), aliases)
+	}
+	alias := &identity.Alias{}
+	if err := mapstructure.Decode(aliases[0], alias); err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate
+	if alias.Name != entityAliasName {
+		t.Fatalf("alias name should be '%s' but is '%s'", entityAliasName, alias.Name)
+	}
+}
+
+func TestTokenStore_HandleRequest_CreateToken_GlobPatternWildcardEntityAlias(t *testing.T) {
+	core, _, root := TestCoreUnsealed(t)
+	i := core.identityStore
+	ctx := namespace.RootContext(nil)
+	entityAliasGlobPattern := "*"
+	entityAliasName := "testentity12345"
+	testRoleName := "test"
+
+	// Create token role
+	resp, err := core.HandleRequest(ctx, &logical.Request{
+		Path:        "auth/token/roles/" + testRoleName,
+		ClientToken: root,
+		Operation:   logical.CreateOperation,
+		Data: map[string]interface{}{
+			"period":                 "72h",
+			"path_suffix":            "happening",
+			"bound_cidrs":            []string{"0.0.0.0/0"},
+			"allowed_entity_aliases": []string{"test1", "test2", entityAliasGlobPattern},
 		},
 	})
 	if err != nil || (resp != nil && resp.IsError()) {

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -2768,46 +2768,6 @@ func TestTokenStore_HandleRequest_CreateToken_NonExistingEntityAlias(t *testing.
 	}
 }
 
-func TestTokenStore_HandleRequest_CreateToken_GlobPattern_MultipleAsterisk_EntityAlias(t *testing.T) {
-	core, _, root := TestCoreUnsealed(t)
-	ctx := namespace.RootContext(nil)
-	entityAliasGlobPattern := "*testentity*"
-	entityAliasName := "testentity12345"
-	testRoleName := "test"
-
-	// Create token role
-	resp, err := core.HandleRequest(ctx, &logical.Request{
-		Path:        "auth/token/roles/" + testRoleName,
-		ClientToken: root,
-		Operation:   logical.CreateOperation,
-		Data: map[string]interface{}{
-			"period":                 "72h",
-			"path_suffix":            "happening",
-			"bound_cidrs":            []string{"0.0.0.0/0"},
-			"allowed_entity_aliases": []string{"test1", "test2", entityAliasGlobPattern},
-		},
-	})
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err: %v\nresp: %#v", err, resp)
-	}
-
-	// Create token with non existing entity alias
-	resp, err = core.HandleRequest(ctx, &logical.Request{
-		Path:        "auth/token/create/" + testRoleName,
-		Operation:   logical.UpdateOperation,
-		ClientToken: root,
-		Data: map[string]interface{}{
-			"entity_alias": entityAliasName,
-		},
-	})
-	if err == nil {
-		t.Fatal("err is nil but should be 'invalid request'")
-	}
-	if !strings.Contains(err.Error(), "invalid request") {
-		t.Fatalf("err should contain 'invalid request' but is '%s'", err.Error())
-	}
-}
-
 func TestTokenStore_HandleRequest_CreateToken_GlobPatternWildcardEntityAlias(t *testing.T) {
 	core, _, root := TestCoreUnsealed(t)
 	i := core.identityStore

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"path"
 	"reflect"
 	"sort"
@@ -18,13 +17,15 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/errwrap"
-	hclog "github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
 	"github.com/hashicorp/vault/sdk/helper/tokenutil"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/mitchellh/mapstructure"
 )
 
 func TestTokenStore_CreateOrphanResponse(t *testing.T) {

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -13,12 +13,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-sockaddr"
-
 	"github.com/go-test/deep"
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-uuid"
+	hclog "github.com/hashicorp/go-hclog"
+	sockaddr "github.com/hashicorp/go-sockaddr"
+	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
@@ -2721,7 +2720,7 @@ func TestTokenStore_HandleRequest_CreateToken_NonExistingEntityAlias(t *testing.
 			"period":                 "72h",
 			"path_suffix":            "happenin",
 			"bound_cidrs":            []string{"0.0.0.0/0"},
-			"allowed_entity_aliases": []string{"test1", "test2"},
+			"allowed_entity_aliases": []string{"test1", "test2", entityAliasName},
 		},
 	})
 	if err != nil || (resp != nil && resp.IsError()) {

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -3056,7 +3056,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		"renewable":              true,
 		"token_type":             "default-service",
 		"token_num_uses":         123,
-		"allowed_entity_aliases": []string{},
+		"allowed_entity_aliases": []string(nil),
 	}
 
 	if resp.Data["bound_cidrs"].([]*sockaddr.SockAddrMarshaler)[0].String() != "0.0.0.0/0" {
@@ -3116,7 +3116,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		"explicit_max_ttl":       int64(288000),
 		"renewable":              false,
 		"token_type":             "default-service",
-		"allowed_entity_aliases": []string{},
+		"allowed_entity_aliases": []string(nil),
 	}
 
 	if resp.Data["bound_cidrs"].([]*sockaddr.SockAddrMarshaler)[0].String() != "0.0.0.0/0" {
@@ -3166,7 +3166,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		"token_period":           int64(0),
 		"renewable":              false,
 		"token_type":             "default-service",
-		"allowed_entity_aliases": []string{},
+		"allowed_entity_aliases": []string(nil),
 	}
 
 	if resp.Data["bound_cidrs"].([]*sockaddr.SockAddrMarshaler)[0].String() != "0.0.0.0/0" {
@@ -3216,7 +3216,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		"token_period":           int64(0),
 		"renewable":              false,
 		"token_type":             "default-service",
-		"allowed_entity_aliases": []string{},
+		"allowed_entity_aliases": []string(nil),
 	}
 
 	if diff := deep.Equal(expected, resp.Data); diff != nil {

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -3056,6 +3056,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		"renewable":              true,
 		"token_type":             "default-service",
 		"token_num_uses":         123,
+		"allowed_entity_aliases": []string{},
 	}
 
 	if resp.Data["bound_cidrs"].([]*sockaddr.SockAddrMarshaler)[0].String() != "0.0.0.0/0" {
@@ -3115,6 +3116,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		"explicit_max_ttl":       int64(288000),
 		"renewable":              false,
 		"token_type":             "default-service",
+		"allowed_entity_aliases": []string{},
 	}
 
 	if resp.Data["bound_cidrs"].([]*sockaddr.SockAddrMarshaler)[0].String() != "0.0.0.0/0" {
@@ -3164,6 +3166,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		"token_period":           int64(0),
 		"renewable":              false,
 		"token_type":             "default-service",
+		"allowed_entity_aliases": []string{},
 	}
 
 	if resp.Data["bound_cidrs"].([]*sockaddr.SockAddrMarshaler)[0].String() != "0.0.0.0/0" {
@@ -3213,6 +3216,7 @@ func TestTokenStore_RoleCRUD(t *testing.T) {
 		"token_period":           int64(0),
 		"renewable":              false,
 		"token_type":             "default-service",
+		"allowed_entity_aliases": []string{},
 	}
 
 	if diff := deep.Equal(expected, resp.Data); diff != nil {
@@ -4022,6 +4026,7 @@ func TestTokenStore_RoleTokenFields(t *testing.T) {
 			"explicit_max_ttl":       int64(3600),
 			"renewable":              false,
 			"token_type":             "batch",
+			"allowed_entity_aliases": []string(nil),
 		}
 
 		if resp.Data["bound_cidrs"].([]*sockaddr.SockAddrMarshaler)[0].String() != "127.0.0.1" {
@@ -4074,6 +4079,7 @@ func TestTokenStore_RoleTokenFields(t *testing.T) {
 			"explicit_max_ttl":       int64(7200),
 			"renewable":              false,
 			"token_type":             "default-service",
+			"allowed_entity_aliases": []string(nil),
 		}
 
 		if resp.Data["bound_cidrs"].([]*sockaddr.SockAddrMarshaler)[0].String() != "127.0.0.1" {
@@ -4125,6 +4131,7 @@ func TestTokenStore_RoleTokenFields(t *testing.T) {
 			"explicit_max_ttl":       int64(0),
 			"renewable":              false,
 			"token_type":             "default-service",
+			"allowed_entity_aliases": []string(nil),
 		}
 
 		if resp.Data["token_bound_cidrs"].([]*sockaddr.SockAddrMarshaler)[0].String() != "127.0.0.1" {
@@ -4178,6 +4185,7 @@ func TestTokenStore_RoleTokenFields(t *testing.T) {
 			"explicit_max_ttl":       int64(0),
 			"renewable":              false,
 			"token_type":             "service",
+			"allowed_entity_aliases": []string(nil),
 		}
 
 		if resp.Data["token_bound_cidrs"].([]*sockaddr.SockAddrMarshaler)[0].String() != "127.0.0.1" {

--- a/vendor/github.com/hashicorp/vault/api/auth_token.go
+++ b/vendor/github.com/hashicorp/vault/api/auth_token.go
@@ -272,4 +272,5 @@ type TokenCreateRequest struct {
 	NumUses         int               `json:"num_uses"`
 	Renewable       *bool             `json:"renewable,omitempty"`
 	Type            string            `json:"type"`
+	EntityAlias     string            `json:"entity_alias"`
 }

--- a/vendor/github.com/hashicorp/vault/api/auth_token.go
+++ b/vendor/github.com/hashicorp/vault/api/auth_token.go
@@ -272,5 +272,4 @@ type TokenCreateRequest struct {
 	NumUses         int               `json:"num_uses"`
 	Renewable       *bool             `json:"renewable,omitempty"`
 	Type            string            `json:"type"`
-	EntityAlias     string            `json:"entity_alias"`
 }

--- a/website/source/api/auth/token/index.html.md
+++ b/website/source/api/auth/token/index.html.md
@@ -577,16 +577,20 @@ $ curl \
   "lease_duration": 0,
   "renewable": false,
   "data": {
-    "allowed_policies": [
-      "dev"
+    "allowed_entity_aliases": [
+      "my-entity-alias"
     ],
+    "allowed_policies": [],
     "disallowed_policies": [],
     "explicit_max_ttl": 0,
     "name": "nomad",
     "orphan": false,
     "path_suffix": "",
     "period": 0,
-    "renewable": true
+    "renewable": true,
+    "token_explicit_max_ttl": 0,
+    "token_period": 0,
+    "token_type": "default-service"
   },
   "warnings": null
 }
@@ -699,7 +703,8 @@ tokens created against a role to be revoked using the
   "name": "nomad",
   "orphan": false,
   "bound_cidrs": ["127.0.0.1/32", "128.252.0.0/16"],
-  "renewable": true
+  "renewable": true,
+  "allowed_entity_aliases": ["web-entity-alias", "app-entity-*"]
 ```
 
 ### Sample Request

--- a/website/source/api/auth/token/index.html.md
+++ b/website/source/api/auth/token/index.html.md
@@ -102,7 +102,7 @@ during this call.
 - `period` `(string: "")` - If specified, the token will be periodic; it will have
   no maximum TTL (unless an "explicit-max-ttl" is also set) but every renewal
   will use the given period. Requires a root/sudo token to use.
-- `entity_alias` `string: "")` - Name of the entity alias to associate with 
+- `entity_alias` `(string: "")` - Name of the entity alias to associate with 
    during token creation. Only works in combination with `role_name` argument 
    and used entity alias must be listed in `allowed_entity_aliases`. If this has 
    been specified, the entity will not be inherited from the parent.

--- a/website/source/api/auth/token/index.html.md
+++ b/website/source/api/auth/token/index.html.md
@@ -102,6 +102,10 @@ during this call.
 - `period` `(string: "")` - If specified, the token will be periodic; it will have
   no maximum TTL (unless an "explicit-max-ttl" is also set) but every renewal
   will use the given period. Requires a root/sudo token to use.
+- `entity_alias` `string: "")` - Name of the entity alias to associate with 
+   during token creation. Only works in combination with `role_name` argument 
+   and used entity alias must be listed in `allowed_entity_aliases`. If this has 
+   been specified, the entity will not be inherited from the parent.
 
 ### Sample Payload
 
@@ -682,6 +686,9 @@ tokens created against a role to be revoked using the
   be returned unless the client requests a `batch` type token at token creation
   time. If `default-batch`, `batch` tokens will be returned unless the client
   requests a `service` type token at token creation time.
+- `allowed_entity_aliases` `(string: "", or list: [])` - String or JSON list 
+  of allowed entity aliases. If set, specifies the entity aliases which are 
+  allowed to be used during token generation. This field supports globbing. 
 
 ### Sample Payload
 


### PR DESCRIPTION
With the support of ACL Templating, which allows users to dynamically build paths for the ACL system, it is requested to support the identity system for the token backend. If, for example, tokens created via a token role should have access to a dynamic path where a key/value secret is stored, the entity metadata could be used to dynamically form the related ACL policy. 

One example use-case is Nomad’s integration with Vault. Nomad can automatically create Vault tokens with predefined policies which can be a subset of the originally provided policies. However, to use the ACL templating engine to dynamically build the policies paths, it is required that the entity attached to a newly created token can be dynamically modified.

This PR allows the modification of the entity alias of a token during token creation via a token role. Additionally, the entity alias modification is scoped by a predefined list of allowed entity aliases attached to the token role. 
