### PR TITLE
Fixed `vault operator init -status` which conflicted with `vault status`

### DIFF
--- a/vault/init.go
+++ b/vault/init.go
@@ -77,7 +77,8 @@ func (c *Core) Initialized(ctx context.Context) (bool, error) {
 		c.logger.Error("barrier init check failed", "error", err)
 		return false, err
 	}
-	if !init {
+	// raft.Info set when operator raft join is already invoked - thus init is began with node needing unsealing.
+	if !init && c.raftInfo == nil {
 		c.logger.Info("security barrier not initialized")
 		return false, nil
 	}


### PR DESCRIPTION
when in raft join during init & not yet unsealed. Resolves: #9618