### PR TITLE
Remove --disable-dev-shm-usage flag in CI

### DIFF
--- a/ui/testem.js
+++ b/ui/testem.js
@@ -12,7 +12,6 @@ module.exports = {
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
         '--disable-gpu',
-        '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',
         '--remote-debugging-port=0',


### PR DESCRIPTION
This flag breaks the UI tests in some environments (ex: running in Docker with the `node:10-stretch` official image) when using the latest stable version of Chrome (73).