### PR TITLE
[Doc]: PKI Fix allowed_uri_sans spelling mistake

### DIFF
--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -953,7 +953,7 @@ $ curl \
     "allow_localhost": true,
     "allow_subdomains": false,
     "allowed_domains": ["example.com", "foobar.com"],
-    "allow_uri_sans": ["example.com","spiffe://*"],
+    "allowed_uri_sans": ["example.com","spiffe://*"],
     "client_flag": true,
     "code_signing_flag": false,
     "key_bits": 2048,


### PR DESCRIPTION
The doc of the PKI Role sample response currently reads

  `"allow_uri_sans": ["example.com","spiffe://*"],`

It should read:

  `"allowed_uri_sans": ["example.com","spiffe://*"],`