### PR TITLE
Ui/transform find all roles

### DIFF
--- a/ui/app/components/transform-show-transformation.js
+++ b/ui/app/components/transform-show-transformation.js
@@ -1,3 +1,31 @@
 import TransformBase from './transform-edit-base';
+import { computed } from '@ember/object';
 
-export default TransformBase.extend({});
+export default TransformBase.extend({
+  cliCommand: computed('model.{allowed_roles}', 'model.{type}', 'model.{tweak_source}', function() {
+    if (!this.model) {
+      return;
+    }
+
+    let { type, allowed_roles, tweak_source, template } = this.model;
+    let isWildcardString = allowed_roles[0].includes('*');
+
+    // values to be returned
+    let role = '';
+    let value = 'value=<enter your value here>'; // change this when decode vs encode
+    let tweak = '';
+
+    // determine the role
+    if (allowed_roles.length > 1 || isWildcardString) {
+      role = '<choose a role>';
+    } else {
+      role = allowed_roles[0];
+    }
+    // determine the tweak_source
+    if (type === 'fpe' && tweak_source === 'supplied') {
+      tweak = 'tweak=<enter your tweak>';
+    }
+
+    return `${role} ${value} ${tweak} transformation=${template[0]}`;
+  }),
+});

--- a/ui/app/components/transform-show-transformation.js
+++ b/ui/app/components/transform-show-transformation.js
@@ -2,7 +2,7 @@ import TransformBase from './transform-edit-base';
 import { computed } from '@ember/object';
 
 export default TransformBase.extend({
-  cliCommand: computed('model.{allowed_roles}', 'model.{type}', 'model.{tweak_source}', function() {
+  cliCommand: computed('model.{allowed_roles, type, tweak_source}', function() {
     if (!this.model) {
       return;
     }

--- a/ui/app/components/transform-show-transformation.js
+++ b/ui/app/components/transform-show-transformation.js
@@ -7,18 +7,16 @@ export default TransformBase.extend({
       return;
     }
 
-    let { type, allowed_roles, tweak_source, template } = this.model;
-    let isWildcardString = allowed_roles[0].includes('*');
+    let { type, allowed_roles, tweak_source, name } = this.model;
+    let wildCardRole = allowed_roles.find(role => role.includes('*'));
 
     // values to be returned
-    let role = '';
+    let role = '<choose a role>';
     let value = 'value=<enter your value here>'; // change this when decode vs encode
     let tweak = '';
 
     // determine the role
-    if (allowed_roles.length > 1 || isWildcardString) {
-      role = '<choose a role>';
-    } else {
+    if (allowed_roles.length === 1 && !wildCardRole) {
       role = allowed_roles[0];
     }
     // determine the tweak_source
@@ -26,6 +24,6 @@ export default TransformBase.extend({
       tweak = 'tweak=<enter your tweak>';
     }
 
-    return `${role} ${value} ${tweak} transformation=${template[0]}`;
+    return `${role} ${value} ${tweak} transformation=${name}`;
   }),
 });

--- a/ui/app/components/transform-show-transformation.js
+++ b/ui/app/components/transform-show-transformation.js
@@ -2,7 +2,7 @@ import TransformBase from './transform-edit-base';
 import { computed } from '@ember/object';
 
 export default TransformBase.extend({
-  cliCommand: computed('model.{allowed_roles, type, tweak_source}', function() {
+  cliCommand: computed('model.{allowed_roles,type,tweak_source}', function() {
     if (!this.model) {
       return;
     }
@@ -12,7 +12,7 @@ export default TransformBase.extend({
 
     // values to be returned
     let role = '<choose a role>';
-    let value = 'value=<enter your value here>'; // change this when decode vs encode
+    let value = 'value=<enter your value here>';
     let tweak = '';
 
     // determine the role

--- a/ui/app/helpers/filter-wildcard.js
+++ b/ui/app/helpers/filter-wildcard.js
@@ -1,0 +1,14 @@
+import { helper as buildHelper } from '@ember/component/helper';
+
+export function filterWildcard([string, array]) {
+  if (string && !string.id.includes('*')) {
+    // string does not contain wildcard
+    return;
+  }
+  let stringId = string.id;
+  const filterBy = stringId =>
+    array.filter(item => new RegExp('^' + stringId.replace(/\*/g, '.*') + '$').test(item));
+  return filterBy(stringId).length;
+}
+
+export default buildHelper(filterWildcard);

--- a/ui/app/helpers/filter-wildcard.js
+++ b/ui/app/helpers/filter-wildcard.js
@@ -1,7 +1,7 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
 export function filterWildcard([string, array]) {
-  if (!string) {
+  if (!string || !array) {
     return;
   }
   if (!string.id && string) {

--- a/ui/app/helpers/filter-wildcard.js
+++ b/ui/app/helpers/filter-wildcard.js
@@ -1,6 +1,12 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
 export function filterWildcard([string, array]) {
+  if (!string) {
+    return;
+  }
+  if (!string.id && string) {
+    string = { id: string };
+  }
   let stringId = string.id;
   const filterBy = stringId =>
     array.filter(item => new RegExp('^' + stringId.replace(/\*/g, '.*') + '$').test(item));

--- a/ui/app/helpers/filter-wildcard.js
+++ b/ui/app/helpers/filter-wildcard.js
@@ -1,10 +1,6 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
 export function filterWildcard([string, array]) {
-  if (string && !string.id.includes('*')) {
-    // string does not contain wildcard
-    return;
-  }
   let stringId = string.id;
   const filterBy = stringId =>
     array.filter(item => new RegExp('^' + stringId.replace(/\*/g, '.*') + '$').test(item));

--- a/ui/app/helpers/is-wildcard-string.js
+++ b/ui/app/helpers/is-wildcard-string.js
@@ -6,11 +6,15 @@ export function isWildcardString([string]) {
   }
   // string is actually an object which is what comes in in the searchSelect component
   if (typeof string === 'object') {
-    if (string.id && string.id.includes('*')) {
-      // string with id contains a wildcard
-      return true;
+    if (!string.id && !string.name) {
+      return false;
     }
-    return false;
+    if (string.id) {
+      return string.id.includes('*');
+    }
+    if (string.name) {
+      return string.name.includes('*');
+    }
   }
   // otherwise string is a string
   if (string.includes('*')) {

--- a/ui/app/helpers/is-wildcard-string.js
+++ b/ui/app/helpers/is-wildcard-string.js
@@ -1,0 +1,10 @@
+import { helper as buildHelper } from '@ember/component/helper';
+
+export function isWildcardString([string]) {
+  if (string && string.id && string.id.includes('*')) {
+    // string contains a wildcard
+    return true;
+  }
+}
+
+export default buildHelper(isWildcardString);

--- a/ui/app/helpers/is-wildcard-string.js
+++ b/ui/app/helpers/is-wildcard-string.js
@@ -6,22 +6,10 @@ export function isWildcardString([string]) {
   }
   // string is actually an object which is what comes in in the searchSelect component
   if (typeof string === 'object') {
-    if (!string.id && !string.name) {
-      return false;
-    }
-    if (string.id) {
-      return string.id.includes('*');
-    }
-    if (string.name) {
-      return string.name.includes('*');
-    }
+    string = Object.values(string)[0];
   }
-  // otherwise string is a string
-  if (string.includes('*')) {
-    return true;
-  }
-  // default to false
-  return false;
+
+  return string.includes('*');
 }
 
 export default buildHelper(isWildcardString);

--- a/ui/app/helpers/is-wildcard-string.js
+++ b/ui/app/helpers/is-wildcard-string.js
@@ -1,10 +1,23 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
 export function isWildcardString([string]) {
-  if (string && string.id && string.id.includes('*')) {
-    // string contains a wildcard
+  if (!string) {
+    return false;
+  }
+  // string is actually an object which is what comes in in the searchSelect component
+  if (typeof string === 'object') {
+    if (string.id && string.id.includes('*')) {
+      // string with id contains a wildcard
+      return true;
+    }
+    return false;
+  }
+  // otherwise string is a string
+  if (string.includes('*')) {
     return true;
   }
+  // default to false
+  return false;
 }
 
 export default buildHelper(isWildcardString);

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -78,8 +78,8 @@ const Model = DS.Model.extend({
     label: 'Allowed roles',
     fallbackComponent: 'string-list',
     models: ['transform/role'],
-    wildcardLabel: 'role', // add wildcardLabel is you want to display count when wildcard used in searchSelect component
     subText: 'Search for an existing role, type a new role to create it, or use a wildcard (*).',
+    wildcardLabel: 'role',
   }),
   transformAttrs: computed('type', function() {
     if (this.type === 'masking') {

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -78,7 +78,7 @@ const Model = DS.Model.extend({
     label: 'Allowed roles',
     fallbackComponent: 'string-list',
     models: ['transform/role'],
-    wildCardLabel: 'role', // add wildCardLabel is you want to display count when wildcard used in searchSelect component
+    wildcardLabel: 'role', // add wildcardLabel is you want to display count when wildcard used in searchSelect component
     subText: 'Search for an existing role, type a new role to create it, or use a wildcard (*).',
   }),
   transformAttrs: computed('type', function() {

--- a/ui/app/models/transform.js
+++ b/ui/app/models/transform.js
@@ -78,6 +78,7 @@ const Model = DS.Model.extend({
     label: 'Allowed roles',
     fallbackComponent: 'string-list',
     models: ['transform/role'],
+    wildCardLabel: 'role', // add wildCardLabel is you want to display count when wildcard used in searchSelect component
     subText: 'Search for an existing role, type a new role to create it, or use a wildcard (*).',
   }),
   transformAttrs: computed('type', function() {

--- a/ui/app/models/transform/role.js
+++ b/ui/app/models/transform/role.js
@@ -29,6 +29,7 @@ const Model = DS.Model.extend({
     models: ['transform'],
     subLabel: 'Transformations',
     subText: 'Select which transformations this role will have access to. It must already exist.',
+    wildcardLabel: 'transformation',
   }),
 
   attrs: computed('transformations', function() {

--- a/ui/app/models/transform/role.js
+++ b/ui/app/models/transform/role.js
@@ -30,7 +30,6 @@ const Model = DS.Model.extend({
     onlyAllowExisting: true,
     subLabel: 'Transformations',
     subText: 'Select which transformations this role will have access to. It must already exist.',
-    wildcardLabel: 'transformation',
   }),
 
   attrs: computed('transformations', function() {

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -18,12 +18,8 @@
       </span>
     </div>
     <div class="copy-text level">
-      {{#let (concat 
-        "vault write " model.backend "/encode/" 
-        (if (and (take 1 model.allowed_roles) (eq model.allowed_roles.length 1)) (take 1 model.allowed_roles) "<choose a role>")
-        " value=<enter your value here>" 
-        (if (and (eq model.type 'fpe') (eq model.tweak_source "supplied")) " tweak_source=<enter your tweak>")) as |copyEncodeCommand|}}
-        <code>{{copyEncodeCommand}}</code>
+      {{#let (concat "vault write " model.backend "/encode/" cliCommand) as |copyEncodeCommand|}}
+        <code>vault write {{model.backend}}/encode/{{cliCommand}}</code>
         <CopyButton class="button is-transparent level-right" @clipboardText={{copyEncodeCommand}}
           @buttonType="button" @success={{action (set-flash-message 'Command copied!')}}>
           <Icon @size='l' @glyph="copy-action" aria-label="Copy" />
@@ -39,12 +35,8 @@
       </span>
     </div>
     <div class="copy-text level">
-      {{#let (concat 
-        "vault write " model.backend "/decode/" 
-        (if (and (take 1 model.allowed_roles) (eq model.allowed_roles.length 1)) (take 1 model.allowed_roles) "<choose a role>")
-        " value=<enter your value here>" 
-        (if (and (eq model.type 'fpe') (eq model.tweak_source "supplied")) " tweak_source=<enter your tweak>")) as |copyDecodeCommand|}}
-        <code>{{copyDecodeCommand}}</code>
+      {{#let (concat "vault write " model.backend "/decode/" cliCommand) as |copyDecodeCommand|}}
+        <code>vault write {{model.backend}}/decode/{{cliCommand}}</code>
         <CopyButton class="button is-transparent level-right" @clipboardText={{copyDecodeCommand}}
           @buttonType="button" @success={{action (set-flash-message 'Command copied!')}}>
           <Icon @size='l' @glyph="copy-action" aria-label="Copy" />

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -36,37 +36,45 @@
             <T.trigger @tabindex=false>
               <a
               class="toolbar-link"
-              onclick={{action (mut isModalActive) true}}
               aria-disabled="true"
               disabled
-            >
-              Delete transformation
-            </a>
-          </T.trigger>
-          <T.content @class="tool-tip">
-            <div class="box">
-              This transformation is in use by a role and can’t be deleted.
-            </div>
-          </T.content>
-        </ToolTip>
-      {{else}}
+              >
+                Delete transformation
+              </a>
+            </T.trigger>
+            <T.content @class="tool-tip">
+              <div class="box">
+                This transformation is in use by a role and can’t be deleted.
+              </div>
+            </T.content>
+          </ToolTip>
+        {{else}}
         <a
           class="toolbar-link"
-          onclick={{action (mut isModalActive) true}}
+          onclick={{action (mut isDeleteModalActive) true}}
         >
           Delete transformation
         </a>
         {{/if}}
       {{/if}}
       {{#if capabilities.canUpdate }}
-        <ToolbarSecretLink
-          @secret={{model.id}}
-          @mode="edit"
-          @data-test-edit-link=true
-          @replace=true
-        >
-          Edit transformation
-        </ToolbarSecretLink>
+        {{#if (gt model.allowed_roles.length 0)}}
+          <a
+            class="toolbar-link"
+            onclick={{action (mut isEditModalActive) true}}
+          >
+            Edit transformation
+          </a>
+        {{else}}
+          <ToolbarSecretLink
+            @secret={{model.id}}
+            @mode="edit"
+            @data-test-edit-link=true
+            @replace=true
+          >
+            Edit transformation
+          </ToolbarSecretLink>
+        {{/if}}
       {{/if}}
     </ToolbarActions>
   </Toolbar>
@@ -84,8 +92,8 @@
 
 <ConfirmationModal
   @title="Delete transformation"
-  @onClose={{action (mut isModalActive) false}}
-  @isActive={{isModalActive}}
+  @onClose={{action (mut isDeleteModalActive) false}}
+  @isActive={{isDeleteModalActive}}
   @confirmText={{model.name}}
   @toConfirmMsg="Type {{model.name}} to confirm deleting the transformation."
   @onConfirm={{action "delete"}}
@@ -95,3 +103,28 @@
   </p>
   <MessageError @model={{model}} @errorMessage={{error}} />
 </ConfirmationModal>
+
+<Modal
+  @title="Edit transformation"
+  @onClose={{action (mut isEditModalActive) false}}
+  @isActive={{isEditModalActive}}
+  @type="warning"
+  @showCloseButton={{true}}
+>
+  <section class="modal-card-body">
+    <p>
+      You’re editing a transformation that is in use by at least one role. Editing it may mean that encode and decode operations stop working. Are you sure?
+    </p>
+  </section>
+  <footer class="modal-card-foot modal-card-foot-outlined">
+    {{#link-to "vault.cluster.secrets.backend.edit" model.id tagName="button" class="button is-primary"}}
+      Confirm
+    {{/link-to}}
+    <button
+      class="button is-secondary"
+      onclick={{action (mut isEditModalActive) false}}
+    >
+      Cancel
+    </button>
+  </footer>
+</Modal>

--- a/ui/app/templates/components/transformation-edit.hbs
+++ b/ui/app/templates/components/transformation-edit.hbs
@@ -28,13 +28,35 @@
         <div class="toolbar-separator" />
       {{/if}}
       {{#if capabilities.canDelete}}
+        {{#if (gt model.allowed_roles.length 0)}}
+          <ToolTip
+            @verticalPosition="above"
+            @horizontalPosition="center"
+            as |T|>
+            <T.trigger @tabindex=false>
+              <a
+              class="toolbar-link"
+              onclick={{action (mut isModalActive) true}}
+              aria-disabled="true"
+              disabled
+            >
+              Delete transformation
+            </a>
+          </T.trigger>
+          <T.content @class="tool-tip">
+            <div class="box">
+              This transformation is in use by a role and can’t be deleted.
+            </div>
+          </T.content>
+        </ToolTip>
+      {{else}}
         <a
           class="toolbar-link"
           onclick={{action (mut isModalActive) true}}
-          data-test-replication-action-trigger
         >
           Delete transformation
         </a>
+        {{/if}}
       {{/if}}
       {{#if capabilities.canUpdate }}
         <ToolbarSecretLink

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -40,8 +40,9 @@ export default Component.extend({
   inputValue: computed(function() {
     return [];
   }),
-  selectedOptions: null, //list of selected options
-  options: null, //all possible options
+  allOptions: null, // list of options including matched
+  selectedOptions: null, // list of selected options
+  options: null, // all possible options
   shouldUseFallback: false,
   shouldRenderName: false,
   init() {
@@ -63,6 +64,11 @@ export default Component.extend({
       option.searchText = `${option.name} ${option.id}`;
       return option;
     });
+    let allOptions = options.toArray().map(option => {
+      return option.id;
+    });
+    this.set('allOptions', allOptions); // used by filter-wildcard helper
+
     let formattedOptions = this.selectedOptions.map(option => {
       let matchingOption = options.findBy('id', option);
       options.removeObject(matchingOption);

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -15,13 +15,14 @@ import layout from '../templates/components/search-select';
  * @param models {String} - An array of model types to fetch from the API.
  * @param onChange {Func} - The onchange action for this form field.
  * @param inputValue {String | Array} -  A comma-separated string or an array of strings.
- * @param [helpText] {String} - Text to be displayed in the info tooltip for this form field
- * @param [subText] {String} - Text to be displayed below the label
- * @param [selectLimit] {Number} - A number that sets the limit to how many select options they can choose
  * @param label {String} - Label for this form field
- * @param [subLabel] {String} - a smaller label below the main Label
  * @param fallbackComponent {String} - name of component to be rendered if the API call 403s
  * @param [backend] {String} - name of the backend if the query for options needs additional information (eg. secret backend)
+ * @param [helpText] {String} - Text to be displayed in the info tooltip for this form field
+ * @param [selectLimit] {Number} - A number that sets the limit to how many select options they can choose
+ * @param [subText] {String} - Text to be displayed below the label
+ * @param [subLabel] {String} - a smaller label below the main Label
+ * @param [wildcardLabel] {String} - when you want the searchSelect component to return a count on the model for options returned when using a wildcard you must provide a label of the count e.g. role.  Should be singular.
  *
  * @param options {Array} - *Advanced usage* - `options` can be passed directly from the outside to the
  * power-select component. If doing this, `models` should not also be passed as that will overwrite the

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -74,7 +74,7 @@
       @inputValue={{get model valuePath}}
       @helpText={{attr.options.helpText}}
       @subText={{attr.options.subText}}
-      @wildCardLabel={{attr.options.wildCardLabel}}
+      @wildcardLabel={{attr.options.wildcardLabel}}
       @label={{labelString}}
       @subLabel={{attr.options.subLabel}}
       @fallbackComponent={{attr.options.fallbackComponent}}

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -74,6 +74,7 @@
       @inputValue={{get model valuePath}}
       @helpText={{attr.options.helpText}}
       @subText={{attr.options.subText}}
+      @wildCardLabel={{attr.options.wildCardLabel}}
       @label={{labelString}}
       @subLabel={{attr.options.subLabel}}
       @fallbackComponent={{attr.options.fallbackComponent}}

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -52,6 +52,11 @@
           </small>
         {{else}}
           {{selected.id}}
+          {{#if wildCardLabel}}
+            {{#let (filter-wildcard selected allOptions) as | wildcardCount |}}
+              includes {{wildcardCount}} {{if (gt wildcardCount 1) (pluralize wildCardLabel) wildCardLabel}}
+            {{/let}}
+          {{/if}}
         {{/if}}
         <div class="control">
           <button type="button" class="button is-ghost" data-test-selected-list-button="delete"

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -52,9 +52,9 @@
           </small>
         {{else}}
           {{selected.id}}
-          {{#if wildCardLabel}}
+          {{#if wildcardLabel}}
             {{#let (filter-wildcard selected allOptions) as | wildcardCount |}}
-              includes {{wildcardCount}} {{if (gt wildcardCount 1) (pluralize wildCardLabel) wildCardLabel}}
+              includes {{wildcardCount}} {{if (gt wildcardCount 1) (pluralize wildcardLabel) wildcardLabel}}
             {{/let}}
           {{/if}}
         {{/if}}

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -52,12 +52,14 @@
           </small>
         {{else}}
           <div>{{selected.id}}
-          {{#if (and wildcardLabel (is-wildcard-string selected))}}
-            {{#let (filter-wildcard selected allOptions) as | wildcardCount |}}
-              <span class="tag is-light has-text-grey-dark" data-test-mode={{wildcardCount}}>
-                includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
-              </span>
-            {{/let}}
+          {{#if wildcardLabel}}
+            {{#if (is-wildcard-string selected)}}
+              {{#let (filter-wildcard selected allOptions) as | wildcardCount |}}
+                <span class="tag is-light has-text-grey-dark" data-test-mode={{wildcardCount}}>
+                  includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
+                </span>
+              {{/let}}
+            {{/if}}
           {{/if}}
           </div>
         {{/if}}

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -54,7 +54,7 @@
           <div>{{selected.id}}
           {{#if (and wildcardLabel (is-wildcard-string selected))}}
             {{#let (filter-wildcard selected allOptions) as | wildcardCount |}}
-              <span class="tag is-light has-text-grey-dark" data-test-mode>
+              <span class="tag is-light has-text-grey-dark" data-test-mode={{wildcardCount}}>
                 includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
               </span>
             {{/let}}

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -55,7 +55,7 @@
           {{#if (and wildcardLabel (is-wildcard-string selected))}}
             {{#let (filter-wildcard selected allOptions) as | wildcardCount |}}
               <span class="tag is-light has-text-grey-dark" data-test-mode>
-                includes {{wildcardCount}} {{if (gt wildcardCount 1) (pluralize wildcardLabel) wildcardLabel}}
+                includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
               </span>
             {{/let}}
           {{/if}}

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -51,12 +51,15 @@
             {{selected.id}}
           </small>
         {{else}}
-          {{selected.id}}
-          {{#if wildcardLabel}}
+          <div>{{selected.id}}
+          {{#if (and wildcardLabel (is-wildcard-string selected))}}
             {{#let (filter-wildcard selected allOptions) as | wildcardCount |}}
-              includes {{wildcardCount}} {{if (gt wildcardCount 1) (pluralize wildcardLabel) wildcardLabel}}
+              <span class="tag is-light has-text-grey-dark" data-test-mode>
+                includes {{wildcardCount}} {{if (gt wildcardCount 1) (pluralize wildcardLabel) wildcardLabel}}
+              </span>
             {{/let}}
           {{/if}}
+          </div>
         {{/if}}
         <div class="control">
           <button type="button" class="button is-ghost" data-test-selected-list-button="delete"

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -30,6 +30,13 @@ const storeService = Service.extend({
           error.httpStatus = 500;
           reject(error);
           break;
+        case 'transform/transformation':
+          resolve([
+            { id: 'foo', name: 'bar' },
+            { id: 'foobar', name: '' },
+            { id: 'barfoo1', name: 'different' },
+          ]);
+          break;
         default:
           reject({ httpStatus: 404, message: 'not found' });
           break;
@@ -87,6 +94,17 @@ module('Integration | Component | search select', function(hooks) {
     assert.equal(component.options.length, 2, 'list shows two options, including the add option');
     await typeInSearch('nine');
     assert.equal(component.options.length, 1, 'list shows one option');
+  });
+
+  test('it counts options when wildcard is used and displays the count', async function(assert) {
+    const models = ['transform/transformation'];
+    this.set('models', models);
+    this.set('onChange', sinon.spy());
+    await render(hbs`{{search-select label="foo" models=models onChange=onChange wildcardLabel="role" }}`);
+    await clickTrigger();
+    await typeInSearch('*bar*');
+    await component.selectOption();
+    assert.dom('[data-test-mode="2"]').exists('correctly counts with wildcard filter and shows the count');
   });
 
   test('it moves option from drop down to list when clicked', async function(assert) {

--- a/ui/tests/unit/helpers/filter-wildcard-test.js
+++ b/ui/tests/unit/helpers/filter-wildcard-test.js
@@ -1,0 +1,25 @@
+import { filterWildcard } from 'vault/helpers/filter-wildcard';
+import { module, test } from 'qunit';
+
+module('Unit | Helpers | filter-wildcard', function() {
+  test('it returns a count if array contains a wildcard', function(assert) {
+    let string = { id: 'foo*' };
+    let array = ['foobar', 'foozar', 'boo', 'oof'];
+    let result = filterWildcard([string, array]);
+    assert.equal(2, result);
+  });
+
+  test('it returns zero if no wildcard is string', function(assert) {
+    let string = { id: 'foo#' };
+    let array = ['foobar', 'foozar', 'boo', 'oof'];
+    let result = filterWildcard([string, array]);
+    assert.equal(0, result);
+  });
+
+  test('it escapes function and does not error if no id is in string', function(assert) {
+    let string = '*bar*';
+    let array = ['foobar', 'foozar', 'boobarboo', 'oof'];
+    let result = filterWildcard([string, array]);
+    assert.equal(2, result);
+  });
+});

--- a/ui/tests/unit/helpers/is-wildcard-string-test.js
+++ b/ui/tests/unit/helpers/is-wildcard-string-test.js
@@ -1,0 +1,29 @@
+import { isWildcardString } from 'vault/helpers/is-wildcard-string';
+import { module, test } from 'qunit';
+
+module('Unit | Helpers | is-wildcard-string', function() {
+  test('it returns true if regular string with wildcard', function(assert) {
+    let string = 'foom#*eep';
+    let result = isWildcardString([string]);
+    assert.equal(result, true);
+  });
+
+  test('it returns false if no wildcard', function(assert) {
+    let string = 'foo.bar';
+    let result = isWildcardString([string]);
+    assert.equal(result, false);
+  });
+
+  test('it returns true if string with id as in searchSelect selected has wildcard', function(assert) {
+    let string = { id: 'foo.bar*baz' };
+    let result = isWildcardString([string]);
+    assert.equal(result, true);
+  });
+
+  test('it returns false if string object does not have id', function(assert) {
+    let string = { name: 'foo.bar*baz' };
+    let result = isWildcardString([string]);
+    console.log(result, 'results');
+    assert.equal(result, false);
+  });
+});

--- a/ui/tests/unit/helpers/is-wildcard-string-test.js
+++ b/ui/tests/unit/helpers/is-wildcard-string-test.js
@@ -20,10 +20,15 @@ module('Unit | Helpers | is-wildcard-string', function() {
     assert.equal(result, true);
   });
 
-  test('it returns false if string object does not have id', function(assert) {
+  test('it returns true if string object has name and no id', function(assert) {
     let string = { name: 'foo.bar*baz' };
     let result = isWildcardString([string]);
-    console.log(result, 'results');
+    assert.equal(result, true);
+  });
+
+  test('it returns false if string object has no name or id', function(assert) {
+    let string = { somethingElse: 'foo.bar*baz' };
+    let result = isWildcardString([string]);
     assert.equal(result, false);
   });
 });

--- a/ui/tests/unit/helpers/is-wildcard-string-test.js
+++ b/ui/tests/unit/helpers/is-wildcard-string-test.js
@@ -26,9 +26,9 @@ module('Unit | Helpers | is-wildcard-string', function() {
     assert.equal(result, true);
   });
 
-  test('it returns false if string object has no name or id', function(assert) {
-    let string = { somethingElse: 'foo.bar*baz' };
+  test('it returns true if string object has name and id with with at least one wildcard', function(assert) {
+    let string = { id: '7*', name: 'seven' };
     let result = isWildcardString([string]);
-    assert.equal(result, false);
+    assert.equal(result, true);
   });
 });


### PR DESCRIPTION
This PR does the following for the Transform Secret Engine:

1. Creates two helpers that determine if there is a wildcard in the `searchSelect` component object, and then if there is, filtering through the array sent to it to return a count based on the wildcard used.
2. The helpers are used whenever an Ember model has field type `searchSelect ` _and_ the `wildcardLabel` is defined which tells the component what the wild card is filtering through.  For roles this is "transformation(s)" and for the transformation edit/create this is "role(s").

**See wildcard functionality here:**
<img width=400px src="https://user-images.githubusercontent.com/6618863/92257805-0e8dd200-ee93-11ea-816d-b693420b3f8a.gif" />

3. Adds a disable and tooltip to the "delete" action available on the "Edit Transformation" view.  If there are allowed_roles on the transformation, we are going to assume you can't delete this transformation.  Technically, the role has to be "Attached" from the role to the transformation, but we are setting up this workflow later and are controlling this flow here.

<img width=300px src="https://user-images.githubusercontent.com/6618863/92258006-64fb1080-ee93-11ea-9a2f-6327a9c4f776.png" />


4. Set's up a warning modal when editing a transformation that has an `allowed_role`.

<img width=400px src="https://user-images.githubusercontent.com/6618863/92258021-6d534b80-ee93-11ea-8599-a3d90b1a5dcb.png" />

5. Fixes the CLI commands to handle more use cases and brings the logic inside the js component file as it's too difficult to read from the template.  Additionally, it's likely that more use cases will be added in the future as we bring more functionality into the engine.  There is a google doc Ivana has created to help work through all the situations.

TODO:
- [ ] amend the `searchSelect` test