### PR TITLE
add upgrade sequence for DR and PR clusters to Upgrade Overview page

### DIFF
--- a/website/pages/docs/upgrading/index.mdx
+++ b/website/pages/docs/upgrading/index.mdx
@@ -103,3 +103,13 @@ Upgrading installations of Vault which participate in [Enterprise Replication](/
 - Verify functionality of each secondary instance after upgrading
 - When satisfied with functionality of upgraded secondary instances, upgrade
   the primary instance
+
+For Vault Enterprise customers who have both Disaster Recovery (DR) and Performance Replication (PR) clusters, the recommended sequence for upgrading all clusters is as follows:
+
+* Upgrade Disaster Recovery clusters
+
+* Upgrade Performance Replication secondary clusters
+
+* Upgrade Performance Replication primary clusters
+
+**NOTE**:  If the DR Primary is also a PR Primary, you will upgrade the DR secondary first then upgrade the PR secondary.  As the final step, upgrade the mixed DR+PR Primary. 

--- a/website/pages/docs/upgrading/index.mdx
+++ b/website/pages/docs/upgrading/index.mdx
@@ -103,3 +103,13 @@ Upgrading installations of Vault which participate in [Enterprise Replication](/
 - Verify functionality of each secondary instance after upgrading
 - When satisfied with functionality of upgraded secondary instances, upgrade
   the primary instance
+
+For Vault Enterprise customers who have both Disaster Recovery (DR) and Performance Replication (PR) clusters, the recommended sequence for upgrading is as follows:
+
+* Upgrade Disaster Recovery clusters
+
+* Upgrade Performance Replication secondary clusters
+
+* Upgrade Performance Replication primary clusters
+
+**NOTE**:  If the DR Primary is also a PR Primary, you will upgrade the DR secondary first then upgrade the PR secondary.  As the final step, upgrade the mixed DR+PR Primary. 

--- a/website/pages/docs/upgrading/index.mdx
+++ b/website/pages/docs/upgrading/index.mdx
@@ -103,13 +103,3 @@ Upgrading installations of Vault which participate in [Enterprise Replication](/
 - Verify functionality of each secondary instance after upgrading
 - When satisfied with functionality of upgraded secondary instances, upgrade
   the primary instance
-
-For Vault Enterprise customers who have both Disaster Recovery (DR) and Performance Replication (PR) clusters, the recommended sequence for upgrading all clusters is as follows:
-
-* Upgrade Disaster Recovery clusters
-
-* Upgrade Performance Replication secondary clusters
-
-* Upgrade Performance Replication primary clusters
-
-**NOTE**:  If the DR Primary is also a PR Primary, you will upgrade the DR secondary first then upgrade the PR secondary.  As the final step, upgrade the mixed DR+PR Primary. 


### PR DESCRIPTION
We were going to originally put this in the HC KB but thought it would be more appropriate to be in the Vault overview doc.  Thanks!