### PR TITLE
Ui/replication/refactor dashboard components

### DIFF
--- a/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
@@ -38,15 +38,6 @@
           <Dashboard.card
             @title="Write-Ahead Logs (WALs)"
           />
-          {{#if Dashboard.isSyncing }}
-            <AlertBanner
-              @title="Syncing in progress"
-              @type="info"
-              @secondIconType="loading"
-              @message="The cluster is syncing. This happens when the secondary is too far behind the primary to use the normal stream-wals state for catching up."
-              @class="has-top-margin-xl"
-            />
-          {{/if}}
           <Dashboard.rows/>
         </Page.dashboard>
       {{/if}}

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -10,10 +10,7 @@ export default Component.extend({
     const { data } = this;
     return data.replicationMode;
   }),
-  isSecondary: computed('data', function() {
-    const { data } = this;
-    return data.replicationAttrs.isSecondary;
-  }),
+  isSecondary: null,
   dr: computed('data', function() {
     let dr = this.data.dr;
     if (!dr) {

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -6,6 +6,7 @@ import layout from '../templates/components/replication-dashboard';
 export default Component.extend({
   layout,
   data: null,
+  mode: computed('data', function() {}),
   dr: computed('data', function() {
     let dr = this.data.dr;
     if (!dr) {
@@ -16,5 +17,8 @@ export default Component.extend({
   isSyncing: computed('dr', function() {
     const { state } = this.dr;
     return state && clusterStates([state]).isSyncing;
+  }),
+  isReindexing: computed('data', function() {
+    return true;
   }),
 });

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -6,7 +6,14 @@ import layout from '../templates/components/replication-dashboard';
 export default Component.extend({
   layout,
   data: null,
-  mode: computed('data', function() {}),
+  mode: computed('data', function() {
+    const { data } = this;
+    return data.replicationMode;
+  }),
+  isSecondary: computed('data', function() {
+    const { data } = this;
+    return data.replicationAttrs.isSecondary;
+  }),
   dr: computed('data', function() {
     let dr = this.data.dr;
     if (!dr) {
@@ -14,11 +21,13 @@ export default Component.extend({
     }
     return dr;
   }),
-  isSyncing: computed('dr', function() {
+  isSyncing: computed('dr', 'isSecondary', function() {
     const { state } = this.dr;
-    return state && clusterStates([state]).isSyncing;
+    const isSecondary = this.isSecondary;
+    return isSecondary && state && clusterStates([state]).isSyncing;
   }),
   isReindexing: computed('data', function() {
+    // TODO: make this a real value
     return true;
   }),
 });

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -6,7 +6,6 @@ import layout from '../templates/components/replication-dashboard';
 export default Component.extend({
   layout,
   data: null,
-  mode: null,
   replicationDetails: null,
   isSecondary: null,
   dr: null,

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -16,6 +16,6 @@ export default Component.extend({
   }),
   isReindexing: computed('data', function() {
     // TODO: make this a real value
-    return true;
+    return false;
   }),
 });

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -7,10 +7,11 @@ export default Component.extend({
   layout,
   data: null,
   mode: null,
+  replicationDetails: null,
   isSecondary: null,
   dr: null,
-  isSyncing: computed('dr', 'isSecondary', function() {
-    const { state } = this.dr;
+  isSyncing: computed('replicationDetails', 'isSecondary', function() {
+    const { state } = this.replicationDetails;
     const isSecondary = this.isSecondary;
     return isSecondary && state && clusterStates([state]).isSyncing;
   }),

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -6,18 +6,9 @@ import layout from '../templates/components/replication-dashboard';
 export default Component.extend({
   layout,
   data: null,
-  mode: computed('data', function() {
-    const { data } = this;
-    return data.replicationMode;
-  }),
+  mode: null,
   isSecondary: null,
-  dr: computed('data', function() {
-    let dr = this.data.dr;
-    if (!dr) {
-      return false;
-    }
-    return dr;
-  }),
+  dr: null,
   isSyncing: computed('dr', 'isSecondary', function() {
     const { state } = this.dr;
     const isSecondary = this.isSecondary;

--- a/ui/lib/core/addon/components/replication-header.js
+++ b/ui/lib/core/addon/components/replication-header.js
@@ -9,20 +9,10 @@
  */
 
 import Component from '@ember/component';
-import { computed } from '@ember/object';
 import layout from '../templates/components/replication-header';
 
 export default Component.extend({
   layout,
   data: null,
-  isSecondary: computed('data', function() {
-    let data = this.data;
-    let dr = this.data.dr;
-    if (!dr) {
-      return false;
-    }
-    if (dr.mode === 'secondary' && data.rm.mode == 'dr') {
-      return true;
-    }
-  }),
+  isSecondary: null,
 });

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -13,11 +13,11 @@ export default Component.extend({
     const { model } = this;
     return model.replicationAttrs.isSecondary;
   }),
-  clusterMode: computed('model', function() {
+  clusterMode: computed('model.{replicationAttrs}', function() {
     const { model } = this;
     return model.replicationAttrs.mode;
   }),
-  replicationDetails: computed('model', function() {
+  replicationDetails: computed('model.{replicationMode}', function() {
     const { model } = this;
     const replicationMode = model.replicationMode;
     return model[replicationMode];
@@ -28,11 +28,11 @@ export default Component.extend({
     }
     return false;
   }),
-  mode: computed('model', function() {
+  mode: computed('model.{replicationMode}', function() {
     let mode = this.model.replicationMode;
     return MODE[mode];
   }),
-  message: computed('model', 'mode', function() {
+  message: computed('model.{anyReplicationEnabled}', 'mode', function() {
     if (this.model.anyReplicationEnabled) {
       return `This ${this.mode} secondary has not been enabled.  You can do so from the ${this.mode} Primary.`;
     }

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -17,24 +17,20 @@ export default Component.extend({
     const { model } = this;
     return model.replicationAttrs.isSecondary;
   }),
-  dr: computed('model', function() {
-    let dr = this.model.dr;
-    if (!dr) {
-      return false;
-    }
-    return dr;
+  replicationDetails: computed('model', function() {
+    const { model } = this;
+    const replicationMode = this.model.replicationMode;
+    return model[replicationMode];
   }),
-
-  isDisabled: computed('dr', function() {
-    // this conditional only applies to DR secondaries.
-    if (this.dr.mode === 'disabled' || this.dr.mode === 'primary') {
+  isDisabled: computed('replicationDetails', function() {
+    if (this.replicationDetails.mode === 'disabled' || this.replicationDetails.mode === 'primary') {
       return true;
     }
     return false;
   }),
   message: computed('model', function() {
     if (this.model.anyReplicationEnabled) {
-      return `This ${this.mode} secondary has not been enabled.  You can do so from the Disaster Recovery Primary.`;
+      return `This ${this.mode} secondary has not been enabled.  You can do so from the ${this.mode} Primary.`;
     }
     return `This cluster has not been enabled as a ${this.mode} Secondary. You can do so by enabling replication and adding a secondary from the ${this.mode} Primary.`;
   }),

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -9,17 +9,17 @@ const MODE = {
 
 export default Component.extend({
   layout,
-  mode: computed('model', function() {
-    let mode = this.model.replicationMode;
-    return MODE[mode];
-  }),
   isSecondary: computed('model', function() {
     const { model } = this;
     return model.replicationAttrs.isSecondary;
   }),
+  clusterMode: computed('model', function() {
+    const { model } = this;
+    return model.replicationAttrs.mode;
+  }),
   replicationDetails: computed('model', function() {
     const { model } = this;
-    const replicationMode = this.model.replicationMode;
+    const replicationMode = model.replicationMode;
     return model[replicationMode];
   }),
   isDisabled: computed('replicationDetails', function() {
@@ -28,7 +28,11 @@ export default Component.extend({
     }
     return false;
   }),
-  message: computed('model', function() {
+  mode: computed('model', function() {
+    let mode = this.model.replicationMode;
+    return MODE[mode];
+  }),
+  message: computed('model', 'mode', function() {
     if (this.model.anyReplicationEnabled) {
       return `This ${this.mode} secondary has not been enabled.  You can do so from the ${this.mode} Primary.`;
     }

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -9,13 +9,19 @@ const MODE = {
 
 export default Component.extend({
   layout,
-  isSecondary: computed('model', function() {
-    const { model } = this;
-    return model.replicationAttrs.isSecondary;
+  replicationMode: computed('model.{replicationMode}', function() {
+    // dr or performance 🤯
+    let mode = this.model.replicationMode;
+    return MODE[mode];
   }),
   clusterMode: computed('model.{replicationAttrs}', function() {
+    // primary or secondary
     const { model } = this;
     return model.replicationAttrs.mode;
+  }),
+  isSecondary: computed('clusterMode', function() {
+    const { clusterMode } = this;
+    return clusterMode === 'secondary';
   }),
   replicationDetails: computed('model.{replicationMode}', function() {
     const { model } = this;
@@ -28,14 +34,10 @@ export default Component.extend({
     }
     return false;
   }),
-  mode: computed('model.{replicationMode}', function() {
-    let mode = this.model.replicationMode;
-    return MODE[mode];
-  }),
-  message: computed('model.{anyReplicationEnabled}', 'mode', function() {
+  message: computed('model.{anyReplicationEnabled}', 'replicationMode', function() {
     if (this.model.anyReplicationEnabled) {
-      return `This ${this.mode} secondary has not been enabled.  You can do so from the ${this.mode} Primary.`;
+      return `This ${this.replicationMode} secondary has not been enabled.  You can do so from the ${this.replicationMode} Primary.`;
     }
-    return `This cluster has not been enabled as a ${this.mode} Secondary. You can do so by enabling replication and adding a secondary from the ${this.mode} Primary.`;
+    return `This cluster has not been enabled as a ${this.replicationMode} Secondary. You can do so by enabling replication and adding a secondary from the ${this.replicationMode} Primary.`;
   }),
 });

--- a/ui/lib/core/addon/components/replication-page.js
+++ b/ui/lib/core/addon/components/replication-page.js
@@ -10,8 +10,12 @@ const MODE = {
 export default Component.extend({
   layout,
   mode: computed('model', function() {
-    let mode = this.model.rm.mode;
+    let mode = this.model.replicationMode;
     return MODE[mode];
+  }),
+  isSecondary: computed('model', function() {
+    const { model } = this;
+    return model.replicationAttrs.isSecondary;
   }),
   dr: computed('model', function() {
     let dr = this.model.dr;
@@ -20,6 +24,7 @@ export default Component.extend({
     }
     return dr;
   }),
+
   isDisabled: computed('dr', function() {
     // this conditional only applies to DR secondaries.
     if (this.dr.mode === 'disabled' || this.dr.mode === 'primary') {

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -5,14 +5,14 @@ import { clusterStates } from 'core/helpers/cluster-states';
 
 export default Component.extend({
   layout,
-  data: null,
+  title: null,
   replicationDetails: null,
   state: computed('replicationDetails', function() {
     return this.replicationDetails && this.replicationDetails.state
       ? this.replicationDetails.state
       : 'unknown';
   }),
-  connection: computed('data', function() {
+  connection: computed('replicationDetails', function() {
     return this.replicationDetails.connection_state ? this.replicationDetails.connection_state : 'unknown';
   }),
   lastWAL: computed('replicationDetails', function() {
@@ -23,7 +23,7 @@ export default Component.extend({
       ? this.replicationDetails.lastRemoteWAL
       : 0;
   }),
-  delta: computed('data', function() {
+  delta: computed('replicationDetails', function() {
     return Math.abs(this.get('lastWAL') - this.get('lastRemoteWAL'));
   }),
   inSyncState: computed('state', function() {
@@ -32,7 +32,7 @@ export default Component.extend({
     return this.state === 'stream-wals';
   }),
 
-  hasErrorClass: computed('data', 'title', 'state', 'connection', function() {
+  hasErrorClass: computed('replicationDetails', 'title', 'state', 'connection', function() {
     const { title, state, connection } = this;
 
     // only show errors on the state card

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -6,17 +6,22 @@ import { clusterStates } from 'core/helpers/cluster-states';
 export default Component.extend({
   layout,
   data: null,
-  state: computed('dr', function() {
-    return this.dr && this.dr.state ? this.dr.state : 'unknown';
+  replicationDetails: null,
+  state: computed('replicationDetails', function() {
+    return this.replicationDetails && this.replicationDetails.state
+      ? this.replicationDetails.state
+      : 'unknown';
   }),
   connection: computed('data', function() {
-    return this.dr.connection_state ? this.dr.connection_state : 'unknown';
+    return this.replicationDetails.connection_state ? this.replicationDetails.connection_state : 'unknown';
   }),
-  lastWAL: computed('dr', function() {
-    return this.dr && this.dr.lastWAL ? this.dr.lastWAL : 0;
+  lastWAL: computed('replicationDetails', function() {
+    return this.replicationDetails && this.replicationDetails.lastWAL ? this.replicationDetails.lastWAL : 0;
   }),
-  lastRemoteWAL: computed('dr', function() {
-    return this.dr && this.dr.lastRemoteWAL ? this.dr.lastRemoteWAL : 0;
+  lastRemoteWAL: computed('replicationDetails', function() {
+    return this.replicationDetails && this.replicationDetails.lastRemoteWAL
+      ? this.replicationDetails.lastRemoteWAL
+      : 0;
   }),
   delta: computed('data', function() {
     return Math.abs(this.get('lastWAL') - this.get('lastRemoteWAL'));

--- a/ui/lib/core/addon/components/replication-table-rows.js
+++ b/ui/lib/core/addon/components/replication-table-rows.js
@@ -13,7 +13,4 @@ export default Component.extend({
   clusterId: computed('replicationDetails', function() {
     return this.replicationDetails.clusterId || 'unknown';
   }),
-  syncProgress: computed('replicationDetails', function() {
-    return this.replicationDetails.syncProgress || false;
-  }),
 });

--- a/ui/lib/core/addon/components/replication-table-rows.js
+++ b/ui/lib/core/addon/components/replication-table-rows.js
@@ -5,21 +5,15 @@ import layout from '../templates/components/replication-table-rows';
 export default Component.extend({
   layout,
   classNames: ['replication-table-rows'],
-  data: null,
-  clusterDetails: computed('data', function() {
-    const { data } = this;
-    return data.dr || data;
+  replicationDetails: null,
+  clusterMode: null,
+  merkleRoot: computed('replicationDetails', function() {
+    return this.replicationDetails.merkleRoot || 'unknown';
   }),
-  mode: computed('clusterDetails', function() {
-    return this.clusterDetails.mode || 'unknown';
+  clusterId: computed('replicationDetails', function() {
+    return this.replicationDetails.clusterId || 'unknown';
   }),
-  merkleRoot: computed('clusterDetails', function() {
-    return this.clusterDetails.merkleRoot || 'unknown';
-  }),
-  clusterId: computed('clusterDetails', function() {
-    return this.clusterDetails.clusterId || 'unknown';
-  }),
-  syncProgress: computed('clusterDetails', function() {
-    return this.clusterDetails.syncProgress || false;
+  syncProgress: computed('replicationDetails', function() {
+    return this.replicationDetails.syncProgress || false;
   }),
 });

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -24,7 +24,7 @@
 
   <div class="selectable-card-container has-top-margin-xl">
     {{yield (hash
-      card=(component componentToRender data=data replicationDetails=replicationDetails)
+      card=(component componentToRender replicationDetails=replicationDetails)
     )}}
     {{#if (not isSecondary)}}
       {{yield (hash secondaryCard=(component 'known-secondaries-card'))}}

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -1,12 +1,35 @@
 <div class="replication-dashboard box is-sideless is-fullwidth is-marginless">
   {{!-- TODO this section is only needed for secondaries --}}
-  <h2 class="has-text-weight-semibold is-size-4 has-bottom-margin-xs">Primary Cluster</h2>
-  <p class="has-text-grey is-size-8">If you set a primary_cluster_addr when enabling replication, it will appear here.</p>
+  {{#if isSecondary}}
+    <h2 class="has-text-weight-semibold is-size-4 has-bottom-margin-xs">
+        Primary Cluster
+    </h2>
+    <p class="has-text-grey is-size-8">
+      If you set a primary_cluster_addr when enabling replication, it will appear here.
+    </p>
+    {{#if data.dr.primaryClusterAddr}}
+      <code>{{data.dr.primaryClusterAddr}}</code>
+    {{else}}
+      <code>no known primary cluster address</code>
+    {{/if}}
+  {{/if}}
 
-  {{#if data.dr.primaryClusterAddr}}
-    <code>{{data.dr.primaryClusterAddr}}</code>
-  {{else}}
-    <code>no known primary cluster address</code>
+  {{!-- TODO check for actual reindexing status --}}
+  {{#if isReindexing}}
+    <AlertBanner
+      @title="Re-indexing in progress: Scanning"
+      @type="info"
+      @secondIconType="loading"
+      @message="This can cause a delay depending on the size of the data store. You can use Vault during this time."
+      @class="has-top-margin-xl" />
+  {{/if}}
+  {{#if isSyncing}}
+    <AlertBanner
+      @title="Syncing in progress"
+      @type="info"
+      @secondIconType="loading"
+      @message="The cluster is syncing. This happens when the secondary is too far behind the primary to use the normal stream-wals state for catching up."
+      @class="has-top-margin-xl" />
   {{/if}}
 
   <div class="selectable-card-container has-top-margin-xl">
@@ -23,7 +46,6 @@
   </div>
 
   {{yield (hash
-    isSyncing=isSyncing
     rows=(component 'replication-table-rows' data=data)
   )}}
 

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -24,7 +24,6 @@
   {{/if}}
 
   <div class="selectable-card-container has-top-margin-xl">
-    {{!-- TODO remove dr from being passed in automatically because we don't need it on perf dashboards --}}
     {{yield (hash
       card=(component componentToRender data=data replicationDetails=replicationDetails)
     )}}
@@ -41,6 +40,8 @@
       @message="The cluster is syncing. This happens when the secondary is too far behind the primary to use the normal stream-wals state for catching up."
       @class="has-top-margin-xl" />
   {{/if}}
-  <ReplicationTableRows @data={{data}} />
+  <ReplicationTableRows
+    @replicationDetails={{replicationDetails}}
+    @clusterMode={{clusterMode}} />
   <ReplicationDocLink />
 </div>

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -1,5 +1,4 @@
 <div class="replication-dashboard box is-sideless is-fullwidth is-marginless">
-  {{!-- TODO this section is only needed for secondaries --}}
   {{#if isSecondary}}
     <h2 class="has-text-weight-semibold is-size-4 has-bottom-margin-xs">
         Primary Cluster
@@ -29,7 +28,7 @@
     {{yield (hash
       card=(component componentToRender data=data dr=dr)
     )}}
-    {{#if true}}
+    {{#if (not isSecondary)}}
       {{yield (hash secondaryCard=(component 'known-secondaries-card'))}}
     {{/if}}
 

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -1,4 +1,5 @@
 <div class="replication-dashboard box is-sideless is-fullwidth is-marginless">
+  {{!-- TODO this section is only needed for secondaries --}}
   <h2 class="has-text-weight-semibold is-size-4 has-bottom-margin-xs">Primary Cluster</h2>
   <p class="has-text-grey is-size-8">If you set a primary_cluster_addr when enabling replication, it will appear here.</p>
 
@@ -9,9 +10,16 @@
   {{/if}}
 
   <div class="selectable-card-container has-top-margin-xl">
-    {{yield (hash 
+    {{!-- TODO remove dr from being passed in automatically because we don't need it on perf dashboards --}}
+    {{yield (hash
       card=(component componentToRender data=data dr=dr)
     )}}
+
+    {{!-- TODO is there another way I can yield whatever I want in here without having to specify every component inside this hash? --}}
+    {{!-- TODO change this to check whether the dashboard is for a primary or secondary --}}
+    {{#if true}}
+      {{yield (hash secondaryCard=(component 'known-secondaries-card'))}}
+    {{/if}}
   </div>
 
   {{yield (hash

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -23,6 +23,17 @@
       @message="This can cause a delay depending on the size of the data store. You can use Vault during this time."
       @class="has-top-margin-xl" />
   {{/if}}
+
+  <div class="selectable-card-container has-top-margin-xl">
+    {{!-- TODO remove dr from being passed in automatically because we don't need it on perf dashboards --}}
+    {{yield (hash
+      card=(component componentToRender data=data dr=dr)
+    )}}
+    {{#if true}}
+      {{yield (hash secondaryCard=(component 'known-secondaries-card'))}}
+    {{/if}}
+
+  </div>
   {{#if isSyncing}}
     <AlertBanner
       @title="Syncing in progress"
@@ -31,23 +42,6 @@
       @message="The cluster is syncing. This happens when the secondary is too far behind the primary to use the normal stream-wals state for catching up."
       @class="has-top-margin-xl" />
   {{/if}}
-
-  <div class="selectable-card-container has-top-margin-xl">
-    {{!-- TODO remove dr from being passed in automatically because we don't need it on perf dashboards --}}
-    {{yield (hash
-      card=(component componentToRender data=data dr=dr)
-    )}}
-
-    {{!-- TODO is there another way I can yield whatever I want in here without having to specify every component inside this hash? --}}
-    {{!-- TODO change this to check whether the dashboard is for a primary or secondary --}}
-    {{#if true}}
-      {{yield (hash secondaryCard=(component 'known-secondaries-card'))}}
-    {{/if}}
-  </div>
-
-  {{yield (hash
-    rows=(component 'replication-table-rows' data=data)
-  )}}
-
+  <ReplicationTableRows @data={{data}} />
   <ReplicationDocLink />
 </div>

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -6,8 +6,8 @@
     <p class="has-text-grey is-size-8">
       If you set a primary_cluster_addr when enabling replication, it will appear here.
     </p>
-    {{#if data.dr.primaryClusterAddr}}
-      <code>{{data.dr.primaryClusterAddr}}</code>
+    {{#if replicationDetails.primaryClusterAddr}}
+      <code>{{replicationDetails.primaryClusterAddr}}</code>
     {{else}}
       <code>no known primary cluster address</code>
     {{/if}}
@@ -26,7 +26,7 @@
   <div class="selectable-card-container has-top-margin-xl">
     {{!-- TODO remove dr from being passed in automatically because we don't need it on perf dashboards --}}
     {{yield (hash
-      card=(component componentToRender data=data dr=dr)
+      card=(component componentToRender data=data replicationDetails=replicationDetails)
     )}}
     {{#if (not isSecondary)}}
       {{yield (hash secondaryCard=(component 'known-secondaries-card'))}}

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -19,8 +19,7 @@
       @title="Re-indexing in progress: Scanning"
       @type="info"
       @secondIconType="loading"
-      @message="This can cause a delay depending on the size of the data store. You can use Vault during this time."
-      @class="has-top-margin-xl" />
+      @message="This can cause a delay depending on the size of the data store. You can use Vault during this time."/>
   {{/if}}
 
   <div class="selectable-card-container has-top-margin-xl">

--- a/ui/lib/core/addon/templates/components/replication-header.hbs
+++ b/ui/lib/core/addon/templates/components/replication-header.hbs
@@ -34,7 +34,7 @@
     <h1 class="title is-3">
       {{title}}
       <span class="tag">
-        {{data.dr.mode}}
+        {{if isSecondary 'Secondary' 'Primary'}}
       </span>
       <span class="tag">
         {{data.dr.clusterIdDisplay}}

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -1,8 +1,8 @@
 <div class="replication-page">
 {{yield (hash
-  header=(component 'replication-header' data=model title=mode)
+  header=(component 'replication-header' data=model title=mode isSecondary=isSecondary)
   toggle=(component 'replication-toggle')
-  dashboard=(component 'replication-dashboard' data=model dr=dr)
+  dashboard=(component 'replication-dashboard' data=model dr=dr isSecondary=isSecondary)
   isDisabled=isDisabled
   message=message
 )}}

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -2,7 +2,7 @@
 {{yield (hash
   header=(component 'replication-header' data=model title=mode isSecondary=isSecondary)
   toggle=(component 'replication-toggle')
-  dashboard=(component 'replication-dashboard' data=model dr=dr isSecondary=isSecondary mode=mode)
+  dashboard=(component 'replication-dashboard' data=model isSecondary=isSecondary mode=mode replicationDetails=replicationDetails)
   isDisabled=isDisabled
   message=message
 )}}

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -2,7 +2,7 @@
 {{yield (hash
   header=(component 'replication-header' data=model title=mode isSecondary=isSecondary)
   toggle=(component 'replication-toggle')
-  dashboard=(component 'replication-dashboard' data=model isSecondary=isSecondary mode=mode replicationDetails=replicationDetails)
+  dashboard=(component 'replication-dashboard' data=model isSecondary=isSecondary replicationDetails=replicationDetails clusterMode=clusterMode)
   isDisabled=isDisabled
   message=message
 )}}

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -1,5 +1,5 @@
 <div class="replication-page">
-{{yield (hash 
+{{yield (hash
   header=(component 'replication-header' data=model title=mode)
   toggle=(component 'replication-toggle')
   dashboard=(component 'replication-dashboard' data=model dr=dr)

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -2,7 +2,7 @@
 {{yield (hash
   header=(component 'replication-header' data=model title=mode isSecondary=isSecondary)
   toggle=(component 'replication-toggle')
-  dashboard=(component 'replication-dashboard' data=model dr=dr isSecondary=isSecondary)
+  dashboard=(component 'replication-dashboard' data=model dr=dr isSecondary=isSecondary mode=mode)
   isDisabled=isDisabled
   message=message
 )}}

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -1,6 +1,6 @@
 <div class="replication-page">
 {{yield (hash
-  header=(component 'replication-header' data=model title=mode isSecondary=isSecondary)
+  header=(component 'replication-header' data=model title=replicationMode isSecondary=isSecondary)
   toggle=(component 'replication-toggle')
   dashboard=(component 'replication-dashboard' data=model isSecondary=isSecondary replicationDetails=replicationDetails clusterMode=clusterMode)
   isDisabled=isDisabled

--- a/ui/lib/core/addon/templates/components/replication-table-rows.hbs
+++ b/ui/lib/core/addon/templates/components/replication-table-rows.hbs
@@ -1,27 +1,21 @@
-{{#unless data}}
-  <EmptyState
-    @title="Data not available"
-  />
-{{else}}
-  <div class="has-top-margin-xl has-bottom-margin-s"
-    data-test-table-rows>
-    {{info-table-row
-      label="Merkle root index"
-      helperText="A snapshot in time of the merkle tree's root hash. Changes on every update to storage."
-      value=merkleRoot}}
-    {{info-table-row
-      label="Mode"
-      value=mode}}
-    {{info-table-row
-      label="Replication set"
-      helperText="The ID for the group of clusters communicating for this replication mode"
-      value=clusterId}}
-  </div>
+<div class="has-top-margin-xl has-bottom-margin-s"
+  data-test-table-rows>
+  {{info-table-row
+    label="Merkle root index"
+    helperText="A snapshot in time of the merkle tree's root hash. Changes on every update to storage."
+    value=merkleRoot}}
+  {{info-table-row
+    label="Mode"
+    value=clusterMode}}
+  {{info-table-row
+    label="Replication set"
+    helperText="The ID for the group of clusters communicating for this replication mode"
+    value=clusterId}}
+</div>
 
-  {{#if syncProgress}}
-  {{!-- ARG TODO: need to test this --}}
-    {{info-table-row
-      label="Sync progress"
-      value=(concat syncProgress.progress '/' syncProgress.total)}}
-  {{/if}}
-{{/unless}}
+{{#if syncProgress}}
+{{!-- ARG TODO: need to test this --}}
+  {{info-table-row
+    label="Sync progress"
+    value=(concat syncProgress.progress '/' syncProgress.total)}}
+{{/if}}

--- a/ui/lib/core/addon/templates/components/replication-table-rows.hbs
+++ b/ui/lib/core/addon/templates/components/replication-table-rows.hbs
@@ -12,10 +12,3 @@
     helperText="The ID for the group of clusters communicating for this replication mode"
     value=clusterId}}
 </div>
-
-{{#if syncProgress}}
-{{!-- ARG TODO: need to test this --}}
-  {{info-table-row
-    label="Sync progress"
-    value=(concat syncProgress.progress '/' syncProgress.total)}}
-{{/if}}

--- a/ui/lib/replication/addon/templates/components/replication-summary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-summary.hbs
@@ -332,15 +332,6 @@
     <div class="replication">
       <ReplicationToggle />
       <ReplicationDashboard @data={{cluster}} @componentToRender='replication-primary-card' as |Dashboard|>
-        {{!-- TODO check for actual reindexing status --}}
-        {{#if true}}
-          <AlertBanner
-            @title="Re-indexing in progress: Scanning"
-            @type="info"
-            @secondIconType="loading"
-            @message="This can cause a delay depending on the size of the data store. You can use Vault during this time."
-            @class="has-top-margin-xl" />
-        {{/if}}
         <Dashboard.card
           @title='State'
           @description='Updated every ten seconds.'

--- a/ui/lib/replication/addon/templates/components/replication-summary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-summary.hbs
@@ -276,7 +276,7 @@
     </h3>
     {{#if cluster.dr.replicationEnabled}}
       {{#if submit.isRunning }}
-          <LayoutLoading />
+        <LayoutLoading />
       {{else}}
         {{#link-to
           "mode.index"
@@ -301,11 +301,7 @@
   {{#unless (and submit.isRunning (eq cluster.dr.mode "bootstrapping"))}}
     <div class="box is-bottomless is-fullwidth is-marginless">
       <h3 class="title is-flex-center is-5 is-marginless">
-        <Icon
-          @size="xl"
-          aria-hidden="true"
-          @glyph="perf-replication"
-        />
+        <Icon @size="xl" aria-hidden="true" @glyph="perf-replication" />
         Performance
       </h3>
       {{#if cluster.dr.replicationEnabled}}
@@ -335,22 +331,30 @@
   {{else}}
     <div class="replication">
       <ReplicationToggle />
-      <div class="selectable-card-container">
-        <ReplicationPrimaryCard
+      <ReplicationDashboard @data={{cluster}} @componentToRender='replication-primary-card' as |Dashboard|>
+        {{!-- TODO check for actual reindexing status --}}
+        {{#if true}}
+          <AlertBanner
+            @title="Re-indexing in progress: Scanning"
+            @type="info"
+            @secondIconType="loading"
+            @message="This can cause a delay depending on the size of the data store. You can use Vault during this time."
+            @class="has-top-margin-xl" />
+        {{/if}}
+        <Dashboard.card
           @title='State'
           @description='Updated every ten seconds.'
           @glyph={{get (cluster-states replicationAttrs.state) "glyph"}}
           @metric={{replicationAttrs.state}} />
-        <ReplicationPrimaryCard
+        <Dashboard.card
           @title='Last WAL entry'
           @description='Index of last Write Ahead Logs entry written on local storage.'
           @metric={{replicationAttrs.lastWAL}} />
-        <KnownSecondariesCard
+        <Dashboard.secondaryCard
           @cluster={{cluster}}
           @replicationAttrs={{replicationAttrs}} />
-      </div>
-      <ReplicationTableRows @data={{replicationAttrs}} />
-      <ReplicationDocLink />
+        <Dashboard.rows />
+      </ReplicationDashboard>
     </div>
   {{/if}}
 {{/if}}

--- a/ui/lib/replication/addon/templates/components/replication-summary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-summary.hbs
@@ -330,22 +330,23 @@
     The cluster is initializing replication. This may take some time.
   {{else}}
     <div class="replication">
-      <ReplicationToggle />
-      <ReplicationDashboard @data={{cluster}} @componentToRender='replication-primary-card' as |Dashboard|>
-        <Dashboard.card
-          @title='State'
-          @description='Updated every ten seconds.'
-          @glyph={{get (cluster-states replicationAttrs.state) "glyph"}}
-          @metric={{replicationAttrs.state}} />
-        <Dashboard.card
-          @title='Last WAL entry'
-          @description='Index of last Write Ahead Logs entry written on local storage.'
-          @metric={{replicationAttrs.lastWAL}} />
-        <Dashboard.secondaryCard
-          @cluster={{cluster}}
-          @replicationAttrs={{replicationAttrs}} />
-        <Dashboard.rows />
-      </ReplicationDashboard>
+      <ReplicationPage @model={{cluster}} as |Page|>
+        <Page.toggle />
+        <Page.dashboard @data={{cluster}} @componentToRender='replication-primary-card' as |Dashboard|>
+          <Dashboard.card
+            @title='State'
+            @description='Updated every ten seconds.'
+            @glyph={{get (cluster-states replicationAttrs.state) "glyph"}}
+            @metric={{replicationAttrs.state}} />
+          <Dashboard.card
+            @title='Last WAL entry'
+            @description='Index of last Write Ahead Logs entry written on local storage.'
+            @metric={{replicationAttrs.lastWAL}} />
+          <Dashboard.secondaryCard
+            @cluster={{cluster}}
+            @replicationAttrs={{replicationAttrs}} />
+        </Page.dashboard>
+      </ReplicationPage>
     </div>
   {{/if}}
 {{/if}}

--- a/ui/tests/integration/components/known-secondaries-card-test.js
+++ b/ui/tests/integration/components/known-secondaries-card-test.js
@@ -14,7 +14,7 @@ const REPLICATION_ATTRS = {
   knownSecondaries: ['firstSecondary', 'secondary-2', '3'],
 };
 
-module('Integration | Enterprise | Component | replication known-secondaries-card', function(hooks) {
+module('Integration | Component | replication known-secondaries-card', function(hooks) {
   setupRenderingTest(hooks, { resolver });
 
   hooks.beforeEach(function() {

--- a/ui/tests/integration/components/known-secondaries-table-test.js
+++ b/ui/tests/integration/components/known-secondaries-table-test.js
@@ -9,7 +9,7 @@ const REPLICATION_ATTRS = {
   knownSecondaries: ['firstSecondary', 'secondary-2'],
 };
 
-module('Integration | Enterprise | Component | replication known-secondaries-table', function(hooks) {
+module('Integration | Component | replication known-secondaries-table', function(hooks) {
   setupRenderingTest(hooks, { resolver });
 
   hooks.beforeEach(function() {

--- a/ui/tests/integration/components/replication-primary-card-test.js
+++ b/ui/tests/integration/components/replication-primary-card-test.js
@@ -6,7 +6,7 @@ import { CLUSTER_STATES } from 'core/helpers/cluster-states';
 import hbs from 'htmlbars-inline-precompile';
 const resolver = engineResolverFor('replication');
 
-module('Integration | Enterprise | Component | replication-primary-card', function(hooks) {
+module('Integration | Component | replication-primary-card', function(hooks) {
   setupRenderingTest(hooks, { resolver });
 
   test('it renders', async function(assert) {

--- a/ui/tests/integration/components/replication-table-rows-test.js
+++ b/ui/tests/integration/components/replication-table-rows-test.js
@@ -9,7 +9,7 @@ const DATA = {
   merkleRoot: 'c21c8428a0a06135cef6ae25bf8e0267ff1592a6',
 };
 
-module('Integration | Enterprise | Component | replication-table-rows', function(hooks) {
+module('Integration | Component | replication-table-rows', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {


### PR DESCRIPTION
This PR refactors the `ReplicationPage` and `ReplicationDashboard` components so they can be used on both the Primary and Secondary Replication dashboards.