### PR TITLE
Sanitize Vault version strings for Kubernetes

### DIFF
--- a/serviceregistration/kubernetes/client/client.go
+++ b/serviceregistration/kubernetes/client/client.go
@@ -257,6 +257,8 @@ func Sanitize(val string) string {
 	for _, ru := range val {
 		if isAllowable(ru) {
 			allowable += string(ru)
+		} else {
+			allowable += "-"
 		}
 	}
 	return allowable

--- a/serviceregistration/kubernetes/client/client.go
+++ b/serviceregistration/kubernetes/client/client.go
@@ -264,14 +264,8 @@ func replaceBadCharsWithDashes(r rune) rune {
 	if unicode.IsNumber(r) {
 		return r
 	}
-	char := string(r)
-	if char == "-" {
-		return r
-	}
-	if char == "_" {
-		return r
-	}
-	if char == "." {
+	switch string(r) {
+	case "-", "_", ".":
 		return r
 	}
 	return '-'

--- a/serviceregistration/kubernetes/client/client.go
+++ b/serviceregistration/kubernetes/client/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 	"unicode"
 
@@ -253,35 +254,27 @@ func (e *ErrNotFound) Error() string {
 // Any other characters found in the original value will be stripped,
 // and the surrounding characters will be concatenated.
 func Sanitize(val string) string {
-	allowable := ""
-	for _, ru := range val {
-		if isAllowable(ru) {
-			allowable += string(ru)
-		} else {
-			allowable += "-"
-		}
-	}
-	return allowable
+	return strings.Map(replaceBadCharsWithDashes, val)
 }
 
-func isAllowable(r rune) bool {
+func replaceBadCharsWithDashes(r rune) rune {
 	if unicode.IsLetter(r) {
-		return true
+		return r
 	}
 	if unicode.IsNumber(r) {
-		return true
+		return r
 	}
 	char := string(r)
 	if char == "-" {
-		return true
+		return r
 	}
 	if char == "_" {
-		return true
+		return r
 	}
 	if char == "." {
-		return true
+		return r
 	}
-	return false
+	return '-'
 }
 
 // sanitizedDebuggingInfo provides a returnable string that can be used for debugging. This is intentionally somewhat vague

--- a/serviceregistration/kubernetes/client/client.go
+++ b/serviceregistration/kubernetes/client/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+	"unicode"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-hclog"
@@ -245,6 +246,40 @@ type ErrNotFound struct {
 
 func (e *ErrNotFound) Error() string {
 	return e.debuggingInfo
+}
+
+// Sanitize is for "data" being sent to the Kubernetes API.
+// Data must consist of alphanumeric characters, '-', '_' or '.'.
+// Any other characters found in the original value will be stripped,
+// and the surrounding characters will be concatenated.
+func Sanitize(val string) string {
+	allowable := ""
+	for _, ru := range val {
+		if isAllowable(ru) {
+			allowable += string(ru)
+		}
+	}
+	return allowable
+}
+
+func isAllowable(r rune) bool {
+	if unicode.IsLetter(r) {
+		return true
+	}
+	if unicode.IsNumber(r) {
+		return true
+	}
+	char := string(r)
+	if char == "-" {
+		return true
+	}
+	if char == "_" {
+		return true
+	}
+	if char == "." {
+		return true
+	}
+	return false
 }
 
 // sanitizedDebuggingInfo provides a returnable string that can be used for debugging. This is intentionally somewhat vague

--- a/serviceregistration/kubernetes/client/client_test.go
+++ b/serviceregistration/kubernetes/client/client_test.go
@@ -95,7 +95,7 @@ func (e *env) TestUpdatePodTagsNotFound(t *testing.T) {
 }
 
 func TestSanitize(t *testing.T) {
-	expected := "fizzbuzz"
+	expected := "fizz-buzz"
 	result := Sanitize("fizz+buzz")
 	if result != expected {
 		t.Fatalf("expected %q but received %q", expected, result)
@@ -119,13 +119,13 @@ func TestSanitize(t *testing.T) {
 		t.Fatalf("expected %q but received %q", expected, result)
 	}
 
-	expected = "123-fhd"
+	expected = "123--fhd"
 	result = Sanitize("123-*fhd")
 	if result != expected {
 		t.Fatalf("expected %q but received %q", expected, result)
 	}
 
-	expected = "1.4.0-beta1ent"
+	expected = "1.4.0-beta1-ent"
 	result = Sanitize("1.4.0-beta1+ent")
 	if result != expected {
 		t.Fatalf("expected %q but received %q", expected, result)

--- a/serviceregistration/kubernetes/client/client_test.go
+++ b/serviceregistration/kubernetes/client/client_test.go
@@ -93,3 +93,41 @@ func (e *env) TestUpdatePodTagsNotFound(t *testing.T) {
 		t.Fatalf("expected *ErrNotFound but received %T", err)
 	}
 }
+
+func TestSanitize(t *testing.T) {
+	expected := "fizzbuzz"
+	result := Sanitize("fizz+buzz")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+
+	expected = "fizz_buzz"
+	result = Sanitize("fizz_buzz")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+
+	expected = "fizz.buzz"
+	result = Sanitize("fizz.buzz")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+
+	expected = "fizz-buzz"
+	result = Sanitize("fizz-buzz")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+
+	expected = "123-fhd"
+	result = Sanitize("123-*fhd")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+
+	expected = "1.4.0-beta1ent"
+	result = Sanitize("1.4.0-beta1+ent")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+}

--- a/serviceregistration/kubernetes/service_registration.go
+++ b/serviceregistration/kubernetes/service_registration.go
@@ -32,6 +32,9 @@ func NewServiceRegistration(config map[string]string, logger hclog.Logger, state
 	if err != nil {
 		return nil, err
 	}
+	// The Vault version must be sanitized because it can contain special
+	// characters like "+" which aren't acceptable by the Kube API.
+	state.VaultVersion = client.Sanitize(state.VaultVersion)
 	return &serviceRegistration{
 		logger:       logger,
 		namespace:    namespace,

--- a/serviceregistration/kubernetes/service_registration_test.go
+++ b/serviceregistration/kubernetes/service_registration_test.go
@@ -12,7 +12,7 @@ import (
 	kubetest "github.com/hashicorp/vault/serviceregistration/kubernetes/testing"
 )
 
-var testVersion = "version 1"
+var testVersion = "version1"
 
 func TestServiceRegistration(t *testing.T) {
 	testState, testConf, closeFunc := kubetest.Server(t)


### PR DESCRIPTION
We have found that if the Vault version contains a "+", as is used with Vault enterprise, the Kubernetes API returns a 422 and service registration fails.

This PR adds a `Sanitize` method to the hand-rolled Kube client, which is then used by Kube service registration to clean the Vault version string.

When creating this PR, I considered the possibility of using `regex`. I chose this approach because in my opinion, this is the most readable/maintainable option, however, I am flexible on that as it's quite subjective.