### PR TITLE
Move "counters" path to the logical system's local path list. (#10314)

### DIFF
--- a/vault/counters.go
+++ b/vault/counters.go
@@ -12,8 +12,11 @@ import (
 
 const (
 	requestCounterDatePathFormat = "2006/01"
-	countersPath                 = systemBarrierPrefix + "counters"
-	requestCountersPath          = "sys/counters/requests/"
+
+	// This storage path stores both the request counters in this file, and the activity log.
+	countersSubPath = "counters/"
+
+	requestCountersPath = "sys/counters/requests/"
 )
 
 type counters struct {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -141,6 +141,7 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 
 			LocalStorage: []string{
 				expirationSubPath,
+				countersSubPath,
 			},
 		},
 	}


### PR DESCRIPTION
Backport planned for GA, but not for RC.