### PR TITLE
Force docker API version to use.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,6 +749,13 @@ jobs:
 
           # Create a docker network for our testcontainer
           if [ $USE_DOCKER == 1 ]; then
+            # Despite the fact that we're using a circleci image (thus getting the
+            # version they chose for the docker cli) and that we're specifying a
+            # docker version to use for the remote docker instances, we occasionally
+            # see "client version too new, max supported version 1.39" errors for
+            # reasons unclear.
+            export DOCKER_API_VERSION=1.39
+
             export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
@@ -942,6 +949,13 @@ jobs:
 
           # Create a docker network for our testcontainer
           if [ $USE_DOCKER == 1 ]; then
+            # Despite the fact that we're using a circleci image (thus getting the
+            # version they chose for the docker cli) and that we're specifying a
+            # docker version to use for the remote docker instances, we occasionally
+            # see "client version too new, max supported version 1.39" errors for
+            # reasons unclear.
+            export DOCKER_API_VERSION=1.39
+
             export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
@@ -1341,6 +1355,13 @@ jobs:
 
           # Create a docker network for our testcontainer
           if [ $USE_DOCKER == 1 ]; then
+            # Despite the fact that we're using a circleci image (thus getting the
+            # version they chose for the docker cli) and that we're specifying a
+            # docker version to use for the remote docker instances, we occasionally
+            # see "client version too new, max supported version 1.39" errors for
+            # reasons unclear.
+            export DOCKER_API_VERSION=1.39
+
             export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
@@ -1480,6 +1501,13 @@ jobs:
 
           # Create a docker network for our testcontainer
           if [ $USE_DOCKER == 1 ]; then
+            # Despite the fact that we're using a circleci image (thus getting the
+            # version they chose for the docker cli) and that we're specifying a
+            # docker version to use for the remote docker instances, we occasionally
+            # see "client version too new, max supported version 1.39" errors for
+            # reasons unclear.
+            export DOCKER_API_VERSION=1.39
+
             export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)
@@ -2057,6 +2085,13 @@ jobs:
 
           # Create a docker network for our testcontainer
           if [ $USE_DOCKER == 1 ]; then
+            # Despite the fact that we're using a circleci image (thus getting the
+            # version they chose for the docker cli) and that we're specifying a
+            # docker version to use for the remote docker instances, we occasionally
+            # see "client version too new, max supported version 1.39" errors for
+            # reasons unclear.
+            export DOCKER_API_VERSION=1.39
+
             export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
             if [ -z $TEST_DOCKER_NETWORK_ID ]; then
               TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -74,6 +74,13 @@ steps:
 
         # Create a docker network for our testcontainer
         if [ $USE_DOCKER == 1 ]; then
+          # Despite the fact that we're using a circleci image (thus getting the
+          # version they chose for the docker cli) and that we're specifying a
+          # docker version to use for the remote docker instances, we occasionally
+          # see "client version too new, max supported version 1.39" errors for
+          # reasons unclear.
+          export DOCKER_API_VERSION=1.39
+
           export TEST_DOCKER_NETWORK_ID=$(docker network list -q -f 'name=vaulttest')
           if [ -z $TEST_DOCKER_NETWORK_ID ]; then
             TEST_DOCKER_NETWORK_ID=$(docker network create vaulttest)


### PR DESCRIPTION
Example failure this should fix: https://app.circleci.com/pipelines/github/hashicorp/vault/12211/workflows/66295509-b9c3-4d61-98fe-662c0d15bfd8/jobs/82289
```
Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.39
```