### PR TITLE
Ui/fix list roles transformation

### DIFF
--- a/ui/app/adapters/transform/role.js
+++ b/ui/app/adapters/transform/role.js
@@ -3,14 +3,13 @@ import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 export default ApplicationAdapater.extend({
   namespace: 'v1',
-  modelName: 'transform/role',
 
-  pathForType(type) {
-    return type.replace('transform/', '');
+  pathForType() {
+    return type.replace('role');
   },
 
-  _url(modelType, backend, id) {
-    let type = this.pathForType(modelType);
+  _url(backend, id) {
+    let type = this.pathForType();
     let base = `/v1/${encodePath(backend)}/${type}`;
     if (id) {
       return `${base}/${encodePath(id)}`;
@@ -19,12 +18,8 @@ export default ApplicationAdapater.extend({
   },
 
   query(store, type, query) {
-    return this.ajax(this._url(this.modelName, query.backend), 'GET').then(result => {
+    return this.ajax(this._url(query.backend), 'GET').then(result => {
       return result;
     });
   },
-
-  // buildURL(modelName, id, snapshot, requestType, query) {
-  //   return this._super(`${modelName}/`, id, snapshot, requestType, query);
-  // },
 });

--- a/ui/app/adapters/transform/role.js
+++ b/ui/app/adapters/transform/role.js
@@ -1,20 +1,30 @@
 import ApplicationAdapater from '../application';
+import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 export default ApplicationAdapater.extend({
   namespace: 'v1',
+  modelName: 'transform/role',
+
   pathForType(type) {
-    return type;
+    return type.replace('transform/', '');
   },
 
-  urlForQuery() {
-    return this._super(...arguments) + '?list=true';
+  _url(modelType, backend, id) {
+    let type = this.pathForType(modelType);
+    let base = `/v1/${encodePath(backend)}/${type}`;
+    if (id) {
+      return `${base}/${encodePath(id)}`;
+    }
+    return base + '?list=true';
   },
 
-  query(store, type) {
-    return this.ajax(this.buildURL(type.modelName, null, null, 'query'), 'GET');
+  query(store, type, query) {
+    return this.ajax(this._url(this.modelName, query.backend), 'GET').then(result => {
+      return result;
+    });
   },
 
-  buildURL(modelName, id, snapshot, requestType, query) {
-    return this._super(`${modelName}/`, id, snapshot, requestType, query);
-  },
+  // buildURL(modelName, id, snapshot, requestType, query) {
+  //   return this._super(`${modelName}/`, id, snapshot, requestType, query);
+  // },
 });

--- a/ui/app/adapters/transform/role.js
+++ b/ui/app/adapters/transform/role.js
@@ -5,7 +5,7 @@ export default ApplicationAdapater.extend({
   namespace: 'v1',
 
   pathForType() {
-    return type.replace('role');
+    return 'role';
   },
 
   _url(backend, id) {

--- a/ui/app/adapters/transform/template.js
+++ b/ui/app/adapters/transform/template.js
@@ -3,14 +3,13 @@ import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 export default ApplicationAdapater.extend({
   namespace: 'v1',
-  modelName: 'transform/template',
 
-  pathForType(type) {
-    return type.replace('transform/', '');
+  pathForType() {
+    return 'template';
   },
 
-  _url(modelType, backend, id) {
-    let type = this.pathForType(modelType);
+  _url(backend, id) {
+    let type = this.pathForType();
     let base = `${this.buildURL()}/${encodePath(backend)}/${type}`;
     if (id) {
       return `${base}/${encodePath(id)}`;
@@ -19,12 +18,8 @@ export default ApplicationAdapater.extend({
   },
 
   query(store, type, query) {
-    return this.ajax(this._url(this.modelName, query.backend), 'GET').then(result => {
+    return this.ajax(this._url(query.backend), 'GET').then(result => {
       return result;
     });
   },
-
-  // buildURL(modelName, id, snapshot, requestType, query) {
-  //   return this._super(`${modelName}/`, id, snapshot, requestType, query);
-  // },
 });

--- a/ui/app/adapters/transform/template.js
+++ b/ui/app/adapters/transform/template.js
@@ -1,20 +1,30 @@
 import ApplicationAdapater from '../application';
+import { encodePath } from 'vault/utils/path-encoding-helpers';
 
 export default ApplicationAdapater.extend({
   namespace: 'v1',
+  modelName: 'transform/template',
+
   pathForType(type) {
-    return type;
+    return type.replace('transform/', '');
   },
 
-  urlForQuery() {
-    return this._super(...arguments) + '?list=true';
+  _url(modelType, backend, id) {
+    let type = this.pathForType(modelType);
+    let base = `${this.buildURL()}/${encodePath(backend)}/${type}`;
+    if (id) {
+      return `${base}/${encodePath(id)}`;
+    }
+    return base + '?list=true';
   },
 
-  query(store, type) {
-    return this.ajax(this.buildURL(type.modelName, null, null, 'query'), 'GET');
+  query(store, type, query) {
+    return this.ajax(this._url(this.modelName, query.backend), 'GET').then(result => {
+      return result;
+    });
   },
 
-  buildURL(modelName, id, snapshot, requestType, query) {
-    return this._super(`${modelName}/`, id, snapshot, requestType, query);
-  },
+  // buildURL(modelName, id, snapshot, requestType, query) {
+  //   return this._super(`${modelName}/`, id, snapshot, requestType, query);
+  // },
 });

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -22,6 +22,7 @@ import layout from '../templates/components/search-select';
  * @param label {String} - Label for this form field
  * @param [subLabel] {String} - a smaller label below the main Label
  * @param fallbackComponent {String} - name of component to be rendered if the API call 403s
+ * @param [backend] {String} - name of the backend if the query for options needs additional information (eg. secret backend)
  *
  * @param options {Array} - *Advanced usage* - `options` can be passed directly from the outside to the
  * power-select component. If doing this, `models` should not also be passed as that will overwrite the
@@ -93,7 +94,11 @@ export default Component.extend({
         this.set('shouldRenderName', true);
       }
       try {
-        let options = yield this.store.query(modelType, {});
+        let queryOptions = {};
+        if (this.backend) {
+          queryOptions = { backend: this.backend };
+        }
+        let options = yield this.store.query(modelType, queryOptions);
         this.formatOptions(options);
       } catch (err) {
         if (err.httpStatus === 404) {

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -74,6 +74,7 @@
       @fallbackComponent={{attr.options.fallbackComponent}}
       @initialSelected={{initialSelected}}
       @selectLimit={{attr.options.selectLimit}}
+      @backend={{model.backend}}
     />
   </div>
 {{else if (eq attr.options.editType "mountAccessor")}}


### PR DESCRIPTION
This PR fixes an issue where the roles and templates fetched for the search-select list on `transformation edit` or `transformation create` did not use the name of the backend in question, which led to weird and inconsistent behavior on the edit view in particular.

BEFORE:
<img width="1157" alt="edit-before" src="https://user-images.githubusercontent.com/16182107/90797629-80342080-e2d6-11ea-8817-24793c61d92f.png">

AFTER: 
<img width="1157" alt="edit-after" src="https://user-images.githubusercontent.com/16182107/90797644-84603e00-e2d6-11ea-9c07-042c77ba5ac3.png">
