### PR TITLE
Fix 404 for Vault Helm ref arch site

### DIFF
--- a/website/pages/docs/platform/k8s/helm/index.mdx
+++ b/website/pages/docs/platform/k8s/helm/index.mdx
@@ -29,7 +29,7 @@ may still change significantly over time. Please always run Helm with
 of Vault. This provides a less complicated out-of-box experience for new users,
 but is not appropriate for a production setup. It is highly recommended to use
 a [properly secured Kubernetes cluster](https://kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/).
-See the [architecture reference](/docs/platform/k8s/run#architecture)
+See the [architecture reference](https://www.vaultproject.io/docs/platform/k8s/helm/run/#architecture)
 for a Vault Helm production deployment checklist.
 
 ## Using the Helm Chart


### PR DESCRIPTION
Link in `See the architecture reference for a Vault Helm production deployment checklist` was redirecting to invalid site https://www.vaultproject.io/docs/platform/k8s/run.html#architecture. 
Revised to https://www.vaultproject.io/docs/platform/k8s/helm/run/#architecture.