### PR TITLE
ci: make ember-ci-test (browserstack)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
           name: Run BrowserStack tests
           command: |
             set -eux -o pipefail
-            make ember-ci-test
+            make test-ui-browserstack
 
   test-go:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,10 @@ jobs:
           name: Run BrowserStack tests
           command: |
             set -eux -o pipefail
+
+            # Add ./bin to the PATH so vault binary can be run by Ember tests
+            export PATH="${PWD}"/bin:${PATH}
+
             make test-ui-browserstack
 
   test-go:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Test Ember
+          name: Run BrowserStack tests
           command: |
             set -eux -o pipefail
             make ember-ci-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,4 +220,5 @@ workflows:
             - build-go-dev
       - test-ember:
           requires:
+            - install-ui-dependencies
             - build-go-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - store_test_results:
           path: ui/test-results
 
-  test-ember:
+  test-ui-browserstack:
     docker:
       - image: *NODE_IMAGE
     steps:
@@ -218,7 +218,7 @@ workflows:
       - test-go:
           requires:
             - build-go-dev
-      - test-ember:
+      - test-ui-browserstack:
           requires:
             - install-ui-dependencies
             - build-go-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,21 @@ jobs:
       - store_test_results:
           path: ui/test-results
 
+  test-ember:
+    docker:
+      - image: *NODE_IMAGE
+    steps:
+      - checkout
+      - restore_cache:
+          key: *YARN_LOCK_CACHE_KEY
+      - attach_workspace:
+          at: .
+      - run:
+          name: Test Ember
+          command: |
+            set -eux -o pipefail
+            make ember-ci-test
+
   test-go:
     machine: true
     environment:
@@ -201,5 +216,8 @@ workflows:
             - install-ui-dependencies
             - build-go-dev
       - test-go:
+          requires:
+            - build-go-dev
+      - test-ember:
           requires:
             - build-go-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ branches:
 
 env:
   - TEST_COMMAND='make dev test-ember'
-  - TEST_COMMAND='make dev ember-ci-test'
+  - TEST_COMMAND='make dev test-ui-browserstack'
   - TEST_COMMAND='travis_wait 75 make testtravis'
   - TEST_COMMAND='travis_wait 75 make testracetravis'
   - GO111MODULE=on

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,11 @@ test-ember:
 	@echo "--> Running ember tests"
 	@cd ui && yarn run test-oss
 
-ember-ci-test:
+ember-ci-test: # Deprecated, to be removed soon.
+	@echo "ember-ci-test is deprecated in favour of test-ui-browserstack"
+	@exit 1
+
+test-ui-browserstack:
 	@echo "--> Installing JavaScript assets"
 	@cd ui && yarn --ignore-optional
 	@echo "--> Running ember tests in Browserstack"

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,16 @@ ember-ci-test: # Deprecated, to be removed soon.
 	@echo "ember-ci-test is deprecated in favour of test-ui-browserstack"
 	@exit 1
 
-test-ui-browserstack:
+check-vault-in-path:
+	@VAULT_BIN=$$(command -v vault) || { echo "vault command not found"; exit 1; }; \
+		[ -x "$$VAULT_BIN" ] || { echo "$$VAULT_BIN not executable"; exit 1; }; \
+		printf "Using Vault at %s:\n\$$ vault version\n%s\n" "$$VAULT_BIN" "$$(vault version)"
+
+check-browserstack-creds:
+	@[ -n "$$BROWSERSTACK_ACCESS_KEY" ] || { echo "BROWSERSTACK_ACCESS_KEY not set"; exit 1; }
+	@[ -n "$$BROWSERSTACK_USERNAME" ] || { echo "BROWSERSTACK_USERNAME not set"; exit 1; }
+
+test-ui-browserstack: check-vault-in-path check-browserstack-creds
 	@echo "--> Installing JavaScript assets"
 	@cd ui && yarn --ignore-optional
 	@echo "--> Running ember tests in Browserstack"
@@ -208,6 +217,6 @@ hana-database-plugin:
 mongodb-database-plugin:
 	@CGO_ENABLED=0 go build -o bin/mongodb-database-plugin ./plugins/database/mongodb/mongodb-database-plugin
 
-.PHONY: bin default prep test vet bootstrap fmt fmtcheck mysql-database-plugin mysql-legacy-database-plugin cassandra-database-plugin influxdb-database-plugin postgresql-database-plugin mssql-database-plugin hana-database-plugin mongodb-database-plugin static-assets ember-dist ember-dist-dev static-dist static-dist-dev assetcheck
+.PHONY: bin default prep test vet bootstrap fmt fmtcheck mysql-database-plugin mysql-legacy-database-plugin cassandra-database-plugin influxdb-database-plugin postgresql-database-plugin mssql-database-plugin hana-database-plugin mongodb-database-plugin static-assets ember-dist ember-dist-dev static-dist static-dist-dev assetcheck check-vault-in-path check-browserstack-creds test-ui-browserstack
 
 .NOTPARALLEL: ember-dist ember-dist-dev static-assets

--- a/ui/scripts/run-browserstack-tests.js
+++ b/ui/scripts/run-browserstack-tests.js
@@ -16,8 +16,8 @@ function run(command, args = []) {
 }
 
 (async function() {
-  await run('ember', ['browserstack:connect']);
   try {
+    await run('ember', ['browserstack:connect']);
     try {
       await run('ember', ['test', '-f=secrets/secret/create', '-c', 'testem.browserstack.js']);
 


### PR DESCRIPTION
Runs `make ember-ci-test` in CircleCI in parallel with other tests.

EDIT: Now that it's run, see the new check "ci/circleci: test-ember" which is green at the time of writing. Other checks that are failing seem unrelated to this change. This check is currently not _required_ but maybe it should be @meirish?

EDIT2: 2 checks added to the Makefile to fail faster and with good error messages when either vault not in path, or browserstack creds missing. Also added vault to the path in circleci.