### PR TITLE
Implement lease expiration as a priority queue rather than Go timers.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.2
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.1.3
 	github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f
-	github.com/hashicorp/vault/sdk v0.1.14-0.20200519221838-e0cfd64bc267
+	github.com/hashicorp/vault/sdk v0.1.14-0.20200611144237-57e5222ef9c2
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4
 	github.com/jcmturner/gokrb5/v8 v8.0.0
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f

--- a/sdk/helper/sync/cond.go
+++ b/sdk/helper/sync/cond.go
@@ -1,0 +1,58 @@
+package sync
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+// Conditional variable implementation that uses channels for notifications.
+// Only supports .Broadcast() method, however supports timeout based Wait() calls
+// unlike regular sync.TimeoutCond.
+//
+// Credit to Zviad Metreveli
+type TimeoutCond struct {
+	L sync.Locker
+	n unsafe.Pointer
+}
+
+func NewTimeoutCond(l sync.Locker) *TimeoutCond {
+	c := &TimeoutCond{L: l}
+	n := make(chan struct{})
+	c.n = unsafe.Pointer(&n)
+	return c
+}
+
+// Waits for Broadcast calls. Similar to regular sync.TimeoutCond, this unlocks the underlying
+// locker first, waits on changes and re-locks it before returning.
+func (c *TimeoutCond) Wait() {
+	n := c.NotifyChan()
+	c.L.Unlock()
+	<-n
+	c.L.Lock()
+}
+
+// Same as Wait() call, but will only wait up to a given timeout.
+func (c *TimeoutCond) WaitWithTimeout(t time.Duration) {
+	n := c.NotifyChan()
+	c.L.Unlock()
+	select {
+	case <-n:
+	case <-time.After(t):
+	}
+	c.L.Lock()
+}
+
+// Returns a channel that can be used to wait for next Broadcast() call.
+func (c *TimeoutCond) NotifyChan() <-chan struct{} {
+	ptr := atomic.LoadPointer(&c.n)
+	return *((*chan struct{})(ptr))
+}
+
+// Broadcast call notifies everyone that something has changed.
+func (c *TimeoutCond) Broadcast() {
+	n := make(chan struct{})
+	ptrOld := atomic.SwapPointer(&c.n, unsafe.Pointer(&n))
+	close(*(*chan struct{})(ptrOld))
+}

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -207,7 +207,7 @@ func (c *Core) setupExpiration(e ExpireLeaseStrategy) error {
 		}
 	}
 	go c.expiration.Restore(errorFunc)
-	if err := startExpiration(); err != nil {
+	if err := c.expiration.startExpiration(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
For 100k active leases, seems to use 90% less RAM and depending on concurrency, competitive in lease registration speed (30% faster single threaded, starts to lose to go timers on contention ~16 threads)

Modified our Priority Queue implementation to add Peek and Clear, and disabled it's deep copy of the items stored in the queue.  This probably breaks other code, so it'd need to be configurable on New.

Credit to @ncabatoff for the idea.