### PR TITLE
Fixing a typo with the sample payload

### DIFF
--- a/website/source/api/secret/rabbitmq/index.html.md
+++ b/website/source/api/secret/rabbitmq/index.html.md
@@ -116,7 +116,7 @@ This endpoint creates or updates the role definition.
 ```json
 {
   "tags": "tag1,tag2",
-  "vhost": "{\"/\": {\"configure\":\".*\", \"write\":\".*\", \"read\": \".*\"}}"
+  "vhosts": "{\"/\": {\"configure\":\".*\", \"write\":\".*\", \"read\": \".*\"}}"
 }
 ```
 


### PR DESCRIPTION
This typo is related to  https://github.com/hashicorp/vault/issues/7603 .  The typo was causing issues with getting this working correctly when following the guide.  I imagine any other newbie to this plugin will have the same struggle.  I had to delve into the source code to figure out that the parameter required is "vhosts" and not "vhost" as the docs currently