### PR TITLE
Diagnose startup coverage

### DIFF
--- a/command/diagnose_util.go
+++ b/command/diagnose_util.go
@@ -1,0 +1,24 @@
+package command
+
+type DiagnoseObserver interface {
+	Exited(status int)
+	Success(key string)
+	Error(key string, err error)
+	IsEnabled() bool
+}
+
+type NullDiagnoseObserver struct {
+}
+
+func (n *NullDiagnoseObserver) Exited(status int) {
+}
+
+func (n *NullDiagnoseObserver) Success(key string) {
+}
+
+func (n *NullDiagnoseObserver) Error(key string, err error) {
+}
+
+func (n *NullDiagnoseObserver) IsEnabled() bool {
+	return false
+}

--- a/command/diagnose_util.go
+++ b/command/diagnose_util.go
@@ -1,22 +1,26 @@
 package command
 
+import (
+	"github.com/hashicorp/vault/command/server"
+)
+
 type DiagnoseObserver interface {
-	Exited(status int)
 	Success(key string)
 	Error(key string, err error)
+	ConfigCreated(config *server.Config)
 	IsEnabled() bool
 }
 
 type NullDiagnoseObserver struct {
 }
 
-func (n *NullDiagnoseObserver) Exited(status int) {
-}
-
 func (n *NullDiagnoseObserver) Success(key string) {
 }
 
 func (n *NullDiagnoseObserver) Error(key string, err error) {
+}
+
+func (n *NullDiagnoseObserver) ConfigCreated(config *server.Config) {
 }
 
 func (n *NullDiagnoseObserver) IsEnabled() bool {

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -103,6 +103,28 @@ func (c *OperatorDiagnoseCommand) Run(args []string) int {
 	return c.RunWithParsedFlags()
 }
 
+// This class records any errors issued during execution of the
+// server command.
+
+type StartupObserver struct {
+	Errors    map[string]error
+	Successes map[string]struct{}
+}
+
+func (n *StartupObserver) Exited(status int) {
+}
+
+func (n *StartupObserver) Success(key string) {
+
+}
+
+func (n *StartupObserver) Error(key string, err error) {
+}
+
+func (n *StartupObserver) IsEnabled() bool {
+	return true
+}
+
 func (c *OperatorDiagnoseCommand) RunWithParsedFlags() int {
 	if len(c.flagConfigs) == 0 {
 		c.UI.Error("Must specify a configuration file using -config.")
@@ -134,6 +156,7 @@ func (c *OperatorDiagnoseCommand) RunWithParsedFlags() int {
 	server.flagConfigs = c.flagConfigs
 	config, err := server.parseConfig()
 	if err != nil {
+		// TODO: show every file one by one?
 		c.UI.Output(same_line + status_failed + phase)
 		c.UI.Output("Error while reading configuration files:")
 		c.UI.Output(err.Error())


### PR DESCRIPTION
This PR instruments the server command's Run() method to programatically report errors.

It would be somewhat better to refactor some of this code into separate functions.  But, the problem for Diagnose is that we would either have to run them one-by-one in the same order, duplicating what Run() would be doing anyway. I think the observer pattern here is a little closer to what we'd actually like to do in the long run with trace spans.

However, there are downsides as illustrated by the need to pass the config object back to the observer.  If Diagnose called parseConfig() itself then it would already have that object.

Sample outputs from hand testing:
```
mgritter@ubuntu:~/vault$ VAULT_DIAGNOSE=1 bin/vault operator diagnose -config ../vault-enterprise/splunk-testing.hcl
Vault v1.6.0-dev ('b421c3348d2a299563ac4252392b57838e7796f0+CHANGES')
[  ok  ] Parsed configuration
[  ok  ] Started raft storage
[  ok  ] Started listeners
[      ] Shamir unseal requires user input
Vault diagnose could not detect any problems.
```

```
[  ok  ] Parsed configuration
[  ok  ] Started raft storage
[failed] Error initializing listeners
listen tcp 127.0.0.1:8200: bind: address already in use
```

```
[  ok  ] Parsed configuration
[  ok  ] Started file storage
[failed] Error during transit unseal
Put "https://test-vault.example.com:8300/v1/transit/encrypt/autounseal": dial tcp 127.0.0.1:8300: connect: connection refused
```

```
[  ok  ] Parsed configuration
[failed] Storage error initializing raft
Error initializing storage of type raft: failed to create fsm: failed to open bolt file: open /var/doesnotexist/raft/vault.db: no such file or directory
```

```
mgritter@ubuntu:~/vault$ VAULT_DIAGNOSE=1 bin/vault operator diagnose -config foo.hcl
Vault v1.6.0-dev ('b421c3348d2a299563ac4252392b57838e7796f0+CHANGES')
[failed] Configuration error
No configuration files found.
```

