### PR TITLE
Update Alert banner message-body to match design system

### DIFF
--- a/ui/app/styles/core.scss
+++ b/ui/app/styles/core.scss
@@ -15,6 +15,7 @@
 @import 'bulma/switch';
 
 // Override Bulma details where appropriate
+@import './core/alert-banner';
 @import './core/generic';
 @import './core/box';
 @import './core/breadcrumb';

--- a/ui/app/styles/core/alert-banner.scss
+++ b/ui/app/styles/core/alert-banner.scss
@@ -1,4 +1,3 @@
-// To match the updated design system, alert banner messages should have black text
 .alert-banner-message-body {
   border: 0;
   margin-top: $spacing-xxs;

--- a/ui/app/styles/core/alert-banner.scss
+++ b/ui/app/styles/core/alert-banner.scss
@@ -1,0 +1,7 @@
+// To match the updated design system, alert banner messages should have black text
+.alert-banner-message-body {
+  border: 0;
+  margin-top: $spacing-xxs;
+
+  color: $black;
+}

--- a/ui/lib/core/addon/templates/components/alert-banner.hbs
+++ b/ui/lib/core/addon/templates/components/alert-banner.hbs
@@ -31,7 +31,7 @@
           {{/if}}
         </div>
         {{#if @message}}
-          <p class="message-body">
+          <p class="alert-banner-message-body">
             {{@message}}
           </p>
         {{/if}}


### PR DESCRIPTION
The new design system has the alert banner text black.  This PR updates that. 

To have the least impact on other elements/components using the `.message-body` class I created a new .scss file for alert-banners and renamed the class it's using.  This keeps the change contained to the `alert-banner` component.

**Here are the design system pictures:**
<img width=500 src="https://user-images.githubusercontent.com/6618863/87331428-2bdb9b00-c4f7-11ea-8c27-7f01cfdafd52.png">

**Here is the before the fix:**
<img width=500 src="https://user-images.githubusercontent.com/6618863/87331469-3ac24d80-c4f7-11ea-89ea-b776d6d1d543.png">

**Here is the fix with the PR:**
<img width=500 src="https://user-images.githubusercontent.com/6618863/87331132-c12a5f80-c4f6-11ea-8827-f177afa4eeaf.png">





