### PR TITLE
Fix license caching issue

### DIFF
--- a/changelog/10424.txt
+++ b/changelog/10424.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+license: Fix license caching issue that prevents new licenses to get picked up by the license manager
+```

--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -29,6 +29,7 @@ var cacheExceptionsPaths = []string{
 	"sys/expire/",
 	"core/poison-pill",
 	"core/raft/tls",
+	"core/license",
 }
 
 // CacheRefreshContext returns a context with an added value denoting if the

--- a/vendor/github.com/hashicorp/vault/sdk/physical/cache.go
+++ b/vendor/github.com/hashicorp/vault/sdk/physical/cache.go
@@ -29,6 +29,7 @@ var cacheExceptionsPaths = []string{
 	"sys/expire/",
 	"core/poison-pill",
 	"core/raft/tls",
+	"core/license",
 }
 
 // CacheRefreshContext returns a context with an added value denoting if the


### PR DESCRIPTION
This PR fixes an issue where the license is cached and impossible to pickup a new license by the License-Manager if it got updated by an active node.