### PR TITLE
Agent Template: check rendering to match expectations

### DIFF
--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -126,7 +126,6 @@ func (ts *Server) Run(ctx context.Context, incoming chan string, templates []*ct
 	}
 	ts.lookupMap = lookupMap
 
-WAIT:
 	for {
 		select {
 		case <-ctx.Done():
@@ -166,19 +165,21 @@ WAIT:
 				continue
 			}
 
+			// assume the renders are finished, until we find otherwise
+			doneRendering := true
 			for _, event := range events {
 				// This template hasn't been rendered
 				if event.LastWouldRender.IsZero() {
-					continue WAIT
+					doneRendering = false
 				}
 			}
 
-			if ts.exitAfterAuth {
+			if doneRendering && ts.exitAfterAuth {
 				// if we want to exit after auth, go ahead and shut down the runner and
 				// return. The deferred closing of the DoneCh will allow agent to
 				// continue with closing down
 				ts.runner.Stop()
-				break WAIT
+				return
 			}
 		}
 	}

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -50,6 +50,11 @@ type Server struct {
 	// Templates holds the parsed Consul Templates
 	Templates []*ctconfig.TemplateConfig
 
+	// lookupMap is alist of templates indexed by their consul-template ID. This
+	// is used to ensure all Vault templates have been rendered before returning
+	// from the runner in the event we're using exit after auth.
+	lookupMap map[string][]*ctconfig.TemplateConfig
+
 	DoneCh        chan struct{}
 	logger        hclog.Logger
 	exitAfterAuth bool
@@ -104,6 +109,24 @@ func (ts *Server) Run(ctx context.Context, incoming chan string, templates []*ct
 		return
 	}
 
+	// Build the lookup map using the id mapping from the Template runner. This is
+	// used to check the template rendering against the expected templates. This
+	// returns a map with a generated ID and a slice of templates for that id. The
+	// slice is determined by the source or contents of the template, so if a
+	// configuration has multiple templates specified, but are the same source /
+	// contents, they will be identified by the same key.
+	idMap := ts.runner.TemplateConfigMapping()
+	lookupMap := make(map[string][]*ctconfig.TemplateConfig, len(idMap))
+	for id, ctmpls := range idMap {
+		for _, ctmpl := range ctmpls {
+			tl := lookupMap[id]
+			tl = append(tl, ctmpl)
+			lookupMap[id] = tl
+		}
+	}
+	ts.lookupMap = lookupMap
+
+WAIT:
 	for {
 		select {
 		case <-ctx.Done():
@@ -133,12 +156,29 @@ func (ts *Server) Run(ctx context.Context, incoming chan string, templates []*ct
 			ts.logger.Error("template server error", "error", err.Error())
 			return
 		case <-ts.runner.TemplateRenderedCh():
+			// A template has been rendered, figure out what to do
+			events := ts.runner.RenderEvents()
+
+			// events are keyed by template ID, and can be matched up to the id's from
+			// the lookupMap
+			if len(events) < len(ts.lookupMap) {
+				// Not all templates have been rendered yet
+				continue
+			}
+
+			for _, event := range events {
+				// This template hasn't been rendered
+				if event.LastWouldRender.IsZero() {
+					continue WAIT
+				}
+			}
+
 			if ts.exitAfterAuth {
 				// if we want to exit after auth, go ahead and shut down the runner and
 				// return. The deferred closing of the DoneCh will allow agent to
 				// continue with closing down
 				ts.runner.Stop()
-				return
+				break WAIT
 			}
 		}
 	}

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"os"
 	"reflect"
@@ -721,7 +720,7 @@ func TestAgent_Template_Basic(t *testing.T) {
 			// make some template files
 			var templatePaths []string
 			for i := 0; i < tc.templateCount; i++ {
-				path := makeTempFile(t, fmt.Sprintf("render_%d", i), templateContents())
+				path := makeTempFile(t, fmt.Sprintf("render_%d", i), templateContents(i))
 				templatePaths = append(templatePaths, path)
 			}
 
@@ -1074,12 +1073,12 @@ var templates = []string{
 {{ end }}`,
 }
 
-// templateContents returns one of 2 templates at pseudo-random. We do this to
-// create a dynamic, changing number of template stanzas with different sources,
-// to simulate multiple stanzas with a varying number of source templates.
-func templateContents() string {
-	rand.Seed(time.Now().UnixNano())
-	index := rand.Intn(len(templates))
+// templateContents returns a template from the above templates slice. Each
+// invocation with incrementing seed will return "the next" template, and loop.
+// This ensures as we use multiple templates that we have a increasing number of
+// sources before we reuse a template.
+func templateContents(seed int) string {
+	index := seed % len(templates)
 	return templates[index]
 }
 


### PR DESCRIPTION
Add a map to track the Consul Template ID's of the templates used in Vault Agent. Templates are keyed based on their contents, so multiple template stanzas could be keyed under the same key if they have identical sources/contents. 

Here we add a regression test (lifted from #7883, thanks @jasonodonnell !) and then a commit to build up a map and compare the rendering results. If `exit_after_auth` is specified, we continue to loop until all rendering events are accounted for and all included templates have rendered. 

This implementation was [lifted from Nomad][1]

Fixes https://github.com/hashicorp/vault/issues/7883


[1]: https://github.com/hashicorp/nomad/blob/387b016ac442ed7c3d8d81144abda48f6953e587/client/allocrunner/taskrunner/template/template.go#L261