### PR TITLE
Increase no_output_timeout for test-go job to 20 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ jobs:
       GO_TAGS:
     parallelism: 2
     working_directory: ~/src
+    no_output_timeout: 20m
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This seemed to fix the CircleCI timeouts in my testing and should hopefully hold us over until we can start refactoring tests to parallelize more.