### PR TITLE
Backport 9825 1.5.x

### DIFF
--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -18,6 +18,7 @@ import (
 )
 
 const amzHeaderPrefix = "X-Amz-"
+
 var defaultAllowedSTSRequestHeaders = []string{
 	"X-Amz-Date",
 	"X-Amz-Credential",

--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -20,6 +20,7 @@ import (
 const amzHeaderPrefix = "X-Amz-"
 var defaultAllowedSTSRequestHeaders = []string{
 	"X-Amz-Date",
+	"X-Amz-Credential",
 	"X-Amz-Security-Token",
 	"X-Amz-Algorithm",
 	"X-Amz-Signature",

--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -336,7 +336,7 @@ type clientConfig struct {
 func (c *clientConfig) validateAllowedSTSHeaderValues(headers http.Header) error {
 	for k := range headers {
 		h := textproto.CanonicalMIMEHeaderKey(k)
-		if 	strings.HasPrefix(h, amzHeaderPrefix) &&
+		if strings.HasPrefix(h, amzHeaderPrefix) &&
 			!strutil.StrListContains(defaultAllowedSTSRequestHeaders, h) &&
 			!strutil.StrListContains(c.AllowedSTSHeaderValues, h) {
 			return errors.New("invalid request header: " + k)

--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -3,13 +3,13 @@ package awsauth
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"net/http"
 	"net/textproto"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 


### PR DESCRIPTION
Brings over the two small additions of X-Awz-Credential and import reordering.