### PR TITLE
Fix panic that could occur after a listener fails to startup

### DIFF
--- a/vault/cluster/tcp_layer.go
+++ b/vault/cluster/tcp_layer.go
@@ -58,7 +58,7 @@ func (l *TCPLayer) Listeners() []NetworkListener {
 		return l.listeners
 	}
 
-	listeners := make([]NetworkListener, len(l.addrs))
+	listeners := []NetworkListener{}
 	for i, laddr := range l.addrs {
 		if l.logger.IsInfo() {
 			l.logger.Info("starting listener", "listener_address", laddr)
@@ -74,7 +74,7 @@ func (l *TCPLayer) Listeners() []NetworkListener {
 			l.addrs[i] = tcpLn.Addr().(*net.TCPAddr)
 		}
 
-		listeners[i] = tcpLn
+		listeners = append(listeners, tcpLn)
 	}
 
 	l.listeners = listeners


### PR DESCRIPTION
Fixes a panic that was introduced by #8173. It can occur after a TCP listener fails to startup:

```
2020-01-17T02:09:23.827Z [INFO]  core.cluster-listener.tcp: starting listener: listener_address=127.0.0.1:35767
2020-01-17T02:09:23.827Z [ERROR] core.cluster-listener.tcp: error starting listener: error="listen tcp 127.0.0.1:35767: bind: address already in use"
2020-01-17T02:09:23.827Z [INFO]  TestBackend_E2E_Initialize: cleaning up vault cluster
--- FAIL: TestBackend_E2E_Initialize (3.06s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x764082]

goroutine 8 [running]:
testing.tRunner.func1(0xc000228400)
	/usr/local/go/src/testing/testing.go:830 +0x392
panic(0x151f8a0, 0x285aaf0)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
crypto/tls.(*listener).Addr(0xc0004d0dc0, 0xc0004d0d01, 0x0)
	<autogenerated>:1 +0x32
github.com/hashicorp/vault/vault/cluster.(*Listener).Run(0xc000226100, 0x1ac6140, 0xc0000a8010, 0x1ada280, 0xc0002969c0)
	/go/src/github.com/hashicorp/vault/vault/cluster/cluster.go:257 +0x2fb
github.com/hashicorp/vault/vault.(*Core).startClusterListener(0xc00024fb80, 0x1ac6140, 0xc0000a8010, 0xc0000a49f0, 0x20)
	/go/src/github.com/hashicorp/vault/vault/cluster.go:312 +0x4df
github.com/hashicorp/vault/vault.(*Core).unsealInternal(0xc00024fb80, 0x1ac6140, 0xc0000a8010, 0xc0000a49f0, 0x20, 0x21, 0x0, 0x0, 0x0)
	/go/src/github.com/hashicorp/vault/vault/core.go:1372 +0x121
github.com/hashicorp/vault/vault.(*Core).unseal(0xc00024fb80, 0xc0000a4990, 0x21, 0x21, 0x187ce00, 0x27d7900, 0x0, 0x0)
	/go/src/github.com/hashicorp/vault/vault/core.go:1056 +0x5e7
github.com/hashicorp/vault/vault.(*Core).Unseal(...)
	/go/src/github.com/hashicorp/vault/vault/core.go:966
github.com/hashicorp/vault/vault.(*TestCluster).UnsealCoresWithError.func1(0xc00024fb80, 0xc000347580, 0xc0000cbe28)
	/go/src/github.com/hashicorp/vault/vault/testing.go:842 +0xdf
github.com/hashicorp/vault/vault.(*TestCluster).UnsealCoresWithError(0xc00022cfc0, 0xc000010000, 0x0, 0x0)
	/go/src/github.com/hashicorp/vault/vault/testing.go:855 +0xa9
github.com/hashicorp/vault/vault.(*TestCluster).UnsealCores(0xc00022cfc0, 0x1ad8e00, 0xc000228400)
	/go/src/github.com/hashicorp/vault/vault/testing.go:834 +0x48
github.com/hashicorp/vault/builtin/credential/aws.TestBackend_E2E_Initialize(0xc000228400)
	/go/src/github.com/hashicorp/vault/builtin/credential/aws/backend_e2e_test.go:89 +0x94e
testing.tRunner(0xc000228400, 0x17b97c0)
	/usr/local/go/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:916 +0x35a
FAIL	github.com/hashicorp/vault/builtin/credential/aws	3.075s
```