### PR TITLE
[backport] rate limit: fix initialize defaults (#10536)

### DIFF
--- a/changelog/10536.txt
+++ b/changelog/10536.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+core: Fix rate limit resource quota migration from 1.5.x to 1.6.x by ensuring `purgeInterval` and
+`staleAge` are set appropriately.
+```

--- a/vault/quotas/quotas_rate_limit.go
+++ b/vault/quotas/quotas_rate_limit.go
@@ -138,6 +138,17 @@ func (rlq *RateLimitQuota) initialize(logger log.Logger, ms *metricsutil.Cluster
 		rlq.ID = id
 	}
 
+	// Set purgeInterval if coming from a previous version where purgeInterval was
+	// not defined.
+	if rlq.purgeInterval == 0 {
+		rlq.purgeInterval = DefaultRateLimitPurgeInterval
+	}
+
+	// Set staleAge if coming from a previous version where staleAge was not defined.
+	if rlq.staleAge == 0 {
+		rlq.staleAge = DefaultRateLimitStaleAge
+	}
+
 	rlStore, err := memorystore.New(&memorystore.Config{
 		Tokens:        uint64(math.Round(rlq.Rate)), // allow 'rlq.Rate' number of requests per 'Interval'
 		Interval:      rlq.Interval,                 // time interval in which to enforce rate limiting


### PR DESCRIPTION
Backport #10536 to 1.6.x