### PR TITLE
fix uninitialized tlsConfig in influxdb plugin

### DIFF
--- a/plugins/database/influxdb/connection_producer.go
+++ b/plugins/database/influxdb/connection_producer.go
@@ -168,7 +168,7 @@ func (i *influxdbConnectionProducer) createClient() (influx.Client, error) {
 	}
 
 	if i.TLS {
-		var tlsConfig *tls.Config
+		tlsConfig := &tls.Config{}
 		if len(i.certificate) > 0 || len(i.issuingCA) > 0 {
 			if len(i.certificate) > 0 && len(i.privateKey) == 0 {
 				return nil, fmt.Errorf("found certificate for TLS authentication but no private key")


### PR DESCRIPTION
fix for panic when configuring influxdb with tls but without pem_bundle or pem_json
crash log: https://gist.github.com/jleinfors/425c105f0146ba89ccb934f69ddce5d0