### PR TITLE
Changed second put to use patch

### DIFF
--- a/website/source/intro/getting-started/first-secret.html.md
+++ b/website/source/intro/getting-started/first-secret.html.md
@@ -43,7 +43,7 @@ path is prefixed with `secret/`, otherwise this example won't work. The
 You can even write multiple pieces of data, if you want:
 
 ```text
-$ vault kv put secret/hello foo=world excited=yes
+$ vault kv patch secret/hello foo=world excited=yes
 Success! Data written to: secret/hello
 ```
 


### PR DESCRIPTION
Most recent release of Vault would cause an overwrite of the kv pair rather than append ... patch will append.  This is different than the learn.hashicorp.com website data - which is also subject to the same issue.