### PR TITLE
Use a much longer delay before giving up and failing the test.  

### DIFF
--- a/physical/dynamodb/dynamodb_test.go
+++ b/physical/dynamodb/dynamodb_test.go
@@ -225,9 +225,9 @@ func testDynamoDBLockTTL(t *testing.T, ha physical.HABackend) {
 	lock2.ttl = lockTTL
 	lock2.watchRetryInterval = watchInterval
 
-	// Cancel attempt in 6 sec so as not to block unit tests forever
+	// Cancel attempt eventually so as not to block unit tests forever
 	stopCh := make(chan struct{})
-	time.AfterFunc(lockTTL*2, func() {
+	time.AfterFunc(lockTTL*10, func() {
 		close(stopCh)
 	})
 


### PR DESCRIPTION
On circleci we've seen the test run very slowly so it's often failing here.