### PR TITLE
database/test: use vault.TestWaitActive when starting up a test cluster

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -41,6 +41,7 @@ func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
 	})
 	cluster.Start()
 	cores := cluster.Cores
+	vault.TestWaitActive(t, cores[0].Core)
 
 	os.Setenv(pluginutil.PluginCACertPEMEnv, cluster.CACertPEMFile)
 


### PR DESCRIPTION
This PR adds a call to `vault.TestWaitActive` within `database. getCluster` on the test cluster's core0 (which is always expected to become the active due to how `TestCluster` works). This gives time for the cluster to become ready and prevents potential timeouts before the cluster can start servicing requests.