### PR TITLE
Fix redoing redirect response raft snapshot cli

### DIFF
--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -93,6 +94,34 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 	resp, err := c.c.config.HttpClient.Do(req)
 	if resp == nil {
 		return nil
+	}
+
+	// Check for a redirect, only allowing for a single redirect
+	if resp.StatusCode == 301 || resp.StatusCode == 302 || resp.StatusCode == 307 {
+		// Parse the updated location
+		respLoc, err := resp.Location()
+		if err != nil {
+			return err
+		}
+
+		// Ensure a protocol downgrade doesn't happen
+		if req.URL.Scheme == "https" && respLoc.Scheme != "https" {
+			return fmt.Errorf("redirect would cause protocol downgrade")
+		}
+
+		// Update the request
+		req.URL = respLoc
+
+		// Reset the request body if any
+		if err := r.ResetJSONBody(); err != nil {
+			return err
+		}
+
+		// Retry the request
+		resp, err = c.c.config.HttpClient.Do(req)
+		if err != nil {
+			return err
+		}
 	}
 
 	result = &Response{Response: resp}

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -112,11 +112,6 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 		// Update the request
 		req.URL = respLoc
 
-		// Reset the request body if any
-		if err := r.ResetJSONBody(); err != nil {
-			return err
-		}
-
 		// Retry the request
 		resp, err = c.c.config.HttpClient.Do(req)
 		if err != nil {

--- a/vendor/github.com/hashicorp/vault/api/sys_raft.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_raft.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -93,6 +94,34 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 	resp, err := c.c.config.HttpClient.Do(req)
 	if resp == nil {
 		return nil
+	}
+
+	// Check for a redirect, only allowing for a single redirect
+	if resp.StatusCode == 301 || resp.StatusCode == 302 || resp.StatusCode == 307 {
+		// Parse the updated location
+		respLoc, err := resp.Location()
+		if err != nil {
+			return err
+		}
+
+		// Ensure a protocol downgrade doesn't happen
+		if req.URL.Scheme == "https" && respLoc.Scheme != "https" {
+			return fmt.Errorf("redirect would cause protocol downgrade")
+		}
+
+		// Update the request
+		req.URL = respLoc
+
+		// Reset the request body if any
+		if err := r.ResetJSONBody(); err != nil {
+			return err
+		}
+
+		// Retry the request
+		resp, err = c.c.config.HttpClient.Do(req)
+		if err != nil {
+			return err
+		}
 	}
 
 	result = &Response{Response: resp}

--- a/vendor/github.com/hashicorp/vault/api/sys_raft.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_raft.go
@@ -112,11 +112,6 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 		// Update the request
 		req.URL = respLoc
 
-		// Reset the request body if any
-		if err := r.ResetJSONBody(); err != nil {
-			return err
-		}
-
 		// Retry the request
 		resp, err = c.c.config.HttpClient.Do(req)
 		if err != nil {


### PR DESCRIPTION
Fixes #8097

Sending a raft snapshot save request to a hot standby node results in a redirect response.
Since the raft snapshot save CLI command is a bit different compared to our usual CLI commands, this command needs extra functionality to redo the request in case of a redirect response.