### PR TITLE
Retry on failed lease collection

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -43,6 +43,12 @@ const (
 	// revokeRetryBase is a baseline retry time
 	revokeRetryBase = 10 * time.Second
 
+	// maxCollectAttempts limits how many attempts are made to collect leases on start
+	maxCollectAttempts = 3
+
+	// collectRetryBase is a baseline retry time
+	collectRetryBase = 10 * time.Second
+
 	// maxLeaseDuration is the default maximum lease duration
 	maxLeaseTTL = 32 * 24 * time.Hour
 

--- a/vault/expiration_util.go
+++ b/vault/expiration_util.go
@@ -3,6 +3,8 @@
 package vault
 
 import (
+	"time"
+
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -19,7 +21,18 @@ func (m *ExpirationManager) tokenIndexView(*namespace.Namespace) *BarrierView {
 func (m *ExpirationManager) collectLeases() (map[*namespace.Namespace][]string, int, error) {
 	leaseCount := 0
 	existing := make(map[*namespace.Namespace][]string)
-	keys, err := logical.CollectKeys(m.quitContext, m.leaseView(namespace.RootNamespace))
+
+	var keys []string
+	var err error
+	for attempt := uint(0); attempt < maxCollectAttempts; attempt++ {
+		keys, err = logical.CollectKeys(m.quitContext, m.leaseView(namespace.RootNamespace))
+		if err == nil || m.quitContext.Err() != nil {
+			break
+		}
+
+		m.logger.Error("failed to scan for leases", "error", err)
+		time.Sleep((1 << attempt) * collectRetryBase)
+	}
 	if err != nil {
 		return nil, 0, errwrap.Wrapf("failed to scan for leases: {{err}}", err)
 	}

--- a/vault/expiration_util_test.go
+++ b/vault/expiration_util_test.go
@@ -1,0 +1,80 @@
+// +build !enterprise
+
+package vault
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// badStorage simulates a storage that returns count-1 errors on List before returning success
+type badStorage struct {
+	logical.Storage
+	count int
+}
+
+func (b *badStorage) List(ctx context.Context, _ string) ([]string, error) {
+	b.count--
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	if b.count == 0 {
+		return nil, nil
+	}
+
+	return nil, errors.New("storage timeout")
+}
+
+func TestExpirationManager_collectLeases(t *testing.T) {
+	_, barrier, _ := mockBarrier(t)
+
+	m := &ExpirationManager{
+		quitContext: context.Background(),
+		logger:      log.New(nil),
+	}
+
+	// Check that we retry a few errors
+	m.idView = NewBarrierView(&badStorage{barrier, maxCollectAttempts}, "")
+
+	_, _, err := m.collectLeases()
+	if err != nil {
+		t.Fatalf("error despite retries: %v", err)
+	}
+
+	// Check that we don't retry beyond the error limit
+	m.idView = NewBarrierView(&badStorage{barrier, maxCollectAttempts + 1}, "")
+	_, _, err = m.collectLeases()
+	if err == nil {
+		t.Fatal("no error despite surpassing max retries")
+	}
+
+	if err.Error() != `failed to scan for leases: list failed at path "": storage timeout` {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(m.quitContext)
+	cancel()
+	m.quitContext = ctx
+
+	// Check that we only try once when there's a context error
+	b := &badStorage{barrier, maxCollectAttempts}
+	m.idView = NewBarrierView(b, "")
+	_, _, err = m.collectLeases()
+	if err == nil {
+		t.Fatal("no error despite cancelled context")
+	}
+
+	if err.Error() != `failed to scan for leases: list failed at path "": context canceled` {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if b.count != maxCollectAttempts-1 {
+		t.Fatalf("unexpected number of calls to badStorage: %d", maxCollectAttempts-b.count)
+	}
+}


### PR DESCRIPTION
On the C* storage backend, collecting all the leases is a really expensive operation and often times out. This operation is attempted when a node becomes leader, and the time out leads a node to seal. This means in practice that a leadership election often leads to one or two nodes sealing before a lease restore happens to succeed. It seems harmless to retry collecting the leases a few times before giving up and sealing.

https://github.com/hashicorp/vault/pull/7199 will help with our issue, but all the same I think it makes sense to retry