### PR TITLE
request.connection.remote_addr only has IP

### DIFF
--- a/website/pages/docs/enterprise/sentinel/properties.mdx
+++ b/website/pages/docs/enterprise/sentinel/properties.mdx
@@ -30,7 +30,7 @@ The following properties are available in the `request` namespace.
 
 | Name                     | Type                  | Description                                                                                 |
 | :----------------------- | :-------------------- | :------------------------------------------------------------------------------------------ |
-| `connection.remote_addr` | `string`              | TCP/IP source IP of the client                                                    |
+| `connection.remote_addr` | `string`              | TCP/IP source address of the client                                                    |
 | `data`                   | `map (string -> any)` | Raw request data                                                                            |
 | `operation`              | `string`              | Operation type, e.g. "read" or "update"                                                     |
 | `path`                   | `string`              | Path, with any leading `/` trimmed                                                          |

--- a/website/pages/docs/enterprise/sentinel/properties.mdx
+++ b/website/pages/docs/enterprise/sentinel/properties.mdx
@@ -30,7 +30,7 @@ The following properties are available in the `request` namespace.
 
 | Name                     | Type                  | Description                                                                                 |
 | :----------------------- | :-------------------- | :------------------------------------------------------------------------------------------ |
-| `connection.remote_addr` | `string`              | TCP/IP source address/port of the client                                                    |
+| `connection.remote_addr` | `string`              | TCP/IP source IP of the client                                                    |
 | `data`                   | `map (string -> any)` | Raw request data                                                                            |
 | `operation`              | `string`              | Operation type, e.g. "read" or "update"                                                     |
 | `path`                   | `string`              | Path, with any leading `/` trimmed                                                          |


### PR DESCRIPTION
The request.connection.remote_addr property exposed to Sentinel only has an IP.
It does not include a port.
I tested this in a policy with `print("remote address:", request.connection.remote_addr)` and got back 150.10.0.26.