### PR TITLE
Adds "raw(/pem)" format to individual cert routes closes #10947

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -71,6 +71,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathFetchCAChain(&b),
 			pathFetchCRL(&b),
 			pathFetchCRLViaCertPath(&b),
+			pathFetchValidRaw(&b),
 			pathFetchValid(&b),
 			pathFetchListCerts(&b),
 			pathRevoke(&b),


### PR DESCRIPTION
Similar to "/pki/ca(/pem)" routes to retrieve
certificates in raw or pem formats, this adds
"pki/cert/{serial}/raw(/pem)" routes for any
certificate.