### PR TITLE
secrets/openldap: update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.4-beta1
 	github.com/hashicorp/vault-plugin-secrets-kv v0.5.4-beta1
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.0-beta1
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.1.0-beta1
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.1.0-beta1.0.20200304213227-4e174d6dcb2c
 	github.com/hashicorp/vault/api v1.0.5-0.20200215224050-f6547fa8e820
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200220181328-627cbfe69505
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4

--- a/go.sum
+++ b/go.sum
@@ -439,8 +439,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.5.4-beta1 h1:y0QBQiZgLxWudRyuhRe
 github.com/hashicorp/vault-plugin-secrets-kv v0.5.4-beta1/go.mod h1:B/Cybh5aVF7LNAMHwVBxY8t7r2eL0C6HVGgTyP4nKK4=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.0-beta1 h1:uPmTSjMmlvhfJWOvv6SJgn6ZyMGAdr+gN0G2PyZGdwM=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.0-beta1/go.mod h1:ke9kWnEmX0SutdHyi/MYeY27J9YI2LLWotmG5cJdiYI=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.1.0-beta1 h1:BF0krGegLyXXJs7h2xkFwrWqXFvmZjPjyQ6cHT9wots=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.1.0-beta1/go.mod h1:mfMeH+oOuVMgJVQahScA7ic+q8HfzHTocE3xJhmk4Co=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.1.0-beta1.0.20200304213227-4e174d6dcb2c h1:0cprD/Z12tfsQSrWYIEZjFEvHr2OQ6JgLRgciFE1274=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.1.0-beta1.0.20200304213227-4e174d6dcb2c/go.mod h1:mfMeH+oOuVMgJVQahScA7ic+q8HfzHTocE3xJhmk4Co=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/client.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/client.go
@@ -42,16 +42,19 @@ func (c *Client) Get(conf *client.Config, dn string) (*client.Entry, error) {
 }
 
 func (c *Client) UpdatePassword(conf *client.Config, dn string, newPassword string) error {
-	filters := map[*client.Field][]string{
-		client.FieldRegistry.ObjectClass: {"*"},
+	filters := map[*client.Field][]string{client.FieldRegistry.ObjectClass: {"*"}}
+
+	newValues, err := client.GetSchemaFieldRegistry(conf.Schema, newPassword)
+	if err != nil {
+		return fmt.Errorf("error updating password: %s", err)
 	}
-	return c.ldap.UpdatePassword(conf, dn, filters, newPassword)
+
+	return c.ldap.UpdatePassword(conf, dn, newValues, filters)
 }
 
 func (c *Client) UpdateRootPassword(conf *client.Config, newPassword string) error {
-	filters := map[*client.Field][]string{
-		client.FieldRegistry.ObjectClass: {"*"},
-	}
+	filters := map[*client.Field][]string{client.FieldRegistry.ObjectClass: {"*"}}
+	newValues := map[*client.Field][]string{client.FieldRegistry.UserPassword: {newPassword}}
 
-	return c.ldap.UpdatePassword(conf, conf.BindDN, filters, newPassword)
+	return c.ldap.UpdatePassword(conf, conf.BindDN, newValues, filters)
 }

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/client/client.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/client/client.go
@@ -15,6 +15,7 @@ type Config struct {
 	*ldaputil.ConfigEntry
 	LastBindPassword         string    `json:"last_bind_password"`
 	LastBindPasswordRotation time.Time `json:"last_bind_password_rotation"`
+	Schema                   string    `json:"schema"`
 }
 
 func New() Client {
@@ -92,10 +93,7 @@ func (c *Client) UpdateEntry(cfg *Config, baseDN string, filters map[*Field][]st
 // UpdatePassword uses a Modify call under the hood instead of LDAP change password function.
 // This allows AD and OpenLDAP secret engines to use the same api without changes to
 // the interface.
-func (c *Client) UpdatePassword(cfg *Config, baseDN string, filters map[*Field][]string, newPassword string) error {
-	newValues := map[*Field][]string{
-		FieldRegistry.UserPassword: {newPassword},
-	}
+func (c *Client) UpdatePassword(cfg *Config, baseDN string, newValues map[*Field][]string, filters map[*Field][]string) error {
 	return c.UpdateEntry(cfg, baseDN, filters, newValues)
 }
 

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/client/fieldregistry.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/client/fieldregistry.go
@@ -59,6 +59,8 @@ type fieldRegistry struct {
 	ObjectSID          *Field `ldap:"objectSid"`
 	OrganizationalUnit *Field `ldap:"ou"`
 	PasswordLastSet    *Field `ldap:"passwordLastSet"`
+	RACFPassword       *Field `ldap:"racfPassword"`
+	RACFAttributes     *Field `ldap:"racfAttributes"`
 	UnicodePassword    *Field `ldap:"unicodePwd"`
 	UserPassword       *Field `ldap:"userPassword"`
 	UserPrincipalName  *Field `ldap:"userPrincipalName"`

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/client/schema.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/client/schema.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"fmt"
+	"github.com/hashicorp/vault/sdk/helper/strutil"
+)
+
+// SupportedSchemas returns a slice of different OpenLDAP schemas supported
+// by the plugin.  This is used to change the FieldRegistry when modifying
+// user passwords.
+func SupportedSchemas() []string {
+	return []string{"openldap", "racf"}
+}
+
+// ValidSchema checks if the configured schema is supported by the plugin.
+func ValidSchema(schema string) bool {
+	return strutil.StrListContains(SupportedSchemas(), schema)
+}
+
+// GetSchemaFieldRegistry type switches field registries depending on the configured schema.
+// For example, IBM RACF has a custom OpenLDAP schema so the password is stored in a different
+// attribute.
+func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]string, error) {
+	switch schema {
+	case "openldap":
+		fields := map[*Field][]string{FieldRegistry.UserPassword: {newPassword}}
+		return fields, nil
+	case "racf":
+		fields := map[*Field][]string{
+			FieldRegistry.RACFPassword:   {newPassword},
+			FieldRegistry.RACFAttributes: {"noexpire"},
+		}
+		return fields, nil
+	default:
+		return nil, fmt.Errorf("configured schema %s not valid", schema)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -425,7 +425,7 @@ github.com/hashicorp/vault-plugin-secrets-gcpkms
 github.com/hashicorp/vault-plugin-secrets-kv
 # github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.0-beta1
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas
-# github.com/hashicorp/vault-plugin-secrets-openldap v0.1.0-beta1
+# github.com/hashicorp/vault-plugin-secrets-openldap v0.1.0-beta1.0.20200304213227-4e174d6dcb2c
 github.com/hashicorp/vault-plugin-secrets-openldap
 github.com/hashicorp/vault-plugin-secrets-openldap/client
 # github.com/hashicorp/vault/api v1.0.5-0.20200215224050-f6547fa8e820 => ./api


### PR DESCRIPTION
Updating go.mod to include RACF support for the OpenLDAP secret engine: https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/5.