### PR TITLE
Revert "Generalize and improve testcluster-building code"

### DIFF
--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -3,7 +3,6 @@ package testhelpers
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -15,30 +14,28 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	realtesting "testing"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/physical/raft"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault/cluster"
+
+	log "github.com/hashicorp/go-hclog"
 	raftlib "github.com/hashicorp/raft"
 	"github.com/hashicorp/vault/api"
 	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
-	"github.com/hashicorp/vault/builtin/credential/ldap"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/namespace"
-	"github.com/hashicorp/vault/helper/testhelpers/consul"
 	"github.com/hashicorp/vault/helper/xor"
-	physConsul "github.com/hashicorp/vault/physical/consul"
-	"github.com/hashicorp/vault/physical/raft"
 	"github.com/hashicorp/vault/sdk/helper/consts"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
-	physFile "github.com/hashicorp/vault/sdk/physical/file"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/hashicorp/vault/vault"
-	"github.com/hashicorp/vault/vault/cluster"
-	"github.com/mitchellh/go-testing-interface"
+	testing "github.com/mitchellh/go-testing-interface"
 )
 
 type ReplicatedTestClusters struct {
@@ -179,15 +176,9 @@ func EnsureCoresUnsealed(t testing.T, c *vault.TestCluster) {
 		EnsureCoreUnsealed(t, c, core)
 	}
 }
-
 func EnsureCoreUnsealed(t testing.T, c *vault.TestCluster, core *vault.TestClusterCore) {
 	if !core.Sealed() {
 		return
-	}
-
-	core.SealAccess().ClearCaches(context.Background())
-	if err := core.UnsealWithStoredKeys(context.Background()); err != nil {
-		t.Fatal(err)
 	}
 
 	client := core.Client
@@ -216,7 +207,7 @@ func EnsureCoreUnsealed(t testing.T, c *vault.TestCluster, core *vault.TestClust
 
 func EnsureCoreIsPerfStandby(t testing.T, client *api.Client) {
 	t.Helper()
-	logger := logging.NewVaultLogger(hclog.Info).Named(t.Name())
+	logger := logging.NewVaultLogger(log.Info).Named(t.Name())
 	start := time.Now()
 	for {
 		health, err := client.Sys().Health()
@@ -271,239 +262,215 @@ func PassthroughWithLocalPathsFactory(ctx context.Context, c *logical.BackendCon
 }
 
 func ConfClusterAndCore(t testing.T, conf *vault.CoreConfig, opts *vault.TestClusterOptions) (*vault.TestCluster, *vault.TestClusterCore) {
-	{
-		var coreConfig vault.CoreConfig
-		if conf != nil {
-			coreConfig = *conf
-		}
-		conf = &coreConfig
+	if conf.Physical != nil || conf.HAPhysical != nil {
+		t.Fatalf("conf.Physical and conf.HAPhysical cannot be specified")
+	}
+	if opts.Logger == nil {
+		t.Fatalf("opts.Logger must be specified")
 	}
 
-	conf.CredentialBackends = map[string]logical.Factory{
+	inm, err := inmem.NewTransactionalInmem(nil, opts.Logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inmha, err := inmem.NewInmemHA(nil, opts.Logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	coreConfig := *conf
+	coreConfig.Physical = inm
+	coreConfig.HAPhysical = inmha.(physical.HABackend)
+	coreConfig.CredentialBackends = map[string]logical.Factory{
 		"approle":  credAppRole.Factory,
 		"userpass": credUserpass.Factory,
-		"ldap":     ldap.Factory,
 	}
-
-	opts = getClusterDefaultsOpts(t, opts, "")
-
-	vault.AddNoopAudit(conf)
-
-	cluster := vault.NewTestCluster(t, conf, opts)
+	vault.AddNoopAudit(&coreConfig)
+	cluster := vault.NewTestCluster(t, &coreConfig, opts)
 	cluster.Start()
-	vault.TestWaitActive(t, cluster.Cores[0].Core)
-	return cluster, cluster.Cores[0]
+
+	cores := cluster.Cores
+	core := cores[0]
+
+	vault.TestWaitActive(t, core.Core)
+
+	return cluster, core
 }
 
-// GetPerfReplicatedClusters returns a ReplicatedTestClusters containing both
-// a perf primary and a pref secondary cluster, with replication enabled.
 func GetPerfReplicatedClusters(t testing.T, conf *vault.CoreConfig, opts *vault.TestClusterOptions) *ReplicatedTestClusters {
-	rc := PrepPerfReplicatedClusters(t, conf, opts)
-	rc.SetupTwoClusterPerfReplication(t, false)
-	return rc
-}
-
-// getClusterDefaultsOpts returns a non-nil TestClusterOptions, based on opts
-// if it is non-nil.  The Logger option will be populated.  If name is given,
-// the logger will be created using the Named logger method, such that the string
-// will appear as part of every log entry.
-func getClusterDefaultsOpts(t testing.T, opts *vault.TestClusterOptions, name string) *vault.TestClusterOptions {
-	if opts == nil {
-		opts = &vault.TestClusterOptions{}
-	}
-
-	localOpts := *opts
-	opts = &localOpts
-
-	if opts.Logger == nil {
-		opts.Logger = logging.NewVaultLogger(hclog.Trace).Named(t.Name())
-	}
-	if name != "" {
-		opts.Logger = opts.Logger.Named(name)
-	}
-	if opts.PhysicalFactory == nil {
-		opts.PhysicalFactory = sharedPhysicalFactory(MakeInmemBackend)
-	}
-
-	return opts
-}
-
-// GetPerfPrimaryCluster returns a ReplicatedTestClusters containing only a
-// single cluster.  Normally you would use NewTestCluster directly, but this
-// helper may make sense if you want to test cluster replication but first do
-// something with a standalone cluster.
-func GetPerfPrimaryCluster(t testing.T, conf *vault.CoreConfig, opts *vault.TestClusterOptions) *ReplicatedTestClusters {
-	opts = getClusterDefaultsOpts(t, opts, "")
 	ret := &ReplicatedTestClusters{}
+
+	var logger hclog.Logger
+	if opts != nil {
+		logger = opts.Logger
+	}
+	if logger == nil {
+		logger = log.New(&log.LoggerOptions{
+			Mutex: &sync.Mutex{},
+			Level: log.Trace,
+		})
+	}
 
 	// Set this lower so that state populates quickly to standby nodes
 	cluster.HeartbeatInterval = 2 * time.Second
 
-	ret.PerfPrimaryCluster, _ = ConfClusterAndCore(t, conf, getClusterDefaultsOpts(t, opts, "perf-pri"))
-	return ret
-}
-
-// AddPerfSecondaryCluster spins up a Perf Secondary cluster and adds it to
-// the receiver.  Replication is not enabled.
-func (r *ReplicatedTestClusters) AddPerfSecondaryCluster(t testing.T, conf *vault.CoreConfig, opts *vault.TestClusterOptions) {
-	if r.PerfSecondaryCluster != nil {
-		t.Fatal("adding a perf secondary cluster when one is already present")
+	numCores := opts.NumCores
+	if numCores == 0 {
+		numCores = vault.DefaultNumCores
 	}
-	opts = getClusterDefaultsOpts(t, opts, "perf-sec")
-	opts.FirstCoreNumber += len(r.PerfPrimaryCluster.Cores)
-	r.PerfSecondaryCluster, _ = ConfClusterAndCore(t, conf, opts)
-}
 
-// PrepPerfReplicatedClusters returns a ReplicatedTestClusters containing both
-// a perf primary and a pref secondary cluster.  Replication is not enabled.
-func PrepPerfReplicatedClusters(t testing.T, conf *vault.CoreConfig, opts *vault.TestClusterOptions) *ReplicatedTestClusters {
-	ret := GetPerfPrimaryCluster(t, conf, opts)
-	ret.AddPerfSecondaryCluster(t, conf, opts)
+	localopts := *opts
+	localopts.Logger = logger.Named("perf-pri")
+	ret.PerfPrimaryCluster, _ = ConfClusterAndCore(t, conf, &localopts)
+
+	localopts.Logger = logger.Named("perf-sec")
+	localopts.FirstCoreNumber += numCores
+	ret.PerfSecondaryCluster, _ = ConfClusterAndCore(t, conf, &localopts)
+
+	SetupTwoClusterPerfReplication(t, ret.PerfPrimaryCluster, ret.PerfSecondaryCluster)
+
 	return ret
 }
 
-// GetFourReplicatedClusters returns an inmem ReplicatedTestClusters with all
-// clusters populated and replication enabled.
 func GetFourReplicatedClusters(t testing.T, handlerFunc func(*vault.HandlerProperties) http.Handler) *ReplicatedTestClusters {
 	return GetFourReplicatedClustersWithConf(t, &vault.CoreConfig{}, &vault.TestClusterOptions{
 		HandlerFunc: handlerFunc,
 	})
 }
 
-// GetFourReplicatedClustersWithConf returns a ReplicatedTestClusters with all
-// clusters populated and replication enabled.
 func GetFourReplicatedClustersWithConf(t testing.T, conf *vault.CoreConfig, opts *vault.TestClusterOptions) *ReplicatedTestClusters {
 	ret := &ReplicatedTestClusters{}
 
-	opts = getClusterDefaultsOpts(t, opts, "")
+	logger := log.New(&log.LoggerOptions{
+		Mutex: &sync.Mutex{},
+		Level: log.Trace,
+	})
 	// Set this lower so that state populates quickly to standby nodes
 	cluster.HeartbeatInterval = 2 * time.Second
 
+	numCores := opts.NumCores
+	if numCores == 0 {
+		numCores = vault.DefaultNumCores
+	}
+
 	localopts := *opts
-	localopts.Logger = opts.Logger.Named("perf-pri")
+	localopts.Logger = logger.Named("perf-pri")
 	ret.PerfPrimaryCluster, _ = ConfClusterAndCore(t, conf, &localopts)
 
-	localopts.Logger = opts.Logger.Named("perf-sec")
-	localopts.FirstCoreNumber += len(ret.PerfPrimaryCluster.Cores)
+	localopts.Logger = logger.Named("perf-sec")
+	localopts.FirstCoreNumber += numCores
 	ret.PerfSecondaryCluster, _ = ConfClusterAndCore(t, conf, &localopts)
 
-	localopts.Logger = opts.Logger.Named("perf-pri-dr")
-	localopts.FirstCoreNumber += len(ret.PerfSecondaryCluster.Cores)
+	localopts.Logger = logger.Named("perf-pri-dr")
+	localopts.FirstCoreNumber += numCores
 	ret.PerfPrimaryDRCluster, _ = ConfClusterAndCore(t, conf, &localopts)
 
-	localopts.Logger = opts.Logger.Named("perf-sec-dr")
-	localopts.FirstCoreNumber += len(ret.PerfPrimaryDRCluster.Cores)
+	localopts.Logger = logger.Named("perf-sec-dr")
+	localopts.FirstCoreNumber += numCores
 	ret.PerfSecondaryDRCluster, _ = ConfClusterAndCore(t, conf, &localopts)
 
-	SetupFourClusterReplication(t, ret.PerfPrimaryCluster, ret.PerfSecondaryCluster, ret.PerfPrimaryDRCluster, ret.PerfSecondaryDRCluster)
+	builder := &ReplicatedTestClustersBuilder{clusters: ret}
+	builder.setupFourClusterReplication(t)
+
+	// Wait until poison pills have been read
+	time.Sleep(45 * time.Second)
+	EnsureCoresUnsealed(t, ret.PerfPrimaryCluster)
+	EnsureCoresUnsealed(t, ret.PerfSecondaryCluster)
+	EnsureCoresUnsealed(t, ret.PerfPrimaryDRCluster)
+	EnsureCoresUnsealed(t, ret.PerfSecondaryDRCluster)
 
 	return ret
 }
 
-func (r *ReplicatedTestClusters) SetupTwoClusterPerfReplication(t testing.T, maskSecondaryToken bool) {
-	SetupTwoClusterPerfReplication(t, r.PerfPrimaryCluster, r.PerfSecondaryCluster, maskSecondaryToken)
+type ReplicatedTestClustersBuilder struct {
+	clusters               *ReplicatedTestClusters
+	perfToken              string
+	drToken                string
+	perfSecondaryRootToken string
+	perfSecondaryDRToken   string
 }
 
-func SetupTwoClusterPerfReplication(t testing.T, pri, sec *vault.TestCluster, maskSecondaryToken bool) {
-	EnablePerfPrimary(t, pri)
-
-	var publicKey string
-	if maskSecondaryToken {
-		publicKey = generatePublicKey(t, sec)
+func SetupTwoClusterPerfReplication(t testing.T, pri, sec *vault.TestCluster) {
+	clusters := &ReplicatedTestClusters{
+		PerfPrimaryCluster:   pri,
+		PerfSecondaryCluster: sec,
 	}
-	perfToken := GetPerformanceToken(t, pri, sec.ID, publicKey)
-
-	EnablePerformanceSecondary(t, perfToken, pri, sec, false, false)
+	builder := &ReplicatedTestClustersBuilder{clusters: clusters}
+	builder.setupTwoClusterReplication(t)
 }
 
-func GetDRReplicatedClusters(t testing.T, conf *vault.CoreConfig, opts *vault.TestClusterOptions) *ReplicatedTestClusters {
-	clusters := PrepDRReplicatedClusters(t, conf, opts)
-	SetupTwoClusterDRReplication(t, clusters.PerfPrimaryCluster, clusters.PerfPrimaryDRCluster, false)
-	return clusters
-}
-
-func (r *ReplicatedTestClusters) AddDRSecondaryCluster(t testing.T, conf *vault.CoreConfig, opts *vault.TestClusterOptions) {
-	opts = getClusterDefaultsOpts(t, opts, "perf-dr-pri")
-	opts.FirstCoreNumber += len(r.PerfPrimaryCluster.Cores)
-	r.PerfPrimaryDRCluster, _ = ConfClusterAndCore(t, conf, opts)
-}
-
-func PrepDRReplicatedClusters(t testing.T, conf *vault.CoreConfig, opts *vault.TestClusterOptions) *ReplicatedTestClusters {
-	ret := GetPerfPrimaryCluster(t, conf, opts)
-	ret.AddDRSecondaryCluster(t, conf, opts)
-	return ret
-}
-
-func SetupTwoClusterDRReplication(t testing.T, pri, sec *vault.TestCluster, maskSecondaryToken bool) {
-	EnableDrPrimary(t, pri)
-	setupDRReplication(t, pri, sec, maskSecondaryToken)
-}
-
-func setupDRReplication(t testing.T, pri, sec *vault.TestCluster, maskSecondaryToken bool) {
-	var publicKey string
-	if maskSecondaryToken {
-		publicKey = generatePublicKey(t, sec)
-	}
-	drToken := getDrToken(t, pri, sec.ID, publicKey)
-
-	EnableDrSecondary(t, pri, sec, drToken)
-	for _, core := range sec.Cores {
-		core.Client.SetToken(pri.Cores[0].Client.Token())
-	}
-	WaitForActiveNode(t, sec)
-	WaitForMatchingMerkleRoots(t, "sys/replication/dr/", pri.Cores[0].Client, sec.Cores[0].Client)
-	WaitForDRReplicationWorking(t, pri, sec)
+func (r *ReplicatedTestClustersBuilder) setupTwoClusterReplication(t testing.T) {
+	t.Log("enabling perf primary")
+	r.enablePerfPrimary(t)
+	WaitForActiveNode(t, r.clusters.PerfPrimaryCluster)
+	r.getPerformanceToken(t)
+	t.Log("enabling perf secondary")
+	r.enablePerformanceSecondary(t)
 }
 
 func SetupFourClusterReplication(t testing.T, pri, sec, pridr, secdr *vault.TestCluster) {
-	SetupTwoClusterPerfReplication(t, pri, sec, false)
-	SetupTwoClusterDRReplication(t, pri, pridr, false)
-	SetupTwoClusterDRReplication(t, sec, secdr, false)
+	clusters := &ReplicatedTestClusters{
+		PerfPrimaryCluster:     pri,
+		PerfSecondaryCluster:   sec,
+		PerfPrimaryDRCluster:   pridr,
+		PerfSecondaryDRCluster: secdr,
+	}
+	builder := &ReplicatedTestClustersBuilder{clusters: clusters}
+	builder.setupFourClusterReplication(t)
 }
 
-func EnablePerfPrimary(t testing.T, cluster *vault.TestCluster) {
-	cluster.Logger.Info("enabling performance primary")
-	c := cluster.Cores[0]
+func (r *ReplicatedTestClustersBuilder) setupFourClusterReplication(t testing.T) {
+	t.Log("enabling perf primary")
+	r.enablePerfPrimary(t)
+	r.getPerformanceToken(t)
+
+	t.Log("enabling dr primary")
+	enableDrPrimary(t, r.clusters.PerfPrimaryCluster)
+	r.drToken = getDrToken(t, r.clusters.PerfPrimaryCluster, "primary-dr-secondary")
+	WaitForActiveNode(t, r.clusters.PerfPrimaryCluster)
+	time.Sleep(1 * time.Second)
+
+	t.Log("enabling perf secondary")
+	r.enablePerformanceSecondary(t)
+	enableDrPrimary(t, r.clusters.PerfSecondaryCluster)
+	r.perfSecondaryDRToken = getDrToken(t, r.clusters.PerfSecondaryCluster, "secondary-dr-secondary")
+
+	t.Log("enabling dr secondary on primary dr cluster")
+	r.enableDrSecondary(t, r.clusters.PerfPrimaryDRCluster, r.drToken, r.clusters.PerfPrimaryCluster.CACertPEMFile)
+	r.clusters.PerfPrimaryDRCluster.Cores[0].Client.SetToken(r.clusters.PerfPrimaryCluster.Cores[0].Client.Token())
+	WaitForActiveNode(t, r.clusters.PerfPrimaryDRCluster)
+	time.Sleep(1 * time.Second)
+
+	t.Log("enabling dr secondary on secondary dr cluster")
+	r.enableDrSecondary(t, r.clusters.PerfSecondaryDRCluster, r.perfSecondaryDRToken, r.clusters.PerfSecondaryCluster.CACertPEMFile)
+	r.clusters.PerfSecondaryDRCluster.Cores[0].Client.SetToken(r.perfSecondaryRootToken)
+	WaitForActiveNode(t, r.clusters.PerfSecondaryDRCluster)
+}
+
+func (r *ReplicatedTestClustersBuilder) enablePerfPrimary(t testing.T) {
+	c := r.clusters.PerfPrimaryCluster.Cores[0]
 	_, err := c.Client.Logical().Write("sys/replication/performance/primary/enable", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	WaitForReplicationState(t, c.Core, consts.ReplicationPerformancePrimary)
-	WaitForActiveNodeAndPerfStandbys(t, cluster)
-	cluster.Logger.Info("enabled performance primary")
+	WaitForActiveNodeAndPerfStandbys(t, r.clusters.PerfPrimaryCluster)
 }
 
-func generatePublicKey(t testing.T, cluster *vault.TestCluster) string {
-	generateKeyPath := "sys/replication/performance/secondary/generate-public-key"
-	secret, err := cluster.Cores[0].Client.Logical().Write(generateKeyPath, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if secret == nil || secret.Data == nil {
-		t.Fatal("secret or secret data is nil")
-	}
-
-	return secret.Data["secondary_public_key"].(string)
-}
-
-func GetPerformanceToken(t testing.T, pri *vault.TestCluster, id, secondaryPublicKey string) string {
-	client := pri.Cores[0].Client
+func (r *ReplicatedTestClustersBuilder) getPerformanceToken(t testing.T) {
+	client := r.clusters.PerfPrimaryCluster.Cores[0].Client
 	req := map[string]interface{}{
-		"id": id,
-	}
-	if secondaryPublicKey != "" {
-		req["secondary_public_key"] = secondaryPublicKey
+		"id": r.clusters.PerfSecondaryCluster.ID,
 	}
 	secret, err := client.Logical().Write("sys/replication/performance/primary/secondary-token", req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return secret.WrapInfo.Token
+	r.perfToken = secret.WrapInfo.Token
 }
 
-func EnableDrPrimary(t testing.T, tc *vault.TestCluster) {
-	tc.Logger.Info("enabling dr primary")
+func enableDrPrimary(t testing.T, tc *vault.TestCluster) {
 	c := tc.Cores[0]
 	_, err := c.Client.Logical().Write("sys/replication/dr/primary/enable", nil)
 	if err != nil {
@@ -513,15 +480,11 @@ func EnableDrPrimary(t testing.T, tc *vault.TestCluster) {
 	WaitForReplicationStatus(t, c.Client, true, func(secret map[string]interface{}) bool {
 		return secret["mode"] != nil && secret["mode"] == "primary"
 	})
-	tc.Logger.Info("enabled dr primary")
 }
 
-func getDrToken(t testing.T, tc *vault.TestCluster, id, secondaryPublicKey string) string {
+func getDrToken(t testing.T, tc *vault.TestCluster, id string) string {
 	req := map[string]interface{}{
 		"id": id,
-	}
-	if secondaryPublicKey != "" {
-		req["secondary_public_key"] = secondaryPublicKey
 	}
 	secret, err := tc.Cores[0].Client.Logical().Write("sys/replication/dr/primary/secondary-token", req)
 	if err != nil {
@@ -530,89 +493,57 @@ func getDrToken(t testing.T, tc *vault.TestCluster, id, secondaryPublicKey strin
 	return secret.WrapInfo.Token
 }
 
-func EnablePerformanceSecondary(t testing.T, perfToken string, pri, sec *vault.TestCluster, updatePrimary, skipPoisonPill bool) string {
+func (r *ReplicatedTestClustersBuilder) enablePerformanceSecondary(t testing.T) {
+	c := r.clusters.PerfSecondaryCluster.Cores[0]
 	postData := map[string]interface{}{
-		"token":   perfToken,
-		"ca_file": pri.CACertPEMFile,
+		"token":   r.perfToken,
+		"ca_file": r.clusters.PerfPrimaryCluster.CACertPEMFile,
 	}
-	if pri.ClientAuthRequired {
-		p := pri.Cores[0]
+	if r.clusters.PerfPrimaryCluster.ClientAuthRequired {
+		p := r.clusters.PerfPrimaryCluster.Cores[0]
 		postData["client_cert_pem"] = string(p.ServerCertPEM)
 		postData["client_key_pem"] = string(p.ServerKeyPEM)
 	}
-	path := "sys/replication/performance/secondary/enable"
-	if updatePrimary {
-		path = "sys/replication/performance/secondary/update-primary"
-	}
-	_, err := sec.Cores[0].Client.Logical().Write(path, postData)
+	_, err := c.Client.Logical().Write("sys/replication/performance/secondary/enable", postData)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	sec.Logger.Info("enabled perf secondary, waiting for its replication state")
-	WaitForReplicationState(t, sec.Cores[0].Core, consts.ReplicationPerformanceSecondary)
-	WaitForMatchingMerkleRootsCore(t, pri.Cores[0], sec.Cores[0], false)
+	WaitForReplicationState(t, c.Core, consts.ReplicationPerformanceSecondary)
 
-	var perfSecondaryRootToken string
-	if !updatePrimary {
-		sec.BarrierKeys = pri.BarrierKeys
-		if !pri.Cores[0].SealAccess().RecoveryKeySupported() {
-			sec.RecoveryKeys = pri.BarrierKeys
-		} else {
-			sec.RecoveryKeys = pri.RecoveryKeys
-		}
+	r.clusters.PerfSecondaryCluster.BarrierKeys = r.clusters.PerfPrimaryCluster.BarrierKeys
 
-		if len(sec.Cores) > 1 {
-			if skipPoisonPill {
-				// As part of prepareSecondary on the active node the keyring is
-				// deleted from storage.  Its absence can cause standbys to seal
-				// themselves. But it's not reliable, so we'll seal them
-				// ourselves to force the issue.
-				for _, core := range sec.Cores[1:] {
-					EnsureCoreSealed(t, core)
-				}
-			} else {
-				sec.Logger.Info("waiting for perf secondary standbys to seal")
-				// We want to make sure we unseal all the nodes so we first need to wait
-				// until two of the nodes seal due to the poison pill being written
-				WaitForNCoresSealed(t, sec, len(sec.Cores)-1)
-			}
-		}
-		sec.Logger.Info("waiting for perf secondary standbys to be unsealed")
-		EnsureCoresUnsealed(t, sec)
-		sec.Logger.Info("waiting for perf secondary active node")
-		WaitForActiveNode(t, sec)
-		sec.Logger.Info("generating new perf secondary root")
+	// We want to make sure we unseal all the nodes so we first need to wait
+	// until two of the nodes seal due to the poison pill being written
+	WaitForNCoresSealed(t, r.clusters.PerfSecondaryCluster, 2)
+	EnsureCoresUnsealed(t, r.clusters.PerfSecondaryCluster)
+	WaitForActiveNode(t, r.clusters.PerfSecondaryCluster)
 
-		perfSecondaryRootToken = GenerateRoot(t, sec, false)
-		for _, core := range sec.Cores {
-			core.Client.SetToken(perfSecondaryRootToken)
-		}
-		WaitForActiveNodeAndPerfStandbys(t, sec)
+	r.perfSecondaryRootToken = GenerateRoot(t, r.clusters.PerfSecondaryCluster, false)
+	for _, core := range r.clusters.PerfSecondaryCluster.Cores {
+		core.Client.SetToken(r.perfSecondaryRootToken)
 	}
 
-	WaitForPerfReplicationWorking(t, pri, sec)
-	return perfSecondaryRootToken
+	WaitForPerfReplicationWorking(t, r.clusters.PerfPrimaryCluster, r.clusters.PerfSecondaryCluster)
 }
 
-func EnableDrSecondary(t testing.T, pri, sec *vault.TestCluster, token string) {
-	sec.Logger.Info("enabling dr secondary")
-	_, err := sec.Cores[0].Client.Logical().Write("sys/replication/dr/secondary/enable", map[string]interface{}{
+func (r *ReplicatedTestClustersBuilder) enableDrSecondary(t testing.T, tc *vault.TestCluster, token, ca_file string) {
+	_, err := tc.Cores[0].Client.Logical().Write("sys/replication/dr/secondary/enable", map[string]interface{}{
 		"token":   token,
-		"ca_file": pri.CACertPEMFile,
+		"ca_file": ca_file,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	WaitForReplicationState(t, sec.Cores[0].Core, consts.ReplicationDRSecondary)
-	sec.BarrierKeys = pri.BarrierKeys
+	WaitForReplicationState(t, tc.Cores[0].Core, consts.ReplicationDRSecondary)
+	tc.BarrierKeys = r.clusters.PerfPrimaryCluster.BarrierKeys
 
 	// We want to make sure we unseal all the nodes so we first need to wait
 	// until two of the nodes seal due to the poison pill being written
-	WaitForNCoresSealed(t, sec, len(sec.Cores)-1)
-	EnsureCoresUnsealed(t, sec)
-	WaitForReplicationStatus(t, sec.Cores[0].Client, true, func(secret map[string]interface{}) bool {
+	WaitForNCoresSealed(t, tc, len(tc.Cores)-1)
+	EnsureCoresUnsealed(t, tc)
+	WaitForReplicationStatus(t, tc.Cores[0].Client, true, func(secret map[string]interface{}) bool {
 		return secret["mode"] != nil && secret["mode"] == "secondary"
 	})
 }
@@ -685,7 +616,7 @@ func WaitForNCoresUnsealed(t testing.T, cluster *vault.TestCluster, n int) {
 
 func WaitForNCoresSealed(t testing.T, cluster *vault.TestCluster, n int) {
 	t.Helper()
-	for i := 0; i < 60; i++ {
+	for i := 0; i < 30; i++ {
 		sealed := 0
 		for _, core := range cluster.Cores {
 			if core.Core.Sealed() {
@@ -704,20 +635,13 @@ func WaitForNCoresSealed(t testing.T, cluster *vault.TestCluster, n int) {
 
 func WaitForActiveNodeAndPerfStandbys(t testing.T, cluster *vault.TestCluster) {
 	t.Helper()
-
-	expectedStandbys := 0
-	for _, core := range cluster.Cores[1:] {
-		if !core.CoreConfig.DisablePerformanceStandby {
-			expectedStandbys++
-		}
-	}
 	mountPoint, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)
 	}
 	err = cluster.Cores[0].Client.Sys().Mount(mountPoint, &api.MountInput{
 		Type:  "kv",
-		Local: true,
+		Local: false,
 	})
 	if err != nil {
 		t.Fatal("unable to mount KV engine")
@@ -728,48 +652,40 @@ func WaitForActiveNodeAndPerfStandbys(t testing.T, cluster *vault.TestCluster) {
 	deadline := time.Now().Add(30 * time.Second)
 	for _, c := range cluster.Cores {
 		wg.Add(1)
-		go func(core *vault.TestClusterCore) {
+		go func(client *api.Client) {
 			defer wg.Done()
 			val := 1
 			for time.Now().Before(deadline) {
-				_, err := cluster.Cores[0].Client.Logical().Write(path, map[string]interface{}{
+				_, err = cluster.Cores[0].Client.Logical().Write(path, map[string]interface{}{
 					"bar": val,
 				})
+				if err != nil {
+					t.Fatal("unable to write KV", "path", path)
+				}
 				val++
 				time.Sleep(250 * time.Millisecond)
-				if err != nil {
-					if strings.Contains(err.Error(), "Vault is sealed") {
-						continue
-					}
-					if strings.Contains(err.Error(), "still catching up to primary") {
-						continue
-					}
-					t.Fatal(err)
-				}
-				leader, err := core.Client.Sys().Leader()
+				leader, err := client.Sys().Leader()
 				if err != nil {
 					if strings.Contains(err.Error(), "Vault is sealed") {
 						continue
 					}
 					t.Fatal(err)
 				}
-				switch {
-				case leader.IsSelf:
+				if leader.IsSelf {
 					atomic.AddInt64(&actives, 1)
 					return
-				case leader.LeaderAddress != "" && core.CoreConfig.DisablePerformanceStandby:
-					return
-				case leader.PerfStandby && leader.PerfStandbyLastRemoteWAL > 0:
+				}
+				if leader.PerfStandby && leader.PerfStandbyLastRemoteWAL > 0 {
 					atomic.AddInt64(&standbys, 1)
 					return
 				}
 			}
-		}(c)
+		}(c.Client)
 	}
 	wg.Wait()
-	if actives != 1 || int(standbys) != expectedStandbys {
+	if actives != 1 || int(standbys) != len(cluster.Cores)-1 {
 		t.Fatalf("expected 1 active core and %d standbys, got %d active and %d standbys",
-			expectedStandbys, actives, standbys)
+			len(cluster.Cores)-1, actives, standbys)
 	}
 	err = cluster.Cores[0].Client.Sys().Unmount(mountPoint)
 	if err != nil {
@@ -917,8 +833,7 @@ func RekeyCluster(t testing.T, cluster *vault.TestCluster) {
 	cluster.BarrierKeys = newBarrierKeys
 }
 
-func MakeRaftBackend(t testing.T, coreIdx int, logger hclog.Logger) *vault.PhysicalBackendBundle {
-	nodeID := fmt.Sprintf("core-%d", coreIdx)
+func CreateRaftBackend(t testing.T, logger hclog.Logger, nodeID string) (physical.Backend, func(), error) {
 	raftDir, err := ioutil.TempDir("", "vault-raft-")
 	if err != nil {
 		t.Fatal(err)
@@ -942,11 +857,7 @@ func MakeRaftBackend(t testing.T, coreIdx int, logger hclog.Logger) *vault.Physi
 		t.Fatal(err)
 	}
 
-	return &vault.PhysicalBackendBundle{
-		Backend:   backend,
-		HABackend: backend.(physical.HABackend),
-		Cleanup:   cleanupFunc,
-	}
+	return backend, cleanupFunc, nil
 }
 
 type TestRaftServerAddressProvider struct {
@@ -1048,154 +959,4 @@ func WaitForPerfReplicationWorking(t testing.T, pri, sec *vault.TestCluster) {
 		time.Sleep(100 * time.Millisecond)
 	}
 	t.Fatal("unable to read replicated KV on secondary", "path", path, "err", err)
-}
-
-func WaitForDRReplicationWorking(t testing.T, pri, sec *vault.TestCluster) {
-	priClient, secClient := pri.Cores[0].Client, sec.Cores[0].Client
-	mountPoint, err := uuid.GenerateUUID()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = priClient.Sys().Mount(mountPoint, &api.MountInput{
-		Type:  "kv",
-		Local: false,
-	})
-	if err != nil {
-		t.Fatal("unable to mount KV engine on primary")
-	}
-
-	path := mountPoint + "/foo"
-	_, err = priClient.Logical().Write(path, map[string]interface{}{
-		"bar": 1,
-	})
-	if err != nil {
-		t.Fatal("unable to write KV on primary", "path", path)
-	}
-
-	WaitForReplicationStatus(t, secClient, true, func(secret map[string]interface{}) bool {
-		if secret["last_remote_wal"] != nil {
-			lastRemoteWal, _ := secret["last_remote_wal"].(json.Number).Int64()
-			return lastRemoteWal > 0
-		}
-
-		return false
-	})
-
-	err = priClient.Sys().Unmount(mountPoint)
-	if err != nil {
-		t.Fatal("unable to unmount KV engine on primary")
-	}
-}
-
-func MakeInmemBackend(t testing.T, logger hclog.Logger) *vault.PhysicalBackendBundle {
-	inm, err := inmem.NewTransactionalInmem(nil, logger)
-	if err != nil {
-		t.Fatal(err)
-	}
-	inmha, err := inmem.NewInmemHA(nil, logger)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return &vault.PhysicalBackendBundle{
-		Backend:   inm,
-		HABackend: inmha.(physical.HABackend),
-	}
-}
-
-func MakeInmemNonTransactionalBackend(t testing.T, logger hclog.Logger) *vault.PhysicalBackendBundle {
-	inm, err := inmem.NewInmem(nil, logger)
-	if err != nil {
-		t.Fatal(err)
-	}
-	inmha, err := inmem.NewInmemHA(nil, logger)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return &vault.PhysicalBackendBundle{
-		Backend:   inm,
-		HABackend: inmha.(physical.HABackend),
-	}
-}
-
-func MakeFileBackend(t testing.T, logger hclog.Logger) *vault.PhysicalBackendBundle {
-	path, err := ioutil.TempDir("", "vault-integ-file-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	fileConf := map[string]string{
-		"path": path,
-	}
-	fileBackend, err := physFile.NewTransactionalFileBackend(fileConf, logger)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	inmha, err := inmem.NewInmemHA(nil, logger)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return &vault.PhysicalBackendBundle{
-		Backend:   fileBackend,
-		HABackend: inmha.(physical.HABackend),
-		Cleanup: func() {
-			err := os.RemoveAll(path)
-			if err != nil {
-				t.Fatal(err)
-			}
-		},
-	}
-}
-
-func MakeConsulBackend(t testing.T, logger hclog.Logger) *vault.PhysicalBackendBundle {
-	cleanup, consulAddress, consulToken := consul.PrepareTestContainer(t.(*realtesting.T), "1.4.0-rc1")
-	consulConf := map[string]string{
-		"address":      consulAddress,
-		"token":        consulToken,
-		"max_parallel": "32",
-	}
-	consulBackend, err := physConsul.NewConsulBackend(consulConf, logger)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return &vault.PhysicalBackendBundle{
-		Backend: consulBackend,
-		Cleanup: cleanup,
-	}
-}
-
-type ClusterSetupMutator func(conf *vault.CoreConfig, opts *vault.TestClusterOptions)
-
-func sharedPhysicalFactory(f func(t testing.T, logger hclog.Logger) *vault.PhysicalBackendBundle) func(t testing.T, coreIdx int, logger hclog.Logger) *vault.PhysicalBackendBundle {
-	return func(t testing.T, coreIdx int, logger hclog.Logger) *vault.PhysicalBackendBundle {
-		if coreIdx == 0 {
-			return f(t, logger)
-		}
-		return nil
-	}
-}
-
-func InmemBackendSetup(conf *vault.CoreConfig, opts *vault.TestClusterOptions) {
-	opts.PhysicalFactory = sharedPhysicalFactory(MakeInmemBackend)
-}
-func InmemNonTransactionalBackendSetup(conf *vault.CoreConfig, opts *vault.TestClusterOptions) {
-	opts.PhysicalFactory = sharedPhysicalFactory(MakeInmemNonTransactionalBackend)
-}
-func FileBackendSetup(conf *vault.CoreConfig, opts *vault.TestClusterOptions) {
-	opts.PhysicalFactory = sharedPhysicalFactory(MakeFileBackend)
-}
-func ConsulBackendSetup(conf *vault.CoreConfig, opts *vault.TestClusterOptions) {
-	opts.PhysicalFactory = sharedPhysicalFactory(MakeConsulBackend)
-}
-
-func RaftBackendSetup(conf *vault.CoreConfig, opts *vault.TestClusterOptions) {
-	conf.DisablePerformanceStandby = true
-	opts.KeepStandbysSealed = true
-	opts.PhysicalFactory = MakeRaftBackend
-	opts.SetupFunc = func(t testing.T, c *vault.TestCluster) {
-		RaftClusterJoinNodes(t, c)
-		time.Sleep(15 * time.Second)
-	}
 }

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -6,35 +6,50 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-cleanhttp"
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/testhelpers"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/physical/raft"
+	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/vault"
 	"golang.org/x/net/http2"
 )
 
-func raftCluster(t *testing.T) *vault.TestCluster {
-	var conf vault.CoreConfig
-	var opts = vault.TestClusterOptions{HandlerFunc: vaulthttp.Handler}
-	testhelpers.RaftBackendSetup(&conf, &opts)
-	cluster := vault.NewTestCluster(t, &conf, &opts)
-	cluster.Start()
-	vault.TestWaitActive(t, cluster.Cores[0].Core)
-	return cluster
-}
-
 func TestRaft_Join(t *testing.T) {
-	var conf vault.CoreConfig
-	var opts = vault.TestClusterOptions{HandlerFunc: vaulthttp.Handler}
-	testhelpers.RaftBackendSetup(&conf, &opts)
-	opts.SetupFunc = nil
-	cluster := vault.NewTestCluster(t, &conf, &opts)
+	var cleanupFuncs []func()
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level: hclog.Trace,
+		Mutex: &sync.Mutex{},
+	})
+	coreConfig := &vault.CoreConfig{
+		Logger: logger,
+		// TODO: remove this later
+		DisablePerformanceStandby: true,
+	}
+	i := 0
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		PhysicalFactory: func(logger hclog.Logger) (physical.Backend, error) {
+			backend, cleanupFunc, err := testhelpers.CreateRaftBackend(t, logger, fmt.Sprintf("core-%d", i))
+			i++
+			cleanupFuncs = append(cleanupFuncs, cleanupFunc)
+			return backend, err
+		},
+		Logger:             logger,
+		KeepStandbysSealed: true,
+		HandlerFunc:        vaulthttp.Handler,
+	})
+	defer func() {
+		for _, c := range cleanupFuncs {
+			c()
+		}
+	}()
 	cluster.Start()
 	defer cluster.Cleanup()
 
@@ -92,8 +107,37 @@ func TestRaft_Join(t *testing.T) {
 }
 
 func TestRaft_RemovePeer(t *testing.T) {
-	cluster := raftCluster(t)
+	var cleanupFuncs []func()
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level: hclog.Trace,
+		Mutex: &sync.Mutex{},
+	})
+	coreConfig := &vault.CoreConfig{
+		Logger: logger,
+		// TODO: remove this later
+		DisablePerformanceStandby: true,
+	}
+	i := 0
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		PhysicalFactory: func(logger hclog.Logger) (physical.Backend, error) {
+			backend, cleanupFunc, err := testhelpers.CreateRaftBackend(t, logger, fmt.Sprintf("core-%d", i))
+			i++
+			cleanupFuncs = append(cleanupFuncs, cleanupFunc)
+			return backend, err
+		},
+		Logger:             logger,
+		KeepStandbysSealed: true,
+		HandlerFunc:        vaulthttp.Handler,
+	})
+	defer func() {
+		for _, c := range cleanupFuncs {
+			c()
+		}
+	}()
+	cluster.Start()
 	defer cluster.Cleanup()
+
+	testhelpers.RaftClusterJoinNodes(t, cluster)
 
 	for i, c := range cluster.Cores {
 		if c.Core.Sealed() {
@@ -150,8 +194,37 @@ func TestRaft_RemovePeer(t *testing.T) {
 }
 
 func TestRaft_Configuration(t *testing.T) {
-	cluster := raftCluster(t)
+	var cleanupFuncs []func()
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level: hclog.Trace,
+		Mutex: &sync.Mutex{},
+	})
+	coreConfig := &vault.CoreConfig{
+		Logger: logger,
+		// TODO: remove this later
+		DisablePerformanceStandby: true,
+	}
+	i := 0
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		PhysicalFactory: func(logger hclog.Logger) (physical.Backend, error) {
+			backend, cleanupFunc, err := testhelpers.CreateRaftBackend(t, logger, fmt.Sprintf("core-%d", i))
+			i++
+			cleanupFuncs = append(cleanupFuncs, cleanupFunc)
+			return backend, err
+		},
+		Logger:             logger,
+		KeepStandbysSealed: true,
+		HandlerFunc:        vaulthttp.Handler,
+	})
+	defer func() {
+		for _, c := range cleanupFuncs {
+			c()
+		}
+	}()
+	cluster.Start()
 	defer cluster.Cleanup()
+
+	testhelpers.RaftClusterJoinNodes(t, cluster)
 
 	for i, c := range cluster.Cores {
 		if c.Core.Sealed() {
@@ -196,8 +269,37 @@ func TestRaft_Configuration(t *testing.T) {
 }
 
 func TestRaft_ShamirUnseal(t *testing.T) {
-	cluster := raftCluster(t)
+	var cleanupFuncs []func()
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level: hclog.Trace,
+		Mutex: &sync.Mutex{},
+	})
+	coreConfig := &vault.CoreConfig{
+		Logger: logger,
+		// TODO: remove this later
+		DisablePerformanceStandby: true,
+	}
+	i := 0
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		PhysicalFactory: func(logger hclog.Logger) (physical.Backend, error) {
+			backend, cleanupFunc, err := testhelpers.CreateRaftBackend(t, logger, fmt.Sprintf("core-%d", i))
+			i++
+			cleanupFuncs = append(cleanupFuncs, cleanupFunc)
+			return backend, err
+		},
+		Logger:             logger,
+		KeepStandbysSealed: true,
+		HandlerFunc:        vaulthttp.Handler,
+	})
+	defer func() {
+		for _, c := range cleanupFuncs {
+			c()
+		}
+	}()
+	cluster.Start()
 	defer cluster.Cleanup()
+
+	testhelpers.RaftClusterJoinNodes(t, cluster)
 
 	for i, c := range cluster.Cores {
 		if c.Core.Sealed() {
@@ -207,8 +309,37 @@ func TestRaft_ShamirUnseal(t *testing.T) {
 }
 
 func TestRaft_SnapshotAPI(t *testing.T) {
-	cluster := raftCluster(t)
+	var cleanupFuncs []func()
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level: hclog.Trace,
+		Mutex: &sync.Mutex{},
+	})
+	coreConfig := &vault.CoreConfig{
+		Logger: logger,
+		// TODO: remove this later
+		DisablePerformanceStandby: true,
+	}
+	i := 0
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		PhysicalFactory: func(logger hclog.Logger) (physical.Backend, error) {
+			backend, cleanupFunc, err := testhelpers.CreateRaftBackend(t, logger, fmt.Sprintf("core-%d", i))
+			i++
+			cleanupFuncs = append(cleanupFuncs, cleanupFunc)
+			return backend, err
+		},
+		Logger:             logger,
+		KeepStandbysSealed: true,
+		HandlerFunc:        vaulthttp.Handler,
+	})
+	defer func() {
+		for _, c := range cleanupFuncs {
+			c()
+		}
+	}()
+	cluster.Start()
 	defer cluster.Cleanup()
+
+	testhelpers.RaftClusterJoinNodes(t, cluster)
 
 	leaderClient := cluster.Cores[0].Client
 
@@ -312,9 +443,38 @@ func TestRaft_SnapshotAPI_RekeyRotate_Backward(t *testing.T) {
 			// bind locally
 			tCaseLocal := tCase
 			t.Parallel()
-
-			cluster := raftCluster(t)
+			var cleanupFuncs []func()
+			logger := hclog.New(&hclog.LoggerOptions{
+				Level: hclog.Trace,
+				Mutex: &sync.Mutex{},
+				Name:  tCaseLocal.Name,
+			})
+			coreConfig := &vault.CoreConfig{
+				Logger: logger,
+				// TODO: remove this later
+				DisablePerformanceStandby: true,
+			}
+			i := 0
+			cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+				PhysicalFactory: func(logger hclog.Logger) (physical.Backend, error) {
+					backend, cleanupFunc, err := testhelpers.CreateRaftBackend(t, logger, fmt.Sprintf("core-%d", i))
+					i++
+					cleanupFuncs = append(cleanupFuncs, cleanupFunc)
+					return backend, err
+				},
+				Logger:             logger,
+				KeepStandbysSealed: true,
+				HandlerFunc:        vaulthttp.Handler,
+			})
+			defer func() {
+				for _, c := range cleanupFuncs {
+					c()
+				}
+			}()
+			cluster.Start()
 			defer cluster.Cleanup()
+
+			testhelpers.RaftClusterJoinNodes(t, cluster)
 
 			leaderClient := cluster.Cores[0].Client
 
@@ -470,9 +630,38 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 			// bind locally
 			tCaseLocal := tCase
 			t.Parallel()
-
-			cluster := raftCluster(t)
+			var cleanupFuncs []func()
+			logger := hclog.New(&hclog.LoggerOptions{
+				Level: hclog.Trace,
+				Mutex: &sync.Mutex{},
+				Name:  tCaseLocal.Name,
+			})
+			coreConfig := &vault.CoreConfig{
+				Logger: logger,
+				// TODO: remove this later
+				DisablePerformanceStandby: true,
+			}
+			i := 0
+			cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+				PhysicalFactory: func(logger hclog.Logger) (physical.Backend, error) {
+					backend, cleanupFunc, err := testhelpers.CreateRaftBackend(t, logger, fmt.Sprintf("core-%d", i))
+					i++
+					cleanupFuncs = append(cleanupFuncs, cleanupFunc)
+					return backend, err
+				},
+				Logger:             logger,
+				KeepStandbysSealed: true,
+				HandlerFunc:        vaulthttp.Handler,
+			})
+			defer func() {
+				for _, c := range cleanupFuncs {
+					c()
+				}
+			}()
+			cluster.Start()
 			defer cluster.Cleanup()
+
+			testhelpers.RaftClusterJoinNodes(t, cluster)
 
 			leaderClient := cluster.Cores[0].Client
 
@@ -639,8 +828,39 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 }
 
 func TestRaft_SnapshotAPI_DifferentCluster(t *testing.T) {
-	cluster := raftCluster(t)
+
+	var cleanupFuncs []func()
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level: hclog.Trace,
+		Mutex: &sync.Mutex{},
+		Name:  "cluster1",
+	})
+	coreConfig := &vault.CoreConfig{
+		Logger: logger,
+		// TODO: remove this later
+		DisablePerformanceStandby: true,
+	}
+	i := 0
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		PhysicalFactory: func(logger hclog.Logger) (physical.Backend, error) {
+			backend, cleanupFunc, err := testhelpers.CreateRaftBackend(t, logger, fmt.Sprintf("core-%d", i))
+			i++
+			cleanupFuncs = append(cleanupFuncs, cleanupFunc)
+			return backend, err
+		},
+		Logger:             logger,
+		KeepStandbysSealed: true,
+		HandlerFunc:        vaulthttp.Handler,
+	})
+	defer func() {
+		for _, c := range cleanupFuncs {
+			c()
+		}
+	}()
+	cluster.Start()
 	defer cluster.Cleanup()
+
+	testhelpers.RaftClusterJoinNodes(t, cluster)
 
 	leaderClient := cluster.Cores[0].Client
 
@@ -685,8 +905,32 @@ func TestRaft_SnapshotAPI_DifferentCluster(t *testing.T) {
 
 	// Cluster 2
 	{
-		cluster2 := raftCluster(t)
+		logger := hclog.New(&hclog.LoggerOptions{
+			Level: hclog.Trace,
+			Mutex: &sync.Mutex{},
+			Name:  "cluster2",
+		})
+		coreConfig := &vault.CoreConfig{
+			Logger: logger,
+			// TODO: remove this later
+			DisablePerformanceStandby: true,
+		}
+		i := 0
+		cluster2 := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+			PhysicalFactory: func(logger hclog.Logger) (physical.Backend, error) {
+				backend, cleanupFunc, err := testhelpers.CreateRaftBackend(t, logger, fmt.Sprintf("core-%d", i))
+				i++
+				cleanupFuncs = append(cleanupFuncs, cleanupFunc)
+				return backend, err
+			},
+			Logger:             logger,
+			KeepStandbysSealed: true,
+			HandlerFunc:        vaulthttp.Handler,
+		})
+		cluster2.Start()
 		defer cluster2.Cleanup()
+
+		testhelpers.RaftClusterJoinNodes(t, cluster2)
 
 		leaderClient := cluster2.Cores[0].Client
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -797,8 +797,6 @@ type TestCluster struct {
 	TempDir            string
 	ClientAuthRequired bool
 	Logger             log.Logger
-	CleanupFunc        func()
-	SetupFunc          func()
 }
 
 func (c *TestCluster) Start() {
@@ -808,9 +806,6 @@ func (c *TestCluster) Start() {
 				go core.Server.Serve(ln)
 			}
 		}
-	}
-	if c.SetupFunc != nil {
-		c.SetupFunc()
 	}
 }
 
@@ -952,9 +947,6 @@ func (c *TestCluster) Cleanup() {
 
 	// Give time to actually shut down/clean up before the next test
 	time.Sleep(time.Second)
-	if c.CleanupFunc != nil {
-		c.CleanupFunc()
-	}
 }
 
 func (c *TestCluster) ensureCoresSealed() error {
@@ -1026,12 +1018,6 @@ type TestClusterCore struct {
 	NodeID               string
 }
 
-type PhysicalBackendBundle struct {
-	Backend   physical.Backend
-	HABackend physical.HABackend
-	Cleanup   func()
-}
-
 type TestClusterOptions struct {
 	KeepStandbysSealed bool
 	SkipInit           bool
@@ -1043,18 +1029,9 @@ type TestClusterOptions struct {
 	TempDir            string
 	CACert             []byte
 	CAKey              *ecdsa.PrivateKey
-	// PhysicalFactory is used to create backends.
-	// The int argument is the index of the core within the cluster, i.e. first
-	// core in cluster will have 0, second 1, etc.
-	// If the backend is shared across the cluster (i.e. is not Raft) then it
-	// should return nil when coreIdx != 0.
-	PhysicalFactory func(t testing.T, coreIdx int, logger hclog.Logger) *PhysicalBackendBundle
-	// FirstCoreNumber is used to assign a unique number to each core within
-	// a multi-cluster setup.
-	FirstCoreNumber   int
-	RequireClientAuth bool
-	// SetupFunc is called after the cluster is started.
-	SetupFunc func(t testing.T, c *TestCluster)
+	PhysicalFactory    func(hclog.Logger) (physical.Backend, error)
+	FirstCoreNumber    int
+	RequireClientAuth  bool
 }
 
 var DefaultNumCores = 3
@@ -1437,7 +1414,6 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		t.Fatalf("err: %v", err)
 	}
 
-	cleanupFuncs := []func(){}
 	cores := []*Core{}
 	coreConfigs := []*CoreConfig{}
 	for i := 0; i < numCores; i++ {
@@ -1452,28 +1428,15 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		if coreConfig.Logger == nil || (opts != nil && opts.Logger != nil) {
 			localConfig.Logger = testCluster.Logger.Named(fmt.Sprintf("core%d", i))
 		}
+
 		if opts != nil && opts.PhysicalFactory != nil {
-			physBundle := opts.PhysicalFactory(t, i, localConfig.Logger)
-			switch {
-			case physBundle == nil && coreConfig.Physical != nil:
-			case physBundle == nil && coreConfig.Physical == nil:
-				t.Fatal("PhysicalFactory produced no physical and none in CoreConfig")
-			case physBundle != nil:
-				testCluster.Logger.Info("created physical backend", "instance", i)
-				coreConfig.Physical = physBundle.Backend
-				localConfig.Physical = physBundle.Backend
-				base.Physical = physBundle.Backend
-				haBackend := physBundle.HABackend
-				if haBackend == nil {
-					if ha, ok := physBundle.Backend.(physical.HABackend); ok {
-						haBackend = ha
-					}
-				}
-				coreConfig.HAPhysical = haBackend
-				localConfig.HAPhysical = haBackend
-				if physBundle.Cleanup != nil {
-					cleanupFuncs = append(cleanupFuncs, physBundle.Cleanup)
-				}
+			localConfig.Physical, err = opts.PhysicalFactory(localConfig.Logger)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			if haPhysical, ok := localConfig.Physical.(physical.HABackend); ok {
+				localConfig.HAPhysical = haPhysical
 			}
 		}
 
@@ -1734,19 +1697,6 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 	testCluster.Cores = ret
 
 	testExtraClusterCoresTestSetup(t, priKey, testCluster.Cores)
-
-	testCluster.CleanupFunc = func() {
-		for _, c := range cleanupFuncs {
-			c()
-		}
-	}
-	if opts != nil {
-		if opts.SetupFunc != nil {
-			testCluster.SetupFunc = func() {
-				opts.SetupFunc(t, &testCluster)
-			}
-		}
-	}
 
 	return &testCluster
 }


### PR DESCRIPTION
Reverts hashicorp/vault#7177

@ncabatoff For reasons I don't have time to dig into right now, the commit causes failures to build on several platforms:

```
6 errors occurred:
--> netbsd/386 error: exit status 2
Stderr: # github.com/hashicorp/vault/vendor/github.com/ory/dockertest/docker/pkg/term
vendor/github.com/ory/dockertest/docker/pkg/term/tc.go:12:27: undefined: Termios
vendor/github.com/ory/dockertest/docker/pkg/term/tc.go:17:27: undefined: Termios
vendor/github.com/ory/dockertest/docker/pkg/term/term.go:24:10: undefined: Termios
# github.com/hashicorp/vault/vendor/github.com/ory/dockertest/docker/pkg/system
vendor/github.com/ory/dockertest/docker/pkg/system/lstat_unix.go:18:9: undefined: fromStatT
vendor/github.com/ory/dockertest/docker/pkg/system/stat_unix.go:64:9: undefined: fromStatT

--> freebsd/arm error: exit status 2
Stderr: # github.com/hashicorp/vault/vendor/github.com/ory/dockertest/docker/pkg/system
vendor/github.com/ory/dockertest/docker/pkg/system/mknod.go:12:19: cannot use dev (type int) as type uint64 in argument to unix.Mknod

--> netbsd/amd64 error: exit status 2
Stderr: # github.com/hashicorp/vault/vendor/github.com/ory/dockertest/docker/pkg/term
vendor/github.com/ory/dockertest/docker/pkg/term/tc.go:12:27: undefined: Termios
vendor/github.com/ory/dockertest/docker/pkg/term/tc.go:17:27: undefined: Termios
vendor/github.com/ory/dockertest/docker/pkg/term/term.go:24:10: undefined: Termios
# github.com/hashicorp/vault/vendor/github.com/ory/dockertest/docker/pkg/system
vendor/github.com/ory/dockertest/docker/pkg/system/lstat_unix.go:18:9: undefined: fromStatT
vendor/github.com/ory/dockertest/docker/pkg/system/stat_unix.go:64:9: undefined: fromStatT

--> freebsd/386 error: exit status 2
Stderr: # github.com/hashicorp/vault/vendor/github.com/ory/dockertest/docker/pkg/system
vendor/github.com/ory/dockertest/docker/pkg/system/mknod.go:12:19: cannot use dev (type int) as type uint64 in argument to unix.Mknod

--> freebsd/amd64 error: exit status 2
Stderr: # github.com/hashicorp/vault/vendor/github.com/ory/dockertest/docker/pkg/system
vendor/github.com/ory/dockertest/docker/pkg/system/mknod.go:12:19: cannot use dev (type int) as type uint64 in argument to unix.Mknod

--> solaris/amd64 error: exit status 2
Stderr: # github.com/hashicorp/vault/vendor/github.com/ory/dockertest/docker/pkg/term
vendor/github.com/ory/dockertest/docker/pkg/term/tc.go:12:27: undefined: Termios
vendor/github.com/ory/dockertest/docker/pkg/term/tc.go:17:27: undefined: Termios
vendor/github.com/ory/dockertest/docker/pkg/term/term.go:24:10: undefined: Termios
```
Reverting for now so I can continue with the release.