### PR TITLE
UI - Unwrap Wrapping token from Login page. Resolves: #5893.

### DIFF
--- a/ui/app/helpers/supported-auth-backends.js
+++ b/ui/app/helpers/supported-auth-backends.js
@@ -10,6 +10,14 @@ const SUPPORTED_AUTH_BACKENDS = [
     formAttributes: ['token'],
   },
   {
+    type: 'unwrap',
+    typeDisplay: 'Unwrap',
+    description: 'Wrapping Token unwrap backend.',
+    tokenPath: 'client_token',
+    displayNamePath: 'metadata.username',
+    formAttributes: ['token'],
+  },
+  {
     type: 'userpass',
     typeDisplay: 'Username',
     description: 'A simple username and password backend.',

--- a/ui/app/styles/components/codemirror.scss
+++ b/ui/app/styles/components/codemirror.scss
@@ -56,6 +56,7 @@ $gutter-grey: #2a2f36;
     font-family: $family-monospace;
     -webkit-font-smoothing: auto;
     line-height: 1.4;
+    height: auto;
   }
 
   .CodeMirror-gutters {
@@ -198,3 +199,4 @@ $gutter-grey: #2a2f36;
 .cm-s-auto-height.CodeMirror {
   height: auto;
 }
+

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -70,7 +70,7 @@
       onsubmit={{action "doSubmit"}}
     >
         {{partial providerPartialName}}
-        {{#if (and (not-eq selectedAuthBackend.type "token") (not-eq selectedAuthBackend.type "unwrap")) }}
+        {{#if (and selectedAuthBackend.type (not-eq selectedAuthBackend.type "token") (not-eq selectedAuthBackend.type "unwrap")) }}
           <AuthFormOptions
             @customPath={{this.customPath}}
             @onPathChange={{action (mut this.customPath)}}

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -70,16 +70,18 @@
       onsubmit={{action "doSubmit"}}
     >
         {{partial providerPartialName}}
-        {{#if (not-eq selectedAuthBackend.type "token")}}
+        {{#if (and (not-eq selectedAuthBackend.type "token") (not-eq selectedAuthBackend.type "unwrap")) }}
           <AuthFormOptions
             @customPath={{this.customPath}}
             @onPathChange={{action (mut this.customPath)}}
             @selectedAuthIsPath={{this.selectedAuthIsPath}}
           />
         {{/if}}
+        {{#if (not-eq selectedAuthBackend.type "unwrap") }}
         <button data-test-auth-submit=true type="submit" disabled={{authenticate.isRunning}} class="button is-primary {{if authenticate.isRunning 'is-loading'}}" id="auth-submit">
           Sign In
         </button>
+        {{/if}}
     </form>
   {{/if}}
 </div>

--- a/ui/app/templates/partials/auth-form/unwrap.hbs
+++ b/ui/app/templates/partials/auth-form/unwrap.hbs
@@ -1,0 +1,1 @@
+{{partial "partials/tools/unwrap"}}

--- a/ui/app/templates/partials/auth-form/unwrap.hbs
+++ b/ui/app/templates/partials/auth-form/unwrap.hbs
@@ -1,1 +1,86 @@
-{{partial "partials/tools/unwrap"}}
+<!-- {{partial "partials/tools/unwrap"}} -->
+{{#if unwrap_data}}
+  <div class="box is-sideless is-fullwidth is-marginless">
+    <nav class="tabs">
+      <ul>
+        <li role="tab" aria-selected={{if (eq unwrapActiveTab "data") "true" "false"}} class="{{if (eq unwrapActiveTab "data") "is-active"}}">
+          <button class="link link-plain tab has-text-weight-semibold" {{action (mut unwrapActiveTab) "data"}} data-test-button-data>Data</button>
+        </li>
+        <li role="tab" aria-selected={{if (eq unwrapActiveTab "data") "true" "false"}} class="{{if (eq unwrapActiveTab "details") "is-active"}}">
+          <button class="link link-plain tab has-text-weight-semibold" {{action (mut unwrapActiveTab) "details"}} data-test-button-details>Wrap Details</button>
+        </li>
+      </ul>
+    </nav>
+    {{#if (eq unwrapActiveTab "data")}}
+      <div class="field">
+        <div class="control" style="font-size:x-small;">
+          {{json-editor
+            value=(stringify unwrap_data)
+            options=(hash
+              readOnly=true
+            )
+          }}
+        </div>
+      </div>
+    {{else}}
+      <div class="field box is-fullwidth is-shadowless is-paddingless is-marginless" style="font-size:x-small;">
+        {{#each-in details as |key detail|}}
+          {{#info-table-row label=key value=key}}
+            {{#if (or (eq detail "No") (eq detail "None"))}}
+              <Icon class="has-text-grey" @glyph="cancel-square-outline" /> {{detail}}
+            {{else}}
+              {{#if (eq detail "Yes") }}
+                <Icon class="has-text-success" @glyph="check-circle-outline" />
+              {{/if}}
+              {{detail}}
+            {{/if}}
+          {{/info-table-row}}
+        {{/each-in}}
+      </div>
+    {{/if}}
+  </div>
+  <div class="field is-grouped box is-fullwidth is-bottomless">
+    <div class="control">
+      {{#copy-button
+        clipboardText=(stringify unwrap_data)
+        class="button is-primary"
+        buttonType="button"
+        success=(action (set-flash-message 'Data copied!'))
+      }}
+        Copy
+      {{/copy-button}}
+    </div>
+    <div class="control">
+      <button {{action 'onClear'}} type="button" class="button">
+        Back
+      </button>
+    </div>
+  </div>
+{{else}}
+  <div class="box is-sideless is-fullwidth is-marginless">
+    <NamespaceReminder @mode="perform" @noun={{selectedAction}} />
+    {{message-error errors=errors}}
+    <div class="field">
+      <label for="token" class="is-label">Wrapping token</label>
+      <div class="control">
+        {{input
+          value=token
+          class="input"
+          id="token"
+          name="token"
+          autocomplete="off"
+          spellcheck="false"
+          data-test-tools-input="wrapping-token"
+        }}
+      </div>
+    </div>
+  </div>
+  <div class="field is-grouped box is-fullwidth is-bottomless">
+    <div class="control">
+      <button type="submit" data-test-tools-submit="true" class="button is-primary">
+        Unwrap data
+      </button>
+    </div>
+  </div>
+{{/if}}
+


### PR DESCRIPTION
Provided new feature for unwrapping data on login screen as per the request on GH-Issue: #5893 

Re-used existing unwrap templates which were added to login. Credentials or other pertinent data can be unwrapped by end-users via UI without the need for CLI or API specific access.

PS - advance apologies for missing tests - kindly help with my inadequacies there.

![90963669-f5ac1680-e4b9-11ea-82e9-5d55d9050760](https://user-images.githubusercontent.com/974854/93604962-6e719600-f9c6-11ea-974e-e5870245a2d1.gif)