### PR TITLE
Use an atomic to avoid a race in runEventDemuxer.

### DIFF
--- a/changelog/10901.txt
+++ b/changelog/10901.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+serviceregistration: Fix race during shutdown of Consul service registration.
+```


### PR DESCRIPTION
Example failure: https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/2845/workflows/9b83b007-91bb-4639-a6c8-7e2498e63a09/jobs/106868