### PR TITLE
Ui/fix component story generators

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -15,6 +15,8 @@
     - [Storybook Commands at a Glance](#storybook-commands-at-a-glance)
     - [Writing Stories](#writing-stories)
       - [Adding a new story](#adding-a-new-story)
+    - [Code Generators](#code-generators-1)
+  - [Further Reading / Useful Links](#further-reading--useful-links)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -30,12 +32,10 @@ You will need the following things properly installed on your computer.
 - [Yarn](https://yarnpkg.com/en/)
 - [Git](https://git-scm.com/)
 - [Ember CLI](https://ember-cli.com/)
-- [Husky\*](https://github.com/typicode/husky)
 - [lint-staged\*](https://www.npmjs.com/package/lint-staged)
 
-\* Husky and lint-staged are optional dependencies - running `yarn` will install them.
-If don't want them installed (husky adds files for every hooks in `.git/hooks/`),
-then you can run `yarn --ignore-optional`. If you've ignored the optional deps
+\* lint-staged is an optional dependency - running `yarn` will install it.
+If don't want optional dependencies installed you can run `yarn --ignore-optional`. If you've ignored the optional deps
 previously and want to install them, you have to tell yarn to refetch all deps by
 running `yarn --force`.
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -143,10 +143,10 @@ Each component in `vault/ui/app/components` should have a corresponding `[compon
  *   {{/if}}
  * ```
  *
- * @param toggleAttr=null {String} - The attribute upon which to toggle.
- * @param attrTarget=null {Object} - The target upon which the event handler should be added.
- * @param [openLabel=Hide options] {String} - The message to display when the toggle is open. //optional params are denoted by square brackets
- * @param [closedLabel=More options] {String} - The message to display when the toggle is closed.
+ * @param {String} toggleAttr=null - The attribute upon which to toggle.
+ * @param {Object} attrTarget=null - The target upon which the event handler should be added.
+ * @param {String} [openLabel=Hide options] - The message to display when the toggle is open. //optional params are denoted by square brackets
+ * @param {String} [closedLabel=More options] - The message to display when the toggle is closed.
  */
 ````
 Note that placing a param inside brackets (e.g. `[closedLabel=More options]` indicates it is optional and has a default value of `'More options'`.)

--- a/ui/blueprints/component/files/__root__/__path__/__name__.js
+++ b/ui/blueprints/component/files/__root__/__path__/__name__.js
@@ -1,16 +1,17 @@
 /**
  * @module <%= classifiedModuleName %>
  * <%= classifiedModuleName %> components are used to...
- * 
+ *
  * @example
  * ```js
- * <<%= classifiedModuleName %> @param1={param1} @param2={param2} />
+ * <<%= classifiedModuleName %> @requiredParam={requiredParam} @optionalParam={optionalParam} @param1={{param1}}/>
  * ```
- *
- * @param param1 {String} - param1 is...
- * @param [param2=value] {String} - param2 is... //brackets mean it is optional and = sets the default value
+ * @param {object} requiredParam - requiredParam is...
+ * @param {string} [optionalParam] - optionalParam is...
+ * @param {string} [param1=defaultValue] - param1 is...
  */
-import Component from '@ember/component';
+
+ import Component from '@ember/component';
 <%= importTemplate %>
 export default Component.extend({<%= contents %>
 });

--- a/ui/blueprints/component/index.js
+++ b/ui/blueprints/component/index.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const stringUtil = require('ember-cli-string-utils');
 const pathUtil = require('ember-cli-path-utils');
-const validComponentName = require('ember-cli-valid-component-name');
 const getPathOption = require('ember-cli-get-component-path-option');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
 
@@ -50,9 +49,7 @@ module.exports = {
   },
 
   normalizeEntityName: function(entityName) {
-    entityName = normalizeEntityName(entityName);
-
-    return validComponentName(entityName);
+    return normalizeEntityName(entityName);
   },
 
   locals: function(options) {

--- a/ui/blueprints/component/index.js
+++ b/ui/blueprints/component/index.js
@@ -7,7 +7,7 @@ const getPathOption = require('ember-cli-get-component-path-option');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
 
 module.exports = {
-  description: 'Generates a component. Name must contain a hyphen.',
+  description: 'Generates a component.',
 
   availableOptions: [
     {

--- a/ui/lib/story-md.hbs
+++ b/ui/lib/story-md.hbs
@@ -8,6 +8,7 @@
 
 {{>description~}}
 
+**Params**
 {{>params~}}
 
 {{>properties~}}


### PR DESCRIPTION
This PR includes a couple small bug fixes and improvements to our component and story file generators:

- Removes `ember-cli-valid-component-name`, which we no longer need as pointed out in [this issue](https://github.com/ember-cli/ember-cli/issues/8144). This resolves a bug where we couldn't run `ember generate component`
- Adds a table header to the Params table inside the Storybook notes.md template
- Updates the JSDoc and Storybook examples
- Removes Husky from the README since we no longer use it
