### PR TITLE
[DRAFT] Change the default for max_open_connections for DB plugins to 4

### DIFF
--- a/sdk/database/helper/connutil/sql.go
+++ b/sdk/database/helper/connutil/sql.go
@@ -63,7 +63,7 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 	})
 
 	if c.MaxOpenConnections == 0 {
-		c.MaxOpenConnections = 2
+		c.MaxOpenConnections = 4
 	}
 
 	if c.MaxIdleConnections == 0 {


### PR DESCRIPTION
[DRAFT]

Change the default for `max_open_connections` for DB plugins to 4, for all database types.

This PR fixes issue #6790 