### PR TITLE
Fix create token sudo non-root namespace check

### DIFF
--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -118,7 +118,7 @@ func (d dynamicSystemView) SudoPrivilege(ctx context.Context, path string, token
 	req := new(logical.Request)
 	req.Operation = logical.ReadOperation
 	req.Path = path
-	authResults := acl.AllowOperation(ctx, req, true)
+	authResults := acl.AllowOperation(tokenCtx, req, true)
 	return authResults.RootPrivs
 }
 

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/errwrap"
@@ -87,6 +88,9 @@ func (d dynamicSystemView) SudoPrivilege(ctx context.Context, path string, token
 		d.core.logger.Error("failed to lookup token namespace", "error", namespace.ErrNoNamespace)
 		return false
 	}
+
+	// AllowOperation path should be namespace scoped
+	path = strings.TrimPrefix(path, tokenNS.Path)
 
 	// Add identity policies from all the namespaces
 	entity, identityPolicies, err := d.core.fetchEntityAndDerivedPolicies(ctx, tokenNS, te.EntityID)

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -2094,18 +2094,8 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 			logical.ErrInvalidRequest
 	}
 
-	// Get the context namespace
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// Check if the client token has sudo/root privileges for the requested path
-	mountPath := req.MountPoint+req.Path
-	if ns != namespace.RootNamespace {
-		mountPath = strings.TrimPrefix(mountPath, ns.Path)
-	}
-	isSudo := ts.System().SudoPrivilege(ctx, mountPath, req.ClientToken)
+	isSudo := ts.System().SudoPrivilege(ctx, req.MountPoint+req.Path, req.ClientToken)
 
 	// Read and parse the fields
 	var data struct {
@@ -2132,6 +2122,10 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 	// If the context's namespace is different from the parent and this is an
 	// orphan token creation request, then this is an admin token generation for
 	// the namespace
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if ns.ID != parent.NamespaceID {
 		parentNS, err := NamespaceByID(ctx, parent.NamespaceID, ts.core)
 		if err != nil {


### PR DESCRIPTION
The `SudoPrivilege` check expects a path without a namespace prefix since it calls `AllowOperation` which is already namespace-aware and checks by default the full context namespace path: https://github.com/hashicorp/vault/blob/master/vault/acl.go#L342

The consequence is that you have to define a separate policy to apply `sudo` rights for the `token/create` endpoint e.g.:

This policy allows you to create tokens but only without sudo-rights:
```
vault policy write -ns=test pol1 -<<EOF
path "auth/token/*" {
    capabilities=["sudo", "create", "update", "delete", "list", "read"]
}
EOF
```

You can only get sudo-rights by explicitly specifying the namespace:
```
vault policy write -ns=test pol1 -<<EOF
path "auth/token/*" {
    capabilities=["sudo", "create", "update", "delete", "list", "read"]
}

path "test/auth/token/*" {
    capabilities=["sudo", "create", "update", "delete", "list", "read"]
}
EOF
```

We should add additional tests on the enterprise side to make sure that this change doesn't introduce other side effects. 