### PR TITLE
mod: update secrets-gcp to v0.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.8.0
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-azure v0.8.0
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.8.0
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.8.1
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -656,8 +656,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.7.0 h1:VoB3Q11LX+wF5w5TC8j
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.7.0/go.mod h1:SSkKpSTOMnX84PfgYiWHgwVg+YMhxHNjo+YCJGNBoZk=
 github.com/hashicorp/vault-plugin-secrets-azure v0.8.0 h1:3BAhoqqDN198vynAfS3rcxUW2STBjREluGPsYCOy2mA=
 github.com/hashicorp/vault-plugin-secrets-azure v0.8.0/go.mod h1:4jCVjTG809NCQ8mrSnbBtX17gX1Iush+558BVO6MJeo=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.8.0 h1:RcJHTlsB3CuZ1xq+syjtgEKfPqIyYriUl+TnjTDRShc=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.8.0/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.8.1 h1:61wEFhbiV/lOQ512wcdRGSPfs4E4JBbfaR40VyIm0ao=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.8.1/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.7.0 h1:dKPQIr6tLcMmhNKdc2A9pbwaIFLooC80UfNZL+jWMlA=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.7.0/go.mod h1:hhwps56f2ATeC4Smgghrc5JH9dXR31b4ehSf1HblP5Q=
 github.com/hashicorp/vault-plugin-secrets-kv v0.7.0 h1:Sq5CmKWxQu+MtO6AXYM+STPHGnrGD50iKuwzaw87OVM=

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-gcp/plugin/role_set.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-gcp/plugin/role_set.go
@@ -22,8 +22,10 @@ import (
 )
 
 const (
-	serviceAccountMaxLen          = 30
-	serviceAccountDisplayNameTmpl = "Service account for Vault secrets backend role set %s"
+	serviceAccountMaxLen             = 30
+	serviceAccountDisplayNameHashLen = 8
+	serviceAccountDisplayNameMaxLen  = 100
+	serviceAccountDisplayNameTmpl    = "Service account for Vault secrets backend role set %s"
 )
 
 type RoleSet struct {
@@ -304,7 +306,7 @@ func (rs *RoleSet) addWALsForCurrentAccount(ctx context.Context, s logical.Stora
 func (rs *RoleSet) newServiceAccount(ctx context.Context, s logical.Storage, iamAdmin *iam.Service, project string) (string, error) {
 	saEmailPrefix := roleSetServiceAccountName(rs.Name)
 	projectName := fmt.Sprintf("projects/%s", project)
-	displayName := fmt.Sprintf(serviceAccountDisplayNameTmpl, rs.Name)
+	displayName := roleSetServiceAccountDisplayName(rs.Name)
 
 	walId, err := framework.PutWAL(ctx, s, walTypeAccount, &walAccount{
 		RoleSet: rs.Name,
@@ -413,6 +415,17 @@ func roleSetServiceAccountName(rsName string) (name string) {
 		name = fmt.Sprintf("vault%s-%s", rsName[:len(rsName)-toTrunc], intSuffix)
 	}
 	return name
+}
+
+func roleSetServiceAccountDisplayName(name string) string {
+	fullDisplayName := fmt.Sprintf(serviceAccountDisplayNameTmpl, name)
+	displayName := fullDisplayName
+	if len(fullDisplayName) > serviceAccountDisplayNameMaxLen {
+		truncIndex := serviceAccountDisplayNameMaxLen - serviceAccountDisplayNameHashLen
+		h := fmt.Sprintf("%x", sha256.Sum256([]byte(fullDisplayName[truncIndex:])))
+		displayName = fullDisplayName[:truncIndex] + h[:serviceAccountDisplayNameHashLen]
+	}
+	return displayName
 }
 
 func getStringHash(bindingsRaw string) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -540,7 +540,7 @@ github.com/hashicorp/vault-plugin-secrets-alicloud
 github.com/hashicorp/vault-plugin-secrets-alicloud/clients
 # github.com/hashicorp/vault-plugin-secrets-azure v0.8.0
 github.com/hashicorp/vault-plugin-secrets-azure
-# github.com/hashicorp/vault-plugin-secrets-gcp v0.8.0
+# github.com/hashicorp/vault-plugin-secrets-gcp v0.8.1
 github.com/hashicorp/vault-plugin-secrets-gcp/plugin
 github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil
 github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util


### PR DESCRIPTION
Updates vault-plugin-secrets-gcp to v0.8.1

Steps taken:
- `get github.com/hashicorp/vault-plugin-secrets-gcp@release/vault-1.6.x`
- `go mod vendor && go mod tidy`