### PR TITLE
Adding vault kv command doc

### DIFF
--- a/website/source/docs/commands/kv/delete.html.md
+++ b/website/source/docs/commands/kv/delete.html.md
@@ -4,7 +4,7 @@ page_title: "kv delete - Command"
 sidebar_title: "<code>delete</code>"
 sidebar_current: "docs-commands-kv-delete"
 description: |-
-  The "kv delete" command disables an secrets engine at a given PATH. The
+  The "kv delete" command disables a secrets engine at a given PATH. The
   argument corresponds to the enabled PATH of the engine, not the TYPE! All
   secrets created by this engine are revoked and its Vault data is removed.
 ---

--- a/website/source/docs/commands/kv/delete.html.md
+++ b/website/source/docs/commands/kv/delete.html.md
@@ -1,0 +1,47 @@
+---
+layout: "docs"
+page_title: "kv delete - Command"
+sidebar_title: "<code>delete</code>"
+sidebar_current: "docs-commands-kv-delete"
+description: |-
+  The "kv delete" command disables an secrets engine at a given PATH. The
+  argument corresponds to the enabled PATH of the engine, not the TYPE! All
+  secrets created by this engine are revoked and its Vault data is removed.
+---
+
+# kv delete
+
+The `kv delete` command deletes the data for the provided path in
+the key/value secrets engine. If using K/V Version 2, its versioned data will
+not be fully removed, but marked as deleted and will no longer be returned in
+normal get requests.
+
+## Examples
+
+Delete the latest version of the key "creds":
+
+```text
+$ vault kv delete secret/creds
+Success! Data deleted (if it existed) at: secret/creds
+```
+
+**[K/V Version 2]** Delete version 3 of key "creds":
+
+```text
+$ vault kv delete -versions=3 secret/creds
+Success! Data deleted (if it existed) at: secret/creds
+```
+
+## Usage
+
+There are no flags beyond the [standard set of flags](/docs/commands/index.html)
+included on all commands.
+
+
+### Command Options
+
+- `-versions` `([]int: <required>)` - The versions to be deleted. The versioned
+data will not be deleted, but it will no longer be returned in normal get
+requests.
+
+~> **NOTE:** This command option is only for K/V v2.

--- a/website/source/docs/commands/kv/delete.html.md
+++ b/website/source/docs/commands/kv/delete.html.md
@@ -25,7 +25,7 @@ $ vault kv delete secret/creds
 Success! Data deleted (if it existed) at: secret/creds
 ```
 
-**[K/V Version 2]** Delete version 3 of key "creds":
+**[K/V Version 2]** Delete version 11 of key "creds":
 
 ```text
 $ vault kv delete -versions=3 secret/creds

--- a/website/source/docs/commands/kv/delete.html.md
+++ b/website/source/docs/commands/kv/delete.html.md
@@ -28,7 +28,7 @@ Success! Data deleted (if it existed) at: secret/creds
 **[K/V Version 2]** Delete version 11 of key "creds":
 
 ```text
-$ vault kv delete -versions=3 secret/creds
+$ vault kv delete -versions=11 secret/creds
 Success! Data deleted (if it existed) at: secret/creds
 ```
 

--- a/website/source/docs/commands/kv/destroy.html.md
+++ b/website/source/docs/commands/kv/destroy.html.md
@@ -1,0 +1,44 @@
+---
+layout: "docs"
+page_title: "kv destroy - Command"
+sidebar_title: "<code>destroy</code>"
+sidebar_current: "docs-commands-kv-destroy"
+description: |-
+  The "kv destroy" command permanently removes the specified version data for
+  the provided key and version numbers from the key-value store.
+---
+
+# kv destroy
+
+~> **NOTE:** This is a [K/V Version 2](/docs/secrets/kv/kv-v2.html) secrets
+engine command, and not available for Version 1.
+
+The `secrets enable` command permanently removes the specified versions' data
+from the key/value secrets engine. If no key exists at the path, no action is
+taken.
+
+
+## Examples
+
+Destroy version 3 of the key "creds":
+
+```text
+$ vault kv destroy -versions=3 secret/creds
+Success! Data written to: secret/destroy/creds
+```
+
+## Usage
+
+There are no flags beyond the [standard set of flags](/docs/commands/index.html)
+included on all commands.
+
+### Output Options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+### Command Options
+
+- `-versions` `([]int: <required>)` - The versions to destroy. Their data will
+be permanently deleted.

--- a/website/source/docs/commands/kv/destroy.html.md
+++ b/website/source/docs/commands/kv/destroy.html.md
@@ -23,7 +23,7 @@ taken.
 Destroy version 11 of the key "creds":
 
 ```text
-$ vault kv destroy -versions=3 secret/creds
+$ vault kv destroy -versions=11 secret/creds
 Success! Data written to: secret/destroy/creds
 ```
 

--- a/website/source/docs/commands/kv/destroy.html.md
+++ b/website/source/docs/commands/kv/destroy.html.md
@@ -20,7 +20,7 @@ taken.
 
 ## Examples
 
-Destroy version 3 of the key "creds":
+Destroy version 11 of the key "creds":
 
 ```text
 $ vault kv destroy -versions=3 secret/creds

--- a/website/source/docs/commands/kv/enable-versioning.html.md
+++ b/website/source/docs/commands/kv/enable-versioning.html.md
@@ -1,0 +1,35 @@
+---
+layout: "docs"
+page_title: "kv enable-versioning - Command"
+sidebar_title: "<code>enable-versioning</code>"
+sidebar_current: "docs-commands-kv-enable-versioning"
+description: |-
+  The "kv enable-versioning" command turns on versioning for the backend
+  at the provided path.
+---
+
+# kv enable-versioning
+
+The `kv enable-versioning` command turns on versioning for an existing
+non-versioned key/value secrets engine (K/V Version 1) at its path.
+
+## Examples
+
+This command turns on versioning for the K/V Version 1 secrets engine enabled at
+"secret".
+
+```text
+$ vault kv enable-versioning secret
+Success! Tuned the secrets engine at: secret/
+```
+
+## Usage
+
+There are no flags beyond the [standard set of flags](/docs/commands/index.html)
+included on all commands.
+
+### Output Options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.

--- a/website/source/docs/commands/kv/get.html.md
+++ b/website/source/docs/commands/kv/get.html.md
@@ -1,0 +1,68 @@
+---
+layout: "docs"
+page_title: "kv get - Command"
+sidebar_title: "<code>get</code>"
+sidebar_current: "docs-commands-kv-get"
+description: |-
+  The "kv get" command retrieves the value from Vault's key-value store at the
+  given key name. If no key exists with that name, an error is returned. If a
+  key exists with that name but has no data, nothing is returned.
+---
+
+# kv get
+
+The `kv get` command retrieves the value from K/V secrets engine at the given
+key name. If no key exists with that name, an error is returned. If a key exists
+with the name but has no data, nothing is returned.
+
+## Examples
+
+Retrieve the data of the key "creds":
+
+```text
+$ vault kv get secret/creds
+====== Metadata ======
+Key              Value
+---              -----
+created_time     2019-06-06T06:03:26.595978Z
+deletion_time    n/a
+destroyed        false
+version          5
+
+====== Data ======
+Key         Value
+---         -----
+passcode    my-long-passcode
+```
+
+If K/V Version 1 secrets engine is enabled at "secret", the output has no
+metadata since there is no versioning information associated with the data:
+
+```text
+$ vault kv get secret/creds
+====== Data ======
+Key         Value
+---         -----
+passcode    my-long-passcode
+```
+
+## Usage
+
+There are no flags beyond the [standard set of flags](/docs/commands/index.html)
+included on all commands.
+
+### Output Options
+
+- `-field` `(string: "")` - Print only the field with the given name. Specifying
+  this option will take precedence over other formatting directives. The result
+  will not have a trailing newline making it ideal for piping to other
+  processes.
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+### Command Options
+
+- `-version` `(int: 0)` - Specifies the version to return. If not set the
+ latest version is returned.

--- a/website/source/docs/commands/kv/index.html.md
+++ b/website/source/docs/commands/kv/index.html.md
@@ -1,0 +1,114 @@
+---
+layout: "docs"
+page_title: "kv - Command"
+sidebar_title: "<code>kv</code>"
+sidebar_current: "docs-commands-kv"
+description: |-
+  The "kv" command groups subcommands for interacting with Vault's key/value
+  secret engine.
+---
+
+# kv
+
+The `kv` command groups subcommands for interacting with Vault's key/value
+secrets engine (both [K/V Version 1](/docs/secrets/kv/kv-v1.html) and [K/V
+Version 2](/docs/secrets/kv/kv-v2.html).
+
+
+## Examples
+
+Create or update the key named "creds" in the K/V Version 2 enabled at "secret"
+with the value "passcode=my-long-passcode":
+
+```text
+$ vault kv put secret/creds passcode=my-long-passcode
+Key              Value
+---              -----
+created_time     2019-06-06T04:07:33.279432Z
+deletion_time    n/a
+destroyed        false
+version          1
+```
+
+Read this value back:
+
+```text
+$ vault kv get secret/creds
+====== Metadata ======
+Key              Value
+---              -----
+created_time     2019-06-06T04:07:33.279432Z
+deletion_time    n/a
+destroyed        false
+version          1
+
+====== Data ======
+Key         Value
+---         -----
+passcode    my-long-passcode
+```
+
+Get metadata for the key named "creds":
+
+```text
+$ vault kv metadata get secret/creds
+======= Metadata =======
+Key                Value
+---                -----
+cas_required       false
+created_time       2019-06-06T04:07:33.279432Z
+current_version    1
+max_versions       0
+oldest_version     0
+updated_time       2019-06-06T04:07:33.279432Z
+
+====== Version 1 ======
+Key              Value
+---              -----
+created_time     2019-06-06T04:07:33.279432Z
+deletion_time    n/a
+destroyed        false
+```
+
+
+Get a specific version of the key named "creds":
+
+```text
+$ vault kv get -version=1 secret/creds
+====== Metadata ======
+Key              Value
+---              -----
+created_time     2019-06-06T04:07:33.279432Z
+deletion_time    n/a
+destroyed        false
+version          1
+
+====== Data ======
+Key         Value
+---         -----
+passcode    my-long-passcode
+```
+
+
+## Usage
+
+```text
+Usage: vault kv <subcommand> [options] [args]
+
+  # ...
+
+Subcommands:
+    delete               Deletes versions in the KV store
+    destroy              Permanently removes one or more versions in the KV store
+    enable-versioning    Turns on versioning for a KV store
+    get                  Retrieves data from the KV store
+    list                 List data or secrets
+    metadata             Interact with Vault's Key-Value storage
+    patch                Sets or updates data in the KV store without overwriting
+    put                  Sets or updates data in the KV store
+    rollback             Rolls back to a previous version of data
+    undelete             Undeletes versions in the KV store
+```
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar.

--- a/website/source/docs/commands/kv/list.html.md
+++ b/website/source/docs/commands/kv/list.html.md
@@ -1,0 +1,45 @@
+---
+layout: "docs"
+page_title: "kv list - Command"
+sidebar_title: "<code>list</code>"
+sidebar_current: "docs-commands-kv-list"
+description: |-
+  The "kv list" command lists data from Vault's K/V secrets engine at the given
+  path.
+---
+
+# kv list
+
+The `kv list` command returns a list of key names at the specified location.
+Folders are suffixed with /. The input must be a folder; list on a file will not
+return a value. Note that no policy-based filtering is performed on keys; do not
+encode sensitive information in key names. The values themselves are not
+accessible via this command.
+
+Use this command to list all existing key names at a specific path.
+
+## Examples
+
+List values under the key "my-app":
+
+```text
+$ vault kv list secret/my-app/
+Keys
+----
+admin_creds
+domain
+eng_creds
+qa_creds
+release
+```
+
+## Usage
+
+There are no flags beyond the [standard set of flags](/docs/commands/index.html)
+included on all commands.
+
+### Output Options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.

--- a/website/source/docs/commands/kv/metadata.html.md
+++ b/website/source/docs/commands/kv/metadata.html.md
@@ -1,0 +1,140 @@
+---
+layout: "docs"
+page_title: "kv metadata - Command"
+sidebar_title: "<code>metadata</code>"
+sidebar_current: "docs-commands-kv-metadata"
+description: |-
+  The "kv metadata" command has subcommands for interacting with the metadata
+  endpoint in Vault's key-value store.
+---
+
+# kv metadata
+
+~> **NOTE:** This is a [K/V Version 2](/docs/secrets/kv/kv-v2.html) secrets
+engine command, and not available for Version 1.
+
+
+The `kv metadata` command has subcommands for interacting with the metadata and
+versions for the versioned secrets (K/V Version 2 secrets engine) at the
+specified path.  
+
+
+## Usage
+
+```text
+Usage: vault kv metadata <subcommand> [options] [args]
+
+  # ...
+
+Subcommands:
+    delete    Deletes all versions and metadata for a key in the KV store
+    get       Retrieves key metadata from the KV store
+    put       Sets or updates key settings in the KV store
+```
+
+### kv metadata delete
+
+The `kv metadata delete` command deletes all versions and metadata for the
+provided key.
+
+#### Examples
+
+Deletes all versions and metadata of the key "creds":
+
+```text
+$ vault kv metadata delete secret/creds
+Success! Data deleted (if it existed) at: secret/metadata/creds
+```
+
+
+### kv metadata get
+
+The `kv metadata get` command retrieves the metadata of the versioned secrets at
+the given key name. If no key exists with that name, an error is returned.
+
+#### Examples
+
+Retrieves the metadata of the key name, "creds":
+
+```text
+$ vault kv metadata get secret/creds
+======= Metadata =======
+Key                Value
+---                -----
+cas_required       false
+created_time       2019-06-06T04:07:33.279432Z
+current_version    5
+max_versions       0
+oldest_version     0
+updated_time       2019-06-06T06:03:26.595978Z
+
+====== Version 1 ======
+Key              Value
+---              -----
+created_time     2019-06-06T04:07:33.279432Z
+deletion_time    n/a
+destroyed        false
+
+====== Version 2 ======
+Key              Value
+---              -----
+created_time     2019-06-06T06:03:12.187441Z
+deletion_time    n/a
+destroyed        false
+
+...
+```
+
+
+### kv metadata put
+
+The `kv metadata put` command can be used to create a blank key in the K/V v2
+secrets engine or to update key configuration for a specified key.
+
+
+#### Examples
+
+Create a key in the K/V v2 with no data at the key "creds":
+
+```text
+$ vault kv metadata put secret/creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```text
+$ vault kv metadata put -max-versions=5 secret/creds
+Success! Data written to: secret/metadata/creds
+```
+
+**NOTE:** If not set, the backend’s configured max version is used. Once a key
+has more than the configured allowed versions the oldest version will be
+permanently deleted.
+
+
+Require Check-and-Set for the key "creds":
+
+```text
+$ vault kv metadata put -cas-required secret/creds
+```
+
+**NOTE:** When check-and-set is required, the key will require the `cas`
+parameter to be set on all write requests. Otherwise, the backend’s
+configuration will be used.
+
+#### Output Options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand Options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+ parameter to be set on all write requests. If false, the backend’s
+ configuration will be used. The default is false.
+
+- `-max-versions` `(int: 0)` - The number of versions to keep per key. If not
+ set, the backend’s configured max version is used. Once a key has more than the
+ configured allowed versions the oldest version will be permanently deleted.

--- a/website/source/docs/commands/kv/patch.html.md
+++ b/website/source/docs/commands/kv/patch.html.md
@@ -1,0 +1,72 @@
+---
+layout: "docs"
+page_title: "kv patch - Command"
+sidebar_title: "<code>patch</code>"
+sidebar_current: "docs-commands-kv-patch"
+description: |-
+  The "kv patch" command writes the data to the given path in the key-value
+  store. The data can be of any type.
+---
+
+# kv patch
+
+~> **NOTE:** This is a [K/V Version 2](/docs/secrets/kv/kv-v2.html) secrets
+engine command, and not available for Version 1.
+
+
+The `kv patch` command writes the data to the given path in the K/V v2 secrets
+engine. The data can be of any type. Unlike the `kv put` command, the `patch`
+command combines the change with existing data instead of replacing them.
+Therefore, this command makes it easy to make a partial updates to an existing
+data.
+
+## Examples
+
+If you wish to add an additional key-value (`ttl=48h`) to the existing data at
+the key "creds":
+
+```text
+$ vault kv patch secret/creds ttl=48h
+Key              Value
+---              -----
+created_time     2019-06-06T16:46:22.090654Z
+deletion_time    n/a
+destroyed        false
+version          6
+```
+
+**NOTE:** The `kv put` command requires both the existing data and
+the data you wish to add in order to accomplish the same result.
+
+```text
+$ vault kv put secret/creds ttl=48h passcode=my-long-passcode
+```
+
+The data can also be consumed from a file on disk by prefixing with the "@"
+symbol. For example:
+
+```text
+$ vault kv patch secret/creds @data.json
+```
+
+Or it can be read from stdin using the "-" symbol:
+
+```text
+$ echo "abcd1234" | vault kv patch secret/foo bar=-
+```
+
+## Usage
+
+There are no flags beyond the [standard set of flags](/docs/commands/index.html)
+included on all commands.
+
+### Output Options
+
+- `-field` `(string: "")` - Print only the field with the given name. Specifying
+  this option will take precedence over other formatting directives. The result
+  will not have a trailing newline making it ideal for piping to other
+  processes.
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.

--- a/website/source/docs/commands/kv/put.html.md
+++ b/website/source/docs/commands/kv/put.html.md
@@ -1,0 +1,69 @@
+---
+layout: "docs"
+page_title: "kv put - Command"
+sidebar_title: "<code>put</code>"
+sidebar_current: "docs-commands-kv-put"
+description: |-
+  The "kv put" command writes the data to the given path in the K/V secrets
+  engine. The data can be of any type.
+---
+
+# kv put
+
+The `kv put` command writes the data to the given path in the K/V secrets
+engine.
+
+If working with K/V v2, this command creates a new version of a secret at the
+specified location. If working with K/V v1, this command stores the given secret
+at the specified location.
+
+Regardless of the K/V version, if the value does not yet exist at the specified
+path, the calling token must have an ACL policy granting the "create"
+capability. If the value already exists, the calling token must have an ACL
+policy granting the "update" capability.
+
+
+## Examples
+
+Writes the data to the key "creds":
+
+```text
+$ vault kv put secret/creds passcode=my-long-passcode
+```
+
+The data can also be consumed from a file on disk by prefixing with the "@"
+symbol. For example:
+
+```text
+$ vault kv put secret/foo @data.json
+```
+
+Or it can be read from stdin using the "-" symbol:
+
+```text
+$ echo "abcd1234" | vault kv put secret/foo bar=-
+```
+
+## Usage
+
+There are no flags beyond the [standard set of flags](/docs/commands/index.html)
+included on all commands.
+
+### Output Options
+
+- `-field` `(string: "")` - Print only the field with the given name. Specifying
+  this option will take precedence over other formatting directives. The result
+  will not have a trailing newline making it ideal for piping to other
+  processes.
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+### Command Options
+
+- `-cas` `(int: 0)` - Specifies to use a Check-And-Set operation. If not set the
+ write will be allowed. If set to 0 a write will only be allowed if the key
+ doesn’t exist. If the index is non-zero the write will only be allowed if the
+ key’s current version matches the version specified in the cas parameter. The
+ default is -1.

--- a/website/source/docs/commands/kv/rollback.html.md
+++ b/website/source/docs/commands/kv/rollback.html.md
@@ -1,0 +1,51 @@
+---
+layout: "docs"
+page_title: "kv rollback - Command"
+sidebar_title: "<code>rollback</code>"
+sidebar_current: "docs-commands-kv-rollback"
+description: |-
+  The "kv rollback" command restores a given previous version to the current
+  version at the given path.
+---
+
+# kv rollback
+
+~> **NOTE:** This is a [K/V Version 2](/docs/secrets/kv/kv-v2.html) secrets
+engine command, and not available for Version 1.
+
+
+The `kv rollback` command restores a given previous version to the current
+version at the given path. The value is written as a new version; for instance,
+if the current version is 5 and the rollback version is 2, the data from version
+2 will become version 6. This command makes it easy to restore unintentionally
+overwritten data.
+
+## Examples
+
+Restores the version 2 of the data at key "creds":
+
+```text
+$ vault kv rollback -version=2 secret/creds
+Key              Value
+---              -----
+created_time     2019-06-06T17:07:19.299831Z
+deletion_time    n/a
+destroyed        false
+version          6
+```
+
+## Usage
+
+There are no flags beyond the [standard set of flags](/docs/commands/index.html)
+included on all commands.
+
+### Output Options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+### Command Options
+
+- `-version` `(int: 0)` - Specifies the version number that should be made
+current again.

--- a/website/source/docs/commands/kv/undelete.html.md
+++ b/website/source/docs/commands/kv/undelete.html.md
@@ -1,0 +1,45 @@
+---
+layout: "docs"
+page_title: "kv undelete - Command"
+sidebar_title: "<code>undelete</code>"
+sidebar_current: "docs-commands-kv-undelete"
+description: |-
+  The "kv undelete" command undeletes the data for the provided version and path
+  in the key-value store. This restores the data, allowing it to be returned on
+  get requests.
+---
+
+# kv undelete
+
+~> **NOTE:** This is a [K/V Version 2](/docs/secrets/kv/kv-v2.html) secrets
+engine command, and not available for Version 1.
+
+
+The `kv undelete` command undo the deletes of the data for the provided version
+and path in the key-value store. This restores the data, allowing it to be
+returned on get requests.
+
+## Examples
+
+Undelete version 3 of the key "creds":
+
+```text
+$ vault kv undelete -versions=3 secret/creds
+Success! Data written to: secret/undelete/creds
+```
+
+## Usage
+
+There are no flags beyond the [standard set of flags](/docs/commands/index.html)
+included on all commands.
+
+### Output Options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+### Command Options
+
+- `-versions` `([]int: <required>)` - Specifies the version number that should
+be made current again.

--- a/website/source/docs/commands/kv/undelete.html.md
+++ b/website/source/docs/commands/kv/undelete.html.md
@@ -15,7 +15,7 @@ description: |-
 engine command, and not available for Version 1.
 
 
-The `kv undelete` command undo the deletes of the data for the provided version
+The `kv undelete` command undoes the deletes of the data for the provided version
 and path in the key-value store. This restores the data, allowing it to be
 returned on get requests.
 

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -101,6 +101,21 @@
             },
             'delete',
             {
+              category: 'kv',
+              content: [
+                'delete',
+                'destroy',
+                'enable-versioning',
+                'get',
+                'list',
+                'metadata',
+                'patch',
+                'put',
+                'rollback',
+                'undelete'
+              ]
+            },
+            {
               category: 'lease',
               content: ['renew', 'revoke']
             },


### PR DESCRIPTION
Vault users reported:  

> There is not a consistent documentation page for the "vault kv" CLI command where I would expect it. This lead to some confusion and difficulty in onboarding users into Vault as they are not familiar with the "vault kv" CLI. 

This PR is to fill in the gap in the doc. 
