### PR TITLE
fix deep links to consul-template docs

### DIFF
--- a/website/content/docs/agent/template.mdx
+++ b/website/content/docs/agent/template.mdx
@@ -12,7 +12,7 @@ description: >-
 # Vault Agent Templates
 
 Vault Agent's Template functionality allows Vault secrets to be rendered to files
-using [Consul Template markup](https://github.com/hashicorp/consul-template#templating-language).
+using [Consul Template markup](https://github.com/hashicorp/consul-template/blob/master/docs/templating-language.md).
 
 ## Functionality
 
@@ -74,7 +74,8 @@ The top level `template` block has multiple configurations entries:
 
 ## Example Template
 
-Template with Vault Agent requires the use of the `secret` [function from Consul Template](https://github.com/hashicorp/consul-template#secret).  
+Template with Vault Agent requires the use of the `secret` [function from Consul
+Template](https://github.com/hashicorp/consul-template/blob/master/docs/templating-language.md#secret).
 The following is an example of a template that retrieves a generic secret from Vault's
 KV store:
 

--- a/website/content/guides/secret-mgmt/app-integration.mdx
+++ b/website/content/guides/secret-mgmt/app-integration.mdx
@@ -313,7 +313,7 @@ database: "myapp"
 
 To have Consul Template to populate the `<DB_USRENAME>` and `<DB_PASSWORD>`, you
 need to create a template file with Consul Template [templating
-language](https://github.com/hashicorp/consul-template#templating-language).
+language](https://github.com/hashicorp/consul-template/blob/master/docs/templating-language.md).
 
 1. Create a template file by replacing the username and password with
    Consul Template syntax and save it as **`config.yml.tpl`**. The file should


### PR DESCRIPTION
Just a few links that needed fixing due to a re-org of consul-template docs.
Guessed at appropriate labels and reviewers.

Thanks.