### PR TITLE
Fix: rotate root credentials for database plugins using WAL

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -25,7 +25,7 @@ const (
 	databaseConfigPath     = "database/config/"
 	databaseRolePath       = "role/"
 	databaseStaticRolePath = "static-role/"
-	minRootCredRollbackAge = 10 * time.Second
+	minRootCredRollbackAge = 1 * time.Minute
 )
 
 type dbPluginInstance struct {

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -226,9 +226,7 @@ func (b *databaseBackend) invalidate(ctx context.Context, key string) {
 	}
 }
 
-func (b *databaseBackend) GetConnection(ctx context.Context, s logical.Storage,
-	name string) (*dbPluginInstance, error) {
-
+func (b *databaseBackend) GetConnection(ctx context.Context, s logical.Storage, name string) (*dbPluginInstance, error) {
 	config, err := b.DatabaseConfig(ctx, s, name)
 	if err != nil {
 		return nil, err
@@ -237,9 +235,7 @@ func (b *databaseBackend) GetConnection(ctx context.Context, s logical.Storage,
 	return b.GetConnectionWithConfig(ctx, name, config)
 }
 
-func (b *databaseBackend) GetConnectionWithConfig(ctx context.Context, name string,
-	config *DatabaseConfig) (*dbPluginInstance, error) {
-
+func (b *databaseBackend) GetConnectionWithConfig(ctx context.Context, name string, config *DatabaseConfig) (*dbPluginInstance, error) {
 	b.RLock()
 	unlockFunc := b.RUnlock
 	defer func() { unlockFunc() }()

--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -71,7 +71,7 @@ func preparePostgresTestContainer(t *testing.T, s logical.Storage, b logical.Bac
 		})
 		if err != nil || (resp != nil && resp.IsError()) {
 			// It's likely not up and running yet, so return error and try again
-			return fmt.Errorf("err:%#v resp:%#v", err, resp)
+			return fmt.Errorf("err:%#v resp:%+v", err, resp)
 		}
 		if resp == nil {
 			t.Fatal("expected warning")

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/queue"
@@ -80,12 +84,59 @@ func (b *databaseBackend) pathRotateCredentialsUpdate() framework.OperationFunc 
 		db.Lock()
 		defer db.Unlock()
 
-		connectionDetails, err := db.RotateRootCredentials(ctx, config.RootCredentialsRotateStatements)
+		// Generate new credentials
+		userName := config.ConnectionDetails["username"].(string)
+		oldPassword := config.ConnectionDetails["password"].(string)
+		newPassword, err := db.GenerateCredentials(ctx)
+
+		// Write a WAL entry with old and new credentials
+		walID, err := framework.PutWAL(ctx, req.Storage, rootWALKey, &rotateRootCredentialsWAL{
+			ConnectionName: name,
+			UserName:       userName,
+			OldPassword:    oldPassword,
+			NewPassword:    newPassword,
+		})
 		if err != nil {
 			return nil, err
 		}
 
-		config.ConnectionDetails = connectionDetails
+		// Attempt to use SetCredentials for the rotation
+		rotationStatements := dbplugin.Statements{Rotation: config.RootCredentialsRotateStatements}
+		_, _, err = db.SetCredentials(ctx, rotationStatements, dbplugin.StaticUserConfig{
+			Username: userName,
+			Password: newPassword,
+		})
+		if err != nil && status.Code(err) != codes.Unimplemented {
+			if err := framework.DeleteWAL(ctx, req.Storage, walID); err != nil {
+				b.Logger().Warn("unable to delete WAL", "error", err, "WAL ID", walID)
+			}
+			return nil, err
+		}
+
+		// Fall back on RotateRootCredentials if SetCredentials is unimplemented
+		if err != nil && status.Code(err) == codes.Unimplemented {
+			_, err = db.RotateRootCredentials(ctx, config.RootCredentialsRotateStatements)
+			if err != nil {
+				if err := framework.DeleteWAL(ctx, req.Storage, walID); err != nil {
+					b.Logger().Warn("unable to delete WAL", "error", err, "WAL ID", walID)
+				}
+				return nil, err
+			}
+		}
+
+		// At this point, we always want to close the plugin so that the cached
+		// plugin connection is not used in a WAL rollback operation
+		defer func() {
+			db.closed = true
+			if err := db.Database.Close(); err != nil {
+				b.Logger().Error("error closing the database plugin connection", "err", err)
+			}
+			// Even on error, still remove the connection
+			delete(b.connections, name)
+		}()
+
+		// Update Vault storage with the new credentials
+		config.ConnectionDetails["password"] = newPassword
 		entry, err := logical.StorageEntryJSON(fmt.Sprintf("config/%s", name), config)
 		if err != nil {
 			return nil, err
@@ -94,17 +145,17 @@ func (b *databaseBackend) pathRotateCredentialsUpdate() framework.OperationFunc 
 			return nil, err
 		}
 
-		// Close the plugin
-		db.closed = true
-		if err := db.Database.Close(); err != nil {
-			b.Logger().Error("error closing the database plugin connection", "err", err)
+		// Delete the WAL entry after successfully rotating credentials
+		if err := framework.DeleteWAL(ctx, req.Storage, walID); err != nil {
+			// The credentials were successfully rotated, so just log a warning.
+			// The WAL entry will eventually be deleted in the WALRollbackFunc.
+			b.Logger().Warn("unable to delete WAL", "error", err, "WAL ID", walID)
 		}
-		// Even on error, still remove the connection
-		delete(b.connections, name)
 
 		return nil, nil
 	}
 }
+
 func (b *databaseBackend) pathRotateRoleCredentialsUpdate() framework.OperationFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 		name := data.Get("name").(string)

--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -110,17 +110,15 @@ func (b *databaseBackend) pathRotateCredentialsUpdate() framework.OperationFunc 
 			Username: userName,
 			Password: newPassword,
 		}
-		_, _, err = db.SetCredentials(ctx, statements, userConfig)
-
-		// Fall back to using RotateRootCredentials if unimplemented
-		if err != nil && status.Code(err) == codes.Unimplemented {
-			config.ConnectionDetails, err = db.RotateRootCredentials(ctx,
-				config.RootCredentialsRotateStatements)
-		}
-
-		// Handle any error from the root credential rotation
-		if err != nil {
-			return nil, err
+		if _, _, err := db.SetCredentials(ctx, statements, userConfig); err != nil {
+			if status.Code(err) == codes.Unimplemented {
+				// Fall back to using RotateRootCredentials if unimplemented
+				config.ConnectionDetails, err = db.RotateRootCredentials(ctx,
+					config.RootCredentialsRotateStatements)
+			}
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		// Update storage with the new root credentials

--- a/builtin/logical/database/rollback.go
+++ b/builtin/logical/database/rollback.go
@@ -1,0 +1,92 @@
+package database
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/mitchellh/mapstructure"
+)
+
+// WAL storage key used for root credential rotations on database plugins
+const rootWALKey = "rootRotationKey"
+
+type rotateRootCredentialsWAL struct {
+	ConnectionName string
+	UserName       string
+	NewPassword    string
+	OldPassword    string
+}
+
+// TODO: Considerations for HA and Replication?
+func (b *databaseBackend) walRollback(ctx context.Context, req *logical.Request, kind string,
+	data interface{}) error {
+	if kind != rootWALKey {
+		return nil
+	}
+
+	// Decode the WAL data
+	var entry rotateRootCredentialsWAL
+	if err := mapstructure.Decode(data, &entry); err != nil {
+		b.Logger().Info("error decoding WAL data", "data", data)
+		return err
+	}
+
+	// Get the current database configuration from Vault storage
+	config, err := b.DatabaseConfig(ctx, req.Storage, entry.ConnectionName)
+	if err != nil {
+		return err
+	}
+
+	// The password in Vault storage does not match the new password
+	// in the WAL entry. This means there was a partial failure where
+	// the database password was updated but Vault storage was not.
+	// To reconcile the password between Vault and the database, roll
+	// back the database password to the old password.
+	if config.ConnectionDetails["password"] != entry.NewPassword {
+		return b.rollbackDatabasePassword(ctx, config, entry)
+	}
+
+	// The password in Vault storage matches the new password
+	// in the WAL entry, so there is nothing to roll back. This
+	// means the new password was successfully updated in the
+	// database and Vault storage, but the WAL was not deleted.
+	return nil
+}
+
+func (b *databaseBackend) rollbackDatabasePassword(ctx context.Context, config *DatabaseConfig, entry rotateRootCredentialsWAL) error {
+	// Get a connection using the new password
+	config.ConnectionDetails["password"] = entry.NewPassword
+	dbc, err := b.GetConnectionWithConfig(ctx, entry.ConnectionName, config)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := b.ClearConnection(entry.ConnectionName); err != nil {
+			b.Logger().Error("error closing database plugin connection", "err", err)
+		}
+	}()
+
+	// Roll back the database password to the WAL old password
+	// in order to reconcile the database and Vault storage.
+	rotationStatements := dbplugin.Statements{
+		Rotation: config.RootCredentialsRotateStatements,
+	}
+	userConfig := dbplugin.StaticUserConfig{
+		Username: entry.UserName,
+		Password: entry.OldPassword,
+	}
+	_, _, err = dbc.SetCredentials(ctx, rotationStatements, userConfig)
+
+	// If SetCredentials is unimplemented in the plugin, this means that
+	// the root credential rotation happened via the RotateRootCredentials
+	// RPC. Delete the WAL by returning nil.
+	if err != nil && status.Code(err) == codes.Unimplemented {
+		return nil
+	}
+
+	return err
+}

--- a/builtin/logical/database/rollback.go
+++ b/builtin/logical/database/rollback.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/vault/sdk/database/dbplugin"
 	"google.golang.org/grpc/codes"
@@ -25,7 +26,7 @@ type rotateRootCredentialsWAL struct {
 func (b *databaseBackend) walRollback(ctx context.Context, req *logical.Request, kind string,
 	data interface{}) error {
 	if kind != rootWALKey {
-		return nil
+		return fmt.Errorf("unknown type to rollback")
 	}
 
 	// Decode the WAL data
@@ -57,7 +58,9 @@ func (b *databaseBackend) walRollback(ctx context.Context, req *logical.Request,
 	return nil
 }
 
-func (b *databaseBackend) rollbackDatabasePassword(ctx context.Context, config *DatabaseConfig, entry rotateRootCredentialsWAL) error {
+func (b *databaseBackend) rollbackDatabasePassword(ctx context.Context, config *DatabaseConfig,
+	entry rotateRootCredentialsWAL) error {
+
 	// Get a connection using the new password
 	config.ConnectionDetails["password"] = entry.NewPassword
 	dbc, err := b.GetConnectionWithConfig(ctx, entry.ConnectionName, config)

--- a/builtin/logical/database/rollback.go
+++ b/builtin/logical/database/rollback.go
@@ -60,7 +60,7 @@ func (b *databaseBackend) walRollback(ctx context.Context, req *logical.Request,
 func (b *databaseBackend) rollbackDatabasePassword(ctx context.Context, req *logical.Request,
 	config *DatabaseConfig, entry rotateRootCredentialsWAL) error {
 
-	// Clear the current connection
+	// Clear any cached plugin connection
 	err := b.ClearConnection(entry.ConnectionName)
 	if err != nil {
 		return err
@@ -75,8 +75,8 @@ func (b *databaseBackend) rollbackDatabasePassword(ctx context.Context, req *log
 		return nil
 	}
 
-	// The root credentials according to the database and Vault storage
-	// are different. Attempt to connect with the new password from the
+	// The root credentials are different according to the database and
+	// Vault storage. Attempt to connect with the new password from the
 	// WAL entry.
 	config.ConnectionDetails["password"] = entry.NewPassword
 	dbc, err := b.GetConnectionWithConfig(ctx, entry.ConnectionName, config)
@@ -84,7 +84,7 @@ func (b *databaseBackend) rollbackDatabasePassword(ctx context.Context, req *log
 		return err
 	}
 
-	// Clear the connection used to roll back the database password
+	// Always clear the connection used to roll back the database password
 	defer func() {
 		if err := b.ClearConnection(entry.ConnectionName); err != nil {
 			b.Logger().Error("error closing database plugin connection", "err", err)

--- a/builtin/logical/database/rollback.go
+++ b/builtin/logical/database/rollback.go
@@ -58,8 +58,8 @@ func (b *databaseBackend) walRollback(ctx context.Context, req *logical.Request,
 
 		// Attempt to get a connection with the current configuration.
 		// If successful, the WAL entry can be deleted. This means
-		// the root credentials according to the database and storage
-		// are the same.
+		// the root credentials are the same according to the database
+		// and storage.
 		_, err = b.GetConnection(ctx, req.Storage, entry.ConnectionName)
 		if err == nil {
 			return nil

--- a/builtin/logical/database/rollback.go
+++ b/builtin/logical/database/rollback.go
@@ -2,8 +2,7 @@ package database
 
 import (
 	"context"
-	"fmt"
-
+	"errors"
 	"github.com/hashicorp/vault/sdk/database/dbplugin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -26,7 +25,7 @@ type rotateRootCredentialsWAL struct {
 func (b *databaseBackend) walRollback(ctx context.Context, req *logical.Request, kind string,
 	data interface{}) error {
 	if kind != rootWALKey {
-		return fmt.Errorf("unknown type to rollback")
+		return errors.New("unknown type to rollback")
 	}
 
 	// Decode the WAL data
@@ -48,7 +47,7 @@ func (b *databaseBackend) walRollback(ctx context.Context, req *logical.Request,
 	// To reconcile the password between Vault and the database, roll
 	// back the database password to the old password.
 	if config.ConnectionDetails["password"] != entry.NewPassword {
-		return b.rollbackDatabasePassword(ctx, config, entry)
+		return b.rollbackDatabasePassword(ctx, req, config, entry)
 	}
 
 	// The password in Vault storage matches the new password
@@ -58,31 +57,48 @@ func (b *databaseBackend) walRollback(ctx context.Context, req *logical.Request,
 	return nil
 }
 
-func (b *databaseBackend) rollbackDatabasePassword(ctx context.Context, config *DatabaseConfig,
-	entry rotateRootCredentialsWAL) error {
+func (b *databaseBackend) rollbackDatabasePassword(ctx context.Context, req *logical.Request,
+	config *DatabaseConfig, entry rotateRootCredentialsWAL) error {
 
-	// Get a connection using the new password
+	// Clear the current connection
+	err := b.ClearConnection(entry.ConnectionName)
+	if err != nil {
+		return err
+	}
+
+	// Attempt to connect with the current configuration.
+	// If successful, the WAL can be delete because the root
+	// credentials according to the database and Vault storage
+	// are the same.
+	_, err = b.GetConnection(ctx, req.Storage, entry.ConnectionName)
+	if err == nil {
+		return nil
+	}
+
+	// The root credentials according to the database and Vault storage
+	// are different. Attempt to connect with the new password from the
+	// WAL entry.
 	config.ConnectionDetails["password"] = entry.NewPassword
 	dbc, err := b.GetConnectionWithConfig(ctx, entry.ConnectionName, config)
 	if err != nil {
 		return err
 	}
+
+	// Clear the connection used to roll back the database password
 	defer func() {
 		if err := b.ClearConnection(entry.ConnectionName); err != nil {
 			b.Logger().Error("error closing database plugin connection", "err", err)
 		}
 	}()
 
-	// Roll back the database password to the WAL old password
+	// Roll back the database password to the WAL entry old password
 	// in order to reconcile the database and Vault storage.
-	rotationStatements := dbplugin.Statements{
-		Rotation: config.RootCredentialsRotateStatements,
-	}
+	statements := dbplugin.Statements{Rotation: config.RootCredentialsRotateStatements}
 	userConfig := dbplugin.StaticUserConfig{
 		Username: entry.UserName,
 		Password: entry.OldPassword,
 	}
-	_, _, err = dbc.SetCredentials(ctx, rotationStatements, userConfig)
+	_, _, err = dbc.SetCredentials(ctx, statements, userConfig)
 
 	// If SetCredentials is unimplemented in the plugin, this means that
 	// the root credential rotation happened via the RotateRootCredentials

--- a/builtin/logical/database/rollback.go
+++ b/builtin/logical/database/rollback.go
@@ -36,7 +36,6 @@ func (b *databaseBackend) walRollback(ctx context.Context, req *logical.Request,
 	// Decode the WAL data
 	var entry rotateRootCredentialsWAL
 	if err := mapstructure.Decode(data, &entry); err != nil {
-		b.Logger().Info("error decoding WAL data", "data", data)
 		return err
 	}
 

--- a/builtin/logical/database/rollback_test.go
+++ b/builtin/logical/database/rollback_test.go
@@ -1,0 +1,135 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/vault/helper/namespace"
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+	"strings"
+	"testing"
+)
+
+func TestBackend_RotateRootCredentials_WAL(t *testing.T) {
+	cluster, sys := getCluster(t)
+	defer cluster.Cleanup()
+
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = sys
+
+	lb, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbBackend, ok := lb.(*databaseBackend)
+	if !ok {
+		t.Fatal("could not convert to db backend")
+	}
+	defer lb.Cleanup(context.Background())
+
+	connectionName := "plugin-test"
+	roleName := "plugin-role-test"
+	userName := "postgres"
+	oldPassword := "secret"
+	newPassword := "newSecret"
+
+	// Create a database connection to postgres
+	cleanup, connURL := preparePostgresTestContainer(t, config.StorageView, lb)
+	defer cleanup()
+
+	connURL = strings.Replace(connURL, "postgres:secret", "{{username}}:{{password}}", -1)
+	data := map[string]interface{}{
+		"connection_url": connURL,
+		"plugin_name":    "postgresql-database-plugin",
+		"allowed_roles":  []string{roleName},
+		"username":       userName,
+		"password":       oldPassword,
+	}
+	req := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      fmt.Sprintf("config/%s", connectionName),
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	resp, err := lb.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	// Create a role
+	data = map[string]interface{}{
+		"db_name":             connectionName,
+		"creation_statements": testRole,
+		"max_ttl":             "10m",
+	}
+	req = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      fmt.Sprintf("roles/%s", roleName),
+		Storage:   config.StorageView,
+		Data:      data,
+	}
+	resp, err = lb.HandleRequest(namespace.RootContext(nil), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	// Read database credentials
+	credReq := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      fmt.Sprintf("creds/%s", roleName),
+		Storage:   config.StorageView,
+		Data:      make(map[string]interface{}),
+	}
+	credRes, err := lb.HandleRequest(namespace.RootContext(nil), credReq)
+	if err != nil || (credRes != nil && credRes.IsError()) {
+		t.Fatalf("err:%s resp:%v\n", err, credRes)
+	}
+
+	// Set database root credentials to "newSecret"
+	pluginConn, err := dbBackend.GetConnection(context.Background(),
+		config.StorageView, connectionName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pluginConn.SetCredentials(context.Background(), dbplugin.Statements{}, dbplugin.StaticUserConfig{
+		Username: userName,
+		Password: newPassword,
+	})
+	dbBackend.ClearConnection(connectionName)
+
+	// Reading credentials should not work because the credentials changes
+	credRes, err = lb.HandleRequest(namespace.RootContext(nil), credReq)
+	if err == nil {
+		t.Fatalf("err:%s resp:%v\n", err, credRes)
+	}
+
+	// Put a rotateRootCredentialsWAL
+	walEntry := &rotateRootCredentialsWAL{
+		ConnectionName: connectionName,
+		UserName:       userName,
+		OldPassword:    oldPassword,
+		NewPassword:    newPassword,
+	}
+	framework.PutWAL(context.Background(), config.StorageView, rootWALKey, walEntry)
+
+	// Trigger an immediate rollback operation
+	_, err = lb.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.RollbackOperation,
+		Path:      "",
+		Storage:   config.StorageView,
+		Data: map[string]interface{}{
+			"immediate": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Getting credentials should work because of the WAL rollback
+	credRes, err = lb.HandleRequest(namespace.RootContext(nil), credReq)
+	if err != nil || (credRes != nil && credRes.IsError()) {
+		t.Fatalf("err:%s resp:%v\n", err, credRes)
+	}
+}

--- a/builtin/logical/database/rollback_test.go
+++ b/builtin/logical/database/rollback_test.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"fmt"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/database/dbplugin"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -11,7 +10,17 @@ import (
 	"testing"
 )
 
-func TestBackend_RotateRootCredentials_WALRollback(t *testing.T) {
+const (
+	databaseUser    = "postgres"
+	defaultPassword = "secret"
+)
+
+// Tests that the WAL rollback function rolls back the database password.
+// The database password should be rolled back when:
+//  - A WAL entry exists
+//  - Password has been altered on the database
+//  - Password has not been updated in storage
+func TestBackend_RotateRootCredentials_WAL_rollback(t *testing.T) {
 	cluster, sys := getCluster(t)
 	defer cluster.Cleanup()
 
@@ -29,98 +38,101 @@ func TestBackend_RotateRootCredentials_WALRollback(t *testing.T) {
 	}
 	defer lb.Cleanup(context.Background())
 
-	connectionName := "plugin-test"
-	roleName := "plugin-role-test"
-	userName := "postgres" // TODO: Const?
-	oldPassword := "secret"
-	newPassword := "newSecret"
-
 	cleanup, connURL := preparePostgresTestContainer(t, config.StorageView, lb)
 	defer cleanup()
 
 	connURL = strings.Replace(connURL, "postgres:secret", "{{username}}:{{password}}", -1)
+
+	// Configure a connection to the database
 	data := map[string]interface{}{
 		"connection_url": connURL,
 		"plugin_name":    "postgresql-database-plugin",
-		"allowed_roles":  []string{roleName},
-		"username":       userName,
-		"password":       oldPassword,
+		"allowed_roles":  []string{"plugin-role-test"},
+		"username":       databaseUser,
+		"password":       defaultPassword,
 	}
-	req := &logical.Request{
+	resp, err := lb.HandleRequest(namespace.RootContext(nil), &logical.Request{
 		Operation: logical.UpdateOperation,
-		Path:      fmt.Sprintf("config/%s", connectionName),
+		Path:      "config/plugin-test",
 		Storage:   config.StorageView,
 		Data:      data,
-	}
-	resp, err := lb.HandleRequest(namespace.RootContext(nil), req)
+	})
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
+	// Create a role
 	data = map[string]interface{}{
-		"db_name":             connectionName,
+		"db_name":             "plugin-test",
 		"creation_statements": testRole,
 		"max_ttl":             "10m",
 	}
-	req = &logical.Request{
+	resp, err = lb.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
-		Path:      fmt.Sprintf("roles/%s", roleName),
+		Path:      "roles/plugin-role-test",
 		Storage:   config.StorageView,
 		Data:      data,
-	}
-	resp, err = lb.HandleRequest(namespace.RootContext(nil), req)
+	})
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
 
+	// Read credentials to verify this initially works
 	credReq := &logical.Request{
 		Operation: logical.ReadOperation,
-		Path:      fmt.Sprintf("creds/%s", roleName),
+		Path:      "creds/plugin-role-test",
 		Storage:   config.StorageView,
 		Data:      make(map[string]interface{}),
 	}
-	credRes, err := lb.HandleRequest(namespace.RootContext(nil), credReq)
-	if err != nil || (credRes != nil && credRes.IsError()) {
-		t.Fatalf("err:%s resp:%v\n", err, credRes)
+	credResp, err := lb.HandleRequest(context.Background(), credReq)
+	if err != nil || (credResp != nil && credResp.IsError()) {
+		t.Fatalf("err:%s resp:%v\n", err, credResp)
 	}
 
-	pluginConn, err := dbBackend.GetConnection(context.Background(),
-		config.StorageView, connectionName)
+	// Get a connection to the database plugin
+	pc, err := dbBackend.GetConnection(context.Background(),
+		config.StorageView, "plugin-test")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, _, err = pluginConn.SetCredentials(context.Background(), dbplugin.Statements{}, dbplugin.StaticUserConfig{
-		Username: userName,
-		Password: newPassword,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = dbBackend.ClearConnection(connectionName)
+	// Alter the database password so it no longer matches what is in storage
+	_, _, err = pc.SetCredentials(context.Background(), dbplugin.Statements{},
+		dbplugin.StaticUserConfig{
+			Username: databaseUser,
+			Password: "newSecret",
+		})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Reading credentials should not work because the credentials changes
-	credRes, err = lb.HandleRequest(namespace.RootContext(nil), credReq)
+	// Clear the plugin connection to verify we're no longer able to connect
+	err = dbBackend.ClearConnection("plugin-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reading credentials should no longer work
+	credResp, err = lb.HandleRequest(namespace.RootContext(nil), credReq)
 	if err == nil {
-		t.Fatalf("err:%s resp:%v\n", err, credRes)
+		t.Fatalf("expected authentication to fail when reading credentials")
 	}
 
-	// Put a rotateRootCredentialsWAL
+	// Put a WAL entry that will be used for rolling back the database password
 	walEntry := &rotateRootCredentialsWAL{
-		ConnectionName: connectionName,
-		UserName:       userName,
-		OldPassword:    oldPassword,
-		NewPassword:    newPassword,
+		ConnectionName: "plugin-test",
+		UserName:       databaseUser,
+		OldPassword:    defaultPassword,
+		NewPassword:    "newSecret",
 	}
 	_, err = framework.PutWAL(context.Background(), config.StorageView, rotateRootWALKey, walEntry)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assertWALCount(t, config.StorageView, 1, rotateRootWALKey)
 
-	// Trigger an immediate rollback operation
+	// Trigger an immediate RollbackOperation so that the WAL rollback
+	// function can use the WAL entry to roll back the database password
 	_, err = lb.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.RollbackOperation,
 		Path:      "",
@@ -130,14 +142,270 @@ func TestBackend_RotateRootCredentials_WALRollback(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal(err)
 	}
+	assertWALCount(t, config.StorageView, 0, rotateRootWALKey)
 
-	// Getting credentials should work because of the WAL rollback
-	credRes, err = lb.HandleRequest(namespace.RootContext(nil), credReq)
-	if err != nil || (credRes != nil && credRes.IsError()) {
-		t.Fatalf("err:%s resp:%v\n", err, credRes)
+	// Reading credentials should work again after the database
+	// password has been rolled back.
+	credResp, err = lb.HandleRequest(namespace.RootContext(nil), credReq)
+	if err != nil || (credResp != nil && credResp.IsError()) {
+		t.Fatalf("err:%s resp:%v\n", err, credResp)
 	}
 }
 
-// TODO: test for non-rollback condition
+// Tests that the WAL rollback function does not roll back the database password.
+// The database password should not be rolled back when:
+//  - A WAL entry exists
+//  - Password has not been altered on the database
+//  - Password has not been updated in storage
+func TestBackend_RotateRootCredentials_WAL_no_rollback_1(t *testing.T) {
+	cluster, sys := getCluster(t)
+	defer cluster.Cleanup()
+
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = sys
+
+	lb, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lb.Cleanup(context.Background())
+
+	cleanup, connURL := preparePostgresTestContainer(t, config.StorageView, lb)
+	defer cleanup()
+
+	connURL = strings.Replace(connURL, "postgres:secret", "{{username}}:{{password}}", -1)
+
+	// Configure a connection to the database
+	data := map[string]interface{}{
+		"connection_url": connURL,
+		"plugin_name":    "postgresql-database-plugin",
+		"allowed_roles":  []string{"plugin-role-test"},
+		"username":       databaseUser,
+		"password":       defaultPassword,
+	}
+	resp, err := lb.HandleRequest(namespace.RootContext(nil), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/plugin-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	// Create a role
+	data = map[string]interface{}{
+		"db_name":             "plugin-test",
+		"creation_statements": testRole,
+		"max_ttl":             "10m",
+	}
+	resp, err = lb.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "roles/plugin-role-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	// Read credentials to verify this initially works
+	credReq := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "creds/plugin-role-test",
+		Storage:   config.StorageView,
+		Data:      make(map[string]interface{}),
+	}
+	credResp, err := lb.HandleRequest(context.Background(), credReq)
+	if err != nil || (credResp != nil && credResp.IsError()) {
+		t.Fatalf("err:%s resp:%v\n", err, credResp)
+	}
+
+	// Put a WAL entry
+	walEntry := &rotateRootCredentialsWAL{
+		ConnectionName: "plugin-test",
+		UserName:       databaseUser,
+		OldPassword:    defaultPassword,
+		NewPassword:    "newSecret",
+	}
+	_, err = framework.PutWAL(context.Background(), config.StorageView, rotateRootWALKey, walEntry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertWALCount(t, config.StorageView, 1, rotateRootWALKey)
+
+	// Trigger an immediate RollbackOperation
+	_, err = lb.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.RollbackOperation,
+		Path:      "",
+		Storage:   config.StorageView,
+		Data: map[string]interface{}{
+			"immediate": true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertWALCount(t, config.StorageView, 0, rotateRootWALKey)
+
+	// Reading credentials should work
+	credResp, err = lb.HandleRequest(namespace.RootContext(nil), credReq)
+	if err != nil || (credResp != nil && credResp.IsError()) {
+		t.Fatalf("err:%s resp:%v\n", err, credResp)
+	}
+}
+
+// Tests that the WAL rollback function does not roll back the database password.
+// The database password should not be rolled back when:
+//  - A WAL entry exists
+//  - Password has been altered on the database
+//  - Password has been updated in storage
+func TestBackend_RotateRootCredentials_WAL_no_rollback_2(t *testing.T) {
+	cluster, sys := getCluster(t)
+	defer cluster.Cleanup()
+
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = sys
+
+	lb, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbBackend, ok := lb.(*databaseBackend)
+	if !ok {
+		t.Fatal("could not convert to db backend")
+	}
+	defer lb.Cleanup(context.Background())
+
+	cleanup, connURL := preparePostgresTestContainer(t, config.StorageView, lb)
+	defer cleanup()
+
+	connURL = strings.Replace(connURL, "postgres:secret", "{{username}}:{{password}}", -1)
+
+	// Configure a connection to the database
+	data := map[string]interface{}{
+		"connection_url": connURL,
+		"plugin_name":    "postgresql-database-plugin",
+		"allowed_roles":  []string{"plugin-role-test"},
+		"username":       databaseUser,
+		"password":       defaultPassword,
+	}
+	resp, err := lb.HandleRequest(namespace.RootContext(nil), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "config/plugin-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	// Create a role
+	data = map[string]interface{}{
+		"db_name":             "plugin-test",
+		"creation_statements": testRole,
+		"max_ttl":             "10m",
+	}
+	resp, err = lb.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "roles/plugin-role-test",
+		Storage:   config.StorageView,
+		Data:      data,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	// Read credentials to verify this initially works
+	credReq := &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "creds/plugin-role-test",
+		Storage:   config.StorageView,
+		Data:      make(map[string]interface{}),
+	}
+	credResp, err := lb.HandleRequest(context.Background(), credReq)
+	if err != nil || (credResp != nil && credResp.IsError()) {
+		t.Fatalf("err:%s resp:%v\n", err, credResp)
+	}
+
+	// Get a connection to the database plugin
+	pc, err := dbBackend.GetConnection(context.Background(), config.StorageView, "plugin-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Alter the database password
+	_, _, err = pc.SetCredentials(context.Background(), dbplugin.Statements{},
+		dbplugin.StaticUserConfig{
+			Username: databaseUser,
+			Password: "newSecret",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update storage with the new password
+	dbConfig, err := dbBackend.DatabaseConfig(context.Background(), config.StorageView,
+		"plugin-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbConfig.ConnectionDetails["password"] = "newSecret"
+	entry, err := logical.StorageEntryJSON("config/plugin-test", dbConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = config.StorageView.Put(context.Background(), entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Clear the plugin connection to verify we can connect to the database
+	err = dbBackend.ClearConnection("plugin-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reading credentials should work
+	credResp, err = lb.HandleRequest(namespace.RootContext(nil), credReq)
+	if err != nil || (credResp != nil && credResp.IsError()) {
+		t.Fatalf("err:%s resp:%v\n", err, credResp)
+	}
+
+	// Put a WAL entry
+	walEntry := &rotateRootCredentialsWAL{
+		ConnectionName: "plugin-test",
+		UserName:       databaseUser,
+		OldPassword:    defaultPassword,
+		NewPassword:    "newSecret",
+	}
+	_, err = framework.PutWAL(context.Background(), config.StorageView, rotateRootWALKey, walEntry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertWALCount(t, config.StorageView, 1, rotateRootWALKey)
+
+	// Trigger an immediate RollbackOperation
+	_, err = lb.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.RollbackOperation,
+		Path:      "",
+		Storage:   config.StorageView,
+		Data: map[string]interface{}{
+			"immediate": true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertWALCount(t, config.StorageView, 0, rotateRootWALKey)
+
+	// Reading credentials should work
+	credResp, err = lb.HandleRequest(namespace.RootContext(nil), credReq)
+	if err != nil || (credResp != nil && credResp.IsError()) {
+		t.Fatalf("err:%s resp:%v\n", err, credResp)
+	}
+}

--- a/builtin/logical/database/rollback_test.go
+++ b/builtin/logical/database/rollback_test.go
@@ -115,7 +115,7 @@ func TestBackend_RotateRootCredentials_WALRollback(t *testing.T) {
 		OldPassword:    oldPassword,
 		NewPassword:    newPassword,
 	}
-	_, err = framework.PutWAL(context.Background(), config.StorageView, rootWALKey, walEntry)
+	_, err = framework.PutWAL(context.Background(), config.StorageView, rotateRootWALKey, walEntry)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -477,7 +477,7 @@ func TestBackend_Static_QueueWAL_discard_role_not_found(t *testing.T) {
 		t.Fatalf("error with PutWAL: %s", err)
 	}
 
-	assertWALCount(t, config.StorageView, 1)
+	assertWALCount(t, config.StorageView, 1, staticWALKey)
 
 	b, err := Factory(ctx, config)
 	if err != nil {
@@ -496,7 +496,7 @@ func TestBackend_Static_QueueWAL_discard_role_not_found(t *testing.T) {
 		t.Fatalf("expected zero queue items, got: %d", bd.credRotationQueue.Len())
 	}
 
-	assertWALCount(t, config.StorageView, 0)
+	assertWALCount(t, config.StorageView, 0, staticWALKey)
 }
 
 // Second scenario, WAL contains a role name that does exist, but the role's
@@ -597,7 +597,7 @@ func TestBackend_Static_QueueWAL_discard_role_newer_rotation_date(t *testing.T) 
 		t.Fatalf("error with PutWAL: %s", err)
 	}
 
-	assertWALCount(t, config.StorageView, 1)
+	assertWALCount(t, config.StorageView, 1, staticWALKey)
 
 	// Reload backend
 	lb, err = Factory(context.Background(), config)
@@ -614,7 +614,7 @@ func TestBackend_Static_QueueWAL_discard_role_newer_rotation_date(t *testing.T) 
 	time.Sleep(time.Second * 12)
 
 	// PopulateQueue should have processed the entry
-	assertWALCount(t, config.StorageView, 0)
+	assertWALCount(t, config.StorageView, 0, staticWALKey)
 
 	// Read the role
 	data = map[string]interface{}{}
@@ -656,7 +656,7 @@ func TestBackend_Static_QueueWAL_discard_role_newer_rotation_date(t *testing.T) 
 }
 
 // Helper to assert the number of WAL entries is what we expect
-func assertWALCount(t *testing.T, s logical.Storage, expected int) {
+func assertWALCount(t *testing.T, s logical.Storage, expected int, key string) {
 	var count int
 	ctx := context.Background()
 	keys, err := framework.ListWAL(ctx, s)
@@ -671,7 +671,7 @@ func assertWALCount(t *testing.T, s logical.Storage, expected int) {
 			continue
 		}
 
-		if walEntry.Kind != staticWALKey {
+		if walEntry.Kind != key {
 			continue
 		}
 		count++

--- a/go.sum
+++ b/go.sum
@@ -150,7 +150,6 @@ github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7 h1:u9SHYsPQNyt5tgDm3YN7+9dYrpK96E5wFilTFWIDZOM=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,7 @@ github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7 h1:u9SHYsPQNyt5tgDm3YN7+9dYrpK96E5wFilTFWIDZOM=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -112,7 +112,7 @@ func (p *PostgreSQL) getConnection(ctx context.Context) (*sql.DB, error) {
 // Vault's storage.
 func (p *PostgreSQL) SetCredentials(ctx context.Context, statements dbplugin.Statements, staticUser dbplugin.StaticUserConfig) (username, password string, err error) {
 	if len(statements.Rotation) == 0 {
-		return "", "", errors.New("empty rotation statements")
+		statements.Rotation = []string{defaultPostgresRotateRootCredentialsSQL}
 	}
 
 	username = staticUser.Username

--- a/plugins/database/redshift/redshift.go
+++ b/plugins/database/redshift/redshift.go
@@ -107,7 +107,7 @@ func (r *RedShift) getConnection(ctx context.Context) (*sql.DB, error) {
 // Vault's storage.
 func (r *RedShift) SetCredentials(ctx context.Context, statements dbplugin.Statements, staticUser dbplugin.StaticUserConfig) (username, password string, err error) {
 	if len(statements.Rotation) == 0 {
-		return "", "", errors.New("empty rotation statements")
+		statements.Rotation = []string{defaultRotateRootCredentialsSQL}
 	}
 
 	username = staticUser.Username

--- a/sdk/database/dbplugin/databasemiddleware.go
+++ b/sdk/database/dbplugin/databasemiddleware.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/grpc/status"
+
 	"github.com/hashicorp/errwrap"
 
 	metrics "github.com/armon/go-metrics"
@@ -318,6 +320,13 @@ func (mw *DatabaseErrorSanitizerMiddleware) sanitize(err error) error {
 			if k == "" {
 				continue
 			}
+			// Attempt to keep the status code attached to the error
+			s, ok := status.FromError(err)
+			if ok {
+				err = status.Error(s.Code(), strings.Replace(s.Message(), k, v.(string), -1))
+				continue
+			}
+
 			err = errors.New(strings.Replace(err.Error(), k, v.(string), -1))
 		}
 	}

--- a/sdk/database/dbplugin/databasemiddleware.go
+++ b/sdk/database/dbplugin/databasemiddleware.go
@@ -320,7 +320,9 @@ func (mw *DatabaseErrorSanitizerMiddleware) sanitize(err error) error {
 			if k == "" {
 				continue
 			}
-			// Attempt to keep the status code attached to the error
+
+			// Attempt to keep the status code attached to the
+			// error without changing the actual error message
 			s, ok := status.FromError(err)
 			if ok {
 				err = status.Error(s.Code(), strings.Replace(s.Message(), k, v.(string), -1))

--- a/sdk/database/dbplugin/databasemiddleware.go
+++ b/sdk/database/dbplugin/databasemiddleware.go
@@ -8,12 +8,10 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc/status"
-
-	"github.com/hashicorp/errwrap"
-
 	metrics "github.com/armon/go-metrics"
+	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc/status"
 )
 
 // ---- Tracing Middleware Domain ----


### PR DESCRIPTION
Fixes: #6042 

This PR enables recovery from partial failure when rotating the root credentials of a database while Vault's storage backend is unavailable.

To achieve recovery from partial failure, this PR introduces:
- Use of WAL when rotating root credentials of a database
- A WAL rollback function on the database backend

The WAL rollback function will use WAL entries existing from partial failures to roll back the password on the database when doing so would reconcile the credentials with Vault storage.