### PR TITLE
Factor out test logger creation

### DIFF
--- a/vault/external_tests/identity/identity_test.go
+++ b/vault/external_tests/identity/identity_test.go
@@ -12,7 +12,6 @@ import (
 	ldaphelper "github.com/hashicorp/vault/helper/testhelpers/ldap"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/ldaputil"
-	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
@@ -332,7 +331,6 @@ func TestIdentityStore_Integ_RemoveFromExternalGroup(t *testing.T) {
 
 	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
-		Logger:      logging.NewVaultLogger(log.Debug),
 	})
 
 	cluster.Start()

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1084,6 +1084,38 @@ type certInfo struct {
 	keyPEM    []byte
 }
 
+type TestLogger struct {
+	hclog.Logger
+	Path string
+	File *os.File
+}
+
+func NewTestLogger(t testing.T) *TestLogger {
+	var logDir = os.Getenv("VAULT_TEST_LOG_DIR")
+	if logDir == "" {
+		return &TestLogger{
+			Logger: logging.NewVaultLogger(log.Trace).Named(t.Name()),
+		}
+	}
+
+	logFileName := filepath.Join(logDir, t.Name()+".log")
+	// t.Name may include slashes.
+	dir, _ := filepath.Split(logFileName)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	logFile, err := os.Create(logFileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &TestLogger{
+		Path:   logFileName,
+		File:   logFile,
+		Logger: logging.NewVaultLoggerWithWriter(logFile, log.Trace),
+	}
+}
+
 // NewTestCluster creates a new test cluster based on the provided core config
 // and test cluster options.
 //
@@ -1132,31 +1164,11 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 
 	var testCluster TestCluster
 
-	var logDir = os.Getenv("VAULT_TEST_LOG_DIR")
-	var logFileName string
-	var logFile *os.File
-
 	switch {
 	case opts != nil && opts.Logger != nil:
 		testCluster.Logger = opts.Logger
-	case logDir != "":
-		// This is not ideal because t.Name does not include the package, and
-		// there's no easy way to get it.  However, at present there aren't many
-		// tests that have the same name, and from what I can see there are no
-		// duplicates that call NewTestCluster.
-		logFileName = filepath.Join(logDir, t.Name()+".log")
-		// t.Name may include slashes.
-		dir, _ := filepath.Split(logFileName)
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		logFile, err = os.Create(logFileName)
-		if err != nil {
-			t.Fatal(err)
-		}
-		testCluster.Logger = logging.NewVaultLoggerWithWriter(logFile, log.Trace)
 	default:
-		testCluster.Logger = logging.NewVaultLogger(log.Trace).Named(t.Name())
+		testCluster.Logger = NewTestLogger(t)
 	}
 
 	if opts != nil && opts.TempDir != "" {
@@ -1810,11 +1822,11 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		for _, c := range cleanupFuncs {
 			c()
 		}
-		if logFile != nil {
+		if l, ok := testCluster.Logger.(*TestLogger); ok {
 			if t.Failed() {
-				logFile.Close()
+				_ = l.File.Close()
 			} else {
-				os.Remove(logFileName)
+				_ = os.Remove(l.Path)
 			}
 		}
 	}


### PR DESCRIPTION
...so that it can be used when the caller wants to specify a logger explicitly, e.g. because they also want to use it when creating storage.