### PR TITLE
Fix crash when KV store has a zero-length key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ BUG FIXES:
 
 * core: Fix resource leak in plugin API (plugin-dependent, not all plugins impacted) [[GH-9557](https://github.com/hashicorp/vault/pull/9557)]
 * core: Fix race involved in enabling certain features via a license change
-* core: Fix crash when metrics collection encounters zero-length keys in KV store
+* core: Fix crash when metrics collection encounters zero-length keys in KV store [[GH-9811](https://github.com/hashicorp/vault/pull/9881)]
 * replication (enterprise): Only write failover cluster addresses if they've changed
 * secrets/database: Fix handling of TLS options in mongodb connection strings [[GH-9519](https://github.com/hashicorp/vault/pull/9519)]
 * secrets/gcp: Ensure that the IAM policy version is appropriately set after a roleset's bindings have changed. [[GH-93](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/93)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ BUG FIXES:
 
 * core: Fix resource leak in plugin API (plugin-dependent, not all plugins impacted) [[GH-9557](https://github.com/hashicorp/vault/pull/9557)]
 * core: Fix race involved in enabling certain features via a license change
+* core: Fix crash when metrics collection encounters zero-length keys in KV store
 * replication (enterprise): Only write failover cluster addresses if they've changed
 * secrets/database: Fix handling of TLS options in mongodb connection strings [[GH-9519](https://github.com/hashicorp/vault/pull/9519)]
 * secrets/gcp: Ensure that the IAM policy version is appropriately set after a roleset's bindings have changed. [[GH-93](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/93)]

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -294,7 +294,7 @@ func (c *Core) walkKvMountSecrets(ctx context.Context, m *kvMount) {
 			return
 		}
 		for _, path := range keys {
-			if path[len(path)-1] == '/' {
+			if len(path) > 0 && path[len(path)-1] == '/' {
 				subdirectories = append(subdirectories, currentDirectory+path)
 			} else {
 				m.NumSecrets += 1


### PR DESCRIPTION
Unit test successfully demonstrates the crash:

```
--- FAIL: TestCoreMetrics_KvSecretGauge_BadPath (0.03s)
panic: runtime error: index out of range [-1] [recovered]
	panic: runtime error: index out of range [-1]

goroutine 9 [running]:
testing.tRunner.func1.1(0x2e2d400, 0xc0007a8680)
	/usr/local/go/src/testing/testing.go:1057 +0x30d
testing.tRunner.func1(0xc000643e00)
	/usr/local/go/src/testing/testing.go:1060 +0x41a
panic(0x2e2d400, 0xc0007a8680)
	/usr/local/go/src/runtime/panic.go:969 +0x175
github.com/hashicorp/vault/vault.(*Core).walkKvMountSecrets(0xc0001de600, 0x35b39e0, 0xc000703a10, 0xc0007039e0)
	/home/mgritter/vault/vault/core_metrics.go:297 +0xa94
github.com/hashicorp/vault/vault.(*Core).kvSecretGaugeCollector(0xc0001de600, 0x35b39e0, 0xc000703a10, 0xc0007038f0, 0x0, 0x0, 0x5, 0xc000798840)
	/home/mgritter/vault/vault/core_metrics.go:332 +0xd3
github.com/hashicorp/vault/vault.TestCoreMetrics_KvSecretGauge_BadPath(0xc000643e00)
	/home/mgritter/vault/vault/core_metrics_test.go:175 +0x478
testing.tRunner(0xc000643e00, 0x3190700)
	/usr/local/go/src/testing/testing.go:1108 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1159 +0x386
```