### PR TITLE
secret/database: Guard against panic with InfluxDB plugin

### DIFF
--- a/plugins/database/influxdb/connection_producer.go
+++ b/plugins/database/influxdb/connection_producer.go
@@ -249,7 +249,7 @@ func isUserAdmin(cli influx.Client, user string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if response.Error() != nil {
+	if response != nil && response.Error() != nil {
 		return false, response.Error()
 	}
 	for _, res := range response.Results {

--- a/plugins/database/influxdb/connection_producer.go
+++ b/plugins/database/influxdb/connection_producer.go
@@ -249,7 +249,10 @@ func isUserAdmin(cli influx.Client, user string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if response != nil && response.Error() != nil {
+	if response == nil {
+		return false, fmt.Errorf("empty response")
+	}
+	if response.Error() != nil {
 		return false, response.Error()
 	}
 	for _, res := range response.Results {


### PR DESCRIPTION
The InfluxDB SDK client can return a `nil` response from some queries that result in an error. Guard against using the `response.Error()` method if the response is `nil`.

Fixes #6734
