### PR TITLE
Remove the warning about raft storage being in beta.

### DIFF
--- a/website/pages/docs/configuration/storage/raft.mdx
+++ b/website/pages/docs/configuration/storage/raft.mdx
@@ -13,9 +13,6 @@ description: |-
 
 # Raft Storage Backend
 
-~> **NOTE:** Vault's Integrated Storage is currently a **_Beta_**
-feature and not recommended for deployment in production.
-
 The Raft storage backend is used to persist Vault's data. Unlike other storage
 backends, Raft storage does not operate from a single source of data. Instead
 all the nodes in a Vault cluster will have a replicated copy of Vault's data.


### PR DESCRIPTION
It's GA now. I did a quick scan for other files where the words raft and beta occurred in the same document but didn't turn anything up.