### PR TITLE
New database credentials producer

### DIFF
--- a/helper/builtinplugins/registry.go
+++ b/helper/builtinplugins/registry.go
@@ -29,7 +29,6 @@ import (
 	dbMysql "github.com/hashicorp/vault/plugins/database/mysql"
 	dbPostgres "github.com/hashicorp/vault/plugins/database/postgresql"
 	dbRedshift "github.com/hashicorp/vault/plugins/database/redshift"
-	"github.com/hashicorp/vault/sdk/database/helper/credsutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
 
@@ -40,6 +39,7 @@ import (
 	logicalGcpKms "github.com/hashicorp/vault-plugin-secrets-gcpkms"
 	logicalKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	logicalMongoAtlas "github.com/hashicorp/vault-plugin-secrets-mongodbatlas"
+	logicalOpenLDAP "github.com/hashicorp/vault-plugin-secrets-openldap"
 	logicalAws "github.com/hashicorp/vault/builtin/logical/aws"
 	logicalCass "github.com/hashicorp/vault/builtin/logical/cassandra"
 	logicalConsul "github.com/hashicorp/vault/builtin/logical/consul"
@@ -47,7 +47,6 @@ import (
 	logicalMssql "github.com/hashicorp/vault/builtin/logical/mssql"
 	logicalMysql "github.com/hashicorp/vault/builtin/logical/mysql"
 	logicalNomad "github.com/hashicorp/vault/builtin/logical/nomad"
-	logicalOpenLDAP "github.com/hashicorp/vault-plugin-secrets-openldap"
 	logicalPki "github.com/hashicorp/vault/builtin/logical/pki"
 	logicalPostgres "github.com/hashicorp/vault/builtin/logical/postgresql"
 	logicalRabbit "github.com/hashicorp/vault/builtin/logical/rabbitmq"
@@ -93,10 +92,10 @@ func newRegistry() *registry {
 		databasePlugins: map[string]BuiltinFactory{
 			// These four plugins all use the same mysql implementation but with
 			// different username settings passed by the constructor.
-			"mysql-database-plugin":        dbMysql.New(dbMysql.MetadataLen, dbMysql.MetadataLen, dbMysql.UsernameLen),
-			"mysql-aurora-database-plugin": dbMysql.New(credsutil.NoneLength, dbMysql.LegacyMetadataLen, dbMysql.LegacyUsernameLen),
-			"mysql-rds-database-plugin":    dbMysql.New(credsutil.NoneLength, dbMysql.LegacyMetadataLen, dbMysql.LegacyUsernameLen),
-			"mysql-legacy-database-plugin": dbMysql.New(credsutil.NoneLength, dbMysql.LegacyMetadataLen, dbMysql.LegacyUsernameLen),
+			"mysql-database-plugin":        dbMysql.New(dbMysql.DefaultTemplate, dbMysql.UsernameLen),
+			"mysql-aurora-database-plugin": dbMysql.New(dbMysql.LegacyTemplate, dbMysql.LegacyUsernameLen),
+			"mysql-rds-database-plugin":    dbMysql.New(dbMysql.LegacyTemplate, dbMysql.LegacyUsernameLen),
+			"mysql-legacy-database-plugin": dbMysql.New(dbMysql.LegacyTemplate, dbMysql.LegacyUsernameLen),
 
 			"postgresql-database-plugin":    dbPostgres.New,
 			"redshift-database-plugin":      dbRedshift.New(true),

--- a/plugins/database/cassandra/cassandra_test.go
+++ b/plugins/database/cassandra/cassandra_test.go
@@ -84,8 +84,11 @@ func TestCassandra_Initialize(t *testing.T) {
 		"protocol_version": 4,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -129,8 +132,11 @@ func TestCassandra_CreateUser(t *testing.T) {
 		"protocol_version": 4,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -169,8 +175,11 @@ func TestMyCassandra_RenewUser(t *testing.T) {
 		"protocol_version": 4,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -214,8 +223,11 @@ func TestCassandra_RevokeUser(t *testing.T) {
 		"protocol_version": 4,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -264,11 +276,14 @@ func TestCassandra_RotateRootCredentials(t *testing.T) {
 		"protocol_version": 4,
 	}
 
-	db := new()
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 
 	connProducer := db.cassandraConnectionProducer
 
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/plugins/database/hana/hana_test.go
+++ b/plugins/database/hana/hana_test.go
@@ -22,8 +22,11 @@ func TestHANA_Initialize(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -49,8 +52,11 @@ func TestHANA_CreateUser(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -90,8 +96,11 @@ func TestHANA_RevokeUser(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/plugins/database/influxdb/influxdb_test.go
+++ b/plugins/database/influxdb/influxdb_test.go
@@ -81,8 +81,11 @@ func TestInfluxdb_Initialize(t *testing.T) {
 		"password": "influx-root",
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -124,8 +127,11 @@ func TestInfluxdb_CreateUser(t *testing.T) {
 		"password": "influx-root",
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -163,8 +169,11 @@ func TestMyInfluxdb_RenewUser(t *testing.T) {
 		"password": "influx-root",
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -209,8 +218,11 @@ func TestInfluxdb_RevokeDeletedUser(t *testing.T) {
 		"password": "influx-root",
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -257,8 +269,11 @@ func TestInfluxdb_RevokeUser(t *testing.T) {
 		"password": "influx-root",
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -305,11 +320,14 @@ func TestInfluxdb_RotateRootCredentials(t *testing.T) {
 		"password": "influx-root",
 	}
 
-	db := new()
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 
 	connProducer := db.influxdbConnectionProducer
 
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/plugins/database/mongodb/connection_producer_test.go
+++ b/plugins/database/mongodb/connection_producer_test.go
@@ -75,7 +75,10 @@ net:
 
 	// //////////////////////////////////////////////////////
 	// Test
-	mongo := new()
+	mongo, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 
 	conf := map[string]interface{}{
 		"connection_url":      retURL,
@@ -87,7 +90,7 @@ net:
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_, err := mongo.Init(ctx, conf, true)
+	_, err = mongo.Init(ctx, conf, true)
 	if err != nil {
 		t.Fatalf("Unable to initialize mongo engine: %s", err)
 	}

--- a/plugins/database/mongodb/mongodb_test.go
+++ b/plugins/database/mongodb/mongodb_test.go
@@ -29,8 +29,11 @@ func TestMongoDB_Initialize(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -53,8 +56,11 @@ func TestMongoDB_CreateUser(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -87,8 +93,11 @@ func TestMongoDB_CreateUser_writeConcern(t *testing.T) {
 		"write_concern":  testMongoDBWriteConcern,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -120,8 +129,11 @@ func TestMongoDB_RevokeUser(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -177,8 +189,11 @@ func TestMongoDB_SetCredentials(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -305,7 +320,10 @@ func TestGetTLSAuth(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			c := new()
+			c, err := new()
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
 			c.Username = test.username
 			c.TLSCAData = test.tlsCAData
 			c.TLSCertificateKeyData = test.tlsKeyData

--- a/plugins/database/mssql/mssql_test.go
+++ b/plugins/database/mssql/mssql_test.go
@@ -22,8 +22,11 @@ func TestMSSQL_Initialize(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -59,8 +62,11 @@ func TestMSSQL_CreateUser(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -102,11 +108,14 @@ func TestMSSQL_RotateRootCredentials(t *testing.T) {
 		"password":       "yourStrong(!)Password",
 	}
 
-	db := new()
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 
 	connProducer := db.SQLConnectionProducer
 
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -139,8 +148,11 @@ func TestMSSQL_RevokeUser(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/plugins/database/mysql/mysql_test.go
+++ b/plugins/database/mysql/mysql_test.go
@@ -10,7 +10,6 @@ import (
 	stdmysql "github.com/go-sql-driver/mysql"
 	mysqlhelper "github.com/hashicorp/vault/helper/testhelpers/mysql"
 	"github.com/hashicorp/vault/sdk/database/dbplugin"
-	"github.com/hashicorp/vault/sdk/database/helper/credsutil"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 )
@@ -25,8 +24,11 @@ func TestMySQL_Initialize(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new(MetadataLen, MetadataLen, UsernameLen)
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := newMySQL(DefaultTemplate, UsernameLen)
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -54,7 +56,10 @@ func TestMySQL_Initialize(t *testing.T) {
 
 func TestMySQL_CreateUser(t *testing.T) {
 	t.Run("missing creation statements", func(t *testing.T) {
-		db := new(MetadataLen, MetadataLen, UsernameLen)
+		db, err := newMySQL(DefaultTemplate, UsernameLen)
+		if err != nil {
+			t.Fatalf("no error expected, got: %s", err)
+		}
 
 		usernameConfig := dbplugin.UsernameConfig{
 			DisplayName: "test-long-displayname",
@@ -82,8 +87,12 @@ func TestMySQL_CreateUser(t *testing.T) {
 			"connection_url": connURL,
 		}
 
-		db := new(MetadataLen, MetadataLen, UsernameLen)
-		_, err := db.Init(context.Background(), connectionDetails, true)
+		db, err := newMySQL(DefaultTemplate, UsernameLen)
+		if err != nil {
+			t.Fatalf("no error expected, got: %s", err)
+		}
+
+		_, err = db.Init(context.Background(), connectionDetails, true)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -100,8 +109,11 @@ func TestMySQL_CreateUser(t *testing.T) {
 			"connection_url": connURL,
 		}
 
-		db := new(credsutil.NoneLength, LegacyMetadataLen, LegacyUsernameLen)
-		_, err := db.Init(context.Background(), connectionDetails, true)
+		db, err := newMySQL(LegacyTemplate, LegacyUsernameLen)
+		if err != nil {
+			t.Fatalf("no error expected, got: %s", err)
+		}
+		_, err = db.Init(context.Background(), connectionDetails, true)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -153,8 +165,8 @@ func testCreateUser(t *testing.T, db *MySQL, connURL string) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			usernameConfig := dbplugin.UsernameConfig{
-				DisplayName: "test-long-displayname",
-				RoleName:    "test-long-rolename",
+				DisplayName: "long-displayname",
+				RoleName:    "long-rolename",
 			}
 
 			statements := dbplugin.Statements{
@@ -219,8 +231,12 @@ func TestMySQL_RotateRootCredentials(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			db := new(MetadataLen, MetadataLen, UsernameLen)
-			_, err := db.Init(ctx, connectionDetails, true)
+			db, err := newMySQL(DefaultTemplate, UsernameLen)
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+
+			_, err = db.Init(ctx, connectionDetails, true)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}
@@ -277,8 +293,12 @@ func TestMySQL_RevokeUser(t *testing.T) {
 	initCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	db := new(MetadataLen, MetadataLen, UsernameLen)
-	_, err := db.Init(initCtx, connectionDetails, true)
+	db, err := newMySQL(DefaultTemplate, UsernameLen)
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+
+	_, err = db.Init(initCtx, connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -368,8 +388,12 @@ func TestMySQL_SetCredentials(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			db := new(MetadataLen, MetadataLen, UsernameLen)
-			_, err := db.Init(ctx, connectionDetails, true)
+			db, err := newMySQL(DefaultTemplate, UsernameLen)
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+
+			_, err = db.Init(ctx, connectionDetails, true)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}
@@ -425,8 +449,12 @@ func TestMySQL_Initialize_ReservedChars(t *testing.T) {
 		"password":       pw,
 	}
 
-	db := new(MetadataLen, MetadataLen, UsernameLen)
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := newMySQL(DefaultTemplate, UsernameLen)
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/plugins/database/postgresql/postgresql_test.go
+++ b/plugins/database/postgresql/postgresql_test.go
@@ -64,8 +64,11 @@ func TestPostgreSQL_Initialize(t *testing.T) {
 		"max_open_connections": 5,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -93,7 +96,10 @@ func TestPostgreSQL_Initialize(t *testing.T) {
 }
 
 func TestPostgreSQL_CreateUser_missingArgs(t *testing.T) {
-	db := new()
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 
 	usernameConfig := dbplugin.UsernameConfig{
 		DisplayName: "test",
@@ -166,8 +172,11 @@ func TestPostgreSQL_CreateUser(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
-	_, err := db.Init(context.Background(), connectionDetails, true)
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
+	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -233,13 +242,16 @@ func TestPostgreSQL_RenewUser(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 
 	// Give a timeout just in case the test decides to be problematic
 	initCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	_, err := db.Init(initCtx, connectionDetails, true)
+	_, err = db.Init(initCtx, connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -317,7 +329,10 @@ func TestPostgreSQL_RotateRootCredentials(t *testing.T) {
 				"password":             "secret",
 			}
 
-			db := new()
+			db, err := new()
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
 
 			connProducer := db.SQLConnectionProducer
 
@@ -325,7 +340,7 @@ func TestPostgreSQL_RotateRootCredentials(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			_, err := db.Init(ctx, connectionDetails, true)
+			_, err = db.Init(ctx, connectionDetails, true)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}
@@ -381,13 +396,16 @@ func TestPostgreSQL_RevokeUser(t *testing.T) {
 		"connection_url": connURL,
 	}
 
-	db := new()
+	db, err := new()
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 
 	// Give a timeout just in case the test decides to be problematic
 	initCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	_, err := db.Init(initCtx, connectionDetails, true)
+	_, err = db.Init(initCtx, connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -468,7 +486,10 @@ func TestPostgreSQL_SetCredentials_missingArgs(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			db := new()
+			db, err := new()
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
 
 			username, password, err := db.SetCredentials(context.Background(), test.statements, test.userConfig)
 			if err == nil {
@@ -517,13 +538,16 @@ func TestPostgresSQL_SetCredentials(t *testing.T) {
 				"connection_url": connURL,
 			}
 
-			db := new()
+			db, err := new()
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
 
 			// Give a timeout just in case the test decides to be problematic
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			_, err := db.Init(ctx, connectionDetails, true)
+			_, err = db.Init(ctx, connectionDetails, true)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}

--- a/plugins/database/redshift/redshift_test.go
+++ b/plugins/database/redshift/redshift_test.go
@@ -68,7 +68,7 @@ func redshiftEnv() (url string, user string, password string, errEmpty error) {
 	return url, user, password, nil
 }
 
-func TestPostgreSQL_Initialize(t *testing.T) {
+func TestRedshift_Initialize(t *testing.T) {
 	if os.Getenv(vaultACC) != "1" {
 		t.SkipNow()
 	}
@@ -83,7 +83,10 @@ func TestPostgreSQL_Initialize(t *testing.T) {
 		"max_open_connections": 5,
 	}
 
-	db := newRedshift(true)
+	db, err := newRedshift(true)
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -111,7 +114,7 @@ func TestPostgreSQL_Initialize(t *testing.T) {
 
 }
 
-func TestPostgreSQL_CreateUser(t *testing.T) {
+func TestRedshift_CreateUser(t *testing.T) {
 	if os.Getenv(vaultACC) != "1" {
 		t.SkipNow()
 	}
@@ -125,7 +128,10 @@ func TestPostgreSQL_CreateUser(t *testing.T) {
 		"connection_url": url,
 	}
 
-	db := newRedshift(true)
+	db, err := newRedshift(true)
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -169,7 +175,7 @@ func TestPostgreSQL_CreateUser(t *testing.T) {
 	}
 }
 
-func TestPostgreSQL_RenewUser(t *testing.T) {
+func TestRedshift_RenewUser(t *testing.T) {
 	if os.Getenv(vaultACC) != "1" {
 		t.SkipNow()
 	}
@@ -183,7 +189,10 @@ func TestPostgreSQL_RenewUser(t *testing.T) {
 		"connection_url": url,
 	}
 
-	db := newRedshift(true)
+	db, err := newRedshift(true)
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -242,7 +251,7 @@ func TestPostgreSQL_RenewUser(t *testing.T) {
 
 }
 
-func TestPostgreSQL_RevokeUser(t *testing.T) {
+func TestRedshift_RevokeUser(t *testing.T) {
 	if os.Getenv(vaultACC) != "1" {
 		t.SkipNow()
 	}
@@ -256,7 +265,10 @@ func TestPostgreSQL_RevokeUser(t *testing.T) {
 		"connection_url": url,
 	}
 
-	db := newRedshift(true)
+	db, err := newRedshift(true)
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -311,7 +323,7 @@ func TestPostgreSQL_RevokeUser(t *testing.T) {
 	}
 }
 
-func TestPostgresSQL_SetCredentials(t *testing.T) {
+func TestRedshift_SetCredentials(t *testing.T) {
 	if os.Getenv(vaultACC) != "1" {
 		t.SkipNow()
 	}
@@ -333,7 +345,10 @@ func TestPostgresSQL_SetCredentials(t *testing.T) {
 	dbUser := "vaultstatictest-" + fmt.Sprintf("%s", uid)
 	createTestPGUser(t, url, dbUser, "1Password", testRoleStaticCreate)
 
-	db := newRedshift(true)
+	db, err := newRedshift(true)
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 	_, err = db.Init(context.Background(), connectionDetails, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -385,7 +400,7 @@ func TestPostgresSQL_SetCredentials(t *testing.T) {
 	}
 }
 
-func TestPostgreSQL_RotateRootCredentials(t *testing.T) {
+func TestRedshift_RotateRootCredentials(t *testing.T) {
 	/*
 		   Extra precaution is taken for rotating root creds because it's assumed that this
 		   test will run against a live redshift cluster. This test must run last because
@@ -408,7 +423,10 @@ func TestPostgreSQL_RotateRootCredentials(t *testing.T) {
 		"password":       adminPassword,
 	}
 
-	db := newRedshift(true)
+	db, err := newRedshift(true)
+	if err != nil {
+		t.Fatalf("no error expected, got: %s", err)
+	}
 
 	connProducer := db.SQLConnectionProducer
 

--- a/sdk/database/helper/credsutil/passwords.go
+++ b/sdk/database/helper/credsutil/passwords.go
@@ -1,0 +1,90 @@
+package credsutil
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+const (
+	MinPasswordLength     = 10
+	DefaultPasswordLength = 15
+
+	// DefaultPasswordPrefix to prepend to the password. This is here to adhere to minimum password requirements
+	// that the password may be used in.
+	DefaultPasswordPrefix = "A1a-"
+)
+
+type PasswordProducer struct {
+	Charset string
+	Length  int
+	Prefix  string
+}
+
+type PasswordOpt func(*PasswordProducer) error
+
+// PasswordCharset specifies the charset to be used when generating the random password.
+func PasswordCharset(charset string) PasswordOpt {
+	return func(p *PasswordProducer) error {
+		p.Charset = charset
+		return nil
+	}
+}
+
+// PasswordLength to be generated. This includes the length of the prefix, if specified.
+func PasswordLength(length int) PasswordOpt {
+	return func(p *PasswordProducer) error {
+		if length < MinPasswordLength {
+			return fmt.Errorf("length must be >= %d", MinPasswordLength)
+		}
+		p.Length = length
+		return nil
+	}
+}
+
+// PasswordPrefix specifies the prefix to prepend to the generated password.
+func PasswordPrefix(prefix string) PasswordOpt {
+	return func(p *PasswordProducer) error {
+		p.Prefix = prefix
+		return nil
+	}
+}
+
+// NewPasswordProducer for generating passwords. This has reasonable defaults so it can be used without any arguments.
+func NewPasswordProducer(opts ...PasswordOpt) (p PasswordProducer, err error) {
+	p = PasswordProducer{
+		Charset: DefaultCharset,
+		Length:  DefaultPasswordLength,
+		Prefix:  DefaultPasswordPrefix,
+	}
+	merr := &multierror.Error{}
+	for _, opt := range opts {
+		merr = multierror.Append(merr, opt(&p))
+	}
+
+	return p, merr.ErrorOrNil()
+}
+
+// GeneratePassword using the values specified. This adheres to the CredentialsProducer interface.
+func (pg PasswordProducer) GeneratePassword() (password string, err error) {
+	charset := pg.Charset
+	if charset == "" {
+		charset = DefaultCharset
+	}
+
+	length := pg.Length
+	if length == 0 {
+		length = DefaultPasswordLength
+	}
+	if length < MinPasswordLength {
+		return "", fmt.Errorf("length must be >= %d", MinPasswordLength)
+	}
+
+	length = length - len(pg.Prefix)
+
+	chars, err := randomChars(charset, length)
+	if err != nil {
+		return "", fmt.Errorf("unable to generate password: %w", err)
+	}
+	return pg.Prefix + chars, nil
+}

--- a/sdk/database/helper/credsutil/passwords_test.go
+++ b/sdk/database/helper/credsutil/passwords_test.go
@@ -1,0 +1,188 @@
+package credsutil
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGeneratePassword_Constructor(t *testing.T) {
+	type testCase struct {
+		opts        []PasswordOpt
+		expectRegex string
+	}
+
+	tests := map[string]testCase{
+		"default": {
+			opts:        []PasswordOpt{},
+			expectRegex: "^A1a-[a-zA-Z0-9]{11}$",
+		},
+		"charset lowercase only": {
+			opts: []PasswordOpt{
+				PasswordCharset(LowerCharset),
+			},
+			expectRegex: "^A1a-[a-z]{11}$",
+		},
+		"charset uppercase only": {
+			opts: []PasswordOpt{
+				PasswordCharset(UpperCharset),
+			},
+			expectRegex: "^A1a-[A-Z]{11}$",
+		},
+		"charset numbers only": {
+			opts: []PasswordOpt{
+				PasswordCharset(NumericCharset),
+			},
+			expectRegex: "^A1a-[0-9]{11}$",
+		},
+		"long length": {
+			opts: []PasswordOpt{
+				PasswordLength(100),
+			},
+			expectRegex: "^A1a-[a-zA-Z0-9]{96}$",
+		},
+		"empty prefix": {
+			opts: []PasswordOpt{
+				PasswordPrefix(""),
+			},
+			expectRegex: "^[a-zA-Z0-9]{15}$",
+		},
+		"non-default prefix": {
+			opts: []PasswordOpt{
+				PasswordPrefix("abcde"),
+			},
+			expectRegex: "^abcde[a-zA-Z0-9]{10}$",
+		},
+		"mixed opts": {
+			opts: []PasswordOpt{
+				PasswordCharset(UpperCharset),
+				PasswordLength(20),
+				PasswordPrefix("abcde"),
+			},
+			expectRegex: "^abcde[A-Z]{15}$",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			p, err := NewPasswordProducer(test.opts...)
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+			re := regexp.MustCompile(test.expectRegex)
+
+			// Because this is a randomly generated value, let's run this a bunch of times to detect any flakiness
+			for i := 0; i < 1000; i++ {
+				password, err := p.GeneratePassword()
+				if err != nil {
+					t.Fatalf("no error expected, got: %s", err)
+				}
+
+				if !re.MatchString(password) {
+					t.Fatalf("Password [%s] did not match regex [%s]", password, test.expectRegex)
+				}
+			}
+		})
+	}
+}
+
+func TestGeneratePassword_NoConstructor(t *testing.T) {
+	type testCase struct {
+		charset     string
+		length      int
+		prefix      string
+		expectRegex string
+	}
+
+	tests := map[string]testCase{
+		"default": {
+			expectRegex: "^[a-zA-Z0-9]{15}$",
+		},
+		"charset lowercase only": {
+			charset:     LowerCharset,
+			expectRegex: "^[a-z]{15}$",
+		},
+		"charset uppercase only": {
+			charset:     UpperCharset,
+			expectRegex: "^[A-Z]{15}$",
+		},
+		"charset numbers only": {
+			charset:     NumericCharset,
+			expectRegex: "^[0-9]{15}$",
+		},
+		"long length": {
+			length:      100,
+			expectRegex: "^[a-zA-Z0-9]{100}$",
+		},
+		"empty prefix": {
+			prefix:      "",
+			expectRegex: "^[a-zA-Z0-9]{15}$",
+		},
+		"non-default prefix": {
+			prefix:      "abcde",
+			expectRegex: "^abcde[a-zA-Z0-9]{10}$",
+		},
+		"mixed opts": {
+			charset:     UpperCharset,
+			length:      20,
+			prefix:      "abcde",
+			expectRegex: "^abcde[A-Z]{15}$",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := PasswordProducer{
+				Charset: test.charset,
+				Length:  test.length,
+				Prefix:  test.prefix,
+			}
+			re := regexp.MustCompile(test.expectRegex)
+
+			// Because this is a randomly generated value, let's run this a bunch of times to detect any flakiness
+			for i := 0; i < 1000; i++ {
+				password, err := p.GeneratePassword()
+				if err != nil {
+					t.Fatalf("no error expected, got: %s", err)
+				}
+
+				if !re.MatchString(password) {
+					t.Fatalf("Password [%s] did not match regex [%s]", password, test.expectRegex)
+				}
+			}
+		})
+	}
+}
+
+func TestPasswordProducer_Constructor(t *testing.T) {
+	type testCase struct {
+		opts      []PasswordOpt
+		expectErr bool
+	}
+
+	tests := map[string]testCase{
+		"password length too short": {
+			opts: []PasswordOpt{
+				PasswordLength(MinPasswordLength - 1),
+			},
+			expectErr: true,
+		},
+		"password length at minimum": {
+			opts: []PasswordOpt{
+				PasswordLength(MinPasswordLength),
+			},
+			expectErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewPasswordProducer(test.opts...)
+			if test.expectErr && err == nil {
+				t.Fatalf("err expected, got nil")
+			}
+			if !test.expectErr && err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+		})
+	}
+}

--- a/sdk/database/helper/credsutil/usernamepassword.go
+++ b/sdk/database/helper/credsutil/usernamepassword.go
@@ -1,0 +1,91 @@
+package credsutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+)
+
+const (
+	DefaultExpirationFormat = "2006-01-02 15:04:05-0700"
+)
+
+// UsernamePasswordProducer is a combined wrapper around UsernameProducer and PasswordProducer that adheres
+// to the CredentialsProducer interface
+type UsernamePasswordProducer struct {
+	UsernameProducer
+	PasswordProducer
+
+	ExpirationFormat string
+}
+
+type UsernamePasswordOpt func(*UsernamePasswordProducer) error
+
+// UsernameOpts is a collection of options passed into the UsernameProducer.
+// This is a passthrough to the UsernameProducer. Multiple calls to this will not build upon each other.
+func UsernameOpts(opts ...UsernameOpt) UsernamePasswordOpt {
+	return func(up *UsernamePasswordProducer) error {
+		user, err := NewUsernameProducer(opts...)
+		if err != nil {
+			return fmt.Errorf("unable to create username producer: %w", err)
+		}
+
+		up.UsernameProducer = user
+		return nil
+	}
+}
+
+// PasswordOpts is a collection of options passed into the PasswordProducer.
+// This is a passthrough to the PasswordProducer. Multiple calls to this will not build upon each other.
+func PasswordOpts(opts ...PasswordOpt) UsernamePasswordOpt {
+	return func(up *UsernamePasswordProducer) error {
+		pass, err := NewPasswordProducer(opts...)
+		if err != nil {
+			return fmt.Errorf("unable to create username producer: %w", err)
+		}
+
+		up.PasswordProducer = pass
+		return nil
+	}
+}
+
+// ExpirationFormat for use when generating an expiration string.
+func ExpirationFormat(format string) UsernamePasswordOpt {
+	return func(up *UsernamePasswordProducer) error {
+		up.ExpirationFormat = format
+		return nil
+	}
+}
+
+// NewUsernamePasswordProducer creates a UsernamePasswordProducer that can be used when the CredentialsProducer
+// interface is embedded in a struct. This adheres to the entire CredentialsProducer interface.
+func NewUsernamePasswordProducer(opts ...UsernamePasswordOpt) (up UsernamePasswordProducer, err error) {
+	merr := &multierror.Error{}
+	for _, opt := range opts {
+		merr = multierror.Append(merr, opt(&up))
+	}
+
+	return up, merr.ErrorOrNil()
+}
+
+func (up UsernamePasswordProducer) GenerateUsername(config dbplugin.UsernameConfig) (string, error) {
+	return up.UsernameProducer.GenerateUsername(config)
+}
+
+func (up UsernamePasswordProducer) GeneratePassword() (string, error) {
+	return up.PasswordProducer.GeneratePassword()
+}
+
+func (up UsernamePasswordProducer) GenerateCredentials(ctx context.Context) (string, error) {
+	return up.GeneratePassword()
+}
+
+func (up UsernamePasswordProducer) GenerateExpiration(t time.Time) (string, error) {
+	if up.ExpirationFormat == "" {
+		return t.Format(DefaultExpirationFormat), nil
+	}
+	return t.Format(up.ExpirationFormat), nil
+}

--- a/sdk/database/helper/credsutil/usernames.go
+++ b/sdk/database/helper/credsutil/usernames.go
@@ -1,0 +1,249 @@
+package credsutil
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+)
+
+const (
+	DefaultCharset = LowerCharset + UpperCharset + NumericCharset
+	UpperCharset   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	LowerCharset   = "abcdefghijklmnopqrstuvwxyz"
+	NumericCharset = "0123456789"
+	SymbolsCharset = "!\"#$%&'()*+,-./:;<=>?`\\~[]^_@|" // no whitespace characters for safety
+
+	DefaultTemplate = "v_{{.RoleName}}_{{.DisplayName}}_{{now_seconds}}_{{rand 10}}"
+)
+
+type UsernameOpt func(*UsernameProducer) error
+
+// UsernameTemplate specifies the template to use when generating a username.
+func UsernameTemplate(pattern string) UsernameOpt {
+	return func(up *UsernameProducer) error {
+		up.rawTemplate = pattern
+		return nil
+	}
+}
+
+// UsernameFuncMap allows the user to specify functions for use in the template. This can be used to override the
+// behavior of any of the built-in functions (such as rand). Overriding the built-in functions is not recommended.
+func UsernameFuncMap(name string, f interface{}) UsernameOpt {
+	return func(up *UsernameProducer) error {
+		if name == "" {
+			return fmt.Errorf("missing function name")
+		}
+		if f == nil {
+			return fmt.Errorf("missing function")
+		}
+		up.funcMap[name] = f
+		return nil
+	}
+}
+
+// UsernameMaxLength is the maximum allowed length of the username. This will take effect after applying the template.
+// A length of 0 indicates no maximum length
+func UsernameMaxLength(maxLen int) UsernameOpt {
+	return func(up *UsernameProducer) error {
+		if maxLen < 0 {
+			return fmt.Errorf("max username length must be >= 0")
+		}
+		up.maxLen = maxLen
+		return nil
+	}
+}
+
+// UsernameRandomCharset specifies the charset used when using the `rand` template function.
+// This will remove duplicate characters from the charset to prevent bias.
+func UsernameRandomCharset(charset string) UsernameOpt {
+	if charset == "" {
+		charset = DefaultCharset
+	}
+	charset = removeDuplicateChars(charset)
+	f := func(length int) (randStr string, err error) {
+		return randomChars(charset, length)
+	}
+	return UsernameFuncMap("rand", f)
+}
+
+// UsernameProducer creates usernames based on the provided template.
+// This uses the go templating language, so anything that adheres to that language will function in this struct.
+// There are several custom functions available for use in the template:
+// - rand
+//   - Randomly generated characters. This uses the charset specified in UsernameRandomCharset. Must include a length.
+//     Example: {{rand 20}}
+// - truncate
+//   - Truncates the previous value to the specified length. Must include a maximum length.
+//     Example: {{.DisplayName | truncate 10}}
+// - now_seconds
+//   - Provides the current unix time in seconds.
+//     Example: {{now_seconds}}
+// - now_nano
+//   - Provides the current unix time in nanoseconds.
+//     Example: {{now_nano}}
+// - uppercase
+//   - Uppercases the previous value.
+//     Example: {{.RoleName | uppercase}}
+// - lowercase
+//   - Lowercases the previous value.
+//     Example: {{.DisplayName | lowercase}}
+type UsernameProducer struct {
+	rawTemplate string
+	tmpl        *template.Template
+	funcMap     template.FuncMap
+	maxLen      int
+}
+
+// NewUsernameProducer creates a UsernameProducer. No arguments are required
+// as this has reasonable defaults for all values.
+// The default template is specified in the DefaultTemplate constant.
+func NewUsernameProducer(opts ...UsernameOpt) (up UsernameProducer, err error) {
+	up = UsernameProducer{
+		rawTemplate: DefaultTemplate,
+		funcMap: map[string]interface{}{
+			"rand":        randCharset(DefaultCharset),
+			"truncate":    truncate,
+			"now_seconds": nowSeconds,
+			"now_nano":    nowNano,
+			"uppercase":   uppercase,
+			"lowercase":   lowercase,
+		},
+	}
+
+	merr := &multierror.Error{}
+	for _, opt := range opts {
+		merr = multierror.Append(merr, opt(&up))
+	}
+
+	err = merr.ErrorOrNil()
+	if err != nil {
+		return up, err
+	}
+
+	tmpl := template.New("usernames")
+	tmpl.Funcs(up.funcMap)
+	tmpl, err = tmpl.Parse(up.rawTemplate)
+	if err != nil {
+		return up, fmt.Errorf("unable to parse template: %w", err)
+	}
+	up.tmpl = tmpl
+
+	return up, nil
+}
+
+// GenerateUsername based on the provided template. This adheres to the CredentialsProducer interface.
+func (up UsernameProducer) GenerateUsername(config dbplugin.UsernameConfig) (username string, err error) {
+	str := &strings.Builder{}
+	err = up.tmpl.Execute(str, config)
+	if err != nil {
+		return "", fmt.Errorf("unable to apply template: %w", err)
+	}
+	username = str.String()
+	if up.maxLen > 0 && len(username) > up.maxLen {
+		username = username[:up.maxLen]
+	}
+	return username, nil
+}
+
+// randCharset returns a function for use in UsernameFuncMap. This allows the user to specify custom charsets for the
+// random string generation
+func randCharset(charset string) func(length int) (randStr string, err error) {
+	return func(length int) (randStr string, err error) {
+		return randomChars(charset, length)
+	}
+}
+
+// randomChars creates a string of the provided length
+func randomChars(charset string, length int) (randStr string, err error) {
+	if length < 0 {
+		return "", fmt.Errorf("length must be >= 0")
+	}
+	reader := rand.Reader
+
+	output := make([]byte, 0, length)
+
+	// Request a bit more than length to reduce the chance
+	// of needing more than one batch of random bytes
+	batchSize := length + length/4
+
+	for {
+		buf, err := uuid.GenerateRandomBytesWithReader(batchSize, reader)
+		if err != nil {
+			return "", fmt.Errorf("unable to generate random bytes: %w", err)
+		}
+
+		csLen := byte(len(charset))
+
+		for _, b := range buf {
+			// Avoid bias by using a value range that's a multiple of the charset size
+			if b < (csLen * 4) {
+				output = append(output, charset[b%csLen])
+
+				if len(output) == length {
+					return string(output), nil
+				}
+			}
+		}
+	}
+}
+
+func randIntBetween(min, max int) int {
+	if min == max {
+		return min
+	}
+
+	nBig, err := rand.Int(rand.Reader, big.NewInt(int64(max-min+1))) // +1 so it's inclusive on both ends
+	if err != nil {
+		panic("unable to get random integer")
+	}
+	return int(nBig.Int64()) + min
+}
+
+func nowSeconds() string {
+	return strconv.FormatInt(time.Now().Unix(), 10)
+}
+
+func nowNano() string {
+	return strconv.FormatInt(time.Now().UnixNano(), 10)
+}
+
+func truncate(maxLen int, str string) (string, error) {
+	if maxLen <= 0 {
+		return str, fmt.Errorf("max length must be > 0 but was %d", maxLen)
+	}
+	if len(str) > maxLen {
+		return str[:maxLen], nil
+	}
+	return str, nil
+}
+
+func uppercase(str string) string {
+	return strings.ToUpper(str)
+}
+
+func lowercase(str string) string {
+	return strings.ToLower(str)
+}
+
+// removeDuplicateChars from the provided string. Does not care about order. Will keep the first unique character.
+func removeDuplicateChars(str string) string {
+	seen := map[string]bool{}
+	newStr := &strings.Builder{}
+	for i := range str {
+		v := str[i : i+1]
+		if seen[v] {
+			continue
+		}
+		newStr.WriteString(v)
+		seen[v] = true
+	}
+	return newStr.String()
+}

--- a/sdk/database/helper/credsutil/usernames_test.go
+++ b/sdk/database/helper/credsutil/usernames_test.go
@@ -1,0 +1,427 @@
+package credsutil
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+)
+
+func TestRemoveDuplicateChars(t *testing.T) {
+	type testCase struct {
+		input    string
+		expected string
+	}
+
+	tests := map[string]testCase{
+		"DefaultCharset": {
+			input:    DefaultCharset,
+			expected: DefaultCharset,
+		},
+		"UpperCharset": {
+			input:    UpperCharset,
+			expected: UpperCharset,
+		},
+		"LowerCharset": {
+			input:    LowerCharset,
+			expected: LowerCharset,
+		},
+		"NumericCharset": {
+			input:    NumericCharset,
+			expected: NumericCharset,
+		},
+		"SymbolsCharset": {
+			input:    SymbolsCharset,
+			expected: SymbolsCharset,
+		},
+		"Duplicate default charset": {
+			input:    DefaultCharset + DefaultCharset,
+			expected: DefaultCharset,
+		},
+		"many duplicates": {
+			input:    "aaaaaaaaaaaaaaaaaaa",
+			expected: "a",
+		},
+		"order is kept": {
+			input:    "abcdefabcdefabcdefabcdef",
+			expected: "abcdef",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := removeDuplicateChars(test.input)
+			if actual != test.expected {
+				t.Fatalf("Actual: [%s]\nExpected: [%s]", actual, test.expected)
+			}
+		})
+	}
+}
+
+func BenchmarkRemoveDuplicateChars(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		removeDuplicateChars(DefaultCharset + SymbolsCharset)
+	}
+}
+
+func TestRandCharset(t *testing.T) {
+	type testCase struct {
+		charset     string
+		length      int
+		expectRegex string
+		expectErr   bool
+	}
+
+	tests := map[string]testCase{
+		"default charset": {
+			charset:     DefaultCharset,
+			length:      10,
+			expectRegex: "^[a-zA-Z0-9]{10}$",
+			expectErr:   false,
+		},
+		"unusual charset": {
+			charset:     "abcdefg01234",
+			length:      20,
+			expectRegex: "^[a-g0-4]{20}$",
+			expectErr:   false,
+		},
+		"very long symbols": {
+			charset:     SymbolsCharset,
+			length:      200,
+			expectRegex: "^[!\"#$%&'\\(\\)\\*\\+,-./:;<=>?`\\~\\[\\]^_@|\\\\]{200}$",
+			expectErr:   false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Because the value is random, run this a bunch of times to ensure that each run has the expected behavior
+			for i := 0; i < 100; i++ {
+				actual, err := randCharset(test.charset)(test.length)
+				if test.expectErr && err == nil {
+					t.Fatalf("err expected, got nil")
+				}
+				if !test.expectErr && err != nil {
+					t.Fatalf("no error expected, got: %s", err)
+				}
+				expectedRegex := regexp.MustCompile(test.expectRegex)
+				if !expectedRegex.MatchString(actual) {
+					t.Fatalf("Random characters [%s] did not match regexp [%s]", actual, test.expectRegex)
+				}
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	type testCase struct {
+		input     string
+		maxLen    int
+		expected  string
+		expectErr bool
+	}
+
+	tests := map[string]testCase{
+		"no truncate": {
+			input:     "foobar",
+			maxLen:    10,
+			expected:  "foobar",
+			expectErr: false,
+		},
+		"max len equals length": {
+			input:     "foobar",
+			maxLen:    6,
+			expected:  "foobar",
+			expectErr: false,
+		},
+		"max len equals length-1": {
+			input:     "foobar",
+			maxLen:    5,
+			expected:  "fooba",
+			expectErr: false,
+		},
+		"max len 1": {
+			input:     "foobar",
+			maxLen:    1,
+			expected:  "f",
+			expectErr: false,
+		},
+		"max len is zero": {
+			input:     "foobar",
+			maxLen:    0,
+			expected:  "foobar",
+			expectErr: true,
+		},
+		"max len is negative": {
+			input:     "foobar",
+			maxLen:    -10,
+			expected:  "foobar",
+			expectErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := truncate(test.maxLen, test.input)
+			if test.expectErr && err == nil {
+				t.Fatalf("err expected, got nil")
+			}
+			if !test.expectErr && err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+			if actual != test.expected {
+				t.Fatalf("Actual [%s] Expected [%s]", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateUsername(t *testing.T) {
+	type testCase struct {
+		opts        []UsernameOpt
+		config      dbplugin.UsernameConfig
+		expectRegex string
+	}
+
+	tests := map[string]testCase{
+		"default values": {
+			config: dbplugin.UsernameConfig{
+				DisplayName: "dispname",
+				RoleName:    "rolename",
+			},
+			expectRegex: `^v_rolename_dispname_[0-9]+_[a-zA-Z0-9]{10}$`,
+		},
+		"multiple roles": {
+			opts: []UsernameOpt{
+				UsernameTemplate("{{.RoleName}}_{{.RoleName}}"),
+			},
+			config: dbplugin.UsernameConfig{
+				DisplayName: "dispname",
+				RoleName:    "rolename",
+			},
+			expectRegex: `^rolename_rolename$`,
+		},
+		"truncate": {
+			opts: []UsernameOpt{
+				UsernameTemplate("{{.RoleName | truncate 5}}"),
+			},
+			config: dbplugin.UsernameConfig{
+				DisplayName: "dispname",
+				RoleName:    "rolename",
+			},
+			expectRegex: `^rolen$`,
+		},
+		"multiple displays": {
+			opts: []UsernameOpt{
+				UsernameTemplate("{{.DisplayName}}_{{.DisplayName}}"),
+			},
+			config: dbplugin.UsernameConfig{
+				DisplayName: "dispname",
+				RoleName:    "rolename",
+			},
+			expectRegex: `^dispname_dispname$`,
+		},
+		"random": {
+			opts: []UsernameOpt{
+				UsernameTemplate("{{rand 10}}"),
+			},
+			config: dbplugin.UsernameConfig{
+				DisplayName: "dispname",
+				RoleName:    "rolename",
+			},
+			expectRegex: `^[a-zA-Z0-9]{10}$`,
+		},
+		"multiple randoms": {
+			opts: []UsernameOpt{
+				UsernameTemplate("{{rand 10}}_{{rand 20}}"),
+			},
+			config: dbplugin.UsernameConfig{
+				DisplayName: "dispname",
+				RoleName:    "rolename",
+			},
+			expectRegex: `^[a-zA-Z0-9]{10}_[a-zA-Z0-9]{20}$`,
+		},
+		"random with custom charset": {
+			opts: []UsernameOpt{
+				UsernameTemplate("{{rand 30}}"),
+				UsernameFuncMap("rand", randCharset("abcdefg012345")),
+			},
+			config: dbplugin.UsernameConfig{
+				DisplayName: "dispname",
+				RoleName:    "rolename",
+			},
+			expectRegex: `^[a-g0-5]{30}$`,
+		},
+		"mix and match": {
+			opts: []UsernameOpt{
+				UsernameTemplate("Prefix_{{.DisplayName | truncate 5}}-{{rand 10}}={{.RoleName}}_suffix"),
+			},
+			config: dbplugin.UsernameConfig{
+				DisplayName: "dispname",
+				RoleName:    "rolename",
+			},
+			expectRegex: `^Prefix_dispn-[a-zA-Z0-9]{10}=rolename_suffix$`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			up, err := NewUsernameProducer(test.opts...)
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+			username, err := up.GenerateUsername(test.config)
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+			expectedRegex := regexp.MustCompile(test.expectRegex)
+			if !expectedRegex.MatchString(username) {
+				t.Fatalf("Username [%s] did not match regexp [%s]", username, test.expectRegex)
+			}
+		})
+	}
+}
+
+func TestUsernameBackwardsCompatibility(t *testing.T) {
+	type testCase struct {
+		dispLen   int
+		roleLen   int
+		maxLen    int
+		separator string
+		lowercase bool
+
+		template string
+
+		expectRegex string
+	}
+
+	tests := map[string]testCase{
+		"cassandra & influxdb": {
+			dispLen:     15,
+			roleLen:     15,
+			maxLen:      100,
+			separator:   "_",
+			lowercase:   false,
+			template:    "v_{{.DisplayName | truncate 15}}_{{.RoleName | truncate 15}}_{{rand 20}}_{{now_seconds}}",
+			expectRegex: "^v_aBcDeFgHiJkLmNo_012345678901234_[a-zA-Z0-9]{20}_[0-9]+$",
+		},
+		"hana": {
+			dispLen:     32,
+			roleLen:     20,
+			maxLen:      128,
+			separator:   "_",
+			lowercase:   false,
+			template:    "v_{{.DisplayName | truncate 32}}_{{.RoleName | truncate 20}}_{{rand 20}}_{{now_seconds}}",
+			expectRegex: "^v_aBcDeFgHiJkLmNoPqRsTuVwXyZaBcDeF_01234567890123456789_[a-zA-Z0-9]{20}_[0-9]+$",
+		},
+		"mongodb": {
+			dispLen:     15,
+			roleLen:     15,
+			maxLen:      100,
+			separator:   "-",
+			lowercase:   false,
+			template:    "v-{{.DisplayName | truncate 15}}-{{.RoleName | truncate 15}}-{{rand 20}}-{{now_seconds}}",
+			expectRegex: "^v-aBcDeFgHiJkLmNo-012345678901234-[a-zA-Z0-9]{20}-[0-9]+$",
+		},
+		"mssql": {
+			dispLen:     20,
+			roleLen:     20,
+			maxLen:      128,
+			separator:   "-",
+			lowercase:   false,
+			template:    "v-{{.DisplayName | truncate 20}}-{{.RoleName | truncate 20}}-{{rand 20}}-{{now_seconds}}",
+			expectRegex: "^v-aBcDeFgHiJkLmNoPqRsT-01234567890123456789-[a-zA-Z0-9]{20}-[0-9]+$",
+		},
+		"mysql": {
+			dispLen:     10,
+			roleLen:     10,
+			maxLen:      32,
+			separator:   "-",
+			lowercase:   false,
+			template:    "v-{{.DisplayName | truncate 10}}-{{.RoleName | truncate 10}}-{{rand 20}}-{{now_seconds}}",
+			expectRegex: "^v-aBcDeFgHiJ-0123456789-[a-zA-Z0-9]{8}$",
+		},
+		"mysql alternatives": {
+			dispLen:     -1,
+			roleLen:     4,
+			maxLen:      16,
+			separator:   "-",
+			lowercase:   false,
+			template:    "v-{{.RoleName | truncate 4}}-{{rand 20}}-{{now_seconds}}",
+			expectRegex: "^v-0123-[a-zA-Z0-9]{9}$",
+		},
+		"postgresql": {
+			dispLen:     8,
+			roleLen:     8,
+			maxLen:      63,
+			separator:   "-",
+			lowercase:   false,
+			template:    "v-{{.DisplayName | truncate 8}}-{{.RoleName | truncate 8}}-{{rand 20}}-{{now_seconds}}",
+			expectRegex: "^v-aBcDeFgH-01234567-[a-zA-Z0-9]{20}-[0-9]+$",
+		},
+		"redshift": {
+			dispLen:     8,
+			roleLen:     8,
+			maxLen:      63,
+			separator:   "-",
+			lowercase:   false,
+			template:    "v-{{.DisplayName | truncate 8}}-{{.RoleName | truncate 8}}-{{rand 20}}-{{now_seconds}}",
+			expectRegex: "^v-aBcDeFgH-01234567-[a-zA-Z0-9]{20}-[0-9]+$",
+		},
+		"redshift lowercase": {
+			dispLen:     8,
+			roleLen:     8,
+			maxLen:      63,
+			separator:   "-",
+			lowercase:   true,
+			template:    "v-{{.DisplayName | truncate 8 | lowercase}}-{{.RoleName | truncate 8 | lowercase}}-{{rand 20 | lowercase}}-{{now_seconds}}",
+			expectRegex: "^v-abcdefgh-01234567-[a-z0-9]{20}-[0-9]+$",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			sqlCredProducer := &SQLCredentialsProducer{
+				DisplayNameLen:    test.dispLen,
+				RoleNameLen:       test.roleLen,
+				UsernameLen:       test.maxLen,
+				Separator:         test.separator,
+				LowercaseUsername: test.lowercase,
+			}
+
+			t.Logf("Template: %s", test.template)
+
+			up, err := NewUsernamePasswordProducer(
+				UsernameOpts(
+					UsernameTemplate(test.template),
+					UsernameMaxLength(test.maxLen),
+				),
+			)
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+
+			config := dbplugin.UsernameConfig{
+				DisplayName: "aBcDeFgHiJkLmNoPqRsTuVwXyZaBcDeFgHiJkLmNoPqRsTuVwXyZ",
+				RoleName:    "0123456789012345678901234567890123456789012345678901",
+			}
+			sqlUsername, err := sqlCredProducer.GenerateUsername(config)
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+
+			upUsername, err := up.GenerateUsername(config)
+			if err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+
+			re := regexp.MustCompile(test.expectRegex)
+			if !re.MatchString(sqlUsername) {
+				t.Fatalf("SQL username [%s] did not match regex [%s]", sqlUsername, test.expectRegex)
+			}
+			if !re.MatchString(upUsername) {
+				t.Fatalf("UsernameProducer username [%s] did not match regex [%s]", upUsername, test.expectRegex)
+			}
+		})
+	}
+}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1825,7 +1825,7 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 	if name == "postgresql-database-plugin" {
 		return dbPostgres.New, true
 	}
-	return dbMysql.New(dbMysql.MetadataLen, dbMysql.MetadataLen, dbMysql.UsernameLen), true
+	return dbMysql.New(dbMysql.DefaultTemplate, dbMysql.UsernameLen), true
 }
 
 // Keys only supports getting a realistic list of the keys for database plugins.

--- a/vendor/github.com/hashicorp/vault/sdk/database/helper/credsutil/passwords.go
+++ b/vendor/github.com/hashicorp/vault/sdk/database/helper/credsutil/passwords.go
@@ -1,0 +1,58 @@
+package credsutil
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+const (
+	DefaultPasswordLength = 15
+)
+
+type PasswordProducer struct {
+	Charset string
+	Length  int
+}
+
+type PasswordOpt func(*PasswordProducer) error
+
+func PasswordCharset(charset string) PasswordOpt {
+	return func(p *PasswordProducer) error {
+		p.Charset = charset
+		return nil
+	}
+}
+
+func PasswordLength(length int) PasswordOpt {
+	return func(p *PasswordProducer) error {
+		if length < 10 {
+			return fmt.Errorf("length must be >= 10")
+		}
+		p.Length = length
+		return nil
+	}
+}
+
+func NewPasswordProducer(opts ...PasswordOpt) (p PasswordProducer, err error) {
+	merr := &multierror.Error{}
+	for _, opt := range opts {
+		merr = multierror.Append(merr, opt(&p))
+	}
+
+	return p, merr.ErrorOrNil()
+}
+
+func (pg PasswordProducer) GeneratePassword() (password string, err error) {
+	charset := pg.Charset
+	if charset == "" {
+		charset = DefaultCharset
+	}
+
+	length := pg.Length
+	if length == 0 {
+		length = DefaultPasswordLength
+	}
+
+	return randomChars(charset, length)
+}

--- a/vendor/github.com/hashicorp/vault/sdk/database/helper/credsutil/usernamepassword.go
+++ b/vendor/github.com/hashicorp/vault/sdk/database/helper/credsutil/usernamepassword.go
@@ -1,0 +1,91 @@
+package credsutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+)
+
+const (
+	DefaultExpirationFormat = "2006-01-02 15:04:05-0700"
+)
+
+// UsernamePasswordProducer is a combined wrapper around UsernameProducer and PasswordProducer that adheres
+// to the CredentialsProducer interface
+type UsernamePasswordProducer struct {
+	UsernameProducer
+	PasswordProducer
+
+	ExpirationFormat string
+}
+
+type UsernamePasswordOpt func(*UsernamePasswordProducer) error
+
+// UsernameOpts is a collection of options passed into the UsernameProducer.
+// This is a passthrough to the UsernameProducer. Multiple calls to this will not build upon each other.
+func UsernameOpts(opts ...UsernameOpt) UsernamePasswordOpt {
+	return func(up *UsernamePasswordProducer) error {
+		user, err := NewUsernameProducer(opts...)
+		if err != nil {
+			return fmt.Errorf("unable to create username producer: %w", err)
+		}
+
+		up.UsernameProducer = user
+		return nil
+	}
+}
+
+// PasswordOpts is a collection of options passed into the PasswordProducer.
+// This is a passthrough to the PasswordProducer. Multiple calls to this will not build upon each other.
+func PasswordOpts(opts ...PasswordOpt) UsernamePasswordOpt {
+	return func(up *UsernamePasswordProducer) error {
+		pass, err := NewPasswordProducer(opts...)
+		if err != nil {
+			return fmt.Errorf("unable to create username producer: %w", err)
+		}
+
+		up.PasswordProducer = pass
+		return nil
+	}
+}
+
+// ExpirationFormat for use when generating an expiration string.
+func ExpirationFormat(format string) UsernamePasswordOpt {
+	return func(up *UsernamePasswordProducer) error {
+		up.ExpirationFormat = format
+		return nil
+	}
+}
+
+// NewUsernamePasswordProducer creates a UsernamePasswordProducer that can be used when the CredentialsProducer
+// interface is embedded in a struct. This adheres to the entire CredentialsProducer interface.
+func NewUsernamePasswordProducer(opts ...UsernamePasswordOpt) (up UsernamePasswordProducer, err error) {
+	merr := &multierror.Error{}
+	for _, opt := range opts {
+		merr = multierror.Append(merr, opt(&up))
+	}
+
+	return up, merr.ErrorOrNil()
+}
+
+func (up UsernamePasswordProducer) GenerateUsername(config dbplugin.UsernameConfig) (string, error) {
+	return up.UsernameProducer.GenerateUsername(config)
+}
+
+func (up UsernamePasswordProducer) GeneratePassword() (string, error) {
+	return up.PasswordProducer.GeneratePassword()
+}
+
+func (up UsernamePasswordProducer) GenerateCredentials(ctx context.Context) (string, error) {
+	return up.GeneratePassword()
+}
+
+func (up UsernamePasswordProducer) GenerateExpiration(t time.Time) (string, error) {
+	if up.ExpirationFormat == "" {
+		return t.Format(DefaultExpirationFormat), nil
+	}
+	return t.Format(up.ExpirationFormat), nil
+}

--- a/vendor/github.com/hashicorp/vault/sdk/database/helper/credsutil/usernames.go
+++ b/vendor/github.com/hashicorp/vault/sdk/database/helper/credsutil/usernames.go
@@ -1,0 +1,249 @@
+package credsutil
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+)
+
+const (
+	DefaultCharset = LowerCharset + UpperCharset + NumericCharset
+	UpperCharset   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	LowerCharset   = "abcdefghijklmnopqrstuvwxyz"
+	NumericCharset = "0123456789"
+	SymbolsCharset = "!\"#$%&'()*+,-./:;<=>?`\\~[]^_@|" // no whitespace characters for safety
+
+	DefaultTemplate = "v_{{.RoleName}}_{{.DisplayName}}_{{now_seconds}}_{{rand 10}}"
+)
+
+type UsernameOpt func(*UsernameProducer) error
+
+// UsernameTemplate specifies the template to use when generating a username.
+func UsernameTemplate(pattern string) UsernameOpt {
+	return func(up *UsernameProducer) error {
+		up.rawTemplate = pattern
+		return nil
+	}
+}
+
+// UsernameFuncMap allows the user to specify functions for use in the template. This can be used to override the
+// behavior of any of the built-in functions (such as rand). Overriding the built-in functions is not recommended.
+func UsernameFuncMap(name string, f interface{}) UsernameOpt {
+	return func(up *UsernameProducer) error {
+		if name == "" {
+			return fmt.Errorf("missing function name")
+		}
+		if f == nil {
+			return fmt.Errorf("missing function")
+		}
+		up.funcMap[name] = f
+		return nil
+	}
+}
+
+// UsernameMaxLength is the maximum allowed length of the username. This will take effect after applying the template.
+// A length of 0 indicates no maximum length
+func UsernameMaxLength(maxLen int) UsernameOpt {
+	return func(up *UsernameProducer) error {
+		if maxLen < 0 {
+			return fmt.Errorf("max username length must be >= 0")
+		}
+		up.maxLen = maxLen
+		return nil
+	}
+}
+
+// UsernameRandomCharset specifies the charset used when using the `rand` template function.
+// This will remove duplicate characters from the charset to prevent bias.
+func UsernameRandomCharset(charset string) UsernameOpt {
+	if charset == "" {
+		charset = DefaultCharset
+	}
+	charset = removeDuplicateChars(charset)
+	f := func(length int) (randStr string, err error) {
+		return randomChars(charset, length)
+	}
+	return UsernameFuncMap("rand", f)
+}
+
+// UsernameProducer creates usernames based on the provided template.
+// This uses the go templating language, so anything that adheres to that language will function in this struct.
+// There are several custom functions available for use in the template:
+// - rand
+//   - Randomly generated characters. This uses the charset specified in UsernameRandomCharset. Must include a length.
+//     Example: {{rand 20}}
+// - truncate
+//   - Truncates the previous value to the specified length. Must include a maximum length.
+//     Example: {{.DisplayName | truncate 10}}
+// - now_seconds
+//   - Provides the current unix time in seconds.
+//     Example: {{now_seconds}}
+// - now_nano
+//   - Provides the current unix time in nanoseconds.
+//     Example: {{now_nano}}
+// - uppercase
+//   - Uppercases the previous value.
+//     Example: {{.RoleName | uppercase}}
+// - lowercase
+//   - Lowercases the previous value.
+//     Example: {{.DisplayName | lowercase}}
+type UsernameProducer struct {
+	rawTemplate string
+	tmpl        *template.Template
+	funcMap     template.FuncMap
+	maxLen      int
+}
+
+// NewUsernameProducer creates a UsernameProducer. No arguments are required
+// as this has reasonable defaults for all values.
+// The default template is specified in the DefaultTemplate constant.
+func NewUsernameProducer(opts ...UsernameOpt) (up UsernameProducer, err error) {
+	up = UsernameProducer{
+		rawTemplate: DefaultTemplate,
+		funcMap: map[string]interface{}{
+			"rand":        randCharset(DefaultCharset),
+			"truncate":    truncate,
+			"now_seconds": nowSeconds,
+			"now_nano":    nowNano,
+			"uppercase":   uppercase,
+			"lowercase":   lowercase,
+		},
+	}
+
+	merr := &multierror.Error{}
+	for _, opt := range opts {
+		merr = multierror.Append(merr, opt(&up))
+	}
+
+	err = merr.ErrorOrNil()
+	if err != nil {
+		return up, err
+	}
+
+	tmpl := template.New("usernames")
+	tmpl.Funcs(up.funcMap)
+	tmpl, err = tmpl.Parse(up.rawTemplate)
+	if err != nil {
+		return up, fmt.Errorf("unable to parse template: %w", err)
+	}
+	up.tmpl = tmpl
+
+	return up, nil
+}
+
+// GenerateUsername based on the provided template. This adheres to the CredentialsProducer interface.
+func (up UsernameProducer) GenerateUsername(config dbplugin.UsernameConfig) (username string, err error) {
+	str := &strings.Builder{}
+	err = up.tmpl.Execute(str, config)
+	if err != nil {
+		return "", fmt.Errorf("unable to apply template: %w", err)
+	}
+	username = str.String()
+	if up.maxLen > 0 && len(username) > up.maxLen {
+		username = username[:up.maxLen]
+	}
+	return username, nil
+}
+
+// randCharset returns a function for use in UsernameFuncMap. This allows the user to specify custom charsets for the
+// random string generation
+func randCharset(charset string) func(length int) (randStr string, err error) {
+	return func(length int) (randStr string, err error) {
+		return randomChars(charset, length)
+	}
+}
+
+// randomChars creates a string of the provided length
+func randomChars(charset string, length int) (randStr string, err error) {
+	if length < 0 {
+		return "", fmt.Errorf("length must be >= 0")
+	}
+	reader := rand.Reader
+
+	output := make([]byte, 0, length)
+
+	// Request a bit more than length to reduce the chance
+	// of needing more than one batch of random bytes
+	batchSize := length + length/4
+
+	for {
+		buf, err := uuid.GenerateRandomBytesWithReader(batchSize, reader)
+		if err != nil {
+			return "", fmt.Errorf("unable to generate random bytes: %w", err)
+		}
+
+		csLen := byte(len(charset))
+
+		for _, b := range buf {
+			// Avoid bias by using a value range that's a multiple of the charset size
+			if b < (csLen * 4) {
+				output = append(output, charset[b%csLen])
+
+				if len(output) == length {
+					return string(output), nil
+				}
+			}
+		}
+	}
+}
+
+func randIntBetween(min, max int) int {
+	if min == max {
+		return min
+	}
+
+	nBig, err := rand.Int(rand.Reader, big.NewInt(int64(max-min+1))) // +1 so it's inclusive on both ends
+	if err != nil {
+		panic("unable to get random integer")
+	}
+	return int(nBig.Int64()) + min
+}
+
+func nowSeconds() string {
+	return strconv.FormatInt(time.Now().Unix(), 10)
+}
+
+func nowNano() string {
+	return strconv.FormatInt(time.Now().UnixNano(), 10)
+}
+
+func truncate(maxLen int, str string) (string, error) {
+	if maxLen <= 0 {
+		return str, fmt.Errorf("max length must be > 0 but was %d", maxLen)
+	}
+	if len(str) > maxLen {
+		return str[:maxLen], nil
+	}
+	return str, nil
+}
+
+func uppercase(str string) string {
+	return strings.ToUpper(str)
+}
+
+func lowercase(str string) string {
+	return strings.ToLower(str)
+}
+
+// removeDuplicateChars from the provided string. Does not care about order. Will keep the first unique character.
+func removeDuplicateChars(str string) string {
+	seen := map[string]bool{}
+	newStr := &strings.Builder{}
+	for i := range str {
+		v := str[i : i+1]
+		if seen[v] {
+			continue
+		}
+		newStr.WriteString(v)
+		seen[v] = true
+	}
+	return newStr.String()
+}


### PR DESCRIPTION
# Database Credentials Producer
This creates a new database credentials producer that can be used to generate any username/password requested. We've had issues where certain databases need specific username structures (such as all-uppercase or all-lowercase) that aren't well supported by the `SQLCredentialsProducer`. This aims to replace the existing producer with improved functionality without sacrificing backwards-compatibility.

## `UsernameProducer`
  - Creates usernames based on a template that adheres to the go templating language. This allows us to specify any structure of username we want.
  - Has the following built-in functions that can be used in the template:
    - `rand` - Randomly generated characters. This uses the charset specified in UsernameRandomCharset. Must include a length. Ex: `{{rand 20}}`
    - `truncate` - Truncates the previous value to the specified length. Must include a maximum length. Ex: `{{.DisplayName | truncate 10}}`
    - `now_seconds` - Provides the current unix time in seconds. Ex: `{{now_seconds}}`
    - `now_nano` - Provides the current unix time in nanoseconds. Ex: `{{now_nano}}`
    - `uppercase` - Uppercases the previous value. Ex: `{{.RoleName | uppercase}}`
    - `lowercase` - Lowercases the previous value. Ex: `{{.DisplayName | lowercase}}`

## `PasswordProducer`
  - An improved version of what the SQLCredentialsProducer is doing. This version allows you to specify the charset and requested length of the password. The SQLCredentialsProducer hard codes both of those arguments.

## `UsernamePasswordProducer`
This wraps both `UsernameProducer` and `PasswordProducer` for use in places where we are embedding a `CredentialsProducer` interface into a struct. This does a pass through to the underlying `UsernameProducer` and `PasswordProducer` where appropriate. It also adheres to the other functions on the interface that the other two producers do not.

All of these structs have default behavior for all fields, so all arguments to the constructors are optional.

**Note**: the `PasswordProducer` has a `Prefix` field to match the behavior of the `SQLCredentialsProducer`. If the producer is built without using the constructor, the prefix will be an empty string and will NOT default to the default prefix in order to allow for no prefix being specified.