### PR TITLE
Backport: Ignore any existing token during CLI login (#7508)

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -215,6 +215,12 @@ func (c *LoginCommand) Run(args []string) int {
 		return 2
 	}
 
+	// Evolving token formats across Vault versions have caused issues during CLI logins. Unless
+	// token auth is being used, omit any token picked up from TokenHelper.
+	if authMethod != "token" {
+		client.SetToken("")
+	}
+
 	// Authenticate delegation to the auth handler
 	secret, err := authHandler.Auth(client, config)
 	if err != nil {

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -58,6 +58,9 @@ func TestLoginCommand_Run(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// Emulate an unknown token format present in ~/.vault-token, for example
+		client.SetToken("a.a")
+
 		code := cmd.Run([]string{
 			"-method", "userpass",
 			"-path", "my-auth",


### PR DESCRIPTION
Fixes #6694