### PR TITLE
Bump TestCassandraBackend timeout from 5s to 15s

### DIFF
--- a/physical/cassandra/cassandra_test.go
+++ b/physical/cassandra/cassandra_test.go
@@ -78,7 +78,7 @@ func prepareCassandraTestContainer(t *testing.T) (func(), string) {
 		cluster := gocql.NewCluster("127.0.0.1")
 		p, _ := strconv.Atoi(resource.GetPort("9042/tcp"))
 		cluster.Port = p
-		cluster.Timeout = 5 * time.Second
+		cluster.Timeout = 15 * time.Second
 		sess, err := cluster.CreateSession()
 		if err != nil {
 			return err


### PR DESCRIPTION
The theory is that since I haven't seen this failing on the OSS side, it's failing because the ent side is heavier in terms of test load and thus the tests face more resource contention.