### PR TITLE
Fixed wrong API method in API docs for identity token generation

### DIFF
--- a/website/source/api/secret/identity/tokens.html.md
+++ b/website/source/api/secret/identity/tokens.html.md
@@ -359,7 +359,7 @@ Use this endpoint to generate a signed ID (OIDC) token.
 
 | Method   | Path                |
 | :------------------ | :----------------------|
-| `POST`   | `identity/oidc/token/:name`  |
+| `GET`   | `identity/oidc/token/:name`  |
 
 ### Parameters
 


### PR DESCRIPTION
Fixes #7457
