### PR TITLE
add ember assign polyfill for ie11

### DIFF
--- a/ui/.storybook/config.js
+++ b/ui/.storybook/config.js
@@ -1,6 +1,7 @@
 import { configure, addParameters, addDecorator } from '@storybook/ember';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import theme from './theme.js';
+import { assign } from '@ember/polyfills';
 
 function loadStories() {
   // automatically import all files ending in *.stories.js
@@ -25,7 +26,7 @@ addDecorator(storyFn => {
 
   // Create a div to wrap the Canvas tab with the applied styles.
   const element = document.createElement('div');
-  Object.assign(element.style, styles.style);
+  assign(element.style, styles.style);
 
   const innerElement = document.createElement('div');
 

--- a/ui/app/serializers/secret-v2-version.js
+++ b/ui/app/serializers/secret-v2-version.js
@@ -1,4 +1,5 @@
 import { get } from '@ember/object';
+import { assign } from '@ember/polyfills';
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
@@ -8,7 +9,7 @@ export default ApplicationSerializer.extend({
     // move response that is the contents of the secret from the dataPath
     // to `secret_data` so it will be `secretData` in the model
     payload.secret_data = get(payload, path);
-    payload = Object.assign({}, payload, payload.data.metadata);
+    payload = assign({}, payload, payload.data.metadata);
     delete payload.data;
     payload.path = payload.id;
     // return the payload if it's expecting a single object or wrap


### PR DESCRIPTION
This PR replaces the use of `Object.assign`, which isn't supported by ie11, with the ember assign polyfill. This bug was causing the Vault UI not to render in ie11.