### PR TITLE
update yarn to 1.19.1

### DIFF
--- a/scripts/cross/Dockerfile
+++ b/scripts/cross/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-RUN apt-get update -y && apt-get install -y -q nodejs yarn=1.17.3
+RUN apt-get update -y && apt-get install -y -q nodejs yarn=1.19.1
 
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -156,7 +156,7 @@
   },
   "engines": {
     "node": " >= 10.* <11",
-    "yarn": "1.17.3"
+    "yarn": "1.19.1"
   },
   "private": true,
   "ember-addon": {


### PR DESCRIPTION
We were seeing build failures due to 1.17.3 no longer being in updated distro packages. This updates the version we rely on so that tests and builds work again.