### PR TITLE
add google cloudhsm and pricing

### DIFF
--- a/website/pages/docs/vs/hsm.mdx
+++ b/website/pages/docs/vs/hsm.mdx
@@ -12,10 +12,13 @@ A [hardware security module
 device that is meant to secure various secrets using protections against access
 and tampering at both the software and hardware layers.
 
-The primary issue with HSMs is that they are expensive and not very cloud
-friendly. An exception to the latter is Amazon's CloudHSM service, which is
-friendly for AWS users but still costs more than \$14k per year per instance,
-and not as useful for heterogenous cloud architectures.
+The primary issue with Cloud HSMs is that they are expensive.
+Amazon and Google both provide a managed CloudHSM service, which is
+friendly for AWS/GCP users. Cost for AWS CloudHSM is $14k per year per instance,
+while Google charges a different rate per key operation by 10k batches. You can
+find more details on pricing for GCP CloudHSM 
+[here](https://cloud.google.com/hsm/) and 
+AWS CloudHSM [here](https://aws.amazon.com/cloudhsm/pricing/).
 
 Once an HSM is up and running, configuring it is generally very tedious, and
 the API to request secrets is also difficult to use. Example: CloudHSM requires


### PR DESCRIPTION
Updating this documentation to add Google CloudHSM along with pricing information for those that want to calculate the actual cost based on their use cases.