### PR TITLE
If 'plugin_directory' is configured, then 'api_addr' must be configured

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -683,6 +683,14 @@ func (c *ServerCommand) Run(args []string) int {
 
 	// Attempt to detect the redirect address, if possible
 	if coreConfig.RedirectAddr == "" {
+		// If 'plugin_directory' is configured, then 'api_addr' must also be
+		// configured. This will prevent plugins from being enabled successfully
+		// but then failing mysteriously when one tries to address them through
+		// their API endpoints.
+		if coreConfig.PluginDirectory != ""  {
+			c.UI.Error(fmt.Sprintf("No `api_addr` value specified in config or in VAULT_API_ADDR; this value must be manually set if `plugin_directory` is set."))
+			return 1
+		}
 		c.logger.Warn("no `api_addr` value specified in config or in VAULT_API_ADDR; falling back to detection if possible, but this value should be manually set")
 	}
 	var detect physical.RedirectDetect

--- a/website/source/docs/configuration/index.html.md
+++ b/website/source/docs/configuration/index.html.md
@@ -101,7 +101,8 @@ to specify where the configuration is.
 
 - `plugin_directory` `(string: "")` – A directory from which plugins are
   allowed to be loaded. Vault must have permission to read files in this
-  directory to successfully load plugins.
+  directory to successfully load plugins. If this parameter is set, then 
+  the [api_addr](#api_addr) parameter must also be set.
 
 - `telemetry` <tt>([Telemetry][telemetry]: &lt;none&gt;)</tt> – Specifies the telemetry
   reporting system.
@@ -146,7 +147,9 @@ The following parameters are used on backends that support [high availability][h
   other Vault servers in the cluster for client redirection. This value is also
   used for [plugin backends][plugins]. This can also be provided via the
   environment variable `VAULT_API_ADDR`. In general this should be set as a full
-  URL that points to the value of the [`listener`](#listener) address.
+  URL that points to the value of the [`listener`](#listener) address. If the
+  [plugin_directory](#plugin_directory) parameter is set, then this parameter must
+  also be set.
 
 - `cluster_addr` `(string: "")` -  – Specifies the address to advertise to other
   Vault servers in the cluster for request forwarding. This can also be provided


### PR DESCRIPTION
If `plugin_directory` is configured, then `api_addr` must also be
configured. This change will prevent plugins from being enabled successfully
but then failing mysteriously when one tries to address them through
their API endpoints. 

The `vault server` command will now exit with an error message if this 
misconfiguration is detected.

This will change backwards compatibility for vault servers configured 
in the following way:

1. `plugin_directory` is configured
1. `api_addr` is _not_ configured
1. No plugins are actually being used, so the problem hasn't shown up yet.

Those servers will now have to be configured correctly before they will start.

This PR references issue #6487

