### PR TITLE
Logging tweaks, mostly for tests

### DIFF
--- a/helper/testhelpers/teststorage/teststorage.go
+++ b/helper/testhelpers/teststorage/teststorage.go
@@ -98,7 +98,7 @@ func MakeRaftBackend(t testing.T, coreIdx int, logger hclog.Logger) *vault.Physi
 		"performance_multiplier": "8",
 	}
 
-	backend, err := raft.NewRaftBackend(conf, logger)
+	backend, err := raft.NewRaftBackend(conf, logger.Named("raft"))
 	if err != nil {
 		cleanupFunc()
 		t.Fatal(err)

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -607,6 +607,7 @@ func (b *RaftBackend) SetupCluster(ctx context.Context, opts SetupOpts) error {
 			MaxPool:               3,
 			Timeout:               10 * time.Second,
 			ServerAddressProvider: b.serverAddressProvider,
+			Logger:                b.logger.Named("raft-net"),
 		}
 		transport := raft.NewNetworkTransportWithConfig(transConfig)
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -910,7 +910,8 @@ func (c *TestCluster) Cleanup() {
 		go func() {
 			defer wg.Done()
 			if err := lc.stop(); err != nil {
-				// TODO do we care about this?
+				// Note that this log won't be seen if using TestLogger, due to
+				// the above call to StopLogging.
 				lc.Logger().Error("error during cleanup", "error", err)
 			}
 		}()


### PR DESCRIPTION
Fix some places where raft wasn't hooking into the core logger as it should.

Revisited the code that was setting the log level to Error during test cluster cleanup: it's normal for there to be a bunch of errors then, which makes it harder to see what went wrong up to the point where the test was deemed to have failed.  So now, instead of setting log level to Error, we actually stop logging altogether.  This only applies if the test didn't pass in its own logger during cluster creation, but we should be moving away from that anyway.