### PR TITLE
Adds changelog file for auth-jwt bug fix

### DIFF
--- a/changelog/10546.txt
+++ b/changelog/10546.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/jwt: Fixes `bound_claims` validation for provider-specific group and user info fetching.
+```


### PR DESCRIPTION
This PR adds a changelog file into `release/1.6.x` for the bug fix introduced in https://github.com/hashicorp/vault/pull/10546. The source for the fix is in an external plugin repository, so the changelog file isn't a part of the 1.6.x backport PR https://github.com/hashicorp/vault/pull/10557.