### PR TITLE
Add GCP permission required for using iam auth.

### DIFF
--- a/website/pages/api-docs/auth/gcp/index.mdx
+++ b/website/pages/api-docs/auth/gcp/index.mdx
@@ -37,6 +37,7 @@ to confirm signed JWTs passed in during login.
   ```
   iam.serviceAccounts.get
   iam.serviceAccountKeys.get
+  iam.serviceAccounts.signJwt (type iam only)
   ```
 
   If this value is empty, Vault will try to use [Application Default


### PR DESCRIPTION
When using gcp auth with type iam, vault agent reported an error saying the permission `iam.serviceAccounts.signJwt` was required. Adding the permission fixed the issue, so I'm updating the document here.