### PR TITLE
docs: fix port number in curl command for aws rotate root iam creds

### DIFF
--- a/website/pages/api-docs/secret/aws/index.mdx
+++ b/website/pages/api-docs/secret/aws/index.mdx
@@ -137,7 +137,7 @@ There are no parameters to this operation.
 $ curl \
   --header "X-Vault-Token: ..." \
   --request POST \
-  http://127.0.0.1:8211/v1/aws/config/rotate-root
+  http://127.0.0.1:8200/v1/aws/config/rotate-root
 ```
 
 ### Sample Response


### PR DESCRIPTION
Fixes the port number specified in the curl command in the API docs for the AWS rotate root IAM credentials API. See: [current docs](https://www.vaultproject.io/api-docs/secret/aws#rotate-root-iam-credentials).

I tested using port `8211` to confirm this isn't intentional:
```
$ curl --header "X-Vault-Token: $(cat ~/.vault-token)" --request POST http://127.0.0.1:8211/v1/aws/config/rotate-root 
curl: (7) Failed to connect to 127.0.0.1 port 8211: Connection refused

$ curl --header "X-Vault-Token: $(cat ~/.vault-token)" --request POST http://127.0.0.1:8200/v1/aws/config/rotate-root
{"request_id":"af878f63-66f6-d932-89ba-cb62384a240d","lease_id":"","renewable":false,"lease_duration":0,"data":{"access_key":"XXX"},"wrap_info":null,"warnings":null,"auth":null}
```