### PR TITLE
Correctly mark Cassandra as not supporting static roles

### DIFF
--- a/website/pages/docs/secrets/databases/cassandra.mdx
+++ b/website/pages/docs/secrets/databases/cassandra.mdx
@@ -20,7 +20,7 @@ more information about setting up the database secrets engine.
 ## Capabilities
 | Plugin Name | Root Credential Rotation | Dynamic Roles | Static Roles |
 | --- | --- | --- | --- |
-| `cassandra-database-plugin` | Yes | Yes | Yes |
+| `cassandra-database-plugin` | Yes | Yes | No |
 
 ## Setup
 

--- a/website/pages/docs/secrets/databases/index.mdx
+++ b/website/pages/docs/secrets/databases/index.mdx
@@ -131,7 +131,7 @@ the proper permission, it can generate credentials.
 ## Database Capabilities
 | Database | Root Credential Rotation | Dynamic Roles | Static Roles |
 | --- | --- | --- | --- |
-| [Cassandra](/docs/secrets/databases/cassandra)        | Yes | Yes | Yes |
+| [Cassandra](/docs/secrets/databases/cassandra)        | Yes | Yes | No  |
 | [Elasticsearch](/docs/secrets/databases/elasticdb)    | Yes | Yes | No  |
 | [HanaDB](/docs/secrets/databases/hanadb)              | No  | Yes | No  |
 | [InfluxDB](/docs/secrets/databases/influxdb)          | Yes | Yes | No  |


### PR DESCRIPTION
Update docs to show that Cassandra does not support static roles.

[https://github.com/hashicorp/vault/blob/master/plugins/database/cassandra/cassandra.go](https://github.com/hashicorp/vault/blob/master/plugins/database/cassandra/cassandra.go) does not have `SetCredentials`.