### PR TITLE
add vsh to 3rd party tools page

### DIFF
--- a/website/pages/api-docs/relatedtools.mdx
+++ b/website/pages/api-docs/relatedtools.mdx
@@ -33,5 +33,6 @@ The following list of tools is maintained by the community of Vault users; Hashi
 - [Cruise Daytona](https://github.com/cruise-automation/daytona) - An alternative implementation of the Vault client CLI for services and containers. Its core features are the abilty to automate authentication, fetching of secrets, and automated token renewal. Support for AWS, GCP, & Kubernetes Vault Auth Backends.
 - [Vault-CRD](https://vault.koudingspawn.de/) - Synchronize secrets stored in HashiCorp Vault to Kubernetes Secrets for better GitOps without secrets stored in git manifest files.
 - [nc-vault-env](https://github.com/namecheap/nc-vault-env) - JS CLI tool that fetches secrets in parallel, puts them into the environment and then `exec`s the process that needs them. Supports auth token renewal, multiple auth backends, verbose logging and dummy mode.
+- [vsh](https://github.com/fishi0x01/vsh) - Interactive shell with tab-completion. Allows recursive operations on paths. Allows migration of secrets between both KV versions.
 
 Want to add your own project, or one that you use? Additions are welcome via [pull requests](https://github.com/hashicorp/vault/blob/master/website/pages/api-docs/relatedtools.mdx).


### PR DESCRIPTION
This PR humbly asks to add [vsh](https://github.com/fishi0x01/vsh) to the list of 3rd party tools (if it is found worthy). 

`vsh` is an interactive vault shell which allows recursive operations on paths. Further, it allows migration of secrets between kv1 and kv2. It also comes with a non-interactive mode to integrate with automation. It is actively maintained and developed. 