### PR TITLE
command/server: fix TestLoadConfigFile_json2 test, fix hcl tags

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -208,10 +208,10 @@ type Telemetry struct {
 	// CirconusCheckTags is a comma separated list of tags to apply to the check. Note that
 	// the value of CirconusCheckSearchTag will always be added to the check.
 	// Default: none
-	CirconusCheckTags string `mapstructure:"circonus_check_tags"`
+	CirconusCheckTags string `hcl:"circonus_check_tags"`
 	// CirconusCheckDisplayName is the name for the check which will be displayed in the Circonus UI.
 	// Default: value of CirconusCheckInstanceID
-	CirconusCheckDisplayName string `mapstructure:"circonus_check_display_name"`
+	CirconusCheckDisplayName string `hcl:"circonus_check_display_name"`
 	// CirconusBrokerID is an explicit broker to use when creating a new check. The numeric portion
 	// of broker._cid. If metric management is enabled and neither a Submission URL nor Check ID
 	// is provided, an attempt will be made to search for an existing check using Instance ID and

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -239,7 +239,7 @@ type Telemetry struct {
 	// Prometheus:
 	// PrometheusRetentionTime is the retention time for prometheus metrics if greater than 0.
 	// Default: 24h
-	PrometheusRetentionTime    time.Duration `hcl:-`
+	PrometheusRetentionTime    time.Duration `hcl:"-"`
 	PrometheusRetentionTimeRaw interface{}   `hcl:"prometheus_retention_time"`
 }
 

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -247,7 +247,6 @@ func TestLoadConfigFile_json2(t *testing.T) {
 			Config: map[string]string{
 				"foo": "bar",
 			},
-			DisableClustering: true,
 		},
 
 		HAStorage: &Storage{
@@ -255,15 +254,19 @@ func TestLoadConfigFile_json2(t *testing.T) {
 			Config: map[string]string{
 				"bar": "baz",
 			},
+			DisableClustering: true,
 		},
 
 		CacheSize: 45678,
 
-		EnableUI: true,
+		EnableUI:    true,
+		EnableUIRaw: true,
 
-		EnableRawEndpoint: true,
+		EnableRawEndpoint:    true,
+		EnableRawEndpointRaw: true,
 
-		DisableSealWrap: true,
+		DisableSealWrap:    true,
+		DisableSealWrapRaw: true,
 
 		Telemetry: &Telemetry{
 			StatsiteAddr:                       "foo",
@@ -287,6 +290,7 @@ func TestLoadConfigFile_json2(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(config, expected) {
+		t.Fatalf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config, expected)
 	}
 }
 


### PR DESCRIPTION
Fixes test to call the equality check, and add missing values to the expected object. Fixes hcl tags in the Telemetry structs.