### PR TITLE
docs: fix sentence in vault debug command

### DIFF
--- a/website/pages/docs/commands/debug.mdx
+++ b/website/pages/docs/commands/debug.mdx
@@ -18,7 +18,7 @@ commands. The `debug` command aims to provide a simple workflow that produces a
 consistent output to help operators retrieve and share information about the
 server in question.
 
-The `debug` command honors the same the variables that the base command
+The `debug` command honors the same variables that the base command
 accepts, such as the token stored via a previous login or the environment
 variables `VAULT_TOKEN` and `VAULT_ADDR`. The token used determines the
 permissions and, in turn, the information that `debug` may be able to collect.


### PR DESCRIPTION
This PR fixes a sentence in the `vault debug` command documentation.