### PR TITLE
Improve website docker image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,11 +325,7 @@ jobs:
     - setup_remote_docker
     - run:
         command: |
-          # There is an edge case that would cause an issue here - if dependencies are updated to an exact copy
-          # of a previous version, for example if packge-lock.json is reverted, we need to manually push the new
-          # image to the "latest" tag
-          # Ignore job if running an enterprise build
-          IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+          IMAGE_TAG="$(git rev-list -n1 HEAD -- website/Dockerfile website/package-lock.json)"
           echo "Using $IMAGE_TAG"
           if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/vault" ]; then
             echo "Not Vault OSS Repo, not building website docker image"
@@ -648,11 +644,7 @@ workflows:
 #     - setup_remote_docker
 #     - run:
 #         command: |
-#           # There is an edge case that would cause an issue here - if dependencies are updated to an exact copy
-#           # of a previous version, for example if packge-lock.json is reverted, we need to manually push the new
-#           # image to the \"latest\" tag
-#           # Ignore job if running an enterprise build
-#           IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+#           IMAGE_TAG=\"$(git rev-list -n1 HEAD -- website/Dockerfile website/package-lock.json)\"
 #           echo \"Using $IMAGE_TAG\"
 #           if  [ \"$CIRCLE_REPOSITORY_URL\" != \"git@github.com:hashicorp/vault\" ]; then
 #             echo \"Not Vault OSS Repo, not building website docker image\"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,29 +325,23 @@ jobs:
     - setup_remote_docker
     - run:
         command: |
-          # BUILD_FROM_REPO should ALWAYS be the main OSS Vault repo URL.
-          BUILD_FROM_REPO=git@github.com:hashicorp/vault.git
-          [ "$CIRCLE_REPOSITORY_URL" = "$BUILD_FROM_REPO" ] || {
-            echo "Not building website docker image for repo '$CIRCLE_REPOSITORY_URL' - we only build it for $BUILD_FROM_REPO."
-            exit 0
-          }
-          [ "$CIRCLE_BRANCH" = "master" ] || {
-            echo "Not building website docker image for branch '$CIRCLE_BRANCH' - we only build it for master."
-            exit 0
-          }
-          PACKAGE_LOCK_CHANGED="$( \
-            git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | \
-            grep -c website/package-lock.json; \
-          )" || true
-          [ $PACKAGE_LOCK_CHANGED -gt 0 ] || {
-            echo "Not building a new website docker image - dependencies have not changed."
-            exit 0
-          }
-          cd website/
-          docker build -t hashicorp/vault-website:$CIRCLE_SHA1 .
-          docker tag hashicorp/vault-website:$CIRCLE_SHA1 hashicorp/vault-website:latest
-          docker login -u $DOCKER_USER -p $DOCKER_PASS
-          docker push hashicorp/vault-website
+          # There is an edge case that would cause an issue here - if dependencies are updated to an exact copy
+          # of a previous version, for example if packge-lock.json is reverted, we need to manually push the new
+          # image to the "latest" tag
+          # Ignore job if running an enterprise build
+          IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+          echo "Using $IMAGE_TAG"
+          if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/vault" ]; then
+            echo "Not Vault OSS Repo, not building website docker image"
+          elif curl https://hub.docker.com/v2/repositories/hashicorp/vault-website/tags/$IMAGE_TAG -fsL > /dev/null; then
+              echo "Dependencies have not changed, not building a new website docker image."
+          else
+              cd website/
+              docker build -t hashicorp/vault-website:$IMAGE_TAG .
+              docker tag hashicorp/vault-website:$IMAGE_TAG hashicorp/vault-website:latest
+              docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
+              docker push hashicorp/vault-website
+          fi
         name: Build Docker Image if Necessary
 workflows:
   ci:
@@ -382,6 +376,10 @@ workflows:
         requires:
         - build-go-dev
     - website-docker-image:
+        filters:
+          branches:
+            only:
+            - master
         context: vault-docs
   version: 2
 
@@ -650,29 +648,23 @@ workflows:
 #     - setup_remote_docker
 #     - run:
 #         command: |
-#           # BUILD_FROM_REPO should ALWAYS be the main OSS Vault repo URL.
-#           BUILD_FROM_REPO=git@github.com:hashicorp/vault.git
-#           [ \"$CIRCLE_REPOSITORY_URL\" = \"$BUILD_FROM_REPO\" ] || {
-#             echo \"Not building website docker image for repo '$CIRCLE_REPOSITORY_URL' - we only build it for $BUILD_FROM_REPO.\"
-#             exit 0
-#           }
-#           [ \"$CIRCLE_BRANCH\" = \"master\" ] || {
-#             echo \"Not building website docker image for branch '$CIRCLE_BRANCH' - we only build it for master.\"
-#             exit 0
-#           }
-#           PACKAGE_LOCK_CHANGED=\"$( \\
-#             git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | \\
-#             grep -c website/package-lock.json; \\
-#           )\" || true
-#           [ $PACKAGE_LOCK_CHANGED -gt 0 ] || {
-#             echo \"Not building a new website docker image - dependencies have not changed.\"
-#             exit 0
-#           }
-#           cd website/
-#           docker build -t hashicorp/vault-website:$CIRCLE_SHA1 .
-#           docker tag hashicorp/vault-website:$CIRCLE_SHA1 hashicorp/vault-website:latest
-#           docker login -u $DOCKER_USER -p $DOCKER_PASS
-#           docker push hashicorp/vault-website
+#           # There is an edge case that would cause an issue here - if dependencies are updated to an exact copy
+#           # of a previous version, for example if packge-lock.json is reverted, we need to manually push the new
+#           # image to the \"latest\" tag
+#           # Ignore job if running an enterprise build
+#           IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+#           echo \"Using $IMAGE_TAG\"
+#           if  [ \"$CIRCLE_REPOSITORY_URL\" != \"git@github.com:hashicorp/vault\" ]; then
+#             echo \"Not Vault OSS Repo, not building website docker image\"
+#           elif curl https://hub.docker.com/v2/repositories/hashicorp/vault-website/tags/$IMAGE_TAG -fsL > /dev/null; then
+#               echo \"Dependencies have not changed, not building a new website docker image.\"
+#           else
+#               cd website/
+#               docker build -t hashicorp/vault-website:$IMAGE_TAG .
+#               docker tag hashicorp/vault-website:$IMAGE_TAG hashicorp/vault-website:latest
+#               docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
+#               docker push hashicorp/vault-website
+#           fi
 #         name: Build Docker Image if Necessary
 # references:
 #   cache:
@@ -715,3 +707,7 @@ workflows:
 #         - build-go-dev
 #     - website-docker-image:
 #         context: vault-docs
+#         filters:
+#           branches:
+#             only:
+#             - master

--- a/.circleci/config/jobs/website-docker-image.yml
+++ b/.circleci/config/jobs/website-docker-image.yml
@@ -7,26 +7,20 @@ steps:
   - run:
       name: Build Docker Image if Necessary
       command: |
-        # BUILD_FROM_REPO should ALWAYS be the main OSS Vault repo URL.
-        BUILD_FROM_REPO=git@github.com:hashicorp/vault.git
-        [ "$CIRCLE_REPOSITORY_URL" = "$BUILD_FROM_REPO" ] || {
-          echo "Not building website docker image for repo '$CIRCLE_REPOSITORY_URL' - we only build it for $BUILD_FROM_REPO."
-          exit 0
-        }
-        [ "$CIRCLE_BRANCH" = "master" ] || {
-          echo "Not building website docker image for branch '$CIRCLE_BRANCH' - we only build it for master."
-          exit 0
-        }
-        PACKAGE_LOCK_CHANGED="$( \
-          git diff --name-only $(git log --pretty=format:'%h' -n1 HEAD~1)...HEAD | \
-          grep -c website/package-lock.json; \
-        )" || true
-        [ $PACKAGE_LOCK_CHANGED -gt 0 ] || {
-          echo "Not building a new website docker image - dependencies have not changed."
-          exit 0
-        }
-        cd website/
-        docker build -t hashicorp/vault-website:$CIRCLE_SHA1 .
-        docker tag hashicorp/vault-website:$CIRCLE_SHA1 hashicorp/vault-website:latest
-        docker login -u $DOCKER_USER -p $DOCKER_PASS
-        docker push hashicorp/vault-website
+        # There is an edge case that would cause an issue here - if dependencies are updated to an exact copy
+        # of a previous version, for example if packge-lock.json is reverted, we need to manually push the new
+        # image to the "latest" tag
+        # Ignore job if running an enterprise build
+        IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+        echo "Using $IMAGE_TAG"
+        if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/vault" ]; then
+          echo "Not Vault OSS Repo, not building website docker image"
+        elif curl https://hub.docker.com/v2/repositories/hashicorp/vault-website/tags/$IMAGE_TAG -fsL > /dev/null; then
+            echo "Dependencies have not changed, not building a new website docker image."
+        else
+            cd website/
+            docker build -t hashicorp/vault-website:$IMAGE_TAG .
+            docker tag hashicorp/vault-website:$IMAGE_TAG hashicorp/vault-website:latest
+            docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
+            docker push hashicorp/vault-website
+        fi

--- a/.circleci/config/jobs/website-docker-image.yml
+++ b/.circleci/config/jobs/website-docker-image.yml
@@ -7,11 +7,7 @@ steps:
   - run:
       name: Build Docker Image if Necessary
       command: |
-        # There is an edge case that would cause an issue here - if dependencies are updated to an exact copy
-        # of a previous version, for example if packge-lock.json is reverted, we need to manually push the new
-        # image to the "latest" tag
-        # Ignore job if running an enterprise build
-        IMAGE_TAG=$(cat website/Dockerfile website/package-lock.json | sha256sum | awk '{print $1;}')
+        IMAGE_TAG="$(git rev-list -n1 HEAD -- website/Dockerfile website/package-lock.json)"
         echo "Using $IMAGE_TAG"
         if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/vault" ]; then
           echo "Not Vault OSS Repo, not building website docker image"

--- a/.circleci/config/workflows/ci.yml
+++ b/.circleci/config/workflows/ci.yml
@@ -32,3 +32,7 @@ jobs:
             - /^ui\/.*/
   - website-docker-image:
       context: vault-docs
+      filters:
+        branches:
+          only:
+            - master


### PR DESCRIPTION
There are some inefficiencies and bugs in the circleci process, specifically:

- The process runs on every branch and simply exits early rather than running on only master. This adds unnecessary checks noise on other branches. This was fixed by changing the circle config such that the check only runs on master.
- The process checks only the most recent commit for package-lock.json changes - in cases where package changes were made in commits other than the last/only one in a PR, a new docker image will not be released. This was changed by updating the strategy for dependency change checking.
- The process does not release a new docker image when the Dockerfile has changed, and it should as we expect a new Docker image in this instance. This was changed by checking also against changes against Dockerfile.

This PR should fix all these problems, as well as compressing some of the logic a bit within the task!

Changes needed before merge:
- change environment variable names from `DOCKER_USER` and `DOCKER_PASS` to `WEBSITE_DOCKER_USER` and `WEBSITE_DOCKER_PASS`
- change out docker credentials in CI config