### PR TITLE
agent: route templating server through cache

### DIFF
--- a/changelog/10927.txt
+++ b/changelog/10927.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Route templating server through cache when enabled.
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -589,7 +589,7 @@ func (c *AgentCommand) Run(args []string) int {
 			Logger:        c.logger.Named("template.server"),
 			LogLevel:      level,
 			LogWriter:     c.logWriter,
-			VaultConf:     config.Vault,
+			AgentConfig:   config,
 			TemplateRetry: config.TemplateRetry,
 			Namespace:     namespace,
 			ExitAfterAuth: exitAfterAuth,

--- a/command/agent.go
+++ b/command/agent.go
@@ -590,7 +590,6 @@ func (c *AgentCommand) Run(args []string) int {
 			LogLevel:      level,
 			LogWriter:     c.logWriter,
 			AgentConfig:   config,
-			TemplateRetry: config.TemplateRetry,
 			Namespace:     namespace,
 			ExitAfterAuth: exitAfterAuth,
 		})

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -30,7 +30,6 @@ type ServerConfig struct {
 	AgentConfig *config.Config
 
 	ExitAfterAuth bool
-	TemplateRetry *config.TemplateRetry
 	Namespace     string
 
 	// LogLevel is needed to set the internal Consul Template Runner's log level
@@ -165,12 +164,12 @@ func (ts *Server) Run(ctx context.Context, incoming chan string, templates []*ct
 					},
 				}
 
-				if ts.config.TemplateRetry != nil && ts.config.TemplateRetry.Enabled {
+				if ts.config.AgentConfig.TemplateRetry != nil && ts.config.AgentConfig.TemplateRetry.Enabled {
 					ctv.Vault.Retry = &ctconfig.RetryConfig{
-						Attempts:   &ts.config.TemplateRetry.Attempts,
-						Backoff:    &ts.config.TemplateRetry.Backoff,
-						MaxBackoff: &ts.config.TemplateRetry.MaxBackoff,
-						Enabled:    &ts.config.TemplateRetry.Enabled,
+						Attempts:   &ts.config.AgentConfig.TemplateRetry.Attempts,
+						Backoff:    &ts.config.AgentConfig.TemplateRetry.Backoff,
+						MaxBackoff: &ts.config.AgentConfig.TemplateRetry.MaxBackoff,
+						Enabled:    &ts.config.AgentConfig.TemplateRetry.Enabled,
 					}
 				} else if ts.testingLimitRetry != 0 {
 					// If we're testing, limit retries to 3 attempts to avoid
@@ -243,7 +242,7 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 	conf.Vault.Address = &sc.AgentConfig.Vault.Address
 
 	if sc.AgentConfig.Cache != nil && len(sc.AgentConfig.Listeners) != 0 {
-		scheme := "unix:/"
+		scheme := "unix://"
 		if sc.AgentConfig.Listeners[0].Type == "tcp" {
 			scheme = "https://"
 			if sc.AgentConfig.Listeners[0].TLSDisable {

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -281,9 +281,7 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 
 		// Only configure TLS Skip Verify if CT is not going through the cache. We can
 		// skip verification if its using the cache because they're part of the same agent.
-		// Agent listener doesn't support mTLS listeners.
 		if sc.AgentConfig.Cache != nil {
-			conf.Vault.SSL.Enabled = pointerutil.BoolPtr(true)
 			conf.Vault.SSL.Verify = pointerutil.BoolPtr(false)
 			conf.Vault.SSL.Cert = pointerutil.StringPtr("")
 			conf.Vault.SSL.Key = pointerutil.StringPtr("")

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -268,10 +268,11 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		conf.Vault.Address = &address
 
 		// Skip verification if its using the cache because they're part of the same agent.
-		if scheme == "https" {
+		if scheme == "https://" {
+			if sc.AgentConfig.Listeners[0].TLSRequireAndVerifyClientCert {
+				return nil, errors.New("template server cannot use local cache when mTLS is enabled")
+			}
 			conf.Vault.SSL.Verify = pointerutil.BoolPtr(false)
-			conf.Vault.SSL.Cert = &sc.AgentConfig.Vault.ClientCert
-			conf.Vault.SSL.Key = &sc.AgentConfig.Vault.ClientKey
 		}
 	} else if strings.HasPrefix(sc.AgentConfig.Vault.Address, "https") || sc.AgentConfig.Vault.CACert != "" {
 		skipVerify := sc.AgentConfig.Vault.TLSSkipVerify

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -267,12 +267,11 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		address := fmt.Sprintf("%s%s", scheme, sc.AgentConfig.Listeners[0].Address)
 		conf.Vault.Address = &address
 
-		// Only configure TLS Skip Verify if CT is not going through the cache. We can
-		// skip verification if its using the cache because they're part of the same agent.
+		// Skip verification if its using the cache because they're part of the same agent.
 		if scheme == "https" {
 			conf.Vault.SSL.Verify = pointerutil.BoolPtr(false)
-			conf.Vault.SSL.Cert = pointerutil.StringPtr("")
-			conf.Vault.SSL.Key = pointerutil.StringPtr("")
+			conf.Vault.SSL.Cert = &sc.AgentConfig.Vault.ClientCert
+			conf.Vault.SSL.Key = &sc.AgentConfig.Vault.ClientKey
 		}
 	} else if strings.HasPrefix(sc.AgentConfig.Vault.Address, "https") || sc.AgentConfig.Vault.CACert != "" {
 		skipVerify := sc.AgentConfig.Vault.TLSSkipVerify

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -214,10 +214,6 @@ func TestCacheConfigNoCache(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !strings.HasPrefix(*ctConfig.Vault.Address, "http") {
-		t.Fatalf("expected http address, got %s", *ctConfig.Vault.Address)
-	}
-
 	expected := "http://127.0.0.1:1111"
 	if *ctConfig.Vault.Address != expected {
 		t.Fatalf("expected %s, got %s", expected, *ctConfig.Vault.Address)

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -140,10 +140,6 @@ func TestCacheConfigHTTP(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !strings.HasPrefix(*ctConfig.Vault.Address, "http") {
-		t.Fatalf("expected http address, got %s", *ctConfig.Vault.Address)
-	}
-
 	expected := "http://127.0.0.1:8300"
 	if *ctConfig.Vault.Address != expected {
 		t.Fatalf("expected %s, got %s", expected, *ctConfig.Vault.Address)

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -177,10 +177,6 @@ func TestCacheConfigHTTPS(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !strings.HasPrefix(*ctConfig.Vault.Address, "https") {
-		t.Fatalf("expected https address, got %s", *ctConfig.Vault.Address)
-	}
-
 	expected := "https://127.0.0.1:8300"
 	if *ctConfig.Vault.Address != expected {
 		t.Fatalf("expected %s, got %s", expected, *ctConfig.Vault.Address)

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -231,10 +231,6 @@ func TestCacheConfigNoListener(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !strings.HasPrefix(*ctConfig.Vault.Address, "http") {
-		t.Fatalf("expected http address, got %s", *ctConfig.Vault.Address)
-	}
-
 	expected := "http://127.0.0.1:1111"
 	if *ctConfig.Vault.Address != expected {
 		t.Fatalf("expected %s, got %s", expected, *ctConfig.Vault.Address)

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -103,10 +103,6 @@ func TestCacheConfigUnix(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if !strings.HasPrefix(*ctConfig.Vault.Address, "unix") {
-		t.Fatalf("expected unix address, got %s", *ctConfig.Vault.Address)
-	}
-
 	expected := "unix://foobar"
 	if *ctConfig.Vault.Address != expected {
 		t.Fatalf("expected %s, got %s", expected, *ctConfig.Vault.Address)

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -107,7 +107,7 @@ func TestCacheConfigUnix(t *testing.T) {
 		t.Fatalf("expected unix address, got %s", *ctConfig.Vault.Address)
 	}
 
-	expected := "unix:/foobar"
+	expected := "unix://foobar"
 	if *ctConfig.Vault.Address != expected {
 		t.Fatalf("expected %s, got %s", expected, *ctConfig.Vault.Address)
 	}

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -112,6 +112,7 @@ func TestCacheConfigUnix(t *testing.T) {
 		t.Fatalf("expected %s, got %s", expected, *ctConfig.Vault.Address)
 	}
 }
+
 func TestCacheConfigHTTP(t *testing.T) {
 	listeners := []*configutil.Listener{
 		{


### PR DESCRIPTION
This PR enhances the Vault Agent Templating server to support using the local proxy cache. The templating server will automatically configure itself to use the cache if caching is enabled and a listener is present. If either of these requirements aren't satisfied, the templating server will use the `vault` configuration as it does today.

The only caveat to this change is we ignore TLS verification if the listener has TLS enabled. We do this because a CA would be required to verify the certificate but the proxy and templating server are spawned by the same Vault Agent process.

