### PR TITLE
Backport 1.3.x: Fix identity token caching (#8412)

### DIFF
--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -315,7 +315,15 @@ func (i *IdentityStore) Invalidate(ctx context.Context, key string) {
 		return
 
 	case strings.HasPrefix(key, oidcTokensPrefix):
-		if err := i.oidcCache.Flush(noNamespace); err != nil {
+		ns, err := namespace.FromContext(ctx)
+		if err != nil {
+			i.logger.Error("error retrieving namespace", "error", err)
+			return
+		}
+
+		// Wipe the cache for the requested namespace. This will also clear
+		// the shared namespace as well.
+		if err := i.oidcCache.Flush(ns); err != nil {
 			i.logger.Error("error flushing oidc cache", "error", err)
 		}
 	}

--- a/vault/identity_store_oidc_util.go
+++ b/vault/identity_store_oidc_util.go
@@ -6,6 +6,6 @@ import (
 	"github.com/hashicorp/vault/helper/namespace"
 )
 
-func (i *IdentityStore) listNamespacePaths() []string {
-	return []string{namespace.RootNamespace.Path}
+func (i *IdentityStore) listNamespaces() []*namespace.Namespace {
+	return []*namespace.Namespace{namespace.RootNamespace}
 }


### PR DESCRIPTION
Backport of #8412 

The namespace-partitioned cache flushing was not being used correctly,
which could leave standby nodes with stale information.

Fixes #8284