### PR TITLE
Backport [1.6.x] Fix compilation of MySQL & Redshift plugins (#10640)

### DIFF
--- a/plugins/database/mysql/mysql-database-plugin/main.go
+++ b/plugins/database/mysql/mysql-database-plugin/main.go
@@ -19,7 +19,7 @@ func main() {
 // Run instantiates a MySQL object, and runs the RPC server for the plugin
 func Run() error {
 	var f func() (interface{}, error)
-	f = mysql.New(false)
+	f = mysql.New(mysql.MetadataLen, mysql.MetadataLen, mysql.UsernameLen)
 	dbType, err := f()
 	if err != nil {
 		return err

--- a/plugins/database/mysql/mysql-legacy-database-plugin/main.go
+++ b/plugins/database/mysql/mysql-legacy-database-plugin/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/vault/plugins/database/mysql"
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
+	"github.com/hashicorp/vault/sdk/database/helper/credsutil"
 )
 
 func main() {
@@ -19,7 +20,7 @@ func main() {
 // Run instantiates a MySQL object, and runs the RPC server for the plugin
 func Run() error {
 	var f func() (interface{}, error)
-	f = mysql.New(true)
+	f = mysql.New(credsutil.NoneLength, mysql.LegacyMetadataLen, mysql.LegacyUsernameLen)
 	dbType, err := f()
 	if err != nil {
 		return err

--- a/plugins/database/redshift/redshift-database-plugin/main.go
+++ b/plugins/database/redshift/redshift-database-plugin/main.go
@@ -22,7 +22,7 @@ func main() {
 
 // Run instantiates a RedShift object, and runs the RPC server for the plugin
 func Run(apiTLSConfig *api.TLSConfig) error {
-	dbType, err := redshift.New(true)()
+	dbType, err := redshift.New()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backports #10640 to `releases/1.6.x`

Fixes the main funcs associated with MySQL and Redshift database plugins. They were calling their respective Run functions with an old function signature. These specific packages aren't normally built with CI so we didn't catch this previously.