### PR TITLE
Fix failing AWS region test

### DIFF
--- a/helper/awsutil/region_test.go
+++ b/helper/awsutil/region_test.go
@@ -110,6 +110,12 @@ func TestGetOrDefaultRegion_ConfigFileUnfound(t *testing.T) {
 }
 
 func TestGetOrDefaultRegion_EC2InstanceMetadataPreferredFourth(t *testing.T) {
+	if !shouldTestFiles {
+		// In some test environments, like a CI environment, we may not have the
+		// permissions to write to the ~/.aws/config file. Thus, this test is off
+		// by default but can be set to on for local development.
+		t.SkipNow()
+	}
 	configuredRegion := ""
 
 	cleanupEnv := setEnvRegion(t, "")


### PR DESCRIPTION
This test was failing remotely:
```
--- FAIL: TestGetOrDefaultRegion_EC2InstanceMetadataPreferredFourth (0.00s)
    region_test.go:126: expected: us-west-2; actual: us-east-1
FAIL
FAIL    github.com/hashicorp/vault/helper/awsutil       0.009s
```
It was failing because, while the test itself respected that it should ignore the `.aws/config` file, the code interior to the method being tested didn't. That code is deep, deep in the AWS SDK so it's not easy to do that. 

This PR puts that test behind a "skip" flag so it can still be used for local development.