### PR TITLE
UI/add usage metrics description

### DIFF
--- a/changelog/10951.txt
+++ b/changelog/10951.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Clarify language on usage metrics page empty state
+```

--- a/ui/app/templates/vault/cluster/metrics/index.hbs
+++ b/ui/app/templates/vault/cluster/metrics/index.hbs
@@ -41,7 +41,7 @@
 
 {{#if (eq model.config.queriesAvailable false)}}
   {{#if (eq model.config.enabled "On")}}
-    <EmptyState @title="No data is being received" @message='We haven\'t yet gathered enough data to display here. We collect it at the end of each month, so your data will be available on the first of next month.. It will include the current namespace and all its children.' />
+    <EmptyState @title="No data is being received" @message="We haven't yet gathered enough data to display here. We collect it at the end of each month, so your data will be available on the first of next month.. It will include the current namespace and all its children." />
   {{else}}
     <EmptyState @title="No data is being received" @message='Tracking is disabled, and no data is being collected. To turn it on, edit the configuration.'>
       <p>{{#link-to 'vault.cluster.metrics.config'}}Go to configuration{{/link-to}}</p>

--- a/ui/app/templates/vault/cluster/metrics/index.hbs
+++ b/ui/app/templates/vault/cluster/metrics/index.hbs
@@ -41,7 +41,7 @@
 
 {{#if (eq model.config.queriesAvailable false)}}
   {{#if (eq model.config.enabled "On")}}
-    <EmptyState @title="No data is being received" @message="We haven't yet gathered enough data to display here. We collect it at the end of each month, so your data will be available on the first of next month.. It will include the current namespace and all its children." />
+    <EmptyState @title="No data is being received" @message="We haven't yet gathered enough data to display here. We collect it at the end of each month, so your data will be available on the first of next month. It will include the current namespace and all its children." />
   {{else}}
     <EmptyState @title="No data is being received" @message='Tracking is disabled, and no data is being collected. To turn it on, edit the configuration.'>
       <p>{{#link-to 'vault.cluster.metrics.config'}}Go to configuration{{/link-to}}</p>

--- a/ui/app/templates/vault/cluster/metrics/index.hbs
+++ b/ui/app/templates/vault/cluster/metrics/index.hbs
@@ -39,12 +39,9 @@
   </nav>
 </div>
 
-<div class="box is-fullwidth is-shadowless">
-The active clients metric contributes to billing. It is collected at the end of each month alongside unique entities and direct active tokens. The data below includes the current namespace and all its children.
-</div>
 {{#if (eq model.config.queriesAvailable false)}}
   {{#if (eq model.config.enabled "On")}}
-    <EmptyState @title="No data is being received" @message='We haven’t yet gathered enough data to display here. We collect it at the end of each month, so your data will be available on the first of next month.' />
+    <EmptyState @title="No data is being received" @message='We haven\'t yet gathered enough data to display here. We collect it at the end of each month, so your data will be available on the first of next month.. It will include the current namespace and all its children.' />
   {{else}}
     <EmptyState @title="No data is being received" @message='Tracking is disabled, and no data is being collected. To turn it on, edit the configuration.'>
       <p>{{#link-to 'vault.cluster.metrics.config'}}Go to configuration{{/link-to}}</p>

--- a/ui/app/templates/vault/cluster/metrics/index.hbs
+++ b/ui/app/templates/vault/cluster/metrics/index.hbs
@@ -39,6 +39,9 @@
   </nav>
 </div>
 
+<div class="box is-fullwidth is-shadowless">
+The active clients metric contributes to billing. It is collected at the end of each month alongside unique entities and direct active tokens. The data below includes the current namespace and all its children.
+</div>
 {{#if (eq model.config.queriesAvailable false)}}
   {{#if (eq model.config.enabled "On")}}
     <EmptyState @title="No data is being received" @message='We haven’t yet gathered enough data to display here. We collect it at the end of each month, so your data will be available on the first of next month.' />


### PR DESCRIPTION
Clarify the language in the usage metrics empty state to reflect the fact that all child namespaces are included in the numbers. The regular dashboard with metrics already has such language. 

<img width="1158" alt="no-data-description" src="https://user-images.githubusercontent.com/16182107/108561356-bb360180-72c3-11eb-957a-bf146247e650.png">
