### PR TITLE
builtin/database: fix creds rotation panic for nil resp

### DIFF
--- a/builtin/logical/database/path_rotate_credentials.go
+++ b/builtin/logical/database/path_rotate_credentials.go
@@ -187,7 +187,7 @@ func (b *databaseBackend) pathRotateRoleCredentialsUpdate() framework.OperationF
 			item.Priority = time.Now().Add(10 * time.Second).Unix()
 
 			// Preserve the WALID if it was returned
-			if resp.WALID != "" {
+			if resp != nil && resp.WALID != "" {
 				item.Value = resp.WALID
 			}
 		} else {


### PR DESCRIPTION
A panic occurs if `resp` is a nil pointer in the event of a password rotation failure. Added a small check if `resp` is nil before trying to extract WAL ID from it.