### PR TITLE
[Website] - removed unnecessary 'the' (minor typo)

### DIFF
--- a/website/pages/docs/configuration/storage/raft.mdx
+++ b/website/pages/docs/configuration/storage/raft.mdx
@@ -16,7 +16,7 @@ description: |-
 The Integrated Storage backend is used to persist Vault's data. Unlike other storage
 backends, Integrated Storage does not operate from a single source of data. Instead
 all the nodes in a Vault cluster will have a replicated copy of Vault's data.
-Data gets replicated across the all the nodes via the [Raft Consensus
+Data gets replicated across all the nodes via the [Raft Consensus
 Algorithm][raft].
 
 - **High Availability** – the Integrated Storage backend supports high availability.


### PR DESCRIPTION
I was going through the docs for _Integrated Storage_ and I believe I found a minor typo.