### PR TITLE
Allow globbing dis/allowed_policies in token roles with flag

### DIFF
--- a/sdk/helper/strutil/strutil.go
+++ b/sdk/helper/strutil/strutil.go
@@ -43,6 +43,17 @@ func StrListSubset(super, sub []string) bool {
 	return true
 }
 
+// StrListSubsetGlob checks if a given list is a subset of
+// another set, allowing for globs.
+func StrListSubsetGlob(super, sub []string) bool {
+	for _, item := range sub {
+		if !StrListContainsGlob(super, item) {
+			return false
+		}
+	}
+	return true
+}
+
 // ParseDedupAndSortStrings parses a comma separated list of strings
 // into a slice of strings. The return slice will be sorted and will
 // not contain duplicate or empty items.
@@ -275,6 +286,18 @@ func RemoveEmpty(items []string) []string {
 		itemsSlice = append(itemsSlice, item)
 	}
 	return itemsSlice
+}
+
+// RemoveGlobs removes any elements containing globs from a slice of strings.
+func RemoveGlobs(items []string) []string {
+	ret := make([]string, 0, len(items))
+	for _, item := range items {
+		// glob.GLOB is "*"; ignore items containing that
+		if !strings.Contains(item, glob.GLOB) {
+			ret = append(ret, item)
+		}
+	}
+	return ret
 }
 
 // EquivalentSlices checks whether the given string sets are equivalent, as in,

--- a/sdk/helper/strutil/strutil_test.go
+++ b/sdk/helper/strutil/strutil_test.go
@@ -135,6 +135,43 @@ func TestStrutil_ListSubset(t *testing.T) {
 	}
 }
 
+func TestStrutil_ListSubsetGlob(t *testing.T) {
+	parent := []string{
+		"dev",
+		"ops*",
+		"root/*",
+		"*-dev",
+		"_*_",
+	}
+	if StrListSubsetGlob(parent, []string{"tubez", "dev", "root/admin"}) {
+		t.Fatalf("Bad")
+	}
+	if StrListSubsetGlob(parent, []string{"devops", "ops-dev"}) {
+		t.Fatalf("Bad")
+	}
+	if StrListSubsetGlob(nil, parent) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, []string{"root/test", "dev", "_test_"}) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, []string{"ops_test", "ops", "devops-dev"}) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, []string{"ops"}) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, []string{"test-dev"}) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, []string{"_test_"}) {
+		t.Fatalf("Bad")
+	}
+	if !StrListSubsetGlob(parent, nil) {
+		t.Fatalf("Bad")
+	}
+}
+
 func TestStrutil_ParseKeyValues(t *testing.T) {
 	actual := make(map[string]string)
 	expected := map[string]string{
@@ -460,6 +497,28 @@ func TestStrUtil_RemoveDuplicatesStable(t *testing.T) {
 
 	for _, tc := range tCases {
 		actual := RemoveDuplicatesStable(tc.input, tc.caseInsensitive)
+
+		if !reflect.DeepEqual(actual, tc.expect) {
+			t.Fatalf("Bad testcase %#v, expected %v, got %v", tc, tc.expect, actual)
+		}
+	}
+}
+
+func TestStrUtil_RemoveGlobs(t *testing.T) {
+	type tCase struct {
+		input  []string
+		expect []string
+	}
+
+	tCases := []tCase{
+		tCase{[]string{}, []string{}},
+		tCase{[]string{"hello"}, []string{"hello"}},
+		tCase{[]string{"h*i"}, []string{}},
+		tCase{[]string{"one", "two*", "*three", "f*our", "five"}, []string{"one", "five"}},
+	}
+
+	for _, tc := range tCases {
+		actual := RemoveGlobs(tc.input)
 
 		if !reflect.DeepEqual(actual, tc.expect) {
 			t.Fatalf("Bad testcase %#v, expected %v, got %v", tc, tc.expect, actual)

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -2366,7 +2366,7 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 			if len(finalPolicies) == 0 {
 				finalPolicies = sanitizedRolePolicies
 			} else {
-				if !strutil.StrListSubset(sanitizedRolePolicies, finalPolicies) {
+				if !strutil.StrListSubsetGlob(sanitizedRolePolicies, finalPolicies) {
 					return logical.ErrorResponse(fmt.Sprintf("token policies (%q) must be subset of the role's allowed policies (%q)", finalPolicies, sanitizedRolePolicies)), logical.ErrInvalidRequest
 				}
 			}
@@ -2383,7 +2383,7 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 			sanitizedRolePolicies = strutil.RemoveDuplicates(role.DisallowedPolicies, true)
 
 			for _, finalPolicy := range finalPolicies {
-				if strutil.StrListContains(sanitizedRolePolicies, finalPolicy) {
+				if strutil.StrListContainsGlob(sanitizedRolePolicies, finalPolicy) {
 					return logical.ErrorResponse(fmt.Sprintf("token policy %q is disallowed by this role", finalPolicy)), logical.ErrInvalidRequest
 				}
 			}
@@ -2440,6 +2440,9 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 			return logical.ErrorResponse(fmt.Sprintf("cannot assign policy %q", policy)), nil
 		}
 	}
+
+	// Remove any glob strings from policy list
+	te.Policies = strutil.RemoveGlobs(te.Policies)
 
 	if strutil.StrListContains(te.Policies, "root") {
 		// Prevent attempts to create a root token without an actual root token as parent.
@@ -3324,9 +3327,10 @@ as revocation of tokens. The tokens are renewable if associated with a lease.`
 	tokenAllowedPoliciesHelp = `If set, tokens can be created with any subset of the policies in this
 list, rather than the normal semantics of tokens being a subset of the
 calling token's policies. The parameter is a comma-delimited string of
-policy names.`
+policy names or globs.`
 	tokenDisallowedPoliciesHelp = `If set, successful token creation via this role will require that
-no policies in the given list are requested. The parameter is a comma-delimited string of policy names.`
+no policies in the given list are requested. The parameter is a comma-delimited string of policy names
+or globs.`
 	tokenOrphanHelp = `If true, tokens created via this role
 will be orphan tokens (have no parent)`
 	tokenPeriodHelp = `If set, tokens created via this role

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -3310,7 +3310,7 @@ func TestTokenStore_RoleDisallowedPolicies(t *testing.T) {
 	ts := core.tokenStore
 	ps := core.policyStore
 
-	// Create 3 different policies
+	// Create 4 different policies
 	policy, _ := ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
 	policy.Name = "test1"
 	if err := ps.SetPolicy(namespace.RootContext(nil), policy); err != nil {
@@ -3325,6 +3325,12 @@ func TestTokenStore_RoleDisallowedPolicies(t *testing.T) {
 
 	policy, _ = ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
 	policy.Name = "test3"
+	if err := ps.SetPolicy(namespace.RootContext(nil), policy); err != nil {
+		t.Fatal(err)
+	}
+
+	policy, _ = ParseACLPolicy(namespace.RootNamespace, tokenCreationPolicy)
+	policy.Name = "test3b"
 	if err := ps.SetPolicy(namespace.RootContext(nil), policy); err != nil {
 		t.Fatal(err)
 	}
@@ -3360,10 +3366,20 @@ func TestTokenStore_RoleDisallowedPolicies(t *testing.T) {
 		t.Fatalf("err:%v resp:%v", err, resp)
 	}
 
+	req = logical.TestRequest(t, logical.UpdateOperation, "roles/testnot23")
+	req.ClientToken = root
+	req.Data = map[string]interface{}{
+		"disallowed_policies": "test2,test3*",
+	}
+	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%v", err, resp)
+	}
+
 	// Create a token that has all the policies defined above
 	req = logical.TestRequest(t, logical.UpdateOperation, "create")
 	req.ClientToken = root
-	req.Data["policies"] = []string{"test1", "test2", "test3"}
+	req.Data["policies"] = []string{"test1", "test2", "test3", "test3b"}
 	resp = testMakeTokenViaRequest(t, ts, req)
 	if resp == nil || resp.Auth == nil {
 		t.Fatal("got nil response")
@@ -3394,10 +3410,41 @@ func TestTokenStore_RoleDisallowedPolicies(t *testing.T) {
 		t.Fatalf("expected an error response, got %#v", resp)
 	}
 
+	req = logical.TestRequest(t, logical.UpdateOperation, "create/testnot23")
+	req.ClientToken = parentToken
+	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
+	if err == nil || resp != nil && !resp.IsError() {
+		t.Fatalf("expected an error response, got %#v", resp)
+	}
+
 	// Disallowed should act as a blacklist so make sure we can still make
 	// something with other policies in the request
 	req = logical.TestRequest(t, logical.UpdateOperation, "create/test123")
 	req.Data["policies"] = []string{"foo", "bar"}
+	req.ClientToken = parentToken
+	testMakeTokenViaRequest(t, ts, req)
+
+	// Check to be sure 'test3*' matches 'test3'
+	req = logical.TestRequest(t, logical.UpdateOperation, "create/testnot23")
+	req.Data["policies"] = []string{"test3"}
+	req.ClientToken = parentToken
+	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
+	if err == nil || resp != nil && !resp.IsError() {
+		t.Fatalf("expected an error response, got %#v", resp)
+	}
+
+	// Check to be sure 'test3*' matches 'test3b'
+	req = logical.TestRequest(t, logical.UpdateOperation, "create/testnot23")
+	req.Data["policies"] = []string{"test3b"}
+	req.ClientToken = parentToken
+	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
+	if err == nil || resp != nil && !resp.IsError() {
+		t.Fatalf("expected an error response, got %#v", resp)
+	}
+
+	// Check that non-blacklisted policies still work
+	req = logical.TestRequest(t, logical.UpdateOperation, "create/testnot23")
+	req.Data["policies"] = []string{"test1"}
 	req.ClientToken = parentToken
 	testMakeTokenViaRequest(t, ts, req)
 
@@ -3448,6 +3495,34 @@ func TestTokenStore_RoleAllowedPolicies(t *testing.T) {
 	}
 
 	req.Data["policies"] = []string{"test2"}
+	resp = testMakeTokenViaRequest(t, ts, req)
+	if resp.Auth.ClientToken == "" {
+		t.Fatalf("bad: %#v", resp)
+	}
+
+	// allowed_policies should also support globs
+	req = logical.TestRequest(t, logical.UpdateOperation, "roles/test")
+	req.ClientToken = root
+	req.Data = map[string]interface{}{
+		"allowed_policies": "test*",
+	}
+
+	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err: %v\nresp: %#v", err, resp)
+	}
+	if resp != nil {
+		t.Fatalf("expected a nil response")
+	}
+
+	req.Path = "create/test"
+	req.Data["policies"] = []string{"footest"}
+	resp, err = ts.HandleRequest(namespace.RootContext(nil), req)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	req.Data["policies"] = []string{"testfoo", "test2"}
 	resp = testMakeTokenViaRequest(t, ts, req)
 	if resp.Auth.ClientToken == "" {
 		t.Fatalf("bad: %#v", resp)


### PR DESCRIPTION
Based off the existing work in PR #5815 rebased onto latest master.

This adds globbing support to the allowed_policies and disallowed_policies token role fields. This functionality is opt-in, controlled by the role flag allow_glob_policies, to preserve existing behaviour modelled after allow_glob_domains in the pki secrets engine.