### PR TITLE
pin github and netlify providers and fix config

### DIFF
--- a/website/deploy/main.tf
+++ b/website/deploy/main.tf
@@ -13,6 +13,7 @@ GitHub Resources
 
 provider "github" {
   organization = "${local.github_org}"
+  version      = "~>2.0.0"
 }
 
 // Configure the repository with the dynamically created Netlify key.
@@ -26,12 +27,12 @@ resource "github_repository_deploy_key" "key" {
 // Create a webhook that triggers Netlify builds on push.
 resource "github_repository_webhook" "main" {
   repository = "${local.github_repo}"
-  name       = "web"
   events     = ["delete", "push", "pull_request"]
 
   configuration {
     content_type = "json"
     url          = "https://api.netlify.com/hooks/github"
+    insecure_ssl = false
   }
 
   depends_on = ["netlify_site.main"]
@@ -43,11 +44,16 @@ Netlify Resources
 -------------------------------------------------------------------
 */
 
+provider "netlify" {
+  version = "~> 0.1.0"
+}
+
 // A new, unique deploy key for this specific website
 resource "netlify_deploy_key" "key" {}
 
 resource "netlify_site" "main" {
-  name = "${var.name}"
+  name          = "${var.name}"
+  custom_domain = "${var.custom_site_domain}"
 
   repo {
     repo_branch   = "${var.github_branch}"

--- a/website/deploy/variables.tf
+++ b/website/deploy/variables.tf
@@ -1,14 +1,19 @@
 variable "name" {
-  default = "vault-www"
+  default     = "vault-www"
   description = "Name of the website in slug format."
 }
 
 variable "github_repo" {
-  default = "hashicorp/vault"
+  default     = "hashicorp/vault"
   description = "GitHub repository of the provider in 'org/name' format."
 }
 
 variable "github_branch" {
-  default = "stable-website"
+  default     = "stable-website"
   description = "GitHub branch which netlify will continuously deploy."
+}
+
+variable "custom_site_domain" {
+  default     = "www.vaultproject.io"
+  description = "The custom domain to use for the Netlify site."
 }


### PR DESCRIPTION
This PR should fix the Netlify website creation failures we are seeing.

The name argument error we were seeing was due to the GitHub provider not being pinned and as a result, used the 2.0.0 provider version which removed the argument altogether (https://github.com/terraform-providers/terraform-provider-github/blob/master/CHANGELOG.md#200-may-02-2019). This has now been removed from the configuration and there is version pinning to prevent this from happening next time 😄.