### PR TITLE
[docs/website/dynamic-secrets] - fix typo in multi-line cli command for configuring postgres as a secrets engine

### DIFF
--- a/website/source/guides/secret-mgmt/app-integration.html.md
+++ b/website/source/guides/secret-mgmt/app-integration.html.md
@@ -168,7 +168,7 @@ working with `database` secrets engine is out of scope for this guide.
 $ vault secrets enable database
 
 # Configure the secret engine with appropriate parameter values
-$ vault write database/config/postgresql
+$ vault write database/config/postgresql \
       plugin_name=postgresql-database-plugin \
       allowed_roles=* \
       connection_url=postgresql://root:rootpassword@localhost:5432/myapp

--- a/website/source/guides/secret-mgmt/dynamic-secrets.html.md
+++ b/website/source/guides/secret-mgmt/dynamic-secrets.html.md
@@ -204,7 +204,7 @@ command with correct URL to match your environment.
 **Example:**
 
 ```plaintext
-$ vault write database/config/postgresql
+$ vault write database/config/postgresql \
       plugin_name=postgresql-database-plugin \
       allowed_roles=readonly \
       connection_url=postgresql://root:rootpassword@localhost:5432/myapp


### PR DESCRIPTION
On [this page of the docs for dynamic secrets managment](https://learn.hashicorp.com/vault/secrets-management/sm-dynamic-secrets), specifically, [here](https://learn.hashicorp.com/vault/secrets-management/sm-dynamic-secrets#cli-command-1), there is a missing `\`. I just did a cross-codebase grep and found the same issue [here](https://learn.hashicorp.com/vault/developer/sm-app-integration#cli-command).

Related to this issue that I opened - https://github.com/hashicorp/vault/issues/7843