### PR TITLE
docs: fix broken k8s auth method link

### DIFF
--- a/website/pages/docs/agent/autoauth/methods/kubernetes.mdx
+++ b/website/pages/docs/agent/autoauth/methods/kubernetes.mdx
@@ -10,7 +10,7 @@ description: Kubernetes Method for Vault Agent Auto-Auth
 The `kubernetes` method reads in a Kubernetes service account token from the
 running pod (via `/var/run/secrets/kubernetes.io/serviceaccount/token`) and
 sends it to the [Kubernetes Auth
-method](/docs/auth/kubernetes).
+method](/docs/auth/kubernetes/).
 
 ## Configuration
 


### PR DESCRIPTION
The website is generating the wrong link to K8s auth method doc by appending `.html` to the end of the link.  