### PR TITLE
Revert "allow create to create transit keys" [VAULT-1352]

### DIFF
--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -99,7 +99,6 @@ return the public key for the given context.`,
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.pathPolicyWrite,
-			logical.CreateOperation: b.pathPolicyWrite,
 			logical.DeleteOperation: b.pathPolicyDelete,
 			logical.ReadOperation:   b.pathPolicyRead,
 		},

--- a/changelog/10706.txt
+++ b/changelog/10706.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-transit: Allow create capability in policies to create transit keys
-```


### PR DESCRIPTION
Reverts hashicorp/vault#10706