### PR TITLE
UI - cross-browser svg scaling fixes

### DIFF
--- a/ui/app/styles/components/hs-icon.scss
+++ b/ui/app/styles/components/hs-icon.scss
@@ -5,6 +5,7 @@
   align-items: flex-start;
   vertical-align: middle;
   width: 16px;
+  height: 16px;
   margin: 2px 4px;
 }
 
@@ -21,16 +22,20 @@
 
 .hs-icon-s {
   width: 12px;
+  height: 12px;
 }
 
 .hs-icon-l {
   width: 20px;
+  height: 20px;
 }
 
 .hs-icon-xl {
   width: 28px;
+  height: 28px;
 }
 
 .hs-icon-xxl {
   width: 32px;
+  height: 32px;
 }

--- a/ui/app/styles/core/message.scss
+++ b/ui/app/styles/core/message.scss
@@ -103,7 +103,6 @@
 
   .hs-icon {
     margin: 0 $spacing-xxs 0 0;
-    min-width: fit-content;
   }
 
   .p {


### PR DESCRIPTION
There were a few cases where the new Icon svgs didn't scale properly across browsers still. 

In FF, the inline one still had content-fit which made the SVG really large. In IE, not specifying a height meant that the container was really tall which pushed out all of the rows and made things look generally bad.
