### PR TITLE
Handle POST requests to ui paths

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -395,9 +395,17 @@ func handleUIPost(h http.Handler) http.Handler {
 			return
 		}
 
+		// Limit handling to only the expected callback URL
+		if !strings.HasPrefix(req.URL.Path, "/ui/vault/auth") ||
+			!strings.HasSuffix(req.URL.Path, "callback") {
+			http.NotFound(w, req)
+			return
+		}
+
 		state := req.FormValue("state")
 		code := req.FormValue("code")
 
+		// state and code will always be part of a valid callback request
 		if state == "" || code == "" {
 			http.NotFound(w, req)
 			return


### PR DESCRIPTION
This support is narrowly targeted at auth login callbacks and is required to support the `form_post` method in OIDC logins. In that case, the request is converted into a GET (which we already support). In all other cases, a 404 is returned.

Companion plugin PR:  https://github.com/hashicorp/vault-plugin-auth-jwt/pull/96