### PR TITLE
Make manualStepDownCh a 1-buffered channel to ensure StepDown works in tests

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1493,7 +1493,7 @@ func (c *Core) unsealInternal(ctx context.Context, masterKey []byte) (bool, erro
 	} else {
 		// Go to standby mode, wait until we are active to unseal
 		c.standbyDoneCh = make(chan struct{})
-		c.manualStepDownCh = make(chan struct{})
+		c.manualStepDownCh = make(chan struct{}, 1)
 		c.standbyStopCh.Store(make(chan struct{}))
 		go c.runStandby(c.standbyDoneCh, c.manualStepDownCh, c.standbyStopCh.Load().(chan struct{}))
 	}

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -1250,7 +1250,7 @@ func TestCore_Standby_Seal(t *testing.T) {
 
 func TestCore_StepDown(t *testing.T) {
 	// Create the first core and initialize it
-	logger = logging.NewVaultLogger(log.Trace)
+	logger = logging.NewVaultLogger(log.Trace).Named(t.Name())
 
 	inm, err := inmem.NewInmemHA(nil, logger)
 	if err != nil {
@@ -1267,6 +1267,7 @@ func TestCore_StepDown(t *testing.T) {
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal,
 		DisableMlock: true,
+		Logger:       logger.Named("core1"),
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -1305,6 +1306,7 @@ func TestCore_StepDown(t *testing.T) {
 		HAPhysical:   inmha.(physical.HABackend),
 		RedirectAddr: redirectOriginal2,
 		DisableMlock: true,
+		Logger:       logger.Named("core2"),
 	})
 	if err != nil {
 		t.Fatalf("err: %v", err)


### PR DESCRIPTION
Here's an example of the intermittent test failure we're trying to fix: https://app.circleci.com/pipelines/github/hashicorp/vault/11021/workflows/d78cf5ce-9c18-4195-84db-0408ed1f36b8/jobs/73404/steps

```
2020-07-29T10:44:48.730Z [WARN]  core: manual step-down operation already queued
2020-07-29T10:44:48.730Z [INFO]  core: entering standby mode
    core_test.go:1370: should be standby
```

What seems to be happening is that although we've become the leader, we haven't yet started reading from manualStepDownCh, so when `Core.StepDown` gets here:

```
	select {
	case c.manualStepDownCh <- struct{}{}:
	default:
		c.logger.Warn("manual step-down operation already queued")
	}
```

it merely logs without stepping down.