### PR TITLE
api.NewClient() now uses $VAULT_NAMESPACE as an input.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -422,6 +422,10 @@ func NewClient(c *Config) (*Client, error) {
 		client.token = token
 	}
 
+	if namespace := os.Getenv(EnvVaultNamespace); namespace != "" {
+		client.SetNamespace(namespace)
+	}
+
 	return client, nil
 }
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -213,13 +213,11 @@ func TestClientEnvNamespace(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Do a raw "/" request
 	_, err = client.RawRequest(client.NewRequest("GET", "/"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Verify we got the response from the primary
 	if seenNamespace != "test" {
 		t.Fatalf("Bad: %s", seenNamespace)
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"github.com/hashicorp/vault/helper/consts"
 	"io"
 	"net/http"
 	"os"
@@ -192,6 +193,35 @@ func TestClientEnvSettings(t *testing.T) {
 	}
 	if tlsConfig.InsecureSkipVerify != true {
 		t.Fatalf("bad: %v", tlsConfig.InsecureSkipVerify)
+	}
+}
+
+func TestClientEnvNamespace(t *testing.T) {
+	var seenNamespace string
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		seenNamespace = req.Header.Get(consts.NamespaceHeaderName)
+	}
+	config, ln := testHTTPServer(t, http.HandlerFunc(handler))
+	defer ln.Close()
+
+	oldVaultNamespace := os.Getenv(EnvVaultNamespace)
+	defer os.Setenv(EnvVaultNamespace, oldVaultNamespace)
+	os.Setenv(EnvVaultNamespace, "test")
+
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Do a raw "/" request
+	_, err = client.RawRequest(client.NewRequest("GET", "/"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Verify we got the response from the primary
+	if seenNamespace != "test" {
+		t.Fatalf("Bad: %s", seenNamespace)
 	}
 }
 


### PR DESCRIPTION
Fixes #6438.