### PR TITLE
store secret key and value as an object to fix copy/show secret bug

### DIFF
--- a/ui/app/models/secret.js
+++ b/ui/app/models/secret.js
@@ -13,6 +13,12 @@ export default DS.Model.extend(KeyMixin, {
   renewable: attr('boolean'),
 
   secretData: attr('object'),
+  secretKeyAndValue: computed('secretData', function() {
+    const data = this.get('secretData');
+    return Object.keys(data).map(key => {
+      return { key, value: data[key] };
+    });
+  }),
 
   dataAsJSONString: computed('secretData', function() {
     return JSON.stringify(this.get('secretData'), null, 2);

--- a/ui/app/templates/partials/secret-form-show.hbs
+++ b/ui/app/templates/partials/secret-form-show.hbs
@@ -46,10 +46,10 @@
         </div>
       </div>
     </div>
-    {{#each-in modelForData.secretData as |key value|}}
-      {{#info-table-row label=key value=value alwaysRender=true}}
-        {{masked-input value=value displayOnly=true allowCopy=true}}
+    {{#each modelForData.secretKeyAndValue as |secret|}}
+      {{#info-table-row label=secret.key value=secret.value alwaysRender=true}}
+        {{masked-input value=secret.value displayOnly=true allowCopy=true}}
       {{/info-table-row}}
-    {{/each-in}}
+    {{/each}}
   {{/if}}
 {{/if}}


### PR DESCRIPTION
# Ensure secrets with '.' in their key can show and be copied

This PR fixes a bug where secrets with a period in their key (such as `hello.hi`) do not copy nor display when revealed. The problem was that Ember's `each-in` helper called `secret.hello.hi` instead of `secret["hello.hi"]`, so the secret key was being passed into the `masked-input` as undefined and not displaying. The Ember bug was fixed in https://github.com/emberjs/ember.js/pull/18296, but we won't have access to that fix until we upgrade to Ember to 3.13.

Fixes https://github.com/hashicorp/vault/issues/7895

![copybug](https://user-images.githubusercontent.com/903288/69451311-ec680080-0d13-11ea-8f0d-2825618087a4.gif)


## Testing
1. Create a secret with a period in the name.
2. Ensure you can reveal it and copy/paste! 🎉 