### PR TITLE
Remove incorrect couchbase command

### DIFF
--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -51,7 +51,6 @@ vault secrets enable aws
 vault secrets enable azure
 vault secrets enable cassandra
 vault secrets enable consul
-vault secrets enable couchbase
 vault secrets enable database
 vault secrets enable gcp
 vault secrets enable gcpkms


### PR DESCRIPTION
This command fails - using couchbase is enabled through `vault enable secrets database`