### PR TITLE
Forward requests for rotate-root on Performance secondary / standbys

### DIFF
--- a/builtin/logical/aws/path_config_rotate_root.go
+++ b/builtin/logical/aws/path_config_rotate_root.go
@@ -14,8 +14,12 @@ import (
 func pathConfigRotateRoot(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "config/rotate-root",
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathConfigRotateRootUpdate,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback:                    b.pathConfigRotateRootUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
 		},
 
 		HelpSynopsis:    pathConfigRotateRootHelpSyn,


### PR DESCRIPTION
In the AWS secret backend, rotating root credentials first creates a new key pair before attempting to store the updated key. 

If the rotation request is sent to a performance standby, the new key gets created but saving to Vault state will fail due to the read-only access to state. The request is forwarded to the primary, and at that point the AWS user has 2 keys created; the original it was configured with, and the new key that failed to save. 

When the primary attempts to complete the request, it also tries to create a new key before saving it to state, triggering an AWS error `LimitExceeded: Cannot exceed quota for AccessKeysPerUser: 2`. This then bubbles up in a confusing error message:

```
Errors:
2 errors occurred:
* errors from both primary and secondary; primary error was error calling CreateAccessKey: LimitExceeded: Cannot exceed quota for AccessKeysPerUser: 2
status code: 409, request id: [Request 1234]; secondary errors follow
* error calling CreateAccessKey: LimitExceeded: Cannot exceed quota for AccessKeysPerUser: 2
status code: 409, request id: [Request 1234]
```

In this PR we update the `config/rotate-root` path to use the update `OperationHandler` attribute, and designate this request should be forwarded before even attempting it in the secondary.

An alternate solution would be to delete the key that was created but which failed to save to state. A PR that does just that will likely follow this one, however due to the eventual consistency nature of IAM in AWS I feel it's better to immediately forward the request instead. 

Similar PRs:

- https://github.com/hashicorp/vault/pull/8105
- https://github.com/hashicorp/vault-plugin-secrets-ad/pull/66