### PR TITLE
Bump aws sdk to v1.23.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e
 	github.com/armon/go-radix v1.0.0
 	github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf
-	github.com/aws/aws-sdk-go v1.19.39
+	github.com/aws/aws-sdk-go v1.23.13
 	github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/chrismalek/oktasdk-go v0.0.0-20181212195951-3430665dfaa0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf h1:eg0MeVzs
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.19.39 h1:pIez14zQWSd/TER2Scohm7aCEG2TgoyXSOX6srOKt6o=
 github.com/aws/aws-sdk-go v1.19.39/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.23.13 h1:l/NG+mgQFRGG3dsFzEj0jw9JIs/zYdtU6MXhY1WIDmM=
+github.com/aws/aws-sdk-go v1.23.13/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f h1:ZNv7On9kyUzm7fvRZumSyy/IUiSC7AzL0I1jKKtwooA=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,7 +95,7 @@ github.com/armon/go-proxyproto
 github.com/armon/go-radix
 # github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf
 github.com/asaskevich/govalidator
-# github.com/aws/aws-sdk-go v1.19.39
+# github.com/aws/aws-sdk-go v1.23.13
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/credentials
 github.com/aws/aws-sdk-go/aws/credentials/stscreds


### PR DESCRIPTION
Hello, we are using Vault inside an Amazon EKS cluster. Recently they released a new feature which allows users to attach IAM roles directly to service accounts in the cluster (for reference [here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)). 

We tried to use this approach with Vault, but it seems this functionality is not supported in aws-sdk-go v1.19.39. There might be other people out there wishing to use this. So, I upgraded the version to minimum required to be able to use this functionality (see [docs](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html)). 

Output of `make test` is pasted below, everything looks fine:
```
make test
==> Checking that build is using go version >= 1.12.7...
==> Using go version 1.12.7...
ok      github.com/hashicorp/vault      (cached) [no tests to run]
ok      github.com/hashicorp/vault/audit        (cached)
ok      github.com/hashicorp/vault/builtin/audit/file   0.015s
?       github.com/hashicorp/vault/builtin/audit/socket [no test files]
?       github.com/hashicorp/vault/builtin/audit/syslog [no test files]
ok      github.com/hashicorp/vault/builtin/credential/app-id    (cached)
?       github.com/hashicorp/vault/builtin/credential/app-id/cmd/app-id [no test files]
ok      github.com/hashicorp/vault/builtin/credential/approle   (cached)
?       github.com/hashicorp/vault/builtin/credential/approle/cmd/approle       [no test files]
ok      github.com/hashicorp/vault/builtin/credential/aws       10.186s
?       github.com/hashicorp/vault/builtin/credential/aws/cmd/aws       [no test files]
ok      github.com/hashicorp/vault/builtin/credential/cert      10.471s
?       github.com/hashicorp/vault/builtin/credential/cert/cmd/cert     [no test files]
ok      github.com/hashicorp/vault/builtin/credential/github    (cached)
?       github.com/hashicorp/vault/builtin/credential/github/cmd/github [no test files]
ok      github.com/hashicorp/vault/builtin/credential/ldap      (cached)
?       github.com/hashicorp/vault/builtin/credential/ldap/cmd/ldap     [no test files]
ok      github.com/hashicorp/vault/builtin/credential/okta      (cached)
?       github.com/hashicorp/vault/builtin/credential/okta/cmd/okta     [no test files]
ok      github.com/hashicorp/vault/builtin/credential/radius    (cached)
?       github.com/hashicorp/vault/builtin/credential/radius/cmd/radius [no test files]
?       github.com/hashicorp/vault/builtin/credential/token     [no test files]
ok      github.com/hashicorp/vault/builtin/credential/userpass  (cached)
?       github.com/hashicorp/vault/builtin/credential/userpass/cmd/userpass     [no test files]
ok      github.com/hashicorp/vault/builtin/logical/aws  1.061s
?       github.com/hashicorp/vault/builtin/logical/aws/cmd/aws  [no test files]
ok      github.com/hashicorp/vault/builtin/logical/cassandra    (cached)
?       github.com/hashicorp/vault/builtin/logical/cassandra/cmd/cassandra      [no test files]
ok      github.com/hashicorp/vault/builtin/logical/consul       (cached)
?       github.com/hashicorp/vault/builtin/logical/consul/cmd/consul    [no test files]
ok      github.com/hashicorp/vault/builtin/logical/database     660.001s
ok      github.com/hashicorp/vault/builtin/logical/database/dbplugin    16.998s
ok      github.com/hashicorp/vault/builtin/logical/mongodb      (cached)
?       github.com/hashicorp/vault/builtin/logical/mongodb/cmd/mongodb  [no test files]
ok      github.com/hashicorp/vault/builtin/logical/mssql        (cached)
?       github.com/hashicorp/vault/builtin/logical/mssql/cmd/mssql      [no test files]
ok      github.com/hashicorp/vault/builtin/logical/mysql        (cached)
?       github.com/hashicorp/vault/builtin/logical/mysql/cmd/mysql      [no test files]
ok      github.com/hashicorp/vault/builtin/logical/nomad        37.429s
?       github.com/hashicorp/vault/builtin/logical/nomad/cmd/nomad      [no test files]
ok      github.com/hashicorp/vault/builtin/logical/pki  122.180s
?       github.com/hashicorp/vault/builtin/logical/pki/cmd/pki  [no test files]
ok      github.com/hashicorp/vault/builtin/logical/postgresql   (cached)
?       github.com/hashicorp/vault/builtin/logical/postgresql/cmd/postgresql    [no test files]
ok      github.com/hashicorp/vault/builtin/logical/rabbitmq     (cached)
?       github.com/hashicorp/vault/builtin/logical/rabbitmq/cmd/rabbitmq        [no test files]
ok      github.com/hashicorp/vault/builtin/logical/ssh  (cached)
?       github.com/hashicorp/vault/builtin/logical/ssh/cmd/ssh  [no test files]
ok      github.com/hashicorp/vault/builtin/logical/totp (cached)
?       github.com/hashicorp/vault/builtin/logical/totp/cmd/totp        [no test files]
ok      github.com/hashicorp/vault/builtin/logical/transit      62.084s
?       github.com/hashicorp/vault/builtin/logical/transit/cmd/transit  [no test files]
ok      github.com/hashicorp/vault/builtin/plugin       8.675s
ok      github.com/hashicorp/vault/command      106.765s
ok      github.com/hashicorp/vault/command/agent        275.442s
ok      github.com/hashicorp/vault/command/agent/auth   8.770s
?       github.com/hashicorp/vault/command/agent/auth/alicloud  [no test files]
?       github.com/hashicorp/vault/command/agent/auth/approle   [no test files]
?       github.com/hashicorp/vault/command/agent/auth/aws       [no test files]
?       github.com/hashicorp/vault/command/agent/auth/azure     [no test files]
?       github.com/hashicorp/vault/command/agent/auth/cert      [no test files]
?       github.com/hashicorp/vault/command/agent/auth/cf        [no test files]
?       github.com/hashicorp/vault/command/agent/auth/gcp       [no test files]
?       github.com/hashicorp/vault/command/agent/auth/jwt       [no test files]
ok      github.com/hashicorp/vault/command/agent/auth/kubernetes        (cached)
ok      github.com/hashicorp/vault/command/agent/cache  100.243s
ok      github.com/hashicorp/vault/command/agent/cache/cachememdb       (cached)
ok      github.com/hashicorp/vault/command/agent/config (cached)
?       github.com/hashicorp/vault/command/agent/sink   [no test files]
ok      github.com/hashicorp/vault/command/agent/sink/file      17.641s
?       github.com/hashicorp/vault/command/agent/sink/inmem     [no test files]
?       github.com/hashicorp/vault/command/agent/sink/mock      [no test files]
ok      github.com/hashicorp/vault/command/agent/template       0.310s
ok      github.com/hashicorp/vault/command/config       (cached)
ok      github.com/hashicorp/vault/command/server       (cached)
?       github.com/hashicorp/vault/command/server/seal  [no test files]
ok      github.com/hashicorp/vault/command/token        0.061s
ok      github.com/hashicorp/vault/helper/awsutil       (cached)
?       github.com/hashicorp/vault/helper/builtinplugins        [no test files]
?       github.com/hashicorp/vault/helper/dhutil        [no test files]
ok      github.com/hashicorp/vault/helper/flag-kv       (cached)
ok      github.com/hashicorp/vault/helper/flag-slice    (cached)
ok      github.com/hashicorp/vault/helper/forwarding    (cached)
ok      github.com/hashicorp/vault/helper/gated-writer  (cached)
ok      github.com/hashicorp/vault/helper/hostutil      0.068s
ok      github.com/hashicorp/vault/helper/identity      (cached)
?       github.com/hashicorp/vault/helper/identity/mfa  [no test files]
ok      github.com/hashicorp/vault/helper/kv-builder    (cached)
ok      github.com/hashicorp/vault/helper/listenerutil  (cached)
?       github.com/hashicorp/vault/helper/metricsutil   [no test files]
ok      github.com/hashicorp/vault/helper/mfa   (cached)
ok      github.com/hashicorp/vault/helper/mfa/duo       (cached)
ok      github.com/hashicorp/vault/helper/namespace     (cached)
ok      github.com/hashicorp/vault/helper/pgpkeys       2.072s
ok      github.com/hashicorp/vault/helper/policies      (cached)
?       github.com/hashicorp/vault/helper/proxyutil     [no test files]
ok      github.com/hashicorp/vault/helper/reload        0.009s
ok      github.com/hashicorp/vault/helper/storagepacker (cached)
?       github.com/hashicorp/vault/helper/testhelpers   [no test files]
?       github.com/hashicorp/vault/helper/testhelpers/consul    [no test files]
?       github.com/hashicorp/vault/helper/testhelpers/docker    [no test files]
?       github.com/hashicorp/vault/helper/testhelpers/ldap      [no test files]
ok      github.com/hashicorp/vault/helper/testhelpers/logical   (cached)
?       github.com/hashicorp/vault/helper/testhelpers/mongodb   [no test files]
?       github.com/hashicorp/vault/helper/testhelpers/teststorage       [no test files]
ok      github.com/hashicorp/vault/helper/xor   (cached)
ok      github.com/hashicorp/vault/http 100.505s
ok      github.com/hashicorp/vault/physical/alicloudoss (cached)
ok      github.com/hashicorp/vault/physical/azure       (cached)
ok      github.com/hashicorp/vault/physical/cassandra   (cached)
ok      github.com/hashicorp/vault/physical/cockroachdb (cached)
ok      github.com/hashicorp/vault/physical/consul      (cached)
ok      github.com/hashicorp/vault/physical/couchdb     (cached)
ok      github.com/hashicorp/vault/physical/dynamodb    (cached)
ok      github.com/hashicorp/vault/physical/etcd        (cached)
?       github.com/hashicorp/vault/physical/foundationdb        [no test files]
ok      github.com/hashicorp/vault/physical/gcs (cached)
ok      github.com/hashicorp/vault/physical/manta       (cached)
ok      github.com/hashicorp/vault/physical/mssql       (cached)
ok      github.com/hashicorp/vault/physical/mysql       (cached)
ok      github.com/hashicorp/vault/physical/oci (cached)
ok      github.com/hashicorp/vault/physical/postgresql  (cached)
ok      github.com/hashicorp/vault/physical/raft        163.486s
?       github.com/hashicorp/vault/physical/raft/logstore       [no test files]
ok      github.com/hashicorp/vault/physical/s3  (cached)
ok      github.com/hashicorp/vault/physical/spanner     (cached)
ok      github.com/hashicorp/vault/physical/swift       (cached)
ok      github.com/hashicorp/vault/physical/zookeeper   (cached)
ok      github.com/hashicorp/vault/plugins/database/cassandra   (cached)
?       github.com/hashicorp/vault/plugins/database/cassandra/cassandra-database-plugin [no test files]
ok      github.com/hashicorp/vault/plugins/database/hana        (cached)
?       github.com/hashicorp/vault/plugins/database/hana/hana-database-plugin   [no test files]
ok      github.com/hashicorp/vault/plugins/database/influxdb    (cached)
?       github.com/hashicorp/vault/plugins/database/influxdb/influxdb-database-plugin   [no test files]
ok      github.com/hashicorp/vault/plugins/database/mongodb     (cached)
?       github.com/hashicorp/vault/plugins/database/mongodb/mongodb-database-plugin     [no test files]
ok      github.com/hashicorp/vault/plugins/database/mssql       (cached)
?       github.com/hashicorp/vault/plugins/database/mssql/mssql-database-plugin [no test files]
ok      github.com/hashicorp/vault/plugins/database/mysql       (cached)
?       github.com/hashicorp/vault/plugins/database/mysql/mysql-database-plugin [no test files]
?       github.com/hashicorp/vault/plugins/database/mysql/mysql-legacy-database-plugin  [no test files]
ok      github.com/hashicorp/vault/plugins/database/postgresql  (cached)
?       github.com/hashicorp/vault/plugins/database/postgresql/postgresql-database-plugin       [no test files]
ok      github.com/hashicorp/vault/shamir       (cached)
ok      github.com/hashicorp/vault/vault        261.552s
?       github.com/hashicorp/vault/vault/cluster        [no test files]
ok      github.com/hashicorp/vault/vault/external_tests/api     38.531s
ok      github.com/hashicorp/vault/vault/external_tests/identity        37.364s
ok      github.com/hashicorp/vault/vault/external_tests/misc    27.001s
ok      github.com/hashicorp/vault/vault/external_tests/policy  4.244s
ok      github.com/hashicorp/vault/vault/external_tests/pprof   9.387s
ok      github.com/hashicorp/vault/vault/external_tests/raft    495.787s
ok      github.com/hashicorp/vault/vault/external_tests/response        3.661s
ok      github.com/hashicorp/vault/vault/external_tests/router  25.409s
ok      github.com/hashicorp/vault/vault/external_tests/token   46.932s
?       github.com/hashicorp/vault/vault/replication    [no test files]
ok      github.com/hashicorp/vault/vault/seal   (cached)
ok      github.com/hashicorp/vault/vault/seal/alicloudkms       (cached)
ok      github.com/hashicorp/vault/vault/seal/awskms    (cached)
ok      github.com/hashicorp/vault/vault/seal/azurekeyvault     (cached)
ok      github.com/hashicorp/vault/vault/seal/gcpckms   (cached)
ok      github.com/hashicorp/vault/vault/seal/ocikms    (cached)
?       github.com/hashicorp/vault/vault/seal/shamir    [no test files]
ok      github.com/hashicorp/vault/vault/seal/transit   (cached)
```