### PR TITLE
Backport 1.4.x: Always pick us-east-1 for the "aws" partition

### DIFF
--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -307,8 +307,13 @@ func generatePartitionToRegionMap() map[string]*endpoints.Region {
 	partitions := resolver.(endpoints.EnumPartitions).Partitions()
 
 	for _, p := range partitions {
-		// Choose a single region randomly from the partition
+		// For most partitions, it's fine to choose a single region randomly.
+		// However, for the "aws" partition, it's best to choose "us-east-1"
+		// because it is always enabled (and enabled for STS) by default.
 		for _, r := range p.Regions() {
+			if p.ID() == "aws" && r.ID() != "us-east-1" {
+				continue
+			}
 			partitionToRegion[p.ID()] = &r
 			break
 		}

--- a/builtin/credential/aws/backend_test.go
+++ b/builtin/credential/aws/backend_test.go
@@ -1813,3 +1813,10 @@ func generateRenewRequest(s logical.Storage, auth *logical.Auth) *logical.Reques
 
 	return renewReq
 }
+
+func TestGeneratePartitionToRegionMap(t *testing.T) {
+	m := generatePartitionToRegionMap()
+	if m["aws"].ID() != "us-east-1" {
+		t.Fatal("expected us-east-1 but received " + m["aws"].ID())
+	}
+}


### PR DESCRIPTION
This PR backports #8679 to include it in our next Vault release.