### PR TITLE
docs: add missing "_prefix" to Consul 1.4+ policy "service" rule

### DIFF
--- a/website/pages/docs/configuration/storage/consul.mdx
+++ b/website/pages/docs/configuration/storage/consul.mdx
@@ -191,7 +191,7 @@ language:
       "policy": "write"
     }
   },
-  "service": {
+  "service_prefix": {
     "vault": {
       "policy": "write"
     }


### PR DESCRIPTION
Hello,

just noticed that missing "_prefix" in the example Consul policy rules when using it as Vault storage backend.

Cheers,
Andreas