### PR TITLE
agent: use oklog's run.Group to schedule subsystem runners

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -15,8 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/oklog/run"
-
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
@@ -44,6 +42,7 @@ import (
 	"github.com/hashicorp/vault/sdk/version"
 	"github.com/kr/pretty"
 	"github.com/mitchellh/cli"
+	"github.com/oklog/run"
 	"github.com/posener/complete"
 )
 
@@ -533,11 +532,12 @@ func (c *AgentCommand) Run(args []string) int {
 
 	var g run.Group
 
-	// This run group watches for
+	// This run group watches for signal termination
 	g.Add(func() error {
 		for {
 			select {
 			case <-c.ShutdownCh:
+				c.UI.Output("==> Vault agent shutdown triggered")
 				return nil
 			case <-ctx.Done():
 				return nil

--- a/command/agent.go
+++ b/command/agent.go
@@ -579,9 +579,12 @@ func (c *AgentCommand) Run(args []string) int {
 
 		g.Add(func() error {
 			err := ss.Run(ctx, ah.OutputCh, sinks)
+			c.logger.Info("sinks finished, exiting")
 
 			// Wait until templates are rendered
-			<-ts.DoneCh
+			if len(config.Templates) > 0 {
+				<-ts.DoneCh
+			}
 
 			return err
 		}, func(error) {

--- a/command/agent.go
+++ b/command/agent.go
@@ -626,7 +626,8 @@ func (c *AgentCommand) Run(args []string) int {
 	}()
 
 	if err := g.Run(); err != nil {
-		c.UI.Error(fmt.Sprintf("Error encountered: %s", err))
+		c.logger.Error("runtime error encountered", "error", err)
+		c.UI.Error("Error encountered during run, refer to logs for more details.")
 		return 1
 	}
 

--- a/command/agent/alicloud_end_to_end_test.go
+++ b/command/agent/alicloud_end_to_end_test.go
@@ -100,13 +100,9 @@ func TestAliCloudEndToEnd(t *testing.T) {
 		Client: client,
 	}
 
-	errCh := make(chan error)
 	ah := auth.NewAuthHandler(ahConfig)
-	go ah.Run(ctx, am, errCh)
-	defer func() {
-		select {
-		case <-ah.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ah.Run(ctx, am); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -138,11 +134,8 @@ func TestAliCloudEndToEnd(t *testing.T) {
 		Logger: logger.Named("sink.server"),
 		Client: client,
 	})
-	go ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}, errCh)
-	defer func() {
-		select {
-		case <-ss.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/command/agent/approle_end_to_end_test.go
+++ b/command/agent/approle_end_to_end_test.go
@@ -222,12 +222,8 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 		Client: client,
 	}
 	ah := auth.NewAuthHandler(ahConfig)
-	errCh := make(chan error)
-	go ah.Run(ctx, am, errCh)
-	defer func() {
-		select {
-		case <-ah.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ah.Run(ctx, am); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -248,11 +244,8 @@ func testAppRoleEndToEnd(t *testing.T, removeSecretIDFile bool, bindSecretID boo
 		Logger: logger.Named("sink.server"),
 		Client: client,
 	})
-	go ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}, errCh)
-	defer func() {
-		select {
-		case <-ss.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -557,12 +550,8 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 		Client: client,
 	}
 	ah := auth.NewAuthHandler(ahConfig)
-	errCh := make(chan error)
-	go ah.Run(ctx, am, errCh)
-	defer func() {
-		select {
-		case <-ah.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ah.Run(ctx, am); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -583,11 +572,8 @@ func testAppRoleWithWrapping(t *testing.T, bindSecretID bool, secretIDLess bool,
 		Logger: logger.Named("sink.server"),
 		Client: client,
 	})
-	go ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}, errCh)
-	defer func() {
-		select {
-		case <-ss.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -31,7 +31,6 @@ type AuthConfig struct {
 // AuthHandler is responsible for keeping a token alive and renewed and passing
 // new tokens to the sink server
 type AuthHandler struct {
-	DoneCh                       chan struct{}
 	OutputCh                     chan string
 	TemplateTokenCh              chan string
 	logger                       hclog.Logger
@@ -52,7 +51,6 @@ type AuthHandlerConfig struct {
 
 func NewAuthHandler(conf *AuthHandlerConfig) *AuthHandler {
 	ah := &AuthHandler{
-		DoneCh: make(chan struct{}),
 		// This is buffered so that if we try to output after the sink server
 		// has been shut down, during agent shutdown, we won't block
 		OutputCh:                     make(chan string, 1),
@@ -84,7 +82,6 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 	defer func() {
 		am.Shutdown()
 		close(ah.OutputCh)
-		close(ah.DoneCh)
 		close(ah.TemplateTokenCh)
 		ah.logger.Info("auth handler stopped")
 	}()

--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -75,10 +75,9 @@ func backoffOrQuit(ctx context.Context, backoff time.Duration) {
 	}
 }
 
-func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod, errCh chan<- error) {
+func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 	if am == nil {
-		errCh <- errors.New("auth handler: nil auth method")
-		return
+		return errors.New("auth handler: nil auth method")
 	}
 
 	ah.logger.Info("starting auth handler")
@@ -115,7 +114,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod, errCh chan<- erro
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 
 		default:
 		}

--- a/command/agent/aws_end_to_end_test.go
+++ b/command/agent/aws_end_to_end_test.go
@@ -114,12 +114,8 @@ func TestAWSEndToEnd(t *testing.T) {
 	}
 
 	ah := auth.NewAuthHandler(ahConfig)
-	errCh := make(chan error)
-	go ah.Run(ctx, am, errCh)
-	defer func() {
-		select {
-		case <-ah.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ah.Run(ctx, am); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -151,11 +147,8 @@ func TestAWSEndToEnd(t *testing.T) {
 		Logger: logger.Named("sink.server"),
 		Client: client,
 	})
-	go ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}, errCh)
-	defer func() {
-		select {
-		case <-ss.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/command/agent/cache_end_to_end_test.go
+++ b/command/agent/cache_end_to_end_test.go
@@ -199,12 +199,9 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 		Client: client,
 	}
 	ah := auth.NewAuthHandler(ahConfig)
-	errCh := make(chan error)
-	go ah.Run(ctx, am, errCh)
-	defer func() {
-		select {
-		case <-ah.DoneCh:
-		case err := <-errCh:
+	go func() {
+		err := ah.Run(ctx, am)
+		if err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -236,11 +233,9 @@ func TestCache_UsingAutoAuthToken(t *testing.T) {
 	}
 	inmemSinkConfig.Sink = inmemSink
 
-	go ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config, inmemSinkConfig}, errCh)
-	defer func() {
-		select {
-		case <-ss.DoneCh:
-		case err := <-errCh:
+	go func() {
+		err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config, inmemSinkConfig})
+		if err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/command/agent/cert_with_name_end_to_end_test.go
+++ b/command/agent/cert_with_name_end_to_end_test.go
@@ -127,12 +127,8 @@ func testCertWithNameEndToEnd(t *testing.T, ahWrapping bool) {
 		ahConfig.WrapTTL = 10 * time.Second
 	}
 	ah := auth.NewAuthHandler(ahConfig)
-	errCh := make(chan error)
-	go ah.Run(ctx, am, errCh)
-	defer func() {
-		select {
-		case <-ah.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ah.Run(ctx, am); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -159,11 +155,8 @@ func testCertWithNameEndToEnd(t *testing.T, ahWrapping bool) {
 		Logger: logger.Named("sink.server"),
 		Client: client,
 	})
-	go ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}, errCh)
-	defer func() {
-		select {
-		case <-ss.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/command/agent/cert_with_name_end_to_end_test.go
+++ b/command/agent/cert_with_name_end_to_end_test.go
@@ -127,9 +127,17 @@ func testCertWithNameEndToEnd(t *testing.T, ahWrapping bool) {
 		ahConfig.WrapTTL = 10 * time.Second
 	}
 	ah := auth.NewAuthHandler(ahConfig)
+	errCh := make(chan error)
 	go func() {
-		if err := ah.Run(ctx, am); err != nil {
-			t.Fatal(err)
+		errCh <- ah.Run(ctx, am)
+	}()
+	defer func() {
+		select {
+		case <-ctx.Done():
+		case err := <-errCh:
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 	}()
 
@@ -156,8 +164,15 @@ func testCertWithNameEndToEnd(t *testing.T, ahWrapping bool) {
 		Client: client,
 	})
 	go func() {
-		if err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}); err != nil {
-			t.Fatal(err)
+		errCh <- ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config})
+	}()
+	defer func() {
+		select {
+		case <-ctx.Done():
+		case err := <-errCh:
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 	}()
 

--- a/command/agent/cert_with_no_name_end_to_end_test.go
+++ b/command/agent/cert_with_no_name_end_to_end_test.go
@@ -124,12 +124,8 @@ func testCertWithNoNAmeEndToEnd(t *testing.T, ahWrapping bool) {
 		ahConfig.WrapTTL = 10 * time.Second
 	}
 	ah := auth.NewAuthHandler(ahConfig)
-	errCh := make(chan error)
-	go ah.Run(ctx, am, errCh)
-	defer func() {
-		select {
-		case <-ah.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ah.Run(ctx, am); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -156,11 +152,8 @@ func testCertWithNoNAmeEndToEnd(t *testing.T, ahWrapping bool) {
 		Logger: logger.Named("sink.server"),
 		Client: client,
 	})
-	go ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}, errCh)
-	defer func() {
-		select {
-		case <-ss.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/command/agent/cert_with_no_name_end_to_end_test.go
+++ b/command/agent/cert_with_no_name_end_to_end_test.go
@@ -124,9 +124,17 @@ func testCertWithNoNAmeEndToEnd(t *testing.T, ahWrapping bool) {
 		ahConfig.WrapTTL = 10 * time.Second
 	}
 	ah := auth.NewAuthHandler(ahConfig)
+	errCh := make(chan error)
 	go func() {
-		if err := ah.Run(ctx, am); err != nil {
-			t.Fatal(err)
+		errCh <- ah.Run(ctx, am)
+	}()
+	defer func() {
+		select {
+		case <-ctx.Done():
+		case err := <-errCh:
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 	}()
 
@@ -153,8 +161,15 @@ func testCertWithNoNAmeEndToEnd(t *testing.T, ahWrapping bool) {
 		Client: client,
 	})
 	go func() {
-		if err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}); err != nil {
-			t.Fatal(err)
+		errCh <- ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config})
+	}()
+	defer func() {
+		select {
+		case <-ctx.Done():
+		case err := <-errCh:
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 	}()
 

--- a/command/agent/cf_end_to_end_test.go
+++ b/command/agent/cf_end_to_end_test.go
@@ -112,12 +112,8 @@ func TestCFEndToEnd(t *testing.T) {
 	}
 
 	ah := auth.NewAuthHandler(ahConfig)
-	errCh := make(chan error)
-	go ah.Run(ctx, am, errCh)
-	defer func() {
-		select {
-		case <-ah.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ah.Run(ctx, am); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -149,11 +145,8 @@ func TestCFEndToEnd(t *testing.T) {
 		Logger: logger.Named("sink.server"),
 		Client: client,
 	})
-	go ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}, errCh)
-	defer func() {
-		select {
-		case <-ss.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/command/agent/jwt_end_to_end_test.go
+++ b/command/agent/jwt_end_to_end_test.go
@@ -149,11 +149,8 @@ func testJWTEndToEnd(t *testing.T, ahWrapping bool) {
 	}
 	ah := auth.NewAuthHandler(ahConfig)
 	errCh := make(chan error)
-	go ah.Run(ctx, am, errCh)
-	defer func() {
-		select {
-		case <-ah.DoneCh:
-		case err := <-errCh:
+	go func() {
+		if err := ah.Run(ctx, am); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -180,7 +177,11 @@ func testJWTEndToEnd(t *testing.T, ahWrapping bool) {
 		Logger: logger.Named("sink.server"),
 		Client: client,
 	})
-	go ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}, errCh)
+	go func() {
+		if err := ss.Run(ctx, ah.OutputCh, []*sink.SinkConfig{config}); err != nil {
+			t.Fatal(err)
+		}
+	}()
 	defer func() {
 		select {
 		case <-ss.DoneCh:

--- a/command/agent/sink/sink.go
+++ b/command/agent/sink/sink.go
@@ -70,7 +70,7 @@ func NewSinkServer(conf *SinkServerConfig) *SinkServer {
 
 // Run executes the server's run loop, which is responsible for reading
 // in new tokens and pushing them out to the various sinks.
-func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*SinkConfig, errCh chan error) {
+func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*SinkConfig) error {
 	latestToken := new(string)
 	writeSink := func(currSink *SinkConfig, currToken string) error {
 		if currToken != *latestToken {
@@ -94,8 +94,7 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 	}
 
 	if incoming == nil {
-		errCh <- errors.New("sink server: incoming channel is nil")
-		return
+		return errors.New("sink server: incoming channel is nil")
 	}
 
 	ss.logger.Info("starting sink server")
@@ -112,7 +111,7 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 
 		case token := <-incoming:
 			if len(sinks) > 0 {
@@ -140,14 +139,14 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 				ss.logger.Trace("no sinks, ignoring new token")
 				if ss.exitAfterAuth {
 					ss.logger.Trace("no sinks, exitAfterAuth, bye")
-					return
+					return nil
 				}
 			}
 		case st := <-sinkCh:
 			atomic.AddInt32(ss.remaining, -1)
 			select {
 			case <-ctx.Done():
-				return
+				return nil
 			default:
 			}
 
@@ -156,14 +155,14 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 				ss.logger.Error("error returned by sink function, retrying", "error", err, "backoff", backoff.String())
 				select {
 				case <-ctx.Done():
-					return
+					return nil
 				case <-time.After(backoff):
 					atomic.AddInt32(ss.remaining, 1)
 					sinkCh <- st
 				}
 			} else {
 				if atomic.LoadInt32(ss.remaining) == 0 && ss.exitAfterAuth {
-					return
+					return nil
 				}
 			}
 		}

--- a/command/agent/sink/sink.go
+++ b/command/agent/sink/sink.go
@@ -47,7 +47,6 @@ type SinkServerConfig struct {
 
 // SinkServer is responsible for pushing tokens to sinks
 type SinkServer struct {
-	DoneCh        chan struct{}
 	logger        hclog.Logger
 	client        *api.Client
 	random        *rand.Rand
@@ -57,7 +56,6 @@ type SinkServer struct {
 
 func NewSinkServer(conf *SinkServerConfig) *SinkServer {
 	ss := &SinkServer{
-		DoneCh:        make(chan struct{}),
 		logger:        conf.Logger,
 		client:        conf.Client,
 		random:        rand.New(rand.NewSource(int64(time.Now().Nanosecond()))),
@@ -100,7 +98,6 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 	ss.logger.Info("starting sink server")
 	defer func() {
 		ss.logger.Info("sink server stopped")
-		close(ss.DoneCh)
 	}()
 
 	type sinkToken struct {

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -205,8 +205,7 @@ func (ts *Server) Run(ctx context.Context, incoming chan string, templates []*ct
 }
 
 func (ts *Server) Stop() {
-	if !ts.stopped.Load() {
-		ts.stopped.Store(true)
+	if ts.stopped.CAS(false, true) {
 		close(ts.DoneCh)
 	}
 }

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -177,7 +177,9 @@ func TestServerRun(t *testing.T) {
 			server.testingLimitRetry = 3
 
 			errCh := make(chan error)
-			go server.Run(ctx, templateTokenCh, templatesToRender, errCh)
+			go func() {
+				errCh <- server.Run(ctx, templateTokenCh, templatesToRender)
+			}()
 
 			// send a dummy value to trigger the internal Runner to query for secret
 			// info


### PR DESCRIPTION
Use run.Group mechanism to schedule and manage the lifecycle of different subsystems' runners within agent. This mostly gets rid of the need for a `DoneCh` and `errCh`, since each Run funcs can return an error and goroutine termination is properly handled by by `oklog/run`'s Group.Run. 

The exception to this is `template.Server` which still requires a `DoneCh` as the signal to block the termination of the sink and prevent the actor from potentially triggering its interrupt first. More specifically, in the case that `exit_after_auth = true`, we would still want the template server to finish rendering any pending templates before exiting so we need to utilize its `DoneCh` to block on the sink's actor.