### PR TITLE
Changed behavior of LDAP helper to have a 10s timeout per url

### DIFF
--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -406,8 +406,6 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
-google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -46,7 +46,7 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 			if port == "" {
 				port = "389"
 			}
-			conn, err = c.LDAP.Dial(uut)
+			conn, err = c.LDAP.Dial("tcp", uut)
 			if err != nil {
 				break
 			}
@@ -69,7 +69,7 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 			if err != nil {
 				break
 			}
-			conn, err = c.LDAP.DialTLS(uut, tlsConfig)
+			conn, err = c.LDAP.DialTLS("tcp", uut, tlsConfig)
 		default:
 			retErr = multierror.Append(retErr, fmt.Errorf("invalid LDAP scheme in url %q", net.JoinHostPort(host, port)))
 			continue

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -46,7 +46,7 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 			if port == "" {
 				port = "389"
 			}
-			conn, err = c.LDAP.Dial("tcp", net.JoinHostPort(host, port))
+			conn, err = c.LDAP.Dial(uut)
 			if err != nil {
 				break
 			}
@@ -69,7 +69,7 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 			if err != nil {
 				break
 			}
-			conn, err = c.LDAP.DialTLS("tcp", net.JoinHostPort(host, port), tlsConfig)
+			conn, err = c.LDAP.DialTLS(uut, tlsConfig)
 		default:
 			retErr = multierror.Append(retErr, fmt.Errorf("invalid LDAP scheme in url %q", net.JoinHostPort(host, port)))
 			continue
@@ -77,7 +77,7 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 		if err == nil {
 			if retErr != nil {
 				if c.Logger.IsDebug() {
-					c.Logger.Debug("errors connecting to some hosts: %s", retErr.Error())
+					c.Logger.Debug("errors connecting to some hosts", "error", retErr.Error())
 				}
 			}
 			retErr = nil

--- a/sdk/helper/ldaputil/ldap.go
+++ b/sdk/helper/ldaputil/ldap.go
@@ -15,18 +15,18 @@ func NewLDAP() LDAP {
 // LDAP provides ldap functionality, but through an interface
 // rather than statically. This allows faking it for tests.
 type LDAP interface {
-	Dial(addr string) (Connection, error)
-	DialTLS(addr string, config *tls.Config) (Connection, error)
+	Dial(network string, addr string) (Connection, error)
+	DialTLS(network string, addr string, config *tls.Config) (Connection, error)
 }
 
 type ldapIfc struct{}
 
-func (l *ldapIfc) Dial(addr string) (Connection, error) {
+func (l *ldapIfc) Dial(_network string, addr string) (Connection, error) {
 	dialer := ldap.DialWithDialer(&net.Dialer{Timeout: 10 * time.Second})
 	return ldap.DialURL(addr, dialer)
 }
 
-func (l *ldapIfc) DialTLS(addr string, config *tls.Config) (Connection, error) {
+func (l *ldapIfc) DialTLS(_network string, addr string, config *tls.Config) (Connection, error) {
 	tlsOpts := ldap.DialWithTLSConfig(config)
 	dialer := ldap.DialWithDialer(&net.Dialer{Timeout: 10 * time.Second})
 	return ldap.DialURL(addr, dialer, tlsOpts)


### PR DESCRIPTION
This involved updating the Dial and DialTLS methods to use the `net.DialUrl` method. This also allowed us to move away from deprecated methods.