### PR TITLE
Fix typo in vault agent injector example docs

### DIFF
--- a/website/pages/docs/platform/k8s/injector/examples.mdx
+++ b/website/pages/docs/platform/k8s/injector/examples.mdx
@@ -40,7 +40,7 @@ owner of the pod. Check the following for errors:
 
 ## Patching Existing Pods
 
-To patch existing pods, a Kubernetes patch can be applied to add the required annoations
+To patch existing pods, a Kubernetes patch can be applied to add the required annotations
 to pods. When applying a patch, the pods will be rescheduled.
 
 First, create the patch:


### PR DESCRIPTION
Fix mispelling of `annotation`.