### PR TITLE
Added support for LDAP client certificate

### DIFF
--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -489,5 +489,12 @@ func getTLSConfig(cfg *ConfigEntry, host string) (*tls.Config, error) {
 		}
 		tlsConfig.RootCAs = caPool
 	}
+	if cfg.ClientCertificate != "" && cfg.ClientKey != "" {
+		cert, err := tls.X509KeyPair([]byte(cfg.ClientCertificate), []byte(cfg.ClientKey))
+		if err != nil {
+			return nil, fmt.Errorf("could not load Client Certificate")
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
 	return tlsConfig, nil
 }

--- a/website/pages/docs/auth/ldap.mdx
+++ b/website/pages/docs/auth/ldap.mdx
@@ -104,6 +104,8 @@ management tool.
 - `starttls` (bool, optional) - If true, issues a `StartTLS` command after establishing an unencrypted connection.
 - `insecure_tls` - (bool, optional) - If true, skips LDAP server SSL certificate verification - insecure, use with caution!
 - `certificate` - (string, optional) - CA certificate to use when verifying LDAP server certificate, must be x509 PEM encoded.
+- `clientcertificate` - (string, optional) - Client certificate to use when connecting to LDAP server, must be x509 PEM encoded.
+- `clientkey` - (string, optional) - Private key for Client certificate, must be x509 PEM encoded.
 
 ### Binding parameters
 
@@ -210,6 +212,25 @@ $ vault write auth/ldap/config \
     discoverdn=true \
     groupdn="ou=Groups,dc=example,dc=com" \
     certificate=@ldap_ca_cert.pem \
+    insecure_tls=false \
+    starttls=true
+...
+```
+
+### Scenario 4
+
+- G-Suite ldap service
+
+```
+$ vault write auth/ldap/config \
+    url="ldap://ldap.google.com" \
+    userdn="ou=Users,dc=example,dc=com" \
+    groupdn="ou=Groups,dc=example,dc=com" \
+    groupfilter="(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))" \
+    userattr="uid" \
+    groupattr="cn" \
+    clientcertificate=@Google_2023_02_05_35779.crt \
+    clientkey=@Google_2023_02_05_35779.key \
     insecure_tls=false \
     starttls=true
 ...


### PR DESCRIPTION
This commit adds support to use a client certificate when connecting to a ldap server for services requiring that (Such as G-Suites LDAP service)

Work sponsored by Speqta AB