### PR TITLE
Backport 1.2.x: http/raft: fix JoinRequest.LeaderCACert json tag

### DIFF
--- a/http/sys_raft.go
+++ b/http/sys_raft.go
@@ -57,7 +57,7 @@ type JoinResponse struct {
 
 type JoinRequest struct {
 	LeaderAPIAddr    string `json:"leader_api_addr"`
-	LeaderCACert     string `json:"leader_ca_cert":`
+	LeaderCACert     string `json:"leader_ca_cert"`
 	LeaderClientCert string `json:"leader_client_cert"`
 	LeaderClientKey  string `json:"leader_client_key"`
 	Retry            bool   `json:"retry"`


### PR DESCRIPTION
Backport of #7393 