### PR TITLE
Correct lock acquisition order in the `pathEntityMergeID` identity to fix deadlock condition

### DIFF
--- a/changelog/10877.txt
+++ b/changelog/10877.txt
@@ -1,1 +1,3 @@
+```release-note:bug
 core/identity: Fix deadlock in entity merge endpoint.
+```

--- a/changelog/10877.txt
+++ b/changelog/10877.txt
@@ -1,0 +1,1 @@
+core/identity: Fix deadlock in entity merge endpoint.

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -164,6 +164,9 @@ func (i *IdentityStore) pathEntityMergeID() framework.OperationFunc {
 		force := d.Get("force").(bool)
 
 		// Create a MemDB transaction to merge entities
+		i.lock.Lock()
+		defer i.lock.Unlock()
+
 		txn := i.db.Txn(true)
 		defer txn.Abort()
 
@@ -172,7 +175,7 @@ func (i *IdentityStore) pathEntityMergeID() framework.OperationFunc {
 			return nil, err
 		}
 
-		userErr, intErr := i.mergeEntity(ctx, txn, toEntity, fromEntityIDs, force, true, false, true)
+		userErr, intErr := i.mergeEntity(ctx, txn, toEntity, fromEntityIDs, force, false, false, true)
 		if userErr != nil {
 			return logical.ErrorResponse(userErr.Error()), nil
 		}


### PR DESCRIPTION
fixes #10876

This fixes lock acquisition ordering in the  `pathEntityMergeID` function so that it matches other code in the identity backend's locking order by locking the `IdentityStore` lock before creating a memdb write transaction that requires a memdb lock.  This avoids the dead lock scenario encountered in #10876.

In order to confirm this works, I ran the same reproduction harness described in #10876 against a locally built version of Vault with this patch and both loops got through over 20,000 requests without issue -- without the patch I had never seen the loops get past 400-500 requests.