### PR TITLE
backport: allow null in transit requests [VAULT-849]

### DIFF
--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"reflect"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -158,7 +159,8 @@ func decodeBatchRequestItems(src interface{}, dst *[]BatchRequestItem) error {
 		}
 
 		if v, has := item["context"]; has {
-			if casted, ok := v.(string); ok {
+			if !reflect.ValueOf(v).IsValid() {
+			} else if casted, ok := v.(string); ok {
 				(*dst)[i].Context = casted
 			} else {
 				errs.Errors = append(errs.Errors, fmt.Sprintf("'[%d].context' expected type 'string', got unconvertible type '%T'", i, item["context"]))
@@ -166,13 +168,15 @@ func decodeBatchRequestItems(src interface{}, dst *[]BatchRequestItem) error {
 		}
 
 		if v, has := item["ciphertext"]; has {
-			if casted, ok := v.(string); ok {
+			if !reflect.ValueOf(v).IsValid() {
+			} else if casted, ok := v.(string); ok {
 				(*dst)[i].Ciphertext = casted
 			} else {
 				errs.Errors = append(errs.Errors, fmt.Sprintf("'[%d].ciphertext' expected type 'string', got unconvertible type '%T'", i, item["ciphertext"]))
 			}
 		}
 
+		// don't allow "null" to be passed in for the plaintext value
 		if v, has := item["plaintext"]; has {
 			if casted, ok := v.(string); ok {
 				(*dst)[i].Plaintext = casted
@@ -182,7 +186,8 @@ func decodeBatchRequestItems(src interface{}, dst *[]BatchRequestItem) error {
 		}
 
 		if v, has := item["nonce"]; has {
-			if casted, ok := v.(string); ok {
+			if !reflect.ValueOf(v).IsValid() {
+			} else if casted, ok := v.(string); ok {
 				(*dst)[i].Nonce = casted
 			} else {
 				errs.Errors = append(errs.Errors, fmt.Sprintf("'[%d].nonce' expected type 'string', got unconvertible type '%T'", i, item["nonce"]))
@@ -190,7 +195,8 @@ func decodeBatchRequestItems(src interface{}, dst *[]BatchRequestItem) error {
 		}
 
 		if v, has := item["key_version"]; has {
-			if casted, ok := v.(int); ok {
+			if !reflect.ValueOf(v).IsValid() {
+			} else if casted, ok := v.(int); ok {
 				(*dst)[i].KeyVersion = casted
 			} else {
 				errs.Errors = append(errs.Errors, fmt.Sprintf("'[%d].key_version' expected type 'int', got unconvertible type '%T'", i, item["key_version"]))

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -681,6 +681,11 @@ func TestTransit_decodeBatchRequestItems(t *testing.T) {
 			},
 			dest: []BatchRequestItem{},
 		},
+		{
+			name: "src_plaintext-nil-nonce",
+			src:  []interface{}{map[string]interface{}{"plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA==", "nonce": "null"}},
+			dest: []BatchRequestItem{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/changelog/10386.txt
+++ b/changelog/10386.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ secrets/transit: allow for null string to be used for optional parameters in encrypt and decrypt
+ ```


### PR DESCRIPTION
Related PRs:

https://github.com/hashicorp/vault/pull/10386/files (change to master)
https://github.com/hashicorp/vault/pull/10435 (changelog)
https://github.com/hashicorp/vault/pull/10431/files (1.6 backport)