### PR TITLE
Add link to R client on libraries list

### DIFF
--- a/website/source/api/libraries.html.md
+++ b/website/source/api/libraries.html.md
@@ -149,6 +149,10 @@ $ pip install hvac
 $ pip install async-hvac
 ```
 
+### R
+
+* [vaultr](https://github.com/vimc/vaultr)
+
 ### Rust
 
 * [HashicorpVault](https://crates.io/crates/hashicorp_vault)


### PR DESCRIPTION
This is a link for an R client for vault that we have developed (https://github.com/vimc/vaultr)