### PR TITLE
`vault operator diagnose` stub command

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -686,6 +686,15 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 			}, nil
 		},
 	}
+
+	// Disabled by default until functional
+	if os.Getenv(OperatorDiagnoseEnableEnv) != "" {
+		Commands["operator diagnose"] = func() (cli.Command, error) {
+			return &OperatorDiagnoseCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		}
+	}
 }
 
 // MakeShutdownCh returns a channel that can be used for shutdown

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -1,0 +1,98 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+const OperatorDiagnoseEnableEnv = "VAULT_DIAGNOSE"
+
+var _ cli.Command = (*OperatorDiagnoseCommand)(nil)
+var _ cli.CommandAutocomplete = (*OperatorDiagnoseCommand)(nil)
+
+type OperatorDiagnoseCommand struct {
+	*BaseCommand
+
+	flagDebug   bool
+	flagSkips   []string
+	flagConfigs []string
+}
+
+func (c *OperatorDiagnoseCommand) Synopsis() string {
+	return "Troubleshoot problems starting Vault"
+}
+
+func (c *OperatorDiagnoseCommand) Help() string {
+	helpText := `
+Usage: vault operator diagnose 
+
+  This command troubleshoots Vault startup issues, such as TLS configuration or
+  auto-unseal. It should be run using the same environment variables and configuration
+  files as the "vault server" command, so that startup problems can be accurately
+  reproduced.
+
+  Start diagnose with a configuration file:
+    
+     $ vault operator diagnose -config=/etc/vault/config.hcl
+
+  Perform a diagnostic check while Vault is still running:
+
+     $ vault operator diagnose -config=/etc/vault/config.hcl -skip=listener
+
+` + c.Flags().Help()
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorDiagnoseCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetNone)
+	f := set.NewFlagSet("Command Options")
+
+	f.StringSliceVar(&StringSliceVar{
+		Name:   "config",
+		Target: &c.flagConfigs,
+		Completion: complete.PredictOr(
+			complete.PredictFiles("*.hcl"),
+			complete.PredictFiles("*.json"),
+			complete.PredictDirs("*"),
+		),
+		Usage: "Path to a Vault configuration file or directory of configuration " +
+			"files. This flag can be specified multiple times to load multiple " +
+			"configurations. If the path is a directory, all files which end in " +
+			".hcl or .json are loaded.",
+	})
+
+	f.StringSliceVar(&StringSliceVar{
+		Name:   "skip",
+		Target: &c.flagSkips,
+		Usage:  "Skip the health checks named as arguments. May be 'listener', 'storage', or 'autounseal'.",
+	})
+
+	f.BoolVar(&BoolVar{
+		Name:    "debug",
+		Target:  &c.flagDebug,
+		Default: false,
+		Usage:   "Dump all information collected by Diagnose.",
+	})
+	return set
+}
+
+func (c *OperatorDiagnoseCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *OperatorDiagnoseCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *OperatorDiagnoseCommand) Run(args []string) int {
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.UI.Output("No implementation yet.")
+	return 0
+}

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -100,7 +100,10 @@ func (c *OperatorDiagnoseCommand) Run(args []string) int {
 		c.UI.Error(err.Error())
 		return 1
 	}
+	return c.RunWithParsedFlags()
+}
 
+func (c *OperatorDiagnoseCommand) RunWithParsedFlags() int {
 	if len(c.flagConfigs) == 0 {
 		c.UI.Error("Must specify a configuration file using -config.")
 		return 1

--- a/command/server.go
+++ b/command/server.go
@@ -128,6 +128,7 @@ type ServerCommand struct {
 	flagTestServerConfig   bool
 	flagDevConsul          bool
 	flagExitOnCoreShutdown bool
+	flagDiagnose           string
 }
 
 func (c *ServerCommand) Synopsis() string {
@@ -211,6 +212,16 @@ func (c *ServerCommand) Flags() *FlagSets {
 		Usage: "Enable recovery mode. In this mode, Vault is used to perform recovery actions." +
 			"Using a recovery operation token, \"sys/raw\" API can be used to manipulate the storage.",
 	})
+
+	// Disabled by default until functional
+	if os.Getenv(OperatorDiagnoseEnableEnv) != "" {
+		f.StringVar(&StringVar{
+			Name:    "diagnose",
+			Target:  &c.flagDiagnose,
+			Default: notSetValue,
+			Usage:   "Run diagnostics before starting Vault. Specify a filename to direct output to that file.",
+		})
+	}
 
 	f = set.NewFlagSet("Dev Options")
 
@@ -886,6 +897,21 @@ func (c *ServerCommand) Run(args []string) int {
 					"Your request has been ignored."))
 			c.flagDevRootTokenID = ""
 		}
+	}
+
+	if c.flagDiagnose != notSetValue {
+		if c.flagDev {
+			c.UI.Error("Cannot run diagnose on Vault in dev mode.")
+			return 1
+		}
+		// TODO: add a file output flag to Diagnose
+		diagnose := &OperatorDiagnoseCommand{
+			BaseCommand: c.BaseCommand,
+			flagDebug:   false,
+			flagSkips:   []string{},
+			flagConfigs: c.flagConfigs,
+		}
+		diagnose.RunWithParsedFlags()
 	}
 
 	// Load the configuration

--- a/command/server.go
+++ b/command/server.go
@@ -100,6 +100,8 @@ type ServerCommand struct {
 	startedCh       chan (struct{}) // for tests
 	reloadedCh      chan (struct{}) // for tests
 
+	allLoggers []log.Logger
+
 	// new stuff
 	flagConfigs            []string
 	flagLogLevel           string
@@ -812,6 +814,49 @@ func (q quiescenceSink) Accept(name string, level log.Level, msg string, args ..
 	q.t.Reset(100 * time.Millisecond)
 }
 
+func (c *ServerCommand) setupStorage(config *server.Config) (physical.Backend, error) {
+	// Ensure that a backend is provided
+	if config.Storage == nil {
+		return nil, fmt.Errorf("A storage backend must be specified")
+	}
+
+	// Initialize the backend
+	factory, exists := c.PhysicalBackends[config.Storage.Type]
+	if !exists {
+		return nil, fmt.Errorf("Unknown storage type %s", config.Storage.Type)
+	}
+
+	// Do any custom configuration needed per backend
+	switch config.Storage.Type {
+	case storageTypeConsul:
+		if config.ServiceRegistration == nil {
+			// If Consul is configured for storage and service registration is unconfigured,
+			// use Consul for service registration without requiring additional configuration.
+			// This maintains backward-compatibility.
+			config.ServiceRegistration = &server.ServiceRegistration{
+				Type:   "consul",
+				Config: config.Storage.Config,
+			}
+		}
+	case storageTypeRaft:
+		if envCA := os.Getenv("VAULT_CLUSTER_ADDR"); envCA != "" {
+			config.ClusterAddr = envCA
+		}
+		if len(config.ClusterAddr) == 0 {
+			return nil, fmt.Errorf("Cluster address must be set when using raft storage")
+		}
+	}
+
+	namedStorageLogger := c.logger.Named("storage." + config.Storage.Type)
+	c.allLoggers = append(c.allLoggers, namedStorageLogger)
+	backend, err := factory(config.Storage.Config, namedStorageLogger)
+	if err != nil {
+		return nil, fmt.Errorf("Error initializing storage of type %s: %w", config.Storage.Type, err)
+	}
+
+	return backend, nil
+}
+
 func (c *ServerCommand) Run(args []string) int {
 	f := c.Flags()
 
@@ -918,7 +963,7 @@ func (c *ServerCommand) Run(args []string) int {
 	// Ensure logging is flushed if initialization fails
 	defer c.flushLog()
 
-	allLoggers := []log.Logger{c.logger}
+	c.allLoggers = []log.Logger{c.logger}
 
 	logLevelStr, err := c.adjustLogLevel(config, logLevelWasNotSet)
 	if err != nil {
@@ -931,7 +976,7 @@ func (c *ServerCommand) Run(args []string) int {
 
 	// create GRPC logger
 	namedGRPCLogFaker := c.logger.Named("grpclogfaker")
-	allLoggers = append(allLoggers, namedGRPCLogFaker)
+	c.allLoggers = append(c.allLoggers, namedGRPCLogFaker)
 	grpclog.SetLogger(&grpclogFaker{
 		logger: namedGRPCLogFaker,
 		log:    os.Getenv("VAULT_GRPC_LOGGING") != "",
@@ -939,12 +984,6 @@ func (c *ServerCommand) Run(args []string) int {
 
 	if memProfilerEnabled {
 		c.startMemProfiler()
-	}
-
-	// Ensure that a backend is provided
-	if config.Storage == nil {
-		c.UI.Output("A storage backend must be specified")
-		return 1
 	}
 
 	if config.DefaultMaxRequestDuration != 0 {
@@ -988,44 +1027,15 @@ func (c *ServerCommand) Run(args []string) int {
 	}
 	metricsHelper := metricsutil.NewMetricsHelper(inmemMetrics, prometheusEnabled)
 
-	// Initialize the backend
-	factory, exists := c.PhysicalBackends[config.Storage.Type]
-	if !exists {
-		c.UI.Error(fmt.Sprintf("Unknown storage type %s", config.Storage.Type))
-		return 1
-	}
-
-	// Do any custom configuration needed per backend
-	switch config.Storage.Type {
-	case storageTypeConsul:
-		if config.ServiceRegistration == nil {
-			// If Consul is configured for storage and service registration is unconfigured,
-			// use Consul for service registration without requiring additional configuration.
-			// This maintains backward-compatibility.
-			config.ServiceRegistration = &server.ServiceRegistration{
-				Type:   "consul",
-				Config: config.Storage.Config,
-			}
-		}
-	case storageTypeRaft:
-		if envCA := os.Getenv("VAULT_CLUSTER_ADDR"); envCA != "" {
-			config.ClusterAddr = envCA
-		}
-		if len(config.ClusterAddr) == 0 {
-			c.UI.Error("Cluster address must be set when using raft storage")
-			return 1
-		}
-	}
-
-	namedStorageLogger := c.logger.Named("storage." + config.Storage.Type)
-	allLoggers = append(allLoggers, namedStorageLogger)
-	backend, err := factory(config.Storage.Config, namedStorageLogger)
+	// Initialize the storage backend
+	backend, err := c.setupStorage(config)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error initializing storage of type %s: %s", config.Storage.Type, err))
+		c.UI.Error(err.Error())
 		return 1
 	}
 
 	// Prevent server startup if migration is active
+	// TODO: how to incorporate this check into Diagnose?
 	if c.storageMigrationActive(backend) {
 		return 1
 	}
@@ -1040,7 +1050,7 @@ func (c *ServerCommand) Run(args []string) int {
 		}
 
 		namedSDLogger := c.logger.Named("service_registration." + config.ServiceRegistration.Type)
-		allLoggers = append(allLoggers, namedSDLogger)
+		c.allLoggers = append(c.allLoggers, namedSDLogger)
 
 		// Since we haven't even begun starting Vault's core yet,
 		// we know that Vault is in its pre-running state.
@@ -1094,7 +1104,7 @@ func (c *ServerCommand) Run(args []string) int {
 
 			var seal vault.Seal
 			sealLogger := c.logger.ResetNamed(fmt.Sprintf("seal.%s", sealType))
-			allLoggers = append(allLoggers, sealLogger)
+			c.allLoggers = append(c.allLoggers, sealLogger)
 			defaultSeal := vault.NewDefaultSeal(&vaultseal.Access{
 				Wrapper: aeadwrapper.NewShamirWrapper(&wrapping.WrapperOptions{
 					Logger: c.logger.Named("shamir"),
@@ -1180,7 +1190,7 @@ func (c *ServerCommand) Run(args []string) int {
 		DisableSealWrap:           config.DisableSealWrap,
 		DisablePerformanceStandby: config.DisablePerformanceStandby,
 		DisableIndexing:           config.DisableIndexing,
-		AllLoggers:                allLoggers,
+		AllLoggers:                c.allLoggers,
 		BuiltinRegistry:           builtinplugins.Registry,
 		DisableKeyEncodingChecks:  config.DisablePrintableCheck,
 		MetricsHelper:             metricsHelper,
@@ -1237,7 +1247,7 @@ func (c *ServerCommand) Run(args []string) int {
 		}
 
 		namedHALogger := c.logger.Named("ha." + config.HAStorage.Type)
-		allLoggers = append(allLoggers, namedHALogger)
+		c.allLoggers = append(c.allLoggers, namedHALogger)
 		habackend, err := factory(config.HAStorage.Config, namedHALogger)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf(

--- a/command/server.go
+++ b/command/server.go
@@ -221,6 +221,9 @@ func (c *ServerCommand) Flags() *FlagSets {
 			Default: notSetValue,
 			Usage:   "Run diagnostics before starting Vault. Specify a filename to direct output to that file.",
 		})
+	} else {
+		// Ensure diagnose is *not* run when feature flag is off.
+		c.flagDiagnose = notSetValue
 	}
 
 	f = set.NewFlagSet("Dev Options")


### PR DESCRIPTION
This adds the new command to the CLI, and a flag to `vault server`.
It performs some light refactoring to allow us to see the storage setup status, but startup is not completely covered yet (nor meant to be.)

As part of Vault Server:
```
mgritter@ubuntu:~/vault$ VAULT_DIAGNOSE=1 bin/vault server -diagnose= -config=../vault-enterprise/diagnose-proto/test-config.hcl
Vault v1.6.0-dev ('cbbc0d815b131c97da59692a4cb0289f075d23e2+CHANGES')
[  ok  ] Parse configuration
[  ok  ] Access storage
Error parsing Seal configuration: Put "https://test-vault.example.com:8300/v1/transit/encrypt/autounseal": dial tcp 127.0.0.1:8300: connect: connection refused
2021-02-01T15:21:07.168-0800 [INFO]  proxy environment: http_proxy= https_proxy= no_proxy=
2021-02-01T15:21:10.951-0800 [INFO]  seal.transit: unable to renew token, disabling renewal: err="Put "https://test-vault.example.com:8300/v1/auth/token/renew-self": dial tcp 127.0.0.1:8300: connect: connection refused"
```

As standalone command:
```
mgritter@ubuntu:~/vault$ VAULT_DIAGNOSE=1 bin/vault operator diagnose -config bad-config.hcl
Vault v1.6.0-dev ('cbbc0d815b131c97da59692a4cb0289f075d23e2+CHANGES')
[  ok  ] Parse configuration
[failed] Access storage
Error initializing storage of type raft: failed to create fsm: failed to open bolt file: open /var/doesnotexist/raft/vault.db: no such file or directory
```
