### PR TITLE
Use proper pathSeparator for the operating system

### DIFF
--- a/command/token/helper_internal.go
+++ b/command/token/helper_internal.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"path/filepath"
-	
+	"strings"
+
 	homedir "github.com/mitchellh/go-homedir"
 )
 
@@ -22,11 +22,11 @@ type InternalTokenHelper struct {
 // populateTokenPath figures out the token path using homedir to get the user's
 // home directory
 func (i *InternalTokenHelper) populateTokenPath() {
-        homePath, err := homedir.Dir()
-        if err != nil {
-                panic(fmt.Sprintf("error getting user's home directory: %v", err))
-        }
-	i.tokenPath = filepath.Join(homePath,".vault-token")
+	homePath, err := homedir.Dir()
+	if err != nil {
+		panic(fmt.Sprintf("error getting user's home directory: %v", err))
+	}
+	i.tokenPath = filepath.Join(homePath, ".vault-token")
 }
 
 func (i *InternalTokenHelper) Path() string {

--- a/command/token/helper_internal.go
+++ b/command/token/helper_internal.go
@@ -21,11 +21,16 @@ type InternalTokenHelper struct {
 // populateTokenPath figures out the token path using homedir to get the user's
 // home directory
 func (i *InternalTokenHelper) populateTokenPath() {
-	homePath, err := homedir.Dir()
-	if err != nil {
-		panic(fmt.Sprintf("error getting user's home directory: %v", err))
+        if runtime.GOOS == "windows" {
+		pathSeparator := "\\"
+	} else {
+		pathSeparator := "/"
 	}
-	i.tokenPath = homePath + "/.vault-token"
+        homePath, err := homedir.Dir()
+        if err != nil {
+                panic(fmt.Sprintf("error getting user's home directory: %v", err))
+        }
+        i.tokenPath = homePath + pathSeparator + ".vault-token"
 }
 
 func (i *InternalTokenHelper) Path() string {

--- a/command/token/helper_internal.go
+++ b/command/token/helper_internal.go
@@ -6,7 +6,8 @@ import (
 	"io"
 	"os"
 	"strings"
-
+	"path/filepath"
+	
 	homedir "github.com/mitchellh/go-homedir"
 )
 
@@ -21,16 +22,11 @@ type InternalTokenHelper struct {
 // populateTokenPath figures out the token path using homedir to get the user's
 // home directory
 func (i *InternalTokenHelper) populateTokenPath() {
-        if runtime.GOOS == "windows" {
-		pathSeparator := "\\"
-	} else {
-		pathSeparator := "/"
-	}
         homePath, err := homedir.Dir()
         if err != nil {
                 panic(fmt.Sprintf("error getting user's home directory: %v", err))
         }
-        i.tokenPath = homePath + pathSeparator + ".vault-token"
+	i.tokenPath = filepath.Join(homePath,".vault-token")
 }
 
 func (i *InternalTokenHelper) Path() string {


### PR DESCRIPTION
When running on Windows use the backslash as the path separator, other wise use the forward slash