### PR TITLE
Show KMIP un-selectable if enterprise but no ADP module

### DIFF
--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -56,14 +56,10 @@ export default Component.extend({
   }),
 
   engines: computed('version.features[]', function() {
-    let mountEngines = [...ENGINES];
-    if (this.version.hasFeature('KMIP')) {
-      mountEngines.push(KMIP);
-    }
     if (this.get('version.isEnterprise')) {
-      mountEngines.push(TRANSFORM);
+      return ENGINES.concat([KMIP, TRANSFORM]);
     }
-    return mountEngines;
+    return ENGINES;
   }),
 
   willDestroy() {

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -60,8 +60,8 @@
                 (action "onTypeChange" "type")
               }}
               @disabled={{if type.requiredFeature (not (has-feature type.requiredFeature)) false}}
-              @tooltipMessage={{if (eq type.type 'transform')
-                'Transform is part of the Advanced Data Protection module, which is not included in your enterprise license.'
+              @tooltipMessage={{if (or (eq type.type 'transform') (eq type.type 'kmip'))
+                (concat (capitalize type.displayName) " is part of the Advanced Data Protection module, which is not included in your enterprise license.")
                 'This secret engine is not included in your license.'
               }}
             />

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -61,7 +61,7 @@
               }}
               @disabled={{if type.requiredFeature (not (has-feature type.requiredFeature)) false}}
               @tooltipMessage={{if (or (eq type.type 'transform') (eq type.type 'kmip'))
-                (concat (capitalize type.displayName) " is part of the Advanced Data Protection module, which is not included in your enterprise license.")
+                (concat type.displayName " is part of the Advanced Data Protection module, which is not included in your enterprise license.")
                 'This secret engine is not included in your license.'
               }}
             />


### PR DESCRIPTION
This PR allows enterprise-only secret engines to be visible as a secrets mount, even if the required module is not present. When the required module is not part of the license, the options are grayed out, not selectable, and have a tooltip. The enterprise secret engines don't show up if it is an OSS instance of Vault.

<img width="1157" alt="secret-mounts-with-adp" src="https://user-images.githubusercontent.com/16182107/90672543-e27c1b00-e21b-11ea-94e9-5c1f67600d96.png">

<img width="1157" alt="secret-mounts-without-adp" src="https://user-images.githubusercontent.com/16182107/90672561-ea3bbf80-e21b-11ea-9507-ac5fd761cbae.png">

<img width="1157" alt="secret-mounts-oss" src="https://user-images.githubusercontent.com/16182107/90672571-ed36b000-e21b-11ea-91d1-c9b9d44dbeb8.png">
