### PR TITLE
Create .bundle and set group when running container

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -1,5 +1,5 @@
 configure-cache:
-	@mkdir -p tmp/cache
+	@mkdir -p tmp/cache .bundle
 
 build: configure-cache
 	@echo "==> Starting build in Docker..."
@@ -9,6 +9,7 @@ build: configure-cache
 		--tty \
 		--volume "$(shell pwd):/opt/buildhome/repo" \
 		--volume "$(shell pwd)/tmp/cache:/opt/buildhome/cache" \
+		--user buildbot:$(shell id -g) \
 		--env "ENV=production" \
 		netlify/build \
 		build "sh bootstrap.sh && middleman build --verbose"
@@ -21,6 +22,7 @@ website: configure-cache
 		--tty \
 		--volume "$(shell pwd):/opt/buildhome/repo" \
 		--volume "$(shell pwd)/tmp/cache:/opt/buildhome/cache" \
+		--user buildbot:$(shell id -g) \
 		--publish "4567:4567" \
 		--publish "35729:35729" \
 		--env "ENV=production" \


### PR DESCRIPTION
If this is not set, `make website` fails due to permission errors in the docker container
Fixes #5589. 

Side note: it takes **a lot** to build and run the application. I believe several stuff could be improved here, starting with the fact that the `netlify` image is about 4gb which seems completely unnecessary.