### PR TITLE
plugin: fix process leak when Setup() fails

### DIFF
--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -56,6 +56,7 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	}
 	err = raw.Setup(ctx, conf)
 	if err != nil {
+		raw.Cleanup(ctx)
 		return nil, err
 	}
 	// Get SpecialPaths and BackendType
@@ -108,6 +109,7 @@ func (b *PluginBackend) startBackend(ctx context.Context, storage logical.Storag
 	}
 	err = nb.Setup(ctx, b.config)
 	if err != nil {
+		nb.Cleanup(ctx)
 		return err
 	}
 


### PR DESCRIPTION
We've noticed some leftover processes from vault plugins on our boxes. Some
of them were even left over from previous instances of the service and reparented
to init.  This could cause issues if too many of them accumulate.

When running with TRACE logging the logs showed that there was an error return by
the call to Setup() the plugin. Looking through the code it looks like we do not
call Cleanup() in that case.

Before the patch our logs used to show this:
```
{"@level":"trace","@message":"setup","@module":"aplugin","@timestamp":"2020-06-30T11:42:42.110935-04:00","status":"started","transport":"gRPC"}
{"@level":"trace","@message":"setup","@module":"aplugin,"@timestamp":"2020-06-30T11:42:42.110986-04:00","err":"rpc error: code = Canceled desc = context canceled","status":"finished","took":50151,"transport":"gRPC"}
```
and after the patch we get the trace that the plugin has existed:
```
{"@level":"trace","@message":"setup","@module":"aplugin","@timestamp":"2020-07-02T05:27:02.065347-04:00","status":"started","transport":"gRPC"}
{"@level":"trace","@message":"setup","@module":"aplugin,"@timestamp":"2020-07-02T05:27:02.065386-04:00","err":"rpc error: code = Canceled desc = context canceled","status":"finished","took":39222,"transport":"gRPC"}
{"@level":"trace","@message":"cleanup","@module":"aplugin","@timestamp":"2020-07-02T05:27:02.065410-04:00","status":"started","transport":"gRPC"}
{"@level":"trace","@message":"cleanup","@module":"aplugin","@timestamp":"2020-07-02T05:27:02.065883-04:00","status":"finished","took":471538,"transport":"gRPC"}
{"@level":"warn","@message":"error closing client during Kill","@module":"aplugin","@timestamp":"2020-07-02T05:27:02.065929-04:00","err":"rpc error: code = Canceled desc = grpc: the client connection is closing"}
{"@level":"debug","@message":"plugin process exited","@module":"aaplugin","@timestamp":"2020-07-02T05:27:02.118913-04:00","error":"signal: killed","path":"...","pid":92276}
```