### PR TITLE
pgp list fix

### DIFF
--- a/ui/app/components/pgp-file.js
+++ b/ui/app/components/pgp-file.js
@@ -4,6 +4,7 @@ import { task } from 'ember-concurrency';
 const BASE_64_REGEX = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/gi;
 
 export default Component.extend({
+  'data-test-pgp-file': true,
   classNames: ['box', 'is-fullwidth', 'is-marginless', 'is-shadowless'],
   key: null,
   index: null,

--- a/ui/app/components/pgp-list.js
+++ b/ui/app/components/pgp-list.js
@@ -3,6 +3,51 @@ import Component from '@ember/component';
 
 export default Component.extend({
   onDataUpdate: () => {},
+  listLength: 0,
+  listData: null,
+
+  init() {
+    this._super(...arguments);
+    let num = this.listLength;
+    if (num) {
+      num = parseInt(num, 10);
+    }
+    let list = this.newList(num);
+    this.set('listData', list);
+  },
+
+  didReceiveAttrs() {
+    this._super(...arguments);
+    let list;
+    if (!this.listLength) {
+      this.set('listData', []);
+      return;
+    }
+    // no update needed
+    if (this.listData.length === this.listLength) {
+      return;
+    }
+    // shorten the current list
+    if (this.listLength < this.listData.length) {
+      list = this.listData.slice(0, this.listLength);
+    }
+    // add to the current list by creating a new list and copying over existing list
+    if (this.listLength > this.listData.length) {
+      list = this.newList(this.listLength);
+      if (this.listData.length) {
+        list.splice(0, this.listData.length, ...this.listData);
+      }
+    }
+    this.set('listData', list || this.listData);
+    this.onDataUpdate((list || this.listData).compact().map(k => k.value));
+  },
+
+  newList(length) {
+    return Array(length || 0)
+      .fill(null)
+      .map(() => ({ value: '' }));
+  },
+
   listData: computed('listLength', function() {
     let num = this.get('listLength');
     if (num) {
@@ -12,12 +57,12 @@ export default Component.extend({
       .fill(null)
       .map(() => ({ value: '' }));
   }),
-  listLength: 0,
+
   actions: {
     setKey(index, key) {
-      let listData = this.get('listData');
-      listData.replace(index, 1, key);
-      this.get('onDataUpdate')(listData.compact().map(k => k.value));
+      let { listData } = this;
+      listData.splice(index, 1, key);
+      this.onDataUpdate(listData.compact().map(k => k.value));
     },
   },
 });

--- a/ui/app/components/pgp-list.js
+++ b/ui/app/components/pgp-list.js
@@ -26,12 +26,11 @@ export default Component.extend({
     if (this.listData.length === this.listLength) {
       return;
     }
-    // shorten the current list
     if (this.listLength < this.listData.length) {
+      // shorten the current list
       list = this.listData.slice(0, this.listLength);
-    }
-    // add to the current list by creating a new list and copying over existing list
-    if (this.listLength > this.listData.length) {
+    } else if (this.listLength > this.listData.length) {
+      // add to the current list by creating a new list and copying over existing list
       list = this.newList(this.listLength);
       if (this.listData.length) {
         list.splice(0, this.listData.length, ...this.listData);

--- a/ui/app/components/pgp-list.js
+++ b/ui/app/components/pgp-list.js
@@ -1,4 +1,3 @@
-import { computed } from '@ember/object';
 import Component from '@ember/component';
 
 export default Component.extend({
@@ -47,16 +46,6 @@ export default Component.extend({
       .fill(null)
       .map(() => ({ value: '' }));
   },
-
-  listData: computed('listLength', function() {
-    let num = this.get('listLength');
-    if (num) {
-      num = parseInt(num, 10);
-    }
-    return Array(num || 0)
-      .fill(null)
-      .map(() => ({ value: '' }));
-  }),
 
   actions: {
     setKey(index, key) {

--- a/ui/app/templates/components/pgp-file.hbs
+++ b/ui/app/templates/components/pgp-file.hbs
@@ -1,4 +1,4 @@
-<div class="level is-mobile" data-test-pgp-file>
+<div class="level is-mobile">
   <div class="level-left">
     <label class="is-label" data-test-pgp-label>
       {{#if label}}

--- a/ui/app/templates/components/pgp-file.hbs
+++ b/ui/app/templates/components/pgp-file.hbs
@@ -1,4 +1,4 @@
-<div class="level is-mobile">
+<div class="level is-mobile" data-test-pgp-file>
   <div class="level-left">
     <label class="is-label" data-test-pgp-label>
       {{#if label}}

--- a/ui/app/templates/components/pgp-list.hbs
+++ b/ui/app/templates/components/pgp-list.hbs
@@ -1,7 +1,7 @@
 {{#each listData as |key index|}}
   {{pgp-file key=key index=index onChange=(action 'setKey')}}
 {{else}}
-  <p class="has-text-grey">
+  <p class="has-text-grey" data-test-empty-text>
     Enter a number of Key Shares to enter PGP keys.
   </p>
 {{/each}}

--- a/ui/tests/integration/components/pgp-list-test.js
+++ b/ui/tests/integration/components/pgp-list-test.js
@@ -119,8 +119,7 @@ module('Integration | Component | pgp list', function(hooks) {
       'calls onchange with an array 2 base64 converted files'
     );
 
-    // this will trim off the last input which was filled, so we should only have one file in the array
-    // now
+    // this will add a couple of inputs but should keep the existing 3
     this.set('listLength', 5);
     let expected3 = [btoa(data), '', btoa(data), '', ''];
     assert.deepEqual(

--- a/ui/tests/integration/components/pgp-list-test.js
+++ b/ui/tests/integration/components/pgp-list-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { settled, render, click, fillIn, findAll, find, triggerEvent, waitUntil } from '@ember/test-helpers';
+import { render, triggerEvent, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 

--- a/ui/tests/integration/components/pgp-list-test.js
+++ b/ui/tests/integration/components/pgp-list-test.js
@@ -1,0 +1,132 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { settled, render, click, fillIn, findAll, find, triggerEvent, waitUntil } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+let file;
+const data = JSON.stringify({ some: 'content' }, null, 2);
+const fileEvent = () => {
+  file = new Blob([data], { type: 'application/json' });
+  file.name = 'file.json';
+  return ['change', { files: [file] }];
+};
+
+module('Integration | Component | pgp list', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('listLength', 0);
+    await render(hbs`<PgpList @listLength={{listLength}} />`);
+    assert.dom('[data-test-empty-text]').exists('shows the empty state');
+    this.set('listLength', 1);
+    assert
+      .dom('[data-test-pgp-file]')
+      .exists({ count: 1 }, 'renders pgp-file one component when length is updated');
+    this.set('listLength', 2);
+    assert
+      .dom('[data-test-pgp-file]')
+      .exists({ count: 2 }, 'renders multiple pgp-file components when length is updated');
+  });
+
+  test('onDataUpdate is called properly', async function(assert) {
+    this.set('spy', sinon.spy());
+    let event = fileEvent();
+
+    await render(hbs`<PgpList @listLength={{1}} @onDataUpdate={{this.spy}} />`);
+    triggerEvent('[data-test-pgp-file-input]', ...event);
+
+    // FileReader is async, but then we need extra run loop wait to re-render
+    await waitUntil(() => {
+      return !!this.spy.calledOnce;
+    });
+    let expected = [btoa(data)];
+    assert.deepEqual(
+      this.spy.getCall(0).args[0],
+      expected,
+      'calls onchange with an array of base64 converted files'
+    );
+  });
+
+  test('sparse filling of multiple files, then shortening', async function(assert) {
+    this.set('spy', sinon.spy());
+    this.set('listLength', 3);
+
+    await render(hbs`<PgpList @listLength={{this.listLength}} @onDataUpdate={{this.spy}} />`);
+
+    // add a file to the first input
+    triggerEvent('[data-test-pgp-file]:nth-child(1) [data-test-pgp-file-input]', ...fileEvent());
+    await waitUntil(() => {
+      return !!this.spy.calledOnce;
+    });
+    let expected = [btoa(data), '', ''];
+    assert.deepEqual(
+      this.spy.getCall(0).args[0],
+      expected,
+      'calls onchange with an array of base64 converted files'
+    );
+
+    // add a file to the third input
+    triggerEvent('[data-test-pgp-file]:nth-child(3) [data-test-pgp-file-input]', ...fileEvent());
+    await waitUntil(() => {
+      return !!this.spy.calledTwice;
+    });
+    let expected2 = [btoa(data), '', btoa(data)];
+    assert.deepEqual(
+      this.spy.getCall(1).args[0],
+      expected2,
+      'calls onchange with an array 2 base64 converted files'
+    );
+
+    // this will trim off the last input which was filled, so we should only have one file in the array
+    // now
+    this.set('listLength', 2);
+    let expected3 = [btoa(data), ''];
+    assert.deepEqual(
+      this.spy.getCall(2).args[0],
+      expected3,
+      'shortens the list with an array with one base64 converted files'
+    );
+  });
+
+  test('sparse filling of multiple files, then lengthening', async function(assert) {
+    this.set('spy', sinon.spy());
+    this.set('listLength', 3);
+
+    await render(hbs`<PgpList @listLength={{this.listLength}} @onDataUpdate={{this.spy}} />`);
+
+    // add a file to the first input
+    triggerEvent('[data-test-pgp-file]:nth-child(1) [data-test-pgp-file-input]', ...fileEvent());
+    await waitUntil(() => {
+      return !!this.spy.calledOnce;
+    });
+    let expected = [btoa(data), '', ''];
+    assert.deepEqual(
+      this.spy.getCall(0).args[0],
+      expected,
+      'calls onchange with an array of base64 converted files'
+    );
+
+    // add a file to the third input
+    triggerEvent('[data-test-pgp-file]:nth-child(3) [data-test-pgp-file-input]', ...fileEvent());
+    await waitUntil(() => {
+      return !!this.spy.calledTwice;
+    });
+    let expected2 = [btoa(data), '', btoa(data)];
+    assert.deepEqual(
+      this.spy.getCall(1).args[0],
+      expected2,
+      'calls onchange with an array 2 base64 converted files'
+    );
+
+    // this will trim off the last input which was filled, so we should only have one file in the array
+    // now
+    this.set('listLength', 5);
+    let expected3 = [btoa(data), '', btoa(data), '', ''];
+    assert.deepEqual(
+      this.spy.getCall(2).args[0],
+      expected3,
+      'lengthening the list with an array with one base64 converted files'
+    );
+  });
+});


### PR DESCRIPTION
The `PgpList` component was erroring out on `replace` which is an ember array proxy method, but not a native JS array method. One of the ember updates must have changed how prototype extensions work and there were no tests for `PgpList` so we missed the breakage.

This adds tests for `PgpList` and refactors the component so we're not mutating a computed property.

Fixes #7250