### PR TITLE
Define Consul version to test against in one place

### DIFF
--- a/builtin/logical/consul/backend_test.go
+++ b/builtin/logical/consul/backend_test.go
@@ -23,9 +23,9 @@ func TestBackend_Config_Access(t *testing.T) {
 			t.Parallel()
 			testBackendConfigAccess(t, "1.3.0")
 		})
-		t.Run("1.4.0-rc", func(t *testing.T) {
+		t.Run("post-1.4.0", func(t *testing.T) {
 			t.Parallel()
-			testBackendConfigAccess(t, "1.4.0-rc1")
+			testBackendConfigAccess(t, "")
 		})
 	})
 }
@@ -83,14 +83,14 @@ func TestBackend_Renew_Revoke(t *testing.T) {
 			t.Parallel()
 			testBackendRenewRevoke(t, "1.3.0")
 		})
-		t.Run("1.4.0-rc", func(t *testing.T) {
+		t.Run("post-1.4.0", func(t *testing.T) {
 			t.Parallel()
 			t.Run("legacy", func(t *testing.T) {
 				t.Parallel()
-				testBackendRenewRevoke(t, "1.4.0-rc1")
+				testBackendRenewRevoke(t, "")
 			})
 
-			testBackendRenewRevoke14(t, "1.4.0-rc1")
+			testBackendRenewRevoke14(t, "")
 		})
 	})
 }
@@ -317,7 +317,7 @@ func TestBackend_LocalToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cleanup, connURL, connToken := consul.PrepareTestContainer(t, "1.4.0-rc1")
+	cleanup, connURL, connToken := consul.PrepareTestContainer(t, "")
 	defer cleanup()
 	connData := map[string]interface{}{
 		"address": connURL,
@@ -444,9 +444,9 @@ func TestBackend_Management(t *testing.T) {
 			t.Parallel()
 			testBackendManagement(t, "1.3.0")
 		})
-		t.Run("1.4.0-rc", func(t *testing.T) {
+		t.Run("post-1.4.0", func(t *testing.T) {
 			t.Parallel()
-			testBackendManagement(t, "1.4.0-rc1")
+			testBackendManagement(t, "")
 		})
 	})
 }
@@ -483,14 +483,14 @@ func TestBackend_Basic(t *testing.T) {
 			t.Parallel()
 			testBackendBasic(t, "1.3.0")
 		})
-		t.Run("1.4.0-rc", func(t *testing.T) {
+		t.Run("post-1.4.0", func(t *testing.T) {
 			t.Parallel()
 			t.Run("legacy", func(t *testing.T) {
 				t.Parallel()
-				testBackendRenewRevoke(t, "1.4.0-rc1")
+				testBackendRenewRevoke(t, "")
 			})
 
-			testBackendBasic(t, "1.4.0-rc1")
+			testBackendBasic(t, "")
 		})
 	})
 }

--- a/helper/testhelpers/consul/consulhelper.go
+++ b/helper/testhelpers/consul/consulhelper.go
@@ -11,6 +11,10 @@ import (
 	"github.com/ory/dockertest"
 )
 
+// PrepareTestContainer creates a Consul docker container.  If version is empty,
+// the Consul version used will be given by the environment variable
+// CONSUL_DOCKER_VERSION, or if that's empty, whatever we've hardcoded as the
+// the latest Consul version.
 func PrepareTestContainer(t *testing.T, version string) (cleanup func(), retAddress string, consulToken string) {
 	t.Logf("preparing test container")
 	consulToken = os.Getenv("CONSUL_HTTP_TOKEN")
@@ -25,6 +29,14 @@ func PrepareTestContainer(t *testing.T, version string) (cleanup func(), retAddr
 	}
 
 	config := `acl { enabled = true default_policy = "deny" }`
+	if version == "" {
+		consulVersion := os.Getenv("CONSUL_DOCKER_VERSION")
+		if consulVersion != "" {
+			version = consulVersion
+		} else {
+			version = "1.7.2" // Latest Consul version, update as new releases come out
+		}
+	}
 	if strings.HasPrefix(version, "1.3") {
 		config = `datacenter = "test" acl_default_policy = "deny" acl_datacenter = "test" acl_master_token = "test"`
 	}

--- a/helper/testhelpers/teststorage/teststorage.go
+++ b/helper/testhelpers/teststorage/teststorage.go
@@ -83,7 +83,7 @@ func MakeFileBackend(t testing.T, logger hclog.Logger) *vault.PhysicalBackendBun
 }
 
 func MakeConsulBackend(t testing.T, logger hclog.Logger) *vault.PhysicalBackendBundle {
-	cleanup, consulAddress, consulToken := consul.PrepareTestContainer(t.(*realtesting.T), "1.4.0-rc1")
+	cleanup, consulAddress, consulToken := consul.PrepareTestContainer(t.(*realtesting.T), "")
 	consulConf := map[string]string{
 		"address":      consulAddress,
 		"token":        consulToken,

--- a/serviceregistration/consul/consul_service_registration_test.go
+++ b/serviceregistration/consul/consul_service_registration_test.go
@@ -52,7 +52,7 @@ func testConsulServiceRegistrationConfig(t *testing.T, conf *consulConf) *servic
 func TestConsul_ServiceRegistration(t *testing.T) {
 
 	// Prepare a docker-based consul instance
-	cleanup, addr, token := consul.PrepareTestContainer(t, "1.4.0-rc1")
+	cleanup, addr, token := consul.PrepareTestContainer(t, "")
 	defer cleanup()
 
 	// Create a consul client


### PR DESCRIPTION
…, and let it be overriden by environment.  Exception: some tests that verify interoperability with older Consul versions still specify a version explicitly.