### PR TITLE
Allow configuration of nonce for ec2 authentication

### DIFF
--- a/command/agent/auth/aws/aws.go
+++ b/command/agent/auth/aws/aws.go
@@ -155,6 +155,14 @@ func NewAWSAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 		a.lastCreds = creds
 
 		go a.pollForCreds(accessKey, secretKey, sessionToken, credentialPollIntervalSec)
+	} else {
+		nonceRaw, ok := conf.Config["nonce"]
+		if ok {
+			a.nonce, ok = nonceRaw.(string)
+			if !ok {
+				return nil, errors.New("could not convert 'nonce' value into string")
+			}
+		}
 	}
 
 	return a, nil

--- a/command/agent/auth/aws/aws.go
+++ b/command/agent/auth/aws/aws.go
@@ -134,6 +134,14 @@ func NewAWSAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 		}
 	}
 
+	nonceRaw, ok := conf.Config["nonce"]
+	if ok {
+		a.nonce, ok = nonceRaw.(string)
+		if !ok {
+			return nil, errors.New("could not convert 'nonce' value into string")
+		}
+	}
+
 	if a.authType == typeIAM {
 
 		// Check for an optional custom frequency at which we should poll for creds.
@@ -155,14 +163,6 @@ func NewAWSAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 		a.lastCreds = creds
 
 		go a.pollForCreds(accessKey, secretKey, sessionToken, credentialPollIntervalSec)
-	} else {
-		nonceRaw, ok := conf.Config["nonce"]
-		if ok {
-			a.nonce, ok = nonceRaw.(string)
-			if !ok {
-				return nil, errors.New("could not convert 'nonce' value into string")
-			}
-		}
 	}
 
 	return a, nil


### PR DESCRIPTION
I'd like to be able to specify a nonce in the agent configuration file. Without this option, the agent cannot reauthenticate when the service/server restarts. I realize that I could allow reauthentication without the nonce, but that raises security concerns. Any user on the box on then authenticate as the server. Preventing this is my main reason for using ec2 authentication rather than IAM. By limiting access to the agent configuration file, I can limit access to root. 