### PR TITLE
add disable_iss_validation option to k8s auth docs

### DIFF
--- a/website/pages/api-docs/auth/kubernetes/index.mdx
+++ b/website/pages/api-docs/auth/kubernetes/index.mdx
@@ -40,6 +40,8 @@ access the Kubernetes API.
   keys.
 - `issuer` `(string: "")` - Optional JWT issuer. If no issuer is specified, then this plugin will
   use `kubernetes.io/serviceaccount` as the default issuer.
+- `disable_iss_validation` `(bool: false)` - Disable JWT issuer validation. Allows to skip ISS validation.
+
 
 ### Sample Payload
 
@@ -84,7 +86,9 @@ $ curl \
   "data":{
     "kubernetes_host": "https://192.168.99.100:8443",
     "kubernetes_ca_cert": "-----BEGIN CERTIFICATE-----.....-----END CERTIFICATE-----",
-    "pem_keys": ["-----BEGIN CERTIFICATE-----.....", .....]
+    "pem_keys": ["-----BEGIN CERTIFICATE-----.....", .....],
+    "disable_iss_validation": false
+    
   }
 }
 ```

--- a/website/pages/api-docs/auth/kubernetes/index.mdx
+++ b/website/pages/api-docs/auth/kubernetes/index.mdx
@@ -88,7 +88,6 @@ $ curl \
     "kubernetes_ca_cert": "-----BEGIN CERTIFICATE-----.....-----END CERTIFICATE-----",
     "pem_keys": ["-----BEGIN CERTIFICATE-----.....", .....],
     "disable_iss_validation": false
-    
   }
 }
 ```


### PR DESCRIPTION
add disable_iss_validation option to k8s auth docs
related to: https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/91