### PR TITLE
Set PKI CA cert default for ttl

### DIFF
--- a/ui/app/models/pki-certificate.js
+++ b/ui/app/models/pki-certificate.js
@@ -53,6 +53,7 @@ export default DS.Model.extend({
   ttl: attr({
     label: 'TTL',
     editType: 'ttl',
+    defaultValue: '720h',
   }),
 
   format: attr('string', {


### PR DESCRIPTION
The open api was missing the default ttl for when a user created a PKI ca certification.  This PR fixes that.

Per the [documentation](https://www.vaultproject.io/docs/secrets/pki), the default should be 30day (e.g. 720h). 

**Gif before:**
![withoutfix](https://user-images.githubusercontent.com/6618863/86640737-cbe57180-bf97-11ea-834b-65ac8ddd9072.gif)

**Gif of with fix:**
![withfix](https://user-images.githubusercontent.com/6618863/86640591-aa848580-bf97-11ea-9193-a458b5b5f1d2.gif)


