### PR TITLE
Website: correct quotes in docs layout

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -49,7 +49,7 @@
                   'azurekeyvault',
                   'gcpckms',
                   'pkcs11',
-                  `transit`
+                  'transit'
                 ]
               }, {
                 category: 'storage',
@@ -324,7 +324,7 @@
               'upgrade-to-0.11.2',
               'upgrade-to-0.11.6',
               'upgrade-to-1.0.0',
-              `upgrade-to-1.1.0`
+              'upgrade-to-1.1.0'
             ]
           },
           '----------------',


### PR DESCRIPTION
It looks like some of the quotes were reformatted as backticks which broke the build process, this should fix it!