### PR TITLE
Fix OpenAPI cleanResponse and test

### DIFF
--- a/logical/framework/openapi.go
+++ b/logical/framework/openapi.go
@@ -618,7 +618,8 @@ type cleanedResponse struct {
 	Data     map[string]interface{}     `json:"data,omitempty"`
 	Redirect string                     `json:"redirect,omitempty"`
 	Warnings []string                   `json:"warnings,omitempty"`
-	WrapInfo *wrapping.ResponseWrapInfo `json:"wrap_info,omitempty"`
+	WrapInfo *wrapping.ResponseWrapInfo `json:"wrap_info,omitempty" mapstructure:"wrap_info"`
+	Headers  map[string][]string        `json:"headers,omitempty"`
 }
 
 func cleanResponse(resp *logical.Response) (*cleanedResponse, error) {

--- a/logical/framework/openapi.go
+++ b/logical/framework/openapi.go
@@ -402,10 +402,7 @@ func documentPath(p *Path, specialPaths *logical.Paths, backendType logical.Back
 						}
 
 						// create a version of the response that will not emit null items
-						cr, err := cleanResponse(resp.Example)
-						if err != nil {
-							return err
-						}
+						cr := cleanResponse(resp.Example)
 
 						// Only one example per media type is allowed, so first one wins
 						if _, ok := content[mediaType]; !ok {
@@ -618,18 +615,20 @@ type cleanedResponse struct {
 	Data     map[string]interface{}     `json:"data,omitempty"`
 	Redirect string                     `json:"redirect,omitempty"`
 	Warnings []string                   `json:"warnings,omitempty"`
-	WrapInfo *wrapping.ResponseWrapInfo `json:"wrap_info,omitempty" mapstructure:"wrap_info"`
+	WrapInfo *wrapping.ResponseWrapInfo `json:"wrap_info,omitempty"`
 	Headers  map[string][]string        `json:"headers,omitempty"`
 }
 
-func cleanResponse(resp *logical.Response) (*cleanedResponse, error) {
-	var r cleanedResponse
-
-	if err := mapstructure.Decode(resp, &r); err != nil {
-		return nil, err
+func cleanResponse(resp *logical.Response) *cleanedResponse {
+	return &cleanedResponse{
+		Secret:   resp.Secret,
+		Auth:     resp.Auth,
+		Data:     resp.Data,
+		Redirect: resp.Redirect,
+		Warnings: resp.Warnings,
+		WrapInfo: resp.WrapInfo,
+		Headers:  resp.Headers,
 	}
-
-	return &r, nil
 }
 
 // CreateOperationIDs generates unique operationIds for all paths/methods.

--- a/logical/framework/openapi_test.go
+++ b/logical/framework/openapi_test.go
@@ -521,10 +521,7 @@ func TestOpenAPI_CleanResponse(t *testing.T) {
 	// Verify that an all-null input results in empty JSON
 	orig := &logical.Response{}
 
-	cr, err := cleanResponse(orig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	cr := cleanResponse(orig)
 
 	newJSON := mustJSONMarshal(t, cr)
 
@@ -546,10 +543,7 @@ func TestOpenAPI_CleanResponse(t *testing.T) {
 	}
 	origJSON := mustJSONMarshal(t, orig)
 
-	cr, err = cleanResponse(orig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	cr = cleanResponse(orig)
 
 	cleanJSON := mustJSONMarshal(t, cr)
 

--- a/logical/framework/openapi_test.go
+++ b/logical/framework/openapi_test.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
@@ -9,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/vault/helper/wrapping"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/vault/helper/jsonutil"
@@ -474,15 +477,18 @@ func TestOpenAPI_CustomDecoder(t *testing.T) {
 				Responses: map[int][]Response{
 					100: {{
 						Description: "OK",
-						Example:     &logical.Response{},
+						Example: &logical.Response{
+							Data: map[string]interface{}{
+								"foo": 42,
+							},
+						},
 					}},
 					200: {{
 						Description: "Good",
-						Example:     &logical.Response{},
+						Example:     (*logical.Response)(nil),
 					}},
 					599: {{
 						Description: "Bad",
-						Example:     &logical.Response{},
 					}},
 				},
 			},
@@ -492,10 +498,7 @@ func TestOpenAPI_CustomDecoder(t *testing.T) {
 	docOrig := NewOASDocument()
 	documentPath(p, nil, logical.TypeLogical, docOrig)
 
-	docJSON, err := json.Marshal(docOrig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	docJSON := mustJSONMarshal(t, docOrig)
 
 	var intermediate map[string]interface{}
 	if err := jsonutil.DecodeJSON(docJSON, &intermediate); err != nil {
@@ -507,7 +510,50 @@ func TestOpenAPI_CustomDecoder(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if diff := deep.Equal(docOrig, docNew); diff != nil {
+	docNewJSON := mustJSONMarshal(t, docNew)
+
+	if diff := deep.Equal(docJSON, docNewJSON); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+func TestOpenAPI_CleanResponse(t *testing.T) {
+	// Verify that an all-null input results in empty JSON
+	orig := &logical.Response{}
+
+	cr, err := cleanResponse(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newJSON := mustJSONMarshal(t, cr)
+
+	if !bytes.Equal(newJSON, []byte("{}")) {
+		t.Fatalf("expected {}, got: %q", newJSON)
+	}
+
+	// Verify that all non-null inputs results in JSON that matches the marshalling of
+	// logical.Response. This will fail if logical.Response changes without a corresponding
+	// change to cleanResponse()
+	orig = &logical.Response{
+		Secret:   new(logical.Secret),
+		Auth:     new(logical.Auth),
+		Data:     map[string]interface{}{"foo": 42},
+		Redirect: "foo",
+		Warnings: []string{"foo"},
+		WrapInfo: &wrapping.ResponseWrapInfo{Token: "foo"},
+		Headers:  map[string][]string{"foo": {"bar"}},
+	}
+	origJSON := mustJSONMarshal(t, orig)
+
+	cr, err = cleanResponse(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cleanJSON := mustJSONMarshal(t, cr)
+
+	if diff := deep.Equal(origJSON, cleanJSON); diff != nil {
 		t.Fatal(diff)
 	}
 }
@@ -562,4 +608,13 @@ func expected(name string) string {
 	content := strings.Replace(string(data), "<vault_version>", version.GetVersion().Version, 1)
 
 	return content
+}
+
+func mustJSONMarshal(t *testing.T, data interface{}) []byte {
+	j, err := json.MarshalIndent(data, "", "  ")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	return j
 }

--- a/logical/framework/openapi_test.go
+++ b/logical/framework/openapi_test.go
@@ -11,10 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/vault/helper/wrapping"
-
 	"github.com/go-test/deep"
 	"github.com/hashicorp/vault/helper/jsonutil"
+	"github.com/hashicorp/vault/helper/wrapping"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/version"
 )

--- a/vendor/github.com/go-test/deep/deep.go
+++ b/vendor/github.com/go-test/deep/deep.go
@@ -19,8 +19,9 @@ var (
 	// MaxDiff specifies the maximum number of differences to return.
 	MaxDiff = 10
 
-	// MaxDepth specifies the maximum levels of a struct to recurse into.
-	MaxDepth = 10
+	// MaxDepth specifies the maximum levels of a struct to recurse into,
+	// if greater than zero. If zero, there is no limit.
+	MaxDepth = 0
 
 	// LogErrors causes errors to be logged to STDERR when true.
 	LogErrors = false
@@ -50,8 +51,9 @@ type cmp struct {
 var errorType = reflect.TypeOf((*error)(nil)).Elem()
 
 // Equal compares variables a and b, recursing into their structure up to
-// MaxDepth levels deep, and returns a list of differences, or nil if there are
-// none. Some differences may not be found if an error is also returned.
+// MaxDepth levels deep (if greater than zero), and returns a list of differences,
+// or nil if there are none. Some differences may not be found if an error is
+// also returned.
 //
 // If a type has an Equal method, like time.Equal, it is called to check for
 // equality.
@@ -66,7 +68,7 @@ func Equal(a, b interface{}) []string {
 	if a == nil && b == nil {
 		return nil
 	} else if a == nil && b != nil {
-		c.saveDiff(b, "<nil pointer>")
+		c.saveDiff("<nil pointer>", b)
 	} else if a != nil && b == nil {
 		c.saveDiff(a, "<nil pointer>")
 	}
@@ -82,7 +84,7 @@ func Equal(a, b interface{}) []string {
 }
 
 func (c *cmp) equals(a, b reflect.Value, level int) {
-	if level > MaxDepth {
+	if MaxDepth > 0 && level > MaxDepth {
 		logError(ErrMaxRecursion)
 		return
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -929,10 +929,10 @@
 			"revisionTime": "2018-10-01T07:22:39Z"
 		},
 		{
-			"checksumSHA1": "TI+QiWWuz4SQKW/MyRRYhjzdq2A=",
+			"checksumSHA1": "at1y9um6fBwntQTOsP5eCFDqNfA=",
 			"path": "github.com/go-test/deep",
-			"revision": "57af0be209c537ba1d9c2a4b285ab7aea0897e51",
-			"revisionTime": "2018-05-09T20:02:13Z"
+			"revision": "042da051cf3189d80f667339b822c7effac29cd6",
+			"revisionTime": "2018-11-18T22:09:53Z"
 		},
 		{
 			"checksumSHA1": "R6itMAIo8MvEkf0FYAeXtaBhcfc=",


### PR DESCRIPTION
Add missing Headers field, along with a test to detect changes.

The custom decoder test should be ensuring only that the resulting
OpenAPI JSON outputs are equal. Updating the go-test deep library
reveals the error.