### PR TITLE
Add go version to server message output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGES:
 
 IMPROVEMENTS:
 
+* core: Add the Go version used to build a Vault binary to the server message output. [[GH-9078](https://github.com/hashicorp/vault/pull/9078)]
 * cli: Support reading TLS parameters from file for the `vault operator raft join` command. [[GH-9060](https://github.com/hashicorp/vault/pull/9060)]
 * plugin: Add SDK method, `Sys.ReloadPlugin`, and CLI command, `vault plugin reload`, 
   for reloading plugins. [[GH-8777](https://github.com/hashicorp/vault/pull/8777)]

--- a/command/server.go
+++ b/command/server.go
@@ -591,6 +591,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 	infoKeys = append(infoKeys, "version")
 	verInfo := version.GetVersion()
 	info["version"] = verInfo.FullVersionNumber(false)
+
 	if verInfo.Revision != "" {
 		info["version sha"] = strings.Trim(verInfo.Revision, "'")
 		infoKeys = append(infoKeys, "version sha")
@@ -599,10 +600,15 @@ func (c *ServerCommand) runRecoveryMode() int {
 	infoKeys = append(infoKeys, "recovery mode")
 	info["recovery mode"] = "true"
 
+	infoKeys = append(infoKeys, "go version")
+	info["go version"] = runtime.Version()
+
 	// Server configuration output
 	padding := 24
+
 	sort.Strings(infoKeys)
 	c.UI.Output("==> Vault server configuration:\n")
+
 	for _, k := range infoKeys {
 		c.UI.Output(fmt.Sprintf(
 			"%s%s: %s",
@@ -610,6 +616,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 			strings.Title(k),
 			info[k]))
 	}
+
 	c.UI.Output("")
 
 	for _, ln := range lns {
@@ -1479,6 +1486,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 		info["version sha"] = strings.Trim(verInfo.Revision, "'")
 		infoKeys = append(infoKeys, "version sha")
 	}
+
 	infoKeys = append(infoKeys, "cgo")
 	info["cgo"] = "disabled"
 	if version.CgoEnabled {
@@ -1488,10 +1496,15 @@ CLUSTER_SYNTHESIS_COMPLETE:
 	infoKeys = append(infoKeys, "recovery mode")
 	info["recovery mode"] = "false"
 
+	infoKeys = append(infoKeys, "go version")
+	info["go version"] = runtime.Version()
+
 	// Server configuration output
 	padding := 24
+
 	sort.Strings(infoKeys)
 	c.UI.Output("==> Vault server configuration:\n")
+
 	for _, k := range infoKeys {
 		c.UI.Output(fmt.Sprintf(
 			"%s%s: %s",
@@ -1499,6 +1512,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 			strings.Title(k),
 			info[k]))
 	}
+
 	c.UI.Output("")
 
 	// Tests might not want to start a vault server and just want to verify
@@ -2037,16 +2051,22 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 		info["version sha"] = strings.Trim(verInfo.Revision, "'")
 		infoKeys = append(infoKeys, "version sha")
 	}
+
 	infoKeys = append(infoKeys, "cgo")
 	info["cgo"] = "disabled"
 	if version.CgoEnabled {
 		info["cgo"] = "enabled"
 	}
 
+	infoKeys = append(infoKeys, "go version")
+	info["go version"] = runtime.Version()
+
 	// Server configuration output
 	padding := 24
+
 	sort.Strings(infoKeys)
 	c.UI.Output("==> Vault server configuration:\n")
+
 	for _, k := range infoKeys {
 		c.UI.Output(fmt.Sprintf(
 			"%s%s: %s",
@@ -2054,6 +2074,7 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 			strings.Title(k),
 			info[k]))
 	}
+
 	c.UI.Output("")
 
 	for _, core := range testCluster.Cores {


### PR DESCRIPTION
Add `Go Version` to the existing output when starting a vault server.

```
==> Vault server configuration:

              // ...
              Go Version: go1.14.2
              // ...
```