### PR TITLE
Fix a case where mounts could be duplicated

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -76,7 +76,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 	// Populate cache
 	NamespaceByID(ctx, ns.ID, c)
 
-	// Look for matching name
+	// Basic check for matching names
 	for _, ent := range c.auth.Entries {
 		if ns.ID == ent.NamespaceID {
 			switch {
@@ -85,7 +85,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 			case strings.HasPrefix(ent.Path, entry.Path):
 				fallthrough
 			case strings.HasPrefix(entry.Path, ent.Path):
-				return logical.CodedError(409, "path is already in use")
+				return logical.CodedError(409, fmt.Sprintf("path is already in use at %s", ent.Path))
 			}
 		}
 	}
@@ -95,6 +95,7 @@ func (c *Core) enableCredentialInternal(ctx context.Context, entry *MountEntry, 
 		return fmt.Errorf("token credential backend cannot be instantiated")
 	}
 
+	// Check for conflicts according to the router
 	if conflict := c.router.MountConflict(ctx, credentialRoutePrefix+entry.Path); conflict != "" {
 		return logical.CodedError(409, fmt.Sprintf("existing mount at %s", conflict))
 	}
@@ -258,11 +259,6 @@ func (c *Core) disableCredentialInternal(ctx context.Context, path string, updat
 		backend.Cleanup(ctx)
 	}
 
-	// Unmount the backend
-	if err := c.router.Unmount(ctx, path); err != nil {
-		return err
-	}
-
 	viewPath := entry.ViewPath()
 	switch {
 	case !updateStorage:
@@ -281,6 +277,11 @@ func (c *Core) disableCredentialInternal(ctx context.Context, path string, updat
 
 	// Remove the mount table entry
 	if err := c.removeCredEntry(ctx, strings.TrimPrefix(path, credentialRoutePrefix), updateStorage); err != nil {
+		return err
+	}
+
+	// Unmount the backend
+	if err := c.router.Unmount(ctx, path); err != nil {
 		return err
 	}
 

--- a/vault/external_tests/router/router_ext_test.go
+++ b/vault/external_tests/router/router_ext_test.go
@@ -5,19 +5,23 @@ import (
 
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/builtin/credential/userpass"
+	"github.com/hashicorp/vault/builtin/logical/pki"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
 
 func TestRouter_MountSubpath_Checks(t *testing.T) {
-	testRouter_MountSubpath(t, []string{"auth/abcd/123", "abcd/123"})
-	testRouter_MountSubpath(t, []string{"abcd/123", "auth/abcd/123"})
-	testRouter_MountSubpath(t, []string{"auth/abcd/123", "abcd/123"})
+	testRouter_MountSubpath(t, []string{"a/abcd/123", "abcd/123"})
+	testRouter_MountSubpath(t, []string{"abcd/123", "a/abcd/123"})
+	testRouter_MountSubpath(t, []string{"a/abcd/123", "abcd/123"})
 }
 
 func testRouter_MountSubpath(t *testing.T, mountPoints []string) {
 	coreConfig := &vault.CoreConfig{
+		LogicalBackends: map[string]logical.Factory{
+			"pki": pki.Factory,
+		},
 		CredentialBackends: map[string]logical.Factory{
 			"userpass": userpass.Factory,
 		},
@@ -31,22 +35,33 @@ func testRouter_MountSubpath(t *testing.T, mountPoints []string) {
 	vault.TestWaitActive(t, cluster.Cores[0].Core)
 	client := cluster.Cores[0].Client
 
+	// Test auth
 	authInput := &api.EnableAuthOptions{
 		Type: "userpass",
 	}
-
 	for _, mp := range mountPoints {
-		t.Logf("mounting %s", mp)
+		t.Logf("mounting %s", "auth/"+mp)
 		var err error
-		err = client.Sys().EnableAuthWithOptions(mp, authInput)
+		err = client.Sys().EnableAuthWithOptions("auth/"+mp, authInput)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	// Test secrets
+	mountInput := &api.MountInput{
+		Type: "pki",
+	}
+	for _, mp := range mountPoints {
+		t.Logf("mounting %s", "s/"+mp)
+		var err error
+		err = client.Sys().Mount("s/"+mp, mountInput)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	}
 
 	cluster.EnsureCoresSealed(t)
-
 	cluster.UnsealCores(t)
-
 	t.Logf("Done: %#v", mountPoints)
 }

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -395,7 +395,21 @@ func (c *Core) mountInternal(ctx context.Context, entry *MountEntry, updateStora
 	// Ensure the cache is populated, don't need the result
 	NamespaceByID(ctx, ns.ID, c)
 
-	// Verify there are no conflicting mounts
+	// Basic check for matching names
+	for _, ent := range c.mounts.Entries {
+		if ns.ID == ent.NamespaceID {
+			switch {
+			// Existing is oauth/github/ new is oauth/ or
+			// existing is oauth/ and new is oauth/github/
+			case strings.HasPrefix(ent.Path, entry.Path):
+				fallthrough
+			case strings.HasPrefix(entry.Path, ent.Path):
+				return logical.CodedError(409, fmt.Sprintf("path is already in use at %s", ent.Path))
+			}
+		}
+	}
+
+	// Verify there are no conflicting mounts in the router
 	if match := c.router.MountConflict(ctx, entry.Path); match != "" {
 		return logical.CodedError(409, fmt.Sprintf("existing mount at %s", match))
 	}
@@ -571,11 +585,6 @@ func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage b
 		backend.Cleanup(ctx)
 	}
 
-	// Unmount the backend entirely
-	if err := c.router.Unmount(ctx, path); err != nil {
-		return err
-	}
-
 	viewPath := entry.ViewPath()
 	switch {
 	case !updateStorage:
@@ -592,9 +601,15 @@ func (c *Core) unmountInternal(ctx context.Context, path string, updateStorage b
 			return err
 		}
 	}
+
 	// Remove the mount table entry
 	if err := c.removeMountEntry(ctx, path, updateStorage); err != nil {
 		c.logger.Error("failed to remove mount entry for path being unmounted", "error", err, "path", path)
+		return err
+	}
+
+	// Unmount the backend entirely
+	if err := c.router.Unmount(ctx, path); err != nil {
 		return err
 	}
 

--- a/vault/router.go
+++ b/vault/router.go
@@ -121,7 +121,7 @@ func (r *Router) Mount(backend logical.Backend, prefix string, mountEntry *Mount
 
 	// Create a mount entry
 	re := &routeEntry{
-		tainted:       false,
+		tainted:       mountEntry.Tainted,
 		backend:       backend,
 		mountEntry:    mountEntry,
 		storagePrefix: storageView.Prefix(),


### PR DESCRIPTION
When unmounting, the router entry would be tainted, preventing routing.
However, we would then unmount the router before clearing storage, so if
an error occurred the router would have forgotten the path. For auth
mounts this isn't a problem since they had a secondary check, but
regular mounts didn't (not sure why, but this is true back to at least
0.2.0). This meant you could then create a duplicate mount using the
same path which would then not conflict in the router until postUnseal.

This adds the extra check to regular mounts, and also moves the location
of the router unmount.

This also ensures that on the next router.Mount, tainted is set to the
mount entry's tainted status.

Fixes #6769