### PR TITLE
Vault status version & storage listing in init too.

### DIFF
--- a/command/format.go
+++ b/command/format.go
@@ -335,6 +335,7 @@ func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusRespo
 	}
 
 	out = append(out, fmt.Sprintf("Version | %s", status.Version))
+	out = append(out, fmt.Sprintf("Storage Type | %s", status.StorageType))
 
 	if status.ClusterName != "" && status.ClusterID != "" {
 		out = append(out, fmt.Sprintf("Cluster Name | %s", status.ClusterName))
@@ -347,14 +348,14 @@ func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusRespo
 	if err != nil && strings.Contains(err.Error(), "Vault is sealed") {
 		leaderStatus = &api.LeaderResponse{HAEnabled: true}
 		err = nil
-	}
-	if err != nil {
+	} else if err != nil {
 		ui.Error(fmt.Sprintf("Error checking leader status: %s", err))
 		return 1
+	} else {
+		// Output if HA is enabled
+		out = append(out, fmt.Sprintf("HA Enabled | %t", leaderStatus.HAEnabled))
 	}
 
-	// Output if HA is enabled
-	out = append(out, fmt.Sprintf("HA Enabled | %t", leaderStatus.HAEnabled))
 	if leaderStatus.HAEnabled {
 		mode := "sealed"
 		if !status.Sealed {

--- a/command/format.go
+++ b/command/format.go
@@ -348,10 +348,12 @@ func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusRespo
 	if err != nil && strings.Contains(err.Error(), "Vault is sealed") {
 		leaderStatus = &api.LeaderResponse{HAEnabled: true}
 		err = nil
-	} else if err != nil {
+	} 
+	if err != nil {
 		ui.Error(fmt.Sprintf("Error checking leader status: %s", err))
 		return 1
-	} else {
+	}
+	if err == nil {
 		// Output if HA is enabled
 		out = append(out, fmt.Sprintf("HA Enabled | %t", leaderStatus.HAEnabled))
 	}

--- a/command/format.go
+++ b/command/format.go
@@ -353,10 +353,9 @@ func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusRespo
 		ui.Error(fmt.Sprintf("Error checking leader status: %s", err))
 		return 1
 	}
-	if err == nil {
-		// Output if HA is enabled
-		out = append(out, fmt.Sprintf("HA Enabled | %t", leaderStatus.HAEnabled))
-	}
+
+	// Output if HA is enabled
+	out = append(out, fmt.Sprintf("HA Enabled | %t", leaderStatus.HAEnabled))
 
 	if leaderStatus.HAEnabled {
 		mode := "sealed"

--- a/http/sys_seal.go
+++ b/http/sys_seal.go
@@ -199,6 +199,7 @@ func handleSysSealStatusRaw(core *vault.Core, w http.ResponseWriter, r *http.Req
 			Sealed:       true,
 			RecoverySeal: core.SealAccess().RecoveryKeySupported(),
 			StorageType:  core.StorageType(),
+			Version:      version.GetVersion().VersionNumber(),
 		})
 		return
 	}


### PR DESCRIPTION
Increased consistency with `vault status` providing version as well as storage type.
Fixes #9248
