### PR TITLE
Allow retry for 307 - temporary redirect - response code

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -58,7 +58,6 @@ type AgentCommand struct {
 
 	logWriter io.Writer
 	logGate   *gatedwriter.Writer
-	logger    log.Logger
 
 	cleanupGuard sync.Once
 

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -33,10 +33,10 @@ func testAgentCommand(tb testing.TB, logger hclog.Logger) (*cli.MockUi, *AgentCo
 	ui := cli.NewMockUi()
 	return ui, &AgentCommand{
 		BaseCommand: &BaseCommand{
-			UI: ui,
+			UI:     ui,
+			logger: logger,
 		},
 		ShutdownCh: MakeShutdownCh(),
-		logger:     logger,
 	}
 }
 


### PR DESCRIPTION
We are running into problematic edge cases running vault-agent as sidecar container in production environments: When we provision vault or when vault has leader elections, the server returns a 307 - temporary redirect - back to the vault agent side container. As a result, the vault agent re-authenticates and fetches new secrets, instead of retrying to renew the lease of the vault token, and the old vault token is eventually revoked together with all its issues secrets. Unfortunately, some of our Kubernetes services do not have the ability to renew database sessions with new credentials, or respond too late, resulting in many authorization errors in our production environments. 

The problem is that `retryablehttp.DefaultRetryPolicy` function does not allow 307 to be retried. Consequently, the lifetime watcher for the vault token is _canceled_ and the vault agent re-authenticates and fetches new secrets. The default check-retry policy from `retryablehttp` makes sense for common use cases, but Vault is designed to return a 307 when hitting a standby node, and that should not deny a retry, like it does now. 

This PR wraps `retryablehttp.DefaultRetryPolicy` to add logic for allowing 307 retries. It only affects the vault agent but it might be useful to set the wrapped retry policy in `api.DefaultConfig()` and make it default behavior. With this PR, vault agent recovers from vault token lease renewals in case of a temporary 307:

```$ kubectl logs kibana-test-5fbc54df65-pd4gt vault-agent -f
==> Vault agent started! Log data will stream in below:
==> Vault agent configuration:
                     Cgo: disabled
               Log Level: trace
                 Version: Vault v1.6.0-dev
             Version Sha: 0adf0329808576601bafb2584b719e7e1c44545a+CHANGES
2021-02-11T10:22:50.157Z [INFO]  sink.file: creating file sink
2021-02-11T10:22:50.157Z [TRACE] sink.file: enter write_token: path=/home/vault/.vault-token
2021-02-11T10:22:50.157Z [TRACE] sink.file: exit write_token: path=/home/vault/.vault-token
2021-02-11T10:22:50.157Z [INFO]  sink.file: file sink configured: path=/home/vault/.vault-token mode=-rw-r-----
2021-02-11T10:22:50.158Z [INFO]  template.server: starting template server
2021-02-11T10:22:50.158Z [INFO]  template.server: no templates found
2021-02-11T10:22:50.158Z [INFO]  sink.server: starting sink server
2021-02-11T10:22:50.158Z [INFO]  auth.handler: starting auth handler
2021-02-11T10:22:50.158Z [INFO]  auth.handler: authenticating
2021-02-11T10:22:50.158Z [TRACE] auth.kubernetes: beginning authentication
2021-02-11T10:22:50.253Z [INFO]  auth.handler: authentication successful, sending token to sinks
2021-02-11T10:22:50.253Z [INFO]  auth.handler: starting renewal process
2021-02-11T10:22:50.253Z [TRACE] sink.file: enter write_token: path=/home/vault/.vault-token
2021-02-11T10:22:50.253Z [INFO]  sink.file: token written: path=/home/vault/.vault-token
2021-02-11T10:22:50.253Z [TRACE] sink.file: exit write_token: path=/home/vault/.vault-token
2021-02-11T10:22:50.264Z [INFO]  auth.handler: renewed auth token
2021-02-11T10:33:45.378Z [DEBUG] retry.check: retry for response code 503
2021-02-11T10:33:45.378Z [DEBUG] retry.backoff: min duration 1s, max duration 1.5s, attempt 0, next retry: 1.137832553s
2021-02-11T10:33:46.520Z [DEBUG] retry.check: retry for response code 503
2021-02-11T10:33:46.520Z [DEBUG] retry.backoff: min duration 1s, max duration 1.5s, attempt 1, next retry: 2.025932636s
2021-02-11T10:33:48.549Z [DEBUG] retry.check: retry for response code 307
2021-02-11T10:33:48.549Z [DEBUG] retry.backoff: min duration 1s, max duration 1.5s, attempt 2, next retry: 3.531723531s
2021-02-11T10:33:52.083Z [DEBUG] retry.check: retry for response code 503
2021-02-11T10:33:52.083Z [DEBUG] retry.backoff: min duration 1s, max duration 1.5s, attempt 3, next retry: 5.613898064s
2021-02-11T10:33:57.699Z [DEBUG] retry.check: retry for response code 503
2021-02-11T10:33:57.699Z [DEBUG] retry.backoff: min duration 1s, max duration 1.5s, attempt 4, next retry: 7.359382325s
2021-02-11T10:34:05.061Z [DEBUG] retry.check: retry for response code 307
2021-02-11T10:34:05.061Z [DEBUG] retry.backoff: min duration 1s, max duration 1.5s, attempt 5, next retry: 8.222880168s
2021-02-11T10:34:13.287Z [DEBUG] retry.check: retry for response code 503
2021-02-11T10:34:13.287Z [DEBUG] retry.backoff: min duration 1s, max duration 1.5s, attempt 6, next retry: 7.514124968s
2021-02-11T10:34:20.816Z [INFO]  auth.handler: renewed auth token
2021-02-11T10:45:15.921Z [INFO]  auth.handler: renewed auth token
2021-02-11T10:56:11.028Z [INFO]  auth.handler: renewed auth token
2021-02-11T11:07:06.136Z [INFO]  auth.handler: renewed auth token
2021-02-11T11:18:01.266Z [INFO]  auth.handler: renewed auth token
```

In the above logs, after 10 minutes the vault token renewal process starts. At that time, vault is sealed. After less than 1 minute the Vault is unsealed and the lease on the vault token is renewed successfully, leaving the already issued secrets unaffected.
