### PR TITLE
identity propagation in ssh secrets engine #7547

### DIFF
--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -37,6 +37,7 @@ type sshRole struct {
 	Port                   int               `mapstructure:"port" json:"port"`
 	InstallScript          string            `mapstructure:"install_script" json:"install_script"`
 	AllowedUsers           string            `mapstructure:"allowed_users" json:"allowed_users"`
+	AllowedUsersTemplate   bool              `mapstructure:"allowed_users_template" json:"allowed_users_template"`
 	AllowedDomains         string            `mapstructure:"allowed_domains" json:"allowed_domains"`
 	KeyOptionSpecs         string            `mapstructure:"key_option_specs" json:"key_option_specs"`
 	MaxTTL                 string            `mapstructure:"max_ttl" json:"max_ttl"`
@@ -181,6 +182,15 @@ func pathRoles(b *backend) *framework.Path {
 				list means that no users are allowed; explicitly specify '*' to
 				allow any user.
 				`,
+			},
+			"allowed_users_template": &framework.FieldSchema{
+				Type: framework.TypeBool,
+				Description: `
+				[Not applicable for Dynamic type] [Not applicable for OTP type] [Optional for CA type]
+				If set, Allowed users can be specified using identity template policies.
+				Non-templated users are also permitted.
+				`,
+				Default: false,
 			},
 			"allowed_domains": &framework.FieldSchema{
 				Type: framework.TypeString,
@@ -485,6 +495,7 @@ func (b *backend) createCARole(allowedUsers, defaultUser string, data *framework
 		AllowUserCertificates:  data.Get("allow_user_certificates").(bool),
 		AllowHostCertificates:  data.Get("allow_host_certificates").(bool),
 		AllowedUsers:           allowedUsers,
+		AllowedUsersTemplate:   data.Get("allowed_users_template").(bool),
 		AllowedDomains:         data.Get("allowed_domains").(string),
 		DefaultUser:            defaultUser,
 		AllowBareDomains:       data.Get("allow_bare_domains").(bool),
@@ -565,6 +576,7 @@ func (b *backend) parseRole(role *sshRole) (map[string]interface{}, error) {
 
 		result = map[string]interface{}{
 			"allowed_users":            role.AllowedUsers,
+			"allowed_users_template":   role.AllowedUsersTemplate,
 			"allowed_domains":          role.AllowedDomains,
 			"default_user":             role.DefaultUser,
 			"ttl":                      int64(ttl.Seconds()),

--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -133,12 +134,12 @@ func (b *backend) pathSignCertificate(ctx context.Context, req *logical.Request,
 
 	var parsedPrincipals []string
 	if certificateType == ssh.HostCert {
-		parsedPrincipals, err = b.calculateValidPrincipals(data, "", role.AllowedDomains, validateValidPrincipalForHosts(role))
+		parsedPrincipals, err = b.calculateValidPrincipals(data, req, "", role.AllowedDomains, validateValidPrincipalForHosts(role))
 		if err != nil {
 			return logical.ErrorResponse(err.Error()), nil
 		}
 	} else {
-		parsedPrincipals, err = b.calculateValidPrincipals(data, role.DefaultUser, role.AllowedUsers, strutil.StrListContains)
+		parsedPrincipals, err = b.calculateValidPrincipals(data, req, role.DefaultUser, role.AllowedUsers, strutil.StrListContains)
 		if err != nil {
 			return logical.ErrorResponse(err.Error()), nil
 		}
@@ -204,7 +205,7 @@ func (b *backend) pathSignCertificate(ctx context.Context, req *logical.Request,
 	return response, nil
 }
 
-func (b *backend) calculateValidPrincipals(data *framework.FieldData, defaultPrincipal, principalsAllowedByRole string, validatePrincipal func([]string, string) bool) ([]string, error) {
+func (b *backend) calculateValidPrincipals(data *framework.FieldData, req *logical.Request, defaultPrincipal, principalsAllowedByRole string, validatePrincipal func([]string, string) bool) ([]string, error) {
 	validPrincipals := ""
 	validPrincipalsRaw, ok := data.GetOk("valid_principals")
 	if ok {
@@ -214,7 +215,28 @@ func (b *backend) calculateValidPrincipals(data *framework.FieldData, defaultPri
 	}
 
 	parsedPrincipals := strutil.RemoveDuplicates(strutil.ParseStringSlice(validPrincipals, ","), false)
-	allowedPrincipals := strutil.RemoveDuplicates(strutil.ParseStringSlice(principalsAllowedByRole, ","), false)
+	// Build list of allowed Principals from template and static principalsAllowedByRole
+	var allowedPrincipals []string
+	for _, principal := range strutil.RemoveDuplicates(strutil.ParseStringSlice(principalsAllowedByRole, ","), false) {
+		// Look for templating markers {{ .* }}
+		matched, _ := regexp.MatchString(`^{{.+?}}$`, principal)
+		if matched {
+			if req.EntityID != "" {
+				// Retrieve principal based on template + entityID from request.
+				templatePrincipal, err := framework.PopulateIdentityTemplate(principal, req.EntityID, b.System())
+				if err == nil {
+					// Template returned a principal
+					allowedPrincipals = append(allowedPrincipals, templatePrincipal)
+				} else {
+					return nil, fmt.Errorf("Template '%s' could not be rendered -> %s", principal, err)
+				}
+			}
+		} else {
+			// Static principal or err template
+			allowedPrincipals = append(allowedPrincipals, principal)
+		}
+	}
+
 	switch {
 	case len(parsedPrincipals) == 0:
 		// There is nothing to process
@@ -230,7 +252,7 @@ func (b *backend) calculateValidPrincipals(data *framework.FieldData, defaultPri
 		}
 
 		for _, principal := range parsedPrincipals {
-			if !validatePrincipal(allowedPrincipals, principal) {
+			if !validatePrincipal(strutil.RemoveDuplicates(allowedPrincipals, false), principal) {
 				return nil, fmt.Errorf("%v is not a valid value for valid_principals", principal)
 			}
 		}

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -66,7 +66,7 @@ export default DS.Model.extend({
   }),
   allowedUsers: attr('string', {
     helpText:
-      'Create a whitelist of users that can use this key (e.g. `admin, dev`, or use `*` to allow all)',
+      'Create a whitelist of users that can use this key (e.g. `admin, dev`, use `*` to allow all. Supports templated policies e.g. {{identity.entity.aliases.mount_accessor_xyz.name}})',
   }),
   allowedDomains: attr('string', {
     helpText:

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -26,6 +26,7 @@ const CA_FIELDS = [
   'allowHostCertificates',
   'defaultUser',
   'allowedUsers',
+  'allowedUsersTemplate',
   'allowedDomains',
   'ttl',
   'maxTtl',
@@ -65,8 +66,11 @@ export default DS.Model.extend({
     helpText: "Username to use when one isn't specified",
   }),
   allowedUsers: attr('string', {
+    helpText: 'Create a whitelist of users that can use this key (e.g. `admin, dev`, use `*` to allow all.)',
+  }),
+  allowedUsersTemplate: attr('boolean', {
     helpText:
-      'Create a whitelist of users that can use this key (e.g. `admin, dev`, use `*` to allow all. Supports templated policies e.g. {{identity.entity.aliases.mount_accessor_xyz.name}})',
+      'Specifies that Allowed users can be templated e.g. {{identity.entity.aliases.mount_accessor_xyz.name}}',
   }),
   allowedDomains: attr('string', {
     helpText:


### PR DESCRIPTION
To test you may run:
```
pkill -f -9 vault
make dev-ui
export VAULT_DEV_ROOT_TOKEN_ID=test
export VAULT_TOKEN=test
vault server -dev -dev-no-store-token&
sleep 5
export VAULT_ADDR=http://127.0.0.1:8200
vault token lookup
cat <<EOF > user-policy.hcl
# Configure auth methods
path "/*" {
  capabilities = [ "create", "update", "read", "delete", "list", "sudo" ]
}
EOF
vault policy write user user-policy.hcl
vault auth enable userpass
vault write auth/userpass/users/ubuntu password=test policies=user
vault secrets enable -path=ssh ssh
vault write ssh/config/ca generate_signing_key=true
cat <<EOF > signer-clientrole.hcl
{
    "allow_user_certificates": true,
    "allowed_users": "root,{{identity.entity.aliases.$(vault auth list -format=json | jq -r '.["userpass/"].accessor').name}}",
    "default_user": "",
    "allow_user_key_ids": "false",
    "default_extensions": [
        {
          "permit-pty": ""
        }
    ],
    "key_type": "ca",
    "ttl": "60m0s"
}
EOF
vault write ssh/roles/clientrole @signer-clientrole.hcl
vault token lookup
vault write \
    -field=signed_key \
    ssh/sign/clientrole \
    valid_principals="root" \
    public_key=@$HOME/.ssh/id_rsa.pub \
    > $HOME/.ssh/cert-signed.pub
ssh-keygen -L -f $HOME/.ssh/cert-signed.pub
export VAULT_TOKEN=$(vault login -token-only -method=userpass username=ubuntu password=test)
vault token lookup
vault write \
    -field=signed_key \
    ssh/sign/clientrole \
    valid_principals="ubuntu" \
    public_key=@$HOME/.ssh/id_rsa.pub \
    > $HOME/.ssh/cert-signed.pub
ssh-keygen -L -f $HOME/.ssh/cert-signed.pub

```