### PR TITLE
Docs: Internals: add note about plugin_directory

### DIFF
--- a/website/source/docs/internals/plugins.html.md
+++ b/website/source/docs/internals/plugins.html.md
@@ -33,9 +33,9 @@ share the same memory space as Vault and therefore can only access the
 interfaces and arguments given to it. This also means a crash in a plugin can not
 crash the entirety of Vault.
 
-It is possible to enable a custom plugin with a name that's identical to a 
+It is possible to enable a custom plugin with a name that's identical to a
 built-in plugin. In such a situation, Vault will always choose the custom plugin
-when enabling it. 
+when enabling it.
 
 ## Plugin Communication
 Vault creates a mutually authenticated TLS connection for communication with the
@@ -62,7 +62,8 @@ plugin directory and the plugin catalog entry.
 ### Plugin Directory
 The plugin directory is a configuration option of Vault, and can be specified in
 the [configuration file](https://www.vaultproject.io/docs/configuration/index.html).
-This setting specifies a directory that all plugin binaries must live. A plugin
+This setting specifies a directory in which all plugin binaries must live;
+_this value cannot be a symbolic link_. A plugin
 can not be added to Vault unless it exists in the plugin directory. There is no
 default for this configuration option, and if it is not set plugins can not be
 added to Vault.


### PR DESCRIPTION
- Note that `plugin_directory` value cannot be a symbolic link
- Delete trailing space