### PR TITLE
CI - go mod test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           mkdir ./pkg
 
           # Build dev binary
-          make ci-bootstrap dev
+          make bootstrap dev
         name: Build dev binary
     - persist_to_workspace:
         paths:
@@ -96,7 +96,7 @@ jobs:
     - CIRCLECI_CLI_VERSION: 0.1.5546
     - GO_TAGS: ''
     - GO_VERSION: 1.13.8
-    - GO111MODULE: 'off'
+    - GOFLAGS: -mod=vendor
     - GOTESTSUM_VERSION: 0.3.3
   test-ui:
     docker:
@@ -244,7 +244,7 @@ jobs:
     - CIRCLECI_CLI_VERSION: 0.1.5546
     - GO_TAGS: ''
     - GO_VERSION: 1.13.8
-    - GO111MODULE: 'off'
+    - GOFLAGS: -mod=vendor
     - GOTESTSUM_VERSION: 0.3.3
   test-go-race:
     machine: true
@@ -320,7 +320,7 @@ jobs:
     - CIRCLECI_CLI_VERSION: 0.1.5546
     - GO_TAGS: ''
     - GO_VERSION: 1.13.8
-    - GO111MODULE: 'off'
+    - GOFLAGS: -mod=vendor
     - GOTESTSUM_VERSION: 0.3.3
   website-docker-image:
     docker:
@@ -495,7 +495,7 @@ workflows:
 #       CIRCLECI_CLI_VERSION: 0.1.5546
 #       GO_TAGS: \"\"
 #       GO_VERSION: 1.13.8
-#       GO111MODULE: \"off\"
+#       GOFLAGS: -mod=vendor
 #       GOTESTSUM_VERSION: 0.3.3
 #     machine: true
 #     shell: /usr/bin/env bash -euo pipefail -c
@@ -527,7 +527,7 @@ workflows:
 #           mkdir ./pkg
 # 
 #           # Build dev binary
-#           make ci-bootstrap dev
+#           make bootstrap dev
 #         name: Build dev binary
 #     - persist_to_workspace:
 #         paths:

--- a/.circleci/config/@config.yml
+++ b/.circleci/config/@config.yml
@@ -27,7 +27,7 @@ executors:
     machine: true
     shell: /usr/bin/env bash -euo pipefail -c
     environment:
-      GO111MODULE: "off"
+      GOFLAGS: -mod=vendor
       CIRCLECI_CLI_VERSION: 0.1.5546  # Pin CircleCI CLI to patch version (ex: 1.2.3)
       GO_VERSION: 1.13.8  # Pin Go to patch version (ex: 1.2.3)
       GOTESTSUM_VERSION: 0.3.3  # Pin gotestsum to patch version (ex: 1.2.3)

--- a/.circleci/config/jobs/build-go-dev.yml
+++ b/.circleci/config/jobs/build-go-dev.yml
@@ -12,7 +12,7 @@ steps:
         mkdir ./pkg
 
         # Build dev binary
-        make ci-bootstrap dev
+        make bootstrap dev
   - persist_to_workspace:
       root: .
       paths:

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,6 @@ TEST_TIMEOUT?=45m
 EXTENDED_TEST_TIMEOUT=60m
 INTEG_TEST_TIMEOUT=120m
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
-EXTERNAL_TOOLS_CI=\
-	github.com/elazarl/go-bindata-assetfs/... \
-	github.com/hashicorp/go-bindata/... \
-	github.com/mitchellh/gox \
-	golang.org/x/tools/cmd/goimports 
-EXTERNAL_TOOLS=\
-	github.com/client9/misspell/cmd/misspell
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v pb.go | grep -v vendor)
 
 
@@ -125,15 +118,8 @@ ci-config:
 ci-verify:
 	@$(MAKE) -C .circleci ci-verify
 
-# bootstrap the build by downloading additional tools needed to build
-ci-bootstrap:
-	@for tool in  $(EXTERNAL_TOOLS_CI) ; do \
-		echo "Installing/Updating $$tool" ; \
-		GO111MODULE=off $(GO_CMD) get -u $$tool; \
-	done
-
 # bootstrap the build by downloading additional tools that may be used by devs
-bootstrap: ci-bootstrap
+bootstrap:
 	go generate -tags tools tools/tools.go
 
 # Note: if you have plugins in GOPATH you can update all of them via something like:

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -22,10 +22,10 @@ import _ "golang.org/x/tools/cmd/goimports"
 //go:generate go install github.com/mitchellh/gox
 import _ "github.com/mitchellh/gox"
 
-//go:generate go install github.com/hashicorp/go-bindata
+//go:generate go install github.com/hashicorp/go-bindata/...
 import _ "github.com/hashicorp/go-bindata"
 
-//go:generate go install github.com/elazarl/go-bindata-assetfs
+//go:generate go install github.com/elazarl/go-bindata-assetfs/...
 import _ "github.com/elazarl/go-bindata-assetfs"
 
 //go:generate go install github.com/client9/misspell/cmd/misspell


### PR DESCRIPTION
This makes use of Jeff's changes in - https://github.com/hashicorp/vault/pull/9000
to allow us to lock build-time dependencies to specific versions in CI as well (https://hashicorp.atlassian.net/browse/VLTES-102).
We will hopefully be able to move to Artifactory for our GOPROXY soon in CI once the Artifactory server is upgraded to fix - https://www.jfrog.com/jira/browse/RTFACT-19395.