### PR TITLE
Last changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-metrics-stackdriver v0.0.0-20190816035513-b52628e82e2a
-	github.com/google/uuid v1.0.0
 	github.com/hashicorp/consul-template v0.22.0
 	github.com/hashicorp/consul/api v1.2.1-0.20200128105449-6681be918a6e
 	github.com/hashicorp/errwrap v1.0.0

--- a/plugins/database/redshift/redshift-database-plugin/main.go
+++ b/plugins/database/redshift/redshift-database-plugin/main.go
@@ -13,8 +13,7 @@ func main() {
 	flags := apiClientMeta.FlagSet()
 	flags.Parse(os.Args[1:])
 
-	err := redshift.Run(apiClientMeta.GetTLSConfig())
-	if err != nil {
+	if err := redshift.Run(apiClientMeta.GetTLSConfig()); err != nil {
 		log.Println(err)
 		os.Exit(1)
 	}

--- a/plugins/database/redshift/redshift_test.go
+++ b/plugins/database/redshift/redshift_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/database/dbplugin"
 	"github.com/hashicorp/vault/sdk/helper/dbtxn"
 	"github.com/lib/pq"
@@ -326,7 +326,11 @@ func TestPostgresSQL_SetCredentials(t *testing.T) {
 	}
 
 	// create the database user
-	dbUser := "vaultstatictest-" + fmt.Sprintf("%s", uuid.New())
+	uid, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbUser := "vaultstatictest-" + fmt.Sprintf("%s", uid)
 	createTestPGUser(t, url, dbUser, "1Password", testRoleStaticCreate)
 
 	db := newRedshift(true)


### PR DESCRIPTION
This PR:
- Uses the `uuid` library we've already used a lot in Vault to avoid a new dependency.
- Adds a tiny bit more commentary.
- Just a couple nit-picky changes like not having a space before the defer statements. This is basically a somewhat irrational tick I have because I worry that down the road others will add more code there and further separate the defer.