### PR TITLE
Clarify JWT in kubernetes auth docs

### DIFF
--- a/website/pages/api-docs/auth/kubernetes/index.mdx
+++ b/website/pages/api-docs/auth/kubernetes/index.mdx
@@ -29,7 +29,7 @@ access the Kubernetes API.
 ### Parameters
 
 - `kubernetes_host` `(string: <required>)` - Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.
-- `kubernetes_ca_cert` `(string: "")` - PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API. NOTE: Every line must end with a newline: \n
+- `kubernetes_ca_cert` `(string: "")` - PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API. NOTE: Every line must end with a newline: `\n`
 - `token_reviewer_jwt` `(string: "")` - A service account JWT used to access the TokenReview
   API to validate other JWTs during login. If not set,
   the JWT submitted in the login payload will be used to access the Kubernetes TokenReview API.

--- a/website/pages/docs/auth/kubernetes.mdx
+++ b/website/pages/docs/auth/kubernetes.mdx
@@ -32,7 +32,7 @@ at a different path, use that value instead of `kubernetes`.
 ```shell-session
 $ curl \
     --request POST \
-    --data '{"jwt": "your_service_account_jwt", "role": "demo"}' \
+    --data '{"jwt": "<your service account jwt>", "role": "demo"}' \
     http://127.0.0.1:8200/v1/auth/kubernetes/login
 ```
 

--- a/website/pages/docs/auth/kubernetes.mdx
+++ b/website/pages/docs/auth/kubernetes.mdx
@@ -74,7 +74,7 @@ management tool.
 
     ```text
     $ vault write auth/kubernetes/config \
-        token_reviewer_jwt="reviewer_service_account_jwt" \
+        token_reviewer_jwt="<your reviewer service account JWT>" \
         kubernetes_host=https://192.168.99.100:8443 \
         kubernetes_ca_cert=@ca.crt
     ```


### PR DESCRIPTION
Clarifies JWT configuration parameter in Kubernetes auth docs.

Fixes https://github.com/hashicorp/vault-plugin-auth-kubernetes/issues/15