### PR TITLE
Fix identity entity capabilities path

### DIFF
--- a/ui/app/models/identity/entity.js
+++ b/ui/app/models/identity/entity.js
@@ -50,6 +50,6 @@ let Model = IdentityModel.extend({
 });
 
 export default attachCapabilities(Model, {
-  updatePath: apiPath`identity/${'identityType'}/id/${'id'}`,
+  updatePath: apiPath`identity/entity/id/${'id'}`,
   aliasPath: apiPath`identity/entity-alias`,
 });


### PR DESCRIPTION
This issue was causing a bug where the capabilities on an `identity/entity` model had the incorrect `updatePath` due to `identityType` not properly being passed into the apiPath method. This change hardcodes the path for the entity model, since by the model's own definition the type is `entity`. 

Investigation is still needed for why the computed property was not being passed into the apiPath method properly, but this should fix adverse side affects such as tokens with policy including the path `identity/entity/id/*` not having the correct options on an entity dropdown.

Sample policy: 
```
path "identity/entity/id/*"
{
  capabilities = ["list", "read", "delete", "sudo", "create", "update"]
}
```
<img width="1157" alt="has-sample-policy" src="https://user-images.githubusercontent.com/16182107/93249118-6b706e80-f756-11ea-8013-4ae1b59d3784.png">
