### PR TITLE
Backport 1.3.x: ldap, okta: fix renewal when login policies are empty (#8072)

### DIFF
--- a/builtin/credential/ldap/path_login.go
+++ b/builtin/credential/ldap/path_login.go
@@ -133,9 +133,10 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 	password := req.Auth.InternalData["password"].(string)
 
 	loginPolicies, resp, groupNames, err := b.Login(ctx, req, username, password)
-	if len(loginPolicies) == 0 {
+	if err != nil || (resp != nil && resp.IsError()) {
 		return resp, err
 	}
+
 	finalPolicies := cfg.TokenPolicies
 	if len(loginPolicies) > 0 {
 		finalPolicies = append(finalPolicies, loginPolicies...)

--- a/builtin/credential/okta/path_login.go
+++ b/builtin/credential/okta/path_login.go
@@ -118,7 +118,7 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 	}
 
 	loginPolicies, resp, groupNames, err := b.Login(ctx, req, username, password)
-	if len(loginPolicies) == 0 {
+	if err != nil || (resp != nil && resp.IsError()) {
 		return resp, err
 	}
 

--- a/vault/external_tests/policy/no_default_test.go
+++ b/vault/external_tests/policy/no_default_test.go
@@ -1,21 +1,20 @@
 package policy
 
-// This is TODO once tokenhelper is added to ldaputil
-/*
-
 import (
 	"testing"
+	"time"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/builtin/credential/ldap"
+	ldaphelper "github.com/hashicorp/vault/helper/testhelpers/ldap"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
 
-func TestNoDefaultPolicy(t *testing.T) {
+func TestPolicy_NoDefaultPolicy(t *testing.T) {
 	var err error
 	coreConfig := &vault.CoreConfig{
 		DisableMlock: true,
@@ -47,12 +46,17 @@ func TestNoDefaultPolicy(t *testing.T) {
 	}
 
 	// Configure LDAP auth backend
-	secret, err := client.Logical().Write("auth/ldap/config", map[string]interface{}{
-		"url":                     "ldap://ldap.forumsys.com",
-		"userattr":                "uid",
-		"userdn":                  "dc=example,dc=com",
-		"groupdn":                 "dc=example,dc=com",
-		"binddn":                  "cn=read-only-admin,dc=example,dc=com",
+	cleanup, cfg := ldaphelper.PrepareTestContainer(t, "latest")
+	defer cleanup()
+
+	_, err = client.Logical().Write("auth/ldap/config", map[string]interface{}{
+		"url":                     cfg.Url,
+		"userattr":                cfg.UserAttr,
+		"userdn":                  cfg.UserDN,
+		"groupdn":                 cfg.GroupDN,
+		"groupattr":               cfg.GroupAttr,
+		"binddn":                  cfg.BindDN,
+		"bindpass":                cfg.BindPassword,
 		"token_no_default_policy": true,
 	})
 	if err != nil {
@@ -60,7 +64,7 @@ func TestNoDefaultPolicy(t *testing.T) {
 	}
 
 	// Create a local user in LDAP
-	secret, err = client.Logical().Write("auth/ldap/users/tesla", map[string]interface{}{
+	secret, err := client.Logical().Write("auth/ldap/users/hermes conrad", map[string]interface{}{
 		"policies": "foo",
 	})
 	if err != nil {
@@ -68,8 +72,8 @@ func TestNoDefaultPolicy(t *testing.T) {
 	}
 
 	// Login with LDAP and create a token
-	secret, err = client.Logical().Write("auth/ldap/login/tesla", map[string]interface{}{
-		"password": "password",
+	secret, err = client.Logical().Write("auth/ldap/login/hermes conrad", map[string]interface{}{
+		"password": "hermes",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -86,4 +90,94 @@ func TestNoDefaultPolicy(t *testing.T) {
 		t.Fatal(diff)
 	}
 }
-*/
+
+func TestPolicy_NoConfiguredPolicy(t *testing.T) {
+	var err error
+	coreConfig := &vault.CoreConfig{
+		DisableMlock: true,
+		DisableCache: true,
+		Logger:       hclog.NewNullLogger(),
+		CredentialBackends: map[string]logical.Factory{
+			"ldap": ldap.Factory,
+		},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+
+	vault.TestWaitActive(t, cores[0].Core)
+
+	client := cores[0].Client
+
+	err = client.Sys().EnableAuthWithOptions("ldap", &api.EnableAuthOptions{
+		Type: "ldap",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure LDAP auth backend
+	cleanup, cfg := ldaphelper.PrepareTestContainer(t, "latest")
+	defer cleanup()
+
+	_, err = client.Logical().Write("auth/ldap/config", map[string]interface{}{
+		"url":       cfg.Url,
+		"userattr":  cfg.UserAttr,
+		"userdn":    cfg.UserDN,
+		"groupdn":   cfg.GroupDN,
+		"groupattr": cfg.GroupAttr,
+		"binddn":    cfg.BindDN,
+		"bindpass":  cfg.BindPassword,
+		"token_ttl": "24h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a local user in LDAP without any policies configured
+	secret, err := client.Logical().Write("auth/ldap/users/hermes conrad", map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Login with LDAP and create a token
+	secret, err = client.Logical().Write("auth/ldap/login/hermes conrad", map[string]interface{}{
+		"password": "hermes",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := secret.Auth.ClientToken
+
+	// Lookup the token to get the entity ID
+	secret, err = client.Auth().Token().Lookup(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := deep.Equal(secret.Data["policies"], []interface{}{"default"}); diff != nil {
+		t.Fatal(diff)
+	}
+
+	// Renew the token with an increment of 2 hours to ensure that lease renewal
+	// occurred and can be checked against the default lease duration with a
+	// big enough delta.
+	secret, err = client.Logical().Write("auth/token/renew", map[string]interface{}{
+		"token":     token,
+		"increment": "2h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the lease renewal extended the duration properly.
+	if float64(secret.Auth.LeaseDuration) < (1 * time.Hour).Seconds() {
+		t.Fatalf("failed to renew lease, got: %v", secret.Auth.LeaseDuration)
+	}
+}


### PR DESCRIPTION
* ldap, okta: fix renewal when login policies are empty

* test/policy: add test for login renewal without configured policy

* test/policy: remove external dependency on tests, refactor lease duration check