### PR TITLE
Adds docs for session_token for awskms

### DIFF
--- a/website/source/docs/configuration/seal/awskms.html.md
+++ b/website/source/docs/configuration/seal/awskms.html.md
@@ -48,6 +48,9 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
   specified by the `AWS_ACCESS_KEY_ID` environment variable or as part of the
   AWS profile from the AWS CLI or instance profile.
 
+- `session_token` `(string: "")`: Specifies the AWS session token. This can
+  also be provided via the environment variable `AWS_SESSION_TOKEN`.
+
 - `secret_key` `(string: <required>)`: The AWS secret access key to use. May
   also be specified by the `AWS_SECRET_ACCESS_KEY` environment variable or as
   part of the AWS profile from the AWS CLI or instance profile.


### PR DESCRIPTION
Missing doc for `session_token` parameter for AWS KMS auto-unseal