### PR TITLE
docs: add injector tls setup

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -331,6 +331,7 @@ export default [
                   'enterprise-with-raft',
                   'enterprise-dr-with-raft',
                   'enterprise-perf-with-raft',
+                  'injector-tls',
                 ],
               },
             ],

--- a/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
@@ -60,7 +60,7 @@ $ openssl req \
    -subj "/C=US/ST=CA/L=San Francisco/O=HashiCorp/CN=vault-agent-injector-svc"
 ```
 
-After creating the CSR, configure an extension file to configure additional parameters for signing 
+After creating the CSR, create an extension file to configure additional parameters for signing 
 the certificate.
 
 ~> **Important Note:** The alternative names for the certificate must be configured to use the name 

--- a/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
@@ -1,0 +1,132 @@
+---
+layout: "docs"
+page_title: "Vault Agent Injector TLS Configuration"
+sidebar_current: "docs-platform-k8s-examples-vault-agent-injector-tls-configuration"
+sidebar_title: "Vault Agent Injector TLS Configuration"
+description: |-
+  Describes how to set up the Vault Agent Injector with manually generate certificates and keys.
+---
+
+# Vault Agent Injector TLS Configuration
+
+~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
+
+The following instructions demonstrate how to create manually configure the Vault Agent Injector 
+with self-signed certificates.
+
+## Create a Certiticate Authority (CA)
+
+First, create a private key to be used by our custom Certificate Authority (CA):
+
+```shell
+$ openssl genrsa -out injector-ca.key 2048
+```
+
+Next, create a certificate authority certificate:
+
+~> **Important Note:** Values such as days (how long the certificate is valid for) should be configured for your environment.
+
+```shell
+$ openssl req \
+   -x509 \
+   -new \
+   -nodes \
+   -key injector-ca.key \
+   -sha256 \
+   -days 1825 \
+   -out injector-ca.crt \
+   -subj "/C=US/ST=CA/L=San Francisco/O=HashiCorp/CN=vault-agent-injector-svc"
+```
+
+## Create Vault Agent Injector Certificate
+
+Next we can create a certificate and key signed by the certificiate authority generated above.  This 
+certificiate and key will be used by the Vault Agent Injector for TLS communications with the Kuberenetes 
+API.
+
+First, create a private key for the certificate:
+
+```shell
+$ openssl genrsa -out tls.key 2048
+```
+
+Next, create a certificate signing request (CSR) to be used when signing the certificate:
+
+```shell
+$ openssl req \
+   -new \
+   -key tls.key \
+   -out tls.csr \
+   -subj "/C=US/ST=CA/L=San Francisco/O=HashiCorp/CN=vault-agent-injector-svc"
+```
+
+After creating the CSR, configure an extension file to configure additional parameters for signing 
+the certificate.
+
+~> **Important Note:** The alternative names for the certificate must be configured to use the name 
+  of the Vault Agent Injector Kubernetes service and namespace where its created.
+
+In this example the Vault Agent Injector service name is `vault-agent-injector-svc` in the `vault` namespace. 
+This uses the pattern `<k8s service name>.<k8s namespace>.svc.cluster.local`.
+
+```shell
+$ cat <<EOF >csr.conf
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = vault-agent-injector-svc
+DNS.2 = vault-agent-injector-svc.vault
+DNS.3 = vault-agent-injector-svc.vault.svc
+DNS.4 = vault-agent-injector-svc.vault.svc.cluster.local
+EOF
+```
+
+Finally, sign the certificiate:
+
+```shell
+$ openssl x509 \
+  -req \
+  -in tls.csr \
+  -CA injector-ca.crt \
+  -CAkey injector-ca.key \
+  -CAcreateserial \
+  -out tls.crt \
+  -days 1825 \
+  -sha256 \
+  -extfile csr.conf
+```
+
+~> **Important Note:** Values such as days (how long the certificate is valid for) should be configured for your environment.
+
+## Configuration
+
+Now that a certificate authority and a signed certificate have been created, we can now configure 
+Helm and the Vault Agent Injector to use them.
+
+First, create a Kubernetes secret containing the certificate and key created above:
+
+~> **Important Note:** This example assumes the Vault Agent Injector is running in the `vault` namespace.
+
+```shell
+$ kubectl create secret generic injector-tls \
+    --from-file tls.crt \
+    --from-file tls.key \
+    --namespace=vault
+```
+
+Next, base64 encode the certificate authority so Kubernetes can verify the authenticity of the certificate:
+
+```shell
+export CA_BUNDLE=$(cat injector-ca.crt | base64)
+```
+
+Finally, install the Vault Agent Injector with the following custom values:
+
+```shell
+helm install vault hashicorp/vault \
+  --set="injector.certs.secretName=injector-tls" \
+  --set="injector.certs.caBundle=${CA_BUNDLE?}" 
+```

--- a/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
@@ -127,6 +127,7 @@ Finally, install the Vault Agent Injector with the following custom values:
 
 ```shell
 $ helm install vault hashicorp/vault \
+  --namespace=vault \
   --set="injector.certs.secretName=injector-tls" \
   --set="injector.certs.caBundle=${CA_BUNDLE?}" 
 ```

--- a/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
@@ -11,7 +11,7 @@ description: |-
 
 ~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
 
-The following instructions demonstrate how to create manually configure the Vault Agent Injector 
+The following instructions demonstrate how to manually configure the Vault Agent Injector 
 with self-signed certificates.
 
 ## Create a Certiticate Authority (CA)

--- a/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
@@ -4,7 +4,7 @@ page_title: "Vault Agent Injector TLS Configuration"
 sidebar_current: "docs-platform-k8s-examples-injector-tls"
 sidebar_title: "Vault Agent Injector TLS Configuration"
 description: |-
-  Describes how to set up the Vault Agent Injector with manually generate certificates and keys.
+  Describes how to set up the Vault Agent Injector with manually generated certificates and keys.
 ---
 
 # Vault Agent Injector TLS Configuration

--- a/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
@@ -120,13 +120,13 @@ $ kubectl create secret generic injector-tls \
 Next, base64 encode the certificate authority so Kubernetes can verify the authenticity of the certificate:
 
 ```shell
-export CA_BUNDLE=$(cat injector-ca.crt | base64)
+$ export CA_BUNDLE=$(cat injector-ca.crt | base64)
 ```
 
 Finally, install the Vault Agent Injector with the following custom values:
 
 ```shell
-helm install vault hashicorp/vault \
+$ helm install vault hashicorp/vault \
   --set="injector.certs.secretName=injector-tls" \
   --set="injector.certs.caBundle=${CA_BUNDLE?}" 
 ```

--- a/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Vault Agent Injector TLS Configuration"
-sidebar_current: "docs-platform-k8s-examples-vault-agent-injector-tls-configuration"
+sidebar_current: "docs-platform-k8s-examples-injector-tls"
 sidebar_title: "Vault Agent Injector TLS Configuration"
 description: |-
   Describes how to set up the Vault Agent Injector with manually generate certificates and keys.

--- a/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/injector-tls.mdx
@@ -86,6 +86,8 @@ EOF
 
 Finally, sign the certificiate:
 
+~> **Important Note:** Values such as days (how long the certificate is valid for) should be configured for your environment.
+
 ```shell
 $ openssl x509 \
   -req \
@@ -98,8 +100,6 @@ $ openssl x509 \
   -sha256 \
   -extfile csr.conf
 ```
-
-~> **Important Note:** Values such as days (how long the certificate is valid for) should be configured for your environment.
 
 ## Configuration
 


### PR DESCRIPTION
This adds instructions on installing the Vault Agent Injector using user generated certificates. Out of the box the injector supports auto-tls where it generates these for the user, however, it also supports manual certificate injection (which this document is describing).