### PR TITLE
Link to release notes on downloads page

### DIFF
--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -2,6 +2,7 @@ import fetch from 'isomorphic-unfetch'
 import { VERSION, CHANGELOG_URL } from '../../data/version.js'
 import ProductDownloader from '@hashicorp/react-product-downloader'
 import Head from 'next/head'
+import Link from 'next/link'
 import HashiHead from '@hashicorp/react-head'
 
 export default function DownloadsPage({ releaseData }) {
@@ -15,8 +16,11 @@ export default function DownloadsPage({ releaseData }) {
         product="Vault"
         version={VERSION}
         releaseData={releaseData}
-        changelog={changelogUrl}
-      />
+        changelog={changelogUrl}>
+        <p className="description g-type-body">Release notes are available in our
+          <Link href={`/docs/release-notes/${VERSION}`}><a> documentation</a></Link>.
+        </p>
+      </ProductDownloader>
     </div>
   )
 }

--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -18,7 +18,7 @@ export default function DownloadsPage({ releaseData }) {
         releaseData={releaseData}
         changelog={changelogUrl}>
         <p className="description g-type-body">Release notes are available in our
-          <Link href={`/docs/release-notes/${VERSION}`}><a> documentation</a></Link>.
+          <Link href="/docs/release-notes"><a> documentation</a></Link>.
         </p>
       </ProductDownloader>
     </div>


### PR DESCRIPTION
Is it ok to add children to ProductDownloader so we can get this link to our release notes?