### PR TITLE
Handle request errors during raft snapshot

### DIFF
--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -92,6 +92,9 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 	// to determine if the body contains error message.
 	var result *Response
 	resp, err := c.c.config.HttpClient.Do(req)
+	if err != nil {
+		return err
+	}
 	if resp == nil {
 		return nil
 	}

--- a/helper/testhelpers/tmp/raft_test.go
+++ b/helper/testhelpers/tmp/raft_test.go
@@ -1,0 +1,14 @@
+package tmp
+
+import (
+	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
+	"github.com/hashicorp/vault/vault"
+	"testing"
+)
+
+func TestRaftSnapshot(t *testing.T) {
+	conf, opts := teststorage.ClusterSetup(nil, nil, teststorage.RaftBackendSetup)
+	opts.SetupFunc = nil
+	cluster := vault.NewTestCluster(t, conf, opts)
+	cluster.Start()
+}


### PR DESCRIPTION
Add a missing error check in the raft snapshot save API.