### PR TITLE
website: bump consent manager version

### DIFF
--- a/website/assets/package-lock.json
+++ b/website/assets/package-lock.json
@@ -139,9 +139,9 @@
       "integrity": "sha512-sFcVJyW6SYGVxzTH55FWzvYKqv13Ten+BGFclr6lO4XpvnQpewP75BkLhnIq7lVf0gpFtOjo5kC3qmpyRJVLeQ=="
     },
     "@hashicorp/hashi-consent-manager": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@hashicorp/hashi-consent-manager/-/hashi-consent-manager-1.0.8.tgz",
-      "integrity": "sha512-1r9CvBk4JeAs5H8FBaKrTANE8meYs3s73h/4iGCba0fPR3wJaikUq3swFWrGAOtAJs8IxvCX2Gm0rPlOK7qZaA=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@hashicorp/hashi-consent-manager/-/hashi-consent-manager-1.0.10.tgz",
+      "integrity": "sha512-T3njOQOB8M8b4TGzDpfEtd05jdiprlQSzGYCe72dYcJDdgu0iUAmpx50b7dL09gGlUuxPI6wYCRff+ZQzLfFPQ=="
     },
     "@hashicorp/hashi-content": {
       "version": "0.1.0",
@@ -154,9 +154,9 @@
       "integrity": "sha512-DDaKSfAnMKOreNWLnNIsVYfE1zfdCu07We1zuY0VN1KKlNSMp3tLdnjCMXrWU+6iKTzBJh6s8xQQV8KepI8MMA=="
     },
     "@hashicorp/hashi-docs-sitemap": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@hashicorp/hashi-docs-sitemap/-/hashi-docs-sitemap-0.1.5.tgz",
-      "integrity": "sha512-BM+PPASQ1ceysc1Q4kg7RF5pGNw9xxhTpS/SxeeMFjM9usfbGCoNp/qXiTrf2bk9v9H9JcIYAtofHuzpRadaFA=="
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@hashicorp/hashi-docs-sitemap/-/hashi-docs-sitemap-0.1.6.tgz",
+      "integrity": "sha512-jrRZ1Hq4TQXSptt45vEn4ZtOZC7iyQt9Abnif6iltLpPDJIqV/yl9wB7HLODI0Thw5SThIU6AABX0bLEwxuGJA=="
     },
     "@hashicorp/hashi-footer": {
       "version": "1.5.3",

--- a/website/assets/package.json
+++ b/website/assets/package.json
@@ -10,7 +10,7 @@
     "@hashicorp/hashi-alert": "^1.1.0",
     "@hashicorp/hashi-button": "1.0.5",
     "@hashicorp/hashi-callouts": "^2.0.5",
-    "@hashicorp/hashi-consent-manager": "^1.0.8",
+    "@hashicorp/hashi-consent-manager": "^1.0.10",
     "@hashicorp/hashi-content": "^0.1.0",
     "@hashicorp/hashi-docs-sidenav": "^1.0.2",
     "@hashicorp/hashi-docs-sitemap": "^0.1.6",


### PR DESCRIPTION
A bug in our consent manager component was preventing a marketing script (opt-in monster) from loading properly. The product marketing team uses that service for lead gen campaigns.

See this (private) [Asana task](https://app.asana.com/0/346384260719996/1144755624118048/f) for details and context.