### PR TITLE
Ui/wrap tool ttl

### DIFF
--- a/ui/app/components/tool-actions-form.js
+++ b/ui/app/components/tool-actions-form.js
@@ -137,6 +137,11 @@ export default Component.extend(DEFAULTS, {
       this.reset();
     },
 
+    updateTtl(evt) {
+      const ttl = evt.enabled ? `${evt.seconds}s` : '30m';
+      set(this, wrapTTL, ttl);
+    },
+
     codemirrorUpdated(val, codemirror) {
       codemirror.performLint();
       const hasErrors = codemirror.state.lint.marked.length > 0;

--- a/ui/app/components/tool-actions-form.js
+++ b/ui/app/components/tool-actions-form.js
@@ -139,7 +139,7 @@ export default Component.extend(DEFAULTS, {
 
     updateTtl(evt) {
       const ttl = evt.enabled ? `${evt.seconds}s` : '30m';
-      set(this, wrapTTL, ttl);
+      set(this, 'wrapTTL', ttl);
     },
 
     codemirrorUpdated(val, codemirror) {

--- a/ui/app/templates/partials/tools/wrap.hbs
+++ b/ui/app/templates/partials/tools/wrap.hbs
@@ -52,7 +52,13 @@
         }}
       </div>
     </div>
-  {{ttl-picker labelText='Wrap TTL' onChange=(action (mut wrapTTL))}}
+    <TtlPicker2
+      @label="Wrap TTL"
+      @initialValue="30m"
+      @onChange={{action 'updateTtl'}}
+      @helperTextDisabled="Vault will use the default (30m)"
+      @helperTextEnabled="Wrap will expire after"
+    />
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">

--- a/ui/app/templates/partials/tools/wrap.hbs
+++ b/ui/app/templates/partials/tools/wrap.hbs
@@ -58,6 +58,7 @@
       @onChange={{action 'updateTtl'}}
       @helperTextDisabled="Vault will use the default (30m)"
       @helperTextEnabled="Wrap will expire after"
+      @changeOnInit={{true}}
     />
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">


### PR DESCRIPTION
This PR updates the TTL Picker in the Wrap Tool UI, fixing an issue where the wrap is created with the wrong TTL if the TTL value is not adjusted.

**In Action:** 
![wrap-tool-ttl](https://user-images.githubusercontent.com/16182107/89691583-e0869380-d8ce-11ea-855d-31f0065fff86.gif)
