### PR TITLE
Mention Linux packages on install page

### DIFF
--- a/website/pages/docs/install/index.mdx
+++ b/website/pages/docs/install/index.mdx
@@ -46,35 +46,31 @@ your first secret, and use other features of Vault.
 ## Compiling from Source
 
 To compile from source, you will need [Go](https://golang.org) installed and
-configured properly (including a `GOPATH` environment variable set), as well
-as a copy of [`git`](https://www.git-scm.com/) in your `PATH`.
+configured properly (including a `GOPATH` environment variable set), as well as
+a copy of [`git`](https://www.git-scm.com/) in your `PATH`.
 
-1. Clone the Vault repository from GitHub into your `GOPATH`:
+Clone the Vault repository from GitHub into your `GOPATH`:
 
+```shell
+$ mkdir -p $GOPATH/src/github.com/hashicorp && cd $_
+$ git clone https://github.com/hashicorp/vault.git
+$ cd vault
+```
 
-    ```shell
-    $ mkdir -p $GOPATH/src/github.com/hashicorp && cd $_
-    $ git clone https://github.com/hashicorp/vault.git
-    $ cd vault
-    ```
+Bootstrap the project. This will download and compile libraries and tools needed
+to compile Vault:
 
-1. Bootstrap the project. This will download and compile libraries and tools
-   needed to compile Vault:
+```shell
+$ make bootstrap
+```
 
+Build Vault for your current system and put the binary in `./bin/` (relative to
+the git checkout). The `make dev` target is just a shortcut that builds `vault`
+for only your local build environment (no cross-compiled targets).
 
-    ```shell
-    $ make bootstrap
-    ```
-
-1. Build Vault for your current system and put the
-   binary in `./bin/` (relative to the git checkout). The `make dev` target is
-   just a shortcut that builds `vault` for only your local build environment (no
-   cross-compiled targets).
-
-
-    ```shell
-    $ make dev
-    ```
+```shell
+$ make dev
+```
 
 ## Verifying the Installation
 

--- a/website/pages/docs/install/index.mdx
+++ b/website/pages/docs/install/index.mdx
@@ -25,7 +25,7 @@ with the SHA256 sums that can be verified.
 
 We build and sign official packages for Ubuntu, Debian, Fedora, RHEL, Amazon
 Linux, and other distributions. Follow the instructions at [HashiCorp
-Learn][learn-vault-install-linux] to add our GPG key, add our repository, and
+Learn][learn-vault-install] to add our GPG key, add our repository, and
 install.
 
 ## Precompiled Binaries
@@ -86,5 +86,5 @@ on your PATH or you may get an error about Vault not being found.
 $ vault -h
 ```
 
-[learn-vault-install-linux]: https://learn.hashicorp.com/vault/getting-started/install#linux-packages
+[learn-vault-install]: https://learn.hashicorp.com/vault/getting-started/install
 [learn-vault-dev-server]: https://learn.hashicorp.com/vault/getting-started/dev-server

--- a/website/pages/docs/install/index.mdx
+++ b/website/pages/docs/install/index.mdx
@@ -3,34 +3,45 @@ layout: docs
 page_title: Install Vault
 sidebar_title: Installing Vault
 description: |-
-  Installing Vault is simple. You can download a precompiled binary or compile
-  from source. This page details both methods.
+  Download a precompiled binary, compile from source, or use a package.
 ---
 
 # Install Vault
 
-Installing Vault is simple. There are two approaches to installing Vault:
+There are several approaches to installing Vault:
 
-1. Using a [precompiled binary](#precompiled-binaries)
+1. Install a [Linux package](#linux-package)
 
-1. Installing [from source](#compiling-from-source)
+1. Use a [precompiled binary](#precompiled-binaries)
 
-Downloading a precompiled binary is easiest, and we provide downloads over TLS
+1. Install [from source](#compiling-from-source)
+
+Installing a Linux package is the easiest. If you develop or deploy on another
+platform, the precompiled binary will be easiest. We provide downloads over TLS
 along with SHA256 sums to verify the binary. We also distribute a PGP signature
 with the SHA256 sums that can be verified.
+
+## Linux Package
+
+We build and sign official packages for Ubuntu, Debian, Fedora, RHEL, Amazon
+Linux, and other distributions. Follow the instructions at [HashiCorp
+Learn][learn-vault-install-linux] to add our GPG key, add our repository, and
+install.
 
 ## Precompiled Binaries
 
 To install the precompiled binary, [download](/downloads) the appropriate
-package for your system. Vault is currently packaged as a zip file. We do not
-have any near term plans to provide system packages.
+package for your system. Vault is currently packaged as a zip file.
 
 Once the zip is downloaded, unzip it into any directory. The `vault` binary
-inside is all that is necessary to run Vault (or `vault.exe` for Windows). Any
-additional files, if any, aren't required to run Vault.
+inside is all that is necessary to run Vault (or `vault.exe` for Windows). No
+additional files are required to run Vault.
 
 Copy the binary to anywhere on your system. If you intend to access it from the
 command-line, make sure to place it somewhere on your `PATH`.
+
+Continue on to [HashiCorp Learn][learn-vault-dev-server] to start a server, `put`
+your first secret, and use other features of Vault.
 
 ## Compiling from Source
 
@@ -74,3 +85,6 @@ on your PATH or you may get an error about Vault not being found.
 ```shell-session
 $ vault -h
 ```
+
+[learn-vault-install-linux]: https://learn.hashicorp.com/vault/getting-started/install#linux-packages
+[learn-vault-dev-server]: https://learn.hashicorp.com/vault/getting-started/dev-server


### PR DESCRIPTION
Linux packages are now available for Debian, RedHat, and other distros. 

This PR removes wording that said "there are no plans to create Linux packages."

It also adds instructions and links to add the official HashiCorp package repository and install Vault from a package.