### PR TITLE
Fix error message for when an invalid uri_sans is provided via the API

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -965,7 +965,7 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 
 					if !valid {
 						return nil, errutil.UserError{Err: fmt.Sprintf(
-							"URI Subject Alternative Names were provided via CSR which are not valid for this role"),
+							"URI Subject Alternative Names were provided via the API which are not valid for this role"),
 						}
 					}
 


### PR DESCRIPTION
Quick fix for a misleading error message.
The surrounding context suggests the uri_sans that's claimed to be invalid is from API data and not a CSR.