### PR TITLE
Cert auth method examples need to use https

### DIFF
--- a/website/source/api/auth/cert/index.html.md
+++ b/website/source/api/auth/cert/index.html.md
@@ -362,7 +362,7 @@ https://tools.ietf.org/html/rfc6125#section-2.3)
 $ curl \
     --request POST \
     --data @payload.json \
-    http://127.0.0.1:8200/v1/auth/cert/login
+    https://127.0.0.1:8200/v1/auth/cert/login
 ```
 
 ### Sample Response

--- a/website/source/docs/auth/cert.html.md
+++ b/website/source/docs/auth/cert.html.md
@@ -91,7 +91,7 @@ $ curl \
     --cert cert.pem \
     --key key.pem \
     --data '{"name": "web"}' \
-    http://127.0.0.1:8200/v1/auth/cert/login
+    https://127.0.0.1:8200/v1/auth/cert/login
 ```
 
 ## Configuration


### PR DESCRIPTION
In order to present a client certificate to use the certificate
auth method, you must use https.