### PR TITLE
Backport 1.4.x: Sanitize Vault version strings for Kubernetes

### DIFF
--- a/serviceregistration/kubernetes/client/client.go
+++ b/serviceregistration/kubernetes/client/client.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-hclog"
@@ -245,6 +247,28 @@ type ErrNotFound struct {
 
 func (e *ErrNotFound) Error() string {
 	return e.debuggingInfo
+}
+
+// Sanitize is for "data" being sent to the Kubernetes API.
+// Data must consist of alphanumeric characters, '-', '_' or '.'.
+// Any other characters found in the original value will be stripped,
+// and the surrounding characters will be concatenated.
+func Sanitize(val string) string {
+	return strings.Map(replaceBadCharsWithDashes, val)
+}
+
+func replaceBadCharsWithDashes(r rune) rune {
+	if unicode.IsLetter(r) {
+		return r
+	}
+	if unicode.IsNumber(r) {
+		return r
+	}
+	switch string(r) {
+	case "-", "_", ".":
+		return r
+	}
+	return '-'
 }
 
 // sanitizedDebuggingInfo provides a returnable string that can be used for debugging. This is intentionally somewhat vague

--- a/serviceregistration/kubernetes/client/client_test.go
+++ b/serviceregistration/kubernetes/client/client_test.go
@@ -93,3 +93,41 @@ func (e *env) TestUpdatePodTagsNotFound(t *testing.T) {
 		t.Fatalf("expected *ErrNotFound but received %T", err)
 	}
 }
+
+func TestSanitize(t *testing.T) {
+	expected := "fizz-buzz"
+	result := Sanitize("fizz+buzz")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+
+	expected = "fizz_buzz"
+	result = Sanitize("fizz_buzz")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+
+	expected = "fizz.buzz"
+	result = Sanitize("fizz.buzz")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+
+	expected = "fizz-buzz"
+	result = Sanitize("fizz-buzz")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+
+	expected = "123--fhd"
+	result = Sanitize("123-*fhd")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+
+	expected = "1.4.0-beta1-ent"
+	result = Sanitize("1.4.0-beta1+ent")
+	if result != expected {
+		t.Fatalf("expected %q but received %q", expected, result)
+	}
+}

--- a/serviceregistration/kubernetes/service_registration.go
+++ b/serviceregistration/kubernetes/service_registration.go
@@ -32,6 +32,9 @@ func NewServiceRegistration(config map[string]string, logger hclog.Logger, state
 	if err != nil {
 		return nil, err
 	}
+	// The Vault version must be sanitized because it can contain special
+	// characters like "+" which aren't acceptable by the Kube API.
+	state.VaultVersion = client.Sanitize(state.VaultVersion)
 	return &serviceRegistration{
 		logger:       logger,
 		namespace:    namespace,

--- a/serviceregistration/kubernetes/service_registration_test.go
+++ b/serviceregistration/kubernetes/service_registration_test.go
@@ -12,7 +12,7 @@ import (
 	kubetest "github.com/hashicorp/vault/serviceregistration/kubernetes/testing"
 )
 
-var testVersion = "version 1"
+var testVersion = "version1"
 
 func TestServiceRegistration(t *testing.T) {
 	testState, testConf, closeFunc := kubetest.Server(t)


### PR DESCRIPTION
Backports https://github.com/hashicorp/vault/pull/8411, please see there for further detail. This PR is intended to be included in the 1.4 GA.