### PR TITLE
Fix error interpolation in LDAP client

### DIFF
--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -217,7 +217,7 @@ func (c *Client) performLdapFilterGroupsSearch(cfg *ConfigEntry, conn Connection
 
 	var renderedQuery bytes.Buffer
 	if err := t.Execute(&renderedQuery, context); err != nil {
-		return nil, errwrap.Wrapf("LDAP search failed due to template parsing error: {{error}}", err)
+		return nil, errwrap.Wrapf("LDAP search failed due to template parsing error: {{err}}", err)
 	}
 
 	if c.Logger.IsDebug() {


### PR DESCRIPTION
Thank you all for such an awesome product :heart: 

Save for this error not being rendered, enabling LDAP was super easy :smile: 