### PR TITLE
Allow easier swapping of Go version

### DIFF
--- a/scripts/goversioncheck.sh
+++ b/scripts/goversioncheck.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
+GO_CMD=${GO_CMD:-go}
+
 GO_VERSION_MIN=$1
 echo "==> Checking that build is using go version >= $1..."
 
-if go version | grep -q devel;
+if $GO_CMD version | grep -q devel;
 then
 	GO_VERSION="devel"
 else
-	GO_VERSION=$(go version | grep -o 'go[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?' | tr -d 'go')
+	GO_VERSION=$($GO_CMD version | grep -o 'go[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?' | tr -d 'go')
 
 	IFS="." read -r -a GO_VERSION_ARR <<< "$GO_VERSION"
 	IFS="." read -r -a GO_VERSION_REQ <<< "$GO_VERSION_MIN"


### PR DESCRIPTION
This adds support for using an alternate Go binary if `GO_CMD` is set, which can be useful if you want to test against multiple Go versions, e.g.:

```
$ go get golang.org/dl/go1.13rc1
$ go1.13rc1 download
$ go1.13rc1 get|build|...
$ export GO_CMD=go1.13rc1
```
