### PR TITLE
don't specify yarn in engines for now

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -155,8 +155,7 @@
     "handlebars": "^4.1.2"
   },
   "engines": {
-    "node": " >= 10.*",
-    "yarn": "~1.16.0"
+    "node": " >= 10.*"
   },
   "private": true,
   "ember-addon": {


### PR DESCRIPTION
We'll want to re-add this later. We don't want release builds that currently install yarn 1.12.1 to error out. For now it looks like BrowserStack tests pass with this change, so I'm going to merge this instead of https://github.com/hashicorp/vault/pull/7180.