### PR TITLE
Update database docs

### DIFF
--- a/website/data/api-navigation.js
+++ b/website/data/api-navigation.js
@@ -30,8 +30,9 @@ export default [
           'mongodbatlas',
           'mssql',
           'mysql-maria',
+          'oracle',
           'postgresql',
-          'oracle'
+          'redshift'
         ]
       },
       { category: 'gcp' },

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -224,8 +224,9 @@ export default [
           'mongodbatlas',
           'mssql',
           'mysql-maria',
-          'postgresql',
           'oracle',
+          'postgresql',
+          'redshift',
           'custom'
         ]
       },

--- a/website/pages/docs/secrets/databases/mongodb.mdx
+++ b/website/pages/docs/secrets/databases/mongodb.mdx
@@ -12,7 +12,8 @@ description: |-
 
 MongoDB is one of the supported plugins for the database secrets engine. This
 plugin generates database credentials dynamically based on configured roles for
-the MongoDB database.
+the MongoDB database and also supports
+[Static Roles](/docs/secrets/databases#static-roles).
 
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.


### PR DESCRIPTION
Redshift was missing from the sidebars, as was a reference to static
roles in MongoDB.