### PR TITLE
docs: fix typo in gcp and gcpkms secrets

### DIFF
--- a/website/pages/docs/secrets/gcp/index.mdx
+++ b/website/pages/docs/secrets/gcp/index.mdx
@@ -60,7 +60,7 @@ management tool.
 
     If you are running Vault from inside [Google Compute Engine][gce] or [Google
     Kubernetes Engine][gke], the instance or pod service account can be used in
-    place or specifying the credentials JSON file.
+    place of specifying the credentials JSON file.
     For more information on authentication, see the [authentication section](#authentication) below.
 
 1.  Configure a roleset. Rolesets determine the permissions that Service Account

--- a/website/pages/docs/secrets/gcpkms/index.mdx
+++ b/website/pages/docs/secrets/gcpkms/index.mdx
@@ -41,7 +41,7 @@ management tool.
 
    If you are running Vault from inside [Google Compute Engine][gce] or [Google
    Kubernetes Engine][gke], the instance or pod service account can be used in
-   place or specifying the credentials JSON file. For more information on
+   place of specifying the credentials JSON file. For more information on
    authentication, see the [authentication section](#authentication) below.
 
 1. Create a Google Cloud KMS key:


### PR DESCRIPTION
This PR fixes a typo in the GCP and GCP KMS secrets engine documentation. It replaces `in place or` with `in place of`.