### PR TITLE
Backport 1.5: Modifying base can break tests that share the same coreConfig passed

### DIFF
--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1485,10 +1485,6 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		}
 	}
 
-	if base != nil {
-		base.Physical = coreConfig.Physical
-	}
-
 	// Clustering setup
 	for i := 0; i < numCores; i++ {
 		testCluster.setupClusterListener(t, i, cores[i], coreConfigs[i], opts, listeners[i], handlers[i])
@@ -1522,7 +1518,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 		(*tcc.ReloadFuncs)["listener|tcp"] = []reloadutil.ReloadFunc{certGetters[i].Reload}
 		tcc.ReloadFuncsLock.Unlock()
 
-		testAdjustUnderlyingStorage(base, tcc)
+		testAdjustUnderlyingStorage(tcc)
 
 		ret = append(ret, tcc)
 	}
@@ -1635,7 +1631,7 @@ func (cluster *TestCluster) StartCore(t testing.T, idx int, opts *TestClusterOpt
 
 	tcc.Client = cluster.getAPIClient(t, opts, tcc.Listeners[0].Address.Port, tcc.TLSConfig)
 
-	testAdjustUnderlyingStorage(cluster.base, tcc)
+	testAdjustUnderlyingStorage(tcc)
 	testExtraTestCoreSetup(t, cluster.priKey, tcc)
 
 	// Start listeners

--- a/vault/testing_util.go
+++ b/vault/testing_util.go
@@ -9,6 +9,6 @@ import (
 func testGenerateCoreKeys() (interface{}, interface{}, error)         { return nil, nil, nil }
 func testGetLicensingConfig(interface{}) *LicensingConfig             { return &LicensingConfig{} }
 func testExtraTestCoreSetup(testing.T, interface{}, *TestClusterCore) {}
-func testAdjustUnderlyingStorage(_ *CoreConfig, tcc *TestClusterCore) {
+func testAdjustUnderlyingStorage(tcc *TestClusterCore) {
 	tcc.UnderlyingStorage = tcc.physical
 }


### PR DESCRIPTION
…to NewTestCluster.