### PR TITLE
Backport: UI/OIDC: allow passing namespace in state (#10171)

### DIFF
--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -128,6 +128,18 @@ export default Component.extend({
     let { namespace, path, state, code } = JSON.parse(oidcState);
     this.getWindow().localStorage.removeItem('oidcState');
 
+    // The namespace can be either be passed as a query paramter, or be embedded
+    // in the state param in the format `<state_id>,ns=<namespace>`. So if
+    // `namespace` is empty, check for namespace in state as well.
+    if (namespace === '') {
+      let i = state.indexOf(',ns=');
+      if (i >= 0) {
+        // ",ns=" is 4 characters
+        namespace = state.substring(i + 4);
+        state = state.substring(0, i);
+      }
+    }
+
     // defer closing of the window, but continue executing the task
     later(() => {
       this.closeWindow(oidcWindow);

--- a/website/pages/api-docs/auth/jwt/index.mdx
+++ b/website/pages/api-docs/auth/jwt/index.mdx
@@ -43,6 +43,7 @@ set.
 - `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256]. ([Available algorithms](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/master/vendor/github.com/coreos/go-oidc/jose.go#L7) + EdDSA)
 - `default_role` `(string: <optional>)` - The default role to use if none is provided during login.
 - `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include Azure; the options are described in each provider's section in [OIDC Provider Setup](/docs/auth/jwt_oidc_providers)
+- `namespace_in_state` `(bool: false)` - Pass namespace in the state parameter instead of as a separate query parameter. With this setting the allowed redirect URL in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it.
 
 ### Sample Payload
 

--- a/website/pages/docs/auth/jwt.mdx
+++ b/website/pages/docs/auth/jwt.mdx
@@ -145,10 +145,14 @@ Logging in via the Vault UI requires a redirect URI of the form:
 
 The "host:port" must be correct for the Vault server, and "path" must match the path the JWT
 backend is mounted at (e.g. "oidc" or "jwt").
-If [namespaces](/docs/enterprise/namespaces) are being used,
+By default, if [namespaces](/docs/enterprise/namespaces) are being used,
 they must be added as query parameters, for example:
 
 `https://vault.example.com:8200/ui/vault/auth/oidc/oidc/callback?namespace=my_ns`
+
+However, as of Vault 1.6, it is no longer necessary to add the namespace as a
+query parameter in the redirect URI, if
+[`namespace_in_state`](/api-docs/auth/jwt#namespace_in_state) is set to `true`.
 
 ### OIDC Login (Vault UI)
 


### PR DESCRIPTION
* UI/OIDC: allow passing namespace in state

Suppport in the UI OIDC callback flow to parse namespace out of the
state parameter instead of a separate query parameter in the
redirect_uri. Includes docs for the option that enables this behavior
in the JWT plugin.

* 1.6 wordsmithing

* pass_namespace_in_state -> namespace_in_state

* re-wording

* use strict equals

Co-authored-by: Vishal Nayak <vishalnayak@users.noreply.github.com>