### PR TITLE
UI - Added success message to core for the copy-buttn action in masked-inputs view. Resolves: #7321

### DIFF
--- a/ui/lib/core/addon/templates/components/masked-input.hbs
+++ b/ui/lib/core/addon/templates/components/masked-input.hbs
@@ -8,7 +8,10 @@
       onchange={{action "updateValue"}} value={{readonly displayValue}} data-test-textarea />
   {{/if}}
   {{#if allowCopy}}
-    <CopyButton @clipboardText={{value}} @success={{success}} class="copy-button button {{if displayOnly "is-compact"}}"
+    <CopyButton
+    @clipboardText={{value}}
+    @success={{action (set-flash-message 'Data copied!')}}
+    class="copy-button button {{if displayOnly "is-compact"}}"
       data-test-copy-button>
       <Icon @glyph="copy-action" aria-hidden="Copy value" />
     </CopyButton>


### PR DESCRIPTION
![ui_copy-message-on-secrets](https://user-images.githubusercontent.com/974854/91080323-a692ec80-e645-11ea-9168-13f7de356277.gif)
