### PR TITLE
Add Kerberos agent docs

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -185,6 +185,7 @@ export default [
               'cf',
               'gcp',
               'jwt',
+              'kerberos',
               'kubernetes'
             ]
           },

--- a/website/pages/docs/agent/autoauth/methods/kerberos.mdx
+++ b/website/pages/docs/agent/autoauth/methods/kerberos.mdx
@@ -14,7 +14,7 @@ a Vault token for Kerberos entities. It reads in configuration and
 identification information from the surrounding environment, and uses
 it to authenticate to Vault.
 
-For more on this auth method, see the [Kerberos auth method](https://www.vaultproject.io/docs/auth/kerberos.html).
+For more on this auth method, see the [Kerberos auth method](/docs/auth/kerberos).
 
 ## Configuration
 
@@ -23,7 +23,7 @@ communicate with the Kerberos environment.
 - `keytab_path` is the path to the `keytab` in which the entry lives for the
 entity authenticating to Vault. Keytab files should be protected from other
 users on a shared server using appropriate file permissions.
-- `username` is the username for the entry _within_ the `keytab` to use for 
+- `username` is the username for the entry _within_ the `keytab` to use for
 logging into Kerberos. This username must match a service account in LDAP.
 - `service` is the service principal name to use in obtaining a service ticket for
 gaining a SPNEGO token. This service must exist in LDAP.

--- a/website/pages/docs/agent/autoauth/methods/kerberos.mdx
+++ b/website/pages/docs/agent/autoauth/methods/kerberos.mdx
@@ -1,0 +1,31 @@
+---
+layout: "docs"
+page_title: "Vault Agent Auto-Auth Kerberos Method"
+sidebar_title: "Kerberos"
+sidebar_current: "docs-agent-autoauth-methods-kerberos"
+description: |-
+  Kerberos Method for Vault Agent Auto-Auth
+---
+
+# Vault Agent Auto-Auth Kerberos Method
+
+The `kerberos` agent provides an automated mechanism to retrieve
+a Vault token for Kerberos entities. It reads in configuration and
+identification information from the surrounding environment, and uses
+it to authenticate to Vault.
+
+For more on this auth method, see the [Kerberos auth method](https://www.vaultproject.io/docs/auth/kerberos.html).
+
+## Configuration
+
+- `krb5conf_path` is the path to a valid `krb5.conf` file describing how to
+communicate with the Kerberos environment.
+- `keytab_path` is the path to the `keytab` in which the entry lives for the
+entity authenticating to Vault. Keytab files should be protected from other
+users on a shared server using appropriate file permissions.
+- `username` is the username for the entry _within_ the `keytab` to use for 
+logging into Kerberos. This username must match a service account in LDAP.
+- `service` is the service principal name to use in obtaining a service ticket for
+gaining a SPNEGO token. This service must exist in LDAP.
+- `realm` is the name of the Kerberos realm. This realm must match the UPNDomain
+configured on the LDAP connection. This check is case-sensitive.

--- a/website/pages/docs/auth/kerberos.mdx
+++ b/website/pages/docs/auth/kerberos.mdx
@@ -149,7 +149,8 @@ $ vault login -method=kerberos \
 - `krb5conf_path` is the path to a valid `krb5.conf` file describing how to
   communicate with the Kerberos environment.
 - `keytab_path` is the path to the `keytab` in which the entry lives for the
-  entity authenticating to Vault.
+  entity authenticating to Vault. Keytab files should be protected from other
+  users on a shared server using appropriate file permissions.
 - `username` is the username for the entry _within_ the `keytab` to use for
   logging into Kerberos. This username must match a service account in LDAP.
 - `service` is the service principal name to use in obtaining a service ticket for


### PR DESCRIPTION
This PR adds documentation for the Kerberos auth agent. The field descriptions match those already added in #7993 [here](https://github.com/hashicorp/vault/pull/7993/files#diff-8b8c7800989f1410f4b3be75dfc65d32R151).