### PR TITLE
Docs: Remove response code info from non-overview API docs (contd)

### DIFF
--- a/website/source/api/secret/pki/index.html.md
+++ b/website/source/api/secret/pki/index.html.md
@@ -57,7 +57,7 @@ This is an unauthenticated endpoint.
 
 | Method   | Path                         |
 | :--------------------------- | :--------------------- |
-| `GET`    | `/pki/ca(/pem)`              | `200 application/binary` |
+| `GET`    | `/pki/ca(/pem)`              | 
 
 ### Sample Request
 
@@ -82,7 +82,7 @@ This is an unauthenticated endpoint.
 
 | Method   | Path                         |
 | :--------------------------- | :--------------------- |
-| `GET`    | `/pki/ca_chain`              | `200 application/binary` |
+| `GET`    | `/pki/ca_chain`              |
 
 ### Sample Request
 
@@ -371,7 +371,7 @@ This is an unauthenticated endpoint.
 
 | Method   | Path                         |
 | :--------------------------- | :--------------------- |
-| `GET`    | `/pki/crl(/pem)`             | `200 application/binary` |
+| `GET`    | `/pki/crl(/pem)`             | 
 
 ### Sample Request
 

--- a/website/source/api/secret/totp/index.html.md
+++ b/website/source/api/secret/totp/index.html.md
@@ -23,7 +23,7 @@ This endpoint creates or updates a key definition.
 
 | Method   | Path                         |
 | :--------------------------- | :--------------------------------------------------------------------------------------------- |
-| `POST`   | `/totp/keys/:name`           | if generating a key and exported is true: `200 application/json` else: `204 (empty body)`      |
+| `POST`   | `/totp/keys/:name`           | 
 
 ### Parameters
 

--- a/website/source/api/system/control-group.html.md
+++ b/website/source/api/system/control-group.html.md
@@ -15,7 +15,7 @@ This endpoint authorizes a control group request.
 
 | Method   | Path                           |
 | :----------------------------- | :--------------------- |
-| `POST`   | `/sys/control-group/authorize`   | `200 (application/json)`     |
+| `POST`   | `/sys/control-group/authorize`   | 
 
 ### Parameters
 
@@ -55,7 +55,7 @@ This endpoint checks the status of a control group request.
 
 | Method   | Path                           |
 | :----------------------------- | :--------------------- |
-| `POST`   | `/sys/control-group/request`   | `200 (application/json)`     |
+| `POST`   | `/sys/control-group/request`   | 
 
 ### Parameters
 

--- a/website/source/api/system/health.html.md
+++ b/website/source/api/system/health.html.md
@@ -19,8 +19,8 @@ Vault instance.
 
 | Method   | Path                         |
 | :--------------------------- | :--------------------- |
-| `HEAD`   | `/sys/health`                | `000 (empty body)`     |
-| `GET`    | `/sys/health`                | `000 application/json` |
+| `HEAD`   | `/sys/health`                | 
+| `GET`    | `/sys/health`                | 
 
 The default status codes are:
 

--- a/website/source/api/system/namespaces.html.md
+++ b/website/source/api/system/namespaces.html.md
@@ -66,7 +66,7 @@ This endpoint deletes a namespace at the specified path.
 
 | Method   | Path                         |
 | :--------------------------- | :--------------------- |
-| `DELETE` | `/sys/namespaces/:path`      | `204 (empty body)    ` |
+| `DELETE` | `/sys/namespaces/:path`      | 
 
 ### Sample Request
 

--- a/website/source/api/system/rekey-recovery-key.html.md
+++ b/website/source/api/system/rekey-recovery-key.html.md
@@ -287,7 +287,7 @@ along with the new nonce.
 
 | Method   | Path                                        |
 | :------------------------------------------ | :--------------------- |
-| `DELETE` | `/sys/rekey-recovery-key/verify`            | `200 (empty body)`     |
+| `DELETE` | `/sys/rekey-recovery-key/verify`            | 
 
 ### Sample Request
 

--- a/website/source/api/system/rekey.html.md
+++ b/website/source/api/system/rekey.html.md
@@ -289,7 +289,7 @@ nonce.
 
 | Method   | Path                           |
 | :----------------------------- | :--------------------- |
-| `DELETE` | `/sys/rekey/verify`            | `200 (empty body)`     |
+| `DELETE` | `/sys/rekey/verify`            | 
 
 ### Sample Request
 


### PR DESCRIPTION
Continues https://github.com/hashicorp/vault/pull/6459:

> Remove response code info from non-overview API docs as it can be
> misinterpreted and is always the same anyways.

Cleans up some spots that should have been deleted, but due to markdown formatting, weren't being rendered anyway.

