### PR TITLE
ci: make ci-config atomically updates .circleci/config.yml

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -60,10 +60,14 @@ define GENERATED_FILE_HEADER
 endef
 export GENERATED_FILE_HEADER
 
+# GEN_CONFIG writes the config to a temporary file. If the whole process succeeds,
+# it then moves that file to $@. This makes is an atomic operation, so if it fails
+# make doesn't consider a half-baked file up to date.
 define GEN_CONFIG
 	@$(CIRCLECI) config pack $(SOURCE_DIR) > $(CONFIG_PACKED)
-	@echo "$$GENERATED_FILE_HEADER" > $@
-	@$(CIRCLECI) config process $(CONFIG_PACKED) >> $@
+	@echo "$$GENERATED_FILE_HEADER" > $@.tmp || { rm -f $@; exit 1; }
+	@$(CIRCLECI) config process $(CONFIG_PACKED) >> $@.tmp || { rm -f $@.tmp; exit 1; }
+	@mv -f $@.tmp $@
 endef
 
 $(OUT): $(CONFIG_SOURCE) 


### PR DESCRIPTION
- Previously, `.circleci/config.yml` could be updated erroneously when problems
  occurred during `config pack` or `config process`.
