### PR TITLE
Ui/transform info table row roles

### DIFF
--- a/ui/app/components/transform-role-edit.js
+++ b/ui/app/components/transform-role-edit.js
@@ -95,7 +95,7 @@ export default TransformBase.extend({
         const newModelTransformations = this.get('model.transformations');
 
         if (!this.initialTransformations) {
-          this.handleUpdatedTransformations(
+          this.handleUpdateTransformations(
             newModelTransformations.map(t => ({
               id: t,
               action: 'ADD',

--- a/ui/app/helpers/is-wildcard-string.js
+++ b/ui/app/helpers/is-wildcard-string.js
@@ -1,6 +1,6 @@
 import { helper as buildHelper } from '@ember/component/helper';
 
-export function isWildcardString([string]) {
+export function isWildcardString(string) {
   if (!string) {
     return false;
   }

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -59,7 +59,7 @@ Router.map(function() {
           this.route('index', { path: '/' });
           // lookup prefix
           // revoke prefix + revoke force
-          this.route('list-root', { path: '/list/' });
+          this.route('list-root', { path: '/list/:specific_tab' });
           this.route('list', { path: '/list/*prefix' });
           //renew + revoke
           this.route('show', { path: '/show/*lease_id' });

--- a/ui/app/router.js
+++ b/ui/app/router.js
@@ -59,7 +59,7 @@ Router.map(function() {
           this.route('index', { path: '/' });
           // lookup prefix
           // revoke prefix + revoke force
-          this.route('list-root', { path: '/list/:specific_tab' });
+          this.route('list-root', { path: '/list/' });
           this.route('list', { path: '/list/*prefix' });
           //renew + revoke
           this.route('show', { path: '/show/*lease_id' });

--- a/ui/app/styles/components/info-table-row.scss
+++ b/ui/app/styles/components/info-table-row.scss
@@ -42,6 +42,10 @@
   .icon-false {
     color: $ui-gray-300;
   }
+
+  a {
+    text-decoration: none;
+  }
 }
 
 .info-table-row:not(.is-mobile) .column {

--- a/ui/app/templates/components/transform-role-edit.hbs
+++ b/ui/app/templates/components/transform-role-edit.hbs
@@ -92,6 +92,14 @@
   {{#each model.attrs as |attr|}}
     {{#if (eq attr.type "object")}}
       {{info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=(stringify (get model attr.name))}}
+    {{else if (eq attr.type "array")}}
+      {{info-table-row
+        label=(capitalize (or attr.options.label (humanize (dasherize attr.name))))
+        value=(get model attr.name)
+        type=attr.type
+        isLink=(eq attr.name 'transformations')
+        viewAll="transformations"
+      }}
     {{else}}
       {{info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=(get model attr.name)}}
     {{/if}}

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -8,7 +8,7 @@
         value=(get model attr.name)
         type=attr.type
         isLink=(eq attr.name 'allowed_roles')
-        queryParam="role/"
+        queryParam="role"
         modelType="transform/role"
         wildcardLabel=attr.options.wildcardLabel
         viewAll="roles"

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -2,14 +2,22 @@
   {{#each model.transformFieldAttrs as |attr|}}
     {{#if (eq attr.type "object")}}
       {{info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=(stringify (get model attr.name))}}
-    {{else}}
+    {{else if (eq attr.type "array")}}
       {{info-table-row
         label=(capitalize (or attr.options.label (humanize (dasherize attr.name))))
         value=(get model attr.name)
         type=attr.type
         isLink=(eq attr.name 'allowed_roles')
+        queryParam="role/"
         modelType="transform/role"
         wildcardLabel=attr.options.wildcardLabel
+        viewAll="roles"
+      }}
+    {{else}}
+      {{info-table-row
+        label=(capitalize (or attr.options.label (humanize (dasherize attr.name))))
+        value=(get model attr.name)
+        type=attr.type
       }}
     {{/if}}
   {{/each}}

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -3,7 +3,14 @@
     {{#if (eq attr.type "object")}}
       {{info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=(stringify (get model attr.name))}}
     {{else}}
-      {{info-table-row label=(capitalize (or attr.options.label (humanize (dasherize attr.name)))) value=(get model attr.name) type=attr.type}}
+      {{info-table-row
+        label=(capitalize (or attr.options.label (humanize (dasherize attr.name))))
+        value=(get model attr.name)
+        type=attr.type
+        isLink=(eq attr.name 'allowed_roles')
+        modelType="transform/role"
+        wildcardLabel=attr.options.wildcardLabel
+      }}
     {{/if}}
   {{/each}}
 </div>

--- a/ui/app/templates/components/transform-show-transformation.hbs
+++ b/ui/app/templates/components/transform-show-transformation.hbs
@@ -12,6 +12,7 @@
         modelType="transform/role"
         wildcardLabel=attr.options.wildcardLabel
         viewAll="roles"
+        backend=model.backend
       }}
     {{else}}
       {{info-table-row

--- a/ui/lib/core/addon/components/info-table-item-array.js
+++ b/ui/lib/core/addon/components/info-table-item-array.js
@@ -15,24 +15,26 @@ import { isWildcardString } from 'vault/helpers/is-wildcard-string';
  *
  * @example
  * ```js
- * <InfoTableItemArray @displayArray={{['test-1','test-2','test-3']}} @isLink={{true}} @modelType="transform/role"/ @queryParam="role/">
+ * <InfoTableItemArray @displayArray={{['test-1','test-2','test-3']}} @isLink={{true}} @modelType="transform/role"/ @queryParam="role" @backend="transform" viewAll="roles">
  * ```
  *
  * @param displayArray=null {array} - This array of data to be displayed.  If there are more than 10 items in the array only five will show and a count of the other number in the array will show.
  * @param [isLink=true] {Boolean} - Indicates if the item should contain a link-to component.  Only setup for arrays, but this could be changed if needed.
  * @param [modelType=null] {string} - Tells what model you want data for the allOptions to be returned from.  Used in conjunction with the the isLink.
  * @param [wildcardLabel] {String} - when you want the component to return a count on the model for options returned when using a wildcard you must provide a label of the count e.g. role.  Should be singular.
- * @param [queryParam] {String} - If you want to specific a tab for the View All XX to display to.  Ex: role/
+ * @param [queryParam] {String} - If you want to specific a tab for the View All XX to display to.  Ex: role
+ * @param [backend] {String} - To specify which backend to point the link to.
+ * @param [viewAll] {String} - Specify the word at the end of the link View all xx.
  */
 export default Component.extend({
   layout,
+  'data-test-info-table-item-array': true,
   allOptions: null,
   displayArray: null,
   wildcardInDisplayArray: false,
   store: service(),
   displayArrayAmended: computed('displayArray', function() {
     let { displayArray } = this;
-    // cut down array to length 5 if more than 10 items
     if (displayArray.length >= 10) {
       // if array greater than 10 in length only display the first 5
       displayArray = displayArray.slice(0, 5);
@@ -49,13 +51,11 @@ export default Component.extend({
   fetchOptions: task(function*() {
     if (this.isLink && this.modelType) {
       let queryOptions = {};
-      let backendModel = yield this.store.peekAll('secret-engine');
-      let array = backendModel.toArray().map(option => {
-        return option.id;
-      });
-      if (array) {
-        queryOptions = { backend: array.get('firstObject') };
+
+      if (this.backend) {
+        queryOptions = { backend: this.backend };
       }
+
       let options = yield this.store.query(this.modelType, queryOptions);
       this.formatOptions(options);
     }

--- a/ui/lib/core/addon/components/info-table-item-array.js
+++ b/ui/lib/core/addon/components/info-table-item-array.js
@@ -3,41 +3,61 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import layout from '../templates/components/info-table-item-array';
+import { isWildcardString } from 'vault/helpers/is-wildcard-string';
 
 /**
  * @module InfoTableItemArray
- * `InfoTableItemArray` //
+ * The `InfoTableItemArray` component handles arrays in the info-table-row component.
+ * If an array has more than 10 items, then only 5 are displayed and a count of total items is displayed next to the five.
+ * If a isLink is true than a link can be set for the use to click on the specific array item
+ * If a wildcard is a potential variable in the string of an item, then you can use the modelType and wildcardLabel parameters to
+ * return a wildcard count similar to what is done in the searchSelect component.
  *
  * @example
  * ```js
- * <InfoTableItemArray @value={{['test-1','test-2','test-3']}} @isLink={{true}} @modelType="transform/role"/>
+ * <InfoTableItemArray @displayArray={{['test-1','test-2','test-3']}} @isLink={{true}} @modelType="transform/role"/ @queryParam="role/">
  * ```
  *
- * @param value=null {array} - This array of data to be displayed.  If there are more than 10 items in the array only five will show and a count of the other number in the array will show.
+ * @param displayArray=null {array} - This array of data to be displayed.  If there are more than 10 items in the array only five will show and a count of the other number in the array will show.
  * @param [isLink=true] {Boolean} - Indicates if the item should contain a link-to component.  Only setup for arrays, but this could be changed if needed.
  * @param [modelType=null] {string} - Tells what model you want data for the allOptions to be returned from.  Used in conjunction with the the isLink.
+ * @param [wildcardLabel] {String} - when you want the component to return a count on the model for options returned when using a wildcard you must provide a label of the count e.g. role.  Should be singular.
+ * @param [queryParam] {String} - If you want to specific a tab for the View All XX to display to.  Ex: role/
  */
 export default Component.extend({
   layout,
   allOptions: null,
-  value: null,
+  displayArray: null,
+  wildcardInDisplayArray: false,
   store: service(),
+  displayArrayAmended: computed('displayArray', function() {
+    let { displayArray } = this;
+    // cut down array to length 5 if more than 10 items
+    if (displayArray.length >= 10) {
+      // if array greater than 10 in length only display the first 5
+      displayArray = displayArray.slice(0, 5);
+    }
+
+    return displayArray;
+  }),
+
+  checkWildcardInArray: task(function*() {
+    let filteredArray = yield this.displayArray.filter(item => isWildcardString(item));
+    this.set('wildcardInDisplayArray', filteredArray.length > 0 ? true : false);
+  }).on('didInsertElement'),
+
   fetchOptions: task(function*() {
     if (this.isLink && this.modelType) {
-      try {
-        let queryOptions = {};
-        let backendModel = yield this.store.peekAll('secret-engine');
-        let array = backendModel.toArray().map(option => {
-          return option.id;
-        });
-        if (array) {
-          queryOptions = { backend: array.get('firstObject') };
-        }
-        let options = yield this.store.query(this.modelType, queryOptions);
-        this.formatOptions(options);
-      } catch (err) {
-        throw err;
+      let queryOptions = {};
+      let backendModel = yield this.store.peekAll('secret-engine');
+      let array = backendModel.toArray().map(option => {
+        return option.id;
+      });
+      if (array) {
+        queryOptions = { backend: array.get('firstObject') };
       }
+      let options = yield this.store.query(this.modelType, queryOptions);
+      this.formatOptions(options);
     }
   }).on('didInsertElement'),
 

--- a/ui/lib/core/addon/components/info-table-item-array.js
+++ b/ui/lib/core/addon/components/info-table-item-array.js
@@ -1,0 +1,50 @@
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { task } from 'ember-concurrency';
+import layout from '../templates/components/info-table-item-array';
+
+/**
+ * @module InfoTableItemArray
+ * `InfoTableItemArray` //
+ *
+ * @example
+ * ```js
+ * <InfoTableItemArray @value={{['test-1','test-2','test-3']}} @isLink={{true}} @modelType="transform/role"/>
+ * ```
+ *
+ * @param value=null {array} - This array of data to be displayed.  If there are more than 10 items in the array only five will show and a count of the other number in the array will show.
+ * @param [isLink=true] {Boolean} - Indicates if the item should contain a link-to component.  Only setup for arrays, but this could be changed if needed.
+ * @param [modelType=null] {string} - Tells what model you want data for the allOptions to be returned from.  Used in conjunction with the the isLink.
+ */
+export default Component.extend({
+  layout,
+  allOptions: null,
+  value: null,
+  store: service(),
+  fetchOptions: task(function*() {
+    if (this.isLink && this.modelType) {
+      try {
+        let queryOptions = {};
+        let backendModel = yield this.store.peekAll('secret-engine');
+        let array = backendModel.toArray().map(option => {
+          return option.id;
+        });
+        if (array) {
+          queryOptions = { backend: array.get('firstObject') };
+        }
+        let options = yield this.store.query(this.modelType, queryOptions);
+        this.formatOptions(options);
+      } catch (err) {
+        throw err;
+      }
+    }
+  }).on('didInsertElement'),
+
+  formatOptions: function(options) {
+    let allOptions = options.toArray().map(option => {
+      return option.id;
+    });
+    this.set('allOptions', allOptions);
+  },
+});

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -19,6 +19,8 @@ import layout from '../templates/components/info-table-row';
  * @param helperText=null {string} - Text to describe the value displayed beneath the label.
  * @param alwaysRender=false {Boolean} - Indicates if the component content should be always be rendered.  When false, the value of `value` will be used to determine if the component should render.
  * @param [type=array] {string} - The type of value being passed in.  This is used for when you want to trim an array.  For example, if you have an array value that can equal length 15+ this will trim to show 5 and count how many more are there
+ * @param [isLink=true] {Boolean} - Indicates if the item should contain a link-to component.  Only setup for arrays, but this could be changed if needed.
+ * @param [modelType=null] {string} - Tells what model you want data for the allOptions to be returned from.  Used in conjunction with the the isLink.
  */
 export default Component.extend({
   layout,

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -19,9 +19,11 @@ import layout from '../templates/components/info-table-row';
  * @param helperText=null {string} - Text to describe the value displayed beneath the label.
  * @param alwaysRender=false {Boolean} - Indicates if the component content should be always be rendered.  When false, the value of `value` will be used to determine if the component should render.
  * @param [type=array] {string} - The type of value being passed in.  This is used for when you want to trim an array.  For example, if you have an array value that can equal length 15+ this will trim to show 5 and count how many more are there
- * @param [isLink=true] {Boolean} - Indicates if the item should contain a link-to component.  Only setup for arrays, but this could be changed if needed.
- * @param [modelType=null] {string} - Tells what model you want data for the allOptions to be returned from.  Used in conjunction with the the isLink.
+ * @param [isLink=true] {Boolean} - Passed through to InfoTableItemArray. Indicates if the item should contain a link-to component.  Only setup for arrays, but this could be changed if needed.
+ * @param [modelType=null] {string} - Passed through to InfoTableItemArray. Tells what model you want data for the allOptions to be returned from.  Used in conjunction with the the isLink.
+ * @param [queryParam] {String} - Passed through to InfoTableItemArray. If you want to specific a tab for the View All XX to display to.  Ex: role/
  */
+
 export default Component.extend({
   layout,
   'data-test-component': 'info-table-row',

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -21,7 +21,9 @@ import layout from '../templates/components/info-table-row';
  * @param [type=array] {string} - The type of value being passed in.  This is used for when you want to trim an array.  For example, if you have an array value that can equal length 15+ this will trim to show 5 and count how many more are there
  * @param [isLink=true] {Boolean} - Passed through to InfoTableItemArray. Indicates if the item should contain a link-to component.  Only setup for arrays, but this could be changed if needed.
  * @param [modelType=null] {string} - Passed through to InfoTableItemArray. Tells what model you want data for the allOptions to be returned from.  Used in conjunction with the the isLink.
- * @param [queryParam] {String} - Passed through to InfoTableItemArray. If you want to specific a tab for the View All XX to display to.  Ex: role/
+ * @param [queryParam] {String} - Passed through to InfoTableItemArray. If you want to specific a tab for the View All XX to display to.  Ex: role
+ * @param [backend] {String} - Passed through to InfoTableItemArray. To specify secrets backend to point link to  Ex: transformation
+ * @param [viewAll] {String} - Passed through to InfoTableItemArray. Specify the word at the end of the link View all xx.
  */
 
 export default Component.extend({

--- a/ui/lib/core/addon/templates/components/info-table-item-array.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-item-array.hbs
@@ -1,21 +1,19 @@
-
 {{#if isLink}}
   {{#each displayArrayAmended as |name|}}
     {{#if (is-wildcard-string name)}}
       {{#let (filter-wildcard name allOptions) as | wildcardCount |}}
         <span>{{name}}</span>
-        <span class="tag is-light has-text-grey-dark" data-test-mode={{wildcardCount}}>
+        <span class="tag is-light has-text-grey-dark" data-test-count={{wildcardCount}}>
           includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
         </span>
         {{#if (eq displayArrayAmended.lastObject name)}}
           {{#link-to "vault.cluster.secrets.backend.list-root" (query-params tab=queryParam)}}
-            <span>View all {{viewAll}}</span>
+            <span data-test-view-all={{viewAll}}>View all {{viewAll}}</span>
           {{/link-to}}
         {{/if}}
       {{/let}}
     {{else}}
-      {{!-- Currently setup for roles only for the transform engine, this could be amended if a use case arises --}}
-      {{#link-to "vault.cluster.secrets.backend.show" (if queryParam (concat "role/" name) name)}}
+      {{#link-to "vault.cluster.secrets.backend.show" (if queryParam (concat queryParam "/" name) name)}}
         <span>{{name}}</span>
       {{/link-to}}
     {{/if}}
@@ -23,11 +21,11 @@
       ,&nbsp;
     {{/if}}
     {{#if (and (eq name displayArrayAmended.lastObject) (gte displayArray.length 10)) }}
-      &nbsp;and {{dec 5 displayArray.length}} others.&nbsp;
+      <span data-test-and={{dec 5 displayArray.length}}>&nbsp;and {{dec 5 displayArray.length}} others.&nbsp;</span>
     {{/if}}
     {{#if (and (eq name displayArrayAmended.lastObject) (gte displayArray.length 10)) }}
       {{#link-to "vault.cluster.secrets.backend.list-root" (query-params tab=queryParam)}}
-        <span>View all {{viewAll}} </span>
+        <span data-test-view-all={{viewAll}}>View all {{viewAll}} </span>
       {{/link-to}}
     {{/if}}
   {{/each}}

--- a/ui/lib/core/addon/templates/components/info-table-item-array.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-item-array.hbs
@@ -1,0 +1,32 @@
+{{#if isLink}}
+  {{#let (if (gte displayArray.length 10) (take 5 displayArray ) displayArray) as | amendedArray |}}
+    {{#each displayArray as |name|}}
+      {{#if (is-wildcard-string name)}}
+        {{#let (filter-wildcard name allOptions) as | wildcardCount |}}
+          <span>{{name}}</span>
+          <span class="tag is-light has-text-grey-dark" data-test-mode={{wildcardCount}}>
+            includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
+          </span>
+          {{#link-to "vault.cluster.secrets.backend.list-root" (query-params tab="role")}}
+            <span>View all roles</span>
+          {{/link-to}}
+        {{/let}}
+      {{else}}
+        {{!-- Currently setup for roles only for the transform engine, this could be amended if a use case arises --}}
+        {{#link-to "vault.cluster.secrets.backend.show" (concat "role/" name)}}
+          <span>{{name}}</span>
+        {{/link-to}}
+      {{/if}}
+      {{#if (not-eq name amendedArray.lastObject)}} ,&nbsp;{{/if}}
+      {{#if (and (eq name amendedArray.lastObject) (gte value.length 10))}}
+        &nbsp;and {{dec 5 value.length}} others.&nbsp;
+        {{#link-to "vault.cluster.secrets.backend.list-root" (query-params tab="role")}}
+          <span>View all roles</span>
+        {{/link-to}}
+      {{/if}}
+    {{/each}}
+  {{/let}}
+{{else}}
+  <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{if (gte displayArray.length 10) (concat (take 5 displayArray) ", and " (dec 5 displayArray.length) " more.") displayArray}}</code>
+{{/if}}
+

--- a/ui/lib/core/addon/templates/components/info-table-item-array.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-item-array.hbs
@@ -1,32 +1,37 @@
+
 {{#if isLink}}
-  {{#let (if (gte displayArray.length 10) (take 5 displayArray ) displayArray) as | amendedArray |}}
-    {{#each displayArray as |name|}}
-      {{#if (is-wildcard-string name)}}
-        {{#let (filter-wildcard name allOptions) as | wildcardCount |}}
-          <span>{{name}}</span>
-          <span class="tag is-light has-text-grey-dark" data-test-mode={{wildcardCount}}>
-            includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
-          </span>
-          {{#link-to "vault.cluster.secrets.backend.list-root" (query-params tab="role")}}
-            <span>View all roles</span>
+  {{#each displayArrayAmended as |name|}}
+    {{#if (is-wildcard-string name)}}
+      {{#let (filter-wildcard name allOptions) as | wildcardCount |}}
+        <span>{{name}}</span>
+        <span class="tag is-light has-text-grey-dark" data-test-mode={{wildcardCount}}>
+          includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
+        </span>
+        {{#if (eq displayArrayAmended.lastObject name)}}
+          {{#link-to "vault.cluster.secrets.backend.list-root" (query-params tab=queryParam)}}
+            <span>View all {{viewAll}}</span>
           {{/link-to}}
-        {{/let}}
-      {{else}}
-        {{!-- Currently setup for roles only for the transform engine, this could be amended if a use case arises --}}
-        {{#link-to "vault.cluster.secrets.backend.show" (concat "role/" name)}}
-          <span>{{name}}</span>
-        {{/link-to}}
-      {{/if}}
-      {{#if (not-eq name amendedArray.lastObject)}} ,&nbsp;{{/if}}
-      {{#if (and (eq name amendedArray.lastObject) (gte value.length 10))}}
-        &nbsp;and {{dec 5 value.length}} others.&nbsp;
-        {{#link-to "vault.cluster.secrets.backend.list-root" (query-params tab="role")}}
-          <span>View all roles</span>
-        {{/link-to}}
-      {{/if}}
-    {{/each}}
-  {{/let}}
+        {{/if}}
+      {{/let}}
+    {{else}}
+      {{!-- Currently setup for roles only for the transform engine, this could be amended if a use case arises --}}
+      {{#link-to "vault.cluster.secrets.backend.show" (if queryParam (concat "role/" name) name)}}
+        <span>{{name}}</span>
+      {{/link-to}}
+    {{/if}}
+    {{#if (or (and (not-eq name displayArrayAmended.lastObject) wildcardInDisplayArray) (not-eq name displayArrayAmended.lastObject))}}
+      ,&nbsp;
+    {{/if}}
+    {{#if (and (eq name displayArrayAmended.lastObject) (gte displayArray.length 10)) }}
+      &nbsp;and {{dec 5 displayArray.length}} others.&nbsp;
+    {{/if}}
+    {{#if (and (eq name displayArrayAmended.lastObject) (gte displayArray.length 10)) }}
+      {{#link-to "vault.cluster.secrets.backend.list-root" (query-params tab=queryParam)}}
+        <span>View all {{viewAll}} </span>
+      {{/link-to}}
+    {{/if}}
+  {{/each}}
 {{else}}
-  <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{if (gte displayArray.length 10) (concat (take 5 displayArray) ", and " (dec 5 displayArray.length) " more.") displayArray}}</code>
+  <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{if (gte displayArray.length 10) (concat displayArray ", and " (dec 5 displayArray.length) " more.") displayArray}}</code>
 {{/if}}
 

--- a/ui/lib/core/addon/templates/components/info-table-item-array.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-item-array.hbs
@@ -4,7 +4,7 @@
       {{#let (filter-wildcard name allOptions) as | wildcardCount |}}
         <span>{{name}}</span>
         <span class="tag is-light has-text-grey-dark" data-test-count={{wildcardCount}}>
-          includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
+          includes {{if wildcardCount wildcardCount 0}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
         </span>
         {{#if (eq displayArrayAmended.lastObject name)}}
           {{#link-to "vault.cluster.secrets.backend.list-root" (query-params tab=queryParam)}}

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -30,11 +30,15 @@
       {{/if}}
     {{else}}
       {{#if (eq type 'array')}}
-      <InfoTableItemArray 
-        @isLink={{isLink}}
-        @modelType={{modelType}}
-        @displayArray={{value}}
-      />
+        <InfoTableItemArray 
+          @label={{label}}
+          @isLink={{isLink}}
+          @modelType={{modelType}}
+          @displayArray={{value}}
+          @wildcardLabel={{wildcardLabel}}
+          @queryParam={{queryParam}}
+          @viewAll={{viewAll}}
+        />
       {{else}}
         <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{value}}</code>
       {{/if}}

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -30,7 +30,11 @@
       {{/if}}
     {{else}}
       {{#if (eq type 'array')}}
-        <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{if (gte value.length 10) (concat (take 5 value) ", and " (dec 5 value.length) " more.") value}}</code>
+      <InfoTableItemArray 
+        @isLink={{isLink}}
+        @modelType={{modelType}}
+        @displayArray={{value}}
+      />
       {{else}}
         <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{value}}</code>
       {{/if}}

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -30,14 +30,15 @@
       {{/if}}
     {{else}}
       {{#if (eq type 'array')}}
-        <InfoTableItemArray 
-          @label={{label}}
-          @isLink={{isLink}}
-          @modelType={{modelType}}
+        <InfoTableItemArray
+          @backend={{backend}}
           @displayArray={{value}}
-          @wildcardLabel={{wildcardLabel}}
+          @isLink={{isLink}}
+          @label={{label}}
+          @modelType={{modelType}}
           @queryParam={{queryParam}}
           @viewAll={{viewAll}}
+          @wildcardLabel={{wildcardLabel}}
         />
       {{else}}
         <code class="is-word-break has-text-black" data-test-row-value="{{label}}">{{value}}</code>

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -53,7 +53,7 @@
         {{else}}
           <div>{{selected.id}}
           {{#if wildcardLabel}}
-            {{#if (is-wildcard-string selected)}}
+            {{#if (is-wildcard-string selected.id)}}
               {{#let (filter-wildcard selected allOptions) as | wildcardCount |}}
                 <span class="tag is-light has-text-grey-dark" data-test-mode={{wildcardCount}}>
                   includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -56,7 +56,7 @@
             {{#if (is-wildcard-string selected.id)}}
               {{#let (filter-wildcard selected allOptions) as | wildcardCount |}}
                 <span class="tag is-light has-text-grey-dark" data-test-count={{wildcardCount}}>
-                  includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
+                  includes {{if wildcardCount wildcardCount 0}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
                 </span>
               {{/let}}
             {{/if}}

--- a/ui/lib/core/addon/templates/components/search-select.hbs
+++ b/ui/lib/core/addon/templates/components/search-select.hbs
@@ -55,7 +55,7 @@
           {{#if wildcardLabel}}
             {{#if (is-wildcard-string selected.id)}}
               {{#let (filter-wildcard selected allOptions) as | wildcardCount |}}
-                <span class="tag is-light has-text-grey-dark" data-test-mode={{wildcardCount}}>
+                <span class="tag is-light has-text-grey-dark" data-test-count={{wildcardCount}}>
                   includes {{wildcardCount}} {{if (eq wildcardCount 1) wildcardLabel (pluralize wildcardLabel)}}
                 </span>
               {{/let}}

--- a/ui/lib/core/app/components/info-table-item-array.js
+++ b/ui/lib/core/app/components/info-table-item-array.js
@@ -1,0 +1,1 @@
+export { default } from 'core/components/info-table-item-array';

--- a/ui/tests/integration/components/info-table-item-array-test.js
+++ b/ui/tests/integration/components/info-table-item-array-test.js
@@ -1,0 +1,127 @@
+import { module, test } from 'qunit';
+import Service from '@ember/service';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { run } from '@ember/runloop';
+import hbs from 'htmlbars-inline-precompile';
+
+const DISPLAY_ARRAY = ['role-1', 'role-2', 'role-3', 'role-4', 'role-5'];
+
+const storeService = Service.extend({
+  query() {
+    return new Promise(resolve => {
+      resolve([
+        { id: 'role-1' },
+        { id: 'role-2' },
+        { id: 'role-3' },
+        { id: 'role-4' },
+        { id: 'role-5' },
+        { id: 'role-6' },
+      ]);
+    });
+  },
+});
+
+module('Integration | Component | InfoTableItemArray', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.set('displayArray', DISPLAY_ARRAY);
+    this.set('isLink', true);
+    this.set('modelType', 'transform/role');
+    this.set('queryParam', 'role');
+    this.set('backend', 'transform');
+    this.set('wildcardLabel', 'role');
+    this.set('viewAll', 'roles');
+    run(() => {
+      this.owner.unregister('service:store');
+      this.owner.register('service:store', storeService);
+    });
+  });
+
+  hooks.afterEach(function() {
+    this.owner.unregister('service:store');
+  });
+
+  test('it renders', async function(assert) {
+    await render(hbs`<InfoTableItemArray
+        @displayArray={{displayArray}}
+      />`);
+
+    assert.dom('[data-test-info-table-item-array]').exists();
+    let noLinkString = document.querySelector('code').textContent;
+
+    assert.equal(
+      noLinkString.length,
+      DISPLAY_ARRAY.toString().length,
+      'renders a string of the array if isLink is not provided'
+    );
+  });
+
+  test('it renders links if isLink is true', async function(assert) {
+    await render(hbs`<InfoTableItemArray
+      @displayArray={{displayArray}}
+      @isLink={{isLink}}
+      @modelType={{modelType}}
+      @queryParam={{queryParam}}
+      @backend={{backend}}
+    />`);
+    assert.equal(
+      document.querySelectorAll('a > span').length,
+      DISPLAY_ARRAY.length,
+      'renders each item in array with link'
+    );
+  });
+
+  test('it renders a badge and view all if wildcard in display array && < 10', async function(assert) {
+    const displayArrayWithWildcard = ['role-1', 'role-2', 'role-3', 'r*'];
+    this.set('displayArrayWithWildcard', displayArrayWithWildcard);
+    await render(hbs`<InfoTableItemArray
+      @displayArray={{displayArrayWithWildcard}}
+      @isLink={{isLink}}
+      @modelType={{modelType}}
+      @queryParam={{queryParam}}
+      @backend={{backend}}
+      @viewAll={{viewAll}}
+    />`);
+
+    assert.equal(
+      document.querySelectorAll('a > span').length,
+      DISPLAY_ARRAY.length - 1,
+      'renders each item in array with link'
+    );
+    // 6 here comes from the six roles setup in the store service.
+    assert.dom('[data-test-count="6"]').exists('correctly counts with wildcard filter and shows the count');
+    assert.dom('[data-test-view-all="roles"]').exists({ count: 1 }, 'renders 1 view all roles');
+  });
+
+  test('it renders a badge and view all if wildcard in display array && >= 10', async function(assert) {
+    const displayArrayWithWildcard = [
+      'role-1',
+      'role-2',
+      'role-3',
+      'r*',
+      'role-4',
+      'role-5',
+      'role-6',
+      'role-7',
+      'role-8',
+      'role-9',
+      'role-10',
+    ];
+    this.set('displayArrayWithWildcard', displayArrayWithWildcard);
+    await render(hbs`<InfoTableItemArray
+      @displayArray={{displayArrayWithWildcard}}
+      @isLink={{isLink}}
+      @modelType={{modelType}}
+      @queryParam={{queryParam}}
+      @backend={{backend}}
+      @viewAll={{viewAll}}
+    />`);
+    const numberCutOffTruncatedArray = displayArrayWithWildcard.length - 5;
+    assert.equal(document.querySelectorAll('a > span').length, 5, 'renders truncated array of five');
+    assert
+      .dom(`[data-test-and="${numberCutOffTruncatedArray}"]`)
+      .exists('correctly counts with wildcard filter and shows the count');
+  });
+});

--- a/ui/tests/integration/components/search-select-test.js
+++ b/ui/tests/integration/components/search-select-test.js
@@ -104,7 +104,7 @@ module('Integration | Component | search select', function(hooks) {
     await clickTrigger();
     await typeInSearch('*bar*');
     await component.selectOption();
-    assert.dom('[data-test-mode="2"]').exists('correctly counts with wildcard filter and shows the count');
+    assert.dom('[data-test-count="2"]').exists('correctly counts with wildcard filter and shows the count');
   });
 
   test('it behaves correctly if new items not allowed', async function(assert) {

--- a/ui/tests/unit/helpers/is-wildcard-string-test.js
+++ b/ui/tests/unit/helpers/is-wildcard-string-test.js
@@ -4,37 +4,37 @@ import { module, test } from 'qunit';
 module('Unit | Helpers | is-wildcard-string', function() {
   test('it returns true if regular string with wildcard', function(assert) {
     let string = 'foom#*eep';
-    let result = isWildcardString([string]);
+    let result = isWildcardString(string);
     assert.equal(result, true);
   });
 
   test('it returns false if no wildcard', function(assert) {
     let string = 'foo.bar';
-    let result = isWildcardString([string]);
+    let result = isWildcardString(string);
     assert.equal(result, false);
   });
 
   test('it returns true if string with id as in searchSelect selected has wildcard', function(assert) {
     let string = { id: 'foo.bar*baz' };
-    let result = isWildcardString([string]);
+    let result = isWildcardString(string);
     assert.equal(result, true);
   });
 
   test('it returns true if string object has name and no id', function(assert) {
     let string = { name: 'foo.bar*baz' };
-    let result = isWildcardString([string]);
+    let result = isWildcardString(string);
     assert.equal(result, true);
   });
 
   test('it returns true if string object has name and id with at least one wildcard', function(assert) {
     let string = { id: '7*', name: 'seven' };
-    let result = isWildcardString([string]);
+    let result = isWildcardString(string);
     assert.equal(result, true);
   });
 
   test('it returns true if string object has name and id with wildcard in name not id', function(assert) {
     let string = { id: '7', name: 'sev*n' };
-    let result = isWildcardString([string]);
+    let result = isWildcardString(string);
     assert.equal(result, true);
   });
 });


### PR DESCRIPTION
This PR adds links to arrays passed into the `info-table-row` component.  (See gif at end of PR)

If a wildcard is used as an `allowed_roles` then a count and link to "View all roles" is displayed. (I say `allowed_roles` here for example, but this is a component, so any array passed into this component follows this logic).

If the array of `allowed_roles.length` is >= 10, then the first 5 `allowed_roles` are displayed and a link next to it that says how many more there are and a link to "View all roles."

To accomplish the above, a new component called `info-table-item-array` was created that handles arrays inside of the `info-table-row` component.  

**Note**: there are a lot of situations that I did my best to handle, but I was not able to handle every situation.  I gave preference to the situations I thought more common.  An example situation I did handle is the following:  you have a wild card and an array greater than 10.  The View all roles would normally show up twice in this situation, but I prevent this by checking first if a wildcard string exists in the truncated array 5 length array.   In the following screenshot, "View all roles" shows at the end and not _also_ next to the wildcard.

<img width=400 src="https://user-images.githubusercontent.com/6618863/93102067-4d2c4500-f668-11ea-9be7-571b1d31b9a6.png">

An example of a situation I do _not_ handle is when you do not have a truncated array but you have a wildcard.  In this situation, I do not include a link to "View all roles."  This is because the conditional flow is as follows: is there a wildcard in the truncated array AND it's the last object of the truncated array? if yes, show "View all roles."  The second conditional check, is the item in the array the last in the array AND the array length is greater than 10, then show "View all roles."  In this situation, none of these conditions are truthy, so the "View all roles" does not show.  Trying to accommodate for this particular situation was difficult because I did not want to show "View all roles" twice, which would have happened if I showed "View all roles" if there were a wildcard and no other checks.

<img width=400 src="https://user-images.githubusercontent.com/6618863/93102379-aa27fb00-f668-11ea-9e87-cb8c0bdbc674.png">

Though, this situation is handled if the wildcard is the last item in the truncated array.  
<img width=400 src="https://user-images.githubusercontent.com/6618863/93104450-1572cc80-f66b-11ea-8608-1146d85dced6.png">

Here is a walk through gif, where you can link back and forth between roles and transformations.
![transform](https://user-images.githubusercontent.com/6618863/93106906-23761c80-f66e-11ea-9f23-b0a35ddab20c.gif)

