### PR TITLE
Fix token_store_test.go

### DIFF
--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -849,6 +849,9 @@ func TestTokenStore_HandleRequest_RevokeAccessor(t *testing.T) {
 	ts := exp.tokenStore
 
 	rootToken, err := ts.rootToken(namespace.RootContext(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
 	root := rootToken.ID
 
 	testMakeServiceTokenViaBackend(t, ts, root, "tokenid", "", []string{"foo"})
@@ -2117,6 +2120,9 @@ func TestTokenStore_HandleRequest_Revoke(t *testing.T) {
 	ts := exp.tokenStore
 
 	rootToken, err := ts.rootToken(namespace.RootContext(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
 	root := rootToken.ID
 
 	testMakeServiceTokenViaBackend(t, ts, root, "child", "", []string{"root", "foo"})
@@ -2657,6 +2663,9 @@ func TestTokenStore_HandleRequest_CreateToken_ExistingEntityAlias(t *testing.T) 
 			"mount_accessor": tokenMountAccessor,
 		},
 	})
+	if err != nil {
+		t.Fatalf("error handling request: %v", err)
+	}
 
 	// Create token role
 	resp, err = core.HandleRequest(ctx, &logical.Request{


### PR DESCRIPTION
There are currently two problems with error handling in `token_store_test.go`.

First, there are some dropped error variables. This PR corrects them.

Additionally, `testing.T` is used inside a goroutine, which doesn't work.

`T.Fatal()` is a convenience function that combines `T.Log()` and `T.FailNow()`. 

From the godoc of `T.FailNow()`: 

> FailNow must be called from the goroutine running the test or benchmark function, not from other goroutines created during the test. Calling FailNow does not stop those other goroutines.

To see this in action, take a look at `main_test.go` in my [example repo](https://github.com/alrs/fatalfail/).
