### PR TITLE
Add X-Amz-Content-Sha256 as a default allowed STS header

### DIFF
--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -20,10 +20,11 @@ import (
 const amzHeaderPrefix = "X-Amz-"
 
 var defaultAllowedSTSRequestHeaders = []string{
-	"X-Amz-Date",
-	"X-Amz-Credential",
-	"X-Amz-Security-Token",
 	"X-Amz-Algorithm",
+	"X-Amz-Content-Sha256",
+	"X-Amz-Credential",
+	"X-Amz-Date",
+	"X-Amz-Security-Token",
 	"X-Amz-Signature",
 	"X-Amz-SignedHeaders"}
 


### PR DESCRIPTION
Adding `X-Amz-Content-Sha256` as a default header due to an auth issue that some users have encountered when upgrading to a more recent version of Vault.

The list has also been alphabetized for clarity's sake.