### PR TITLE
Backport 1.5: fix ui tests (#9438)

### DIFF
--- a/ui/lib/core/addon/components/replication-secondary-card.js
+++ b/ui/lib/core/addon/components/replication-secondary-card.js
@@ -56,6 +56,9 @@ export default Component.extend({
     return this.replicationDetails.knownPrimaryClusterAddrs;
   }),
   primaryUiUrl: computed('replicationDetails.{primaries,knownPrimaryClusterAddrs}', function() {
-    return this.replicationDetails.primaries.length && this.replicationDetails.primaries[0].api_address;
+    const { replicationDetails } = this;
+    if (replicationDetails.primaries && replicationDetails.primaries.length) {
+      return this.replicationDetails.primaries[0].api_address;
+    }
   }),
 });

--- a/ui/tests/integration/components/info-table-test.js
+++ b/ui/tests/integration/components/info-table-test.js
@@ -7,7 +7,7 @@ const TITLE = 'My Table';
 const HEADER = 'Cool Header';
 const ITEMS = ['https://127.0.0.1:8201', 'hello', 3];
 
-module('Integration | Enterprise | Component | InfoTable', function(hooks) {
+module('Integration | Component | InfoTable', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {

--- a/ui/tests/integration/components/replication-dashboard-test.js
+++ b/ui/tests/integration/components/replication-dashboard-test.js
@@ -24,7 +24,7 @@ const IS_REINDEXING = {
   state: 'running',
 };
 
-module('Integration | Enterprise | Component | replication-dashboard', function(hooks) {
+module('Integration | Component | replication-dashboard', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {

--- a/ui/tests/integration/components/replication-header-test.js
+++ b/ui/tests/integration/components/replication-header-test.js
@@ -17,7 +17,7 @@ const DATA = {
 const TITLE = 'Disaster Recovery';
 const SECONDARY_ID = '123abc';
 
-module('Integration | Enterprise | Component | replication-header', function(hooks) {
+module('Integration | Component | replication-header', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {

--- a/ui/tests/integration/components/replication-page-test.js
+++ b/ui/tests/integration/components/replication-page-test.js
@@ -12,7 +12,7 @@ const MODEL = {
   },
 };
 
-module('Integration | Enterprise | Component | replication-page', function(hooks) {
+module('Integration | Component | replication-page', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {

--- a/ui/tests/integration/components/replication-secondary-card-test.js
+++ b/ui/tests/integration/components/replication-secondary-card-test.js
@@ -17,7 +17,7 @@ const REPLICATION_DETAILS = {
   ],
 };
 
-module('Integration | Enterprise | Component | replication-secondary-card', function(hooks) {
+module('Integration | Component | replication-secondary-card', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {

--- a/ui/tests/integration/components/replication-summary-card-test.js
+++ b/ui/tests/integration/components/replication-summary-card-test.js
@@ -18,7 +18,7 @@ const REPLICATION_DETAILS = {
   },
 };
 
-module('Integration | Enterprise | Component | replication-summary-card', function(hooks) {
+module('Integration | Component | replication-summary-card', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {


### PR DESCRIPTION
Backport to https://github.com/hashicorp/vault/pull/9438, which fixes a few failing UI component tests.