### PR TITLE
Backport 1.6.1: No 'v' in version HTML anchor

### DIFF
--- a/changelog/10491.txt
+++ b/changelog/10491.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix footer URL linking to the correct version changelog.
+```

--- a/ui/lib/core/addon/helpers/changelog-url-for.js
+++ b/ui/lib/core/addon/helpers/changelog-url-for.js
@@ -4,10 +4,10 @@ import { helper } from '@ember/component/helper';
 This helper returns a url to the changelog for the specified version.
 It assumes that Changelog headers for Vault versions >= 1.4.3 are structured as:
 
-## v1.5.0
+## 1.5.0
 ### Month, DD, YYYY
 
-## v1.4.5
+## 1.4.5
 ### Month, DD, YYY
 
 etc.
@@ -25,7 +25,7 @@ export function changelogUrlFor([version]) {
 
     // only recent versions have a predictable url
     if (versionNumber >= '143') {
-      return url.concat('v', versionNumber);
+      return url.concat(versionNumber);
     }
   } catch (e) {
     console.log(e);

--- a/ui/tests/integration/helpers/changelog-url-for-test.js
+++ b/ui/tests/integration/helpers/changelog-url-for-test.js
@@ -9,12 +9,12 @@ module('Integration | Helper | changelog-url-for', function(hooks) {
 
   test('it builds an enterprise URL', function(assert) {
     const result = changelogUrlFor(['1.5.0+prem']);
-    assert.equal(result, CHANGELOG_URL.concat('v150'));
+    assert.equal(result, CHANGELOG_URL.concat('150'));
   });
 
   test('it builds an OSS URL', function(assert) {
     const result = changelogUrlFor(['1.4.3']);
-    assert.equal(result, CHANGELOG_URL.concat('v143'));
+    assert.equal(result, CHANGELOG_URL.concat('143'));
   });
 
   test('it returns the base changelog URL if the version is less than 1.4.3', function(assert) {


### PR DESCRIPTION
See PR #10491 