### PR TITLE
Backport 1.2.4: core: add hook for initializing seals for migration

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1912,6 +1912,7 @@ func (c *Core) SetSealsForMigration(migrationSeal, newSeal, unwrapSeal Seal) {
 		c.seal = newSeal
 		c.seal.SetCore(c)
 		c.logger.Warn("entering seal migration mode; Vault will not automatically unseal even if using an autoseal", "from_barrier_type", c.migrationSeal.BarrierType(), "to_barrier_type", c.seal.BarrierType())
+		c.initSealsForMigration()
 	}
 }
 

--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -116,3 +116,5 @@ func (c *Core) removeAllPerfStandbySecondaries() {}
 func (c *Core) perfStandbyClusterHandler() (*replication.Cluster, *cache.Cache, chan struct{}, error) {
 	return nil, cache.New(2*cluster.HeartbeatInterval, 1*time.Second), make(chan struct{}), nil
 }
+
+func (c *Core) initSealsForMigration() {}


### PR DESCRIPTION
Backport of #7666 