### PR TITLE
docs: fixed sample json payload parse error

### DIFF
--- a/website/source/api/secret/identity/tokens.html.md
+++ b/website/source/api/secret/identity/tokens.html.md
@@ -100,7 +100,7 @@ This endpoint creates or updates a named key which is used by a role to sign tok
 ```json
 {
   "rotation_period":"12h",
-  "verification_ttl":43200,
+  "verification_ttl":43200
 }
 ```
 


### PR DESCRIPTION
Fixed malformed json example (removed extra comma). Here's the payload parse error I was running into with the example.

```
{
  "rotation_period":"12h",
  "verification_ttl":43200,
}
```

Vault does not like this JSON.

```
curl -s \
    --header "X-Vault-Token: ..." \
    --request POST \
    --data @payload-2.json \
    http://127.0.0.1:8200/v1/identity/oidc/key/named-key-001 | jq
{
  "errors": [
    "failed to parse JSON input: invalid character '}' looking for beginning of object key string"
  ]
}
```