### PR TITLE
docs: add missing kubernetes role verb

### DIFF
--- a/website/pages/docs/configuration/service-registration/kubernetes.mdx
+++ b/website/pages/docs/configuration/service-registration/kubernetes.mdx
@@ -54,7 +54,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "update"]
+  verbs: ["get", "update", "patch"]
 ```
 
 ## Examples


### PR DESCRIPTION
The `patch` verb is required to update labels for the Service Registration feature.