### PR TITLE
Backport 1.6: Add configuration to specify a TLS ServerName to use in the TLS hands…

### DIFF
--- a/http/sys_raft.go
+++ b/http/sys_raft.go
@@ -64,6 +64,7 @@ func handleSysRaftJoinPost(core *vault.Core, w http.ResponseWriter, r *http.Requ
 			respondError(w, http.StatusBadRequest, err)
 			return
 		}
+		tlsConfig.ServerName = req.LeaderTLSServerName
 	}
 
 	if req.AutoJoinScheme != "" && (req.AutoJoinScheme != "http" && req.AutoJoinScheme != "https") {
@@ -99,13 +100,14 @@ type JoinResponse struct {
 }
 
 type JoinRequest struct {
-	AutoJoin         string `json:"auto_join"`
-	AutoJoinScheme   string `json:"auto_join_scheme"`
-	AutoJoinPort     uint   `json:"auto_join_port"`
-	LeaderAPIAddr    string `json:"leader_api_addr"`
-	LeaderCACert     string `json:"leader_ca_cert"`
-	LeaderClientCert string `json:"leader_client_cert"`
-	LeaderClientKey  string `json:"leader_client_key"`
-	Retry            bool   `json:"retry"`
-	NonVoter         bool   `json:"non_voter"`
+	AutoJoin            string `json:"auto_join"`
+	AutoJoinScheme      string `json:"auto_join_scheme"`
+	AutoJoinPort        uint   `json:"auto_join_port"`
+	LeaderAPIAddr       string `json:"leader_api_addr"`
+	LeaderCACert        string `json:"leader_ca_cert"`
+	LeaderClientCert    string `json:"leader_client_cert"`
+	LeaderClientKey     string `json:"leader_client_key"`
+	LeaderTLSServerName string `json:"leader_tls_servername"`
+	Retry               bool   `json:"retry"`
+	NonVoter            bool   `json:"non_voter"`
 }

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -166,6 +166,10 @@ type LeaderJoinInfo struct {
 	// only be provided via Vault's configuration file.
 	LeaderClientKeyFile string `json:"leader_client_key_file"`
 
+	// LeaderTLSServerName is the optional ServerName to expect in the leader's
+	// certificate, instead of the host/IP we're actually connecting to.
+	LeaderTLSServerName string `json:"leader_tls_servername"`
+
 	// Retry indicates if the join process should automatically be retried
 	Retry bool `json:"-"`
 
@@ -226,6 +230,7 @@ func parseTLSInfo(leaderInfo *LeaderJoinInfo) (*tls.Config, error) {
 			return nil, err
 		}
 	}
+	tlsConfig.ServerName = leaderInfo.LeaderTLSServerName
 
 	return tlsConfig, nil
 }

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -814,6 +814,7 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 				if err != nil {
 					return errwrap.Wrapf("failed to create TLS config: {{err}}", err)
 				}
+				leaderInfo.TLSConfig.ServerName = leaderInfo.LeaderTLSServerName
 			}
 
 			if leaderInfo.TLSConfig != nil {


### PR DESCRIPTION
…hake when performing a raft join. (#10698)