### PR TITLE
secrets/database: return any error from rotations

### DIFF
--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -177,6 +177,9 @@ func (b *databaseBackend) pathRotateRoleCredentialsUpdate() framework.OperationF
 			RoleName: name,
 			Role:     role,
 		})
+		// if err is not nil, we need to attempt to update the priority and place
+		// this item back on the queue. The err should still be returned at the end
+		// of this method.
 		if err != nil {
 			b.logger.Warn("unable to rotate credentials in rotate-role", "error", err)
 			// Update the priority to re-try this rotation and re-add the item to
@@ -196,7 +199,8 @@ func (b *databaseBackend) pathRotateRoleCredentialsUpdate() framework.OperationF
 			return nil, err
 		}
 
-		return nil, nil
+		// return any err from the setStaticAccount call
+		return nil, err
 	}
 }
 


### PR DESCRIPTION
When rotating credentials, if the call to `setStaticAccount` to rotate the credentials of a static account were to fail (ex. read-only storage) the role gets an updated priority and placed back on the queue to try again. The error returned from `setStaticAccount` gets lost and is not returned, which could result in a `200` type API response even though the operation actually failed. 

This change makes sure we return any error from `setStaticAccount`

------
Related to https://github.com/hashicorp/vault/pull/8105