### PR TITLE
Transit: update documentation strings

### DIFF
--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -17,7 +17,7 @@ func (b *backend) pathDecrypt() *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"name": &framework.FieldSchema{
 				Type:        framework.TypeString,
-				Description: "Name of the policy",
+				Description: "Name of the key",
 			},
 
 			"ciphertext": &framework.FieldSchema{

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -61,7 +61,7 @@ func (b *backend) pathEncrypt() *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"name": {
 				Type:        framework.TypeString,
-				Description: "Name of the policy",
+				Description: "Name of the key",
 			},
 
 			"plaintext": {


### PR DESCRIPTION
Update descriptions to match field content (the field is actually key name, not policy name).

As shown in the attached screen shot of API Explorer for Transit, the encrypt endpoint takes a key name, and the UI text appears to be pulling the **Description** field as  "Name of the policy" from the secrets engine instead of "Name of the key", which is what really goes in the field (i.e. "my-key").

<img width="1364" alt="Screen Shot 2020-09-23 at 12 18 40 PM" src="https://user-images.githubusercontent.com/77563/94040853-71d69a00-fd97-11ea-8e3e-ce9adea844f9.png">
