### PR TITLE
database: return a hashed password field when reading config

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -78,6 +78,7 @@ func Backend(conf *logical.BackendConfig) *databaseBackend {
 		BackendType: logical.TypeLogical,
 	}
 
+	b.id = conf.BackendUUID
 	b.logger = conf.Logger
 	b.connections = make(map[string]*dbPluginInstance)
 	return &b
@@ -86,6 +87,7 @@ func Backend(conf *logical.BackendConfig) *databaseBackend {
 type databaseBackend struct {
 	connections map[string]*dbPluginInstance
 	logger      log.Logger
+	id          string
 
 	*framework.Backend
 	sync.RWMutex

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -620,7 +620,7 @@ func TestBackend_basic(t *testing.T) {
 	}
 }
 
-func TestBackend_connectionCrud(t *testing.T) {
+func TestBackend_connectionCRUD(t *testing.T) {
 	cluster, sys := getCluster(t)
 	defer cluster.Cleanup()
 
@@ -717,8 +717,9 @@ func TestBackend_connectionCrud(t *testing.T) {
 	expected := map[string]interface{}{
 		"plugin_name": "postgresql-database-plugin",
 		"connection_details": map[string]interface{}{
-			"username":       "postgres",
-			"connection_url": connURL,
+			"username":        "postgres",
+			"hashed_password": "f572948d91bfcd02899875e32846cfad68504d3f6b657974d0ad0bccc9d37e08",
+			"connection_url":  connURL,
 		},
 		"allowed_roles":                      []string{"plugin-role-test"},
 		"root_credentials_rotate_statements": []string(nil),

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -207,7 +207,7 @@ func (b *databaseBackend) connectionReadHandler() framework.OperationFunc {
 				return nil, err
 			}
 
-			// Hash the password and return is as `hashed_password`
+			// Hash the password and return it as `hashed_password`
 			config.ConnectionDetails["hashed_password"] = hashedPwd
 		}
 

--- a/helper/cryptoutil/cryptoutil.go
+++ b/helper/cryptoutil/cryptoutil.go
@@ -1,6 +1,13 @@
 package cryptoutil
 
-import "golang.org/x/crypto/blake2b"
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"golang.org/x/crypto/blake2b"
+)
 
 func Blake2b256Hash(key string) []byte {
 	hf, _ := blake2b.New256(nil)
@@ -8,4 +15,15 @@ func Blake2b256Hash(key string) []byte {
 	hf.Write([]byte(key))
 
 	return hf.Sum(nil)
+}
+
+// HMACSHA256Hash returns a hex-encoded HMAC-SHA256 value based
+// on the provided key and raw value to hash.
+func HMACSHA256Hash(key, value string) (string, error) {
+	if key == "" {
+		return "", fmt.Errorf("invalid HMAC key")
+	}
+	hm := hmac.New(sha256.New, []byte(key))
+	hm.Write([]byte(value))
+	return hex.EncodeToString(hm.Sum(nil)), nil
 }

--- a/helper/cryptoutil/cryptoutil_test.go
+++ b/helper/cryptoutil/cryptoutil_test.go
@@ -9,3 +9,19 @@ func TestBlake2b256Hash(t *testing.T) {
 		t.Fatalf("failed to hash the text")
 	}
 }
+
+func TestHMACSHA256Hash(t *testing.T) {
+	// Test on empty value
+	if _, err := HMACSHA256Hash("", "bar"); err == nil {
+		t.Fatal("expected error when an empty key is provided")
+	}
+
+	hashVal, err := HMACSHA256Hash("foo", "bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hashVal == "" || hashVal == "bar" {
+		t.Fatalf("expected result to return a hashed value, got: %v", hashVal)
+	}
+}

--- a/logical/testing.go
+++ b/logical/testing.go
@@ -77,8 +77,9 @@ func TestSystemView() *StaticSystemView {
 
 func TestBackendConfig() *BackendConfig {
 	bc := &BackendConfig{
-		Logger: logging.NewVaultLogger(log.Trace),
-		System: TestSystemView(),
+		Logger:      logging.NewVaultLogger(log.Trace),
+		System:      TestSystemView(),
+		BackendUUID: "testuuid",
 	}
 
 	return bc


### PR DESCRIPTION
This PR adds a `hashed_password` field using HMAC-SHA256 to hash the password field to be returned. This is useful for operators and applications to know when the password has changed (e.g. via credential rotation) without exposing the secret value itself.

Closes https://github.com/hashicorp/vault/issues/6231