### PR TITLE
Fix upgrade logic with tokenutil

### DIFF
--- a/builtin/credential/userpass/path_user_policies.go
+++ b/builtin/credential/userpass/path_user_policies.go
@@ -54,7 +54,7 @@ func (b *backend) pathUserPoliciesUpdate(ctx context.Context, req *logical.Reque
 		policiesRaw, ok = d.GetOk("policies")
 		if ok {
 			userEntry.Policies = policyutil.ParsePolicies(policiesRaw)
-			userEntry.TokenPolicies = nil
+			userEntry.TokenPolicies = userEntry.Policies
 		}
 	} else {
 		userEntry.TokenPolicies = policyutil.ParsePolicies(policiesRaw)

--- a/builtin/credential/userpass/path_users.go
+++ b/builtin/credential/userpass/path_users.go
@@ -215,7 +215,7 @@ func (b *backend) userCreateUpdate(ctx context.Context, req *logical.Request, d 
 			policiesRaw, ok = d.GetOk("policies")
 			if ok {
 				userEntry.Policies = policyutil.ParsePolicies(policiesRaw)
-				userEntry.TokenPolicies = nil
+				userEntry.TokenPolicies = userEntry.Policies
 			}
 		} else {
 			_, ok = d.GetOk("policies")
@@ -231,7 +231,7 @@ func (b *backend) userCreateUpdate(ctx context.Context, req *logical.Request, d 
 			ttlRaw, ok = d.GetOk("ttl")
 			if ok {
 				userEntry.TTL = time.Duration(ttlRaw.(int)) * time.Second
-				userEntry.TokenTTL = 0
+				userEntry.TokenTTL = userEntry.TTL
 			}
 		} else {
 			_, ok = d.GetOk("ttl")
@@ -247,7 +247,7 @@ func (b *backend) userCreateUpdate(ctx context.Context, req *logical.Request, d 
 			maxTTLRaw, ok = d.GetOk("max_ttl")
 			if ok {
 				userEntry.MaxTTL = time.Duration(maxTTLRaw.(int)) * time.Second
-				userEntry.TokenMaxTTL = 0
+				userEntry.TokenMaxTTL = userEntry.TokenMaxTTL
 			}
 		} else {
 			_, ok = d.GetOk("max_ttl")
@@ -267,7 +267,7 @@ func (b *backend) userCreateUpdate(ctx context.Context, req *logical.Request, d 
 					return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 				}
 				userEntry.BoundCIDRs = boundCIDRs
-				userEntry.TokenBoundCIDRs = nil
+				userEntry.TokenBoundCIDRs = userEntry.BoundCIDRs
 			}
 		} else {
 			_, ok = d.GetOk("bound_cidrs")

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -3094,7 +3094,7 @@ func (ts *TokenStore) tokenStoreRoleCreateUpdate(ctx context.Context, req *logic
 		periodRaw, ok = data.GetOk("period")
 		if ok {
 			entry.Period = time.Second * time.Duration(periodRaw.(int))
-			entry.TokenPeriod = 0
+			entry.TokenPeriod = entry.Period
 		}
 	} else {
 		_, ok = data.GetOk("period")
@@ -3116,7 +3116,7 @@ func (ts *TokenStore) tokenStoreRoleCreateUpdate(ctx context.Context, req *logic
 				return logical.ErrorResponse(errwrap.Wrapf("error parsing bound_cidrs: {{err}}", err).Error()), nil
 			}
 			entry.BoundCIDRs = boundCIDRs
-			entry.TokenBoundCIDRs = nil
+			entry.TokenBoundCIDRs = entry.BoundCIDRs
 		}
 	} else {
 		_, ok = data.GetOk("bound_cidrs")
@@ -3135,7 +3135,7 @@ func (ts *TokenStore) tokenStoreRoleCreateUpdate(ctx context.Context, req *logic
 		explicitMaxTTLRaw, ok = data.GetOk("explicit_max_ttl")
 		if ok {
 			entry.ExplicitMaxTTL = time.Second * time.Duration(explicitMaxTTLRaw.(int))
-			entry.TokenExplicitMaxTTL = 0
+			entry.TokenExplicitMaxTTL = entry.ExplicitMaxTTL
 		}
 		finalExplicitMaxTTL = entry.ExplicitMaxTTL
 	} else {


### PR DESCRIPTION
If only a non-_token field is provided we don't want to clear out the
Token version of the params, we want to set both. Otherwise we can't
rely on using the Token version of the parameter when creating the Auth
struct.