### PR TITLE
Sidebranch: UI transform create and edit clean up

### DIFF
--- a/ui/app/adapters/transform.js
+++ b/ui/app/adapters/transform.js
@@ -1,5 +1,5 @@
 import { assign } from '@ember/polyfills';
-import { resolve, allSettled } from 'rsvp';
+import { allSettled } from 'rsvp';
 import ApplicationAdapter from './application';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 

--- a/ui/app/adapters/transform.js
+++ b/ui/app/adapters/transform.js
@@ -4,13 +4,10 @@ import ApplicationAdapter from './application';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 export default ApplicationAdapter.extend({
-  // TODO this adapter was copied over, much of this stuff may or may not need to be here.
   namespace: 'v1',
 
-  // defaultSerializer: 'role',
-
   createOrUpdate(store, type, snapshot) {
-    const serializer = store.serializerFor('transform'); // TODO replace transform with type.modelName
+    const serializer = store.serializerFor(type.modelName);
     const data = serializer.serialize(snapshot);
     const { id } = snapshot;
     let url = this.urlForTransformations(snapshot.record.get('backend'), id);
@@ -35,14 +32,6 @@ export default ApplicationAdapter.extend({
     return 'transform';
   },
 
-  urlForAlphabet(backend, id) {
-    let url = `${this.buildURL()}/${encodePath(backend)}/alphabet`;
-    if (id) {
-      url = url + '/' + encodePath(id);
-    }
-    return url;
-  },
-
   urlForTransformations(backend, id) {
     let url = `${this.buildURL()}/${encodePath(backend)}/transformation`;
     if (id) {
@@ -61,14 +50,9 @@ export default ApplicationAdapter.extend({
 
   fetchByQuery(store, query) {
     const { id, backend } = query;
-    let zeroAddressAjax = resolve();
     const queryAjax = this.ajax(this.urlForTransformations(backend, id), 'GET', this.optionsForQuery(id));
-    // TODO: come back to why you need this, carry over.
-    // if (!id) {
-    //   zeroAddressAjax = this.findAllZeroAddress(store, query);
-    // }
 
-    return allSettled([queryAjax, zeroAddressAjax]).then(results => {
+    return allSettled([queryAjax]).then(results => {
       // query result 404d, so throw the adapterError
       if (!results[0].value) {
         throw results[0].reason;
@@ -91,12 +75,6 @@ export default ApplicationAdapter.extend({
       });
       return resp;
     });
-  },
-
-  findAllZeroAddress(store, query) {
-    const { backend } = query;
-    const url = `/v1/${encodePath(backend)}/config/zeroaddress`;
-    return this.ajax(url, 'GET');
   },
 
   query(store, type, query) {

--- a/ui/app/components/role-edit.js
+++ b/ui/app/components/role-edit.js
@@ -88,8 +88,7 @@ export default Component.extend(FocusOnInsertMixin, {
   actions: {
     createOrUpdate(type, event) {
       event.preventDefault();
-
-      const modelId = this.get('model.id') || this.get('model.name'); // ARG TODO this is not okay
+      const modelId = this.get('model.id') || this.get('model.name'); // transform comes in as model.name
       // prevent from submitting if there's no key
       // maybe do something fancier later
       if (type === 'create' && isBlank(modelId)) {

--- a/ui/app/components/transform-create-form.js
+++ b/ui/app/components/transform-create-form.js
@@ -1,0 +1,9 @@
+import RoleEdit from './role-edit';
+import transform from '../models/transform';
+
+export default RoleEdit.extend({
+  init() {
+    this._super(...arguments);
+    this.set('backendType', 'transform');
+  },
+});

--- a/ui/app/components/transform-create-form.js
+++ b/ui/app/components/transform-create-form.js
@@ -1,5 +1,4 @@
 import RoleEdit from './role-edit';
-import transform from '../models/transform';
 
 export default RoleEdit.extend({
   init() {

--- a/ui/app/helpers/options-for-backend.js
+++ b/ui/app/helpers/options-for-backend.js
@@ -55,7 +55,6 @@ const SECRET_BACKENDS = {
     editComponent: 'role-ssh-edit',
     listItemPartial: 'partials/secret-list/ssh-role-item',
   },
-  // TODO: edit or remove listItemPartial and better understand what's happening here
   transform: {
     displayName: 'Transformation',
     navigateTree: false,

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -42,6 +42,7 @@ const Model = DS.Model.extend({
     label: 'Name',
     fieldValue: 'id',
     readOnly: true,
+    subText: 'The name for your transformation. This cannot be edited later.',
   }),
   type: attr('string', {
     defaultValue: 'fpe',

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -48,7 +48,7 @@ const Model = DS.Model.extend({
     label: 'Type',
     possibleValues: TYPES,
     subText:
-      'Vault provides two types of transformations: Format Preserving Encryption (FPE) is reversible, while Masking is not.',
+      'Vault provides two types of transformations: Format Preserving Encryption (FPE) is reversible, while Masking is not. This cannot be edited later.',
   }),
   tweak_source: attr('string', {
     defaultValue: 'supplied',

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -72,9 +72,9 @@ const Model = DS.Model.extend({
       'Templates allow Vault to determine what and how to capture the value to be transformed. Type to use an existing template or create a new one.',
   }),
   templates: attr('array'), // TODO: remove once BE changes the returned property to a singular template on the GET request.
-  allowed_roles: attr('string', {
-    label: 'Allowed roles',
+  allowed_roles: attr('array', {
     editType: 'searchSelect',
+    label: 'Allowed roles',
     fallbackComponent: 'string-list',
     models: ['transform/role'],
     subText: 'Search for an existing role, type a new role to create it, or use a wildcard (*).',

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -36,11 +36,7 @@ const TWEAK_SOURCE = [
 ];
 
 const Model = DS.Model.extend({
-  // TODO: for now, commenting out openApi info, but keeping here just in case we end up using it.
-  // useOpenAPI: true,
-  // getHelpUrl: function(backend) {
-  //   return `/v1/${backend}?help=1`;
-  // },
+  useOpenAPI: false,
   name: attr('string', {
     // TODO: make this required for making a transformation
     label: 'Name',
@@ -83,8 +79,6 @@ const Model = DS.Model.extend({
     subText: 'Search for an existing role, type a new role to create it, or use a wildcard (*).',
   }),
   transformAttrs: computed('type', function() {
-    // TODO: group them into sections/groups.  Right now, we don't different between required and not required as we do by hiding options.
-    // will default to design mocks on how to handle as it will likely be a different pattern using client-side validation, which we have not done before
     if (this.type === 'masking') {
       return ['name', 'type', 'masking_character', 'template', 'templates', 'allowed_roles'];
     }
@@ -93,8 +87,6 @@ const Model = DS.Model.extend({
   transformFieldAttrs: computed('transformAttrs', function() {
     return expandAttributeMeta(this, this.get('transformAttrs'));
   }),
-  // zeroAddressPath: lazyCapabilities(apiPath`${'backend'}/config/zeroaddress`, 'backend'),
-  // canEditZeroAddress: alias('zeroAddressPath.canUpdate'),
 });
 
 export default attachCapabilities(Model, {

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -67,6 +67,7 @@ const Model = DS.Model.extend({
     fallbackComponent: 'string-list',
     label: 'Template', // TODO: make this required for making a transformation
     models: ['transform/template'],
+    selectLimit: 1,
     subLabel: 'Template Name',
     subText:
       'Templates allow Vault to determine what and how to capture the value to be transformed. Type to use an existing template or create a new one.',

--- a/ui/app/styles/core/forms.scss
+++ b/ui/app/styles/core/forms.scss
@@ -214,6 +214,12 @@ label {
 .field-body .field {
   margin-bottom: 0;
 }
+.field {
+  // cannot use :read-only selector because tag used for other purposes
+  &.is-readOnly {
+    background-color: $ui-gray-100;
+  }
+}
 .field.has-addons {
   flex-wrap: wrap;
   .control {

--- a/ui/app/templates/components/transform-create-form.hbs
+++ b/ui/app/templates/components/transform-create-form.hbs
@@ -4,11 +4,15 @@
     {{!-- TODO: figure out what this ?? --}}
     {{!-- <NamespaceReminder @mode={{mode}} @noun="SSH role" /> --}}
     {{#each model.transformFieldAttrs as |attr|}}
-      <FormField
-        data-test-field
-        @attr={{attr}}
-        @model={{model}}
-      />
+      {{#if (eq attr.name 'templates')}}
+        {{!-- TODO: for now don't show until backend makes api changes. --}}
+      {{else}}
+        <FormField
+          data-test-field
+          @attr={{attr}}
+          @model={{model}}
+        />
+      {{/if}}
     {{/each}}
   </div>
   <div class="field is-grouped-split box is-fullwidth is-bottomless">

--- a/ui/app/templates/components/transform-create-form.hbs
+++ b/ui/app/templates/components/transform-create-form.hbs
@@ -6,7 +6,14 @@
     {{#each model.transformFieldAttrs as |attr|}}
       {{#if (eq attr.name 'templates')}}
         {{!-- TODO: for now don't show until backend makes api changes. --}}
-      {{else}}
+      {{else if (eq attr.name 'template')}}
+        <FormField
+          data-test-field
+          @attr={{attr}}
+          @model={{model}}
+          @selectLimit={{1}}
+        />
+       {{else}}
         <FormField
           data-test-field
           @attr={{attr}}

--- a/ui/app/templates/components/transform-create-form.hbs
+++ b/ui/app/templates/components/transform-create-form.hbs
@@ -1,0 +1,37 @@
+<form onsubmit={{action "createOrUpdate" "create"}}>
+  <div class="box is-sideless is-fullwidth is-marginless">
+    {{message-error model=model}}
+    {{!-- TODO: figure out what this ?? --}}
+    {{!-- <NamespaceReminder @mode={{mode}} @noun="SSH role" /> --}}
+    {{#each model.transformFieldAttrs as |attr|}}
+      <FormField
+        data-test-field
+        @attr={{attr}}
+        @model={{model}}
+      />
+    {{/each}}
+  </div>
+  <div class="field is-grouped-split box is-fullwidth is-bottomless">
+    <div class="control">
+      <button
+        type="submit"
+        disabled={{buttonDisabled}}
+        class="button is-primary"
+        data-test-role-ssh-create=true
+      >
+        {{#if (eq mode 'create')}}
+          Create transformation
+        {{else if (eq mode 'edit')}}
+          Save
+        {{/if}}
+      </button>
+      {{#secret-link
+        mode=(if (eq mode "create") "list" "show")
+        class="button"
+        secret=model.id
+      }}
+        Cancel
+      {{/secret-link}}
+    </div>
+  </div>
+</form>

--- a/ui/app/templates/components/transform-create-form.hbs
+++ b/ui/app/templates/components/transform-create-form.hbs
@@ -11,7 +11,7 @@
           data-test-field
           @attr={{attr}}
           @model={{model}}
-          @selectLimit={{1}}
+          @selectLimit={{selectLimit}}
         />
        {{else}}
         <FormField

--- a/ui/app/templates/components/transform-edit-form.hbs
+++ b/ui/app/templates/components/transform-edit-form.hbs
@@ -31,7 +31,7 @@
           @attr={{attr}}
           @model={{model}}
           @initialSelected={{model.templates}}
-          @selectLimit={{1}}
+          @selectLimit={{selectLimit}}
         />
       {{else if (eq attr.name 'templates')}}
         {{!-- TODO: for now don't show until backend makes api changes. --}}

--- a/ui/app/templates/components/transform-edit-form.hbs
+++ b/ui/app/templates/components/transform-edit-form.hbs
@@ -4,11 +4,35 @@
     {{!-- TODO: figure out what this ?? --}}
     {{!-- <NamespaceReminder @mode={{mode}} @noun="SSH role" /> --}}
     {{#each model.transformFieldAttrs as |attr|}}
+      {{#if (or (eq attr.name 'name') (eq attr.name 'type')) }}
+        <label for="{{attr.name}}" class="is-label">
+          {{attr.options.label}}
+        </label>
+        {{#if attr.options.subText}}
+          <p class="sub-text">{{attr.options.subText}}</p>
+        {{/if}}
+        {{#if attr.options.possibleValues}}
+          <div class="control is-expanded field is-readOnly">
+            <div class="select is-fullwidth">
+              <select name="{{attr.name}}" id="{{attr.name}}" disabled data-test-input={{attr.name}}>
+                <option selected={{get model attr.name}} value={{get model attr.name}}>
+                  {{log (get model attr.name)}}
+                  {{get model attr.name}}
+                </option>
+              </select>
+            </div>
+          </div>
+        {{else}}
+          <input data-test-input={{attr.name}} id={{attr.name}} autocomplete="off" spellcheck="false"
+            value={{or (get model attr.name) attr.options.defaultValue}} readonly class="field input is-readOnly" type={{attr.type}} />
+        {{/if}}
+      {{else}}
       <FormField
         data-test-field
         @attr={{attr}}
         @model={{model}}
       />
+      {{/if}}
     {{/each}}
   </div>
   <div class="field is-grouped-split box is-fullwidth is-bottomless">

--- a/ui/app/templates/components/transform-edit-form.hbs
+++ b/ui/app/templates/components/transform-edit-form.hbs
@@ -34,12 +34,12 @@
         />
       {{else if (eq attr.name 'templates')}}
         {{!-- TODO: for now don't show until backend makes api changes. --}}
-      {{else if (eq attr.name 'roles')}}
+      {{else if (eq attr.name 'allowed_roles')}}
         <FormField
           data-test-field
           @attr={{attr}}
           @model={{model}}
-          @initialSelected={{model.roles}}
+          @initialSelected={{model.allowed_roles}}
         />
       {{else}}
       <FormField

--- a/ui/app/templates/components/transform-edit-form.hbs
+++ b/ui/app/templates/components/transform-edit-form.hbs
@@ -31,6 +31,7 @@
           @attr={{attr}}
           @model={{model}}
           @initialSelected={{model.templates}}
+          @selectLimit={{1}}
         />
       {{else if (eq attr.name 'templates')}}
         {{!-- TODO: for now don't show until backend makes api changes. --}}

--- a/ui/app/templates/components/transform-edit-form.hbs
+++ b/ui/app/templates/components/transform-edit-form.hbs
@@ -16,7 +16,6 @@
             <div class="select is-fullwidth">
               <select name="{{attr.name}}" id="{{attr.name}}" disabled data-test-input={{attr.name}}>
                 <option selected={{get model attr.name}} value={{get model attr.name}}>
-                  {{log (get model attr.name)}}
                   {{get model attr.name}}
                 </option>
               </select>
@@ -26,6 +25,22 @@
           <input data-test-input={{attr.name}} id={{attr.name}} autocomplete="off" spellcheck="false"
             value={{or (get model attr.name) attr.options.defaultValue}} readonly class="field input is-readOnly" type={{attr.type}} />
         {{/if}}
+      {{else if (eq attr.name 'template')}}
+        <FormField
+          data-test-field
+          @attr={{attr}}
+          @model={{model}}
+          @initialSelected={{model.templates}}
+        />
+      {{else if (eq attr.name 'templates')}}
+        {{!-- TODO: for now don't show until backend makes api changes. --}}
+      {{else if (eq attr.name 'roles')}}
+        <FormField
+          data-test-field
+          @attr={{attr}}
+          @model={{model}}
+          @initialSelected={{model.roles}}
+        />
       {{else}}
       <FormField
         data-test-field

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -10,7 +10,6 @@
 
 <div class="has-top-margin-xl has-bottom-margin-s">
   <label class="title has-border-bottom-light page-header">CLI Commands</label>
-  {{!-- ARG TODO make these components? --}}
   <div class="has-bottom-margin-s">
     <h2 class="title is-6">Encode</h2>
     <div class="has-bottom-margin-s">

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -53,8 +53,10 @@
   </Toolbar>
 {{/if}}
 
-{{#if (or (eq mode 'edit') (eq mode 'create'))}}
+{{#if (eq mode 'edit')}}
   <TransformEditForm @mode={{mode}} @model={{model}} />
+{{else if (eq mode 'create')}}
+  <TransformCreateForm @mode={{mode}} @model={{model}} />
 {{else}}
   <TransformShowTransformation
     @model={{model}}

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -132,10 +132,7 @@ export default Component.extend({
     },
     selectOption(option) {
       if (this.selectLimit) {
-        if (
-          this.selectLimit === this.selectedOptions.length ||
-          this.selectLimit < this.selectedOptions.length
-        ) {
+        if (this.selectLimit <= this.selectedOptions.length) {
           return;
         }
       }

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -9,7 +9,7 @@ import layout from '../templates/components/search-select';
  * @module SearchSelect
  * The `SearchSelect` is an implementation of the [ember-power-select-with-create](https://github.com/poteto/ember-cli-flash) used for form elements where options come dynamically from the API.
  * @example
- * <SearchSelect @id="group-policies" @models={{["policies/acl"]}} @onChange={{onChange}} @initialSelected={{array 'selectedValue'}} @inputValue={{get model valuePath}} @helpText="Policies associated with this group" @label="Policies" @fallbackComponent="string-list" />
+ * <SearchSelect @id="group-policies" @models={{["policies/acl"]}} @onChange={{onChange}} @initialSelected={{array 'selectedValue'}} @selectLimit={{2}} @inputValue={{get model valuePath}} @helpText="Policies associated with this group" @label="Policies" @fallbackComponent="string-list" />
  *
  * @param id {String} - The name of the form field
  * @param models {String} - An array of model types to fetch from the API.
@@ -18,6 +18,7 @@ import layout from '../templates/components/search-select';
  * @param [initialSelected] {Array} -  An array of initially selected options to display.
  * @param [helpText] {String} - Text to be displayed in the info tooltip for this form field
  * @param [subText] {String} - Text to be displayed below the label
+ * @param [selectLimit] {Number} - A number that sets the limit to how many select options they can choose
  * @param label {String} - Label for this form field
  * @param [subLabel] {String} - a smaller label below the main Label
  * @param fallbackComponent {String} - name of component to be rendered if the API call 403s
@@ -114,7 +115,6 @@ export default Component.extend({
     }
   }).on('didInsertElement'),
   handleChange() {
-    // if select limit < selection length don't change, just return, selectLimit new property
     if (this.selectedOptions.length && typeof this.selectedOptions.firstObject === 'object') {
       this.onChange(Array.from(this.selectedOptions, option => option.id));
     } else {
@@ -131,6 +131,14 @@ export default Component.extend({
       this.handleChange();
     },
     selectOption(option) {
+      if (this.selectLimit) {
+        if (
+          this.selectLimit === this.selectedOptions.length ||
+          this.selectLimit < this.selectedOptions.length
+        ) {
+          return;
+        }
+      }
       this.selectedOptions.pushObject(option);
       this.options.removeObject(option);
       this.handleChange();

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -9,12 +9,13 @@ import layout from '../templates/components/search-select';
  * @module SearchSelect
  * The `SearchSelect` is an implementation of the [ember-power-select-with-create](https://github.com/poteto/ember-cli-flash) used for form elements where options come dynamically from the API.
  * @example
- * <SearchSelect @id="group-policies" @models={{["policies/acl"]}} @onChange={{onChange}} @inputValue={{get model valuePath}} @helpText="Policies associated with this group" @label="Policies" @fallbackComponent="string-list" />
+ * <SearchSelect @id="group-policies" @models={{["policies/acl"]}} @onChange={{onChange}} @initialSelected={{array 'selectedValue'}} @inputValue={{get model valuePath}} @helpText="Policies associated with this group" @label="Policies" @fallbackComponent="string-list" />
  *
  * @param id {String} - The name of the form field
  * @param models {String} - An array of model types to fetch from the API.
  * @param onChange {Func} - The onchange action for this form field.
  * @param inputValue {String | Array} -  A comma-separated string or an array of strings.
+ * @param [initialSelected] {Array} -  An array of initially selected options to display.
  * @param [helpText] {String} - Text to be displayed in the info tooltip for this form field
  * @param [subText] {String} - Text to be displayed below the label
  * @param label {String} - Label for this form field
@@ -44,6 +45,9 @@ export default Component.extend({
   shouldRenderName: false,
   init() {
     this._super(...arguments);
+    if (this.initialSelected) {
+      return this.set('selectedOptions', this.initialSelected); // need array helper to pass in.
+    }
     this.set('selectedOptions', this.inputValue || []);
   },
   didRender() {
@@ -110,6 +114,7 @@ export default Component.extend({
     }
   }).on('didInsertElement'),
   handleChange() {
+    // if select limit < selection length don't change, just return, selectLimit new property
     if (this.selectedOptions.length && typeof this.selectedOptions.firstObject === 'object') {
       this.onChange(Array.from(this.selectedOptions, option => option.id));
     } else {

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -71,7 +71,9 @@
       @onChange={{action (action "setAndBroadcast" valuePath)}} @inputValue={{get model valuePath}}
       @helpText={{attr.options.helpText}} @subText={{attr.options.subText}} @label={{labelString}}
       @subLabel={{attr.options.subLabel}}
-      @fallbackComponent={{attr.options.fallbackComponent}} />
+      @fallbackComponent={{attr.options.fallbackComponent}}
+      @initialSelected={{initialSelected}}
+      />
   </div>
 {{else if (eq attr.options.editType "mountAccessor")}}
   {{mount-accessor-select

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -73,7 +73,7 @@
       @subLabel={{attr.options.subLabel}}
       @fallbackComponent={{attr.options.fallbackComponent}}
       @initialSelected={{initialSelected}}
-      @selectLimit={{selectLimit}}
+      @selectLimit={{attr.options.selectLimit}}
     />
   </div>
 {{else if (eq attr.options.editType "mountAccessor")}}

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -73,7 +73,8 @@
       @subLabel={{attr.options.subLabel}}
       @fallbackComponent={{attr.options.fallbackComponent}}
       @initialSelected={{initialSelected}}
-      />
+      @selectLimit={{selectLimit}}
+    />
   </div>
 {{else if (eq attr.options.editType "mountAccessor")}}
   {{mount-accessor-select

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -19,27 +19,29 @@
   {{#if subText}}
     <p class="sub-text">{{subText}}</p>
   {{/if}}
-  {{#power-select-with-create
-    options=options
-    search=search
-    onchange=(action "selectOption")
-    oncreate=(action "createOption")
-    placeholderComponent=(component "search-select-placeholder")
-    renderInPlace=true
-    searchField="searchText"
-    verticalPosition="below"
-    showCreateWhen=(action "hideCreateOptionOnSameID")
-    buildSuggestion=(action "constructSuggestion") as |option|
-  }}
-    {{#if shouldRenderName}}
-      {{option.name}}
-      <small class="search-select-list-key" data-test-smaller-id="true">
+  {{#unless (gte selectedOptions.length selectLimit)}}
+    {{#power-select-with-create
+      options=options
+      search=search
+      onchange=(action "selectOption")
+      oncreate=(action "createOption")
+      placeholderComponent=(component "search-select-placeholder")
+      renderInPlace=true
+      searchField="searchText"
+      verticalPosition="below"
+      showCreateWhen=(action "hideCreateOptionOnSameID")
+      buildSuggestion=(action "constructSuggestion") as |option|
+    }}
+      {{#if shouldRenderName}}
+        {{option.name}}
+        <small class="search-select-list-key" data-test-smaller-id="true">
+          {{option.id}}
+        </small>
+      {{else}}
         {{option.id}}
-      </small>
-    {{else}}
-      {{option.id}}
-    {{/if}}
-  {{/power-select-with-create}}
+      {{/if}}
+    {{/power-select-with-create}}
+  {{/unless}}
   <ul class="search-select-list">
     {{#each selectedOptions as |selected|}}
       <li class="search-select-list-item" data-test-selected-option="true">


### PR DESCRIPTION
**This PR addresses the following:**

* Removes/addresses the TODOs that can be addressed.  Some still remain due to potential API changes.
* Sets up `readOnly` attributes and styling when editing the transformation.  This will be the same pattern for roles and alphabets.  You cannot edit the name or the template it is using once created.
* Adds new properties to the `SearchSelect` component that allows you to: 1. pass in a default set of already selected options (needed for the edit view), and 2. set a `selectLimit` which limits the number of items you can select.  This is needed for templates because you can only select 1 template.
* Hides the `#power-select-with-create` part of the `SearchSelect` component when the limit is reached.  This was how design wanted this to be disabled.
* hides the `templates` model property from edit and create views (This property is needed because of the whole templates vs template return property from the API).

Here is a gif of the changes.
![changes](https://user-images.githubusercontent.com/6618863/90658484-ddf63900-e200-11ea-8b13-47ad8a65ae30.gif)

