### PR TITLE
Update elasticsearch docs

### DIFF
--- a/website/pages/docs/secrets/databases/elasticdb.mdx
+++ b/website/pages/docs/secrets/databases/elasticdb.mdx
@@ -73,8 +73,8 @@ POST to Elasticsearch. To do this, we used the `elastic` vaultuser whose passwor
 $ curl \
     -X POST \
     -H "Content-Type: application/json" \
-    -d '{"cluster": ["manage_security"]}' \
-    http://vaultuser:$PASSWORD@localhost:9200/_xpack/security/role/vault
+    -d '{"cluster": ["manage_security", "monitor"]}' \
+    http://vaultuser:$PASSWORD@localhost:9200/_security/role/vault
 ```
 
 Next, create a user for Vault associated with that role.
@@ -84,7 +84,7 @@ $ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d @data.json \
-    http://vaultuser:$PASSWORD@localhost:9200/_xpack/security/user/vault
+    http://vaultuser:$PASSWORD@localhost:9200/_security/user/vault
 ```
 
 The contents of `data.json` in this example are:


### PR DESCRIPTION
Add "monitor" to example role permissions, necessary for the plugin to determine which version of elasticsearch is in use, and to adjust the x-pack api url accordingly.

Depends on https://github.com/hashicorp/vault-plugin-database-elasticsearch/pull/25