### PR TITLE
Add Docs For Prometheus Metrics

### DIFF
--- a/website/source/docs/configuration/telemetry.html.md
+++ b/website/source/docs/configuration/telemetry.html.md
@@ -135,3 +135,31 @@ These `telemetry` parameters apply to
 - `dogstatsd_tags` `(string array: [])` - This provides a list of global tags
   that will be added to all telemetry packets sent to DogStatsD. It is a list
   of strings, where each string looks like "my_tag_name:my_tag_value".
+
+### `prometheus`
+
+These `telemetry` parameters apply to
+[prometheus](https://prometheus.io).
+
+* `prometheus_retention_time` `(string: "24h")` - Specifies the amount of time that
+  prometheus metrics are retained in memory. It is recommended to also enable the option
+  `disable_hostname` to avoid having prefixed metrics with hostname. Vault does not use the
+  default Prometheus path, so Prometheus must be configured as follows. Note that using
+  ?format=prometheus in the path won't work as ? will be escaped, so it must be specified
+  as a parameter. Addtionally a Vault token is required to access /v1/sys/metrics. The prometheus
+  `bearer_token` or `bearer_token_file` options must be added to the scrape job.
+
+```
+metrics_path: "/v1/sys/metrics"
+params:
+  format: ['prometheus']
+bearer_token: your_vault_token_here
+
+```
+
+```hcl
+telemetry {
+  prometheus_retention_time = "30s",
+  disable_hostname = true
+}
+```


### PR DESCRIPTION
Prometheus metrics were added as part
of the Vault v1.1.0 release in PR #5308.
But no documentation was created.

This adds the configuration docs, but
does not include the missing API docs. It
also looks like the OpenAPI endpoint is missing
the the details for /v1/sys/metrics?format=prometheus
which is also not fixed with this change.