### PR TITLE
Allow Raft storage to be configured via env variables

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/armon/go-metrics"
 	"io"
 	"io/ioutil"
 	"os"
@@ -13,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -32,6 +32,9 @@ import (
 // EnvVaultRaftNodeID is used to fetch the Raft node ID from the environment.
 const EnvVaultRaftNodeID = "VAULT_RAFT_NODE_ID"
 
+// EnvVaultRaftPath is used to fetch the path where Raft data is stored from the environment.
+const EnvVaultRaftPath = "VAULT_RAFT_PATH"
+
 // Verify RaftBackend satisfies the correct interfaces
 var _ physical.Backend = (*RaftBackend)(nil)
 var _ physical.Transactional = (*RaftBackend)(nil)
@@ -121,7 +124,11 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 
 	path, ok := conf["path"]
 	if !ok {
-		return nil, fmt.Errorf("'path' must be set")
+		if pathFromEnv := os.Getenv(EnvVaultRaftPath); pathFromEnv != "" {
+			path = pathFromEnv
+		} else {
+			return nil, fmt.Errorf("'path' must be set")
+		}
 	}
 
 	// Build an all in-memory setup for dev mode, otherwise prepare a full

--- a/website/source/docs/configuration/storage/raft.html.md
+++ b/website/source/docs/configuration/storage/raft.html.md
@@ -44,6 +44,7 @@ cluster_addr = "http://127.0.0.1:8201"
 
 - `path` `(string: "")` – The file system path where all the Vault data gets
   stored.
+  This value can be overridden by setting the `VAULT_RAFT_PATH` environment variable.
 
 - `node_id` `(string: "")` - The identifier for the node in the Raft cluster.
   This value can be overridden by setting the `VAULT_RAFT_NODE_ID` environment variable.

--- a/website/source/docs/configuration/storage/raft.html.md
+++ b/website/source/docs/configuration/storage/raft.html.md
@@ -46,5 +46,6 @@ cluster_addr = "http://127.0.0.1:8201"
   stored.
 
 - `node_id` `(string: "")` - The identifier for the node in the Raft cluster.
+  This value can be overridden by setting the `VAULT_RAFT_NODE_ID` environment variable.
 
 [raft]: https://raft.github.io/ "The Raft Consensus Algorithm"


### PR DESCRIPTION
This allows some parts of the Raft storage engine configuration to be fetched from the environment.

Mainly that's the path where data is stored as well as the Raft node ID assigned. The usecase of both additions is configuring both of these when running in a StatefulSet on Kubernetes.