### PR TITLE
use api.Config.Timeout instead of http.Client.Timeout 

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -140,8 +140,8 @@ func DefaultConfig() *Config {
 	config := &Config{
 		Address:    "https://127.0.0.1:8200",
 		HttpClient: cleanhttp.DefaultPooledClient(),
+		Timeout:    time.Second * 60,
 	}
-	config.HttpClient.Timeout = time.Second * 60
 
 	transport := config.HttpClient.Transport.(*http.Transport)
 	transport.TLSHandshakeTimeout = 10 * time.Second


### PR DESCRIPTION
Currently, if a user specifies a `VAULT_CLIENT_TIMEOUT` value of greater than 60s in a CLI command, the request always will time out in 60s.

This PR fixes that behavior by change the default value for `VAULT_CLIENT_TIMEOUT` to 60s, and setting the CLI command's `http.Client.Timeout` value to its default of 0.

This causes the command timeout to always be driven solely by the `VAULT_CLIENT_TIMEOUT` value.