### PR TITLE
fix missing plaintext in bulk decrypt response

### DIFF
--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -11,6 +11,16 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+type DecryptBatchResponseItem struct {
+	// Plaintext for the ciphertext present in the corresponding batch
+	// request item
+	Plaintext string `json:"plaintext" structs:"plaintext" mapstructure:"plaintext"`
+
+	// Error, if set represents a failure encountered while encrypting a
+	// corresponding batch request item
+	Error string `json:"error,omitempty" structs:"error" mapstructure:"error"`
+}
+
 func (b *backend) pathDecrypt() *framework.Path {
 	return &framework.Path{
 		Pattern: "decrypt/" + framework.GenericNameRegex("name"),
@@ -78,7 +88,7 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 		}
 	}
 
-	batchResponseItems := make([]BatchResponseItem, len(batchInputItems))
+	batchResponseItems := make([]DecryptBatchResponseItem, len(batchInputItems))
 	contextSet := len(batchInputItems[0].Context) != 0
 
 	for i, item := range batchInputItems {

--- a/builtin/logical/transit/path_decrypt_bench_test.go
+++ b/builtin/logical/transit/path_decrypt_bench_test.go
@@ -62,7 +62,7 @@ func BTransit_BatchDecryption(b *testing.B, bsize int) {
 		b.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchResponseItems := resp.Data["batch_results"].([]BatchResponseItem)
+	batchResponseItems := resp.Data["batch_results"].([]EncryptBatchResponseItem)
 	batchDecryptionInput := make([]interface{}, len(batchResponseItems))
 	for i, item := range batchResponseItems {
 		batchDecryptionInput[i] = map[string]interface{}{"ciphertext": item.Ciphertext}

--- a/builtin/logical/transit/path_decrypt_test.go
+++ b/builtin/logical/transit/path_decrypt_test.go
@@ -125,7 +125,7 @@ func TestTransit_BatchDecryption_DerivedKey(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchDecryptionResponseItems := resp.Data["batch_results"].([]BatchResponseItem)
+	batchDecryptionResponseItems := resp.Data["batch_results"].([]DecryptBatchResponseItem)
 
 	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
 	for _, item := range batchDecryptionResponseItems {

--- a/builtin/logical/transit/path_decrypt_test.go
+++ b/builtin/logical/transit/path_decrypt_test.go
@@ -33,7 +33,7 @@ func TestTransit_BatchDecryption(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchResponseItems := resp.Data["batch_results"].([]BatchResponseItem)
+	batchResponseItems := resp.Data["batch_results"].([]EncryptBatchResponseItem)
 	batchDecryptionInput := make([]interface{}, len(batchResponseItems))
 	for i, item := range batchResponseItems {
 		batchDecryptionInput[i] = map[string]interface{}{"ciphertext": item.Ciphertext}
@@ -103,7 +103,7 @@ func TestTransit_BatchDecryption_DerivedKey(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchDecryptionInputItems := resp.Data["batch_results"].([]BatchResponseItem)
+	batchDecryptionInputItems := resp.Data["batch_results"].([]EncryptBatchResponseItem)
 
 	batchDecryptionInput := make([]interface{}, len(batchDecryptionInputItems))
 	for i, item := range batchDecryptionInputItems {

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -37,8 +37,8 @@ type BatchRequestItem struct {
 	DecodedNonce []byte
 }
 
-// BatchResponseItem represents a response item for batch processing
-type BatchResponseItem struct {
+// EncryptBatchResponseItem represents a response item for batch processing
+type EncryptBatchResponseItem struct {
 	// Ciphertext for the plaintext present in the corresponding batch
 	// request item
 	Ciphertext string `json:"ciphertext,omitempty" structs:"ciphertext" mapstructure:"ciphertext"`
@@ -250,7 +250,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		}
 	}
 
-	batchResponseItems := make([]BatchResponseItem, len(batchInputItems))
+	batchResponseItems := make([]EncryptBatchResponseItem, len(batchInputItems))
 	contextSet := len(batchInputItems[0].Context) != 0
 
 	// Before processing the batch request items, get the policy. If the

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -46,10 +46,6 @@ type EncryptBatchResponseItem struct {
 	// KeyVersion defines the key version used to encrypt plaintext.
 	KeyVersion int `json:"key_version,omitempty" structs:"key_version" mapstructure:"key_version"`
 
-	// Plaintext for the ciphertext present in the corresponding batch
-	// request item
-	Plaintext string `json:"plaintext,omitempty" structs:"plaintext" mapstructure:"plaintext"`
-
 	// Error, if set represents a failure encountered while encrypting a
 	// corresponding batch request item
 	Error string `json:"error,omitempty" structs:"error" mapstructure:"error"`

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -192,7 +192,7 @@ func TestTransit_BatchEncryptionCase4(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchResponseItems := resp.Data["batch_results"].([]BatchResponseItem)
+	batchResponseItems := resp.Data["batch_results"].([]EncryptBatchResponseItem)
 
 	decReq := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -264,7 +264,7 @@ func TestTransit_BatchEncryptionCase5(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchResponseItems := resp.Data["batch_results"].([]BatchResponseItem)
+	batchResponseItems := resp.Data["batch_results"].([]EncryptBatchResponseItem)
 
 	decReq := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -320,7 +320,7 @@ func TestTransit_BatchEncryptionCase6(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchResponseItems := resp.Data["batch_results"].([]BatchResponseItem)
+	batchResponseItems := resp.Data["batch_results"].([]EncryptBatchResponseItem)
 
 	decReq := &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -331,7 +331,7 @@ func TestTransit_BatchEncryptionCase6(t *testing.T) {
 	plaintext := "dGhlIHF1aWNrIGJyb3duIGZveA=="
 
 	for _, responseItem := range batchResponseItems {
-		var item BatchResponseItem
+		var item EncryptBatchResponseItem
 		if err := mapstructure.Decode(responseItem, &item); err != nil {
 			t.Fatal(err)
 		}
@@ -380,7 +380,7 @@ func TestTransit_BatchEncryptionCase7(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchResponseItems := resp.Data["batch_results"].([]BatchResponseItem)
+	batchResponseItems := resp.Data["batch_results"].([]EncryptBatchResponseItem)
 
 	decReq := &logical.Request{
 		Operation: logical.UpdateOperation,

--- a/builtin/logical/transit/path_hmac.go
+++ b/builtin/logical/transit/path_hmac.go
@@ -19,7 +19,7 @@ import (
 // A map type allows us to distinguish between empty and missing values.
 type batchRequestHMACItem map[string]string
 
-// BatchResponseItem represents a response item for batch processing
+// batchResponseHMACItem represents a response item for batch processing
 type batchResponseHMACItem struct {
 	// HMAC for the input present in the corresponding batch request item
 	HMAC string `json:"hmac,omitempty" mapstructure:"hmac"`

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -82,7 +82,7 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 		}
 	}
 
-	batchResponseItems := make([]BatchResponseItem, len(batchInputItems))
+	batchResponseItems := make([]EncryptBatchResponseItem, len(batchInputItems))
 	contextSet := len(batchInputItems[0].Context) != 0
 
 	for i, item := range batchInputItems {

--- a/builtin/logical/transit/path_rewrap_test.go
+++ b/builtin/logical/transit/path_rewrap_test.go
@@ -241,7 +241,7 @@ func TestTransit_BatchRewrapCase3(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchEncryptionResponseItems := resp.Data["batch_results"].([]BatchResponseItem)
+	batchEncryptionResponseItems := resp.Data["batch_results"].([]EncryptBatchResponseItem)
 
 	batchRewrapInput := make([]interface{}, len(batchEncryptionResponseItems))
 	for i, item := range batchEncryptionResponseItems {
@@ -274,7 +274,7 @@ func TestTransit_BatchRewrapCase3(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	batchRewrapResponseItems := resp.Data["batch_results"].([]BatchResponseItem)
+	batchRewrapResponseItems := resp.Data["batch_results"].([]EncryptBatchResponseItem)
 
 	if len(batchRewrapResponseItems) != len(batchEncryptionResponseItems) {
 		t.Fatalf("bad: length of input and output or rewrap are not matching; expected: %d, actual: %d", len(batchEncryptionResponseItems), len(batchRewrapResponseItems))


### PR DESCRIPTION
This PR

- [x] fixes #6140 
- [x] changes the go test to check against an json payload in order to:
  - check the correct order of the expected results
  - check if the missing `plaintext` property is correctly added for "empty" string values