### PR TITLE
Remove vaulted as supported nodejs client

### DIFF
--- a/website/source/api/libraries.html.md
+++ b/website/source/api/libraries.html.md
@@ -112,12 +112,6 @@ $ stack install gothic
 $ npm install node-vault
 ```
 
-* [vaulted](https://github.com/chiefy/vaulted)
-
-```shell
-$ npm install vaulted
-```
-
 ### PHP
 
 * [vault-php-sdk](https://github.com/jippi/vault-php-sdk)


### PR DESCRIPTION
Vaulted is no longer maintained according to the readme. 

https://github.com/chiefy/vaulted#vaulted 

"No Longer Being Maintained Use node-vault for future support of Vault features!"