### PR TITLE
Fix typo in Entropy Augmentation docs sales contact link

### DIFF
--- a/website/pages/docs/enterprise/entropy-augmentation/index.mdx
+++ b/website/pages/docs/enterprise/entropy-augmentation/index.mdx
@@ -19,7 +19,7 @@ operating in most threat models, there are some situations where additional
 entropy from hardware-based random number generators is desirable.
 
 To use this feature, you must have an active or trial license for Vault
-Enterprise. To start a trial, contact [HashiCorpsales](mailto:sales@hashicorp.com).
+Enterprise. To start a trial, contact [HashiCorp sales](mailto:sales@hashicorp.com).
 
 # Critical Security Parameters (CSPs)
 


### PR DESCRIPTION
Small typo fix on the below docs page:

https://www.vaultproject.io/docs/enterprise/entropy-augmentation

The HashiCorp sales mail link is missing a whitespace: `HashiCorpsales.`