### PR TITLE
Add response_types_supported to OIDC configuration

### DIFF
--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -78,10 +78,11 @@ type idToken struct {
 //
 // https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
 type discovery struct {
-	Issuer      string   `json:"issuer"`
-	Keys        string   `json:"jwks_uri"`
-	Subjects    []string `json:"subject_types_supported"`
-	IDTokenAlgs []string `json:"id_token_signing_alg_values_supported"`
+	Issuer        string   `json:"issuer"`
+	Keys          string   `json:"jwks_uri"`
+	ResponseTypes []string `json:"response_types_supported"`
+	Subjects      []string `json:"subject_types_supported"`
+	IDTokenAlgs   []string `json:"id_token_signing_alg_values_supported"`
 }
 
 // oidcCache is a thin wrapper around go-cache to partition by namespace
@@ -202,7 +203,7 @@ func oidcPaths(i *IdentityStore) []*framework.Path {
 				logical.ReadOperation: i.pathOIDCDiscovery,
 			},
 			HelpSynopsis:    "Query OIDC configurations",
-			HelpDescription: "Query this path to retrieve the configured OIDC Issuer and Keys endpoints, Subjects, and signing algorithms used by the OIDC backend.",
+			HelpDescription: "Query this path to retrieve the configured OIDC Issuer and Keys endpoints, response types, subject types, and signing algorithms used by the OIDC backend.",
 		},
 		{
 			Pattern: "oidc/.well-known/keys/?$",
@@ -1002,10 +1003,11 @@ func (i *IdentityStore) pathOIDCDiscovery(ctx context.Context, req *logical.Requ
 		}
 
 		disc := discovery{
-			Issuer:      c.effectiveIssuer,
-			Keys:        c.effectiveIssuer + "/.well-known/keys",
-			Subjects:    []string{"public"},
-			IDTokenAlgs: supportedAlgs,
+			Issuer:        c.effectiveIssuer,
+			Keys:          c.effectiveIssuer + "/.well-known/keys",
+			ResponseTypes: []string{"id_token"},
+			Subjects:      []string{"public"},
+			IDTokenAlgs:   supportedAlgs,
 		}
 
 		data, err = json.Marshal(disc)


### PR DESCRIPTION
The AWS IAM OIDC consumer requires the field to exist, and won't accept Vault as an identity provider without it. The value of 'null' that will be produced by adding this empty field to the structure is acceptable, but the key must exist in the structure.

I wasn't able to find anything in the IAM documentation about what fields are required. Instead, I figured this out through trial and error.

## Reproducing the Problem

Set up an unsealed Vault 1.2.3 server on a public Internet-accessible address with a valid TLS configuration. Beyond unsealing, no additional Vault server configuration is required.

Visit the IAM console in your AWS account, choose "Identity Providers" and then click "Create Provider". Choose "OpenID Connect" for "Provider Type", then put your publicly accessible Vault server's OpenID configuration URL in the "Provider URL" box, eg:

    https://vault.example.com/v1/identity/oidc/.well-known/openid-configuration

In the "Audience" field, you can put any string of alphanumeric characters, it doesn't need to be a valid value or correspond to anything in your Vault configuration.

When you click the "Next Step" button, you will receive this confusing and unhelpful error:

    We encountered the following errors while processing your request:
    Please check .well-known/openid-configuration of provider: 
    https://vault.example.com/v1/identity/oidc/.well-known/openid-configuration is valid.

You will be unable to continue through the web wizard at this point. Directly calling the API will allow you to set up the provider, but when you attempt to use the sts:AssumeRoleWithWebIdentity API call with a correctly configured IAM role, you will receive this error:

    Couldn't retrieve verification key from your identity provider,  please reference AssumeRoleWithWebIdentity documentation for requirements

Unfortunately there's no listing I can find of exactly what the requirements are other than that the configuration must be "valid".

## Solving the problem

Applying this patch will add a field `response_types_supported` to the structure that is marshalled to JSON in response to the openid-configuration request. The value of the field will be `null` but that is acceptable to the AWS IAM OIDC consumer. (You can also simulate this by using a reverse proxy service in front of Vault to intercept the openid-configuration request and returning the structure with  `"response_types_supported": null` injected.

Then if you go through the "Create Provider" process again, you will get past the error message and get to a confirmation screen. You can then follow instructions in the IAM documentation for creating roles that may be assumed using OIDC ID tokens generated by  Vault. I've confirmed that assuming a role using the sts:AssumeRoleWithWebIdentity API call and a Vault OIDC ID token is in fact possible using the updated configuration generated by this patch.