### PR TITLE
Update vault-plugin-auth-kubernetes to v0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-gcp v0.7.1-0.20200824223748-9b39891cb353
 	github.com/hashicorp/vault-plugin-auth-jwt v0.7.3
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.1.6
-	github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.0
+	github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.1
 	github.com/hashicorp/vault-plugin-auth-oci v0.5.5
 	github.com/hashicorp/vault-plugin-database-elasticsearch v0.5.4
 	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -531,8 +531,8 @@ github.com/hashicorp/vault-plugin-auth-kerberos v0.1.5/go.mod h1:r4UqWITHYKmBeAM
 github.com/hashicorp/vault-plugin-auth-kerberos v0.1.6 h1:l5wu8J7aiQBLsTtkKhf1QQjGoeVjcfcput+uJ/pu2MM=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.1.6/go.mod h1:IM/n7LY1rIM4MVzOfSH6cRmY/C2rGkrjGrEr0B/yO9c=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.6.1/go.mod h1:/Y9W5aZULfPeNVRQK0/nrFGpHWyNm0J3UWhOdsAu0vM=
-github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.0 h1:tt/kHMFB1qjp2b2ZRSI1KbH2CRV91VHghgr+5x9grgM=
-github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.0/go.mod h1:2c/k3nsoGPKV+zpAWCiajt4e66vncEq8Li/eKLqErAc=
+github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.1 h1:0bUiJyKK4G7PaTDF03K50Ep1jQc2Vv0cQNo0rUi85X4=
+github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.1/go.mod h1:2c/k3nsoGPKV+zpAWCiajt4e66vncEq8Li/eKLqErAc=
 github.com/hashicorp/vault-plugin-auth-oci v0.5.4/go.mod h1:j05O2b9fw2Q82NxDPhHMYVfHKvitUYGWfmqmpBdqmmc=
 github.com/hashicorp/vault-plugin-auth-oci v0.5.5 h1:nIP8g+VZd2V+LY/D5omWhLSnhHuogIJx7Bz6JyLt628=
 github.com/hashicorp/vault-plugin-auth-oci v0.5.5/go.mod h1:Cn5cjR279Y+snw8LTaiLTko3KGrbigRbsQPOd2D5xDw=
@@ -550,8 +550,6 @@ github.com/hashicorp/vault-plugin-secrets-azure v0.5.6/go.mod h1:Q0cIL4kZWnMmQWk
 github.com/hashicorp/vault-plugin-secrets-azure v0.6.2-0.20200818154643-63f769e87b12 h1:AoWuVIcqlISlINDq9crOwne9N3IVWlKuJuPUbu1j5tA=
 github.com/hashicorp/vault-plugin-secrets-azure v0.6.2-0.20200818154643-63f769e87b12/go.mod h1:4jCVjTG809NCQ8mrSnbBtX17gX1Iush+558BVO6MJeo=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.6.2-0.20200507171538-2548e2b5058d/go.mod h1:jVTE1fuhRcBOb/gnCT9W++AnlwiyQEX4S8iVCKhKQsE=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.6.4-0.20200727183837-4005bee700bf h1:7d6iDdI9/m9T6hF6TyNaqGoSqrEoToH7dL5q+iJyJNE=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.6.4-0.20200727183837-4005bee700bf/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.6.5 h1:tH9HaDag4p1tpaP7zmZvpv3t1aPIVzwpzntWcXb2gpw=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.6.5/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.5/go.mod h1:b6RwFD1bny1zbfqhD35iGJdQYHRtJLx3HfBD109GO38=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -465,7 +465,7 @@ github.com/hashicorp/vault-plugin-auth-gcp/plugin/cache
 github.com/hashicorp/vault-plugin-auth-jwt
 # github.com/hashicorp/vault-plugin-auth-kerberos v0.1.6
 github.com/hashicorp/vault-plugin-auth-kerberos
-# github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.0
+# github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.1
 github.com/hashicorp/vault-plugin-auth-kubernetes
 # github.com/hashicorp/vault-plugin-auth-oci v0.5.5
 github.com/hashicorp/vault-plugin-auth-oci


### PR DESCRIPTION
Brings in the `disable_local_ca_jwt` option from https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/97

Ran:

```sh
go get github.com/hashicorp/vault-plugin-auth-kubernetes@v0.7.1
go mod tidy
go mod vendor
```