### PR TITLE
add short sleep between revocation and lookup

### DIFF
--- a/vault/external_tests/token/batch_token_test.go
+++ b/vault/external_tests/token/batch_token_test.go
@@ -300,6 +300,8 @@ path "kv/*" {
 		t.Fatal(err)
 	}
 
+	time.Sleep(1 * time.Second)
+
 	// Verify the batch token is not usable anymore
 	client.SetToken(rootToken)
 	_, err = client.Auth().Token().Lookup(batchToken)


### PR DESCRIPTION
Small one that prevent tests from passing every now and then due to lookup before the token is revoked async.

```
--- FAIL: TestBatchToken_ParentLeaseRevoke (4.19s)
    batch_token_test.go:315: expected error
```

