### PR TITLE
ensure primary cluster information displays on initial page load

### DIFF
--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -56,6 +56,6 @@ export default Component.extend({
     return this.replicationDetails.knownPrimaryClusterAddrs;
   }),
   primaryUiUrl: computed('replicationDetails.{primaries,knownPrimaryClusterAddrs}', function() {
-    return this.replicationDetails.primaries && this.replicationDetails.primaries[0].api_address;
+    return this.replicationDetails.primaries.length && this.replicationDetails.primaries[0].api_address;
   }),
 });


### PR DESCRIPTION
This PR fixes a bug in which details about the Primary Cluster didn't display after initially enabling a cluster as a DR Secondary.