### PR TITLE
ui/storybook/add form components

### DIFF
--- a/ui/.storybook/addons.js
+++ b/ui/.storybook/addons.js
@@ -1,4 +1,3 @@
-import '@storybook/addon-actions/register';
 import '@storybook/addon-links/register';
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-notes/register';

--- a/ui/app/components/auth-config-form/config.js
+++ b/ui/app/components/auth-config-form/config.js
@@ -12,7 +12,7 @@ import DS from 'ember-data';
  * {{auth-config-form/config model.model}}
  * ```
  *
- * @property model=null {String} - The corresponding auth model that is being configured.
+ * @property model=null {DS.Model} - The corresponding auth model that is being configured.
  *
  */
 

--- a/ui/app/components/auth-config-form/options.js
+++ b/ui/app/components/auth-config-form/options.js
@@ -12,7 +12,7 @@ import DS from 'ember-data';
  * {{auth-config-form/options model.model}}
  * ```
  *
- * @property model=null {String} - The corresponding auth model that is being configured.
+ * @property model=null {DS.Model} - The corresponding auth model that is being configured.
  *
  */
 

--- a/ui/app/components/form-field-groups.js
+++ b/ui/app/components/form-field-groups.js
@@ -1,30 +1,39 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
+/**
+ * @module FormFieldGroups
+ * `FormFieldGroups` components are field groups associated with a particular model. They render individual `FormField` components.
+ *
+ * @example
+ * ```js
+ * {{if model.fieldGroups}}
+ *  <FormFieldGroups @model={{model}} />
+ * {{/if}}
+ *
+ * ...
+ *
+ * <FormFieldGroups
+ *  @model={{mountModel}}
+ *  @onChange={{action "onTypeChange"}}
+ *  @renderGroup="Method Options"
+ * />
+ * ```
+ *
+ * @param [renderGroup=null] {String} - A whitelist of groups to include in the render.
+ * @param model=null {DS.Model} - Model to be passed down to form-field component. If `fieldGroups` is present on the model then it will be iterated over and groups of `FormField` components will be rendered.
+ * @param onChange=null {Func} - Handler that will get set on the `FormField` component.
+ *
+ */
+
 export default Component.extend({
   tagName: '',
 
-  /*
-   * @public String
-   * A whitelist of groups to include in the render
-   */
   renderGroup: computed(function() {
     return null;
   }),
 
-  /*
-   * @public DS.Model
-   * model to be passed down to form-field component
-   * if `fieldGroups` is present on the model then it will be iterated over and
-   * groups of `form-field` components will be rendered
-   *
-   */
   model: null,
 
-  /*
-   * @public Function
-   * onChange handler that will get set on the form-field component
-   *
-   */
   onChange: () => {},
 });

--- a/ui/app/components/form-field.js
+++ b/ui/app/components/form-field.js
@@ -4,15 +4,27 @@ import { capitalize } from 'vault/helpers/capitalize';
 import { humanize } from 'vault/helpers/humanize';
 import { dasherize } from 'vault/helpers/dasherize';
 
+/**
+ * @module FormField
+ * `FormField` components are field elements associated with a particular model.
+ *
+ * @example
+ * ```js
+ * {{#each @model.fields as |attr|}}
+ *  <FormField data-test-field @attr={{attr}} @model={{this.model}} />
+ * {{/each}}
+ * ```
+ *
+ * @param [onChange=null] {Func} - Called whenever a value on the model changes via the component.
+ * @param attr=null {Object} - This is usually derived from ember model `attributes` lookup, and all members of `attr.options` are optional.
+ * @param model=null {DS.Model} - The Ember Data model that `attr` is defined on
+ *
+ */
+
 export default Component.extend({
   'data-test-field': true,
   classNames: ['field'],
 
-  /*
-   * @public Function
-   * called whenever a value on the model changes via the component
-   *
-   */
   onChange() {},
 
   /*
@@ -29,9 +41,6 @@ export default Component.extend({
    *   },
    *   type: "boolean"
    * }
-   *
-   * this is usually derived from ember model `attributes` lookup,
-   * and all members of `attr.options` are optional
    *
    */
   attr: null,
@@ -65,13 +74,6 @@ export default Component.extend({
     return this.get('attr.options.fieldValue') || this.get('attr.name');
   }),
 
-  /*
-   *
-   * @public
-   * @param DS.Model
-   *
-   * the Ember Data model that `attr` is defined on
-   */
   model: null,
 
   /*

--- a/ui/app/components/masked-input.js
+++ b/ui/app/components/masked-input.js
@@ -2,6 +2,26 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import autosize from 'autosize';
 
+/**
+ * @module MaskedInput
+ * `MaskedInput` components are textarea inputs where the input is hidden. They are used to enter sensitive information like passwords.
+ *
+ * @example
+ * ```js
+ * <MaskedInput
+ *  @value={{attr.options.defaultValue}}
+ *  @placeholder="secret"
+ *  @allowCopy={{true}}
+ * />
+ * ```
+ *
+ * @param [value] {String} - The value to display in the input.
+ * @param [placeholder=value] {String} - The placeholder to display before the user has entered any input.
+ * @param [allowCopy=null] {bool} - Whether or not the input should render with a copy button.
+ * @param [displayOnly=false] {bool} - Whether or not to display the value as a display only `pre` element or as an input.
+ *
+ */
+
 export default Component.extend({
   value: null,
   placeholder: 'value',

--- a/ui/blueprints/story/index.js
+++ b/ui/blueprints/story/index.js
@@ -19,7 +19,7 @@ module.exports = {
   locals: function(options) {
     let contents = '';
 
-    let importMD = "import notes from './" + stringUtil.dasherize(options.entity.name) + "';\n";
+    let importMD = "import notes from './" + stringUtil.dasherize(options.entity.name) + ".md';\n";
     return {
       importMD: importMD,
       contents: contents,

--- a/ui/package.json
+++ b/ui/package.json
@@ -122,7 +122,6 @@
   },
   "optionalDependencies": {
     "@babel/core": "^7.3.4",
-    "@storybook/addon-actions": "^5.0.5",
     "@storybook/addon-knobs": "^5.0.5",
     "@storybook/addon-links": "^5.0.5",
     "@storybook/addon-notes": "^5.0.5",

--- a/ui/stories/auth-config-form/config.md
+++ b/ui/stories/auth-config-form/config.md
@@ -7,7 +7,7 @@ The `AuthConfigForm/Config` is the base form to configure auth methods.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| model | <code>String</code> | <code></code> | The corresponding auth model that is being configured. |
+| model | <code>DS.Model</code> | <code></code> | The corresponding auth model that is being configured. |
 
 **Example**
   

--- a/ui/stories/auth-config-form/options.md
+++ b/ui/stories/auth-config-form/options.md
@@ -7,7 +7,7 @@ The `AuthConfigForm/Options` is options portion of the auth config form.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| model | <code>String</code> | <code></code> | The corresponding auth model that is being configured. |
+| model | <code>DS.Model</code> | <code></code> | The corresponding auth model that is being configured. |
 
 **Example**
   

--- a/ui/stories/form-field-groups.md
+++ b/ui/stories/form-field-groups.md
@@ -1,0 +1,34 @@
+<!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in app/components/form-field-groups.js. To make changes, first edit that file and run "yarn gen-story-md form-field-groups" to re-generate the content.-->
+
+## FormFieldGroups
+`FormFieldGroups` components are field groups associated with a particular model. They render individual `FormField` components.
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [renderGroup] | <code>String</code> | <code></code> | A whitelist of groups to include in the render. |
+| model | <code>DS.Model</code> | <code></code> | Model to be passed down to form-field component. If `fieldGroups` is present on the model then it will be iterated over and groups of `FormField` components will be rendered. |
+| onChange | <code>Func</code> | <code></code> | Handler that will get set on the `FormField` component. |
+
+**Example**
+  
+```js
+{{if model.fieldGroups}}
+ <FormFieldGroups @model={{model}} />
+{{/if}}
+
+...
+
+<FormFieldGroups
+ @model={{mountModel}}
+ @onChange={{action "onTypeChange"}}
+ @renderGroup="Method Options"
+/>
+```
+
+**See**
+
+- [Uses of FormFieldGroups](https://github.com/hashicorp/vault/search?l=Handlebars&q=FormFieldGroups)
+- [FormFieldGroups Source Code](https://github.com/hashicorp/vault/blob/master/ui/app/components/form-field-groups.js)
+
+---

--- a/ui/stories/form-field-groups.stories.js
+++ b/ui/stories/form-field-groups.stories.js
@@ -1,0 +1,49 @@
+/* eslint-disable import/extensions */
+import hbs from 'htmlbars-inline-precompile';
+import { storiesOf } from '@storybook/ember';
+import { withKnobs, select } from '@storybook/addon-knobs';
+import notes from './form-field-groups.md';
+
+// This will need to be replaced with a fake model, since the form fields associated with
+// each model come from OpenApi and Storybook doesn't have a Vault server to call OpenApi from.
+// Without OpenApi, not all of the models' form fields will show up in the Storybook UI.
+const MODELS = {
+  Approle: 'approle',
+  AWS: 'aws/client',
+  Azure: 'azure',
+  Cert: 'cert',
+  GCP: 'gcp',
+  Github: 'github',
+  JWT: 'jwt',
+  Kubernetes: 'kubernetes',
+  LDAP: 'ldap',
+  OKTA: 'okta',
+  Radius: 'radius',
+  Userpass: 'userpass',
+};
+
+const DEFAULT_VALUE = 'aws/client';
+
+storiesOf('Form/FormFieldGroups/', module)
+  .addParameters({ options: { showPanel: true } })
+  .addDecorator(withKnobs())
+  .add(
+    `FormFieldGroups`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">Form Field Groups</h5>
+        <FormFieldGroups @model={{compute (action 'getModel' model)}} />
+    `,
+      context: {
+        actions: {
+          getModel(modelType) {
+            return Ember.getOwner(this)
+              .lookup('service:store')
+              .createRecord(`auth-config/${modelType}`);
+          },
+        },
+        model: select('model', MODELS, DEFAULT_VALUE),
+      },
+    }),
+    { notes }
+  );

--- a/ui/stories/form-field.md
+++ b/ui/stories/form-field.md
@@ -1,0 +1,26 @@
+<!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in app/components/form-field.js. To make changes, first edit that file and run "yarn gen-story-md form-field" to re-generate the content.-->
+
+## FormField
+`FormField` components are field elements associated with a particular model.
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [onChange] | <code>Func</code> | <code></code> | Called whenever a value on the model changes via the component. |
+| attr | <code>Object</code> | <code></code> | This is usually derived from ember model `attributes` lookup, and all members of `attr.options` are optional. |
+| model | <code>DS.Model</code> | <code></code> | The Ember Data model that `attr` is defined on |
+
+**Example**
+  
+```js
+{{#each @model.fields as |attr|}}
+  <FormField data-test-field @attr={{attr}} @model={{this.model}} />
+{{/each}}
+```
+
+**See**
+
+- [Uses of FormField](https://github.com/hashicorp/vault/search?l=Handlebars&q=form-field)
+- [FormField Source Code](https://github.com/hashicorp/vault/blob/master/ui/app/components/form-field.js)
+
+---

--- a/ui/stories/form-field.md
+++ b/ui/stories/form-field.md
@@ -10,6 +10,21 @@
 | attr | <code>Object</code> | <code></code> | This is usually derived from ember model `attributes` lookup, and all members of `attr.options` are optional. |
 | model | <code>DS.Model</code> | <code></code> | The Ember Data model that `attr` is defined on |
 
+### Example Attr
+
+```js
+{
+   name: "foo",
+   options: {
+     label: "Foo",
+     defaultValue: "",
+     editType: "ttl",
+     helpText: "This will be in a tooltip"
+   },
+   type: "boolean"
+}
+```
+
 **Example**
   
 ```js

--- a/ui/stories/form-field.stories.js
+++ b/ui/stories/form-field.stories.js
@@ -12,7 +12,7 @@ const createAttr = (name, type, options) => {
   };
 };
 
-storiesOf('FormField/', module)
+storiesOf('Form/FormField/', module)
   .add(
     `FormField|string`,
     () => ({

--- a/ui/stories/form-field.stories.js
+++ b/ui/stories/form-field.stories.js
@@ -1,0 +1,141 @@
+/* eslint-disable import/extensions */
+import hbs from 'htmlbars-inline-precompile';
+import { storiesOf } from '@storybook/ember';
+import notes from './form-field.md';
+import EmberObject from '@ember/object';
+
+const createAttr = (name, type, options) => {
+  return {
+    name,
+    type,
+    options,
+  };
+};
+
+storiesOf('FormField/', module)
+  .add(
+    `FormField|string`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">String Form Field</h5>
+        <FormField @attr={{attr}} @model={{model}}/>
+    `,
+      context: {
+        attr: createAttr('foo', 'string', { defaultValue: 'default' }),
+        model: EmberObject.create({}),
+      },
+    }),
+    { notes }
+  )
+  .add(
+    `FormField|boolean`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">Boolean Form Field</h5>
+        <FormField @attr={{attr}} @model={{model}}/>
+    `,
+      context: {
+        attr: createAttr('foo', 'boolean', { defaultValue: false }),
+        model: EmberObject.create({}),
+      },
+    }),
+    { notes }
+  )
+  .add(
+    `FormField|number`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">Number Form Field</h5>
+        <FormField @attr={{attr}} @model={{model}}/>
+    `,
+      context: {
+        attr: createAttr('foo', 'number', { defaultValue: 5 }),
+        model: EmberObject.create({}),
+      },
+    }),
+    { notes }
+  )
+  .add(
+    `FormField|object`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">Object Form Field</h5>
+        <FormField @attr={{attr}} @model={{model}}/>
+    `,
+      context: {
+        attr: createAttr('foo', 'object'),
+        model: EmberObject.create({}),
+      },
+    }),
+    { notes }
+  )
+  .add(
+    `FormField|textarea`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">Textarea Form Field</h5>
+        <FormField @attr={{attr}} @model={{model}}/>
+    `,
+      context: {
+        attr: createAttr('foo', 'string', { defaultValue: 'goodbye', editType: 'textarea' }),
+        model: EmberObject.create({}),
+      },
+    }),
+    { notes }
+  )
+  .add(
+    `FormField|file`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">File Form Field</h5>
+        <FormField @attr={{attr}} @model={{model}}/>
+    `,
+      context: {
+        attr: createAttr('foo', 'string', { editType: 'file' }),
+        model: EmberObject.create({}),
+      },
+    }),
+    { notes }
+  )
+  .add(
+    `FormField|ttl`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">ttl Form Field</h5>
+        <FormField @attr={{attr}} @model={{model}}/>
+    `,
+      context: {
+        attr: createAttr('foo', null, { editType: 'ttl' }),
+        model: EmberObject.create({}),
+      },
+    }),
+    { notes }
+  )
+  .add(
+    `FormField|stringArray`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">String Array Form Field</h5>
+        <FormField @attr={{attr}} @model={{model}}/>
+    `,
+      context: {
+        attr: createAttr('foo', 'string', { editType: 'stringArray' }),
+        model: EmberObject.create({}),
+      },
+    }),
+    { notes }
+  )
+  .add(
+    `FormField|sensitive`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">Sensitive Form Field</h5>
+        <FormField @attr={{attr}} @model={{model}}/>
+    `,
+      context: {
+        attr: createAttr('password', 'string', { sensitive: true }),
+        model: EmberObject.create({}),
+      },
+    }),
+    { notes }
+  );

--- a/ui/stories/masked-input.md
+++ b/ui/stories/masked-input.md
@@ -1,0 +1,30 @@
+<!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in app/components/masked-input.js. To make changes, first edit that file and run "yarn gen-story-md masked-input" to re-generate the content.-->
+
+## MaskedInput
+`MaskedInput` components are textarea inputs where the input is hidden. They are used to enter sensitive information like passwords.
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [value] | <code>String</code> |  | The value to display in the input. |
+| [placeholder] | <code>String</code> | <code>value</code> | The placeholder to display before the user has entered any input. |
+| [allowCopy] | <code>bool</code> | <code></code> | Whether or not the input should render with a copy button. |
+| [displayOnly] | <code>bool</code> | <code>false</code> | Whether or not to display the value as a display only `pre` element or as an input. |
+
+**Example**
+  
+```js
+<MaskedInput
+ @value={{attr.options.defaultValue}}
+ @placeholder="secret"
+ @allowCopy={{true}}
+/>
+```
+ 
+
+**See**
+
+- [Uses of MaskedInput](https://github.com/hashicorp/vault/search?l=Handlebars&q=MaskedInput)
+- [MaskedInput Source Code](https://github.com/hashicorp/vault/blob/master/ui/app/components/masked-input.js)
+
+---

--- a/ui/stories/masked-input.stories.js
+++ b/ui/stories/masked-input.stories.js
@@ -1,0 +1,30 @@
+/* eslint-disable import/extensions */
+import hbs from 'htmlbars-inline-precompile';
+import { storiesOf } from '@storybook/ember';
+import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import notes from './masked-input.md';
+
+storiesOf('MaskedInput/', module)
+  .addParameters({ options: { showPanel: true } })
+  .addDecorator(withKnobs())
+  .add(
+    `MaskedInput`,
+    () => ({
+      template: hbs`
+        <h5 class="title is-5">Masked Input</h5>
+        <MaskedInput
+          @value={{value}}
+          @placeholder={{placeholder}}
+          @allowCopy={{allowCopy}}
+          @displayOnly={{displayOnly}}
+        />
+    `,
+      context: {
+        value: text('value', ''),
+        placeholder: text('placeholder', 'super-secret'),
+        allowCopy: boolean('allowCopy', false),
+        displayOnly: boolean('displayOnly', false),
+      },
+    }),
+    { notes }
+  );

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1497,26 +1497,6 @@
   dependencies:
     samsam "1.3.0"
 
-"@storybook/addon-actions@^5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-5.0.5.tgz#9179d08262c326c865021f5ecd173708c82edc87"
-  integrity sha512-m7uNuniFXmMdVSYEajlQ6us465NtLXoIj9cfYGX9wwzxb5tB2EG1oBUxVF5Q6JHC/HlRCsieYViHA+rprVLpJw==
-  dependencies:
-    "@storybook/addons" "5.0.5"
-    "@storybook/components" "5.0.5"
-    "@storybook/core-events" "5.0.5"
-    "@storybook/theming" "5.0.5"
-    core-js "^2.6.5"
-    fast-deep-equal "^2.0.1"
-    global "^4.3.2"
-    lodash "^4.17.11"
-    make-error "^1.3.5"
-    polished "^2.3.3"
-    prop-types "^15.6.2"
-    react "^16.8.1"
-    react-inspector "^2.3.0"
-    uuid "^3.3.2"
-
 "@storybook/addon-knobs@^5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-5.0.5.tgz#965d3afc86bd2373ad4514529ec0f4e590c7db45"
@@ -11799,11 +11779,6 @@ make-dir@^1.0.0:
   integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
   dependencies:
     pify "^3.0.0"
-
-make-error@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
-  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
 
 "make-fetch-happen@^2.5.0 || 3 || 4", make-fetch-happen@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## Add Form Components to Storybook

This pr adds `FormField`, `FormFieldGroups`, and `MaskedInput` to Storybook. Note that not all of the form fields for each model show up in Storybook because Storybook doesn't have access to OpenApi which is needed to get all of the model attributes (which become form fields).

This also fixes a small bug with the `gen-story-md` generator by adding the `.md` suffix to the import statement.

### FormFieldGroups
<img width="1192" alt="Screen Shot 2019-04-04 at 2 01 30 PM" src="https://user-images.githubusercontent.com/903288/55590001-9a239200-56e6-11e9-8b7a-4416e38335b5.png">

### FormField
<img width="1192" alt="Screen Shot 2019-04-04 at 2 34 29 PM" src="https://user-images.githubusercontent.com/903288/55590086-cf2fe480-56e6-11e9-8039-9448f8971e77.png">

### MaskedInput
<img width="1192" alt="Screen Shot 2019-04-04 at 2 01 39 PM" src="https://user-images.githubusercontent.com/903288/55589990-942db100-56e6-11e9-91a1-edd6ddb20a6d.png">
