### PR TITLE
update to include vault_format

### DIFF
--- a/website/pages/docs/commands/index.mdx
+++ b/website/pages/docs/commands/index.mdx
@@ -243,6 +243,10 @@ Timeout variable. The default value is 60s.
 Address that should be used for other cluster members to connect to this node
 when in High Availability mode.
 
+### `VAULT_FORMAT`
+
+Provide Vault output (read/status/write) in the specified format. Valid formats are "table", "json", or "yaml".
+
 ### `VAULT_MAX_RETRIES`
 
 Maximum number of retries when a `5xx` error code is encountered. The default is


### PR DESCRIPTION
Working with cert training, realized that VAULT_FORMAT isn't listed as an available Vault environment variable, yet it is listed in the documentation for read, status, and write (maybe others).