### PR TITLE
Backport 1.6.3: Allow docs/ and ui/ branches to skip go tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2397,19 +2397,9 @@ workflows:
         - install-ui-dependencies
         - build-go-dev
     - test-go:
-        filters:
-          branches:
-            ignore:
-            - /^docs\/.*/
-            - /^ui\/.*/
         requires:
         - pre-flight-checks
     - test-go-remote-docker:
-        filters:
-          branches:
-            ignore:
-            - /^docs\/.*/
-            - /^ui\/.*/
         requires:
         - pre-flight-checks
     - test-go-race:

--- a/.circleci/config/workflows/ci.yml
+++ b/.circleci/config/workflows/ci.yml
@@ -21,21 +21,9 @@ jobs:
   - test-go:
       requires:
         - pre-flight-checks
-      filters:
-        branches:
-          # UI and Docs-only branches should skip go tests
-          ignore:
-            - /^docs\/.*/
-            - /^ui\/.*/
   - test-go-remote-docker:
       requires:
         - pre-flight-checks
-      filters:
-        branches:
-          # UI and Docs-only branches should skip go tests
-          ignore:
-            - /^docs\/.*/
-            - /^ui\/.*/
   - test-go-race:
       requires:
         - pre-flight-checks


### PR DESCRIPTION
Backport of #10763 