### PR TITLE
Add PR template

### DIFF
--- a/.github/PR_TEMPLATE.md
+++ b/.github/PR_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Problem
+
+_What problem are you trying to solve? Issue link, use case, or steps to reproduce?
+This should be understandable to someone with no context regarding the problem._
+
+## Checklist
+
+- [ ] Positive and negative test coverage
+- [ ] Tests shown to be successful either through automated tests or a copy-paste of running the PR's tests locally
+- [ ] Updated docs if applicable
+- [ ] Updated dependencies if applicable (`$ go mod` and `$ go mod vendor`)


### PR DESCRIPTION
Relates to #8067 

Adds a PR template including a problem statement and checklist to help folks nail their PRs the first time around.

TODO
- If accepted, need to configure this PR template in Vault settings.