### PR TITLE
Backport 1.5.1: UI: Update DR Operation token workflow with corrected instructions

### DIFF
--- a/ui/lib/core/addon/templates/components/shamir-modal-flow.hbs
+++ b/ui/lib/core/addon/templates/components/shamir-modal-flow.hbs
@@ -50,7 +50,9 @@
           </p>
           <div class="message is-list has-copy-button" tabindex="-1">
             {{#let (if otp
-              (concat 'vault operator generate-root -otp="' otp '" -decode="' encoded_token '"') (concat 'vault operator generate-root -otp="<enter your otp here>" -decode="' encoded_token '"') ) as |cmd|}}
+              (concat 'vault operator generate-root -dr-token -otp="' otp '" -decode="' encoded_token '"')
+              (concat 'vault operator generate-root -dr-token -otp="<enter your otp here>" -decode="' encoded_token '"')
+              ) as |cmd|}}
               <HoverCopyButton @copyValue={{cmd}} />
               <code class="is-word-break">{{cmd}}</code>
             {{/let}}


### PR DESCRIPTION
[Original PR](https://github.com/hashicorp/vault/pull/9675)

The original workflow for generating a DR Operation Token was missing a flag.