### PR TITLE
Optimize Postgres storage backend LIST function

### DIFF
--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -157,7 +157,7 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 		get_query:    "SELECT value FROM " + quoted_table + " WHERE path = $1 AND key = $2",
 		delete_query: "DELETE FROM " + quoted_table + " WHERE path = $1 AND key = $2",
 		list_query: "SELECT key FROM " + quoted_table + " WHERE path = $1" +
-			" UNION SELECT DISTINCT substring(substr(path, length($1)+1) from '^.*?/') FROM " + quoted_table +
+			" UNION ALL SELECT DISTINCT substring(substr(path, length($1)+1) from '^.*?/') FROM " + quoted_table +
 			" WHERE parent_path LIKE $1 || '%'",
 		haGetLockValueQuery:
 		// only read non expired data


### PR DESCRIPTION
Since the two branches of the UNION produce disjoint sets, do a UNION ALL so as to eliminate the need for a sort/eliminate duplicates step.