### PR TITLE
bug: VAULT_CLUSTER_ADDR not used in raft

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -579,10 +579,20 @@ func (c *ServerCommand) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Unknown storage type %s", config.Storage.Type))
 		return 1
 	}
-	if config.Storage.Type == "raft" && len(config.ClusterAddr) == 0 {
-		c.UI.Error("Cluster address must be set when using raft storage")
-		return 1
+
+
+	if config.Storage.Type == "raft" {
+		if config.ClusterAddr == "" {
+			if envCA := os.Getenv("VAULT_CLUSTER_ADDR"); envCA != "" {
+				config.ClusterAddr = envCA
+			}
+		}
+		if len(config.ClusterAddr) == 0 {
+			c.UI.Error("Cluster address must be set when using raft storage")
+			return 1
+		}
 	}
+
 	namedStorageLogger := c.logger.Named("storage." + config.Storage.Type)
 	allLoggers = append(allLoggers, namedStorageLogger)
 	backend, err := factory(config.Storage.Config, namedStorageLogger)

--- a/command/server.go
+++ b/command/server.go
@@ -582,11 +582,10 @@ func (c *ServerCommand) Run(args []string) int {
 
 
 	if config.Storage.Type == "raft" {
-		if config.ClusterAddr == "" {
-			if envCA := os.Getenv("VAULT_CLUSTER_ADDR"); envCA != "" {
-				config.ClusterAddr = envCA
-			}
+		if envCA := os.Getenv("VAULT_CLUSTER_ADDR"); envCA != "" {
+			config.ClusterAddr = envCA
 		}
+
 		if len(config.ClusterAddr) == 0 {
 			c.UI.Error("Cluster address must be set when using raft storage")
 			return 1


### PR DESCRIPTION
This fixes a bug in Raft where `VAULT_CLUSTER_ADDR` environment variable is ignored.

I'm having difficulty dropping in a test for this as the testing cluster setup hardcodes `https://127.0.0.1:0` into the coreConfig.  If you have any suggestions how I can do this differently, let me know!  In general it seems like we don't really test any environment variables.