### PR TITLE
Fix ldap client upndomain

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -127,7 +127,7 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 		}
 	}
 
-	userDN, err := ldapClient.GetUserDN(cfg.ConfigEntry, c, userBindDN)
+	userDN, err := ldapClient.GetUserDN(cfg.ConfigEntry, c, userBindDN, username)
 	if err != nil {
 		return nil, logical.ErrorResponse(err.Error()), nil, nil
 	}

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
-
 	goldap "github.com/go-ldap/ldap/v3"
 	"github.com/go-test/deep"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers/ldap"
 	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"

--- a/helper/testhelpers/ldap/ldaphelper.go
+++ b/helper/testhelpers/ldap/ldaphelper.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/go-hclog"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/testhelpers/docker"
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
 	"github.com/ory/dockertest"
@@ -17,7 +17,9 @@ func PrepareTestContainer(t *testing.T, version string) (cleanup func(), cfg *ld
 	}
 
 	dockerOptions := &dockertest.RunOptions{
-		Repository: "rroemhild/test-openldap",
+		// Currently set to "michelvocks" until https://github.com/rroemhild/docker-test-openldap/pull/14
+		// has been merged.
+		Repository: "michelvocks/docker-test-openldap",
 		Tag:        version,
 		Privileged: true,
 		//Env:        []string{"LDAP_DEBUG_LEVEL=384"},


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault/issues/6325

Currently, if you use `discoverdn` or `binddn` and/or `bindpass`, `upndomain` is ignored and `GetUserBindDN` returns an unexpected `bindDN` for `GetUserDN` if `upndomain` is set.

This PR forces `GetUserBindDN` to honor `upndomain` even if the above parameters are set. It also allows `GetUserDN` to format always the right filter. 

TODO: Changes need to be synced to https://github.com/hashicorp/vault-plugin-auth-kerberos after this PR has been merged.