### PR TITLE
Backport 1.3: Update API to use lease_id in body of sys/leases/revoke call (#7777)

### DIFF
--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -28,7 +28,13 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 }
 
 func (c *Sys) Revoke(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke/"+id)
+	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke")
+	body := map[string]interface{}{
+		"lease_id": id,
+	}
+	if err := r.SetJSONBody(body); err != nil {
+		return err
+	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()


### PR DESCRIPTION
We didn't make this change earlier because not everyone would have had
an updated version of Vault with this API change but it's definitely
time.

Fixes https://github.com/hashicorp/vault-ssh-helper/issues/40