### PR TITLE
Forward PKI issue/sign request to primary if storing certificate

### DIFF
--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -188,6 +189,11 @@ func (b *backend) pathSignVerbatim(ctx context.Context, req *logical.Request, da
 }
 
 func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, data *framework.FieldData, role *roleEntry, useCSR, useCSRValues bool) (*logical.Response, error) {
+	// If storing the certificate and on a performance standby, forward this request on to the primary
+	if !role.NoStore && b.System().ReplicationState().HasState(consts.ReplicationPerformanceStandby) {
+		return nil, logical.ErrReadOnly
+	}
+
 	format := getFormat(data)
 	if format == "" {
 		return logical.ErrorResponse(


### PR DESCRIPTION
This is a small optimization to the PKI backend to not generate the certificate on a performance standby if we are going to eventually store it since it will eventually be forwarded to the primary anyway.