### PR TITLE
Add `token` ACL templating support

### DIFF
--- a/helper/identity/templating.go
+++ b/helper/identity/templating.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/vault/sdk/logical"
 	"strconv"
 	"strings"
 	"time"
@@ -27,6 +28,7 @@ const (
 type PopulateStringInput struct {
 	String            string
 	ValidityCheckOnly bool
+	Token             *logical.TokenEntry
 	Entity            *Entity
 	Groups            []*Group
 	Namespace         *namespace.Namespace
@@ -338,6 +340,22 @@ func performTemplating(input string, p *PopulateStringInput) (string, error) {
 		return strconv.FormatInt(result.Unix(), 10), nil
 	}
 
+	performTokenTemplating := func(trimmed string) (string, error) {
+		switch {
+		case trimmed == "display_name":
+			return p.templateHandler(p.Token.DisplayName)
+
+		case trimmed == "metadata":
+			return p.templateHandler(p.Token.Meta)
+
+		case strings.HasPrefix(trimmed, "metadata."):
+			split := strings.SplitN(trimmed, ".", 2)
+			return p.templateHandler(p.Token.Meta, split[1])
+		}
+
+		return "", ErrTemplateValueNotFound
+	}
+
 	switch {
 	case strings.HasPrefix(input, "identity.entity."):
 		if p.Entity == nil {
@@ -353,6 +371,9 @@ func performTemplating(input string, p *PopulateStringInput) (string, error) {
 
 	case strings.HasPrefix(input, "time."):
 		return performTimeTemplating(strings.TrimPrefix(input, "time."))
+
+	case strings.HasPrefix(input, "token."):
+		return performTokenTemplating(strings.TrimPrefix(input, "token."))
 	}
 
 	return "", ErrTemplateValueNotFound

--- a/vault/capabilities.go
+++ b/vault/capabilities.go
@@ -65,7 +65,7 @@ func (c *Core) Capabilities(ctx context.Context, token, path string) ([]string, 
 	// Construct the corresponding ACL object. ACL construction should be
 	// performed on the token's namespace.
 	tokenCtx := namespace.ContextWithNamespace(ctx, tokenNS)
-	acl, err := c.policyStore.ACL(tokenCtx, entity, policyNames)
+	acl, err := c.policyStore.ACL(tokenCtx, te, entity, policyNames)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -102,7 +102,7 @@ func (e extendedSystemViewImpl) SudoPrivilege(ctx context.Context, path string, 
 
 	// Construct the corresponding ACL object. Derive and use a new context that
 	// uses the req.ClientToken's namespace
-	acl, err := e.core.policyStore.ACL(tokenCtx, entity, policies)
+	acl, err := e.core.policyStore.ACL(tokenCtx, te, entity, policies)
 	if err != nil {
 		e.core.logger.Error("failed to retrieve ACL for token's policies", "token_policies", te.Policies, "error", err)
 		return false

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -750,7 +750,7 @@ func (t *TemplateError) Error() string {
 
 // ACL is used to return an ACL which is built using the
 // named policies.
-func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string) (*ACL, error) {
+func (ps *PolicyStore) ACL(ctx context.Context, token *logical.TokenEntry, entity *identity.Entity, policyNames map[string][]string) (*ACL, error) {
 	var policies []*Policy
 	// Fetch the policies
 	for nsID, nsPolicyNames := range policyNames {
@@ -787,7 +787,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 					groups = append(directGroups, inheritedGroups...)
 				}
 			}
-			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, entity, groups)
+			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, token, entity, groups)
 			if err != nil {
 				return nil, errwrap.Wrapf(fmt.Sprintf("error parsing templated policy %q: {{err}}", policy.Name), err)
 			}

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -293,7 +293,7 @@ func testPolicyStoreACL(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) 
 	}
 
 	ctx = namespace.ContextWithNamespace(context.Background(), ns)
-	acl, err := ps.ACL(ctx, nil, map[string][]string{ns.ID: []string{"dev", "ops"}})
+	acl, err := ps.ACL(ctx, nil, nil, map[string][]string{ns.ID: []string{"dev", "ops"}})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -215,7 +215,7 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 
 	// Construct the corresponding ACL object. ACL construction should be
 	// performed on the token's namespace.
-	acl, err := c.policyStore.ACL(tokenCtx, entity, policies)
+	acl, err := c.policyStore.ACL(tokenCtx, te, entity, policies)
 	if err != nil {
 		if errwrap.ContainsType(err, new(TemplateError)) {
 			c.logger.Warn("permission denied due to a templated policy being invalid or containing directives not satisfied by the requestor", "error", err)


### PR DESCRIPTION
Adds the ability to target `token.display_name` and `token.metadata.*` in policy templates