### PR TITLE
Add README and doc.go to the command/agent directory

### DIFF
--- a/command/agent/README.md
+++ b/command/agent/README.md
@@ -1,0 +1,11 @@
+# Vault Agent
+
+Vault Agent is a client daemon that provides Auth-Auth, Caching, and Template
+features. 
+
+Vault Agent provides a number of different helper features, specifically
+addressing the following challenges:
+
+- Automatic authentication
+- Secure delivery/storage of tokens
+- Lifecycle management of these tokens (renewal & re-authentication)

--- a/command/agent/README.md
+++ b/command/agent/README.md
@@ -9,3 +9,7 @@ addressing the following challenges:
 - Automatic authentication
 - Secure delivery/storage of tokens
 - Lifecycle management of these tokens (renewal & re-authentication)
+
+See the usage documentation on the Vault website here:
+
+- https://www.vaultproject.io/docs/agent/

--- a/command/agent/doc.go
+++ b/command/agent/doc.go
@@ -1,0 +1,8 @@
+/*
+Package agent implements a daemon mode of Vault designed to provide helper
+features like auto-auth, caching, and templating.
+
+Agent has it's own configuration stanza and operates as a proxy to a Vault
+service.
+*/
+package agent


### PR DESCRIPTION
Adds a `README.md` and a `docs.go` file to `command/agent`. Vault Agent is it's own thing enough that I think it useful to have more documentation on it's purpose. 

That said, I'm not sure what else to add here 🤔 