### PR TITLE
Updates to groups without ID are not consistent.

### DIFF
--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -219,10 +219,10 @@ func (i *IdentityStore) handleGroupUpdateCommon(ctx context.Context, req *logica
 		switch {
 		case groupByName == nil:
 			// Allowed
+		case newGroup && groupByName.ID != group.ID:
+			return logical.ErrorResponse("group name is already in use"), nil
 		case group.ID == "":
 			group = groupByName
-		case group.ID != "" && groupByName.ID != group.ID:
-			return logical.ErrorResponse("group name is already in use"), nil
 		}
 		group.Name = groupName
 	}

--- a/vault/identity_store_groups.go
+++ b/vault/identity_store_groups.go
@@ -219,10 +219,12 @@ func (i *IdentityStore) handleGroupUpdateCommon(ctx context.Context, req *logica
 		switch {
 		case groupByName == nil:
 			// Allowed
-		case newGroup && groupByName.ID != group.ID:
-			return logical.ErrorResponse("group name is already in use"), nil
+		case newGroup && groupByName != nil:
+			return logical.ErrorResponse("new group name is already in use"), nil
 		case group.ID == "":
 			group = groupByName
+		case group.ID != "" && groupByName.ID != group.ID:
+			return logical.ErrorResponse("group name is already in use"), nil
 		}
 		group.Name = groupName
 	}


### PR DESCRIPTION
When using the `entity/group` endpoint and NOT providing the ID as required the entity groups are not updated.

`id (string: <optional>) - ID of the group. If set, updates the corresponding existing group.`

https://www.vaultproject.io/api-docs/secret/identity/group#create-a-group

The bug happens when we don't provide an ID but we include the name of an already existing group which results in an inconsistent update.

Originally reported by @luke-clifton

Reproduction, in this case, the group has 3 entities and we remove 1.
The entity still shows the group ID when reading the properties but the group no longer shows the entity ID.

```
+ vault read identity/group/name/cdaa75b0-0cc8-4902-bfe4-5a3878013528 -format=json
+ jq .data.member_entity_ids
[
  "0ebdf3f1-6067-36ed-3bb1-5a087395a0ff",
  "28b2bf74-db92-c004-53bf-9140851e1784",
  "7ff2f3b2-3b2c-82a0-b6fa-046025111339"
]
+ vault write identity/group name=cdaa75b0-0cc8-4902-bfe4-5a3878013528 member_entity_ids=28b2bf74-db92-c004-53bf-9140851e1784,0ebdf3f1-6067-36ed-3bb1-5a087395a0ff
Key     Value
---     -----
id      57cde975-abf9-5ad9-39bd-e32f613acd20
name    cdaa75b0-0cc8-4902-bfe4-5a3878013528
+ vault read identity/entity/id/7ff2f3b2-3b2c-82a0-b6fa-046025111339 -format=json
+ jq .data.group_ids
[
  "57cde975-abf9-5ad9-39bd-e32f613acd20"
]
+ vault read identity/group/name/cdaa75b0-0cc8-4902-bfe4-5a3878013528 -format=json
+ jq .data.member_entity_ids
[
  "0ebdf3f1-6067-36ed-3bb1-5a087395a0ff",
  "28b2bf74-db92-c004-53bf-9140851e1784"
]
```

This PR is a draft until I add unit testing.