### PR TITLE
Clarify sys/leases/renew behavior with respect to tokens

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -822,7 +822,7 @@ func (m *ExpirationManager) Renew(ctx context.Context, leaseID string, increment
 
 	if le.Secret == nil {
 		if le.Auth != nil {
-			return logical.ErrorResponse("tokens cannot be renewed through this endpoint"), logical.ErrPermissionDenied
+			return logical.ErrorResponse("tokens cannot be renewed through this endpoint"), nil
 		}
 		return logical.ErrorResponse("lease does not correspond to a secret"), nil
 	}

--- a/website/source/api/system/leases.html.md
+++ b/website/source/api/system/leases.html.md
@@ -90,7 +90,8 @@ $ curl \
 
 ## Renew Lease
 
-This endpoint renews a lease, requesting to extend the lease.
+This endpoint renews a lease, requesting to extend the lease.  Token leases 
+cannot be renewed using this endpoint, use instead the auth/token/renew endpoint.
 
 | Method   | Path                          |
 | :---------------------------- | :--------------------- |


### PR DESCRIPTION
Return a useful error message instead of permission denied when someone attempts to renew a token via sys/leases/renew.  Clarify docs.  Fixes #7297.  New output:

```
$ vault write sys/leases/renew lease_id="auth/token/create/$KEY"
Error writing data to sys/leases/renew: Error making API request.

URL: PUT http://localhost:8200/v1/sys/leases/renew
Code: 400. Errors:

* tokens cannot be renewed through this endpoint
```