### PR TITLE
Update mysql.go

### DIFF
--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -172,7 +172,7 @@ func NewMySQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 	// Prepare all the statements required
 	statements := map[string]string{
 		"put": "INSERT INTO " + dbTable +
-			" VALUES( ?, ? ) ON DUPLICATE KEY UPDATE vault_value=VALUES(vault_value)",
+			" (vault_key,vault_value) VALUES( ?, ? ) ON DUPLICATE KEY UPDATE vault_value=VALUES(vault_value)",
 		"get":    "SELECT vault_value FROM " + dbTable + " WHERE vault_key = ?",
 		"delete": "DELETE FROM " + dbTable + " WHERE vault_key = ?",
 		"list":   "SELECT vault_key FROM " + dbTable + " WHERE vault_key LIKE ?",


### PR DESCRIPTION
Add column names to the INSERT statement for the vault db table. The existing SQL fails if any other columns exist.

This has to be added to accommodate customization that's being done after-the-fact on our vault mysql database.

Previous mysql tests cover this change - I've also tested this change with mysql manually to verify it is OK.