### PR TITLE
Fix a nil map pointer in mergeEntity.

### DIFF
--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/vault/helper/identity"
+	"github.com/hashicorp/vault/helper/identity/mfa"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/storagepacker"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -649,6 +650,9 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 			if ok && !force {
 				return nil, fmt.Errorf("conflicting MFA config ID %q in entity ID %q", configID, fromEntity.ID)
 			} else {
+				if toEntity.MFASecrets == nil {
+					toEntity.MFASecrets = make(map[string]*mfa.Secret)
+				}
 				toEntity.MFASecrets[configID] = configSecret
 			}
 		}


### PR DESCRIPTION
This was observed to cause a panic during startup in 1.1.3:

```
 panic: assignment to entry in nil map
 goroutine 116 [running]:
 github.com/hashicorp/vault/vault.(*IdentityStore).mergeEntity(0xc0052aa180, 0x30ebac0, 0xc006b08360, 0xc006b04600, 0xc006af7d40, 0xc006a3f978, 0x1, 0x1, 0x10001, 0x0, ...)
 /gopath/src/github.com/hashicorp/vault/vault/identity_store_entities.go:650 +0x23d
 github.com/hashicorp/vault/vault.(*IdentityStore).upsertEntityInTxn(0xc0052aa180, 0x30ebac0, 0xc006b08360, 0xc006b04600, 0xc006af7d40, 0x0, 0x27f2200, 0x0, 0x0)
 /gopath/src/github.com/hashicorp/vault/vault/identity_store_util.go:380 +0x9ab
 github.com/hashicorp/vault/vault.(*IdentityStore).upsertEntity(0xc0052aa180, 0x30ebac0, 0xc006b08360, 0xc006af7d40, 0x0, 0x4fcc400, 0x0, 0x0)
 /gopath/src/github.com/hashicorp/vault/vault/identity_store_util.go:470 +0xbc
 github.com/hashicorp/vault/vault.(*IdentityStore).loadEntities(0xc0052aa180, 0x30eba00, 0xc000cdc0c0, 0x40c238, 0x20)
 /gopath/src/github.com/hashicorp/vault/vault/identity_store_util.go:307 +0x774
 github.com/hashicorp/vault/vault.(*Core).loadIdentityStoreArtifacts.func1(0x30eba00, 0xc000cdc0c0, 0xc0029df240, 0xc0057d42c0)
 /gopath/src/github.com/hashicorp/vault/vault/identity_store_util.go:38 +0x56
 github.com/hashicorp/vault/vault.(*Core).loadIdentityStoreArtifacts(0xc0004a8000, 0x30eba00, 0xc000cdc0c0, 0x0, 0x0)
 /gopath/src/github.com/hashicorp/vault/vault/identity_store_util.go:47 +0x17f
 github.com/hashicorp/vault/vault.standardUnsealStrategy.unseal(0x30eba00, 0xc000cdc0c0, 0x3105fe0, 0xc00008efc0, 0xc0004a8000, 0x0, 0x0)
 /gopath/src/github.com/hashicorp/vault/vault/core.go:1499 +0x59f
 github.com/hashicorp/vault/vault.(*Core).postUnseal(0xc0004a8000, 0x30eba00, 0xc000cdc0c0, 0xc000a09e80, 0x30cbd20, 0x5017ce8, 0x0, 0x0)
 /gopath/src/github.com/hashicorp/vault/vault/core.go:1561 +0x2fc
 github.com/hashicorp/vault/vault.(*Core).waitForLeadership(0xc0004a8000, 0xc0006f9500, 0xc000604de0, 0xc00007c540)
 /gopath/src/github.com/hashicorp/vault/vault/ha.go:518 +0xaa3
 github.com/hashicorp/vault/vault.(*Core).runStandby.func7(0xc00058cfaf, 0xc0002128c0)
 /gopath/src/github.com/hashicorp/vault/vault/ha.go:371 +0x45
 github.com/hashicorp/vault/vendor/github.com/oklog/run.(*Group).Run.func1(0xc0006f9560, 0xc00065df50, 0xc00000ae00)
 /gopath/src/github.com/hashicorp/vault/vendor/github.com/oklog/run/group.go:38 +0x27
 created by github.com/hashicorp/vault/vendor/github.com/oklog/run.(*Group).Run
 /gopath/src/github.com/hashicorp/vault/vendor/github.com/oklog/run/group.go:37 +0xbe
```