### PR TITLE
Auto renew token leases

### DIFF
--- a/auto-renewer/Dockerfile
+++ b/auto-renewer/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:latest
+RUN apt-get update 
+RUN apt-get install -y curl
+COPY script.sh /script.sh 
+COPY payload.json /payload.json
+RUN chmod +x script.sh
+RUN chmod +x payload.json
+ENTRYPOINT ["/script.sh"]

--- a/auto-renewer/payload.json
+++ b/auto-renewer/payload.json
@@ -1,0 +1,4 @@
+{
+   "token": "RENEW_TOKEN",
+   "increment": "INCREMENT_VALUE"
+}

--- a/auto-renewer/readme.md
+++ b/auto-renewer/readme.md
@@ -14,5 +14,5 @@
 - RENEW_TOKEN : The token which has to be renewed.
 - INCREMENT_VALUE : The duration of time by which the lease has to be extended. e.g. 3h, 755h.
 - ROOT_TOKEN : The root token of the vault, this is required by the vault to authorize the API request.
-- URL : The URL at which vault can be accessed by the Docker image inside the cronjob. This is required to make the API call for lease renewal.
+- URL : The url at which vault can be accessed by the Docker image inside the cronjob. This is required to make the API call for lease renewal.
 

--- a/auto-renewer/readme.md
+++ b/auto-renewer/readme.md
@@ -1,5 +1,6 @@
 # Auto renew token leases
-The maximum lease for a token other than a root token is 755 hours i.e. approximately 31 days. In case one wants to setup the tokens to be renewed without any intervention, a kubernetes cron job can be used.
+- The maximum lease for a token other than a root token is 755 hours i.e. approximately 31 days. 
+- In case one wants to setup the tokens to be renewed without any intervention, like say for a production env, a kubernetes cron job can be used.
 
 # How to use it
 - Build the Dockerfile
@@ -8,4 +9,10 @@ The maximum lease for a token other than a root token is 755 hours i.e. approxim
 # How it works
 - Dockerfile's entrypoint runs a script (script.sh)
 - The script makes an API call to vault server with the payload information like the token whose lease is to be renewed and the duration for which the lease has to be extended.
+
+# Info about the env vars of the Docker image
+- RENEW_TOKEN : The token which has to be renewed.
+- INCREMENT_VALUE : The duration of time by which the lease has to be extended. e.g. 3h, 755h.
+- ROOT_TOKEN : The root token of the vault, this is required by the vault to authorize the API request.
+- URL : The URL at which vault can be accessed by the Docker image inside the cronjob. This is required to make the API call for lease renewal.
 

--- a/auto-renewer/readme.md
+++ b/auto-renewer/readme.md
@@ -1,1 +1,11 @@
-A feature to auto renew token leases using a kubernetes cron job
+# Auto renew token leases
+The maximum lease for a token other than a root token is 755 hours i.e. approximately 31 days. In case one wants to setup the tokens to be renewed without any intervention, a kubernetes cron job can be used.
+
+# How to use it
+- Build the Dockerfile
+- Give appropriate env vars to the cron-job.yaml file
+
+# How it works
+- Dockerfile's entrypoint runs a script (script.sh)
+- The script makes an API call to vault server with the payload information like the token whose lease is to be renewed and the duration for which the lease has to be extended.
+

--- a/auto-renewer/readme.md
+++ b/auto-renewer/readme.md
@@ -1,0 +1,1 @@
+A feature to auto renew token leases using a kubernetes cron job

--- a/auto-renewer/script.sh
+++ b/auto-renewer/script.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+sed -i "s/RENEW_TOKEN/$RENEW_TOKEN/g" payload.json
+sed -i "s/INCREMENT_VALUE/$INCREMENT_VALUE/g" payload.json
+exec curl -L --header "X-Vault-Token: $ROOT_TOKEN" --request POST --data @payload.json http://$URL/v1/auth/token/renew

--- a/auto-renewer/vault-cron-job.yaml
+++ b/auto-renewer/vault-cron-job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cron
+spec:
+  schedule: "1 1 */28 * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: renew-vault-lease
+            image: "<<Build the image>>"
+            env:
+            - name: RENEW_TOKEN                                 
+              value: ""                       
+            - name: INCREMENT_VALUE
+              value: "740h"
+            - name: ROOT_TOKEN
+              value: ""
+            - name: URL
+              value: "<<URL of vault>>"
+          restartPolicy: OnFailure


### PR DESCRIPTION
- Tokens other than the root tokens have a maximum ttl of about 755 hours before which they must be renewed.
- This feature automatically renews the tokens through a cron job.
- Also gives option to specify duration for which lease has to be renewed.