### PR TITLE
UI - namespace fixes

### DIFF
--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -20,7 +20,7 @@ export { TOKEN_SEPARATOR, TOKEN_PREFIX, ROOT_PREFIX };
 
 export default Service.extend({
   permissions: service(),
-  namespace: service(),
+  namespaceService: service(),
   IDLE_TIMEOUT: 3 * 60e3,
   expirationCalcTS: null,
   init() {
@@ -129,7 +129,7 @@ export default Service.extend({
   persistAuthData() {
     let [firstArg, resp] = arguments;
     let tokens = this.get('tokens');
-    let currentNamespace = this.get('namespace.path') || '';
+    let currentNamespace = this.get('namespaceService.path') || '';
     let tokenName;
     let options;
     let backend;
@@ -324,7 +324,11 @@ export default Service.extend({
     const adapter = this.clusterAdapter();
 
     let resp = await adapter.authenticate(options);
-    let authData = await this.persistAuthData(options, resp.auth || resp.data, this.get('namespace.path'));
+    let authData = await this.persistAuthData(
+      options,
+      resp.auth || resp.data,
+      this.get('namespaceService.path')
+    );
     await this.get('permissions').getPaths.perform();
     return authData;
   },

--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -20,7 +20,7 @@ export { TOKEN_SEPARATOR, TOKEN_PREFIX, ROOT_PREFIX };
 
 export default Service.extend({
   permissions: service(),
-  namespaceService: service(),
+  namespaceService: service('namespace'),
   IDLE_TIMEOUT: 3 * 60e3,
   expirationCalcTS: null,
   init() {

--- a/ui/lib/core/addon/components/edit-form.js
+++ b/ui/lib/core/addon/components/edit-form.js
@@ -42,20 +42,21 @@ export default Component.extend({
       }
       return;
     }
-    this.get('flashMessages').success(this.get(messageKey));
+    this.flashMessages.success(this.get(messageKey));
     if (this.callOnSaveAfterRender) {
       next(() => {
-        this.get('onSave')({ saveType: method, model });
+        this.onSave({ saveType: method, model });
       });
       return;
     }
-    yield this.get('onSave')({ saveType: method, model });
+    yield this.onSave({ saveType: method, model });
   })
     .drop()
     .withTestWaiter(),
 
   willDestroy() {
-    let model = this.get('model');
+    let { model } = this;
+    if (!model) return;
     if ((model.get('isDirty') && !model.isDestroyed) || !model.isDestroying) {
       model.rollbackAttributes();
     }


### PR DESCRIPTION
@johncowen noticed a couple of errors when looking at namespaces in Vault - this PR addresses those. Neither are showstoppers, but it's better to have them corrected.

The first is the edit-form doesn't always have a model (as is the case when creating a namespace) so it errors after you create one.

The second issue is we were referring to a service as `namespaceService` in the auth service file, but the injected service was called `namespace`. This wasn't an issue in its current state because the auth service always calls the `ajax` method with `options.namespace`, but we want to correct it here. This PR normalizes the naming to `namespaceService`.