### PR TITLE
Handle request errors during raft snapshot

### DIFF
--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -92,7 +92,6 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 	// to determine if the body contains error message.
 	var result *Response
 	resp, err := c.c.config.HttpClient.Do(req)
-
 	if err != nil {
 		return err
 	}

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -92,6 +92,11 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 	// to determine if the body contains error message.
 	var result *Response
 	resp, err := c.c.config.HttpClient.Do(req)
+
+	if err != nil {
+		return err
+	}
+
 	if resp == nil {
 		return nil
 	}


### PR DESCRIPTION
Add a missing error check in the raft snapshot save API.