### PR TITLE
Create test cores with an error injector. 

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -143,8 +143,10 @@ func TestCoreWithSealAndUI(t testing.T, opts *CoreConfig) *Core {
 		t.Fatal(err)
 	}
 
+	errInjector := physical.NewErrorInjector(physicalBackend, 0, logger)
+
 	// Start off with base test core config
-	conf := testCoreConfig(t, physicalBackend, logger)
+	conf := testCoreConfig(t, errInjector, logger)
 
 	// Override config values with ones that gets passed in
 	conf.EnableUI = opts.EnableUI


### PR DESCRIPTION
It's created with a 0% error rate, which means it's a no-op, but tests can opt-in to errors when needed via core.underlyingPhysical.