### PR TITLE
docs: fix auth/k8s broken link

### DIFF
--- a/website/pages/docs/auth/kubernetes.mdx
+++ b/website/pages/docs/auth/kubernetes.mdx
@@ -138,4 +138,4 @@ subjects:
 The Kubernetes Auth Plugin has a full HTTP API. Please see the
 [API docs](/api/auth/kubernetes) for more details.
 
-[k8s-tokenreview]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#tokenreview-v1-authentication-k8s-io
+[k8s-tokenreview]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#tokenreview-v1beta1-authentication-k8s-io


### PR DESCRIPTION
The link to the TokenReview API spec in the K8s documentation is broken. Fixed here by pointing to the correct URL.