### PR TITLE
Update mssql.go

### DIFF
--- a/physical/mssql/mssql.go
+++ b/physical/mssql/mssql.go
@@ -128,7 +128,7 @@ func NewMSSQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		}
 
 		var num int
-		err = db.QueryRow("SELECT 1 FROM sys.schemas WHERE name = '" + schema + "'").Scan(&num)
+		err = db.QueryRow("SELECT 1 FROM database.sys.schemas WHERE name = '" + schema + "'").Scan(&num)
 
 		switch {
 		case err == sql.ErrNoRows:

--- a/physical/mssql/mssql.go
+++ b/physical/mssql/mssql.go
@@ -123,16 +123,13 @@ func NewMSSQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		"') CREATE TABLE " + dbTable + " (Path VARCHAR(512) PRIMARY KEY, Value VARBINARY(MAX))"
 
 	if schema != "dbo" {
-		if _, err := db.Exec("USE " + database); err != nil {
-			return nil, errwrap.Wrapf("failed to switch mssql database: {{err}}", err)
-		}
 
 		var num int
 		err = db.QueryRow("SELECT 1 FROM database.sys.schemas WHERE name = '" + schema + "'").Scan(&num)
 
 		switch {
 		case err == sql.ErrNoRows:
-			if _, err := db.Exec("CREATE SCHEMA " + schema); err != nil {
+			if _, err := db.Exec("CREATE SCHEMA " + database.schema); err != nil {
 				return nil, errwrap.Wrapf("failed to create mssql schema: {{err}}", err)
 			}
 


### PR DESCRIPTION
Added database name to the select statement so that the select statement runs on the relevant database to return the pre-defined schemas.
This select query by default always runs on the master database, even if we "use the pre created database"