### PR TITLE
Add ElasticSearch docs to sidebars

### DIFF
--- a/website/source/docs/secrets/databases/elasticdb.html.md
+++ b/website/source/docs/secrets/databases/elasticdb.html.md
@@ -2,7 +2,7 @@
 layout: "docs"
 page_title: "Elasticsearch - Database - Secrets Engines"
 sidebar_title: "Elasticsearch"
-sidebar_current: "docs-secrets-databases-elasticsearch"
+sidebar_current: "docs-secrets-databases-elasticdb"
 description: |-
   Elasticsearch is one of the supported plugins for the database secrets engine. This
   plugin generates database credentials dynamically based on configured roles

--- a/website/source/layouts/api.erb
+++ b/website/source/layouts/api.erb
@@ -25,6 +25,7 @@
                 category: 'databases',
                 content: [
                   'cassandra',
+                  'elasticdb',
                   'influxdb',
                   'hanadb',
                   'mongodb',

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -224,6 +224,7 @@
                 category: 'databases',
                 content: [
                   'cassandra',
+                  'elasticdb',
                   'influxdb',
                   'hanadb',
                   'mongodb',


### PR DESCRIPTION
I overlooked adding ES docs to the website sidebars in https://github.com/hashicorp/vault/pull/6857, this fixes that.