### PR TITLE
Move from allowing vault keys of 512 to 1024

### DIFF
--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -112,7 +112,7 @@ func NewMySQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 	// Create the required table if it doesn't exists.
 	if !tableExist {
 		create_query := "CREATE TABLE IF NOT EXISTS " + dbTable +
-			" (vault_key varbinary(512), vault_value mediumblob, PRIMARY KEY (vault_key))"
+			" (vault_key varbinary(1024), vault_value mediumblob, PRIMARY KEY (vault_key))"
 		if _, err := db.Exec(create_query); err != nil {
 			return nil, errwrap.Wrapf("failed to create mysql table: {{err}}", err)
 		}


### PR DESCRIPTION
We ran into issues with people going over the 512 key length limit in production. We modified the table to be 1024 which seems like a reasonably long key length to allow for now.