### PR TITLE
Fix issue with secrets consul docs

### DIFF
--- a/website/source/docs/secrets/consul/index.html.md
+++ b/website/source/docs/secrets/consul/index.html.md
@@ -80,8 +80,8 @@ When users generate credentials, they are generated against this role. For Consu
     ```
 The policy must be base64-encoded. The policy language is [documented by Consul](https://www.consul.io/docs/internals/acl.html).
 
-For Consul versions 1.4 and above, [generate a policy in Consul](https://www.consul.io/docs/guides/acl.html), and proceed to link it 
-to the role:
+For Consul versions 1.4 and above, [generate a policy in Consul](https://www.consul.io/docs/guides/acl.html), and proceed to link it to the role:
+
     ```text
     $ vault write consul/roles/my-role policies=readonly
     Success! Data written to: consul/roles/my-role


### PR DESCRIPTION
Currently command is not formatted properly due to new line character causing no gap between code block, see image:

![Screenshot 2019-10-15 at 14 53 52](https://user-images.githubusercontent.com/10371667/66837907-b2a91a80-ef5b-11e9-9668-afbc54232cfa.png)
