### PR TITLE
Makefile: link git hooks instead of copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,16 @@ vet:
 			echo "and fix them if necessary before submitting the code for reviewal."; \
 		fi
 
-# githooks installs git hooks by linking .hooks/* to .git/hooks/
+ifeq ($(OS),Windows_NT)
+INSTALL_GIT_HOOKS := cp .hooks/* .git/hooks/
+else
+INSTALL_GIT_HOOKS := for H in .hooks/*; do ln -sf ../../$$H .git/hooks/; done
+endif
+
 githooks:
-	@if [ -d .git/hooks ]; then for H in .hooks/*; do ln -sf ../../$$H .git/hooks/; done; fi
+	@if [ -d .git/hooks ]; then $(INSTALL_GIT_HOOKS); fi
+
+
 
 # prep runs `go generate` to build the dynamically generated
 # source files.

--- a/Makefile
+++ b/Makefile
@@ -97,12 +97,15 @@ vet:
 			echo "and fix them if necessary before submitting the code for reviewal."; \
 		fi
 
+# githooks installs git hooks by linking .hooks/* to .git/hooks/
+githooks:
+	@if [ -d .git/hooks ]; then for H in .hooks/*; do ln -sf ../../$$H .git/hooks/; done; fi
+
 # prep runs `go generate` to build the dynamically generated
 # source files.
-prep: fmtcheck
+prep: fmtcheck githooks
 	@sh -c "'$(CURDIR)/scripts/goversioncheck.sh' '$(GO_VERSION_MIN)'"
 	@go generate $(go list ./... | grep -v /vendor/)
-	@if [ -d .git/hooks ]; then cp .hooks/* .git/hooks/; fi
 
 # bootstrap the build by downloading additional tools
 bootstrap:
@@ -217,6 +220,6 @@ hana-database-plugin:
 mongodb-database-plugin:
 	@CGO_ENABLED=0 go build -o bin/mongodb-database-plugin ./plugins/database/mongodb/mongodb-database-plugin
 
-.PHONY: bin default prep test vet bootstrap fmt fmtcheck mysql-database-plugin mysql-legacy-database-plugin cassandra-database-plugin influxdb-database-plugin postgresql-database-plugin mssql-database-plugin hana-database-plugin mongodb-database-plugin static-assets ember-dist ember-dist-dev static-dist static-dist-dev assetcheck check-vault-in-path check-browserstack-creds test-ui-browserstack
+.PHONY: bin default prep test vet bootstrap fmt fmtcheck mysql-database-plugin mysql-legacy-database-plugin cassandra-database-plugin influxdb-database-plugin postgresql-database-plugin mssql-database-plugin hana-database-plugin mongodb-database-plugin static-assets ember-dist ember-dist-dev static-dist static-dist-dev assetcheck check-vault-in-path check-browserstack-creds test-ui-browserstack githooks
 
 .NOTPARALLEL: ember-dist ember-dist-dev static-assets

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,6 @@ endif
 githooks:
 	@if [ -d .git/hooks ]; then $(INSTALL_GIT_HOOKS); fi
 
-
-
 # prep runs `go generate` to build the dynamically generated
 # source files.
 prep: fmtcheck githooks


### PR DESCRIPTION
This means the hooks are updated on pull rather than only after running
make, hopefully this will increase the likelihood the hooks are right
for a given commit.

Using links also makes developing the hooks easier as you can just edit
the scripts in place rather than having to copy each time.

A separate githooks make target is included for enhanced documentation
as well as the ability to run just that target when wanted.

See also:
https://github.com/hashicorp/vault/commit/ed1cbb0a789a2de3f87775444f5ee472278fcad6#r33667509