### PR TITLE
Added missing check for agent config vault entry

### DIFF
--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -127,6 +127,10 @@ func parseVault(result *Config, list *ast.ObjectList) error {
 	name := "vault"
 
 	vaultList := list.Filter(name)
+	if len(vaultList.Items) == 0 {
+		return nil
+	}
+
 	if len(vaultList.Items) > 1 {
 		return fmt.Errorf("one and only one %q block is required", name)
 	}


### PR DESCRIPTION
@vishalnayak I think this has been introduced with #6306 and is the reason why the tests are failing: https://travis-ci.org/hashicorp/vault/jobs/500074773#L807
 