### PR TITLE
Add workflow to auto-add any GitHub Issue labeled 'bug' to an internal project board

### DIFF
--- a/.github/workflows/sustain-bugs.yml
+++ b/.github/workflows/sustain-bugs.yml
@@ -1,0 +1,23 @@
+name: sustain
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Maybe move an issue to the project board
+      uses: actions/github-script@0.4.0
+      if: github.event.label.name == 'bug'
+      with: 
+        github-token: ${{secrets.GITHUB_TOKEN}}
+      env: 
+        column_id: ${{ secrets.PROJECT_COLUMN_ID }}
+        script: |            
+            github.projects.createCard({
+              column_id: ${COLUMN_ID},
+              content_id: context.payload.issue.id,
+              content_type: "Issue"
+            })

--- a/.github/workflows/sustain-bugs.yml
+++ b/.github/workflows/sustain-bugs.yml
@@ -11,7 +11,7 @@ jobs:
       PROJECT_COLUMN_ID: ${{secrets.PROJECT_COLUMN_ID}}
     steps:
     - name: Maybe move an issue to the project board
-      uses: actions/github-script@0.4.0
+      uses: actions/github-script@0.8.0
       if: github.event.label.name == 'bug'
       with: 
         github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/sustain-bugs.yml
+++ b/.github/workflows/sustain-bugs.yml
@@ -7,17 +7,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env: 
+      PROJECT_COLUMN_ID: ${{secrets.PROJECT_COLUMN_ID}}
     steps:
     - name: Maybe move an issue to the project board
       uses: actions/github-script@0.4.0
       if: github.event.label.name == 'bug'
       with: 
         github-token: ${{secrets.GITHUB_TOKEN}}
-      env: 
-        column_id: ${{ secrets.PROJECT_COLUMN_ID }}
         script: |            
             github.projects.createCard({
-              column_id: ${COLUMN_ID},
+              column_id: process.env.PROJECT_COLUMN_ID,
               content_id: context.payload.issue.id,
               content_type: "Issue"
             })


### PR DESCRIPTION
For internal processes, any GitHub issue on this repository labeled as `bug` will be auto-added to an internal project for triage. `PROJECT_COLUMN_ID` references an encrypted secret added to this repo