### PR TITLE
Add link to go-discover README to raft documentation

### DIFF
--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -156,7 +156,10 @@ by `\n`, but not a combination of both. Each [`retry_join`](#retry_join-stanza)
 stanza may contain either a [`leader_api_addr`](#leader_api_addr) value or a
 cloud [`auto_join`](#auto_join) configuration value, but not both. When an
 [`auto_join`](#auto_join) value is provided, Vault will automatically attempt to
-discover and resolve potential Raft leader addresses.
+discover and resolve potential Raft leader addresses using [go-discover](https://github.com/hashicorp/go-discover).
+See the go-discover
+[README](https://github.com/hashicorp/go-discover/blob/master/README.md)
+for details on the format of the `auto_join` value.
 
 By default, Vault will attempt to reach discovered peers using HTTPS and port
 8200.  Operators may override these through the


### PR DESCRIPTION
I thought it would be beneficial if the link to the go-discover would also be in `configuration/storage/raft.mdx` and not only in `concepts/integrated-storage.mdx`