### PR TITLE
Fix user name length

### DIFF
--- a/plugins/database/mssql/mssql.go
+++ b/plugins/database/mssql/mssql.go
@@ -43,7 +43,7 @@ func new() *MSSQL {
 	connProducer.Type = msSQLTypeName
 
 	credsProducer := &credsutil.SQLCredentialsProducer{
-		DisplayNameLen: 20,
+		DisplayNameLen: 73,
 		RoleNameLen:    20,
 		UsernameLen:    128,
 		Separator:      "-",


### PR DESCRIPTION
# Overview
The current max display name length (20 chars) cuts off user names. 
# Proposal
After the change https://github.com/hashicorp/vault-plugin-auth-azure/pull/34 the user name will contain user identifier which is a GUID (36 chars) plus the authenticator's portion. If it is not cut off while formulating database user name, it can be used by audit to trace back temporary Vault DB user to the Azure AD user.

Let's calculate max length of the display name's portion. The structure of the user name created by the MSSQL plugin:
v-[DisplayName:?]-[RoleName:20]-[RandomChars:20]-[EpocTimeStamp:10]
(here I put max lengths of segments after ":")
The MS database imposes length of 128 char, which is what specified in the code ("UsernameLen:    128").
Then the portion left for the display name: 128-20-20-10-5(separators) = 73
While GUID portion will only use 36 chars, the authenticator name is be prepended to it.

# Effects on Existing Users
None. Having longer limits will have no effects on existing users.

