### PR TITLE
Added docs for PR in Vault GCP Secrets repo

### DIFF
--- a/website/pages/api-docs/secret/gcp/index.mdx
+++ b/website/pages/api-docs/secret/gcp/index.mdx
@@ -155,6 +155,12 @@ resource "//cloudresourcemanager.googleapis.com/projects/mygcpproject" {
   ],
 }
 
+resource "//bigquery.googleapis.com/projects/my-project/datasets/mydataset" {
+  roles = [
+    "roles/bigquery.dataViewer"
+  ],
+}
+
 resource "https://selflink/to/my/resource" {
   roles = [
     "project/mygcpproject/roles/projcustomrole",

--- a/website/pages/docs/secrets/gcp/index.mdx
+++ b/website/pages/docs/secrets/gcp/index.mdx
@@ -236,6 +236,9 @@ few different formats:
   # Pubsub snapshot
   //pubsub.googleapis.com/project/my-project/snapshots/my-pubsub-snapshot
 
+  # BigQuery dataset
+  //bigquery.googleapis.com/projects/my-project/datasets/mydataset
+
   # Resource manager
   //cloudresourcemanager.googleapis.com/projects/my-project"
   ```
@@ -346,6 +349,10 @@ resourcemanager.projects.setIamPolicy
 # All compute
 compute.*.getIamPolicy
 compute.*.setIamPolicy
+
+# BigQuery Datasets
+bigquery.datasets.get
+bigquery.datasets.update
 ```
 
 You can either:
@@ -357,6 +364,11 @@ You can either:
   `getIamPolicy/setIamPolicy` permissions. At a minimum you will need to assign
   `roles/iam.serviceAccountAdmin` and `roles/iam.serviceAccountKeyAdmin` so
   Vault can manage service accounts and keys.
+
+- Notice that BigQuery requires different permissions than other resource. This is
+  because BigQuery currently uses legacy ACL instead of traditional IAM permissions.
+  This means to update access on the dataset, Vault must be able to update the dataset's
+  metadata.
 
 ### Root Credential Rotation
 


### PR DESCRIPTION
Updated docs for addition of BigQuery Dataset support for GCP secret plugin.

See: https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/78