### PR TITLE
Allow users to non-interactively pass in the password to tls_key_file

### DIFF
--- a/command/main.go
+++ b/command/main.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -134,6 +135,7 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 			ErrorColor: cli.UiColorRed,
 			WarnColor:  cli.UiColorYellow,
 			Ui: &cli.BasicUi{
+				Reader:      bufio.NewReader(os.Stdin),
 				Writer:      runOpts.Stdout,
 				ErrorWriter: uiErrWriter,
 			},
@@ -146,6 +148,7 @@ func RunCustom(args []string, runOpts *RunOptions) int {
 			ErrorColor: cli.UiColorRed,
 			WarnColor:  cli.UiColorYellow,
 			Ui: &cli.BasicUi{
+				Reader: bufio.NewReader(os.Stdin),
 				Writer: runOpts.Stdout,
 			},
 		},


### PR DESCRIPTION
Fixes #3844 

When users attempt to non-interactively provide a password for their `tls_key_file` using a syntax like this:
```
echo $PASSWORD | vault server -config=/path/to/config-with-password-protected-tls-key.hcl
``` 

They receive a panic like this:
```
Enter passphrase for /home/tbex/Documents/vault_configs/key-with-pass/private.key: panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x5a6f90]

goroutine 72 [running]:
bufio.(*Reader).fill(0xc000525f58)
	/usr/local/go/src/bufio/bufio.go:100 +0xe0
bufio.(*Reader).ReadSlice(0xc000746f58, 0x7f8c2a568a0a, 0x1245401, 0x101000000000010, 0x0, 0x1000, 0xc000740000)
	/usr/local/go/src/bufio/bufio.go:356 +0x3d
bufio.(*Reader).ReadBytes(0xc000746f58, 0x100a, 0x1000, 0xc000740000, 0x0, 0x0, 0x0)
	/usr/local/go/src/bufio/bufio.go:434 +0x70
bufio.(*Reader).ReadString(...)
	/usr/local/go/src/bufio/bufio.go:474
github.com/mitchellh/cli.(*BasicUi).ask.func1(0xc0006e1d01, 0xc0005804e0, 0xc0006e1ce0, 0xc0006e1d40)
	/home/tbex/go/pkg/mod/github.com/mitchellh/cli@v1.0.0/ui.go:83 +0xd6
created by github.com/mitchellh/cli.(*BasicUi).ask
	/home/tbex/go/pkg/mod/github.com/mitchellh/cli@v1.0.0/ui.go:76 +0x243
```

This was happening because the reader used at line 76 was nil. It resolves the panic to add a reader to our UI that takes user input. (The UI here is actually the CLI btw.)

This results in the expected behavior:
```
$ echo $PASSWORD | vault server -config=/home/tbex/Documents/vault_configs/key-with-pass/private-key-tls-cert-test.hcl
Enter passphrase for /home/tbex/Documents/vault_configs/key-with-pass/private.key: ==> Vault server configuration:

             Api Address: http://127.0.0.1:8200
                     Cgo: disabled
         Cluster Address: https://127.0.0.1:8201
              Listener 1: tcp (addr: "127.0.0.1:8200", cluster address: "127.0.0.1:8201", max_request_duration: "1m30s", max_request_size: "33554432", tls: "enabled")
               Log Level: debug
                   Mlock: supported: true, enabled: false
                 Storage: inmem
                 Version: Vault v1.2.0-beta1
             Version Sha: 4cdbe34c02fbde25d5603dfa2dba6bb66a8b309f+CHANGES

==> Vault server started! Log data will stream in below:
```