### PR TITLE
Cassandra - Add username customization

### DIFF
--- a/helper/testhelpers/cassandra/cassandrahelper.go
+++ b/helper/testhelpers/cassandra/cassandrahelper.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gocql/gocql"
-	"github.com/hashicorp/vault/helper/testhelpers/docker"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/hashicorp/vault/helper/testhelpers/docker"
 )
 
 func PrepareTestContainer(t *testing.T, version string) (func(), string) {

--- a/plugins/database/cassandra/cassandra_test.go
+++ b/plugins/database/cassandra/cassandra_test.go
@@ -1,11 +1,13 @@
 package cassandra
 
 import (
+	"context"
 	"reflect"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	backoff "github.com/cenkalti/backoff/v3"
 	"github.com/gocql/gocql"
@@ -65,31 +67,99 @@ func TestCassandra_Initialize(t *testing.T) {
 }
 
 func TestCassandra_CreateUser(t *testing.T) {
-	db, cleanup := getCassandra(t, 4)
-	defer cleanup()
-
-	password := "myreallysecurepassword"
-	createReq := dbplugin.NewUserRequest{
-		UsernameConfig: dbplugin.UsernameMetadata{
-			DisplayName: "test",
-			RoleName:    "test",
-		},
-		Statements: dbplugin.Statements{
-			Commands: []string{createUserStatements},
-		},
-		Password:   password,
-		Expiration: time.Now().Add(1 * time.Minute),
+	type testCase struct {
+		// Config will have the hosts & port added to it during the test
+		config                map[string]interface{}
+		newUserReq            dbplugin.NewUserRequest
+		expectErr             bool
+		expectedUsernameRegex string
+		assertCreds           func(t testing.TB, address string, port int, username, password string, timeout time.Duration)
 	}
 
-	createResp := dbtesting.AssertNewUser(t, db, createReq)
-
-	expectedRegex := "^v_test_test_[a-zA-Z0-9]{20}_[0-9]{10}$"
-	re := regexp.MustCompile(expectedRegex)
-	if !re.MatchString(createResp.Username) {
-		t.Fatalf("Generated username %q did not match regexp %q", createResp.Username, expectedRegex)
+	tests := map[string]testCase{
+		"default username_template": {
+			config: map[string]interface{}{
+				"username":         "cassandra",
+				"password":         "cassandra",
+				"protocol_version": "4",
+				"connect_timeout":  "20s",
+			},
+			newUserReq: dbplugin.NewUserRequest{
+				UsernameConfig: dbplugin.UsernameMetadata{
+					DisplayName: "token",
+					RoleName:    "mylongrolenamewithmanycharacters",
+				},
+				Statements: dbplugin.Statements{
+					Commands: []string{createUserStatements},
+				},
+				Password:   "bfn985wjAHIh6t",
+				Expiration: time.Now().Add(1 * time.Minute),
+			},
+			expectErr:             false,
+			expectedUsernameRegex: `^v_token_mylongrolenamew_[a-z0-9]{20}_[0-9]{10}$`,
+			assertCreds:           assertCreds,
+		},
+		"custom username_template": {
+			config: map[string]interface{}{
+				"username":          "cassandra",
+				"password":          "cassandra",
+				"protocol_version":  "4",
+				"connect_timeout":   "20s",
+				"username_template": `foo_{{random 20}}_{{.RoleName | replace "e" "3"}}_{{unix_time}}`,
+			},
+			newUserReq: dbplugin.NewUserRequest{
+				UsernameConfig: dbplugin.UsernameMetadata{
+					DisplayName: "token",
+					RoleName:    "mylongrolenamewithmanycharacters",
+				},
+				Statements: dbplugin.Statements{
+					Commands: []string{createUserStatements},
+				},
+				Password:   "bfn985wjAHIh6t",
+				Expiration: time.Now().Add(1 * time.Minute),
+			},
+			expectErr:             false,
+			expectedUsernameRegex: `^foo_[a-zA-Z0-9]{20}_mylongrol3nam3withmanycharact3rs_[0-9]{10}$`,
+			assertCreds:           assertCreds,
+		},
 	}
 
-	assertCreds(t, db.Hosts, db.Port, createResp.Username, password, 5*time.Second)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cleanup, connURL := cassandra.PrepareTestContainer(t, "latest")
+			pieces := strings.Split(connURL, ":")
+			defer cleanup()
+
+			db := new()
+
+			config := test.config
+			config["hosts"] = connURL
+			config["port"] = pieces[1]
+
+			initReq := dbplugin.InitializeRequest{
+				Config:           config,
+				VerifyConnection: true,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			dbtesting.AssertInitialize(t, db, initReq)
+
+			require.True(t, db.Initialized, "Database is not initialized")
+
+			ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			newUserResp, err := db.NewUser(ctx, test.newUserReq)
+			if test.expectErr && err == nil {
+				t.Fatalf("err expected, got nil")
+			}
+			if !test.expectErr && err != nil {
+				t.Fatalf("no error expected, got: %s", err)
+			}
+			require.Regexp(t, test.expectedUsernameRegex, newUserResp.Username)
+			test.assertCreds(t, db.Hosts, db.Port, newUserResp.Username, test.newUserReq.Password, 5*time.Second)
+		})
+	}
 }
 
 func TestMyCassandra_UpdateUserPassword(t *testing.T) {
@@ -217,4 +287,4 @@ func assertNoCreds(t testing.TB, address string, port int, username, password st
 }
 
 const createUserStatements = `CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER;
-GRANT ALL PERMISSIONS ON ALL KEYSPACES TO {{username}};`
+GRANT ALL PERMISSIONS ON ALL KEYSPACES TO '{{username}}';`

--- a/plugins/database/cassandra/connection_producer.go
+++ b/plugins/database/cassandra/connection_producer.go
@@ -8,14 +8,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gocql/gocql"
-	"github.com/hashicorp/errwrap"
-	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
 	"github.com/hashicorp/vault/sdk/helper/tlsutil"
+
+	"github.com/gocql/gocql"
+	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -67,7 +67,7 @@ func (c *cassandraConnectionProducer) Initialize(ctx context.Context, req dbplug
 	}
 	c.connectTimeout, err = parseutil.ParseDurationSecond(c.ConnectTimeoutRaw)
 	if err != nil {
-		return errwrap.Wrapf("invalid connect_timeout: {{err}}", err)
+		return fmt.Errorf("invalid connect_timeout: %w", err)
 	}
 
 	if c.SocketKeepAliveRaw == nil {
@@ -75,7 +75,7 @@ func (c *cassandraConnectionProducer) Initialize(ctx context.Context, req dbplug
 	}
 	c.socketKeepAlive, err = parseutil.ParseDurationSecond(c.SocketKeepAliveRaw)
 	if err != nil {
-		return errwrap.Wrapf("invalid socket_keep_alive: {{err}}", err)
+		return fmt.Errorf("invalid socket_keep_alive: %w", err)
 	}
 
 	switch {
@@ -93,11 +93,11 @@ func (c *cassandraConnectionProducer) Initialize(ctx context.Context, req dbplug
 	case len(c.PemJSON) != 0:
 		parsedCertBundle, err = certutil.ParsePKIJSON([]byte(c.PemJSON))
 		if err != nil {
-			return errwrap.Wrapf("could not parse given JSON; it must be in the format of the output of the PKI backend certificate issuing command: {{err}}", err)
+			return fmt.Errorf("could not parse given JSON; it must be in the format of the output of the PKI backend certificate issuing command: %w", err)
 		}
 		certBundle, err = parsedCertBundle.ToCertBundle()
 		if err != nil {
-			return errwrap.Wrapf("Error marshaling PEM information: {{err}}", err)
+			return fmt.Errorf("error marshaling PEM information: %w", err)
 		}
 		c.certificate = certBundle.Certificate
 		c.privateKey = certBundle.PrivateKey
@@ -107,11 +107,11 @@ func (c *cassandraConnectionProducer) Initialize(ctx context.Context, req dbplug
 	case len(c.PemBundle) != 0:
 		parsedCertBundle, err = certutil.ParsePEMBundle(c.PemBundle)
 		if err != nil {
-			return errwrap.Wrapf("Error parsing the given PEM information: {{err}}", err)
+			return fmt.Errorf("error parsing the given PEM information: %w", err)
 		}
 		certBundle, err = parsedCertBundle.ToCertBundle()
 		if err != nil {
-			return errwrap.Wrapf("Error marshaling PEM information: {{err}}", err)
+			return fmt.Errorf("error marshaling PEM information: %w", err)
 		}
 		c.certificate = certBundle.Certificate
 		c.privateKey = certBundle.PrivateKey
@@ -125,7 +125,7 @@ func (c *cassandraConnectionProducer) Initialize(ctx context.Context, req dbplug
 
 	if req.VerifyConnection {
 		if _, err := c.Connection(ctx); err != nil {
-			return errwrap.Wrapf("error verifying connection: {{err}}", err)
+			return fmt.Errorf("error verifying connection: %w", err)
 		}
 	}
 
@@ -203,12 +203,12 @@ func (c *cassandraConnectionProducer) createSession(ctx context.Context) (*gocql
 
 			parsedCertBundle, err := certBundle.ToParsedCertBundle()
 			if err != nil {
-				return nil, errwrap.Wrapf("failed to parse certificate bundle: {{err}}", err)
+				return nil, fmt.Errorf("failed to parse certificate bundle: %w", err)
 			}
 
 			tlsConfig, err = parsedCertBundle.GetTLSConfig(certutil.TLSClient)
 			if err != nil || tlsConfig == nil {
-				return nil, errwrap.Wrapf(fmt.Sprintf("failed to get TLS configuration: tlsConfig:%#v err:{{err}}", tlsConfig), err)
+				return nil, fmt.Errorf("failed to get TLS configuration: tlsConfig:%#v err:%w", tlsConfig, err)
 			}
 			tlsConfig.InsecureSkipVerify = c.InsecureTLS
 
@@ -236,7 +236,7 @@ func (c *cassandraConnectionProducer) createSession(ctx context.Context) (*gocql
 
 	session, err := clusterConfig.CreateSession()
 	if err != nil {
-		return nil, errwrap.Wrapf("error creating session: {{err}}", err)
+		return nil, fmt.Errorf("error creating session: %w", err)
 	}
 
 	if c.Consistency != "" {
@@ -258,11 +258,11 @@ func (c *cassandraConnectionProducer) createSession(ctx context.Context) (*gocql
 
 			if rowNum < 1 {
 				session.Close()
-				return nil, errwrap.Wrapf("error validating connection info: No role create permissions found, previous error: {{err}}", err)
+				return nil, fmt.Errorf("error validating connection info: No role create permissions found, previous error: %w", err)
 			}
 		} else if err != nil {
 			session.Close()
-			return nil, errwrap.Wrapf("error validating connection info: {{err}}", err)
+			return nil, fmt.Errorf("error validating connection info: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Adds the ability to customize username generation for dynamic users in Cassandra.

Uses the new field `username_template` with the [go template language](https://golang.org/pkg/text/template/).