### PR TITLE
Fix incorrect env vars example

### DIFF
--- a/website/source/docs/platform/k8s/helm.html.md
+++ b/website/source/docs/platform/k8s/helm.html.md
@@ -96,9 +96,9 @@ and consider if they're appropriate for your deployment.
     ```yaml
     # Extra Environment Variables are defined as key/value strings.
      extraEnvironmentVars:
-       GOOGLE_REGION: global,
-       GOOGLE_PROJECT: myproject,
-       GOOGLE_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
+       GOOGLE_REGION: global
+       GOOGLE_PROJECT: myproject
+       GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
     ```
 
   * `extraSecretEnvironmentVars` (`string: null`) - The extra environment variables populated from a secret to be applied to the Vault server.  This should be a multi-line key/value string.


### PR DESCRIPTION
Bring k8s Helm docs up to date with the fixed commented examples in the `values.yml`

https://github.com/hashicorp/vault-helm/pull/101