### PR TITLE
Postgres increase displayname

### DIFF
--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -45,7 +45,7 @@ func new() *PostgreSQL {
 
 	credsProducer := &credsutil.SQLCredentialsProducer{
 		DisplayNameLen: 30,
-		RoleNameLen:    6,
+		RoleNameLen:    8,
 		UsernameLen:    63,
 		Separator:      "-",
 	}

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -44,8 +44,8 @@ func new() *PostgreSQL {
 	connProducer.Type = postgreSQLTypeName
 
 	credsProducer := &credsutil.SQLCredentialsProducer{
-		DisplayNameLen: 8,
-		RoleNameLen:    8,
+		DisplayNameLen: 30,
+		RoleNameLen:    6,
 		UsernameLen:    63,
 		Separator:      "-",
 	}


### PR DESCRIPTION
Hi @tyrannosaurus-becks 

As discussed on https://github.com/hashicorp/vault/issues/8560.  This is a small PR that increases the amount of the display name shown in username given.

This provides better information on who or what requested this Postgres user and will help give database admins more insight who has access to their databases.

The total username length remains the same just some of the random string will be chunked off.

For example before the display name length was set at 8 chars this would produce a username like 

v-userpass-sim-my-rol-SqB9aQG2QXjOhaMXuAbo-1584467244dsjsjssjsss

Now with setting the display name length to 30 it would return 

v-userpass-simon.macklin-my-rol-SqB9aQG2QXjOhaMXuAbo-1584467244

which has my full username included 

Kind Regards

Simon



