### PR TITLE
Backport 1.2: Fix regression that causes panic when logging in via Radius.

### DIFF
--- a/builtin/credential/radius/path_login.go
+++ b/builtin/credential/radius/path_login.go
@@ -123,11 +123,11 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 	}
 	cfg.PopulateTokenAuth(auth)
 
+	resp.Auth = auth
 	if policies != nil {
 		resp.Auth.Policies = append(resp.Auth.Policies, policies...)
 	}
 
-	resp.Auth = auth
 	return resp, nil
 }
 


### PR DESCRIPTION
Fixes #7286.