### PR TITLE
ui: show kmip details in wizard

### DIFF
--- a/ui/app/templates/components/wizard/kmip-engine.hbs
+++ b/ui/app/templates/components/wizard/kmip-engine.hbs
@@ -1,0 +1,9 @@
+<WizardSection @headerText="KMIP" @headerIcon="kmip" @docText="Docs: KMIP Secrets Engine"
+  @docPath="/docs/secrets/kmip/index.html">
+  <p>
+    The KMIP secrets engine allows Vault to act as a KMIP server provider and handle the lifecycle of KMIP managed
+    objects. KMIP, which stands for Key Management Interoperability Protocol, is a standardized protocol that allows
+    services and applications to perform cryptographic operations without having to manage cryptographic material,
+    otherwise known as manage objects, by delegating its storage and lifecycle to a key management server.
+  </p>
+</WizardSection>


### PR DESCRIPTION
This PR fixes a bug where the UI Wizard didn't display the KMIP Secrets Engine description or link to documentation when enabling it. 

Fixes this issue: https://github.com/hashicorp/vault/issues/8198

![kmip wizard](https://user-images.githubusercontent.com/903288/73286843-e08a3600-41bd-11ea-8c68-63b7b3870e5d.gif)

