### PR TITLE
Add version-ttl support to kv command line

### DIFF
--- a/command/kv_metadata.go
+++ b/command/kv_metadata.go
@@ -24,9 +24,9 @@ Usage: vault kv metadata <subcommand> [options] [args]
   Vault's key-value store. Here are some simple examples, and more detailed
   examples are available in the subcommands or the documentation.
 
-  Create or update a metadata entry for a key: 
+  Create or update a metadata entry for a key:
 
-      $ vault kv metadata put -max-versions=5 secret/foo
+      $ vault kv metadata put -max-versions=5 -version-ttl=3h25m19s secret/foo
 
   Get the metadata for a key, this provides information about each existing
   version:

--- a/command/kv_rollback.go
+++ b/command/kv_rollback.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
@@ -15,7 +16,8 @@ var _ cli.CommandAutocomplete = (*KVRollbackCommand)(nil)
 type KVRollbackCommand struct {
 	*BaseCommand
 
-	flagVersion int
+	flagVersion    int
+	flagVersionTTL time.Duration
 }
 
 func (c *KVRollbackCommand) Synopsis() string {
@@ -51,6 +53,19 @@ func (c *KVRollbackCommand) Flags() *FlagSets {
 		Name:   "version",
 		Target: &c.flagVersion,
 		Usage:  `Specifies the version number that should be made current again.`,
+	})
+
+	f.DurationVar(&DurationVar{
+		Name:       "version-ttl",
+		Target:     &c.flagVersionTTL,
+		Default:    0,
+		EnvVar:     "",
+		Completion: complete.PredictAnything,
+		Usage: `Specifies the length of time before this version is
+		deleted. If not set, the metadata's version-ttl is used. Cannot be
+		greater than the metadata's version-ttl. The version-ttl is
+		specified as a numeric string with a suffix like "30s" or
+		"3h25m19s".`,
 	})
 
 	return set
@@ -217,12 +232,18 @@ func (c *KVRollbackCommand) Run(args []string) int {
 		}
 	}
 
-	secret, err := client.Logical().Write(path, map[string]interface{}{
+	data = map[string]interface{}{
 		"data": data,
 		"options": map[string]interface{}{
 			"cas": casVersion,
 		},
-	})
+	}
+
+	if c.flagVersionTTL > 0 {
+		data["options"].(map[string]interface{})["version_ttl"] = c.flagVersionTTL.String()
+	}
+
+	secret, err := client.Logical().Write(path, data)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error writing data to %s: %s", path, err))
 		return 2

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -120,7 +120,7 @@ func TestKVPutCommand(t *testing.T) {
 		cmd.client = client
 
 		code := cmd.Run([]string{
-			"-cas", "0", "kv/write/cas", "bar=baz",
+			"-cas", "0", "-version-ttl", "1h", "kv/write/cas", "bar=baz",
 		})
 		if code != 0 {
 			t.Fatalf("expected 0 to be %d", code)
@@ -133,7 +133,7 @@ func TestKVPutCommand(t *testing.T) {
 		ui, cmd = testKVPutCommand(t)
 		cmd.client = client
 		code = cmd.Run([]string{
-			"-cas", "1", "kv/write/cas", "bar=baz",
+			"-cas", "1", "-version-ttl", "1h", "kv/write/cas", "bar=baz",
 		})
 		if code != 0 {
 			t.Fatalf("expected 0 to be %d", code)

--- a/website/source/api/secret/kv/kv-v2.html.md
+++ b/website/source/api/secret/kv/kv-v2.html.md
@@ -20,7 +20,7 @@ possible to enable secrets engines at any location, please update your API calls
 accordingly.
 
 
-## Configure the KV Engine 
+## Configure the KV Engine
 
 This path configures backend level settings that are applied to every key in the
 key-value store.
@@ -34,17 +34,24 @@ key-value store.
 - `max_versions` `(int: 0)` – The number of versions to keep per key. This value
   applies to all keys, but a key's metadata setting can overwrite this value.
   Once a key has more than the configured allowed versions the oldest version
-  will be permanently deleted. Defaults to 10. 
+  will be permanently deleted. Defaults to 10.
 
 - `cas_required` `(bool: false)` – If true all keys will require the cas
   parameter to be set on all write requests.
+
+- `version_ttl` (`int: 0 || string:"0s"`) – If set, specifies the length
+  of time before a version is deleted. Accepts integer number of seconds
+  or [Go duration format string][duration-godoc].
+
+[duration-godoc]: https://golang.org/pkg/time/#ParseDuration
 
 ### Sample Payload
 
 ```json
 {
   "max_versions": 5,
-  "cas_required": false
+  "cas_required": false,
+  "version_ttl": "3h25m19s"
 }
 ```
 
@@ -82,7 +89,8 @@ $ curl \
 {
   "data": {
     "cas_required": false,
-    "max_versions": 0
+    "max_versions": 0,
+    "version_ttl": "3h25m19s"
   }
 }
 ```
@@ -143,11 +151,21 @@ have an ACL policy granting the `update` capability.
 ### Parameters
 
 - `options` `(Map: <optional>)` – An object that holds option settings.
+
     - `cas` `(int: <optional>)` - Set the "cas" value to use a Check-And-Set
       operation. If not set the write will be allowed. If set to 0 a write will
       only be allowed if the key doesn’t exist. If the index is non-zero the
       write will only be allowed if the key’s current version matches the
-      version specified in the cas parameter.  
+      version specified in the cas parameter.
+
+	- `version_ttl` (`int: 0 || string:"0s"`) – Set the `version_ttl`
+	  value to a duration to specify the `deletion_time` for this
+	  version. If not set, the metadata's `version_ttl` will be used. If
+	  the metadata's `version_ttl` is not set, the backend's
+	  `version_ttl` will be used. If the value is greater than the
+	  metadata's `version_ttl`, the metadata's `version_ttl` will be
+	  used. Accepts integer number of seconds or [Go duration format
+	  string][duration-godoc].
 
 - `data` `(Map: <required>)` – The contents of the data map will be stored and
   returned on read.
@@ -157,7 +175,8 @@ have an ACL policy granting the `update` capability.
 ```json
 {
   "options": {
-      "cas": 0
+      "cas": 0,
+	  "version_ttl": "3m"
   },
   "data": {
 	  "foo": "bar",
@@ -182,7 +201,7 @@ $ curl \
 {
   "data": {
     "created_time": "2018-03-22T02:36:43.986212308Z",
-    "deletion_time": "",
+    "deletion_time": "2018-03-22T02:39:43.986212308Z",
     "destroyed": false,
     "version": 1
   }
@@ -264,14 +283,25 @@ This restores the data, allowing it to be returned on get requests.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to undelete.
   This is specified as part of the URL.
+
 - `versions` `([]int: <required>)` - The versions to undelete. The versions will
   be restored and their data will be returned on normal get requests.
+
+- `version_ttl` (`int: 0 || string:"0s"`) – Set the `version_ttl` value
+  to a duration to specify the `deletion_time` for the versions being
+  undeleted. If not set, the metadata's `version_ttl` will be used. If
+  the metadata's `version_ttl` is not set, the backend's `version_ttl`
+  will be used. If the value is greater than the metadata's
+  `version_ttl`, the metadata's `version_ttl` will be used. Accepts
+  integer number of seconds or [Go duration format
+  string][duration-godoc].
 
 ### Sample Payload
 
 ```json
 {
-    "versions": [1, 2]
+    "versions": [1, 2],
+    "version_ttl": "25m"
 }
 ```
 
@@ -298,8 +328,9 @@ numbers from the key-value store.
 
 - `path` `(string: <required>)` – Specifies the path of the secret to destroy.
   This is specified as part of the URL.
+
 - `versions` `([]int: <required>)` - The versions to destroy. Their data will be
-  permanently deleted. 
+  permanently deleted.
 
 ### Sample Payload
 
@@ -429,18 +460,26 @@ have an ACL policy granting the `update` capability.
 - `max_versions` `(int: 0)` – The number of versions to keep per key. If not
   set, the backend’s configured max version is used. Once a key has more than
   the configured allowed versions the oldest version will be permanently
-  deleted. 
+  deleted.
 
 - `cas_required` `(bool: false)` – If true the key will require the cas
   parameter to be set on all write requests. If false, the backend’s
-  configuration will be used. 
+  configuration will be used.
+
+- `version_ttl` (`int: 0 || string:"0s"`) – Set the `version_ttl` value
+  to a duration to specify the `deletion_time` for all new versions
+  written to this key. If not set, the backend's `version_ttl` will be
+  used. If the value is greater than the backend's `version_ttl`, the
+  backend's `version_ttl` will be used. Accepts integer number of
+  seconds or [Go duration format string][duration-godoc].
 
 ### Sample Payload
 
 ```json
 {
   "max_versions": 5,
-  "cas_required": false	
+  "cas_required": false,
+  "version_ttl": "3h25m19s"
 }
 ```
 
@@ -457,7 +496,7 @@ $ curl \
 ## Delete Metadata and All Versions
 
 This endpoint permanently deletes the key metadata and all version data for the
-specified key. All version history will be removed.  
+specified key. All version history will be removed.
 
 | Method   | Path                         |
 | :--------------------------- | :--------------------- |

--- a/website/source/docs/secrets/kv/kv-v2.html.md
+++ b/website/source/docs/secrets/kv/kv-v2.html.md
@@ -28,13 +28,13 @@ management tool.
 
 A v2 `kv` secrets engine can be enabled by:
 
-```
+```text
 $ vault secrets enable -version=2 kv
 ```
 
 Or, you can pass `kv-v2` as the secrets engine type:
 
-```
+```text
 $ vault secrets enable kv-v2
 ```
 
@@ -44,20 +44,20 @@ different paths. Each instance of the KV secrets engine is isolated and unique.
 
 ## Upgrading from Version 1
 
-An existing version 1 kv store can be upgraded to a version 2 kv store via the CLI or API, as shown below. This will start an upgrade process to upgrade the existing key/value data to a versioned format. The mount will be inaccessible during this process. This process could take a long time, so plan accordingly.  
+An existing version 1 kv store can be upgraded to a version 2 kv store via the CLI or API, as shown below. This will start an upgrade process to upgrade the existing key/value data to a versioned format. The mount will be inaccessible during this process. This process could take a long time, so plan accordingly.
 
 Once upgraded to version 2, the former paths at which the data was accessible will no longer suffice. You will need to adjust user policies to add access to the version 2 paths as detailed in the [ACL Rules section below](/docs/secrets/kv/kv-v2.html#acl-rules). Similarly, users/applications will need to update the paths at which they interact with the kv data once it has been upgraded to version 2.
 
 An existing version 1 kv can be upgraded to a version 2 KV store with the CLI command:
 
-```
+```text
 $ vault kv enable-versioning secret/
 Success! Tuned the secrets engine at: secret/
 ```
 
 or via the API:
 
-```
+```text
 $ cat payload.json
 {
   "options": {
@@ -163,18 +163,16 @@ allows for writing keys with arbitrary values.
 
 ### Writing/Reading arbitrary data
 
-
-
 1. Write arbitrary data:
 
     ```text
     $ vault kv put secret/my-secret my-value=s3cr3t
-    Key              Value
-    ---              -----
-    created_time     2018-03-30T22:11:48.589157362Z
-    deletion_time    n/a
-    destroyed        false
-    version          1
+	Key              Value
+	---              -----
+	created_time     2019-06-06T17:03:28.205822Z
+	deletion_time    n/a
+	destroyed        false
+	version          1
     ```
 
 1. Read arbitrary data:
@@ -184,7 +182,7 @@ allows for writing keys with arbitrary values.
     ====== Metadata ======
     Key              Value
     ---              -----
-    created_time     2018-03-30T22:11:48.589157362Z
+    created_time     2019-06-06T17:03:28.205822Z
     deletion_time    n/a
     destroyed        false
     version          1
@@ -206,7 +204,7 @@ allows for writing keys with arbitrary values.
     $ vault kv put -cas=1 secret/my-secret my-value=new-s3cr3t
     Key              Value
     ---              -----
-    created_time     2018-03-30T22:18:37.124228658Z
+    created_time     2019-06-06T17:04:54.437108Z
     deletion_time    n/a
     destroyed        false
     version          2
@@ -219,7 +217,7 @@ allows for writing keys with arbitrary values.
     ====== Metadata ======
     Key              Value
     ---              -----
-    created_time     2018-03-30T22:18:37.124228658Z
+    created_time     2019-06-06T17:04:54.437108Z
     deletion_time    n/a
     destroyed        false
     version          2
@@ -232,12 +230,12 @@ allows for writing keys with arbitrary values.
 
 1. Previous versions can be accessed with the `-version` flag:
 
-    ```
+    ```text
     $ vault kv get -version=1 secret/my-secret
     ====== Metadata ======
     Key              Value
     ---              -----
-    created_time     2018-03-30T22:16:39.808909557Z
+    created_time     2019-06-06T17:03:28.205822Z
     deletion_time    n/a
     destroyed        false
     version          1
@@ -248,12 +246,78 @@ allows for writing keys with arbitrary values.
     my-value    s3cr3t
     ```
 
+1. Write another version which will be deleted after a specified
+   duration. The `-version-ttl` flag can optionally be passed to specify
+   a duration of time until the version will be deleted. The previous
+   versions will still be accessible.
+
+    ```text
+    $ vault kv put -version-ttl=2m secret/my-secret my-value=short-lived-s3cr3t
+	Key              Value
+	---              -----
+	created_time     2019-06-06T17:25:10.965962Z
+	deletion_time    2019-06-06T17:27:10.965962Z
+	destroyed        false
+	version          3
+	```
+
+1. Reading now will return the newest version of the data and show the
+   `deletion_time`:
+
+    ```text
+	$ vault kv get secret/my-secret
+	====== Metadata ======
+	Key              Value
+	---              -----
+	created_time     2019-06-06T17:25:10.965962Z
+	deletion_time    2019-06-06T17:27:10.965962Z
+	destroyed        false
+	version          3
+
+	====== Data ======
+	Key         Value
+	---         -----
+	my-value    short-lived-s3cr3t
+	```
+
+1. Reading after the `deletion_time` will only return metadata:
+
+    ```text
+	$ vault kv get secret/my-secret
+	====== Metadata ======
+	Key              Value
+	---              -----
+	created_time     2019-06-06T17:25:10.965962Z
+	deletion_time    2019-06-06T17:27:10.965962Z
+	destroyed        false
+	version          3
+
+	```
+
+1. Previous versions not deleted can still be accessed with the `-version` flag:
+
+    ```text
+    $ vault kv get -version=2 secret/my-secret
+	====== Metadata ======
+	Key              Value
+	---              -----
+	created_time     2019-06-06T17:04:54.437108Z
+	deletion_time    n/a
+	destroyed        false
+	version          2
+
+	====== Data ======
+	Key         Value
+	---         -----
+	my-value    new-s3cr3t
+    ```
+
 ### Deleting and Destroying Data
 
 When deleting data the standard `vault kv delete` command will perform a
 soft delete. It will mark the version as deleted and populate a `deletion_time`
 timestamp. Soft deletes do not remove the underlying version data from storage,
-which allows the version to be undeleted. The `vault kv undelete` commmand
+which allows the version to be undeleted. The `vault kv undelete` command
 handles undeleting versions.
 
 A version's data is permanently deleted only when the key has more versions than
@@ -267,36 +331,36 @@ See the commands below for more information:
 1. The latest version of a key can be deleted with the delete command, this also
    takes a `-versions` flag to delete prior versions:
 
-    ```
+    ```text
     $ vault kv delete secret/my-secret
     Success! Data deleted (if it existed) at: secret/my-secret
     ```
 
 1. Versions can be undeleted:
 
-    ```
-    $ vault kv undelete -versions=2 secret/my-secret
+    ```text
+    $ vault kv undelete -versions=3 secret/my-secret
     Success! Data written to: secret/undelete/my-secret
 
     $ vault kv get secret/my-secret
-    ====== Metadata ======
-    Key              Value
-    ---              -----
-    created_time     2018-03-30T22:18:37.124228658Z
-    deletion_time    n/a
-    destroyed        false
-    version          2
+	====== Metadata ======
+	Key              Value
+	---              -----
+	created_time     2019-06-06T17:25:10.965962Z
+	deletion_time    n/a
+	destroyed        false
+	version          3
 
-    ====== Data ======
-    Key         Value
-    ---         -----
-    my-value    new-s3cr3t
+	====== Data ======
+	Key         Value
+	---         -----
+	my-value    short-lived-s3cr3t
     ```
 
 1. Destroying a version permanently deletes the underlying data:
 
-    ```
-    $ vault kv destroy -versions=2 secret/my-secret
+    ```text
+    $ vault kv destroy -versions=3 secret/my-secret
     Success! Data written to: secret/destroy/my-secret
     ```
 
@@ -310,76 +374,95 @@ See the commands below for more information:
 
 1. All metadata and versions for a key can be viewed:
 
-    ```
+    ```text
     $ vault kv metadata get secret/my-secret
-    ======= Metadata =======
-    Key                Value
-    ---                -----
-    created_time       2018-03-30T22:16:39.808909557Z
-    current_version    2
-    max_versions       0
-    oldest_version     0
-    updated_time       2018-03-30T22:18:37.124228658Z
+	======= Metadata =======
+	Key                Value
+	---                -----
+	cas_required       false
+	created_time       2019-06-06T17:03:28.205822Z
+	current_version    3
+	max_versions       0
+	oldest_version     0
+	updated_time       2019-06-06T17:25:10.965962Z
+	version_ttl        0s
 
-    ====== Version 1 ======
-    Key              Value
-    ---              -----
-    created_time     2018-03-30T22:16:39.808909557Z
-    deletion_time    n/a
-    destroyed        false
+	====== Version 1 ======
+	Key              Value
+	---              -----
+	created_time     2019-06-06T17:03:28.205822Z
+	deletion_time    n/a
+	destroyed        false
 
-    ====== Version 2 ======
-    Key              Value
-    ---              -----
-    created_time     2018-03-30T22:18:37.124228658Z
-    deletion_time    n/a
-    destroyed        true
+	====== Version 2 ======
+	Key              Value
+	---              -----
+	created_time     2019-06-06T17:04:54.437108Z
+	deletion_time    n/a
+	destroyed        false
+
+	====== Version 3 ======
+	Key              Value
+	---              -----
+	created_time     2019-06-06T17:25:10.965962Z
+	deletion_time    n/a
+	destroyed        true
     ```
 
 1. The metadata settings for a key can be configured:
 
-    ```
-    $ vault kv metadata put -max-versions 1 secret/my-secret
+    ```text
+    $ vault kv metadata put -max-versions 2 -version-ttl="3h25m19s" secret/my-secret
     Success! Data written to: secret/metadata/my-secret
     ```
 
-    Max versions changes will be applied on next write:
+	Version TTL settings will apply only to new versions. Max versions
+	changes will be applied on next write:
 
-    ```
+    ```text
     $ vault kv put secret/my-secret my-value=newer-s3cr3t
-    Key              Value
-    ---              -----
-    created_time     2018-03-30T22:41:09.193643571Z
-    deletion_time    n/a
-    destroyed        false
-    version          3
+	Key              Value
+	---              -----
+	created_time     2019-06-06T18:03:02.979832Z
+	deletion_time    2019-06-06T21:28:21.979832Z
+	destroyed        false
+	version          4
     ```
 
-    Once a key has more versions than max versions the oldest versions are cleaned
-    up:
+	Once a key has more versions than max versions the oldest versions
+	are cleaned up:
 
-    ```
+    ```text
     $ vault kv metadata get secret/my-secret
-    ======= Metadata =======
-    Key                Value
-    ---                -----
-    created_time       2018-03-30T22:16:39.808909557Z
-    current_version    3
-    max_versions       1
-    oldest_version     3
-    updated_time       2018-03-30T22:41:09.193643571Z
+	======= Metadata =======
+	Key                Value
+	---                -----
+	cas_required       false
+	created_time       2019-06-06T17:03:28.205822Z
+	current_version    4
+	max_versions       2
+	oldest_version     3
+	updated_time       2019-06-06T18:03:02.979832Z
+	version_ttl        3h25m19s
 
-    ====== Version 3 ======
-    Key              Value
-    ---              -----
-    created_time     2018-03-30T22:41:09.193643571Z
-    deletion_time    n/a
-    destroyed        false
+	====== Version 3 ======
+	Key              Value
+	---              -----
+	created_time     2019-06-06T17:54:14.426645Z
+	deletion_time    n/a
+	destroyed        false
+
+	====== Version 4 ======
+	Key              Value
+	---              -----
+	created_time     2019-06-06T18:03:02.979832Z
+	deletion_time    2019-06-06T21:28:21.979832Z
+	destroyed        false
     ```
 
 1. Permanently delete all metadata and versions for a key:
 
-    ```
+    ```text
     $ vault kv metadata delete secret/my-secret
     Success! Data deleted (if it existed) at: secret/metadata/my-secret
     ```


### PR DESCRIPTION
Depends on hashicorp/vault-plugin-secrets-kv#32.

**TODO**
- [ ] Update `go.mod` after hashicorp/vault-plugin-secrets-kv#32 is merged into master
