### PR TITLE
clarify that EditType is optional

### DIFF
--- a/sdk/framework/path.go
+++ b/sdk/framework/path.go
@@ -190,8 +190,8 @@ type DisplayAttributes struct {
 	// Action is the verb to use for the operation.
 	Action string `json:"action,omitempty"`
 
-	// EditType is the type of form field needed for a property
-	// e.g. "textarea" or "file"
+	// EditType is the optional type of form field needed for a property
+	// This is only necessary for a "textarea" or "file"
 	EditType string `json:"editType,omitempty"`
 }
 


### PR DESCRIPTION
This PR adds a comment clarifying that the `EditType` property in `DisplayAttrs` is optional. This came up during discussion in https://github.com/hashicorp/vault/pull/8365#discussion_r381270012