### PR TITLE
Backport 1.4.x: In the KV metadata put CLI, allow delete-version-after to be reset to 0

### DIFF
--- a/command/kv_metadata_put.go
+++ b/command/kv_metadata_put.go
@@ -78,7 +78,7 @@ func (c *KVMetadataPutCommand) Flags() *FlagSets {
 	f.DurationVar(&DurationVar{
 		Name:       "delete-version-after",
 		Target:     &c.flagDeleteVersionAfter,
-		Default:    0,
+		Default:    -1,
 		EnvVar:     "",
 		Completion: complete.PredictAnything,
 		Usage: `Specifies the length of time before a version is deleted.
@@ -141,7 +141,7 @@ func (c *KVMetadataPutCommand) Run(args []string) int {
 		"cas_required": c.flagCASRequired,
 	}
 
-	if c.flagDeleteVersionAfter > 0 {
+	if c.flagDeleteVersionAfter >= 0 {
 		data["delete_version_after"] = c.flagDeleteVersionAfter.String()
 	}
 

--- a/command/kv_metadata_put_test.go
+++ b/command/kv_metadata_put_test.go
@@ -1,0 +1,76 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/mitchellh/cli"
+)
+
+func testKVMetadataPutCommand(tb testing.TB) (*cli.MockUi, *KVMetadataPutCommand) {
+	tb.Helper()
+
+	ui := cli.NewMockUi()
+	return ui, &KVMetadataPutCommand{
+		BaseCommand: &BaseCommand{
+			UI: ui,
+		},
+	}
+}
+
+func TestKvMetadataPutCommandDeleteVersionAfter(t *testing.T) {
+	client, closer := testVaultServer(t)
+	defer closer()
+
+	if err := client.Sys().Mount("kv/", &api.MountInput{
+		Type: "kv-v2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ui, cmd := testKVMetadataPutCommand(t)
+	cmd.client = client
+
+	// Set a limit of 1s first.
+	code := cmd.Run([]string{"-delete-version-after=1s", "kv/secret/my-secret"})
+	if code != 0 {
+		t.Errorf("expected %d but received %d", 0, code)
+	}
+
+	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+	if !strings.Contains(combined, "Success! Data written to: kv/metadata/secret/my-secret\n") {
+		t.Errorf("expected %q but received %q", "Success! Data written to: kv/metadata/secret/my-secret\n", combined)
+	}
+
+	secret, err := client.Logical().Read("kv/metadata/secret/my-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret.Data["delete_version_after"] != "1s" {
+		t.Fatalf("expected 1s but received %q", secret.Data["delete_version_after"])
+	}
+
+	// Now verify that we can return it to 0s.
+	ui, cmd = testKVMetadataPutCommand(t)
+	cmd.client = client
+
+	// Set a limit of 1s first.
+	code = cmd.Run([]string{"-delete-version-after=0", "kv/secret/my-secret"})
+	if code != 0 {
+		t.Errorf("expected %d but received %d", 0, code)
+	}
+
+	combined = ui.OutputWriter.String() + ui.ErrorWriter.String()
+	if !strings.Contains(combined, "Success! Data written to: kv/metadata/secret/my-secret\n") {
+		t.Errorf("expected %q but received %q", "Success! Data written to: kv/metadata/secret/my-secret\n", combined)
+	}
+
+	secret, err = client.Logical().Read("kv/metadata/secret/my-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret.Data["delete_version_after"] != "0s" {
+		t.Fatalf("expected 0s but received %q", secret.Data["delete_version_after"])
+	}
+}


### PR DESCRIPTION
Backports #8635 