### PR TITLE
Handle inconsistent URL path prefix across okta libs, fixing MFA regression

### DIFF
--- a/builtin/credential/okta/backend.go
+++ b/builtin/credential/okta/backend.go
@@ -100,7 +100,7 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 		StateToken   string         `json:"stateToken"`
 	}
 
-	authReq, err := shim.NewRequest("POST", "/api/v1/authn", map[string]interface{}{
+	authReq, err := shim.NewRequest("POST", "authn", map[string]interface{}{
 		"username": username,
 		"password": password,
 	})

--- a/builtin/credential/okta/backend_test.go
+++ b/builtin/credential/okta/backend_test.go
@@ -15,6 +15,15 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+// To run this test, set the following env variables:
+// VAULT_ACC=1
+// OKTA_ORG=dev-219337
+// OKTA_API_TOKEN=<find in 1password>
+// OKTA_USERNAME=test2@example.com
+// OKTA_PASSWORD=<find in 1password>
+//
+// You will need to install the Okta client app on your mobile device and
+// setup MFA.
 func TestBackend_Config(t *testing.T) {
 	defaultLeaseTTLVal := time.Hour * 12
 	maxLeaseTTLVal := time.Hour * 24

--- a/builtin/credential/okta/path_config.go
+++ b/builtin/credential/okta/path_config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	oktaold "github.com/chrismalek/oktasdk-go/okta"
@@ -282,6 +283,9 @@ func (new *oktaShimNew) Client() *oktanew.Client {
 }
 
 func (new *oktaShimNew) NewRequest(method string, url string, body interface{}) (*http.Request, error) {
+	if !strings.HasPrefix(url, "/") {
+		url = "/api/v1/" + url
+	}
 	return new.client.GetRequestExecutor().NewRequest(method, url, body)
 }
 


### PR DESCRIPTION
The new okta library doesn't prepend /api/v1 to our URL paths like the old one does (we still use the old one in the absence of an API token, since the new one doesn't support that.)  Make our shim prepend /api/v1 to manual requests for the new library like the old library does, and remove explicit /api/v1 from our request paths.

Fixes #8779.