### PR TITLE
Backport 1.6.1: Only set the namespace if the env var isn't present (#1519) (#10556)

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -463,6 +463,28 @@ func NewClient(c *Config) (*Client, error) {
 	return client, nil
 }
 
+func (c *Client) CloneConfig() *Config {
+	c.modifyLock.RLock()
+	defer c.modifyLock.RUnlock()
+
+	newConfig := DefaultConfig()
+	newConfig.Address = c.config.Address
+	newConfig.AgentAddress = c.config.AgentAddress
+	newConfig.MaxRetries = c.config.MaxRetries
+	newConfig.Timeout = c.config.Timeout
+	newConfig.Backoff = c.config.Backoff
+	newConfig.CheckRetry = c.config.CheckRetry
+	newConfig.Limiter = c.config.Limiter
+	newConfig.OutputCurlString = c.config.OutputCurlString
+	newConfig.SRVLookup = c.config.SRVLookup
+
+	// we specifically want a _copy_ of the client here, not a pointer to the original one
+	newClient := *c.config.HttpClient
+	newConfig.HttpClient = &newClient
+
+	return newConfig
+}
+
 // Sets the address of Vault in the client. The format of address should be
 // "<Scheme>://<Host>:<Port>". Setting this on a client will override the
 // value of VAULT_ADDR environment variable.

--- a/changelog/10556.txt
+++ b/changelog/10556.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Only set the namespace if the VAULT_NAMESPACE env var isn't present
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -369,9 +369,11 @@ func (c *AgentCommand) Run(args []string) int {
 
 		// Check if a default namespace has been set
 		mountPath := config.AutoAuth.Method.MountPath
-		if config.AutoAuth.Method.Namespace != "" {
-			namespace = config.AutoAuth.Method.Namespace
-			mountPath = path.Join(namespace, mountPath)
+		if cns := config.AutoAuth.Method.Namespace; cns != "" {
+			// Only set this value if the env var is empty, otherwise we end up with a nested namespace
+			if ens := os.Getenv(api.EnvVaultNamespace); ens == "" {
+				mountPath = path.Join(cns, mountPath)
+			}
 		}
 
 		authConfig := &auth.AuthConfig{

--- a/vendor/github.com/hashicorp/vault/api/client.go
+++ b/vendor/github.com/hashicorp/vault/api/client.go
@@ -463,6 +463,28 @@ func NewClient(c *Config) (*Client, error) {
 	return client, nil
 }
 
+func (c *Client) CloneConfig() *Config {
+	c.modifyLock.RLock()
+	defer c.modifyLock.RUnlock()
+
+	newConfig := DefaultConfig()
+	newConfig.Address = c.config.Address
+	newConfig.AgentAddress = c.config.AgentAddress
+	newConfig.MaxRetries = c.config.MaxRetries
+	newConfig.Timeout = c.config.Timeout
+	newConfig.Backoff = c.config.Backoff
+	newConfig.CheckRetry = c.config.CheckRetry
+	newConfig.Limiter = c.config.Limiter
+	newConfig.OutputCurlString = c.config.OutputCurlString
+	newConfig.SRVLookup = c.config.SRVLookup
+
+	// we specifically want a _copy_ of the client here, not a pointer to the original one
+	newClient := *c.config.HttpClient
+	newConfig.HttpClient = &newClient
+
+	return newConfig
+}
+
 // Sets the address of Vault in the client. The format of address should be
 // "<Scheme>://<Host>:<Port>". Setting this on a client will override the
 // value of VAULT_ADDR environment variable.


### PR DESCRIPTION
Original https://github.com/hashicorp/vault/pull/10556