### PR TITLE
Bug fix: Update Shamir Modal to clarify dr operation token command

### DIFF
--- a/ui/lib/core/addon/templates/components/shamir-modal-flow.hbs
+++ b/ui/lib/core/addon/templates/components/shamir-modal-flow.hbs
@@ -43,9 +43,9 @@
           </h4>
           <p class="help has-text-grey has-bottom-margin-xs">
             {{#if otp}}
-            This command contains both the encoded token and the OTP. It should be executed on the primary cluster in order to generate the operation token.
+            This command contains both the encoded token and the OTP. It should be executed on the secondary cluster in order to generate the operation token.
             {{else}}
-            This command requires the OTP saved earlier. It should be executed on the primary cluster in order to generate the operation token.
+            This command requires the OTP saved earlier. It should be executed on the secondary cluster in order to generate the operation token.
             {{/if}}
           </p>
           <div class="message is-list has-copy-button" tabindex="-1">


### PR DESCRIPTION
This was brought up in a ticket and confirmed that the subtext for where the DR operation token should be run was incorrect.  It stated the token command should be run on the primary, when in fact it should be run on the secondary.

This PR fixes the text.

![image](https://user-images.githubusercontent.com/6618863/96161482-92949a00-0ed4-11eb-8889-662437147b96.png)
