### PR TITLE
fix output-curl-string for 'vault kv patch'

### DIFF
--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -119,8 +119,9 @@ func (c *KVPatchCommand) Run(args []string) int {
 		return 2
 	}
 
-	// First, do a read
-	curOutputCurl := client.OutputCurlString() // we don't want to see curl output for the read request
+	// First, do a read.
+	// Note that we don't want to see curl output for the read request.
+	curOutputCurl := client.OutputCurlString()
 	client.SetOutputCurlString(false)
 	secret, err := kvReadRequest(client, path, nil)
 	client.SetOutputCurlString(curOutputCurl)

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -120,7 +120,10 @@ func (c *KVPatchCommand) Run(args []string) int {
 	}
 
 	// First, do a read
+	curOutputCurl := client.OutputCurlString() // we don't want to see curl output for the read request
+	client.SetOutputCurlString(false)
 	secret, err := kvReadRequest(client, path, nil)
+	client.SetOutputCurlString(curOutputCurl)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error doing pre-read at %s: %s", path, err))
 		return 2


### PR DESCRIPTION
The output for `vault kv patch -output-curl-string` is wrong, since it shows the initial read request for the patch, instead of the subsequent write request.  This PR fixes that so that the curl for the write request is now shown instead.

This fixes issue #6783.

To test, do:

```
vault kv put secret/hello a=b
vault kv patch -output-curl-string secret/hello a=b c=d
curl -X PUT -H "X-Vault-Token: $(vault print token)" -d '{"data":{"a":"b","c":"d"},"options":{"cas":1}}' http://127.0.0.1:8200/v1/secret/data/hello
vault kv get secret/hello
```