### PR TITLE
Fixed minor typo in secrets documentation page

### DIFF
--- a/website/pages/docs/secrets/index.mdx
+++ b/website/pages/docs/secrets/index.mdx
@@ -65,7 +65,7 @@ storage. This is a lot like a [chroot](https://en.wikipedia.org/wiki/Chroot).
 When a secrets engine is enabled, a random UUID is generated. This becomes the
 data root for that engine. Whenever that engine writes to the physical storage
 layer, it is prefixed with that UUID folder. Since the Vault storage layer
-doesn't support relative access (such as `../`), this makes it impossible for a
+doesn't support relative access (such as `../`), this makes it impossible for an
 enabled secrets engine to access other data.
 
 This is an important security feature in Vault - even a malicious engine


### PR DESCRIPTION
`a enabled` -> `an enabled`