### PR TITLE
Disclosure of internal IP addresses from unauthenticated request

### DIFF
--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -1663,6 +1663,7 @@ func TestAppRole_RoleWithTokenBoundCIDRsCRUD(t *testing.T) {
 	if !reflect.DeepEqual(expectedStruct, actualStruct) {
 		t.Fatalf("bad:\nexpected:%#v\nactual:%#v\n", expectedStruct, actualStruct)
 	}
+	t.Logf("bad:\nexpected:%#v\nactual:%#v\n", expectedStruct, actualStruct)
 
 	roleData = map[string]interface{}{
 		"role_id":            "test_role_id",

--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -1663,7 +1663,6 @@ func TestAppRole_RoleWithTokenBoundCIDRsCRUD(t *testing.T) {
 	if !reflect.DeepEqual(expectedStruct, actualStruct) {
 		t.Fatalf("bad:\nexpected:%#v\nactual:%#v\n", expectedStruct, actualStruct)
 	}
-	t.Logf("bad:\nexpected:%#v\nactual:%#v\n", expectedStruct, actualStruct)
 
 	roleData = map[string]interface{}{
 		"role_id":            "test_role_id",

--- a/http/logical.go
+++ b/http/logical.go
@@ -112,13 +112,13 @@ func buildLogicalRequestNoAuth(perfStandby bool, w http.ResponseWriter, r *http.
 			// and an incorrect content-type).
 			head, err := bufferedBody.Peek(512)
 			if err != nil && err != bufio.ErrBufferFull && err != io.EOF {
-				return nil, nil, http.StatusBadRequest, err
+				return nil, nil, http.StatusBadRequest, fmt.Errorf("error reading data")
 			}
 
 			if isForm(head, r.Header.Get("Content-Type")) {
 				formData, err := parseFormRequest(r)
 				if err != nil {
-					return nil, nil, http.StatusBadRequest, fmt.Errorf("error parsing form data: %w", err)
+					return nil, nil, http.StatusBadRequest, fmt.Errorf("error parsing form data")
 				}
 
 				data = formData
@@ -129,7 +129,7 @@ func buildLogicalRequestNoAuth(perfStandby bool, w http.ResponseWriter, r *http.
 					err = nil
 				}
 				if err != nil {
-					return nil, nil, http.StatusBadRequest, err
+					return nil, nil, http.StatusBadRequest, fmt.Errorf("error parsing JSON")
 				}
 			}
 		}


### PR DESCRIPTION
Removing extra information from the returned error, to avoid leaking it to unauthenticated requests