### PR TITLE
Add backwards compat support for API env vars

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -41,6 +41,10 @@ const EnvVaultToken = "VAULT_TOKEN"
 const EnvVaultMFA = "VAULT_MFA"
 const EnvRateLimit = "VAULT_RATE_LIMIT"
 
+// Deprecated values
+const EnvVaultAgentAddress = "VAULT_AGENT_ADDR"
+const EnvVaultInsecure = "VAULT_SKIP_VERIFY"
+
 // WrappingLookupFunc is a function that, given an HTTP verb and a path,
 // returns an optional string duration to be used for response wrapping (e.g.
 // "15s", or simply "15"). The path will not begin with "/v1/" or "v1/" or "/",
@@ -246,6 +250,8 @@ func (c *Config) ReadEnvironment() error {
 	}
 	if v := os.Getenv(EnvVaultAgentAddr); v != "" {
 		envAgentAddress = v
+	} else if v := os.Getenv(EnvVaultAgentAddress); v != "" {
+		envAgentAddress = v
 	}
 	if v := os.Getenv(EnvVaultMaxRetries); v != "" {
 		maxRetries, err := strconv.ParseUint(v, 10, 32)
@@ -286,7 +292,14 @@ func (c *Config) ReadEnvironment() error {
 		if err != nil {
 			return fmt.Errorf("could not parse VAULT_SKIP_VERIFY")
 		}
+	} else if v := os.Getenv(EnvVaultInsecure); v != "" {
+		var err error
+		envInsecure, err = strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("could not parse VAULT_INSECURE")
+		}
 	}
+
 	if v := os.Getenv(EnvVaultTLSServerName); v != "" {
 		envTLSServerName = v
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"bytes"
-	"github.com/hashicorp/vault/sdk/helper/consts"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/vault/sdk/helper/consts"
 )
 
 func init() {
@@ -191,6 +192,22 @@ func TestClientEnvSettings(t *testing.T) {
 	if tlsConfig.GetClientCertificate == nil {
 		t.Fatalf("bad: expected client tls config to have a certificate getter")
 	}
+	if tlsConfig.InsecureSkipVerify != true {
+		t.Fatalf("bad: %v", tlsConfig.InsecureSkipVerify)
+	}
+}
+
+func TestClientDeprecatedEnvSettings(t *testing.T) {
+	oldInsecure := os.Getenv(EnvVaultInsecure)
+	os.Setenv(EnvVaultInsecure, "true")
+	defer os.Setenv(EnvVaultInsecure, oldInsecure)
+
+	config := DefaultConfig()
+	if err := config.ReadEnvironment(); err != nil {
+		t.Fatalf("error reading environment: %v", err)
+	}
+
+	tlsConfig := config.HttpClient.Transport.(*http.Transport).TLSClientConfig
 	if tlsConfig.InsecureSkipVerify != true {
 		t.Fatalf("bad: %v", tlsConfig.InsecureSkipVerify)
 	}


### PR DESCRIPTION
Several env vars got renamed in
https://github.com/hashicorp/vault/pull/6306. This re-adds support for
those.

Indirectly addresses
https://github.com/hashicorp/consul-template/pull/1233 although they
should still update to the new values.