### PR TITLE
Handle JWT checks with namespaced service tokens

### DIFF
--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -333,8 +333,12 @@ func (c *Core) ValidateWrappingToken(ctx context.Context, req *logical.Request) 
 	}
 
 	// Check for it being a JWT. If it is, and it is valid, we extract the
-	// internal client token from it and use that during lookup.
-	if strings.Count(token, ".") == 2 {
+	// internal client token from it and use that during lookup. The second
+	// check is a quick check to verify that we don't consider a namespaced
+	// token to be a JWT -- namespaced tokens have two dots too, but Vault
+	// token types (for now at least) begin with a letter representing a type
+	// and then a dot.
+	if strings.Count(token, ".") == 2 && token[1] != '.' {
 		// Implement the jose library way
 		parsedJWT, err := squarejwt.ParseSigned(token)
 		if err != nil {


### PR DESCRIPTION
Some checks would fail because we considered a token with two dots a
JWT, but service tokens in namespaces also fit this bill.