### PR TITLE
InfluxDB - Check for errors in the response too

### DIFF
--- a/plugins/database/influxdb/influxdb.go
+++ b/plugins/database/influxdb/influxdb.go
@@ -112,7 +112,7 @@ func (i *Influxdb) NewUser(ctx context.Context, req dbplugin.NewUserRequest) (re
 					attemptRollback(cli, username, rollbackIFQL)
 				}
 
-				return dbplugin.NewUserResponse{}, fmt.Errorf("failed to run query in InfluxDB: %w", merr.ErrorOrNil())
+				return dbplugin.NewUserResponse{}, fmt.Errorf("failed to run query in InfluxDB: %w", merr)
 			}
 		}
 	}
@@ -140,7 +140,7 @@ func attemptRollback(cli influx.Client, username string, rollbackStatements []st
 			// err can be nil with response.Error() being not nil, so both need to be handled
 			merr := multierror.Append(err, response.Error())
 			if merr.ErrorOrNil() != nil {
-				return merr.ErrorOrNil()
+				return merr
 			}
 		}
 	}

--- a/plugins/database/influxdb/influxdb.go
+++ b/plugins/database/influxdb/influxdb.go
@@ -107,6 +107,7 @@ func (i *Influxdb) NewUser(ctx context.Context, req dbplugin.NewUserRequest) (re
 			// err can be nil with response.Error() being not nil, so both need to be handled
 			merr := multierror.Append(err, response.Error())
 			if merr.ErrorOrNil() != nil {
+				// Attempt rollback only when the response has an error
 				if response != nil && response.Error() != nil {
 					attemptRollback(cli, username, rollbackIFQL)
 				}
@@ -139,9 +140,7 @@ func attemptRollback(cli influx.Client, username string, rollbackStatements []st
 			// err can be nil with response.Error() being not nil, so both need to be handled
 			merr := multierror.Append(err, response.Error())
 			if merr.ErrorOrNil() != nil {
-				if response != nil && response.Error() != nil {
-					return merr.ErrorOrNil()
-				}
+				return merr.ErrorOrNil()
 			}
 		}
 	}


### PR DESCRIPTION
Fixes an issue where we aren't checking the error in the `Response` object in addition to the `err` returned.