### PR TITLE
Normalize format output for vault status [VAULT-508]

### DIFF
--- a/command/format.go
+++ b/command/format.go
@@ -306,12 +306,6 @@ func (t TableFormatter) OutputMap(ui cli.Ui, data map[string]interface{}) error 
 
 // OutputSealStatus will print *api.SealStatusResponse in the CLI according to the format provided
 func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusResponse) int {
-	switch Format(ui) {
-	case "table":
-	default:
-		return OutputData(ui, status)
-	}
-
 	var sealPrefix string
 	if status.RecoverySeal {
 		sealPrefix = "Recovery "
@@ -395,7 +389,7 @@ func OutputSealStatus(ui cli.Ui, client *api.Client, status *api.SealStatusRespo
 		out = append(out, fmt.Sprintf("Last WAL | %d", leaderStatus.LastWAL))
 	}
 
-	ui.Output(tableOutput(out, nil))
+	OutputData(ui, out)
 	return 0
 }
 


### PR DESCRIPTION
This PR corresponds to: https://hashicorp.atlassian.net/browse/VAULT-508 

As a result of this change, vault status acts like so: 

```
vault status -format=json
[
  "Key | Value",
  "Seal Type | shamir",
  "Initialized | true",
  "Sealed | false",
  "Total Shares | 1",
  "Threshold | 1",
  "Version | 1.5.0",
  "Storage Type | inmem",
  "Cluster Name | vault-cluster-0e5ef4e5",
  "Cluster ID | 2b50d1ea-2c08-e7f8-a04a-3072088154d3",
  "HA Enabled | false"
]
```

```
vault status -format=yaml
- Key | Value
- Seal Type | shamir
- Initialized | true
- Sealed | false
- Total Shares | 1
- Threshold | 1
- Version | 1.5.0
- Storage Type | inmem
- Cluster Name | vault-cluster-0e5ef4e5
- Cluster ID | 2b50d1ea-2c08-e7f8-a04a-3072088154d3
- HA Enabled | false
```

```
vault status -format=table
Key             Value
---             -----
Seal Type       shamir
Initialized     true
Sealed          false
Total Shares    1
Threshold       1
Version         1.5.0
Storage Type    inmem
Cluster Name    vault-cluster-0e5ef4e5
Cluster ID      2b50d1ea-2c08-e7f8-a04a-3072088154d3
HA Enabled      false
```

in contrast to:

```
vault status -format=json 
{
  "type": "shamir",
  "initialized": true,
  "sealed": false,
  "t": 1,
  "n": 1,
  "progress": 0,
  "nonce": "",
  "version": "1.5.0",
  "migration": false,
  "cluster_name": "vault-cluster-d9d7a354",
  "cluster_id": "f8b13bde-eda0-a1ba-1eac-96d9639c9a46",
  "recovery_seal": false,
  "storage_type": "inmem"
}
```

Similar fields are output for -format=<not-table>. 

Context: this change was introduced here: https://github.com/hashicorp/vault/commit/3189278c847abf8e8053905302f63f184309dd7f#diff-3e4377911a05a6f261016d1d5e1fec91R252 