### PR TITLE
Refactor Replication Action: Promote to use modal flow

### DIFF
--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -30,7 +30,7 @@
   <section class="modal-card-body">
     <div class="box is-shadowless is-fullwidth is-sideless">
 
-      {{#if (eq replicationDisplayMode "DR")}}
+      {{#if (eq replicationMode "dr")}}
       <p class="has-bottom-margin-m">
         To promote this DR Replication Secondary to a primary, enter the DR Operation token.
       </p>
@@ -40,7 +40,7 @@
       </p>
 
       <div data-test-promote-dr-inputs>
-        {{#if (eq replicationDisplayMode "DR")}}
+        {{#if (eq replicationMode "dr")}}
         <div class="field is-borderless">
           <label for="dr_operation_token" class="is-label is-size-6">
             DR Operation Token
@@ -82,7 +82,7 @@
   <footer class="modal-card-foot modal-card-foot-outlined">
     <button
       class="button is-primary"
-      disabled={{if (and (eq replicationDisplayMode "DR") (not dr_operation_token)) true}}
+      disabled={{if (and (eq replicationMode "dr") (not dr_operation_token)) true}}
       onclick={{action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token primary_cluster_addr=primary_cluster_addr force=force)}}
       data-test-promote-confirm-button
     >

--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -19,7 +19,6 @@
   </div>
 </div>
 
-
 <Modal
   @title="Promote cluster?"
   @onClose={{action (mut isModalActive) false}}

--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -39,29 +39,19 @@
         Vault Replication is not designed for active-active usage. Enabling two primaries should never be done, as it can lead to data loss if they or their secondaries are ever reconnected. If the cluster has a primary, be sure to demote it before promoting a secondary.
       </p>
 
-      {{#if (eq replicationDisplayMode "DR")}}
       <div data-test-promote-dr-inputs>
+        {{#if (eq replicationDisplayMode "DR")}}
         <div class="field is-borderless">
-          <label for="dr_operation_token" class="is-label">
+          <label for="dr_operation_token" class="is-label is-size-6">
             DR Operation Token
           </label>
           <div class="control">
             {{input class="input" id="dr_operation_token" name="dr_operation_token" value=dr_operation_token}}
           </div>
         </div>
-        <ToggleButton
-          @class="is-block"
-          @toggleAttr="showOptions"
-          @toggleTarget={{this}}
-          @openLabel="Hide options"
-          @closedLabel="Options"
-        />
-      </div>
-      {{/if}}
-      {{#if (or (eq replicationDisplayMode "Performance") showOptions)}}
-      <div data-test-promote-performance-inputs>
+        {{/if}}
         <div class="field">
-          <label for="primary_cluster_addr" class="is-label">
+          <label for="primary_cluster_addr" class="is-label is-size-6">
             Primary cluster address <em class="is-optional">(optional)</em>
           </label>
           <div class="control">
@@ -80,19 +70,13 @@
             checked={{force}}
             onchange={{action (mut force) value="target.checked"}}
             />
-            <label for="forcePromote" class="is-label">
+            <label for="forcePromote" class="is-label is-size-6">
               Force promotion of this cluster
             </label>
+            <p>Promote the cluster even if certain safety checks fail. This could result in data loss of data isn't fully replicated</p>
           </div>
-          <AlertInline
-            @type="warning"
-            @message="Forcing promotion could result in data loss if data isn't fully replicated. Force promotion
-            promotes the cluster even if certain safety checks fail."
-          />
         </div>
       </div>
-      {{/if}}
-
     </div>
   </section>
   <footer class="modal-card-foot modal-card-foot-outlined">

--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -1,26 +1,65 @@
-{{#if (and (eq replicationMode 'dr') (eq model.replicationAttrs.modeForUrl 'secondary'))}}
-  <div class="box is-marginless is-shadowless">
+<div class="action-block is-rounded">
+  <div class="action-block-info">
+    <h4 class="title is-5 is-marginless">
+      Promote cluster
+    </h4>
     <p>
-      This cluster is currently running as a DR Replication Secondary.
-      Promote the cluster to a primary by entering DR Operation Token.
+      Promote this cluster to a {{replicationDisplayMode}} primary
     </p>
-    <div class="field">
-      <label for="dr_operation_token" class="is-label">
-        DR Operation Token
-      </label>
-      <div class="control">
-        {{input class="input" id="dr_operation_token" name="dr_operation_token" value=dr_operation_token}}
+  </div>
+
+  <div class="action-block-action">
+    <button
+      class="button is-tertiary"
+      onclick={{action (mut isModalActive) true}}
+      data-test-replication-action-trigger
+    >
+      Update
+    </button>
+  </div>
+</div>
+
+
+<Modal
+  @title="Promote cluster?"
+  @onClose={{action (mut isModalActive) false}}
+  @isActive={{isModalActive}}
+  @type="warning"
+  @showCloseButton={{true}}
+>
+  <section class="modal-card-body">
+    <div class="box is-shadowless is-fullwidth is-sideless">
+
+      {{#if (eq replicationDisplayMode "DR")}}
+      <p class="has-bottom-margin-m">
+        To promote this DR Replication Secondary to a primary, enter the DR Operation token.
+      </p>
+      {{/if}}
+      <p class="has-bottom-margin-m">
+        Vault Replication is not designed for active-active usage. Enabling two primaries should never be done, as it can lead to data loss if they or their secondaries are ever reconnected. If the cluster has a primary, be sure to demote it before promoting a secondary.
+      </p>
+
+      {{#if (eq replicationDisplayMode "DR")}}
+      <div data-test-promote-dr-inputs>
+        <div class="field is-borderless">
+          <label for="dr_operation_token" class="is-label">
+            DR Operation Token
+          </label>
+          <div class="control">
+            {{input class="input" id="dr_operation_token" name="dr_operation_token" value=dr_operation_token}}
+          </div>
+        </div>
+        <ToggleButton
+          @class="is-block"
+          @toggleAttr="showOptions"
+          @toggleTarget={{this}}
+          @openLabel="Hide options"
+          @closedLabel="Options"
+        />
       </div>
-    </div>
-    <ToggleButton
-      @class="is-block"
-      @toggleAttr="showOptions"
-      @toggleTarget={{this}}
-      @openLabel="Hide options"
-      @closedLabel="Options"
-      />
-    {{#if showOptions}}
-      <div class="box is-marginless">
+      {{/if}}
+      {{#if (or (eq replicationDisplayMode "Performance") showOptions)}}
+      <div data-test-promote-performance-inputs>
         <div class="field">
           <label for="primary_cluster_addr" class="is-label">
             Primary cluster address <em class="is-optional">(optional)</em>
@@ -52,78 +91,24 @@
           />
         </div>
       </div>
-    {{/if}}
-  </div>
-  <div class="box is-marginless is-shadowless">
-   <div class="field">
-    <div class="control">
-      <ConfirmAction
-        @buttonClasses="button is-primary"
-        @confirmTitle="Promote this cluster?"
-        @confirmMessage="This will affect how your Vault data is replicated."
-        @confirmButtonText="Promote"
-        @horizontalPosition="auto-left"
-        @onConfirmAction={{action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token primary_cluster_addr=primary_cluster_addr force=force)}}
-      >
-        Promote cluster
-      </ConfirmAction>
+      {{/if}}
+
     </div>
-   </div>
- </div>
-{{else}}
-  <h4 class="title is-5 is-marginless">
-    Promote cluster
-  </h4>
-  <div class="content">
-    <p>Promote the cluster to primary.
-    <AlertInline
-      @type="warning"
-      @message="Vault Replication is not designed for active-active usage and enabling two primaries should never be done, as it can lead to data loss if they or their secondaries are ever reconnected.
-        If the cluster has a primary, be sure to demote it before promoting a secondary."
-    />
-    </p>
-    <div class="field">
-      <label for="primary_cluster_addr" class="is-label">
-        Primary cluster address <em class="is-optional">(optional)</em>
-      </label>
-      <div class="control">
-        {{input class="input" id="primary_cluster_addr" name="primary_cluster_addr" value=primary_cluster_addr}}
-      </div>
-      <p class="help has-text-grey">
-        Overrides the cluster address that the primary gives to secondary nodes.
-      </p>
-    </div>
-    <div class="field">
-      <div class="b-checkbox">
-        <input type="checkbox"
-        id="forcePromote"
-        class="styled"
-        checked={{force}}
-        onchange={{action (mut force) value="target.checked"}}
-        />
-        <label for="forcePromote" class="is-label">
-          Force promotion of this cluster
-        </label>
-      </div>
-      <AlertInline
-        @type="warning"
-        @message="Forcing promotion could result in data loss if data isn't fully replicated. Force promotion
-          promotes the cluster even if certain safety checks fail."
-      />
-    </div>
-  </div>
-  <div class="field">
-    <div class="control">
-      <ConfirmAction
-        @buttonClasses="button is-primary"
-        @confirmTitle="Promote this cluster?"
-        @confirmMessage="This will affect how your Vault data is replicated."
-        @confirmButtonText="Promote"
-        @horizontalPosition="auto-left"
-        @onConfirmAction={{action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash primary_cluster_addr=primary_cluster_addr force=force)}}
-      >
-        Promote cluster
-      </ConfirmAction>
-    </div>
-  </div>
-{{/if}}
+  </section>
+  <footer class="modal-card-foot modal-card-foot-outlined">
+    <button
+      class="button is-primary"
+      disabled={{if (and (eq replicationDisplayMode "DR") (not dr_operation_token)) true}}
+      onclick={{action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token primary_cluster_addr=primary_cluster_addr force=force)}}
+      data-test-promote-confirm-button
+    >
+      Promote
+    </button>
+    <button
+      class="button is-secondary"
+      onclick={{action (mut isModalActive) false}}
+      data-test-promote-cancel-button>
+      Cancel
+    </button>
+  </footer>
+</Modal>


### PR DESCRIPTION
This is the promote action refactor, with modal. Promote actions are only available on secondary clusters. 

**NOTE** Tests will be fixed with a follow-on PR to `ui/replication-mgmt-sidebranch`

Old promote (DR): 
<img width="413" alt="Screen Shot 2020-06-02 at 11 46 51 AM" src="https://user-images.githubusercontent.com/16182107/83547258-8d0b5a00-a4c7-11ea-8383-f8ceb69a358a.png">

Old promote (Performance):
<img width="1373" alt="Screen Shot 2020-06-02 at 12 22 48 PM" src="https://user-images.githubusercontent.com/16182107/83550049-dc538980-a4cb-11ea-815a-05cd858ad1da.png">

New promote modal (DR):
<img width="971" alt="dr-promote" src="https://user-images.githubusercontent.com/16182107/83549880-9b5b7500-a4cb-11ea-9afc-79f658c0ed36.png">

New promote modal (Performance):
<img width="1026" alt="perf-promote" src="https://user-images.githubusercontent.com/16182107/83549885-9d253880-a4cb-11ea-883b-b1825d374ce1.png">
 

