### PR TITLE
secrets/database: Fix test for autoMTLS

### DIFF
--- a/builtin/logical/database/versioning_large_test.go
+++ b/builtin/logical/database/versioning_large_test.go
@@ -250,7 +250,7 @@ func TestBackend_PluginMain_MockV4(t *testing.T) {
 }
 
 func TestBackend_PluginMain_MockV5(t *testing.T) {
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" {
+	if os.Getenv(pluginutil.PluginVaultVersionEnv) == "" {
 		return
 	}
 


### PR DESCRIPTION
With this test change the old SHA with AutoMTLS passes. I think we should re-enable that