### PR TITLE
Change tab completion in the UI to prefer common prefix

### DIFF
--- a/ui/app/mixins/list-controller.js
+++ b/ui/app/mixins/list-controller.js
@@ -1,6 +1,7 @@
 import { computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 import escapeStringRegexp from 'escape-string-regexp';
+import commonPrefix from 'vault/utils/common-prefix';
 
 export default Mixin.create({
   queryParams: {
@@ -26,11 +27,20 @@ export default Mixin.create({
     var content = this.get('model');
     var filterMatchesKey = this.get('filterMatchesKey');
     var re = new RegExp('^' + escapeStringRegexp(filter));
-    return filterMatchesKey
-      ? null
-      : content.find(function(key) {
-          return re.test(key.get('id'));
-        });
+    let matchSet = content.filter(key => re.test(key.id));
+    let match = matchSet.firstObject;
+
+    if (filterMatchesKey || !match) {
+      return null;
+    }
+
+    let sharedPrefix = commonPrefix(content);
+    // if we already are filtering the prefix, then next we want
+    // the exact match
+    if (filter === sharedPrefix || matchSet.length === 1) {
+      return match;
+    }
+    return { id: sharedPrefix };
   }),
 
   actions: {

--- a/ui/app/mixins/list-controller.js
+++ b/ui/app/mixins/list-controller.js
@@ -17,18 +17,15 @@ export default Mixin.create({
   isLoading: false,
 
   filterMatchesKey: computed('filter', 'model', 'model.[]', function() {
-    var filter = this.get('filter');
-    var content = this.get('model');
+    let { filter, model: content } = this;
     return !!(content.length && content.findBy('id', filter));
   }),
 
   firstPartialMatch: computed('filter', 'model', 'model.[]', 'filterMatchesKey', function() {
-    var filter = this.get('filter');
-    var content = this.get('model');
-    var filterMatchesKey = this.get('filterMatchesKey');
-    var re = new RegExp('^' + escapeStringRegexp(filter));
+    let { filter, filterMatchesKey, model: content } = this;
+    let re = new RegExp('^' + escapeStringRegexp(filter));
     let matchSet = content.filter(key => re.test(key.id));
-    let match = matchSet.firstObject;
+    let match = matchSet[0];
 
     if (filterMatchesKey || !match) {
       return null;

--- a/ui/app/utils/common-prefix.js
+++ b/ui/app/utils/common-prefix.js
@@ -2,8 +2,9 @@ import { get } from '@ember/object';
 
 export default function(arr, attribute = 'id') {
   let content = arr || [];
-  // this assumes an already sorted array, if we have a match,
-  // it will have matched the first one so we also want the last one
+  // this assumes an already sorted array
+  // if the array is sorted, we want to compare the first and last
+  // item in the array - if they share a prefix, all of the items do
   let firstString = get(content[0], attribute);
   let lastString = get(content[arr.length - 1], attribute);
 
@@ -11,13 +12,13 @@ export default function(arr, attribute = 'id') {
   let targetLength = firstString.length;
   let prefixLength = 0;
   // walk the two strings, and if they match at the current length,
-  // increment the prefix and try again
+  // increment the prefixLength and try again
   while (
     prefixLength < targetLength &&
     firstString.charAt(prefixLength) === lastString.charAt(prefixLength)
   ) {
     prefixLength++;
   }
-  // slice the prefix from the match
+  // slice the prefix from the first item
   return firstString.substring(0, prefixLength);
 }

--- a/ui/app/utils/common-prefix.js
+++ b/ui/app/utils/common-prefix.js
@@ -1,0 +1,23 @@
+import { get } from '@ember/object';
+
+export default function(arr, attribute = 'id') {
+  let content = arr || [];
+  // this assumes an already sorted array, if we have a match,
+  // it will have matched the first one so we also want the last one
+  let firstString = get(content[0], attribute);
+  let lastString = get(content[arr.length - 1], attribute);
+
+  // the longest the shared prefix could be is the length of the match
+  let targetLength = firstString.length;
+  let prefixLength = 0;
+  // walk the two strings, and if they match at the current length,
+  // increment the prefix and try again
+  while (
+    prefixLength < targetLength &&
+    firstString.charAt(prefixLength) === lastString.charAt(prefixLength)
+  ) {
+    prefixLength++;
+  }
+  // slice the prefix from the match
+  return firstString.substring(0, prefixLength);
+}

--- a/ui/app/utils/common-prefix.js
+++ b/ui/app/utils/common-prefix.js
@@ -1,12 +1,12 @@
-import { get } from '@ember/object';
-
-export default function(arr, attribute = 'id') {
-  let content = arr || [];
+export default function(arr = [], attribute = 'id') {
+  if (!arr.length) {
+    return '';
+  }
   // this assumes an already sorted array
   // if the array is sorted, we want to compare the first and last
   // item in the array - if they share a prefix, all of the items do
-  let firstString = get(content[0], attribute);
-  let lastString = get(content[arr.length - 1], attribute);
+  let firstString = arr[0][attribute];
+  let lastString = arr[arr.length - 1][attribute];
 
   // the longest the shared prefix could be is the length of the match
   let targetLength = firstString.length;

--- a/ui/lib/.eslintrc.js
+++ b/ui/lib/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
     node: true,
-    browser: false,
+    browser: true,
   },
 };

--- a/ui/tests/unit/utils/common-prefix-test.js
+++ b/ui/tests/unit/utils/common-prefix-test.js
@@ -1,0 +1,27 @@
+import commonPrefix from 'vault/utils/common-prefix';
+import { module, test } from 'qunit';
+
+module('Unit | Util | common prefix', function() {
+  test('it returns empty string if there are no common prefixes', function(assert) {
+    let secrets = ['asecret', 'secret2', 'secret3'].map(s => ({id: s}));
+    let returned = commonPrefix(secrets);
+    assert.equal(returned, '', 'returns an empty string');
+  });
+
+  test('it returns the longest prefix', function(assert) {
+    let secrets = ['secret1', 'secret2', 'secret3'].map(s => ({id: s}));
+    let returned = commonPrefix(secrets);
+    assert.equal(returned, 'secret', 'finds secret prefix');
+    let greetings = ['hello-there', 'hello-hi', 'hello-howdy'].map(s => ({id: s}));
+    returned = commonPrefix(greetings);
+    assert.equal(returned, 'hello-', 'finds hello- prefix');
+  });
+
+
+  test('it can compare an attribute that is not "id" to calculate the longest prefix', function(assert) {
+    let secrets = ['secret1', 'secret2', 'secret3'].map(s => ({name: s}));
+    let returned = commonPrefix(secrets, 'name');
+    assert.equal(returned, 'secret', 'finds secret prefix from name attribute');
+  });
+});
+

--- a/ui/tests/unit/utils/common-prefix-test.js
+++ b/ui/tests/unit/utils/common-prefix-test.js
@@ -2,26 +2,31 @@ import commonPrefix from 'vault/utils/common-prefix';
 import { module, test } from 'qunit';
 
 module('Unit | Util | common prefix', function() {
+  test('it returns empty string if called with no args or an empty array', function(assert) {
+    let returned = commonPrefix();
+    assert.equal(returned, '', 'returns an empty string');
+    returned = commonPrefix([]);
+    assert.equal(returned, '', 'returns an empty string for an empty array');
+  });
+
   test('it returns empty string if there are no common prefixes', function(assert) {
-    let secrets = ['asecret', 'secret2', 'secret3'].map(s => ({id: s}));
+    let secrets = ['asecret', 'secret2', 'secret3'].map(s => ({ id: s }));
     let returned = commonPrefix(secrets);
     assert.equal(returned, '', 'returns an empty string');
   });
 
   test('it returns the longest prefix', function(assert) {
-    let secrets = ['secret1', 'secret2', 'secret3'].map(s => ({id: s}));
+    let secrets = ['secret1', 'secret2', 'secret3'].map(s => ({ id: s }));
     let returned = commonPrefix(secrets);
     assert.equal(returned, 'secret', 'finds secret prefix');
-    let greetings = ['hello-there', 'hello-hi', 'hello-howdy'].map(s => ({id: s}));
+    let greetings = ['hello-there', 'hello-hi', 'hello-howdy'].map(s => ({ id: s }));
     returned = commonPrefix(greetings);
     assert.equal(returned, 'hello-', 'finds hello- prefix');
   });
 
-
   test('it can compare an attribute that is not "id" to calculate the longest prefix', function(assert) {
-    let secrets = ['secret1', 'secret2', 'secret3'].map(s => ({name: s}));
+    let secrets = ['secret1', 'secret2', 'secret3'].map(s => ({ name: s }));
     let returned = commonPrefix(secrets, 'name');
     assert.equal(returned, 'secret', 'finds secret prefix from name attribute');
   });
 });
-


### PR DESCRIPTION
This changes the autocomplete behavior on routes that use the `NavigateInput` with the list-controller mixin so that tabbing on the keyboard will first check to see if there is a common prefix. Previous to this, tabbing would complete the first match in the list - this is now only done when there isn't a common prefix for all of the currently listed keys.

In the example gif we see that hitting tab on the full list auto-completes "one" - this behavior is the same as before. What's new is if you filter the list (in the gif typing `sec`) and then tab, the completion fills to `secret-` and then will complete `secret-one` on a second tab. This behavior is closer to how autocomplete works on the Vault CLI.
![autocomplete](https://user-images.githubusercontent.com/39469/58055590-d3dc1b00-7b23-11e9-8a4a-bf7c4a4108d7.gif)