### PR TITLE
Add documentation about flag -target=recovery for auto-unseal mode

### DIFF
--- a/website/source/guides/operations/rekeying-and-rotating.html.md
+++ b/website/source/guides/operations/rekeying-and-rotating.html.md
@@ -68,6 +68,8 @@ Rekeying the Vault requires a quorum of unseal keys. Before continuing, you
 should ensure enough unseal key holders are available to assist with the
 rekeying to match the threshold configured when the keys were issued.
 
+Please also observe that if Vault is configured with *auto_unseal* (and the keys thus are the *recovery_keys*) an extra flag `-target=recovery` has to be provided for each of the commands below. Otherwise the *key-shares* will default to **1** no matter what value you set.
+
 First, initialize a rekeying operation. The flags represent the **newly
 desired** number of keys and threshold:
 


### PR DESCRIPTION
The exact wording or style does not matter for me. The important thing is that information about this extra flag is given. (As mentioned in https://github.com/hashicorp/vault/issues/6658)