### PR TITLE
Fix delete namespaces

### DIFF
--- a/ui/lib/core/addon/templates/components/list-view.hbs
+++ b/ui/lib/core/addon/templates/components/list-view.hbs
@@ -5,7 +5,7 @@
   )
 }}
   <div class="box is-fullwidth is-bottomless is-sideless is-paddingless" data-test-list-view-list>
-    {{#each (or items.content items) as |item|}}
+    {{#each items as |item|}}
       {{yield (hash item=item)}}
     {{else}}
       {{yield}}

--- a/ui/lib/core/stories/list-view.stories.js
+++ b/ui/lib/core/stories/list-view.stories.js
@@ -12,20 +12,11 @@ filtered.set('meta', {
   total: 100,
 });
 
-let paginated = ArrayProxy.create({
-  content: [{ id: 'middle' }, { id: 'of' }, { id: 'the' }, { id: 'list' }],
-});
-paginated.set('meta', {
-  lastPage: 10,
-  currentPage: 4,
-  total: 100,
-});
-
+// TODO: add a pagination option when we have a better way to fake Ember models in Storybook.
 let options = {
   list: [{ id: 'one' }, { id: 'two' }],
   empty: [],
   filtered,
-  paginated,
 };
 
 storiesOf('ListView/', module)


### PR DESCRIPTION
# Fix Delete Namespaces
This PR fixes a bug where users were unable to delete namespaces. The bug was introduced by using the new `Confirm` component, but was ultimately a problem the `ListView` component. Accessing `items.content` within the `ListView` component returned an `InternalModel` instead of a `Model`, which led us to be unable to call `model.destroyRecord` [here](https://github.com/hashicorp/vault/blob/master/ui/lib/core/addon/components/list-item.js#L17).

We originally added the `items.content` so the `ListView` would [work with Storybook](https://github.com/hashicorp/vault/pull/7129#discussion_r305129155) but it is no longer necessary, so I've removed it to fix the bug.

### Before
![image](https://user-images.githubusercontent.com/903288/72178003-c61b2480-3396-11ea-89cc-1a0d5691c7d0.png)

### After
![image](https://user-images.githubusercontent.com/903288/72177977-bb608f80-3396-11ea-9aa9-7cce3d282d97.png)

## Testing
1. In the UI, navigate to Access --> Namespaces
2. Create a namespace
- [x] You should be able to delete a namespace

1. Open up the Storybook netlify link for this PR
- [ ] Verify the `ListView` component works the same as it does on the [master Storybook](https://vault-storybook.netlify.com/?path=/story/listview--listview)