### PR TITLE
Browserstack: test ie11 on windows 8.1 instead of windows 10

### DIFF
--- a/ui/testem.browserstack.js
+++ b/ui/testem.browserstack.js
@@ -69,7 +69,7 @@ module.exports = {
         '--os',
         'Windows',
         '--osv',
-        '10',
+        '8.1',
         '--b',
         'ie',
         '--bv',


### PR DESCRIPTION
# Test IE11 on Windows 8.1

This PR is an attempt to resolve our Browsesr