### PR TITLE
Fix automatic token set for plugin unwrap requests

### DIFF
--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -119,7 +119,7 @@ func VaultPluginTLSProvider(apiTLSConfig *TLSConfig) func() (*tls.Config, error)
 		}
 
 		// Reset token value to make sure nothing has been set by default
-		client.SetToken("")
+		client.ClearToken()
 
 		secret, err := client.Logical().Unwrap(unwrapToken)
 		if err != nil {

--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -118,6 +118,9 @@ func VaultPluginTLSProvider(apiTLSConfig *TLSConfig) func() (*tls.Config, error)
 			return nil, errwrap.Wrapf("error during api client creation: {{err}}", err)
 		}
 
+		// Reset token value to make sure nothing has been set by default
+		client.SetToken("")
+
 		secret, err := client.Logical().Unwrap(unwrapToken)
 		if err != nil {
 			return nil, errwrap.Wrapf("error during token unwrap request: {{err}}", err)


### PR DESCRIPTION
Inspired by https://github.com/hashicorp/vault/pull/8056 `NewClient` automatically sets the token for the client even tho we don't need a token to send a `sys/wrapping/unwrap`-request.

Fixes #7176 