### PR TITLE
Bug Fix: allow certificates to be copy/pasted on LDAP auth config

### DIFF
--- a/ui/app/models/auth-config/ldap.js
+++ b/ui/app/models/auth-config/ldap.js
@@ -1,4 +1,5 @@
 import { computed } from '@ember/object';
+
 import DS from 'ember-data';
 import AuthConfig from '../auth-config';
 import fieldToAttrs from 'vault/utils/field-to-attrs';

--- a/ui/app/models/auth-config/ldap.js
+++ b/ui/app/models/auth-config/ldap.js
@@ -1,11 +1,17 @@
 import { computed } from '@ember/object';
-
+import DS from 'ember-data';
 import AuthConfig from '../auth-config';
 import fieldToAttrs from 'vault/utils/field-to-attrs';
 import { combineFieldGroups } from 'vault/utils/openapi-to-attrs';
 
+const { attr } = DS;
+
 export default AuthConfig.extend({
   useOpenAPI: true,
+  certificate: attr({
+    label: 'Certificate',
+    editType: 'textarea',
+  }),
   fieldGroups: computed(function() {
     let groups = [
       {


### PR DESCRIPTION
The Bug 🐛: If you try and add a certificate on the LDAP auth config page you get a "failed to decode PEM block in the certificate" error.  This happened because it was a text input field and certificates are multi-line.   I made this field a text-area field, which solves the problem.

[Related GH issue here](https://github.com/hashicorp/vault/issues/7187)

In the future, we plan on creating a new component that will allow you to either copy/paste the certificate or file upload it.  We currently have a file/upload component, but we need additional functionality that will allow someone to come back and either edit or delete the certificate.  This same situation occurs in several other places.

**Before the fix:**
<img width=600 src="https://user-images.githubusercontent.com/6618863/76791932-86eac480-6787-11ea-8ea7-71604d9b4993.gif">

**With the fix:**
<img width=600 src="https://user-images.githubusercontent.com/6618863/76791947-8ce0a580-6787-11ea-9a84-f09fe6e60462.gif">
