### PR TITLE
Minimize memory used by expiration manager

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1602,15 +1602,14 @@ func (b *SystemBackend) handleLeaseLookup(ctx context.Context, req *logical.Requ
 			"ttl":          int64(0),
 		},
 	}
-	renewable, _ := leaseTimes.renewable()
-	resp.Data["renewable"] = renewable
+	resp.Data["renewable"] = leaseTimes.Renewable
 
 	if !leaseTimes.LastRenewalTime.IsZero() {
 		resp.Data["last_renewal"] = leaseTimes.LastRenewalTime
 	}
 	if !leaseTimes.ExpireTime.IsZero() {
 		resp.Data["expire_time"] = leaseTimes.ExpireTime
-		resp.Data["ttl"] = leaseTimes.ttl()
+		resp.Data["ttl"] = int64(leaseTimes.ExpireTime.Sub(time.Now().Round(time.Second)).Seconds())
 	}
 	return resp, nil
 }

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -1306,7 +1306,7 @@ func (ts *TokenStore) lookupInternal(ctx context.Context, id string, salted, tai
 
 	switch {
 	// It's any kind of expiring token with no lease, immediately delete it
-	case lt.IssueTime.IsZero():
+	case lt == nil:
 		tokenNS, err := NamespaceByID(ctx, entry.NamespaceID, ts.core)
 		if err != nil {
 			return nil, err

--- a/vault/token_store.go
+++ b/vault/token_store.go
@@ -2974,8 +2974,7 @@ func (ts *TokenStore) handleLookup(ctx context.Context, req *logical.Request, da
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
 	}
-	if !leaseTimes.IssueTime.IsZero() {
-
+	if leaseTimes != nil {
 		if !leaseTimes.LastRenewalTime.IsZero() {
 			resp.Data["last_renewal_time"] = leaseTimes.LastRenewalTime.Unix()
 			resp.Data["last_renewal"] = leaseTimes.LastRenewalTime


### PR DESCRIPTION
After doing a restore of ~700K auth cert leases, 1.6.1:

```
Showing nodes accounting for 1768.55MB, 87.72% of 2016.18MB total
Dropped 184 nodes (cum <= 10.08MB)
Showing top 15 nodes out of 75
      flat  flat%   sum%        cum   cum%
  327.52MB 16.24% 16.24%   336.52MB 16.69%  encoding/json.(*decodeState).literalStore
  302.08MB 14.98% 31.23%   302.08MB 14.98%  reflect.mapassign
  248.07MB 12.30% 43.53%   248.07MB 12.30%  reflect.New
  241.07MB 11.96% 55.49%   241.07MB 11.96%  github.com/hashicorp/vault/vault.(*ExpirationManager).leaseTimesForExport (inline)
  102.52MB  5.08% 60.57%  1233.28MB 61.17%  github.com/hashicorp/vault/vault.decodeLeaseEntry
   89.56MB  4.44% 65.01%    97.06MB  4.81%  sync.(*Map).Store
   73.01MB  3.62% 68.64%    83.85MB  4.16%  github.com/hashicorp/vault/vendor/github.com/hashicorp/vault/sdk/logical.ScanView
   68.08MB  3.38% 72.01%    68.08MB  3.38%  encoding/json.(*Decoder).refill
   58.50MB  2.90% 74.91%    58.50MB  2.90%  reflect.makemap
   51.07MB  2.53% 77.45%    51.07MB  2.53%  github.com/hashicorp/vault/vault.(*AESGCMBarrier).decrypt
      51MB  2.53% 79.98%       55MB  2.73%  reflect.cvtBytesString
   47.07MB  2.33% 82.31%    83.07MB  4.12%  github.com/hashicorp/vault/vendor/go.etcd.io/bbolt.(*DB).View
      40MB  1.98% 84.30%   360.89MB 17.90%  github.com/hashicorp/vault/vault.(*ExpirationManager).updatePendingInternal
      36MB  1.79% 86.08%    41.20MB  2.04%  time.AfterFunc
      33MB  1.64% 87.72%       33MB  1.64%  reflect.unsafe_NewArray
```

With this branch:
```
Showing nodes accounting for 385.69MB, 97.30% of 396.41MB total
Dropped 143 nodes (cum <= 1.98MB)
Showing top 15 nodes out of 54
      flat  flat%   sum%        cum   cum%
  124.01MB 31.28% 31.28%   245.93MB 62.04%  github.com/hashicorp/vault/vault.(*ExpirationManager).updatePendingInternal
   86.01MB 21.70% 52.98%    86.01MB 21.70%  encoding/json.(*decodeState).literalStore
   81.07MB 20.45% 73.43%    94.07MB 23.73%  sync.(*Map).Store
      57MB 14.38% 87.81%    61.98MB 15.64%  time.AfterFunc
      13MB  3.28% 91.09%       13MB  3.28%  sync.newEntry (inline)
    9.50MB  2.40% 93.49%   375.58MB 94.75%  github.com/hashicorp/vault/vault.(*ExpirationManager).loadEntryInternal
    7.08MB  1.79% 95.27%     7.08MB  1.79%  github.com/beorn7/perks/quantile.newStream (inline)
    4.98MB  1.26% 96.53%     4.98MB  1.26%  time.startTimer
    2.04MB  0.51% 97.04%     2.04MB  0.51%  github.com/beorn7/perks/quantile.(*stream).merge
    0.50MB  0.13% 97.17%     7.58MB  1.91%  github.com/prometheus/client_golang/prometheus.newSummary
    0.50MB  0.13% 97.30%   376.08MB 94.87%  github.com/hashicorp/vault/vault.(*ExpirationManager).Restore.func2
         0     0% 97.30%    86.01MB 21.70%  encoding/json.(*Decoder).Decode
         0     0% 97.30%    86.01MB 21.70%  encoding/json.(*decodeState).object
         0     0% 97.30%    86.01MB 21.70%  encoding/json.(*decodeState).unmarshal
         0     0% 97.30%    86.01MB 21.70%  encoding/json.(*decodeState).value
```