### PR TITLE
To CONTRIBUTING.md, add PR instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,31 @@ quickly merge or address your contributions.
 5. The issue is closed. Sometimes, valid issues will be closed to keep
    the issue tracker clean. The issue is still indexed and available for
    future viewers, or can be re-opened if necessary.
+   
+## Pull Requests
+
+We deeply appreciate community pull requests and have placed this guide here to help 
+you complete yours in as few iterations as possible. Please note, Github offers 
+[Draft Pull Requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) 
+which you are welcome to use as you prepare for review.
+
+A PR that's ready for review was the following components:
+
+- A link to any issues the PR closes, though it isn't required that a PR be related to an open issue.
+
+  - Alternatively, please discuss the motivation for the PR, such as the use case, including steps to 
+    reproduce the problem the PR solves.
+    
+- The code that's been changed, of course.
+
+- At least one each of a positive and negative path for the changed code.
+
+- If the code's tests are not automated, output from running the tests locally on your machine.
+
+- Updated docs, if any are needed.
+
+- As a final step, if any dependencies have been added or stripped, `$ go mod` and `$ go mod vendor`
+may be required to update Vault's `vendor` directory.
 
 ## Setting up Go to work on Vault
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ A PR that's ready for review was the following components:
     
 - The code that's been changed, of course.
 
-- At least one each of a positive and negative path for the changed code.
+- At least one each of a positive and negative test for the changed code.
 
 - If the code's tests are not automated, output from running the tests locally on your machine.
 


### PR DESCRIPTION
Relates to #8068 

This PR is simply to add some "How to PR" instructions to our CONTRIBUTING.md file, which is shown to anyone doing a first-time PR. I implemented this on the Terraform Vault Provider and it turned out really nicely, I got a much higher percentage of PRs that were 100% ready to go on the first pass of the review. Seems like it might be useful here too. 