### PR TITLE
Add AllowedHeader and fix AllowedOrigins in the API

### DIFF
--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -95,11 +95,13 @@ func (c *Sys) DisableCORS() (*CORSResponse, error) {
 }
 
 type CORSRequest struct {
-	AllowedOrigins string `json:"allowed_origins" mapstructure:"allowed_origins"`
-	Enabled        bool   `json:"enabled" mapstructure:"enabled"`
+	AllowedOrigins []string `json:"allowed_origins" mapstructure:"allowed_origins"`
+	AllowedHeaders []string `json:"allowed_headers" mapstructure:"allowed_headers"`
+	Enabled        bool     `json:"enabled" mapstructure:"enabled"`
 }
 
 type CORSResponse struct {
-	AllowedOrigins string `json:"allowed_origins" mapstructure:"allowed_origins"`
-	Enabled        bool   `json:"enabled" mapstructure:"enabled"`
+	AllowedOrigins []string `json:"allowed_origins" mapstructure:"allowed_origins"`
+	AllowedHeaders []string `json:"allowed_headers" mapstructure:"allowed_headers"`
+	Enabled        bool     `json:"enabled" mapstructure:"enabled"`
 }

--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -35,63 +35,31 @@ func (c *Sys) CORSStatus() (*CORSResponse, error) {
 	return &result, err
 }
 
-func (c *Sys) ConfigureCORS(req *CORSRequest) (*CORSResponse, error) {
+func (c *Sys) ConfigureCORS(req *CORSRequest) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/config/cors")
 	if err := r.SetJSONBody(req); err != nil {
-		return nil, err
+		return err
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		defer resp.Body.Close()
 	}
-	defer resp.Body.Close()
-
-	secret, err := ParseSecret(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if secret == nil || secret.Data == nil {
-		return nil, errors.New("data from server response is empty")
-	}
-
-	var result CORSResponse
-	err = mapstructure.Decode(secret.Data, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result, err
+	return err
 }
 
-func (c *Sys) DisableCORS() (*CORSResponse, error) {
+func (c *Sys) DisableCORS() error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/config/cors")
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		defer resp.Body.Close()
 	}
-	defer resp.Body.Close()
-
-	secret, err := ParseSecret(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if secret == nil || secret.Data == nil {
-		return nil, errors.New("data from server response is empty")
-	}
-
-	var result CORSResponse
-	err = mapstructure.Decode(secret.Data, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result, err
+	return err
 }
 
 type CORSRequest struct {

--- a/changelog/10444.txt
+++ b/changelog/10444.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+api: Fixes issue where the AllowedHeaders parameters was missing in the input/output and the AllowedOrigins was not a slice
+```
+

--- a/changelog/10444.txt
+++ b/changelog/10444.txt
@@ -1,4 +1,4 @@
 ```release-note:bug
-api: Fixes issue where the CORS API AllowedHeaders parameter was missing in the input/output and the AllowedOrigins was a string instead of a slice
+api: Fixes CORS API methods that were outdated and invalid
 ```
 

--- a/changelog/10444.txt
+++ b/changelog/10444.txt
@@ -1,4 +1,4 @@
 ```release-note:bug
-api: Fixes issue where the AllowedHeaders parameters was missing in the input/output and the AllowedOrigins was not a slice
+api: Fixes issue where the CORS API AllowedHeaders parameter was missing in the input/output and the AllowedOrigins was a string instead of a slice
 ```
 

--- a/vendor/github.com/hashicorp/vault/api/sys_config_cors.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_config_cors.go
@@ -95,11 +95,13 @@ func (c *Sys) DisableCORS() (*CORSResponse, error) {
 }
 
 type CORSRequest struct {
-	AllowedOrigins string `json:"allowed_origins" mapstructure:"allowed_origins"`
-	Enabled        bool   `json:"enabled" mapstructure:"enabled"`
+	AllowedOrigins []string `json:"allowed_origins" mapstructure:"allowed_origins"`
+	AllowedHeaders []string `json:"allowed_headers" mapstructure:"allowed_headers"`
+	Enabled        bool     `json:"enabled" mapstructure:"enabled"`
 }
 
 type CORSResponse struct {
-	AllowedOrigins string `json:"allowed_origins" mapstructure:"allowed_origins"`
-	Enabled        bool   `json:"enabled" mapstructure:"enabled"`
+	AllowedOrigins []string `json:"allowed_origins" mapstructure:"allowed_origins"`
+	AllowedHeaders []string `json:"allowed_headers" mapstructure:"allowed_headers"`
+	Enabled        bool     `json:"enabled" mapstructure:"enabled"`
 }


### PR DESCRIPTION
The backend got updated a while ago to include `AllowedHeaders` and changed `AllowedOrigins` to return a slice instead of a simple string:

https://github.com/hashicorp/vault/blob/f0849708a59e02025ac9808e6c1d451553af048f/vault/cors.go#L33-L40

This PR updates the API methods to reflect these changes.