### PR TITLE
Add JSDocs to components

### DIFF
--- a/ui/lib/core/addon/components/replication-doc-link.js
+++ b/ui/lib/core/addon/components/replication-doc-link.js
@@ -3,7 +3,7 @@ import layout from '../templates/components/replication-doc-link';
 
 /**
  * @module ReplicationDocLink
- * The `ReplicationDocLink` component is learn link with helper text used on the Replication Dashboards.
+ * The `ReplicationDocLink` component is a learn link with helper text used on the Replication Dashboards.
  * The link takes you to the key monitoring metrics learn doc.
  *
  * @example

--- a/ui/lib/core/addon/components/replication-doc-link.js
+++ b/ui/lib/core/addon/components/replication-doc-link.js
@@ -1,6 +1,17 @@
 import Component from '@ember/component';
 import layout from '../templates/components/replication-doc-link';
 
+/**
+ * @module ReplicationDocLink
+ * The `ReplicationDocLink` component is learn link with helper text used on the Replication Dashboards.
+ * The link takes you to the key monitoring metrics learn doc.
+ *
+ * @example
+ * ```js
+ * <ReplicationDocLink />
+ * ```
+ */
+
 export default Component.extend({
   layout,
 });

--- a/ui/lib/core/addon/components/replication-header.js
+++ b/ui/lib/core/addon/components/replication-header.js
@@ -1,6 +1,26 @@
 import Component from '@ember/component';
 import layout from '../templates/components/replication-header';
 
+/**
+ * @module ReplicationHeader
+ * The `ReplicationHeader` component is a header component used on the Replication Dashboards.
+ * It is a contextual component of the Replication Page component.
+ *
+ * @example
+ * ```js
+ * <ReplicationHeader
+    @data={{model}}
+    @title="Secondary"
+    @secondaryID="meep_123"
+    @isSummaryDashboard=false
+    />
+ * ```
+ * @param {Object} model=null - An Ember data object pulled form the Ember cluster model.
+ * @param {String} title=null - The title of the header.
+ * @param {String} [secondaryID=null] - The secondaryID pulled off of the model object. 
+ * @param {Boolean} isSummaryDashboard=false - if the Dashboard is for when you have both a primary performance and dr cluster, then this is true.
+ */
+
 export default Component.extend({
   layout,
   classNames: ['replication-header'],

--- a/ui/lib/core/addon/components/replication-header.js
+++ b/ui/lib/core/addon/components/replication-header.js
@@ -14,7 +14,7 @@ import layout from '../templates/components/replication-header';
     @isSummaryDashboard=false
     />
  * ```
- * @param {Object} model=null - An Ember data object pulled form the Ember cluster model.
+ * @param {Object} model=null - An Ember data object pulled from the Ember cluster model.
  * @param {String} title=null - The title of the header.
  * @param {String} [secondaryID=null] - The secondaryID pulled off of the model object. 
  * @param {Boolean} isSummaryDashboard=false - True when you have both a primary performance and dr cluster dashboard.

--- a/ui/lib/core/addon/components/replication-header.js
+++ b/ui/lib/core/addon/components/replication-header.js
@@ -3,8 +3,7 @@ import layout from '../templates/components/replication-header';
 
 /**
  * @module ReplicationHeader
- * The `ReplicationHeader` component is a header component used on the Replication Dashboards.
- * It is a contextual component of the Replication Page component.
+ * The `ReplicationHeader` is a header component used on the Replication Dashboards.
  *
  * @example
  * ```js
@@ -18,7 +17,7 @@ import layout from '../templates/components/replication-header';
  * @param {Object} model=null - An Ember data object pulled form the Ember cluster model.
  * @param {String} title=null - The title of the header.
  * @param {String} [secondaryID=null] - The secondaryID pulled off of the model object. 
- * @param {Boolean} isSummaryDashboard=false - if the Dashboard is for when you have both a primary performance and dr cluster, then this is true.
+ * @param {Boolean} isSummaryDashboard=false - True when you have both a primary performance and dr cluster dashboard.
  */
 
 export default Component.extend({

--- a/ui/lib/core/addon/components/replication-table-rows.js
+++ b/ui/lib/core/addon/components/replication-table-rows.js
@@ -2,6 +2,21 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from '../templates/components/replication-table-rows';
 
+/**
+ * @module ReplicationTableRows
+ * The `ReplicationTableRows` component is table component.  It displays cluster mode details specific to the cluster of the Dashboard it is used on.
+ *
+ * @example
+ * ```js
+ * <ReplicationTableRows
+    @replicationDetails={{replicationDetails}}
+    @clusterMode="primary"
+    />
+ * ```
+ * @param {Object} replicationDetails=null - An Ember data object pulled from the Ember Model. It contains details specific to the whether the replication is dr or performance.
+ * @param {String} clusterMode=null - The cluster mode passed through to a table component. 
+ */
+
 export default Component.extend({
   layout,
   classNames: ['replication-table-rows'],

--- a/ui/lib/core/addon/components/replication-table-rows.js
+++ b/ui/lib/core/addon/components/replication-table-rows.js
@@ -14,7 +14,7 @@ import layout from '../templates/components/replication-table-rows';
     />
  * ```
  * @param {Object} replicationDetails=null - An Ember data object pulled from the Ember Model. It contains details specific to the whether the replication is dr or performance.
- * @param {String} clusterMode=null - The cluster mode passed through to a table component. 
+ * @param {String} clusterMode=null - The cluster mode (e.g. primary or secondary) passed through to a table component. 
  */
 
 export default Component.extend({

--- a/ui/lib/replication/addon/components/replication-primary-card.js
+++ b/ui/lib/replication/addon/components/replication-primary-card.js
@@ -36,7 +36,6 @@ export default Component.extend({
     return false;
   }),
   errorMessage: computed('hasError', function() {
-    // TODO figure out if we need another error message
     return this.hasError ? 'Check server logs!' : false;
   }),
 });


### PR DESCRIPTION
This PR adds JSDocs to the components that still need it.    

I also went ahead and removed the TODO that was no longer relevant. 

As a side note, I find it helpful to see a list of all the components we've added in this replication project.  Here they are for reference.  After this PR all of these will have JSDocumentation.

1. replication-dashboard
2. replication-documentation-link
3. replication-header
4. replication-page
5. replication-primary-card
6. replication-secondary-card
7. replication-summary-card
8. replication-table-rows
9. known-secondaries-card
10. known-secondaries-table
