### PR TITLE
fix tests for auth-jwt and related functionality

### DIFF
--- a/ui/app/adapters/cluster.js
+++ b/ui/app/adapters/cluster.js
@@ -119,7 +119,7 @@ export default ApplicationAdapter.extend({
       options.headers = {
         'X-Vault-Token': token,
       };
-    } else if (backend === 'jwt') {
+    } else if (backend === 'jwt' || backend === 'oidc') {
       options.data = { role, jwt };
     } else {
       options.data = token ? { token, password } : { password };
@@ -142,6 +142,7 @@ export default ApplicationAdapter.extend({
     const authURLs = {
       github: 'login',
       jwt: 'login',
+      oidc: 'login',
       userpass: `login/${encodeURIComponent(username)}`,
       ldap: `login/${encodeURIComponent(username)}`,
       okta: `login/${encodeURIComponent(username)}`,

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -156,7 +156,7 @@ export default Component.extend({
       let oidcWindow = win.open(
         this.role.authUrl,
         'vaultOIDCWindow',
-        `width=${POPUP_WIDTH},height=${POPUP_HEIGHT}resizable,scrollbars=yes,top=${top},left=${left}`
+        `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},resizable,scrollbars=yes,top=${top},left=${left}`
       );
 
       this.prepareForOIDC.perform(oidcWindow);

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -64,7 +64,7 @@ module('Acceptance | auth', function(hooks) {
       if (backend.type === 'github') {
         await component.token('token');
       }
-      if (backend.type === 'jwt') {
+      if (backend.type === 'jwt' || backend.type === 'oidc') {
         await jwtComponent.jwt('1');
         await jwtComponent.role('test');
       }
@@ -78,7 +78,7 @@ module('Acceptance | auth', function(hooks) {
         );
       } else if (backend.type === 'github') {
         assert.ok(Object.keys(body).includes('token'), 'GitHub includes token');
-      } else if (backend.type === 'jwt') {
+      } else if (backend.type === 'jwt' || backend.type === 'oidc') {
         assert.ok(Object.keys(body).includes('jwt'), `${backend.type} includes jwt`);
         assert.ok(Object.keys(body).includes('role'), `${backend.type} includes role`);
       } else {


### PR DESCRIPTION
Fixes ember tests in master - missed this originally because I didn't realize tests weren't being run when the branch changed from master to the 1.1 beta branch.

This also uncovered a bug where using the UI to authenticate an "oidc" type auth method, but entering a jwt would error.