### PR TITLE
raft: Fix some snapshot restore issues

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -955,9 +955,7 @@ func (b *RaftBackend) RestoreSnapshot(ctx context.Context, metadata raft.Snapsho
 		},
 	}
 
-	b.l.RLock()
 	err := b.applyLog(ctx, command)
-	b.l.RUnlock()
 
 	// Do a best-effort attempt to let the standbys apply the restoreCallbackOp
 	// before we continue.

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -632,12 +632,6 @@ func (c *Core) raftSnapshotRestoreCallback(grabLock bool, sealNode bool) func(co
 		// Purge the cache so we make sure we are operating on fresh data
 		c.physicalCache.Purge(ctx)
 
-		// Refresh the raft TLS keys
-		if err := c.checkRaftTLSKeyUpgrades(ctx); err != nil {
-			c.logger.Info("failed to perform TLS key upgrades, sealing", "error", err)
-			return err
-		}
-
 		// Reload the keyring in case it changed. If this fails it's likely
 		// we've changed master keys.
 		err := c.performKeyUpgrades(ctx)
@@ -673,6 +667,12 @@ func (c *Core) raftSnapshotRestoreCallback(grabLock bool, sealNode bool) func(co
 				}
 				c.logger.Info("done reloading master key using auto seal")
 			}
+		}
+
+		// Refresh the raft TLS keys
+		if err := c.checkRaftTLSKeyUpgrades(ctx); err != nil {
+			c.logger.Info("failed to perform TLS key upgrades, sealing", "error", err)
+			return err
 		}
 
 		return nil


### PR DESCRIPTION
This PR removes a double read lock call & moves the TLS keyring reload after the barrier keyring reload. This was causing an issue when the TLS keyring was encrypted with a different key. 