### PR TITLE
#7485 Add check for empty filename

### DIFF
--- a/helper/pgpkeys/flag.go
+++ b/helper/pgpkeys/flag.go
@@ -76,6 +76,10 @@ func ParsePGPKeys(keyfiles []string) ([]string, error) {
 	for i, keyfile := range keyfiles {
 		keyfile = strings.TrimSpace(keyfile)
 
+		if len(keyfile) <= 0 {
+			return nil, fmt.Errorf("empty filename with index %v, can't open it", i)
+		}
+
 		if strings.HasPrefix(keyfile, kbPrefix) {
 			key, ok := keybaseMap[keyfile]
 			if !ok || key == "" {

--- a/helper/pgpkeys/flag_test.go
+++ b/helper/pgpkeys/flag_test.go
@@ -157,6 +157,18 @@ func TestPubKeyFilesFlagSetKeybase(t *testing.T) {
 	}
 }
 
+func TestEmptyFileNameList(t *testing.T) {
+	emptyFileNames := []string{""}
+	_, e := ParsePGPKeys(emptyFileNames)
+	if e == nil {
+		t.Error("Error is nil")
+		return
+	}
+	if e.Error() != "empty filename with index 0, can't open it" {
+		t.Error("An error message doesn't match")
+	}
+}
+
 const pubKey1 = `mQENBFXbjPUBCADjNjCUQwfxKL+RR2GA6pv/1K+zJZ8UWIF9S0lk7cVIEfJiprzzwiMwBS5cD0da
 rGin1FHvIWOZxujA7oW0O2TUuatqI3aAYDTfRYurh6iKLC+VS+F7H+/mhfFvKmgr0Y5kDCF1j0T/
 063QZ84IRGucR/X43IY7kAtmxGXH0dYOCzOe5UBX1fTn3mXGe2ImCDWBH7gOViynXmb6XNvXkP0f


### PR DESCRIPTION
This is a fix for #7485. Add check for string emptiness and tests.