### PR TITLE
Fixes for AWS sts allowed header values

### DIFF
--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -19,7 +19,7 @@ import (
 )
 
 var defaultAllowedSTSRequestHeaders = []string{"Authorization", "Content-Length", "Content-Type", "Host", "User-Agent",
-	"X-Amz-Date", "X-Amz-Security-Token", "X-Vault-Aws-Iam-Server-Id",textproto.CanonicalMIMEHeaderKey(iamServerIdHeader)}
+	"X-Amz-Date", "X-Amz-Security-Token", textproto.CanonicalMIMEHeaderKey(iamServerIdHeader)}
 
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	b, err := Backend(conf)

--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -3,10 +3,6 @@ package awsauth
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/awsutil"
-	"github.com/hashicorp/vault/sdk/helper/consts"
-	"github.com/hashicorp/vault/sdk/logical"
 	"strings"
 	"sync"
 	"time"
@@ -14,6 +10,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/awsutil"
+	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/sdk/logical"
 	cache "github.com/patrickmn/go-cache"
 )
 

--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -18,7 +18,8 @@ import (
 	cache "github.com/patrickmn/go-cache"
 )
 
-var defaultAllowedSTSRequestHeaders = []string{"Authorization", "Content-Length", "Content-Type", "User-Agent", "X-Amz-Date", textproto.CanonicalMIMEHeaderKey(iamServerIdHeader)}
+var defaultAllowedSTSRequestHeaders = []string{"Authorization", "Content-Length", "Content-Type", "Host", "User-Agent",
+	"X-Amz-Date", "X-Amz-Security-Token", "X-Vault-Aws-Iam-Server-Id",textproto.CanonicalMIMEHeaderKey(iamServerIdHeader)}
 
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	b, err := Backend(conf)

--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -18,7 +18,11 @@ import (
 )
 
 const amzHeaderPrefix = "X-Amz-"
-var defaultAllowedSTSRequestHeaders = []string{"X-Amz-Date", "X-Amz-Security-Token", "X-Amz-Algorithm", "X-Amz-Signature",
+var defaultAllowedSTSRequestHeaders = []string{
+	"X-Amz-Date",
+	"X-Amz-Security-Token",
+	"X-Amz-Algorithm",
+	"X-Amz-Signature",
 	"X-Amz-SignedHeaders"}
 
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {

--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -3,7 +3,10 @@ package awsauth
 import (
 	"context"
 	"fmt"
-	"net/textproto"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/awsutil"
+	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/sdk/logical"
 	"strings"
 	"sync"
 	"time"
@@ -11,15 +14,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/awsutil"
-	"github.com/hashicorp/vault/sdk/helper/consts"
-	"github.com/hashicorp/vault/sdk/logical"
 	cache "github.com/patrickmn/go-cache"
 )
 
-var defaultAllowedSTSRequestHeaders = []string{"Authorization", "Content-Length", "Content-Type", "Host", "User-Agent",
-	"X-Amz-Date", "X-Amz-Security-Token", textproto.CanonicalMIMEHeaderKey(iamServerIdHeader)}
+const amzHeaderPrefix = "X-Amz-"
+var defaultAllowedSTSRequestHeaders = []string{"X-Amz-Date", "X-Amz-Security-Token", "X-Amz-Algorithm", "X-Amz-Signature",
+	"X-Amz-SignedHeaders"}
 
 func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend, error) {
 	b, err := Backend(conf)

--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -58,7 +58,7 @@ func (b *backend) pathConfigClient() *framework.Path {
 				Description: "Value to require in the X-Vault-AWS-IAM-Server-ID request header",
 			},
 			"allowed_sts_header_values": {
-				Type:        framework.TypeStringSlice,
+				Type:        framework.TypeCommaStringSlice,
 				Default:     nil,
 				Description: "List of headers that are allowed to be in AWS STS request headers",
 			},
@@ -332,12 +332,10 @@ type clientConfig struct {
 }
 
 func (c *clientConfig) validateAllowedSTSHeaderValues(headers http.Header) error {
-	allowList := c.AllowedSTSHeaderValues
-	if c.AllowedSTSHeaderValues == nil {
-		allowList = defaultAllowedSTSRequestHeaders
-	}
 	for k := range headers {
-		if !strutil.StrListContains(allowList, textproto.CanonicalMIMEHeaderKey(k)) {
+		h := textproto.CanonicalMIMEHeaderKey(k)
+		if 	!strutil.StrListContains(defaultAllowedSTSRequestHeaders, h) &&
+			!strutil.StrListContains(c.AllowedSTSHeaderValues, h) {
 			return errors.New("invalid request header: " + k)
 		}
 	}

--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"net/http"
 	"net/textproto"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -335,7 +336,8 @@ type clientConfig struct {
 func (c *clientConfig) validateAllowedSTSHeaderValues(headers http.Header) error {
 	for k := range headers {
 		h := textproto.CanonicalMIMEHeaderKey(k)
-		if 	!strutil.StrListContains(defaultAllowedSTSRequestHeaders, h) &&
+		if 	strings.HasPrefix(h, amzHeaderPrefix) &&
+			!strutil.StrListContains(defaultAllowedSTSRequestHeaders, h) &&
 			!strutil.StrListContains(c.AllowedSTSHeaderValues, h) {
 			return errors.New("invalid request header: " + k)
 		}

--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -60,7 +60,7 @@ func (b *backend) pathConfigClient() *framework.Path {
 			"allowed_sts_header_values": {
 				Type:        framework.TypeCommaStringSlice,
 				Default:     nil,
-				Description: "List of headers that are allowed to be in AWS STS request headers",
+				Description: "List of additional headers that are allowed to be in AWS STS request headers",
 			},
 			"max_retries": {
 				Type:        framework.TypeInt,
@@ -145,6 +145,7 @@ func (b *backend) pathConfigClientRead(ctx context.Context, req *logical.Request
 			"sts_region":                 clientConfig.STSRegion,
 			"iam_server_id_header_value": clientConfig.IAMServerIdHeaderValue,
 			"max_retries":                clientConfig.MaxRetries,
+			"allowed_sts_header_values":  clientConfig.AllowedSTSHeaderValues,
 		},
 	}, nil
 }

--- a/builtin/credential/aws/path_login_test.go
+++ b/builtin/credential/aws/path_login_test.go
@@ -314,9 +314,9 @@ func TestBackend_pathLogin_IAMHeaders(t *testing.T) {
 				"X-Amz-Date":                "20180910T203328Z",
 				"Authorization":             "AWS4-HMAC-SHA256 Credential=AKIAJPQ466AIIQW4LPSQ/20180910/us-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-vault-aws-iam-server-id, Signature=cdef5819b2e97f1ff0f3e898fd2621aa03af00a4ec3e019122c20e5482534bf4",
 				"X-Vault-Aws-Iam-Server-Id": "VaultAcceptanceTesting",
-				"X-Mallory-Header":          "<?xml><h4ck0r/>",
+				"X-Amz-Mallory-Header":      "<?xml><h4ck0r/>",
 			},
-			ExpectErr: errors.New("invalid request header: X-Mallory-Header"),
+			ExpectErr: errors.New("invalid request header: X-Amz-Mallory-Header"),
 		},
 		{
 			Name: "JSON-complete",

--- a/website/pages/api-docs/auth/aws/index.mdx
+++ b/website/pages/api-docs/auth/aws/index.mdx
@@ -66,10 +66,10 @@ capabilities, the credentials are fetched automatically.
   signed headers validated by AWS. This is to protect against different types of
   replay attacks, for example a signed request sent to a dev server being resent
   to a production server. Consider setting this to the Vault server's DNS name.
-- `allowed_sts_header_values` `([]string: nil)` The list of allowed request headers 
-  when providing the iam_request_headers for an IAM based login call.  If not 
-  provided (recommended), defaults to the set of headers AWS STS expects for a 
-  GetCallerIdentity call.   
+- `allowed_sts_header_values` `(string: "")` A comma separated list of
+  additional request headers permitted when providing the iam_request_headers for 
+  an IAM based login call.  In any case, a default list of headers AWS STS
+  expects for a GetCallerIdentity are allowed.
  
 ### Sample Payload
 


### PR DESCRIPTION
- Only validates AWS related (X-Amz-) headers.
- Changes the aws_sts_allowed_header_values parameter to be additive to the default list.
- Changes parsing of that config entry to a comma separated string for ease of use.
- Adds that config entry to output of reads to an aws client config.
