### PR TITLE
Add known primaries info table

### DIFF
--- a/ui/app/styles/components/info-table.scss
+++ b/ui/app/styles/components/info-table.scss
@@ -1,0 +1,9 @@
+.info-table {
+  &.vlt-table td {
+    padding-top: 0px;
+    padding-bottom: 0px;
+  }
+  .info-table-row {
+    box-shadow: none;
+  }
+}

--- a/ui/app/styles/components/replication-dashboard.scss
+++ b/ui/app/styles/components/replication-dashboard.scss
@@ -82,6 +82,12 @@
         grid-column: 2/2;
         grid-row: 2/2;
       }
+
+      .grid-item-full-middle {
+        grid-column: 1 / span 2;
+        grid-row: 2/4;
+      }
+
       .grid-item-left-bottom {
         grid-column: 1/1;
         grid-row: 3/3;

--- a/ui/app/styles/components/replication-dashboard.scss
+++ b/ui/app/styles/components/replication-dashboard.scss
@@ -49,7 +49,7 @@
       display: grid;
       grid-gap: $spacing-s;
       grid-template-columns: 1fr 1fr;
-      grid-template-rows: 0.2fr 1fr 0.2fr;
+      grid-template-rows: 0.2fr 0.2fr 0.2fr;
       padding: $spacing-l;
       line-height: 1.5;
 
@@ -83,23 +83,26 @@
         grid-row: 2/2;
       }
 
-      .grid-item-full-middle {
+      .grid-item-second-row {
         grid-column: 1 / span 2;
-        grid-row: 2/4;
+        grid-row: 2/2;
+      }
+
+      .grid-item-third-row {
+        grid-column: 1 / span 2;
+        grid-row: 3/4;
+        max-height: 240px;
       }
 
       .grid-item-left-bottom {
         grid-column: 1/1;
         grid-row: 3/3;
-        margin-top: -8px;
-
         display: flex;
         align-items: center;
       }
       .grid-item-right-bottom {
         grid-column: 2/2;
         grid-row: 3/3;
-        margin-top: -8px;
       }
       .grid-item-full-bottom {
         grid-column: 1 / span 2;

--- a/ui/app/styles/components/replication-dashboard.scss
+++ b/ui/app/styles/components/replication-dashboard.scss
@@ -91,7 +91,6 @@
       .grid-item-third-row {
         grid-column: 1 / span 2;
         grid-row: 3/4;
-        max-height: 240px;
       }
 
       .grid-item-left-bottom {

--- a/ui/app/styles/components/replication-dashboard.scss
+++ b/ui/app/styles/components/replication-dashboard.scss
@@ -83,6 +83,17 @@
         grid-row: 2/2;
       }
 
+      .grid-item-bottom-left {
+        grid-column: 1/1;
+        grid-row: 3/3;
+        display: flex;
+        align-items: center;
+      }
+      .grid-item-bottom-right {
+        grid-column: 2/2;
+        grid-row: 3/3;
+      }
+
       .grid-item-second-row {
         grid-column: 1 / span 2;
         grid-row: 2/2;
@@ -92,18 +103,7 @@
         grid-column: 1 / span 2;
         grid-row: 3/4;
       }
-
-      .grid-item-left-bottom {
-        grid-column: 1/1;
-        grid-row: 3/3;
-        display: flex;
-        align-items: center;
-      }
-      .grid-item-right-bottom {
-        grid-column: 2/2;
-        grid-row: 3/3;
-      }
-      .grid-item-full-bottom {
+      .grid-item-bottom-row {
         grid-column: 1 / span 2;
         grid-row: 4/4;
       }

--- a/ui/app/styles/components/selectable-card.scss
+++ b/ui/app/styles/components/selectable-card.scss
@@ -67,6 +67,11 @@
     font-weight: 500;
     line-height: 1.33;
   }
+
+  .vlt-table {
+    max-height: 240px;
+    overflow: scroll;
+  }
 }
 
 .selectable-card.is-rounded {

--- a/ui/app/styles/components/selectable-card.scss
+++ b/ui/app/styles/components/selectable-card.scss
@@ -70,7 +70,7 @@
 
   .vlt-table {
     max-height: 240px;
-    overflow: scroll;
+    overflow-y: scroll;
   }
 }
 

--- a/ui/app/styles/components/vlt-table.scss
+++ b/ui/app/styles/components/vlt-table.scss
@@ -4,6 +4,15 @@
     height: 0;
   }
 
+  &.sticky-header {
+    thead th {
+      position: sticky;
+      background: #fff;
+      box-shadow: 0 1px 0px 0px rgba($grey-dark, 0.3);
+      top: 0;
+    }
+  }
+
   th,
   td {
     padding: $spacing-s;

--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -60,6 +60,7 @@
 @import './components/http-requests-bar-chart';
 @import './components/http-requests-table';
 @import './components/init-illustration';
+@import './components/info-table';
 @import './components/info-table-row';
 @import './components/input-hint';
 @import './components/kmip-role-edit';

--- a/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
+++ b/ui/app/templates/vault/cluster/replication-dr-promote/details.hbs
@@ -32,7 +32,7 @@
         {{!-- passing in component to render so that the yielded components are flexible based on the dashboard --}}
           @componentToRender='replication-secondary-card' as |Dashboard|>
           <Dashboard.card
-            @title="States"
+            @title="Status"
           />
           <Dashboard.card
             @title="Primary cluster"

--- a/ui/lib/core/addon/components/info-table.js
+++ b/ui/lib/core/addon/components/info-table.js
@@ -7,15 +7,21 @@ import layout from '../templates/components/info-table';
  *
  * @example
  * ```js
- * <InfoTable @replicationAttrs={{replicationAttrs}} />
+ * <InfoTable
+        @title="Known Primary Cluster Addrs"
+        @header="cluster_addr"
+        @items={{knownPrimaryClusterAddrs}}
+      />
  * ```
- * @param {object} replicationAttrs=null - The attributes passed directly from the cluster model used to access the array of known secondaries. We use this to grab the secondaries.
+ * @param {String} [title=Info Table] - The title of the table. Used for accessibility purposes.
+ * @param {String} header=null - The column header.
+ * @param {Array} items=null - An array of strings which will be used as the InfoTableRow value.
  */
 
 export default Component.extend({
   layout,
   tagName: '',
-  title: null,
+  title: 'Info Table',
   header: null,
   items: null,
 });

--- a/ui/lib/core/addon/components/info-table.js
+++ b/ui/lib/core/addon/components/info-table.js
@@ -14,6 +14,7 @@ import layout from '../templates/components/info-table';
 
 export default Component.extend({
   layout,
+  tagName: '',
   title: null,
   header: null,
   items: null,

--- a/ui/lib/core/addon/components/info-table.js
+++ b/ui/lib/core/addon/components/info-table.js
@@ -1,0 +1,20 @@
+import Component from '@ember/component';
+import layout from '../templates/components/info-table';
+
+/**
+ * @module InfoTable
+ * InfoTable components are a table with a single column and header. They are used to render a list of InfoTableRow components.
+ *
+ * @example
+ * ```js
+ * <InfoTable @replicationAttrs={{replicationAttrs}} />
+ * ```
+ * @param {object} replicationAttrs=null - The attributes passed directly from the cluster model used to access the array of known secondaries. We use this to grab the secondaries.
+ */
+
+export default Component.extend({
+  layout,
+  title: null,
+  header: null,
+  items: null,
+});

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -44,7 +44,7 @@ export default Component.extend({
     const { title, state, connection } = this;
 
     // only show errors on the state card
-    if (title === 'States') {
+    if (title === 'Status') {
       const currentClusterisOk = clusterStates([state]).isOk;
       const primaryIsOk = clusterStates([connection]).isOk;
       return !(currentClusterisOk && primaryIsOk);

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -51,7 +51,7 @@ export default Component.extend({
     }
     return false;
   }),
-  primaryClusterAddr: computed('replicationDetails.{primaryClusterAddr}', function() {
-    return this.replicationDetails.primaryClusterAddr;
+  knownPrimaryClusterAddrs: computed('replicationDetails.{knownPrimaryClusterAddrs}', function() {
+    return this.replicationDetails.knownPrimaryClusterAddrs;
   }),
 });

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -53,6 +53,19 @@ export default Component.extend({
     return false;
   }),
   knownPrimaryClusterAddrs: computed('replicationDetails.{knownPrimaryClusterAddrs}', function() {
-    return this.replicationDetails.knownPrimaryClusterAddrs;
+    // return this.replicationDetails.knownPrimaryClusterAddrs;
+    return [
+      'https://127.0.0.1:8201',
+      'https://127.0.0.1:8201',
+      'https://127.0.0.1:8201',
+      'https://127.0.0.1:8201',
+      'https://127.0.0.1:8201',
+      'https://127.0.0.1:8201',
+      'https://127.0.0.1:8201',
+      'https://127.0.0.1:8201',
+      'https://127.0.0.1:8201',
+      'https://127.0.0.1:8201',
+      'https://127.0.0.1:8201',
+    ];
   }),
 });

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -20,6 +20,7 @@ import { clusterStates } from 'core/helpers/cluster-states';
 
 export default Component.extend({
   layout,
+  tagName: '',
   title: null,
   replicationDetails: null,
   state: computed('replicationDetails.{state}', function() {

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -53,19 +53,6 @@ export default Component.extend({
     return false;
   }),
   knownPrimaryClusterAddrs: computed('replicationDetails.{knownPrimaryClusterAddrs}', function() {
-    // return this.replicationDetails.knownPrimaryClusterAddrs;
-    return [
-      'https://127.0.0.1:8201',
-      'https://127.0.0.1:8201',
-      'https://127.0.0.1:8201',
-      'https://127.0.0.1:8201',
-      'https://127.0.0.1:8201',
-      'https://127.0.0.1:8201',
-      'https://127.0.0.1:8201',
-      'https://127.0.0.1:8201',
-      'https://127.0.0.1:8201',
-      'https://127.0.0.1:8201',
-      'https://127.0.0.1:8201',
-    ];
+    return this.replicationDetails.knownPrimaryClusterAddrs;
   }),
 });

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -1,12 +1,14 @@
 {{#if (or alwaysRender value)}}
-  <div class="column is-one-quarter">
-    <span class="is-label has-text-grey-dark" data-test-row-label="{{label}}">{{label}}</span>
-    {{#if helperText}}
-      <div>
-        <span class="is-label helper-text has-text-grey">{{helperText}}</span>
-      </div>
-    {{/if}}
-  </div>
+  {{#if label}}
+    <div class="column is-one-quarter">
+      <span class="is-label has-text-grey-dark" data-test-row-label="{{label}}">{{label}}</span>
+      {{#if helperText}}
+        <div>
+          <span class="is-label helper-text has-text-grey">{{helperText}}</span>
+        </div>
+      {{/if}}
+    </div>
+  {{/if}}
   <div class="column is-flex">
     {{#if (has-block)}}
       {{yield}}

--- a/ui/lib/core/addon/templates/components/info-table.hbs
+++ b/ui/lib/core/addon/templates/components/info-table.hbs
@@ -1,0 +1,23 @@
+<div class="vlt-table info-table" data-test-info-table>
+  <table class="is-fullwidth">
+    <caption class="is-collapsed">
+      {{title}}
+    </caption>
+    <thead class="has-text-weight-semibold">
+      <tr>
+        <th scope="col">
+          {{header}}
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each items as |item|}}
+        <tr>
+          <td>
+            {{info-table-row value=item}}
+          </td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>

--- a/ui/lib/core/addon/templates/components/info-table.hbs
+++ b/ui/lib/core/addon/templates/components/info-table.hbs
@@ -1,4 +1,4 @@
-<div class="vlt-table info-table" data-test-info-table>
+<div class="vlt-table info-table sticky-header" data-test-info-table>
   <table class="is-fullwidth">
     <caption class="is-collapsed">
       {{title}}

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -51,22 +51,16 @@
       <p class="has-text-grey is-size-8">The last WAL index that the secondary received from the primary. Updates every 10 seconds.</p>
     </div>
     <div class="grid-item-right">
-      <h6 class="title is-6">primary_cluster_addr</h6>
-      {{#if primaryClusterAddr}}
-        <span>
-          <a
-            href={{primaryClusterAddr}}
-            class="link"
-            target="_blank"
-            rel="noreferrer noopener" 
-            data-test-primaryClusterAddr
-          >
-            {{primaryClusterAddr}}
-          </a>
-        </span>
-      {{else}}
-        <p class="has-text-grey is-size-8">unknown</p>
-      {{/if}}
+      <h6 class="title is-6">known_primary_cluster_addr</h6>
+      <p class="has-text-grey">A list of all the nodes in the primary's cluster. This is updated every ten seconds.</p>
+      <div class="info-table-row">
+        <p class="is-label has-text-grey-dark">cluster_addr</p>
+      </div>
+      {{#each knownPrimaryClusterAddrs as |clusterAddr|}}
+          <div class="info-table-row is-flex">
+            <code class="is-word-break has-text-black">{{clusterAddr}}</code>
+          </div>
+      {{/each}}
     </div>
     <h2 class="title is-3 grid-item-left-bottom" data-test-lastRemoteWAL>{{format-number lastRemoteWAL}}</h2>
     <div class="grid-item-right-bottom">

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -1,6 +1,6 @@
 <div class="selectable-card is-rounded card-container {{if hasErrorClass "has-border-danger"}}" data-test-replication-secondary-card>
-  {{!-- Check if State or WAL Card --}}
-  {{#if (eq title "States")}}
+  {{!-- Check if Status or Primary Cluster Card --}}
+  {{#if (eq title "Status")}}
     <h3 class="title is-5 grid-item-top-left card-title">{{title}}</h3>
     <div class="grid-item-left">
       {{#if (get (cluster-states state) "isOk")}}
@@ -43,14 +43,23 @@
         </ToolTip>
       {{/if}}
     </h2>
-    <h2 class="title is-3 grid-item-right-bottom" data-test-connection>{{connection}}</h2>
-  {{else}}
-    <h3 class="title is-5 grid-item-top-left card-title">{{title}}</h3>
-    <div class="grid-item-left">
-      <h6 class="title is-6">last_remote_wal</h6>
-      <p class="has-text-grey is-size-8">The last WAL index that the secondary received from the primary. Updates every 10 seconds.</p>
+    <h2 class="title is-3 grid-item-right-bottom" data-test-connection>
+     {{connection}}
+    </h2>
+    <div class="grid-item-full-bottom">
+      <h6 class="title is-6">
+        last_remote_wal
+      </h6>
+      <p class="has-text-grey is-size-8">
+        The last WAL index that the secondary received from the primary. Updates every 10 seconds.
+      </p>
+      <h2 class="title is-3" data-test-lastRemoteWAL>
+        {{format-number lastRemoteWAL}}
+      </h2>
     </div>
-    <div class="grid-item-right">
+  {{else}}
+    <h3 class="title is-5">{{title}}</h3>
+    <div class="grid-item-full-bottom">
       <h6 class="title is-6">known_primary_cluster_addr</h6>
       <p class="has-text-grey">A list of all the nodes in the primary's cluster. This is updated every ten seconds.</p>
       <div class="info-table-row">
@@ -61,10 +70,6 @@
             <code class="is-word-break has-text-black">{{clusterAddr}}</code>
           </div>
       {{/each}}
-    </div>
-    <h2 class="title is-3 grid-item-left-bottom" data-test-lastRemoteWAL>{{format-number lastRemoteWAL}}</h2>
-    <div class="grid-item-right-bottom">
-        {{!-- Empty --}}
     </div>
   {{/if}}
 </div>

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -78,7 +78,7 @@
       </h2>
     </div>
   {{else}}
-    <h3 class="title is-5">
+    <h3 class="title is-5 grid-item-top-left card-title">
       {{title}}
     </h3>
     <div class="grid-item-full-middle">
@@ -88,6 +88,8 @@
       <p class="has-text-grey">
         A list of all the nodes in the primary's cluster. This is updated every ten seconds.
       </p>
+    </div>
+    <div class="grid-item-full-bottom">
       <InfoTable
         @title="Known Primary Cluster Addrs"
         @header="cluster_addr"

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -81,7 +81,7 @@
     <h3 class="title is-5 grid-item-top-left card-title">
       {{title}}
     </h3>
-    <div class="grid-item-full-middle">
+    <div class="grid-item-second-row">
       <h6 class="title is-6">
         known_primary_cluster_addr
       </h6>
@@ -89,7 +89,7 @@
         A list of all the nodes in the primary's cluster. This is updated every ten seconds.
       </p>
     </div>
-    <div class="grid-item-full-bottom">
+    <div class="grid-item-third-row">
       <InfoTable
         @title="Known Primary Cluster Addrs"
         @header="cluster_addr"

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -48,7 +48,7 @@
         </p>
       {{/if}}
     </div>
-    <h2 class="title is-3 grid-item-left-bottom" data-test-state>
+    <h2 class="title is-3 grid-item-bottom-left" data-test-state>
       {{state}}
       {{#if inSyncState}}
         <ToolTip @verticalPosition="above" as |T|>
@@ -63,10 +63,10 @@
         </ToolTip>
       {{/if}}
     </h2>
-    <h2 class="title is-3 grid-item-right-bottom" data-test-connection>
+    <h2 class="title is-3 grid-item-bottom-right" data-test-connection>
       {{connection}}
     </h2>
-    <div class="grid-item-full-bottom">
+    <div class="grid-item-bottom-row">
       <h6 class="title is-6">
         last_remote_wal
       </h6>

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -1,39 +1,59 @@
-<div class="selectable-card is-rounded card-container {{if hasErrorClass "has-border-danger"}}" data-test-replication-secondary-card>
-  {{!-- Check if Status or Primary Cluster Card --}}
-  {{#if (eq title "Status")}}
-    <h3 class="title is-5 grid-item-top-left card-title">{{title}}</h3>
+<div
+  class="selectable-card is-rounded card-container {{if hasErrorClass 'has-border-danger'}}"
+  data-test-replication-secondary-card
+>
+  {{! Check if Status or Primary Cluster Card }}
+  {{#if (eq title 'Status')}}
+    <h3 class="title is-5 grid-item-top-left card-title">
+      {{title}}
+    </h3>
     <div class="grid-item-left">
-      {{#if (get (cluster-states state) "isOk")}}
-        <h6 class="title is-6">state</h6>
-        <p class="has-text-grey is-size-8">How this cluster is communicating with others at this moment.</p>
+      {{#if (get (cluster-states state) 'isOk')}}
+        <h6 class="title is-6">
+          state
+        </h6>
+        <p class="has-text-grey is-size-8">
+          How this cluster is communicating with others at this moment.
+        </p>
       {{else}}
-        <h6 class="has-text-danger" data-test-error>state</h6>
-        <AlertInline
-          @type="danger"
-          @message="Please check your server logs." />
+        <h6 class="has-text-danger" data-test-error>
+          state
+        </h6>
+        <AlertInline @type="danger" @message="Please check your server logs." />
       {{/if}}
     </div>
     <div class="grid-item-right">
-      {{#if (eq connection "transient_failure")}}
-        <h6 class="title is-6 has-text-danger" data-test-error>connection_state</h6>
+      {{#if (eq connection 'transient_failure')}}
+        <h6 class="title is-6 has-text-danger" data-test-error>
+          connection_state
+        </h6>
         <AlertInline
           @type="danger"
-          @message="There has been some transient failure.  Your cluster will eventually switch back to connection and try to establish a connection again." />
-      {{else if (eq connection "shutdown")}}
-        <h6 class="title is-6 has-text-danger" data-test-error>connection_state</h6>
+          @message="There has been some transient failure.  Your cluster will eventually switch back to connection and try to establish a connection again."
+        />
+      {{else if (eq connection 'shutdown')}}
+        <h6 class="title is-6 has-text-danger" data-test-error>
+          connection_state
+        </h6>
         <AlertInline
           @type="danger"
-          @message="Your connection has shut down. This may be because the application explicitly requested a shutdown or a non-recoverable error has happened during attempts to communicate." />
+          @message="Your connection has shut down. This may be because the application explicitly requested a shutdown or a non-recoverable error has happened during attempts to communicate."
+        />
       {{else}}
-        <h6 class="title is-6">connection_state</h6>
-        <p class="has-text-grey is-size-8">The health of the connection between this cluster and others.</p>
+        <h6 class="title is-6">
+          connection_state
+        </h6>
+        <p class="has-text-grey is-size-8">
+          The health of the connection between this cluster and others.
+        </p>
       {{/if}}
     </div>
-    <h2 class="title is-3 grid-item-left-bottom" data-test-state>{{state}}
-      {{#if inSyncState }}
+    <h2 class="title is-3 grid-item-left-bottom" data-test-state>
+      {{state}}
+      {{#if inSyncState}}
         <ToolTip @verticalPosition="above" as |T|>
           <T.trigger>
-            <Icon @glyph={{"check-circle-outline" }} @size="m" class={{"has-text-success"}} data-test-glyph />
+            <Icon @glyph={{'check-circle-outline'}} @size="m" class={{'has-text-success'}} data-test-glyph />
           </T.trigger>
           <T.content @class="tool-tip">
             <div class="box">
@@ -44,7 +64,7 @@
       {{/if}}
     </h2>
     <h2 class="title is-3 grid-item-right-bottom" data-test-connection>
-     {{connection}}
+      {{connection}}
     </h2>
     <div class="grid-item-full-bottom">
       <h6 class="title is-6">
@@ -58,18 +78,21 @@
       </h2>
     </div>
   {{else}}
-    <h3 class="title is-5">{{title}}</h3>
-    <div class="grid-item-full-bottom">
-      <h6 class="title is-6">known_primary_cluster_addr</h6>
-      <p class="has-text-grey">A list of all the nodes in the primary's cluster. This is updated every ten seconds.</p>
-      <div class="info-table-row">
-        <p class="is-label has-text-grey-dark">cluster_addr</p>
-      </div>
-      {{#each knownPrimaryClusterAddrs as |clusterAddr|}}
-          <div class="info-table-row is-flex">
-            <code class="is-word-break has-text-black">{{clusterAddr}}</code>
-          </div>
-      {{/each}}
+    <h3 class="title is-5">
+      {{title}}
+    </h3>
+    <div class="grid-item-full-middle">
+      <h6 class="title is-6">
+        known_primary_cluster_addr
+      </h6>
+      <p class="has-text-grey">
+        A list of all the nodes in the primary's cluster. This is updated every ten seconds.
+      </p>
+      <InfoTable
+        @title="Known Primary Cluster Addrs"
+        @header="cluster_addr"
+        @items={{knownPrimaryClusterAddrs}}
+      />
     </div>
   {{/if}}
 </div>

--- a/ui/lib/core/addon/templates/components/replication-summary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-summary-card.hbs
@@ -15,9 +15,9 @@
       <h6 class="title is-6">known_secondaries</h6>
       <p class="helper-text is-label has-text-grey">Number of secondaries connected to this primary.</p>
     </div>
-    <h2 class="title is-3 grid-item-left-bottom" data-test-lastWAL>{{format-number lastDrWAL}}</h2>
-    <h2 class="title is-3 grid-item-right-bottom" data-test-known-secondaries>{{format-number knownSecondariesDr}}</h2>
-    <div class="grid-item-full-bottom">
+    <h2 class="title is-3 grid-item-bottom-left" data-test-lastWAL>{{format-number lastDrWAL}}</h2>
+    <h2 class="title is-3 grid-item-bottom-right" data-test-known-secondaries>{{format-number knownSecondariesDr}}</h2>
+    <div class="grid-item-bottom-row">
       <h6 class="title is-6">merkle_root</h6>
       <p class="helper-text is-label has-text-grey">A snapshot of the merkle tree's root hash.</p>
       <div><code class="is-word-break has-text-black">{{merkleRootDr}}</code></div>
@@ -37,9 +37,9 @@
       <h6 class="title is-6">known_secondaries</h6>
       <p class="helper-text is-label has-text-grey">Number of secondaries connected to this primary.</p>
     </div>
-    <h2 class="title is-3 grid-item-left-bottom" data-test-lastWAL>{{format-number lastPerformanceWAL}}</h2>
-    <h2 class="title is-3 grid-item-right-bottom" data-test-known-secondaries>{{format-number knownSecondariesPerformance}}</h2>
-    <div class="grid-item-full-bottom">
+    <h2 class="title is-3 grid-item-bottom-left" data-test-lastWAL>{{format-number lastPerformanceWAL}}</h2>
+    <h2 class="title is-3 grid-item-bottom-right" data-test-known-secondaries>{{format-number knownSecondariesPerformance}}</h2>
+    <div class="grid-item-bottom-row">
       <h6 class="title is-6">merkle_root</h6>
       <p class="helper-text is-label has-text-grey">A snapshot of the merkle tree's root hash.</p>
       <div><code class="is-word-break has-text-black">{{merkleRootPerformance}}</code></div>

--- a/ui/lib/core/app/components/info-table.js
+++ b/ui/lib/core/app/components/info-table.js
@@ -1,0 +1,1 @@
+export { default } from 'core/components/info-table';

--- a/ui/lib/core/stories/info-table.md
+++ b/ui/lib/core/stories/info-table.md
@@ -1,0 +1,30 @@
+<!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in lib/core/addon/components/info-table.js. To make changes, first edit that file and run "yarn gen-story-md info-table" to re-generate the content.-->
+
+## InfoTable
+InfoTable components are a table with a single column and header. They are used to render a list of InfoTableRow components.
+
+**Params**
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [title] | <code>String</code> | <code>Info Table</code> | The title of the table. Used for accessibility purposes. |
+| header | <code>String</code> | <code></code> | The column header. |
+| items | <code>Array</code> | <code></code> | An array of strings which will be used as the InfoTableRow value. |
+
+**Example**
+  
+```js
+<InfoTable
+  @title="Known Primary Cluster Addrs"
+  @header="cluster_addr"
+  @items={{knownPrimaryClusterAddrs}}
+/>
+```
+        
+
+**See**
+
+- [Uses of InfoTable](https://github.com/hashicorp/vault/search?l=Handlebars&q=InfoTable+OR+info-table)
+- [InfoTable Source Code](https://github.com/hashicorp/vault/blob/master/ui/lib/core/addon/components/info-table.js)
+
+---

--- a/ui/lib/core/stories/info-table.stories.js
+++ b/ui/lib/core/stories/info-table.stories.js
@@ -1,0 +1,27 @@
+import hbs from 'htmlbars-inline-precompile';
+import { storiesOf } from '@storybook/ember';
+import { withKnobs, object, text } from '@storybook/addon-knobs';
+import notes from './info-table.md';
+
+const ITEMS = ['https://127.0.0.1:8201', 'hello', 3];
+
+storiesOf('InfoTable/', module)
+  .addParameters({ options: { showPanel: true } })
+  .addDecorator(withKnobs({ escapeHTML: false }))
+  .add(
+    `InfoTable`,
+    () => ({
+      template: hbs`
+      <h5 class="title is-5">Info Table</h5>
+      <InfoTable
+        @header={{header}}
+        @items={{items}}
+      />
+    `,
+      context: {
+        header: text('Header', 'Column Header'),
+        items: object('Items', ITEMS),
+      },
+    }),
+    { notes }
+  );

--- a/ui/lib/replication/addon/templates/components/known-secondaries-table.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-table.hbs
@@ -1,4 +1,4 @@
-<div class="replication vlt-table" data-test-known-secondaries-table>
+<div class="replication vlt-table sticky-header" data-test-known-secondaries-table>
   <table class="is-fullwidth">
     <caption class="is-collapsed">
       Known Secondaries

--- a/ui/lib/replication/addon/templates/components/replication-summary.hbs
+++ b/ui/lib/replication/addon/templates/components/replication-summary.hbs
@@ -350,7 +350,7 @@
           as |Dashboard|>
           {{#if (eq replicationAttrs.mode 'secondary')}}
             <Dashboard.card
-              @title="States"
+              @title="Status"
             />
             <Dashboard.card
               @title="Primary cluster"

--- a/ui/tests/integration/components/info-table-test.js
+++ b/ui/tests/integration/components/info-table-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+const TITLE = 'My Table';
+const HEADER = 'Cool Header';
+const ITEMS = ['https://127.0.0.1:8201', 'hello', 3];
+
+module('Integration | Enterprise | Component | InfoTable', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.set('title', TITLE);
+    this.set('header', HEADER);
+    this.set('items', ITEMS);
+  });
+
+  test('it renders', async function(assert) {
+    await render(hbs`<InfoTable
+        @title={{title}}
+        @header={{header}}
+        @items={{items}}
+      />`);
+
+    assert.dom('[data-test-info-table]').exists();
+    assert.dom('[data-test-info-table] th').includesText(HEADER, `shows the table header`);
+
+    const rows = document.querySelectorAll('.info-table-row');
+    assert.equal(rows.length, ITEMS.length, 'renders an InfoTableRow for each item');
+
+    rows.forEach((row, i) => {
+      assert.equal(row.innerText, ITEMS[i], 'handles strings and numbers as row values');
+    });
+  });
+});


### PR DESCRIPTION
# Show known_primary_cluster_addrs
This PR replaces the last wal and primary cluster address on the replication secondary dashboards with the known_primary_cluster_addrs. 

It also adds a new component, the `InfoTable`, which uses our existing `InfoTableRow` component and `vlt-table` style-only component to render a list-like table of `InfoTableRow`s. We can reuse this elsewhere in the Vault UI, hopefully refactoring it to accept multiple columns so it can replace the `KnownSecondariesTable` component, for instance.

*Note:* I haven't yet figured out what size the max-height should be of the Primary Clusters card, or where to set it. Ideas welcome!

## Changes
### Before
#### Primary Cluster card displays the last_remote_wal and primary_cluster_add
![image](https://user-images.githubusercontent.com/903288/83824182-9e509400-a68a-11ea-8607-4acc32e34454.png)


### After
#### The Primary Cluster Card on a secondary now has a scrollable list of known_primary_addrs
![image](https://user-images.githubusercontent.com/903288/83914170-8e39c280-a725-11ea-9b5d-fc790bb09bfc.png)


#### The Known Secondaries Card on a primary is now scrollable
![image](https://user-images.githubusercontent.com/903288/83823692-6ac13a00-a689-11ea-929c-39108c1b52b9.png)

#### An info table row component with a label, no change
![image](https://user-images.githubusercontent.com/903288/83823573-2cc41600-a689-11ea-857d-7fe53a537c2b.png)