### PR TITLE
Combined Database backend: Add GenerateCredentials to the CredentialsProducer Interface

### DIFF
--- a/plugins/database/cassandra/cassandra.go
+++ b/plugins/database/cassandra/cassandra.go
@@ -239,12 +239,3 @@ func (c *Cassandra) RotateRootCredentials(ctx context.Context, statements []stri
 	c.rawConfig["password"] = password
 	return c.rawConfig, nil
 }
-
-// GenerateCredentials returns a generated password
-func (c *Cassandra) GenerateCredentials(ctx context.Context) (string, error) {
-	password, err := c.GeneratePassword()
-	if err != nil {
-		return "", err
-	}
-	return password, nil
-}

--- a/plugins/database/hana/hana.go
+++ b/plugins/database/hana/hana.go
@@ -293,12 +293,3 @@ func (h *HANA) revokeUserDefault(ctx context.Context, username string) error {
 func (h *HANA) RotateRootCredentials(ctx context.Context, statements []string) (map[string]interface{}, error) {
 	return nil, errors.New("root credentaion rotation is not currently implemented in this database secrets engine")
 }
-
-// GenerateCredentials returns a generated password
-func (h *HANA) GenerateCredentials(ctx context.Context) (string, error) {
-	password, err := h.GeneratePassword()
-	if err != nil {
-		return "", err
-	}
-	return password, nil
-}

--- a/plugins/database/influxdb/influxdb.go
+++ b/plugins/database/influxdb/influxdb.go
@@ -242,12 +242,3 @@ func (i *Influxdb) RotateRootCredentials(ctx context.Context, statements []strin
 	i.rawConfig["password"] = password
 	return i.rawConfig, nil
 }
-
-// GenerateCredentials returns a generated password
-func (i *Influxdb) GenerateCredentials(ctx context.Context) (string, error) {
-	password, err := i.GeneratePassword()
-	if err != nil {
-		return "", err
-	}
-	return password, nil
-}

--- a/plugins/database/mongodb/mongodb.go
+++ b/plugins/database/mongodb/mongodb.go
@@ -224,12 +224,3 @@ func (m *MongoDB) RevokeUser(ctx context.Context, statements dbplugin.Statements
 func (m *MongoDB) RotateRootCredentials(ctx context.Context, statements []string) (map[string]interface{}, error) {
 	return nil, errors.New("root credential rotation is not currently implemented in this database secrets engine")
 }
-
-// GenerateCredentials returns a generated password
-func (m *MongoDB) GenerateCredentials(ctx context.Context) (string, error) {
-	password, err := m.GeneratePassword()
-	if err != nil {
-		return "", err
-	}
-	return password, nil
-}

--- a/plugins/database/mssql/mssql.go
+++ b/plugins/database/mssql/mssql.go
@@ -381,12 +381,3 @@ END
 const rotateRootCredentialsSQL = `
 ALTER LOGIN [{{username}}] WITH PASSWORD = '{{password}}' 
 `
-
-// GenerateCredentials returns a generated password
-func (m *MSSQL) GenerateCredentials(ctx context.Context) (string, error) {
-	password, err := m.GeneratePassword()
-	if err != nil {
-		return "", err
-	}
-	return password, nil
-}

--- a/plugins/database/mysql/mysql.go
+++ b/plugins/database/mysql/mysql.go
@@ -315,12 +315,3 @@ func (m *MySQL) RotateRootCredentials(ctx context.Context, statements []string) 
 	m.RawConfig["password"] = password
 	return m.RawConfig, nil
 }
-
-// GenerateCredentials returns a generated password
-func (m *MySQL) GenerateCredentials(ctx context.Context) (string, error) {
-	password, err := m.GeneratePassword()
-	if err != nil {
-		return "", err
-	}
-	return password, nil
-}

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -500,12 +500,3 @@ func (p *PostgreSQL) RotateRootCredentials(ctx context.Context, statements []str
 	p.RawConfig["password"] = password
 	return p.RawConfig, nil
 }
-
-// GenerateCredentials returns a generated password
-func (p *PostgreSQL) GenerateCredentials(ctx context.Context) (string, error) {
-	password, err := p.GeneratePassword()
-	if err != nil {
-		return "", err
-	}
-	return password, nil
-}

--- a/sdk/database/helper/credsutil/credsutil.go
+++ b/sdk/database/helper/credsutil/credsutil.go
@@ -1,6 +1,7 @@
 package credsutil
 
 import (
+	"context"
 	"time"
 
 	"fmt"
@@ -13,9 +14,10 @@ import (
 // definition. It implements the methods for generating user information for a
 // particular database type and is used in all the builtin database types.
 type CredentialsProducer interface {
-	GenerateUsername(usernameConfig dbplugin.UsernameConfig) (string, error)
+	GenerateCredentials(context.Context) (string, error)
+	GenerateUsername(dbplugin.UsernameConfig) (string, error)
 	GeneratePassword() (string, error)
-	GenerateExpiration(ttl time.Time) (string, error)
+	GenerateExpiration(time.Time) (string, error)
 }
 
 const (

--- a/sdk/database/helper/credsutil/sql.go
+++ b/sdk/database/helper/credsutil/sql.go
@@ -1,6 +1,7 @@
 package credsutil
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -17,6 +18,14 @@ type SQLCredentialsProducer struct {
 	RoleNameLen    int
 	UsernameLen    int
 	Separator      string
+}
+
+func (scp *SQLCredentialsProducer) GenerateCredentials(ctx context.Context) (string, error) {
+	password, err := scp.GeneratePassword()
+	if err != nil {
+		return "", err
+	}
+	return password, nil
 }
 
 func (scp *SQLCredentialsProducer) GenerateUsername(config dbplugin.UsernameConfig) (string, error) {


### PR DESCRIPTION
This PR adds `GenerateCredentials` to the `CredentialsProducer` interface, and adds an implementation of it to `SQLCredentialsProducer`. The database plugins embed `SQLCredentialsProducer` and so no longer need their own implementation of `GenerateCredentials`, so we remove those here. 