### PR TITLE
Fix typo in the documentation

### DIFF
--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -126,7 +126,7 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 			"the format \"keybase:<username>\". When supplied, the generated " +
 			"unseal keys will be encrypted and base64-encoded in the order " +
 			"specified in this list. The number of entries must match -key-shares, " +
-			"unless -store-shares are used.",
+			"unless -stored-shares are used.",
 	})
 
 	f.VarFlag(&VarFlag{

--- a/website/source/docs/commands/operator/init.html.md
+++ b/website/source/docs/commands/operator/init.html.md
@@ -84,7 +84,7 @@ flags](/docs/commands/index.html) included on all commands.
   containing public GPG keys OR a comma-separated list of Keybase usernames
   using the format `keybase:<username>`. When supplied, the generated unseal
   keys will be encrypted and base64-encoded in the order specified in this list.
-  The number of entries must match -key-shares, unless -store-shares are used.
+  The number of entries must match -key-shares, unless -stored-shares are used.
 
 - `-root-token-pgp-key` `(string: "")` - Path to a file on disk containing a
   binary or base64-encoded public GPG key. This can also be specified as a


### PR DESCRIPTION
I know `stored-shares` is going to be removed in Vault 1.3, but still typo is a little typo.