### PR TITLE
Fix navigation for the Sentinel config and clarify module usage

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -86,6 +86,7 @@ export default [
           'zookeeper',
         ],
       },
+      'sentinel',
       {
         category: 'service-registration',
         content: ['consul', 'kubernetes'],

--- a/website/pages/docs/configuration/sentinel.mdx
+++ b/website/pages/docs/configuration/sentinel.mdx
@@ -9,7 +9,8 @@ description: |-
 
 # `sentinel` Stanza
 
-The sentinel stanza specifies configurations for Vault's Sentinel integration.
+The sentinel stanza specifies configurations for Vault's
+[Sentinel](https://docs.hashicorp.com/sentinel/) integration.
 
 ```hcl
 sentinel {
@@ -25,12 +26,18 @@ A valid Vault Enterprise license is required for use of Sentinel policies.
 
 The sentinel stanza currently supports only one parameter, `additional_enabled_modules`.
 
-- `additional_enabled_modules` `(string array: [])`` - Specifies a list of
-  sentinel policy modules to enable above the default set.  For example,
-  adding "http" to this list indicates sentinel policies may import
+- `additional_enabled_modules` `(string array: [])`` - By default Vault supports
+  all of Sentinel's [standard imports](https://docs.hashicorp.com/sentinel/imports/)
+  except "http", which has performance and security implications.
 
-  ~> **Warning**: Care should be taken when enabling some modules which
-  could have performance and security implications in policies.  For
-  example, enabling "http" could cause your Vault servers to submit outbound
-  requests to arbitrary endpoints.  See [the Sentinel Documentation](https://docs.hashicorp.com/sentinel/imports/http/)
-  for more information.
+  This parameter specifies a list of modules to allow.  At this time "http"
+  is the only candidate, but in the future other Sentinel modules that may not
+  be included could be overridden here.
+  
+
+  ~> **Warning**: Care should be taken when enabling modules which
+  could have performance and security implications in policies.  Enabling "http" 
+  could cause your Vault servers to submit outbound requests to arbitrary endpoints.  
+  See the 
+  [Sentinel HTTP Module ](https://docs.hashicorp.com/sentinel/imports/http/)
+  documentation for more information.

--- a/website/pages/docs/configuration/sentinel.mdx
+++ b/website/pages/docs/configuration/sentinel.mdx
@@ -9,8 +9,8 @@ description: |-
 
 # `sentinel` Stanza
 
-The sentinel stanza specifies configurations for Vault's
-[Sentinel](https://docs.hashicorp.com/sentinel/) integration.
+The sentinel stanza specifies configurations for 
+[Vault's Sentinel](https://www.vaultproject.io/docs/enterprise/sentinel) integration.
 
 ```hcl
 sentinel {

--- a/website/pages/docs/configuration/sentinel.mdx
+++ b/website/pages/docs/configuration/sentinel.mdx
@@ -26,18 +26,20 @@ A valid Vault Enterprise license is required for use of Sentinel policies.
 
 The sentinel stanza currently supports only one parameter, `additional_enabled_modules`.
 
-- `additional_enabled_modules` `(string array: [])`` - By default Vault supports
-  all of Sentinel's [standard imports](https://docs.hashicorp.com/sentinel/imports/)
-  except "http", which has performance and security implications.
+- `additional_enabled_modules` `(string array: [])`` - This parameter specifies a list of imports (modules)
+to allow in Sentinel policies.
 
-  This parameter specifies a list of modules to allow.  At this time "http"
-  is the only candidate, but in the future other Sentinel modules that may not
-  be included could be overridden here.
+  Vault currently enables all of Sentinel's [standard imports](https://docs.hashicorp.com/sentinel/imports/)
+  except the "http" import, which has performance and security implications. In the future, if any new Sentinel
+  imports are not automatically enabled by Vault, users could enable them in this stanza.
+  
+  Additionally, users can enable their own custom [import plugins](https://docs.hashicorp.com/sentinel/extending/plugins/)
+  in this stanza.
   
 
-  ~> **Warning**: Care should be taken when enabling modules which
-  could have performance and security implications in policies.  Enabling "http" 
-  could cause your Vault servers to submit outbound requests to arbitrary endpoints.  
+  ~> **Warning**: Care should be taken when enabling imports (modules) which
+  could have performance and security implications in policies.  Enabling the "http" import could cause your Vault
+  servers to submit outbound requests to arbitrary endpoints.  
   See the 
-  [Sentinel HTTP Module](https://docs.hashicorp.com/sentinel/imports/http/) 
+  [Sentinel HTTP Import](https://docs.hashicorp.com/sentinel/imports/http/) 
   documentation for more information.

--- a/website/pages/docs/configuration/sentinel.mdx
+++ b/website/pages/docs/configuration/sentinel.mdx
@@ -33,8 +33,6 @@ to allow in Sentinel policies.
   except the "http" import, which has performance and security implications. In the future, if any new Sentinel
   imports are not automatically enabled by Vault, users could enable them in this stanza.
   
-  Additionally, users can enable their own custom [import plugins](https://docs.hashicorp.com/sentinel/extending/plugins/)
-  in this stanza.
   
 
   ~> **Warning**: Care should be taken when enabling imports (modules) which

--- a/website/pages/docs/configuration/sentinel.mdx
+++ b/website/pages/docs/configuration/sentinel.mdx
@@ -32,10 +32,7 @@ to allow in Sentinel policies.
   Vault currently enables all of Sentinel's [standard imports](https://docs.hashicorp.com/sentinel/imports/)
   except the "http" import, which has performance and security implications. In the future, if any new Sentinel
   imports are not automatically enabled by Vault, users could enable them in this stanza.
-  Note that this setting only affects available imports, it cannot be used to load
-  custom modules.
-  
-  
+  Note that this setting cannot be used to load custom import plugins.
 
   ~> **Warning**: Care should be taken when enabling imports (modules) which
   could have performance and security implications in policies.  Enabling the "http" import could cause your Vault

--- a/website/pages/docs/configuration/sentinel.mdx
+++ b/website/pages/docs/configuration/sentinel.mdx
@@ -32,6 +32,8 @@ to allow in Sentinel policies.
   Vault currently enables all of Sentinel's [standard imports](https://docs.hashicorp.com/sentinel/imports/)
   except the "http" import, which has performance and security implications. In the future, if any new Sentinel
   imports are not automatically enabled by Vault, users could enable them in this stanza.
+  Note that this setting only affects available imports, it cannot be used to load
+  custom modules.
   
   
 

--- a/website/pages/docs/configuration/sentinel.mdx
+++ b/website/pages/docs/configuration/sentinel.mdx
@@ -39,5 +39,5 @@ The sentinel stanza currently supports only one parameter, `additional_enabled_m
   could have performance and security implications in policies.  Enabling "http" 
   could cause your Vault servers to submit outbound requests to arbitrary endpoints.  
   See the 
-  [Sentinel HTTP Module ](https://docs.hashicorp.com/sentinel/imports/http/)
+  [Sentinel HTTP Module](https://docs.hashicorp.com/sentinel/imports/http/) 
   documentation for more information.

--- a/website/pages/docs/secrets/gcp/index.mdx
+++ b/website/pages/docs/secrets/gcp/index.mdx
@@ -441,7 +441,7 @@ running into this limit, consider the following:
 
 ### Resources Must Exist at Roleset Creation
 
-Because we the bindings for the Service Account are set during roleset creation,
+Because the bindings for the Service Account are set during roleset creation,
 resources that do not exist will fail the `getIamPolicy` API call.
 
 ### Roleset Creation May Partially Fail


### PR DESCRIPTION
This hopefully get's the Sentinel stanza docs into the sidebar, and tries to
address any confusion around which modules Vault generally supports and the 
justification for additonal_enabled_modules.