### PR TITLE
Clarify docs around autoseals

### DIFF
--- a/website/pages/docs/concepts/seal.mdx
+++ b/website/pages/docs/concepts/seal.mdx
@@ -19,14 +19,13 @@ read the decryption key to decrypt the data, allowing access to the Vault.
 Prior to unsealing, almost no operations are possible with Vault. For
 example authentication, managing the mount tables, etc. are all not possible.
 The only possible operations are to unseal the Vault and check the status
-of the unseal.
+of the seal.
 
 ## Why?
 
-The data stored by Vault is stored encrypted. Vault needs the
-_encryption key_ in order to decrypt the data. The encryption key is
-also stored with the data (in the _keyring_), but encrypted with another
-encryption key known as the _master key_.
+The data stored by Vault is encrypted. Vault needs the _encryption key_ in order
+to decrypt the data. The encryption key is also stored with the data
+(in the _keyring_), but encrypted with another encryption key known as the _master key_.
 
 Therefore, to decrypt the data, Vault must decrypt the encryption key
 which requires the master key. Unsealing is the process of getting access to
@@ -74,8 +73,8 @@ AutoUnseal will provide a better experience.
 ## Sealing
 
 There is also an API to seal the Vault. This will throw away the master
-key and require another unseal process to restore it. Sealing only requires
-a single operator with root privileges.
+key in memory and require another unseal process to restore it. Sealing
+only requires a single operator with root privileges.
 
 This way, if there is a detected intrusion, the Vault data can be locked
 quickly to try to minimize damages. It can't be accessed again without
@@ -91,10 +90,18 @@ to decrypt the master key Vault read from storage.
 
 ![AutoUnseal](/img/vault-autounseal-storage.png)
 
-When using Auto Unseal there are certain operations in Vault that still
-require a quorum of users to perform an operation such as generating a root token.
-During the initialization process, a set of Shamir keys are generated that are called
-_recovery keys_ and are used for these operations.
+There are certain operations in Vault besides unsealing that
+require a quorum of users to perform, e.g. generating a root token.  When
+using a Shamir seal the unseal keys must be provided to authorize these
+operations.  When using Auto Unseal these operations require _recovery
+keys_ instead.
+
+Just as the initialization process with a Shamir seal yields unseal keys,
+initializing with an Auto Unseal yields recovery keys.
+
+-> **Note:** Recovery keys cannot decrypt the master key, and thus are not
+sufficient to unseal Vault if the AutoUnseal mechanism isn't working.  They
+are purely an authorization mechanism.
 
 It is still possible to seal a Vault node using the API.  In this case Vault
 will remain sealed until restarted, or the unseal API is used, which with AutoUnseal
@@ -106,16 +113,14 @@ For a list of examples and supported providers, please see the
 
 ## Recovery Key Rekeying
 
-During the KMS Seal initialization process, a set of Shamir keys called recovery keys are
-generated which are used for operations that still require a quorum of users.
-
-Recovery keys can be rekeyed to change the number of shares or thresholds. When using the
-Vault CLI, this is performed by using the `-target=recovery` flag to `vault operator rekey`.
+Recovery keys can be rekeyed to change the number of shares or thresholds.
+When using the Vault CLI, this is performed by using the `-target=recovery` flag
+to `vault operator rekey`.
 
 ## Seal Migration
 
-The seal can be migrated from Shamir Seal to KMS Seal, KMS Seal to Shamir Seal,
-and KMS Seal to another KMS Seal.
+The seal can be migrated from Shamir Seal to Auto Unseal, Auto Unseal to Shamir Seal,
+and Auto Unseal to another Auto Unseal.
 
 ~> **NOTE**: A backup should be taken before starting seal migration in case
 something goes wrong.
@@ -128,11 +133,12 @@ but we believe that switching seals is a rare event and hence we hope for the
 downtime to be considered as an acceptable trade-off.
 
 ~> **NOTE**: Seal migration operation will require both old and new seals to be
-available during the migration. For example, migration from KMS seal to Shamir
-seal will require that the KMS key be accessible during the migration.
+available during the migration. For example, migration from Auto Unseal to Shamir
+seal will require that the service backing the Auto Unseal is accessible during
+the migration.
 
-~> **NOTE**: Seal migration from KMS seal to KMS seal of same kind is not
-currently supported. We plan to support this officially in a future release.
+~> **NOTE**: Seal migration from Auto Unseal to Auto Unseal of the same type
+(e.g. AWSKMS to AWSKMS with a different key) is supported since Vault 1.6.0.
 
 ### Migration post Vault 1.5.1
 
@@ -142,20 +148,20 @@ any storage backend.
 1. Take a standby node down and update the [seal
    configuration](/docs/configuration/seal).
 
-    * If the migration is from Shamir seal to KMS seal, add the desired new KMS
+    * If the migration is from Shamir seal to Auto seal, add the desired new Auto
       seal block to the configuration.
-    * If the migration is from KMS seal to Shamir seal, add `disabled = "true"`
+    * If the migration is from Auto seal to Shamir seal, add `disabled = "true"`
       to the old seal block.
-    * If the migration is from KMS seal to another KMS seal, add `disabled =
-      "true"` to the old seal block and add the desired new KMS seal block.
+    * If the migration is from Auto seal to another Auto seal, add `disabled =
+      "true"` to the old seal block and add the desired new Auto seal block.
 
     Now, bring the standby node back up and run the unseal command on each key, by
     supplying the `-migrate` flag.
 
     * Supply Shamir unseal keys if the old seal was Shamir, which will be migrated
-      as the recovery keys for the KMS seal.
-    * Supply recovery keys if the old seal is one of KMS seals, which will be
-      migrated as the recovery keys of the new KMS seal, or as Shamir unseal
+      as the recovery keys for the Auto seal.
+    * Supply recovery keys if the old seal is one of Auto seals, which will be
+      migrated as the recovery keys of the new Auto seal, or as Shamir unseal
       keys if the new seal is Shamir.
 
 1. Perform step 1 for all the standby nodes, one at a time. It is necessary to
@@ -171,14 +177,14 @@ any storage backend.
 1. The new active node will perform the migration. Monitor the server log in
    the active node to witness the completion of the seal migration process.
    Wait for a little while for the migration information to replicate to all the
-   nodes in case of Integrated Storage. In enterprise Vault, switching a KMS seal
+   nodes in case of Integrated Storage. In enterprise Vault, switching a Auto seal
    implies that the seal wrapped storage entries get re-wrapped. Monitor the log
    and wait until this process is complete (look for `seal re-wrap completed`).
 
 1. Seal migration is now completed. Take down the old active node, update its
    configuration of the old active node to use the new seal blocks (completely
    unaware of the old seal type) and bring it back up. It will be auto-unsealed if
-   the new seal is one of the KMS seals, or will require unseal keys if the new
+   the new seal is one of the Auto seals, or will require unseal keys if the new
    seal is Shamir.
 
 1. At this point, configuration files of all the nodes can be updated to only have the


### PR DESCRIPTION
Avoid using "KMS seal" since it causes confusion: some people think that excludes HSMs, and it's not obvious that Transit is a KMS.

Highlight that recovery keys can't be used for recovery when an auto seal is broken (unfortunate name, that.)