### PR TITLE
Bug: Fix namespace test 

### DIFF
--- a/ui/app/components/namespace-link.js
+++ b/ui/app/components/namespace-link.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Component from '@ember/component';

--- a/ui/app/components/namespace-link.js
+++ b/ui/app/components/namespace-link.js
@@ -33,13 +33,6 @@ export default Component.extend({
   }),
 
   get namespaceLink() {
-    if (Ember.testing) {
-      if (this.normalizedNamespace) {
-        return `/ui/vault/secrets?namespace=${this.normalizedNamespace}`;
-      }
-      return `/ui/vault/secrets`;
-    }
-
     let origin =
       window.location.protocol +
       '//' +

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -1,4 +1,4 @@
-import { click, settled, visit, pauseTest } from '@ember/test-helpers';
+import { click, settled, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
@@ -16,6 +16,7 @@ const createNS = async name => {
 const switchToNS = async name => {
   await click('[data-test-namespace-toggle]');
   await settled();
+  // visit the URL instead of using the toggle because it refreshes the page and Qunit doesn't like that
   let url = `/vault/secrets?namespace=${name}`;
   await visit(url);
 };

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -1,4 +1,4 @@
-import { click, settled } from '@ember/test-helpers';
+import { click, settled, visit, pauseTest } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
@@ -15,8 +15,9 @@ const createNS = async name => {
 
 const switchToNS = async name => {
   await click('[data-test-namespace-toggle]');
-  await click(`[data-test-namespace-link="${name}"]`);
-  await click('[data-test-namespace-toggle]');
+  await settled();
+  let url = `/vault/secrets?namespace=${name}`;
+  await visit(url);
 };
 
 module('Acceptance | Enterprise | namespaces', function(hooks) {

--- a/ui/tests/acceptance/enterprise-namespaces-test.js
+++ b/ui/tests/acceptance/enterprise-namespaces-test.js
@@ -13,14 +13,6 @@ const createNS = async name => {
   await shell.runCommands(`write sys/namespaces/${name} -force`);
 };
 
-const switchToNS = async name => {
-  await click('[data-test-namespace-toggle]');
-  await settled();
-  // visit the URL instead of using the toggle because it refreshes the page and Qunit doesn't like that
-  let url = `/vault/secrets?namespace=${name}`;
-  await visit(url);
-};
-
 module('Acceptance | Enterprise | namespaces', function(hooks) {
   setupApplicationTest(hooks);
 
@@ -52,7 +44,18 @@ module('Acceptance | Enterprise | namespaces', function(hooks) {
       }
       // the namespace path will include all of the namespaces up to this point
       let targetNamespace = nses.slice(0, i + 1).join('/');
-      await switchToNS(targetNamespace);
+      let url = `/vault/secrets?namespace=${targetNamespace}`;
+      // check if namespace is in the toggle
+      await click('[data-test-namespace-toggle]');
+      await settled();
+      // check that the single namespace "beep" or "boop" not "beep/boop" shows in the toggle display
+      assert
+        .dom(`[data-test-namespace-link="${targetNamespace}"]`)
+        .hasText(ns, 'shows the namespace in the toggle component');
+      // close toggle
+      await click('[data-test-namespace-toggle]');
+      // because quint does not like page reloads, visiting url directing instead of clicking on namespace in toggle
+      await visit(url);
       await settled();
     }
     await logout.visit();


### PR DESCRIPTION
_Should not be backported because was an issue caused by Ember Upgrade_

This test was broken in this [PR](https://github.com/hashicorp/vault/pull/10572/files)

The problem was with the new functionality, the page refreshed when switching namespaces.  Qunit doesn't like this.  So instead of using the toggle (which I could stop from refreshing), I instead just manually change to URL to get into the nested namespaces and then confirm they exist –which is the purpose of the test.

I've run the full test suite, and everything passes (CircleCI won't run the enterprise test).