### PR TITLE
Remove 512 entity limit

### DIFF
--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -241,9 +241,6 @@ func (i *IdentityStore) handleGroupUpdateCommon(ctx context.Context, req *logica
 			return logical.ErrorResponse("member entities can't be set manually for external groups"), nil
 		}
 		group.MemberEntityIDs = memberEntityIDsRaw.([]string)
-		if len(group.MemberEntityIDs) > 512 {
-			return logical.ErrorResponse("member entity IDs exceeding the limit of 512"), nil
-		}
 	}
 
 	memberGroupIDsRaw, ok := d.GetOk("member_group_ids")


### PR DESCRIPTION
* Integrated Raft
* Consul 1.5.3 has configurable value limit for KV storage