### PR TITLE
prepare KnownSecondariesTable for backend compatibility

### DIFF
--- a/ui/lib/replication/addon/components/known-secondaries-table.js
+++ b/ui/lib/replication/addon/components/known-secondaries-table.js
@@ -9,13 +9,15 @@ import { computed } from '@ember/object';
  * ```js
  * <KnownSecondariesTable @replicationAttrs={{replicationAttrs}} />
  * ```
- * @param {object} replicationAttrs=null - The attributes passed directly from the cluster model used to access the array of known secondaries.
+ * @param {object} replicationAttrs=null - The attributes passed directly from the cluster model used to access the array of known secondaries. We use this to grab the secondaries.
  */
 
 export default Component.extend({
   replicationAttrs: null,
-  knownSecondaries: computed('replicationAttrs', function() {
+  secondaries: computed('replicationAttrs', function() {
     const { replicationAttrs } = this;
-    return replicationAttrs.knownSecondaries;
+    // TODO: when the backend changes are merged we will only need replicationAttrs.secondaries instead of knownSecondaries
+    const secondaries = replicationAttrs.secondaries || replicationAttrs.knownSecondaries;
+    return secondaries;
   }),
 });

--- a/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
@@ -6,7 +6,8 @@
     </ToolbarLink>
   </div>
   <div class="secondaries-table">
-    {{#unless replicationAttrs.knownSecondaries}}
+    {{!-- TODO remove this or when backend api changes are merged --}}
+    {{#unless (or replicationAttrs.knownSecondaries replicationAttrs.secondaries)}}
       <EmptyState
         @title="No known {{cluster.replicationMode}} secondary clusters associated with this cluster"
         @message="Associated secondary clusters will be listed here. Add your first secondary cluster to get started." />

--- a/ui/lib/replication/addon/templates/components/known-secondaries-table.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-table.hbs
@@ -1,27 +1,40 @@
 <div class="replication vlt-table" data-test-known-secondaries-table>
   <table class="is-fullwidth">
-    <caption class="is-collapsed">Known Secondaries</caption>
+    <caption class="is-collapsed">
+      Known Secondaries
+    </caption>
     <thead class="has-text-weight-semibold">
       <tr>
-        <th scope="col">Secondary ID</th>
-        <th scope="col">URL</th>
-        <th scope="col">Connected?</th>
+        <th scope="col">
+          Secondary ID
+        </th>
+        <th scope="col">
+          URL
+        </th>
+        <th scope="col">
+          Connected?
+        </th>
       </tr>
     </thead>
     <tbody>
-      {{!-- TODO: use real values for URL and connected --}}
-      {{#each knownSecondaries as |secondary|}}
-          <tr>
-            <th scope="row" data-test-secondaries-row={{secondary}}>
-              <code>{{or secondary.id secondary}}</code>
-            </th>
-            <td>
-              <code class="is-word-break" data-test-url>{{or secondary.url 'unknown'}}</code>
-            </td>
-            <td>
-              <code>{{or secondary.connected 'unknown'}}</code>
-            </td>
-          </tr>
+      {{! TODO: this should be compliant with the new api attributes, but we should verify this
+      when those attributes are merged. At that point we can also get rid of all the 'or's in here. --}}
+      {{#each secondaries as |secondary|}}
+        <tr>
+          <th scope="row">
+            <code data-test-secondaries={{concat 'row-for-' (or secondary.id secondary)}}>
+              {{or secondary.id secondary}}
+            </code>
+          </th>
+          <td>
+            <a href={{secondary.api_address}} data-test-secondaries={{concat 'api-address-for-' secondary.id}}>
+              <code class="is-word-break">{{secondary.api_address}}</code>
+            </a>
+          </td>
+          <td>
+            <code data-test-secondaries={{concat 'connection-status-for-' (or secondary.id secondary)}}>{{secondary.connection_status}}</code>
+          </td>
+        </tr>
       {{/each}}
     </tbody>
   </table>

--- a/ui/tests/integration/components/known-secondaries-card-test.js
+++ b/ui/tests/integration/components/known-secondaries-card-test.js
@@ -11,7 +11,11 @@ const CLUSTER = {
 };
 
 const REPLICATION_ATTRS = {
-  knownSecondaries: ['firstSecondary', 'secondary-2', '3'],
+  secondaries: [
+    { id: 'secondary-1', api_address: 'https://stuff.com/', connection_status: 'connected' },
+    { id: '2nd', api_address: 'https://10.0.0.2:1234/', connection_status: 'disconnected' },
+    { id: '_three_', api_address: 'https://10.0.0.2:1000/', connection_status: 'connected' },
+  ],
 };
 
 module('Integration | Component | replication known-secondaries-card', function(hooks) {
@@ -31,9 +35,24 @@ module('Integration | Component | replication known-secondaries-card', function(
     assert.dom('[data-test-manage-link]').exists('shows manage link');
   });
 
+  // TODO: this test can be deleted once the 'secondaries' array replaces 'knownSecondaries'
+  // in the backend
+  test('it renders a known secondaries table even if api address and connection_status are missing', async function(assert) {
+    const missingSecondariesInfo = {
+      knownSecondaries: ['secondary-1', '2nd', '_three_'],
+    };
+    this.set('replicationAttrs', missingSecondariesInfo);
+
+    await render(hbs`<KnownSecondariesCard @cluster={{cluster}} @replicationAttrs={{replicationAttrs}} />`);
+
+    assert
+      .dom('[data-test-known-secondaries-table]')
+      .exists('shows known secondaries table when there are known secondaries');
+  });
+
   test('it renders an empty state if there are no known secondaries', async function(assert) {
     const noSecondaries = {
-      knownSecondaries: null,
+      secondaries: [],
     };
     this.set('replicationAttrs', noSecondaries);
     await render(hbs`<KnownSecondariesCard @cluster={{cluster}} @replicationAttrs={{replicationAttrs}} />`);


### PR DESCRIPTION
This PR updates the known secondaries card and known secondaries table on the replication primary dashboards so they will be compatible with the backend API changes proposed in VLT-102. 
Of particular note:
- for the time being, the `KnownSecondariesCard` and `KnownSecondariesTable` will receive an array of secondary information from the `sys/replication/status` called `knownSecondaries` or `secondaries`. the `secondaries` array is ultimately what we will be using in the UI, but for now i've left the components able to work with `knownSecondaries` as well
- i removed the conditionals that display `unknown` when an api address or connection status is not found. this is due to the discussion i had with @raskchanky, who mentioned that the backend endpoint would only return complete information about a secondary. that is, `api_address` or `connection_status` should never return an empty or otherwise `null` value. josh, lemme know if i've misunderstood that!

## Examples
### When there are no known secondaries
![image](https://user-images.githubusercontent.com/903288/82266587-ed729700-991e-11ea-90c6-d5ac5156180b.png)

## When there are secondaries
![image](https://user-images.githubusercontent.com/903288/82266610-fd8a7680-991e-11ea-8535-2b05e3745d7a.png)

![image](https://user-images.githubusercontent.com/903288/82267169-6d4d3100-9920-11ea-83b6-37d1082b32fa.png)

### Notes
- ☝️ i also removed the `unknown`s to match the pattern with the rest of the Vault UI, which is that we display a blank value/empty string when values aren't found from the backend. see this example from a secrets engine config. i'm def open to changing this back if we think that the `unknown` is important, though!
