### PR TITLE
Change "Generate Intermediate" example to exported

### DIFF
--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -523,7 +523,7 @@ $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
-    http://127.0.0.1:8200/v1/pki/intermediate/generate/internal
+    http://127.0.0.1:8200/v1/pki/intermediate/generate/exported
 ```
 
 ```json


### PR DESCRIPTION
The example request for "Generate Intermediate" was type "internal", but the example response contained the private key, which "internal" doesn't do. This patch fixes the example request to be type "exported" to match the example response.