### PR TITLE
OpenAPI - Don't panic if field isn't found

### DIFF
--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -257,6 +257,10 @@ func documentPath(p *Path, specialPaths *logical.Paths, backendType logical.Back
 			location := "path"
 			required := true
 
+			if field == nil {
+				continue
+			}
+
 			if field.Query {
 				location = "query"
 				required = false

--- a/vendor/github.com/hashicorp/vault/sdk/framework/openapi.go
+++ b/vendor/github.com/hashicorp/vault/sdk/framework/openapi.go
@@ -257,6 +257,10 @@ func documentPath(p *Path, specialPaths *logical.Paths, backendType logical.Back
 			location := "path"
 			required := true
 
+			if field == nil {
+				continue
+			}
+
 			if field.Query {
 				location = "query"
 				required = false


### PR DESCRIPTION
Don't panic if a field isn't found when generating OpenAPI info.