### PR TITLE
change message with bold 'not' if primary

### DIFF
--- a/ui/lib/core/addon/components/replication-dashboard.js
+++ b/ui/lib/core/addon/components/replication-dashboard.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { clusterStates } from 'core/helpers/cluster-states';
 import { capitalize } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import layout from '../templates/components/replication-dashboard';
 
 /**
@@ -90,4 +91,12 @@ export default Component.extend({
       return drState;
     }
   ),
+  reindexMessage: computed('isSecondary', 'progressBar', function() {
+    if (!this.isSecondary) {
+      return htmlSafe(
+        'This can cause a delay depending on the size of the data store. You can <b>not</b> use Vault during this time.'
+      );
+    }
+    return 'This can cause a delay depending on the size of the data store. You can use Vault during this time.';
+  }),
 });

--- a/ui/lib/core/addon/templates/components/replication-dashboard.hbs
+++ b/ui/lib/core/addon/templates/components/replication-dashboard.hbs
@@ -5,7 +5,7 @@
         @title={{concat "Re-indexing in progress" reindexingStage}}
         @type="info"
         @progressBar={{progressBar}}
-        @message="This can cause a delay depending on the size of the data store. You can use Vault during this time."
+        @message={{reindexMessage}}
         data-test-isReindexing />
     </div>
   {{/if}}


### PR DESCRIPTION
This PR changes the reindexing message based on if it's a primary or secondary.  From a secondary it's relatively safe to continue using vault during a reindex, but not if it's a primary. 

I moved the message into a computed property because for the life of me (I even tried creating a helper) I could not get the property message to include a bold word without it rendering the HTML tags as a string.

**Primary**
![image](https://user-images.githubusercontent.com/6618863/83432537-44d03700-a3f6-11ea-8d26-9887173763e6.png)

**Secondary**
![image](https://user-images.githubusercontent.com/6618863/83432573-544f8000-a3f6-11ea-983f-3d749caf9c8e.png)
