### PR TITLE
Allow plugins to submit audit requests/responses via extended SystemView

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -16,13 +16,13 @@ type Backend interface {
 	// request is authorized but before the request is executed. The arguments
 	// MUST not be modified in anyway. They should be deep copied if this is
 	// a possibility.
-	LogRequest(context.Context, *LogInput) error
+	LogRequest(context.Context, *logical.LogInput) error
 
 	// LogResponse is used to synchronously log a response. This is done after
 	// the request is processed but before the response is sent. The arguments
 	// MUST not be modified in anyway. They should be deep copied if this is
 	// a possibility.
-	LogResponse(context.Context, *LogInput) error
+	LogResponse(context.Context, *logical.LogInput) error
 
 	// GetHash is used to return the given data with the backend's hash,
 	// so that a caller can determine if a value in the audit log matches
@@ -34,16 +34,6 @@ type Backend interface {
 
 	// Invalidate is called for path invalidation
 	Invalidate(context.Context)
-}
-
-// LogInput contains the input parameters passed into LogRequest and LogResponse
-type LogInput struct {
-	Auth                *logical.Auth
-	Request             *logical.Request
-	Response            *logical.Response
-	OuterErr            error
-	NonHMACReqDataKeys  []string
-	NonHMACRespDataKeys []string
 }
 
 // BackendConfig contains configuration parameters used in the factory func to

--- a/audit/format.go
+++ b/audit/format.go
@@ -2,6 +2,8 @@ package audit
 
 import (
 	"context"
+	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -30,7 +32,7 @@ type AuditFormatter struct {
 
 var _ Formatter = (*AuditFormatter)(nil)
 
-func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config FormatterConfig, in *LogInput) error {
+func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config FormatterConfig, in *logical.LogInput) error {
 	if in == nil || in.Request == nil {
 		return fmt.Errorf("request to request-audit a nil request")
 	}
@@ -51,15 +53,19 @@ func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config 
 	// Set these to the input values at first
 	auth := in.Auth
 	req := in.Request
+	var connState *tls.ConnectionState
+
+	if in.Request.Connection != nil && in.Request.Connection.ConnState != nil {
+		connState = in.Request.Connection.ConnState
+	}
 
 	if !config.Raw {
 		// Before we copy the structure we must nil out some data
 		// otherwise we will cause reflection to panic and die
-		if in.Request.Connection != nil && in.Request.Connection.ConnState != nil {
-			origState := in.Request.Connection.ConnState
+		if connState != nil {
 			in.Request.Connection.ConnState = nil
 			defer func() {
-				in.Request.Connection.ConnState = origState
+				in.Request.Connection.ConnState = connState
 			}()
 		}
 
@@ -77,6 +83,17 @@ func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config 
 			return err
 		}
 		req = cp.(*logical.Request)
+		for k, v := range req.Data {
+			if o, ok := v.(logical.OptMarshaler); ok {
+				marshaled, err := o.MarshalJSONWithOptions(&logical.MarshalOptions{
+					ValueHasher: salt.GetIdentifiedHMAC,
+				})
+				if err != nil {
+					return err
+				}
+				req.Data[k] = json.RawMessage(marshaled)
+			}
+		}
 
 		// Hash any sensitive information
 		if auth != nil {
@@ -120,8 +137,12 @@ func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config 
 		return err
 	}
 
+	reqType := in.Type
+	if reqType == "" {
+		reqType = "request"
+	}
 	reqEntry := &AuditRequestEntry{
-		Type:  "request",
+		Type:  reqType,
 		Error: errString,
 
 		Auth: AuditAuth{
@@ -147,12 +168,13 @@ func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config 
 				ID:   ns.ID,
 				Path: ns.Path,
 			},
-			Path:               req.Path,
-			Data:               req.Data,
-			PolicyOverride:     req.PolicyOverride,
-			RemoteAddr:         getRemoteAddr(req),
-			ReplicationCluster: req.ReplicationCluster,
-			Headers:            req.Headers,
+			Path:                          req.Path,
+			Data:                          req.Data,
+			PolicyOverride:                req.PolicyOverride,
+			RemoteAddr:                    getRemoteAddr(req),
+			ReplicationCluster:            req.ReplicationCluster,
+			Headers:                       req.Headers,
+			ClientCertificateSerialNumber: getClientCertificateSerialNumber(connState),
 		},
 	}
 
@@ -167,7 +189,7 @@ func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config 
 	return f.AuditFormatWriter.WriteRequest(w, reqEntry)
 }
 
-func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config FormatterConfig, in *LogInput) error {
+func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config FormatterConfig, in *logical.LogInput) error {
 	if in == nil || in.Request == nil {
 		return fmt.Errorf("request to response-audit a nil request")
 	}
@@ -189,15 +211,19 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 	auth := in.Auth
 	req := in.Request
 	resp := in.Response
+	var connState *tls.ConnectionState
+
+	if in.Request.Connection != nil && in.Request.Connection.ConnState != nil {
+		connState = in.Request.Connection.ConnState
+	}
 
 	if !config.Raw {
 		// Before we copy the structure we must nil out some data
 		// otherwise we will cause reflection to panic and die
-		if in.Request.Connection != nil && in.Request.Connection.ConnState != nil {
-			origState := in.Request.Connection.ConnState
+		if connState != nil {
 			in.Request.Connection.ConnState = nil
 			defer func() {
-				in.Request.Connection.ConnState = origState
+				in.Request.Connection.ConnState = connState
 			}()
 		}
 
@@ -215,6 +241,17 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 			return err
 		}
 		req = cp.(*logical.Request)
+		for k, v := range req.Data {
+			if o, ok := v.(logical.OptMarshaler); ok {
+				marshaled, err := o.MarshalJSONWithOptions(&logical.MarshalOptions{
+					ValueHasher: salt.GetIdentifiedHMAC,
+				})
+				if err != nil {
+					return err
+				}
+				req.Data[k] = json.RawMessage(marshaled)
+			}
+		}
 
 		if in.Response != nil {
 			cp, err := copystructure.Copy(in.Response)
@@ -222,6 +259,17 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 				return err
 			}
 			resp = cp.(*logical.Response)
+			for k, v := range resp.Data {
+				if o, ok := v.(logical.OptMarshaler); ok {
+					marshaled, err := o.MarshalJSONWithOptions(&logical.MarshalOptions{
+						ValueHasher: salt.GetIdentifiedHMAC,
+					})
+					if err != nil {
+						return err
+					}
+					resp.Data[k] = json.RawMessage(marshaled)
+				}
+			}
 		}
 
 		// Hash any sensitive information
@@ -334,8 +382,12 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 		}
 	}
 
+	respType := in.Type
+	if respType == "" {
+		respType = "request"
+	}
 	respEntry := &AuditResponseEntry{
-		Type:  "response",
+		Type:  respType,
 		Error: errString,
 		Auth: AuditAuth{
 			ClientToken:               auth.ClientToken,
@@ -360,12 +412,13 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 				ID:   ns.ID,
 				Path: ns.Path,
 			},
-			Path:               req.Path,
-			Data:               req.Data,
-			PolicyOverride:     req.PolicyOverride,
-			RemoteAddr:         getRemoteAddr(req),
-			ReplicationCluster: req.ReplicationCluster,
-			Headers:            req.Headers,
+			Path:                          req.Path,
+			Data:                          req.Data,
+			PolicyOverride:                req.PolicyOverride,
+			RemoteAddr:                    getRemoteAddr(req),
+			ClientCertificateSerialNumber: getClientCertificateSerialNumber(connState),
+			ReplicationCluster:            req.ReplicationCluster,
+			Headers:                       req.Headers,
 		},
 
 		Response: AuditResponse{
@@ -410,18 +463,19 @@ type AuditResponseEntry struct {
 }
 
 type AuditRequest struct {
-	ID                  string                 `json:"id"`
-	ReplicationCluster  string                 `json:"replication_cluster,omitempty"`
-	Operation           logical.Operation      `json:"operation"`
-	ClientToken         string                 `json:"client_token"`
-	ClientTokenAccessor string                 `json:"client_token_accessor"`
-	Namespace           AuditNamespace         `json:"namespace"`
-	Path                string                 `json:"path"`
-	Data                map[string]interface{} `json:"data"`
-	PolicyOverride      bool                   `json:"policy_override"`
-	RemoteAddr          string                 `json:"remote_address"`
-	WrapTTL             int                    `json:"wrap_ttl"`
-	Headers             map[string][]string    `json:"headers"`
+	ID                            string                 `json:"id"`
+	ReplicationCluster            string                 `json:"replication_cluster,omitempty"`
+	Operation                     logical.Operation      `json:"operation"`
+	ClientToken                   string                 `json:"client_token"`
+	ClientTokenAccessor           string                 `json:"client_token_accessor"`
+	Namespace                     AuditNamespace         `json:"namespace"`
+	Path                          string                 `json:"path"`
+	Data                          map[string]interface{} `json:"data"`
+	PolicyOverride                bool                   `json:"policy_override"`
+	RemoteAddr                    string                 `json:"remote_address"`
+	WrapTTL                       int                    `json:"wrap_ttl"`
+	Headers                       map[string][]string    `json:"headers"`
+	ClientCertificateSerialNumber string                 `json:"client_certificate_serial_number,omitempty"`
 }
 
 type AuditResponse struct {
@@ -473,6 +527,14 @@ func getRemoteAddr(req *logical.Request) string {
 		return req.Connection.RemoteAddr
 	}
 	return ""
+}
+
+func getClientCertificateSerialNumber(connState *tls.ConnectionState) string {
+	if connState == nil || len(connState.VerifiedChains) == 0 || len(connState.VerifiedChains[0]) == 0 {
+		return ""
+	}
+
+	return connState.VerifiedChains[0][0].SerialNumber.String()
 }
 
 // parseVaultTokenFromJWT returns a string iff the token was a JWT and we could

--- a/audit/format.go
+++ b/audit/format.go
@@ -384,7 +384,7 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 
 	respType := in.Type
 	if respType == "" {
-		respType = "request"
+		respType = "response"
 	}
 	respEntry := &AuditResponseEntry{
 		Type:  respType,

--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -99,7 +99,7 @@ func TestFormatJSON_formatRequest(t *testing.T) {
 		config := FormatterConfig{
 			HMACAccessor: false,
 		}
-		in := &LogInput{
+		in := &logical.LogInput{
 			Auth:     tc.Auth,
 			Request:  tc.Req,
 			OuterErr: tc.Err,

--- a/audit/format_jsonx_test.go
+++ b/audit/format_jsonx_test.go
@@ -103,7 +103,7 @@ func TestFormatJSONx_formatRequest(t *testing.T) {
 			OmitTime:     true,
 			HMACAccessor: false,
 		}
-		in := &LogInput{
+		in := &logical.LogInput{
 			Auth:     tc.Auth,
 			Request:  tc.Req,
 			OuterErr: tc.Err,

--- a/audit/format_test.go
+++ b/audit/format_test.go
@@ -41,11 +41,11 @@ func TestFormatRequestErrors(t *testing.T) {
 		AuditFormatWriter: &noopFormatWriter{},
 	}
 
-	if err := formatter.FormatRequest(context.Background(), ioutil.Discard, config, &LogInput{}); err == nil {
+	if err := formatter.FormatRequest(context.Background(), ioutil.Discard, config, &logical.LogInput{}); err == nil {
 		t.Fatal("expected error due to nil request")
 	}
 
-	in := &LogInput{
+	in := &logical.LogInput{
 		Request: &logical.Request{},
 	}
 	if err := formatter.FormatRequest(context.Background(), nil, config, in); err == nil {
@@ -59,11 +59,11 @@ func TestFormatResponseErrors(t *testing.T) {
 		AuditFormatWriter: &noopFormatWriter{},
 	}
 
-	if err := formatter.FormatResponse(context.Background(), ioutil.Discard, config, &LogInput{}); err == nil {
+	if err := formatter.FormatResponse(context.Background(), ioutil.Discard, config, &logical.LogInput{}); err == nil {
 		t.Fatal("expected error due to nil request")
 	}
 
-	in := &LogInput{
+	in := &logical.LogInput{
 		Request: &logical.Request{},
 	}
 	if err := formatter.FormatResponse(context.Background(), nil, config, in); err == nil {

--- a/audit/formatter.go
+++ b/audit/formatter.go
@@ -3,6 +3,8 @@ package audit
 import (
 	"context"
 	"io"
+
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 // Formatter is an interface that is responsible for formating a
@@ -11,8 +13,8 @@ import (
 //
 // It is recommended that you pass data through Hash prior to formatting it.
 type Formatter interface {
-	FormatRequest(context.Context, io.Writer, FormatterConfig, *LogInput) error
-	FormatResponse(context.Context, io.Writer, FormatterConfig, *LogInput) error
+	FormatRequest(context.Context, io.Writer, FormatterConfig, *logical.LogInput) error
+	FormatResponse(context.Context, io.Writer, FormatterConfig, *logical.LogInput) error
 }
 
 type FormatterConfig struct {

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -172,7 +172,7 @@ func (b *Backend) GetHash(ctx context.Context, data string) (string, error) {
 	return audit.HashString(salt, data), nil
 }
 
-func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogRequest(ctx context.Context, in *logical.LogInput) error {
 	b.fileLock.Lock()
 	defer b.fileLock.Unlock()
 
@@ -202,7 +202,7 @@ func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
 	return b.formatter.FormatRequest(ctx, b.f, b.formatConfig, in)
 }
 
-func (b *Backend) LogResponse(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 
 	b.fileLock.Lock()
 	defer b.fileLock.Unlock()

--- a/builtin/audit/socket/backend.go
+++ b/builtin/audit/socket/backend.go
@@ -131,7 +131,7 @@ func (b *Backend) GetHash(ctx context.Context, data string) (string, error) {
 	return audit.HashString(salt, data), nil
 }
 
-func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogRequest(ctx context.Context, in *logical.LogInput) error {
 	var buf bytes.Buffer
 	if err := b.formatter.FormatRequest(ctx, &buf, b.formatConfig, in); err != nil {
 		return err
@@ -154,7 +154,7 @@ func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
 	return err
 }
 
-func (b *Backend) LogResponse(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 	var buf bytes.Buffer
 	if err := b.formatter.FormatResponse(ctx, &buf, b.formatConfig, in); err != nil {
 		return err

--- a/builtin/audit/syslog/backend.go
+++ b/builtin/audit/syslog/backend.go
@@ -118,7 +118,7 @@ func (b *Backend) GetHash(ctx context.Context, data string) (string, error) {
 	return audit.HashString(salt, data), nil
 }
 
-func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogRequest(ctx context.Context, in *logical.LogInput) error {
 	var buf bytes.Buffer
 	if err := b.formatter.FormatRequest(ctx, &buf, b.formatConfig, in); err != nil {
 		return err
@@ -129,7 +129,7 @@ func (b *Backend) LogRequest(ctx context.Context, in *audit.LogInput) error {
 	return err
 }
 
-func (b *Backend) LogResponse(ctx context.Context, in *audit.LogInput) error {
+func (b *Backend) LogResponse(ctx context.Context, in *logical.LogInput) error {
 	var buf bytes.Buffer
 	if err := b.formatter.FormatResponse(ctx, &buf, b.formatConfig, in); err != nil {
 		return err

--- a/sdk/logical/audit.go
+++ b/sdk/logical/audit.go
@@ -3,8 +3,8 @@ package logical
 type LogInput struct {
 	Type                string
 	Auth                *Auth
-	Request             interface{}
-	Response            interface{}
+	Request             *Request
+	Response            *Response
 	OuterErr            error
 	NonHMACReqDataKeys  []string
 	NonHMACRespDataKeys []string

--- a/sdk/logical/logical.go
+++ b/sdk/logical/logical.go
@@ -124,3 +124,8 @@ type Paths struct {
 	// unless it ends with '/' in which case it will be treated as a prefix.
 	SealWrapStorage []string
 }
+
+type Auditor interface {
+	AuditRequest(ctx context.Context, input *LogInput) error
+	AuditResponse(ctx context.Context, input *LogInput) error
+}

--- a/sdk/logical/system_view.go
+++ b/sdk/logical/system_view.go
@@ -70,6 +70,10 @@ type SystemView interface {
 	PluginEnv(context.Context) (*PluginEnvironment, error)
 }
 
+type ExtendedSystemView interface {
+	Auditor() Auditor
+}
+
 type StaticSystemView struct {
 	DefaultLeaseTTLVal  time.Duration
 	MaxLeaseTTLVal      time.Duration
@@ -84,6 +88,20 @@ type StaticSystemView struct {
 	Features            license.Features
 	VaultVersion        string
 	PluginEnvironment   *PluginEnvironment
+}
+
+type noopAuditor struct{}
+
+func (a noopAuditor) AuditRequest(ctx context.Context, input *LogInput) error {
+	return nil
+}
+
+func (a noopAuditor) AuditResponse(ctx context.Context, input *LogInput) error {
+	return nil
+}
+
+func (d StaticSystemView) Auditor() Auditor {
+	return noopAuditor{}
 }
 
 func (d StaticSystemView) DefaultLeaseTTL() time.Duration {

--- a/vault/audit.go
+++ b/vault/audit.go
@@ -505,3 +505,23 @@ func defaultAuditTable() *MountTable {
 	}
 	return table
 }
+
+type genericAuditor struct {
+	c         *Core
+	mountType string
+	namespace *namespace.Namespace
+}
+
+func (g genericAuditor) AuditRequest(ctx context.Context, input *logical.LogInput) error {
+	ctx = namespace.ContextWithNamespace(ctx, g.namespace)
+	logInput := *input
+	logInput.Type = g.mountType + "-request"
+	return g.c.auditBroker.LogRequest(ctx, &logInput, g.c.auditedHeaders)
+}
+
+func (g genericAuditor) AuditResponse(ctx context.Context, input *logical.LogInput) error {
+	ctx = namespace.ContextWithNamespace(ctx, g.namespace)
+	logInput := *input
+	logInput.Type = g.mountType + "-response"
+	return g.c.auditBroker.LogResponse(ctx, &logInput, g.c.auditedHeaders)
+}

--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/audit"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 type backendEntry struct {
@@ -86,7 +87,7 @@ func (a *AuditBroker) GetHash(ctx context.Context, name string, input string) (s
 
 // LogRequest is used to ensure all the audit backends have an opportunity to
 // log the given request and that *at least one* succeeds.
-func (a *AuditBroker) LogRequest(ctx context.Context, in *audit.LogInput, headersConfig *AuditedHeadersConfig) (ret error) {
+func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput, headersConfig *AuditedHeadersConfig) (ret error) {
 	defer metrics.MeasureSince([]string{"audit", "log_request"}, time.Now())
 	a.RLock()
 	defer a.RUnlock()
@@ -148,7 +149,7 @@ func (a *AuditBroker) LogRequest(ctx context.Context, in *audit.LogInput, header
 
 // LogResponse is used to ensure all the audit backends have an opportunity to
 // log the given response and that *at least one* succeeds.
-func (a *AuditBroker) LogResponse(ctx context.Context, in *audit.LogInput, headersConfig *AuditedHeadersConfig) (ret error) {
+func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput, headersConfig *AuditedHeadersConfig) (ret error) {
 	defer metrics.MeasureSince([]string{"audit", "log_response"}, time.Now())
 	a.RLock()
 	defer a.RUnlock()

--- a/vault/audit_test.go
+++ b/vault/audit_test.go
@@ -44,7 +44,7 @@ type NoopAudit struct {
 	saltMutex sync.RWMutex
 }
 
-func (n *NoopAudit) LogRequest(ctx context.Context, in *audit.LogInput) error {
+func (n *NoopAudit) LogRequest(ctx context.Context, in *logical.LogInput) error {
 	n.ReqAuth = append(n.ReqAuth, in.Auth)
 	n.Req = append(n.Req, in.Request)
 	n.ReqHeaders = append(n.ReqHeaders, in.Request.Headers)
@@ -53,7 +53,7 @@ func (n *NoopAudit) LogRequest(ctx context.Context, in *audit.LogInput) error {
 	return n.ReqErr
 }
 
-func (n *NoopAudit) LogResponse(ctx context.Context, in *audit.LogInput) error {
+func (n *NoopAudit) LogResponse(ctx context.Context, in *logical.LogInput) error {
 	n.RespAuth = append(n.RespAuth, in.Auth)
 	n.RespReq = append(n.RespReq, in.Request)
 	n.Resp = append(n.Resp, in.Response)
@@ -483,7 +483,7 @@ func TestAuditBroker_LogRequest(t *testing.T) {
 		Headers: make(map[string]*auditedHeaderSettings),
 	}
 
-	logInput := &audit.LogInput{
+	logInput := &logical.LogInput{
 		Auth:     authCopy,
 		Request:  reqCopy,
 		OuterErr: reqErrs,
@@ -507,7 +507,7 @@ func TestAuditBroker_LogRequest(t *testing.T) {
 
 	// Should still work with one failing backend
 	a1.ReqErr = fmt.Errorf("failed")
-	logInput = &audit.LogInput{
+	logInput = &logical.LogInput{
 		Auth:    auth,
 		Request: req,
 	}
@@ -579,7 +579,7 @@ func TestAuditBroker_LogResponse(t *testing.T) {
 		Headers: make(map[string]*auditedHeaderSettings),
 	}
 
-	logInput := &audit.LogInput{
+	logInput := &logical.LogInput{
 		Auth:     authCopy,
 		Request:  reqCopy,
 		Response: respCopy,
@@ -607,7 +607,7 @@ func TestAuditBroker_LogResponse(t *testing.T) {
 
 	// Should still work with one failing backend
 	a1.RespErr = fmt.Errorf("failed")
-	logInput = &audit.LogInput{
+	logInput = &logical.LogInput{
 		Auth:     auth,
 		Request:  req,
 		Response: resp,
@@ -668,7 +668,7 @@ func TestAuditBroker_AuditHeaders(t *testing.T) {
 	headersConf.add(context.Background(), "X-Test-Header", false)
 	headersConf.add(context.Background(), "X-Vault-Header", false)
 
-	logInput := &audit.LogInput{
+	logInput := &logical.LogInput{
 		Auth:     auth,
 		Request:  reqCopy,
 		OuterErr: respErr,
@@ -691,7 +691,7 @@ func TestAuditBroker_AuditHeaders(t *testing.T) {
 
 	// Should still work with one failing backend
 	a1.ReqErr = fmt.Errorf("failed")
-	logInput = &audit.LogInput{
+	logInput = &logical.LogInput{
 		Auth:     auth,
 		Request:  req,
 		OuterErr: respErr,

--- a/vault/core.go
+++ b/vault/core.go
@@ -1233,7 +1233,7 @@ func (c *Core) sealInitCommon(ctx context.Context, req *logical.Request) (retErr
 		auth.TokenType = te.Type
 	}
 
-	logInput := &audit.LogInput{
+	logInput := &logical.LogInput{
 		Auth:    auth,
 		Request: req,
 	}

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -21,6 +21,18 @@ type dynamicSystemView struct {
 	mountEntry *MountEntry
 }
 
+type extendedSystemView struct {
+	dynamicSystemView
+}
+
+func (e extendedSystemView) Auditor() logical.Auditor {
+	return genericAuditor{
+		mountType: e.mountEntry.Type,
+		namespace: e.mountEntry.Namespace(),
+		c:         e.core,
+	}
+}
+
 func (d dynamicSystemView) DefaultLeaseTTL() time.Duration {
 	def, _ := d.fetchTTLs()
 	return def

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/errwrap"
 	multierror "github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -249,7 +248,7 @@ func (c *Core) StepDown(httpCtx context.Context, req *logical.Request) (retErr e
 		auth.TokenType = te.Type
 	}
 
-	logInput := &audit.LogInput{
+	logInput := &logical.LogInput{
 		Auth:    auth,
 		Request: req,
 	}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1198,9 +1198,11 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 // mount-specific entries; because this should be called when setting
 // up a mountEntry, it doesn't check to ensure that me is not nil
 func (c *Core) mountEntrySysView(entry *MountEntry) logical.SystemView {
-	return dynamicSystemView{
-		core:       c,
-		mountEntry: entry,
+	return extendedSystemView{
+		dynamicSystemView{
+			core:       c,
+			mountEntry: entry,
+		},
 	}
 }
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/errwrap"
 	multierror "github.com/hashicorp/go-multierror"
 	sockaddr "github.com/hashicorp/go-sockaddr"
-	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/helper/identity"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -537,7 +536,7 @@ func (c *Core) handleCancelableRequest(ctx context.Context, ns *namespace.Namesp
 
 	// Create an audit trail of the response
 	if !isControlGroupRun(req) {
-		logInput := &audit.LogInput{
+		logInput := &logical.LogInput{
 			Auth:                auth,
 			Request:             req,
 			Response:            auditResp,
@@ -668,7 +667,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 		}
 
 		if !isControlGroupRun(req) {
-			logInput := &audit.LogInput{
+			logInput := &logical.LogInput{
 				Auth:               auth,
 				Request:            req,
 				OuterErr:           ctErr,
@@ -690,7 +689,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 
 	// Create an audit trail of the request
 	if !isControlGroupRun(req) {
-		logInput := &audit.LogInput{
+		logInput := &logical.LogInput{
 			Auth:               auth,
 			Request:            req,
 			NonHMACReqDataKeys: nonHMACReqDataKeys,
@@ -941,7 +940,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 			errType = logical.ErrInvalidRequest
 		}
 
-		logInput := &audit.LogInput{
+		logInput := &logical.LogInput{
 			Auth:               auth,
 			Request:            req,
 			OuterErr:           ctErr,
@@ -963,7 +962,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 
 	// Create an audit trail of the request. Attach auth if it was returned,
 	// e.g. if a token was provided.
-	logInput := &audit.LogInput{
+	logInput := &logical.LogInput{
 		Auth:               auth,
 		Request:            req,
 		NonHMACReqDataKeys: nonHMACReqDataKeys,

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -600,11 +600,11 @@ func (n *noopAudit) GetHash(ctx context.Context, data string) (string, error) {
 	return salt.GetIdentifiedHMAC(data), nil
 }
 
-func (n *noopAudit) LogRequest(_ context.Context, _ *audit.LogInput) error {
+func (n *noopAudit) LogRequest(_ context.Context, _ *logical.LogInput) error {
 	return nil
 }
 
-func (n *noopAudit) LogResponse(_ context.Context, _ *audit.LogInput) error {
+func (n *noopAudit) LogResponse(_ context.Context, _ *logical.LogInput) error {
 	return nil
 }
 


### PR DESCRIPTION
Move audit.LogInput to sdk/logical.  Allow the Data values in audited
logical.Request and Response to implement OptMarshaler, in which case
we delegate hashing/serializing responsibility to them.  Add new
ClientCertificateSerialNumber audit request field.

SystemView can now be cast to ExtendedSystemView to expose the Auditor
interface, which allows submitting requests and responses to the audit
broker.