### PR TITLE
Adding leader status to the sys/health endpoint

### DIFF
--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -38,4 +38,6 @@ type HealthResponse struct {
 	ClusterName                string `json:"cluster_name,omitempty"`
 	ClusterID                  string `json:"cluster_id,omitempty"`
 	LastWAL                    uint64 `json:"last_wal,omitempty"`
+	IsLeader                   bool   `json:"is_leader"`
+	LeaderAddress              string `json:"leader_address"`
 }


### PR DESCRIPTION
This PR adds 2 new fields to the `sys/health` endpoint:
`is_leader`: boolean, true if the local node is the cluster leader
`leader_address`: current leader API address

The reason for adding this field is because when creating a system to detect leadership changes and possibly reroute client traffic it becomes cumbersome to create the logic.
To make the decision if the traffic should be routed it would involve the output of the `sys/leader` and `sys/health` endpoints and require custom logic.
This simplifies the process by combining the important parts of `sys/leader` in `sys/health`.
