### PR TITLE
website: redirect raft snapshot url to automated storage snapshots

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -23,6 +23,7 @@
 /docs/enterprise/auto-unseal/index.html /docs/concepts/seal.html 301!
 /docs/enterprise/hsm/configuration.html  /docs/configuration/seal/pkcs11 301!
 /docs/enterprise/ui/index.html  /docs/configuration/ui 301!
+/docs/enterprise/automated-raft-snapshots  /docs/enterprise/automated-integrated-storage-snapshots 301!
 /docs/guides/generate-root.html /guides/operations/generate-root 301!
 /docs/guides/index.html /guides 301!
 /docs/guides/production.html  /guides/operations/production 301!


### PR DESCRIPTION
redirects [/docs/enterprise/automated-raft-snapshots](https://deploy-preview-10553--vault-www.netlify.app/docs/enterprise/automated-raft-snapshots)  to [/docs/enterprise/automated-integrated-storage-snapshots](https://deploy-preview-10553--vault-www.netlify.app/docs/enterprise/automated-integrated-storage-snapshots)