### PR TITLE
Add encode & decode operations to base62 helper

### DIFF
--- a/sdk/helper/base62/base62.go
+++ b/sdk/helper/base62/base62.go
@@ -4,13 +4,17 @@ package base62
 
 import (
 	"crypto/rand"
+	"errors"
 	"io"
+	"math/big"
+	"strings"
 
 	uuid "github.com/hashicorp/go-uuid"
 )
 
 const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 const csLen = byte(len(charset))
+var csLenBig = big.NewInt(int64(len(charset)))
 
 // Random generates a random string using base-62 characters.
 // Resulting entropy is ~5.95 bits/character.
@@ -47,4 +51,44 @@ func RandomWithReader(length int, reader io.Reader) (string, error) {
 			}
 		}
 	}
+}
+
+// Encode encodes bytes to base62.
+func Encode(src []byte) string {
+	if src == nil {
+		return ""
+	}
+
+	var b string
+
+	var zero big.Int
+	var rem big.Int
+	var x big.Int
+	x.SetBytes(src)
+
+	for x.Cmp(&zero) > 0 {
+		x.DivMod(&x, csLenBig, &rem)
+		b = string(charset[int(rem.Int64())]) + b
+	}
+	return b
+}
+
+// Decode decodes a base62 string into bytes
+func DecodeString(src string) ([]byte, error) {
+	var num big.Int
+	var x big.Int
+	var y big.Int
+	strlen := len(src)
+	for i, c := range src {
+		idx := strings.IndexRune(charset, c)
+		if idx < 0 {
+			return nil, errors.New("invalid base62 character")
+		}
+		y.SetInt64(int64(strlen - (i + 1)))
+		y.Exp(csLenBig, &y, nil)
+		x.SetInt64(int64(idx))
+		x.Mul(&x, &y)
+		num.Add(&num, &x)
+	}
+	return num.Bytes(), nil
 }

--- a/sdk/helper/base62/base62_test.go
+++ b/sdk/helper/base62/base62_test.go
@@ -29,3 +29,30 @@ func TestRandom(t *testing.T) {
 		}
 	}
 }
+
+func TestDecode(t *testing.T) {
+	str := "A fairly simple test"
+	e := Encode([]byte(str))
+	b, err := Decode(e)
+
+	if err != nil {
+		t.Fail()
+	}
+	if string(b) != str {
+		t.Fail()
+	}
+
+	// A slightly harder test
+	str,err = Random(200)
+	if err != nil {
+		t.Fail()
+	}
+	b, err = Decode(str)
+	if err != nil {
+		t.Fail()
+	}
+	e = Encode(b)
+	if e != str {
+		t.Fail()
+	}
+}

--- a/vendor/github.com/hashicorp/vault/sdk/helper/base62/base64_test.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/base62/base64_test.go
@@ -1,0 +1,1 @@
+package base62


### PR DESCRIPTION
Use bit.Int to implement base62 encoding/decoding.