### PR TITLE
website: fix broken link to api docs

### DIFF
--- a/website/pages/docs/secrets/ad/index.mdx
+++ b/website/pages/docs/secrets/ad/index.mdx
@@ -31,7 +31,7 @@ will check them in when their lending period (or, "ttl", in Vault's language) en
 There are two ways of customizing how passwords are generated in the Active Directory secret engine:
 
 1. [Password Policies](/docs/concepts/password-policies)
-2. `length` and `formatter` fields within the [configuration](api-docs/secret/ad#password-parameters)
+2. `length` and `formatter` fields within the [configuration](/api-docs/secret/ad#password-parameters)
 
 Utilizing password policies is the recommended path as the `length` and `formatter` fields have
 been deprecated in favor of password policies. The `password_policy` field within the configuration


### PR DESCRIPTION
Destination was correct, just missing the leading slash. 