### PR TITLE
Backport 1.3.x: secret/database: Guard against panic with InfluxDB plugin (#8282)

### DIFF
--- a/plugins/database/influxdb/connection_producer.go
+++ b/plugins/database/influxdb/connection_producer.go
@@ -249,6 +249,9 @@ func isUserAdmin(cli influx.Client, user string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if response == nil {
+		return false, fmt.Errorf("empty response")
+	}
 	if response.Error() != nil {
 		return false, response.Error()
 	}


### PR DESCRIPTION
Backport of #8282 to `1.3.x`

* database/influx: fix panic when trying to revoke user