### PR TITLE
Fix typo in Leases concept docs title

### DIFF
--- a/website/pages/docs/concepts/lease.mdx
+++ b/website/pages/docs/concepts/lease.mdx
@@ -1,13 +1,13 @@
 ---
 layout: docs
-page_title: 'Lease, Renew, and Revoke'
-sidebar_title: 'Lease, Renew, and Revoke'
+page_title: 'Lease, Renew and Revoke'
+sidebar_title: 'Lease, Renew and Revoke'
 description: >-
   Vault provides a lease with every secret. When this lease is expired, Vault
   will revoke that secret.
 ---
 
-# Lease, Renew, and Revoke
+# Lease, Renew and Revoke
 
 With every dynamic secret and `service` type authentication token, Vault
 creates a _lease_: metadata containing information such as a time duration,


### PR DESCRIPTION
Just a small typo PR that removes the additional comma in the Leases concepts docs.