### PR TITLE
Backport (1.6.X): DBPW - Remove AutoMTLS option from DB plugin opts (#10182)

### DIFF
--- a/sdk/database/dbplugin/v5/plugin_client.go
+++ b/sdk/database/dbplugin/v5/plugin_client.go
@@ -45,7 +45,6 @@ func NewPluginClient(ctx context.Context, sys pluginutil.RunnerUtil, pluginRunne
 		pluginutil.HandshakeConfig(handshakeConfig),
 		pluginutil.Logger(logger),
 		pluginutil.MetadataMode(isMetadataMode),
-		pluginutil.AutoMTLS(false),
 	)
 	if err != nil {
 		return nil, err

--- a/sdk/database/newdbplugin/plugin_client.go
+++ b/sdk/database/newdbplugin/plugin_client.go
@@ -45,7 +45,6 @@ func NewPluginClient(ctx context.Context, sys pluginutil.RunnerUtil, pluginRunne
 		pluginutil.HandshakeConfig(handshakeConfig),
 		pluginutil.Logger(logger),
 		pluginutil.MetadataMode(isMetadataMode),
-		pluginutil.AutoMTLS(false),
 	)
 	if err != nil {
 		return nil, err

--- a/sdk/helper/pluginutil/run_config.go
+++ b/sdk/helper/pluginutil/run_config.go
@@ -26,7 +26,6 @@ type runConfig struct {
 	hs             plugin.HandshakeConfig
 	logger         log.Logger
 	isMetadataMode bool
-	autoMTLS       bool
 }
 
 func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error) {
@@ -46,7 +45,7 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 	cmd.Env = append(cmd.Env, metadataEnv)
 
 	var clientTLSConfig *tls.Config
-	if !rc.autoMTLS && !rc.isMetadataMode {
+	if !rc.isMetadataMode {
 		// Get a CA TLS Certificate
 		certBytes, key, err := generateCert()
 		if err != nil {
@@ -86,7 +85,7 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 			plugin.ProtocolNetRPC,
 			plugin.ProtocolGRPC,
 		},
-		AutoMTLS: rc.autoMTLS,
+		AutoMTLS: false,
 	}
 	return clientConfig, nil
 }
@@ -136,12 +135,6 @@ func Logger(logger log.Logger) RunOpt {
 func MetadataMode(isMetadataMode bool) RunOpt {
 	return func(rc *runConfig) {
 		rc.isMetadataMode = isMetadataMode
-	}
-}
-
-func AutoMTLS(autoMTLS bool) RunOpt {
-	return func(rc *runConfig) {
-		rc.autoMTLS = autoMTLS
 	}
 }
 

--- a/sdk/helper/pluginutil/run_config_test.go
+++ b/sdk/helper/pluginutil/run_config_test.go
@@ -50,7 +50,6 @@ func TestNameMakeConfig(t *testing.T) {
 				},
 				logger:         hclog.NewNullLogger(),
 				isMetadataMode: true,
-				autoMTLS:       false,
 			},
 
 			responseWrapInfoTimes: 0,
@@ -109,7 +108,6 @@ func TestNameMakeConfig(t *testing.T) {
 				},
 				logger:         hclog.NewNullLogger(),
 				isMetadataMode: false,
-				autoMTLS:       false,
 			},
 
 			responseWrapInfo: &wrapping.ResponseWrapInfo{
@@ -154,124 +152,6 @@ func TestNameMakeConfig(t *testing.T) {
 				AutoMTLS: false,
 			},
 			expectTLSConfig: true,
-		},
-		"metadata mode, AutoMTLS": {
-			rc: runConfig{
-				command: "echo",
-				args:    []string{"foo", "bar"},
-				sha256:  []byte("some_sha256"),
-				env:     []string{"initial=true"},
-				pluginSets: map[int]plugin.PluginSet{
-					1: plugin.PluginSet{
-						"bogus": nil,
-					},
-				},
-				hs: plugin.HandshakeConfig{
-					ProtocolVersion:  1,
-					MagicCookieKey:   "magic_cookie_key",
-					MagicCookieValue: "magic_cookie_value",
-				},
-				logger:         hclog.NewNullLogger(),
-				isMetadataMode: true,
-				autoMTLS:       true,
-			},
-
-			responseWrapInfoTimes: 0,
-
-			mlockEnabled:      false,
-			mlockEnabledTimes: 1,
-
-			expectedConfig: &plugin.ClientConfig{
-				HandshakeConfig: plugin.HandshakeConfig{
-					ProtocolVersion:  1,
-					MagicCookieKey:   "magic_cookie_key",
-					MagicCookieValue: "magic_cookie_value",
-				},
-				VersionedPlugins: map[int]plugin.PluginSet{
-					1: plugin.PluginSet{
-						"bogus": nil,
-					},
-				},
-				Cmd: commandWithEnv(
-					"echo",
-					[]string{"foo", "bar"},
-					[]string{
-						"initial=true",
-						fmt.Sprintf("%s=%s", PluginVaultVersionEnv, version.GetVersion().Version),
-						fmt.Sprintf("%s=%t", PluginMetadataModeEnv, true),
-					},
-				),
-				SecureConfig: &plugin.SecureConfig{
-					Checksum: []byte("some_sha256"),
-					// Hash is generated
-				},
-				AllowedProtocols: []plugin.Protocol{
-					plugin.ProtocolNetRPC,
-					plugin.ProtocolGRPC,
-				},
-				Logger:   hclog.NewNullLogger(),
-				AutoMTLS: true,
-			},
-			expectTLSConfig: false,
-		},
-		"not-metadata mode, AutoMTLS": {
-			rc: runConfig{
-				command: "echo",
-				args:    []string{"foo", "bar"},
-				sha256:  []byte("some_sha256"),
-				env:     []string{"initial=true"},
-				pluginSets: map[int]plugin.PluginSet{
-					1: plugin.PluginSet{
-						"bogus": nil,
-					},
-				},
-				hs: plugin.HandshakeConfig{
-					ProtocolVersion:  1,
-					MagicCookieKey:   "magic_cookie_key",
-					MagicCookieValue: "magic_cookie_value",
-				},
-				logger:         hclog.NewNullLogger(),
-				isMetadataMode: false,
-				autoMTLS:       true,
-			},
-
-			responseWrapInfoTimes: 0,
-
-			mlockEnabled:      false,
-			mlockEnabledTimes: 1,
-
-			expectedConfig: &plugin.ClientConfig{
-				HandshakeConfig: plugin.HandshakeConfig{
-					ProtocolVersion:  1,
-					MagicCookieKey:   "magic_cookie_key",
-					MagicCookieValue: "magic_cookie_value",
-				},
-				VersionedPlugins: map[int]plugin.PluginSet{
-					1: plugin.PluginSet{
-						"bogus": nil,
-					},
-				},
-				Cmd: commandWithEnv(
-					"echo",
-					[]string{"foo", "bar"},
-					[]string{
-						"initial=true",
-						fmt.Sprintf("%s=%s", PluginVaultVersionEnv, version.GetVersion().Version),
-						fmt.Sprintf("%s=%t", PluginMetadataModeEnv, false),
-					},
-				),
-				SecureConfig: &plugin.SecureConfig{
-					Checksum: []byte("some_sha256"),
-					// Hash is generated
-				},
-				AllowedProtocols: []plugin.Protocol{
-					plugin.ProtocolNetRPC,
-					plugin.ProtocolGRPC,
-				},
-				Logger:   hclog.NewNullLogger(),
-				AutoMTLS: true,
-			},
-			expectTLSConfig: false,
 		},
 	}
 

--- a/vendor/github.com/hashicorp/vault/sdk/database/dbplugin/v5/plugin_client.go
+++ b/vendor/github.com/hashicorp/vault/sdk/database/dbplugin/v5/plugin_client.go
@@ -45,7 +45,6 @@ func NewPluginClient(ctx context.Context, sys pluginutil.RunnerUtil, pluginRunne
 		pluginutil.HandshakeConfig(handshakeConfig),
 		pluginutil.Logger(logger),
 		pluginutil.MetadataMode(isMetadataMode),
-		pluginutil.AutoMTLS(false),
 	)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/hashicorp/vault/sdk/helper/pluginutil/run_config.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/pluginutil/run_config.go
@@ -26,7 +26,6 @@ type runConfig struct {
 	hs             plugin.HandshakeConfig
 	logger         log.Logger
 	isMetadataMode bool
-	autoMTLS       bool
 }
 
 func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error) {
@@ -46,7 +45,7 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 	cmd.Env = append(cmd.Env, metadataEnv)
 
 	var clientTLSConfig *tls.Config
-	if !rc.autoMTLS && !rc.isMetadataMode {
+	if !rc.isMetadataMode {
 		// Get a CA TLS Certificate
 		certBytes, key, err := generateCert()
 		if err != nil {
@@ -86,7 +85,7 @@ func (rc runConfig) makeConfig(ctx context.Context) (*plugin.ClientConfig, error
 			plugin.ProtocolNetRPC,
 			plugin.ProtocolGRPC,
 		},
-		AutoMTLS: rc.autoMTLS,
+		AutoMTLS: false,
 	}
 	return clientConfig, nil
 }
@@ -136,12 +135,6 @@ func Logger(logger log.Logger) RunOpt {
 func MetadataMode(isMetadataMode bool) RunOpt {
 	return func(rc *runConfig) {
 		rc.isMetadataMode = isMetadataMode
-	}
-}
-
-func AutoMTLS(autoMTLS bool) RunOpt {
-	return func(rc *runConfig) {
-		rc.autoMTLS = autoMTLS
 	}
 }
 


### PR DESCRIPTION
Backports https://github.com/hashicorp/vault/pull/10182 to 1.6.X

edited to add:
Note that this backport is mainly to sync up the state between the release branch and master (and avoid merge conflicts). A separate PR on master will be made to add back this functionality and backported in.