### PR TITLE
Correct GCP auth permissions list

### DIFF
--- a/website/pages/docs/auth/gcp.mdx
+++ b/website/pages/docs/auth/gcp.mdx
@@ -165,7 +165,6 @@ iam.serviceAccounts.get
 iam.serviceAccountKeys.get
 compute.instances.get
 compute.instanceGroups.list
-compute.instanceGroups.listInstances
 ```
 
 These allow Vault to:


### PR DESCRIPTION
Remove `listInstances`, which isn't a valid permission.

Fixes #8328 