### PR TITLE
Bump vault-plugin-auth-kubernetes with fixes for projected token support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ FEATURES:
    documentation](https://www.vaultproject.io/docs/config/index.html) for
    details. [GH-6957]
 
-
 ## 1.2.3 (Unreleased)
 
 IMPROVEMENTS:
@@ -25,6 +24,7 @@ BUG FIXES:
  * ui: Fix a regression that prevented input of custom items in search-select [GH-7338]
  * ui: Fix an issue with the namespace picker being unable to render nested
    namespaces named with numbers and sorting of namespaces in the picker [GH-7333]
+ * auth plugin for Kubernetes: enable better support for projected tokens API by allowing user to specify issuer ([GH-65](https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/65))
 
 ## 1.2.2 (August 15, 2019)
 

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-cf v0.0.0-20190821162840-1c2205826fee
 	github.com/hashicorp/vault-plugin-auth-gcp v0.5.2-0.20190814210049-1ccb3dc10102
 	github.com/hashicorp/vault-plugin-auth-jwt v0.5.2-0.20190814210057-5e4c92d2b835
-	github.com/hashicorp/vault-plugin-auth-kubernetes v0.5.2-0.20190814210103-f64f0cb4d8cf
+	github.com/hashicorp/vault-plugin-auth-kubernetes v0.5.2-0.20190826163451-8461c66275a9
 	github.com/hashicorp/vault-plugin-database-elasticsearch v0.0.0-20190814210117-e079e01fbb93
 	github.com/hashicorp/vault-plugin-secrets-ad v0.5.3-0.20190814210122-0f2fd536b250
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.5.2-0.20190814210129-4d18bec92f56

--- a/go.sum
+++ b/go.sum
@@ -338,6 +338,8 @@ github.com/hashicorp/vault-plugin-auth-jwt v0.5.2-0.20190814210057-5e4c92d2b835 
 github.com/hashicorp/vault-plugin-auth-jwt v0.5.2-0.20190814210057-5e4c92d2b835/go.mod h1:Ti2NPndKhSGpSL6gWg11n7TkmuI7318BIPeojayIVRU=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.5.2-0.20190814210103-f64f0cb4d8cf h1:JnBSA5CnZps9JEX9RJZAdJ5tUVogWMIvVvatNmzGe38=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.5.2-0.20190814210103-f64f0cb4d8cf/go.mod h1:qkrONCr71ckSCTItJQ1j9uet/faieZJ5c7+GZugTm7s=
+github.com/hashicorp/vault-plugin-auth-kubernetes v0.5.2-0.20190826163451-8461c66275a9 h1:PjbIf3mlPBJopQSJstQAhVbdGTVZ/W35RZtm/GCOTUs=
+github.com/hashicorp/vault-plugin-auth-kubernetes v0.5.2-0.20190826163451-8461c66275a9/go.mod h1:qkrONCr71ckSCTItJQ1j9uet/faieZJ5c7+GZugTm7s=
 github.com/hashicorp/vault-plugin-database-elasticsearch v0.0.0-20190814210117-e079e01fbb93 h1:kXTV1ImOPgDGZxAlbEQfiXgnZY/34vfgnZVhI/tscmg=
 github.com/hashicorp/vault-plugin-database-elasticsearch v0.0.0-20190814210117-e079e01fbb93/go.mod h1:N9XpfMXjeLHBgUd8iy4avOC4mCSqUC7B/R8AtCYhcfE=
 github.com/hashicorp/vault-plugin-secrets-ad v0.5.3-0.20190814210122-0f2fd536b250 h1:+mm2cM5msg/USImbvnMS2yzCMBYMCO3CrvsATWGtHtY=

--- a/vendor/github.com/hashicorp/vault-plugin-auth-kubernetes/path_login.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-kubernetes/path_login.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	// expectedJWTIssuer is used to verify the iss header on the JWT.
-	expectedJWTIssuer = "kubernetes/serviceaccount"
+	// defaultJWTIssuer is used to verify the iss header on the JWT if the config doesn't specify an issuer.
+	defaultJWTIssuer = "kubernetes/serviceaccount"
 
 	uidJWTClaimKey = "kubernetes.io/serviceaccount/service-account.uid"
 
@@ -179,10 +179,8 @@ func (b *kubeAuthBackend) parseAndValidateJWT(jwtStr string, role *roleStorageEn
 	}
 
 	sa := &serviceAccount{}
+
 	validator := &jwt.Validator{
-		Expected: jwt.Claims{
-			"iss": expectedJWTIssuer,
-		},
 		Fn: func(c jwt.Claims) error {
 			// Decode claims into a service account object
 			err := mapstructure.Decode(c, sa)
@@ -206,6 +204,18 @@ func (b *kubeAuthBackend) parseAndValidateJWT(jwtStr string, role *roleStorageEn
 
 			return nil
 		},
+	}
+
+	// set the expected issuer to the default kubernetes issuer if the config doesn't specify it
+	if config.Issuer != "" {
+		validator.SetIssuer(config.Issuer)
+	} else {
+		validator.SetIssuer(defaultJWTIssuer)
+	}
+
+	// validate the audience if the role expects it
+	if role.Audience != "" {
+		validator.SetAudience(role.Audience)
 	}
 
 	if err := validator.Validate(parsedJWT); err != nil {
@@ -289,7 +299,7 @@ type serviceAccount struct {
 	UID        string   `mapstructure:"kubernetes.io/serviceaccount/service-account.uid"`
 	SecretName string   `mapstructure:"kubernetes.io/serviceaccount/secret.name"`
 	Namespace  string   `mapstructure:"kubernetes.io/serviceaccount/namespace"`
-	Aud        []string `mapstructure:"aud"`
+	Audience   []string `mapstructure:"aud"`
 
 	// the JSON returned from reviewing a Projected Service account has a
 	// different structure, where the information is in a sub-structure instead of

--- a/vendor/github.com/hashicorp/vault/sdk/helper/salt/salt.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/salt/salt.go
@@ -135,8 +135,8 @@ func (s *Salt) GetIdentifiedHMAC(data string) string {
 	return s.config.HMACType + ":" + s.GetHMAC(data)
 }
 
-// DidGenerate returns if the underlying salt value was generated
-// on initialization or if an existing salt value was loaded
+// DidGenerate returns true if the underlying salt value was generated
+// on initialization.
 func (s *Salt) DidGenerate() bool {
 	return s.generated
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -350,7 +350,7 @@ github.com/hashicorp/vault-plugin-auth-gcp/plugin
 github.com/hashicorp/vault-plugin-auth-gcp/plugin/cache
 # github.com/hashicorp/vault-plugin-auth-jwt v0.5.2-0.20190814210057-5e4c92d2b835
 github.com/hashicorp/vault-plugin-auth-jwt
-# github.com/hashicorp/vault-plugin-auth-kubernetes v0.5.2-0.20190814210103-f64f0cb4d8cf
+# github.com/hashicorp/vault-plugin-auth-kubernetes v0.5.2-0.20190826163451-8461c66275a9
 github.com/hashicorp/vault-plugin-auth-kubernetes
 # github.com/hashicorp/vault-plugin-database-elasticsearch v0.0.0-20190814210117-e079e01fbb93
 github.com/hashicorp/vault-plugin-database-elasticsearch


### PR DESCRIPTION
Bumps the auth plugin for Kubernetes and updates the changelog to reflect new features from https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/70. 