### PR TITLE
set configSeal.Type to the type specified via the env var if provided

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -518,6 +518,7 @@ func (c *ServerCommand) Run(args []string) int {
 			sealType := vaultseal.Shamir
 			if !configSeal.Disabled && os.Getenv("VAULT_SEAL_TYPE") != "" {
 				sealType = os.Getenv("VAULT_SEAL_TYPE")
+				configSeal.Type = sealType
 			} else {
 				sealType = configSeal.Type
 			}


### PR DESCRIPTION
If `VAULT_SEAL_TYPE` is provided, set that back to `configSeal.Type` so that `ConfigureSeal` can properly set up the correct seal instead of incorrectly assuming the existing seal to be of type shamir.

Fixes https://github.com/hashicorp/vault/issues/6436