### PR TITLE
vault agent - respect consul-template retry configuration

### DIFF
--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -539,3 +539,26 @@ func TestLoadConfigFile_Template(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadConfigFile_Retry(t *testing.T) {
+	config, err := LoadConfig("./test-fixtures/retry.hcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &Config{
+		SharedConfig: &configutil.SharedConfig{},
+		Vault: &Vault{
+			Retry: &ctconfig.RetryConfig{
+				Enabled:    pointerutil.BoolPtr(true),
+				Attempts:   pointerutil.IntPtr(6),
+				Backoff:    pointerutil.TimeDurationPtr("1s"),
+				MaxBackoff: pointerutil.TimeDurationPtr("1s"),
+			},
+		},
+	}
+
+	if diff := deep.Equal(config, expected); diff != nil {
+		t.Fatal(diff)
+	}
+}

--- a/command/agent/config/test-fixtures/retry.hcl
+++ b/command/agent/config/test-fixtures/retry.hcl
@@ -1,0 +1,8 @@
+vault {
+  retry {
+    enabled = true
+    attempts = 6
+    backoff = "1s"
+    max_backoff = "1s"
+  }
+}

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -224,6 +224,10 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		}
 	}
 
+	if sc.VaultConf.Retry != nil {
+		conf.Vault.Retry = sc.VaultConf.Retry
+	}
+
 	conf.Finalize()
 
 	// setup log level from TemplateServer config

--- a/sdk/helper/pointerutil/pointer.go
+++ b/sdk/helper/pointerutil/pointer.go
@@ -31,3 +31,8 @@ func FileModePtr(o os.FileMode) *os.FileMode {
 func Int64Ptr(i int64) *int64 {
 	return &i
 }
+
+// IntPtr returns a pointer to an int value
+func IntPtr(i int) *int {
+	return &i
+}


### PR DESCRIPTION
The consul template retry stanza from configuration was not being passed
through appropriately, this should fix that.

Since a duration is not a valid HCL type, the swap from a simple hcl
decode had to be changed to `mapstructure`.