### PR TITLE
UI kmip scope delete and role form

### DIFF
--- a/ui/app/adapters/kmip/scope.js
+++ b/ui/app/adapters/kmip/scope.js
@@ -14,6 +14,8 @@ export default BaseAdapter.extend({
   },
 
   deleteRecord(store, type, snapshot) {
-    return this.ajax(this._url(type.modelName, { backend: snapshot.record.backend }, snapshot.id), 'DELETE');
+    let url = this._url(type.modelName, { backend: snapshot.record.backend }, snapshot.id);
+    url = `${url}?force=true`;
+    return this.ajax(url, 'DELETE');
   },
 });

--- a/ui/app/models/kmip/role.js
+++ b/ui/app/models/kmip/role.js
@@ -15,8 +15,12 @@ export const COMPUTEDS = {
     return this.operationFields.slice().removeObjects(['operationAll', 'operationNone']);
   }),
 
-  nonOperationFields: computed('operationFields', function() {
-    let excludeFields = ['role'].concat(this.operationFields);
+  tlsFields: computed(function() {
+    return ['tlsClientKeyBits', 'tlsClientKeyType', 'tlsClientTtl'];
+  }),
+
+  nonOperationFields: computed('tlsFields', 'newFields', 'operationFields', function() {
+    let excludeFields = ['role'].concat(this.operationFields).concat(this.tlsFields);
     return this.newFields.slice().removeObjects(excludeFields);
   }),
 };
@@ -29,14 +33,20 @@ const Model = DS.Model.extend(COMPUTEDS, {
   getHelpUrl(path) {
     return `/v1/${path}/scope/example/role/example?help=1`;
   },
-  fieldGroups: computed('fields', 'nonOperationFields', function() {
-    const groups = [{ default: this.nonOperationFields }, { 'Allowed Operations': this.operationFields }];
+  fieldGroups: computed('fields', 'tlsFields', 'nonOperationFields', function() {
+    const groups = [{ TLS: this.tlsFields }, { 'Allowed Operations': this.operationFields }];
+    if (this.nonOperationFields.length) {
+      groups.unshift({ default: this.nonOperationFields });
+    }
     let ret = fieldToAttrs(this, groups);
     return ret;
   }),
 
   operationFormFields: computed('operationFieldsWithoutSpecial', function() {
     return expandAttributeMeta(this, this.operationFieldsWithoutSpecial);
+  }),
+  tlsFormFields: computed('tlsFields', function() {
+    return expandAttributeMeta(this, this.tlsFields);
   }),
   fields: computed('nonOperationFields', function() {
     return expandAttributeMeta(this, this.nonOperationFields);

--- a/ui/app/models/kmip/role.js
+++ b/ui/app/models/kmip/role.js
@@ -20,7 +20,7 @@ export const COMPUTEDS = {
   }),
 
   nonOperationFields: computed('tlsFields', 'newFields', 'operationFields', function() {
-    let excludeFields = ['role'].concat(this.operationFields).concat(this.tlsFields);
+    let excludeFields = ['role'].concat(this.operationFields, this.tlsFields);
     return this.newFields.slice().removeObjects(excludeFields);
   }),
 };
@@ -34,7 +34,7 @@ const Model = DS.Model.extend(COMPUTEDS, {
     return `/v1/${path}/scope/example/role/example?help=1`;
   },
   fieldGroups: computed('fields', 'tlsFields', 'nonOperationFields', function() {
-    const groups = [{ TLS: this.tlsFields }, { 'Allowed Operations': this.operationFields }];
+    const groups = [{ TLS: this.tlsFields }];
     if (this.nonOperationFields.length) {
       groups.unshift({ default: this.nonOperationFields });
     }
@@ -43,7 +43,30 @@ const Model = DS.Model.extend(COMPUTEDS, {
   }),
 
   operationFormFields: computed('operationFieldsWithoutSpecial', function() {
-    return expandAttributeMeta(this, this.operationFieldsWithoutSpecial);
+    let objects = [
+      'operationCreate',
+      'operationActivate',
+      'operationGet',
+      'operationLocate',
+      'operationRekey',
+      'operationRevoke',
+      'operationDestroy',
+    ];
+
+    let attributes = ['operationAddAttribute', 'operationGetAttributes'];
+    let server = ['operationDiscoverVersion'];
+    let others = this.operationFieldsWithoutSpecial.slice().removeObjects(objects.concat(attributes, server));
+    const groups = [
+      { 'Managed Cryptographic Objects': objects },
+      { 'Object Attributes': attributes },
+      { Server: server },
+    ];
+    if (others.length) {
+      groups.push({
+        '': others,
+      });
+    }
+    return fieldToAttrs(this, groups);
   }),
   tlsFormFields: computed('tlsFields', function() {
     return expandAttributeMeta(this, this.tlsFields);

--- a/ui/app/models/kmip/role.js
+++ b/ui/app/models/kmip/role.js
@@ -19,7 +19,7 @@ export const COMPUTEDS = {
     return ['tlsClientKeyBits', 'tlsClientKeyType', 'tlsClientTtl'];
   }),
 
-  nonOperationFields: computed('tlsFields', 'newFields', 'operationFields', function() {
+  nonOperationFields: computed('tlsFields', 'operationFields', function() {
     let excludeFields = ['role'].concat(this.operationFields, this.tlsFields);
     return this.newFields.slice().removeObjects(excludeFields);
   }),

--- a/ui/app/styles/components/kmip-role-edit.scss
+++ b/ui/app/styles/components/kmip-role-edit.scss
@@ -1,0 +1,9 @@
+.kmip-role-allowed-operations {
+  @extend .box;
+  flex: 1 1 auto;
+  box-shadow: none;
+  padding: 0;
+}
+.kmip-role-allowed-operations .field {
+  margin-bottom: $spacing-xxs;
+}

--- a/ui/app/styles/components/kmip-role-edit.scss
+++ b/ui/app/styles/components/kmip-role-edit.scss
@@ -1,3 +1,8 @@
+.kmip-allowed-operations-header {
+  @extend .title;
+  @extend .is-6;
+  padding-left: $spacing-s;
+}
 .kmip-role-allowed-operations {
   @extend .box;
   flex: 1 1 auto;

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -60,6 +60,7 @@
 @import './components/init-illustration';
 @import './components/info-table-row';
 @import './components/input-hint';
+@import './components/kmip-role-edit';
 @import './components/linked-block';
 @import './components/list-item-row';
 @import './components/list-pagination';

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -19,6 +19,9 @@ import layout from '../templates/components/form-field';
  * @param [onChange=null] {Func} - Called whenever a value on the model changes via the component.
  * @param attr=null {Object} - This is usually derived from ember model `attributes` lookup, and all members of `attr.options` are optional.
  * @param model=null {DS.Model} - The Ember Data model that `attr` is defined on
+ * @param [disabled=false] {Boolean} - whether the field is disabled
+ * @param [showHelpText=false] {Boolean} - whether to show the tooltip with help text from OpenAPI
+ *
  *
  */
 
@@ -26,6 +29,8 @@ export default Component.extend({
   layout,
   'data-test-field': true,
   classNames: ['field'],
+  disabled: false,
+  showHelpText: true,
 
   onChange() {},
 

--- a/ui/lib/core/addon/components/form-field.js
+++ b/ui/lib/core/addon/components/form-field.js
@@ -20,7 +20,7 @@ import layout from '../templates/components/form-field';
  * @param attr=null {Object} - This is usually derived from ember model `attributes` lookup, and all members of `attr.options` are optional.
  * @param model=null {DS.Model} - The Ember Data model that `attr` is defined on
  * @param [disabled=false] {Boolean} - whether the field is disabled
- * @param [showHelpText=false] {Boolean} - whether to show the tooltip with help text from OpenAPI
+ * @param [showHelpText=true] {Boolean} - whether to show the tooltip with help text from OpenAPI
  *
  *
  */

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -162,14 +162,14 @@
   </div>
 {{else if (eq attr.type "boolean")}}
   <div class="b-checkbox">
-    <input type="checkbox" id="{{attr.name}}" class="styled" checked={{get model attr.name}} onchange={{action
+    <input disabled={{this.disabled}} type="checkbox" id="{{attr.name}}" class="styled" checked={{get model attr.name}} onchange={{action
         (action "setAndBroadcast" valuePath)
         value="target.checked"
       }} data-test-input={{attr.name}} />
 
     <label for="{{attr.name}}" class="is-label">
       {{labelString}}
-      {{#if attr.options.helpText}}
+      {{#if (and this.showHelpText attr.options.helpText)}}
         {{#info-tooltip}}{{attr.options.helpText}}{{/info-tooltip}}
       {{/if}}
     </label>

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -18,7 +18,7 @@
           aria-hidden="true"
           class="icon-false"
           @size="l"
-          @glyph="cancel-circle-outline"
+          @glyph="cancel-square-outline"
         /> No
       {{/if}}
     {{else}}

--- a/ui/lib/kmip/addon/components/edit-form-kmip-role.js
+++ b/ui/lib/kmip/addon/components/edit-form-kmip-role.js
@@ -1,55 +1,24 @@
 import EditForm from 'core/components/edit-form';
 import layout from '../templates/components/edit-form-kmip-role';
 import { Promise } from 'rsvp';
+import { computed } from '@ember/object';
 
 export default EditForm.extend({
   layout,
-  display: null,
+  model: null,
+
   init() {
     this._super(...arguments);
-    let display = 'operationAll';
-    if (this.model.operationNone) {
-      display = 'operationNone';
+
+    if (this.model.isNew) {
+      this.model.set('operationAll', true);
     }
-    if (!this.model.isNew && !this.model.operationNone && !this.model.operationAll) {
-      display = 'choose';
-    }
-    this.set('display', display);
   },
 
   actions: {
-    updateModel(val) {
-      // here we only want to toggle operation(None|All) because we don't want to clear the other options in
-      // the case where the user clicks back to "choose" before saving
-      if (val === 'operationAll') {
-        this.model.set('operationNone', false);
-        this.model.set('operationAll', true);
-      }
-      if (val === 'operationNone') {
-        this.model.set('operationNone', true);
-        this.model.set('operationAll', false);
-      }
-    },
-
-    preSave(model) {
-      let { display } = this;
-
-      return new Promise(function(resolve) {
-        if (display === 'choose') {
-          model.set('operationNone', null);
-          model.set('operationAll', null);
-          return resolve(model);
-        }
-        model.operationFields.concat(['operationAll', 'operationNone']).forEach(field => {
-          // this will set operationAll or operationNone to true
-          if (field === display) {
-            model.set(field, true);
-          } else {
-            model.set(field, null);
-          }
-        });
-        return resolve(model);
-      });
+    switchUpdated(checked) {
+      this.model.set('operationNone', !checked);
+      this.model.set('operationAll', checked);
     },
   },
 });

--- a/ui/lib/kmip/addon/components/edit-form-kmip-role.js
+++ b/ui/lib/kmip/addon/components/edit-form-kmip-role.js
@@ -1,7 +1,5 @@
 import EditForm from 'core/components/edit-form';
 import layout from '../templates/components/edit-form-kmip-role';
-import { Promise } from 'rsvp';
-import { computed } from '@ember/object';
 
 export default EditForm.extend({
   layout,
@@ -19,6 +17,14 @@ export default EditForm.extend({
     switchUpdated(checked) {
       this.model.set('operationNone', !checked);
       this.model.set('operationAll', checked);
+    },
+
+    preSave(model) {
+      // if we have operationAll or operationNone, we want to clear
+      // out the others so that display shows the right data
+      if (model.operationAll || model.operationNone) {
+        model.operationFieldsWithoutSpecial.forEach(field => model.set(field, null));
+      }
     },
   },
 });

--- a/ui/lib/kmip/addon/components/edit-form-kmip-role.js
+++ b/ui/lib/kmip/addon/components/edit-form-kmip-role.js
@@ -14,7 +14,7 @@ export default EditForm.extend({
   },
 
   actions: {
-    switchUpdated(checked) {
+    toggleOperationSpecial(checked) {
       this.model.set('operationNone', !checked);
       this.model.set('operationAll', checked);
     },

--- a/ui/lib/kmip/addon/components/edit-form-kmip-role.js
+++ b/ui/lib/kmip/addon/components/edit-form-kmip-role.js
@@ -19,6 +19,14 @@ export default EditForm.extend({
       this.model.set('operationAll', checked);
     },
 
+    // when operationAll is true, we want all of the items
+    // to appear checked, but we don't want to override what items
+    // a user has selected - so this action creates an object that we
+    // pass to the FormField component as the model instead of the real model
+    placeholderOrModel(isOperationAll, attr) {
+      return isOperationAll ? { [attr.name]: true } : this.model;
+    },
+
     preSave(model) {
       // if we have operationAll or operationNone, we want to clear
       // out the others so that display shows the right data

--- a/ui/lib/kmip/addon/components/operation-field-display.js
+++ b/ui/lib/kmip/addon/components/operation-field-display.js
@@ -1,0 +1,39 @@
+/**
+ * @module OperationFieldDisplay
+ * OperationFieldDisplay components are used on KMIP role show pages to display the allowed operations on that model
+ *
+ * @example
+ * ```js
+ * <OperationFieldDisplay @model={{model}} />
+ * ```
+ *
+ * @param model {DS.Model} - model is the KMIP role model that needs to display its allowed operations
+ *
+ */
+import Component from '@ember/component';
+import layout from '../templates/components/operation-field-display';
+
+export default Component.extend({
+  layout,
+  tagName: '',
+  model: null,
+
+  trueOrFalseString(model, field, returnTrue, returnFalse) {
+    if (model.operationAll) {
+      return returnTrue;
+    }
+    if (model.operationNone) {
+      return returnFalse;
+    }
+    return model.get(field.name) ? returnTrue : returnFalse;
+  },
+
+  actions: {
+    iconClass(model, field) {
+      return this.trueOrFalseString(model, field, 'icon-true', 'icon-false');
+    },
+    iconGlyph(model, field) {
+      return this.trueOrFalseString(model, field, 'check-circle-outline', 'cancel-square-outline');
+    },
+  },
+});

--- a/ui/lib/kmip/addon/components/operation-field-display.js
+++ b/ui/lib/kmip/addon/components/operation-field-display.js
@@ -18,14 +18,14 @@ export default Component.extend({
   tagName: '',
   model: null,
 
-  trueOrFalseString(model, field, returnTrue, returnFalse) {
+  trueOrFalseString(model, field, trueString, falseString) {
     if (model.operationAll) {
-      return returnTrue;
+      return trueString;
     }
     if (model.operationNone) {
-      return returnFalse;
+      return falseString;
     }
-    return model.get(field.name) ? returnTrue : returnFalse;
+    return model.get(field.name) ? trueString : falseString;
   },
 
   actions: {

--- a/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
+++ b/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
@@ -1,6 +1,5 @@
-<form {{action (perform save model) on="submit"}}>
-  <MessageError @model={{model}} data-test-edit-form-error />
-  <div class="box is-sideless is-fullwidth is-marginless">
+<form {{action (queue (action "preSave" model) (perform save model)) on="submit"}}>
+  <MessageError @model={{model}} data-test-edit-form-error /> <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode="save" />
     {{#if (eq @mode "create")}}
       <FormField
@@ -9,7 +8,6 @@
         @model={{model}}
       />
     {{/if}}
-
     <div class="control is-flex box is-shadowless is-fullwidth is-marginless">
       <input
         data-test-text-toggle
@@ -24,27 +22,51 @@
       </label>
     </div>
     {{#if (not this.model.operationNone) }}
-
-    <Toolbar>
-      <h3 class="title is-6">
-        Allowed Operations
-      </h3>
-    </Toolbar>
+      <Toolbar>
+        <h3 class="title is-6">
+          Allowed Operations
+        </h3>
+      </Toolbar>
       <div class="box">
         <FormField
           @attr={{hash name="operationAll" type="boolean" options=(hash label="Allow this role to perform all operations")}}
           @model={{this.model}}
         />
         <hr />
-        {{#each this.model.operationFormFields as |attr|}}
-          <FormField
-            data-test-field
-            @disabled={{or this.model.operationNone this.model.operationAll}}
-            @attr={{attr}}
-            @model={{model}}
-            @showHelpText={{false}}
-          />
-        {{/each}}
+        <div class="is-flex">
+          <div class="kmip-role-allowed-operations">
+            {{#each-in this.model.operationFormFields.firstObject as |groupName fieldsInGroup|}}
+              <h4 class="title is-7">{{groupName}}</h4>
+              {{#each fieldsInGroup as |attr|}}
+                <FormField
+                  data-test-field
+                  @disabled={{or this.model.operationNone this.model.operationAll}}
+                  @attr={{attr}}
+                  @model={{model}}
+                  @showHelpText={{false}}
+                />
+              {{/each}}
+            {{/each-in}}
+          </div>
+          <div class="kmip-role-allowed-operations">
+            {{#each (drop 1 this.model.operationFormFields) as |group index|}}
+              <div class="kmip-role-allowed-operations">
+                {{#each-in group as |groupName fieldsInGroup|}}
+                  <h4 class="title is-7">{{groupName}}</h4>
+                  {{#each fieldsInGroup as |attr|}}
+                    <FormField
+                      data-test-field
+                      @disabled={{or this.model.operationNone this.model.operationAll}}
+                      @attr={{attr}}
+                      @model={{model}}
+                      @showHelpText={{false}}
+                    />
+                  {{/each}}
+                {{/each-in}}
+              </div>
+            {{/each}}
+          </div>
+        </div>
       </div>
     {{/if}}
     <div class="box is-fullwidth is-shadowless">

--- a/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
+++ b/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
@@ -1,4 +1,4 @@
-<form {{action (queue (action "preSave" model) (perform save model)) on="submit"}}>
+<form {{action (perform save model) on="submit"}}>
   <MessageError @model={{model}} data-test-edit-form-error />
   <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode="save" />
@@ -9,48 +9,63 @@
         @model={{model}}
       />
     {{/if}}
-    <h3 class="title is-5">
-      Allowed Operations
-    </h3>
-    {{#each (array
-      (hash label="Allow all" value="operationAll")
-      (hash label="Allow none" value="operationNone")
-      (hash label="Let me choose" value="choose")
-      ) as |displayType|}}
-        <RadioButton
-          @value={{displayType.value}}
-          @groupValue={{this.display}}
-          @changed={{queue
-            (action (mut this.display))
-            (action "updateModel")
-          }}
-          @name="role-display"
-          @radioId={{displayType.value}}
-          @classNames="vlt-radio is-block"
-        >
-          <label for={{displayType.value}} />
-          {{displayType.label}}
-        </RadioButton>
-    {{/each}}
-    {{#if (eq this.display "choose")}}
-      <div class="box is-sideless is-shadowless is-marginless">
+
+    <div class="control is-flex box is-shadowless is-fullwidth is-marginless">
+      <input
+        data-test-text-toggle
+        id="operationNone"
+        type="checkbox"
+        class="switch is-rounded is-success is-small"
+        checked={{not this.model.operationNone}}
+        onchange={{action "switchUpdated" value="target.checked"}}
+      />
+      <label for="operationNone">
+        Allow this role to perform KMIP operations
+      </label>
+    </div>
+    {{#if (not this.model.operationNone) }}
+
+    <Toolbar>
+      <h3 class="title is-6">
+        Allowed Operations
+      </h3>
+    </Toolbar>
+      <div class="box">
+        <FormField
+          @attr={{hash name="operationAll" type="boolean" options=(hash label="Allow this role to perform all operations")}}
+          @model={{this.model}}
+        />
+        <hr />
         {{#each this.model.operationFormFields as |attr|}}
           <FormField
             data-test-field
+            @disabled={{or this.model.operationNone this.model.operationAll}}
             @attr={{attr}}
             @model={{model}}
+            @showHelpText={{false}}
           />
         {{/each}}
       </div>
     {{/if}}
-
-        {{#each this.model.fields as |attr|}}
-          <FormField
-            data-test-field
-            @attr={{attr}}
-            @model={{model}}
-          />
-        {{/each}}
+    <div class="box is-fullwidth is-shadowless">
+      <h3 class="title is-3">
+        TLS
+      </h3>
+      {{#each this.model.tlsFormFields as |attr|}}
+        <FormField
+          data-test-field
+          @attr={{attr}}
+          @model={{model}}
+        />
+      {{/each}}
+    </div>
+    {{#each this.model.fields as |attr|}}
+      <FormField
+        data-test-field
+        @attr={{attr}}
+        @model={{model}}
+      />
+    {{/each}}
   </div>
   <div class="field is-grouped is-grouped-split is-fullwidth box is-bottomless">
     <div class="field is-grouped">

--- a/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
+++ b/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
@@ -23,7 +23,7 @@
     </div>
     {{#if (not this.model.operationNone) }}
       <Toolbar>
-        <h3 class="title is-6">
+        <h3 class="kmip-allowed-operations-header">
           Allowed Operations
         </h3>
       </Toolbar>

--- a/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
+++ b/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
@@ -15,7 +15,7 @@
         type="checkbox"
         class="switch is-rounded is-success is-small"
         checked={{not this.model.operationNone}}
-        onchange={{action "switchUpdated" value="target.checked"}}
+        onchange={{action "toggleOperationSpecial" value="target.checked"}}
       />
       <label for="operationNone">
         Allow this role to perform KMIP operations

--- a/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
+++ b/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
@@ -10,7 +10,7 @@
     {{/if}}
     <div class="control is-flex box is-shadowless is-fullwidth is-marginless">
       <input
-        data-test-text-toggle
+        data-test-input="operationNone"
         id="operationNone"
         type="checkbox"
         class="switch is-rounded is-success is-small"
@@ -49,7 +49,7 @@
             {{/each-in}}
           </div>
           <div class="kmip-role-allowed-operations">
-            {{#each (drop 1 this.model.operationFormFields) as |group index|}}
+            {{#each (drop 1 (or this.model.operationFormFields (array))) as |group|}}
               <div class="kmip-role-allowed-operations">
                 {{#each-in group as |groupName fieldsInGroup|}}
                   <h4 class="title is-7">{{groupName}}</h4>

--- a/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
+++ b/ui/lib/kmip/addon/templates/components/edit-form-kmip-role.hbs
@@ -42,7 +42,7 @@
                   data-test-field
                   @disabled={{or this.model.operationNone this.model.operationAll}}
                   @attr={{attr}}
-                  @model={{model}}
+                  @model={{compute (action "placeholderOrModel") this.model.operationAll attr}}
                   @showHelpText={{false}}
                 />
               {{/each}}
@@ -58,7 +58,7 @@
                       data-test-field
                       @disabled={{or this.model.operationNone this.model.operationAll}}
                       @attr={{attr}}
-                      @model={{model}}
+                      @model={{compute (action "placeholderOrModel") this.model.operationAll attr}}
                       @showHelpText={{false}}
                     />
                   {{/each}}

--- a/ui/lib/kmip/addon/templates/components/operation-field-display.hbs
+++ b/ui/lib/kmip/addon/templates/components/operation-field-display.hbs
@@ -1,0 +1,22 @@
+{{#if model.operationAll}}
+  <AlertInline @type="info" @message="This role allows all KMIP operations" class="is-marginless" />
+{{/if}}
+{{#each @model.operationFormFields as |group index|}}
+  {{#each-in group as |groupName fieldsInGroup|}}
+    <InfoTableRow @alwaysRender={{true}}
+      @label={{groupName}}
+      @value={{true}}
+    >
+      <div>
+        {{#each fieldsInGroup as |field|}}
+          <Icon
+            aria-hidden="true"
+            class={{compute (action "iconClass") model field}}
+            @glyph={{compute (action "iconGlyph") model field}}
+            /> {{field.options.label}}
+          <br />
+        {{/each}}
+      </div>
+    </InfoTableRow>
+  {{/each-in}}
+{{/each}}

--- a/ui/lib/kmip/addon/templates/components/operation-field-display.hbs
+++ b/ui/lib/kmip/addon/templates/components/operation-field-display.hbs
@@ -1,7 +1,7 @@
 {{#if model.operationAll}}
   <AlertInline @type="info" @message="This role allows all KMIP operations" class="is-marginless" />
 {{/if}}
-{{#each @model.operationFormFields as |group index|}}
+{{#each @model.operationFormFields as |group|}}
   {{#each-in group as |groupName fieldsInGroup|}}
     <InfoTableRow @alwaysRender={{true}}
       @label={{groupName}}

--- a/ui/lib/kmip/addon/templates/role.hbs
+++ b/ui/lib/kmip/addon/templates/role.hbs
@@ -33,4 +33,10 @@
 </Toolbar>
 <div class="box is-fullwidth is-sideless is-shadowless">
   <FieldGroupShow @model={{model}} @showAllFields={{false}} />
+  <div class="box is-fullwidth is-shadowless">
+    <h2 class="title is-5">
+      Allowed Operations
+    </h2>
+    <OperationFieldDisplay @model={{this.model}} />
+  </div>
 </div>

--- a/ui/lib/kmip/addon/templates/scopes/index.hbs
+++ b/ui/lib/kmip/addon/templates/scopes/index.hbs
@@ -73,7 +73,8 @@
                     (action "refresh")
                   )
                 }}
-                @confirmMessage={{concat "Are you sure you want to delete " list.item.id "?"}}
+                @confirmTitle={{concat "Delete scope " list.item.id "?"}}
+                @confirmMessage="This will permanently delete this scope and all roles and credentials contained within"
                 @cancelButtonText="Cancel"
                 data-test-scope-delete="true"
                 >

--- a/ui/tests/integration/components/edit-form-kmip-role-test.js
+++ b/ui/tests/integration/components/edit-form-kmip-role-test.js
@@ -4,7 +4,7 @@ import EmberObject, { computed } from '@ember/object';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, click } from '@ember/test-helpers';
+import { click, find, render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import engineResolverFor from 'ember-engines/test-support/engine-resolver-for';
@@ -15,6 +15,8 @@ const flash = Service.extend({
   success: sinon.stub(),
 });
 const namespace = Service.extend({});
+
+const fieldToCheckbox = field => ({ name: field, type: 'boolean' });
 
 const createModel = options => {
   let model = EmberObject.extend(COMPUTEDS, {
@@ -38,7 +40,7 @@ const createModel = options => {
       'tlsClientTtl',
     ],
     fields: computed('operationFields', function() {
-      return this.operationFields.map(field => ({ name: field, type: 'boolean' }));
+      return this.operationFields.map(fieldToCheckbox);
     }),
     destroyRecord() {
       return resolve();
@@ -69,15 +71,14 @@ module('Integration | Component | edit form kmip role', function(hooks) {
     this.set('model', model);
     await render(hbs`<EditFormKmipRole @model={{model}} />`);
 
-    assert.dom('[name=role-display]:checked').hasValue('operationAll', 'defaults to all on new models');
+    assert.dom('[data-test-input="operationAll"').isChecked('sets operationAll');
   });
 
   test('it renders: operationAll', async function(assert) {
     let model = createModel({ operationAll: true });
     this.set('model', model);
     await render(hbs`<EditFormKmipRole @model={{model}} />`);
-
-    assert.dom('[name=role-display]:checked').hasValue('operationAll', 'sets operationAll');
+    assert.dom('[data-test-input="operationAll"').isChecked('sets operationAll');
   });
 
   test('it renders: operationNone', async function(assert) {
@@ -85,7 +86,7 @@ module('Integration | Component | edit form kmip role', function(hooks) {
     this.set('model', model);
     await render(hbs`<EditFormKmipRole @model={{model}} />`);
 
-    assert.dom('[name=role-display]:checked').hasValue('operationNone', 'sets operationNone');
+    assert.dom('[data-test-input="operationNone"]').isNotChecked('sets operationNone');
   });
 
   test('it renders: choose operations', async function(assert) {
@@ -93,14 +94,15 @@ module('Integration | Component | edit form kmip role', function(hooks) {
     this.set('model', model);
     await render(hbs`<EditFormKmipRole @model={{model}} />`);
 
-    assert.dom('[name=role-display]:checked').hasValue('choose', 'sets choose');
+    assert.dom('[data-test-input="operationNone"]').isChecked('sets operationNone');
+    assert.dom('[data-test-input="operationAll"').isNotChecked('sets operationAll');
   });
 
   let savingTests = [
     [
       'setting operationAll',
       { operationNone: true, operationGet: true },
-      'operationAll',
+      'operationNone',
       {
         operationAll: true,
         operationNone: false,
@@ -108,7 +110,7 @@ module('Integration | Component | edit form kmip role', function(hooks) {
       },
       {
         operationGet: null,
-        operationNone: null,
+        operationNone: false,
       },
     ],
     [
@@ -123,16 +125,16 @@ module('Integration | Component | edit form kmip role', function(hooks) {
       {
         operationNone: true,
         operationCreate: null,
-        operationAll: null,
+        operationAll: false,
       },
     ],
 
     [
       'setting choose, and selecting an additional item',
       { operationAll: true, operationGet: true, operationCreate: true },
-      'choose,operationDestroy',
+      'operationAll,operationDestroy',
       {
-        operationAll: true,
+        operationAll: false,
         operationCreate: true,
         operationGet: true,
       },
@@ -140,8 +142,7 @@ module('Integration | Component | edit form kmip role', function(hooks) {
         operationGet: true,
         operationCreate: true,
         operationDestroy: true,
-        operationAll: null,
-        operationNone: null,
+        operationAll: false,
       },
     ],
   ];
@@ -159,7 +160,6 @@ module('Integration | Component | edit form kmip role', function(hooks) {
       for (let beforeStateKey of Object.keys(stateBeforeSave)) {
         assert.equal(model.get(beforeStateKey), stateBeforeSave[beforeStateKey], `sets ${beforeStateKey}`);
       }
-      assert.dom('[name=role-display]:checked').hasValue(clickTargets[0], `sets clickTargets[0]`);
 
       click('[data-test-edit-form-submit]');
 


### PR DESCRIPTION
This changes scope deletes so that we always pass `?force=true` since there's already a confirmation step.

Additionally this revamps the KMIP role edit and show pages with a new designs.

## Before
![Screen Shot 2019-07-22 at 4 06 42 PM](https://user-images.githubusercontent.com/39469/61665508-c87bac00-ac9a-11e9-9d05-6a6dbde28bb6.png)


## After
![new-kmip-role edit](https://user-images.githubusercontent.com/39469/61665447-9f5b1b80-ac9a-11e9-9325-096b34d388af.gif)


Draft for now while I fix up the kmip-role-edit tests.


Items to follow up on that I didn't do here because they were bigger changes:

- [ ] pipe `disabled`, and `showHelpText` attributes through to _all_ of the field types in `form-field` component - currently they're just wired up to boolean fields