### PR TITLE
Fixed import order to match goimports

### DIFF
--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -5,10 +5,11 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"github.com/go-test/deep"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/go-test/deep"
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/salt"

--- a/helper/metricsutil/metricsutil.go
+++ b/helper/metricsutil/metricsutil.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
-	"strings"
 )
 
 const (


### PR DESCRIPTION
Helps preventing unnecessary formatting rewrites in the future.