### PR TITLE
Add Transform to enterprise OpenAPI doc

### DIFF
--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -74,6 +74,7 @@ VERSION=$(vault status -format=json | jq -r .version)
 if [[ $VERSION =~ prem|ent ]]
 then
   vault secrets enable kmip
+  vault secrets enable transform
 fi
 
 # Output OpenAPI, optionally formatted

--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -68,11 +68,10 @@ vault secrets enable ssh
 vault secrets enable totp
 vault secrets enable transit
 
-# Enterprise backends
-VERSION=$(vault status -format=json | jq -r .version)
-
-if [[ $VERSION =~ prem|ent ]]
+# Enable enterprise features
+if [[ ! -z "$VAULT_LICENSE" ]]
 then
+  vault write sys/license text="$VAULT_LICENSE"
   vault secrets enable kmip
   vault secrets enable transform
 fi


### PR DESCRIPTION
The Transform secrets engine requires a license for its paths to be included in generating the OpenAPI doc. This PR requires a license env var for enterprise paths to be generated.