### PR TITLE
Docs: update Transit Secrets Engine Create Key

### DIFF
--- a/website/source/api/secret/transit/index.html.md
+++ b/website/source/api/secret/transit/index.html.md
@@ -66,7 +66,7 @@ values set here cannot be changed after key creation.
 
 ```json
 {
-  "type": "ecdsa-p256",
+  "type": "ed25519",
   "derived": true
 }
 ```


### PR DESCRIPTION
Use a type that supports derivation in sample payload

Current example does not work as-is, and instead results in:

```
{"errors":["1 error occurred:\n\t* key derivation and convergent encryption not supported for keys of type ecdsa-p256\n\n"]}
```