### PR TITLE
Ui/rep design updates

### DIFF
--- a/ui/lib/core/addon/components/replication-table-rows.js
+++ b/ui/lib/core/addon/components/replication-table-rows.js
@@ -14,7 +14,7 @@ import layout from '../templates/components/replication-table-rows';
     />
  * ```
  * @param {Object} replicationDetails=null - An Ember data object pulled from the Ember Model. It contains details specific to the whether the replication is dr or performance.
- * @param {String} clusterMode=null - The cluster mode (e.g. primary or secondary) passed through to a table component. 
+ * @param {String} clusterMode=null - The cluster mode (e.g. primary or secondary) passed through to a table component.
  */
 
 export default Component.extend({
@@ -22,6 +22,9 @@ export default Component.extend({
   classNames: ['replication-table-rows'],
   replicationDetails: null,
   clusterMode: null,
+  secondaryId: computed('replicationDetails.{secondaryId}', function() {
+    return this.replicationDetails.secondaryId;
+  }),
   merkleRoot: computed('replicationDetails.{merkleRoot}', function() {
     return this.replicationDetails.merkleRoot || 'unknown';
   }),

--- a/ui/lib/core/addon/components/replication-table-rows.js
+++ b/ui/lib/core/addon/components/replication-table-rows.js
@@ -25,6 +25,9 @@ export default Component.extend({
   secondaryId: computed('replicationDetails.{secondaryId}', function() {
     return this.replicationDetails.secondaryId;
   }),
+  primaryClusterAddr: computed('replcationDetails.{primaryClusterAddr}', function() {
+    return this.replicationDetails.primaryClusterAddr;
+  }),
   merkleRoot: computed('replicationDetails.{merkleRoot}', function() {
     return this.replicationDetails.merkleRoot || 'unknown';
   }),

--- a/ui/lib/core/addon/templates/components/replication-header.hbs
+++ b/ui/lib/core/addon/templates/components/replication-header.hbs
@@ -38,9 +38,6 @@
       <span class="tag is-light has-text-grey-dark" data-test-mode>
         {{if isSecondary 'secondary' 'primary'}}
       </span>
-      <span class="tag is-light has-text-grey-dark" data-test-secondaryId>
-        {{secondaryId}}
-      </span>
     </h1>
   </p.levelLeft>
 </PageHeader>

--- a/ui/lib/core/addon/templates/components/replication-table-rows.hbs
+++ b/ui/lib/core/addon/templates/components/replication-table-rows.hbs
@@ -1,5 +1,11 @@
 <div class="has-top-margin-xl has-bottom-margin-s"
   data-test-table-rows>
+  {{#if (eq clusterMode 'secondary')}}
+    {{info-table-row
+      label='secondary_id'
+      helperText="The ID of the secondary activation token used to enable replication."
+      value=secondaryId}}
+  {{/if}}
   {{info-table-row
     label="Merkle root index"
     helperText="A snapshot in time of the merkle tree's root hash. Changes on every update to storage."

--- a/ui/lib/core/addon/templates/components/replication-table-rows.hbs
+++ b/ui/lib/core/addon/templates/components/replication-table-rows.hbs
@@ -7,6 +7,10 @@
       value=secondaryId}}
   {{/if}}
   {{info-table-row
+      label='primary_cluster_addr'
+      helperText='The configuration of the cluster. This was set when replication was enabled.'
+      value=primaryClusterAddr}}
+  {{info-table-row
     label="Merkle root index"
     helperText="A snapshot in time of the merkle tree's root hash. Changes on every update to storage."
     value=merkleRoot}}

--- a/ui/lib/replication/addon/templates/mode.hbs
+++ b/ui/lib/replication/addon/templates/mode.hbs
@@ -24,19 +24,6 @@
               <span class="tag is-light has-text-grey-dark" data-test-replication-mode-display=true>
                 {{model.replicationAttrs.modeForHeader}}
               </span>
-              {{#if model.replicationAttrs.secondaryId}}
-                <span class="tag is-light has-text-grey-dark">
-                  <code>
-                    {{model.replicationAttrs.secondaryId}}
-                  </code>
-                </span>
-              {{else}}
-                <span class="tag is-light has-text-grey-dark">
-                  <code>
-                    {{model.replicationAttrs.clusterIdDisplay}}
-                  </code>
-                </span>
-              {{/if}}
             </h1>
         </p.levelLeft>
       </PageHeader>


### PR DESCRIPTION
## Secondary Dashboard
- Move the `secondaryId` out of the header and into the replication table rows
### Example
![image](https://user-images.githubusercontent.com/903288/84095538-690eb380-a9b4-11ea-9027-54b212ba4649.png)


## Primary Dashboard
- Move the clusterId out of the header and into the replication table rows
- If a `primary_cluster_addr` has been set when replication was enabled, show it in the replication table rows

### Example
![image](https://user-images.githubusercontent.com/903288/84079568-a7de4280-a98f-11ea-83f5-8e1fdbc471fa.png)
