### PR TITLE
Expose ssh algorithm_signer in web interface (#10114)

### DIFF
--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -360,6 +360,7 @@ func pathRoles(b *backend) *framework.Path {
 				When supplied, this value specifies a signing algorithm for the key. Possible values:
 				ssh-rsa, rsa-sha2-256, rsa-sha2-512, default, or the empty string.
 				`,
+				AllowedValues: []interface{}{"", ssh.SigAlgoRSA, ssh.SigAlgoRSASHA2256, ssh.SigAlgoRSASHA2512},
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Signing Algorithm",
 				},

--- a/changelog/10299.txt
+++ b/changelog/10299.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Add algorithm-signer as a SSH Secrets Engine UI field
+```

--- a/ui/app/models/role-ssh.js
+++ b/ui/app/models/role-ssh.js
@@ -37,6 +37,7 @@ const CA_FIELDS = [
   'allowUserKeyIds',
   'keyIdFormat',
   'notBeforeDuration',
+  'algorithmSigner',
 ];
 
 export default Model.extend({
@@ -116,6 +117,9 @@ export default Model.extend({
   }),
   keyIdFormat: attr('string', {
     helpText: 'When supplied, this value specifies a custom format for the key id of a signed certificate',
+  }),
+  algorithmSigner: attr('string', {
+    helpText: 'When supplied, this value specifies a signing algorithm for the key',
   }),
 
   showFields: computed('keyType', function () {


### PR DESCRIPTION
Implements: #10114 
* Adds allowed values for algorithm_signer to ssh plugin API
* Adds algorithm_signer as field in UI