### PR TITLE
docs(css) fix button padding on use-case pages

### DIFF
--- a/website/components/use-case-cta-section/style.css
+++ b/website/components/use-case-cta-section/style.css
@@ -12,6 +12,10 @@
   text-align: center;
   color: var(--white);
 
+  & .g-btn {
+    padding: 14px 20px;
+  }
+  
   & .g-btn.white {
     background: var(--white);
     border: 2px solid var(--white);


### PR DESCRIPTION
Buttons at the bottom of each use-case page look squished. This new padding is consistent with the "subscribe to newsletter" button in the footer. 

The maintainer may want to create a class that applies to all buttons instead.

Fixes issue: https://github.com/hashicorp/vault/issues/8232

Before:
<img width="1635" alt="Screen Shot 2020-02-08 at 5 48 19 PM" src="https://user-images.githubusercontent.com/21048592/74094814-546cee00-4a9c-11ea-844e-6d87270d0074.png">

After:
<img width="1634" alt="Screen Shot 2020-02-08 at 5 48 10 PM" src="https://user-images.githubusercontent.com/21048592/74094817-5767de80-4a9c-11ea-96e1-435c69976eeb.png">

Pages affected:
https://www.vaultproject.io/use-cases/secrets-management/
https://www.vaultproject.io/use-cases/identity-based-access/
https://www.vaultproject.io/use-cases/data-encryption/