### PR TITLE
stable-website: Add AWS auth info to upgrade guide (#8731)

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -382,6 +382,9 @@ export default [
       'upgrade-to-1.2.1',
       'upgrade-to-1.2.4',
       'upgrade-to-1.3.0',
+      'upgrade-to-1.3.2',
+      'upgrade-to-1.3.3',
+      'upgrade-to-1.3.4',
       'upgrade-to-1.4.0'
     ]
   },

--- a/website/pages/docs/upgrading/upgrade-to-1.3.2.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.3.2.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: Upgrading to Vault 1.4.0 - Guides
-sidebar_title: Upgrade to 1.4.0
+page_title: Upgrading to Vault 1.3.2 - Guides
+sidebar_title: Upgrade to 1.3.2
 description: |-
   This page contains the list of deprecations and important or breaking changes
-  for Vault 1.4.0. Please read it carefully.
+  for Vault 1.3.2. Please read it carefully.
 ---
 
 # Overview
 
 This page contains the list of deprecations and important or breaking changes
-for Vault 1.3.4 compared to 1.4.0. Please read it carefully.
+for Vault 1.3.0 compared to 1.3.2. Please read it carefully.
 
 @include 'partials/aws-auth-metadata-issue.mdx'

--- a/website/pages/docs/upgrading/upgrade-to-1.3.3.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.3.3.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: Upgrading to Vault 1.4.0 - Guides
-sidebar_title: Upgrade to 1.4.0
+page_title: Upgrading to Vault 1.3.3 - Guides
+sidebar_title: Upgrade to 1.3.3
 description: |-
   This page contains the list of deprecations and important or breaking changes
-  for Vault 1.4.0. Please read it carefully.
+  for Vault 1.3.3. Please read it carefully.
 ---
 
 # Overview
 
 This page contains the list of deprecations and important or breaking changes
-for Vault 1.3.4 compared to 1.4.0. Please read it carefully.
+for Vault 1.3.2 compared to 1.3.3. Please read it carefully.
 
 @include 'partials/aws-auth-metadata-issue.mdx'

--- a/website/pages/docs/upgrading/upgrade-to-1.3.4.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.3.4.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: Upgrading to Vault 1.4.0 - Guides
-sidebar_title: Upgrade to 1.4.0
+page_title: Upgrading to Vault 1.3.4 - Guides
+sidebar_title: Upgrade to 1.3.4
 description: |-
   This page contains the list of deprecations and important or breaking changes
-  for Vault 1.4.0. Please read it carefully.
+  for Vault 1.3.4. Please read it carefully.
 ---
 
 # Overview
 
 This page contains the list of deprecations and important or breaking changes
-for Vault 1.3.4 compared to 1.4.0. Please read it carefully.
+for Vault 1.3.3 compared to 1.3.4. Please read it carefully.
 
 @include 'partials/aws-auth-metadata-issue.mdx'

--- a/website/pages/partials/aws-auth-metadata-issue.mdx
+++ b/website/pages/partials/aws-auth-metadata-issue.mdx
@@ -1,0 +1,49 @@
+## The AWS Auth Engine
+
+Users of the AWS Auth Engine should be cautious with this upgrade, because in
+1.3.2 we began adding metadata to tokens issued with this method. While the
+metadata does help with tying tokens to a particular person or machine, it
+also can also take a performance toll.
+
+Whether there's a performance toll depends on if and how you've configured the
+`auth/aws/config/identity` endpoint. To determine if you could be effected:
+
+- Read your identity configuration: `$ vault read auth/aws/config/identity`
+- Determine what Vault is using for identity (`role_id` if unconfigured)
+- Determine what role type(s) you're using (`iam` and/or `ec2`)
+- Consider the rate of change of the metadata fields for each role type
+
+Metadata fields for `iam` roles:
+- `client_arn`
+- `canonical_arn`
+- `client_user_id`
+- `auth_type`
+- `inferred_entity_type`
+- `inferred_entity_id`
+- `inferred_aws_region`
+- `account_id`
+
+Metadata fields for `ec2` roles:
+- `instance_id`
+- `region`
+- `account_id`
+- `ami_id`
+
+For example, if you use `role_id` for identity and only `iam` roles, and
+_many_ machines use the same role, you would conclude that the `client_arn`
+for the machines logging in would have a high rate of change, and so you'd
+see a new storage write each time a new machine logged in under that role.
+
+If you use `role_id` for identity and only `iam` roles, and
+and only _one_ long-lived machine used the role, you would conclude that the
+`client_arn` for the machines logging in would have a low rate of change.
+Unless you added the optional "role-session" to its ARN, in which case you
+could still have a higher rate of change.
+
+However, if you had configured identity to use an `iam_alias` of the `full_arn`,
+or an `ec2_alias` of `instance_id`, you would be likely to see a lower rate of
+change for all fields.
+
+For users seeing a performance issue, we recommend implementing one of the
+aliases above, or waiting until a patch is released providing greater
+flexibility around whether to use this functionality.


### PR DESCRIPTION
Adds #8731 to the `stable-website` branch so it won't wait to go out.