### PR TITLE
http: add handleLogicalNoForward handler for local-only requests

### DIFF
--- a/http/logical.go
+++ b/http/logical.go
@@ -150,9 +150,9 @@ func handleLogical(core *vault.Core) http.Handler {
 	return handleLogicalInternal(core, false, false)
 }
 
-// handleLogicalNoForward returns a handler for processing logical requests that
-// also have their logical response data injected at the top-level payload. All
-// forwarding behavior remains the same as `handleLogical`.
+// handleLogicalWithInjector returns a handler for processing logical requests
+// that also have their logical response data injected at the top-level payload.
+// All forwarding behavior remains the same as `handleLogical`.
 func handleLogicalWithInjector(core *vault.Core) http.Handler {
 	return handleLogicalInternal(core, true, false)
 }

--- a/http/logical.go
+++ b/http/logical.go
@@ -312,7 +312,9 @@ func handleLogicalInternal(core *vault.Core, injectDataIntoTopLevel bool, noForw
 			forwardRequest(core, w, r)
 			return
 		case !ok:
-			// If not ok, we simply return. The
+			// If not ok, we simply return. The call on request should have
+			// taken care of setting the appropriate response code and payload
+			// in this case.
 			return
 		default:
 			// Build and return the proper response if everything is fine.

--- a/http/logical.go
+++ b/http/logical.go
@@ -164,6 +164,9 @@ func handleLogicalNoForward(core *vault.Core) http.Handler {
 	return handleLogicalInternal(core, false, true)
 }
 
+// handleLogicalInternal is a common helper that returns a handler for
+// processing logical requests. The behavior depends on the various boolean
+// toggles. Refer to usage on functions for possible behaviors.
 func handleLogicalInternal(core *vault.Core, injectDataIntoTopLevel bool, noForward bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req, origBody, statusCode, err := buildLogicalRequest(core, w, r)

--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -37,7 +37,8 @@ const (
 )
 
 var (
-	ErrCannotForward = errors.New("cannot forward request; no connection or address not known")
+	ErrCannotForward          = errors.New("cannot forward request; no connection or address not known")
+	ErrCannotForwardLocalOnly = errors.New("cannot forward local-only request")
 )
 
 type ClusterLeaderParams struct {


### PR DESCRIPTION
Adds a handler that deals with requests that we should not forward to avoid adding special-casing logic inside `handleLogicalInternal`, for instance the new `sys/host-info` endpoint. 