### PR TITLE
website - bump global-styles to ^2.0.3

### DIFF
--- a/website/assets/package-lock.json
+++ b/website/assets/package-lock.json
@@ -189,9 +189,9 @@
       "integrity": "sha512-nKa5Z+5AiVgY44Q2iij35bybsjMHQdwsBGgm2tvY2vcFuj7GTCyJgA510Vvpvwz86mK+dYwgfJil+rti/b3O8w=="
     },
     "@hashicorp/hashi-global-styles": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/hashi-global-styles/-/hashi-global-styles-2.0.1.tgz",
-      "integrity": "sha512-XPk1xNTCuExLewN68mhTuKcqrWXJql22xTR5HLRWyp3sT39wVMSMJ/IT+jpFLRMpM3eu+S6YiwRXvbj6rYBhWQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/hashi-global-styles/-/hashi-global-styles-2.0.3.tgz",
+      "integrity": "sha512-p/QmdTmVyNSoBdqFjFkSkOYI0b452AUdKWcj8AevjqAz0nt+l2KSWAtwK1QLwjqvkx+7tp1/1SjmpRMMMxXY8Q=="
     },
     "@hashicorp/hashi-hero": {
       "version": "4.0.0",

--- a/website/assets/package.json
+++ b/website/assets/package.json
@@ -17,7 +17,7 @@
     "@hashicorp/hashi-docs-sitemap": "^0.1.6",
     "@hashicorp/hashi-footer": "^2.0.2",
     "@hashicorp/hashi-ga-form-fields": "1.0.2",
-    "@hashicorp/hashi-global-styles": "^2.0.1",
+    "@hashicorp/hashi-global-styles": "^2.0.3",
     "@hashicorp/hashi-hero": "^4.0.0",
     "@hashicorp/hashi-image": "1.0.5",
     "@hashicorp/hashi-linked-text-summary-list": "^1.0.1",


### PR DESCRIPTION
This just bumps up `global-styles` to `2.0.3` to bring in the latest fixes to the way fonts are rendering in Firefox in OSX.