### PR TITLE
docs: add required/optional to kerberos autoauth config

### DIFF
--- a/website/pages/docs/agent/autoauth/methods/kerberos.mdx
+++ b/website/pages/docs/agent/autoauth/methods/kerberos.mdx
@@ -33,4 +33,4 @@ configured on the LDAP connection. This check is case-sensitive.
 of using FAST negotiation. FAST is a pre-authentication framework for Kerberos.
 It includes a mechanism for tunneling pre-authentication exchanges using armoured
 KDC messages. FAST provides increased resistance to passive password guessing attacks.
-Some common Kerberos implementations do not support FAST negotiation.  The default is false.
+Some common Kerberos implementations do not support FAST negotiation. The default is false.

--- a/website/pages/docs/agent/autoauth/methods/kerberos.mdx
+++ b/website/pages/docs/agent/autoauth/methods/kerberos.mdx
@@ -18,19 +18,19 @@ For more on this auth method, see the [Kerberos auth method](/docs/auth/kerberos
 
 ## Configuration
 
-- `krb5conf_path` is the path to a valid `krb5.conf` file describing how to
+- `krb5conf_path` `(string: required)` is the path to a valid `krb5.conf` file describing how to
 communicate with the Kerberos environment.
-- `keytab_path` is the path to the `keytab` in which the entry lives for the
+- `keytab_path` `(string: required)` is the path to the `keytab` in which the entry lives for the
 entity authenticating to Vault. Keytab files should be protected from other
 users on a shared server using appropriate file permissions.
-- `username` is the username for the entry _within_ the `keytab` to use for
+- `username` `(string: required)` is the username for the entry _within_ the `keytab` to use for
 logging into Kerberos. This username must match a service account in LDAP.
-- `service` is the service principal name to use in obtaining a service ticket for
+- `service` `(string: required)` is the service principal name to use in obtaining a service ticket for
 gaining a SPNEGO token. This service must exist in LDAP.
-- `realm` is the name of the Kerberos realm. This realm must match the UPNDomain
+- `realm` `(string: required)` is the name of the Kerberos realm. This realm must match the UPNDomain
 configured on the LDAP connection. This check is case-sensitive.
-- `disable_fast_negotiation` is for disabling the Kerberos auth method's default
+- `disable_fast_negotiation` `(bool: optional)` is for disabling the Kerberos auth method's default
 of using FAST negotiation. FAST is a pre-authentication framework for Kerberos.
 It includes a mechanism for tunneling pre-authentication exchanges using armoured
 KDC messages. FAST provides increased resistance to passive password guessing attacks.
-Some common Kerberos implementations do not support FAST negotiation.
+Some common Kerberos implementations do not support FAST negotiation.  The default is false.


### PR DESCRIPTION
This adds required/optional and types to the Kerberos auto-auth configuration documentation which is currently missing.