### PR TITLE
Allow updating group by name.

### DIFF
--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -220,7 +220,11 @@ func (i *IdentityStore) handleGroupUpdateCommon(ctx context.Context, req *logica
 		case groupByName == nil:
 			// Allowed
 		case group.ID == "":
-			group = groupByName
+			groupCloned, err := groupByName.Clone()
+			if err != nil {
+				return nil, err
+			}
+			group = groupCloned
 		case group.ID != "" && groupByName.ID != group.ID:
 			return logical.ErrorResponse("group name is already in use"), nil
 		}


### PR DESCRIPTION
Specifically, when using the identity/group endpoint with a name
parameter. Currently this is broken. If a name already exists it does
not bail out, and it fails to properly update the entities `group_ids`
fields, resulting in entities that continue to effectively be in the
group without actually being in the group (they continue to be able to
access group policies).

The alternate to this is to actually disallow this code path completely.

**Any Vault instances that have used this endpoint to update by name will find that entities that were removed using this endpoint continue to have access to policies associated with the group they were removed from.**