### PR TITLE
Backport 1.4.3: Add go version to server message output

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -602,6 +602,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 	infoKeys = append(infoKeys, "version")
 	verInfo := version.GetVersion()
 	info["version"] = verInfo.FullVersionNumber(false)
+
 	if verInfo.Revision != "" {
 		info["version sha"] = strings.Trim(verInfo.Revision, "'")
 		infoKeys = append(infoKeys, "version sha")
@@ -610,10 +611,15 @@ func (c *ServerCommand) runRecoveryMode() int {
 	infoKeys = append(infoKeys, "recovery mode")
 	info["recovery mode"] = "true"
 
+	infoKeys = append(infoKeys, "go version")
+	info["go version"] = runtime.Version()
+
 	// Server configuration output
 	padding := 24
+
 	sort.Strings(infoKeys)
 	c.UI.Output("==> Vault server configuration:\n")
+
 	for _, k := range infoKeys {
 		c.UI.Output(fmt.Sprintf(
 			"%s%s: %s",
@@ -621,6 +627,7 @@ func (c *ServerCommand) runRecoveryMode() int {
 			strings.Title(k),
 			info[k]))
 	}
+
 	c.UI.Output("")
 
 	for _, ln := range lns {
@@ -1512,6 +1519,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 		info["version sha"] = strings.Trim(verInfo.Revision, "'")
 		infoKeys = append(infoKeys, "version sha")
 	}
+
 	infoKeys = append(infoKeys, "cgo")
 	info["cgo"] = "disabled"
 	if version.CgoEnabled {
@@ -1521,10 +1529,15 @@ CLUSTER_SYNTHESIS_COMPLETE:
 	infoKeys = append(infoKeys, "recovery mode")
 	info["recovery mode"] = "false"
 
+	infoKeys = append(infoKeys, "go version")
+	info["go version"] = runtime.Version()
+
 	// Server configuration output
 	padding := 24
+
 	sort.Strings(infoKeys)
 	c.UI.Output("==> Vault server configuration:\n")
+
 	for _, k := range infoKeys {
 		c.UI.Output(fmt.Sprintf(
 			"%s%s: %s",
@@ -1532,6 +1545,7 @@ CLUSTER_SYNTHESIS_COMPLETE:
 			strings.Title(k),
 			info[k]))
 	}
+
 	c.UI.Output("")
 
 	// Tests might not want to start a vault server and just want to verify
@@ -2098,16 +2112,22 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 		info["version sha"] = strings.Trim(verInfo.Revision, "'")
 		infoKeys = append(infoKeys, "version sha")
 	}
+
 	infoKeys = append(infoKeys, "cgo")
 	info["cgo"] = "disabled"
 	if version.CgoEnabled {
 		info["cgo"] = "enabled"
 	}
 
+	infoKeys = append(infoKeys, "go version")
+	info["go version"] = runtime.Version()
+
 	// Server configuration output
 	padding := 24
+
 	sort.Strings(infoKeys)
 	c.UI.Output("==> Vault server configuration:\n")
+
 	for _, k := range infoKeys {
 		c.UI.Output(fmt.Sprintf(
 			"%s%s: %s",
@@ -2115,6 +2135,7 @@ func (c *ServerCommand) enableThreeNodeDevCluster(base *vault.CoreConfig, info m
 			strings.Title(k),
 			info[k]))
 	}
+
 	c.UI.Output("")
 
 	for _, core := range testCluster.Cores {


### PR DESCRIPTION
Backport of https://github.com/hashicorp/vault/pull/9078 to 1.4.3.