### PR TITLE
Fix DB static role credential rotation replication issue

### DIFF
--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/queue"
@@ -149,19 +148,7 @@ func (b *databaseBackend) pathRotateRoleCredentialsUpdate() framework.OperationF
 			return nil, err
 		}
 
-		// Send a canary to force a guard check which prevents the client
-		// to run in a timeout if the request was originally send to a
-		// performance secondary/standby node.
-		canaryUUID, err := uuid.GenerateUUID()
-		if err != nil {
-			return nil, err
-		}
-		canaryEntry := &logical.StorageEntry{
-			Key:   "core/replication-canary",
-			Value: []byte(canaryUUID),
-		}
-
-		return nil, req.Storage.Put(ctx, canaryEntry)
+		return nil, nil
 	}
 }
 

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/queue"
 )
@@ -104,6 +106,11 @@ func (b *databaseBackend) pathRotateRoleCredentialsUpdate() framework.OperationF
 			return logical.ErrorResponse("empty role name attribute given"), nil
 		}
 
+		// If on a performance secondary/standby, forward this request on to the primary
+		if b.System().ReplicationState().HasState(consts.ReplicationPerformanceSecondary | consts.ReplicationPerformanceStandby) {
+			return nil, logical.ErrReadOnly
+		}
+
 		role, err := b.StaticRole(ctx, req.Storage, name)
 		if err != nil {
 			return nil, err
@@ -144,6 +151,21 @@ func (b *databaseBackend) pathRotateRoleCredentialsUpdate() framework.OperationF
 			return nil, err
 		}
 
+		// Send a canary to force a guard check which prevents the client
+		// to run in a timeout if the request was originally send to a
+		// performance secondary/standby node.
+		if b.System().ReplicationState().HasState(consts.ReplicationPerformanceSecondary | consts.ReplicationPerformanceStandby) {
+			canaryUUID, err := uuid.GenerateUUID()
+			if err != nil {
+				return nil, err
+			}
+			canaryEntry := &logical.StorageEntry{
+				Key:   "core/replication-canary",
+				Value: []byte(canaryUUID),
+			}
+
+			return nil, req.Storage.Put(ctx, canaryEntry)
+		}
 		return nil, nil
 	}
 }


### PR DESCRIPTION
This PR fixes a bug that prevents Vault performance secondaries and performance standby's to successfully forward a manual static role credential rotation request e.g. `vault write -f database/rotate-role/education`. 

To prevent the client to run in a timeout: https://github.com/hashicorp/vault/blob/31bbb813e7b8250a1e9ffe09ddc81e8f2653b476/http/handler.go#L642 

And the manual static role credential rotation method does not store anything in the backend (which usually triggers a guard check), we have to store a canary to make sure that a guard check is triggered.