### PR TITLE
Make signature error more informative

### DIFF
--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -532,7 +532,7 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 	algo := b.Role.AlgorithmSigner
 	sig, err := sshAlgorithmSigner.SignWithAlgorithm(rand.Reader, certificateBytes, algo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate signed SSH key: sign error")
+		return nil, errwrap.Wrapf("failed to generate signed SSH key: sign error: {{err}}", err)
 	}
 
 	certificate.Signature = sig


### PR DESCRIPTION
The brief "sign error" error message might cause confusion, which, for example, resulted in #10067 being filed.
Changes in this PR wrap an error coming from `golang.org/x/crypto/ssh` to make the error message a bit more informative, in order to simplify troubleshooting by an end-user.