### PR TITLE
correct sockaddr.is_contained example

### DIFF
--- a/website/pages/docs/enterprise/sentinel/examples.mdx
+++ b/website/pages/docs/enterprise/sentinel/examples.mdx
@@ -25,7 +25,7 @@ import "strings"
 
 # We expect logins to come only from our private IP range
 cidrcheck = rule {
-    sockaddr.is_contained(request.connection.remote_addr, "10.20.0.0/16")
+    sockaddr.is_contained("10.20.0.0/16", request.connection.remote_addr)
 }
 
 # Require Ping MFA validation to succeed


### PR DESCRIPTION
Syntax for sockaddr.is_contained should be outer, inner - i.e. range, IP. See https://docs.hashicorp.com/sentinel/imports/sockaddr/ for reference.