### PR TITLE
ci: re-enable browserstack tests

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,5 +1,5 @@
-SHELL       := /usr/bin/env bash
-.SHELLFLAGS := -euo pipefail -c
+# SHELL includes all flags for maximum compatibility, see https://fieldnotes.tech/how-to-shell-for-compatible-makefiles/
+SHELL := /usr/bin/env bash -euo pipefail -c
 
 # CONFIG is the name of the make target someone
 # would invoke to update the main config file (config.yml).

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
   install-ui-dependencies:
     docker:
     - image: node:10-stretch
+    shell: /usr/bin/env bash -euo pipefail -c
     working_directory: /src
     steps:
     - checkout
@@ -53,6 +54,7 @@ jobs:
   go-mod-download:
     docker:
     - image: golang:1.12.4-stretch
+    shell: /usr/bin/env bash -euo pipefail -c
     working_directory: /src
     steps:
     - add_ssh_keys:
@@ -74,6 +76,7 @@ jobs:
   build-go-dev:
     docker:
     - image: golang:1.12.4-stretch
+    shell: /usr/bin/env bash -euo pipefail -c
     working_directory: /src
     steps:
     - checkout
@@ -99,6 +102,7 @@ jobs:
   test-ui:
     docker:
     - image: node:10-stretch
+    shell: /usr/bin/env bash -euo pipefail -c
     working_directory: /src
     resource_class: medium+
     steps:
@@ -133,8 +137,26 @@ jobs:
         path: ui/test-results
     - store_test_results:
         path: ui/test-results
+  test-ui-browserstack:
+    docker:
+    - image: node:10-stretch
+    shell: /usr/bin/env bash -euo pipefail -c
+    working_directory: /src
+    steps:
+    - checkout
+    - restore_cache:
+        key: yarn-lock-v1-{{ checksum "ui/yarn.lock" }}
+    - attach_workspace:
+        at: .
+    - run:
+        command: |
+          # Add ./bin to the PATH so vault binary can be found.
+          export PATH="${PWD}"/bin:${PATH}
+          make test-ui-browserstack
+        name: Run Browserstack Tests
   test-go:
     machine: true
+    shell: /usr/bin/env bash -euo pipefail -c
     working_directory: ~/src
     parallelism: 2
     steps:
@@ -207,6 +229,7 @@ jobs:
     - GOTESTSUM_VERSION: 0.3.3
   test-go-race:
     machine: true
+    shell: /usr/bin/env bash -euo pipefail -c
     working_directory: ~/src
     steps:
     - checkout
@@ -290,6 +313,10 @@ workflows:
         requires:
         - go-mod-download
     - test-ui:
+        requires:
+        - install-ui-dependencies
+        - build-go-dev
+    - test-ui-browserstack:
         requires:
         - install-ui-dependencies
         - build-go-dev
@@ -382,6 +409,7 @@ workflows:
 #   go:
 #     docker:
 #     - image: golang:1.12.4-stretch
+#     shell: /usr/bin/env bash -euo pipefail -c
 #     working_directory: /src
 #   go-machine:
 #     environment:
@@ -390,10 +418,12 @@ workflows:
 #       GO_VERSION: 1.12.4
 #       GOTESTSUM_VERSION: 0.3.3
 #     machine: true
+#     shell: /usr/bin/env bash -euo pipefail -c
 #     working_directory: ~/src
 #   node:
 #     docker:
 #     - image: node:10-stretch
+#     shell: /usr/bin/env bash -euo pipefail -c
 #     working_directory: /src
 # jobs:
 #   build-go-dev:
@@ -546,6 +576,19 @@ workflows:
 #         path: ui/test-results
 #     - store_test_results:
 #         path: ui/test-results
+#   test-ui-browserstack:
+#     executor: node
+#     steps:
+#     - checkout
+#     - restore_yarn_cache
+#     - attach_workspace:
+#         at: .
+#     - run:
+#         command: |
+#           # Add ./bin to the PATH so vault binary can be found.
+#           export PATH=\"${PWD}\"/bin:${PATH}
+#           make test-ui-browserstack
+#         name: Run Browserstack Tests
 # references:
 #   cache:
 #     go-sum: go-sum-v1-{{ checksum \"go.sum\" }}
@@ -568,6 +611,10 @@ workflows:
 #         requires:
 #         - go-mod-download
 #     - test-ui:
+#         requires:
+#         - install-ui-dependencies
+#         - build-go-dev
+#     - test-ui-browserstack:
 #         requires:
 #         - install-ui-dependencies
 #         - build-go-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,6 @@ jobs:
         key: yarn-lock-v1-{{ checksum "ui/yarn.lock" }}
     - run:
         command: |
-          set -eux -o pipefail
-
           cd ui
           yarn install --ignore-optional
           npm rebuild node-sass
@@ -86,8 +84,6 @@ jobs:
         at: .
     - run:
         command: |
-          set -eux -o pipefail
-
           # Move dev UI assets to expected location
           rm -rf ./pkg
           mkdir ./pkg
@@ -113,7 +109,7 @@ jobs:
         at: .
     - run:
         command: |
-          set -eux -o pipefail
+          set -x
 
           # Install Chrome
           wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
@@ -163,8 +159,6 @@ jobs:
     - checkout
     - run:
         command: |
-          set -eux -o pipefail
-
           sudo mkdir /go
           sudo chown -R circleci:circleci /go
         name: Allow circleci user to restore Go modules cache
@@ -172,7 +166,7 @@ jobs:
         key: go-sum-v1-{{ checksum "go.sum" }}
     - run:
         command: |
-          set -eux -o pipefail
+          set -x
 
           # Install Go
           curl -sSLO "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz"
@@ -235,8 +229,6 @@ jobs:
     - checkout
     - run:
         command: |
-          set -eux -o pipefail
-
           sudo mkdir /go
           sudo chown -R circleci:circleci /go
         name: Allow circleci user to restore Go modules cache
@@ -244,7 +236,7 @@ jobs:
         key: go-sum-v1-{{ checksum "go.sum" }}
     - run:
         command: |
-          set -eux -o pipefail
+          set -x
 
           # Install Go
           curl -sSLO "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz"
@@ -339,7 +331,7 @@ workflows:
 #     steps:
 #     - run:
 #         command: |
-#           set -eux -o pipefail
+#           set -x
 # 
 #           # Install Go
 #           curl -sSLO \"https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz\"
@@ -435,8 +427,6 @@ workflows:
 #         at: .
 #     - run:
 #         command: |
-#           set -eux -o pipefail
-# 
 #           # Move dev UI assets to expected location
 #           rm -rf ./pkg
 #           mkdir ./pkg
@@ -470,8 +460,6 @@ workflows:
 #     - restore_yarn_cache
 #     - run:
 #         command: |
-#           set -eux -o pipefail
-# 
 #           cd ui
 #           yarn install --ignore-optional
 #           npm rebuild node-sass
@@ -513,8 +501,6 @@ workflows:
 #     - checkout
 #     - run:
 #         command: |
-#           set -eux -o pipefail
-# 
 #           sudo mkdir /go
 #           sudo chown -R circleci:circleci /go
 #         name: Allow circleci user to restore Go modules cache
@@ -530,8 +516,6 @@ workflows:
 #     - checkout
 #     - run:
 #         command: |
-#           set -eux -o pipefail
-# 
 #           sudo mkdir /go
 #           sudo chown -R circleci:circleci /go
 #         name: Allow circleci user to restore Go modules cache
@@ -552,7 +536,7 @@ workflows:
 #         at: .
 #     - run:
 #         command: |
-#           set -eux -o pipefail
+#           set -x
 # 
 #           # Install Chrome
 #           wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \\

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -37,6 +37,7 @@ executors:
   go:
     docker:
       - image: *GOLANG_IMAGE
+    shell: /usr/bin/env bash -euo pipefail -c
     working_directory: /src
   go-machine:
     machine: true
@@ -45,9 +46,11 @@ executors:
       GO_VERSION: 1.12.4  # Pin Go to patch version (ex: 1.2.3)
       GOTESTSUM_VERSION: 0.3.3  # Pin gotestsum to patch version (ex: 1.2.3)
       GO_TAGS:
+    shell: /usr/bin/env bash -euo pipefail -c
     working_directory: ~/src
   node:
     docker:
       - image: *NODE_IMAGE
+    shell: /usr/bin/env bash -euo pipefail -c
     working_directory: /src
 

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -8,7 +8,7 @@ steps:
       name: Run Go tests
       no_output_timeout: 20m
       command: |
-        set -eux -o pipefail
+        set -x
 
         # Install Go
         curl -sSLO "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz"

--- a/.circleci/config/jobs/build-go-dev.yml
+++ b/.circleci/config/jobs/build-go-dev.yml
@@ -7,8 +7,6 @@ steps:
   - run:
       name: Build dev binary
       command: |
-        set -eux -o pipefail
-
         # Move dev UI assets to expected location
         rm -rf ./pkg
         mkdir ./pkg

--- a/.circleci/config/jobs/install-ui-dependencies.yml
+++ b/.circleci/config/jobs/install-ui-dependencies.yml
@@ -5,8 +5,6 @@ steps:
   - run:
       name: Install UI dependencies
       command: |
-        set -eux -o pipefail
-
         cd ui
         yarn install --ignore-optional
         npm rebuild node-sass

--- a/.circleci/config/jobs/install-ui-dependencies.yml
+++ b/.circleci/config/jobs/install-ui-dependencies.yml
@@ -6,6 +6,10 @@ steps:
       name: Install UI dependencies
       command: |
         cd ui
+        nvm install 10
+        nvm use 10
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.1
+        export PATH="$HOME/.yarn/bin:$PATH"
         yarn install --ignore-optional
         npm rebuild node-sass
   - save_yarn_cache

--- a/.circleci/config/jobs/install-ui-dependencies.yml
+++ b/.circleci/config/jobs/install-ui-dependencies.yml
@@ -6,10 +6,6 @@ steps:
       name: Install UI dependencies
       command: |
         cd ui
-        nvm install 10
-        nvm use 10
-        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.1
-        export PATH="$HOME/.yarn/bin:$PATH"
         yarn install --ignore-optional
         npm rebuild node-sass
   - save_yarn_cache

--- a/.circleci/config/jobs/test-go-race.yml
+++ b/.circleci/config/jobs/test-go-race.yml
@@ -4,8 +4,6 @@ steps:
   - run:
       name: Allow circleci user to restore Go modules cache
       command: |
-        set -eux -o pipefail
-
         sudo mkdir /go
         sudo chown -R circleci:circleci /go
   - restore_go_cache

--- a/.circleci/config/jobs/test-go.yml
+++ b/.circleci/config/jobs/test-go.yml
@@ -5,8 +5,6 @@ steps:
   - run:
       name: Allow circleci user to restore Go modules cache
       command: |
-        set -eux -o pipefail
-
         sudo mkdir /go
         sudo chown -R circleci:circleci /go
   - restore_go_cache

--- a/.circleci/config/jobs/test-ui-browserstack.yml
+++ b/.circleci/config/jobs/test-ui-browserstack.yml
@@ -1,0 +1,14 @@
+executor: node
+steps:
+  - checkout
+  - restore_yarn_cache
+  - attach_workspace:
+      at: .
+  - run:
+      name: Run Browserstack Tests
+      command: |
+        # Add ./bin to the PATH so vault binary can be found.
+        export PATH="${PWD}"/bin:${PATH}
+        make test-ui-browserstack
+
+

--- a/.circleci/config/jobs/test-ui-browserstack.yml
+++ b/.circleci/config/jobs/test-ui-browserstack.yml
@@ -10,5 +10,3 @@ steps:
         # Add ./bin to the PATH so vault binary can be found.
         export PATH="${PWD}"/bin:${PATH}
         make test-ui-browserstack
-
-

--- a/.circleci/config/jobs/test-ui.yml
+++ b/.circleci/config/jobs/test-ui.yml
@@ -8,7 +8,7 @@ steps:
   - run:
       name: Test UI
       command: |
-        set -eux -o pipefail
+        set -x
 
         # Install Chrome
         wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \

--- a/.circleci/config/workflows/ci.yml
+++ b/.circleci/config/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
       requires:
         - install-ui-dependencies
         - build-go-dev
+  - test-ui-browserstack:
+      requires:
+        - install-ui-dependencies
+        - build-go-dev
   - test-go:
       requires:
         - build-go-dev

--- a/ui/package.json
+++ b/ui/package.json
@@ -155,7 +155,8 @@
     "handlebars": "^4.1.2"
   },
   "engines": {
-    "node": " >= 10.*"
+    "node": " >= 10.*",
+    "yarn": "~1.16.0"
   },
   "private": true,
   "ember-addon": {


### PR DESCRIPTION
This also updates circleci executors and .circleci/Makefile to use the "strict mode" bash shell `/usr/bin/env/bash -euo pipefail -c` by default.