### PR TITLE
doc: add extraArgs example to vault-helm

### DIFF
--- a/website/source/docs/platform/k8s/helm/configuration.html.md
+++ b/website/source/docs/platform/k8s/helm/configuration.html.md
@@ -203,7 +203,7 @@ and consider if they're appropriate for your deployment.
      extraArgs: "-config=/path/to/extra/config.hcl -log-format=json"
     ```
 
-    * `extraSecretEnvironmentVars` (`string: null`) - The extra environment variables populated from a secret to be applied to the Vault server.  This should be a multi-line key/value string.
+     * `extraSecretEnvironmentVars` (`string: null`) - The extra environment variables populated from a secret to be applied to the Vault server. This should be a multi-line key/value string.
 
         - `envName` (`string: required`) -
         Name of the environment variable to be populated in the Vault container.

--- a/website/source/docs/platform/k8s/helm/configuration.html.md
+++ b/website/source/docs/platform/k8s/helm/configuration.html.md
@@ -197,7 +197,7 @@ and consider if they're appropriate for your deployment.
        GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
     ```
 
-    * `extraArgs` `string: null`) - The extra arguments to be applied to the Vault server startup command.
+    * `extraArgs` (`string: null`) - The extra arguments to be applied to the Vault server startup command.
 
     ```yaml
      extraArgs: "-config=/path/to/extra/config.hcl -log-format=json"

--- a/website/source/docs/platform/k8s/helm/configuration.html.md
+++ b/website/source/docs/platform/k8s/helm/configuration.html.md
@@ -197,6 +197,12 @@ and consider if they're appropriate for your deployment.
        GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
     ```
 
+    * `extraArgs` `string: null`) - The extra arguments to be applied to the Vault server startup command.
+
+    ```yaml
+     extraArgs: "-config=/path/to/extra/config.hcl -log-format=json"
+    ```
+
     * `extraSecretEnvironmentVars` (`string: null`) - The extra environment variables populated from a secret to be applied to the Vault server.  This should be a multi-line key/value string.
 
         - `envName` (`string: required`) -

--- a/website/source/docs/platform/k8s/helm/index.html.md
+++ b/website/source/docs/platform/k8s/helm/index.html.md
@@ -54,7 +54,7 @@ $ git clone https://github.com/hashicorp/vault-helm.git
 $ cd vault-helm
 
 # Checkout a tagged version
-$ git checkout v0.3.2
+$ git checkout v0.3.3
 
 # Run Helm
 $ helm install --dry-run ./

--- a/website/source/docs/platform/k8s/helm/run.html.md
+++ b/website/source/docs/platform/k8s/helm/run.html.md
@@ -62,7 +62,7 @@ $ git clone https://github.com/hashicorp/vault-helm.git
 $ cd vault-helm
 
 # Checkout a tagged version
-$ git checkout v0.3.2
+$ git checkout v0.3.3
 
 # Run Helm
 $ helm install --name vault ./
@@ -195,6 +195,47 @@ $ kubectl exec -ti <name of pod> -- vault operator unseal
 
 After a few moments the Vault cluster should elect a new active primary.  The Vault
 cluster is now upgraded!
+
+#### Protecting Sensitive Vault Configurations
+
+Vault Helm renders a Vault configuration file during installation and stores the 
+file in a Kubernetes configmap.  Some configurations require sensitive data to be 
+included in the configuration file and would not be encrypted at rest once created 
+in Kubernetes.  
+
+The following example shows how to add extra configuration files to Vault Helm 
+to protect sensitive configurations from being in plaintext at rest using Kubernetes 
+secrets.
+
+First, create a partial Vault configuration with the sensitive settings Vault will 
+load during startup:
+
+```yaml
+cat <<EOF >>config.hcl
+storage "mysql" {
+  username = "user1234"
+  password = "secret123!"
+  database = "vault"
+}
+EOF
+```
+
+Next, create a Kubernetes secret containing this partial configuration:
+
+```bash
+kubectl create secret generic vault-storage-config \
+    --from-file=config.hcl
+```
+
+Finally, mount this secret as an extra volume and add an additional `-config` flag 
+to the Vault startup command:
+
+```bash
+helm install --name=vault \
+  --set='server.extraVolumes[0].type=secret' \
+  --set='server.extraVolumes[0].name=vault-storage-config' \
+  --set='server.extraArgs=-config=/vault/userconfig/vault-storage-config/config.hcl' .
+```
 
 #### Google KMS Auto Unseal
 

--- a/website/source/docs/platform/k8s/helm/run.html.md
+++ b/website/source/docs/platform/k8s/helm/run.html.md
@@ -199,7 +199,7 @@ cluster is now upgraded!
 ### Protecting Sensitive Vault Configurations
 
 Vault Helm renders a Vault configuration file during installation and stores the 
-file in a Kubernetes configmap.  Some configurations require sensitive data to be 
+file in a Kubernetes configmap. Some configurations require sensitive data to be 
 included in the configuration file and would not be encrypted at rest once created 
 in Kubernetes.  
 

--- a/website/source/docs/platform/k8s/helm/run.html.md
+++ b/website/source/docs/platform/k8s/helm/run.html.md
@@ -196,7 +196,7 @@ $ kubectl exec -ti <name of pod> -- vault operator unseal
 After a few moments the Vault cluster should elect a new active primary.  The Vault
 cluster is now upgraded!
 
-#### Protecting Sensitive Vault Configurations
+### Protecting Sensitive Vault Configurations
 
 Vault Helm renders a Vault configuration file during installation and stores the 
 file in a Kubernetes configmap.  Some configurations require sensitive data to be 

--- a/website/source/docs/platform/k8s/injector/installation.html.md
+++ b/website/source/docs/platform/k8s/injector/installation.html.md
@@ -24,7 +24,7 @@ To install a new instance of Vault and the Vault Agent Injector, run the followi
 ```bash
 helm install --name=vault \
   --set="injector.enabled=true" \
-  https://github.com/hashicorp/vault-helm/archive/v0.3.2.tar.gz
+  https://github.com/hashicorp/vault-helm/archive/v0.3.3.tar.gz
 ``` 
 
 Other values in the Helm chart can be used to limit the namespaces the injector


### PR DESCRIPTION
Adding the documentation about protecting sensitive Vault configurations using the `extraArgs` configurable.