### PR TITLE
Handle TokenType serialized as string or as uint8.

### DIFF
--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -1864,7 +1864,7 @@ func TestAppRole_TokenutilUpgrade(t *testing.T) {
 	// Hand craft JSON because there is overlap between fields
 	if err := s.Put(ctx, &logical.StorageEntry{
 		Key:   "role/foo",
-		Value: []byte(`{"policies": ["foo"], "period": 300000000000, "token_bound_cidrs": ["127.0.0.1", "10.10.10.10/24"]}`),
+		Value: []byte(`{"policies": ["foo"], "period": 300000000000, "token_bound_cidrs": ["127.0.0.1", "10.10.10.10/24"], "token_type": "service"}`),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1882,6 +1882,7 @@ func TestAppRole_TokenutilUpgrade(t *testing.T) {
 			TokenPolicies:   []string{"foo"},
 			TokenPeriod:     300 * time.Second,
 			TokenBoundCIDRs: []*sockaddr.SockAddrMarshaler{&sockaddr.SockAddrMarshaler{SockAddr: sockaddr.MustIPAddr("127.0.0.1")}, &sockaddr.SockAddrMarshaler{SockAddr: sockaddr.MustIPAddr("10.10.10.10/24")}},
+			TokenType:       logical.TokenTypeService,
 		},
 	}
 	if diff := deep.Equal(fooEntry, exp); diff != nil {

--- a/sdk/logical/token.go
+++ b/sdk/logical/token.go
@@ -31,7 +31,7 @@ const (
 
 func (t *TokenType) UnmarshalJSON(b []byte) error {
 	if len(b) == 1 {
-		*t = TokenType(b[0])
+		*t = TokenType(b[0] - '0')
 		return nil
 	}
 
@@ -44,8 +44,12 @@ func (t *TokenType) UnmarshalJSON(b []byte) error {
 		*t = TokenTypeService
 	case `"batch"`:
 		*t = TokenTypeBatch
+	case `"default-service"`:
+		*t = TokenTypeDefaultService
+	case `"default-batch"`:
+		*t = TokenTypeDefaultBatch
 	default:
-		return fmt.Errorf("Unknown token type %q", s)
+		return fmt.Errorf("unknown token type %q", s)
 	}
 	return nil
 }

--- a/sdk/logical/token.go
+++ b/sdk/logical/token.go
@@ -1,6 +1,7 @@
 package logical
 
 import (
+	"fmt"
 	"time"
 
 	sockaddr "github.com/hashicorp/go-sockaddr"
@@ -27,6 +28,27 @@ const (
 	// TokenTypeDefault is sent back by the mount, create Batch tokens
 	TokenTypeDefaultBatch
 )
+
+func (t *TokenType) UnmarshalJSON(b []byte) error {
+	if len(b) == 1 {
+		*t = TokenType(b[0])
+		return nil
+	}
+
+	// Handle upgrade from pre-1.2 where we were serialized as string:
+	s := string(b)
+	switch s {
+	case `"default"`:
+		*t = TokenTypeDefault
+	case `"service"`:
+		*t = TokenTypeService
+	case `"batch"`:
+		*t = TokenTypeBatch
+	default:
+		return fmt.Errorf("Unknown token type %q", s)
+	}
+	return nil
+}
 
 func (t TokenType) String() string {
 	switch t {

--- a/sdk/logical/token_test.go
+++ b/sdk/logical/token_test.go
@@ -1,0 +1,33 @@
+package logical
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestJSONSerialization(t *testing.T) {
+	tt := TokenTypeDefaultBatch
+	s, err := json.Marshal(tt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var utt TokenType
+	err = json.Unmarshal(s, &utt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tt != utt {
+		t.Fatalf("expected %v, got %v", tt, utt)
+	}
+
+	utt = TokenTypeDefault
+	err = json.Unmarshal([]byte(`"default-batch"`), &utt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tt != utt {
+		t.Fatalf("expected %v, got %v", tt, utt)
+	}
+}


### PR DESCRIPTION
Fixes #7231.  Tested manually, now working on an automated test.