### PR TITLE
add consul service metadata

### DIFF
--- a/serviceregistration/consul/consul_service_registration.go
+++ b/serviceregistration/consul/consul_service_registration.go
@@ -66,6 +66,7 @@ type serviceRegistration struct {
 	serviceName         string
 	serviceTags         []string
 	serviceAddress      *string
+	meta                map[string]string
 	disableRegistration bool
 	checkTimeout        time.Duration
 
@@ -122,6 +123,13 @@ func NewServiceRegistration(conf map[string]string, logger log.Logger, state sr.
 	}
 	if logger.IsDebug() {
 		logger.Debug("config service_address set", "service_address", serviceAddr)
+	}
+
+	meta := make(map[string]string)
+	if metaStr, ok := conf["meta"]; ok {
+		if err := strutil.ParseKeyValues(metaStr, meta, ","); err != nil {
+			return nil, err
+		}
 	}
 
 	checkTimeout := defaultCheckTimeout
@@ -208,6 +216,7 @@ func NewServiceRegistration(conf map[string]string, logger log.Logger, state sr.
 		serviceName:         service,
 		serviceTags:         strutil.ParseDedupLowercaseAndSortStrings(tags, ","),
 		serviceAddress:      serviceAddr,
+		meta:                meta,
 		checkTimeout:        checkTimeout,
 		disableRegistration: disableRegistration,
 
@@ -476,6 +485,7 @@ func (c *serviceRegistration) reconcileConsul(registeredServiceID string) (servi
 		ID:                serviceID,
 		Name:              c.serviceName,
 		Tags:              tags,
+		Meta:              c.meta,
 		Port:              int(c.redirectPort),
 		Address:           serviceAddress,
 		EnableTagOverride: false,

--- a/website/pages/docs/configuration/service-registration/consul.mdx
+++ b/website/pages/docs/configuration/service-registration/consul.mdx
@@ -59,7 +59,7 @@ at Consul's service discovery layer.
 - `disable_registration` `(string: "false")` – Specifies whether Vault should
   register itself with Consul.
 
-- `meta` `(string: "")` - Species a comma-separated list of `<key>=<value>`
+- `meta` `(string: "")` - Specifies a comma-separated list of `<key>=<value>`
   pairs to be added as metadata to the service registration in Consul.
 
 - `scheme` `(string: "http")` – Specifies the scheme to use when communicating

--- a/website/pages/docs/configuration/service-registration/consul.mdx
+++ b/website/pages/docs/configuration/service-registration/consul.mdx
@@ -59,6 +59,9 @@ at Consul's service discovery layer.
 - `disable_registration` `(string: "false")` – Specifies whether Vault should
   register itself with Consul.
 
+- `meta` `(string: "")` - Species a comma-separated list of `<key>=<value>`
+  pairs to be added as metadata to the service registration in Consul.
+
 - `scheme` `(string: "http")` – Specifies the scheme to use when communicating
   with Consul. This can be set to "http" or "https". It is highly recommended
   you communicate with Consul over https over non-local connections. When

--- a/website/pages/docs/configuration/storage/consul.mdx
+++ b/website/pages/docs/configuration/storage/consul.mdx
@@ -77,7 +77,7 @@ and [`cluster_addr`][cluster-addr] ([example][listener-example]).
   support this level of parallelism, see
   [http_max_conns_per_client](https://www.consul.io/docs/agent/options.html#http_max_conns_per_client).
 
-- `meta` `(string: "")` - Species a comma-separated list of `<key>=<value>`
+- `meta` `(string: "")` - Specifies a comma-separated list of `<key>=<value>`
   pairs to be added as metadata to the service registration in Consul.
 
 - `path` `(string: "vault/")` – Specifies the path in Consul's key-value store

--- a/website/pages/docs/configuration/storage/consul.mdx
+++ b/website/pages/docs/configuration/storage/consul.mdx
@@ -77,6 +77,9 @@ and [`cluster_addr`][cluster-addr] ([example][listener-example]).
   support this level of parallelism, see
   [http_max_conns_per_client](https://www.consul.io/docs/agent/options.html#http_max_conns_per_client).
 
+- `meta` `(string: "")` - Species a comma-separated list of `<key>=<value>`
+  pairs to be added as metadata to the service registration in Consul.
+
 - `path` `(string: "vault/")` – Specifies the path in Consul's key-value store
   where Vault data will be stored.
 


### PR DESCRIPTION
An extra configuration parameter "meta" in the Vault configuration's storage block to specify metadata for Consul service registration. Addresses #9121 