### PR TITLE
raft/test: fix snapshot peers race test by using committed and applie…

### DIFF
--- a/physical/raft/snapshot_test.go
+++ b/physical/raft/snapshot_test.go
@@ -251,14 +251,17 @@ func TestRaft_Snapshot_Peers(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	commitIdx := raft1.CommittedIndex()
+
 	// Add raft2 to the cluster
 	addPeer(t, raft1, raft2)
 
-	// TODO: remove sleeps from these tests
-	time.Sleep(10 * time.Second)
+	ensureCommitApplied(t, commitIdx, raft2)
 
 	// Make sure the snapshot was applied correctly on the follower
-	compareDBs(t, raft1.fsm.db, raft2.fsm.db, false)
+	if err := compareDBs(t, raft1.fsm.db, raft2.fsm.db, false); err != nil {
+		t.Fatal(err)
+	}
 
 	// Write some more data
 	for i := 1000; i < 2000; i++ {
@@ -276,15 +279,34 @@ func TestRaft_Snapshot_Peers(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	commitIdx = raft1.CommittedIndex()
+
 	// Add raft3 to the cluster
 	addPeer(t, raft1, raft3)
 
-	// TODO: remove sleeps from these tests
-	time.Sleep(10 * time.Second)
+	ensureCommitApplied(t, commitIdx, raft2)
+	ensureCommitApplied(t, commitIdx, raft3)
 
 	// Make sure all stores are the same
 	compareFSMs(t, raft1.fsm, raft2.fsm)
 	compareFSMs(t, raft1.fsm, raft3.fsm)
+}
+
+func ensureCommitApplied(t *testing.T, leaderCommitIdx uint64, backend *RaftBackend) {
+	t.Helper()
+
+	timeout := time.Now().Add(10 * time.Second)
+	for {
+		if time.Now().After(timeout) {
+			t.Fatal("timeout reached while verifying applied index on raft backend")
+		}
+
+		if backend.AppliedIndex() >= leaderCommitIdx {
+			break
+		}
+
+		time.Sleep(1 * time.Second)
+	}
 }
 
 func TestRaft_Snapshot_Restart(t *testing.T) {


### PR DESCRIPTION
…d indexes

Fixes a data race that can occur in `TestRaft_Snapshot_Peers` which happens when we try to compare the follower's FSM database as the snapshot is being restored.

```
==================
WARNING: DATA RACE
Read at 0x00c000126760 by goroutine 77:
  github.com/hashicorp/vault/physical/raft.TestRaft_Snapshot_Peers()
      /go/src/github.com/hashicorp/vault/physical/raft/snapshot_test.go:261 +0x647
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb

Previous write at 0x00c000126760 by goroutine 164:
  github.com/hashicorp/vault/physical/raft.(*FSM).openDBFile()
      /go/src/github.com/hashicorp/vault/physical/raft/fsm.go:176 +0x1ba
  github.com/hashicorp/vault/physical/raft.(*FSM).Restore()
      /go/src/github.com/hashicorp/vault/physical/raft/fsm.go:642 +0x71d
  github.com/hashicorp/vault/vendor/github.com/hashicorp/go-raftchunking.(*ChunkingFSM).Restore()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/go-raftchunking/fsm.go:164 +0x68
  github.com/hashicorp/vault/vendor/github.com/hashicorp/go-raftchunking.(*ChunkingBatchingFSM).Restore()
      <autogenerated>:1 +0x75
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.(*Raft).runFSM.func3()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/fsm.go:181 +0x3c3
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.(*Raft).runFSM()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/fsm.go:222 +0x473
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.(*Raft).runFSM-fm()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/fsm.go:69 +0x41
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.(*raftState).goFunc.func1()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/state.go:146 +0x6e

Goroutine 77 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:98 +0x223

Goroutine 164 (running) created at:
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.(*raftState).goFunc()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/state.go:144 +0x73
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.NewRaft()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/api.go:563 +0x167b
  github.com/hashicorp/vault/physical/raft.(*RaftBackend).SetupCluster()
      /go/src/github.com/hashicorp/vault/physical/raft/raft.go:677 +0xa4c
  github.com/hashicorp/vault/physical/raft.addPeer()
      /go/src/github.com/hashicorp/vault/physical/raft/snapshot_test.go:48 +0x364
  github.com/hashicorp/vault/physical/raft.TestRaft_Snapshot_Peers()
      /go/src/github.com/hashicorp/vault/physical/raft/snapshot_test.go:255 +0x59e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb
==================
==================
WARNING: DATA RACE
Write at 0x00c000306bb8 by goroutine 77:
  sync/atomic.CompareAndSwapInt32()
      /usr/local/go/src/runtime/race_amd64.s:293 +0xb
  sync.(*Mutex).Lock()
      /usr/local/go/src/sync/mutex.go:74 +0x49
  github.com/hashicorp/vault/vendor/go.etcd.io/bbolt.(*DB).beginTx()
      /go/src/github.com/hashicorp/vault/vendor/go.etcd.io/bbolt/db.go:551 +0x61
  github.com/hashicorp/vault/vendor/go.etcd.io/bbolt.(*DB).Begin()
      /go/src/github.com/hashicorp/vault/vendor/go.etcd.io/bbolt/db.go:544 +0x9e
  github.com/hashicorp/vault/vendor/go.etcd.io/bbolt.(*DB).View()
      /go/src/github.com/hashicorp/vault/vendor/go.etcd.io/bbolt/db.go:709 +0x60
  github.com/hashicorp/vault/physical/raft.compareDBs()
      /go/src/github.com/hashicorp/vault/physical/raft/raft_test.go:190 +0x18b
  github.com/hashicorp/vault/physical/raft.TestRaft_Snapshot_Peers()
      /go/src/github.com/hashicorp/vault/physical/raft/snapshot_test.go:261 +0x67b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb

Previous write at 0x00c000306bb8 by goroutine 164:
  github.com/hashicorp/vault/vendor/go.etcd.io/bbolt.Open()
      /go/src/github.com/hashicorp/vault/vendor/go.etcd.io/bbolt/db.go:179 +0x71
  github.com/hashicorp/vault/physical/raft.(*FSM).openDBFile()
      /go/src/github.com/hashicorp/vault/physical/raft/fsm.go:130 +0x13e
  github.com/hashicorp/vault/physical/raft.(*FSM).Restore()
      /go/src/github.com/hashicorp/vault/physical/raft/fsm.go:642 +0x71d
  github.com/hashicorp/vault/vendor/github.com/hashicorp/go-raftchunking.(*ChunkingFSM).Restore()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/go-raftchunking/fsm.go:164 +0x68
  github.com/hashicorp/vault/vendor/github.com/hashicorp/go-raftchunking.(*ChunkingBatchingFSM).Restore()
      <autogenerated>:1 +0x75
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.(*Raft).runFSM.func3()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/fsm.go:181 +0x3c3
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.(*Raft).runFSM()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/fsm.go:222 +0x473
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.(*Raft).runFSM-fm()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/fsm.go:69 +0x41
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.(*raftState).goFunc.func1()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/state.go:146 +0x6e

Goroutine 77 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:98 +0x223

Goroutine 164 (running) created at:
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.(*raftState).goFunc()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/state.go:144 +0x73
  github.com/hashicorp/vault/vendor/github.com/hashicorp/raft.NewRaft()
      /go/src/github.com/hashicorp/vault/vendor/github.com/hashicorp/raft/api.go:563 +0x167b
  github.com/hashicorp/vault/physical/raft.(*RaftBackend).SetupCluster()
      /go/src/github.com/hashicorp/vault/physical/raft/raft.go:677 +0xa4c
  github.com/hashicorp/vault/physical/raft.addPeer()
      /go/src/github.com/hashicorp/vault/physical/raft/snapshot_test.go:48 +0x364
  github.com/hashicorp/vault/physical/raft.TestRaft_Snapshot_Peers()
      /go/src/github.com/hashicorp/vault/physical/raft/snapshot_test.go:255 +0x59e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb
==================
```