### PR TITLE
Add aws metadata to identity alias

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -839,6 +839,12 @@ func (b *backend) pathLoginUpdateEc2(ctx context.Context, req *logical.Request, 
 		},
 		Alias: &logical.Alias{
 			Name: identityAlias,
+			Metadata: map[string]string{
+				"instance_id": identityDocParsed.InstanceID,
+				"region":      identityDocParsed.Region,
+				"account_id":  identityDocParsed.AccountID,
+				"ami_id":      identityDocParsed.AmiID,
+			},
 		},
 	}
 	roleEntry.PopulateTokenAuth(auth)
@@ -1359,6 +1365,16 @@ func (b *backend) pathLoginUpdateIam(ctx context.Context, req *logical.Request, 
 		DisplayName: entity.FriendlyName,
 		Alias: &logical.Alias{
 			Name: identityAlias,
+			Metadata: map[string]string{
+				"client_arn":           callerID.Arn,
+				"canonical_arn":        entity.canonicalArn(),
+				"client_user_id":       callerUniqueId,
+				"auth_type":            iamAuthType,
+				"inferred_entity_type": inferredEntityType,
+				"inferred_entity_id":   inferredEntityID,
+				"inferred_aws_region":  roleEntry.InferredAWSRegion,
+				"account_id":           entity.AccountNumber,
+			},
 		},
 	}
 	roleEntry.PopulateTokenAuth(auth)


### PR DESCRIPTION
This allows for writing identity token templates that include these attributes
(And including these attributes in path templates)