### PR TITLE
Add environment variable for bearer auth token

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -38,6 +38,7 @@ const EnvVaultNamespace = "VAULT_NAMESPACE"
 const EnvVaultTLSServerName = "VAULT_TLS_SERVER_NAME"
 const EnvVaultWrapTTL = "VAULT_WRAP_TTL"
 const EnvVaultMaxRetries = "VAULT_MAX_RETRIES"
+const EnvVaultBearerAuthToken = "VAULT_BEARER_AUTH_TOKEN"
 const EnvVaultToken = "VAULT_TOKEN"
 const EnvVaultMFA = "VAULT_MFA"
 const EnvRateLimit = "VAULT_RATE_LIMIT"
@@ -454,6 +455,10 @@ func NewClient(c *Config) (*Client, error) {
 
 	if token := os.Getenv(EnvVaultToken); token != "" {
 		client.token = token
+	}
+
+	if bearerAuthToken := os.Getenv(EnvVaultBearerAuthToken); bearerAuthToken != "" {
+		client.AddHeader("Authorization", "Bearer "+bearerAuthToken)
 	}
 
 	if namespace := os.Getenv(EnvVaultNamespace); namespace != "" {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -75,7 +75,7 @@ func TestClientSetAddress(t *testing.T) {
 func TestClientBearerAuthToken(t *testing.T) {
 	var seenBearerToken string
 	handler := func(w http.ResponseWriter, req *http.Request) {
-		seenBearerToken = req.Header.Get("Authentication")
+		seenBearerToken = req.Header.Get("Authorization")
 	}
 	config, ln := testHTTPServer(t, http.HandlerFunc(handler))
 	defer ln.Close()


### PR DESCRIPTION
Our vault instances are behind company internal network with edge gateway that requires a valid bearer token. 
Right now, we have to ssh into jump box to run the script with Vault.
It would be great that if Vault supports adding auth bearer token environment into http request header.