### PR TITLE
Adding note about commands that are root only

### DIFF
--- a/website/pages/docs/enterprise/namespaces/index.mdx
+++ b/website/pages/docs/enterprise/namespaces/index.mdx
@@ -60,6 +60,21 @@ For example, these three requests are equivalent:
 2. Path: `secret/foo`, Header: `X-Vault-Namespace: ns1/ns2/`
 3. Path: `ns2/secret/foo`, Header: `X-Vault-Namespace: ns1/`
 
+## Root only API Paths
+
+There are certain API paths that can only be called from the root namespace:
+
+* `sys/init`
+* `sys/license`
+* `sys/leader`
+* `sys/health`
+* `sys/metrics`
+* `sys/config/state`
+* `sys/host-info`
+* `sys/key-status`
+* `sys/storage`
+* `sys/storage/raft`
+
 ## Architecture
 
 Namespaces are isolated environments that functionally exist as "Vaults within a Vault."


### PR DESCRIPTION
* We don’t specifically note anywhere that these 
have to be run from root, so makes sense to add