### PR TITLE
[Doc] Fix curl example syntax in the plugins reload backend

### DIFF
--- a/website/pages/api-docs/system/plugins-reload-backend.mdx
+++ b/website/pages/api-docs/system/plugins-reload-backend.mdx
@@ -41,6 +41,7 @@ This endpoint reloads mounted plugin backends.
 ```
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT
+    --request PUT \
+    --data @payload.json \
     http://127.0.0.1:8200/v1/sys/plugins/reload/backend
 ```


### PR DESCRIPTION
Add the data argument to pass the payload file