### PR TITLE
agent/auth/kerberos: add disable_fast_negotiation

### DIFF
--- a/command/agent/auth/kerberos/kerberos.go
+++ b/command/agent/auth/kerberos/kerberos.go
@@ -10,6 +10,7 @@ import (
 	kerberos "github.com/hashicorp/vault-plugin-auth-kerberos"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/agent/auth"
+	"github.com/hashicorp/vault/sdk/helper/parseutil"
 	"github.com/jcmturner/gokrb5/v8/spnego"
 )
 
@@ -46,15 +47,26 @@ func NewKerberosAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	disableFast := false
+	disableFastRaw, ok := conf.Config["disable_fast_negotiation"]
+	if ok {
+		disableFast, err = parseutil.ParseBool(disableFastRaw)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing 'disable_fast_negotiation': %s", err)
+		}
+	}
+
 	return &kerberosMethod{
 		logger:    conf.Logger,
 		mountPath: conf.MountPath,
 		loginCfg: &kerberos.LoginCfg{
-			Username:     username,
-			Service:      service,
-			Realm:        realm,
-			KeytabPath:   keytabPath,
-			Krb5ConfPath: krb5ConfPath,
+			Username:               username,
+			Service:                service,
+			Realm:                  realm,
+			KeytabPath:             keytabPath,
+			Krb5ConfPath:           krb5ConfPath,
+			DisableFASTNegotiation: disableFast,
 		},
 	}, nil
 }

--- a/command/agent/auth/kerberos/kerberos_test.go
+++ b/command/agent/auth/kerberos/kerberos_test.go
@@ -51,9 +51,8 @@ func TestNewKerberosAuthMethod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation != false {
-		t.Fatalf("disable_fast_negotation should be false, it wasn't: %t",
-			authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation)
+	if actual := authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation; actual != false {
+		t.Fatalf("disable_fast_negotation should be false, it wasn't: %t", actual)
 	}
 
 	authConfig.Config["disable_fast_negotiation"] = "true"

--- a/command/agent/auth/kerberos/kerberos_test.go
+++ b/command/agent/auth/kerberos/kerberos_test.go
@@ -51,7 +51,8 @@ func TestNewKerberosAuthMethod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if actual := authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation; actual != false {
+	// False by default
+	if actual := authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation; actual {
 		t.Fatalf("disable_fast_negotation should be false, it wasn't: %t", actual)
 	}
 
@@ -61,9 +62,9 @@ func TestNewKerberosAuthMethod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation != true {
-		t.Fatalf("disable_fast_negotation should be true, it wasn't: %t",
-			authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation)
+	// True from override
+	if actual := authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation; !actual {
+		t.Fatalf("disable_fast_negotation should be true, it wasn't: %t", actual)
 	}
 }
 

--- a/command/agent/auth/kerberos/kerberos_test.go
+++ b/command/agent/auth/kerberos/kerberos_test.go
@@ -46,8 +46,30 @@ func TestNewKerberosAuthMethod(t *testing.T) {
 	}
 
 	authConfig = simpleAuthConfig()
+	delete(authConfig.Config, "disable_fast_negotiation")
 	if _, err := NewKerberosAuthMethod(authConfig); err != nil {
+		t.Fatal("err shouldn't be returned for missing disable_fast_negotiation")
+	}
+
+	authConfig = simpleAuthConfig()
+	authMethod, err := NewKerberosAuthMethod(authConfig)
+	if err != nil {
 		t.Fatal(err)
+	}
+
+	if authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation != true {
+		t.Fatalf("disable_fast_negotation should be true, it wasn't: %t",
+			authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation)
+	}
+
+	delete(authConfig.Config, "disable_fast_negotiation")
+	authMethod, err = NewKerberosAuthMethod(authConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation != false {
+		t.Fatalf("disable_fast_negotation should be false, it wasn't: %t", authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation)
 	}
 }
 
@@ -57,11 +79,12 @@ func simpleAuthConfig() *auth.AuthConfig {
 		MountPath: "kerberos",
 		WrapTTL:   20,
 		Config: map[string]interface{}{
-			"username":      "grace",
-			"service":       "HTTP/05a65fad28ef.matrix.lan:8200",
-			"realm":         "MATRIX.LAN",
-			"keytab_path":   "grace.keytab",
-			"krb5conf_path": "krb5.conf",
+			"username":                 "grace",
+			"service":                  "HTTP/05a65fad28ef.matrix.lan:8200",
+			"realm":                    "MATRIX.LAN",
+			"keytab_path":              "grace.keytab",
+			"krb5conf_path":            "krb5.conf",
+			"disable_fast_negotiation": "true",
 		},
 	}
 }

--- a/command/agent/auth/kerberos/kerberos_test.go
+++ b/command/agent/auth/kerberos/kerberos_test.go
@@ -46,13 +46,18 @@ func TestNewKerberosAuthMethod(t *testing.T) {
 	}
 
 	authConfig = simpleAuthConfig()
-	delete(authConfig.Config, "disable_fast_negotiation")
-	if _, err := NewKerberosAuthMethod(authConfig); err != nil {
-		t.Fatal("err shouldn't be returned for missing disable_fast_negotiation")
+	authMethod, err := NewKerberosAuthMethod(authConfig)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	authConfig = simpleAuthConfig()
-	authMethod, err := NewKerberosAuthMethod(authConfig)
+	if authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation != false {
+		t.Fatalf("disable_fast_negotation should be false, it wasn't: %t",
+			authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation)
+	}
+
+	authConfig.Config["disable_fast_negotiation"] = "true"
+	authMethod, err = NewKerberosAuthMethod(authConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,16 +65,6 @@ func TestNewKerberosAuthMethod(t *testing.T) {
 	if authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation != true {
 		t.Fatalf("disable_fast_negotation should be true, it wasn't: %t",
 			authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation)
-	}
-
-	delete(authConfig.Config, "disable_fast_negotiation")
-	authMethod, err = NewKerberosAuthMethod(authConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation != false {
-		t.Fatalf("disable_fast_negotation should be false, it wasn't: %t", authMethod.(*kerberosMethod).loginCfg.DisableFASTNegotiation)
 	}
 }
 
@@ -79,12 +74,11 @@ func simpleAuthConfig() *auth.AuthConfig {
 		MountPath: "kerberos",
 		WrapTTL:   20,
 		Config: map[string]interface{}{
-			"username":                 "grace",
-			"service":                  "HTTP/05a65fad28ef.matrix.lan:8200",
-			"realm":                    "MATRIX.LAN",
-			"keytab_path":              "grace.keytab",
-			"krb5conf_path":            "krb5.conf",
-			"disable_fast_negotiation": "true",
+			"username":      "grace",
+			"service":       "HTTP/05a65fad28ef.matrix.lan:8200",
+			"realm":         "MATRIX.LAN",
+			"keytab_path":   "grace.keytab",
+			"krb5conf_path": "krb5.conf",
 		},
 	}
 }


### PR DESCRIPTION
A documented parameter `disable_fast_negotiation` wasn't being configured on the Kerberos auth-method, resulting in the boolean always being false.  This adds proper support to override the value.

Fixes https://github.com/hashicorp/vault/issues/9567