### PR TITLE
allow permissions service to match on glob path that may end with a slash

### DIFF
--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -138,7 +138,9 @@ export default Service.extend({
   hasMatchingGlobPath(pathName, capability) {
     const globPaths = this.get('globPaths');
     if (globPaths) {
-      const matchingPath = Object.keys(globPaths).find(k => pathName.includes(k));
+      const matchingPath = Object.keys(globPaths).find(k => {
+        return pathName.includes(k) || pathName.includes(k.replace(/\/$/, ''));
+      });
       const hasMatchingPath =
         (matchingPath && !this.isDenied(globPaths[matchingPath])) || globPaths.hasOwnProperty('');
 

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -20,6 +20,9 @@ const PERMISSIONS_RESPONSE = {
       'baz/biz': {
         capabilities: ['read'],
       },
+      'ends/in/slash/': {
+        capabilities: ['list'],
+      },
     },
   },
 };
@@ -74,6 +77,13 @@ module('Unit | Service | permissions', function(hooks) {
     let service = this.owner.lookup('service:permissions');
     service.set('globPaths', PERMISSIONS_RESPONSE.data.glob_paths);
     assert.equal(service.hasPermission('boo'), false);
+  });
+
+  test('it returns true if passed path does not end in a slash but globPath does', function(assert) {
+    let service = this.owner.lookup('service:permissions');
+    service.set('globPaths', PERMISSIONS_RESPONSE.data.glob_paths);
+    assert.equal(service.hasPermission('ends/in/slash'), true, 'matches without slash');
+    assert.equal(service.hasPermission('ends/in/slash/'), true, 'matches with slash');
   });
 
   test('it returns false if a policy does not includes access to a path', function(assert) {


### PR DESCRIPTION
We want to allow users with a policy of `sys/policies/acl/*` to also see and use the Policies tab - currently the permissions service is only looking for `sys/policies/acl`. This changes that so that any path we're checking against globbed acl paths will match with a trailing slash and without.

Fixes #6292.