### PR TITLE
Operator members

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -412,6 +412,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"operator members": func() (cli.Command, error) {
+			return &OperatorMembersCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"path-help": func() (cli.Command, error) {
 			return &PathHelpCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/operator_members.go
+++ b/command/operator_members.go
@@ -1,0 +1,104 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+var _ cli.Command = (*OperatorMembersCommand)(nil)
+var _ cli.CommandAutocomplete = (*OperatorMembersCommand)(nil)
+
+type OperatorMembersCommand struct {
+	*BaseCommand
+}
+
+func (c *OperatorMembersCommand) Synopsis() string {
+	return "Returns the list of Nodes in the cluster"
+}
+
+func (c *OperatorMembersCommand) Help() string {
+	helpText := `
+Usage: vault operator members
+  Provides the details of all the nodes in the cluster.
+	  $ vault operator members
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorMembersCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP | FlagSetOutputFormat)
+
+	return set
+}
+
+func (c *OperatorMembersCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictAnything
+}
+
+func (c *OperatorMembersCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *OperatorMembersCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	r := client.NewRequest("GET", "/v1/sys/ha-status")
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	resp, err := client.RawRequestWithContext(ctx, r)
+	if err != nil {
+		return 1
+	}
+	defer resp.Body.Close()
+
+	var result HaStatusResponse
+	err = resp.DecodeJSON(&result)
+
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	switch Format(c.UI) {
+	case "table":
+		leader := result.Leader
+		nodes := result.Standby
+		out := []string{"Host Name | API Address | Cluster Address | Type"}
+		out = append(out, fmt.Sprintf("%s | %s | %s | %s", leader.HostName, leader.ApiAddress, leader.ClusterAddress, "Active"))
+		for _, node := range nodes {
+			out = append(out, fmt.Sprintf("%s | %s | %s | %s", node.HostName, node.ApiAddress, node.ClusterAddress, "Standby"))
+		}
+		c.UI.Output(tableOutput(out, nil))
+		return 0
+	default:
+		return OutputData(c.UI, result)
+	}
+}
+
+type NodeAddr struct {
+	HostName       string `json:"host_name"`
+	ApiAddress     string `json:"api_addr"`
+	ClusterAddress string `json:"cluster_addr"`
+}
+
+type HaStatusResponse struct {
+	Leader      NodeAddr   `json:"leader"`
+	PerfStandby []NodeAddr `json:"performance_standby"`
+	Standby     []NodeAddr `json:"standby"`
+}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf
 	github.com/aws/aws-sdk-go v1.30.27
 	github.com/bitly/go-hostpool v0.1.0 // indirect
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/chrismalek/oktasdk-go v0.0.0-20181212195951-3430665dfaa0
 	github.com/client9/misspell v0.3.4
 	github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c

--- a/http/handler.go
+++ b/http/handler.go
@@ -132,6 +132,7 @@ func Handler(props *vault.HandlerProperties) http.Handler {
 		mux.Handle("/v1/sys/step-down", handleRequestForwarding(core, handleSysStepDown(core)))
 		mux.Handle("/v1/sys/unseal", handleSysUnseal(core))
 		mux.Handle("/v1/sys/leader", handleSysLeader(core))
+		mux.Handle("/v1/sys/ha-status", handleSysHaStatus(core))
 		mux.Handle("/v1/sys/health", handleSysHealth(core))
 		mux.Handle("/v1/sys/monitor", handleLogicalNoForward(core))
 		mux.Handle("/v1/sys/generate-root/attempt", handleRequestForwarding(core,

--- a/http/sys_ha_status.go
+++ b/http/sys_ha_status.go
@@ -37,10 +37,6 @@ func handleSysHaStatusGet(core *vault.Core, w http.ResponseWriter, r *http.Reque
 
 		}
 	}
-	if err != nil {
-		respondError(w, http.StatusInternalServerError, err)
-		return
-	}
 	h, _ := host.Info()
 	leaderAddr := NodeAddr{
 		HostName:       h.Hostname,

--- a/http/sys_ha_status.go
+++ b/http/sys_ha_status.go
@@ -1,0 +1,65 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/vault"
+	"github.com/shirou/gopsutil/host"
+)
+
+func handleSysHaStatus(core *vault.Core) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			handleSysHaStatusGet(core, w, r)
+		default:
+			respondError(w, http.StatusMethodNotAllowed, nil)
+		}
+	})
+}
+
+func handleSysHaStatusGet(core *vault.Core, w http.ResponseWriter, r *http.Request) {
+	_, address, clusterAddr, err := core.Leader()
+	if errwrap.Contains(err, vault.ErrHANotEnabled.Error()) {
+		err = nil
+	}
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err)
+		return
+	}
+	h, _ := host.Info()
+	leaderAddr := NodeAddr{
+		HostName:       h.Hostname,
+		ApiAddress:     address,
+		ClusterAddress: clusterAddr,
+	}
+
+	addrsCache := core.GetclusterPeerClusterAddrsCache()
+	standbyAddr := []NodeAddr{}
+	for itemClusterAddr, item := range addrsCache {
+		standbyAddr = append(standbyAddr, NodeAddr{
+			ClusterAddress: itemClusterAddr,
+			ApiAddress:     item.Object.(*vault.NodeInformation).ApiAddr,
+			HostName:       item.Object.(*vault.NodeInformation).NodeID,
+		})
+	}
+	resp := &HaStatusResponse{
+		Leader:  &leaderAddr,
+		Standby: &standbyAddr,
+	}
+
+	respondOk(w, resp)
+}
+
+type NodeAddr struct {
+	HostName       string `json:"host_name"`
+	ApiAddress     string `json:"api_addr"`
+	ClusterAddress string `json:"cluster_addr"`
+}
+
+type HaStatusResponse struct {
+	Leader      *NodeAddr   `json:"leader"`
+	PerfStandby *[]NodeAddr `json:"performance_standby"`
+	Standby     *[]NodeAddr `json:"standby"`
+}

--- a/vault/core.go
+++ b/vault/core.go
@@ -2543,3 +2543,9 @@ func (c *Core) RateLimitResponseHeadersEnabled() bool {
 
 	return false
 }
+
+// GetclusterPeerClusterAddrsCache returns a map with the contents of the PeerCluster cache
+func (c *Core) GetclusterPeerClusterAddrsCache() map[string]cache.Item {
+
+	return c.clusterPeerClusterAddrsCache.Items()
+}


### PR DESCRIPTION
# Goals
* Show a global view of the HA cluster by showing the status and addresses of the active Node and standby nodes.

# Non-Goals
* Show status of cluster replication 
* Detailed information of the hosts
  
# How
* Reuse the NodeInformation field of the EchoReply message for the RequestForwarding service. (done)
* Insert the NodeInformation as the value of the clusterPeerClusterAddrsCache key. (done)
* Create API endpoint that will show the information (done)
* Create a CLI command (done)

# TODO
* Create tests

# Model to follow
```log
# consul members
Node              Address              Status  Type    Build      Protocol  DC       Segment
primary-unsealer  10.201.175.155:8301  alive   client  1.7.2+ent  2         primary  <default>
primary-vault01   10.201.175.119:8301  alive   client  1.7.2+ent  2         primary  <default>
primary-vault02   10.201.175.228:8301  alive   client  1.7.2+ent  2         primary  <default>
primary-vault03   10.201.175.214:8301  alive   client  1.7.2+ent  2         primary  <default>
```
# Proposed UX via cli
HA mode
```log
$ vault operator members
Host Name    API Address               Cluster Address           Type
---------    -----------               ---------------           ----
LXC1         https://127.0.0.2:8200    https://127.0.0.2:8201    Active
LXC2         https://127.0.0.4:8200    https://127.0.0.4:8201    Standby
LXC3         https://127.0.0.3:8200    https://127.0.0.3:8301    Standby
```
Non HA Mode
```log
$ vault operator members
Host Name    API Address       Cluster Address    Type
---------    -----------       ---------------    ----
LXC1         127.0.0.1:8200    n/a                Active
```
Sealed

```log
$ vault operator members
Error: Vault is sealed
```
# Proposed UX via API

`/sys/ha-status`

```json
{
  "leader": {
    "host_name": "LXC1",
    "api_addr": "https://127.0.0.2:8200",
    "cluster_addr": "https://127.0.0.2:8201"
  },
  "performance_standby": null,
  "standby": [
    {
      "host_name": "LXC2",
      "api_addr": "https://127.0.0.3:8200",
      "cluster_addr": "https://127.0.0.3:8301"
    },
    {
      "host_name": "LXC3",
      "api_addr": "https://127.0.0.4:8200",
      "cluster_addr": "https://127.0.0.4:8201"
    }
  ]
}
```