### PR TITLE
Allow token metadata for templating

### DIFF
--- a/sdk/helper/identitytpl/templating.go
+++ b/sdk/helper/identitytpl/templating.go
@@ -29,6 +29,7 @@ type PopulateStringInput struct {
 	ValidityCheckOnly bool
 	Entity            *logical.Entity
 	Groups            []*logical.Group
+	TokenMeta         map[string]string
 	NamespaceID       string
 	Mode              int       // processing mode, ACLTemplate or JSONTemplating
 	Now               time.Time // optional, defaults to current time
@@ -337,6 +338,13 @@ func performTemplating(input string, p *PopulateStringInput) (string, error) {
 		return strconv.FormatInt(result.Unix(), 10), nil
 	}
 
+	performTokenMetaTemplating := func(trimmed string) (string, error) {
+		if val, ok := p.TokenMeta[trimmed]; ok {
+			return val, nil
+		}
+		return "", ErrTemplateValueNotFound
+	}
+
 	switch {
 	case strings.HasPrefix(input, "identity.entity."):
 		if p.Entity == nil {
@@ -352,6 +360,9 @@ func performTemplating(input string, p *PopulateStringInput) (string, error) {
 
 	case strings.HasPrefix(input, "time."):
 		return performTimeTemplating(strings.TrimPrefix(input, "time."))
+
+	case strings.HasPrefix(input, "token.meta."):
+		return performTokenMetaTemplating(strings.TrimPrefix(input, "token.meta."))
 	}
 
 	return "", ErrTemplateValueNotFound

--- a/sdk/helper/identitytpl/templating_test.go
+++ b/sdk/helper/identitytpl/templating_test.go
@@ -33,6 +33,7 @@ func TestPopulate_Basic(t *testing.T) {
 		groupName         string
 		groupMetadata     map[string]string
 		groupMemberships  []string
+		tokenMeta         map[string]string
 		now               time.Time
 	}{
 		// time.* tests. Keep tests with time.Now() at the front to avoid false
@@ -329,6 +330,24 @@ func TestPopulate_Basic(t *testing.T) {
 			aliasMetadata: map[string]string{"foo": "bar", "color": "green"},
 			output:        `{}`,
 		},
+		{
+			name:      "token_meta_basic",
+			input:     "path /{{token.meta.foo}}/ {",
+			tokenMeta: map[string]string{"foo": "bar"},
+			output:    "path /bar/ {",
+		},
+		{
+			name:      "token_meta_missing_key",
+			input:     "path /{{token.meta.foo2}}/ {",
+			tokenMeta: map[string]string{"foo": "bar"},
+			err:       ErrTemplateValueNotFound,
+		},
+		{
+			name:      "token_meta_multiple_keys",
+			input:     "path /secret/{{token.meta.cluster}}/{{token.meta.env}}/ {",
+			tokenMeta: map[string]string{"cluster": "amsterdam", "env": "prod"},
+			output:    "path /secret/amsterdam/prod/ {",
+		},
 	}
 
 	for _, test := range tests {
@@ -377,6 +396,7 @@ func TestPopulate_Basic(t *testing.T) {
 			Groups:            groups,
 			NamespaceID:       "root",
 			Now:               test.now,
+			TokenMeta:         test.tokenMeta,
 		})
 		if err != nil {
 			if test.err == nil {

--- a/vault/capabilities.go
+++ b/vault/capabilities.go
@@ -65,7 +65,7 @@ func (c *Core) Capabilities(ctx context.Context, token, path string) ([]string, 
 	// Construct the corresponding ACL object. ACL construction should be
 	// performed on the token's namespace.
 	tokenCtx := namespace.ContextWithNamespace(ctx, tokenNS)
-	acl, err := c.policyStore.ACL(tokenCtx, entity, policyNames)
+	acl, err := c.policyStore.ACL(tokenCtx, entity, policyNames, te.Meta)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -103,7 +103,7 @@ func (e extendedSystemViewImpl) SudoPrivilege(ctx context.Context, path string, 
 
 	// Construct the corresponding ACL object. Derive and use a new context that
 	// uses the req.ClientToken's namespace
-	acl, err := e.core.policyStore.ACL(tokenCtx, entity, policies)
+	acl, err := e.core.policyStore.ACL(tokenCtx, entity, policies, te.Meta)
 	if err != nil {
 		e.core.logger.Error("failed to retrieve ACL for token's policies", "token_policies", te.Policies, "error", err)
 		return false

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -224,14 +224,14 @@ func (p *ACLPermissions) Clone() (*ACLPermissions, error) {
 // intermediary set of policies, before being compiled into
 // the ACL
 func ParseACLPolicy(ns *namespace.Namespace, rules string) (*Policy, error) {
-	return parseACLPolicyWithTemplating(ns, rules, false, nil, nil)
+	return parseACLPolicyWithTemplating(ns, rules, false, nil, nil, nil)
 }
 
 // parseACLPolicyWithTemplating performs the actual work and checks whether we
 // should perform substitutions. If performTemplating is true we know that it
 // is templated so we don't check again, otherwise we check to see if it's a
 // templated policy.
-func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, performTemplating bool, entity *identity.Entity, groups []*identity.Group) (*Policy, error) {
+func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, performTemplating bool, entity *identity.Entity, groups []*identity.Group, tokenMeta map[string]string) (*Policy, error) {
 	// Parse the rules
 	root, err := hcl.Parse(rules)
 	if err != nil {
@@ -264,7 +264,7 @@ func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, perform
 	}
 
 	if o := list.Filter("path"); len(o.Items) > 0 {
-		if err := parsePaths(&p, o, performTemplating, entity, groups); err != nil {
+		if err := parsePaths(&p, o, performTemplating, entity, groups, tokenMeta); err != nil {
 			return nil, errwrap.Wrapf("failed to parse policy: {{err}}", err)
 		}
 	}
@@ -272,7 +272,7 @@ func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, perform
 	return &p, nil
 }
 
-func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, entity *identity.Entity, groups []*identity.Group) error {
+func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, entity *identity.Entity, groups []*identity.Group, tokenMeta map[string]string) error {
 	paths := make([]*PathRules, 0, len(list.Items))
 	for _, item := range list.Items {
 		key := "path"
@@ -287,6 +287,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 				String:      key,
 				Entity:      identity.ToSDKEntity(entity),
 				Groups:      identity.ToSDKGroups(groups),
+				TokenMeta:   tokenMeta,
 				NamespaceID: result.namespace.ID,
 			})
 			if err != nil {

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -750,7 +750,7 @@ func (t *TemplateError) Error() string {
 
 // ACL is used to return an ACL which is built using the
 // named policies.
-func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string) (*ACL, error) {
+func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string, tokenMeta map[string]string) (*ACL, error) {
 	var policies []*Policy
 	// Fetch the policies
 	for nsID, nsPolicyNames := range policyNames {
@@ -787,7 +787,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 					groups = append(directGroups, inheritedGroups...)
 				}
 			}
-			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, entity, groups)
+			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, entity, groups, tokenMeta)
 			if err != nil {
 				return nil, errwrap.Wrapf(fmt.Sprintf("error parsing templated policy %q: {{err}}", policy.Name), err)
 			}

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -268,7 +268,7 @@ func testPolicyStoreACL(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) 
 	}
 
 	ctx = namespace.ContextWithNamespace(context.Background(), ns)
-	acl, err := ps.ACL(ctx, nil, map[string][]string{ns.ID: []string{"dev", "ops"}})
+	acl, err := ps.ACL(ctx, nil, map[string][]string{ns.ID: []string{"dev", "ops"}}, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -216,7 +216,7 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 
 	// Construct the corresponding ACL object. ACL construction should be
 	// performed on the token's namespace.
-	acl, err := c.policyStore.ACL(tokenCtx, entity, policies)
+	acl, err := c.policyStore.ACL(tokenCtx, entity, policies, te.Meta)
 	if err != nil {
 		if errwrap.ContainsType(err, new(TemplateError)) {
 			c.logger.Warn("permission denied due to a templated policy being invalid or containing directives not satisfied by the requestor", "error", err)

--- a/vendor/github.com/hashicorp/vault/sdk/helper/identitytpl/templating.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/identitytpl/templating.go
@@ -29,6 +29,7 @@ type PopulateStringInput struct {
 	ValidityCheckOnly bool
 	Entity            *logical.Entity
 	Groups            []*logical.Group
+	TokenMeta         map[string]string
 	NamespaceID       string
 	Mode              int       // processing mode, ACLTemplate or JSONTemplating
 	Now               time.Time // optional, defaults to current time
@@ -337,6 +338,13 @@ func performTemplating(input string, p *PopulateStringInput) (string, error) {
 		return strconv.FormatInt(result.Unix(), 10), nil
 	}
 
+	performTokenMetaTemplating := func(trimmed string) (string, error) {
+		if val, ok := p.TokenMeta[trimmed]; ok {
+			return val, nil
+		}
+		return "", ErrTemplateValueNotFound
+	}
+
 	switch {
 	case strings.HasPrefix(input, "identity.entity."):
 		if p.Entity == nil {
@@ -352,6 +360,9 @@ func performTemplating(input string, p *PopulateStringInput) (string, error) {
 
 	case strings.HasPrefix(input, "time."):
 		return performTimeTemplating(strings.TrimPrefix(input, "time."))
+
+	case strings.HasPrefix(input, "token.meta."):
+		return performTokenMetaTemplating(strings.TrimPrefix(input, "token.meta."))
 	}
 
 	return "", ErrTemplateValueNotFound

--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -233,7 +233,7 @@ credentials, the policy would grant `read` access on the appropriate path.
 ## Templated Policies
 
 The policy syntax allows for doing variable replacement in some policy strings
-with values available to the token. Currently `identity` information can be
+with values available to the token. Currently `identity` and `token` information can be
 injected, and currently the `path` keys in policies allow injection.
 
 ### Parameters
@@ -250,6 +250,7 @@ injected, and currently the `path` keys in policies allow injection.
 | `identity.groups.names.<group name>.id`                            | The group ID for the given group name                                   |
 | `identity.groups.ids.<group id>.metadata.<metadata key>`           | Metadata associated with the group for the given key                    |
 | `identity.groups.names.<group name>.metadata.<metadata key>`       | Metadata associated with the group for the given key                    |
+| `token.meta.<metadata key>`                                        | Metadata associated with the token for the given key                    |
 
 ### Examples
 


### PR DESCRIPTION
This pull request adds functionality of using token metadata for templated policies, similarly to the current available templates for metadata in stored in entities.

**RATIONALE:**

I am aware this was discussed in the past (https://github.com/hashicorp/vault/issues/5916#issuecomment-448298263) and HashiCorp's response was to keep templated policies centralized with the Identity secrets engine, the solution Vault provides for identities.

However, Identity does not provide **Implicit Groups**, or automated group sync, just [Implicit Entities](https://www.vaultproject.io/docs/secrets/identity#implicit-entities). The rationale for this change is substantially simplifying many workflows (usually cronjobs) that need to sync external groups into "Identity" groups via leveraging more metadata than just the one coming from the Entity.

Furthermore, when setting up an auth backend we need to specify both the `metadata` **and** `policies`. Therefore, we cannot have confusion here, since prior to using the policy in an Auth backend, we will know if metadata needs to be supplied as well. The same goes when using metadata in from an Entity, such as `{{identity.entity.metadata.color}}`