### PR TITLE
[Website] Set X-Frame-Options: SAMEORIGIN header for pages

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -11,3 +11,8 @@
 
 [context.deploy-preview]
   environment = { HASHI_ENV = "staging" }
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"


### PR DESCRIPTION
This PR aims to mitigate possible click-jacking exploits in the Vault website by applying the `X-Frame-Options: SAMEORIGIN` header to all pages.