### PR TITLE
Fixed typo in GCP auth docs

### DIFF
--- a/website/source/docs/auth/gcp.html.md
+++ b/website/source/docs/auth/gcp.html.md
@@ -41,12 +41,11 @@ $ vault login -method=gcp \
     role="my-role" \
     service_account="authenticating-account@my-project.iam.gserviceaccount.com" \
     project="my-project" \
-    jwt_exp="15m"
+    jwt_exp="15m" \
+    credentials=@path/to/signer/credentials.json
 ```
 
 For more usage information, run `vault auth help gcp`.
-
-_NOTE:_ While it is possible to specify `credentials` in the login command, it is recommended to use the `GOOGLE_APPLICATION_CREDENTIALS` envrionment variable to point to the JSON file where credentials are stored.
 
 ### Via the CLI
 

--- a/website/source/docs/auth/gcp.html.md
+++ b/website/source/docs/auth/gcp.html.md
@@ -39,13 +39,14 @@ request to Vault. This helper is only available for IAM-type roles.
 ```text
 $ vault login -method=gcp \
     role="my-role" \
-    service_account="authenticating-account@my-project.iam.gserviceaccounts.com" \
+    service_account="authenticating-account@my-project.iam.gserviceaccount.com" \
     project="my-project" \
-    jwt_exp="15m" \
-    credentials=@path/to/signer/credentials.json
+    jwt_exp="15m"
 ```
 
 For more usage information, run `vault auth help gcp`.
+
+_NOTE:_ While it is possible to specify `credentials` in the login command, it is recommended to use the `GOOGLE_APPLICATION_CREDENTIALS` envrionment variable to point to the JSON file where credentials are stored.
 
 ### Via the CLI
 


### PR DESCRIPTION
* Fixed typo where `gserviceaccount` was `gserviceaccounts` which would always give a 403
* ~Since the CLI help message recommends not using credentials it makes sense not to use that as an example, but to add a note about default credentials.~