### PR TITLE
expose 'storage_type' on the sys/seal-status endpoint

### DIFF
--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -77,6 +77,7 @@ type SealStatusResponse struct {
 	ClusterName  string `json:"cluster_name,omitempty"`
 	ClusterID    string `json:"cluster_id,omitempty"`
 	RecoverySeal bool   `json:"recovery_seal"`
+	StorageType  string `json:"storage_type,omitempty"`
 }
 
 type UnsealOpts struct {

--- a/command/server.go
+++ b/command/server.go
@@ -664,6 +664,7 @@ func (c *ServerCommand) Run(args []string) int {
 	coreConfig := &vault.CoreConfig{
 		Physical:                  backend,
 		RedirectAddr:              config.Storage.RedirectAddr,
+		StorageType:               config.Storage.Type,
 		HAPhysical:                nil,
 		Seal:                      barrierSeal,
 		AuditBackends:             c.AuditBackends,

--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -198,6 +198,7 @@ func handleSysSealStatusRaw(core *vault.Core, w http.ResponseWriter, r *http.Req
 			Initialized:  false,
 			Sealed:       true,
 			RecoverySeal: core.SealAccess().RecoveryKeySupported(),
+			StorageType: core.StorageType(),
 		})
 		return
 	}
@@ -233,6 +234,7 @@ func handleSysSealStatusRaw(core *vault.Core, w http.ResponseWriter, r *http.Req
 		ClusterName:  clusterName,
 		ClusterID:    clusterID,
 		RecoverySeal: core.SealAccess().RecoveryKeySupported(),
+		StorageType: core.StorageType(),
 	})
 }
 
@@ -249,6 +251,7 @@ type SealStatusResponse struct {
 	ClusterName  string `json:"cluster_name,omitempty"`
 	ClusterID    string `json:"cluster_id,omitempty"`
 	RecoverySeal bool   `json:"recovery_seal"`
+	StorageType  string `json:"storage_type,omitempty"`
 }
 
 // Note: because we didn't provide explicit tagging in the past we can't do it

--- a/vault/core.go
+++ b/vault/core.go
@@ -172,6 +172,7 @@ type Core struct {
 	// HABackend may be available depending on the physical backend
 	ha physical.HABackend
 
+  // storageType is the the storage type set in the storage configuration
 	storageType string
 
 	// redirectAddr is the address we advertise as leader if held
@@ -1826,6 +1827,7 @@ func (c *Core) SealAccess() *SealAccess {
 	return NewSealAccess(c.seal)
 }
 
+// StorageType returns a string equal to the storage configuration's type.
 func (c *Core) StorageType() string {
 	return c.storageType
 }

--- a/vault/core.go
+++ b/vault/core.go
@@ -172,6 +172,8 @@ type Core struct {
 	// HABackend may be available depending on the physical backend
 	ha physical.HABackend
 
+	storageType string
+
 	// redirectAddr is the address we advertise as leader if held
 	redirectAddr string
 
@@ -474,6 +476,8 @@ type CoreConfig struct {
 
 	Physical physical.Backend `json:"physical" structs:"physical" mapstructure:"physical"`
 
+	StorageType string `json:"storage_type" structs:"storage_type" mapstructure:"storage_type"`
+
 	// May be nil, which disables HA operations
 	HAPhysical physical.HABackend `json:"ha_physical" structs:"ha_physical" mapstructure:"ha_physical"`
 
@@ -546,6 +550,7 @@ func (c *CoreConfig) Clone() *CoreConfig {
 		DisableCache:              c.DisableCache,
 		DisableMlock:              c.DisableMlock,
 		CacheSize:                 c.CacheSize,
+		StorageType:               c.StorageType,
 		RedirectAddr:              c.RedirectAddr,
 		ClusterAddr:               c.ClusterAddr,
 		DefaultLeaseTTL:           c.DefaultLeaseTTL,
@@ -613,6 +618,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		devToken:                     conf.DevToken,
 		physical:                     conf.Physical,
 		underlyingPhysical:           conf.Physical,
+		storageType:                  conf.StorageType,
 		redirectAddr:                 conf.RedirectAddr,
 		clusterAddr:                  new(atomic.Value),
 		clusterListener:              new(atomic.Value),
@@ -1818,6 +1824,10 @@ func (c *Core) ActiveNodeReplicationState() consts.ReplicationState {
 
 func (c *Core) SealAccess() *SealAccess {
 	return NewSealAccess(c.seal)
+}
+
+func (c *Core) StorageType() string {
+	return c.storageType
 }
 
 func (c *Core) Logger() log.Logger {

--- a/vault/core.go
+++ b/vault/core.go
@@ -172,7 +172,7 @@ type Core struct {
 	// HABackend may be available depending on the physical backend
 	ha physical.HABackend
 
-  // storageType is the the storage type set in the storage configuration
+	// storageType is the the storage type set in the storage configuration
 	storageType string
 
 	// redirectAddr is the address we advertise as leader if held


### PR DESCRIPTION
This is so the UI can present you the option to join an existing raft cluster when you're initializing and so it can show the raft storage item in the status menu.

Let me know if you think this isn't the right place for this or if it's done entirely wrong 😬. 

Thanks!