### PR TITLE
Change box-radio height to min-height to prevent overflow issues

### DIFF
--- a/ui/app/styles/components/box-radio.scss
+++ b/ui/app/styles/components/box-radio.scss
@@ -11,7 +11,7 @@
   box-sizing: border-box;
   flex-basis: 7rem;
   width: 7rem;
-  height: 7.5rem;
+  min-height: 7.5rem;
   padding: $size-10 $size-6 $size-10;
   flex-direction: column;
   justify-content: space-between;


### PR DESCRIPTION
This PR address an overflow issue that was experienced on an older version of Firefox - [#6562](https://github.com/hashicorp/vault/issues/6562).

I could not replicate it on the version of Firefox used, or any other browsers, but the min-height did fix the issue if the text was longer.  See below.  

<img width=500 src="https://user-images.githubusercontent.com/6618863/71280509-a2753900-2318-11ea-9186-f366242c68cf.gif">

I tested this in the latest versions of Firefox, Safari, Chrome, and IE-edge. 