### PR TITLE
Test for overflow of the capacity value.

### DIFF
--- a/vault/barrier.go
+++ b/vault/barrier.go
@@ -24,6 +24,10 @@ var (
 
 	// ErrBarrierInvalidKey is returned if the Unseal key is invalid
 	ErrBarrierInvalidKey = errors.New("Unseal failed, invalid key")
+
+	// ErrPlaintextTooLarge is returned if a plaintext is offered for encryption
+	// that is too large to encrypt in memory
+	ErrPlaintextTooLarge = errors.New("plaintext value too large")
 )
 
 const (

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -910,6 +910,9 @@ func (b *AESGCMBarrier) encrypt(path string, term uint32, gcm cipher.AEAD, plain
 	// Allocate the output buffer with room for tern, version byte,
 	// nonce, GCM tag and the plaintext
 	capacity := termSize + 1 + gcm.NonceSize() + gcm.Overhead() + len(plain)
+	if capacity < 0 {
+		return nil, ErrPlaintextTooLarge
+	}
 	size := termSize + 1 + gcm.NonceSize()
 	out := make([]byte, size, capacity)
 


### PR DESCRIPTION
Technically capacity should never be less than the fixed overhead, but you
can't wrap so far as to be non-negative.  In addition, it's probably still
bad if you had a plaintext of 2^31 for allocation reasons, but this is the
smaller fix.