### PR TITLE
add support for authenticating with RADIUS

### DIFF
--- a/ui/app/adapters/cluster.js
+++ b/ui/app/adapters/cluster.js
@@ -146,6 +146,7 @@ export default ApplicationAdapter.extend({
       userpass: `login/${encodeURIComponent(username)}`,
       ldap: `login/${encodeURIComponent(username)}`,
       okta: `login/${encodeURIComponent(username)}`,
+      radius: `login/${encodeURIComponent(username)}`,
       token: 'lookup-self',
     };
     const urlSuffix = authURLs[authBackend];

--- a/ui/app/helpers/supported-auth-backends.js
+++ b/ui/app/helpers/supported-auth-backends.js
@@ -50,6 +50,14 @@ const SUPPORTED_AUTH_BACKENDS = [
     formAttributes: ['role', 'jwt'],
   },
   {
+    type: 'radius',
+    typeDisplay: 'RADIUS',
+    description: 'Authenticate with your RADIUS username and password.',
+    tokenPath: 'client_token',
+    displayNamePath: 'metadata.username',
+    formAttributes: ['username', 'password'],
+  },
+  {
     type: 'github',
     typeDisplay: 'GitHub',
     description: 'GitHub authentication.',

--- a/ui/app/templates/partials/auth-form/radius.hbs
+++ b/ui/app/templates/partials/auth-form/radius.hbs
@@ -1,0 +1,1 @@
+{{partial "partials/userpass-form"}}

--- a/ui/tests/unit/adapters/cluster-test.js
+++ b/ui/tests/unit/adapters/cluster-test.js
@@ -96,6 +96,15 @@ module('Unit | Adapter | cluster', function(hooks) {
       'auth:userpass options OK'
     );
 
+    adapter.authenticate({ backend: 'radius', data });
+    assert.equal('/v1/auth/radius/login/username', url, 'auth:RADIUS url OK');
+    assert.equal('POST', method, 'auth:RADIUS method OK');
+    assert.deepEqual(
+      { data: { password: 'password' }, unauthenticated: true },
+      options,
+      'auth:RADIUS options OK'
+    );
+
     adapter.authenticate({ backend: 'LDAP', data });
     assert.equal('/v1/auth/ldap/login/username', url, 'ldap:userpass url OK');
     assert.equal('POST', method, 'ldap:userpass method OK');


### PR DESCRIPTION
I tested this manually with freeradius-servers's [docker container](https://hub.docker.com/r/freeradius/freeradius-server).

![RADIUS](https://user-images.githubusercontent.com/39469/55106333-a67f6d80-509c-11e9-94b5-bf5db32f9d0a.gif)
