### PR TITLE
Re-enable seal migration

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -955,6 +955,11 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, err
 	}
 
+	err = c.adjustForSealMigration(conf.UnwrapSeal)
+	if err != nil {
+		return nil, err
+	}
+
 	return c, nil
 }
 


### PR DESCRIPTION
This PR re-enables seal migration, which was accidentally disabled in a previous PR.