### PR TITLE
fixes roleset GET doc to say 'read' instead of 'delete'

### DIFF
--- a/website/pages/api-docs/secret/gcp/index.mdx
+++ b/website/pages/api-docs/secret/gcp/index.mdx
@@ -225,7 +225,7 @@ $ curl \
 
 ### Parameters
 
-- `name` (`string:<required>`): Name of the roleset to delete.
+- `name` (`string:<required>`): Name of the roleset to read.
 
 ### Sample Request
 


### PR DESCRIPTION
Simple PR; was reading through rolesets and discovered that the word `delete` is mentioned in the `Read Roleset` doc instead of `read`.