### PR TITLE
ssh certificate signing: fix documentation of extensions

### DIFF
--- a/website/pages/api-docs/secret/ssh/index.mdx
+++ b/website/pages/api-docs/secret/ssh/index.mdx
@@ -163,9 +163,9 @@ This endpoint creates or updates a named role.
   critical options.
 
 - `allowed_extensions` `(string: "")` – Specifies a comma-separated list of
-  extensions that certificates can have when signed. To allow any critical
-  options, set this to an empty string. Will default to allowing any
-  extensions. For the list of extensions, take a look at the [sshd
+  extensions that certificates can have when signed. To allow any extensions,
+  set this to an empty string. Will default to allowing any extensions.
+  For the list of extensions, take a look at the [sshd
   manual's](https://man.openbsd.org/sshd#AUTHORIZED_KEYS_FILE_FORMAT)
   `AUTHORIZED_KEYS FILE FORMAT` section. You should add a `permit-` before the
   name of extension to allow it.
@@ -777,7 +777,7 @@ to the restrictions contained in the role named in the endpoint.
 - `critical_options` `(map<string|string>: "")` – Specifies a map of the
   critical options that the certificate should be signed for. Defaults to none.
 
-- `extension` `(map<string|string>: "")` – Specifies a map of the extensions
+- `extensions` `(map<string|string>: "")` – Specifies a map of the extensions
   that the certificate should be signed for. Defaults to none.
 
 ### Sample Payload

--- a/website/pages/docs/secrets/ssh/signed-ssh-certificates.mdx
+++ b/website/pages/docs/secrets/ssh/signed-ssh-certificates.mdx
@@ -109,6 +109,7 @@ team, or configuration management tooling.
     {
       "allow_user_certificates": true,
       "allowed_users": "*",
+      "allowed_extensions": "permit-pty,permit-port-forwarding",
       "default_extensions": [
         {
           "permit-pty": ""
@@ -158,8 +159,9 @@ the client's local workstation.
       "public_key": "ssh-rsa AAA...",
       "valid_principals": "my-user",
       "key_id": "custom-prefix",
-      "extension": {
-        "permit-pty": ""
+      "extensions": {
+        "permit-pty": "",
+        "permit-port-forwarding": ""
       }
     }
     EOH


### PR DESCRIPTION
This pull request fixes the documentation of the SSH signing API and CLI example, when using the `extensions` parameter.