### PR TITLE
Ui/switch component

### DIFF
--- a/ui/app/components/switch.js
+++ b/ui/app/components/switch.js
@@ -1,0 +1,47 @@
+/**
+ * @module Switch
+ * Switch components are used to...
+ *
+ * @example
+ * ```js
+ * <Switch @requiredParam={requiredParam} @optionalParam={optionalParam} @param1={{param1}}/>
+ * ```
+ * @param {function} onChange - requiredParam is...
+ * @param {string} id - id is for the input
+ * @param {string} [name='json'] - param1 is...
+ * @param {boolean} [disabled=false] - param1 is...
+ * @param {boolean} [isChecked=true] - param1 is...
+ * @param {string} [classNames] - param1 is...
+ * @param {boolean} [round=false] - default switch is squared off
+ * @param {string} [size='small'] - Sizing which is
+ */
+
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  id: null,
+  name: 'json',
+  classNames: ['switch', 'is-small'],
+  classNameBindings: ['round:is-round'],
+  isChecked: true,
+  onChange: () => {},
+  disabled: false,
+  size: 'small',
+  isSize: computed('size', function() {
+    return `is-${this.size}`;
+  }),
+  round: false,
+  barfoo() {},
+  actions: {
+    handleChange(key, value) {
+      console.log('switch clicked');
+      console.log(key, value);
+      this.onChange(key, value);
+    },
+    foobar(value) {
+      console.log(`clicked! ${value}`);
+      // this.onChange();
+    },
+  },
+});

--- a/ui/app/components/switch.js
+++ b/ui/app/components/switch.js
@@ -1,47 +1,40 @@
 /**
  * @module Switch
- * Switch components are used to...
+ * Switch components are used to indicate boolean values which can be toggled on or off.
+ * They are a stylistic alternative to checkboxes, but use the input[type="checkbox"] under the hood.
  *
  * @example
  * ```js
  * <Switch @requiredParam={requiredParam} @optionalParam={optionalParam} @param1={{param1}}/>
  * ```
- * @param {function} onChange - requiredParam is...
- * @param {string} id - id is for the input
- * @param {string} [name='json'] - param1 is...
- * @param {boolean} [disabled=false] - param1 is...
- * @param {boolean} [isChecked=true] - param1 is...
- * @param {string} [classNames] - param1 is...
- * @param {boolean} [round=false] - default switch is squared off
- * @param {string} [size='small'] - Sizing which is
+ * @param {function} onChange - onChange is triggered on checkbox change (select, deselect)
+ * @param {string} inputId - Input ID is needed to match the label to the input
+ * @param {boolean} [disabled=false] - disabled makes the switch unclickable
+ * @param {boolean} [isChecked=true] - isChecked is the checked status of the input, and must be passed and mutated from the parent
+ * @param {boolean} [round=false] - default switch is squared off, this param makes it rounded
+ * @param {string} [size='small'] - Sizing can be small, medium, or large
+ * @param {string} [status='normal'] - Status can be normal or success, which makes the switch have a blue background when on
  */
 
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default Component.extend({
-  id: null,
   name: 'json',
-  classNames: ['switch', 'is-small'],
-  classNameBindings: ['round:is-round'],
-  isChecked: true,
-  onChange: () => {},
+  isChecked: false,
   disabled: false,
   size: 'small',
-  isSize: computed('size', function() {
-    return `is-${this.size}`;
-  }),
   round: false,
-  barfoo() {},
+  status: 'normal',
+  inputClasses: computed('size', 'round', 'status', function() {
+    const roundClass = this.round ? 'is-rounded' : '';
+    const sizeClass = `is-${this.size}`;
+    const statusClass = `is-${this.status}`;
+    return `switch ${statusClass} ${sizeClass} ${roundClass}`;
+  }),
   actions: {
-    handleChange(key, value) {
-      console.log('switch clicked');
-      console.log(key, value);
-      this.onChange(key, value);
-    },
-    foobar(value) {
-      console.log(`clicked! ${value}`);
-      // this.onChange();
+    handleChange(value) {
+      this.onChange(value);
     },
   },
 });

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -26,17 +26,18 @@
 <Toolbar>
   {{#unless (and (eq mode 'show') isWriteWithoutRead)}}
     <ToolbarFilters>
-      <input
-        data-test-secret-json-toggle=true
-        id="json"
-        type="checkbox"
-        name="json"
-        class="switch is-rounded is-success is-small"
-        checked={{showAdvancedMode}}
-        onchange={{action "toggleAdvanced" value="target.checked"}}
-        disabled={{and (eq mode 'show') secretDataIsAdvanced}}
-      />
-      <label for="json" class="has-text-grey">JSON</label>
+      <Switch
+        data-test-secret-json-toggle="true"
+        @inputId="json"
+        @status="success"
+        @round={{true}}
+        @size="small"
+        @disabled={{and (eq mode 'show') secretDataIsAdvanced}}
+        @isChecked={{showAdvancedMode}}
+        @onChange={{action "toggleAdvanced"}}
+        >
+        <span class="has-text-grey">JSON</span>
+      </Switch>
     </ToolbarFilters>
   {{/unless}}
   <ToolbarActions>

--- a/ui/app/templates/components/switch.hbs
+++ b/ui/app/templates/components/switch.hbs
@@ -1,23 +1,9 @@
 {{input
-  id="curly"
+  id=this.inputId
   type="checkbox"
-  checked=this.isChecked
-  change=(action "handleChange")
+  checked=isChecked
+  change=(action "handleChange" value='target.checked')
+  class=inputClasses
+  disabled=this.disabled
 }}
-<label for="curly" class="has-text-grey">Curly</label>
-<br/>
-<input
-  class="switch is-small"
-  type="checkbox"
-  value="angle-bracket"
-  checked={{this.isChecked}}
-  {{action "handleChange"}}
-  id="angle"
-/>
-<label for="angle" class="has-text-grey">Angle</label>
-{{!-- {{!-- id={{id}}
-  type="checkbox"
-  name={{this.name}}
-  class={{this.classNames}}
-  checked={{this.isChecked}} --}} {{!-- disabled={{this.disabled}} --}}
-  {{!-- ...attributes --}}
+<label for={{this.inputId}} class="has-text-grey">{{yield}}</label>

--- a/ui/app/templates/components/switch.hbs
+++ b/ui/app/templates/components/switch.hbs
@@ -1,0 +1,23 @@
+{{input
+  id="curly"
+  type="checkbox"
+  checked=this.isChecked
+  change=(action "handleChange")
+}}
+<label for="curly" class="has-text-grey">Curly</label>
+<br/>
+<input
+  class="switch is-small"
+  type="checkbox"
+  value="angle-bracket"
+  checked={{this.isChecked}}
+  {{action "handleChange"}}
+  id="angle"
+/>
+<label for="angle" class="has-text-grey">Angle</label>
+{{!-- {{!-- id={{id}}
+  type="checkbox"
+  name={{this.name}}
+  class={{this.classNames}}
+  checked={{this.isChecked}} --}} {{!-- disabled={{this.disabled}} --}}
+  {{!-- ...attributes --}}

--- a/ui/stories/switch.md
+++ b/ui/stories/switch.md
@@ -1,0 +1,30 @@
+<!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in app/components/switch.js. To make changes, first edit that file and run "yarn gen-story-md switch" to re-generate the content.-->
+
+## Switch
+Switch components are used to...
+
+**Params**
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| onChange | <code>function</code> |  | requiredParam is... |
+| id | <code>string</code> |  | id is for the input |
+| [name] | <code>string</code> | <code>&quot;&#x27;json&#x27;&quot;</code> | param1 is... |
+| [disabled] | <code>boolean</code> | <code>false</code> | param1 is... |
+| [isChecked] | <code>boolean</code> | <code>true</code> | param1 is... |
+| [classNames] | <code>string</code> |  | param1 is... |
+| [round] | <code>boolean</code> | <code>false</code> | default switch is squared off |
+| [size] | <code>string</code> | <code>&quot;&#x27;small&#x27;&quot;</code> | Sizing which is |
+
+**Example**
+  
+```js
+<Switch @requiredParam={requiredParam} @optionalParam={optionalParam} @param1={{param1}}/>
+```
+
+**See**
+
+- [Uses of Switch](https://github.com/hashicorp/vault/search?l=Handlebars&q=Switch+OR+switch)
+- [Switch Source Code](https://github.com/hashicorp/vault/blob/master/ui/app/components/switch.js)
+
+---

--- a/ui/stories/switch.md
+++ b/ui/stories/switch.md
@@ -1,20 +1,20 @@
 <!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in app/components/switch.js. To make changes, first edit that file and run "yarn gen-story-md switch" to re-generate the content.-->
 
 ## Switch
-Switch components are used to...
+Switch components are used to indicate boolean values which can be toggled on or off.
+They are a stylistic alternative to checkboxes, but use the input[type=checkbox] under the hood.
 
 **Params**
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| onChange | <code>function</code> |  | requiredParam is... |
-| id | <code>string</code> |  | id is for the input |
-| [name] | <code>string</code> | <code>&quot;&#x27;json&#x27;&quot;</code> | param1 is... |
-| [disabled] | <code>boolean</code> | <code>false</code> | param1 is... |
-| [isChecked] | <code>boolean</code> | <code>true</code> | param1 is... |
-| [classNames] | <code>string</code> |  | param1 is... |
-| [round] | <code>boolean</code> | <code>false</code> | default switch is squared off |
-| [size] | <code>string</code> | <code>&quot;&#x27;small&#x27;&quot;</code> | Sizing which is |
+| onChange | <code>function</code> |  | onChange is triggered on checkbox change (select, deselect) |
+| inputId | <code>string</code> |  | Input ID is needed to match the label to the input |
+| [disabled] | <code>boolean</code> | <code>false</code> | disabled makes the switch unclickable |
+| [isChecked] | <code>boolean</code> | <code>true</code> | isChecked is the checked status of the input, and must be passed and mutated from the parent |
+| [round] | <code>boolean</code> | <code>false</code> | default switch is squared off, this param makes it rounded |
+| [size] | <code>string</code> | <code>&quot;&#x27;small&#x27;&quot;</code> | Sizing can be small, medium, or large |
+| [status] | <code>string</code> | <code>&quot;&#x27;normal&#x27;&quot;</code> | Status can be normal or success, which makes the switch have a blue background when on |
 
 **Example**
   

--- a/ui/stories/switch.stories.js
+++ b/ui/stories/switch.stories.js
@@ -1,0 +1,39 @@
+import hbs from 'htmlbars-inline-precompile';
+import { storiesOf } from '@storybook/ember';
+import notes from './switch.md';
+import { withKnobs, object, text, boolean, select } from '@storybook/addon-knobs';
+
+storiesOf('Switch/', module)
+  .addParameters({ options: { showPanel: true } })
+  .addDecorator(withKnobs())
+  .add(
+    `Switch`,
+    () => ({
+      template: hbs`
+      <h5 class="title is-5">Switch</h5>
+      <Switch
+        @id={{id}}
+        @name={{name}}
+        @isChecked={{isChecked}}
+        @disabled={{disabled}}
+        @size={{size}}
+        @round={{round}}
+      >
+        {{yielded}}
+      </Switch>
+    `,
+      context: {
+        id: text('id', 'my-switch'),
+        name: text('name', 'my-checkbox'),
+        yielded: text('yield', 'Inner content here'),
+        isChecked: boolean('isChecked', false),
+        disabled: boolean('disabled', false),
+        size: select('size', ['small', 'medium', 'large'], 'small'),
+        round: boolean('round', true),
+        onChange(key, value) {
+          console.log(`${key} =  ${value}`);
+        },
+      },
+    }),
+    { notes }
+  );

--- a/ui/stories/switch.stories.js
+++ b/ui/stories/switch.stories.js
@@ -12,26 +12,28 @@ storiesOf('Switch/', module)
       template: hbs`
       <h5 class="title is-5">Switch</h5>
       <Switch
-        @id={{id}}
-        @name={{name}}
+        @inputId={{inputId}}
         @isChecked={{isChecked}}
+        @onChange={{onChange}}
         @disabled={{disabled}}
         @size={{size}}
+        @status={{status}}
         @round={{round}}
       >
         {{yielded}}
       </Switch>
     `,
       context: {
-        id: text('id', 'my-switch'),
+        inputId: text('id', 'my-switch'),
         name: text('name', 'my-checkbox'),
-        yielded: text('yield', 'Inner content here'),
-        isChecked: boolean('isChecked', false),
+        yielded: text('yield', 'Label content here ✔️'),
+        isChecked: boolean('isChecked', true),
         disabled: boolean('disabled', false),
         size: select('size', ['small', 'medium', 'large'], 'small'),
+        status: select('status', ['normal', 'success'], 'normal'),
         round: boolean('round', true),
-        onChange(key, value) {
-          console.log(`${key} =  ${value}`);
+        onChange() {
+          this.set('isChecked', !this.isChecked);
         },
       },
     }),

--- a/ui/tests/integration/components/switch-test.js
+++ b/ui/tests/integration/components/switch-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | switch', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{switch}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#switch}}
+        template block text
+      {{/switch}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
**SUMMARY**

This component will be used in the upcoming TTL picker redesign. The styling already exists and is in use in secrets version editing, but not as a component.

![switchgif](https://user-images.githubusercontent.com/16182107/77119542-aa6e7300-6a04-11ea-8871-aab05a4ede63.gif)

One open question I have re: styling, the current stylesheet assumes the `switch` and other relevant classes apply to the `input` itself, but in components the default styling, IDs, etc apply to the wrapping component. So this draft has some hacky workarounds for that, so that the appropriate styles apply to the input itself. The benefit of this is that it's slightly more performant that looking for a child of a given class, while the alternative is to rewrite (or append) the css so that you could wrap a checkbox input with the switch class and it will still apply.
