### PR TITLE
docs: add ldap ppolicy to enforce password hashing

### DIFF
--- a/website/pages/docs/secrets/openldap/index.mdx
+++ b/website/pages/docs/secrets/openldap/index.mdx
@@ -69,8 +69,8 @@ values in LDAP. This behavior can cause plaintext passwords to be stored in LDAP
 To avoid having plaintext passwords stored an LDAP password policy (ppolicy) should 
 be configured on the LDAP server to enforce hashing or encryption by default.
 
-The following is an example of a password policy to enforce hashing on data information 
-tree (DIT) `dc=hashicorp,dc=com`:
+The following is an example of a password policy to enforce hashing on the data 
+information tree (DIT) `dc=hashicorp,dc=com`:
 
 ```
 dn: cn=module{0},cn=config

--- a/website/pages/docs/secrets/openldap/index.mdx
+++ b/website/pages/docs/secrets/openldap/index.mdx
@@ -66,11 +66,12 @@ This plugin currently supports LDAP v3.
 The OpenLDAP secret engine does not hash or encrypt passwords prior to modifying 
 values in LDAP. This behavior can cause plaintext passwords to be stored in LDAP.
 
-To avoid having plaintext passwords stored an LDAP password policy (ppolicy) should 
-be configured on the LDAP server to enforce hashing or encryption by default.
+To avoid having plaintext passwords stored, the LDAP server should be configured 
+with an LDAP password policy (ppolicy, not to be confused with a Vault password 
+policy).  A ppolicy can enforce rules such as hashing plaintext passwords by default.
 
-The following is an example of a password policy to enforce hashing on the data 
-information tree (DIT) `dc=hashicorp,dc=com`:
+The following is an example of an LDAP password policy to enforce hashing on the 
+data information tree (DIT) `dc=hashicorp,dc=com`:
 
 ```
 dn: cn=module{0},cn=config

--- a/website/pages/docs/secrets/openldap/index.mdx
+++ b/website/pages/docs/secrets/openldap/index.mdx
@@ -61,6 +61,34 @@ This plugin currently supports LDAP v3.
     $ vault read openldap/static-role/hashicorp
     ```
 
+## LDAP Password Policy
+
+The OpenLDAP secret engine does not hash or encrypt passwords prior to modifying 
+values in LDAP.  This behavior can cause plaintext passwords to be stored in LDAP.
+
+To avoid having plaintext passwords stored an LDAP password policy (ppolicy) should 
+be configured on the LDAP server to enforce hashing or encryption by default.
+
+The following is an example of a password policy to enforce hashing on data information 
+tree (DIT) `dc=hashicorp,dc=com`:
+
+```
+dn: cn=module{0},cn=config
+changetype: modify
+add: olcModuleLoad
+olcModuleLoad: ppolicy
+
+dn: olcOverlay={2}ppolicy,olcDatabase={1}mdb,cn=config
+changetype: add
+objectClass: olcPPolicyConfig
+objectClass: olcOverlayConfig
+olcOverlay: {2}ppolicy
+olcPPolicyDefault: cn=default,ou=pwpolicies,dc=hashicorp,dc=com
+olcPPolicyForwardUpdates: FALSE
+olcPPolicyHashCleartext: TRUE
+olcPPolicyUseLockout: TRUE
+```  
+
 ## Schema
 
 The OpenLDAP Secret Engine supports three different schemas: `openldap` (default),

--- a/website/pages/docs/secrets/openldap/index.mdx
+++ b/website/pages/docs/secrets/openldap/index.mdx
@@ -64,7 +64,7 @@ This plugin currently supports LDAP v3.
 ## LDAP Password Policy
 
 The OpenLDAP secret engine does not hash or encrypt passwords prior to modifying 
-values in LDAP.  This behavior can cause plaintext passwords to be stored in LDAP.
+values in LDAP. This behavior can cause plaintext passwords to be stored in LDAP.
 
 To avoid having plaintext passwords stored an LDAP password policy (ppolicy) should 
 be configured on the LDAP server to enforce hashing or encryption by default.


### PR DESCRIPTION
This adds a note to the OpenLDAP doc about using an LDAP ppolicy to the LDAP server for enforcing plaintext passwords to be hashed by the server. The consequence of not using this results in plaintext passwords being stored in LDAP.