### PR TITLE
approle: add ttl to the secret ID generation response

### DIFF
--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
@@ -2363,20 +2362,8 @@ func (b *backend) handleRoleSecretIDCommon(ctx context.Context, req *logical.Req
 		Data: map[string]interface{}{
 			"secret_id":          secretID,
 			"secret_id_accessor": secretIDStorage.SecretIDAccessor,
+			"secret_id_ttl":      int64(b.deriveSecretIDTTL(secretIDStorage.SecretIDTTL).Seconds()),
 		},
-	}
-
-	// Follow the behavior from registerSecretIDEntry and set the response TTL
-	// to the entry's TTL unless it's negative or greater than the system's max
-	// lease TTL.
-	switch {
-	case secretIDStorage.SecretIDTTL < time.Duration(0):
-		// This case should not be possible since TypeDurationSecond does not
-		// support negative values, but we follow the same convention as
-		// registerSecretIDEntry
-		resp.Data["ttl"] = int(b.System().MaxLeaseTTL().Seconds())
-	case secretIDStorage.SecretIDTTL > time.Duration(0):
-		resp.Data["ttl"] = int(math.Min(secretIDStorage.SecretIDTTL.Seconds(), b.System().MaxLeaseTTL().Seconds()))
 	}
 
 	return resp, nil

--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -1936,12 +1936,12 @@ func TestAppRole_SecretID_WithTTL(t *testing.T) {
 	tests := []struct {
 		name      string
 		roleName  string
-		ttl       int
+		ttl       int64
 		sysTTLCap bool
 	}{
 		{
 			"zero ttl",
-			"role-no-ttl",
+			"role-zero-ttl",
 			0,
 			false,
 		},
@@ -1992,24 +1992,24 @@ func TestAppRole_SecretID_WithTTL(t *testing.T) {
 			}
 
 			// Extract the "ttl" value from the response data if it exists
-			var respTTL int
-			ttlRaw, okTTL := resp.Data["ttl"]
-			if okTTL {
-				var ok bool
-				respTTL, ok = ttlRaw.(int)
-				if !ok {
-					t.Fatalf("expected ttl to be an integer, got: %v", respTTL)
-				}
+			ttlRaw, okTTL := resp.Data["secret_id_ttl"]
+			if !okTTL {
+				t.Fatalf("expected TTL value in response")
+			}
+
+			var (
+				respTTL int64
+				ok      bool
+			)
+			respTTL, ok = ttlRaw.(int64)
+			if !ok {
+				t.Fatalf("expected ttl to be an integer, got: %s", err)
 			}
 
 			// Verify secret ID response for different cases
 			switch {
-			case tt.ttl == 0 && okTTL:
-				t.Fatalf("expected no TTL in response, got: %v", ttlRaw)
-			case tt.ttl != 0 && !okTTL:
-				t.Fatalf("expected TTL value in response")
 			case tt.sysTTLCap:
-				if respTTL != int(b.System().MaxLeaseTTL().Seconds()) {
+				if respTTL != int64(b.System().MaxLeaseTTL().Seconds()) {
 					t.Fatalf("expected TTL value to be system's max lease TTL, got: %d", respTTL)
 				}
 			default:

--- a/changelog/10826.txt
+++ b/changelog/10826.txt
@@ -1,0 +1,3 @@
+```changelog:changes
+auth/approle: Secrets ID generation endpoint now returns `secret_id_ttl` as part of its response.
+```

--- a/website/content/api-docs/auth/approle.mdx
+++ b/website/content/api-docs/auth/approle.mdx
@@ -301,7 +301,8 @@ $ curl \
   "wrap_info": null,
   "data": {
     "secret_id_accessor": "84896a0c-1347-aa90-a4f6-aca8b7558780",
-    "secret_id": "841771dc-11c9-bbc7-bcac-6a3945a69cd9"
+    "secret_id": "841771dc-11c9-bbc7-bcac-6a3945a69cd9",
+    "secret_id_ttl": 600
   },
   "lease_duration": 0,
   "renewable": false,

--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -113,6 +113,7 @@ documentation.
    $ vault write -f auth/approle/role/my-role/secret-id
    secret_id               6a174c20-f6de-a53c-74d2-6018fcceff64
    secret_id_accessor      c454f7e5-996e-7230-6074-6ef26b7bcf86
+   secret_id_ttl           10m
    ```
 
 ### Via the API
@@ -170,7 +171,8 @@ documentation.
    {
      "data": {
        "secret_id_accessor": "45946873-1d96-a9d4-678c-9229f74386a5",
-       "secret_id": "37b74931-c4cd-d49a-9246-ccc62d682a25"
+       "secret_id": "37b74931-c4cd-d49a-9246-ccc62d682a25",
+       "secret_id_ttl": 600
      }
    }
    ```


### PR DESCRIPTION
This PR adds `ttl` to the response on the [secret ID generation endpoint](https://www.vaultproject.io/api-docs/auth/approle#generate-new-secret-id). This allows external parties, such as consul-template, to parse and perform renew logic based on this value.