### PR TITLE
Unique lock key based on database and table name

### DIFF
--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -574,7 +574,7 @@ func NewMySQLLock(in *MySQLBackend, l log.Logger, key, value string) (*MySQLLock
 	conn, _ := NewMySQLClient(in.conf, in.logger)
 
 	// If multiple instances of Vault deployment trying to use the same MySQL
-	// DB endpoint first deployment will hold lock forever and others
+	// DB endpoint, the first deployment will hold lock forever and others
 	// deployment will fail to insert record in the lock table,
 	// the unique lock key will resolve this problem.
 	lockKey := key + "/" + in.conf["database"] + "/" + in.conf["table"]

--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -573,12 +573,18 @@ func NewMySQLLock(in *MySQLBackend, l log.Logger, key, value string) (*MySQLLock
 	// the rest of the MySQL backend and any cleanup that might need to be done.
 	conn, _ := NewMySQLClient(in.conf, in.logger)
 
+	// If multiple instances of Vault deployment trying to use the same MySQL
+	// DB endpoint first deployment will hold lock forever and others
+	// deployment will fail to insert record in the lock table,
+	// the unique lock key will resolve this problem.
+	lockKey := key + "/" + in.conf["database"] + "/" + in.conf["table"]
+
 	m := &MySQLLock{
 		parentConn: in,
 		in:         conn,
 		logger:     l,
 		statements: make(map[string]*sql.Stmt),
-		key:        key,
+		key:        lockKey,
 		value:      value,
 	}
 


### PR DESCRIPTION
If multiple instances of Vault deployment trying to use the same MySQL DB endpoint, the first deployment will hold lock forever and others deployment will fail to insert record in the lock table, which is causing the following issue,

```

URL: GET https://127.0.0.1:8200/v1/sys/leader
Code: 500. Errors:

* SQL: no rows in result set
```

The unique lock key per vault deployment will resolve this problem.