### PR TITLE
don't use fit-content, ff doesn't love it

### DIFF
--- a/ui/app/styles/components/hs-icon.scss
+++ b/ui/app/styles/components/hs-icon.scss
@@ -5,7 +5,6 @@
   align-items: flex-start;
   vertical-align: middle;
   width: 16px;
-  min-width: fit-content;
   margin: 2px 4px;
 }
 


### PR DESCRIPTION
When building the production version of the app, auto-prefixer adds some vendor prefixes for FF and content-fit. This caused the new Icon SVGs to all be sized by their viewBox, breaking the layout. And it turns out that everything looks fine without this CSS declaration, so we just remove it.

Before:
![image](https://user-images.githubusercontent.com/39469/58051106-ee5bc780-7b16-11e9-9224-687acb66a944.png)

After:
![Screen Shot 2019-05-20 at 3 51 37 PM](https://user-images.githubusercontent.com/39469/58051201-2cf18200-7b17-11e9-9152-5a88f05a47c6.png)
