### PR TITLE
Change regexes for reading entity/group names

### DIFF
--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -65,7 +65,7 @@ func entityPaths(i *IdentityStore) []*framework.Path {
 			HelpDescription: strings.TrimSpace(entityHelp["entity"][1]),
 		},
 		{
-			Pattern: "entity/name/" + framework.GenericNameRegex("name"),
+			Pattern: "entity/name/(?P<name>.+)",
 			Fields:  entityPathFields(),
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.UpdateOperation: i.handleEntityUpdateCommon(),

--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -90,7 +90,7 @@ func groupPaths(i *IdentityStore) []*framework.Path {
 			HelpDescription: strings.TrimSpace(groupHelp["group-id-list"][1]),
 		},
 		{
-			Pattern: "group/name/" + framework.GenericNameRegex("name"),
+			Pattern: "group/name/(?P<name>.+)",
 			Fields:  groupPathFields(),
 			Callbacks: map[logical.Operation]framework.OperationFunc{
 				logical.UpdateOperation: i.pathGroupNameUpdate(),


### PR DESCRIPTION
We don't restrict the name itself, so we shouldn't restrict lookup.

Fixes #7054