### PR TITLE
Backport 1.3.x: Guard against using Raft as a seperate HA Storage

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1073,6 +1073,12 @@ func (c *ServerCommand) Run(args []string) int {
 	// Initialize the separate HA storage backend, if it exists
 	var ok bool
 	if config.HAStorage != nil {
+		// TODO: Remove when Raft can server as the ha_storage backend.
+		// See https://github.com/hashicorp/vault/issues/8206
+		if config.HAStorage.Type == "raft" {
+			c.UI.Error("Raft cannot be used as seperate HA storage at this time")
+			return 1
+		}
 		factory, exists := c.PhysicalBackends[config.HAStorage.Type]
 		if !exists {
 			c.UI.Error(fmt.Sprintf("Unknown HA storage type %s", config.HAStorage.Type))

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -963,6 +963,13 @@ func (l *RaftLock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) {
 	// Cache the notifyCh locally
 	leaderNotifyCh := l.b.raftNotifyCh
 
+	// TODO: Remove when Raft can server as the ha_storage backend. The internal
+	// raft pointer should not be nil here, but the nil check is a guard against
+	// https://github.com/hashicorp/vault/issues/8206
+	if l.b.raft == nil {
+		return nil, errors.New("attempted to grab a lock on a nil raft backend")
+	}
+
 	// Check to see if we are already leader.
 	if l.b.raft.State() == raft.Leader {
 		err := l.b.applyLog(context.Background(), &LogData{

--- a/website/source/docs/configuration/storage/raft.html.md
+++ b/website/source/docs/configuration/storage/raft.html.md
@@ -38,7 +38,13 @@ storage "raft" {
 cluster_addr = "http://127.0.0.1:8201"
 ```
 
-**Note:** When using the Raft storage backend, it is required to provide `cluster_addr` to indicate the address and port to be used for communication between the nodes in the Raft cluster.
+~> **Note:** When using the Raft storage backend, it is required to provide
+`cluster_addr` to indicate the address and port to be used for communication
+between the nodes in the Raft cluster.
+
+~> **Note:** Raft cannot be used as the configured `ha_storage` backend at this
+time. To use Raft for HA coordination users must also use Raft for storage and
+set `ha_enabled = true`.
 
 ## `raft` Parameters
 


### PR DESCRIPTION
Backport to 1.3.x of #8239 

Note that the website pages are different in the 1.3.x branch, so there's a mis-match of what files were changed between this and #8239 