### PR TITLE
UI - fetch role for oidc auth when rendering the default form

### DIFF
--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -31,10 +31,10 @@ export default Component.extend({
       let shouldDebounce = !oldSelectedAuthPath && !selectedAuthPath;
       if (oldSelectedAuthPath !== selectedAuthPath) {
         this.set('role', null);
-        this.onRoleName(null);
+        this.onRoleName(this.roleName);
         this.fetchRole.perform(null, { debounce: false });
       } else if (shouldDebounce) {
-        this.fetchRole.perform(null);
+        this.fetchRole.perform(this.roleName);
       }
       this.set('oldSelectedAuthPath', selectedAuthPath);
     });

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -28,10 +28,13 @@ export default Component.extend({
   didReceiveAttrs() {
     next(() => {
       let { oldSelectedAuthPath, selectedAuthPath } = this;
+      let shouldDebounce = !oldSelectedAuthPath && !selectedAuthPath;
       if (oldSelectedAuthPath !== selectedAuthPath) {
         this.set('role', null);
         this.onRoleName(null);
         this.fetchRole.perform(null, { debounce: false });
+      } else if (shouldDebounce) {
+        this.fetchRole.perform(null);
       }
       this.set('oldSelectedAuthPath', selectedAuthPath);
     });

--- a/ui/app/helpers/supported-auth-backends.js
+++ b/ui/app/helpers/supported-auth-backends.js
@@ -35,7 +35,7 @@ const SUPPORTED_AUTH_BACKENDS = [
   },
   {
     type: 'jwt',
-    typeDisplay: 'JWT/OIDC',
+    typeDisplay: 'JWT',
     description: 'Authenticate using JWT or OIDC provider.',
     tokenPath: 'client_token',
     displayNamePath: 'display_name',

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -79,6 +79,8 @@ module('Acceptance | auth', function(hooks) {
       } else if (backend.type === 'github') {
         assert.ok(Object.keys(body).includes('token'), 'GitHub includes token');
       } else if (backend.type === 'jwt' || backend.type === 'oidc') {
+        let authReq = this.server.passthroughRequests[this.server.passthroughRequests.length - 2];
+        body = JSON.parse(authReq.requestBody);
         assert.ok(Object.keys(body).includes('jwt'), `${backend.type} includes jwt`);
         assert.ok(Object.keys(body).includes('role'), `${backend.type} includes role`);
       } else {


### PR DESCRIPTION
Previously we weren't doing the call to the server to look for default roles if you hadn't filled in the `path` attribute on the login form. This changes it so that we do!

To test:

1) enable the JWT/OIDC auth method at the default path - `jwt` for JWT/OIDC type or `oidc` for OIDC type
2) configure the auth method with a default role
3) go to the UI and select JWT/OIDC for the auth method
4) verify that the UI fetches the role by observing that the "Sign In" button changes based on your provider

Fixes #6383