### PR TITLE
Backport 1.5.x: UI Transit: Add missed algorithms (#9070)

### DIFF
--- a/ui/app/templates/partials/transit-form-create.hbs
+++ b/ui/app/templates/partials/transit-form-create.hbs
@@ -16,6 +16,9 @@
             onchange={{action (mut key.type) value="target.value"}}
             data-test-transit-key-type=true
           >
+            <option selected={{eq key.type "aes128-gcm96"}} value="aes128-gcm96">
+              aes128-gcm96
+            </option>
             <option selected={{eq key.type "aes256-gcm96"}} value="aes256-gcm96">
               aes256-gcm96
             </option>
@@ -24,6 +27,12 @@
             </option>
             <option selected={{eq key.type "ecdsa-p256"}} value="ecdsa-p256">
               ecdsa-p256
+            </option>
+            <option selected={{eq key.type "ecdsa-p384"}} value="ecdsa-p384">
+              ecdsa-p384
+            </option>
+            <option selected={{eq key.type "ecdsa-p521"}} value="ecdsa-p521">
+              ecdsa-p521
             </option>
             <option selected={{eq key.type "ed25519"}} value="ed25519">
               ed25519
@@ -56,6 +65,7 @@
       </div>
     </div>
     {{#if (or
+        (eq key.type "aes128-gcm96")
         (eq key.type "aes256-gcm96")
         (eq key.type "chacha20-poly1305")
         (eq key.type "ed25519")
@@ -77,6 +87,7 @@
       </div>
     {{/if}}
     {{#if (or
+        (eq key.type "aes128-gcm96")
         (eq key.type "aes256-gcm96")
         (eq key.type "chacha20-poly1305")
       )

--- a/ui/tests/acceptance/transit-test.js
+++ b/ui/tests/acceptance/transit-test.js
@@ -9,6 +9,18 @@ import secretListPage from 'vault/tests/pages/secrets/backend/list';
 const keyTypes = [
   {
     name: ts => `aes-${ts}`,
+    type: 'aes128-gcm96',
+    exportable: true,
+    supportsEncryption: true,
+  },
+  {
+    name: ts => `aes-convergent-${ts}`,
+    type: 'aes128-gcm96',
+    convergent: true,
+    supportsEncryption: true,
+  },
+  {
+    name: ts => `aes-${ts}`,
     type: 'aes256-gcm96',
     exportable: true,
     supportsEncryption: true,
@@ -34,6 +46,18 @@ const keyTypes = [
   {
     name: ts => `ecdsa-${ts}`,
     type: 'ecdsa-p256',
+    exportable: true,
+    supportsSigning: true,
+  },
+  {
+    name: ts => `ecdsa-${ts}`,
+    type: 'ecdsa-p384',
+    exportable: true,
+    supportsSigning: true,
+  },
+  {
+    name: ts => `ecdsa-${ts}`,
+    type: 'ecdsa-p521',
     exportable: true,
     supportsSigning: true,
   },


### PR DESCRIPTION
Co-authored-by: Noelle Daley <noelledaley@users.noreply.github.com>

Backport for this [PR](https://github.com/hashicorp/vault/pull/9070).  It was not backported in time fo the 1.4.x which is why though it was originally setup for 1.4.4 milestone it is being added to 1.5.x now.