### PR TITLE
Backport raft-storage.entry_size Metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 IMPROVEMENTS:
 
-* storage/raft: Introduce a new Raft metric, `vault.raft-storage.entry_size`, that allows for operators
-  to sample the entry size and view the average.
 * storage/raft: The storage stanza now accepts `leader_ca_cert_file`, `leader_client_cert_file`, and 
   `leader_client_key_file` parameters to read and parse TLS certificate information from paths on disk.
   Existing non-path based parameters will continue to work, but their values will need to be provided as a 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 IMPROVEMENTS:
 
+* storage/raft: Introduce a new Raft metric, `vault.raft-storage.entry_size`, that allows for operators
+  to sample the entry size and view the average.
 * storage/raft: The storage stanza now accepts `leader_ca_cert_file`, `leader_client_cert_file`, and 
   `leader_client_key_file` parameters to read and parse TLS certificate information from paths on disk.
   Existing non-path based parameters will continue to work, but their values will need to be provided as a 

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -991,8 +991,11 @@ func (b *RaftBackend) applyLog(ctx context.Context, command *LogData) error {
 		return err
 	}
 
+	defer metrics.AddSample([]string{"raft-storage", "entry_size"}, float32(len(commandBytes)))
+
 	var chunked bool
 	var applyFuture raft.ApplyFuture
+
 	switch {
 	case len(commandBytes) <= raftchunking.ChunkSize:
 		applyFuture = b.raft.Apply(commandBytes, 0)


### PR DESCRIPTION
Backport the new raft entry size metric added a la https://github.com/hashicorp/vault/pull/9027