### PR TITLE
Add the Canal Erlang client library

### DIFF
--- a/website/pages/api-docs/libraries.mdx
+++ b/website/pages/api-docs/libraries.mdx
@@ -72,6 +72,10 @@ $ Install-Package Vault
 - [libvault](https://hex.pm/packages/libvault)
 - [vaultex](https://hex.pm/packages/vaultex)
 
+### Erlang
+
+- [canal](https://github.com/rkallos/canal)
+
 ### Go
 
 - [vc](https://github.com/adfinis-sygroup/vault-client)


### PR DESCRIPTION
This PR links to an Erlang client library we developed. It's very minimal, but covers the essential features.

As for why it's called Canal, [our lead engineer](https://github.com/lpgauth?utf8=%E2%9C%93&tab=repositories&q=&type=source&language=erlang) has created precedent for naming Erlang libraries under a nautical theme. @rkallos snuck a pun in there for good measure.