### PR TITLE
Plugin Portal: Link to community plugin for Artifactory secrets

### DIFF
--- a/website/pages/docs/plugin-portal/index.mdx
+++ b/website/pages/docs/plugin-portal/index.mdx
@@ -116,6 +116,7 @@ Plugin authors who wish to have their plugins listed may file a submission via a
 
 ### Secrets
 
+- [Artifactory](https://github.com/jsok/vault-plugin-secrets-artifactory)
 - [Ethereum](https://github.com/immutability-io/vault-ethereum)
 - [GitHub](https://github.com/martinbaillie/vault-plugin-secrets-github)
 


### PR DESCRIPTION
A secrets plugin which issues Artifactory access tokens (short-lived and revocable).