### PR TITLE
Document new GCP auth metadata fields

### DIFF
--- a/website/pages/api-docs/auth/gcp/index.mdx
+++ b/website/pages/api-docs/auth/gcp/index.mdx
@@ -49,9 +49,30 @@ to confirm signed JWTs passed in during login.
   alias names during login. If `role_id` is specified, the ID of the Vault role
   will be used. Only used if role `type` is `iam`.
 
+- `iam_metadata` `(string: "default")` - The metadata to include on the token
+  returned by the `login` endpoint. This metadata will be added to both audit logs,
+  and on the `iam_alias`. By default, it includes `project_id`, `role`,
+  `service_account_id`, and `service_account_email`. To include no metadata,
+  set to `""` via the CLI or `[]` via the API. To use only particular fields, select
+  the explicit fields. To restore to defaults, send only a field of `default`.
+  **Only select fields that will have a low rate of change** for your `iam_alias` because
+  each change triggers a storage write and can have a performance impact at scale.
+  Only used if role `type` is `iam`.
+
 - `gce_alias` `(string: "instance_id")` - Must be either `instance_id` or `role_id`.
   If `instance_id` is specified, the GCE instance ID will be used for alias names
   during login. If `role_id` is specified, the ID of the Vault role will be used.
+  Only used if role `type` is `gce`.
+
+- `gce_metadata` `(string: "default")` - The metadata to include on the token
+  returned by the `login` endpoint. This metadata will be added to both audit logs,
+  and on the `gce_alias`. By default, it includes `instance_creation_timestamp`,
+  `instance_id`, `instance_name`, `project_id`, `project_number`, `role`,
+  `service_account_id`, `service_account_email`, and `zone`. To include no metadata,
+  set to `""` via the CLI or `[]` via the API. To use only particular fields, select
+  the explicit fields. To restore to defaults, send only a field of `default`.
+  **Only select fields that will have a low rate of change** for your `gce_alias` because
+  each change triggers a storage write and can have a performance impact at scale.
   Only used if role `type` is `gce`.
 
 ### Sample Payload


### PR DESCRIPTION
This PR documents the fields added in https://github.com/hashicorp/vault-plugin-auth-gcp/pull/92 that will go out with 1.4.1.