### PR TITLE
Fix TestPluginCatalog_List

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1645,6 +1645,7 @@ func (m *mockBuiltinRegistry) Keys(pluginType consts.PluginType) []string {
 		"mysql-rds-database-plugin",
 		"mysql-legacy-database-plugin",
 		"postgresql-database-plugin",
+		"elasticsearch-database-plugin",
 		"mssql-database-plugin",
 		"cassandra-database-plugin",
 		"mongodb-database-plugin",


### PR DESCRIPTION
Fixes this test failure:
```
--- FAIL: TestPluginCatalog_List (0.02s)
    plugin_catalog_test.go:132: unexpected length of plugin list, expected 11, got 10
```
It happened because plugin names had to be hard-coded in the testing framework to avoid an import cycle. This adds it to the hard-coded list to match the real-life one.