### PR TITLE
support automatically unsealing using files

### DIFF
--- a/command/server/seal/server_seal.go
+++ b/command/server/seal/server_seal.go
@@ -33,6 +33,9 @@ func configureSeal(configSeal *server.Seal, infoKeys *[]string, info *map[string
 	case seal.Transit:
 		return configureTransitSeal(configSeal, infoKeys, info, logger, inseal)
 
+	case seal.Local:
+		return configureLocalSeal(configSeal, infoKeys, info, logger, inseal)
+
 	case seal.PKCS11:
 		return nil, fmt.Errorf("Seal type 'pkcs11' requires the Vault Enterprise HSM binary")
 

--- a/command/server/seal/server_seal_local.go
+++ b/command/server/seal/server_seal_local.go
@@ -1,0 +1,31 @@
+package seal
+
+import (
+	"github.com/hashicorp/errwrap"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/command/server"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault"
+	"github.com/hashicorp/vault/vault/seal/local"
+)
+
+func configureLocalSeal(configSeal *server.Seal, infoKeys *[]string, info *map[string]string, logger log.Logger, inseal vault.Seal) (vault.Seal, error) {
+	localSeal := local.NewSeal(logger)
+	sealInfo, err := localSeal.SetConfig(configSeal.Config)
+	if err != nil {
+		// If the error is any other than logical.KeyNotFoundError, return the error
+		if !errwrap.ContainsType(err, new(logical.KeyNotFoundError)) {
+			return nil, err
+		}
+	}
+
+	autoseal := vault.NewAutoSeal(localSeal)
+	if sealInfo != nil {
+		// set data about our seal that's written to the server output
+		// on startup
+		*infoKeys = append(*infoKeys, "Seal Type", "Key Glob")
+		(*info)["Seal Type"] = configSeal.Type
+		(*info)["Key Glob"] = sealInfo["key_glob"]
+	}
+	return autoseal, nil
+}

--- a/vault/seal/local/local.go
+++ b/vault/seal/local/local.go
@@ -1,0 +1,257 @@
+package local
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	"github.com/hashicorp/errwrap"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/physical"
+	"github.com/hashicorp/vault/vault/seal"
+)
+
+const (
+	// EnvLocalSealKeyGlob is an environment variable name whose value
+	// is expected to contain a shell glob pattern.  The files that match
+	// this pattern will be used as LocalSeal's encryption and decryption
+	// keys.  These filenames must contain a numerical index as one of
+	// their period delimited components which identifies the key version
+	// (e.g. foo.5.key is considered to have index 5)
+	EnvLocalSealKeyGlob = "VAULT_LOCAL_SEAL_KEY_GLOB"
+
+	// KeyLen is the length of encryption keys used by this seal
+	KeyLen = 32
+
+	// NonceLen is the length of encryption nonces used by this seal
+	NonceLen = 12
+)
+
+// LocalSeal provides a seal.Access implementation that uses on-disk secrets to
+// support auto seal functionality.
+type LocalSeal struct {
+	keyGlob      string
+	logger       log.Logger
+	currentKeyID *atomic.Value
+}
+
+// ensure LocalSeal implements the seal.Access interface
+var _ seal.Access = (*LocalSeal)(nil)
+
+// NewSeal creates a new LocalSeal with the provided logger
+func NewSeal(logger log.Logger) *LocalSeal {
+	l := &LocalSeal{
+		logger:       logger,
+		currentKeyID: new(atomic.Value),
+	}
+	l.currentKeyID.Store("")
+	return l
+}
+
+// Init is called during core.Initialize
+func (l *LocalSeal) Init(context.Context) error {
+	return nil
+}
+
+// Finalize is called during shutdown
+func (l *LocalSeal) Finalize(context.Context) error {
+	return nil
+}
+
+// SealType returns the seal type for this particular seal implementation.
+func (l *LocalSeal) SealType() string {
+	return seal.Local
+}
+
+// SetConfig sets the fields on the LocalSeal object based on
+// values from the config parameter.
+func (l *LocalSeal) SetConfig(config map[string]string) (map[string]string, error) {
+	if config == nil {
+		config = map[string]string{}
+	}
+
+	switch {
+	case os.Getenv(EnvLocalSealKeyGlob) != "":
+		l.keyGlob = os.Getenv(EnvLocalSealKeyGlob)
+	case config["key_glob"] != "":
+		l.keyGlob = config["key_glob"]
+	default:
+		return nil, fmt.Errorf("'key_glob' not found for local seal configuration")
+	}
+
+	if _, err := filepath.Glob(l.keyGlob); err != nil {
+		return nil, errwrap.Wrapf("'key_glob' is invalid for local seal configuration: {{err}}", err)
+	}
+
+	// Map that holds non-sensitive configuration info to return
+	sealInfo := make(map[string]string)
+	sealInfo["key_glob"] = l.keyGlob
+	return sealInfo, nil
+}
+
+// KeyID returns the last known key id
+func (l *LocalSeal) KeyID() string {
+	return l.currentKeyID.Load().(string)
+}
+
+// Encrypt is used to encrypt the master key using a local on-disk secret.
+// Returns the ciphertext, and/or any errors from this call.
+func (l *LocalSeal) Encrypt(ctx context.Context, plaintext []byte) (*physical.EncryptedBlobInfo, error) {
+	if plaintext == nil {
+		return nil, errors.New("given plaintext for encryption is nil")
+	}
+
+	f, keyIdx, err := l.getCurrentFile()
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := l.readKey(f)
+	if err != nil {
+		return nil, err
+	}
+
+	aead, err := l.aeadEncrypter(key)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, NonceLen)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("failed to read random bytes: %v", err)
+	}
+
+	enc := &physical.EncryptedBlobInfo{
+		Ciphertext: aead.Seal(nil, nonce, plaintext, nil),
+		IV:         nonce,
+		KeyInfo: &physical.SealKeyInfo{
+			KeyID: strconv.Itoa(keyIdx),
+		},
+	}
+	l.currentKeyID.Store(enc.KeyInfo.KeyID)
+	return enc, nil
+}
+
+// Decrypt is used to decrypt the ciphertext.
+func (l *LocalSeal) Decrypt(ctx context.Context, in *physical.EncryptedBlobInfo) ([]byte, error) {
+	if in == nil {
+		return nil, errors.New("given ciphertext for decryption is nil")
+	}
+
+	if in.KeyInfo == nil {
+		return nil, errors.New("key info is nil")
+	}
+
+	f, err := l.getKeyFile(in.KeyInfo.KeyID)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := l.readKey(f)
+	if err != nil {
+		return nil, err
+	}
+
+	aead, err := l.aeadEncrypter(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return aead.Open(nil, in.IV, in.Ciphertext, nil)
+}
+
+// getCurrentFile finds the key with the highest index that matches l.keyGlob.
+// On success returns the full path of the file, its index and a nil error.
+func (l *LocalSeal) getCurrentFile() (string, int, error) {
+	files, err := filepath.Glob(l.keyGlob)
+	if err != nil {
+		return "", 0, err
+	}
+
+	maxIdx := -1
+	maxFile := ""
+	for _, f := range files {
+		fIdx, err := l.getIndex(f)
+		if err == nil && fIdx > maxIdx {
+			maxIdx = fIdx
+			maxFile = f
+		}
+	}
+
+	if maxFile == "" {
+		return "", 0, fmt.Errorf("unable to find current seal secret")
+	}
+
+	return maxFile, maxIdx, nil
+}
+
+// getKeyFile finds the full path key that has the given index
+func (l *LocalSeal) getKeyFile(keyIndex string) (string, error) {
+	idx, err := strconv.Atoi(keyIndex)
+	if err != nil {
+		return "", errwrap.Wrapf(fmt.Sprintf("error parsing key index '%s': {{err}}", keyIndex), err)
+	}
+
+	files, err := filepath.Glob(l.keyGlob)
+	if err != nil {
+		return "", err
+	}
+
+	for _, f := range files {
+		fIdx, err := l.getIndex(f)
+		if err == nil && fIdx == idx {
+			return f, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to find seal secret for index '%s'", keyIndex)
+}
+
+// getIndex returns the key index of the given filename
+func (l *LocalSeal) getIndex(filename string) (int, error) {
+	parts := strings.Split(path.Base(filename), ".")
+	for i := len(parts) - 1; i >= 0; i-- {
+		if v, err := strconv.Atoi(parts[i]); err == nil {
+			return v, nil
+		}
+	}
+
+	return 0, fmt.Errorf("could not determine index of '%s'", filename)
+}
+
+func (l *LocalSeal) readKey(filename string) ([]byte, error) {
+	key, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errwrap.Wrapf(fmt.Sprintf("error reading key from '%s': {{err}}", filename), err)
+	}
+
+	if len(key) < KeyLen {
+		return nil, fmt.Errorf("key '%s' is too small", filename)
+	}
+
+	return key[:KeyLen], nil
+}
+
+func (l *LocalSeal) aeadEncrypter(key []byte) (cipher.AEAD, error) {
+	aesCipher, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to create cipher: {{err}}", err)
+	}
+
+	gcm, err := cipher.NewGCM(aesCipher)
+	if err != nil {
+		return nil, errors.New("failed to initialize GCM mode")
+	}
+
+	return gcm, nil
+}

--- a/vault/seal/local/local_test.go
+++ b/vault/seal/local/local_test.go
@@ -1,0 +1,96 @@
+package local
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	log "github.com/hashicorp/go-hclog"
+	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+)
+
+func TestLocalSeal_RoundTrip(t *testing.T) {
+	l := newLocalSealTest(t)
+	defer l.Cleanup()
+	l.WriteRandKeys([]string{"test.0.key", "test.1.key", "test.2.key", "should_be_ignored"})
+
+	sealConfig := map[string]string{
+		"key_glob": filepath.Join(l.Dir, "*.key"),
+	}
+
+	s := NewSeal(logging.NewVaultLogger(log.Trace))
+	_, err := s.SetConfig(sealConfig)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	input := []byte("foo")
+	enc, err := s.Encrypt(context.Background(), input)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// verify Encrypt() uses the key with the biggest index
+	if enc.KeyInfo == nil {
+		t.Fatal("KeyInfo not set")
+	}
+	if enc.KeyInfo.KeyID != "2" {
+		t.Fatalf("wrong key used: %s", enc.KeyInfo.KeyID)
+	}
+
+	// create another key to verify that decrypting doesn't just use the
+	// current key
+	l.WriteRandKey("test.3.key")
+
+	dec, err := s.Decrypt(context.Background(), enc)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(input, dec) {
+		t.Fatalf("expected %s, got %s", input, dec)
+	}
+}
+
+func newLocalSealTest(t *testing.T) *localSealTest {
+	dir, err := ioutil.TempDir("", "local_seal_test")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	return &localSealTest{
+		t:   t,
+		Dir: dir,
+	}
+}
+
+type localSealTest struct {
+	Dir string
+	t   *testing.T
+}
+
+func (l *localSealTest) Cleanup() {
+	os.RemoveAll(l.Dir)
+}
+
+func (l *localSealTest) WriteRandKey(file string) {
+	key, err := uuid.GenerateRandomBytes(KeyLen)
+	if err != nil {
+		l.t.Fatalf("err: %s", err)
+	}
+
+	fileWithPath := filepath.Join(l.Dir, file)
+	if err := ioutil.WriteFile(fileWithPath, key, 0444); err != nil {
+		l.t.Fatalf("err: %s", err)
+	}
+}
+
+func (l *localSealTest) WriteRandKeys(files []string) {
+	for _, f := range files {
+		l.WriteRandKey(f)
+	}
+}

--- a/vault/seal/seal.go
+++ b/vault/seal/seal.go
@@ -16,6 +16,7 @@ const (
 	OCIKMS        = "ocikms"
 	Transit       = "transit"
 	Test          = "test-auto"
+	Local         = "local"
 
 	// HSMAutoDeprecated is a deprecated seal type prior to 0.9.0.
 	// It is still referenced in certain code paths for upgrade purporses


### PR DESCRIPTION
Adds support for automatically unsealing vault using files.

Rotation of the seal key is supported.  Each seal key is required to contain the key index in its filename.  This index is used to identify the key and must be incremented when the key rotates.   Users of this plugin must define a glob that's used to locate all files for the plugin.