### PR TITLE
Add base64 function to string template library

### DIFF
--- a/sdk/helper/template/funcs.go
+++ b/sdk/helper/template/funcs.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
@@ -53,6 +54,10 @@ func truncateSHA256(maxLen int, str string) (string, error) {
 
 func hashSHA256(str string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(str)))
+}
+
+func encodeBase64(str string) string {
+	return base64.StdEncoding.EncodeToString([]byte(str))
 }
 
 func uppercase(str string) string {

--- a/sdk/helper/template/template.go
+++ b/sdk/helper/template/template.go
@@ -59,6 +59,9 @@ func Function(name string, f interface{}) Opt {
 // - sha256
 //   - SHA256 hashes the previous value.
 //     Example: {{ .DisplayName | sha256 }}
+// - base64
+//   - base64 encodes the previous value.
+//     Example: {{ .DisplayName | base64 }}
 // - unix_time
 //   - Provides the current unix time in seconds.
 //     Example: {{ unix_time }}
@@ -89,6 +92,7 @@ func NewTemplate(opts ...Opt) (up StringTemplate, err error) {
 			"lowercase":       lowercase,
 			"replace":         replace,
 			"sha256":          hashSHA256,
+			"base64":          encodeBase64,
 
 			"unix_time":        unixTime,
 			"unix_time_millis": unixTimeMillis,

--- a/sdk/helper/template/template_test.go
+++ b/sdk/helper/template/template_test.go
@@ -46,6 +46,7 @@ func TestGenerate(t *testing.T) {
 {{.String | lowercase}}
 {{.String | replace " " "."}}
 {{.String | sha256}}
+{{.String | base64}}
 {{.String | truncate_sha256 20}}`,
 			data: struct {
 				String string
@@ -57,6 +58,7 @@ SOME STRING WITH MULTIPLE CAPITALS LETTERS
 some string with multiple capitals letters
 Some.string.with.Multiple.Capitals.LETTERS
 da9872dd96609c72897defa11fe81017a62c3f44339d9d3b43fe37540ede3601
+U29tZSBzdHJpbmcgd2l0aCBNdWx0aXBsZSBDYXBpdGFscyBMRVRURVJT
 Some string 6841cf80`,
 			expectErr: false,
 		},


### PR DESCRIPTION
Adds `base64` function to string template library. This function base64 encodes the provided string similar to the existing `sha256` function.