### PR TITLE
docs/website: fix broken chef-puppet with vault blog link

### DIFF
--- a/website/source/docs/vs/chef-puppet-etc.html.md
+++ b/website/source/docs/vs/chef-puppet-etc.html.md
@@ -46,6 +46,6 @@ accessed. It is rare to have a single key that can access all secrets. This
 makes it easier to have fine-grained access for consumers of Vault.
 
 For tips on how to integrate Vault using configuration management, please see
-[Using HashiCorp's Vault with Chef](https://www.hashicorp.com/blog/using-hashicorps-vault-with-chef.html).
+[Using HashiCorp's Vault with Chef](https://www.hashicorp.com/blog/using-hashicorps-vault-with-chef/).
 Although this post is about Chef, the principles can be broadly applied to many
 of the tools listed here.


### PR DESCRIPTION
current, broken, link - https://www.hashicorp.com/blog/using-hashicorps-vault-with-chef.html
updated, working, link - https://www.hashicorp.com/blog/using-hashicorps-vault-with-chef/

The working link is also used [here](https://github.com/hashicorp/vault/blame/master/website/source/guides/identity/approle-trusted-entities.html.md#L901)