### PR TITLE
UI CI exit 1 if there's an error

### DIFF
--- a/ui/app/templates/components/identity/popup-alias.hbs
+++ b/ui/app/templates/components/identity/popup-alias.hbs
@@ -26,7 +26,9 @@
               <li class="action">
                 <c.Message
                   @id={{item.id}}
-                  @onConfirm={{action "performTransaction" item}} />
+                  @onConfirm={{action "performTransaction" item}}
+                  data-test-item-delete
+                  />
               </li>
             {{/if}}
           {{/if}}

--- a/ui/lib/core/addon/templates/components/confirm/message.hbs
+++ b/ui/lib/core/addon/templates/components/confirm/message.hbs
@@ -35,6 +35,8 @@
   class="link is-destroy"
   disabled={{showConfirm}}
   onclick={{action this.onTrigger id}}
-  data-test-confirm-action-trigger={{id}}>
+  data-test-confirm-action-trigger={{id}}
+  ...attributes
+  >
   {{triggerText}}
 </button>

--- a/ui/scripts/start-vault.js
+++ b/ui/scripts/start-vault.js
@@ -95,6 +95,8 @@ async function processLines(input, eachLine = () => {}) {
     } catch (error) {
       console.log(error);
       process.exit(1);
+    } finally {
+      process.exit(0);
     }
   } catch (error) {
     console.log(error);

--- a/ui/scripts/start-vault.js
+++ b/ui/scripts/start-vault.js
@@ -94,11 +94,10 @@ async function processLines(input, eachLine = () => {}) {
       }
     } catch (error) {
       console.log(error);
-    } finally {
-      process.exit(0);
+      process.exit(1);
     }
   } catch (error) {
     console.log(error);
-    process.exit(0);
+    process.exit(1);
   }
 })();

--- a/ui/tests/acceptance/aws-test.js
+++ b/ui/tests/acceptance/aws-test.js
@@ -83,7 +83,7 @@ module('Acceptance | aws secret backend', function(hooks) {
 
     //and delete
     await click(`[data-test-secret-link="${roleName}"] [data-test-popup-menu-trigger]`);
-    await click(`[data-test-aws-role-delete="${roleName}"] button`);
+    await click(`[data-test-aws-role-delete="${roleName}"]`);
 
     await click(`[data-test-confirm-button]`);
     await settled();

--- a/ui/tests/acceptance/ssh-test.js
+++ b/ui/tests/acceptance/ssh-test.js
@@ -124,7 +124,7 @@ module('Acceptance | ssh secret backend', function(hooks) {
 
       //and delete
       await click(`[data-test-secret-link="${role.name}"] [data-test-popup-menu-trigger]`);
-      await click(`[data-test-ssh-role-delete="${role.name}"] button`);
+      await click(`[data-test-ssh-role-delete="${role.name}"]`);
       await click(`[data-test-confirm-button]`);
 
       await settled();

--- a/ui/tests/pages/access/identity/aliases/index.js
+++ b/ui/tests/pages/access/identity/aliases/index.js
@@ -8,8 +8,7 @@ export default create({
     menu: clickable('[data-test-popup-menu-trigger]'),
     name: text('[data-test-identity-link]'),
   }),
-  delete: clickable('[data-test-confirm-action-trigger]', {
-    scope: '[data-test-item-delete]',
+  delete: clickable('[data-test-item-delete]', {
     testContainer: '#ember-testing',
   }),
   confirmDelete: clickable('[data-test-confirm-button]'),

--- a/ui/tests/pages/access/identity/index.js
+++ b/ui/tests/pages/access/identity/index.js
@@ -9,8 +9,7 @@ export default create({
     name: text('[data-test-identity-link]'),
   }),
 
-  delete: clickable('[data-test-confirm-action-trigger]', {
-    scope: '[data-test-item-delete]',
+  delete: clickable('[data-test-item-delete]', {
     testContainer: '#ember-testing',
   }),
   confirmDelete: clickable('[data-test-confirm-button]'),


### PR DESCRIPTION
In the UI script runner, we were catching all errors and exiting with a 0 so CI builds were not reporting correctly. This should correct that.