### PR TITLE
Bug Fix: remove duplicate form inputs on GitHub auth config page

### DIFF
--- a/ui/app/models/auth-config/github.js
+++ b/ui/app/models/auth-config/github.js
@@ -19,7 +19,6 @@ export default AuthConfig.extend({
       {
         'GitHub Options': ['baseUrl'],
       },
-      { TTLs: ['ttl', 'maxTtl'] },
     ];
     if (this.newFields) {
       groups = combineFieldGroups(groups, this.newFields, []);


### PR DESCRIPTION
There were two form inputs under "Hide TTLs" on the GitHub Auth configuration page.  The bug originally reported that they didn't have any actual input options, just the label.  However, under further investigation, they appear to be duplicates or unused form inputs.  I compared all the API parameters we use for the GitHub `auth/github/config` endpoint and determined none were missing.  

This PR removes these two labels with no inputs from the GitHub auth config page.

**Here were the inputs before the fix:**
<img width=300 src="https://user-images.githubusercontent.com/6618863/76326545-6796f780-62ae-11ea-8591-729a3c758982.png">

**Here is after the fix:**
<img width=300 src="https://user-images.githubusercontent.com/6618863/76326224-f5beae00-62ad-11ea-9b71-c40284a3d287.png">

