### PR TITLE
Fix batch token test

### DIFF
--- a/sdk/helper/tokenutil/tokenutil.go
+++ b/sdk/helper/tokenutil/tokenutil.go
@@ -186,14 +186,12 @@ func (t *TokenParams) ParseTokenFields(req *logical.Request, d *framework.FieldD
 		var tokenType logical.TokenType
 		tokenTypeStr := tokenTypeRaw.(string)
 		switch tokenTypeStr {
+		case "", "default":
+			tokenType = logical.TokenTypeDefault
 		case "service":
 			tokenType = logical.TokenTypeService
 		case "batch":
 			tokenType = logical.TokenTypeBatch
-		case "", "default", "default-service":
-			tokenType = logical.TokenTypeDefaultService
-		case "default-batch":
-			tokenType = logical.TokenTypeDefaultBatch
 		default:
 			return fmt.Errorf("invalid 'token_type' value %q", tokenTypeStr)
 		}

--- a/vault/core.go
+++ b/vault/core.go
@@ -648,6 +648,9 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	atomic.StoreUint32(c.sealed, 1)
 	c.allLoggers = append(c.allLoggers, c.logger)
 
+	c.router.logger = c.logger.Named("router")
+	c.allLoggers = append(c.allLoggers, c.router.logger)
+
 	atomic.StoreUint32(c.replicationState, uint32(consts.ReplicationDRDisabled|consts.ReplicationPerformanceDisabled))
 	c.localClusterCert.Store(([]byte)(nil))
 	c.localClusterParsedCert.Store((*x509.Certificate)(nil))

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1166,7 +1166,7 @@ func (c *Core) unloadMounts(ctx context.Context) error {
 	}
 
 	c.mounts = nil
-	c.router = NewRouter()
+	c.router.reset()
 	c.systemBarrierView = nil
 	return nil
 }

--- a/vault/router.go
+++ b/vault/router.go
@@ -10,6 +10,7 @@ import (
 
 	metrics "github.com/armon/go-metrics"
 	radix "github.com/armon/go-radix"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/salt"
@@ -34,6 +35,7 @@ type Router struct {
 	// to the backend. This is used to map a key back into the backend that owns it.
 	// For example, logical/uuid1/foobar -> secrets/ (kv backend) + foobar
 	storagePrefix *radix.Tree
+	logger        hclog.Logger
 }
 
 // NewRouter returns a new router
@@ -64,6 +66,15 @@ type validateMountResponse struct {
 	MountAccessor string `json:"mount_accessor" structs:"mount_accessor" mapstructure:"mount_accessor"`
 	MountPath     string `json:"mount_path" structs:"mount_path" mapstructure:"mount_path"`
 	MountLocal    bool   `json:"mount_local" structs:"mount_local" mapstructure:"mount_local"`
+}
+
+func (r *Router) reset() {
+	r.l.Lock()
+	defer r.l.Unlock()
+	r.root = radix.New()
+	r.storagePrefix = radix.New()
+	r.mountUUIDCache = radix.New()
+	r.mountAccessorCache = radix.New()
 }
 
 // validateMountByAccessor returns the mount type and ID for a given mount
@@ -700,12 +711,18 @@ func (r *Router) routeCommon(ctx context.Context, req *logical.Request, existenc
 					case logical.TokenTypeService, logical.TokenTypeBatch:
 						resp.Auth.TokenType = re.mountEntry.Config.TokenType
 					case logical.TokenTypeDefault, logical.TokenTypeDefaultService:
-						if resp.Auth.TokenType == logical.TokenTypeDefault {
+						switch resp.Auth.TokenType {
+						case logical.TokenTypeDefault, logical.TokenTypeDefaultService, logical.TokenTypeService:
 							resp.Auth.TokenType = logical.TokenTypeService
+						default:
+							resp.Auth.TokenType = logical.TokenTypeBatch
 						}
 					case logical.TokenTypeDefaultBatch:
-						if resp.Auth.TokenType == logical.TokenTypeDefault {
+						switch resp.Auth.TokenType {
+						case logical.TokenTypeDefault, logical.TokenTypeDefaultBatch, logical.TokenTypeBatch:
 							resp.Auth.TokenType = logical.TokenTypeBatch
+						default:
+							resp.Auth.TokenType = logical.TokenTypeService
 						}
 					}
 				}


### PR DESCRIPTION
At the level of role config it doesn't mean anything to use
default-service or default-batch; that's for mount tuning. So disallow
it in tokenutil. This also fixes the fact that the switch statement
wasn't right.