### PR TITLE
Remove the had limit to 512 entities

### DIFF
--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -240,10 +240,7 @@ func (i *IdentityStore) handleGroupUpdateCommon(ctx context.Context, req *logica
 		if group.Type == groupTypeExternal {
 			return logical.ErrorResponse("member entities can't be set manually for external groups"), nil
 		}
-		group.MemberEntityIDs = memberEntityIDsRaw.([]string)
-		if len(group.MemberEntityIDs) > 512 {
-			return logical.ErrorResponse("member entity IDs exceeding the limit of 512"), nil
-		}
+		group.MemberEntityIDs = memberEntityIDsRaw.([]string)		
 	}
 
 	memberGroupIDsRaw, ok := d.GetOk("member_group_ids")


### PR DESCRIPTION
* Consul 1.5.3 has configurable value limit for KV storage

* Integrated Raft