### PR TITLE
Backport: Fix automatic token set for plugin unwrap requests (#8058)

### DIFF
--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -118,6 +118,9 @@ func VaultPluginTLSProvider(apiTLSConfig *TLSConfig) func() (*tls.Config, error)
 			return nil, errwrap.Wrapf("error during api client creation: {{err}}", err)
 		}
 
+		// Reset token value to make sure nothing has been set by default
+		client.ClearToken()
+
 		secret, err := client.Logical().Unwrap(unwrapToken)
 		if err != nil {
 			return nil, errwrap.Wrapf("error during token unwrap request: {{err}}", err)


### PR DESCRIPTION
* Fix automatic token set for plugin unwrap requests

* Change to ClearToken helper-method