### PR TITLE
Update documentation for MySQL Secrets Engine (#9671)

### DIFF
--- a/website/pages/api-docs/secret/databases/mysql-maria.mdx
+++ b/website/pages/api-docs/secret/databases/mysql-maria.mdx
@@ -45,6 +45,12 @@ has a number of parameters to further configure a connection.
 
 - `password` `(string: "")` - The root credential password used in the connection URL.
 
+- `tls_certificate_key` `(string: "")` - x509 certificate for connecting to the database.
+  This must be a PEM encoded version of the private key and the certificate combined.
+
+- `tls_ca` `(string: "")` - x509 CA file for validating the certificate presented by the
+  MySQL server. Must be PEM encoded.
+
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
* Update documentation for MySQL Secrets Engine

Update documentation for MySQL Database Secrets Engine to reflect changes introduced with https://github.com/hashicorp/vault/pull/9181

* Empty Commit to re-trigger tests