### PR TITLE
Add truthy check for data.policies before calling 'includes' on it

### DIFF
--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -313,7 +313,7 @@ export default Service.extend({
 
     this.getTokensFromStorage().forEach(key => {
       const data = this.getTokenData(key);
-      if (data && data.policies.includes('root')) {
+      if (data && data.policies && data.policies.includes('root')) {
         this.removeTokenData(key);
       }
     });


### PR DESCRIPTION
This _should_ fix issue #9179 but unfortunately I haven't been able to replicate the same behavior, before or after the fix. 

Should be backported to the next 1.4.x release. Still looking into what could be causing the root issue (`policies` is saved as null) and open to other ways this could be addressed