### PR TITLE
Backport 1.4.3: Update mongodbatlas database plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.6.1
 	github.com/hashicorp/vault-plugin-auth-oci v0.5.5-0.20200616221217-ae6d56006639
 	github.com/hashicorp/vault-plugin-database-elasticsearch v0.5.4
-	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.1.2-0.20200520204052-f840e9d4895c
+	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.1.2-0.20200624203152-e5cd7c505e55
 	github.com/hashicorp/vault-plugin-secrets-ad v0.6.6-0.20200520202259-fc6b89630f9f
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.5.5
 	github.com/hashicorp/vault-plugin-secrets-azure v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,6 @@ github.com/hashicorp/vault-plugin-auth-gcp v0.6.2-0.20200428223335-82bd3a3ad5b3 
 github.com/hashicorp/vault-plugin-auth-gcp v0.6.2-0.20200428223335-82bd3a3ad5b3/go.mod h1:U0fkAlxWTEyQ74lx8wlGdD493lP1DD/qpMjXgOEbwj0=
 github.com/hashicorp/vault-plugin-auth-jwt v0.6.2 h1:fp6Rk89iPjDS8dyEK7lEauYE/UhkgkHbmwRZKuQA01U=
 github.com/hashicorp/vault-plugin-auth-jwt v0.6.2/go.mod h1:SFadxIfoLGzugEjwUUmUaCGbsYEz2/jJymZDDQjEqYg=
-github.com/hashicorp/vault-plugin-auth-kerberos v0.1.5 h1:knWedzZ51g8Aj6Hyi1ATlQ/7jEx6nJeqFoCoHSrbQFI=
-github.com/hashicorp/vault-plugin-auth-kerberos v0.1.5/go.mod h1:r4UqWITHYKmBeAMKPWqLo4V8bl/wNqoSIaQcMpeK9ss=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.1.6-0.20200527181845-3c7b47e8be2c h1:6HerT+apUSw9kJ7pEHcU+uBOKCTHRHThl4mH0SAsh+I=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.1.6-0.20200527181845-3c7b47e8be2c/go.mod h1:r4UqWITHYKmBeAMKPWqLo4V8bl/wNqoSIaQcMpeK9ss=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.6.1 h1:TpdQhHdZZN1Wo9RpJG33gUfuiVtajVcSF/hNpHWaatI=
@@ -415,8 +413,8 @@ github.com/hashicorp/vault-plugin-auth-oci v0.5.5-0.20200616221217-ae6d56006639 
 github.com/hashicorp/vault-plugin-auth-oci v0.5.5-0.20200616221217-ae6d56006639/go.mod h1:j05O2b9fw2Q82NxDPhHMYVfHKvitUYGWfmqmpBdqmmc=
 github.com/hashicorp/vault-plugin-database-elasticsearch v0.5.4 h1:YE4qndazWmYGpVOoZI7nDGG+gwTZKzL1Ou4WZQ+Tdxk=
 github.com/hashicorp/vault-plugin-database-elasticsearch v0.5.4/go.mod h1:QjGrrxcRXv/4XkEZAlM0VMZEa3uxKAICFqDj27FP/48=
-github.com/hashicorp/vault-plugin-database-mongodbatlas v0.1.2-0.20200520204052-f840e9d4895c h1:P9rZXBJx+UHu/T8lK8NEtS2PGeSnyZ31zeOtkvGo4yo=
-github.com/hashicorp/vault-plugin-database-mongodbatlas v0.1.2-0.20200520204052-f840e9d4895c/go.mod h1:MP3kfr0N+7miOTZFwKv952b9VkXM4S2Q6YtQCiNKWq8=
+github.com/hashicorp/vault-plugin-database-mongodbatlas v0.1.2-0.20200624203152-e5cd7c505e55 h1:zrP0293ipY7x06MWSHUsfsaeEz4yKPwZHft6LuzeB8Q=
+github.com/hashicorp/vault-plugin-database-mongodbatlas v0.1.2-0.20200624203152-e5cd7c505e55/go.mod h1:MP3kfr0N+7miOTZFwKv952b9VkXM4S2Q6YtQCiNKWq8=
 github.com/hashicorp/vault-plugin-secrets-ad v0.6.6-0.20200520202259-fc6b89630f9f h1:2pbH2I37C40+VvC5YkQONEwcqqFLNzsoFxJPiWaZZHE=
 github.com/hashicorp/vault-plugin-secrets-ad v0.6.6-0.20200520202259-fc6b89630f9f/go.mod h1:kk98nB+cwDbt3I7UGQq3ota7+eHZrGSTQZfSRGpluvA=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.5.5 h1:BOOtSls+BQ1EtPmpE9LoqZztsEZ1fRWVSkHWtRIrCB4=

--- a/vendor/github.com/hashicorp/vault-plugin-database-mongodbatlas/mongodbatlas.go
+++ b/vendor/github.com/hashicorp/vault-plugin-database-mongodbatlas/mongodbatlas.go
@@ -149,12 +149,6 @@ func (m *MongoDBAtlas) SetCredentials(ctx context.Context, statements dbplugin.S
 	m.Lock()
 	defer m.Unlock()
 
-	statements = dbutil.StatementCompatibilityHelper(statements)
-
-	if len(statements.Creation) == 0 {
-		return "", "", dbutil.ErrEmptyCreationStatement
-	}
-
 	client, err := m.getConnection(ctx)
 	if err != nil {
 		return "", "", err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -409,7 +409,7 @@ github.com/hashicorp/vault-plugin-auth-kubernetes
 github.com/hashicorp/vault-plugin-auth-oci
 # github.com/hashicorp/vault-plugin-database-elasticsearch v0.5.4
 github.com/hashicorp/vault-plugin-database-elasticsearch
-# github.com/hashicorp/vault-plugin-database-mongodbatlas v0.1.2-0.20200520204052-f840e9d4895c
+# github.com/hashicorp/vault-plugin-database-mongodbatlas v0.1.2-0.20200624203152-e5cd7c505e55
 github.com/hashicorp/vault-plugin-database-mongodbatlas
 # github.com/hashicorp/vault-plugin-secrets-ad v0.6.6-0.20200520202259-fc6b89630f9f
 github.com/hashicorp/vault-plugin-secrets-ad/plugin


### PR DESCRIPTION
Updates to bring in backport https://github.com/hashicorp/vault-plugin-database-mongodbatlas/pull/13 from branch [release/vault-1.4.x](https://github.com/hashicorp/vault-plugin-database-mongodbatlas/tree/release/vault-1.4.x) of vault-plugin-database-mongodbatlas.

The following steps were taken:
1. `go get github.com/hashicorp/vault-plugin-database-mongodbatlas@release/vault-1.4.x`
2. `go mod tidy`
3. `go mod vendor`