### PR TITLE
Add token as parameter for postgres queries

### DIFF
--- a/builtin/logical/postgresql/path_role_create.go
+++ b/builtin/logical/postgresql/path_role_create.go
@@ -113,7 +113,13 @@ func (b *backend) pathRoleCreateRead(ctx context.Context, req *logical.Request, 
 			"expiration": expiration,
 		}
 
-		if err := dbtxn.ExecuteTxQueryDirect(ctx, tx, m, query); err != nil {
+		// inject metadata as parameters
+		metadata := req.TokenEntry().Meta
+		for k, v := range metadata {
+			m[fmt.Sprintf("token.metadata.%s", k)] = v
+		}
+
+		if err := dbtxn.ExecuteTxQuery(ctx, tx, m, query); err != nil {
 			return nil, err
 		}
 	}

--- a/changelog/10682.txt
+++ b/changelog/10682.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: support token metadata in template
+```

--- a/sdk/helper/identitytpl/templating_test.go
+++ b/sdk/helper/identitytpl/templating_test.go
@@ -553,3 +553,41 @@ func TestPopulate_FullObject(t *testing.T) {
 		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, out)
 	}
 }
+
+func TestPopulate_TokenMetaData(t *testing.T) {
+	testToken := &logical.TokenEntry{
+		Meta: map[string]string{
+			"color":         "green",
+			"size":          "small",
+			"non-printable": "\"\n\t",
+		},
+	}
+
+	template := `
+			{
+			    "all metadata": {{token.metadata}},
+			    "one metadata key": {{token.metadata.color}},
+			    "one metadata key not found": {{token.metadata.asldfk}}
+			}`
+
+	expected := `
+			{
+			    "all metadata": {"color":"green","non-printable":"\"\n\t","size":"small"},
+			    "one metadata key": "green",
+			    "one metadata key not found": ""
+			}`
+
+	input := PopulateStringInput{
+		Mode:   JSONTemplating,
+		String: template,
+		Token:  testToken,
+	}
+	_, out, err := PopulateString(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if out != expected {
+		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, out)
+	}
+}

--- a/vault/capabilities.go
+++ b/vault/capabilities.go
@@ -19,7 +19,7 @@ func (c *Core) Capabilities(ctx context.Context, token, path string) ([]string, 
 		return nil, &logical.StatusBadRequest{Err: "missing token"}
 	}
 
-	te, err := c.tokenStore.Lookup(ctx, token)
+	te, err := c.LookupToken(ctx, token)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (c *Core) Capabilities(ctx context.Context, token, path string) ([]string, 
 	// Construct the corresponding ACL object. ACL construction should be
 	// performed on the token's namespace.
 	tokenCtx := namespace.ContextWithNamespace(ctx, tokenNS)
-	acl, err := c.policyStore.ACL(tokenCtx, entity, policyNames, policies...)
+	acl, err := c.policyStore.ACL(tokenCtx, entity, te, policyNames, policies...)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -114,7 +114,7 @@ func (e extendedSystemViewImpl) SudoPrivilege(ctx context.Context, path string, 
 
 	// Construct the corresponding ACL object. Derive and use a new context that
 	// uses the req.ClientToken's namespace
-	acl, err := e.core.policyStore.ACL(tokenCtx, entity, policyNames, policies...)
+	acl, err := e.core.policyStore.ACL(tokenCtx, entity, te, policyNames, policies...)
 	if err != nil {
 		e.core.logger.Error("failed to retrieve ACL for token's policies", "token_policies", te.Policies, "error", err)
 		return false

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -268,14 +268,14 @@ func addGrantingPoliciesToMap(m map[uint32][]logical.PolicyInfo, policy *Policy,
 // intermediary set of policies, before being compiled into
 // the ACL
 func ParseACLPolicy(ns *namespace.Namespace, rules string) (*Policy, error) {
-	return parseACLPolicyWithTemplating(ns, rules, false, nil, nil)
+	return parseACLPolicyWithTemplating(ns, rules, false, nil, nil, nil)
 }
 
 // parseACLPolicyWithTemplating performs the actual work and checks whether we
 // should perform substitutions. If performTemplating is true we know that it
 // is templated so we don't check again, otherwise we check to see if it's a
 // templated policy.
-func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, performTemplating bool, entity *identity.Entity, groups []*identity.Group) (*Policy, error) {
+func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, performTemplating bool, entity *identity.Entity, groups []*identity.Group, token *logical.TokenEntry) (*Policy, error) {
 	// Parse the rules
 	root, err := hcl.Parse(rules)
 	if err != nil {
@@ -308,7 +308,7 @@ func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, perform
 	}
 
 	if o := list.Filter("path"); len(o.Items) > 0 {
-		if err := parsePaths(&p, o, performTemplating, entity, groups); err != nil {
+		if err := parsePaths(&p, o, performTemplating, entity, groups, token); err != nil {
 			return nil, fmt.Errorf("failed to parse policy: %w", err)
 		}
 	}
@@ -316,7 +316,7 @@ func parseACLPolicyWithTemplating(ns *namespace.Namespace, rules string, perform
 	return &p, nil
 }
 
-func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, entity *identity.Entity, groups []*identity.Group) error {
+func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, entity *identity.Entity, groups []*identity.Group, token *logical.TokenEntry) error {
 	paths := make([]*PathRules, 0, len(list.Items))
 	for _, item := range list.Items {
 		key := "path"
@@ -329,6 +329,7 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 			_, templated, err := identitytpl.PopulateString(identitytpl.PopulateStringInput{
 				Mode:        identitytpl.ACLTemplating,
 				String:      key,
+				Token:       token,
 				Entity:      identity.ToSDKEntity(entity),
 				Groups:      identity.ToSDKGroups(groups),
 				NamespaceID: result.namespace.ID,

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -754,7 +754,7 @@ func (t *TemplateError) Error() string {
 
 // ACL is used to return an ACL which is built using the
 // named policies and pre-fetched policies if given.
-func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*Policy) (*ACL, error) {
+func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, token *logical.TokenEntry, policyNames map[string][]string, additionalPolicies ...*Policy) (*ACL, error) {
 	var allPolicies []*Policy
 
 	// Fetch the named policies
@@ -795,7 +795,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 					groups = append(directGroups, inheritedGroups...)
 				}
 			}
-			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, entity, groups)
+			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, entity, groups, token)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing templated policy %q: %w", policy.Name, err)
 			}

--- a/vault/policy_store_test.go
+++ b/vault/policy_store_test.go
@@ -268,7 +268,7 @@ func testPolicyStoreACL(t *testing.T, ps *PolicyStore, ns *namespace.Namespace) 
 	}
 
 	ctx = namespace.ContextWithNamespace(context.Background(), ns)
-	acl, err := ps.ACL(ctx, nil, map[string][]string{ns.ID: {"dev", "ops"}})
+	acl, err := ps.ACL(ctx, nil, nil, map[string][]string{ns.ID: {"dev", "ops"}})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -237,7 +237,7 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 
 	// Construct the corresponding ACL object. ACL construction should be
 	// performed on the token's namespace.
-	acl, err := c.policyStore.ACL(tokenCtx, entity, policyNames, policies...)
+	acl, err := c.policyStore.ACL(tokenCtx, entity, te, policyNames, policies...)
 	if err != nil {
 		if errwrap.ContainsType(err, new(TemplateError)) {
 			c.logger.Warn("permission denied due to a templated policy being invalid or containing directives not satisfied by the requestor", "error", err)

--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -265,6 +265,7 @@ injected, and currently the `path` keys in policies allow injection.
 
 | Name                                                                             | Description                                                                            |
 | :------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- |
+| `token.metadata.<metadata key>`                                    | The token's associated metadata                                         |
 | `identity.entity.id`                                                             | The entity's ID                                                                        |
 | `identity.entity.name`                                                           | The entity's name                                                                      |
 | `identity.entity.metadata.<metadata key>`                                        | Metadata associated with the entity for the given key                                  |


### PR DESCRIPTION
An initial effort to provide variables in database queries.
I stuck with what I know and limited this to postgres.

Initially I wanted to re-use the code used to interpolate variables in the policies but they both have very different implementations. I kinda like the simplicity of what was implemented here though and am willing to expand the scope of both the database that are supported as well as to rework this code to be on par with the variable interpolations available for policies.

This adds the possibility to use {{token.metadata.<key>}} (next to {{name}}, {{password}} and {{expiration}})