### PR TITLE
Ui/http request fixes

### DIFF
--- a/ui/app/components/http-requests-bar-chart.js
+++ b/ui/app/components/http-requests-bar-chart.js
@@ -120,7 +120,7 @@ export default Component.extend({
     // scale and render the axes
     const yAxis = d3Axis
       .axisRight(yScale)
-      .ticks(3, '.0s')
+      .ticks(3, '~s')
       .tickSizeOuter(0);
     const xAxis = d3Axis
       .axisBottom(xScale)

--- a/ui/app/components/http-requests-container.js
+++ b/ui/app/components/http-requests-container.js
@@ -43,8 +43,8 @@ export default Component.extend({
     }
 
     filteredCounters = counters.filter(counter => {
-      const year = counter.start_time.substr(0, 4);
-      return year === timeWindow;
+      const year = new Date(counter.start_time).getUTCFullYear();
+      return year.toString() === timeWindow;
     });
     return filteredCounters;
   }),

--- a/ui/app/templates/components/http-requests-dropdown.hbs
+++ b/ui/app/templates/components/http-requests-dropdown.hbs
@@ -6,7 +6,7 @@
       <option value="All" selected={{eq timeWindow "All"}}>All</option>/>
       <option value="Last 12 Months" selected={{eq timeWindow "Last 12 Months"}}>Last 12 Months</option>
     {{#each options as |op|}}
-      <option value={{op}} selected={{eq timeWindow op}}>{{op}}</option>
+      <option value={{op}} selected={{eq timeWindow.value op}}>{{op}}</option>
     {{/each}}
   </select>
 </div>


### PR DESCRIPTION
This PR fixes several bugs related to the HTTP Request Metrics page:
1. The bar chart would display duplicate ticks in some cases
2. The bar chart wouldn't filter to specific years when you manually set the `counters` via the knobs panel in Storybook
3. The select dropdown wouldn't update the selected item

### Before
<img width="1552" alt="Screen Shot 2019-07-15 at 4 22 08 PM" src="https://user-images.githubusercontent.com/903288/61330194-fa40ce80-a7d3-11e9-81ea-d57af831f71f.png">

### After
<img width="1312" alt="Screen Shot 2019-07-16 at 2 12 38 PM" src="https://user-images.githubusercontent.com/903288/61330132-cd8cb700-a7d3-11e9-8586-d7ed656bc076.png">
