### PR TITLE
Raft recovery peers non voter (#8681)

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -570,7 +570,16 @@ func (b *RaftBackend) SetupCluster(ctx context.Context, opts SetupOpts) error {
 			return errwrap.Wrapf("raft recovery failed to parse peers.json: {{err}}", err)
 		}
 
-		b.logger.Info("raft recovery: found new config", "config", recoveryConfig)
+		// Non-voting servers are only allowed in enterprise. If Suffrage is disabled,
+		// error out to indicate that it isn't allowed.
+		for idx := range recoveryConfig.Servers {
+			if !nonVotersAllowed && recoveryConfig.Servers[idx].Suffrage == raft.Nonvoter {
+				return fmt.Errorf("raft recovery failed to parse configuration for node %q: setting `non_voter` is only supported in enterprise", recoveryConfig.Servers[idx].ID)
+			}
+		}
+
+		b.logger.Info("raft recovery found new config", "config", recoveryConfig)
+
 		err = raft.RecoverCluster(raftConfig, b.fsm, b.logStore, b.stableStore, b.snapStore, b.raftTransport, recoveryConfig)
 		if err != nil {
 			return errwrap.Wrapf("raft recovery failed: {{err}}", err)

--- a/physical/raft/raft_util.go
+++ b/physical/raft/raft_util.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 )
 
+const nonVotersAllowed = false
+
 // AddPeer adds a new server to the raft cluster
 func (b *RaftBackend) AddNonVotingPeer(ctx context.Context, peerID, clusterAddr string) error {
 	return errors.New("not implemented")


### PR DESCRIPTION
* Disallow non-voter setting from peers.json

* Fix bug that would make the actual fix a no-op

* Change order of evaluation

* Error out instead of resetting the value

* Update physical/raft/raft.go

Co-Authored-By: Calvin Leung Huang <cleung2010@gmail.com>

* Print node ID

Co-authored-by: Calvin Leung Huang <cleung2010@gmail.com>