### PR TITLE
Return correct response in Transit.create_key

### DIFF
--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -1068,8 +1068,11 @@ func testConvergentEncryptionCommon(t *testing.T, ver int, keyType keysutil.KeyT
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp != nil {
-		t.Fatal("expected nil response")
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if !resp.IsEmpty() {
+		t.Fatal("expected empty response")
 	}
 
 	p, err := keysutil.LoadPolicy(context.Background(), storage, path.Join("policy", "testkey"))
@@ -1556,8 +1559,11 @@ func TestBadInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp != nil {
-		t.Fatal("expected nil response")
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if !resp.IsEmpty() {
+		t.Fatal("expected empty response")
 	}
 
 	req.Path = "decrypt/test"

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -211,7 +211,7 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 		resp.AddWarning(fmt.Sprintf("key %s already existed", name))
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 // Built-in helper type for returning asymmetric keys

--- a/changelog/9859.txt
+++ b/changelog/9859.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-secrets/transit: Return correct responses when creating a key.
+secrets/transit: Return a warning in key creation when the key already existed.
 ```

--- a/changelog/9859.txt
+++ b/changelog/9859.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/transit: Return correct responses when creating a key.
+```

--- a/sdk/logical/response.go
+++ b/sdk/logical/response.go
@@ -96,6 +96,11 @@ func (r *Response) IsError() bool {
 	return r != nil && r.Data != nil && r.Data["error"] != nil && (len(r.Data) == 1 || (r.Data["data"] != nil && len(r.Data) == 2))
 }
 
+// IsEmpty returns true if this response seems to be an empty struct.
+func (r *Response) IsEmpty() bool {
+	return r != nil && r.Secret == nil && r.Auth == nil && r.Data == nil && r.Redirect == "" && r.Warnings == nil && r.WrapInfo == nil && r.Headers == nil
+}
+
 func (r *Response) Error() error {
 	if !r.IsError() {
 		return nil


### PR DESCRIPTION
Presently, Vault does not return the intended response when a key has been not upserted when creating a key in the Transit secrets engine. This PR fixes that.

Incidentally: is raising a warning sufficient for ensuring that a key has not been accidentally updated? Should we raise an error instead?

Signed-off-by: Trishank Karthik Kuppusamy <trishank.kuppusamy@datadoghq.com>