### PR TITLE
UI: fix bug where users couldn't nav back to unwrapped data

### DIFF
--- a/ui/app/templates/partials/tools/unwrap.hbs
+++ b/ui/app/templates/partials/tools/unwrap.hbs
@@ -11,10 +11,10 @@
     <nav class="tabs">
       <ul>
         <li role="tab" aria-selected={{if (eq unwrapActiveTab "data") "true" "false"}} class="{{if (eq unwrapActiveTab "data") "is-active"}}">
-          <button class="link link-plain tab has-text-weight-semibold" {{action (mut unwrapActiveTab)}}>Data</button>
+          <button class="link link-plain tab has-text-weight-semibold" {{action (mut unwrapActiveTab) "data"}} data-test-button-data>Data</button>
         </li>
         <li role="tab" aria-selected={{if (eq unwrapActiveTab "data") "true" "false"}} class="{{if (eq unwrapActiveTab "details") "is-active"}}">
-          <button class="link link-plain tab has-text-weight-semibold" {{action (mut unwrapActiveTab) "details"}}>Wrap Details</button>
+          <button class="link link-plain tab has-text-weight-semibold" {{action (mut unwrapActiveTab) "details"}} data-test-button-details>Wrap Details</button>
         </li>
       </ul>
     </nav>

--- a/ui/app/templates/partials/tools/unwrap.hbs
+++ b/ui/app/templates/partials/tools/unwrap.hbs
@@ -75,6 +75,7 @@
           class="input"
           id="token"
           name="token"
+          autocomplete="off"
           data-test-tools-input="wrapping-token"
         }}
       </div>

--- a/ui/tests/acceptance/tools-test.js
+++ b/ui/tests/acceptance/tools-test.js
@@ -82,6 +82,9 @@ module('Acceptance | tools', function(hooks) {
       JSON.parse(DATA_TO_WRAP),
       'unwrapped data equals input data'
     );
+    await click('[data-test-button-details]');
+    await click('[data-test-button-data]');
+    assert.dom('.CodeMirror').exists();
 
     //random
     await click('[data-test-tools-action-link="random"]');


### PR DESCRIPTION
Previously, if you clicked "Wrap Details" after unwrapping, clicking the "Data" tab didn't do anything. This changes it so that you can navigate to the data tab again.

To test:
1. Tools > Wrap some data
1. Unwrap the token
1. View "Wrap Details"
1. Verify you can view "Data" until navigating away from Tools and returning.


![unwrap-tabs](https://user-images.githubusercontent.com/39469/54285350-c9276780-456f-11e9-8ea4-343604065edb.gif)
