### PR TITLE
Unconditionally use the root namespace when calling sys/seal-status.

### DIFF
--- a/command/status.go
+++ b/command/status.go
@@ -71,6 +71,11 @@ func (c *StatusCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Always query in the root namespace.
+	// Although seal-status is present in other namespaces, it will not
+	// be available until Vault is unsealed.
+	client.SetNamespace("")
+
 	status, err := client.Sys().SealStatus()
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error checking seal status: %s", err))


### PR DESCRIPTION
Though PR #10725 and it accompanying enterprise PR added sys/seal-status to all namespaces, it will only be available there when Vault is unsealed.  `v1/sys/seal-status` is the only point guaranteed to work, so this change ensures that is what gets called, ignoring the VAULT_NAMESPACE environment variable or a command line flag.

