### PR TITLE
Update reported version to 1.5.0

### DIFF
--- a/sdk/version/version_base.go
+++ b/sdk/version/version_base.go
@@ -8,7 +8,7 @@ var (
 	// Whether cgo is enabled or not; set at build time
 	CgoEnabled bool
 
-	Version           = "1.4.0"
+	Version           = "1.5.0"
 	VersionPrerelease = ""
 	VersionMetadata   = ""
 )


### PR DESCRIPTION
Seeing 1.4.0 displayed in the UI during development is confusing.