### PR TITLE
Re-enable toggling renewable off for tokens

### DIFF
--- a/sdk/helper/tokenutil/tokenutil.go
+++ b/sdk/helper/tokenutil/tokenutil.go
@@ -258,6 +258,7 @@ func (t *TokenParams) PopulateTokenAuth(auth *logical.Auth) {
 	auth.NoDefaultPolicy = t.TokenNoDefaultPolicy
 	auth.Period = t.TokenPeriod
 	auth.Policies = t.TokenPolicies
+	auth.Renewable = true
 	auth.TokenType = t.TokenType
 	auth.TTL = t.TokenTTL
 	auth.NumUses = t.TokenNumUses

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1030,11 +1030,6 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 		var entity *identity.Entity
 		auth = resp.Auth
 
-		// Only the token store can toggle this off, and that's via a different
-		// path since it's not a login request; it's explicitly disallowed
-		// above
-		auth.Renewable = true
-
 		mEntry := c.router.MatchingMountEntry(ctx, req.Path)
 
 		if auth.Alias != nil &&


### PR DESCRIPTION
Earlier in tokenutil's dev it seemed like there was no reason to allow
auth plugins to toggle renewability off. However, it turns out Centrify
makes use of this for sensible reasons. As a result, move the forcing-on
of renewability into tokenutil, but then allow overriding after
PopulateTokenAuth is called.