### PR TITLE
doc: add notes about injector annotations

### DIFF
--- a/website/pages/docs/platform/k8s/injector/annotations.mdx
+++ b/website/pages/docs/platform/k8s/injector/annotations.mdx
@@ -7,9 +7,15 @@ description: This section documents the configurable annotations for the Vault A
 
 # Annotations
 
-The following are the available annotations for the injector.
+The following are the available annotations for the injector.  These annotations 
+are organized into two sections: agent and vault.  All of the annotations below 
+change the configurations of the Vault Agent containers injected into the pod.
 
 ## Agent Annotations
+
+Agent annotations change the Vault Agent containers templating configuration.  For 
+example, agent annotations allow users to define what secrets they want, how to render 
+them, optional commands to run, etc.
 
 - `vault.hashicorp.com/agent-inject` - configures whether injection is explicitly
   enabled or disabled for a pod. This should be set to a `true` or `false` value.
@@ -97,6 +103,10 @@ The following are the available annotations for the injector.
   secrets in the pod.
 
 ## Vault Annotations
+
+Vault annotations change how the Vault Agent containers communicate with Vault.  For 
+example, Vault's address, TLS certificates to use, client parameters such as timeouts, 
+etc. 
 
 - `vault.hashicorp.com/auth-path` - configures the auth path for the Kubernetes 
   auth method.  Defaults to `kubernetes`.


### PR DESCRIPTION
There is some confusion about how we organize Vault Injector annotations into two categories: agent and vault.  All of these annotations configure the Vault Agent containers, but what they configure differ.  Added some notes to hopefully clarify the distinction.