### PR TITLE
Ui/dismiss status menu click

### DIFF
--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -93,7 +93,9 @@ export default Service.extend({
       method: opts.method || 'GET',
       headers: opts.headers || {},
     }).then(response => {
-      if (response.status >= 200 && response.status < 300) {
+      if (response.status === 204) {
+        return resolve();
+      } else if (response.status >= 200 && response.status < 300) {
         return resolve(response.json());
       } else {
         return reject();

--- a/ui/app/templates/components/status-menu.hbs
+++ b/ui/app/templates/components/status-menu.hbs
@@ -1,4 +1,4 @@
-{{#basic-dropdown-hover horizontalPosition="auto-left" verticalPosition="below" renderInPlace=media.isMobile as |d|}}
+{{#basic-dropdown horizontalPosition="auto-left" verticalPosition="below" renderInPlace=media.isMobile as |d|}}
   {{#d.trigger tagName=(if (eq type "replication") "span" "button") class=(if (eq type "replication") "" "button is-transparent")}}
     <Icon @glyph={{glyphName}} @size="l" aria-label={{ariaLabel}} />
     <div class="status-menu-label">
@@ -9,4 +9,4 @@
   {{#d.content class=(concat "status-menu-content status-menu-content-" type)}}
     {{partial partialName}}
   {{/d.content}}
-{{/basic-dropdown-hover}}
+{{/basic-dropdown}}


### PR DESCRIPTION
# Dismiss Status Menu on Click
This PR dismisses the Status Menu by clicking outside of the menu instead of when hovering off of it. This new behavior fixes the case where users couldn't revoke a token because the menu would disappear before they had the chance to click on the the 'revoke' button.

![revoke-token](https://user-images.githubusercontent.com/903288/63300587-64460b00-c28d-11e9-8fd1-bc710136865c.gif)
