### PR TITLE
Set MaxIdleConns to reduce connection churn (postgresql physical)

### DIFF
--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -114,13 +114,28 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 		maxParInt = physical.DefaultParallelOperations
 	}
 
+	maxIdleConnsStr, maxIdleConnsIsSet := conf["max_idle_connections"]
+	var maxIdleConns int
+	if maxIdleConnsIsSet {
+		maxIdleConns, err = strconv.Atoi(maxIdleConnsStr)
+		if err != nil {
+			return nil, errwrap.Wrapf("failed parsing max_idle_connections parameter: {{err}}", err)
+		}
+		if logger.IsDebug() {
+			logger.Debug("max_idle_connections set", "max_idle_connections", maxIdleConnsStr)
+		}
+	}
+
 	// Create PostgreSQL handle for the database.
 	db, err := sql.Open("postgres", connURL)
 	if err != nil {
 		return nil, errwrap.Wrapf("failed to connect to postgres: {{err}}", err)
 	}
 	db.SetMaxOpenConns(maxParInt)
-	db.SetMaxIdleConns(maxParInt)
+
+	if maxIdleConnsIsSet {
+		db.SetMaxIdleConns(maxIdleConns)
+	}
 
 	// Determine if we should use a function to work around lack of upsert (versions < 9.5)
 	var upsertAvailable bool

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -120,6 +120,7 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 		return nil, errwrap.Wrapf("failed to connect to postgres: {{err}}", err)
 	}
 	db.SetMaxOpenConns(maxParInt)
+	db.SetMaxIdleConns(maxParInt)
 
 	// Determine if we should use a function to work around lack of upsert (versions < 9.5)
 	var upsertAvailable bool

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -100,6 +100,20 @@ func TestPostgreSQLBackend(t *testing.T) {
 	}
 }
 
+func TestPostgreSQLBackendMaxIdleConnectionsParameter(t *testing.T) {
+	_, err := NewPostgreSQLBackend(map[string]string{
+		"connection_url":       "some connection url",
+		"max_idle_connections": "bad param",
+	}, logging.NewVaultLogger(log.Debug))
+	if err == nil {
+		t.Error("Expected invalid max_idle_connections param to return error")
+	}
+	expectedErrStr := "failed parsing max_idle_connections parameter: strconv.Atoi: parsing \"bad param\": invalid syntax"
+	if err.Error() != expectedErrStr {
+		t.Errorf("Expected: \"%s\" but found \"%s\"", expectedErrStr, err.Error())
+	}
+}
+
 // Similar to testHABackend, but using internal implementation details to
 // trigger the lock failure scenario by setting the lock renew period for one
 // of the locks to a higher value than the lock TTL.

--- a/website/source/docs/configuration/storage/postgresql.html.md
+++ b/website/source/docs/configuration/storage/postgresql.html.md
@@ -96,6 +96,10 @@ LANGUAGE plpgsql;
   which to write Vault data. This table must already exist (Vault will not
   attempt to create it).
 
+- `max_idle_connections` `(int)` - Default not set. Sets the maximum number of 
+  connections in the idle connection pool. See
+  [golang docs on SetMaxIdleConns][golang_SetMaxIdleConns] for more information.
+
 - `max_parallel` `(string: "128")` – Specifies the maximum number of concurrent
   requests to PostgreSQL.
 
@@ -123,5 +127,6 @@ storage "postgresql" {
 }
 ```
 
+[golang_SetMaxIdleConns]: https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
 [postgresql]: https://www.postgresql.org/
 [pglib]: https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters

--- a/website/source/docs/configuration/storage/postgresql.html.md
+++ b/website/source/docs/configuration/storage/postgresql.html.md
@@ -98,7 +98,8 @@ LANGUAGE plpgsql;
 
 - `max_idle_connections` `(int)` - Default not set. Sets the maximum number of 
   connections in the idle connection pool. See
-  [golang docs on SetMaxIdleConns][golang_SetMaxIdleConns] for more information.
+  [golang docs on SetMaxIdleConns][golang_SetMaxIdleConns] for more information. 
+  Requires 1.2 or later.
 
 - `max_parallel` `(string: "128")` – Specifies the maximum number of concurrent
   requests to PostgreSQL.


### PR DESCRIPTION
Our system runs under fairly heavy load. Bursting up to several thousand requests per second. I noticed that the `db.SetMaxIdleConns` param had not been configured for the physical postgresql backend, but had been configured for the logical backend. Seems like both should be using this param. Btw, I should admit at this point that I'm not very familiar with the vault internals.

I discovered heavy connection churn while observing our pgbouncer logs. In a 24 hours period we had nearly 6 million connections open/closed. I think it would be more appropriate to keep those connections open for more efficient use later, especially since max parallel is explicitly set. Without max idle connections, db connections will be closed when left idle for a short period of time.

Let me know if I need to add anything! Thank you!