### PR TITLE
Add config parameter to Azure storage backend to allow specifying the ARM endpoint

### DIFF
--- a/physical/azure/azure_test.go
+++ b/physical/azure/azure_test.go
@@ -16,9 +16,12 @@ import (
 	"github.com/hashicorp/vault/sdk/physical"
 )
 
-func environmentForCleanupClient(name string) (azure.Environment, error) {
+func environmentForCleanupClient(name string, armUrl string) (azure.Environment, error) {
+	if armUrl != "" {
+		return azure.EnvironmentFromURL(armUrl)
+	}
 	if name == "" {
-		return azure.EnvironmentFromName("AzurePublicCloud")
+		name = "AzurePublicCloud"
 	}
 	return azure.EnvironmentFromName(name)
 }
@@ -32,11 +35,12 @@ func TestAzureBackend(t *testing.T) {
 	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
 	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
 	environmentName := os.Getenv("AZURE_ENVIRONMENT")
+	environmentUrl := os.Getenv("AZURE_ARM_ENDPOINT")
 
 	ts := time.Now().UnixNano()
 	name := fmt.Sprintf("vault-test-%d", ts)
 
-	cleanupEnvironment, err := environmentForCleanupClient(environmentName)
+	cleanupEnvironment, err := environmentForCleanupClient(environmentName, environmentUrl)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -46,10 +50,11 @@ func TestAzureBackend(t *testing.T) {
 	logger := logging.NewVaultLogger(log.Debug)
 
 	backend, err := NewAzureBackend(map[string]string{
-		"container":   name,
-		"accountName": accountName,
-		"accountKey":  accountKey,
-		"environment": environmentName,
+		"container":    name,
+		"accountName":  accountName,
+		"accountKey":   accountKey,
+		"environment":  environmentName,
+		"arm_endpoint": environmentUrl,
 	}, logger)
 
 	defer func() {
@@ -75,11 +80,12 @@ func TestAzureBackend_ListPaging(t *testing.T) {
 	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
 	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
 	environmentName := os.Getenv("AZURE_ENVIRONMENT")
+	environmentUrl := os.Getenv("AZURE_ARM_ENDPOINT")
 
 	ts := time.Now().UnixNano()
 	name := fmt.Sprintf("vault-test-%d", ts)
 
-	cleanupEnvironment, err := environmentForCleanupClient(environmentName)
+	cleanupEnvironment, err := environmentForCleanupClient(environmentName, environmentUrl)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -89,10 +95,11 @@ func TestAzureBackend_ListPaging(t *testing.T) {
 	logger := logging.NewVaultLogger(log.Debug)
 
 	backend, err := NewAzureBackend(map[string]string{
-		"container":   name,
-		"accountName": accountName,
-		"accountKey":  accountKey,
-		"environment": environmentName,
+		"container":    name,
+		"accountName":  accountName,
+		"accountKey":   accountKey,
+		"environment":  environmentName,
+		"arm_endpoint": environmentUrl,
 	}, logger)
 
 	defer func() {

--- a/website/source/docs/configuration/storage/azure.html.md
+++ b/website/source/docs/configuration/storage/azure.html.md
@@ -49,6 +49,10 @@ The current implementation is limited to a maximum of 4 megabytes per blob.
    environment the storage account belongs to by way of the case-insensitive
    name defined in the [Azure Go SDK][azure-environment].
 
+- `arm_endpoint` `(string: "")` - Specifies the cloud environment
+  the storage account belongs to by way of the Azure Resource Manager endpoint
+  URL.
+
 - `max_parallel` `(string: "128")` – Specifies The maximum number of concurrent
   requests to Azure.
 


### PR DESCRIPTION
This PR introduces a config parameter to allow specifying the ARM endpoint to use when using the Azure Storage backend to support Azure Stack/sovereign clouds.

