### PR TITLE
WIP: Vault Agent: Add configuration for maximum connection attempts

### DIFF
--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -8,7 +8,6 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
-	"github.com/y0ssar1an/q"
 )
 
 type AuthMethod interface {
@@ -96,7 +95,6 @@ func (ah *AuthHandler) RunWithMaxAttempts(ctx context.Context, am AuthMethod, ma
 		close(ah.DoneCh)
 		close(ah.TemplateTokenCh)
 		ah.logger.Info("auth handler stopped")
-		q.Q(">-->Auth Handler defer func")
 	}()
 
 	credCh := am.NewCreds()
@@ -132,7 +130,6 @@ func (ah *AuthHandler) RunWithMaxAttempts(ctx context.Context, am AuthMethod, ma
 
 		if maxConnectionAttempts > 0 && connErrCount >= maxConnectionAttempts {
 			ah.logger.Error("too many connection attempts, quitting", "attempts", maxConnectionAttempts)
-			q.Q("->>->> auth handler max attempts, return")
 			return
 		}
 

--- a/command/agent/auth/auth_test.go
+++ b/command/agent/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
+	"github.com/y0ssar1an/q"
 )
 
 type userpassTestMethod struct{}
@@ -51,6 +53,25 @@ func (u *userpassTestMethod) CredSuccess() {
 }
 
 func (u *userpassTestMethod) Shutdown() {
+}
+
+// fakeTestMethod is meant to fake the minimum amount needed to get to the point
+// where testing connection failed attempts is possible
+type fakeTestMethod struct {
+	// embed a userpassTestMethod to inherit NewCreds, CredSuccess, and Shutdown
+	// methods
+	*userpassTestMethod
+}
+
+func newFakeTestMethod(t *testing.T, client *api.Client) AuthMethod {
+	return &fakeTestMethod{}
+}
+
+func (u *fakeTestMethod) Authenticate(_ context.Context, client *api.Client) (string, map[string]interface{}, error) {
+	// simply need to return something here
+	return "auth/userpass/login/foo", map[string]interface{}{
+		"password": "bar",
+	}, nil
 }
 
 func TestAuthHandler(t *testing.T) {
@@ -97,5 +118,113 @@ consumption:
 		case <-ah.DoneCh:
 			break consumption
 		}
+	}
+}
+
+/// TestConnectionAttempts verifies the max-connection-attempts flag is fully
+//supported
+func TestConnectionAttempts(t *testing.T) {
+	logger := logging.NewVaultLogger(hclog.Trace)
+
+	// start a network listener, intentionally don't listen for anything. This
+	// simulates an unresponsive Vault cluster
+	testCases := map[string]int{
+		"unset": 0,
+		"low":   1,
+		"high":  15,
+	}
+
+	for name, maxAttempts := range testCases {
+		t.Run(name, func(t *testing.T) {
+			q.Q("")
+			q.Q(">>>> running:", name)
+			q.Q("")
+			l, err := net.Listen("tcp", ":1234")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Use local host with the same port as the net listener. We can't use
+			// l.Addr().String() because it's not an http address, and then the listener
+			// will never get connection attempts from Vault
+			client, err := api.NewClient(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client.SetAddress("http://127.0.0.1:1234")
+			client.SetMaxRetries(0)
+
+			ctx, cancelFunc := context.WithCancel(context.Background())
+
+			// attempts tracks the connection attempts
+			var attempts int
+			go func(ctx context.Context) {
+				for {
+					conn, _ := l.Accept()
+					select {
+					case <-ctx.Done():
+						return
+					default:
+					}
+
+					conn.Close()
+					attempts++
+				}
+			}(ctx)
+
+			ah := NewAuthHandler(&AuthHandlerConfig{
+				Logger: logger.Named("auth.handler"),
+				Client: client,
+			})
+
+			am := newFakeTestMethod(t, client)
+			go ah.RunWithMaxAttempts(ctx, am, maxAttempts)
+
+			// all the tests should complete well within this time. We use a timer to
+			// ensure that if something does break, we don't hang forever
+			timeout := maxAttempts * 5
+			if timeout == 0 {
+				timeout = 5
+			}
+			stopTime := time.Now().Add(time.Duration(timeout) * time.Second)
+
+			var closed bool
+			// Consume tokens so we don't block
+		consumption:
+			for {
+				select {
+				case <-ah.OutputCh:
+				case <-ah.TemplateTokenCh:
+				// Nothing
+				case <-time.After(stopTime.Sub(time.Now())):
+					q.Q("--> timeout")
+					// if test max is not zero and we've reached the timeout, something is
+					// wrong
+					if !closed {
+						cancelFunc()
+						closed = true
+					}
+					if maxAttempts != 0 {
+						t.Fatalf("test timeout. Expected: %d, actual: %d", maxAttempts, attempts)
+					}
+					break consumption
+				case <-ah.DoneCh:
+					break consumption
+				}
+			}
+
+			if !closed {
+				cancelFunc()
+				closed = true
+			}
+
+			if maxAttempts != 0 {
+				if attempts != maxAttempts {
+					t.Fatalf("connection attempts did not match expected. Expected: %d, actual: %d", maxAttempts, attempts)
+				}
+			}
+
+			l.Close()
+		})
 	}
 }

--- a/command/agent/auth/auth_test.go
+++ b/command/agent/auth/auth_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
-	"github.com/y0ssar1an/q"
 )
 
 type userpassTestMethod struct{}
@@ -136,9 +135,6 @@ func TestConnectionAttempts(t *testing.T) {
 
 	for name, maxAttempts := range testCases {
 		t.Run(name, func(t *testing.T) {
-			q.Q("")
-			q.Q(">>>> running:", name)
-			q.Q("")
 			l, err := net.Listen("tcp", ":1234")
 			if err != nil {
 				t.Fatal(err)
@@ -197,7 +193,6 @@ func TestConnectionAttempts(t *testing.T) {
 				case <-ah.TemplateTokenCh:
 				// Nothing
 				case <-time.After(stopTime.Sub(time.Now())):
-					q.Q("--> timeout")
 					// if test max is not zero and we've reached the timeout, something is
 					// wrong
 					if !closed {

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -20,13 +20,14 @@ import (
 
 // Config is the configuration for the vault server.
 type Config struct {
-	AutoAuth      *AutoAuth                  `hcl:"auto_auth"`
-	ExitAfterAuth bool                       `hcl:"exit_after_auth"`
-	PidFile       string                     `hcl:"pid_file"`
-	Listeners     []*Listener                `hcl:"listeners"`
-	Cache         *Cache                     `hcl:"cache"`
-	Vault         *Vault                     `hcl:"vault"`
-	Templates     []*ctconfig.TemplateConfig `hcl:"templates"`
+	AutoAuth              *AutoAuth                  `hcl:"auto_auth"`
+	ExitAfterAuth         bool                       `hcl:"exit_after_auth"`
+	MaxConnectionAttempts int                        `hcl:"max_connection_attempts"`
+	PidFile               string                     `hcl:"pid_file"`
+	Listeners             []*Listener                `hcl:"listeners"`
+	Cache                 *Cache                     `hcl:"cache"`
+	Vault                 *Vault                     `hcl:"vault"`
+	Templates             []*ctconfig.TemplateConfig `hcl:"templates"`
 }
 
 // Vault contains configuration for connnecting to Vault servers

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -20,14 +20,15 @@ import (
 
 // Config is the configuration for the vault server.
 type Config struct {
-	AutoAuth              *AutoAuth                  `hcl:"auto_auth"`
-	ExitAfterAuth         bool                       `hcl:"exit_after_auth"`
-	MaxConnectionAttempts int                        `hcl:"max_connection_attempts"`
-	PidFile               string                     `hcl:"pid_file"`
-	Listeners             []*Listener                `hcl:"listeners"`
-	Cache                 *Cache                     `hcl:"cache"`
-	Vault                 *Vault                     `hcl:"vault"`
-	Templates             []*ctconfig.TemplateConfig `hcl:"templates"`
+	AutoAuth                *AutoAuth                  `hcl:"auto_auth"`
+	ExitAfterAuth           bool                       `hcl:"exit_after_auth"`
+	MaxConnectionTimeout    time.Duration              `hcl:"-"`
+	MaxConnectionTimeoutRaw interface{}                `hcl:"max_connection_timeout"`
+	PidFile                 string                     `hcl:"pid_file"`
+	Listeners               []*Listener                `hcl:"listeners"`
+	Cache                   *Cache                     `hcl:"cache"`
+	Vault                   *Vault                     `hcl:"vault"`
+	Templates               []*ctconfig.TemplateConfig `hcl:"templates"`
 }
 
 // Vault contains configuration for connnecting to Vault servers


### PR DESCRIPTION
WIP

Vault Agent can be configured to attempt to authenticate with a Vault cluster that is not responsive. When this occurs, the goroutine running the Auth Method can enter an infinite loop of attempting to connect and receiving tcp dial errors like so:

```
2020-01-10T16:33:13.848-0600 [INFO]  auth.handler: authenticating
2020-01-10T16:33:13.849-0600 [ERROR] auth.handler: error authenticating: error="Put http://127.0.0.1:8200/v1/auth/approle/login: dial tcp 127.0.0.1:8200: connect: connection refused" backoff=2.496237872
```

This repeats until either Vault becomes responsive or the Agent process is terminated. Note that this is different than a failed auth attempt or responses from a sealed Vault; the dial error occurs when no connection can be made at the tcp layer. Because of that fact the existing `VAULT_CLIENT_TIMEOUT` and `VAULT_MAX_RETRIES` configuration options are never even considered, and Agent attempts to authenticate indefinitely. 

This pull request adds an additional configuration, `max-connection-attempts` which is specific to Vault Agent. This option can limit the number of failed connection attempts before exiting the Agent process. The default is `0`, which indicates "unlimited", so that the current behavior is unchanged and this change is backwards compatible. 

The maximum connection attempts can be set with the `-max-connection-attempts` command line flag, the `VAULT_MAX_CONNECTION_ATTEMPTS` environment variable, or the `max_connection_attempts` configuration variable, in that order of precedence. 

------

Remaining items:

- [ ] Clean up / add code comments
- [ ] Agent web documentation 