### PR TITLE
use proto() not prototype

### DIFF
--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -38,10 +38,11 @@ export default Service.extend({
   getNewModel(modelType, owner, backend) {
     let name = `model:${modelType}`;
     let newModel = owner.factoryFor(name).class;
-    if (newModel.merged || newModel.prototype.useOpenAPI !== true) {
+    let modelProto = newModel.proto();
+    if (newModel.merged || modelProto.useOpenAPI !== true) {
       return resolve();
     }
-    let helpUrl = newModel.prototype.getHelpUrl(backend);
+    let helpUrl = modelProto.getHelpUrl(backend);
 
     return this.getProps(helpUrl, backend).then(props => {
       if (owner.hasRegistration(name) && !newModel.merged) {


### PR DESCRIPTION
In dev, the prototype was already populated - this isn't true of ember apps in production - they're populated lazily by calling `proto()`, so that's what we're doing now.

To test:

1. Build the UI with `make static-dist dev-ui`
2. Run the built binary and verify items that should be using OpenAPI do (PKI roles, and LDAP auth config are good candidates)

Fixes #6465