### PR TITLE
fix by returning apiPath from the model

### DIFF
--- a/ui/app/adapters/generated-item-list.js
+++ b/ui/app/adapters/generated-item-list.js
@@ -1,6 +1,5 @@
 import { assign } from '@ember/polyfills';
 import ApplicationAdapter from './application';
-import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 
 export default ApplicationAdapter.extend({

--- a/ui/app/adapters/generated-item-list.js
+++ b/ui/app/adapters/generated-item-list.js
@@ -17,8 +17,8 @@ export default ApplicationAdapter.extend({
     let data = {};
     if (isList) {
       data.list = true;
+      yield this.getDynamicApiPath.perform(id);
     }
-    yield this.getDynamicApiPath.perform(id);
 
     return this.ajax(this.urlForItem(id, isList, this.dynamicApiPath), 'GET', { data }).then(resp => {
       const data = {
@@ -34,6 +34,6 @@ export default ApplicationAdapter.extend({
   },
 
   queryRecord(store, type, query) {
-    return this.fetchByQuery(store, query);
+    return this.fetchByQuery.perform(store, query);
   },
 });

--- a/ui/app/adapters/generated-item-list.js
+++ b/ui/app/adapters/generated-item-list.js
@@ -1,28 +1,37 @@
 import { assign } from '@ember/polyfills';
 import ApplicationAdapter from './application';
+import { inject as service } from '@ember/service';
+import { task } from 'ember-concurrency';
 
 export default ApplicationAdapter.extend({
   namespace: 'v1',
   urlForItem() {},
+  dynamicApiPath: '',
+  getDynamicApiPath: task(function*(id) {
+    let result = yield this.store.peekRecord('auth-method', id);
+    this.dynamicApiPath = result.apiPath;
+    return;
+  }),
 
-  fetchByQuery(store, query, isList) {
+  fetchByQuery: task(function*(store, query, isList) {
     const { id } = query;
     let data = {};
     if (isList) {
       data.list = true;
     }
+    yield this.getDynamicApiPath.perform(id);
 
-    return this.ajax(this.urlForItem(id, isList), 'GET', { data }).then(resp => {
+    return this.ajax(this.urlForItem(id, isList, this.dynamicApiPath), 'GET', { data }).then(resp => {
       const data = {
         id,
         method: id,
       };
       return assign({}, resp, data);
     });
-  },
+  }),
 
   query(store, type, query) {
-    return this.fetchByQuery(store, query, true);
+    return this.fetchByQuery.perform(store, query, true);
   },
 
   queryRecord(store, type, query) {

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -232,8 +232,8 @@ export default Service.extend({
         let url;
         id = encodePath(id);
         // the apiPath changes when you switch between routes but the apiPath variable does not unless the model is reloaded
-        // check first for the dynamicApiPath which is passed through from the model->adapter
-        // If no dynamicApiPath, then use apiPath set higher up in function
+        // overwrite apiPath if dynamicApiPath exist.
+        // dynamicApiPath comes from the model->adapter
         if (dynamicApiPath) {
           apiPath = dynamicApiPath;
         }

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -226,15 +226,18 @@ export default Service.extend({
     const deletePath = paths.find(path => path.operations.includes('delete'));
 
     return generatedItemAdapter.extend({
-      urlForItem(id, isList) {
+      urlForItem(id, isList, dynamicApiPath) {
         const itemType = getPath.path.slice(1);
         let url;
         id = encodePath(id);
-
+        // the apiPath changes when you switch between routes but the apiPath variable does not unless the model is reloaded
+        // check first for the dynamicApiPath which is passed through from the model->adapter
+        // If no dynamicApiPath, then use apiPath set higher up in function
+        dynamicApiPath = dynamicApiPath || apiPath;
         // isList indicates whether we are viewing the list page
         // of a top-level item such as userpass
         if (isList) {
-          url = `${this.buildURL()}/${apiPath}${itemType}/`;
+          url = `${this.buildURL()}/${dynamicApiPath}/${itemType}/`;
         } else {
           // build the URL for the show page of a nested item
           // such as a userpass group

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -23,6 +23,7 @@ export function sanitizePath(path) {
 
 export default Service.extend({
   attrs: null,
+  dynamicApiPath: '',
   ajax(url, options = {}) {
     let appAdapter = getOwner(this).lookup(`adapter:application`);
     let { data } = options;
@@ -233,11 +234,13 @@ export default Service.extend({
         // the apiPath changes when you switch between routes but the apiPath variable does not unless the model is reloaded
         // check first for the dynamicApiPath which is passed through from the model->adapter
         // If no dynamicApiPath, then use apiPath set higher up in function
-        dynamicApiPath = dynamicApiPath || apiPath;
+        if (dynamicApiPath) {
+          apiPath = dynamicApiPath;
+        }
         // isList indicates whether we are viewing the list page
         // of a top-level item such as userpass
         if (isList) {
-          url = `${this.buildURL()}/${dynamicApiPath}/${itemType}/`;
+          url = `${this.buildURL()}/${apiPath}${itemType}/`;
         } else {
           // build the URL for the show page of a nested item
           // such as a userpass group

--- a/ui/app/templates/components/generated-item-list.hbs
+++ b/ui/app/templates/components/generated-item-list.hbs
@@ -41,6 +41,7 @@
 <Toolbar>
   <ToolbarActions>
     <ToolbarLink
+      data-test-create={{itemType}}
       @type="add"
       @params={{array
         "vault.cluster.access.method.item.create"

--- a/ui/app/templates/vault/cluster/access/methods.hbs
+++ b/ui/app/templates/vault/cluster/access/methods.hbs
@@ -8,7 +8,7 @@
 
 <Toolbar>
   <ToolbarActions>
-    <ToolbarLink @type="add" @params={{array 'vault.cluster.settings.auth.enable'}}>
+    <ToolbarLink @type="add" @params={{array 'vault.cluster.settings.auth.enable'}} data-test-auth-enable>
       Enable new method
     </ToolbarLink>
   </ToolbarActions>

--- a/ui/tests/acceptance/auth-list-test.js
+++ b/ui/tests/acceptance/auth-list-test.js
@@ -1,0 +1,69 @@
+import { click, fillIn, settled, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import authPage from 'vault/tests/pages/auth';
+import logout from 'vault/tests/pages/logout';
+import enablePage from 'vault/tests/pages/settings/auth/enable';
+
+module('Acceptance | userpass secret backend', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    return authPage.login();
+  });
+
+  hooks.afterEach(function() {
+    return logout.visit();
+  });
+
+  const POLICY = {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Action: 'iam:*',
+        Resource: '*',
+      },
+    ],
+  };
+  test('userpass backend', async function(assert) {
+    let n = Math.random();
+    const path1 = `userpass-${++n}`;
+    const path2 = `userpass-${++n}`;
+    const user1 = 'user1';
+    const user2 = 'user2';
+
+    // enable the first userpass method with one username
+    await enablePage.enable('userpass', path1);
+    await click('[data-test-save-config="true"]');
+    await visit(`/vault/access/${path1}/item/user/create`);
+    await fillIn('[data-test-input="username"]', user1);
+    await fillIn('[data-test-textarea]', user1);
+    await click('[data-test-save-config="true"]');
+
+    // enable the first userpass method with one username
+    await visit(`/vault/settings/auth/enable`);
+    await click('[data-test-mount-type="userpass"]');
+    await click('[data-test-mount-next]');
+    await fillIn('[data-test-input="path"]', path2);
+    await click('[data-test-mount-submit="true"]');
+    await click('[data-test-save-config="true"]');
+    await settled();
+    await click(`[data-test-auth-backend-link="${path2}"]`);
+    await click('[data-test-create="user"]');
+    await fillIn('[data-test-input="username"]', user2);
+    await fillIn('[data-test-textarea]', user2);
+    await click('[data-test-save-config="true"]');
+
+    //confirming that the user was created.  There was a bug where the apiPath was not being updated when toggling between auth routes
+    assert
+      .dom('[data-test-list-item-content]')
+      .hasText(user2, 'user just created shows in current auth list');
+
+    //confirm that the auth method 1 shows the user1.  There was a bug where it was not updated the list when toggling between auth routes
+    await visit(`/vault/access/${path1}/item/user`);
+    assert
+      .dom('[data-test-list-item-content]')
+      .hasText(user1, 'first user created shows in current auth list');
+  });
+});

--- a/ui/tests/acceptance/auth-list-test.js
+++ b/ui/tests/acceptance/auth-list-test.js
@@ -16,16 +16,6 @@ module('Acceptance | userpass secret backend', function(hooks) {
     return logout.visit();
   });
 
-  const POLICY = {
-    Version: '2012-10-17',
-    Statement: [
-      {
-        Effect: 'Allow',
-        Action: 'iam:*',
-        Resource: '*',
-      },
-    ],
-  };
   test('userpass backend', async function(assert) {
     let n = Math.random();
     const path1 = `userpass-${++n}`;


### PR DESCRIPTION
This PR fixes an issue where on route change the model is not refreshed and therefore the path to the auth method for listing roles was not being called properly. Originally this was reported in an Asana ticket for Kubernetes, but it's an issue with all auth methods.  

The fix was to use the store to return the `generated-item-list` adapter that is then passed to the `path-help` service.

Below you can see the change.  Where before you'd see the same role list from the previous auth method selected.  It would only change on refresh which would cause the model to refresh.

![auth](https://user-images.githubusercontent.com/6618863/95770442-a216a780-0c76-11eb-984b-053cb878e903.gif)

Additionally, when I was writing a test I noticed that in certain cases if you transitioned between auth methods and created a role or user you would create that user at the endpoint of the previous route you had visited.  Here's a video of that happening.  The test I wrote checks both for this and the original fix.  This can still happen if you copy/paste to the create link, but that does not follow the regular flow of a UI user.  However, I thought it was worthing pointing out.  It has something to do with how the path is first created and not refreshed, but I was unable to get to the meat of the problem.  

![Screen Recording 2020-10-13 at 12 01 02 PM](https://user-images.githubusercontent.com/6618863/96021659-fbb0da80-0e0c-11eb-931f-8114e30dde1e.gif)
