### PR TITLE
audit: conditionally call reflect.Value.Set

### DIFF
--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -350,8 +350,11 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 		si := int(w.csKey[len(w.cs)-1].Int())
 		s.Slice(si, si+1).Index(0).Set(resultVal)
 	default:
-		// Otherwise, we should be addressable
-		setV.Set(resultVal)
+		// Otherwise, we set it if if value is both addressable
+		// and is not an from an unexported field.
+		if setV.CanSet() {
+			setV.Set(resultVal)
+		}
 	}
 
 	return nil

--- a/audit/hashstructure.go
+++ b/audit/hashstructure.go
@@ -351,7 +351,7 @@ func (w *hashWalker) Primitive(v reflect.Value) error {
 		s.Slice(si, si+1).Index(0).Set(resultVal)
 	default:
 		// Otherwise, we set it if if value is both addressable
-		// and is not an from an unexported field.
+		// and is not from an unexported field.
 		if setV.CanSet() {
 			setV.Set(resultVal)
 		}

--- a/audit/hashstructure_test.go
+++ b/audit/hashstructure_test.go
@@ -179,6 +179,12 @@ func (o *testOptMarshaler) MarshalJSONWithOptions(options *logical.MarshalOption
 
 var _ logical.OptMarshaler = &testOptMarshaler{}
 
+type testStruct struct {
+	S       string
+	I       int
+	private string
+}
+
 func TestHashRequest(t *testing.T) {
 	cases := []struct {
 		Input           *logical.Request
@@ -193,6 +199,7 @@ func TestHashRequest(t *testing.T) {
 					"baz":              "foobar",
 					"private_key_type": certutil.PrivateKeyType("rsa"),
 					"om":               &testOptMarshaler{S: "bar", I: 1},
+					"ts":               &testStruct{S: "bar", I: 1, private: "foo"},
 				},
 			},
 			&logical.Request{
@@ -201,6 +208,7 @@ func TestHashRequest(t *testing.T) {
 					"baz":              "foobar",
 					"private_key_type": "hmac-sha256:995230dca56fffd310ff591aa404aab52b2abb41703c787cfa829eceb4595bf1",
 					"om":               json.RawMessage(`{"S":"hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317","I":1}`),
+					"ts":               &testStruct{S: "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317", I: 1},
 				},
 			},
 			[]string{"baz"},
@@ -250,6 +258,7 @@ func TestHashResponse(t *testing.T) {
 					// a known fixed value.
 					"bar": now,
 					"om":  &testOptMarshaler{S: "bar", I: 1},
+					"ts":  &testStruct{S: "bar", I: 1, private: "foo"},
 				},
 				WrapInfo: &wrapping.ResponseWrapInfo{
 					TTL:             60,
@@ -265,6 +274,7 @@ func TestHashResponse(t *testing.T) {
 					"baz": "foobar",
 					"bar": now.Format(time.RFC3339Nano),
 					"om":  json.RawMessage(`{"S":"hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317","I":1}`),
+					"ts":  &testStruct{S: "hmac-sha256:f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317", I: 1},
 				},
 				WrapInfo: &wrapping.ResponseWrapInfo{
 					TTL:             60,
@@ -298,7 +308,7 @@ func TestHashResponse(t *testing.T) {
 			t.Fatalf("err: %s\n\n%s", err, input)
 		}
 		if diff := deep.Equal(out, tc.Output); len(diff) > 0 {
-			t.Fatalf("bad:\nInput:\n%s\nDiff:\n%#v", input, diff)
+			t.Fatalf("bad:\nInput:\n%s\nOutput:\n%#v\nDiff:\n%#v", input, out, diff)
 		}
 	}
 }


### PR DESCRIPTION
This change updates the call on `reflect.Value.Set` to be executed only if the value is addressable _and_ obtained by the use of unexported struct fields. Since these values are omitted when serialized and only exported fields remain thereafter anyways, it should be fine that they are left out of the resulting hashed request/response.

It resolves potential panics for cases were the request or response data might contain typed structs that contain unexported fields.

```
=== RUN   TestHashResponse
--- FAIL: TestHashResponse (0.00s)
panic: reflect: reflect.flag.mustBeAssignable using value obtained using unexported field [recovered]
	panic: reflect: reflect.flag.mustBeAssignable using value obtained using unexported field
goroutine 18 [running]:
testing.tRunner.func1.1(0x160c4e0, 0xc0002f0d70)
	/usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:940 +0x2f5
testing.tRunner.func1(0xc0002c6120)
	/usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:943 +0x3f9
panic(0x160c4e0, 0xc0002f0d70)
	/usr/local/Cellar/go/1.14.4/libexec/src/runtime/panic.go:969 +0x166
reflect.flag.mustBeAssignableSlow(0x1b8)
	/usr/local/Cellar/go/1.14.4/libexec/src/reflect/value.go:244 +0x1b9
reflect.flag.mustBeAssignable(...)
	/usr/local/Cellar/go/1.14.4/libexec/src/reflect/value.go:234
reflect.Value.Set(0x160c4e0, 0xc000282618, 0x1b8, 0x160c4e0, 0xc0002f0d60, 0x98)
	/usr/local/Cellar/go/1.14.4/libexec/src/reflect/value.go:1526 +0x3b
github.com/hashicorp/vault/audit.(*hashWalker).Primitive(0xc0002a4280, 0x160c4e0, 0xc000282618, 0x1b8, 0xc0002a4280, 0x168d101)
	/Users/calvin/hc/vault/audit/hashstructure.go:355 +0x427
github.com/mitchellh/reflectwalk.walkPrimitive(...)
	/Users/calvin/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.1/reflectwalk.go:252
github.com/mitchellh/reflectwalk.walk(0x160c4e0, 0xc000282618, 0x1b8, 0x16b1080, 0xc0002a4280, 0x1809b01, 0x160c4e0)
	/Users/calvin/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.1/reflectwalk.go:179 +0x29f
github.com/mitchellh/reflectwalk.walkStruct(0x168d140, 0xc000282600, 0x199, 0x16b1080, 0xc0002a4280, 0x100, 0xc0000d1920)
	/Users/calvin/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.1/reflectwalk.go:386 +0x3d5
github.com/mitchellh/reflectwalk.walk(0x1631ba0, 0xc0002f0d00, 0x94, 0x16b1080, 0xc0002a4280, 0x98, 0x1631ba0)
	/Users/calvin/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.1/reflectwalk.go:188 +0x564
github.com/mitchellh/reflectwalk.walkMap(0x1642f00, 0xc000282540, 0x15, 0x16b1080, 0xc0002a4280, 0x104de00, 0xc00028bbb8)
	/Users/calvin/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.1/reflectwalk.go:234 +0x331
github.com/mitchellh/reflectwalk.walk(0x1642f00, 0xc000282540, 0x15, 0x16b1080, 0xc0002a4280, 0xaf6fba01, 0x76e2267bd181ba7)
	/Users/calvin/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.1/reflectwalk.go:182 +0x4be
github.com/mitchellh/reflectwalk.Walk(0x1642f00, 0xc000282540, 0x16b1080, 0xc0002a4280, 0x0, 0x0)
	/Users/calvin/go/pkg/mod/github.com/mitchellh/reflectwalk@v1.0.1/reflectwalk.go:92 +0x17a
github.com/hashicorp/vault/audit.HashStructure(...)
	/Users/calvin/hc/vault/audit/hashstructure.go:177
github.com/hashicorp/vault/audit.hashMap(0xc000286650, 0xc000282540, 0xc000286570, 0x1, 0x1, 0xc000282540, 0x0)
	/Users/calvin/hc/vault/audit/hashstructure.go:97 +0x28e
github.com/hashicorp/vault/audit.HashResponse(0xc0002842c0, 0xc0002920a0, 0xc0000d1e01, 0xc000286570, 0x1, 0x1, 0x190, 0x0, 0x1c03e9b)
	/Users/calvin/hc/vault/audit/hashstructure.go:132 +0x258
github.com/hashicorp/vault/audit.TestHashResponse(0xc0002c6120)
	/Users/calvin/hc/vault/audit/hashstructure_test.go:304 +0xb03
testing.tRunner(0xc0002c6120, 0x1733ea0)
	/usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:991 +0xdc
created by testing.(*T).Run
	/usr/local/Cellar/go/1.14.4/libexec/src/testing/testing.go:1042 +0x357
Process finished with exit code 1
```