### PR TITLE
Fix panic in RekeyVerifyRestart (#9930)

### DIFF
--- a/vault/rekey.go
+++ b/vault/rekey.go
@@ -949,14 +949,18 @@ func (c *Core) RekeyVerifyRestart(recovery bool) logical.HTTPCodedError {
 
 	// Clear any progress or config
 	if recovery {
-		c.recoveryRekeyConfig.VerificationProgress = nil
-		if nonceErr == nil {
-			c.recoveryRekeyConfig.VerificationNonce = nonce
+		if c.recoveryRekeyConfig != nil {
+			c.recoveryRekeyConfig.VerificationProgress = nil
+			if nonceErr == nil {
+				c.recoveryRekeyConfig.VerificationNonce = nonce
+			}
 		}
 	} else {
-		c.barrierRekeyConfig.VerificationProgress = nil
-		if nonceErr == nil {
-			c.barrierRekeyConfig.VerificationNonce = nonce
+		if c.barrierRekeyConfig != nil {
+			c.barrierRekeyConfig.VerificationProgress = nil
+			if nonceErr == nil {
+				c.barrierRekeyConfig.VerificationNonce = nonce
+			}
 		}
 	}
 


### PR DESCRIPTION
A panic occurs if recoveryRekeyConfig or barrierRekeyConfig is a nil pointer in RekeyVerifyRestart. Added a small nil check.

