### PR TITLE
Ui/transit modal

### DIFF
--- a/ui/app/components/modal.js
+++ b/ui/app/components/modal.js
@@ -1,6 +1,7 @@
 /**
  * @module Modal
- * Modal components are used to...
+ * Modal components are used to overlay content on top of the page. Has a darkened background,
+ * a title, and in order to close it you must pass an onClose function.
  *
  * @example
  * ```js

--- a/ui/app/components/modal.js
+++ b/ui/app/components/modal.js
@@ -1,0 +1,19 @@
+/**
+ * @module Modal
+ * Modal components are used to...
+ *
+ * @example
+ * ```js
+ * <Modal @requiredParam={requiredParam} @optionalParam={optionalParam} @param1={{param1}}/>
+ * ```
+ * @param {object} requiredParam - requiredParam is...
+ * @param {string} [optionalParam] - optionalParam is...
+ * @param {string} [param1=defaultValue] - param1 is...
+ */
+
+import Component from '@ember/component';
+
+export default Component.extend({
+  title: null,
+  onClose: () => {},
+});

--- a/ui/app/components/modal.js
+++ b/ui/app/components/modal.js
@@ -4,16 +4,17 @@
  *
  * @example
  * ```js
- * <Modal @requiredParam={requiredParam} @optionalParam={optionalParam} @param1={{param1}}/>
+ * <Modal @title={'myTitle'} @showCloseButton={true} @onClose={() => {}}/>
  * ```
- * @param {object} requiredParam - requiredParam is...
- * @param {string} [optionalParam] - optionalParam is...
- * @param {string} [param1=defaultValue] - param1 is...
+ * @param {function} onClose - onClose is the action taken when someone clicks the modal background or close button (if shown).
+ * @param {string} [title] - This text shows up in the header section of the modal.
+ * @param {boolean} [showCloseButton=false] - controls whether the close button in the top right corner shows.
  */
 
 import Component from '@ember/component';
 
 export default Component.extend({
   title: null,
+  showCloseButton: false,
   onClose: () => {},
 });

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -202,8 +202,10 @@ export default Component.extend(TRANSIT_PARAMS, {
       arr.forEach(param => this.set(param, null));
     },
 
-    toggleModal() {
-      this.get('flashMessages').success('Text copied!');
+    toggleModal(successMessage) {
+      if (!!successMessage && typeof successMessage === 'string') {
+        this.get('flashMessages').success(successMessage);
+      }
       this.toggleProperty('isModalActive');
     },
 

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -49,6 +49,7 @@ export default Component.extend(TRANSIT_PARAMS, {
   // public attrs
   selectedAction: null,
   key: null,
+  isModalActive: true,
 
   onRefresh() {},
   init() {
@@ -186,6 +187,7 @@ export default Component.extend(TRANSIT_PARAMS, {
 
     closeModal() {
       console.log('close');
+      this.toggleProperty('isModalActive');
     },
 
     doSubmit(data, options = {}) {

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -45,6 +45,7 @@ const PARAMS_FOR_ACTION = {
 };
 export default Component.extend(TRANSIT_PARAMS, {
   store: service(),
+  flashMessages: service(),
 
   // public attrs
   selectedAction: null,
@@ -188,6 +189,7 @@ export default Component.extend(TRANSIT_PARAMS, {
 
     toggleModal() {
       console.log('close');
+      this.get('flashMessages').success('Ciphertext copied!');
       this.toggleProperty('isModalActive');
     },
 

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -184,6 +184,10 @@ export default Component.extend(TRANSIT_PARAMS, {
       arr.forEach(param => this.set(param, null));
     },
 
+    closeModal() {
+      console.log('close');
+    },
+
     doSubmit(data, options = {}) {
       const { backend, id } = this.getModelInfo();
       const action = this.get('selectedAction');

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -49,7 +49,7 @@ export default Component.extend(TRANSIT_PARAMS, {
   // public attrs
   selectedAction: null,
   key: null,
-  isModalActive: true,
+  isModalActive: false,
 
   onRefresh() {},
   init() {
@@ -150,6 +150,7 @@ export default Component.extend(TRANSIT_PARAMS, {
     if (options.wrapTTL) {
       props = assign({}, props, { wrappedToken: resp.wrap_info.token });
     }
+    this.toggleProperty('isModalActive');
     this.setProperties(props);
     if (action === 'rotate') {
       this.get('onRefresh')();

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -45,7 +45,7 @@ const PARAMS_FOR_ACTION = {
 };
 const SUCCESS_MESSAGE_FOR_ACTION = {
   sign: 'Signed your data',
-  // verify doesn't trigger a success message
+  // the verify action doesn't trigger a success message
   hmac: 'Created your hash output',
   encrypt: 'Created a wrapped token for your data',
   decrypt: 'Decrypted the data from your token',

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -188,8 +188,7 @@ export default Component.extend(TRANSIT_PARAMS, {
     },
 
     toggleModal() {
-      console.log('close');
-      this.get('flashMessages').success('Ciphertext copied!');
+      this.get('flashMessages').success('Text copied!');
       this.toggleProperty('isModalActive');
     },
 

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -217,7 +217,7 @@ export default Component.extend(TRANSIT_PARAMS, {
         if (action === 'encrypt' && !!formData.plaintext) {
           formData.plaintext = encodeString(formData.plaintext);
         }
-        if ((action === 'hmac' || action === 'verify') && !!formData.input) {
+        if ((action === 'hmac' || action === 'verify' || action === 'sign') && !!formData.input) {
           formData.input = encodeString(formData.input);
         }
       }

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -50,6 +50,8 @@ const SUCCESS_MESSAGE_FOR_ACTION = {
   encrypt: 'Created a wrapped token for your data',
   decrypt: 'Decrypted the data from your token',
   rewrap: 'Created a new token for your data',
+  datakey: 'Generated your key',
+  export: 'Exported your key',
 };
 export default Component.extend(TRANSIT_PARAMS, {
   store: service(),

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -185,7 +185,7 @@ export default Component.extend(TRANSIT_PARAMS, {
       arr.forEach(param => this.set(param, null));
     },
 
-    closeModal() {
+    toggleModal() {
       console.log('close');
       this.toggleProperty('isModalActive');
     },

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -43,6 +43,14 @@ const PARAMS_FOR_ACTION = {
   decrypt: ['ciphertext', 'context', 'nonce'],
   rewrap: ['ciphertext', 'context', 'nonce', 'key_version'],
 };
+const SUCCESS_MESSAGE_FOR_ACTION = {
+  sign: 'Generated your key',
+  // verify doesn't trigger a success message
+  hmac: 'Created your hash output',
+  encrypt: 'Created a wrapped token for your data',
+  decrypt: 'Decrypted the data from your token',
+  rewrap: 'Created a new token for your data',
+};
 export default Component.extend(TRANSIT_PARAMS, {
   store: service(),
   flashMessages: service(),
@@ -139,6 +147,12 @@ export default Component.extend(TRANSIT_PARAMS, {
     this.set('errors', null);
   },
 
+  triggerSuccessMessage(action) {
+    const message = SUCCESS_MESSAGE_FOR_ACTION[action];
+    if (!message) return;
+    this.get('flashMessages').success(message);
+  },
+
   handleSuccess(resp, options, action) {
     let props = {};
     if (resp && resp.data) {
@@ -156,6 +170,7 @@ export default Component.extend(TRANSIT_PARAMS, {
     if (action === 'rotate') {
       this.get('onRefresh')();
     }
+    this.triggerSuccessMessage(action);
   },
 
   compactData(data) {

--- a/ui/app/components/transit-key-actions.js
+++ b/ui/app/components/transit-key-actions.js
@@ -44,7 +44,7 @@ const PARAMS_FOR_ACTION = {
   rewrap: ['ciphertext', 'context', 'nonce', 'key_version'],
 };
 const SUCCESS_MESSAGE_FOR_ACTION = {
-  sign: 'Generated your key',
+  sign: 'Signed your data',
   // verify doesn't trigger a success message
   hmac: 'Created your hash output',
   encrypt: 'Created a wrapped token for your data',

--- a/ui/app/styles/components/modal.scss
+++ b/ui/app/styles/components/modal.scss
@@ -33,4 +33,8 @@
       background-color: inherit;
     }
   }
+
+  .copy-close {
+    margin-top: $spacing-s;
+  }
 }

--- a/ui/app/styles/components/modal.scss
+++ b/ui/app/styles/components/modal.scss
@@ -1,5 +1,10 @@
+.modal-background {
+  background: rgb(235, 238, 242, 0.9);
+}
+
 .modal-card {
-  box-shadow: $box-shadow, $box-shadow-middle;
+  box-shadow: $box-shadow-highest;
+  border: 1px solid $grey-light;
 
   &-head {
     border-radius: 0;
@@ -10,10 +15,17 @@
   &-foot {
     border-radius: 0;
     border: 0;
-    background-color: white;
+    background-color: $white;
   }
 
   &-title.title {
     margin: 0;
+  }
+
+  .copy-text {
+    background-color: $grey-lightest;
+    padding: $spacing-s;
+    width: max-content;
+    margin-bottom: $spacing-s;
   }
 }

--- a/ui/app/styles/components/modal.scss
+++ b/ui/app/styles/components/modal.scss
@@ -1,0 +1,19 @@
+.modal-card {
+  box-shadow: $box-shadow, $box-shadow-middle;
+
+  &-head {
+    border-radius: 0;
+    background-color: $grey-lightest;
+    border-bottom: 1px solid $grey-light;
+  }
+
+  &-foot {
+    border-radius: 0;
+    border: 0;
+    background-color: white;
+  }
+
+  &-title.title {
+    margin: 0;
+  }
+}

--- a/ui/app/styles/components/modal.scss
+++ b/ui/app/styles/components/modal.scss
@@ -38,3 +38,7 @@
     margin-top: $spacing-s;
   }
 }
+
+pre {
+  background-color: inherit;
+}

--- a/ui/app/styles/components/modal.scss
+++ b/ui/app/styles/components/modal.scss
@@ -25,7 +25,12 @@
   .copy-text {
     background-color: $grey-lightest;
     padding: $spacing-s;
-    width: max-content;
     margin-bottom: $spacing-s;
+
+    code {
+      overflow: scroll;
+      max-width: calc(100% - 36px);
+      background-color: inherit;
+    }
   }
 }

--- a/ui/app/styles/components/transit-card.scss
+++ b/ui/app/styles/components/transit-card.scss
@@ -9,10 +9,11 @@
 
 .transit-card {
   border-radius: $radius;
-  box-shadow: 0 0 0 1px rgba($grey-dark, 0.3), $box-shadow-middle;
+  box-shadow: 0 0 0 1px rgba($grey-light, 0.4);
   display: grid;
   grid-template-columns: 0.45fr 2fr;
   padding: $spacing-m;
+  border: none;
 
   .transit-icon {
     justify-self: center;

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -68,6 +68,7 @@
 @import './components/loader';
 @import './components/login-form';
 @import './components/masked-input';
+@import './components/modal';
 @import './components/namespace-picker';
 @import './components/namespace-reminder';
 @import './components/navigate-input';

--- a/ui/app/templates/components/modal.hbs
+++ b/ui/app/templates/components/modal.hbs
@@ -2,16 +2,11 @@
   <div class="modal {{if isActive 'is-active'}}" aria-modal="true">
     <div class="modal-background" onclick={{onClose}} data-test-modal-background></div>
     <div class="modal-card">
-      <header class="modal-card-head">
-        <p class="modal-card-title" data-test-modal-title>{{title}}</p>
-        <button class="delete" aria-label="close" onclick={{onClose}}></button>
-      </header>
-      <section class="modal-card-body">
-        {{yield}}
-      </section>
-      <footer class="modal-card-foot">
-        <button class="button is-success" onclick={{onClose}} data-test-button="modal-copy-close">Copy & Close</button>
-      </footer>
+        <header class="modal-card-head">
+          <p class="modal-card-title" data-test-modal-title>{{title}}</p>
+          <button class="delete" aria-label="close" onclick={{onClose}}></button>
+        </header>
+      {{yield}}
     </div>
   </div>
 {{/ember-wormhole}}

--- a/ui/app/templates/components/modal.hbs
+++ b/ui/app/templates/components/modal.hbs
@@ -4,7 +4,9 @@
     <div class="modal-card">
         <header class="modal-card-head">
           <h2 class="modal-card-title title is-5" data-test-modal-title>{{title}}</h2>
-          <button class="delete" aria-label="close" onclick={{onClose}}></button>
+          {{#if showCloseButton}}
+            <button class="delete" aria-label="close" onclick={{onClose}} data-test-modal-close-button></button>
+          {{/if}}
         </header>
       {{yield}}
     </div>

--- a/ui/app/templates/components/modal.hbs
+++ b/ui/app/templates/components/modal.hbs
@@ -1,0 +1,17 @@
+{{#ember-wormhole to="modal-wormhole"}}
+  <div class="modal is-active" aria-modal="true">
+    <div class="modal-background" onclick={{onClose}} data-test-modal-background></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title" data-test-modal-title>{{title}}</p>
+        <button class="delete" aria-label="close" onclick={{onClose}}></button>
+      </header>
+      <section class="modal-card-body">
+        {{yield}}
+      </section>
+      <footer class="modal-card-foot">
+        <button class="button is-success" onclick={{onClose}} data-test-button="modal-copy-close">Copy & Close</button>
+      </footer>
+    </div>
+  </div>
+{{/ember-wormhole}}

--- a/ui/app/templates/components/modal.hbs
+++ b/ui/app/templates/components/modal.hbs
@@ -3,7 +3,7 @@
     <div class="modal-background" onclick={{onClose}} data-test-modal-background></div>
     <div class="modal-card">
         <header class="modal-card-head">
-          <p class="modal-card-title" data-test-modal-title>{{title}}</p>
+          <h2 class="modal-card-title title is-5" data-test-modal-title>{{title}}</h2>
           <button class="delete" aria-label="close" onclick={{onClose}}></button>
         </header>
       {{yield}}

--- a/ui/app/templates/components/modal.hbs
+++ b/ui/app/templates/components/modal.hbs
@@ -1,5 +1,5 @@
 {{#ember-wormhole to="modal-wormhole"}}
-  <div class="modal is-active" aria-modal="true">
+  <div class="modal {{if isActive 'is-active'}}" aria-modal="true">
     <div class="modal-background" onclick={{onClose}} data-test-modal-background></div>
     <div class="modal-card">
       <header class="modal-card-head">

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -1,151 +1,81 @@
 <form {{action 'doSubmit' (hash param=param context=context nonce=nonce bits=bits) on="submit"}}>
-  {{#if ciphertext}}
   <div class="box is-sideless is-fullwidth is-marginless">
-    {{#if (eq param 'plaintext')}}
+    <NamespaceReminder @mode="perform" @noun="datakey creation" />
+    <div class="content">
+      <p>Generate a new high-entropy key and value using <code>{{key.name}}</code> as the encryption key.</p>
+    </div>
     <div class="field">
-      <label for="plaintext" class="is-label">Plaintext</label>
-      <div class="control">
-        {{ivy-codemirror
-          id="plaintext"
-          value=plaintext
-          valueUpdated=(action (mut plaintext))
-          options=(hash
-            lineNumbers=true
-            tabSize=2
-            mode='ruby'
-            theme='hashi'
-            readonly=true
-          )
-        }}
+      <label for="param" class="is-label">Output format</label>
+      <div class="control is-expanded">
+        <div class="select is-fullwidth">
+          <select
+            name="param"
+            id="param"
+            onchange={{action (mut param) value="target.value"}}
+          >
+            {{#each (array "plaintext" "wrapped") as |paramOption|}}
+              <option selected={{eq param paramOption}} value={{paramOption}}>
+                {{paramOption}}
+              </option>
+            {{/each}}
+          </select>
+        </div>
       </div>
     </div>
+    {{#if key.derived}}
+      <div class="field">
+        <label for="context" class="is-label">
+          Context
+        </label>
+        <div class="field has-addons">
+          <div class="control">
+            {{input type="text" id="context" value=context class="input" data-test-transit-input="context"}}
+          </div>
+          <div class="control">
+            {{b64-toggle value=context data-test-transit-b64-toggle="context"}}
+          </div>
+        </div>
+      </div>
+    {{/if}}
+    {{#if (eq key.convergentEncryptionVersion 1)}}
+      <div class="field">
+        <label for="nonce" class="is-label">Nonce</label>
+        <div class="field has-addons">
+          <div class="control">
+            {{input type="text" id="nonce" value=nonce class="input" data-test-transit-input="nonce"}}
+          </div>
+          <div class="control">
+            {{b64-toggle value=nonce data-test-transit-b64-toggle="nonce"}}
+          </div>
+        </div>
+      </div>
     {{/if}}
     <div class="field">
-      <label for="ciphertext" class="is-label">Ciphertext</label>
-      <div class="control">
-      {{ivy-codemirror
-        id="ciphertext"
-        value=ciphertext
-        valueUpdated=(action (mut ciphertext))
-        options=(hash
-          lineNumbers=true
-          tabSize=2
-          mode='ruby'
-          theme='hashi'
-          readonly=true
-        )
-      }}
+      <label for="bits" class="is-label">Bits</label>
+      <div class="control is-expanded">
+        <div class="select is-fullwidth">
+        <select
+          name="bits"
+          id="bits"
+          onchange={{action (mut bits) value="target.value"}}
+        >
+          {{#each (array 128 256 512) as |bitOption|}}
+            <option selected={{eq bits bitOption}} value={{bitOption}}>
+              <code>{{bitOption}}</code>
+            </option>
+          {{/each}}
+        </select>
+        </div>
       </div>
     </div>
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
-    {{#if (eq param 'plaintext')}}
-      <div class="control">
-        {{#copy-button
-        clipboardTarget="#plaintext"
-        class="button is-primary"
-        buttonType="button"
-        success=(action (set-flash-message 'Plaintext copied!'))
-        }}
-        Copy plaintext
-        {{/copy-button}}
-      </div>
-    {{/if}}
     <div class="control">
-      {{#copy-button
-      clipboardTarget="#ciphertext"
-      class=(concat "button is-primary " (if (eq param "plaintext") "is-outlined" ""))
-      buttonType="button"
-      success=(action (set-flash-message 'Ciphertext copied!'))
-      }}
-      Copy ciphertext
-      {{/copy-button}}
-    </div>
-    <div class="control">
-      <button {{action 'onClear'}} type="button" class="button">
-        Back
+      <button type="submit" class="button is-primary">
+        Create datakey
       </button>
     </div>
   </div>
-  {{else}}
-    <div class="box is-sideless is-fullwidth is-marginless">
-      <NamespaceReminder @mode="perform" @noun="datakey creation" />
-      <div class="content">
-        <p>Generate a new high-entropy key and value using <code>{{key.name}}</code> as the encryption key.</p>
-      </div>
-      <div class="field">
-        <label for="param" class="is-label">Output format</label>
-        <div class="control is-expanded">
-          <div class="select is-fullwidth">
-            <select
-              name="param"
-              id="param"
-              onchange={{action (mut param) value="target.value"}}
-            >
-              {{#each (array "plaintext" "wrapped") as |paramOption|}}
-                <option selected={{eq param paramOption}} value={{paramOption}}>
-                  {{paramOption}}
-                </option>
-              {{/each}}
-            </select>
-          </div>
-        </div>
-      </div>
-      {{#if key.derived}}
-        <div class="field">
-          <label for="context" class="is-label">
-            Context
-          </label>
-          <div class="field has-addons">
-            <div class="control">
-              {{input type="text" id="context" value=context class="input" data-test-transit-input="context"}}
-            </div>
-            <div class="control">
-              {{b64-toggle value=context data-test-transit-b64-toggle="context"}}
-            </div>
-          </div>
-        </div>
-      {{/if}}
-      {{#if (eq key.convergentEncryptionVersion 1)}}
-        <div class="field">
-          <label for="nonce" class="is-label">Nonce</label>
-          <div class="field has-addons">
-            <div class="control">
-              {{input type="text" id="nonce" value=nonce class="input" data-test-transit-input="nonce"}}
-            </div>
-            <div class="control">
-              {{b64-toggle value=nonce data-test-transit-b64-toggle="nonce"}}
-            </div>
-          </div>
-        </div>
-      {{/if}}
-      <div class="field">
-        <label for="bits" class="is-label">Bits</label>
-        <div class="control is-expanded">
-          <div class="select is-fullwidth">
-          <select
-            name="bits"
-            id="bits"
-            onchange={{action (mut bits) value="target.value"}}
-          >
-            {{#each (array 128 256 512) as |bitOption|}}
-              <option selected={{eq bits bitOption}} value={{bitOption}}>
-                <code>{{bitOption}}</code>
-              </option>
-            {{/each}}
-          </select>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
-        <button type="submit" class="button is-primary">
-          Create datakey
-        </button>
-      </div>
-    </div>
-  {{/if}}
 </form>
 <Modal @title="Copy your generated key" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
   <section class="modal-card-body">

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -69,6 +69,7 @@
   </div>
   {{else}}
     <div class="box is-sideless is-fullwidth is-marginless">
+      <p>Generate a new high-entropy key and value using <code>{{key.name}}</code> as the encryption key.</p>
       <NamespaceReminder @mode="perform" @noun="datakey creation" />
       <div class="field">
         <label for="param" class="is-label">Output format</label>
@@ -149,9 +150,9 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       {{#if (eq param 'plaintext')}}
         <h2 class="title is-6">Plaintext</h2>
-        <div class="copy-text"><code>{{plaintext}}</code></div>
+        <div class="copy-text"><pre>{{plaintext}}</pre></div>
         <h2 class="title is-6">Ciphertext</h2>
-        <div class="copy-text"><code>{{ciphertext}}</code></div>
+        <div class="copy-text"><pre>{{ciphertext}}</pre></div>
         <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
           @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
           Copy Plaintext
@@ -163,7 +164,7 @@
         <button type="submit" class="button is-secondary" onclick={{action (mut isModalActive) false}}>Close</button>
       {{else}}
         <h2 class="title is-6">Ciphertext</h2>
-        <span><code>{{ciphertext}}</code></span>
+        <span><pre>{{ciphertext}}</pre></span>
         <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
           @buttonType="button" @success={{action "toggleModal"}}>
           Copy & Close

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -69,8 +69,10 @@
   </div>
   {{else}}
     <div class="box is-sideless is-fullwidth is-marginless">
-      <p>Generate a new high-entropy key and value using <code>{{key.name}}</code> as the encryption key.</p>
       <NamespaceReminder @mode="perform" @noun="datakey creation" />
+      <div class="content">
+        <p>Generate a new high-entropy key and value using <code>{{key.name}}</code> as the encryption key.</p>
+      </div>
       <div class="field">
         <label for="param" class="is-label">Output format</label>
         <div class="control is-expanded">

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -150,9 +150,21 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       {{#if (eq param 'plaintext')}}
         <h2 class="title is-6">Plaintext</h2>
-        <div class="copy-text"><pre>{{plaintext}}</pre></div>
+        <div class="copy-text level">
+          <code class="level-left">{{plaintext}}</code>
+          <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
+            @clipboardText={{plaintext}} @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
+            <Icon @glyph="copy-action" aria-label="Copy" />
+          </CopyButton>
+        </div>
         <h2 class="title is-6">Ciphertext</h2>
-        <div class="copy-text"><pre>{{ciphertext}}</pre></div>
+        <div class="copy-text level">
+          <code class="level-left">{{ciphertext}}</code>
+          <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
+            @clipboardText={{ciphertext}} @buttonType="button" @success={{action (set-flash-message 'Ciphertext copied!')}}>
+            <Icon @glyph="copy-action" aria-label="Copy" />
+          </CopyButton>
+        </div>
         <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
           @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
           Copy Plaintext
@@ -164,10 +176,16 @@
         <button type="submit" class="button is-secondary" onclick={{action (mut isModalActive) false}}>Close</button>
       {{else}}
         <h2 class="title is-6">Ciphertext</h2>
-        <span><pre>{{ciphertext}}</pre></span>
-        <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
+        <div class="copy-text level">
+          <code class="level-left">{{ciphertext}}</code>
+          <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
+            @clipboardText={{ciphertext}} @buttonType="button" @success={{action (set-flash-message 'Ciphertext copied!')}}>
+            <Icon @glyph="copy-action" aria-label="Copy" />
+          </CopyButton>
+        </div>
+        <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
           @buttonType="button" @success={{action "toggleModal"}}>
-          Copy & Close
+          Copy &amp; Close
         </CopyButton>
       {{/if}}
     </div>

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -89,6 +89,7 @@
             <Icon @glyph="copy-action" aria-label="Copy" />
           </CopyButton>
         </div>
+        <p class="help has-bottom-margin">Plaintext is base64 encoded</p>
         <h2 class="title is-6">Ciphertext</h2>
         <div class="copy-text level">
           <code class="level-left">{{ciphertext}}</code>

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -5,14 +5,36 @@
     <div class="field">
       <label for="plaintext" class="is-label">Plaintext</label>
       <div class="control">
-        <textarea readonly class="textarea" id="plaintext">{{plaintext}}</textarea>
+        {{ivy-codemirror
+          id="plaintext"
+          value=plaintext
+          valueUpdated=(action (mut plaintext))
+          options=(hash
+            lineNumbers=true
+            tabSize=2
+            mode='ruby'
+            theme='hashi'
+            readonly=true
+          )
+        }}
       </div>
     </div>
     {{/if}}
     <div class="field">
       <label for="ciphertext" class="is-label">Ciphertext</label>
       <div class="control">
-        <textarea readonly class="textarea" id="ciphertext">{{ciphertext}}</textarea>
+      {{ivy-codemirror
+        id="ciphertext"
+        value=ciphertext
+        valueUpdated=(action (mut ciphertext))
+        options=(hash
+          lineNumbers=true
+          tabSize=2
+          mode='ruby'
+          theme='hashi'
+          readonly=true
+        )
+      }}
       </div>
     </div>
   </div>
@@ -128,15 +150,17 @@
       {{#if (eq param 'plaintext')}}
           <p>Plaintext</p>
           <p>{{plaintext}}</p>
+          <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
+            @buttonType="button" @success={{action "toggleModal"}}>
+            Copy Plaintext & Close
+          </CopyButton>
       {{/if}}
       <p>Ciphertext</p>
       <p>{{ciphertext}}</p>
+      <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
+        @buttonType="button" @success={{action "toggleModal"}}>
+        Copy Ciphertext & Close
+      </CopyButton>
     </div>
   </section>
-  <footer class="modal-card-foot">
-    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
-      @buttonType="button" @success={{action "toggleModal"}}>
-      Copy & Close
-    </CopyButton>
-  </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -148,19 +148,23 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       {{#if (eq param 'plaintext')}}
-          <p>Plaintext</p>
-          <p>{{plaintext}}</p>
-          <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
-            @buttonType="button" @success={{action "toggleModal"}}>
-            Copy Plaintext & Close
-          </CopyButton>
+        <p>Plaintext</p>
+        <p>{{plaintext}}</p>
+        <p>Ciphertext</p>
+        <p>{{ciphertext}}</p>
+        <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
+          @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
+          Copy Plaintext
+        </CopyButton>
+      {{else}}
+        <p>Ciphertext</p>
+        <p>{{ciphertext}}</p>
       {{/if}}
-      <p>Ciphertext</p>
-      <p>{{ciphertext}}</p>
       <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
-        @buttonType="button" @success={{action "toggleModal"}}>
-        Copy Ciphertext & Close
+        @buttonType="button" @success={{action (set-flash-message 'Ciphertext copied!')}}>
+        Copy Ciphertext
       </CopyButton>
+      <button type="submit" class="button is-secondary" onclick={{action (mut isModalActive) false}}>Close</button>
     </div>
   </section>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -156,15 +156,19 @@
           @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
           Copy Plaintext
         </CopyButton>
+        <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
+          @buttonType="button" @success={{action (set-flash-message 'Ciphertext copied!')}}>
+          Copy Ciphertext
+        </CopyButton>
+        <button type="submit" class="button is-secondary" onclick={{action (mut isModalActive) false}}>Close</button>
       {{else}}
         <h2 class="title is-6">Ciphertext</h2>
         <span><code>{{ciphertext}}</code></span>
+        <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
+          @buttonType="button" @success={{action "toggleModal"}}>
+          Copy & Close
+        </CopyButton>
       {{/if}}
-      <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
-        @buttonType="button" @success={{action (set-flash-message 'Ciphertext copied!')}}>
-        Copy Ciphertext
-      </CopyButton>
-      <button type="submit" class="button is-secondary" onclick={{action (mut isModalActive) false}}>Close</button>
     </div>
   </section>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -149,9 +149,9 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       {{#if (eq param 'plaintext')}}
         <h2 class="title is-6">Plaintext</h2>
-        <span><code>{{plaintext}}</code></span>
+        <div class="copy-text"><code>{{plaintext}}</code></div>
         <h2 class="title is-6">Ciphertext</h2>
-        <span><code>{{ciphertext}}</code></span>
+        <div class="copy-text"><code>{{ciphertext}}</code></div>
         <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
           @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
           Copy Plaintext

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -116,7 +116,7 @@
           </CopyButton>
         </div>
         <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
-          @buttonType="button" @success={{action "toggleModal"}}>
+          @buttonType="button" @success={{action "toggleModal" "Ciphertext copied!"}}>
           Copy &amp; Close
         </CopyButton>
       {{/if}}

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -148,17 +148,17 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       {{#if (eq param 'plaintext')}}
-        <p>Plaintext</p>
-        <p>{{plaintext}}</p>
-        <p>Ciphertext</p>
-        <p>{{ciphertext}}</p>
+        <h2 class="title is-6">Plaintext</h2>
+        <span><code>{{plaintext}}</code></span>
+        <h2 class="title is-6">Ciphertext</h2>
+        <span><code>{{ciphertext}}</code></span>
         <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
           @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
           Copy Plaintext
         </CopyButton>
       {{else}}
-        <p>Ciphertext</p>
-        <p>{{ciphertext}}</p>
+        <h2 class="title is-6">Ciphertext</h2>
+        <span><code>{{ciphertext}}</code></span>
       {{/if}}
       <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
         @buttonType="button" @success={{action (set-flash-message 'Ciphertext copied!')}}>

--- a/ui/app/templates/components/transit-key-action/datakey.hbs
+++ b/ui/app/templates/components/transit-key-action/datakey.hbs
@@ -122,3 +122,21 @@
     </div>
   {{/if}}
 </form>
+<Modal @title="Copy your generated key" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
+  <section class="modal-card-body">
+    <div class="box is-shadowless is-fullwidth is-sideless">
+      {{#if (eq param 'plaintext')}}
+          <p>Plaintext</p>
+          <p>{{plaintext}}</p>
+      {{/if}}
+      <p>Ciphertext</p>
+      <p>{{ciphertext}}</p>
+    </div>
+  </section>
+  <footer class="modal-card-foot">
+    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
+      @buttonType="button" @success={{action "toggleModal"}}>
+      Copy & Close
+    </CopyButton>
+  </footer>
+</Modal>

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -67,6 +67,7 @@
           <Icon @glyph="copy-action" aria-label="Copy" />
         </CopyButton>
       </div>
+      <p class="help">Plaintext is base64 encoded</p>
     </div>
   </section>
   <footer class="modal-card-foot">

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -56,7 +56,8 @@
 <Modal @title="Copy your unwrapped data" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
-      <p>{{plaintext}}</p>
+      <h2 class="title is-6">Plaintext</h2>
+      <span><code>{{plaintext}}</code></span>
     </div>
   </section>
   <footer class="modal-card-foot">

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -94,3 +94,22 @@
     </div>
   {{/if}}
 </form>
+{{#if isModalActive}}
+<Modal @title="Copy your unwrapped data" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
+  <section class="modal-card-body">
+    <div class="box is-shadowless is-fullwidth is-sideless">
+      {{#if (and plaintext ciphertext)}}
+        <p>{{plaintext}}</p>
+      {{else}}
+        <p>{{ciphertext}}</p>
+      {{/if}}
+    </div>
+  </section>
+  <footer class="modal-card-foot">
+    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
+      @buttonType="button" @success={{action "toggleModal"}}>
+      Copy & Close
+    </CopyButton>
+  </footer>
+</Modal>
+{{/if}}

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -57,7 +57,13 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Plaintext</h2>
-      <span><code>{{plaintext}}</code></span>
+      <div class="copy-text">
+        <code>{{plaintext}}</code>
+        <CopyButton class="button is-compact is-transparent" data-test-button="modal-copy" @clipboardText={{plaintext}}
+          @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
+          <Icon @glyph="copy-action" aria-label="Copy" />
+        </CopyButton>
+      </div>
     </div>
   </section>
   <footer class="modal-card-foot">

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -71,7 +71,7 @@
   </section>
   <footer class="modal-card-foot">
     <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
-      @buttonType="button" @success={{action "toggleModal"}}>
+      @buttonType="button" @success={{action "toggleModal" "Plaintext copied!"}}>
       Copy &amp; Close
     </CopyButton>
   </footer>

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -1,5 +1,6 @@
 <form {{action 'doSubmit' (hash ciphertext=ciphertext context=context nonce=nonce) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">
+    <p>You can decrypt ciphertext using <code>{{key.name}}</code> as the encryption key.</p>
     <div class="field">
       <label for="ciphertext" class="is-label">Ciphertext</label>
       <div id="ciphertext-control" class="control">
@@ -57,9 +58,9 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Plaintext</h2>
-      <div class="copy-text">
-        <code>{{plaintext}}</code>
-        <CopyButton class="button is-compact is-transparent" data-test-button="modal-copy" @clipboardText={{plaintext}}
+      <div class="copy-text level">
+        <pre class="level-left">{{plaintext}}</pre>
+        <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy" @clipboardText={{plaintext}}
           @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
           <Icon @glyph="copy-action" aria-label="Copy" />
         </CopyButton>

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -61,7 +61,7 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Plaintext</h2>
       <div class="copy-text level">
-        <code class="level-left">{{plaintext}}</code>
+        <code class="level-left" data-test-encrypted-value="plaintext">{{plaintext}}</code>
         <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy" @clipboardText={{plaintext}}
           @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
           <Icon @glyph="copy-action" aria-label="Copy" />

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -59,7 +59,7 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Plaintext</h2>
       <div class="copy-text level">
-        <pre class="level-left">{{plaintext}}</pre>
+        <code class="level-left">{{plaintext}}</code>
         <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy" @clipboardText={{plaintext}}
           @buttonType="button" @success={{action (set-flash-message 'Plaintext copied!')}}>
           <Icon @glyph="copy-action" aria-label="Copy" />

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -68,9 +68,9 @@
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
+    <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
       @buttonType="button" @success={{action "toggleModal"}}>
-      Copy & Close
+      Copy &amp; Close
     </CopyButton>
   </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -1,6 +1,8 @@
 <form {{action 'doSubmit' (hash ciphertext=ciphertext context=context nonce=nonce) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">
-    <p>You can decrypt ciphertext using <code>{{key.name}}</code> as the encryption key.</p>
+    <div class="content">
+      <p>You can decrypt ciphertext using <code>{{key.name}}</code> as the encryption key.</p>
+    </div>
     <div class="field">
       <label for="ciphertext" class="is-label">Ciphertext</label>
       <div id="ciphertext-control" class="control">

--- a/ui/app/templates/components/transit-key-action/decrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/decrypt.hbs
@@ -1,112 +1,66 @@
 <form {{action 'doSubmit' (hash ciphertext=ciphertext context=context nonce=nonce) on="submit"}}>
-  {{#if (and plaintext ciphertext)}}
-    <div class="box is-sideless is-fullwidth is-marginless">
-      <div class="field">
-        <label for="plaintext" class="is-label">
-          Plaintext
-        </label>
-        <div id="plaintext-control" class="control is-relative">
-          {{ivy-codemirror
-            value=plaintext
-            options=(hash
-              readOnly=true
-              lineNumbers=true
-              tabSize=2
-              mode='ruby'
-              theme='hashi'
-            )
-            data-test-transit-input="plaintext"
-          }}
-          {{b64-toggle value=plaintext isInput=false initialEncoding="base64" data-test-transit-b64-toggle="plaintext"}}
-        </div>
-      </div>
-    </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
-        {{#copy-button
-          clipboardTarget="#plaintext"
-          class="button is-primary"
-          buttonType="button"
-          success=(action (set-flash-message 'Plaintext copied!'))
+  <div class="box is-sideless is-fullwidth is-marginless">
+    <div class="field">
+      <label for="ciphertext" class="is-label">Ciphertext</label>
+      <div id="ciphertext-control" class="control">
+        {{ivy-codemirror
+          valueUpdated=(action (mut ciphertext))
+          options=(hash
+            lineNumbers=true
+            tabSize=2
+            mode='ruby'
+            theme='hashi'
+          )
+          data-test-transit-input="ciphertext"
         }}
-          Copy
-        {{/copy-button}}
-      </div>
-      <div class="control">
-        <button {{action 'onClear'}} type="button" class="button">
-          Back
-        </button>
       </div>
     </div>
-  {{else}}
-    <div class="box is-sideless is-fullwidth is-marginless">
+    {{#if key.derived}}
       <div class="field">
-        <label for="ciphertext" class="is-label">Ciphertext</label>
-        <div id="ciphertext-control" class="control">
-          {{ivy-codemirror
-            value=ciphertext
-            valueUpdated=(action (mut ciphertext))
-            options=(hash
-              lineNumbers=true
-              tabSize=2
-              mode='ruby'
-              theme='hashi'
-            )
-            data-test-transit-input="ciphertext"
-          }}
-        </div>
-      </div>
-      {{#if key.derived}}
-        <div class="field">
-          <label for="context" class="is-label">
-            Context
-          </label>
-          <div class="field has-addons">
-            <div class="control">
-              {{input type="text" id="context" value=context class="input" data-test-transit-input="context"}}
-            </div>
-            <div class="control">
-              {{b64-toggle value=context data-test-transit-b64-toggle="context"}}
-            </div>
+        <label for="context" class="is-label">
+          Context
+        </label>
+        <div class="field has-addons">
+          <div class="control">
+            {{input type="text" id="context" value=context class="input" data-test-transit-input="context"}}
+          </div>
+          <div class="control">
+            {{b64-toggle value=context data-test-transit-b64-toggle="context"}}
           </div>
         </div>
-      {{/if}}
-      {{#if (eq key.convergentEncryptionVersion 1)}}
-        <div class="field">
-          <label for="nonce" class="is-label">Nonce</label>
-          <div class="field has-addons">
-            <div class="control">
-              {{input type="text" id="nonce" value=nonce class="input" data-test-transit-input="nonce"}}
-            </div>
-            <div class="control">
-              {{b64-toggle value=nonce data-test-transit-b64-toggle="nonce"}}
-            </div>
+      </div>
+    {{/if}}
+    {{#if (eq key.convergentEncryptionVersion 1)}}
+      <div class="field">
+        <label for="nonce" class="is-label">Nonce</label>
+        <div class="field has-addons">
+          <div class="control">
+            {{input type="text" id="nonce" value=nonce class="input" data-test-transit-input="nonce"}}
+          </div>
+          <div class="control">
+            {{b64-toggle value=nonce data-test-transit-b64-toggle="nonce"}}
           </div>
         </div>
-      {{/if}}
-    </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
-        <button type="submit" class="button is-primary" id="decrypt" data-test-button-decrypt>
-           Decrypt
-        </button>
       </div>
+    {{/if}}
+  </div>
+  <div class="field is-grouped box is-fullwidth is-bottomless">
+    <div class="control">
+      <button type="submit" class="button is-primary" id="decrypt" data-test-button-decrypt>
+          Decrypt
+      </button>
     </div>
-  {{/if}}
+  </div>
 </form>
 {{#if isModalActive}}
 <Modal @title="Copy your unwrapped data" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
-      {{#if (and plaintext ciphertext)}}
-        <p>{{plaintext}}</p>
-      {{else}}
-        <p>{{ciphertext}}</p>
-      {{/if}}
+      <p>{{plaintext}}</p>
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
+    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{plaintext}}
       @buttonType="button" @success={{action "toggleModal"}}>
       Copy & Close
     </CopyButton>

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -105,3 +105,20 @@
     </div>
   {{/if}}
 </form>
+<Modal @title="Copy Your Token" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
+  <section class="modal-card-body">
+    <div class="box is-shadowless is-fullwidth is-sideless">
+      {{#if (and plaintext ciphertext)}}
+        <p>{{ciphertext}}</p>
+      {{else}}
+        <p>{{plaintext}}</p>
+      {{/if}}
+    </div>
+  </section>
+  <footer class="modal-card-foot">
+    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
+      @buttonType="button" @success={{action "toggleModal"}}>
+      Copy & Close
+    </CopyButton>
+  </footer>
+</Modal>

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -73,12 +73,13 @@
 <Modal
   @title="Copy your token"
   @onClose={{action (mut isModalActive) false}}
-  @isActive={{isModalActive}}>
+  @isActive={{isModalActive}}
+  data-test-encrypt-modal>
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Ciphertext</h2>
       <div class="copy-text level">
-        <code class="level-left">{{ciphertext}}</code>
+        <code class="level-left" data-test-encrypted-value="ciphertext">{{ciphertext}}</code>
         <CopyButton
           class="button is-compact is-transparent level-right"
           data-test-button="modal-copy"

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -90,12 +90,12 @@
   </section>
   <footer class="modal-card-foot">
     <CopyButton
-      class="button is-primary"
+      class="button is-primary copy-close"
       data-test-button="modal-copy-close"
       @clipboardText={{ciphertext}}
       @buttonType="button"
       @success={{action "toggleModal"}}>
-      Copy & Close
+      Copy &amp; Close
     </CopyButton>
   </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -1,7 +1,9 @@
 <form {{action 'doSubmit' (hash plaintext=plaintext context=context nonce=nonce key_version=key_version encodedBase64=encodedBase64) on="submit"}}>
     <div class="box is-sideless is-fullwidth is-marginless">
-      <p>You can encrypt plaintext data using <code>{{key.name}}</code> as the encryption key.</p>
       <NamespaceReminder @mode="perform" @noun="encryption" />
+      <div class="content">
+        <p>You can encrypt plaintext data using <code>{{key.name}}</code> as the encryption key.</p>
+      </div>
       {{key-version-select
         key=key
         onVersionChange=(action (mut key_version))

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -74,15 +74,17 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Ciphertext</h2>
-      <span><code>{{ciphertext}}</code></span>
-      <CopyButton
-        class="button is-compact is-transparent"
-        data-test-button="modal-copy"
-        @clipboardText={{ciphertext}}
-        @buttonType="button"
-        @success={{action (set-flash-message 'Ciphertext copied!')}}>
-        <Icon @glyph="copy-action" aria-label="Copy" />
-      </CopyButton>
+      <div class="copy-text">
+        <code>{{ciphertext}}</code>
+        <CopyButton
+          class="button is-compact is-transparent"
+          data-test-button="modal-copy"
+          @clipboardText={{ciphertext}}
+          @buttonType="button"
+          @success={{action (set-flash-message 'Ciphertext copied!')}}>
+          <Icon @glyph="copy-action" aria-label="Copy" />
+        </CopyButton>
+      </div>
     </div>
   </section>
   <footer class="modal-card-foot">

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -1,5 +1,6 @@
 <form {{action 'doSubmit' (hash plaintext=plaintext context=context nonce=nonce key_version=key_version encodedBase64=encodedBase64) on="submit"}}>
     <div class="box is-sideless is-fullwidth is-marginless">
+      <p>You can encrypt plaintext data using <code>{{key.name}}</code> as the encryption key.</p>
       <NamespaceReminder @mode="perform" @noun="encryption" />
       {{key-version-select
         key=key
@@ -74,10 +75,10 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Ciphertext</h2>
-      <div class="copy-text">
-        <code>{{ciphertext}}</code>
+      <div class="copy-text level">
+        <code class="level-left">{{ciphertext}}</code>
         <CopyButton
-          class="button is-compact is-transparent"
+          class="button is-compact is-transparent level-right"
           data-test-button="modal-copy"
           @clipboardText={{ciphertext}}
           @buttonType="button"

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -98,20 +98,10 @@
     </div>
     <div class="field is-grouped box is-fullwidth is-bottomless">
       <div class="control">
-        <button type="submit" class="button is-primary" data-test-button-encrypt onsubmit={{action "toggleModal"}}>
+        <button type="submit" class="button is-primary" data-test-button-encrypt>
           Encrypt
         </button>
       </div>
     </div>
   {{/if}}
 </form>
-<Modal
-  @title="Copy Your Token"
-  @onClose={{action "toggleModal"}}
-  @isActive={{isModalActive}}>
-  <p>Ciphertext</p>
-  <div class="box is-shadowless is-fullwidth is-sideless">
-    <InfoTableRow @label="TTL" @value="8 hours, 30 minutes" />
-    <InfoTableRow @label="Expires" @value="8 hours, 30 minutes" />
-  </div>
-</Modal>

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -67,15 +67,31 @@
       </div>
     </div>
 </form>
-<Modal @title="Copy Your Token" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
+<Modal
+  @title="Copy Your Token"
+  @onClose={{action (mut isModalActive) false}}
+  @isActive={{isModalActive}}>
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
-      <p>{{ciphertext}}</p>
+      <h2 class="title is-6">Ciphertext</h2>
+      <span><code>{{ciphertext}}</code></span>
+      <CopyButton
+        class="button is-compact is-transparent"
+        data-test-button="modal-copy"
+        @clipboardText={{ciphertext}}
+        @buttonType="button"
+        @success={{action (set-flash-message 'Ciphertext copied!')}}>
+        <Icon @glyph="copy-action" aria-label="Copy" />
+      </CopyButton>
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
-      @buttonType="button" @success={{action "toggleModal"}}>
+    <CopyButton
+      class="button is-primary"
+      data-test-button="modal-copy-close"
+      @clipboardText={{ciphertext}}
+      @buttonType="button"
+      @success={{action "toggleModal"}}>
       Copy & Close
     </CopyButton>
   </footer>

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -98,7 +98,7 @@
     </div>
     <div class="field is-grouped box is-fullwidth is-bottomless">
       <div class="control">
-        <button type="submit" class="button is-primary" data-test-button-encrypt>
+        <button type="submit" class="button is-primary" data-test-button-encrypt onsubmit={{action "toggleModal"}}>
           Encrypt
         </button>
       </div>
@@ -107,7 +107,11 @@
 </form>
 <Modal
   @title="Copy Your Token"
-  @onClose={{action "closeModal"}}
+  @onClose={{action "toggleModal"}}
   @isActive={{isModalActive}}>
   <p>Ciphertext</p>
+  <div class="box is-shadowless is-fullwidth is-sideless">
+    <InfoTableRow @label="TTL" @value="8 hours, 30 minutes" />
+    <InfoTableRow @label="Expires" @value="8 hours, 30 minutes" />
+  </div>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -97,7 +97,7 @@
       data-test-button="modal-copy-close"
       @clipboardText={{ciphertext}}
       @buttonType="button"
-      @success={{action "toggleModal"}}>
+      @success={{action "toggleModal" "Ciphertext copied!"}}>
       Copy &amp; Close
     </CopyButton>
   </footer>

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -68,7 +68,7 @@
     </div>
 </form>
 <Modal
-  @title="Copy Your Token"
+  @title="Copy your token"
   @onClose={{action (mut isModalActive) false}}
   @isActive={{isModalActive}}>
   <section class="modal-card-body">

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -107,6 +107,7 @@
 </form>
 <Modal
   @title="Copy Your Token"
-  @onClose={{this.closeModal}}>
+  @onClose={{action "closeModal"}}
+  @isActive={{isModalActive}}>
   <p>Ciphertext</p>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -105,3 +105,8 @@
     </div>
   {{/if}}
 </form>
+<Modal
+  @title="Copy Your Token"
+  @onClose={{this.closeModal}}>
+  <p>Ciphertext</p>
+</Modal>

--- a/ui/app/templates/components/transit-key-action/encrypt.hbs
+++ b/ui/app/templates/components/transit-key-action/encrypt.hbs
@@ -1,41 +1,4 @@
 <form {{action 'doSubmit' (hash plaintext=plaintext context=context nonce=nonce key_version=key_version encodedBase64=encodedBase64) on="submit"}}>
-  {{#if (and plaintext ciphertext)}}
-    <div class="box is-sideless is-fullwidth is-marginless">
-      <div class="field">
-        <label for="ciphertext" class="is-label">Ciphertext</label>
-        <div id="ciphertext-control" class="control is-expanded">
-          {{ivy-codemirror
-            value=ciphertext
-            options=(hash
-              readOnly=true
-              lineNumbers=true
-              tabSize=2
-              mode='ruby'
-              theme='hashi'
-            )
-            data-test-transit-input="ciphertext"
-          }}
-        </div>
-      </div>
-    </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
-        {{#copy-button
-          clipboardText=ciphertext
-          class="button is-primary"
-          buttonType="button"
-          success=(action (set-flash-message 'Ciphertext copied!'))
-        }}
-          Copy
-        {{/copy-button}}
-      </div>
-      <div class="control">
-        <button {{action "onClear"}} type="button" class="button" data-test-encrypt-back-button>
-          Back
-        </button>
-      </div>
-    </div>
-  {{else}}
     <div class="box is-sideless is-fullwidth is-marginless">
       <NamespaceReminder @mode="perform" @noun="encryption" />
       {{key-version-select
@@ -103,16 +66,11 @@
         </button>
       </div>
     </div>
-  {{/if}}
 </form>
 <Modal @title="Copy Your Token" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
-      {{#if (and plaintext ciphertext)}}
-        <p>{{ciphertext}}</p>
-      {{else}}
-        <p>{{plaintext}}</p>
-      {{/if}}
+      <p>{{ciphertext}}</p>
     </div>
   </section>
   <footer class="modal-card-foot">

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -5,8 +5,8 @@
 >
   {{#if (or keys wrappedToken) }}
     <div class="box is-sideless is-fullwidth is-marginless">
-      <div class="box is-borderless">
-        <p>You can rewrap the provided ciphertext using the latest version of <code>{{key.name}}</code> as the encryption key.
+      <div class="content">
+        <p>Export a key using <code>{{key.name}}</code> as the encryption key.
         </p>
       </div>
       <div class="field">
@@ -56,9 +56,8 @@
     </div>
   {{else}}
     <div class="box is-sideless is-fullwidth is-marginless">
-      <div class="box is-borderless">
-        <p>You can rewrap the provided ciphertext using the latest version of <code>{{key.name}}</code> as the encryption key.
-        </p>
+      <div class="content">
+        <p>Export a key using <code>{{key.name}}</code> as the encryption key.</p>
       </div>
       <div class="field">
         <label for="type" class="is-label">Key type</label>
@@ -140,3 +139,5 @@
     </CopyButton>
   </footer>
 </Modal>
+
+{{!-- show eithe wrapped key or exported key --}}

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -5,11 +5,26 @@
 >
   {{#if (or keys wrappedToken) }}
     <div class="box is-sideless is-fullwidth is-marginless">
+      <div class="box is-borderless">
+        <p>You can rewrap the provided ciphertext using the latest version of <code>{{key.name}}</code> as the encryption key.
+        </p>
+      </div>
       <div class="field">
         {{#if wrapTTL}}
           <label for="export" class="is-label">Wrapped Key</label>
           <div class="control">
-            <textarea readonly nowrap wrap="off" class="textarea" id="export">{{wrappedToken}}</textarea>
+            {{ivy-codemirror
+              id="export"
+              value=wrappedToken
+              valueUpdated=(action (mut wrappedToken))
+              options=(hash
+                lineNumbers=true
+                tabSize=2
+                mode='ruby'
+                theme='hashi'
+                readOnly=true
+              )
+            }}
           </div>
         {{else}}
           <label class="is-label">Exported Key</label>
@@ -41,6 +56,10 @@
     </div>
   {{else}}
     <div class="box is-sideless is-fullwidth is-marginless">
+      <div class="box is-borderless">
+        <p>You can rewrap the provided ciphertext using the latest version of <code>{{key.name}}</code> as the encryption key.
+        </p>
+      </div>
       <div class="field">
         <label for="type" class="is-label">Key type</label>
         <div class="control is-expanded">
@@ -101,3 +120,23 @@
     </div>
   {{/if}}
 </form>
+<Modal @title="Copy your wrapped key" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
+  <section class="modal-card-body">
+    <div class="box is-shadowless is-fullwidth is-sideless">
+      <h2 class="title is-6">Wrapped Key</h2>
+      <div class="copy-text level">
+        <code class="level-left">{{wrappedToken}}</code>
+        <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
+          @clipboardText={{wrappedToken}} @buttonType="button" @success={{action (set-flash-message 'Token copied!')}}>
+          <Icon @glyph="copy-action" aria-label="Copy" />
+        </CopyButton>
+      </div>
+    </div>
+  </section>
+  <footer class="modal-card-foot">
+    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{wrappedToken}}
+      @buttonType="button" @success={{action "toggleModal"}}>
+      Copy & Close
+    </CopyButton>
+  </footer>
+</Modal>

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -3,137 +3,84 @@
        (hash wrapTTL=wrapTTL)
        on="submit" }}
 >
-  {{#if (or keys wrappedToken) }}
-    <div class="box is-sideless is-fullwidth is-marginless">
-      <div class="content">
-        <p>Export a key using <code>{{key.name}}</code> as the encryption key.
-        </p>
-      </div>
-      <div class="field">
-        {{#if wrapTTL}}
-          <label for="export" class="is-label">Wrapped Key</label>
-          <div class="control">
-            {{ivy-codemirror
-              id="export"
-              value=wrappedToken
-              valueUpdated=(action (mut wrappedToken))
-              options=(hash
-                lineNumbers=true
-                tabSize=2
-                mode='ruby'
-                theme='hashi'
-                readOnly=true
-              )
-            }}
-          </div>
-        {{else}}
-          <label class="is-label">Exported Key</label>
-          {{json-editor
-            value=(stringify keys)
-            options=(hash
-              readOnly=true
-            )
-          }}
-        {{/if}}
-      </div>
+  <div class="box is-sideless is-fullwidth is-marginless">
+    <div class="content">
+      <p>Export a key using <code>{{key.name}}</code> as the encryption key.</p>
     </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
-        {{#copy-button
-          clipboardText=(if wrapTTL wrappedToken (stringify keys))
-          class="button is-primary"
-          buttonType="button"
-          success=(action (set-flash-message (if wrapTTL 'Wrapped key copied!' 'Exported key copied!')))
-        }}
-          Copy
-        {{/copy-button}}
-      </div>
-      <div class="control">
-        <button {{action 'onClear'}} type="button" class="button">
-          Back
-        </button>
-      </div>
-    </div>
-  {{else}}
-    <div class="box is-sideless is-fullwidth is-marginless">
-      <div class="content">
-        <p>Export a key using <code>{{key.name}}</code> as the encryption key.</p>
-      </div>
-      <div class="field">
-        <label for="type" class="is-label">Key type</label>
-        <div class="control is-expanded">
-          <div class="select is-fullwidth">
-            <select
-               name="type"
-               id="type"
-               onchange={{action (mut exportKeyType) value="target.value"}}
-            >
-              {{#each key.exportKeyTypes as |currOption|}}
-                <option selected={{eq exportKeyType currOption}} value={{currOption}}>
-                  <code>{{currOption}}</code>
-                </option>
-              {{/each}}
-            </select>
-          </div>
+    <div class="field">
+      <label for="type" class="is-label">Key type</label>
+      <div class="control is-expanded">
+        <div class="select is-fullwidth">
+          <select
+              name="type"
+              id="type"
+              onchange={{action (mut exportKeyType) value="target.value"}}
+          >
+            {{#each key.exportKeyTypes as |currOption|}}
+              <option selected={{eq exportKeyType currOption}} value={{currOption}}>
+                <code>{{currOption}}</code>
+              </option>
+            {{/each}}
+          </select>
         </div>
       </div>
-      <div class="field">
-        <div class="b-checkbox">
-          {{input type="checkbox" name="exportVersion" id="exportVersion" class="styled" checked=exportVersion}}
-          <label for="exportVersion" class="is-label">
-            Export a single version
-          </label>
-        </div>
-        {{#if exportVersion}}
-          <div class="field">
-            <label for="version" class="is-label">Version</label>
-            <div class="control is-expanded">
-              <div class="select is-fullwidth">
-                <select
-                 name="version"
-                 id="version"
-                 onchange={{action (mut exportKeyVersion) value="target.value"}}
-                >
-                  {{#each key.validKeyVersions as |versionOption|}}
-                    <option selected={{eq exportKeyVersion versionOption}} value={{versionOption}}>
-                      <code>{{versionOption}}</code>
-                      {{#if (eq key.validKeyVersions.lastObject versionOption)}}
-                        <span> (latest) </span>
-                      {{/if}}
-                    </option>
-                  {{/each}}
-                </select>
-              </div>
+    </div>
+    <div class="field">
+      <div class="b-checkbox">
+        {{input type="checkbox" name="exportVersion" id="exportVersion" class="styled" checked=exportVersion}}
+        <label for="exportVersion" class="is-label">
+          Export a single version
+        </label>
+      </div>
+      {{#if exportVersion}}
+        <div class="field">
+          <label for="version" class="is-label">Version</label>
+          <div class="control is-expanded">
+            <div class="select is-fullwidth">
+              <select
+                name="version"
+                id="version"
+                onchange={{action (mut exportKeyVersion) value="target.value"}}
+              >
+                {{#each key.validKeyVersions as |versionOption|}}
+                  <option selected={{eq exportKeyVersion versionOption}} value={{versionOption}}>
+                    <code>{{versionOption}}</code>
+                    {{#if (eq key.validKeyVersions.lastObject versionOption)}}
+                      <span> (latest) </span>
+                    {{/if}}
+                  </option>
+                {{/each}}
+              </select>
             </div>
           </div>
-        {{/if}}
-      </div>
-      {{wrap-ttl onChange=(action (mut wrapTTL))}}
+        </div>
+      {{/if}}
     </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
-        <button type="submit" class="button is-primary">
-          Export key
-        </button>
-      </div>
+    {{wrap-ttl onChange=(action (mut wrapTTL))}}
+  </div>
+  <div class="field is-grouped box is-fullwidth is-bottomless">
+    <div class="control">
+      <button type="submit" class="button is-primary">
+        Export key
+      </button>
     </div>
-  {{/if}}
+  </div>
 </form>
 <Modal @title="Copy your wrapped key" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Wrapped Key</h2>
       <div class="copy-text level">
-        <code data-test-encrypted-value="export" class="level-left">{{wrappedToken}}</code>
+        <code data-test-encrypted-value="export" class="level-left">{{if wrapTTL wrappedToken (stringify keys)}}</code>
         <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
-          @clipboardText={{wrappedToken}} @buttonType="button" @success={{action (set-flash-message 'Token copied!')}}>
+          @clipboardText={{if wrapTTL wrappedToken (stringify keys)}} @buttonType="button" @success={{action (set-flash-message 'Token copied!')}}>
           <Icon @glyph="copy-action" aria-label="Copy" />
         </CopyButton>
       </div>
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{wrappedToken}}
+    <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{if wrapTTL wrappedToken (stringify keys)}}
       @buttonType="button" @success={{action "toggleModal"}}>
       Copy &amp; Close
     </CopyButton>

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -81,10 +81,8 @@
   </section>
   <footer class="modal-card-foot">
     <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{if wrapTTL wrappedToken (stringify keys)}}
-      @buttonType="button" @success={{action "toggleModal"}}>
+      @buttonType="button" @success={{action "toggleModal" "Token copied!"}}>
       Copy &amp; Close
     </CopyButton>
   </footer>
 </Modal>
-
-{{!-- show eithe wrapped key or exported key --}}

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -134,9 +134,9 @@
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{wrappedToken}}
+    <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{wrappedToken}}
       @buttonType="button" @success={{action "toggleModal"}}>
-      Copy & Close
+      Copy &amp; Close
     </CopyButton>
   </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -124,7 +124,7 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Wrapped Key</h2>
       <div class="copy-text level">
-        <code class="level-left">{{wrappedToken}}</code>
+        <code data-test-encrypted-value="export" class="level-left">{{wrappedToken}}</code>
         <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
           @clipboardText={{wrappedToken}} @buttonType="button" @success={{action (set-flash-message 'Token copied!')}}>
           <Icon @glyph="copy-action" aria-label="Copy" />

--- a/ui/app/templates/components/transit-key-action/export.hbs
+++ b/ui/app/templates/components/transit-key-action/export.hbs
@@ -71,7 +71,7 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Wrapped Key</h2>
       <div class="copy-text level">
-        <code data-test-encrypted-value="export" class="level-left">{{if wrapTTL wrappedToken (stringify keys)}}</code>
+        <pre data-test-encrypted-value="export" class="level-left">{{if wrapTTL wrappedToken (stringify keys)}}</pre>
         <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
           @clipboardText={{if wrapTTL wrappedToken (stringify keys)}} @buttonType="button" @success={{action (set-flash-message 'Token copied!')}}>
           <Icon @glyph="copy-action" aria-label="Copy" />

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -62,9 +62,11 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       {{#if hmac}}
-        <p>{{hmac}}</p>
+        <h2 class="title is-6">HMAC</h2>
+        <span><code>{{hmac}}</code></span>
       {{else}}
-        <p>{{input}}</p>
+        <h2 class="title is-6">Input</h2>
+        <span><code>{{input}}</code></span>
       {{/if}}
     </div>
   </section>

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -1,7 +1,9 @@
 <form {{action 'doSubmit' (hash input=input algorithm=algorithm key_version=key_version) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">
-    <p>Generate the digest of given data using the specified hash algorithm and <code>{{key.name}}</code> as the named key.</p>
     <NamespaceReminder @mode="perform" @noun="HMAC creation" />
+    <div class="content">
+      <p>Generate the digest of given data using the specified hash algorithm and <code>{{key.name}}</code> as the named key.</p>
+    </div>
     {{key-version-select
       key=key
       onVersionChange=(action (mut key_version))

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -62,13 +62,14 @@
 <Modal @title="Copy your unwrapped data" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
-      {{#if hmac}}
-        <h2 class="title is-6">HMAC</h2>
-        <span><code>{{hmac}}</code></span>
-      {{else}}
-        <h2 class="title is-6">Input</h2>
-        <span><code>{{input}}</code></span>
-      {{/if}}
+      <h2 class="title is-6">HMAC</h2>
+      <div class="copy-text level">
+        <code class="level-left">{{hmac}}</code>
+        <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
+          @clipboardText={{hmac}} @buttonType="button" @success={{action (set-flash-message 'HMAC copied!')}}>
+          <Icon @glyph="copy-action" aria-label="Copy" />
+        </CopyButton>
+      </div>
     </div>
   </section>
   <footer class="modal-card-foot">

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -1,5 +1,6 @@
 <form {{action 'doSubmit' (hash input=input algorithm=algorithm key_version=key_version) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">
+    <p>Generate the digest of given data using the specified hash algorithm and <code>{{key.name}}</code> as the named key.</p>
     <NamespaceReminder @mode="perform" @noun="HMAC creation" />
     {{key-version-select
       key=key

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -1,100 +1,62 @@
 <form {{action 'doSubmit' (hash input=input algorithm=algorithm key_version=key_version) on="submit"}}>
-  {{#if hmac}}
-    <div class="box is-sideless is-fullwidth is-marginless">
-      <div class="field">
-        <label for="hmac" class="is-label">HMAC</label>
-        <div id="hmac-control" class="control">
-          {{ivy-codemirror
-            value=hmac
-            options=(hash
-              readOnly=true
-              lineNumbers=true
-              tabSize=2
-              mode='ruby'
-              theme='hashi'
-            )
-          }}
-        </div>
-      </div>
-    </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
-        {{#copy-button
-          clipboardText=hmac
-          class="button is-primary"
-          buttonType="button"
-          success=(action (set-flash-message 'HMAC copied!'))
+  <div class="box is-sideless is-fullwidth is-marginless">
+    <NamespaceReminder @mode="perform" @noun="HMAC creation" />
+    {{key-version-select
+      key=key
+      onVersionChange=(action (mut key_version))
+      key_version=key_version
+    }}
+    <div class="field">
+      <label for="input" class="is-label">
+        Input
+      </label>
+      <div id="input-control" class="control is-relative">
+        {{ivy-codemirror
+          valueUpdated=(action (mut input))
+          options=(hash
+            lineNumbers=true
+            tabSize=2
+            mode='ruby'
+            theme='hashi'
+          )
+          data-test-transit-input="input"
         }}
-          Copy
-        {{/copy-button}}
-      </div>
-      <div class="control">
-        <button {{action 'onClear'}} type="button" class="button">
-          Back
-        </button>
       </div>
     </div>
-  {{else}}
-    <div class="box is-sideless is-fullwidth is-marginless">
-      <NamespaceReminder @mode="perform" @noun="HMAC creation" />
-      {{key-version-select
-        key=key
-        onVersionChange=(action (mut key_version))
-        key_version=key_version
-      }}
-      <div class="field">
-        <label for="input" class="is-label">
-          Input
-        </label>
-        <div id="input-control" class="control is-relative">
-          {{ivy-codemirror
-            value=input
-            valueUpdated=(action (mut input))
-            options=(hash
-              lineNumbers=true
-              tabSize=2
-              mode='ruby'
-              theme='hashi'
-            )
-            data-test-transit-input="input"
-          }}
-        </div>
-      </div>
-      <div class="field">
-        {{input
-          type="checkbox"
-          id="encodedBase64"
-          checked=encodedBase64
-          data-test-transit-input="encodedBase64" }}
-        <label for="encodedBase64">This data is already encoded in base64</label>
-      </div>
-      <div class="field">
-        <label for="algorithm" class="is-label">Hash Algorithm</label>
-        <div class="control is-expanded">
-          <div class="select is-fullwidth">
-            <select
-             name="algorithm"
-             id="algorithm"
-             onchange={{action (mut algorithm) value="target.value"}}
-             >
-               {{#each (sha2-digest-sizes) as |algo|}}
-                 <option selected={{if algorithm (eq algorithm algo)}} value={{algo}}>
-                   <code>{{algo}}</code>
-                 </option>
-               {{/each}}
-            </select>
-          </div>
+    <div class="field">
+      {{input
+        type="checkbox"
+        id="encodedBase64"
+        checked=encodedBase64
+        data-test-transit-input="encodedBase64" }}
+      <label for="encodedBase64">This data is already encoded in base64</label>
+    </div>
+    <div class="field">
+      <label for="algorithm" class="is-label">Hash Algorithm</label>
+      <div class="control is-expanded">
+        <div class="select is-fullwidth">
+          <select
+            name="algorithm"
+            id="algorithm"
+            onchange={{action (mut algorithm) value="target.value"}}
+            >
+              {{#each (sha2-digest-sizes) as |algo|}}
+                <option selected={{if algorithm (eq algorithm algo)}} value={{algo}}>
+                  <code>{{algo}}</code>
+                </option>
+              {{/each}}
+          </select>
         </div>
       </div>
     </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
-        <button type="submit" class="button is-primary">
-          HMAC
-        </button>
-      </div>
+  </div>
+  <div class="field is-grouped box is-fullwidth is-bottomless">
+    <div class="control">
+      <button type="submit" class="button is-primary">
+        HMAC
+      </button>
     </div>
-  {{/if}}
+  </div>
 </form>
 <Modal @title="Copy your unwrapped data" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
   <section class="modal-card-body">

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -96,3 +96,20 @@
     </div>
   {{/if}}
 </form>
+<Modal @title="Copy your unwrapped data" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
+  <section class="modal-card-body">
+    <div class="box is-shadowless is-fullwidth is-sideless">
+      {{#if hmac}}
+        <p>{{hmac}}</p>
+      {{else}}
+        <p>{{input}}</p>
+      {{/if}}
+    </div>
+  </section>
+  <footer class="modal-card-foot">
+    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{hmac}}
+      @buttonType="button" @success={{action "toggleModal"}}>
+      Copy & Close
+    </CopyButton>
+  </footer>
+</Modal>

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -66,7 +66,7 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">HMAC</h2>
       <div class="copy-text level">
-        <code class="level-left">{{hmac}}</code>
+        <code class="level-left" data-test-encrypted-value="hmac">{{hmac}}</code>
         <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
           @clipboardText={{hmac}} @buttonType="button" @success={{action (set-flash-message 'HMAC copied!')}}>
           <Icon @glyph="copy-action" aria-label="Copy" />

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -76,7 +76,7 @@
   </section>
   <footer class="modal-card-foot">
     <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{hmac}}
-      @buttonType="button" @success={{action "toggleModal"}}>
+      @buttonType="button" @success={{action "toggleModal" "HMAC copied!"}}>
       Copy &amp; Close
     </CopyButton>
   </footer>

--- a/ui/app/templates/components/transit-key-action/hmac.hbs
+++ b/ui/app/templates/components/transit-key-action/hmac.hbs
@@ -73,9 +73,9 @@
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{hmac}}
+    <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{hmac}}
       @buttonType="button" @success={{action "toggleModal"}}>
-      Copy & Close
+      Copy &amp; Close
     </CopyButton>
   </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -80,7 +80,7 @@
   </section>
   <footer class="modal-card-foot">
     <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
-      @buttonType="button" @success={{action "toggleModal"}}>
+      @buttonType="button" @success={{action "toggleModal" "Ciphertext copied!"}}>
       Copy &amp; Close
     </CopyButton>
   </footer>

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -70,7 +70,7 @@
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Ciphertext</h2>
       <div class="copy-text level">
-        <code class="level-left">{{ciphertext}}</code>
+        <code class="level-left" data-test-encrypted-value="ciphertext">{{ciphertext}}</code>
         <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
           @clipboardText={{ciphertext}} @buttonType="button" @success={{action (set-flash-message 'Ciphertext copied!')}}>
           <Icon @glyph="copy-action" aria-label="Copy" />

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -63,3 +63,16 @@
     </div>
   </div>
 </form>
+<Modal @title="Copy your token" @onClose={{action (mut isModalActive)}} @isActive={{isModalActive}}>
+  <section class="modal-card-body">
+    <div class="box is-shadowless is-fullwidth is-sideless">
+      <p>{{ciphertext}}</p>
+    </div>
+  </section>
+  <footer class="modal-card-foot">
+    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
+      @buttonType="button" @success={{action "toggleModal"}}>
+      Copy & Close
+    </CopyButton>
+  </footer>
+</Modal>

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -1,7 +1,7 @@
 <form {{action 'doSubmit' (hash ciphertext=ciphertext context=context nonce=nonce key_version=key_version) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode="perform" @noun="rewrap" />
-      <div class="transit-description">
+      <div class="content">
         <p>You can rewrap the provided ciphertext using the latest version of <code>{{key.name}}</code> as the encryption key.</p>
       </div>
     {{key-version-select

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -10,7 +10,6 @@
       <label for="ciphertext" class="is-label">Ciphertext</label>
       <div class="control is-expanded">
         {{ivy-codemirror
-            value=ciphertext
             valueUpdated=(action (mut ciphertext))
             options=(hash
               lineNumbers=true

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -65,7 +65,8 @@
 <Modal @title="Copy your token" @onClose={{action (mut isModalActive)}} @isActive={{isModalActive}}>
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
-      <p>{{ciphertext}}</p>
+      <h2 class="title is-6">Ciphertext</h2>
+      <span><code>{{ciphertext}}</code></span>
     </div>
   </section>
   <footer class="modal-card-foot">

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -1,6 +1,9 @@
 <form {{action 'doSubmit' (hash ciphertext=ciphertext context=context nonce=nonce key_version=key_version) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode="perform" @noun="rewrap" />
+      <div class="transit-description">
+        <p>You can rewrap the provided ciphertext using the latest version of <code>{{key.name}}</code> as the encryption key.</p>
+      </div>
     {{key-version-select
       key=key
       onVersionChange=(action (mut key_version))

--- a/ui/app/templates/components/transit-key-action/rewrap.hbs
+++ b/ui/app/templates/components/transit-key-action/rewrap.hbs
@@ -69,13 +69,19 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
       <h2 class="title is-6">Ciphertext</h2>
-      <span><code>{{ciphertext}}</code></span>
+      <div class="copy-text level">
+        <code class="level-left">{{ciphertext}}</code>
+        <CopyButton class="button is-compact is-transparent level-right" data-test-button="modal-copy"
+          @clipboardText={{ciphertext}} @buttonType="button" @success={{action (set-flash-message 'Ciphertext copied!')}}>
+          <Icon @glyph="copy-action" aria-label="Copy" />
+        </CopyButton>
+      </div>
     </div>
   </section>
   <footer class="modal-card-foot">
-    <CopyButton class="button is-primary" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
+    <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{ciphertext}}
       @buttonType="button" @success={{action "toggleModal"}}>
-      Copy & Close
+      Copy &amp; Close
     </CopyButton>
   </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/sign.hbs
+++ b/ui/app/templates/components/transit-key-action/sign.hbs
@@ -1,121 +1,138 @@
-<form {{action 'doSubmit' (hash input=input hash_algorithm=hash_algorithm signature_algorithm=signature_algorithm key_version=key_version context=context prehashed=prehashed) on="submit"}}>
-  {{#if signature}}
-    <div class="box is-sideless is-fullwidth is-marginless">
-      <div class="field">
-        <label for="signature" class="is-label">Signature</label>
-        <div class="control">
-          <textarea readonly class="textarea" id="signature">{{signature}}</textarea>
-        </div>
+<form {{action 'doSubmit' (hash input=input hash_algorithm=hash_algorithm signature_algorithm=signature_algorithm key_version=key_version context=context prehashed=prehashed encodedBase64=encodedBase64) on="submit"}}>
+  <div class="box is-sideless is-fullwidth is-marginless">
+    <NamespaceReminder @mode="perform" @noun="signing" />
+    <div class="content">
+      <p>Return the cryptographic signature of the given data using <code>{{key.name}}</code> as the encryption key and the specified hash algorithm.</p>
+    </div>
+    {{key-version-select
+      key=key
+      onVersionChange=(action (mut key_version))
+      key_version=key_version
+    }}
+    <div class="field">
+      <label for="input" class="is-label">
+        Input
+      </label>
+      <div class="control is-relative">
+        {{ivy-codemirror
+            value=input
+            valueUpdated=(action (mut input))
+            options=(hash
+              lineNumbers=true
+              tabSize=2
+              mode='ruby'
+              theme='hashi'
+            )
+            data-test-transit-input="input"
+          }}
       </div>
     </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
-        {{#copy-button
-          clipboardTarget="#signature"
-          class="button is-primary"
-          buttonType="button"
-          success=(action (set-flash-message 'Signature copied!'))
-        }}
-          Copy
-        {{/copy-button}}
-      </div>
-      <div class="control">
-        <button {{action 'onClear'}} type="button" class="button">
-          Back
-        </button>
-      </div>
+    <div class="field">
+      {{input type="checkbox" id="encodedBase64" checked=encodedBase64 data-test-transit-input="encodedBase64"}}
+      <label for="encodedBase64">This data is already encoded in base64</label>
     </div>
-  {{else}}
-    <div class="box is-sideless is-fullwidth is-marginless">
-      <NamespaceReminder @mode="perform" @noun="signing" />
-      <div class="content">
-        <p>Return the cryptographic signature of the given data using <code>{{key.name}}</code> as the encryption key and the specified hash algorithm.</p>
-      </div>
-      {{key-version-select
-        key=key
-        onVersionChange=(action (mut key_version))
-        key_version=key_version
-      }}
+    {{#if key.derived}}
       <div class="field">
-        <label for="input" class="is-label">
-          Input
+        <label for="context" class="is-label">
+          Context
         </label>
-        <div class="control is-relative">
-          {{textarea id="input" name="input" value=input class="textarea" data-test-transit-input="input"}}
-          {{b64-toggle value=input isInput=false data-test-transit-b64-toggle="input"}}
+        <div class="field has-addons">
+          <div class="control">
+            {{input type="text" id="context" value=context class="input" data-test-transit-input="context"}}
+          </div>
+          <div class="control">
+            {{b64-toggle value=context data-test-transit-b64-toggle="context"}}
+          </div>
         </div>
       </div>
-      {{#if key.derived}}
-        <div class="field">
-          <label for="context" class="is-label">
-            Context
-          </label>
-          <div class="field has-addons">
-            <div class="control">
-              {{input type="text" id="context" value=context class="input" data-test-transit-input="context"}}
-            </div>
-            <div class="control">
-              {{b64-toggle value=context data-test-transit-b64-toggle="context"}}
-            </div>
+    {{/if}}
+    <div class="field">
+      <div class="level is-mobile">
+        <div class="level-left">
+          <label for="hash_algorithm" class="is-label">Hash Algorithm</label>
+        </div>
+        <div class="level-right">
+          <div class="control is-flex">
+            {{input  id="prehashed" type="checkbox" name="prehashed" class="switch is-rounded is-success is-small" checked=prehashed }}
+            <label for="prehashed">Prehashed</label>
           </div>
         </div>
-      {{/if}}
+      </div>
+      <div class="control is-expanded">
+        <div class="select is-fullwidth">
+          <select
+            name="hash_algorithm"
+            id="hash_algorithm"
+            onchange={{action (mut hash_algorithm) value="target.value"}}
+            >
+            {{#each (sha2-digest-sizes) as |algo|}}
+              <option selected={{if hash_algorithm (eq hash_algorithm algo) (eq algo 'sha2-256')}} value={{algo}}>
+                {{algo}}
+              </option>
+            {{/each}}
+          </select>
+        </div>
+      </div>
+    </div>
+    {{#if (or (eq key.type 'rsa-2048') (eq key.type 'rsa-3072') (eq key.type 'rsa-4096'))}}
       <div class="field">
-        <div class="level is-mobile">
-          <div class="level-left">
-            <label for="hash_algorithm" class="is-label">Hash Algorithm</label>
-          </div>
-          <div class="level-right">
-            <div class="control is-flex">
-              {{input  id="prehashed" type="checkbox" name="prehashed" class="switch is-rounded is-success is-small" checked=prehashed }}
-              <label for="prehashed">Prehashed</label>
-            </div>
-          </div>
-        </div>
+        <label for="signature_algorithm" class="is-label">Signature Algorithm</label>
         <div class="control is-expanded">
           <div class="select is-fullwidth">
             <select
-             name="hash_algorithm"
-             id="hash_algorithm"
-             onchange={{action (mut hash_algorithm) value="target.value"}}
-             >
-             {{#each (sha2-digest-sizes) as |algo|}}
-               <option selected={{if hash_algorithm (eq hash_algorithm algo) (eq algo 'sha2-256')}} value={{algo}}>
-                 {{algo}}
-               </option>
-             {{/each}}
+              name="signature_algorithm"
+              id="signature_algorithm"
+              data-test-signature-algorithm="true"
+              onchange={{action (mut signature_algorithm) value="target.value"}}
+              >
+              {{#each (array 'pss' 'pkcs1v15') as |sigAlgo|}}
+                <option selected={{if signature_algorithm (eq signature_algorithm sigAlgo) (eq sigAlgo 'pss')}} value={{sigAlgo}}>
+                  {{sigAlgo}}
+                </option>
+              {{/each}}
             </select>
           </div>
         </div>
       </div>
-      {{#if (or (eq key.type 'rsa-2048') (eq key.type 'rsa-3072') (eq key.type 'rsa-4096'))}}
-        <div class="field">
-          <label for="signature_algorithm" class="is-label">Signature Algorithm</label>
-          <div class="control is-expanded">
-            <div class="select is-fullwidth">
-              <select
-               name="signature_algorithm"
-               id="signature_algorithm"
-               data-test-signature-algorithm="true"
-               onchange={{action (mut signature_algorithm) value="target.value"}}
-               >
-               {{#each (array 'pss' 'pkcs1v15') as |sigAlgo|}}
-                 <option selected={{if signature_algorithm (eq signature_algorithm sigAlgo) (eq sigAlgo 'pss')}} value={{sigAlgo}}>
-                   {{sigAlgo}}
-                 </option>
-               {{/each}}
-              </select>
-            </div>
-          </div>
-        </div>
-      {{/if}}
+    {{/if}}
+  </div>
+  <div class="field is-grouped box is-fullwidth is-bottomless">
+    <div class="control">
+      <button type="submit" disabled={{loading}} class="button is-primary {{if loading 'is-loading'}}">
+        Sign
+      </button>
     </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <div class="control">
-        <button type="submit" disabled={{loading}} class="button is-primary {{if loading 'is-loading'}}">
-          Sign
-        </button>
+  </div>
+</form>
+<Modal
+  @title="Copy your signature"
+  @onClose={{action (mut isModalActive) false}}
+  @isActive={{isModalActive}}
+  data-test-sign-modal>
+  <section class="modal-card-body">
+    <div class="box is-shadowless is-fullwidth is-sideless">
+      <h2 class="title is-6">Signature</h2>
+      <div class="copy-text level">
+        <code class="level-left" data-test-encrypted-value="signature">{{signature}}</code>
+        <CopyButton
+          class="button is-compact is-transparent level-right"
+          data-test-button="modal-copy"
+          @clipboardText={{signature}}
+          @buttonType="button"
+          @success={{action (set-flash-message 'Signature copied!')}}>
+          <Icon @glyph="copy-action" aria-label="Copy" />
+        </CopyButton>
       </div>
     </div>
-  {{/if}}
-</form>
+  </section>
+  <footer class="modal-card-foot">
+    <CopyButton
+      class="button is-primary copy-close"
+      data-test-button="modal-copy-close"
+      @clipboardText={{signature}}
+      @buttonType="button"
+      @success={{action "toggleModal" "Signature copied!"}}>
+      Copy &amp; Close
+    </CopyButton>
+  </footer>
+</Modal>

--- a/ui/app/templates/components/transit-key-action/sign.hbs
+++ b/ui/app/templates/components/transit-key-action/sign.hbs
@@ -28,6 +28,9 @@
   {{else}}
     <div class="box is-sideless is-fullwidth is-marginless">
       <NamespaceReminder @mode="perform" @noun="signing" />
+      <div class="content">
+        <p>Return the cryptographic signature of the given data using <code>{{key.name}}</code> as the encryption key and the specified hash algorithm.</p>
+      </div>
       {{key-version-select
         key=key
         onVersionChange=(action (mut key_version))

--- a/ui/app/templates/components/transit-key-action/verify.hbs
+++ b/ui/app/templates/components/transit-key-action/verify.hbs
@@ -1,23 +1,16 @@
 <form {{action "doSubmit" (hash input=input signature=signature signature_algorithm=signature_algorithm hmac=hmac hash_algorithm=hash_algorithm context=context prehashed=prehashed encodedBase64=encodedBase64) on="submit"}}>
   {{#if (not-eq valid null)}}
-    <div class="box is-sideless is-fullwidth is-marginless">
-      <h4 class="is-label">Verified</h4>
-      <div class="box">
-        <div class="columns is-centered">
-          <div class="column is-half has-text-centered">
-            <p class="box is-shadowless {{if valid 'has-text-success' 'has-text-danger'}}" data-test-transit-verify="true">
+    <Modal @title="Copy your unwrapped data" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
+      <section class="modal-card-body">
+        <div class="box is-shadowless is-fullwidth is-sideless">
+          <h4 class="is-label">Verified</h4>
+          <p class="box is-shadowless {{if valid 'has-text-success' 'has-text-danger'}}" data-test-transit-verify="true">
             <Icon @glyph={{if valid "check-plain" "cancel-plain"}} />
             The input is <b>{{if valid 'valid' 'not valid'}}</b> for the given {{if signature 'signature' 'hmac'}}.
-            </p>
-          </div>
+          </p>
         </div>
-      </div>
-    </div>
-    <div class="field is-grouped box is-fullwidth is-bottomless">
-      <button {{action 'onClear'}} type="button" class="button">
-        Back
-      </button>
-    </div>
+      </section>
+    </Modal>
   {{else}}
     <div class="box is-sideless is-fullwidth is-marginless">
       <div class="field">

--- a/ui/app/templates/components/transit-key-action/verify.hbs
+++ b/ui/app/templates/components/transit-key-action/verify.hbs
@@ -1,17 +1,4 @@
 <form {{action "doSubmit" (hash input=input signature=signature signature_algorithm=signature_algorithm hmac=hmac hash_algorithm=hash_algorithm context=context prehashed=prehashed encodedBase64=encodedBase64) on="submit"}}>
-  {{#if (not-eq valid null)}}
-    <Modal @title="Copy your unwrapped data" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
-      <section class="modal-card-body">
-        <div class="box is-shadowless is-fullwidth is-sideless">
-          <h4 class="is-label">Verified</h4>
-          <p class="box is-shadowless {{if valid 'has-text-success' 'has-text-danger'}}" data-test-transit-verify="true">
-            <Icon @glyph={{if valid "check-plain" "cancel-plain"}} />
-            The input is <b>{{if valid 'valid' 'not valid'}}</b> for the given {{if signature 'signature' 'hmac'}}.
-          </p>
-        </div>
-      </section>
-    </Modal>
-  {{else}}
     <div class="box is-sideless is-fullwidth is-marginless">
       <div class="field">
         <label for="input" class="is-label">
@@ -215,5 +202,15 @@
         </button>
       </div>
     </div>
-  {{/if}}
 </form>
+<Modal @title="Copy your unwrapped data" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
+  <section class="modal-card-body">
+    <div class="box is-shadowless is-fullwidth is-sideless">
+      <h4 class="is-label">Verified</h4>
+      <p class="box is-shadowless {{if valid 'has-text-success' 'has-text-danger'}}" data-test-transit-verify="true">
+        <Icon @glyph={{if valid "check-plain" "cancel-plain"}} />
+        The input is <b>{{if valid 'valid' 'not valid'}}</b> for the given {{if signature 'signature' 'hmac'}}.
+      </p>
+    </div>
+  </section>
+</Modal>

--- a/ui/app/templates/components/transit-key-action/verify.hbs
+++ b/ui/app/templates/components/transit-key-action/verify.hbs
@@ -1,6 +1,8 @@
 <form {{action "doSubmit" (hash input=input signature=signature signature_algorithm=signature_algorithm hmac=hmac hash_algorithm=hash_algorithm context=context prehashed=prehashed encodedBase64=encodedBase64) on="submit"}}>
     <div class="box is-sideless is-fullwidth is-marginless">
-      <p>Check whether the provided signature is valid for the given data.</p>
+      <div class="content">
+        <p>Check whether the provided signature is valid for the given data.</p>
+      </div>
       <div class="field">
         <label for="input" class="is-label">
           Input

--- a/ui/app/templates/components/transit-key-action/verify.hbs
+++ b/ui/app/templates/components/transit-key-action/verify.hbs
@@ -211,7 +211,7 @@
     <AlertBanner
       @type={{if valid 'success' 'danger'}}
       @title={{if valid 'Valid' 'Not Valid'}}
-      @message="The input is {{if valid 'valid' 'not valid'}} for the given {{if signature 'signature' 'hmac'}}"
+      @message="The input is {{if valid 'valid' 'not valid'}} for the given {{if signature 'signature' 'HMAC'}}"
       data-test-transit-verify="true"/>
   </section>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/verify.hbs
+++ b/ui/app/templates/components/transit-key-action/verify.hbs
@@ -206,14 +206,12 @@
       </div>
     </div>
 </form>
-<Modal @title="Copy your unwrapped data" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
+<Modal @title="Results" @onClose={{action (mut isModalActive) false}} @isActive={{isModalActive}}>
   <section class="modal-card-body">
-    <div class="box is-shadowless is-fullwidth is-sideless">
-      <h4 class="is-label">Verified</h4>
-      <p class="box is-shadowless {{if valid 'has-text-success' 'has-text-danger'}}" data-test-transit-verify="true">
-        <Icon @glyph={{if valid "check-plain" "cancel-plain"}} />
-        The input is <b>{{if valid 'valid' 'not valid'}}</b> for the given {{if signature 'signature' 'hmac'}}.
-      </p>
-    </div>
+    <AlertBanner
+      @type={{if valid 'success' 'danger'}}
+      @title={{if valid 'Valid' 'Not Valid'}}
+      @message="The input is {{if valid 'valid' 'not valid'}} for the given {{if signature 'signature' 'hmac'}}"
+      data-test-transit-verify="true"/>
   </section>
 </Modal>

--- a/ui/app/templates/components/transit-key-action/verify.hbs
+++ b/ui/app/templates/components/transit-key-action/verify.hbs
@@ -1,5 +1,6 @@
 <form {{action "doSubmit" (hash input=input signature=signature signature_algorithm=signature_algorithm hmac=hmac hash_algorithm=hash_algorithm context=context prehashed=prehashed encodedBase64=encodedBase64) on="submit"}}>
     <div class="box is-sideless is-fullwidth is-marginless">
+      <p>Check whether the provided signature is valid for the given data.</p>
       <div class="field">
         <label for="input" class="is-label">
           Input

--- a/ui/app/templates/components/transit-key-actions.hbs
+++ b/ui/app/templates/components/transit-key-actions.hbs
@@ -19,21 +19,4 @@
     </div>
    {{/if}}
 {{/if}}
-<Modal @title="Copy Your Token" @onClose={{action "toggleModal"}} @isActive={{isModalActive}}>
-    <section class="modal-card-body">
-    <div class="box is-shadowless is-fullwidth is-sideless">
-      <p>{{ciphertext}}</p>
-    </div>
-    </section>
-    <footer class="modal-card-foot">
-      <CopyButton
-        class="button is-primary"
-        data-test-button="modal-copy-close"
-        @clipboardText={{ciphertext}}
-        @buttonType="button"
-        @success={{action "toggleModal"}}
-      >
-        Copy & Close
-      </CopyButton>
-    </footer>
-</Modal>
+

--- a/ui/app/templates/components/transit-key-actions.hbs
+++ b/ui/app/templates/components/transit-key-actions.hbs
@@ -26,14 +26,14 @@
     </div>
     </section>
     <footer class="modal-card-foot">
-      {{#copy-button
-        data-test-button="modal-copy-close"
-        clipboardText=ciphertext
+      <CopyButton
         class="button is-primary"
-        buttonType="button"
-        success=(action (set-flash-message 'Ciphertext copied!'))
-      }}
+        data-test-button="modal-copy-close"
+        @clipboardText={{ciphertext}}
+        @buttonType="button"
+        @success={{action "toggleModal"}}
+      >
         Copy & Close
-      {{/copy-button}}
+      </CopyButton>
     </footer>
 </Modal>

--- a/ui/app/templates/components/transit-key-actions.hbs
+++ b/ui/app/templates/components/transit-key-actions.hbs
@@ -19,3 +19,21 @@
     </div>
    {{/if}}
 {{/if}}
+<Modal @title="Copy Your Token" @onClose={{action "toggleModal"}} @isActive={{isModalActive}}>
+    <section class="modal-card-body">
+    <div class="box is-shadowless is-fullwidth is-sideless">
+      <p>{{ciphertext}}</p>
+    </div>
+    </section>
+    <footer class="modal-card-foot">
+      {{#copy-button
+        data-test-button="modal-copy-close"
+        clipboardText=ciphertext
+        class="button is-primary"
+        buttonType="button"
+        success=(action (set-flash-message 'Ciphertext copied!'))
+      }}
+        Copy & Close
+      {{/copy-button}}
+    </footer>
+</Modal>

--- a/ui/package.json
+++ b/ui/package.json
@@ -114,6 +114,7 @@
     "ember-svg-jar": "^2.1.0",
     "ember-test-selectors": "^2.1.0",
     "ember-truth-helpers": "^2.1.0",
+    "ember-wormhole": "^0.5.5",
     "escape-string-regexp": "^2.0.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/ui/tests/acceptance/transit-test.js
+++ b/ui/tests/acceptance/transit-test.js
@@ -94,7 +94,6 @@ const testConvergentEncryption = async function(assert, keyName) {
       context: 'nqR8LiVgNh/lwO2rArJJE9F9DMhh0lKo4JX9DAAkCDw=',
       encodePlaintext: false,
       encodeContext: false,
-      decodeAfterDecrypt: false,
       assertAfterEncrypt: key => {
         assert.dom('.modal.is-active').exists(`${key}: Modal opens after encrypt`);
         assert.ok(
@@ -127,7 +126,6 @@ const testConvergentEncryption = async function(assert, keyName) {
       context: encodeString('context'),
       encodePlaintext: false,
       encodeContext: false,
-      decodeAfterDecrypt: false,
       assertAfterEncrypt: key => {
         assert.dom('.modal.is-active').exists(`${key}: Modal opens after encrypt`);
         assert.ok(
@@ -156,7 +154,6 @@ const testConvergentEncryption = async function(assert, keyName) {
       context: encodeString('context'),
       encodePlaintext: false,
       encodeContext: false,
-      decodeAfterDecrypt: false,
       assertAfterEncrypt: key => {
         assert.dom('.modal.is-active').exists(`${key}: Modal opens after encrypt`);
         assert.ok(
@@ -186,7 +183,6 @@ const testConvergentEncryption = async function(assert, keyName) {
       context: 'secret 2',
       encodePlaintext: true,
       encodeContext: true,
-      decodeAfterDecrypt: false,
       assertAfterEncrypt: key => {
         assert.dom('.modal.is-active').exists(`${key}: Modal opens after encrypt`);
         assert.ok(
@@ -243,13 +239,7 @@ const testConvergentEncryption = async function(assert, keyName) {
     await settled();
 
     if (testCase.assertAfterDecrypt) {
-      if (testCase.decodeAfterDecrypt) {
-        // The decrypted modal no longer has a way to decode from base64
-        await click('[data-test-transit-b64-toggle="plaintext"]');
-        testCase.assertAfterDecrypt(keyName);
-      } else {
-        testCase.assertAfterDecrypt(keyName);
-      }
+      testCase.assertAfterDecrypt(keyName);
     }
 
     await click('[data-test-modal-background]');

--- a/ui/tests/integration/components/modal-test.js
+++ b/ui/tests/integration/components/modal-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | modal', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{modal}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#modal}}
+        template block text
+      {{/modal}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/ui/tests/integration/components/modal-test.js
+++ b/ui/tests/integration/components/modal-test.js
@@ -10,15 +10,16 @@ module('Integration | Component | modal', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{modal}}`);
+    await render(hbs`<Modal></Modal><div id="modal-wormhole"></div>`);
 
     assert.equal(this.element.textContent.trim(), '');
 
     // Template block usage:
     await render(hbs`
-      {{#modal}}
+      <Modal>
         template block text
-      {{/modal}}
+      </Modal>
+      <div id="modal-wormhole"></div>
     `);
 
     assert.equal(this.element.textContent.trim(), 'template block text');

--- a/ui/tests/integration/components/modal-test.js
+++ b/ui/tests/integration/components/modal-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll, pauseTest } from '@ember/test-helpers';
+import { render, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | modal', function(hooks) {

--- a/ui/tests/integration/components/modal-test.js
+++ b/ui/tests/integration/components/modal-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, find, findAll, pauseTest } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | modal', function(hooks) {
@@ -12,16 +12,18 @@ module('Integration | Component | modal', function(hooks) {
 
     await render(hbs`<Modal></Modal><div id="modal-wormhole"></div>`);
 
-    assert.equal(this.element.textContent.trim(), '');
+    assert.equal(this.element.textContent.trim(), '', 'renders without interior content');
+    assert.equal(findAll('[data-test-modal-close-button]').length, 0, 'does not render close modal button');
 
     // Template block usage:
     await render(hbs`
-      <Modal>
+      <Modal @showCloseButton={{true}}>
         template block text
       </Modal>
       <div id="modal-wormhole"></div>
     `);
 
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.equal(this.element.textContent.trim(), 'template block text', 'renders with interior content');
+    assert.equal(findAll('[data-test-modal-close-button]').length, 1, 'renders close modal button');
   });
 });

--- a/ui/tests/integration/components/transit-key-actions-test.js
+++ b/ui/tests/integration/components/transit-key-actions-test.js
@@ -62,7 +62,9 @@ module('Integration | Component | transit key actions', function(hooks) {
     assert.equal(findAll('[data-test-transit-action="encrypt"]').length, 1, 'renders encrypt');
 
     this.set('key', { backend: 'transit', supportedActions: ['sign'] });
-    await render(hbs`{{transit-key-actions selectedAction="sign" key=key}}`);
+    await render(hbs`
+      {{transit-key-actions selectedAction="sign" key=key}}
+      <div id="modal-wormhole"></div>`);
     assert.equal(findAll('[data-test-transit-action="sign"]').length, 1, 'renders sign');
   });
 
@@ -107,7 +109,10 @@ module('Integration | Component | transit key actions', function(hooks) {
 
   test('it renders: rotate', async function(assert) {
     this.set('key', { backend: 'transit', id: 'akey', supportedActions: ['rotate'] });
-    await render(hbs`{{transit-key-actions selectedAction="rotate" key=key}}`);
+    await render(hbs`
+      {{transit-key-actions selectedAction="rotate" key=key}}
+      <div id="modal-wormhole"></div>
+    `);
 
     assert.equal(find('*').textContent.trim(), '', 'renders an empty div');
 
@@ -278,9 +283,10 @@ module('Integration | Component | transit key actions', function(hooks) {
     await click('#wrap-response');
     await triggerEvent('#wrap-response', 'change');
     await click('button[type="submit"]');
+    assert.dom('.modal.is-active').exists('Modal opens after export');
     assert.deepEqual(
-      JSON.parse(findAll('.CodeMirror')[0].CodeMirror.getValue()),
-      response,
+      find('.modal [data-test-encrypted-value="export"]').innerText,
+      JSON.stringify(response, null, 2),
       'prints json response'
     );
   });
@@ -294,9 +300,10 @@ module('Integration | Component | transit key actions', function(hooks) {
     await click('#exportVersion');
     await triggerEvent('#exportVersion', 'change');
     await click('button[type="submit"]');
+    assert.dom('.modal.is-active').exists('Modal opens after export');
     assert.deepEqual(
-      JSON.parse(findAll('.CodeMirror')[0].CodeMirror.getValue()),
-      response,
+      find('.modal [data-test-encrypted-value="export"]').innerText,
+      JSON.stringify(response, null, 2),
       'prints json response'
     );
     assert.deepEqual(

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7576,6 +7576,14 @@ ember-truth-helpers@^2.1.0:
   dependencies:
     ember-cli-babel "^6.6.0"
 
+ember-wormhole@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/ember-wormhole/-/ember-wormhole-0.5.5.tgz#db417ff748cb21e574cd5f233889897bc27096cb"
+  integrity sha512-z8l3gpoKmRA2BnTwvnYRk4jKVcETKHpddsD6kpS+EJ4EfyugadFS3zUqBmRDuJhFbNP8BVBLXlbbATj+Rk1Kgg==
+  dependencies:
+    ember-cli-babel "^6.10.0"
+    ember-cli-htmlbars "^2.0.1"
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"


### PR DESCRIPTION
# Move Transit Actions into Modals
This PR contains the last portion of the Transit UX improvements. It includes moving the results of transit key actions into a modal instead of on the page. This is an updated version of https://github.com/hashicorp/vault/pull/8482

![modalgif](https://user-images.githubusercontent.com/903288/76805482-785ed600-67a4-11ea-9985-f7eb12203167.gif)


### Testing
Using the [Transit Learn Docs](https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-transit) as a guide, verify that you can perform each key action (encrypt, decrypt, HMAC, etc), as well as copy and paste the results of the text.