### PR TITLE
Backport: Fix Agent handling of gzipped responses (#7470)

### DIFF
--- a/command/agent/cache/api_proxy.go
+++ b/command/agent/cache/api_proxy.go
@@ -36,6 +36,11 @@ func (ap *APIProxy) Send(ctx context.Context, req *SendRequest) (*SendResponse, 
 		return nil, err
 	}
 	client.SetToken(req.Token)
+
+	// http.Transport will transparently request gzip and decompress the response, but only if
+	// the client doesn't manually set the header. Removing any Accept-Encoding header allows the
+	// transparent compression to occur.
+	req.Request.Header.Del("Accept-Encoding")
 	client.SetHeaders(req.Request.Header)
 
 	fwReq := client.NewRequest(req.Request.Method, req.Request.URL.Path)


### PR DESCRIPTION
* Fix Agent handling of gzipped responses

Fixes #6606
