### PR TITLE
Backport 1.5.1: OpenLDAP plugin can rotate AD passwords (#9673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 ## Next
 
+IMPROVEMENTS:
+
+* auth/jwt: Add support for fetching groups and user information from G Suite during authentication. [[GH-123](https://github.com/hashicorp/vault-plugin-auth-jwt/pull/123)]
+* secrets/openldap: Add "ad" schema that allows the engine to correctly rotate AD passwords. [[GH-16](https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/16)]
+
+BUG FIXES:
+
+* core: Handle a trailing slash in the API address used for enabling replication
+* core: Fix resource leak in plugin API (plugin-dependent, not all plugins impacted) [[GH-9557](https://github.com/hashicorp/vault/pull/9557)]
+* core: Fix race involved in enabling certain features via a license change
+* secrets/aws: Fix possible issue creating access keys when using Performance Standbys  [[GH-9606](https://github.com/hashicorp/vault/pull/9606)]
+* secrets/database: Fix handling of TLS options in mongodb connection strings [[GH-9519](https://github.com/hashicorp/vault/pull/9519)]
+* secrets/gcp: Ensure that the IAM policy version is appropriately set after a roleset's bindings have changed. [[GH-93](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/93)]
+
+## 1.5.1
+### TBD
+
+CHANGES:
+
+* pki: The tidy operation will now remove revoked certificates if the parameter `tidy_revoked_certs` is set to `true`. This will result in certificate entries being immediately removed, as opposed to awaiting until its NotAfter time. Note that this only affects certificates that have been already revoked. [[GH-9609](https://github.com/hashicorp/vault/pull/9609)]
+
+IMPROVEMENTS:
+
+* auth/jwt: Add support for fetching groups and user information from G Suite during authentication. [[GH-9574](https://github.com/hashicorp/vault/pull/9574)]
+* secrets/openldap: Add "ad" schema that allows the engine to correctly rotate AD passwords. [[GH-9740](https://github.com/hashicorp/vault/pull/9740)]
+* ui: Wrap TTL option on transit engine export action is updated to a new component. [[GH-9632](https://github.com/hashicorp/vault/pull/9632)]
+
+BUG FIXES:
+
+* secrets/gcp: Ensure that the IAM policy version is appropriately set after a roleset's bindings have changed. [[GH-9603](https://github.com/hashicorp/vault/pull/9603)]
+* replication (enterprise): Fix status API output incorrectly stating replication is in `idle` state.
+* core: Fix panic when printing over-long info fields at startup [[GH-9681](https://github.com/hashicorp/vault/pull/9681)]
+
+## 1.5.0
+### July 21st, 2020
+
 CHANGES:
 
 * storage/raft: The storage configuration now accepts a new `max_entry_size` config that will limit

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.6
 	github.com/hashicorp/vault-plugin-secrets-kv v0.5.6
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.2
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.1.4
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.1.5
 	github.com/hashicorp/vault/api v1.0.5-0.20200630205458-1a16f3c699c6
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200718021857-871b5365aa35
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4

--- a/go.sum
+++ b/go.sum
@@ -592,6 +592,8 @@ github.com/hashicorp/vault-plugin-secrets-openldap v0.1.4-0.20200618161832-cae59
 github.com/hashicorp/vault-plugin-secrets-openldap v0.1.4-0.20200618161832-cae59ebde561/go.mod h1:SeP/cV0AF4gxkPOvbsLyOIjNjbI6hsIs6fQb8IZldM4=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.1.4 h1:FWuOJPquEDV1zbaaaq05cGwXb6OAoG67ERJe0wOAY0I=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.1.4/go.mod h1:SeP/cV0AF4gxkPOvbsLyOIjNjbI6hsIs6fQb8IZldM4=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.1.5 h1:jLYOv9YdaPdb7qfBrLDaHd8AxDjapBKHLviwftt7biw=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.1.5/go.mod h1:NM+5N+URHHg8ZvlyOJuPy5McC3x0m//96uDCbM8Ygzc=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/client/schema.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/client/schema.go
@@ -2,14 +2,16 @@ package client
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/vault/sdk/helper/strutil"
+	"golang.org/x/text/encoding/unicode"
 )
 
 // SupportedSchemas returns a slice of different OpenLDAP schemas supported
 // by the plugin.  This is used to change the FieldRegistry when modifying
 // user passwords.
 func SupportedSchemas() []string {
-	return []string{"openldap", "racf"}
+	return []string{"openldap", "racf", "ad"}
 }
 
 // ValidSchema checks if the configured schema is supported by the plugin.
@@ -31,7 +33,20 @@ func GetSchemaFieldRegistry(schema string, newPassword string) (map[*Field][]str
 			FieldRegistry.RACFAttributes: {"noexpired"},
 		}
 		return fields, nil
+	case "ad":
+		pwdEncoded, err := formatPassword(newPassword)
+		if err != nil {
+			return nil, err
+		}
+		fields := map[*Field][]string{FieldRegistry.UnicodePassword: {pwdEncoded}}
+		return fields, nil
 	default:
 		return nil, fmt.Errorf("configured schema %s not valid", schema)
 	}
+}
+
+// According to the MS docs, the password needs to be utf16 and enclosed in quotes.
+func formatPassword(original string) (string, error) {
+	utf16 := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
+	return utf16.NewEncoder().String("\"" + original + "\"")
 }

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/go.mod
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20200519113804-d87ec0cfa476 // indirect
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
-	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/text v0.3.2
 	google.golang.org/genproto v0.0.0-20200519141106-08726f379972 // indirect
 	google.golang.org/grpc v1.29.1 // indirect
 )

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/path_roles.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-openldap/path_roles.go
@@ -46,7 +46,7 @@ func (b *backend) pathRoles() []*framework.Path {
 					Callback: b.pathStaticRoleRead,
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: b.pathStaticRoleDelete,
+					Callback:                    b.pathStaticRoleDelete,
 					ForwardPerformanceStandby:   true,
 					ForwardPerformanceSecondary: true,
 				},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -492,7 +492,7 @@ github.com/hashicorp/vault-plugin-secrets-gcpkms
 github.com/hashicorp/vault-plugin-secrets-kv
 # github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.2
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas
-# github.com/hashicorp/vault-plugin-secrets-openldap v0.1.4
+# github.com/hashicorp/vault-plugin-secrets-openldap v0.1.5
 github.com/hashicorp/vault-plugin-secrets-openldap
 github.com/hashicorp/vault-plugin-secrets-openldap/client
 # github.com/hashicorp/vault/api v1.0.5-0.20200630205458-1a16f3c699c6 => ./api

--- a/website/pages/api-docs/secret/openldap/index.mdx
+++ b/website/pages/api-docs/secret/openldap/index.mdx
@@ -40,7 +40,7 @@ to search and change entry passwords in OpenLDAP.
 - `password_policy` `(string: <optional>)` - The name of the [password policy](/docs/concepts/password-policies)
   to use to generate passwords. Note that this accepts the name of the policy, not the policy itself.
 - `schema` `(string: "openldap")` - The OpenLDAP schema to use when storing entry passwords.
-  Valid schemas include:`openldap` and `racf`.
+  Valid schemas include:`openldap`, `racf` and `ad`.
 - `request_timeout` `(integer: 90, string: "90s" <optional>)` - Timeout, in seconds, for the connection when
   making requests against the server before returning back an error.
 - `starttls` `(bool: <optional>)` - If true, issues a `StartTLS` command after establishing an unencrypted connection.

--- a/website/pages/docs/secrets/openldap/index.mdx
+++ b/website/pages/docs/secrets/openldap/index.mdx
@@ -63,8 +63,8 @@ This plugin currently supports LDAP v3.
 
 ## Schema
 
-The OpenLDAP Secret Engine supports two different schemas: `openldap` (default) and
-`racf`.
+The OpenLDAP Secret Engine supports three different schemas: `openldap` (default),
+`racf` and `ad`.
 
 ### OpenLDAP
 
@@ -91,6 +91,19 @@ vault write openldap/config \
 	url=ldaps://138.91.247.105 \
 	schema=racf \
 	password_policy=racf_password_policy
+```
+
+### Active Directory (AD)
+
+For managing Active Directory instances, the secret engine must be configured to use the
+schema `ad`.
+
+```bash
+vault write openldap/config \
+	binddn=$USERNAME \
+	bindpass=$PASSWORD \
+	url=ldaps://138.91.247.105 \
+	schema=ad
 ```
 
 ## Password Generation


### PR DESCRIPTION
This PR backports #9673 and #9619 by cherry-picking 4fd17c2 and d3f43d6