### PR TITLE
Ui/replication/primary reindexing

### DIFF
--- a/ui/app/adapters/cluster.js
+++ b/ui/app/adapters/cluster.js
@@ -159,7 +159,7 @@ export default ApplicationAdapter.extend({
 
   urlForReplication(replicationMode, clusterMode, endpoint) {
     let suffix;
-    const errString = `Calls to replication ${endpoint} endpoint are not currently allowed in the vault cluster adapter`;
+    const errString = `Calls to replication ${endpoint} endpoint are not currently allowed in the vault cluster adapater`;
     if (clusterMode) {
       assert(errString, REPLICATION_ENDPOINTS[clusterMode].includes(endpoint));
       suffix = `${replicationMode}/${clusterMode}/${endpoint}`;

--- a/ui/app/adapters/cluster.js
+++ b/ui/app/adapters/cluster.js
@@ -159,7 +159,7 @@ export default ApplicationAdapter.extend({
 
   urlForReplication(replicationMode, clusterMode, endpoint) {
     let suffix;
-    const errString = `Calls to replication ${endpoint} endpoint are not currently allowed in the vault cluster adapater`;
+    const errString = `Calls to replication ${endpoint} endpoint are not currently allowed in the vault cluster adapter`;
     if (clusterMode) {
       assert(errString, REPLICATION_ENDPOINTS[clusterMode].includes(endpoint));
       suffix = `${replicationMode}/${clusterMode}/${endpoint}`;

--- a/ui/app/adapters/replication-mode.js
+++ b/ui/app/adapters/replication-mode.js
@@ -1,0 +1,14 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+  getStatusUrl(mode) {
+    return this.buildURL() + `/replication/${mode}/status`;
+  },
+
+  fetchStatus(mode) {
+    let url = this.getStatusUrl(mode);
+    return this.ajax(url, 'GET', { unauthenticated: true }).then(resp => {
+      return resp.data;
+    });
+  },
+});

--- a/ui/app/models/replication-mode.js
+++ b/ui/app/models/replication-mode.js
@@ -1,0 +1,38 @@
+import DS from 'ember-data';
+const { attr } = DS;
+
+/* sample response
+
+{
+  "request_id": "d81bba81-e8a1-0ee9-240e-a77d36e3e08f",
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": {
+    "cluster_id": "ab7d4191-d1a3-b4d6-6297-5a41af6154ae",
+    "known_secondaries": [
+      "test"
+    ],
+    "last_performance_wal": 72,
+    "last_reindex_epoch": "1588281113",
+    "last_wal": 73,
+    "merkle_root": "c8d258d376f01d98156f74e8d8f82ea2aca8dc4a",
+    "mode": "primary",
+    "primary_cluster_addr": "",
+    "reindex_building_progress": 26838,
+    "reindex_building_total": 305443,
+    "reindex_in_progress": true,
+    "reindex_stage": "building",
+    "state": "running"
+  },
+  "wrap_info": null,
+  "warnings": null,
+  "auth": null
+}
+
+
+*/
+
+export default DS.Model.extend({
+  status: attr('object'),
+});

--- a/ui/app/serializers/replication-mode.js
+++ b/ui/app/serializers/replication-mode.js
@@ -1,0 +1,12 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+    const normalizedPayload = {
+      id: payload.id,
+      status: payload.data,
+    };
+
+    return this._super(store, primaryModelClass, normalizedPayload, id, requestType);
+  },
+});

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -29,8 +29,7 @@ export default Component.extend({
   }),
   reindexingProgress: computed('replicationDetails', function() {
     // TODO: use this value to display a progress bar
-    const { replicationDetails } = this;
-    const { reindex_building_progress, reindex_building_total } = replicationDetails;
+    const { reindex_building_progress, reindex_building_total } = this.replicationDetails;
     let progress = 0;
 
     if (reindex_building_progress && reindex_building_total) {

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -8,7 +8,6 @@ export default Component.extend({
   data: null,
   replicationDetails: null,
   isSecondary: null,
-  dr: null,
   isSyncing: computed('replicationDetails', 'isSecondary', function() {
     const { state } = this.replicationDetails;
     const isSecondary = this.isSecondary;
@@ -26,5 +25,18 @@ export default Component.extend({
       return `: ${stage}`;
     }
     return '';
+  }),
+  reindexingProgress: computed('replicationDetails', function() {
+    // TODO: use this value to display a progress bar
+    const { replicationDetails } = this;
+    const { reindex_building_progress, reindex_building_total } = replicationDetails;
+    let progress = '';
+
+    if (reindex_building_progress && reindex_building_total) {
+      // convert progress to a percentage
+      progress = (reindex_building_progress / reindex_building_total) * 100;
+    }
+
+    return progress;
   }),
 });

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { clusterStates } from 'core/helpers/cluster-states';
+import { capitalize } from '@ember/string';
 import layout from '../templates/components/replication-dashboard';
 
 export default Component.extend({
@@ -22,7 +23,7 @@ export default Component.extend({
     const stage = replicationDetails.reindex_stage;
     // specify the stage if we have one
     if (stage) {
-      return `: ${stage}`;
+      return `: ${capitalize(stage)}`;
     }
     return '';
   }),
@@ -30,7 +31,7 @@ export default Component.extend({
     // TODO: use this value to display a progress bar
     const { replicationDetails } = this;
     const { reindex_building_progress, reindex_building_total } = replicationDetails;
-    let progress = '';
+    let progress = 0;
 
     if (reindex_building_progress && reindex_building_total) {
       // convert progress to a percentage

--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -14,8 +14,17 @@ export default Component.extend({
     const isSecondary = this.isSecondary;
     return isSecondary && state && clusterStates([state]).isSyncing;
   }),
-  isReindexing: computed('data', function() {
-    // TODO: make this a real value
-    return false;
+  isReindexing: computed('replicationDetails', function() {
+    const { replicationDetails } = this;
+    return !!replicationDetails.reindex_in_progress;
+  }),
+  reindexingStage: computed('replicationDetails', function() {
+    const { replicationDetails } = this;
+    const stage = replicationDetails.reindex_stage;
+    // specify the stage if we have one
+    if (stage) {
+      return `: ${stage}`;
+    }
+    return '';
   }),
 });

--- a/ui/lib/core/addon/mixins/replication-actions.js
+++ b/ui/lib/core/addon/mixins/replication-actions.js
@@ -28,7 +28,6 @@ export default Mixin.create({
       }, {});
       delete data.replicationMode;
     }
-
     return yield this.save.perform(action, replicationMode, clusterMode, data);
   }),
 

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -16,7 +16,7 @@
   {{!-- TODO check for actual reindexing status --}}
   {{#if isReindexing}}
     <AlertBanner
-      @title="Re-indexing in progress: Scanning"
+      @title={{concat "Re-indexing in progress" reindexingStage}}
       @type="info"
       @secondIconType="loading"
       @message="This can cause a delay depending on the size of the data store. You can use Vault during this time."/>

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -13,7 +13,6 @@
     {{/if}}
   {{/if}}
 
-  {{!-- TODO check for actual reindexing status --}}
   {{#if isReindexing}}
     <AlertBanner
       @title={{concat "Re-indexing in progress" reindexingStage}}

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -2,7 +2,7 @@
 {{yield (hash
   header=(component 'replication-header' data=model title=replicationMode isSecondary=isSecondary)
   toggle=(component 'replication-toggle')
-  dashboard=(component 'replication-dashboard' data=model isSecondary=isSecondary replicationDetails=replicationDetails clusterMode=clusterMode)
+  dashboard=(component 'replication-dashboard' data=model isSecondary=isSecondary replicationDetails=replicationDetails clusterMode=clusterMode reindexingDetails=reindexingDetails)
   isDisabled=isDisabled
   message=message
 )}}

--- a/ui/lib/core/addon/templates/components/replication-page.hbs
+++ b/ui/lib/core/addon/templates/components/replication-page.hbs
@@ -1,9 +1,18 @@
 <div class="replication-page">
-{{yield (hash
-  header=(component 'replication-header' data=model title=replicationMode isSecondary=isSecondary)
-  toggle=(component 'replication-toggle')
-  dashboard=(component 'replication-dashboard' data=model isSecondary=isSecondary replicationDetails=replicationDetails clusterMode=clusterMode reindexingDetails=reindexingDetails)
-  isDisabled=isDisabled
-  message=message
-)}}
+  {{yield
+    (hash
+      header=(component 'replication-header' data=model title=replicationMode isSecondary=isSecondary)
+      toggle=(component 'replication-toggle')
+      dashboard=(component
+        'replication-dashboard'
+        data=model
+        isSecondary=isSecondary
+        replicationDetails=replicationDetails
+        clusterMode=clusterMode
+        reindexingDetails=reindexingDetails
+      )
+      isDisabled=isDisabled
+      message=message
+    )
+  }}
 </div>

--- a/ui/lib/replication/addon/templates/components/replication-summary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-summary.hbs
@@ -332,7 +332,6 @@
     <p>{{cluster.replicationModeStatus.cluster_id}}</p>
     <div class="replication">
       <ReplicationPage @model={{cluster}} as |Page|>
-        <Page.toggle />
         <Page.dashboard @data={{cluster}} @componentToRender='replication-primary-card' as |Dashboard|>
           <Dashboard.card
             @title='State'

--- a/ui/lib/replication/addon/templates/components/replication-summary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-summary.hbs
@@ -329,6 +329,7 @@
   {{#if (eq replicationAttrs.mode 'initializing')}}
     The cluster is initializing replication. This may take some time.
   {{else}}
+    <p>{{cluster.replicationModeStatus.cluster_id}}</p>
     <div class="replication">
       <ReplicationPage @model={{cluster}} as |Page|>
         <Page.toggle />

--- a/ui/tests/acceptance/replication/dr/secondary-test.js
+++ b/ui/tests/acceptance/replication/dr/secondary-test.js
@@ -4,7 +4,7 @@ import { currentURL, visit } from '@ember/test-helpers';
 
 import authPage from 'vault/tests/pages/auth';
 
-module('Acceptance | DR secondary details', function(hooks) {
+module('Acceptance | Enterprise | DR secondary details', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function() {


### PR DESCRIPTION
# Add Reindexing alert banner to Primary Dashboards
This PR adds an AlertBanner when the Primary or Secondary cluster is reindexing. The progress bar and tests will be added in a follow-up PR since the `ReplicationDashboard` tests are still being written.
## Examples
### on a DR Primary
![image](https://user-images.githubusercontent.com/903288/81124898-7931ff80-8eeb-11ea-91e9-e385ef5055fc.png)

### on a DR Secondary
note: I left the lack of margin above the `AlertBanner` in this case because per the most recent design mocks this section is going to be removed.
![image](https://user-images.githubusercontent.com/903288/81125042-dfb71d80-8eeb-11ea-94f6-b9c7de822f97.png)
