### PR TITLE
fix namespace picker so that it always expands into an object when co…

### DIFF
--- a/ui/app/lib/path-to-tree.js
+++ b/ui/app/lib/path-to-tree.js
@@ -45,7 +45,7 @@ export default function(paths) {
   return deepmerge.all(
     tree.map(p => {
       p = p.replace(/\.+/g, DOT_REPLACEMENT);
-      return unflatten({ [p]: null }, { delimiter: '/' });
+      return unflatten({ [p]: null }, { delimiter: '/', object: true });
     })
   );
 }

--- a/ui/app/lib/path-to-tree.js
+++ b/ui/app/lib/path-to-tree.js
@@ -38,6 +38,8 @@ export default function(paths) {
     return accumulator;
   }, []);
 
+
+  tree = tree.sort((a, b)=> a.localeCompare(b));
   // after the reduction we're left with an array that contains
   // strings that represent the longest branches
   // we'll replace the dots in the paths, then expand the path

--- a/ui/app/lib/path-to-tree.js
+++ b/ui/app/lib/path-to-tree.js
@@ -38,8 +38,7 @@ export default function(paths) {
     return accumulator;
   }, []);
 
-
-  tree = tree.sort((a, b)=> a.localeCompare(b));
+  tree = tree.sort((a, b) => a.localeCompare(b));
   // after the reduction we're left with an array that contains
   // strings that represent the longest branches
   // we'll replace the dots in the paths, then expand the path

--- a/ui/tests/unit/lib/path-to-tree-test.js
+++ b/ui/tests/unit/lib/path-to-tree-test.js
@@ -67,6 +67,28 @@ module('Unit | Lib | path to tree', function() {
         },
       },
     ],
+    [
+      'sorting lexicographically',
+      ['99', 'bat', 'bat/bird', 'animal/flying/birds', 'animal/walking/dogs', 'animal/walking/cats', '1/thing'],
+      {
+        1: {
+          thing: null,
+        },
+        99: null,
+        animal:  {
+          flying: {
+            birds:null,
+          },
+          walking: {
+            cats: null,
+            dogs: null,
+          }
+        },
+        bat: {
+          bird: null
+        }
+      },
+    ],
   ];
 
   tests.forEach(function([name, input, expected]) {

--- a/ui/tests/unit/lib/path-to-tree-test.js
+++ b/ui/tests/unit/lib/path-to-tree-test.js
@@ -49,6 +49,24 @@ module('Unit | Lib | path to tree', function() {
         },
       },
     ],
+    [
+      'leaves with nested number and shared prefix',
+      ['ns1', 'ns1a', 'ns1a/99999/five9s', 'ns1a/999/ns3', 'ns1a/9999/ns3'],
+      {
+        ns1: null,
+        ns1a: {
+          999: {
+            ns3: null,
+          },
+          9999: {
+            ns3: null,
+          },
+          99999: {
+            five9s: null,
+          },
+        },
+      },
+    ],
   ];
 
   tests.forEach(function([name, input, expected]) {

--- a/ui/tests/unit/lib/path-to-tree-test.js
+++ b/ui/tests/unit/lib/path-to-tree-test.js
@@ -69,24 +69,32 @@ module('Unit | Lib | path to tree', function() {
     ],
     [
       'sorting lexicographically',
-      ['99', 'bat', 'bat/bird', 'animal/flying/birds', 'animal/walking/dogs', 'animal/walking/cats', '1/thing'],
+      [
+        '99',
+        'bat',
+        'bat/bird',
+        'animal/flying/birds',
+        'animal/walking/dogs',
+        'animal/walking/cats',
+        '1/thing',
+      ],
       {
         1: {
           thing: null,
         },
         99: null,
-        animal:  {
+        animal: {
           flying: {
-            birds:null,
+            birds: null,
           },
           walking: {
             cats: null,
             dogs: null,
-          }
+          },
         },
         bat: {
-          bird: null
-        }
+          bird: null,
+        },
       },
     ],
   ];


### PR DESCRIPTION
…nstructing a tree

Previously, if you had a nested namespace that was a number, it would get expanded by the `unflatten` method from [`flat`](https://github.com/hughsk/flat) as an array, so if you had a namespace named `foo/999999`, foo would be an array with 999999 members. This caused a pretty rough lag in the ui, but also resulted in incorrect links.

The fix was to use `unflatten` with the `object:true` option. I also added a test for this particular case that failed without the code change: 
![Screen Shot 2019-08-19 at 1 13 36 PM](https://user-images.githubusercontent.com/39469/63289130-f9440680-c283-11e9-94be-42848250e2c9.png)

While I was in the area, I also sorted the namespaces which closes https://github.com/hashicorp/vault/issues/7339