### PR TITLE
Backport 1.5: Remove namespace from mount_point label. (#9436)

### DIFF
--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -583,7 +583,7 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 	entry := c.router.MatchingMountEntry(ctx, req.Path)
 	if entry != nil {
 		// Set here so the audit log has it even if authorization fails
-		req.MountType=entry.Type
+		req.MountType = entry.Type
 		// Get and set ignored HMAC'd value.
 		if rawVals, ok := entry.synthesizedConfigCache.Load("audit_non_hmac_request_keys"); ok {
 			nonHMACReqDataKeys = rawVals.([]string)
@@ -877,13 +877,14 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 
 			// Count the lease creation
 			ttl_label := metricsutil.TTLBucket(resp.Secret.TTL)
+			mountPointWithoutNs := ns.TrimmedPath(req.MountPoint)
 			c.MetricSink().IncrCounterWithLabels(
 				[]string{"secret", "lease", "creation"},
 				1,
 				[]metrics.Label{
 					metricsutil.NamespaceLabel(ns),
 					{"secret_engine", req.MountType},
-					{"mount_point", req.MountPoint},
+					{"mount_point", mountPointWithoutNs},
 					{"creation_ttl", ttl_label},
 				},
 			)
@@ -990,7 +991,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 	entry := c.router.MatchingMountEntry(ctx, req.Path)
 	if entry != nil {
 		// Set here so the audit log has it even if authorization fails
-		req.MountType=entry.Type
+		req.MountType = entry.Type
 		// Get and set ignored HMAC'd value.
 		if rawVals, ok := entry.synthesizedConfigCache.Load("audit_non_hmac_request_keys"); ok {
 			nonHMACReqDataKeys = rawVals.([]string)
@@ -1272,13 +1273,15 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 
 		// Count the successful token creation
 		ttl_label := metricsutil.TTLBucket(tokenTTL)
+		// Do not include namespace path in mount point; already present as separate label.
+		mountPointWithoutNs := ns.TrimmedPath(req.MountPoint)
 		c.metricSink.IncrCounterWithLabels(
 			[]string{"token", "creation"},
 			1,
 			[]metrics.Label{
 				metricsutil.NamespaceLabel(ns),
 				{"auth_method", req.MountType},
-				{"mount_point", req.MountPoint},
+				{"mount_point", mountPointWithoutNs},
 				{"creation_ttl", ttl_label},
 				{"token_type", auth.TokenType.String()},
 			},

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1822,7 +1822,7 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 				for index, child := range children {
 					countParentList++
 					if countParentList%500 == 0 {
-						percentComplete := float64(index)/float64(len(children))*100
+						percentComplete := float64(index) / float64(len(children)) * 100
 						ts.logger.Info("checking validity of tokens in secondary index list", "progress", countParentList, "percent_complete", percentComplete)
 					}
 
@@ -1883,7 +1883,7 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 			for index, saltedAccessor := range saltedAccessorList {
 				countAccessorList++
 				if countAccessorList%500 == 0 {
-					percentComplete := float64(index)/float64(len(saltedAccessorList))*100
+					percentComplete := float64(index) / float64(len(saltedAccessorList)) * 100
 					ts.logger.Info("checking if accessors contain valid tokens", "progress", countAccessorList, "percent_complete", percentComplete)
 				}
 
@@ -1980,7 +1980,7 @@ func (ts *TokenStore) handleTidy(ctx context.Context, req *logical.Request, data
 			for index, key := range cubbyholeKeys {
 				countCubbyholeKeys++
 				if countCubbyholeKeys%500 == 0 {
-					percentComplete := float64(index)/float64(len(cubbyholeKeys))*100
+					percentComplete := float64(index) / float64(len(cubbyholeKeys)) * 100
 					ts.logger.Info("checking if there are invalid cubbyholes", "progress", countCubbyholeKeys, "percent_complete", percentComplete)
 				}
 
@@ -2723,14 +2723,14 @@ func (ts *TokenStore) handleCreateCommon(ctx context.Context, req *logical.Reque
 
 	// Count the successful token creation.
 	ttl_label := metricsutil.TTLBucket(te.TTL)
-
+	mountPointWithoutNs := ns.TrimmedPath(req.MountPoint)
 	ts.core.metricSink.IncrCounterWithLabels(
 		[]string{"token", "creation"},
 		1,
 		[]metrics.Label{
 			metricsutil.NamespaceLabel(ns),
 			{"auth_method", "token"},
-			{"mount_point", req.MountPoint}, // path, not accessor
+			{"mount_point", mountPointWithoutNs}, // path, not accessor
 			{"creation_ttl", ttl_label},
 			{"token_type", tokenType.String()},
 		},

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -147,6 +147,7 @@ DONELISTHANDLING:
 
 	// Count the successful token creation
 	ttl_label := metricsutil.TTLBucket(resp.WrapInfo.TTL)
+	mountPointWithoutNs := ns.TrimmedPath(req.MountPoint)
 	c.metricSink.IncrCounterWithLabels(
 		[]string{"token", "creation"},
 		1,
@@ -156,7 +157,7 @@ DONELISTHANDLING:
 			// we could use "token" but let's be more descriptive,
 			// even if it's not a real auth method.
 			{"auth_method", "response_wrapping"},
-			{"mount_point", req.MountPoint},
+			{"mount_point", mountPointWithoutNs},
 			{"creation_ttl", ttl_label},
 			// *Should* be service, but let's use whatever create() did..
 			{"token_type", te.Type.String()},


### PR DESCRIPTION
* Remove namespace from mount_point label.
* Fix the other two places where vault.token.creation is emitted.