### PR TITLE
Update api-docs for static role deletion

### DIFF
--- a/website/content/api-docs/secret/databases/index.mdx
+++ b/website/content/api-docs/secret/databases/index.mdx
@@ -568,7 +568,8 @@ $ curl \
 
 ## Delete Static Role
 
-This endpoint deletes the static role definition and revokes the database user.
+This endpoint deletes the static role definition. The user, having been defined externally,
+must be cleaned up manually.
 
 | Method   | Path                           |
 | :------- | :----------------------------- |


### PR DESCRIPTION
We now specify that the user will remain in the DB unless cleaned up manually.