### PR TITLE
Close cassandra session if we fail to validate it

### DIFF
--- a/plugins/database/cassandra/connection_producer.go
+++ b/plugins/database/cassandra/connection_producer.go
@@ -249,6 +249,7 @@ func (c *cassandraConnectionProducer) createSession(ctx context.Context) (*gocql
 	if c.Consistency != "" {
 		consistencyValue, err := gocql.ParseConsistencyWrapper(c.Consistency)
 		if err != nil {
+			session.Close()
 			return nil, err
 		}
 
@@ -263,9 +264,11 @@ func (c *cassandraConnectionProducer) createSession(ctx context.Context) (*gocql
 		})).Iter().NumRows()
 
 		if rowNum < 1 {
+			session.Close()
 			return nil, errwrap.Wrapf("error validating connection info: No role create permissions found, previous error: {{err}}", err)
 		}
 	} else if err != nil {
+		session.Close()
 		return nil, errwrap.Wrapf("error validating connection info: {{err}}", err)
 	}
 


### PR DESCRIPTION
Currently in the C* database plugin, connection validation errors, as
well as a parsing error, can lead us to return an error and never use an
open gocql session, which may in fact have many open connections. These
connections stay open forever. If you end up in an error loop due to,
for example, a problem with permissions, you will eventually exhaust
file descriptors on the machine.

We simply need to close the session if we aren't going to use it.