### PR TITLE
Add documentation for upcoming Terraform Cloud secret engine

### DIFF
--- a/website/content/api-docs/secret/terraform.mdx
+++ b/website/content/api-docs/secret/terraform.mdx
@@ -248,7 +248,8 @@ $ curl \
 ## Rotate Role
 
 This endpoint rotates the credentials for a Terraform Cloud role that manages an
-Organization or Team. 
+Organization or Team. This endpoint is only valid for those roles; attempting to
+rotate a role that manages user tokens will result in an error.
 
 
 | Method   | Path                |

--- a/website/content/api-docs/secret/terraform.mdx
+++ b/website/content/api-docs/secret/terraform.mdx
@@ -1,0 +1,310 @@
+---
+layout: api
+page_title: Terraform Cloud Secret Backend - HTTP API
+sidebar_title: Terraform Cloud
+description: This is the API documentation for the Vault Terraform Cloud secret backend.
+---
+
+# Terraform Cloud Secret Backend HTTP API
+
+This is the API documentation for the Vault Terraform Cloud secret backend. For general
+information about the usage and operation of the Terraform Cloud backend, please see the
+[Vault Terraform Cloud backend documentation](/docs/secrets/terraform).
+
+This documentation assumes the Terraform Cloud backend is mounted at the `/terraform` path
+in Vault. Since it is possible to mount secret backends at any location, please
+update your API calls accordingly.
+
+## Configure Access
+
+This endpoint configures the access information for Terraform Cloud. This access
+information is used so that Vault can communicate with Terraform Cloud and generate
+Terraform Cloud tokens.
+
+| Method | Path                   |
+| :----- | :--------------------- |
+| `POST` | `/terraform/config` |
+
+### Parameters
+
+- `address` `(string: "")` – Specifies the address of the Terraform Cloud
+  server, if using Terraform Enterprise, provided as `"protocol://host:port"`.
+  The default is `https://app.terraform.io` for Terraform Cloud.
+
+- `token` `(string: "")` – Specifies the Terraform Cloud authentication token to
+  use. This token must have the needed permissions to manage all Organization,
+  Team, and User tokens desired for this mount.
+
+
+### Sample Payload
+
+```json
+{
+  "address": "https://app.terraform.io",
+  "token": "glhf..."
+}
+```
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request POST \
+    --header "X-Vault-Token: ..." \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/terraform/config
+```
+
+## Read Access Configuration
+
+This endpoint queries for information about the Terraform Cloud connection.
+
+| Method | Path                   |
+| :----- | :--------------------- |
+| `GET`  | `/terraform/config` |
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/terraform/config
+```
+
+### Sample Response
+
+```json
+  "data": {
+    "address": "https://app.terraform.io",
+    "base_path": "/api/v2/"
+  }
+```
+
+
+## Create/Update Role
+
+This endpoint creates or updates the Terraform Cloud role definition in Vault.
+If the role does not exist, it will be created. If the role already exists, it
+will receive updated attributes. 
+
+Terraform Cloud offers three distinct types of API tokens with varying level of
+access: Organizations, Teams, and Users. A Vault Role can manage a single type
+of API token at a time, determined by how it is configured: 
+
+- To manage an Organization API token, provide the organization
+name with the `organization` parameter
+- To manage a Team API token, provide the `team_id` parameter
+- To manage a User API token, provide a `user_id` parameter
+
+~> **Special Note:** both Organizations and Teams can only have a single active API
+token at any given time. Generating a new token for a team or organization will
+effectively revoke any existing tokens, regardless if those tokens were
+originally created by Vault. As such, requesting an Organization or Team token
+from Vault will return the same token indefinitely until that token is rotated
+with the `/rotate-role` endpoint.
+
+Please see the [Terraform Cloud API
+Token documentation for more
+information](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html).
+
+
+| Method | Path                |
+| :----- | :------------------ |
+| `POST` | `/terraform/role/:name` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name for the Vault role. This is
+  part of the request URL.
+
+- `organization` `(string: "")` – Organization name to manage the single API
+  token. Organizations can only have a single active API token at any given
+  time. Conflicts with `user_id`. 
+
+- `team_id` `(string: "")` – Team ID to manage the single API token. Teams can
+  only have a single active API token at any given time. Conflicts with
+  `user_id`.
+
+- `user_id` `(string: "")` – User ID to manage dynamic tokens. Conflicts with
+  `organization` and `team_id`.
+
+- `ttl` `(duration: "")` – Specifies the TTL for this role. This is provided
+  as a string duration with a time suffix like `"30s"` or `"1h"` or as seconds. If not
+  provided, the default Vault TTL is used. Only applies to User API tokens.
+
+- `max_ttl` `(duration: "")` – Specifies the max TTL for this role. This is provided
+  as a string duration with a time suffix like `"30s"` or `"1h"` or as seconds. If not
+  provided, the default Vault Max TTL is used. Only applies to User API tokens.
+
+
+### Sample Payload
+
+To create a Vault role to manage a Terraform Cloud User tokens
+
+```json
+{
+  "user_id": "user-glhf1234",
+  "ttl":"1h",
+  "max_ttl":"24h",
+}
+```
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request POST \
+    --header "X-Vault-Token: ..." \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/terraform/role/tfuser
+```
+
+## Read Role
+
+This endpoint queries for information about a Terraform Cloud role with the given name.
+If no role exists with that name, a 404 is returned.
+
+| Method | Path                |
+| :----- | :------------------ |
+| `GET`  | `/terraform/role/:name` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name of the role to query. This
+  is part of the request URL.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/terraform/role/tfuser
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "max_ttl": 86400,
+    "name": "tfuser",
+    "ttl": 3600,
+    "user_id": "user-glhf1234"
+  },
+}
+```
+
+## List Roles
+
+This endpoint lists all existing roles in the backend.
+
+| Method | Path                    |
+| :----- | :---------------------- |
+| `LIST` | `/terraform/role`           |
+| `GET`  | `/terraform/role?list=true` |
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request LIST \
+    http://127.0.0.1:8200/v1/terraform/role
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "keys": ["tfuser"]
+  }
+}
+```
+
+## Delete Role
+
+This endpoint deletes a Terraform Cloud role with the given name. Even if the role does
+not exist, this endpoint will still return a successful response.
+
+| Method   | Path                |
+| :------- | :------------------ |
+| `DELETE` | `/terraform/role/:name` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name of the role to delete. This
+  is part of the request URL.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request DELETE \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/terraform/role/tfuser
+```
+
+## Rotate Role
+
+This endpoint rotates the credentials for a Terraform Cloud role that manages an
+Organization or Team. 
+
+
+| Method   | Path                |
+| :------- | :------------------ |
+| `POST` | `/terraform/rotate-role/:name` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name of the role to rotate. This
+  is part of the request URL.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request POST \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/terraform/rotate-role/testing
+```
+
+## Generate Credential
+
+This endpoint returns a Terraform Cloud token based on the given role
+definition. For Organization and Team roles, the same API token is returned
+until the token is rotated with `rotate-role`. For User roles, a new token is
+generated with each request.
+
+| Method | Path                 |
+| :----- | :------------------- |
+| `GET`  | `/terraform/creds/:name` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name of an existing role against
+  which to create this Terraform Cloud token. This is part of the request URL.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/terraform/creds/example
+```
+
+### Sample Response
+
+```json
+{
+  "request_id": "71629848-778d-f9ae-c396-0b02fae2adda",
+  "lease_id": "terraform/creds/tfuser/dWa2E5aiIX7jJfyMqPm1fSPr",
+  "lease_duration": 60,
+  "renewable": true,
+  "data": {
+    "token": "<example-token>",
+    "token_id": "at-example"
+  },
+  "warnings": null
+}
+```

--- a/website/content/docs/secrets/terraform.mdx
+++ b/website/content/docs/secrets/terraform.mdx
@@ -29,7 +29,7 @@ management tool.
 
 1.  Enable the Terraform Cloud secrets engine:
 
-    ```text
+    ```shell-session
     $ vault secrets enable terraform
     Success! Enabled the terraform cloud secrets engine at: terraform/
     ```
@@ -39,7 +39,7 @@ management tool.
 
 2.  Configure Vault to connect and authenticate to Terraform Cloud:
 
-    ```text
+    ```shell-session
     $ vault write terraform/config \
         token=Vhz7652ba4c-0f6e-8e75-5724-5e083d72cfe4
     Success! Data written to: terraform/config
@@ -59,7 +59,7 @@ management tool.
     API](https://www.terraform.io/docs/cloud/api/account.html) to find the
     desired User ID.
 
-    ```text
+    ```shell-session
     $ vault write terraform/roles/my-role user_id=user-12345abcde
     Success! Data written to: terraform/roles/my-role
     ```

--- a/website/content/docs/secrets/terraform.mdx
+++ b/website/content/docs/secrets/terraform.mdx
@@ -102,7 +102,7 @@ Due to this behavior, Organization and Team API tokens created by Vault will be
 stored and returned on future requests, until the credentials get rotated. This
 is to prevent unintentional revocation of tokens that are currently in-use.
 
-Below is an example of creating a Vault role to manage manage an Organization
+Below is an example of creating a Vault role to manage an Organization
 API token and rotating the token:
 
 ```shell-session
@@ -128,10 +128,10 @@ token_id        at-fqvtdTQ5kQWcjUfG
 
 ### User roles 
 
-Traditionally Vault secret engines creates dynamic users and dynamic credentials
+Traditionally, Vault secret engines create dynamic users and dynamic credentials
 along with them. At the time of writing, the Terraform Cloud API does not allow
 for creating dynamic users. Instead, the Terraform Cloud secret engine creates
-dynamice User API tokens by configuring a Vault role to manage an existing
+dynamic User API tokens by configuring a Vault role to manage an existing
 Terraform Cloud user. The lifecycle of these tokens is managed by Vault and
 will auto expire according to the configured TTL and Max TTL of the Vault
 role.

--- a/website/content/docs/secrets/terraform.mdx
+++ b/website/content/docs/secrets/terraform.mdx
@@ -133,7 +133,7 @@ along with them. At the time of writing, the Terraform Cloud API does not allow
 for creating dynamic users. Instead, the Terraform Cloud secret engine creates
 dynamic User API tokens by configuring a Vault role to manage an existing
 Terraform Cloud user. The lifecycle of these tokens is managed by Vault and
-will auto expire according to the configured TTL and Max TTL of the Vault
+will auto expire according to the configured TTL and max TTL of the Vault
 role.
 
 Below is an example of creating a Vault role to manage manage User API tokens:

--- a/website/content/docs/secrets/terraform.mdx
+++ b/website/content/docs/secrets/terraform.mdx
@@ -1,0 +1,167 @@
+---
+layout: docs
+page_title: Terraform Cloud Secret Backend
+sidebar_title: Terraform Cloud
+description: The Terraform Cloud secret backend for Vault generates tokens for Terraform Cloud dynamically.
+---
+
+# Terraform Cloud Secret Backend
+
+Name: `Terraform Cloud`
+
+The Terraform Cloud secret backend for Vault generates
+[Terraform Cloud](https://www.terraform.io/cloud)
+API tokens dynamically for Organizations, Teams, and Users.
+
+This page will show a quick start for this backend. For detailed documentation
+on every path, use `vault path-help` after mounting the backend.
+
+~> **Terraform Enterprise Support:** this secret engine supports both Terraform
+Cloud ([app.terraform.io](https://app.terraform.io)) as well as on-premise 
+Terraform Enterprise. Any version requirements will be documented alongside the
+features that require them, if any. 
+
+## Quick Start
+
+Most secrets engines must be configured in advance before they can perform their
+functions. These steps are usually completed by an operator or configuration
+management tool.
+
+1.  Enable the Terraform Cloud secrets engine:
+
+    ```text
+    $ vault secrets enable terraform
+    Success! Enabled the terraform cloud secrets engine at: terraform/
+    ```
+
+    By default, the secrets engine will mount at the name of the engine. To
+    enable the secrets engine at a different path, use the `-path` argument.
+
+2.  Configure Vault to connect and authenticate to Terraform Cloud:
+
+    ```text
+    $ vault write terraform/config \
+        token=Vhz7652ba4c-0f6e-8e75-5724-5e083d72cfe4
+    Success! Data written to: terraform/config
+    ```
+
+    See [Terraform Cloud's documentation on API
+    tokens](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html)
+    to determine the appropriate API token for use with the secret engine. In
+    order to perform all operations, a User API token is recommended. 
+
+3.  Configure a role that maps a name in Vault to a Terraform Cloud User. At
+    this time the Terraform Cloud API does not allow dynamic user generation. As
+    a result this secret engine creates dynamic API tokens for an existing user,
+    and manages the lifecycle of that API token. You will need to know the User
+    ID in order to generate User API tokens for that user. You can use the
+    Terraform Cloud [Account
+    API](https://www.terraform.io/docs/cloud/api/account.html) to find the
+    desired User ID.
+
+    ```text
+    $ vault write terraform/roles/my-role user_id=user-12345abcde
+    Success! Data written to: terraform/roles/my-role
+    ```
+
+## Usage
+
+After the secrets engine is configured and a user/machine has a Vault token with
+the proper permission, it can generate credentials.
+
+Generate a new credential by reading from the `/creds` endpoint with the name
+of the role:
+
+```shell-session
+$ vault read terraform/creds/my-role
+Key                Value
+---                -----
+lease_id           terraform/creds/my-user/A_LEASE_ID_PdvmJjACTtKrY2I
+lease_duration     180s
+lease_renewable    true
+token              TJFDSIFDSKFEKZX.FKFKA.akjlfdiouajlkdakadfiowe
+token_id           at-123acbdfask
+```
+
+## Organization, Team, and User Roles
+
+Terraform Cloud supports three distinct types of API tokens; Organizations,
+Teams, and Users. Each token type has distinct access levels and generation
+workflows. A given Vault role can manage any one of the three types at a time,
+however there are important differences to be aware of.
+
+### Organization and Team roles 
+
+The Terraform Cloud API limits both Organization and Team roles to **one active
+token at any given time**. Generating a new Organization or Team API token by
+reading the credentials in Vault or otherwise generating them on
+[app.terraform.io](https://app.terraform.io) will effectively revoke **any**
+existing API token for that Organization or Team. 
+
+Due to this behavior, Organization and Team API tokens created by Vault will be
+stored and returned on future requests, until the credentials get rotated. This
+is to prevent unintentional revocation of tokens that are currently in-use.
+
+Below is an example of creating a Vault role to manage manage an Organization
+API token and rotating the token:
+
+```shell-session
+$ vault write terraform/role/testing organization="${TF_ORGANIZATION}"
+Success! Data written to: terraform/role/testing
+
+$ vault write -f terraform/rotate-role/testing
+Success! Data written to: terraform/rotate-role/testing
+```
+
+The API token is retrieved by reading the credentials for the role:
+
+```
+$ vault read terraform/creds/testing
+
+Key             Value
+---             -----
+organization    hashicorp-vault-testing
+role            testing
+token           <example token>
+token_id        at-fqvtdTQ5kQWcjUfG
+```
+
+### User roles 
+
+Traditionally Vault secret engines creates dynamic users and dynamic credentials
+along with them. At the time of writing, the Terraform Cloud API does not allow
+for creating dynamic users. Instead, the Terraform Cloud secret engine creates
+dynamice User API tokens by configuring a Vault role to manage an existing
+Terraform Cloud user. The lifecycle of these tokens is managed by Vault and
+will auto expire according to the configured TTL and Max TTL of the Vault
+role.
+
+Below is an example of creating a Vault role to manage manage User API tokens:
+
+```shell-session
+$ vault write terraform/role/user-testing user_id="${TF_USER_ID}"
+Success! Data written to: terraform/role/user-testing
+```
+
+The API token is retrieved by reading the credentials for the role:
+
+```
+$ vault read terraform/creds/user-testing
+
+Key             Value
+---             -----
+role            user-testing
+token           <example token>
+token_id        at-fqvtdTQ5kQWcjUfG
+```
+
+Please see the [Terraform Cloud API
+Token documentation for more
+information](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html).
+
+
+## API
+
+The Terraform Cloud secrets engine has a full HTTP API. Please see the
+[Terraform Cloud secrets engine API](/api/secret/terraform) for more
+details.

--- a/website/data/api-navigation.js
+++ b/website/data/api-navigation.js
@@ -62,6 +62,7 @@ export default [
       'pki',
       'rabbitmq',
       'ssh',
+      'terraform',
       'totp',
       'transform',
       'transit',

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -260,6 +260,7 @@ export default [
           'dynamic-ssh-keys',
         ],
       },
+      'terraform',
       'totp',
       { category: 'transform', content: ['tokenization'] },
       'transit',


### PR DESCRIPTION
This is a work-in-progress PR to add documentation for the upcoming Terraform Cloud Secret engine. The documentation reflects this companion PR: https://github.com/hashicorp/vault-plugin-secrets-terraform/pull/3

Prerequisites:

- [x] Merge https://github.com/hashicorp/vault-plugin-secrets-terraform/pull/3 
- [x] Merge https://github.com/hashicorp/vault/pull/10931 to bundle hashicorp/vault-plugin-secrets-terraform into Vault