### PR TITLE
The Link to the Getting started Guide is not working

### DIFF
--- a/website/pages/docs/index.mdx
+++ b/website/pages/docs/index.mdx
@@ -5,4 +5,4 @@ page_title: Documentation
 
 # Documentation
 
-Welcome to the Vault documentation! This documentation is more of a reference guide for all available features and options of Vault. If you're just getting started with Vault, please start with the [introduction](what-is-vault) instead, and work your way up to the [Getting Started](intro/getting-started/install) guide.
+Welcome to the Vault documentation! This documentation is more of a reference guide for all available features and options of Vault. If you're just getting started with Vault, please start with the [introduction](what-is-vault) instead, and work your way up to the [Getting Started](https://learn.hashicorp.com/vault#getting-started) guide.


### PR DESCRIPTION
The link to the getting started with Vault in the Learn section seems to be broken.