### PR TITLE
UI transit date fix

### DIFF
--- a/ui/app/serializers/transit-key.js
+++ b/ui/app/serializers/transit-key.js
@@ -16,6 +16,12 @@ export default DS.RESTSerializer.extend({
     }
     assign(payload, payload.data);
     delete payload.data;
+    // timestamps for these two are in seconds...
+    if (payload.type === 'aes256-gcm96' || payload.type === 'chacha20-poly1305') {
+      for (let version in payload.keys) {
+        payload.keys[version] = payload.keys[version] * 1000;
+      }
+    }
     return [payload];
   },
 
@@ -26,14 +32,7 @@ export default DS.RESTSerializer.extend({
     let transformedPayload = { [modelName]: secrets };
     // just return the single object because ember is picky
     if (requestType === 'queryRecord') {
-      let model = secrets[0];
-      // timestamps for these two are in seconds...
-      if (model.type === 'aes256-gcm96' || model.type === 'chacha20-poly1305') {
-        for (let version in model.keys) {
-          model.keys[version] = model.keys[version] * 1000;
-        }
-      }
-      transformedPayload = { [modelName]: model };
+      transformedPayload = { [modelName]: secrets[0] };
     }
 
     return this._super(store, primaryModelClass, transformedPayload, id, requestType);

--- a/ui/app/serializers/transit-key.js
+++ b/ui/app/serializers/transit-key.js
@@ -26,7 +26,14 @@ export default DS.RESTSerializer.extend({
     let transformedPayload = { [modelName]: secrets };
     // just return the single object because ember is picky
     if (requestType === 'queryRecord') {
-      transformedPayload = { [modelName]: secrets[0] };
+      let model = secrets[0];
+      // timestamps for these two are in seconds...
+      if (model.type === 'aes256-gcm96' || model.type === 'chacha20-poly1305') {
+        for (let version in model.keys) {
+          model.keys[version] = model.keys[version] * 1000;
+        }
+      }
+      transformedPayload = { [modelName]: model };
     }
 
     return this._super(store, primaryModelClass, transformedPayload, id, requestType);

--- a/ui/tests/unit/serializers/transit-key-test.js
+++ b/ui/tests/unit/serializers/transit-key-test.js
@@ -1,0 +1,78 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+const CHACHA = {
+  request_id: 'a5695685-584c-6b25-fada-35304d3d583d',
+  lease_id: '',
+  renewable: false,
+  lease_duration: 0,
+  data: {
+    allow_plaintext_backup: false,
+    deletion_allowed: false,
+    derived: false,
+    exportable: false,
+    keys: {
+      '1': 1559598610,
+    },
+    latest_version: 1,
+    min_available_version: 0,
+    min_decryption_version: 1,
+    min_encryption_version: 0,
+    name: 'anewone',
+    supports_decryption: true,
+    supports_derivation: true,
+    supports_encryption: true,
+    supports_signing: false,
+    type: 'chacha20-poly1305',
+  },
+  wrap_info: null,
+  warnings: null,
+  auth: null,
+};
+
+const AES = {
+  request_id: '90c327a8-9a68-6fab-13a1-f51b68cb24d7',
+  lease_id: '',
+  renewable: false,
+  lease_duration: 0,
+  data: {
+    allow_plaintext_backup: false,
+    deletion_allowed: false,
+    derived: false,
+    exportable: false,
+    keys: {
+      '1': 1559577523,
+    },
+    latest_version: 1,
+    min_available_version: 0,
+    min_decryption_version: 1,
+    min_encryption_version: 0,
+    name: 'new',
+    supports_decryption: true,
+    supports_derivation: true,
+    supports_encryption: true,
+    supports_signing: false,
+    type: 'aes256-gcm96',
+  },
+  wrap_info: null,
+  warnings: null,
+  auth: null,
+};
+
+module('Unit | Serializer | transit-key', function(hooks) {
+  setupTest(hooks);
+  test('it expands the timestamp for aes and chacha-poly keys', function(assert) {
+    let serializer = this.owner.lookup('serializer:transit-key');
+    let aesExpected = AES.data.keys[1] * 1000;
+    let chachaExpected = CHACHA.data.keys[1] * 1000;
+    let aesData = serializer.normalizeSecrets(AES);
+    assert.equal(aesData.firstObject.keys[1], aesExpected, 'converts seconds to millis for aes keys');
+
+    let chachaData = serializer.normalizeSecrets(CHACHA);
+    assert.equal(
+      chachaData.firstObject.keys[1],
+      chachaExpected,
+      'converts seconds to millis for chacha keys'
+    );
+  });
+});


### PR DESCRIPTION
Dates for transit keys that are timestamps come from the api as seconds - this is true for aes256-gcm96 and chacha20-poly1305 type keys. Our date helpers expect input as either a date time string or milliseconds - so we now transform the appropriate responses in the serializer to convert seconds to milliseconds.