### PR TITLE
Backport 1.5.x: forward AWS config rotations (#9606)

### DIFF
--- a/builtin/logical/aws/path_config_rotate_root.go
+++ b/builtin/logical/aws/path_config_rotate_root.go
@@ -14,8 +14,12 @@ import (
 func pathConfigRotateRoot(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "config/rotate-root",
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathConfigRotateRootUpdate,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback:                    b.pathConfigRotateRootUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
 		},
 
 		HelpSynopsis:    pathConfigRotateRootHelpSyn,


### PR DESCRIPTION
Backports #9606 to the 1.5.x branch

Forward root rotation requests from performance standby/secondaries to the primary