### PR TITLE
add acceptance test for the api explorer 

### DIFF
--- a/ui/lib/open-api-explorer/addon/templates/components/swagger-ui.hbs
+++ b/ui/lib/open-api-explorer/addon/templates/components/swagger-ui.hbs
@@ -20,6 +20,7 @@
 					disabled={{this.swaggerLoading}}
 					class="filter input"
 					placeholder="Filter ops by path"
+          data-test-filter-input
 				/>
 				<Icon
           @glyph="search"

--- a/ui/tests/acceptance/api-explorer/index-test.js
+++ b/ui/tests/acceptance/api-explorer/index-test.js
@@ -1,0 +1,22 @@
+import { find, fillIn, visit, waitUntil } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+
+import authPage from 'vault/tests/pages/auth';
+
+module('Acceptance | API Explorer', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    return authPage.login();
+  });
+
+  test('it filters paths after swagger-ui is loaded', async function(assert) {
+    await visit('/vault/api-explorer');
+    await waitUntil(() => {
+      return find('[data-test-filter-input]').disabled === false;
+    });
+    await fillIn('[data-test-filter-input]', 'sys/health');
+    assert.dom('.opblock').exists({ count: 1 }, 'renders a single opblock for sys/health');
+  });
+});


### PR DESCRIPTION
Just wanted to add a test to make sure the inclusion and filtering is generally working - this should catch any breakage related to updates to swagger-ui (though styling, etc. should still be checked manually).