### PR TITLE
Fix for broken link docs platform/k8s/injector/annotations

### DIFF
--- a/website/pages/docs/platform/k8s/injector/annotations.mdx
+++ b/website/pages/docs/platform/k8s/injector/annotations.mdx
@@ -136,7 +136,7 @@ them, optional commands to run, etc.
   (uid 0), the `run-as-same-user` annotation will fail injection with an error.
 
 - `vault.hashicorp.com/agent-cache-enable` - configures Vault Agent to enable 
-  [caching](/docs/caching). Defaults to `false`.
+  [caching](/docs/agent/caching). Defaults to `false`.
 
 - `vault.hashicorp.com/agent-cache-use-auto-auth-token` - configures Vault Agent cache 
   to authenticate on behalf of the requester. Set to `force` to enable. Disabled 


### PR DESCRIPTION
See https://www.vaultproject.io/docs/platform/k8s/injector/annotations#vault-hashicorp-com-agent-cache-enable

Pointing to https://www.vaultproject.io/docs/caching (404)

This pr fixes it , so it goes to https://www.vaultproject.io/docs/agent/caching (200)