### PR TITLE
Allow setting file mode on vault agent sink file

### DIFF
--- a/command/agent/sink/file/file_sink_test.go
+++ b/command/agent/sink/file/file_sink_test.go
@@ -80,3 +80,65 @@ func TestFileSink(t *testing.T) {
 		t.Fatalf("expected %s, got %s", uuidStr, string(fileBytes))
 	}
 }
+
+func testFileSinkMode(t *testing.T, log hclog.Logger) (*sink.SinkConfig, string) {
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("%s.", fileServerTestDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(tmpDir, "token")
+
+	config := &sink.SinkConfig{
+		Logger: log.Named("sink.file"),
+		Config: map[string]interface{}{
+			"path": path,
+			"mode": 0644,
+		},
+	}
+
+	s, err := NewFileSink(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Sink = s
+
+	return config, tmpDir
+}
+
+func TestFileSinkMode(t *testing.T) {
+	log := logging.NewVaultLogger(hclog.Trace)
+
+	fs, tmpDir := testFileSinkMode(t, log)
+	defer os.RemoveAll(tmpDir)
+
+	path := filepath.Join(tmpDir, "token")
+
+	uuidStr, _ := uuid.GenerateUUID()
+	if err := fs.WriteToken(uuidStr); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	fi, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode() != os.FileMode(0644) {
+		t.Fatalf("wrong file mode was detected at %s", path)
+	}
+
+	fileBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(fileBytes) != uuidStr {
+		t.Fatalf("expected %s, got %s", uuidStr, string(fileBytes))
+	}
+}

--- a/website/source/docs/agent/autoauth/sinks/file.html.md
+++ b/website/source/docs/agent/autoauth/sinks/file.html.md
@@ -18,8 +18,10 @@ generally it is best for the client to remove the file as soon as it is seen.
 
 It is also best practice to write the file to a ramdisk, ideally an encrypted
 ramdisk, and use appropriate filesystem permissions. The file is currently
-always written with `0640` permissions.
+written with `0640` permissions as default, but can be overridden with the optional
+'mode' setting.
 
 ## Configuration
 
 - `path` `(string: required)` - The path to use to write the token file
+- `mode` `(int: optional)` - A string containing an octal number representing the bit pattern for the file mode, similar to chmod. Set to "0000" to prevent Vault from modifying the file mode


### PR DESCRIPTION
Enable setting the mode on the sink file created by the Vault agent. 