### PR TITLE
Update ad plugin to v0.6.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/hashicorp/vault-plugin-database-elasticsearch v0.5.4
 	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.1.2
 	github.com/hashicorp/vault-plugin-mock v0.16.1
-	github.com/hashicorp/vault-plugin-secrets-ad v0.6.6
+	github.com/hashicorp/vault-plugin-secrets-ad v0.6.7
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.5.5
 	github.com/hashicorp/vault-plugin-secrets-azure v0.6.2
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.6.4

--- a/go.sum
+++ b/go.sum
@@ -548,6 +548,8 @@ github.com/hashicorp/vault-plugin-mock v0.16.1 h1:5QQvSUHxDjEEbrd2REOeacqyJnCLPD
 github.com/hashicorp/vault-plugin-mock v0.16.1/go.mod h1:83G4JKlOwUtxVourn5euQfze3ZWyXcUiLj2wqrKSDIM=
 github.com/hashicorp/vault-plugin-secrets-ad v0.6.6 h1:GskxrCCL2flrBtnAeOsBV+whCaqnnM/+t/h1IyqukNo=
 github.com/hashicorp/vault-plugin-secrets-ad v0.6.6/go.mod h1:L5L6NoJFxRvgxhuA2sWhloc3sbgmE7KxhNcoRxcaH9U=
+github.com/hashicorp/vault-plugin-secrets-ad v0.6.7 h1:Q7PoUKfbZCep3ZkIf+aFR9UzVuqa7bwVN6xX5pX6bFs=
+github.com/hashicorp/vault-plugin-secrets-ad v0.6.7/go.mod h1:L5L6NoJFxRvgxhuA2sWhloc3sbgmE7KxhNcoRxcaH9U=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.5.5 h1:BOOtSls+BQ1EtPmpE9LoqZztsEZ1fRWVSkHWtRIrCB4=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.5.5/go.mod h1:gAoReoUpBHaBwkxQqTK7FY8nQC0MuaZHLiW5WOSny5g=
 github.com/hashicorp/vault-plugin-secrets-azure v0.6.2 h1:+7UdgMNUKriemf/UPUotfX3aNE82zB3UuWWWUO09PkQ=

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-ad/plugin/config.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-ad/plugin/config.go
@@ -18,37 +18,37 @@ type passwordConf struct {
 	MaxTTL int `json:"max_ttl"`
 
 	// Mutually exclusive with Length and Formatter
-	PolicyName string `json:"password_policy"`
+	PasswordPolicy string `json:"password_policy"`
 
-	// Length of the password to generate. Mutually exclusive with PolicyName.
+	// Length of the password to generate. Mutually exclusive with PasswordPolicy.
 	// Deprecated
 	Length int `json:"length"`
 
 	// Formatter describes how to format a password. This allows for prefixes and suffixes on the password.
-	// Mutually exclusive with PolicyName.
+	// Mutually exclusive with PasswordPolicy.
 	// Deprecated
 	Formatter string `json:"formatter"`
 }
 
 func (c passwordConf) Map() map[string]interface{} {
 	return map[string]interface{}{
-		"ttl":         c.TTL,
-		"max_ttl":     c.MaxTTL,
-		"length":      c.Length,
-		"formatter":   c.Formatter,
-		"policy_name": c.PolicyName,
+		"ttl":             c.TTL,
+		"max_ttl":         c.MaxTTL,
+		"length":          c.Length,
+		"formatter":       c.Formatter,
+		"password_policy": c.PasswordPolicy,
 	}
 }
 
 // validate returns an error if the configuration is invalid/unable to process for whatever reason.
 func (c passwordConf) validate() error {
-	if c.PolicyName != "" &&
+	if c.PasswordPolicy != "" &&
 		(c.Length != 0 || c.Formatter != "") {
 		return fmt.Errorf("cannot set password_policy and either length or formatter")
 	}
 
-	// Don't validate the length and formatter fields if a policy is set
-	if c.PolicyName != "" {
+	// Don't PasswordPolicy the length and formatter fields if a policy is set
+	if c.PasswordPolicy != "" {
 		return nil
 	}
 

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-ad/plugin/passwords.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-ad/plugin/passwords.go
@@ -27,8 +27,8 @@ func GeneratePassword(ctx context.Context, passConf passwordConf, generator pass
 		return "", err
 	}
 
-	if passConf.PolicyName != "" {
-		return generator.GeneratePasswordFromPolicy(ctx, passConf.PolicyName)
+	if passConf.PasswordPolicy != "" {
+		return generator.GeneratePasswordFromPolicy(ctx, passConf.PasswordPolicy)
 	}
 	return generateDeprecatedPassword(passConf.Formatter, passConf.Length)
 }

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-ad/plugin/path_config.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-ad/plugin/path_config.go
@@ -143,11 +143,11 @@ func (b *backend) configUpdateOperation(ctx context.Context, req *logical.Reques
 	}
 
 	passwordConf := passwordConf{
-		TTL:        ttl,
-		MaxTTL:     maxTTL,
-		Length:     length,
-		Formatter:  formatter,
-		PolicyName: passwordPolicy,
+		TTL:            ttl,
+		MaxTTL:         maxTTL,
+		Length:         length,
+		Formatter:      formatter,
+		PasswordPolicy: passwordPolicy,
 	}
 	err = passwordConf.validate()
 	if err != nil {

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-ad/plugin/path_rotate_root_creds.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-ad/plugin/path_rotate_root_creds.go
@@ -16,7 +16,17 @@ func (b *backend) pathRotateCredentials() *framework.Path {
 	return &framework.Path{
 		Pattern: "rotate-root",
 		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback:                    b.pathRotateCredentialsUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
 			logical.ReadOperation: &framework.PathOperation{
+				Callback:                    b.pathRotateCredentialsUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
 				Callback:                    b.pathRotateCredentialsUpdate,
 				ForwardPerformanceStandby:   true,
 				ForwardPerformanceSecondary: true,

--- a/vendor/github.com/hashicorp/vault/api/README.md
+++ b/vendor/github.com/hashicorp/vault/api/README.md
@@ -1,0 +1,6 @@
+Vault API
+=================
+
+This provides the `github.com/hashicorp/vault/api` package which contains code useful for interacting with a Vault server.
+
+[![GoDoc](https://godoc.org/github.com/hashicorp/vault/api?status.png)](https://godoc.org/github.com/hashicorp/vault/api)

--- a/vendor/github.com/hashicorp/vault/sdk/database/newdbplugin/testing/test_helpers.go
+++ b/vendor/github.com/hashicorp/vault/sdk/database/newdbplugin/testing/test_helpers.go
@@ -1,0 +1,85 @@
+package dbtesting
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/database/newdbplugin"
+)
+
+func getRequestTimeout(t *testing.T) time.Duration {
+	rawDur := os.Getenv("VAULT_TEST_DATABASE_REQUEST_TIMEOUT")
+	if rawDur == "" {
+		return 2 * time.Second
+	}
+
+	dur, err := time.ParseDuration(rawDur)
+	if err != nil {
+		t.Fatalf("Failed to parse custom request timeout %q: %s", rawDur, err)
+	}
+	return dur
+}
+
+func AssertInitialize(t *testing.T, db newdbplugin.Database, req newdbplugin.InitializeRequest) newdbplugin.InitializeResponse {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), getRequestTimeout(t))
+	defer cancel()
+
+	resp, err := db.Initialize(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to initialize: %s", err)
+	}
+	return resp
+}
+
+func AssertNewUser(t *testing.T, db newdbplugin.Database, req newdbplugin.NewUserRequest) newdbplugin.NewUserResponse {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), getRequestTimeout(t))
+	defer cancel()
+
+	resp, err := db.NewUser(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to create new user: %s", err)
+	}
+
+	if resp.Username == "" {
+		t.Fatalf("Missing username from NewUser response")
+	}
+	return resp
+}
+
+func AssertUpdateUser(t *testing.T, db newdbplugin.Database, req newdbplugin.UpdateUserRequest) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), getRequestTimeout(t))
+	defer cancel()
+
+	_, err := db.UpdateUser(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to update user: %s", err)
+	}
+}
+
+func AssertDeleteUser(t *testing.T, db newdbplugin.Database, req newdbplugin.DeleteUserRequest) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), getRequestTimeout(t))
+	defer cancel()
+
+	_, err := db.DeleteUser(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to delete user %q: %s", req.Username, err)
+	}
+}
+
+func AssertClose(t *testing.T, db newdbplugin.Database) {
+	t.Helper()
+	err := db.Close()
+	if err != nil {
+		t.Fatalf("Failed to close database: %s", err)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -489,7 +489,7 @@ github.com/hashicorp/vault-plugin-database-elasticsearch
 github.com/hashicorp/vault-plugin-database-mongodbatlas
 # github.com/hashicorp/vault-plugin-mock v0.16.1
 github.com/hashicorp/vault-plugin-mock
-# github.com/hashicorp/vault-plugin-secrets-ad v0.6.6
+# github.com/hashicorp/vault-plugin-secrets-ad v0.6.7
 github.com/hashicorp/vault-plugin-secrets-ad/plugin
 github.com/hashicorp/vault-plugin-secrets-ad/plugin/client
 github.com/hashicorp/vault-plugin-secrets-ad/plugin/util


### PR DESCRIPTION
A small bug was found in `ad/config` where `password_policy` had the wrong key name when the config was read. https://github.com/hashicorp/vault-plugin-secrets-ad/pull/71

`go mod vendor` pulled in other things which seem to be missing from the repo.