### PR TITLE
Add plugin reload docs to the website sidebar

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -152,7 +152,7 @@ export default [
       'path-help',
       {
         category: 'plugin',
-        content: ['deregister', 'info', 'list', 'register'],
+        content: ['deregister', 'info', 'list', 'register', 'reload'],
       },
       {
         category: 'policy',

--- a/website/pages/docs/commands/plugin/reload.mdx
+++ b/website/pages/docs/commands/plugin/reload.mdx
@@ -33,3 +33,6 @@ flags](/docs/commands) included on all commands.
 
 - `-mounts` `(array: [])` - Array or comma-separated string mount paths of the
   plugin backends to reload.
+
+- `-scope` `(string: "")` - The scope of the reload, omitted for local, 'global'
+  for replicated reloads.

--- a/website/pages/docs/commands/plugin/reload.mdx
+++ b/website/pages/docs/commands/plugin/reload.mdx
@@ -34,5 +34,5 @@ flags](/docs/commands) included on all commands.
 - `-mounts` `(array: [])` - Array or comma-separated string mount paths of the
   plugin backends to reload.
 
-- `-scope` `(string: "")` - The scope of the reload, omitted for local, 'global'
-  for replicated reloads.
+- `-scope` `(string: "")` - The scope of the reload. For local reloads, omit this flag.
+  For reloads that span multiple Vault clusters, use `global`.


### PR DESCRIPTION
They weren't in the sidebar, and the `-scope` flag was also missing, so I added that.