### PR TITLE
Addition TCP listener syntax demonstration

### DIFF
--- a/website/source/docs/configuration/listener/tcp.html.md
+++ b/website/source/docs/configuration/listener/tcp.html.md
@@ -155,7 +155,7 @@ listener "tcp" {
 
 ### Listening on Multiple Interfaces
 
-This example shows Vault listening on a private interface, as well as localhost.
+Vault listeners with unique settings can co-exist, and each listener can be configured independently. This example shows Vault listening on multiple interfaces and multiple ports. The listeners on port 8200 are bound to the loopback interface and a private interface. The listener on port 8210 is bound to a private interface, and is configured to require mutual TLS.
 
 ```hcl
 listener "tcp" {
@@ -166,23 +166,6 @@ listener "tcp" {
   address = "10.0.0.5:8200"
 }
 
-# Advertise the non-loopback interface
-api_addr = "https://10.0.0.5:8200"
-cluster_addr = "https://10.0.0.5:8201"
-```
-
-### Multiple Listeners Using Different Configurations
-
-This example shows Vault listening on two ports: one port is configured to require mutual TLS, and one port is configured without mutual TLS. This pattern is commonly used when the API will be accessed by machines using mutual TLS, but the UI will be accessed by humans with another Auth Method. While a single listener statement can be used, this often results in frequent browser prompts on the Vault UI asking for a TLS certificate.
-
-```hcl
-
-# regular listener that does not require mutual TLS
-listener "tcp" {
-  address = "10.0.0.5:8200"
-}
-
-# additional listener that does require mutual TLS
 listener "tcp" {
   address = "10.0.0.5:8210"
   tls_require_and_verify_client_cert = true
@@ -193,7 +176,6 @@ listener "tcp" {
 api_addr = "https://10.0.0.5:8200"
 cluster_addr = "https://10.0.0.5:8201"
 ```
-
 
 [golang-tls]: https://golang.org/src/crypto/tls/cipher_suites.go
 [api-addr]: /docs/configuration/index.html#api_addr

--- a/website/source/docs/configuration/listener/tcp.html.md
+++ b/website/source/docs/configuration/listener/tcp.html.md
@@ -171,6 +171,30 @@ api_addr = "https://10.0.0.5:8200"
 cluster_addr = "https://10.0.0.5:8201"
 ```
 
+### Multiple Listeners Using Different Configurations
+
+This example shows Vault listening on two ports: one port is configured to require mutual TLS, and one port is configured without mutual TLS. This pattern is commonly used when the API will be accessed by machines using mutual TLS, but the UI will be accessed by humans with another Auth Method. While a single listener statement can be used, this often results in frequent browser prompts on the Vault UI asking for a TLS certificate.
+
+```hcl
+
+# regular listener that does not require mutual TLS
+listener "tcp" {
+  address = "10.0.0.5:8200"
+}
+
+# additional listener that does require mutual TLS
+listener "tcp" {
+  address = "10.0.0.5:8210"
+  tls_require_and_verify_client_cert = true
+  tls_client_ca_file = "userCertCA.pem"
+}
+
+# Advertise the non-loopback interface
+api_addr = "https://10.0.0.5:8200"
+cluster_addr = "https://10.0.0.5:8201"
+```
+
+
 [golang-tls]: https://golang.org/src/crypto/tls/cipher_suites.go
 [api-addr]: /docs/configuration/index.html#api_addr
 [cluster-addr]: /docs/configuration/index.html#cluster_addr


### PR DESCRIPTION
Users who implement mutual TLS for API client authentication often comment that when human users access the API address, it "nags" them for a client certificate frequently. This seems to be a natural response to the browser being asked to present a client certificate.

This example syntax demonstrates configuration of two listeners: one that enables mutual TLS so that automated systems can use mutual TLS, and one that disables mutual TLS, so that human interaction can use another form of authentication.

Tagging @nwatnick @lcopeland who have been involved in configuration/troubleshooting with users that ended up using something similar to this config example.