### PR TITLE
Add RC note on downloads page

### DIFF
--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -16,6 +16,11 @@ export default function DownloadsPage({ releaseData }) {
         version={VERSION}
         releaseData={releaseData}
         changelog={changelogUrl}
+        prerelease={{
+          type: 'release candidate',
+          name: 'v1.5.0',
+          version: '1.5.0-rc',
+        }}
       />
     </div>
   )


### PR DESCRIPTION
Looks like this locally:
<img width="1304" alt="Screen Shot 2020-07-13 at 17 57 07" src="https://user-images.githubusercontent.com/9422872/87357709-7d554b80-c532-11ea-9239-11a5bdb4fda1.png">
