### PR TITLE
Ui/replication merge cleanup

### DIFF
--- a/ui/app/styles/components/replication-dashboard.scss
+++ b/ui/app/styles/components/replication-dashboard.scss
@@ -102,6 +102,11 @@
       .grid-item-third-row {
         grid-column: 1 / span 2;
         grid-row: 3/4;
+
+        .empty-state {
+          padding: 0px 12px;
+          box-shadow: none;
+        }
       }
       .grid-item-bottom-row {
         grid-column: 1 / span 2;

--- a/ui/app/styles/components/selectable-card.scss
+++ b/ui/app/styles/components/selectable-card.scss
@@ -69,8 +69,8 @@
   }
 
   .vlt-table {
-    max-height: 240px;
-    overflow-y: scroll;
+    max-height: 200px;
+    overflow-y: auto;
   }
 }
 

--- a/ui/lib/core/addon/components/replication-action-demote.js
+++ b/ui/lib/core/addon/components/replication-action-demote.js
@@ -1,6 +1,18 @@
 import Actions from 'core/components/replication-actions-single';
 import layout from '../templates/components/replication-action-demote';
+import keys from 'vault/lib/keycodes';
 
 export default Actions.extend({
   layout,
+  onSubmit() {},
+  actions: {
+    onSubmit() {
+      if (event.keyCode === keys.ESC) {
+        // if escape close modal and return
+        this.toggleProperty('isModalActive');
+        return;
+      }
+      return this.onSubmit(...arguments);
+    },
+  },
 });

--- a/ui/lib/core/addon/components/replication-action-demote.js
+++ b/ui/lib/core/addon/components/replication-action-demote.js
@@ -1,18 +1,6 @@
 import Actions from 'core/components/replication-actions-single';
 import layout from '../templates/components/replication-action-demote';
-import keys from 'vault/lib/keycodes';
 
 export default Actions.extend({
   layout,
-  onSubmit() {},
-  actions: {
-    onSubmit() {
-      if (event.keyCode === keys.ESC) {
-        // if escape close modal and return
-        this.toggleProperty('isModalActive');
-        return;
-      }
-      return this.onSubmit(...arguments);
-    },
-  },
 });

--- a/ui/lib/core/addon/components/replication-action-disable.js
+++ b/ui/lib/core/addon/components/replication-action-disable.js
@@ -1,18 +1,6 @@
 import Actions from 'core/components/replication-actions-single';
 import layout from '../templates/components/replication-action-disable';
-import keys from 'vault/lib/keycodes';
 
 export default Actions.extend({
   layout,
-  onSubmit() {},
-  actions: {
-    onSubmit() {
-      if (event.keyCode === keys.ESC) {
-        // if escape close modal and return
-        this.toggleProperty('isModalActive');
-        return;
-      }
-      return this.onSubmit(...arguments);
-    },
-  },
 });

--- a/ui/lib/core/addon/components/replication-action-disable.js
+++ b/ui/lib/core/addon/components/replication-action-disable.js
@@ -1,6 +1,18 @@
 import Actions from 'core/components/replication-actions-single';
 import layout from '../templates/components/replication-action-disable';
+import keys from 'vault/lib/keycodes';
 
 export default Actions.extend({
   layout,
+  onSubmit() {},
+  actions: {
+    onSubmit() {
+      if (event.keyCode === keys.ESC) {
+        // if escape close modal and return
+        this.toggleProperty('isModalActive');
+        return;
+      }
+      return this.onSubmit(...arguments);
+    },
+  },
 });

--- a/ui/lib/core/addon/components/replication-action-promote.js
+++ b/ui/lib/core/addon/components/replication-action-promote.js
@@ -1,6 +1,18 @@
 import Actions from './replication-actions-single';
 import layout from '../templates/components/replication-action-promote';
+import keys from 'vault/lib/keycodes';
 
 export default Actions.extend({
   layout,
+  onSubmit() {},
+  actions: {
+    onSubmit() {
+      if (event.keyCode === keys.ESC) {
+        // if escape close modal and return
+        this.toggleProperty('isModalActive');
+        return;
+      }
+      return this.onSubmit(...arguments);
+    },
+  },
 });

--- a/ui/lib/core/addon/components/replication-action-recover.js
+++ b/ui/lib/core/addon/components/replication-action-recover.js
@@ -1,6 +1,18 @@
 import Actions from 'core/components/replication-actions-single';
 import layout from '../templates/components/replication-action-recover';
+import keys from 'vault/lib/keycodes';
 
 export default Actions.extend({
   layout,
+  onSubmit() {},
+  actions: {
+    onSubmit() {
+      if (event.keyCode === keys.ESC) {
+        // if escape close modal and return
+        this.toggleProperty('isModalActive');
+        return;
+      }
+      return this.onSubmit(...arguments);
+    },
+  },
 });

--- a/ui/lib/core/addon/components/replication-action-reindex.js
+++ b/ui/lib/core/addon/components/replication-action-reindex.js
@@ -1,6 +1,18 @@
 import Actions from 'core/components/replication-actions-single';
 import layout from '../templates/components/replication-action-reindex';
+import keys from 'vault/lib/keycodes';
 
 export default Actions.extend({
   layout,
+  onSubmit() {},
+  actions: {
+    onSubmit() {
+      if (event.keyCode === keys.ESC) {
+        // if escape close modal and return
+        this.toggleProperty('isModalActive');
+        return;
+      }
+      return this.onSubmit(...arguments);
+    },
+  },
 });

--- a/ui/lib/core/addon/components/replication-action-update-primary.js
+++ b/ui/lib/core/addon/components/replication-action-update-primary.js
@@ -1,6 +1,18 @@
 import Actions from './replication-actions-single';
 import layout from '../templates/components/replication-action-update-primary';
+import keys from 'vault/lib/keycodes';
 
 export default Actions.extend({
   layout,
+  onSubmit() {},
+  actions: {
+    onSubmit() {
+      if (event.keyCode === keys.ESC) {
+        // if escape close modal and return
+        this.toggleProperty('isModalActive');
+        return;
+      }
+      return this.onSubmit(...arguments);
+    },
+  },
 });

--- a/ui/lib/core/addon/components/replication-actions.js
+++ b/ui/lib/core/addon/components/replication-actions.js
@@ -2,6 +2,7 @@ import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
 import ReplicationActions from 'core/mixins/replication-actions';
 import layout from '../templates/components/replication-actions';
+import keys from 'vault/lib/keycodes';
 
 const DEFAULTS = {
   token: null,
@@ -26,6 +27,10 @@ export default Component.extend(ReplicationActions, DEFAULTS, {
 
   actions: {
     onSubmit() {
+      // do not submit if a key is pressed and it is not the enter key
+      if (event.keyCode && event.keyCode !== keys.ENTER) {
+        return;
+      }
       return this.submitHandler.perform(...arguments);
     },
     clear() {

--- a/ui/lib/core/addon/components/replication-table-rows.js
+++ b/ui/lib/core/addon/components/replication-table-rows.js
@@ -25,8 +25,8 @@ export default Component.extend({
   secondaryId: computed('replicationDetails.{secondaryId}', function() {
     return this.replicationDetails.secondaryId;
   }),
-  primaryClusterAddr: computed('replcationDetails.{primaryClusterAddr}', function() {
-    return this.replicationDetails.primaryClusterAddr;
+  primaryClusterAddr: computed('replicationDetails.{primaryClusterAddr}', function() {
+    return this.replicationDetails.primaryClusterAddr || 'Not defined';
   }),
   merkleRoot: computed('replicationDetails.{merkleRoot}', function() {
     return this.replicationDetails.merkleRoot || 'unknown';

--- a/ui/lib/core/addon/templates/components/confirmation-modal.hbs
+++ b/ui/lib/core/addon/templates/components/confirmation-modal.hbs
@@ -6,25 +6,23 @@
   @showCloseButton={{true}}
 >
   <section class="modal-card-body">
-    <div class="box is-shadowless is-fullwidth is-sideless">
 
-      {{yield}}
+    {{yield}}
 
-      <div class="modal-confirm-section">
-        <p class="has-text-weight-semibold is-size-6">
-          Confirm
-        </p>
-        <p class="is-help">Type <strong>{{confirmText}}</strong> to confirm {{toConfirmMsg}}</p>
-        {{input
-            type="text"
-            value=confirmationInput
-            name="confirmationInput"
-            class="input has-margin-top"
-            autocomplete="off"
-            spellcheck="false"
-            data-test-confirmation-modal-input=testSelector
-          }}
-        </div>
+    <div class="modal-confirm-section">
+      <p class="has-text-weight-semibold is-size-6">
+        Confirm
+      </p>
+      <p class="is-help">Type <strong>{{confirmText}}</strong> to confirm {{toConfirmMsg}}</p>
+      {{input
+        type="text"
+        value=confirmationInput
+        name="confirmationInput"
+        class="input has-margin-top"
+        autocomplete="off"
+        spellcheck="false"
+        data-test-confirmation-modal-input=testSelector
+      }}
     </div>
   </section>
   <footer class="modal-card-foot modal-card-foot-outlined">

--- a/ui/lib/core/addon/templates/components/confirmation-modal.hbs
+++ b/ui/lib/core/addon/templates/components/confirmation-modal.hbs
@@ -21,7 +21,8 @@
         class="input has-margin-top"
         autocomplete="off"
         spellcheck="false"
-        enter=onConfirm
+        enter=(if (eq confirmationInput confirmText) onConfirm)
+        escape-press=onClose
         data-test-confirmation-modal-input=testSelector
       }}
     </div>

--- a/ui/lib/core/addon/templates/components/confirmation-modal.hbs
+++ b/ui/lib/core/addon/templates/components/confirmation-modal.hbs
@@ -21,6 +21,7 @@
         class="input has-margin-top"
         autocomplete="off"
         spellcheck="false"
+        enter=onConfirm
         data-test-confirmation-modal-input=testSelector
       }}
     </div>

--- a/ui/lib/core/addon/templates/components/replication-action-demote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-demote.hbs
@@ -1,58 +1,56 @@
-<div onkeyup={{action "onSubmit" "demote" model.replicationAttrs.modeForUrl}}>
-  <div class="action-block is-rounded" data-test-demote-replication>
-    <div class="action-block-info">
-      <h4 class="title is-5 is-marginless">
-        Demote cluster
-      </h4>
-      <p>
-        Demote this {{model.replicationModeForDisplay}} primary to a secondary.
-      </p>
-    </div>
-    <div class="action-block-action">
-      <button
-        class="button is-secondary"
-        onclick={{action (mut isModalActive) true}}
-        data-test-replication-action-trigger
-      >
-        Demote
-      </button>
-    </div>
+<div class="action-block is-rounded" data-test-demote-replication>
+  <div class="action-block-info">
+    <h4 class="title is-5 is-marginless">
+      Demote cluster
+    </h4>
+    <p>
+      Demote this {{model.replicationModeForDisplay}} primary to a secondary.
+    </p>
   </div>
-
-  <ConfirmationModal
-    @title="Demote to secondary?"
-    @onClose={{action (mut isModalActive) false}}
-    @isActive={{isModalActive}}
-    @buttonClass="is-primary"
-    @confirmText={{model.replicationModeForDisplay}}
-    @toConfirmMsg="demoting this cluster"
-    @onConfirm={{action "onSubmit" "demote" model.replicationAttrs.modeForUrl}}
-    @testSelector="demote"
-  >
-    <p class="has-bottom-margin-m">
-      {{#if (and
-        (eq replicationMode 'dr')
-        (not model.performance.replicationDisabled)
-      )}}
-        <p class="has-bottom-margin-m" data-test-demote-warning>
-          This cluster is currently operating as a performance secondary. Demoting it will leave your replication setup <strong>without a performance primary cluster</strong> until a new cluster is promoted.
-        </p>
-      {{/if}}
-      Demoting this{{model.replicationModeForDisplay}} primary to a {{model.replicationModeForDisplay}} secondary means that the resulting secondary cluster:
-    </p>
-    <ul class="bullet has-bottom-margin-m">
-      {{#if (and
-        (eq replicationMode 'dr')
-        (not model.performance.replicationDisabled)
-      )}}
-        <li>Will be read-only</li>
-      {{/if}}
-      <li>Will not attempt to connect to a primary</li>
-      <li>Will maintain knowledge of its cluster ID</li>
-      <li>Can be reconnected to the same set of replication clusters without wiping local storage.</li>
-    </ul>
-    <p class="has-bottom-margin-m">
-      To connect the resulting secondary to a new primary, use the Update primary action.
-    </p>
-  </ConfirmationModal>
+  <div class="action-block-action">
+    <button
+      class="button is-secondary"
+      onclick={{action (mut isModalActive) true}}
+      data-test-replication-action-trigger
+    >
+      Demote
+    </button>
+  </div>
 </div>
+
+<ConfirmationModal
+  @title="Demote to secondary?"
+  @onClose={{action (mut isModalActive) false}}
+  @isActive={{isModalActive}}
+  @buttonClass="is-primary"
+  @confirmText={{model.replicationModeForDisplay}}
+  @toConfirmMsg="demoting this cluster"
+  @onConfirm={{action "onSubmit" "demote" model.replicationAttrs.modeForUrl}}
+  @testSelector="demote"
+>
+  <p class="has-bottom-margin-m">
+    {{#if (and
+      (eq replicationMode 'dr')
+      (not model.performance.replicationDisabled)
+    )}}
+      <p class="has-bottom-margin-m" data-test-demote-warning>
+        This cluster is currently operating as a performance secondary. Demoting it will leave your replication setup <strong>without a performance primary cluster</strong> until a new cluster is promoted.
+      </p>
+    {{/if}}
+    Demoting this{{model.replicationModeForDisplay}} primary to a {{model.replicationModeForDisplay}} secondary means that the resulting secondary cluster:
+  </p>
+  <ul class="bullet has-bottom-margin-m">
+    {{#if (and
+      (eq replicationMode 'dr')
+      (not model.performance.replicationDisabled)
+    )}}
+      <li>Will be read-only</li>
+    {{/if}}
+    <li>Will not attempt to connect to a primary</li>
+    <li>Will maintain knowledge of its cluster ID</li>
+    <li>Can be reconnected to the same set of replication clusters without wiping local storage.</li>
+  </ul>
+  <p class="has-bottom-margin-m">
+    To connect the resulting secondary to a new primary, use the Update primary action.
+  </p>
+</ConfirmationModal>

--- a/ui/lib/core/addon/templates/components/replication-action-demote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-demote.hbs
@@ -4,7 +4,7 @@
       Demote cluster
     </h4>
     <p>
-      Demote this {{if (eq model.replicationMode "dr") "Disaster Recovery" "Performance"}} primary to a secondary.
+      Demote this {{model.replicationModeForDisplay}} primary to a secondary.
     </p>
   </div>
   <div class="action-block-action">
@@ -23,7 +23,7 @@
   @onClose={{action (mut isModalActive) false}}
   @isActive={{isModalActive}}
   @buttonClass="is-primary"
-  @confirmText={{if (eq replicationDisplayMode "DR") "Disaster Recovery" replicationDisplayMode}}
+  @confirmText={{model.replicationModeForDisplay}}
   @toConfirmMsg="demoting this cluster"
   @onConfirm={{action "onSubmit" "demote" model.replicationAttrs.modeForUrl}}
   @testSelector="demote"
@@ -37,7 +37,7 @@
         This cluster is currently operating as a performance secondary. Demoting it will leave your replication setup <strong>without a performance primary cluster</strong> until a new cluster is promoted.
       </p>
     {{/if}}
-    Demoting this {{replicationDisplayMode}} primary to a {{replicationDisplayMode}} secondary means that the resulting secondary cluster:
+    Demoting this{{model.replicationModeForDisplay}} primary to a {{model.replicationModeForDisplay}} secondary means that the resulting secondary cluster:
   </p>
   <ul class="bullet has-bottom-margin-m">
     {{#if (and

--- a/ui/lib/core/addon/templates/components/replication-action-demote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-demote.hbs
@@ -1,56 +1,58 @@
-<div class="action-block is-rounded" data-test-demote-replication>
-  <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
-      Demote cluster
-    </h4>
-    <p>
-      Demote this {{model.replicationModeForDisplay}} primary to a secondary.
-    </p>
-  </div>
-  <div class="action-block-action">
-    <button
-      class="button is-secondary"
-      onclick={{action (mut isModalActive) true}}
-      data-test-replication-action-trigger
-    >
-      Demote
-    </button>
-  </div>
-</div>
-
-<ConfirmationModal
-  @title="Demote to secondary?"
-  @onClose={{action (mut isModalActive) false}}
-  @isActive={{isModalActive}}
-  @buttonClass="is-primary"
-  @confirmText={{model.replicationModeForDisplay}}
-  @toConfirmMsg="demoting this cluster"
-  @onConfirm={{action "onSubmit" "demote" model.replicationAttrs.modeForUrl}}
-  @testSelector="demote"
->
-  <p class="has-bottom-margin-m">
-    {{#if (and
-      (eq replicationMode 'dr')
-      (not model.performance.replicationDisabled)
-    )}}
-      <p class="has-bottom-margin-m" data-test-demote-warning>
-        This cluster is currently operating as a performance secondary. Demoting it will leave your replication setup <strong>without a performance primary cluster</strong> until a new cluster is promoted.
+<div onkeyup={{action "onSubmit" "demote" model.replicationAttrs.modeForUrl}}>
+  <div class="action-block is-rounded" data-test-demote-replication>
+    <div class="action-block-info">
+      <h4 class="title is-5 is-marginless">
+        Demote cluster
+      </h4>
+      <p>
+        Demote this {{model.replicationModeForDisplay}} primary to a secondary.
       </p>
-    {{/if}}
-    Demoting this{{model.replicationModeForDisplay}} primary to a {{model.replicationModeForDisplay}} secondary means that the resulting secondary cluster:
-  </p>
-  <ul class="bullet has-bottom-margin-m">
-    {{#if (and
-      (eq replicationMode 'dr')
-      (not model.performance.replicationDisabled)
-    )}}
-      <li>Will be read-only</li>
-    {{/if}}
-    <li>Will not attempt to connect to a primary</li>
-    <li>Will maintain knowledge of its cluster ID</li>
-    <li>Can be reconnected to the same set of replication clusters without wiping local storage.</li>
-  </ul>
-  <p class="has-bottom-margin-m">
-    To connect the resulting secondary to a new primary, use the Update primary action.
-  </p>
-</ConfirmationModal>
+    </div>
+    <div class="action-block-action">
+      <button
+        class="button is-secondary"
+        onclick={{action (mut isModalActive) true}}
+        data-test-replication-action-trigger
+      >
+        Demote
+      </button>
+    </div>
+  </div>
+
+  <ConfirmationModal
+    @title="Demote to secondary?"
+    @onClose={{action (mut isModalActive) false}}
+    @isActive={{isModalActive}}
+    @buttonClass="is-primary"
+    @confirmText={{model.replicationModeForDisplay}}
+    @toConfirmMsg="demoting this cluster"
+    @onConfirm={{action "onSubmit" "demote" model.replicationAttrs.modeForUrl}}
+    @testSelector="demote"
+  >
+    <p class="has-bottom-margin-m">
+      {{#if (and
+        (eq replicationMode 'dr')
+        (not model.performance.replicationDisabled)
+      )}}
+        <p class="has-bottom-margin-m" data-test-demote-warning>
+          This cluster is currently operating as a performance secondary. Demoting it will leave your replication setup <strong>without a performance primary cluster</strong> until a new cluster is promoted.
+        </p>
+      {{/if}}
+      Demoting this{{model.replicationModeForDisplay}} primary to a {{model.replicationModeForDisplay}} secondary means that the resulting secondary cluster:
+    </p>
+    <ul class="bullet has-bottom-margin-m">
+      {{#if (and
+        (eq replicationMode 'dr')
+        (not model.performance.replicationDisabled)
+      )}}
+        <li>Will be read-only</li>
+      {{/if}}
+      <li>Will not attempt to connect to a primary</li>
+      <li>Will maintain knowledge of its cluster ID</li>
+      <li>Can be reconnected to the same set of replication clusters without wiping local storage.</li>
+    </ul>
+    <p class="has-bottom-margin-m">
+      To connect the resulting secondary to a new primary, use the Update primary action.
+    </p>
+  </ConfirmationModal>
+</div>

--- a/ui/lib/core/addon/templates/components/replication-action-disable.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-disable.hbs
@@ -1,53 +1,61 @@
-<div class="action-block is-rounded" data-test-disable-replication>
-  <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
-      Disable Replication
-    </h4>
-    <p>
-      Disable {{model.replicationModeForDisplay}} Replication entirely on the cluster.
+<div onkeyup={{action "onSubmit" "disable"
+  (if
+    (eq model.replicationAttrs.modeForUrl 'bootstrapping')
+    mode
+    model.replicationAttrs.modeForUrl
+  )
+}}>
+  <div class="action-block is-rounded" data-test-disable-replication>
+    <div class="action-block-info">
+      <h4 class="title is-5 is-marginless">
+        Disable Replication
+      </h4>
+      <p>
+        Disable {{model.replicationModeForDisplay}} Replication entirely on the cluster.
+      </p>
+    </div>
+
+    <div class="action-block-action">
+      <button
+        class="button is-danger"
+        onclick={{action (mut isModalActive) true}}
+        data-test-replication-action-trigger
+      >
+        Disable Replication
+      </button>
+    </div>
+  </div>
+
+  <ConfirmationModal
+    @title="Disable Replication?"
+    @onClose={{action (mut isModalActive) false}}
+    @isActive={{isModalActive}}
+    @confirmText={{model.replicationModeForDisplay}}
+    @toConfirmMsg="disabling {{model.replicationModeForDisplay}} Replication on this cluster"
+    @onConfirm={{action
+      "onSubmit"
+      "disable"
+      (if
+        (eq model.replicationAttrs.modeForUrl 'bootstrapping')
+        mode
+        model.replicationAttrs.modeForUrl
+      )
+    }}
+    @testSelector="disable"
+  >
+    <p class="has-bottom-margin-m">
+      {{#if (and model.replicationAttrs.isPrimary (eq model.replicationModeForDisplay "Disaster Recovery"))}}This cannot be undone. {{/if}}
+      Disabling {{model.replicationModeForDisplay}} Replication entirely on this {{if (eq model.replicationAttrs.isPrimary true) "primary" "secondary"}} cluster means that:
     </p>
-  </div>
-
-  <div class="action-block-action">
-    <button
-      class="button is-danger"
-      onclick={{action (mut isModalActive) true}}
-      data-test-replication-action-trigger
-    >
-      Disable Replication
-    </button>
-  </div>
+    <ul class="bullet">
+      {{#if model.replicationAttrs.isPrimary}}
+      <li>Secondaries will no longer be able to connect</li>
+      <li>We will wipe the underlying storage of connected secondaries</li>
+      <li>Secondaries connecting back to the cluster will require a wipe of the underlying storage</li>
+      {{else}}
+      <li>We will wipe the underlying storage of this secondary when connected to a primary</li>
+      {{/if}}
+      <li>Re-enabling this node will change its cluster ID</li>
+    </ul>
+  </ConfirmationModal>
 </div>
-
-<ConfirmationModal
-  @title="Disable Replication?"
-  @onClose={{action (mut isModalActive) false}}
-  @isActive={{isModalActive}}
-  @confirmText={{model.replicationModeForDisplay}}
-  @toConfirmMsg="disabling {{model.replicationModeForDisplay}} Replication on this cluster"
-  @onConfirm={{action
-    "onSubmit"
-    "disable"
-    (if
-      (eq model.replicationAttrs.modeForUrl 'bootstrapping')
-      mode
-      model.replicationAttrs.modeForUrl
-    )
-  }}
-  @testSelector="disable"
->
-  <p class="has-bottom-margin-m">
-    {{#if (and model.replicationAttrs.isPrimary (eq model.replicationModeForDisplay "Disaster Recovery"))}}This cannot be undone. {{/if}}
-    Disabling {{model.replicationModeForDisplay}} Replication entirely on this {{if (eq model.replicationAttrs.isPrimary true) "primary" "secondary"}} cluster means that:
-  </p>
-  <ul class="bullet">
-    {{#if model.replicationAttrs.isPrimary}}
-    <li>Secondaries will no longer be able to connect</li>
-    <li>We will wipe the underlying storage of connected secondaries</li>
-    <li>Secondaries connecting back to the cluster will require a wipe of the underlying storage</li>
-    {{else}}
-    <li>We will wipe the underlying storage of this secondary when connected to a primary</li>
-    {{/if}}
-    <li>Re-enabling this node will change its cluster ID</li>
-  </ul>
-</ConfirmationModal>

--- a/ui/lib/core/addon/templates/components/replication-action-disable.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-disable.hbs
@@ -4,7 +4,7 @@
       Disable Replication
     </h4>
     <p>
-      Disable {{replicationDisplayMode}} Replication entirely on the cluster.
+      Disable {{model.replicationModeForDisplay}} Replication entirely on the cluster.
     </p>
   </div>
 
@@ -23,8 +23,8 @@
   @title="Disable Replication?"
   @onClose={{action (mut isModalActive) false}}
   @isActive={{isModalActive}}
-  @confirmText={{if (eq replicationDisplayMode "DR") "Disaster Recovery" replicationDisplayMode}}
-  @toConfirmMsg="disabling {{replicationDisplayMode}} Replication on this cluster"
+  @confirmText={{model.replicationModeForDisplay}}
+  @toConfirmMsg="disabling {{model.replicationModeForDisplay}} Replication on this cluster"
   @onConfirm={{action
     "onSubmit"
     "disable"
@@ -37,8 +37,8 @@
   @testSelector="disable"
 >
   <p class="has-bottom-margin-m">
-    {{#if (and model.replicationAttrs.isPrimary (eq replicationDisplayMode "DR"))}}This cannot be undone. {{/if}}
-    Disabling {{replicationDisplayMode}} Replication entirely on this {{if (eq model.replicationAttrs.isPrimary true) "primary" "secondary"}} cluster means that:
+    {{#if (and model.replicationAttrs.isPrimary (eq model.replicationModeForDisplay "Disaster Recovery"))}}This cannot be undone. {{/if}}
+    Disabling {{model.replicationModeForDisplay}} Replication entirely on this {{if (eq model.replicationAttrs.isPrimary true) "primary" "secondary"}} cluster means that:
   </p>
   <ul class="bullet">
     {{#if model.replicationAttrs.isPrimary}}

--- a/ui/lib/core/addon/templates/components/replication-action-disable.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-disable.hbs
@@ -1,61 +1,53 @@
-<div onkeyup={{action "onSubmit" "disable"
-  (if
-    (eq model.replicationAttrs.modeForUrl 'bootstrapping')
-    mode
-    model.replicationAttrs.modeForUrl
-  )
-}}>
-  <div class="action-block is-rounded" data-test-disable-replication>
-    <div class="action-block-info">
-      <h4 class="title is-5 is-marginless">
-        Disable Replication
-      </h4>
-      <p>
-        Disable {{model.replicationModeForDisplay}} Replication entirely on the cluster.
-      </p>
-    </div>
-
-    <div class="action-block-action">
-      <button
-        class="button is-danger"
-        onclick={{action (mut isModalActive) true}}
-        data-test-replication-action-trigger
-      >
-        Disable Replication
-      </button>
-    </div>
+<div class="action-block is-rounded" data-test-disable-replication>
+  <div class="action-block-info">
+    <h4 class="title is-5 is-marginless">
+      Disable Replication
+    </h4>
+    <p>
+      Disable {{model.replicationModeForDisplay}} Replication entirely on the cluster.
+    </p>
   </div>
 
-  <ConfirmationModal
-    @title="Disable Replication?"
-    @onClose={{action (mut isModalActive) false}}
-    @isActive={{isModalActive}}
-    @confirmText={{model.replicationModeForDisplay}}
-    @toConfirmMsg="disabling {{model.replicationModeForDisplay}} Replication on this cluster"
-    @onConfirm={{action
-      "onSubmit"
-      "disable"
-      (if
-        (eq model.replicationAttrs.modeForUrl 'bootstrapping')
-        mode
-        model.replicationAttrs.modeForUrl
-      )
-    }}
-    @testSelector="disable"
-  >
-    <p class="has-bottom-margin-m">
-      {{#if (and model.replicationAttrs.isPrimary (eq model.replicationModeForDisplay "Disaster Recovery"))}}This cannot be undone. {{/if}}
-      Disabling {{model.replicationModeForDisplay}} Replication entirely on this {{if (eq model.replicationAttrs.isPrimary true) "primary" "secondary"}} cluster means that:
-    </p>
-    <ul class="bullet">
-      {{#if model.replicationAttrs.isPrimary}}
-      <li>Secondaries will no longer be able to connect</li>
-      <li>We will wipe the underlying storage of connected secondaries</li>
-      <li>Secondaries connecting back to the cluster will require a wipe of the underlying storage</li>
-      {{else}}
-      <li>We will wipe the underlying storage of this secondary when connected to a primary</li>
-      {{/if}}
-      <li>Re-enabling this node will change its cluster ID</li>
-    </ul>
-  </ConfirmationModal>
+  <div class="action-block-action">
+    <button
+      class="button is-danger"
+      onclick={{action (mut isModalActive) true}}
+      data-test-replication-action-trigger
+    >
+      Disable Replication
+    </button>
+  </div>
 </div>
+
+<ConfirmationModal
+  @title="Disable Replication?"
+  @onClose={{action (mut isModalActive) false}}
+  @isActive={{isModalActive}}
+  @confirmText={{model.replicationModeForDisplay}}
+  @toConfirmMsg="disabling {{model.replicationModeForDisplay}} Replication on this cluster"
+  @onConfirm={{action
+    "onSubmit"
+    "disable"
+    (if
+      (eq model.replicationAttrs.modeForUrl 'bootstrapping')
+      mode
+      model.replicationAttrs.modeForUrl
+    )
+  }}
+  @testSelector="disable"
+>
+  <p class="has-bottom-margin-m">
+    {{#if (and model.replicationAttrs.isPrimary (eq model.replicationModeForDisplay "Disaster Recovery"))}}This cannot be undone. {{/if}}
+    Disabling {{model.replicationModeForDisplay}} Replication entirely on this {{if (eq model.replicationAttrs.isPrimary true) "primary" "secondary"}} cluster means that:
+  </p>
+  <ul class="bullet">
+    {{#if model.replicationAttrs.isPrimary}}
+    <li>Secondaries will no longer be able to connect</li>
+    <li>We will wipe the underlying storage of connected secondaries</li>
+    <li>Secondaries connecting back to the cluster will require a wipe of the underlying storage</li>
+    {{else}}
+    <li>We will wipe the underlying storage of this secondary when connected to a primary</li>
+    {{/if}}
+    <li>Re-enabling this node will change its cluster ID</li>
+  </ul>
+</ConfirmationModal>

--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -4,7 +4,7 @@
       Promote cluster
     </h4>
     <p>
-      Promote this cluster to a {{replicationDisplayMode}} primary
+      Promote this cluster to a {{model.replicationModeForDisplay}} primary
     </p>
   </div>
 

--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -1,95 +1,103 @@
-<div class="action-block is-rounded" data-test-promote-replication>
-  <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
-      Promote cluster
-    </h4>
-    <p>
-      Promote this cluster to a {{model.replicationModeForDisplay}} primary
-    </p>
-  </div>
-
-  <div class="action-block-action">
-    <button
-      class="button is-tertiary"
-      onclick={{action (mut isModalActive) true}}
-      data-test-replication-action-trigger
-    >
-      Update
-    </button>
-  </div>
-</div>
-
-<Modal
-  @title="Promote cluster?"
-  @onClose={{action (mut isModalActive) false}}
-  @isActive={{isModalActive}}
-  @type="warning"
-  @showCloseButton={{true}}
->
-  <section class="modal-card-body">
-
-    {{#if (eq replicationMode "dr")}}
-    <p class="has-bottom-margin-m">
-      To promote this DR Replication Secondary to a primary, enter the DR Operation token.
-    </p>
-    {{/if}}
-    <p class="has-bottom-margin-m">
-      Vault Replication is not designed for active-active usage. Enabling two primaries should never be done, as it can lead to data loss if they or their secondaries are ever reconnected. If the cluster has a primary, be sure to demote it before promoting a secondary.
-    </p>
-
-    <div data-test-promote-dr-inputs>
-      {{#if (eq replicationMode "dr")}}
-      <div class="field is-borderless">
-        <label for="dr_operation_token" class="is-label is-size-6">
-          DR Operation Token
-        </label>
-        <div class="control">
-          {{input class="input" id="dr_operation_token" name="dr_operation_token" value=dr_operation_token}}
-        </div>
-      </div>
-      {{/if}}
-      <div class="field">
-        <label for="primary_cluster_addr" class="is-label is-size-6">
-          Primary cluster address <em class="is-optional">(optional)</em>
-        </label>
-        <div class="control">
-          {{input class="input" id="primary_cluster_addr" name="primary_cluster_addr" value=primary_cluster_addr}}
-        </div>
-        <p class="help">
-          Overrides the cluster address that the primary gives to secondary nodes.
-        </p>
-      </div>
-
-      <div class="field">
-        <div class="b-checkbox">
-          <input type="checkbox"
-          id="forcePromote"
-          class="styled"
-          checked={{force}}
-          onchange={{action (mut force) value="target.checked"}}
-          />
-          <label for="forcePromote" class="is-label is-size-6">
-            Force promotion of this cluster
-          </label>
-          <p>Promote the cluster even if certain safety checks fail. This could result in data loss of data isn't fully replicated</p>
-        </div>
-      </div>
+<div onkeyup={{action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token primary_cluster_addr=primary_cluster_addr force=force)}}>
+  <div class="action-block is-rounded" data-test-promote-replication>
+    <div class="action-block-info">
+      <h4 class="title is-5 is-marginless">
+        Promote cluster
+      </h4>
+      <p>
+        Promote this cluster to a {{model.replicationModeForDisplay}} primary
+      </p>
     </div>
-  </section>
-  <footer class="modal-card-foot modal-card-foot-outlined">
-    <button
-      class="button is-primary"
-      disabled={{if (and (eq replicationMode "dr") (not dr_operation_token)) true}}
-      onclick={{action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token primary_cluster_addr=primary_cluster_addr force=force)}}
-      data-test-promote-confirm-button
-    >
-      Promote
-    </button>
-    <button
-      class="button is-secondary"
-      onclick={{action (mut isModalActive) false}}
-      data-test-promote-cancel-button>
-      Cancel
-    </button>
-  </footer>
-</Modal>
+
+    <div class="action-block-action">
+      <button
+        class="button is-tertiary"
+        onclick={{action (mut isModalActive) true}}
+        data-test-replication-action-trigger
+      >
+        Update
+      </button>
+    </div>
+  </div>
+
+  <Modal
+    @title="Promote cluster?"
+    @onClose={{action (mut isModalActive) false}}
+    @isActive={{isModalActive}}
+    @type="warning"
+    @showCloseButton={{true}}
+  >
+    <section class="modal-card-body">
+
+      {{#if (eq replicationMode "dr")}}
+      <p class="has-bottom-margin-m">
+        To promote this DR Replication Secondary to a primary, enter the DR Operation token.
+      </p>
+      {{/if}}
+      <p class="has-bottom-margin-m">
+        Vault Replication is not designed for active-active usage. Enabling two primaries should never be done, as it can lead to data loss if they or their secondaries are ever reconnected. If the cluster has a primary, be sure to demote it before promoting a secondary.
+      </p>
+
+      <div data-test-promote-dr-inputs>
+        {{#if (eq replicationMode "dr")}}
+        <div class="field is-borderless">
+          <label for="dr_operation_token" class="is-label is-size-6">
+            DR Operation Token
+          </label>
+          <div class="control">
+            {{input class="input" id="dr_operation_token" name="dr_operation_token" value=dr_operation_token}}
+          </div>
+        </div>
+        {{/if}}
+        <div class="field">
+          <label for="primary_cluster_addr" class="is-label is-size-6">
+            Primary cluster address <em class="is-optional">(optional)</em>
+          </label>
+          <div class="control">
+            {{input
+              class="input"
+              id="primary_cluster_addr"
+              name="primary_cluster_addr"
+              value=primary_cluster_addr
+              enter=(action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token primary_cluster_addr=primary_cluster_addr force=force))
+            }}
+          </div>
+          <p class="help">
+            Overrides the cluster address that the primary gives to secondary nodes.
+          </p>
+        </div>
+
+        <div class="field">
+          <div class="b-checkbox">
+            <input type="checkbox"
+            id="forcePromote"
+            class="styled"
+            checked={{force}}
+            onchange={{action (mut force) value="target.checked"}}
+            />
+            <label for="forcePromote" class="is-label is-size-6">
+              Force promotion of this cluster
+            </label>
+            <p>Promote the cluster even if certain safety checks fail. This could result in data loss of data isn't fully replicated</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <footer class="modal-card-foot modal-card-foot-outlined">
+      <button
+        class="button is-primary"
+        disabled={{if (and (eq replicationMode "dr") (not dr_operation_token)) true}}
+        onclick={{action "onSubmit" "promote" model.replicationAttrs.modeForUrl (hash dr_operation_token=dr_operation_token primary_cluster_addr=primary_cluster_addr force=force)}}
+        data-test-promote-confirm-button
+      >
+        Promote
+      </button>
+      <button
+        class="button is-secondary"
+        onclick={{action (mut isModalActive) false}}
+        data-test-promote-cancel-button>
+        Cancel
+      </button>
+    </footer>
+  </Modal>
+</div>

--- a/ui/lib/core/addon/templates/components/replication-action-promote.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-promote.hbs
@@ -27,53 +27,51 @@
   @showCloseButton={{true}}
 >
   <section class="modal-card-body">
-    <div class="box is-shadowless is-fullwidth is-sideless">
 
+    {{#if (eq replicationMode "dr")}}
+    <p class="has-bottom-margin-m">
+      To promote this DR Replication Secondary to a primary, enter the DR Operation token.
+    </p>
+    {{/if}}
+    <p class="has-bottom-margin-m">
+      Vault Replication is not designed for active-active usage. Enabling two primaries should never be done, as it can lead to data loss if they or their secondaries are ever reconnected. If the cluster has a primary, be sure to demote it before promoting a secondary.
+    </p>
+
+    <div data-test-promote-dr-inputs>
       {{#if (eq replicationMode "dr")}}
-      <p class="has-bottom-margin-m">
-        To promote this DR Replication Secondary to a primary, enter the DR Operation token.
-      </p>
+      <div class="field is-borderless">
+        <label for="dr_operation_token" class="is-label is-size-6">
+          DR Operation Token
+        </label>
+        <div class="control">
+          {{input class="input" id="dr_operation_token" name="dr_operation_token" value=dr_operation_token}}
+        </div>
+      </div>
       {{/if}}
-      <p class="has-bottom-margin-m">
-        Vault Replication is not designed for active-active usage. Enabling two primaries should never be done, as it can lead to data loss if they or their secondaries are ever reconnected. If the cluster has a primary, be sure to demote it before promoting a secondary.
-      </p>
-
-      <div data-test-promote-dr-inputs>
-        {{#if (eq replicationMode "dr")}}
-        <div class="field is-borderless">
-          <label for="dr_operation_token" class="is-label is-size-6">
-            DR Operation Token
-          </label>
-          <div class="control">
-            {{input class="input" id="dr_operation_token" name="dr_operation_token" value=dr_operation_token}}
-          </div>
+      <div class="field">
+        <label for="primary_cluster_addr" class="is-label is-size-6">
+          Primary cluster address <em class="is-optional">(optional)</em>
+        </label>
+        <div class="control">
+          {{input class="input" id="primary_cluster_addr" name="primary_cluster_addr" value=primary_cluster_addr}}
         </div>
-        {{/if}}
-        <div class="field">
-          <label for="primary_cluster_addr" class="is-label is-size-6">
-            Primary cluster address <em class="is-optional">(optional)</em>
-          </label>
-          <div class="control">
-            {{input class="input" id="primary_cluster_addr" name="primary_cluster_addr" value=primary_cluster_addr}}
-          </div>
-          <p class="help">
-            Overrides the cluster address that the primary gives to secondary nodes.
-          </p>
-        </div>
+        <p class="help">
+          Overrides the cluster address that the primary gives to secondary nodes.
+        </p>
+      </div>
 
-        <div class="field">
-          <div class="b-checkbox">
-            <input type="checkbox"
-            id="forcePromote"
-            class="styled"
-            checked={{force}}
-            onchange={{action (mut force) value="target.checked"}}
-            />
-            <label for="forcePromote" class="is-label is-size-6">
-              Force promotion of this cluster
-            </label>
-            <p>Promote the cluster even if certain safety checks fail. This could result in data loss of data isn't fully replicated</p>
-          </div>
+      <div class="field">
+        <div class="b-checkbox">
+          <input type="checkbox"
+          id="forcePromote"
+          class="styled"
+          checked={{force}}
+          onchange={{action (mut force) value="target.checked"}}
+          />
+          <label for="forcePromote" class="is-label is-size-6">
+            Force promotion of this cluster
+          </label>
+          <p>Promote the cluster even if certain safety checks fail. This could result in data loss of data isn't fully replicated</p>
         </div>
       </div>
     </div>

--- a/ui/lib/core/addon/templates/components/replication-action-recover.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-recover.hbs
@@ -1,49 +1,51 @@
-<div class="action-block is-rounded" data-test-recover-replication>
-  <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
-      Recover
-    </h4>
-    <p>
-      Attempt recovery if replication is in a bad state.
-    </p>
+<div onkeyup={{action "onSubmit" "recover"}}>
+  <div class="action-block is-rounded" data-test-recover-replication>
+    <div class="action-block-info">
+      <h4 class="title is-5 is-marginless">
+        Recover
+      </h4>
+      <p>
+        Attempt recovery if replication is in a bad state.
+      </p>
+    </div>
+
+    <div class="action-block-action">
+      <button
+        class="button is-secondary"
+        onclick={{action (mut isModalActive) true}}
+        data-test-replication-action-trigger
+      >
+        Recover
+      </button>
+    </div>
   </div>
 
-  <div class="action-block-action">
-    <button
-      class="button is-secondary"
-      onclick={{action (mut isModalActive) true}}
-      data-test-replication-action-trigger
-    >
-      Recover
-    </button>
-  </div>
+  <Modal
+    @title="Begin recovery?"
+    @onClose={{action (mut isModalActive) false}}
+    @isActive={{isModalActive}}
+    @type="warning"
+    @showCloseButton={{true}}
+  >
+    <section class="modal-card-body">
+      <p>
+        If replication is in an adverse state, we can begin recovery. This will attempt to recover to continue syncing.
+      </p>
+    </section>
+    <footer class="modal-card-foot modal-card-foot-outlined">
+      <button
+        class="button is-primary"
+        onclick={{action "onSubmit" "recover"}}
+        data-test-recover-confirm-button
+      >
+        Recover
+      </button>
+      <button
+        class="button is-secondary"
+        onclick={{action (mut isModalActive) false}}
+        data-test-recover-cancel-button>
+        Cancel
+      </button>
+    </footer>
+  </Modal>
 </div>
-
-<Modal
-  @title="Begin recovery?"
-  @onClose={{action (mut isModalActive) false}}
-  @isActive={{isModalActive}}
-  @type="warning"
-  @showCloseButton={{true}}
->
-  <section class="modal-card-body">
-    <p>
-      If replication is in an adverse state, we can begin recovery. This will attempt to recover to continue syncing.
-    </p>
-  </section>
-  <footer class="modal-card-foot modal-card-foot-outlined">
-    <button
-      class="button is-primary"
-      onclick={{action "onSubmit" "recover"}}
-      data-test-recover-confirm-button
-    >
-      Recover
-    </button>
-    <button
-      class="button is-secondary"
-      onclick={{action (mut isModalActive) false}}
-      data-test-recover-cancel-button>
-      Cancel
-    </button>
-  </footer>
-</Modal>

--- a/ui/lib/core/addon/templates/components/replication-action-reindex.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-reindex.hbs
@@ -1,54 +1,56 @@
-<div class="action-block is-rounded" data-test-reindex-replication>
-  <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
-      Reindex
-    </h4>
-    <p>
-      Reindex the local data storage
-    </p>
+<div onkeyup={{action 'onSubmit' 'reindex'}}>
+  <div class="action-block is-rounded" data-test-reindex-replication>
+    <div class="action-block-info">
+      <h4 class="title is-5 is-marginless">
+        Reindex
+      </h4>
+      <p>
+        Reindex the local data storage
+      </p>
+    </div>
+    <div class="action-block-action">
+      <button
+        class="button is-secondary"
+        onclick={{action (mut isModalActive) true}}
+        data-test-replication-action-trigger
+      >
+        Reindex
+      </button>
+    </div>
   </div>
-  <div class="action-block-action">
-    <button
-      class="button is-secondary"
-      onclick={{action (mut isModalActive) true}}
-      data-test-replication-action-trigger
-    >
-      Reindex
-    </button>
-  </div>
+  <Modal
+    @title="Begin reindex?"
+    @onClose={{action (mut isModalActive) false}}
+    @isActive={{isModalActive}}
+    @type="warning"
+    @showCloseButton={{true}}
+  >
+    <section class="modal-card-body">
+      <p class="has-bottom-margin-m">
+        Reindexing can cause a very long delay depending on the number and size of objects in the data store.
+        {{if model.replicationAttrs.isPrimary 'You should always re-index your secondary first.'}}
+      </p>
+      <p>
+        Progress will be shown, and you will
+        {{if model.replicationAttrs.isPrimary 'not'}}
+        be able to use Vault during this time.
+      </p>
+    </section>
+    <footer class="modal-card-foot modal-card-foot-outlined">
+      <button
+        class="button is-primary"
+        onclick={{action 'onSubmit' 'reindex'}}
+        data-test-reindex-confirm-button
+      >
+        Reindex
+      </button>
+      <button
+        class="button is-secondary"
+        onclick={{action (mut isModalActive) false}}
+        data-test-reindex-cancel-button
+      >
+        Cancel
+      </button>
+    </footer>
+  </Modal>
 </div>
-<Modal
-  @title="Begin reindex?"
-  @onClose={{action (mut isModalActive) false}}
-  @isActive={{isModalActive}}
-  @type="warning"
-  @showCloseButton={{true}}
->
-  <section class="modal-card-body">
-    <p class="has-bottom-margin-m">
-      Reindexing can cause a very long delay depending on the number and size of objects in the data store.
-      {{if model.replicationAttrs.isPrimary 'You should always re-index your secondary first.'}}
-    </p>
-    <p>
-      Progress will be shown, and you will
-      {{if model.replicationAttrs.isPrimary 'not'}}
-      be able to use Vault during this time.
-    </p>
-  </section>
-  <footer class="modal-card-foot modal-card-foot-outlined">
-    <button
-      class="button is-primary"
-      onclick={{action 'onSubmit' 'reindex'}}
-      data-test-reindex-confirm-button
-    >
-      Reindex
-    </button>
-    <button
-      class="button is-secondary"
-      onclick={{action (mut isModalActive) false}}
-      data-test-reindex-cancel-button
-    >
-      Cancel
-    </button>
-  </footer>
-</Modal>

--- a/ui/lib/core/addon/templates/components/replication-action-update-primary.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-update-primary.hbs
@@ -1,104 +1,112 @@
-<div class="action-block is-rounded" data-test-update-primary-replication>
-  <div class="action-block-info">
-    <h4 class="title is-5 is-marginless">
-      Update primary
-    </h4>
-    <p>
-      Change this secondary's assigned primary cluster
-    </p>
-  </div>
-
-  <div class="action-block-action">
-    <button
-      class="button is-secondary"
-      onclick={{action (mut isModalActive) true}}
-      data-test-update-primary-action-trigger
-    >
-      Update
-    </button>
-  </div>
-</div>
-
-<Modal
-  @title="Update primary"
-  @onClose={{action (mut isModalActive) false}}
-  @isActive={{isModalActive}}
-  @type="warning"
-  @showCloseButton={{true}}
->
-  <section class="modal-card-body">
-    <p class="has-bottom-margin-m">
-      Use a secondary activation token to change this secondary’s assigned primary. This does not wipe all data in the cluster.
-    </p>
-
-    <div data-test-update-primary-inputs>
-      {{#if (eq replicationMode "dr")}}
-      <div class="field">
-        <label for="dr_operation_token" class="is-label">
-          DR operation token
-        </label>
-        <div class="control">
-          {{input class="input" id="dr_operation_token" name="dr_operation_token" value=dr_operation_token}}
-        </div>
-      </div>
-      {{/if}}
-      <div class="field">
-        <label for="secondary-token" class="is-label">
-          Secondary activation token
-        </label>
-        <div class="control">
-          {{textarea value=token id="secondary-token" name="secondary-token" class="textarea"}}
-        </div>
-      </div>
-      <div class="field">
-        <label for="primary_api_addr" class="is-label">
-          Primary API address <em class="is-optional">(optional)</em>
-        </label>
-        <div class="control">
-          {{input class="input" value=primary_api_addr id="primary_api_addr" name="primary_api_addr"}}
-        </div>
-        <p class="help">
-          Set this to the API address (normal Vault address) to override the
-          value embedded in the token.
-        </p>
-      </div>
-      <div class="field">
-        <label for="ca_file" class="is-label">
-          CA file <em class="is-optional">(optional)</em>
-        </label>
-        <div class="control">
-          {{input value=ca_file id="ca_file" name="ca_file" class="input"}}
-        </div>
-        <p class="help">
-          Specifies the path to a CA root file (PEM format) that the secondary can use when unwrapping the token from the primary.
-        </p>
-      </div>
-      <div class="field">
-        <label for="ca_path" class="is-label">
-          CA path <em class="is-optional">(optional)</em>
-        </label>
-        <div class="control">
-          {{input value=ca_path id="ca_path" name="ca_file" class="input"}}
-        </div>
-        <p class="help">
-          Specifies the path to a CA root directory containing PEM-format files that the secondary can use when unwrapping the token from the primary.
-        </p>
-      </div>
+<div onkeyup={{action "onSubmit" "update-primary" model.replicationAttrs.modeForUrl (hash token=token primary_api_addr=primary_api_addr ca_path=ca_path ca_file=ca_file)}}>
+  <div class="action-block is-rounded" data-test-update-primary-replication>
+    <div class="action-block-info">
+      <h4 class="title is-5 is-marginless">
+        Update primary
+      </h4>
+      <p>
+        Change this secondary's assigned primary cluster
+      </p>
     </div>
-  </section>
-  <footer class="modal-card-foot modal-card-foot-outlined">
-    <button
-      class="button is-primary"
-      onclick={{action "onSubmit" "update-primary" model.replicationAttrs.modeForUrl (hash token=token primary_api_addr=primary_api_addr ca_path=ca_path ca_file=ca_file)}}
-      data-test-confirm-action-trigger
-    >
-      Update
-    </button>
-    <button
-      class="button is-secondary"
-      onclick={{action (mut isModalActive) false}}
-      data-test-update-primary-cancel-button>
-      Cancel
-    </button>
-  </footer>
-</Modal>
+
+    <div class="action-block-action">
+      <button
+        class="button is-secondary"
+        onclick={{action (mut isModalActive) true}}
+        data-test-update-primary-action-trigger
+      >
+        Update
+      </button>
+    </div>
+  </div>
+
+  <Modal
+    @title="Update primary"
+    @onClose={{action (mut isModalActive) false}}
+    @isActive={{isModalActive}}
+    @type="warning"
+    @showCloseButton={{true}}
+  >
+    <section class="modal-card-body">
+      <p class="has-bottom-margin-m">
+        Use a secondary activation token to change this secondary’s assigned primary. This does not wipe all data in the cluster.
+      </p>
+
+      <div data-test-update-primary-inputs>
+        {{#if (eq replicationMode "dr")}}
+        <div class="field">
+          <label for="dr_operation_token" class="is-label">
+            DR operation token
+          </label>
+          <div class="control">
+            {{input class="input" id="dr_operation_token" name="dr_operation_token" value=dr_operation_token}}
+          </div>
+        </div>
+        {{/if}}
+        <div class="field">
+          <label for="secondary-token" class="is-label">
+            Secondary activation token
+          </label>
+          <div class="control">
+            {{textarea
+              value=token
+              id="secondary-token"
+              name="secondary-token"
+              class="textarea"
+              enter=(action "onSubmit" "update-primary" model.replicationAttrs.modeForUrl (hash token=token primary_api_addr=primary_api_addr ca_path=ca_path ca_file=ca_file))
+            }}
+          </div>
+        </div>
+        <div class="field">
+          <label for="primary_api_addr" class="is-label">
+            Primary API address <em class="is-optional">(optional)</em>
+          </label>
+          <div class="control">
+            {{input class="input" value=primary_api_addr id="primary_api_addr" name="primary_api_addr"}}
+          </div>
+          <p class="help">
+            Set this to the API address (normal Vault address) to override the
+            value embedded in the token.
+          </p>
+        </div>
+        <div class="field">
+          <label for="ca_file" class="is-label">
+            CA file <em class="is-optional">(optional)</em>
+          </label>
+          <div class="control">
+            {{input value=ca_file id="ca_file" name="ca_file" class="input"}}
+          </div>
+          <p class="help">
+            Specifies the path to a CA root file (PEM format) that the secondary can use when unwrapping the token from the primary.
+          </p>
+        </div>
+        <div class="field">
+          <label for="ca_path" class="is-label">
+            CA path <em class="is-optional">(optional)</em>
+          </label>
+          <div class="control">
+            {{input value=ca_path id="ca_path" name="ca_file" class="input"}}
+          </div>
+          <p class="help">
+            Specifies the path to a CA root directory containing PEM-format files that the secondary can use when unwrapping the token from the primary.
+          </p>
+        </div>
+      </div>
+    </section>
+    <footer class="modal-card-foot modal-card-foot-outlined">
+      <button
+        class="button is-primary"
+        onclick={{action "onSubmit" "update-primary" model.replicationAttrs.modeForUrl (hash token=token primary_api_addr=primary_api_addr ca_path=ca_path ca_file=ca_file)}}
+        data-test-confirm-action-trigger
+      >
+        Update
+      </button>
+      <button
+        class="button is-secondary"
+        onclick={{action (mut isModalActive) false}}
+        data-test-update-primary-cancel-button>
+        Cancel
+      </button>
+    </footer>
+  </Modal>
+</div>

--- a/ui/lib/core/addon/templates/components/replication-actions.hbs
+++ b/ui/lib/core/addon/templates/components/replication-actions.hbs
@@ -12,7 +12,6 @@
             onSubmit=(action "onSubmit")
             replicationMode=replicationMode
             model=model
-            replicationDisplayMode=replicationDisplayMode
           }}
         </div>
     {{/each}}

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -86,15 +86,25 @@
         known_primary_cluster_addr
       </h6>
       <p class="has-text-grey">
-        A list of all the nodes in the primary's cluster. This is updated every ten seconds.
+        A list of all the nodes in the primary's cluster. This value is updated every ten seconds.
       </p>
     </div>
     <div class="grid-item-third-row">
-      <InfoTable
-        @title="Known Primary Cluster Addrs"
-        @header="cluster_addr"
-        @items={{knownPrimaryClusterAddrs}}
-      />
+      {{#if (is-empty knownPrimaryClusterAddrs)}}
+        <EmptyState
+          @title="No known_primary_cluster_addrs"
+          @message="These addresses are used by the secondary to communicate with the primary cluster.  Should always be non-zero in a functioning replication setup.">
+          <LearnLink @path="/vault/operations/monitor-replication">
+            Learn more
+          </LearnLink>
+        </EmptyState>
+      {{else}}
+        <InfoTable
+          @title="Known Primary Cluster Addrs"
+          @header="cluster_addr"
+          @items={{knownPrimaryClusterAddrs}}
+        />
+      {{/if}}
     </div>
   {{/if}}
 </div>

--- a/ui/lib/replication/addon/controllers/application.js
+++ b/ui/lib/replication/addon/controllers/application.js
@@ -114,6 +114,10 @@ export default Controller.extend(copy(DEFAULTS, true), {
 
   actions: {
     onSubmit(/*action, mode, data, event*/) {
+      if (this.isModalActive) {
+        // capturing the enter action if the modal is open
+        return this.send('copyClose', 'Token copied!');
+      }
       return this.submitHandler(...arguments);
     },
     copyClose(successMessage) {

--- a/ui/lib/replication/addon/controllers/application.js
+++ b/ui/lib/replication/addon/controllers/application.js
@@ -5,6 +5,7 @@ import Controller from '@ember/controller';
 import { copy } from 'ember-copy';
 import { resolve } from 'rsvp';
 import decodeConfigFromJWT from 'replication/utils/decode-config-from-jwt';
+import keys from 'vault/lib/keycodes';
 
 const DEFAULTS = {
   token: null,
@@ -129,13 +130,26 @@ export default Controller.extend(copy(DEFAULTS, true), {
       this.transitionToRoute('mode.secondaries');
     },
     toggleModal(successMessage) {
-      if (!!successMessage && typeof successMessage === 'string') {
-        this.get('flashMessages').success(successMessage);
+      // if modal is not active return.
+      // This is a separate conditional because of the enter that can happen on the form submit
+      if (!this.isModalActive) {
+        return;
       }
+
+      if (event.keyCode !== keys.ENTER) {
+        // because we want them to copy this token and not think they can cancel the operation,
+        // we are not allowing the ESCAPE key functionality
+        return;
+      }
+
       // use copy browser extension to copy token if you close the modal by clicking outside of it.
       const htmlSelectedToken = document.querySelector('#token-textarea');
       htmlSelectedToken.select();
       document.execCommand('copy');
+
+      if (!!successMessage && typeof successMessage === 'string') {
+        this.get('flashMessages').success(successMessage);
+      }
 
       this.toggleProperty('isModalActive');
       this.transitionToRoute('mode.secondaries');

--- a/ui/lib/replication/addon/controllers/application.js
+++ b/ui/lib/replication/addon/controllers/application.js
@@ -115,10 +115,6 @@ export default Controller.extend(copy(DEFAULTS, true), {
 
   actions: {
     onSubmit(/*action, mode, data, event*/) {
-      if (this.isModalActive) {
-        // capturing the enter action if the modal is open
-        return this.send('copyClose', 'Token copied!');
-      }
       return this.submitHandler(...arguments);
     },
     copyClose(successMessage) {

--- a/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
+++ b/ui/lib/replication/addon/templates/components/known-secondaries-card.hbs
@@ -1,7 +1,7 @@
 <div class="selectable-card is-rounded secondaries">
   <div class="level">
     <h3 class="card-title title is-5">Known Secondaries</h3>
-    <ToolbarLink @params={{array "mode.manage" cluster.replicationMode}} data-test-manage-link>
+    <ToolbarLink @params={{array "mode.secondaries" cluster.replicationMode}} data-test-manage-link>
       Manage
     </ToolbarLink>
   </div>

--- a/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
@@ -50,7 +50,7 @@
 </form>
 
 {{#if isModalActive}}
-  <Modal @title="Copy your token" @onClose={{action "toggleModal" "Token copied!"}} @isActive={{isModalActive}}>
+  <Modal @title="Copy your token" @onKeyUp={{action "toggleModal"}} @onClose={{action "toggleModal" "Token copied!"}} @isActive={{isModalActive}}>
     <section class="modal-card-body">
       <p>This token can be used to enable {{model.replicationModeForDisplay}} replication or change primaries on the secondary cluster.</p>
       <div class="box is-shadowless is-fullwidth is-sideless">

--- a/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
@@ -1,80 +1,86 @@
-<form {{action "onSubmit" "secondary-token" "primary" (hash ttl=ttl id=id) on="submit"}}>
-  <div class="box is-fullwidth is-shadowless is-marginless">
-    <h4 class="title is-5">
-      Generate a secondary token
-    </h4>
-    <p>Generate a token to enable {{model.replicationModeForDisplay}} replication or change primaries on secondary cluster.</p>
-  </div>
-  {{message-error errors=errors}}
-  <div class="field">
-    <label for="activation-token-id" class="is-label">
-      Secondary ID
-    </label>
-    <div class="control">
-      {{input class="input" name="activation-token-id" id="activation-token-id" value=id data-test-replication-secondary-id=true}}
+<div onkeypress={{action "toggleModal"}}>
+  <form {{action "onSubmit" "secondary-token" "primary" (hash ttl=ttl id=id) on="submit"}}>
+    <div class="box is-fullwidth is-shadowless is-marginless">
+      <h4 class="title is-5">
+        Generate a secondary token
+      </h4>
+      <p>Generate a token to enable {{model.replicationModeForDisplay}} replication or change primaries on secondary cluster.</p>
     </div>
-    <p class="help has-text-grey">
-      This will be used to identify a secondary cluster once a connection has been established with the primary.
-    </p>
-  </div>
-  <div class="field">
-    {{!-- TODO fix so it defaults to 30s like in other places or replace with new TTL picker --}}
-    {{ttl-picker onChange=(action (mut ttl)) initialValue="30m" class="is-marginless"}}
-    <p class="help has-text-grey">
-      This is the Time To Live for the generated secondary token. After this period, the generated token will no longer be valid.
-    </p>
-  </div>
-  {{#if (eq replicationMode "performance")}}
-    <PathFilterConfigList
-      @paths={{paths}}
-      @config={{filterConfig}}
-      @id={{id}}
-    />
-  {{/if}}
-  <div class="field is-grouped box is-fullwidth is-bottomless">
-    <div class="control">
-      <button
-        type="submit"
-        class="button is-primary"
-        data-test-secondary-add=true
-        >
-        Generate token
-      </button>
+    {{message-error errors=errors}}
+    <div class="field">
+      <label for="activation-token-id" class="is-label">
+        Secondary ID
+      </label>
+      <div class="control">
+        {{input class="input" name="activation-token-id" id="activation-token-id" value=id data-test-replication-secondary-id=true}}
+      </div>
+      <p class="help has-text-grey">
+        This will be used to identify a secondary cluster once a connection has been established with the primary.
+      </p>
     </div>
-    <div class="control">
-      {{#link-to "mode.secondaries" replicationMode class="button"}}
-        Cancel
-      {{/link-to}}
+    <div class="field">
+      {{!-- TODO fix so it defaults to 30s like in other places or replace with new TTL picker --}}
+      {{ttl-picker onChange=(action (mut ttl)) initialValue="30m" class="is-marginless"}}
+      <p class="help has-text-grey">
+        This is the Time To Live for the generated secondary token. After this period, the generated token will no longer be valid.
+      </p>
     </div>
-  </div>
-</form>
+    {{#if (eq replicationMode "performance")}}
+      <PathFilterConfigList
+        @paths={{paths}}
+        @config={{filterConfig}}
+        @id={{id}}
+      />
+    {{/if}}
+    <div class="field is-grouped box is-fullwidth is-bottomless">
+      <div class="control">
+        <button
+          type="submit"
+          class="button is-primary"
+          data-test-secondary-add=true
+          >
+          Generate token
+        </button>
+      </div>
+      <div class="control">
+        {{#link-to "mode.secondaries" replicationMode class="button"}}
+          Cancel
+        {{/link-to}}
+      </div>
+    </div>
+  </form>
 
-{{#if isModalActive}}
-  <Modal @title="Copy your token" @onKeyUp={{action "toggleModal"}} @onClose={{action "toggleModal" "Token copied!"}} @isActive={{isModalActive}}>
-    <section class="modal-card-body">
-      <p>This token can be used to enable {{model.replicationModeForDisplay}} replication or change primaries on the secondary cluster.</p>
-      <div class="box is-shadowless is-fullwidth is-sideless">
-        <h2 class="title is-6">Activation token</h2>
-        <div class="copy-text level">
-          <div class="is-fullwidth">
-            <textarea readonly value={{token}} id="token-textarea" class="textarea level-left"/>
+  {{#if isModalActive}}
+    <Modal 
+      @title="Copy your token"
+      @onClose={{action "toggleModal" "Token copied!"}}
+      @isActive={{isModalActive}}
+    >
+      <section class="modal-card-body">
+        <p>This token can be used to enable {{model.replicationModeForDisplay}} replication or change primaries on the secondary cluster.</p>
+        <div class="box is-shadowless is-fullwidth is-sideless">
+          <h2 class="title is-6">Activation token</h2>
+          <div class="copy-text level">
+            <div class="is-fullwidth">
+              <textarea readonly value={{token}} id="token-textarea" class="textarea level-left"/>
+            </div>
+          </div>
+          <div class="has-top-margin-xl has-bottom-margin-s">
+            {{info-table-row
+              label="TTL"
+              value=ttl}}
+            {{info-table-row
+              label="Expires"
+              value=(date-format expirationDate 'MMM DD, YYYY hh:mm:ss A')}}
           </div>
         </div>
-        <div class="has-top-margin-xl has-bottom-margin-s">
-          {{info-table-row
-            label="TTL"
-            value=ttl}}
-          {{info-table-row
-            label="Expires"
-            value=(date-format expirationDate 'MMM DD, YYYY hh:mm:ss A')}}
-        </div>
-      </div>
-    </section>
-    <footer class="modal-card-foot">
-      <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{token}}
-        @buttonType="button" @type="copy" @success={{action "copyClose" "Token copied!"}}>
-        Copy &amp; Close
-      </CopyButton>
-    </footer>
-  </Modal>
-{{/if}}
+      </section>
+      <footer class="modal-card-foot">
+        <CopyButton class="button is-primary copy-close" data-test-button="modal-copy-close" @clipboardText={{token}}
+          @buttonType="button" @type="copy" @success={{action "copyClose" "Token copied!"}}>
+          Copy &amp; Close
+        </CopyButton>
+      </footer>
+    </Modal>
+  {{/if}}
+</div>


### PR DESCRIPTION
This PR address a couple of minor fixes I noticed after the merge.  These fixes are not related to the merge, but just things I came across while double-checking.  

Fixes in PR:
- replace with replicationModeForDisplay
- fix a refresh issue on the primary_cluster_addr that was due to a spelling error and add in default.  Confirmed with design.
- remove extra div with box class per Chelsea's comment
- change manage link on known secondaries card to take you to the secondaries manage and not the cluster manage page.
- fix some overflow scroll issues on the sticky-header class, still working on this as I add in the empty state and do some QA on it. 
- Capture escape and enter keyboard actions.  Note: for the modal's (disable and demote) where you have to type the mode (e.g. Performance or Disaster Recovery) the escape is captured only on the modal level.  This means that escape only closes the modal if you have clicked on the input.  I only handle it on the modal, because if I handle the keypress outside these models, I don't know if the `confirmText` and `confirmationText` are the same.  It gets super complicated handling the submit action after that.  The only way I could see to get it to work (if I was actually able to do it) added way more complexity than it was worth.  

Here is a gif of the modal actions.  I am not using my mouse in any of these, I'm just using the keyboard.  If you wanted to test this yourself, make sure to not only hit enter and escape but other keys and try to use your mouse as well.  I've tested this pretty extensively, but more testing wouldn't hurt.

<img width=500 src="https://user-images.githubusercontent.com/6618863/84420495-59bb8000-abd7-11ea-8fc3-7bdf2bb8b6ec.gif">

Note: There is an error currently when you demote to a DR secondary.  Chelsea is fixing that in another PR.