### PR TITLE
Show versions that are active when delete_version_after is configured

### DIFF
--- a/ui/app/models/secret-v2-version.js
+++ b/ui/app/models/secret-v2-version.js
@@ -1,6 +1,6 @@
 import Secret from './secret';
 import DS from 'ember-data';
-import { bool } from '@ember/object/computed';
+import { computed } from '@ember/object';
 
 const { attr, belongsTo } = DS;
 
@@ -12,7 +12,11 @@ export default Secret.extend({
   path: attr('string'),
   deletionTime: attr('string'),
   createdTime: attr('string'),
-  deleted: bool('deletionTime'),
+  deleted: computed('deletionTime', function() {
+    const deletionTime = new Date(this.get('deletionTime'));
+    const now = new Date();
+    return deletionTime <= now;
+  }),
   destroyed: attr('boolean'),
   currentVersion: attr('number'),
 });

--- a/ui/tests/unit/models/secret-v2-version-test.js
+++ b/ui/tests/unit/models/secret-v2-version-test.js
@@ -1,0 +1,31 @@
+import { run } from '@ember/runloop';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | secret-v2-version', function(hooks) {
+  setupTest(hooks);
+
+  test('deleted is true for a past deletionTime', function(assert) {
+    let model;
+    run(() => {
+      model = run(() =>
+        this.owner.lookup('service:store').createRecord('secret-v2-version', {
+          deletionTime: '2000-10-14T00:00:00.000000Z',
+        })
+      );
+      assert.equal(model.get('deleted'), true);
+    });
+  });
+
+  test('deleted is false for a future deletionTime', function(assert) {
+    let model;
+    run(() => {
+      model = run(() =>
+        this.owner.lookup('service:store').createRecord('secret-v2-version', {
+          deletionTime: '2999-10-14T00:00:00.000000Z',
+        })
+      );
+      assert.equal(model.get('deleted'), false);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #7644 

Computed properties in Vault UI take the delta between `now` and `deletion_time` into consideration.