### PR TITLE
Disable file backend on TestSealMigration_ShamirToTransit_Post14

### DIFF
--- a/vault/external_tests/sealmigration/seal_migration_test.go
+++ b/vault/external_tests/sealmigration/seal_migration_test.go
@@ -52,6 +52,7 @@ func testVariousBackends(t *testing.T, tf testFunc, basePort int, includeRaft bo
 
 	t.Run("file", func(t *testing.T) {
 		t.Parallel()
+		t.Skip("fails intermittently")
 
 		logger := logger.Named("file")
 		storage, cleanup := teststorage.MakeReusableStorage(


### PR DESCRIPTION
Intermittently failing:

https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/429/workflows/93be0605-3ee7-4ea4-a938-eede03aa94fe/jobs/9451

https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/522/workflows/0356c64e-b9ef-44ae-af2c-af8e7161dca0/jobs/11510

I can't see a good way for only catching _Post14, so disabling the file backend for all tests using the same code.

The failing line is:
```
    seal_migration_test.go:291: unseal core 0 err: Vault is not initialized
```

