### PR TITLE
Exit DynamoDB tryToLock when stop channel is closed

### DIFF
--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -600,11 +600,11 @@ func (l *DynamoDBLock) Value() (bool, string, error) {
 // channel is closed.
 func (l *DynamoDBLock) tryToLock(stop, success chan struct{}, errors chan error) {
 	ticker := time.NewTicker(DynamoDBLockRetryInterval)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-stop:
-			ticker.Stop()
 			return
 		case <-ticker.C:
 			err := l.updateItem(true)
@@ -621,7 +621,6 @@ func (l *DynamoDBLock) tryToLock(stop, success chan struct{}, errors chan error)
 					return
 				}
 			} else {
-				ticker.Stop()
 				close(success)
 				return
 			}

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -605,6 +605,7 @@ func (l *DynamoDBLock) tryToLock(stop, success chan struct{}, errors chan error)
 		select {
 		case <-stop:
 			ticker.Stop()
+			return
 		case <-ticker.C:
 			err := l.updateItem(true)
 			if err != nil {


### PR DESCRIPTION
If the stop channel is closed (e.g. an error is returned which triggers
close(stop) in Lock), this loop will spin and use 100% CPU.