### PR TITLE
Fix doc to add missing permission to use gcpkms seal

### DIFF
--- a/website/source/docs/configuration/seal/gcpckms.html.md
+++ b/website/source/docs/configuration/seal/gcpckms.html.md
@@ -81,14 +81,17 @@ The service account needs the following minimum permissions on the crypto key:
 ```text
 cloudkms.cryptoKeyVersions.useToEncrypt
 cloudkms.cryptoKeyVersions.useToDecrypt
+cloudkms.cryptKeys.get
 ```
 
-these permissions are available as part of the following role:
+These permissions can be described with the following role:
 
 ```text
 roles/cloudkms.cryptoKeyEncrypterDecrypter
+cloudkms.cryptKeys.get
 ```
 
+`cloudkms.cryptKeys.get` permission is used for retrieving metadata information of keys from CloudKMS within this engine initialization process.
 
 ## `gcpckms` Environment Variables
 


### PR DESCRIPTION
`cloudkms.cryptKeys.get` permission is needed for following process.

https://github.com/hashicorp/vault/blob/39b8acb91597c7b4beede17858569a774d8ef1e3/command/server/seal/server_seal_gcpckms.go#L12-L14

Without this permission, it causes 403 error below:

```
key information: googleapi: Error 403: Permission 'cloudkms.cryptoKeys.get' denied for resource ...
```