### PR TITLE
Add helper text to openapi display attributes

### DIFF
--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -49,7 +49,8 @@ requested. The lease duration controls the expiration
 of certificates issued by this backend. Defaults to
 the value of max_ttl.`,
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name: "TTL",
+					Name:     "TTL",
+					HelpText: "Vault will by default set this value to match Max TTL",
 				},
 			},
 
@@ -57,7 +58,8 @@ the value of max_ttl.`,
 				Type:        framework.TypeDurationSecond,
 				Description: "The maximum allowed lease duration",
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name: "Max TTL",
+					Name:     "Max TTL",
+					HelpText: "Vault will by default set this value to match Max TTL for the secrets engine",
 				},
 			},
 

--- a/sdk/framework/path.go
+++ b/sdk/framework/path.go
@@ -193,6 +193,9 @@ type DisplayAttributes struct {
 	// EditType is the optional type of form field needed for a property
 	// This is only necessary for a "textarea" or "file"
 	EditType string `json:"editType,omitempty"`
+
+	// HelpText is the optional helper text for display on the UI
+	HelpText string `json:"helpText,omitempty"`
 }
 
 // RequestExample is example of request data.


### PR DESCRIPTION
This helper text string will allow the UI to give details about the default TTL value, specifically where it is inherited from (if different than the default). Next steps are tracking down what the defaults for each of the secret engines' default and max ttls are, if different than the default (set to vault config default TTL)
