### PR TITLE
Ui/fix manage grid

### DIFF
--- a/ui/app/styles/components/action-block.scss
+++ b/ui/app/styles/components/action-block.scss
@@ -56,10 +56,11 @@
 .replication-actions-grid-item {
   flex-basis: 50%;
   padding: $spacing-s;
+  display: flex;
+  width: 100%;
 }
 
 .replication-actions-grid-item .action-block {
-  height: 100%;
   width: 100%;
   @include until($tablet) {
     height: inherit;

--- a/ui/lib/core/addon/components/replication-action-demote.js
+++ b/ui/lib/core/addon/components/replication-action-demote.js
@@ -3,4 +3,5 @@ import layout from '../templates/components/replication-action-demote';
 
 export default Actions.extend({
   layout,
+  tagName: '',
 });

--- a/ui/lib/core/addon/components/replication-action-disable.js
+++ b/ui/lib/core/addon/components/replication-action-disable.js
@@ -3,4 +3,5 @@ import layout from '../templates/components/replication-action-disable';
 
 export default Actions.extend({
   layout,
+  tagName: '',
 });

--- a/ui/lib/core/addon/components/replication-action-generate-token.js
+++ b/ui/lib/core/addon/components/replication-action-generate-token.js
@@ -3,4 +3,5 @@ import layout from '../templates/components/replication-action-generate-token';
 
 export default Actions.extend({
   layout,
+  tagName: '',
 });

--- a/ui/lib/core/addon/components/replication-action-promote.js
+++ b/ui/lib/core/addon/components/replication-action-promote.js
@@ -3,4 +3,5 @@ import layout from '../templates/components/replication-action-promote';
 
 export default Actions.extend({
   layout,
+  tagName: '',
 });

--- a/ui/lib/core/addon/components/replication-action-recover.js
+++ b/ui/lib/core/addon/components/replication-action-recover.js
@@ -3,4 +3,5 @@ import layout from '../templates/components/replication-action-recover';
 
 export default Actions.extend({
   layout,
+  tagName: '',
 });

--- a/ui/lib/core/addon/components/replication-action-reindex.js
+++ b/ui/lib/core/addon/components/replication-action-reindex.js
@@ -3,4 +3,5 @@ import layout from '../templates/components/replication-action-reindex';
 
 export default Actions.extend({
   layout,
+  tagName: '',
 });

--- a/ui/lib/core/addon/components/replication-action-update-primary.js
+++ b/ui/lib/core/addon/components/replication-action-update-primary.js
@@ -3,4 +3,5 @@ import layout from '../templates/components/replication-action-update-primary';
 
 export default Actions.extend({
   layout,
+  tagName: '',
 });

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -83,7 +83,7 @@
     </h3>
     <div class="grid-item-second-row">
       <h6 class="title is-6">
-        known_primary_cluster_addr
+        known_primary_cluster_addrs
       </h6>
       <p class="has-text-grey">
         A list of all the nodes in the primary's cluster. This value is updated every ten seconds.


### PR DESCRIPTION
This PR fixes the vertical alignment of the manage actions on the replication dashboards, which were previously broken in Safari.

## Before
<img width="1079" alt="vertical" src="https://user-images.githubusercontent.com/903288/85619206-d1959b80-b616-11ea-829c-6d5e948aa131.png">


## After

### Full width on Safari
![image](https://user-images.githubusercontent.com/903288/85618939-61871580-b616-11ea-8acf-56575951b5c2.png)

### Tablet width on Safari
![image](https://user-images.githubusercontent.com/903288/85618981-72378b80-b616-11ea-9c52-8850218388d9.png)

### Full width on Chrome 
![image](https://user-images.githubusercontent.com/903288/85619033-87acb580-b616-11ea-8c65-569d1662441b.png)
