### PR TITLE
Update Vault 1.6.x with Azure secret plugin v0.8.1

### DIFF
--- a/changelog/10902.txt
+++ b/changelog/10902.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+secrets/azure (enterprise): Forward service principal credential creation to the
+primary cluster if called on a performance standby or performance secondary.
+```

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.8.0
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.7.0
-	github.com/hashicorp/vault-plugin-secrets-azure v0.8.0
+	github.com/hashicorp/vault-plugin-secrets-azure v0.8.1
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.8.2
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -654,10 +654,8 @@ github.com/hashicorp/vault-plugin-secrets-ad v0.8.0 h1:SBOxEjYtxkipmp8AC7Yy3vjBV
 github.com/hashicorp/vault-plugin-secrets-ad v0.8.0/go.mod h1:L5L6NoJFxRvgxhuA2sWhloc3sbgmE7KxhNcoRxcaH9U=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.7.0 h1:VoB3Q11LX+wF5w5TC8j3LYh6PNfeL1XM0zQAMaT04sY=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.7.0/go.mod h1:SSkKpSTOMnX84PfgYiWHgwVg+YMhxHNjo+YCJGNBoZk=
-github.com/hashicorp/vault-plugin-secrets-azure v0.8.0 h1:3BAhoqqDN198vynAfS3rcxUW2STBjREluGPsYCOy2mA=
-github.com/hashicorp/vault-plugin-secrets-azure v0.8.0/go.mod h1:4jCVjTG809NCQ8mrSnbBtX17gX1Iush+558BVO6MJeo=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.8.1 h1:61wEFhbiV/lOQ512wcdRGSPfs4E4JBbfaR40VyIm0ao=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.8.1/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
+github.com/hashicorp/vault-plugin-secrets-azure v0.8.1 h1:OVPAfhr4NVNu/CP8lR+QEk3l4uocP+gHRKQtKiB1AUo=
+github.com/hashicorp/vault-plugin-secrets-azure v0.8.1/go.mod h1:4jCVjTG809NCQ8mrSnbBtX17gX1Iush+558BVO6MJeo=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.8.2 h1:iZDbNQnlNzwXnuUwOykQ54ReRmKc0VoxXz/b8V48EDM=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.8.2/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.7.0 h1:dKPQIr6tLcMmhNKdc2A9pbwaIFLooC80UfNZL+jWMlA=

--- a/vendor/github.com/hashicorp/vault-plugin-secrets-azure/path_service_principal.go
+++ b/vendor/github.com/hashicorp/vault-plugin-secrets-azure/path_service_principal.go
@@ -46,9 +46,14 @@ func pathServicePrincipal(b *azureSecretBackend) *framework.Path {
 				Description: "Name of the Vault role",
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation: b.pathSPRead,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback:                    b.pathSPRead,
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
+			},
 		},
+
 		HelpSynopsis:    pathServicePrincipalHelpSyn,
 		HelpDescription: pathServicePrincipalHelpDesc,
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -538,7 +538,7 @@ github.com/hashicorp/vault-plugin-secrets-ad/plugin/util
 # github.com/hashicorp/vault-plugin-secrets-alicloud v0.7.0
 github.com/hashicorp/vault-plugin-secrets-alicloud
 github.com/hashicorp/vault-plugin-secrets-alicloud/clients
-# github.com/hashicorp/vault-plugin-secrets-azure v0.8.0
+# github.com/hashicorp/vault-plugin-secrets-azure v0.8.1
 github.com/hashicorp/vault-plugin-secrets-azure
 # github.com/hashicorp/vault-plugin-secrets-gcp v0.8.2
 github.com/hashicorp/vault-plugin-secrets-gcp/plugin


### PR DESCRIPTION
Updates the builtin Vault Azure secrets backend in version `release/1.6.x`  to include hashicorp/vault-plugin-secrets-azure#54 