### PR TITLE
Instrument all connection pool PermitPools

### DIFF
--- a/helper/permits/permits.go
+++ b/helper/permits/permits.go
@@ -1,0 +1,46 @@
+package permits
+
+import (
+	"github.com/armon/go-metrics"
+	"github.com/hashicorp/vault/sdk/physical"
+)
+
+type InstrumentedPermitPool struct {
+	*physical.PermitPool
+	permitCountMetricName []string
+}
+
+func NewInstrumentedPermitPool(permits int, keyPrefix ...string) *InstrumentedPermitPool {
+	limitMetricName := append(keyPrefix, "permits-limit")
+	metrics.SetGauge(limitMetricName, float32(permits))
+
+	pool := &InstrumentedPermitPool{
+		PermitPool:            physical.NewPermitPool(permits),
+		permitCountMetricName: append(keyPrefix, "permits"),
+	}
+
+	// initialize gauge to 0
+	pool.updatePermitGauge()
+	return pool
+}
+
+// Acquire returns when a permit has been acquired
+func (pool *InstrumentedPermitPool) Acquire() {
+	pool.PermitPool.Acquire()
+	pool.updatePermitGauge()
+}
+
+// Release returns a permit to the pool
+func (pool *InstrumentedPermitPool) Release() {
+	pool.PermitPool.Release()
+	pool.updatePermitGauge()
+}
+
+// Get number of requests in the permit pool
+func (pool *InstrumentedPermitPool) CurrentPermits() int {
+	return pool.PermitPool.CurrentPermits()
+}
+
+func (pool *InstrumentedPermitPool) updatePermitGauge() {
+	metrics.SetGauge(pool.permitCountMetricName, float32(pool.PermitPool.CurrentPermits()))
+}

--- a/helper/permits/permits_test.go
+++ b/helper/permits/permits_test.go
@@ -1,0 +1,86 @@
+package permits
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+
+	"github.com/armon/go-metrics"
+)
+
+func TestInstrumentedPermitPool(t *testing.T) {
+	conf := metrics.DefaultConfig("test-permits")
+	conf.EnableHostname = false
+	conf.EnableHostnameLabel = false
+	sink := metrics.NewInmemSink(time.Hour, time.Hour)
+	metrics.NewGlobal(conf, sink)
+
+	permitsUsedMetricName := "test-permits.a.pool.permits"
+	maxPermitMetricName := "test-permits.a.pool.permits-limit"
+	sinkAssert := newSinkAssert(t, sink)
+
+	pool := NewInstrumentedPermitPool(658, "a", "pool")
+	sinkAssert.GaugeEquals(permitsUsedMetricName, 0)
+	sinkAssert.GaugeEquals(maxPermitMetricName, 658)
+
+	pool.Acquire()
+	sinkAssert.GaugeEquals(permitsUsedMetricName, 1)
+	sinkAssert.GaugeEquals(maxPermitMetricName, 658)
+
+	pool.Acquire()
+	sinkAssert.GaugeEquals(permitsUsedMetricName, 2)
+	sinkAssert.GaugeEquals(maxPermitMetricName, 658)
+
+	pool.Release()
+	sinkAssert.GaugeEquals(permitsUsedMetricName, 1)
+	sinkAssert.GaugeEquals(maxPermitMetricName, 658)
+
+	pool.Acquire()
+	sinkAssert.GaugeEquals(permitsUsedMetricName, 2)
+	sinkAssert.GaugeEquals(maxPermitMetricName, 658)
+
+	pool.Release()
+	sinkAssert.GaugeEquals(permitsUsedMetricName, 1)
+	sinkAssert.GaugeEquals(maxPermitMetricName, 658)
+
+	pool.Release()
+	sinkAssert.GaugeEquals(permitsUsedMetricName, 0)
+	sinkAssert.GaugeEquals(maxPermitMetricName, 658)
+}
+
+type sinkAssert struct {
+	t    *testing.T
+	sink *metrics.InmemSink
+}
+
+func newSinkAssert(t *testing.T, sink *metrics.InmemSink) *sinkAssert {
+	return &sinkAssert{
+		t:    t,
+		sink: sink,
+	}
+}
+
+func (st *sinkAssert) GaugeEquals(gaugeName string, expected interface{}) {
+	data := st.sink.Data()
+	require.Equal(st.t, 1, len(data), "expected 1 and only 1 interval, found %v intervals", len(data))
+
+	interval := data[0]
+	gauge, err := readGaugeFromInterval(interval, gaugeName)
+	assert.NoError(st.t, err, "could not find gauge named %q", gaugeName)
+	assert.InDelta(st.t, expected, gauge.Value, 0.0001, "gauge %q should be %v but was %v", gaugeName, expected, gauge.Value)
+}
+
+func readGaugeFromInterval(metric *metrics.IntervalMetrics, name string) (metrics.GaugeValue, error) {
+	metric.RLock()
+	defer metric.RUnlock()
+	gaugesFound := []string{}
+	for k, gauge := range metric.Gauges {
+		if k == name {
+			return gauge, nil
+		}
+		gaugesFound = append(gaugesFound, k)
+	}
+	return metrics.GaugeValue{}, fmt.Errorf("no gauge named %s found (current gauges were %+v)", name, gaugesFound)
+}

--- a/physical/alicloudoss/alicloudoss.go
+++ b/physical/alicloudoss/alicloudoss.go
@@ -16,6 +16,7 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/physical"
 )
 
@@ -37,7 +38,7 @@ type AliCloudOSSBackend struct {
 	bucket     string
 	client     *oss.Client
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 }
 
 // NewAliCloudOSSBackend constructs an OSS backend using a pre-existing
@@ -111,7 +112,7 @@ func NewAliCloudOSSBackend(conf map[string]string, logger log.Logger) (physical.
 		client:     client,
 		bucket:     bucket,
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permits.NewInstrumentedPermitPool(maxParInt, AlibabaMetricKey),
 	}
 	return a, nil
 }

--- a/physical/azure/azure.go
+++ b/physical/azure/azure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/vault/helper/permits"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -34,7 +35,7 @@ const (
 type AzureBackend struct {
 	container  *azblob.ContainerURL
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 }
 
 // Verify AzureBackend satisfies the correct interfaces
@@ -181,7 +182,7 @@ func NewAzureBackend(conf map[string]string, logger log.Logger) (physical.Backen
 	a := &AzureBackend{
 		container:  &containerURL,
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permits.NewInstrumentedPermitPool(maxParInt, "azure"),
 	}
 	return a, nil
 }

--- a/physical/cockroachdb/cockroachdb.go
+++ b/physical/cockroachdb/cockroachdb.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"github.com/hashicorp/vault/sdk/physical"
 
@@ -40,7 +41,7 @@ type CockroachDBBackend struct {
 	rawStatements map[string]string
 	statements    map[string]*sql.Stmt
 	logger        log.Logger
-	permitPool    *physical.PermitPool
+	permitPool    *permits.InstrumentedPermitPool
 }
 
 // NewCockroachDBBackend constructs a CockroachDB backend using the given
@@ -101,7 +102,7 @@ func NewCockroachDBBackend(conf map[string]string, logger log.Logger) (physical.
 		},
 		statements: make(map[string]*sql.Stmt),
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permits.NewInstrumentedPermitPool(maxParInt, "cockroachdb"),
 	}
 
 	// Prepare all the statements required

--- a/physical/consul/consul.go
+++ b/physical/consul/consul.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
 	"github.com/hashicorp/vault/sdk/helper/tlsutil"
@@ -44,7 +45,7 @@ type ConsulBackend struct {
 	client          *api.Client
 	path            string
 	kv              *api.KV
-	permitPool      *physical.PermitPool
+	permitPool      *permits.InstrumentedPermitPool
 	consistencyMode string
 
 	sessionTTL   string
@@ -184,7 +185,7 @@ func NewConsulBackend(conf map[string]string, logger log.Logger) (physical.Backe
 		path:            path,
 		client:          client,
 		kv:              client.KV(),
-		permitPool:      physical.NewPermitPool(maxParInt),
+		permitPool:      permits.NewInstrumentedPermitPool(maxParInt, "consul"),
 		consistencyMode: consistencyMode,
 
 		sessionTTL:   sessionTTL,

--- a/physical/couchdb/couchdb.go
+++ b/physical/couchdb/couchdb.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/physical"
 )
 
@@ -24,7 +25,7 @@ import (
 type CouchDBBackend struct {
 	logger     log.Logger
 	client     *couchDBClient
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 }
 
 // Verify CouchDBBackend satisfies the correct interfaces
@@ -192,7 +193,7 @@ func buildCouchDBBackend(conf map[string]string, logger log.Logger) (*CouchDBBac
 			Client:   cleanhttp.DefaultPooledClient(),
 		},
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permits.NewInstrumentedPermitPool(maxParInt, "couchdb"),
 	}, nil
 }
 
@@ -272,7 +273,7 @@ func NewTransactionalCouchDBBackend(conf map[string]string, logger log.Logger) (
 	if err != nil {
 		return nil, err
 	}
-	backend.permitPool = physical.NewPermitPool(1)
+	backend.permitPool = permits.NewInstrumentedPermitPool(1, "couchdb", "transcational")
 
 	return &TransactionalCouchDBBackend{
 		CouchDBBackend: *backend,

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/helper/awsutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/physical"
@@ -82,7 +83,7 @@ type DynamoDBBackend struct {
 	client     *dynamodb.DynamoDB
 	logger     log.Logger
 	haEnabled  bool
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 }
 
 // DynamoDBRecord is the representation of a vault entry in
@@ -238,7 +239,7 @@ func NewDynamoDBBackend(conf map[string]string, logger log.Logger) (physical.Bac
 	return &DynamoDBBackend{
 		table:      table,
 		client:     client,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permits.NewInstrumentedPermitPool(maxParInt, "dynamodb"),
 		haEnabled:  haEnabledBool,
 		logger:     logger,
 	}, nil

--- a/physical/etcd/etcd2.go
+++ b/physical/etcd/etcd2.go
@@ -14,6 +14,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/physical"
 	"go.etcd.io/etcd/client"
 	"go.etcd.io/etcd/pkg/transport"
@@ -51,7 +52,7 @@ const (
 type Etcd2Backend struct {
 	path       string
 	kAPI       client.KeysAPI
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 	logger     log.Logger
 	haEnabled  bool
 }
@@ -117,7 +118,7 @@ func newEtcd2Backend(conf map[string]string, logger log.Logger) (physical.Backen
 	return &Etcd2Backend{
 		path:       path,
 		kAPI:       kAPI,
-		permitPool: physical.NewPermitPool(physical.DefaultParallelOperations),
+		permitPool: permits.NewInstrumentedPermitPool(physical.DefaultParallelOperations, "etcd"),
 		logger:     logger,
 		haEnabled:  haEnabledBool,
 	}, nil

--- a/physical/etcd/etcd3.go
+++ b/physical/etcd/etcd3.go
@@ -14,6 +14,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"github.com/hashicorp/vault/sdk/physical"
@@ -32,7 +33,7 @@ type EtcdBackend struct {
 	lockTimeout    time.Duration
 	requestTimeout time.Duration
 
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 
 	etcd *clientv3.Client
 }
@@ -165,7 +166,7 @@ func newEtcd3Backend(conf map[string]string, logger log.Logger) (physical.Backen
 	return &EtcdBackend{
 		path:           path,
 		etcd:           etcd,
-		permitPool:     physical.NewPermitPool(physical.DefaultParallelOperations),
+		permitPool:     permits.NewInstrumentedPermitPool(physical.DefaultParallelOperations, "etcd"),
 		logger:         logger,
 		haEnabled:      haEnabledBool,
 		lockTimeout:    lock,

--- a/physical/gcs/gcs.go
+++ b/physical/gcs/gcs.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/vault/helper/permits"
 	"io/ioutil"
 	"os"
 	"sort"
@@ -74,7 +75,7 @@ type Backend struct {
 	// client is the API client and permitPool is the allowed concurrent uses of
 	// the client.
 	client     *storage.Client
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 
 	// haEnabled indicates if HA is enabled.
 	haEnabled bool
@@ -170,7 +171,7 @@ func NewBackend(c map[string]string, logger log.Logger) (physical.Backend, error
 		bucket:     bucket,
 		chunkSize:  chunkSize,
 		client:     client,
-		permitPool: physical.NewPermitPool(maxParallel),
+		permitPool: permits.NewInstrumentedPermitPool(maxParallel, "gcs"),
 
 		haEnabled: haEnabled,
 		haClient:  haClient,

--- a/physical/manta/manta.go
+++ b/physical/manta/manta.go
@@ -15,6 +15,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/physical"
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/authentication"
@@ -26,7 +27,7 @@ const mantaDefaultRootStore = "/stor"
 
 type MantaBackend struct {
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 	client     *storage.StorageClient
 	directory  string
 }
@@ -93,7 +94,7 @@ func NewMantaBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		client:     client,
 		directory:  conf["directory"],
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permits.NewInstrumentedPermitPool(maxParInt, "manta"),
 	}, nil
 }
 

--- a/physical/manta/manta_test.go
+++ b/physical/manta/manta_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/vault/helper/permits"
+
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/physical"
@@ -54,7 +56,7 @@ func TestMantaBackend(t *testing.T) {
 		client:     client,
 		directory:  testHarnessBucket,
 		logger:     logger.Named("storage.mantabackend"),
-		permitPool: physical.NewPermitPool(128),
+		permitPool: permits.NewInstrumentedPermitPool(128, "manta"),
 	}
 
 	err = mb.client.Dir().Put(context.Background(), &storage.PutDirectoryInput{

--- a/physical/mssql/mssql.go
+++ b/physical/mssql/mssql.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"github.com/hashicorp/vault/sdk/physical"
 )
@@ -25,7 +26,7 @@ type MSSQLBackend struct {
 	client     *sql.DB
 	statements map[string]*sql.Stmt
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 }
 
 func NewMSSQLBackend(conf map[string]string, logger log.Logger) (physical.Backend, error) {
@@ -147,7 +148,7 @@ func NewMSSQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		client:     db,
 		statements: make(map[string]*sql.Stmt),
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permits.NewInstrumentedPermitPool(maxParInt, "mssql"),
 	}
 
 	statements := map[string]string{

--- a/physical/mysql/mysql.go
+++ b/physical/mysql/mysql.go
@@ -17,6 +17,8 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/hashicorp/vault/helper/permits"
+
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 
@@ -44,7 +46,7 @@ type MySQLBackend struct {
 	client       *sql.DB
 	statements   map[string]*sql.Stmt
 	logger       log.Logger
-	permitPool   *physical.PermitPool
+	permitPool   *permits.InstrumentedPermitPool
 	conf         map[string]string
 	redirectHost string
 	redirectPort int64
@@ -172,7 +174,7 @@ func NewMySQLBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		client:      db,
 		statements:  make(map[string]*sql.Stmt),
 		logger:      logger,
-		permitPool:  physical.NewPermitPool(maxParInt),
+		permitPool:  permits.NewInstrumentedPermitPool(maxParInt, "mysql"),
 		conf:        conf,
 		haEnabled:   haEnabled,
 	}

--- a/physical/oci/oci.go
+++ b/physical/oci/oci.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/vault/helper/permits"
 	"io/ioutil"
 	"net/http"
 	"sort"
@@ -65,7 +66,7 @@ type Backend struct {
 	client         *objectstorage.ObjectStorageClient
 	bucketName     string
 	logger         log.Logger
-	permitPool     *physical.PermitPool
+	permitPool     *permits.InstrumentedPermitPool
 	namespaceName  string
 	haEnabled      bool
 	lockBucketName string
@@ -142,7 +143,7 @@ func NewBackend(conf map[string]string, logger log.Logger) (physical.Backend, er
 		client:         &objectStorageClient,
 		bucketName:     bucketName,
 		logger:         logger,
-		permitPool:     physical.NewPermitPool(MaxNumberOfPermits),
+		permitPool:     permits.NewInstrumentedPermitPool(MaxNumberOfPermits, "oci"),
 		namespaceName:  namespaceName,
 		haEnabled:      haEnabled,
 		lockBucketName: lockBucketName,

--- a/physical/postgresql/postgresql.go
+++ b/physical/postgresql/postgresql.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/physical"
 
 	log "github.com/hashicorp/go-hclog"
@@ -63,7 +64,7 @@ type PostgreSQLBackend struct {
 
 	haEnabled  bool
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 }
 
 // PostgreSQLLock implements a lock using an PostgreSQL client.
@@ -191,7 +192,7 @@ func NewPostgreSQLBackend(conf map[string]string, logger log.Logger) (physical.B
 		// $1=ha_identity $2=ha_key
 		" DELETE FROM " + quoted_ha_table + " WHERE ha_identity=$1 AND ha_key=$2 ",
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permits.NewInstrumentedPermitPool(maxParInt, "postgres"),
 		haEnabled:  conf["ha_enabled"] == "true",
 	}
 

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/raft"
 	snapshot "github.com/hashicorp/raft-snapshot"
+	"github.com/hashicorp/vault/helper/permits"
 	raftboltdb "github.com/hashicorp/vault/physical/raft/logstore"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -114,7 +115,7 @@ type RaftBackend struct {
 	serverAddressProvider raft.ServerAddressProvider
 
 	// permitPool is used to limit the number of concurrent storage calls.
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 
 	// maxEntrySize imposes a size limit (in bytes) on a raft entry (put or transaction).
 	// It is suggested to use a value of 2x the Raft chunking size for optimal
@@ -374,7 +375,7 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 		snapStore:    snap,
 		dataDir:      path,
 		localID:      localID,
-		permitPool:   physical.NewPermitPool(physical.DefaultParallelOperations),
+		permitPool:   permits.NewInstrumentedPermitPool(physical.DefaultParallelOperations, "raft-storage"),
 		maxEntrySize: maxEntrySize,
 	}, nil
 }

--- a/physical/s3/s3.go
+++ b/physical/s3/s3.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/hashicorp/vault/helper/permits"
 	"io"
 	"net/http"
 	"os"
@@ -38,7 +39,7 @@ type S3Backend struct {
 	kmsKeyId   string
 	client     *s3.S3
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 }
 
 // NewS3Backend constructs a S3 backend using a pre-existing
@@ -155,7 +156,7 @@ func NewS3Backend(conf map[string]string, logger log.Logger) (physical.Backend, 
 		path:       path,
 		kmsKeyId:   kmsKeyId,
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permits.NewInstrumentedPermitPool(maxParInt, "s3"),
 	}
 	return s, nil
 }

--- a/physical/swift/swift.go
+++ b/physical/swift/swift.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/hashicorp/go-hclog"
-
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/helper/permits"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/ncw/swift"
@@ -28,7 +28,7 @@ type SwiftBackend struct {
 	container  string
 	client     *swift.Connection
 	logger     log.Logger
-	permitPool *physical.PermitPool
+	permitPool *permits.InstrumentedPermitPool
 }
 
 // NewSwiftBackend constructs a Swift backend using a pre-existing
@@ -147,7 +147,7 @@ func NewSwiftBackend(conf map[string]string, logger log.Logger) (physical.Backen
 		client:     &c,
 		container:  container,
 		logger:     logger,
-		permitPool: physical.NewPermitPool(maxParInt),
+		permitPool: permits.NewInstrumentedPermitPool(maxParInt, "swift"),
 	}
 	return s, nil
 }


### PR DESCRIPTION
We've run into cases where we believe that our Vault clusters are saturating the permit pool for our backend, leading to connection queueing and client timeouts. 

Currently, we cannot directly verify this using metrics and have to infer it based on behavior. Additionally, when testing an increase to the concurrent connection permits for our backend it is harder to directly verify that the increased permit limit is being consumed as expected. Having insight at runtime into each permit pool's limit and current consumption will help us better understand what limits we are hitting within Vault as we operate it in our production environments.

This PR adds a package (`helper/permits`) that includes a metrics instrumented wrapper of the SDK's `PermitPool` type (`InstrumentedPermitPool`).

Each instance of the instrumented pool adds 2 metric gauges:
- `$prefix.permits`: number of permits currently being consumed
- `$prefix.permits-limit`: the permit pools maximum permit limit

If the permit pool size were not configurable in many places, I would've opted for a single "free permits" gauge that counts down to 0 as permits are used rather than the 2 gauges included. But being able to see the current max size line on a graph and being able to calculate the percentage of permits currently in use is valuable if permit maximum can change over time. 

I've instrumented the lease revocation/expiration pool and all storage backends that currently use the PermitPool in some form.

One storage backend ([the oci backend](https://github.com/hashicorp/vault/blob/master/physical/oci/oci.go#L156)) already included some similar metrics. The new implementation does not clobber or otherwise disrupt those metrics, and instead adds the new metrics to that backend as well, so that current users of the existing metrics are not impacted, but the backend has the standard named metrics for permit usage going forward as well.

I created `helper/permits` as a separate package to avoid requiring this server side metrics implementation to show up in the SDK `physical` package, if there is a better way to do I am happy to change things.

Let me know if there's any other information I can provide, or if you'd like to take a different approach to adding visibility to the semaphore/permit pools used within Vault