### PR TITLE
storage/raft: Fix leadership deadlock

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -1002,8 +1002,11 @@ func (l *RaftLock) monitorLeadership(stopCh <-chan struct{}, leaderNotifyCh <-ch
 		for {
 			select {
 			case isLeader := <-leaderNotifyCh:
-				// if isLeader is true we want to continue to loop until we see
-				// a notification that we lost leadership.
+				// leaderNotifyCh may deliver a true value initially if this
+				// server is already the leader prior to RaftLock.Lock call
+				// (the true message was already queued). The next message is
+				// always going to be false. The for loop should loop at most
+				// twice.
 				if !isLeader {
 					close(leaderLost)
 					return


### PR DESCRIPTION
This fixes a potential deadlock due to a race that could occur in this block of code:

https://github.com/hashicorp/vault/blob/351d3ace7dece526efdcc85b98a091a976325667/physical/raft/raft.go#L1028-L1073

If the node is already reporting as leader before we get to this function than the leader notification will not be read from the `leaderNotifyCh`. If this occurs, when the monitor leadership code is run, `true` will be read off the channel and exit early:

https://github.com/hashicorp/vault/blob/351d3ace7dece526efdcc85b98a091a976325667/physical/raft/raft.go#L999-L1011

If that go routine exits early then Vault is deadlocked waiting for leadership to be lost. If, at any point afterwards, raft loses and gains leadership then the raft thread will also be deadlocked since no one is listening on the `leaderNotifyCh` anymore. 

This PR adds a loop to monitor leadership so we can continue to wait for a `false` value to come down the `leaderNotifyCh`. 