### PR TITLE
Docs: Add telemetry reference to answer "where are the metrics listed"?

### DIFF
--- a/website/source/docs/configuration/telemetry.html.md
+++ b/website/source/docs/configuration/telemetry.html.md
@@ -11,7 +11,8 @@ description: |-
 # `telemetry` Stanza
 
 The `telemetry` stanza specifies various configurations for Vault to publish
-metrics to upstream systems.
+metrics to upstream systems. Available Vault metrics can be found in the
+[Telemetry internals documentation](/docs/internals/telemetry.html).
 
 ```hcl
 telemetry {


### PR DESCRIPTION
Few customers have asked what metrics are there when on this page
https://www.vaultproject.io/docs/configuration/telemetry.html

This just adds a link back to the page that has them. 