### PR TITLE
Docs: add enterprise note to k8s service discovery

### DIFF
--- a/website/pages/docs/configuration/service-registration/kubernetes.mdx
+++ b/website/pages/docs/configuration/service-registration/kubernetes.mdx
@@ -9,6 +9,8 @@ description: >-
 
 # Kubernetes Service Registration
 
+~> **Important Note:** This feature is currently not supported in Vault Enterprise.
+
 Kubernetes Service Registration tags Vault pods with their current status for
 use with selectors. Service registration is only available when Vault is running in
 [High Availability mode](/docs/concepts/ha).


### PR DESCRIPTION
Adding a note to the documentation about K8s service discover in enterprise not being supported due to a bug.