### PR TITLE
Ui/add primary link

### DIFF
--- a/ui/app/models/replication-attributes.js
+++ b/ui/app/models/replication-attributes.js
@@ -40,6 +40,7 @@ export default Fragment.extend({
   secondaryId: attr('string'),
   primaryClusterAddr: attr('string'),
   knownPrimaryClusterAddrs: attr('array'),
+  primaries: attr('array'),
   state: attr('string'), //stream-wal, merkle-diff, merkle-sync, idle
   lastRemoteWAL: attr('number'),
 

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -55,7 +55,7 @@ export default Component.extend({
   knownPrimaryClusterAddrs: computed('replicationDetails.{knownPrimaryClusterAddrs}', function() {
     return this.replicationDetails.knownPrimaryClusterAddrs;
   }),
-  primaryUiUrl: computed('replicationDetails.{primaries}', function() {
+  primaryUiUrl: computed('replicationDetails.{primaries,knownPrimaryClusterAddrs}', function() {
     return this.replicationDetails.primaries && this.replicationDetails.primaries[0].api_address;
   }),
 });

--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -55,4 +55,7 @@ export default Component.extend({
   knownPrimaryClusterAddrs: computed('replicationDetails.{knownPrimaryClusterAddrs}', function() {
     return this.replicationDetails.knownPrimaryClusterAddrs;
   }),
+  primaryUiUrl: computed('replicationDetails.{primaries}', function() {
+    return this.replicationDetails.primaries && this.replicationDetails.primaries[0].api_address;
+  }),
 });

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -83,7 +83,7 @@
         {{title}}
       </h3>
     </div>
-      {{#if primaryUiUrl}}
+      {{#if (and primaryUiUrl knownPrimaryClusterAddrs)}}
         <div class="grid-item-top-right">
           <a href={{concat primaryUiUrl '/ui/'}} class="toolbar-link" data-test-primary-link>
             View primary cluster

--- a/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
+++ b/ui/lib/core/addon/templates/components/replication-secondary-card.hbs
@@ -78,9 +78,19 @@
       </h2>
     </div>
   {{else}}
-    <h3 class="title is-5 grid-item-top-left card-title">
-      {{title}}
-    </h3>
+    <div class="grid-item-top-left">
+      <h3 class="title is-5 card-title">
+        {{title}}
+      </h3>
+    </div>
+      {{#if primaryUiUrl}}
+        <div class="grid-item-top-right">
+          <a href={{concat primaryUiUrl '/ui/'}} class="toolbar-link" data-test-primary-link>
+            View primary cluster
+            <Icon @glyph='chevron-right' />
+          </a>
+        </div>
+      {{/if}}
     <div class="grid-item-second-row">
       <h6 class="title is-6">
         known_primary_cluster_addrs


### PR DESCRIPTION
# Add link from the Secondary Dashboard to the Primary Cluster's UI

This adds a link in the Primary Cluster card to the primary cluster's UI. It only shows up if we have information about the primary; otherwise the link is not displayed.

![image](https://user-images.githubusercontent.com/903288/85883295-9b325a80-b795-11ea-8188-eb1c88e08e77.png)
