### PR TITLE
Updated missing code encoding around two path references

### DIFF
--- a/website/pages/docs/concepts/policies.mdx
+++ b/website/pages/docs/concepts/policies.mdx
@@ -86,7 +86,7 @@ user or machine is allowed to access.
 [hcl]: https://github.com/hashicorp/hcl
 
 Here is a very simple policy which grants read capabilities to the path
-"secret/foo":
+`"secret/foo"`:
 
 ```ruby
 path "secret/foo" {
@@ -167,7 +167,7 @@ path "secret/+/+/teamb" {
 
 Vault's architecture is similar to a filesystem. Every action in Vault has a
 corresponding path and capability - even Vault's internal core configuration
-endpoints live under the "sys/" path. Policies define access to these paths and
+endpoints live under the `"sys/"` path. Policies define access to these paths and
 capabilities, which controls a token's access to credentials in Vault.
 
 ~> Policy paths are matched using the **most specific path match**. This may be


### PR DESCRIPTION
Found missing formatting on a couple path references in the Doc. Updated to include inline code formatting to maintain consistency with remainder of document.