### PR TITLE
fix extensions name in client signing example

### DIFF
--- a/website/pages/docs/secrets/ssh/signed-ssh-certificates.mdx
+++ b/website/pages/docs/secrets/ssh/signed-ssh-certificates.mdx
@@ -406,7 +406,7 @@ this extension to the signed certificate.
   ```text
   $ vault write ssh-client-signer/sign/my-role -<<"EOH"
   {
-    "extension": {
+    "extensions": {
       "permit-pty": ""
     }
     // ...


### PR DESCRIPTION
"extension" does nothing, the proper syntax seems to be "extensions"