### PR TITLE
Add the possibility to configure a custom prefix for GCS

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,7 @@ github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7 h1:u9SHYsPQNyt5tgDm3YN7+9dYrpK96E5wFilTFWIDZOM=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d h1:t5Wuyh53qYyg9eqn4BbnlIT+vmhyww0TatL+zT3uWgI=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/physical/gcs/gcs_ha_test.go
+++ b/physical/gcs/gcs_ha_test.go
@@ -29,7 +29,6 @@ func TestHABackend(t *testing.T) {
 		{name: "WithPrefix", prefix: "some-prefix"},
 		{name: "WithPrefixWithTrailingObjectDelimiter", prefix: "some-prefix-with-trailing-object-delimiter" + objectDelimiter},
 	}
-	t.Parallel()
 	for _, variant := range variants {
 		t.Run(variant.name, func(t *testing.T) {
 			r := rand.New(rand.NewSource(time.Now().UnixNano())).Int()

--- a/physical/gcs/gcs_test.go
+++ b/physical/gcs/gcs_test.go
@@ -42,7 +42,6 @@ func TestBackend(t *testing.T) {
 		{name: "WithPrefix", prefix: "some-prefix"},
 		{name: "WithPrefixWithTrailingObjectDelimiter", prefix: "some-prefix-with-trailing-object-delimiter" + objectDelimiter},
 	}
-	t.Parallel()
 	for _, variant := range variants {
 		t.Run(variant.name, func(t *testing.T) {
 			r := rand.New(rand.NewSource(time.Now().UnixNano())).Int()

--- a/website/pages/docs/configuration/storage/google-cloud-storage.mdx
+++ b/website/pages/docs/configuration/storage/google-cloud-storage.mdx
@@ -99,6 +99,10 @@ https://www.googleapis.com/auth/devstorage.read_write
 - `bucket` `(string: <required>)` – Specifies the name of the bucket to use for
   storage.
 
+- `prefix` `(string: "")` - Arbitrary prefix to use when storing object in
+  the bucket. The prefix is added as is, to simulate a directory
+  add a trailing `/` to the prefix.
+
 - `chunk_size` `(string: "8192")` – Specifies the maximum size (in kilobytes) to
   send in a single request. If set to 0, it will attempt to send the whole
   object at once, but will not retry any failures. If you are not storing large
@@ -141,6 +145,18 @@ will increase the number of outbound requests.
 storage "gcs" {
   bucket     = "mycompany-vault-data"
   chunk_size = "512"
+}
+```
+
+### Custom Prefix
+
+This example shows setting a custom prefix. All Vault data will be stored under the
+prefix `some-prefix/`.
+
+```hcl
+storage "gcs" {
+  bucket     = "mycompany-vault-data"
+  prefix     = "some-prefix/"
 }
 ```
 


### PR DESCRIPTION
Add the possibility to configure a custom prefix for GCS.
The prefix is added as is to all objects name. 

## Example 
```
storage "gcs" {
  bucket = "vault-data"
  prefix = "some-prefix/"
}
```
All data will be stored under `some-prefix/` within the GCS bucket. 
```
some-prefix/foo
some-prefix/foo/bar
```

```
storage "gcs" {
  bucket = "vault-data"
  prefix = "some-prefix"
}
```

Yield, note the absence of delimiter. 
```
some-prefixfoo
some-prefixfoo/bar
```

##  Context / Use Case 
This features issued from the following use-cases:
Vault data are backup in GCS like
```
gs://vault-data/2020/01/01/<..vault data...>
gs://vault-data/2020/01/02/<..vault data...>
gs://vault-data/2020/01/03/<..vault data...>
...
```
Having a single bucket in some case can be advantageous (easier to manage, the automated system taking the backup doesn't need permissions to create a bucket, ...)

Adding the `prefix` option in Vault GCS backend allows then to easily use `vault operator migrate -config migrate.hcl`  to restore from a backup and streamline the process. 

``` 
// migrate.hcl
storage_source "gcs" {
  bucket = "vault-data"
  prefix = "2020/01/03/"
}

storage_destination "consul" {
  address = "127.0.0.1:8500"
  path    = "vault"
}
```