### PR TITLE
Use the accessor method so state lock is used to check if perf standby

### DIFF
--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -369,7 +369,7 @@ func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, erro
 	// If we are a perf standby and the request was forwarded to the active node
 	// we should attempt to wait for the WAL to ship to offer best effort read after
 	// write guarantees
-	if c.perfStandby && resp.LastRemoteWal > 0 {
+	if c.PerfStandby() && resp.LastRemoteWal > 0 {
 		WaitUntilWALShipped(req.Context(), c, resp.LastRemoteWal)
 	}
 


### PR DESCRIPTION
Solves this race:

```
ARNING: DATA RACE
Read at 0x00c0046f3061 by goroutine 434:
  github.com/hashicorp/vault/vault.(*Core).ForwardRequest()
      /home/ncc/gh/vault-enterprise/vault/request_forwarding.go:374 +0x7f9
  github.com/hashicorp/vault/http.forwardRequest()
      /home/ncc/gh/vault-enterprise/http/handler.go:741 +0x2bb
  github.com/hashicorp/vault/http.handleRequestForwarding.func1()
      /home/ncc/gh/vault-enterprise/http/handler.go:709 +0x17a
  net/http.HandlerFunc.ServeHTTP()
      /home/ncc/go1.13.7/src/net/http/server.go:2007 +0x51
  net/http.(*ServeMux).ServeHTTP()
      /home/ncc/go1.13.7/src/net/http/server.go:2387 +0x288
  github.com/hashicorp/vault/http.wrapHelpHandler.func1()
      /home/ncc/gh/vault-enterprise/http/help.go:24 +0x1b3
  net/http.HandlerFunc.ServeHTTP()
      /home/ncc/go1.13.7/src/net/http/server.go:2007 +0x51
  github.com/hashicorp/vault/http.wrapCORSHandler.func1()
      /home/ncc/gh/vault-enterprise/http/cors.go:29 +0xe37
  net/http.HandlerFunc.ServeHTTP()
      /home/ncc/go1.13.7/src/net/http/server.go:2007 +0x51
  github.com/hashicorp/vault/http.rateLimitQuotaWrapping.func1()
      /home/ncc/gh/vault-enterprise/http/util.go:90 +0xd45
  net/http.HandlerFunc.ServeHTTP()
      /home/ncc/go1.13.7/src/net/http/server.go:2007 +0x51
  github.com/hashicorp/vault/http.wrapDRSecondaryHandler.func1()
      /home/ncc/gh/vault-enterprise/http/util_ent.go:72 +0x960
  net/http.HandlerFunc.ServeHTTP()
      /home/ncc/go1.13.7/src/net/http/server.go:2007 +0x51
  github.com/hashicorp/vault/http.wrapGenericHandler.func1()
      /home/ncc/gh/vault-enterprise/http/handler.go:308 +0x7c0
  net/http.HandlerFunc.ServeHTTP()
      /home/ncc/go1.13.7/src/net/http/server.go:2007 +0x51
  github.com/hashicorp/go-cleanhttp.PrintablePathCheckHandler.func1()
      /home/ncc/gh/vault-enterprise/vendor/github.com/hashicorp/go-cleanhttp/handlers.go:42 +0x105
  net/http.HandlerFunc.ServeHTTP()
      /home/ncc/go1.13.7/src/net/http/server.go:2007 +0x51
  net/http.serverHandler.ServeHTTP()
      /home/ncc/go1.13.7/src/net/http/server.go:2802 +0xce
  net/http.initNPNRequest.ServeHTTP()
      /home/ncc/go1.13.7/src/net/http/server.go:3366 +0xfc
  net/http.(*initNPNRequest).ServeHTTP()
      <autogenerated>:1 +0xa6
  net/http.Handler.ServeHTTP-fm()
      /home/ncc/go1.13.7/src/net/http/server.go:86 +0x64
  net/http.(*http2serverConn).runHandler()
      /home/ncc/go1.13.7/src/net/http/h2_bundle.go:5713 +0xac

Previous write at 0x00c0046f3061 by goroutine 336:
  github.com/hashicorp/vault/vault.(*Core).waitForPerfStandby.func5()
      /home/ncc/gh/vault-enterprise/vault/ha_ent.go:238 +0x1629
  github.com/oklog/run.(*Group).Run.func1()
      /home/ncc/gh/vault-enterprise/vendor/github.com/oklog/run/group.go:38 +0x34

Goroutine 434 (running) created at:
  net/http.(*http2serverConn).processHeaders()
      /home/ncc/go1.13.7/src/net/http/h2_bundle.go:5447 +0x90f
  net/http.(*http2serverConn).processFrame()
      /home/ncc/go1.13.7/src/net/http/h2_bundle.go:4976 +0x59b
  net/http.(*http2serverConn).processFrameFromReader()
      /home/ncc/go1.13.7/src/net/http/h2_bundle.go:4934 +0x7ad
  net/http.(*http2serverConn).serve()
      /home/ncc/go1.13.7/src/net/http/h2_bundle.go:4433 +0x1493
  net/http.(*http2Server).ServeConn()
      /home/ncc/go1.13.7/src/net/http/h2_bundle.go:4031 +0xd9b
  net/http.http2ConfigureServer.func1()
      /home/ncc/go1.13.7/src/net/http/h2_bundle.go:3857 +0x117
  net/http.(*conn).serve()
      /home/ncc/go1.13.7/src/net/http/server.go:1800 +0x1d35

Goroutine 336 (running) created at:
  github.com/oklog/run.(*Group).Run()
      /home/ncc/gh/vault-enterprise/vendor/github.com/oklog/run/group.go:37 +0x11c
  github.com/hashicorp/vault/vault.(*Core).waitForPerfStandby()
      /home/ncc/gh/vault-enterprise/vault/ha_ent.go:298 +0xf93
  github.com/hashicorp/vault/vault.addEnterpriseHaActorsImpl.func1()
      /home/ncc/gh/vault-enterprise/vault/ha_ent.go:48 +0x53
  github.com/oklog/run.(*Group).Run.func1()
      /home/ncc/gh/vault-enterprise/vendor/github.com/oklog/run/group.go:38 +0x34
```