### PR TITLE
Changes the Vault address in the example config

### DIFF
--- a/website/pages/docs/agent/index.mdx
+++ b/website/pages/docs/agent/index.mdx
@@ -61,7 +61,7 @@ There can at most be one top level `vault` block and it has the following
 configuration entries:
 
 - `address` `(string: <optional>)` - The address of the Vault server. This should
-  be a complete URL such as `https://127.0.0.1:8200`. This value can be
+  be a complete URL such as `https://vault.company.internal:8200`. This value can be
   overridden by setting the `VAULT_ADDR` environment variable.
 
 - `ca_cert` `(string: <optional>)` - Path on the local disk to a single PEM-encoded
@@ -112,7 +112,7 @@ An example configuration, with very contrived values, follows:
 pid_file = "./pidfile"
 
 vault {
-        address = "https://127.0.0.1:8200"
+        address = "https://vault.company.internal:8200"
 }
 
 auto_auth {

--- a/website/pages/docs/agent/index.mdx
+++ b/website/pages/docs/agent/index.mdx
@@ -61,7 +61,7 @@ There can at most be one top level `vault` block and it has the following
 configuration entries:
 
 - `address` `(string: <optional>)` - The address of the Vault server. This should
-  be a complete URL such as `https://vault.company.internal:8200`. This value can be
+  be a complete URL such as `https://vault.example.org:8200`. This value can be
   overridden by setting the `VAULT_ADDR` environment variable.
 
 - `ca_cert` `(string: <optional>)` - Path on the local disk to a single PEM-encoded
@@ -112,7 +112,7 @@ An example configuration, with very contrived values, follows:
 pid_file = "./pidfile"
 
 vault {
-        address = "https://vault.company.internal:8200"
+        address = "https://vault.example.org:8200"
 }
 
 auto_auth {


### PR DESCRIPTION
The example configuration of the Vault Agent shouldn't point to a local address "127.0.0.1" when referring to the address of the Vault server since it's not a realistic endpoint, so people might get confused.  

```
vault {
        address = "https://127.0.0.1:8200"
}
``` 

This PR changes the address to a generic example address: `https://vault.company.internal:8200`