### PR TITLE
plugging file descriptor leak in couchdb backend

### DIFF
--- a/physical/couchdb/couchdb.go
+++ b/physical/couchdb/couchdb.go
@@ -86,7 +86,7 @@ func (m *couchDBClient) put(e couchDBEntry) error {
 		return err
 	}
 	req.SetBasicAuth(m.username, m.password)
-  resp, err := m.Client.Do(req)
+	resp, err := m.Client.Do(req)
 	if err == nil {
 		resp.Body.Close()
 	}

--- a/physical/couchdb/couchdb.go
+++ b/physical/couchdb/couchdb.go
@@ -86,7 +86,10 @@ func (m *couchDBClient) put(e couchDBEntry) error {
 		return err
 	}
 	req.SetBasicAuth(m.username, m.password)
-	_, err = m.Client.Do(req)
+	resp, err = m.Client.Do(req)
+	if err == nil {
+		resp.Body.Close()
+	}
 
 	return err
 }

--- a/physical/couchdb/couchdb.go
+++ b/physical/couchdb/couchdb.go
@@ -86,7 +86,7 @@ func (m *couchDBClient) put(e couchDBEntry) error {
 		return err
 	}
 	req.SetBasicAuth(m.username, m.password)
-	resp, err = m.Client.Do(req)
+  resp, err := m.Client.Do(req)
 	if err == nil {
 		resp.Body.Close()
 	}


### PR DESCRIPTION
I've noticed that the couchdb storage backend is leaking file descriptors, which causes the vault process to run out of available file descriptors and hang. This PR should fix it.