### PR TITLE
fix: removes broken golangci-lint external tool from bootstrap target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ EXTERNAL_TOOLS_CI=\
 	github.com/mitchellh/gox
 EXTERNAL_TOOLS=\
 	golang.org/x/tools/cmd/goimports \
-	github.com/client9/misspell/cmd/misspell \
-	github.com/golangci/golangci-lint/cmd/golangci-lint
+	github.com/client9/misspell/cmd/misspell
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v pb.go | grep -v vendor)
 
 


### PR DESCRIPTION
Removes the [golangci-lint](https://github.com/golangci/golangci-lint) external tool that was being installed via the `make bootstrap` target. Installing the tool via `GO111MODULE=off go get ...` in the Makefile fails because the project build is currently broken if not installed in a module context.

I left the `lint` and `ci-lint` targets that use the `golangci-lint` program in the Makefile in case someone wants to install the tool themselves and use them. Neither of these targets currently run in the Vault CI pipeline.