### PR TITLE
RabbitMQ 'vhost' parameter on roles endpoint should be 'vhosts'

### DIFF
--- a/website/source/api/secret/rabbitmq/index.html.md
+++ b/website/source/api/secret/rabbitmq/index.html.md
@@ -108,7 +108,7 @@ This endpoint creates or updates the role definition.
 
 - `tags` `(string: "")` – Specifies a comma-separated RabbitMQ management tags.
 
-- `vhost` `(string: "")` – Specifies a map of virtual hosts to
+- `vhosts` `(string: "")` – Specifies a map of virtual hosts to
   permissions.
 
 ### Sample Payload


### PR DESCRIPTION
In deploying this, I noted that passing `vhost` was unsuccessful, yet `vhosts` is.