### PR TITLE
Fix typo in lease renew documentation

### DIFF
--- a/website/content/docs/commands/lease/renew.mdx
+++ b/website/content/docs/commands/lease/renew.mdx
@@ -21,7 +21,11 @@ Renew a lease:
 
 ```shell-session
 $ vault lease renew database/creds/readonly/27e1b9a1-27b8-83d9-9fe0-d99d786bdc83
-Success! Revoked lease: database/creds/readonly/27e1b9a1-27b8-83d9-9fe0-d99d786bdc83
+Key                Value
+---                -----
+lease_id           database/creds/readonly/27e1b9a1-27b8-83d9-9fe0-d99d786bdc83
+lease_duration     5m
+lease_renewable    true
 ```
 
 ## Usage


### PR DESCRIPTION
The documentation for `renew` is showing the output for `revoke`.