### PR TITLE
Backport 1.5.1: UI: Wrap tool ttl picker updated (#9691)

### DIFF
--- a/ui/app/components/tool-actions-form.js
+++ b/ui/app/components/tool-actions-form.js
@@ -137,6 +137,11 @@ export default Component.extend(DEFAULTS, {
       this.reset();
     },
 
+    updateTtl(evt) {
+      const ttl = evt.enabled ? `${evt.seconds}s` : '30m';
+      set(this, 'wrapTTL', ttl);
+    },
+
     codemirrorUpdated(val, codemirror) {
       codemirror.performLint();
       const hasErrors = codemirror.state.lint.marked.length > 0;

--- a/ui/app/templates/partials/tools/wrap.hbs
+++ b/ui/app/templates/partials/tools/wrap.hbs
@@ -52,7 +52,14 @@
         }}
       </div>
     </div>
-  {{ttl-picker labelText='Wrap TTL' onChange=(action (mut wrapTTL))}}
+    <TtlPicker2
+      @label="Wrap TTL"
+      @initialValue="30m"
+      @onChange={{action 'updateTtl'}}
+      @helperTextDisabled="Vault will use the default (30m)"
+      @helperTextEnabled="Wrap will expire after"
+      @changeOnInit={{true}}
+    />
   </div>
   <div class="field is-grouped box is-fullwidth is-bottomless">
     <div class="control">


### PR DESCRIPTION
[Original PR](https://github.com/hashicorp/vault/pull/9691)

This change fixes unexpected behavior from the original TTL Picker where if left untouched, the TTL value used in the wrap tool differs from the value displayed in the UI.