### PR TITLE
Add command for windows10 users

### DIFF
--- a/website/pages/docs/secrets/ssh/signed-ssh-certificates.mdx
+++ b/website/pages/docs/secrets/ssh/signed-ssh-certificates.mdx
@@ -169,9 +169,16 @@ the client's local workstation.
 
 1.  Save the resulting signed, public key to disk. Limit permissions as needed.
 
+    On Linux host:
     ```text
     $ vault write -field=signed_key ssh-client-signer/sign/my-role \
         public_key=@$HOME/.ssh/id_rsa.pub > signed-cert.pub
+    ```
+    
+    On Windows host (Force the UTF-8 encoding):
+    ```text
+    $ vault write -field=signed_key ssh-client-signer/sign/my-role \
+        public_key=@$HOME\.ssh\id_rsa.pub | out-file -encoding utf8 signed-cert.pub
     ```
 
     If you are saving the certificate directly beside your SSH keypair, suffix


### PR DESCRIPTION
By default the encoding format is `UTF-16 LE` on windows host.

The commande line `SSH` doesn't like it:
```bash
$ ssh -i .\signed-cert.pub -i ~\.ssh\id_rsa ubuntu@<server_ip>
# in the command result
Load key ".\signed-cert.pub": invalid format
```