### PR TITLE
Fix typo in YAML markup

### DIFF
--- a/website/pages/docs/platform/k8s/injector/examples.mdx
+++ b/website/pages/docs/platform/k8s/injector/examples.mdx
@@ -120,7 +120,7 @@ spec:
         vault.hashicorp.com/tls-secret: "vault-tls-client"
     spec:
       containers:
-        - name:app
+        - name: app
           image: "app:1.0.0"
       serviceAccountName: app-example
 ```


### PR DESCRIPTION
Fix a small typo that breaks YAML spec and syntax highlight on the official documentation webpage.