### PR TITLE
Update handleRollback to support both PeriodicFunc and handleWALRollback

### DIFF
--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -418,16 +418,22 @@ func (b *Backend) handleRevokeRenew(ctx context.Context, req *logical.Request) (
 	}
 }
 
-// handleRollback invokes the PeriodicFunc set on the backend. It also does a WAL rollback operation.
+// handleRollback invokes the PeriodicFunc set on the backend. It also does a
+// WAL rollback operation.
 func (b *Backend) handleRollback(ctx context.Context, req *logical.Request) (*logical.Response, error) {
 	// Response is not expected from the periodic operation.
+	var merr error
 	if b.PeriodicFunc != nil {
 		if err := b.PeriodicFunc(ctx, req); err != nil {
-			return nil, err
+			merr = multierror.Append(merr, err)
 		}
 	}
 
-	return b.handleWALRollback(ctx, req)
+	resp, err := b.handleWALRollback(ctx, req)
+	if err != nil {
+		merr = multierror.Append(merr, err)
+	}
+	return resp, merr
 }
 
 func (b *Backend) handleAuthRenew(ctx context.Context, req *logical.Request) (*logical.Response, error) {


### PR DESCRIPTION
This PR changes the behavior of Backends that provide both [PeriodicFunc and WALRollback][1]. Currently if both are defined only the `PeriodicFunc` gets invoke and we return a nil response and the `PeriodicFunc`'s error. 

With this change, we invoke the `PeriodicFunc` if set and append its error response to a `multierror` error, if any. We then continue and call `b.handleWALRollback`, appending it's error if any, and return its response and the `multierror`.


----
[1]: https://github.com/hashicorp/vault/blob/de1dc459957f7a85fc42d810cf5c0151e77dc94c/sdk/framework/backend.go#L53-L69