### PR TITLE
Update base64 decrypt command documentation

### DIFF
--- a/website/source/docs/concepts/pgp-gpg-keybase.html.md
+++ b/website/source/docs/concepts/pgp-gpg-keybase.html.md
@@ -164,7 +164,7 @@ plain-text unseal key, you must decrypt the value given to you by the
 initializer. To get the plain-text value, run the following command:
 
 ```
-$ echo "wcBMA37..." | base64 -d | gpg -dq
+$ echo "wcBMA37..." | base64 --decode | gpg -dq
 ```
 
 And replace `wcBMA37...` with the encrypted key.

--- a/website/source/docs/concepts/pgp-gpg-keybase.html.md
+++ b/website/source/docs/concepts/pgp-gpg-keybase.html.md
@@ -85,7 +85,7 @@ plain-text unseal key, you must decrypt the value given to you by the
 initializer. To get the plain-text value, run the following command:
 
 ```
-$ echo "wcBMA37..." | base64 -d | keybase pgp decrypt
+$ echo "wcBMA37..." | base64 -D | keybase pgp decrypt
 ```
 
 And replace `wcBMA37...` with the encrypted key.
@@ -164,10 +164,10 @@ plain-text unseal key, you must decrypt the value given to you by the
 initializer. To get the plain-text value, run the following command:
 
 ```
-$ echo "wcBMA37..." | base64 -d | gpg -dq 
+$ echo "wcBMA37..." | base64 -d | gpg -dq
 ```
 
-And replace `wcBMA37...` with the encrypted key. 
+And replace `wcBMA37...` with the encrypted key.
 
 If you encrypted your private PGP key with a passphrase, you may be prompted to
 enter it.  After you enter your password, the output will be the plain-text

--- a/website/source/docs/concepts/pgp-gpg-keybase.html.md
+++ b/website/source/docs/concepts/pgp-gpg-keybase.html.md
@@ -85,7 +85,7 @@ plain-text unseal key, you must decrypt the value given to you by the
 initializer. To get the plain-text value, run the following command:
 
 ```
-$ echo "wcBMA37..." | base64 -D | keybase pgp decrypt
+$ echo "wcBMA37..." | base64 --decode | keybase pgp decrypt
 ```
 
 And replace `wcBMA37...` with the encrypted key.


### PR DESCRIPTION
Running `base64 -d` returns `base64: invalid option -- d`. The correct option should be `-D` (capitalized)