### PR TITLE
remove link to old comparisons page

### DIFF
--- a/website/pages/docs/what-is-vault/index.mdx
+++ b/website/pages/docs/what-is-vault/index.mdx
@@ -69,8 +69,6 @@ The key features of Vault are:
 ## Next Steps
 
 See the page on [Vault use cases](/docs/use-cases) to see the
-multiple ways Vault can be used. Then see
-[how Vault compares to other software](/docs/vs)
-to see how it fits into your existing infrastructure. Finally, continue onwards with
+multiple ways Vault can be used. Then, continue onwards with
 the [getting started guide](https://learn.hashicorp.com/vault/getting-started/install) to use
 Vault to read, write, and create real secrets and see how it works in practice.


### PR DESCRIPTION
The what-is-vault page had a link to a comparisons page, but that page now includes only a disclaimer that it's been removed. So, lets remove the link, too.