### PR TITLE
Hacky fix to allow raft clusters to work with auditing.  

### DIFF
--- a/physical/raft/streamlayer.go
+++ b/physical/raft/streamlayer.go
@@ -69,17 +69,17 @@ type RaftTLSKeyring struct {
 
 	// ActiveKeyID is the key ID to track the active key in the keyring. Only
 	// the active key is used for dialing.
-	ActiveKeyID string `json:"active_key_id"`
+	ActiveKeyID *string `json:"active_key_id"`
 }
 
 // GetActive returns the active key.
 func (k *RaftTLSKeyring) GetActive() *RaftTLSKey {
-	if k.ActiveKeyID == "" {
+	if *k.ActiveKeyID == "" {
 		return nil
 	}
 
 	for _, key := range k.Keys {
-		if key.ID == k.ActiveKeyID {
+		if key.ID == *k.ActiveKeyID {
 			return key
 		}
 	}

--- a/vault/init.go
+++ b/vault/init.go
@@ -305,7 +305,7 @@ func (c *Core) Initialize(ctx context.Context, initParams *InitParams) (*InitRes
 
 		keyring := &raft.RaftTLSKeyring{
 			Keys:        []*raft.RaftTLSKey{raftTLS},
-			ActiveKeyID: raftTLS.ID,
+			ActiveKeyID: &raftTLS.ID,
 		}
 
 		entry, err := logical.StorageEntryJSON(raftTLSStoragePath, keyring)

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -265,7 +265,7 @@ func (c *Core) startPeriodicRaftTLSRotate(ctx context.Context) error {
 
 		// Upgrade to the new key
 		keyring.Keys = keyring.Keys[1:]
-		keyring.ActiveKeyID = keyring.Keys[0].ID
+		keyring.ActiveKeyID = &keyring.Keys[0].ID
 		keyring.Term += 1
 		entry, err := logical.StorageEntryJSON(raftTLSStoragePath, keyring)
 		if err != nil {


### PR DESCRIPTION
reflect.Value.Set requires that the target be addressable:

>  A value is addressable if it is an element of a slice, an element of
>  an addressable array, a field of an addressable struct, or the result
>  of dereferencing a pointer.

This fix addresses the problem by making the problematic string be a pointer.  Still looking for a better solution, but for now this will unbreak things.