### PR TITLE
fixing issue #7288 , so if the last character is newline, it trims it.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -735,6 +735,8 @@ func (c *Client) RawRequest(r *Request) (*Response, error) {
 // that generally won't need to be called externally.
 func (c *Client) RawRequestWithContext(ctx context.Context, r *Request) (*Response, error) {
 	c.modifyLock.RLock()
+	// In some cases, the token may have an extra line character at end, so trim it
+	c.token = strings.TrimSuffix(c.token, "\n")
 	token := c.token
 
 	c.config.modifyLock.RLock()


### PR DESCRIPTION
Fixes #7288 where sometimes Vault returns an error about non-printable characters. This PR removes that issues by trimming the newline character, if it exists.