### PR TITLE
Update JWT plugin dependency and docs

### DIFF
--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/cli.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/cli.go
@@ -16,7 +16,7 @@ import (
 )
 
 const defaultMount = "oidc"
-const defaultPort = "8300"
+const defaultPort = "8250"
 
 var errorRegex = regexp.MustCompile(`(?s)Errors:.*\* *(.*)`)
 
@@ -202,7 +202,7 @@ Configuration:
       Vault role of type "OIDC" to use for authentication.
 
   port=<string>
-      Optional localhost port to use for OIDC callback (default: 8300).
+      Optional localhost port to use for OIDC callback (default: 8250).
 `
 
 	return strings.TrimSpace(help)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1409,10 +1409,10 @@
 			"revisionTime": "2019-02-01T21:54:14Z"
 		},
 		{
-			"checksumSHA1": "3kSHUWLAr+Ec+10KORcYMEDFFVs=",
+			"checksumSHA1": "ZaATL8iKTxT7saq7VSmKvTVsM4M=",
 			"path": "github.com/hashicorp/vault-plugin-auth-jwt",
-			"revision": "6f35dea7f7201bbec80fd497f02bf93e711390b3",
-			"revisionTime": "2019-03-01T00:41:26Z"
+			"revision": "b9b5cad5b9807d9733fc8cbe5f0d5cf49aa4c617",
+			"revisionTime": "2019-03-05T16:24:23Z"
 		},
 		{
 			"checksumSHA1": "NfVgV3CmKXGRsXk1sYVgMMRZ5Zc=",

--- a/website/source/docs/auth/jwt_beta.html.md
+++ b/website/source/docs/auth/jwt_beta.html.md
@@ -101,7 +101,7 @@ be set up depending on the installation.
 **CLI**
 
 If you plan to support authentication via `vault login -method=oidc`, a localhost redirect URI
-must be set. This can usually be: `http://localhost:8300/oidc/callback`. Logins via the CLI may
+must be set. This can usually be: `http://localhost:8250/oidc/callback`. Logins via the CLI may
 specify a different listening port if needed, and a URI with this port must match one of the
 configured redirected URIs. These same "localhost" URIs must be added to the provider as well.
 
@@ -126,7 +126,7 @@ they must be added as query parameters, for example:
 ### OIDC Login (CLI)
 
 The CLI login defaults to path of `/oidc`. If this auth method was enabled at a
-different path, specify `-path=/my-path` in the CLI. The default local listening port is 8300. This
+different path, specify `-path=/my-path` in the CLI. The default local listening port is 8250. This
 can be changed with the `port` option.
 
 ```text


### PR DESCRIPTION
This changes the default CLI listening port from 8300 to 8250 to avoid conflicting with Consul.