### PR TITLE
Avoid storage operations with pendingLock is held.

### DIFF
--- a/changelog/10934.txt
+++ b/changelog/10934.txt
@@ -1,0 +1,3 @@
+```release-node:improvement
+core: Do not hold expiration manager's mutex while performing storage operations.
+```

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -709,7 +709,6 @@ func (m *ExpirationManager) LazyRevoke(ctx context.Context, leaseID string) erro
 	le.ExpireTime = time.Now()
 	// TODO: potential race with concurrent renew.
 	if err := m.persistEntry(ctx, le); err != nil {
-		m.pendingLock.Unlock()
 		return err
 	}
 	m.updatePending(le)
@@ -853,7 +852,6 @@ func (m *ExpirationManager) RevokeByToken(ctx context.Context, te *logical.Token
 
 			// TODO: storage race with concurrent renew
 			if err := m.persistEntry(ctx, le); err != nil {
-				m.pendingLock.Unlock()
 				return err
 			}
 			m.updatePending(le)

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -991,7 +991,7 @@ func (m *ExpirationManager) Renew(ctx context.Context, leaseID string, increment
 	// renewal fails due to a later cause. On an error, re-insert the
 	// original lease saved above.
 	defer func() {
-		if renewErr != nil || renewResp == nil {
+		if renewError != nil || renewResp == nil {
 			m.updatePending(originalLease)
 		} else {
 			m.updatePending(le)
@@ -2192,15 +2192,15 @@ type leaseEntry struct {
 // Returns a shallow clone; data, secret, and auth are shared with original object.
 func (le *leaseEntry) Clone() *leaseEntry {
 	return &leaseEntry{
-		LeaseID:         le.leaseID,
+		LeaseID:         le.LeaseID,
 		ClientToken:     le.ClientToken,
 		ClientTokenType: le.ClientTokenType,
 		Path:            le.Path,
 		Data:            le.Data,
 		Secret:          le.Secret,
 		Auth:            le.Auth,
-		IssueType:       le.IssueTime,
-		ExpireTime:      le.ExireTime,
+		IssueTime:       le.IssueTime,
+		ExpireTime:      le.ExpireTime,
 		LastRenewalTime: le.LastRenewalTime,
 		Version:         le.Version,
 		namespace:       le.namespace,


### PR DESCRIPTION
Allow renew and lazy revoke methods to write the new lease entry without holding pendingLock. This should reduce contention on pendingLock.

This means that, in the worst case, the entry on disk and in-memory could have different expiration times.

An additional safety measure is the following
  * renew will attempt to stop the pending timer
  * if it succeeds, no concurrent renew can set a different time
  * if it fails, the renew operation fails with an error
 
This mechanism protects against concurrent renew operations with different times, but not against concurrent renew and revoke.  However, it was already the case that a Renew() operation could overwrite a LeaseEntry that has been deleted by a concurrent revokeCommon(), and this remains an open bug.

One complexity in the implementation is that should a subsequent error cause a renew to fail, we want to restore the original timer so that the lease expires as normal.