### PR TITLE
Reworded disable_mlock docs

### DIFF
--- a/website/pages/docs/configuration/index.mdx
+++ b/website/pages/docs/configuration/index.mdx
@@ -74,9 +74,9 @@ to specify where the configuration is.
 
 - `disable_mlock` `(bool: false)` – Disables the server from executing the
   `mlock` syscall. `mlock` prevents memory from being swapped to disk. Disabling
-  `mlock` is not recommended in production, but is fine for local development
-  and testing. This can also be provided via the environment variable 
-  `VAULT_DISABLE_MLOCK`.
+  `mlock` is not recommended unless using [integrated storage](/docs/internals/integrated-storage).
+  Follow the additional security precautions outlined below when disabling `mlock`.
+  This can also be provided via the environment variable `VAULT_DISABLE_MLOCK`.
 
   Disabling `mlock` is not recommended unless the systems running Vault only
   use encrypted swap or do not use swap at all. Vault only supports memory


### PR DESCRIPTION
Reworded disable_mlock to remove confusion regarding what is acceptable for production deployments.  Disabling mlock is alright for production given the additional security recommendations are implemented.  Disabling mlock is also recommended for integrated storage