### PR TITLE
Reduce a required permission for OIDC with AzureAD

### DIFF
--- a/website/pages/docs/auth/jwt_oidc_providers.mdx
+++ b/website/pages/docs/auth/jwt_oidc_providers.mdx
@@ -26,7 +26,7 @@ Reference: [Azure Active Directory v2.0 and the OpenID Connect protocol](https:/
      - https://hostname:port_number/ui/vault/auth/oidc/oidc/callback
 1. Record "Application (client) ID" as you will need it as the oidc_client_id
 1. Under API Permissions grant the following permission:
-   - Microsoft Graph API permission [Group.Read.All](https://docs.microsoft.com/en-us/graph/permissions-reference#application-permissions-10)
+   - Microsoft Graph API permission [GroupMember.Read.All](https://docs.microsoft.com/en-us/graph/permissions-reference#application-permissions-23)
 1. Under "Endpoints", copy the OpenID Connect metadata document URL, omitting the `/well-known...` portion.
    - The endpoint url (oidc_discovery_url) will look like: https://login.microsoftonline.com/tenant-guid-dead-beef-aaaa-aaaa/v2.0
 1. Switch to Certificates & Secrets. Create a new client secret and record the generated value as


### PR DESCRIPTION
# What
Reduce a required permission for setting up OIDC provider with AzureAD

# Why
`Group.Read.All` is too permissive policy to achieve external groups feature. `GroupMembers.Read.All` is enough for that purpose.

MicroSoft Graph API Permission reference follows
https://docs.microsoft.com/en-us/graph/permissions-reference#application-permissions-23

Permission | Display String | Description | Admin Consent Required
-- | -- | -- | --
Group.Read.All | Read all groups | Allows the app to read memberships for all groups without a signed-in user. Also allows the app to read calendar, conversations, files, and other group content for all groups.Note: Not all group APIs support access using app-only permissions. See known issues for examples. | Yes
GroupMember.Read.All | Read group memberships | Allows the app to read memberships and basic group properties for all groups without a signed-in user. | Yes

`Group.Read.All` accesses 

> to read calendar, conversations, files, and other group content for all groups

, but these accesses are not required for the OIDC feature. `GroupMember.Read.All` is enough to get group information to work with external groups.

With `GroupMember.Read.All`, our OIDC provider setup works fine now :)