### PR TITLE
Fix typos in doc

### DIFF
--- a/website/source/api/system/namespaces.html.md
+++ b/website/source/api/system/namespaces.html.md
@@ -40,7 +40,7 @@ $ curl \
 
 ## Create Namespace
 
-This endpoint creates a namespace at the givent path.
+This endpoint creates a namespace at the given path.
 
 | Method   | Path                         |
 | :--------------------------- | :--------------------- |

--- a/website/source/docs/secrets/identity/index.html.md
+++ b/website/source/docs/secrets/identity/index.html.md
@@ -187,7 +187,7 @@ Identity tokens will always contain, at a minimum, the claims required by OIDC:
 * `iss` - Issuer URL
 * `sub` - Requester's entity ID
 * `aud` - `client_id` for the role
-* `iss` - Time of issue
+* `iat` - Time of issue
 * `exp` - Expiration time for the token
 
 In addition, the operator may configure per-role templates that allow a variety
@@ -228,7 +228,7 @@ which would be merged with the base OIDC claims into the final token:
   "iss": "https://10.1.1.45:8200/v1/identity/oidc",
   "sub": "a2cd63d3-5364-406f-980e-8d71bb0692f5",
   "aud": "SxSouteCYPBoaTFy94hFghmekos",
-  "iss": 1561411915,
+  "iat": 1561411915,
   "exp": 1561412215,
   "color": "green",
   "userinfo": {


### PR DESCRIPTION
This PR fixes 2 tiny typos:

- one extra keystroke in the namespace API documentation
- one misleading confusion between `iat` and `iss` claims of the Identify Token claims

This mismatch between `iat` and `iss` is the most visible in the second occurence, when a sample token  has 2 `iss` keys, one with the real & correct issuer, and then a second one with the issued-at epoch:


> which would be merged with the base OIDC claims into the final token:
```
{
  "iss": "https://10.1.1.45:8200/v1/identity/oidc",
  "sub": "a2cd63d3-5364-406f-980e-8d71bb0692f5",
  "aud": "SxSouteCYPBoaTFy94hFghmekos",
  "iss": 1561411915,
  "exp": 1561412215,
  "color": "green",
  "userinfo": {
     "username": "bob",
     "groups": ["web", "engr", "default"]
  },
  "nbf": 1561411915,
}
```