### PR TITLE
Flaky Test Fix: TestSink [VAULT-720]

### DIFF
--- a/command/agent/sink/file/sink_test.go
+++ b/command/agent/sink/file/sink_test.go
@@ -47,18 +47,6 @@ func TestSinkServer(t *testing.T) {
 	})
 	defer timer.Stop()
 
-	// Solution to sink problem: The code commented out below selects the appropriate case; whether ctx.Done,
-	// or errCh returns. In the case that errCh returns BECAUSE ctx.Done() is hit, we get a race condition,
-	// where depending on which case returns first we either err, or succeed. We should explicitly check for
-	// errors instead like in the following block. I think this change will need to proliferate everywhere
-	// in the following PR: https://github.com/hashicorp/vault/pull/9670
-
-	// select {
-	// case <-ctx.Done():
-	// case err := <-errCh:
-	// 	t.Fatal(err)
-	// }
-
 	select {
 	case err := <-errCh:
 		if err != nil {

--- a/command/agent/sink/sink.go
+++ b/command/agent/sink/sink.go
@@ -85,8 +85,6 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 
 		if currSink.DHType != "" {
 			if currToken, err = currSink.encryptToken(currToken); err != nil {
-				// fmt.Println("here!!!")
-				ss.logger.Info("here!!!")
 				return err
 			}
 		}

--- a/command/agent/sink/sink.go
+++ b/command/agent/sink/sink.go
@@ -73,18 +73,24 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 	latestToken := new(string)
 	writeSink := func(currSink *SinkConfig, currToken string) error {
 		if currToken != *latestToken {
+			ss.logger.Info("here!")
+			// fmt.Println("here!")
 			return nil
 		}
 		var err error
 
 		if currSink.WrapTTL != 0 {
 			if currToken, err = currSink.wrapToken(ss.client, currSink.WrapTTL, currToken); err != nil {
+				// fmt.Println("here!!")
+				ss.logger.Info("here!!")
 				return err
 			}
 		}
 
 		if currSink.DHType != "" {
 			if currToken, err = currSink.encryptToken(currToken); err != nil {
+				// fmt.Println("here!!!")
+				ss.logger.Info("here!!!")
 				return err
 			}
 		}
@@ -109,6 +115,8 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 	for {
 		select {
 		case <-ctx.Done():
+			// fmt.Println("here!!!!")
+			ss.logger.Info("here!!!!") // this is the issue
 			return nil
 
 		case token := <-incoming:
@@ -144,6 +152,8 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 			atomic.AddInt32(ss.remaining, -1)
 			select {
 			case <-ctx.Done():
+				// fmt.Println("here!!!!!")
+				ss.logger.Info("here!!!!!")
 				return nil
 			default:
 			}
@@ -153,6 +163,8 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 				ss.logger.Error("error returned by sink function, retrying", "error", err, "backoff", backoff.String())
 				select {
 				case <-ctx.Done():
+					// fmt.Println("here!!!!!!")
+					ss.logger.Info("here!!!!!!")
 					return nil
 				case <-time.After(backoff):
 					atomic.AddInt32(ss.remaining, 1)
@@ -160,6 +172,8 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 				}
 			} else {
 				if atomic.LoadInt32(ss.remaining) == 0 && ss.exitAfterAuth {
+					// fmt.Println("here!!!!!!!")
+					ss.logger.Info("here!!!!!!!")
 					return nil
 				}
 			}

--- a/command/agent/sink/sink.go
+++ b/command/agent/sink/sink.go
@@ -73,16 +73,12 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 	latestToken := new(string)
 	writeSink := func(currSink *SinkConfig, currToken string) error {
 		if currToken != *latestToken {
-			ss.logger.Info("here!")
-			// fmt.Println("here!")
 			return nil
 		}
 		var err error
 
 		if currSink.WrapTTL != 0 {
 			if currToken, err = currSink.wrapToken(ss.client, currSink.WrapTTL, currToken); err != nil {
-				// fmt.Println("here!!")
-				ss.logger.Info("here!!")
 				return err
 			}
 		}
@@ -115,8 +111,6 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 	for {
 		select {
 		case <-ctx.Done():
-			// fmt.Println("here!!!!")
-			ss.logger.Info("here!!!!") // this is the issue
 			return nil
 
 		case token := <-incoming:
@@ -152,8 +146,6 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 			atomic.AddInt32(ss.remaining, -1)
 			select {
 			case <-ctx.Done():
-				// fmt.Println("here!!!!!")
-				ss.logger.Info("here!!!!!")
 				return nil
 			default:
 			}
@@ -163,8 +155,6 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 				ss.logger.Error("error returned by sink function, retrying", "error", err, "backoff", backoff.String())
 				select {
 				case <-ctx.Done():
-					// fmt.Println("here!!!!!!")
-					ss.logger.Info("here!!!!!!")
 					return nil
 				case <-time.After(backoff):
 					atomic.AddInt32(ss.remaining, 1)
@@ -172,8 +162,6 @@ func (ss *SinkServer) Run(ctx context.Context, incoming chan string, sinks []*Si
 				}
 			} else {
 				if atomic.LoadInt32(ss.remaining) == 0 && ss.exitAfterAuth {
-					// fmt.Println("here!!!!!!!")
-					ss.logger.Info("here!!!!!!!")
 					return nil
 				}
 			}


### PR DESCRIPTION
This PR is a fix for the following test failure in CI: https://app.circleci.com/pipelines/github/hashicorp/vault/12546/workflows/de56ebec-c308-401f-b5d8-3d30125e6c8c/jobs/86309

The flakiness comes from the fact that ctx.Done() is checked in the Run function of sink.go. If ctx.Done(), then a nil error is returned. Therefore, testSink had nondeterministic behavior, depending on whether the Run routine first saw that ctx.Done() had finished, or whether the test itself did. 

Associated PR: https://github.com/hashicorp/vault/pull/9670/files#diff-4b75904a0327b9ea5cd107a225c2fda4R51