### PR TITLE
redirect /index.html to root

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -234,5 +234,6 @@
 /docs/secrets/postgresql/index.html     /docs/secrets/databases/postgresql 301!
 /docs/secrets/postgresql                /docs/secrets/databases/postgresql 301!
 
-/api/*         /api-docs/:splat     200
-/*/index.html  /:splat              301!
+/api/*              /api-docs/:splat     200
+/api/*/index.html   /api-docs/:splat     301!
+/*/index.html       /:splat              301!

--- a/website/_redirects
+++ b/website/_redirects
@@ -234,4 +234,5 @@
 /docs/secrets/postgresql/index.html     /docs/secrets/databases/postgresql 301!
 /docs/secrets/postgresql                /docs/secrets/databases/postgresql 301!
 
-/api/*  /api-docs/:splat 200
+/api/*         /api-docs/:splat     200
+/*/index.html  /:splat              301!

--- a/website/_redirects
+++ b/website/_redirects
@@ -234,6 +234,6 @@
 /docs/secrets/postgresql/index.html     /docs/secrets/databases/postgresql 301!
 /docs/secrets/postgresql                /docs/secrets/databases/postgresql 301!
 
-/api/*              /api-docs/:splat     200
 /api/*/index.html   /api-docs/:splat     301!
+/api/*              /api-docs/:splat     200
 /*/index.html       /:splat              301!


### PR DESCRIPTION
We're on a mission to remove all `.html` and `/index.html` extensions from this site to make links more clear and resilient, but are trying to make sure the ".html" versions still work if someone have them linked externally. This is another step in that direction!