### PR TITLE
Update OIDC docs

### DIFF
--- a/website/pages/docs/auth/jwt.mdx
+++ b/website/pages/docs/auth/jwt.mdx
@@ -230,7 +230,7 @@ EOF
   `cat jwt.json | jq -r .access_token | cut -d. -f2 | base64 -D`
 
 - As of Vault 1.2, the [`verbose_oidc_logging`](/api/auth/jwt#verbose_oidc_logging) role
-  option is available which will log the received OIDC token if debug-level logging is enabled. This can
+  option is available which will log the received OIDC token to the _server_ logs if debug-level logging is enabled. This can
   be helpful when debugging provider setup and verifying that the received claims are what you expect.
   Since claims data is logged verbatim and may contain sensitive information, this option should not be
   used in production.


### PR DESCRIPTION
Clarify that verbose logging is to the server logs.