### PR TITLE
Add additional check for consul storage backend TLS options

### DIFF
--- a/serviceregistration/consul/consul_service_registration.go
+++ b/serviceregistration/consul/consul_service_registration.go
@@ -267,6 +267,8 @@ func setupTLSConfig(conf map[string]string, address string) (*tls.Config, error)
 		}
 
 		tlsClientConfig.Certificates = []tls.Certificate{tlsCert}
+	} else if okCert || okKey {
+		return nil, fmt.Errorf("both tls_cert_file and tls_key_file must be provided")
 	}
 
 	if tlsCaFile, ok := conf["tls_ca_file"]; ok {


### PR DESCRIPTION
Fixes #4930

Adds an additional check for the Consul storage backend to make sure that both client cert and client key were provided. 