### PR TITLE
plugin docs: update example code snippet with correct imports

### DIFF
--- a/website/source/docs/internals/plugins.html.md
+++ b/website/source/docs/internals/plugins.html.md
@@ -128,20 +128,33 @@ package main
 import (
 	"os"
 
-	"github.com/hashicorp/vault/sdk/helper/pluginutil"
-	"github.com/hashicorp/vault/api/plugins"
+	myPlugin "your/plugin/import/path"
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/sdk/plugin"
 )
 
 func main() {
-	apiClientMeta := &api.APIClientMeta{}
+	apiClientMeta := &api.PluginAPIClientMeta{}
 	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args)
+	flags.Parse(os.Args[1:])
 
-	plugins.Serve(New().(MyPlugin), apiClientMeta.GetTLSConfig())
+	tlsConfig := apiClientMeta.GetTLSConfig()
+	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
+
+	err := plugin.Serve(&plugin.ServeOpts{
+		BackendFactoryFunc: myPlugin.Factory,
+		TLSProviderFunc:    tlsProviderFunc,
+	})
+	if err != nil {
+		logger := hclog.New(&hclog.LoggerOptions{})
+
+		logger.Error("plugin shutting down", "error", err)
+		os.Exit(1)
+	}
 }
 ```
 
-And that's basically it! You would just need to change MyPlugin to your actual
-plugin.
+And that's basically it! You would just need to change `myPlugin` to your actual
+plugin. For more information on how to register and enable your plugin, check out the [Building Plugin Backends](https://learn.hashicorp.com/vault/developer/plugin-backends) tutorial.
 
 [api_addr]: /docs/configuration/index.html#api_addr


### PR DESCRIPTION
- Updates the import paths to be correct (previous import paths did not exist)
- Update `plugin.Serve()` to be more aligned with design of existing plugins
- Add link to Vault [Developing Plugin Backends](https://learn.hashicorp.com/vault/developer/plugin-backends) tutorial for further steps

Partially Fixes #6822 

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>