### PR TITLE
Replace audit.LogInput with more flexible logical.LogInput. 

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -16,13 +16,13 @@ type Backend interface {
 	// request is authorized but before the request is executed. The arguments
 	// MUST not be modified in anyway. They should be deep copied if this is
 	// a possibility.
-	LogRequest(context.Context, *LogInput) error
+	LogRequest(context.Context, *logical.LogInput) error
 
 	// LogResponse is used to synchronously log a response. This is done after
 	// the request is processed but before the response is sent. The arguments
 	// MUST not be modified in anyway. They should be deep copied if this is
 	// a possibility.
-	LogResponse(context.Context, *LogInput) error
+	LogResponse(context.Context, *logical.LogInput) error
 
 	// GetHash is used to return the given data with the backend's hash,
 	// so that a caller can determine if a value in the audit log matches
@@ -34,16 +34,6 @@ type Backend interface {
 
 	// Invalidate is called for path invalidation
 	Invalidate(context.Context)
-}
-
-// LogInput contains the input parameters passed into LogRequest and LogResponse
-type LogInput struct {
-	Auth                *logical.Auth
-	Request             *logical.Request
-	Response            *logical.Response
-	OuterErr            error
-	NonHMACReqDataKeys  []string
-	NonHMACRespDataKeys []string
 }
 
 // BackendConfig contains configuration parameters used in the factory func to

--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -99,7 +99,7 @@ func TestFormatJSON_formatRequest(t *testing.T) {
 		config := FormatterConfig{
 			HMACAccessor: false,
 		}
-		in := &LogInput{
+		in := &logical.LogInput{
 			Auth:     tc.Auth,
 			Request:  tc.Req,
 			OuterErr: tc.Err,

--- a/audit/format_jsonx_test.go
+++ b/audit/format_jsonx_test.go
@@ -103,7 +103,7 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 			OmitTime:     true,
 			HMACAccessor: false,
 		}
-		in := &LogInput{
+		in := &logical.LogInput{
 			Auth:     tc.Auth,
 			Request:  tc.Req,
 			OuterErr: tc.Err,

--- a/audit/format_test.go
+++ b/audit/format_test.go
@@ -41,11 +41,11 @@ func TestFormatRequestErrors(t *testing.T) {
 		AuditFormatWriter: &noopFormatWriter{},
 	}
 
-	if err := formatter.FormatRequest(context.Background(), ioutil.Discard, config, &LogInput{}); err == nil {
+	if err := formatter.FormatRequest(context.Background(), ioutil.Discard, config, &logical.LogInput{}); err == nil {
 		t.Fatal("expected error due to nil request")
 	}
 
-	in := &LogInput{
+	in := &logical.LogInput{
 		Request: &logical.Request{},
 	}
 	if err := formatter.FormatRequest(context.Background(), nil, config, in); err == nil {
@@ -59,11 +59,11 @@ func TestFormatResponseErrors(t *testing.T) {
 		AuditFormatWriter: &noopFormatWriter{},
 	}
 
-	if err := formatter.FormatResponse(context.Background(), ioutil.Discard, config, &LogInput{}); err == nil {
+	if err := formatter.FormatResponse(context.Background(), ioutil.Discard, config, &logical.LogInput{}); err == nil {
 		t.Fatal("expected error due to nil request")
 	}
 
-	in := &LogInput{
+	in := &logical.LogInput{
 		Request: &logical.Request{},
 	}
 	if err := formatter.FormatResponse(context.Background(), nil, config, in); err == nil {

--- a/audit/formatter.go
+++ b/audit/formatter.go
@@ -3,6 +3,8 @@ package audit
 import (
 	"context"
 	"io"
+
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 // Formatter is an interface that is responsible for formating a
@@ -11,8 +13,8 @@ import (
 //
 // It is recommended that you pass data through Hash prior to formatting it.
 type Formatter interface {
-	FormatRequest(context.Context, io.Writer, FormatterConfig, *LogInput) error
-	FormatResponse(context.Context, io.Writer, FormatterConfig, *LogInput) error
+	FormatRequest(context.Context, io.Writer, FormatterConfig, *logical.LogInput) error
+	FormatResponse(context.Context, io.Writer, FormatterConfig, *logical.LogInput) error
 }
 
 type FormatterConfig struct {

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -172,7 +172,7 @@ func (b *Backend) GetHash(ctx context.Context, data string) (string, error) {
 	return audit.HashString(salt, data), nil
 }
 
-func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogRequest(ctx context.Context, in *logical.LogInput) error {
 	b.fileLock.Lock()
 	defer b.fileLock.Unlock()
 
@@ -202,7 +202,7 @@ func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
 	return b.formatter.FormatRequest(ctx, b.f, b.formatConfig, in)
 }
 
-func (b *Backend) LogResponse(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 
 	b.fileLock.Lock()
 	defer b.fileLock.Unlock()

--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -131,7 +131,7 @@ func (b *Backend) GetHash(ctx context.Context, data string) (string, error) {
 	return audit.HashString(salt, data), nil
 }
 
-func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogRequest(ctx context.Context, in *logical.LogInput) error {
 	var buf bytes.Buffer
 	if err := b.formatter.FormatRequest(ctx, &buf, b.formatConfig, in); err != nil {
 		return err
@@ -154,7 +154,7 @@ func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
 	return err
 }
 
-func (b *Backend) LogResponse(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 	var buf bytes.Buffer
 	if err := b.formatter.FormatResponse(ctx, &buf, b.formatConfig, in); err != nil {
 		return err

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -118,7 +118,7 @@ func (b *Backend) GetHash(ctx context.Context, data string) (string, error) {
 	return audit.HashString(salt, data), nil
 }
 
-func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogRequest(ctx context.Context, in *logical.LogInput) error {
 	var buf bytes.Buffer
 	if err := b.formatter.FormatRequest(ctx, &buf, b.formatConfig, in); err != nil {
 		return err
@@ -129,7 +129,7 @@ func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
 	return err
 }
 
-func (b *Backend) LogResponse(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 	var buf bytes.Buffer
 	if err := b.formatter.FormatResponse(ctx, &buf, b.formatConfig, in); err != nil {
 		return err

--- a/sdk/logical/logical.go
+++ b/sdk/logical/logical.go
@@ -124,3 +124,8 @@ type Paths struct {
 	// unless it ends with '/' in which case it will be treated as a prefix.
 	SealWrapStorage []string
 }
+
+type Auditor interface {
+	AuditRequest(ctx context.Context, input *LogInput) error
+	AuditResponse(ctx context.Context, input *LogInput) error
+}

--- a/sdk/logical/system_view.go
+++ b/sdk/logical/system_view.go
@@ -70,6 +70,10 @@ type SystemView interface {
 	PluginEnv(context.Context) (*PluginEnvironment, error)
 }
 
+type ExtendedSystemView interface {
+	Auditor() Auditor
+}
+
 type StaticSystemView struct {
 	DefaultLeaseTTLVal  time.Duration
 	MaxLeaseTTLVal      time.Duration

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -505,3 +505,15 @@ func defaultAuditTable() *MountTable {
 	}
 	return table
 }
+
+type genericAuditor struct {
+	c *Core
+}
+
+func (g genericAuditor) AuditRequest(ctx context.Context, input *logical.LogInput) error {
+	return g.c.auditBroker.LogRequest(ctx, input, nil)
+}
+
+func (g genericAuditor) AuditResponse(ctx context.Context, input *logical.LogInput) error {
+	return g.c.auditBroker.LogResponse(ctx, input, nil)
+}

--- a/vault/core.go
+++ b/vault/core.go
@@ -1233,7 +1233,7 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 		auth.TokenType = te.Type
 	}
 
-	logInput := &audit.LogInput{
+	logInput := &logical.LogInput{
 		Auth:    auth,
 		Request: req,
 	}

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -21,6 +21,14 @@ type dynamicSystemView struct {
 	mountEntry *MountEntry
 }
 
+type extendedSystemView struct {
+	dynamicSystemView
+}
+
+func (e extendedSystemView) Auditor() logical.Auditor {
+	return genericAuditor{e.core}
+}
+
 func (d dynamicSystemView) DefaultLeaseTTL() time.Duration {
 	def, _ := d.fetchTTLs()
 	return def

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/errwrap"
 	multierror "github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -249,7 +248,7 @@ func (c *Core) StepDown(httpCtx context.Context, req *logical.Request) (retErr e
 		auth.TokenType = te.Type
 	}
 
-	logInput := &audit.LogInput{
+	logInput := &logical.LogInput{
 		Auth:    auth,
 		Request: req,
 	}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1198,9 +1198,11 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 // mount-specific entries; because this should be called when setting
 // up a mountEntry, it doesn't check to ensure that me is not nil
 func (c *Core) mountEntrySysView(entry *MountEntry) logical.SystemView {
-	return dynamicSystemView{
-		core:       c,
-		mountEntry: entry,
+	return extendedSystemView{
+		dynamicSystemView{
+			core:       c,
+			mountEntry: entry,
+		},
 	}
 }
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/errwrap"
 	multierror "github.com/hashicorp/go-multierror"
 	sockaddr "github.com/hashicorp/go-sockaddr"
-	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -537,7 +536,7 @@ func (c *Core) handleCancelableRequest(ctx context.Context, ns *namespace.Namesp
 
 	// Create an audit trail of the response
 	if !isControlGroupRun(req) {
-		logInput := &audit.LogInput{
+		logInput := &logical.LogInput{
 			Auth:                auth,
 			Request:             req,
 			Response:            auditResp,
@@ -668,7 +667,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 		}
 
 		if !isControlGroupRun(req) {
-			logInput := &audit.LogInput{
+			logInput := &logical.LogInput{
 				Auth:               auth,
 				Request:            req,
 				OuterErr:           ctErr,
@@ -690,7 +689,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 
 	// Create an audit trail of the request
 	if !isControlGroupRun(req) {
-		logInput := &audit.LogInput{
+		logInput := &logical.LogInput{
 			Auth:               auth,
 			Request:            req,
 			NonHMACReqDataKeys: nonHMACReqDataKeys,
@@ -941,7 +940,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 			errType = logical.ErrInvalidRequest
 		}
 
-		logInput := &audit.LogInput{
+		logInput := &logical.LogInput{
 			Auth:               auth,
 			Request:            req,
 			OuterErr:           ctErr,
@@ -963,7 +962,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 
 	// Create an audit trail of the request. Attach auth if it was returned,
 	// e.g. if a token was provided.
-	logInput := &audit.LogInput{
+	logInput := &logical.LogInput{
 		Auth:               auth,
 		Request:            req,
 		NonHMACReqDataKeys: nonHMACReqDataKeys,

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -600,11 +600,11 @@ func (n *noopAudit) GetHash(ctx context.Context, data string) (string, error) {
 	return salt.GetIdentifiedHMAC(data), nil
 }
 
-func (n *noopAudit) LogRequest(_ context.Context, _ *audit.LogInput) error {
+func (n *noopAudit) LogRequest(_ context.Context, _ *logical.LogInput) error {
 	return nil
 }
 
-func (n *noopAudit) LogResponse(_ context.Context, _ *audit.LogInput) error {
+func (n *noopAudit) LogResponse(_ context.Context, _ *logical.LogInput) error {
 	return nil
 }
 


### PR DESCRIPTION
The Request and Response fields can be *logical.Request and *logical.Response as before,
or now they can instead be of type logical.OptMarshaler.  In that case
the auditing subsystem delegates HMACing to the audit caller.

There is now an ExtendedSystemView interface that exposes an Auditor
interface, and an implementor genericAuditor.