### PR TITLE
Remove unused non-exported method of LifetimeWatcher type

### DIFF
--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -346,23 +346,6 @@ func (r *LifetimeWatcher) doRenew() error {
 	}
 }
 
-// sleepDuration calculates the time to sleep given the base lease duration. The
-// base is the resulting lease duration. It will be reduced to 1/3 and
-// multiplied by a random float between 0.0 and 1.0. This extra randomness
-// prevents multiple clients from all trying to renew simultaneously.
-func (r *LifetimeWatcher) sleepDuration(base time.Duration) time.Duration {
-	sleep := float64(base)
-
-	// Renew at 1/3 the remaining lease. This will give us an opportunity to retry
-	// at least one more time should the first renewal fail.
-	sleep = sleep / 3.0
-
-	// Use a randomness so many clients do not hit Vault simultaneously.
-	sleep = sleep * (r.random.Float64() + 1) / 2.0
-
-	return time.Duration(sleep)
-}
-
 // calculateGrace calculates the grace period based on a reasonable set of
 // assumptions given the total lease time; it also adds some jitter to not have
 // clients be in sync.


### PR DESCRIPTION
The `sleepDuration` method of the `LifetimeWatcher` type appears unused.

There is a function var named sleepDuration, but no references to
`sleepDuration` as a function on the `LifetimeWatcher` type within the
`api` package, and the `sleepDuration` function itself is not exported:

```
./vault/api > ag sleepDuration
lifetime_watcher.go
328:            sleepDuration := time.Duration(float64(leaseDuration.Nanoseconds())*2/3 + float64(r.grace.Nanoseconds())/3)
336:            if leaseDuration <= r.grace || leaseDuration-sleepDuration <= r.grace {
343:            case <-time.After(sleepDuration):
349:// sleepDuration calculates the time to sleep given the base lease duration. The
353:func (r *LifetimeWatcher) sleepDuration(base time.Duration) time.Duration {
```

I believe based on that, that that function is not actively used. This
pull request removes the function to avoid confusion for readers who may
see that function and believe it is how a LifetimeWatcher is calculating
the retry/sleep timing.