### PR TITLE
allow create to create transit keys

### DIFF
--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -99,6 +99,7 @@ return the public key for the given context.`,
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.pathPolicyWrite,
+			logical.CreateOperation: b.pathPolicyWrite,
 			logical.DeleteOperation: b.pathPolicyDelete,
 			logical.ReadOperation:   b.pathPolicyRead,
 		},

--- a/changelog/10706.txt
+++ b/changelog/10706.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+transit: Allow create capability in policies to create transit keys
+```


### PR DESCRIPTION
As per https://www.vaultproject.io/api-docs/secret/transit , create key values can't be changed via key creation. So, the create capability should allow the creation of transit keys. 

We can't remove the update capability from allowing this, since it's already in use by customers and would most likely require a large overhaul of policy restructuring on the customer end. 