### PR TITLE
Removing timing-dependent aspects of test.

### DIFF
--- a/serviceregistration/consul/consul_service_registration_test.go
+++ b/serviceregistration/consul/consul_service_registration_test.go
@@ -66,7 +66,7 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 
 	// transitionFrom waits patiently for the services in the Consul catalog to
 	// transition from a known value, and then returns the new value.
-	transitionFrom := func(t *testing.T, known map[string][]string) map[string][]string {
+	waitForServices := func(t *testing.T, expected map[string][]string) map[string][]string {
 		t.Helper()
 		// Wait for up to 10 seconds
 		for i := 0; i < 10; i++ {
@@ -74,12 +74,12 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := deep.Equal(services, known); diff != nil {
+			if diff := deep.Equal(services, expected); diff == nil {
 				return services
 			}
 			time.Sleep(time.Second)
 		}
-		t.Fatalf("Catalog Services never transitioned from %v", known)
+		t.Fatalf("Catalog Services never reached expected state %v", expected)
 		return nil
 	}
 
@@ -122,27 +122,10 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Vault should not yet be registered with Consul
-	services, _, err := client.Catalog().Services(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if diff := deep.Equal(services, map[string][]string{
-		"consul": []string{},
-	}); diff != nil {
-		t.Fatal(diff)
-	}
-
-	// Vault should soon be registered with Consul in standby mode
-	services = transitionFrom(t, map[string][]string{
-		"consul": []string{},
-	})
-	if diff := deep.Equal(services, map[string][]string{
+	waitForServices(t, map[string][]string{
 		"consul": []string{},
 		"vault":  []string{"standby"},
-	}); diff != nil {
-		t.Fatal(diff)
-	}
+	})
 
 	// Initialize and unseal the core
 	keys, _ := vault.TestCoreInit(t, core)
@@ -158,17 +141,10 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 	// Wait for the core to become active
 	vault.TestWaitActive(t, core)
 
-	// Vault should soon be registered with Consul in active mode
-	services = transitionFrom(t, map[string][]string{
-		"consul": []string{},
-		"vault":  []string{"standby"},
-	})
-	if diff := deep.Equal(services, map[string][]string{
+	waitForServices(t, map[string][]string{
 		"consul": []string{},
 		"vault":  []string{"active"},
-	}); diff != nil {
-		t.Fatal(diff)
-	}
+	})
 }
 
 func TestConsul_ServiceTags(t *testing.T) {

--- a/serviceregistration/consul/consul_service_registration_test.go
+++ b/serviceregistration/consul/consul_service_registration_test.go
@@ -64,8 +64,8 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// transitionFrom waits patiently for the services in the Consul catalog to
-	// transition from a known value, and then returns the new value.
+	// waitForServices waits for the services in the Consul catalog to
+	// reach an expected value, returning the delta if that doesn't happen in time.
 	waitForServices := func(t *testing.T, expected map[string][]string) map[string][]string {
 		t.Helper()
 		// Wait for up to 10 seconds


### PR DESCRIPTION
This addresses two failures I've see:

```
--- FAIL: TestConsul_ServiceRegistration (11.35s)
    consulhelper.go:15: preparing test container
    consulhelper.go:79: Generated Master token: 95b3bac9-fd3e-9392-2570-720ddcec64bc
    consul_service_registration_test.go:133: [map[consul]: <does not have key> != []]
```

and, from https://circleci.hashicorp.engineering/gh/hashicorp/vault-enterprise/22753?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification

```
--- FAIL: TestConsul_ServiceRegistration (1.76s)
    consulhelper.go:15: preparing test container
    consulhelper.go:79: Generated Master token: 4d34b9be-ea6e-09e9-5592-8c699efdf7db
    consul_service_registration_test.go:133: [map[vault]: [standby] != <does not have key>]
```
