### PR TITLE
updated 1.3.2 and 1.4.0 upgrade guides to note AWS STS region issue

### DIFF
--- a/website/pages/docs/upgrading/upgrade-to-1.3.2.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.3.2.mdx
@@ -13,3 +13,5 @@ This page contains the list of deprecations and important or breaking changes
 for Vault 1.3.0 compared to 1.3.2. Please read it carefully.
 
 @include 'partials/aws-auth-metadata-issue.mdx'
+
+@include 'partials/aws-sts-issue.mdx'

--- a/website/pages/docs/upgrading/upgrade-to-1.4.0.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.4.0.mdx
@@ -14,5 +14,7 @@ for Vault 1.3.X compared to 1.4.0. Please read it carefully.
 
 @include 'partials/aws-auth-metadata-issue.mdx'
 
+@include 'partials/aws-sts-issue.mdx'
+
 @include 'partials/ldap-upndomain-issue.mdx'
 

--- a/website/pages/partials/aws-sts-issue.mdx
+++ b/website/pages/partials/aws-sts-issue.mdx
@@ -1,0 +1,9 @@
+## The AWS STS Region Selection
+
+The AWS Client used in Vault was updated for improved STS performance in 
+1.3.2 and 1.4.0 [#8161](https://github.com/hashicorp/vault/pull/8161), 
+however this introduced a side effect of limiting the regions being selected for validation 
+and a greater possibility of encountering an "invalid security token" error.  
+
+Users of the AWS auth engine should upgrade to 1.4.1 release instead, 
+where this side effect was fixed in [#8679](https://github.com/hashicorp/vault/pull/8679).  


### PR DESCRIPTION
1.4.1 resolves an issue with AWS STS region selection in the AWS Client that Vault creates.  This issue appears to have been introduced in 1.3.2 & 1.4.0.

(This came from an issue from a customer who upgraded to 1.4.0, and we confirmed 1.4.1 resolved their issue - I can provide details internally).

