### PR TITLE
Fixed Typos

### DIFF
--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -271,10 +271,10 @@ If provided, Vault output will not include ANSI color escape sequence characters
 
 ### `VAULT_RATE_LIMIT`
 
-This enviroment variable will limit the rate at which the `vault` command
+This environment variable will limit the rate at which the `vault` command
 sends requests to Vault.
 
-This enviroment variable has the format `rate[:burst]` (where items in `[]` are
+This environment variable has the format `rate[:burst]` (where items in `[]` are
 optional). If not specified, the burst value defaults to rate. Both rate and
 burst are specified in "operations per second". If the environment variable is
 not specified, then the rate and burst will be unlimited *i.e.* rate
@@ -282,7 +282,7 @@ limiting is off by default.
 
 *Note:* The rate is limited for each invocation of the `vault` CLI. Since
 each invocation of the `vault` CLI typically only makes a few requests,
-this enviroment variable is most useful when using the Go
+this environment variable is most useful when using the Go
 [Vault client API](https://www.vaultproject.io/api/libraries.html#go).
 
 ### `VAULT_NAMESPACE`


### PR DESCRIPTION
Fixed typos: enviroment/environment x3.