### PR TITLE
Improve documentation around database plugins

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -220,8 +220,8 @@ export default [
         content: [
           'cassandra',
           'elasticdb',
-          'influxdb',
           'hanadb',
+          'influxdb',
           'mongodb',
           'mongodbatlas',
           'mssql',

--- a/website/pages/api-docs/secret/databases/index.mdx
+++ b/website/pages/api-docs/secret/databases/index.mdx
@@ -48,7 +48,7 @@ list of additional parameters.
   executed to rotate the root user's credentials. See the plugin's API page for more
   information on support and formatting for this parameter.
 
-~> It is recommended that you use a super-user rather than the root user when
+~> It is recommended that you create a user rather than use the root user when
    configuring the plugin. This user will be used to create/update/delete users
    within the database so it will need to have the appropriate permissions to do so.
    If the plugin supports [rotating the root credentials](#rotate-root-credentials),
@@ -84,7 +84,7 @@ for details on whether these fields are supported and any additional details abo
   "plugin_name": "mysql-database-plugin",
   "allowed_roles": "readonly",
   "connection_url": "{{username}}:{{password}}@tcp(127.0.0.1:3306)/",
-  "username": "vaultsuperuser",
+  "username": "vaultuser",
   "password": "secretpassword"
 }
 ```
@@ -106,7 +106,7 @@ $ vault write database/config/mysql \
     plugin_name="mysql-database-plugin" \
     allowed_roles="readonly" \
     connection_url="{{username}}:{{password}}@tcp(127.0.0.1:3306)/" \
-    username="vaultsuperuser" \
+    username="vaultuser" \
     password="secretpassword"
 ```
 
@@ -140,7 +140,7 @@ $ curl \
     "allowed_roles": ["readonly"],
     "connection_details": {
       "connection_url": "{{username}}:{{password}}@tcp(127.0.0.1:3306)/",
-      "username": "vaultsuperuser"
+      "username": "vaultuser"
     },
     "plugin_name": "mysql-database-plugin"
   }
@@ -222,7 +222,7 @@ $ curl \
 
 ## Rotate Root Credentials
 
-This endpoint is used to rotate the root superuser credentials stored for
+This endpoint is used to rotate the "root" user credentials stored for
 the database connection. This user must have permissions to update its own
 password.
 
@@ -231,7 +231,7 @@ password.
 | `POST` | `/database/rotate-root/:name` |
 
 !> **Use caution:** the root user's password will not be accessible once rotated so it is highly
-   recommended that you create a super-user for Vault to utilize rather than using the actual root user.
+   recommended that you create a user for Vault to utilize rather than using the actual root user.
 
 ### Parameters
 

--- a/website/pages/api-docs/secret/databases/index.mdx
+++ b/website/pages/api-docs/secret/databases/index.mdx
@@ -48,6 +48,35 @@ list of additional parameters.
   executed to rotate the root user's credentials. See the plugin's API page for more
   information on support and formatting for this parameter.
 
+~> It is recommended that you use a super-user rather than the root user when
+   configuring the plugin. This user will be used to create/update/delete users
+   within the database so it will need to have the appropriate permissions to do so.
+   If the plugin supports [rotating the root credentials](#rotate-root-credentials),
+   it is highly recommended you perform that action after configuring the plugin.
+
+### Common fields
+There are several common fields that you will see across many but not all of the database
+plugins. Below is several common fields. Please reference the individual plugin documentation
+for details on whether these fields are supported and any additional details about them.
+
+- `connection_url` `(string)` - Specifies the connection string used to connect to the
+  database. Some plugins use `url` rather than `connection_url`. This allows for simple
+  templating of the username and password of the root user. Typically this is done by
+  including a `{{username}}`, `{{name}}`, and/or `{{password}}` field within the string.
+  These fields are typically be replaced with the values in the `username` and
+  `password` fields.
+
+- `username` `(string)` - Specifies the name of the user to use as the "root" user when
+  connecting to the database. This "root" user is used to create/update/delete users
+  managed by these plugins, so you will need to ensure that this user has permissions to
+  manipulate users appropriate to the database. This is typically used in the
+  `connection_url` field via the templating directive `{{username}}` or `{{name}}`.
+
+- `password` `(string)` - Specifies the password to use when connecting with the
+  `username`. This value will not be returned by Vault when performing a read upon the
+  configuration. This is typically used in the `connection_url` field via the templating
+  directive `{{password}}`.
+
 ### Sample Payload
 
 ```json
@@ -55,12 +84,12 @@ list of additional parameters.
   "plugin_name": "mysql-database-plugin",
   "allowed_roles": "readonly",
   "connection_url": "{{username}}:{{password}}@tcp(127.0.0.1:3306)/",
-  "username": "root",
-  "password": "mysql"
+  "username": "vaultsuperuser",
+  "password": "secretpassword"
 }
 ```
 
-### Sample Request
+### Sample cURL Request
 
 ```console
 $ curl \
@@ -68,6 +97,17 @@ $ curl \
     --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/database/config/mysql
+```
+
+### Sample CLI Request
+
+```console
+$ vault write database/config/mysql \
+    plugin_name="mysql-database-plugin" \
+    allowed_roles="readonly" \
+    connection_url="{{username}}:{{password}}@tcp(127.0.0.1:3306)/" \
+    username="vaultsuperuser" \
+    password="secretpassword"
 ```
 
 ## Read Connection
@@ -100,7 +140,7 @@ $ curl \
     "allowed_roles": ["readonly"],
     "connection_details": {
       "connection_url": "{{username}}:{{password}}@tcp(127.0.0.1:3306)/",
-      "username": "root"
+      "username": "vaultsuperuser"
     },
     "plugin_name": "mysql-database-plugin"
   }
@@ -189,6 +229,9 @@ password.
 | Method | Path                          |
 | :----- | :---------------------------- |
 | `POST` | `/database/rotate-root/:name` |
+
+!> **Use caution:** the root user's password will not be accessible once rotated so it is highly
+   recommended that you create a super-user for Vault to utilize rather than using the actual root user.
 
 ### Parameters
 

--- a/website/pages/docs/secrets/databases/cassandra.mdx
+++ b/website/pages/docs/secrets/databases/cassandra.mdx
@@ -17,6 +17,11 @@ the Cassandra database.
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| `cassandra-database-plugin` | Yes | Yes | Yes |
+
 ## Setup
 
 1.  Enable the database secrets engine if it is not already enabled:
@@ -36,8 +41,8 @@ more information about setting up the database secrets engine.
         plugin_name="cassandra-database-plugin" \
         hosts=127.0.0.1 \
         protocol_version=4 \
-        username=cassandra \
-        password=cassandra \
+        username=superuser \
+        password=superpass \
         allowed_roles=my-role
     ```
 
@@ -70,7 +75,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-root-e2978cd0-
+    username           v-superuser-e2978cd0-
     ```
 
 ## API

--- a/website/pages/docs/secrets/databases/cassandra.mdx
+++ b/website/pages/docs/secrets/databases/cassandra.mdx
@@ -41,8 +41,8 @@ more information about setting up the database secrets engine.
         plugin_name="cassandra-database-plugin" \
         hosts=127.0.0.1 \
         protocol_version=4 \
-        username=superuser \
-        password=superpass \
+        username=vaultuser \
+        password=vaultpass \
         allowed_roles=my-role
     ```
 
@@ -75,7 +75,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-superuser-e2978cd0-
+    username           v-vaultuser-e2978cd0-
     ```
 
 ## API

--- a/website/pages/docs/secrets/databases/elasticdb.mdx
+++ b/website/pages/docs/secrets/databases/elasticdb.mdx
@@ -20,6 +20,11 @@ Elasticsearch.
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| `elasticsearch-database-plugin` | Yes | Yes | No |
+
 ## Getting Started
 
 To take advantage of this plugin, you must first enable Elasticsearch's native realm of security by activating X-Pack. These
@@ -68,7 +73,7 @@ $ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"cluster": ["manage_security"]}' \
-    http://elastic:$PASSWORD@localhost:9200/_xpack/security/role/vault
+    http://superuser:$PASSWORD@localhost:9200/_xpack/security/role/vault
 ```
 
 Next, create a user for Vault associated with that role.
@@ -78,7 +83,7 @@ $ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d @data.json \
-    http://elastic:$PASSWORD@localhost:9200/_xpack/security/user/vault
+    http://superuser:$PASSWORD@localhost:9200/_xpack/security/user/vault
 ```
 
 The contents of `data.json` in this example are:
@@ -165,7 +170,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-root-e2978cd0-
+    username           v-superuser-e2978cd0-
     ```
 
 ## API

--- a/website/pages/docs/secrets/databases/elasticdb.mdx
+++ b/website/pages/docs/secrets/databases/elasticdb.mdx
@@ -65,7 +65,7 @@ know it's been set up successfully if it takes you through a number of password-
 Next, in Elasticsearch, we recommend that you create a user just for Vault to use in managing secrets.
 
 To do this, first create a role that will allow Vault the minimum privileges needed to administer users and passwords by performing a
-POST to Elasticsearch. To do this, we used the `elastic` superuser whose password we created in the
+POST to Elasticsearch. To do this, we used the `elastic` vaultuser whose password we created in the
 `$ $ES_HOME/bin/elasticsearch-setup-passwords interactive` step.
 
 ```
@@ -73,7 +73,7 @@ $ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"cluster": ["manage_security"]}' \
-    http://superuser:$PASSWORD@localhost:9200/_xpack/security/role/vault
+    http://vaultuser:$PASSWORD@localhost:9200/_xpack/security/role/vault
 ```
 
 Next, create a user for Vault associated with that role.
@@ -83,7 +83,7 @@ $ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d @data.json \
-    http://superuser:$PASSWORD@localhost:9200/_xpack/security/user/vault
+    http://vaultuser:$PASSWORD@localhost:9200/_xpack/security/user/vault
 ```
 
 The contents of `data.json` in this example are:
@@ -170,7 +170,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-superuser-e2978cd0-
+    username           v-vaultuser-e2978cd0-
     ```
 
 ## API

--- a/website/pages/docs/secrets/databases/hanadb.mdx
+++ b/website/pages/docs/secrets/databases/hanadb.mdx
@@ -41,8 +41,8 @@ more information about setting up the database secrets engine.
         plugin_name=hana-database-plugin \
         connection_url="hdb://{{username}}:{{password}}@localhost:1433" \
         allowed_roles="my-role" \
-        username="superuser" \
-        password="superpass"
+        username="vaultuser" \
+        password="vaultpass"
     ```
 
 1.  Configure a role that maps a name in Vault to an SQL statement to execute to
@@ -74,7 +74,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-superuser-e2978cd0-
+    username           v-vaultuser-e2978cd0-
     ```
 
 ## API

--- a/website/pages/docs/secrets/databases/hanadb.mdx
+++ b/website/pages/docs/secrets/databases/hanadb.mdx
@@ -17,6 +17,11 @@ the HANA database.
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| `hanadb-database-plugin` | No | Yes | No |
+
 ## Setup
 
 1.  Enable the database secrets engine if it is not already enabled:
@@ -36,8 +41,8 @@ more information about setting up the database secrets engine.
         plugin_name=hana-database-plugin \
         connection_url="hdb://{{username}}:{{password}}@localhost:1433" \
         allowed_roles="my-role" \
-        username="username" \
-        password="password"
+        username="superuser" \
+        password="superpass"
     ```
 
 1.  Configure a role that maps a name in Vault to an SQL statement to execute to
@@ -69,7 +74,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-root-e2978cd0-
+    username           v-superuser-e2978cd0-
     ```
 
 ## API

--- a/website/pages/docs/secrets/databases/index.mdx
+++ b/website/pages/docs/secrets/databases/index.mdx
@@ -17,7 +17,7 @@ interface. There are a number of builtin database types and an exposed framework
 for running custom database types for extendability. This means that services
 that need to access a database no longer need to hardcode credentials: they can
 request them from Vault, and use Vault's leasing mechanism to more easily roll
-keys.
+keys. These are referred to as "dynamic roles" or "dynamic secrets".
 
 Since every service is accessing the database with unique credentials, it makes
 auditing much easier when questionable data access is discovered. You can track
@@ -37,9 +37,10 @@ When credentials are requested for the Role, Vault returns the current
 password for the configured database user, allowing anyone with the proper
 Vault policies to have access to the user account in the database.
 
-Not all database types support static roles at this time. Please consult the
-specific database documentation on the left navigation to see if a given
-database backend supports static roles.
+~> Not all database types support static roles at this time. Please consult the
+specific database documentation on the left navigation or the table below under
+[Database Capabilities](#database-capabilities) to see if a given database
+backend supports static roles.
 
 ## Setup
 
@@ -68,11 +69,32 @@ management tool.
        password="..."
    ```
 
+   ~> It is highly recommended a super-user is created for Vault to use to
+      manage users rather than using the database's root account.
+
+   Vault will use the user specified here to create/update/revoke database
+   credentials. That user must have the appropriate permissions to perform
+   actions upon other database users.
+
    This secrets engine can configure multiple database connections. For details
    on the specific configuration options, please see the database-specific
    documentation.
 
-1. Configure a role that maps a name in Vault to an SQL statement to execute to create the database credential:
+1. After configuring the user, it is highly recommended to rotate that user's
+   password such that the super-user is not accessible by any users other than
+   Vault itself:
+
+   ```text
+   $ vault write -force database/rotate-root/my-database
+   ```
+
+   When this is done, the password for the user specified in the previous step
+   is no longer accessible. Because of this, it is highly recommended that a
+   super-user is created specifically for Vault to use to manage database
+   users.
+
+1. Configure a role that maps a name in Vault to an SQL statement to execute to
+   create the database credential:
 
    ```text
    $ vault write database/roles/my-role \
@@ -83,7 +105,7 @@ management tool.
    Success! Data written to: database/roles/my-role
    ```
 
-   The `{{name}}` and `{{password}}` fields will be populated by the plugin
+   The `{{username}}` and `{{password}}` fields will be populated by the plugin
    with dynamically generated values. In some plugins the `{{expiration}}`
    field is also be supported.
 
@@ -103,19 +125,39 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-root-e2978cd0-
+    username           v-superuser-e2978cd0-
     ```
+
+## Database Capabilities
+| Database | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| [Cassandra](/docs/secrets/databases/cassandra)        | Yes | Yes | Yes |
+| [Elasticsearch](/docs/secrets/databases/elasticdb)    | Yes | Yes | No  |
+| [HanaDB](/docs/secrets/databases/hanadb)              | No  | Yes | No  |
+| [InfluxDB](/docs/secrets/databases/influxdb)          | Yes | Yes | No  |
+| [MongoDB](/docs/secrets/databases/mongodb)            | No  | Yes | Yes |
+| [MongoDB Atlas](/docs/secrets/databases/mongodbatlas) | No  | Yes | Yes |
+| [MSSQL](/docs/secrets/databases/mssql)                | Yes | Yes | No  |
+| [MySQL/MariaDB](/docs/secrets/databases/mysql-maria)  | Yes | Yes | Yes |
+| [Oracle](/docs/secrets/databases/oracle)              | Yes | Yes | Yes |
+| [PostgreSQL](/docs/secrets/databases/postgresql)      | Yes | Yes | Yes |
+| [Redshift](/docs/secrets/databases/redshift)          | Yes | Yes | Yes |
 
 ## Custom Plugins
 
 This secrets engine allows custom database types to be run through the exposed
-plugin interface. Please see the [custom database plugin](/docs/secrets/databases/custom) for more information.
+plugin interface. Please see the [custom database plugin]
+(/docs/secrets/databases/custom) for more information.
 
 ## Password Generation
 
-Password generation for both static and dynamic database credentials occurs via the ''GetPassword()'' function. For static credentials, the ''SetCredentials()''function is also used on the output of ''GetPassword().''
+Password generation for both static and dynamic database credentials occurs via
+the `GetPassword()` function. For static credentials, the `SetCredentials()`
+function is also used on the output of `GetPassword().`
 
-Please see the [DB plugin credentials source code](https://github.com/hashicorp/vault/blob/master/sdk/database/dbplugin/database.pb.go) for more information.
+Please see the [DB plugin credentials source code]
+(https://github.com/hashicorp/vault/blob/master/sdk/database/dbplugin/database.pb.go)
+for more information.
 
 ## Learn
 

--- a/website/pages/docs/secrets/databases/index.mdx
+++ b/website/pages/docs/secrets/databases/index.mdx
@@ -69,7 +69,7 @@ management tool.
        password="..."
    ```
 
-   ~> It is highly recommended a super-user is created for Vault to use to
+   ~> It is highly recommended a user is created for Vault to use to
       manage users rather than using the database's root account.
 
    Vault will use the user specified here to create/update/revoke database
@@ -81,7 +81,7 @@ management tool.
    documentation.
 
 1. After configuring the user, it is highly recommended to rotate that user's
-   password such that the super-user is not accessible by any users other than
+   password such that the vault user is not accessible by any users other than
    Vault itself:
 
    ```shell
@@ -90,7 +90,7 @@ management tool.
 
    When this is done, the password for the user specified in the previous step
    is no longer accessible. Because of this, it is highly recommended that a
-   super-user is created specifically for Vault to use to manage database
+   user is created specifically for Vault to use to manage database
    users.
 
 1. Configure a role that maps a name in Vault to an SQL statement to execute to
@@ -125,7 +125,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-superuser-e2978cd0-
+    username           v-vaultuser-e2978cd0-
     ```
 
 ## Database Capabilities

--- a/website/pages/docs/secrets/databases/index.mdx
+++ b/website/pages/docs/secrets/databases/index.mdx
@@ -50,7 +50,7 @@ management tool.
 
 1. Enable the database secrets engine:
 
-   ```text
+   ```shell
    $ vault secrets enable database
    Success! Enabled the database secrets engine at: database/
    ```
@@ -60,7 +60,7 @@ management tool.
 
 1. Configure Vault with the proper plugin and connection information:
 
-   ```text
+   ```shell
    $ vault write database/config/my-database \
        plugin_name="..." \
        connection_url="..." \
@@ -84,7 +84,7 @@ management tool.
    password such that the super-user is not accessible by any users other than
    Vault itself:
 
-   ```text
+   ```shell
    $ vault write -force database/rotate-root/my-database
    ```
 
@@ -96,7 +96,7 @@ management tool.
 1. Configure a role that maps a name in Vault to an SQL statement to execute to
    create the database credential:
 
-   ```text
+   ```shell
    $ vault write database/roles/my-role \
        db_name=my-database \
        creation_statements="..." \
@@ -117,7 +117,7 @@ the proper permission, it can generate credentials.
 1.  Generate a new credential by reading from the `/creds` endpoint with the name
     of the role:
 
-    ```text
+    ```shell
     $ vault read database/creds/my-role
     Key                Value
     ---                -----

--- a/website/pages/docs/secrets/databases/influxdb.mdx
+++ b/website/pages/docs/secrets/databases/influxdb.mdx
@@ -1,21 +1,26 @@
 ---
 layout: docs
-page_title: Influxdb - Database - Secrets Engines
-sidebar_title: Influxdb
+page_title: InfluxDB - Database - Secrets Engines
+sidebar_title: InfluxDB
 description: |-
-  Influxdb is one of the supported plugins for the database secrets engine.
+  InfluxDB is one of the supported plugins for the database secrets engine.
   This plugin generates database credentials dynamically based on configured
-  roles for the Influxdb database.
+  roles for the InfluxDB database.
 ---
 
-# Influxdb Database Secrets Engine
+# InfluxDB Database Secrets Engine
 
-Influxdb is one of the supported plugins for the database secrets engine. This
+InfluxDB is one of the supported plugins for the database secrets engine. This
 plugin generates database credentials dynamically based on configured roles for
-the Influxdb database.
+the InfluxDB database.
 
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
+
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| `influxdb-database-plugin` | Yes | Yes | No |
 
 ## Setup
 
@@ -35,8 +40,8 @@ more information about setting up the database secrets engine.
     $ vault write database/config/my-influxdb-database \
         plugin_name="influxdb-database-plugin" \
         host=127.0.0.1 \
-        username=influx-root \
-        password=influx-toor \
+        username=superuser \
+        password=superpass \
         allowed_roles=my-role
     ```
 
@@ -69,12 +74,12 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-root-e2978cd0-
+    username           v-superuser-e2978cd0-
     ```
 
 ## API
 
-The full list of configurable options can be seen in the [Influxdb database
+The full list of configurable options can be seen in the [InfluxDB database
 plugin API](/api/secret/databases/influxdb) page.
 
 For more information on the database secrets engine's HTTP API please see the [Database secret

--- a/website/pages/docs/secrets/databases/influxdb.mdx
+++ b/website/pages/docs/secrets/databases/influxdb.mdx
@@ -40,8 +40,8 @@ more information about setting up the database secrets engine.
     $ vault write database/config/my-influxdb-database \
         plugin_name="influxdb-database-plugin" \
         host=127.0.0.1 \
-        username=superuser \
-        password=superpass \
+        username=vaultuser \
+        password=vaultpass \
         allowed_roles=my-role
     ```
 
@@ -74,7 +74,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-superuser-e2978cd0-
+    username           v-vaultuser-e2978cd0-
     ```
 
 ## API

--- a/website/pages/docs/secrets/databases/mongodb.mdx
+++ b/website/pages/docs/secrets/databases/mongodb.mdx
@@ -42,8 +42,8 @@ more information about setting up the database secrets engine.
         plugin_name=mongodb-database-plugin \
         allowed_roles="my-role" \
         connection_url="mongodb://{{username}}:{{password}}@mongodb.acme.com:27017/admin?tls=true" \
-        username="superuser" \
-        password="superpass!"
+        username="vaultuser" \
+        password="vaultpass!"
     ```
 
 1.  Configure a role that maps a name in Vault to a MongoDB command that executes and
@@ -74,7 +74,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-superuser-e2978cd0-
+    username           v-vaultuser-e2978cd0-
     ```
 
 ## Client x509 Certificate Authentication

--- a/website/pages/docs/secrets/databases/mongodb.mdx
+++ b/website/pages/docs/secrets/databases/mongodb.mdx
@@ -18,6 +18,11 @@ the MongoDB database and also supports
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| `mongodb-database-plugin` | No | Yes | Yes |
+
 ## Setup
 
 1.  Enable the database secrets engine if it is not already enabled:
@@ -37,8 +42,8 @@ more information about setting up the database secrets engine.
         plugin_name=mongodb-database-plugin \
         allowed_roles="my-role" \
         connection_url="mongodb://{{username}}:{{password}}@mongodb.acme.com:27017/admin?tls=true" \
-        username="admin" \
-        password="Password!"
+        username="superuser" \
+        password="superpass!"
     ```
 
 1.  Configure a role that maps a name in Vault to a MongoDB command that executes and
@@ -69,7 +74,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-root-e2978cd0-
+    username           v-superuser-e2978cd0-
     ```
 
 ## Client x509 Certificate Authentication

--- a/website/pages/docs/secrets/databases/mongodbatlas.mdx
+++ b/website/pages/docs/secrets/databases/mongodbatlas.mdx
@@ -17,6 +17,11 @@ MongoDB Atlas databases.
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| `mongodbatlas-database-plugin` | No | Yes | Yes |
+
 ## Setup
 
 1.  Enable the database secrets engine if it is not already enabled:

--- a/website/pages/docs/secrets/databases/mssql.mdx
+++ b/website/pages/docs/secrets/databases/mssql.mdx
@@ -42,7 +42,7 @@ more information about setting up the database secrets engine.
         plugin_name=mssql-database-plugin \
         connection_url='sqlserver://{{username}}:{{password}}@localhost:1433' \
         allowed_roles="my-role" \
-        username="superuser" \
+        username="vaultuser" \
         password="yourStrong(!)Password"
     ```
 
@@ -91,7 +91,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-superuser-e2978cd0-
+    username           v-vaultuser-e2978cd0-
     ```
 
 ## Example for Azure SQL Database

--- a/website/pages/docs/secrets/databases/mssql.mdx
+++ b/website/pages/docs/secrets/databases/mssql.mdx
@@ -18,6 +18,11 @@ the MSSQL database.
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| `mssql-database-plugin` | Yes | Yes | Yes |
+
 ## Setup
 
 1.  Enable the database secrets engine if it is not already enabled:
@@ -37,7 +42,7 @@ more information about setting up the database secrets engine.
         plugin_name=mssql-database-plugin \
         connection_url='sqlserver://{{username}}:{{password}}@localhost:1433' \
         allowed_roles="my-role" \
-        username="sa" \
+        username="superuser" \
         password="yourStrong(!)Password"
     ```
 
@@ -86,7 +91,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-root-e2978cd0-
+    username           v-superuser-e2978cd0-
     ```
 
 ## Example for Azure SQL Database

--- a/website/pages/docs/secrets/databases/mysql-maria.mdx
+++ b/website/pages/docs/secrets/databases/mysql-maria.mdx
@@ -28,6 +28,11 @@ accept different lengths. The available plugins are:
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| Depends (see: [above](#mysql-mariadb-database-secrets-engine)) | Yes | Yes | Yes |
+
 ## Setup
 
 1.  Enable the database secrets engine if it is not already enabled:
@@ -47,8 +52,8 @@ more information about setting up the database secrets engine.
         plugin_name=mysql-database-plugin \
         connection_url="{{username}}:{{password}}@tcp(127.0.0.1:3306)/" \
         allowed_roles="my-role" \
-        username="root" \
-        password="mysql"
+        username="superuser" \
+        password="superpass"
     ```
 
 1.  Configure a role that maps a name in Vault to an SQL statement to execute to
@@ -79,7 +84,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-root-e2978cd0-
+    username           v-superuser-e2978cd0-
     ```
 
 ## Examples

--- a/website/pages/docs/secrets/databases/mysql-maria.mdx
+++ b/website/pages/docs/secrets/databases/mysql-maria.mdx
@@ -52,8 +52,8 @@ more information about setting up the database secrets engine.
         plugin_name=mysql-database-plugin \
         connection_url="{{username}}:{{password}}@tcp(127.0.0.1:3306)/" \
         allowed_roles="my-role" \
-        username="superuser" \
-        password="superpass"
+        username="vaultuser" \
+        password="vaultpass"
     ```
 
 1.  Configure a role that maps a name in Vault to an SQL statement to execute to
@@ -84,7 +84,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-superuser-e2978cd0-
+    username           v-vaultuser-e2978cd0-
     ```
 
 ## Examples

--- a/website/pages/docs/secrets/databases/oracle.mdx
+++ b/website/pages/docs/secrets/databases/oracle.mdx
@@ -69,31 +69,35 @@ you will need to enable ipc_lock capabilities for the plugin binary.
         password="myreallysecurepassword"
     ```
 
-~> It is highly recommended that you immediately rotate the "root" user's password. (see [Rotate Root Credentials]
-   (/api-docs/secret/databases#rotate-root-credentials)).
+   When specifying the `connection_url` field, it will likely need to connect to one of the pluggable databases
+   and not the container database level.
 
-!> **Use caution:** the root user's password will no longer be accessible once rotated so it is highly
+1. It is highly recommended that you immediately rotate the "root" user's password. (see [Rotate Root Credentials]
+   (/api-docs/secret/databases#rotate-root-credentials)). This will ensure that only Vault is able to access
+   the "root" user that Vault uses to manipulate dynamic & static credentials.
+
+   !> **Use caution:** the root user's password will not be accessible once rotated so it is highly
    recommended that you create a super-user for Vault to utilize rather than using the actual root user.
 
-1.  Configure a role that maps a name in Vault to an SQL statement to execute to
-    create the database credential:
+1. Configure a role that maps a name in Vault to an SQL statement to execute to
+   create the database credential:
 
-    ```shell
-    $ vault write database/roles/my-role \
-        db_name=my-oracle-database \
-        creation_statements="CREATE USER {{name}} IDENTIFIED BY {{password}}; GRANT CONNECT TO {{name}}; GRANT CREATE SESSION TO {{name}};" \
-        default_ttl="1h" \
-        max_ttl="24h"
-    Success! Data written to: database/roles/my-role
-    ```
+   ```shell
+   $ vault write database/roles/my-role \
+       db_name=my-oracle-database \
+       creation_statements="CREATE USER {{name}} IDENTIFIED BY {{password}}; GRANT CONNECT TO {{name}}; GRANT CREATE SESSION TO {{name}};" \
+       default_ttl="1h" \
+       max_ttl="24h"
+   Success! Data written to: database/roles/my-role
+   ```
 
-    Note: The `creation_statements` may be specified in a file and interpreted by the Vault CLI using the `@` symbol:
+   Note: The `creation_statements` may be specified in a file and interpreted by the Vault CLI using the `@` symbol:
 
-    ```shell
-    $ vault write database/roles/my-role \
-        creation_statements=@creation_statements.sql \
-        ...
-    ```
+   ```shell
+   $ vault write database/roles/my-role \
+       creation_statements=@creation_statements.sql \
+       ...
+   ```
 
     See the [Commands](/docs/commands#files) docs for more details.
 

--- a/website/pages/docs/secrets/databases/oracle.mdx
+++ b/website/pages/docs/secrets/databases/oracle.mdx
@@ -10,17 +10,21 @@ description: |-
 
 # Oracle Database Secrets Engine
 
-Oracle is one of the supported plugins for the database secrets engine. This
-plugin generates database credentials dynamically based on configured roles for
-the Oracle database and also supports [Static Roles](/docs/secrets/databases#static-roles).
-the Oracle database and also supports [Static Roles](/docs/secrets/databases#static-roles).
+This secrets engine is a part of the Database Secrets Engine. If you have not read the [Database Backend]
+(/docs/secrets/databases) page, please do so now as it explains how to set up the database backend and
+gives an overview of how the engine functions.
+
+Oracle is one of the supported plugins for the database secrets engine. It is capable of dynamically generating
+credentials based on configured roles for Oracle databases. It also supports [Static Roles](/docs/secrets/databases#static-roles).
 
 ~> The Oracle database plugin is not bundled in the core Vault code tree and can be
 found at its own git repository here:
 [hashicorp/vault-plugin-database-oracle](https://github.com/hashicorp/vault-plugin-database-oracle)
 
-See the [Database Backend](/docs/secrets/databases) docs for more
-information about setting up the Database Backend.
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| Customizable (see: [Custom Plugins](/docs/secrets/databases/custom)) | Yes | Yes | Yes |
 
 ## Setup
 
@@ -38,7 +42,7 @@ you will need to enable ipc_lock capabilities for the plugin binary.
 
 1.  Enable the database secrets engine if it is not already enabled:
 
-    ```text
+    ```shell
     $ vault secrets enable database
     Success! Enabled the database secrets engine at: database/
     ```
@@ -48,7 +52,7 @@ you will need to enable ipc_lock capabilities for the plugin binary.
 
 1.  Download and register the plugin:
 
-    ```text
+    ```shell
     $ vault write sys/plugins/catalog/database/oracle-database-plugin \
         sha256="..." \
         command=vault-plugin-database-oracle
@@ -56,17 +60,25 @@ you will need to enable ipc_lock capabilities for the plugin binary.
 
 1.  Configure Vault with the proper plugin and connection information:
 
-    ```text
+    ```shell
     $ vault write database/config/my-oracle-database \
         plugin_name=oracle-database-plugin \
-        connection_url="system/Oracle@localhost:1521/OraDoc.localhost" \
-        allowed_roles="my-role"
+        connection_url="{{username}}/{{password}}@localhost:1521/OraDoc.localhost" \
+        allowed_roles="my-role" \
+        username="VAULT_SUPER_USER" \
+        password="myreallysecurepassword"
     ```
+
+~> It is highly recommended that you immediately rotate the "root" user's password. (see [Rotate Root Credentials]
+   (/api-docs/secret/databases#rotate-root-credentials)).
+
+!> **Use caution:** the root user's password will no longer be accessible once rotated so it is highly
+   recommended that you create a super-user for Vault to utilize rather than using the actual root user.
 
 1.  Configure a role that maps a name in Vault to an SQL statement to execute to
     create the database credential:
 
-    ```text
+    ```shell
     $ vault write database/roles/my-role \
         db_name=my-oracle-database \
         creation_statements="CREATE USER {{name}} IDENTIFIED BY {{password}}; GRANT CONNECT TO {{name}}; GRANT CREATE SESSION TO {{name}};" \
@@ -75,7 +87,19 @@ you will need to enable ipc_lock capabilities for the plugin binary.
     Success! Data written to: database/roles/my-role
     ```
 
+    Note: The `creation_statements` may be specified in a file and interpreted by the Vault CLI using the `@` symbol:
+
+    ```shell
+    $ vault write database/roles/my-role \
+        creation_statements=@creation_statements.sql \
+        ...
+    ```
+
+    See the [Commands](/docs/commands#files) docs for more details.
+
 ## Usage
+
+### Dynamic Credentials
 
 After the secrets engine is configured and a user/machine has a Vault token with
 the proper permission, it can generate credentials.

--- a/website/pages/docs/secrets/databases/oracle.mdx
+++ b/website/pages/docs/secrets/databases/oracle.mdx
@@ -77,7 +77,7 @@ you will need to enable ipc_lock capabilities for the plugin binary.
    the "root" user that Vault uses to manipulate dynamic & static credentials.
 
    !> **Use caution:** the root user's password will not be accessible once rotated so it is highly
-   recommended that you create a super-user for Vault to utilize rather than using the actual root user.
+   recommended that you create a user for Vault to utilize rather than using the actual root user.
 
 1. Configure a role that maps a name in Vault to an SQL statement to execute to
    create the database credential:

--- a/website/pages/docs/secrets/databases/oracle.mdx
+++ b/website/pages/docs/secrets/databases/oracle.mdx
@@ -69,8 +69,8 @@ you will need to enable ipc_lock capabilities for the plugin binary.
         password="myreallysecurepassword"
     ```
 
-   When specifying the `connection_url` field, it will likely need to connect to one of the pluggable databases
-   and not the container database level.
+   If the version of Oracle you are using has a container database, you will need to connect to one of the
+   pluggable databases rather than the container database in the `connection_url` field.
 
 1. It is highly recommended that you immediately rotate the "root" user's password. (see [Rotate Root Credentials]
    (/api-docs/secret/databases#rotate-root-credentials)). This will ensure that only Vault is able to access

--- a/website/pages/docs/secrets/databases/postgresql.mdx
+++ b/website/pages/docs/secrets/databases/postgresql.mdx
@@ -49,8 +49,8 @@ options, including SSL options, can be found
         plugin_name=postgresql-database-plugin \
         allowed_roles="my-role" \
         connection_url="postgresql://{{username}}:{{password}}@localhost:5432/" \
-        username="superuser" \
-        password="root"
+        username="vaultuser" \
+        password="vaultpass"
     ```
 
 1.  Configure a role that maps a name in Vault to an SQL statement to execute to
@@ -82,7 +82,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-superuse-e2978cd0-
+    username           v-vaultuse-e2978cd0-
     ```
 
 ## API

--- a/website/pages/docs/secrets/databases/postgresql.mdx
+++ b/website/pages/docs/secrets/databases/postgresql.mdx
@@ -25,6 +25,11 @@ backend](/docs/configuration/storage/postgresql).  Connection string
 options, including SSL options, can be found
 [here](https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters)
 
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| `postgresql-database-plugin` | Yes | Yes | Yes |
+
 ## Setup
 
 1.  Enable the database secrets engine if it is not already enabled:
@@ -44,7 +49,7 @@ options, including SSL options, can be found
         plugin_name=postgresql-database-plugin \
         allowed_roles="my-role" \
         connection_url="postgresql://{{username}}:{{password}}@localhost:5432/" \
-        username="root" \
+        username="superuser" \
         password="root"
     ```
 
@@ -77,7 +82,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-root-e2978cd0-
+    username           v-superuse-e2978cd0-
     ```
 
 ## API

--- a/website/pages/docs/secrets/databases/redshift.mdx
+++ b/website/pages/docs/secrets/databases/redshift.mdx
@@ -42,8 +42,8 @@ more information about setting up the database secrets engine.
         plugin_name=redshift-database-plugin \
         allowed_roles="my-role" \
         connection_url="postgresql://{{username}}:{{password}}@localhost:5432/<optional: db-name>" \
-        username="superuser" \
-        password="superpass"
+        username="vaultuser" \
+        password="vaultpass"
     ```
 
 1.  Configure a role that maps a name in Vault to a SQL statement to execute which
@@ -75,7 +75,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-superuse-e2978cd0-
+    username           v-vaultuse-e2978cd0-
     ```
 
 ## API

--- a/website/pages/docs/secrets/databases/redshift.mdx
+++ b/website/pages/docs/secrets/databases/redshift.mdx
@@ -18,6 +18,11 @@ Roles](/docs/secrets/databases#static-roles).
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.
 
+## Capabilities
+| Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
+| --- | --- | --- | --- |
+| `redshift-database-plugin` | Yes | Yes | Yes |
+
 ## Setup
 
 1.  Enable the database secrets engine if it is not already enabled:
@@ -37,11 +42,11 @@ more information about setting up the database secrets engine.
         plugin_name=redshift-database-plugin \
         allowed_roles="my-role" \
         connection_url="postgresql://{{username}}:{{password}}@localhost:5432/<optional: db-name>" \
-        username="root" \
-        password="root"
+        username="superuser" \
+        password="superpass"
     ```
 
-1.  Configure a role that maps a name in Vault to a SQL statement to execute which 
+1.  Configure a role that maps a name in Vault to a SQL statement to execute which
     creates the database credential:
 
     ```text
@@ -70,7 +75,7 @@ the proper permission, it can generate credentials.
     lease_duration     1h
     lease_renewable    true
     password           8cab931c-d62e-a73d-60d3-5ee85139cd66
-    username           v-root-e2978cd0-
+    username           v-superuse-e2978cd0-
     ```
 
 ## API


### PR DESCRIPTION
* Adds a summary to the top of each plugin's page showing the capabilities that the plugin has.
* Fixed sidebar sorting (they weren't quite alpabetical)
* Improved instructions for using the Oracle plugin
  * Added note about using the pluggable database rather than the container database
* Replaced admin/root usernames with super-user ones to encourage users to not use the root user in Vault
* Included suggestions to rotate the root user's password when the plugin is capable
* Improve documentation around rotating the root user's password
* Fixed various typos