### PR TITLE
Ui search select fix

### DIFF
--- a/ui/app/components/identity/edit-form.js
+++ b/ui/app/components/identity/edit-form.js
@@ -20,8 +20,7 @@ export default Component.extend({
   onSave: () => {},
 
   cancelLink: computed('mode', 'model.identityType', function() {
-    let { model, mode } = this.getProperties('model', 'mode');
-    let key = `${mode}-${model.get('identityType')}`;
+    let { model, mode } = this;
     let routes = {
       'create-entity': 'vault.cluster.access.identity',
       'edit-entity': 'vault.cluster.access.identity.show',
@@ -33,25 +32,25 @@ export default Component.extend({
       'create-group-alias': 'vault.cluster.access.identity.aliases',
       'edit-group-alias': 'vault.cluster.access.identity.aliases.show',
     };
-
+    let key = model ? `${mode}-${model.identityType}` : 'merge-entity-alias';
     return routes[key];
   }),
 
   getMessage(model, isDelete = false) {
-    let mode = this.get('mode');
-    let typeDisplay = humanize([model.get('identityType')]);
+    let mode = this.mode;
+    let typeDisplay = humanize([model.identityType]);
     let action = isDelete ? 'deleted' : 'saved';
     if (mode === 'merge') {
       return 'Successfully merged entities';
     }
-    if (model.get('id')) {
+    if (model.id) {
       return `Successfully ${action} ${typeDisplay} ${model.id}.`;
     }
     return `Successfully ${action} ${typeDisplay}.`;
   },
 
   save: task(function*() {
-    let model = this.get('model');
+    let model = this.model;
     let message = this.getMessage(model);
 
     try {
@@ -67,7 +66,8 @@ export default Component.extend({
     .withTestWaiter(),
 
   willDestroy() {
-    let model = this.get('model');
+    let model = this.model;
+    if (!model) return;
     if ((model.get('isDirty') && !model.isDestroyed) || !model.isDestroying) {
       model.rollbackAttributes();
     }

--- a/ui/app/components/search-select.js
+++ b/ui/app/components/search-select.js
@@ -129,7 +129,7 @@ export default Component.extend({
       return `Add new ${singularize(this.label)}: ${id}`;
     },
     hideCreateOptionOnSameID(id) {
-      let existingOption = this.options.findBy('id', id) || this.options.findBy('name', id);
+      let existingOption = this.options && (this.options.findBy('id', id) || this.options.findBy('name', id));
       return !existingOption;
     },
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -101,7 +101,7 @@
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-maybe-in-element": "^0.4.0",
-    "ember-power-select-with-create": "cibernox/ember-power-select-with-create#6203918f247c1c5d692db4f9185ab8321d2125e1",
+    "ember-power-select-with-create": "^0.6.2",
     "ember-qunit": "^4.4.1",
     "ember-radio-button": "^2.0.1",
     "ember-resolver": "^5.0.1",

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -173,6 +173,18 @@ module('Integration | Component | search select', function(hooks) {
     assert.equal(component.options.objectAt(0).text, 'Type to search', 'text of option shows Type to search');
   });
 
+  test('it shows add suggestion if there are no options', async function(assert) {
+    const models = [];
+    this.set('models', models);
+    this.set('onChange', sinon.spy());
+    await render(
+      hbs`{{search-select label="foo" inputValue=inputValue models=models fallbackComponent="string-list" onChange=onChange}}`
+    );
+    await clickTrigger();
+
+    await typeInSearch('new item');
+    assert.equal(component.options.objectAt(0).text, 'Add new foo: new item', 'shows the create suggestion');
+  });
   test('it shows items not in the returned response', async function(assert) {
     const models = ['test'];
     this.set('models', models);

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7321,12 +7321,13 @@ ember-native-dom-helpers@^0.5.3:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
 
-ember-power-select-with-create@cibernox/ember-power-select-with-create#6203918f247c1c5d692db4f9185ab8321d2125e1:
-  version "0.6.1"
-  resolved "https://codeload.github.com/cibernox/ember-power-select-with-create/tar.gz/6203918f247c1c5d692db4f9185ab8321d2125e1"
+ember-power-select-with-create@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/ember-power-select-with-create/-/ember-power-select-with-create-0.6.2.tgz#05faf361c435f5c2c61c24e687aebddefd569897"
+  integrity sha512-8OKUJWpLTImP+N+SkUqTYJByaZ7XDhePdhjqZtcimc6O1eEAdEGkh8itOLMLw95+X51Wua1DwfdoRycu+iqqQQ==
   dependencies:
-    ember-cli-babel "^6.6.0"
-    ember-cli-htmlbars "^2.0.1"
+    ember-cli-babel "^7.1.2"
+    ember-cli-htmlbars "^3.0.0"
     ember-power-select "^2.0.0"
 
 ember-power-select@^2.0.0:


### PR DESCRIPTION
There was a regression where if there were no options, the error would get swallowed in a try/catch and we wouldn't show the add option.

Returning early when there are no `options` avoids the error.

This also updates `ember-power-select-with-create` to the latest release, and fixes some errors I encountered when clicking the `Cancel` link on the identity edit form.