### PR TITLE
Allow InfluxDB to use insecure TLS without cert bundle

### DIFF
--- a/plugins/database/influxdb/connection_producer.go
+++ b/plugins/database/influxdb/connection_producer.go
@@ -194,20 +194,22 @@ func (i *influxdbConnectionProducer) createClient() (influx.Client, error) {
 			if err != nil || tlsConfig == nil {
 				return nil, errwrap.Wrapf(fmt.Sprintf("failed to get TLS configuration: tlsConfig:%#v err:{{err}}", tlsConfig), err)
 			}
-			tlsConfig.InsecureSkipVerify = i.InsecureTLS
-
-			if i.TLSMinVersion != "" {
-				var ok bool
-				tlsConfig.MinVersion, ok = tlsutil.TLSLookup[i.TLSMinVersion]
-				if !ok {
-					return nil, fmt.Errorf("invalid 'tls_min_version' in config")
-				}
-			} else {
-				// MinVersion was not being set earlier. Reset it to
-				// zero to gracefully handle upgrades.
-				tlsConfig.MinVersion = 0
-			}
 		}
+		
+		tlsConfig.InsecureSkipVerify = i.InsecureTLS
+
+		if i.TLSMinVersion != "" {
+			var ok bool
+			tlsConfig.MinVersion, ok = tlsutil.TLSLookup[i.TLSMinVersion]
+			if !ok {
+				return nil, fmt.Errorf("invalid 'tls_min_version' in config")
+			}
+		} else {
+			// MinVersion was not being set earlier. Reset it to
+			// zero to gracefully handle upgrades.
+			tlsConfig.MinVersion = 0
+		}
+		
 		clientConfig.TLSConfig = tlsConfig
 		clientConfig.Addr = fmt.Sprintf("https://%s:%s", i.Host, i.Port)
 	}


### PR DESCRIPTION
Currently the the InfluxDB plugin requires a certificate bundle to be provided if you want to use insecure TLS or set a TLS version.

This PR moves these two settings outside of the certificate bundle block. Allowing you to control these settings and not pass a certificate bundle.