### PR TITLE
Misc Documentation Fixes

### DIFF
--- a/website/source/api/auth/aws/index.html.md.erb
+++ b/website/source/api/auth/aws/index.html.md.erb
@@ -158,7 +158,7 @@ This configures the way that Vault interacts with the
   Vault won't be aware and any identity aliases set up for the role name will
   still be valid.
 
-- `ec2_alias (string: "role_id")` - Configures how to generate the identity
+- `ec2_alias` `(string: "role_id")` - Configures how to generate the identity
   alias when using the `ec2` auth method. Valid choices are `role_id`,
   `instance_id`, and `image_id`. When `role_id` is selected, the randomly
   generated ID of the role is used. When `instance_id` is selected, the

--- a/website/source/api/auth/github/index.html.md.erb
+++ b/website/source/api/auth/github/index.html.md.erb
@@ -97,7 +97,7 @@ Map a list of policies to a team that exists in the configured GitHub organizati
 
 ### Parameters
 
-- `key` `(string)` - GitHub team name in "slugified" format
+- `team_name` `(string)` - GitHub team name in "slugified" format
 - `value` `(string)` - Comma separated list of policies to assign
 
 ### Sample Payload
@@ -164,7 +164,7 @@ organization.
 
 ### Parameters
 
-- `key` `(string)` - GitHub user name
+- `user_name` `(string)` - GitHub user name
 - `value` `(string)` - Comma separated list of policies to assign
 
 ### Sample Payload

--- a/website/source/api/auth/ldap/index.html.md.erb
+++ b/website/source/api/auth/ldap/index.html.md.erb
@@ -52,7 +52,7 @@ This endpoint configures the LDAP auth method.
   user search.
 - `userdn` `(string: "")` – Base DN under which to perform user search. Example:
   `ou=Users,dc=example,dc=com`
-- `userattr` `(string: "")` – Attribute on user attribute object matching the
+- `userattr` `(string: "cn")` – Attribute on user attribute object matching the
   username passed when authenticating. Examples: `sAMAccountName`, `cn`, `uid`
 - `discoverdn` `(bool: false)` – Use anonymous bind to discover the bind DN of a
   user.

--- a/website/source/api/auth/ldap/index.html.md.erb
+++ b/website/source/api/auth/ldap/index.html.md.erb
@@ -27,7 +27,7 @@ This endpoint configures the LDAP auth method.
 
 ### Parameters
 
-- `url` `(string: <required>)` – The LDAP server to connect to. Examples:
+- `url` `(string: ldap://127.0.0.1)` – The LDAP server to connect to. Examples:
   `ldap://ldap.myorg.com`, `ldaps://ldap.myorg.com:636`. Multiple URLs can be
   specified with commas, e.g. `ldap://ldap.myorg.com,ldap://ldap2.myorg.com`;
   these will be tried in-order.

--- a/website/source/api/secret/ad/index.html.md
+++ b/website/source/api/secret/ad/index.html.md
@@ -34,7 +34,7 @@ text that fulfills those requirements. `{{PASSWORD}}` must appear exactly once a
 
 ### Connection parameters
 
-* `url` (string, required) - The LDAP server to connect to. Examples: `ldaps://ldap.myorg.com`, `ldaps://ldap.myorg.com:636`. This can also be a comma-delineated list of URLs, e.g. `ldaps://ldap.myorg.com,ldaps://ldap.myorg.com:636`, in which case the servers will be tried in-order if there are errors during the connection process.
+* `url` (string, optional) - The LDAP server to connect to. Examples: `ldaps://ldap.myorg.com`, `ldaps://ldap.myorg.com:636`. This can also be a comma-delineated list of URLs, e.g. `ldaps://ldap.myorg.com,ldaps://ldap.myorg.com:636`, in which case the servers will be tried in-order if there are errors during the connection process.  Default is `ldap://127.0.0.1`.
 * `starttls` (bool, optional) - If true, issues a `StartTLS` command after establishing an unencrypted connection.
 * `insecure_tls` - (bool, optional) - If true, skips LDAP server SSL certificate verification - insecure, use with caution!
 * `certificate` - (string, optional) - CA certificate to use when verifying LDAP server certificate, must be x509 PEM encoded.


### PR DESCRIPTION
This contains fixes for some issues I ran into while reading through the API.

The LDAP authentication `config` endpoint `userattr` parameter actually has a default value of "cn" and the `url` parameter isn't actually required because it has a default of "ldap://127.0.0.1".  Both of these have their default values defined in ldaputil: https://github.com/hashicorp/vault/blob/e6e844d6b5e8625133ed259cc7e9d178e7a2d6d4/sdk/helper/ldaputil/config.go

The other changes are typos and formatting issues.