### PR TITLE
Bug: Fix issue with double encoding on space in secret history route

### DIFF
--- a/changelog/10596.txt
+++ b/changelog/10596.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Fix bug that double encodes secret route when there are spaces in the path and makes you unable to view the version history.
+```
+

--- a/ui/app/adapters/secret-v2.js
+++ b/ui/app/adapters/secret-v2.js
@@ -8,9 +8,10 @@ export default ApplicationAdapter.extend({
   _url(backend, id) {
     let url = `${this.buildURL()}/${encodePath(backend)}/metadata/`;
     if (!isEmpty(id)) {
-      let test = id.replace(/%20/g, ' ');
-      console.log(id, 'id');
-      url = url + encodePath(test);
+      // if path has a whitespace already encoded, return to whitespace because method encodePath will encode it.
+      // if we don't return to a whitespace it will get encoded as %20, resulting in a %2520 (% => 25).
+      let path = id.replace(/%20/g, ' ');
+      url = url + encodePath(path);
     }
     return url;
   },

--- a/ui/app/adapters/secret-v2.js
+++ b/ui/app/adapters/secret-v2.js
@@ -8,10 +8,7 @@ export default ApplicationAdapter.extend({
   _url(backend, id) {
     let url = `${this.buildURL()}/${encodePath(backend)}/metadata/`;
     if (!isEmpty(id)) {
-      // if path has a whitespace already encoded, return to whitespace because method encodePath will encode it.
-      // if we don't return to a whitespace it will get encoded as %20, resulting in a %2520 (% => 25).
-      let path = id.replace(/%20/g, ' ');
-      url = url + encodePath(path);
+      url = url + encodePath(id);
     }
     return url;
   },

--- a/ui/app/adapters/secret-v2.js
+++ b/ui/app/adapters/secret-v2.js
@@ -8,7 +8,9 @@ export default ApplicationAdapter.extend({
   _url(backend, id) {
     let url = `${this.buildURL()}/${encodePath(backend)}/metadata/`;
     if (!isEmpty(id)) {
-      url = url + encodePath(id);
+      let test = id.replace(/%20/g, ' ');
+      console.log(id, 'id');
+      url = url + encodePath(test);
     }
     return url;
   },

--- a/ui/app/routes/vault/cluster/secrets/backend/versions.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/versions.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import utils from 'vault/lib/key-utils';
 import UnloadModelRoute from 'vault/mixins/unload-model-route';
+import { normalizePath } from 'vault/utils/path-encoding-helpers';
 
 export default Route.extend(UnloadModelRoute, {
   templateName: 'vault/cluster/secrets/backend/versions',
@@ -22,6 +23,7 @@ export default Route.extend(UnloadModelRoute, {
   model(params) {
     let { secret } = params;
     const { backend } = this.paramsFor('vault.cluster.secrets.backend');
-    return this.store.queryRecord('secret-v2', { id: secret, backend });
+    let id = normalizePath(secret);
+    return this.store.queryRecord('secret-v2', { id, backend });
   },
 });

--- a/ui/app/templates/components/secret-edit.hbs
+++ b/ui/app/templates/components/secret-edit.hbs
@@ -45,7 +45,7 @@
         as |D|
       >
         <D.trigger
-          data-test-popup-menu-trigger="true"
+          data-test-popup-menu-trigger="history"
           @class={{concat "popup-menu-trigger toolbar-link" (if D.isOpen " is-active")}}
           @tagName="button"
         >
@@ -56,6 +56,7 @@
             <ul class="menu-list">
               <li class="action">
                 <SecretLink
+                  @data-test-version-history
                   @mode="versions"
                   @secret={{this.model.id}}
                   @class="has-text-black has-text-weight-semibold has-bottom-shadow"

--- a/ui/app/templates/components/secret-link.hbs
+++ b/ui/app/templates/components/secret-link.hbs
@@ -8,6 +8,8 @@
   data-test-transit-link=data-test-transit-link
   data-test-transit-key-actions-link=data-test-transit-key-actions-link
   data-test-transit-action-link=data-test-transit-action-link
+  data-test-version-history=data-test-version-history
+  data-test-version=data-test-version
   invokeAction=(action onLinkClick)
 }}
   {{yield}}

--- a/ui/app/templates/vault/cluster/secrets/backend/versions.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/versions.hbs
@@ -43,6 +43,7 @@
       <SecretVersionMenu @version={{list.item}} @useDefaultTrigger={{true}}>
         <li class="action">
           <SecretLink
+            @data-test-version
             @mode="show"
             @secret={{model.id}}
             @class="has-text-black has-text-weight-semibold"

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -1,4 +1,4 @@
-import { visit, settled, currentURL, currentRouteName } from '@ember/test-helpers';
+import { click, visit, settled, currentURL, currentRouteName } from '@ember/test-helpers';
 import { create } from 'ember-cli-page-object';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
@@ -20,7 +20,7 @@ let writeSecret = async function(backend, path, key, val) {
   return editPage.createSecret(path, key, val);
 };
 
-module('Acceptance | secrets/secret/create meep', function(hooks) {
+module('Acceptance | secrets/secret/create', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function() {
@@ -251,6 +251,7 @@ module('Acceptance | secrets/secret/create meep', function(hooks) {
   test('paths are properly encoded', async function(assert) {
     let backend = 'kv';
     let paths = [
+      ' ',
       '(',
       ')',
       '"',
@@ -275,6 +276,7 @@ module('Acceptance | secrets/secret/create meep', function(hooks) {
     assert.expect(paths.length * 2);
     let secretName = '2';
     let commands = paths.map(path => `write '${backend}/${path}/${secretName}' 3=4`);
+    console.log(commands, 'commands');
     await consoleComponent.runCommands(['write sys/mounts/kv type=kv', ...commands]);
     for (let path of paths) {
       await listPage.visit({ backend, id: path });
@@ -286,6 +288,55 @@ module('Acceptance | secrets/secret/create meep', function(hooks) {
         `${path}: show page renders correctly`
       );
     }
+  });
+
+  // test('first level secrets redirect properly upon deletion', async function(assert) {
+  //   let enginePath = `kv-${new Date().getTime()}`;
+  //   let secretPath = 'test';
+  //   // mount version 1 engine
+  //   await mountSecrets.visit();
+  //   await mountSecrets.selectType('kv');
+  //   await mountSecrets
+  //     .next()
+  //     .path(enginePath)
+  //     .version(1)
+  //     .submit();
+  //   await listPage.create();
+  //   await editPage.createSecret(secretPath, 'foo', 'bar');
+  //   await showPage.deleteSecret();
+  //   assert.equal(
+  //     currentRouteName(),
+  //     'vault.cluster.secrets.backend.list-root',
+  //     'redirected to the list page on delete'
+  //   );
+  // });
+
+  test('create secret with space shows version data', async function(assert) {
+    let enginePath = `kv-${new Date().getTime()}`;
+    let secretPath = 'space space';
+    // mount version 2
+    await mountSecrets.visit();
+    await mountSecrets.selectType('kv');
+    await mountSecrets
+      .next()
+      .path(enginePath)
+      .submit();
+    await settled();
+    await listPage.create();
+    await editPage.createSecret(secretPath, 'foo', 'bar');
+    await settled();
+    await click('[data-test-popup-menu-trigger="history"]');
+    await settled();
+    await click('[data-test-version-history]');
+    await settled();
+    assert.dom('[data-test-list-item-content]').exists('renders the version and not an error state');
+    // click on version
+    await click('[data-test-popup-menu-trigger="true"]');
+    await click('[data-test-version]');
+    await settled();
+    // perform encode function that should be done by the encodePath
+    let encodedSecretPath = secretPath.replace(/ /g, '%20');
+    assert.equal(currentURL(), `/vault/secrets/${enginePath}/show/${encodedSecretPath}?version=1`);
   });
 
   // the web cli does not handle a quote as part of a path, so we test it here via the UI

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -251,7 +251,6 @@ module('Acceptance | secrets/secret/create', function(hooks) {
   test('paths are properly encoded', async function(assert) {
     let backend = 'kv';
     let paths = [
-      ' ',
       '(',
       ')',
       '"',
@@ -276,7 +275,6 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     assert.expect(paths.length * 2);
     let secretName = '2';
     let commands = paths.map(path => `write '${backend}/${path}/${secretName}' 3=4`);
-    console.log(commands, 'commands');
     await consoleComponent.runCommands(['write sys/mounts/kv type=kv', ...commands]);
     for (let path of paths) {
       await listPage.visit({ backend, id: path });
@@ -289,27 +287,6 @@ module('Acceptance | secrets/secret/create', function(hooks) {
       );
     }
   });
-
-  // test('first level secrets redirect properly upon deletion', async function(assert) {
-  //   let enginePath = `kv-${new Date().getTime()}`;
-  //   let secretPath = 'test';
-  //   // mount version 1 engine
-  //   await mountSecrets.visit();
-  //   await mountSecrets.selectType('kv');
-  //   await mountSecrets
-  //     .next()
-  //     .path(enginePath)
-  //     .version(1)
-  //     .submit();
-  //   await listPage.create();
-  //   await editPage.createSecret(secretPath, 'foo', 'bar');
-  //   await showPage.deleteSecret();
-  //   assert.equal(
-  //     currentRouteName(),
-  //     'vault.cluster.secrets.backend.list-root',
-  //     'redirected to the list page on delete'
-  //   );
-  // });
 
   test('create secret with space shows version data', async function(assert) {
     let enginePath = `kv-${new Date().getTime()}`;


### PR DESCRIPTION
This fix address [PR issue 10418](https://github.com/hashicorp/vault/issues/10418)

We call a method `encodePath` which is apart of a third-party library. By default, this method encodes spaces from ` ` to `%20`.  The problem is that we have already encoded white spaces before it gets sent to this method, such that the white spaces essential get encoded twice resulting in ` %2520`  instead of `%20`.  To fix this, I replaced the already encoded space using regex back to whitespace before it gets sent to this method.

Because the URL is getting sent to `encodePath` no matter what, I don't see any issues here, but it's worth some consideration.

[Here is the library](https://github.com/tildeio/route-recognizer) for the encodePath and here is a [PR](https://github.com/tildeio/route-recognizer/pull/109) that talks about the special characters it does not encode (white space is not included).

**With fix:** The version page now shows where before it didn't.
![image](https://user-images.githubusercontent.com/6618863/102525653-ccf6f080-4057-11eb-878e-b439011ecb27.png)


**Without fix:** Double encoding on the spaces shows up at %2520 
![image](https://user-images.githubusercontent.com/6618863/102525409-7093d100-4057-11eb-968c-34bdc7526a03.png)

[From a helpful Stackoverflow article](https://stackoverflow.com/questions/16084935/a-html-space-is-showing-as-2520-instead-of-20#:~:text=A%20bit%20of%20explaining%20as,the%20%20%20to%20%2520%20)
>The common space character is encoded as %20 as you noted yourself. The % character is encoded as %25.
>The way you get %2520 is when your url already has a %20 in it, and gets urlencoded again, which transforms the %20 to %2520
