### PR TITLE
Postgres: Provide option to disable connection caching

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,7 @@ github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7 h1:u9SHYsPQNyt5tgDm3YN7+9dYrpK96E5wFilTFWIDZOM=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d h1:t5Wuyh53qYyg9eqn4BbnlIT+vmhyww0TatL+zT3uWgI=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/sdk/database/helper/connutil/sql.go
+++ b/sdk/database/helper/connutil/sql.go
@@ -108,10 +108,10 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 
 // Connection returns a connection for the caller to use. By default, database
 // connections are reused. However, this behavior may be disabled by setting a key
-// of "should_reuse" to false. This can help with failovers like the one discussed
+// of "disable_connection_caching" to true. This can help with failovers like the one discussed
 // in https://github.com/hashicorp/vault/issues/6792. Normally we would just pass
 // in a parameter to that effect, but we did it this way to avoid changing the
-// exported method.
+// exported method, which only receives a ctx variable.
 func (c *SQLConnectionProducer) Connection(ctx context.Context) (interface{}, error) {
 	if !c.Initialized {
 		return nil, ErrNotInitialized

--- a/vendor/github.com/coreos/go-systemd/journal/journal.go
+++ b/vendor/github.com/coreos/go-systemd/journal/journal.go
@@ -119,8 +119,8 @@ func Print(priority Priority, format string, a ...interface{}) error {
 }
 
 func appendVariable(w io.Writer, name, value string) {
-	if err := validVarName(name); err != nil {
-		journalError(err.Error())
+	if !validVarName(name) {
+		journalError("variable name contains invalid character, ignoring")
 	}
 	if strings.ContainsRune(value, '\n') {
 		/* When the value contains a newline, we write:
@@ -137,23 +137,16 @@ func appendVariable(w io.Writer, name, value string) {
 	}
 }
 
-// validVarName validates a variable name to make sure it journald will accept it.
-// The variable name must be in uppercase and consist only of characters,
-// numbers and underscores, and may not begin with an underscore. (from the docs)
-// https://www.freedesktop.org/software/systemd/man/sd_journal_print.html
-func validVarName(name string) error {
-	if name == "" {
-		return errors.New("Empty variable name")
-	} else if name[0] == '_' {
-		return errors.New("Variable name begins with an underscore")
-	}
+func validVarName(name string) bool {
+	/* The variable name must be in uppercase and consist only of characters,
+	 * numbers and underscores, and may not begin with an underscore. (from the docs)
+	 */
 
+	valid := name[0] != '_'
 	for _, c := range name {
-		if !(('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') || c == '_') {
-			return errors.New("Variable name contains invalid characters")
-		}
+		valid = valid && ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') || c == '_'
 	}
-	return nil
+	return valid
 }
 
 func isSocketSpaceError(err error) bool {

--- a/vendor/github.com/hashicorp/vault/api/request.go
+++ b/vendor/github.com/hashicorp/vault/api/request.go
@@ -18,6 +18,7 @@ import (
 type Request struct {
 	Method        string
 	URL           *url.URL
+	Host          string
 	Params        url.Values
 	Headers       http.Header
 	ClientToken   string
@@ -115,7 +116,7 @@ func (r *Request) toRetryableHTTP() (*retryablehttp.Request, error) {
 	req.URL.User = r.URL.User
 	req.URL.Scheme = r.URL.Scheme
 	req.URL.Host = r.URL.Host
-	req.Host = r.URL.Host
+	req.Host = r.Host
 
 	if r.Headers != nil {
 		for header, vals := range r.Headers {

--- a/vendor/github.com/hashicorp/vault/sdk/database/helper/connutil/sql.go
+++ b/vendor/github.com/hashicorp/vault/sdk/database/helper/connutil/sql.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+const DisableConnectionCaching = "disable_connection_caching"
+
 var _ ConnectionProducer = &SQLConnectionProducer{}
 
 // SQLConnectionProducer implements ConnectionProducer and provides a generic producer for most sql databases
@@ -104,19 +106,36 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 	return c.RawConfig, nil
 }
 
+// Connection returns a connection for the caller to use. By default, database
+// connections are reused. However, this behavior may be disabled by setting a key
+// of "disable_connection_caching" to true. This can help with failovers like the one discussed
+// in https://github.com/hashicorp/vault/issues/6792. Normally we would just pass
+// in a parameter to that effect, but we did it this way to avoid changing the
+// exported method, which only receives a ctx variable.
 func (c *SQLConnectionProducer) Connection(ctx context.Context) (interface{}, error) {
 	if !c.Initialized {
 		return nil, ErrNotInitialized
 	}
 
-	// If we already have a DB, test it and return
-	if c.db != nil {
-		if err := c.db.PingContext(ctx); err == nil {
-			return c.db, nil
+	disableConnCaching := false
+	disableConnCachingIfc := ctx.Value(DisableConnectionCaching)
+	if disableConnCachingIfc != nil {
+		if b, ok := disableConnCachingIfc.(bool); ok {
+			disableConnCaching = b
 		}
-		// If the ping was unsuccessful, close it and ignore errors as we'll be
-		// reestablishing anyways
-		c.db.Close()
+	}
+
+	// If we already have a DB and should be reusing the connection, test it and return
+	if c.db != nil {
+		if !disableConnCaching {
+			if err := c.db.PingContext(ctx); err == nil {
+				return c.db, nil
+			}
+		}
+		// If the ping was unsuccessful or we're not caching connections,
+		// close the previous connection before establishing a new one
+		// below.
+		_ = c.db.Close()
 	}
 
 	// For mssql backend, switch to sqlserver instead

--- a/vendor/github.com/hashicorp/vault/sdk/helper/ldaputil/client.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/ldaputil/client.go
@@ -217,7 +217,7 @@ func (c *Client) performLdapFilterGroupsSearch(cfg *ConfigEntry, conn Connection
 
 	var renderedQuery bytes.Buffer
 	if err := t.Execute(&renderedQuery, context); err != nil {
-		return nil, errwrap.Wrapf("LDAP search failed due to template parsing error: {{error}}", err)
+		return nil, errwrap.Wrapf("LDAP search failed due to template parsing error: {{err}}", err)
 	}
 
 	if c.Logger.IsDebug() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -193,7 +193,7 @@ github.com/containerd/continuity/pathdriver
 github.com/coreos/go-oidc
 # github.com/coreos/go-semver v0.2.0
 github.com/coreos/go-semver/semver
-# github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d
+# github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7
 github.com/coreos/go-systemd/journal
 # github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf
 github.com/coreos/pkg/capnslog

--- a/website/pages/api-docs/secret/databases/postgresql.mdx
+++ b/website/pages/api-docs/secret/databases/postgresql.mdx
@@ -45,6 +45,15 @@ has a number of parameters to further configure a connection.
 
 - `password` `(string: "")` - The root credential password used in the connection URL.
 
+- `disable_connection_caching` `(string: "false")` - Generally, Vault
+  establishes a connection to a database and reuses it until a new configuration is received.
+  However, if Postgres is hosted on AWS RDS using [multi-az failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html),
+  then after the failover, Vault will hang trying to use an obsolete connection. Setting
+  this to "true" means that Vault will create a new connection for every credential request.
+  This enables failovers, but will cause Vault to cycle through many more connections than
+  otherwise. Before turning this to true, consider how many concurrent connections Vault
+  will likely be using, and the limit of connections available on your database.
+
 ### Sample Payload
 
 ```json

--- a/website/pages/docs/secrets/databases/postgresql.mdx
+++ b/website/pages/docs/secrets/databases/postgresql.mdx
@@ -47,6 +47,10 @@ options, including SSL options, can be found
         username="root" \
         password="root"
     ```
+    If you're hosting Postgres through AWS RDS and you may experience
+    [multi-az failover](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html),
+    you should also consider adding `disable_connection_caching="true"`. See more
+    on this [here](/api-docs/secret/databases/postgresql#disable_connection_caching).
 
 1.  Configure a role that maps a name in Vault to an SQL statement to execute to
     create the database credential:


### PR DESCRIPTION
Fixes #6792 

Users have noticed that when they're hosting Postgres on AWS through RDS, and their cluster is in multiple AZ's, then when a failover occurs Vault can no longer issue credentials in a timely manner. Upon closer inspection, this was happening because Vault was caching and reusing connections. It tried to reuse a connection that was no longer valid after a failover.

This PR allows users to disable Vault's connection caching. Backwards compatibility is fully maintained. 

It's not easy to create an automated local test replicating this behavior because a failover must be triggered remotely.