### PR TITLE
Docs: Mark MongoDB Atlas as supporting static creds

### DIFF
--- a/website/pages/docs/secrets/databases/index.mdx
+++ b/website/pages/docs/secrets/databases/index.mdx
@@ -146,8 +146,8 @@ the proper permission, it can generate credentials.
 ## Custom Plugins
 
 This secrets engine allows custom database types to be run through the exposed
-plugin interface. Please see the [custom database plugin]
-(/docs/secrets/databases/custom) for more information.
+plugin interface. Please see the [custom database plugin](/docs/secrets/databases/custom)
+for more information.
 
 ## Password Generation
 
@@ -155,8 +155,7 @@ Password generation for both static and dynamic database credentials occurs via
 the `GetPassword()` function. For static credentials, the `SetCredentials()`
 function is also used on the output of `GetPassword().`
 
-Please see the [DB plugin credentials source code]
-(https://github.com/hashicorp/vault/blob/master/sdk/database/dbplugin/database.pb.go)
+Please see the [DB plugin credentials source code](https://github.com/hashicorp/vault/blob/master/sdk/database/dbplugin/database.pb.go)
 for more information.
 
 ## Learn

--- a/website/pages/docs/secrets/databases/mongodbatlas.mdx
+++ b/website/pages/docs/secrets/databases/mongodbatlas.mdx
@@ -20,7 +20,7 @@ more information about setting up the database secrets engine.
 ## Capabilities
 | Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
 | --- | --- | --- | --- |
-| `mongodbatlas-database-plugin` | No | Yes | No |
+| `mongodbatlas-database-plugin` | No | Yes | Yes |
 
 ## Setup
 

--- a/website/pages/docs/secrets/databases/oracle.mdx
+++ b/website/pages/docs/secrets/databases/oracle.mdx
@@ -10,8 +10,8 @@ description: |-
 
 # Oracle Database Secrets Engine
 
-This secrets engine is a part of the Database Secrets Engine. If you have not read the [Database Backend]
-(/docs/secrets/databases) page, please do so now as it explains how to set up the database backend and
+This secrets engine is a part of the Database Secrets Engine. If you have not read the
+[Database Backend](/docs/secrets/databases) page, please do so now as it explains how to set up the database backend and
 gives an overview of how the engine functions.
 
 Oracle is one of the supported plugins for the database secrets engine. It is capable of dynamically generating


### PR DESCRIPTION
Fixes a copy-paste error in the MongoDB Atlas docs. It does support static credential rotation.

This also fixes some links that are not rendering properly with a newline between the text and the link.