### PR TITLE
[Fix] correct make command in ui page

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -441,7 +441,7 @@ func handleUIStub() http.Handler {
 	<p>To get Vault UI do one of the following:</p>
 	<ul>
 	<li><a href="https://www.vaultproject.io/downloads.html">Download an official release</a></li>
-	<li>Run <code>make release</code> to create your own release binaries.
+	<li>Run <code>make bin</code> to create your own release binaries.
 	<li>Run <code>make dev-ui</code> to create a development binary with the UI.
 	</ul>
 	</div>


### PR DESCRIPTION
In the page vault uses to tell you to build a release if no `ui` is present is says to use `make release` which returns the error `make: *** No rule to make target 'release'.  Stop.`

I am pretty sure that what is meant is to use `make bin`. This PR just updates that command.