### PR TITLE
Backport 1.4.3: remove mount prefix from config path used to invalidate connections

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	databaseConfigPath     = "database/config/"
+	databaseConfigPath     = "config/"
 	databaseRolePath       = "role/"
 	databaseStaticRolePath = "static-role/"
 )


### PR DESCRIPTION
This PR backports a bug fix from https://github.com/hashicorp/vault/pull/9129.