### PR TITLE
vault: Remove Dead Test Code

### DIFF
--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -5,10 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/namespace"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func mockPolicyWithCore(t *testing.T, disableCache bool) (*Core, *PolicyStore) {

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -11,16 +11,6 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func mockPolicyStore(t *testing.T) *PolicyStore {
-	_, barrier, _ := mockBarrier(t)
-	view := NewBarrierView(barrier, "foo/")
-	p, err := NewPolicyStore(context.Background(), nil, view, logical.TestSystemView(), logging.NewVaultLogger(log.Trace))
-	if err != nil {
-		t.Fatal(err)
-	}
-	return p
-}
-
 func mockPolicyWithCore(t *testing.T, disableCache bool) (*Core, *PolicyStore) {
 	conf := &CoreConfig{
 		DisableCache: disableCache,

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -21,18 +21,6 @@ func mockPolicyStore(t *testing.T) *PolicyStore {
 	return p
 }
 
-func mockPolicyStoreNoCache(t *testing.T) *PolicyStore {
-	sysView := logical.TestSystemView()
-	sysView.CachingDisabledVal = true
-	_, barrier, _ := mockBarrier(t)
-	view := NewBarrierView(barrier, "foo/")
-	p, err := NewPolicyStore(context.Background(), nil, view, sysView, logging.NewVaultLogger(log.Trace))
-	if err != nil {
-		t.Fatal(err)
-	}
-	return p
-}
-
 func mockPolicyWithCore(t *testing.T, disableCache bool) (*Core, *PolicyStore) {
 	conf := &CoreConfig{
 		DisableCache: disableCache,

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -540,10 +540,6 @@ func getBackendConfig(c *Core) *logical.BackendConfig {
 	}
 }
 
-func testMakeBatchTokenViaBackend(t testing.TB, ts *TokenStore, root, client, ttl string, policy []string) {
-	testMakeTokenViaBackend(t, ts, root, client, ttl, policy, true)
-}
-
 func testMakeServiceTokenViaBackend(t testing.TB, ts *TokenStore, root, client, ttl string, policy []string) {
 	testMakeTokenViaBackend(t, ts, root, client, ttl, policy, false)
 }

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -647,10 +647,6 @@ func testMakeServiceTokenViaCore(t testing.TB, c *Core, root, client, ttl string
 	testMakeTokenViaCore(t, c, root, client, ttl, policy, false, nil)
 }
 
-func testMakeBatchTokenViaCore(t testing.TB, c *Core, root, client, ttl string, policy []string) {
-	testMakeTokenViaCore(t, c, root, client, ttl, policy, true, nil)
-}
-
 func testMakeTokenViaCore(t testing.TB, c *Core, root, client, ttl string, policy []string, batch bool, outAuth *logical.Auth) {
 	req := logical.TestRequest(t, logical.UpdateOperation, "auth/token/create")
 	req.ClientToken = root


### PR DESCRIPTION
This PR removes four unused test helper functions from the `vault` package.