### PR TITLE
Fix is-wildcard-string helper to check for classes

### DIFF
--- a/ui/app/helpers/is-wildcard-string.js
+++ b/ui/app/helpers/is-wildcard-string.js
@@ -6,7 +6,11 @@ export function isWildcardString([string]) {
   }
   // string is actually an object which is what comes in in the searchSelect component
   if (typeof string === 'object') {
-    string = Object.values(string)[0];
+    // if the dropdown is used the object is a class which cannot be converted into a string
+    if (Object.prototype.hasOwnProperty.call(string, 'store')) {
+      return false;
+    }
+    string = Object.values(string).toString();
   }
 
   return string.includes('*');

--- a/ui/tests/unit/helpers/is-wildcard-string-test.js
+++ b/ui/tests/unit/helpers/is-wildcard-string-test.js
@@ -26,8 +26,14 @@ module('Unit | Helpers | is-wildcard-string', function() {
     assert.equal(result, true);
   });
 
-  test('it returns true if string object has name and id with with at least one wildcard', function(assert) {
+  test('it returns true if string object has name and id with at least one wildcard', function(assert) {
     let string = { id: '7*', name: 'seven' };
+    let result = isWildcardString([string]);
+    assert.equal(result, true);
+  });
+
+  test('it returns true if string object has name and id with wildcard in name not id', function(assert) {
+    let string = { id: '7', name: 'sev*n' };
     let result = isWildcardString([string]);
     assert.equal(result, true);
   });


### PR DESCRIPTION
The wildcard helper was being used on both typed inputs and a select dropdown. The later returned a class that was causing it to error.  It now checks for the class object and returns false in that situation.  The test has also been updated.