### PR TITLE
doc: remove beta warnings for openshift

### DIFF
--- a/website/pages/docs/platform/k8s/helm/configuration.mdx
+++ b/website/pages/docs/platform/k8s/helm/configuration.mdx
@@ -27,8 +27,6 @@ and consider if they're appropriate for your deployment.
 
   - `openshift` (`boolean: false`) - If `true`, enables configuration specific to OpenShift such as NetworkPolicy, SecurityContext, and Route.
 
-    ~> **Note:** OpenShift support is a beta feature.
-
 - `injector` - Values that configure running a Vault Agent Injector Admission Webhook Controller within Kubernetes.
 
   - `enabled` (`boolean: true`) - When set to `true`, the Vault Agent Injector Admission Webhook controller will be created.

--- a/website/pages/docs/platform/k8s/helm/openshift.mdx
+++ b/website/pages/docs/platform/k8s/helm/openshift.mdx
@@ -10,8 +10,6 @@ description: >-
 
 # Run Vault on OpenShift
 
-~> **Note:** OpenShift support is a beta feature.
-
 The following documentation describes installing, running and using 
 Vault and Vault Agent Injector on OpenShift.
 


### PR DESCRIPTION
Removing beta warnings since we now officially support OpenShift with Vault 1.5.