### PR TITLE
The generate credentials link doesn't exist

### DIFF
--- a/ui/app/templates/components/wizard/secrets-display-role.hbs
+++ b/ui/app/templates/components/wizard/secrets-display-role.hbs
@@ -2,6 +2,6 @@
   @headerText="Your new role"
 >
   <p>
-    With our new role, we can generate a credential that has the same permissions as that role. Click on "Generate credentials" links at the top of the page.
+    With our new role, we can generate a credential that has the same permissions as that role.
   </p>
 </WizardSection>


### PR DESCRIPTION
![Screen Shot 2020-04-23 at 3 50 16 PM](https://user-images.githubusercontent.com/334809/80157021-29ae1400-857a-11ea-988d-1c994260f1ee.png)

Not sure what's supposed to be done here, but this text doesn't make sense?