### PR TITLE
k8s doc: update for 0.9.1 and 0.8.0 releases

### DIFF
--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -142,7 +142,7 @@ and consider if they're appropriate for your deployment.
     # Recommended default server affinity:
     affinity: |
       podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
+        requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -142,12 +142,12 @@ and consider if they're appropriate for your deployment.
     # Recommended default server affinity:
     affinity: |
       podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
+      requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
-          matchLabels:
-            app: {{ template "vault.name" . }}
-            release: "{{ .Release.Name }}"
-            component: injector
+            matchLabels:
+              app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
+              app.kubernetes.io/instance: "{{ .Release.Name }}"
+              component: webhook
           topologyKey: kubernetes.io/hostname
     ```
 

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
@@ -22,7 +22,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.5.4_ent' \
+  --set='server.image.tag=1.6.2_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -74,7 +74,7 @@ disaster recovery replication.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.5.4_ent' \
+  --set='server.image.tag=1.6.2_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
@@ -22,7 +22,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.5.4_ent' \
+  --set='server.image.tag=1.6.2_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -73,7 +73,7 @@ With the primary cluster created, next create a secondary cluster.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.5.4_ent' \
+  --set='server.image.tag=1.6.2_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
@@ -16,7 +16,7 @@ Integrated storage (raft) can be enabled using the `server.ha.raft.enabled` valu
 ```shell
 helm install vault hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.5.4_ent' \
+  --set='server.image.tag=1.6.2_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/index.mdx
+++ b/website/content/docs/platform/k8s/helm/index.mdx
@@ -36,7 +36,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -58,13 +58,14 @@ Installing a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
 hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.9.0
-$ helm install vault hashicorp/vault --version 0.9.0
+# Install version 0.9.1
+$ helm install vault hashicorp/vault --version 0.9.1
 ```
 
 ~> **Security Warning:** By default, the chart runs in standalone mode. This

--- a/website/content/docs/platform/k8s/helm/openshift.mdx
+++ b/website/content/docs/platform/k8s/helm/openshift.mdx
@@ -70,7 +70,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -89,13 +89,14 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
 hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.9.0
-$ helm install vault hashicorp/vault --version 0.9.0
+# Install version 0.9.1
+$ helm install vault hashicorp/vault --version 0.9.1
 ```
 
 The `helm install` command accepts parameters to override default configuration

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -54,7 +54,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -73,13 +73,14 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
 hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.9.0
-$ helm install vault hashicorp/vault --version 0.9.0
+# Install version 0.9.1
+$ helm install vault hashicorp/vault --version 0.9.1
 ```
 
 The `helm install` command accepts parameters to override default configuration
@@ -422,14 +423,14 @@ Next, list the Helm versions and choose the desired version to install.
 ```bash
 helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 ```
 
 Next, test the upgrade with `--dry-run` first to verify the changes sent to the
 Kubernetes cluster.
 
 ```shell-session
-$ helm upgrade vault hashicorp/vault --version=0.9.0 \
+$ helm upgrade vault hashicorp/vault --version=0.9.1 \
     --set='server.image.repository=vault' \
     --set='server.image.tag=123.456' \
     --dry-run

--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -153,6 +153,10 @@ them, optional commands to run, etc.
 - `vault.hashicorp.com/agent-cache-listener-port` - configures Vault Agent cache
   listening port. Defaults to `8080`.
 
+- `vault.hashicorp.com/agent-copy-volume-mounts` - copies the mounts from the specified 
+  container and mounts them to the Vault Agent containers. The service account volume is 
+  ignored.
+
 ## Vault Annotations
 
 Vault annotations change how the Vault Agent containers communicate with Vault. For
@@ -183,6 +187,9 @@ etc.
 
 - `vault.hashicorp.com/log-level` - configures the verbosity of the Vault Agent
   log level. Default is `info`.
+
+- `vault.hashicorp.com/log-format` - configures the log type for Vault Agent. Possible 
+  values are `standard` and `json`. Default is `standard`.
 
 - `vault.hashicorp.com/namespace` - configures the Vault Enterprise namespace to
   be used when requesting secrets from Vault.

--- a/website/content/docs/platform/k8s/injector/installation.mdx
+++ b/website/content/docs/platform/k8s/injector/installation.mdx
@@ -21,7 +21,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 ```
 
 Then install the chart and enable the injection feature by setting the


### PR DESCRIPTION
Updated the website for Vault K8s 0.8.0 and Vault Helm 0.9.1:

Vault K8s: https://github.com/hashicorp/vault-k8s/blob/master/CHANGELOG.md#080-february-2-2021
Vault Helm: https://github.com/hashicorp/vault-helm/blob/master/CHANGELOG.md#091-february-2nd-2021