### PR TITLE
Backport: Fix identity store 'key not found' response (#7267)

### DIFF
--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -518,7 +518,7 @@ func (i *IdentityStore) pathOIDCReadKey(ctx context.Context, req *logical.Reques
 		return nil, err
 	}
 	if entry == nil {
-		return logical.ErrorResponse("no named key found at %q", name), nil
+		return nil, nil
 	}
 
 	var storedNamedKey namedKey


### PR DESCRIPTION
The existing custom response results in a 400 instead of the typical
404 which confuses the Terraform provider (and is inconsistent).