### PR TITLE
docker-dev: add go version as build arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,12 @@ dev-dynamic-mem: BUILD_TAGS+=memprofiler
 dev-dynamic-mem: dev-dynamic
 
 # Creates a Docker image by adding the compiled linux/amd64 binary found in ./bin.
-# The resulting image is tagged "vault:dev". 
+# The resulting image is tagged "vault:dev".
 docker-dev: prep
-	docker build -f scripts/docker/Dockerfile -t vault:dev .
+	docker build --build-arg VERSION=$(GO_VERSION_MIN) -f scripts/docker/Dockerfile -t vault:dev .
 
 docker-dev-ui: prep
-	docker build -f scripts/docker/Dockerfile.ui -t vault:dev-ui .
+	docker build --build-arg VERSION=$(GO_VERSION_MIN) -f scripts/docker/Dockerfile.ui -t vault:dev-ui .
 
 # test runs the unit tests and vets the code
 test: prep

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,7 +1,7 @@
-# Multi-stage builder to avoid polluting users environment with wrong 
-# architecture binaries.  Since this binary is used in an alpine container, 
+# Multi-stage builder to avoid polluting users environment with wrong
+# architecture binaries.  Since this binary is used in an alpine container,
 # we're explicitly compiling for 'linux/amd64'
-ARG VERSION=1.13.10
+ARG VERSION=1.14.7
 
 FROM golang:${VERSION} AS builder
 

--- a/scripts/docker/Dockerfile.ui
+++ b/scripts/docker/Dockerfile.ui
@@ -3,7 +3,7 @@
 # we're explicitly compiling for 'linux/amd64'
 FROM debian:buster AS builder
 
-ARG VERSION=1.13.10
+ARG VERSION=1.14.7
 ARG CGO_ENABLED=0
 ARG BUILD_TAGS
 ENV JOBS=2


### PR DESCRIPTION
`make docker-dev` was intended to pass `GO_MIN_VERSION` in as a build-arg, but was left out.  I updated the versions in the builder images and added it as a build-arg so it stays up to date.