### PR TITLE
Update GCP secrets plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.6.6
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.5.5
 	github.com/hashicorp/vault-plugin-secrets-azure v0.5.6
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.6.2
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.6.3-0.20200615210754-6c617f9285c3
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.5
 	github.com/hashicorp/vault-plugin-secrets-kv v0.5.5
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -508,8 +508,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.5.5 h1:BOOtSls+BQ1EtPmpE9L
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.5.5/go.mod h1:gAoReoUpBHaBwkxQqTK7FY8nQC0MuaZHLiW5WOSny5g=
 github.com/hashicorp/vault-plugin-secrets-azure v0.5.6 h1:4PgQ5rCT29wW5PMyebEhPkEYuR5s+SnInuZz3x2cP50=
 github.com/hashicorp/vault-plugin-secrets-azure v0.5.6/go.mod h1:Q0cIL4kZWnMmQWkBfWtyOd7+JXTEpAyU4L932PMHq3E=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.6.2 h1:ovziWUzmj83UlVXK8tM926ZitLKa5ZwRvlMqVibWHEs=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.6.2/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.6.3-0.20200615210754-6c617f9285c3 h1:yVlEx1z3AgSWl7VKwSyQi9Di0nHnwHV76mC3OI9gC0c=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.6.3-0.20200615210754-6c617f9285c3/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.5 h1:NigzA2v+h+cjBPl41pRirRwWELF+RPJGch/ys0Sijrc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.5/go.mod h1:b6RwFD1bny1zbfqhD35iGJdQYHRtJLx3HfBD109GO38=
 github.com/hashicorp/vault-plugin-secrets-kv v0.5.5 h1:yLtfsAiJOkpRkk+OxQmFluQJ35OUw420Y+CwfGMWuSc=

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-gcp/plugin/path_role_set.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-gcp/plugin/path_role_set.go
@@ -362,6 +362,9 @@ func (b *backend) pathRoleSetCreateUpdate(ctx context.Context, req *logical.Requ
 	// If no new bindings or new bindings are exactly same as old bindings,
 	// just update the role set without rotating service account.
 	if !newBindings || rs.bindingHash() == getStringHash(bRaw.(string)) {
+		if rs.TokenGen != nil {
+			rs.TokenGen.Scopes = scopes
+		}
 		// Just save role with updated metadata:
 		if err := rs.save(ctx, req.Storage); err != nil {
 			return logical.ErrorResponse(err.Error()), nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -442,7 +442,7 @@ github.com/hashicorp/vault-plugin-secrets-alicloud
 github.com/hashicorp/vault-plugin-secrets-alicloud/clients
 # github.com/hashicorp/vault-plugin-secrets-azure v0.5.6
 github.com/hashicorp/vault-plugin-secrets-azure
-# github.com/hashicorp/vault-plugin-secrets-gcp v0.6.2
+# github.com/hashicorp/vault-plugin-secrets-gcp v0.6.3-0.20200615210754-6c617f9285c3
 github.com/hashicorp/vault-plugin-secrets-gcp/plugin
 github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil
 github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util


### PR DESCRIPTION
Updates to bring in https://github.com/hashicorp/vault-plugin-secrets-gcp/commit/6c617f9285c3da64820daf2756c6e60e80deee0f.

The following steps were taken:
1. `go get github.com/hashicorp/vault-plugin-secrets-gcp@master`
2. `go mod tidy`
3. `go mod vendor`