### PR TITLE
Backport v1.2.1: Fix buggy health check when perfstandyok=true

### DIFF
--- a/http/sys_health.go
+++ b/http/sys_health.go
@@ -146,10 +146,14 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 		code = sealedCode
 	case replicationState.HasState(consts.ReplicationDRSecondary):
 		code = drSecondaryCode
-	case !perfStandbyOK && perfStandby:
-		code = perfStandbyCode
-	case !standbyOK && standby:
-		code = standbyCode
+	case perfStandby:
+		if !perfStandbyOK {
+			code = perfStandbyCode
+		}
+	case standby:
+		if !standbyOK {
+			code = standbyCode
+		}
 	}
 
 	// Fetch the local cluster name and identifier

--- a/website/source/api/system/health.html.md
+++ b/website/source/api/system/health.html.md
@@ -35,12 +35,12 @@ The default status codes are:
 
 - `standbyok` `(bool: false)` – Specifies if being a standby should still return
   the active status code instead of the standby status code. This is useful when
-  Vault is behind a non-configurable load balance that just wants a 200-level
+  Vault is behind a non-configurable load balancer that just wants a 200-level
   response. This will not apply if the node is a performance standby.
   
 - `perfstandbyok` `(bool: false)` – Specifies if being a performance standby should
   still return the active status code instead of the performance standby status code.
-  This is useful when Vault is behind a non-configurable load balance that just wants
+  This is useful when Vault is behind a non-configurable load balancer that just wants
   a 200-level response.
 
 - `activecode` `(int: 200)` – Specifies the status code that should be returned


### PR DESCRIPTION
Follow what documentation says we should do if we're a perf standby and perfstandbyok=true, i.e. return 200 instead of 429.