### PR TITLE
http: ensure return after writing response by respondError

### DIFF
--- a/command/agent/cache/handler.go
+++ b/command/agent/cache/handler.go
@@ -40,6 +40,7 @@ func Handler(ctx context.Context, logger hclog.Logger, proxier Proxier, inmemSin
 		if err != nil {
 			logger.Error("failed to read request body")
 			logical.RespondError(w, http.StatusInternalServerError, errors.New("failed to read request body"))
+			return
 		}
 		if r.Body != nil {
 			r.Body.Close()

--- a/http/logical.go
+++ b/http/logical.go
@@ -232,6 +232,7 @@ func handleLogicalRecovery(raw *vault.RawBackend, token *atomic.String) http.Han
 		reqToken := r.Header.Get(consts.AuthHeaderName)
 		if reqToken == "" || token.Load() == "" || reqToken != token.Load() {
 			respondError(w, http.StatusForbidden, nil)
+			return
 		}
 
 		resp, err := raw.HandleRequest(r.Context(), req)
@@ -379,6 +380,7 @@ func handleLogicalInternal(core *vault.Core, injectDataIntoTopLevel bool, noForw
 		case strings.HasPrefix(req.Path, "sys/metrics"):
 			if isStandby, _ := core.Standby(); isStandby {
 				respondError(w, http.StatusBadRequest, vault.ErrCannotForwardLocalOnly)
+				return
 			}
 		}
 

--- a/http/sys_metrics.go
+++ b/http/sys_metrics.go
@@ -17,6 +17,7 @@ func handleMetricsUnauthenticated(core *vault.Core) http.Handler {
 		case "GET":
 		default:
 			respondError(w, http.StatusMethodNotAllowed, nil)
+			return
 		}
 
 		// Parse form

--- a/http/sys_raft.go
+++ b/http/sys_raft.go
@@ -33,6 +33,7 @@ func handleSysRaftJoinPost(core *vault.Core, w http.ResponseWriter, r *http.Requ
 
 	if req.NonVoter && !nonVotersAllowed {
 		respondError(w, http.StatusBadRequest, errors.New("non-voting nodes not allowed"))
+		return
 	}
 
 	var tlsConfig *tls.Config


### PR DESCRIPTION
This PR adds `return` after `respondError` or `logical.RespondError` calls in places where we should have returned from the func call but we were not doing so. If the response header gets further modified, the stdlib `http` package complains and floods the server logs with a message similar to this every time it happens:
```
http: superfluous response.WriteHeader call from github.com/hashicorp/vault/http.respondRaw (logical.go:564)
```