### PR TITLE
Backport 1.3.x: fix deleting namespaces

### DIFF
--- a/ui/lib/core/addon/templates/components/list-view.hbs
+++ b/ui/lib/core/addon/templates/components/list-view.hbs
@@ -5,7 +5,7 @@
   )
 }}
   <div class="box is-fullwidth is-bottomless is-sideless is-paddingless" data-test-list-view-list>
-    {{#each (or items.content items) as |item|}}
+    {{#each items as |item|}}
       {{yield (hash item=item)}}
     {{else}}
       {{yield}}

--- a/ui/lib/core/stories/list-view.stories.js
+++ b/ui/lib/core/stories/list-view.stories.js
@@ -12,20 +12,11 @@ filtered.set('meta', {
   total: 100,
 });
 
-let paginated = ArrayProxy.create({
-  content: [{ id: 'middle' }, { id: 'of' }, { id: 'the' }, { id: 'list' }],
-});
-paginated.set('meta', {
-  lastPage: 10,
-  currentPage: 4,
-  total: 100,
-});
-
+// TODO: add a pagination option when we have a better way to fake Ember models in Storybook.
 let options = {
   list: [{ id: 'one' }, { id: 'two' }],
   empty: [],
   filtered,
-  paginated,
 };
 
 storiesOf('ListView/', module)


### PR DESCRIPTION
Backport for https://github.com/hashicorp/vault/pull/8132, which fixes the ability to delete namespaces in Vault 1.3 and above.