### PR TITLE
Fixes hashicorp/vault#10830 Wild cards are allowed for both service account and namespace in k8s auth role creation

### DIFF
--- a/website/content/api-docs/auth/kubernetes.mdx
+++ b/website/content/api-docs/auth/kubernetes.mdx
@@ -119,11 +119,9 @@ entities attempting to login.
 
 - `name` `(string: <required>)` - Name of the role.
 - `bound_service_account_names` `(array: <required>)` - List of service account
-  names able to access this role. If set to "\*" all names are allowed, both this
-  and bound_service_account_namespaces can not be "\*".
+  names able to access this role. If set to "\*" all names are allowed.
 - `bound_service_account_namespaces` `(array: <required>)` - List of namespaces
-  allowed to access this role. If set to "\*" all namespaces are allowed, both
-  this and bound_service_account_names can not be set to "\*".
+  allowed to access this role. If set to "\*" all namespaces are allowed.
 - `audience` `(string: "")` - Optional Audience claim to verify in the JWT.
 
 @include 'tokenfields.mdx'


### PR DESCRIPTION
[Plugin was changed just over a year ago.](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/78/commits/70bc47384bedfc895d08d1df17a45b0c4ea8b6de)

Docs for the website in this repo were never modified.

Is there a way to allow the website's .mdx files for plugins to live in their respective repos?