### PR TITLE
changed misspelled english words

### DIFF
--- a/builtin/credential/radius/backend_test.go
+++ b/builtin/credential/radius/backend_test.go
@@ -214,7 +214,7 @@ func TestBackend_acceptance(t *testing.T) {
 		PreCheck:          testAccPreCheck(t, host, port),
 		AcceptanceTest:    true,
 		Steps: []logicaltest.TestStep{
-			// Login with valid but unknown user will fail because unregistered_user_policies is emtpy
+			// Login with valid but unknown user will fail because unregistered_user_policies is empty
 			testConfigWrite(t, configDataAcceptanceNoAllowUnreg, false),
 			testAccUserLogin(t, username, dataRealpassword, true),
 			// Once the user is registered auth will succeed

--- a/builtin/credential/radius/path_config.go
+++ b/builtin/credential/radius/path_config.go
@@ -30,7 +30,7 @@ func pathConfig(b *backend) *framework.Path {
 			"unregistered_user_policies": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Default:     "",
-				Description: "Comma-separated list of policies to grant upon successful RADIUS authentication of an unregisted user (default: emtpy)",
+				Description: "Comma-separated list of policies to grant upon successful RADIUS authentication of an unregisted user (default: empty)",
 				DisplayName: "Policies for unregistered users",
 			},
 			"dial_timeout": &framework.FieldSchema{

--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -250,7 +250,7 @@ func createUser(t *testing.T, userName string, accessKey *awsAccessKey) {
 	// 1. Create user, without any permissions or credentials. At this point,
 	//	  nobody cares if creds compromised because this user can do nothing.
 	// 2. Attach the timebomb policy. This grants no access but puts a time limit
-	//	  on validitity of compromised credentials. If this fails, nobody cares
+	//	  on validity of compromised credentials. If this fails, nobody cares
 	//	  because the user has no permissions to do anything anyway
 	// 3. Attach the AdminAccess policy. The IAM user still has no credentials to
 	//	  do anything

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2112,7 +2112,7 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 // top-level sequence; see
 // https://lapo.it/asn1js/#3046A020060A2B060104018237140203A0120C106465766F7073406C6F63616C686F7374A022060A2B060104018237140204A0140C12322D6465766F7073406C6F63616C686F7374 for an openssl-generated example.
 //
-// The good news is that it's valid to simply copy and paste the PEM ouput from
+// The good news is that it's valid to simply copy and paste the PEM output from
 // here into the form at that site as it will do the right thing so it's pretty
 // easy to validate.
 func TestBackend_OID_SANs(t *testing.T) {

--- a/builtin/logical/totp/backend_test.go
+++ b/builtin/logical/totp/backend_test.go
@@ -1050,7 +1050,7 @@ func testAccStepCreateKey(t *testing.T, name string, keyData map[string]interfac
 			urlObject, err := url.Parse(d.Url)
 
 			if err != nil {
-				t.Fatal("an error occured while parsing url string")
+				t.Fatal("an error occurred while parsing url string")
 			}
 
 			//Set up query object

--- a/builtin/logical/totp/path_code.go
+++ b/builtin/logical/totp/path_code.go
@@ -98,7 +98,7 @@ func (b *backend) pathValidateCode(ctx context.Context, req *logical.Request, da
 		Algorithm: key.Algorithm,
 	})
 	if err != nil && err != otplib.ErrValidateInputInvalidLength {
-		return logical.ErrorResponse("an error occured while validating the code"), err
+		return logical.ErrorResponse("an error occurred while validating the code"), err
 	}
 
 	// Take the key skew, add two for behind and in front, and multiple that by

--- a/builtin/logical/totp/path_keys.go
+++ b/builtin/logical/totp/path_keys.go
@@ -208,7 +208,7 @@ func (b *backend) pathKeyCreate(ctx context.Context, req *logical.Request, data 
 		//Parse url
 		urlObject, err := url.Parse(inputURL)
 		if err != nil {
-			return logical.ErrorResponse("an error occured while parsing url string"), err
+			return logical.ErrorResponse("an error occurred while parsing url string"), err
 		}
 
 		//Set up query object
@@ -241,7 +241,7 @@ func (b *backend) pathKeyCreate(ctx context.Context, req *logical.Request, data 
 		if periodQuery != "" {
 			periodInt, err := strconv.Atoi(periodQuery)
 			if err != nil {
-				return logical.ErrorResponse("an error occured while parsing period value in url"), err
+				return logical.ErrorResponse("an error occurred while parsing period value in url"), err
 			}
 			period = periodInt
 		}
@@ -251,7 +251,7 @@ func (b *backend) pathKeyCreate(ctx context.Context, req *logical.Request, data 
 		if digitsQuery != "" {
 			digitsInt, err := strconv.Atoi(digitsQuery)
 			if err != nil {
-				return logical.ErrorResponse("an error occured while parsing digits value in url"), err
+				return logical.ErrorResponse("an error occurred while parsing digits value in url"), err
 			}
 			digits = digitsInt
 		}
@@ -335,7 +335,7 @@ func (b *backend) pathKeyCreate(ctx context.Context, req *logical.Request, data 
 			SecretSize:  uintKeySize,
 		})
 		if err != nil {
-			return logical.ErrorResponse("an error occured while generating a key"), err
+			return logical.ErrorResponse("an error occurred while generating a key"), err
 		}
 
 		// Get key string value

--- a/builtin/logical/transit/path_restore_test.go
+++ b/builtin/logical/transit/path_restore_test.go
@@ -90,7 +90,7 @@ func TestTransit_Restore(t *testing.T) {
 		// Seed dermines if we start the test by restoring the initial backup we
 		// took, to test a restore operation based on the key existing or not
 		Seed bool
-		// Force is a pointer to differenciate between default false and given false
+		// Force is a pointer to differentiate between default false and given false
 		Force *bool
 		// The error we expect, if any
 		ExpectedErr error

--- a/command/agent.go
+++ b/command/agent.go
@@ -113,7 +113,7 @@ func (c *AgentCommand) Flags() *FlagSets {
 	//
 	// Why hello there little source code reader! Welcome to the Vault source
 	// code. The remaining options are intentionally undocumented and come with
-	// no warranty or backwards-compatability promise. Do not use these flags
+	// no warranty or backwards-compatibility promise. Do not use these flags
 	// in production. Do not build automation using these flags. Unless you are
 	// developing against Vault, you should not need any of these flags.
 

--- a/command/agent/auth/approle/approle.go
+++ b/command/agent/auth/approle/approle.go
@@ -136,15 +136,15 @@ func (a *approleMethod) Authenticate(ctx context.Context, client *api.Client) (s
 					return "", nil, errors.New("response nil when looking up wrapped secret ID")
 				}
 				if resp.Data == nil {
-					return "", nil, errors.New("data in repsonse nil when looking up wrapped secret ID")
+					return "", nil, errors.New("data in response nil when looking up wrapped secret ID")
 				}
 				creationPathRaw, ok := resp.Data["creation_path"]
 				if !ok {
-					return "", nil, errors.New("creation_path in repsonse nil when looking up wrapped secret ID")
+					return "", nil, errors.New("creation_path in response nil when looking up wrapped secret ID")
 				}
 				creationPath, ok := creationPathRaw.(string)
 				if !ok {
-					return "", nil, errors.New("creation_path in repsonse could not be parsed as string when looking up wrapped secret ID")
+					return "", nil, errors.New("creation_path in response could not be parsed as string when looking up wrapped secret ID")
 				}
 				if creationPath != a.secretIDResponseWrappingPath {
 					a.logger.Error("SECURITY: unable to validate wrapping token creation path", "expected", a.secretIDResponseWrappingPath, "found", creationPath)
@@ -159,15 +159,15 @@ func (a *approleMethod) Authenticate(ctx context.Context, client *api.Client) (s
 					return "", nil, errors.New("response nil when unwrapping secret ID")
 				}
 				if resp.Data == nil {
-					return "", nil, errors.New("data in repsonse nil when unwrapping secret ID")
+					return "", nil, errors.New("data in response nil when unwrapping secret ID")
 				}
 				secretIDRaw, ok := resp.Data["secret_id"]
 				if !ok {
-					return "", nil, errors.New("secret_id in repsonse nil when unwrapping secret ID")
+					return "", nil, errors.New("secret_id in response nil when unwrapping secret ID")
 				}
 				secretID, ok := secretIDRaw.(string)
 				if !ok {
-					return "", nil, errors.New("secret_id in repsonse could not be parsed as string when unwrapping secret ID")
+					return "", nil, errors.New("secret_id in response could not be parsed as string when unwrapping secret ID")
 				}
 				stringSecretID = secretID
 			}

--- a/command/main.go
+++ b/command/main.go
@@ -88,7 +88,7 @@ func Run(args []string) int {
 }
 
 // RunCustom allows passing in a base command template to pass to other
-// commands. Currenty, this is only used for setting a custom token helper.
+// commands. Currently, this is only used for setting a custom token helper.
 func RunCustom(args []string, runOpts *RunOptions) int {
 	if runOpts == nil {
 		runOpts = &RunOptions{}

--- a/command/server.go
+++ b/command/server.go
@@ -203,7 +203,7 @@ func (c *ServerCommand) Flags() *FlagSets {
 	//
 	// Why hello there little source code reader! Welcome to the Vault source
 	// code. The remaining options are intentionally undocumented and come with
-	// no warranty or backwards-compatability promise. Do not use these flags
+	// no warranty or backwards-compatibility promise. Do not use these flags
 	// in production. Do not build automation using these flags. Unless you are
 	// developing against Vault, you should not need any of these flags.
 

--- a/command/server_devfourcluster.go
+++ b/command/server_devfourcluster.go
@@ -292,7 +292,7 @@ func (c *ServerCommand) enableFourClusterDev(base *vault.CoreConfig, info map[st
 		case <-c.ShutdownCh:
 			c.UI.Output("==> Vault shutdown triggered")
 
-			// Stop the listners so that we don't process further client requests.
+			// Stop the listeners so that we don't process further client requests.
 			c.cleanupGuard.Do(clusterCleanup)
 
 			shutdownTriggered = true

--- a/command/ssh.go
+++ b/command/ssh.go
@@ -310,7 +310,7 @@ func (c *SSHCommand) Run(args []string) int {
 	}
 
 	// If no mode was given, perform the old-school lookup. Keep this now for
-	// backwards-compatability, but print a warning.
+	// backwards-compatibility, but print a warning.
 	//
 	// TODO: remove in 0.9.0, convert to validation error
 	if c.flagMode == "" {
@@ -863,7 +863,7 @@ func (c *SSHCommand) parseSSHCommand(args []string) (hostname string, username s
 			continue
 		} else {
 			// The second bare argument is the command to run on the remote host.
-			// We need to break out and stop parsing arugments now
+			// We need to break out and stop parsing arguments now
 			break
 		}
 

--- a/command/ssh_test.go
+++ b/command/ssh_test.go
@@ -122,7 +122,7 @@ func TestParseSSHCommand(t *testing.T) {
 			nil,
 		},
 		{
-			"Flags after the ssh command are not pased because they are part of the command",
+			"Flags after the ssh command are not passed because they are part of the command",
 			[]string{
 				"username@hostname",
 				"command",

--- a/helper/kdf/kdf.go
+++ b/helper/kdf/kdf.go
@@ -17,7 +17,7 @@ import (
 // functions or block ciphers.
 type PRF func([]byte, []byte) ([]byte, error)
 
-// CounterMode implements the counter mode KDF that uses a psuedo-random-function (PRF)
+// CounterMode implements the counter mode KDF that uses a pseudo-random-function (PRF)
 // along with a counter to generate derived keys. The KDF takes a base key
 // a derivation context, and the required number of output bits.
 func CounterMode(prf PRF, prfLen uint32, key []byte, context []byte, bits uint32) ([]byte, error) {

--- a/helper/keysutil/lock_manager.go
+++ b/helper/keysutil/lock_manager.go
@@ -128,7 +128,7 @@ func (lm *LockManager) RestorePolicy(ctx context.Context, storage logical.Storag
 	// and we do not look the policy up from storage
 	//
 	// - If it was found in cache and we are not using 'force', we should have
-	// returned above wih error
+	// returned above with error
 	var p *Policy
 	if pRaw == nil {
 		p, err = lm.getPolicyFromStorage(ctx, storage, name)

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -305,7 +305,7 @@ func SetupTwoClusterPerfReplication(t testing.T, perfPrimary, perfSecondary *vau
 
 	token := secret.WrapInfo.Token
 
-	// enable performace secondary
+	// enable performance secondary
 	secret, err = perfSecondary.Cores[0].Client.Logical().Write("sys/replication/performance/secondary/enable", map[string]interface{}{
 		"token":   token,
 		"ca_file": perfPrimary.CACertPEMFile,

--- a/http/handler.go
+++ b/http/handler.go
@@ -779,7 +779,7 @@ func parseMFAHeader(req *logical.Request) error {
 		// Handle the case where only method name is mentioned and no value
 		// is supplied
 		if !strings.Contains(mfaHeaderValue, ":") {
-			// Mark the presense of method name, but set an empty set to it
+			// Mark the presence of method name, but set an empty set to it
 			// indicating that there were no values supplied for the method
 			if req.MFACreds[mfaHeaderValue] == nil {
 				req.MFACreds[mfaHeaderValue] = []string{}

--- a/logical/error.go
+++ b/logical/error.go
@@ -71,7 +71,7 @@ func (s *StatusBadRequest) Error() string {
 // This is a new type declared to not cause potential compatibility problems if
 // the logic around the CodedError changes; in particular for logical request
 // paths it is basically ignored, and changing that behavior might cause
-// unforseen issues.
+// unforeseen issues.
 type ReplicationCodedError struct {
 	Msg  string
 	Code int

--- a/logical/plugin/grpc_backend_client.go
+++ b/logical/plugin/grpc_backend_client.go
@@ -150,7 +150,7 @@ func (b *backendGRPCPluginClient) Cleanup(ctx context.Context) {
 
 	// This will block until Setup has run the function to create a new server
 	// in b.server. If we stop here before it has a chance to actually start
-	// listening, when it starts listening it will immediatley error out and
+	// listening, when it starts listening it will immediately error out and
 	// exit, which is fine. Overall this ensures that we do not miss stopping
 	// the server if it ends up being created after Cleanup is called.
 	<-b.cleanupCh

--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -561,8 +561,8 @@ var (
 	// ErrUnlockFailed
 	ErrUnlockFailed = errors.New("mysql: unable to release lock, already released or not held by this session")
 	// You were unable to update that you are the new leader in the DB
-	ErrClaimFailed = errors.New("mysql: unable to update DB with new leader infromation")
-	// Error to thow if inbetween getting the lock and checking the ID of it we lost it.
+	ErrClaimFailed = errors.New("mysql: unable to update DB with new leader information")
+	// Error to throw if between getting the lock and checking the ID of it we lost it.
 	ErrSettingGlobalID = errors.New("mysql: getting global lock id failed")
 )
 
@@ -639,7 +639,7 @@ func (i *MySQLLock) Lock() error {
 	}
 
 	// 1 is returned from GET_LOCK if it was able to get the lock
-	// 0 if it failed and NULL if some stange error happened.
+	// 0 if it failed and NULL if some strange error happened.
 	// https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_get-lock
 	if !lock.Valid || lock.Int64 != 1 {
 		return ErrLockHeld

--- a/plugins/database/cassandra/cassandra_test.go
+++ b/plugins/database/cassandra/cassandra_test.go
@@ -94,7 +94,7 @@ func TestCassandra_Initialize(t *testing.T) {
 	}
 
 	if !db.Initialized {
-		t.Fatal("Database should be initalized")
+		t.Fatal("Database should be initialized")
 	}
 
 	err = db.Close()

--- a/plugins/database/influxdb/influxdb_test.go
+++ b/plugins/database/influxdb/influxdb_test.go
@@ -90,7 +90,7 @@ func TestInfluxdb_Initialize(t *testing.T) {
 	}
 
 	if !db.Initialized {
-		t.Fatal("Database should be initalized")
+		t.Fatal("Database should be initialized")
 	}
 
 	err = db.Close()

--- a/plugins/database/mssql/mssql_test.go
+++ b/plugins/database/mssql/mssql_test.go
@@ -29,7 +29,7 @@ func TestMSSQL_Initialize(t *testing.T) {
 	}
 
 	if !db.Initialized {
-		t.Fatal("Database should be initalized")
+		t.Fatal("Database should be initialized")
 	}
 
 	err = db.Close()
@@ -112,7 +112,7 @@ func TestMSSQL_RotateRootCredentials(t *testing.T) {
 	}
 
 	if !connProducer.Initialized {
-		t.Fatal("Database should be initalized")
+		t.Fatal("Database should be initialized")
 	}
 
 	newConf, err := db.RotateRootCredentials(context.Background(), nil)

--- a/plugins/database/mysql/mysql_test.go
+++ b/plugins/database/mysql/mysql_test.go
@@ -77,7 +77,7 @@ func TestMySQL_Initialize(t *testing.T) {
 	}
 
 	if !db.Initialized {
-		t.Fatal("Database should be initalized")
+		t.Fatal("Database should be initialized")
 	}
 
 	err = db.Close()
@@ -227,7 +227,7 @@ func TestMySQL_RotateRootCredentials(t *testing.T) {
 	}
 
 	if !db.Initialized {
-		t.Fatal("Database should be initalized")
+		t.Fatal("Database should be initialized")
 	}
 
 	newConf, err := db.RotateRootCredentials(context.Background(), nil)

--- a/plugins/database/postgresql/postgresql_test.go
+++ b/plugins/database/postgresql/postgresql_test.go
@@ -76,7 +76,7 @@ func TestPostgreSQL_Initialize(t *testing.T) {
 	}
 
 	if !db.Initialized {
-		t.Fatal("Database should be initalized")
+		t.Fatal("Database should be initialized")
 	}
 
 	err = db.Close()
@@ -186,7 +186,7 @@ func TestPostgreSQL_RenewUser(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Sleep longer than the inital expiration time
+	// Sleep longer than the initial expiration time
 	time.Sleep(2 * time.Second)
 
 	if err = testCredsExist(t, connURL, username, password); err != nil {
@@ -207,7 +207,7 @@ func TestPostgreSQL_RenewUser(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Sleep longer than the inital expiration time
+	// Sleep longer than the initial expiration time
 	time.Sleep(2 * time.Second)
 
 	if err = testCredsExist(t, connURL, username, password); err != nil {
@@ -239,7 +239,7 @@ func TestPostgreSQL_RotateRootCredentials(t *testing.T) {
 	}
 
 	if !connProducer.Initialized {
-		t.Fatal("Database should be initalized")
+		t.Fatal("Database should be initialized")
 	}
 
 	newConf, err := db.RotateRootCredentials(context.Background(), nil)

--- a/plugins/helper/database/connutil/connutil.go
+++ b/plugins/helper/database/connutil/connutil.go
@@ -7,10 +7,10 @@ import (
 )
 
 var (
-	ErrNotInitialized = errors.New("connection has not been initalized")
+	ErrNotInitialized = errors.New("connection has not been initialized")
 )
 
-// ConnectionProducer can be used as an embeded interface in the Database
+// ConnectionProducer can be used as an embedded interface in the Database
 // definition. It implements the methods dealing with individual database
 // connections and is used in all the builtin database types.
 type ConnectionProducer interface {

--- a/plugins/helper/database/credsutil/credsutil.go
+++ b/plugins/helper/database/credsutil/credsutil.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/vault/helper/base62"
 )
 
-// CredentialsProducer can be used as an embeded interface in the Database
+// CredentialsProducer can be used as an embedded interface in the Database
 // definition. It implements the methods for generating user information for a
 // particular database type and is used in all the builtin database types.
 type CredentialsProducer interface {

--- a/plugins/serve.go
+++ b/plugins/serve.go
@@ -10,7 +10,7 @@ import (
 
 // Serve is used to start a plugin's RPC server. It takes an interface that must
 // implement a known plugin interface to vault and an optional api.TLSConfig for
-// use during the inital unwrap request to vault. The api config is particularly
+// use during the initial unwrap request to vault. The api config is particularly
 // useful when vault is setup to require client cert checking.
 func Serve(plugin interface{}, tlsConfig *api.TLSConfig) {
 	tlsProvider := pluginutil.VaultPluginTLSProvider(tlsConfig)

--- a/vault/core.go
+++ b/vault/core.go
@@ -1734,7 +1734,7 @@ func (c *Core) PhysicalSealConfigs(ctx context.Context) (*SealConfig, *SealConfi
 		return nil, nil, errwrap.Wrapf("failed to validate barrier seal configuration at migration check time: {{err}}", err)
 	}
 	// In older versions of vault the default seal would not store a type. This
-	// is here to offer backwards compatability for older seal configs.
+	// is here to offer backwards compatibility for older seal configs.
 	if barrierConf.Type == "" {
 		barrierConf.Type = seal.Shamir
 	}
@@ -1754,7 +1754,7 @@ func (c *Core) PhysicalSealConfigs(ctx context.Context) (*SealConfig, *SealConfi
 			return nil, nil, errwrap.Wrapf("failed to validate seal configuration at migration check time: {{err}}", err)
 		}
 		// In older versions of vault the default seal would not store a type. This
-		// is here to offer backwards compatability for older seal configs.
+		// is here to offer backwards compatibility for older seal configs.
 		if recoveryConf.Type == "" {
 			recoveryConf.Type = seal.Shamir
 		}


### PR DESCRIPTION
changed misspelled english words

I used [goreportcard.com](https://goreportcard.com/report/github.com/hashicorp/vault#misspell) as a spell check tool.

 - vault/command/agent/auth/approle/approle.go
   - Line 139: warning: "repsonse" is a misspelling of "response" (misspell)
   - Line 143: warning: "repsonse" is a misspelling of "response" (misspell)
   - Line 147: warning: "repsonse" is a misspelling of "response" (misspell)
   - Line 162: warning: "repsonse" is a misspelling of "response" (misspell)
   - Line 166: warning: "repsonse" is a misspelling of "response" (misspell)
   - Line 170: warning: "repsonse" is a misspelling of "response" (misspell)

 - vault/http/handler.go
   - Line 746: warning: "presense" is a misspelling of "presence" (misspell)

 - vault/helper/keysutil/lock_manager.go
   - Line 131: warning: "wih" is a misspelling of "with" (misspell)

 - vault/vault/core.go
   - Line 1649: warning: "compatability" is a misspelling of "compatibility" (misspell)
   - Line 1669: warning: "compatability" is a misspelling of "compatibility" (misspell)

 - vault/builtin/credential/radius/backend_test.go
   - Line 217: warning: "emtpy" is a misspelling of "empty" (misspell)

 - vault/builtin/logical/totp/path_code.go
   - Line 101: warning: "occured" is a misspelling of "occurred" (misspell)

 - vault/logical/error.go
   - Line 70: warning: "unforseen" is a misspelling of "unforeseen" (misspell)

 - vault/physical/mysql/mysql.go
   -Line 564: warning: "infromation" is a misspelling of "information" (misspell)
   -Line 565: warning: "inbetween" is a misspelling of "between" (misspell)
   -Line 642: warning: "stange" is a misspelling of "strange" (misspell)

 - vault/plugins/database/cassandra/cassandra_test.go
   - Line 97: warning: "initalized" is a misspelling of "initialized" (misspell)

 - vault/command/ssh.go
   - Line 313: warning: "compatability" is a misspelling of "compatibility" (misspell)
   - Line 862: warning: "arugments" is a misspelling of "arguments" (misspell)

 - vault/logical/plugin/grpc_backend_client.go
   - Line 152: warning: "immediatley" is a misspelling of "immediately" (misspell)

 - vault/plugins/serve.go
   - Line 13: warning: "inital" is a misspelling of "initial" (misspell)

 - vault/plugins/database/postgresql/postgresql_test.go
   - Line 79: warning: "initalized" is a misspelling of "initialized" (misspell)
   - Line 189: warning: "inital" is a misspelling of "initial" (misspell)
   - Line 210: warning: "inital" is a misspelling of "initial" (misspell)
   - Line 242: warning: "initalized" is a misspelling of "initialized" (misspell)

 - vault/command/agent.go
   - Line 109: warning: "compatability" is a misspelling of "compatibility" (misspell)

 - vault/command/server.go
   - Line 202: warning: "compatability" is a misspelling of "compatibility" (misspell)

 - vault/plugins/database/mssql/mssql_test.go
   - Line 37: warning: "initalized" is a misspelling of "initialized" (misspell)
   - Line 119: warning: "initalized" is a misspelling of "initialized" (misspell)

 - vault/plugins/helper/database/connutil/connutil.go
   - Line 10: warning: "initalized" is a misspelling of "initialized" (misspell)
   - Line 13: warning: "embeded" is a misspelling of "embedded" (misspell)

 - vault/helper/kdf/kdf.go
   - Line 20: warning: "psuedo" is a misspelling of "pseudo" (misspell)

 - vault/builtin/credential/radius/path_config.go
   - Line 32: warning: "emtpy" is a misspelling of "empty" (misspell)

 - vault/builtin/logical/transit/path_restore_test.go
   - Line 93: warning: "differenciate" is a misspelling of "differentiate" (misspell)

 - vault/builtin/logical/totp/path_keys.go
   - Line 211: warning: "occured" is a misspelling of "occurred" (misspell)
   - Line 244: warning: "occured" is a misspelling of "occurred" (misspell)
   - Line 254: warning: "occured" is a misspelling of "occurred" (misspell)
   - Line 338: warning: "occured" is a misspelling of "occurred" (misspell)

 - vault/plugins/database/mysql/mysql_test.go
   - Line 80: warning: "initalized" is a misspelling of "initialized" (misspell)
   - Line 230: warning: "initalized" is a misspelling of "initialized" (misspell)
 
 - vault/helper/testhelpers/testhelpers.go
   - Line 257: warning: "performace" is a misspelling of "performance" (misspell)

 - vault/builtin/logical/aws/backend_test.go
   - Line 253: warning: "validitity" is a misspelling of "validity" (misspell)

 - vault/command/main.go
   - Line 85: warning: "Currenty" is a misspelling of "Currently" (misspell)

 - vault/builtin/logical/pki/backend_test.go
   - Line 2115: warning: "ouput" is a misspelling of "output" (misspell)

 - vault/builtin/logical/totp/backend_test.go
   - Line 1052: warning: "occured" is a misspelling of "occurred" (misspell)

 - vault/command/ssh_test.go
   - Line 125: warning: "pased" is a misspelling of "passed" (misspell)

 - vault/plugins/database/influxdb/influxdb_test.go
   - Line 93: warning: "initalized" is a misspelling of "initialized" (misspell)

 - vault/plugins/helper/database/credsutil/credsutil.go
   - Line 12: warning: "embeded" is a misspelling of "embedded" (misspell)

 - vault/command/server_devfourcluster.go
   - Line 295: warning: "listners" is a misspelling of "listeners" (misspell)