### PR TITLE
Correct AWS Auth API docs 

### DIFF
--- a/website/source/api/auth/aws/index.html.md
+++ b/website/source/api/auth/aws/index.html.md
@@ -144,7 +144,7 @@ This configures the way that Vault interacts with the
 
 ### Parameters
 
-- `iam_alias` `(string: "unique_id")` - How to generate the identity alias when
+- `iam_alias` `(string: "role_id")` - How to generate the identity alias when
   using the `iam` auth method. Valid choices are `role_id`, `unique_id`, and
   `full_arn`  When `role_id` is selected, the randomly generated ID of the role
   is used. When `unique_id` is selected, the [IAM Unique
@@ -158,7 +158,7 @@ This configures the way that Vault interacts with the
   Vault won't be aware and any identity aliases set up for the role name will
   still be valid.
 
-- `ec2_alias (string: "instance_id")` - Configures how to generate the identity
+- `ec2_alias (string: "role_id")` - Configures how to generate the identity
   alias when using the `ec2` auth method. Valid choices are `role_id`,
   `instance_id`, and `image_id`. When `role_id` is selected, the randomly
   generated ID of the role is used. When `instance_id` is selected, the


### PR DESCRIPTION
update AWS Auth API docs to show that role_id is the default for ec2_alias and iam_alias (auth/aws/config/identity endpoint)