### PR TITLE
doc: update openldap with racf schema support

### DIFF
--- a/website/pages/api-docs/secret/openldap/index.mdx
+++ b/website/pages/api-docs/secret/openldap/index.mdx
@@ -33,6 +33,8 @@ to search and change entry passwords in OpenLDAP.
 - `binddn` `(string: <required>)` - Distinguished name (DN) of object to bind for managing user entries. Example: `cn=vault,ou=Users,dc=hashicorp,dc=com`
 - `bindpass` `(string: <required>)` - Password to use along with `binddn` for managing user entries.
 - `url` `(string: <optional>)` - The LDAP server to connect to. Examples: `ldaps://ldap.myorg.com`, `ldaps://ldap.myorg.com:636`. This can also be a comma-delineated list of URLs, e.g. `ldaps://ldap.myorg.com,ldaps://ldap.myorg.com:636`, in which case the servers will be tried in-order if there are errors during the connection process. Default is `ldap://127.0.0.1`.
+- `length` `(int: 64)` - The length of generated password strings.
+- `schema` `(string: openldap)` - The OpenLDAP schema to use when storing entry passwords.  Valid schemas include: `openldap` and `racf`.
 - `request_timeout` `(integer: 90, string: "90s" <optional>)` - Timeout, in seconds, for the connection when making requests against the server before returning back an error.
 - `starttls` `(bool: <optional>)` - If true, issues a `StartTLS` command after establishing an unencrypted connection.
 - `insecure_tls` - `(bool: <optional>)` - If true, skips LDAP server SSL certificate verification - insecure, use with caution!
@@ -77,6 +79,7 @@ $ curl \
     "certificate": "",
     "insecure_tls": false,
     "length": 64,
+    "schema": "openldap",
     "starttls": false,
     "tls_max_version": "tls12",
     "tls_min_version": "tls12",

--- a/website/pages/api-docs/secret/openldap/index.mdx
+++ b/website/pages/api-docs/secret/openldap/index.mdx
@@ -33,7 +33,7 @@ to search and change entry passwords in OpenLDAP.
 - `binddn` `(string: <required>)` - Distinguished name (DN) of object to bind for managing user entries. Example: `cn=vault,ou=Users,dc=hashicorp,dc=com`
 - `bindpass` `(string: <required>)` - Password to use along with `binddn` for managing user entries.
 - `url` `(string: <optional>)` - The LDAP server to connect to. Examples: `ldaps://ldap.myorg.com`, `ldaps://ldap.myorg.com:636`. This can also be a comma-delineated list of URLs, e.g. `ldaps://ldap.myorg.com,ldaps://ldap.myorg.com:636`, in which case the servers will be tried in-order if there are errors during the connection process. Default is `ldap://127.0.0.1`.
-- `length` `(int: 64)` - The length of generated password strings.
+- `length` `(int: 64)` - The length of generated password strings.  Note: some schemas may require shorter password lengths (such as `racf`).
 - `schema` `(string: "openldap")` - The OpenLDAP schema to use when storing entry passwords.  Valid schemas include: `openldap` and `racf`.
 - `request_timeout` `(integer: 90, string: "90s" <optional>)` - Timeout, in seconds, for the connection when making requests against the server before returning back an error.
 - `starttls` `(bool: <optional>)` - If true, issues a `StartTLS` command after establishing an unencrypted connection.

--- a/website/pages/api-docs/secret/openldap/index.mdx
+++ b/website/pages/api-docs/secret/openldap/index.mdx
@@ -34,7 +34,7 @@ to search and change entry passwords in OpenLDAP.
 - `bindpass` `(string: <required>)` - Password to use along with `binddn` for managing user entries.
 - `url` `(string: <optional>)` - The LDAP server to connect to. Examples: `ldaps://ldap.myorg.com`, `ldaps://ldap.myorg.com:636`. This can also be a comma-delineated list of URLs, e.g. `ldaps://ldap.myorg.com,ldaps://ldap.myorg.com:636`, in which case the servers will be tried in-order if there are errors during the connection process. Default is `ldap://127.0.0.1`.
 - `length` `(int: 64)` - The length of generated password strings.
-- `schema` `(string: openldap)` - The OpenLDAP schema to use when storing entry passwords.  Valid schemas include: `openldap` and `racf`.
+- `schema` `(string: "openldap")` - The OpenLDAP schema to use when storing entry passwords.  Valid schemas include: `openldap` and `racf`.
 - `request_timeout` `(integer: 90, string: "90s" <optional>)` - Timeout, in seconds, for the connection when making requests against the server before returning back an error.
 - `starttls` `(bool: <optional>)` - If true, issues a `StartTLS` command after establishing an unencrypted connection.
 - `insecure_tls` - `(bool: <optional>)` - If true, skips LDAP server SSL certificate verification - insecure, use with caution!

--- a/website/pages/docs/secrets/openldap/index.mdx
+++ b/website/pages/docs/secrets/openldap/index.mdx
@@ -61,6 +61,39 @@ This plugin currently supports LDAP v3.
     $ vault read openldap/static-role/hashicorp
     ```
 
+## Schema
+
+The OpenLDAP Secret Engine supports two different schemas: `openldap` (default) and 
+`racf`. 
+
+### OpenLDAP
+
+By default the OpenLDAP Secret Engine assumes the entry password is stored in `userPassword`.  
+The following object classes provide `userPassword`:
+
+* `organization`
+* `organizationalUnit`
+* `person`
+* `posixAccount`
+
+### Resource Access Control Facility (RACF)
+
+For managing IBM's Resource Access Control Facility (RACF) security system, the secret 
+engine must be configured to use the schema `racf`.
+
+Generated passwords must be 8 characters or less to support RACF.  The length of the 
+password can be configured as shown:
+
+```bash
+
+vault write openldap/config \
+	binddn=$USERNAME \
+	bindpass=$PASSWORD \
+	url=ldaps://138.91.247.105 \
+    schema=racf \
+    length=8
+```
+
 ## Password Rotation
 
 Passwords can be managed in two ways:


### PR DESCRIPTION
This adds the supporting `racf` schema documentation and extra guidance/requirements around the default `openldap` schema.