### PR TITLE
Use option.WithCredentialsFile() instead of deprecated method

### DIFF
--- a/physical/gcs/gcs.go
+++ b/physical/gcs/gcs.go
@@ -148,7 +148,7 @@ func NewBackend(c map[string]string, logger log.Logger) (physical.Backend, error
 		logger.Warn("specifying credentials_file as an option is " +
 			"deprecated. Please use the GOOGLE_APPLICATION_CREDENTIALS environment " +
 			"variable or instance credentials instead.")
-		opts = append(opts, option.WithServiceAccountFile(credentialsFile))
+		opts = append(opts, option.WithCredentialsFile(credentialsFile))
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
`WithServiceAccountFile` is deprecated. 

https://github.com/hashicorp/vault/blob/f2233d7a1c671e61c656e90e5d76528a668e0604/vendor/google.golang.org/api/option/option.go#L59-L62