### PR TITLE
k8s/injector: update docs for 0.6.0

### DIFF
--- a/website/pages/docs/platform/k8s/injector/annotations.mdx
+++ b/website/pages/docs/platform/k8s/injector/annotations.mdx
@@ -73,22 +73,30 @@ them, optional commands to run, etc.
   `vault.hashicorp.com/agent-inject-secret-foobar` is configured,
   `vault.hashicorp.com/agent-inject-file-foobar` would configure the filename.
 
+- `vault.hashicorp.com/agent-extra-secret` - mounts Kubernetes secret as a volume at 
+  `/vault/custom` in the sidecar/init containers. Useful for custom Agent configs with 
+  auto-auth methods such as approle that require paths to secrets be present.
+
 - `vault.hashicorp.com/agent-inject-token` - configures Vault Agent to share the Vault 
   token with other containers in the pod. This is helpful when other containers 
   communicate directly with Vault but require auto-authentication provided by Vault 
   Agent. This should be set to a `true` or `false` value. Defaults to `false`.
 
 - `vault.hashicorp.com/agent-limits-cpu` - configures the CPU limits on the Vault
-  Agent containers. Defaults to `500m`.
+  Agent containers. Defaults to `500m`. Setting this to an empty string disables
+  CPU limits.
 
 - `vault.hashicorp.com/agent-limits-mem` - configures the memory limits on the Vault
-  Agent containers. Defaults to `128Mi`.
+  Agent containers. Defaults to `128Mi`. Setting this to an empty string disables
+  memory limits.
 
 - `vault.hashicorp.com/agent-requests-cpu` - configures the CPU requests on the
-  Vault Agent containers. Defaults to `250m`.
+  Vault Agent containers. Defaults to `250m`. Setting this to an empty string disables
+  CPU requests.
 
 - `vault.hashicorp.com/agent-requests-mem` - configures the memory requests on the
-  Vault Agent containers. Defaults to `64Mi`.
+  Vault Agent containers. Defaults to `64Mi`. Setting this to an empty string disables
+  memory requests.
 
 - `vault.hashicorp.com/agent-revoke-on-shutdown` - configures whether the sidecar 
   will revoke it's own token before shutting down. This setting will only be applied 


### PR DESCRIPTION
This adds documentation related to the [0.6.0 release of Vault K8s](https://github.com/hashicorp/vault-k8s/blob/master/CHANGELOG.md#060-october-20-2020). 

Omitted from these changes are the Helm documentation references to this new image because Helm isn't released yet. I will update the Helm documentation after Vault Helm 0.8.0 is pushed to the repository.