### PR TITLE
Bump internal @hashicorp dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -4,7 +4,7 @@ import ProductDownloader from '@hashicorp/react-product-downloader'
 import Head from 'next/head'
 import HashiHead from '@hashicorp/react-head'
 
-export default function DownloadsPage({ releaseData }) {
+export default function DownloadsPage(props) {
   const changelogUrl = CHANGELOG_URL.length
     ? CHANGELOG_URL
     : `https://github.com/hashicorp/vault/blob/v${VERSION}/CHANGELOG.md`
@@ -14,7 +14,7 @@ export default function DownloadsPage({ releaseData }) {
       <ProductDownloader
         product="Vault"
         version={VERSION}
-        releaseData={releaseData}
+        releaseData={props.releaseData}
         changelog={changelogUrl}
       />
     </div>


### PR DESCRIPTION
- 🎟️ [Asana](https://app.asana.com/0/346384260719996/1182163857683059/f)
- 🔍 [Preview `/docs`](https://deploy-preview-9364--vault-www.netlify.app/docs)
- 🔍 [Production `/docs`](https://www.vaultproject.io/docs)
- 🔍 [Preview `/downloads`](https://deploy-preview-9364--vault-www.netlify.app/downloads)
- 🔍 [Production `/downloads`](https://www.vaultproject.io/downloads)

This PR patch bumps internal Hashicorp dependencies. The changes this PR is after in particular are from `@hashicorp/react-product-downloader`, where a small note about Fastly appears above its logo, and `@hashicorp/react-docs-sidenav` where the contrast of the search filter has been increased.

In order to bump these dependencies, other changes make their way into the fold. One change is the addition of `website/.stylelintrc.js`, a file generated by the linting that ships with `@hashicorp/nextjs-scripts`. The other change is to `website/pages/downloads/index.jsx`, which receives download data a little differently.