### PR TITLE
docs(s3-storage-backend): update required permissions

### DIFF
--- a/website/pages/docs/configuration/storage/s3.mdx
+++ b/website/pages/docs/configuration/storage/s3.mdx
@@ -68,7 +68,7 @@ cause Vault to attempt to retrieve credentials from the AWS metadata service.
   endpoint connection (highly recommended not to disable for production).
 
 - `kms_key_id` `(string: "")` - Specifies the ID or Alias of the KMS key used to
-  encrypt data in the S3 backend. Vault must have `kms:Encrypt` and `kms:Decrypt`
+  encrypt data in the S3 backend. Vault must have `kms:Encrypt`, `kms:Decrypt`, `kms:DescribeKey', `kms:GenerateDataKey`, and `kms:ReEncrypt`
   permissions for this key. You can use `alias/aws/s3` to specify the default
   key for the account.
 


### PR DESCRIPTION
add required AWS IAM permissions for Vault in order to use an AWS KMS-encrypted S3 storage backend,
as for the AWS documentation:
https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html.

without them the barrier can't be configured at initialization.