### PR TITLE
Bump cross Dockerfile to 1.12.7

### DIFF
--- a/scripts/cross/Dockerfile
+++ b/scripts/cross/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -y && apt-get install -y -q nodejs yarn=1.12.1-1
 RUN rm -rf /var/lib/apt/lists/*
 
 
-ENV GOVERSION 1.12.6
+ENV GOVERSION 1.12.7
 RUN mkdir /goroot && mkdir /gopath
 RUN curl https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz \
            | tar xvzf - -C /goroot --strip-components=1


### PR DESCRIPTION
This version fixes a bug that is bad, but hard to say whether it might
affect us or not -- or more crucially, any of our dependencies. It's
almost certainly worth updating just in case. See
https://github.com/golang/go/issues/32560