### PR TITLE
Add disable_mlock env support

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -801,7 +801,6 @@ type quiescenceSink struct {
 	t *time.Timer
 }
 
-
 func (q quiescenceSink) Accept(name string, level log.Level, msg string, args ...interface{}) {
 	q.t.Reset(100 * time.Millisecond)
 }
@@ -943,6 +942,15 @@ func (c *ServerCommand) Run(args []string) int {
 	}
 
 	logProxyEnvironmentVariables(c.logger)
+
+	if envMlock := os.Getenv("VAULT_DISABLE_MLOCK"); envMlock != "" {
+		var err error
+		config.DisableMlock, err = strconv.ParseBool(envMlock)
+		if err != nil {
+			c.UI.Output("Error parsing the environment variable VAULT_DISABLE_MLOCK")
+			return 1
+		}
+	}
 
 	// If mlockall(2) isn't supported, show a warning. We disable this in dev
 	// because it is quite scary to see when first using Vault. We also disable


### PR DESCRIPTION
This adds environment variable support for setting `disable_mlock`.  Having environment variable support is useful for Kubernetes where Kubelet requires swap to be disabled, so mlock isn't explicitly needed.  We can set this environment variable on the Vault pod and have one less setting in the config.

IDE removed an extra newline as well.