### PR TITLE
Backport 1.4.2: Refactor service registration (#8976)

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -966,9 +966,6 @@ func (c *ServerCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Instantiate the wait group
-	c.WaitGroup = &sync.WaitGroup{}
-
 	// Initialize the Service Discovery, if there is one
 	var configSR sr.ServiceRegistration
 	if config.ServiceRegistration != nil {
@@ -990,13 +987,9 @@ func (c *ServerCommand) Run(args []string) int {
 			IsActive:             false,
 			IsPerformanceStandby: false,
 		}
-		configSR, err = sdFactory(config.ServiceRegistration.Config, namedSDLogger, state, config.Storage.RedirectAddr)
+		configSR, err = sdFactory(config.ServiceRegistration.Config, namedSDLogger, state)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error initializing service_registration of type %s: %s", config.ServiceRegistration.Type, err))
-			return 1
-		}
-		if err := configSR.Run(c.ShutdownCh, c.WaitGroup); err != nil {
-			c.UI.Error(fmt.Sprintf("Error running service_registration of type %s: %s", config.ServiceRegistration.Type, err))
 			return 1
 		}
 	}
@@ -1311,7 +1304,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 
 	// If ServiceRegistration is configured, then the backend must support HA
 	isBackendHA := coreConfig.HAPhysical != nil && coreConfig.HAPhysical.HAEnabled()
-	if !c.flagDev && (coreConfig.ServiceRegistration != nil) && !isBackendHA {
+	if !c.flagDev && (coreConfig.GetServiceRegistration() != nil) && !isBackendHA {
 		c.UI.Output("service_registration is configured, but storage does not support HA")
 		return 1
 	}
@@ -1578,6 +1571,18 @@ CLUSTER_SYNTHESIS_COMPLETE:
 	}
 
 	// Perform initialization of HTTP server after the verifyOnly check.
+
+	// Instantiate the wait group
+	c.WaitGroup = &sync.WaitGroup{}
+
+	// If service discovery is available, run service discovery
+	if sd := coreConfig.GetServiceRegistration(); sd != nil {
+		if err := configSR.Run(c.ShutdownCh, c.WaitGroup, coreConfig.RedirectAddr); err != nil {
+			c.UI.Error(fmt.Sprintf("Error running service_registration of type %s: %s", config.ServiceRegistration.Type, err))
+			return 1
+		}
+	}
+
 	// If we're in Dev mode, then initialize the core
 	if c.flagDev && !c.flagDevSkipInit {
 		init, err := c.enableDev(core, coreConfig)

--- a/serviceregistration/consul/consul_service_registration_test.go
+++ b/serviceregistration/consul/consul_service_registration_test.go
@@ -32,11 +32,11 @@ func testConsulServiceRegistrationConfig(t *testing.T, conf *consulConf) *servic
 	defer func() {
 		close(shutdownCh)
 	}()
-	be, err := NewServiceRegistration(*conf, logger, sr.State{}, "")
+	be, err := NewServiceRegistration(*conf, logger, sr.State{})
 	if err != nil {
 		t.Fatalf("Expected Consul to initialize: %v", err)
 	}
-	if err := be.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+	if err := be.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -69,8 +69,10 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 	waitForServices := func(t *testing.T, expected map[string][]string) map[string][]string {
 		t.Helper()
 		// Wait for up to 10 seconds
+		var services map[string][]string
+		var err error
 		for i := 0; i < 10; i++ {
-			services, _, err := client.Catalog().Services(nil)
+			services, _, err = client.Catalog().Services(nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -79,7 +81,7 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 			}
 			time.Sleep(time.Second)
 		}
-		t.Fatalf("Catalog Services never reached expected state %v", expected)
+		t.Fatalf("Catalog Services never reached: got: %v, expected state: %v", services, expected)
 		return nil
 	}
 
@@ -94,11 +96,11 @@ func TestConsul_ServiceRegistration(t *testing.T) {
 	sd, err := NewServiceRegistration(map[string]string{
 		"address": addr,
 		"token":   token,
-	}, logger, sr.State{}, redirectAddr)
+	}, logger, sr.State{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := sd.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+	if err := sd.Run(shutdownCh, &sync.WaitGroup{}, redirectAddr); err != nil {
 		t.Fatal(err)
 	}
 
@@ -167,11 +169,11 @@ func TestConsul_ServiceTags(t *testing.T) {
 		close(shutdownCh)
 	}()
 
-	be, err := NewServiceRegistration(consulConfig, logger, sr.State{}, "")
+	be, err := NewServiceRegistration(consulConfig, logger, sr.State{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := be.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+	if err := be.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -226,11 +228,11 @@ func TestConsul_ServiceAddress(t *testing.T) {
 		shutdownCh := make(chan struct{})
 		logger := logging.NewVaultLogger(log.Debug)
 
-		be, err := NewServiceRegistration(test.consulConfig, logger, sr.State{}, "")
+		be, err := NewServiceRegistration(test.consulConfig, logger, sr.State{})
 		if err != nil {
 			t.Fatalf("expected Consul to initialize: %v", err)
 		}
-		if err := be.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+		if err := be.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -355,7 +357,7 @@ func TestConsul_newConsulServiceRegistration(t *testing.T) {
 		shutdownCh := make(chan struct{})
 		logger := logging.NewVaultLogger(log.Debug)
 
-		be, err := NewServiceRegistration(test.consulConfig, logger, sr.State{}, "")
+		be, err := NewServiceRegistration(test.consulConfig, logger, sr.State{})
 		if test.fail {
 			if err == nil {
 				t.Fatalf(`Expected config "%s" to fail`, test.name)
@@ -365,7 +367,7 @@ func TestConsul_newConsulServiceRegistration(t *testing.T) {
 		} else if !test.fail && err != nil {
 			t.Fatalf("Expected config %s to not fail: %v", test.name, err)
 		}
-		if err := be.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+		if err := be.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 			t.Fatal(err)
 		}
 
@@ -559,7 +561,7 @@ func TestConsul_serviceID(t *testing.T) {
 		shutdownCh := make(chan struct{})
 		be, err := NewServiceRegistration(consulConf{
 			"service": test.serviceName,
-		}, logger, sr.State{}, "")
+		}, logger, sr.State{})
 		if !test.valid {
 			if err == nil {
 				t.Fatalf("expected an error initializing for name %q", test.serviceName)
@@ -569,7 +571,7 @@ func TestConsul_serviceID(t *testing.T) {
 		if test.valid && err != nil {
 			t.Fatalf("expected Consul to initialize: %v", err)
 		}
-		if err := be.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+		if err := be.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 			t.Fatal(err)
 		}
 

--- a/serviceregistration/kubernetes/client/client_test.go
+++ b/serviceregistration/kubernetes/client/client_test.go
@@ -22,7 +22,7 @@ func TestClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client, err := New(hclog.Default(), make(chan struct{}))
+	client, err := New(hclog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/serviceregistration/kubernetes/retry_handler.go
+++ b/serviceregistration/kubernetes/retry_handler.go
@@ -2,11 +2,14 @@ package kubernetes
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	sr "github.com/hashicorp/vault/serviceregistration"
 	"github.com/hashicorp/vault/serviceregistration/kubernetes/client"
+	"github.com/oklog/run"
 )
 
 // How often to retry sending a state update if it fails.
@@ -22,58 +25,93 @@ type retryHandler struct {
 	// To synchronize setInitialState and patchesToRetry.
 	lock sync.Mutex
 
-	// setInitialState will be nil if this has been done successfully.
-	// It must be done before any patches are retried.
-	setInitialState func() error
+	// initialStateSet determines whether an initial state has been set
+	// successfully or whether a state already exists.
+	initialStateSet bool
+
+	// State stores an initial state to be set
+	initialState sr.State
 
 	// The map holds the path to the label being updated. It will only either
 	// not hold a particular label, or hold _the last_ state we were aware of.
 	// These should only be updated after initial state has been set.
 	patchesToRetry map[string]*client.Patch
-}
 
-func (r *retryHandler) SetInitialState(setInitialState func() error) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	if err := setInitialState(); err != nil {
-		if r.logger.IsWarn() {
-			r.logger.Warn(fmt.Sprintf("unable to set initial state due to %s, will retry", err.Error()))
-		}
-		r.setInitialState = setInitialState
-	}
+	// client is the Client to use when making API calls against kubernetes
+	client *client.Client
 }
 
 // Run must be called for retries to be started.
-func (r *retryHandler) Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup, c *client.Client) {
+func (r *retryHandler) Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup) {
+	r.setInitialState(shutdownCh)
+
 	// Run this in a go func so this call doesn't block.
+	wait.Add(1)
 	go func() {
 		// Make sure Vault will give us time to finish up here.
-		wait.Add(1)
 		defer wait.Done()
 
-		retry := time.NewTicker(retryFreq)
-		defer retry.Stop()
-		for {
+		var g run.Group
+
+		// This run group watches for the shutdownCh
+		shutdownActorStop := make(chan struct{})
+		g.Add(func() error {
 			select {
 			case <-shutdownCh:
-				return
-			case <-retry.C:
-				r.retry(c)
+			case <-shutdownActorStop:
 			}
+			return nil
+		}, func(error) {
+			close(shutdownActorStop)
+		})
+
+		checkUpdateStateStop := make(chan struct{})
+		g.Add(func() error {
+			r.periodicUpdateState(checkUpdateStateStop)
+			return nil
+		}, func(error) {
+			close(checkUpdateStateStop)
+			r.client.Shutdown()
+		})
+
+		if err := g.Run(); err != nil {
+			r.logger.Error("error encountered during periodic state update", "error", err)
 		}
 	}()
 }
 
+func (r *retryHandler) setInitialState(shutdownCh <-chan struct{}) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		if err := r.setInitialStateInternal(); err != nil {
+			if r.logger.IsWarn() {
+				r.logger.Warn(fmt.Sprintf("unable to set initial state due to %s, will retry", err.Error()))
+			}
+		}
+		close(doneCh)
+	}()
+
+	// Wait until the state is set or shutdown happens
+	select {
+	case <-doneCh:
+	case <-shutdownCh:
+	}
+}
+
 // Notify adds a patch to be retried until it's either completed without
 // error, or no longer needed.
-func (r *retryHandler) Notify(c *client.Client, patch *client.Patch) {
+func (r *retryHandler) Notify(patch *client.Patch) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	// Initial state must be set first, or subsequent notifications we've
 	// received could get smashed by a late-arriving initial state.
 	// We will store this to retry it when appropriate.
-	if r.setInitialState != nil {
+	if !r.initialStateSet {
 		if r.logger.IsWarn() {
 			r.logger.Warn(fmt.Sprintf("cannot notify of present state for %s because initial state is unset", patch.Path))
 		}
@@ -82,7 +120,7 @@ func (r *retryHandler) Notify(c *client.Client, patch *client.Patch) {
 	}
 
 	// Initial state has been sent, so it's OK to attempt a patch immediately.
-	if err := c.PatchPod(r.namespace, r.podName, patch); err != nil {
+	if err := r.client.PatchPod(r.namespace, r.podName, patch); err != nil {
 		if r.logger.IsWarn() {
 			r.logger.Warn(fmt.Sprintf("unable to update state for %s due to %s, will retry", patch.Path, err.Error()))
 		}
@@ -90,23 +128,110 @@ func (r *retryHandler) Notify(c *client.Client, patch *client.Patch) {
 	}
 }
 
-func (r *retryHandler) retry(c *client.Client) {
+// setInitialStateInternal sets the initial state remotely. This should be
+// called with the lock held.
+func (r *retryHandler) setInitialStateInternal() error {
+	// If this is set, we return immediately
+	if r.initialStateSet {
+		return nil
+	}
+
+	// Verify that the pod exists and our configuration looks good.
+	pod, err := r.client.GetPod(r.namespace, r.podName)
+	if err != nil {
+		return err
+	}
+
+	// Now to initially label our pod.
+	if pod.Metadata == nil {
+		// This should never happen IRL, just being defensive.
+		return fmt.Errorf("no pod metadata on %+v", pod)
+	}
+	if pod.Metadata.Labels == nil {
+		// Notify the labels field, and the labels as part of that one call.
+		// The reason we must take a different approach to adding them is discussed here:
+		// https://stackoverflow.com/questions/57480205/error-while-applying-json-patch-to-kubernetes-custom-resource
+		if err := r.client.PatchPod(r.namespace, r.podName, &client.Patch{
+			Operation: client.Add,
+			Path:      "/metadata/labels",
+			Value: map[string]string{
+				labelVaultVersion: r.initialState.VaultVersion,
+				labelActive:       strconv.FormatBool(r.initialState.IsActive),
+				labelSealed:       strconv.FormatBool(r.initialState.IsSealed),
+				labelPerfStandby:  strconv.FormatBool(r.initialState.IsPerformanceStandby),
+				labelInitialized:  strconv.FormatBool(r.initialState.IsInitialized),
+			},
+		}); err != nil {
+			return err
+		}
+	} else {
+		// Create the labels through a patch to each individual field.
+		patches := []*client.Patch{
+			{
+				Operation: client.Replace,
+				Path:      pathToLabels + labelVaultVersion,
+				Value:     r.initialState.VaultVersion,
+			},
+			{
+				Operation: client.Replace,
+				Path:      pathToLabels + labelActive,
+				Value:     strconv.FormatBool(r.initialState.IsActive),
+			},
+			{
+				Operation: client.Replace,
+				Path:      pathToLabels + labelSealed,
+				Value:     strconv.FormatBool(r.initialState.IsSealed),
+			},
+			{
+				Operation: client.Replace,
+				Path:      pathToLabels + labelPerfStandby,
+				Value:     strconv.FormatBool(r.initialState.IsPerformanceStandby),
+			},
+			{
+				Operation: client.Replace,
+				Path:      pathToLabels + labelInitialized,
+				Value:     strconv.FormatBool(r.initialState.IsInitialized),
+			},
+		}
+		if err := r.client.PatchPod(r.namespace, r.podName, patches...); err != nil {
+			return err
+		}
+	}
+	r.initialStateSet = true
+	return nil
+}
+
+func (r *retryHandler) periodicUpdateState(stopCh chan struct{}) {
+	retry := time.NewTicker(retryFreq)
+	defer retry.Stop()
+
+	for {
+		// Call updateState immediately so we don't wait for the first tick
+		// if setting the initial state
+		r.updateState()
+
+		select {
+		case <-stopCh:
+			return
+		case <-retry.C:
+		}
+	}
+}
+
+func (r *retryHandler) updateState() {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	// Initial state must be set first, or subsequent notifications we've
 	// received could get smashed by a late-arriving initial state.
-	if r.setInitialState != nil {
-		if err := r.setInitialState(); err != nil {
-			if r.logger.IsWarn() {
-				r.logger.Warn(fmt.Sprintf("unable to set initial state due to %s, will retry", err.Error()))
-			}
-			// On failure, we leave the initial state func populated for
-			// the next retry.
-			return
+	// If the state is already set, this is a no-op.
+	if err := r.setInitialStateInternal(); err != nil {
+		if r.logger.IsWarn() {
+			r.logger.Warn(fmt.Sprintf("unable to set initial state due to %s, will retry", err.Error()))
 		}
-		// On success, we set it to nil and allow the logic to continue.
-		r.setInitialState = nil
+		// On failure, we leave the initial state func populated for
+		// the next retry.
+		return
 	}
 
 	if len(r.patchesToRetry) == 0 {
@@ -121,7 +246,7 @@ func (r *retryHandler) retry(c *client.Client) {
 		i++
 	}
 
-	if err := c.PatchPod(r.namespace, r.podName, patches...); err != nil {
+	if err := r.client.PatchPod(r.namespace, r.podName, patches...); err != nil {
 		if r.logger.IsWarn() {
 			r.logger.Warn(fmt.Sprintf("unable to update state for due to %s, will retry", err.Error()))
 		}

--- a/serviceregistration/kubernetes/service_registration.go
+++ b/serviceregistration/kubernetes/service_registration.go
@@ -23,7 +23,7 @@ const (
 	pathToLabels = "/metadata/labels/"
 )
 
-func NewServiceRegistration(config map[string]string, logger hclog.Logger, state sr.State, _ string) (sr.ServiceRegistration, error) {
+func NewServiceRegistration(config map[string]string, logger hclog.Logger, state sr.State) (sr.ServiceRegistration, error) {
 	namespace, err := getRequiredField(logger, config, client.EnvVarKubernetesNamespace, "namespace")
 	if err != nil {
 		return nil, err
@@ -32,19 +32,26 @@ func NewServiceRegistration(config map[string]string, logger hclog.Logger, state
 	if err != nil {
 		return nil, err
 	}
+
+	c, err := client.New(logger)
+	if err != nil {
+		return nil, err
+	}
+
 	// The Vault version must be sanitized because it can contain special
 	// characters like "+" which aren't acceptable by the Kube API.
 	state.VaultVersion = client.Sanitize(state.VaultVersion)
 	return &serviceRegistration{
-		logger:       logger,
-		namespace:    namespace,
-		podName:      podName,
-		initialState: state,
+		logger:    logger,
+		namespace: namespace,
+		podName:   podName,
 		retryHandler: &retryHandler{
 			logger:         logger,
 			namespace:      namespace,
 			podName:        podName,
+			initialState:   state,
 			patchesToRetry: make(map[string]*client.Patch),
+			client:         c,
 		},
 	}, nil
 }
@@ -52,91 +59,16 @@ func NewServiceRegistration(config map[string]string, logger hclog.Logger, state
 type serviceRegistration struct {
 	logger             hclog.Logger
 	namespace, podName string
-	client             *client.Client
-	initialState       sr.State
 	retryHandler       *retryHandler
 }
 
-func (r *serviceRegistration) Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup) error {
-	c, err := client.New(r.logger, shutdownCh)
-	if err != nil {
-		return err
-	}
-	r.client = c
-
-	// Now that we've populated the client, we can begin using the retry handler.
-	r.retryHandler.SetInitialState(r.setInitialState)
-	r.retryHandler.Run(shutdownCh, wait, c)
-	return nil
-}
-
-func (r *serviceRegistration) setInitialState() error {
-	// Verify that the pod exists and our configuration looks good.
-	pod, err := r.client.GetPod(r.namespace, r.podName)
-	if err != nil {
-		return err
-	}
-
-	// Now to initially label our pod.
-	if pod.Metadata == nil {
-		// This should never happen IRL, just being defensive.
-		return fmt.Errorf("no pod metadata on %+v", pod)
-	}
-	if pod.Metadata.Labels == nil {
-		// Notify the labels field, and the labels as part of that one call.
-		// The reason we must take a different approach to adding them is discussed here:
-		// https://stackoverflow.com/questions/57480205/error-while-applying-json-patch-to-kubernetes-custom-resource
-		if err := r.client.PatchPod(r.namespace, r.podName, &client.Patch{
-			Operation: client.Add,
-			Path:      "/metadata/labels",
-			Value: map[string]string{
-				labelVaultVersion: r.initialState.VaultVersion,
-				labelActive:       strconv.FormatBool(r.initialState.IsActive),
-				labelSealed:       strconv.FormatBool(r.initialState.IsSealed),
-				labelPerfStandby:  strconv.FormatBool(r.initialState.IsPerformanceStandby),
-				labelInitialized:  strconv.FormatBool(r.initialState.IsInitialized),
-			},
-		}); err != nil {
-			return err
-		}
-	} else {
-		// Create the labels through a patch to each individual field.
-		patches := []*client.Patch{
-			{
-				Operation: client.Replace,
-				Path:      pathToLabels + labelVaultVersion,
-				Value:     r.initialState.VaultVersion,
-			},
-			{
-				Operation: client.Replace,
-				Path:      pathToLabels + labelActive,
-				Value:     strconv.FormatBool(r.initialState.IsActive),
-			},
-			{
-				Operation: client.Replace,
-				Path:      pathToLabels + labelSealed,
-				Value:     strconv.FormatBool(r.initialState.IsSealed),
-			},
-			{
-				Operation: client.Replace,
-				Path:      pathToLabels + labelPerfStandby,
-				Value:     strconv.FormatBool(r.initialState.IsPerformanceStandby),
-			},
-			{
-				Operation: client.Replace,
-				Path:      pathToLabels + labelInitialized,
-				Value:     strconv.FormatBool(r.initialState.IsInitialized),
-			},
-		}
-		if err := r.client.PatchPod(r.namespace, r.podName, patches...); err != nil {
-			return err
-		}
-	}
+func (r *serviceRegistration) Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup, _ string) error {
+	r.retryHandler.Run(shutdownCh, wait)
 	return nil
 }
 
 func (r *serviceRegistration) NotifyActiveStateChange(isActive bool) error {
-	r.retryHandler.Notify(r.client, &client.Patch{
+	r.retryHandler.Notify(&client.Patch{
 		Operation: client.Replace,
 		Path:      pathToLabels + labelActive,
 		Value:     strconv.FormatBool(isActive),
@@ -145,7 +77,7 @@ func (r *serviceRegistration) NotifyActiveStateChange(isActive bool) error {
 }
 
 func (r *serviceRegistration) NotifySealedStateChange(isSealed bool) error {
-	r.retryHandler.Notify(r.client, &client.Patch{
+	r.retryHandler.Notify(&client.Patch{
 		Operation: client.Replace,
 		Path:      pathToLabels + labelSealed,
 		Value:     strconv.FormatBool(isSealed),
@@ -154,7 +86,7 @@ func (r *serviceRegistration) NotifySealedStateChange(isSealed bool) error {
 }
 
 func (r *serviceRegistration) NotifyPerformanceStandbyStateChange(isStandby bool) error {
-	r.retryHandler.Notify(r.client, &client.Patch{
+	r.retryHandler.Notify(&client.Patch{
 		Operation: client.Replace,
 		Path:      pathToLabels + labelPerfStandby,
 		Value:     strconv.FormatBool(isStandby),
@@ -163,7 +95,7 @@ func (r *serviceRegistration) NotifyPerformanceStandbyStateChange(isStandby bool
 }
 
 func (r *serviceRegistration) NotifyInitializedStateChange(isInitialized bool) error {
-	r.retryHandler.Notify(r.client, &client.Patch{
+	r.retryHandler.Notify(&client.Patch{
 		Operation: client.Replace,
 		Path:      pathToLabels + labelInitialized,
 		Value:     strconv.FormatBool(isInitialized),

--- a/serviceregistration/kubernetes/service_registration_test.go
+++ b/serviceregistration/kubernetes/service_registration_test.go
@@ -44,11 +44,11 @@ func TestServiceRegistration(t *testing.T) {
 		IsActive:             true,
 		IsPerformanceStandby: true,
 	}
-	reg, err := NewServiceRegistration(config, logger, state, "")
+	reg, err := NewServiceRegistration(config, logger, state)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := reg.Run(shutdownCh, &sync.WaitGroup{}); err != nil {
+	if err := reg.Run(shutdownCh, &sync.WaitGroup{}, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -648,7 +648,7 @@ func (c *CoreConfig) Clone() *CoreConfig {
 // not exist.
 func (c *CoreConfig) GetServiceRegistration() sr.ServiceRegistration {
 
-	// Check whether there is a ServiceRegistration explictly configured
+	// Check whether there is a ServiceRegistration explicitly configured
 	if c.ServiceRegistration != nil {
 		return c.ServiceRegistration
 	}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -2476,7 +2476,7 @@ type mockServiceRegistration struct {
 	runDiscoveryCount int
 }
 
-func (m *mockServiceRegistration) Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup) error {
+func (m *mockServiceRegistration) Run(shutdownCh <-chan struct{}, wait *sync.WaitGroup, redirectAddr string) error {
 	m.runDiscoveryCount++
 	return nil
 }


### PR DESCRIPTION
* serivceregistration: refactor service registration logic to run later

* move state check to the internal func

* sr/kubernetes: update setInitialStateInternal godoc

* sr/kubernetes: remove return in setInitialState

* core/test: fix mockServiceRegistration

* address review feedback