### PR TITLE
When using tokenutil, return []string not nil for empty slices

### DIFF
--- a/builtin/credential/userpass/path_users.go
+++ b/builtin/credential/userpass/path_users.go
@@ -172,7 +172,7 @@ func (b *backend) pathUserRead(ctx context.Context, req *logical.Request, d *fra
 		data["max_ttl"] = int64(user.MaxTTL.Seconds())
 	}
 	if len(user.Policies) > 0 {
-		data["policies"] = user.Policies
+		data["policies"] = data["token_policies"]
 	}
 	if len(user.BoundCIDRs) > 0 {
 		data["bound_cidrs"] = user.BoundCIDRs

--- a/sdk/helper/tokenutil/tokenutil.go
+++ b/sdk/helper/tokenutil/tokenutil.go
@@ -212,6 +212,14 @@ func (t *TokenParams) PopulateTokenData(m map[string]interface{}) {
 	m["token_type"] = t.TokenType.String()
 	m["token_ttl"] = int64(t.TokenTTL.Seconds())
 	m["token_num_uses"] = t.TokenNumUses
+
+	if len(t.TokenPolicies) == 0 {
+		m["token_policies"] = []string{}
+	}
+
+	if len(t.TokenBoundCIDRs) == 0 {
+		m["token_bound_cidrs"] = []string{}
+	}
 }
 
 // PopulateTokenAuth populates Auth with parameters


### PR DESCRIPTION
This conveys type information instead of being a JSON null.