### PR TITLE
Correct key length in Transit storage limits (#10422)

### DIFF
--- a/website/pages/docs/internals/limits.mdx
+++ b/website/pages/docs/internals/limits.mdx
@@ -204,7 +204,7 @@ This limit depends on the key size.
 | Key length | Consul default (512 KiB) | Integrated storage default (1 MiB) |
 |----------|--------------------------|---------------------------------------|
 | aes128-gcm96 keys    |  2008   |  4017   |
-| aes128-gcm96 keys    |  1865   |  3731   |
+| aes256-gcm96 keys    |  1865   |  3731   |
 | chacha-poly1305 keys |  1865   |  3731   |
 | ed25519 keys         |  1420   |  2841   |
 | ecdsa-p256 keys      |   817   |  1635   |


### PR DESCRIPTION
The AES256-GCM96 key was mis-labeled as AES128 under Transit storage limits. Corrected the table.

Co-authored-by: Mark Gritter <mgritter@hashicorp.com>