### PR TITLE
agent/caching: add X-Cache and Age headers

### DIFF
--- a/command/agent/cache/api_proxy.go
+++ b/command/agent/cache/api_proxy.go
@@ -1,10 +1,8 @@
 package cache
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
@@ -46,32 +44,15 @@ func (ap *APIProxy) Send(ctx context.Context, req *SendRequest) (*SendResponse, 
 	// Make the request to Vault and get the response
 	ap.logger.Info("forwarding request", "path", req.Request.URL.Path, "method", req.Request.Method)
 
-	var sendResponse *SendResponse
 	resp, err := client.RawRequestWithContext(ctx, fwReq)
-	if resp != nil {
-		sendResponse = &SendResponse{Response: resp}
-	}
-	if err != nil {
-		// Bubble back the api.Response as well for error checking/handling at the handler layer.
-		return sendResponse, err
-	}
 
-	// Set SendResponse.ResponseBody if the response body is non-nil
-	if resp.Body != nil {
-		respBody, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			ap.logger.Error("failed to read request body", "error", err)
-			return nil, err
-		}
-		// Close the old body
-		resp.Body.Close()
-
-		// Re-set the response body for potential consumption on the way back up the
-		// Proxier middleware chain.
-		resp.Body = ioutil.NopCloser(bytes.NewReader(respBody))
-
-		sendResponse.ResponseBody = respBody
+	// Before error checking from the request call, we'd want to initialize a SendResponse to
+	// potentially return
+	sendResponse, newErr := NewSendResponse(resp, nil)
+	if newErr != nil {
+		return nil, newErr
 	}
 
-	return sendResponse, nil
+	// Bubble back the api.Response as well for error checking/handling at the handler layer.
+	return sendResponse, err
 }

--- a/command/agent/cache/lease_cache.go
+++ b/command/agent/cache/lease_cache.go
@@ -144,7 +144,7 @@ func (c *LeaseCache) checkCacheForRequest(id string) (*SendResponse, error) {
 
 	sendResp, err := NewSendResponse(&api.Response{Response: resp}, index.Response)
 	if err != nil {
-		c.logger.Error("failed to create new SendResponse", "error", err)
+		c.logger.Error("failed to create new send response", "error", err)
 		return nil, err
 	}
 	sendResp.CacheMeta.Hit = true

--- a/command/agent/cache/lease_cache.go
+++ b/command/agent/cache/lease_cache.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/errwrap"
 	hclog "github.com/hashicorp/go-hclog"
@@ -141,12 +142,21 @@ func (c *LeaseCache) checkCacheForRequest(id string) (*SendResponse, error) {
 		return nil, err
 	}
 
-	return &SendResponse{
-		Response: &api.Response{
-			Response: resp,
-		},
-		ResponseBody: index.Response,
-	}, nil
+	sendResp, err := NewSendResponse(&api.Response{Response: resp}, index.Response)
+	if err != nil {
+		c.logger.Error("failed to create new SendResponse", "error", err)
+		return nil, err
+	}
+	sendResp.CacheMeta.Hit = true
+
+	respTime, err := http.ParseTime(resp.Header.Get("Date"))
+	if err != nil {
+		c.logger.Error("failed to parse cached response date", "error", err)
+		return nil, err
+	}
+	sendResp.CacheMeta.Age = time.Now().Sub(respTime)
+
+	return sendResp, nil
 }
 
 // Send performs a cache lookup on the incoming request. If it's a cache hit,

--- a/command/agent/cache/proxy.go
+++ b/command/agent/cache/proxy.go
@@ -59,7 +59,7 @@ func NewSendResponse(apiResponse *api.Response, responseBody []byte) (*SendRespo
 	}
 
 	// If a response body is separately provided we set that as the SendResponse.ResponseBody,
-	// otherwiese we will do an ioutil.ReadAll to extract the response body from apiResponse.
+	// otherwise we will do an ioutil.ReadAll to extract the response body from apiResponse.
 	switch {
 	case len(responseBody) > 0:
 		resp.ResponseBody = responseBody

--- a/command/agent/cache/proxy.go
+++ b/command/agent/cache/proxy.go
@@ -1,23 +1,42 @@
 package cache
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/hashicorp/vault/api"
 )
 
 // SendRequest is the input for Proxier.Send.
 type SendRequest struct {
-	Token       string
-	Request     *http.Request
+	Token   string
+	Request *http.Request
+
+	// RequestBody is the stored body bytes from Request.Body. It is set here to
+	// avoid reading and re-setting the stream multiple times.
 	RequestBody []byte
 }
 
 // SendResponse is the output from Proxier.Send.
 type SendResponse struct {
-	Response     *api.Response
+	Response *api.Response
+
+	// ResponseBody is the stored body bytes from Response.Body. It is set here to
+	// avoid reading and re-setting the stream multiple times.
 	ResponseBody []byte
+	CacheMeta    *CacheMeta
+}
+
+// CacheMeta contains metadata information about the response,
+// such as whether it was a cache hit or miss, and the age of the
+// cached entry.
+type CacheMeta struct {
+	Hit bool
+	Age time.Duration
 }
 
 // Proxier is the interface implemented by different components that are
@@ -25,4 +44,38 @@ type SendResponse struct {
 // these tasks combined together would serve the request received by the agent.
 type Proxier interface {
 	Send(ctx context.Context, req *SendRequest) (*SendResponse, error)
+}
+
+// NewSendResponse creates a new SendResponse and takes care of initializing its
+// fields properly.
+func NewSendResponse(apiResponse *api.Response, responseBody []byte) (*SendResponse, error) {
+	if apiResponse == nil {
+		return nil, fmt.Errorf("nil api response provided")
+	}
+
+	resp := &SendResponse{
+		Response:  apiResponse,
+		CacheMeta: &CacheMeta{},
+	}
+
+	// If a response body is separately provided we set that as the SendResponse.ResponseBody,
+	// otherwiese we will do an ioutil.ReadAll to extract the response body from apiResponse.
+	switch {
+	case len(responseBody) > 0:
+		resp.ResponseBody = responseBody
+	case apiResponse.Body != nil:
+		respBody, err := ioutil.ReadAll(apiResponse.Body)
+		if err != nil {
+			return nil, err
+		}
+		// Close the old body
+		apiResponse.Body.Close()
+
+		// Re-set the response body after reading from the Reader
+		apiResponse.Body = ioutil.NopCloser(bytes.NewReader(respBody))
+
+		resp.ResponseBody = respBody
+	}
+
+	return resp, nil
 }

--- a/command/agent/cache/testing.go
+++ b/command/agent/cache/testing.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/vault/api"
 )
@@ -46,9 +47,11 @@ func newTestSendResponse(status int, body string) *SendResponse {
 		Response: &api.Response{
 			Response: &http.Response{
 				StatusCode: status,
+				Header:     http.Header{},
 			},
 		},
 	}
+	resp.Response.Header.Set("Date", time.Now().Format(http.TimeFormat))
 
 	if body != "" {
 		resp.Response.Body = ioutil.NopCloser(strings.NewReader(body))
@@ -56,7 +59,6 @@ func newTestSendResponse(status int, body string) *SendResponse {
 	}
 
 	if json.Valid([]byte(body)) {
-		resp.Response.Header = http.Header{}
 		resp.Response.Header.Set("content-type", "application/json")
 	}
 


### PR DESCRIPTION
The following PR includes the following changes:
- Adds a `X-Cache` header to indicate whether the response was a from a cache `HIT` or `MISS`
- Adds an `Age` header to indicate freshness of the header value in the case of a cache hit.
- Updates the `Date` header to the current date on responses that result from cache hits. A cache miss will have a date value that is close to the current date so there's no need to re-set it.

Sample cache hit/miss (via dev-leased-kv):
```
› curl -v 127.0.0.1:8007/v1/secret/foo    
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8007 (#0)
> GET /v1/secret/foo HTTP/1.1
> Host: 127.0.0.1:8007
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Cache-Control: no-store
< Content-Length: 221
< Content-Type: application/json
< Date: Mon, 11 Mar 2019 18:57:59 GMT
< X-Cache: MISS
< 
{"request_id":"a8090c17-102c-4146-aed9-97aaaf2aaa55","lease_id":"secret/foo/vZnQ7cAeW0PV6hyCvL3m23ee","renewable":true,"lease_duration":600,"data":{"ttl":"10m","value":"bar"},"wrap_info":null,"warnings":null,"auth":null}
* Connection #0 to host 127.0.0.1 left intact

› curl -v 127.0.0.1:8007/v1/secret/foo
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8007 (#0)
> GET /v1/secret/foo HTTP/1.1
> Host: 127.0.0.1:8007
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Age: 5
< Cache-Control: no-store
< Content-Length: 221
< Content-Type: application/json
< Date: Mon, 11 Mar 2019 11:58:04 GMT
< X-Cache: HIT
< 
{"request_id":"a8090c17-102c-4146-aed9-97aaaf2aaa55","lease_id":"secret/foo/vZnQ7cAeW0PV6hyCvL3m23ee","renewable":true,"lease_duration":600,"data":{"ttl":"10m","value":"bar"},"wrap_info":null,"warnings":null,"auth":null}
* Connection #0 to host 127.0.0.1 left intact
```