### PR TITLE
Fix allowed_parameters to work with multiple values in any order

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -720,7 +720,21 @@ func valueInSlice(v interface{}, list []interface{}) bool {
 			item := el.(string)
 			val := v.(string)
 
-			if strutil.GlobbedStringsMatch(item, val) {
+			// At this point, if val contains a comma, it means multiple values were specified and we
+			// need to check each of them in turn, rather than treating the entire thing like 1 value.
+			// In order for this to return true, strutil.GlobbedStringsMatch must return true for
+			// all of them. Even if val doesn't contain a comma, this is still safe because strings.Split()
+			// will return a slice of length 1 with val in it.
+			allMatch := true
+
+			for _, s := range strings.Split(val, ",") {
+				if !strutil.GlobbedStringsMatch(item, s) {
+					allMatch = false
+					break
+				}
+			}
+
+			if allMatch {
 				return true
 			}
 		} else if reflect.DeepEqual(el, v) {


### PR DESCRIPTION
This started as an investigation of https://hashicorp.atlassian.net/browse/VLTC-45, the goal of which was just to provide some better documentation around why `allowed_parameters` is broken and not fixable in certain very specific scenarios involving globbing. The more I dug into how globbing works in the ACL checks, the more I thought maybe this is fixable after all.

This is my attempt at fixing the problem. I took the repro steps from the JIRA ticket and made it into a test. With the change I made, the problem described in the ticket is fixed and none of the other ACL tests are broken, as far as I can tell.

Have I overlooked something obvious or is this a reasonable solution?