### PR TITLE
Respect VAULT_MAX_RETRIES from environment in DefaultConfig()

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -149,6 +149,8 @@ func DefaultConfig() *Config {
 		Address:    "https://127.0.0.1:8200",
 		HttpClient: cleanhttp.DefaultPooledClient(),
 		Timeout:    time.Second * 60,
+		MaxRetries: 2,
+		Backoff:    retryablehttp.LinearJitterBackoff,
 	}
 
 	transport := config.HttpClient.Transport.(*http.Transport)
@@ -177,9 +179,6 @@ func DefaultConfig() *Config {
 		// function (to prevent redirects) passing through to it.
 		return http.ErrUseLastResponse
 	}
-
-	config.Backoff = retryablehttp.LinearJitterBackoff
-	config.MaxRetries = 2
 
 	return config
 }


### PR DESCRIPTION
The value api.Config.MaxRetries from environment variable VAULT_MAX_RETRIES is always overwritten by 2. This forces default clients to call config.ReadEnvironment() again, just to set this value correctly.

This PR fixes the above.