### PR TITLE
Fix activity log test timing failures

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -657,10 +657,10 @@ func (a *ActivityLog) entityBackgroundLoader(ctx context.Context, wg *sync.WaitG
 
 // Initialize a new current segment, based on the current time.
 // Call with fragmentLock and l held.
-func (a *ActivityLog) startNewCurrentLogLocked() {
+func (a *ActivityLog) startNewCurrentLogLocked(now time.Time) {
 	a.logger.Trace("initializing new log")
 	a.resetCurrentLog()
-	a.currentSegment.startTimestamp = time.Now().Unix()
+	a.currentSegment.startTimestamp = now.Unix()
 }
 
 // Should be called with fragmentLock and l held.
@@ -748,7 +748,7 @@ func (a *ActivityLog) WaitForDeletion() {
 // refreshFromStoredLog loads the appropriate entities/tokencounts for active and performance standbys
 // the most recent segment is loaded synchronously, and older segments are loaded in the background
 // this function expects stateLock to be held
-func (a *ActivityLog) refreshFromStoredLog(ctx context.Context, wg *sync.WaitGroup) error {
+func (a *ActivityLog) refreshFromStoredLog(ctx context.Context, wg *sync.WaitGroup, now time.Time) error {
 	a.l.Lock()
 	defer a.l.Unlock()
 	a.fragmentLock.Lock()
@@ -765,7 +765,7 @@ func (a *ActivityLog) refreshFromStoredLog(ctx context.Context, wg *sync.WaitGro
 				// reset the log without updating the timestamp
 				a.resetCurrentLog()
 			} else {
-				a.startNewCurrentLogLocked()
+				a.startNewCurrentLogLocked(now)
 			}
 		}
 
@@ -776,7 +776,7 @@ func (a *ActivityLog) refreshFromStoredLog(ctx context.Context, wg *sync.WaitGro
 
 	if !a.enabled {
 		a.logger.Debug("activity log not enabled, skipping refresh from storage")
-		if !a.core.perfStandby && timeutil.IsCurrentMonth(mostRecent, time.Now().UTC()) {
+		if !a.core.perfStandby && timeutil.IsCurrentMonth(mostRecent, now) {
 			a.logger.Debug("activity log is disabled, cleaning up logs for the current month")
 			go a.deleteLogWorker(mostRecent.Unix(), make(chan struct{}))
 		}
@@ -784,7 +784,6 @@ func (a *ActivityLog) refreshFromStoredLog(ctx context.Context, wg *sync.WaitGro
 		return nil
 	}
 
-	now := time.Now().UTC()
 	if timeutil.IsPreviousMonth(mostRecent, now) {
 		// no activity logs to load for this month. if we are enabled, interpret
 		// it as having missed the rotation, so let it fall through and load
@@ -805,7 +804,7 @@ func (a *ActivityLog) refreshFromStoredLog(ctx context.Context, wg *sync.WaitGro
 			// reset the log without updating the timestamp
 			a.resetCurrentLog()
 		} else {
-			a.startNewCurrentLogLocked()
+			a.startNewCurrentLogLocked(now)
 		}
 
 		return nil
@@ -896,7 +895,7 @@ func (a *ActivityLog) SetConfig(ctx context.Context, config activityConfig) {
 
 	forceSave := false
 	if a.enabled && a.currentSegment.startTimestamp == 0 {
-		a.startNewCurrentLogLocked()
+		a.startNewCurrentLogLocked(time.Now().UTC())
 		// Force a save so we can distinguish between
 		//
 		// Month N-1: present
@@ -975,7 +974,7 @@ func (c *Core) setupActivityLog(ctx context.Context) error {
 	refreshCtx, cancelFunc := context.WithCancel(namespace.RootContext(nil))
 	manager.activityCancel = cancelFunc
 	var wg sync.WaitGroup
-	err = manager.refreshFromStoredLog(refreshCtx, &wg)
+	err = manager.refreshFromStoredLog(refreshCtx, &wg, time.Now().UTC())
 	if err != nil {
 		return err
 	}

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -1360,7 +1360,7 @@ func TestActivityLog_refreshFromStoredLog(t *testing.T) {
 	a.enabled = true
 
 	var wg sync.WaitGroup
-	err := a.refreshFromStoredLog(context.Background(), &wg)
+	err := a.refreshFromStoredLog(context.Background(), &wg, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("got error loading stored activity logs: %v", err)
 	}
@@ -1395,7 +1395,7 @@ func TestActivityLog_refreshFromStoredLogWithBackgroundLoadingCancelled(t *testi
 	var wg sync.WaitGroup
 	close(a.doneCh)
 
-	err := a.refreshFromStoredLog(context.Background(), &wg)
+	err := a.refreshFromStoredLog(context.Background(), &wg, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("got error loading stored activity logs: %v", err)
 	}
@@ -1427,7 +1427,7 @@ func TestActivityLog_refreshFromStoredLogContextCancelled(t *testing.T) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	cancelFn()
 
-	err := a.refreshFromStoredLog(ctx, &wg)
+	err := a.refreshFromStoredLog(ctx, &wg, time.Now().UTC())
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context cancelled error, got: %v", err)
 	}
@@ -1438,7 +1438,7 @@ func TestActivityLog_refreshFromStoredLogNoTokens(t *testing.T) {
 	a.enabled = true
 
 	var wg sync.WaitGroup
-	err := a.refreshFromStoredLog(context.Background(), &wg)
+	err := a.refreshFromStoredLog(context.Background(), &wg, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("got error loading stored activity logs: %v", err)
 	}
@@ -1470,7 +1470,7 @@ func TestActivityLog_refreshFromStoredLogNoEntities(t *testing.T) {
 	a.enabled = true
 
 	var wg sync.WaitGroup
-	err := a.refreshFromStoredLog(context.Background(), &wg)
+	err := a.refreshFromStoredLog(context.Background(), &wg, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("got error loading stored activity logs: %v", err)
 	}
@@ -1536,14 +1536,12 @@ func expectCurrentSegmentRefreshed(t *testing.T, a *ActivityLog, expectedStart i
 }
 
 func TestActivityLog_refreshFromStoredLogNoData(t *testing.T) {
-	t.Skip("fails on OSS")
-
 	now := time.Now().UTC()
 	a, _, _ := setupActivityRecordsInStorage(t, now, false, false)
 	a.enabled = true
 
 	var wg sync.WaitGroup
-	err := a.refreshFromStoredLog(context.Background(), &wg)
+	err := a.refreshFromStoredLog(context.Background(), &wg, now)
 	if err != nil {
 		t.Fatalf("got error loading stored activity logs: %v", err)
 	}
@@ -1560,7 +1558,7 @@ func TestActivityLog_refreshFromStoredLogTwoMonthsPrevious(t *testing.T) {
 	a.enabled = true
 
 	var wg sync.WaitGroup
-	err := a.refreshFromStoredLog(context.Background(), &wg)
+	err := a.refreshFromStoredLog(context.Background(), &wg, now)
 	if err != nil {
 		t.Fatalf("got error loading stored activity logs: %v", err)
 	}
@@ -1579,7 +1577,7 @@ func TestActivityLog_refreshFromStoredLogPreviousMonth(t *testing.T) {
 	a.enabled = true
 
 	var wg sync.WaitGroup
-	err := a.refreshFromStoredLog(context.Background(), &wg)
+	err := a.refreshFromStoredLog(context.Background(), &wg, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("got error loading stored activity logs: %v", err)
 	}
@@ -1605,25 +1603,6 @@ func TestActivityLog_refreshFromStoredLogPreviousMonth(t *testing.T) {
 		// we expect activeEntities to be loaded for the entire month
 		t.Errorf("bad data loaded into active entities. expected only set of EntityID from %v in %v", expectedActive.Entities, activeEntities)
 	}
-}
-
-func TestActivityLog_refreshFromStoredLogNextMonth(t *testing.T) {
-	t.Skip("works on enterprise, fails on oss (oss boots with activity log disabled)")
-
-	// test what happens when most recent data is from month M+1
-	nextMonthStart := timeutil.StartOfNextMonth(time.Now().UTC())
-	a, _, _ := setupActivityRecordsInStorage(t, nextMonthStart, true, true)
-	a.enabled = true
-
-	var wg sync.WaitGroup
-	err := a.refreshFromStoredLog(context.Background(), &wg)
-	if err != nil {
-		t.Fatalf("got error loading stored activity logs: %v", err)
-	}
-	wg.Wait()
-
-	// we can't know exactly what the timestamp should be set to, just that it shouldn't be zero
-	expectCurrentSegmentRefreshed(t, a, time.Now().Unix(), true)
 }
 
 func TestActivityLog_IncludeNamespace(t *testing.T) {


### PR DESCRIPTION
Failures look like "bad start timestamp. expected: 1606313752 got: 1606313753".  Also re-enable a test that probably shouldn't be skipped, and delete a test that's meant for ent (see also https://github.com/hashicorp/vault-enterprise/pull/1613)