### PR TITLE
replacing "a key usage mode" on transit doc page as it is confusing

### DIFF
--- a/website/pages/docs/secrets/transit/index.mdx
+++ b/website/pages/docs/secrets/transit/index.mdx
@@ -84,7 +84,7 @@ derivation function but also by deterministically deriving a nonce. Because
 these properties differ for any combination of plaintext and ciphertext over a
 keyspace the size of 2^256, the risk of nonce reuse is near zero.
 
-This has many practical uses. A key usage mode is to allow values to be stored
+This has many practical uses. One common usage mode is to allow values to be stored
 encrypted in a database, but with limited lookup/query support, so that rows
 with the same value for a specific field can be returned from a query.
 


### PR DESCRIPTION
Since the context of this page is transit and encryption keys, the use of the word "key" to mean effectively common seems ill advised. Proposing an alternative wording.