### PR TITLE
use 'oidc' as the default when it's selected

### DIFF
--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -16,6 +16,7 @@ export { ERROR_WINDOW_CLOSED, ERROR_MISSING_PARAMS };
 export default Component.extend({
   store: service(),
   selectedAuthPath: null,
+  selectedAuthType: null,
   roleName: null,
   role: null,
   onRoleName() {},
@@ -52,7 +53,7 @@ export default Component.extend({
       // debounce
       yield timeout(WAIT_TIME);
     }
-    let path = this.selectedAuthPath || 'jwt';
+    let path = this.selectedAuthPath || this.selectedAuthType;
     let id = JSON.stringify([path, roleName]);
     let role = null;
     try {

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -65,6 +65,7 @@
       @onSubmit={{action "doSubmit"}}
       @onRoleName={{action (mut this.roleName)}}
       @roleName={{this.roleName}}
+      @selectedAuthType={{this.selectedAuthBackend.type}}
       @selectedAuthPath={{or this.customPath this.selectedAuthBackend.id}}
       @disabled={{authenticate.isRunning}}
     >


### PR DESCRIPTION
When the OIDC type is selected from the drop down on the auth form, the default path should be `auth/oidc` not `auth/jwt` - this PR makes it so ✨.