### PR TITLE
avoid a panic on failed creds polling

### DIFF
--- a/command/agent/auth/alicloud/alicloud.go
+++ b/command/agent/auth/alicloud/alicloud.go
@@ -207,7 +207,7 @@ func (a *alicloudMethod) pollForCreds(credProvider providers.Provider, frequency
 			return
 		case <-ticker.C:
 			if err := a.checkCreds(credProvider); err != nil {
-				a.logger.Warn("unable to retrieve current creds, retaining last creds", err)
+				a.logger.Warn("unable to retrieve current creds, retaining last creds", "error", err)
 			}
 		}
 	}

--- a/command/agent/auth/aws/aws.go
+++ b/command/agent/auth/aws/aws.go
@@ -279,7 +279,7 @@ func (a *awsMethod) pollForCreds(accessKey, secretKey, sessionToken string, freq
 			return
 		case <-ticker.C:
 			if err := a.checkCreds(accessKey, secretKey, sessionToken); err != nil {
-				a.logger.Warn("unable to retrieve current creds, retaining last creds", err)
+				a.logger.Warn("unable to retrieve current creds, retaining last creds", "error", err)
 			}
 		}
 	}


### PR DESCRIPTION
We run Vault Agent on k8s with kiam. Occasionally, the kiam-agent will be unavailable due to maintenance, which causes Agent's creds poll loop to panic.

I haven't tried running this change, but it seems pretty straightforward.

```
panic: interface conversion: interface {} is *errwrap.wrappedError, not string
goroutine 69 [running]:
github.com/hashicorp/vault/vendor/github.com/hashicorp/go-hclog.(*intLogger).log(0xc000701200, 0xbf48e5d44eb0be7e, 0x4a96954a2a, 0x4d2ae40, 0x4, 0x2bde115, 0x36, 0xc000c561d0, 0x2, 0x1)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/go-hclog/int.go:238 +0xf6f
github.com/hashicorp/vault/vendor/github.com/hashicorp/go-hclog.(*intLogger).Log(0xc000701200, 0xc000000004, 0x2bde115, 0x36, 0xc000c561d0, 0x1, 0x1)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/go-hclog/int.go:107 +0x1b3
github.com/hashicorp/vault/vendor/github.com/hashicorp/go-hclog.(*intLogger).Warn(0xc000701200, 0x2bde115, 0x36, 0xc000c561d0, 0x1, 0x1)
	/gopath/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/go-hclog/int.go:393 +0x65
github.com/hashicorp/vault/command/agent/auth/aws.(*awsMethod).pollForCreds(0xc000702d80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3c)
	/gopath/src/github.com/hashicorp/vault/command/agent/auth/aws/aws.go:274 +0x202
created by github.com/hashicorp/vault/command/agent/auth/aws.NewAWSAuthMethod
	/gopath/src/github.com/hashicorp/vault/command/agent/auth/aws/aws.go:157 +0x644
```