### PR TITLE
docs: enabling mtls with cf auth plugin

### DIFF
--- a/website/pages/docs/auth/cf.mdx
+++ b/website/pages/docs/auth/cf.mdx
@@ -251,6 +251,26 @@ $ vault login -method=cf role=test-role
 For CF, we do also offer an agent that, once configured, can be used to obtain a Vault token on
 your behalf.
 
+
+### Enabling mutual TLS with the CF API
+
+The CF API can be configured to require mutual TLS with clients. This plugin supports mutual TLS by setting the
+`cf_api_mutual_tls_certificate` and `cf_api_mutual_tls_key` configuration properties.
+
+```
+$ vault write auth/cf/config \
+      identity_ca_certificates=@ca.crt \
+      cf_api_addr=https://api.dev.cfdev.sh \
+      cf_username=vault \
+      cf_password=pa55w0rd \
+      cf_api_trusted_certificates=@cfapi.crt \
+      cf_api_mutual_tls_certificate=@cfmutualtls.crt \
+      cf_api_mutual_tls_key=@cfmutualtls.key
+```
+
+The provided certificate must be signed by a certificate authority trusted by the CF API. Obtaining such a certificate
+depends on the specifics of your deployment of Cloud Foundry.
+
 ### Maintenance
 
 In testing we found that CF instance identity CA certificates were set to expire in 3 years. Some


### PR DESCRIPTION
This PR adds documentation for enabling mutual TLS with the CloudFoundry API. It accompanies [hashicorp/vault-plugin-auth-cf/pull/41](https://github.com/hashicorp/vault-plugin-auth-cf/pull/41)