### PR TITLE
Unseal standbys after generating new root

### DIFF
--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -578,8 +578,6 @@ func EnablePerformanceSecondary(t testing.T, perfToken string, pri, sec *vault.T
 				WaitForNCoresSealed(t, sec, len(sec.Cores)-1)
 			}
 		}
-		sec.Logger.Info("waiting for perf secondary standbys to be unsealed")
-		EnsureCoresUnsealed(t, sec)
 		sec.Logger.Info("waiting for perf secondary active node")
 		WaitForActiveNode(t, sec)
 		sec.Logger.Info("generating new perf secondary root")
@@ -588,6 +586,9 @@ func EnablePerformanceSecondary(t testing.T, perfToken string, pri, sec *vault.T
 		for _, core := range sec.Cores {
 			core.Client.SetToken(perfSecondaryRootToken)
 		}
+		sec.Logger.Info("waiting for perf secondary standbys to be unsealed")
+		EnsureCoresUnsealed(t, sec)
+		sec.Logger.Info("waiting for cluster to be fully online")
 		WaitForActiveNodeAndPerfStandbys(t, sec)
 	}
 


### PR DESCRIPTION
I'm unsure about this change.  It does seem to eliminate an intermittent test failure wherein a standby seals itself when it sees the new generated root and doesn't unseal itself later.  On the other hand I might be papering over a real issue with standbys that should be fixed.