### PR TITLE
Add Docs For Prometheus Metrics

### DIFF
--- a/website/source/api/system/metrics.html.md
+++ b/website/source/api/system/metrics.html.md
@@ -1,0 +1,69 @@
+---
+layout: "api"
+page_title: "/sys/metrics - HTTP API"
+sidebar_title: "<code>/sys/metrics</code>"
+sidebar_current: "api-http-system-metrics"
+description: |-
+  The `/sys/metrics` endpoint is used to get telemetry metrics for Vault.
+---
+
+# `/sys/metrics`
+
+The `/sys/metrics` endpoint is used to get telemetry metrics for Vault.
+
+## Read Telemetry Metrics
+
+This endpoint returns the telemetry metrics for Vault. It can be used by metrics
+collections systems like [Prometheus](https://prometheus.io) that use a pull
+model for metrics collection.
+
+| Method   | Path                         | Produces               |
+| :------- | :--------------------------- | :--------------------- |
+| `GET`    | `/sys/metrics`               | `000 application/json` |
+
+### Parameters
+
+- `format` `(string: "")` – Specifies the format used for the returned metrics. The
+  default metrics format is JSON. Setting `format` to `prometheus` will return the
+  metrics in [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format).
+  
+### Sample Request
+
+```
+$ curl -H "X-Vault-Token: f3b09679-3001-009d-2b80-9c306ab81aa6" \
+    http://127.0.0.1:8200/v1/sys/metrics?format=prometheus
+```
+
+### Sample Response
+
+This response is only returned for a `GET` request.
+
+```
+# HELP vault_audit_log_request vault_audit_log_request
+# TYPE vault_audit_log_request summary
+vault_audit_log_request{quantile="0.5"} 0.005927000194787979
+vault_audit_log_request{quantile="0.9"} 0.005927000194787979
+vault_audit_log_request{quantile="0.99"} 0.005927000194787979
+vault_audit_log_request_sum 0.014550999738276005
+vault_audit_log_request_count 2
+# HELP vault_audit_log_request_failure vault_audit_log_request_failure
+# TYPE vault_audit_log_request_failure counter
+vault_audit_log_request_failure 0
+# HELP vault_audit_log_response vault_audit_log_response
+# TYPE vault_audit_log_response summary
+vault_audit_log_response{quantile="0.5"} NaN
+vault_audit_log_response{quantile="0.9"} NaN
+vault_audit_log_response{quantile="0.99"} NaN
+vault_audit_log_response_sum 0.0057669999077916145
+vault_audit_log_response_count 1
+# HELP vault_audit_log_response_failure vault_audit_log_response_failure
+# TYPE vault_audit_log_response_failure counter
+vault_audit_log_response_failure 0
+# HELP vault_barrier_get vault_barrier_get
+# TYPE vault_barrier_get summary
+vault_barrier_get{quantile="0.5"} 0.011938000097870827
+vault_barrier_get{quantile="0.9"} 0.011938000097870827
+vault_barrier_get{quantile="0.99"} 0.011938000097870827
+vault_barrier_get_sum 0.1814980012131855
+vault_barrier_get_count 36
+```

--- a/website/source/api/system/metrics.html.md
+++ b/website/source/api/system/metrics.html.md
@@ -17,9 +17,9 @@ This endpoint returns the telemetry metrics for Vault. It can be used by metrics
 collections systems like [Prometheus](https://prometheus.io) that use a pull
 model for metrics collection.
 
-| Method   | Path                         | Produces               |
-| :------- | :--------------------------- | :--------------------- |
-| `GET`    | `/sys/metrics`               | `000 application/json` |
+| Method   | Path             |
+| :------- | :--------------- |
+| `GET`    | `/sys/metrics`   |
 
 ### Parameters
 

--- a/website/source/docs/configuration/telemetry.html.md
+++ b/website/source/docs/configuration/telemetry.html.md
@@ -135,3 +135,31 @@ These `telemetry` parameters apply to
 - `dogstatsd_tags` `(string array: [])` - This provides a list of global tags
   that will be added to all telemetry packets sent to DogStatsD. It is a list
   of strings, where each string looks like "my_tag_name:my_tag_value".
+
+### `prometheus`
+
+These `telemetry` parameters apply to
+[prometheus](https://prometheus.io).
+
+* `prometheus_retention_time` `(string: "24h")` - Specifies the amount of time that
+  prometheus metrics are retained in memory. It is recommended to also enable the option
+  `disable_hostname` to avoid having prefixed metrics with hostname. Vault does not use the
+  default Prometheus path, so Prometheus must be configured as follows. Note that using
+  ?format=prometheus in the path won't work as ? will be escaped, so it must be specified
+  as a parameter. Addtionally a Vault token is required to access /v1/sys/metrics. The prometheus
+  `bearer_token` or `bearer_token_file` options must be added to the scrape job.
+
+```
+metrics_path: "/v1/sys/metrics"
+params:
+  format: ['prometheus']
+bearer_token: your_vault_token_here
+
+```
+
+```hcl
+telemetry {
+  prometheus_retention_time = "30s",
+  disable_hostname = true
+}
+```

--- a/website/source/docs/configuration/telemetry.html.md
+++ b/website/source/docs/configuration/telemetry.html.md
@@ -145,7 +145,7 @@ These `telemetry` parameters apply to
   prometheus metrics are retained in memory. It is recommended to also enable the option
   `disable_hostname` to avoid having prefixed metrics with hostname. Vault does not use the
   default Prometheus path, so Prometheus must be configured as follows. Note that using
-  ?format=prometheus in the path won't work as ? will be escaped, so it must be specified
+  `?format=prometheus` in the path won't work as "?" will be escaped, so it must be specified
   as a parameter. Addtionally a Vault token is required to access /v1/sys/metrics. The prometheus
   `bearer_token` or `bearer_token_file` options must be added to the scrape job.
 

--- a/website/source/docs/configuration/telemetry.html.md
+++ b/website/source/docs/configuration/telemetry.html.md
@@ -146,7 +146,7 @@ These `telemetry` parameters apply to
   `disable_hostname` to avoid having prefixed metrics with hostname. Vault does not use the
   default Prometheus path, so Prometheus must be configured as follows. Note that using
   `?format=prometheus` in the path won't work as "?" will be escaped, so it must be specified
-  as a parameter. Addtionally a Vault token is required to access /v1/sys/metrics. The prometheus
+  as a parameter. Additionally a Vault token is required to access /v1/sys/metrics. The prometheus
   `bearer_token` or `bearer_token_file` options must be added to the scrape job.
 
 ```

--- a/website/source/layouts/api.erb
+++ b/website/source/layouts/api.erb
@@ -114,6 +114,7 @@
                   'totp'
                 ]
               },
+              'metrics',
               'mounts',
               'plugins-reload-backend',
               'plugins-catalog',


### PR DESCRIPTION
Prometheus metrics were added as part of the Vault v1.1.0 release in PR #5308. But no documentation was created. Adds the telemetry configuration docs and the API docs.