### PR TITLE
AWS credential plugin maintenance

### DIFF
--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -87,7 +87,7 @@ type backend struct {
 	upgradeCancelFunc context.CancelFunc
 }
 
-func Backend(conf *logical.BackendConfig) (*backend, error) {
+func Backend(_ *logical.BackendConfig) (*backend, error) {
 	b := &backend{
 		// Setting the periodic func to be run once in an hour.
 		// If there is a real need, this can be made configurable.
@@ -118,25 +118,25 @@ func Backend(conf *logical.BackendConfig) (*backend, error) {
 			},
 		},
 		Paths: []*framework.Path{
-			pathLogin(b),
-			pathListRole(b),
-			pathListRoles(b),
-			pathRole(b),
-			pathRoleTag(b),
-			pathConfigClient(b),
-			pathConfigCertificate(b),
-			pathConfigIdentity(b),
-			pathConfigSts(b),
-			pathListSts(b),
-			pathConfigTidyRoletagBlacklist(b),
-			pathConfigTidyIdentityWhitelist(b),
-			pathListCertificates(b),
-			pathListRoletagBlacklist(b),
-			pathRoletagBlacklist(b),
-			pathTidyRoletagBlacklist(b),
-			pathListIdentityWhitelist(b),
-			pathIdentityWhitelist(b),
-			pathTidyIdentityWhitelist(b),
+			b.pathLogin(),
+			b.pathListRole(),
+			b.pathListRoles(),
+			b.pathRole(),
+			b.pathRoleTag(),
+			b.pathConfigClient(),
+			b.pathConfigCertificate(),
+			b.pathConfigIdentity(),
+			b.pathConfigSts(),
+			b.pathListSts(),
+			b.pathConfigTidyRoletagBlacklist(),
+			b.pathConfigTidyIdentityWhitelist(),
+			b.pathListCertificates(),
+			b.pathListRoletagBlacklist(),
+			b.pathRoletagBlacklist(),
+			b.pathTidyRoletagBlacklist(),
+			b.pathListIdentityWhitelist(),
+			b.pathIdentityWhitelist(),
+			b.pathTidyIdentityWhitelist(),
 		},
 		Invalidate:     b.invalidate,
 		InitializeFunc: b.initialize,

--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -160,8 +160,8 @@ func (b *backend) periodicFunc(ctx context.Context, req *logical.Request) error 
 	// time matches the nextTidyTime.
 	if b.nextTidyTime.IsZero() || !time.Now().Before(b.nextTidyTime) {
 		if b.System().LocalMount() || !b.System().ReplicationState().HasState(consts.ReplicationPerformanceSecondary|consts.ReplicationPerformanceStandby) {
-			// safety_buffer defaults to 180 days for roletag blacklist
-			safety_buffer := 15552000
+			// safetyBuffer defaults to 180 days for roletag blacklist
+			safetyBuffer := 15552000
 			tidyBlacklistConfigEntry, err := b.lockedConfigTidyRoleTags(ctx, req.Storage)
 			if err != nil {
 				return err
@@ -173,12 +173,12 @@ func (b *backend) periodicFunc(ctx context.Context, req *logical.Request) error 
 				if tidyBlacklistConfigEntry.DisablePeriodicTidy {
 					skipBlacklistTidy = true
 				}
-				// overwrite the default safety_buffer with the configured value
-				safety_buffer = tidyBlacklistConfigEntry.SafetyBuffer
+				// overwrite the default safetyBuffer with the configured value
+				safetyBuffer = tidyBlacklistConfigEntry.SafetyBuffer
 			}
 			// tidy role tags if explicitly not disabled
 			if !skipBlacklistTidy {
-				b.tidyBlacklistRoleTag(ctx, req, safety_buffer)
+				b.tidyBlacklistRoleTag(ctx, req, safetyBuffer)
 			}
 		}
 

--- a/builtin/credential/aws/backend_e2e_test.go
+++ b/builtin/credential/aws/backend_e2e_test.go
@@ -100,7 +100,7 @@ func TestBackend_E2E_Initialize(t *testing.T) {
 	}
 }
 
-func setupAwsTestCluster(t *testing.T, ctx context.Context) *vault.TestCluster {
+func setupAwsTestCluster(t *testing.T, _ context.Context) *vault.TestCluster {
 
 	// create a cluster with the aws auth backend built-in
 	logger := logging.NewVaultLogger(hclog.Trace)

--- a/builtin/credential/aws/backend_test.go
+++ b/builtin/credential/aws/backend_test.go
@@ -1690,7 +1690,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	renewReq.Auth.Metadata["canonical_arn"] = "fake_arn"
 	empty_login_fd := &framework.FieldData{
 		Raw:    map[string]interface{}{},
-		Schema: pathLogin(b).Fields,
+		Schema: b.pathLogin().Fields,
 	}
 	// ensure we can renew
 	resp, err = b.pathLoginRenew(context.Background(), renewReq, empty_login_fd)

--- a/builtin/credential/aws/backend_test.go
+++ b/builtin/credential/aws/backend_test.go
@@ -1688,12 +1688,12 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	// dump a fake ARN into the metadata to ensure that we ONLY look
 	// at the unique ID that has been generated
 	renewReq.Auth.Metadata["canonical_arn"] = "fake_arn"
-	empty_login_fd := &framework.FieldData{
+	emptyLoginFd := &framework.FieldData{
 		Raw:    map[string]interface{}{},
 		Schema: b.pathLogin().Fields,
 	}
 	// ensure we can renew
-	resp, err = b.pathLoginRenew(context.Background(), renewReq, empty_login_fd)
+	resp, err = b.pathLoginRenew(context.Background(), renewReq, emptyLoginFd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1721,7 +1721,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	}
 
 	// and ensure a renew no longer works
-	resp, err = b.pathLoginRenew(context.Background(), renewReq, empty_login_fd)
+	resp, err = b.pathLoginRenew(context.Background(), renewReq, emptyLoginFd)
 	if err == nil || (resp != nil && !resp.IsError()) {
 		t.Errorf("bad: expected failed renew due to changed AWS role ID: resp: %#v", resp)
 	}
@@ -1749,7 +1749,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	}
 	// and ensure we can renew
 	renewReq = generateRenewRequest(storage, resp.Auth)
-	resp, err = b.pathLoginRenew(context.Background(), renewReq, empty_login_fd)
+	resp, err = b.pathLoginRenew(context.Background(), renewReq, emptyLoginFd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1784,7 +1784,7 @@ func TestBackendAcc_LoginWithCallerIdentity(t *testing.T) {
 	}
 
 	renewReq = generateRenewRequest(storage, resp.Auth)
-	resp, err = b.pathLoginRenew(context.Background(), renewReq, empty_login_fd)
+	resp, err = b.pathLoginRenew(context.Background(), renewReq, emptyLoginFd)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/credential/aws/client.go
+++ b/builtin/credential/aws/client.go
@@ -94,7 +94,11 @@ func (b *backend) getClientConfig(ctx context.Context, s logical.Storage, region
 		return nil, err
 	}
 	if stsRole != "" {
-		assumedCredentials := stscreds.NewCredentials(session.New(stsConfig), stsRole)
+		sess, err := session.NewSession(stsConfig)
+		if err != nil {
+			return nil, err
+		}
+		assumedCredentials := stscreds.NewCredentials(sess, stsRole)
 		// Test that we actually have permissions to assume the role
 		if _, err = assumedCredentials.Get(); err != nil {
 			return nil, err
@@ -102,7 +106,11 @@ func (b *backend) getClientConfig(ctx context.Context, s logical.Storage, region
 		config.Credentials = assumedCredentials
 	} else {
 		if b.defaultAWSAccountID == "" {
-			client := sts.New(session.New(stsConfig))
+			sess, err := session.NewSession(stsConfig)
+			if err != nil {
+				return nil, err
+			}
+			client := sts.New(sess)
 			if client == nil {
 				return nil, errwrap.Wrapf("could not obtain sts client: {{err}}", err)
 			}
@@ -214,7 +222,11 @@ func (b *backend) clientEC2(ctx context.Context, s logical.Storage, region, acco
 	}
 
 	// Create a new EC2 client object, cache it and return the same
-	client := ec2.New(session.New(awsConfig))
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, err
+	}
+	client := ec2.New(sess)
 	if client == nil {
 		return nil, fmt.Errorf("could not obtain ec2 client")
 	}
@@ -263,7 +275,11 @@ func (b *backend) clientIAM(ctx context.Context, s logical.Storage, region, acco
 	}
 
 	// Create a new IAM client object, cache it and return the same
-	client := iam.New(session.New(awsConfig))
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, err
+	}
+	client := iam.New(sess)
 	if client == nil {
 		return nil, fmt.Errorf("could not obtain iam client")
 	}

--- a/builtin/credential/aws/path_config_certificate.go
+++ b/builtin/credential/aws/path_config_certificate.go
@@ -68,8 +68,10 @@ func (b *backend) pathListCertificates() *framework.Path {
 	return &framework.Path{
 		Pattern: "config/certificates/?",
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: b.pathCertificatesList,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.pathCertificatesList,
+			},
 		},
 
 		HelpSynopsis:    pathListCertificatesHelpSyn,
@@ -103,11 +105,19 @@ vary. Defaults to "pkcs7".`,
 
 		ExistenceCheck: b.pathConfigCertificateExistenceCheck,
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.CreateOperation: b.pathConfigCertificateCreateUpdate,
-			logical.UpdateOperation: b.pathConfigCertificateCreateUpdate,
-			logical.ReadOperation:   b.pathConfigCertificateRead,
-			logical.DeleteOperation: b.pathConfigCertificateDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathConfigCertificateCreateUpdate,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathConfigCertificateCreateUpdate,
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathConfigCertificateRead,
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathConfigCertificateDelete,
+			},
 		},
 
 		HelpSynopsis:    pathConfigCertificateSyn,

--- a/builtin/credential/aws/path_config_certificate.go
+++ b/builtin/credential/aws/path_config_certificate.go
@@ -6,18 +6,11 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"math/big"
 	"strings"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
-
-// dsaSignature represents the contents of the signature of a signed
-// content using digital signature algorithm.
-type dsaSignature struct {
-	R, S *big.Int
-}
 
 // This certificate is used to verify the PKCS#7 signature of the instance
 // identity document. As per AWS documentation, this public key is valid for
@@ -71,7 +64,7 @@ C1haGgSI/A1uZUKs/Zfnph0oEI0/hu1IIJ/SKBDtN5lvmZ/IzbOPIJWirlsllQIQ
 
 // pathListCertificates creates a path that enables listing of all
 // the AWS public certificates registered with Vault.
-func pathListCertificates(b *backend) *framework.Path {
+func (b *backend) pathListCertificates() *framework.Path {
 	return &framework.Path{
 		Pattern: "config/certificates/?",
 
@@ -84,7 +77,7 @@ func pathListCertificates(b *backend) *framework.Path {
 	}
 }
 
-func pathConfigCertificate(b *backend) *framework.Path {
+func (b *backend) pathConfigCertificate() *framework.Path {
 	return &framework.Path{
 		Pattern: "config/certificate/" + framework.GenericNameRegex("cert_name"),
 		Fields: map[string]*framework.FieldSchema{

--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func pathConfigClient(b *backend) *framework.Path {
+func (b *backend) pathConfigClient() *framework.Path {
 	return &framework.Path{
 		Pattern: "config/client$",
 		Fields: map[string]*framework.FieldSchema{

--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -56,11 +56,19 @@ func (b *backend) pathConfigClient() *framework.Path {
 
 		ExistenceCheck: b.pathConfigClientExistenceCheck,
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.CreateOperation: b.pathConfigClientCreateUpdate,
-			logical.UpdateOperation: b.pathConfigClientCreateUpdate,
-			logical.DeleteOperation: b.pathConfigClientDelete,
-			logical.ReadOperation:   b.pathConfigClientRead,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathConfigClientCreateUpdate,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathConfigClientCreateUpdate,
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathConfigClientDelete,
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathConfigClientRead,
+			},
 		},
 
 		HelpSynopsis:    pathConfigClientHelpSyn,

--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -12,42 +12,42 @@ func (b *backend) pathConfigClient() *framework.Path {
 	return &framework.Path{
 		Pattern: "config/client$",
 		Fields: map[string]*framework.FieldSchema{
-			"access_key": &framework.FieldSchema{
+			"access_key": {
 				Type:        framework.TypeString,
 				Default:     "",
 				Description: "AWS Access Key ID for the account used to make AWS API requests.",
 			},
 
-			"secret_key": &framework.FieldSchema{
+			"secret_key": {
 				Type:        framework.TypeString,
 				Default:     "",
 				Description: "AWS Secret Access Key for the account used to make AWS API requests.",
 			},
 
-			"endpoint": &framework.FieldSchema{
+			"endpoint": {
 				Type:        framework.TypeString,
 				Default:     "",
 				Description: "URL to override the default generated endpoint for making AWS EC2 API calls.",
 			},
 
-			"iam_endpoint": &framework.FieldSchema{
+			"iam_endpoint": {
 				Type:        framework.TypeString,
 				Default:     "",
 				Description: "URL to override the default generated endpoint for making AWS IAM API calls.",
 			},
 
-			"sts_endpoint": &framework.FieldSchema{
+			"sts_endpoint": {
 				Type:        framework.TypeString,
 				Default:     "",
 				Description: "URL to override the default generated endpoint for making AWS STS API calls.",
 			},
 
-			"iam_server_id_header_value": &framework.FieldSchema{
+			"iam_server_id_header_value": {
 				Type:        framework.TypeString,
 				Default:     "",
 				Description: "Value to require in the X-Vault-AWS-IAM-Server-ID request header",
 			},
-			"max_retries": &framework.FieldSchema{
+			"max_retries": {
 				Type:        framework.TypeInt,
 				Default:     aws.UseServiceDefaultRetries,
 				Description: "Maximum number of retries for recoverable exceptions of AWS APIs",

--- a/builtin/credential/aws/path_config_identity.go
+++ b/builtin/credential/aws/path_config_identity.go
@@ -63,7 +63,7 @@ func identityConfigEntry(ctx context.Context, s logical.Storage) (*identityConfi
 	return &entry, nil
 }
 
-func pathConfigIdentityRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+func pathConfigIdentityRead(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
 	config, err := identityConfigEntry(ctx, req.Storage)
 	if err != nil {
 		return nil, err

--- a/builtin/credential/aws/path_config_identity.go
+++ b/builtin/credential/aws/path_config_identity.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func pathConfigIdentity(b *backend) *framework.Path {
+func (b *backend) pathConfigIdentity() *framework.Path {
 	return &framework.Path{
 		Pattern: "config/identity$",
 		Fields: map[string]*framework.FieldSchema{

--- a/builtin/credential/aws/path_config_identity.go
+++ b/builtin/credential/aws/path_config_identity.go
@@ -25,9 +25,13 @@ func (b *backend) pathConfigIdentity() *framework.Path {
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation:   pathConfigIdentityRead,
-			logical.UpdateOperation: pathConfigIdentityUpdate,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: pathConfigIdentityRead,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: pathConfigIdentityUpdate,
+			},
 		},
 
 		HelpSynopsis:    pathConfigIdentityHelpSyn,

--- a/builtin/credential/aws/path_config_sts.go
+++ b/builtin/credential/aws/path_config_sts.go
@@ -17,8 +17,10 @@ func (b *backend) pathListSts() *framework.Path {
 	return &framework.Path{
 		Pattern: "config/sts/?",
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: b.pathStsList,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.pathStsList,
+			},
 		},
 
 		HelpSynopsis:    pathListStsHelpSyn,
@@ -45,11 +47,19 @@ The Vault server must have permissions to assume this role.`,
 
 		ExistenceCheck: b.pathConfigStsExistenceCheck,
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.CreateOperation: b.pathConfigStsCreateUpdate,
-			logical.UpdateOperation: b.pathConfigStsCreateUpdate,
-			logical.ReadOperation:   b.pathConfigStsRead,
-			logical.DeleteOperation: b.pathConfigStsDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathConfigStsCreateUpdate,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathConfigStsCreateUpdate,
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathConfigStsRead,
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathConfigStsDelete,
+			},
 		},
 
 		HelpSynopsis:    pathConfigStsSyn,

--- a/builtin/credential/aws/path_config_sts.go
+++ b/builtin/credential/aws/path_config_sts.go
@@ -13,7 +13,7 @@ type awsStsEntry struct {
 	StsRole string `json:"sts_role"`
 }
 
-func pathListSts(b *backend) *framework.Path {
+func (b *backend) pathListSts() *framework.Path {
 	return &framework.Path{
 		Pattern: "config/sts/?",
 
@@ -26,7 +26,7 @@ func pathListSts(b *backend) *framework.Path {
 	}
 }
 
-func pathConfigSts(b *backend) *framework.Path {
+func (b *backend) pathConfigSts() *framework.Path {
 	return &framework.Path{
 		Pattern: "config/sts/" + framework.GenericNameRegex("account_id"),
 		Fields: map[string]*framework.FieldSchema{

--- a/builtin/credential/aws/path_config_tidy_identity_whitelist.go
+++ b/builtin/credential/aws/path_config_tidy_identity_whitelist.go
@@ -31,11 +31,19 @@ expiration, before it is removed from the backend storage.`,
 
 		ExistenceCheck: b.pathConfigTidyIdentityWhitelistExistenceCheck,
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.CreateOperation: b.pathConfigTidyIdentityWhitelistCreateUpdate,
-			logical.UpdateOperation: b.pathConfigTidyIdentityWhitelistCreateUpdate,
-			logical.ReadOperation:   b.pathConfigTidyIdentityWhitelistRead,
-			logical.DeleteOperation: b.pathConfigTidyIdentityWhitelistDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathConfigTidyIdentityWhitelistCreateUpdate,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathConfigTidyIdentityWhitelistCreateUpdate,
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathConfigTidyIdentityWhitelistRead,
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathConfigTidyIdentityWhitelistDelete,
+			},
 		},
 
 		HelpSynopsis:    pathConfigTidyIdentityWhitelistHelpSyn,

--- a/builtin/credential/aws/path_config_tidy_identity_whitelist.go
+++ b/builtin/credential/aws/path_config_tidy_identity_whitelist.go
@@ -12,7 +12,7 @@ const (
 	identityWhitelistConfigPath = "config/tidy/identity-whitelist"
 )
 
-func pathConfigTidyIdentityWhitelist(b *backend) *framework.Path {
+func (b *backend) pathConfigTidyIdentityWhitelist() *framework.Path {
 	return &framework.Path{
 		Pattern: fmt.Sprintf("%s$", identityWhitelistConfigPath),
 		Fields: map[string]*framework.FieldSchema{

--- a/builtin/credential/aws/path_config_tidy_identity_whitelist.go
+++ b/builtin/credential/aws/path_config_tidy_identity_whitelist.go
@@ -16,13 +16,13 @@ func (b *backend) pathConfigTidyIdentityWhitelist() *framework.Path {
 	return &framework.Path{
 		Pattern: fmt.Sprintf("%s$", identityWhitelistConfigPath),
 		Fields: map[string]*framework.FieldSchema{
-			"safety_buffer": &framework.FieldSchema{
+			"safety_buffer": {
 				Type:    framework.TypeDurationSecond,
 				Default: 259200, //72h
 				Description: `The amount of extra time that must have passed beyond the identity's
 expiration, before it is removed from the backend storage.`,
 			},
-			"disable_periodic_tidy": &framework.FieldSchema{
+			"disable_periodic_tidy": {
 				Type:        framework.TypeBool,
 				Default:     false,
 				Description: "If set to 'true', disables the periodic tidying of the 'identity-whitelist/<instance_id>' entries.",

--- a/builtin/credential/aws/path_config_tidy_roletag_blacklist.go
+++ b/builtin/credential/aws/path_config_tidy_roletag_blacklist.go
@@ -16,7 +16,7 @@ func (b *backend) pathConfigTidyRoletagBlacklist() *framework.Path {
 	return &framework.Path{
 		Pattern: fmt.Sprintf("%s$", roletagBlacklistConfigPath),
 		Fields: map[string]*framework.FieldSchema{
-			"safety_buffer": &framework.FieldSchema{
+			"safety_buffer": {
 				Type:    framework.TypeDurationSecond,
 				Default: 15552000, //180d
 				Description: `The amount of extra time that must have passed beyond the roletag
@@ -24,7 +24,7 @@ expiration, before it is removed from the backend storage.
 Defaults to 4320h (180 days).`,
 			},
 
-			"disable_periodic_tidy": &framework.FieldSchema{
+			"disable_periodic_tidy": {
 				Type:        framework.TypeBool,
 				Default:     false,
 				Description: "If set to 'true', disables the periodic tidying of blacklisted entries.",

--- a/builtin/credential/aws/path_config_tidy_roletag_blacklist.go
+++ b/builtin/credential/aws/path_config_tidy_roletag_blacklist.go
@@ -33,11 +33,19 @@ Defaults to 4320h (180 days).`,
 
 		ExistenceCheck: b.pathConfigTidyRoletagBlacklistExistenceCheck,
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.CreateOperation: b.pathConfigTidyRoletagBlacklistCreateUpdate,
-			logical.UpdateOperation: b.pathConfigTidyRoletagBlacklistCreateUpdate,
-			logical.ReadOperation:   b.pathConfigTidyRoletagBlacklistRead,
-			logical.DeleteOperation: b.pathConfigTidyRoletagBlacklistDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathConfigTidyRoletagBlacklistCreateUpdate,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathConfigTidyRoletagBlacklistCreateUpdate,
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathConfigTidyRoletagBlacklistRead,
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathConfigTidyRoletagBlacklistDelete,
+			},
 		},
 
 		HelpSynopsis:    pathConfigTidyRoletagBlacklistHelpSyn,

--- a/builtin/credential/aws/path_config_tidy_roletag_blacklist.go
+++ b/builtin/credential/aws/path_config_tidy_roletag_blacklist.go
@@ -12,7 +12,7 @@ const (
 	roletagBlacklistConfigPath = "config/tidy/roletag-blacklist"
 )
 
-func pathConfigTidyRoletagBlacklist(b *backend) *framework.Path {
+func (b *backend) pathConfigTidyRoletagBlacklist() *framework.Path {
 	return &framework.Path{
 		Pattern: fmt.Sprintf("%s$", roletagBlacklistConfigPath),
 		Fields: map[string]*framework.FieldSchema{

--- a/builtin/credential/aws/path_identity_whitelist.go
+++ b/builtin/credential/aws/path_identity_whitelist.go
@@ -19,9 +19,13 @@ gets cached in this whitelist, keyed off of instance ID.`,
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation:   b.pathIdentityWhitelistRead,
-			logical.DeleteOperation: b.pathIdentityWhitelistDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathIdentityWhitelistRead,
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathIdentityWhitelistDelete,
+			},
 		},
 
 		HelpSynopsis:    pathIdentityWhitelistSyn,
@@ -33,8 +37,10 @@ func (b *backend) pathListIdentityWhitelist() *framework.Path {
 	return &framework.Path{
 		Pattern: "identity-whitelist/?",
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: b.pathWhitelistIdentitiesList,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.pathWhitelistIdentitiesList,
+			},
 		},
 
 		HelpSynopsis:    pathListIdentityWhitelistHelpSyn,

--- a/builtin/credential/aws/path_identity_whitelist.go
+++ b/builtin/credential/aws/path_identity_whitelist.go
@@ -12,7 +12,7 @@ func (b *backend) pathIdentityWhitelist() *framework.Path {
 	return &framework.Path{
 		Pattern: "identity-whitelist/" + framework.GenericNameRegex("instance_id"),
 		Fields: map[string]*framework.FieldSchema{
-			"instance_id": &framework.FieldSchema{
+			"instance_id": {
 				Type: framework.TypeString,
 				Description: `EC2 instance ID. A successful login operation from an EC2 instance
 gets cached in this whitelist, keyed off of instance ID.`,

--- a/builtin/credential/aws/path_identity_whitelist.go
+++ b/builtin/credential/aws/path_identity_whitelist.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func pathIdentityWhitelist(b *backend) *framework.Path {
+func (b *backend) pathIdentityWhitelist() *framework.Path {
 	return &framework.Path{
 		Pattern: "identity-whitelist/" + framework.GenericNameRegex("instance_id"),
 		Fields: map[string]*framework.FieldSchema{
@@ -29,7 +29,7 @@ gets cached in this whitelist, keyed off of instance ID.`,
 	}
 }
 
-func pathListIdentityWhitelist(b *backend) *framework.Path {
+func (b *backend) pathListIdentityWhitelist() *framework.Path {
 	return &framework.Path{
 		Pattern: "identity-whitelist/?",
 

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -109,9 +109,13 @@ needs to be supplied along with 'identity' parameter.`,
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation:         b.pathLoginUpdate,
-			logical.AliasLookaheadOperation: b.pathLoginUpdate,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathLoginUpdate,
+			},
+			logical.AliasLookaheadOperation: &framework.PathOperation{
+				Callback: b.pathLoginUpdate,
+			},
 		},
 
 		HelpSynopsis:    pathLoginSyn,

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -1427,7 +1427,7 @@ func parseIamArn(iamArn string) (*iamEntity, error) {
 	return &entity, nil
 }
 
-func validateVaultHeaderValue(headers http.Header, requestUrl *url.URL, requiredHeaderValue string) error {
+func validateVaultHeaderValue(headers http.Header, _ *url.URL, requiredHeaderValue string) error {
 	providedValue := ""
 	for k, v := range headers {
 		if strings.EqualFold(iamServerIdHeader, k) {

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -37,7 +37,7 @@ const (
 	ec2EntityType                 = "ec2_instance"
 )
 
-func pathLogin(b *backend) *framework.Path {
+func (b *backend) pathLogin() *framework.Path {
 	return &framework.Path{
 		Pattern: "login$",
 		Fields: map[string]*framework.FieldSchema{

--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -132,7 +132,7 @@ of the tag should be generated using 'role/<role>/tag' endpoint.
 Defaults to an empty string, meaning that role tags are disabled. This
 is only allowed if auth_type is ec2.`,
 			},
-			"period": &framework.FieldSchema{
+			"period": {
 				Type:        framework.TypeDurationSecond,
 				Description: tokenutil.DeprecationText("token_period"),
 				Deprecated:  true,

--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -175,11 +175,19 @@ auth_type is ec2.`,
 
 		ExistenceCheck: b.pathRoleExistenceCheck,
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.CreateOperation: b.pathRoleCreateUpdate,
-			logical.UpdateOperation: b.pathRoleCreateUpdate,
-			logical.ReadOperation:   b.pathRoleRead,
-			logical.DeleteOperation: b.pathRoleDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathRoleCreateUpdate,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathRoleCreateUpdate,
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathRoleRead,
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathRoleDelete,
+			},
 		},
 
 		HelpSynopsis:    pathRoleSyn,
@@ -194,8 +202,10 @@ func (b *backend) pathListRole() *framework.Path {
 	return &framework.Path{
 		Pattern: "role/?",
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: b.pathRoleList,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.pathRoleList,
+			},
 		},
 
 		HelpSynopsis:    pathListRolesHelpSyn,
@@ -207,8 +217,10 @@ func (b *backend) pathListRoles() *framework.Path {
 	return &framework.Path{
 		Pattern: "roles/?",
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: b.pathRoleList,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.pathRoleList,
+			},
 		},
 
 		HelpSynopsis:    pathListRolesHelpSyn,

--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -20,7 +20,7 @@ var (
 	currentRoleStorageVersion = 3
 )
 
-func pathRole(b *backend) *framework.Path {
+func (b *backend) pathRole() *framework.Path {
 	p := &framework.Path{
 		Pattern: "role/" + framework.GenericNameRegex("role"),
 		Fields: map[string]*framework.FieldSchema{
@@ -190,7 +190,7 @@ auth_type is ec2.`,
 	return p
 }
 
-func pathListRole(b *backend) *framework.Path {
+func (b *backend) pathListRole() *framework.Path {
 	return &framework.Path{
 		Pattern: "role/?",
 
@@ -203,7 +203,7 @@ func pathListRole(b *backend) *framework.Path {
 	}
 }
 
-func pathListRoles(b *backend) *framework.Path {
+func (b *backend) pathListRoles() *framework.Path {
 	return &framework.Path{
 		Pattern: "roles/?",
 

--- a/builtin/credential/aws/path_role_tag.go
+++ b/builtin/credential/aws/path_role_tag.go
@@ -20,7 +20,7 @@ import (
 
 const roleTagVersion = "v1"
 
-func pathRoleTag(b *backend) *framework.Path {
+func (b *backend) pathRoleTag() *framework.Path {
 	return &framework.Path{
 		Pattern: "role/" + framework.GenericNameRegex("role") + "/tag$",
 		Fields: map[string]*framework.FieldSchema{

--- a/builtin/credential/aws/path_role_tag.go
+++ b/builtin/credential/aws/path_role_tag.go
@@ -24,35 +24,35 @@ func (b *backend) pathRoleTag() *framework.Path {
 	return &framework.Path{
 		Pattern: "role/" + framework.GenericNameRegex("role") + "/tag$",
 		Fields: map[string]*framework.FieldSchema{
-			"role": &framework.FieldSchema{
+			"role": {
 				Type:        framework.TypeString,
 				Description: "Name of the role.",
 			},
 
-			"instance_id": &framework.FieldSchema{
+			"instance_id": {
 				Type: framework.TypeString,
 				Description: `Instance ID for which this tag is intended for.
 If set, the created tag can only be used by the instance with the given ID.`,
 			},
 
-			"policies": &framework.FieldSchema{
+			"policies": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: "Policies to be associated with the tag. If set, must be a subset of the role's policies. If set, but set to an empty value, only the 'default' policy will be given to issued tokens.",
 			},
 
-			"max_ttl": &framework.FieldSchema{
+			"max_ttl": {
 				Type:        framework.TypeDurationSecond,
 				Default:     0,
 				Description: "If set, specifies the maximum allowed token lifetime.",
 			},
 
-			"allow_instance_migration": &framework.FieldSchema{
+			"allow_instance_migration": {
 				Type:        framework.TypeBool,
 				Default:     false,
 				Description: "If set, allows migration of the underlying instance where the client resides. This keys off of pendingTime in the metadata document, so essentially, this disables the client nonce check whenever the instance is migrated to a new host and pendingTime is newer than the previously-remembered time. Use with caution.",
 			},
 
-			"disallow_reauthentication": &framework.FieldSchema{
+			"disallow_reauthentication": {
 				Type:        framework.TypeBool,
 				Default:     false,
 				Description: "If set, only allows a single token to be granted per instance ID. In order to perform a fresh login, the entry in whitelist for the instance ID needs to be cleared using the 'auth/aws-ec2/identity-whitelist/<instance_id>' endpoint.",

--- a/builtin/credential/aws/path_role_tag.go
+++ b/builtin/credential/aws/path_role_tag.go
@@ -59,8 +59,10 @@ If set, the created tag can only be used by the instance with the given ID.`,
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathRoleTagUpdate,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathRoleTagUpdate,
+			},
 		},
 
 		HelpSynopsis:    pathRoleTagSyn,

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -757,13 +757,13 @@ func TestAwsEc2_RoleDurationSeconds(t *testing.T) {
 		t.Fatalf("resp: %#v, err: %v", resp, err)
 	}
 
-	if int64(resp.Data["ttl"].(int64)) != 10 {
+	if resp.Data["ttl"].(int64) != 10 {
 		t.Fatalf("bad: period; expected: 10, actual: %d", resp.Data["ttl"])
 	}
-	if int64(resp.Data["max_ttl"].(int64)) != 20 {
+	if resp.Data["max_ttl"].(int64) != 20 {
 		t.Fatalf("bad: period; expected: 20, actual: %d", resp.Data["max_ttl"])
 	}
-	if int64(resp.Data["period"].(int64)) != 30 {
+	if resp.Data["period"].(int64) != 30 {
 		t.Fatalf("bad: period; expected: 30, actual: %d", resp.Data["period"])
 	}
 }
@@ -986,6 +986,6 @@ func TestAwsVersion(t *testing.T) {
 	}
 }
 
-func resolveArnToFakeUniqueId(ctx context.Context, s logical.Storage, arn string) (string, error) {
+func resolveArnToFakeUniqueId(_ context.Context, _ logical.Storage, _ string) (string, error) {
 	return "FakeUniqueId1", nil
 }

--- a/builtin/credential/aws/path_roletag_blacklist.go
+++ b/builtin/credential/aws/path_roletag_blacklist.go
@@ -13,7 +13,7 @@ func (b *backend) pathRoletagBlacklist() *framework.Path {
 	return &framework.Path{
 		Pattern: "roletag-blacklist/(?P<role_tag>.*)",
 		Fields: map[string]*framework.FieldSchema{
-			"role_tag": &framework.FieldSchema{
+			"role_tag": {
 				Type: framework.TypeString,
 				Description: `Role tag to be blacklisted. The tag can be supplied as-is. In order
 to avoid any encoding problems, it can be base64 encoded.`,

--- a/builtin/credential/aws/path_roletag_blacklist.go
+++ b/builtin/credential/aws/path_roletag_blacklist.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func pathRoletagBlacklist(b *backend) *framework.Path {
+func (b *backend) pathRoletagBlacklist() *framework.Path {
 	return &framework.Path{
 		Pattern: "roletag-blacklist/(?P<role_tag>.*)",
 		Fields: map[string]*framework.FieldSchema{
@@ -32,7 +32,7 @@ to avoid any encoding problems, it can be base64 encoded.`,
 }
 
 // Path to list all the blacklisted tags.
-func pathListRoletagBlacklist(b *backend) *framework.Path {
+func (b *backend) pathListRoletagBlacklist() *framework.Path {
 	return &framework.Path{
 		Pattern: "roletag-blacklist/?",
 

--- a/builtin/credential/aws/path_roletag_blacklist.go
+++ b/builtin/credential/aws/path_roletag_blacklist.go
@@ -20,10 +20,16 @@ to avoid any encoding problems, it can be base64 encoded.`,
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathRoletagBlacklistUpdate,
-			logical.ReadOperation:   b.pathRoletagBlacklistRead,
-			logical.DeleteOperation: b.pathRoletagBlacklistDelete,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathRoletagBlacklistUpdate,
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathRoletagBlacklistRead,
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathRoletagBlacklistDelete,
+			},
 		},
 
 		HelpSynopsis:    pathRoletagBlacklistSyn,
@@ -36,8 +42,10 @@ func (b *backend) pathListRoletagBlacklist() *framework.Path {
 	return &framework.Path{
 		Pattern: "roletag-blacklist/?",
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: b.pathRoletagBlacklistsList,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.pathRoletagBlacklistsList,
+			},
 		},
 
 		HelpSynopsis:    pathListRoletagBlacklistHelpSyn,

--- a/builtin/credential/aws/path_tidy_identity_whitelist.go
+++ b/builtin/credential/aws/path_tidy_identity_whitelist.go
@@ -25,8 +25,10 @@ expiration, before it is removed from the backend storage.`,
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathTidyIdentityWhitelistUpdate,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathTidyIdentityWhitelistUpdate,
+			},
 		},
 
 		HelpSynopsis:    pathTidyIdentityWhitelistSyn,

--- a/builtin/credential/aws/path_tidy_identity_whitelist.go
+++ b/builtin/credential/aws/path_tidy_identity_whitelist.go
@@ -17,7 +17,7 @@ func (b *backend) pathTidyIdentityWhitelist() *framework.Path {
 	return &framework.Path{
 		Pattern: "tidy/identity-whitelist$",
 		Fields: map[string]*framework.FieldSchema{
-			"safety_buffer": &framework.FieldSchema{
+			"safety_buffer": {
 				Type:    framework.TypeDurationSecond,
 				Default: 259200,
 				Description: `The amount of extra time that must have passed beyond the identity's

--- a/builtin/credential/aws/path_tidy_identity_whitelist.go
+++ b/builtin/credential/aws/path_tidy_identity_whitelist.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func pathTidyIdentityWhitelist(b *backend) *framework.Path {
+func (b *backend) pathTidyIdentityWhitelist() *framework.Path {
 	return &framework.Path{
 		Pattern: "tidy/identity-whitelist$",
 		Fields: map[string]*framework.FieldSchema{

--- a/builtin/credential/aws/path_tidy_roletag_blacklist.go
+++ b/builtin/credential/aws/path_tidy_roletag_blacklist.go
@@ -25,8 +25,10 @@ expiration, before it is removed from the backend storage.`,
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathTidyRoletagBlacklistUpdate,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathTidyRoletagBlacklistUpdate,
+			},
 		},
 
 		HelpSynopsis:    pathTidyRoletagBlacklistSyn,

--- a/builtin/credential/aws/path_tidy_roletag_blacklist.go
+++ b/builtin/credential/aws/path_tidy_roletag_blacklist.go
@@ -17,7 +17,7 @@ func (b *backend) pathTidyRoletagBlacklist() *framework.Path {
 	return &framework.Path{
 		Pattern: "tidy/roletag-blacklist$",
 		Fields: map[string]*framework.FieldSchema{
-			"safety_buffer": &framework.FieldSchema{
+			"safety_buffer": {
 				Type:    framework.TypeDurationSecond,
 				Default: 259200, // 72h
 				Description: `The amount of extra time that must have passed beyond the roletag

--- a/builtin/credential/aws/path_tidy_roletag_blacklist.go
+++ b/builtin/credential/aws/path_tidy_roletag_blacklist.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func pathTidyRoletagBlacklist(b *backend) *framework.Path {
+func (b *backend) pathTidyRoletagBlacklist() *framework.Path {
 	return &framework.Path{
 		Pattern: "tidy/roletag-blacklist$",
 		Fields: map[string]*framework.FieldSchema{


### PR DESCRIPTION
I am about to start working on #5844 , and I noticed that this plugin could use some updates. 

This PR places functions that create paths paths on the `backend` rather than passing the `backend` into them. This makes sense because a) they're only used by the backend, and b) a path is something the `backend` _has_, so it jives with OOP. We also do it elsewhere now as the standard practice.

This also strips redundant field type declarations like the `&Object` below, which is no longer preferred in Go:
```
map[string]*Object {
    "first_thing": &Object{"something"},
}
```
This also replaces deprecated fields. Vault's implementation of OpenAPI has deprecated the `Callbacks` field in favor of `Operations`. AWS has deprecated `session.New` (which doesn't return an error) in favor of `session.NewSession`.

I also fixed a couple of minor linting issues along the way.