### PR TITLE
Allow the policies menu point to be displayed in ui

### DIFF
--- a/website/source/guides/identity/policies.html.md
+++ b/website/source/guides/identity/policies.html.md
@@ -129,6 +129,12 @@ path "sys/policies/acl/*"
   capabilities = ["create", "read", "update", "delete", "list", "sudo"]
 }
 
+# To make the Policy menu point visible for the user
+path "sys/policies/acl"
+{
+  capabilities = ["list"]
+}
+
 # To list policies - Step 3
 path "sys/policy"
 {


### PR DESCRIPTION
Allows the policies menu point to be displayed to the user when the user has access to the policies.