### PR TITLE
Mask LDAP bindpass while typing

### DIFF
--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -129,8 +129,7 @@
   }}
 {{else if (eq attr.options.sensitive true)}}
   <MaskedInput @value={{or (get model valuePath) attr.options.defaultValue}} @placeholder="" @allowCopy="true"
-    @onChange={{action (action "setAndBroadcast" valuePath)}} />
-
+    @onChange={{action (action "setAndBroadcast" valuePath)}} @maskWhileTyping={{if (eq attr.name "bindpass") true}}/>
 {{else if (or (eq attr.type "number") (eq attr.type "string"))}}
   <div class="control">
     {{#if (eq attr.options.editType "textarea")}}

--- a/ui/lib/core/addon/templates/components/masked-input.hbs
+++ b/ui/lib/core/addon/templates/components/masked-input.hbs
@@ -9,7 +9,7 @@
       type={{if isMasked "password" "text"}}
       value={{value}}
       onchange={{action "updateValue"}}
-      class="input is"
+      class="input"
       data-test-input
     />
   {{else}}

--- a/ui/lib/core/addon/templates/components/masked-input.hbs
+++ b/ui/lib/core/addon/templates/components/masked-input.hbs
@@ -10,7 +10,7 @@
       value={{value}}
       onchange={{action "updateValue"}}
       class="input is"
-      data-test-password={{true}}
+      data-test-input
     />
   {{else}}
     <textarea class="input masked-value" rows=1 wrap="off" placeholder={{placeholder}}

--- a/ui/lib/core/addon/templates/components/masked-input.hbs
+++ b/ui/lib/core/addon/templates/components/masked-input.hbs
@@ -2,6 +2,16 @@
   data-test-masked-input data-test-field>
   {{#if displayOnly}}
     <pre class="masked-value display-only is-word-break">{{displayValue}}</pre>
+  {{else if maskWhileTyping}}
+    <input
+      autocomplete="off"
+      spellcheck="false"
+      type={{if isMasked "password" "text"}}
+      value={{value}}
+      onchange={{action "updateValue"}}
+      class="input is"
+      data-test-password={{true}}
+    />
   {{else}}
     <textarea class="input masked-value" rows=1 wrap="off" placeholder={{placeholder}}
       onfocus={{action (mut isFocused) true}} onblur={{action (mut isFocused) false}} onkeydown={{action onKeyDown}}

--- a/ui/tests/integration/components/masked-input-test.js
+++ b/ui/tests/integration/components/masked-input-test.js
@@ -22,6 +22,7 @@ module('Integration | Component | masked input', function(hooks) {
 
   test('it renders a textarea', async function(assert) {
     await render(hbs`{{masked-input}}`);
+
     assert.ok(component.textareaIsPresent);
   });
 

--- a/ui/tests/integration/components/masked-input-test.js
+++ b/ui/tests/integration/components/masked-input-test.js
@@ -22,8 +22,17 @@ module('Integration | Component | masked input', function(hooks) {
 
   test('it renders a textarea', async function(assert) {
     await render(hbs`{{masked-input}}`);
-
     assert.ok(component.textareaIsPresent);
+  });
+
+  test('it renders an input with type password when maskWhileTyping is true', async function(assert) {
+    await render(hbs`{{masked-input maskWhileTyping=true}}`);
+    assert.ok(component.inputIsPresent);
+    assert.equal(
+      this.element.querySelector('input').getAttribute('type'),
+      'password',
+      'default type equals password'
+    );
   });
 
   test('it does not render a textarea when displayOnly is true', async function(assert) {
@@ -84,5 +93,17 @@ module('Integration | Component | masked input', function(hooks) {
     await component.toggleMasked();
 
     assert.ok(hasClass(component.wrapperClass, 'masked'));
+  });
+
+  test('it changes type to text when unmasked button is clicked', async function(assert) {
+    this.set('value', 'value');
+    await render(hbs`{{masked-input value=value maskWhileTyping=true}}`);
+    await component.toggleMasked();
+
+    assert.equal(
+      this.element.querySelector('input').getAttribute('type'),
+      'text',
+      'when unmasked type changes to text'
+    );
   });
 });

--- a/ui/tests/pages/components/masked-input.js
+++ b/ui/tests/pages/components/masked-input.js
@@ -5,6 +5,7 @@ export default {
   wrapperClass: attribute('class', '[data-test-masked-input]'),
   enterText: fillable('[data-test-textarea]'),
   textareaIsPresent: isPresent('[data-test-textarea]'),
+  inputIsPresent: isPresent('[data-test-input]'),
   copyButtonIsPresent: isPresent('[data-test-copy-button]'),
   toggleMasked: clickable('[data-test-button]'),
   async focusField() {


### PR DESCRIPTION
This PR addresses a request to mask the LDAP bindpass field while typing.  This field is generated by the `masked-input` component, which uses a `textArea` html element.  However, to effectively mask the field while typing we needed to change the element to `input` and add `type=password` (see screenshot and MDN docs [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)).

![image](https://user-images.githubusercontent.com/6618863/95135273-64b79480-0721-11eb-80b8-d8645a75f8e2.png)

Before -with the `textArea` element- you could enter a multi-line password for bindpass.  However, given that bindpass is defined as a password field in the LDAP [API docs ](https://www.vaultproject.io/docs/auth/ldap) we felt it safe to go ahead and change this to a single-line input field. 

There are similar requests for the value field in the KV secret engine.  Right now, this component will only show the input field when the name is `bindpass` but if we later determine to add other fields we can add a list of them in the `masked-input` javascript file and pass a computed property to the new `maskWhileTyping` property.

See gif
![ldap](https://user-images.githubusercontent.com/6618863/95135831-469e6400-0722-11eb-807a-bfbbf157d50f.gif)

*You'll notice the browser warning in the gif.  I tried a variety of suggestions for preventing this, but ultimately this is a browser setting and not something we can safely prevent when we use `type=password`.  I tried as[ suggested here](https://stackoverflow.com/questions/41217019/how-to-prevent-a-browser-from-storing-passwords) turning the input field to readonly and readonly=false onfocus, but that did not work.  
