### PR TITLE
Update index.mdx

### DIFF
--- a/website/pages/api-docs/auth/userpass/index.mdx
+++ b/website/pages/api-docs/auth/userpass/index.mdx
@@ -27,7 +27,7 @@ Create a new user or update an existing user. This path honors the distinction b
 
 ### Parameters
 
-- `username` `(string: <required>)` – The username for the user.
+- `username` `(string: <required>)` – The username for the user. Accepted characters: alphanumeric plus "\_", "-", "." (underscore, hyphen and period).
 - `password` `(string: <required>)` - The password for the user. Only required
   when creating the user.
 

--- a/website/pages/api-docs/auth/userpass/index.mdx
+++ b/website/pages/api-docs/auth/userpass/index.mdx
@@ -27,7 +27,7 @@ Create a new user or update an existing user. This path honors the distinction b
 
 ### Parameters
 
-- `username` `(string: <required>)` – The username for the user. Accepted characters: alphanumeric plus "\_", "-", "." (underscore, hyphen and period).
+- `username` `(string: <required>)` – The username for the user. Accepted characters: alphanumeric plus "_", "-", "." (underscore, hyphen and period); username cannot begin with hyphen or period.
 - `password` `(string: <required>)` - The password for the user. Only required
   when creating the user.
 


### PR DESCRIPTION
The Vault userpass auth method only accepts specific characters for a username, as per the regex string within its function. This PR updates the documentation to indicate the acceptable characters, previously undocumented.
This [Slack thread discusses the details](https://hashicorp.slack.com/archives/C04L34UGZ/p1596816678335100) with @mgritter, but the function is listed below for convenience. 

```
func GenericNameRegex(name string) string {
	return fmt.Sprintf("(?P<%s>\\w(([\\w-.]+)?\\w)?)", name)
}
```
