### PR TITLE
sdk/framework: add TypeSignedDurationSecond FieldType

### DIFF
--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -539,7 +539,7 @@ type FieldSchema struct {
 func (s *FieldSchema) DefaultOrZero() interface{} {
 	if s.Default != nil {
 		switch s.Type {
-		case TypeDurationSecond:
+		case TypeDurationSecond, TypeSignedDurationSecond:
 			resultDur, err := parseutil.ParseDurationSecond(s.Default)
 			if err != nil {
 				return s.Type.Zero()
@@ -567,7 +567,7 @@ func (t FieldType) Zero() interface{} {
 		return map[string]interface{}{}
 	case TypeKVPairs:
 		return map[string]string{}
-	case TypeDurationSecond:
+	case TypeDurationSecond, TypeSignedDurationSecond:
 		return 0
 	case TypeSlice:
 		return []interface{}{}

--- a/sdk/framework/backend_test.go
+++ b/sdk/framework/backend_test.go
@@ -564,6 +564,11 @@ func TestFieldSchemaDefaultOrZero(t *testing.T) {
 			60,
 		},
 
+		"illegal default duration string": {
+			&FieldSchema{Type: TypeDurationSecond, Default: "h1"},
+			0,
+		},
+
 		"default duration time.Duration": {
 			&FieldSchema{Type: TypeDurationSecond, Default: 60 * time.Second},
 			60,
@@ -574,6 +579,55 @@ func TestFieldSchemaDefaultOrZero(t *testing.T) {
 			0,
 		},
 
+		"default signed positive duration set": {
+			&FieldSchema{Type: TypeSignedDurationSecond, Default: 60},
+			60,
+		},
+
+		"default signed positive duration int64": {
+			&FieldSchema{Type: TypeSignedDurationSecond, Default: int64(60)},
+			60,
+		},
+
+		"default signed positive duration string": {
+			&FieldSchema{Type: TypeSignedDurationSecond, Default: "60s"},
+			60,
+		},
+
+		"illegal default signed duration string": {
+			&FieldSchema{Type: TypeDurationSecond, Default: "-h1"},
+			0,
+		},
+
+		"default signed positive duration time.Duration": {
+			&FieldSchema{Type: TypeSignedDurationSecond, Default: 60 * time.Second},
+			60,
+		},
+
+		"default signed negative duration set": {
+			&FieldSchema{Type: TypeSignedDurationSecond, Default: -60},
+			-60,
+		},
+
+		"default signed negative duration int64": {
+			&FieldSchema{Type: TypeSignedDurationSecond, Default: int64(-60)},
+			-60,
+		},
+
+		"default signed negative duration string": {
+			&FieldSchema{Type: TypeSignedDurationSecond, Default: "-60s"},
+			-60,
+		},
+
+		"default signed negative duration time.Duration": {
+			&FieldSchema{Type: TypeSignedDurationSecond, Default: -60 * time.Second},
+			-60,
+		},
+
+		"default signed negative duration not set": {
+			&FieldSchema{Type: TypeSignedDurationSecond},
+			0,
+		},
 		"default header not set": {
 			&FieldSchema{Type: TypeHeader},
 			http.Header{},
@@ -583,7 +637,7 @@ func TestFieldSchemaDefaultOrZero(t *testing.T) {
 	for name, tc := range cases {
 		actual := tc.Schema.DefaultOrZero()
 		if !reflect.DeepEqual(actual, tc.Value) {
-			t.Fatalf("bad: %s\n\nExpected: %#v\nGot: %#v",
+			t.Errorf("bad: %s\n\nExpected: %#v\nGot: %#v",
 				name, tc.Value, actual)
 		}
 	}

--- a/sdk/framework/field_data.go
+++ b/sdk/framework/field_data.go
@@ -38,8 +38,8 @@ func (d *FieldData) Validate() error {
 		}
 
 		switch schema.Type {
-		case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeString, TypeLowerCaseString,
-			TypeNameString, TypeSlice, TypeStringSlice, TypeCommaStringSlice,
+		case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
+			TypeLowerCaseString, TypeNameString, TypeSlice, TypeStringSlice, TypeCommaStringSlice,
 			TypeKVPairs, TypeCommaIntSlice, TypeHeader:
 			_, _, err := d.getPrimitive(field, schema)
 			if err != nil {
@@ -131,8 +131,8 @@ func (d *FieldData) GetOkErr(k string) (interface{}, bool, error) {
 	}
 
 	switch schema.Type {
-	case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeString, TypeLowerCaseString,
-		TypeNameString, TypeSlice, TypeStringSlice, TypeCommaStringSlice,
+	case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
+		TypeLowerCaseString, TypeNameString, TypeSlice, TypeStringSlice, TypeCommaStringSlice,
 		TypeKVPairs, TypeCommaIntSlice, TypeHeader:
 		return d.getPrimitive(k, schema)
 	default:
@@ -147,7 +147,7 @@ func (d *FieldData) getPrimitive(k string, schema *FieldSchema) (interface{}, bo
 		return nil, false, nil
 	}
 
-	switch schema.Type {
+	switch t := schema.Type; t {
 	case TypeBool:
 		var result bool
 		if err := mapstructure.WeakDecode(raw, &result); err != nil {
@@ -197,7 +197,7 @@ func (d *FieldData) getPrimitive(k string, schema *FieldSchema) (interface{}, bo
 		}
 		return result, true, nil
 
-	case TypeDurationSecond:
+	case TypeDurationSecond, TypeSignedDurationSecond:
 		var result int
 		switch inp := raw.(type) {
 		case nil:
@@ -209,7 +209,7 @@ func (d *FieldData) getPrimitive(k string, schema *FieldSchema) (interface{}, bo
 			}
 			result = int(dur.Seconds())
 		}
-		if result < 0 {
+		if t == TypeDurationSecond && result < 0 {
 			return nil, false, fmt.Errorf("cannot provide negative value '%d'", result)
 		}
 		return result, true, nil

--- a/sdk/framework/field_data_test.go
+++ b/sdk/framework/field_data_test.go
@@ -202,6 +202,17 @@ func TestFieldDataGet(t *testing.T) {
 			0,
 		},
 
+		"duration type, 0 value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": 0,
+			},
+			"foo",
+			0,
+		},
+
 		"signed duration type, positive string value": {
 			map[string]*FieldSchema{
 				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
@@ -296,6 +307,17 @@ func TestFieldDataGet(t *testing.T) {
 			},
 			map[string]interface{}{
 				"foo": nil,
+			},
+			"foo",
+			0,
+		},
+
+		"signed duration type, 0 value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": 0,
 			},
 			"foo",
 			0,

--- a/sdk/framework/field_data_test.go
+++ b/sdk/framework/field_data_test.go
@@ -675,21 +675,23 @@ func TestFieldDataGet(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		data := &FieldData{
-			Raw:    tc.Raw,
-			Schema: tc.Schema,
-		}
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			data := &FieldData{
+				Raw:    tc.Raw,
+				Schema: tc.Schema,
+			}
 
-		if err := data.Validate(); err != nil {
-			t.Fatalf("bad: %s", err)
-		}
+			if err := data.Validate(); err != nil {
+				t.Fatalf("bad: %s", err)
+			}
 
-		actual := data.Get(tc.Key)
-		if !reflect.DeepEqual(actual, tc.Value) {
-			t.Fatalf(
-				"bad: %s\n\nExpected: %#v\nGot: %#v",
-				name, tc.Value, actual)
-		}
+			actual := data.Get(tc.Key)
+			if !reflect.DeepEqual(actual, tc.Value) {
+				t.Fatalf("Expected: %#v\nGot: %#v", tc.Value, actual)
+			}
+		})
 	}
 }
 
@@ -746,16 +748,20 @@ func TestFieldDataGet_Error(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		data := &FieldData{
-			Raw:    tc.Raw,
-			Schema: tc.Schema,
-		}
+	for name, tc := range cases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			data := &FieldData{
+				Raw:    tc.Raw,
+				Schema: tc.Schema,
+			}
 
-		_, _, err := data.GetOkErr(tc.Key)
-		if err == nil {
-			t.Fatalf("error expected, none received")
-		}
+			got, _, err := data.GetOkErr(tc.Key)
+			if err == nil {
+				t.Fatalf("error expected, none received, got result: %#v", got)
+			}
+		})
 	}
 }
 

--- a/sdk/framework/field_data_test.go
+++ b/sdk/framework/field_data_test.go
@@ -202,6 +202,105 @@ func TestFieldDataGet(t *testing.T) {
 			0,
 		},
 
+		"signed duration type, positive string value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": "42",
+			},
+			"foo",
+			42,
+		},
+
+		"signed duration type, positive string duration value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": "42m",
+			},
+			"foo",
+			2520,
+		},
+
+		"signed duration type, positive int value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": 42,
+			},
+			"foo",
+			42,
+		},
+
+		"signed duration type, positive float value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": 42.0,
+			},
+			"foo",
+			42,
+		},
+
+		"signed duration type, negative string value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": "-42",
+			},
+			"foo",
+			-42,
+		},
+
+		"signed duration type, negative string duration value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": "-42m",
+			},
+			"foo",
+			-2520,
+		},
+
+		"signed duration type, negative int value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": -42,
+			},
+			"foo",
+			-42,
+		},
+
+		"signed duration type, negative float value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": -42.0,
+			},
+			"foo",
+			-42,
+		},
+
+		"signed duration type, nil value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": nil,
+			},
+			"foo",
+			0,
+		},
+
 		"slice type, empty slice": {
 			map[string]*FieldSchema{
 				"foo": &FieldSchema{Type: TypeSlice},
@@ -628,6 +727,15 @@ func TestFieldDataGet(t *testing.T) {
 			0,
 		},
 
+		"type signed duration second, not supplied": {
+			map[string]*FieldSchema{
+				"foo": {Type: TypeSignedDurationSecond},
+			},
+			map[string]interface{}{},
+			"foo",
+			0,
+		},
+
 		"type slice, not supplied": {
 			map[string]*FieldSchema{
 				"foo": {Type: TypeSlice},
@@ -743,6 +851,42 @@ func TestFieldDataGet_Error(t *testing.T) {
 			},
 			map[string]interface{}{
 				"foo": []interface{}{"=value1", "key2=value2", "key3=1"},
+			},
+			"foo",
+		},
+		"duration type, negative string value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": "-42",
+			},
+			"foo",
+		},
+		"duration type, negative string duration value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": "-42m",
+			},
+			"foo",
+		},
+		"duration type, negative int value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": -42,
+			},
+			"foo",
+		},
+		"duration type, negative float value": {
+			map[string]*FieldSchema{
+				"foo": &FieldSchema{Type: TypeDurationSecond},
+			},
+			map[string]interface{}{
+				"foo": -42.0,
 			},
 			"foo",
 		},

--- a/sdk/framework/field_type.go
+++ b/sdk/framework/field_type.go
@@ -14,6 +14,11 @@ const (
 	// integer or go duration format string (e.g. 24h)
 	TypeDurationSecond
 
+	// TypeSignedDurationSecond represents a positive or negative duration
+	// as seconds, this can be either an integer or go duration format
+	// string (e.g. 24h).
+	TypeSignedDurationSecond
+
 	// TypeSlice represents a slice of any type
 	TypeSlice
 
@@ -66,7 +71,7 @@ func (t FieldType) String() string {
 		return "map"
 	case TypeKVPairs:
 		return "keypair"
-	case TypeDurationSecond:
+	case TypeDurationSecond, TypeSignedDurationSecond:
 		return "duration (sec)"
 	case TypeSlice, TypeStringSlice, TypeCommaStringSlice, TypeCommaIntSlice:
 		return "slice"

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -552,7 +552,7 @@ func convertType(t FieldType) schemaType {
 		ret.format = "lowercase"
 	case TypeInt:
 		ret.baseType = "integer"
-	case TypeDurationSecond:
+	case TypeDurationSecond, TypeSignedDurationSecond:
 		ret.baseType = "integer"
 		ret.format = "seconds"
 	case TypeBool:


### PR DESCRIPTION
Adds the `TypeSignedDurationSecond` `FieldType` which accepts positive and negative durations. The existing `TypeDurationSecond` `FieldType` does not accept negative durations.

Will close #6979 in favor of this PR.