### PR TITLE
Build: Respect the CGO_ENABLED environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ EXTERNAL_TOOLS=\
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 GO_VERSION_MIN=1.11
-CGO_ENABLED=0
+CGO_ENABLED?=0
 ifneq ($(FDB_ENABLED), )
 	CGO_ENABLED=1
 	BUILD_TAGS+=foundationdb


### PR DESCRIPTION
The PR just allows building using CGO. This is needed on MacOS to be able to use the OS implementation of the DNS resolver. Otherwise if you use different servers for different domains (for example, internal ones), vault does not resolve the names correctly. With the patch, vault can be built using something like `CGO_ENABLED=1 BUILD_TAGS="netcgo vault" make dev`
