### PR TITLE
Combined Database backend: Add Static Account support to MongoDB

### DIFF
--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -2,14 +2,7 @@ package database
 
 import (
 	"context"
-	"crypto/tls"
-	"errors"
-	"fmt"
 	"log"
-	"net"
-	"net/url"
-	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -17,11 +10,10 @@ import (
 	"database/sql"
 
 	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/helper/testhelpers/mongodb"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/dbtxn"
 	"github.com/hashicorp/vault/sdk/logical"
-	"github.com/ory/dockertest"
-	"gopkg.in/mgo.v2"
 
 	"github.com/lib/pq"
 )
@@ -846,7 +838,7 @@ func TestBackend_StaticRole_Rotations_MongoDB(t *testing.T) {
 	}
 
 	// configure backend, add item and confirm length
-	cleanup, connURL := prepareMongoDBTestContainer(t)
+	cleanup, connURL := mongodb.PrepareTestContainerWithDatabase(t, "latest", "vaulttestdb")
 	defer cleanup()
 
 	// Configure a connection
@@ -996,123 +988,4 @@ func capturePasswords(t *testing.T, b logical.Backend, config *logical.BackendCo
 func newBoolPtr(b bool) *bool {
 	v := b
 	return &v
-}
-
-// copied from plugins/database/mongodb/mongodb_test.go
-// maybe move to a new builtin/logical/database/dbplugin/helper
-func prepareMongoDBTestContainer(t *testing.T) (cleanup func(), retURL string) {
-	if os.Getenv("MONGODB_URL") != "" {
-		return func() {}, os.Getenv("MONGODB_URL")
-	}
-
-	pool, err := dockertest.NewPool("")
-	if err != nil {
-		t.Fatalf("Failed to connect to docker: %s", err)
-	}
-
-	resource, err := pool.Run("mongo", "latest", []string{})
-	if err != nil {
-		t.Fatalf("Could not start local mongo docker container: %s", err)
-	}
-
-	cleanup = func() {
-		err := pool.Purge(resource)
-		if err != nil {
-			t.Fatalf("Failed to cleanup local container: %s", err)
-		}
-	}
-
-	retURL = fmt.Sprintf("mongodb://localhost:%s/vaulttestdb", resource.GetPort("27017/tcp"))
-
-	// exponential backoff-retry
-	if err = pool.Retry(func() error {
-		var err error
-		dialInfo, err := parseMongoURL(retURL)
-		if err != nil {
-			return err
-		}
-
-		session, err := mgo.DialWithInfo(dialInfo)
-		if err != nil {
-			return err
-		}
-		defer session.Close()
-		session.SetSyncTimeout(1 * time.Minute)
-		session.SetSocketTimeout(1 * time.Minute)
-		return session.Ping()
-	}); err != nil {
-		cleanup()
-		t.Fatalf("Could not connect to mongo docker container: %s", err)
-	}
-
-	return
-}
-
-// copied from plugins/database/mongodb/connection_producer.go
-func parseMongoURL(rawURL string) (*mgo.DialInfo, error) {
-	url, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, err
-	}
-
-	info := mgo.DialInfo{
-		Addrs:    strings.Split(url.Host, ","),
-		Database: strings.TrimPrefix(url.Path, "/"),
-		Timeout:  10 * time.Second,
-	}
-
-	if url.User != nil {
-		info.Username = url.User.Username()
-		info.Password, _ = url.User.Password()
-	}
-
-	query := url.Query()
-	for key, values := range query {
-		var value string
-		if len(values) > 0 {
-			value = values[0]
-		}
-
-		switch key {
-		case "authSource":
-			info.Source = value
-		case "authMechanism":
-			info.Mechanism = value
-		case "gssapiServiceName":
-			info.Service = value
-		case "replicaSet":
-			info.ReplicaSetName = value
-		case "maxPoolSize":
-			poolLimit, err := strconv.Atoi(value)
-			if err != nil {
-				return nil, errors.New("bad value for maxPoolSize: " + value)
-			}
-			info.PoolLimit = poolLimit
-		case "ssl":
-			// Unfortunately, mgo doesn't support the ssl parameter in its MongoDB URI parsing logic, so we have to handle that
-			// ourselves. See https://github.com/go-mgo/mgo/issues/84
-			ssl, err := strconv.ParseBool(value)
-			if err != nil {
-				return nil, errors.New("bad value for ssl: " + value)
-			}
-			if ssl {
-				info.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
-					return tls.Dial("tcp", addr.String(), &tls.Config{})
-				}
-			}
-		case "connect":
-			if value == "direct" {
-				info.Direct = true
-				break
-			}
-			if value == "replicaSet" {
-				break
-			}
-			fallthrough
-		default:
-			return nil, errors.New("unsupported connection URL option: " + key + "=" + value)
-		}
-	}
-
-	return &info, nil
 }

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -935,6 +935,9 @@ func TestBackend_StaticRole_Rotations_MongoDB(t *testing.T) {
 	// verify all pws are as they should
 	pass := true
 	for k, v := range pws {
+		if len(v) < 3 {
+			t.Fatalf("expected to find 3 passwords for (%s), only found (%d)", k, len(v))
+		}
 		switch {
 		case k == "plugin-static-role-65":
 			// expect all passwords to be different

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -2,7 +2,14 @@ package database
 
 import (
 	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
 	"log"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -13,11 +20,15 @@ import (
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/dbtxn"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/ory/dockertest"
+	"gopkg.in/mgo.v2"
 
 	"github.com/lib/pq"
 )
 
 const dbUser = "vaultstatictest"
+
+const testMongoDBRole = `{ "db": "admin", "roles": [ { "role": "readWrite" } ] }`
 
 func TestBackend_StaticRole_Rotate_basic(t *testing.T) {
 	cluster, sys := getCluster(t)
@@ -814,6 +825,139 @@ func TestBackend_StaticRole_Rotations_PostgreSQL(t *testing.T) {
 	}
 }
 
+func TestBackend_StaticRole_Rotations_MongoDB(t *testing.T) {
+	cluster, sys := getCluster(t)
+	defer cluster.Cleanup()
+
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = sys
+
+	b, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Cleanup(context.Background())
+
+	// allow initQueue to finish
+	bd := b.(*databaseBackend)
+	if bd.credRotationQueue == nil {
+		t.Fatal("database backend had no credential rotation queue")
+	}
+
+	// configure backend, add item and confirm length
+	cleanup, connURL := prepareMongoDBTestContainer(t)
+	defer cleanup()
+
+	// Configure a connection
+	data := map[string]interface{}{
+		"connection_url":    connURL,
+		"plugin_name":       "mongodb-database-plugin",
+		"verify_connection": false,
+		"allowed_roles":     []string{"*"},
+		"name":              "plugin-mongo-test",
+	}
+
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/plugin-mongo-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	// create three static roles with different rotation periods
+	testCases := []string{"65", "130", "5400"}
+	for _, tc := range testCases {
+		roleName := "plugin-static-role-" + tc
+		data = map[string]interface{}{
+			"name":            roleName,
+			"db_name":         "plugin-mongo-test",
+			"username":        "statictestMongo" + tc,
+			"rotation_period": tc,
+		}
+
+		req = &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "static-roles/" + roleName,
+			Storage:   config.StorageView,
+			Data:      data,
+		}
+
+		resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+		if err != nil || (resp != nil && resp.IsError()) {
+			t.Fatalf("err:%s resp:%#v\n", err, resp)
+		}
+	}
+
+	// verify the queue has 3 items in it
+	if bd.credRotationQueue.Len() != 3 {
+		t.Fatalf("expected 3 items in the rotation queue, got: (%d)", bd.credRotationQueue.Len())
+	}
+
+	// List the roles
+	data = map[string]interface{}{}
+	req = &logical.Request{
+		Operation: logical.ListOperation,
+		Path:      "static-roles/",
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	keys := resp.Data["keys"].([]string)
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 roles, got: (%d)", len(keys))
+	}
+
+	// capture initial passwords, before the periodic function is triggered
+	pws := make(map[string][]string, 0)
+	pws = capturePasswords(t, b, config, testCases, pws)
+
+	// sleep to make sure the 65s role will be up for rotation by the time the
+	// periodic function ticks
+	time.Sleep(7 * time.Second)
+
+	// sleep 75 to make sure the periodic func has time to actually run
+	time.Sleep(75 * time.Second)
+	pws = capturePasswords(t, b, config, testCases, pws)
+
+	// sleep more, this should allow both sr65 and sr130 to rotate
+	time.Sleep(140 * time.Second)
+	pws = capturePasswords(t, b, config, testCases, pws)
+
+	// verify all pws are as they should
+	pass := true
+	for k, v := range pws {
+		switch {
+		case k == "plugin-static-role-65":
+			// expect all passwords to be different
+			if v[0] == v[1] || v[1] == v[2] || v[0] == v[2] {
+				pass = false
+			}
+		case k == "plugin-static-role-130":
+			// expect the first two to be equal, but different from the third
+			if v[0] != v[1] || v[0] == v[2] {
+				pass = false
+			}
+		case k == "plugin-static-role-5400":
+			// expect all passwords to be equal
+			if v[0] != v[1] || v[1] != v[2] {
+				pass = false
+			}
+		}
+	}
+	if !pass {
+		t.Fatalf("password rotations did not match expected: %#v", pws)
+	}
+}
+
 // capturePasswords captures the current passwords at the time of calling, and
 // returns a map of username / passwords building off of the input map
 func capturePasswords(t *testing.T, b logical.Backend, config *logical.BackendConfig, testCases []string, pws map[string][]string) map[string][]string {
@@ -849,4 +993,123 @@ func capturePasswords(t *testing.T, b logical.Backend, config *logical.BackendCo
 func newBoolPtr(b bool) *bool {
 	v := b
 	return &v
+}
+
+// copied from plugins/database/mongodb/mongodb_test.go
+// maybe move to a new builtin/logical/database/dbplugin/helper
+func prepareMongoDBTestContainer(t *testing.T) (cleanup func(), retURL string) {
+	if os.Getenv("MONGODB_URL") != "" {
+		return func() {}, os.Getenv("MONGODB_URL")
+	}
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Fatalf("Failed to connect to docker: %s", err)
+	}
+
+	resource, err := pool.Run("mongo", "latest", []string{})
+	if err != nil {
+		t.Fatalf("Could not start local mongo docker container: %s", err)
+	}
+
+	cleanup = func() {
+		err := pool.Purge(resource)
+		if err != nil {
+			t.Fatalf("Failed to cleanup local container: %s", err)
+		}
+	}
+
+	retURL = fmt.Sprintf("mongodb://localhost:%s/vaulttestdb", resource.GetPort("27017/tcp"))
+
+	// exponential backoff-retry
+	if err = pool.Retry(func() error {
+		var err error
+		dialInfo, err := parseMongoURL(retURL)
+		if err != nil {
+			return err
+		}
+
+		session, err := mgo.DialWithInfo(dialInfo)
+		if err != nil {
+			return err
+		}
+		defer session.Close()
+		session.SetSyncTimeout(1 * time.Minute)
+		session.SetSocketTimeout(1 * time.Minute)
+		return session.Ping()
+	}); err != nil {
+		cleanup()
+		t.Fatalf("Could not connect to mongo docker container: %s", err)
+	}
+
+	return
+}
+
+// copied from plugins/database/mongodb/connection_producer.go
+func parseMongoURL(rawURL string) (*mgo.DialInfo, error) {
+	url, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	info := mgo.DialInfo{
+		Addrs:    strings.Split(url.Host, ","),
+		Database: strings.TrimPrefix(url.Path, "/"),
+		Timeout:  10 * time.Second,
+	}
+
+	if url.User != nil {
+		info.Username = url.User.Username()
+		info.Password, _ = url.User.Password()
+	}
+
+	query := url.Query()
+	for key, values := range query {
+		var value string
+		if len(values) > 0 {
+			value = values[0]
+		}
+
+		switch key {
+		case "authSource":
+			info.Source = value
+		case "authMechanism":
+			info.Mechanism = value
+		case "gssapiServiceName":
+			info.Service = value
+		case "replicaSet":
+			info.ReplicaSetName = value
+		case "maxPoolSize":
+			poolLimit, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, errors.New("bad value for maxPoolSize: " + value)
+			}
+			info.PoolLimit = poolLimit
+		case "ssl":
+			// Unfortunately, mgo doesn't support the ssl parameter in its MongoDB URI parsing logic, so we have to handle that
+			// ourselves. See https://github.com/go-mgo/mgo/issues/84
+			ssl, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, errors.New("bad value for ssl: " + value)
+			}
+			if ssl {
+				info.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
+					return tls.Dial("tcp", addr.String(), &tls.Config{})
+				}
+			}
+		case "connect":
+			if value == "direct" {
+				info.Direct = true
+				break
+			}
+			if value == "replicaSet" {
+				break
+			}
+			fallthrough
+		default:
+			return nil, errors.New("unsupported connection URL option: " + key + "=" + value)
+		}
+	}
+
+	return &info, nil
 }

--- a/helper/testhelpers/mongodb/mongodbhelper.go
+++ b/helper/testhelpers/mongodb/mongodbhelper.go
@@ -1,17 +1,30 @@
 package mongodb
 
 import (
+	"crypto/tls"
+	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/helper/testhelpers/docker"
 	"github.com/ory/dockertest"
 	"gopkg.in/mgo.v2"
 )
 
+// PrepareTestContainer calls PrepareTestContainerWithDatabase without a
+// database name value, which results in configuring a database named "test"
 func PrepareTestContainer(t *testing.T, version string) (cleanup func(), retURL string) {
+	return PrepareTestContainerWithDatabase(t, version, "")
+}
+
+// PrepareTestContainerWithDatabase configures a test container with a given
+// database name, to test non-test/admin database configurations
+func PrepareTestContainerWithDatabase(t *testing.T, version, dbName string) (cleanup func(), retURL string) {
 	if os.Getenv("MONGODB_URL") != "" {
 		return func() {}, os.Getenv("MONGODB_URL")
 	}
@@ -21,29 +34,36 @@ func PrepareTestContainer(t *testing.T, version string) (cleanup func(), retURL 
 		t.Fatalf("Failed to connect to docker: %s", err)
 	}
 
-	resource, err := pool.Run("mongo", "latest", []string{})
+	resource, err := pool.Run("mongo", version, []string{})
 	if err != nil {
 		t.Fatalf("Could not start local mongo docker container: %s", err)
 	}
 
 	cleanup = func() {
-		docker.CleanupResource(t, pool, resource)
+		err := pool.Purge(resource)
+		if err != nil {
+			t.Fatalf("Failed to cleanup local container: %s", err)
+		}
 	}
 
-	addr := fmt.Sprintf("localhost:%s", resource.GetPort("27017/tcp"))
-	retURL = "mongodb://" + addr
+	retURL = fmt.Sprintf("mongodb://localhost:%s", resource.GetPort("27017/tcp"))
+	if dbName != "" {
+		retURL = fmt.Sprintf("%s/%s", retURL, dbName)
+	}
 
 	// exponential backoff-retry
 	if err = pool.Retry(func() error {
-		session, err := mgo.DialWithInfo(&mgo.DialInfo{
-			Addrs:   []string{addr},
-			Timeout: 10 * time.Second,
-		})
+		var err error
+		dialInfo, err := parseMongoURL(retURL)
+		if err != nil {
+			return err
+		}
+
+		session, err := mgo.DialWithInfo(dialInfo)
 		if err != nil {
 			return err
 		}
 		defer session.Close()
-
 		session.SetSyncTimeout(1 * time.Minute)
 		session.SetSocketTimeout(1 * time.Minute)
 		return session.Ping()
@@ -53,4 +73,73 @@ func PrepareTestContainer(t *testing.T, version string) (cleanup func(), retURL 
 	}
 
 	return
+}
+
+// parseMongoURL will parse a connection string and return a configured dialer
+func parseMongoURL(rawURL string) (*mgo.DialInfo, error) {
+	url, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	info := mgo.DialInfo{
+		Addrs:    strings.Split(url.Host, ","),
+		Database: strings.TrimPrefix(url.Path, "/"),
+		Timeout:  10 * time.Second,
+	}
+
+	if url.User != nil {
+		info.Username = url.User.Username()
+		info.Password, _ = url.User.Password()
+	}
+
+	query := url.Query()
+	for key, values := range query {
+		var value string
+		if len(values) > 0 {
+			value = values[0]
+		}
+
+		switch key {
+		case "authSource":
+			info.Source = value
+		case "authMechanism":
+			info.Mechanism = value
+		case "gssapiServiceName":
+			info.Service = value
+		case "replicaSet":
+			info.ReplicaSetName = value
+		case "maxPoolSize":
+			poolLimit, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, errors.New("bad value for maxPoolSize: " + value)
+			}
+			info.PoolLimit = poolLimit
+		case "ssl":
+			// Unfortunately, mgo doesn't support the ssl parameter in its MongoDB URI parsing logic, so we have to handle that
+			// ourselves. See https://github.com/go-mgo/mgo/issues/84
+			ssl, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, errors.New("bad value for ssl: " + value)
+			}
+			if ssl {
+				info.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
+					return tls.Dial("tcp", addr.String(), &tls.Config{})
+				}
+			}
+		case "connect":
+			if value == "direct" {
+				info.Direct = true
+				break
+			}
+			if value == "replicaSet" {
+				break
+			}
+			fallthrough
+		default:
+			return nil, errors.New("unsupported connection URL option: " + key + "=" + value)
+		}
+	}
+
+	return &info, nil
 }

--- a/plugins/database/mongodb/connection_producer.go
+++ b/plugins/database/mongodb/connection_producer.go
@@ -15,11 +15,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/vault/sdk/database/dbplugin"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
 	"github.com/mitchellh/mapstructure"
-
 	mgo "gopkg.in/mgo.v2"
 )
 
@@ -152,16 +150,6 @@ func (c *mongoDBConnectionProducer) Close() error {
 	c.session = nil
 
 	return nil
-}
-
-// SetCredentials uses provided information to set/create a user in the
-// database. Unlike CreateUser, this method requires a username be provided and
-// uses the name given, instead of generating a name. This is used for creating
-// and setting the password of static accounts, as well as rolling back
-// passwords in the database in the event an updated database fails to save in
-// Vault's storage.
-func (c *mongoDBConnectionProducer) SetCredentials(ctx context.Context, statements dbplugin.Statements, staticUser dbplugin.StaticUserConfig) (username, password string, err error) {
-	return "", "", dbutil.Unimplemented()
 }
 
 func parseMongoURL(rawURL string) (*mgo.DialInfo, error) {

--- a/plugins/database/mongodb/mongodb_test.go
+++ b/plugins/database/mongodb/mongodb_test.go
@@ -170,6 +170,9 @@ func TestMongoDB_SetCredentials(t *testing.T) {
 	cleanup, connURL := mongodb.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
+	// The docker test method PrepareTestContainer defaults to a database "test"
+	// if none is provided
+	connURL = connURL + "/test"
 	connectionDetails := map[string]interface{}{
 		"connection_url": connURL,
 	}
@@ -233,7 +236,7 @@ func testCreateDBUser(t testing.TB, connURL, username, password string) {
 		Password: password,
 	}
 
-	if err := session.DB("admin").UpsertUser(&mUser); err != nil {
+	if err := session.DB(dialInfo.Database).UpsertUser(&mUser); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/plugins/database/mongodb/util.go
+++ b/plugins/database/mongodb/util.go
@@ -1,10 +1,24 @@
 package mongodb
 
+import (
+	"encoding/json"
+	"fmt"
+
+	mgo "gopkg.in/mgo.v2"
+)
+
 type createUserCommand struct {
 	Username string        `bson:"createUser"`
 	Password string        `bson:"pwd"`
 	Roles    []interface{} `bson:"roles"`
 }
+
+type upsertUserCommand struct {
+	Username string        `bson:"updateUser"`
+	Password string        `bson:"pwd"`
+	Roles    []interface{} `bson:"roles"`
+}
+
 type mongodbRole struct {
 	Role string `json:"role" bson:"role"`
 	DB   string `json:"db"   bson:"db"`
@@ -33,6 +47,24 @@ func (roles mongodbRoles) toStandardRolesArray() []interface{} {
 			standardRolesArray = append(standardRolesArray, role.Role)
 		} else {
 			standardRolesArray = append(standardRolesArray, role)
+		}
+	}
+	return standardRolesArray
+}
+
+// mgo.Role is a named string type
+func (roles mongodbRoles) toStandardRolesStringArray() []mgo.Role {
+	var standardRolesArray []mgo.Role
+	for _, role := range roles {
+		if role.DB == "" {
+			standardRolesArray = append(standardRolesArray, mgo.Role(role.Role))
+		} else {
+			b, err := json.Marshal(role)
+			if err != nil {
+				fmt.Println("error:", err)
+			}
+			s := string(b)
+			standardRolesArray = append(standardRolesArray, mgo.Role(s))
 		}
 	}
 	return standardRolesArray

--- a/plugins/database/mongodb/util.go
+++ b/plugins/database/mongodb/util.go
@@ -1,12 +1,5 @@
 package mongodb
 
-import (
-	"encoding/json"
-	"fmt"
-
-	mgo "gopkg.in/mgo.v2"
-)
-
 type createUserCommand struct {
 	Username string        `bson:"createUser"`
 	Password string        `bson:"pwd"`
@@ -47,24 +40,6 @@ func (roles mongodbRoles) toStandardRolesArray() []interface{} {
 			standardRolesArray = append(standardRolesArray, role.Role)
 		} else {
 			standardRolesArray = append(standardRolesArray, role)
-		}
-	}
-	return standardRolesArray
-}
-
-// mgo.Role is a named string type
-func (roles mongodbRoles) toStandardRolesStringArray() []mgo.Role {
-	var standardRolesArray []mgo.Role
-	for _, role := range roles {
-		if role.DB == "" {
-			standardRolesArray = append(standardRolesArray, mgo.Role(role.Role))
-		} else {
-			b, err := json.Marshal(role)
-			if err != nil {
-				fmt.Println("error:", err)
-			}
-			s := string(b)
-			standardRolesArray = append(standardRolesArray, mgo.Role(s))
 		}
 	}
 	return standardRolesArray

--- a/plugins/database/mongodb/util.go
+++ b/plugins/database/mongodb/util.go
@@ -6,12 +6,6 @@ type createUserCommand struct {
 	Roles    []interface{} `bson:"roles"`
 }
 
-type upsertUserCommand struct {
-	Username string        `bson:"updateUser"`
-	Password string        `bson:"pwd"`
-	Roles    []interface{} `bson:"roles"`
-}
-
 type mongodbRole struct {
 	Role string `json:"role" bson:"role"`
 	DB   string `json:"db"   bson:"db"`


### PR DESCRIPTION
Similar to https://github.com/hashicorp/vault/pull/6970, this PR adds support for Static Accounts (introduced in #6834 , modified in #6951) to the MongoDB database plugin.

Unlike MySQL or PostgreSQL, MongoDB does not make use of `rotation_statements`. The SDK supports changing the password directly, as opposed to other SQL type databases where the password is modified via an SQL statement. 

I added `TestMongoDB_SetCredentials` to the MongoDB plugin for testing `SetCredentials` directly, and `TestBackend_StaticRole_Rotations_MongoDB` to the database rotation tests to verify rotations being handled correctly. 