### PR TITLE
Fix links to documentation.

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -384,6 +384,7 @@ export default [
       'upgrade-to-1.3.5',
       'upgrade-to-1.4.0',
       'upgrade-to-1.4.1',
+      'upgrade-to-1.5.0',
     ],
   },
   '----------------',

--- a/website/pages/docs/upgrading/upgrade-to-1.5.0.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.5.0.mdx
@@ -23,14 +23,14 @@ configuration is 1MiB.
 In addition, a new metric has been introduced, `vault.raft-storage.entry_size`,
 that allows for operators to sample the entry size, view the average, and adjust
 the configuration value as necessary. For additional details, please see
-[Raft configuration](docs/configuration/storage/raft).
+[Raft configuration](/docs/configuration/storage/raft).
 
 ## Known Issues
 
 ### Enabling telemetry on 32-bit systems will cause Vault to crash.
 
 A workaround for this issue is to disable collection of usage gauges in
-the [telemetry](docs/configuration/telemetry) stanza of the configuration.
+the [telemetry](/docs/configuration/telemetry) stanza of the configuration.
 
 ```
 telemetry {

--- a/website/pages/docs/upgrading/upgrade-to-1.5.0.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.5.0.mdx
@@ -46,7 +46,7 @@ that were introduced in version 1.5.0, but all other Vault telemetry will remain
 
 ### Non-string values in seal config prevent startup
 
-Any values in the [Seal configuration stanza](https://www.vaultproject.io/docs/configuration/seal)
+Any values in the [Seal configuration stanza](/docs/configuration/seal)
 that are not quoted strings yield a parse error of the form:
 
 ```


### PR DESCRIPTION
The links at https://www.vaultproject.io/docs/upgrading/upgrade-to-1.5.0 were interpreted relative to "upgrading".

However, I don't see 1.5.0 listed in the index on the right, is there some other step necessary to get it to appear?


