### PR TITLE
docs: fix agent listener link

### DIFF
--- a/website/pages/docs/agent/index.mdx
+++ b/website/pages/docs/agent/index.mdx
@@ -94,7 +94,7 @@ configuration entries:
 
 ### listener Stanza
 
-Agent supports one or more [listener](listener_main) stanzas. In addition to
+Agent supports one or more [listener][listener_main] stanzas. In addition to
 the standard listener configuration, an Agent's listener configuration also
 supports an additional optional entry:
 


### PR DESCRIPTION
I was looking through the docs and saw the listener link on https://www.vaultproject.io/docs/agent#listener-stanza went to a 404 page at https://www.vaultproject.io/docs/listener_main