### PR TITLE
Add upgrade note for #9553.

### DIFF
--- a/website/pages/docs/upgrading/upgrade-to-1.5.0.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.5.0.mdx
@@ -28,7 +28,7 @@ the configuration value as necessary. For additional details, please see
 ## Known Issues
 
 Enabling telemetry on 32-bit systems will cause Vault to crash.  A workaround for this
-issue is to disable collection of usage gauges in the telemetry stanza of the configuration.
+issue is to disable collection of usage gauges in the [telemetry](docs/configuration/telemetry) stanza of the configuration.
 
 ```
 telemetry {

--- a/website/pages/docs/upgrading/upgrade-to-1.5.0.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.5.0.mdx
@@ -24,5 +24,5 @@ telemetry {
 }
 ```
 
-This will suppress the metrics `vault.identity.entity.count`, `vault.identity.entity.alias.count`, `vault.token.count`, `vault.token.count.by_auth`, `vault.token.count.by_policy`, `vault.token.count.by_ttl` and `vault.secret.kv.count`, but all other Vault telemetry will remain available.
+This will suppress the metrics `vault.identity.entity.count`, `vault.identity.entity.alias.count`, `vault.token.count`, `vault.token.count.by_auth`, `vault.token.count.by_policy`, `vault.token.count.by_ttl` and `vault.secret.kv.count` that were introduced in version 1.5.0, but all other Vault telemetry will remain available.
 

--- a/website/pages/docs/upgrading/upgrade-to-1.5.0.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.5.0.mdx
@@ -1,0 +1,28 @@
+---
+layout: docs
+page_title: Upgrading to Vault 1.5.0 - Guides
+sidebar_title: Upgrade to 1.5.0
+description: |-
+  This page contains the list of deprecations and important or breaking changes
+  for Vault 1.5.0. Please read it carefully.
+---
+
+# Overview
+
+This page contains the list of deprecations and important or breaking changes
+for Vault 1.5.0 compared to 1.4.1. Please read it carefully.
+
+## Known Issues
+
+Enabling telemetry on 32-bit systems will cause Vault to crash.  A workaround for this
+issue is to disable collection of usage gauges in the telemetry stanza of the configuration.
+
+```
+telemetry {
+  ...
+  usage_gauge_period = "none"
+}
+```
+
+This will suppress the metrics `vault.identity.entity.count`, `vault.identity.entity.alias.count`, `vault.token.count`, `vault.token.count.by_auth`, `vault.token.count.by_policy`, `vault.token.count.by_ttl` and `vault.secret.kv.count`, but all other Vault telemetry will remain available.
+


### PR DESCRIPTION
https://github.com/hashicorp/vault/issues/9553 reports that telemetry crashes Vault on 32-bit systems. Nick already created a fix, but this upgrade note explains the problem and suggests a workaround.