### PR TITLE
Add Priority Queue library to sdk

### DIFF
--- a/sdk/queue/README.md
+++ b/sdk/queue/README.md
@@ -1,0 +1,9 @@
+Vault SDK - Queue
+=================
+
+The `queue` package provides Vault plugins with a Priority Queue. It can be used
+as an in-memory list of `queue.Item` sorted by their `priority`, and offers
+methods to find or remove items by their key. Internally it
+uses `container/heap`; see [Example Priority
+Queue](https://golang.org/pkg/container/heap/#example__priorityQueue)
+

--- a/sdk/queue/item.go
+++ b/sdk/queue/item.go
@@ -1,0 +1,9 @@
+package queue
+
+// Item is something managed in the priority queue
+type Item struct {
+	Key      string // key is used as an index in the internal map of a Queue
+	Value    interface{}
+	Priority int64 // priority of item in queue
+	index    int   // index is needed by update and maintained by heap package
+}

--- a/sdk/queue/item.go
+++ b/sdk/queue/item.go
@@ -1,9 +1,0 @@
-package queue
-
-// Item is something managed in the priority queue
-type Item struct {
-	Key      string // key is used as an index in the internal map of a Queue
-	Value    interface{}
-	Priority int64 // priority of item in queue
-	index    int   // index is needed by update and maintained by heap package
-}

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -8,7 +8,6 @@ package queue
 import (
 	"container/heap"
 	"errors"
-	"sort"
 	"sync"
 
 	"github.com/mitchellh/copystructure"
@@ -58,7 +57,6 @@ type PriorityQueue struct {
 type queue []*Item
 
 var _ heap.Interface = &queue{}
-var _ sort.Interface = &queue{}
 
 // Item is something managed in the priority queue
 type Item struct {
@@ -182,7 +180,8 @@ func (q *queue) Pop() interface{} {
 	old := *q
 	n := len(old)
 	item := old[n-1]
-	item.index = -1 //for saftey
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
 	*q = old[0 : n-1]
 	return item
 }

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -1,0 +1,160 @@
+package queue
+
+import (
+	"container/heap"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var ErrEmpty = errors.New("queue is empty")
+var ErrDuplicateItem = errors.New("duplicate item")
+
+// NewPriorityQueue initializes a PriorityQueue struct for use as a PriorityQueue
+func NewPriorityQueue() *PriorityQueue {
+	pq := PriorityQueue{
+		data:    make([]*Item, 0),
+		dataMap: make(map[string]*Item),
+	}
+	heap.Init(&pq)
+	return &pq
+}
+
+// PriorityQueue satisfies heap.Interface and adds a few additional methods. The
+// ordering (priority) is an integer value with the smallest value is the
+// highest priority.
+type PriorityQueue struct {
+	// data is the internal structure that holds the queue, and is operated on by
+	// heap functions
+	data []*Item
+
+	// dataMap represents all the items in the queue, with unique indexes, used
+	// for finding specific items. dataMap must be kept in sync with data
+	dataMap map[string]*Item
+
+	// mapMutex is used to facilitate read/write locks on the dataMap
+	dataMutex sync.Mutex
+}
+
+// PopItem pops the highest priority item from the queue. This is a
+// wrapper/convenience method that calls heap.Pop, so consumers do not need to
+// invoke heap functions directly
+func (pq *PriorityQueue) PopItem() (*Item, error) {
+	pq.dataMutex.Lock()
+	defer pq.dataMutex.Unlock()
+
+	if pq.Len() == 0 {
+		return nil, ErrEmpty
+	}
+
+	item := heap.Pop(pq).(*Item)
+	delete(pq.dataMap, item.Key)
+	return item, nil
+}
+
+// PushItem pushes an item on to the queue. This is a wrapper/convenience
+// method that calls heap.Push, so consumers do not need to invoke heap
+// functions directly
+func (pq *PriorityQueue) PushItem(i *Item) error {
+	if i.Key == "" {
+		return errors.New("error adding item: Item Key is required")
+	}
+
+	pq.dataMutex.Lock()
+	defer pq.dataMutex.Unlock()
+
+	if _, ok := pq.dataMap[i.Key]; ok {
+		return ErrDuplicateItem
+	}
+
+	pq.dataMap[i.Key] = i
+	heap.Push(pq, i)
+	return nil
+}
+
+// PopItemByKey searches the queue for an item with the given key and removes it
+// from the queue if found. Returns ErrItemNotFound(key) if not found. This
+// method must fix the queue after removal.
+func (pq *PriorityQueue) PopItemByKey(key string) (*Item, error) {
+	pq.dataMutex.Lock()
+	defer pq.dataMutex.Unlock()
+
+	item, ok := pq.dataMap[key]
+	if !ok {
+		return nil, NewErrItemNotFound(key)
+	}
+
+	// remove the item the heap and delete it from the dataMap
+	itemRaw := heap.Remove(pq, item.index)
+	delete(pq.dataMap, key)
+
+	if i, ok := itemRaw.(*Item); ok {
+		return i, nil
+	}
+
+	return nil, NewErrItemNotFound(key)
+}
+
+//////
+// begin heap.Interface and sort.Interface methods
+//////
+
+// Len returns the count of items in the queue.
+func (pq *PriorityQueue) Len() int { return len(pq.data) }
+
+// Less returns the less of two things, which in this case, we return the
+// highest thing.
+func (pq *PriorityQueue) Less(i, j int) bool {
+	return pq.data[i].Priority < pq.data[j].Priority
+}
+
+// Swap swaps things in-place
+func (pq *PriorityQueue) Swap(i, j int) {
+	pq.data[i], pq.data[j] = pq.data[j], pq.data[i]
+	pq.data[i].index = i
+	pq.data[j].index = j
+}
+
+// Push is used by heap.Interface to push items onto the heap. Do not use this
+// method to add items to a queue: use PushItem instead.
+// See also: https://golang.org/pkg/container/heap/#Interface
+func (pq *PriorityQueue) Push(x interface{}) {
+	n := len(pq.data)
+	item := x.(*Item)
+	item.index = n
+	pq.data = append(pq.data, item)
+}
+
+// Pop is used by heap.Interface to pop items off of the heap. Do not use this
+// method to remove items from a queue: use PopItem instead.
+// See also: https://golang.org/pkg/container/heap/#Interface
+func (pq *PriorityQueue) Pop() interface{} {
+	old := pq.data
+	n := len(old)
+	item := old[n-1]
+	item.index = -1 //for saftey
+	pq.data = old[0 : n-1]
+	return item
+}
+
+//////
+// end heap.Interface methods
+//////
+
+// NewErrItemNotFound creates a "not found" error for the given key
+func NewErrItemNotFound(key string) error {
+	return &ErrItemNotFound{
+		Key: key,
+	}
+}
+
+// ErrItemNotFound is a struct that implements the error interface
+var _ error = &ErrItemNotFound{}
+
+type ErrItemNotFound struct {
+	Key string
+}
+
+func (e *ErrItemNotFound) Error() string {
+	return fmt.Sprintf("queue item with key (%s) not found", e.Key)
+}

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -1,9 +1,15 @@
+// Package queue  provides Vault plugins with a Priority Queue. It can be used
+// as an in-memory list of queue.Item sorted by their priority, and offers
+// methods to find or remove items by their key. Internally it uses
+// container/heap; see Example Priority Queue:
+// https://golang.org/pkg/container/heap/#example__priorityQueue
 package queue
 
 import (
 	"container/heap"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/mitchellh/copystructure"
@@ -28,12 +34,49 @@ func (e *ErrItemNotFound) Error() string {
 	return fmt.Sprintf("queue item with key (%s) not found", e.Key)
 }
 
-// NewErrItemNotFound creates a "not found" error for the given key
-func NewErrItemNotFound(key string) *ErrItemNotFound {
+func newErrItemNotFound(key string) *ErrItemNotFound {
 	return &ErrItemNotFound{
 		Key: key,
 	}
 }
+
+// New initializes the internal data structures and returns a new
+// PriorityQueue
+func New() *PriorityQueue {
+	pq := PriorityQueue{
+		data:    make(pQueue, 0),
+		dataMap: make(map[string]*Item),
+	}
+	heap.Init(&pq.data)
+	return &pq
+}
+
+// PriorityQueue facilitates queue of Items, providing PushItem, PopItem, and
+// PopItemByKey convenience methods. The ordering (priority) is an int64 value
+// with the smallest value is the highest priority. PriorityQueue maintains both
+// an internal slice for the queue as well as a map of the same items with their
+// keys as the index. This enables users to find specific items by key. The map
+// must be kept in sync with the data slice.
+// See https://golang.org/pkg/container/heap/#example__priorityQueue
+type PriorityQueue struct {
+	// data is the internal structure that holds the queue, and is operated on by
+	// heap functions
+	data pQueue
+
+	// dataMap represents all the items in the queue, with unique indexes, used
+	// for finding specific items. dataMap is kept in sync with the data slice
+	dataMap map[string]*Item
+
+	// mapMutex is used to facilitate read/write locks on the dataMap
+	dataMutex sync.Mutex
+}
+
+// pQueue is the internal data structure used to satisfy heap.Interface. This
+// prevents users from calling Pop and Push heap methods directly
+type pQueue []*Item
+
+var _ heap.Interface = &pQueue{}
+var _ sort.Interface = &pQueue{}
 
 // Item is something managed in the priority queue
 type Item struct {
@@ -52,34 +95,6 @@ type Item struct {
 	index int
 }
 
-// NewPriorityQueue initializes the internal data structures and returns a new
-// PriorityQueue
-func NewPriorityQueue() *PriorityQueue {
-	pq := PriorityQueue{
-		data:    make([]*Item, 0),
-		dataMap: make(map[string]*Item),
-	}
-	heap.Init(&pq)
-	return &pq
-}
-
-// PriorityQueue satisfies heap.Interface and sort.Interface, and adds a few
-// convenience methods. The ordering (priority) is an int64 value with the
-// smallest value is the highest priority.
-// See https://golang.org/pkg/container/heap/#example__priorityQueue
-type PriorityQueue struct {
-	// data is the internal structure that holds the queue, and is operated on by
-	// heap functions
-	data []*Item
-
-	// dataMap represents all the items in the queue, with unique indexes, used
-	// for finding specific items. dataMap is kept in sync with the data slice
-	dataMap map[string]*Item
-
-	// mapMutex is used to facilitate read/write locks on the dataMap
-	dataMutex sync.Mutex
-}
-
 // PopItem pops the highest priority item from the queue. This is a
 // wrapper/convenience method that calls heap.Pop, so consumers do not need to
 // invoke heap functions directly
@@ -90,7 +105,7 @@ func (pq *PriorityQueue) PopItem() (*Item, error) {
 	if pq.Len() == 0 {
 		return nil, ErrEmpty
 	}
-	item := heap.Pop(pq).(*Item)
+	item := heap.Pop(&pq.data).(*Item)
 	delete(pq.dataMap, item.Key)
 	return item, nil
 }
@@ -120,7 +135,7 @@ func (pq *PriorityQueue) PushItem(i *Item) error {
 	}
 
 	pq.dataMap[i.Key] = clone.(*Item)
-	heap.Push(pq, clone)
+	heap.Push(&pq.data, clone)
 	return nil
 }
 
@@ -133,55 +148,56 @@ func (pq *PriorityQueue) PopItemByKey(key string) (*Item, error) {
 
 	item, ok := pq.dataMap[key]
 	if !ok {
-		return nil, NewErrItemNotFound(key)
+		return nil, newErrItemNotFound(key)
 	}
 
 	// remove the item the heap and delete it from the dataMap
-	itemRaw := heap.Remove(pq, item.index)
+	itemRaw := heap.Remove(&pq.data, item.index)
 	delete(pq.dataMap, key)
 
 	if i, ok := itemRaw.(*Item); ok {
 		return i, nil
 	}
 
-	return nil, NewErrItemNotFound(key)
+	return nil, newErrItemNotFound(key)
 }
 
 // Len returns the count of items in the queue.
-func (pq *PriorityQueue) Len() int { return len(pq.data) }
+func (pq pQueue) Len() int        { return len(pq) }
+func (q *PriorityQueue) Len() int { return q.data.Len() }
 
 // Less returns the less of two things, which in this case, we return the
 // highest thing, because the priority ordering is "lowest value, highest
 // priority"
-func (pq *PriorityQueue) Less(i, j int) bool {
-	return pq.data[i].Priority < pq.data[j].Priority
+func (pq pQueue) Less(i, j int) bool {
+	return pq[i].Priority < pq[j].Priority
 }
 
 // Swap swaps things in-place
-func (pq *PriorityQueue) Swap(i, j int) {
-	pq.data[i], pq.data[j] = pq.data[j], pq.data[i]
-	pq.data[i].index = i
-	pq.data[j].index = j
+func (pq pQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
 }
 
 // Push is used by heap.Interface to push items onto the heap. Do not use this
 // method to add items to a queue: use PushItem instead.
 // See: https://golang.org/pkg/container/heap/#Interface
-func (pq *PriorityQueue) Push(x interface{}) {
-	n := len(pq.data)
+func (pq *pQueue) Push(x interface{}) {
+	n := len(*pq)
 	item := x.(*Item)
 	item.index = n
-	pq.data = append(pq.data, item)
+	*pq = append(*pq, item)
 }
 
 // Pop is used by heap.Interface to pop items off of the heap. Do not use this
 // method to remove items from a queue: use PopItem instead.
 // See: https://golang.org/pkg/container/heap/#Interface
-func (pq *PriorityQueue) Pop() interface{} {
-	old := pq.data
+func (pq *pQueue) Pop() interface{} {
+	old := *pq
 	n := len(old)
 	item := old[n-1]
 	item.index = -1 //for saftey
-	pq.data = old[0 : n-1]
+	*pq = old[0 : n-1]
 	return item
 }

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/mitchellh/copystructure"
 )
 
 // ErrEmpty is returned for queues with no items
@@ -89,9 +91,13 @@ func (pq *PriorityQueue) PushItem(i *Item) error {
 		return ErrDuplicateItem
 	}
 
-	x := *i
-	pq.dataMap[x.Key] = &x
-	heap.Push(pq, &x)
+	clone, err := copystructure.Copy(i)
+	if err != nil {
+		return err
+	}
+
+	pq.dataMap[i.Key] = clone.(*Item)
+	heap.Push(pq, clone)
 	return nil
 }
 

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -51,8 +51,8 @@ func New() *PriorityQueue {
 	return &pq
 }
 
-// PriorityQueue facilitates queue of Items, providing PushItem, PopItem, and
-// PopItemByKey convenience methods. The ordering (priority) is an int64 value
+// PriorityQueue facilitates queue of Items, providing Push, Pop, and
+// PopByKey convenience methods. The ordering (priority) is an int64 value
 // with the smallest value is the highest priority. PriorityQueue maintains both
 // an internal slice for the queue as well as a map of the same items with their
 // keys as the index. This enables users to find specific items by key. The map
@@ -95,10 +95,10 @@ type Item struct {
 	index int
 }
 
-// PopItem pops the highest priority item from the queue. This is a
+// Pop pops the highest priority item from the queue. This is a
 // wrapper/convenience method that calls heap.Pop, so consumers do not need to
 // invoke heap functions directly
-func (pq *PriorityQueue) PopItem() (*Item, error) {
+func (pq *PriorityQueue) Pop() (*Item, error) {
 	pq.dataMutex.Lock()
 	defer pq.dataMutex.Unlock()
 
@@ -110,12 +110,12 @@ func (pq *PriorityQueue) PopItem() (*Item, error) {
 	return item, nil
 }
 
-// PushItem pushes an item on to the queue. This is a wrapper/convenience
+// Push pushes an item on to the queue. This is a wrapper/convenience
 // method that calls heap.Push, so consumers do not need to invoke heap
 // functions directly. Items must have unique Keys, and Items in the queue
 // cannot be updated. To modify an Item, users must first remove it and re-push
 // it after modifications
-func (pq *PriorityQueue) PushItem(i *Item) error {
+func (pq *PriorityQueue) Push(i *Item) error {
 	if i.Key == "" {
 		return errors.New("error adding item: Item Key is required")
 	}
@@ -139,10 +139,10 @@ func (pq *PriorityQueue) PushItem(i *Item) error {
 	return nil
 }
 
-// PopItemByKey searches the queue for an item with the given key and removes it
+// PopByKey searches the queue for an item with the given key and removes it
 // from the queue if found. Returns ErrItemNotFound(key) if not found. This
 // method must fix the queue after removal.
-func (pq *PriorityQueue) PopItemByKey(key string) (*Item, error) {
+func (pq *PriorityQueue) PopByKey(key string) (*Item, error) {
 	pq.dataMutex.Lock()
 	defer pq.dataMutex.Unlock()
 
@@ -162,26 +162,29 @@ func (pq *PriorityQueue) PopItemByKey(key string) (*Item, error) {
 	return nil, newErrItemNotFound(key)
 }
 
-// Len returns the count of items in the queue.
-func (pq pQueue) Len() int        { return len(pq) }
+// Len returns the number of items in the queue data structure. Do not use this
+// method directly on the queue, use PriorityQueue.Len() instead.
+func (pq pQueue) Len() int { return len(pq) }
+
+// Len returns the count of items in the Priority Queue
 func (q *PriorityQueue) Len() int { return q.data.Len() }
 
 // Less returns the less of two things, which in this case, we return the
-// highest thing, because the priority ordering is "lowest value, highest
+// highest value thing, because the priority ordering is "lowest value, highest
 // priority"
 func (pq pQueue) Less(i, j int) bool {
 	return pq[i].Priority < pq[j].Priority
 }
 
-// Swap swaps things in-place
+// Swap swaps things in-place; part of sort.Interface
 func (pq pQueue) Swap(i, j int) {
 	pq[i], pq[j] = pq[j], pq[i]
 	pq[i].index = i
 	pq[j].index = j
 }
 
-// Push is used by heap.Interface to push items onto the heap. Do not use this
-// method to add items to a queue: use PushItem instead.
+// Push is used by heap.Interface to push items onto the heap. This method is
+// invoked by container/heap, and should not be used directly.
 // See: https://golang.org/pkg/container/heap/#Interface
 func (pq *pQueue) Push(x interface{}) {
 	n := len(*pq)
@@ -190,8 +193,8 @@ func (pq *pQueue) Push(x interface{}) {
 	*pq = append(*pq, item)
 }
 
-// Pop is used by heap.Interface to pop items off of the heap. Do not use this
-// method to remove items from a queue: use PopItem instead.
+// Pop is used by heap.Interface to pop items off of the heap. This method is
+// invoked by container/heap, and should not be used directly.
 // See: https://golang.org/pkg/container/heap/#Interface
 func (pq *pQueue) Pop() interface{} {
 	old := *pq

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -35,6 +35,23 @@ func NewErrItemNotFound(key string) *ErrItemNotFound {
 	}
 }
 
+// Item is something managed in the priority queue
+type Item struct {
+	// Key is a unique string used to identify items in the internal data map
+	Key string
+	// Value is an unspecified type that implementations can use to store
+	// information
+	Value interface{}
+
+	// Priority determines ordering in the queue, with the lowest value being the
+	// highest priority
+	Priority int64
+
+	// index is an internal value used by the heap package, and should not be
+	// modified by any consumer of the priority queue
+	index int
+}
+
 // NewPriorityQueue initializes a PriorityQueue struct for use as a PriorityQueue
 func NewPriorityQueue() *PriorityQueue {
 	pq := PriorityQueue{

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -84,12 +84,13 @@ func (pq *PriorityQueue) Len() int {
 // wrapper/convenience method that calls heap.Pop, so consumers do not need to
 // invoke heap functions directly
 func (pq *PriorityQueue) Pop() (*Item, error) {
-	pq.Lock()
-	defer pq.Unlock()
-
 	if pq.Len() == 0 {
 		return nil, ErrEmpty
 	}
+
+	pq.Lock()
+	defer pq.Unlock()
+
 	item := heap.Pop(&pq.data).(*Item)
 	delete(pq.dataMap, item.Key)
 	return item, nil

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -65,6 +65,7 @@ func NewPriorityQueue() *PriorityQueue {
 // PriorityQueue satisfies heap.Interface and adds a few additional methods. The
 // ordering (priority) is an integer value with the smallest value is the
 // highest priority.
+// See https://golang.org/pkg/container/heap/#example__priorityQueue
 type PriorityQueue struct {
 	// data is the internal structure that holds the queue, and is operated on by
 	// heap functions

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -101,7 +101,7 @@ func (pq *PriorityQueue) Pop() (*Item, error) {
 // cannot be updated. To modify an Item, users must first remove it and re-push
 // it after modifications
 func (pq *PriorityQueue) Push(i *Item) error {
-	if i.Key == "" {
+	if i == nil || i.Key == "" {
 		return errors.New("error adding item: Item Key is required")
 	}
 

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -141,8 +141,10 @@ func (pq *PriorityQueue) PopByKey(key string) (*Item, error) {
 	itemRaw := heap.Remove(&pq.data, item.index)
 	delete(pq.dataMap, key)
 
-	if i, ok := itemRaw.(*Item); ok {
-		return i, nil
+	if itemRaw != nil {
+		if i, ok := itemRaw.(*Item); ok {
+			return i, nil
+		}
 	}
 
 	return nil, nil

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -56,8 +56,6 @@ type PriorityQueue struct {
 // prevents users from calling Pop and Push heap methods directly
 type queue []*Item
 
-var _ heap.Interface = &queue{}
-
 // Item is something managed in the priority queue
 type Item struct {
 	// Key is a unique string used to identify items in the internal data map
@@ -76,7 +74,11 @@ type Item struct {
 }
 
 // Len returns the count of items in the Priority Queue
-func (pq *PriorityQueue) Len() int { return pq.data.Len() }
+func (pq *PriorityQueue) Len() int {
+	pq.Lock()
+	defer pq.Unlock()
+	return pq.data.Len()
+}
 
 // Pop pops the highest priority item from the queue. This is a
 // wrapper/convenience method that calls heap.Pop, so consumers do not need to

--- a/sdk/queue/priority_queue_test.go
+++ b/sdk/queue/priority_queue_test.go
@@ -48,6 +48,11 @@ func TestPriorityQueue_New(t *testing.T) {
 func TestPriorityQueue_Push(t *testing.T) {
 	pq := New()
 
+	// don't allow nil pushing
+	if err := pq.Push(nil); err == nil {
+		t.Fatal("Expected error on pushing nil")
+	}
+
 	tc := testCases()
 	tcl := len(tc)
 	for _, i := range tc {

--- a/sdk/queue/priority_queue_test.go
+++ b/sdk/queue/priority_queue_test.go
@@ -1,0 +1,183 @@
+package queue
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// some tests rely on the ordering of items from this method
+func testCases() (tc []*Item) {
+	// create a slice of items with priority / times offest by these seconds
+	for i, m := range []time.Duration{
+		5,
+		183600,  // 51 hours
+		15,      // 15 seconds
+		45,      // 45 seconds
+		900,     // 15 minutes
+		300,     // 5 minutes
+		7200,    // 2 hours
+		183600,  // 51 hours
+		7201,    // 2 hours, 1 second
+		115200,  // 32 hours
+		1209600, // 2 weeks
+	} {
+		n := time.Now()
+		ft := n.Add(time.Second * m)
+		tc = append(tc, &Item{
+			Key:      fmt.Sprintf("item-%d", i),
+			Value:    1,
+			Priority: ft.Unix(),
+		})
+	}
+	return
+}
+
+func TestPriorityQueue_New(t *testing.T) {
+	pq := NewPriorityQueue()
+
+	if len(pq.data) != len(pq.dataMap) || len(pq.data) != 0 {
+		t.Fatalf("error in queue/map size, expected data and map to be initialized, got (%d) and (%d)", len(pq.data), len(pq.dataMap))
+	}
+
+	if pq.Len() != 0 {
+		t.Fatalf("expected new queue to have zero size, got (%d)", pq.Len())
+	}
+}
+
+func TestPriorityQueue_PushItem(t *testing.T) {
+	pq := NewPriorityQueue()
+
+	tc := testCases()
+	tcl := len(tc)
+	for _, i := range tc {
+		if err := pq.PushItem(i); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if pq.Len() != tcl {
+		t.Fatalf("error adding items, expected (%d) items, got (%d)", tcl, pq.Len())
+	}
+
+	testValidateInternalData(t, pq, len(tc), false)
+
+	item, err := pq.PopItem()
+	if err != nil {
+		t.Fatalf("error popping item: %s", err)
+	}
+	if tc[0].Priority != item.Priority {
+		t.Fatalf("expected tc[0] and popped item to match, got (%q) and (%q)", tc[0], item.Priority)
+	}
+	if !reflect.DeepEqual(tc[0], item) {
+		t.Fatal("expected test case and popped item match")
+	}
+
+	testValidateInternalData(t, pq, len(tc)-1, true)
+}
+
+func TestPriorityQueue_PopItem(t *testing.T) {
+	pq := NewPriorityQueue()
+
+	tc := testCases()
+	for _, i := range tc {
+		if err := pq.PushItem(i); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	topItem, err := pq.PopItem()
+	if err != nil {
+		t.Fatalf("error calling pop: %s", err)
+	}
+	if tc[0].Priority != topItem.Priority {
+		t.Fatalf("expected tc[0] and popped item to match, got (%q) and (%q)", tc[0], topItem.Priority)
+	}
+	if !reflect.DeepEqual(tc[0], topItem) {
+		t.Fatal("expected test case and popped item match")
+	}
+
+	var items []*Item
+	items = append(items, topItem)
+	// pop the remaining items, compare size of input and output
+	it, _ := pq.PopItem()
+	for ; it != nil; it, _ = pq.PopItem() {
+		items = append(items, it)
+	}
+	if len(items) != len(tc) {
+		t.Fatalf("expected popped item count to match test cases, got (%d)", len(items))
+	}
+
+	testValidateInternalData(t, pq, 0, true)
+}
+
+func TestPriorityQueue_PopItemByKey(t *testing.T) {
+	pq := NewPriorityQueue()
+
+	tc := testCases()
+	for _, i := range tc {
+		if err := pq.PushItem(i); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// grab the top priority item, to capture it's value for checking later
+	item, _ := pq.PopItem()
+	oldPriority := item.Priority
+	oldKey := item.Key
+
+	// push the item back on, so it gets removed with PopItemByKey and we verify
+	// the top item has changed later
+	err := pq.PushItem(item)
+	if err != nil {
+		t.Fatalf("error re-pushing top item: %s", err)
+	}
+
+	popKeys := []int{2, 4, 7, 1, 0}
+	for _, i := range popKeys {
+		item, err := pq.PopItemByKey(fmt.Sprintf("item-%d", i))
+		if err != nil || item == nil {
+			t.Fatalf("failed to pop item-%d, \n\terr: %s\n\titem: %#v", i, err, item)
+		}
+	}
+
+	testValidateInternalData(t, pq, len(tc)-len(popKeys), false)
+
+	// grab the top priority item again, to compare with the top item priority
+	// from above
+	item, _ = pq.PopItem()
+	newPriority := item.Priority
+	newKey := item.Key
+
+	if oldPriority == newPriority || oldKey == newKey {
+		t.Fatalf("expected old/new key and priority to differ, got (%s/%s) and (%d/%d)", oldKey, newKey, oldPriority, newPriority)
+	}
+
+	testValidateInternalData(t, pq, len(tc)-len(popKeys)-1, true)
+}
+
+// testValidateInternalData checks the internal data stucture of the PriorityQueue
+// and verifies that items are in-sync. Use drain only at the end of a test,
+// because it will mutate the input queue
+func testValidateInternalData(t *testing.T, pq *PriorityQueue, expectedSize int, drain bool) {
+	actualSize := pq.Len()
+	if actualSize != expectedSize {
+		t.Fatalf("expected new queue size to be (%d), got (%d)", expectedSize, actualSize)
+	}
+
+	if len(pq.data) != len(pq.dataMap) || len(pq.data) != expectedSize {
+		t.Fatalf("error in queue/map size, expected data and map to be (%d), got (%d) and (%d)", expectedSize, len(pq.data), len(pq.dataMap))
+	}
+
+	if drain && pq.Len() > 0 {
+		// pop all the items, verify lengths
+		i, _ := pq.PopItem()
+		for ; i != nil; i, _ = pq.PopItem() {
+			expectedSize--
+			if len(pq.data) != len(pq.dataMap) || len(pq.data) != expectedSize {
+				t.Fatalf("error in queue/map size, expected data and map to be (%d), got (%d) and (%d)", expectedSize, len(pq.data), len(pq.dataMap))
+			}
+		}
+	}
+}

--- a/sdk/queue/priority_queue_test.go
+++ b/sdk/queue/priority_queue_test.go
@@ -89,18 +89,10 @@ func TestPriorityQueue_Push(t *testing.T) {
 
 	testValidateInternalData(t, pq, len(tc)-1, true)
 
-	// check err not found
-	_, fErr := pq.PopByKey("empty")
-	if fErr == nil {
-		t.Fatalf("expected not found error")
-	}
-	switch fErr.(type) {
-	case *ErrItemNotFound:
-		if fErr.Error() != "queue item with key (empty) not found" {
-			t.Fatalf("expected error not found item message to match, got (%s)", fErr.Error())
-		}
-	default:
-		t.Fatalf("expected ErrItemNotFound error, got: %#v", fErr)
+	// check nil,nil error for not found
+	i, err := pq.PopByKey("empty")
+	if err != nil && i != nil {
+		t.Fatalf("expected nil error for PopByKey of non-existing key, got: %s", err)
 	}
 }
 
@@ -128,9 +120,9 @@ func TestPriorityQueue_Pop(t *testing.T) {
 	var items []*Item
 	items = append(items, topItem)
 	// pop the remaining items, compare size of input and output
-	it, _ := pq.Pop()
-	for ; it != nil; it, _ = pq.Pop() {
-		items = append(items, it)
+	i, _ := pq.Pop()
+	for ; i != nil; i, _ = pq.Pop() {
+		items = append(items, i)
 	}
 	if len(items) != len(tc) {
 		t.Fatalf("expected popped item count to match test cases, got (%d)", len(items))
@@ -162,7 +154,7 @@ func TestPriorityQueue_PopByKey(t *testing.T) {
 	popKeys := []int{2, 4, 7, 1, 0}
 	for _, i := range popKeys {
 		item, err := pq.PopByKey(fmt.Sprintf("item-%d", i))
-		if err != nil || item == nil {
+		if err != nil {
 			t.Fatalf("failed to pop item-%d, \n\terr: %s\n\titem: %#v", i, err, item)
 		}
 	}

--- a/sdk/queue/priority_queue_test.go
+++ b/sdk/queue/priority_queue_test.go
@@ -1,10 +1,14 @@
 package queue
 
 import (
+	"container/heap"
 	"fmt"
 	"testing"
 	"time"
 )
+
+// Ensure we satisfy the heap.Interface
+var _ heap.Interface = &queue{}
 
 // some tests rely on the ordering of items from this method
 func testCases() (tc []*Item) {

--- a/sdk/queue/priority_queue_test.go
+++ b/sdk/queue/priority_queue_test.go
@@ -34,7 +34,7 @@ func testCases() (tc []*Item) {
 }
 
 func TestPriorityQueue_New(t *testing.T) {
-	pq := NewPriorityQueue()
+	pq := New()
 
 	if len(pq.data) != len(pq.dataMap) || len(pq.data) != 0 {
 		t.Fatalf("error in queue/map size, expected data and map to be initialized, got (%d) and (%d)", len(pq.data), len(pq.dataMap))
@@ -46,7 +46,7 @@ func TestPriorityQueue_New(t *testing.T) {
 }
 
 func TestPriorityQueue_PushItem(t *testing.T) {
-	pq := NewPriorityQueue()
+	pq := New()
 
 	tc := testCases()
 	tcl := len(tc)
@@ -105,7 +105,7 @@ func TestPriorityQueue_PushItem(t *testing.T) {
 }
 
 func TestPriorityQueue_PopItem(t *testing.T) {
-	pq := NewPriorityQueue()
+	pq := New()
 
 	tc := testCases()
 	for _, i := range tc {
@@ -138,7 +138,7 @@ func TestPriorityQueue_PopItem(t *testing.T) {
 }
 
 func TestPriorityQueue_PopItemByKey(t *testing.T) {
-	pq := NewPriorityQueue()
+	pq := New()
 
 	tc := testCases()
 	for _, i := range tc {

--- a/sdk/queue/priority_queue_test.go
+++ b/sdk/queue/priority_queue_test.go
@@ -45,13 +45,13 @@ func TestPriorityQueue_New(t *testing.T) {
 	}
 }
 
-func TestPriorityQueue_PushItem(t *testing.T) {
+func TestPriorityQueue_Push(t *testing.T) {
 	pq := New()
 
 	tc := testCases()
 	tcl := len(tc)
 	for _, i := range tc {
-		if err := pq.PushItem(i); err != nil {
+		if err := pq.Push(i); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -62,7 +62,7 @@ func TestPriorityQueue_PushItem(t *testing.T) {
 
 	testValidateInternalData(t, pq, len(tc), false)
 
-	item, err := pq.PopItem()
+	item, err := pq.Pop()
 	if err != nil {
 		t.Fatalf("error popping item: %s", err)
 	}
@@ -76,13 +76,13 @@ func TestPriorityQueue_PushItem(t *testing.T) {
 	testValidateInternalData(t, pq, len(tc)-1, false)
 
 	// push item with no key
-	dErr := pq.PushItem(tc[1])
+	dErr := pq.Push(tc[1])
 	if dErr != ErrDuplicateItem {
 		t.Fatal(err)
 	}
 	// push item with no key
 	tc[2].Key = ""
-	kErr := pq.PushItem(tc[2])
+	kErr := pq.Push(tc[2])
 	if kErr != nil && kErr.Error() != "error adding item: Item Key is required" {
 		t.Fatal(kErr)
 	}
@@ -90,7 +90,7 @@ func TestPriorityQueue_PushItem(t *testing.T) {
 	testValidateInternalData(t, pq, len(tc)-1, true)
 
 	// check err not found
-	_, fErr := pq.PopItemByKey("empty")
+	_, fErr := pq.PopByKey("empty")
 	if fErr == nil {
 		t.Fatalf("expected not found error")
 	}
@@ -104,17 +104,17 @@ func TestPriorityQueue_PushItem(t *testing.T) {
 	}
 }
 
-func TestPriorityQueue_PopItem(t *testing.T) {
+func TestPriorityQueue_Pop(t *testing.T) {
 	pq := New()
 
 	tc := testCases()
 	for _, i := range tc {
-		if err := pq.PushItem(i); err != nil {
+		if err := pq.Push(i); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	topItem, err := pq.PopItem()
+	topItem, err := pq.Pop()
 	if err != nil {
 		t.Fatalf("error calling pop: %s", err)
 	}
@@ -128,8 +128,8 @@ func TestPriorityQueue_PopItem(t *testing.T) {
 	var items []*Item
 	items = append(items, topItem)
 	// pop the remaining items, compare size of input and output
-	it, _ := pq.PopItem()
-	for ; it != nil; it, _ = pq.PopItem() {
+	it, _ := pq.Pop()
+	for ; it != nil; it, _ = pq.Pop() {
 		items = append(items, it)
 	}
 	if len(items) != len(tc) {
@@ -137,31 +137,31 @@ func TestPriorityQueue_PopItem(t *testing.T) {
 	}
 }
 
-func TestPriorityQueue_PopItemByKey(t *testing.T) {
+func TestPriorityQueue_PopByKey(t *testing.T) {
 	pq := New()
 
 	tc := testCases()
 	for _, i := range tc {
-		if err := pq.PushItem(i); err != nil {
+		if err := pq.Push(i); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// grab the top priority item, to capture it's value for checking later
-	item, _ := pq.PopItem()
+	item, _ := pq.Pop()
 	oldPriority := item.Priority
 	oldKey := item.Key
 
-	// push the item back on, so it gets removed with PopItemByKey and we verify
+	// push the item back on, so it gets removed with PopByKey and we verify
 	// the top item has changed later
-	err := pq.PushItem(item)
+	err := pq.Push(item)
 	if err != nil {
 		t.Fatalf("error re-pushing top item: %s", err)
 	}
 
 	popKeys := []int{2, 4, 7, 1, 0}
 	for _, i := range popKeys {
-		item, err := pq.PopItemByKey(fmt.Sprintf("item-%d", i))
+		item, err := pq.PopByKey(fmt.Sprintf("item-%d", i))
 		if err != nil || item == nil {
 			t.Fatalf("failed to pop item-%d, \n\terr: %s\n\titem: %#v", i, err, item)
 		}
@@ -171,7 +171,7 @@ func TestPriorityQueue_PopItemByKey(t *testing.T) {
 
 	// grab the top priority item again, to compare with the top item priority
 	// from above
-	item, _ = pq.PopItem()
+	item, _ = pq.Pop()
 	newPriority := item.Priority
 	newKey := item.Key
 
@@ -197,8 +197,8 @@ func testValidateInternalData(t *testing.T, pq *PriorityQueue, expectedSize int,
 
 	if drain && pq.Len() > 0 {
 		// pop all the items, verify lengths
-		i, _ := pq.PopItem()
-		for ; i != nil; i, _ = pq.PopItem() {
+		i, _ := pq.Pop()
+		for ; i != nil; i, _ = pq.Pop() {
 			expectedSize--
 			if len(pq.data) != len(pq.dataMap) || len(pq.data) != expectedSize {
 				t.Fatalf("error in queue/map size, expected data and map to be (%d), got (%d) and (%d)", expectedSize, len(pq.data), len(pq.dataMap))


### PR DESCRIPTION
This pull request adds a [Priority Queue][1] package to Vault's SDK. The first use-case will be used by plugins to maintain an in-memory priority queue to perform periodic actions on, which will be added in upcoming pull requests following this one.



[1]: https://en.wikipedia.org/wiki/Priority_queue