### PR TITLE
Mark secret version as deleted in history dropdown

### DIFF
--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -78,7 +78,7 @@
               <li class="action">
                 <LinkTo class="link" @params={{array (query-params version=secretVersion.version)}} @invokeAction={{action D.actions.close}} >
                   Version {{secretVersion.version}}
-                  {{#if (eq secretVersion.version this.model.currentVersion)}}
+                  {{#if (and (eq secretVersion.version this.model.currentVersion) (not secretVersion.deleted))}}
                     <Icon @glyph="check-circle-outline" class="has-text-success is-pulled-right" />
                   {{else if secretVersion.deleted}}
                     <Icon @glyph="cancel-square-outline" class="has-text-grey is-pulled-right" />


### PR DESCRIPTION
This PR is a small UX improvement -- it ensures that a deleted secret version is marked as deleted in the history dropdown even when it is the currently active version.

![version-fix](https://user-images.githubusercontent.com/903288/67339577-59ebfb80-f4e0-11e9-94d0-433bfa4d985e.gif)

Follow up to https://github.com/hashicorp/vault/pull/7685 which fixes https://github.com/hashicorp/vault/issues/7644