### PR TITLE
vault: Remove Unused Test Helper Functions

### DIFF
--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -33,11 +33,6 @@ func mockExpiration(t testing.TB) *ExpirationManager {
 	return c.expiration
 }
 
-func mockBackendExpiration(t testing.TB, backend physical.Backend) (*Core, *ExpirationManager) {
-	c, _, _ := TestCoreUnsealedBackend(t, backend)
-	return c, c.expiration
-}
-
 func TestExpiration_Tidy(t *testing.T) {
 	var err error
 

--- a/vault/identity_store_test.go
+++ b/vault/identity_store_test.go
@@ -572,11 +572,6 @@ func testCoreWithIdentityTokenGithub(ctx context.Context, t *testing.T) (*Core, 
 	return core, is, core.tokenStore, ghAccessor
 }
 
-func testCoreWithIdentityTokenGithubRoot(ctx context.Context, t *testing.T) (*Core, *IdentityStore, *TokenStore, string, string) {
-	is, ghAccessor, core, root := testIdentityStoreWithGithubAuthRoot(ctx, t)
-	return core, is, core.tokenStore, ghAccessor, root
-}
-
 func testIdentityStoreWithGithubAuth(ctx context.Context, t *testing.T) (*IdentityStore, string, *Core) {
 	is, ghA, c, _ := testIdentityStoreWithGithubAuthRoot(ctx, t)
 	return is, ghA, c


### PR DESCRIPTION
This PR prunes two dead functions from the `vault` package tests, `mockBackendExpiration` and `testCoreWithIdentityTokenGithubRoot`.