### PR TITLE
Backport 1.3.x: plugin: fix panic on router.MatchingSystemView if backend is nil (#7991)

### DIFF
--- a/vault/router.go
+++ b/vault/router.go
@@ -416,7 +416,7 @@ func (r *Router) MatchingSystemView(ctx context.Context, path string) logical.Sy
 	r.l.RLock()
 	_, raw, ok := r.root.LongestPrefix(path)
 	r.l.RUnlock()
-	if !ok {
+	if !ok || raw.(*routeEntry).backend == nil {
 		return nil
 	}
 	return raw.(*routeEntry).backend.System()


### PR DESCRIPTION
* plugin: fix panic on router.MatchingSystemView if backend is nil

* correctly determine the plugin binary file in the directory

* docs: simplify plugin file removal