### PR TITLE
 auth/aws: guard against malformed assumed role ARNs

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -1404,6 +1404,10 @@ func parseIamArn(iamArn string) (*iamEntity, error) {
 	// now, entity.FriendlyName should either be <UserName> or <RoleName>
 	switch entity.Type {
 	case "assumed-role":
+		// Check for three parts for assumed role ARNs
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("unrecognized arn: %q contains fewer than 3 slash-separated parts", fullParts[5])
+		}
 		// Assumed roles don't have paths and have a slightly different format
 		// parts[2] is <RoleSessionName>
 		entity.Path = ""

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -63,7 +63,7 @@ func TestBackend_pathLogin_getCallerIdentityResponse(t *testing.T) {
 }
 
 func TestBackend_pathLogin_parseIamArn(t *testing.T) {
-	testParser := func(t *testing.T, inputArn, expectedCanonicalArn string, expectedEntity iamEntity, expectFail bool) {
+	testParser := func(inputArn, expectedCanonicalArn string, expectedEntity iamEntity) {
 		entity, err := parseIamArn(inputArn)
 		if err != nil {
 			t.Fatal(err)
@@ -76,26 +76,22 @@ func TestBackend_pathLogin_parseIamArn(t *testing.T) {
 		}
 	}
 
-	testParser(t, "arn:aws:iam::123456789012:user/UserPath/MyUserName",
+	testParser("arn:aws:iam::123456789012:user/UserPath/MyUserName",
 		"arn:aws:iam::123456789012:user/MyUserName",
 		iamEntity{Partition: "aws", AccountNumber: "123456789012", Type: "user", Path: "UserPath", FriendlyName: "MyUserName"},
-		false,
 	)
 	canonicalRoleArn := "arn:aws:iam::123456789012:role/RoleName"
-	testParser(t, "arn:aws:sts::123456789012:assumed-role/RoleName/RoleSessionName",
+	testParser("arn:aws:sts::123456789012:assumed-role/RoleName/RoleSessionName",
 		canonicalRoleArn,
 		iamEntity{Partition: "aws", AccountNumber: "123456789012", Type: "assumed-role", FriendlyName: "RoleName", SessionInfo: "RoleSessionName"},
-		false,
 	)
-	testParser(t, "arn:aws:iam::123456789012:role/RolePath/RoleName",
+	testParser("arn:aws:iam::123456789012:role/RolePath/RoleName",
 		canonicalRoleArn,
 		iamEntity{Partition: "aws", AccountNumber: "123456789012", Type: "role", Path: "RolePath", FriendlyName: "RoleName"},
-		false,
 	)
-	testParser(t, "arn:aws:iam::123456789012:instance-profile/profilePath/InstanceProfileName",
+	testParser("arn:aws:iam::123456789012:instance-profile/profilePath/InstanceProfileName",
 		"",
 		iamEntity{Partition: "aws", AccountNumber: "123456789012", Type: "instance-profile", Path: "profilePath", FriendlyName: "InstanceProfileName"},
-		false,
 	)
 
 	// Test that it properly handles pathological inputs...


### PR DESCRIPTION
This PR properly checks for the length on the parts split string for assumed-role ARNs.

/cc: @brianshumate 