### PR TITLE
Add core.coreNumber field, used to differentiate multiple cores/clusters

### DIFF
--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -294,15 +294,16 @@ func GetPerfReplicatedClusters(t testing.T, conf *vault.CoreConfig, opts *vault.
 	// Set this lower so that state populates quickly to standby nodes
 	cluster.HeartbeatInterval = 2 * time.Second
 
+	numCores := opts.NumCores
+	if numCores == 0 {
+		numCores = vault.DefaultNumCores
+	}
+
 	localopts := *opts
 	localopts.Logger = logger.Named("perf-pri")
 	ret.PerfPrimaryCluster, _ = ConfClusterAndCore(t, conf, &localopts)
 
 	localopts.Logger = logger.Named("perf-sec")
-	numCores := opts.NumCores
-	if numCores == 0 {
-		numCores = vault.DefaultNumCores
-	}
 	localopts.FirstCoreNumber += numCores
 	ret.PerfSecondaryCluster, _ = ConfClusterAndCore(t, conf, &localopts)
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -427,6 +427,8 @@ type Core struct {
 
 	// Stores request counters
 	counters counters
+
+	coreNumber int
 }
 
 // CoreConfig is used to parameterize a core

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1199,6 +1199,7 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 		BackendUUID: entry.BackendAwareUUID,
 	}
 
+	ctx = context.WithValue(ctx, "core_number", c.coreNumber)
 	b, err := f(ctx, config)
 	if err != nil {
 		return nil, err

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -989,6 +989,7 @@ type TestClusterOptions struct {
 	TempDir            string
 	CACert             []byte
 	CAKey              *ecdsa.PrivateKey
+	FirstCoreNumber    int
 }
 
 var DefaultNumCores = 3
@@ -1371,6 +1372,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
+		c.coreNumber = opts.FirstCoreNumber + i
 		cores = append(cores, c)
 		coreConfigs = append(coreConfigs, &localConfig)
 		if opts != nil && opts.HandlerFunc != nil {

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1020,6 +1020,11 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		numCores = opts.NumCores
 	}
 
+	var firstCoreNumber int
+	if opts != nil {
+		firstCoreNumber = opts.FirstCoreNumber
+	}
+
 	certIPs := []net.IP{
 		net.IPv6loopback,
 		net.ParseIP("127.0.0.1"),
@@ -1372,7 +1377,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		c.coreNumber = opts.FirstCoreNumber + i
+		c.coreNumber = firstCoreNumber + i
 		cores = append(cores, c)
 		coreConfigs = append(coreConfigs, &localConfig)
 		if opts != nil && opts.HandlerFunc != nil {


### PR DESCRIPTION
when running tests.  This is not used or exposed in prod.

Remove some test-specific code from the cluster-building helpers. The
corresponding additions go on the ent side.