### PR TITLE
Combined Database backend: remove create/delete support

### DIFF
--- a/builtin/logical/database/path_roles.go
+++ b/builtin/logical/database/path_roles.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -88,32 +87,6 @@ func fieldsForType(roleType string) map[string]*framework.FieldSchema {
 			Type:        framework.TypeString,
 			Description: "Name of the database this role acts on.",
 		},
-		"creation_statements": {
-			Type: framework.TypeStringSlice,
-			Description: `Specifies the database statements executed to
-	create and configure a user. See the plugin's API page for more
-	information on support and formatting for this parameter.`,
-		},
-		"revocation_statements": {
-			Type: framework.TypeStringSlice,
-			Description: `Specifies the database statements to be executed
-	to revoke a user. See the plugin's API page for more information
-	on support and formatting for this parameter.`,
-		},
-		"renew_statements": {
-			Type: framework.TypeStringSlice,
-			Description: `Specifies the database statements to be executed
-	to renew a user. Not every plugin type will support this
-	functionality. See the plugin's API page for more information on
-	support and formatting for this parameter. `,
-		},
-		"rollback_statements": {
-			Type: framework.TypeStringSlice,
-			Description: `Specifies the database statements to be executed
-	rollback a create operation in the event of an error. Not every plugin
-	type will support this functionality. See the plugin's API page for
-	more information on support and formatting for this parameter.`,
-		},
 	}
 
 	// Get the fields that are specific to the type of role, and add them to the
@@ -141,10 +114,35 @@ func dynamicFields() map[string]*framework.FieldSchema {
 			Type:        framework.TypeDurationSecond,
 			Description: "Default ttl for role.",
 		},
-
 		"max_ttl": {
 			Type:        framework.TypeDurationSecond,
 			Description: "Maximum time a credential is valid for",
+		},
+		"creation_statements": {
+			Type: framework.TypeStringSlice,
+			Description: `Specifies the database statements executed to
+	create and configure a user. See the plugin's API page for more
+	information on support and formatting for this parameter.`,
+		},
+		"revocation_statements": {
+			Type: framework.TypeStringSlice,
+			Description: `Specifies the database statements to be executed
+	to revoke a user. See the plugin's API page for more information
+	on support and formatting for this parameter.`,
+		},
+		"renew_statements": {
+			Type: framework.TypeStringSlice,
+			Description: `Specifies the database statements to be executed
+	to renew a user. Not every plugin type will support this
+	functionality. See the plugin's API page for more information on
+	support and formatting for this parameter. `,
+		},
+		"rollback_statements": {
+			Type: framework.TypeStringSlice,
+			Description: `Specifies the database statements to be executed
+	rollback a create operation in the event of an error. Not every plugin
+	type will support this functionality. See the plugin's API page for
+	more information on support and formatting for this parameter.`,
 		},
 	}
 	return fields
@@ -171,13 +169,6 @@ func staticFields() map[string]*framework.FieldSchema {
 	rotate the accounts credentials. Not every plugin type will support
 	this functionality. See the plugin's API page for more information on
 	support and formatting for this parameter.`,
-		},
-		"revoke_user_on_delete": {
-			Type:    framework.TypeBool,
-			Default: false,
-			Description: `Revoke the database user identified by the username when
-	this Role is deleted. Revocation will use the configured
-	revocation_statements if provided. Default false.`,
 		},
 	}
 	return fields
@@ -219,34 +210,7 @@ func (b *databaseBackend) pathStaticRoleDelete(ctx context.Context, req *logical
 	// Remove the item from the queue
 	_, _ = b.popFromRotationQueueByKey(name)
 
-	// If this role is a static account, we need to revoke the user from the
-	// database
-	role, err := b.StaticRole(ctx, req.Storage, name)
-	if err != nil {
-		return nil, err
-	}
-	if role == nil {
-		return nil, nil
-	}
-
-	// Clean up the static useraccount, if it exists
-	revoke := role.StaticAccount.RevokeUserOnDelete
-	if revoke {
-		db, err := b.GetConnection(ctx, req.Storage, role.DBName)
-		if err != nil {
-			return nil, err
-		}
-
-		db.RLock()
-		defer db.RUnlock()
-
-		if err := db.RevokeUser(ctx, role.Statements, role.StaticAccount.Username); err != nil {
-			b.CloseIfShutdown(db, err)
-			return nil, err
-		}
-	}
-
-	err = req.Storage.Delete(ctx, databaseStaticRolePath+name)
+	err := req.Storage.Delete(ctx, databaseStaticRolePath+name)
 	if err != nil {
 		return nil, err
 	}
@@ -262,14 +226,19 @@ func (b *databaseBackend) pathStaticRoleRead(ctx context.Context, req *logical.R
 	if role == nil {
 		return nil, nil
 	}
-	data := pathRoleReadCommon(role)
+
+	data := map[string]interface{}{
+		"db_name":             role.DBName,
+		"rotation_statements": role.Statements.Rotation,
+	}
+
+	// guard against nil StaticAccount; shouldn't happen but we'll be safe
 	if role.StaticAccount != nil {
 		data["username"] = role.StaticAccount.Username
 		data["rotation_period"] = role.StaticAccount.RotationPeriod.Seconds()
 		if !role.StaticAccount.LastVaultRotation.IsZero() {
 			data["last_vault_rotation"] = role.StaticAccount.LastVaultRotation
 		}
-		data["revoke_user_on_delete"] = role.StaticAccount.RevokeUserOnDelete
 	}
 
 	return &logical.Response{
@@ -286,12 +255,6 @@ func (b *databaseBackend) pathRoleRead(ctx context.Context, req *logical.Request
 		return nil, nil
 	}
 
-	return &logical.Response{
-		Data: pathRoleReadCommon(role),
-	}, nil
-}
-
-func pathRoleReadCommon(role *roleEntry) map[string]interface{} {
 	data := map[string]interface{}{
 		"db_name":               role.DBName,
 		"creation_statements":   role.Statements.Creation,
@@ -317,7 +280,10 @@ func pathRoleReadCommon(role *roleEntry) map[string]interface{} {
 	if len(role.Statements.Rotation) == 0 {
 		data["rotation_statements"] = []string{}
 	}
-	return data
+
+	return &logical.Response{
+		Data: data,
+	}, nil
 }
 
 func (b *databaseBackend) pathRoleList(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
@@ -355,20 +321,65 @@ func (b *databaseBackend) pathRoleCreateUpdate(ctx context.Context, req *logical
 		role = &roleEntry{}
 	}
 
-	if err := pathRoleCreateUpdateCommon(ctx, role, req.Operation, data); err != nil {
-		return logical.ErrorResponse(err.Error()), nil
+	createOperation := (req.Operation == logical.CreateOperation)
+
+	// DB Attributes
+	{
+		if dbNameRaw, ok := data.GetOk("db_name"); ok {
+			role.DBName = dbNameRaw.(string)
+		} else if createOperation {
+			role.DBName = data.Get("db_name").(string)
+		}
+		if role.DBName == "" {
+			return logical.ErrorResponse("database name is required"), nil
+		}
 	}
+
+	// Statements
+	{
+		if creationStmtsRaw, ok := data.GetOk("creation_statements"); ok {
+			role.Statements.Creation = creationStmtsRaw.([]string)
+		} else if createOperation {
+			role.Statements.Creation = data.Get("creation_statements").([]string)
+		}
+
+		if revocationStmtsRaw, ok := data.GetOk("revocation_statements"); ok {
+			role.Statements.Revocation = revocationStmtsRaw.([]string)
+		} else if createOperation {
+			role.Statements.Revocation = data.Get("revocation_statements").([]string)
+		}
+
+		if rollbackStmtsRaw, ok := data.GetOk("rollback_statements"); ok {
+			role.Statements.Rollback = rollbackStmtsRaw.([]string)
+		} else if createOperation {
+			role.Statements.Rollback = data.Get("rollback_statements").([]string)
+		}
+
+		if renewStmtsRaw, ok := data.GetOk("renew_statements"); ok {
+			role.Statements.Renewal = renewStmtsRaw.([]string)
+		} else if createOperation {
+			role.Statements.Renewal = data.Get("renew_statements").([]string)
+		}
+
+		// Do not persist deprecated statements that are populated on role read
+		role.Statements.CreationStatements = ""
+		role.Statements.RevocationStatements = ""
+		role.Statements.RenewStatements = ""
+		role.Statements.RollbackStatements = ""
+	}
+
+	role.Statements.Revocation = strutil.RemoveEmpty(role.Statements.Revocation)
 
 	// TTLs
 	{
 		if defaultTTLRaw, ok := data.GetOk("default_ttl"); ok {
 			role.DefaultTTL = time.Duration(defaultTTLRaw.(int)) * time.Second
-		} else if req.Operation == logical.CreateOperation {
+		} else if createOperation {
 			role.DefaultTTL = time.Duration(data.Get("default_ttl").(int)) * time.Second
 		}
 		if maxTTLRaw, ok := data.GetOk("max_ttl"); ok {
 			role.MaxTTL = time.Duration(maxTTLRaw.(int)) * time.Second
-		} else if req.Operation == logical.CreateOperation {
+		} else if createOperation {
 			role.MaxTTL = time.Duration(data.Get("max_ttl").(int)) * time.Second
 		}
 	}
@@ -422,8 +433,15 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 		createRole = true
 	}
 
-	if err := pathRoleCreateUpdateCommon(ctx, role, req.Operation, data); err != nil {
-		return logical.ErrorResponse(err.Error()), nil
+	// DB Attributes
+	if dbNameRaw, ok := data.GetOk("db_name"); ok {
+		role.DBName = dbNameRaw.(string)
+	} else if createRole {
+		role.DBName = data.Get("db_name").(string)
+	}
+
+	if role.DBName == "" {
+		return logical.ErrorResponse("database name is a required field"), nil
 	}
 
 	username := data.Get("username").(string)
@@ -457,8 +475,6 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 	} else if req.Operation == logical.CreateOperation {
 		role.Statements.Rotation = data.Get("rotation_statements").([]string)
 	}
-
-	role.StaticAccount.RevokeUserOnDelete = data.Get("revoke_user_on_delete").(bool)
 
 	// lvr represents the roles' LastVaultRotation
 	lvr := role.StaticAccount.LastVaultRotation
@@ -502,57 +518,6 @@ func (b *databaseBackend) pathStaticRoleCreateUpdate(ctx context.Context, req *l
 	}
 
 	return nil, nil
-}
-
-func pathRoleCreateUpdateCommon(ctx context.Context, role *roleEntry, operation logical.Operation, data *framework.FieldData) error {
-	// DB Attributes
-	{
-		if dbNameRaw, ok := data.GetOk("db_name"); ok {
-			role.DBName = dbNameRaw.(string)
-		} else if operation == logical.CreateOperation {
-			role.DBName = data.Get("db_name").(string)
-		}
-		if role.DBName == "" {
-			return errors.New("empty database name attribute")
-		}
-	}
-
-	// Statements
-	{
-		if creationStmtsRaw, ok := data.GetOk("creation_statements"); ok {
-			role.Statements.Creation = creationStmtsRaw.([]string)
-		} else if operation == logical.CreateOperation {
-			role.Statements.Creation = data.Get("creation_statements").([]string)
-		}
-
-		if revocationStmtsRaw, ok := data.GetOk("revocation_statements"); ok {
-			role.Statements.Revocation = revocationStmtsRaw.([]string)
-		} else if operation == logical.CreateOperation {
-			role.Statements.Revocation = data.Get("revocation_statements").([]string)
-		}
-
-		if rollbackStmtsRaw, ok := data.GetOk("rollback_statements"); ok {
-			role.Statements.Rollback = rollbackStmtsRaw.([]string)
-		} else if operation == logical.CreateOperation {
-			role.Statements.Rollback = data.Get("rollback_statements").([]string)
-		}
-
-		if renewStmtsRaw, ok := data.GetOk("renew_statements"); ok {
-			role.Statements.Renewal = renewStmtsRaw.([]string)
-		} else if operation == logical.CreateOperation {
-			role.Statements.Renewal = data.Get("renew_statements").([]string)
-		}
-
-		// Do not persist deprecated statements that are populated on role read
-		role.Statements.CreationStatements = ""
-		role.Statements.RevocationStatements = ""
-		role.Statements.RenewStatements = ""
-		role.Statements.RollbackStatements = ""
-	}
-
-	role.Statements.Revocation = strutil.RemoveEmpty(role.Statements.Revocation)
-
-	return nil
 }
 
 type roleEntry struct {

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -62,17 +62,17 @@ func TestBackend_StaticRole_Config(t *testing.T) {
 	}{
 		"basic": {
 			account: map[string]interface{}{
-				"username":        "statictest",
+				"username":        dbUser,
 				"rotation_period": "5400s",
 			},
 			expected: map[string]interface{}{
-				"username":        "statictest",
+				"username":        dbUser,
 				"rotation_period": float64(5400),
 			},
 		},
 		"missing rotation period": {
 			account: map[string]interface{}{
-				"username": "statictest",
+				"username": dbUser,
 			},
 			err: errors.New("rotation_period is required to create static accounts"),
 		},
@@ -81,13 +81,9 @@ func TestBackend_StaticRole_Config(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			data := map[string]interface{}{
-				"name":                  "plugin-role-test",
-				"db_name":               "plugin-test",
-				"creation_statements":   testRoleStaticCreate,
-				"rotation_statements":   testRoleStaticUpdate,
-				"revocation_statements": defaultRevocationSQL,
-				"default_ttl":           "5m",
-				"max_ttl":               "10m",
+				"name":                "plugin-role-test",
+				"db_name":             "plugin-test",
+				"rotation_statements": testRoleStaticUpdate,
 			}
 
 			for k, v := range tc.account {
@@ -226,15 +222,11 @@ func TestBackend_StaticRole_Updates(t *testing.T) {
 	}
 
 	data = map[string]interface{}{
-		"name":                  "plugin-role-test-updates",
-		"db_name":               "plugin-test",
-		"creation_statements":   testRoleStaticCreate,
-		"rotation_statements":   testRoleStaticUpdate,
-		"revocation_statements": defaultRevocationSQL,
-		"default_ttl":           "5m",
-		"max_ttl":               "10m",
-		"username":              "statictest",
-		"rotation_period":       "5400s",
+		"name":                "plugin-role-test-updates",
+		"db_name":             "plugin-test",
+		"rotation_statements": testRoleStaticUpdate,
+		"username":            dbUser,
+		"rotation_period":     "5400s",
 	}
 
 	req = &logical.Request{
@@ -285,7 +277,7 @@ func TestBackend_StaticRole_Updates(t *testing.T) {
 	updateData := map[string]interface{}{
 		"name":            "plugin-role-test-updates",
 		"db_name":         "plugin-test",
-		"username":        "statictest",
+		"username":        dbUser,
 		"rotation_period": "6400s",
 	}
 	req = &logical.Request{
@@ -340,7 +332,7 @@ func TestBackend_StaticRole_Updates(t *testing.T) {
 	updateData = map[string]interface{}{
 		"name":                "plugin-role-test-updates",
 		"db_name":             "plugin-test",
-		"username":            "statictest",
+		"username":            dbUser,
 		"rotation_statements": testRoleStaticUpdateRotation,
 	}
 	req = &logical.Request{
@@ -514,7 +506,6 @@ const testRoleStaticCreate = `
 CREATE ROLE "{{name}}" WITH
   LOGIN
   PASSWORD '{{password}}';
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO "{{name}}";
 `
 
 const testRoleStaticUpdate = `

--- a/builtin/logical/database/path_roles_test.go
+++ b/builtin/logical/database/path_roles_test.go
@@ -34,6 +34,9 @@ func TestBackend_StaticRole_Config(t *testing.T) {
 	cleanup, connURL := preparePostgresTestContainer(t, config.StorageView, b)
 	defer cleanup()
 
+	// create the database user
+	createTestPGUser(t, connURL, dbUser, "password", testRoleStaticCreate)
+
 	// Configure a connection
 	data := map[string]interface{}{
 		"connection_url":    connURL,
@@ -200,6 +203,9 @@ func TestBackend_StaticRole_Updates(t *testing.T) {
 
 	cleanup, connURL := preparePostgresTestContainer(t, config.StorageView, b)
 	defer cleanup()
+
+	// create the database user
+	createTestPGUser(t, connURL, dbUser, "password", testRoleStaticCreate)
 
 	// Configure a connection
 	data := map[string]interface{}{
@@ -391,6 +397,9 @@ func TestBackend_StaticRole_Role_name_check(t *testing.T) {
 	cleanup, connURL := preparePostgresTestContainer(t, config.StorageView, b)
 	defer cleanup()
 
+	// create the database user
+	createTestPGUser(t, connURL, dbUser, "password", testRoleStaticCreate)
+
 	// Configure a connection
 	data := map[string]interface{}{
 		"connection_url":    connURL,
@@ -458,13 +467,11 @@ func TestBackend_StaticRole_Role_name_check(t *testing.T) {
 
 	// repeat, with a static role first
 	data = map[string]interface{}{
-		"name":                  "plugin-role-test-2",
-		"db_name":               "plugin-test",
-		"creation_statements":   testRoleStaticCreate,
-		"rotation_statements":   testRoleStaticUpdate,
-		"revocation_statements": defaultRevocationSQL,
-		"username":              "testusername",
-		"rotation_period":       "1h",
+		"name":                "plugin-role-test-2",
+		"db_name":             "plugin-test",
+		"rotation_statements": testRoleStaticUpdate,
+		"username":            dbUser,
+		"rotation_period":     "1h",
 	}
 
 	req = &logical.Request{

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -106,7 +106,7 @@ func TestBackend_StaticRole_Rotate_basic(t *testing.T) {
 	}
 
 	// Verify username/password
-	verifyPgConn(t, dbUser, "password", connURL)
+	verifyPgConn(t, dbUser, password, connURL)
 
 	// Re-read the creds, verifying they aren't changing on read
 	data = map[string]interface{}{}
@@ -187,6 +187,9 @@ func TestBackend_StaticRole_Rotate_NonStaticError(t *testing.T) {
 
 	cleanup, connURL := preparePostgresTestContainer(t, config.StorageView, b)
 	defer cleanup()
+
+	// create the database user
+	createTestPGUser(t, connURL, dbUser, "password", testRoleStaticCreate)
 
 	// Configure a connection
 	data := map[string]interface{}{
@@ -288,6 +291,9 @@ func TestBackend_StaticRole_Revoke_user(t *testing.T) {
 
 	cleanup, connURL := preparePostgresTestContainer(t, config.StorageView, b)
 	defer cleanup()
+
+	// create the database user
+	createTestPGUser(t, connURL, dbUser, "password", testRoleStaticCreate)
 
 	// Configure a connection
 	data := map[string]interface{}{
@@ -510,6 +516,9 @@ func TestBackend_Static_QueueWAL_discard_role_newer_rotation_date(t *testing.T) 
 
 	cleanup, connURL := preparePostgresTestContainer(t, config.StorageView, b)
 	defer cleanup()
+
+	// create the database user
+	createTestPGUser(t, connURL, dbUser, "password", testRoleStaticCreate)
 
 	// Configure a connection
 	data := map[string]interface{}{

--- a/website/source/api/secret/databases/index.html.md
+++ b/website/source/api/secret/databases/index.html.md
@@ -425,34 +425,10 @@ Static Roles, please see the database-specific documentation.
 - `db_name` `(string: <required>)` - The name of the database connection to use
   for this role.
 
-- `creation_statements` `(list: <required>)` – Specifies the database
-  statements executed to create and configure a user. See the plugin's API page
-  for more information on support and formatting for this parameter.
-
-- `revocation_statements` `(list: [])` – Specifies the database statements to
-  be executed to revoke a user. See the plugin's API page for more information
-  on support and formatting for this parameter.
-
-- `rollback_statements` `(list: [])` – Specifies the database statements to be
-  executed rollback a create operation in the event of an error. Not every
-  plugin type will support this functionality. See the plugin's API page for
-  more information on support and formatting for this parameter.
-
-- `renew_statements` `(list: [])` – Specifies the database statements to be
-  executed to renew a user. Not every plugin type will support this
-  functionality. See the plugin's API page for more information on support and
-  formatting for this parameter.
-
 - `rotation_statements` `(list: [])` – Specifies the database statements to be
   executed to rotate the password for the configured database user. Not every
   plugin type will support this functionality. See the plugin's API page for
   more information on support and formatting for this parameter.
-
-- `revoke_user_on_delete` `(boolean: false)` – Specifies if Vault should attempt
-  to revoke the database user associated with this static role, indicated by the
-  `username`. If `true`, when Vault deletes this Role it will attempt to revoke
-  the database user using the configured `revocation_statements` if they exist.
-  Default `false`
 
 
 
@@ -462,7 +438,6 @@ Static Roles, please see the database-specific documentation.
 {
     "db_name": "mysql",
     "username": "static-database-user",
-    "creation_statements": ["CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}'", "GRANT SELECT ON *.* TO '{{name}}'@'%'"],
     "rotation_statements": ["ALTER USER "{{name}}" WITH PASSWORD '{{password}}';"],
     "rotation_period": "1h"
 }
@@ -506,13 +481,8 @@ $ curl \
     "data": {
 		"db_name": "mysql",
     "username":"static-user",
-		"creation_statements": ["CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';"], "GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";"],
     "rotation_statements": ["ALTER USER "{{name}}" WITH PASSWORD '{{password}}';"],
     "rotation_period":"1h",
-		"renew_statements": [],
-		"revocation_statements": [],
-		"rollback_statements": []
-		"revoke_user_on_delete": false,
 	},
 }
 ```


### PR DESCRIPTION
After https://github.com/hashicorp/vault/pull/6834 was merged we decided to remove the support for creating or deleting database users with the new Static Roles feature. Instead, Vault requires the database user already exist at the time the Static Role is created, and continue to exist for the duration that Vault will manage password rotation. When destroying the Static Role in Vault, we will no longer offer or attempt to also delete the database user. We felt that the core purpose / benefit of this feature is to automate password rotation, and as such we should not cross over the boundary into managing the existence of the database user as well. 

This PR removes all database statement fields except `rotation_statements`, as well as the optional toggle to delete the database user, from the Static Role configuration. 

Misc. details:

- refactored out some of the "common" methods like `pathRoleReadCommon`. Static Roles no longer have any statements other than `rotation_statements`, so the common methods seemed superfluous. 
- refactored tests to always create the database user in advance
- refactored some tests that used to check for database user being created or removed, since Static Roles no longer do that
- refactored the PostgreSQL implementation to only reference the rotation statements 