### PR TITLE
Update Auto Unseal info to say KMS instead of EKS

### DIFF
--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -305,9 +305,9 @@ server:
       }
 ```
 
-#### Amazon EKS Auto Unseal
+#### Amazon KMS Auto Unseal
 
-The Helm chart may be run with [AWS EKS for Auto
+The Helm chart may be run with [AWS KMS for Auto
 Unseal](/docs/configuration/seal/awskms). This enables Vault server pods to auto
 unseal if they are rescheduled.
 
@@ -316,17 +316,17 @@ are defined in each Vault server pod.
 
 ##### Create the Secret
 
-First, create a secret with your EKS access key/secret:
+First, create a secret with your KMS access key/secret:
 
 ```shell-session
-$ kubectl create secret generic eks-creds \
+$ kubectl create secret generic kms-creds \
     --from-literal=AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID?}" \
     --from-literal=AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY?}"
 ```
 
 ##### Config Example
 
-This is a Vault Helm configuration that uses AWS EKS:
+This is a Vault Helm configuration that uses AWS KMS:
 
 ```yaml
 global:
@@ -335,10 +335,10 @@ global:
 server:
   extraSecretEnvironmentVars:
     - envName: AWS_ACCESS_KEY_ID
-      secretName: eks-creds
+      secretName: kms-creds
       secretKey: AWS_ACCESS_KEY_ID
     - envName: AWS_SECRET_ACCESS_KEY
-      secretName: eks-creds
+      secretName: kms-creds
       secretKey: AWS_SECRET_ACCESS_KEY
 
   ha:


### PR DESCRIPTION
While EKS may be the managed kubernetes environment under the hood, I believe the idea behind this section of the documentation is to use AWS KMS for seal/unseal operations, not EKS.  (i.e. The surrounding documentation is discussing other Auto Unseal options such as Google KMS.)  

The use of the term EKS instead of KMS made it hard for me to discover this section of documentation, and was a little confusing at first until I realized the possible error.