### PR TITLE
Bug fix: add in missing curly braces to demote danger message

### DIFF
--- a/ui/lib/core/addon/templates/components/replication-action-demote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-demote.hbs
@@ -14,7 +14,7 @@
         @message="Demoting this DR primary cluster
           would result in a DR secondary and in that mode Vault is read-only. This
           cluster is also currently operating as a Performance
-          capitalize {{model.performance.modeForUrl}}, demoting it will leave your
+          {{capitalize model.performance.modeForUrl}}, demoting it will leave your
           replication setup without a performance primary cluster until a new
           cluster is promoted."
       />

--- a/ui/lib/core/addon/templates/components/replication-action-demote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-demote.hbs
@@ -14,7 +14,7 @@
         @message="Demoting this DR primary cluster
           would result in a DR secondary and in that mode Vault is read-only. This
           cluster is also currently operating as a Performance
-          capitalize model.performance.modeForUrl}}, demoting it will leave your
+          capitalize {{model.performance.modeForUrl}}, demoting it will leave your
           replication setup without a performance primary cluster until a new
           cluster is promoted."
       />

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -11,3 +11,8 @@
 
 [context.deploy-preview]
   environment = { HASHI_ENV = "staging" }
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"


### PR DESCRIPTION
Ivana noticed this error.  It was a simple fix, we were just missing the opening curly braces around the variable.  

**Before the fix:**
<img width=700 src="https://user-images.githubusercontent.com/6618863/76644585-e09b8680-651c-11ea-8636-9e516f502428.png">

**With the fix:**
<img width=700 src="https://user-images.githubusercontent.com/6618863/76644649-0e80cb00-651d-11ea-986f-5c2a2e10057a.png">

