### PR TITLE
Moves the transit asymKey struct to the SDK

### DIFF
--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -182,13 +182,6 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 	return nil, nil
 }
 
-// Built-in helper type for returning asymmetric keys
-type asymKey struct {
-	Name         string    `json:"name" structs:"name" mapstructure:"name"`
-	PublicKey    string    `json:"public_key" structs:"public_key" mapstructure:"public_key"`
-	CreationTime time.Time `json:"creation_time" structs:"creation_time" mapstructure:"creation_time"`
-}
-
 func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
@@ -274,7 +267,7 @@ func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *f
 	case keysutil.KeyType_ECDSA_P256, keysutil.KeyType_ECDSA_P384, keysutil.KeyType_ECDSA_P521, keysutil.KeyType_ED25519, keysutil.KeyType_RSA2048, keysutil.KeyType_RSA3072, keysutil.KeyType_RSA4096:
 		retKeys := map[string]map[string]interface{}{}
 		for k, v := range p.Keys {
-			key := asymKey{
+			key := keysutil.AsymKey{
 				PublicKey:    v.FormattedPublicKey,
 				CreationTime: v.CreationTime,
 			}

--- a/builtin/logical/transit/path_sign_verify_test.go
+++ b/builtin/logical/transit/path_sign_verify_test.go
@@ -321,7 +321,7 @@ func validatePublicKey(t *testing.T, in string, sig string, pubKeyRaw []byte, ex
 		t.Fatal(err)
 	}
 	val := keyReadResp.Data["keys"].(map[string]map[string]interface{})[strings.TrimPrefix(splitSig[1], "v")]
-	var ak asymKey
+	var ak keysutil.AsymKey
 	if err := mapstructure.Decode(val, &ak); err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -158,6 +158,13 @@ func (kt KeyType) String() string {
 	return "[unknown]"
 }
 
+// Built-in helper type for returning asymmetric keys
+type AsymKey struct {
+	Name         string    `json:"name" structs:"name" mapstructure:"name"`
+	PublicKey    string    `json:"public_key" structs:"public_key" mapstructure:"public_key"`
+	CreationTime time.Time `json:"creation_time" structs:"creation_time" mapstructure:"creation_time"`
+}
+
 type KeyData struct {
 	Policy       *Policy       `json:"policy"`
 	ArchivedKeys *archivedKeys `json:"archived_keys"`


### PR DESCRIPTION
## Overview

Moves the transit `asymKey` struct into the Vault SDK so that it can be more easily shared with plugins.

## Testing

Compiled Vault and ran transit tests.

```sh
$ TEST="./builtin/logical/transit" make test 
==> Checking that build is using go version >= 1.14.7...
==> Using go version 1.14.7...
go: downloading github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
go: downloading github.com/opencontainers/runc v1.0.0-rc9
ok      github.com/hashicorp/vault/builtin/logical/transit      40.681s
```