### PR TITLE
docs: change code blocks to bold in k8s doc

### DIFF
--- a/website/pages/docs/platform/k8s/injector/index.mdx
+++ b/website/pages/docs/platform/k8s/injector/index.mdx
@@ -179,7 +179,7 @@ annotation. The configuration files will be mounted to `/vault/configs`.
 
 The configuration map must contain either one or both of the following files:
 
-- `config-init.hcl` used by the init container. This must have `exit_after_auth` set to `true`.
-- `config.hcl` used by the sidecar container. This must have `exit_after_auth` set to `false`.
+- **config-init.hcl** used by the init container. This must have `exit_after_auth` set to `true`.
+- **config.hcl** used by the sidecar container. This must have `exit_after_auth` set to `false`.
 
 An example of mounting a Vault Agent configmap [can be found here](/docs/platform/k8s/injector/examples#configmap-example).


### PR DESCRIPTION
For some reason the website is rendering these as links (which are broken), so changing them to be bold instead.