### PR TITLE
Backport #9826 (PSIRT-38) to 1.4.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ replace github.com/hashicorp/vault/api => ./api
 
 replace github.com/hashicorp/vault/sdk => ./sdk
 
-replace github.com/hashicorp/vault-plugin-auth-gcp => github.com/hashicorp/vault-plugin-auth-gcpent v0.0.0-20200817171055-a9f45f91913d
-
 require (
 	cloud.google.com/go v0.39.0
 	github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
@@ -76,7 +74,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-azure v0.5.6-0.20200422235613-1b5c70f9ef68
 	github.com/hashicorp/vault-plugin-auth-centrify v0.5.5
 	github.com/hashicorp/vault-plugin-auth-cf v0.5.4
-	github.com/hashicorp/vault-plugin-auth-gcp v0.6.2-0.20200428223335-82bd3a3ad5b3
+	github.com/hashicorp/vault-plugin-auth-gcp v0.6.2-0.20200817171055-a9f45f91913d
 	github.com/hashicorp/vault-plugin-auth-jwt v0.6.2
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.1.6-0.20200527181845-3c7b47e8be2c
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -406,6 +406,8 @@ github.com/hashicorp/vault-plugin-auth-cf v0.5.4/go.mod h1:idkFYHc6ske2BE7fe00Sp
 github.com/hashicorp/vault-plugin-auth-gcp v0.5.1/go.mod h1:eLj92eX8MPI4vY1jaazVLF2sVbSAJ3LRHLRhF/pUmlI=
 github.com/hashicorp/vault-plugin-auth-gcp v0.6.2-0.20200428223335-82bd3a3ad5b3 h1:GTQYSsqv/2jjdTm0DawBSljMmZTc/js6zLer+9A5e2U=
 github.com/hashicorp/vault-plugin-auth-gcp v0.6.2-0.20200428223335-82bd3a3ad5b3/go.mod h1:U0fkAlxWTEyQ74lx8wlGdD493lP1DD/qpMjXgOEbwj0=
+github.com/hashicorp/vault-plugin-auth-gcp v0.6.2-0.20200817171055-a9f45f91913d h1:UpZomZFVJlA/qSpPNQ2zxNEEk6M9/ncnil8awxlEugM=
+github.com/hashicorp/vault-plugin-auth-gcp v0.6.2-0.20200817171055-a9f45f91913d/go.mod h1:U0fkAlxWTEyQ74lx8wlGdD493lP1DD/qpMjXgOEbwj0=
 github.com/hashicorp/vault-plugin-auth-gcpent v0.0.0-20200817171055-a9f45f91913d h1:+IaVkRBWlNte1HVK7d8PJf0h2/60ayJd6uy0nLacwJw=
 github.com/hashicorp/vault-plugin-auth-gcpent v0.0.0-20200817171055-a9f45f91913d/go.mod h1:U0fkAlxWTEyQ74lx8wlGdD493lP1DD/qpMjXgOEbwj0=
 github.com/hashicorp/vault-plugin-auth-jwt v0.6.2 h1:fp6Rk89iPjDS8dyEK7lEauYE/UhkgkHbmwRZKuQA01U=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -396,7 +396,7 @@ github.com/hashicorp/vault-plugin-auth-cf/signatures
 github.com/hashicorp/vault-plugin-auth-cf/testing/certificates
 github.com/hashicorp/vault-plugin-auth-cf/testing/cf
 github.com/hashicorp/vault-plugin-auth-cf/util
-# github.com/hashicorp/vault-plugin-auth-gcp v0.6.2-0.20200428223335-82bd3a3ad5b3 => github.com/hashicorp/vault-plugin-auth-gcpent v0.0.0-20200817171055-a9f45f91913d
+# github.com/hashicorp/vault-plugin-auth-gcp v0.6.2-0.20200817171055-a9f45f91913d
 github.com/hashicorp/vault-plugin-auth-gcp/plugin
 github.com/hashicorp/vault-plugin-auth-gcp/plugin/cache
 # github.com/hashicorp/vault-plugin-auth-jwt v0.6.2


### PR DESCRIPTION
Simply repoints vault-plugin-auth-gcp to the patched OSS version.