### PR TITLE
If standbyok/perfstandbyok are provided to sys/health, honor the values

### DIFF
--- a/http/sys_health.go
+++ b/http/sys_health.go
@@ -8,7 +8,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/sdk/helper/parseutil"
 	"github.com/hashicorp/vault/sdk/version"
 	"github.com/hashicorp/vault/vault"
 )
@@ -43,7 +45,7 @@ func handleSysHealthGet(core *vault.Core, w http.ResponseWriter, r *http.Request
 	code, body, err := getSysHealth(core, r)
 	if err != nil {
 		core.Logger().Error("error checking health", "error", err)
-		respondError(w, http.StatusInternalServerError, nil)
+		respondError(w, code, nil)
 		return
 	}
 
@@ -62,9 +64,6 @@ func handleSysHealthGet(core *vault.Core, w http.ResponseWriter, r *http.Request
 
 func handleSysHealthHead(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 	code, body, err := getSysHealth(core, r)
-	if err != nil {
-		code = http.StatusInternalServerError
-	}
 
 	if body != nil {
 		w.Header().Set("Content-Type", "application/json")
@@ -73,9 +72,23 @@ func handleSysHealthHead(core *vault.Core, w http.ResponseWriter, r *http.Reques
 }
 
 func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, error) {
+	var err error
+
 	// Check if being a standby is allowed for the purpose of a 200 OK
-	_, standbyOK := r.URL.Query()["standbyok"]
-	_, perfStandbyOK := r.URL.Query()["perfstandbyok"]
+	standbyOKStr, standbyOK := r.URL.Query()["standbyok"]
+	if standbyOK {
+		standbyOK, err = parseutil.ParseBool(standbyOKStr[0])
+		if err != nil {
+			return http.StatusBadRequest, nil, errwrap.Wrapf("bad value for standbyok parameter: {{err}}", err)
+		}
+	}
+	perfStandbyOKStr, perfStandbyOK := r.URL.Query()["perfstandbyok"]
+	if perfStandbyOK {
+		perfStandbyOK, err = parseutil.ParseBool(perfStandbyOKStr[0])
+		if err != nil {
+			return http.StatusBadRequest, nil, errwrap.Wrapf("bad value for perfstandbyok parameter: {{err}}", err)
+		}
+	}
 
 	uninitCode := http.StatusNotImplemented
 	if code, found, ok := fetchStatusCode(r, "uninitcode"); !ok {


### PR DESCRIPTION
Don't just use the presence of it to indicate behavior.

Fixes #7323

Also, fixes a bug where if an error was returned along with a status
code, the status code was being ignored.