### PR TITLE
Backport 1.4.2: raft: use file paths for TLS info in the retry_join block (#8894)

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -118,13 +118,27 @@ type LeaderJoinInfo struct {
 	// LeaderCACert is the CA cert of the leader node
 	LeaderCACert string `json:"leader_ca_cert"`
 
-	// LeaderClientCert is the client certificate for the follower node to establish
-	// client authentication during TLS
+	// LeaderClientCert is the client certificate for the follower node to
+	// establish client authentication during TLS
 	LeaderClientCert string `json:"leader_client_cert"`
 
-	// LeaderClientKey is the client key for the follower node to establish client
-	// authentication during TLS
+	// LeaderClientKey is the client key for the follower node to establish
+	// client authentication during TLS.
 	LeaderClientKey string `json:"leader_client_key"`
+
+	// LeaderCACertFile is the path on disk to the the CA cert file of the
+	// leader node. This should only be provided via Vault's configuration file.
+	LeaderCACertFile string `json:"leader_ca_cert_file"`
+
+	// LeaderClientCertFile is the path on disk to the client certificate file
+	// for the follower node to establish client authentication during TLS. This
+	// should only be provided via Vault's configuration file.
+	LeaderClientCertFile string `json:"leader_client_cert_file"`
+
+	// LeaderClientKeyFile is the path on disk to the client key file for the
+	// follower node to establish client authentication during TLS. This should
+	// only be provided via Vault's configuration file.
+	LeaderClientKeyFile string `json:"leader_client_key_file"`
 
 	// Retry indicates if the join process should automatically be retried
 	Retry bool `json:"-"`
@@ -153,18 +167,33 @@ func (b *RaftBackend) JoinConfig() ([]*LeaderJoinInfo, error) {
 
 	for _, info := range leaderInfos {
 		info.Retry = true
-		var tlsConfig *tls.Config
-		var err error
-		if len(info.LeaderCACert) != 0 || len(info.LeaderClientCert) != 0 || len(info.LeaderClientKey) != 0 {
-			tlsConfig, err = tlsutil.ClientTLSConfig([]byte(info.LeaderCACert), []byte(info.LeaderClientCert), []byte(info.LeaderClientKey))
-			if err != nil {
-				return nil, errwrap.Wrapf(fmt.Sprintf("failed to create tls config to communicate with leader node %q: {{err}}", info.LeaderAPIAddr), err)
-			}
+		info.TLSConfig, err = parseTLSInfo(info)
+		if err != nil {
+			return nil, errwrap.Wrapf(fmt.Sprintf("failed to create tls config to communicate with leader node %q: {{err}}", info.LeaderAPIAddr), err)
 		}
-		info.TLSConfig = tlsConfig
 	}
 
 	return leaderInfos, nil
+}
+
+// parseTLSInfo is a helper for parses the TLS information, preferring file
+// paths over raw certificate content.
+func parseTLSInfo(leaderInfo *LeaderJoinInfo) (*tls.Config, error) {
+	var tlsConfig *tls.Config
+	var err error
+	if len(leaderInfo.LeaderCACertFile) != 0 || len(leaderInfo.LeaderClientCertFile) != 0 || len(leaderInfo.LeaderClientKeyFile) != 0 {
+		tlsConfig, err = tlsutil.LoadClientTLSConfig(leaderInfo.LeaderCACertFile, leaderInfo.LeaderClientCertFile, leaderInfo.LeaderClientKeyFile)
+		if err != nil {
+			return nil, err
+		}
+	} else if len(leaderInfo.LeaderCACert) != 0 || len(leaderInfo.LeaderClientCert) != 0 || len(leaderInfo.LeaderClientKey) != 0 {
+		tlsConfig, err = tlsutil.ClientTLSConfig([]byte(leaderInfo.LeaderCACert), []byte(leaderInfo.LeaderClientCert), []byte(leaderInfo.LeaderClientKey))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return tlsConfig, nil
 }
 
 // EnsurePath is used to make sure a path exists

--- a/website/pages/docs/configuration/storage/raft.mdx
+++ b/website/pages/docs/configuration/storage/raft.mdx
@@ -96,13 +96,29 @@ time. To use Raft for HA coordination users must also use Raft for storage.
 
 ### `retry_join` stanza
 
-- `leader_api_addr` `(string: "")` - Address of a possible leader node
+- `leader_api_addr` `(string: "")` - Address of a possible leader node.
 
-- `leader_ca_cert` `(string: "")` - CA cert of the possible leader node
+- `leader_ca_cert_file` `(string: "")` - File path to the CA cert of the
+  possible leader node.
 
-- `leader_client_cert` `(string: "")` - Client certificate for the follower node to establish client authentication with the possible leader node
+- `leader_client_cert_file` `(string: "")` - File path to the client certificate
+for the follower node to establish client authentication with the possible
+leader node.
 
-- `leader_client_key` `(string: "")` - Client key for the follower node to establish client authentication with the possible leader node
+- `leader_client_key_file` `(string: "")` - File path to the client key for the
+follower node to establish client authentication with the possible leader node.
+
+- `leader_ca_cert` `(string: "")` - CA cert of the possible leader node.
+
+- `leader_client_cert` `(string: "")` - Client certificate for the follower node
+to establish client authentication with the possible leader node.
+
+- `leader_client_key` `(string: "")` - Client key for the follower node to
+establish client authentication with the possible leader node.
+
+Each `retry_join` block may provide TLS certificates via file paths or as a
+single-line certificate string value with newlines delimited by `\n`, but not a
+combination of both.
 
 Example Configuration:
 ```
@@ -111,21 +127,21 @@ storage "raft" {
   node_id = "node1"
   retry_join {
     leader_api_addr = "http://127.0.0.2:8200"
-    leader_ca_cert = "/path/to/ca1"
-    leader_client_cert = "/path/to/client/cert1"
-    leader_client_key = "/path/to/client/key1"
+    leader_ca_cer_file = "/path/to/ca1"
+    leader_client_cert_file = "/path/to/client/cert1"
+    leader_client_key_file = "/path/to/client/key1"
   }
   retry_join {
     leader_api_addr = "http://127.0.0.3:8200"
-    leader_ca_cert = "/path/to/ca2"
-    leader_client_cert = "/path/to/client/cert2"
-    leader_client_key = "/path/to/client/key2"
+    leader_ca_cert_file = "/path/to/ca2"
+    leader_client_cert_file = "/path/to/client/cert2"
+    leader_client_key_file = "/path/to/client/key2"
   }
   retry_join {
     leader_api_addr = "http://127.0.0.4:8200"
-    leader_ca_cert = "/path/to/ca3"
-    leader_client_cert = "/path/to/client/cert3"
-    leader_client_key = "/path/to/client/key3"
+    leader_ca_cert_file = "/path/to/ca3"
+    leader_client_cert_file = "/path/to/client/cert3"
+    leader_client_key_file = "/path/to/client/key3"
   }
 }
 ```


### PR DESCRIPTION
* raft: use file paths for TLS info in the retry_join stanza

* raft: maintain backward compat for existing tls params

* docs: update raft docs with new file-based TLS params

* Update godoc comment, fix docs