### PR TITLE
Delete unused parameter in token role docs

### DIFF
--- a/website/pages/api-docs/auth/token/index.mdx
+++ b/website/pages/api-docs/auth/token/index.mdx
@@ -717,7 +717,6 @@ tokens created against a role to be revoked using the
   "allowed_policies": [
     "dev"
   ],
-  "name": "nomad",
   "orphan": false,
   "bound_cidrs": ["127.0.0.1/32", "128.252.0.0/16"],
   "renewable": true,


### PR DESCRIPTION
Update website/pages/api-docs/auth/token/index.mdx
The ```name``` parameter is useless