### PR TITLE
Update Cert Auth Login API docs — resolves #7039

### DIFF
--- a/website/source/api/auth/cert/index.html.md
+++ b/website/source/api/auth/cert/index.html.md
@@ -361,6 +361,8 @@ https://tools.ietf.org/html/rfc6125#section-2.3)
 ```
 $ curl \
     --request POST \
+    --cert cert.pem \
+    --key key.pem \
     --data @payload.json \
     https://127.0.0.1:8200/v1/auth/cert/login
 ```


### PR DESCRIPTION
- Add `--cert` and `--key` options to `curl` example so that it is
  clearer that the certificate and key must also be passed in