### PR TITLE
Backport 1.5.x: UI/transit add missed algorithms follow up (#9520)

### DIFF
--- a/ui/app/serializers/transit-key.js
+++ b/ui/app/serializers/transit-key.js
@@ -17,7 +17,11 @@ export default DS.RESTSerializer.extend({
     assign(payload, payload.data);
     delete payload.data;
     // timestamps for these two are in seconds...
-    if (payload.type === 'aes256-gcm96' || payload.type === 'chacha20-poly1305') {
+    if (
+      payload.type === 'aes256-gcm96' ||
+      payload.type === 'chacha20-poly1305' ||
+      payload.type === 'aes128-gcm96'
+    ) {
       for (let version in payload.keys) {
         payload.keys[version] = payload.keys[version] * 1000;
       }

--- a/ui/app/templates/partials/transit-form-show.hbs
+++ b/ui/app/templates/partials/transit-form-show.hbs
@@ -103,6 +103,7 @@
   {{#if (or
       (eq key.type "aes256-gcm96")
       (eq key.type "chacha20-poly1305")
+      (eq key.type "aes128-gcm96")
     )
   }}
     {{#each-in key.keys as |version creationTimestamp|}}


### PR DESCRIPTION
Backport for this [PR](https://github.com/hashicorp/vault/pull/9520)

Because this PR was missed in backporting for 1.4.4 adding it now to 1.5.1