### PR TITLE
Backport 1.3: Don't allow registering a non-root zero TTL token lease (#7524)

### DIFF
--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -528,6 +528,7 @@ func TestExpiration_RegisterAuth_NoLease(t *testing.T) {
 	te := &logical.TokenEntry{
 		ID:          root.ID,
 		Path:        "auth/github/login",
+		Policies:    []string{"root"},
 		NamespaceID: namespace.RootNamespaceID,
 	}
 	err = exp.RegisterAuth(namespace.RootContext(nil), te, auth)
@@ -559,6 +560,55 @@ func TestExpiration_RegisterAuth_NoLease(t *testing.T) {
 	}
 	if out == nil {
 		t.Fatalf("missing token")
+	}
+}
+
+// Tests both the expiration function and the core function
+func TestExpiration_RegisterAuth_NoTTL(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	exp := c.expiration
+	ctx := namespace.RootContext(nil)
+
+	root, err := exp.tokenStore.rootToken(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	auth := &logical.Auth{
+		ClientToken:   root.ID,
+		TokenPolicies: []string{"root"},
+	}
+
+	// First on core
+	err = c.RegisterAuth(ctx, 0, "auth/github/login", auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	auth.TokenPolicies[0] = "default"
+	err = c.RegisterAuth(ctx, 0, "auth/github/login", auth)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Now expiration
+	// Should work, root token with zero TTL
+	te := &logical.TokenEntry{
+		ID:          root.ID,
+		Path:        "auth/github/login",
+		Policies:    []string{"root"},
+		NamespaceID: namespace.RootNamespaceID,
+	}
+	err = exp.RegisterAuth(ctx, te, auth)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Test non-root token with zero TTL
+	te.Policies = []string{"default"}
+	err = exp.RegisterAuth(ctx, te, auth)
+	if err == nil {
+		t.Fatal("expected error")
 	}
 }
 

--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -55,11 +55,15 @@ func TestTokenStore_CubbyholeDeletion(t *testing.T) {
 			Operation:   logical.UpdateOperation,
 			Path:        "create",
 			ClientToken: root,
+			Data: map[string]interface{}{
+				"ttl": "600s",
+			},
 		}
 		// Supplying token ID forces SHA1 hashing to be used
 		if i%2 == 0 {
 			tokenReq.Data = map[string]interface{}{
-				"id": "testroot",
+				"id":  "testroot",
+				"ttl": "600s",
 			}
 		}
 		resp := testMakeTokenViaRequest(t, ts, tokenReq)
@@ -111,6 +115,9 @@ func TestTokenStore_CubbyholeTidy(t *testing.T) {
 			Operation:   logical.UpdateOperation,
 			Path:        "create",
 			ClientToken: root,
+			Data: map[string]interface{}{
+				"ttl": "600s",
+			},
 		}
 
 		resp := testMakeTokenViaRequest(t, ts, tokenReq)
@@ -119,7 +126,8 @@ func TestTokenStore_CubbyholeTidy(t *testing.T) {
 		// Supplying token ID forces SHA1 hashing to be used
 		if i%3 == 0 {
 			tokenReq.Data = map[string]interface{}{
-				"id": "testroot",
+				"id":  "testroot",
+				"ttl": "600s",
 			}
 		}
 
@@ -545,10 +553,12 @@ func testMakeBatchTokenViaBackend(t testing.TB, ts *TokenStore, root, client, tt
 }
 
 func testMakeServiceTokenViaBackend(t testing.TB, ts *TokenStore, root, client, ttl string, policy []string) {
+	t.Helper()
 	testMakeTokenViaBackend(t, ts, root, client, ttl, policy, false)
 }
 
 func testMakeTokenViaBackend(t testing.TB, ts *TokenStore, root, client, ttl string, policy []string, batch bool) {
+	t.Helper()
 	req := logical.TestRequest(t, logical.UpdateOperation, "create")
 	req.ClientToken = root
 	if batch {
@@ -566,6 +576,7 @@ func testMakeTokenViaBackend(t testing.TB, ts *TokenStore, root, client, ttl str
 }
 
 func testMakeTokenViaRequest(t testing.TB, ts *TokenStore, req *logical.Request) *logical.Response {
+	t.Helper()
 	resp, err := ts.HandleRequest(namespace.RootContext(nil), req)
 	if err != nil {
 		t.Fatal(err)
@@ -727,7 +738,7 @@ func TestTokenStore_HandleRequest_LookupAccessor(t *testing.T) {
 	c, _, root := TestCoreUnsealed(t)
 	ts := c.tokenStore
 
-	testMakeServiceTokenViaBackend(t, ts, root, "tokenid", "", []string{"foo"})
+	testMakeServiceTokenViaBackend(t, ts, root, "tokenid", "60s", []string{"foo"})
 	out, err := ts.Lookup(namespace.RootContext(nil), "tokenid")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -765,7 +776,7 @@ func TestTokenStore_HandleRequest_ListAccessors(t *testing.T) {
 
 	testKeys := []string{"token1", "token2", "token3", "token4"}
 	for _, key := range testKeys {
-		testMakeServiceTokenViaBackend(t, ts, root, key, "", []string{"foo"})
+		testMakeServiceTokenViaBackend(t, ts, root, key, "60s", []string{"foo"})
 	}
 
 	// Revoke root to make the number of accessors match
@@ -2125,7 +2136,7 @@ func TestTokenStore_HandleRequest_Revoke(t *testing.T) {
 	}
 	root := rootToken.ID
 
-	testMakeServiceTokenViaBackend(t, ts, root, "child", "", []string{"root", "foo"})
+	testMakeServiceTokenViaBackend(t, ts, root, "child", "60s", []string{"root", "foo"})
 
 	te, err := ts.Lookup(namespace.RootContext(nil), "child")
 	if err != nil {
@@ -2147,7 +2158,7 @@ func TestTokenStore_HandleRequest_Revoke(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	testMakeServiceTokenViaBackend(t, ts, "child", "sub-child", "", []string{"foo"})
+	testMakeServiceTokenViaBackend(t, ts, "child", "sub-child", "50s", []string{"foo"})
 
 	te, err = ts.Lookup(namespace.RootContext(nil), "sub-child")
 	if err != nil {
@@ -2201,8 +2212,8 @@ func TestTokenStore_HandleRequest_Revoke(t *testing.T) {
 	}
 
 	// Now test without registering the tokens through the expiration manager
-	testMakeServiceTokenViaBackend(t, ts, root, "child", "", []string{"root", "foo"})
-	testMakeServiceTokenViaBackend(t, ts, "child", "sub-child", "", []string{"foo"})
+	testMakeServiceTokenViaBackend(t, ts, root, "child", "60s", []string{"root", "foo"})
+	testMakeServiceTokenViaBackend(t, ts, "child", "sub-child", "50s", []string{"foo"})
 
 	req = logical.TestRequest(t, logical.UpdateOperation, "revoke")
 	req.Data = map[string]interface{}{
@@ -2239,8 +2250,8 @@ func TestTokenStore_HandleRequest_Revoke(t *testing.T) {
 func TestTokenStore_HandleRequest_RevokeOrphan(t *testing.T) {
 	c, _, root := TestCoreUnsealed(t)
 	ts := c.tokenStore
-	testMakeServiceTokenViaBackend(t, ts, root, "child", "", []string{"root", "foo"})
-	testMakeServiceTokenViaBackend(t, ts, "child", "sub-child", "", []string{"foo"})
+	testMakeServiceTokenViaBackend(t, ts, root, "child", "60s", []string{"root", "foo"})
+	testMakeServiceTokenViaBackend(t, ts, "child", "sub-child", "50s", []string{"foo"})
 
 	req := logical.TestRequest(t, logical.UpdateOperation, "revoke-orphan")
 	req.Data = map[string]interface{}{
@@ -2291,7 +2302,7 @@ func TestTokenStore_HandleRequest_RevokeOrphan(t *testing.T) {
 func TestTokenStore_HandleRequest_RevokeOrphan_NonRoot(t *testing.T) {
 	c, _, root := TestCoreUnsealed(t)
 	ts := c.tokenStore
-	testMakeServiceTokenViaBackend(t, ts, root, "child", "", []string{"foo"})
+	testMakeServiceTokenViaBackend(t, ts, root, "child", "60s", []string{"foo"})
 
 	out, err := ts.Lookup(namespace.RootContext(nil), "child")
 	if err != nil {


### PR DESCRIPTION
* Don't allow registering a non-root zero TTL token lease

This is defense-in-depth in that such a token was not allowed to be
used; however it's also a bug fix in that this would then cause no lease
to be generated but the token entry to be written, meaning the token
entry would stick around until it was attempted to be used or tidied (in
both cases the internal lookup would see that this was invalid and do a
revoke on the spot).

* Fix tests

* tidy