### PR TITLE
Revert a change introduced 13dbb3aac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ EXTERNAL_TOOLS=\
 	github.com/kardianos/govendor \
 	github.com/client9/misspell/cmd/misspell \
 	github.com/golangci/golangci-lint/cmd/golangci-lint
-GOFMT_FILES?=$$(find . -name '*.go' | grep -v pb.go | grep -v vendor | grep -v testdata)
+GOFMT_FILES?=$$(find . -name '*.go' | grep -v pb.go | grep -v vendor)
+
 
 GO_VERSION_MIN=1.12.7
 CGO_ENABLED?=0


### PR DESCRIPTION
I merged #7865 a bit prematurely, and we've decided to revert this part of it where `testdata` directories are excluded from formatting. At this time we're not sure this represents an issue outside of a specific setup. cc @swills for awareness and discussion 