### PR TITLE
Backport 1.5.0: quotas: fix data race that could occur if ApplyQuota was called durin…

### DIFF
--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -372,6 +372,14 @@ func (m *Manager) QuotaByFactors(ctx context.Context, qType, nsPath, mountPath s
 	return quotas[0], nil
 }
 
+// QueryQuota returns the most specific applicable quota for a given request.
+func (m *Manager) QueryQuota(req *Request) (Quota, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.queryQuota(nil, req)
+}
+
 // queryQuota returns the quota rule that is applicable for the given request. It
 // queries all the quota rules that are defined against request values and finds
 // the quota rule that takes priority.
@@ -494,7 +502,7 @@ func (m *Manager) DeleteQuota(ctx context.Context, qType string, name string) er
 func (m *Manager) ApplyQuota(req *Request) (Response, error) {
 	var resp Response
 
-	quota, err := m.queryQuota(nil, req)
+	quota, err := m.QueryQuota(req)
 	if err != nil {
 		return resp, err
 	}

--- a/vault/quotas/quotas_test.go
+++ b/vault/quotas/quotas_test.go
@@ -28,7 +28,7 @@ func TestQuotas_Precedence(t *testing.T) {
 
 	checkQuotaFunc := func(t *testing.T, nsPath, mountPath string, expected Quota) {
 		t.Helper()
-		quota, err := qm.queryQuota(nil, &Request{
+		quota, err := qm.QueryQuota(&Request{
 			Type:          TypeRateLimit,
 			NamespacePath: nsPath,
 			MountPath:     mountPath,


### PR DESCRIPTION
…… (#9458)

* quotas: fix data race that could occur if ApplyQuota was called during a db reset

* Abstract out the locking caller

* Remove unneeded lock

* Update

Co-authored-by: Vishal Nayak <vishalnayakv@gmail.com>
Co-authored-by: Vishal Nayak <vishalnayak@users.noreply.github.com>