### PR TITLE
Docs: Minor updates to PKI Secrets Engine

### DIFF
--- a/website/source/docs/secrets/pki/index.html.md
+++ b/website/source/docs/secrets/pki/index.html.md
@@ -443,7 +443,7 @@ Successfully mounted 'pki' at 'pki_int'!
 #### Configure an Intermediate CA
 
 ```text
-$ vault secrets tune -max-lease-ttl=43800h pki_int
+$ vault secrets tune -max-lease-ttl=4380h pki_int
 Successfully tuned mount 'pki_int'!
 ```
 
@@ -453,7 +453,7 @@ value should be less than or equal to the root certificate authority.
 Now, we generate our intermediate certificate signing request:
 
 ```text
-$ vault write pki_int/intermediate/generate/internal common_name="myvault.com Intermediate Authority" ttl=43800h
+$ vault write pki_int/intermediate/generate/internal common_name="myvault.com Intermediate Authority" ttl=4380h
 Key Value
 csr -----BEGIN CERTIFICATE REQUEST-----
 MIICsjCCAZoCAQAwLTErMCkGA1UEAxMibXl2YXVsdC5jb20gSW50ZXJtZWRpYXRl
@@ -479,7 +479,7 @@ another certificate authority, in this case the root certificate authority
 generated in the first example.
 
 ```text
-$ vault write pki/root/sign-intermediate csr=@pki_int.csr format=pem_bundle ttl=43800h
+$ vault write pki/root/sign-intermediate csr=@pki_int.csr format=pem_bundle ttl=4380h
 Key             Value
 certificate     -----BEGIN CERTIFICATE-----
 MIIDZTCCAk2gAwIBAgIUENxQD7KIJi1zE/jEiYqAG1VC4NwwDQYJKoZIhvcNAQEL

--- a/website/source/docs/secrets/pki/index.html.md
+++ b/website/source/docs/secrets/pki/index.html.md
@@ -90,11 +90,11 @@ certificate. When users or machines generate credentials, they are generated
 against this role:
 
     ```text
-    $ vault write pki/roles/my-role \
+    $ vault write pki/roles/example-dot-com \
         allowed_domains=my-website.com \
         allow_subdomains=true \
         max_ttl=72h
-    Success! Data written to: pki/roles/my-role
+    Success! Data written to: pki/roles/example-dot-com
     ```
 
 ## Usage
@@ -106,7 +106,7 @@ the proper permission, it can generate credentials.
 of the role:
 
     ```text
-    $ vault write pki/issue/my-role \
+    $ vault write pki/issue/example-dot-com \
         common_name=www.my-website.com
 
     Key                 Value


### PR DESCRIPTION
- Change _my-role_ role name to _example-dot-com_ in **Setup** to help reduce confusion and match what is used in **Quick Start**
- Update `ttl` and `max-lease-ttl` values from _43800_ which appears to be a typo, to _4380_; this helps avoid warnings like: "The expiration time for the signed certificate is after the CA's expiration time. If the new certificate is not treated as a root, validation paths with the certificate past the issuing CA's expiration time will fail." when following the Quick Start and using the tuned Root CA TTL of 8760h