### PR TITLE
auth/kubernetes docs: Correct default issuer

### DIFF
--- a/website/content/api-docs/auth/kubernetes.mdx
+++ b/website/content/api-docs/auth/kubernetes.mdx
@@ -39,7 +39,7 @@ access the Kubernetes API.
   extracted. Not every installation of Kubernetes exposes these
   keys.
 - `issuer` `(string: "")` - Optional JWT issuer. If no issuer is specified, then this plugin will
-  use `kubernetes.io/serviceaccount` as the default issuer.
+  use `kubernetes/serviceaccount` as the default issuer.
 - `disable_iss_validation` `(bool: false)` - Disable JWT issuer validation. Allows to skip ISS validation.
 - `disable_local_ca_jwt` `(bool: false)` - Disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod.
 


### PR DESCRIPTION
As per https://github.com/hashicorp/vault-plugin-auth-kubernetes/blob/207d1b4c1cdc4babbde00aeeb76f0a4a021a9954/path_login.go#L24, the default issuer when none is set is `kubernetes/serviceaccount`.