### PR TITLE
always show secrets tab in the main nav

### DIFF
--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -2,7 +2,6 @@ import Service, { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 
 const API_PATHS = {
-  secrets: { engine: 'cubbyhole/' },
   access: {
     methods: 'sys/auth',
     entities: 'identity/entities',

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -17,18 +17,16 @@
             </NamespacePicker>
           </li>
         {{/if}}
-        {{#if (has-permission 'secrets')}}
-          <li class="{{if (is-active-route 'vault.cluster.secrets') 'is-active'}}">
-            {{#link-to
-              "vault.cluster.secrets"
-              current-when="vault.cluster.secrets vault.cluster.settings.mount-secret-backend vault.cluster.settings.configure-secret-backend"
-              invokeAction=(action Nav.closeDrawer)
-              data-test-navbar-item='secrets'
-            }}
-              Secrets
-            {{/link-to}}
-          </li>
-        {{/if}}
+        <li class="{{if (is-active-route 'vault.cluster.secrets') 'is-active'}}">
+          {{#link-to
+            "vault.cluster.secrets"
+            current-when="vault.cluster.secrets vault.cluster.settings.mount-secret-backend vault.cluster.settings.configure-secret-backend"
+            invokeAction=(action Nav.closeDrawer)
+            data-test-navbar-item='secrets'
+          }}
+            Secrets
+          {{/link-to}}
+        </li>
         {{#if (has-permission 'access')}}
           <li class="{{if (is-active-route 'vault.cluster.access') 'is-active'}}">
             {{#link-to

--- a/ui/tests/acceptance/cluster-test.js
+++ b/ui/tests/acceptance/cluster-test.js
@@ -39,21 +39,6 @@ module('Acceptance | cluster', function(hooks) {
     await logout.visit();
   });
 
-  test('shows nav item if user does have permission', async function(assert) {
-    const read_secrets_policy = `'
-      path "cubbyhole/" {
-        capabilities = ["read"]
-      },
-    '`;
-
-    const userToken = await tokenWithPolicy('show-secrets-nav', read_secrets_policy);
-    await logout.visit();
-    await authPage.login(userToken);
-
-    assert.dom('[data-test-navbar-item=secrets]').exists();
-    await logout.visit();
-  });
-
   test('enterprise nav item links to first route that user has access to', async function(assert) {
     const read_rgp_policy = `'
       path "sys/policies/rgp" {


### PR DESCRIPTION
Currently we rely on access to cubbyhole to show the secrets tab, but this isn't a very good indicator if users have access to secrets. Instead, we're just going to always show the secrets nav item and the API call will filter mounts appropriately (the API we use will only return mounts they have access to).

To test: 

1. Create a policy w/o access to cubbyhole - `path "secret*" { capabilities = [ "read" ] }`
2. Create a token with that policy
3. Log in to the UI with that new token
4. Verify that Secrets still shows up in the main navigation