### PR TITLE
ui: Update selected item on HttpRequestsDropdown

### DIFF
--- a/ui/app/components/http-requests-dropdown.js
+++ b/ui/app/components/http-requests-dropdown.js
@@ -30,7 +30,7 @@ export default Component.extend({
       const years = counters
         .map(counter => {
           const year = new Date(counter.start_time);
-          return year.getUTCFullYear();
+          return year.getUTCFullYear().toString();
         })
         .uniq();
       years.sort().reverse();

--- a/ui/app/templates/components/http-requests-dropdown.hbs
+++ b/ui/app/templates/components/http-requests-dropdown.hbs
@@ -6,7 +6,7 @@
       <option value="All" selected={{eq timeWindow "All"}}>All</option>/>
       <option value="Last 12 Months" selected={{eq timeWindow "Last 12 Months"}}>Last 12 Months</option>
     {{#each options as |op|}}
-      <option value={{op}} selected={{eq timeWindow.value op}}>{{op}}</option>
+      <option value={{op}} selected={{eq timeWindow op}}>{{op}}</option>
     {{/each}}
   </select>
 </div>


### PR DESCRIPTION
This PR fixes a bug in which the `HttpRequestsDropdown` didn't update the `timeWindow` when a new option was selected from the dropdown.