### PR TITLE
Docs: Add note about needing to do plugin reload on each node

### DIFF
--- a/website/source/docs/upgrading/plugins.html.md
+++ b/website/source/docs/upgrading/plugins.html.md
@@ -35,4 +35,9 @@ with either the `plugin` or `mounts` parameter respectively.
 Until step 4, the mount will still use plugin_v1, and when the reload is
 triggered, Vault will kill plugin_v1’s process and start a plugin_v2 process.
 
+-> **Important:** Plugin registration and reload of a new plugin binary must be 
+performed on each Vault instance within all clusters. Performing a plugin 
+upgrade on a single instance or through a load balancer can result in mismatched 
+plugin binaries within a cluster. 
+
 [plugin_reload_api]: /api/system/plugins-reload-backend.html

--- a/website/source/docs/upgrading/plugins.html.md
+++ b/website/source/docs/upgrading/plugins.html.md
@@ -35,9 +35,9 @@ with either the `plugin` or `mounts` parameter respectively.
 Until step 4, the mount will still use plugin_v1, and when the reload is
 triggered, Vault will kill plugin_v1’s process and start a plugin_v2 process.
 
--> **Important:** Plugin registration and reload of a new plugin binary must be 
-performed on each Vault instance within all clusters. Performing a plugin 
-upgrade on a single instance or through a load balancer can result in mismatched 
+-> **Important:** Plugin reload of a new plugin binary must be 
+performed on each Vault instance. Performing a plugin upgrade on a single 
+instance or through a load balancer can result in mismatched 
 plugin binaries within a cluster. 
 
 [plugin_reload_api]: /api/system/plugins-reload-backend.html


### PR DESCRIPTION
Specifically calling this out will heed off operators doing this on a single node and thinking it is a bug that it didn't propagate to the other nodes, secondaries, etc.
