### PR TITLE
Backport 1.4.2: storage/raft: Advertise the configured cluster address (#9008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ BUG FIXES:
 * serviceregistration: Fix a regression for Consul service registration that ignored using the listener address as
   the redirect address unless api_addr was provided. It now properly uses the same redirect address as the one
   used by Vault's Core object. [[GH-8976](https://github.com/hashicorp/vault/pull/8976)] 
+* storage/raft: Advertise the configured cluster address to the rest of the nodes in the raft cluster. This fixes
+  an issue where a node advertising 0.0.0.0 is not using a unique hostname. [[GH-9008](https://github.com/hashicorp/vault/pull/9008)]
+* storage/raft: Fix panic when multiple nodes attempt to join the cluster at once. [[GH-9008](https://github.com/hashicorp/vault/pull/9008)]
 * sys: The path provided in `sys/internal/ui/mounts/:path` is now namespace-aware. This fixes an issue
   with `vault kv` subcommands that had namespaces provided in the path returning permission denied all the time.
   [[GH-8962](https://github.com/hashicorp/vault/pull/8962)]

--- a/physical/raft/streamlayer_test.go
+++ b/physical/raft/streamlayer_test.go
@@ -1,0 +1,70 @@
+package raft
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/vault/cluster"
+)
+
+type mockClusterHook struct {
+	address net.Addr
+}
+
+func (*mockClusterHook) AddClient(alpn string, client cluster.Client)       {}
+func (*mockClusterHook) RemoveClient(alpn string)                           {}
+func (*mockClusterHook) AddHandler(alpn string, handler cluster.Handler)    {}
+func (*mockClusterHook) StopHandler(alpn string)                            {}
+func (*mockClusterHook) TLSConfig(ctx context.Context) (*tls.Config, error) { return nil, nil }
+func (m *mockClusterHook) Addr() net.Addr                                   { return m.address }
+func (*mockClusterHook) GetDialerFunc(ctx context.Context, alpnProto string) func(string, time.Duration) (net.Conn, error) {
+	return func(string, time.Duration) (net.Conn, error) {
+		return nil, nil
+	}
+}
+
+func TestStreamLayer_UnspecifiedIP(t *testing.T) {
+	m := &mockClusterHook{
+		address: &cluster.NetAddr{
+			Host: "0.0.0.0:8200",
+		},
+	}
+
+	raftTLSKey, err := GenerateTLSKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raftTLS := &TLSKeyring{
+		Keys:        []*TLSKey{raftTLSKey},
+		ActiveKeyID: raftTLSKey.ID,
+	}
+
+	layer, err := NewRaftLayer(nil, raftTLS, m)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if err.Error() != "cannot use unspecified IP with raft storage: 0.0.0.0:8200" {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+
+	if layer != nil {
+		t.Fatal("expected nil layer")
+	}
+
+	m.address.(*cluster.NetAddr).Host = "10.0.0.1:8200"
+
+	layer, err = NewRaftLayer(nil, raftTLS, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if layer == nil {
+		t.Fatal("nil layer")
+	}
+}

--- a/vault/cluster.go
+++ b/vault/cluster.go
@@ -317,6 +317,13 @@ func (c *Core) startClusterListener(ctx context.Context) error {
 		// If we listened on port 0, record the port the OS gave us.
 		c.clusterAddr.Store(fmt.Sprintf("https://%s", c.getClusterListener().Addr()))
 	}
+
+	if len(c.ClusterAddr()) != 0 {
+		if err := c.getClusterListener().SetAdvertiseAddr(c.ClusterAddr()); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -498,7 +498,7 @@ type Core struct {
 	// Stop channel for raft TLS rotations
 	raftTLSRotationStopCh chan struct{}
 	// Stores the pending peers we are waiting to give answers
-	pendingRaftPeers map[string][]byte
+	pendingRaftPeers *sync.Map
 
 	// rawConfig stores the config as-is from the provided server configuration.
 	rawConfig *atomic.Value

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -171,7 +171,7 @@ func (c *Core) startRaftStorage(ctx context.Context) (retErr error) {
 }
 
 func (c *Core) setupRaftActiveNode(ctx context.Context) error {
-	c.pendingRaftPeers = make(map[string][]byte)
+	c.pendingRaftPeers = &sync.Map{}
 	return c.startPeriodicRaftTLSRotate(ctx)
 }
 


### PR DESCRIPTION
* storage/raft: Advertise the configured cluster address

* Don't allow raft to start with unspecified IP

* Fix concurrent map write panic

* Add test file

* changelog++

* changelog++

* changelog++

* Update tcp_layer.go

* Update tcp_layer.go

* Only set the adverise addr if set