### PR TITLE
Add `nonce` configuration parameter to agent AWS auto-auth documentation 

### DIFF
--- a/website/content/docs/agent/autoauth/methods/aws.mdx
+++ b/website/content/docs/agent/autoauth/methods/aws.mdx
@@ -57,6 +57,8 @@ parameters unset in your configuration.
 - `header_value` `(string: optional)` - If configured in Vault, the value to use for
   [`iam_server_id_header_value`](/api/auth/aws#iam_server_id_header_value).
 
+- `nonce` `(string: optional)` - If not provided, vault will generate a new UUID every time `vault agent` runs.  If set, make sure you understand the importance of generating a good, unique nonce and protecting it. See [Client Nonce](/docs/auth/aws#client-nonce) for more.
+
 ## Learn
 
 Refer to the [Vault Agent with


### PR DESCRIPTION
Was looking how to give the vault agent with AWS auth-auth the same nonce, but saw it wasn't documented.  Dove through the code, found https://github.com/hashicorp/vault/blob/master/command/agent/auth/aws/aws.go#L139 and https://github.com/hashicorp/vault/blob/master/command/agent/auth/aws/aws.go#L215 

(tried to call out the importance and point to docs, know setting `nonce` poorly could be very bad!)