### PR TITLE
Fix a test failure I observed on ent re cluster listener

### DIFF
--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -222,9 +222,10 @@ func (c *Core) startForwarding(ctx context.Context) error {
 }
 
 func (c *Core) stopForwarding() {
-	if c.getClusterListener() != nil {
-		c.getClusterListener().StopHandler(consts.RequestForwardingALPN)
-		c.getClusterListener().StopHandler(consts.PerfStandbyALPN)
+	clusterListener := c.getClusterListener()
+	if clusterListener != nil {
+		clusterListener.StopHandler(consts.RequestForwardingALPN)
+		clusterListener.StopHandler(consts.PerfStandbyALPN)
 	}
 	c.removeAllPerfStandbySecondaries()
 }

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -200,7 +200,8 @@ func (c *Core) startForwarding(ctx context.Context) error {
 	c.clearForwardingClients()
 	c.requestForwardingConnectionLock.Unlock()
 
-	if c.ha == nil || c.getClusterListener() == nil {
+	clusterListener := c.getClusterListener()
+	if c.ha == nil || clusterListener == nil {
 		c.logger.Debug("request forwarding not setup")
 		return nil
 	}
@@ -210,12 +211,12 @@ func (c *Core) startForwarding(ctx context.Context) error {
 		return err
 	}
 
-	handler, err := NewRequestForwardingHandler(c, c.getClusterListener().Server(), perfStandbySlots, perfStandbyRepCluster)
+	handler, err := NewRequestForwardingHandler(c, clusterListener.Server(), perfStandbySlots, perfStandbyRepCluster)
 	if err != nil {
 		return err
 	}
 
-	c.getClusterListener().AddHandler(consts.RequestForwardingALPN, handler)
+	clusterListener.AddHandler(consts.RequestForwardingALPN, handler)
 
 	return nil
 }


### PR DESCRIPTION
As I recall, this solves a panic when the cluster listener is changing while we're setting up request forwarding.