### PR TITLE
API Docs: edits to OpenLDAP secrets engine

### DIFF
--- a/website/pages/api-docs/secret/openldap/index.mdx
+++ b/website/pages/api-docs/secret/openldap/index.mdx
@@ -15,7 +15,7 @@ This documentation assumes the OpenLDAP secrets engine is enabled at the `/openl
 in Vault. Since it is possible to mount secrets engines at any path, please
 update your API calls accordingly.
 
-## Configuration Management 
+## Configuration Management
 
 | Method   | Path               |
 | :-----   | :----------------- |
@@ -25,7 +25,7 @@ update your API calls accordingly.
 
 This endpoint configures the OpenLDAP secret engine to managed user entries.
 
-Note: the OpenLDAP entry used by `config` should have the neccessary privileges 
+Note: the OpenLDAP entry used by `config` should have the necessary privileges 
 to search and change entry passwords in OpenLDAP.
 
 ### Parameters
@@ -180,7 +180,7 @@ $ curl \
   "ttl": 86072,
   "username": "hashicorp"
 }
-``` 
+```
 
 ## Rotate Root Password
 


### PR DESCRIPTION
- Fix typo
- Remove trailing spaces