### PR TITLE
Specify the userpass name creating the alias entity

### DIFF
--- a/website/source/guides/identity/identity.html.md
+++ b/website/source/guides/identity/identity.html.md
@@ -478,8 +478,8 @@ attached.
     -> Make a note of the generated entity ID (**`id`**).
 
 1. Now, add the user `bob` to the `bob-smith` entity by creating an entity alias.
-In the request body, you need to pass the userpass accessor value as
-`mount_accessor`, and the entity id as `canonical_id`.
+In the request body, you need to pass the userpass name as `name`, the userpass 
+accessor value as `mount_accessor`, and the entity id as `canonical_id`.
 
     **Example:**
 


### PR DESCRIPTION
It took me a while to understand the `mount_accessor` and the name are used together to identify the auth and link it to the entity creating the alias entity. I was expecting an ID or Path for the username and not two different parameters used together and with the EntityID in the middle which made me think they are unrelated.

It's a very minor thing but it could save time to someone. 