### PR TITLE
Fix race with test that mutates KeyRotateGracePeriod

### DIFF
--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -638,7 +638,9 @@ func TestRaft_SnapshotAPI_RekeyRotate_Forward(t *testing.T) {
 				// Set the key clean up to 0 so it's cleaned immediately. This
 				// will simulate that there are no ways to upgrade to the latest
 				// term.
-				vault.KeyRotateGracePeriod = 0
+				for _, c := range cluster.Cores {
+					c.Core.SetKeyRotateGracePeriod(0)
+				}
 
 				// Rotate
 				err = leaderClient.Sys().Rotate()

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -44,10 +44,6 @@ const (
 )
 
 var (
-	// KeyRotateGracePeriod is how long we allow an upgrade path
-	// for standby instances before we delete the upgrade keys
-	KeyRotateGracePeriod = 2 * time.Minute
-
 	addEnterpriseHaActors func(*Core, *run.Group) chan func()            = addEnterpriseHaActorsNoop
 	interruptPerfStandby  func(chan func(), chan struct{}) chan struct{} = interruptPerfStandbyNoop
 )
@@ -882,7 +878,7 @@ func (c *Core) scheduleUpgradeCleanup(ctx context.Context) error {
 	}
 
 	// Schedule cleanup for all of them
-	time.AfterFunc(KeyRotateGracePeriod, func() {
+	time.AfterFunc(c.KeyRotateGracePeriod(), func() {
 		sealed, err := c.barrier.Sealed()
 		if err != nil {
 			c.logger.Warn("failed to check barrier status at upgrade cleanup time")

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2540,8 +2540,8 @@ func (b *SystemBackend) handleRotate(ctx context.Context, req *logical.Request, 
 		}
 
 		// Schedule the destroy of the upgrade path
-		time.AfterFunc(KeyRotateGracePeriod, func() {
-			b.Backend.Logger().Debug("cleaning up upgrade keys", "waited", KeyRotateGracePeriod)
+		time.AfterFunc(b.Core.KeyRotateGracePeriod(), func() {
+			b.Backend.Logger().Debug("cleaning up upgrade keys", "waited", b.Core.KeyRotateGracePeriod())
 			if err := b.Core.barrier.DestroyUpgrade(b.Core.activeContext, newTerm); err != nil {
 				b.Backend.Logger().Error("failed to destroy upgrade", "term", newTerm, "error", err)
 			}


### PR DESCRIPTION
Make the global be a Core field instead.

Example failure: https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/2070/workflows/75e46f96-8dbf-4918-9cf9-d89bf7b78e2f/jobs/72729

```
WARNING: DATA RACE
Read at 0x0000074e6de8 by goroutine 485:
  github.com/hashicorp/vault/vault.(*SystemBackend).handleRotate.func1()
      /go/src/github.com/hashicorp/vault/vault/logical_system.go:2544 +0x138

Previous write at 0x0000074e6de8 by goroutine 579:
  github.com/hashicorp/vault/vault/external_tests/raft.TestRaft_SnapshotAPI_RekeyRotate_Forward.func1()
      /go/src/github.com/hashicorp/vault/vault/external_tests/raft/raft_test.go:641 +0x1eb4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1123 +0x202

Goroutine 485 (running) created at:
  time.goFunc()
      /usr/local/go/src/time/sleep.go:167 +0x51

Goroutine 579 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1168 +0x5bb
  github.com/hashicorp/vault/vault/external_tests/raft.TestRaft_SnapshotAPI_RekeyRotate_Forward()
      /go/src/github.com/hashicorp/vault/vault/external_tests/raft/raft_test.go:584 +0x23b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1123 +0x202
```