### PR TITLE
vault operator doc page example usage update for v1.4.2

### DIFF
--- a/website/pages/docs/commands/operator/index.mdx
+++ b/website/pages/docs/commands/operator/index.mdx
@@ -57,6 +57,8 @@ Subcommands:
     generate-root    Generates a new root token
     init             Initializes a server
     key-status       Provides information about the active encryption key
+    migrate          Migrates Vault data between storage backends
+    raft             Interact with Vault's raft storage backend
     rekey            Generates new unseal keys
     rotate           Rotates the underlying encryption key
     seal             Seals the Vault server


### PR DESCRIPTION
updating the vault operator example usage on the vault operator doc page for v1.4.2 which includes migrate and raft subcommands