### PR TITLE
don't abort transitions if you're already on that route

### DIFF
--- a/ui/app/mixins/cluster-route.js
+++ b/ui/app/mixins/cluster-route.js
@@ -38,9 +38,6 @@ export default Mixin.create({
       return this.transitionTo(targetRoute);
     }
 
-    if (transition.abort && targetRoute === this.router.currentRouteName) {
-      transition.abort();
-    }
     return RSVP.resolve();
   },
 

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -52,7 +52,7 @@ module('Acceptance | Enterprise | namespaces', function(hooks) {
       await switchToNS(targetNamespace);
     }
     await logout.visit();
-    await authPage.visit({ with: 'token', namespace: '/beep/boop' });
+    await authPage.visit({ namespace: '/beep/boop' });
     await authPage.tokenInput('root').submit();
     await click('[data-test-namespace-toggle]');
     assert.dom('[data-test-current-namespace]').hasText('/beep/boop/', 'current namespace begins with a /');


### PR DESCRIPTION
I added this as an optimization when I was doing the `redirect_to` work. Turns out aborting transitions throws errors which doesn't play well with some of our tests.

This fixes the enterprise CI for ui tests.