### PR TITLE
Replace deprecated AWS client instantiations

### DIFF
--- a/builtin/logical/aws/client.go
+++ b/builtin/logical/aws/client.go
@@ -74,9 +74,11 @@ func nonCachedClientIAM(ctx context.Context, s logical.Storage) (*iam.IAM, error
 	if err != nil {
 		return nil, err
 	}
-
-	client := iam.New(session.New(awsConfig))
-
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, err
+	}
+	client := iam.New(sess)
 	if client == nil {
 		return nil, fmt.Errorf("could not obtain iam client")
 	}
@@ -88,8 +90,11 @@ func nonCachedClientSTS(ctx context.Context, s logical.Storage) (*sts.STS, error
 	if err != nil {
 		return nil, err
 	}
-	client := sts.New(session.New(awsConfig))
-
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, err
+	}
+	client := sts.New(sess)
 	if client == nil {
 		return nil, fmt.Errorf("could not obtain sts client")
 	}

--- a/physical/s3/s3_test.go
+++ b/physical/s3/s3_test.go
@@ -7,15 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-
+	"github.com/aws/aws-sdk-go/service/s3"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/awsutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 func TestDefaultS3Backend(t *testing.T) {

--- a/physical/s3/s3_test.go
+++ b/physical/s3/s3_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
+
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/awsutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
@@ -51,11 +52,15 @@ func DoS3BackendTest(t *testing.T, kmsKeyId string) {
 		region = "us-east-1"
 	}
 
-	s3conn := s3.New(session.New(&aws.Config{
+	sess, err := session.NewSession(&aws.Config{
 		Credentials: credsChain,
 		Endpoint:    aws.String(endpoint),
 		Region:      aws.String(region),
-	}))
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s3conn := s3.New(sess)
 
 	var randInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	bucket := fmt.Sprintf("vault-s3-testacc-%d", randInt)


### PR DESCRIPTION
This PR is to replace deprecated AWS client instantiations at all points where they exist in Vault. This PR has some overlap with https://github.com/hashicorp/vault/pull/7738, but updates the client in more places. It doesn't really matter which of these gets merged first, probably best to merge whichever is ready first.

I ran acceptance tests locally with a valid AWS key and secret to verify that nothing was broken. I can't post the output of all tests because some of it may be sensitive. However, all tests passed and none were skipped as a result of this call:
```
tbex@pop-os:~/go/src/github.com/hashicorp/vault/builtin/logical/aws$ go test -v ./...
```
Also, the s3 tests were run and passed and are safe to post:
```
tbex@pop-os:~/go/src/github.com/hashicorp/vault/physical/s3$ go test -v ./...
=== RUN   TestDefaultS3Backend
--- PASS: TestDefaultS3Backend (6.70s)
=== RUN   TestS3BackendSseKms
--- PASS: TestS3BackendSseKms (6.42s)
PASS
ok  	github.com/hashicorp/vault/physical/s3	13.128s
```