### PR TITLE
fix: configutil redeclared as imported package name

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -26,8 +26,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/vault/internalshared/configutil"
-
 	"github.com/armon/go-metrics"
 	hclog "github.com/hashicorp/go-hclog"
 	log "github.com/hashicorp/go-hclog"


### PR DESCRIPTION
Fixes the build by removing the redeclared `github.com/hashicorp/vault/internalshared/configutil` import introduced in https://github.com/hashicorp/vault/commit/3d02fb4b86385666c2f2e43b48c79119402731a4.

```
make dev
==> Checking that build is using go version >= 1.13.7...
==> Using go version 1.13.10...
==> Removing old directory...
==> Building...
Number of parallel builds: 15

-->    darwin/amd64: github.com/hashicorp/vault

1 errors occurred:
--> darwin/amd64 error: exit status 2
Stderr: # github.com/hashicorp/vault/vault
vault/testing.go:47:2: configutil redeclared as imported package name
        previous declaration at vault/testing.go:29:2
```