### PR TITLE
core/expiration: Add backoff jitter to the expiration retries

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"path"
 	"strconv"
@@ -218,8 +219,7 @@ func (r *revocationJob) OnFailure(err error) {
 		return
 	}
 
-	// TODO vault 1.8 we added an exponential backoff library, check to see if it would be useful here
-	pending.timer.Reset((1 << pending.revokesAttempted) * revokeRetryBase)
+	pending.timer.Reset(revokeExponentialBackoff(pending.revokesAttempted))
 	r.m.pending.Store(r.leaseID, pending)
 }
 
@@ -246,6 +246,15 @@ func expireLeaseStrategyFairsharing(ctx context.Context, m *ExpirationManager, l
 	}
 
 	m.jobManager.AddJob(job, mountAccessor)
+}
+
+func revokeExponentialBackoff(attempt uint8) time.Duration {
+	exp := (1 << attempt) * revokeRetryBase
+	randomDelta := 0.5 * float64(exp)
+
+	// Allow backoff time to be a random value between exp +/- (0.5*exp)
+	backoffTime := (float64(exp) - randomDelta) + (rand.Float64() * (2 * randomDelta))
+	return time.Duration(backoffTime)
 }
 
 // revokeIDFunc is invoked when a given ID is expired


### PR DESCRIPTION
Allow retry backoff time to be a random value between 2^n +/- (0.5*2^n)

Example Backoff:

```
Attempt  0
	 new:  14.360669943s
	 existing:  10s
Attempt  1
	 new:  27.304622311s
	 existing:  20s
Attempt  2
	 new:  33.817540175s
	 existing:  40s
Attempt  3
	 new:  1m32.140496807s
	 existing:  1m20s
Attempt  4
	 new:  2m38.33880368s
	 existing:  2m40s
Attempt  5
	 new:  7m16.455974504s
	 existing:  5m20s
Attempt  6
	 new:  10m51.998922445s
	 existing:  10m40s
 ```