### PR TITLE
Mongo atlas static roles test

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
+	"github.com/hashicorp/vault-plugin-database-mongodbatlas"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers/docker"
@@ -104,6 +105,7 @@ func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
 	sys := vault.TestDynamicSystemView(cores[0].Core)
 	vault.TestAddTestPlugin(t, cores[0].Core, "postgresql-database-plugin", consts.PluginTypeDatabase, "TestBackend_PluginMain_Postgres", []string{}, "")
 	vault.TestAddTestPlugin(t, cores[0].Core, "mongodb-database-plugin", consts.PluginTypeDatabase, "TestBackend_PluginMain_Mongo", []string{}, "")
+	vault.TestAddTestPlugin(t, cores[0].Core, "mongodbatlas-database-plugin", consts.PluginTypeDatabase, "TestBackend_PluginMain_MongoAtlas", []string{}, "")
 
 	return cluster, sys
 }
@@ -144,6 +146,28 @@ func TestBackend_PluginMain_Mongo(t *testing.T) {
 	flags.Parse(args)
 
 	err := mongodb.Run(apiClientMeta.GetTLSConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBackend_PluginMain_MongoAtlas(t *testing.T) {
+	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" {
+		return
+	}
+
+	caPEM := os.Getenv(pluginutil.PluginCACertPEMEnv)
+	if caPEM == "" {
+		t.Fatal("CA cert not passed in")
+	}
+
+	args := []string{"--ca-cert=" + caPEM}
+
+	apiClientMeta := &api.PluginAPIClientMeta{}
+	flags := apiClientMeta.FlagSet()
+	flags.Parse(args)
+
+	err := mongodbatlas.Run(apiClientMeta.GetTLSConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -686,152 +686,40 @@ func assertWALCount(t *testing.T, s logical.Storage, expected int, key string) {
 // End WAL testing
 //
 
+type userCreator func(t *testing.T, username, password string)
+
 func TestBackend_StaticRole_Rotations_PostgreSQL(t *testing.T) {
-	cluster, sys := getCluster(t)
-	defer cluster.Cleanup()
-
-	// Configure backend, add item and confirm length
-	cleanup, connURL := postgreshelper.PrepareTestContainer(t, "")
+	cleanup, connURL := postgreshelper.PrepareTestContainer(t, "latest")
 	defer cleanup()
-
-	config := logical.TestBackendConfig()
-	config.StorageView = &logical.InmemStorage{}
-	config.System = sys
-
-	b, err := Factory(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer b.Cleanup(context.Background())
-
-	bd := b.(*databaseBackend)
-	if bd.credRotationQueue == nil {
-		t.Fatal("database backend had no credential rotation queue")
-	}
-
-	testCases := []string{"10", "20", "100"}
-	// Create database users ahead
-	for _, tc := range testCases {
-		createTestPGUser(t, connURL, dbUser+tc, dbUserDefaultPassword, testRoleStaticCreate)
-	}
-
-	// Configure a connection
-	data := map[string]interface{}{
-		"connection_url":    connURL,
-		"plugin_name":       "postgresql-database-plugin",
-		"verify_connection": false,
-		"allowed_roles":     []string{"*"},
-		"name":              "plugin-test",
-	}
-	req := &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "config/plugin-test",
-		Storage:   config.StorageView,
-		Data:      data,
-	}
-	resp, err := b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
-
-	// Create three static roles with different rotation periods
-	for _, tc := range testCases {
-		roleName := "plugin-static-role-" + tc
-		data = map[string]interface{}{
-			"name":                roleName,
-			"db_name":             "plugin-test",
-			"rotation_statements": testRoleStaticUpdate,
-			"username":            dbUser + tc,
-			"rotation_period":     tc,
-		}
-
-		req = &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      "static-roles/" + roleName,
-			Storage:   config.StorageView,
-			Data:      data,
-		}
-
-		resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-		if err != nil || (resp != nil && resp.IsError()) {
-			t.Fatalf("err:%s resp:%#v\n", err, resp)
-		}
-	}
-
-	// Verify the queue has 3 items in it
-	if bd.credRotationQueue.Len() != 3 {
-		t.Fatalf("expected 3 items in the rotation queue, got: (%d)", bd.credRotationQueue.Len())
-	}
-
-	// List the roles
-	data = map[string]interface{}{}
-	req = &logical.Request{
-		Operation: logical.ListOperation,
-		Path:      "static-roles/",
-		Storage:   config.StorageView,
-		Data:      data,
-	}
-	resp, err = b.HandleRequest(namespace.RootContext(nil), req)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, resp)
-	}
-
-	keys := resp.Data["keys"].([]string)
-	if len(keys) != 3 {
-		t.Fatalf("expected 3 roles, got: (%d)", len(keys))
-	}
-
-	// Capture initial passwords, before the periodic function is triggered
-	pws := make(map[string][]string, 0)
-	pws = capturePasswords(t, b, config, testCases, pws)
-
-	// Sleep to make sure the 10s role will be have rotated
-	time.Sleep(15 * time.Second)
-	pws = capturePasswords(t, b, config, testCases, pws)
-
-	// Sleep more, this should allow both sr10 and sr20 to rotate
-	time.Sleep(10 * time.Second)
-	pws = capturePasswords(t, b, config, testCases, pws)
-
-	// Verify all pws are as they should
-	pass := true
-	for k, v := range pws {
-		switch {
-		case k == "plugin-static-role-10":
-			// expect all passwords to be different
-			if v[0] == v[1] || v[1] == v[2] || v[0] == v[2] {
-				pass = false
-			}
-		case k == "plugin-static-role-20":
-			// expect the first two to be equal, but different from the third
-			if v[0] != v[1] || v[0] == v[2] {
-				pass = false
-			}
-		case k == "plugin-static-role-100":
-			// expect all passwords to be equal
-			if v[0] != v[1] || v[1] != v[2] {
-				pass = false
-			}
-		default:
-			t.Fatalf("unexpected password key: %v", k)
-		}
-	}
-	if !pass {
-		t.Fatalf("password rotations did not match expected: %#v", pws)
-	}
+	uc := userCreator(func(t *testing.T, username, password string) {
+		createTestPGUser(t, connURL, username, password, testRoleStaticCreate)
+	})
+	testBackend_StaticRole_Rotations(t, uc, map[string]interface{}{
+		"connection_url": connURL,
+		"plugin_name":    "postgresql-database-plugin",
+	})
 }
 
 func TestBackend_StaticRole_Rotations_MongoDB(t *testing.T) {
+	cleanup, connURL := mongodb.PrepareTestContainerWithDatabase(t, "latest", "vaulttestdb")
+	defer cleanup()
+
+	uc := userCreator(func(t *testing.T, username, password string) {
+		testCreateDBUser(t, connURL, "vaulttestdb", username, password)
+	})
+	testBackend_StaticRole_Rotations(t, uc, map[string]interface{}{
+		"connection_url": connURL,
+		"plugin_name":    "mongodb-database-plugin",
+	})
+}
+
+func testBackend_StaticRole_Rotations(t *testing.T, createUser userCreator, opts map[string]interface{}) {
 	cluster, sys := getCluster(t)
 	defer cluster.Cleanup()
 
 	config := logical.TestBackendConfig()
 	config.StorageView = &logical.InmemStorage{}
 	config.System = sys
-
-	// configure backend, add item and confirm length
-	cleanup, connURL := mongodb.PrepareTestContainerWithDatabase(t, "latest", "vaulttestdb")
-	defer cleanup()
 
 	// Rotation ticker starts running in Factory call
 	b, err := Factory(context.Background(), config)
@@ -849,21 +737,22 @@ func TestBackend_StaticRole_Rotations_MongoDB(t *testing.T) {
 	testCases := []string{"10", "20", "100"}
 	// Create database users ahead
 	for _, tc := range testCases {
-		testCreateDBUser(t, connURL, "vaulttestdb", "statictestMongo"+tc, "test")
+		createUser(t, "statictest"+tc, "test")
 	}
 
 	// Configure a connection
 	data := map[string]interface{}{
-		"connection_url":    connURL,
-		"plugin_name":       "mongodb-database-plugin",
 		"verify_connection": false,
 		"allowed_roles":     []string{"*"},
-		"name":              "plugin-mongo-test",
+		"name":              "plugin-test",
+	}
+	for k, v := range opts {
+		data[k] = v
 	}
 
 	req := &logical.Request{
 		Operation: logical.UpdateOperation,
-		Path:      "config/plugin-mongo-test",
+		Path:      "config/plugin-test",
 		Storage:   config.StorageView,
 		Data:      data,
 	}
@@ -877,8 +766,8 @@ func TestBackend_StaticRole_Rotations_MongoDB(t *testing.T) {
 		roleName := "plugin-static-role-" + tc
 		data = map[string]interface{}{
 			"name":            roleName,
-			"db_name":         "plugin-mongo-test",
-			"username":        "statictestMongo" + tc,
+			"db_name":         "plugin-test",
+			"username":        "statictest" + tc,
 			"rotation_period": tc,
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/DataDog/zstd v1.4.4 // indirect
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/SAP/go-hdb v0.14.1
+	github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190620160927-9418d7b0cd0f
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190307165228-86c17b95fcd5
@@ -106,6 +107,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/mitchellh/reflectwalk v1.0.1
+	github.com/mongodb/go-client-mongodb-atlas v0.1.2
 	github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc
 	github.com/ncw/swift v1.0.47
 	github.com/nwaples/rardecode v1.0.0 // indirect

--- a/helper/testhelpers/postgresql/postgreshelper.go
+++ b/helper/testhelpers/postgresql/postgreshelper.go
@@ -1,0 +1,53 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/vault/helper/testhelpers/docker"
+	"github.com/ory/dockertest"
+)
+
+func PrepareTestContainer(t *testing.T, version string) (cleanup func(), retURL string) {
+	if os.Getenv("PG_URL") != "" {
+		return func() {}, os.Getenv("PG_URL")
+	}
+	if version == "" {
+		version = "latest"
+	}
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Fatalf("Failed to connect to docker: %s", err)
+	}
+
+	resource, err := pool.Run("postgres", "latest", []string{"POSTGRES_PASSWORD=secret", "POSTGRES_DB=database"})
+	if err != nil {
+		t.Fatalf("Could not start local PostgreSQL docker container: %s", err)
+	}
+
+	cleanup = func() {
+		docker.CleanupResource(t, pool, resource)
+	}
+
+	retURL = fmt.Sprintf("postgres://postgres:secret@localhost:%s/database?sslmode=disable", resource.GetPort("5432/tcp"))
+
+	// exponential backoff-retry
+	if err = pool.Retry(func() error {
+		var err error
+		var db *sql.DB
+		db, err = sql.Open("postgres", retURL)
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		return db.Ping()
+	}); err != nil {
+		cleanup()
+		t.Fatalf("Could not connect to PostgreSQL docker container: %s", err)
+	}
+
+	return
+}

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -7,10 +7,9 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/helper/testhelpers/docker"
+	"github.com/hashicorp/vault/helper/testhelpers/postgresql"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
-	"github.com/ory/dockertest"
 
 	_ "github.com/lib/pq"
 )
@@ -19,11 +18,11 @@ func TestPostgreSQLBackend(t *testing.T) {
 	logger := logging.NewVaultLogger(log.Debug)
 
 	// Use docker as pg backend if no url is provided via environment variables
-	var cleanup func()
 	connURL := os.Getenv("PGURL")
 	if connURL == "" {
-		cleanup, connURL = prepareTestContainer(t, logger)
+		cleanup, u := postgresql.PrepareTestContainer(t, "11.1")
 		defer cleanup()
+		connURL = u
 	}
 
 	table := os.Getenv("PGTABLE")
@@ -359,47 +358,6 @@ func testPostgresSQLLockRenewal(t *testing.T, ha physical.HABackend) {
 
 	// Cleanup
 	newLock.Unlock()
-}
-
-func prepareTestContainer(t *testing.T, logger log.Logger) (cleanup func(), retConnString string) {
-	// If environment variable is set, use this connectionstring without starting docker container
-	if os.Getenv("PGURL") != "" {
-		return func() {}, os.Getenv("PGURL")
-	}
-
-	pool, err := dockertest.NewPool("")
-	if err != nil {
-		t.Fatalf("Failed to connect to docker: %s", err)
-	}
-	// using 11.1 which is currently latest, use hard version for stability of tests
-	resource, err := pool.Run("postgres", "11.1", []string{})
-	if err != nil {
-		t.Fatalf("Could not start docker Postgres: %s", err)
-	}
-
-	retConnString = fmt.Sprintf("postgres://postgres@localhost:%v/postgres?sslmode=disable", resource.GetPort("5432/tcp"))
-
-	cleanup = func() {
-		docker.CleanupResource(t, pool, resource)
-	}
-
-	// Provide a test function to the pool to test if docker instance service is up.
-	// We try to setup a pg backend as test for successful connect
-	// exponential backoff-retry, because the dockerinstance may not be able to accept
-	// connections yet, test by trying to setup a postgres backend, max-timeout is 60s
-	if err := pool.Retry(func() error {
-		var err error
-		_, err = NewPostgreSQLBackend(map[string]string{
-			"connection_url": retConnString,
-		}, logger)
-		return err
-
-	}); err != nil {
-		cleanup()
-		t.Fatalf("Could not connect to docker: %s", err)
-	}
-
-	return cleanup, retConnString
 }
 
 func setupDatabaseObjects(t *testing.T, logger log.Logger, pg *PostgreSQLBackend) {

--- a/vault/external_tests/api/renewer_integration_test.go
+++ b/vault/external_tests/api/renewer_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
+	postgreshelper "github.com/hashicorp/vault/helper/testhelpers/postgresql"
 )
 
 func TestRenewer_Renew(t *testing.T) {
@@ -89,8 +90,8 @@ func TestRenewer_Renew(t *testing.T) {
 		t.Run("database", func(t *testing.T) {
 			t.Parallel()
 
-			pgURL, pgDone := testPostgresDB(t)
-			defer pgDone()
+			cleanup, pgURL := postgreshelper.PrepareTestContainer(t, "")
+			defer cleanup()
 
 			if err := client.Sys().Mount("database", &api.MountInput{
 				Type: "database",

--- a/vendor/github.com/hashicorp/vault/api/client.go
+++ b/vendor/github.com/hashicorp/vault/api/client.go
@@ -813,13 +813,10 @@ START:
 	}
 
 	if timeout != 0 {
-		// NOTE: this leaks a timer. But when we defer a cancel call here for
-		// the returned function we see errors in tests with contxt canceled.
-		// Although the request is done by the time we exit this function it is
-		// still causing something else to go wrong. Maybe it ends up being
-		// tied to the response somehow and reading the response body ends up
-		// checking it, or something. I don't know, but until we can chase this
-		// down, keep it not-canceled even though vet complains.
+		// Note: we purposefully do not call cancel manually. The reason is
+		// when canceled, the request.Body will EOF when reading due to the way
+		// it streams data in. Cancel will still be run when the timeout is
+		// hit, so this doesn't really harm anything.
 		ctx, _ = context.WithTimeout(ctx, timeout)
 	}
 	req.Request = req.Request.WithContext(ctx)

--- a/vendor/github.com/hashicorp/vault/api/sys_plugins.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_plugins.go
@@ -225,7 +225,7 @@ func (c *Sys) DeregisterPlugin(i *DeregisterPluginInput) error {
 	return err
 }
 
-// ReloadPluginInput is used as input fo the ReloadPlugin function.
+// ReloadPluginInput is used as input to the ReloadPlugin function.
 type ReloadPluginInput struct {
 	// Plugin is the name of the plugin to reload, as registered in the plugin catalog
 	Plugin string `json:"plugin"`
@@ -247,9 +247,10 @@ func (c *Sys) ReloadPlugin(i *ReloadPluginInput) error {
 	defer cancelFunc()
 
 	resp, err := c.c.RawRequestWithContext(ctx, req)
-	if err == nil {
-		defer resp.Body.Close()
+	if err != nil {
+		return err
 	}
+	defer resp.Body.Close()
 	return err
 }
 

--- a/vendor/github.com/hashicorp/vault/sdk/framework/backend.go
+++ b/vendor/github.com/hashicorp/vault/sdk/framework/backend.go
@@ -623,6 +623,8 @@ func (t FieldType) Zero() interface{} {
 		return []int{}
 	case TypeHeader:
 		return http.Header{}
+	case TypeFloat:
+		return 0.0
 	default:
 		panic("unknown type: " + t.String())
 	}

--- a/vendor/github.com/hashicorp/vault/sdk/framework/field_data.go
+++ b/vendor/github.com/hashicorp/vault/sdk/framework/field_data.go
@@ -40,7 +40,7 @@ func (d *FieldData) Validate() error {
 		switch schema.Type {
 		case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
 			TypeLowerCaseString, TypeNameString, TypeSlice, TypeStringSlice, TypeCommaStringSlice,
-			TypeKVPairs, TypeCommaIntSlice, TypeHeader:
+			TypeKVPairs, TypeCommaIntSlice, TypeHeader, TypeFloat:
 			_, _, err := d.getPrimitive(field, schema)
 			if err != nil {
 				return errwrap.Wrapf(fmt.Sprintf("error converting input %v for field %q: {{err}}", value, field), err)
@@ -133,7 +133,7 @@ func (d *FieldData) GetOkErr(k string) (interface{}, bool, error) {
 	switch schema.Type {
 	case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
 		TypeLowerCaseString, TypeNameString, TypeSlice, TypeStringSlice, TypeCommaStringSlice,
-		TypeKVPairs, TypeCommaIntSlice, TypeHeader:
+		TypeKVPairs, TypeCommaIntSlice, TypeHeader, TypeFloat:
 		return d.getPrimitive(k, schema)
 	default:
 		return nil, false,
@@ -157,6 +157,13 @@ func (d *FieldData) getPrimitive(k string, schema *FieldSchema) (interface{}, bo
 
 	case TypeInt:
 		var result int
+		if err := mapstructure.WeakDecode(raw, &result); err != nil {
+			return nil, false, err
+		}
+		return result, true, nil
+
+	case TypeFloat:
+		var result float64
 		if err := mapstructure.WeakDecode(raw, &result); err != nil {
 			return nil, false, err
 		}

--- a/vendor/github.com/hashicorp/vault/sdk/framework/field_type.go
+++ b/vendor/github.com/hashicorp/vault/sdk/framework/field_type.go
@@ -53,6 +53,9 @@ const (
 	// benevolent MITM for a request, and the headers are sent through and
 	// parsed.
 	TypeHeader
+
+	// TypeFloat parses both float32 and float64 values
+	TypeFloat
 )
 
 func (t FieldType) String() string {
@@ -77,6 +80,8 @@ func (t FieldType) String() string {
 		return "slice"
 	case TypeHeader:
 		return "header"
+	case TypeFloat:
+		return "float"
 	default:
 		return "unknown type"
 	}

--- a/vendor/github.com/hashicorp/vault/sdk/helper/certutil/helpers.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/certutil/helpers.go
@@ -169,6 +169,8 @@ func ParsePEMBundle(pemBundle string) (*ParsedCertBundle, error) {
 				Certificate: certificates[0],
 				Bytes:       pemBlock.Bytes,
 			})
+		} else if x509.IsEncryptedPEMBlock(pemBlock) {
+			return nil, errutil.UserError{Err: "Encrypted private key given; provide only decrypted private key in the bundle"}
 		}
 	}
 

--- a/vendor/github.com/hashicorp/vault/sdk/helper/certutil/types.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/certutil/types.go
@@ -321,8 +321,10 @@ func (p *ParsedCertBundle) Verify() error {
 				return fmt.Errorf("certificate %d of certificate chain is not a certificate authority", i+1)
 			}
 			if !bytes.Equal(certPath[i].Certificate.AuthorityKeyId, caCert.Certificate.SubjectKeyId) {
-				return fmt.Errorf("certificate %d of certificate chain ca trust path is incorrect (%q/%q)",
-					i+1, certPath[i].Certificate.Subject.CommonName, caCert.Certificate.Subject.CommonName)
+				return fmt.Errorf("certificate %d of certificate chain ca trust path is incorrect (%q/%q) (%X/%X)",
+					i+1,
+					certPath[i].Certificate.Subject.CommonName, caCert.Certificate.Subject.CommonName,
+					certPath[i].Certificate.AuthorityKeyId, caCert.Certificate.SubjectKeyId)
 			}
 		}
 	}


### PR DESCRIPTION
I incorporated some of my changes from my docker-test branch that weren't actually specific to testing with docker.  They made these changes easier by allowing me to pre-create the PG container and have the rotation tests complete in 30s instead of several minutes.

The needed env var settings to run this test have been added to 1p.  I'd like to add them to CircleCI as well if folks are ok with that.

Note that the test will fail until we apply https://github.com/hashicorp/vault-plugin-database-mongodbatlas/pull/11.