### PR TITLE
ci: build website docker image only on OSS repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,19 +314,26 @@ jobs:
     - setup_remote_docker
     - run:
         command: |
-          echo 'export PACKAGE_LOCK_CHANGED=$(git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | grep -c website/package-lock.json)' >> $BASH_ENV
-        name: Diff package-lock.json
-    - run:
-        command: |
-          if [ "$CIRCLE_BRANCH" = "master" ] && [ $PACKAGE_LOCK_CHANGED -gt 0 ]; then
-            cd website/
-            docker build -t hashicorp/vault-website:$CIRCLE_SHA1 .
-            docker tag hashicorp/vault-website:$CIRCLE_SHA1 hashicorp/vault-website:latest
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker push hashicorp/vault-website
-          else
-            echo "Not building a new website docker image - branch is not master and/or dependencies have not changed."
-          fi
+          # BUILD_FROM_REPO should ALWAYS be the main OSS Vault repo URL.
+          BUILD_FROM_REPO=git@github.com:hashicorp/vault.git
+          [ "$CIRCLE_REPOSITORY_URL" = "$BUILD_FROM_REPO" ] || {
+            echo "Not building website docker image for repo '$CIRCLE_REPOSITORY_URL' - we only build it for $BUILD_FROM_REPO."
+            exit 0
+          }
+          [ "$CIRCLE_BRANCH" = "master" ] || {
+            echo "Not building website docker image for branch '$CIRCLE_BRANCH' - we only build it for master."
+            exit 0
+          }
+          PACKAGE_LOCK_CHANGED=$(git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | grep -c website/package-lock.json)
+          [ $PACKAGE_LOCK_CHANGED -gt 0 ] || {
+            echo "Not building a new website docker image - dependencies have not changed."
+            exit 0
+          }
+          cd website/
+          docker build -t hashicorp/vault-website:$CIRCLE_SHA1 .
+          docker tag hashicorp/vault-website:$CIRCLE_SHA1 hashicorp/vault-website:latest
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
+          docker push hashicorp/vault-website
         name: Build Docker Image if Necessary
 workflows:
   ci:
@@ -608,19 +615,26 @@ workflows:
 #     - setup_remote_docker
 #     - run:
 #         command: |
-#           echo 'export PACKAGE_LOCK_CHANGED=$(git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | grep -c website/package-lock.json)' >> $BASH_ENV
-#         name: Diff package-lock.json
-#     - run:
-#         command: |
-#           if [ \"$CIRCLE_BRANCH\" = \"master\" ] && [ $PACKAGE_LOCK_CHANGED -gt 0 ]; then
-#             cd website/
-#             docker build -t hashicorp/vault-website:$CIRCLE_SHA1 .
-#             docker tag hashicorp/vault-website:$CIRCLE_SHA1 hashicorp/vault-website:latest
-#             docker login -u $DOCKER_USER -p $DOCKER_PASS
-#             docker push hashicorp/vault-website
-#           else
-#             echo \"Not building a new website docker image - branch is not master and/or dependencies have not changed.\"
-#           fi
+#           # BUILD_FROM_REPO should ALWAYS be the main OSS Vault repo URL.
+#           BUILD_FROM_REPO=git@github.com:hashicorp/vault.git
+#           [ \"$CIRCLE_REPOSITORY_URL\" = \"$BUILD_FROM_REPO\" ] || {
+#             echo \"Not building website docker image for repo '$CIRCLE_REPOSITORY_URL' - we only build it for $BUILD_FROM_REPO.\"
+#             exit 0
+#           }
+#           [ \"$CIRCLE_BRANCH\" = \"master\" ] || {
+#             echo \"Not building website docker image for branch '$CIRCLE_BRANCH' - we only build it for master.\"
+#             exit 0
+#           }
+#           PACKAGE_LOCK_CHANGED=$(git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | grep -c website/package-lock.json)
+#           [ $PACKAGE_LOCK_CHANGED -gt 0 ] || {
+#             echo \"Not building a new website docker image - dependencies have not changed.\"
+#             exit 0
+#           }
+#           cd website/
+#           docker build -t hashicorp/vault-website:$CIRCLE_SHA1 .
+#           docker tag hashicorp/vault-website:$CIRCLE_SHA1 hashicorp/vault-website:latest
+#           docker login -u $DOCKER_USER -p $DOCKER_PASS
+#           docker push hashicorp/vault-website
 #         name: Build Docker Image if Necessary
 # references:
 #   cache:

--- a/.circleci/config/jobs/website-docker-image.yml
+++ b/.circleci/config/jobs/website-docker-image.yml
@@ -5,18 +5,25 @@ steps:
   - checkout
   - setup_remote_docker
   - run:
-      name: Diff package-lock.json
-      command: |
-        echo 'export PACKAGE_LOCK_CHANGED=$(git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | grep -c website/package-lock.json)' >> $BASH_ENV
-  - run:
       name: Build Docker Image if Necessary
       command: |
-        if [ "$CIRCLE_BRANCH" = "master" ] && [ $PACKAGE_LOCK_CHANGED -gt 0 ]; then
-          cd website/
-          docker build -t hashicorp/vault-website:$CIRCLE_SHA1 .
-          docker tag hashicorp/vault-website:$CIRCLE_SHA1 hashicorp/vault-website:latest
-          docker login -u $DOCKER_USER -p $DOCKER_PASS
-          docker push hashicorp/vault-website
-        else
-          echo "Not building a new website docker image - branch is not master and/or dependencies have not changed."
-        fi
+        # BUILD_FROM_REPO should ALWAYS be the main OSS Vault repo URL.
+        BUILD_FROM_REPO=git@github.com:hashicorp/vault.git
+        [ "$CIRCLE_REPOSITORY_URL" = "$BUILD_FROM_REPO" ] || {
+          echo "Not building website docker image for repo '$CIRCLE_REPOSITORY_URL' - we only build it for $BUILD_FROM_REPO."
+          exit 0
+        }
+        [ "$CIRCLE_BRANCH" = "master" ] || {
+          echo "Not building website docker image for branch '$CIRCLE_BRANCH' - we only build it for master."
+          exit 0
+        }
+        PACKAGE_LOCK_CHANGED=$(git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | grep -c website/package-lock.json)
+        [ $PACKAGE_LOCK_CHANGED -gt 0 ] || {
+          echo "Not building a new website docker image - dependencies have not changed."
+          exit 0
+        }
+        cd website/
+        docker build -t hashicorp/vault-website:$CIRCLE_SHA1 .
+        docker tag hashicorp/vault-website:$CIRCLE_SHA1 hashicorp/vault-website:latest
+        docker login -u $DOCKER_USER -p $DOCKER_PASS
+        docker push hashicorp/vault-website


### PR DESCRIPTION
This also separates out the conditions for clearer messaging when we don't build it, and puts them all in the same shell for simplicity.