### PR TITLE
storage/raft: Add committed and applied indexes to the status output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ IMPROVEMENTS:
   `leader_client_key_file` parameters to read and parse TLS certificate information from paths on disk.
   Existing non-path based parameters will continue to work, but their values will need to be provided as a 
   single-line string with newlines delimited by `\n`.  [[GH-8894](https://github.com/hashicorp/vault/pull/8894)]
+* storage/raft: The `vault status` CLI command and the `sys/leader` API now contain the committed and applied
+  raft indexes. [[GH-9011](https://github.com/hashicorp/vault/pull/9011)]
   
 BUG FIXES:
 

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -26,4 +26,6 @@ type LeaderResponse struct {
 	PerfStandby              bool   `json:"performance_standby"`
 	PerfStandbyLastRemoteWAL uint64 `json:"performance_standby_last_remote_wal"`
 	LastWAL                  uint64 `json:"last_wal"`
+	RaftCommittedIndex       uint64 `json:"raft_committed_index,omitempty"`
+	RaftAppliedIndex         uint64 `json:"raft_applied_index,omitempty"`
 }

--- a/command/format.go
+++ b/command/format.go
@@ -383,6 +383,12 @@ func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusRespo
 		}
 	}
 
+	if leaderStatus.RaftCommittedIndex > 0 {
+		out = append(out, fmt.Sprintf("Raft Committed Index | %d", leaderStatus.RaftCommittedIndex))
+	}
+	if leaderStatus.RaftAppliedIndex > 0 {
+		out = append(out, fmt.Sprintf("Raft Applied Index | %d", leaderStatus.RaftAppliedIndex))
+	}
 	if leaderStatus.LastWAL != 0 {
 		out = append(out, fmt.Sprintf("Last WAL | %d", leaderStatus.LastWAL))
 	}

--- a/http/sys_leader.go
+++ b/http/sys_leader.go
@@ -42,6 +42,8 @@ func handleSysLeaderGet(core *vault.Core, w http.ResponseWriter, r *http.Request
 		resp.LastWAL = vault.LastWAL(core)
 	}
 
+	resp.RaftCommittedIndex, resp.RaftAppliedIndex = core.GetRaftIndexes()
+
 	respondOk(w, resp)
 }
 
@@ -53,4 +55,8 @@ type LeaderResponse struct {
 	PerfStandby              bool   `json:"performance_standby"`
 	PerfStandbyLastRemoteWAL uint64 `json:"performance_standby_last_remote_wal"`
 	LastWAL                  uint64 `json:"last_wal,omitempty"`
+
+	// Raft Indexs for this node
+	RaftCommittedIndex uint64 `json:"raft_committed_index,omitempty"`
+	RaftAppliedIndex   uint64 `json:"raft_applied_index,omitempty"`
 }

--- a/http/sys_leader.go
+++ b/http/sys_leader.go
@@ -56,7 +56,7 @@ type LeaderResponse struct {
 	PerfStandbyLastRemoteWAL uint64 `json:"performance_standby_last_remote_wal"`
 	LastWAL                  uint64 `json:"last_wal,omitempty"`
 
-	// Raft Indexs for this node
+	// Raft Indexes for this node
 	RaftCommittedIndex uint64 `json:"raft_committed_index,omitempty"`
 	RaftAppliedIndex   uint64 `json:"raft_applied_index,omitempty"`
 }

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -680,6 +680,18 @@ func (b *RaftBackend) TeardownCluster(clusterListener cluster.ClusterHook) error
 	return future.Error()
 }
 
+// CommittedIndex returns the latest index committed to stable storage
+func (b *RaftBackend) CommittedIndex() uint64 {
+	b.l.RLock()
+	defer b.l.RUnlock()
+
+	if b.raft == nil {
+		return 0
+	}
+
+	return b.raft.LastIndex()
+}
+
 // AppliedIndex returns the latest index applied to the FSM
 func (b *RaftBackend) AppliedIndex() uint64 {
 	b.l.RLock()

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -76,6 +76,18 @@ func (s *raftFollowerStates) minIndex() uint64 {
 	return min
 }
 
+func (c *Core) GetRaftIndexes() (committed uint64, applied uint64) {
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+
+	raftStorage, ok := c.underlyingPhysical.(*raft.RaftBackend)
+	if !ok {
+		return 0, 0
+	}
+
+	return raftStorage.CommittedIndex(), raftStorage.AppliedIndex()
+}
+
 // startRaftStorage will call SetupCluster in the raft backend which starts raft
 // up and enables the cluster handler.
 func (c *Core) startRaftStorage(ctx context.Context) (retErr error) {

--- a/vendor/github.com/hashicorp/vault/api/sys_leader.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_leader.go
@@ -26,4 +26,6 @@ type LeaderResponse struct {
 	PerfStandby              bool   `json:"performance_standby"`
 	PerfStandbyLastRemoteWAL uint64 `json:"performance_standby_last_remote_wal"`
 	LastWAL                  uint64 `json:"last_wal"`
+	RaftCommittedIndex       uint64 `json:"raft_committed_index,omitempty"`
+	RaftAppliedIndex         uint64 `json:"raft_applied_index,omitempty"`
 }


### PR DESCRIPTION
```
% vault status
Key                      Value
---                      -----
...
HA Mode                  standby
Active Node Address      http://127.0.0.2:8200
Raft Committed Index     317
Raft Applied Index       316
```