### PR TITLE
UI - dynamic related capabilities

### DIFF
--- a/ui/app/adapters/kmip/base.js
+++ b/ui/app/adapters/kmip/base.js
@@ -38,7 +38,12 @@ export default ApplicationAdapter.extend({
   },
 
   query(store, type, query) {
-    return this.ajax(this.urlForQuery(query, type.modelName), 'GET');
+    return this.ajax(this.urlForQuery(query, type.modelName), 'GET').then(resp => {
+      // remove pagination query items here
+      const { size, page, responsePath, pageFilter, ...modelAttrs } = query;
+      resp._requestQuery = modelAttrs;
+      return resp;
+    });
   },
 
   queryRecord(store, type, query) {

--- a/ui/app/lib/attach-capabilities.js
+++ b/ui/app/lib/attach-capabilities.js
@@ -1,0 +1,66 @@
+import DS from 'ember-data';
+import { debug, warn } from '@ember/debug';
+import { typeOf } from '@ember/utils';
+const { belongsTo } = DS;
+
+/*
+ *
+ * attachCapabilities
+ *
+ * @param modelClass = An Ember Data model class
+ * @param capabilities - an Object whose keys will added to the model class as related 'capabilities' models
+ * and whose values should be functions that return the id of the related capabilites model
+ *
+ * definition of capabilities be done shorthand with the apiPath tagged template funtion
+ *
+ *
+ * @usage
+ *
+ * let Model = DS.Model.extend({
+ *   backend: attr(),
+ *   scope: attr(),
+ * });
+ *
+ * export default attachCapabilities(Model, {
+ *   updatePath: apiPath`${'backend'}/scope/${'scope'}/role/${'id'}`,
+ * });
+ *
+ */
+export default function attachCapabilities(modelClass, capabilities) {
+  let capabilityKeys = Object.keys(capabilities);
+  let newRelationships = capabilityKeys.reduce((ret, key) => {
+    ret[key] = belongsTo('capabilities');
+    return ret;
+  }, {});
+
+  debug(`adding new relationships: ${capabilityKeys.join(', ')} to ${modelClass.toString()}`);
+  modelClass.reopen(...newRelationships);
+  modelClass.reopenClass({
+    // relatedCapabilities is called in the application serializer's
+    // normalizeResponse hook to add the capabilities relationships to the
+    // JSON-API document used by Ember Data
+    relatedCapabilities({ data, included }) {
+      let context = {
+        id: data.id,
+        ...data.attributes,
+      };
+      for (let newCapability of capabilityKeys) {
+        let templateFn = capabilityKeys[newCapability];
+        let type = typeOf(templateFn);
+        warn(`expected value of ${newCapability} to be a function but found ${type}.`, type !== 'function');
+        data.relationships[newCapability] = {
+          data: {
+            type: 'capabilities',
+            id: templateFn(context),
+          },
+        };
+      }
+
+      return {
+        data,
+        included,
+      };
+    },
+  });
+  return modelClass;
+}

--- a/ui/app/models/kmip/role.js
+++ b/ui/app/models/kmip/role.js
@@ -2,13 +2,14 @@ import DS from 'ember-data';
 import { computed } from '@ember/object';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import fieldToAttrs from 'vault/utils/field-to-attrs';
+import apiPath from 'vault/utils/api-path';
+import attachCapabilities from 'vault/lib/attach-capabilities';
 
-const { attr, belongsTo } = DS;
-const model = DS.Model.extend({
+const { attr } = DS;
+const Model = DS.Model.extend({
   useOpenAPI: true,
   backend: attr({ readOnly: true }),
   scope: attr({ readOnly: true }),
-  updatePath: belongsTo('capabilities'),
   getHelpUrl(path) {
     return `/v1/${path}/scope/example/role/example?help=1`;
   },
@@ -26,22 +27,6 @@ const model = DS.Model.extend({
   }),
 });
 
-model.reopenClass({
-  relatedCapabilities({ data, included }) {
-    let { backend, scope } = data.attributes;
-    let url = `${backend}/scope/${scope}/role/${data.id}`;
-    data.relationships['updatePath'] = {
-      data: {
-        type: 'capabilities',
-        id: url,
-      },
-    };
-
-    console.log(data);
-    return {
-      data,
-      included,
-    };
-  },
+export default attachCapabilities(Model, {
+  updatePath: apiPath`${'backend'}/scope/${'scope'}/role/${'id'}`,
 });
-export default model;

--- a/ui/app/models/kmip/role.js
+++ b/ui/app/models/kmip/role.js
@@ -3,11 +3,12 @@ import { computed } from '@ember/object';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import fieldToAttrs from 'vault/utils/field-to-attrs';
 
-const { attr } = DS;
-export default DS.Model.extend({
+const { attr, belongsTo } = DS;
+const model = DS.Model.extend({
   useOpenAPI: true,
   backend: attr({ readOnly: true }),
   scope: attr({ readOnly: true }),
+  updatePath: belongsTo('capabilities'),
   getHelpUrl(path) {
     return `/v1/${path}/scope/example/role/example?help=1`;
   },
@@ -24,3 +25,23 @@ export default DS.Model.extend({
     return expandAttributeMeta(this, fields);
   }),
 });
+
+model.reopenClass({
+  relatedCapabilities({ data, included }) {
+    let { backend, scope } = data.attributes;
+    let url = `${backend}/scope/${scope}/role/${data.id}`;
+    data.relationships['updatePath'] = {
+      data: {
+        type: 'capabilities',
+        id: url,
+      },
+    };
+
+    console.log(data);
+    return {
+      data,
+      included,
+    };
+  },
+});
+export default model;

--- a/ui/app/serializers/application.js
+++ b/ui/app/serializers/application.js
@@ -15,7 +15,14 @@ export default DS.JSONSerializer.extend({
           return key;
         }
         let pk = this.get('primaryKey') || 'id';
-        return { [pk]: key };
+        let model = { [pk]: key };
+        // if we've added a in the adapter, we want
+        // attach it to the individual models
+        if (payload._requestQuery) {
+          model = { ...model, ...payload._requestQuery };
+          delete payload._requestQuery;
+        }
+        return model;
       });
       return models;
     }
@@ -42,14 +49,8 @@ export default DS.JSONSerializer.extend({
     }
     let jsonAPIRepresentation = this._super(store, primaryModelClass, responseJSON, id, requestType);
     if (primaryModelClass.relatedCapabilities) {
-      if (Array.isArray(jsonAPIRepresentation)) {
-        jsonAPIRepresentation = jsonAPIRepresentation.map(primaryModelClass.relatedCapabilities);
-      } else {
-        jsonAPIRepresentation = primaryModelClass.relatedCapabilities(jsonAPIRepresentation);
-      }
-      debugger;
+      jsonAPIRepresentation = primaryModelClass.relatedCapabilities(jsonAPIRepresentation);
     }
-    console.log(jsonAPIRepresentation);
     return jsonAPIRepresentation;
   },
 

--- a/ui/app/serializers/application.js
+++ b/ui/app/serializers/application.js
@@ -40,7 +40,17 @@ export default DS.JSONSerializer.extend({
     if (id && !responseJSON.id) {
       responseJSON.id = id;
     }
-    return this._super(store, primaryModelClass, responseJSON, id, requestType);
+    let jsonAPIRepresentation = this._super(store, primaryModelClass, responseJSON, id, requestType);
+    if (primaryModelClass.relatedCapabilities) {
+      if (Array.isArray(jsonAPIRepresentation)) {
+        jsonAPIRepresentation = jsonAPIRepresentation.map(primaryModelClass.relatedCapabilities);
+      } else {
+        jsonAPIRepresentation = primaryModelClass.relatedCapabilities(jsonAPIRepresentation);
+      }
+      debugger;
+    }
+    console.log(jsonAPIRepresentation);
+    return jsonAPIRepresentation;
   },
 
   serializeAttribute(snapshot, json, key, attributes) {

--- a/ui/app/utils/api-path.js
+++ b/ui/app/utils/api-path.js
@@ -1,3 +1,5 @@
+import { assert } from '@ember/debug';
+
 // This is a tagged template function that will
 // replace placeholders in the form of 'id' with the value from the passed context
 //
@@ -10,6 +12,10 @@ export default function apiPath(strings, ...keys) {
   return function(data) {
     let dict = data || {};
     let result = [strings[0]];
+    assert(
+      `Expected ${keys.length} keys in apiPath context, only recieved ${Object.keys(data).length}`,
+      keys.length === Object.keys(data).length
+    );
     keys.forEach((key, i) => {
       result.push(dict[key], strings[i + 1]);
     });

--- a/ui/lib/core/addon/utils/api-path.js
+++ b/ui/lib/core/addon/utils/api-path.js
@@ -1,0 +1,18 @@
+// This is a tagged template function that will
+// replace placeholders in the form of 'id' with the value from the passed context
+//
+// usage:
+// let fn = apiPath`foo/bar/${'id'}`;
+// let output = fn({id: 'an-id'});
+// output will result in 'foo/bar/an-id';
+
+export default function apiPath(strings, ...keys) {
+  return function(data) {
+    let dict = data || {};
+    let result = [strings[0]];
+    keys.forEach((key, i) => {
+      result.push(dict[key], strings[i + 1]);
+    });
+    return result.join('');
+  };
+}

--- a/ui/tests/unit/lib/attach-capabilities-test.js
+++ b/ui/tests/unit/lib/attach-capabilities-test.js
@@ -1,0 +1,161 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import attachCapabilities from 'vault/lib/attach-capabilities';
+import apiPath from 'vault/utils/api-path';
+import { get } from '@ember/object';
+
+let MODEL_TYPE = 'test-form-model';
+
+module('Unit | lib | attach capabilities', function(hooks) {
+  setupTest(hooks);
+
+  test('it attaches passed capabilities', function(assert) {
+    let mc = this.owner.lookup('service:store').modelFor(MODEL_TYPE);
+    mc = attachCapabilities(mc, {
+      updatePath: apiPath`update/{'id'}`,
+      deletePath: apiPath`delete/{'id'}`,
+    });
+    let relationship = get(mc, 'relationshipsByName').get('updatePath');
+
+    assert.equal(relationship.key, 'updatePath', 'has updatePath relationship');
+    assert.equal(relationship.kind, 'belongsTo', 'kind of relationship is belongsTo');
+    assert.equal(relationship.type, 'capabilities', 'updatePath is a related capabilities model');
+
+    relationship = get(mc, 'relationshipsByName').get('deletePath');
+    assert.equal(relationship.key, 'deletePath', 'has deletePath relationship');
+    assert.equal(relationship.kind, 'belongsTo', 'kind of relationship is belongsTo');
+    assert.equal(relationship.type, 'capabilities', 'deletePath is a related capabilities model');
+  });
+
+  test('it adds a static method to the model class', function(assert) {
+    let mc = this.owner.lookup('service:store').modelFor(MODEL_TYPE);
+    mc = attachCapabilities(mc, {
+      updatePath: apiPath`update/{'id'}`,
+      deletePath: apiPath`delete/{'id'}`,
+    });
+    assert.ok(
+      !!mc.relatedCapabilities && typeof mc.relatedCapabilities === 'function',
+      'model class now has a relatedCapabilities static function'
+    );
+  });
+
+  test('calling static method with single response JSON-API document adds expected relationships', function(assert) {
+    let mc = this.owner.lookup('service:store').modelFor(MODEL_TYPE);
+    mc = attachCapabilities(mc, {
+      updatePath: apiPath`update/${'id'}`,
+      deletePath: apiPath`delete/${'id'}`,
+    });
+    let jsonAPIDocSingle = {
+      data: {
+        id: 'test',
+        type: MODEL_TYPE,
+        attributes: {},
+        relationships: {},
+      },
+      included: [],
+    };
+
+    let expected = {
+      data: {
+        id: 'test',
+        type: MODEL_TYPE,
+        attributes: {},
+        relationships: {
+          updatePath: {
+            data: {
+              type: 'capabilities',
+              id: 'update/test',
+            },
+          },
+          deletePath: {
+            data: {
+              type: 'capabilities',
+              id: 'delete/test',
+            },
+          },
+        },
+      },
+      included: [],
+    };
+
+    mc.relatedCapabilities(jsonAPIDocSingle);
+
+    assert.equal(
+      Object.keys(jsonAPIDocSingle.data.relationships).length,
+      2,
+      'document now has 2 relationships'
+    );
+    assert.deepEqual(jsonAPIDocSingle, expected, 'has the exected new document structure');
+  });
+
+  test('calling static method with an arrary response JSON-API document adds expected relationships', function(assert) {
+    let mc = this.owner.lookup('service:store').modelFor(MODEL_TYPE);
+    mc = attachCapabilities(mc, {
+      updatePath: apiPath`update/${'id'}`,
+      deletePath: apiPath`delete/${'id'}`,
+    });
+    let jsonAPIDocSingle = {
+      data: [
+        {
+          id: 'test',
+          type: MODEL_TYPE,
+          attributes: {},
+          relationships: {},
+        },
+        {
+          id: 'foo',
+          type: MODEL_TYPE,
+          attributes: {},
+          relationships: {},
+        },
+      ],
+      included: [],
+    };
+
+    let expected = {
+      data: [
+        {
+          id: 'test',
+          type: MODEL_TYPE,
+          attributes: {},
+          relationships: {
+            updatePath: {
+              data: {
+                type: 'capabilities',
+                id: 'update/test',
+              },
+            },
+            deletePath: {
+              data: {
+                type: 'capabilities',
+                id: 'delete/test',
+              },
+            },
+          },
+        },
+        {
+          id: 'foo',
+          type: MODEL_TYPE,
+          attributes: {},
+          relationships: {
+            updatePath: {
+              data: {
+                type: 'capabilities',
+                id: 'update/foo',
+              },
+            },
+            deletePath: {
+              data: {
+                type: 'capabilities',
+                id: 'delete/foo',
+              },
+            },
+          },
+        },
+      ],
+      included: [],
+    };
+    mc.relatedCapabilities(jsonAPIDocSingle);
+    assert.deepEqual(jsonAPIDocSingle, expected, 'has the exected new document structure');
+  });
+});

--- a/ui/tests/unit/utils/api-path-test.js
+++ b/ui/tests/unit/utils/api-path-test.js
@@ -1,0 +1,23 @@
+import apiPath from 'vault/utils/api-path';
+import { module, test } from 'qunit';
+
+module('Unit | Util | api path', function() {
+  test('it returns a function', function(assert) {
+    let ret = apiPath`foo`;
+    assert.ok(typeof ret === 'function');
+  });
+
+  test('it iterpolates strings from passed context object', function(assert) {
+    let ret = apiPath`foo/${'one'}/${'two'}`;
+    let result = ret({ one: 1, two: 2 });
+
+    assert.equal(result, 'foo/1/2', 'returns the expected string');
+  });
+
+  test('it throws when the key is not found in the context', function(assert) {
+    let ret = apiPath`foo/${'one'}/${'two'}`;
+    assert.throws(() => {
+      ret({ one: 1 });
+    }, /Error: Assertion Failed: Expected 2 keys in apiPath context, only recieved 1/);
+  });
+});


### PR DESCRIPTION
Currently all checks to `sys/capabilities-self` are done via a [capabilities model](https://github.com/hashicorp/vault/blob/981c19e9324b50317c3b1a78c71bec589d8440b7/ui/app/models/capabilities.js). In order to no spam the server with api calls on long lists or other places where we might want to do this, it’s wired up to a [computed macro](https://github.com/hashicorp/vault/blob/981c19e9324b50317c3b1a78c71bec589d8440b7/ui/app/macros/lazy-capabilities.js) that uses another [macro](https://github.com/hashicorp/vault/blob/981c19e9324b50317c3b1a78c71bec589d8440b7/ui/app/macros/maybe-query-record.js) based off of https://github.com/mikkopaderes/ember-computed-query. 

Having models defined in a computed property / macro has a number of downsides. Ember Data doesn’t know about the relationship (because it isn’t one) which has caused us issues with how we empty the Ember Data store at various times in the Vault application. Each property done this way must also be defined manually.

At @alisdair’s suggestion, I looked into making these actual relationships via defining them on the model by manipulating the server responses in the application serializer. This PR is the result - there’s now a model class decorator function that can be used where models are defined like this:

``` 
let ModelClass = DS.Model.extend({ 
  name: DS.attr(‘string’),
// other model definition here 
});
export default attachCapabilities(ModelClass, {
  updatePath: apiPath`path/to/model/${‘name’}/save/${‘id’}`
});
```

This will do 2 things - add an `updatePath` relationship to the `capabilities` model linked above, and create a static method on the class that will be called in the application serializer to attach the relevant capabilities data to the JSON API document that Ember Data loads. The template fn `apiPath` will get used to determine the id of the related capabilities model, and that function is passed the model’s attributes and id as context when it is interpolated.

The result of all of this is that in templates, it’s then possible to do `{{model.updatePath}}` and trigger a lazy request to `sys/capabilities-self`.