### PR TITLE
add proxy auth method

### DIFF
--- a/builtin/credential/proxy/backend.go
+++ b/builtin/credential/proxy/backend.go
@@ -1,0 +1,58 @@
+package proxy
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	rolePrefixStoragePath string = "role/"
+)
+
+func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
+	b := Backend()
+	if err := b.Setup(ctx, conf); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Backend() *backend {
+	b := backend{}
+	b.Backend = &framework.Backend{
+		Help:        backendHelp,
+		BackendType: logical.TypeCredential,
+		AuthRenew:   b.pathLoginRenew,
+		Paths: []*framework.Path{
+			pathLogin(&b),
+			pathConfig(&b),
+			pathRoleList(&b),
+			pathRole(&b),
+		},
+		PathsSpecial: &logical.Paths{
+			Unauthenticated: []string{
+				"login",
+			},
+		},
+	}
+
+	return &b
+}
+
+type backend struct {
+	*framework.Backend
+}
+
+const backendHelp = `
+The "proxy" credential provider allows authentication using headers provided
+by a trusted proxy server.  A client connects to vault via a trusted proxy
+server, which performs its own authentication, adds a header with the
+authenticated username, and then forwards the request to vault.  The
+"proxy" credential provider can then issue a token based on the header
+that was written by the proxy.
+
+The "proxy" credential provider must only ever be used when all requests
+from vault are first processed by a trusted proxy server.
+`

--- a/builtin/credential/proxy/backend_test.go
+++ b/builtin/credential/proxy/backend_test.go
@@ -1,0 +1,161 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type testBackend struct {
+	Backend logical.Backend
+	Storage logical.Storage
+	testing *testing.T
+}
+
+func newTestBackend(t *testing.T) *testBackend {
+	defaultLeaseTTLVal := time.Hour * 12
+	maxLeaseTTLVal := time.Hour * 24
+
+	storage := &logical.InmemStorage{}
+	b, err := Factory(context.Background(), &logical.BackendConfig{
+		Logger: logging.NewVaultLogger(log.Trace),
+		System: &logical.StaticSystemView{
+			DefaultLeaseTTLVal: defaultLeaseTTLVal,
+			MaxLeaseTTLVal:     maxLeaseTTLVal,
+		},
+		StorageView: storage,
+	})
+
+	if err != nil {
+		t.Fatalf("Unable to create backend: %s", err)
+	}
+
+	return &testBackend{
+		Backend: b,
+		Storage: storage,
+		testing: t,
+	}
+}
+
+func (t *testBackend) HandleRequest(req *logical.Request) (resp *logical.Response, err error) {
+	t.testing.Helper()
+	req.Storage = t.Storage
+	return t.Backend.HandleRequest(context.Background(), req)
+}
+
+func (t *testBackend) AssertHandleRequest(req *logical.Request) (resp *logical.Response) {
+	t.testing.Helper()
+	resp, err := t.HandleRequest(req)
+	assertSuccess(t.testing, err, resp)
+	return resp
+}
+
+func assertSuccess(t *testing.T, err error, resp *logical.Response) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("request failed. err=%+v\n", err)
+	}
+
+	if resp.IsError() {
+		t.Fatalf("erroneous response:\n%+v", resp)
+	}
+}
+
+func createConfigRequest(data map[string]interface{}) *logical.Request {
+	return &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "config",
+		Data:      data,
+	}
+}
+
+func updateConfigRequest(data map[string]interface{}) *logical.Request {
+	req := createConfigRequest(data)
+	req.Operation = logical.UpdateOperation
+	return req
+}
+
+func readConfigRequest() *logical.Request {
+	return &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config",
+	}
+}
+
+func createRoleRequest(roleName string, data map[string]interface{}) *logical.Request {
+	return &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      fmt.Sprintf("role/%s", roleName),
+		Data:      data,
+	}
+}
+
+func updateRoleRequest(roleName string, data map[string]interface{}) *logical.Request {
+	req := createRoleRequest(roleName, data)
+	req.Operation = logical.UpdateOperation
+	return req
+}
+
+func readRoleRequest(roleName string) *logical.Request {
+	return &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      fmt.Sprintf("role/%s", roleName),
+	}
+}
+
+func listRoleRequest() *logical.Request {
+	return &logical.Request{
+		Operation: logical.ListOperation,
+		Path:      "role/",
+	}
+}
+
+func loginRequest(username, role, userHeader string, headers map[string][]string) *logical.Request {
+	if headers == nil {
+		headers = make(map[string][]string)
+	}
+	headers[userHeader] = []string{username}
+
+	return &logical.Request{
+		Operation:       logical.UpdateOperation,
+		Unauthenticated: true,
+		Path:            "login",
+		Data:            map[string]interface{}{"role": role},
+		Headers:         headers,
+	}
+}
+
+// assertSerializedEqual checks to see if 'expected' and 'actual' have the
+// same representations when serialized to JSON
+func assertSerializedEqual(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	expJSON, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("marshal failure: %+v\n", err)
+	}
+
+	var expObj interface{}
+	if err := json.Unmarshal(expJSON, &expObj); err != nil {
+		t.Fatalf("unmarshal failure: %+v\n", err)
+	}
+
+	actualJSON, err := json.Marshal(actual)
+	if err != nil {
+		t.Fatalf("marshal failure: %+v\n", err)
+	}
+
+	var actualObj interface{}
+	if err := json.Unmarshal(actualJSON, &actualObj); err != nil {
+		t.Fatalf("unmarshal failure: %+v\n", err)
+	}
+	if !reflect.DeepEqual(actualObj, expObj) {
+		t.Fatalf("Unexpected value\ngot: %+v\nexp: %+v", actualObj, expObj)
+	}
+}

--- a/builtin/credential/proxy/cli.go
+++ b/builtin/credential/proxy/cli.go
@@ -1,0 +1,61 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/mitchellh/mapstructure"
+)
+
+type CLIHandler struct{}
+
+func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
+	var data struct {
+		Mount string `mapstructure:"mount"`
+		Role  string `mapstructure:"role"`
+	}
+	if err := mapstructure.WeakDecode(m, &data); err != nil {
+		return nil, err
+	}
+
+	if data.Mount == "" {
+		data.Mount = "proxy"
+	}
+
+	options := map[string]interface{}{
+		"role": data.Role,
+	}
+	path := fmt.Sprintf("auth/%s/login", data.Mount)
+	secret, err := c.Logical().Write(path, options)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil {
+		return nil, fmt.Errorf("empty response from credential provider")
+	}
+
+	return secret, nil
+}
+
+func (h *CLIHandler) Help() string {
+	help := `
+Usage: vault login -method=proxy [CONFIG K=V...]
+
+  The proxy auth method allows users to authenticate to a vault cluster that's
+  fronted by a proxy that handles authentication.  Note that the -client-cert
+  and -client-key flags are included with the "vault login" command, NOT as
+  configuration to the auth method.
+
+  Sample invocation to login to the "users" role:
+
+      $ vault login -method=proxy -client-cert=cert.pem -client-key=key.pem role=users
+
+Configuration:
+
+  role=<string>
+      Role name to authenticate against.
+`
+
+	return strings.TrimSpace(help)
+}

--- a/builtin/credential/proxy/cmd/proxy/main.go
+++ b/builtin/credential/proxy/cmd/proxy/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/builtin/credential/proxy"
+	"github.com/hashicorp/vault/sdk/plugin"
+)
+
+func main() {
+	apiClientMeta := &api.PluginAPIClientMeta{}
+	flags := apiClientMeta.FlagSet()
+	flags.Parse(os.Args[1:])
+
+	tlsConfig := apiClientMeta.GetTLSConfig()
+	tlsProviderFunc := api.VaultPluginTLSProvider(tlsConfig)
+
+	if err := plugin.Serve(&plugin.ServeOpts{
+		BackendFactoryFunc: proxy.Factory,
+		TLSProviderFunc:    tlsProviderFunc,
+	}); err != nil {
+		logger := hclog.New(&hclog.LoggerOptions{})
+
+		logger.Error("plugin shutting down", "error", err)
+		os.Exit(1)
+	}
+}

--- a/builtin/credential/proxy/config_test.go
+++ b/builtin/credential/proxy/config_test.go
@@ -1,0 +1,51 @@
+package proxy
+
+import (
+	"testing"
+)
+
+func TestConfigReadWrite(t *testing.T) {
+	b := newTestBackend(t)
+
+	data := map[string]interface{}{
+		"user_header": "Foobar",
+		"bound_cidrs": []interface{}{"1.2.3.4/8", "5.6.7.8/24"},
+	}
+	req := createConfigRequest(data)
+	b.AssertHandleRequest(req)
+
+	req = readConfigRequest()
+	resp := b.AssertHandleRequest(req)
+
+	assertSerializedEqual(t, data, resp.Data)
+}
+
+func TestConfigValidation(t *testing.T) {
+	b := newTestBackend(t)
+
+	// missing required user header
+	req := createConfigRequest(map[string]interface{}{})
+	resp, err := b.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %+v\n", err)
+	}
+
+	if !resp.IsError() {
+		t.Fatalf("did not get error when required field not set")
+	}
+
+	// invalid cidr
+	data := map[string]interface{}{
+		"user_header": "Foobar",
+		"bound_cidrs": "monkey",
+	}
+	req = createConfigRequest(data)
+	resp, err = b.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %+v\n", err)
+	}
+
+	if !resp.IsError() {
+		t.Fatalf("did not get error when invalid CIDR provided")
+	}
+}

--- a/builtin/credential/proxy/login_test.go
+++ b/builtin/credential/proxy/login_test.go
@@ -1,0 +1,165 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/api"
+	credCert "github.com/hashicorp/vault/builtin/credential/cert"
+	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault"
+)
+
+func TestLogin(t *testing.T) {
+	b := newTestBackend(t)
+
+	header := "REMOTE_USER"
+	req := createConfigRequest(map[string]interface{}{"user_header": header})
+	b.AssertHandleRequest(req)
+
+	roleName := "test1"
+	requiredHeaders := map[string]string{
+		"REQ_HDR_1": "REQ_VAL_1",
+		"REQ_HDR_2": "REQ_VAL_2",
+	}
+	roleData := map[string]interface{}{
+		"allowed_users":    "user1,user2,user3*x",
+		"required_headers": requiredHeaders,
+	}
+	req = createRoleRequest(roleName, roleData)
+	b.AssertHandleRequest(req)
+
+	incHeaders := map[string][]string{
+		"REQ_HDR_1": []string{"REQ_VAL_1"},
+		"REQ_HDR_2": []string{"REQ_VAL_2"},
+	}
+
+	tests := []struct {
+		role          string
+		username      string
+		userHeader    string
+		headers       map[string][]string
+		expectSuccess bool
+		expectError   bool
+	}{
+		{roleName, "user1", header, incHeaders, true, false},
+		{roleName, "user2", header, incHeaders, true, false},
+
+		// user that matches glob => success
+		{roleName, "user3foobarx", header, incHeaders, true, false},
+
+		// user that does not glob => fail
+		{roleName, "johndoe", header, incHeaders, false, false},
+		{roleName, "user3foobar", header, incHeaders, false, false},
+
+		// user doesn't match any existing role => fail
+		{"unknownrole", "user1", header, incHeaders, false, false},
+
+		// missing a required header => fail
+		{roleName, "user1", header, map[string][]string{
+			"REQ_HDR_1": []string{"REQ_VAL_1"},
+		}, false, false},
+
+		// required header has wrong value => fail
+		{roleName, "user1", header, map[string][]string{
+			"REQ_HDR_1": []string{"REQ_VAL_1"},
+			"REQ_HDR_2": []string{"WRONG_VALUE"},
+		}, false, false},
+
+		// required header has two values => fail
+		{roleName, "user1", header, map[string][]string{
+			"REQ_HDR_1": []string{"REQ_VAL_1"},
+			"REQ_HDR_2": []string{"REQ_VAL_2", "WRONG_VALUE"},
+		}, false, false},
+	}
+
+	for idx, test := range tests {
+		t.Logf("performing login test idx=%d, user=%s, role=%s", idx, test.username, test.role)
+		req := loginRequest(test.username, test.role, test.userHeader, test.headers)
+
+		if test.expectSuccess {
+			b.AssertHandleRequest(req)
+		} else {
+			resp, err := b.HandleRequest(req)
+			if test.expectError && err == nil {
+				t.Fatal("unexpectedly got nil error")
+			}
+
+			if !test.expectSuccess && !resp.IsError() {
+				t.Fatal("expected failed response but got success")
+			}
+		}
+	}
+}
+
+// TestLoginWithCertClient verifies we can login to the proxy engine using the
+// cert engines cli; allowing clients that lack proxy auth support to
+// authenticate
+func TestLoginWithCertClient(t *testing.T) {
+	// start backend
+	coreConfig := &vault.CoreConfig{
+		DisableMlock: true,
+		DisableCache: true,
+		Logger:       log.NewNullLogger(),
+		CredentialBackends: map[string]logical.Factory{
+			"proxy": Factory,
+		},
+	}
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+	cores := cluster.Cores
+	vault.TestWaitActive(t, cores[0].Core)
+	client := cores[0].Client
+
+	proxyHeader := "remote_user"
+	authOpts := &api.EnableAuthOptions{
+		Type:        "proxy",
+		Description: "enables entities that have authenticated to AB apache to obtain a token",
+		Config: api.AuthConfigInput{
+			DefaultLeaseTTL:           "24h",
+			PassthroughRequestHeaders: []string{proxyHeader},
+		},
+	}
+
+	// mount the proxy auth engine
+	mountPoint := "proxy_auth/"
+	if err := client.Sys().EnableAuthWithOptions(mountPoint, authOpts); err != nil {
+		t.Fatalf("err mounting proxy auth engine: %+v", err)
+	}
+
+	if _, err := client.Logical().Write("auth/"+mountPoint+"config", map[string]interface{}{"user_header": proxyHeader}); err != nil {
+		t.Fatalf("Error configuring proxy auth engine: %+v", err)
+	}
+
+	// setup a role
+	role := "test_role"
+	allowedUser := "user1"
+	if _, err := client.Logical().Write("auth/"+mountPoint+"role/"+role, map[string]interface{}{"allowed_users": allowedUser}); err != nil {
+		t.Fatalf("Error configuring proxy auth role: %+v", err)
+	}
+
+	// login to role with cert cli client
+	headers := client.Headers()
+	if headers == nil {
+		headers = make(http.Header)
+	}
+
+	headers.Set(proxyHeader, allowedUser)
+	client.SetHeaders(headers)
+	cli := credCert.CLIHandler{}
+	secret, err := cli.Auth(client, map[string]string{
+		"name":  role,
+		"mount": mountPoint,
+	})
+	if err != nil {
+		t.Fatalf("login failed: %+v", err)
+	}
+	if secret.Auth == nil {
+		t.Fatalf("login returned nil Auth")
+	}
+}

--- a/builtin/credential/proxy/path_config.go
+++ b/builtin/credential/proxy/path_config.go
@@ -1,0 +1,153 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/textproto"
+
+	"github.com/hashicorp/errwrap"
+	sockaddr "github.com/hashicorp/go-sockaddr"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/parseutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	configStoragePath     string = "config"
+	configBoundCidrsField        = "bound_cidrs"
+	configUserHeaderField        = "user_header"
+)
+
+func pathConfig(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "config",
+		Fields: map[string]*framework.FieldSchema{
+			configUserHeaderField: &framework.FieldSchema{
+				Type:     framework.TypeString,
+				Required: true,
+				Description: `The name of the header that contains the authenticated user’s` +
+					`username.  Case insensitive.`,
+			},
+			configBoundCidrsField: &framework.FieldSchema{
+				Type: framework.TypeCommaStringSlice,
+				Description: `Comma separated string or list of CIDR blocks. If ` +
+					`set, restricts the blocks of IP addresses which can perform the ` +
+					`login operation.`,
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathConfigRead,
+				Summary:  "Read the current proxy authentication backend configuration.",
+			},
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathConfigCreateUpdate,
+				Summary:  "Set the current proxy authentication backend configuration.",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathConfigCreateUpdate,
+				Summary:  "Update the current proxy authentication backend configuration.",
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathConfigDelete,
+				Summary:  "Delete the current proxy authentication backend configuration.",
+			},
+		},
+
+		ExistenceCheck: b.pathConfigExistenceCheck,
+
+		HelpSynopsis: "Manage the proxy authentication backend configuration",
+	}
+}
+
+type proxyConfig struct {
+	UserHeader string                        `json:"user_header"`
+	BoundCIDRs []*sockaddr.SockAddrMarshaler `json:"bound_cidrs"`
+}
+
+// config fetchs the proxyConfig from the storage backend
+func (b *backend) config(ctx context.Context, s logical.Storage) (*proxyConfig, error) {
+	entry, err := s.Get(ctx, configStoragePath)
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	config := proxyConfig{}
+	if err := entry.DecodeJSON(&config); err != nil {
+		return nil, errwrap.Wrapf("error reading proxy backend configuration: {{err}}", err)
+	}
+	return &config, nil
+}
+
+func (b *backend) pathConfigExistenceCheck(ctx context.Context, req *logical.Request, data *framework.FieldData) (bool, error) {
+	config, err := b.config(ctx, req.Storage)
+	if err != nil {
+		return false, err
+	}
+
+	return config != nil, nil
+}
+
+func (b *backend) pathConfigCreateUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	config, err := b.config(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	if config == nil {
+		config = &proxyConfig{}
+	}
+
+	if val, ok := data.GetOk(configUserHeaderField); ok {
+		config.UserHeader = textproto.CanonicalMIMEHeaderKey(val.(string))
+	}
+	if config.UserHeader == "" {
+		return logical.ErrorResponse(fmt.Sprintf("%s must be set", configUserHeaderField)), nil
+	}
+
+	if val, ok := data.GetOk(configBoundCidrsField); ok {
+		parsedCIDRs, err := parseutil.ParseAddrs(val)
+		if err != nil {
+			return logical.ErrorResponse(fmt.Sprintf("%s is invalid: %s", configBoundCidrsField, err.Error())), nil
+		}
+		config.BoundCIDRs = parsedCIDRs
+	}
+
+	entry, err := logical.StorageEntryJSON(configStoragePath, config)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := req.Storage.Put(ctx, entry); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	config, err := b.config(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	if config == nil {
+		return nil, nil
+	}
+
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			configUserHeaderField: config.UserHeader,
+			configBoundCidrsField: config.BoundCIDRs,
+		},
+	}
+	return resp, nil
+}
+
+func (b *backend) pathConfigDelete(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	err := req.Storage.Delete(ctx, configStoragePath)
+	return nil, err
+}

--- a/builtin/credential/proxy/path_login.go
+++ b/builtin/credential/proxy/path_login.go
@@ -1,0 +1,238 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/textproto"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/cidrutil"
+	"github.com/hashicorp/vault/sdk/helper/policyutil"
+	"github.com/hashicorp/vault/sdk/logical"
+	glob "github.com/ryanuber/go-glob"
+)
+
+const (
+	loginHelpSyn   = `Authenticate to vault using credentials supplied from a trusted proxy`
+	loginRoleField = "role"
+	loginNameField = "name"
+)
+
+func pathLogin(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: `login$`,
+		Fields: map[string]*framework.FieldSchema{
+			loginRoleField: {
+				Type:        framework.TypeLowerCaseString,
+				Description: "The role to login against.",
+			},
+
+			// support 'name' as an alias for 'role'.  This allows the login
+			// method of the cert engine in the default vault client to work
+			// with this backend
+			loginNameField: {
+				Type:        framework.TypeLowerCaseString,
+				Description: fmt.Sprintf("alias for %q field", loginRoleField),
+			},
+		},
+
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathLogin,
+				Summary:  loginHelpSyn,
+			},
+			logical.AliasLookaheadOperation: &framework.PathOperation{
+				Callback: b.pathLogin,
+			},
+		},
+
+		HelpSynopsis: loginHelpSyn,
+	}
+}
+
+func (b *backend) pathLogin(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	config, err := b.config(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return logical.ErrorResponse("could not load configuration"), nil
+	}
+
+	rolename := data.Get(loginRoleField).(string)
+	if rolename == "" {
+		rolename = data.Get(loginNameField).(string)
+		if rolename == "" {
+			return logical.ErrorResponse(fmt.Sprintf("either %q or %q must be set", loginRoleField, loginNameField)), nil
+		}
+	}
+
+	role, err := b.getRole(ctx, req.Storage, rolename)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return logical.ErrorResponse("role %q could not be found", rolename), nil
+	}
+
+	if req.Headers == nil {
+		// a likely cause of this error is when the proxy authentication
+		// method was enabled the "passthrough_request_headers" option
+		// was not specified.  This option should include the configured
+		// user header
+		return nil, fmt.Errorf("failed to get request headers")
+	}
+
+	username, err := getHeaderVal(config.UserHeader, req)
+	if err != nil || username == "" {
+		return nil, fmt.Errorf("could not identify remote user")
+	}
+
+	if req.Operation == logical.AliasLookaheadOperation {
+		return &logical.Response{
+			Auth: &logical.Auth{
+				Alias: b.getAuthAlias(username, rolename),
+			},
+		}, nil
+	}
+
+	if allowed, resp, err := b.authorize(config, role, req, username); !allowed {
+		return resp, err
+	}
+
+	// grant the token
+	resp := logical.Response{
+		Auth: &logical.Auth{
+			DisplayName: username,
+			Period:      role.Period,
+			Policies:    role.Policies,
+
+			Metadata: map[string]string{
+				"username": username,
+				"role":     rolename,
+			},
+			LeaseOptions: logical.LeaseOptions{
+				Renewable: true,
+				TTL:       role.TTL,
+				MaxTTL:    role.MaxTTL,
+			},
+			Alias:      b.getAuthAlias(username, rolename),
+			BoundCIDRs: config.BoundCIDRs,
+		},
+	}
+
+	return &resp, nil
+}
+
+func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	config, err := b.config(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return logical.ErrorResponse("could not load configuration"), nil
+	}
+
+	rolename := req.Auth.Metadata["role"]
+	role, err := b.getRole(ctx, req.Storage, rolename)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return logical.ErrorResponse("role %q could not be found during renewal", rolename), nil
+	}
+
+	username := req.Auth.Metadata["username"]
+	if allowed, resp, err := b.authorize(config, role, req, username); !allowed {
+		return resp, err
+	}
+
+	if !policyutil.EquivalentPolicies(role.Policies, req.Auth.TokenPolicies) {
+		return nil, fmt.Errorf("policies have changed, not renewing")
+	}
+
+	resp := &logical.Response{Auth: req.Auth}
+	resp.Auth.TTL = role.TTL
+	resp.Auth.MaxTTL = role.MaxTTL
+	return resp, nil
+}
+
+func (b *backend) getAuthAlias(username, role string) *logical.Alias {
+	return &logical.Alias{
+		Name: username,
+		Metadata: map[string]string{
+			"role": role,
+		},
+	}
+}
+
+func (b *backend) hasRequiredUser(username string, role *proxyRole) bool {
+	isAllowedUser := false
+	for _, allowedUserGlob := range role.AllowedUsers {
+		if glob.Glob(allowedUserGlob, username) {
+			isAllowedUser = true
+			break
+		}
+	}
+
+	return isAllowedUser
+}
+
+func (b *backend) hasRequiredHeaders(role *proxyRole, req *logical.Request) bool {
+	for reqHdrName, reqHdrVal := range role.RequiredHeaders {
+		val, err := getHeaderVal(reqHdrName, req)
+		if err != nil || val != reqHdrVal {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (b *backend) hasRequiredRemoteAddr(config *proxyConfig, req *logical.Request) (bool, error) {
+	if len(config.BoundCIDRs) != 0 {
+		if req.Connection == nil || req.Connection.RemoteAddr == "" {
+			return false, fmt.Errorf("failed to get connection information")
+		}
+
+		if !cidrutil.RemoteAddrIsOk(req.Connection.RemoteAddr, config.BoundCIDRs) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (b *backend) authorize(config *proxyConfig, role *proxyRole, req *logical.Request, username string) (allowed bool, resp *logical.Response, err error) {
+	if !b.hasRequiredUser(username, role) {
+		return false, logical.ErrorResponse("user not permitted to authenticate with this role"), nil
+	}
+
+	if !b.hasRequiredHeaders(role, req) {
+		return false, logical.ErrorResponse("required header not present, or has incorrect value"), nil
+	}
+
+	if ok, err := b.hasRequiredRemoteAddr(config, req); err != nil {
+		return false, nil, err
+	} else if !ok {
+		return false, logical.ErrorResponse("unauthorized source address"), nil
+	}
+
+	return true, nil, nil
+}
+
+func getHeaderVal(headerName string, req *logical.Request) (string, error) {
+	canonHeaderName := textproto.CanonicalMIMEHeaderKey(headerName)
+	for k, v := range req.Headers {
+		if canonHeaderName == textproto.CanonicalMIMEHeaderKey(k) {
+			if len(v) == 1 {
+				return v[0], nil
+			}
+
+			return "", fmt.Errorf("header present %d times", len(v))
+		}
+
+	}
+
+	return "", nil
+}

--- a/builtin/credential/proxy/path_role.go
+++ b/builtin/credential/proxy/path_role.go
@@ -1,0 +1,295 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/textproto"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/policyutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	roleStoragePathPrefix = "role/"
+
+	roleNameField            = "name"
+	roleAllowedUsersField    = "allowed_users"
+	roleRequiredHeadersField = "required_headers"
+	rolePoliciesField        = "policies"
+	roleTTLField             = "ttl"
+	roleMaxTTLField          = "max_ttl"
+	rolePeriodField          = "period"
+
+	roleHelpSyn  = `Manage the roles that are registered with the backend.`
+	roleHelpDesc = `All logins with the "proxy" credential provider must be made against a ` +
+		`preconfigured role.  A role configuration defines constraints around what ` +
+		`conditions must be in place for a user to authenticate using that role, along with ` +
+		`properties to apply to tokens that are generated when a successful login occurs.`
+)
+
+func pathRoleList(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "role/?",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.pathRolesList,
+				Summary:  `List the registered roles`,
+			},
+		},
+		HelpSynopsis: roleHelpSyn,
+	}
+}
+
+func pathRole(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "role/" + framework.GenericNameRegex("name"),
+		Fields: map[string]*framework.FieldSchema{
+			roleNameField: &framework.FieldSchema{
+				Type:        framework.TypeLowerCaseString,
+				Description: "The name of the role",
+			},
+			roleAllowedUsersField: &framework.FieldSchema{
+				Type:     framework.TypeCommaStringSlice,
+				Required: true,
+				Description: `A comma-separated list of names.  Supports globbing.  At least ` +
+					`one glob must match the username`,
+			},
+			roleRequiredHeadersField: &framework.FieldSchema{
+				Type: framework.TypeKVPairs,
+				Description: `Mapping of headers (key) and values.  If set, login attempts` +
+					`will only be successful if the required case insensitive ` +
+					`headers are set to the specified case sensitive value`,
+			},
+			rolePoliciesField: &framework.FieldSchema{
+				Type:        framework.TypeCommaStringSlice,
+				Description: `Comma-separated list of policies.`,
+			},
+			roleTTLField: &framework.FieldSchema{
+				Type: framework.TypeDurationSecond,
+				Description: `TTL for tokens issued by this backend.  Defaults to ` +
+					`system/backend default TTL time.`,
+			},
+			roleMaxTTLField: &framework.FieldSchema{
+				Type: framework.TypeDurationSecond,
+				Description: `Duration in either an integer number of seconds (3600) or an ` +
+					`integer time unit (60m) after which the issued token can no ` +
+					`longer be renewed.`,
+			},
+			rolePeriodField: &framework.FieldSchema{
+				Type: framework.TypeDurationSecond,
+				Description: `If set, indicates that the token generated using this role ` +
+					`should never expire. The token should be renewed within the ` +
+					`duration specified by this value. At each renewal, the token's ` +
+					`TTL will be set to the value of this parameter.`,
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathRoleRead,
+				Summary:  "Read an existing role.",
+			},
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathRoleCreateUpdate,
+				Summary:  "Register a role with the backend.",
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathRoleCreateUpdate,
+				Summary:  "Update an existing role.",
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathRoleDelete,
+				Summary:  "Delete an existing role.",
+			},
+		},
+
+		ExistenceCheck: b.pathRoleExistenceCheck,
+
+		HelpSynopsis:    roleHelpSyn,
+		HelpDescription: roleHelpDesc,
+	}
+}
+
+type proxyRole struct {
+	AllowedUsers    []string          `json:"allowed_users"`
+	RequiredHeaders map[string]string `json:"required_headers"`
+	Policies        []string          `json:"policies"`
+	Period          time.Duration     `json:"period"`
+	TTL             time.Duration     `json:"ttl"`
+	MaxTTL          time.Duration     `json:"max_ttl"`
+}
+
+func (b *backend) pathRoleRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	roleName := data.Get("name").(string)
+	if roleName == "" {
+		return logical.ErrorResponse("missing name"), nil
+	}
+
+	role, err := b.getRole(ctx, req.Storage, roleName)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, nil
+	}
+
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			roleAllowedUsersField:    role.AllowedUsers,
+			roleRequiredHeadersField: role.RequiredHeaders,
+			rolePoliciesField:        role.Policies,
+			rolePeriodField:          int64(role.Period.Seconds()),
+			roleTTLField:             int64(role.TTL.Seconds()),
+			roleMaxTTLField:          int64(role.MaxTTL.Seconds()),
+		},
+	}
+
+	return resp, nil
+}
+
+func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	roleName := data.Get(roleNameField).(string)
+	if roleName == "" {
+		return logical.ErrorResponse("missing role name"), nil
+	}
+
+	role, err := b.getRole(ctx, req.Storage, roleName)
+	if err != nil {
+		return nil, err
+	}
+
+	if role == nil {
+		role = &proxyRole{}
+	}
+
+	if allowedUsers, ok := data.GetOk(roleAllowedUsersField); ok {
+		role.AllowedUsers = allowedUsers.([]string)
+	}
+	if len(role.AllowedUsers) == 0 {
+		return logical.ErrorResponse(fmt.Sprintf("%s must be set", roleAllowedUsersField)), nil
+	}
+
+	if requiredHeaders, ok := data.GetOk(roleRequiredHeadersField); ok {
+		role.RequiredHeaders = make(map[string]string)
+		for k, v := range requiredHeaders.(map[string]string) {
+			nKey := textproto.CanonicalMIMEHeaderKey(k)
+			if _, ok := role.RequiredHeaders[nKey]; ok {
+				return logical.ErrorResponse("canonical form of required header %q specified multiple times", k), nil
+			}
+
+			role.RequiredHeaders[nKey] = v
+		}
+	}
+
+	if policies, ok := data.GetOk(rolePoliciesField); ok {
+		role.Policies = policyutil.ParsePolicies(policies)
+	}
+
+	resp := logical.Response{}
+
+	systemDefaultTTL := b.System().DefaultLeaseTTL()
+	if ttl, ok := data.GetOk(roleTTLField); ok {
+		role.TTL = time.Duration(ttl.(int)) * time.Second
+		if role.TTL < time.Duration(0) {
+			return logical.ErrorResponse(fmt.Sprintf("%q cannot be negative", roleTTLField)), nil
+		}
+		if role.TTL > systemDefaultTTL {
+			resp.AddWarning(fmt.Sprintf("%q of %d seconds is greater than current mount/system default of %d seconds",
+				roleTTLField, role.TTL/time.Second, systemDefaultTTL/time.Second))
+		}
+	}
+
+	systemMaxTTL := b.System().MaxLeaseTTL()
+	if maxTTL, ok := data.GetOk(roleMaxTTLField); ok {
+		role.MaxTTL = time.Duration(maxTTL.(int)) * time.Second
+		if role.MaxTTL < time.Duration(0) {
+			return logical.ErrorResponse(fmt.Sprintf("%q cannot be negative", roleMaxTTLField)), nil
+		}
+
+		if role.MaxTTL > systemMaxTTL {
+			resp.AddWarning(fmt.Sprintf("%q of %d seconds is greater than current mount/system default of %d seconds",
+				roleMaxTTLField, role.MaxTTL/time.Second, systemMaxTTL/time.Second))
+		}
+	}
+
+	if role.MaxTTL > 0 && role.TTL > role.MaxTTL {
+		return logical.ErrorResponse(fmt.Sprintf("%q should not be greater than %s", roleTTLField, roleMaxTTLField)), nil
+	}
+
+	if period, ok := data.GetOk(rolePeriodField); ok {
+		role.Period = time.Duration(period.(int)) * time.Second
+		if role.Period < time.Duration(0) {
+			return logical.ErrorResponse(fmt.Sprintf("%q cannot be negative", rolePeriodField)), nil
+		}
+
+		if role.Period > systemMaxTTL {
+			resp.AddWarning(fmt.Sprintf("%q of %d seconds is greater than the backend's maximum TTL of %d seconds",
+				rolePeriodField, role.Period/time.Second, systemMaxTTL/time.Second))
+		}
+	}
+
+	entry, err := logical.StorageEntryJSON(b.getRoleStoragePath(roleName), role)
+	if err != nil {
+		return nil, err
+	}
+	if err = req.Storage.Put(ctx, entry); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (b *backend) pathRoleDelete(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	roleName := data.Get("name").(string)
+	if roleName == "" {
+		return logical.ErrorResponse("role name required"), nil
+	}
+
+	if err := req.Storage.Delete(ctx, b.getRoleStoragePath(roleName)); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (b *backend) pathRolesList(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	roles, err := req.Storage.List(ctx, roleStoragePathPrefix)
+	if err != nil {
+		return nil, err
+	}
+	return logical.ListResponse(roles), nil
+}
+
+// getRole takes a storage backend and the name and returns the role's storage entry
+func (b *backend) getRole(ctx context.Context, s logical.Storage, name string) (*proxyRole, error) {
+	raw, err := s.Get(ctx, b.getRoleStoragePath(name))
+	if err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return nil, nil
+	}
+
+	role := proxyRole{}
+	if err := raw.DecodeJSON(&role); err != nil {
+		return nil, errwrap.Wrapf("error reading role configuration: {{err}}", err)
+	}
+
+	return &role, nil
+}
+
+func (b *backend) pathRoleExistenceCheck(ctx context.Context, req *logical.Request, data *framework.FieldData) (bool, error) {
+	role, err := b.getRole(ctx, req.Storage, data.Get("name").(string))
+	if err != nil {
+		return false, err
+	}
+
+	return role != nil, nil
+}
+
+func (b *backend) getRoleStoragePath(name string) string {
+	return roleStoragePathPrefix + strings.ToLower(name)
+}

--- a/builtin/credential/proxy/role_test.go
+++ b/builtin/credential/proxy/role_test.go
@@ -1,0 +1,62 @@
+package proxy
+
+import (
+	"testing"
+)
+
+func TestRoleReadWrite(t *testing.T) {
+	b := newTestBackend(t)
+
+	data := map[string]interface{}{
+		"allowed_users": []interface{}{"foo1,foo2"},
+		"required_headers": map[string]interface{}{
+			"Hdr1": "value1",
+			"Hdr2": "value2",
+		},
+		"policies": []interface{}{"policy1", "policy2"},
+		"ttl":      20,
+		"max_ttl":  40,
+		"period":   7200,
+	}
+	req := createRoleRequest("foo", data)
+	b.AssertHandleRequest(req)
+
+	req = readRoleRequest("foo")
+	resp := b.AssertHandleRequest(req)
+
+	assertSerializedEqual(t, data, resp.Data)
+}
+
+func TestRoleValidation(t *testing.T) {
+	b := newTestBackend(t)
+
+	// missing allowed_users
+	req := createRoleRequest("role1", map[string]interface{}{})
+	resp, err := b.HandleRequest(req)
+	if err != nil {
+		t.Fatalf("err: %+v\n", err)
+	}
+
+	if !resp.IsError() {
+		t.Fatalf("did not get error when required field not set")
+	}
+}
+
+func TestRoleList(t *testing.T) {
+	b := newTestBackend(t)
+
+	data := map[string]interface{}{
+		"allowed_users": []interface{}{"foo1,foo2"},
+	}
+	req := createRoleRequest("role1", data)
+	b.AssertHandleRequest(req)
+
+	req = createRoleRequest("role2", data)
+	b.AssertHandleRequest(req)
+
+	req = listRoleRequest()
+	resp := b.AssertHandleRequest(req)
+
+	exp := map[string][]string{"keys": []string{"role1", "role2"}}
+	assertSerializedEqual(t, exp, resp.Data)
+}

--- a/command/base_predict_test.go
+++ b/command/base_predict_test.go
@@ -363,6 +363,7 @@ func TestPredict_Plugins(t *testing.T) {
 				"pki",
 				"postgresql",
 				"postgresql-database-plugin",
+				"proxy",
 				"rabbitmq",
 				"radius",
 				"ssh",

--- a/command/commands.go
+++ b/command/commands.go
@@ -34,6 +34,7 @@ import (
 	credGitHub "github.com/hashicorp/vault/builtin/credential/github"
 	credLdap "github.com/hashicorp/vault/builtin/credential/ldap"
 	credOkta "github.com/hashicorp/vault/builtin/credential/okta"
+	credProxy "github.com/hashicorp/vault/builtin/credential/proxy"
 	credToken "github.com/hashicorp/vault/builtin/credential/token"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 
@@ -171,6 +172,7 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 		"oidc":     &credOIDC.CLIHandler{},
 		"okta":     &credOkta.CLIHandler{},
 		"pcf":      &credCF.CLIHandler{}, // Deprecated.
+		"proxy":    &credProxy.CLIHandler{},
 		"radius": &credUserpass.CLIHandler{
 			DefaultMount: "radius",
 		},

--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -20,6 +20,7 @@ import (
 	credGitHub "github.com/hashicorp/vault/builtin/credential/github"
 	credLdap "github.com/hashicorp/vault/builtin/credential/ldap"
 	credOkta "github.com/hashicorp/vault/builtin/credential/okta"
+	credProxy "github.com/hashicorp/vault/builtin/credential/proxy"
 	credRadius "github.com/hashicorp/vault/builtin/credential/radius"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 
@@ -83,6 +84,7 @@ func newRegistry() *registry {
 			"oidc":       credJWT.Factory,
 			"okta":       credOkta.Factory,
 			"pcf":        credCF.Factory, // Deprecated.
+			"proxy":      credProxy.Factory,
 			"radius":     credRadius.Factory,
 			"userpass":   credUserpass.Factory,
 		},


### PR DESCRIPTION
Adds support for authenticating users based on HTTP header added by a reverse proxy.

In my environment incoming TLS requests are terminated by a reverse proxy that runs on the same machine as vault.  This proxy forwards the HTTP (not HTTPS) request to vault.  Users can authenticate to the proxy using optional client certificate authentication.  Because the proxy terminates the TLS connection I cannot use vault's "cert" auth method, and so I developed this proxy auth method to fill the gap.  The proxy auth method is configured with the name of a HTTP header to read the authenticated username from.  Roles can be defined to specify what users can authenticate, what policies to apply, and the typical token related properties (ttl, etc).