### PR TITLE
Ui/transform delete v2

### DIFF
--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -18,8 +18,8 @@
       </span>
     </div>
     <div class="copy-text level">
-      {{#let "vault write <backend>/encode/<your role name> value=<enter your value here> tweak=<base-64-string>" as |copyEncodeCommand|}}
-        <code>vault write &lt;backend&gt;/encode/&lt;your role name&gt; value=&lt;enter your value here&gt; tweak=&lt;base-64 string&gt;</code>
+      {{#let (concat "vault write <backend>/encode/<your role name> value=<enter your value here>" (if (eq model.type 'fpe')"tweak_source =<base-64-string>")) as |copyEncodeCommand|}}
+        <code>{{copyEncodeCommand}}</code>
         <CopyButton class="button is-transparent level-right" @clipboardText={{copyEncodeCommand}}
           @buttonType="button" @success={{action (set-flash-message 'Command copied!')}}>
           <Icon @size='l' @glyph="copy-action" aria-label="Copy" />
@@ -35,8 +35,8 @@
       </span>
     </div>
     <div class="copy-text level">
-      {{#let "vault write <backend>/decode/<your role name> value=<enter your value here> tweak=<base-64-string>" as |copyDecodeCommand|}}
-        <code>vault write &lt;backend&gt;/decode/&lt;your role name&gt; value=&lt;enter your value here&gt; tweak=&lt;base-64 string&gt;</code>
+      {{#let (concat "vault write <backend>/decode/<your role name> value=<enter your value here>" (if (eq model.type 'fpe')"tweak_source =<base-64-string>")) as |copyDecodeCommand|}}
+        <code>{{copyDecodeCommand}}</code>
         <CopyButton class="button is-transparent level-right" @clipboardText={{copyDecodeCommand}}
           @buttonType="button" @success={{action (set-flash-message 'Command copied!')}}>
           <Icon @size='l' @glyph="copy-action" aria-label="Copy" />

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -18,7 +18,11 @@
       </span>
     </div>
     <div class="copy-text level">
-      {{#let (concat "vault write <backend>/encode/<your role name> value=<enter your value here>" (if (eq model.type 'fpe')"tweak_source =<base-64-string>")) as |copyEncodeCommand|}}
+      {{#let (concat 
+        "vault write <backend>/encode/" 
+        (if (and (take 1 model.allowed_roles) (eq model.allowed_roles.length 1)) (take 1 model.allowed_roles) "<choose a role>")
+        " value=<enter your value here>" 
+        (if (and (eq model.type 'fpe') (eq model.tweak_source "supplied")) " tweak_source=<enter your tweak>")) as |copyEncodeCommand|}}
         <code>{{copyEncodeCommand}}</code>
         <CopyButton class="button is-transparent level-right" @clipboardText={{copyEncodeCommand}}
           @buttonType="button" @success={{action (set-flash-message 'Command copied!')}}>
@@ -35,7 +39,11 @@
       </span>
     </div>
     <div class="copy-text level">
-      {{#let (concat "vault write <backend>/decode/<your role name> value=<enter your value here>" (if (eq model.type 'fpe')"tweak_source =<base-64-string>")) as |copyDecodeCommand|}}
+      {{#let (concat 
+        "vault write <backend>/decode/" 
+        (if (and (take 1 model.allowed_roles) (eq model.allowed_roles.length 1)) (take 1 model.allowed_roles) "<choose a role>")
+        " value=<enter your value here>" 
+        (if (and (eq model.type 'fpe') (eq model.tweak_source "supplied")) " tweak_source=<enter your tweak>")) as |copyDecodeCommand|}}
         <code>{{copyDecodeCommand}}</code>
         <CopyButton class="button is-transparent level-right" @clipboardText={{copyDecodeCommand}}
           @buttonType="button" @success={{action (set-flash-message 'Command copied!')}}>

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -19,7 +19,7 @@
     </div>
     <div class="copy-text level">
       {{#let (concat 
-        "vault write <backend>/encode/" 
+        "vault write " model.backend "/encode/" 
         (if (and (take 1 model.allowed_roles) (eq model.allowed_roles.length 1)) (take 1 model.allowed_roles) "<choose a role>")
         " value=<enter your value here>" 
         (if (and (eq model.type 'fpe') (eq model.tweak_source "supplied")) " tweak_source=<enter your tweak>")) as |copyEncodeCommand|}}
@@ -40,7 +40,7 @@
     </div>
     <div class="copy-text level">
       {{#let (concat 
-        "vault write <backend>/decode/" 
+        "vault write " model.backend "/decode/" 
         (if (and (take 1 model.allowed_roles) (eq model.allowed_roles.length 1)) (take 1 model.allowed_roles) "<choose a role>")
         " value=<enter your value here>" 
         (if (and (eq model.type 'fpe') (eq model.tweak_source "supplied")) " tweak_source=<enter your tweak>")) as |copyDecodeCommand|}}

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -3,7 +3,7 @@
     {{#if (eq attr.type "object")}}
       {{info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=(stringify (get model attr.name))}}
     {{else}}
-      {{info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=(get model attr.name)}}
+      {{info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=(get model attr.name) type=attr.type}}
     {{/if}}
   {{/each}}
 </div>

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -71,4 +71,5 @@
   <p class="has-bottom-margin-m">
     Deleting the <strong>{{model.name}}</strong> transformation means that the underlying keys are lost and the data encoded by the transformation are unrecoverable and cannot be decoded.
   </p>
+  <MessageError @model={{model}} @errorMessage={{error}} />
 </ConfirmationModal>

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -24,22 +24,20 @@
 {{#if (eq mode "show")}}
   <Toolbar>
     <ToolbarActions>
-      {{!-- TODO: update these actions, show delete grey out if not allowed --}}
-      {{#if (or model.canUpdate model.canDelete)}}
+      {{#if (or capabilities.canUpdate capabilities.canDelete)}}
         <div class="toolbar-separator" />
       {{/if}}
-      {{#if model.canDelete}}
-      {{!-- TODO only allow deletion when not in use by a role --}}
-        <ConfirmAction
-          @buttonClasses="toolbar-link"
-          @onConfirmAction={{action "delete"}}
-          @confirmTitle="Are you sure?"
-          @confirmMessage="This transformation is not in use by a role and can be deleted."
+      {{#if capabilities.canDelete}}
+        <ToolbarSecretLink
+          @secret={{model.id}}
+          @mode="edit"
+          @data-test-edit-link=true
+          @replace=true
         >
           Delete transformation
-        </ConfirmAction>
+        </ToolbarSecretLink>
       {{/if}}
-      {{#if model.canUpdate }}
+      {{#if capabilities.canUpdate }}
         <ToolbarSecretLink
           @secret={{model.id}}
           @mode="edit"

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -28,14 +28,13 @@
         <div class="toolbar-separator" />
       {{/if}}
       {{#if capabilities.canDelete}}
-        <ToolbarSecretLink
-          @secret={{model.id}}
-          @mode="edit"
-          @data-test-edit-link=true
-          @replace=true
+        <a
+          class="toolbar-link"
+          onclick={{action (mut isModalActive) true}}
+          data-test-replication-action-trigger
         >
           Delete transformation
-        </ToolbarSecretLink>
+        </a>
       {{/if}}
       {{#if capabilities.canUpdate }}
         <ToolbarSecretLink
@@ -60,3 +59,16 @@
     @model={{model}}
   />
 {{/if}}
+
+<ConfirmationModal
+  @title="Delete transformation"
+  @onClose={{action (mut isModalActive) false}}
+  @isActive={{isModalActive}}
+  @confirmText={{model.name}}
+  @toConfirmMsg="Type {{model.name}} to confirm deleting the transformation."
+  @onConfirm={{action "delete"}}
+>
+  <p class="has-bottom-margin-m">
+    Deleting the <strong>{{model.name}}</strong> transformation means that the underlying keys are lost and the data encoded by the transformation are unrecoverable and cannot be decoded.
+  </p>
+</ConfirmationModal>

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -11,9 +11,9 @@
   <p.levelLeft>
     <h1 class="title is-3" data-test-secret-header="true">
       {{#if (eq mode "create") }}
-        Create Transformation
+        Create transformation
       {{else if (eq mode 'edit')}}
-        Edit Transformation
+        Edit transformation
       {{else}}
         Transformation <code>{{model.id}}</code>
       {{/if}}

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -18,7 +18,7 @@ import layout from '../templates/components/info-table-row';
  * @param label=null {string} - The display name for the value.
  * @param helperText=null {string} - Text to describe the value displayed beneath the label.
  * @param alwaysRender=false {Boolean} - Indicates if the component content should be always be rendered.  When false, the value of `value` will be used to determine if the component should render.
- *
+ * @param [type=array] {string} - The type of value being passed in.  This is used for when you want to trim an array.  For example, if you have an array value that can equal length 15+ this will trim to show 5 and count how many more are there
  */
 export default Component.extend({
   layout,

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -29,7 +29,7 @@
         /> No
       {{/if}}
     {{else}}
-      <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{value}}</code>
+      <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{if (gt value.length 10) (concat (take 5 value) ", and " (dec 5 value.length) " more.") value}}</code>
     {{/if}}
   </div>
 {{/if}}

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -29,7 +29,7 @@
         /> No
       {{/if}}
     {{else}}
-      <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{if (gt value.length 10) (concat (take 5 value) ", and " (dec 5 value.length) " more.") value}}</code>
+      <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{if (gte value.length 10) (concat (take 5 value) ", and " (dec 5 value.length) " more.") value}}</code>
     {{/if}}
   </div>
 {{/if}}

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -29,7 +29,11 @@
         /> No
       {{/if}}
     {{else}}
-      <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{if (gte value.length 10) (concat (take 5 value) ", and " (dec 5 value.length) " more.") value}}</code>
+      {{#if (eq type 'array')}}
+        <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{if (gte value.length 10) (concat (take 5 value) ", and " (dec 5 value.length) " more.") value}}</code>
+      {{else}}
+        <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{value}}</code>
+      {{/if}}
     {{/if}}
   </div>
 {{/if}}

--- a/ui/tests/pages/components/info-table-row.js
+++ b/ui/tests/pages/components/info-table-row.js
@@ -1,5 +1,5 @@
 import { text, isPresent } from 'ember-cli-page-object';
-//  ARG TODO: add test that shows table value concatenated when over 10 in length.
+
 export default {
   hasLabel: isPresent('[data-test-row-label]'),
   rowLabel: text('[data-test-row-label]'),

--- a/ui/tests/pages/components/info-table-row.js
+++ b/ui/tests/pages/components/info-table-row.js
@@ -1,5 +1,5 @@
 import { text, isPresent } from 'ember-cli-page-object';
-
+//  ARG TODO: add test that shows table value concatenated when over 10 in length.
 export default {
   hasLabel: isPresent('[data-test-row-label]'),
   rowLabel: text('[data-test-row-label]'),


### PR DESCRIPTION
This PR addresses the following:

* Modifies the "show" route to handle edit and delete functionality of a transformation.
![image](https://user-images.githubusercontent.com/6618863/91357399-68fda300-e7ae-11ea-811f-0b23e302f6ad.png)

* implements the delete modal and handles any edge case errors.
![delete](https://user-images.githubusercontent.com/6618863/91357343-55523c80-e7ae-11ea-8511-f4c928bd29ee.gif)

* will concat the view when there are greater than 15 roles (or 15 items in an array passed to the item-list). If there are more than 15 items, it will display the first 5, and then tell how many more there are. This only happens if you pass in the new property `type` to the `info-table-rows` component and the type is `array`. 

![image](https://user-images.githubusercontent.com/6618863/91357476-82065400-e7ae-11ea-8a73-7a1c90582372.png)

* dynamically fill in the cli copy clipboard commands for encode and decode for a transformation. (this follows the google doc ivana created for the varations of cli commands based on the type of transformation).  Below is an example when I remove any allowed_roles and when I change the tweak source.  There are other variations such as when it's type=masking that I have not demoed.

![cli](https://user-images.githubusercontent.com/6618863/91357560-acf0a800-e7ae-11ea-973d-c44e3ee7a39f.gif)




