### PR TITLE
Port: Protect part of emitMetrics from panic behavior during post-seal

### DIFF
--- a/changelog/10708.txt
+++ b/changelog/10708.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ metrics: Protect emitMetrics from panicking during post-seal
+ ```

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -242,6 +242,13 @@ func (c *Core) findKvMounts() []*kvMount {
 	c.mountsLock.RLock()
 	defer c.mountsLock.RUnlock()
 
+	// emitMetrics doesn't grab the statelock, so this code might run during or after the seal process.
+	// Therefore, we need to check if c.mounts is nil. If we do not, emitMetrics will panic if this is
+	// run after seal.
+	if c.mounts == nil {
+		return mounts
+	}
+
 	for _, entry := range c.mounts.Entries {
 		if entry.Type == "kv" {
 			version, ok := entry.Options["version"]


### PR DESCRIPTION
This is a backport for: https://github.com/hashicorp/vault/pull/10708