### PR TITLE
Fix inverted description for ldap/users$ and ldap/groups$ endpoints

### DIFF
--- a/builtin/credential/ldap/path_groups.go
+++ b/builtin/credential/ldap/path_groups.go
@@ -150,7 +150,7 @@ type GroupEntry struct {
 }
 
 const pathGroupHelpSyn = `
-Manage users allowed to authenticate.
+Manage additional groups for users allowed to authenticate.
 `
 
 const pathGroupHelpDesc = `

--- a/builtin/credential/ldap/path_users.go
+++ b/builtin/credential/ldap/path_users.go
@@ -168,7 +168,7 @@ type UserEntry struct {
 }
 
 const pathUserHelpSyn = `
-Manage additional groups for users allowed to authenticate.
+Manage users allowed to authenticate.
 `
 
 const pathUserHelpDesc = `


### PR DESCRIPTION
Stumbled upon them while testing OpenAPI support