### PR TITLE
Clarify docs around audit non-hmac request and response keys

### DIFF
--- a/website/pages/docs/commands/auth/enable.mdx
+++ b/website/pages/docs/commands/auth/enable.mdx
@@ -47,6 +47,7 @@ flags](/docs/commands) included on all commands.
 - `-audit-non-hmac-request-keys` `(string: "")` - Key that will not be HMAC'd
   by audit devices in the request data object. Note that multiple keys may be
   specified by providing this option multiple times, each time with 1 key.
+  An example of this is provided in the [tune section](/docs/commands/auth/tune).
 
 - `-audit-non-hmac-response-keys` `(string: "")` - Key that will not be HMAC'd
   by audit devices in the response data object. Note that multiple keys may be

--- a/website/pages/docs/commands/auth/enable.mdx
+++ b/website/pages/docs/commands/auth/enable.mdx
@@ -44,13 +44,13 @@ the [auth method](/docs/auth) documentation.
 The following flags are available in addition to the [standard set of
 flags](/docs/commands) included on all commands.
 
-- `-audit-non-hmac-request-keys` `(string: "")` - Comma-separated
-  string or list of keys that will not be HMAC'd by audit devices in the
-  request data object.
+- `-audit-non-hmac-request-keys` `(string: "")` - Key that will not be HMAC'd
+  by audit devices in the request data object. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.
 
-- `-audit-non-hmac-response-keys` `(string: "")` - Comma-separated
-  string or list of keys that will not be HMAC'd by audit devices in the
-  response data object.
+- `-audit-non-hmac-response-keys` `(string: "")` - Key that will not be HMAC'd
+  by audit devices in the response data object. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.
 
 - `-default-lease-ttl` `(duration: "")` - The default lease TTL for this auth
   method. If unspecified, this defaults to the Vault server's globally

--- a/website/pages/docs/commands/auth/tune.mdx
+++ b/website/pages/docs/commands/auth/tune.mdx
@@ -27,13 +27,13 @@ Success! Tuned the auth method at: github/
 The following flags are available in addition to the [standard set of
 flags](/docs/commands) included on all commands.
 
-- `-audit-non-hmac-request-keys` `(string: "")` - Comma-separated
-  string or list of keys that will not be HMAC'd by audit devices in the
-  request data object.
+- `-audit-non-hmac-request-keys` `(string: "")` - Key that will not be HMAC'd
+  by audit devices in the request data object. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.
 
-- `-audit-non-hmac-response-keys` `(string: "")` - Comma-separated
-  string or list of keys that will not be HMAC'd by audit devices in the
-  response data object.
+- `-audit-non-hmac-response-keys` `(string: "")` - Key that will not be HMAC'd
+  by audit devices in the response data object. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.
 
 - `-default-lease-ttl` `(duration: "")` - The default lease TTL for this auth
   method. If unspecified, this defaults to the Vault server's globally

--- a/website/pages/docs/commands/auth/tune.mdx
+++ b/website/pages/docs/commands/auth/tune.mdx
@@ -22,6 +22,12 @@ $ vault auth tune -default-lease-ttl=72h github/
 Success! Tuned the auth method at: github/
 ```
 
+Specify multiple audit non-hmac request keys:
+
+```shell-session
+$ vault auth tune -audit-non-hmac-request-keys=value1 -audit-non-hmac-request-keys=value2 github/
+```
+
 ## Usage
 
 The following flags are available in addition to the [standard set of

--- a/website/pages/docs/commands/secrets/enable.mdx
+++ b/website/pages/docs/commands/secrets/enable.mdx
@@ -60,13 +60,13 @@ the [secrets engine](/docs/secrets) documentation.
 The following flags are available in addition to the [standard set of
 flags](/docs/commands) included on all commands.
 
-- `-audit-non-hmac-request-keys` `(string: "")` - Comma-separated
-  string or list of keys that will not be HMAC'd by audit devices in the
-  request data object.
+- `-audit-non-hmac-request-keys` `(string: "")` - Key that will not be HMAC'd
+  by audit devices in the request data object. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.
 
-- `-audit-non-hmac-response-keys` `(string: "")` - Comma-separated
-  string or list of keys that will not be HMAC'd by audit devices in the
-  response data object.
+- `-audit-non-hmac-response-keys` `(string: "")` - Key that will not be HMAC'd
+  by audit devices in the response data object. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.
 
 - `-default-lease-ttl` `(duration: "")` - The default lease TTL for this secrets
   engine. If unspecified, this defaults to the Vault server's globally

--- a/website/pages/docs/commands/secrets/enable.mdx
+++ b/website/pages/docs/commands/secrets/enable.mdx
@@ -63,6 +63,7 @@ flags](/docs/commands) included on all commands.
 - `-audit-non-hmac-request-keys` `(string: "")` - Key that will not be HMAC'd
   by audit devices in the request data object. Note that multiple keys may be
   specified by providing this option multiple times, each time with 1 key.
+  An example of this is provided in the [tune section](/docs/commands/secrets/tune).
 
 - `-audit-non-hmac-response-keys` `(string: "")` - Key that will not be HMAC'd
   by audit devices in the response data object. Note that multiple keys may be

--- a/website/pages/docs/commands/secrets/tune.mdx
+++ b/website/pages/docs/commands/secrets/tune.mdx
@@ -27,13 +27,13 @@ $ vault secrets tune -default-lease-ttl=72h pki/
 The following flags are available in addition to the [standard set of
 flags](/docs/commands) included on all commands.
 
-- `-audit-non-hmac-request-keys` `(string: "")` - Comma-separated
-  string or list of keys that will not be HMAC'd by audit devices in the
-  request data object.
+- `-audit-non-hmac-request-keys` `(string: "")` - Key that will not be HMAC'd
+  by audit devices in the request data object. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.
 
-- `-audit-non-hmac-response-keys` `(string: "")` - Comma-separated
-  string or list of keys that will not be HMAC'd by audit devices in the
-  response data object.
+- `-audit-non-hmac-response-keys` `(string: "")` - Key that will not be HMAC'd
+  by audit devices in the response data object. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.
 
 - `-default-lease-ttl` `(duration: "")` - The default lease TTL for this secrets
   engine. If unspecified, this defaults to the Vault server's globally

--- a/website/pages/docs/commands/secrets/tune.mdx
+++ b/website/pages/docs/commands/secrets/tune.mdx
@@ -22,6 +22,12 @@ Tune the default lease for the PKI secrets engine:
 $ vault secrets tune -default-lease-ttl=72h pki/
 ```
 
+Specify multiple audit non-hmac request keys:
+
+```shell-session
+$ vault secrets tune -audit-non-hmac-request-keys=value1 -audit-non-hmac-request-keys=value2 pki/
+```
+
 ## Usage
 
 The following flags are available in addition to the [standard set of


### PR DESCRIPTION
This doesn't rule out the possibility of actually accepting comma delimited lists, as the docs previously stated, but in the interim, the docs should at least be correct in describing the current behavior.

Closes https://github.com/hashicorp/vault/issues/9294