### PR TITLE
Add fine-grained locking for file audit sink.

### DIFF
--- a/builtin/audit/file/backend_test.go
+++ b/builtin/audit/file/backend_test.go
@@ -7,8 +7,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/vault/audit"
+	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/salt"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -89,4 +91,53 @@ func TestAuditFile_fileModeExisting(t *testing.T) {
 	if info.Mode() != os.FileMode(0600) {
 		t.Fatalf("File mode does not match.")
 	}
+}
+
+func BenchmarkAuditFile_request(b *testing.B) {
+	config := map[string]string{
+		"path": "/dev/null",
+	}
+	sink, err := Factory(context.Background(), &audit.BackendConfig{
+		Config:     config,
+		SaltConfig: &salt.Config{},
+		SaltView:   &logical.InmemStorage{},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	in := &logical.LogInput{
+		Auth: &logical.Auth{
+			ClientToken:     "foo",
+			Accessor:        "bar",
+			EntityID:        "foobarentity",
+			DisplayName:     "testtoken",
+			NoDefaultPolicy: true,
+			Policies:        []string{"root"},
+			TokenType:       logical.TokenTypeService,
+		},
+		Request: &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "/foo",
+			Connection: &logical.Connection{
+				RemoteAddr: "127.0.0.1",
+			},
+			WrapInfo: &logical.RequestWrapInfo{
+				TTL: 60 * time.Second,
+			},
+			Headers: map[string][]string{
+				"foo": []string{"bar"},
+			},
+		},
+	}
+
+	ctx := namespace.RootContext(nil)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := sink.LogRequest(ctx, in); err != nil {
+				panic(err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
This replaces the exclusive mutex that protected the logging of
requests and responses. This limited the overall throughput when
file auditng is enabled as only a single goroutine at a time could
be marshalling request/response data.

This creates a new mutex which only protects write access to the
the file. The lock is only taken after the data has marshalled and
is ready for writing to the file. 

Resolves #7014

Before change:
```
$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/hashicorp/vault/builtin/audit/file
BenchmarkAuditFile_request-8   	   30000	     54506 ns/op
PASS
ok  	github.com/hashicorp/vault/builtin/audit/file	2.288s
```

After change:
```
$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/hashicorp/vault/builtin/audit/file
BenchmarkAuditFile_request-8   	  100000	     15289 ns/op
PASS
ok  	github.com/hashicorp/vault/builtin/audit/file	1.767s
```