### PR TITLE
Pin HTTP Host header for all client requests

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -729,6 +729,7 @@ func (c *Client) NewRequest(method, requestPath string) *Request {
 			Host:   host,
 			Path:   path.Join(addr.Path, requestPath),
 		},
+		Host: c.addr.Host,
 		ClientToken: token,
 		Params:      make(map[string][]string),
 	}

--- a/api/request.go
+++ b/api/request.go
@@ -18,6 +18,7 @@ import (
 type Request struct {
 	Method        string
 	URL           *url.URL
+	Host          string
 	Params        url.Values
 	Headers       http.Header
 	ClientToken   string
@@ -115,7 +116,7 @@ func (r *Request) toRetryableHTTP() (*retryablehttp.Request, error) {
 	req.URL.User = r.URL.User
 	req.URL.Scheme = r.URL.Scheme
 	req.URL.Host = r.URL.Host
-	req.Host = r.URL.Host
+	req.Host = r.Host
 
 	if r.Headers != nil {
 		for header, vals := range r.Headers {


### PR DESCRIPTION
Fixes #5525

SRV lookups override the Host header against the RFC Draft.