### PR TITLE
document all of the supported elliptic curves

### DIFF
--- a/website/pages/api-docs/secret/pki/index.mdx
+++ b/website/pages/api-docs/secret/pki/index.mdx
@@ -468,7 +468,7 @@ can be set in a CSR are supported.
   or `ec`.
 
 - `key_bits` `(int: 2048)` – Specifies the number of bits to use. This must be
-  changed to a valid value if the `key_type` is `ec`, e.g., 224 or 521.
+  changed to a valid value if the `key_type` is `ec`, e.g., 224, 256, 384 or 521.
 
 - `exclude_cn_from_sans` `(bool: false)` – If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).
@@ -817,7 +817,7 @@ request is denied.
   1024 bits for RSA keys).
 
 - `key_bits` `(int: 2048)` – Specifies the number of bits to use for the
-  generated keys. This will need to be changed for `ec` keys, e.g., 224 or 521.
+  generated keys. This will need to be changed for `ec` keys, e.g., 224, 256, 384 or 521.
 
 - `key_usage` `(list: ["DigitalSignature", "KeyAgreement", "KeyEncipherment"])` –
   Specifies the allowed key usage constraint on issued certificates. Valid
@@ -1086,7 +1086,7 @@ overwrite the existing cert/key with new values.
   or `ec`.
 
 - `key_bits` `(int: 2048)` – Specifies the number of bits to use. This must be
-  changed to a valid value if the `key_type` is `ec`, e.g., 224 or 521.
+  changed to a valid value if the `key_type` is `ec`, e.g., 224, 256, 384 or 521.
 
 - `max_path_length` `(int: -1)` – Specifies the maximum path length to encode in
   the generated certificate. `-1` means no limit. Unless the signing certificate


### PR DESCRIPTION
Small documentation update to list all of the supported EC's.

This would have saved me a few minutes of time and could help someone else in the future. I was not sure if 224 and 521 were the only supported curves as they were the only ones listed in the documentation. I had to dig into the code https://github.com/hashicorp/vault/blob/0937a58ad78c3d1f21a580651d2331115be172ff/sdk/helper/certutil/helpers.go#L210-L216 to find that the p256 curve I was looking for was supported.