### PR TITLE
Fix AWS region tests

### DIFF
--- a/builtin/credential/aws/cli.go
+++ b/builtin/credential/aws/cli.go
@@ -7,14 +7,13 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/hashicorp/go-hclog"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/awsutil"
 )

--- a/builtin/credential/aws/cli.go
+++ b/builtin/credential/aws/cli.go
@@ -38,10 +38,7 @@ func GenerateLoginData(creds *credentials.Credentials, headerValue, configuredRe
 	loginData := make(map[string]interface{})
 
 	// Use the credentials we've found to construct an STS session
-	region, err := awsutil.GetRegion(configuredRegion)
-	if err != nil {
-		return nil, err
-	}
+	region := awsutil.GetRegion(configuredRegion)
 	stsSession, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			Credentials:      creds,

--- a/builtin/credential/aws/cli.go
+++ b/builtin/credential/aws/cli.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -38,7 +40,11 @@ func GenerateLoginData(creds *credentials.Credentials, headerValue, configuredRe
 	loginData := make(map[string]interface{})
 
 	// Use the credentials we've found to construct an STS session
-	region := awsutil.GetRegion(configuredRegion)
+	region, err := awsutil.GetRegion(configuredRegion)
+	if err != nil {
+		hclog.Default().Warn(fmt.Sprintf("defaulting region to %q due to %s", awsutil.DefaultRegion, err.Error()))
+		region = awsutil.DefaultRegion
+	}
 	stsSession, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			Credentials:      creds,

--- a/sdk/helper/awsutil/region.go
+++ b/sdk/helper/awsutil/region.go
@@ -25,18 +25,19 @@ variable (and not `AWS_REGION`, while the golang SDK does _mostly_ the opposite 
 reads the region **only** from `AWS_REGION` and not at all `~/.aws/config`, **unless**
 the `AWS_SDK_LOAD_CONFIG` environment variable is set. So, we must define our own
 approach to walking AWS config and deciding what to use.
+
 Our chosen approach is:
+
 	"More specific takes precedence over less specific."
+
 1. User-provided configuration is the most explicit.
 2. Environment variables are potentially shared across many invocations and so they have less precedence.
 3. Configuration in `~/.aws/config` is shared across all invocations of a given user and so this has even less precedence.
 4. Configuration retrieved from the EC2 instance metadata service is shared by all invocations on a given machine, and so it has the lowest precedence.
+
 This approach should be used in future updates to this logic.
 */
 func GetRegion(configuredRegion string) (string, error) {
-	// We create a logger here because all callers won't have access to a logger.
-	// This allows us to log any errors we encounter while falling back to the
-	// default region, which maintains backwards compatibility.
 	if configuredRegion != "" {
 		return configuredRegion, nil
 	}
@@ -68,5 +69,6 @@ func GetRegion(configuredRegion string) (string, error) {
 	if err != nil {
 		return "", errwrap.Wrapf("unable to retrieve region from instance metadata: {{err}}", err)
 	}
+	
 	return region, nil
 }

--- a/sdk/helper/awsutil/region.go
+++ b/sdk/helper/awsutil/region.go
@@ -15,7 +15,7 @@ import (
 const DefaultRegion = "us-east-1"
 
 // This is nil by default, but is exposed in case it needs to be changed for tests.
-var ec2Endpoint *string = nil
+var ec2Endpoint *string
 
 /*
 It's impossible to mimic "normal" AWS behavior here because it's not consistent
@@ -69,6 +69,6 @@ func GetRegion(configuredRegion string) (string, error) {
 	if err != nil {
 		return "", errwrap.Wrapf("unable to retrieve region from instance metadata: {{err}}", err)
 	}
-	
+
 	return region, nil
 }

--- a/sdk/helper/awsutil/region.go
+++ b/sdk/helper/awsutil/region.go
@@ -1,20 +1,22 @@
 package awsutil
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/hashicorp/errwrap"
+	hclog "github.com/hashicorp/go-hclog"
 )
 
 // "us-east-1 is used because it's where AWS first provides support for new features,
 // is a widely used region, and is the most common one for some services like STS.
 const DefaultRegion = "us-east-1"
 
-var ec2MetadataBaseURL = "http://169.254.169.254"
+// This is nil by default, but is exposed in case it needs to be changed for tests.
+var ec2Endpoint *string = nil
 
 /*
 It's impossible to mimic "normal" AWS behavior here because it's not consistent
@@ -24,50 +26,47 @@ variable (and not `AWS_REGION`, while the golang SDK does _mostly_ the opposite 
 reads the region **only** from `AWS_REGION` and not at all `~/.aws/config`, **unless**
 the `AWS_SDK_LOAD_CONFIG` environment variable is set. So, we must define our own
 approach to walking AWS config and deciding what to use.
-
 Our chosen approach is:
-
 	"More specific takes precedence over less specific."
-
 1. User-provided configuration is the most explicit.
 2. Environment variables are potentially shared across many invocations and so they have less precedence.
 3. Configuration in `~/.aws/config` is shared across all invocations of a given user and so this has even less precedence.
 4. Configuration retrieved from the EC2 instance metadata service is shared by all invocations on a given machine, and so it has the lowest precedence.
-
 This approach should be used in future updates to this logic.
 */
-func GetRegion(configuredRegion string) (string, error) {
+func GetOrDefaultRegion(logger hclog.Logger, configuredRegion string) string {
 	if configuredRegion != "" {
-		return configuredRegion, nil
+		return configuredRegion
 	}
 
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {
-		return "", errwrap.Wrapf("got error when starting session: {{err}}", err)
+		logger.Warn(fmt.Sprintf("unable to start session, defaulting region to %s", DefaultRegion))
+		return DefaultRegion
 	}
 
 	region := aws.StringValue(sess.Config.Region)
 	if region != "" {
-		return region, nil
+		return region
 	}
 
 	metadata := ec2metadata.New(sess, &aws.Config{
-		Endpoint:                          aws.String(ec2MetadataBaseURL + "/latest"),
+		Endpoint:                          ec2Endpoint,
 		EC2MetadataDisableTimeoutOverride: aws.Bool(true),
 		HTTPClient: &http.Client{
 			Timeout: time.Second,
 		},
 	})
 	if !metadata.Available() {
-		return DefaultRegion, nil
+		return DefaultRegion
 	}
 
 	region, err = metadata.Region()
 	if err != nil {
-		return "", errwrap.Wrapf("unable to retrieve region from instance metadata: {{err}}", err)
+		logger.Warn("unable to retrieve region from instance metadata, defaulting region to %s", DefaultRegion)
+		return DefaultRegion
 	}
-
-	return region, nil
+	return region
 }

--- a/sdk/helper/awsutil/region.go
+++ b/sdk/helper/awsutil/region.go
@@ -1,14 +1,12 @@
 package awsutil
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
-	hclog "github.com/hashicorp/go-hclog"
 )
 
 // "us-east-1 is used because it's where AWS first provides support for new features,
@@ -34,7 +32,7 @@ Our chosen approach is:
 4. Configuration retrieved from the EC2 instance metadata service is shared by all invocations on a given machine, and so it has the lowest precedence.
 This approach should be used in future updates to this logic.
 */
-func GetOrDefaultRegion(logger hclog.Logger, configuredRegion string) string {
+func GetRegion(configuredRegion string) string {
 	if configuredRegion != "" {
 		return configuredRegion
 	}
@@ -43,7 +41,6 @@ func GetOrDefaultRegion(logger hclog.Logger, configuredRegion string) string {
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {
-		logger.Warn(fmt.Sprintf("unable to start session, defaulting region to %s", DefaultRegion))
 		return DefaultRegion
 	}
 
@@ -65,7 +62,6 @@ func GetOrDefaultRegion(logger hclog.Logger, configuredRegion string) string {
 
 	region, err = metadata.Region()
 	if err != nil {
-		logger.Warn("unable to retrieve region from instance metadata, defaulting region to %s", DefaultRegion)
 		return DefaultRegion
 	}
 	return region

--- a/sdk/helper/awsutil/region_test.go
+++ b/sdk/helper/awsutil/region_test.go
@@ -38,7 +38,7 @@ func TestGetOrDefaultRegion_UserConfigPreferredFirst(t *testing.T) {
 	cleanupMetadata := setInstanceMetadata(t, unexpectedTestRegion)
 	defer cleanupMetadata()
 
-	result := GetOrDefaultRegion(logger, configuredRegion)
+	result := GetRegion(logger, configuredRegion)
 	if result != expectedTestRegion {
 		t.Fatalf("expected: %s; actual: %s", expectedTestRegion, result)
 	}
@@ -56,7 +56,7 @@ func TestGetOrDefaultRegion_EnvVarsPreferredSecond(t *testing.T) {
 	cleanupMetadata := setInstanceMetadata(t, unexpectedTestRegion)
 	defer cleanupMetadata()
 
-	result := GetOrDefaultRegion(logger, configuredRegion)
+	result := GetRegion(logger, configuredRegion)
 	if result != expectedTestRegion {
 		t.Fatalf("expected: %s; actual: %s", expectedTestRegion, result)
 	}
@@ -80,7 +80,7 @@ func TestGetOrDefaultRegion_ConfigFilesPreferredThird(t *testing.T) {
 	cleanupMetadata := setInstanceMetadata(t, unexpectedTestRegion)
 	defer cleanupMetadata()
 
-	result := GetOrDefaultRegion(logger, configuredRegion)
+	result := GetRegion(logger, configuredRegion)
 	if result != expectedTestRegion {
 		t.Fatalf("expected: %s; actual: %s", expectedTestRegion, result)
 	}
@@ -104,7 +104,7 @@ func TestGetOrDefaultRegion_ConfigFileUnfound(t *testing.T) {
 		}
 	}()
 
-	result := GetOrDefaultRegion(logger, configuredRegion)
+	result := GetRegion(logger, configuredRegion)
 	if result != DefaultRegion {
 		t.Fatalf("expected: %s; actual: %s", DefaultRegion, result)
 	}
@@ -128,7 +128,7 @@ func TestGetOrDefaultRegion_EC2InstanceMetadataPreferredFourth(t *testing.T) {
 	cleanupMetadata := setInstanceMetadata(t, expectedTestRegion)
 	defer cleanupMetadata()
 
-	result := GetOrDefaultRegion(logger, configuredRegion)
+	result := GetRegion(logger, configuredRegion)
 	if result != expectedTestRegion {
 		t.Fatalf("expected: %s; actual: %s", expectedTestRegion, result)
 	}
@@ -147,7 +147,7 @@ func TestGetOrDefaultRegion_DefaultsToDefaultRegionWhenRegionUnavailable(t *test
 	cleanupFile := setConfigFileRegion(t, "")
 	defer cleanupFile()
 
-	result := GetOrDefaultRegion(logger, configuredRegion)
+	result := GetRegion(logger, configuredRegion)
 	if result != DefaultRegion {
 		t.Fatalf("expected: %s; actual: %s", DefaultRegion, result)
 	}

--- a/sdk/helper/awsutil/region_test.go
+++ b/sdk/helper/awsutil/region_test.go
@@ -26,7 +26,7 @@ var (
 	regionEnvKeys        = []string{"AWS_REGION", "AWS_DEFAULT_REGION"}
 )
 
-func TestGetOrDefaultRegion_UserConfigPreferredFirst(t *testing.T) {
+func TestGetRegion_UserConfigPreferredFirst(t *testing.T) {
 	configuredRegion := expectedTestRegion
 
 	cleanupEnv := setEnvRegion(t, unexpectedTestRegion)
@@ -38,13 +38,16 @@ func TestGetOrDefaultRegion_UserConfigPreferredFirst(t *testing.T) {
 	cleanupMetadata := setInstanceMetadata(t, unexpectedTestRegion)
 	defer cleanupMetadata()
 
-	result := GetRegion(logger, configuredRegion)
+	result, err := GetRegion(configuredRegion)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != expectedTestRegion {
 		t.Fatalf("expected: %s; actual: %s", expectedTestRegion, result)
 	}
 }
 
-func TestGetOrDefaultRegion_EnvVarsPreferredSecond(t *testing.T) {
+func TestGetRegion_EnvVarsPreferredSecond(t *testing.T) {
 	configuredRegion := ""
 
 	cleanupEnv := setEnvRegion(t, expectedTestRegion)
@@ -56,13 +59,16 @@ func TestGetOrDefaultRegion_EnvVarsPreferredSecond(t *testing.T) {
 	cleanupMetadata := setInstanceMetadata(t, unexpectedTestRegion)
 	defer cleanupMetadata()
 
-	result := GetRegion(logger, configuredRegion)
+	result, err := GetRegion(configuredRegion)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != expectedTestRegion {
 		t.Fatalf("expected: %s; actual: %s", expectedTestRegion, result)
 	}
 }
 
-func TestGetOrDefaultRegion_ConfigFilesPreferredThird(t *testing.T) {
+func TestGetRegion_ConfigFilesPreferredThird(t *testing.T) {
 	if !shouldTestFiles {
 		// In some test environments, like a CI environment, we may not have the
 		// permissions to write to the ~/.aws/config file. Thus, this test is off
@@ -80,13 +86,16 @@ func TestGetOrDefaultRegion_ConfigFilesPreferredThird(t *testing.T) {
 	cleanupMetadata := setInstanceMetadata(t, unexpectedTestRegion)
 	defer cleanupMetadata()
 
-	result := GetRegion(logger, configuredRegion)
+	result, err := GetRegion(configuredRegion)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != expectedTestRegion {
 		t.Fatalf("expected: %s; actual: %s", expectedTestRegion, result)
 	}
 }
 
-func TestGetOrDefaultRegion_ConfigFileUnfound(t *testing.T) {
+func TestGetRegion_ConfigFileUnfound(t *testing.T) {
 	if enabled := os.Getenv("VAULT_ACC"); enabled == "" {
 		t.Skip()
 	}
@@ -104,13 +113,16 @@ func TestGetOrDefaultRegion_ConfigFileUnfound(t *testing.T) {
 		}
 	}()
 
-	result := GetRegion(logger, configuredRegion)
+	result, err := GetRegion(configuredRegion)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != DefaultRegion {
 		t.Fatalf("expected: %s; actual: %s", DefaultRegion, result)
 	}
 }
 
-func TestGetOrDefaultRegion_EC2InstanceMetadataPreferredFourth(t *testing.T) {
+func TestGetRegion_EC2InstanceMetadataPreferredFourth(t *testing.T) {
 	if !shouldTestFiles {
 		// In some test environments, like a CI environment, we may not have the
 		// permissions to write to the ~/.aws/config file. Thus, this test is off
@@ -128,13 +140,16 @@ func TestGetOrDefaultRegion_EC2InstanceMetadataPreferredFourth(t *testing.T) {
 	cleanupMetadata := setInstanceMetadata(t, expectedTestRegion)
 	defer cleanupMetadata()
 
-	result := GetRegion(logger, configuredRegion)
+	result, err := GetRegion(configuredRegion)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != expectedTestRegion {
 		t.Fatalf("expected: %s; actual: %s", expectedTestRegion, result)
 	}
 }
 
-func TestGetOrDefaultRegion_DefaultsToDefaultRegionWhenRegionUnavailable(t *testing.T) {
+func TestGetRegion_DefaultsToDefaultRegionWhenRegionUnavailable(t *testing.T) {
 	if enabled := os.Getenv("VAULT_ACC"); enabled == "" {
 		t.Skip()
 	}
@@ -147,7 +162,10 @@ func TestGetOrDefaultRegion_DefaultsToDefaultRegionWhenRegionUnavailable(t *test
 	cleanupFile := setConfigFileRegion(t, "")
 	defer cleanupFile()
 
-	result := GetRegion(logger, configuredRegion)
+	result, err := GetRegion(configuredRegion)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if result != DefaultRegion {
 		t.Fatalf("expected: %s; actual: %s", DefaultRegion, result)
 	}

--- a/sdk/helper/awsutil/region_test.go
+++ b/sdk/helper/awsutil/region_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	hclog "github.com/hashicorp/go-hclog"
 )
 
 const testConfigFile = `[default]
@@ -20,7 +19,6 @@ output=json`
 var (
 	shouldTestFiles = os.Getenv("VAULT_ACC_AWS_FILES") == "1"
 
-	logger               = hclog.NewNullLogger()
 	expectedTestRegion   = "us-west-2"
 	unexpectedTestRegion = "us-east-2"
 	regionEnvKeys        = []string{"AWS_REGION", "AWS_DEFAULT_REGION"}


### PR DESCRIPTION
This PR fixes the following failure on master:
```
=== Errors
sdk/helper/awsutil/region_test.go:260:2: undefined: ec2Endpoint
sdk/helper/awsutil/region_test.go:263:3: undefined: ec2Endpoint
```
This code has already been reviewed as part of https://github.com/hashicorp/vault/pull/8062/files but appears to have gotten wiped out since it was merged on Friday by a subsequent mistake of GH's.