### PR TITLE
[vault-cli]: Add flags to recursively list secrets for KV Engine.

### DIFF
--- a/command/base_helpers.go
+++ b/command/base_helpers.go
@@ -50,7 +50,7 @@ func ensureTrailingSlash(s string) string {
 	return s
 }
 
-// ensureNoTrailingSlash ensures the given string has a trailing slash.
+// ensureNoTrailingSlash ensures the given string has no trailing slash.
 func ensureNoTrailingSlash(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -63,7 +63,7 @@ func ensureNoTrailingSlash(s string) string {
 	return s
 }
 
-// ensureNoLeadingSlash ensures the given string has a trailing slash.
+// ensureNoLeadingSlash ensures the given string has no leading slash.
 func ensureNoLeadingSlash(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -527,3 +527,181 @@ func TestKVMetadataGetCommand(t *testing.T) {
 		assertNoTabs(t, cmd)
 	})
 }
+
+func testKVListCommand(tb testing.TB) (*cli.MockUi, *KVListCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &KVListCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestKVListCommand(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"not_enough_args",
+			[]string{},
+			"Not enough arguments (expected 1, got 0)",
+			1,
+		},
+		{
+			"too_many_args",
+			[]string{"foo", "bar"},
+			"Too many arguments (expected 1, got 2)",
+			1,
+		},
+		{
+			"invalid_depth",
+			[]string{"-recursive", "-depth", "-2", "secret/foo"},
+			"Invalid recursion depth: -2",
+			1,
+		},
+		{
+			"invalid_regexp",
+			[]string{"-recursive", "-filter", "*", "secret/foo"},
+			"Invalid regular expression: *",
+			1,
+		},
+		{
+			"invalid_concurrency",
+			[]string{"-recursive", "-concurrent", "0", "secret/foo"},
+			"Invalid concurrency value: 0",
+			1,
+		},
+		{
+			"not_found",
+			[]string{"secret/nope/not/once/never"},
+			"No value found at secret/nope/not/once/never",
+			2,
+		},
+		{
+			"default",
+			[]string{"secret/list"},
+			"bar/\nbaz/\nfoo/",
+			0,
+		},
+		{
+			"default_slash",
+			[]string{"secret/list/"},
+			"bar/\nbaz/\nfoo/",
+			0,
+		},
+		{
+			"recursive",
+			[]string{"-recursive", "secret/list"},
+			"secret/list/bar/\n" +
+				"secret/list/bar/grault\n" +
+				"secret/list/baz/\n" +
+				"secret/list/baz/xyzzy/\n" +
+				"secret/list/baz/xyzzy/thud\n" +
+				"secret/list/baz/xyzzy/waldo\n" +
+				"secret/list/foo/\n" +
+				"secret/list/foo/grault/\n" +
+				"secret/list/foo/grault/garply\n" +
+				"secret/list/foo/qux/\n" +
+				"secret/list/foo/qux/quux",
+			0,
+		},
+		{
+			"recursive_with_depth",
+			[]string{"-recursive", "-depth", "2", "secret/list"},
+			"secret/list/bar/\nsecret/list/baz/\nsecret/list/foo/",
+			0,
+		},
+		{
+			"recursive_with_filter",
+			[]string{"-recursive", "-filter", "xyz+y", "secret/list"},
+			"secret/list/baz/xyzzy/thud\nsecret/list/baz/xyzzy/waldo",
+			0,
+		},
+		{
+			"recursive_with_filter_depth",
+			[]string{"-recursive", "-depth", "2", "-filter", "/f.*", "secret/list"},
+			"secret/list/foo/",
+			0,
+		},
+	}
+
+	t.Run("validations", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			tc := tc
+
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				client, closer := testVaultServer(t)
+				defer closer()
+
+				keys := []string{
+					"secret/list/foo/qux/quux",
+					"secret/list/foo/grault/garply",
+					"secret/list/bar/grault",
+					"secret/list/baz/xyzzy/thud",
+					"secret/list/baz/xyzzy/waldo",
+				}
+				for _, k := range keys {
+					if _, err := client.Logical().Write(k, map[string]interface{}{
+						"foo": "bar",
+					}); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				ui, cmd := testKVListCommand(t)
+				cmd.client = client
+
+				code := cmd.Run(tc.args)
+				if code != tc.code {
+					t.Errorf("expected %d to be %d", code, tc.code)
+				}
+
+				combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+				if !strings.Contains(combined, tc.out) {
+					t.Errorf("expected %q to contain %q", combined, tc.out)
+				}
+			})
+		}
+	})
+
+	t.Run("communication_failure", func(t *testing.T) {
+		t.Parallel()
+
+		client, closer := testVaultServerBad(t)
+		defer closer()
+
+		ui, cmd := testListCommand(t)
+		cmd.client = client
+
+		code := cmd.Run([]string{
+			"secret/list",
+		})
+		if exp := 2; code != exp {
+			t.Errorf("expected %d to be %d", code, exp)
+		}
+
+		expected := "Error listing secret/list/: "
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		if !strings.Contains(combined, expected) {
+			t.Errorf("expected %q to contain %q", combined, expected)
+		}
+	})
+
+	t.Run("no_tabs", func(t *testing.T) {
+		t.Parallel()
+
+		_, cmd := testListCommand(t)
+		assertNoTabs(t, cmd)
+	})
+}


### PR DESCRIPTION
```
Adds `-recursive', `-depth', `-filter' and `-concurrent' flags to
vault CLI's `kv list' subcommand.

Description of the flags:
    * recursive     Recursively list data for a given path.
    * depth         Specifies the depth for recursive listing.
    * filter        Specifies a regular expression for filtering paths.
    * concurrent    Specifies the number of concurrent recursions to run.
```
Reference: https://github.com/hashicorp/vault/issues/5275.