### PR TITLE
[ssh] add client_token_accessor option to key_id

### DIFF
--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -779,7 +779,7 @@ func TestBackend_CustomKeyIDFormat(t *testing.T) {
 
 			createRoleStep("customrole", map[string]interface{}{
 				"key_type":                 "ca",
-				"key_id_format":            "{{role_name}}-{{token_display_name}}-{{public_key_hash}}",
+				"key_id_format":            "{{role_name}}-{{token_display_name}}-{{public_key_hash}}-{{client_token_accessor}}",
 				"allowed_users":            "tuber",
 				"default_user":             "tuber",
 				"allow_user_certificates":  true,

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -291,7 +291,7 @@ func pathRoles(b *backend) *framework.Path {
 				The following variables are available for use: '{{token_display_name}}' - The display name of
 				the token used to make the request. '{{role_name}}' - The name of the role signing the request.
 				'{{public_key_hash}}' - A SHA256 checksum of the public key that is being signed.
-				'{{client_token_accessor}}' - the token accessor for when the user was authenticated
+				'{{client_token_accessor}}' - The token accessor for when the user was authenticated
 				`,
 				DisplayName: "Key ID Format",
 			},

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -291,6 +291,7 @@ func pathRoles(b *backend) *framework.Path {
 				The following variables are available for use: '{{token_display_name}}' - The display name of
 				the token used to make the request. '{{role_name}}' - The name of the role signing the request.
 				'{{public_key_hash}}' - A SHA256 checksum of the public key that is being signed.
+				'{{client_token_accessor}}' - the token accessor for when the user was authenticated
 				`,
 				DisplayName: "Key ID Format",
 			},

--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -295,6 +295,7 @@ func (b *backend) calculateKeyID(data *framework.FieldData, req *logical.Request
 	}
 
 	keyID := substQuery(keyIDFormat, map[string]string{
+		"client_token_accessor": req.ClientTokenAccessor,
 		"token_display_name": req.DisplayName,
 		"role_name":          data.Get("role").(string),
 		"public_key_hash":    fmt.Sprintf("%x", sha256.Sum256(pubKey.Marshal())),

--- a/website/source/api/secret/ssh/index.html.md
+++ b/website/source/api/secret/ssh/index.html.md
@@ -205,7 +205,8 @@ This endpoint creates or updates a named role.
   format for the key id of a signed certificate. The following variables are
   available for use: '{{token_display_name}}' - The display name of the token used
   to make the request. '{{role_name}}' - The name of the role signing the request.
-  '{{public_key_hash}}' - A SHA256 checksum of the public key that is being signed.
+  '{{public_key_hash}}' - A SHA256 checksum of the public key that is being signed.he t
+  '{{client_token_accessor}}' -  The token accessor for when the user was authenticated
   e.g. "custom-keyid-{{token_display_name}}"
 
 - `allowed_user_key_lengths` `(map<string|int>: "")` – Specifies a map of ssh key types


### PR DESCRIPTION
It is very hard to audit logs when the user has used their aws user to assume a role and then log in as the display name is only the name of aws role. SSH logs only the `ssh-keygen` serial of the key which is also not useful. So we can add this as an option to trace back who has logged in.