### PR TITLE
Backport 10009 to 1.5.x

### DIFF
--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -20,10 +20,11 @@ import (
 const amzHeaderPrefix = "X-Amz-"
 
 var defaultAllowedSTSRequestHeaders = []string{
-	"X-Amz-Date",
-	"X-Amz-Credential",
-	"X-Amz-Security-Token",
 	"X-Amz-Algorithm",
+	"X-Amz-Content-Sha256",
+	"X-Amz-Credential",
+	"X-Amz-Date",
+	"X-Amz-Security-Token",
 	"X-Amz-Signature",
 	"X-Amz-SignedHeaders"}
 


### PR DESCRIPTION
Backporting an update to the default STS headers.