### PR TITLE
agent/raft: fix typo in help strings

### DIFF
--- a/command/operator_raft_join.go
+++ b/command/operator_raft_join.go
@@ -56,21 +56,21 @@ func (c *OperatorRaftJoinCommand) Flags() *FlagSets {
 		Name:       "leader-ca-cert",
 		Target:     &c.flagLeaderCACert,
 		Completion: complete.PredictNothing,
-		Usage:      "CA cert to communicate with Raft leader.",
+		Usage:      "CA cert to use when verifying the Raft leader certificate.",
 	})
 
 	f.StringVar(&StringVar{
 		Name:       "leader-client-cert",
 		Target:     &c.flagLeaderClientCert,
 		Completion: complete.PredictNothing,
-		Usage:      "Client cert to to authenticate to Raft leader.",
+		Usage:      "Client cert to use when authenticating with the Raft leader.",
 	})
 
 	f.StringVar(&StringVar{
 		Name:       "leader-client-key",
 		Target:     &c.flagLeaderClientKey,
 		Completion: complete.PredictNothing,
-		Usage:      "Client key to to authenticate to Raft leader.",
+		Usage:      "Client key to use when authenticating with the Raft leader.",
 	})
 
 	f.BoolVar(&BoolVar{


### PR DESCRIPTION
Small error in the `vault operator raft join` CLI helper text.

```bash
$ vault operator raft join -h
...
Command Options:

  -leader-ca-cert=<string>
      CA cert to communicate with Raft leader.

  -leader-client-cert=<string>
      Client cert to to authenticate to Raft leader.

  -leader-client-key=<string>
      Client key to to authenticate to Raft leader.
...
```