### PR TITLE
More helpful errors when import bundled certificates

### DIFF
--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -47,9 +47,12 @@ func (b *backend) pathCAWrite(ctx context.Context, req *logical.Request, data *f
 		}
 	}
 
-	if parsedBundle.PrivateKey == nil ||
-		parsedBundle.PrivateKeyType == certutil.UnknownPrivateKey {
+	if parsedBundle.PrivateKey == nil {
 		return logical.ErrorResponse("private key not found in the PEM bundle"), nil
+	}
+
+	if parsedBundle.PrivateKeyType == certutil.UnknownPrivateKey {
+		return logical.ErrorResponse("unknown private key found in the PEM bundle"), nil
 	}
 
 	if parsedBundle.Certificate == nil {

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -169,6 +169,8 @@ func ParsePEMBundle(pemBundle string) (*ParsedCertBundle, error) {
 				Certificate: certificates[0],
 				Bytes:       pemBlock.Bytes,
 			})
+		} else if x509.IsEncryptedPEMBlock(pemBlock) {
+			return nil, errutil.UserError{Err: "Encrypted private key given; provide only decrypted private key in the bundle"}
 		}
 	}
 

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -321,8 +321,10 @@ func (p *ParsedCertBundle) Verify() error {
 				return fmt.Errorf("certificate %d of certificate chain is not a certificate authority", i+1)
 			}
 			if !bytes.Equal(certPath[i].Certificate.AuthorityKeyId, caCert.Certificate.SubjectKeyId) {
-				return fmt.Errorf("certificate %d of certificate chain ca trust path is incorrect (%q/%q)",
-					i+1, certPath[i].Certificate.Subject.CommonName, caCert.Certificate.Subject.CommonName)
+				return fmt.Errorf("certificate %d of certificate chain ca trust path is incorrect (%q/%q) (%X/%X)",
+					i+1,
+					certPath[i].Certificate.Subject.CommonName, caCert.Certificate.Subject.CommonName,
+					certPath[i].Certificate.AuthorityKeyId, caCert.Certificate.SubjectKeyId)
 			}
 		}
 	}


### PR DESCRIPTION
1. `private key not found in the PEM bundle` is not the same as `unknown private key found in the PEM bundle`
1. `certificate %d of certificate chain ca trust path is incorrect (CN/CN) (AuthorityKeyId/SubjectKeyId)` instead of only CN's
1. `Encrypted private key given; provide only decrypted private key in the bundle` when provided private key is encrypted