### PR TITLE
Prevent panic due to upgrading existing `kv` mount to v2.

### DIFF
--- a/command/kv_metadata_put_test.go
+++ b/command/kv_metadata_put_test.go
@@ -23,7 +23,8 @@ func TestKvMetadataPutCommandDeleteVersionAfter(t *testing.T) {
 	client, closer := testVaultServer(t)
 	defer closer()
 
-	if err := client.Sys().Mount("kv/", &api.MountInput{
+	basePath := t.Name() + "/"
+	if err := client.Sys().Mount(basePath, &api.MountInput{
 		Type: "kv-v2",
 	}); err != nil {
 		t.Fatal(err)
@@ -33,17 +34,19 @@ func TestKvMetadataPutCommandDeleteVersionAfter(t *testing.T) {
 	cmd.client = client
 
 	// Set a limit of 1s first.
-	code := cmd.Run([]string{"-delete-version-after=1s", "kv/secret/my-secret"})
+	code := cmd.Run([]string{"-delete-version-after=1s", basePath + "secret/my-secret"})
 	if code != 0 {
-		t.Errorf("expected %d but received %d", 0, code)
+		t.Fatalf("expected %d but received %d", 0, code)
 	}
 
+	metaFullPath := basePath + "metadata/secret/my-secret"
 	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
-	if !strings.Contains(combined, "Success! Data written to: kv/metadata/secret/my-secret\n") {
-		t.Errorf("expected %q but received %q", "Success! Data written to: kv/metadata/secret/my-secret\n", combined)
+	success := "Success! Data written to: " + metaFullPath
+	if !strings.Contains(combined, success) {
+		t.Fatalf("expected %q but received %q", success, combined)
 	}
 
-	secret, err := client.Logical().Read("kv/metadata/secret/my-secret")
+	secret, err := client.Logical().Read(metaFullPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,17 +59,17 @@ func TestKvMetadataPutCommandDeleteVersionAfter(t *testing.T) {
 	cmd.client = client
 
 	// Set a limit of 1s first.
-	code = cmd.Run([]string{"-delete-version-after=0", "kv/secret/my-secret"})
+	code = cmd.Run([]string{"-delete-version-after=0", basePath + "secret/my-secret"})
 	if code != 0 {
 		t.Errorf("expected %d but received %d", 0, code)
 	}
 
 	combined = ui.OutputWriter.String() + ui.ErrorWriter.String()
-	if !strings.Contains(combined, "Success! Data written to: kv/metadata/secret/my-secret\n") {
-		t.Errorf("expected %q but received %q", "Success! Data written to: kv/metadata/secret/my-secret\n", combined)
+	if !strings.Contains(combined, success) {
+		t.Errorf("expected %q but received %q", success, combined)
 	}
 
-	secret, err = client.Logical().Read("kv/metadata/secret/my-secret")
+	secret, err = client.Logical().Read(metaFullPath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Example failure: https://circleci.hashicorp.engineering/gh/hashicorp/vault-enterprise/42631?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Note the log output:
```
  kv_metadata_put_test.go:38: expected 0 but received 2
    kv_metadata_put_test.go:43: expected "Success! Data written to: kv/metadata/secret/my-secret\n" but received "Error writing data to kv/metadata/secret/my-secret: Error making API request.\n\nURL: PUT https://127.0.0.1:44348/v1/kv/metadata/secret/my-secret\nCode: 400. Errors:\n\n* Upgrading from non-versioned to versioned data. This backend will be unavailable for a brief period and will resume service shortly.\n"
```

We now use a unique mount point instead of `kv`, which is already setup as a kvv1 mount by the shared test code used to create the core.