### PR TITLE
physical/postgresql: Refactor test code to avoid panic if tests ran multiple times

### DIFF
--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -264,10 +264,6 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 	newlockch := make(chan struct{})
 	go func() {
 		leaderCh2, err = newLock.Lock(stopCh)
-		// Attempt to lock should work
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
 		close(newlockch)
 	}()
 
@@ -280,6 +276,10 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 		// pass through
 	}
 
+	// Attempt to lock should work
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 	if leaderCh2 == nil {
 		t.Fatalf("should get leader ch")
 	}

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -257,7 +257,6 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Cancel attempt after lock ttl + 1s so as not to block unit tests forever
 	stopCh := make(chan struct{})
 	timeout := time.Duration(lock.ttlSeconds)*time.Second + lock.retryInterval + time.Second
 
@@ -268,6 +267,7 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 		close(newlockch)
 	}()
 
+	// Cancel attempt after lock ttl + 1s so as not to block unit tests forever
 	select {
 	case <-time.After(timeout):
 		t.Logf("giving up on lock attempt after %v", timeout)

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -264,6 +264,10 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 	newlockch := make(chan struct{})
 	go func() {
 		leaderCh2, err = newLock.Lock(stopCh)
+		// Attempt to lock should work
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
 		close(newlockch)
 	}()
 
@@ -276,10 +280,6 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 		// pass through
 	}
 
-	// Attempt to lock should work
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
 	if leaderCh2 == nil {
 		t.Fatalf("should get leader ch")
 	}

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -265,16 +265,15 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 	newlockch := make(chan struct{})
 	go func() {
 		leaderCh2, err = newLock.Lock(stopCh)
-		newlockch <- struct{}{}
+		close(newlockch)
 	}()
 
 	select {
-	case <-newlockch:
-		// close and move on
-		close(newlockch)
 	case <-time.After(timeout):
 		t.Logf("giving up on lock attempt after %v", timeout)
 		close(stopCh)
+	case <-newlockch:
+		// pass through
 	}
 
 	// Attempt to lock should work


### PR DESCRIPTION
Refactors a test in postgresql backend to remove a panic that can be caused if you run the tests with `count` greater than 1. 

```
[vault][master](4)$ make test TEST=./physical/postgresql/... TESTARGS="-run=TestPostgreSQLBackend -count=2"
==> Checking that build is using go version >= 1.12.7...
==> Using go version 1.12.13...
[...]
panic: Log in goroutine after TestPostgreSQLBackend has completed

goroutine 123 [running]:
[...]
github.com/hashicorp/vault/physical/postgresql.testPostgresSQLLockRenewal.func1()
        /Users/clint/go-src/vault/physical/postgresql/postgresql_test.go:264 +0x9f
created by time.goFunc
```

The `time.AfterFunc` launches a goroutine which was wrapping the `t` variable here. After the first run `t` gets cleaned up but the goroutine still tries to call the `Log()` method. 

Here we move the `newLock.Lock` call into a goroutine, as that's the _thing_ that could take time and we want to short-circuit if it takes too long. We then `select` on a channel from the goroutine and a `time.After()` call, and log there if it fires. 