### PR TITLE
Issue #7874 AWS IAM Authentication without region set in config defaults to us-east-1

### DIFF
--- a/command/agent/auth/aws/aws.go
+++ b/command/agent/auth/aws/aws.go
@@ -72,7 +72,7 @@ func NewAWSAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 		mountPath:  conf.MountPath,
 		credsFound: make(chan struct{}),
 		stopCh:     make(chan struct{}),
-		region:     awsutil.DefaultRegion,
+		region:     "",
 	}
 
 	typeRaw, ok := conf.Config["type"]


### PR DESCRIPTION
This would be the easiest fix for the bug introduced in vault 1.2.4.

See full description in issue:
https://github.com/hashicorp/vault/issues/7874