### PR TITLE
UI: Fix shape of response anticipated from feature-flags endpoint

### DIFF
--- a/changelog/10684.txt
+++ b/changelog/10684.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix expected response from feature-flags endpoint
+```

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -89,7 +89,7 @@ export default Route.extend({
     });
     if (result.status === 200) {
       const body = await result.json();
-      const flags = body.data?.feature_flags || [];
+      const flags = body.feature_flags || [];
       this.featureFlagService.setFeatureFlags(flags);
     }
   },

--- a/ui/tests/acceptance/managed-namespace-test.js
+++ b/ui/tests/acceptance/managed-namespace-test.js
@@ -4,9 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import Pretender from 'pretender';
 
 const FEATURE_FLAGS_RESPONSE = {
-  data: {
-    feature_flags: ['VAULT_CLOUD_ADMIN_NAMESPACE'],
-  },
+  feature_flags: ['VAULT_CLOUD_ADMIN_NAMESPACE'],
 };
 
 module('Acceptance | Enterprise | Managed namespace root', function(hooks) {


### PR DESCRIPTION
After testing with the real endpoint, I discovered that the shape of the data does not include a data key as initially thought. This fixes the response parsing and the test so that it works as expected with the live endpoint. 