### PR TITLE
GCP Auth docs - Move `iam_alias` and `gce_alias` to config instead of role

### DIFF
--- a/website/pages/api-docs/auth/gcp/index.mdx
+++ b/website/pages/api-docs/auth/gcp/index.mdx
@@ -44,6 +44,16 @@ to confirm signed JWTs passed in during login.
 
   The project must have the `iam.googleapis.com` API [enabled](https://console.cloud.google.com/flows/enableapi?apiid=iam.googleapis.com).
 
+- `iam_alias` `(string: unique_id)` - Must be either `unique_id` or `role_id`.
+  If `unique_id` is specified, the service account's unique ID will be used for
+  alias names during login. If `role_id` is specified, the ID of the Vault role
+  will be used. Only used if role `type` is `iam`.
+
+- `gce_alias` `(string: instance_id)` - Must be either `instance_id` or `role_id`.
+  If `instance_id` is specified, the GCE instance ID will be used for alias names
+  during login. If `role_id` is specified, the ID of the Vault role will be used.
+  Only used if role `type` is `gce`.
+
 ### Sample Payload
 
 ```json
@@ -142,11 +152,6 @@ The following parameters are only valid when the role is of type `"iam"`:
   allow GCE instances to authenticate by inferring service accounts from the
   GCE identity metadata token.
 
-- `iam_alias` `(string: unique_id)` - Must be either `unique_id` or `role_id`.
-  If `unique_id` is specified, the service account's unique ID will be used for
-  alias names. If `role_id` is specified, the ID of the Vault role will be used.
-  Only used if `type` is `iam`.
-
 #### `gce`-only Parameters
 
 The following parameters are only valid when the role is of type `"gce"`:
@@ -168,11 +173,6 @@ The following parameters are only valid when the role is of type `"gce"`:
   as "key:value" strings that must be set on authorized GCE instances. Because
   GCP labels are not currently ACL'd, we recommend that this be used in
   conjunction with other restrictions.
-
-- `gce_alias` `(string: instance_id)` - Must be either `instance_id` or `role_id`.
-  If `instance_id` is specified, the GCE instance ID will be used for alias names.
-  If `role_id` is specified, the ID of the Vault role will be used. Only used if
-  `type` is `gce`.
 
 ### Sample Payload
 

--- a/website/pages/api-docs/auth/gcp/index.mdx
+++ b/website/pages/api-docs/auth/gcp/index.mdx
@@ -44,12 +44,12 @@ to confirm signed JWTs passed in during login.
 
   The project must have the `iam.googleapis.com` API [enabled](https://console.cloud.google.com/flows/enableapi?apiid=iam.googleapis.com).
 
-- `iam_alias` `(string: unique_id)` - Must be either `unique_id` or `role_id`.
+- `iam_alias` `(string: "unique_id")` - Must be either `unique_id` or `role_id`.
   If `unique_id` is specified, the service account's unique ID will be used for
   alias names during login. If `role_id` is specified, the ID of the Vault role
   will be used. Only used if role `type` is `iam`.
 
-- `gce_alias` `(string: instance_id)` - Must be either `instance_id` or `role_id`.
+- `gce_alias` `(string: "instance_id")` - Must be either `instance_id` or `role_id`.
   If `instance_id` is specified, the GCE instance ID will be used for alias names
   during login. If `role_id` is specified, the ID of the Vault role will be used.
   Only used if role `type` is `gce`.


### PR DESCRIPTION
Moves `iam_alias` and `gce_alias` from the role to the GCP config.

Related Issues/PRs:
- Issue: https://github.com/hashicorp/vault/issues/8761
- Code change: https://github.com/hashicorp/vault-plugin-auth-gcp/pull/91
- Previous docs: https://github.com/hashicorp/vault/pull/8822