### PR TITLE
Avoid panic if no user found.

### DIFF
--- a/builtin/credential/userpass/path_login.go
+++ b/builtin/credential/userpass/path_login.go
@@ -65,7 +65,7 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 	user, userError := b.user(ctx, req.Storage, username)
 
 	// Check for a CIDR match.
-	if !cidrutil.RemoteAddrIsOk(req.Connection.RemoteAddr, user.TokenBoundCIDRs) {
+	if user != nil && !cidrutil.RemoteAddrIsOk(req.Connection.RemoteAddr, user.TokenBoundCIDRs) {
 		return nil, logical.ErrPermissionDenied
 	}
 


### PR DESCRIPTION
Regression from #7046 makes some integ tests panic.