### PR TITLE
Backport 1.5: plugin: fix process leak when Setup() fails (#9557)

### DIFF
--- a/builtin/plugin/backend.go
+++ b/builtin/plugin/backend.go
@@ -56,6 +56,7 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	}
 	err = raw.Setup(ctx, conf)
 	if err != nil {
+		raw.Cleanup(ctx)
 		return nil, err
 	}
 	// Get SpecialPaths and BackendType
@@ -108,6 +109,7 @@ func (b *PluginBackend) startBackend(ctx context.Context, storage logical.Storag
 	}
 	err = nb.Setup(ctx, b.config)
 	if err != nil {
+		nb.Cleanup(ctx)
 		return err
 	}
 


### PR DESCRIPTION
We've noticed some leftover processes from vault plugins on our boxes. Some
of them were even left over from previous instances of the service and reparented
to init.  This could cause issues if too many of them accumulate.

When running with TRACE logging the logs showed that there was an error return by
the call to Setup() the plugin. Looking through the code it looks like we do not
call Cleanup() in that case.

Co-authored-by: Sorin Dumitru <sorindumitru@users.noreply.github.com>