### PR TITLE
Actually lazy load swagger ui

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: 'babel-eslint',
   root: true,
   parserOptions: {
     ecmaVersion: 2018,

--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.js
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.js
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import parseURL from 'core/utils/parse-url';
 import config from 'open-api-explorer/config/environment';
-//import Swag from 'swagger-ui-dist';
 
 const { APP } = config;
 

--- a/ui/lib/open-api-explorer/addon/components/swagger-ui.js
+++ b/ui/lib/open-api-explorer/addon/components/swagger-ui.js
@@ -2,9 +2,8 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import parseURL from 'core/utils/parse-url';
 import config from 'open-api-explorer/config/environment';
-import Swag from 'swagger-ui-dist';
+//import Swag from 'swagger-ui-dist';
 
-const { SwaggerUIBundle } = Swag;
 const { APP } = config;
 
 const SearchFilterPlugin = () => {
@@ -28,7 +27,7 @@ const SearchFilterPlugin = () => {
   };
 };
 
-const CONFIG = (componentInstance, initialFilter) => {
+const CONFIG = (SwaggerUIBundle, componentInstance, initialFilter) => {
   return {
     dom_id: `#${componentInstance.elementId}-swagger`,
     url: '/v1/sys/internal/specs/openapi',
@@ -76,11 +75,12 @@ export default Component.extend({
   onFilterChange() {},
   swaggerLoading: true,
 
-  didInsertElement() {
+  async didInsertElement() {
+    const { default: SwaggerUIBundle } = await import('swagger-ui-dist/swagger-ui-bundle.js');
     this._super(...arguments);
     // trim any initial slashes
     let initialFilter = this.initialFilter.replace(/^(\/)+/, '');
-    SwaggerUIBundle(CONFIG(this, initialFilter));
+    SwaggerUIBundle(CONFIG(SwaggerUIBundle, this, initialFilter));
   },
 
   actions: {

--- a/ui/lib/open-api-explorer/index.js
+++ b/ui/lib/open-api-explorer/index.js
@@ -12,8 +12,11 @@ module.exports = EngineAddon.extend({
   },
   included() {
     this._super.included && this._super.included.apply(this, arguments);
-    // we want to lazy load these deps, importing them here will result in them being added to the
-    // engine-vendor files that will be lazy loaded with the engine
+    // we want to lazy load the CSS deps, importing them here will result in them being added to the
+    // engine-vendor.css files that will be lazy loaded with the engine
+    // We DON'T want to add the JS deps here because currently that leads to their inclusion in the vendor.js
+    // (this is likely a bug) - to get around that we lazy-load via dynamic `import()` in the swagger-ui.js
+    // component
     this.import('node_modules/swagger-ui-dist/swagger-ui.css');
   },
 

--- a/ui/lib/open-api-explorer/index.js
+++ b/ui/lib/open-api-explorer/index.js
@@ -7,11 +7,13 @@ const EngineAddon = require('ember-engines/lib/engine-addon');
 module.exports = EngineAddon.extend({
   name: 'open-api-explorer',
 
+  babel: {
+    plugins: [require.resolve('ember-auto-import/babel-plugin')],
+  },
   included() {
     this._super.included && this._super.included.apply(this, arguments);
     // we want to lazy load these deps, importing them here will result in them being added to the
     // engine-vendor files that will be lazy loaded with the engine
-    this.import('node_modules/swagger-ui-dist/swagger-ui-bundle.js');
     this.import('node_modules/swagger-ui-dist/swagger-ui.css');
   },
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -64,7 +64,6 @@
     "date-fns": "^1.29.0",
     "deepmerge": "^2.1.1",
     "doctoc": "^1.4.0",
-    "ember-ajax": "^3.1.0",
     "ember-api-actions": "^0.1.8",
     "ember-auto-import": "^1.2.3",
     "ember-basic-dropdown": "^1.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,6 +44,7 @@
     "@hashicorp/structure-icons": "^1.3.0",
     "Duration.js": "icholy/Duration.js#golang_compatible",
     "autosize": "^4.0.0",
+    "babel-eslint": "^10.0.2",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "base64-js": "1.2.1",
     "broccoli-asset-rev": "^2.7.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7204,14 +7204,6 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-ember-ajax@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/ember-ajax/-/ember-ajax-3.1.1.tgz#dcb55aaf1a9fe8b2ce04206863384709ebc2358b"
-  integrity sha512-jepaHuSuJCxiyKMKcyXrBLFmUoZV4UlkS6yfLpNC55pLJjCnJzomeAooe97qt2gGxIdSChpagpgwfTU9RclF2w==
-  dependencies:
-    ember-cli-babel "^6.16.0"
-    najax "^1.0.3"
-
 ember-api-actions@^0.1.8:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/ember-api-actions/-/ember-api-actions-0.1.9.tgz#6a90af17bf79c42daa9b3b06b86a6f60bc098e7f"
@@ -11453,11 +11445,6 @@ jest-validate@^23.5.0:
     leven "^2.1.0"
     pretty-format "^23.6.0"
 
-jquery-deferred@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/jquery-deferred/-/jquery-deferred-0.3.1.tgz#596eca1caaff54f61b110962b23cafea74c35355"
-  integrity sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=
-
 jquery@^3.2.1, jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
@@ -13405,15 +13392,6 @@ mute-stream@0.0.7, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-najax@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/najax/-/najax-1.0.4.tgz#63fd8dbf15d18f24dc895b3a16fec66c136b8084"
-  integrity sha512-wsSacA+RkgY1wxRxXCT3tdqzmamEv9PLeoV/ub9SlLf2RngbPMSqc3A7H35XJDfURC0twMmZsnPdsYPkuuFSVg==
-  dependencies:
-    jquery-deferred "^0.3.0"
-    lodash.defaultsdeep "^4.6.0"
-    qs "^6.2.0"
-
 nan@^2.10.0, nan@^2.9.2:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
@@ -15174,7 +15152,7 @@ qs@6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
-qs@6.5.2, qs@^6.2.0, qs@^6.4.0, qs@~6.5.2:
+qs@6.5.2, qs@^6.4.0, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -82,6 +82,17 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/generator@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.5.0.tgz#f20e4b7a91750ee8b63656073d843d2a736dca4a"
+  integrity sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==
+  dependencies:
+    "@babel/types" "^7.5.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.11"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
@@ -314,6 +325,11 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.0.tgz#3e0713dff89ad6ae37faec3b29dcfc5c979770b7"
+  integrity sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==
 
 "@babel/parser@^7.1.2", "@babel/parser@^7.1.3":
   version "7.1.3"
@@ -1086,6 +1102,21 @@
     "@babel/parser" "^7.2.2"
     "@babel/types" "^7.2.2"
 
+"@babel/traverse@^7.0.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.5.0.tgz#4216d6586854ef5c3c4592dab56ec7eb78485485"
+  integrity sha512-SnA9aLbyOCcnnbQEGwdfBggnc142h/rbqqsXcaATj2hZcegCl903pUD/lfpsNBlBSuWow/YDfRyJuWi2EPR5cg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.5.0"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.5.0"
+    "@babel/types" "^7.5.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
 "@babel/traverse@^7.1.0":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.4.tgz#f4f83b93d649b4b2c91121a9087fa2fa949ec2b4"
@@ -1153,6 +1184,15 @@
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
   integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.0.tgz#e47d43840c2e7f9105bc4d3a2c371b4d0c7832ab"
+  integrity sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
@@ -3019,6 +3059,18 @@ babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.26.3:
     private "^0.1.8"
     slash "^1.0.0"
     source-map "^0.5.7"
+
+babel-eslint@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.2.tgz#182d5ac204579ff0881684b040560fdcc1558456"
+  integrity sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.26.0:
   version "6.26.1"
@@ -8541,6 +8593,14 @@ eslint-plugin-prettier@^3.0.0:
   integrity sha512-4g11opzhqq/8+AMmo5Vc2Gn7z9alZ4JqrbZ+D4i8KlSyxeQhZHlmIrY8U9Akf514MoEhogPa87Jgkq87aZ2Ohw==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^3.7.1:
   version "3.7.3"


### PR DESCRIPTION
When adding the API explorer, we used that engine's `included` hook to import the `swagger-ui-dist` dependencies as is the recommendation. The dev was getting loaded in `engine-vendor.js` lazily, so I thought everything was fine - but oh was I wrong 😬! What I missed is that the dev was also included in the host app's vendor.js contents, ballooning the size of the app for everyone which is exactly the opposite of what we wanted when implementing the API explorer as an engine.

So! `ember-auto-import` supports [dynamic `import()`](https://github.com/ef4/ember-auto-import#dynamic-import)s and that breaks out the dependency appropriately and gets us lazy loading. I'll follow up on that project to see if that's the expected behavior - I'm guessing it's use from an -in-repo-engine that is the tricky / unexpected bit.

Here's the output from building a production bundle before:
```
Built project successfully. Stored in "../pkg/web_ui".
File sizes:
 - ../pkg/web_ui/assets/auto-import-fastboot-d41d8cd98f00b204e9800998ecf8427e.js: 0 B
 - ../pkg/web_ui/assets/node-asset-manifest.js: 1.13 KB (473 B gzipped)
 - ../pkg/web_ui/assets/vault-13cf5e52270944ce414f91cea5c977f2.js: 1.04 MB (165.93 KB gzipped)
 - ../pkg/web_ui/assets/vault-c0721bc5ae0908e5fd269e47e340e68f.css: 461.64 KB (52.94 KB gzipped)
 - ../pkg/web_ui/assets/vendor-38a3a9886f46638d26215bc4deba375e.js: 2.78 MB (783.6 KB gzipped)
 - ../pkg/web_ui/assets/vendor-80e5aa891cdede4b1c75dded09c689cd.css: 13.57 KB (3.59 KB gzipped)
 - ../pkg/web_ui/ember-fetch/fetch-fastboot-5e5d008c8b65b0ac116f7635d0c6c6b9.js: 790 B (465 B gzipped)
 - ../pkg/web_ui/engines-dist/kmip/assets/engine-a00a638bc6e0b688b53d7c56919f4197.js: 57.19 KB (7.82 KB gzipped)
 - ../pkg/web_ui/engines-dist/kmip/assets/engine-vendor-d41d8cd98f00b204e9800998ecf8427e.css: 0 B
 - ../pkg/web_ui/engines-dist/kmip/assets/engine-vendor-d41d8cd98f00b204e9800998ecf8427e.js: 0 B
 - ../pkg/web_ui/engines-dist/kmip/config/environment-07494fb70475ddd62f80eb4d9413b5d0.js: 84 B (98 B gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/assets/engine-9dcfdf942f31c3caa1d6dfd57c3cc072.css: 3.38 KB (829 B gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/assets/engine-ef8492e496a16ddad5d79a8c6972d904.js: 19.4 KB (3.88 KB gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/assets/engine-vendor-461fcd2eddf5fb800aab4dc6da3ebb6b.css: 146.62 KB (22.19 KB gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/assets/engine-vendor-9beab4f5e4fc600cd0960f458e328d59.js: 924.82 KB (270.45 KB gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/config/environment-6a63ae65638dce4cbdec84b219e26ee6.js: 192 B (169 B gzipped)
 - ../pkg/web_ui/engines-dist/replication/assets/engine-6b6ea4817a843d9a5e5763ed2d1adda1.js: 104.92 KB (15.35 KB gzipped)
 - ../pkg/web_ui/engines-dist/replication/assets/engine-vendor-d41d8cd98f00b204e9800998ecf8427e.css: 0 B
 - ../pkg/web_ui/engines-dist/replication/assets/engine-vendor-d41d8cd98f00b204e9800998ecf8427e.js: 0 B
 - ../pkg/web_ui/engines-dist/replication/config/environment-25c3909fb237c2ba58330a02fb739d52.js: 98 B (102 B gzipped)
```

and after: 
```
Built project successfully. Stored in "../pkg/web_ui".
File sizes:
 - ../pkg/web_ui/assets/auto-import-fastboot-1349f61a0ae946250af8aa80bdf3390d.js: 924.56 KB (270.38 KB gzipped)
 - ../pkg/web_ui/assets/chunk.a1b03ad79e3dcadde4fa.js: 924.56 KB (270.38 KB gzipped)
 - ../pkg/web_ui/assets/node-asset-manifest.js: 1.02 KB (445 B gzipped)
 - ../pkg/web_ui/assets/vault-71f8265451907e7cb60e3e5af67265ee.js: 1.04 MB (165.91 KB gzipped)
 - ../pkg/web_ui/assets/vault-c0721bc5ae0908e5fd269e47e340e68f.css: 461.64 KB (52.94 KB gzipped)
 - ../pkg/web_ui/assets/vendor-52425c76c9e941ead3116b3147927831.js: 1.55 MB (410.5 KB gzipped)
 - ../pkg/web_ui/assets/vendor-80e5aa891cdede4b1c75dded09c689cd.css: 13.57 KB (3.59 KB gzipped)
 - ../pkg/web_ui/ember-fetch/fetch-fastboot-5e5d008c8b65b0ac116f7635d0c6c6b9.js: 790 B (465 B gzipped)
 - ../pkg/web_ui/engines-dist/kmip/assets/engine-a00a638bc6e0b688b53d7c56919f4197.js: 57.19 KB (7.82 KB gzipped)
 - ../pkg/web_ui/engines-dist/kmip/assets/engine-vendor-d41d8cd98f00b204e9800998ecf8427e.css: 0 B
 - ../pkg/web_ui/engines-dist/kmip/assets/engine-vendor-d41d8cd98f00b204e9800998ecf8427e.js: 0 B
 - ../pkg/web_ui/engines-dist/kmip/config/environment-07494fb70475ddd62f80eb4d9413b5d0.js: 84 B (98 B gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/assets/engine-9dcfdf942f31c3caa1d6dfd57c3cc072.css: 3.38 KB (829 B gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/assets/engine-eebd3e09f23ff440200a0472ccf37811.js: 19.95 KB (4.13 KB gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/assets/engine-vendor-461fcd2eddf5fb800aab4dc6da3ebb6b.css: 146.62 KB (22.19 KB gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/assets/engine-vendor-d41d8cd98f00b204e9800998ecf8427e.js: 0 B
 - ../pkg/web_ui/engines-dist/open-api-explorer/config/environment-6a63ae65638dce4cbdec84b219e26ee6.js: 192 B (169 B gzipped)
 - ../pkg/web_ui/engines-dist/replication/assets/engine-6b6ea4817a843d9a5e5763ed2d1adda1.js: 104.92 KB (15.35 KB gzipped)
 - ../pkg/web_ui/engines-dist/replication/assets/engine-vendor-d41d8cd98f00b204e9800998ecf8427e.css: 0 B
 - ../pkg/web_ui/engines-dist/replication/assets/engine-vendor-d41d8cd98f00b204e9800998ecf8427e.js: 0 B
 - ../pkg/web_ui/engines-dist/replication/config/environment-25c3909fb237c2ba58330a02fb739d52.js: 98 B (102 B gzipped)
```


The relevant comparisons being:
```
before:
 - ../pkg/web_ui/assets/vendor-38a3a9886f46638d26215bc4deba375e.js: 2.78 MB (783.6 KB gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/assets/engine-vendor-9beab4f5e4fc600cd0960f458e328d59.js: 924.82 KB (270.45 KB gzipped)


after:
 - ../pkg/web_ui/assets/vendor-52425c76c9e941ead3116b3147927831.js: 1.55 MB (410.5 KB gzipped)
 - ../pkg/web_ui/engines-dist/open-api-explorer/assets/engine-vendor-d41d8cd98f00b204e9800998ecf8427e.js: 0 B
 - ../pkg/web_ui/assets/chunk.a1b03ad79e3dcadde4fa.js: 924.56 KB (270.38 KB gzipped)
```

The after shows that the `chunk.` file has been extracted from the two places it was included before - this if the file that gets lazy loaded on the api explorer page.
The before also included a 324KB (before gzip) file that's in `swagger-ui-dist` that we don't use which accounts for the gap in size differences.

Additionally we're removing `ember-ajax` here because it's not needed now that we use ember-fetch and ember's jQuery integration has been disabled.