### PR TITLE
Rabbitmq: surface errors from responses

### DIFF
--- a/builtin/logical/rabbitmq/path_role_create.go
+++ b/builtin/logical/rabbitmq/path_role_create.go
@@ -93,11 +93,11 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		// Delete the user because it's in an unknown state.
 		resp, err := client.DeleteUser(username)
 		if err != nil {
-			b.Logger().Error(fmt.Sprintf("failed to delete %s: %s", username, err))
+			b.Logger().Error(fmt.Sprintf("deleting %s due to permissions being in an unknown state, but failed: %s", username, err))
 		}
 		if !isIn200s(resp.StatusCode) {
 			body, _ := ioutil.ReadAll(resp.Body)
-			b.Logger().Error(fmt.Sprintf("error deleting %s - %d: %s", username, resp.StatusCode, body))
+			b.Logger().Error(fmt.Sprintf("deleting %s due to permissions being in an unknown state, but error deleting: %d: %s", username, resp.StatusCode, body))
 		}
 	}()
 

--- a/builtin/logical/rabbitmq/path_role_create.go
+++ b/builtin/logical/rabbitmq/path_role_create.go
@@ -82,7 +82,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 	}()
 	if !isIn200s(resp.StatusCode) {
 		body, _ := ioutil.ReadAll(resp.Body)
-		return nil, fmt.Errorf("error putting user %s - %d: %s", username, resp.StatusCode, body)
+		return nil, fmt.Errorf("error creating user %s - %d: %s", username, resp.StatusCode, body)
 	}
 
 	success := false


### PR DESCRIPTION
A user stated that Rabbitmq was creating credentials but not adding the expected permissions. In following their duplication, I found that the user was providing a `vhost` that didn't exist, but rather than error, Vault was still creating the credentials and swallowing the permissions error. I also found that when the correct vhost is provided, Vault _does_ apply permissions correctly.

The errors were being swallowed because responses, which sometimes were 400's, were not being inspected. This PR captures all responses from Rabbitmq and inspects them for errors. If they're not 200 responses, Vault fails loudly and rolls back adding the user.

Output from acceptance tests on this branch:
<details>

```
=== RUN   TestBackend_basic
2020-03-25T16:51:51.275-0700 [DEBUG] storage.cache: creating LRU cache: size=0
2020-03-25T16:51:51.275-0700 [ERROR] core: no seal config found, can't determine if legacy or new-style shamir
2020-03-25T16:51:51.275-0700 [INFO]  core: security barrier not initialized
2020-03-25T16:51:51.275-0700 [INFO]  core: security barrier initialized: stored=1 shares=1 threshold=1
2020-03-25T16:51:51.276-0700 [DEBUG] core: cluster name not found/set, generating new
2020-03-25T16:51:51.276-0700 [DEBUG] core: cluster name set: name=vault-cluster-cb9bfd56
2020-03-25T16:51:51.276-0700 [DEBUG] core: cluster ID not found, generating new
2020-03-25T16:51:51.276-0700 [DEBUG] core: cluster ID set: id=74cb1896-4092-8271-909b-f76b82d3b831
2020-03-25T16:51:51.276-0700 [INFO]  core: post-unseal setup starting
2020-03-25T16:51:51.276-0700 [DEBUG] core: clearing forwarding clients
2020-03-25T16:51:51.276-0700 [DEBUG] core: done clearing forwarding clients
2020-03-25T16:51:51.276-0700 [DEBUG] core: persisting feature flags
2020-03-25T16:51:51.288-0700 [INFO]  core: loaded wrapping token key
2020-03-25T16:51:51.288-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-03-25T16:51:51.288-0700 [INFO]  core: no mounts; adding default mount table
2020-03-25T16:51:51.290-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-03-25T16:51:51.290-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-03-25T16:51:51.290-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-03-25T16:51:51.291-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-03-25T16:51:51.291-0700 [INFO]  core: restoring leases
2020-03-25T16:51:51.291-0700 [INFO]  rollback: starting rollback manager
2020-03-25T16:51:51.292-0700 [DEBUG] expiration: collecting leases
2020-03-25T16:51:51.292-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-03-25T16:51:51.292-0700 [INFO]  expiration: lease restore complete
2020-03-25T16:51:51.293-0700 [DEBUG] identity: loading entities
2020-03-25T16:51:51.293-0700 [DEBUG] identity: entities collected: num_existing=0
2020-03-25T16:51:51.293-0700 [INFO]  identity: entities restored
2020-03-25T16:51:51.293-0700 [DEBUG] identity: identity loading groups
2020-03-25T16:51:51.293-0700 [DEBUG] identity: groups collected: num_existing=0
2020-03-25T16:51:51.293-0700 [INFO]  identity: groups restored
2020-03-25T16:51:51.293-0700 [INFO]  core: post-unseal setup complete
2020-03-25T16:51:51.293-0700 [INFO]  core: root token generated
2020-03-25T16:51:51.293-0700 [INFO]  core: pre-seal teardown starting
2020-03-25T16:51:51.293-0700 [DEBUG] expiration: stop triggered
2020-03-25T16:51:51.293-0700 [DEBUG] expiration: finished stopping
2020-03-25T16:51:51.293-0700 [INFO]  rollback: stopping rollback manager
2020-03-25T16:51:51.293-0700 [INFO]  core: pre-seal teardown complete
2020-03-25T16:51:51.293-0700 [DEBUG] core: unseal key supplied
2020-03-25T16:51:51.294-0700 [INFO]  core: clustering disabled, not starting listeners
2020-03-25T16:51:51.294-0700 [INFO]  core: post-unseal setup starting
2020-03-25T16:51:51.294-0700 [DEBUG] core: clearing forwarding clients
2020-03-25T16:51:51.294-0700 [DEBUG] core: done clearing forwarding clients
2020-03-25T16:51:51.294-0700 [DEBUG] core: persisting feature flags
2020-03-25T16:51:51.294-0700 [INFO]  core: loaded wrapping token key
2020-03-25T16:51:51.294-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-03-25T16:51:51.294-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-03-25T16:51:51.294-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-03-25T16:51:51.294-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-03-25T16:51:51.295-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-03-25T16:51:51.295-0700 [INFO]  core: restoring leases
2020-03-25T16:51:51.295-0700 [DEBUG] identity: loading entities
2020-03-25T16:51:51.295-0700 [DEBUG] identity: entities collected: num_existing=0
2020-03-25T16:51:51.295-0700 [INFO]  rollback: starting rollback manager
2020-03-25T16:51:51.295-0700 [DEBUG] expiration: collecting leases
2020-03-25T16:51:51.295-0700 [INFO]  identity: entities restored
2020-03-25T16:51:51.295-0700 [DEBUG] identity: identity loading groups
2020-03-25T16:51:51.295-0700 [DEBUG] identity: groups collected: num_existing=0
2020-03-25T16:51:51.295-0700 [INFO]  identity: groups restored
2020-03-25T16:51:51.295-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-03-25T16:51:51.295-0700 [INFO]  core: post-unseal setup complete
2020-03-25T16:51:51.295-0700 [INFO]  core: vault is unsealed
2020-03-25T16:51:51.295-0700 [INFO]  expiration: lease restore complete
2020-03-25T16:51:51.297-0700 [INFO]  core: successful mount: namespace= path=mnt/ type=test
2020-03-25T16:51:51.299-0700 [WARN]  Executing test step: step_number=1
2020-03-25T16:51:51.301-0700 [WARN]  Executing test step: step_number=2
2020-03-25T16:51:51.301-0700 [WARN]  Executing test step: step_number=3
2020/03/25 16:51:51 [WARN] Generated credentials: {root-e8b17c9c-f072-88d1-82ef-c21e7e4b2d80 287d003c-e275-71c7-8f99-475967912cbf}
2020-03-25T16:51:51.317-0700 [WARN]  Revoking secret: secret="*logical.Request{ID:"", ReplicationCluster:"", Operation:"update", Path:"sys/revoke/mnt/creds/web/s62u03HCTrKZ3TihUOsh6kjM", Data:map[string]interface {}(nil), Storage:logical.Storage(nil), Secret:<nil>, Auth:<nil>, Headers:map[string][]string(nil), Connection:(*logical.Connection)(nil), ClientToken:"", ClientTokenAccessor:"", DisplayName:"", MountPoint:"", MountType:"", MountAccessor:"", WrapInfo:(*logical.RequestWrapInfo)(nil), ClientTokenRemainingUses:0, EntityID:"", PolicyOverride:false, Unauthenticated:false, MFACreds:logical.MFACreds(nil), tokenEntry:(*logical.TokenEntry)(nil), lastRemoteWAL:0x0, ControlGroup:(*logical.ControlGroup)(nil), ClientTokenSource:0x0, HTTPRequest:(*http.Request)(nil), ResponseWriter:(*logical.HTTPResponseWriter)(nil)}"
2020-03-25T16:51:51.318-0700 [INFO]  expiration: revoked lease: lease_id=mnt/creds/web/s62u03HCTrKZ3TihUOsh6kjM
2020-03-25T16:51:51.318-0700 [WARN]  Requesting RollbackOperation
--- PASS: TestBackend_basic (25.92s)
=== RUN   TestBackend_returnsErrs
2020-03-25T16:52:12.023-0700 [DEBUG] storage.cache: creating LRU cache: size=0
2020-03-25T16:52:12.023-0700 [ERROR] core: no seal config found, can't determine if legacy or new-style shamir
2020-03-25T16:52:12.023-0700 [INFO]  core: security barrier not initialized
2020-03-25T16:52:12.023-0700 [INFO]  core: security barrier initialized: stored=1 shares=1 threshold=1
2020-03-25T16:52:12.023-0700 [DEBUG] core: cluster name not found/set, generating new
2020-03-25T16:52:12.023-0700 [DEBUG] core: cluster name set: name=vault-cluster-a475ea91
2020-03-25T16:52:12.023-0700 [DEBUG] core: cluster ID not found, generating new
2020-03-25T16:52:12.023-0700 [DEBUG] core: cluster ID set: id=726821bd-5508-2101-a36e-3c9e0c963611
2020-03-25T16:52:12.023-0700 [INFO]  core: post-unseal setup starting
2020-03-25T16:52:12.023-0700 [DEBUG] core: clearing forwarding clients
2020-03-25T16:52:12.023-0700 [DEBUG] core: done clearing forwarding clients
2020-03-25T16:52:12.023-0700 [DEBUG] core: persisting feature flags
2020-03-25T16:52:12.032-0700 [INFO]  core: loaded wrapping token key
2020-03-25T16:52:12.032-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-03-25T16:52:12.032-0700 [INFO]  core: no mounts; adding default mount table
2020-03-25T16:52:12.033-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-03-25T16:52:12.033-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-03-25T16:52:12.033-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-03-25T16:52:12.034-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-03-25T16:52:12.034-0700 [INFO]  core: restoring leases
2020-03-25T16:52:12.035-0700 [INFO]  rollback: starting rollback manager
2020-03-25T16:52:12.035-0700 [DEBUG] expiration: collecting leases
2020-03-25T16:52:12.035-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-03-25T16:52:12.035-0700 [INFO]  expiration: lease restore complete
2020-03-25T16:52:12.036-0700 [DEBUG] identity: loading entities
2020-03-25T16:52:12.036-0700 [DEBUG] identity: entities collected: num_existing=0
2020-03-25T16:52:12.036-0700 [INFO]  identity: entities restored
2020-03-25T16:52:12.036-0700 [DEBUG] identity: identity loading groups
2020-03-25T16:52:12.036-0700 [DEBUG] identity: groups collected: num_existing=0
2020-03-25T16:52:12.036-0700 [INFO]  identity: groups restored
2020-03-25T16:52:12.036-0700 [INFO]  core: post-unseal setup complete
2020-03-25T16:52:12.036-0700 [INFO]  core: root token generated
2020-03-25T16:52:12.036-0700 [INFO]  core: pre-seal teardown starting
2020-03-25T16:52:12.036-0700 [DEBUG] expiration: stop triggered
2020-03-25T16:52:12.036-0700 [DEBUG] expiration: finished stopping
2020-03-25T16:52:12.036-0700 [INFO]  rollback: stopping rollback manager
2020-03-25T16:52:12.036-0700 [INFO]  core: pre-seal teardown complete
2020-03-25T16:52:12.036-0700 [DEBUG] core: unseal key supplied
2020-03-25T16:52:12.036-0700 [INFO]  core: clustering disabled, not starting listeners
2020-03-25T16:52:12.036-0700 [INFO]  core: post-unseal setup starting
2020-03-25T16:52:12.036-0700 [DEBUG] core: clearing forwarding clients
2020-03-25T16:52:12.036-0700 [DEBUG] core: done clearing forwarding clients
2020-03-25T16:52:12.036-0700 [DEBUG] core: persisting feature flags
2020-03-25T16:52:12.036-0700 [INFO]  core: loaded wrapping token key
2020-03-25T16:52:12.036-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-03-25T16:52:12.037-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-03-25T16:52:12.037-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-03-25T16:52:12.037-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-03-25T16:52:12.038-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-03-25T16:52:12.038-0700 [INFO]  core: restoring leases
2020-03-25T16:52:12.038-0700 [INFO]  rollback: starting rollback manager
2020-03-25T16:52:12.038-0700 [DEBUG] identity: loading entities
2020-03-25T16:52:12.038-0700 [DEBUG] identity: entities collected: num_existing=0
2020-03-25T16:52:12.038-0700 [DEBUG] expiration: collecting leases
2020-03-25T16:52:12.038-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-03-25T16:52:12.038-0700 [INFO]  identity: entities restored
2020-03-25T16:52:12.038-0700 [DEBUG] identity: identity loading groups
2020-03-25T16:52:12.038-0700 [DEBUG] identity: groups collected: num_existing=0
2020-03-25T16:52:12.038-0700 [INFO]  identity: groups restored
2020-03-25T16:52:12.038-0700 [INFO]  expiration: lease restore complete
2020-03-25T16:52:12.038-0700 [INFO]  core: post-unseal setup complete
2020-03-25T16:52:12.038-0700 [INFO]  core: vault is unsealed
2020-03-25T16:52:12.040-0700 [INFO]  core: successful mount: namespace= path=mnt/ type=test
2020-03-25T16:52:12.041-0700 [WARN]  Executing test step: step_number=1
2020-03-25T16:52:12.043-0700 [WARN]  Executing test step: step_number=2
2020-03-25T16:52:12.043-0700 [WARN]  Executing test step: step_number=3
2020-03-25T16:52:12.051-0700 [WARN]  Requesting RollbackOperation
--- PASS: TestBackend_returnsErrs (26.85s)
=== RUN   TestBackend_roleCrud
2020-03-25T16:52:45.476-0700 [DEBUG] storage.cache: creating LRU cache: size=0
2020-03-25T16:52:45.476-0700 [ERROR] core: no seal config found, can't determine if legacy or new-style shamir
2020-03-25T16:52:45.476-0700 [INFO]  core: security barrier not initialized
2020-03-25T16:52:45.476-0700 [INFO]  core: security barrier initialized: stored=1 shares=1 threshold=1
2020-03-25T16:52:45.476-0700 [DEBUG] core: cluster name not found/set, generating new
2020-03-25T16:52:45.476-0700 [DEBUG] core: cluster name set: name=vault-cluster-0d1ef53f
2020-03-25T16:52:45.476-0700 [DEBUG] core: cluster ID not found, generating new
2020-03-25T16:52:45.476-0700 [DEBUG] core: cluster ID set: id=d43c1700-4c8f-67c7-8938-c69956336aa0
2020-03-25T16:52:45.476-0700 [INFO]  core: post-unseal setup starting
2020-03-25T16:52:45.477-0700 [DEBUG] core: clearing forwarding clients
2020-03-25T16:52:45.477-0700 [DEBUG] core: done clearing forwarding clients
2020-03-25T16:52:45.477-0700 [DEBUG] core: persisting feature flags
2020-03-25T16:52:45.486-0700 [INFO]  core: loaded wrapping token key
2020-03-25T16:52:45.486-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-03-25T16:52:45.486-0700 [INFO]  core: no mounts; adding default mount table
2020-03-25T16:52:45.487-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-03-25T16:52:45.487-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-03-25T16:52:45.487-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-03-25T16:52:45.488-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-03-25T16:52:45.488-0700 [INFO]  core: restoring leases
2020-03-25T16:52:45.488-0700 [INFO]  rollback: starting rollback manager
2020-03-25T16:52:45.488-0700 [DEBUG] expiration: collecting leases
2020-03-25T16:52:45.489-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-03-25T16:52:45.489-0700 [INFO]  expiration: lease restore complete
2020-03-25T16:52:45.490-0700 [DEBUG] identity: loading entities
2020-03-25T16:52:45.490-0700 [DEBUG] identity: entities collected: num_existing=0
2020-03-25T16:52:45.490-0700 [INFO]  identity: entities restored
2020-03-25T16:52:45.490-0700 [DEBUG] identity: identity loading groups
2020-03-25T16:52:45.490-0700 [DEBUG] identity: groups collected: num_existing=0
2020-03-25T16:52:45.490-0700 [INFO]  identity: groups restored
2020-03-25T16:52:45.490-0700 [INFO]  core: post-unseal setup complete
2020-03-25T16:52:45.490-0700 [INFO]  core: root token generated
2020-03-25T16:52:45.490-0700 [INFO]  core: pre-seal teardown starting
2020-03-25T16:52:45.490-0700 [DEBUG] expiration: stop triggered
2020-03-25T16:52:45.490-0700 [DEBUG] expiration: finished stopping
2020-03-25T16:52:45.490-0700 [INFO]  rollback: stopping rollback manager
2020-03-25T16:52:45.490-0700 [INFO]  core: pre-seal teardown complete
2020-03-25T16:52:45.490-0700 [DEBUG] core: unseal key supplied
2020-03-25T16:52:45.490-0700 [INFO]  core: clustering disabled, not starting listeners
2020-03-25T16:52:45.490-0700 [INFO]  core: post-unseal setup starting
2020-03-25T16:52:45.491-0700 [DEBUG] core: clearing forwarding clients
2020-03-25T16:52:45.491-0700 [DEBUG] core: done clearing forwarding clients
2020-03-25T16:52:45.491-0700 [DEBUG] core: persisting feature flags
2020-03-25T16:52:45.491-0700 [INFO]  core: loaded wrapping token key
2020-03-25T16:52:45.491-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-03-25T16:52:45.491-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-03-25T16:52:45.491-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-03-25T16:52:45.491-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-03-25T16:52:45.492-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-03-25T16:52:45.492-0700 [INFO]  core: restoring leases
2020-03-25T16:52:45.492-0700 [INFO]  rollback: starting rollback manager
2020-03-25T16:52:45.492-0700 [DEBUG] identity: loading entities
2020-03-25T16:52:45.492-0700 [DEBUG] identity: entities collected: num_existing=0
2020-03-25T16:52:45.492-0700 [DEBUG] expiration: collecting leases
2020-03-25T16:52:45.492-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-03-25T16:52:45.492-0700 [INFO]  identity: entities restored
2020-03-25T16:52:45.492-0700 [DEBUG] identity: identity loading groups
2020-03-25T16:52:45.492-0700 [DEBUG] identity: groups collected: num_existing=0
2020-03-25T16:52:45.492-0700 [INFO]  identity: groups restored
2020-03-25T16:52:45.492-0700 [INFO]  core: post-unseal setup complete
2020-03-25T16:52:45.492-0700 [INFO]  core: vault is unsealed
2020-03-25T16:52:45.492-0700 [INFO]  expiration: lease restore complete
2020-03-25T16:52:45.494-0700 [INFO]  core: successful mount: namespace= path=mnt/ type=test
2020-03-25T16:52:45.496-0700 [WARN]  Executing test step: step_number=1
2020-03-25T16:52:45.498-0700 [WARN]  Executing test step: step_number=2
2020-03-25T16:52:45.498-0700 [WARN]  Executing test step: step_number=3
2020-03-25T16:52:45.498-0700 [WARN]  Executing test step: step_number=4
2020-03-25T16:52:45.498-0700 [WARN]  Executing test step: step_number=5
2020-03-25T16:52:45.498-0700 [WARN]  Requesting RollbackOperation
--- PASS: TestBackend_roleCrud (16.92s)
=== RUN   TestBackend_config_lease_RU
--- PASS: TestBackend_config_lease_RU (0.00s)
PASS
ok  	github.com/hashicorp/vault/builtin/logical/rabbitmq	69.699s
?   	github.com/hashicorp/vault/builtin/logical/rabbitmq/cmd/rabbitmq	[no test files]

Process finished with exit code 0
```

</details>