### PR TITLE
Return error when a standby node receives a metrics request

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -19,8 +19,8 @@ import (
 	"github.com/NYTimes/gziphandler"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-cleanhttp"
-	"github.com/hashicorp/go-sockaddr"
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	sockaddr "github.com/hashicorp/go-sockaddr"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -160,6 +160,8 @@ func Handler(props *vault.HandlerProperties) http.Handler {
 		// Register metrics path without authentication if enabled
 		if props.UnauthenticatedMetricsAccess {
 			mux.Handle("/v1/sys/metrics", handleMetricsUnauthenticated(core))
+		} else {
+			mux.Handle("/v1/sys/metrics", handleLogicalNoForward(core))
 		}
 
 		additionalRoutes(mux, core)

--- a/http/logical.go
+++ b/http/logical.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-uuid"
+	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -232,6 +232,13 @@ func handleLogicalInternal(core *vault.Core, injectDataIntoTopLevel bool, noForw
 			}
 			forwardRequest(core, w, r)
 			return
+		}
+
+		// Prevent any metrics requests to be forwarded from a standby node.
+		// Instead, we return an error since we cannot be sure if we have an
+		// active token store to validate the provided token.
+		if isStandby, _ := core.Standby(); isStandby {
+			respondError(w, http.StatusBadRequest, vault.ErrCannotForwardLocalOnly)
 		}
 
 		// req.Path will be relative by this point. The prefix check is first

--- a/http/sys_metrics.go
+++ b/http/sys_metrics.go
@@ -13,6 +13,12 @@ func handleMetricsUnauthenticated(core *vault.Core) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req := &logical.Request{Headers: r.Header}
 
+		switch r.Method {
+		case "GET":
+		default:
+			respondError(w, http.StatusMethodNotAllowed, nil)
+		}
+
 		// Parse form
 		if err := r.ParseForm(); err != nil {
 			respondError(w, http.StatusBadRequest, err)

--- a/website/pages/docs/configuration/telemetry.mdx
+++ b/website/pages/docs/configuration/telemetry.mdx
@@ -141,6 +141,10 @@ These `telemetry` parameters apply to
 
 ### `prometheus`
 
+~> **Note:** The `/v1/sys/metrics` endpoint is only accessible on active nodes
+and automatically disabled on standby nodes. You can enable the `/v1/sys/metrics`
+endpoint on standby nodes by [enabling unauthenticated metrics access][telemetry-tcp].
+
 These `telemetry` parameters apply to
 [prometheus](https://prometheus.io).
 
@@ -206,3 +210,5 @@ telemetry {
   enable_hostname_label = true
 }
 ```
+
+[telemetry-tcp]: /docs/configuration/listener/tcp#telemetry


### PR DESCRIPTION
Related PR: https://github.com/hashicorp/vault/issues/6802

By default, the `sys/metrics` API endpoint is restricted. That means all incoming requests need to provide a valid token. Since the token store is never initialized for standby nodes, we currently can't validate incoming requests with their respective tokens which results in a forward to the primary.

This PR adds additional behavior that returns the `cannot forward local-only request` error for the above scenario. Metrics requests on standby nodes where the unauthenticated metrics access has been enabled will not change and will continue to work.