### PR TITLE
Docs: Swap Consul Secret Engine Role Version Titles

### DIFF
--- a/website/pages/api-docs/secret/consul/index.mdx
+++ b/website/pages/api-docs/secret/consul/index.mdx
@@ -76,6 +76,34 @@ updated attributes.
 
 ### Parameters for Consul versions 1.4 and above
 
+- `lease` `(string: "")` – Specifies the lease for this role. This is provided
+  as a string duration with a time suffix like `"30s"` or `"1h"`. If not
+  provided, the default Vault lease is used.
+
+- `policies` `(string: <required>)` – Comma separated list of policies to be applied
+  to the tokens.
+
+### Sample payload
+
+```json
+{
+  "policies": "global-management"
+}
+```
+
+### Sample request
+
+```sh
+curl \
+→     --request POST \
+→     --header "X-Vault-Token: ..."\
+→     --data @payload.json \
+→     http://127.0.0.1:8200/v1/consul/roles/example-role
+```
+
+### Parameters for Consul version below 1.4
+
+
 - `name` `(string: <required>)` – Specifies the name of an existing role against
   which to create this Consul credential. This is part of the request URL.
 
@@ -128,33 +156,6 @@ $ curl \
     --header "X-Vault-Token: ..." \
     --data @payload.json \
     http://127.0.0.1:8200/v1/consul/roles/example-role
-```
-
-### Parameters for Consul version below 1.4
-
-- `lease` `(string: "")` – Specifies the lease for this role. This is provided
-  as a string duration with a time suffix like `"30s"` or `"1h"`. If not
-  provided, the default Vault lease is used.
-
-- `policies` `(string: <required>)` – Comma separated list of policies to be applied
-  to the tokens.
-
-### Sample payload
-
-```json
-{
-  "policies": "global-management"
-}
-```
-
-### Sample request
-
-```sh
-curl \
-→     --request POST \
-→     --header "X-Vault-Token: ..."\
-→     --data @payload.json \
-→     http://127.0.0.1:8200/v1/consul/roles/example-role
 ```
 
 ## Read Role


### PR DESCRIPTION
I noticed these titles were swapped around, so I fixed them. I also moved the Consul >= 1.4.0 information above the legacy parameters since it is likely more relevant. 