### PR TITLE
doc: add client tls parameters to openldap

### DIFF
--- a/website/pages/api-docs/secret/openldap/index.mdx
+++ b/website/pages/api-docs/secret/openldap/index.mdx
@@ -39,6 +39,8 @@ to search and change entry passwords in OpenLDAP.
 - `starttls` `(bool: <optional>)` - If true, issues a `StartTLS` command after establishing an unencrypted connection.
 - `insecure_tls` - `(bool: <optional>)` - If true, skips LDAP server SSL certificate verification - insecure, use with caution!
 - `certificate` - `(string: <optional>)` - CA certificate to use when verifying LDAP server certificate, must be x509 PEM encoded.
+- `client_tls_cert` - `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509 PEM encoded.
+- `client_tls_key` - `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
 
 ### Sample Payload
 


### PR DESCRIPTION
Added undocumented TLS configurables for the OpenLDAP secret engine.