### PR TITLE
Bug Fix: Add in missing License Features into License view

### DIFF
--- a/ui/app/helpers/all-features.js
+++ b/ui/app/helpers/all-features.js
@@ -12,7 +12,6 @@ const ALL_FEATURES = [
   'Performance Standby',
   'Sentinel',
   'Seal Wrapping',
-  'Transform Secrets Engine',
 ];
 
 export function allFeatures() {

--- a/ui/app/helpers/all-features.js
+++ b/ui/app/helpers/all-features.js
@@ -1,15 +1,18 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
 const ALL_FEATURES = [
-  'HSM',
-  'Performance Replication',
+  'Control Groups',
   'DR Replication',
+  'Entropy Augmentation',
+  'HSM',
+  'KMIP',
   'MFA',
+  'Namespaces',
+  'Performance Replication',
+  'Performance Standby',
   'Sentinel',
   'Seal Wrapping',
-  'Control Groups',
-  'Performance Standby',
-  'Namespaces',
+  'Transform Secrets Engine',
 ];
 
 export function allFeatures() {


### PR DESCRIPTION
This was brought to our attention in this [GH Issue](https://github.com/hashicorp/vault-enterprise/issues/1212).

This PR adds in the missing license features.  I compared the previous list to the feature list in the enterprise repo, removed any that were deprecated, and added those that were missing.  I also put them in alphabetical order. 

