### PR TITLE
command/agent/template: pass along TLSServerName

### DIFF
--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -221,12 +221,13 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		skipVerify := sc.VaultConf.TLSSkipVerify
 		verify := !skipVerify
 		conf.Vault.SSL = &ctconfig.SSLConfig{
-			Enabled: pointerutil.BoolPtr(true),
-			Verify:  &verify,
-			Cert:    &sc.VaultConf.ClientCert,
-			Key:     &sc.VaultConf.ClientKey,
-			CaCert:  &sc.VaultConf.CACert,
-			CaPath:  &sc.VaultConf.CAPath,
+			Enabled:    pointerutil.BoolPtr(true),
+			Verify:     &verify,
+			Cert:       &sc.VaultConf.ClientCert,
+			Key:        &sc.VaultConf.ClientKey,
+			CaCert:     &sc.VaultConf.CACert,
+			CaPath:     &sc.VaultConf.CAPath,
+			ServerName: &sc.VaultConf.TLSServerName,
 		}
 	}
 


### PR DESCRIPTION
When preparing the consul-template Vault config, the provided
TLSServerName (in the Vault agent config as tls_server_name) was not
being passed along to the consul-template Vault config.

Using the VAULT_TLS_SERVER_NAME environment variable was working since
the consul-template config building does consider it.

To fix that, pass it along when setting up the consul-template
config. Add a test which verifies basic TLS connectivity to Vault,
including passing along the server name.

Fixes https://github.com/hashicorp/vault/issues/9183