### PR TITLE
all: fix no-op append calls

### DIFF
--- a/builtin/credential/cert/backend.go
+++ b/builtin/credential/cert/backend.go
@@ -26,13 +26,13 @@ func Backend() *backend {
 				"login",
 			},
 		},
-		Paths: append([]*framework.Path{
+		Paths: []*framework.Path{
 			pathConfig(&b),
 			pathLogin(&b),
 			pathListCerts(&b),
 			pathCerts(&b),
 			pathCRLs(&b),
-		}),
+		},
 		AuthRenew:   b.pathLoginRenew,
 		Invalidate:  b.invalidate,
 		BackendType: logical.TypeCredential,

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -467,11 +467,11 @@ func (c *SSHCommand) handleTypeCA(username, ip, port string, sshArgs []string) i
 		return 2
 	}
 
-	args := append([]string{
+	args := []string{
 		"-i", c.flagPrivateKeyPath,
 		"-i", signedPublicKeyPath,
 		"-o StrictHostKeyChecking=" + strictHostKeyChecking,
-	})
+	}
 
 	if userKnownHostsFile != "" {
 		args = append(args,


### PR DESCRIPTION
Append call in form of `append(s)` has no effect,
it just returns `s`. Sometimes such invocation is a sign
of a programming error, so it's better to remove these.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>