### PR TITLE
Set chunkSize when creating a new GCS backend

### DIFF
--- a/physical/gcs/gcs.go
+++ b/physical/gcs/gcs.go
@@ -158,9 +158,9 @@ func NewBackend(c map[string]string, logger log.Logger) (physical.Backend, error
 	}
 
 	return &Backend{
-		bucket:    bucket,
-		haEnabled: haEnabled,
-
+		bucket:     bucket,
+		haEnabled:  haEnabled,
+		chunkSize:  chunkSize,
 		client:     client,
 		permitPool: physical.NewPermitPool(maxParallel),
 		logger:     logger,

--- a/physical/gcs/gcs_test.go
+++ b/physical/gcs/gcs_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -55,6 +56,17 @@ func TestBackend(t *testing.T) {
 	}, logging.NewVaultLogger(log.Trace))
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// Verify chunkSize is set correctly on the Backend
+	be := backend.(*Backend)
+	expectedChunkSize, err := strconv.Atoi(defaultChunkSize)
+	if err != nil {
+		t.Fatalf("failed to convert defaultChunkSize to int: %s", err)
+	}
+	expectedChunkSize = expectedChunkSize * 1024
+	if be.chunkSize != expectedChunkSize {
+		t.Fatalf("expected chunkSize to be %d. got=%d", expectedChunkSize, be.chunkSize)
 	}
 
 	physical.ExerciseBackend(t, backend)


### PR DESCRIPTION
This PR sets the chunkSize on the GCS Backend in `New` and adds a small regression test to `TestBackend`.

## Rationale
I was taking a look at the GCS physical backend code and noticed that `chunkSize` was being parsed and checked but never set on the actual backend in `New`. Looking through the commit history, it appears that `chunkSize` was originally a [package level variable](https://github.com/hashicorp/vault/blob/ceef3b60d82be5d8a534ca55b23bbc6cb1e31cf9/physical/gcs/gcs.go#L39) but was later changed to a [parameter within the Backend](https://github.com/sethvargo/vault/blob/9bca0a3e442ccd2eab9e5d4f692b780342d9c8c9/physical/gcs/gcs.go#L70) but it was never wired up inside of `New`.

## Tests
To verify I wasn't crazy, I ran the new test before changing the `New` func:

```terminal
$ go test ./physical/gcs
2019-04-30T02:54:15.062-0400 [DEBUG] configuring backend
2019-04-30T02:54:15.062-0400 [DEBUG] configuration: bucket=vault-gcs-testacc-352928274214603302 chunk_size=8388608 ha_enabled=true max_parallel=0
2019-04-30T02:54:15.062-0400 [DEBUG] creating client
2019-04-30T02:54:15.062-0400 [DEBUG] configuring backend
2019-04-30T02:54:15.062-0400 [DEBUG] configuration: bucket=vault-gcs-testacc-352928274214603302 chunk_size=8388608 ha_enabled=true max_parallel=0
2019-04-30T02:54:15.062-0400 [DEBUG] creating client
2019-04-30T02:54:49.938-0400 [DEBUG] configuring backend
2019-04-30T02:54:49.938-0400 [DEBUG] configuration: bucket=vault-gcs-testacc-7058591571723470507 chunk_size=8388608 ha_enabled=false max_parallel=0
2019-04-30T02:54:49.938-0400 [DEBUG] creating client
--- FAIL: TestBackend (1.82s)
    gcs_test.go:68: expected chunkSize to be 8388608. got=0
FAIL
FAIL	github.com/usererror/vault/physical/gcs	36.771s
```

After setting the chunkSize in `New` the tests are all green:

```terminal
$ go test ./physical/gcs
ok  	github.com/usererror/vault/physical/gcs	69.402s
```