### PR TITLE
Describe API calls made by the CF client

### DIFF
--- a/website/source/docs/auth/pcf.html.md
+++ b/website/source/docs/auth/pcf.html.md
@@ -188,6 +188,14 @@ $ cf org-users my-example-org
 $ cf set-org-role vault my-example-org OrgManager
 ```
 
+Specifically, the `vault` user created here will need to be able to perform the following API calls:
+
+- Method: "GET", endpoint: "/v2/info"
+- Method: "POST", endpoint: "/oauth/token"
+- Method: "GET", endpoint: "/v2/apps/$APP_ID"
+- Method: "GET", endpoint: "/v2/organizations/$ORG_ID"
+- Method: "GET", endpoint: "/v2/spaces/$SPACE_ID"
+
 Next, PCF often uses a self-signed certificate for TLS, which can be rejected at first 
 with an error like:
 


### PR DESCRIPTION
This PR explains what specific API calls are made by the Cloud Foundry client in the PCF auth method to enable users to tune permissions to their minimum levels.