### PR TITLE
Metrics for request forwarding

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/NYTimes/gziphandler"
+	"github.com/armon/go-metrics"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"


### PR DESCRIPTION
We'd really want to measure the extra hop of forwarding requests from follow to leader Vault, specifically 
* `vault.core.forwarded_request`: counter metric indicating the number of forwarded requests
* `vault.core.forwarded_request_error`: counter metric indicating the number of times request forwarding failed because there was not an active leader
* `vault.core.handle_request_forwarding`: summary metric measuring the total duration of a forwarded request

Look forwards to your comments/suggestion!