### PR TITLE
storage/raft: Buffer leader notify channel more aggressively

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -522,7 +522,7 @@ func (b *RaftBackend) SetupCluster(ctx context.Context, opts SetupOpts) error {
 	raftConfig.LocalID = raft.ServerID(b.localID)
 
 	// Set up a channel for reliable leader notifications.
-	raftNotifyCh := make(chan bool, 1)
+	raftNotifyCh := make(chan bool, 10)
 	raftConfig.NotifyCh = raftNotifyCh
 
 	// If we have a bootstrapConfig set we should bootstrap now.


### PR DESCRIPTION
This follows suit from: https://github.com/hashicorp/consul/pull/6863

The goal is to buffer the raft leader's notification channel more to better recover from leader flapping