### PR TITLE
Log sanitized config at startup and when it changes.

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -7,6 +7,7 @@ import (
 	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -2424,7 +2425,8 @@ func (c *Core) SetLogLevel(level log.Level) {
 // SetConfig sets core's config object to the newly provided config.
 func (c *Core) SetConfig(conf *server.Config) {
 	c.rawConfig.Store(conf)
-	c.logger.Debug("set config", "sanitized config", c.SanitizedConfig())
+	bz, _ := json.Marshal(c.SanitizedConfig())
+	c.logger.Debug("set config", "sanitized config", string(bz))
 }
 
 // SanitizedConfig returns a sanitized version of the current config.

--- a/vault/core.go
+++ b/vault/core.go
@@ -2425,7 +2425,12 @@ func (c *Core) SetLogLevel(level log.Level) {
 // SetConfig sets core's config object to the newly provided config.
 func (c *Core) SetConfig(conf *server.Config) {
 	c.rawConfig.Store(conf)
-	bz, _ := json.Marshal(c.SanitizedConfig())
+	bz, err := json.Marshal(c.SanitizedConfig())
+	if err != nil {
+		c.logger.Error("error serializing sanitized config", "error", err)
+		return
+	}
+
 	c.logger.Debug("set config", "sanitized config", string(bz))
 }
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -761,8 +761,6 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	}
 	c.standbyStopCh.Store(make(chan struct{}))
 
-	c.rawConfig.Store(conf.RawConfig)
-
 	atomic.StoreUint32(c.sealed, 1)
 	c.metricSink.SetGaugeWithLabels([]string{"core", "unsealed"}, 0, nil)
 
@@ -770,6 +768,8 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 
 	c.router.logger = c.logger.Named("router")
 	c.allLoggers = append(c.allLoggers, c.router.logger)
+
+	c.SetConfig(conf.RawConfig)
 
 	atomic.StoreUint32(c.replicationState, uint32(consts.ReplicationDRDisabled|consts.ReplicationPerformanceDisabled))
 	c.localClusterCert.Store(([]byte)(nil))
@@ -2424,6 +2424,7 @@ func (c *Core) SetLogLevel(level log.Level) {
 // SetConfig sets core's config object to the newly provided config.
 func (c *Core) SetConfig(conf *server.Config) {
 	c.rawConfig.Store(conf)
+	c.logger.Debug("set config", "sanitized config", c.SanitizedConfig())
 }
 
 // SanitizedConfig returns a sanitized version of the current config.


### PR DESCRIPTION
Example log line:

```
...
2020-07-30T12:28:41.421-0400 [DEBUG] core: set config: sanitized config={"api_addr":"","cache_size":0,"cluster_addr":"","cluster_cipher_suites":"","cluster_name":"","default_lease_ttl":0,"default_max_request_duration":0,"disable_cache":false,"disable_clustering":false,"disable_indexing":false,"disable_mlock":true,"disable_performance_standby":false,"disable_printable_check":false,"disable_sealwrap":false,"enable_ui":true,"listeners":[{"config":{"address":"127.0.0.1:8200","proxy_protocol_authorized_addrs":"127.0.0.1:8200","proxy_protocol_behavior":"allow_authorized","tls_disable":true},"type":"tcp"}],"log_format":"unspecified","log_level":"","max_lease_ttl":0,"pid_file":"","plugin_directory":"","raw_storage_endpoint":false,"seals":[{"disabled":false,"type":"shamir"}],"storage":{"cluster_addr":"","disable_clustering":false,"redirect_addr":"","type":"inmem"},"telemetry":{"circonus_api_app":"","circonus_api_token":"","circonus_api_url":"","circonus_broker_id":"","circonus_broker_select_tag":"","circonus_check_display_name":"","circonus_check_force_metric_activation":"","circonus_check_id":"","circonus_check_instance_id":"","circonus_check_search_tag":"","circonus_check_tags":"","circonus_submission_interval":"","circonus_submission_url":"","disable_hostname":true,"dogstatsd_addr":"","dogstatsd_tags":null,"maximum_gauge_cardinality":500,"metrics_prefix":"","prometheus_retention_time":86400000000000,"stackdriver_debug_logs":false,"stackdriver_location":"","stackdriver_namespace":"","stackdriver_project_id":"","statsd_address":"","statsite_address":"","usage_gauge_period":600000000000}}
2020-07-30T12:28:41.421-0400 [DEBUG] storage.cache: creating LRU cache: size=0
2020-07-30T12:28:41.422-0400 [DEBUG] cluster listener addresses synthesized: cluster_addresses=[127.0.0.1:8201]
...
```