### PR TITLE
storage/raft: Fix panic when no Join TLS is being used

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -230,7 +230,9 @@ func parseTLSInfo(leaderInfo *LeaderJoinInfo) (*tls.Config, error) {
 			return nil, err
 		}
 	}
-	tlsConfig.ServerName = leaderInfo.LeaderTLSServerName
+	if tlsConfig != nil {
+		tlsConfig.ServerName = leaderInfo.LeaderTLSServerName
+	}
 
 	return tlsConfig, nil
 }


### PR DESCRIPTION
Fixes panic introduced by #10698 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0x38f1caf]

goroutine 1 [running]:
github.com/hashicorp/vault/physical/raft.parseTLSInfo(0xc0002e3080, 0x59, 0x60, 0x4e948e0)
	/Users/brian/Code/vault/physical/raft/raft.go:233 +0xaf
github.com/hashicorp/vault/physical/raft.(*RaftBackend).JoinConfig(0xc0002d41c0, 0xc000021e00, 0xc00113b080, 0x15, 0x14, 0x15)
	/Users/brian/Code/vault/physical/raft/raft.go:208 +0x1c6
github.com/hashicorp/vault/vault.(*Core).InitiateRetryJoin(0xc000ebc000, 0x6688f20, 0xc000076098, 0xc000142000, 0x2)
	/Users/brian/Code/vault/vault/raft.go:694 +0x9e
github.com/hashicorp/vault/command.(*ServerCommand).Run(0xc000142000, 0xc00006e0c0, 0x3, 0x3, 0x0)
	/Users/brian/Code/vault/command/server.go:1609 +0x62be
github.com/mitchellh/cli.(*CLI).Run(0xc000edf040, 0xc000edf040, 0xc0005b0aa0, 0xc0005b09a0)
	/Users/brian/Code/go/pkg/mod/github.com/mitchellh/cli@v1.1.1/cli.go:261 +0x1cf
github.com/hashicorp/vault/command.RunCustom(0xc00006e0b0, 0x4, 0x4, 0xc000121770, 0xc00007a0b8)
	/Users/brian/Code/vault/command/main.go:180 +0x86f
github.com/hashicorp/vault/command.Run(...)
	/Users/brian/Code/vault/command/main.go:88
main.main()
	/Users/brian/Code/vault/main.go:10 +0x71
```