### PR TITLE
Rename raft configuration command to list-peers and make output easier to read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Next
 
+CHANGES:
+
+* cli: The raft configuration command has been renamed to list-peers to avoid
+  confusion.
+
 IMPROVEMENTS:
 
 * auth/azure: subscription ID, resource group, vm and vmss names are now stored in alias metadata [[GH-30](https://github.com/hashicorp/vault-plugin-auth-azure/pull/30)]

--- a/command/commands.go
+++ b/command/commands.go
@@ -357,8 +357,8 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
-		"operator raft configuration": func() (cli.Command, error) {
-			return &OperatorRaftConfigurationCommand{
+		"operator raft list-peers": func() (cli.Command, error) {
+			return &OperatorRaftListPeersCommand{
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},

--- a/command/operator_raft.go
+++ b/command/operator_raft.go
@@ -28,13 +28,17 @@ Usage: vault operator raft <subcommand> [options] [args]
 
       $ vault operator raft join https://127.0.0.1:8200
 
-  Returns the raft cluster configuration:
+  Returns the set of raft peers:
 
-      $ vault operator raft configuration
+      $ vault operator raft list-peers
 
   Removes a node from the raft cluster:
 
       $ vault operator raft remove-peer
+
+  Restores and saves snapshots from the raft cluster:
+
+      $ vault operator raft snapshot take out.snap
 
   Please see the individual subcommand help for detailed usage information.
 `

--- a/command/operator_raft_listpeers.go
+++ b/command/operator_raft_listpeers.go
@@ -8,45 +8,45 @@ import (
 	"github.com/posener/complete"
 )
 
-var _ cli.Command = (*OperatorRaftConfigurationCommand)(nil)
-var _ cli.CommandAutocomplete = (*OperatorRaftConfigurationCommand)(nil)
+var _ cli.Command = (*OperatorRaftListPeersCommand)(nil)
+var _ cli.CommandAutocomplete = (*OperatorRaftListPeersCommand)(nil)
 
-type OperatorRaftConfigurationCommand struct {
+type OperatorRaftListPeersCommand struct {
 	*BaseCommand
 }
 
-func (c *OperatorRaftConfigurationCommand) Synopsis() string {
-	return "Returns the raft cluster configuration"
+func (c *OperatorRaftListPeersCommand) Synopsis() string {
+	return "Returns the raft peer set"
 }
 
-func (c *OperatorRaftConfigurationCommand) Help() string {
+func (c *OperatorRaftListPeersCommand) Help() string {
 	helpText := `
-Usage: vault operator raft configuration
+Usage: vault operator raft list-peers
 
   Provides the details of all the peers in the raft cluster.
 
-	  $ vault operator raft configuration
+	  $ vault operator raft list-peers
 
 ` + c.Flags().Help()
 
 	return strings.TrimSpace(helpText)
 }
 
-func (c *OperatorRaftConfigurationCommand) Flags() *FlagSets {
+func (c *OperatorRaftListPeersCommand) Flags() *FlagSets {
 	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
 
 	return set
 }
 
-func (c *OperatorRaftConfigurationCommand) AutocompleteArgs() complete.Predictor {
+func (c *OperatorRaftListPeersCommand) AutocompleteArgs() complete.Predictor {
 	return complete.PredictAnything
 }
 
-func (c *OperatorRaftConfigurationCommand) AutocompleteFlags() complete.Flags {
+func (c *OperatorRaftListPeersCommand) AutocompleteFlags() complete.Flags {
 	return c.Flags().Completions()
 }
 
-func (c *OperatorRaftConfigurationCommand) Run(args []string) int {
+func (c *OperatorRaftListPeersCommand) Run(args []string) int {
 	f := c.Flags()
 
 	if err := f.Parse(args); err != nil {

--- a/command/operator_raft_listpeers.go
+++ b/command/operator_raft_listpeers.go
@@ -66,6 +66,7 @@ func (c *OperatorRaftListPeersCommand) Run(args []string) int {
 		return 2
 	}
 	if secret == nil {
+		c.UI.Error("No raft cluster configuration found")
 		return 2
 	}
 


### PR DESCRIPTION
Old:
```
% vault3 operator raft configuration
Key       Value
---       -----
config    map[index:67 servers:[map[address:vault2:8201 leader:true node_id:node2 protocol_version:3 voter:true] map[address:vault3:8201 leader:false node_id:node3 protocol_version:3 voter:true] map[address:vault4:8201 leader:false node_id:node4 protocol_version:3 voter:true]]]
```

New:
```
% vault3 operator raft list-peers
Node     Address        State       Voter
----     -------        -----       -----
node2    vault2:8201    leader      true
node3    vault3:8201    follower    true
node4    vault4:8201    follower    true
```