### PR TITLE
UI - Secrets KV Download Json Button. Resolves: #6364

### DIFF
--- a/ui/app/templates/partials/secret-form-show.hbs
+++ b/ui/app/templates/partials/secret-form-show.hbs
@@ -48,6 +48,17 @@
     </div>
     {{#each modelForData.secretKeyAndValue as |secret|}}
       {{#info-table-row label=secret.key value=secret.value alwaysRender=true}}
+        <DownloadButton
+            @data={{secret.value}}
+            @filename={{secret.key}}
+            @mime="application/json"
+            @extension="json"
+            @class="DownloadButton is-ghost"
+            @stringify={{true}}
+          >
+          <Icon @glyph="download" style="margin-left:-10px; margin-top: 5px; color:#A0A0A0;" />
+        </DownloadButton>
+
         {{masked-input value=secret.value displayOnly=true allowCopy=true}}
       {{/info-table-row}}
     {{/each}}


### PR DESCRIPTION
Provided new feature for JSON download of secrets as per the request on GH-Issue: #6364.

Feature request seems reasonable for workflows where needing to interact with many secrets or larger size ones.

PS - advance apologies for missing tests - kindly help with my inadequacies there.

![Screenshot 2020-08-23 at 02 48 17](https://user-images.githubusercontent.com/974854/90968326-5b64c680-e4eb-11ea-88e9-4ab650cdc5be.png)
