### PR TITLE
Update MongoDB Atlas plugin docs

### DIFF
--- a/website/pages/docs/secrets/databases/index.mdx
+++ b/website/pages/docs/secrets/databases/index.mdx
@@ -131,7 +131,9 @@ the proper permission, it can generate credentials.
     ```
 
 ## Database Capabilities
-As of Vault 1.6, all databases support dynamic roles, static roles, and rotating the root user's credentials.
+As of Vault 1.6, all databases support dynamic roles and static roles. All plugins except MongoDB Atlas support rotating
+the root user's credentials. MongoDB Atlas cannot support rotating the root user's credentials because it uses a public
+and private key pair to authenticate.
 
 | Database                                              | Root Credential Rotation | Dynamic Roles | Static Roles |
 | ----------------------------------------------------- | ------------------------ | ------------- | ------------ |

--- a/website/pages/docs/secrets/databases/index.mdx
+++ b/website/pages/docs/secrets/databases/index.mdx
@@ -141,7 +141,7 @@ As of Vault 1.6, all databases support dynamic roles, static roles, and rotating
 | [HanaDB](/docs/secrets/databases/hanadb)              | Yes (1.6+)               | Yes           | Yes (1.6+)   |
 | [InfluxDB](/docs/secrets/databases/influxdb)          | Yes                      | Yes           | Yes (1.6+)   |
 | [MongoDB](/docs/secrets/databases/mongodb)            | Yes                      | Yes           | Yes          |
-| [MongoDB Atlas](/docs/secrets/databases/mongodbatlas) | Yes (1.6+)               | Yes           | Yes          |
+| [MongoDB Atlas](/docs/secrets/databases/mongodbatlas) | No                       | Yes           | Yes          |
 | [MSSQL](/docs/secrets/databases/mssql)                | Yes                      | Yes           | Yes          |
 | [MySQL/MariaDB](/docs/secrets/databases/mysql-maria)  | Yes                      | Yes           | Yes          |
 | [Oracle](/docs/secrets/databases/oracle)              | Yes                      | Yes           | Yes          |

--- a/website/pages/docs/secrets/databases/mongodbatlas.mdx
+++ b/website/pages/docs/secrets/databases/mongodbatlas.mdx
@@ -12,7 +12,8 @@ description: |-
 
 MongoDB Atlas is one of the supported plugins for the database secrets engine. This
 plugin generates database credentials dynamically based on configured roles for
-MongoDB Atlas databases.
+MongoDB Atlas databases. It cannot support rotating the root user's credentials because
+it uses a public and private key pair to authenticate.
 
 See the [database secrets engine](/docs/secrets/databases) docs for
 more information about setting up the database secrets engine.

--- a/website/pages/docs/secrets/databases/mongodbatlas.mdx
+++ b/website/pages/docs/secrets/databases/mongodbatlas.mdx
@@ -20,7 +20,7 @@ more information about setting up the database secrets engine.
 ## Capabilities
 | Plugin Name                    | Root Credential Rotation | Dynamic Roles | Static Roles |
 | ------------------------------ | ------------------------ | ------------- | ------------ |
-| `mongodbatlas-database-plugin` | Yes (1.6+)               | Yes           | Yes          |
+| `mongodbatlas-database-plugin` | No                       | Yes           | Yes          |
 
 ## Setup
 


### PR DESCRIPTION
Root credential rotation not supported as the Vault user uses public/private keys instead of passwords to authenticate.