### PR TITLE
Always pick us-east-1 for the "aws" partition

### DIFF
--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -309,7 +309,7 @@ func generatePartitionToRegionMap() map[string]*endpoints.Region {
 	for _, p := range partitions {
 		// For most partitions, it's fine to choose a single region randomly.
 		// However, for the "aws" partition, it's best to choose "us-east-1"
-		// because it also support STS out of the box.
+		// because it is always enabled (and enabled for STS) by default.
 		for _, r := range p.Regions() {
 			if p.ID() == "aws" && r.ID() != "us-east-1" {
 				continue

--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -307,8 +307,13 @@ func generatePartitionToRegionMap() map[string]*endpoints.Region {
 	partitions := resolver.(endpoints.EnumPartitions).Partitions()
 
 	for _, p := range partitions {
-		// Choose a single region randomly from the partition
+		// For most partitions, it's fine to choose a single region randomly.
+		// However, for the "aws" partition, it's best to choose "us-east-1"
+		// because it also support STS out of the box.
 		for _, r := range p.Regions() {
+			if p.ID() == "aws" && r.ID() != "us-east-1" {
+				continue
+			}
 			partitionToRegion[p.ID()] = &r
 			break
 		}

--- a/builtin/credential/aws/backend_test.go
+++ b/builtin/credential/aws/backend_test.go
@@ -1813,3 +1813,10 @@ func generateRenewRequest(s logical.Storage, auth *logical.Auth) *logical.Reques
 
 	return renewReq
 }
+
+func TestGeneratePartitionToRegionMap(t *testing.T) {
+	m := generatePartitionToRegionMap()
+	if m["aws"].ID() != "us-east-1" {
+		t.Fatal("expected us-east-1 but received " + m["aws"].ID())
+	}
+}


### PR DESCRIPTION
A user who has been using the "assume role" functionality for the AWS auth back-end has observed failures where Vault has created an IAM client located in the "me-south-1" region, rather than "us-west-2" where all of this user's resources are currently located. Upon testing, we found that there were many regions where, if they were selected, using a client in that region _with_ assume role would work. But, there were some regions where they wouldn't, like "me-south-1". 

We found (through [these](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html) docs) that the "us-east-1" and the global region _always_ work. 

This PR seeks to fix the problem with the absolute minimum code change. It forces the region selector for the clients, which usually picks random regions, to _only_ select a region that will work for our needs. This has been tested against the reproduction and solves the issue. 