### PR TITLE
Documents `CONSUL_HTTP_TOKEN` in consul.html.md

### DIFF
--- a/website/source/docs/configuration/storage/consul.html.md
+++ b/website/source/docs/configuration/storage/consul.html.md
@@ -100,7 +100,8 @@ and [`cluster_addr`][cluster-addr] ([example][listener-example]).
 
 - `token` `(string: "")` – Specifies the [Consul ACL token][consul-acl] with
   permission to read and write from the `path` in Consul's key-value store.
-  This is **not** a Vault token. See the ACL section below for help.
+  This is **not** a Vault token. This can also be provided via the environment
+  variable [`CONSUL_HTTP_TOKEN`][consul-token]. See the ACL section below for help.
 
 - `session_ttl` `(string: "15s")` - Specifies the minimum allowed [session
   TTL][consul-session-ttl]. Consul server has a lower limit of 10s on the
@@ -273,6 +274,7 @@ storage "consul" {
 [consul-consistency]: https://www.consul.io/api/index.html#consistency-modes "Consul Consistency Modes"
 [consul-encryption]: https://www.consul.io/docs/agent/encryption.html "Consul Encryption"
 [consul-translate-wan-addrs]: https://www.consul.io/docs/agent/options.html#translate_wan_addrs "Consul Configuration"
+[consul-token]: https://www.consul.io/docs/commands/acl/set-agent-token.html#token-lt-value-gt- "Consul Token"
 [consul-session-ttl]: https://www.consul.io/docs/agent/options.html#session_ttl_min "Consul Configuration"
 [api-addr]: /docs/configuration/index.html#api_addr
 [cluster-addr]: /docs/configuration/index.html#cluster_addr


### PR DESCRIPTION
Adds a note that the `token` parameter for Consul storage may also be provided via the `CONSUL_HTTP_TOKEN` environment variable.

I was recently working on deploying a Vault cluster using [the Vault Helm Chart](https://github.com/hashicorp/vault-helm) via Terraform and was trying to work out how to pass the Consul token to Vault while maintaining its security (i.e., not reading it in Terraform via `data.kubenetes_secret`, since it would end up being stored in state in plaintext, and also not storing the token itself in plaintext in my Terraform config). It would've been helpful to me if the ability to use `CONSUL_HTTP_TOKEN` had been documented on [vaultproject.io](https://www.vaultproject.io/docs/configuration/storage/consul.html#token). Eventually I found it on documented on [consul.io](https://www.consul.io/docs/commands/acl/set-agent-token.html#token-lt-value-gt-) and wondered if it would work, and it did.

We were originally interpolating the token in `VAULT_LOCAL_CONFIG` via something like `consul { token = $(CONSUL_TOKEN) }` where `CONSUL_TOKEN` was an environment variable whose value came from a `secretKeyRef`. That didn't work with the Vault Helm Chart since the content of `VAULT_LOCAL_CONFIG` is stored to `/vault/config/local.json` in the container by the `docker-entrypoint.sh` script but the Vault Helm Chart mounts a ConfigMap to `/vault/config` instead, resulting in failures to start the container because that location is a read-only file system.