### PR TITLE
Bump required go to 1.12 and enable modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ EXTERNAL_TOOLS=\
 	github.com/client9/misspell/cmd/misspell
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
-GO_VERSION_MIN=1.11
+GO_VERSION_MIN=1.12
+GO111MODULE=on
 CGO_ENABLED?=0
 ifneq ($(FDB_ENABLED), )
 	CGO_ENABLED=1


### PR DESCRIPTION
This updates the Makefile to more closely match Travis which uses go
1.12 and enables go module support. Leaving the goversioncheck in here
for now in case anybody is still using a version of go that doesn't
understand the GO111MODULE flag (such as go 1.10) and thus won't
interpret the go version specified in go.mod