### PR TITLE
Make sure cluster is stopped before wiping storage.

### DIFF
--- a/vault/external_tests/sealmigration/seal_migration_pre14_test.go
+++ b/vault/external_tests/sealmigration/seal_migration_pre14_test.go
@@ -43,8 +43,8 @@ func testSealMigrationTransitToShamir_Pre14(t *testing.T, logger hclog.Logger, s
 	cluster, _, transitSeal := initializeTransit(t, logger, storage, basePort, tss)
 	rootToken, recoveryKeys := cluster.RootToken, cluster.RecoveryKeys
 	cluster.EnsureCoresSealed(t)
-	storage.Cleanup(t, cluster)
 	cluster.Cleanup()
+	storage.Cleanup(t, cluster)
 
 	// Migrate the backend from transit to shamir
 	migrateFromTransitToShamir_Pre14(t, logger, storage, basePort, tss, transitSeal, rootToken, recoveryKeys)
@@ -83,8 +83,8 @@ func migrateFromTransitToShamir_Pre14(t *testing.T, logger hclog.Logger, storage
 	cluster := vault.NewTestCluster(t, &conf, &opts)
 	cluster.Start()
 	defer func() {
-		storage.Cleanup(t, cluster)
 		cluster.Cleanup()
+		storage.Cleanup(t, cluster)
 	}()
 
 	leader := cluster.Cores[0]

--- a/vault/external_tests/sealmigration/seal_migration_test.go
+++ b/vault/external_tests/sealmigration/seal_migration_test.go
@@ -102,8 +102,8 @@ func testSealMigrationShamirToTransit_Pre14(t *testing.T, logger hclog.Logger, s
 	cluster, _ := initializeShamir(t, logger, storage, basePort)
 	rootToken, barrierKeys := cluster.RootToken, cluster.BarrierKeys
 	cluster.EnsureCoresSealed(t)
-	storage.Cleanup(t, cluster)
 	cluster.Cleanup()
+	storage.Cleanup(t, cluster)
 
 	// Create the transit server.
 	tss := sealhelper.NewTransitSealServer(t)
@@ -146,8 +146,8 @@ func migrateFromShamirToTransit_Pre14(t *testing.T, logger hclog.Logger, storage
 	cluster := vault.NewTestCluster(t, &conf, &opts)
 	cluster.Start()
 	defer func() {
-		storage.Cleanup(t, cluster)
 		cluster.Cleanup()
+		storage.Cleanup(t, cluster)
 	}()
 
 	leader := cluster.Cores[0]
@@ -212,8 +212,8 @@ func testSealMigrationShamirToTransit_Post14(t *testing.T, logger hclog.Logger, 
 	transitSeal := migrateFromShamirToTransit_Post14(t, logger, storage, basePort, tss, cluster, opts)
 	cluster.EnsureCoresSealed(t)
 
-	storage.Cleanup(t, cluster)
 	cluster.Cleanup()
+	storage.Cleanup(t, cluster)
 
 	// Run the backend with transit.
 	runTransit(t, logger, storage, basePort, cluster.RootToken, transitSeal)
@@ -280,8 +280,8 @@ func testSealMigrationTransitToShamir_Post14(t *testing.T, logger hclog.Logger, 
 	// Migrate the backend from transit to shamir
 	migrateFromTransitToShamir_Post14(t, logger, storage, basePort, tss, transitSeal, cluster, opts)
 	cluster.EnsureCoresSealed(t)
-	storage.Cleanup(t, cluster)
 	cluster.Cleanup()
+	storage.Cleanup(t, cluster)
 
 	// Now that migration is done, we can nuke the transit server, since we
 	// can unseal without it.
@@ -589,8 +589,8 @@ func runShamir(t *testing.T, logger hclog.Logger, storage teststorage.ReusableSt
 	cluster := vault.NewTestCluster(t, &conf, &opts)
 	cluster.Start()
 	defer func() {
-		storage.Cleanup(t, cluster)
 		cluster.Cleanup()
+		storage.Cleanup(t, cluster)
 	}()
 
 	leader := cluster.Cores[0]
@@ -718,8 +718,8 @@ func runTransit(t *testing.T, logger hclog.Logger, storage teststorage.ReusableS
 	cluster := vault.NewTestCluster(t, &conf, &opts)
 	cluster.Start()
 	defer func() {
-		storage.Cleanup(t, cluster)
 		cluster.Cleanup()
+		storage.Cleanup(t, cluster)
 	}()
 
 	leader := cluster.Cores[0]


### PR DESCRIPTION
This is an attempted fix for the errors we've seen in seal migration post14 tests, e.g. https://app.circleci.com/pipelines/github/hashicorp/vault/10564/workflows/7426f035-9917-465e-ad05-7d384e262881/jobs/70198

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xefffe0]

goroutine 18741 [running]:
github.com/hashicorp/vault/vault.(*Core).migrateSeal(0xc0006a9800, 0x1811ae0, 0xc0029854c0, 0xc0029854c0, 0xc001752350)
	/go/src/github.com/hashicorp/vault/vault/core.go:1336 +0x150
github.com/hashicorp/vault/vault.(*Core).waitForLeadership(0xc0006a9800, 0x0, 0xc0018283c0, 0xc0015477a0)
	/go/src/github.com/hashicorp/vault/vault/ha.go:471 +0x635
github.com/hashicorp/vault/vault.(*Core).runStandby.func7(0xc0015d3780, 0x0)
	/go/src/github.com/hashicorp/vault/vault/ha.go:372 +0x45
github.com/hashicorp/vault/vendor/github.com/oklog/run.(*Group).Run.func1(0xc0016a6360, 0xc002493c80, 0xc00251d540)
	/go/src/github.com/hashicorp/vault/vendor/github.com/oklog/run/group.go:38 +0x27
created by github.com/hashicorp/vault/vendor/github.com/oklog/run.(*Group).Run
	/go/src/github.com/hashicorp/vault/vendor/github.com/oklog/run/group.go:37 +0xbb
FAIL	github.com/hashicorp/vault/vault/external_tests/sealmigration	160.674s
```

The line 1336 in that branch was this:

```
	if existBarrierSealConfig.Type != c.migrationInfo.seal.BarrierType() {
```

We'd assumed the nil value was c.migrationInfo, but I think it was actually existBarrierSealConfig, because we were wiping storage before stopping the cluster.