### PR TITLE
ci: factor out go mod cache permissions fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,12 @@ jobs:
         fingerprints:
         - c6:96:98:82:dc:04:6c:39:dd:ac:83:05:e3:15:1c:98
     - checkout
+    - run:
+        command: |
+          set -eux -o pipefail
+          sudo mkdir /go
+          sudo chown -R circleci:circleci /go
+        name: Allow circleci user to restore Go modules cache
     - restore_cache:
         key: go-sum-v1-{{ checksum "go.sum" }}
     - run:
@@ -48,6 +54,12 @@ jobs:
     working_directory: /src
     steps:
     - checkout
+    - run:
+        command: |
+          set -eux -o pipefail
+          sudo mkdir /go
+          sudo chown -R circleci:circleci /go
+        name: Allow circleci user to restore Go modules cache
     - restore_cache:
         key: go-sum-v1-{{ checksum "go.sum" }}
     - attach_workspace:
@@ -113,7 +125,6 @@ jobs:
     - run:
         command: |
           set -eux -o pipefail
-
           sudo mkdir /go
           sudo chown -R circleci:circleci /go
         name: Allow circleci user to restore Go modules cache
@@ -184,7 +195,6 @@ jobs:
     - run:
         command: |
           set -eux -o pipefail
-
           sudo mkdir /go
           sudo chown -R circleci:circleci /go
         name: Allow circleci user to restore Go modules cache
@@ -326,6 +336,12 @@ workflows:
 #         no_output_timeout: 20m
 #   restore_go_cache:
 #     steps:
+#     - run:
+#         command: |
+#           set -eux -o pipefail
+#           sudo mkdir /go
+#           sudo chown -R circleci:circleci /go
+#         name: Allow circleci user to restore Go modules cache
 #     - restore_cache:
 #         key: go-sum-v1-{{ checksum \"go.sum\" }}
 #   restore_yarn_cache:
@@ -418,13 +434,6 @@ workflows:
 #     parallelism: 2
 #     steps:
 #     - checkout
-#     - run:
-#         command: |
-#           set -eux -o pipefail
-# 
-#           sudo mkdir /go
-#           sudo chown -R circleci:circleci /go
-#         name: Allow circleci user to restore Go modules cache
 #     - restore_go_cache
 #     - go_test
 #     - store_artifacts:
@@ -435,13 +444,6 @@ workflows:
 #     executor: go-machine
 #     steps:
 #     - checkout
-#     - run:
-#         command: |
-#           set -eux -o pipefail
-# 
-#           sudo mkdir /go
-#           sudo chown -R circleci:circleci /go
-#         name: Allow circleci user to restore Go modules cache
 #     - restore_go_cache
 #     - go_test:
 #         extra_flags: -race

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
     - run:
         command: |
           set -eux -o pipefail
+          # Exit early if there is no user called circleci.
+          id -u circleci > /dev/null 2>&1 || exit 0
           SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
           $SUDO mkdir -p /go
           $SUDO chown -R circleci:circleci /go
@@ -58,6 +60,8 @@ jobs:
     - run:
         command: |
           set -eux -o pipefail
+          # Exit early if there is no user called circleci.
+          id -u circleci > /dev/null 2>&1 || exit 0
           SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
           $SUDO mkdir -p /go
           $SUDO chown -R circleci:circleci /go
@@ -127,6 +131,8 @@ jobs:
     - run:
         command: |
           set -eux -o pipefail
+          # Exit early if there is no user called circleci.
+          id -u circleci > /dev/null 2>&1 || exit 0
           SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
           $SUDO mkdir -p /go
           $SUDO chown -R circleci:circleci /go
@@ -198,6 +204,8 @@ jobs:
     - run:
         command: |
           set -eux -o pipefail
+          # Exit early if there is no user called circleci.
+          id -u circleci > /dev/null 2>&1 || exit 0
           SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
           $SUDO mkdir -p /go
           $SUDO chown -R circleci:circleci /go
@@ -343,6 +351,8 @@ workflows:
 #     - run:
 #         command: |
 #           set -eux -o pipefail
+#           # Exit early if there is no user called circleci.
+#           id -u circleci > /dev/null 2>&1 || exit 0
 #           SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
 #           $SUDO mkdir -p /go
 #           $SUDO chown -R circleci:circleci /go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,9 @@ jobs:
     - run:
         command: |
           set -eux -o pipefail
-          sudo mkdir /go
-          sudo chown -R circleci:circleci /go
+          SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
+          $SUDO mkdir -p /go
+          $SUDO chown -R circleci:circleci /go
         name: Allow circleci user to restore Go modules cache
     - restore_cache:
         key: go-sum-v1-{{ checksum "go.sum" }}
@@ -57,8 +58,9 @@ jobs:
     - run:
         command: |
           set -eux -o pipefail
-          sudo mkdir /go
-          sudo chown -R circleci:circleci /go
+          SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
+          $SUDO mkdir -p /go
+          $SUDO chown -R circleci:circleci /go
         name: Allow circleci user to restore Go modules cache
     - restore_cache:
         key: go-sum-v1-{{ checksum "go.sum" }}
@@ -125,8 +127,9 @@ jobs:
     - run:
         command: |
           set -eux -o pipefail
-          sudo mkdir /go
-          sudo chown -R circleci:circleci /go
+          SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
+          $SUDO mkdir -p /go
+          $SUDO chown -R circleci:circleci /go
         name: Allow circleci user to restore Go modules cache
     - restore_cache:
         key: go-sum-v1-{{ checksum "go.sum" }}
@@ -195,8 +198,9 @@ jobs:
     - run:
         command: |
           set -eux -o pipefail
-          sudo mkdir /go
-          sudo chown -R circleci:circleci /go
+          SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
+          $SUDO mkdir -p /go
+          $SUDO chown -R circleci:circleci /go
         name: Allow circleci user to restore Go modules cache
     - restore_cache:
         key: go-sum-v1-{{ checksum "go.sum" }}
@@ -339,8 +343,9 @@ workflows:
 #     - run:
 #         command: |
 #           set -eux -o pipefail
-#           sudo mkdir /go
-#           sudo chown -R circleci:circleci /go
+#           SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
+#           $SUDO mkdir -p /go
+#           $SUDO chown -R circleci:circleci /go
 #         name: Allow circleci user to restore Go modules cache
 #     - restore_cache:
 #         key: go-sum-v1-{{ checksum \"go.sum\" }}

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -28,6 +28,8 @@ commands:
           name: Allow circleci user to restore Go modules cache
           command: |
             set -eux -o pipefail
+            # Exit early if there is no user called circleci.
+            id -u circleci > /dev/null 2>&1 || exit 0
             SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
             $SUDO mkdir -p /go
             $SUDO chown -R circleci:circleci /go

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -24,6 +24,12 @@ commands:
             - ui/node_modules
   restore_go_cache:
     steps:
+      - run:
+          name: Allow circleci user to restore Go modules cache
+          command: |
+            set -eux -o pipefail
+            sudo mkdir /go
+            sudo chown -R circleci:circleci /go
       - restore_cache:
           key: *GO_SUM_CACHE_KEY
   save_go_cache:

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -28,7 +28,7 @@ commands:
           name: Allow circleci user to restore Go modules cache
           command: |
             set -eux -o pipefail
-            sudo mkdir /go
+            sudo mkdir -p /go
             sudo chown -R circleci:circleci /go
       - restore_cache:
           key: *GO_SUM_CACHE_KEY

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -28,8 +28,9 @@ commands:
           name: Allow circleci user to restore Go modules cache
           command: |
             set -eux -o pipefail
-            sudo mkdir -p /go
-            sudo chown -R circleci:circleci /go
+            SUDO=$(if command -v sudo > /dev/null 2>&1; then echo sudo; fi)
+            $SUDO mkdir -p /go
+            $SUDO chown -R circleci:circleci /go
       - restore_cache:
           key: *GO_SUM_CACHE_KEY
   save_go_cache:

--- a/.circleci/config/jobs/test-go-race.yml
+++ b/.circleci/config/jobs/test-go-race.yml
@@ -1,13 +1,6 @@
 executor: go-machine
 steps:
   - checkout
-  - run:
-      name: Allow circleci user to restore Go modules cache
-      command: |
-        set -eux -o pipefail
-
-        sudo mkdir /go
-        sudo chown -R circleci:circleci /go
   - restore_go_cache
   - go_test:
       extra_flags: "-race"

--- a/.circleci/config/jobs/test-go.yml
+++ b/.circleci/config/jobs/test-go.yml
@@ -2,13 +2,6 @@ executor: go-machine
 parallelism: 2
 steps:
   - checkout
-  - run:
-      name: Allow circleci user to restore Go modules cache
-      command: |
-        set -eux -o pipefail
-
-        sudo mkdir /go
-        sudo chown -R circleci:circleci /go
   - restore_go_cache
   - go_test
   - store_artifacts:


### PR DESCRIPTION
Eliminates some repetition.

UPDATE: This needs some work, as it's causing issues on the non-machine executors due to lack of circleci user. I'll get to this tomorrow.