### PR TITLE
Add TOTP support to Okta Auth

### DIFF
--- a/builtin/credential/okta/backend.go
+++ b/builtin/credential/okta/backend.go
@@ -176,7 +176,8 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username, pas
 
 		// Scan for available factors
 		for _, v := range result.Embedded.Factors {
-			v := v
+			v := v // create a new copy since we'll be taking the address later
+
 			if v.Provider != "OKTA" {
 				continue
 			}

--- a/builtin/credential/okta/cli.go
+++ b/builtin/credential/okta/cli.go
@@ -38,13 +38,8 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		"password": password,
 	}
 
-	mfa_method, ok := m["method"]
-	if ok {
-		data["method"] = mfa_method
-	}
-	mfa_passcode, ok := m["passcode"]
-	if ok {
-		data["passcode"] = mfa_passcode
+	if totp, ok := m["totp"]; ok {
+		data["totp"] = totp
 	}
 
 	path := fmt.Sprintf("auth/%s/login/%s", mount, username)

--- a/builtin/credential/okta/cli.go
+++ b/builtin/credential/okta/cli.go
@@ -38,8 +38,19 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		"password": password,
 	}
 
+	// Okta totp code
 	if totp, ok := m["totp"]; ok {
 		data["totp"] = totp
+	}
+
+	// Legacy MFA support
+	mfa_method, ok := m["method"]
+	if ok {
+		data["method"] = mfa_method
+	}
+	mfa_passcode, ok := m["passcode"]
+	if ok {
+		data["passcode"] = mfa_passcode
 	}
 
 	path := fmt.Sprintf("auth/%s/login/%s", mount, username)

--- a/builtin/credential/okta/path_login.go
+++ b/builtin/credential/okta/path_login.go
@@ -123,6 +123,7 @@ func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *f
 	}
 
 	// No TOTP entry is possible on renew. If push MFA is enabled it will still be triggered, however.
+	// Sending "" as the totp will prompt the push action if it is configured.
 	loginPolicies, resp, groupNames, err := b.Login(ctx, req, username, password, "")
 	if err != nil || (resp != nil && resp.IsError()) {
 		return resp, err

--- a/builtin/credential/okta/path_login.go
+++ b/builtin/credential/okta/path_login.go
@@ -116,14 +116,14 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 func (b *backend) pathLoginRenew(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	username := req.Auth.Metadata["username"]
 	password := req.Auth.InternalData["password"].(string)
-	totp := d.Get("totp").(string)
 
 	cfg, err := b.getConfig(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
-	loginPolicies, resp, groupNames, err := b.Login(ctx, req, username, password, totp)
+	// No TOTP entry is possible on renew. If push MFA is enabled it will still be triggered, however.
+	loginPolicies, resp, groupNames, err := b.Login(ctx, req, username, password, "")
 	if err != nil || (resp != nil && resp.IsError()) {
 		return resp, err
 	}

--- a/changelog/10942.txt
+++ b/changelog/10942.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/okta: Adds support for Okta Verify TOTP MFA.
+```

--- a/website/content/api-docs/auth/okta.mdx
+++ b/website/content/api-docs/auth/okta.mdx
@@ -352,6 +352,7 @@ Login with the username and password.
 
 - `username` `(string: <required>)` - Username for this user.
 - `password` `(string: <required>)` - Password for the authenticating user.
+- `totp` `(string: <optional>)` - Okta Verify TOTP passcode.
 
 ### Sample Payload
 

--- a/website/content/docs/auth/okta.mdx
+++ b/website/content/docs/auth/okta.mdx
@@ -52,6 +52,21 @@ The response will contain a token at `auth.client_token`:
 }
 ```
 
+### MFA
+
+Okta Verify Push and TOTP MFA methods are supported during login. For TOTP, the current
+passcode may be provided via the `totp` parameter:
+
+```shell-session
+$ vault login -method=okta username=my-username totp=123456
+```
+
+If `totp` is not set and MFA Push is configured in Okta, a Push will be sent during login.
+
+Note that this MFA support is integrated with Okta Auth and is limited strictly to login
+operations. It is not related to [Enterprise MFA](https://www.vaultproject.io/docs/enterprise/mfa).
+
+
 ## Configuration
 
 Auth methods must be configured in advance before users or machines can


### PR DESCRIPTION
Okta Verify Push is currently supported. This PR adds support for the TOTP method, via an optional login parameter.