### PR TITLE
recompute has-permissions helper on permission service attr change 

### DIFF
--- a/ui/app/helpers/has-permission.js
+++ b/ui/app/helpers/has-permission.js
@@ -1,8 +1,18 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
+import { observer } from '@ember/object';
 
 export default Helper.extend({
   permissions: service(),
+  onPermissionsChange: observer(
+    'permissions.exactPaths',
+    'permissions.globPaths',
+    'permissions.canViewAll',
+    function() {
+      this.recompute();
+    }
+  ),
+
   compute([route], { routeParams, capability }) {
     let permissions = this.permissions;
     return permissions.hasNavPermission(route, routeParams, capability);

--- a/ui/tests/integration/helpers/has-permission-test.js
+++ b/ui/tests/integration/helpers/has-permission-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { run } from '@ember/runloop';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+const Permissions = Service.extend({
+  globPaths: null,
+  hasNavPermission() {
+    return this.globPaths ? true : false;
+  },
+});
+
+module('Integration | Helper | has-permission', function(hooks) {
+  setupRenderingTest(hooks);
+  hooks.beforeEach(function() {
+    this.owner.register('service:permissions', Permissions);
+    this.permissions = this.owner.lookup('service:permissions');
+  });
+
+  test('it renders', async function(assert) {
+    await render(hbs`{{#if (has-permission)}}Yes{{else}}No{{/if}}`);
+
+    assert.equal(this.element.textContent.trim(), 'No');
+    await run(() => {
+      this.permissions.set('globPaths', { 'test/': { capabilities: ['update'] } });
+    });
+    assert.equal(this.element.textContent.trim(), 'Yes', 'the helper re-computes when globPaths changes');
+  });
+});


### PR DESCRIPTION
Previously, if a user was in a namespace, and switched - the navigation would stay the same as the previous namespace because the main nav doesn't get re-rendered and the `has-permission` helper shows the stale value. Now, we call the helper's `recompute` method when attributes on the permission service change.

To test using Vault Enterprise:

1. create a namespace (I did one called “test”)
2. enable userpass, create a user, and log in with them - give the user the default policy
3. create a policy called “test-admin” where the content is  `path "test/*" { capabilities = [ "create", "read", "list", "delete", "update" ] }` 
4. log in with the userpass user so that Vault generates an entity
5. (I did this in the UI) look up the entity and edit it - where it asks what policies to assign, add the `test-admin` policy
6. log in with the user in the root namespace
7. switch to the “test” namespace
8. the "Policies" tab should show up in the test namespace and disappear in the root namespace
