### PR TITLE
ssh backend: Change the default signature algorithm to rsa-sha2-256

### DIFF
--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -531,7 +531,7 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 
 	algo := b.Role.AlgorithmSigner
 	if algo == "" {
-		algo = ssh.SigAlgoRSA
+		algo = ssh.SigAlgoRSASHA2256
 	}
 	sig, err := sshAlgorithmSigner.SignWithAlgorithm(rand.Reader, certificateBytes, algo)
 	if err != nil {


### PR DESCRIPTION
The current default rsa-sha1 signature algorithm for SSH certificates is now no longer accepted by modern versions of SSH (> 8.2).

It would make sense to update it to another algorithm that works out of the box and provides an increased level of security.