### PR TITLE
Fix "List Template" table path within Transform Docs

### DIFF
--- a/website/pages/api-docs/secret/transform/index.mdx
+++ b/website/pages/api-docs/secret/transform/index.mdx
@@ -377,7 +377,7 @@ This endpoint lists all existing templates in the secrets engine.
 
 | Method | Path                         |
 | :----- | :--------------------------- |
-| `LIST` | `/transform/transformation`  |
+| `LIST` | `/transform/template`        |
 
 ### Sample Request
 


### PR DESCRIPTION
I happened to be referencing these docs when updating a Vault API client and noticed this Path column typo.