### PR TITLE
Fix typo about environment variable in docs

### DIFF
--- a/website/pages/docs/configuration/seal/transit.mdx
+++ b/website/pages/docs/configuration/seal/transit.mdx
@@ -69,7 +69,7 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
 
 - `tls_ca_cert` `(string: "")`: Specifies the path to the CA certificate file used
   for communication with the Vault server. This may also be specified using the
-  `VAULT_CA_CERT` environment variable.
+  `VAULT_CACERT` environment variable.
 
 - `tls_client_cert` `(string: "")`: Specifies the path to the client certificate
   for communication with the Vault server. This may also be specified using the


### PR DESCRIPTION
The CLI appears to read from `VAULT_CACERT` instead of `VAULT_CA_CERT` as the docs currently say. Basing this off code [here](https://github.com/hashicorp/vault/blob/a8566c4f8999b96e540f9001d5d8ab9433e82a92/api/client.go#L30) and personal observation.