### PR TITLE
Close link-to tag in header

### DIFF
--- a/ui/lib/core/addon/templates/components/replication-header.hbs
+++ b/ui/lib/core/addon/templates/components/replication-header.hbs
@@ -68,7 +68,8 @@
           {{#link-to "vault.cluster.replication-dr-promote"}}
             Manage
           {{/link-to}}
-        </ul>
+        {{/link-to}}
+      </ul>
       {{else}}
         <ul>
           <li class="is-active">


### PR DESCRIPTION
Fixes close tag, which was removed due to a bad resolution of merge conflict