### PR TITLE
Sidebranch: dr-secondary-dashboard-pr7

### DIFF
--- a/ui/app/models/cluster.js
+++ b/ui/app/models/cluster.js
@@ -75,9 +75,9 @@ export default DS.Model.extend({
     const glyph = 'check-circle-outline';
 
     const glyphs = {
-      'stream-wals': 'android-sync',
+      'stream-wals': 'check-circle-outline',
       'merkle-diff': 'android-sync',
-      'merkle-sync': null,
+      'merkle-sync': 'android-sync',
     };
 
     return glyphs[state] || glyph;

--- a/ui/app/styles/components/empty-state.scss
+++ b/ui/app/styles/components/empty-state.scss
@@ -36,3 +36,8 @@
     margin-left: $spacing-s;
   }
 }
+
+.empty-state-icon > .hs-icon {
+  float: left;
+  margin-right: $spacing-xs;
+}

--- a/ui/app/styles/components/empty-state.scss
+++ b/ui/app/styles/components/empty-state.scss
@@ -2,10 +2,13 @@
   align-items: center;
   color: $grey;
   display: flex;
-  background: $ui-gray-010;
   justify-content: center;
   padding: $spacing-xxl $spacing-s;
   box-shadow: 0 -2px 0 -1px $ui-gray-300;
+}
+
+.empty-state-background {
+  background: $ui-gray-010;
 }
 
 .empty-state-content {
@@ -40,4 +43,9 @@
 .empty-state-icon > .hs-icon {
   float: left;
   margin-right: $spacing-xs;
+}
+
+.empty-state-message-border {
+  padding-bottom: $spacing-s;
+  border-bottom: 1px solid $grey-light;
 }

--- a/ui/app/styles/components/empty-state.scss
+++ b/ui/app/styles/components/empty-state.scss
@@ -1,14 +1,11 @@
 .empty-state {
   align-items: center;
   color: $grey;
+  background: $ui-gray-010;
   display: flex;
   justify-content: center;
   padding: $spacing-xxl $spacing-s;
   box-shadow: 0 -2px 0 -1px $ui-gray-300;
-}
-
-.empty-state-background {
-  background: $ui-gray-010;
 }
 
 .empty-state-content {
@@ -43,9 +40,4 @@
 .empty-state-icon > .hs-icon {
   float: left;
   margin-right: $spacing-xs;
-}
-
-.empty-state-message-border {
-  padding-bottom: $spacing-s;
-  border-bottom: 1px solid $grey-light;
 }

--- a/ui/app/styles/components/replication-dashboard.scss
+++ b/ui/app/styles/components/replication-dashboard.scss
@@ -29,7 +29,7 @@
       padding: $spacing-l 0 18px $spacing-l;
       line-height: 1.5;
 
-      height: 220px;
+      height: 230px;
 
       @include until(1320px) {
         // prevent an issue with the card descriptions wrapping and expanding height

--- a/ui/app/styles/components/replication-page.scss
+++ b/ui/app/styles/components/replication-page.scss
@@ -1,0 +1,10 @@
+.replication-page {
+  .empty-state {
+    background: none;
+
+    .empty-state-message {
+      padding-bottom: $spacing-s;
+      border-bottom: 1px solid $grey-light;
+    }
+  }
+}

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -81,6 +81,7 @@
 @import './components/raft-join';
 @import './components/replication-dashboard';
 @import './components/replication-doc-link';
+@import './components/replication-page';
 @import './components/replication-primary-card';
 @import './components/replication-summary';
 @import './components/role-item';

--- a/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
@@ -9,7 +9,6 @@
             @title="Disaster Recovery secondary not set up"
             @message={{Page.message}}
             @icon="alert-circle-outline"
-            @backgroundColor={{false}}
             @bottomBorder={{true}}
           >
             <nav class="breadcrumb">

--- a/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
@@ -7,7 +7,7 @@
         {{#if Page.isDisabled}}
           <EmptyState
             @title="Disaster Recovery secondary not set up"
-            @message="This Disaster Recovery secondary has not been enabled.  You can do so from the Disaster Recovery Primary."
+            @message={{Page.message}}
             @icon="alert-circle-outline"
             @backgroundColor={{false}}
             @bottomBorder={{true}}

--- a/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
@@ -1,6 +1,5 @@
 <section class="section">
   <div class="container is-widescreen">
-    {{!-- ARG TODO setup error state and return --}}
     <ReplicationPage @model={{model}} as |Page|>
       {{#if Page.isDisabled}}
         <EmptyState

--- a/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
@@ -3,9 +3,26 @@
     <ReplicationPage @model={{model}} as |Page|>
       {{#if Page.isDisabled}}
         <EmptyState
-          @title="This cluster is not setup as DR Secondary"
-          @message="... No idea what to put here"
-        />
+          @title="Disaster Recovery secondary not set up"
+          @message="This Disaster Recovery secondary has not been enabled.  You can do so from the Disaster Recovery Primary."
+          @icon="alert-circle-outline"
+        >
+          <nav class="breadcrumb">
+            <ul class="is-grouped-split">
+              <li>
+                {{#link-to "vault.cluster.secrets.backends" }}
+                  <span class="sep"/>
+                  Go back
+                {{/link-to}}
+              </li>
+              <li>
+                <LearnLink @path="/vault/operations/ops-disaster-recovery">
+                  Need help?
+                </LearnLink>
+              </li>
+            </ul>
+          </nav>
+        </EmptyState>
       {{else}}
         <Page.header 
           @showTabs={{false}}

--- a/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
@@ -1,32 +1,34 @@
 <section class="section">
   <div class="container is-widescreen">
     <ReplicationPage @model={{model}} as |Page|>
-      {{#if Page.isDisabled}}
-        <EmptyState
-          @title="Disaster Recovery secondary not set up"
-          @message="This Disaster Recovery secondary has not been enabled.  You can do so from the Disaster Recovery Primary."
-          @icon="alert-circle-outline"
-        >
-          <nav class="breadcrumb">
-            <ul class="is-grouped-split">
-              <li>
-                {{#link-to "vault.cluster.secrets.backends" }}
-                  <span class="sep"/>
-                  Go back
-                {{/link-to}}
-              </li>
-              <li>
-                <LearnLink @path="/vault/operations/ops-disaster-recovery">
-                  Need help?
-                </LearnLink>
-              </li>
-            </ul>
-          </nav>
-        </EmptyState>
-      {{else}}
         <Page.header 
           @showTabs={{false}}
         />
+        {{#if Page.isDisabled}}
+          <EmptyState
+            @title="Disaster Recovery secondary not set up"
+            @message="This Disaster Recovery secondary has not been enabled.  You can do so from the Disaster Recovery Primary."
+            @icon="alert-circle-outline"
+            @backgroundColor={{false}}
+            @bottomBorder={{true}}
+          >
+            <nav class="breadcrumb">
+              <ul class="is-grouped-split">
+                <li>
+                  {{#link-to "vault.cluster.secrets.backends" }}
+                    <span class="sep"/>
+                    Go back
+                  {{/link-to}}
+                </li>
+                <li>
+                  <LearnLink @path="/vault/operations/ops-disaster-recovery" @class="has-text-grey">
+                    Need help?
+                  </LearnLink>
+                </li>
+              </ul>
+            </nav>
+          </EmptyState>
+        {{else}}
         <Page.toggle />
         <Page.dashboard 
         {{!-- passing in component to render so that the yielded components are flexible based on the dashboard --}}

--- a/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
@@ -2,30 +2,37 @@
   <div class="container is-widescreen">
     {{!-- ARG TODO setup error state and return --}}
     <ReplicationPage @model={{model}} as |Page|>
-      <Page.header 
-        @showTabs={{false}}
-      />
-      <Page.toggle />
-      <Page.dashboard 
-      {{!-- passing in component to render so that the yielded components are flexible based on the dashboard --}}
-        @componentToRender='replication-secondary-card' as |Dashboard|>
-        <Dashboard.card
-          @title="States"
+      {{#if Page.isDisabled}}
+        <EmptyState
+          @title="This cluster is not setup as DR Secondary"
+          @message="... No idea what to put here"
         />
-        <Dashboard.card
-          @title="Write-Ahead Logs (WALs)"
+      {{else}}
+        <Page.header 
+          @showTabs={{false}}
         />
-        {{#if Dashboard.isSyncing }}
-          <AlertBanner 
-            @title="Syncing in progress"
-            @type="info"
-            @secondIconType="loading"
-            @message="The cluster is syncing. This happens when the secondary is too far behind the primary to use the normal stream-wals state for catching up."
-            @class="has-top-margin-xl"
+        <Page.toggle />
+        <Page.dashboard 
+        {{!-- passing in component to render so that the yielded components are flexible based on the dashboard --}}
+          @componentToRender='replication-secondary-card' as |Dashboard|>
+          <Dashboard.card
+            @title="States"
           />
-        {{/if}}
-        <Dashboard.rows/>
-      </Page.dashboard>
+          <Dashboard.card
+            @title="Write-Ahead Logs (WALs)"
+          />
+          {{#if Dashboard.isSyncing }}
+            <AlertBanner 
+              @title="Syncing in progress"
+              @type="info"
+              @secondIconType="loading"
+              @message="The cluster is syncing. This happens when the secondary is too far behind the primary to use the normal stream-wals state for catching up."
+              @class="has-top-margin-xl"
+            />
+          {{/if}}
+          <Dashboard.rows/>
+        </Page.dashboard>
+      {{/if}}
     </ReplicationPage>
   </div>
 </section>

--- a/ui/lib/core/addon/components/empty-state.js
+++ b/ui/lib/core/addon/components/empty-state.js
@@ -13,7 +13,7 @@ import layout from '../templates/components/empty-state';
  *
  * @param title=null{String} - A short label for the empty state
  * @param message=null{String} - A description of why a user might be seeing the empty state and possibly instructions for actions they may take.
- * @param icon=null{String} - A option param to display icon to the right of the title
+ * @param icon=null{String} - A optional param to display icon to the right of the title
  *
  */
 

--- a/ui/lib/core/addon/components/empty-state.js
+++ b/ui/lib/core/addon/components/empty-state.js
@@ -13,7 +13,8 @@ import layout from '../templates/components/empty-state';
  *
  * @param title=null{String} - A short label for the empty state
  * @param message=null{String} - A description of why a user might be seeing the empty state and possibly instructions for actions they may take.
- * @param icon=null{String} - A optional param to display icon to the right of the title
+ * @param [icon]=''{String} - A optional param to display icon to the right of the title
+ * @param [backgroundColor]=true{Boolean} - whether there is a light grey background color
  *
  */
 
@@ -22,5 +23,6 @@ export default Component.extend({
   tagName: '',
   title: null,
   message: null,
+  backgroundColor: true,
   icon: '',
 });

--- a/ui/lib/core/addon/components/empty-state.js
+++ b/ui/lib/core/addon/components/empty-state.js
@@ -13,8 +13,8 @@ import layout from '../templates/components/empty-state';
  *
  * @param title=null{String} - A short label for the empty state
  * @param message=null{String} - A description of why a user might be seeing the empty state and possibly instructions for actions they may take.
- * @param [icon]=''{String} - A optional param to display icon to the right of the title
- * @param [backgroundColor]=true{Boolean} - whether there is a light grey background color
+ * @param [icon='']{String} - A optional param to display icon to the right of the title
+ * @param [backgroundColor=true]{Boolean} - whether there is a light grey background color
  *
  */
 

--- a/ui/lib/core/addon/components/empty-state.js
+++ b/ui/lib/core/addon/components/empty-state.js
@@ -14,8 +14,6 @@ import layout from '../templates/components/empty-state';
  * @param title=null{String} - A short label for the empty state
  * @param message=null{String} - A description of why a user might be seeing the empty state and possibly instructions for actions they may take.
  * @param [icon='']{String} - A optional param to display icon to the right of the title
- * @param [backgroundColor=true]{Boolean} - whether there is a light grey background color
- *
  */
 
 export default Component.extend({
@@ -23,6 +21,5 @@ export default Component.extend({
   tagName: '',
   title: null,
   message: null,
-  backgroundColor: true,
   icon: '',
 });

--- a/ui/lib/core/addon/components/empty-state.js
+++ b/ui/lib/core/addon/components/empty-state.js
@@ -13,6 +13,7 @@ import layout from '../templates/components/empty-state';
  *
  * @param title=null{String} - A short label for the empty state
  * @param message=null{String} - A description of why a user might be seeing the empty state and possibly instructions for actions they may take.
+ * @param icon=null{String} - A option param to display icon to the right of the title
  *
  */
 
@@ -21,4 +22,5 @@ export default Component.extend({
   tagName: '',
   title: null,
   message: null,
+  icon: '',
 });

--- a/ui/lib/core/addon/components/replication-actions.js
+++ b/ui/lib/core/addon/components/replication-actions.js
@@ -39,7 +39,7 @@ export default Component.extend(ReplicationActions, DEFAULTS, {
 
   actions: {
     onSubmit() {
-      return this.submitHandler(...arguments);
+      return this.submitHandler.perform(...arguments);
     },
     clear() {
       this.reset();

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -7,13 +7,6 @@ const MERKLE_STATES = { sync: 'merkle-sync', diff: 'merkle-diff' };
 export default Component.extend({
   layout,
   data: null,
-  dr: computed('data', function() {
-    let dr = this.data.dr;
-    if (!dr) {
-      return false;
-    }
-    return dr;
-  }),
   isSyncing: computed('data', function() {
     if (this.dr.state === MERKLE_STATES.sync || this.dr.state === MERKLE_STATES.diff) {
       return true;

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -17,4 +17,16 @@ export default Component.extend({
     }
     return false;
   }),
+  title: computed('model', function() {
+    let mode = this.model.rm.mode;
+    if (mode === 'dr') {
+      return 'Disaster Recovery';
+    } else if (mode === 'performance') {
+      return 'Performance';
+    }
+    return 'unknown';
+  }),
+  message: computed('model', function() {
+    return 'This Disaster Recovery secondary has not been enabled.  You can do so from the Disaster Recovery Primary.';
+  }),
 });

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -1,6 +1,20 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import layout from '../templates/components/replication-page';
 
 export default Component.extend({
   layout,
+  dr: computed('model', function() {
+    let dr = this.model.dr;
+    if (!dr) {
+      return false;
+    }
+    return dr;
+  }),
+  isDisabled: computed('dr', function() {
+    if (this.dr.mode === 'disabled') {
+      return true;
+    }
+    return false;
+  }),
 });

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -21,6 +21,7 @@ export default Component.extend({
     return dr;
   }),
   isDisabled: computed('dr', function() {
+    // this conditional only applies to DR secondaries.
     if (this.dr.mode === 'disabled' || this.dr.mode === 'primary') {
       return true;
     }
@@ -28,7 +29,7 @@ export default Component.extend({
   }),
   message: computed('model', function() {
     if (this.model.anyReplicationEnabled) {
-      return 'This Disaster Recovery secondary has not been enabled.  You can do so from the Disaster Recovery Primary.';
+      return `This ${this.mode} secondary has not been enabled.  You can do so from the Disaster Recovery Primary.`;
     }
     return `This cluster has not been enabled as a ${this.mode} Secondary. You can do so by enabling replication and adding a secondary from the ${this.mode} Primary.`;
   }),

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -2,8 +2,17 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from '../templates/components/replication-page';
 
+const MODE = {
+  dr: 'Disaster Recovery',
+  performance: 'Performance',
+};
+
 export default Component.extend({
   layout,
+  mode: computed('model', function() {
+    let mode = this.model.rm.mode;
+    return MODE[mode];
+  }),
   dr: computed('model', function() {
     let dr = this.model.dr;
     if (!dr) {
@@ -17,16 +26,10 @@ export default Component.extend({
     }
     return false;
   }),
-  title: computed('model', function() {
-    let mode = this.model.rm.mode;
-    if (mode === 'dr') {
-      return 'Disaster Recovery';
-    } else if (mode === 'performance') {
-      return 'Performance';
-    }
-    return 'unknown';
-  }),
   message: computed('model', function() {
-    return 'This Disaster Recovery secondary has not been enabled.  You can do so from the Disaster Recovery Primary.';
+    if (this.model.anyReplicationEnabled) {
+      return 'This Disaster Recovery secondary has not been enabled.  You can do so from the Disaster Recovery Primary.';
+    }
+    return `This cluster has not been enabled as a ${this.mode} Secondary. You can do so by enabling replication and adding a secondary from the ${this.mode} Primary.`;
   }),
 });

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -12,7 +12,7 @@ export default Component.extend({
     return dr;
   }),
   isDisabled: computed('dr', function() {
-    if (this.dr.mode === 'disabled') {
+    if (this.dr.mode === 'disabled' || this.dr.mode === 'primary') {
       return true;
     }
     return false;

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -11,7 +11,7 @@ import layout from '../templates/components/replication-secondary-card';
 const STATES = {
   streamWals: 'stream-wals',
   idle: 'idle',
-  transientFailure: 'transient-failure',
+  transientFailure: 'transient_failure',
   shutdown: 'shutdown',
 };
 

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -1,9 +1,3 @@
-/**
- * @module ReplicationSecondaryCard
- * ARG TODO finish
- *
- */
-
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from '../templates/components/replication-secondary-card';

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -18,13 +18,6 @@ const STATES = {
 export default Component.extend({
   layout,
   data: null,
-  dr: computed('data', function() {
-    let dr = this.data.dr;
-    if (!dr) {
-      return false;
-    }
-    return dr;
-  }),
   state: computed('dr', function() {
     return this.dr && this.dr.state ? this.dr.state : 'unknown';
   }),

--- a/ui/lib/core/addon/mixins/replication-actions.js
+++ b/ui/lib/core/addon/mixins/replication-actions.js
@@ -10,7 +10,7 @@ export default Mixin.create({
   loading: or('save.isRunning', 'submitSuccess.isRunning'),
   onEnable() {},
   onDisable() {},
-  submitHandler(action, clusterMode, data, event) {
+  submitHandler: task(function*(action, clusterMode, data, event) {
     let replicationMode = (data && data.replicationMode) || this.get('replicationMode');
     if (event && event.preventDefault) {
       event.preventDefault();
@@ -29,8 +29,8 @@ export default Mixin.create({
       delete data.replicationMode;
     }
 
-    return this.save.perform(action, replicationMode, clusterMode, data);
-  },
+    return yield this.save.perform(action, replicationMode, clusterMode, data);
+  }),
 
   save: task(function*(action, replicationMode, clusterMode, data) {
     let resp;
@@ -89,12 +89,16 @@ export default Mixin.create({
     if (action === 'disable') {
       yield this.onDisable();
     }
-    if (action === 'enable') {
-      yield this.onEnable(replicationMode);
-    }
-
     if (mode === 'secondary' && replicationMode === 'dr') {
-      yield this.router.transitionTo('vault.cluster');
+      // return out, do not want to run action enable
+      return;
+    }
+    if (action === 'enable') {
+      try {
+        yield this.onEnable(replicationMode); // should not be called for dr secondary
+      } catch (e) {
+        // TODO handle error
+      }
     }
   }).drop(),
 

--- a/ui/lib/core/addon/mixins/replication-actions.js
+++ b/ui/lib/core/addon/mixins/replication-actions.js
@@ -41,7 +41,7 @@ export default Mixin.create({
     } catch (e) {
       return this.submitError(e);
     }
-    yield this.submitSuccess.perform(resp, action, clusterMode);
+    return yield this.submitSuccess.perform(resp, action, clusterMode);
   }).drop(),
 
   submitSuccess: task(function*(resp, action, mode) {
@@ -90,8 +90,8 @@ export default Mixin.create({
       yield this.onDisable();
     }
     if (mode === 'secondary' && replicationMode === 'dr') {
-      // return out, do not want to run action enable
-      return;
+      // return mode so you can properly handle the transition
+      return mode;
     }
     if (action === 'enable') {
       try {

--- a/ui/lib/core/addon/templates/components/empty-state.hbs
+++ b/ui/lib/core/addon/templates/components/empty-state.hbs
@@ -1,4 +1,4 @@
-<div data-test-component="empty-state" class="empty-state {{if backgroundColor "empty-state-background"}}" ...attributes>
+<div data-test-component="empty-state" class="empty-state" ...attributes>
   <div class="empty-state-content">
     {{#if icon}}
       <div class="empty-state-icon">
@@ -13,7 +13,7 @@
     </h3>
     {{/if}}
     {{#if message}}
-    <p class="empty-state-message {{if bottomBorder "empty-state-message-border"}}" data-test-empty-state-message>
+    <p class="empty-state-message" data-test-empty-state-message>
       {{message}}
     </p>
     {{/if}}

--- a/ui/lib/core/addon/templates/components/empty-state.hbs
+++ b/ui/lib/core/addon/templates/components/empty-state.hbs
@@ -1,4 +1,4 @@
-<div data-test-component="empty-state" class="empty-state" ...attributes>
+<div data-test-component="empty-state" class="empty-state {{if backgroundColor "empty-state-background"}}" ...attributes>
   <div class="empty-state-content">
     {{#if icon}}
       <div class="empty-state-icon">
@@ -13,7 +13,7 @@
     </h3>
     {{/if}}
     {{#if message}}
-    <p class="empty-state-message" data-test-empty-state-message>
+    <p class="empty-state-message {{if bottomBorder "empty-state-message-border"}}" data-test-empty-state-message>
       {{message}}
     </p>
     {{/if}}

--- a/ui/lib/core/addon/templates/components/empty-state.hbs
+++ b/ui/lib/core/addon/templates/components/empty-state.hbs
@@ -1,8 +1,17 @@
 <div data-test-component="empty-state" class="empty-state" ...attributes>
   <div class="empty-state-content">
+    {{#if icon}}
+      <div class="empty-state-icon">
+        <Icon @glyph={{icon}} @size="xxl" />
+        <h3 class="empty-state-title" data-test-empty-state-title>
+          {{title}}
+        </h3>
+      </div>
+    {{else}}
     <h3 class="empty-state-title" data-test-empty-state-title>
       {{title}}
     </h3>
+    {{/if}}
     {{#if message}}
     <p class="empty-state-message" data-test-empty-state-message>
       {{message}}

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -9,8 +9,8 @@
   {{/if}}
 
   <div class="selectable-card-container has-top-margin-xl">
-    {{yield (hash
-      card=(component componentToRender data=data)
+    {{yield (hash 
+      card=(component componentToRender data=data dr=dr)
     )}}
   </div>
 

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -2,8 +2,8 @@
   <h2 class="has-text-weight-semibold is-size-4 has-bottom-margin-xs">Primary Cluster</h2>
   <p class="has-text-grey is-size-8">If you set a primary_cluster_addr when enabling replication, it will appear here.</p>
 
-  {{#if model.dr.primaryClusterAddr}}
-    <code>{{model.dr.primaryClusterAddr}}</code>
+  {{#if data.dr.primaryClusterAddr}}
+    <code>{{data.dr.primaryClusterAddr}}</code>
   {{else}}
     <code>no known primary cluster address</code>
   {{/if}}

--- a/ui/lib/core/addon/templates/components/replication-header.hbs
+++ b/ui/lib/core/addon/templates/components/replication-header.hbs
@@ -32,7 +32,7 @@
   </p.top>
   <p.levelLeft>
     <h1 class="title is-3">
-      Details
+      {{title}}
       <span class="tag">
         {{data.dr.mode}}
       </span>

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -1,5 +1,6 @@
 {{yield (hash 
   header=(component 'replication-header' data=model)
   toggle=(component 'replication-toggle')
-  dashboard=(component 'replication-dashboard' data=model)
+  dashboard=(component 'replication-dashboard' data=model dr=dr)
+  isDisabled=isDisabled
 )}}

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -1,3 +1,4 @@
+<div class="replication-page">
 {{yield (hash 
   header=(component 'replication-header' data=model title=mode)
   toggle=(component 'replication-toggle')
@@ -5,3 +6,4 @@
   isDisabled=isDisabled
   message=message
 )}}
+</div>

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -1,6 +1,7 @@
 {{yield (hash 
-  header=(component 'replication-header' data=model)
+  header=(component 'replication-header' data=model title=title)
   toggle=(component 'replication-toggle')
   dashboard=(component 'replication-dashboard' data=model dr=dr)
   isDisabled=isDisabled
+  message=message
 )}}

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -1,5 +1,5 @@
 {{yield (hash 
-  header=(component 'replication-header' data=model title=title)
+  header=(component 'replication-header' data=model title=mode)
   toggle=(component 'replication-toggle')
   dashboard=(component 'replication-dashboard' data=model dr=dr)
   isDisabled=isDisabled

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -15,18 +15,23 @@
       {{/if}}
     </div>
     <div class="grid-item-right">
-      {{#if (or (eq connection "transient-failure") (eq connection "shutdown"))}}
+      {{#if (eq connection "transient-failure")}}
         <code class="has-text-danger">connection_state</code>
         <AlertInline
           @type="danger"
-          @message="ARG TODO: waiting on feedback to fill this in."
+          @message="There has been some transient failure.  Your cluster will eventually switch back to connection and try to establish a connection again."
+        />
+      {{else if (eq connection "shutdown")}}
+        <code class="has-text-danger">connection_state</code>
+        <AlertInline
+          @type="danger"
+          @message="Your connection has shut down. This may be because the application explicitly requested a shutdown or a non-recoverable error has happened during attempts to communicate."
         />
       {{else}}
-        <code class="has-text-black">connection_state</code>
+        <code>connection_state</code>
         <p class="has-text-grey is-size-8">The health of the connection between this cluster and others.</p>
       {{/if}}
     </div>
-    {{!-- ARG TODO connection state is likely wrong here, waiting for reply from RFC --}}
       <h2 class="title-number grid-item-left-bottom">{{state}}
         {{#if inSyncState }}
           <ToolTip @verticalPosition="above" as |T|>

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -15,7 +15,7 @@
       {{/if}}
     </div>
     <div class="grid-item-right">
-      {{#if (eq connection "transient-failure")}}
+      {{#if (eq connection "transient_failure")}}
         <code class="has-text-danger">connection_state</code>
         <AlertInline
           @type="danger"

--- a/ui/lib/core/stories/empty-state.md
+++ b/ui/lib/core/stories/empty-state.md
@@ -10,8 +10,7 @@ encounters a state that would usually be blank.
 | --- | --- | --- | --- |
 | title | <code>String</code> | <code></code> | A short label for the empty state |
 | message | <code>String</code> | <code></code> | A description of why a user might be seeing the empty state and possibly instructions for actions they may take. |
-| [icon] | <code>String</code> |  | A optional param to display icon to the right of the title |
-| [backgroundColor] | <code>Boolean</code> |  | whether there is a light grey background color |
+| [icon] | <code>String</code> | <code>&#x27;&#x27;</code> | A optional param to display icon to the right of the title |
 
 **Example**
   

--- a/ui/lib/core/stories/empty-state.md
+++ b/ui/lib/core/stories/empty-state.md
@@ -1,14 +1,16 @@
-<!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in lib/core/addon/components/empty-state.js. To make changes, first edit that file and run "yarn gen-story-md empty-state" to re-generate the content.-->
+<!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in lib/core//addon/components/empty-state.js. To make changes, first edit that file and run "yarn gen-story-md empty-state" to re-generate the content.-->
 
 ## EmptyState
 `EmptyState` components are used to render a helpful message and any necessary content when a user
 encounters a state that would usually be blank.
 
+**Params**
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | title | <code>String</code> | <code></code> | A short label for the empty state |
 | message | <code>String</code> | <code></code> | A description of why a user might be seeing the empty state and possibly instructions for actions they may take. |
+| icon | <code>String</code> | <code></code> | A option param to display icon to the right of the title |
 
 **Example**
   
@@ -18,7 +20,7 @@ encounters a state that would usually be blank.
 
 **See**
 
-- [Uses of EmptyState](https://github.com/hashicorp/vault/search?l=Handlebars&q=EmptyState)
-- [EmptyState Source Code](https://github.com/hashicorp/vault/blob/master/ui/app/components/empty-state.js)
+- [Uses of EmptyState](https://github.com/hashicorp/vault/search?l=Handlebars&q=EmptyState+OR+empty-state)
+- [EmptyState Source Code](https://github.com/hashicorp/vault/blob/master/ui/lib/core//addon/components/empty-state.js)
 
 ---

--- a/ui/lib/core/stories/empty-state.md
+++ b/ui/lib/core/stories/empty-state.md
@@ -1,4 +1,4 @@
-<!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in lib/core//addon/components/empty-state.js. To make changes, first edit that file and run "yarn gen-story-md empty-state" to re-generate the content.-->
+<!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in lib/core/addon/components/empty-state.js. To make changes, first edit that file and run "yarn gen-story-md empty-state" to re-generate the content.-->
 
 ## EmptyState
 `EmptyState` components are used to render a helpful message and any necessary content when a user
@@ -10,7 +10,8 @@ encounters a state that would usually be blank.
 | --- | --- | --- | --- |
 | title | <code>String</code> | <code></code> | A short label for the empty state |
 | message | <code>String</code> | <code></code> | A description of why a user might be seeing the empty state and possibly instructions for actions they may take. |
-| icon | <code>String</code> | <code></code> | A optional param to display icon to the right of the title |
+| [icon] | <code>String</code> |  | A optional param to display icon to the right of the title |
+| [backgroundColor] | <code>Boolean</code> |  | whether there is a light grey background color |
 
 **Example**
   
@@ -21,6 +22,6 @@ encounters a state that would usually be blank.
 **See**
 
 - [Uses of EmptyState](https://github.com/hashicorp/vault/search?l=Handlebars&q=EmptyState+OR+empty-state)
-- [EmptyState Source Code](https://github.com/hashicorp/vault/blob/master/ui/lib/core//addon/components/empty-state.js)
+- [EmptyState Source Code](https://github.com/hashicorp/vault/blob/master/ui/lib/core/addon/components/empty-state.js)
 
 ---

--- a/ui/lib/core/stories/empty-state.md
+++ b/ui/lib/core/stories/empty-state.md
@@ -10,7 +10,7 @@ encounters a state that would usually be blank.
 | --- | --- | --- | --- |
 | title | <code>String</code> | <code></code> | A short label for the empty state |
 | message | <code>String</code> | <code></code> | A description of why a user might be seeing the empty state and possibly instructions for actions they may take. |
-| icon | <code>String</code> | <code></code> | A option param to display icon to the right of the title |
+| icon | <code>String</code> | <code></code> | A optional param to display icon to the right of the title |
 
 **Example**
   

--- a/ui/lib/replication/addon/components/replication-summary.js
+++ b/ui/lib/replication/addon/components/replication-summary.js
@@ -71,16 +71,17 @@ export default Component.extend(ReplicationActions, DEFAULTS, {
   }),
 
   submit: task(function*() {
+    let mode;
     try {
-      yield this.submitHandler.perform(...arguments);
+      mode = yield this.submitHandler.perform(...arguments);
     } catch (e) {
       // TODO handle error
     }
     // Take transitionTo outside of a yield because it unmounts the cluster and yield cannot return anything
-    this.transitionTo();
-    // ARG TODO these are even getting called.
-    let wizard = this.get('wizard');
-    wizard.transitionFeatureMachine(wizard.get('featureState'), 'ENABLEREPLICATION');
+    // if Secondary, handle transition here, if not, handle transition in mixin Enable
+    if (mode === 'secondary') {
+      this.transitionTo();
+    }
   }),
 
   actions: {

--- a/ui/lib/replication/addon/components/replication-summary.js
+++ b/ui/lib/replication/addon/components/replication-summary.js
@@ -66,8 +66,19 @@ export default Component.extend(ReplicationActions, DEFAULTS, {
     this.setProperties(DEFAULTS);
   },
 
+  transitionTo: computed('mode', 'replicationMode', function() {
+    return () => this.router.transitionTo('vault.cluster');
+  }),
+
   submit: task(function*() {
-    yield this.submitHandler(...arguments);
+    try {
+      yield this.submitHandler.perform(...arguments);
+    } catch (e) {
+      // TODO handle error
+    }
+    // Take transitionTo outside of a yield because it unmounts the cluster and yield cannot return anything
+    this.transitionTo();
+    // ARG TODO these are even getting called.
     let wizard = this.get('wizard');
     wizard.transitionFeatureMachine(wizard.get('featureState'), 'ENABLEREPLICATION');
   }),

--- a/ui/lib/replication/addon/components/replication-summary.js
+++ b/ui/lib/replication/addon/components/replication-summary.js
@@ -67,6 +67,7 @@ export default Component.extend(ReplicationActions, DEFAULTS, {
   },
 
   transitionTo: computed('mode', 'replicationMode', function() {
+    // Take transitionTo outside of a yield because it unmounts the cluster and yield cannot return anything
     return () => this.router.transitionTo('vault.cluster');
   }),
 
@@ -77,7 +78,6 @@ export default Component.extend(ReplicationActions, DEFAULTS, {
     } catch (e) {
       // TODO handle error
     }
-    // Take transitionTo outside of a yield because it unmounts the cluster and yield cannot return anything
     // if Secondary, handle transition here, if not, handle transition in mixin Enable
     if (mode === 'secondary') {
       this.transitionTo();

--- a/ui/lib/replication/addon/templates/components/replication-summary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-summary.hbs
@@ -290,17 +290,21 @@
       Disaster Recovery (DR)
     </h3>
     {{#if cluster.dr.replicationEnabled}}
-      {{#link-to
-        "mode.index"
-        "dr"
-        class="link-plain"
-      }}
-        {{replication-mode-summary
-          mode="dr"
-          cluster=cluster
-          tagName="span"
+      {{#if submit.isRunning }} 
+          <LayoutLoading />
+      {{else}}
+        {{#link-to
+          "mode.index"
+          "dr"
+          class="link-plain"
         }}
-      {{/link-to}}
+          {{replication-mode-summary
+            mode="dr"
+            cluster=cluster
+            tagName="span"
+          }}
+        {{/link-to}}
+      {{/if}}
     {{else}}
       {{replication-mode-summary
         mode="dr"
@@ -309,35 +313,37 @@
       }}
     {{/if}}
   </div>
-  <div class="box is-bottomless is-fullwidth is-marginless">
-    <h3 class="title is-flex-center is-5 is-marginless">
-      <Icon
-        @size="xl"
-        aria-hidden="true"
-        @glyph="perf-replication"
-      />
-      Performance
-    </h3>
-    {{#if cluster.dr.replicationEnabled}}
-      {{#link-to
-        "mode.index"
-        "performance"
-        class="link-plain"
-      }}
+  {{#unless (and submit.isRunning (eq cluster.dr.mode "bootstrapping"))}}
+    <div class="box is-bottomless is-fullwidth is-marginless">
+      <h3 class="title is-flex-center is-5 is-marginless">
+        <Icon
+          @size="xl"
+          aria-hidden="true"
+          @glyph="perf-replication"
+        />
+        Performance
+      </h3>
+      {{#if cluster.dr.replicationEnabled}}
+        {{#link-to
+          "mode.index"
+          "performance"
+          class="link-plain"
+        }}
+          {{replication-mode-summary
+            mode="performance"
+            cluster=cluster
+            tagName="span"
+          }}
+        {{/link-to}}
+      {{else}}
         {{replication-mode-summary
           mode="performance"
           cluster=cluster
-          tagName="span"
+          tagName="div"
         }}
-      {{/link-to}}
-    {{else}}
-      {{replication-mode-summary
-        mode="performance"
-        cluster=cluster
-        tagName="div"
-      }}
-    {{/if}}
-  </div>
+      {{/if}}
+    </div>
+  {{/unless}}
 {{else}}
   {{#if (eq replicationAttrs.mode 'initializing')}}
     The cluster is initializing replication. This may take some time.

--- a/ui/tests/integration/components/replication-table-rows-test.js
+++ b/ui/tests/integration/components/replication-table-rows-test.js
@@ -27,10 +27,13 @@ module('Integration | Enterprise | Component | replication-table-rows', function
 
     assert.dom('.empty-state').doesNotExist('does not show empty state when data is found');
 
-    Object.keys(DATA).forEach(attr => {
-      let expected = DATA[attr];
-      assert.dom(`[data-test-attr="${expected}"]`).includesText(expected, `shows the correct ${attr}`);
-    });
+    assert
+      .dom('[data-test-row-value="Merkle root index"]')
+      .includesText(DATA.merkleRoot, `shows the correct Merkle Root`);
+    assert.dom('[data-test-row-value="Mode"]').includesText(DATA.mode, `shows the correct Merkle Root`);
+    assert
+      .dom('[data-test-row-value="Replication set"]')
+      .includesText(DATA.clusterId, `shows the correct Merkle Root`);
   });
 
   test('it renders unknown if values cannot be found', async function(assert) {


### PR DESCRIPTION
This PR addresses:
- **Updating error messages** when connection_state is "shutdown" or "transient-failure", and when state is "idle".
- **Moving the Dr property** to the higher-level parent and passing it through.
- **Changing the icons inside of cluster.js** based on the fact that `merkle-sync` and `merkle-diff` are truly syncing, and `stream-wals` is in a good connected state.
- **Handling the transition flow of when you change a cluster to a DR primary or Secondary**.  The goal was to fix the transition flow on the DR secondary, but it also cleaned up the DR primary.  Below are two gifs of how they now transition vs. how they used to transition.  The key was to change the `submitHandler` into a concurrency function and remove the `transitionTo ` out of the currency functions yield call.  Because `transitionTo ` unmounts a cluster, the yield would never return nor would an error be thrown.  The visual change doesn't appear to be much, but the `yield` in `replication-summary.js` `save` function was essentially not returning anything.  So anything below that yield never got called.  That was because `transitionTo` inside of submitHandler broke the flow.  We took it out of the flow and now the yeild works and we can access `submit.isRunning` or `submit.isIdle` helping us show loaders inside of the `replication-summary.hbs`

**Make a DR Secondary flow before:**
<img width=600 src="https://user-images.githubusercontent.com/6618863/79599613-09c2b000-80a3-11ea-88b0-8df6d59bdcbf.gif">

**Make a DR Secondary flow with this PR:**
<img width=600 src="https://user-images.githubusercontent.com/6618863/79599498-d4b65d80-80a2-11ea-8647-0355a627fce9.gif">

**Make a DR Primary flow before:**
<img width=600 src="https://user-images.githubusercontent.com/6618863/79600201-fe23b900-80a3-11ea-9ee8-cf91ec317cda.gif">

**Make a DR Primary flow with this PR:**
<img width=600 src="https://user-images.githubusercontent.com/6618863/79609823-a2adf700-80b4-11ea-9618-77e959df8d86.gif">

**Empty state**.   If you were on the URL "http://localhost:4202/ui/vault/replication-dr-promote/details" page, and then you restarted your server, it would no longer be a Dr secondary.  Instead of showing 0 and "unknown" on the details page, we now show this `EmptyState` with a "back" option that takes you the landing page of the primary cluster, or a help button. 
<img width=600 src="https://user-images.githubusercontent.com/6618863/79882363-b35db600-83af-11ea-837a-1fa879503b06.png">