### PR TITLE
Fix example url for sys/wrapping/rewrap

### DIFF
--- a/website/pages/api-docs/system/wrapping-rewrap.mdx
+++ b/website/pages/api-docs/system/wrapping-rewrap.mdx
@@ -42,7 +42,7 @@ $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
-    http://127.0.0.1:8200/v1/sys/wrapping/lookup
+    http://127.0.0.1:8200/v1/sys/wrapping/rewrap
 ```
 
 ### Sample Response


### PR DESCRIPTION
The current example for rewrap points to the lookup endpoint.