### PR TITLE
Refactor service registration

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -966,9 +966,6 @@ func (c *ServerCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Instantiate the wait group
-	c.WaitGroup = &sync.WaitGroup{}
-
 	// Initialize the Service Discovery, if there is one
 	var configSR sr.ServiceRegistration
 	if config.ServiceRegistration != nil {
@@ -990,13 +987,9 @@ func (c *ServerCommand) Run(args []string) int {
 			IsActive:             false,
 			IsPerformanceStandby: false,
 		}
-		configSR, err = sdFactory(config.ServiceRegistration.Config, namedSDLogger, state, config.Storage.RedirectAddr)
+		configSR, err = sdFactory(config.ServiceRegistration.Config, namedSDLogger, state)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error initializing service_registration of type %s: %s", config.ServiceRegistration.Type, err))
-			return 1
-		}
-		if err := configSR.Run(c.ShutdownCh, c.WaitGroup); err != nil {
-			c.UI.Error(fmt.Sprintf("Error running service_registration of type %s: %s", config.ServiceRegistration.Type, err))
 			return 1
 		}
 	}
@@ -1311,7 +1304,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 
 	// If ServiceRegistration is configured, then the backend must support HA
 	isBackendHA := coreConfig.HAPhysical != nil && coreConfig.HAPhysical.HAEnabled()
-	if !c.flagDev && (coreConfig.ServiceRegistration != nil) && !isBackendHA {
+	if !c.flagDev && (coreConfig.GetServiceRegistration() != nil) && !isBackendHA {
 		c.UI.Output("service_registration is configured, but storage does not support HA")
 		return 1
 	}
@@ -1578,6 +1571,18 @@ CLUSTER_SYNTHESIS_COMPLETE:
 	}
 
 	// Perform initialization of HTTP server after the verifyOnly check.
+
+	// Instantiate the wait group
+	c.WaitGroup = &sync.WaitGroup{}
+
+	// If service discovery is available, run service discovery
+	if sd := coreConfig.GetServiceRegistration(); sd != nil {
+		if err := configSR.Run(c.ShutdownCh, c.WaitGroup, coreConfig.RedirectAddr); err != nil {
+			c.UI.Error(fmt.Sprintf("Error running service_registration of type %s: %s", config.ServiceRegistration.Type, err))
+			return 1
+		}
+	}
+
 	// If we're in Dev mode, then initialize the core
 	if c.flagDev && !c.flagDevSkipInit {
 		init, err := c.enableDev(core, coreConfig)

--- a/serviceregistration/consul/consul_service_registration_test.go
+++ b/serviceregistration/consul/consul_service_registration_test.go
@@ -32,11 +32,11 @@ func testConsulServiceRegistrationConfig(t *testing.T, conf *consulConf) *servic
 	defer func() {
 		close(shutdownCh)
 	}()
-	be, err := NewServiceRegistration(*conf, logger, sr.State{}, "")
+	be, err := NewServiceRegistration(*conf, logger, sr.State{})
 	if err != nil {
 		t.Fatalf("Expected Consul to initialize: %v", err)
 	}
-	if err := be.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+	if err := be.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -69,8 +69,10 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 	waitForServices := func(t *testing.T, expected map[string][]string) map[string][]string {
 		t.Helper()
 		// Wait for up to 10 seconds
+		var services map[string][]string
+		var err error
 		for i := 0; i < 10; i++ {
-			services, _, err := client.Catalog().Services(nil)
+			services, _, err = client.Catalog().Services(nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -79,7 +81,7 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 			}
 			time.Sleep(time.Second)
 		}
-		t.Fatalf("Catalog Services never reached expected state %v", expected)
+		t.Fatalf("Catalog Services never reached: got: %v, expected state: %v", services, expected)
 		return nil
 	}
 
@@ -94,11 +96,11 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 	sd, err := NewServiceRegistration(map[string]string{
 		"address": addr,
 		"token":   token,
-	}, logger, sr.State{}, redirectAddr)
+	}, logger, sr.State{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := sd.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+	if err := sd.Run(shutdownCh, &sync.WaitGroup{}, redirectAddr); err != nil {
 		t.Fatal(err)
 	}
 
@@ -167,11 +169,11 @@ func TestConsul_ServiceTags(t *testing.T) {
 		close(shutdownCh)
 	}()
 
-	be, err := NewServiceRegistration(consulConfig, logger, sr.State{}, "")
+	be, err := NewServiceRegistration(consulConfig, logger, sr.State{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := be.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+	if err := be.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -226,11 +228,11 @@ func TestConsul_ServiceAddress(t *testing.T) {
 		shutdownCh := make(chan struct{})
 		logger := logging.NewVaultLogger(log.Debug)
 
-		be, err := NewServiceRegistration(test.consulConfig, logger, sr.State{}, "")
+		be, err := NewServiceRegistration(test.consulConfig, logger, sr.State{})
 		if err != nil {
 			t.Fatalf("expected Consul to initialize: %v", err)
 		}
-		if err := be.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+		if err := be.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -355,7 +357,7 @@ func TestConsul_newConsulServiceRegistration(t *testing.T) {
 		shutdownCh := make(chan struct{})
 		logger := logging.NewVaultLogger(log.Debug)
 
-		be, err := NewServiceRegistration(test.consulConfig, logger, sr.State{}, "")
+		be, err := NewServiceRegistration(test.consulConfig, logger, sr.State{})
 		if test.fail {
 			if err == nil {
 				t.Fatalf(`Expected config "%s" to fail`, test.name)
@@ -365,7 +367,7 @@ func TestConsul_newConsulServiceRegistration(t *testing.T) {
 		} else if !test.fail && err != nil {
 			t.Fatalf("Expected config %s to not fail: %v", test.name, err)
 		}
-		if err := be.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+		if err := be.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -559,7 +561,7 @@ func TestConsul_serviceID(t *testing.T) {
 		shutdownCh := make(chan struct{})
 		be, err := NewServiceRegistration(consulConf{
 			"service": test.serviceName,
-		}, logger, sr.State{}, "")
+		}, logger, sr.State{})
 		if !test.valid {
 			if err == nil {
 				t.Fatalf("expected an error initializing for name %q", test.serviceName)
@@ -569,7 +571,7 @@ func TestConsul_serviceID(t *testing.T) {
 		if test.valid && err != nil {
 			t.Fatalf("expected Consul to initialize: %v", err)
 		}
-		if err := be.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+		if err := be.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 			t.Fatal(err)
 		}
 

--- a/serviceregistration/kubernetes/client/client_test.go
+++ b/serviceregistration/kubernetes/client/client_test.go
@@ -22,7 +22,7 @@ func TestClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client, err := New(hclog.Default(), make(chan struct{}))
+	client, err := New(hclog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/serviceregistration/kubernetes/retry_handler.go
+++ b/serviceregistration/kubernetes/retry_handler.go
@@ -93,8 +93,6 @@ func (r *retryHandler) setInitialState(shutdownCh <-chan struct{}) {
 	case <-doneCh:
 	case <-shutdownCh:
 	}
-
-	return nil
 }
 
 // Notify adds a patch to be retried until it's either completed without

--- a/serviceregistration/kubernetes/retry_handler.go
+++ b/serviceregistration/kubernetes/retry_handler.go
@@ -123,8 +123,8 @@ func (r *retryHandler) Notify(patch *client.Patch) {
 	}
 }
 
-// setInitialState sets the initial state remotely. This should be called with
-// the lock held.
+// setInitialStateInternal sets the initial state remotely. This should be
+// called with the lock held.
 func (r *retryHandler) setInitialStateInternal() error {
 	// If this is set, we return immediately
 	if r.initialStateSet {

--- a/serviceregistration/kubernetes/service_registration.go
+++ b/serviceregistration/kubernetes/service_registration.go
@@ -23,7 +23,7 @@ const (
 	pathToLabels = "/metadata/labels/"
 )
 
-func NewServiceRegistration(config map[string]string, logger hclog.Logger, state sr.State, _ string) (sr.ServiceRegistration, error) {
+func NewServiceRegistration(config map[string]string, logger hclog.Logger, state sr.State) (sr.ServiceRegistration, error) {
 	namespace, err := getRequiredField(logger, config, client.EnvVarKubernetesNamespace, "namespace")
 	if err != nil {
 		return nil, err
@@ -32,19 +32,26 @@ func NewServiceRegistration(config map[string]string, logger hclog.Logger, state
 	if err != nil {
 		return nil, err
 	}
+
+	c, err := client.New(logger)
+	if err != nil {
+		return nil, err
+	}
+
 	// The Vault version must be sanitized because it can contain special
 	// characters like "+" which aren't acceptable by the Kube API.
 	state.VaultVersion = client.Sanitize(state.VaultVersion)
 	return &serviceRegistration{
-		logger:       logger,
-		namespace:    namespace,
-		podName:      podName,
-		initialState: state,
+		logger:    logger,
+		namespace: namespace,
+		podName:   podName,
 		retryHandler: &retryHandler{
 			logger:         logger,
 			namespace:      namespace,
 			podName:        podName,
+			initialState:   state,
 			patchesToRetry: make(map[string]*client.Patch),
+			client:         c,
 		},
 	}, nil
 }
@@ -52,91 +59,16 @@ func NewServiceRegistration(config map[string]string, logger hclog.Logger, state
 type serviceRegistration struct {
 	logger             hclog.Logger
 	namespace, podName string
-	client             *client.Client
-	initialState       sr.State
 	retryHandler       *retryHandler
 }
 
-func (r *serviceRegistration) Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup) error {
-	c, err := client.New(r.logger, shutdownCh)
-	if err != nil {
-		return err
-	}
-	r.client = c
-
-	// Now that we've populated the client, we can begin using the retry handler.
-	r.retryHandler.SetInitialState(r.setInitialState)
-	r.retryHandler.Run(shutdownCh, wait, c)
-	return nil
-}
-
-func (r *serviceRegistration) setInitialState() error {
-	// Verify that the pod exists and our configuration looks good.
-	pod, err := r.client.GetPod(r.namespace, r.podName)
-	if err != nil {
-		return err
-	}
-
-	// Now to initially label our pod.
-	if pod.Metadata == nil {
-		// This should never happen IRL, just being defensive.
-		return fmt.Errorf("no pod metadata on %+v", pod)
-	}
-	if pod.Metadata.Labels == nil {
-		// Notify the labels field, and the labels as part of that one call.
-		// The reason we must take a different approach to adding them is discussed here:
-		// https://stackoverflow.com/questions/57480205/error-while-applying-json-patch-to-kubernetes-custom-resource
-		if err := r.client.PatchPod(r.namespace, r.podName, &client.Patch{
-			Operation: client.Add,
-			Path:      "/metadata/labels",
-			Value: map[string]string{
-				labelVaultVersion: r.initialState.VaultVersion,
-				labelActive:       strconv.FormatBool(r.initialState.IsActive),
-				labelSealed:       strconv.FormatBool(r.initialState.IsSealed),
-				labelPerfStandby:  strconv.FormatBool(r.initialState.IsPerformanceStandby),
-				labelInitialized:  strconv.FormatBool(r.initialState.IsInitialized),
-			},
-		}); err != nil {
-			return err
-		}
-	} else {
-		// Create the labels through a patch to each individual field.
-		patches := []*client.Patch{
-			{
-				Operation: client.Replace,
-				Path:      pathToLabels + labelVaultVersion,
-				Value:     r.initialState.VaultVersion,
-			},
-			{
-				Operation: client.Replace,
-				Path:      pathToLabels + labelActive,
-				Value:     strconv.FormatBool(r.initialState.IsActive),
-			},
-			{
-				Operation: client.Replace,
-				Path:      pathToLabels + labelSealed,
-				Value:     strconv.FormatBool(r.initialState.IsSealed),
-			},
-			{
-				Operation: client.Replace,
-				Path:      pathToLabels + labelPerfStandby,
-				Value:     strconv.FormatBool(r.initialState.IsPerformanceStandby),
-			},
-			{
-				Operation: client.Replace,
-				Path:      pathToLabels + labelInitialized,
-				Value:     strconv.FormatBool(r.initialState.IsInitialized),
-			},
-		}
-		if err := r.client.PatchPod(r.namespace, r.podName, patches...); err != nil {
-			return err
-		}
-	}
+func (r *serviceRegistration) Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup, _ string) error {
+	r.retryHandler.Run(shutdownCh, wait)
 	return nil
 }
 
 func (r *serviceRegistration) NotifyActiveStateChange(isActive bool) error {
-	r.retryHandler.Notify(r.client, &client.Patch{
+	r.retryHandler.Notify(&client.Patch{
 		Operation: client.Replace,
 		Path:      pathToLabels + labelActive,
 		Value:     strconv.FormatBool(isActive),
@@ -145,7 +77,7 @@ func (r *serviceRegistration) NotifyActiveStateChange(isActive bool) error {
 }
 
 func (r *serviceRegistration) NotifySealedStateChange(isSealed bool) error {
-	r.retryHandler.Notify(r.client, &client.Patch{
+	r.retryHandler.Notify(&client.Patch{
 		Operation: client.Replace,
 		Path:      pathToLabels + labelSealed,
 		Value:     strconv.FormatBool(isSealed),
@@ -154,7 +86,7 @@ func (r *serviceRegistration) NotifySealedStateChange(isSealed bool) error {
 }
 
 func (r *serviceRegistration) NotifyPerformanceStandbyStateChange(isStandby bool) error {
-	r.retryHandler.Notify(r.client, &client.Patch{
+	r.retryHandler.Notify(&client.Patch{
 		Operation: client.Replace,
 		Path:      pathToLabels + labelPerfStandby,
 		Value:     strconv.FormatBool(isStandby),
@@ -163,7 +95,7 @@ func (r *serviceRegistration) NotifyPerformanceStandbyStateChange(isStandby bool
 }
 
 func (r *serviceRegistration) NotifyInitializedStateChange(isInitialized bool) error {
-	r.retryHandler.Notify(r.client, &client.Patch{
+	r.retryHandler.Notify(&client.Patch{
 		Operation: client.Replace,
 		Path:      pathToLabels + labelInitialized,
 		Value:     strconv.FormatBool(isInitialized),

--- a/serviceregistration/kubernetes/service_registration_test.go
+++ b/serviceregistration/kubernetes/service_registration_test.go
@@ -44,11 +44,11 @@ func TestServiceRegistration(t *testing.T) {
 		IsActive:             true,
 		IsPerformanceStandby: true,
 	}
-	reg, err := NewServiceRegistration(config, logger, state, "")
+	reg, err := NewServiceRegistration(config, logger, state)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := reg.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+	if err := reg.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/serviceregistration/service_registration.go
+++ b/serviceregistration/service_registration.go
@@ -26,7 +26,7 @@ type State struct {
 // The config is the key/value pairs set _inside_ the service registration config stanza.
 // The state is the initial state.
 // The redirectAddr is Vault core's RedirectAddr.
-type Factory func(config map[string]string, logger log.Logger, state State, redirectAddr string) (ServiceRegistration, error)
+type Factory func(config map[string]string, logger log.Logger, state State) (ServiceRegistration, error)
 
 // ServiceRegistration is an interface that advertises the state of Vault to a
 // service discovery network.
@@ -60,7 +60,7 @@ type ServiceRegistration interface {
 	//		}()
 	//		return nil
 	//	}
-	Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup) error
+	Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup, redirectAddr string) error
 
 	// NotifyActiveStateChange is used by Core to notify that this Vault
 	// instance has changed its status on whether it's active or is

--- a/serviceregistration/service_registration.go
+++ b/serviceregistration/service_registration.go
@@ -31,21 +31,24 @@ type Factory func(config map[string]string, logger log.Logger, state State) (Ser
 // ServiceRegistration is an interface that advertises the state of Vault to a
 // service discovery network.
 type ServiceRegistration interface {
-	// Run provides a shutdownCh and wait WaitGroup. The shutdownCh
-	// is for monitoring when a shutdown occurs and initiating any actions needed
-	// to leave service registration in a final state. When finished, signalling
-	// that with wait means that Vault will wait until complete.
+	// Run provides a shutdownCh, wait WaitGroup, and redirectAddr. The
+	// shutdownCh is for monitoring when a shutdown occurs and initiating any
+	// actions needed to leave service registration in a final state. When
+	// finished, signalling that with wait means that Vault will wait until
+	// complete. The redirectAddr is an optional parameter for implementations
+	// that might need to communicate with Vault's listener via this address.
+	//
 	// Run is called just after Factory instantiation so can be relied upon
 	// for controlling shutdown behavior.
 	// Here is an example of its intended use:
-	//	func Run(shutdownCh <-chan struct{}, wait sync.WaitGroup) error {
+	//	func Run(shutdownCh <-chan struct{}, wait sync.WaitGroup, redirectAddr string) error {
+	//
+	//		// Since we are going to want Vault to wait to shutdown
+	//		// until after we do cleanup...
+	//		wait.Add(1)
 	//
 	//		// Run shutdown code in a goroutine so Run doesn't block.
 	//		go func(){
-	//			// Since we are going to want Vault to wait to shutdown
-	//			// until after we do cleanup...
-	//			wait.Add(1)
-	//
 	//			// Ensure that when this ends, no matter how it ends,
 	//			// we don't cause Vault to hang on shutdown.
 	//			defer wait.Done()

--- a/vault/core.go
+++ b/vault/core.go
@@ -648,7 +648,7 @@ func (c *CoreConfig) Clone() *CoreConfig {
 // not exist.
 func (c *CoreConfig) GetServiceRegistration() sr.ServiceRegistration {
 
-	// Check whether there is a ServiceRegistration explictly configured
+	// Check whether there is a ServiceRegistration explicitly configured
 	if c.ServiceRegistration != nil {
 		return c.ServiceRegistration
 	}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -2476,7 +2476,7 @@ type mockServiceRegistration struct {
 	runDiscoveryCount int
 }
 
-func (m *mockServiceRegistration) Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup) error {
+func (m *mockServiceRegistration) Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup, redirectAddr string) error {
 	m.runDiscoveryCount++
 	return nil
 }


### PR DESCRIPTION
This PR is a first-pass at refactoring service registration logic to allow for `configSR.Run` to be ran at a later point in time, when we've determined/updated `coreConfig.RedirectAddr`. It also does the following cleanup:

- general: pass in the server address via `Run`, which allows us to use one at a later point in time.
- k8s: Moves the client directly into `retryHandler` since that's the wrapper that ends up triggerings the API calls
- k8s: Changed logic around `setInitialState` so that it's fully delegated to `retryHandler`.
- k8s: Change client to use its own shutdown channel instead of passing in one.

Fixes https://github.com/hashicorp/vault/issues/8634