### PR TITLE
Fix hasMountPath for segment wildcard mounts; introduce priority order

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -530,7 +530,7 @@ func (a *ACL) CheckAllowedFromSegmentWildcardPaths(path string, bareMount bool) 
 	// * Total path segments (prefer foo/bar/+/baz/why over foo/bar/+/ba*)
 	// * Whether it's a prefix (prefer foo/+/bar over foo/+/ba*)
 	// * Length check (prefer foo/+/bar/ba* over foo/+/bar/b*)
-	// * Lexigraphical ordering (preferring less, arbitrarily)
+	// * Lexicographical ordering (preferring less, arbitrarily)
 	//
 	// That final case (lexigraphical) should never really come up. It's more
 	// of a throwing-up-hands scenario akin to panic("should not be here")

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -651,15 +651,16 @@ func (a *ACL) CheckAllowedFromSegmentWildcardPaths(path string, bareMount bool) 
 				// Matches anything in the segment, so keep checking
 				constructedPath = append(constructedPath, pathParts[i])
 				skipAfterConsPathCheck = true
+			} else {
+				constructedPath = append(constructedPath, aclPart)
 			}
-			constructedPath = append(constructedPath, aclPart)
 			if bareMount {
 				joinedConstructedPath := strings.Join(constructedPath, "/")
 				// Check the current joined path so far. If we find a prefix,
 				// check permissions. If they're defined but not deny, success.
 				if strings.HasPrefix(joinedConstructedPath, path) {
 					permissions = a.segmentWildcardPaths[origCurrWCPath].(*ACLPermissions)
-					if permissions.CapabilitiesBitmap&DenyCapabilityInt == 0 && perms.CapabilitiesBitmap > 0 {
+					if permissions.CapabilitiesBitmap&DenyCapabilityInt == 0 && permissions.CapabilitiesBitmap > 0 {
 						return permissions
 					} else {
 						// If we already found a match and the permissions

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -524,9 +524,10 @@ func (a *ACL) CheckAllowedFromNonExactPaths(path string, bareMount bool) *ACLPer
 		// In the case of multiple matches, we use this priority order,
 		// which tries to most closely match longest-prefix:
 		//
-		// * First wildcard position (prefer foo/bar/+/baz over foo/+/bar/baz)
+		// * First glob or wildcard position (prefer foo/a* over foo/+,
+		//   foo/bar/+/baz over foo/+/bar/baz)
 		// * Whether it's a prefix (prefer foo/+/bar over foo/+/ba*,
-		//   foo/+/+ over foo/*)
+		//   foo/+ over foo/*)
 		// * Number of wildcard segments (prefer foo/bar/+/baz over foo/+/+/baz)
 		// * Length check (prefer foo/+/bar/ba* over foo/+/bar/b*)
 		// * Lexicographical ordering (preferring less, arbitrarily)

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -632,7 +632,7 @@ func (a *ACL) CheckAllowedFromSegmentWildcardPaths(path string, bareMount bool) 
 							// Carry on checking
 						} else {
 							// At this point do a length check; failing that do
-							// a lexigraphical ordering. I actually can't
+							// a lexicographical ordering. I actually can't
 							// figure out when we'd get to the lexigraphical
 							// case, based on coming up with test cases, so
 							// it's for safety more than anyting else.

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -541,7 +541,7 @@ func (a *ACL) CheckAllowedFromSegmentWildcardPaths(path string, bareMount bool) 
 
 		var isPrefix bool
 		var invalid bool
-		var segments int
+		var wcSegments int
 		var firstWC int = -1
 
 		origCurrWCPath := currWCPath
@@ -552,8 +552,8 @@ func (a *ACL) CheckAllowedFromSegmentWildcardPaths(path string, bareMount bool) 
 		}
 		splitCurrWCPath := strings.Split(currWCPath, "/")
 		if !bareMount && len(pathParts) < len(splitCurrWCPath) {
-			// If not a bare mount, the path coming in is shorter; it can't
-			// match
+			// If not a bare mount, check if the path coming in is shorter; if
+			// so it can't match
 			continue
 		}
 		if !isPrefix && !bareMount && len(splitCurrWCPath) != len(pathParts) {
@@ -570,7 +570,7 @@ func (a *ACL) CheckAllowedFromSegmentWildcardPaths(path string, bareMount bool) 
 		if !bareMount {
 			for i, part := range splitCurrWCPath {
 				if part == "+" {
-					segments++
+					wcSegments++
 					if firstWC == -1 {
 						firstWC = i
 					}
@@ -595,10 +595,10 @@ func (a *ACL) CheckAllowedFromSegmentWildcardPaths(path string, bareMount bool) 
 				switch {
 				// totalWildcardSegment segments will always be greater than
 				// zero if totalPathSegments is
-				case totalWildcardSegments > segments:
+				case totalWildcardSegments > wcSegments:
 					// Continue on here; if it matches, this is less segments so we
 					// want to use that as it's more specific
-				case totalWildcardSegments < segments:
+				case totalWildcardSegments < wcSegments:
 					// What we have is more specific already, so use that
 					continue
 				default:
@@ -704,7 +704,7 @@ func (a *ACL) CheckAllowedFromSegmentWildcardPaths(path string, bareMount bool) 
 		if !invalid && !bareMount {
 			permissions = a.segmentWildcardPaths[origCurrWCPath].(*ACLPermissions)
 			totalPathSegments = len(splitCurrWCPath)
-			totalWildcardSegments = segments
+			totalWildcardSegments = wcSegments
 			currIsPrefix = isPrefix
 			currFoundPath = origCurrWCPath
 			currFirstWC = firstWC

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -633,7 +633,7 @@ func (a *ACL) CheckAllowedFromSegmentWildcardPaths(path string, bareMount bool) 
 						} else {
 							// At this point do a length check; failing that do
 							// a lexicographical ordering. I actually can't
-							// figure out when we'd get to the lexigraphical
+							// figure out when we'd get to the lexicographical
 							// case, based on coming up with test cases, so
 							// it's for safety more than anyting else.
 							switch {

--- a/vault/acl.go
+++ b/vault/acl.go
@@ -532,7 +532,7 @@ func (a *ACL) CheckAllowedFromSegmentWildcardPaths(path string, bareMount bool) 
 	// * Length check (prefer foo/+/bar/ba* over foo/+/bar/b*)
 	// * Lexicographical ordering (preferring less, arbitrarily)
 	//
-	// That final case (lexigraphical) should never really come up. It's more
+	// That final case (lexicographical) should never really come up. It's more
 	// of a throwing-up-hands scenario akin to panic("should not be here")
 	// statements, but less panicky.
 	var totalPathSegments int

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -777,7 +777,7 @@ func TestACL_SegmentWildcardPriority_BareMount(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		hasperms := nil != acl.CheckAllowedFromSegmentWildcardPaths(pt.mountpath, true)
+		hasperms := nil != acl.CheckAllowedFromNonExactPaths(pt.mountpath, true)
 		if hasperms != pt.hasperms {
 			t.Fatalf("bad: case %d: %#v", i, pt)
 		}
@@ -869,7 +869,7 @@ path "test/+/wildcardglob/+/end*" {
 path "1/2/*" {
 	capabilities = ["read"]
 }
-path "1/2/+/4" {
+path "1/2/+/+" {
 	capabilities = ["update"]
 }
 `

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -765,6 +765,11 @@ func TestACL_SegmentWildcardPriority_BareMount(t *testing.T) {
 			"foo/bar/bar/baz/",
 			true,
 		},
+		{
+			`path "foo/+" { capabilities = ["read"] }`,
+			"foo/",
+			true,
+		},
 	}
 
 	for i, pt := range poltests {

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -250,6 +250,12 @@ func testACLSingle(t *testing.T, ns *namespace.Namespace) {
 		{logical.ReadOperation, "test/segment/wildcard/at/foo/", true, false},
 		{logical.ReadOperation, "test/segment/wildcard/at/end", true, false},
 		{logical.ReadOperation, "test/segment/wildcard/at/end/", true, false},
+
+		// Path segment wildcards vs glob
+		{logical.ReadOperation, "1/2/3/4", false, false},
+		{logical.ReadOperation, "1/2/3", true, false},
+		{logical.UpdateOperation, "1/2/3", false, false},
+		{logical.UpdateOperation, "1/2/3/4", true, false},
 	}
 
 	for _, tc := range tcases {
@@ -859,6 +865,12 @@ path "test/+/wildcard/+/*" {
 }
 path "test/+/wildcardglob/+/end*" {
 	capabilities = ["read"]
+}
+path "1/2/*" {
+	capabilities = ["read"]
+}
+path "1/2/+/4" {
+	capabilities = ["update"]
 }
 `
 

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -606,36 +606,27 @@ func TestACL_SegmentWildcardPriority(t *testing.T) {
 	poltests := []poltest{
 
 		{
-			// Verify edge conditions.  Here '+/*' is more specific because
-			// of length.  Not useful, but test is included to document it.
-			`
-path "+*" { capabilities = ["read"] }
-path "+/*" { capabilities = ["update"] }
-`,
-			"foo/bar/bar/baz",
-		},
-		{
 			// Verify edge conditions.  Here '*' is more specific both because
 			// of first wildcard position (0 vs -1/infinity) and #wildcards.
 			`
-path "+*" { capabilities = ["read"] }
+path "+/*" { capabilities = ["read"] }
 path "*" { capabilities = ["update"] }
 `,
 			"foo/bar/bar/baz",
 		},
 		{
-			// Verify edge conditions.  Here '+*' is less specific because of
+			// Verify edge conditions.  Here '+/*' is less specific because of
 			// first wildcard position.
 			`
-path "+*" { capabilities = ["read"] }
-path "foo/+*" { capabilities = ["update"] }
+path "+/*" { capabilities = ["read"] }
+path "foo/+/*" { capabilities = ["update"] }
 `,
 			"foo/bar/bar/baz",
 		},
 		{
 			// Verify that more wildcard segments is lower priority.
 			`
-path "foo/+/+*" { capabilities = ["read"] }
+path "foo/+/+/*" { capabilities = ["read"] }
 path "foo/+/bar/baz" { capabilities = ["update"] }
 `,
 			"foo/bar/bar/baz",
@@ -723,29 +714,29 @@ func TestACL_SegmentWildcardPriority_BareMount(t *testing.T) {
 			true,
 		},
 		{
-			`path "+*" { capabilities = ["read"] }`,
+			`path "+/*" { capabilities = ["read"] }`,
 			"foo/",
 			true,
 		},
 		{
-			`path "foo/+/+*" { capabilities = ["read"] }`,
+			`path "foo/+/+/*" { capabilities = ["read"] }`,
 			"foo/",
 			true,
 		},
 		{
-			`path "foo/+/+*" { capabilities = ["read"] }`,
+			`path "foo/+/+/*" { capabilities = ["read"] }`,
 			"foo/bar/",
 			true,
 		},
 		{
-			`path "foo/+/+*" { capabilities = ["read"] }`,
+			`path "foo/+/+/*" { capabilities = ["read"] }`,
 			"foo/bar/bar/",
 			true,
 		},
 		{
-			`path "foo/+/+*" { capabilities = ["read"] }`,
+			`path "foo/+/+/*" { capabilities = ["read"] }`,
 			"foo/bar/bar/baz/",
-			false,
+			true,
 		},
 		{
 			`path "foo/+/+/baz" { capabilities = ["read"] }`,

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -256,6 +256,7 @@ func testACLSingle(t *testing.T, ns *namespace.Namespace) {
 		{logical.ReadOperation, "1/2/3", true, false},
 		{logical.UpdateOperation, "1/2/3", false, false},
 		{logical.UpdateOperation, "1/2/3/4", true, false},
+		{logical.CreateOperation, "1/2/3/4/5", true, false},
 	}
 
 	for _, tc := range tcases {
@@ -867,6 +868,9 @@ path "test/+/wildcardglob/+/end*" {
 	capabilities = ["read"]
 }
 path "1/2/*" {
+	capabilities = ["create"]
+}
+path "1/2/+" {
 	capabilities = ["read"]
 }
 path "1/2/+/+" {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2819,7 +2819,7 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 		return false
 	}
 
-	// If an earlier policy is giving us access to the mount path then we can do
+	// If a policy is giving us direct access to the mount path then we can do
 	// a fast return.
 	capabilities := acl.Capabilities(ctx, ns.TrimmedPath(path))
 	if !strutil.StrListContains(capabilities, DenyCapability) {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2846,6 +2846,7 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 			perms.CapabilitiesBitmap&UpdateCapabilityInt > 0:
 
 			aclCapabilitiesGiven = true
+
 			return true
 		}
 
@@ -2855,6 +2856,12 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 	acl.exactRules.WalkPrefix(path, walkFn)
 	if !aclCapabilitiesGiven {
 		acl.prefixRules.WalkPrefix(path, walkFn)
+	}
+
+	if !aclCapabilitiesGiven {
+		if perms := acl.CheckAllowedFromSegmentWildcardPaths(path, true); perms != nil {
+			return true
+		}
 	}
 
 	return aclCapabilitiesGiven

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2859,7 +2859,7 @@ func hasMountAccess(ctx context.Context, acl *ACL, path string) bool {
 	}
 
 	if !aclCapabilitiesGiven {
-		if perms := acl.CheckAllowedFromSegmentWildcardPaths(path, true); perms != nil {
+		if perms := acl.CheckAllowedFromNonExactPaths(path, true); perms != nil {
 			return true
 		}
 	}

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -339,7 +339,11 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 		// Ensure we are using the full request path internally
 		pc.Path = result.namespace.Path + pc.Path
 
-		if pc.Path == "+" || pc.Path == "+*" || strings.Count(pc.Path, "/+") > 0 || strings.HasPrefix(pc.Path, "+/") {
+		if strings.Contains(pc.Path, "+*") {
+			return fmt.Errorf("path %q: invalid use of wildcards ('+*' is forbidden)", pc.Path)
+		}
+
+		if pc.Path == "+" || strings.Count(pc.Path, "/+") > 0 || strings.HasPrefix(pc.Path, "+/") {
 			pc.HasSegmentWildcards = true
 		}
 

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -339,7 +339,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 		// Ensure we are using the full request path internally
 		pc.Path = result.namespace.Path + pc.Path
 
-		if strings.Count(pc.Path, "/+") > 0 || strings.HasPrefix(pc.Path, "+/") {
+		if pc.Path == "+" || pc.Path == "+*" || strings.Count(pc.Path, "/+") > 0 || strings.HasPrefix(pc.Path, "+/") {
 			pc.HasSegmentWildcards = true
 		}
 

--- a/vault/policy_test.go
+++ b/vault/policy_test.go
@@ -414,3 +414,18 @@ path "/" {
 		t.Errorf("bad error: %s", err)
 	}
 }
+
+func TestPolicy_ParseBadSegmentWildcard(t *testing.T) {
+	_, err := ParseACLPolicy(namespace.RootNamespace, strings.TrimSpace(`
+path "foo/+*" {
+	capabilities = ["read"]
+}
+`))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	if !strings.Contains(err.Error(), `path "foo/+*": invalid use of wildcards ('+*' is forbidden)`) {
+		t.Errorf("bad error: %s", err)
+	}
+}


### PR DESCRIPTION
This fixes `hasMountPath` when operating on segment wildcards, fixing the kv preflight check. As a part of this, I also introduce a longest-prefix priority ordering for cases where you have path segment wildcards in multiple paths. This will need some explanation in docs but for now it's well-commented.

Fixes #6525 