### PR TITLE
Unify time.Duration handling across framework and parseutil

### DIFF
--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -555,36 +554,11 @@ func (s *FieldSchema) DefaultOrZero() interface{} {
 	if s.Default != nil {
 		switch s.Type {
 		case TypeDurationSecond:
-			var result int
-			switch inp := s.Default.(type) {
-			case nil:
-				return s.Type.Zero()
-			case int:
-				result = inp
-			case int64:
-				result = int(inp)
-			case float32:
-				result = int(inp)
-			case float64:
-				result = int(inp)
-			case string:
-				dur, err := parseutil.ParseDurationSecond(inp)
-				if err != nil {
-					return s.Type.Zero()
-				}
-				result = int(dur.Seconds())
-			case json.Number:
-				valInt64, err := inp.Int64()
-				if err != nil {
-					return s.Type.Zero()
-				}
-				result = int(valInt64)
-			case time.Duration:
-				result = int(inp.Seconds())
-			default:
+			resultDur, err := parseutil.ParseDurationSecond(s.Default)
+			if err != nil {
 				return s.Type.Zero()
 			}
-			return result
+			return int(resultDur.Seconds())
 
 		default:
 			return s.Default

--- a/sdk/framework/field_data.go
+++ b/sdk/framework/field_data.go
@@ -202,36 +202,12 @@ func (d *FieldData) getPrimitive(k string, schema *FieldSchema) (interface{}, bo
 		switch inp := raw.(type) {
 		case nil:
 			return nil, false, nil
-		case int:
-			result = inp
-		case int32:
-			result = int(inp)
-		case int64:
-			result = int(inp)
-		case uint:
-			result = int(inp)
-		case uint32:
-			result = int(inp)
-		case uint64:
-			result = int(inp)
-		case float32:
-			result = int(inp)
-		case float64:
-			result = int(inp)
-		case string:
+		default:
 			dur, err := parseutil.ParseDurationSecond(inp)
 			if err != nil {
 				return nil, false, err
 			}
 			result = int(dur.Seconds())
-		case json.Number:
-			valInt64, err := inp.Int64()
-			if err != nil {
-				return nil, false, err
-			}
-			result = int(valInt64)
-		default:
-			return nil, false, fmt.Errorf("invalid input '%v'", raw)
 		}
 		if result < 0 {
 			return nil, false, fmt.Errorf("cannot provide negative value '%d'", result)

--- a/sdk/helper/parseutil/parseutil.go
+++ b/sdk/helper/parseutil/parseutil.go
@@ -20,11 +20,12 @@ func ParseDurationSecond(in interface{}) (time.Duration, error) {
 	if ok {
 		in = jsonIn.String()
 	}
-	switch in.(type) {
+	switch inp := in.(type) {
+	case nil:
+		// return default of zero
 	case string:
-		inp := in.(string)
 		if inp == "" {
-			return time.Duration(0), nil
+			return dur, nil
 		}
 		var err error
 		// Look for a suffix otherwise its a plain second value
@@ -42,17 +43,23 @@ func ParseDurationSecond(in interface{}) (time.Duration, error) {
 			dur = time.Duration(secs) * time.Second
 		}
 	case int:
-		dur = time.Duration(in.(int)) * time.Second
+		dur = time.Duration(inp) * time.Second
 	case int32:
-		dur = time.Duration(in.(int32)) * time.Second
+		dur = time.Duration(inp) * time.Second
 	case int64:
-		dur = time.Duration(in.(int64)) * time.Second
+		dur = time.Duration(inp) * time.Second
 	case uint:
-		dur = time.Duration(in.(uint)) * time.Second
+		dur = time.Duration(inp) * time.Second
 	case uint32:
-		dur = time.Duration(in.(uint32)) * time.Second
+		dur = time.Duration(inp) * time.Second
 	case uint64:
-		dur = time.Duration(in.(uint64)) * time.Second
+		dur = time.Duration(inp) * time.Second
+	case float32:
+		dur = time.Duration(inp) * time.Second
+	case float64:
+		dur = time.Duration(inp) * time.Second
+	case time.Duration:
+		dur = inp
 	default:
 		return 0, errors.New("could not parse duration from input")
 	}


### PR DESCRIPTION
This removes a lot of duplicated code and adds time.Duration support to
parseutil, needed by the jwt auth method.