### PR TITLE
append slash to consul path in doc

### DIFF
--- a/website/content/docs/commands/operator/migrate.mdx
+++ b/website/content/docs/commands/operator/migrate.mdx
@@ -61,7 +61,7 @@ storage_source "mysql" {
 
 storage_destination "consul" {
   address = "127.0.0.1:8500"
-  path    = "vault"
+  path    = "vault/"
 }
 ```
 

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -14,7 +14,7 @@ An example configuration is shown below:
 ```javascript
 storage "consul" {
   address = "127.0.0.1:8500"
-  path    = "vault"
+  path    = "vault/"
 }
 
 listener "tcp" {

--- a/website/content/docs/configuration/storage/consul.mdx
+++ b/website/content/docs/configuration/storage/consul.mdx
@@ -24,7 +24,7 @@ check.
 ```hcl
 storage "consul" {
   address = "127.0.0.1:8500"
-  path    = "vault"
+  path    = "vault/"
 }
 ```
 

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -684,8 +684,8 @@ and consider if they're appropriate for your deployment.
         }
 
         storage "consul" {
-            path = "vault"
             address = "HOST_IP:8500"
+            path = "vault/"
         }
       ```
 

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -355,8 +355,8 @@ server:
       }
 
       storage "consul" {
-        path = "vault"
         address = "HOST_IP:8500"
+        path = "vault/"
       }
 ```
 


### PR DESCRIPTION
Vault 1.6.1 warns when using `path = "vault"`

```
[WARN]  storage.consul: appending trailing forward slash to path
```