### PR TITLE
ci install ui deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
     - run:
         command: |
           cd ui
-          yarn install --ignore-optional
+          yarn install
           npm rebuild node-sass
         name: Install UI dependencies
     - save_cache:
@@ -468,7 +468,7 @@ workflows:
 #     - run:
 #         command: |
 #           cd ui
-#           yarn install --ignore-optional
+#           yarn install
 #           npm rebuild node-sass
 #         name: Install UI dependencies
 #     - save_yarn_cache

--- a/.circleci/config/jobs/install-ui-dependencies.yml
+++ b/.circleci/config/jobs/install-ui-dependencies.yml
@@ -6,6 +6,6 @@ steps:
       name: Install UI dependencies
       command: |
         cd ui
-        yarn install --ignore-optional
+        yarn install
         npm rebuild node-sass
   - save_yarn_cache


### PR DESCRIPTION
We don't need to `--ignore-optional` when installing deps.