### PR TITLE
Backport 1.5.1: Update GCP secrets plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.6.6
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.5.5
 	github.com/hashicorp/vault-plugin-secrets-azure v0.6.1
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.6.3
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.6.4-0.20200727183837-4005bee700bf
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.6
 	github.com/hashicorp/vault-plugin-secrets-kv v0.5.6
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -575,6 +575,8 @@ github.com/hashicorp/vault-plugin-secrets-gcp v0.6.3-0.20200615210754-6c617f9285
 github.com/hashicorp/vault-plugin-secrets-gcp v0.6.3-0.20200615210754-6c617f9285c3/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.6.3 h1:rf0yHgxuLxwUGAD0ZHFGxTUzoTEmVOvPnFCJYGr3nCU=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.6.3/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.6.4-0.20200727183837-4005bee700bf h1:7d6iDdI9/m9T6hF6TyNaqGoSqrEoToH7dL5q+iJyJNE=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.6.4-0.20200727183837-4005bee700bf/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.5 h1:NigzA2v+h+cjBPl41pRirRwWELF+RPJGch/ys0Sijrc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.5/go.mod h1:b6RwFD1bny1zbfqhD35iGJdQYHRtJLx3HfBD109GO38=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.6 h1:ihwn1Y/H6IRjouXAoiz3euwECGR2Zix7EerH/kmyWrQ=

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil/iam_policy.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil/iam_policy.go
@@ -103,6 +103,7 @@ func (p *Policy) ChangedBindings(toAdd *PolicyDelta, toRemove *PolicyDelta) (cha
 		return true, &Policy{
 			Bindings: newBindings,
 			Etag:     p.Etag,
+			Version:  p.Version,
 		}
 	}
 	return false, p

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -482,7 +482,7 @@ github.com/hashicorp/vault-plugin-secrets-alicloud
 github.com/hashicorp/vault-plugin-secrets-alicloud/clients
 # github.com/hashicorp/vault-plugin-secrets-azure v0.6.1
 github.com/hashicorp/vault-plugin-secrets-azure
-# github.com/hashicorp/vault-plugin-secrets-gcp v0.6.3
+# github.com/hashicorp/vault-plugin-secrets-gcp v0.6.4-0.20200727183837-4005bee700bf
 github.com/hashicorp/vault-plugin-secrets-gcp/plugin
 github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil
 github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util


### PR DESCRIPTION
Updates `go.mod` to bring in a GCP secrets plugin backport https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/94.

The following steps were taken:
1. `go get github.com/hashicorp/vault-plugin-secrets-gcp@release/vault-1.5.x`
2. `go mod tidy`
3. `go mod vendor`