### PR TITLE
Set TokenParent in the Index to be cached

### DIFF
--- a/changelog/10833.txt
+++ b/changelog/10833.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Set TokenParent correctly in the Index to be cached.
+```

--- a/command/agent/cache/lease_cache.go
+++ b/command/agent/cache/lease_cache.go
@@ -353,7 +353,7 @@ func (c *LeaseCache) Send(ctx context.Context, req *SendRequest) (*SendResponse,
 			c.logger.Debug("setting parent context", "method", req.Request.Method, "path", req.Request.URL.Path)
 			parentCtx = entry.RenewCtxInfo.Ctx
 
-			entry.TokenParent = req.Token
+			index.TokenParent = req.Token
 		}
 
 		renewCtxInfo = c.createCtxInfo(parentCtx)

--- a/command/agent/cache/lease_cache_test.go
+++ b/command/agent/cache/lease_cache_test.go
@@ -162,6 +162,18 @@ func TestLeaseCache_SendCacheable(t *testing.T) {
 		t.Fatalf("expected getting proxied response: got %v", diff)
 	}
 
+	// Check TokenParent
+	cachedItem, err := lc.db.Get(cachememdb.IndexNameToken, "testtoken")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cachedItem == nil {
+		t.Fatalf("expected token entry from cache")
+	}
+	if "autoauthtoken" != cachedItem.TokenParent {
+		t.Fatalf("unexpected value for tokenparent: %s", cachedItem.TokenParent)
+	}
+
 	// Modify the request a little bit to ensure the second response is
 	// returned to the lease cache.
 	sendReq = &SendRequest{

--- a/command/agent/cache/lease_cache_test.go
+++ b/command/agent/cache/lease_cache_test.go
@@ -170,7 +170,7 @@ func TestLeaseCache_SendCacheable(t *testing.T) {
 	if cachedItem == nil {
 		t.Fatalf("expected token entry from cache")
 	}
-	if "autoauthtoken" != cachedItem.TokenParent {
+	if cachedItem.TokenParent != "autoauthtoken" {
 		t.Fatalf("unexpected value for tokenparent: %s", cachedItem.TokenParent)
 	}
 


### PR DESCRIPTION
It seems like TokenParent should be set on the index about to be stored, instead of the entry that was looked up, so that when a token is revoked, it's possible to lookup all the child tokens when the parent is revoked:

https://github.com/hashicorp/vault/blob/464f2138302dc52585e7b3b97fb4d740be5385cc/command/agent/cache/lease_cache.go#L768-L781