### PR TITLE
Fix SSH zero address OTP delete

### DIFF
--- a/builtin/logical/ssh/path_config_zeroaddress.go
+++ b/builtin/logical/ssh/path_config_zeroaddress.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/vault/helper/strutil"
+
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 )
@@ -125,48 +127,9 @@ func (b *backend) removeZeroAddressRole(ctx context.Context, s logical.Storage, 
 		return nil
 	}
 
-	err = zeroAddressEntry.remove(roleName)
-	if err != nil {
-		return err
-	}
-
-	// Empty out the zeroAddressEntry if we just cleared the last role
-	if len(zeroAddressEntry.Roles) == 0 {
-		zeroAddressEntry = nil
-		return nil
-	}
+	zeroAddressEntry.Roles = strutil.StrListDelete(zeroAddressEntry.Roles, roleName)
 
 	return b.putZeroAddressRoles(ctx, s, zeroAddressEntry.Roles)
-}
-
-// Removes a given role from the comma separated string
-func (r *zeroAddressRoles) remove(roleName string) error {
-	var index int
-	for i, role := range r.Roles {
-		if role == roleName {
-			index = i
-			break
-		}
-	}
-	length := len(r.Roles)
-	if index >= length || index < 0 {
-		return fmt.Errorf("invalid index %d", index)
-	}
-	// If slice has zero or one item, remove the item by setting slice to nil.
-	if length < 2 {
-		r.Roles = nil
-		return nil
-	}
-
-	// Last item to be deleted
-	if length-1 == index {
-		r.Roles = r.Roles[:length-1]
-		return nil
-	}
-
-	// Delete the item by appending all items except the one at index
-	r.Roles = append(r.Roles[:index], r.Roles[index+1:]...)
-	return nil
 }
 
 const pathConfigZeroAddressSyn = `

--- a/builtin/logical/ssh/path_config_zeroaddress.go
+++ b/builtin/logical/ssh/path_config_zeroaddress.go
@@ -130,6 +130,12 @@ func (b *backend) removeZeroAddressRole(ctx context.Context, s logical.Storage, 
 		return err
 	}
 
+	// Empty out the zeroAddressEntry if we just cleared the last role
+	if len(zeroAddressEntry.Roles) == 0 {
+		zeroAddressEntry = nil
+		return nil
+	}
+
 	return b.putZeroAddressRoles(ctx, s, zeroAddressEntry.Roles)
 }
 


### PR DESCRIPTION
Fixed bug where SSH OTP roles could not be deleted if a zero-address role
previously existed, and there currently exist no zero-address roles.

Fixes #6382

The bug states the bug can be reproduced using the following sequence of commands:
```bash
vault secrets enable ssh
vault write ssh/roles/everyone default_user=ubuntu key_type=otp
vault write ssh/config/zeroaddress roles=everyone
vault delete ssh/roles/everyone
vault write ssh/roles/everyone default_user=ubuntu key_type=otp
vault delete ssh/roles/everyone
```

The result of running these with this change is below:
```bash
Success! Enabled the ssh secrets engine at: ssh/
Success! Data written to: ssh/roles/everyone
Success! Data written to: ssh/config/zeroaddress
Success! Data deleted (if it existed) at: ssh/roles/everyone
Success! Data written to: ssh/roles/everyone
Success! Data deleted (if it existed) at: ssh/roles/everyone
```