### PR TITLE
Added a note about JWT in the K8S auth method config

### DIFF
--- a/website/source/docs/auth/kubernetes.html.md
+++ b/website/source/docs/auth/kubernetes.html.md
@@ -84,6 +84,15 @@ list of available configuration options, please see the API documentation.
         kubernetes_ca_cert=@ca.crt
     ```
 
+    !> **NOTE:** The pattern Vault uses to authenticate Pods depends on sharing
+    the JWT token over the network. Given the [security model of
+    Vault](/docs/internals/security.html), this is allowable because Vault is
+    part of the trusted compute base. In general, Kubernetes applications should
+    **not** share this JWT with other applications, as it allows API calls to be
+    made on behalf of the Pod and can result in unintended access being granted
+    to 3rd parties.
+
+
 1. Create a named role:
 
     ```text


### PR DESCRIPTION
Adding a note to explain why it's acceptable to give Vault your K8S service account JWT while it's considered to be not okay in general practice. 