### PR TITLE
Backport 1.4.3: add changelog link (#9216)

### DIFF
--- a/ui/app/templates/vault.hbs
+++ b/ui/app/templates/vault.hbs
@@ -10,7 +10,10 @@
       &copy; {{date-format (now) "YYYY"}} HashiCorp
     </span>
     <span>
-      Vault {{activeCluster.leaderNode.version}}
+      <a href={{changelog-url-for activeCluster.leaderNode.version}}
+      class="link has-text-grey">
+        Vault {{activeCluster.leaderNode.version}}
+      </a>
     </span>
     {{#if (is-version "OSS")}}
       <span>

--- a/ui/lib/core/addon/helpers/changelog-url-for.js
+++ b/ui/lib/core/addon/helpers/changelog-url-for.js
@@ -1,0 +1,37 @@
+import { helper } from '@ember/component/helper';
+
+/*
+This helper returns a url to the changelog for the specified version.
+It assumes that Changelog headers for Vault versions >= 1.4.3 are structured as:
+
+## v1.5.0
+### Month, DD, YYYY
+
+## v1.4.5
+### Month, DD, YYY
+
+etc.
+*/
+
+export function changelogUrlFor([version]) {
+  let url = 'https://www.github.com/hashicorp/vault/blob/master/CHANGELOG.md#';
+
+  try {
+    // strip the '+prem' from enterprise versions and remove periods
+    let versionNumber = version
+      .split('+')[0]
+      .split('.')
+      .join('');
+
+    // only recent versions have a predictable url
+    if (versionNumber >= '143') {
+      return url.concat('v', versionNumber);
+    }
+  } catch (e) {
+    console.log(e);
+    console.log('Cannot generate URL for version: ', version);
+  }
+  return url;
+}
+
+export default helper(changelogUrlFor);

--- a/ui/lib/core/app/helpers/changelog-url-for.js
+++ b/ui/lib/core/app/helpers/changelog-url-for.js
@@ -1,0 +1,1 @@
+export { default, changelogUrlFor } from 'core/helpers/changelog-url-for';

--- a/ui/tests/integration/helpers/changelog-url-for-test.js
+++ b/ui/tests/integration/helpers/changelog-url-for-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { changelogUrlFor } from '../../../helpers/changelog-url-for';
+
+const CHANGELOG_URL = 'https://www.github.com/hashicorp/vault/blob/master/CHANGELOG.md#';
+
+module('Integration | Helper | changelog-url-for', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it builds an enterprise URL', function(assert) {
+    const result = changelogUrlFor(['1.5.0+prem']);
+    assert.equal(result, CHANGELOG_URL.concat('v150'));
+  });
+
+  test('it builds an OSS URL', function(assert) {
+    const result = changelogUrlFor(['1.4.3']);
+    assert.equal(result, CHANGELOG_URL.concat('v143'));
+  });
+
+  test('it returns the base changelog URL if the version is less than 1.4.3', function(assert) {
+    const result = changelogUrlFor(['1.4.0']);
+    assert.equal(result, CHANGELOG_URL);
+  });
+
+  test('it returns the base changelog URL if version cannot be found', function(assert) {
+    const result = changelogUrlFor(['']);
+    assert.equal(result, CHANGELOG_URL);
+  });
+});


### PR DESCRIPTION
Backport of https://github.com/hashicorp/vault/pull/9216, which adds a link to the changelog in the UI footer.