### PR TITLE
Add TLS server name to config

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -250,7 +250,7 @@ func (c *AgentCommand) Run(args []string) int {
 			Default: false,
 			EnvVar:  api.EnvVaultSkipVerify,
 		})
-		c.setStringFlag(f, config.Vault.TLSSkipVerify, &StringVar{
+		c.setStringFlag(f, config.Vault.TLSServerName, &StringVar{
 			Name:    flagTLSServerName,
 			Target:  &c.flagTLSServerName,
 			Default: "",

--- a/command/agent.go
+++ b/command/agent.go
@@ -250,6 +250,12 @@ func (c *AgentCommand) Run(args []string) int {
 			Default: false,
 			EnvVar:  api.EnvVaultSkipVerify,
 		})
+		c.setStringFlag(f, config.Vault.TLSSkipVerify, &StringVar{
+			Name:    flagTLSServerName,
+			Target:  &c.flagTLSServerName,
+			Default: "",
+			EnvVar:  api.EnvVaultTLSServerName,
+		})
 	}
 
 	infoKeys := make([]string, 0, 10)

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -34,6 +34,7 @@ type Vault struct {
 	TLSSkipVerifyRaw interface{} `hcl:"tls_skip_verify"`
 	ClientCert       string      `hcl:"client_cert"`
 	ClientKey        string      `hcl:"client_key"`
+	TLSServerName    string      `hcl:"tls_server_name"`
 }
 
 type Cache struct {

--- a/command/base.go
+++ b/command/base.go
@@ -296,7 +296,7 @@ func (c *BaseCommand) flagSet(bit FlagSetBit) *FlagSets {
 			})
 
 			f.StringVar(&StringVar{
-				Name:       "tls-server-name",
+				Name:       flagTLSServerName,
 				Target:     &c.flagTLSServerName,
 				Default:    "",
 				EnvVar:     api.EnvVaultTLSServerName,

--- a/command/commands.go
+++ b/command/commands.go
@@ -88,6 +88,9 @@ const (
 	// flagNameTLSSkipVerify is the flag used in the base command to read in
 	// the option to ignore TLS certificate verification.
 	flagNameTLSSkipVerify = "tls-skip-verify"
+	// flagTLSServerName is the flag used in the base command to read in
+	// the TLS server name.
+	flagTLSServerName = "tls-server-name"
 	// flagNameAuditNonHMACRequestKeys is the flag name used for auth/secrets enable
 	flagNameAuditNonHMACRequestKeys = "audit-non-hmac-request-keys"
 	// flagNameAuditNonHMACResponseKeys is the flag name used for auth/secrets enable

--- a/website/source/docs/agent/index.html.md
+++ b/website/source/docs/agent/index.html.md
@@ -85,6 +85,10 @@ configuration entries:
   security of data transmissions to and from the Vault server. This value can
   be overridden by setting the `VAULT_SKIP_VERIFY` environment variable.
 
+- `tls_server_name (string: optional)` - Name to use as the SNI host when
+  connecting via TLS. This value can be overridden by setting the
+  `VAULT_TLS_SERVER_NAME` environment variable.
+
 ## Example Configuration
 
 An example configuration, with very contrived values, follows:


### PR DESCRIPTION
This PR allows users to set the TLS server name to the `vault` stanza of the Agent configuration.