### PR TITLE
Vendor "Fix SRV record lookup if address scheme is known"

### DIFF
--- a/vendor/github.com/hashicorp/vault/api/client.go
+++ b/vendor/github.com/hashicorp/vault/api/client.go
@@ -678,6 +678,12 @@ func (c *Client) SetPolicyOverride(override bool) {
 	c.policyOverride = override
 }
 
+// portMap defines the standard port map
+var portMap = map[string]string{
+	"http":   "80",
+	"https":  "443",
+}
+
 // NewRequest creates a new raw request object to query the Vault server
 // configured for this client. This is an advanced method and generally
 // doesn't need to be called externally.
@@ -694,10 +700,16 @@ func (c *Client) NewRequest(method, requestPath string) *Request {
 	// record and take the highest match; this is not designed for high-availability, just discovery
 	var host string = addr.Host
 	if addr.Port() == "" {
-		// Internet Draft specifies that the SRV record is ignored if a port is given
-		_, addrs, err := net.LookupSRV("http", "tcp", addr.Hostname())
-		if err == nil && len(addrs) > 0 {
-			host = fmt.Sprintf("%s:%d", addrs[0].Target, addrs[0].Port)
+		// Avoid lookup of SRV record if scheme is known
+		port, ok := portMap[addr.Scheme]
+		if ok {
+			host = net.JoinHostPort(host,  port)
+		} else {
+			// Internet Draft specifies that the SRV record is ignored if a port is given
+			_, addrs, err := net.LookupSRV("http", "tcp", addr.Hostname())
+			if err == nil && len(addrs) > 0 {
+				host = fmt.Sprintf("%s:%d", addrs[0].Target, addrs[0].Port)
+			}
 		}
 	}
 


### PR DESCRIPTION
I happened to notice that when I ran `$ go mod vendor`, this file changed. This is a result of #8016 yesterday. Just vendoring it to make sure it gets picked up where intended.