### PR TITLE
fix error when running formatOptions on items that don't come from th…

### DIFF
--- a/ui/app/components/search-select.js
+++ b/ui/app/components/search-select.js
@@ -60,7 +60,11 @@ export default Component.extend({
     let formattedOptions = this.selectedOptions.map(option => {
       let matchingOption = options.findBy('id', option);
       options.removeObject(matchingOption);
-      return { id: option, name: matchingOption.name, searchText: matchingOption.searchText };
+      return {
+        id: option,
+        name: matchingOption ? matchingOption.name : option,
+        searchText: matchingOption ? matchingOption.searchText : option,
+      };
     });
     this.set('selectedOptions', formattedOptions);
     if (this.options) {

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -173,6 +173,16 @@ module('Integration | Component | search select', function(hooks) {
     assert.equal(component.options.objectAt(0).text, 'Type to search', 'text of option shows Type to search');
   });
 
+  test('it shows items not in the returned response', async function(assert) {
+    const models = ['test'];
+    this.set('models', models);
+    this.set('inputValue', ['test', 'two']);
+    await render(
+      hbs`{{search-select label="foo" inputValue=inputValue models=models fallbackComponent="string-list" onChange=onChange}}`
+    );
+    assert.equal(component.selectedOptions.length, 2, 'renders inputOptions as selectedOptions');
+  });
+
   test('it shows both name and smaller id for identity endpoints', async function(assert) {
     const models = ['identity/entity'];
     this.set('models', models);


### PR DESCRIPTION
…e API response

Previously if a user added an item that was not in the api response it would be added and saved to the page correctly, but upon going back to that edit screen the search-select component would not correctly format the new item because it was not in the resulting API request. 

This fixes that error and uses the options name in lieu of any matched items from the response.