### PR TITLE
Improve leadership check

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-uuid"
+	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/builtin/logical/database/dbplugin"
 	"github.com/hashicorp/vault/helper/queue"
 	"github.com/hashicorp/vault/helper/strutil"
@@ -85,13 +85,11 @@ func Backend(conf *logical.BackendConfig) *databaseBackend {
 	b.logger = conf.Logger
 	b.connections = make(map[string]*dbPluginInstance)
 
-	// Always populate the queue to guard against nil pointers.
-	b.credRotationQueue = queue.NewTimeQueue()
-
-	// But only execute cred rotation if we're the leader.
-	// TODO what if leadership changes during the lifecycle of the application?
 	replicationState := conf.System.ReplicationState()
-	if replicationState.IsLeader() {
+	if b.System().LocalMount() || !replicationState.IsFollower() {
+
+		b.credRotationQueue = queue.NewTimeQueue()
+
 		b.Backend.PeriodicFunc = func(ctx context.Context, req *logical.Request) error {
 			// This will loop until either:
 			// - The queue of passwords needing rotation is completely empty.

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/builtin/logical/database/dbplugin"
+	"github.com/hashicorp/vault/helper/consts"
 	"github.com/hashicorp/vault/helper/queue"
 	"github.com/hashicorp/vault/helper/strutil"
 	"github.com/hashicorp/vault/logical"
@@ -86,7 +87,9 @@ func Backend(conf *logical.BackendConfig) *databaseBackend {
 	b.connections = make(map[string]*dbPluginInstance)
 
 	replicationState := conf.System.ReplicationState()
-	if b.System().LocalMount() || !replicationState.IsFollower() {
+	if (b.System().LocalMount() || !replicationState.HasState(consts.ReplicationPerformanceSecondary)) &&
+		!replicationState.HasState(consts.ReplicationDRSecondary) &&
+		!replicationState.HasState(consts.ReplicationPerformanceStandby) {
 
 		b.credRotationQueue = queue.NewTimeQueue()
 

--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -156,9 +156,11 @@ func (b *databaseBackend) pathRoleDelete() framework.OperationFunc {
 			}
 		}
 
-		if _, err := b.credRotationQueue.PopItemByKey(name); err != nil {
-			if _, ok := err.(*queue.ErrItemNotFound); !ok {
-				return nil, err
+		if b.credRotationQueue != nil {
+			if _, err := b.credRotationQueue.PopItemByKey(name); err != nil {
+				if _, ok := err.(*queue.ErrItemNotFound); !ok {
+					return nil, err
+				}
 			}
 		}
 
@@ -355,22 +357,24 @@ func (b *databaseBackend) pathRoleCreateUpdate() framework.OperationFunc {
 			}
 
 			// TODO need to check that we're only updating the revocation statements or rotation frequency
+			if b.credRotationQueue != nil {
 
-			// In case this is an update, remove any previous version of the item from the queue
-			if _, err := b.credRotationQueue.PopItemByKey(name); err != nil {
-				if _, ok := err.(*queue.ErrItemNotFound); !ok {
+				// In case this is an update, remove any previous version of the item from the queue
+				if _, err := b.credRotationQueue.PopItemByKey(name); err != nil {
+					if _, ok := err.(*queue.ErrItemNotFound); !ok {
+						return nil, err
+					}
+				}
+
+				// Add their rotation to the queue
+				if err := b.credRotationQueue.PushItem(&queue.Item{
+					Key:      name,
+					Value:    role, // TODO is this what needs to be here?
+					Priority: time.Now().Add(time.Second * role.StaticAccount.RotationFrequency).Unix(),
+				}); err != nil {
+					// TODO rollback?
 					return nil, err
 				}
-			}
-
-			// Add their rotation to the queue
-			if err := b.credRotationQueue.PushItem(&queue.Item{
-				Key:      name,
-				Value:    role, // TODO is this what needs to be here?
-				Priority: time.Now().Add(time.Second * role.StaticAccount.RotationFrequency).Unix(),
-			}); err != nil {
-				// TODO rollback?
-				return nil, err
 			}
 		}
 		// END create/update static account

--- a/helper/consts/replication.go
+++ b/helper/consts/replication.go
@@ -119,21 +119,12 @@ func (r *ReplicationState) AddState(flag ReplicationState)     { *r |= flag }
 func (r *ReplicationState) ClearState(flag ReplicationState)   { *r &= ^flag }
 func (r *ReplicationState) ToggleState(flag ReplicationState)  { *r ^= flag }
 
-func (r *ReplicationState) IsLeader() bool {
-	// Is Vault clustered and this instance is the leader?
-	if r.HasState(ReplicationPerformancePrimary) {
+func (r *ReplicationState) IsFollower() bool {
+	if r.HasState(ReplicationPerformanceSecondary) {
 		return true
 	}
-	if r.HasState(ReplicationDRPrimary) {
+	if r.HasState(ReplicationPerformanceStandby) {
 		return true
 	}
-	// Is replication disabled so Vault is standalone?
-	if r.HasState(ReplicationPerformanceDisabled) {
-		return true
-	}
-	if r.HasState(ReplicationDRDisabled) {
-		return true
-	}
-	// We're in a cluster and this isn't the leader.
 	return false
 }

--- a/helper/consts/replication.go
+++ b/helper/consts/replication.go
@@ -118,13 +118,3 @@ func (r ReplicationState) HasState(flag ReplicationState) bool { return r&flag !
 func (r *ReplicationState) AddState(flag ReplicationState)     { *r |= flag }
 func (r *ReplicationState) ClearState(flag ReplicationState)   { *r &= ^flag }
 func (r *ReplicationState) ToggleState(flag ReplicationState)  { *r ^= flag }
-
-func (r *ReplicationState) IsFollower() bool {
-	if r.HasState(ReplicationPerformanceSecondary) {
-		return true
-	}
-	if r.HasState(ReplicationPerformanceStandby) {
-		return true
-	}
-	return false
-}


### PR DESCRIPTION
Improves the check for leadership as driven by the fields in the example [here](https://github.com/hashicorp/vault-plugin-secrets-kv/blob/edbfe287c5d9277cecf2c91c79ffcc34f19d2049/upgrade.go#L58).

Also only populates the queue if we are the leader. Otherwise leaves it nil. Adds the necessary nil checks to guard against panics.