### PR TITLE
Backport 1.5.x: Update TTL picker on add replication secondary (#9271)

### DIFF
--- a/ui/lib/core/stories/ttl-picker2.md
+++ b/ui/lib/core/stories/ttl-picker2.md
@@ -21,6 +21,7 @@ TtlPicker2 components are used to enable and select time to live values. Use thi
 | recalculationTimeout | <code>Number</code>   | <code>5000</code>                                             | This is the time, in milliseconds, that `recalculateSeconds` will be be true after time is updated                               |
 | initialValue         | <code>String</code>   | <code></code>                                                 | This is the value set initially (particularly from a string like '30h')                                                          |
 | initialEnabled       | <code>Boolean</code>  | <code></code>                                                 | Set this value if you want the toggle on when component is mounted                                                               |
+| changeOnInit         | <code>Boolean</code>  | <code>false</code>                                            | set this value if you'd like the passed onChange function to be called on component initialization                               |
 
 **Example**
 

--- a/ui/lib/replication/addon/controllers/mode/secondaries/add.js
+++ b/ui/lib/replication/addon/controllers/mode/secondaries/add.js
@@ -1,3 +1,9 @@
 import ReplicationController from 'replication/controllers/application';
 
-export default ReplicationController.extend();
+export default ReplicationController.extend({
+  actions: {
+    updateTtl: function(ttl) {
+      this.set('ttl', `${ttl.seconds}s`);
+    },
+  },
+});

--- a/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/add.hbs
@@ -18,11 +18,14 @@
     </p>
   </div>
   <div class="field">
-    {{!-- TODO fix so it defaults to 30s like in other places or replace with new TTL picker --}}
-    {{ttl-picker onChange=(action (mut ttl)) initialValue="30m" class="is-marginless"}}
-    <p class="help has-text-grey">
-      This is the Time To Live for the generated secondary token. After this period, the generated token will no longer be valid.
-    </p>
+    <TtlPicker2
+      @initialValue="30m"
+      @label="Time to Live (TTL) for generated secondary token"
+      @helperTextDisabled="If not set, the default value (30 minutes) will be used"
+      @helperTextEnabled="After this period, the generated token will no longer be valid."
+      @onChange={{action "updateTtl"}}
+      @changeOnInit={{true}}
+    />
   </div>
   {{#if (eq replicationMode "performance")}}
     <PathFilterConfigList
@@ -40,7 +43,7 @@
         >
         Generate token
       </button>
-    </div>
+      </div>
     <div class="control">
       {{#link-to "mode.secondaries" replicationMode class="button"}}
         Cancel

--- a/ui/tests/integration/components/ttl-picker2-test.js
+++ b/ui/tests/integration/components/ttl-picker2-test.js
@@ -116,7 +116,7 @@ module('Integration | Component | ttl-picker2', function(hooks) {
     );
   });
 
-  test('it sets default value to seconds of parsed value when set', async function(assert) {
+  test('it sets default value to time and unit passed', async function(assert) {
     let changeSpy = sinon.spy();
     this.set('onChange', changeSpy);
     await render(hbs`
@@ -128,8 +128,27 @@ module('Integration | Component | ttl-picker2', function(hooks) {
         @unit="d"
       />
     `);
-    assert.dom('[data-test-ttl-value]').hasValue('7200', 'time value is initialValue as seconds');
-    assert.dom('[data-test-select="ttl-unit"]').hasValue('s', 'unit is seconds');
+    assert.dom('[data-test-ttl-value]').hasValue('2', 'time value is 2');
+    assert.dom('[data-test-select="ttl-unit"]').hasValue('h', 'unit is hours');
+    assert.ok(changeSpy.notCalled, 'it does not call onChange after render when changeOnInit is not set');
+  });
+
+  test('it is disabled on init if initialEnabled is false', async function(assert) {
+    let changeSpy = sinon.spy();
+    this.set('onChange', changeSpy);
+    await render(hbs`
+      <TtlPicker2
+        @label="inittest"
+        @onChange={{onChange}}
+        @initialValue="100m"
+        @initialEnabled={{false}}
+      />
+    `);
+    assert.dom('[data-test-ttl-value]').doesNotExist('Value is not shown on mount');
+    assert.dom('[data-test-ttl-unit]').doesNotExist('Unit is not shown on mount');
+    await click('[data-test-toggle-input="inittest"]');
+    assert.dom('[data-test-ttl-value]').hasValue('100', 'time after toggle is 100');
+    assert.dom('[data-test-select="ttl-unit"]').hasValue('m', 'Unit is minutes after toggle');
   });
 
   test('it is enabled on init if initialEnabled is true', async function(assert) {
@@ -143,8 +162,8 @@ module('Integration | Component | ttl-picker2', function(hooks) {
         @initialEnabled={{true}}
       />
     `);
-    assert.dom('[data-test-ttl-value]').hasValue('6000', 'time value is initialValue as seconds');
-    assert.dom('[data-test-ttl-unit]').exists('Unit is shown on mount');
+    assert.dom('[data-test-ttl-value]').hasValue('100', 'time is shown on mount');
+    assert.dom('[data-test-select="ttl-unit"]').hasValue('m', 'Unit is shown on mount');
     await click('[data-test-toggle-input="inittest"]');
     assert.dom('[data-test-ttl-value]').doesNotExist('Value no longer shows after toggle');
     assert.dom('[data-test-ttl-unit]').doesNotExist('Unit no longer shows after toggle');
@@ -161,7 +180,31 @@ module('Integration | Component | ttl-picker2', function(hooks) {
         @initialEnabled="true"
       />
     `);
-    assert.dom('[data-test-ttl-value]').hasValue('6000', 'time value is initialValue as seconds');
+    assert.dom('[data-test-ttl-value]').hasValue('100', 'time value is shown on mount');
     assert.dom('[data-test-ttl-unit]').exists('Unit is shown on mount');
+    assert.dom('[data-test-select="ttl-unit"]').hasValue('m', 'Unit matches what is passed in');
+  });
+
+  test('it calls onChange on init when rendered if changeOnInit is true', async function(assert) {
+    let changeSpy = sinon.spy();
+    this.set('onChange', changeSpy);
+    await render(hbs`
+      <TtlPicker2
+        @label="changeOnInitTest"
+        @onChange={{onChange}}
+        @initialValue="100m"
+        @initialEnabled="true"
+        @changeOnInit={{true}}
+      />
+    `);
+    assert.ok(
+      changeSpy.calledWith({
+        enabled: true,
+        seconds: 6000,
+        timeString: '100m',
+      }),
+      'Seconds value is recalculated based on time and unit'
+    );
+    assert.ok(changeSpy.calledOnce, 'it calls the passed onChange after render');
   });
 });


### PR DESCRIPTION
This change updates the TTL picker to the new version to match most updated designs. The component also allows the default value to be more obvious.

BEFORE
<img width="1552" alt="ttl-secondary-old" src="https://user-images.githubusercontent.com/16182107/86276266-36627000-bb9a-11ea-9587-3481c87025eb.png">

AFTER (default)
<img width="1552" alt="replication-secondary-ttl-default" src="https://user-images.githubusercontent.com/16182107/86276323-4d08c700-bb9a-11ea-9321-844ef593de30.png">

AFTER (enabled/custom)
<img width="1552" alt="replication-secondary-ttl-enabled" src="https://user-images.githubusercontent.com/16182107/86276351-585bf280-bb9a-11ea-8c7f-24e264a12d7a.png">
