### PR TITLE
Close and flush perf standby conns/cache when sealing.

### DIFF
--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -111,6 +111,8 @@ func (c *Core) invalidateSentinelPolicy(PolicyType, string) {}
 
 func (c *Core) removePerfStandbySecondary(context.Context, string) {}
 
+func (c *Core) removeAllPerfStandbySecondaries() {}
+
 func (c *Core) perfStandbyClusterHandler() (*replication.Cluster, *cache.Cache, chan struct{}, error) {
 	return nil, cache.New(2*cluster.HeartbeatInterval, 1*time.Second), make(chan struct{}), nil
 }

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -214,6 +214,7 @@ func (c *Core) stopForwarding() {
 		c.clusterListener.StopHandler(consts.RequestForwardingALPN)
 		c.clusterListener.StopHandler(consts.PerfStandbyALPN)
 	}
+	c.removeAllPerfStandbySecondaries()
 }
 
 // refreshRequestForwardingConnection ensures that the client/transport are


### PR DESCRIPTION
My first pass at this was in ent, but the test I developed there needs to be adapted so it can be invoked by OSS code.