### PR TITLE
Documentation Typo: Remove unintentional duplicate string

### DIFF
--- a/website/pages/docs/configuration/seal/awskms.mdx
+++ b/website/pages/docs/configuration/seal/awskms.mdx
@@ -70,7 +70,7 @@ Authentication-related values must be provided, either as environment
 variables or as configuration parameters.
 
 ~> **Note:** Although the configuration file allows you to pass in
-`AWS_ACCESS_KEY_ID` and `AWS_ACCESS_KEY_ID` as part of the seal's parameters, it
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as part of the seal's parameters, it
 is _strongly_ recommended to set these values via environment variables.
 
 AWS authentication values:


### PR DESCRIPTION
Same string noted in documentation twice, updating to expected string based on context.