### PR TITLE
Ui/transit key versions update

### DIFF
--- a/ui/app/styles/components/list-item-row.scss
+++ b/ui/app/styles/components/list-item-row.scss
@@ -26,4 +26,8 @@ a.list-item-row,
     box-shadow: 0 2px 0 -1px $grey-light, 0 -2px 0 -1px $grey-light, $box-link-hover-shadow,
       $box-shadow-middle;
   }
+
+  &.no-destination {
+    cursor: default;
+  }
 }

--- a/ui/app/templates/partials/transit-form-show.hbs
+++ b/ui/app/templates/partials/transit-form-show.hbs
@@ -99,35 +99,49 @@
       (eq key.type "chacha20-poly1305")
     )
   }}
-    <div class="columns is-mobile is-gapless is-marginless table">
-      <div class="column is-half thead">
-        <div class="th">
-          Version
-        </div>
-      </div>
-      <div class="column is-half thead">
-        <div class="th">
-          Created at
-        </div>
-      </div>
-    </div>
     {{#each-in key.keys as |version creationTimestamp|}}
-      <div class="columns is-mobile is-gapless is-marginless table" data-test-transit-key-version-row={{version}}>
-        <div class="column is-half td">
-          <div class="td is-borderless">
-            {{version}}
-            {{#if (coerce-eq key.minDecryptionVersion version)}}
-              <p class="help has-text-grey">(current minimum decryption version)</p>
-            {{/if}}
+      <div class="linked-block list-item-row" data-test-transit-key-version-row={{version}}>
+        <div class="columns is-mobile">
+          <div class="column is-3">
+            <div class="level level-left">
+              <Icon @glyph="history" class="has-text-grey-light is-padded" @size="l" />
+              <strong class="has-padding is-size-6">Version {{version}}</strong>
+            </div>
           </div>
-        </div>
-        <div class="column is-half td">
-          <div class="td is-borderless">
-            {{date-format creationTimestamp 'MMM DD, YYYY hh:mm:ss A'}}
-            <br />
-            <small class="is-font-mono has-text-grey">
-              {{date-format creationTimestamp }}
-            </small>
+          <div class="column is-4">
+            <div class="td is-borderless">
+              <small class="help has-text-grey">
+                {{date-from-now creationTimestamp addSuffix=true }}
+              </small>
+            </div>
+          </div>
+          <div class="column is-4">
+            <div class="td is-borderless">
+              {{#if (coerce-eq key.minDecryptionVersion version)}}
+                <p class="help level level-left">
+                  <Icon @glyph="check-circle-fill" class="has-text-success" />
+                  Current minimum decryption version
+                </p>
+              {{/if}}
+            </div>
+          </div>
+          <div class="column is-1 is-flex-end">
+            <PopupMenu name="secret-menu">
+              <nav class="menu">
+                <ul class="menu-list">
+                  <li class="action">
+                    {{#copy-button
+                      clipboardText=(get key.keys version)
+                      class="link button is-transparent"
+                      buttonType="button"
+                      success=(action (set-flash-message 'Public key copied!'))
+                    }}
+                      Copy Public Key
+                    {{/copy-button}}
+                  </li>
+                </ul>
+              </nav>
+            </PopupMenu>
           </div>
         </div>
       </div>

--- a/ui/app/templates/partials/transit-form-show.hbs
+++ b/ui/app/templates/partials/transit-form-show.hbs
@@ -115,7 +115,7 @@
               </small>
             </div>
           </div>
-          <div class="column is-4">
+          <div class="column is-5">
             <div class="td is-borderless">
               {{#if (coerce-eq key.minDecryptionVersion version)}}
                 <p class="help level level-left">
@@ -124,24 +124,6 @@
                 </p>
               {{/if}}
             </div>
-          </div>
-          <div class="column is-1 is-flex-end">
-            <PopupMenu name="secret-menu">
-              <nav class="menu">
-                <ul class="menu-list">
-                  <li class="action">
-                    {{#copy-button
-                      clipboardText=(get key.keys version)
-                      class="link button is-transparent"
-                      buttonType="button"
-                      success=(action (set-flash-message 'Public key copied!'))
-                    }}
-                      Copy Public Key
-                    {{/copy-button}}
-                  </li>
-                </ul>
-              </nav>
-            </PopupMenu>
           </div>
         </div>
       </div>

--- a/ui/app/templates/partials/transit-form-show.hbs
+++ b/ui/app/templates/partials/transit-form-show.hbs
@@ -105,7 +105,7 @@
           <div class="column is-3">
             <div class="level level-left">
               <Icon @glyph="history" class="has-text-grey-light is-padded" @size="l" />
-              <strong class="has-padding is-size-6">Version {{version}}</strong>
+              <strong class="has-padding is-size-5">Version {{version}}</strong>
             </div>
           </div>
           <div class="column is-4">
@@ -147,101 +147,52 @@
       </div>
     {{/each-in}}
   {{else}}
-    <div class="columns is-gapless is-marginless table">
-      <div class="column is-11 thead">
-        <div class="columns is-marginless is-gapless">
-          <div class="column is-one-third">
-            <div class="th">
-              Version
-            </div>
-          </div>
-          <div class="column  is-one-third">
-            <div class="th">
-              Name
-            </div>
-          </div>
-          <div class="column  is-one-third">
-            <div class="th">
-              Created at
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="column is-1 thead is-hidden-mobile">
-        <div class="column thead is-narrow">
-          <div class="th"></div>
-        </div>
-      </div>
-    </div>
     {{#each-in key.keys as |version meta|}}
-      <div class="columns is-gapless is-marginless table {{if (get this (concat version '-open')) 'has-background-grey-lighter' }}"
-        data-test-transit-key-version-row={{version}}>
-        <div class="column {{if (get this (concat version '-open')) '' 'td' }}">
-          <div class="columns is-marginless is-gapless">
-            <div class="column is-11">
-              <div class="columns is-marginless is-gapless">
-                <div class="column is-one-third">
-                  <div class="td is-borderless">
-                    {{version}}
-                    {{#if (coerce-eq key.minDecryptionVersion version)}}
-                      <p class="help has-text-grey">(current minimum decryption version)</p>
-                    {{/if}}
-                  </div>
-                </div>
-                <div class="column is-one-third">
-                  <div class="td is-borderless">
-                    {{meta.name}}
-                  </div>
-                </div>
-                <div class="column is-one-third">
-                  <div class="td is-borderless">
-                    <div>
-                      {{date-format meta.creation_time 'MMM DD, YYYY hh:mm:ss A'}}
-                      <br />
-                      <small class="is-font-mono has-text-grey">
-                        {{date-format meta.creation_time}}
-                      </small>
-                    </div>
-                  </div>
-                </div>
-              </div>
+    <div class="linked-block list-item-row" data-test-transit-key-version-row={{version}}>
+        <div class="columns is-mobile">
+          <div class="column is-3">
+            <div class="level level-left">
+              <Icon @glyph="history" class="has-text-grey-light is-padded" @size="l" />
+              <strong class="has-padding is-size-5">Version {{version}}</strong>
             </div>
-            <div class="column is-1 has-text-centered is-flex-v-centered">
-              <button class="button is-transparent" type="button" {{action (toggle (concat version '-open') this)}}>
-                <Icon
-                  @glyph="more-horizontal"
-                  class="has-text-black auto-width"
-                  aria-label={{concat backend.path " options"}}
-                />
-              </button>
+          </div>
+          <div class="column is-4">
+            <div class="td is-borderless">
+              <small class="help has-text-grey">
+                {{date-from-now meta.creation_time addSuffix=true }}
+              </small>
             </div>
+          </div>
+          <div class="column is-4">
+            <div class="td is-borderless">
+              {{#if (coerce-eq key.minDecryptionVersion version)}}
+                <p class="help level level-left">
+                  <Icon @glyph="check-circle-fill" class="has-text-success" />
+                  Current minimum decryption version
+                </p>
+              {{/if}}
+            </div>
+          </div>
+          <div class="column is-1 is-flex-end">
+            <PopupMenu name="secret-menu">
+              <nav class="menu">
+                <ul class="menu-list">
+                  <li class="action">
+                    {{#copy-button
+                      clipboardText=meta.public_key
+                      class="link button is-transparent"
+                      buttonType="button"
+                      success=(action (set-flash-message 'Public key copied!'))
+                    }}
+                      Copy Public Key
+                    {{/copy-button}}
+                  </li>
+                </ul>
+              </nav>
+            </PopupMenu>
           </div>
         </div>
       </div>
-      {{#if (get this (concat version '-open'))}}
-        <div class="table has-background-grey-lighter is-paddingless is-marginless">
-          <div class="td">
-            <div>
-              <span class="is-label">
-                Public Key
-              </span>
-              <pre class="has-background-transparent"><code class="is-paddingless">{{meta.public_key}}</code></pre>
-              <div class="box is-fullwidth has-background-transparent is-shadowless">
-                <div class="control">
-                  {{#copy-button
-                    clipboardText=meta.public_key
-                    class="button"
-                    buttonType="button"
-                    success=(action (set-flash-message (concat 'Public key for version ' version ' copied!')))
-                  }}
-                    Copy
-                  {{/copy-button}}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      {{/if}}
     {{/each-in}}
   {{/if}}
 {{else}}

--- a/ui/app/templates/partials/transit-form-show.hbs
+++ b/ui/app/templates/partials/transit-form-show.hbs
@@ -100,7 +100,7 @@
     )
   }}
     {{#each-in key.keys as |version creationTimestamp|}}
-      <div class="linked-block list-item-row" data-test-transit-key-version-row={{version}}>
+      <div class="linked-block list-item-row no-destination" data-test-transit-key-version-row={{version}}>
         <div class="columns is-mobile">
           <div class="column is-3">
             <div class="level level-left">


### PR DESCRIPTION
This change updates the styling for transit key versions. It also streamlines the process of copying the public key where applicable (see screenshots)

<img width="1221" alt="asymmetric-versions-new" src="https://user-images.githubusercontent.com/16182107/76003572-de5a7c00-5ecd-11ea-8ca4-4eddb6c4595a.png">
<img width="1213" alt="symmetric-versions-new" src="https://user-images.githubusercontent.com/16182107/76003578-df8ba900-5ecd-11ea-9ca6-4453147f32b1.png">

Note: because the list rows don't actually link to anywhere, I opted to use the "linked-block" class name instead of the component, which would cause a console error every time someone clicked the row.