### PR TITLE
Bump golang to v1.13.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
     environment:
     - CIRCLECI_CLI_VERSION: 0.1.5546
     - GO_TAGS: ''
-    - GO_VERSION: 1.13.8
+    - GO_VERSION: 1.13.9
     - GO111MODULE: 'off'
     - GOTESTSUM_VERSION: 0.3.3
   test-ui:
@@ -240,7 +240,7 @@ jobs:
     environment:
     - CIRCLECI_CLI_VERSION: 0.1.5546
     - GO_TAGS: ''
-    - GO_VERSION: 1.13.8
+    - GO_VERSION: 1.13.9
     - GO111MODULE: 'off'
     - GOTESTSUM_VERSION: 0.3.3
   test-go-race:
@@ -313,7 +313,7 @@ jobs:
     environment:
     - CIRCLECI_CLI_VERSION: 0.1.5546
     - GO_TAGS: ''
-    - GO_VERSION: 1.13.8
+    - GO_VERSION: 1.13.9
     - GO111MODULE: 'off'
     - GOTESTSUM_VERSION: 0.3.3
   website-docker-image:
@@ -484,7 +484,7 @@ workflows:
 #     environment:
 #       CIRCLECI_CLI_VERSION: 0.1.5546
 #       GO_TAGS: \"\"
-#       GO_VERSION: 1.13.8
+#       GO_VERSION: 1.13.9
 #       GO111MODULE: \"off\"
 #       GOTESTSUM_VERSION: 0.3.3
 #     machine: true

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -29,7 +29,7 @@ executors:
     environment:
       GO111MODULE: "off"
       CIRCLECI_CLI_VERSION: 0.1.5546  # Pin CircleCI CLI to patch version (ex: 1.2.3)
-      GO_VERSION: 1.13.8  # Pin Go to patch version (ex: 1.2.3)
+      GO_VERSION: 1.13.9  # Pin Go to patch version (ex: 1.2.3)
       GOTESTSUM_VERSION: 0.3.3  # Pin gotestsum to patch version (ex: 1.2.3)
       GO_TAGS: ""
     working_directory: /go/src/github.com/hashicorp/vault

--- a/scripts/cross/Dockerfile
+++ b/scripts/cross/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -y && apt-get install -y -q nodejs yarn
 RUN rm -rf /var/lib/apt/lists/*
 
 
-ENV GOVERSION 1.13.8
+ENV GOVERSION 1.13.9
 RUN mkdir /goroot && mkdir /gopath
 RUN curl https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz \
            | tar xvzf - -C /goroot --strip-components=1


### PR DESCRIPTION
Relates to https://github.com/Homebrew/homebrew-core/pull/51941