### PR TITLE
Transit: error when restoring to a name that looks like a path

### DIFF
--- a/builtin/logical/transit/path_restore.go
+++ b/builtin/logical/transit/path_restore.go
@@ -2,6 +2,8 @@ package transit
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -42,8 +44,19 @@ func (b *backend) pathRestoreUpdate(ctx context.Context, req *logical.Request, d
 		return logical.ErrorResponse("'backup' must be supplied"), nil
 	}
 
-	return nil, b.lm.RestorePolicy(ctx, req.Storage, d.Get("name").(string), backupB64, force)
+	keyName := d.Get("name").(string)
+	// if a name is given, make sure it does not contain any slashes and look like
+	// a path
+	if keyName != "" {
+		if strings.Contains(keyName, "/") {
+			return nil, ErrInvalidKeyName
+		}
+	}
+
+	return nil, b.lm.RestorePolicy(ctx, req.Storage, keyName, backupB64, force)
 }
 
 const pathRestoreHelpSyn = `Restore the named key`
 const pathRestoreHelpDesc = `This path is used to restore the named key.`
+
+var ErrInvalidKeyName = errors.New("key names cannot be paths")

--- a/builtin/logical/transit/path_restore_test.go
+++ b/builtin/logical/transit/path_restore_test.go
@@ -2,15 +2,12 @@ package transit
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/vault/helper/testhelpers"
 	"github.com/hashicorp/vault/sdk/logical"
 )
-
-var ErrInvalidKeyName = errors.New("key names cannot be paths")
 
 func TestTransit_Restore(t *testing.T) {
 	// Test setup:


### PR DESCRIPTION
When creating a key in the Transit backend, the `:name` cannot be a path, and is enforced by [this regex][1]. This means all keys are (effectively) created and then read from the path `keys/:name` (ex. `keys/test-key`), and sub-path names are not allowed (ex. `keys/sub/path/test-key`)

When restoring a key, an optional `:name` attribute can be specified. If omitted, the name encoded in the key is used (`:force` required to overwrite an existing key). If `:name` is included, the key is restored to a the new name. Because `:name` in the restore process is optional, the regex that governs it is [less restrictive][2]. This means that the original limitation is not enforced, and it's possible to restore keys to sub-paths. The end result is a key that cannot be read, as reported in #7663. 

Worse yet, the key is actually there, and shows in `LIST` results, but just the first part of the path:

```
$ vault list transit/keys
Keys
----
sub/
test-key
```

<details>

```
$ vault secrets enable transit
Success! Enabled the transit secrets engine at: transit/

$ vault write /transit/keys/test-key type=rsa-2048 exportable=true allow_plaintext_backup=true
Success! Data written to: transit/keys/test-key

$ vault read --field=backup /transit/backup/test-key | vault write /transit/restore/sub/path/test-key2 backup=-
Success! Data written to: transit/restore/sub/path/test-key2

$ vault list transit/keys
Keys
----
sub/
test-key

```

</details>

Attempting to read the key at that path fails:

```
$ vault read transit/keys/sub/path/test-key2
No value found at transit/keys/sub/path/test-key2
```

The regex for the key names (`:name` field) is evaluated at the router layer, so if the regex fails there, then the request doesn't even make it to the backed itself ([pathPolicyRead][3] is never called). 

This PR changes the `restore` endpoint to verify the `:name`, if given, does not contain any `/`  
characters, which would denote a sub-path. This prevents keys from being restored to names that are sub-paths which cannot be read later. 

Fixes #7663


[1]: https://github.com/hashicorp/vault/blob/ab0be034866fb7ea3f68c87d4c06d31b31b338a2/builtin/logical/transit/path_keys.go#L37

[2]: https://github.com/hashicorp/vault/blob/ab0be034866fb7ea3f68c87d4c06d31b31b338a2/builtin/logical/transit/path_restore.go#L12

[3]: https://github.com/hashicorp/vault/blob/ab0be034866fb7ea3f68c87d4c06d31b31b338a2/builtin/logical/transit/path_keys.go#L190