### PR TITLE
Backport 1.3.x: fix overflow issue on box-radio

### DIFF
--- a/ui/app/styles/components/box-radio.scss
+++ b/ui/app/styles/components/box-radio.scss
@@ -11,7 +11,7 @@
   box-sizing: border-box;
   flex-basis: 7rem;
   width: 7rem;
-  height: 7.5rem;
+  min-height: 7.5rem;
   padding: $size-10 $size-6 $size-10;
   flex-direction: column;
   justify-content: space-between;


### PR DESCRIPTION
 Backport for [8065](https://github.com/hashicorp/vault/pull/8065), which fixes an overflow issue on box-radio 