### PR TITLE
Support processing parameters sent as a URL-encoded form

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -623,7 +623,8 @@ func parseFormRequest(r *http.Request) (map[string]interface{}, error) {
 		data = make(map[string]interface{}, len(r.PostForm))
 		for k, v := range r.PostForm {
 			switch len(v) {
-			case 0, 1:
+			case 0:
+			case 1:
 				data[k] = v[0]
 			default:
 				// Almost anywhere taking in a string list can take in comma

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -703,6 +703,7 @@ func TestHandler_Parse_Form(t *testing.T) {
 		"zip":   []string{"zap"},
 		"abc":   []string{"xyz"},
 		"multi": []string{"first", "second"},
+		"empty": []string{},
 	}
 	req, err := http.NewRequest("POST", cores[0].Client.Address()+"/v1/secret/foo", nil)
 	if err != nil {

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -2,11 +2,14 @@ package http
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/textproto"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -674,5 +677,65 @@ func testNonPrintable(t *testing.T, disable bool) {
 		testResponseStatus(t, resp, 204)
 	} else {
 		testResponseStatus(t, resp, 400)
+	}
+}
+
+func TestHandler_Parse_Form(t *testing.T) {
+	cluster := vault.NewTestCluster(t, &vault.CoreConfig{}, &vault.TestClusterOptions{
+		HandlerFunc: Handler,
+	})
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+
+	core := cores[0].Core
+	vault.TestWaitActive(t, core)
+
+	c := cleanhttp.DefaultClient()
+	c.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: cluster.RootCAs,
+		},
+	}
+
+	values := url.Values{
+		"zip":   []string{"zap"},
+		"abc":   []string{"xyz"},
+		"multi": []string{"first", "second"},
+	}
+	req, err := http.NewRequest("POST", cores[0].Client.Address()+"/v1/secret/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Body = ioutil.NopCloser(strings.NewReader(values.Encode()))
+	req.Header.Set("x-vault-token", cluster.RootToken)
+	req.Header.Set("content-type", "application/x-www-form-urlencoded")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 204 {
+		t.Fatalf("bad response: %#v\nrequest was: %#v\nurl was: %#v", *resp, *req, req.URL)
+	}
+
+	client := cores[0].Client
+	client.SetToken(cluster.RootToken)
+
+	apiResp, err := client.Logical().Read("secret/foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if apiResp == nil {
+		t.Fatal("api resp is nil")
+	}
+	expected := map[string]interface{}{
+		"zip":   "zap",
+		"abc":   "xyz",
+		"multi": "first,second",
+	}
+	if diff := deep.Equal(expected, apiResp.Data); diff != nil {
+		t.Fatal(diff)
 	}
 }

--- a/http/logical.go
+++ b/http/logical.go
@@ -115,7 +115,7 @@ func buildLogicalRequestNoAuth(perfStandby bool, w http.ResponseWriter, r *http.
 			if isForm(head, r.Header.Get("Content-Type")) {
 				formData, err := parseFormRequest(r)
 				if err != nil {
-					return nil, nil, http.StatusBadRequest, fmt.Errorf("error parsing form data: %w", err)
+					return nil, nil, http.StatusBadRequest, errwrap.Wrapf("error parsing form data: {{err}}", err)
 				}
 
 				data = formData

--- a/http/logical.go
+++ b/http/logical.go
@@ -115,7 +115,7 @@ func buildLogicalRequestNoAuth(perfStandby bool, w http.ResponseWriter, r *http.
 			if isForm(head, r.Header.Get("Content-Type")) {
 				formData, err := parseFormRequest(r)
 				if err != nil {
-					return nil, nil, http.StatusBadRequest, errwrap.Wrapf("error parsing form data: {{err}}", err)
+					return nil, nil, http.StatusBadRequest, fmt.Errorf("error parsing form data: %w", err)
 				}
 
 				data = formData

--- a/http/logical_test.go
+++ b/http/logical_test.go
@@ -437,3 +437,28 @@ func TestLogical_Audit_invalidWrappingToken(t *testing.T) {
 		}
 	}
 }
+
+func TestLogical_ShouldParseForm(t *testing.T) {
+	const formCT = "application/x-www-form-urlencoded"
+
+	tests := map[string]struct {
+		prefix      string
+		contentType string
+		isForm      bool
+	}{
+		"JSON":                 {`{"a":42}`, formCT, false},
+		"JSON 2":               {`[42]`, formCT, false},
+		"JSON w/leading space": {"   \n\n\r\t  [42]  ", formCT, false},
+		"Form":                 {"a=42&b=dog", formCT, true},
+		"Form w/wrong CT":      {"a=42&b=dog", "application/json", false},
+	}
+
+	for name, test := range tests {
+		isForm := isForm([]byte(test.prefix), test.contentType)
+
+		if isForm != test.isForm {
+			t.Fatalf("%s fail: expected isForm %t, got %t", name, test.isForm, isForm)
+		}
+	}
+
+}

--- a/http/sys_generate_root.go
+++ b/http/sys_generate_root.go
@@ -86,7 +86,7 @@ func handleSysGenerateRootAttemptGet(core *vault.Core, w http.ResponseWriter, r 
 func handleSysGenerateRootAttemptPut(core *vault.Core, w http.ResponseWriter, r *http.Request, generateStrategy vault.GenerateRootStrategy) {
 	// Parse the request
 	var req GenerateRootInitRequest
-	if _, err := parseRequest(core.PerfStandby(), r, w, &req); err != nil && err != io.EOF {
+	if _, err := parseJSONRequest(core.PerfStandby(), r, w, &req); err != nil && err != io.EOF {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
@@ -132,7 +132,7 @@ func handleSysGenerateRootUpdate(core *vault.Core, generateStrategy vault.Genera
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse the request
 		var req GenerateRootUpdateRequest
-		if _, err := parseRequest(core.PerfStandby(), r, w, &req); err != nil {
+		if _, err := parseJSONRequest(core.PerfStandby(), r, w, &req); err != nil {
 			respondError(w, http.StatusBadRequest, err)
 			return
 		}

--- a/http/sys_init.go
+++ b/http/sys_init.go
@@ -39,7 +39,7 @@ func handleSysInitPut(core *vault.Core, w http.ResponseWriter, r *http.Request) 
 
 	// Parse the request
 	var req InitRequest
-	if _, err := parseRequest(core.PerfStandby(), r, w, &req); err != nil {
+	if _, err := parseJSONRequest(core.PerfStandby(), r, w, &req); err != nil {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}

--- a/http/sys_raft.go
+++ b/http/sys_raft.go
@@ -26,7 +26,7 @@ func handleSysRaftJoin(core *vault.Core) http.Handler {
 func handleSysRaftJoinPost(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 	// Parse the request
 	var req JoinRequest
-	if _, err := parseRequest(core.PerfStandby(), r, w, &req); err != nil && err != io.EOF {
+	if _, err := parseJSONRequest(core.PerfStandby(), r, w, &req); err != nil && err != io.EOF {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}

--- a/http/sys_rekey.go
+++ b/http/sys_rekey.go
@@ -108,7 +108,7 @@ func handleSysRekeyInitGet(ctx context.Context, core *vault.Core, recovery bool,
 func handleSysRekeyInitPut(ctx context.Context, core *vault.Core, recovery bool, w http.ResponseWriter, r *http.Request) {
 	// Parse the request
 	var req RekeyRequest
-	if _, err := parseRequest(core.PerfStandby(), r, w, &req); err != nil {
+	if _, err := parseJSONRequest(core.PerfStandby(), r, w, &req); err != nil {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}
@@ -158,7 +158,7 @@ func handleSysRekeyUpdate(core *vault.Core, recovery bool) http.Handler {
 
 		// Parse the request
 		var req RekeyUpdateRequest
-		if _, err := parseRequest(core.PerfStandby(), r, w, &req); err != nil {
+		if _, err := parseJSONRequest(core.PerfStandby(), r, w, &req); err != nil {
 			respondError(w, http.StatusBadRequest, err)
 			return
 		}
@@ -306,7 +306,7 @@ func handleSysRekeyVerifyDelete(ctx context.Context, core *vault.Core, recovery 
 func handleSysRekeyVerifyPut(ctx context.Context, core *vault.Core, recovery bool, w http.ResponseWriter, r *http.Request) {
 	// Parse the request
 	var req RekeyVerificationUpdateRequest
-	if _, err := parseRequest(core.PerfStandby(), r, w, &req); err != nil {
+	if _, err := parseJSONRequest(core.PerfStandby(), r, w, &req); err != nil {
 		respondError(w, http.StatusBadRequest, err)
 		return
 	}

--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -86,7 +86,7 @@ func handleSysUnseal(core *vault.Core) http.Handler {
 
 		// Parse the request
 		var req UnsealRequest
-		if _, err := parseRequest(core.PerfStandby(), r, w, &req); err != nil {
+		if _, err := parseJSONRequest(core.PerfStandby(), r, w, &req); err != nil {
 			respondError(w, http.StatusBadRequest, err)
 			return
 		}


### PR DESCRIPTION
The approach taken is intended to be conservative since we've always
assumed JSON and not required Content-Type. Tools and libraries that
default to "application/x-www-form-urlencoded" even when JSON is being
sent (e.g. curl) will break without these extra backwards compatibility
measures.

This PR is a reboot of: https://github.com/hashicorp/vault/pull/5935