### PR TITLE
Backport 1.3.x: agent: add -exit-after-auth flag (#7920)

### DIFF
--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -225,6 +225,16 @@ cache {
 */
 
 func TestAgent_ExitAfterAuth(t *testing.T) {
+	t.Run("via_config", func(t *testing.T) {
+		testAgentExitAfterAuth(t, false)
+	})
+
+	t.Run("via_flag", func(t *testing.T) {
+		testAgentExitAfterAuth(t, true)
+	})
+}
+
+func testAgentExitAfterAuth(t *testing.T, viaFlag bool) {
 	logger := logging.NewVaultLogger(hclog.Trace)
 	coreConfig := &vault.CoreConfig{
 		Logger: logger,
@@ -313,8 +323,13 @@ func TestAgent_ExitAfterAuth(t *testing.T) {
 		logger.Trace("wrote test jwt", "path", in)
 	}
 
+	exitAfterAuthTemplText := "exit_after_auth = true"
+	if viaFlag {
+		exitAfterAuthTemplText = ""
+	}
+
 	config := `
-exit_after_auth = true
+%s
 
 auto_auth {
         method {
@@ -340,23 +355,37 @@ auto_auth {
 }
 `
 
-	config = fmt.Sprintf(config, in, sink1, sink2)
+	config = fmt.Sprintf(config, exitAfterAuthTemplText, in, sink1, sink2)
 	if err := ioutil.WriteFile(conf, []byte(config), 0600); err != nil {
 		t.Fatal(err)
 	} else {
 		logger.Trace("wrote test config", "path", conf)
 	}
 
-	// If this hangs forever until the test times out, exit-after-auth isn't
-	// working
-	ui, cmd := testAgentCommand(t, logger)
-	cmd.client = client
+	doneCh := make(chan struct{})
+	go func() {
+		ui, cmd := testAgentCommand(t, logger)
+		cmd.client = client
 
-	code := cmd.Run([]string{"-config", conf})
-	if code != 0 {
-		t.Errorf("expected %d to be %d", code, 0)
-		t.Logf("output from agent:\n%s", ui.OutputWriter.String())
-		t.Logf("error from agent:\n%s", ui.ErrorWriter.String())
+		args := []string{"-config", conf}
+		if viaFlag {
+			args = append(args, "-exit-after-auth")
+		}
+
+		code := cmd.Run(args)
+		if code != 0 {
+			t.Errorf("expected %d to be %d", code, 0)
+			t.Logf("output from agent:\n%s", ui.OutputWriter.String())
+			t.Logf("error from agent:\n%s", ui.ErrorWriter.String())
+		}
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		break
+	case <-time.After(1 * time.Minute):
+		t.Fatal("timeout reached while waiting for agent to exit")
 	}
 
 	sink1Bytes, err := ioutil.ReadFile(sink1)


### PR DESCRIPTION
* agent: add -exit-after-auth flag

* use short timeout for tests to prevent long test runs on error

* revert sdk/go.mod