### PR TITLE
Existence Check for transit key creation endpoint [VAULT-1352]

### DIFF
--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -99,6 +99,7 @@ return the public key for the given context.`,
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.pathPolicyWrite,
+			logical.CreateOperation: b.pathPolicyWrite,
 			logical.DeleteOperation: b.pathPolicyDelete,
 			logical.ReadOperation:   b.pathPolicyRead,
 		},

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -103,10 +103,26 @@ return the public key for the given context.`,
 			logical.DeleteOperation: b.pathPolicyDelete,
 			logical.ReadOperation:   b.pathPolicyRead,
 		},
-
+		ExistenceCheck:  b.pathTransitKeyExistenceCheck,
 		HelpSynopsis:    pathPolicyHelpSyn,
 		HelpDescription: pathPolicyHelpDesc,
 	}
+}
+
+func (b *backend) pathTransitKeyExistenceCheck(ctx context.Context, req *logical.Request, d *framework.FieldData) (bool, error) {
+	name := d.Get("name").(string)
+	p, _, err := b.lm.GetPolicy(ctx, keysutil.PolicyRequest{
+		Storage: req.Storage,
+		Name:    name,
+	}, b.GetRandomReader())
+	if err != nil {
+		return false, err
+	}
+	if p == nil {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (b *backend) pathKeysList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {

--- a/changelog/10706.txt
+++ b/changelog/10706.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+transit: Allow create capability in policies to create transit keys
+```

--- a/changelog/10717.txt
+++ b/changelog/10717.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+transit: Fix for Vault OSS PR 10706, which allows create capability in policies to create transit keys
+```


### PR DESCRIPTION
This goes hand in hand with: 
https://github.com/hashicorp/vault/pull/10706

and:
https://github.com/hashicorp/vault/issues/10701

and has been tested. 

However, the issue is that with this change, the "create" permission is now necessary to create keys, whereas before only the "update" permission was necessary. This means the change will be breaking for existing customers that have "update" permissions for key creation. 

Currently, I'm not sure how to make this backward compatible so that "update" would function as both create and update simultaneously, or if that is even possible. So, we may want to defer this PR to a later release version. If we do decide to defer, I will roll back https://github.com/hashicorp/vault/pull/10706 as well. 