### PR TITLE
storage/raft: Refresh TLS keyring on snapshot restore

### DIFF
--- a/vault/raft.go
+++ b/vault/raft.go
@@ -484,6 +484,12 @@ func (c *Core) raftSnapshotRestoreCallback(grabLock bool, sealNode bool) func(co
 		// Purge the cache so we make sure we are operating on fresh data
 		c.physicalCache.Purge(ctx)
 
+		// Refresh the raft TLS keys
+		if err := c.checkRaftTLSKeyUpgrades(ctx); err != nil {
+			c.logger.Info("failed to perform TLS key upgrades, sealing", "error", err)
+			return err
+		}
+
 		// Reload the keyring in case it changed. If this fails it's likely
 		// we've changed master keys.
 		err := c.performKeyUpgrades(ctx)


### PR DESCRIPTION
If a snapshot is applied that has an older TLS keyring term the keyring wouldn't be updated right away. It would be updated later at a cadence but this ensures we can start generating new connections right away. 