### PR TITLE
Add "include_alias_metadata" role flag

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -839,13 +839,15 @@ func (b *backend) pathLoginUpdateEc2(ctx context.Context, req *logical.Request, 
 		},
 		Alias: &logical.Alias{
 			Name: identityAlias,
-			Metadata: map[string]string{
-				"instance_id": identityDocParsed.InstanceID,
-				"region":      identityDocParsed.Region,
-				"account_id":  identityDocParsed.AccountID,
-				"ami_id":      identityDocParsed.AmiID,
-			},
 		},
+	}
+	if roleEntry.IncludeAliasMetadata {
+		auth.Alias.Metadata = map[string]string{
+			"instance_id": identityDocParsed.InstanceID,
+			"region":      identityDocParsed.Region,
+			"account_id":  identityDocParsed.AccountID,
+			"ami_id":      identityDocParsed.AmiID,
+		}
 	}
 	roleEntry.PopulateTokenAuth(auth)
 
@@ -1365,17 +1367,19 @@ func (b *backend) pathLoginUpdateIam(ctx context.Context, req *logical.Request, 
 		DisplayName: entity.FriendlyName,
 		Alias: &logical.Alias{
 			Name: identityAlias,
-			Metadata: map[string]string{
-				"client_arn":           callerID.Arn,
-				"canonical_arn":        entity.canonicalArn(),
-				"client_user_id":       callerUniqueId,
-				"auth_type":            iamAuthType,
-				"inferred_entity_type": inferredEntityType,
-				"inferred_entity_id":   inferredEntityID,
-				"inferred_aws_region":  roleEntry.InferredAWSRegion,
-				"account_id":           entity.AccountNumber,
-			},
 		},
+	}
+	if roleEntry.IncludeAliasMetadata {
+		auth.Alias.Metadata = map[string]string{
+			"client_arn":           callerID.Arn,
+			"canonical_arn":        entity.canonicalArn(),
+			"client_user_id":       callerUniqueId,
+			"auth_type":            iamAuthType,
+			"inferred_entity_type": inferredEntityType,
+			"inferred_entity_id":   inferredEntityID,
+			"inferred_aws_region":  roleEntry.InferredAWSRegion,
+			"account_id":           entity.AccountNumber,
+		}
 	}
 	roleEntry.PopulateTokenAuth(auth)
 

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -216,8 +216,9 @@ func TestBackend_pathLogin_IAMHeaders(t *testing.T) {
 
 	// create a role entry
 	roleEntry := &awsRoleEntry{
-		Version:  currentRoleStorageVersion,
-		AuthType: iamAuthType,
+		Version:              currentRoleStorageVersion,
+		AuthType:             iamAuthType,
+		IncludeAliasMetadata: true,
 	}
 
 	if err := b.setRole(context.Background(), storage, testValidRoleName, roleEntry); err != nil {

--- a/website/pages/api-docs/auth/aws/index.mdx
+++ b/website/pages/api-docs/auth/aws/index.mdx
@@ -751,6 +751,15 @@ list in order to satisfy that constraint.
   `auth/aws/identity-whitelist/<instance_id>` endpoint. Defaults to 'false'.
   This only applies to authentications via the ec2 auth method. This is mutually
   exclusive with `allow_instance_migration`.
+- `include_alias_metadata` `(bool: false)` - If set to true, adds multiple metadata
+  fields to each Vault identity alias used for retrieving a Vault token, improving the
+  ease of attributing tokens to particular people or machines. However, enabling this
+  causes Vault to consult storage any time an identity alias' metadata changes, so it
+  does cause a performance toll. If not enabled, identical information can be obtained
+  from Vault's audit logs. The specific fields added for `iam` logins are `client_arn`,
+  `canonical_arn`, `client_user_id`, `auth_type`, `inferred_entity_type`,
+  `inferred_entity_id`, `inferred_aws_region`, and `account_id`. The specific fields
+  added for `ec2` logins are `instance_id`, `region`, `account_id`, and `ami_id`.
 
 @include 'partials/tokenfields.mdx'
 


### PR DESCRIPTION
When #7985 was merged, it had an unintended side-effect. Any time alias metadata changes, there's an additional storage write. Because an alias [can be a role ID](https://github.com/hashicorp/vault/blob/master/builtin/credential/aws/path_login.go#L637) with many entities associated with it, this means that the metadata can change at a very high rate, causing a high additional storage load.

This PR places the additional alias metadata behind a flag that is off by default. Folks who wish to obtain that metadata can enable the flag, under advisement that it may have a performance impact. 

I considered alternative design approaches. One approach was to analyze which metadata fields were unlikely to change often, and keep those. However, the `account_id` field seemed to be the only one that fit, and it seemed like a better user experience from an understandability standpoint to have the fields be included all or nothing rather than piecemeal. 

I also considered defaulting this field to "on" but I would rather have users opt _in_ to the performance impact, rather than opting _out_ of it. Since the linked PR is a fairly recent change, I think this is sensible.

<details>
<summary>Acceptance test output</summary>

```
tbex@pop-os:~/go/src/github.com/hashicorp/vault/builtin/credential/aws$ VAULT_ACC=1 go test -v ./...
=== RUN   TestBackend_E2E_Initialize
2020-04-09T14:53:00.284-0700 [DEBUG] storage.cache: creating LRU cache: size=0
2020-04-09T14:53:00.285-0700 [ERROR] core: no seal config found, can't determine if legacy or new-style shamir
2020-04-09T14:53:00.285-0700 [ERROR] core: no seal config found, can't determine if legacy or new-style shamir
2020-04-09T14:53:00.285-0700 [ERROR] core: no seal config found, can't determine if legacy or new-style shamir
2020-04-09T14:53:00.285-0700 [INFO]  core: security barrier not initialized
2020-04-09T14:53:00.285-0700 [INFO]  core: security barrier initialized: stored=1 shares=3 threshold=3
2020-04-09T14:53:00.285-0700 [DEBUG] core: cluster name not found/set, generating new
2020-04-09T14:53:00.285-0700 [DEBUG] core: cluster name set: name=vault-cluster-495971f0
2020-04-09T14:53:00.285-0700 [DEBUG] core: cluster ID not found, generating new
2020-04-09T14:53:00.285-0700 [DEBUG] core: cluster ID set: id=527d4bea-d01b-8ee5-63d7-7e3141b4d43c
2020-04-09T14:53:00.285-0700 [DEBUG] core: generating cluster private key
2020-04-09T14:53:00.294-0700 [DEBUG] core: generating local cluster certificate
2020-04-09T14:53:00.303-0700 [INFO]  core: post-unseal setup starting
2020-04-09T14:53:00.303-0700 [DEBUG] core: clearing forwarding clients
2020-04-09T14:53:00.303-0700 [DEBUG] core: done clearing forwarding clients
2020-04-09T14:53:00.303-0700 [DEBUG] core: persisting feature flags
2020-04-09T14:53:00.314-0700 [INFO]  core: loaded wrapping token key
2020-04-09T14:53:00.315-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-04-09T14:53:00.315-0700 [INFO]  core: no mounts; adding default mount table
2020-04-09T14:53:00.315-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-04-09T14:53:00.315-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-04-09T14:53:00.316-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-04-09T14:53:00.318-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-04-09T14:53:00.318-0700 [INFO]  core: restoring leases
2020-04-09T14:53:00.318-0700 [INFO]  rollback: starting rollback manager
2020-04-09T14:53:00.318-0700 [DEBUG] expiration: collecting leases
2020-04-09T14:53:00.318-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-04-09T14:53:00.318-0700 [INFO]  expiration: lease restore complete
2020-04-09T14:53:00.318-0700 [DEBUG] identity: loading entities
2020-04-09T14:53:00.318-0700 [DEBUG] identity: entities collected: num_existing=0
2020-04-09T14:53:00.319-0700 [INFO]  identity: entities restored
2020-04-09T14:53:00.319-0700 [DEBUG] identity: identity loading groups
2020-04-09T14:53:00.319-0700 [DEBUG] identity: groups collected: num_existing=0
2020-04-09T14:53:00.319-0700 [INFO]  identity: groups restored
2020-04-09T14:53:00.319-0700 [INFO]  core: post-unseal setup complete
2020-04-09T14:53:00.319-0700 [INFO]  core: root token generated
2020-04-09T14:53:00.319-0700 [INFO]  core: pre-seal teardown starting
2020-04-09T14:53:00.319-0700 [DEBUG] expiration: stop triggered
2020-04-09T14:53:00.319-0700 [DEBUG] expiration: finished stopping
2020-04-09T14:53:00.319-0700 [INFO]  rollback: stopping rollback manager
2020-04-09T14:53:00.319-0700 [INFO]  core: pre-seal teardown complete
2020-04-09T14:53:00.319-0700 [DEBUG] core: unseal key supplied
2020-04-09T14:53:00.319-0700 [DEBUG] core: cannot unseal, not enough keys: keys=1 threshold=3 nonce=c476c52c-86b7-ceb6-9614-44f5129c32ed
2020-04-09T14:53:00.319-0700 [DEBUG] core: unseal key supplied
2020-04-09T14:53:00.319-0700 [DEBUG] core: cannot unseal, not enough keys: keys=2 threshold=3 nonce=c476c52c-86b7-ceb6-9614-44f5129c32ed
2020-04-09T14:53:00.319-0700 [DEBUG] core: unseal key supplied
2020-04-09T14:53:00.319-0700 [DEBUG] core: starting cluster listeners
2020-04-09T14:53:00.319-0700 [INFO]  core.cluster-listener.tcp: starting listener: listener_address=127.0.0.1:0
2020-04-09T14:53:00.319-0700 [INFO]  core.cluster-listener: serving cluster requests: cluster_listen_address=127.0.0.1:43751
2020-04-09T14:53:00.319-0700 [INFO]  core: vault is unsealed
2020-04-09T14:53:00.320-0700 [INFO]  core: entering standby mode
2020-04-09T14:53:00.320-0700 [INFO]  core: acquired lock, enabling active operation
2020-04-09T14:53:00.320-0700 [DEBUG] core: generating cluster private key
2020-04-09T14:53:00.328-0700 [DEBUG] core: generating local cluster certificate
2020-04-09T14:53:00.337-0700 [INFO]  core: post-unseal setup starting
2020-04-09T14:53:00.337-0700 [DEBUG] core: clearing forwarding clients
2020-04-09T14:53:00.337-0700 [DEBUG] core: done clearing forwarding clients
2020-04-09T14:53:00.337-0700 [DEBUG] core: persisting feature flags
2020-04-09T14:53:00.337-0700 [INFO]  core: loaded wrapping token key
2020-04-09T14:53:00.337-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-04-09T14:53:00.337-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-04-09T14:53:00.337-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-04-09T14:53:00.337-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-04-09T14:53:00.338-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-04-09T14:53:00.338-0700 [INFO]  core: restoring leases
2020-04-09T14:53:00.338-0700 [DEBUG] identity: loading entities
2020-04-09T14:53:00.338-0700 [DEBUG] identity: entities collected: num_existing=0
2020-04-09T14:53:00.338-0700 [INFO]  rollback: starting rollback manager
2020-04-09T14:53:00.338-0700 [DEBUG] expiration: collecting leases
2020-04-09T14:53:00.338-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-04-09T14:53:00.338-0700 [INFO]  identity: entities restored
2020-04-09T14:53:00.338-0700 [DEBUG] identity: identity loading groups
2020-04-09T14:53:00.338-0700 [DEBUG] identity: groups collected: num_existing=0
2020-04-09T14:53:00.338-0700 [INFO]  identity: groups restored
2020-04-09T14:53:00.338-0700 [DEBUG] core: request forwarding setup function
2020-04-09T14:53:00.338-0700 [DEBUG] core: clearing forwarding clients
2020-04-09T14:53:00.338-0700 [DEBUG] core: done clearing forwarding clients
2020-04-09T14:53:00.338-0700 [DEBUG] core: leaving request forwarding setup function
2020-04-09T14:53:00.338-0700 [INFO]  expiration: lease restore complete
2020-04-09T14:53:00.338-0700 [INFO]  core: post-unseal setup complete
2020-04-09T14:53:00.339-0700 [INFO]  core: successful mount: namespace= path=secret/ type=kv
2020-04-09T14:53:00.341-0700 [INFO]  core: enabled audit backend: path=noop/ type=noop
2020-04-09T14:53:00.343-0700 [DEBUG] auth.aws.auth_aws_b9ead56f.initialize: starting initialization
2020-04-09T14:53:00.343-0700 [INFO]  core: enabled credential backend: path=aws/ type=aws
2020-04-09T14:53:00.343-0700 [INFO]  auth.aws.auth_aws_b9ead56f.initialize: an upgrade was performed during initialization
2020-04-09T14:53:01.354-0700 [INFO]  core: marked as sealed
2020-04-09T14:53:01.354-0700 [DEBUG] core: clearing forwarding clients
2020-04-09T14:53:01.354-0700 [DEBUG] core: done clearing forwarding clients
2020-04-09T14:53:01.354-0700 [DEBUG] core: finished triggering standbyStopCh for runStandby
2020-04-09T14:53:01.354-0700 [DEBUG] core: shutting down periodic key rotation checker
2020-04-09T14:53:01.354-0700 [DEBUG] core: shutting down periodic leader refresh
2020-04-09T14:53:01.354-0700 [DEBUG] core: shutting down leader elections
2020-04-09T14:53:01.354-0700 [INFO]  core: pre-seal teardown starting
2020-04-09T14:53:01.854-0700 [DEBUG] expiration: stop triggered
2020-04-09T14:53:01.854-0700 [DEBUG] expiration: finished stopping
2020-04-09T14:53:01.854-0700 [INFO]  rollback: stopping rollback manager
2020-04-09T14:53:01.854-0700 [INFO]  core: pre-seal teardown complete
2020-04-09T14:53:01.854-0700 [DEBUG] core: runStandby done
2020-04-09T14:53:01.854-0700 [INFO]  core: stopping cluster listeners
2020-04-09T14:53:01.854-0700 [INFO]  core.cluster-listener: forwarding rpc listeners stopped
2020-04-09T14:53:02.320-0700 [INFO]  core.cluster-listener: rpc listeners successfully shut down
2020-04-09T14:53:02.320-0700 [INFO]  core: cluster listeners successfully shut down
2020-04-09T14:53:02.320-0700 [DEBUG] core: sealing barrier
2020-04-09T14:53:02.320-0700 [INFO]  core: vault is sealed
2020-04-09T14:53:02.320-0700 [DEBUG] core: unseal key supplied
2020-04-09T14:53:02.320-0700 [DEBUG] core: cannot unseal, not enough keys: keys=1 threshold=3 nonce=d9dbf466-9ed8-42ee-bebc-965de7e7cb49
2020-04-09T14:53:02.320-0700 [DEBUG] core: unseal key supplied
2020-04-09T14:53:02.320-0700 [DEBUG] core: cannot unseal, not enough keys: keys=2 threshold=3 nonce=d9dbf466-9ed8-42ee-bebc-965de7e7cb49
2020-04-09T14:53:02.320-0700 [DEBUG] core: unseal key supplied
2020-04-09T14:53:02.320-0700 [DEBUG] core: starting cluster listeners
2020-04-09T14:53:02.320-0700 [INFO]  core.cluster-listener.tcp: starting listener: listener_address=127.0.0.1:43751
2020-04-09T14:53:02.320-0700 [INFO]  core.cluster-listener: serving cluster requests: cluster_listen_address=127.0.0.1:43751
2020-04-09T14:53:02.320-0700 [INFO]  core: vault is unsealed
2020-04-09T14:53:02.321-0700 [INFO]  core: entering standby mode
2020-04-09T14:53:02.321-0700 [INFO]  core: acquired lock, enabling active operation
2020-04-09T14:53:02.321-0700 [DEBUG] core: generating cluster private key
2020-04-09T14:53:02.332-0700 [DEBUG] core: generating local cluster certificate
2020-04-09T14:53:02.342-0700 [INFO]  core: post-unseal setup starting
2020-04-09T14:53:02.342-0700 [DEBUG] core: clearing forwarding clients
2020-04-09T14:53:02.342-0700 [DEBUG] core: done clearing forwarding clients
2020-04-09T14:53:02.342-0700 [DEBUG] core: persisting feature flags
2020-04-09T14:53:02.342-0700 [INFO]  core: loaded wrapping token key
2020-04-09T14:53:02.342-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-04-09T14:53:02.343-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-04-09T14:53:02.343-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-04-09T14:53:02.343-0700 [INFO]  core: successfully mounted backend: type=kv path=secret/
2020-04-09T14:53:02.343-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-04-09T14:53:02.344-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-04-09T14:53:02.344-0700 [INFO]  core: successfully enabled credential backend: type=aws path=aws/
2020-04-09T14:53:02.344-0700 [INFO]  core: restoring leases
2020-04-09T14:53:02.344-0700 [INFO]  rollback: starting rollback manager
2020-04-09T14:53:02.344-0700 [DEBUG] identity: loading entities
2020-04-09T14:53:02.344-0700 [DEBUG] expiration: collecting leases
2020-04-09T14:53:02.344-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-04-09T14:53:02.344-0700 [DEBUG] identity: entities collected: num_existing=0
2020-04-09T14:53:02.344-0700 [INFO]  expiration: lease restore complete
2020-04-09T14:53:02.344-0700 [INFO]  identity: entities restored
2020-04-09T14:53:02.344-0700 [DEBUG] identity: identity loading groups
2020-04-09T14:53:02.344-0700 [DEBUG] identity: groups collected: num_existing=0
2020-04-09T14:53:02.344-0700 [INFO]  identity: groups restored
2020-04-09T14:53:02.344-0700 [DEBUG] core: request forwarding setup function
2020-04-09T14:53:02.344-0700 [DEBUG] core: clearing forwarding clients
2020-04-09T14:53:02.344-0700 [DEBUG] core: done clearing forwarding clients
2020-04-09T14:53:02.344-0700 [DEBUG] core: leaving request forwarding setup function
2020-04-09T14:53:02.344-0700 [DEBUG] auth.aws.auth_aws_b9ead56f.initialize: starting initialization
2020-04-09T14:53:02.344-0700 [INFO]  core: post-unseal setup complete
2020-04-09T14:53:02.344-0700 [INFO]  auth.aws.auth_aws_b9ead56f.initialize: an upgrade was performed during initialization
2020-04-09T14:53:05.344-0700 [INFO]  TestBackend_E2E_Initialize: cleaning up vault cluster
--- PASS: TestBackend_E2E_Initialize (7.05s)
=== RUN   TestBackend_CreateParseVerifyRoleTag
--- PASS: TestBackend_CreateParseVerifyRoleTag (0.00s)
=== RUN   TestBackend_prepareRoleTagPlaintextValue
--- PASS: TestBackend_prepareRoleTagPlaintextValue (0.00s)
=== RUN   TestBackend_CreateRoleTagNonce
--- PASS: TestBackend_CreateRoleTagNonce (0.00s)
=== RUN   TestBackend_ConfigTidyIdentities
--- PASS: TestBackend_ConfigTidyIdentities (0.00s)
=== RUN   TestBackend_ConfigTidyRoleTags
--- PASS: TestBackend_ConfigTidyRoleTags (0.00s)
=== RUN   TestBackend_TidyIdentities
--- PASS: TestBackend_TidyIdentities (1.00s)
=== RUN   TestBackend_TidyRoleTags
--- PASS: TestBackend_TidyRoleTags (1.00s)
=== RUN   TestBackend_ConfigClient
2020-04-09T14:53:09.330-0700 [DEBUG] storage.cache: creating LRU cache: size=0
2020-04-09T14:53:09.330-0700 [ERROR] core: no seal config found, can't determine if legacy or new-style shamir
2020-04-09T14:53:09.330-0700 [INFO]  core: security barrier not initialized
2020-04-09T14:53:09.330-0700 [INFO]  core: security barrier initialized: stored=1 shares=1 threshold=1
2020-04-09T14:53:09.330-0700 [DEBUG] core: cluster name not found/set, generating new
2020-04-09T14:53:09.330-0700 [DEBUG] core: cluster name set: name=vault-cluster-c8eba35b
2020-04-09T14:53:09.330-0700 [DEBUG] core: cluster ID not found, generating new
2020-04-09T14:53:09.330-0700 [DEBUG] core: cluster ID set: id=c496b4f4-4e14-b0ae-df9d-cf06bd259e50
2020-04-09T14:53:09.330-0700 [INFO]  core: post-unseal setup starting
2020-04-09T14:53:09.330-0700 [DEBUG] core: clearing forwarding clients
2020-04-09T14:53:09.330-0700 [DEBUG] core: done clearing forwarding clients
2020-04-09T14:53:09.330-0700 [DEBUG] core: persisting feature flags
2020-04-09T14:53:09.341-0700 [INFO]  core: loaded wrapping token key
2020-04-09T14:53:09.341-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-04-09T14:53:09.341-0700 [INFO]  core: no mounts; adding default mount table
2020-04-09T14:53:09.342-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-04-09T14:53:09.342-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-04-09T14:53:09.342-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-04-09T14:53:09.343-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-04-09T14:53:09.343-0700 [INFO]  core: restoring leases
2020-04-09T14:53:09.343-0700 [INFO]  rollback: starting rollback manager
2020-04-09T14:53:09.343-0700 [DEBUG] expiration: collecting leases
2020-04-09T14:53:09.343-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-04-09T14:53:09.343-0700 [INFO]  expiration: lease restore complete
2020-04-09T14:53:09.344-0700 [DEBUG] identity: loading entities
2020-04-09T14:53:09.344-0700 [DEBUG] identity: entities collected: num_existing=0
2020-04-09T14:53:09.345-0700 [INFO]  identity: entities restored
2020-04-09T14:53:09.345-0700 [DEBUG] identity: identity loading groups
2020-04-09T14:53:09.345-0700 [DEBUG] identity: groups collected: num_existing=0
2020-04-09T14:53:09.345-0700 [INFO]  identity: groups restored
2020-04-09T14:53:09.345-0700 [INFO]  core: post-unseal setup complete
2020-04-09T14:53:09.345-0700 [INFO]  core: root token generated
2020-04-09T14:53:09.345-0700 [INFO]  core: pre-seal teardown starting
2020-04-09T14:53:09.345-0700 [DEBUG] expiration: stop triggered
2020-04-09T14:53:09.345-0700 [DEBUG] expiration: finished stopping
2020-04-09T14:53:09.345-0700 [INFO]  rollback: stopping rollback manager
2020-04-09T14:53:09.345-0700 [INFO]  core: pre-seal teardown complete
2020-04-09T14:53:09.345-0700 [DEBUG] core: unseal key supplied
2020-04-09T14:53:09.345-0700 [INFO]  core: clustering disabled, not starting listeners
2020-04-09T14:53:09.345-0700 [INFO]  core: post-unseal setup starting
2020-04-09T14:53:09.345-0700 [DEBUG] core: clearing forwarding clients
2020-04-09T14:53:09.345-0700 [DEBUG] core: done clearing forwarding clients
2020-04-09T14:53:09.345-0700 [DEBUG] core: persisting feature flags
2020-04-09T14:53:09.345-0700 [INFO]  core: loaded wrapping token key
2020-04-09T14:53:09.345-0700 [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-04-09T14:53:09.345-0700 [INFO]  core: successfully mounted backend: type=system path=sys/
2020-04-09T14:53:09.345-0700 [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-04-09T14:53:09.345-0700 [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-04-09T14:53:09.346-0700 [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-04-09T14:53:09.346-0700 [INFO]  core: restoring leases
2020-04-09T14:53:09.346-0700 [INFO]  rollback: starting rollback manager
2020-04-09T14:53:09.346-0700 [DEBUG] identity: loading entities
2020-04-09T14:53:09.346-0700 [DEBUG] identity: entities collected: num_existing=0
2020-04-09T14:53:09.346-0700 [DEBUG] expiration: collecting leases
2020-04-09T14:53:09.346-0700 [INFO]  identity: entities restored
2020-04-09T14:53:09.346-0700 [DEBUG] identity: identity loading groups
2020-04-09T14:53:09.346-0700 [DEBUG] expiration: leases collected: num_existing=0
2020-04-09T14:53:09.346-0700 [DEBUG] identity: groups collected: num_existing=0
2020-04-09T14:53:09.346-0700 [INFO]  identity: groups restored
2020-04-09T14:53:09.346-0700 [INFO]  core: post-unseal setup complete
2020-04-09T14:53:09.346-0700 [INFO]  expiration: lease restore complete
2020-04-09T14:53:09.346-0700 [INFO]  core: vault is unsealed
2020-04-09T14:53:09.347-0700 [DEBUG] initialize: starting initialization
2020-04-09T14:53:09.347-0700 [INFO]  core: enabled credential backend: path=mnt/ type=test
2020-04-09T14:53:09.347-0700 [INFO]  initialize: an upgrade was performed during initialization
2020-04-09T14:53:09.348-0700 [WARN]  Executing test step: step_number=1
2020-04-09T14:53:09.349-0700 [WARN]  Executing test step: step_number=2
2020-04-09T14:53:09.349-0700 [WARN]  Executing test step: step_number=3
2020-04-09T14:53:09.349-0700 [WARN]  Executing test step: step_number=4
2020-04-09T14:53:09.349-0700 [WARN]  Requesting RollbackOperation
--- PASS: TestBackend_ConfigClient (0.02s)
=== RUN   TestBackend_pathConfigCertificate
--- PASS: TestBackend_pathConfigCertificate (0.00s)
=== RUN   TestBackend_parseAndVerifyRoleTagValue
--- PASS: TestBackend_parseAndVerifyRoleTagValue (0.00s)
=== RUN   TestBackend_PathRoleTag
--- PASS: TestBackend_PathRoleTag (0.00s)
=== RUN   TestBackend_PathBlacklistRoleTag
--- PASS: TestBackend_PathBlacklistRoleTag (0.00s)
=== RUN   TestBackendAcc_LoginWithInstanceIdentityDocAndWhitelistIdentity
--- SKIP: TestBackendAcc_LoginWithInstanceIdentityDocAndWhitelistIdentity (0.00s)
    backend_test.go:1043: env var TEST_AWS_EC2_PKCS7 not set, skipping test
=== RUN   TestBackend_pathStsConfig
--- PASS: TestBackend_pathStsConfig (0.00s)
=== RUN   TestBackendAcc_LoginWithCallerIdentity
--- SKIP: TestBackendAcc_LoginWithCallerIdentity (0.00s)
    backend_test.go:1477: env var TEST_AWS_ACCESS_KEY_ID not set, skipping test
=== RUN   TestGeneratePartitionToRegionMap
--- PASS: TestGeneratePartitionToRegionMap (0.00s)
=== RUN   TestBackend_pathConfigClient
--- PASS: TestBackend_pathConfigClient (0.00s)
=== RUN   TestBackend_pathConfigIdentity
--- PASS: TestBackend_pathConfigIdentity (0.00s)
=== RUN   TestBackend_pathLogin_getCallerIdentityResponse
--- PASS: TestBackend_pathLogin_getCallerIdentityResponse (0.00s)
=== RUN   TestBackend_pathLogin_parseIamArn
--- PASS: TestBackend_pathLogin_parseIamArn (0.00s)
=== RUN   TestBackend_validateVaultHeaderValue
--- PASS: TestBackend_validateVaultHeaderValue (0.00s)
=== RUN   TestBackend_pathLogin_IAMHeaders
=== RUN   TestBackend_pathLogin_IAMHeaders/Default
=== RUN   TestBackend_pathLogin_IAMHeaders/Map-complete
=== RUN   TestBackend_pathLogin_IAMHeaders/Map-incomplete
=== RUN   TestBackend_pathLogin_IAMHeaders/JSON-complete
=== RUN   TestBackend_pathLogin_IAMHeaders/JSON-incomplete
=== RUN   TestBackend_pathLogin_IAMHeaders/Base64-complete
=== RUN   TestBackend_pathLogin_IAMHeaders/Base64-incomplete-missing-header
=== RUN   TestBackend_pathLogin_IAMHeaders/Base64-incomplete-missing-auth-sig
--- PASS: TestBackend_pathLogin_IAMHeaders (0.00s)
    --- PASS: TestBackend_pathLogin_IAMHeaders/Default (0.00s)
    --- PASS: TestBackend_pathLogin_IAMHeaders/Map-complete (0.00s)
    --- PASS: TestBackend_pathLogin_IAMHeaders/Map-incomplete (0.00s)
    --- PASS: TestBackend_pathLogin_IAMHeaders/JSON-complete (0.00s)
    --- PASS: TestBackend_pathLogin_IAMHeaders/JSON-incomplete (0.00s)
    --- PASS: TestBackend_pathLogin_IAMHeaders/Base64-complete (0.00s)
    --- PASS: TestBackend_pathLogin_IAMHeaders/Base64-incomplete-missing-header (0.00s)
    --- PASS: TestBackend_pathLogin_IAMHeaders/Base64-incomplete-missing-auth-sig (0.00s)
=== RUN   TestBackend_pathRoleEc2
--- PASS: TestBackend_pathRoleEc2 (0.00s)
=== RUN   Test_enableIamIDResolution
--- PASS: Test_enableIamIDResolution (0.00s)
=== RUN   TestBackend_pathIam
--- PASS: TestBackend_pathIam (0.00s)
=== RUN   TestBackend_pathRoleMixedTypes
2020-04-09T14:53:09.361-0700 [DEBUG] no stsRole found for 123456789012
2020-04-09T14:53:09.361-0700 [DEBUG] no cached client for region us-east-1 and stsRole 
--- PASS: TestBackend_pathRoleMixedTypes (0.41s)
=== RUN   TestAwsEc2_RoleCrud
--- PASS: TestAwsEc2_RoleCrud (0.00s)
=== RUN   TestAwsEc2_RoleDurationSeconds
--- PASS: TestAwsEc2_RoleDurationSeconds (0.00s)
=== RUN   TestRoleEntryUpgradeV
--- PASS: TestRoleEntryUpgradeV (0.00s)
=== RUN   TestRoleInitialize
--- PASS: TestRoleInitialize (0.00s)
=== RUN   TestAwsVersion
--- PASS: TestAwsVersion (0.00s)
=== RUN   TestRoleResolutionWithSTSEndpointConfigured
--- SKIP: TestRoleResolutionWithSTSEndpointConfigured (0.00s)
    path_role_test.go:1008: skipping because AWS_ASSUMABLE_ROLE_ARN is unset
PASS
ok  	github.com/hashicorp/vault/builtin/credential/aws	(cached)
?   	github.com/hashicorp/vault/builtin/credential/aws/cmd/aws	[no test files]
```

</details>