### PR TITLE
Return a UserError if aead.Open() fails to align with documentation

### DIFF
--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1697,7 +1697,7 @@ func (p *Policy) SymmetricDecryptRaw(encKey, ciphertext []byte, opts SymmetricOp
 	// Verify and Decrypt
 	plain, err := aead.Open(nil, nonce, trueCT, opts.AdditionalData)
 	if err != nil {
-		return nil, err
+		return nil, errutil.UserError{Err: err.Error()}
 	}
 	return plain, nil
 }


### PR DESCRIPTION
As mentioned in this issue: https://github.com/hashicorp/vault/issues/10842 the API documentation states that:
```
500 - Internal server error. An internal error has occurred, try again later. If the error persists, report a bug.
400 - Invalid request, missing or invalid data.
```

This change means that failures in key decryption at the `aead.Open()` step will result in a 400 status code being returned as opposed to a 500 as the problem probably originates from incorrect user data entry (there are other possibilites I imagine).