### PR TITLE
backport 1.6.0: approle: Include role_name in alias metadata (#9529)

### DIFF
--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -287,7 +287,8 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 		},
 		Metadata: metadata,
 		Alias: &logical.Alias{
-			Name: role.RoleID,
+			Name:     role.RoleID,
+			Metadata: metadata,
 		},
 	}
 	role.PopulateTokenAuth(auth)

--- a/builtin/credential/approle/path_login_test.go
+++ b/builtin/credential/approle/path_login_test.go
@@ -171,6 +171,22 @@ func TestAppRole_RoleLogin(t *testing.T) {
 		t.Fatalf("expected a non-nil auth object in the response")
 	}
 
+	if loginResp.Auth.Metadata == nil {
+		t.Fatalf("expected a non-nil metadata object in the response")
+	}
+
+	if val := loginResp.Auth.Metadata["role_name"]; val != "role1" {
+		t.Fatalf("expected metadata.role_name to equal 'role1', got: %v", val)
+	}
+
+	if loginResp.Auth.Alias.Metadata == nil {
+		t.Fatalf("expected a non-nil alias metadata object in the response")
+	}
+
+	if val := loginResp.Auth.Alias.Metadata["role_name"]; val != "role1" {
+		t.Fatalf("expected metadata.alias.role_name to equal 'role1', got: %v", val)
+	}
+
 	// Test renewal
 	renewReq := generateRenewRequest(storage, loginResp.Auth)
 


### PR DESCRIPTION
This change allows people who are using templated policies to use the
role_name in their templates through {{
identity.entity.aliases.approle.metadata.role_name }}.

Co-authored-by: Calvin Leung Huang <cleung2010@gmail.com>