### PR TITLE
Mention allowed_users and allowed_domains are comma separated lists

### DIFF
--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -137,7 +137,7 @@ This endpoint creates or updates a named role.
 - `allowed_users` `(string: "")` – If this option is not specified, or if it is
   `*`, the client can request a credential for any valid user at the remote
   host, including the admin user. If only certain usernames are to be allowed,
-  then this list enforces it. If this field is set, then credentials can only
+  then this comma separated list enforces it. If this field is set, then credentials can only
   be created for `default_user` and usernames present in this list. Setting
   this option will enable all the users with access this role to fetch
   credentials for all other usernames in this list.
@@ -149,7 +149,7 @@ This endpoint creates or updates a named role.
 - `allowed_users_template` `(bool: false)` - If set, `allowed_users` can be specified
   using identity template policies. Non-templated users are also permitted.
 
-- `allowed_domains` `(string: "")` – The list of domains for which a client can
+- `allowed_domains` `(string: "")` – Comma separated list of domains for which a client can
   request a host certificate. If this option is explicitly set to `"*"`, then
   credentials can be created for any domain. See also `allow_bare_domains` and
   `allow_subdomains`.


### PR DESCRIPTION
Other lists in the doc mention that the syntax is comma separated, but allowed_users and allowed_domains didn't. This syncs them with the rest.