### PR TITLE
Add sentinel configuration stanza documentation to OSS.

### DIFF
--- a/website/pages/docs/configuration/index.mdx
+++ b/website/pages/docs/configuration/index.mdx
@@ -191,5 +191,6 @@ The following parameters are only used with Vault Enterprise
 [seal]: /docs/configuration/seal
 [sealwrap]: /docs/enterprise/sealwrap
 [telemetry]: /docs/configuration/telemetry
+[sentinel]: /docs/configuration/sentinel
 [high-availability]: /docs/concepts/ha
 [plugins]: /docs/plugin

--- a/website/pages/docs/configuration/sentinel.mdx
+++ b/website/pages/docs/configuration/sentinel.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: Sentinel - Configuration
+sidebar_title: <code>sentinel</code>
+description: |-
+  The sentinel stanza specifies configurations for Vault's Sentinel integration.
+---
+
+
+# `sentinel` Stanza
+
+The sentinel stanza specifies configurations for Vault's Sentinel integration.
+
+```hcl
+sentinel {
+  additional_enabled_modules = ["http"]
+}
+```
+
+## Requirements
+
+A valid Vault Enterprise license is required for use of Sentinel policies.
+
+## `sentinel` Parameters
+
+The sentinel stanza currently supports only one parameter, `additional_enabled_modules`.
+
+- `additional_enabled_modules` `(string array: [])`` - Specifies a list of
+  sentinel policy modules to enable above the default set.  For example,
+  adding "http" to this list indicates sentinel policies may import
+
+  ~> **Warning**: Care should be taken when enabling some modules which
+  could have performance and security implications in policies.  For
+  example, enabling "http" could cause your Vault servers to submit outbound
+  requests to arbitrary endpoints.  See [the Sentinel Documentation](https://docs.hashicorp.com/sentinel/imports/http/)
+  for more information.


### PR DESCRIPTION
Mistakenly documented the sentinel config stanza in ENT as it was an ent
feature.