### PR TITLE
Backport 1.3.x: Fix for missing License nav item in menu (#8230)

### DIFF
--- a/ui/app/templates/partials/status/cluster.hbs
+++ b/ui/app/templates/partials/status/cluster.hbs
@@ -68,8 +68,7 @@
       {{#if (and (or
         (and version.features (has-permission 'status' routeParams='license'))
         (and cluster.usingRaft (has-permission 'status' routeParams='raft'))
-        )
-        not cluster.dr.isSecondary)
+        ) (not cluster.dr.isSecondary))
       }}
         <nav class="menu">
           <div class="menu-label">


### PR DESCRIPTION
Backport for PR[ 8230](https://github.com/hashicorp/vault/pull/8230)