### PR TITLE
Fix barchart bugs

### DIFF
--- a/ui/app/components/http-requests-container.js
+++ b/ui/app/components/http-requests-container.js
@@ -34,9 +34,9 @@ export default Component.extend({
     let filteredCounters = [];
     if (timeWindow === 'Last 12 Months') {
       const today = new Date();
-      const TwelveMonthsAgo = addMonths(today, -12);
+      const twelveMonthsAgo = addMonths(today, -12);
       filteredCounters = counters.filter(counter => {
-        return isWithinRange(counter.start_time, TwelveMonthsAgo, today);
+        return isWithinRange(counter.start_time, twelveMonthsAgo, today);
       });
 
       return filteredCounters;

--- a/ui/app/components/http-requests-dropdown.js
+++ b/ui/app/components/http-requests-dropdown.js
@@ -27,7 +27,12 @@ export default Component.extend({
     let counters = this.counters || [];
     let options = [];
     if (counters.length) {
-      const years = counters.map(counter => counter.start_time.substr(0, 4)).uniq();
+      const years = counters
+        .map(counter => {
+          const year = new Date(counter.start_time);
+          return year.getUTCFullYear();
+        })
+        .uniq();
       years.sort().reverse();
       options = options.concat(years);
     }

--- a/ui/app/styles/components/http-requests-bar-chart.scss
+++ b/ui/app/styles/components/http-requests-bar-chart.scss
@@ -44,6 +44,7 @@
   background: $grey;
   color: $ui-gray-010;
   border-radius: 2px;
+  pointer-events: none !important;
 }
 
 /* Creates a small triangle extender for the tooltip */


### PR DESCRIPTION
This PR fixes a few bugs:
1) Where the `HttpRequestsDropdown` component would break when you changed the knobs in Storybook. Changing the knobs reformatted the `counter.start_time` as a `Date` instead of a string, so the component now handles both cases.
2) The tooltip would blink erratically when you hover over it. We've manually set `pointer-events` to `none` to ensure this doesn't happen.