### PR TITLE
check for the correct path when showing entities sidenav item

### DIFF
--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -4,8 +4,8 @@ import { task } from 'ember-concurrency';
 const API_PATHS = {
   access: {
     methods: 'sys/auth',
-    entities: 'identity/entities',
-    groups: 'identity/groups',
+    entities: 'identity/entity/id/',
+    groups: 'identity/group/id/',
     leases: 'sys/leases/lookup',
     namespaces: 'sys/namespaces',
     'control-groups': 'sys/control-group/',
@@ -35,8 +35,8 @@ const API_PATHS = {
 
 const API_PATHS_TO_ROUTE_PARAMS = {
   'sys/auth': ['vault.cluster.access.methods'],
-  'identity/entities': ['vault.cluster.access.identity', 'entities'],
-  'identity/groups': ['vault.cluster.access.identity', 'groups'],
+  'identity/entity/id/': ['vault.cluster.access.identity', 'entities'],
+  'identity/group/id/': ['vault.cluster.access.identity', 'groups'],
   'sys/leases/lookup': ['vault.cluster.access.leases'],
   'sys/namespaces': ['vault.cluster.access.namespaces'],
   'sys/control-group/': ['vault.cluster.access.control-groups'],

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -4,8 +4,8 @@ import { task } from 'ember-concurrency';
 const API_PATHS = {
   access: {
     methods: 'sys/auth',
-    entities: 'identity/entity/id/',
-    groups: 'identity/group/id/',
+    entities: 'identity/entity/id',
+    groups: 'identity/group/id',
     leases: 'sys/leases/lookup',
     namespaces: 'sys/namespaces',
     'control-groups': 'sys/control-group/',
@@ -35,8 +35,8 @@ const API_PATHS = {
 
 const API_PATHS_TO_ROUTE_PARAMS = {
   'sys/auth': ['vault.cluster.access.methods'],
-  'identity/entity/id/': ['vault.cluster.access.identity', 'entities'],
-  'identity/group/id/': ['vault.cluster.access.identity', 'groups'],
+  'identity/entity/id': ['vault.cluster.access.identity', 'entities'],
+  'identity/group/id': ['vault.cluster.access.identity', 'groups'],
   'sys/leases/lookup': ['vault.cluster.access.leases'],
   'sys/namespaces': ['vault.cluster.access.namespaces'],
   'sys/control-group/': ['vault.cluster.access.control-groups'],

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -148,7 +148,7 @@ module('Unit | Service | permissions', function(hooks) {
       'sys/auth': {
         capabilities: ['deny'],
       },
-      'identity/entity/id/': {
+      'identity/entity/id': {
         capabilities: ['read'],
       },
     };

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -148,7 +148,7 @@ module('Unit | Service | permissions', function(hooks) {
       'sys/auth': {
         capabilities: ['deny'],
       },
-      'identity/entities': {
+      'identity/entity/id/': {
         capabilities: ['read'],
       },
     };


### PR DESCRIPTION
# Show Entities and Groups in Side Navigation
This PR fixes a bug in which the Entities and Groups items in the side navigation were not being displayed, even when a users' policy granted them access. The problem was caused by the permissions service checking for the wrong API path.

This fixes https://github.com/hashicorp/vault/issues/7138. 