### PR TITLE
Correct migration case to Shamir where it's not explicit

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -511,8 +511,15 @@ func (c *ServerCommand) Run(args []string) int {
 		barrierSeal = vault.NewAutoSeal(vaultseal.NewTestSeal(nil))
 	} else {
 		// Handle the case where no seal is provided
-		if len(config.Seals) == 0 {
+		switch len(config.Seals) {
+		case 0:
 			config.Seals = append(config.Seals, &server.Seal{Type: vaultseal.Shamir})
+		case 1:
+			// If there's only one seal and it's disabled assume they want to
+			// migrate to a shamir seal and simply didn't provide it
+			if config.Seals[0].Disabled {
+				config.Seals = append(config.Seals, &server.Seal{Type: vaultseal.Shamir})
+			}
 		}
 		for _, configSeal := range config.Seals {
 			sealType := vaultseal.Shamir


### PR DESCRIPTION
If you were migrating to Shamir but didn't specify a Shamir block
migration would fail. Being explicit is nice but it's also not really
obvious since you don't need the block normally.

Fixes #6455