### PR TITLE
Resource Quotas: Remove 'burst' Param from Rate Limiter

### DIFF
--- a/vault/external_tests/quotas/quotas_test.go
+++ b/vault/external_tests/quotas/quotas_test.go
@@ -138,9 +138,8 @@ func TestQuotas_RateLimitQuota_DupName(t *testing.T) {
 
 	// create a rate limit quota w/ 'secret' path
 	_, err := client.Logical().Write("sys/quotas/rate-limit/secret-rlq", map[string]interface{}{
-		"rate":  7.7,
-		"burst": 8,
-		"path":  "secret",
+		"rate": 7.7,
+		"path": "secret",
 	})
 	require.NoError(t, err)
 
@@ -150,9 +149,8 @@ func TestQuotas_RateLimitQuota_DupName(t *testing.T) {
 
 	// create a rate limit quota w/ empty path (same name)
 	_, err = client.Logical().Write("sys/quotas/rate-limit/secret-rlq", map[string]interface{}{
-		"rate":  7.7,
-		"burst": 8,
-		"path":  "",
+		"rate": 7.7,
+		"path": "",
 	})
 	require.NoError(t, err)
 
@@ -214,9 +212,8 @@ func TestQuotas_RateLimitQuota_Mount(t *testing.T) {
 	// ⌈7.7⌉*2 requests in the span of roughly a second -- 8 initially, followed
 	// by a refill rate of 7.7 per-second.
 	_, err = client.Logical().Write("sys/quotas/rate-limit/rlq", map[string]interface{}{
-		"rate":  7.7,
-		"burst": 8,
-		"path":  "pki/",
+		"rate": 7.7,
+		"path": "pki/",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -224,7 +221,7 @@ func TestQuotas_RateLimitQuota_Mount(t *testing.T) {
 
 	numSuccess, numFail, elapsed := testRPS(reqFunc, 5*time.Second)
 
-	// evaluate the ideal RPS as (burst + (RPS * totalSeconds))
+	// evaluate the ideal RPS as (ceil(RPS) + (RPS * totalSeconds))
 	ideal := 8 + (7.7 * float64(elapsed) / float64(time.Second))
 
 	// ensure there were some failed requests
@@ -239,9 +236,8 @@ func TestQuotas_RateLimitQuota_Mount(t *testing.T) {
 
 	// update the rate limit quota with a high RPS such that no requests should fail
 	_, err = client.Logical().Write("sys/quotas/rate-limit/rlq", map[string]interface{}{
-		"rate":  1000.0,
-		"burst": 3000,
-		"path":  "pki/",
+		"rate": 1000.0,
+		"path": "pki/",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -294,9 +290,8 @@ func TestQuotas_RateLimitQuota_MountPrecedence(t *testing.T) {
 
 	// create a root rate limit quota
 	_, err = client.Logical().Write("sys/quotas/rate-limit/root-rlq", map[string]interface{}{
-		"name":  "root-rlq",
-		"rate":  14.7,
-		"burst": 15,
+		"name": "root-rlq",
+		"rate": 14.7,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -304,10 +299,9 @@ func TestQuotas_RateLimitQuota_MountPrecedence(t *testing.T) {
 
 	// create a mount rate limit quota with a lower RPS than the root rate limit quota
 	_, err = client.Logical().Write("sys/quotas/rate-limit/mount-rlq", map[string]interface{}{
-		"name":  "mount-rlq",
-		"rate":  7.7,
-		"burst": 8,
-		"path":  "pki/",
+		"name": "mount-rlq",
+		"rate": 7.7,
+		"path": "pki/",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -327,7 +321,7 @@ func TestQuotas_RateLimitQuota_MountPrecedence(t *testing.T) {
 	// ensure mount rate limit quota takes precedence over root rate limit quota
 	numSuccess, numFail, elapsed := testRPS(reqFunc, 5*time.Second)
 
-	// evaluate the ideal RPS as (burst + (RPS * totalSeconds))
+	// evaluate the ideal RPS as (ceil(RPS) + (RPS * totalSeconds))
 	ideal := 8 + (7.7 * float64(elapsed) / float64(time.Second))
 
 	// ensure there were some failed requests
@@ -370,8 +364,7 @@ func TestQuotas_RateLimitQuota(t *testing.T) {
 	// ⌈7.7⌉*2 requests in the span of roughly a second -- 8 initially, followed
 	// by a refill rate of 7.7 per-second.
 	_, err = client.Logical().Write("sys/quotas/rate-limit/rlq", map[string]interface{}{
-		"rate":  7.7,
-		"burst": 8,
+		"rate": 7.7,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -389,7 +382,7 @@ func TestQuotas_RateLimitQuota(t *testing.T) {
 
 	numSuccess, numFail, elapsed := testRPS(reqFunc, 5*time.Second)
 
-	// evaluate the ideal RPS as (burst + (RPS * totalSeconds))
+	// evaluate the ideal RPS as (ceil(RPS) + (RPS * totalSeconds))
 	ideal := 8 + (7.7 * float64(elapsed) / float64(time.Second))
 
 	// ensure there were some failed requests
@@ -407,8 +400,7 @@ func TestQuotas_RateLimitQuota(t *testing.T) {
 
 	// update the rate limit quota with a high RPS such that no requests should fail
 	_, err = client.Logical().Write("sys/quotas/rate-limit/rlq", map[string]interface{}{
-		"rate":  1000.0,
-		"burst": 3000,
+		"rate": 1000.0,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/vault/quotas/quotas_rate_limit.go
+++ b/vault/quotas/quotas_rate_limit.go
@@ -56,7 +56,7 @@ type ClientRateLimiter struct {
 // that is uniquely addressable, where maxRequests defines the requests-per-second
 // and burstSize defines the maximum burst allowed. A caller may provide -1 for
 // burstSize to allow the burst value to be roughly equivalent to the RPS. Note,
-// the underlying rate limiter is already thread-safe.
+// the underlying rate limiter is thread-safe.
 func newClientRateLimiter(maxRequests float64, burstSize int) *ClientRateLimiter {
 	if burstSize < 0 {
 		burstSize = int(math.Ceil(maxRequests))
@@ -93,9 +93,6 @@ type RateLimitQuota struct {
 	// Rate defines the rate of which allowed requests are refilled per second.
 	Rate float64 `json:"rate"`
 
-	// Burst defines maximum number of requests at any given moment to be allowed.
-	Burst int `json:"burst"`
-
 	lock         *sync.RWMutex
 	logger       log.Logger
 	metricSink   *metricsutil.ClusterMetricSink
@@ -120,14 +117,13 @@ type RateLimitQuota struct {
 
 // NewRateLimitQuota creates a quota checker for imposing limits on the number
 // of requests per second.
-func NewRateLimitQuota(name, nsPath, mountPath string, rate float64, burst int) *RateLimitQuota {
+func NewRateLimitQuota(name, nsPath, mountPath string, rate float64) *RateLimitQuota {
 	return &RateLimitQuota{
 		Name:          name,
 		Type:          TypeRateLimit,
 		NamespacePath: nsPath,
 		MountPath:     mountPath,
 		Rate:          rate,
-		Burst:         burst,
 	}
 }
 
@@ -150,10 +146,6 @@ func (rlq *RateLimitQuota) initialize(logger log.Logger, ms *metricsutil.Cluster
 
 	if rlq.Rate <= 0 {
 		return fmt.Errorf("invalid avg rps: %v", rlq.Rate)
-	}
-
-	if rlq.Burst < int(rlq.Rate) {
-		return fmt.Errorf("burst size (%v) must be greater than or equal to average rps (%v)", rlq.Burst, rlq.Rate)
 	}
 
 	if logger != nil {
@@ -260,7 +252,7 @@ func (rlq *RateLimitQuota) clientRateLimiter(addr string) *ClientRateLimiter {
 
 	crl, ok := rlq.rateQuotas[addr]
 	if !ok {
-		limiter := newClientRateLimiter(rlq.Rate, rlq.Burst)
+		limiter := newClientRateLimiter(rlq.Rate, -1)
 		rlq.rateQuotas[addr] = limiter
 		return limiter
 	}

--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -2,6 +2,7 @@ package quotas
 
 import (
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -35,7 +36,7 @@ func TestNewClientRateLimiter(t *testing.T) {
 }
 
 func TestNewRateLimitQuota(t *testing.T) {
-	rlq := NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", 16.7, 50)
+	rlq := NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", 16.7)
 	if err := rlq.initialize(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink()); err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +54,7 @@ func TestNewRateLimitQuota(t *testing.T) {
 }
 
 func TestRateLimitQuota_Close(t *testing.T) {
-	rlq := NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", 16.7, 50)
+	rlq := NewRateLimitQuota("test-rate-limiter", "qa", "/foo/bar", 16.7)
 
 	if err := rlq.initialize(logging.NewVaultLogger(log.Trace), metricsutil.BlackholeSink()); err != nil {
 		t.Fatal(err)
@@ -77,7 +78,6 @@ func TestRateLimitQuota_Allow(t *testing.T) {
 		NamespacePath: "qa",
 		MountPath:     "/foo/bar",
 		Rate:          16.7,
-		Burst:         83,
 		purgeEnabled:  true, // to allow manual setting of purgeInterval and staleAge
 	}
 
@@ -143,8 +143,8 @@ func TestRateLimitQuota_Allow(t *testing.T) {
 
 	elapsed := time.Since(start)
 
-	// evaluate the ideal RPS as (burst + (RPS * totalSeconds))
-	ideal := float64(rlq.Burst) + (rlq.Rate * float64(elapsed) / float64(time.Second))
+	// evaluate the ideal RPS as (ceil(RPS) + (RPS * totalSeconds))
+	ideal := math.Ceil(rlq.Rate) + (rlq.Rate * float64(elapsed) / float64(time.Second))
 
 	for addr, cr := range results {
 		numAllow := cr.atomicNumAllow.Load()

--- a/vault/quotas/quotas_test.go
+++ b/vault/quotas/quotas_test.go
@@ -18,7 +18,7 @@ func TestQuotas_Precedence(t *testing.T) {
 
 	setQuotaFunc := func(t *testing.T, name, nsPath, mountPath string) Quota {
 		t.Helper()
-		quota := NewRateLimitQuota(name, nsPath, mountPath, 10, 20)
+		quota := NewRateLimitQuota(name, nsPath, mountPath, 10)
 		err := qm.SetQuota(context.Background(), TypeRateLimit.String(), quota, true)
 		if err != nil {
 			t.Fatal(err)

--- a/website/pages/api-docs/system/rate-limit-quotas.mdx
+++ b/website/pages/api-docs/system/rate-limit-quotas.mdx
@@ -12,8 +12,8 @@ The `/sys/quotas/rate-limit` endpoint is used to create, edit and delete rate li
 ## Create or Update a Rate Limit Quota
 
 This endpoint is used to create a rate limit quota with an identifier, `name`.
-A rate limit quota must include a `rate` and `burst` value with an optional `path`
-that can either be a namespace or mount.
+A rate limit quota must include a `rate` value with an optional `path` that can
+either be a namespace or mount.
 
 | Method | Path                           |
 | :----- | :----------------------------- |
@@ -29,24 +29,15 @@ that can either be a namespace or mount.
   "moving" effects. For example, updating `auth/userpass` to
   `namespace1/auth/userpass` moves this quota from being a global mount quota to a
   namespace specific mount quota. **Note, namespaces are supported in Enterprise only**.
-- `rate` `(float: 0.0)` - The rate at which allowed requests are refilled per
-  second by the quota rule. Internally, a token-bucket algorithm is used which
-  has a size of `burst`, initially full. The quota limits requests to `rate`
-  per-second, with a maximum burst size of `burst`. Each request takes a single
-  token from this bucket. The `rate` must be positive.
-- `burst` `(int: 0)` - The maximum number of requests at any given second to be
-  allowed by the quota rule, where each request takes a single token. A client
-  may perform up to `burst` requests at once, after which they may invoke
-  additional requests at `rate` per-second. The `burst` value must be greater
-  than or equal to `rate`.
+- `rate` `(float: 0.0)` - The maximum number of requests at any given second to
+  be allowed by the quota rule. The `rate` must be positive.
 
 ### Sample Payload
 
 ```json
 {
   "path": "",
-  "rate": 897.3,
-  "burst": 2692
+  "rate": 897.3
 }
 ```
 
@@ -103,7 +94,6 @@ $ curl \
   "lease_duration": 0,
   "renewable": false,
   "data": {
-    "burst": 2692,
     "name": "global-rate-limiter",
     "path": "",
     "rate": 897.3,

--- a/website/pages/docs/concepts/resource-quotas.mdx
+++ b/website/pages/docs/concepts/resource-quotas.mdx
@@ -30,9 +30,8 @@ limiting using a [token bucket](https://en.wikipedia.org/wiki/Token_bucket) algo
 A rate limit quota can be created at the root level or defined on a namespace or
 mount by specifying a `path` when creating the quota. The rate limiter is applied
 to each unique client IP address on a per-node basis (i.e. rate limit quotas
-are not replicated). A client may invoke `burst` requests at any given second,
-after which they may invoke additional requests at `rate` per-second, where `burst`
-must be greater than or equal to `rate`.
+are not replicated). A client may invoke `rate` requests at any given second,
+after which they may invoke additional requests at `rate` per-second.
 
 A rate limit quota defined at the root level (i.e. empty `path`) is inherited by
 all namespaces and mounts. It acts as a single rate limiter for the entire Vault


### PR DESCRIPTION
Per internal discussions, remove `burst` as a configurable parameter for rate limit quotas.