### PR TITLE
Add independent vault token env variable for transit seal

### DIFF
--- a/vault/seal/transit/transit_client.go
+++ b/vault/seal/transit/transit_client.go
@@ -73,6 +73,14 @@ func newTransitClient(logger log.Logger, config map[string]string) (*transitClie
 		namespace = config["namespace"]
 	}
 
+	var token string
+	switch {
+	case os.Getenv("VAULT_TRANSIT_SEAL_TOKEN") != "":
+		token = os.Getenv("VAULT_TRANSIT_SEAL_TOKEN")
+	case config["token"] != "":
+		token = config["token"]
+	}
+
 	apiConfig := api.DefaultConfig()
 	if config["address"] != "" {
 		apiConfig.Address = config["address"]
@@ -105,8 +113,8 @@ func newTransitClient(logger log.Logger, config map[string]string) (*transitClie
 	if err != nil {
 		return nil, nil, err
 	}
-	if config["token"] != "" {
-		apiClient.SetToken(config["token"])
+	if token != "" {
+		apiClient.SetToken(token)
 	}
 	if namespace != "" {
 		apiClient.SetNamespace(namespace)

--- a/website/source/docs/configuration/seal/transit.html.md
+++ b/website/source/docs/configuration/seal/transit.html.md
@@ -50,7 +50,7 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
   This may also be specified by the `VAULT_ADDR` environment variable.
 
 - `token` `(string: <required>)`: The Vault token to use. This may also be
-  specified by the `VAULT_TOKEN` environment variable.
+  specified by the `VAULT_TOKEN` or `VAULT_TRANSIT_SEAL_TOKEN` environment variable.
 
 - `key_name` `(string: <required>)`: The transit key to use for encryption and
   decryption.  This may also be supplied using the `VAULT_TRANSIT_SEAL_KEY_NAME`


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault/issues/7176

This PR adds an independent environment variable to specify the token used by Transit Seal. This allows users to avoid conflicts with the usual `VAULT_TOKEN` environment variable. 