### PR TITLE
We should allow test-go and test-go-remote-docker to run...

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2245,19 +2245,9 @@ workflows:
         - install-ui-dependencies
         - build-go-dev
     - test-go:
-        filters:
-          branches:
-            ignore:
-            - /^docs\/.*/
-            - /^ui\/.*/
         requires:
         - pre-flight-checks
     - test-go-remote-docker:
-        filters:
-          branches:
-            ignore:
-            - /^docs\/.*/
-            - /^ui\/.*/
         requires:
         - pre-flight-checks
     - test-go-race:

--- a/.circleci/config/workflows/ci.yml
+++ b/.circleci/config/workflows/ci.yml
@@ -24,21 +24,9 @@ jobs:
   - test-go:
       requires:
         - pre-flight-checks
-      filters:
-        branches:
-          # UI and Docs-only branches should skip go tests
-          ignore:
-            - /^docs\/.*/
-            - /^ui\/.*/
   - test-go-remote-docker:
       requires:
         - pre-flight-checks
-      filters:
-        branches:
-          # UI and Docs-only branches should skip go tests
-          ignore:
-            - /^docs\/.*/
-            - /^ui\/.*/
   - test-go-race:
       requires:
         - pre-flight-checks


### PR DESCRIPTION
so that they can satisfy the check.  There's a short-circuit within them to avoid taking time if it's a ui/ or docs/ branch.