### PR TITLE
debug: fix test typo

### DIFF
--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -65,7 +65,7 @@ func TestDebugCommand_Run(t *testing.T) {
 			"invalid_target",
 			[]string{
 				"-duration=1s",
-				fmt.Sprintf("-output=%s/too_many_args", testDir),
+				fmt.Sprintf("-output=%s/invalid_target", testDir),
 				"-target=foo",
 			},
 			"Ignoring invalid targets: foo",


### PR DESCRIPTION
Fix a copy/paste typo in a debug test.

Related to #7860
