### PR TITLE
Fix flaky test of api renewer by moving away from legacy api.

### DIFF
--- a/vault/external_tests/api/renewer_integration_test.go
+++ b/vault/external_tests/api/renewer_integration_test.go
@@ -28,7 +28,7 @@ func TestRenewer_Renew(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			v, err := client.NewRenewer(&api.RenewerInput{
+			v, err := client.NewLifetimeWatcher(&api.RenewerInput{
 				Secret: secret,
 			})
 			if err != nil {
@@ -39,7 +39,7 @@ func TestRenewer_Renew(t *testing.T) {
 
 			select {
 			case err := <-v.DoneCh():
-				if err != api.ErrRenewerNotRenewable {
+				if err != api.ErrLifetimeWatcherNotRenewable {
 					t.Fatal(err)
 				}
 			case renew := <-v.RenewCh():
@@ -65,7 +65,7 @@ func TestRenewer_Renew(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			v, err := client.NewRenewer(&api.RenewerInput{
+			v, err := client.NewLifetimeWatcher(&api.RenewerInput{
 				Secret: secret,
 			})
 			if err != nil {
@@ -76,7 +76,7 @@ func TestRenewer_Renew(t *testing.T) {
 
 			select {
 			case err := <-v.DoneCh():
-				if err != api.ErrRenewerNotRenewable {
+				if err != api.ErrLifetimeWatcherNotRenewable {
 					t.Fatal(err)
 				}
 			case renew := <-v.RenewCh():
@@ -120,7 +120,7 @@ func TestRenewer_Renew(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			v, err := client.NewRenewer(&api.RenewerInput{
+			v, err := client.NewLifetimeWatcher(&api.RenewerInput{
 				Secret: secret,
 			})
 			if err != nil {
@@ -180,7 +180,7 @@ func TestRenewer_Renew(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			v, err := client.NewRenewer(&api.RenewerInput{
+			v, err := client.NewLifetimeWatcher(&api.RenewerInput{
 				Secret: secret,
 			})
 			if err != nil {


### PR DESCRIPTION
I wasn't able to reproduce this, so it's a speculative fix.  An example failure from https://circleci.com/gh/hashicorp/vault/37790?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link looks like

```
        --- FAIL: TestRenewer_Renew/group/auth (10.93s)
            renewer_integration_test.go:203: renewal failed with an error: Error making API request.
                
                URL: PUT https://127.0.0.1:44085/v1/auth/token/renew-self
                Code: 400. Errors:
                
                * lease expired
```

What I think happened is that we renewed successfully at least once, and then due to a slow VM didn't reach https://github.com/hashicorp/vault/blob/master/api/lifetime_watcher.go#L337 (where we'd have exited cleanly) before it encountered a renewal failure here: https://github.com/hashicorp/vault/blob/master/api/lifetime_watcher.go#L286.  The newer API doesn't enter that if statement so shouldn't fail this way.  I converted the other tests in this file to use the newer API as well because I think it makes more sense to exercise the non-legacy API.