### PR TITLE
Docs: Configuration: add note about plugin_directory

### DIFF
--- a/website/source/docs/configuration/index.html.md
+++ b/website/source/docs/configuration/index.html.md
@@ -101,7 +101,7 @@ to specify where the configuration is.
 
 - `plugin_directory` `(string: "")` – A directory from which plugins are
   allowed to be loaded. Vault must have permission to read files in this
-  directory to successfully load plugins.
+  directory to successfully load plugins, and the value cannot be a symbolic link.
 
 - `telemetry` <tt>([Telemetry][telemetry]: &lt;none&gt;)</tt> – Specifies the telemetry
   reporting system.
@@ -112,7 +112,7 @@ to specify where the configuration is.
   parameters). Not all parts of Vault's logging can have its level be changed
   dynamically this way; in particular, secrets/auth plugins are currently not
   updated dynamically. Supported log levels: Trace, Debug, Error, Warn, Info.
-  
+
 - `log_format` `(string: "")` – Specifies the log format to use; overridden by
   CLI and env var parameters. Supported log formats: "standard", "json".
 


### PR DESCRIPTION
- Add note that `plugin_dir` value cannot be a symlink
- Delete trailing spaces