### PR TITLE
Get rid of unused parameter from agent configuration

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -192,7 +192,7 @@ func (c *AgentCommand) Run(args []string) int {
 	}
 
 	// Load the configuration
-	config, err := config.LoadConfig(c.flagConfigs[0], c.logger)
+	config, err := config.LoadConfig(c.flagConfigs[0])
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error loading configuration from %s: %s", c.flagConfigs[0], err))
 		return 1

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
-	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
@@ -77,7 +76,7 @@ type Sink struct {
 
 // LoadConfig loads the configuration at the given path, regardless if
 // its a file or directory.
-func LoadConfig(path string, logger log.Logger) (*Config, error) {
+func LoadConfig(path string) (*Config, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return nil, err

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -6,14 +6,10 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 )
 
 func TestLoadConfigFile_AgentCache(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Debug)
-
-	config, err := LoadConfig("./test-fixtures/config-cache.hcl", logger)
+	config, err := LoadConfig("./test-fixtures/config-cache.hcl")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +81,7 @@ func TestLoadConfigFile_AgentCache(t *testing.T) {
 		t.Fatal(diff)
 	}
 
-	config, err = LoadConfig("./test-fixtures/config-cache-embedded-type.hcl", logger)
+	config, err = LoadConfig("./test-fixtures/config-cache-embedded-type.hcl")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,12 +93,10 @@ func TestLoadConfigFile_AgentCache(t *testing.T) {
 }
 
 func TestLoadConfigFile(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Debug)
-
 	os.Setenv("TEST_AAD_ENV", "aad")
 	defer os.Unsetenv("TEST_AAD_ENV")
 
-	config, err := LoadConfig("./test-fixtures/config.hcl", logger)
+	config, err := LoadConfig("./test-fixtures/config.hcl")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -146,7 +140,7 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Fatal(diff)
 	}
 
-	config, err = LoadConfig("./test-fixtures/config-embedded-type.hcl", logger)
+	config, err = LoadConfig("./test-fixtures/config-embedded-type.hcl")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -157,9 +151,7 @@ func TestLoadConfigFile(t *testing.T) {
 }
 
 func TestLoadConfigFile_Method_Wrapping(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Debug)
-
-	config, err := LoadConfig("./test-fixtures/config-method-wrapping.hcl", logger)
+	config, err := LoadConfig("./test-fixtures/config-method-wrapping.hcl")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -192,9 +184,7 @@ func TestLoadConfigFile_Method_Wrapping(t *testing.T) {
 }
 
 func TestLoadConfigFile_AgentCache_NoAutoAuth(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Debug)
-
-	config, err := LoadConfig("./test-fixtures/config-cache-no-auto_auth.hcl", logger)
+	config, err := LoadConfig("./test-fixtures/config-cache-no-auto_auth.hcl")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -219,54 +209,42 @@ func TestLoadConfigFile_AgentCache_NoAutoAuth(t *testing.T) {
 }
 
 func TestLoadConfigFile_Bad_AgentCache_InconsisentAutoAuth(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Debug)
-
-	_, err := LoadConfig("./test-fixtures/bad-config-cache-inconsistent-auto_auth.hcl", logger)
+	_, err := LoadConfig("./test-fixtures/bad-config-cache-inconsistent-auto_auth.hcl")
 	if err == nil {
 		t.Fatal("LoadConfig should return an error when use_auto_auth_token=true and no auto_auth section present")
 	}
 }
 
 func TestLoadConfigFile_Bad_AgentCache_NoListeners(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Debug)
-
-	_, err := LoadConfig("./test-fixtures/bad-config-cache-no-listeners.hcl", logger)
+	_, err := LoadConfig("./test-fixtures/bad-config-cache-no-listeners.hcl")
 	if err == nil {
 		t.Fatal("LoadConfig should return an error when cache section present and no listeners present")
 	}
 }
 
 func TestLoadConfigFile_Bad_AutoAuth_Wrapped_Multiple_Sinks(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Debug)
-
-	_, err := LoadConfig("./test-fixtures/bad-config-auto_auth-wrapped-multiple-sinks", logger)
+	_, err := LoadConfig("./test-fixtures/bad-config-auto_auth-wrapped-multiple-sinks")
 	if err == nil {
 		t.Fatal("LoadConfig should return an error when auth_auth.method.wrap_ttl nonzero and multiple sinks defined")
 	}
 }
 
 func TestLoadConfigFile_Bad_AutoAuth_Both_Wrapping_Types(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Debug)
-
-	_, err := LoadConfig("./test-fixtures/bad-config-method-wrapping-and-sink-wrapping.hcl", logger)
+	_, err := LoadConfig("./test-fixtures/bad-config-method-wrapping-and-sink-wrapping.hcl")
 	if err == nil {
 		t.Fatal("LoadConfig should return an error when auth_auth.method.wrap_ttl nonzero and sinks.wrap_ttl nonzero")
 	}
 }
 
 func TestLoadConfigFile_Bad_AgentCache_AutoAuth_Method_wrapping(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Debug)
-
-	_, err := LoadConfig("./test-fixtures/bad-config-cache-auto_auth-method-wrapping.hcl", logger)
+	_, err := LoadConfig("./test-fixtures/bad-config-cache-auto_auth-method-wrapping.hcl")
 	if err == nil {
 		t.Fatal("LoadConfig should return an error when auth_auth.method.wrap_ttl nonzero and cache.use_auto_auth_token=true")
 	}
 }
 
 func TestLoadConfigFile_AgentCache_AutoAuth_NoSink(t *testing.T) {
-	logger := logging.NewVaultLogger(log.Debug)
-
-	config, err := LoadConfig("./test-fixtures/config-cache-auto_auth-no-sink.hcl", logger)
+	config, err := LoadConfig("./test-fixtures/config-cache-auto_auth-no-sink.hcl")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
I noticed that [this](https://github.com/hashicorp/vault/blob/master/command/agent/config/config.go#L80) function has two parameters: the path to the configuration file, and a logger. However, it would appear that the logger is not used at all, so I got rid of it.