### PR TITLE
identity: Fix potential deadlock on error to load groups

### DIFF
--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -150,6 +150,7 @@ func (i *IdentityStore) loadGroups(ctx context.Context) error {
 			for _, memberEntityID := range group.MemberEntityIDs {
 				entity, err := i.MemDBEntityByID(memberEntityID, false)
 				if err != nil {
+					txn.Abort()
 					return err
 				}
 				if entity == nil {


### PR DESCRIPTION
I'm not sure the error returned here is all that common, but we were not aborting the transaction in this instance. 