### PR TITLE
fix github star count on website

### DIFF
--- a/website/components/subnav/index.jsx
+++ b/website/components/subnav/index.jsx
@@ -14,7 +14,7 @@ export default function ProductSubnav() {
       ctaLinks={[
         {
           text: 'GitHub',
-          url: 'https://github.com/hashicorp/vault',
+          url: 'https://www.github.com/hashicorp/vault',
         },
         {
           text: 'Download',


### PR DESCRIPTION
Just a small bugfix!

Updated appearance:

![](https://p176.p0.n0.cdn.getcloudapp.com/items/ApukjA65/Screen%20Shot%202020-08-11%20at%203.49.03%20PM.png?v=49d56e7228dd16e9019a8f38afa247e6)