### PR TITLE
Adjust executor sizes based on use case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -784,7 +784,7 @@ jobs:
   test-go-remote-docker:
     docker:
     - image: docker.mirror.hashicorp.services/circleci/golang:1.15.3-buster
-    resource_class: large
+    resource_class: medium
     working_directory: /go/src/github.com/hashicorp/vault
     parallelism: 8
     steps:
@@ -1469,7 +1469,7 @@ jobs:
   test-go:
     docker:
     - image: docker.mirror.hashicorp.services/circleci/golang:1.15.3-buster
-    resource_class: xlarge
+    resource_class: large
     working_directory: /go/src/github.com/hashicorp/vault
     parallelism: 8
     steps:
@@ -2172,7 +2172,7 @@ jobs:
   test-go-race-remote-docker:
     docker:
     - image: docker.mirror.hashicorp.services/circleci/golang:1.15.3-buster
-    resource_class: xlarge
+    resource_class: medium
     working_directory: /go/src/github.com/hashicorp/vault
     parallelism: 8
     steps:

--- a/.circleci/config/executors/@executors.yml
+++ b/.circleci/config/executors/@executors.yml
@@ -23,7 +23,16 @@ alpine:
     - image: docker.mirror.hashicorp.services/alpine:3.10.2
   shell: /bin/sh
   working_directory: /go/src/github.com/hashicorp/vault
-docker-env-large:
+docker-env-go-test-remote-docker:
+  resource_class: medium
+  docker:
+    - image: "docker.mirror.hashicorp.services/circleci/golang:1.15.3-buster"
+  environment:
+    GO111MODULE: "off"
+    CIRCLECI_CLI_VERSION: 0.1.5546  # Pin CircleCI CLI to patch version (ex: 1.2.3)
+    GO_TAGS: ""
+  working_directory: /go/src/github.com/hashicorp/vault
+docker-env-go-test:
   resource_class: large
   docker:
     - image: "docker.mirror.hashicorp.services/circleci/golang:1.15.3-buster"
@@ -32,7 +41,7 @@ docker-env-large:
     CIRCLECI_CLI_VERSION: 0.1.5546  # Pin CircleCI CLI to patch version (ex: 1.2.3)
     GO_TAGS: ""
   working_directory: /go/src/github.com/hashicorp/vault
-docker-env-xlarge:
+docker-env-go-test-race:
   resource_class: xlarge
   docker:
     - image: "docker.mirror.hashicorp.services/circleci/golang:1.15.3-buster"

--- a/.circleci/config/jobs/test-go-race-remote-docker.yml
+++ b/.circleci/config/jobs/test-go-race-remote-docker.yml
@@ -1,4 +1,4 @@
-executor: docker-env-xlarge
+executor: docker-env-go-test-remote-docker
 parallelism: 8
 steps:
   - check-branch-name

--- a/.circleci/config/jobs/test-go-race.yml
+++ b/.circleci/config/jobs/test-go-race.yml
@@ -1,4 +1,4 @@
-executor: docker-env-xlarge
+executor: docker-env-go-test-race
 parallelism: 8
 steps:
   - check-branch-name

--- a/.circleci/config/jobs/test-go-remote-docker.yml
+++ b/.circleci/config/jobs/test-go-remote-docker.yml
@@ -1,4 +1,4 @@
-executor: docker-env-large
+executor: docker-env-go-test-remote-docker
 parallelism: 8
 steps:
   - check-branch-name

--- a/.circleci/config/jobs/test-go.yml
+++ b/.circleci/config/jobs/test-go.yml
@@ -1,4 +1,4 @@
-executor: docker-env-xlarge
+executor: docker-env-go-test
 parallelism: 8
 steps:
   - check-branch-name


### PR DESCRIPTION
Name environments after their use case rather than their size.  We need fewer resources for remote-docker because all the heavy work happens in the remote-docker VMs which we can't configure.  Use a different env for race tests which are more resource hungry.