### PR TITLE
UI: Confirm Action as a popover

### DIFF
--- a/ui/app/styles/components/confirm.scss
+++ b/ui/app/styles/components/confirm.scss
@@ -21,3 +21,41 @@
     text-align: left;
   }
 }
+
+.popup-menu-content .confirm-action-message {
+  margin: 0;
+
+  .message {
+    border: 0;
+    font-size: $size-8;
+    line-height: 1.33;
+    margin: 0;
+  }
+
+  .message-title {
+    font-size: 1rem;
+  }
+
+  .hs-icon {
+    color: $yellow;
+  }
+
+  p {
+    font-weight: $font-weight-semibold;
+    margin-left: $spacing-l;
+    padding-left: $spacing-xxs;
+    padding-top: 0;
+  }
+
+  .confirm-action-options {
+    border-top: $light-border;
+    display: flex;
+    padding: $spacing-xxs;
+
+    .link {
+      flex: 1;
+      text-align: center;
+      width: auto;
+    }
+  }
+}

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -112,10 +112,15 @@
 .popup-menu-content .level-left {
   flex-shrink: 1;
 }
-.popup-menu-trigger {
-  height: 2rem;
-  min-width: 0;
-  padding: 0 $size-10;
+
+.list-item-row,
+.wizard-dismiss-menu {
+  .popup-menu-trigger {
+    height: 2.5rem;
+    min-width: 0;
+    padding: 0;
+    width: 2.5rem;
+  }
 }
 
 .status-menu-content {

--- a/ui/app/styles/components/popup-menu.scss
+++ b/ui/app/styles/components/popup-menu.scss
@@ -114,6 +114,7 @@
 }
 
 .list-item-row,
+.info-table-row,
 .wizard-dismiss-menu {
   .popup-menu-trigger {
     height: 2.5rem;

--- a/ui/app/styles/components/toolbar.scss
+++ b/ui/app/styles/components/toolbar.scss
@@ -22,7 +22,7 @@
 
   .input,
   .select {
-    min-width: 160px;
+    min-width: 190px;
   }
 }
 
@@ -87,6 +87,11 @@
 
   &:active {
     box-shadow: none;
+  }
+
+  &.popup-menu-trigger {
+    height: 2.5rem;
+    padding: $size-10 $size-8;
   }
 }
 

--- a/ui/app/templates/components/auth-info.hbs
+++ b/ui/app/templates/components/auth-info.hbs
@@ -12,6 +12,16 @@
                 on {{date-format auth.tokenExpirationDate 'MMMM Do YYYY, h:mm:ss a'}}" />
           </li>
         {{/if}}
+        <li class="action">
+          <button type="button" class="link" onclick={{action "restartGuide"}}>
+            Restart guide
+          </button>
+        </li>
+        <li class="action">
+          <CopyButton @clipboardText={{auth.currentToken}} class="link" @buttonType="button" @success={{action (set-flash-message 'Token copied!')}}>
+            Copy token
+          </CopyButton>
+        </li>
         {{#if (is-before (now interval=1000) auth.tokenExpirationDate)}}
           {{#if auth.authData.renewable}}
             <li class="action">
@@ -20,50 +30,30 @@
               </button>
             </li>
             <li class="action">
-              {{#confirm-action
-                onConfirmAction=(action "revokeToken")
-                confirmMessage=(concat "Are you sure you want to revoke the token for " (get auth 'authData.displayName') "?")
-                confirmButtonText="Revoke"
-                confirmButtonClasses="button is-primary"
-                buttonClasses="button link"
-                showConfirm=shouldRevoke
-                class=(if shouldRevoke "message is-block is-warning is-outline")
-                containerClasses="message-body is-block"
-                messageClasses="is-block"
-              }}
+              <ConfirmAction
+                @onConfirmAction={{action "revokeToken"}}
+                @confirmMessage={{concat "Are you sure you want to revoke the token for " (get auth 'authData.displayName') "?"}}
+                @confirmButtonText="Revoke"
+                @buttonClasses="button link is-destroy"
+              >
                 Revoke token
-              {{/confirm-action}}
+              </ConfirmAction>
             </li>
           {{else}}
             <li class="action text-right">
-              {{#confirm-action
-                onConfirmAction=(action "revokeToken")
-                confirmMessage=(concat "Are you sure you want to revoke the token for " (get auth 'authData.displayName') "?")
-                confirmButtonText="Revoke"
-                confirmButtonClasses="button is-primary"
-                buttonClasses="button link"
-                showConfirm=shouldRevoke
-                class=(if shouldRevoke "message is-block is-warning is-outline")
-                containerClasses="message-body is-block"
-                messageClasses="is-block"
-              }}
+              <ConfirmAction
+                @onConfirmAction={{action "revokeToken"}}
+                @confirmMessage={{concat "Are you sure you want to revoke the token for " (get auth 'authData.displayName') "?"}}
+                @confirmButtonText="Revoke"
+                @buttonClasses="button link is-destroy"
+              >
                 Revoke token
-              {{/confirm-action}}
+              </ConfirmAction>
             </li>
           {{/if}}
         {{/if}}
         <li class="action">
-          <CopyButton @clipboardText={{auth.currentToken}} class="link" @buttonType="button" @success={{action (set-flash-message 'Token copied!')}}>
-            Copy token
-          </CopyButton>
-        </li>
-        <li class="action">
-          <button type="button" class="link" onclick={{action "restartGuide"}}>
-            Restart guide
-          </button>
-        </li>
-        <li class="action">
-          {{#link-to "vault.cluster.logout" activeClusterName id="logout" invokeAction=onLinkClick}}
+          {{#link-to "vault.cluster.logout" activeClusterName id="logout" class="is-destroy" invokeAction=onLinkClick}}
             Sign out
           {{/link-to}}
         </li>

--- a/ui/app/templates/components/auth-info.hbs
+++ b/ui/app/templates/components/auth-info.hbs
@@ -31,10 +31,11 @@
             </li>
             <li class="action">
               <ConfirmAction
-                @onConfirmAction={{action "revokeToken"}}
-                @confirmMessage={{concat "Are you sure you want to revoke the token for " (get auth 'authData.displayName') "?"}}
-                @confirmButtonText="Revoke"
                 @buttonClasses="button link is-destroy"
+                @confirmTitle={{concat "Revoke " (get auth 'authData.displayName') "?"}}
+                @confirmMessage={{concat "You will not be able to log in again with this token."}}
+                @confirmButtonText="Revoke"
+                @onConfirmAction={{action "revokeToken"}}
               >
                 Revoke token
               </ConfirmAction>
@@ -42,10 +43,11 @@
           {{else}}
             <li class="action text-right">
               <ConfirmAction
-                @onConfirmAction={{action "revokeToken"}}
-                @confirmMessage={{concat "Are you sure you want to revoke the token for " (get auth 'authData.displayName') "?"}}
-                @confirmButtonText="Revoke"
                 @buttonClasses="button link is-destroy"
+                @confirmTitle={{concat "Revoke " (get auth 'authData.displayName') "?"}}
+                @confirmMessage={{concat "You will not be able to log in again with this token."}}
+                @confirmButtonText="Revoke"
+                @onConfirmAction={{action "revokeToken"}}
               >
                 Revoke token
               </ConfirmAction>

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -56,9 +56,9 @@
           {{#if model.canDeleteRoot}}
             <ConfirmAction
               @buttonClasses="button"
+              @confirmTitle="Delete this CA key?"
+              @confirmMessage="This CA certificate will still be available for reading until a new certificate/key are generated or uploaded."
               @onConfirmAction={{action "deleteCA"}}
-              @confirmMessage="Are you sure you want to delete the root CA key?"
-              @cancelButtonText="Cancel"
             >
               Delete
             </ConfirmAction>

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -54,14 +54,14 @@
         </div>
         <div class="control">
           {{#if model.canDeleteRoot}}
-            {{#confirm-action
-              buttonClasses="button"
-              onConfirmAction=(action "deleteCA")
-              confirmMessage="Are you sure you want to delete the root CA key?"
-              cancelButtonText="Cancel"
-            }}
-            Delete
-            {{/confirm-action}}
+            <ConfirmAction
+              @buttonClasses="button"
+              @onConfirmAction={{action "deleteCA"}}
+              @confirmMessage="Are you sure you want to delete the root CA key?"
+              @cancelButtonText="Cancel"
+            >
+              Delete
+            </ConfirmAction>
           {{/if}}
         </div>
       </div>

--- a/ui/app/templates/components/edit-form.hbs
+++ b/ui/app/templates/components/edit-form.hbs
@@ -25,7 +25,7 @@
       <ConfirmAction
         @buttonClasses="button is-ghost"
         @onConfirmAction={{action (perform save model (hash method="destroyRecord"))}}
-        @confirmMessage="Are you sure you want to delete this config?"
+        @confirmMessage="This config will be permanently deleted."
         data-test-edit-delete="true"
       >
         <span data-test-edit-delete-text>

--- a/ui/app/templates/components/edit-form.hbs
+++ b/ui/app/templates/components/edit-form.hbs
@@ -1,3 +1,19 @@
+{{#if model.canDelete}}
+  <Toolbar>
+    <ToolbarActions>
+      <ConfirmAction
+        @buttonClasses="toolbar-link"
+        @onConfirmAction={{action (perform save model (hash method="destroyRecord"))}}
+        @confirmMessage="This config will be permanently deleted."
+        data-test-edit-delete="true"
+      >
+        <span data-test-edit-delete-text>
+          {{deleteButtonText}}
+        </span>
+      </ConfirmAction>
+    </ToolbarActions>
+  </Toolbar>
+{{/if}}
 <form {{action (perform save model) on="submit"}}>
   <MessageError @model={{model}} data-test-edit-form-error />
   <div class="box is-sideless is-fullwidth is-marginless">
@@ -21,17 +37,5 @@
         </div>
       {{/if}}
     </div>
-    {{#if model.canDelete}}
-      <ConfirmAction
-        @buttonClasses="button is-ghost"
-        @onConfirmAction={{action (perform save model (hash method="destroyRecord"))}}
-        @confirmMessage="This config will be permanently deleted."
-        data-test-edit-delete="true"
-      >
-        <span data-test-edit-delete-text>
-          {{deleteButtonText}}
-        </span>
-      </ConfirmAction>
-    {{/if}}
   </div>
 </form>

--- a/ui/app/templates/components/edit-form.hbs
+++ b/ui/app/templates/components/edit-form.hbs
@@ -26,8 +26,8 @@
         @buttonClasses="button is-ghost"
         @onConfirmAction={{action (perform save model (hash method="destroyRecord"))}}
         @confirmMessage="Are you sure you want to delete this config?"
-        data-test-edit-delete
-        >
+        data-test-edit-delete="true"
+      >
         <span data-test-edit-delete-text>
           {{deleteButtonText}}
         </span>

--- a/ui/app/templates/components/identity/edit-form.hbs
+++ b/ui/app/templates/components/identity/edit-form.hbs
@@ -1,3 +1,17 @@
+{{#if (and (eq mode "edit") model.canDelete)}}
+  <Toolbar>
+    <ToolbarActions>
+      <ConfirmAction
+        @buttonClasses="toolbar-link"
+        @onConfirmAction={{action "deleteItem" model}}
+        data-test-entity-item-delete="true"
+      >
+        Delete
+      </ConfirmAction>
+    </ToolbarActions>
+  </Toolbar>
+{{/if}}
+
 <form {{action (perform save) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode={{mode}} @noun={{lowercase (humanize model.identityType)}} />
@@ -34,14 +48,5 @@
         {{/if}}
       </div>
     </div>
-      {{#if (and (eq mode "edit") model.canDelete)}}
-        <ConfirmAction
-          @buttonClasses="button is-ghost"
-          @onConfirmAction={{action "deleteItem" model}}
-          data-test-entity-item-delete="true"
-        >
-            Delete
-        </ConfirmAction>
-      {{/if}}
   </div>
 </form>

--- a/ui/app/templates/components/identity/edit-form.hbs
+++ b/ui/app/templates/components/identity/edit-form.hbs
@@ -35,14 +35,14 @@
       </div>
     </div>
       {{#if (and (eq mode "edit") model.canDelete)}}
-        {{#confirm-action
-          buttonClasses="button is-ghost"
-          onConfirmAction=(action "deleteItem" model)
-          confirmMessage=(concat "Are you sure you want to delete " model.id "?")
-          data-test-entity-item-delete=true
-        }}
+        <ConfirmAction
+          @buttonClasses="button is-ghost"
+          @onConfirmAction={{action "deleteItem" model}}
+          @confirmMessage={{concat "Are you sure you want to delete " model.id "?"}}
+          data-test-entity-item-delete="true"
+        >
             Delete
-        {{/confirm-action}}
+        </ConfirmAction>
       {{/if}}
   </div>
 </form>

--- a/ui/app/templates/components/identity/edit-form.hbs
+++ b/ui/app/templates/components/identity/edit-form.hbs
@@ -38,7 +38,6 @@
         <ConfirmAction
           @buttonClasses="button is-ghost"
           @onConfirmAction={{action "deleteItem" model}}
-          @confirmMessage={{concat "Are you sure you want to delete " model.id "?"}}
           data-test-entity-item-delete="true"
         >
             Delete

--- a/ui/app/templates/components/identity/edit-form.hbs
+++ b/ui/app/templates/components/identity/edit-form.hbs
@@ -6,7 +6,7 @@
         @onConfirmAction={{action "deleteItem" model}}
         data-test-entity-item-delete="true"
       >
-        Delete
+        Delete {{model.identityType}}
       </ConfirmAction>
     </ToolbarActions>
   </Toolbar>

--- a/ui/app/templates/components/identity/popup-alias.hbs
+++ b/ui/app/templates/components/identity/popup-alias.hbs
@@ -23,19 +23,14 @@
         {{/if}}
         {{#if item.canDelete}}
           <li class="action">
-            {{#confirm-action
-              data-test-item-delete=true
-              confirmButtonClasses="button is-primary"
-              buttonClasses="link is-destroy"
-              onConfirmAction=(action "performTransaction" item)
-              confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-              showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
-              class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
-              containerClasses="message-body is-block"
-              messageClasses="is-block"
-            }}
+            <ConfirmAction
+              @buttonClasses="link is-destroy"
+              @onConfirmAction={{action "performTransaction" item}}
+              @confirmMessage={{concat "Are you sure you want to delete " item.id "?"}}
+              data-test-item-delete="true"
+            >
               Delete
-            {{/confirm-action}}
+            </ConfirmAction>
           </li>
         {{/if}}
       {{/if}}

--- a/ui/app/templates/components/identity/popup-alias.hbs
+++ b/ui/app/templates/components/identity/popup-alias.hbs
@@ -26,7 +26,6 @@
             <ConfirmAction
               @buttonClasses="link is-destroy"
               @onConfirmAction={{action "performTransaction" item}}
-              @confirmMessage={{concat "Are you sure you want to delete " item.id "?"}}
               data-test-item-delete="true"
             >
               Delete

--- a/ui/app/templates/components/identity/popup-members.hbs
+++ b/ui/app/templates/components/identity/popup-members.hbs
@@ -2,19 +2,14 @@
   <nav class="menu">
     <ul class="menu-list">
       <li class="action">
-        {{#confirm-action
-          confirmButtonClasses="button is-primary"
-          confirmButtonText="Remove"
-          buttonClasses="link is-destroy"
-          onConfirmAction=(action "performTransaction" model groupArray memberId)
-          confirmMessage=(concat "Are you sure you want to remove " memberId "?")
-          showConfirm=(get this (concat "shouldDelete-" (dot-to-dash memberId)))
-          class=(if (get this (concat "shouldDelete-" (dot-to-dash memberId))) "message is-block is-warning is-outline")
-          containerClasses="message-body is-block"
-          messageClasses="is-block"
-        }}
+        <ConfirmAction
+          @buttonClasses="link is-destroy"
+          @confirmButtonText="Remove"
+          @onConfirmAction={{action "performTransaction" model groupArray memberId}}
+          @confirmMessage={{concat "Are you sure you want to remove " memberId "?"}}
+        >
           Remove
-        {{/confirm-action}}
+        </ConfirmAction>
       </li>
     </ul>
   </nav>

--- a/ui/app/templates/components/identity/popup-members.hbs
+++ b/ui/app/templates/components/identity/popup-members.hbs
@@ -4,9 +4,9 @@
       <li class="action">
         <ConfirmAction
           @buttonClasses="link is-destroy"
-          @confirmButtonText="Remove"
+          @confirmButtonText="Remove this group?"
+          @confirmMessage="This may affect permissions for this group."
           @onConfirmAction={{action "performTransaction" model groupArray memberId}}
-          @confirmMessage={{concat "Are you sure you want to remove " memberId "?"}}
         >
           Remove
         </ConfirmAction>

--- a/ui/app/templates/components/identity/popup-metadata.hbs
+++ b/ui/app/templates/components/identity/popup-metadata.hbs
@@ -4,9 +4,10 @@
       <li class="action">
         <ConfirmAction
           @buttonClasses="link is-destroy"
+          @confirmTitle="Remove metadata?"
+          @confirmMessage="This data may be used outside of Vault."
           @confirmButtonText="Remove"
-          @onConfirmAction={{action "performTransaction" model key }}
-          @confirmMessage={{concat "Are you sure you want to remove " key "?"}}
+          @onConfirmAction={{action "performTransaction" model key}}
         >
           Remove
         </ConfirmAction>

--- a/ui/app/templates/components/identity/popup-metadata.hbs
+++ b/ui/app/templates/components/identity/popup-metadata.hbs
@@ -3,16 +3,11 @@
     <ul class="menu-list">
       <li class="action">
         <ConfirmAction
-          @confirmButtonClasses="button is-primary"
-          @confirmButtonText="Remove"
           @buttonClasses="link is-destroy"
+          @confirmButtonText="Remove"
           @onConfirmAction={{action "performTransaction" model key }}
           @confirmMessage={{concat "Are you sure you want to remove " key "?"}}
-          @showConfirm={{get this (concat "shouldDelete-" key)}}
-          class={{ if (get this (concat "shouldDelete-" key)) "message is-block is-warning is-outline" }}
-          @containerClasses="message-body is-block"
-          @messageClasses="is-block"
-          >
+        >
           Remove
         </ConfirmAction>
       </li>

--- a/ui/app/templates/components/identity/popup-policy.hbs
+++ b/ui/app/templates/components/identity/popup-policy.hbs
@@ -12,19 +12,14 @@
         {{/link-to}}
       </li>
       <li class="action">
-        {{#confirm-action
-          confirmButtonClasses="button is-primary"
-          confirmButtonText="Remove"
-          buttonClasses="link is-destroy"
-          onConfirmAction=(action "performTransaction" model policyName)
-          confirmMessage=(concat "Are you sure you want to remove " policyName "?")
-          showConfirm=(get this (concat "shouldDelete-" (dot-to-dash policyName)))
-          class=(if (get this (concat "shouldDelete-" (dot-to-dash policyName))) "message is-block is-warning is-outline")
-          containerClasses="message-body is-block"
-          messageClasses="is-block"
-        }}
+        <ConfirmAction
+          @buttonClasses="link is-destroy"
+          @confirmButtonText="Remove"
+          @onConfirmAction={{concat "Are you sure you want to remove " policyName "?"}}
+          @confirmMessage={{concat "Are you sure you want to remove " policyName "?"}}
+        >
           Remove from {{model.identityType}}
-        {{/confirm-action}}
+        </ConfirmAction>
       </li>
     </ul>
   </nav>

--- a/ui/app/templates/components/identity/popup-policy.hbs
+++ b/ui/app/templates/components/identity/popup-policy.hbs
@@ -15,8 +15,8 @@
         <ConfirmAction
           @buttonClasses="link is-destroy"
           @confirmButtonText="Remove"
-          @onConfirmAction={{concat "Are you sure you want to remove " policyName "?"}}
-          @confirmMessage={{concat "Are you sure you want to remove " policyName "?"}}
+          @confirmMessage="This policy may affect permissions to access Vault data."
+          @onConfirmAction={{action "performTransaction" model policyName}}
         >
           Remove from {{model.identityType}}
         </ConfirmAction>

--- a/ui/app/templates/components/pki-cert-popup.hbs
+++ b/ui/app/templates/components/pki-cert-popup.hbs
@@ -12,7 +12,7 @@
             @buttonClasses="link is-destroy"
             @onConfirmAction={{action "delete" item}}
             @confirmTitle="Revoke this cert?"
-            @confirmMessage="This may affect access to Vault data."
+            @confirmMessage="Any services using this cert may be affected."
             @confirmButtonText="Revoke"
             data-test-cert-revoke-delete={{item.id}}
           >

--- a/ui/app/templates/components/pki-cert-popup.hbs
+++ b/ui/app/templates/components/pki-cert-popup.hbs
@@ -11,7 +11,8 @@
           <ConfirmAction
             @buttonClasses="link is-destroy"
             @onConfirmAction={{action "delete" item}}
-            @confirmMessage={{concat "Are you sure you want to revoke " item.id "?"}}
+            @confirmTitle="Revoke this cert?"
+            @confirmMessage="This may affect access to Vault data."
             @confirmButtonText="Revoke"
             data-test-cert-revoke-delete={{item.id}}
           >

--- a/ui/app/templates/components/pki-cert-popup.hbs
+++ b/ui/app/templates/components/pki-cert-popup.hbs
@@ -8,20 +8,15 @@
       </li>
       {{#if item.canRevoke}}
         <li class="action">
-          {{#confirm-action
-            confirmButtonClasses="button is-primary"
-            buttonClasses="link is-destroy"
-            onConfirmAction=(action "delete" item)
-            confirmMessage=(concat "Are you sure you want to revoke " item.id "?")
-            showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
-            class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
-            containerClasses="message-body is-block"
-            messageClasses="is-block"
-            confirmButtonText="Revoke"
-            data-test-cert-revoke-delete=item.id
-          }}
+          <ConfirmAction
+            @buttonClasses="link is-destroy"
+            @onConfirmAction={{action "delete" item}}
+            @confirmMessage={{concat "Are you sure you want to revoke " item.id "?"}}
+            @confirmButtonText="Revoke"
+            data-test-cert-revoke-delete={{item.id}}
+          >
             Revoke
-          {{/confirm-action}}
+          </ConfirmAction>
         </li>
       {{/if}}
     </ul>

--- a/ui/app/templates/components/pki-cert-show.hbs
+++ b/ui/app/templates/components/pki-cert-show.hbs
@@ -51,7 +51,8 @@
     <ConfirmAction
       @buttonClasses="button"
       @onConfirmAction={{action "delete"}}
-      @confirmMessage={{concat "Are you sure you want to revoke " model.id "?"}}
+      @confirmTitle="Revoke this cert?"
+      @confirmMessage="This may affect access to Vault data."
       @confirmButtonText="Revoke"
     >
       Revoke

--- a/ui/app/templates/components/pki-cert-show.hbs
+++ b/ui/app/templates/components/pki-cert-show.hbs
@@ -52,7 +52,7 @@
       @buttonClasses="button"
       @onConfirmAction={{action "delete"}}
       @confirmTitle="Revoke this cert?"
-      @confirmMessage="This may affect access to Vault data."
+      @confirmMessage="Any services using this cert may be affected."
       @confirmButtonText="Revoke"
     >
       Revoke

--- a/ui/app/templates/components/pki-cert-show.hbs
+++ b/ui/app/templates/components/pki-cert-show.hbs
@@ -48,14 +48,13 @@
     </div>
   </div>
   {{#if (and (not model.revocationTime) model.canRevoke)}}
-    {{#confirm-action
-      buttonClasses="button"
-      onConfirmAction=(action "delete")
-      confirmMessage=(concat "Are you sure you want to revoke " model.id "?")
-      cancelButtonText="Cancel"
-      confirmButtonText="Revoke"
-    }}
+    <ConfirmAction
+      @buttonClasses="button"
+      @onConfirmAction={{action "delete"}}
+      @confirmMessage={{concat "Are you sure you want to revoke " model.id "?"}}
+      @confirmButtonText="Revoke"
+    >
       Revoke
-    {{/confirm-action}}
+    </ConfirmAction>
   {{/if}}
 </div>

--- a/ui/app/templates/components/role-aws-edit.hbs
+++ b/ui/app/templates/components/role-aws-edit.hbs
@@ -33,7 +33,7 @@
           Generate credentials
         </ToolbarSecretLink>
       {{/if}}
-      {{#if (and model.canGenerate (or model.canDelete model.canUpdate))}}
+      {{#if (and model.canGenerate (or model.canDelete model.canEdit))}}
         <div class="toolbar-separator" />
       {{/if}}
       {{#if model.canDelete}}
@@ -44,7 +44,7 @@
           Delete role
         </ConfirmAction>
       {{/if}}
-      {{#if (or model.canUpdate model.canDelete)}}
+      {{#if model.canEdit}}
         <ToolbarSecretLink
           @secret={{model.id}}
           @mode="edit"

--- a/ui/app/templates/components/role-aws-edit.hbs
+++ b/ui/app/templates/components/role-aws-edit.hbs
@@ -21,18 +21,9 @@
   </p.levelLeft>
 </PageHeader>
 
-<Toolbar>
-  <ToolbarActions>
-    {{#if (eq mode "show")}}
-      {{#if (or model.canUpdate model.canDelete)}}
-        <ToolbarSecretLink
-          @secret={{model.id}}
-          @mode="edit"
-          @replace=true
-        >
-          Edit role
-        </ToolbarSecretLink>
-      {{/if}}
+{{#if (eq mode "show")}}
+  <Toolbar>
+    <ToolbarActions>
       {{#if model.canGenerate}}
         <ToolbarSecretLink
           @secret={{model.id}}
@@ -42,9 +33,29 @@
           Generate credentials
         </ToolbarSecretLink>
       {{/if}}
-    {{/if}}
-  </ToolbarActions>
-</Toolbar>
+      {{#if (and model.canGenerate (or model.canDelete model.canUpdate))}}
+        <div class="toolbar-separator" />
+      {{/if}}
+      {{#if model.canDelete}}
+        <ConfirmAction
+          @buttonClasses="toolbar-link"
+          @onConfirmAction={{action "delete"}}
+        >
+          Delete role
+        </ConfirmAction>
+      {{/if}}
+      {{#if (or model.canUpdate model.canDelete)}}
+        <ToolbarSecretLink
+          @secret={{model.id}}
+          @mode="edit"
+          @replace=true
+        >
+          Edit role
+        </ToolbarSecretLink>
+      {{/if}}
+    </ToolbarActions>
+  </Toolbar>
+{{/if}}
 
 {{#if (or (eq mode 'edit') (eq mode 'create'))}}
   {{partial 'partials/role-aws/form'}}

--- a/ui/app/templates/components/role-pki-edit.hbs
+++ b/ui/app/templates/components/role-pki-edit.hbs
@@ -21,19 +21,9 @@
   </p.levelLeft>
 </PageHeader>
 
-<Toolbar>
-  <ToolbarActions>
-    {{#if (eq mode "show") }}
-      {{#if (or model.canUpdate model.canDelete)}}
-        <ToolbarSecretLink
-          @secret={{model.id}}
-          @mode="edit"
-          @data-test-edit-link=true
-          @replace=true
-        >
-          Edit role
-        </ToolbarSecretLink>
-      {{/if}}
+{{#if (eq mode "show") }}
+  <Toolbar>
+    <ToolbarActions>
       {{#if model.canGenerate}}
         <ToolbarSecretLink
           @secret={{model.id}}
@@ -54,9 +44,31 @@
           Sign Certificate
         </ToolbarSecretLink>
       {{/if}}
-    {{/if}}
-  </ToolbarActions>
-</Toolbar>
+      {{#if (and (or model.canGenerate model.canSign) (or model.canDelete model.canUpdate))}}
+        <div class="toolbar-separator" />
+      {{/if}}
+      {{#if model.canDelete}}
+        <ConfirmAction
+          @buttonClasses="toolbar-link"
+          @onConfirmAction={{action "delete"}}
+          data-test-role-delete="true"
+        >
+          Delete role
+        </ConfirmAction>
+      {{/if}}
+      {{#if (or model.canUpdate model.canDelete)}}
+        <ToolbarSecretLink
+          @secret={{model.id}}
+          @mode="edit"
+          @data-test-edit-link=true
+          @replace=true
+        >
+          Edit role
+        </ToolbarSecretLink>
+      {{/if}}
+    </ToolbarActions>
+  </Toolbar>
+{{/if}}
 
 {{#if (or (eq mode 'edit') (eq mode 'create'))}}
   {{partial 'partials/role-pki/form'}}

--- a/ui/app/templates/components/role-pki-edit.hbs
+++ b/ui/app/templates/components/role-pki-edit.hbs
@@ -44,7 +44,7 @@
           Sign Certificate
         </ToolbarSecretLink>
       {{/if}}
-      {{#if (and (or model.canGenerate model.canSign) (or model.canDelete model.canUpdate))}}
+      {{#if (and (or model.canGenerate model.canSign) (or model.canDelete model.canEdit))}}
         <div class="toolbar-separator" />
       {{/if}}
       {{#if model.canDelete}}
@@ -56,7 +56,7 @@
           Delete role
         </ConfirmAction>
       {{/if}}
-      {{#if (or model.canUpdate model.canDelete)}}
+      {{#if model.canEdit}}
         <ToolbarSecretLink
           @secret={{model.id}}
           @mode="edit"

--- a/ui/app/templates/components/role-ssh-edit.hbs
+++ b/ui/app/templates/components/role-ssh-edit.hbs
@@ -21,19 +21,9 @@
   </p.levelLeft>
 </PageHeader>
 
-{{#if (eq mode "show") }}
+{{#if (eq mode "show")}}
   <Toolbar>
     <ToolbarActions>
-      {{#if (or model.canUpdate model.canDelete)}}
-        <ToolbarSecretLink
-          @secret={{model.id}}
-          @mode="edit"
-          @data-test-edit-link=true
-          @replace=true
-        >
-          Edit role
-        </ToolbarSecretLink>
-      {{/if}}
       {{#if (eq model.keyType "otp")}}
         <ToolbarSecretLink
           @secret={{model.id}}
@@ -51,6 +41,27 @@
           @replace=true
         >
           Sign Keys
+        </ToolbarSecretLink>
+      {{/if}}
+      {{#if (or model.canUpdate model.canDelete)}}
+        <div class="toolbar-separator" />
+      {{/if}}
+      {{#if model.canDelete}}
+        <ConfirmAction
+          @buttonClasses="toolbar-link"
+          @onConfirmAction={{action "delete"}}
+        >
+          Delete role
+        </ConfirmAction>
+      {{/if}}
+      {{#if (or model.canUpdate model.canDelete)}}
+        <ToolbarSecretLink
+          @secret={{model.id}}
+          @mode="edit"
+          @data-test-edit-link=true
+          @replace=true
+        >
+          Edit role
         </ToolbarSecretLink>
       {{/if}}
     </ToolbarActions>

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -102,9 +102,8 @@
         }}
         @cancelButtonText="Cancel"
         data-test-secret-delete="true"
-        >
+      >
         Delete secret
-        <Chevron @isButton={{true}} />
       </ConfirmAction>
     {{/if}}
 

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -97,10 +97,9 @@
         @buttonClasses="toolbar-link"
         @onConfirmAction={{action "deleteKey"}}
         @confirmMessage={{if isV2
-          (concat "This will permanently delete " model.id " and all its versions. Are you sure you want to do this?")
-          (concat "Are you sure you want to delete " model.id "?")
+          (concat "This will permanently delete all versions of this secret.")
+          (concat "You will not be able to recover this secret data later.")
         }}
-        @cancelButtonText="Cancel"
         data-test-secret-delete="true"
       >
         Delete secret

--- a/ui/app/templates/components/secret-version-menu.hbs
+++ b/ui/app/templates/components/secret-version-menu.hbs
@@ -49,17 +49,13 @@
                     {{/if}}
                   {{else if canDeleteVersion}}
                     <ConfirmAction
-                      @buttonClasses="link has-text-danger"
-                      @containerClasses="message-body is-block"
-                      @messageClasses="is-block"
+                      @buttonClasses="link is-destroy"
                       @onConfirmAction={{action "deleteVersion" "delete"}}
-                      @confirmMessage={{
-                        concat "Are you sure you want to delete " this.version.path " version " this.version.version "?"
-                      }}
+                      @confirmMessage={{xconcat "Are you sure you want to delete " this.version.path " version " this.version.version "?"}}
                       @cancelButtonText="Cancel"
                       data-test-secret-v2-delete="true"
-                      >
-                        Delete version
+                    >
+                      Delete version
                     </ConfirmAction>
                   {{else}}
                     <button type="button" class="link" disabled >
@@ -70,17 +66,15 @@
                 {{#if canDestroyVersion}}
                   <li class="action">
                     <ConfirmAction
-                      @buttonClasses="link has-text-danger"
-                      @containerClasses="message-body is-block"
-                      @messageClasses="is-block"
+                      @buttonClasses="link is-destroy"
                       @onConfirmAction={{action "deleteVersion" "destroy"}}
                       @confirmMessage={{
                         concat "This will permanently destroy " this.version.path " version " this.version.version ". Are you sure you want to do this?"
                       }}
                       @cancelButtonText="Cancel"
                       data-test-secret-v2-destroy="true"
-                      >
-                        Permanently destroy version
+                    >
+                      Permanently destroy version
                     </ConfirmAction>
                   </li>
                 {{else}}

--- a/ui/app/templates/components/secret-version-menu.hbs
+++ b/ui/app/templates/components/secret-version-menu.hbs
@@ -50,9 +50,9 @@
                   {{else if canDeleteVersion}}
                     <ConfirmAction
                       @buttonClasses="link is-destroy"
+                      @confirmTitle="Delete version?"
+                      @confirmMessage="This version will no longer be able to be read, but the underlying data will not be removed and can still be undeleted."
                       @onConfirmAction={{action "deleteVersion" "delete"}}
-                      @confirmMessage={{xconcat "Are you sure you want to delete " this.version.path " version " this.version.version "?"}}
-                      @cancelButtonText="Cancel"
                       data-test-secret-v2-delete="true"
                     >
                       Delete version
@@ -67,11 +67,9 @@
                   <li class="action">
                     <ConfirmAction
                       @buttonClasses="link is-destroy"
+                      @confirmTitle="Permanently delete?"
+                      @confirmMessage="This version will no longer be able to be read, and cannot be undeleted."
                       @onConfirmAction={{action "deleteVersion" "destroy"}}
-                      @confirmMessage={{
-                        concat "This will permanently destroy " this.version.path " version " this.version.version ". Are you sure you want to do this?"
-                      }}
-                      @cancelButtonText="Cancel"
                       data-test-secret-v2-destroy="true"
                     >
                       Permanently destroy version

--- a/ui/app/templates/components/transit-key-actions.hbs
+++ b/ui/app/templates/components/transit-key-actions.hbs
@@ -3,7 +3,7 @@
     <ConfirmAction
       @buttonClasses="toolbar-link"
       @confirmTitle="Rotate this key?"
-      @confirmMessage="After rotation, new plaintext requests will be encrypted with the new version of the key."
+      @confirmMessage="After rotation, all key actions will default to using the newest version of the key."
       @confirmButtonText="Rotate"
       @onConfirmAction={{action "doSubmit"}}
       data-test-transit-key-rotate="true"

--- a/ui/app/templates/components/transit-key-actions.hbs
+++ b/ui/app/templates/components/transit-key-actions.hbs
@@ -1,17 +1,16 @@
 {{#if (eq selectedAction 'rotate')}}
   {{#if key.canRotate}}
-    {{#confirm-action
-        buttonClasses="toolbar-link"
-        onConfirmAction=(action "doSubmit")
-        confirmMessage=(concat 'Are you sure you want to rotate "' key.id '"?')
-        confirmButtonText="Confirm rotation"
-        cancelButtonText="Cancel"
-        messageClasses="is-block-mobile has-text-grey"
-        data-test-transit-key-rotate=true
-      }}
+    <ConfirmAction
+      @buttonClasses="toolbar-link"
+      @onConfirmAction={{action "doSubmit"}}
+      @confirmMessage={{concat 'Are you sure you want to rotate "' key.id '"?'}}
+      @confirmButtonText="Confirm rotation"
+      @cancelButtonText="Cancel"
+      data-test-transit-key-rotate="true"
+    >
       Rotate encryption key
       <Chevron @isButton={{true}} />
-    {{/confirm-action}}
+    </ConfirmAction>
   {{/if}}
 {{else}}
   {{message-error errors=errors}}

--- a/ui/app/templates/components/transit-key-actions.hbs
+++ b/ui/app/templates/components/transit-key-actions.hbs
@@ -2,10 +2,10 @@
   {{#if key.canRotate}}
     <ConfirmAction
       @buttonClasses="toolbar-link"
+      @confirmTitle="Rotate this key?"
+      @confirmMessage="After rotation, new plaintext requests will be encrypted with the new version of the key."
+      @confirmButtonText="Rotate"
       @onConfirmAction={{action "doSubmit"}}
-      @confirmMessage={{concat 'Are you sure you want to rotate "' key.id '"?'}}
-      @confirmButtonText="Confirm rotation"
-      @cancelButtonText="Cancel"
       data-test-transit-key-rotate="true"
     >
       Rotate encryption key

--- a/ui/app/templates/partials/role-aws/form.hbs
+++ b/ui/app/templates/partials/role-aws/form.hbs
@@ -37,14 +37,13 @@
       {{/secret-link}}
     </div>
     {{#if (and (eq mode 'edit') model.canDelete)}}
-      {{#confirm-action
-        buttonClasses="button"
-        onConfirmAction=(action "delete")
-        confirmMessage=(concat "Are you sure you want to delete " model.id "?")
-        cancelButtonText="Cancel"
-      }}
+      <ConfirmAction
+        @buttonClasses="button is-ghost"
+        @onConfirmAction={{action "delete"}}
+        @confirmMessage={{concat "Are you sure you want to delete " model.id "?"}}
+      >
         Delete
-      {{/confirm-action}}
+      </ConfirmAction>
     {{/if}}
   </div>
 </form>

--- a/ui/app/templates/partials/role-aws/form.hbs
+++ b/ui/app/templates/partials/role-aws/form.hbs
@@ -36,13 +36,5 @@
         Cancel
       {{/secret-link}}
     </div>
-    {{#if (and (eq mode 'edit') model.canDelete)}}
-      <ConfirmAction
-        @buttonClasses="button is-ghost"
-        @onConfirmAction={{action "delete"}}
-      >
-        Delete
-      </ConfirmAction>
-    {{/if}}
   </div>
 </form>

--- a/ui/app/templates/partials/role-aws/form.hbs
+++ b/ui/app/templates/partials/role-aws/form.hbs
@@ -40,7 +40,6 @@
       <ConfirmAction
         @buttonClasses="button is-ghost"
         @onConfirmAction={{action "delete"}}
-        @confirmMessage={{concat "Are you sure you want to delete " model.id "?"}}
       >
         Delete
       </ConfirmAction>

--- a/ui/app/templates/partials/role-aws/popup-menu.hbs
+++ b/ui/app/templates/partials/role-aws/popup-menu.hbs
@@ -42,19 +42,14 @@
         {{/if}}
         {{#if item.canDelete}}
           <li class="action">
-            {{#confirm-action
-              confirmButtonClasses="button is-primary"
-              buttonClasses="link is-destroy"
-              onConfirmAction=(action "delete" item)
-              confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-              showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
-              class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
-              containerClasses="message-body is-block"
-              messageClasses="is-block"
-              data-test-aws-role-delete=item.id
-            }}
+            <ConfirmAction
+              @buttonClasses="button is-ghost"
+              @onConfirmAction={{action "delete" item}}
+              @confirmMessage={{concat "Are you sure you want to delete " item.id "?"}}
+              data-test-aws-role-delete={{item.id}}
+            >
               Delete
-            {{/confirm-action}}
+            </ConfirmAction>
           </li>
         {{/if}}
       {{/if}}

--- a/ui/app/templates/partials/role-aws/popup-menu.hbs
+++ b/ui/app/templates/partials/role-aws/popup-menu.hbs
@@ -45,7 +45,6 @@
             <ConfirmAction
               @buttonClasses="button is-ghost"
               @onConfirmAction={{action "delete" item}}
-              @confirmMessage={{concat "Are you sure you want to delete " item.id "?"}}
               data-test-aws-role-delete={{item.id}}
             >
               Delete

--- a/ui/app/templates/partials/role-aws/popup-menu.hbs
+++ b/ui/app/templates/partials/role-aws/popup-menu.hbs
@@ -43,7 +43,7 @@
         {{#if item.canDelete}}
           <li class="action">
             <ConfirmAction
-              @buttonClasses="button is-ghost"
+              @buttonClasses="link is-destroy"
               @onConfirmAction={{action "delete" item}}
               data-test-aws-role-delete={{item.id}}
             >

--- a/ui/app/templates/partials/role-pki/form.hbs
+++ b/ui/app/templates/partials/role-pki/form.hbs
@@ -26,14 +26,5 @@
         Cancel
       {{/secret-link}}
     </div>
-    {{#if (and (eq mode 'edit') model.canDelete)}}
-      <ConfirmAction
-        @buttonClasses="button is-ghost"
-        @onConfirmAction={{action "delete"}}
-        data-test-role-delete="true"
-      >
-        Delete
-      </ConfirmAction>
-    {{/if}}
   </div>
 </form>

--- a/ui/app/templates/partials/role-pki/form.hbs
+++ b/ui/app/templates/partials/role-pki/form.hbs
@@ -30,7 +30,6 @@
       <ConfirmAction
         @buttonClasses="button is-ghost"
         @onConfirmAction={{action "delete"}}
-        @confirmMessage={{concat "Are you sure you want to delete " model.id "?"}}
         data-test-role-delete="true"
       >
         Delete

--- a/ui/app/templates/partials/role-pki/form.hbs
+++ b/ui/app/templates/partials/role-pki/form.hbs
@@ -27,15 +27,14 @@
       {{/secret-link}}
     </div>
     {{#if (and (eq mode 'edit') model.canDelete)}}
-      {{#confirm-action
-        data-test-role-delete
-        buttonClasses="button"
-        onConfirmAction=(action "delete")
-        confirmMessage=(concat "Are you sure you want to delete " model.id "?")
-        cancelButtonText="Cancel"
-      }}
+      <ConfirmAction
+        @buttonClasses="button is-ghost"
+        @onConfirmAction={{action "delete"}}
+        @confirmMessage={{concat "Are you sure you want to delete " model.id "?"}}
+        data-test-role-delete="true"
+      >
         Delete
-      {{/confirm-action}}
+      </ConfirmAction>
     {{/if}}
   </div>
 </form>

--- a/ui/app/templates/partials/role-pki/popup-menu.hbs
+++ b/ui/app/templates/partials/role-pki/popup-menu.hbs
@@ -1,4 +1,4 @@
-{{#popup-menu name="role-aws-nav" contentClass="is-wide"}}
+{{#popup-menu name="role-aws-nav"}}
   <nav class="menu">
     {{#if (or item.generatePath.isPending item.signPath.isPending)}}
       <ul class="menu-list">

--- a/ui/app/templates/partials/role-pki/popup-menu.hbs
+++ b/ui/app/templates/partials/role-pki/popup-menu.hbs
@@ -58,7 +58,6 @@
             <ConfirmAction
               @buttonClasses="link is-destroy"
               @onConfirmAction={{action "delete" item}}
-              @confirmMessage={{concat "Are you sure you want to delete " item.id "?"}}
               data-test-aws-role-delete={{item.id}}
             >
               Delete

--- a/ui/app/templates/partials/role-pki/popup-menu.hbs
+++ b/ui/app/templates/partials/role-pki/popup-menu.hbs
@@ -55,19 +55,14 @@
         {{/if}}
         {{#if item.canDelete}}
           <li class="action">
-            {{#confirm-action
-              confirmButtonClasses="button is-primary"
-              buttonClasses="link is-destroy"
-              onConfirmAction=(action "delete" item)
-              confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-              showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
-              class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
-              containerClasses="message-body is-block"
-              messageClasses="is-block"
-              data-test-aws-role-delete=item.id
-            }}
+            <ConfirmAction
+              @buttonClasses="link is-destroy"
+              @onConfirmAction={{action "delete" item}}
+              @confirmMessage={{concat "Are you sure you want to delete " item.id "?"}}
+              data-test-aws-role-delete={{item.id}}
+            >
               Delete
-            {{/confirm-action}}
+            </ConfirmAction>
           </li>
         {{/if}}
       {{/if}}

--- a/ui/app/templates/partials/role-ssh/form.hbs
+++ b/ui/app/templates/partials/role-ssh/form.hbs
@@ -50,7 +50,6 @@
       <ConfirmAction
         @buttonClasses="button is-ghost"
         @onConfirmAction={{action "delete"}}
-        @confirmMessage={{concat "Are you sure you want to delete " model.id "?"}}
       >
         Delete
       </ConfirmAction>

--- a/ui/app/templates/partials/role-ssh/form.hbs
+++ b/ui/app/templates/partials/role-ssh/form.hbs
@@ -46,13 +46,5 @@
         Cancel
       {{/secret-link}}
     </div>
-    {{#if (and (eq mode 'edit') model.canDelete)}}
-      <ConfirmAction
-        @buttonClasses="button is-ghost"
-        @onConfirmAction={{action "delete"}}
-      >
-        Delete
-      </ConfirmAction>
-    {{/if}}
   </div>
 </form>

--- a/ui/app/templates/partials/role-ssh/form.hbs
+++ b/ui/app/templates/partials/role-ssh/form.hbs
@@ -47,14 +47,13 @@
       {{/secret-link}}
     </div>
     {{#if (and (eq mode 'edit') model.canDelete)}}
-      {{#confirm-action
-        buttonClasses="button"
-        onConfirmAction=(action "delete")
-        confirmMessage=(concat "Are you sure you want to delete " model.id "?")
-        cancelButtonText="Cancel"
-      }}
+      <ConfirmAction
+        @buttonClasses="button is-ghost"
+        @onConfirmAction={{action "delete"}}
+        @confirmMessage={{concat "Are you sure you want to delete " model.id "?"}}
+      >
         Delete
-      {{/confirm-action}}
+      </ConfirmAction>
     {{/if}}
   </div>
 </form>

--- a/ui/app/templates/partials/role-ssh/popup-menu.hbs
+++ b/ui/app/templates/partials/role-ssh/popup-menu.hbs
@@ -61,7 +61,6 @@
             <ConfirmAction
               @buttonClasses="link is-destroy"
               @onConfirmAction={{action "delete" item}}
-              @confirmMessage={{concat "Are you sure you want to delete " item.id "?"}}
               data-test-ssh-role-delete={{item.id}}
             >
               Delete

--- a/ui/app/templates/partials/role-ssh/popup-menu.hbs
+++ b/ui/app/templates/partials/role-ssh/popup-menu.hbs
@@ -58,19 +58,14 @@
         {{/if}}
         {{#if item.canDelete}}
           <li class="action">
-            {{#confirm-action
-              confirmButtonClasses="button is-primary"
-              buttonClasses="link is-destroy"
-              onConfirmAction=(action "delete" item)
-              confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-              showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
-              class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
-              containerClasses="message-body is-block"
-              messageClasses="is-block"
-              data-test-ssh-role-delete=item.id
-            }}
+            <ConfirmAction
+              @buttonClasses="link is-destroy"
+              @onConfirmAction={{action "delete" item}}
+              @confirmMessage={{concat "Are you sure you want to delete " item.id "?"}}
+              data-test-ssh-role-delete={{item.id}}
+            >
               Delete
-            {{/confirm-action}}
+            </ConfirmAction>
           </li>
         {{/if}}
       {{/if}}

--- a/ui/app/templates/partials/role-ssh/popup-menu.hbs
+++ b/ui/app/templates/partials/role-ssh/popup-menu.hbs
@@ -30,6 +30,27 @@
           </li>
         {{/if}}
       {{/if}}
+      {{#if item.canEditZeroAddress}}
+        {{#if item.zeroAddress}}
+          <li class="action">
+            <button type="button" disabled={{get this (concat "loading-" item.id)}} class="link button is-transparent
+              {{if (get this (concat "loading-" item.id)) 'is-loading'}} " {{action "toggleZeroAddress" item backendModel}}>
+              Disable Zero Address
+            </button>
+          </li>
+        {{else}}
+          <li class="action">
+            <button
+              type="button"
+              disabled={{get this (concat "loading-" item.id)}}
+              class="link button is-transparent {{if (get this (concat "loading-" item.id)) 'is-loading'}}"
+              {{action "toggleZeroAddress" item backendModel}}
+            >
+              Enable Zero Address
+            </button>
+          </li>
+        {{/if}}
+      {{/if}}
       {{#if item.updatePath.isPending}}
         <li class="action">
           <button disabled type="button" class="link button is-loading is-transparent">
@@ -65,27 +86,6 @@
             >
               Delete
             </ConfirmAction>
-          </li>
-        {{/if}}
-      {{/if}}
-      {{#if item.canEditZeroAddress}}
-        {{#if item.zeroAddress}}
-          <li class="action">
-            <button type="button" disabled={{get this (concat "loading-" item.id)}} class="link button is-transparent
-              {{if (get this (concat "loading-" item.id)) 'is-loading'}} " {{action "toggleZeroAddress" item backendModel}}>
-              Disable Zero Address
-            </button>
-          </li>
-        {{else}}
-          <li class="action">
-            <button
-              type="button"
-              disabled={{get this (concat "loading-" item.id)}}
-              class="link button is-transparent {{if (get this (concat "loading-" item.id)) 'is-loading'}}"
-              {{action "toggleZeroAddress" item backendModel}}
-            >
-              Enable Zero Address
-            </button>
           </li>
         {{/if}}
       {{/if}}

--- a/ui/app/templates/partials/secret-backend-settings/ssh.hbs
+++ b/ui/app/templates/partials/secret-backend-settings/ssh.hbs
@@ -28,14 +28,13 @@
       {{/copy-button}}
     </div>
     <div class="control">
-      {{#confirm-action
-        buttonClasses="button"
-        onConfirmAction=(action "saveConfig" (hash delete=true))
-        confirmMessage=(concat "This will delete the current CA keys associated with this backend. Are you sure you want to delete them?")
-        cancelButtonText="Cancel"
-      }}
+      <ConfirmAction
+        @buttonClasses="button"
+        @onConfirmAction={{action "saveConfig" (hash delete=true)}}
+        @confirmMessage={{concat "This will delete the current CA keys associated with this backend. Are you sure you want to delete them?"}}
+      >
         Delete
-      {{/confirm-action}}
+      </ConfirmAction>
     </div>
   </div>
 {{else}}

--- a/ui/app/templates/partials/secret-backend-settings/ssh.hbs
+++ b/ui/app/templates/partials/secret-backend-settings/ssh.hbs
@@ -30,8 +30,8 @@
     <div class="control">
       <ConfirmAction
         @buttonClasses="button"
+        @confirmMessage="This will remove the CA certificate information."
         @onConfirmAction={{action "saveConfig" (hash delete=true)}}
-        @confirmMessage={{concat "This will delete the current CA keys associated with this backend. Are you sure you want to delete them?"}}
       >
         Delete
       </ConfirmAction>

--- a/ui/app/templates/partials/secret-list/item.hbs
+++ b/ui/app/templates/partials/secret-list/item.hbs
@@ -81,8 +81,8 @@
                   <li class="action">
                     <ConfirmAction
                       @buttonClasses="link is-destroy"
+                      @confirmMessage="This will permanently delete this secret and all its versions."
                       @onConfirmAction={{action "delete" item "secret"}}
-                      @confirmMessage={{concat "Are you sure you want to permanently delete " item.id " and all its versions?"}}
                       data-test-v2-kv-delete={{item.id}}
                     >
                       {{if backendModel.isV2KV

--- a/ui/app/templates/partials/secret-list/item.hbs
+++ b/ui/app/templates/partials/secret-list/item.hbs
@@ -79,22 +79,17 @@
                 {{/if}}
                 {{#if item.canDelete}}
                   <li class="action">
-                    {{#confirm-action
-                      confirmButtonClasses="button is-primary"
-                      buttonClasses="link is-destroy"
-                      onConfirmAction=(action "delete" item "secret")
-                      confirmMessage=(concat "Are you sure you want to permanently delete " item.id " and all its versions?")
-                      showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
-                      class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
-                      containerClasses="message-body is-block"
-                      messageClasses="is-block"
-                      data-test-v2-kv-delete=item.id
-                    }}
+                    <ConfirmAction
+                      @buttonClasses="link is-destroy"
+                      @onConfirmAction={{action "delete" item "secret"}}
+                      @confirmMessage={{concat "Are you sure you want to permanently delete " item.id " and all its versions?"}}
+                      data-test-v2-kv-delete={{item.id}}
+                    >
                       {{if backendModel.isV2KV
                         "Permanently delete"
                         "Delete"
                       }}
-                    {{/confirm-action}}
+                    </ConfirmAction>
                   </li>
                 {{/if}}
               {{/if}}

--- a/ui/app/templates/partials/status/cluster.hbs
+++ b/ui/app/templates/partials/status/cluster.hbs
@@ -99,7 +99,6 @@
             {{#if activeCluster.unsealed}}
               {{#if (has-permission 'status' routeParams='seal')}}
                 {{#link-to 'vault.cluster.settings.seal' cluster.name
-                  class="level is-mobile"
                   invokeAction=(action (queue (action onLinkClick) (action d.actions.close)))
                 }}
                   <div class="level is-mobile">

--- a/ui/app/templates/partials/transit-form-edit.hbs
+++ b/ui/app/templates/partials/transit-form-edit.hbs
@@ -94,7 +94,6 @@
         <ConfirmAction
           @buttonClasses="button"
           @onConfirmAction={{action "deleteKey"}}
-          @confirmMessage={{concat "Are you sure you want to delete " key.id "?"}}
         >
           Delete encryption key
         </ConfirmAction>

--- a/ui/app/templates/partials/transit-form-edit.hbs
+++ b/ui/app/templates/partials/transit-form-edit.hbs
@@ -76,7 +76,7 @@
               disabled={{requestInFlight}}
               class="button is-primary {{if requestInFlight 'is-loading'}}"
             >
-              Update encryption key
+              Update transit key
             </button>
           </div>
         {{/if}}
@@ -95,7 +95,7 @@
           @buttonClasses="button"
           @onConfirmAction={{action "deleteKey"}}
         >
-          Delete encryption key
+          Delete transit key
         </ConfirmAction>
       {{/if}}
     </div>

--- a/ui/app/templates/partials/transit-form-edit.hbs
+++ b/ui/app/templates/partials/transit-form-edit.hbs
@@ -91,14 +91,13 @@
         </div>
       </div>
       {{#if (and key.canDelete capabilities.canDelete)}}
-        {{#confirm-action
-          buttonClasses="button"
-          onConfirmAction=(action "deleteKey")
-          confirmMessage=(concat "Are you sure you want to delete " key.id "?")
-          cancelButtonText="Cancel"
-        }}
+        <ConfirmAction
+          @buttonClasses="button"
+          @onConfirmAction={{action "deleteKey"}}
+          @confirmMessage={{concat "Are you sure you want to delete " key.id "?"}}
+        >
           Delete encryption key
-        {{/confirm-action}}
+        </ConfirmAction>
       {{/if}}
     </div>
 </form>

--- a/ui/app/templates/vault/cluster/access/identity/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/index.hbs
@@ -45,6 +45,13 @@
                     </button>
                   </li>
                 {{else}}
+                  {{#if item.canAddAlias}}
+                    <li class="action">
+                      {{#link-to "vault.cluster.access.identity.aliases.add" (pluralize identityType) item.id}}
+                        Create alias
+                      {{/link-to}}
+                    </li>
+                  {{/if}}
                   {{#if item.canEdit}}
                     <li class="action">
                       {{#link-to "vault.cluster.access.identity.edit" item.id}}
@@ -57,44 +64,27 @@
                           Enable
                         </button>
                       {{else if (eq identityType 'entity')}}
-                        {{#confirm-action
-                          confirmButtonClasses="button is-primary"
-                          confirmButtonText="Disable"
-                          buttonClasses="link"
-                          onConfirmAction=(action "toggleDisabled" item)
-                          confirmMessage=(concat "Are you sure you want to disable " item.id "?")
-                          showConfirm=(get this (concat "shouldDisable-" (dot-to-dash item.id)))
-                          class=(if (get this (concat "shouldDisable-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
-                          containerClasses="message-body is-block"
-                          messageClasses="is-block"
-                        }}
+                        <ConfirmAction
+                          @buttonClasses="link is-destroy"
+                          @confirmButtonText="Disable"
+                          @onConfirmAction={{action "toggleDisabled" item}}
+                          @confirmMessage={{concat "Are you sure you want to disable " item.id "?"}}
+                        >
                           Disable
-                        {{/confirm-action}}
+                        </ConfirmAction>
                       {{/if}}
-                    </li>
-                  {{/if}}
-                  {{#if item.canAddAlias}}
-                    <li class="action">
-                      {{#link-to "vault.cluster.access.identity.aliases.add" (pluralize identityType) item.id}}
-                        Create alias
-                      {{/link-to}}
                     </li>
                   {{/if}}
                   {{#if item.canDelete}}
                     <li class="action">
-                      {{#confirm-action
-                        data-test-item-delete=true
-                        confirmButtonClasses="button is-primary"
-                        buttonClasses="link"
-                        onConfirmAction=(action "delete" item)
-                        confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-                        showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
-                        class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
-                        containerClasses="message-body is-block"
-                        messageClasses="is-block"
-                      }}
+                      <ConfirmAction
+                        @buttonClasses="link is-destroy"
+                        @onConfirmAction={{action "delete" item}}
+                        @confirmMessage={{concat "Are you sure you want to delete " item.id "?"}}
+                        data-test-item-delete="true"
+                      >
                         Delete
-                      {{/confirm-action}}
+                      </ConfirmAction>
                     </li>
                   {{/if}}
                 {{/if}}

--- a/ui/app/templates/vault/cluster/access/identity/index.hbs
+++ b/ui/app/templates/vault/cluster/access/identity/index.hbs
@@ -66,9 +66,10 @@
                       {{else if (eq identityType 'entity')}}
                         <ConfirmAction
                           @buttonClasses="link is-destroy"
+                          @confirmTitle="Disable this?"
+                          @confirmMessage="Associated tokens will not be revoked, but cannot be used"
                           @confirmButtonText="Disable"
                           @onConfirmAction={{action "toggleDisabled" item}}
-                          @confirmMessage={{concat "Are you sure you want to disable " item.id "?"}}
                         >
                           Disable
                         </ConfirmAction>
@@ -80,7 +81,6 @@
                       <ConfirmAction
                         @buttonClasses="link is-destroy"
                         @onConfirmAction={{action "delete" item}}
-                        @confirmMessage={{concat "Are you sure you want to delete " item.id "?"}}
                         data-test-item-delete="true"
                       >
                         Delete

--- a/ui/app/templates/vault/cluster/access/leases/list.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/list.hbs
@@ -53,13 +53,10 @@
         {{#if (and capabilities.forceRevokePrefix.canUpdate (not confirmingRevoke))}}
           <ConfirmAction
             @buttonClasses="toolbar-link"
+            @confirmTitle="Disable this?"
+            @confirmMessage={{concat "All leases under this one will also be removed and disregard any errors encountered."}}
+            @confirmButtonText="Revoke"
             @onConfirmAction={{action "revokePrefix" baseKey.id true}}
-            @confirmMessage={{concat
-              "Confirming removes all leases under "
-              baseKey.id
-              " and disregards any errors encountered."
-            }}
-            @confirmButtonText={{concat "Revoke " baseKey.id}}
           >
             Force revoke prefix
           </ConfirmAction>
@@ -69,9 +66,10 @@
         {{#if (and capabilities.revokePrefix.canUpdate (not confirmingForceRevoke))}}
           <ConfirmAction
             @buttonClasses="toolbar-link"
+            @confirmTitle="Revoke this?"
+            @confirmMessage={{concat "All leases under this one will also be removed"}}
+            @confirmButtonText="Revoke"
             @onConfirmAction={{action "revokePrefix" baseKey.id}}
-            @confirmMessage={{concat "Confirming will remove all leases under " baseKey.id}}
-            @confirmButtonText={{concat "Revoke " baseKey.id}}
             data-test-lease-revoke-prefix="true"
           >
             Revoke prefix

--- a/ui/app/templates/vault/cluster/access/leases/list.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/list.hbs
@@ -51,39 +51,31 @@
     {{#if (not-eq baseKey.id '')}}
       <div class="control">
         {{#if (and capabilities.forceRevokePrefix.canUpdate (not confirmingRevoke))}}
-          {{#confirm-action
-            buttonClasses="button is-ghost is-compact"
-            onConfirmAction=(action "revokePrefix" baseKey.id true)
-            confirmMessage= (concat
-            "Confirming removes all leases under "
-            baseKey.id
-            " and disregards any errors encountered."
-            )
-            confirmButtonText=(concat "Revoke " baseKey.id)
-            confirmButtonClasses="button is-danger is-outlined is-compact"
-            cancelButtonText="Cancel"
-            cancelButtonClasses="button is-outlined is-compact"
-            showConfirm=confirmingForceRevoke
+          <ConfirmAction
+            @buttonClasses="toolbar-link"
+            @onConfirmAction={{action "revokePrefix" baseKey.id true}}
+            @confirmMessage={{concat
+              "Confirming removes all leases under "
+              baseKey.id
+              " and disregards any errors encountered."
             }}
+            @confirmButtonText={{concat "Revoke " baseKey.id}}
+          >
             Force revoke prefix
-          {{/confirm-action}}
+          </ConfirmAction>
         {{/if}}
       </div>
       <div class="control">
         {{#if (and capabilities.revokePrefix.canUpdate (not confirmingForceRevoke))}}
-          {{#confirm-action
-            buttonClasses="button is-ghost is-compact"
-            onConfirmAction=(action "revokePrefix" baseKey.id)
-            confirmMessage= (concat "Confirming will remove all leases under " baseKey.id)
-            confirmButtonText=(concat "Revoke " baseKey.id)
-            confirmButtonClasses="button is-danger is-outlined is-compact"
-            cancelButtonText="Cancel"
-            cancelButtonClasses="button is-outlined is-compact"
-            showConfirm=confirmingRevoke
-            data-test-lease-revoke-prefix=true
-            }}
+          <ConfirmAction
+            @buttonClasses="toolbar-link"
+            @onConfirmAction={{action "revokePrefix" baseKey.id}}
+            @confirmMessage={{concat "Confirming will remove all leases under " baseKey.id}}
+            @confirmButtonText={{concat "Revoke " baseKey.id}}
+            data-test-lease-revoke-prefix="true"
+          >
             Revoke prefix
-          {{/confirm-action}}
+          </ConfirmAction>
         {{/if}}
       </div>
     {{/if}}

--- a/ui/app/templates/vault/cluster/access/leases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/show.hbs
@@ -70,14 +70,13 @@
 <div class="field is-grouped is-grouped-split is-fullwidth box is-bottomless">
   <div class="field">{{!-- needs to be here to push over the button --}}</div>
   {{#if capabilities.revoke.canUpdate}}
-    {{#confirm-action
-      onConfirmAction=(action "revokeLease" model)
-      confirmMessage= (concat "Are you sure you want to revoke this lease?")
-      confirmButtonText="Confirm revocation"
-      cancelButtonText="Cancel"
-      data-test-lease-revoke=true
-    }}
+    <ConfirmAction
+      @onConfirmAction={{action "revokeLease" model}}
+      @confirmMessage={{concat "Are you sure you want to revoke this lease?"}}
+      @confirmButtonText="Confirm revocation"
+      data-test-lease-revoke="true"
+    >
       Revoke lease
-    {{/confirm-action}}
+    </ConfirmAction>
   {{/if}}
 </div>

--- a/ui/app/templates/vault/cluster/access/leases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/show.hbs
@@ -16,6 +16,24 @@
     </h1>
   </p.levelLeft>
 </PageHeader>
+
+{{#if capabilities.revoke.canUpdate}}
+  <Toolbar>
+    <ToolbarActions>
+      <ConfirmAction
+        @buttonClasses="toolbar-link"
+        @confirmTitle="Revoke this?"
+        @confirmMessage={{concat "All leases under this one will also be removed"}}
+        @confirmButtonText="Confirm"
+        @onConfirmAction={{action "revokeLease" model}}
+        data-test-lease-revoke="true"
+      >
+        Revoke lease
+      </ConfirmAction>
+    </ToolbarActions>
+  </Toolbar>
+{{/if}}
+
 <div class="field box is-fullwidth is-sideless is-paddingless is-marginless">
   {{#info-table-row label="Issue time" value=model.issueTime}}
     {{date-format model.issueTime 'MMM DD, YYYY hh:mm:ss A'}}
@@ -67,18 +85,3 @@
     </form>
   </div>
 {{/if}}
-<div class="field is-grouped is-grouped-split is-fullwidth box is-bottomless">
-  <div class="field">{{!-- needs to be here to push over the button --}}</div>
-  {{#if capabilities.revoke.canUpdate}}
-    <ConfirmAction
-      @buttonClasses="button is-ghost"
-      @confirmTitle="Revoke this?"
-      @confirmMessage={{concat "All leases under this one will also be removed"}}
-      @confirmButtonText="Confirm"
-      @onConfirmAction={{action "revokeLease" model}}
-      data-test-lease-revoke="true"
-    >
-      Revoke lease
-    </ConfirmAction>
-  {{/if}}
-</div>

--- a/ui/app/templates/vault/cluster/access/leases/show.hbs
+++ b/ui/app/templates/vault/cluster/access/leases/show.hbs
@@ -71,9 +71,11 @@
   <div class="field">{{!-- needs to be here to push over the button --}}</div>
   {{#if capabilities.revoke.canUpdate}}
     <ConfirmAction
+      @buttonClasses="button is-ghost"
+      @confirmTitle="Revoke this?"
+      @confirmMessage={{concat "All leases under this one will also be removed"}}
+      @confirmButtonText="Confirm"
       @onConfirmAction={{action "revokeLease" model}}
-      @confirmMessage={{concat "Are you sure you want to revoke this lease?"}}
-      @confirmButtonText="Confirm revocation"
       data-test-lease-revoke="true"
     >
       Revoke lease

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -72,19 +72,20 @@
 
                 {{#if (and (not-eq method.methodType 'token') method.canDisable)}}
                   <li class="action">
-                    {{#confirm-action
-                      confirmButtonClasses="button is-primary"
-                      buttonClasses="link is-destroy"
-                      onConfirmAction=(perform disableMethod method)
-                      confirmMessage=(concat "Are you sure you want to disable the " method.id " Auth Method at " method.path "?")
-                      showConfirm=(get this (concat "shouldDelete-" (dot-to-dash method.id)))
-                      class=(if (get this (concat "shouldDelete-" (dot-to-dash method.id))) "message is-block is-warning is-outline")
-                      containerClasses="message-body is-block"
-                      messageClasses="is-block"
-                      confirmButtonText="Disable"
-                    }}
+                    <ConfirmAction
+                      @buttonClasses="link is-destroy"
+                      @onConfirmAction={{perform disableMethod method}}
+                      @confirmMessage={{concat
+                        "Are you sure you want to disable the "
+                        method.id
+                        " Auth Method at "
+                        method.path
+                        "?"
+                      }}
+                      @confirmButtonText="Disable"
+                    >
                       Disable
-                    {{/confirm-action}}
+                    </ConfirmAction>
                   </li>
                 {{/if}}
               </ul>

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -74,15 +74,10 @@
                   <li class="action">
                     <ConfirmAction
                       @buttonClasses="link is-destroy"
-                      @onConfirmAction={{perform disableMethod method}}
-                      @confirmMessage={{concat
-                        "Are you sure you want to disable the "
-                        method.id
-                        " Auth Method at "
-                        method.path
-                        "?"
-                      }}
+                      @confirmTitle="Disable method?"
+                      @confirmMessage="This may affect access to Vault data."
                       @confirmButtonText="Disable"
+                      @onConfirmAction={{perform disableMethod method}}
                     >
                       Disable
                     </ConfirmAction>

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -37,6 +37,7 @@
           <ConfirmAction
             @buttonClasses="link is-destroy"
             @confirmButtonText="Remove"
+            @confirmMessage="Any engines or mounts in this namespace will also be removed."
             @onConfirmAction={{action
               (perform
                 Item.callMethod
@@ -47,7 +48,6 @@
                 (action "refreshNamespaceList")
               )
             }}
-            @confirmMessage={{concat "Are you sure you want to delete " list.item.id "?"}}
           >
             Delete
           </ConfirmAction>

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -35,9 +35,8 @@
         {{/with}}
         <li class="action">
           <ConfirmAction
-            @confirmButtonClasses="button is-primary"
-            @confirmButtonText="Remove"
             @buttonClasses="link is-destroy"
+            @confirmButtonText="Remove"
             @onConfirmAction={{action
               (perform
                 Item.callMethod
@@ -49,10 +48,6 @@
               )
             }}
             @confirmMessage={{concat "Are you sure you want to delete " list.item.id "?"}}
-            @showConfirm={{get this (concat "shouldDelete-" (dot-to-dash list.item.id))}}
-            @class={{if (get this (concat "shouldDelete-" (dot-to-dash list.item.id))) "message is-block is-warning is-outline"}}
-            @containerClasses="message-body is-block"
-            @messageClasses="is-block"
           >
             Delete
           </ConfirmAction>

--- a/ui/app/templates/vault/cluster/policies/index.hbs
+++ b/ui/app/templates/vault/cluster/policies/index.hbs
@@ -121,9 +121,8 @@
                         <li class="action">
                           <ConfirmAction
                             @buttonClasses="link is-destroy"
-                            @onConfirmAction={{action "deletePolicy" item}}
-                            @confirmTitle={{concat "Delete " item.id "?"}}
                             @confirmMessage="This will permanently delete this policy and may affect access to some data"
+                            @onConfirmAction={{action "deletePolicy" item}}
                             data-test-policy-delete={{item.id}}
                           >
                             Delete

--- a/ui/app/templates/vault/cluster/policies/index.hbs
+++ b/ui/app/templates/vault/cluster/policies/index.hbs
@@ -119,19 +119,15 @@
                       {{/if}}
                       {{#if item.canDelete}}
                         <li class="action">
-                          {{#confirm-action
-                            confirmButtonClasses="button is-primary"
-                            buttonClasses="link is-destroy"
-                            onConfirmAction=(action "deletePolicy" item)
-                            confirmMessage=(concat "Are you sure you want to delete " item.id "?")
-                            showConfirm=(get this (concat "shouldDelete-" (dot-to-dash item.id)))
-                            class=(if (get this (concat "shouldDelete-" (dot-to-dash item.id))) "message is-block is-warning is-outline")
-                            containerClasses="message-body is-block"
-                            messageClasses="is-block"
-                            data-test-policy-delete=item.id
-                          }}
+                          <ConfirmAction
+                            @buttonClasses="link is-destroy"
+                            @onConfirmAction={{action "deletePolicy" item}}
+                            @confirmTitle={{concat "Delete " item.id "?"}}
+                            @confirmMessage="This will permanently delete this policy and may affect access to some data"
+                            data-test-policy-delete={{item.id}}
+                          >
                             Delete
-                          {{/confirm-action}}
+                          </ConfirmAction>
                         </li>
                       {{/if}}
                     {{/if}}

--- a/ui/app/templates/vault/cluster/policy/edit.hbs
+++ b/ui/app/templates/vault/cluster/policy/edit.hbs
@@ -33,8 +33,8 @@
       {{#if (and (not-eq model.id "default") capabilities.canDelete)}}
         <ConfirmAction
           @buttonClasses="toolbar-link"
+          @confirmMessage="This may affect access to Vault data."
           @onConfirmAction={{action "deletePolicy" model}}
-          @confirmMessage={{concat "Are you sure you want to delete " model.id "?"}}
           data-test-policy-delete="true"
         >
           Delete

--- a/ui/app/templates/vault/cluster/policy/edit.hbs
+++ b/ui/app/templates/vault/cluster/policy/edit.hbs
@@ -31,15 +31,14 @@
       </ToolbarLink>
       <div class="toolbar-separator" />
       {{#if (and (not-eq model.id "default") capabilities.canDelete)}}
-        {{#confirm-action
-          buttonClasses="toolbar-link"
-          onConfirmAction=(action "deletePolicy" model)
-          confirmMessage=(concat "Are you sure you want to delete " model.id "?")
-          data-test-policy-delete=true
-        }}
+        <ConfirmAction
+          @buttonClasses="toolbar-link"
+          @onConfirmAction={{action "deletePolicy" model}}
+          @confirmMessage={{concat "Are you sure you want to delete " model.id "?"}}
+          data-test-policy-delete="true"
+        >
           Delete
-          <Chevron @isButton={{true}} />
-        {{/confirm-action}}
+        </ConfirmAction>
       {{/if}}
     </ToolbarActions>
   </Toolbar>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -67,16 +67,12 @@
                   {{#unless (eq backend.type "cubbyhole")}}
                   <li class="action">
                     <ConfirmAction
-                      @confirmButtonClasses="button is-primary"
                       @buttonClasses="link is-destroy"
                       @onConfirmAction={{perform disableEngine backend}}
                       @confirmMessage={{concat "Are you sure you want to disable the " backend.engineType " Secrets Engine at " backend.path "?"}}
-                      @showConfirm={{get this (concat "shouldDelete-" (dot-to-dash backend.id))}}
-                      @class={{if (get this (concat "shouldDelete-" (dot-to-dash backend.id))) "message is-block is-warning is-outline"}}
-                      @containerClasses="message-body is-block"
-                      @messageClasses="is-block"
                       @confirmButtonText="Disable"
-                      data-test-engine-disable>
+                      data-test-engine-disable="true"
+                    >
                       Disable
                     </ConfirmAction>
                    </li>
@@ -129,17 +125,12 @@
                  </li>
                  <li>
                    <ConfirmAction
-                     @confirmButtonClasses="button is-primary"
                      @buttonClasses="link is-destroy"
                      @onConfirmAction={{perform disableEngine backend}}
                      @confirmMessage={{concat "Are you sure you want to disable the " backend.engineType " Secrets Engine at " backend.path "?"}}
-                     @showConfirm={{get this (concat "shouldDelete-" (dot-to-dash backend.id))}}
-                     @class={{if (get this (concat "shouldDelete-" (dot-to-dash backend.id))) "message is-block is-warning is-outline"}}
-                     @containerClasses="message-body is-block"
-                     @messageClasses="is-block"
                      @confirmButtonText="Disable"
-                     data-test-engine-disable
-                     >
+                     data-test-engine-disable="true"
+                   >
                      Disable
                    </ConfirmAction>
                  </li>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -68,9 +68,10 @@
                   <li class="action">
                     <ConfirmAction
                       @buttonClasses="link is-destroy"
-                      @onConfirmAction={{perform disableEngine backend}}
-                      @confirmMessage={{concat "Are you sure you want to disable the " backend.engineType " Secrets Engine at " backend.path "?"}}
+                      @confirmTitle="Disable engine?"
+                      @confirmMessage="Any data in this engine will be permanently deleted."
                       @confirmButtonText="Disable"
+                      @onConfirmAction={{perform disableEngine backend}}
                       data-test-engine-disable="true"
                     >
                       Disable
@@ -126,9 +127,10 @@
                  <li>
                    <ConfirmAction
                      @buttonClasses="link is-destroy"
-                     @onConfirmAction={{perform disableEngine backend}}
-                     @confirmMessage={{concat "Are you sure you want to disable the " backend.engineType " Secrets Engine at " backend.path "?"}}
+                     @confirmTitle="Disable engine?"
+                     @confirmMessage="Any data in this engine will be permanently deleted."
                      @confirmButtonText="Disable"
+                     @onConfirmAction={{perform disableEngine backend}}
                      data-test-engine-disable="true"
                    >
                      Disable

--- a/ui/app/templates/vault/cluster/settings/seal.hbs
+++ b/ui/app/templates/vault/cluster/settings/seal.hbs
@@ -17,16 +17,16 @@
     </p>
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
-    {{#confirm-action
-      onConfirmAction=(action "seal")
-      confirmMessage=(concat "Are you sure you want to seal " model.cluster.name "?")
-      confirmButtonText="Seal"
-      buttonClasses="button is-primary"
-      cancelButtonText="Cancel"
-      data-test-seal=true
-      }}
+    <ConfirmAction
+      @buttonClasses="button is-primary"
+      @onConfirmAction={{action "seal"}}
+      @confirmMessage={{concat "Are you sure you want to seal " model.cluster.name "?"}}
+      @confirmButtonText="Seal"
+      @horizontalPosition="auto-left"
+      data-test-seal="true"
+    >
       Seal
-    {{/confirm-action}}
+    </ConfirmAction>
   </div>
 {{else}}
   <EmptyState

--- a/ui/app/templates/vault/cluster/settings/seal.hbs
+++ b/ui/app/templates/vault/cluster/settings/seal.hbs
@@ -19,10 +19,11 @@
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <ConfirmAction
       @buttonClasses="button is-primary"
-      @onConfirmAction={{action "seal"}}
-      @confirmMessage={{concat "Are you sure you want to seal " model.cluster.name "?"}}
+      @confirmTitle="Seal this cluster?"
+      @confirmMessage="You will not be able to read or write any data until the cluster is unsealed again."
       @confirmButtonText="Seal"
       @horizontalPosition="auto-left"
+      @onConfirmAction={{action "seal"}}
       data-test-seal="true"
     >
       Seal

--- a/ui/lib/core/addon/components/confirm-action.js
+++ b/ui/lib/core/addon/components/confirm-action.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import hbs from 'htmlbars-inline-precompile';
+import layout from '../templates/components/confirm-action';
 
 /**
  * @module ConfirmAction
@@ -25,55 +26,8 @@ import hbs from 'htmlbars-inline-precompile';
  */
 
 export default Component.extend({
+  layout,
   classNames: ['confirm-action'],
-  layout: hbs`
-    {{#basic-dropdown class="popup-menu" horizontalPosition=horizontalPosition verticalPosition=verticalPosition onOpen=(action "toggleConfirm") onClose=(action "toggleConfirm") as |d|}}
-      {{#d.trigger
-        tagName="button"
-        type="button"
-        class=(concat buttonClasses " popup-menu-trigger" (if d.isOpen " is-active"))
-        disabled=disabled
-        data-test-confirm-action-trigger="true"
-      }}
-        {{yield}}
-        {{#if (eq buttonClasses 'toolbar-link')}}
-          <Chevron @direction={{if showConfirm 'up' 'down'}} />
-        {{/if}}
-      {{/d.trigger}}
-      {{#d.content class=(concat "popup-menu-content")}}
-        <div class="box confirm-action-message">
-          <div class="message is-highlight">
-            <div class="message-title">
-              <Icon @glyph="alert-triangle" />
-              {{if disabled disabledTitle confirmTitle}}
-            </div>
-            <p>
-              {{if disabled disabledMessage confirmMessage}}
-            </p>
-          </div>
-          <div class="confirm-action-options">
-            <button
-              type="button"
-              disabled={{disabled}}
-              class="link is-destroy"
-              data-test-confirm-button="true"
-              {{action 'onConfirm'}}
-            >
-              {{confirmButtonText}}
-            </button>
-            <button
-              type="button"
-              class="link"
-              data-test-confirm-cancel-button="true"
-              {{action d.actions.close}}
-            >
-              {{cancelButtonText}}
-            </button>
-          </div>
-        </div>
-      {{/d.content}}
-    {{/basic-dropdown}}
-  `,
   buttonText: 'Delete',
   confirmTitle: 'Delete this?',
   confirmMessage: 'You will not be able to recover it later.',

--- a/ui/lib/core/addon/components/confirm-action.js
+++ b/ui/lib/core/addon/components/confirm-action.js
@@ -1,5 +1,4 @@
 import Component from '@ember/component';
-import hbs from 'htmlbars-inline-precompile';
 import layout from '../templates/components/confirm-action';
 
 /**
@@ -27,7 +26,8 @@ import layout from '../templates/components/confirm-action';
 
 export default Component.extend({
   layout,
-  classNames: ['confirm-action'],
+  tagName: '',
+  supportsDataTestProperties: true,
   buttonText: 'Delete',
   confirmTitle: 'Delete this?',
   confirmMessage: 'You will not be able to recover it later.',

--- a/ui/lib/core/addon/components/confirm-action.js
+++ b/ui/lib/core/addon/components/confirm-action.js
@@ -14,29 +14,31 @@ import hbs from 'htmlbars-inline-precompile';
  *  </ConfirmAction>
  * ```
  *
- * @property {Func} onConfirmAction=null - The action to take upon confirming.
- * @property {String} [confirmMessage=Are you sure you want to do this?] - The message to display upon confirming.
+ * @property {Func} [onConfirmAction=null] - The action to take upon confirming.
+ * @property {String} [confirmTitle=Delete this?] - The title to display when confirming.
+ * @property {String} [confirmMessage=Are you sure you want to do this?] - The message to display when confirming.
  * @property {String} [confirmButtonText=Delete] - The confirm button text.
  * @property {String} [cancelButtonText=Cancel] - The cancel button text.
+ * @property {String} [disabledTitle=Can't delete this yet] - The title to display when the button is disabled.
  * @property {String} [disabledMessage=Complete the form to complete this action] - The message to display when the button is disabled.
  *
  */
 
 export default Component.extend({
-  tagName: 'span',
   classNames: ['confirm-action'],
   layout: hbs`
     {{#basic-dropdown class="popup-menu" horizontalPosition=horizontalPosition verticalPosition=verticalPosition onOpen=(action "toggleConfirm") onClose=(action "toggleConfirm") as |d|}}
       {{#d.trigger
         tagName="button"
+        type="button"
         class=(concat buttonClasses " popup-menu-trigger" (if d.isOpen " is-active"))
         disabled=disabled
         data-test-confirm-action-trigger="true"
       }}
         {{yield}}
-        {{#if (eq buttonClasses 'toolbar-link') ~}}
+        {{#if (eq buttonClasses 'toolbar-link')}}
           <Icon @glyph="chevron-{{if showConfirm 'up' 'down'}}" />
-        {{~/if}}
+        {{/if}}
       {{/d.trigger}}
       {{#d.content class=(concat "popup-menu-content")}}
         <div class="box confirm-action-message">
@@ -74,7 +76,7 @@ export default Component.extend({
   `,
   buttonText: 'Delete',
   confirmTitle: 'Delete this?',
-  confirmMessage: 'This data will be permenantly deleted.',
+  confirmMessage: 'You will not be able to recover it later.',
   confirmButtonText: 'Delete',
   cancelButtonText: 'Cancel',
   disabledTitle: "Can't delete this yet",

--- a/ui/lib/core/addon/components/confirm-action.js
+++ b/ui/lib/core/addon/components/confirm-action.js
@@ -37,7 +37,7 @@ export default Component.extend({
       }}
         {{yield}}
         {{#if (eq buttonClasses 'toolbar-link')}}
-          <Icon @glyph="chevron-{{if showConfirm 'up' 'down'}}" />
+          <Chevron @direction={{if showConfirm 'up' 'down'}} />
         {{/if}}
       {{/d.trigger}}
       {{#d.content class=(concat "popup-menu-content")}}

--- a/ui/lib/core/addon/components/confirm-action.js
+++ b/ui/lib/core/addon/components/confirm-action.js
@@ -26,38 +26,63 @@ export default Component.extend({
   tagName: 'span',
   classNames: ['confirm-action'],
   layout: hbs`
-    {{#if showConfirm ~}}
-      <span class={{containerClasses}}>
-        <span class={{concat 'confirm-action-text ' messageClasses}}>{{if disabled disabledMessage confirmMessage}}</span>
-        <button {{action 'onConfirm'}} disabled={{disabled}} class={{confirmButtonClasses}} type="button" data-test-confirm-button=true>{{confirmButtonText}}</button>
-        <button {{action 'toggleConfirm'}} type="button" class={{cancelButtonClasses}} data-test-confirm-cancel-button=true>{{cancelButtonText}}</button>
-      </span>
-    {{else}}
-      <button
-        class={{buttonClasses}}
-        type="button"
-        disabled={{disabled}}
-        data-test-confirm-action-trigger=true
-        {{action 'toggleConfirm'}}
-      >
+    {{#basic-dropdown class="popup-menu" horizontalPosition=horizontalPosition verticalPosition=verticalPosition onOpen=(action "toggleConfirm") onClose=(action "toggleConfirm") as |d|}}
+      {{#d.trigger
+        tagName="button"
+        class=(concat buttonClasses " popup-menu-trigger" (if d.isOpen " is-active"))
+        disabled=disabled
+        data-test-confirm-action-trigger="true"
+      }}
         {{yield}}
-      </button>
-    {{~/if}}
+        {{#if (eq buttonClasses 'toolbar-link') ~}}
+          <Icon @glyph="chevron-{{if showConfirm 'up' 'down'}}" />
+        {{~/if}}
+      {{/d.trigger}}
+      {{#d.content class=(concat "popup-menu-content")}}
+        <div class="box confirm-action-message">
+          <div class="message is-highlight">
+            <div class="message-title">
+              <Icon @glyph="alert-triangle" />
+              {{if disabled disabledTitle confirmTitle}}
+            </div>
+            <p>
+              {{if disabled disabledMessage confirmMessage}}
+            </p>
+          </div>
+          <div class="confirm-action-options">
+            <button
+              type="button"
+              disabled={{disabled}}
+              class="link is-destroy"
+              data-test-confirm-button="true"
+              {{action 'onConfirm'}}
+            >
+              {{confirmButtonText}}
+            </button>
+            <button
+              type="button"
+              class="link"
+              data-test-confirm-cancel-button="true"
+              {{action d.actions.close}}
+            >
+              {{cancelButtonText}}
+            </button>
+          </div>
+        </div>
+      {{/d.content}}
+    {{/basic-dropdown}}
   `,
-
-  disabled: false,
-  disabledMessage: 'Complete the form to complete this action',
-  showConfirm: false,
-  messageClasses: 'is-size-8 has-text-grey',
-  confirmButtonClasses: 'is-danger is-outlined button',
-  containerClasses: '',
-  buttonClasses: 'button',
   buttonText: 'Delete',
-  confirmMessage: 'Are you sure you want to do this?',
+  confirmTitle: 'Delete this?',
+  confirmMessage: 'This data will be permenantly deleted.',
   confirmButtonText: 'Delete',
-  cancelButtonClasses: 'button',
   cancelButtonText: 'Cancel',
-  // the action to take when we confirm
+  disabledTitle: "Can't delete this yet",
+  disabledMessage: 'Complete the form to complete this action',
+  horizontalPosition: 'auto-right',
+  verticalPosition: 'below',
+  disabled: false,
+  showConfirm: false,
   onConfirmAction: null,
 
   actions: {

--- a/ui/lib/core/addon/templates/components/confirm-action.hbs
+++ b/ui/lib/core/addon/templates/components/confirm-action.hbs
@@ -1,46 +1,55 @@
-{{#basic-dropdown class="popup-menu" horizontalPosition=horizontalPosition verticalPosition=verticalPosition onOpen=(action "toggleConfirm") onClose=(action "toggleConfirm") as |d|}}
-  {{#d.trigger
-    tagName="button"
-    type="button"
-    class=(concat buttonClasses " popup-menu-trigger" (if d.isOpen " is-active"))
-    disabled=disabled
-    data-test-confirm-action-trigger="true"
-  }}
-    {{yield}}
-    {{#if (eq buttonClasses 'toolbar-link')}}
-      <Chevron @direction={{if showConfirm 'up' 'down'}} />
-    {{/if}}
-  {{/d.trigger}}
-  {{#d.content class=(concat "popup-menu-content")}}
-    <div class="box confirm-action-message">
-      <div class="message is-highlight">
-        <div class="message-title">
-          <Icon @glyph="alert-triangle" />
-          {{if disabled disabledTitle confirmTitle}}
+<div class="confirm-action" ...attributes>
+  <BasicDropdown
+    @horizontalPosition={{horizontalPosition}}
+    @verticalPosition={{verticalPosition}}
+    @onOpen={{action "toggleConfirm"}}
+    @onClose={{action "toggleConfirm"}}
+    as |d|>
+    <d.trigger
+      @tagName="button"
+      class={{concat buttonClasses " popup-menu-trigger" (if d.isOpen " is-active")}}
+      type="button"
+      disabled={{disabled}}
+      data-test-confirm-action-trigger="true"
+    >
+      {{yield}}
+      {{#if (eq buttonClasses 'toolbar-link')}}
+        <Chevron @direction={{if showConfirm 'up' 'down'}} />
+      {{/if}}
+    </d.trigger>
+    <d.content
+      @class="popup-menu-content"
+    >
+      <div class="box confirm-action-message">
+        <div class="message is-highlight">
+          <div class="message-title">
+            <Icon @glyph="alert-triangle" />
+            {{if disabled disabledTitle confirmTitle}}
+          </div>
+          <p>
+            {{if disabled disabledMessage confirmMessage}}
+          </p>
         </div>
-        <p>
-          {{if disabled disabledMessage confirmMessage}}
-        </p>
+        <div class="confirm-action-options">
+          <button
+            type="button"
+            disabled={{disabled}}
+            class="link is-destroy"
+            data-test-confirm-button="true"
+            {{action 'onConfirm'}}
+          >
+            {{confirmButtonText}}
+          </button>
+          <button
+            type="button"
+            class="link"
+            data-test-confirm-cancel-button="true"
+            {{action d.actions.close}}
+          >
+            {{cancelButtonText}}
+          </button>
+        </div>
       </div>
-      <div class="confirm-action-options">
-        <button
-          type="button"
-          disabled={{disabled}}
-          class="link is-destroy"
-          data-test-confirm-button="true"
-          {{action 'onConfirm'}}
-        >
-          {{confirmButtonText}}
-        </button>
-        <button
-          type="button"
-          class="link"
-          data-test-confirm-cancel-button="true"
-          {{action d.actions.close}}
-        >
-          {{cancelButtonText}}
-        </button>
-      </div>
-    </div>
-  {{/d.content}}
-{{/basic-dropdown}}
+    </d.content>
+  </BasicDropdown>
+</div>

--- a/ui/lib/core/addon/templates/components/confirm-action.hbs
+++ b/ui/lib/core/addon/templates/components/confirm-action.hbs
@@ -1,0 +1,46 @@
+{{#basic-dropdown class="popup-menu" horizontalPosition=horizontalPosition verticalPosition=verticalPosition onOpen=(action "toggleConfirm") onClose=(action "toggleConfirm") as |d|}}
+  {{#d.trigger
+    tagName="button"
+    type="button"
+    class=(concat buttonClasses " popup-menu-trigger" (if d.isOpen " is-active"))
+    disabled=disabled
+    data-test-confirm-action-trigger="true"
+  }}
+    {{yield}}
+    {{#if (eq buttonClasses 'toolbar-link')}}
+      <Chevron @direction={{if showConfirm 'up' 'down'}} />
+    {{/if}}
+  {{/d.trigger}}
+  {{#d.content class=(concat "popup-menu-content")}}
+    <div class="box confirm-action-message">
+      <div class="message is-highlight">
+        <div class="message-title">
+          <Icon @glyph="alert-triangle" />
+          {{if disabled disabledTitle confirmTitle}}
+        </div>
+        <p>
+          {{if disabled disabledMessage confirmMessage}}
+        </p>
+      </div>
+      <div class="confirm-action-options">
+        <button
+          type="button"
+          disabled={{disabled}}
+          class="link is-destroy"
+          data-test-confirm-button="true"
+          {{action 'onConfirm'}}
+        >
+          {{confirmButtonText}}
+        </button>
+        <button
+          type="button"
+          class="link"
+          data-test-confirm-cancel-button="true"
+          {{action d.actions.close}}
+        >
+          {{cancelButtonText}}
+        </button>
+      </div>
+    </div>
+  {{/d.content}}
+{{/basic-dropdown}}

--- a/ui/lib/core/addon/templates/components/toolbar-link.hbs
+++ b/ui/lib/core/addon/templates/components/toolbar-link.hbs
@@ -6,6 +6,7 @@
   data-test-configure-link={{data-test-configure-link}}
   data-test-alias-edit-link={{data-test-alias-edit-link}}
   data-test-entity-edit-link={{data-test-entity-edit-link}}
+  data-test-replication-link={{data-test-replication-link}}
   data-test-entity-merge-link={{data-test-entity-merge-link}}
   data-test-backend-view-link={{data-test-backend-view-link}}
   data-test-entity-create-link={{data-test-entity-create-link}}

--- a/ui/lib/replication/addon/templates/components/replication-action-demote.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-action-demote.hbs
@@ -7,15 +7,15 @@
       (not model.performance.replicationDisabled)
     )
   }}
-  
+
     <div data-test-demote-warning>
       <AlertInline
         @type="danger"
         @message="Demoting this DR primary cluster
           would result in a DR secondary and in that mode Vault is read-only. This
-          cluster is also currently operating as a Performance 
+          cluster is also currently operating as a Performance
           capitalize model.performance.modeForUrl}}, demoting it will leave your
-          replication setup without a performance primary cluster until a new 
+          replication setup without a performance primary cluster until a new
           cluster is promoted."
       />
     </div>
@@ -32,15 +32,16 @@
 </div>
 <div class="field">
   <div class="control">
-    {{#confirm-action
-      buttonClasses="button is-primary"
-      onConfirmAction=(action "onSubmit" "demote" model.replicationAttrs.modeForUrl)
-      confirmMessage="Are you sure you want to demote this cluster?"
-      confirmButtonText="Demote cluster"
-      cancelButtonText="Cancel"
-      data-test-replication-demote=true
-      }}
+    <ConfirmAction
+      @buttonClasses="button is-primary"
+      @confirmTitle="Demote this cluster?"
+      @confirmMessage="This will affect how your Vault data is replicated."
+      @confirmButtonText="Demote"
+      @horizontalPosition="auto-left"
+      @onConfirmAction={{action "onSubmit" "demote" model.replicationAttrs.modeForUrl}}
+      data-test-replication-demote="true"
+    >
       Demote cluster
-    {{/confirm-action}}
+    </ConfirmAction>
   </div>
 </div>

--- a/ui/lib/replication/addon/templates/components/replication-action-disable.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-action-disable.hbs
@@ -44,8 +44,13 @@
 </div>
 <div class="field">
   <div class="control">
-    {{#confirm-action
-      onConfirmAction=(action
+    <ConfirmAction
+      @buttonClasses="button is-primary"
+      @confirmTitle="Disable this cluster?"
+      @confirmMessage="Data in this cluster will no longer be replicated."
+      @confirmButtonText="Disable"
+      @horizontalPosition="auto-left"
+      @onConfirmAction={{action
         "onSubmit"
         "disable"
         (if
@@ -53,14 +58,10 @@
           mode
           model.replicationAttrs.modeForUrl
         )
-      )
-      buttonClasses="button is-primary"
-      confirmMessage=(concat "Are you sure you want to disable Replication on this cluster?")
-      confirmButtonText="Disable"
-      cancelButtonText="Cancel"
-      data-test-disable-replication=true
       }}
+      data-test-disable-replication="true"
+    >
       Disable Replication
-    {{/confirm-action}}
+    </ConfirmAction>
   </div>
 </div>

--- a/ui/lib/replication/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-action-promote.hbs
@@ -57,15 +57,16 @@
   <div class="box is-marginless is-shadowless">
    <div class="field">
     <div class="control">
-      {{#confirm-action
-        buttonClasses="button is-primary"
-        onConfirmAction=(action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token primary_cluster_addr=primary_cluster_addr force=force))
-        confirmMessage="Are you sure you want to promote this cluster?"
-        confirmButtonText="Promote cluster"
-        cancelButtonText="Cancel"
-        }}
+      <ConfirmAction
+        @buttonClasses="button is-primary"
+        @confirmTitle="Promote this cluster?"
+        @confirmMessage="This will affect how your Vault data is replicated."
+        @confirmButtonText="Promote"
+        @horizontalPosition="auto-left"
+        @onConfirmAction={{action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token primary_cluster_addr=primary_cluster_addr force=force)}}
+      >
         Promote cluster
-      {{/confirm-action}}
+      </ConfirmAction>
     </div>
    </div>
  </div>
@@ -113,15 +114,16 @@
   </div>
   <div class="field">
     <div class="control">
-      {{#confirm-action
-        buttonClasses="button is-primary"
-        onConfirmAction=(action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash primary_cluster_addr=primary_cluster_addr force=force))
-        confirmMessage="Are you sure you want to promote this cluster?"
-        confirmButtonText="Promote cluster"
-        cancelButtonText="Cancel"
-        }}
+      <ConfirmAction
+        @buttonClasses="button is-primary"
+        @confirmTitle="Promote this cluster?"
+        @confirmMessage="This will affect how your Vault data is replicated."
+        @confirmButtonText="Promote"
+        @horizontalPosition="auto-left"
+        @onConfirmAction={{action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash primary_cluster_addr=primary_cluster_addr force=force)}}
+      >
         Promote cluster
-      {{/confirm-action}}
+      </ConfirmAction>
     </div>
   </div>
 {{/if}}

--- a/ui/lib/replication/addon/templates/components/replication-action-recover.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-action-recover.hbs
@@ -9,15 +9,15 @@
 </div>
 <div class="field">
   <div class="control">
-    {{#confirm-action
-      buttonClasses="button is-primary"
-      onConfirmAction=(action "onSubmit" "recover")
-      confirmMessage="Are you sure you want to initiate cluster recovery?"
-      confirmButtonText="Begin recovery"
-      cancelButtonText="Cancel"
-      }}
+    <ConfirmAction
+      @buttonClasses="button is-primary"
+      @confirmTitle="Begin recovery?"
+      @confirmMessage="This will attempt to recover to continue syncing."
+      @confirmButtonText="Recover"
+      @horizontalPosition="auto-left"
+      @onConfirmAction={{action "onSubmit" "recover"}}
+    >
       Recover
-    {{/confirm-action}}
+    </ConfirmAction>
   </div>
 </div>
-

--- a/ui/lib/replication/addon/templates/components/replication-action-reindex.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-action-reindex.hbs
@@ -9,14 +9,15 @@
 </div>
 <div class="field">
   <div class="control">
-    {{#confirm-action
-      buttonClasses="button is-primary"
-      onConfirmAction=(action "onSubmit" "reindex")
-      confirmMessage="Are you sure you want to initiate cluster reindex?"
-      confirmButtonText="Begin reindex"
-      cancelButtonText="Cancel"
-      }}
+    <ConfirmAction
+      @buttonClasses="button is-primary"
+      @confirmTitle="Begin reindex?"
+      @confirmMessage="This will initiate reindexing of the local data storage."
+      @confirmButtonText="Reindex"
+      @horizontalPosition="auto-left"
+      @onConfirmAction={{action "onSubmit" "reindex"}}
+    >
       Reindex
-    {{/confirm-action}}
+    </ConfirmAction>
   </div>
 </div>

--- a/ui/lib/replication/addon/templates/components/replication-action-update-primary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-action-update-primary.hbs
@@ -70,15 +70,16 @@
   <div class="box is-marginless is-shadowless">
     <div class="field">
       <div class="control">
-        {{#confirm-action
-          buttonClasses="button is-primary"
-          onConfirmAction=(action "onSubmit" "update-primary" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token token=token primary_api_addr=primary_api_addr ca_path=ca_path ca_file=ca_file))
-          confirmMessage="Are you sure you want to update this cluster's primary?"
-          confirmButtonText="Update primary"
-          cancelButtonText="Cancel"
-          }}
+        <ConfirmAction
+          @buttonClasses="button is-primary"
+          @confirmTitle="Update primary?"
+          @confirmMessage="This will update this cluster's primary."
+          @confirmButtonText="Update"
+          @horizontalPosition="auto-left"
+          @onConfirmAction={{action "onSubmit" "update-primary" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token token=token primary_api_addr=primary_api_addr ca_path=ca_path ca_file=ca_file)}}
+        >
           Update primary
-        {{/confirm-action}}
+        </ConfirmAction>
       </div>
     </div>
   </div>
@@ -137,15 +138,16 @@
 
   <div class="field">
     <div class="control">
-      {{#confirm-action
-        buttonClasses="button is-primary"
-        onConfirmAction=(action "onSubmit" "update-primary" model.replicationAttrs.modeForUrl (hash token=token primary_api_addr=primary_api_addr ca_path=ca_path ca_file=ca_file))
-        confirmMessage="Are you sure you want to update this cluster's primary?"
-        confirmButtonText="Update primary"
-        cancelButtonText="Cancel"
-        }}
+      <ConfirmAction
+        @buttonClasses="button is-primary"
+        @confirmTitle="Update primary?"
+        @confirmMessage="This will update this cluster's primary."
+        @confirmButtonText="Update"
+        @horizontalPosition="auto-left"
+        @onConfirmAction={{action "onSubmit" "update-primary" model.replicationAttrs.modeForUrl (hash token=token primary_api_addr=primary_api_addr ca_path=ca_path ca_file=ca_file)}}
+      >
         Update primary
-      {{/confirm-action}}
+      </ConfirmAction>
     </div>
   </div>
 {{/if}}

--- a/ui/lib/replication/addon/templates/mode/secondaries/config-edit.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/config-edit.hbs
@@ -1,3 +1,16 @@
+<Toolbar>
+  <ToolbarActions>
+    <ConfirmAction
+      @buttonClasses="toolbar-link"
+      @confirmMessage="This will affect which data gets replicated to this secondary."
+      @onConfirmAction={{action "saveConfig" model.config true}}
+      @data-test-delete-mount-config="true"
+    >
+      Delete config
+    </ConfirmAction>
+  </ToolbarActions>
+</Toolbar>
+
 <div class="box is-fullwidth is-shadowless is-marginless">
   <h4 class="title is-5 is-marginless">
     Edit mount filter config for <code>{{model.config.id}}</code>
@@ -25,15 +38,5 @@
         {{/link-to}}
       </div>
     </div>
-    {{#confirm-action
-      onConfirmAction=(action "saveConfig" model.config true)
-      confirmMessage=(concat "Are you sure you want to delete the filter config for " model.config.id "?")
-      confirmButtonText="Delete"
-      cancelButtonText="Cancel"
-      data-test-delete-mount-config=true
-    }}
-      Delete
-      <Chevron @isButton={{true}} />
-    {{/confirm-action}}
   </div>
 </form>

--- a/ui/lib/replication/addon/templates/mode/secondaries/config-edit.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/config-edit.hbs
@@ -4,7 +4,7 @@
       @buttonClasses="toolbar-link"
       @confirmMessage="This will affect which data gets replicated to this secondary."
       @onConfirmAction={{action "saveConfig" model.config true}}
-      @data-test-delete-mount-config="true"
+      data-test-delete-mount-config="true"
     >
       Delete config
     </ConfirmAction>

--- a/ui/lib/replication/addon/templates/mode/secondaries/config-show.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/config-show.hbs
@@ -1,3 +1,22 @@
+<Toolbar>
+  <ToolbarActions>
+    {{#if model.config.mode}}
+      <ToolbarLink
+        @params={{array "mode.secondaries.config-edit" model.config.id}}
+        @data-test-replication-link="edit-mount-config"
+      >
+        Edit config
+      </ToolbarLink>
+    {{else}}
+      <ToolbarLink
+        @params={{array "mode.secondaries.config-create" model.config.id}}
+        @data-test-replication-link="create-mount-config"
+      >
+        Create config
+      </ToolbarLink>
+    {{/if}}
+  </ToolbarActions>
+</Toolbar>
 <div class="box is-fullwidth is-shadowless is-marginless">
   <h4 class="title is-5 is-marginless">
     Mount filter config for <code>{{model.config.id}}</code>
@@ -18,31 +37,7 @@
   </div>
 {{else}}
   <EmptyState
-    @title="Performance Mount Filtering is not configured for this secondary"
+    @title="No config yet"
+    @message="Performance Mount Filtering is not configured for this secondary"
   />
 {{/if}}
-<div class="field is-fullwidth box is-shadowless">
-  {{#if model.config.mode}}
-    <div class="control">
-      {{#link-to
-        "mode.secondaries.config-edit"
-        model.config.id
-        class="button"
-        data-test-replication-link="edit-mount-config"
-        }}
-        Edit
-      {{/link-to}}
-    </div>
-  {{else}}
-    <div class="control">
-      {{#link-to
-        "mode.secondaries.config-create"
-        model.config.id
-        class="button"
-        data-test-replication-link="create-mount-config"
-        }}
-        Create
-      {{/link-to}}
-    </div>
-  {{/if}}
-</div>

--- a/ui/lib/replication/addon/templates/mode/secondaries/index.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/index.hbs
@@ -23,7 +23,7 @@
   </Toolbar>
   {{#if model.replicationAttrs.knownSecondaries.length}}
     {{#each model.replicationAttrs.knownSecondaries as |secondary|}}
-      <div class="box is-shadowless is-marginless" data-test-secondary-name={{secondary}}>
+      <div class="list-item-row" data-test-secondary-name={{secondary}}>
         <div class="columns is-mobile">
           <div class="column is-10">
             {{secondary}}
@@ -33,29 +33,25 @@
               {{#popup-menu name="secondary-details"}}
                 <nav class="menu">
                   <ul class="menu-list">
-                    {{#if model.canRevokeSecondary}}
-                      <li class="action">
-                        {{#confirm-action
-                          onConfirmAction=(action "onSubmit" "revoke-secondary" "primary" (hash id=secondary))
-                          confirmMessage=(concat "Are you sure you want to revoke " secondary "?")
-                          confirmButtonText="Revoke"
-                          cancelButtonText="Cancel"
-                          buttonClasses="button link is-destroy"
-                          confirmButtonClasses="is-danger is-outlined button"
-                          showConfirm=(get this (concat secondary '-isRevoking'))
-                          containerClasses="is-block"
-                          messageClasses="box is-shadowless is-marginless"
-                          class=(if (get this (concat secondary '-isRevoking')) "is-block ")
-                        }}
-                          Revoke
-                        {{/confirm-action}}
-                      </li>
-                    {{/if}}
                     {{#if (eq replicationMode 'performance')}}
                       <li class="action">
                         {{#link-to "mode.secondaries.config-show" replicationMode secondary data-test-replication-mount-filter-link=true}}
                           Mount filter config
                         {{/link-to}}
+                      </li>
+                    {{/if}}
+                    {{#if model.canRevokeSecondary}}
+                      <li class="action">
+                        <ConfirmAction
+                          @buttonClasses="button link is-destroy"
+                          @confirmTitle="Revoke token?"
+                          @confirmMessage="This will revoke this secondary token."
+                          @confirmButtonText="Revoke"
+                          @horizontalPosition="auto-left"
+                          @onConfirmAction={{action "onSubmit" "revoke-secondary" "primary" (hash id=secondary)}}
+                        >
+                          Revoke
+                        </ConfirmAction>
                       </li>
                     {{/if}}
                   </ul>

--- a/ui/lib/replication/addon/templates/mode/secondaries/revoke.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/revoke.hbs
@@ -17,18 +17,18 @@
 </div>
 <div class="field is-grouped box is-fullwidth is-bottomless">
   <div class="control">
-    {{#confirm-action
-      onConfirmAction=(action "onSubmit" "revoke-secondary" "primary" (hash id=id))
-      confirmMessage=(concat "Are you sure you want to revoke " id "?")
-      disabledMessage="A secondary ID is required perform revocation."
-      buttonClasses="is-primary button"
-      confirmButtonText="Revoke"
-      cancelButtonText="Cancel"
-      showConfirm=isRevoking
-      disabled=(not id)
-    }}
+    <ConfirmAction
+      @buttonClasses="button is-primary"
+      @confirmTitle="Revoke token?"
+      @confirmMessage="This will revoke this secondary token."
+      @confirmButtonText="Revoke"
+      @disabled={{not id}}
+      @disabledMessage="A secondary ID is required perform revocation."
+      @horizontalPosition="auto-left"
+      @onConfirmAction={{action "onSubmit" "revoke-secondary" "primary" (hash id=id)}}
+    >
       Revoke
-    {{/confirm-action}}
+    </ConfirmAction>
   </div>
   <div class="control">
     {{#unless isRevoking}}

--- a/ui/tests/acceptance/secrets/backend/pki/role-test.js
+++ b/ui/tests/acceptance/secrets/backend/pki/role-test.js
@@ -53,12 +53,10 @@ module('Acceptance | secrets/pki/create', function(hooks) {
   });
 
   test('it deletes a role', async function(assert) {
-    await mountAndNav(assert);
+    const path = await mountAndNav(assert);
     await editPage.createRole('role', 'example.com');
-    await showPage.edit();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.edit', 'navs to the edit page');
-
-    await editPage.deleteRole();
+    await showPage.visit({ backend: path, id: 'role' });
+    await showPage.deleteRole();
     assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list-root', 'redirects to list page');
     assert.ok(listPage.backendIsEmpty, 'no roles listed');
   });

--- a/ui/tests/acceptance/secrets/backend/ssh/role-test.js
+++ b/ui/tests/acceptance/secrets/backend/ssh/role-test.js
@@ -44,12 +44,10 @@ module('Acceptance | secrets/ssh', function(hooks) {
   });
 
   test('it deletes a role', async function(assert) {
-    await mountAndNav(assert);
+    const path = await mountAndNav(assert);
     await editPage.createOTPRole('role');
-    await showPage.edit();
-    assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.edit', 'navs to the edit page');
-
-    await editPage.deleteRole();
+    await showPage.visit({ backend: path, id: 'role' });
+    await showPage.deleteRole();
     assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.list-root', 'redirects to list page');
     assert.ok(listPage.backendIsEmpty, 'no roles listed');
   });

--- a/ui/tests/integration/components/edit-form-test.js
+++ b/ui/tests/integration/components/edit-form-test.js
@@ -87,25 +87,4 @@ module('Integration | Component | edit form', function(hooks) {
       assert.equal(flash.success.callCount, 1, 'calls flash message success');
     });
   });
-
-  test('it calls flash message fns on delete', async function(assert) {
-    let model = createModel();
-    let onSave = () => {
-      return resolve();
-    };
-    this.set('model', model);
-    this.set('onSave', onSave);
-    let saveSpy = sinon.spy(this, 'onSave');
-
-    await render(hbs`{{edit-form model=model onSave=onSave}}`);
-    await component.deleteButton();
-    await component.deleteConfirm();
-
-    later(() => run.cancelTimers(), 50);
-    return settled().then(() => {
-      assert.ok(saveSpy.calledOnce, 'calls onSave');
-      assert.equal(saveSpy.getCall(0).args[0].saveType, 'destroyRecord');
-      assert.deepEqual(saveSpy.getCall(0).args[0].model, model, 'passes model to onSave');
-    });
-  });
 });

--- a/ui/tests/pages/access/identity/aliases/index.js
+++ b/ui/tests/pages/access/identity/aliases/index.js
@@ -12,8 +12,5 @@ export default create({
     scope: '[data-test-item-delete]',
     testContainer: '#ember-testing',
   }),
-  confirmDelete: clickable('[data-test-confirm-button]', {
-    scope: '[data-test-item-delete]',
-    testContainer: '#ember-testing',
-  }),
+  confirmDelete: clickable('[data-test-confirm-button]'),
 });

--- a/ui/tests/pages/access/identity/index.js
+++ b/ui/tests/pages/access/identity/index.js
@@ -13,8 +13,5 @@ export default create({
     scope: '[data-test-item-delete]',
     testContainer: '#ember-testing',
   }),
-  confirmDelete: clickable('[data-test-confirm-button]', {
-    scope: '[data-test-item-delete]',
-    testContainer: '#ember-testing',
-  }),
+  confirmDelete: clickable('[data-test-confirm-button]'),
 });

--- a/ui/tests/pages/secrets/backend/pki/edit-role.js
+++ b/ui/tests/pages/secrets/backend/pki/edit-role.js
@@ -11,11 +11,6 @@ export default create({
   allowAnyName: clickable('[data-test-input="allowAnyName"]'),
   allowedDomains: fillable('[data-test-input="allowedDomains"] input'),
   save: clickable('[data-test-role-create]'),
-  deleteBtn: clickable('[data-test-role-delete] button'),
-  confirmBtn: clickable('[data-test-confirm-button]'),
-  deleteRole() {
-    return this.deleteBtn().confirmBtn();
-  },
 
   createRole(name, allowedDomains) {
     return this.toggleDomain()

--- a/ui/tests/pages/secrets/backend/pki/show.js
+++ b/ui/tests/pages/secrets/backend/pki/show.js
@@ -12,4 +12,9 @@ export default create({
   generateCertIsPresent: isPresent('[data-test-credentials-link]'),
   signCert: clickable('[data-test-sign-link]'),
   signCertIsPresent: isPresent('[data-test-sign-link]'),
+  deleteBtn: clickable('[data-test-role-delete] button'),
+  confirmBtn: clickable('[data-test-confirm-button]'),
+  deleteRole() {
+    return this.deleteBtn().confirmBtn();
+  },
 });

--- a/ui/tests/pages/secrets/backend/ssh/edit-role.js
+++ b/ui/tests/pages/secrets/backend/ssh/edit-role.js
@@ -11,11 +11,6 @@ export default create({
   name: fillable('[data-test-input="name"]'),
   CIDR: fillable('[data-test-input="cidrList"]'),
   save: clickable('[data-test-role-ssh-create]'),
-  deleteBtn: clickable('[data-test-confirm-action-trigger]'),
-  confirmBtn: clickable('[data-test-confirm-button]'),
-  deleteRole() {
-    return this.deleteBtn().confirmBtn();
-  },
 
   async createOTPRole(name) {
     await this.toggleMore()

--- a/ui/tests/pages/secrets/backend/ssh/show.js
+++ b/ui/tests/pages/secrets/backend/ssh/show.js
@@ -8,4 +8,9 @@ export default create({
   editIsPresent: isPresent('[data-test-edit-link]'),
   generate: clickable('[data-test-backend-credentials]'),
   generateIsPresent: isPresent('[data-test-backend-credentials]'),
+  deleteBtn: clickable('[data-test-confirm-action-trigger]'),
+  confirmBtn: clickable('[data-test-confirm-button]'),
+  deleteRole() {
+    return this.deleteBtn().confirmBtn();
+  },
 });


### PR DESCRIPTION
## Background

Vault stores a lot of sensitive data, so it is generally good to warn a user when an action that they take might have serious consequences. We do this in the UI by giving the user some context around this action and having them confirm that they are sure.

Prior to Vault v1.2, this design was extremely simple, and appeared when the user clicks on a "Delete" button (or "Revoke", or anything similar) on [a list row](https://user-images.githubusercontent.com/111194/57798630-6b97ce80-770a-11e9-9c95-00e614d7d0e8.png) or [anywhere else, such as a "show" page](https://user-images.githubusercontent.com/111194/57798644-7488a000-770a-11e9-9def-172695d4565c.png)

### Along come Toolbars
In Vault v1.2, we are introducing the concept of Toolbars to the UI. The Toolbar gives us a consistent way to present page-level actions, including ones that may require confirmation. Unfortunately, the old design for these confirmations [doesn't work well with the limited space](https://user-images.githubusercontent.com/111194/57798718-9c780380-770a-11e9-9d3e-8c4ac79895fe.png), so in the HashiCorp Design System we have created a more consistent and clear way to confirm these actions with users, called "Confirm Popovers".

This PR includes the new design for this component, which also gave us an opportunity to write new copy making the actions even clearer to the user. The default popover and copy looks like this:

![confirmdelete](https://user-images.githubusercontent.com/111194/57802992-83745000-7714-11e9-85b5-6712f2403684.gif)

Wherever we have clearer context we can provide the user, they would be more customized, like this:
![image](https://user-images.githubusercontent.com/111194/57803110-d221ea00-7714-11e9-844c-49c918c907cb.png)

_Note:_ We plan to utilize a "sliding menu" similar to the Namespace Picker for use in dropdown menus, but because the default solution in this PR is still very usable, we will tackle that later.
