### PR TITLE
Backport 1.5.0: Add dr_operation_token_primary to hashed submit value (#9370)

### DIFF
--- a/ui/lib/core/addon/templates/components/replication-action-update-primary.hbs
+++ b/ui/lib/core/addon/templates/components/replication-action-update-primary.hbs
@@ -89,7 +89,7 @@
   <footer class="modal-card-foot modal-card-foot-outlined">
     <button
       class="button is-primary"
-      onclick={{action "onSubmit" "update-primary" model.replicationAttrs.modeForUrl (hash token=token primary_api_addr=primary_api_addr ca_path=ca_path ca_file=ca_file)}}
+      onclick={{action "onSubmit" "update-primary" model.replicationAttrs.modeForUrl (hash token=token dr_operation_token_primary=dr_operation_token_primary primary_api_addr=primary_api_addr ca_path=ca_path ca_file=ca_file)}}
       data-test-confirm-action-trigger
     >
       Update


### PR DESCRIPTION
This PR fixes a bug where the Update Primary action wasn't working from a DR secondary. The custom DR operation token value was not being passed to the submit action. Link to original PR: https://github.com/hashicorp/vault/pull/9370