### PR TITLE
support setting the API client retry policy

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -174,7 +174,6 @@ func DefaultConfig() *Config {
 	}
 
 	config.Backoff = retryablehttp.LinearJitterBackoff
-	config.CheckRetry = retryablehttp.DefaultRetryPolicy
 	config.MaxRetries = 2
 
 	return config


### PR DESCRIPTION
The existing API client does not expose a way of modifying when a retry will occur; it always uses retryablehttp.DefaultRetryPolicy.  This PR adds support for allowing the client to optionally configure this.

This is needed in my environment as vault sits behind a reverse proxy.  In some cases the proxy returns status codes that I'd like to retry but the DefaultRetryPolicy does not retry them.  Giving users the ability to set the retry policy seems useful outside of this environment too.