### PR TITLE
UI - masked input onchange

### DIFF
--- a/ui/app/components/masked-input.js
+++ b/ui/app/components/masked-input.js
@@ -12,6 +12,7 @@ import autosize from 'autosize';
  *  @value={{attr.options.defaultValue}}
  *  @placeholder="secret"
  *  @allowCopy={{true}}
+ *  @onChange={{action "someAction"}}
  * />
  * ```
  *
@@ -19,6 +20,8 @@ import autosize from 'autosize';
  * @param [placeholder=value] {String} - The placeholder to display before the user has entered any input.
  * @param [allowCopy=null] {bool} - Whether or not the input should render with a copy button.
  * @param [displayOnly=false] {bool} - Whether or not to display the value as a display only `pre` element or as an input.
+ * @param [onChange=false] {Function|action} - A function to call when the value of the input changes.
+ *
  *
  */
 
@@ -63,8 +66,9 @@ export default Component.extend({
       this.toggleProperty('isMasked');
     },
     updateValue(e) {
-      this.set('value', e.target.value);
-      this.onChange();
+      let value = e.target.value;
+      this.set('value', value);
+      this.onChange(value);
     },
   },
 });

--- a/ui/app/components/masked-input.js
+++ b/ui/app/components/masked-input.js
@@ -7,20 +7,18 @@ import autosize from 'autosize';
  * `MaskedInput` components are textarea inputs where the input is hidden. They are used to enter sensitive information like passwords.
  *
  * @example
- * ```js
  * <MaskedInput
  *  @value={{attr.options.defaultValue}}
  *  @placeholder="secret"
  *  @allowCopy={{true}}
  *  @onChange={{action "someAction"}}
  * />
- * ```
  *
  * @param [value] {String} - The value to display in the input.
  * @param [placeholder=value] {String} - The placeholder to display before the user has entered any input.
  * @param [allowCopy=null] {bool} - Whether or not the input should render with a copy button.
  * @param [displayOnly=false] {bool} - Whether or not to display the value as a display only `pre` element or as an input.
- * @param [onChange=false] {Function|action} - A function to call when the value of the input changes.
+ * @param [onChange=Function.prototype] {Function|action} - A function to call when the value of the input changes.
  *
  *
  */

--- a/ui/app/templates/components/form-field.hbs
+++ b/ui/app/templates/components/form-field.hbs
@@ -138,6 +138,7 @@
     @value={{or (get model valuePath) attr.options.defaultValue}}
     @placeholder=""
     @allowCopy="true"
+    @onChange={{action (action "setAndBroadcast" valuePath)}}
    />
 
 {{else if (or (eq attr.type "number") (eq attr.type "string"))}}

--- a/ui/app/templates/components/masked-input.hbs
+++ b/ui/app/templates/components/masked-input.hbs
@@ -1,4 +1,4 @@
-<div class="masked-input {{if shouldObscure "masked"}} {{if displayOnly "display-only"}} {{if allowCopy "allow-copy"}}" data-test-masked-input>
+<div class="masked-input {{if shouldObscure "masked"}} {{if displayOnly "display-only"}} {{if allowCopy "allow-copy"}}" data-test-masked-input data-test-field>
 	{{#if displayOnly}}
 		<pre class="masked-value display-only is-word-break">{{displayValue}}</pre>
   {{else}}

--- a/ui/stories/masked-input.md
+++ b/ui/stories/masked-input.md
@@ -10,16 +10,12 @@
 | [placeholder] | <code>String</code> | <code>value</code> | The placeholder to display before the user has entered any input. |
 | [allowCopy] | <code>bool</code> | <code></code> | Whether or not the input should render with a copy button. |
 | [displayOnly] | <code>bool</code> | <code>false</code> | Whether or not to display the value as a display only `pre` element or as an input. |
+| [onChange] | <code>function</code> \| <code>action</code> | <code>false</code> | A function to call when the value of the input changes. |
 
 **Example**
   
 ```js
 <MaskedInput
- @value={{attr.options.defaultValue}}
- @placeholder="secret"
- @allowCopy={{true}}
-/>
-```
  
 
 **See**

--- a/ui/stories/masked-input.md
+++ b/ui/stories/masked-input.md
@@ -10,13 +10,18 @@
 | [placeholder] | <code>String</code> | <code>value</code> | The placeholder to display before the user has entered any input. |
 | [allowCopy] | <code>bool</code> | <code></code> | Whether or not the input should render with a copy button. |
 | [displayOnly] | <code>bool</code> | <code>false</code> | Whether or not to display the value as a display only `pre` element or as an input. |
-| [onChange] | <code>function</code> \| <code>action</code> | <code>false</code> | A function to call when the value of the input changes. |
+| [onChange] | <code>function</code> \| <code>action</code> | <code>Function.prototype</code> | A function to call when the value of the input changes. |
 
 **Example**
   
 ```js
-<MaskedInput
- 
+ <MaskedInput
+  @value={{attr.options.defaultValue}}
+  @placeholder="secret"
+  @allowCopy={{true}}
+  @onChange={{action "someAction"}}
+ />
+```
 
 **See**
 

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -118,8 +118,11 @@ module('Integration | Component | form field', function(hooks) {
   });
 
   test('it renders: sensitive', async function(assert) {
-    await setup.call(this, createAttr('password', 'string', { sensitive: true }));
+    let [model, spy] = await setup.call(this, createAttr('password', 'string', { sensitive: true }));
     assert.ok(component.hasMaskedInput, 'renders the masked-input component');
+    await component.fields[0].textarea('secret');
+    assert.equal(model.get('password'), 'secret');
+    assert.ok(spy.calledWith('password', 'secret'), 'onChange called with correct args');
   });
 
   test('it uses a passed label', async function(assert) {


### PR DESCRIPTION
This fixes an issue where the masked-input component wasn't firing onchange events when the value changed when it was used in conjunction with the form-field component.

To test:
Enable the OIDC auth method in the UI
Fill out the client secret field
Save the form
Observe that the the secret field gets sent to the server in the browser dev tools

Thanks for catching this @yhyakuna !