### PR TITLE
Add docs for OpenLDAP plugin's new AD schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 IMPROVEMENTS:
 
 * auth/jwt: Add support for fetching groups and user information from G Suite during authentication. [[GH-123](https://github.com/hashicorp/vault-plugin-auth-jwt/pull/123)]
-* secrets/openldap: Add "ad" schema that allows the engine to correctly rotate AD passwords.
+* secrets/openldap: Add "ad" schema that allows the engine to correctly rotate AD passwords. [[GH-16](https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/16)]
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 
 * auth/jwt: Add support for fetching groups and user information from G Suite during authentication. [[GH-123](https://github.com/hashicorp/vault-plugin-auth-jwt/pull/123)]
+* secrets/openldap: Add "ad" schema that allows the engine to correctly rotate AD passwords.
 
 BUG FIXES:
 
@@ -24,7 +25,6 @@ IMPROVEMENTS:
 BUG FIXES:
 
 * secrets/gcp: Ensure that the IAM policy version is appropriately set after a roleset's bindings have changed. [[GH-9603](https://github.com/hashicorp/vault/pull/9603)]
-* secrets/openldap: Add "ad" schema that allows the engine to correctly rotate AD passwords.
 
 ## 1.5.0
 ### July 21st, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
 * secrets/gcp: Ensure that the IAM policy version is appropriately set after a roleset's bindings have changed. [[GH-9603](https://github.com/hashicorp/vault/pull/9603)]
+* secrets/openldap: Add "ad" schema that allows the engine to correctly rotate AD passwords.
 
 ## 1.5.0
 ### July 21st, 2020

--- a/website/pages/api-docs/secret/openldap/index.mdx
+++ b/website/pages/api-docs/secret/openldap/index.mdx
@@ -40,7 +40,7 @@ to search and change entry passwords in OpenLDAP.
 - `password_policy` `(string: <optional>)` - The name of the [password policy](/docs/concepts/password-policies)
   to use to generate passwords. Note that this accepts the name of the policy, not the policy itself.
 - `schema` `(string: "openldap")` - The OpenLDAP schema to use when storing entry passwords.
-  Valid schemas include:`openldap` and `racf`.
+  Valid schemas include:`openldap`, `racf` and `ad`.
 - `request_timeout` `(integer: 90, string: "90s" <optional>)` - Timeout, in seconds, for the connection when
   making requests against the server before returning back an error.
 - `starttls` `(bool: <optional>)` - If true, issues a `StartTLS` command after establishing an unencrypted connection.

--- a/website/pages/docs/secrets/openldap/index.mdx
+++ b/website/pages/docs/secrets/openldap/index.mdx
@@ -63,8 +63,8 @@ This plugin currently supports LDAP v3.
 
 ## Schema
 
-The OpenLDAP Secret Engine supports two different schemas: `openldap` (default) and
-`racf`.
+The OpenLDAP Secret Engine supports three different schemas: `openldap` (default),
+`racf` and `ad`.
 
 ### OpenLDAP
 
@@ -91,6 +91,19 @@ vault write openldap/config \
 	url=ldaps://138.91.247.105 \
 	schema=racf \
 	password_policy=racf_password_policy
+```
+
+### Active Directory (AD)
+
+For managing Active Directory instances, the secret engine must be configured to use the
+schema `ad`.
+
+```bash
+vault write openldap/config \
+	binddn=$USERNAME \
+	bindpass=$PASSWORD \
+	url=ldaps://138.91.247.105 \
+	schema=ad
 ```
 
 ## Password Generation


### PR DESCRIPTION
This PR adds documentation for a new `"ad"` schema for the OpenLDAP plugin. This is to support rotating passwords using the `unicodePwd` field instead of `userPassword`.

See https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/16 for the implementation.