### PR TITLE
Added instructions to step-down the active primary before upgrading

### DIFF
--- a/website/pages/docs/platform/k8s/helm/run.mdx
+++ b/website/pages/docs/platform/k8s/helm/run.mdx
@@ -447,11 +447,18 @@ to be unsealed:
 $ kubectl exec -ti <name of pod> -- vault operator unseal
 ```
 
-Finally, once the standby nodes have been updated and unsealed, delete the active
-primary:
+Finally, once the standby nodes have been updated and unsealed, let the active pod 
+[step-down](/docs/commands/operator/step-down):
 
 ```shell-session
-$ kubectl delete pod <name of Vault primary>
+$ vault operator step-down
+```
+
+You may need to wait a few second that the active flag change woulr reflect on Kubernetes load-balancers, though 
+there will be no downtime. Then delete the former active primary:
+
+```shell-session
+$ kubectl delete pod <name of former Vault primary>
 ```
 
 Similar to the standby nodes, the former primary also needs to be unsealed:


### PR DESCRIPTION
By simply deleting the active primary pod, in a HA cluster the users can experience a few seconds downtime in Vault service, since it takes some time to detect and react on missing the active pod. By manually stepping down the active pod we re-routing the traffic to one of the previously upgraded standby pod. So Kubernetes engine will have the opportunity to recover a now standby pod.

The operation requires a valid root/sudo token.