### PR TITLE
overwrite bulma bug that crashes safari

### DIFF
--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -30,6 +30,7 @@
 @import './core/navbar';
 @import './core/notification';
 @import './core/progress';
+@import './core/select';
 @import './core/switch';
 @import './core/tables';
 @import './core/tags';

--- a/ui/app/styles/core/select.scss
+++ b/ui/app/styles/core/select.scss
@@ -1,0 +1,3 @@
+.select select {
+  text-rendering: auto !important;
+}


### PR DESCRIPTION
# Fix dropdowns for Safari & Mojave
`select` elements were not working for certain versions of Safari on Mojave & causing the browser to crash. This came up when a customer could not log into the Vault UI, and was the same problem that TFC encountered. This PR uses the [same fix](https://github.com/hashicorp/atlas/pull/8149/commits) by overwrriting Bulma.

Fixes https://github.com/hashicorp/vault/issues/7942


### Testing
While running Safari & Mojave:
1. Open the Vault login screen
2. Select an item from the auth method dropdown

You should be able to sign in without safari crashing 🎉 