### PR TITLE
DBPW - Add test helpers for DB v5 interface

### DIFF
--- a/sdk/database/newdbplugin/testing/test_helpers.go
+++ b/sdk/database/newdbplugin/testing/test_helpers.go
@@ -2,16 +2,30 @@ package dbtesting
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/database/newdbplugin"
 )
 
+func getRequestTimeout(t *testing.T) time.Duration {
+	rawDur := os.Getenv("VAULT_TEST_DATABASE_REQUEST_TIMEOUT")
+	if rawDur == "" {
+		return 2 * time.Second
+	}
+
+	dur, err := time.ParseDuration(rawDur)
+	if err != nil {
+		t.Fatalf("Failed to parse custom request timeout %q: %s", rawDur, err)
+	}
+	return dur
+}
+
 func AssertInitialize(t *testing.T, db newdbplugin.Database, req newdbplugin.InitializeRequest) newdbplugin.InitializeResponse {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), getRequestTimeout(t))
 	defer cancel()
 
 	resp, err := db.Initialize(ctx, req)
@@ -24,7 +38,7 @@ func AssertInitialize(t *testing.T, db newdbplugin.Database, req newdbplugin.Ini
 func AssertNewUser(t *testing.T, db newdbplugin.Database, req newdbplugin.NewUserRequest) newdbplugin.NewUserResponse {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), getRequestTimeout(t))
 	defer cancel()
 
 	resp, err := db.NewUser(ctx, req)
@@ -41,7 +55,7 @@ func AssertNewUser(t *testing.T, db newdbplugin.Database, req newdbplugin.NewUse
 func AssertUpdateUser(t *testing.T, db newdbplugin.Database, req newdbplugin.UpdateUserRequest) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), getRequestTimeout(t))
 	defer cancel()
 
 	_, err := db.UpdateUser(ctx, req)
@@ -53,7 +67,7 @@ func AssertUpdateUser(t *testing.T, db newdbplugin.Database, req newdbplugin.Upd
 func AssertDeleteUser(t *testing.T, db newdbplugin.Database, req newdbplugin.DeleteUserRequest) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), getRequestTimeout(t))
 	defer cancel()
 
 	_, err := db.DeleteUser(ctx, req)

--- a/sdk/database/newdbplugin/testing/test_helpers.go
+++ b/sdk/database/newdbplugin/testing/test_helpers.go
@@ -1,0 +1,71 @@
+package dbtesting
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/database/newdbplugin"
+)
+
+func AssertInitialize(t *testing.T, db newdbplugin.Database, req newdbplugin.InitializeRequest) newdbplugin.InitializeResponse {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := db.Initialize(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to initialize: %s", err)
+	}
+	return resp
+}
+
+func AssertNewUser(t *testing.T, db newdbplugin.Database, req newdbplugin.NewUserRequest) newdbplugin.NewUserResponse {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := db.NewUser(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to create new user: %s", err)
+	}
+
+	if resp.Username == "" {
+		t.Fatalf("Missing username from NewUser response")
+	}
+	return resp
+}
+
+func AssertUpdateUser(t *testing.T, db newdbplugin.Database, req newdbplugin.UpdateUserRequest) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := db.UpdateUser(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to update user: %s", err)
+	}
+}
+
+func AssertDeleteUser(t *testing.T, db newdbplugin.Database, req newdbplugin.DeleteUserRequest) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := db.DeleteUser(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to delete user %q: %s", req.Username, err)
+	}
+}
+
+func AssertClose(t *testing.T, db newdbplugin.Database) {
+	t.Helper()
+	err := db.Close()
+	if err != nil {
+		t.Fatalf("Failed to close database: %s", err)
+	}
+}


### PR DESCRIPTION
# Overview
**This PR is part of a larger feature adding support for password policies into the combined database engine. This feature is being split into multiple PRs to make for smaller reviews & earlier feedback.**

Adds some test helper functions to call the various functions on the v5 `Database` interface with common assertions (no error, `NewUser` gives a non-empty username). These do not preclude calling the functions directly in a test if needed. These are made available for the common testing use cases.

# Related PRs
[Original password policies PR](https://github.com/hashicorp/vault/pull/8637)
[1/X - Database interface & gRPC](https://github.com/hashicorp/vault/pull/9641)
[2/X - Middleware](https://github.com/hashicorp/vault/pull/9642)
[3/X - Plugin management](https://github.com/hashicorp/vault/pull/9745)
[4/X - Database engine](https://github.com/hashicorp/vault/pull/9878)