### PR TITLE
Docs: Update MongoDB to support root credential rotation

### DIFF
--- a/website/pages/docs/secrets/databases/index.mdx
+++ b/website/pages/docs/secrets/databases/index.mdx
@@ -135,7 +135,7 @@ the proper permission, it can generate credentials.
 | [Elasticsearch](/docs/secrets/databases/elasticdb)    | Yes | Yes | No  |
 | [HanaDB](/docs/secrets/databases/hanadb)              | No  | Yes | No  |
 | [InfluxDB](/docs/secrets/databases/influxdb)          | Yes | Yes | No  |
-| [MongoDB](/docs/secrets/databases/mongodb)            | No  | Yes | Yes |
+| [MongoDB](/docs/secrets/databases/mongodb)            | Yes | Yes | Yes |
 | [MongoDB Atlas](/docs/secrets/databases/mongodbatlas) | No  | Yes | Yes |
 | [MSSQL](/docs/secrets/databases/mssql)                | Yes | Yes | Yes |
 | [MySQL/MariaDB](/docs/secrets/databases/mysql-maria)  | Yes | Yes | Yes |

--- a/website/pages/docs/secrets/databases/mongodb.mdx
+++ b/website/pages/docs/secrets/databases/mongodb.mdx
@@ -22,7 +22,7 @@ more information about setting up the database secrets engine.
 
 | Plugin Name               | Root Credential Rotation | Dynamic Roles | Static Roles |
 | ------------------------- | ------------------------ | ------------- | ------------ |
-| `mongodb-database-plugin` | No                       | Yes           | Yes          |
+| `mongodb-database-plugin` | Yes                      | Yes           | Yes          |
 
 ## Setup
 


### PR DESCRIPTION
Update MongoDB docs to show that it supports root credential rotation.