### PR TITLE
Backport 1.5.x: Use us-gov-west-1 for global APIs in aws-us-gov

### DIFF
--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -319,10 +319,19 @@ func generatePartitionToRegionMap() map[string]*endpoints.Region {
 
 	for _, p := range partitions {
 		// For most partitions, it's fine to choose a single region randomly.
-		// However, for the "aws" partition, it's best to choose "us-east-1"
-		// because it is always enabled (and enabled for STS) by default.
+		// However, there are a few exceptions:
+		//
+		//   For "aws", choose "us-east-1" because it is always enabled (and
+		//   enabled for STS) by default.
+		//
+		//   For "aws-us-gov", choose "us-gov-west-1" because it is the only
+		//   valid region for IAM operations.
+		//   ref: https://github.com/aws/aws-sdk-go/blob/v1.34.25/aws/endpoints/defaults.go#L8176-L8194
 		for _, r := range p.Regions() {
 			if p.ID() == "aws" && r.ID() != "us-east-1" {
+				continue
+			}
+			if p.ID() == "aws-us-gov" && r.ID() != "us-gov-west-1" {
 				continue
 			}
 			partitionToRegion[p.ID()] = &r

--- a/builtin/credential/aws/backend_test.go
+++ b/builtin/credential/aws/backend_test.go
@@ -1819,4 +1819,7 @@ func TestGeneratePartitionToRegionMap(t *testing.T) {
 	if m["aws"].ID() != "us-east-1" {
 		t.Fatal("expected us-east-1 but received " + m["aws"].ID())
 	}
+	if m["aws-us-gov"].ID() != "us-gov-west-1" {
+		t.Fatal("expected us-gov-west-1 but received " + m["aws-us-gov"].ID())
+	}
 }


### PR DESCRIPTION
Backport of #9947

* Use us-gov-west-1 for global APIs in aws-us-gov

Certain partition-global AWS services, like IAM, seem to require
specific regions. In the regular 'aws' partition, this is us-east-1. In
the 'aws-us-gov' partition, this is us-gov-west-1. Providing
us-gov-east-1 returns an error from AWS:

  SignatureDoesNotMatch: Credential should be scoped to a valid region, not 'us-gov-east-1'.

This resolves a problem where AWS authentication could randomly fail
depending on the value cached by Vault at startup.