### PR TITLE
Use packagespec's auto signed tag feature

### DIFF
--- a/packages-oss.yml
+++ b/packages-oss.yml
@@ -20,6 +20,7 @@ config:
   product-id:            github.com/hashicorp/vault
   circleci-project-slug: gh/hashicorp/vault
   circleci-host:         circleci.com
+  on-publish:            create-github-release
 
 # inputs are a set of environment variables that may affect the set of bytes produced
 # for a given package. Note that a package is a zip file containing the binary, so


### PR DESCRIPTION
This PR needs to be backported to the 1.6 release branch, and 1.5 if it's not there, but I've made the change on master so it will apply to future release branches.

This configuration should not be applied on enterprise, so I don't think we need to re-merge OSS in there.