### PR TITLE
Docs: Transit, fix payload for Trim Key endpoint

### DIFF
--- a/website/pages/api-docs/secret/transit/index.mdx
+++ b/website/pages/api-docs/secret/transit/index.mdx
@@ -1253,7 +1253,7 @@ keyring. Once trimmed, previous versions of the key cannot be recovered.
 
 ```json
 {
-  "min_version": 2
+  "min_available_version": 2
 }
 ```
 


### PR DESCRIPTION
This corrects the sample payload on the Trim Key endpoint for the Transit HTTP API.