### PR TITLE
logical/aws: Clean up test user

### DIFF
--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -917,8 +917,7 @@ func TestBackend_FederationTokenWithPolicyARN(t *testing.T) {
 			testAccStepRead(t, "creds", "test", []credentialTestFunc{listDynamoTablesTest, describeAzsTestUnauthorized}),
 		},
 		Teardown: func() error {
-			//return deleteTestUser(accessKey, userName)
-			return nil
+			return deleteTestUser(accessKey, userName)
 		},
 	})
 }


### PR DESCRIPTION
I probably left this cleanup commented out as part of debugging test
errors in #6789 and forgot to uncomment it, so actually cleaning up the
test user.