### PR TITLE
Fix inner link on transform item

### DIFF
--- a/ui/app/templates/components/transform-list-item.hbs
+++ b/ui/app/templates/components/transform-list-item.hbs
@@ -11,7 +11,7 @@
     <div class="column is-10">
       <SecretLink
         @mode="show"
-        @secret={{item.id}}
+        @secret={{itemPath}}
         @queryParams={{query-params type=modelType}}
         @class="has-text-black has-text-weight-semibold">
         <Icon


### PR DESCRIPTION
This ticket fixes a bug where clicking on the name of the transformation item (such as a role name) directs to the incorrect link. 
![link-bug](https://user-images.githubusercontent.com/16182107/98154485-7748f900-1e9a-11eb-95d0-e634eded87fe.gif)
