### PR TITLE
Fix outdated enable-versioning command usage in kv

### DIFF
--- a/command/kv_enable_versioning.go
+++ b/command/kv_enable_versioning.go
@@ -22,11 +22,11 @@ func (c *KVEnableVersioningCommand) Synopsis() string {
 
 func (c *KVEnableVersioningCommand) Help() string {
 	helpText := `
-Usage: vault kv enable-versions [options] KEY
+Usage: vault kv enable-versioning [options] KEY
 
   This command turns on versioning for the backend at the provided path.
 
-      $ vault kv enable-versions secret
+      $ vault kv enable-versioning secret
 
   Additional flags and more advanced use cases are detailed below.
 


### PR DESCRIPTION
### Background

- The usage of `vault kv enable-versioning` shows different command name.

```bash
❯ vault kv enable-versioning -h
Usage: vault kv enable-versions [options] KEY

  This command turns on versioning for the backend at the provided path.

      $ vault kv enable-versions secret

  Additional flags and more advanced use cases are detailed below.

HTTP Options:
```