### PR TITLE
fix "disable auth method" button

### DIFF
--- a/ui/app/models/auth-method.js
+++ b/ui/app/models/auth-method.js
@@ -96,7 +96,7 @@ let Model = DS.Model.extend({
 });
 
 export default attachCapabilities(Model, {
-  deltePath: apiPath`sys/auth/${'id'}`,
+  deletePath: apiPath`sys/auth/${'id'}`,
   configPath: function(context) {
     if (context.type === 'aws') {
       return apiPath`auth/${'id'}/config/client`;


### PR DESCRIPTION
This typo was preventing us from showing disable buttons for the auth methods. `deltePath` !== `deletePath`.