### PR TITLE
Update template/templates data on transformation

### DIFF
--- a/ui/app/adapters/transform.js
+++ b/ui/app/adapters/transform.js
@@ -67,9 +67,20 @@ export default ApplicationAdapter.extend({
       results.forEach(result => {
         if (result.value) {
           if (result.value.data.roles) {
+            // TODO: Check if this is needed and remove if not
             resp.data = assign({}, resp.data, { zero_address_roles: result.value.data.roles });
           } else {
-            resp.data = assign({}, resp.data, result.value.data);
+            let d = result.value.data;
+            if (d.templates) {
+              // In Transformations data goes up as "template", but comes down as "templates"
+              // To keep the keys consistent we're translating here
+              d = {
+                ...d,
+                template: [d.templates],
+              };
+              delete d.templates;
+            }
+            resp.data = assign({}, resp.data, d);
           }
         }
       });

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -63,7 +63,7 @@ const Model = DS.Model.extend({
     label: 'Masking character',
     subText: 'Specify which character you’d like to mask your data.',
   }),
-  template: attr('string', {
+  template: attr('array', {
     editType: 'searchSelect',
     fallbackComponent: 'string-list',
     label: 'Template', // TODO: make this required for making a transformation
@@ -73,7 +73,6 @@ const Model = DS.Model.extend({
     subText:
       'Templates allow Vault to determine what and how to capture the value to be transformed. Type to use an existing template or create a new one.',
   }),
-  templates: attr('array'), // TODO: remove once BE changes the returned property to a singular template on the GET request.
   allowed_roles: attr('array', {
     editType: 'searchSelect',
     label: 'Allowed roles',
@@ -83,9 +82,9 @@ const Model = DS.Model.extend({
   }),
   transformAttrs: computed('type', function() {
     if (this.type === 'masking') {
-      return ['name', 'type', 'masking_character', 'template', 'templates', 'allowed_roles'];
+      return ['name', 'type', 'masking_character', 'template', 'allowed_roles'];
     }
-    return ['name', 'type', 'tweak_source', 'template', 'templates', 'allowed_roles'];
+    return ['name', 'type', 'tweak_source', 'template', 'allowed_roles'];
   }),
   transformFieldAttrs: computed('transformAttrs', function() {
     return expandAttributeMeta(this, this.get('transformAttrs'));

--- a/ui/app/serializers/transform.js
+++ b/ui/app/serializers/transform.js
@@ -8,10 +8,10 @@ export default ApplicationSerializer.extend({
     return this._super(store, primaryModelClass, payload, id, requestType);
   },
 
-  serialize(snapshot, options) {
+  serialize() {
     let json = this._super(...arguments);
     if (json.template && Array.isArray(json.template)) {
-      //   // Transformations should only ever have one template
+      // Transformations should only ever have one template
       json.template = json.template[0];
     }
     return json;

--- a/ui/app/serializers/transform.js
+++ b/ui/app/serializers/transform.js
@@ -5,7 +5,15 @@ export default ApplicationSerializer.extend({
     if (payload.data.masking_character) {
       payload.data.masking_character = String.fromCharCode(payload.data.masking_character);
     }
-    // TODO: the BE is working on a ticket to amend these response, so revisit.
     return this._super(store, primaryModelClass, payload, id, requestType);
+  },
+
+  serialize(snapshot, options) {
+    let json = this._super(...arguments);
+    if (json.template && Array.isArray(json.template)) {
+      //   // Transformations should only ever have one template
+      json.template = json.template[0];
+    }
+    return json;
   },
 });

--- a/ui/app/templates/components/transform-create-form.hbs
+++ b/ui/app/templates/components/transform-create-form.hbs
@@ -4,21 +4,11 @@
     {{!-- TODO: figure out what this ?? --}}
     {{!-- <NamespaceReminder @mode={{mode}} @noun="SSH role" /> --}}
     {{#each model.transformFieldAttrs as |attr|}}
-      {{#if (eq attr.name 'templates')}}
-        {{!-- TODO: for now don't show until backend makes api changes. --}}
-      {{else if (eq attr.name 'template')}}
-        <FormField
-          data-test-field
-          @attr={{attr}}
-          @model={{model}}
-        />
-       {{else}}
-        <FormField
-          data-test-field
-          @attr={{attr}}
-          @model={{model}}
-        />
-      {{/if}}
+      <FormField
+        data-test-field
+        @attr={{attr}}
+        @model={{model}}
+      />
     {{/each}}
   </div>
   <div class="field is-grouped-split box is-fullwidth is-bottomless">

--- a/ui/app/templates/components/transform-edit-form.hbs
+++ b/ui/app/templates/components/transform-edit-form.hbs
@@ -25,22 +25,6 @@
           <input data-test-input={{attr.name}} id={{attr.name}} autocomplete="off" spellcheck="false"
             value={{or (get model attr.name) attr.options.defaultValue}} readonly class="field input is-readOnly" type={{attr.type}} />
         {{/if}}
-      {{else if (eq attr.name 'template')}}
-        <FormField
-          data-test-field
-          @attr={{attr}}
-          @model={{model}}
-          @initialSelected={{model.templates}}
-        />
-      {{else if (eq attr.name 'templates')}}
-        {{!-- TODO: for now don't show until backend makes api changes. --}}
-      {{else if (eq attr.name 'allowed_roles')}}
-        <FormField
-          data-test-field
-          @attr={{attr}}
-          @model={{model}}
-          @initialSelected={{model.allowed_roles}}
-        />
       {{else}}
       <FormField
         data-test-field


### PR DESCRIPTION
This PR essentially normalizes the data coming back from the API to match what gets set on the API. In addition to simplifying the model it fixes an issue with the Search Select component, shown on the gif below, where the template data on the transformation is not set correctly on the edit form.

**BEFORE:** 
![before-templates-on-transformation](https://user-images.githubusercontent.com/16182107/91314528-45ba0000-e77c-11ea-8c25-658066b8e6cf.gif)

**AFTER**
![after-template-transformations](https://user-images.githubusercontent.com/16182107/91314531-46eb2d00-e77c-11ea-9deb-67a11523f4a1.gif)
