### PR TITLE
UI - Added default text description where none are set for builtin secret engines. Resolves: #7304

### DIFF
--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -64,6 +64,9 @@
           <code class="has-text-grey is-size-8">
             {{backend.accessor}}
           </code>
+          <font class="has-text-grey is-size-8" style="margin-left:10px;">
+            {{backend.description}}
+          </font>
         </div>
       </div>
       <div class="level-right is-flex is-paddingless is-marginless">
@@ -130,6 +133,31 @@
           <code class="has-text-grey is-size-8">
             {{backend.accessor}}
           </code>
+          <font class="has-text-grey is-size-8" style="margin-left:10px;">
+            {{#if (eq backend.description "")}}
+              {{#if (eq "ad" backend.type)}}Active Directory credentials & service accounts.{{/if}}
+              {{#if (eq "alicloud" backend.type)}}AliCloud access tokens & RAM roles, policies / STS credentials.{{/if}}
+              {{#if (eq "aws" backend.type)}}AWS credentials based on IAM / STS.{{/if}}
+              {{#if (eq "azure" backend.type)}}Azure service principals, roles & group assignments.{{/if}}
+              {{#if (eq "database" backend.type)}}DB Specific eg: PostgreSQL, mySQL, OracleSQL, etc.{{/if}}
+              {{#if (eq "consul" backend.type)}}Consul API tokens based on Consul ACL policies.{{/if}}
+              {{#if (eq "gcp" backend.type)}}GCP service account keys & OAuth tokens based on IAM policies.{{/if}}
+              {{#if (eq "gcpkms" backend.type)}}GCP Cloud KMS encryption, key management with IAM & Vault policies.{{/if}}
+              {{#if (eq "kmip" backend.type)}}KMIP server provider, lifecycle & objects handling.{{/if}}
+              {{#if (eq "identity" backend.type)}}Identity - Vault Internal - see documentation.{{/if}}
+              {{#if (eq "mongodb" backend.type)}}MongoDB Atlas Programmatic API keys.{{/if}}
+              {{#if (eq "nomad" backend.type)}}Nomad API tokens based on Nomad ACL policies.{{/if}}
+              {{#if (eq "openldap" backend.type)}}OpenLDAP passwords & existing entries.{{/if}}
+              {{#if (eq "pki" backend.type)}}PKI X.509 certificates, keys, CA, CRL & OCSP management.{{/if}}
+              {{#if (eq "rabbitmq" backend.type)}}RabbitMQ credentials via permissions & virtual hosts.{{/if}}
+              {{#if (eq "ssh" backend.type)}}SSH authorized access & secure authentication to hosts.{{/if}}
+              {{#if (eq "totp" backend.type)}}TOTP time-based credentials according to standard (eg MFA, 2FA).{{/if}}
+              {{#if (eq "transform" backend.type)}}Transform encompassing: NIST, FF3-1 & pseudonyms for fpe / masking.{{/if}}
+              {{#if (eq "transit" backend.type)}}Transit data or Cryptography-as-a-Service via HMAC.{{/if}}
+            {{else}}
+              {{backend.description}}
+            {{/if}}
+          </font>
         </div>
       </div>
       <div class="level-right is-flex is-paddingless is-marginless">


### PR DESCRIPTION
Provided new feature for displaying mount descriptions in the listing view - as per the request on GH-Issue: #7304  

Feature request is reasonable - given that multiple mounts or other's that are similar (eg: `pki1/`, `pki2/`, `pk3/`) are not distinguishable at present due to lacking descriptives as part of the secrets mount-listing view. Presently this data is collected by not displayed unless going much further into the configuration view of the mount.

PS - advance apologies for missing tests - kindly help with my inadequacies there.

![Screenshot 2020-08-25 at 00 41 30](https://user-images.githubusercontent.com/974854/91103647-4a8f8e80-e66c-11ea-9663-ca4c6f3ebadb.png)