### PR TITLE
Clarify when service_registraion was introduced

### DIFF
--- a/website/pages/docs/configuration/service-registration/consul.mdx
+++ b/website/pages/docs/configuration/service-registration/consul.mdx
@@ -17,6 +17,8 @@ a default health check.
 - **HashiCorp Supported** – Consul Service Registration is officially supported
   by HashiCorp.
 
+~> **Version information** Service Registration is only available on Vault 1.4.0 and above.
+
 ```hcl
 service_registration "consul" {
   address      = "127.0.0.1:8500"

--- a/website/pages/docs/configuration/service-registration/consul.mdx
+++ b/website/pages/docs/configuration/service-registration/consul.mdx
@@ -12,12 +12,14 @@ description: >-
 # Consul Service Registration
 
 Consul Service Registration registers Vault as a service in [Consul][consul] with
-a default health check.
+a default health check. 
+
+`service_registration` is not needed when using Consul as Vault's storage backend, as consul will automatically register Vault as a consul service. 
 
 - **HashiCorp Supported** – Consul Service Registration is officially supported
   by HashiCorp.
 
-~> **Version information** Service Registration is only available on Vault 1.4.0 and above.
+~> **Version information** `service_registration` configuration option was introduced in Vault 1.4.0.
 
 ```hcl
 service_registration "consul" {

--- a/website/pages/docs/configuration/service-registration/consul.mdx
+++ b/website/pages/docs/configuration/service-registration/consul.mdx
@@ -14,7 +14,7 @@ description: >-
 Consul Service Registration registers Vault as a service in [Consul][consul] with
 a default health check. 
 
-`service_registration` is not needed when using Consul as Vault's storage backend, as consul will automatically register Vault as a consul service. 
+`service_registration` is not needed when using Consul as Vault's storage backend as Consul will automatically register Vault as a service. 
 
 - **HashiCorp Supported** – Consul Service Registration is officially supported
   by HashiCorp.


### PR DESCRIPTION
Resolves https://github.com/hashicorp/vault/issues/8768
Language is modeled after the nomad acl version limits

> ~> Version information ACLs are only available on Nomad 0.7.0 and above.

https://www.vaultproject.io/docs/configuration/service-registration/consul