### PR TITLE
Add enable_hostname_label option to telemetry stanza

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -2270,6 +2270,7 @@ func (c *ServerCommand) setupTelemetry(config *server.Config) (*metricsutil.Metr
 
 	metricsConf := metrics.DefaultConfig("vault")
 	metricsConf.EnableHostname = !telConfig.DisableHostname
+	metricsConf.EnableHostnameLabel = telConfig.EnableHostnameLabel
 
 	// Configure the statsite sink
 	var fanout metrics.FanoutSink

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -166,7 +166,8 @@ type Telemetry struct {
 	StatsiteAddr string `hcl:"statsite_address"`
 	StatsdAddr   string `hcl:"statsd_address"`
 
-	DisableHostname bool `hcl:"disable_hostname"`
+	DisableHostname     bool `hcl:"disable_hostname"`
+	EnableHostnameLabel bool `hcl:"enable_hostname_label"`
 
 	// Circonus: see https://github.com/circonus-labs/circonus-gometrics
 	// for more details on the various configuration options.


### PR DESCRIPTION
This PR adds a new option to the telemetry stanza which enables hostname labeling to the metrics output. This should fix https://github.com/hashicorp/vault/issues/1898 since it guarantees backward compatibility and enables users to retrieve the hostname via a label.

Example before metrics output:
```
{
      "Name": "vault.consul.list",
      "Count": 8,
      "Rate": 1.7588366985321044,
      "Sum": 17.588366985321045,
      "Min": 1.3662279844284058,
      "Max": 3.806999921798706,
      "Mean": 2.1985458731651306,
      "Stddev": 0.8195748153029976,
      "Labels": {}
},
```

Example after metrics output:
```
{
      "Name": "vault.consul.list",
      "Count": 8,
      "Rate": 1.7588366985321044,
      "Sum": 17.588366985321045,
      "Min": 1.3662279844284058,
      "Max": 3.806999921798706,
      "Mean": 2.1985458731651306,
      "Stddev": 0.8195748153029976,
      "Labels": {
        "host": "my-hostname"
      }
},
```
