### PR TITLE
docs/agent: add overview for consul template fetches

### DIFF
--- a/website/pages/docs/agent/template/index.mdx
+++ b/website/pages/docs/agent/template/index.mdx
@@ -127,8 +127,8 @@ the `auto_auth` stanza in the agent configuration.
 
 ## Renewals and Updating Secrets
 
-The Vault Agent templating automatically renews and fetches secrets.  The behavior
-of how Agent does this depends on the type of secret.  The following is a high level
+The Vault Agent templating automatically renews and fetches secrets/tokens.  The behavior
+of how Agent does this depends on the type of secret or token.  The following is a high level
 overview of different behaviors.
 
 ### Renewable Secrets

--- a/website/pages/docs/agent/template/index.mdx
+++ b/website/pages/docs/agent/template/index.mdx
@@ -133,14 +133,19 @@ overview of different behaviors.
 
 ### Renewable Secrets
 
-If a secret is renewable, Vault Agent will renew and fetch the secret when 85% of the
-secrets time-to-live (TTL) is reached. Renewable secrets include (but not limited
-to) tokens, dynamic secrets such as [database credentials](/docs/secrets/databases) and [KV Version 1](/docs/secrets/kv/kv-v1).
+If a secret is renewable, such as a token, Vault Agent will renew the secret at 1/3 
+of the secret's lease.
 
 ### Non-Renewable Secrets
 
-If a secret isn't renewable, Vault Agent will fetch the secret every 5 minutes. This is not
+If a secret isn't renewable or leased, Vault Agent will fetch the secret every 5 minutes. This is not
 configurable.  Non-renewable secrets include (but not limited to) [KV Version 2](/docs/secrets/kv/kv-v2).
+
+### Non-Renewable Leased Secrets
+
+If a secret is non-renewable but leased, Vault Agent will fetch the secret when 85% of the
+secrets time-to-live (TTL) is reached. Leased, non-renewable secrets include (but not limited
+to) dynamic secrets such as [database credentials](/docs/secrets/databases) and [KV Version 1](/docs/secrets/kv/kv-v1).
 
 ### Static Roles
 

--- a/website/pages/docs/agent/template/index.mdx
+++ b/website/pages/docs/agent/template/index.mdx
@@ -151,4 +151,4 @@ this by inspecting the secret's time-to-live (TTL).
 ### Certificates
 
 If a secret is a [certificate](/docs/secrets/pki), Vault Agent template will fetch the new certificate
-uing the certificates `validTo` field.
+using the certificates `validTo` field.

--- a/website/pages/docs/agent/template/index.mdx
+++ b/website/pages/docs/agent/template/index.mdx
@@ -133,17 +133,17 @@ overview of different behaviors.
 
 ### Renewable Secrets
 
-If a secret is renewable, such as a token, Vault Agent will renew the secret at 1/3 
+If a secret or token is renewable, Vault Agent will renew the secret at 1/3 
 of the secret's lease.
 
 ### Non-Renewable Secrets
 
-If a secret isn't renewable or leased, Vault Agent will fetch the secret every 5 minutes. This is not
+If a secret or token isn't renewable or leased, Vault Agent will fetch the secret every 5 minutes. This is not
 configurable.  Non-renewable secrets include (but not limited to) [KV Version 2](/docs/secrets/kv/kv-v2).
 
 ### Non-Renewable Leased Secrets
 
-If a secret is non-renewable but leased, Vault Agent will fetch the secret when 85% of the
+If a secret or token is non-renewable but leased, Vault Agent will fetch the secret when 85% of the
 secrets time-to-live (TTL) is reached. Leased, non-renewable secrets include (but not limited
 to) dynamic secrets such as [database credentials](/docs/secrets/databases) and [KV Version 1](/docs/secrets/kv/kv-v1).
 
@@ -157,3 +157,6 @@ this by inspecting the secret's time-to-live (TTL).
 
 If a secret is a [certificate](/docs/secrets/pki), Vault Agent template will fetch the new certificate
 using the certificates `validTo` field.
+
+This does not apply to certificates generated with `generate_lease: true`.  If set 
+Vault Agent template will apply the non-renewable, leased secret rules.

--- a/website/pages/docs/agent/template/index.mdx
+++ b/website/pages/docs/agent/template/index.mdx
@@ -127,9 +127,10 @@ the `auto_auth` stanza in the agent configuration.
 
 ## Renewals and Updating Secrets
 
-The Vault Agent templating automatically renews and fetches secrets/tokens.  The behavior
-of how Agent does this depends on the type of secret or token.  The following is a high level
-overview of different behaviors.
+The Vault Agent templating automatically renews and fetches secrets/tokens. 
+Unlike [Vault Agent caching](/docs/agent/caching), the behavior of how Vault Agent 
+templating does this depends on the type of secret or token. The following is a 
+high level overview of different behaviors.
 
 ### Renewable Secrets
 

--- a/website/pages/docs/agent/template/index.mdx
+++ b/website/pages/docs/agent/template/index.mdx
@@ -124,3 +124,31 @@ template {
 If you only want to use the Vault agent to render one or more templates and do
 not need to sink the acquired credentials, you can omit the `sink` stanza from
 the `auto_auth` stanza in the agent configuration.
+
+## Renewals and Updating Secrets
+
+The Vault Agent templating automatically renews and fetches secrets.  The behavior
+of how Agent does this depends on the type of secret.  The following is a high level
+overview of different behaviors.
+
+### Renewable Secrets
+
+If a secret is renewable, Vault Agent will renew and fetch the secret when 85% of the
+secrets time-to-live (TTL) is reached. Renewable secrets include (but not limited
+to) tokens, dynamic secrets such as [database credentials](/docs/secrets/databases) and [KV Version 1](/docs/secrets/kv/kv-v1).
+
+### Non-Renewable Secrets
+
+If a secret isn't renewable, Vault Agent will fetch the secret every 5 minutes. This is not
+configurable.  Non-renewable secrets include (but not limited to) [KV Version 2](/docs/secrets/kv/kv-v2).
+
+### Static Roles
+
+If a secret has a `rotation_period`, such as a [database static role](/docs/secrets/databases#static-roles),
+Vault Agent template will fetch the new secret as it changes in Vault.  It does
+this by inspecting the secret's time-to-live (TTL).
+
+### Certificates
+
+If a secret is a [certificate](/docs/secrets/pki), Vault Agent template will fetch the new certificate
+uing the certificates `validTo` field.

--- a/website/pages/docs/platform/k8s/injector/index.mdx
+++ b/website/pages/docs/platform/k8s/injector/index.mdx
@@ -170,7 +170,35 @@ username: v-kubernet-pg-app-q0Z7WPfVNqqTJuoDqCTY-1576529094
 
 ~> Some secrets such as KV are stored in maps. Their data can be accessed using `.Data.data.<NAME>`
 
-#### Vault Agent Configuration Map
+### Renewals and Updating Secrets
+
+The Vault Agent templating automatically renews and fetches secrets.  The behavior 
+of how Agent does this depends on the type of secret.  The following is a high level 
+overview of different behaviors.
+
+#### Renewable Secrets
+
+If a secret is renewable, Vault Agent will renew and fetch the secret when 85% of the 
+secrets time-to-live (TTL) is reached. Renewable secrets include (but not limited 
+to) tokens, dynamic secrets such as database credentials and [KV Version 1](/docs/secrets/kv/kv-v1).
+
+#### Non-Renewable Secrets
+
+If a secret isn't renewable, Vault Agent will fetch the secret every 5 minutes. This is not 
+configurable.  Non-renewable secrets include (but not limited to) [KV Version 2](/docs/secrets/kv/kv-v2).
+
+#### Static Roles
+
+If a secret has a `rotation_period`, such as a [database static role](/docs/secrets/databases#static-roles), 
+Vault Agent template will fetch the new secret as it changes in Vault.  It does 
+this by inspecting the secret's time-to-live (TTL).
+
+#### Certificates
+
+If a secret is a [certificate](/docs/secrets/pki), Vault Agent template will fetch the new certificate 
+uing the certificates `validTo` field.
+
+### Vault Agent Configuration Map
 
 For advanced use cases, it may be required to define Vault Agent configuration
 files to mount instead of using secret and template annotations. The Vault Agent

--- a/website/pages/docs/platform/k8s/injector/index.mdx
+++ b/website/pages/docs/platform/k8s/injector/index.mdx
@@ -172,31 +172,8 @@ username: v-kubernet-pg-app-q0Z7WPfVNqqTJuoDqCTY-1576529094
 
 ### Renewals and Updating Secrets
 
-The Vault Agent templating automatically renews and fetches secrets.  The behavior 
-of how Agent does this depends on the type of secret.  The following is a high level 
-overview of different behaviors.
-
-#### Renewable Secrets
-
-If a secret is renewable, Vault Agent will renew and fetch the secret when 85% of the 
-secrets time-to-live (TTL) is reached. Renewable secrets include (but not limited 
-to) tokens, dynamic secrets such as [database credentials](/docs/secrets/databases) and [KV Version 1](/docs/secrets/kv/kv-v1).
-
-#### Non-Renewable Secrets
-
-If a secret isn't renewable, Vault Agent will fetch the secret every 5 minutes. This is not 
-configurable.  Non-renewable secrets include (but not limited to) [KV Version 2](/docs/secrets/kv/kv-v2).
-
-#### Static Roles
-
-If a secret has a `rotation_period`, such as a [database static role](/docs/secrets/databases#static-roles), 
-Vault Agent template will fetch the new secret as it changes in Vault.  It does 
-this by inspecting the secret's time-to-live (TTL).
-
-#### Certificates
-
-If a secret is a [certificate](/docs/secrets/pki), Vault Agent template will fetch the new certificate 
-uing the certificates `validTo` field.
+For more information on when Vault Agent fetches and renews secrets, see the 
+[Agent documentation](/docs/agent/template#renewals-and-updating-secrets).
 
 ### Vault Agent Configuration Map
 

--- a/website/pages/docs/platform/k8s/injector/index.mdx
+++ b/website/pages/docs/platform/k8s/injector/index.mdx
@@ -180,7 +180,7 @@ overview of different behaviors.
 
 If a secret is renewable, Vault Agent will renew and fetch the secret when 85% of the 
 secrets time-to-live (TTL) is reached. Renewable secrets include (but not limited 
-to) tokens, dynamic secrets such as database credentials and [KV Version 1](/docs/secrets/kv/kv-v1).
+to) tokens, dynamic secrets such as [database credentials](/docs/secrets/databases) and [KV Version 1](/docs/secrets/kv/kv-v1).
 
 #### Non-Renewable Secrets
 


### PR DESCRIPTION
This outlines various types of secrets and the behavior of Vault Agent template (Consul Template) rendering those secrets.  