### PR TITLE
Use 4.12.0 node-sass to build on darwin

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -123,7 +123,7 @@
     "ivy-codemirror": "2.1.0",
     "jsonlint": "1.6.0",
     "loader.js": "^4.7.0",
-    "node-sass": "^4.10.0",
+    "node-sass": "^4.12.0",
     "normalize.css": "4.1.1",
     "prettier": "^1.14.3",
     "prettier-eslint-cli": "^4.7.1",


### PR DESCRIPTION
Using 4.10.0:
```
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/mlee/github.com/hashicorp/vault/ui/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:200:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:272:12)
gyp ERR! System Darwin 18.6.0
gyp ERR! command "/usr/local/Cellar/node/12.5.0/bin/node" "/Users/mlee/github.com/hashicorp/vault/ui/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd /Users/mlee/github.com/hashicorp/vault/ui/node_modules/node-sass
gyp ERR! node -v v12.5.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
```


`yarn && yarn run start` works with node-sass 4.12.0

