### PR TITLE
UI/Fix snowman that appears when namespaces have more than one period

### DIFF
--- a/ui/app/components/namespace-link.js
+++ b/ui/app/components/namespace-link.js
@@ -14,7 +14,7 @@ export default Component.extend({
 
   normalizedNamespace: computed('targetNamespace', function() {
     let ns = this.get('targetNamespace');
-    return (ns || '').replace(/\.+/g, '/').replace('☃', '.');
+    return (ns || '').replace(/\.+/g, '/').replace(/\☃/g, '.');
   }),
 
   namespaceDisplay: computed('normalizedNamespace', 'showLastSegment', function() {

--- a/ui/app/components/namespace-link.js
+++ b/ui/app/components/namespace-link.js
@@ -14,7 +14,7 @@ export default Component.extend({
 
   normalizedNamespace: computed('targetNamespace', function() {
     let ns = this.get('targetNamespace');
-    return (ns || '').replace(/\.+/g, '/').replace(/\☃/g, '.');
+    return (ns || '').replace(/\.+/g, '/').replace(/☃/g, '.');
   }),
 
   namespaceDisplay: computed('normalizedNamespace', 'showLastSegment', function() {


### PR DESCRIPTION
This fixes a bug where ⛄ (used as a placeholder for `.`) was not getting replaced back to periods globally. See screenshots

NOTE: Not sure which milestone to add to this one. Next bugfix release?

**Before**
<img width="321" alt="Screen Shot 2020-04-30 at 5 11 55 PM" src="https://user-images.githubusercontent.com/16182107/80814490-9b491c00-8b91-11ea-8d99-89883e39861c.png">
Clicking on the snowman namespace takes you to a borked page:
<img width="1440" alt="Screen Shot 2020-05-01 at 12 02 24 PM" src="https://user-images.githubusercontent.com/16182107/80824275-b7ee4f80-8ba3-11ea-84ed-155054d02efc.png">


**After**
<img width="427" alt="Screen Shot 2020-05-01 at 9 31 16 AM" src="https://user-images.githubusercontent.com/16182107/80814509-a4d28400-8b91-11ea-90fb-bcb8201716d9.png">
<img width="438" alt="Screen Shot 2020-05-01 at 9 31 10 AM" src="https://user-images.githubusercontent.com/16182107/80814514-a734de00-8b91-11ea-83ce-fdd7a30dd24e.png">
