### PR TITLE
Only link to nav items that user has access to

### DIFF
--- a/ui/app/helpers/has-permission.js
+++ b/ui/app/helpers/has-permission.js
@@ -15,9 +15,9 @@ export default Helper.extend({
   ),
 
   compute([route], params) {
-    let { routeParams, capabilities } = params;
+    let { routeParams } = params;
     let permissions = this.permissions;
 
-    return permissions.hasNavPermission(route, routeParams, capabilities);
+    return permissions.hasNavPermission(route, routeParams);
   },
 });

--- a/ui/app/helpers/has-permission.js
+++ b/ui/app/helpers/has-permission.js
@@ -17,9 +17,7 @@ export default Helper.extend({
   compute([route], params) {
     let { routeParams, capabilities } = params;
     let permissions = this.permissions;
-    if (route === 'access') {
-      debugger;
-    }
+
     return permissions.hasNavPermission(route, routeParams, capabilities);
   },
 });

--- a/ui/app/helpers/has-permission.js
+++ b/ui/app/helpers/has-permission.js
@@ -14,8 +14,12 @@ export default Helper.extend({
     }
   ),
 
-  compute([route], { routeParams, capability }) {
+  compute([route], params) {
+    let { routeParams, capabilities } = params;
     let permissions = this.permissions;
-    return permissions.hasNavPermission(route, routeParams, capability);
+    if (route === 'access') {
+      debugger;
+    }
+    return permissions.hasNavPermission(route, routeParams, capabilities);
   },
 });

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -86,11 +86,11 @@ export default Service.extend({
     this.set('canViewAll', null);
   },
 
-  hasNavPermission(navItem, routeParams) {
+  hasNavPermission(navItem, routeParams, capabilities = [null]) {
     if (routeParams) {
-      return this.hasPermission(API_PATHS[navItem][routeParams]);
+      return this.hasPermission(API_PATHS[navItem][routeParams], capabilities);
     }
-    return Object.values(API_PATHS[navItem]).some(path => this.hasPermission(path));
+    return Object.values(API_PATHS[navItem]).some(path => this.hasPermission(path, capabilities));
   },
 
   navPathParams(navItem) {

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -99,11 +99,6 @@ export default Service.extend({
       return path.split('/').lastObject;
     }
 
-    if (navItem === 'access') {
-      // return the route param for the first path they have access to
-      // we will need to do the same thing for policies
-    }
-
     return API_PATHS_TO_ROUTE_PARAMS[path];
   },
 

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -87,11 +87,14 @@ export default Service.extend({
     this.set('canViewAll', null);
   },
 
-  hasNavPermission(navItem, routeParams, capabilities = [null]) {
+  hasNavPermission(navItem, routeParams) {
     if (routeParams) {
-      return this.hasPermission(API_PATHS[navItem][routeParams], capabilities);
+      // viewing the entity and groups pages require the list capability, while the others require the default, which is anything other than deny
+      let capability = routeParams === 'entities' || routeParams === 'groups' ? ['list'] : [null];
+
+      return this.hasPermission(API_PATHS[navItem][routeParams], capability);
     }
-    return Object.values(API_PATHS[navItem]).some(path => this.hasPermission(path, capabilities));
+    return Object.values(API_PATHS[navItem]).some(path => this.hasPermission(path));
   },
 
   navPathParams(navItem) {

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -44,11 +44,12 @@ const API_PATHS_TO_ROUTE_PARAMS = {
 };
 
 /*
-  The Permissions service is used to gate top navigation and sidebar items. It fetches
-  a users' policy from the resultant-acl endpoint and stores their allowed exact and glob
-  paths as state. It also has methods for checking whether a user has permission for a given
-  path.
+  The Permissions service is used to gate top navigation and sidebar items.
+  It fetches a users' policy from the resultant-acl endpoint and stores their
+  allowed exact and glob paths as state. It also has methods for checking whether
+  a user has permission for a given path.
 */
+
 export default Service.extend({
   exactPaths: null,
   globPaths: null,

--- a/ui/app/services/permissions.js
+++ b/ui/app/services/permissions.js
@@ -99,6 +99,11 @@ export default Service.extend({
       return path.split('/').lastObject;
     }
 
+    if (navItem === 'access') {
+      // return the route param for the first path they have access to
+      // we will need to do the same thing for policies
+    }
+
     return API_PATHS_TO_ROUTE_PARAMS[path];
   },
 

--- a/ui/app/templates/vault/cluster/access.hbs
+++ b/ui/app/templates/vault/cluster/access.hbs
@@ -14,7 +14,7 @@
         {{/link-to}}
       </li>
     {{/if}}
-    {{#if (has-permission "access" routeParams="groups")}}
+    {{#if (has-permission "access" routeParams="groups" capabilities=(array "list"))}}
       <li>
         {{#link-to "vault.cluster.access.identity" "groups" data-test-link=true }}
           Groups

--- a/ui/app/templates/vault/cluster/access.hbs
+++ b/ui/app/templates/vault/cluster/access.hbs
@@ -7,7 +7,7 @@
         {{/link-to}}
       </li>
     {{/if}}
-    {{#if (has-permission "access" routeParams="entities")}}
+    {{#if (has-permission "access" routeParams="entities" capabilities=(array "list"))}}
       <li>
         {{#link-to "vault.cluster.access.identity" "entities" data-test-link=true }}
           Entities

--- a/ui/app/templates/vault/cluster/access.hbs
+++ b/ui/app/templates/vault/cluster/access.hbs
@@ -7,14 +7,14 @@
         {{/link-to}}
       </li>
     {{/if}}
-    {{#if (has-permission "access" routeParams="entities" capabilities=(array "list"))}}
+    {{#if (has-permission "access" routeParams="entities")}}
       <li>
         {{#link-to "vault.cluster.access.identity" "entities" data-test-link=true }}
           Entities
         {{/link-to}}
       </li>
     {{/if}}
-    {{#if (has-permission "access" routeParams="groups" capabilities=(array "list"))}}
+    {{#if (has-permission "access" routeParams="groups")}}
       <li>
         {{#link-to "vault.cluster.access.identity" "groups" data-test-link=true }}
           Groups

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -163,18 +163,26 @@ module('Unit | Service | permissions', function(hooks) {
       'sys/auth': {
         capabilities: ['deny'],
       },
-      'sys/leases/lookup': {
-        capabilities: ['read'],
+      'identity/group/id': {
+        capabilities: ['list', 'read'],
       },
     };
     service.set('exactPaths', accessPaths);
-    assert.equal(service.hasNavPermission('access', 'leases'), true);
+    assert.equal(service.hasNavPermission('access', 'groups', ['list', 'read']), true);
   });
 
   test('hasNavPermission returns false if a policy does not include access to any paths', function(assert) {
     let service = this.owner.lookup('service:permissions');
-    service.set('exactPaths', {});
-    assert.equal(service.hasNavPermission('access'), false);
+    const accessPaths = {
+      'sys/auth': {
+        capabilities: ['deny'],
+      },
+      'identity/group/id': {
+        capabilities: ['read'],
+      },
+    };
+    service.set('exactPaths', accessPaths);
+    assert.equal(service.hasNavPermission('access', 'groups', ['list', 'read']), false);
   });
 
   test('appends the namespace to the path if there is one', function(assert) {

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -168,23 +168,10 @@ module('Unit | Service | permissions', function(hooks) {
       },
     };
     service.set('exactPaths', accessPaths);
-    assert.equal(
-      service.hasNavPermission(
-        'access',
-        'groups',
-        ['list', 'read'],
-        'checks permission when multiple capabilities are specified'
-      ),
-      true
-    );
-    assert.equal(
-      service.hasNavPermission('access', 'groups'),
-      true,
-      'checks permission when capabilities are not specified'
-    );
+    assert.equal(service.hasNavPermission('access', 'groups'), true);
   });
 
-  test('hasNavPermission returns false if a policy does not include access to any paths', function(assert) {
+  test('hasNavPermission returns false if a policy does not include the required capabilities for at least one path', function(assert) {
     let service = this.owner.lookup('service:permissions');
     const accessPaths = {
       'sys/auth': {
@@ -195,7 +182,7 @@ module('Unit | Service | permissions', function(hooks) {
       },
     };
     service.set('exactPaths', accessPaths);
-    assert.equal(service.hasNavPermission('access', 'groups', ['list', 'read']), false);
+    assert.equal(service.hasNavPermission('access', 'groups'), false);
   });
 
   test('appends the namespace to the path if there is one', function(assert) {

--- a/ui/tests/unit/services/permissions-test.js
+++ b/ui/tests/unit/services/permissions-test.js
@@ -157,7 +157,7 @@ module('Unit | Service | permissions', function(hooks) {
     assert.deepEqual(service.navPathParams('access'), expected);
   });
 
-  test('hasNavPermission returns true if a policy includes access to at least one path', function(assert) {
+  test('hasNavPermission returns true if a policy includes the required capabilities for at least one path', function(assert) {
     let service = this.owner.lookup('service:permissions');
     const accessPaths = {
       'sys/auth': {
@@ -168,7 +168,20 @@ module('Unit | Service | permissions', function(hooks) {
       },
     };
     service.set('exactPaths', accessPaths);
-    assert.equal(service.hasNavPermission('access', 'groups', ['list', 'read']), true);
+    assert.equal(
+      service.hasNavPermission(
+        'access',
+        'groups',
+        ['list', 'read'],
+        'checks permission when multiple capabilities are specified'
+      ),
+      true
+    );
+    assert.equal(
+      service.hasNavPermission('access', 'groups'),
+      true,
+      'checks permission when capabilities are not specified'
+    );
   });
 
   test('hasNavPermission returns false if a policy does not include access to any paths', function(assert) {


### PR DESCRIPTION
This PR fixes a bug where the top navigation items were linking to pages that users didn't have access to. It was caused by us not actually passing the capabilities from the template through `hasNavPathPermission` down to `hasPermission` (fix [here](https://github.com/hashicorp/vault/pull/7590/files#diff-797e02a83b8884e7a73c23729ae83283R89-R93)). I took the opportunity to refactor the helper so we can check for multiple capabilities as well, as there might be cases where we need to check for both `list` and `read`.

### The Old Behavior
<img width="1179" alt="Screen Shot 2019-10-07 at 5 17 52 PM" src="https://user-images.githubusercontent.com/903288/67531537-f0065a00-f677-11e9-8cec-718ef456f42b.png">

### The New Behavior
![new](https://user-images.githubusercontent.com/903288/67532088-d239f480-f679-11e9-808c-000678535cb0.gif)


### Testing
1. Set up the following [policies and users](https://gist.github.com/noelledaley/569babc2c12c070b51173f27f159413e)
2. Log in as the restricted user. Clicking on 'Access' should take them to the 'Groups' page.
3. Log in as the admin user. Clicking on 'Access' should take them to the 'Entities' page.
