### PR TITLE
Add support for telemetry option `metrics_prefix`.  

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -2320,7 +2320,12 @@ func (c *ServerCommand) setupTelemetry(config *server.Config) (*metricsutil.Metr
 		telConfig = &server.Telemetry{}
 	}
 
-	metricsConf := metrics.DefaultConfig("vault")
+	serviceName := "vault"
+	if telConfig.MetricsPrefix != "" {
+		serviceName = telConfig.MetricsPrefix
+	}
+
+	metricsConf := metrics.DefaultConfig(serviceName)
 	metricsConf.EnableHostname = !telConfig.DisableHostname
 	metricsConf.EnableHostnameLabel = telConfig.EnableHostnameLabel
 

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -179,8 +179,9 @@ type Telemetry struct {
 	StatsiteAddr string `hcl:"statsite_address"`
 	StatsdAddr   string `hcl:"statsd_address"`
 
-	DisableHostname     bool `hcl:"disable_hostname"`
-	EnableHostnameLabel bool `hcl:"enable_hostname_label"`
+	DisableHostname     bool   `hcl:"disable_hostname"`
+	EnableHostnameLabel bool   `hcl:"enable_hostname_label"`
+	MetricsPrefix       string `hcl:"metrics_prefix"`
 
 	// Circonus: see https://github.com/circonus-labs/circonus-gometrics
 	// for more details on the various configuration options.
@@ -1099,6 +1100,7 @@ func (c *Config) Sanitized() map[string]interface{} {
 			"statsite_address":                       c.Telemetry.StatsiteAddr,
 			"statsd_address":                         c.Telemetry.StatsdAddr,
 			"disable_hostname":                       c.Telemetry.DisableHostname,
+			"metrics_prefix":                         c.Telemetry.MetricsPrefix,
 			"circonus_api_token":                     "",
 			"circonus_api_app":                       c.Telemetry.CirconusAPIApp,
 			"circonus_api_url":                       c.Telemetry.CirconusAPIURL,

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -321,6 +321,7 @@ func testLoadConfigFile(t *testing.T) {
 			DogStatsDAddr:           "127.0.0.1:7254",
 			DogStatsDTags:           []string{"tag_1:val_1", "tag_2:val_2"},
 			PrometheusRetentionTime: prometheusDefaultRetentionTime,
+			MetricsPrefix:           "myprefix",
 		},
 
 		DisableCache:             true,
@@ -554,6 +555,7 @@ func testConfig_Sanitized(t *testing.T) {
 			"circonus_check_tags":                    "",
 			"circonus_submission_interval":           "",
 			"disable_hostname":                       false,
+			"metrics_prefix":                         "pfx",
 			"dogstatsd_addr":                         "",
 			"dogstatsd_tags":                         []string(nil),
 			"prometheus_retention_time":              24 * time.Hour,

--- a/command/server/test-fixtures/config.hcl
+++ b/command/server/test-fixtures/config.hcl
@@ -27,6 +27,7 @@ telemetry {
     statsite_address = "foo"
     dogstatsd_addr = "127.0.0.1:7254"
     dogstatsd_tags = ["tag_1:val_1", "tag_2:val_2"]
+    metrics_prefix = "myprefix"
 }
 
 max_lease_ttl = "10h"

--- a/command/server/test-fixtures/config3.hcl
+++ b/command/server/test-fixtures/config3.hcl
@@ -29,6 +29,7 @@ service_registration "consul" {
 telemetry {
   statsd_address = "bar"
   circonus_api_token = "baz"
+  metrics_prefix = "pfx"
 }
 
 seal "awskms" {


### PR DESCRIPTION
When set, instead of starting with `vault_`, metrics will start with `${prefix}_`.