### PR TITLE
Backport 1.5.x: Forward requests for rotate-root on Performance secondary / standbys

### DIFF
--- a/builtin/logical/aws/path_config_rotate_root.go
+++ b/builtin/logical/aws/path_config_rotate_root.go
@@ -14,8 +14,12 @@ import (
 func pathConfigRotateRoot(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "config/rotate-root",
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathConfigRotateRootUpdate,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback:                    b.pathConfigRotateRootUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
 		},
 
 		HelpSynopsis:    pathConfigRotateRootHelpSyn,


### PR DESCRIPTION
Backport #9606; forward requests to AWS secret backend to rotate root config to primaries 