### PR TITLE
Backport 1.4.3: Fix JSON encoding adding newlines

### DIFF
--- a/command/server/config.go
+++ b/command/server/config.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -15,7 +16,6 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
 )
 
@@ -753,7 +753,7 @@ func ParseStorage(result *Config, list *ast.ObjectList, name string) error {
 			m[key] = valStr
 			continue
 		}
-		valBytes, err := jsonutil.EncodeJSON(val)
+		valBytes, err := json.Marshal(val)
 		if err != nil {
 			return err
 		}

--- a/command/server/config_test.go
+++ b/command/server/config_test.go
@@ -22,6 +22,14 @@ func TestLoadConfigFile_json2(t *testing.T) {
 	testLoadConfigFile_json2(t, nil)
 }
 
+func TestLoadConfigFileIntegerAndBooleanValues(t *testing.T) {
+	testLoadConfigFileIntegerAndBooleanValues(t)
+}
+
+func TestLoadConfigFileIntegerAndBooleanValuesJson(t *testing.T) {
+	testLoadConfigFileIntegerAndBooleanValuesJson(t)
+}
+
 func TestLoadConfigDir(t *testing.T) {
 	testLoadConfigDir(t)
 }

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -274,6 +274,57 @@ func testParseEntropy(t *testing.T, oss bool) {
 	}
 }
 
+func testLoadConfigFileIntegerAndBooleanValues(t *testing.T) {
+	testLoadConfigFileIntegerAndBooleanValuesCommon(t, "./test-fixtures/config4.hcl")
+}
+
+func testLoadConfigFileIntegerAndBooleanValuesJson(t *testing.T) {
+	testLoadConfigFileIntegerAndBooleanValuesCommon(t, "./test-fixtures/config4.hcl.json")
+}
+
+func testLoadConfigFileIntegerAndBooleanValuesCommon(t *testing.T, path string) {
+	config, err := LoadConfigFile(path)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := &Config{
+		Listeners: []*Listener{
+			&Listener{
+				Type: "tcp",
+				Config: map[string]interface{}{
+					"address": "127.0.0.1:8200",
+				},
+			},
+		},
+
+		Storage: &Storage{
+			Type: "raft",
+			Config: map[string]string{
+				"path":                   "/storage/path/raft",
+				"node_id":                "raft1",
+				"performance_multiplier": "1",
+				"foo":                    "bar",
+				"baz":                    "true",
+			},
+			ClusterAddr: "127.0.0.1:8201",
+		},
+
+		ClusterAddr: "127.0.0.1:8201",
+
+		DisableCache:    true,
+		DisableCacheRaw: true,
+		EnableUI:        true,
+		EnableUIRaw:     true,
+		DisableMlock:    true,
+		DisableMlockRaw: true,
+	}
+
+	if !reflect.DeepEqual(config, expected) {
+		t.Fatalf("expected \n\n%#v\n\n to be \n\n%#v\n\n", config, expected)
+	}
+}
+
 func testLoadConfigFile(t *testing.T) {
 	config, err := LoadConfigFile("./test-fixtures/config.hcl")
 	if err != nil {

--- a/command/server/test-fixtures/config4.hcl
+++ b/command/server/test-fixtures/config4.hcl
@@ -1,0 +1,17 @@
+disable_cache = true
+disable_mlock = true
+ui = true
+
+listener "tcp" {
+  address = "127.0.0.1:8200"
+}
+
+storage "raft" {
+  path = "/storage/path/raft"
+  node_id = "raft1"
+  performance_multiplier = 1
+  foo = "bar"
+  baz = true
+}
+
+cluster_addr = "127.0.0.1:8201"

--- a/command/server/test-fixtures/config4.hcl.json
+++ b/command/server/test-fixtures/config4.hcl.json
@@ -1,0 +1,20 @@
+{
+  "disable_cache": true,
+  "disable_mlock": true,
+  "ui":true,
+  "listener": [{
+    "tcp": {
+      "address": "127.0.0.1:8200"
+    }
+  }],
+  "storage": {
+    "raft": {
+      "path": "/storage/path/raft",
+      "node_id": "raft1",
+      "performance_multiplier": 1,
+      "foo": "bar",
+      "baz": true
+    }
+  },
+  "cluster_addr": "127.0.0.1:8201"
+}


### PR DESCRIPTION
Note that [my original PR](https://github.com/hashicorp/vault/pull/8928) was based on top of the [configutil refactor](https://github.com/hashicorp/vault/pull/8362) which is not being backported, so the diff here is slightly different from the original PR.