### PR TITLE
Backport: Add response_types_supported to OIDC configuration (#7533)

### DIFF
--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -78,10 +78,11 @@ type idToken struct {
 //
 // https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
 type discovery struct {
-	Issuer      string   `json:"issuer"`
-	Keys        string   `json:"jwks_uri"`
-	Subjects    []string `json:"subject_types_supported"`
-	IDTokenAlgs []string `json:"id_token_signing_alg_values_supported"`
+	Issuer        string   `json:"issuer"`
+	Keys          string   `json:"jwks_uri"`
+	ResponseTypes []string `json:"response_types_supported"`
+	Subjects      []string `json:"subject_types_supported"`
+	IDTokenAlgs   []string `json:"id_token_signing_alg_values_supported"`
 }
 
 // oidcCache is a thin wrapper around go-cache to partition by namespace
@@ -202,7 +203,7 @@ func oidcPaths(i *IdentityStore) []*framework.Path {
 				logical.ReadOperation: i.pathOIDCDiscovery,
 			},
 			HelpSynopsis:    "Query OIDC configurations",
-			HelpDescription: "Query this path to retrieve the configured OIDC Issuer and Keys endpoints, Subjects, and signing algorithms used by the OIDC backend.",
+			HelpDescription: "Query this path to retrieve the configured OIDC Issuer and Keys endpoints, response types, subject types, and signing algorithms used by the OIDC backend.",
 		},
 		{
 			Pattern: "oidc/.well-known/keys/?$",
@@ -1002,10 +1003,11 @@ func (i *IdentityStore) pathOIDCDiscovery(ctx context.Context, req *logical.Requ
 		}
 
 		disc := discovery{
-			Issuer:      c.effectiveIssuer,
-			Keys:        c.effectiveIssuer + "/.well-known/keys",
-			Subjects:    []string{"public"},
-			IDTokenAlgs: supportedAlgs,
+			Issuer:        c.effectiveIssuer,
+			Keys:          c.effectiveIssuer + "/.well-known/keys",
+			ResponseTypes: []string{"id_token"},
+			Subjects:      []string{"public"},
+			IDTokenAlgs:   supportedAlgs,
 		}
 
 		data, err = json.Marshal(disc)


### PR DESCRIPTION
Backport of: #7533

The OIDC Discovery standard requires the response_types_supported field
to be returned in the .well-known/openid-configuration response.

Also, the AWS IAM OIDC consumer won't accept Vault as an identity
provider without this field.

Based on examples in the OIDC Core documentation, it appears Vault
supports only the `id_token` flow, and thus that is the only value that
makes sense to be set in this field. See:

https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationExamples