### PR TITLE
Postgres: Correct parsing of multiline statements

### DIFF
--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -528,7 +528,7 @@ func containsMultilineStatement(stmt string) bool {
 	if err != nil {
 		return false
 	}
-	stmtWithoutLiterals := ""
+	stmtWithoutLiterals := stmt
 	for _, literal := range literals {
 		stmtWithoutLiterals = strings.Replace(stmt, literal, "", -1)
 	}

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -556,7 +556,7 @@ func containsMultilineStatement(stmt string) bool {
 // extractQuotedStrings extracts 0 or many substrings
 // that have been single- or double-quoted. Ex:
 // `"Hello", silly 'elephant' from the "zoo".`
-// returns [ `doubleQuotedPhrases.FindAllString(s, -1)`, `'elephant'`, `"zoo"` ]
+// returns [ `Hello`, `'elephant'`, `"zoo"` ]
 func extractQuotedStrings(s string) ([]string, error) {
 	var found []string
 	toFind := []*regexp.Regexp{

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -547,14 +547,14 @@ func extractQuotedStrings(s string) ([]string, error) {
 	var result []string
 
 	// Find all double-quoted sub-strings.
-	reg, err := regexp.Compile(`"(.*?)"`)
+	reg, err := regexp.Compile(`(".*?")`)
 	if err != nil {
 		return nil, err
 	}
 	result = append(result, reg.FindAllString(s, -1)...)
 
 	// Find all single-quoted sub-strings.
-	reg, err = regexp.Compile(`'(.*?)'`)
+	reg, err = regexp.Compile(`('.*?')`)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/database/postgresql/postgresql_test.go
+++ b/plugins/database/postgresql/postgresql_test.go
@@ -696,12 +696,12 @@ func TestContainsMultilineStatement(t *testing.T) {
 			Expected: true,
 		},
 		"multiline with template fields": {
-			Input:    `DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname=\"{{name}}\") THEN CREATE ROLE {{name}}; END IF; END $$`,
+			Input:    `DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname="{{name}}") THEN CREATE ROLE {{name}}; END IF; END $$`,
 			Expected: true,
 		},
 		"docs example": {
-			Input: `CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
-        GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";`,
+			Input: `CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
+        GRANT SELECT ON ALL TABLES IN SCHEMA public TO "{{name}}";`,
 			Expected: false,
 		},
 	}
@@ -739,8 +739,8 @@ func TestExtractQuotedStrings(t *testing.T) {
 			Expected: []string{},
 		},
 		"templated field": {
-			Input:    `DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname=\"{{name}}\") THEN CREATE ROLE {{name}}; END IF; END $$`,
-			Expected: []string{`"{{name}}\"`},
+			Input:    `DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname="{{name}}") THEN CREATE ROLE {{name}}; END IF; END $$`,
+			Expected: []string{`"{{name}}"`},
 		},
 	}
 

--- a/plugins/database/postgresql/postgresql_test.go
+++ b/plugins/database/postgresql/postgresql_test.go
@@ -161,7 +161,8 @@ func TestPostgreSQL_CreateUser(t *testing.T) {
 			},
 			shouldTestCredsExist: true,
 		},
-		"reproduce https://github.com/hashicorp/vault/issues/6098": {
+		// https://github.com/hashicorp/vault/issues/6098
+		"reproduce GH-6098": {
 			createStmts: []string{
 				// NOTE: "rolname" in the following line is not a typo.
 				"DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname='my_role') THEN CREATE ROLE my_role; END IF; END $$",


### PR DESCRIPTION
Fixes #6098 

Postgres was splitting statements on a semicolon. This would be fine normally, but sometimes people do send statements with semicolons that need to be parsed as a single query.

Example:
```
// User sends:
DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname='my_role') THEN CREATE ROLE my_role; END IF; END $$

// In the current state, Postgres executes the first piece as an independent piece
// causing a syntax error: 
DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname='my_role') THEN CREATE ROLE my_role

// After this PR, it will be sent as the original syntax:
DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname='my_role') THEN CREATE ROLE my_role; END IF; END $$
```