### PR TITLE
docs: update helm to 0.8.0

### DIFF
--- a/website/pages/docs/platform/k8s/helm/configuration.mdx
+++ b/website/pages/docs/platform/k8s/helm/configuration.mdx
@@ -53,13 +53,14 @@ and consider if they're appropriate for your deployment.
 
   - `enabled` (`boolean: true`) - When set to `true`, the Vault Agent Injector Admission Webhook controller will be created.
 
-  - `externalVaultAddr` (`string: ""`) - External vault server address for the injector to use. Setting this will disable deployment of the vault server, and only deploy the injector.
+  - `externalVaultAddr` (`string: ""`) - External vault server address for the injector to use. Setting this will disable deployment of the vault server, and only deploy the injector. 
+    A service account with token review permissions is automatically created if `server.serviceAccount.create=true` is set for the external Vault server to use.
 
   - `image` - Values that configure the Vault Agent Injector Docker image.
 
     - `repository` (`string: "hashicorp/vault-k8s"`) - The name of the Docker image for Vault Agent Injector.
 
-    - `tag` (`string: "0.5.0"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "0.6.0"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -67,7 +68,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "vault"`) - The name of the Docker image for the Vault Agent sidecar. This should be set to the official Vault Docker image.
 
-    - `tag` (`string: "1.5.2"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
+    - `tag` (`string: "1.5.4"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
 
   - `metrics` - Values that configure the Vault Agent Injector metric exporter.
 
@@ -121,13 +122,28 @@ and consider if they're appropriate for your deployment.
 
   - `priorityClassName` (`string: ""`) - Priority class for injector pods
 
+  - `annotations` (`dictionary: {}`) - This value defines additional annotations for injector pods. This can either be YAML or a YAML-formatted multi-line templated string.
+
+    ```yaml
+    annotations:
+      "sample/annotation1": "foo"
+      "sample/annotation2": "bar"
+    # or
+    annotations: |
+      "sample/annotation1": "foo"
+      "sample/annotation2": "bar"
+    ```
+
+  - `failurePolicy` (`string : ""`) - When set to `Fail`, an error calling the webhook causes the admission to fail and the API request to be rejected. 
+    When set to `Ignore`, an error calling the webhook is ignored and the API request is allowed to continue.
+
 - `server` - Values that configure running a Vault server within Kubernetes.
 
   - `image` - Values that configure the Vault Docker image.
 
     - `repository` (`string: "vault"`) - The name of the Docker image for the containers running Vault.
 
-    - `tag` (`string: "1.5.2"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "1.5.4"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -213,10 +229,26 @@ and consider if they're appropriate for your deployment.
 
       - `path` (`string: ""`) - When set to a value, enables HTTP/HTTPS probes instead of using the default `exec` probe. The http/https scheme is controlled by the `tlsDisable` value.
 
+      - `failureThreshold` (`int: 2`) - When set to a value, configures how many probe failures will be tolerated by Kubernetes.
+
+      - `initialDelaySeconds` (`int: 5`) - When set to a value, configures the number of seconds after the container has started before probe initiates.
+
+      - `periodSeconds` (`int: 5`) - When set to a value, configures how often (in seconds) to perform the probe.
+
+      - `successThreshold` (`int: 1`) - When set to a value, configures the minimum consecutive successes for the probe to be considered successful after having failed.
+
+      - `timeoutSeconds` (`int: 3`) - When set to a value, configures the number of seconds after which the probe times out.
+
+
     ```yaml
     readinessProbe:
       enabled: true
       path: /v1/sys/health?standbyok=true
+      failureThreshold: 2
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 3
     ```
 
     - `livelinessProbes` - Values that configure the liveliness probe for the Vault pods.
@@ -227,11 +259,23 @@ and consider if they're appropriate for your deployment.
 
       - `initialDelaySeconds` (`int: 60`) - Sets the initial delay of the liveliness probe when the container starts.
 
+      - `failureThreshold` (`int: 2`) - When set to a value, configures how many probe failures will be tolerated by Kubernetes.
+
+      - `periodSeconds` (`int: 5`) - When set to a value, configures how often (in seconds) to perform the probe.
+
+      - `successThreshold` (`int: 1`) - When set to a value, configures the minimum consecutive successes for the probe to be considered successful after having failed.
+
+      - `timeoutSeconds` (`int: 3`) - When set to a value, configures the number of seconds after which the probe times out.
+
     ```yaml
     livelinessProbe:
       enabled: true
       path: /v1/sys/health?standbyok=true
       initialDelaySeconds: 60
+      failureThreshold: 2
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 3
     ```
 
     - `preStopSleepSeconds` (`int: 5`) - Used to set the sleep time during the preStop step.
@@ -367,6 +411,10 @@ and consider if they're appropriate for your deployment.
       disktype: ssd
     ```
 
+    - `networkPolicy` - Values that configure the Vault Network Policy.
+      
+      - `enabled` (`boolean: false`) - When set to `true`, enables a Network Policy for the Vault cluster.
+
     - `priorityClassName` (`string: ""`) - Priority class for server pods
 
     - `extraLabels` (`dictionary: {}`) - This value defines additional labels for server pods.
@@ -444,6 +492,9 @@ and consider if they're appropriate for your deployment.
       - `storageClass` (`string: null`) -
         Name of the storage class to use when creating the data storage volume.
 
+      - `mountPath` (`string: "/vault/data") - 
+        Configures the path in the Vault pod where the data storage will be mounted.
+
       - `accessMode` (`string: ReadWriteOnce`) -
         Type of access mode of the storage device. See the [official Kubernetes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for more information.
 
@@ -469,6 +520,9 @@ and consider if they're appropriate for your deployment.
 
       - `storageClass` (`string: null`) -
         Name of the storage class to use when creating the audit storage volume.
+
+      - `mountPath` (`string: "/vault/audit") - 
+        Configures the path in the Vault pod where the audit storage will be mounted.
 
       - `accessMode` (`string: ReadWriteOnce`) -
         Type of access mode of the storage device.

--- a/website/pages/docs/platform/k8s/helm/configuration.mdx
+++ b/website/pages/docs/platform/k8s/helm/configuration.mdx
@@ -30,7 +30,7 @@ and consider if they're appropriate for your deployment.
   - `psp` - Values that configure Pod Security Policy.
 
     - `enable` (`boolean: false`) - When set to `true`, enables Pod Security Policies for Vault and Vault Agent Injector.
-  
+
     - `annotations` (`dictionary: {}`) - This value defines additional annotations to
       add to the Pod Security Policies. This can either be YAML or a YAML-formatted
       multi-line templated string.
@@ -53,7 +53,7 @@ and consider if they're appropriate for your deployment.
 
   - `enabled` (`boolean: true`) - When set to `true`, the Vault Agent Injector Admission Webhook controller will be created.
 
-  - `externalVaultAddr` (`string: ""`) - External vault server address for the injector to use. Setting this will disable deployment of the vault server, and only deploy the injector. 
+  - `externalVaultAddr` (`string: ""`) - External vault server address for the injector to use. Setting this will disable deployment of the vault server, and only deploy the injector.
     A service account with token review permissions is automatically created if `server.serviceAccount.create=true` is set for the external Vault server to use.
 
   - `image` - Values that configure the Vault Agent Injector Docker image.
@@ -134,7 +134,7 @@ and consider if they're appropriate for your deployment.
       "sample/annotation2": "bar"
     ```
 
-  - `failurePolicy` (`string : ""`) - When set to `Fail`, an error calling the webhook causes the admission to fail and the API request to be rejected. 
+  - `failurePolicy` (`string : ""`) - When set to `Fail`, an error calling the webhook causes the admission to fail and the API request to be rejected.
     When set to `Ignore`, an error calling the webhook is ignored and the API request is allowed to continue.
 
 - `server` - Values that configure running a Vault server within Kubernetes.
@@ -350,8 +350,8 @@ and consider if they're appropriate for your deployment.
       - `path` (`string: /vault/userconfigs`) -
         Name of the path where a configMap or secret is mounted. If not specified
         the volume will be mounted to `/vault/userconfig/<name of volume>`.
-      
-      - `defaultMode` (`string: "420"`) - 
+
+      - `defaultMode` (`string: "420"`) -
         Default mode of the mounted files.
 
       ```yaml
@@ -361,7 +361,7 @@ and consider if they're appropriate for your deployment.
           path: '/etc/pki'
       ```
 
-    - `volumes` (`array: []`) - A list of volumes made available to all containers.  This takes 
+    - `volumes` (`array: []`) - A list of volumes made available to all containers.  This takes
        standard Kubernetes volume definitions.
 
       ```yaml
@@ -369,7 +369,7 @@ and consider if they're appropriate for your deployment.
       - name: plugins
         emptyDir: {}
       ```
-    - `volumeMounts` (`array: []`) - A list of volumes mounts made available to all containers.  This takes 
+    - `volumeMounts` (`array: []`) - A list of volumes mounts made available to all containers.  This takes
        standard Kubernetes volume definitions.
 
       ```yaml
@@ -412,7 +412,7 @@ and consider if they're appropriate for your deployment.
     ```
 
     - `networkPolicy` - Values that configure the Vault Network Policy.
-      
+
       - `enabled` (`boolean: false`) - When set to `true`, enables a Network Policy for the Vault cluster.
 
     - `priorityClassName` (`string: ""`) - Priority class for server pods
@@ -464,7 +464,7 @@ and consider if they're appropriate for your deployment.
       ```
 
     - `serviceAccount` - Values that configure the Kubernetes service account created for Vault.
-      
+
       - `create` (`boolean: true`): If set to true, creates a service account used by Vault.
 
       - `name` (`string: ""`): Name of the service account to use.  If not set and create is true, a name is generated using the name of the installation (default is "vault").
@@ -492,7 +492,7 @@ and consider if they're appropriate for your deployment.
       - `storageClass` (`string: null`) -
         Name of the storage class to use when creating the data storage volume.
 
-      - `mountPath` (`string: "/vault/data") - 
+      - `mountPath` (`string: /vault/data`) -
         Configures the path in the Vault pod where the data storage will be mounted.
 
       - `accessMode` (`string: ReadWriteOnce`) -
@@ -521,12 +521,12 @@ and consider if they're appropriate for your deployment.
       - `storageClass` (`string: null`) -
         Name of the storage class to use when creating the audit storage volume.
 
-      - `mountPath` (`string: "/vault/audit") - 
+      - `mountPath` (`string: /vault/audit`) -
         Configures the path in the Vault pod where the audit storage will be mounted.
 
       - `accessMode` (`string: ReadWriteOnce`) -
         Type of access mode of the storage device.
-      
+
       - `annotations` (`dictionary: {}`) - This value defines additional annotations to
       add to the audit PVCs. This can either be YAML or a YAML-formatted
       multi-line templated string.
@@ -582,7 +582,7 @@ and consider if they're appropriate for your deployment.
       - `enabled` (`boolean: false`) -
         Enables `ha` mode for the Vault server. This mode uses a highly available backend storage (such as Consul) to store Vault's data. By default this is configured to use [Consul Helm](https://github.com/hashicorp/consul-helm). For a complete list of storage backends, see the [Vault documentation](/docs/configuration).
 
-      - `apiAddr`: (`string: "{}"`) - 
+      - `apiAddr`: (`string: "{}"`) -
         Set the API address configuration for a Vault cluster.  If set to an empty string, the pod IP address is used.
 
       - `raft` - This configures `raft` integrated storage mode for the Vault server.
@@ -641,9 +641,9 @@ and consider if they're appropriate for your deployment.
         this to `0`, you will need to add a `--set 'server.disruptionBudget.maxUnavailable=0'`
         flag to the helm chart installation command because of a limitation in the Helm
         templating language.
-  
+
   - `statefulset` - This configures settings for the Vault Statefulset.
-    
+
     - `annotations` (`dictionary: {}`) - This value defines additional annotations to
       add to the Vault statefulset. This can either be YAML or a YAML-formatted
       multi-line templated string.
@@ -669,7 +669,7 @@ and consider if they're appropriate for your deployment.
   - `publishNotReadyAddresses` (`boolean: true`) -
     If set to true, will route traffic to Vault pods that aren't ready (if they're sealed or uninitialized.
 
-  - `activeVaultPodOnly` (`boolean: false`) - 
+  - `activeVaultPodOnly` (`boolean: false`) -
     If set to true, the UI service will only route to the active pod in a Vault HA cluster.
 
   - `serviceNodePort` (`int: null`) -

--- a/website/pages/docs/platform/k8s/helm/configuration.mdx
+++ b/website/pages/docs/platform/k8s/helm/configuration.mdx
@@ -135,7 +135,7 @@ and consider if they're appropriate for your deployment.
     ```
 
   - `failurePolicy` (`string : ""`) - When set to `Fail`, an error calling the webhook causes the admission to fail and the API request to be rejected.
-    When set to `Ignore`, an error calling the webhook is ignored and the API request is allowed to continue.
+    When set to `Ignore`, an error calling the webhook is ignored and the API request is allowed to continue. Allowed values: `Fail`, `Ignore`.
 
 - `server` - Values that configure running a Vault server within Kubernetes.
 

--- a/website/pages/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
@@ -22,7 +22,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.5.2_ent' \
+  --set='server.image.tag=1.5.4_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -74,7 +74,7 @@ disaster recovery replication.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.5.2_ent' \
+  --set='server.image.tag=1.5.4_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/pages/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
@@ -22,7 +22,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.5.2_ent' \
+  --set='server.image.tag=1.5.4_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -73,7 +73,7 @@ With the primary cluster created, next create a secondary cluster.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.5.2_ent' \
+  --set='server.image.tag=1.5.4_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/pages/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
+++ b/website/pages/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
@@ -16,7 +16,7 @@ Integrated storage (raft) can be enabled using the `server.ha.raft.enabled` valu
 ```shell
 helm install vault hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.5.2_ent' \
+  --set='server.image.tag=1.5.4_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/pages/docs/platform/k8s/helm/index.mdx
+++ b/website/pages/docs/platform/k8s/helm/index.mdx
@@ -36,7 +36,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -58,11 +58,12 @@ Installing a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.7.0
-$ helm install vault hashicorp/vault --version 0.7.0
+# Install version 0.8.0
+$ helm install vault hashicorp/vault --version 0.8.0
 ```
 
 ~> **Security Warning:** By default, the chart runs in standalone mode. This

--- a/website/pages/docs/platform/k8s/helm/openshift.mdx
+++ b/website/pages/docs/platform/k8s/helm/openshift.mdx
@@ -70,7 +70,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME            	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault 	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault 	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -89,11 +89,12 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.7.0
-$ helm install vault hashicorp/vault --version 0.7.0
+# Install version 0.8.0
+$ helm install vault hashicorp/vault --version 0.8.0
 ```
 
 The `helm install` command accepts parameters to override default configuration

--- a/website/pages/docs/platform/k8s/helm/run.mdx
+++ b/website/pages/docs/platform/k8s/helm/run.mdx
@@ -54,7 +54,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -73,11 +73,12 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.5.0        	           	Install and configure Vault on Kubernetes.
-hashicorp/vault	0.4.0        	           	Install and configure Vault on Kubernetes.
+hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
+hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.7.0
-$ helm install vault hashicorp/vault --version 0.7.0
+# Install version 0.8.0
+$ helm install vault hashicorp/vault --version 0.8.0
 ```
 
 The `helm install` command accepts parameters to override default configuration
@@ -420,14 +421,14 @@ Next, list the Helm versions and choose the desired version to install.
 ```bash
 helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 ```
 
 Next, test the upgrade with `--dry-run` first to verify the changes sent to the
 Kubernetes cluster.
 
 ```shell-session
-$ helm upgrade vault hashicorp/vault --version=0.7.0 \
+$ helm upgrade vault hashicorp/vault --version=0.8.0 \
     --set='server.image.repository=vault' \
     --set='server.image.tag=123.456' \
     --dry-run


### PR DESCRIPTION
This updates the website for the [newest release of Vault Helm 0.8.0](https://github.com/hashicorp/vault-helm/blob/master/CHANGELOG.md#080-october-20th-2020).