### PR TITLE
vault: fix dropped test error

### DIFF
--- a/vault/token_store_test.go
+++ b/vault/token_store_test.go
@@ -2963,6 +2963,9 @@ func TestTokenStore_HandleRequest_CreateToken_NotAllowedEntityAlias(t *testing.T
 			"mount_accessor": tokenMountAccessor,
 		},
 	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err: %v\nresp: %#v", err, resp)
+	}
 
 	// Create token role
 	resp, err = core.HandleRequest(ctx, &logical.Request{


### PR DESCRIPTION
This fixes a dropped error in `TestTokenStore_HandleRequest_CreateToken_NotAllowedEntityAlias()`.