### PR TITLE
Fix "internal/specs/openapi" endpoint

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3250,6 +3250,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 
 			req := &logical.Request{
 				Operation: logical.HelpOperation,
+				Storage: req.Storage,
 			}
 
 			resp, err := backend.HandleRequest(ctx, req)

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -3250,7 +3250,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 
 			req := &logical.Request{
 				Operation: logical.HelpOperation,
-				Storage: req.Storage,
+				Storage:   req.Storage,
 			}
 
 			resp, err := backend.HandleRequest(ctx, req)


### PR DESCRIPTION
Fixes #7095 

There was a panic when generating OpenAPI docs. The reason was, plugins get initialized on their first call. Because the first call from this endpoint didn't include `storage`, that resulted in a panic. No other plugins had been taking advantage of the initialization functionality until just now.

This PR adds `storage` to this call, so it can succeed.