### PR TITLE
Add support for go-sockaddr templated addresses in config.

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -325,6 +325,17 @@ func ParseConfig(d string) (*Config, error) {
 		return nil, err
 	}
 
+	if rendered, err := configutil.ParseSingleIPTemplate(result.APIAddr); err != nil {
+		return nil, err
+	} else {
+		result.APIAddr = rendered
+	}
+	if rendered, err := configutil.ParseSingleIPTemplate(result.ClusterAddr); err != nil {
+		return nil, err
+	} else {
+		result.ClusterAddr = rendered
+	}
+
 	sharedConfig, err := configutil.ParseConfig(d)
 	if err != nil {
 		return nil, err

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -42,6 +42,10 @@ func TestParseListeners(t *testing.T) {
 	testParseListeners(t)
 }
 
+func TestParseSockaddrTemplate(t *testing.T) {
+	testParseSockaddrTemplate(t)
+}
+
 func TestParseEntropy(t *testing.T) {
 	testParseEntropy(t, true)
 }


### PR DESCRIPTION
Fixes #6409.

I don't know what the repercussions of modifying internalshared are, will have to follow up.