### PR TITLE
reset pageFilter when the model changes

### DIFF
--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -159,8 +159,9 @@ export default Route.extend({
 
   resetController(controller, isExiting) {
     this._super(...arguments);
+    controller.set('pageFilter', null);
     if (isExiting) {
-      controller.set('filter', '');
+      controller.set('filter', null);
     }
   },
 

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -159,8 +159,8 @@ export default Route.extend({
 
   resetController(controller, isExiting) {
     this._super(...arguments);
-    controller.set('pageFilter', null);
     if (isExiting) {
+      controller.set('pageFilter', null);
       controller.set('filter', null);
     }
   },

--- a/ui/app/templates/components/key-value-header.hbs
+++ b/ui/app/templates/components/key-value-header.hbs
@@ -4,7 +4,8 @@
     <li class="{{if (is-active-route path.path path.model isExact=true) 'is-active'}}">
       <span class="sep">&#x0002f;</span>
       {{#if linkToPaths}}
-        {{#link-to params=(array path.path path.model) data-test-secret-root-link=(if (eq index 0) true false)}}
+        {{#link-to params=(array path.path path.model) data-test-secret-root-link=(if (eq index 0) true false) data-test-secret-breadcrumb=path.text}}
+
           {{path.text}}
         {{/link-to}}
       {{else}}

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -16,6 +16,7 @@
             shouldNavigateTree=options.navigateTree
             placeholder=options.searchPlaceholder
             mode=(if (eq tab 'certs') 'secrets-cert' 'secrets')
+            data-test-nav-input=true
           }}
           {{#if filterFocused}}
             {{#if filterMatchesKey}}

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -317,4 +317,22 @@ module('Acceptance | secrets/secret/create', function(hooks) {
       `${path}: show page renders correctly`
     );
   });
+
+  test('filter clears on nav', async function(assert) {
+    await consoleComponent.runCommands([
+      'vault write sys/mounts/test type=kv',
+      'refresh',
+      'vault write test/filter/foo keys=a keys=b',
+      'vault write test/filter/foo1 keys=a keys=b',
+      'vault write test/filter/foo2 keys=a keys=b',
+    ]);
+    await listPage.visit({ backend: 'test', id: 'filter' });
+    assert.equal(listPage.secrets.length, 3, 'renders three secrets');
+    await listPage.filterInput('filter/foo1');
+    assert.equal(listPage.secrets.length, 1, 'renders only one secret');
+    await listPage.secrets[0].click();
+    await showPage.breadcrumbs.filterBy('text', 'filter')[0].click();
+    assert.equal(listPage.secrets.length, 3, 'renders three secrets');
+    assert.equal(listPage.filterInputValue, 'filter/', 'pageFilter has been reset');
+  });
 });

--- a/ui/tests/pages/secrets/backend/kv/show.js
+++ b/ui/tests/pages/secrets/backend/kv/show.js
@@ -1,9 +1,12 @@
 import { Base } from '../show';
-import { create, clickable, collection, isPresent } from 'ember-cli-page-object';
+import { create, clickable, collection, isPresent, text } from 'ember-cli-page-object';
 import { code } from 'vault/tests/pages/helpers/codemirror';
 
 export default create({
   ...Base,
+  breadcrumbs: collection('[data-test-secret-breadcrumb]', {
+    text: text(),
+  }),
   deleteBtn: clickable('[data-test-secret-delete] button'),
   confirmBtn: clickable('[data-test-confirm-button]'),
   rows: collection('data-test-row-label'),

--- a/ui/tests/pages/secrets/backend/list.js
+++ b/ui/tests/pages/secrets/backend/list.js
@@ -1,4 +1,13 @@
-import { create, collection, text, visitable, clickable, isPresent } from 'ember-cli-page-object';
+import {
+  create,
+  collection,
+  fillable,
+  text,
+  visitable,
+  value,
+  clickable,
+  isPresent,
+} from 'ember-cli-page-object';
 import { getter } from 'ember-cli-page-object/macros';
 
 export default create({
@@ -9,6 +18,8 @@ export default create({
   configure: clickable('[data-test-secret-backend-configure]'),
   configureIsPresent: isPresent('[data-test-secret-backend-configure]'),
   tabs: collection('[data-test-tab]'),
+  filterInput: fillable('[data-test-nav-input] input'),
+  filterInputValue: value('[data-test-nav-input] input'),
   secrets: collection('[data-test-secret-link]', {
     menuToggle: clickable('[data-test-popup-menu-trigger]'),
     id: text(),


### PR DESCRIPTION
Currently when navigating secrets via the filter input, the `pageFilter` query param is "sticky" - while this is the default behavior in Ember, this can be surprising when you are redirected or navigate to a list, only to find that a filter is still applied.

This PR changes the secret list routes so that pageFilter gets reset when the model changes resulting in unfiltered lists when when navigating through the tree.
