### PR TITLE
Makefile: use strict mode bash for SHELL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Set SHELL to 'strict mode' without using .SHELLFLAGS for max compatibility.
+# See https://fieldnotes.tech/how-to-shell-for-compatible-makefiles/
+SHELL := /usr/bin/env bash -euo pipefail -c
+
 # Determine this makefile's path.
 # Be sure to place this BEFORE `include` directives, if any.
 THIS_FILE := $(lastword $(MAKEFILE_LIST))
@@ -111,9 +115,6 @@ ci-lint:
 prep: fmtcheck
 	@sh -c "'$(CURDIR)/scripts/goversioncheck.sh' '$(GO_VERSION_MIN)'"
 	@go generate $(go list ./... | grep -v /vendor/)
-	@# Remove old (now broken) husky git hooks.
-	@[ ! -d .git/hooks ] || grep -l '^# husky$$' .git/hooks/* | xargs rm -f
-	@if [ -d .git/hooks ]; then cp .hooks/* .git/hooks/; fi
 
 .PHONY: ci-config
 ci-config:


### PR DESCRIPTION
### What?
- Setting an explicit `bash` shell for `make` recipes, with `-euo pipefail` so that unset variables and unhandled errors anywhere in a pipeline cause the recipe to fail.
- Previously, errors were silently ignored unless checked for explicitly.

### Why?
- This solves a bug where `make testcompile` exits with 0 when it should fail (the root cause of bug report from @ncabatoff where test compilation failures are being detected very late in the pipeline).
- This specific issue could be solved with explicit failure for that condition, however:
- Having scripts fail hard on any error makes it easier to discover problems like this one sooner.

### What else?
- Also removes some old broken husky hook cleanup code that is (hopefully) no longer needed. Anyone with a very old checkout of master might end up with those hooks being written back into `.git/hooks` and will have to manually remove them. This was an example of broken code discovered by this change.

### Caveats:
- This is a very broad change in the execution of scripts in the `Makefile`
- It could potentially break some things relying on strict POSIX shell
- Since errors are no longer silently swallowed, anything relying on that behaviour will be broken.
- Makes `bash` a requirement of building this repo, when any POSIX shell would have worked before.

Let's see how this fares in ci; it might be worth fixing any other issues we see due to this if there aren't too many.