### PR TITLE
Loading directory for configuration files: change load order to be lexicographical 

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -702,13 +702,13 @@ func LoadConfigDir(dir string) (*Config, error) {
 	}
 
 	// Fast-path if we have no files
+	var result *Config
 	if len(files) == 0 {
-		return &Config{}, nil
+		return result, nil
 	}
 
 	sort.Strings(files)
 
-	var result *Config
 	for _, f := range files {
 		config, err := LoadConfigFile(f)
 		if err != nil {

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+        "sort"
 	"strconv"
 	"strings"
 	"time"
@@ -699,6 +700,13 @@ func LoadConfigDir(dir string) (*Config, error) {
 			files = append(files, path)
 		}
 	}
+
+        // Fast-path if we have no files
+        if len(files) == 0 {
+                return &Config{}, nil
+        }
+
+        sort.Strings(files)
 
 	var result *Config
 	for _, f := range files {

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-        "sort"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -701,12 +701,12 @@ func LoadConfigDir(dir string) (*Config, error) {
 		}
 	}
 
-        // Fast-path if we have no files
-        if len(files) == 0 {
-                return &Config{}, nil
-        }
+	// Fast-path if we have no files
+	if len(files) == 0 {
+		return &Config{}, nil
+	}
 
-        sort.Strings(files)
+	sort.Strings(files)
 
 	var result *Config
 	for _, f := range files {

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
-        "github.com/y0ssar1an/q"
+	"github.com/y0ssar1an/q"
 )
 
 func testConfigRaftRetryJoin(t *testing.T) {
@@ -457,7 +457,7 @@ func testLoadConfigDir(t *testing.T) {
 		Storage: &Storage{
 			Type: "consul",
 			Config: map[string]string{
-                                "foo": "baz",
+				"foo": "baz",
 			},
 			RedirectAddr:      "https://vault.local",
 			ClusterAddr:       "https://127.0.0.1:444",
@@ -476,12 +476,12 @@ func testLoadConfigDir(t *testing.T) {
 		},
 
 		MaxLeaseTTL:     10 * time.Hour,
-                DefaultLeaseTTL: 5 * time.Hour,
+		DefaultLeaseTTL: 5 * time.Hour,
 		ClusterName:     "testcluster",
 	}
 	if !reflect.DeepEqual(config, expected) {
-                q.Q("config: consul:", config.Storage)
-                q.Q("config: consul:", config.DefaultLeaseTTL)
+		q.Q("config: consul:", config.Storage)
+		q.Q("config: consul:", config.DefaultLeaseTTL)
 		t.Fatalf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config, expected)
 	}
 }

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/y0ssar1an/q"
 )
 
 func testConfigRaftRetryJoin(t *testing.T) {
@@ -457,7 +456,7 @@ func testLoadConfigDir(t *testing.T) {
 		Storage: &Storage{
 			Type: "consul",
 			Config: map[string]string{
-				"foo": "baz",
+				"foo": "faz",
 			},
 			RedirectAddr:      "https://vault.local",
 			ClusterAddr:       "https://127.0.0.1:444",
@@ -476,12 +475,10 @@ func testLoadConfigDir(t *testing.T) {
 		},
 
 		MaxLeaseTTL:     10 * time.Hour,
-		DefaultLeaseTTL: 5 * time.Hour,
+		DefaultLeaseTTL: 10 * time.Hour,
 		ClusterName:     "testcluster",
 	}
 	if !reflect.DeepEqual(config, expected) {
-		q.Q("config: consul:", config.Storage)
-		q.Q("config: consul:", config.DefaultLeaseTTL)
 		t.Fatalf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config, expected)
 	}
 }

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
+        "github.com/y0ssar1an/q"
 )
 
 func testConfigRaftRetryJoin(t *testing.T) {
@@ -456,7 +457,7 @@ func testLoadConfigDir(t *testing.T) {
 		Storage: &Storage{
 			Type: "consul",
 			Config: map[string]string{
-				"foo": "bar",
+                                "foo": "baz",
 			},
 			RedirectAddr:      "https://vault.local",
 			ClusterAddr:       "https://127.0.0.1:444",
@@ -475,10 +476,12 @@ func testLoadConfigDir(t *testing.T) {
 		},
 
 		MaxLeaseTTL:     10 * time.Hour,
-		DefaultLeaseTTL: 10 * time.Hour,
+                DefaultLeaseTTL: 5 * time.Hour,
 		ClusterName:     "testcluster",
 	}
 	if !reflect.DeepEqual(config, expected) {
+                q.Q("config: consul:", config.Storage)
+                q.Q("config: consul:", config.DefaultLeaseTTL)
 		t.Fatalf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config, expected)
 	}
 }

--- a/command/server/test-fixtures/config-dir/baz.hcl
+++ b/command/server/test-fixtures/config-dir/baz.hcl
@@ -3,7 +3,17 @@ telemetry {
     statsite_address = "qux"
     disable_hostname = true
 }
+
+backend "consul" {
+    path = "vault"
+    foo = "baz"
+}
+
 ui=true
 raw_storage_endpoint=true
 default_lease_ttl = "10h"
 cluster_name = "testcluster"
+
+disable_clustering = true
+
+disable_cache = true

--- a/command/server/test-fixtures/config-dir/foo.hcl
+++ b/command/server/test-fixtures/config-dir/foo.hcl
@@ -5,4 +5,9 @@ backend "consul" {
     foo = "faz"
 }
 
+
+# this does not override previous disable_cache entries
+disable_cache = false
+
+# this does
 disable_clustering = false

--- a/command/server/test-fixtures/config-dir/foo.hcl
+++ b/command/server/test-fixtures/config-dir/foo.hcl
@@ -2,8 +2,7 @@ disable_cache = true
 disable_mlock = true
 
 backend "consul" {
-    foo = "bar"
-    disable_clustering = "true"
+    foo = "faz"
 }
 
 disable_clustering = false

--- a/website/pages/docs/commands/server.mdx
+++ b/website/pages/docs/commands/server.mdx
@@ -51,7 +51,8 @@ flags](/docs/commands) included on all commands.
 - `-config` `(string: "")` - Path to a configuration file or directory of
   configuration files. This flag can be specified multiple times to load
   multiple configurations. If the path is a directory, all files which end in
-  .hcl or .json are loaded.
+  `.hcl` or `.json` are loaded and merged in lexicographical order. Directories
+  are not loaded recursively.
 
 - `-log-level` `(string: "info")` - Log verbosity level. Supported values (in
   order of detail) are "trace", "debug", "info", "warn", and "err". This can

--- a/website/pages/docs/configuration/index.mdx
+++ b/website/pages/docs/configuration/index.mdx
@@ -33,7 +33,7 @@ to specify where the configuration is.
 
 ## Parameters
 
-- `storage` <tt>([StorageBackend][storage-backend]: \<required\>)</tt> –
+- `storage` <tt>([StorageBackend][storage-backend]: <required\>)</tt> –
   Configures the storage backend where Vault data is stored. Please see the
   [storage backends documentation][storage-backend] for the full list of
   available storage backends. Running Vault in HA mode would require
@@ -50,7 +50,7 @@ to specify where the configuration is.
   storage backend supports HA coordination and if HA specific options are
   already specified with `storage` parameter.
 
-- `listener` <tt>([Listener][listener]: \<required\>)</tt> – Configures how
+- `listener` <tt>([Listener][listener]: <required\>)</tt> – Configures how
   Vault is listening for API requests.
 
 - `seal` <tt>([Seal][seal]: nil)</tt> – Configures the seal type to use for


### PR DESCRIPTION
The `server` CLI command accepts a `-config` option, which an optionally be a file or a directory of files ([see the docs](https://www.vaultproject.io/docs/commands/server/#inlinecode--config-2)). 

At present it's not documented _how_ those files are loaded. Personally I assumed lexicographical order, however #5860 prompted investigation and I found that Vault never sorted the files it loaded, and so loaded files in reverse of what I expected. 

In this PR we modify the code to sort the files and load them in lexicographical. Modifications to a test demonstrate that the attributes are overridden as expected. 

This may have larger implications as some users may have configuration that relies on the current load order, either intentionally or accidentally, so I'm opening this as a draft PR for discussion. 