### PR TITLE
agent/auth/cert: fix reauthentication when certs specified in config

### DIFF
--- a/command/agent/auth/cert/cert.go
+++ b/command/agent/auth/cert/cert.go
@@ -108,7 +108,7 @@ func (c *certMethod) AuthClient(client *api.Client) (*api.Client, error) {
 	if c.caCert != "" || (c.clientKey != "" && c.clientCert != "") {
 		// Return cached client if present
 		if c.client != nil {
-			return client, nil
+			return c.client, nil
 		}
 
 		config := api.DefaultConfig()


### PR DESCRIPTION
Vault agent is failing to reauthenticate with cert auth method, when the agent auto_auth method is configured with a client certificate.

It has been broken since https://github.com/hashicorp/vault/pull/9819, Vault v1.5.1.

Adding E2E test to avoid the same bug in future.