### PR TITLE
external_tests: ensure derived cores are stable before proceeding on tests

### DIFF
--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -186,6 +186,14 @@ func AttemptUnsealCore(c *vault.TestCluster, core *vault.TestClusterCore) error 
 }
 
 func EnsureStableActiveNode(t testing.T, cluster *vault.TestCluster) {
+	deriveStableActiveCore(t, cluster)
+}
+
+func DeriveStableActiveCore(t testing.T, cluster *vault.TestCluster) *vault.TestClusterCore {
+	return deriveStableActiveCore(t, cluster)
+}
+
+func deriveStableActiveCore(t testing.T, cluster *vault.TestCluster) *vault.TestClusterCore {
 	activeCore := DeriveActiveCore(t, cluster)
 
 	for i := 0; i < 30; i++ {
@@ -198,6 +206,8 @@ func EnsureStableActiveNode(t testing.T, cluster *vault.TestCluster) {
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
+
+	return activeCore
 }
 
 func DeriveActiveCore(t testing.T, cluster *vault.TestCluster) *vault.TestClusterCore {

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -504,7 +504,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Backward(t *testing.T) {
 			cluster.BarrierKeys = barrierKeys
 			testhelpers.EnsureCoresUnsealed(t, cluster)
 			testhelpers.WaitForActiveNode(t, cluster)
-			activeCore := testhelpers.DeriveActiveCore(t, cluster)
+			activeCore := testhelpers.DeriveStableActiveCore(t, cluster)
 
 			// Read the value.
 			data, err := activeCore.Client.Logical().Read("secret/foo")
@@ -707,7 +707,7 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 				cluster.BarrierKeys = newBarrierKeys
 				testhelpers.EnsureCoresUnsealed(t, cluster)
 				testhelpers.WaitForActiveNode(t, cluster)
-				activeCore := testhelpers.DeriveActiveCore(t, cluster)
+				activeCore := testhelpers.DeriveStableActiveCore(t, cluster)
 
 				// Read the value.
 				data, err := activeCore.Client.Logical().Read("secret/foo")


### PR DESCRIPTION
This PR adds a test helper, `DeriveStableActiveCore`, that ensures a derived active core is stable before returning it back for further use.