### PR TITLE
Docs: Fix anchor link to Generating JWTs

### DIFF
--- a/website/pages/docs/auth/gcp.mdx
+++ b/website/pages/docs/auth/gcp.mdx
@@ -221,7 +221,7 @@ for IAM service accounts looks like this:
 
 1. The client generates a signed JWT using the IAM
    [`projects.serviceAccounts.signJwt`][signjwt-method] method. For examples of
-   how to do this, see the [Obtaining JWT Tokens](#obtaining-jwt-tokens) section.
+   how to do this, see the [Generating JWTs](#generating-jwts) section.
 
 2. The client sends this signed JWT to Vault along with a role name.
 


### PR DESCRIPTION
Updating anchor link for the Generating JWTs-section to avoid dead link.