### PR TITLE
Bug: Add in missing license features

### DIFF
--- a/ui/app/helpers/all-features.js
+++ b/ui/app/helpers/all-features.js
@@ -10,6 +10,8 @@ const ALL_FEATURES = [
   'Control Groups',
   'Performance Standby',
   'Namespaces',
+  'KMIP',
+  'Entropy Augmentation',
 ];
 
 export function allFeatures() {


### PR DESCRIPTION
This was brought to our attention in this [GH Issue.](https://github.com/hashicorp/vault-enterprise/issues/1212)

This PR adds in the missing license features. I compared the previous list to the feature list in the enterprise repo, removed any that were deprecated, and added those that were missing. They are in order as they appear in the feature list in the enterprise repo.

Here is what it looks like:
<img width=400 src="https://user-images.githubusercontent.com/6618863/77581591-9662bf80-6ea3-11ea-9b7f-71090981c94b.png">
