### PR TITLE
fix saving of TTL and string array fields generated by Open API

### DIFF
--- a/ui/app/components/string-list.js
+++ b/ui/app/components/string-list.js
@@ -62,6 +62,7 @@ export default Component.extend({
     *
     */
   inputList: computed(function() {
+    /* eslint-disable ember/no-side-effects */
     return ArrayProxy.create({
       content: [],
       // trim the `value` when accessing objects

--- a/ui/app/utils/openapi-to-attrs.js
+++ b/ui/app/utils/openapi-to-attrs.js
@@ -23,7 +23,6 @@ export const expandOpenApiProps = function(props) {
     }
     let attrDefn = {
       editType: editType,
-      type: details.type,
       helpText: details.description,
       sensitive: details['x-vault-displaySensitive'],
       label: details['x-vault-displayName'],
@@ -31,6 +30,10 @@ export const expandOpenApiProps = function(props) {
       defaultValue:
         details['x-vault-displayValue'] || (!isEmpty(details['default']) ? details['default'] : null),
     };
+
+    if (editType !== 'ttl' && details.type !== 'array') {
+      attrDefn.type = details.type;
+    }
     // loop to remove empty vals
     for (let attrProp in attrDefn) {
       if (attrDefn[attrProp] == null) {

--- a/ui/tests/unit/utils/openapi-to-attrs-test.js
+++ b/ui/tests/unit/utils/openapi-to-attrs-test.js
@@ -41,12 +41,10 @@ module('Unit | Util | OpenAPI Data Utilities', function() {
     ttl: {
       helpText: 'this is a TTL!',
       editType: 'ttl',
-      type: 'string',
       label: 'TTL',
     },
     awesomePeople: {
       editType: 'stringArray',
-      type: 'array',
       defaultValue: 'Grace Hopper,Lady Ada',
     },
     favoriteIceCream: {
@@ -105,7 +103,6 @@ module('Unit | Util | OpenAPI Data Utilities', function() {
     }),
     ttl: attr('string', {
       editType: 'ttl',
-      type: 'string',
       label: 'TTL',
       helpText: 'this is a TTL!',
     }),


### PR DESCRIPTION
This was already fixed in master and the 1.2 betas, so this back ports the fix for 1.1.4.

Fixes https://github.com/hashicorp/vault/issues/6901