### PR TITLE
tests: eliminate flakiness on TestRecovery

### DIFF
--- a/vault/external_tests/misc/recovery_test.go
+++ b/vault/external_tests/misc/recovery_test.go
@@ -124,8 +124,10 @@ func TestRecovery(t *testing.T) {
 		cluster := vault.NewTestCluster(t, &conf, &opts)
 		cluster.BarrierKeys = keys
 		cluster.Start()
-		testhelpers.EnsureCoresUnsealed(t, cluster)
 		defer cluster.Cleanup()
+
+		testhelpers.EnsureCoresUnsealed(t, cluster)
+		vault.TestWaitActive(t, cluster.Cores[0].Core)
 
 		client := cluster.Cores[0].Client
 		client.SetToken(rootToken)


### PR DESCRIPTION
Fix flakiness on `TestRecovery` due the secret list request sometimes being called before core0 became active after a cluster restart. 

```
--- FAIL: TestRecovery (7.40s)
    recovery_test.go:134: Error making API request.
        
        URL: GET https://127.0.0.1:38874/v1/secret?list=true
        Code: 500. Errors:
        
        * local node not active but active cluster node not found
```