### PR TITLE
Fix: Only render JWT input field for mounts configured for JWT auth

### DIFF
--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -28,7 +28,6 @@ export default Component.extend({
   onNamespace() {},
 
   didReceiveAttrs() {
-    console.log(`didReceiveAttrs: ${this.errorMessage}`);
     let { oldSelectedAuthPath, selectedAuthPath } = this;
     let shouldDebounce = !oldSelectedAuthPath && !selectedAuthPath;
     if (oldSelectedAuthPath !== selectedAuthPath) {
@@ -45,7 +44,6 @@ export default Component.extend({
   // Assumes authentication using OIDC until it's known that the mount is
   // configured for JWT authentication via static keys, JWKS, or OIDC discovery.
   isOIDC: computed('errorMessage', function() {
-    console.log(`isOIDC: ${this.errorMessage}`);
     return this.errorMessage !== ERROR_JWT_LOGIN;
   }),
 
@@ -159,11 +157,9 @@ export default Component.extend({
       if (e && e.preventDefault) {
         e.preventDefault();
       }
-      if (!this.isOIDC) {
+      if (!this.isOIDC || !this.role || !this.role.authUrl) {
         return;
       }
-
-      console.log(`Role: ${this.role}`);
 
       await this.fetchRole.perform(this.roleName, { debounce: false });
       let win = this.getWindow();

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -65,7 +65,6 @@ module('Acceptance | auth', function(hooks) {
         await component.token('token');
       }
       if (backend.type === 'jwt' || backend.type === 'oidc') {
-        await jwtComponent.jwt('1');
         await jwtComponent.role('test');
       }
       await component.login();
@@ -81,7 +80,6 @@ module('Acceptance | auth', function(hooks) {
       } else if (backend.type === 'jwt' || backend.type === 'oidc') {
         let authReq = this.server.passthroughRequests[this.server.passthroughRequests.length - 2];
         body = JSON.parse(authReq.requestBody);
-        assert.ok(Object.keys(body).includes('jwt'), `${backend.type} includes jwt`);
         assert.ok(Object.keys(body).includes('role'), `${backend.type} includes role`);
       } else {
         assert.ok(Object.keys(body).includes('password'), `${backend.type} includes password`);

--- a/ui/tests/integration/components/auth-jwt-test.js
+++ b/ui/tests/integration/components/auth-jwt-test.js
@@ -11,7 +11,7 @@ import Pretender from 'pretender';
 import { resolve } from 'rsvp';
 import { create } from 'ember-cli-page-object';
 import form from '../../pages/components/auth-jwt';
-import { ERROR_WINDOW_CLOSED, ERROR_MISSING_PARAMS } from 'vault/components/auth-jwt';
+import { ERROR_WINDOW_CLOSED, ERROR_MISSING_PARAMS, ERROR_JWT_LOGIN } from 'vault/components/auth-jwt';
 
 const component = create(form);
 const windows = [];
@@ -120,7 +120,7 @@ module('Integration | Component | auth jwt', function(hooks) {
             }),
           ];
         }
-        return [400, { 'Content-Type': 'application/json' }, JSON.stringify({ errors: ['nope'] })];
+        return [400, { 'Content-Type': 'application/json' }, JSON.stringify({ errors: [ERROR_JWT_LOGIN] })];
       });
     });
   });


### PR DESCRIPTION
### Description
This PR inverts the logic that decides when to render the JWT input field of the Vault UI login form.

Currently, the JWT input field is rendered until OIDC auth is configured. This was a source of confusion for Vault users as they were configuring OIDC auth. With this change, the JWT input field will not be rendered until it's known that JWT auth is configured for the mount.

To know when JWT auth is configured for a mount, an error message from [vault-plugin-auth-jwt/path_oidc.go#L346](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/master/path_oidc.go#L346) is used. This error is a reliable signal that the mount has not been set up for an OIDC flow. An additional change will be made in [vault-plugin-auth-jwt](https://github.com/hashicorp/vault-plugin-auth-jwt) to make the error message a constant with a comment noting that changing it will have consequences in the UI.

Find below a table of `/auth_url` responses at steps of configuring both OIDC and JWT auth that influenced the decision to use the error message:

| Config Step | OIDC Response `/auth_url` | JWT Response `/auth_url` |
|---|-------|-----|
| 0. Not Configured  | missing client token (400) | missing client token (400) |
| 1. Auth Enable     | could not load configuration (400) | could not load configuration (400) |
| 2. Write Config    | role "..." could not be found (400) | **OIDC login is not configured for this mount** (400) |
| 3. Write Role      | .data.auth_url non empty (200) | **OIDC login is not configured for this mount** (400) |

### Testing

I've manually tested that the UI:
- Doesn't show the JWT input field by default
- Shows the JWT input field when a mount has been configured for JWT auth
- Allows for successful OIDC and JWT authentication

Automated UI tests are fixed in this PR.