### PR TITLE
docs: fixes environment variable in azure secrets config API

### DIFF
--- a/website/pages/api-docs/secret/azure/index.mdx
+++ b/website/pages/api-docs/secret/azure/index.mdx
@@ -32,7 +32,7 @@ service principals. Environment variables will override any parameters set in th
 - `client_id` (`string:""`) - The OAuth2 client id to connect to Azure. This value can also be provided
   with the AZURE_CLIENT_ID environment variable. See [authentication](/docs/secrets/azure#authentication) for more details.
 - `client_secret` (`string:""`) - The OAuth2 client secret to connect to Azure. This value can also be
-  provided with the AZURE_CLIENT_ID environment variable. See [authentication](/docs/secrets/azure#authentication) for more details.
+  provided with the AZURE_CLIENT_SECRET environment variable. See [authentication](/docs/secrets/azure#authentication) for more details.
 - `environment` (`string:""`) - The Azure environment. This value can also be provided with the AZURE_ENVIRONMENT
   environment variable. If not specified, Vault will use Azure Public Cloud.
 - `password_policy` `(string: "")` - Specifies a [password policy](/docs/concepts/password-policies) to


### PR DESCRIPTION
This PR fixes the `client_secret` environment variable in the Azure Secrets config API documentation.