### PR TITLE
Use the Leader API endpoint instead of the internal Standby method, so

### DIFF
--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -274,7 +274,8 @@ func WaitForActiveNode(t testing.T, cluster *vault.TestCluster) *vault.TestClust
 	t.Helper()
 	for i := 0; i < 30; i++ {
 		for _, core := range cluster.Cores {
-			if standby, _ := core.Core.Standby(); !standby {
+			leaderResp, err := core.Client.Sys().Leader()
+			if err == nil && leaderResp.IsSelf {
 				return core
 			}
 		}

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -422,8 +422,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Backward(t *testing.T) {
 
 			cluster.BarrierKeys = barrierKeys
 			testhelpers.EnsureCoresUnsealed(t, cluster)
-			testhelpers.WaitForActiveNode(t, cluster)
-			activeCore := testhelpers.DeriveActiveCore(t, cluster)
+			activeCore := testhelpers.WaitForActiveNode(t, cluster)
 
 			// Read the value.
 			data, err := activeCore.Client.Logical().Read("secret/foo")
@@ -625,8 +624,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 
 				cluster.BarrierKeys = newBarrierKeys
 				testhelpers.EnsureCoresUnsealed(t, cluster)
-				testhelpers.WaitForActiveNode(t, cluster)
-				activeCore := testhelpers.DeriveActiveCore(t, cluster)
+				activeCore := testhelpers.WaitForActiveNode(t, cluster)
 
 				// Read the value.
 				data, err := activeCore.Client.Logical().Read("secret/foo")


### PR DESCRIPTION
we're not fooled by Core.standby being false during startup.  Fixes intermittent test failures in TestRaft_SnapshotAPI_RekeyRotate_Backward, e.g. https://circleci.com/gh/hashicorp/vault/23549.