### PR TITLE
Docs: Support for scopes in MongoDB Atlas database plugin

### DIFF
--- a/website/pages/api-docs/secret/databases/mongodbatlas.mdx
+++ b/website/pages/api-docs/secret/databases/mongodbatlas.mdx
@@ -67,11 +67,14 @@ list the plugin does not support that statement type.
   serialized JSON object, or a base64-encoded serialized JSON object.
   The object can optionally contain a `database_name`, the name of
   the authentication database to log into MongoDB. In Atlas deployments of
-  MongoDB, the authentication database is always the admin database. And
-  also must contain a `roles` array. This array contains objects that holds
-  a series of roles `roleName`, an optional `databaseName` and `collectionName`
-  value. For more information regarding the `roles` field, refer to
-  [MongoDB Atlas documentation](https://docs.atlas.mongodb.com/reference/api/database-users-create-a-user/).
+  MongoDB, the authentication database is always the admin database. The object
+  must also contain a `roles` array, and from Vault version 1.6.0 (plugin
+  version 0.2.0) may optionally contain a `scopes` array. The `roles` array
+  contains objects that hold a series of roles `roleName`, an optional
+  `databaseName` and `collectionName`  value. The `scopes` array determines
+  which clusters and data lakes the user has access to, and defaults to all
+  scopes if omitted. For more information regarding the `roles` and `scopes`
+  fields, refer to [MongoDB Atlas documentation](https://docs.atlas.mongodb.com/reference/api/database-users-create-a-user/).
 - `default_ttl` `(string/int): 0` - Specifies the TTL for the leases associated with this role.
   Accepts time suffixed strings (`1h`) or an integer number of seconds. Defaults to system/engine default TTL time.
 - `max_ttl` `(string/int): 0` - Specifies the maximum TTL for the leases associated with this role. Accepts time
@@ -92,6 +95,12 @@ list the plugin does not support that statement type.
     {
       "collectionName": "acollection",
       "roleName": "read"
+    }
+  ],
+  "scopes": [
+    {
+      "name": "a-cluster",
+      "type": "CLUSTER"
     }
   ]
 }


### PR DESCRIPTION
Adds some documentation for the new field supported from 1.6.0.