### PR TITLE
Update the logic that prepares seal migration

### DIFF
--- a/command/server_util.go
+++ b/command/server_util.go
@@ -54,9 +54,6 @@ func adjustCoreForSealMigration(logger log.Logger, core *vault.Core, barrierSeal
 		}
 	}
 
-	var existSeal vault.Seal
-	var newSeal vault.Seal
-
 	if existBarrierSealConfig.Type == barrierSeal.BarrierType() {
 		// In this case our migration seal is set so we are using it
 		// (potentially) for unwrapping. Set it on core for that purpose then
@@ -69,15 +66,48 @@ func adjustCoreForSealMigration(logger log.Logger, core *vault.Core, barrierSeal
 		return errors.New(`Recovery seal configuration not found for existing seal`)
 	}
 
+	if onEnterprise && barrierSeal.BarrierType() == wrapping.Shamir {
+		return errors.New("Migrating from autoseal to Shamir seal is not currently supported on Vault Enterprise")
+	}
+
+	var migrationSeal vault.Seal
+	var newSeal vault.Seal
+
+	// Determine the migrationSeal. This is either going to be an instance of
+	// shamir or the unwrapSeal.
 	switch existBarrierSealConfig.Type {
 	case wrapping.Shamir:
 		// The value reflected in config is what we're going to
-		existSeal = vault.NewDefaultSeal(&vaultseal.Access{
+		migrationSeal = vault.NewDefaultSeal(&vaultseal.Access{
 			Wrapper: aeadwrapper.NewWrapper(&wrapping.WrapperOptions{
 				Logger: logger.Named("shamir"),
 			}),
 		})
-		newSeal = barrierSeal
+
+	default:
+		// If we're not coming from Shamir we expect the previous seal to be
+		// in the config and disabled.
+		migrationSeal = unwrapSeal
+	}
+
+	// newSeal will be the barrierSeal
+	newSeal = barrierSeal
+
+	// Set the appropriate barrier and recovery configs.
+	switch {
+	case migrationSeal.RecoveryKeySupported() && newSeal.RecoveryKeySupported():
+		// Migrating from auto->auto, copy the configs over
+		newSeal.SetCachedBarrierConfig(existBarrierSealConfig)
+		newSeal.SetCachedRecoveryConfig(existRecoverySealConfig)
+	case migrationSeal.RecoveryKeySupported():
+		// Migrating from auto->shamir, clone auto's recovery config and set
+		// stored keys to 1.
+		newSealConfig := existRecoverySealConfig.Clone()
+		newSealConfig.StoredShares = 1
+		newSeal.SetCachedBarrierConfig(newSealConfig)
+	case newSeal.RecoveryKeySupported():
+		// Migrating from shamir->auto, set a new barrier config and set
+		// recovery config to shamir's barrier config
 		newBarrierSealConfig := &vault.SealConfig{
 			Type:            newSeal.BarrierType(),
 			SecretShares:    1,
@@ -86,20 +116,9 @@ func adjustCoreForSealMigration(logger log.Logger, core *vault.Core, barrierSeal
 		}
 		newSeal.SetCachedBarrierConfig(newBarrierSealConfig)
 		newSeal.SetCachedRecoveryConfig(existBarrierSealConfig)
-
-	default:
-		if onEnterprise && barrierSeal.BarrierType() == wrapping.Shamir {
-			return errors.New("Migrating from autoseal to Shamir seal is not currently supported on Vault Enterprise")
-		}
-
-		// If we're not coming from Shamir we expect the previous seal to be
-		// in the config and disabled.
-		existSeal = unwrapSeal
-		newSeal = barrierSeal
-		newSeal.SetCachedBarrierConfig(existRecoverySealConfig)
 	}
 
-	core.SetSealsForMigration(existSeal, newSeal, unwrapSeal)
+	core.SetSealsForMigration(migrationSeal, newSeal, unwrapSeal)
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c
 	github.com/coreos/go-semver v0.2.0
-	github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20190412130859-3b1d194e553a
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
@@ -48,7 +47,6 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-metrics-stackdriver v0.0.0-20190816035513-b52628e82e2a
-	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.8.5 // indirect
 	github.com/hashicorp/consul-template v0.22.0
 	github.com/hashicorp/consul/api v1.1.0
@@ -97,7 +95,6 @@ require (
 	github.com/joyent/triton-go v0.0.0-20190112182421-51ffac552869
 	github.com/keybase/go-crypto v0.0.0-20190403132359-d65b6b94177f
 	github.com/kr/pretty v0.1.0
-	github.com/kr/pty v1.1.3 // indirect
 	github.com/kr/text v0.1.0
 	github.com/lib/pq v1.2.0
 	github.com/mattn/go-colorable v0.1.4

--- a/vault/core.go
+++ b/vault/core.go
@@ -1284,14 +1284,6 @@ func (c *Core) unsealPart(ctx context.Context, seal Seal, key []byte, useRecover
 			if recoveryKey == nil {
 				return nil, errors.New("did not get expected recovery information to set new seal during migration")
 			}
-			if err := c.seal.SetBarrierConfig(ctx, &SealConfig{
-				Type:            wrapping.Shamir,
-				SecretShares:    config.SecretShares,
-				SecretThreshold: config.SecretThreshold,
-				StoredShares:    1,
-			}); err != nil {
-				return nil, errwrap.Wrapf("failed to store barrier config during migration: {{err}}", err)
-			}
 
 			// We have recovery keys; we're going to use them as the new
 			// shamir KeK.


### PR DESCRIPTION
Instead of calling SetBarrierConfig in #8172 this updates the logic in `adjustCoreForSealMigration` to correctly set the barrier and recovery configs. I think this fixes the issue in #8172 and another issue where auto->auto migrations were not getting the correct config.