### PR TITLE
Backport 1.6: Correct lock acquisition order in the `pathEntityMergeID` identity to…

### DIFF
--- a/changelog/10877.txt
+++ b/changelog/10877.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/identity: Fix deadlock in entity merge endpoint.
+```

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -164,6 +164,9 @@ func (i *IdentityStore) pathEntityMergeID() framework.OperationFunc {
 		force := d.Get("force").(bool)
 
 		// Create a MemDB transaction to merge entities
+		i.lock.Lock()
+		defer i.lock.Unlock()
+
 		txn := i.db.Txn(true)
 		defer txn.Abort()
 
@@ -172,7 +175,7 @@ func (i *IdentityStore) pathEntityMergeID() framework.OperationFunc {
 			return nil, err
 		}
 
-		userErr, intErr := i.mergeEntity(ctx, txn, toEntity, fromEntityIDs, force, true, false, true)
+		userErr, intErr := i.mergeEntity(ctx, txn, toEntity, fromEntityIDs, force, false, false, true)
 		if userErr != nil {
 			return logical.ErrorResponse(userErr.Error()), nil
 		}


### PR DESCRIPTION
… fix deadlock condition (#10877)