### PR TITLE
Sign SSH keys using rsa-sha2-256 algorithm

### DIFF
--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"regexp"
 	"strconv"
 	"strings"
@@ -511,10 +512,27 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 		},
 	}
 
-	err = certificate.SignCert(rand.Reader, b.Signer)
+	sshAlgorithmSigner, _ := b.Signer.(ssh.AlgorithmSigner)
+
+	// prepare certificate for signing
+	certificate.Nonce = make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, certificate.Nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate signed SSH key")
+	}
+	certificate.SignatureKey = sshAlgorithmSigner.PublicKey()
+
+	// get bytes to sign
+	c2 := *certificate
+	c2.Signature = nil
+	out := c2.Marshal()
+	certificateBytes := out[:len(out)-4]
+
+	// sign with rsa-sha2-256
+	sig, err := sshAlgorithmSigner.SignWithAlgorithm(rand.Reader, certificateBytes, ssh.SigAlgoRSASHA2256)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate signed SSH key")
 	}
+	certificate.Signature = sig
 
 	return certificate, nil
 }


### PR DESCRIPTION
Since version 8.2 of openssh the ssh-rsa algorithm is considered insecure and has been removed [1]

With this commit I changed the signing algorithm to rsa-sha2-256

Note that the implementation is not ideal since x/crypto/ssh does not provide a simple method to sign a certificate with an arbitrary algorithm. There's an open issue for that: golang/go/issues/36261.

Note that rsa-sha2-256 is supported since openssh 7.2 so the choice at the moment seems to be between supporting future clients or older ones, which is unfortunate, at least wihout changing vault's api.

It seems that Debian versions <= 8 and RHEL <= 6 do not use a compatible version of openssh.

I tested this on Arch Linux (patch backported to v1.3.2), which already ships openssh 8.2 and it works fine.

[1] https://www.openssh.com/txt/release-8.2