### PR TITLE
Documentation Suggestion: Add a specific reference to AWS IAM Unique Identifiers

### DIFF
--- a/website/pages/docs/auth/aws.mdx
+++ b/website/pages/docs/auth/aws.mdx
@@ -331,7 +331,7 @@ are needed.
 - `iam:GetUser` and `iam:GetRole` are used when using the iam auth method and
   binding to an IAM user or role principal to determine the [AWS IAM Unique Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids)
   or when using a wildcard on the bound ARN to resolve the full ARN of the user
-  or role. IAM Unique Identifiers are mapped to an array `bound_iam_principal_id`
+  or role.
 - The `sts:AssumeRole` stanza is necessary when you are using [Cross Account
   Access](#cross-account-access). The `Resource`s specified should be a list of
   all the roles for which you have configured cross-account access, and each of

--- a/website/pages/docs/auth/aws.mdx
+++ b/website/pages/docs/auth/aws.mdx
@@ -329,9 +329,9 @@ are needed.
   `ec2` auth method. Vault needs to determine which IAM role is attached to the
   instance profile.
 - `iam:GetUser` and `iam:GetRole` are used when using the iam auth method and
-  binding to an IAM user or role principal to determine the unique AWS user ID
+  binding to an IAM user or role principal to determine the [AWS IAM Unique Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids)
   or when using a wildcard on the bound ARN to resolve the full ARN of the user
-  or role.
+  or role. IAM Unique Identifiers are mapped to an array `bound_iam_principal_id`
 - The `sts:AssumeRole` stanza is necessary when you are using [Cross Account
   Access](#cross-account-access). The `Resource`s specified should be a list of
   all the roles for which you have configured cross-account access, and each of


### PR DESCRIPTION
We experienced an issue where IAM roles resources were re-provisioned with the same ARNs and no change had been made to our vault role configuration but users lost access with `-method=aws`. It wasn't immediately clear to us how IAM Unique Identifiers where being used to avoid the same situations outlined in the AWS documentation. We eventually concluded that re-provisioning the roles in our auth/aws/auth would fetch the new IAM Unique Identifiers. 

I hope that this small amendment helps people avoid this problem in the future.