### PR TITLE
Wait for asynchronous deletion to finish before restarting.

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -732,6 +732,19 @@ func (a *ActivityLog) deleteLogWorker(startTimestamp int64, whenDone chan struct
 	close(whenDone)
 }
 
+func (a *ActivityLog) WaitForDeletion() {
+	a.l.Lock()
+	// May be nil, if never set
+	doneCh := a.deleteDone
+	a.l.Unlock()
+	if doneCh != nil {
+		select {
+		case <-doneCh:
+			break
+		}
+	}
+}
+
 // refreshFromStoredLog loads the appropriate entities/tokencounts for active and performance standbys
 // the most recent segment is loaded synchronously, and older segments are loaded in the background
 // this function expects stateLock to be held

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -1238,6 +1238,13 @@ func TestActivityLog_StopAndRestart(t *testing.T) {
 		DefaultReportMonths: 12,
 	})
 
+	// On enterprise, a segment will be created, and
+	// disabling it will trigger deletion, so wait
+	// for that deletion to finish.
+	// (Alternatively, we could ensure that the next segment
+	// uses a different timestamp by waiting 1 second.)
+	a.WaitForDeletion()
+
 	// Go through request to ensure config is persisted
 	req := logical.TestRequest(t, logical.UpdateOperation, "internal/counters/config")
 	req.Storage = sysView


### PR DESCRIPTION
Fixes flaky unit test, with this signature:

```
--- FAIL: TestActivityLog_StopAndRestart (0.02s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x3850921]

goroutine 9717 [running]:
testing.tRunner.func1.1(0x43dd9e0, 0x7bafb20)
	/usr/local/go/src/testing/testing.go:1072 +0x30d
testing.tRunner.func1(0xc002b52f00)
	/usr/local/go/src/testing/testing.go:1075 +0x41a
panic(0x43dd9e0, 0x7bafb20)
	/usr/local/go/src/runtime/panic.go:969 +0x1b9
github.com/hashicorp/vault/vault.(*ActivityLog).loadTokenCount(0xc004351b80, 0x555ca00, 0xc0043aa140, 0x0, 0xed7379650, 0x0, 0x1, 0x0)
	/go/src/github.com/hashicorp/vault/vault/activity_log.go:626 +0x1e1
github.com/hashicorp/vault/vault.(*ActivityLog).refreshFromStoredLog(0xc004351b80, 0x555ca00, 0xc0043aa140, 0xc0046df9d0, 0x0, 0x0)
	/go/src/github.com/hashicorp/vault/vault/activity_log.go:803 +0x8cf
github.com/hashicorp/vault/vault.(*Core).setupActivityLog(0xc002d24000, 0x555cac0, 0xc004360de0, 0xc004351a40, 0x0)
	/go/src/github.com/hashicorp/vault/vault/activity_log.go:965 +0x1e5
github.com/hashicorp/vault/vault.TestActivityLog_StopAndRestart(0xc002b52f00)
	/go/src/github.com/hashicorp/vault/vault/activity_log_test.go:1255 +0x347
testing.tRunner(0xc002b52f00, 0x4f20a78)
	/usr/local/go/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1168 +0x2b3
```

My analysis of this suggests that the problem is that (on enterprise) disabling activity log kicks off an asynchronous deletion worker, which could still be running when we stop and restart activity log.  So if we're very unlucky, the existing token count storage entry could be deleted between checking for its existence, and loading it, resulting in a nil.

I didn't add a nil check, though we *could* do that instead of checking for existence of the storage object first.

This does suggest there's a problem here, though, if somebody enables, disabled, and enables in the same second then the timestamp could be the same.  A quick disable/enable would ordinarily not matter because the timestamp would be some previous second.

