### PR TITLE
Add cors bits into configutil listener

### DIFF
--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -133,6 +133,8 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 				for i, v := range l.Purpose {
 					l.Purpose[i] = strings.ToLower(v)
 				}
+
+				l.PurposeRaw = nil
 			}
 		}
 


### PR DESCRIPTION
This adds a few extra values into the listener block to support cors when configured that way.