### PR TITLE
Backport 1.5.x - Conditionally overwrite TLS parameters for MySQL secrets engine (#9729)

### DIFF
--- a/plugins/database/mysql/connection_producer.go
+++ b/plugins/database/mysql/connection_producer.go
@@ -218,7 +218,9 @@ func (c *mySQLConnectionProducer) addTLStoDSN() (connURL string, err error) {
 		return "", fmt.Errorf("unable to parse connectionURL: %s", err)
 	}
 
-	config.TLSConfig = c.tlsConfigName
+	if len(c.tlsConfigName) > 0 {
+		config.TLSConfig = c.tlsConfigName
+	}
 
 	connURL = config.FormatDSN()
 

--- a/plugins/database/mysql/connection_producer_test.go
+++ b/plugins/database/mysql/connection_producer_test.go
@@ -45,6 +45,11 @@ func Test_addTLStoDSN(t *testing.T) {
 			tlsConfigName:  "tlsTest101",
 			expectedResult: "user:pa?ssword?@tcp(localhost:3306)/test?tls=tlsTest101&foo=bar",
 		},
+		"tls, valid tls parameter in query string": {
+			rootUrl:        "user:password@tcp(localhost:3306)/test?tls=true",
+			tlsConfigName:  "",
+			expectedResult: "user:password@tcp(localhost:3306)/test?tls=true",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
* Conditionally overwrite TLS parameters in MySQL DSN

Overwrite MySQL TLS configuration in MySQL DSN only if have `tls_ca` or `tls_certificate_key` set
Current logic always overwrites it

* Add test for MySQL DSN with a valid TLS parameter in query string