### PR TITLE
Fix for website-docker-image CI task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ jobs:
         command: |
           IMAGE_TAG="$(git rev-list -n1 HEAD -- website/Dockerfile website/package-lock.json)"
           echo "Using $IMAGE_TAG"
-          if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/vault" ]; then
+          if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/vault.git" ]; then
             echo "Not Vault OSS Repo, not building website docker image"
           elif curl https://hub.docker.com/v2/repositories/hashicorp/vault-website/tags/$IMAGE_TAG -fsL > /dev/null; then
               echo "Dependencies have not changed, not building a new website docker image."
@@ -646,7 +646,7 @@ workflows:
 #         command: |
 #           IMAGE_TAG=\"$(git rev-list -n1 HEAD -- website/Dockerfile website/package-lock.json)\"
 #           echo \"Using $IMAGE_TAG\"
-#           if  [ \"$CIRCLE_REPOSITORY_URL\" != \"git@github.com:hashicorp/vault\" ]; then
+#           if  [ \"$CIRCLE_REPOSITORY_URL\" != \"git@github.com:hashicorp/vault.git\" ]; then
 #             echo \"Not Vault OSS Repo, not building website docker image\"
 #           elif curl https://hub.docker.com/v2/repositories/hashicorp/vault-website/tags/$IMAGE_TAG -fsL > /dev/null; then
 #               echo \"Dependencies have not changed, not building a new website docker image.\"

--- a/.circleci/config/jobs/website-docker-image.yml
+++ b/.circleci/config/jobs/website-docker-image.yml
@@ -9,7 +9,7 @@ steps:
       command: |
         IMAGE_TAG="$(git rev-list -n1 HEAD -- website/Dockerfile website/package-lock.json)"
         echo "Using $IMAGE_TAG"
-        if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/vault" ]; then
+        if  [ "$CIRCLE_REPOSITORY_URL" != "git@github.com:hashicorp/vault.git" ]; then
           echo "Not Vault OSS Repo, not building website docker image"
         elif curl https://hub.docker.com/v2/repositories/hashicorp/vault-website/tags/$IMAGE_TAG -fsL > /dev/null; then
             echo "Dependencies have not changed, not building a new website docker image."


### PR DESCRIPTION
The url slug was slightly off, causing docker images to never build when website dependencies updated. This fixes it!