### PR TITLE
Integrate Allowed and Denied Parameters With KV2 [VAULT-616]

### DIFF
--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -588,16 +588,30 @@ func testACLValuePermissions(t *testing.T, ns *namespace.Namespace) {
 			Path: tc.path,
 			Data: make(map[string]interface{}),
 		}
+		requestKV2 := &logical.Request{
+			Path: tc.path,
+			Data: make(map[string]interface{}),
+		}
+		dataKV2 := make(map[string]interface{})
+
 		ctx := namespace.ContextWithNamespace(context.Background(), ns)
 
 		for i, parameter := range tc.parameters {
 			request.Data[parameter] = tc.values[i]
+			dataKV2[parameter] = tc.values[i]
 		}
+
+		requestKV2.Data["data"] = dataKV2
+
 		for _, op := range toperations {
 			request.Operation = op
 			authResults := acl.AllowOperation(ctx, request, false)
 			if authResults.Allowed != tc.allowed {
 				t.Fatalf("bad: case %#v: %v", tc, authResults.Allowed)
+			}
+			authResultsKV2 := acl.AllowOperation(ctx, requestKV2, false)
+			if authResults.Allowed != tc.allowed {
+				t.Fatalf("bad: case %#v: %v", tc, authResultsKV2.Allowed)
 			}
 		}
 	}


### PR DESCRIPTION
Jira ticket: https://hashicorp.atlassian.net/browse/VAULT-616

Description: Vault requests to the KV2 secrets engine contain an extra "data" field, such that request.Data has a field "data" within which the secret key/values are stored, as we can see here: https://github.com/hashicorp/vault/blob/7aa1ffa92ee61b977efad1488b8f309b1e2136df/command/kv_get.go#L128 

Allowed and denied parameters are put within that data block, and therefore are not found up by acl.go, which assumes the format of request.Data is compatible with KV1. 

This PR provides a fix, and adds tests to the current test suite to include KV2-integrable tests. 