### PR TITLE
UI: Add HTTP Requests Bar Chart Tooltip

### DIFF
--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -158,8 +158,9 @@ export default Component.extend({
 
     bars.exit().remove();
 
-    // render transparent bars and bind the tooltip to them
-    // since we cannot bind the tooltip to the actual bars
+    // render transparent bars and bind the tooltip to them since we cannot
+    // bind the tooltip to the actual bars. this is because the bars are
+    // within a clipPath & you cannot bind DOM events to non-display elements.
     const shadowBarsContainer = d3.select('.shadow-bars');
 
     const shadowBars = shadowBarsContainer.selectAll('.bar').data(parsedCounters, c => +c.start_time);

--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -93,7 +93,7 @@ export default Component.extend({
   updateActiveDatum() {},
 
   renderBarChart() {
-    const { margin, padding, width, xScale, yScale, parsedCounters } = this;
+    const { margin, width, xScale, yScale, parsedCounters } = this;
     const height = this.height();
     const barChartSVG = d3.select('.http-requests-bar-chart');
     const barsContainer = d3.select('#bars-container');
@@ -105,7 +105,7 @@ export default Component.extend({
       .html(function(d) {
         return `
           <p>${formatDate(d.start_time, 'MMMM YYYY')}</p>
-          <p>${d.total}</p>
+          <p>${Intl.NumberFormat().format(d.total)} Requests</p>
         `;
       });
 

--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -105,8 +105,9 @@ export default Component.extend({
       .attr('class', 'd3-tooltip')
       .offset([HOVER_PADDING / 2, 0])
       .html(function(d) {
+        const formatter = d3TimeFormat.utcFormat('%B %Y');
         return `
-          <p>${formatDate(d.start_time, 'MMMM YYYY')}</p>
+          <p class="date">${formatter(d.start_time)}</p>
           <p>${Intl.NumberFormat().format(d.total)} Requests</p>
         `;
       });
@@ -166,6 +167,7 @@ export default Component.extend({
     bars.exit().remove();
 
     // render transparent bars and bind the tooltip to them
+    // since we cannot bind the tooltip to the actual bars
     const shadowBarsContainer = d3.select('.shadow-bars');
 
     const shadowBars = shadowBarsContainer.selectAll('.bar').data(parsedCounters, c => +c.start_time);

--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -29,19 +29,13 @@ import formatDate from 'date-fns/format';
  * ]
  */
 
-const COUNTERS = [
-  { start_time: '2019-04-01T00:00:00Z', total: 5500 },
-  { start_time: '2019-05-01T00:00:00Z', total: 4500 },
-  { start_time: '2019-06-01T00:00:00Z', total: 5000 },
-];
-
 const HEIGHT = 240;
 
 const HOVER_PADDING = 12;
 
 export default Component.extend({
   classNames: ['http-requests-bar-chart-container'],
-  counters: COUNTERS,
+  counters: null,
   margin: { top: 24, right: 16, bottom: 24, left: 16 },
   padding: 0.04,
   width: 0,
@@ -91,8 +85,6 @@ export default Component.extend({
       this.renderBarChart();
     });
   },
-
-  updateActiveDatum() {},
 
   renderBarChart() {
     const { margin, width, xScale, yScale, parsedCounters } = this;

--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -37,6 +37,8 @@ const COUNTERS = [
 
 const HEIGHT = 240;
 
+const HOVER_PADDING = 12;
+
 export default Component.extend({
   classNames: ['http-requests-bar-chart-container'],
   counters: COUNTERS,
@@ -101,7 +103,7 @@ export default Component.extend({
     // initialize the tooltip
     const tip = d3Tip()
       .attr('class', 'd3-tooltip')
-      .offset([-10, 0])
+      .offset([HOVER_PADDING / 2, 0])
       .html(function(d) {
         return `
           <p>${formatDate(d.start_time, 'MMMM YYYY')}</p>
@@ -178,9 +180,9 @@ export default Component.extend({
     shadowBars
       .merge(shadowBarsEnter)
       .attr('width', xScale.bandwidth())
-      .attr('height', counter => height - yScale(counter.total))
+      .attr('height', counter => height - yScale(counter.total) + HOVER_PADDING)
       .attr('x', counter => xScale(counter.start_time))
-      .attr('y', counter => yScale(counter.total))
+      .attr('y', counter => yScale(counter.total) - HOVER_PADDING)
       .attr('fill', 'transparent')
       .attr('stroke', 'transparent');
 

--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -4,7 +4,6 @@ import d3Scale from 'd3-scale';
 import d3Axis from 'd3-axis';
 import d3TimeFormat from 'd3-time-format';
 import d3Tip from 'd3-tip';
-import d3Array from 'd3-array';
 import { assign } from '@ember/polyfills';
 import { computed } from '@ember/object';
 import { run } from '@ember/runloop';

--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -8,7 +8,6 @@ import { assign } from '@ember/polyfills';
 import { computed } from '@ember/object';
 import { run } from '@ember/runloop';
 import { task, waitForEvent } from 'ember-concurrency';
-import formatDate from 'date-fns/format';
 
 /**
  * @module HttpRequestsBarChart
@@ -29,7 +28,6 @@ import formatDate from 'date-fns/format';
  */
 
 const HEIGHT = 240;
-
 const HOVER_PADDING = 12;
 
 export default Component.extend({
@@ -86,10 +84,10 @@ export default Component.extend({
   },
 
   renderBarChart() {
-    const { margin, width, xScale, yScale, parsedCounters } = this;
+    const { margin, width, xScale, yScale, parsedCounters, elementId } = this;
     const height = this.height();
     const barChartSVG = d3.select('.http-requests-bar-chart');
-    const barsContainer = d3.select('#bars-container');
+    const barsContainer = d3.select(`#bars-container-${elementId}`);
 
     // initialize the tooltip
     const tip = d3Tip()

--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -9,6 +9,7 @@ import { assign } from '@ember/polyfills';
 import { computed } from '@ember/object';
 import { run } from '@ember/runloop';
 import { task, waitForEvent } from 'ember-concurrency';
+import formatDate from 'date-fns/format';
 
 /**
  * @module HttpRequestsBarChart
@@ -114,7 +115,10 @@ export default Component.extend({
           return '';
         } else {
           const val = yScale.domain()[index];
-          return `<p>${parsedCounters[index].total}</p>`;
+          return `
+            <p>${formatDate(parsedCounters[index].start_time, 'MMMM YYYY')}</p>
+            <p>${parsedCounters[index].total}</p>
+            `;
         }
       });
 

--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -92,7 +92,7 @@ export default Component.extend({
   updateActiveDatum() {},
 
   renderBarChart() {
-    const { margin, width, xScale, yScale, parsedCounters } = this;
+    const { margin, padding, width, xScale, yScale, parsedCounters } = this;
     const height = this.height();
     const barChartSVG = d3.select('.http-requests-bar-chart');
     const barsContainer = d3.select('#bars-container');
@@ -107,11 +107,15 @@ export default Component.extend({
         const mouseXCoord = d3.mouse(this)[0];
         const eachBand = xScale.step();
         const index = Math.floor(mouseXCoord / eachBand);
-        const val = yScale.domain()[index];
-        console.log(parsedCounters);
-        console.log(mouseXCoord);
-        // debugger;
-        return `<p>${parsedCounters[index].total}</p>`;
+        const xWithinBand = mouseXCoord % eachBand;
+        const isWithinMargin = xWithinBand < eachBand * padding;
+
+        if (isWithinMargin) {
+          return '';
+        } else {
+          const val = yScale.domain()[index];
+          return `<p>${parsedCounters[index].total}</p>`;
+        }
       });
 
     barChartSVG.call(tip);

--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -33,7 +33,7 @@ const HOVER_PADDING = 12;
 export default Component.extend({
   classNames: ['http-requests-bar-chart-container'],
   counters: null,
-  margin: { top: 24, right: 16, bottom: 24, left: 16 },
+  margin: Object.freeze({ top: 24, right: 16, bottom: 24, left: 16 }),
   padding: 0.04,
   width: 0,
   height() {

--- a/ui/app/styles/components/http-requests-bar-chart.scss
+++ b/ui/app/styles/components/http-requests-bar-chart.scss
@@ -38,7 +38,7 @@
   }
 }
 
-.d3-tip {
+.d3-tooltip {
   line-height: 1;
   font-weight: bold;
   padding: 12px;
@@ -48,7 +48,7 @@
 }
 
 /* Creates a small triangle extender for the tooltip */
-.d3-tip:after {
+.d3-tooltip:after {
   box-sizing: border-box;
   display: inline;
   font-size: 10px;
@@ -61,7 +61,7 @@
 }
 
 /* Style northward tooltips differently */
-.d3-tip.n:after {
+.d3-tooltip.n:after {
   margin: -1px 0 0 0;
   top: 100%;
   left: 0;

--- a/ui/app/styles/components/http-requests-bar-chart.scss
+++ b/ui/app/styles/components/http-requests-bar-chart.scss
@@ -47,7 +47,7 @@
 }
 
 /* Creates a small triangle extender for the tooltip */
-.d3-tooltip:after {
+.d3-tooltip::after {
   box-sizing: border-box;
   display: inline;
   font-size: 10px;
@@ -59,8 +59,8 @@
 }
 
 /* Style northward tooltips differently */
-.d3-tooltip.n:after {
-  margin: -4px 0 0 0;
+.d3-tooltip.n::after {
+  margin-top: -4px;
   top: 100%;
   left: 0;
 }

--- a/ui/app/styles/components/http-requests-bar-chart.scss
+++ b/ui/app/styles/components/http-requests-bar-chart.scss
@@ -39,11 +39,10 @@
 }
 
 .d3-tooltip {
-  line-height: 1;
-  font-weight: bold;
-  padding: 12px;
-  background: rgba(0, 0, 0, 0.8);
-  color: #fff;
+  line-height: 1.25;
+  padding: $spacing-s;
+  background: $grey;
+  color: $ui-gray-010;
   border-radius: 2px;
 }
 
@@ -53,8 +52,7 @@
   display: inline;
   font-size: 10px;
   width: 100%;
-  line-height: 1;
-  color: rgba(0, 0, 0, 0.8);
+  color: $grey;
   content: '\25BC';
   position: absolute;
   text-align: center;
@@ -62,7 +60,7 @@
 
 /* Style northward tooltips differently */
 .d3-tooltip.n:after {
-  margin: -1px 0 0 0;
+  margin: -4px 0 0 0;
   top: 100%;
   left: 0;
 }

--- a/ui/app/styles/components/http-requests-bar-chart.scss
+++ b/ui/app/styles/components/http-requests-bar-chart.scss
@@ -37,3 +37,32 @@
     }
   }
 }
+
+.d3-tip {
+  line-height: 1;
+  font-weight: bold;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  border-radius: 2px;
+}
+
+/* Creates a small triangle extender for the tooltip */
+.d3-tip:after {
+  box-sizing: border-box;
+  display: inline;
+  font-size: 10px;
+  width: 100%;
+  line-height: 1;
+  color: rgba(0, 0, 0, 0.8);
+  content: '\25BC';
+  position: absolute;
+  text-align: center;
+}
+
+/* Style northward tooltips differently */
+.d3-tip.n:after {
+  margin: -1px 0 0 0;
+  top: 100%;
+  left: 0;
+}

--- a/ui/app/templates/components/http-requests-bar-chart.hbs
+++ b/ui/app/templates/components/http-requests-bar-chart.hbs
@@ -13,7 +13,7 @@
   <g clip-path="url(#bars-container)">
     <rect x="0" y="0" width="100%" height="100%" style="fill: url(#bg-gradient)"></rect>
     <clipPath id="bars-container">
-      <g class="tooltip-container"></g>
     </clipPath>
   </g>
+    <g class="shadow-bars"></g>
 </svg>

--- a/ui/app/templates/components/http-requests-bar-chart.hbs
+++ b/ui/app/templates/components/http-requests-bar-chart.hbs
@@ -13,6 +13,7 @@
   <g clip-path="url(#bars-container)">
     <rect x="0" y="0" width="100%" height="100%" style="fill: url(#bg-gradient)"></rect>
     <clipPath id="bars-container">
+      <g class="tooltip-container"></g>
     </clipPath>
   </g>
 </svg>

--- a/ui/app/templates/components/http-requests-bar-chart.hbs
+++ b/ui/app/templates/components/http-requests-bar-chart.hbs
@@ -10,9 +10,9 @@
   <g  class="gridlines"></g>
   <g class="x-axis"></g>
   <g class="y-axis"></g>
-  <g clip-path="url(#bars-container)">
+  <g clip-path="url(#bars-container-{{this.elementId}})">
     <rect x="0" y="0" width="100%" height="100%" style="fill: url(#bg-gradient)"></rect>
-    <clipPath id="bars-container">
+    <clipPath id="bars-container-{{this.elementId}}">
     </clipPath>
   </g>
     <g class="shadow-bars"></g>

--- a/ui/app/templates/vault/cluster/requests.hbs
+++ b/ui/app/templates/vault/cluster/requests.hbs
@@ -6,8 +6,8 @@
   </p.levelLeft>
 </PageHeader>
 
-{{!-- {{#if (gt model.counters.length 1) }} --}}
-  <HttpRequestsBarChart />
-{{!-- {{/if}} --}}
+{{#if (gt model.counters.length 1) }}
+  <HttpRequestsBarChart @counters={{model.counters}}/>
+{{/if}}
 <AlertInline @type="info" @message="Metrics are recorded only for interactions that produce or use a Vault token." />
 <HttpRequestsTable @counters={{model.counters}} />

--- a/ui/app/templates/vault/cluster/requests.hbs
+++ b/ui/app/templates/vault/cluster/requests.hbs
@@ -6,8 +6,8 @@
   </p.levelLeft>
 </PageHeader>
 
-{{#if (gt model.counters.length 1) }}
-  <HttpRequestsBarChart @counters={{model.counters}}/>
-{{/if}}
+{{!-- {{#if (gt model.counters.length 1) }} --}}
+  <HttpRequestsBarChart />
+{{!-- {{/if}} --}}
 <AlertInline @type="info" @message="Metrics are recorded only for interactions that produce or use a Vault token." />
 <HttpRequestsTable @counters={{model.counters}} />

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,10 +53,12 @@
     "codemirror": "5.15.2",
     "columnify": "^1.5.4",
     "cool-checkboxes-for-bulma.io": "^1.1.0",
+    "d3-array": "^2.2.0",
     "d3-axis": "^1.0.8",
     "d3-scale": "^1.0.7",
     "d3-selection": "^1.3.0",
     "d3-time-format": "^2.1.1",
+    "d3-tip": "^0.9.1",
     "date-fns": "^1.29.0",
     "deepmerge": "^2.1.1",
     "doctoc": "^1.4.0",
@@ -158,6 +160,5 @@
       "lib/replication",
       "lib/kmip"
     ]
-  },
-  "dependencies": {}
+  }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,6 @@
     "codemirror": "5.15.2",
     "columnify": "^1.5.4",
     "cool-checkboxes-for-bulma.io": "^1.1.0",
-    "d3-array": "^2.2.0",
     "d3-axis": "^1.0.8",
     "d3-scale": "^1.0.7",
     "d3-selection": "^1.3.0",

--- a/ui/tests/integration/components/http-requests-bar-chart-test.js
+++ b/ui/tests/integration/components/http-requests-bar-chart-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const COUNTERS = [
@@ -25,7 +25,7 @@ module('Integration | Component | http-requests-bar-chart', function(hooks) {
   test('it renders the correct number of bars, ticks, and gridlines', async function(assert) {
     await render(hbs`<HttpRequestsBarChart @counters={{counters}}/>`);
 
-    assert.equal(this.element.querySelectorAll('.bar').length, 3);
+    assert.equal(this.element.querySelectorAll('.bar').length, 6, 'it renders the bars and shadow bars');
     assert.equal(this.element.querySelectorAll('.tick').length, 9), 'it renders the ticks and gridlines';
   });
 
@@ -42,5 +42,13 @@ module('Integration | Component | http-requests-bar-chart', function(hooks) {
       '2k',
       'y axis ticks should round to the nearest thousand'
     );
+  });
+
+  test('it renders a tooltip', async function(assert) {
+    await render(hbs`<HttpRequestsBarChart @counters={{counters}}/>`);
+    await triggerEvent('.shadow-bars>.bar', 'mouseenter');
+    const tooltipLabel = document.querySelector('.d3-tooltip .date');
+
+    assert.equal(tooltipLabel.textContent, 'April 2019', 'it shows the tooltip with the formatted date');
   });
 });

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6481,11 +6481,6 @@ d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
-d3-array@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.2.0.tgz#a9e966b8f8d78f0888d98db1fb840fc8da8ac5c7"
-  integrity sha512-eE0QmSh6xToqM3sxHiJYg/QFdNn52ZEgmFE8A8abU8GsHvsIOolqH8B70/8+VGAKm5MlwaExhqR3DLIjOJMLPA==
-
 d3-axis@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6481,12 +6481,17 @@ d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
+d3-array@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.2.0.tgz#a9e966b8f8d78f0888d98db1fb840fc8da8ac5c7"
+  integrity sha512-eE0QmSh6xToqM3sxHiJYg/QFdNn52ZEgmFE8A8abU8GsHvsIOolqH8B70/8+VGAKm5MlwaExhqR3DLIjOJMLPA==
+
 d3-axis@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
   integrity sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==
 
-d3-collection@1:
+d3-collection@1, d3-collection@^1.0.4:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
@@ -6537,6 +6542,14 @@ d3-time@1:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.11.tgz#1d831a3e25cd189eb256c17770a666368762bbce"
   integrity sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw==
+
+d3-tip@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/d3-tip/-/d3-tip-0.9.1.tgz#84e6d331c4e6650d80c5228a07e41820609ab64b"
+  integrity sha512-EVBfG9d+HnjIoyVXfhpytWxlF59JaobwizqMX9EBXtsFmJytjwHeYiUs74ldHQjE7S9vzfKTx2LCtvUrIbuFYg==
+  dependencies:
+    d3-collection "^1.0.4"
+    d3-selection "^1.3.0"
 
 dag-map@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
This PR adds a tooltip when hovering over the bar chart on the HTTP requests volume page.

## Testing
- The tooltip should disappear and reappear on hover
- When the bar is short, you should still be able to easily trigger the tooltip on hover (I added 12px of padding to the top of each bar to make the hover zone larger)

![tooltip](https://user-images.githubusercontent.com/903288/60060443-8106fd80-96a5-11e9-8d3c-961730fc86c1.gif)
