### PR TITLE
fix order of arguments for path-service

### DIFF
--- a/ui/app/routes/vault/cluster/secrets/backend/credentials.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/credentials.js
@@ -20,7 +20,7 @@ export default Route.extend({
     }
     let modelType = 'ssh-otp-credential';
     let owner = getOwner(this);
-    return this.pathHelp.getNewModel(modelType, backend, owner);
+    return this.pathHelp.getNewModel(modelType, owner, backend);
   },
 
   model(params) {

--- a/ui/app/templates/components/role-ssh-edit.hbs
+++ b/ui/app/templates/components/role-ssh-edit.hbs
@@ -29,6 +29,7 @@
               mode="edit"
               replace=true
               class="button has-icon-right is-ghost is-compact"
+              data-test-edit-link=true
               }}
               Edit role
               {{i-con glyph="chevron-right" size=11}}

--- a/ui/tests/acceptance/secrets/backend/ssh/role-test.js
+++ b/ui/tests/acceptance/secrets/backend/ssh/role-test.js
@@ -1,0 +1,77 @@
+import { currentRouteName } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import editPage from 'vault/tests/pages/secrets/backend/ssh/edit-role';
+import showPage from 'vault/tests/pages/secrets/backend/ssh/show';
+import generatePage from 'vault/tests/pages/secrets/backend/ssh/generate-otp';
+import listPage from 'vault/tests/pages/secrets/backend/list';
+import enablePage from 'vault/tests/pages/settings/mount-secret-backend';
+import authPage from 'vault/tests/pages/auth';
+
+module('Acceptance | secrets/ssh', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    return authPage.login();
+  });
+
+  const mountAndNav = async () => {
+    const path = `ssh-${new Date().getTime()}`;
+    await enablePage.enable('ssh', path);
+    await editPage.visitRoot({ backend: path });
+    return path;
+  };
+
+  test('it creates a role and redirects', async function(assert) {
+    const path = await mountAndNav(assert);
+    await editPage.createOTPRole('role');
+    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.ok(showPage.generateIsPresent, 'shows the generate button');
+
+    await showPage.visit({ backend: path, id: 'role' });
+    await showPage.generate();
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.credentials',
+      'navs to the credentials page'
+    );
+
+    await listPage.visitRoot({ backend: path });
+    assert.equal(listPage.secrets.length, 1, 'shows role in the list');
+    let secret = listPage.secrets.objectAt(0);
+    await secret.menuToggle();
+    assert.ok(listPage.menuItems.length > 0, 'shows links in the menu');
+  });
+
+  test('it deletes a role', async function(assert) {
+    await mountAndNav(assert);
+    await editPage.createOTPRole('role');
+    await showPage.edit();
+    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.edit', 'navs to the edit page');
+
+    await editPage.deleteRole();
+    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list-root', 'redirects to list page');
+    assert.ok(listPage.backendIsEmpty, 'no roles listed');
+  });
+
+  test('it generates an OTP', async function(assert) {
+    const path = await mountAndNav(assert);
+    await editPage.createOTPRole('role');
+    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
+    assert.ok(showPage.generateIsPresent, 'shows the generate button');
+
+    await showPage.visit({ backend: path, id: 'role' });
+    await showPage.generate();
+    assert.equal(
+      currentRouteName(),
+      'vault.cluster.secrets.backend.credentials',
+      'navs to the credentials page'
+    );
+
+    await generatePage.generateOTP();
+    assert.ok(generatePage.warningIsPresent, 'shows warning');
+    await generatePage.back();
+    assert.ok(generatePage.userIsPresent, 'clears generate, shows user input');
+    assert.ok(generatePage.ipIsPresent, 'clears generate, shows ip input');
+  });
+});

--- a/ui/tests/pages/secrets/backend/ssh/edit-role.js
+++ b/ui/tests/pages/secrets/backend/ssh/edit-role.js
@@ -1,0 +1,28 @@
+import { Base } from '../create';
+import { clickable, visitable, create, fillable } from 'ember-cli-page-object';
+
+export default create({
+  ...Base,
+  visitEdit: visitable('/vault/secrets/:backend/edit/:id'),
+  visitEditRoot: visitable('/vault/secrets/:backend/edit'),
+  keyType: fillable('[data-test-input="keyType"]'),
+  defaultUser: fillable('[data-test-input="defaultUser"]'),
+  toggleMore: clickable('[data-test-toggle-more]'),
+  name: fillable('[data-test-input="name"]'),
+  CIDR: fillable('[data-test-input="cidrList"]'),
+  save: clickable('[data-test-role-ssh-create]'),
+  deleteBtn: clickable('[data-test-confirm-action-trigger]'),
+  confirmBtn: clickable('[data-test-confirm-button]'),
+  deleteRole() {
+    return this.deleteBtn().confirmBtn();
+  },
+
+  async createOTPRole(name) {
+    await this.toggleMore()
+      .keyType('otp')
+      .name(name)
+      .defaultUser('admin')
+      .CIDR('0.0.0.0/0')
+      .save();
+  },
+});

--- a/ui/tests/pages/secrets/backend/ssh/generate-otp.js
+++ b/ui/tests/pages/secrets/backend/ssh/generate-otp.js
@@ -1,0 +1,19 @@
+import { Base } from '../credentials';
+import { clickable, value, create, fillable, isPresent } from 'ember-cli-page-object';
+
+export default create({
+  ...Base,
+  userIsPresent: isPresent('[data-test-input="username"]'),
+  ipIsPresent: isPresent('[data-test-input="ip"]'),
+  user: fillable('[data-test-input="username"]'),
+  ip: fillable('[data-test-input="ip"]'),
+  warningIsPresent: isPresent('[data-test-warning]'),
+  commonNameValue: value('[data-test-input="commonName"]'),
+  submit: clickable('[data-test-secret-generate]'),
+  back: clickable('[data-test-secret-generate-back]'),
+  generateOTP: async function() {
+    await this.user('admin')
+      .ip('192.168.1.1')
+      .submit();
+  },
+});

--- a/ui/tests/pages/secrets/backend/ssh/show.js
+++ b/ui/tests/pages/secrets/backend/ssh/show.js
@@ -1,0 +1,11 @@
+import { Base } from '../show';
+import { create, clickable, collection, isPresent } from 'ember-cli-page-object';
+
+export default create({
+  ...Base,
+  rows: collection('data-test-row-label'),
+  edit: clickable('[data-test-edit-link]'),
+  editIsPresent: isPresent('[data-test-edit-link]'),
+  generate: clickable('[data-test-backend-credentials]'),
+  generateIsPresent: isPresent('[data-test-backend-credentials]'),
+});


### PR DESCRIPTION
The arguments in the `getNewModel` call were transposed so it was causing an error in SSH OTP credential generation. This wasn't caught because we didn't have any tests for this, so I added those as well 🎉.

Fixes #6539