### PR TITLE
Avoid potential panic in LDAP client

### DIFF
--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -85,12 +85,13 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 		}
 		retErr = multierror.Append(retErr, errwrap.Wrapf(fmt.Sprintf("error connecting to host %q: {{err}}", uut), err))
 	}
-
+	if retErr != nil {
+		return nil, retErr
+	}
 	if timeout := cfg.RequestTimeout; timeout > 0 {
 		conn.SetTimeout(time.Duration(timeout) * time.Second)
 	}
-
-	return conn, retErr.ErrorOrNil()
+	return conn, nil
 }
 
 /*

--- a/sdk/helper/ldaputil/client_test.go
+++ b/sdk/helper/ldaputil/client_test.go
@@ -2,7 +2,24 @@ package ldaputil
 
 import (
 	"testing"
+
+	"github.com/hashicorp/go-hclog"
 )
+
+func TestDialLDAP(t *testing.T) {
+	ldapClient := Client{
+		Logger: hclog.NewNullLogger(),
+		LDAP:   NewLDAP(),
+	}
+
+	ce := &ConfigEntry{
+		Url:            "ldap://nowherefoo.com",
+		RequestTimeout: 3,
+	}
+	if _, err := ldapClient.DialLDAP(ce); err == nil {
+		t.Fatal("expected error")
+	}
+}
 
 func TestLDAPEscape(t *testing.T) {
 	testcases := map[string]string{

--- a/sdk/helper/ldaputil/client_test.go
+++ b/sdk/helper/ldaputil/client_test.go
@@ -16,7 +16,7 @@ func TestDialLDAP(t *testing.T) {
 	}
 
 	ce := &ConfigEntry{
-		Url:            "ldap://nowherefoo.com",
+		Url:            "ldap://localhost:384654786",
 		RequestTimeout: 3,
 	}
 	if _, err := ldapClient.DialLDAP(ce); err == nil {

--- a/sdk/helper/ldaputil/client_test.go
+++ b/sdk/helper/ldaputil/client_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+// TestDialLDAP duplicates a potential panic that was
+// present in the previous version of TestDialLDAP,
+// then confirms its fix by passing.
 func TestDialLDAP(t *testing.T) {
 	ldapClient := Client{
 		Logger: hclog.NewNullLogger(),

--- a/vendor/github.com/hashicorp/vault/sdk/helper/ldaputil/client.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/ldaputil/client.go
@@ -85,12 +85,13 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 		}
 		retErr = multierror.Append(retErr, errwrap.Wrapf(fmt.Sprintf("error connecting to host %q: {{err}}", uut), err))
 	}
-
+	if retErr != nil {
+		return nil, retErr
+	}
 	if timeout := cfg.RequestTimeout; timeout > 0 {
 		conn.SetTimeout(time.Duration(timeout) * time.Second)
 	}
-
-	return conn, retErr.ErrorOrNil()
+	return conn, nil
 }
 
 /*


### PR DESCRIPTION
This PR fixes a potential panic in the LDAP client that was introduced after the 1.3.0 release.