### PR TITLE
Adds method for rotating a policy without a persist

### DIFF
--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1452,14 +1452,14 @@ func (p *Policy) RotateInMemory(randReader io.Reader) (retErr error) {
 		}
 	}
 
+	p.LatestVersion += 1
+
 	if p.Keys == nil {
 		// This is an initial key rotation when generating a new policy. We
 		// don't need to call migrate here because if we've called getPolicy to
 		// get the policy in the first place it will have been run.
 		p.Keys = keyEntryMap{}
 	}
-
-	p.LatestVersion += 1
 	p.Keys[strconv.Itoa(p.LatestVersion)] = entry
 
 	// This ensures that with new key creations min decryption version is set

--- a/vendor/github.com/hashicorp/vault/sdk/helper/keysutil/policy.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/keysutil/policy.go
@@ -1357,7 +1357,7 @@ func (p *Policy) Rotate(ctx context.Context, storage logical.Storage, randReader
 		}
 	}()
 
-	if err := p.RotateInMemory(randReader, false); err != nil {
+	if err := p.RotateInMemory(randReader); err != nil {
 		return err
 	}
 
@@ -1365,38 +1365,7 @@ func (p *Policy) Rotate(ctx context.Context, storage logical.Storage, randReader
 }
 
 // RotateInMemory rotates the policy but does not persist it to storage.
-// If restoreOnError is true and the rotation partially fails, the policy
-// state will be restored.
-func (p *Policy) RotateInMemory(randReader io.Reader, restoreOnError bool) (retErr error) {
-	if restoreOnError {
-		priorLatestVersion := p.LatestVersion
-		priorMinDecryptionVersion := p.MinDecryptionVersion
-		var priorKeys keyEntryMap
-
-		if p.Keys != nil {
-			priorKeys = keyEntryMap{}
-			for k, v := range p.Keys {
-				priorKeys[k] = v
-			}
-		}
-
-		defer func() {
-			if retErr != nil {
-				p.LatestVersion = priorLatestVersion
-				p.MinDecryptionVersion = priorMinDecryptionVersion
-				p.Keys = priorKeys
-			}
-		}()
-	}
-
-	if p.Keys == nil {
-		// This is an initial key rotation when generating a new policy. We
-		// don't need to call migrate here because if we've called getPolicy to
-		// get the policy in the first place it will have been run.
-		p.Keys = keyEntryMap{}
-	}
-
-	p.LatestVersion += 1
+func (p *Policy) RotateInMemory(randReader io.Reader) (retErr error) {
 	now := time.Now()
 	entry := KeyEntry{
 		CreationTime:           now,
@@ -1483,6 +1452,14 @@ func (p *Policy) RotateInMemory(randReader io.Reader, restoreOnError bool) (retE
 		}
 	}
 
+	p.LatestVersion += 1
+
+	if p.Keys == nil {
+		// This is an initial key rotation when generating a new policy. We
+		// don't need to call migrate here because if we've called getPolicy to
+		// get the policy in the first place it will have been run.
+		p.Keys = keyEntryMap{}
+	}
 	p.Keys[strconv.Itoa(p.LatestVersion)] = entry
 
 	// This ensures that with new key creations min decryption version is set


### PR DESCRIPTION
## Overview

This PR adds a `RotateInMemory()` method to `keysutil.Policy`. The method rotates a policy without a call to `Persist()`. This method is useful in situations where rotating a policy is part of a multistep operation that may partially fail.

This PR is primarily moving around existing code. The signature and behavior of `Rotate()` is unchanged.

## Testing

I ran the following tests with the changes in this PR to ensure that changes to `Rotate()` don't introduce regressions.

Test output from keysutil package:
```
$ go test -v
=== RUN   TestEncrytedKeysStorage_BadPolicy
--- PASS: TestEncrytedKeysStorage_BadPolicy (0.00s)
=== RUN   TestEncryptedKeysStorage_List
--- PASS: TestEncryptedKeysStorage_List (0.00s)
=== RUN   TestEncryptedKeysStorage_CRUD
--- PASS: TestEncryptedKeysStorage_CRUD (0.00s)
=== RUN   TestPolicy_KeyEntryMapUpgrade
--- PASS: TestPolicy_KeyEntryMapUpgrade (0.00s)
=== RUN   Test_KeyUpgrade
--- PASS: Test_KeyUpgrade (0.00s)
=== RUN   Test_ArchivingUpgrade
--- PASS: Test_ArchivingUpgrade (0.00s)
=== RUN   Test_Archiving
--- PASS: Test_Archiving (0.00s)
=== RUN   Test_StorageErrorSafety
--- PASS: Test_StorageErrorSafety (0.00s)
=== RUN   Test_BadUpgrade
--- PASS: Test_BadUpgrade (0.00s)
=== RUN   Test_BadArchive
--- PASS: Test_BadArchive (0.00s)
PASS
ok      github.com/hashicorp/vault/sdk/helper/keysutil  0.190s
```

Test output from transit package:
```
$ go test ./...
ok      github.com/hashicorp/vault/builtin/logical/transit      40.500s
?       github.com/hashicorp/vault/builtin/logical/transit/cmd/transit  [no test files]
```

Test output from transform secrets engine:
```
$ go test ./...
ok      github.com/hashicorp/vault-plugin-secrets-transform     79.825s
?       github.com/hashicorp/vault-plugin-secrets-transform/cmd/vault-plugin-secrets-transform  [no test files]
?       github.com/hashicorp/vault-plugin-secrets-transform/helpers/testhelpers/docker  [no test files]
?       github.com/hashicorp/vault-plugin-secrets-transform/helpers/testhelpers/mysql   [no test files]
?       github.com/hashicorp/vault-plugin-secrets-transform/helpers/testhelpers/postgresql      [no test files]
```