### PR TITLE
Add spellcheck="false" to form fields

### DIFF
--- a/ui/app/templates/components/auth-jwt.hbs
+++ b/ui/app/templates/components/auth-jwt.hbs
@@ -10,6 +10,7 @@
         placeholder="Default"
         oninput={{perform this.fetchRole value="target.value"}}
         autocomplete="off"
+        spellcheck="false"
         name="role"
         id="role"
         class="input"
@@ -29,6 +30,7 @@
           name="jwt"
           class="input"
           autocomplete="off"
+          spellcheck="false"
           data-test-jwt=true
         }}
       </div>

--- a/ui/app/templates/components/control-group-success.hbs
+++ b/ui/app/templates/components/control-group-success.hbs
@@ -40,7 +40,7 @@
             Token to access data
           </label>
           <div class="control">
-            {{input data-test-token-input class="input" autocomplete="off" name="token" value=token}}
+            {{input data-test-token-input class="input" autocomplete="off" spellcheck="false" name="token" value=token}}
           </div>
         <div class="field is-grouped box is-fullwidth is-bottomless">
           <button data-test-unwrap-button type="submit" class="button is-primary" disabled={{not token}}>

--- a/ui/app/templates/components/form-field.hbs
+++ b/ui/app/templates/components/form-field.hbs
@@ -176,6 +176,7 @@
         data-test-input={{attr.name}}
         id={{attr.name}}
         autocomplete="off"
+        spellcheck="false"
         value={{or (get model valuePath) attr.options.defaultValue}}
         oninput={{action
           (action "setAndBroadcast" valuePath)

--- a/ui/app/templates/components/secret-edit-display.hbs
+++ b/ui/app/templates/components/secret-edit-display.hbs
@@ -68,6 +68,7 @@
             change=(action @editActions.handleChange)
             class="input"
             autocomplete="off"
+            spellcheck="false"
           }}
         </div>
         <div class="column info-table-row-edit">

--- a/ui/app/templates/partials/auth-form/github.hbs
+++ b/ui/app/templates/partials/auth-form/github.hbs
@@ -9,6 +9,7 @@
       class="input"
       data-test-token=true
       autocomplete="off"
+      spellcheck="false"
     }}
   </div>
 </div>

--- a/ui/app/templates/partials/auth-form/token.hbs
+++ b/ui/app/templates/partials/auth-form/token.hbs
@@ -7,6 +7,7 @@
       name="token"
       class="input"
       autocomplete="off"
+      spellcheck="false"
       data-test-token=true
     }}
   </div>

--- a/ui/app/templates/partials/secret-backend-settings/aws.hbs
+++ b/ui/app/templates/partials/secret-backend-settings/aws.hbs
@@ -53,7 +53,7 @@
         Access key
       </label>
       <div class="control">
-        {{input type="text" id="access" name="access" class="input" autocomplete="off" value=accessKey data-test-aws-input="accessKey"}}
+        {{input type="text" id="access" name="access" class="input" autocomplete="off" spellcheck="false" value=accessKey data-test-aws-input="accessKey"}}
       </div>
     </div>
 

--- a/ui/app/templates/partials/secret-form-create.hbs
+++ b/ui/app/templates/partials/secret-form-create.hbs
@@ -6,6 +6,7 @@
     <p class="control is-expanded">
       {{input 
         autocomplete="off"
+        spellcheck="false"
         data-test-secret-path="true"
         id="kv-key"
         class="input"

--- a/ui/app/templates/partials/tools/unwrap.hbs
+++ b/ui/app/templates/partials/tools/unwrap.hbs
@@ -76,6 +76,7 @@
           id="token"
           name="token"
           autocomplete="off"
+          spellcheck="false"
           data-test-tools-input="wrapping-token"
         }}
       </div>

--- a/ui/app/templates/partials/userpass-form.hbs
+++ b/ui/app/templates/partials/userpass-form.hbs
@@ -7,6 +7,7 @@
       id="username"
       class="input"
       autocomplete="off"
+      spellcheck="false"
       data-test-username=true
     }}
   </div>
@@ -21,6 +22,7 @@
       type="password"
       class="input"
       autocomplete="off"
+      spellcheck="false"
       data-test-password=true
     }}
   </div>

--- a/ui/app/templates/vault/cluster/access/control-groups.hbs
+++ b/ui/app/templates/vault/cluster/access/control-groups.hbs
@@ -24,7 +24,7 @@
         Accessor
       </label>
       <div class="control">
-        {{input class="input" autocomplete="off" name="accessor" value=model.id}}
+        {{input class="input" autocomplete="off" spellcheck="false" name="accessor" value=model.id}}
       </div>
     </div>
     <div class="field is-grouped box is-fullwidth is-bottomless">

--- a/ui/app/templates/vault/cluster/auth.hbs
+++ b/ui/app/templates/vault/cluster/auth.hbs
@@ -19,6 +19,7 @@
                   placeholder="/ (Root)"
                   oninput={{perform updateNamespace value="target.value"}}
                   autocomplete="off"
+                  spellcheck="false"
                   name="namespace"
                   id="namespace"
                   class="input"

--- a/ui/app/templates/vault/cluster/init.hbs
+++ b/ui/app/templates/vault/cluster/init.hbs
@@ -136,6 +136,7 @@
                 data-test-key-shares="true"
                 class="input"
                 autocomplete="off"
+                spellcheck="false"
                 name="key-shares"
                 type="number"
                 step="1"
@@ -158,7 +159,9 @@
             <div class="control">
               {{input
                 data-test-key-threshold="true"
-                class="input" autocomplete="off"
+                class="input"
+                autocomplete="off"
+                spellcheck="false"
                 name="key-threshold"
                 type="number"
                 step="1"


### PR DESCRIPTION
In Safari on OSX, it will replace form values with autocorrected values
unless this field is present

There were a couple fields that already had spellcheck="false", this adds the attribute to all other `<input/>` fields that currently have `autocomplete="off"`