### PR TITLE
format errors from auth-jwt plugin like other authentication errors

### DIFF
--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -173,7 +173,7 @@ export default Component.extend(DEFAULTS, {
 
   showLoading: or('isLoading', 'authenticate.isRunning', 'fetchMethods.isRunning', 'unwrapToken.isRunning'),
 
-  handleError(e) {
+  handleError(e, prefixMessage = true) {
     this.set('loading', false);
     if (!e.errors) {
       return e;
@@ -184,7 +184,8 @@ export default Component.extend(DEFAULTS, {
       }
       return error;
     });
-    this.set('error', `Authentication failed: ${errors.join('.')}`);
+    let message = prefixMessage ? 'Authentication failed: ' : '';
+    this.set('error', `${message}${errors.join('.')}`);
   },
 
   authenticate: task(function*(backendType, data) {
@@ -238,6 +239,13 @@ export default Component.extend(DEFAULTS, {
         data.path = this.get('customPath') || get(backend, 'id');
       }
       return this.authenticate.unlinked().perform(backend.type, data);
+    },
+    handleError(e) {
+      if (e) {
+        this.handleError(e, false);
+      } else {
+        this.set('error', null);
+      }
     },
   },
 });

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -56,7 +56,7 @@
     {{/if}}
   {{#if (or (eq this.selectedAuthBackend.type "jwt") (eq this.selectedAuthBackend.type "oidc"))}}
     <AuthJwt
-      @onError={{action (mut this.error)}}
+      @onError={{action "handleError"}}
       @onLoading={{action (mut this.isLoading)}}
       @onToken={{action (mut this.token)}}
       @namespace={{this.namespace}}


### PR DESCRIPTION
When the OIDC flow errors, what the UI displayed wasn't particularly helpful - this PR changes it so that errors from the auth-jwt component get passed through the same path as errors in the auth-form components instead of directly setting auth-form's `error` property.

Before:
<img width="458" alt="Screen Shot 2019-04-09 at 8 22 41 AM" src="https://user-images.githubusercontent.com/39469/55803997-1b8d7280-5aa1-11e9-9af8-6387b0661bdd.png">

After
<img width="413" alt="Screen Shot 2019-04-09 at 8 08 10 AM" src="https://user-images.githubusercontent.com/39469/55803996-1b8d7280-5aa1-11e9-9784-a1886c5c0c61.png">