### PR TITLE
Backport #9826 (PSIRT-38) to 1.3.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-azure v0.5.3
 	github.com/hashicorp/vault-plugin-auth-centrify v0.5.3
 	github.com/hashicorp/vault-plugin-auth-cf v0.5.2
-	github.com/hashicorp/vault-plugin-auth-gcp f1713855d3ad42cc70da549b53bc8001015c388d
+	github.com/hashicorp/vault-plugin-auth-gcp v0.5.4-0.20200819031205-f1713855d3ad
 	github.com/hashicorp/vault-plugin-auth-jwt v0.5.3
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.5.3
 	github.com/hashicorp/vault-plugin-auth-oci v0.5.2

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,6 @@ replace github.com/hashicorp/vault/api => ./api
 
 replace github.com/hashicorp/vault/sdk => ./sdk
 
-replace github.com/hashicorp/vault-plugin-auth-gcp => github.com/hashicorp/vault-plugin-auth-gcpent v0.5.4-0.20200819031205-f1713855d3ad
-
 require (
 	cloud.google.com/go v0.39.0
 	github.com/Azure/azure-sdk-for-go v29.0.0+incompatible
@@ -76,7 +74,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-azure v0.5.3
 	github.com/hashicorp/vault-plugin-auth-centrify v0.5.3
 	github.com/hashicorp/vault-plugin-auth-cf v0.5.2
-	github.com/hashicorp/vault-plugin-auth-gcp v0.5.3
+	github.com/hashicorp/vault-plugin-auth-gcp f1713855d3ad42cc70da549b53bc8001015c388d
 	github.com/hashicorp/vault-plugin-auth-jwt v0.5.3
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.5.3
 	github.com/hashicorp/vault-plugin-auth-oci v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -370,6 +370,8 @@ github.com/hashicorp/vault-plugin-auth-gcp v0.5.1 h1:8DR00s+Wmc21i3sfzvsqW88VMdf
 github.com/hashicorp/vault-plugin-auth-gcp v0.5.1/go.mod h1:eLj92eX8MPI4vY1jaazVLF2sVbSAJ3LRHLRhF/pUmlI=
 github.com/hashicorp/vault-plugin-auth-gcp v0.5.3 h1:6j3hXCDsy0rYkUPus/5fuev5SV/SeR+jZcf/MMlE4sM=
 github.com/hashicorp/vault-plugin-auth-gcp v0.5.3/go.mod h1:vHJ9elo4Tzyao9TyFIvWNY/xbKP4xRUVmnP8B9y3XpA=
+github.com/hashicorp/vault-plugin-auth-gcp v0.5.4-0.20200819031205-f1713855d3ad h1:oQskqUkxWHFnrlMyVc9k293GvhvU00k11VGqz+7Sg/A=
+github.com/hashicorp/vault-plugin-auth-gcp v0.5.4-0.20200819031205-f1713855d3ad/go.mod h1:vHJ9elo4Tzyao9TyFIvWNY/xbKP4xRUVmnP8B9y3XpA=
 github.com/hashicorp/vault-plugin-auth-gcpent v0.5.4-0.20200819031205-f1713855d3ad h1:ng+auFtl2vHobT9qGtFPHac6et7BSl1RhZPTo68ai6w=
 github.com/hashicorp/vault-plugin-auth-gcpent v0.5.4-0.20200819031205-f1713855d3ad/go.mod h1:vHJ9elo4Tzyao9TyFIvWNY/xbKP4xRUVmnP8B9y3XpA=
 github.com/hashicorp/vault-plugin-auth-jwt v0.5.3 h1:Yvk2RQrkho04I/6MX3rp3MxOR3XICKyT/rDBmDCtVEM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -375,7 +375,7 @@ github.com/hashicorp/vault-plugin-auth-cf/models
 github.com/hashicorp/vault-plugin-auth-cf/util
 github.com/hashicorp/vault-plugin-auth-cf/testing/certificates
 github.com/hashicorp/vault-plugin-auth-cf/testing/cf
-# github.com/hashicorp/vault-plugin-auth-gcp v0.5.3
+# github.com/hashicorp/vault-plugin-auth-gcp v0.5.4-0.20200819031205-f1713855d3ad
 github.com/hashicorp/vault-plugin-auth-gcp/plugin
 github.com/hashicorp/vault-plugin-auth-gcp/plugin/cache
 # github.com/hashicorp/vault-plugin-auth-jwt v0.5.3


### PR DESCRIPTION
Simply repoints vault-plugin-auth-gcp to the patched OSS version.