### PR TITLE
Revert "Fix raft config output"

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -534,21 +533,10 @@ func (b *RaftBackend) GetConfiguration(ctx context.Context) (*RaftConfigurationR
 	}
 
 	for _, server := range future.Configuration().Servers {
-		host, port, err := net.SplitHostPort(string(server.Address))
-		if err != nil {
-			return nil, err
-		}
-		addr, err := net.ResolveIPAddr("ip", host)
-		if err != nil {
-			return nil, err
-		}
-		if addr == nil {
-			return nil, errors.New("nil addr after resolving raft server address")
-		}
 		entry := &RaftServer{
 			NodeID:          string(server.ID),
 			Address:         string(server.Address),
-			Leader:          net.JoinHostPort(addr.String(), port) == string(b.raft.Leader()),
+			Leader:          server.Address == b.raft.Leader(),
 			Voter:           server.Suffrage == raft.Voter,
 			ProtocolVersion: strconv.Itoa(raft.ProtocolVersionMax),
 		}


### PR DESCRIPTION
This introduced a number of test failures and I'm not certain it's the correct approach given that not every hostname will include a port number, nor is the cluster addr guaranteed to resolve to the advertised leader IP since vault allows for multiple listener config stanzas. Reverts hashicorp/vault#7113