### PR TITLE
Add upgrade note for Database interface change in 1.6

### DIFF
--- a/website/pages/docs/upgrading/upgrade-to-1.6.0.mdx
+++ b/website/pages/docs/upgrading/upgrade-to-1.6.0.mdx
@@ -19,4 +19,14 @@ storage of its configuration in order to accommodate the new transformation
 type oriented configuration API.  Secondaries will receive the 
 modifications via replication. 
 
+## Database Engine Interface Upgrade
 
+The Database Engine has changed the underlying interface between Vault and each database
+implementation. This change allows use of [password policies](/docs/concepts/password-policies)
+within the Database engine. The API for the Database Engine has not changed, only the underlying
+interface between Vault and the database plugins. All built-in database plugins (as well as the
+[Oracle](https://github.com/hashicorp/vault-plugin-database-oracle) plugin) have been upgraded to
+the new interface so no user actions are needed. Vault will continue to recognize existing custom
+database plugins but the old interface should be considered deprecated and may be removed in a
+future release. See our [upgrade guide for custom databases](/docs/secrets/databases/custom) for
+more information on upgrading custom database plugins.


### PR DESCRIPTION
Adds a note in the upgrade guide about the Database Engine's interface change in 1.6 & warns users that they should upgrade their existing plugins to the new interface as the support for the old interface may be removed at some point in the future.

## Prerequisites before merging
- [x] https://github.com/hashicorp/vault/pull/10371 Merged
- [x] Base branch changed to `master`