### PR TITLE
Update gen_openapi.sh

### DIFF
--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -31,11 +31,15 @@ vault auth enable aws
 vault auth enable azure
 vault auth enable centrify
 vault auth enable cert
+vault auth enable pcf
 vault auth enable gcp
 vault auth enable github
 vault auth enable jwt
+vault auth enable kerberos
 vault auth enable kubernetes
 vault auth enable ldap
+vault auth enable oci
+vault auth enable oidc
 vault auth enable okta
 vault auth enable pcf
 vault auth enable radius

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -31,7 +31,7 @@ vault auth enable aws
 vault auth enable azure
 vault auth enable centrify
 vault auth enable cert
-vault auth enable pcf
+vault auth enable cf
 vault auth enable gcp
 vault auth enable github
 vault auth enable jwt
@@ -41,7 +41,6 @@ vault auth enable ldap
 vault auth enable oci
 vault auth enable oidc
 vault auth enable okta
-vault auth enable pcf
 vault auth enable radius
 vault auth enable userpass
 


### PR DESCRIPTION
This script is used by the Terraform Vault Provider to learn what percentage of API endpoints are supported. We've added a couple of auth plugins since it was last updated.