### PR TITLE
Sanitize private_key from returned db plugin config

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -649,6 +649,7 @@ func TestBackend_connectionCrud(t *testing.T) {
 		"allowed_roles":  []string{"plugin-role-test"},
 		"username":       "postgres",
 		"password":       "secret",
+		"private_key":    "PRIVATE_KEY",
 	}
 	req = &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -669,8 +670,16 @@ func TestBackend_connectionCrud(t *testing.T) {
 	if err != nil || (resp != nil && resp.IsError()) {
 		t.Fatalf("err:%s resp:%#v\n", err, resp)
 	}
-	if strings.Contains(resp.Data["connection_details"].(map[string]interface{})["connection_url"].(string), "secret") {
+	returnedConnectionDetails := resp.Data["connection_details"].(map[string]interface{})
+	if strings.Contains(returnedConnectionDetails["connection_url"].(string), "secret") {
 		t.Fatal("password should not be found in the connection url")
+	}
+	// Covered by the filled out `expected` value below, but be explicit about this requirement.
+	if _, exists := returnedConnectionDetails["password"]; exists {
+		t.Fatal("password should NOT be found in the returned config")
+	}
+	if _, exists := returnedConnectionDetails["private_key"]; exists {
+		t.Fatal("private_key should NOT be found in the returned config")
 	}
 
 	// Replace connection url with templated version

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -207,6 +207,7 @@ func (b *databaseBackend) connectionReadHandler() framework.OperationFunc {
 		}
 
 		delete(config.ConnectionDetails, "password")
+		delete(config.ConnectionDetails, "private_key")
 
 		return &logical.Response{
 			Data: structs.New(config).Map(),


### PR DESCRIPTION
If you go through the [docs for setting up mongodbatlas-database-plugin](https://www.vaultproject.io/docs/secrets/databases/mongodbatlas#setup), and then run `vault read database/config/my-mongodbatlas-database`, you'll get the following:

```bash
vault read database/config/my-mongodbatlas-database
Key                                   Value
---                                   -----
allowed_roles                         [my-role]
connection_details                    map[private_key:ea6acbc7-8a30-4a3f-812e-6f869c08bcd1 project_id:4f96cad208574fd14aa8dda3a public_key:jmskfortvf]
password_policy                       n/a
plugin_name                           mongodbatlas-database-plugin
root_credentials_rotate_statements    []
```

The `private_key` is a sensitive value that should not be printed back out.

We already sanitize `password` for all DB plugins, including in the connection URL, and that covers the sensitive information for all other builtin database plugins. The only exception is hashicorp/vault-plugin-database-mongodbatlas. While we should provide a mechanism for non-builtin plugins to specify config fields as sensitive, this one-liner fix at least shores up the last of the builtin plugins.