### PR TITLE
doc: remove comma from list.html.md

### DIFF
--- a/website/source/docs/commands/list.html.md
+++ b/website/source/docs/commands/list.html.md
@@ -11,7 +11,7 @@ description: |-
 # list
 
 The `list` command lists data from Vault at the given path. This can be used to
-list keys in a, given secrets engine.
+list keys in a given secrets engine.
 
 ## Examples
 


### PR DESCRIPTION
Noticed a tiny typo in the docs. Removed a comma from https://www.vaultproject.io/docs/commands/list.html