### PR TITLE
Don't show TypeHeader fields as being sent as headers in OpenAPI

### DIFF
--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -61,7 +61,11 @@ vault secrets enable ssh
 vault secrets enable totp
 vault secrets enable transit
 
-curl -H "X-Vault-Token: root" "http://127.0.0.1:8200/v1/sys/internal/specs/openapi" > openapi.json
+if [ "$1" == "-p" ]; then
+  curl -H "X-Vault-Token: root" "http://127.0.0.1:8200/v1/sys/internal/specs/openapi" | jq > openapi.json
+else
+  curl -H "X-Vault-Token: root" "http://127.0.0.1:8200/v1/sys/internal/specs/openapi" > openapi.json
+fi
 
 kill $VAULT_PID
 sleep 1

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -257,13 +257,6 @@ func documentPath(p *Path, specialPaths *logical.Paths, backendType logical.Back
 				required = false
 			}
 
-			// Header parameters are part of the Parameters group but with
-			// a dedicated "header" location, a header parameter is not required.
-			if field.Type == TypeHeader {
-				location = "header"
-				required = false
-			}
-
 			t := convertType(field.Type)
 			p := OASParameter{
 				Name:        name,
@@ -608,8 +601,7 @@ func splitFields(allFields map[string]*FieldSchema, pattern string) (pathFields,
 
 	for name, field := range allFields {
 		if _, ok := pathFields[name]; !ok {
-			// Header fields are in "parameters" with other path fields
-			if field.Type == TypeHeader || field.Query {
+			if field.Query {
 				pathFields[name] = field
 			} else {
 				bodyFields[name] = field

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -151,8 +151,8 @@ func TestOpenAPI_Regex(t *testing.T) {
 
 func TestOpenAPI_ExpandPattern(t *testing.T) {
 	tests := []struct {
-		in_pattern   string
-		out_pathlets []string
+		inPattern   string
+		outPathlets []string
 	}{
 		{"rekey/backup", []string{"rekey/backup"}},
 		{"rekey/backup$", []string{"rekey/backup"}},
@@ -203,10 +203,10 @@ func TestOpenAPI_ExpandPattern(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		out := expandPattern(test.in_pattern)
+		out := expandPattern(test.inPattern)
 		sort.Strings(out)
-		if !reflect.DeepEqual(out, test.out_pathlets) {
-			t.Fatalf("Test %d: Expected %v got %v", i, test.out_pathlets, out)
+		if !reflect.DeepEqual(out, test.outPathlets) {
+			t.Fatalf("Test %d: Expected %v got %v", i, test.outPathlets, out)
 		}
 	}
 }
@@ -266,7 +266,10 @@ func TestOpenAPI_SpecialPaths(t *testing.T) {
 			Root:            test.rootPaths,
 			Unauthenticated: test.unauthPaths,
 		}
-		documentPath(&path, sp, logical.TypeLogical, doc)
+		err := documentPath(&path, sp, logical.TypeLogical, doc)
+		if err != nil {
+			t.Fatal(err)
+		}
 		result := test.root
 		if doc.Paths["/"+test.pattern].Sudo != result {
 			t.Fatalf("Test (root) %d: Expected %v got %v", i, test.root, result)
@@ -288,11 +291,11 @@ func TestOpenAPI_Paths(t *testing.T) {
 			Pattern: "lookup/" + GenericNameRegex("id"),
 
 			Fields: map[string]*FieldSchema{
-				"id": &FieldSchema{
+				"id": {
 					Type:        TypeString,
 					Description: "My id parameter",
 				},
-				"token": &FieldSchema{
+				"token": {
 					Type:        TypeString,
 					Description: "My token",
 				},
@@ -442,8 +445,14 @@ func TestOpenAPI_OperationID(t *testing.T) {
 
 	for _, context := range []string{"", "bar"} {
 		doc := NewOASDocument()
-		documentPath(path1, nil, logical.TypeLogical, doc)
-		documentPath(path2, nil, logical.TypeLogical, doc)
+		err := documentPath(path1, nil, logical.TypeLogical, doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = documentPath(path2, nil, logical.TypeLogical, doc)
+		if err != nil {
+			t.Fatal(err)
+		}
 		doc.CreateOperationIDs(context)
 
 		tests := []struct {
@@ -500,7 +509,10 @@ func TestOpenAPI_CustomDecoder(t *testing.T) {
 	}
 
 	docOrig := NewOASDocument()
-	documentPath(p, nil, logical.TypeLogical, docOrig)
+	err := documentPath(p, nil, logical.TypeLogical, docOrig)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	docJSON := mustJSONMarshal(t, docOrig)
 

--- a/sdk/framework/testdata/operations.json
+++ b/sdk/framework/testdata/operations.json
@@ -31,15 +31,6 @@
             "type": "string"
           },
           "required": true
-        },
-        {
-          "name": "x-abc-token",
-          "description": "a header value",
-          "in": "header",
-          "schema": {
-            "type": "string",
-            "enum": ["a", "b", "c"]
-          }
         }
       ],
       "get": {
@@ -95,6 +86,11 @@
                     "description": "the name",
                     "default": "Larry",
                     "pattern": "\\w([\\w-.]*\\w)?"
+                  },
+                  "x-abc-token": {
+                    "type": "string",
+                    "description": "a header value",
+                    "enum": ["a", "b", "c"]
                   }
                 }
               }


### PR DESCRIPTION
TypeHeader means a string the represents a header, not a location.

Fixes #6671