### PR TITLE
Backport 1.2.1: support redirect after login in the UI

### DIFF
--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -192,12 +192,20 @@ export default Component.extend(DEFAULTS, {
 
   authenticate: task(function*(backendType, data) {
     let clusterId = this.cluster.id;
-    let targetRoute = this.redirectTo || 'vault.cluster';
     try {
       let authResponse = yield this.auth.authenticate({ clusterId, backend: backendType, data });
 
       let { isRoot, namespace } = authResponse;
-      let transition = this.router.transitionTo(targetRoute, { queryParams: { namespace } });
+      let transition;
+      let { redirectTo } = this;
+      if (redirectTo) {
+        // reset the value on the controller because it's bound here
+        this.set('redirectTo', '');
+        // here we don't need the namespace because it will be encoded in redirectTo
+        transition = this.router.transitionTo(redirectTo);
+      } else {
+        transition = this.router.transitionTo('vault.cluster', { queryParams: { namespace } });
+      }
       // returning this w/then because if we keep it
       // in the task, it will get cancelled when the component in un-rendered
       yield transition.followRedirects().then(() => {

--- a/ui/app/controllers/vault.js
+++ b/ui/app/controllers/vault.js
@@ -7,9 +7,11 @@ export default Controller.extend({
   queryParams: [
     {
       wrappedToken: 'wrapped_token',
+      redirectTo: 'redirect_to',
     },
   ],
   wrappedToken: '',
+  redirectTo: '',
   env: config.environment,
   auth: service(),
   store: service(),

--- a/ui/app/controllers/vault/cluster/auth.js
+++ b/ui/app/controllers/vault/cluster/auth.js
@@ -11,7 +11,7 @@ export default Controller.extend({
   queryParams: [{ authMethod: 'with' }],
   wrappedToken: alias('vaultController.wrappedToken'),
   authMethod: '',
-  redirectTo: null,
+  redirectTo: alias('vaultController.redirectTo'),
 
   updateNamespace: task(function*(value) {
     // debounce

--- a/ui/app/mixins/cluster-route.js
+++ b/ui/app/mixins/cluster-route.js
@@ -6,26 +6,41 @@ const INIT = 'vault.cluster.init';
 const UNSEAL = 'vault.cluster.unseal';
 const AUTH = 'vault.cluster.auth';
 const CLUSTER = 'vault.cluster';
+const CLUSTER_INDEX = 'vault.cluster.index';
 const OIDC_CALLBACK = 'vault.cluster.oidc-callback';
 const DR_REPLICATION_SECONDARY = 'vault.cluster.replication-dr-promote';
 
-export { INIT, UNSEAL, AUTH, CLUSTER, DR_REPLICATION_SECONDARY };
+export { INIT, UNSEAL, AUTH, CLUSTER, CLUSTER_INDEX, DR_REPLICATION_SECONDARY };
 
 export default Mixin.create({
   auth: service(),
   store: service(),
+  router: service(),
 
-  transitionToTargetRoute(transition) {
+  transitionToTargetRoute(transition = {}) {
     const targetRoute = this.targetRouteName(transition);
-    if (targetRoute && targetRoute !== this.routeName) {
+
+    if (
+      targetRoute &&
+      targetRoute !== this.routeName &&
+      targetRoute !== transition.targetName &&
+      targetRoute !== this.router.currentRouteName
+    ) {
+      if (
+        // only want to redirect if we're going to authenticate
+        targetRoute === AUTH &&
+        transition.targetName !== CLUSTER_INDEX
+      ) {
+        return this.transitionTo(targetRoute, { queryParams: { redirect_to: this.router.currentURL } });
+      }
       return this.transitionTo(targetRoute);
     }
 
     return RSVP.resolve();
   },
 
-  beforeModel() {
-    return this.transitionToTargetRoute();
+  beforeModel(transition) {
+    return this.transitionToTargetRoute(transition);
   },
 
   clusterModel() {

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -22,7 +22,7 @@ export default Route.extend(ModelBoundaryRoute, {
     this.console.set('isOpen', false);
     this.console.clearLog(true);
     this.clearModelCache();
-    this.replaceWith('vault.cluster');
+    this.replaceWith('vault.cluster.auth', { queryParams: { redirect_to: '' } });
     this.flashMessages.clearMessages();
     this.permissions.reset();
   },

--- a/ui/tests/acceptance/redirect-to-test.js
+++ b/ui/tests/acceptance/redirect-to-test.js
@@ -1,0 +1,39 @@
+import { currentURL, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import authPage from 'vault/tests/pages/auth';
+
+module('Acceptance | redirect_to functionality', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('redirect to a route after authentication', async function(assert) {
+    let url = '/vault/secrets/secret/create';
+    await visit(url);
+    assert.equal(
+      currentURL(),
+      `/vault/auth?redirect_to=${encodeURIComponent(url)}&with=token`,
+      'encodes url for the query param'
+    );
+    // the login method on this page does another visit call that we don't want here
+    await authPage.tokenInput('root').submit();
+    assert.equal(currentURL(), url, 'navigates to the redirect_to url after auth');
+  });
+
+  test('redirect from root does not include redirect_to', async function(assert) {
+    let url = '/';
+    await visit(url);
+    assert.equal(currentURL(), `/vault/auth?with=token`, 'there is no redirect_to query param');
+  });
+
+  test('redirect to a route after authentication with a query param', async function(assert) {
+    let url = '/vault/secrets/secret/create?initialKey=hello';
+    await visit(url);
+    assert.equal(
+      currentURL(),
+      `/vault/auth?redirect_to=${encodeURIComponent(url)}&with=token`,
+      'encodes url for the query param'
+    );
+    await authPage.tokenInput('root').submit();
+    assert.equal(currentURL(), url, 'navigates to the redirect_to with the query param after auth');
+  });
+});


### PR DESCRIPTION
Backport of #7088 
* add redirect_to query param

* alias auth controller state to vault controller where the query param is defined

* capture the current url before redirecting a user to auth if they're being redirected

* consume and reset the redirectTo query param when authenticating

* make sure that the current url when logging out does not get set as the redirect_to query param

* add unit tests for the mixin and make it so that redirects from the root don't end up in redirect_to

* acceptance tests for redirect