### PR TITLE
Improve error outputs in LDAP auth plugin

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -93,7 +93,7 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 		if b.Logger().IsDebug() {
 			b.Logger().Debug("error getting user bind DN", "error", err)
 		}
-		return nil, logical.ErrorResponse("ldap operation failed"), nil, nil
+		return nil, logical.ErrorResponse("ldap operation failed: unable to retrieve user bind DN"), nil, nil
 	}
 
 	if b.Logger().IsDebug() {
@@ -110,7 +110,7 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 		if b.Logger().IsDebug() {
 			b.Logger().Debug("ldap bind failed", "error", err)
 		}
-		return nil, logical.ErrorResponse("ldap operation failed"), nil, nil
+		return nil, logical.ErrorResponse("ldap operation failed: failed to bind as user"), nil, nil
 	}
 
 	// We re-bind to the BindDN if it's defined because we assume
@@ -120,7 +120,7 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 			if b.Logger().IsDebug() {
 				b.Logger().Debug("error while attempting to re-bind with the BindDN User", "error", err)
 			}
-			return nil, logical.ErrorResponse("ldap operation failed"), nil, nil
+			return nil, logical.ErrorResponse("ldap operation failed: failed to re-bind with the BindDN user"), nil, nil
 		}
 		if b.Logger().IsDebug() {
 			b.Logger().Debug("re-bound to original binddn")
@@ -135,7 +135,7 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 	if cfg.AnonymousGroupSearch {
 		c, err = ldapClient.DialLDAP(cfg.ConfigEntry)
 		if err != nil {
-			return nil, logical.ErrorResponse("ldap operation failed"), nil, nil
+			return nil, logical.ErrorResponse("ldap operation failed: failed to connect to LDAP server"), nil, nil
 		}
 		defer c.Close() // Defer closing of this connection as the deferal above closes the other defined connection
 	}


### PR DESCRIPTION
Makes "ldap operation failed" error messages a little more useful. Also
makes the errors unique so it's easier to debug where an error is coming
from when one occurs.