### PR TITLE
Agent Caching: Remove response updates using renewal output

### DIFF
--- a/command/agent/cache/lease_cache.go
+++ b/command/agent/cache/lease_cache.go
@@ -373,6 +373,8 @@ func (c *LeaseCache) startRenewing(ctx context.Context, index *cachememdb.Index,
 			}
 			c.logger.Debug("renewal halted; evicting from cache", "path", req.Request.URL.Path)
 			return
+		case <-renewer.RenewCh():
+			c.logger.Debug("secret renewed", "path", req.Request.URL.Path)
 		case <-index.RenewCtxInfo.DoneCh:
 			// This case indicates the renewal process to shutdown and evict
 			// the cache entry. This is triggered when a specific secret


### PR DESCRIPTION
Renewal output doesn't contain the response. Agent attempting to update the response is complete unneeded. Renewer is responsible for the entire lifecycle of the secret and the secret doesn't change in the interim. Lease cache will always return the same cached response every time.