### PR TITLE
docs: default for auth-path annotation

### DIFF
--- a/website/pages/docs/platform/k8s/injector/annotations.mdx
+++ b/website/pages/docs/platform/k8s/injector/annotations.mdx
@@ -133,7 +133,7 @@ example, Vault's address, TLS certificates to use, client parameters such as tim
 etc. 
 
 - `vault.hashicorp.com/auth-path` - configures the auth path for the Kubernetes 
-  auth method.  Defaults to `kubernetes`.
+  auth method.  Defaults to `auth/kubernetes`.
 
 - `vault.hashicorp.com/ca-cert` - path of the CA certificate used to verify Vault's
   TLS.


### PR DESCRIPTION
Updating the default for the auth-path annotation in the k8s injector
docs. This seems to match what's in the code: https://github.com/hashicorp/vault-k8s/blob/v0.4.0/agent-inject/agent/agent.go#L18

and the equivalent helm chart options doc: https://github.com/hashicorp/vault/blob/753a093f4338fafff16f6fc3b2d34e7b724e5c1d/website/pages/docs/platform/k8s/helm/configuration.mdx#L52