### PR TITLE
Ui/pricing metric sparkle

### DIFF
--- a/ui/app/models/metrics/config.js
+++ b/ui/app/models/metrics/config.js
@@ -1,10 +1,12 @@
 import DS from 'ember-data';
 import { computed } from '@ember/object';
+import attachCapabilities from 'vault/lib/attach-capabilities';
 import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import { apiPath } from 'vault/macros/lazy-capabilities';
 
 const { attr } = DS;
 
-export default DS.Model.extend({
+const M = DS.Model.extend({
   queriesAvailable: attr('boolean'),
   defaultReportMonths: attr('number', {
     label: 'Default display',
@@ -27,4 +29,8 @@ export default DS.Model.extend({
     let keys = ['enabled', 'defaultReportMonths', 'retentionMonths'];
     return expandAttributeMeta(this, keys);
   }),
+});
+
+export default attachCapabilities(M, {
+  configPath: apiPath`sys/internal/counters/config`,
 });

--- a/ui/app/templates/vault/cluster/metrics/config.hbs
+++ b/ui/app/templates/vault/cluster/metrics/config.hbs
@@ -39,9 +39,11 @@
 
 <Toolbar>
   <ToolbarActions>
-    {{#link-to 'vault.cluster.metrics.edit' class="toolbar-link"}}
-      Edit configuration
-    {{/link-to}}
+    {{#if model.configPath.canUpdate}}
+      {{#link-to 'vault.cluster.metrics.edit' class="toolbar-link"}}
+        Edit configuration
+      {{/link-to}}
+    {{/if}}
   </ToolbarActions>
 </Toolbar>
 

--- a/ui/app/templates/vault/cluster/metrics/index.hbs
+++ b/ui/app/templates/vault/cluster/metrics/index.hbs
@@ -21,18 +21,20 @@
           Vault usage
         {{/link-to}}
       {{/link-to}}
-      {{#link-to
-        "vault.cluster.metrics.config"
-        tagName="li"
-        activeClass="is-active"
-      }}
+      {{#if model.config.configPath.canRead}}
         {{#link-to
           "vault.cluster.metrics.config"
-          data-test-configuration-tab=true
+          tagName="li"
+          activeClass="is-active"
         }}
-          Configuration
+          {{#link-to
+            "vault.cluster.metrics.config"
+            data-test-configuration-tab=true
+          }}
+            Configuration
+          {{/link-to}}
         {{/link-to}}
-      {{/link-to}}
+      {{/if}}
     </ul>
   </nav>
 </div>

--- a/ui/lib/core/addon/templates/components/form-error.hbs
+++ b/ui/lib/core/addon/templates/components/form-error.hbs
@@ -1,4 +1,4 @@
-<div class="has-top-margin-s is-flex is-flex-center">
+<div class="has-top-margin-s is-flex is-flex-center" data-test-form-error>
   <div class="is-narrow message-icon">
     <Icon
       @size="s"


### PR DESCRIPTION
This PR adds some more safeguards against pricing metrics date inputs, as well as capabilities checking

Config tab is hidden when a policy denies access to metrics config, such as: 
```hcl
path "sys/internal/counters/*" {
    capabilities = ["read"]
}

path "sys/internal/counters/config" {
    capabilities = ["deny"]
}
```
<img width="1103" alt="policy-no-config-update" src="https://user-images.githubusercontent.com/16182107/95513443-ffadaa00-097f-11eb-8f87-85afd90ff6d2.png">

Config edit button is hidden when a policy allows only read access to metrics config, such as: 
```hcl
path "sys/internal/counters/*" {
    capabilities = ["read"]
}
```
<img width="1103" alt="policy-no-config-update" src="https://user-images.githubusercontent.com/16182107/95513456-02100400-0980-11eb-94bf-23f8a6ba6edf.png">

Error message appears when the start date is father than the retained months setting
<img width="1103" alt="start-date-error" src="https://user-images.githubusercontent.com/16182107/95513465-050af480-0980-11eb-937f-924d49e9dff7.png">

Error message appears when the end date is the current month or later
<img width="1103" alt="end-date-error" src="https://user-images.githubusercontent.com/16182107/95513470-063c2180-0980-11eb-9084-8eb583ec0615.png">
