### PR TITLE
remove DSA for SSH

### DIFF
--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -2,7 +2,6 @@ package ssh
 
 import (
 	"context"
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
@@ -432,9 +431,6 @@ func (b *backend) validateSignedKeyRequirements(publickey ssh.PublicKey, role *s
 			case *rsa.PublicKey:
 				kstr = "rsa"
 				kbits = k.N.BitLen()
-			case *dsa.PublicKey:
-				kstr = "dsa"
-				kbits = k.Parameters.P.BitLen()
 			case *ecdsa.PublicKey:
 				kstr = "ecdsa"
 				kbits = k.Curve.Params().BitSize
@@ -451,10 +447,6 @@ func (b *backend) validateSignedKeyRequirements(publickey ssh.PublicKey, role *s
 			var pass bool
 			switch kstr {
 			case "rsa":
-				if kbits == value {
-					pass = true
-				}
-			case "dsa":
 				if kbits == value {
 					pass = true
 				}


### PR DESCRIPTION
Hi,
Using Vault for sensible infrastructure, I needed to patch about DSA keys because OpenSSH deprecated DSA keys in 2015 due to weakness.
Regards

Sources:
- https://github.com/zmedico/gentoo-news/blob/master/2015-08-13-openssh-weak-keys/2015-08-13-openssh-weak-keys.en.txt
- http://www.openssh.com/legacy.html