### PR TITLE
Create raft test clusters faster

### DIFF
--- a/helper/testhelpers/teststorage/teststorage.go
+++ b/helper/testhelpers/teststorage/teststorage.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/helper/testhelpers"
@@ -99,7 +98,7 @@ func MakeRaftBackendWithConf(t testing.T, coreIdx int, logger hclog.Logger, extr
 	conf := map[string]string{
 		"path":                   raftDir,
 		"node_id":                nodeID,
-		"performance_multiplier": "8",
+		"performance_multiplier": "1",
 	}
 	for k, v := range extraConf {
 		conf[k] = v
@@ -194,7 +193,6 @@ func RaftBackendSetup(conf *vault.CoreConfig, opts *vault.TestClusterOptions) {
 	opts.SetupFunc = func(t testing.T, c *vault.TestCluster) {
 		if opts.NumCores != 1 {
 			testhelpers.RaftClusterJoinNodes(t, c)
-			time.Sleep(15 * time.Second)
 		}
 	}
 }

--- a/vault/ha.go
+++ b/vault/ha.go
@@ -697,9 +697,11 @@ func (c *Core) periodicLeaderRefresh(newLeaderCh chan func(), stopCh chan struct
 	opCount := new(int32)
 
 	clusterAddr := ""
+	interval := 100 * time.Millisecond
 	for {
 		select {
-		case <-time.After(leaderCheckInterval):
+		case <-time.After(interval):
+			interval = leaderCheckInterval
 			count := atomic.AddInt32(opCount, 1)
 			if count > 1 {
 				atomic.AddInt32(opCount, -1)


### PR DESCRIPTION
Three changes that make creating a multi-node raft cluster in a test much faster:

1. Use a faster performance multiplier.  We've already discussed this and probably don't want to merge this change unless we make it conditional on not running in CI, where using it will likely provoke more spurious failures.
2. Remove apparently unnecessary post-join sleep.  This one probably makes sense to merge, I suspect the sleep isn't needed anymore (or where it is needed it should be replaced with WaitForActiveNodeAndStandbys).
3.  Do first standby check for leader sooner.  Maybe mergeable?