### PR TITLE
adds Cache-Control header to oidc .well-known endpoints

### DIFF
--- a/http/logical.go
+++ b/http/logical.go
@@ -456,6 +456,10 @@ WRITE_RESPONSE:
 		w.Header().Set("Content-Type", contentType)
 	}
 
+	if cacheControl, ok := resp.Data[logical.HTTPRawCacheControl].(string); ok {
+		w.Header().Set("Cache-Control", cacheControl)
+	}
+
 	w.WriteHeader(status)
 	w.Write(body)
 }

--- a/sdk/logical/response.go
+++ b/sdk/logical/response.go
@@ -33,6 +33,10 @@ const (
 	// that it has already been unmarshaled. That way we don't need to simply
 	// ignore errors.
 	HTTPRawBodyAlreadyJSONDecoded = "http_raw_body_already_json_decoded"
+
+	// If set, HTTPRawCacheControl will replace the default Cache-Control=no-store header
+	// set by the generic wrapping handler. The value must be a string.
+	HTTPRawCacheControl = "http_raw_cache_control"
 )
 
 // Response is a struct that stores the response of a request.


### PR DESCRIPTION
This PR introduces a mechanism for raw responses to override the default `Cache-Control` header value of `no-store` with their own custom value. This mechanism is used by the `.well-known/openid-configuration` and the `.well-known/keys` endpoints of the identity/oidc backend.

Determining an appropriate `Cache-Control` duration leverages the cached `nextRun` value except for when there are no keys in storage. This is because when there are no keys in storage, `nextRun` provides a mechanism to _not_ run through rotation logic at every RollbackManager tick and is set to an arbitrary time far out in the future.

It is also possible that at the time of a query to `.well-known/keys` that `nextRun` is in the past. This just means that keys will be rotated and/or expired at the next RollbackManager tick and that `nextRun` will be re-evaluated at that time (a tick happens every minute). In this scenario, the default value of `no-store` is used.