### PR TITLE
fix missing line-continuation in sample code

### DIFF
--- a/website/pages/api-docs/auth/userpass/index.mdx
+++ b/website/pages/api-docs/auth/userpass/index.mdx
@@ -182,7 +182,7 @@ List available userpass users.
 ```
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request LIST
+    --request LIST \
     http://127.0.0.1:8200/v1/auth/userpass/users
 ```
 


### PR DESCRIPTION
The backslash symbol that indicates that the line is continued in the next line was missing.