### PR TITLE
plugins/ssh: add diabled host key verification warning

### DIFF
--- a/builtin/logical/ssh/util.go
+++ b/builtin/logical/ssh/util.go
@@ -154,6 +154,13 @@ func cidrListContainsIP(ip, cidrList string) (bool, error) {
 	return false, nil
 }
 
+func insecureIgnoreHostWarning(logger log.Logger) ssh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		logger.Warn("cannot verify server key: host key validation disabled")
+		return nil
+	}
+}
+
 func createSSHComm(logger log.Logger, username, ip string, port int, hostkey string) (*comm, error) {
 	signer, err := ssh.ParsePrivateKey([]byte(hostkey))
 	if err != nil {
@@ -165,7 +172,7 @@ func createSSHComm(logger log.Logger, username, ip string, port int, hostkey str
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: insecureIgnoreHostWarning(logger),
 	}
 
 	connfunc := func() (net.Conn, error) {


### PR DESCRIPTION
[In our documentation for a deprecated feature](https://www.vaultproject.io/docs/secrets/ssh/dynamic-ssh-keys#drawbacks) in the Vault SSH secret engine there's a warning about host key verification being ignored.  Adding a log warning for this since Vault cannot verify a server's host key until this is removed from Vault.

```log
2020-06-23T19:20:54.924-0400 [WARN]  cannot verify server key: host key validation disabled
```