### PR TITLE
UI/link to changelog version in ui footer

### DIFF
--- a/ui/app/templates/vault.hbs
+++ b/ui/app/templates/vault.hbs
@@ -10,7 +10,7 @@
       &copy; {{date-format (now) "YYYY"}} HashiCorp
     </span>
     <span>
-      <a href="https://github.com/hashicorp/vault/blob/master/CHANGELOG.md"
+      <a href={{changelog-url-for activeCluster.leaderNode.version}}
       class="link has-text-grey">
         Vault {{activeCluster.leaderNode.version}}
       </a>

--- a/ui/app/templates/vault.hbs
+++ b/ui/app/templates/vault.hbs
@@ -10,7 +10,10 @@
       &copy; {{date-format (now) "YYYY"}} HashiCorp
     </span>
     <span>
-      Vault {{activeCluster.leaderNode.version}}
+      <a href="https://github.com/hashicorp/vault/blob/master/CHANGELOG.md"
+      class="link has-text-grey">
+        Vault {{activeCluster.leaderNode.version}}
+      </a>
     </span>
     {{#if (is-version "OSS")}}
       <span>

--- a/ui/lib/core/addon/helpers/changelog-url-for.js
+++ b/ui/lib/core/addon/helpers/changelog-url-for.js
@@ -10,12 +10,9 @@ export function changelogUrlFor([version]) {
     .split('.')
     .join('');
 
-  if (versionNumber === '142') {
-    url = url.concat('142-may-21st-2020');
-  } else if (versionNumber === '141') {
-    url = url.concat('141-april-30th-2020');
-  } else if (versionNumber === '140') {
-    url = url.concat('140-april-7th-2020');
+  // only the most recent versions have a predictable url
+  if (versionNumber >= '140') {
+    url = url.concat(versionNumber);
   }
 
   return url;

--- a/ui/lib/core/addon/helpers/changelog-url-for.js
+++ b/ui/lib/core/addon/helpers/changelog-url-for.js
@@ -1,0 +1,24 @@
+import { helper } from '@ember/component/helper';
+
+export function changelogUrlFor([version]) {
+  // returns a url to the changelog for the specified version
+  let url = 'http://www.github.com/hashicorp/vault/blob/master/CHANGELOG.md#';
+
+  // strip the '+prem' from enterprise versions and remove periods
+  let versionNumber = version
+    .split('+')[0]
+    .split('.')
+    .join('');
+
+  if (versionNumber === '142') {
+    url = url.concat('142-may-21st-2020');
+  } else if (versionNumber === '141') {
+    url = url.concat('141-april-30th-2020');
+  } else if (versionNumber === '140') {
+    url = url.concat('140-april-7th-2020');
+  }
+
+  return url;
+}
+
+export default helper(changelogUrlFor);

--- a/ui/lib/core/addon/helpers/changelog-url-for.js
+++ b/ui/lib/core/addon/helpers/changelog-url-for.js
@@ -1,7 +1,19 @@
 import { helper } from '@ember/component/helper';
 
+/*
+This helper returns a url to the changelog for the specified version.
+It assumes that Changelog headers for Vault versions >= 1.4.3 are structured as:
+
+## v1.5.0
+### Month, DD, YYYY
+
+## v1.4.5
+### Month, DD, YYY
+
+etc.
+*/
+
 export function changelogUrlFor([version]) {
-  // returns a url to the changelog for the specified version
   let url = 'http://www.github.com/hashicorp/vault/blob/master/CHANGELOG.md#';
 
   // strip the '+prem' from enterprise versions and remove periods
@@ -10,12 +22,12 @@ export function changelogUrlFor([version]) {
     .split('.')
     .join('');
 
-  // only the most recent versions have a predictable url
-  if (versionNumber >= '140') {
-    url = url.concat(versionNumber);
+  // only recent versions have a predictable url
+  if (versionNumber >= '143') {
+    return url.concat('v', versionNumber);
+  } else {
+    return url;
   }
-
-  return url;
 }
 
 export default helper(changelogUrlFor);

--- a/ui/lib/core/addon/helpers/cluster-states.js
+++ b/ui/lib/core/addon/helpers/cluster-states.js
@@ -1,8 +1,10 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
-// A hash of cluster states to ensure that the status menu and replication dashboards
-// display states and glyphs consistently
-// this includes states for the primary vault cluster and the connection_state
+/*
+A hash of cluster states to ensure the status menu and replication dashboards
+display states and glyphs consistently. This includes states for the primary
+vault cluster and the connection_state.
+*/
 
 export const CLUSTER_STATES = {
   running: {

--- a/ui/lib/core/app/helpers/changelog-url-for.js
+++ b/ui/lib/core/app/helpers/changelog-url-for.js
@@ -1,0 +1,1 @@
+export { default, changelogUrlFor } from 'core/helpers/changelog-url-for';

--- a/ui/tests/integration/helpers/changelog-url-for-test.js
+++ b/ui/tests/integration/helpers/changelog-url-for-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { changelogUrlFor } from '../../../helpers/changelog-url-for';
+
+const CHANGELOG_URL = 'http://www.github.com/hashicorp/vault/blob/master/CHANGELOG.md#';
+
+module('Integration | Helper | changelog-url-for', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it builds an enterprise URL', function(assert) {
+    const result = changelogUrlFor(['1.5.0+prem']);
+    assert.equal(result, CHANGELOG_URL.concat('v150'));
+  });
+
+  test('it builds an OSS URL', function(assert) {
+    const result = changelogUrlFor(['1.4.3']);
+    assert.equal(result, CHANGELOG_URL.concat('v143'));
+  });
+
+  test('it returns the base changelog URL if the version is less than 1.4.3', function(assert) {
+    const result = changelogUrlFor(['1.4.0']);
+    assert.equal(result, CHANGELOG_URL);
+  });
+
+  test('it returns the base changelog URL if version cannot be found', function(assert) {
+    const result = changelogUrlFor(['']);
+    assert.equal(result, CHANGELOG_URL);
+  });
+});


### PR DESCRIPTION
# Link to Changelog version in UI Footer

![image](https://user-images.githubusercontent.com/903288/84540833-0d417480-acab-11ea-87f8-cba9d7a57a71.png)


This PR adds a link to the changelog at the version of Vault currently being used. This allows users to quickly view relevant changes, particularly when we have added or changed behavior in the UI.

## Notes
The helper used to generate the URL assumes that changelog items will match the following format:
```
## v1.5.0
### Month, DD, YYYY

## v1.4.5
### Month, DD, YYY
```

Since this new header format will only be used for Vault versions 1.4.3 and beyond, all previous versions just link back to the base changelog link. 