### PR TITLE
Adds note that it requires a PEM-encoded file

### DIFF
--- a/website/pages/docs/configuration/listener/tcp.mdx
+++ b/website/pages/docs/configuration/listener/tcp.mdx
@@ -83,16 +83,16 @@ advertise the correct address to other nodes.
   insecure communication.
 
 - `tls_cert_file` `(string: <required-if-enabled>, reloads-on-SIGHUP)` –
-  Specifies the path to the certificate for TLS. To configure the listener to
-  use a CA certificate, concatenate the primary certificate and the CA
+  Specifies the path to the certificate for TLS. It requires a PEM-encoded file. 
+  To configure the listener to use a CA certificate, concatenate the primary certificate and the CA
   certificate together. The primary certificate should appear first in the
   combined file. On `SIGHUP`, the path set here _at Vault startup_ will be used
   for reloading the certificate; modifying this value while Vault is running
   will have no effect for `SIGHUP`s.
 
 - `tls_key_file` `(string: <required-if-enabled>, reloads-on-SIGHUP)` –
-  Specifies the path to the private key for the certificate. If the key file
-  is encrypted, you will be prompted to enter the passphrase on server startup.
+  Specifies the path to the private key for the certificate. It requires a PEM-encoded file.
+  If the key file is encrypted, you will be prompted to enter the passphrase on server startup.
   The passphrase must stay the same between key files when reloading your
   configuration using `SIGHUP`. On `SIGHUP`, the path set here _at Vault
   startup_ will be used for reloading the certificate; modifying this value


### PR DESCRIPTION
* Method uses `tls.X509KeyPair` method which 
Needs a PEM file, so won’t work with PFX
* Code: https://github.com/hashicorp/vault/blob/f5be0716dbe41ea5b909d3c8a81ebac37fd124e0/internalshared/reloadutil/reload.go#L40