### PR TITLE
Enable encrypted config parameters

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -330,6 +330,22 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"operator config": func() (cli.Command, error) {
+			return &OperatorConfigCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"operator config decrypt": func() (cli.Command, error) {
+			return &OperatorConfigEncryptDecryptCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"operator config encrypt": func() (cli.Command, error) {
+			return &OperatorConfigEncryptDecryptCommand{
+				BaseCommand: getBaseCommand(),
+				encrypt:     true,
+			}, nil
+		},
 		"operator generate-root": func() (cli.Command, error) {
 			return &OperatorGenerateRootCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/operator_config.go
+++ b/command/operator_config.go
@@ -1,0 +1,42 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+)
+
+var _ cli.Command = (*OperatorConfigCommand)(nil)
+
+type OperatorConfigCommand struct {
+	*BaseCommand
+}
+
+func (c *OperatorConfigCommand) Synopsis() string {
+	return "Manage sensitive values in Vault's configuration files"
+}
+
+func (c *OperatorConfigCommand) Help() string {
+	helpText := `
+Usage: vault operator config <subcommand> [options] [args]
+
+  This command groups subcommands for operators interacting with Vault's
+  config files. Here are a few examples of config operator commands:
+
+  Encrypt sensitive values in a config file:
+
+      $ vault operator config encrypt config.hcl
+
+  Decrypt sensitive values in a config file:
+
+      $ vault operator config decrypt config.hcl
+
+  Please see the individual subcommand help for detailed usage information.
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorConfigCommand) Run(args []string) int {
+	return cli.RunResultHelp
+}

--- a/command/operator_config_encryptdecrypt.go
+++ b/command/operator_config_encryptdecrypt.go
@@ -1,0 +1,183 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/vault/internalshared/configutil"
+	"github.com/hashicorp/vault/sdk/helper/strutil"
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+var _ cli.Command = (*OperatorConfigEncryptDecryptCommand)(nil)
+var _ cli.CommandAutocomplete = (*OperatorConfigEncryptDecryptCommand)(nil)
+
+type OperatorConfigEncryptDecryptCommand struct {
+	*BaseCommand
+	encrypt bool
+
+	flagOverwrite bool
+	flagStrip     bool
+}
+
+func (c *OperatorConfigEncryptDecryptCommand) Synopsis() string {
+	dir := "Decrypts"
+	if c.encrypt {
+		dir = "Encrypts"
+	}
+	return fmt.Sprintf("%s sensitive values in Vault's configuration file", dir)
+}
+
+func (c *OperatorConfigEncryptDecryptCommand) Help() string {
+	subCmd := "Decrypt"
+	if c.encrypt {
+		subCmd = "Encrypt"
+	}
+	helpText := `
+Usage: vault operator config %s [options] [args]
+
+  %s sensitive values in a Vault configuration file. These values must be marked
+  with {{%s()}} as appropriate.
+
+  By default this will print the new configuration out. To overwrite into the same
+  file use the -overwrite flag.
+
+      $ vault operator config %s -overwrite config.hcl
+`
+	helpText = fmt.Sprintf(helpText, strings.ToLower(subCmd), subCmd, strings.ToLower(subCmd), strings.ToLower(subCmd))
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorConfigEncryptDecryptCommand) Flags() *FlagSets {
+	set := c.flagSet(0)
+
+	f := set.NewFlagSet("Command Options")
+
+	f.BoolVar(&BoolVar{
+		Name:   "overwrite",
+		Target: &c.flagOverwrite,
+		Usage:  "Overwrite the existing file.",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:   "strip",
+		Target: &c.flagStrip,
+		Usage:  "Strip the declarations from the file afterwards.",
+	})
+
+	return set
+}
+
+func (c *OperatorConfigEncryptDecryptCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictAnything
+}
+
+func (c *OperatorConfigEncryptDecryptCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *OperatorConfigEncryptDecryptCommand) Run(args []string) (ret int) {
+	op := "decrypt"
+	if c.encrypt {
+		op = "encrypt"
+	}
+
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	path := ""
+	args = f.Args()
+	switch len(args) {
+	case 1:
+		path = strings.TrimSpace(args[0])
+	default:
+		c.UI.Error(fmt.Sprintf("Incorrect arguments (expected 1, got %d)", len(args)))
+		return 1
+	}
+
+	if path == "" {
+		c.UI.Error("A configuration file must be specified")
+		return 1
+	}
+
+	kmses, err := configutil.LoadConfigKMSes(path)
+	if err != nil {
+		c.UI.Error(fmt.Errorf("Error loading configuration from %s: %w", path, err).Error())
+		return 1
+	}
+
+	var kms *configutil.KMS
+	for _, v := range kmses {
+		if strutil.StrListContains(v.Purpose, "config") {
+			if kms != nil {
+				c.UI.Error("Only one seal/kms block marked for \"config\" purpose is allowed")
+				return 1
+			}
+			kms = v
+		}
+	}
+	if kms == nil {
+		c.UI.Error("No seal/kms block with \"config\" purpose defined in the configuration file")
+		return 1
+	}
+
+	d, err := ioutil.ReadFile(path)
+	if err != nil {
+		c.UI.Error(fmt.Errorf("Error reading config file: %w", err).Error())
+		return 1
+	}
+
+	raw := string(d)
+
+	wrapper, err := configutil.ConfigureWrapper(kms, nil, nil, nil)
+	if err != nil {
+		c.UI.Error(fmt.Errorf("Error creating kms: %w", err).Error())
+		return 1
+	}
+
+	wrapper.Init(context.Background())
+	defer wrapper.Finalize(context.Background())
+
+	raw, err = configutil.EncryptDecrypt(raw, !c.encrypt, c.flagStrip, wrapper)
+	if err != nil {
+		c.UI.Error(fmt.Errorf("Error %sing via kms: %w", op, err).Error())
+		return 1
+	}
+
+	if !c.flagOverwrite {
+		c.UI.Output(raw)
+		return 0
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		c.UI.Error(fmt.Errorf("Error opening file for writing: %w", err).Error())
+		return 1
+	}
+
+	defer func() {
+		if err := file.Close(); err != nil {
+			c.UI.Error(fmt.Errorf("Error closing file after writing: %w", err).Error())
+			ret = 1
+		}
+	}()
+
+	n, err := file.WriteString(raw)
+	if err != nil {
+		c.UI.Error(fmt.Errorf("Error writing to file: %w", err).Error())
+		return 1
+	}
+	if n != len(raw) {
+		c.UI.Error(fmt.Sprintf("Wrong number of bytes written to file, expected %d, wrote %d", len(raw), n))
+	}
+
+	return 0
+}

--- a/command/operator_config_encryptdecrypt.go
+++ b/command/operator_config_encryptdecrypt.go
@@ -41,7 +41,10 @@ func (c *OperatorConfigEncryptDecryptCommand) Help() string {
 Usage: vault operator config %s [options] [args]
 
   %s sensitive values in a Vault configuration file. These values must be marked
-  with {{%s()}} as appropriate.
+  with {{%s()}} as appropriate. This can only be used with string parameters, and
+  the markers must be inside the quote marks delimiting the string; as an example:
+
+      foo = "{{encrypt(bar)}}"
 
   By default this will print the new configuration out. To overwrite into the same
   file use the -overwrite flag.

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -308,7 +308,7 @@ func LoadConfigFile(path string, kms *configutil.KMS) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		raw, err = configutil.EncryptDecrypt(raw, true, wrapper)
+		raw, err = configutil.EncryptDecrypt(raw, true, true, wrapper)
 		if err != nil {
 			return nil, err
 		}

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -28,9 +29,6 @@ type Config struct {
 	HAStorage *Storage `hcl:"-"`
 
 	ServiceRegistration *ServiceRegistration `hcl:"-"`
-
-	Seals   []*configutil.KMS   `hcl:"-"`
-	Entropy *configutil.Entropy `hcl:"-"`
 
 	CacheSize                int         `hcl:"cache_size"`
 	DisableCache             bool        `hcl:"-"`
@@ -308,6 +306,10 @@ func LoadConfigFile(path string, kms *configutil.KMS) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		wrapper.Init(context.Background())
+		defer wrapper.Finalize(context.Background())
+
 		raw, err = configutil.EncryptDecrypt(raw, true, true, wrapper)
 		if err != nil {
 			return nil, err

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -13,7 +13,7 @@ import (
 )
 
 func testConfigRaftRetryJoin(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/raft_retry_join.hcl")
+	config, err := LoadConfigFile("./test-fixtures/raft_retry_join.hcl", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func testConfigRaftRetryJoin(t *testing.T) {
 }
 
 func testLoadConfigFile_topLevel(t *testing.T, entropy *configutil.Entropy) {
-	config, err := LoadConfigFile("./test-fixtures/config2.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config2.hcl", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -128,7 +128,7 @@ func testLoadConfigFile_topLevel(t *testing.T, entropy *configutil.Entropy) {
 }
 
 func testLoadConfigFile_json2(t *testing.T, entropy *configutil.Entropy) {
-	config, err := LoadConfigFile("./test-fixtures/config2.hcl.json")
+	config, err := LoadConfigFile("./test-fixtures/config2.hcl.json", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -271,7 +271,7 @@ func testParseEntropy(t *testing.T, oss bool) {
 }
 
 func testLoadConfigFile(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config.hcl", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -352,7 +352,7 @@ func testLoadConfigFile(t *testing.T) {
 }
 
 func testLoadConfigFile_json(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config.hcl.json")
+	config, err := LoadConfigFile("./test-fixtures/config.hcl.json", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -426,7 +426,7 @@ func testLoadConfigFile_json(t *testing.T) {
 }
 
 func testLoadConfigDir(t *testing.T) {
-	config, err := LoadConfigDir("./test-fixtures/config-dir")
+	config, err := LoadConfigDir("./test-fixtures/config-dir", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -481,7 +481,7 @@ func testLoadConfigDir(t *testing.T) {
 }
 
 func testConfig_Sanitized(t *testing.T) {
-	config, err := LoadConfigFile("./test-fixtures/config3.hcl")
+	config, err := LoadConfigFile("./test-fixtures/config3.hcl", nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -262,7 +262,7 @@ func testParseEntropy(t *testing.T, oss bool) {
 		},
 	}
 
-	var config Config
+	config := NewConfig()
 
 	for _, test := range tests {
 		obj, _ := hcl.Parse(strings.TrimSpace(test.inConfig))

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -49,6 +49,15 @@ func LoadConfigFile(path string) (*SharedConfig, error) {
 	return ParseConfig(string(d))
 }
 
+func LoadConfigKMSes(path string) ([]*KMS, error) {
+	// Read the file
+	d, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKMSes(string(d))
+}
+
 func ParseConfig(d string) (*SharedConfig, error) {
 	// Parse!
 	obj, err := hcl.Parse(d)
@@ -82,19 +91,19 @@ func ParseConfig(d string) (*SharedConfig, error) {
 	}
 
 	if o := list.Filter("hsm"); len(o.Items) > 0 {
-		if err := parseKMS(&result, o, "hsm", 2); err != nil {
+		if err := parseKMS(&result.Seals, o, "hsm", 2); err != nil {
 			return nil, errwrap.Wrapf("error parsing 'hsm': {{err}}", err)
 		}
 	}
 
 	if o := list.Filter("seal"); len(o.Items) > 0 {
-		if err := parseKMS(&result, o, "seal", 3); err != nil {
+		if err := parseKMS(&result.Seals, o, "seal", 3); err != nil {
 			return nil, errwrap.Wrapf("error parsing 'seal': {{err}}", err)
 		}
 	}
 
 	if o := list.Filter("kms"); len(o.Items) > 0 {
-		if err := parseKMS(&result, o, "kms", 3); err != nil {
+		if err := parseKMS(&result.Seals, o, "kms", 3); err != nil {
 			return nil, errwrap.Wrapf("error parsing 'kms': {{err}}", err)
 		}
 	}

--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -85,19 +85,19 @@ func ParseConfig(d string) (*SharedConfig, error) {
 	}
 
 	if o := list.Filter("hsm"); len(o.Items) > 0 {
-		if err := parseKMS(&result, o, "hsm", 1); err != nil {
+		if err := parseKMS(&result, o, "hsm", 2); err != nil {
 			return nil, errwrap.Wrapf("error parsing 'hsm': {{err}}", err)
 		}
 	}
 
 	if o := list.Filter("seal"); len(o.Items) > 0 {
-		if err := parseKMS(&result, o, "seal", 2); err != nil {
+		if err := parseKMS(&result, o, "seal", 3); err != nil {
 			return nil, errwrap.Wrapf("error parsing 'seal': {{err}}", err)
 		}
 	}
 
 	if o := list.Filter("kms"); len(o.Items) > 0 {
-		if err := parseKMS(&result, o, "kms", 2); err != nil {
+		if err := parseKMS(&result, o, "kms", 3); err != nil {
 			return nil, errwrap.Wrapf("error parsing 'kms': {{err}}", err)
 		}
 	}
@@ -130,7 +130,7 @@ func ParseConfig(d string) (*SharedConfig, error) {
 
 func parseKMS(result *SharedConfig, list *ast.ObjectList, blockName string, maxKMS int) error {
 	if len(list.Items) > maxKMS {
-		return fmt.Errorf("only two or less %q blocks are permitted", blockName)
+		return fmt.Errorf("only %d or less %q blocks are permitted", maxKMS, blockName)
 	}
 
 	seals := make([]*KMS, 0, len(list.Items))

--- a/internalshared/configutil/encrypt_decrypt.go
+++ b/internalshared/configutil/encrypt_decrypt.go
@@ -17,17 +17,22 @@ var (
 	decryptRegex = regexp.MustCompile(`{{decrypt\(.*\)}}`)
 )
 
-func EncryptDecrypt(rawStr string, decrypt bool, wrapper wrapping.Wrapper) (string, error) {
+func EncryptDecrypt(rawStr string, decrypt, strip bool, wrapper wrapping.Wrapper) (string, error) {
 	var locs [][]int
 	raw := []byte(rawStr)
 	searchVal := "{{encrypt("
 	replaceVal := "{{decrypt("
+	suffixVal := ")}}"
 	if decrypt {
 		searchVal = "{{decrypt("
 		replaceVal = "{{encrypt("
 		locs = decryptRegex.FindAllIndex(raw, -1)
 	} else {
 		locs = encryptRegex.FindAllIndex(raw, -1)
+	}
+	if strip {
+		replaceVal = ""
+		suffixVal = ""
 	}
 
 	out := make([]byte, 0, len(rawStr)*2)
@@ -78,7 +83,7 @@ func EncryptDecrypt(rawStr string, decrypt bool, wrapper wrapping.Wrapper) (stri
 		}
 
 		// Append new value
-		out = append(out, []byte(fmt.Sprintf("%s%s)}}", replaceVal, finalVal))...)
+		out = append(out, []byte(fmt.Sprintf("%s%s%s", replaceVal, finalVal, suffixVal))...)
 		prevMaxLoc = match[1]
 	}
 	// At the end, append the rest

--- a/internalshared/configutil/encrypt_decrypt.go
+++ b/internalshared/configutil/encrypt_decrypt.go
@@ -1,0 +1,87 @@
+package configutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/gogo/protobuf/proto"
+	wrapping "github.com/hashicorp/go-kms-wrapping"
+)
+
+var (
+	encryptRegex = regexp.MustCompile(`{{encrypt\(.*\)}}`)
+	decryptRegex = regexp.MustCompile(`{{decrypt\(.*\)}}`)
+)
+
+func EncryptDecrypt(rawStr string, decrypt bool, wrapper wrapping.Wrapper) (string, error) {
+	var locs [][]int
+	raw := []byte(rawStr)
+	searchVal := "{{encrypt("
+	replaceVal := "{{decrypt("
+	if decrypt {
+		searchVal = "{{decrypt("
+		replaceVal = "{{encrypt("
+		locs = decryptRegex.FindAllIndex(raw, -1)
+	} else {
+		locs = encryptRegex.FindAllIndex(raw, -1)
+	}
+
+	out := make([]byte, 0, len(rawStr)*2)
+	var prevMaxLoc int
+	for _, match := range locs {
+		if len(match) != 2 {
+			return "", fmt.Errorf("expected two values for match, got %d", len(match))
+		}
+
+		// Append everything from the end of the last match to the beginning of this one
+		out = append(out, raw[prevMaxLoc:match[0]]...)
+
+		// Transform. First pull off the suffix/prefix
+		matchBytes := raw[match[0]:match[1]]
+		matchBytes = bytes.TrimSuffix(bytes.TrimPrefix(matchBytes, []byte(searchVal)), []byte(")}}"))
+		var finalVal string
+
+		// Now encrypt or decrypt
+		switch decrypt {
+		case false:
+			outBlob, err := wrapper.Encrypt(context.Background(), matchBytes, nil)
+			if err != nil {
+				return "", fmt.Errorf("error encrypting parameter: %w", err)
+			}
+			if outBlob == nil {
+				return "", errors.New("nil value returned from encrypting parameter")
+			}
+			outMsg, err := proto.Marshal(outBlob)
+			if err != nil {
+				return "", fmt.Errorf("error marshaling encrypted parameter: %w", err)
+			}
+			finalVal = base64.RawURLEncoding.EncodeToString(outMsg)
+
+		default:
+			inMsg, err := base64.RawURLEncoding.DecodeString(string(matchBytes))
+			if err != nil {
+				return "", fmt.Errorf("error decoding encrypted parameter: %w", err)
+			}
+			inBlob := new(wrapping.EncryptedBlobInfo)
+			if err := proto.Unmarshal(inMsg, inBlob); err != nil {
+				return "", fmt.Errorf("error unmarshaling encrypted parameter: %w", err)
+			}
+			dec, err := wrapper.Decrypt(context.Background(), inBlob, nil)
+			if err != nil {
+				return "", fmt.Errorf("error decrypting encrypted parameter: %w", err)
+			}
+			finalVal = string(dec)
+		}
+
+		// Append new value
+		out = append(out, []byte(fmt.Sprintf("%s%s)}}", replaceVal, finalVal))...)
+		prevMaxLoc = match[1]
+	}
+	// At the end, append the rest
+	out = append(out, raw[prevMaxLoc:len(raw)]...)
+	return string(out), nil
+}

--- a/internalshared/configutil/encrypt_decrypt_test.go
+++ b/internalshared/configutil/encrypt_decrypt_test.go
@@ -1,0 +1,62 @@
+package configutil
+
+import (
+	"context"
+	"testing"
+
+	wrapping "github.com/hashicorp/go-kms-wrapping"
+)
+
+func getAEADTestKMS(t *testing.T) {
+}
+
+func TestEncryptParams(t *testing.T) {
+	rawStr := `
+storage "consul" {
+	api_key = "{{encrypt(foobar)}}"
+}
+
+telemetry {
+	some_param = "something"
+	circonus_api_key = "{{encrypt(barfoo)}}"
+}
+`
+
+	reverser := new(reversingWrapper)
+	out, err := EncryptDecrypt(rawStr, false, reverser)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decOut, err := EncryptDecrypt(out, true, reverser)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if decOut != rawStr {
+		t.Fatal(decOut)
+	}
+}
+
+type reversingWrapper struct{}
+
+func (r *reversingWrapper) Type() string                     { return "reversing" }
+func (r *reversingWrapper) KeyID() string                    { return "reverser" }
+func (r *reversingWrapper) HMACKeyID() string                { return "" }
+func (r *reversingWrapper) Init(_ context.Context) error     { return nil }
+func (r *reversingWrapper) Finalize(_ context.Context) error { return nil }
+func (r *reversingWrapper) Encrypt(_ context.Context, input []byte, _ []byte) (*wrapping.EncryptedBlobInfo, error) {
+	return &wrapping.EncryptedBlobInfo{
+		Ciphertext: r.reverse(input),
+	}, nil
+}
+func (r *reversingWrapper) Decrypt(_ context.Context, input *wrapping.EncryptedBlobInfo, _ []byte) ([]byte, error) {
+	return r.reverse(input.Ciphertext), nil
+}
+func (r *reversingWrapper) reverse(input []byte) []byte {
+	output := make([]byte, len(input))
+	for i, j := 0, len(input)-1; i < j; i, j = i+1, j-1 {
+		output[i], output[j] = input[j], input[i]
+	}
+	return output
+}

--- a/internalshared/configutil/encrypt_decrypt_test.go
+++ b/internalshared/configutil/encrypt_decrypt_test.go
@@ -22,18 +22,38 @@ telemetry {
 }
 `
 
+	finalStr := `
+storage "consul" {
+	api_key = "foobar"
+}
+
+telemetry {
+	some_param = "something"
+	circonus_api_key = "barfoo"
+}
+`
+
 	reverser := new(reversingWrapper)
-	out, err := EncryptDecrypt(rawStr, false, reverser)
+	out, err := EncryptDecrypt(rawStr, false, false, reverser)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	decOut, err := EncryptDecrypt(out, true, reverser)
+	decOut, err := EncryptDecrypt(out, true, false, reverser)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if decOut != rawStr {
+		t.Fatal(decOut)
+	}
+
+	decOut, err = EncryptDecrypt(out, true, true, reverser)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if decOut != finalStr {
 		t.Fatal(decOut)
 	}
 }

--- a/internalshared/configutil/kms.go
+++ b/internalshared/configutil/kms.go
@@ -97,9 +97,11 @@ func configureWrapper(configKMS *KMS, infoKeys *[]string, info *map[string]strin
 		return nil, err
 	}
 
-	for k, v := range kmsInfo {
-		*infoKeys = append(*infoKeys, k)
-		(*info)[k] = v
+	if infoKeys != nil && info != nil {
+		for k, v := range kmsInfo {
+			*infoKeys = append(*infoKeys, k)
+			(*info)[k] = v
+		}
 	}
 
 	return wrapper, nil

--- a/internalshared/configutil/kms.go
+++ b/internalshared/configutil/kms.go
@@ -59,7 +59,7 @@ func (k *KMS) GoString() string {
 	return fmt.Sprintf("*%#v", *k)
 }
 
-func parseKMS(result *SharedConfig, list *ast.ObjectList, blockName string, maxKMS int) error {
+func parseKMS(result *[]*KMS, list *ast.ObjectList, blockName string, maxKMS int) error {
 	if len(list.Items) > maxKMS {
 		return fmt.Errorf("only two or less %q blocks are permitted", blockName)
 	}
@@ -120,9 +120,45 @@ func parseKMS(result *SharedConfig, list *ast.ObjectList, blockName string, maxK
 		seals = append(seals, seal)
 	}
 
-	result.Seals = append(result.Seals, seals...)
+	*result = append(*result, seals...)
 
 	return nil
+}
+
+func ParseKMSes(d string) ([]*KMS, error) {
+	// Parse!
+	obj, err := hcl.Parse(d)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start building the result
+	var result struct {
+		Seals []*KMS `hcl:"-"`
+	}
+
+	if err := hcl.DecodeObject(&result, obj); err != nil {
+		return nil, err
+	}
+
+	list, ok := obj.Node.(*ast.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("error parsing: file doesn't contain a root object")
+	}
+
+	if o := list.Filter("seal"); len(o.Items) > 0 {
+		if err := parseKMS(&result.Seals, o, "seal", 3); err != nil {
+			return nil, errwrap.Wrapf("error parsing 'seal': {{err}}", err)
+		}
+	}
+
+	if o := list.Filter("kms"); len(o.Items) > 0 {
+		if err := parseKMS(&result.Seals, o, "kms", 3); err != nil {
+			return nil, errwrap.Wrapf("error parsing 'kms': {{err}}", err)
+		}
+	}
+
+	return result.Seals, nil
 }
 
 func configureWrapper(configKMS *KMS, infoKeys *[]string, info *map[string]string, logger hclog.Logger) (wrapping.Wrapper, error) {


### PR DESCRIPTION
This provides a new command, `vault operator config encrypt/decrypt` that can use a defined KMS within the configuration marked for `config` purpose to encrypt or decrypt values. These values can be decrypted with a corresponding seal/kms block at runtime, so in practice, an operator that has access to the secrets can run the encrypt command, but the resulting file is then safe to pass through e.g. CI/CD or store in Git for deployment.

An example (you'd not want to actually use an AEAD KMS in real life, but this works well for demo/test):

```
listener "tcp" {
        address = "127.0.0.1:8205"
        tls_disable = true
}
telemetry {
        prometheus_retention_time = "{{encrypt(24h)}}"
        disable_hostname = true
}
storage "inmem" {
}

kms "aead" {
        purpose = "autoseal"
        key = "{{encrypt(kcI2Pyo6jZBRE9Nr7sdniVAYCRwEmOE93tw7qS0Hjq4=)}}"
        aead_type = "aes-gcm"
}

kms "aead" {
        purpose = "config"
        key = "kcI2Pyo6jZBRE9Nr7sdniVAYCRwEmOE93tw7qS0Hjq4="
        aead_type = "aes-gcm"
}
```
This becomes encrypted via the command to:
```
listener "tcp" {
        address = "127.0.0.1:8205"
        tls_disable = true
}
telemetry {
        prometheus_retention_time = "{{decrypt(Ch-feItbSZwpND15ovFKly_nFxfEnjlpz3g-f-4RVIon)}}"
        disable_hostname = true
}
storage "inmem" {
}

kms "aead" {
        purpose = "autoseal"
        key = "{{decrypt(Ckg1MovuQwkMyK4m2VKNG0WLnOjsqFxU0WDPu2KIL8_dbQWf4xAOxdG9U8suhu9zargZOo4X50IvxHeyfbT6mHgvQfaZEarnSWk)}}"
        aead_type = "aes-gcm"
}

kms "aead" {
        purpose = "config"
        key = "kcI2Pyo6jZBRE9Nr7sdniVAYCRwEmOE93tw7qS0Hjq4="
        aead_type = "aes-gcm"
}
```
At runtime Vault will pass config files, before decoding, to a function that decrypts with the given KMS.

As is apparent from the example, a nice feature of this is the ability to encrypt the other seal/KMS block parameters.