### PR TITLE
Github markdown doesn't use "^" for superscript, have to be explicit

### DIFF
--- a/website/pages/docs/secrets/transform/index.mdx
+++ b/website/pages/docs/secrets/transform/index.mdx
@@ -179,12 +179,12 @@ alphabet the input size does not leave the input guessable by brute force.
 Given an alphabet of length A, an input length L is valid if: 
 
 * L >= 2, 
-* A^L >= 1,000,000
-* and L <= 2 * floor(log<sub>A</sub>(2^96)).
+* A<sup>L</sup> >= 1,000,000
+* and L <= 2 * floor(log<sub>A</sub>(2<sup>96</sup>)).
 
 As a concrete example, for handling credit card numbers, A is 10, L is 16, so
 valid input lengths would be between 6 and 56 characters.  This is because 
-10^6=1,000,000 (already greater than 2), and 2 * floor(log<sub>10</sub>(2^96)) = 56.
+10<sup>6</sup>=1,000,000 (already greater than 2), and 2 * floor(log<sub>10</sub>(2<sup>96</sup>)) = 56.
 
 Of course, in the case of credit card numbers valid input would always be 16 
 decimal digits.


### PR DESCRIPTION
Looked bad when it hit stable-website.