### PR TITLE
Improve Auto Unseal and awskms Seal documentation

### DIFF
--- a/website/source/docs/commands/operator/rekey.html.md
+++ b/website/source/docs/commands/operator/rekey.html.md
@@ -135,7 +135,7 @@ flags](/docs/commands/index.html) included on all commands.
   providing an unseal key. The default is false.
 
 - `-target` `(string: "barrier")` - Target for rekeying. "recovery" only applies
-  when HSM support is enabled.
+  when HSM support is enabled or using `awskms` Seal.
 
 - `-verify` `(bool: false)` - Indicate during the phase `-init` that the
   verification process is activated for the rekey. Along with `-nonce` option

--- a/website/source/docs/concepts/seal.html.md
+++ b/website/source/docs/concepts/seal.html.md
@@ -93,17 +93,19 @@ For a list of examples and supported providers, please see the
 
 The seal can be migrated from Shamir keys to Auto Unseal and vice versa.
 
-  ~> **NOTE**: This is not currently supported when using replication. While
-  the primary can be migrated without issue, the secondaries, depending on
+  ~> **NOTE**: This is not currently supported when using Vault Enterprise Replication.
+  While the primary can be migrated without issue, the secondaries, depending on
   which type of seal is being migrated from/to, may not work correctly. We plan
   to support this officially in a future release.
 
 To migrate from Shamir keys to Auto Unseal, take your server cluster offline and update
 the [seal configuration](/docs/configuration/seal/index.html) with the appropriate seal
-configuration.  When you bring your server back up, run the unseal process with the
-`-migrate` flag.  All unseal commands must specify the `-migrate` flag.  Once the
-required threshold of unseal keys are entered, the unseal keys will be migrated to 
-recovery keys.
+configuration. Bring your server back up and leave the rest of the nodes offline if
+using multi-server mode, then run the unseal process with the `-migrate` flag and bring
+the rest of the cluster online.
+
+All unseal commands must specify the `-migrate` flag. Once the required threshold of
+unseal keys are entered, unseal keys will be migrated to recovery keys.
 
 ```
 $ vault operator unseal -migrate

--- a/website/source/docs/configuration/seal/awskms.html.md
+++ b/website/source/docs/configuration/seal/awskms.html.md
@@ -116,3 +116,11 @@ rotation and manual rotation is supported for KMS since the key information is s
 encrypted data.  Old keys must not be disabled or deleted and are used to decrypt older data. 
 Any new or updated data will be encrypted with the current key defined in the seal configuration
 or set to current under a key alias.
+
+## Recovery Key Rekeying
+
+During the `awskms` Seal initialization process, a set of Shamir keys called Recovery Keys are
+generated which are used for operations that still require a quorum of users.
+
+Recovery Keys can be rekeyed to change the number of shares or thresholds. When using the
+Vault CLI, this is performed by using the `-target=recovery` flag to `vault operator rekey`.


### PR DESCRIPTION
Related to https://github.com/hashicorp/vault/issues/6810#issuecomment-531353771 and https://github.com/hashicorp/vault/issues/6658

When migrating from Shamir keys to Auto Unseal, we hit a few issues like the above which required a bit of trial and error.  We also rekeyed Vault once we migrated to Auto Unseal, and were not clear on how to do this correctly. 

Hoping these updates will be helpful for others migrating from Shamir to Auto Unseal!