### PR TITLE
Backport 1.2.3: fix namespace picker expansion and sorting

### DIFF
--- a/ui/app/lib/path-to-tree.js
+++ b/ui/app/lib/path-to-tree.js
@@ -38,6 +38,7 @@ export default function(paths) {
     return accumulator;
   }, []);
 
+  tree = tree.sort((a, b) => a.localeCompare(b));
   // after the reduction we're left with an array that contains
   // strings that represent the longest branches
   // we'll replace the dots in the paths, then expand the path
@@ -45,7 +46,7 @@ export default function(paths) {
   return deepmerge.all(
     tree.map(p => {
       p = p.replace(/\.+/g, DOT_REPLACEMENT);
-      return unflatten({ [p]: null }, { delimiter: '/' });
+      return unflatten({ [p]: null }, { delimiter: '/', object: true });
     })
   );
 }

--- a/ui/tests/unit/lib/path-to-tree-test.js
+++ b/ui/tests/unit/lib/path-to-tree-test.js
@@ -49,6 +49,54 @@ module('Unit | Lib | path to tree', function() {
         },
       },
     ],
+    [
+      'leaves with nested number and shared prefix',
+      ['ns1', 'ns1a', 'ns1a/99999/five9s', 'ns1a/999/ns3', 'ns1a/9999/ns3'],
+      {
+        ns1: null,
+        ns1a: {
+          999: {
+            ns3: null,
+          },
+          9999: {
+            ns3: null,
+          },
+          99999: {
+            five9s: null,
+          },
+        },
+      },
+    ],
+    [
+      'sorting lexicographically',
+      [
+        '99',
+        'bat',
+        'bat/bird',
+        'animal/flying/birds',
+        'animal/walking/dogs',
+        'animal/walking/cats',
+        '1/thing',
+      ],
+      {
+        1: {
+          thing: null,
+        },
+        99: null,
+        animal: {
+          flying: {
+            birds: null,
+          },
+          walking: {
+            cats: null,
+            dogs: null,
+          },
+        },
+        bat: {
+          bird: null,
+        },
+      },
+    ],
   ];
 
   tests.forEach(function([name, input, expected]) {


### PR DESCRIPTION
Backport of #7333

* fix namespace picker so that it always expands into an object when constructing a tree

* sort namespaces lexicographically

* fix linting