### PR TITLE
Backport 1.5.x: set default to 30 days for pki ca cert (#9405)

### DIFF
--- a/ui/app/models/pki-certificate.js
+++ b/ui/app/models/pki-certificate.js
@@ -53,6 +53,7 @@ export default DS.Model.extend({
   ttl: attr({
     label: 'TTL',
     editType: 'ttl',
+    defaultValue: '720h',
   }),
 
   format: attr('string', {


### PR DESCRIPTION
Backport for PR [9405](https://github.com/hashicorp/vault/pull/9405)