### PR TITLE
Backport 1.3.x: update serialize-javascript to fix security vulnerability (#8029)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -161,7 +161,8 @@
     "lodash": "^4.17.13",
     "merge": "^1.2.1",
     "minimatch": "^3.0.2",
-    "growl": "^1.10.0"
+    "growl": "^1.10.0",
+    "serialize-javascript": "^2.1.1"
   },
   "engines": {
     "node": " >= 10.* <11"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -14618,15 +14618,10 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.4.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
-  integrity sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==
-
-serialize-javascript@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
-  integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
+serialize-javascript@^1.4.0, serialize-javascript@^1.7.0, serialize-javascript@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serve-favicon@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
Backport for https://github.com/hashicorp/vault/pull/8029 which updates `serialize-javascript` to fix a security alert.