### PR TITLE
update docs related to OCI alias changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ BUG FIXES:
 * api/sys/config/ui: Fixes issue where multiple UI custom header values are ignored and only the first given value is used [[GH-10490](https://github.com/hashicorp/vault/pull/10490)]
 * api: Fixes CORS API methods that were outdated and invalid [[GH-10444](https://github.com/hashicorp/vault/pull/10444)]
 * auth/jwt: Fixes `bound_claims` validation for provider-specific group and user info fetching. [[GH-10546](https://github.com/hashicorp/vault/pull/10546)]
-* auth/oci: Fixes alias name to use the role name, and not the literal string `name` [[GH-10](https://github.com/hashicorp/vault-plugin-auth-oci/pull/10)]
 * core (enterprise): Limit entropy augmentation during token generation to root tokens. [[GH-10487](https://github.com/hashicorp/vault/pull/10487)]
 * core (enterprise): Vault EGP policies attached to path * were not correctly scoped to the namespace.
 * core: Avoid deadlocks by ensuring that if grabLockOrStop returns stopped=true, the lock will not be held. [[GH-10456](https://github.com/hashicorp/vault/pull/10456)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ BUG FIXES:
 * api/sys/config/ui: Fixes issue where multiple UI custom header values are ignored and only the first given value is used [[GH-10490](https://github.com/hashicorp/vault/pull/10490)]
 * api: Fixes CORS API methods that were outdated and invalid [[GH-10444](https://github.com/hashicorp/vault/pull/10444)]
 * auth/jwt: Fixes `bound_claims` validation for provider-specific group and user info fetching. [[GH-10546](https://github.com/hashicorp/vault/pull/10546)]
+* auth/oci: Fixes alias name to use the role name, and not the literal string `name` [[GH-10](https://github.com/hashicorp/vault-plugin-auth-oci/pull/10)]
 * core (enterprise): Limit entropy augmentation during token generation to root tokens. [[GH-10487](https://github.com/hashicorp/vault/pull/10487)]
 * core (enterprise): Vault EGP policies attached to path * were not correctly scoped to the namespace.
 * core: Avoid deadlocks by ensuring that if grabLockOrStop returns stopped=true, the lock will not be held. [[GH-10456](https://github.com/hashicorp/vault/pull/10456)]

--- a/changelog/10952.txt
+++ b/changelog/10952.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/oci: Fixes alias name to use the role name, and not the literal string `name` [[GH-10](https://github.com/hashicorp/vault-plugin-auth-oci/pull/10)]
+```

--- a/website/content/docs/secrets/identity.mdx
+++ b/website/content/docs/secrets/identity.mdx
@@ -101,7 +101,7 @@ a particular auth mount point.
 | Kerberos    | Username                                      |
 | Kubernetes  | Service account UID                           |
 | LDAP        | Username                                      |
-| OCI         | Constant “name” (_This is a bug in current version_) |
+| OCI         | Role name                                     |
 | Okta        | Username                                      |
 | RADIUS      | Username                                      |
 | TLS Certificate | Subject CommonName                        |


### PR DESCRIPTION
https://github.com/hashicorp/vault-plugin-auth-oci/pull/10 fixed an issue where the OCI login would use the alias `name` literally. It now will use the role name.

This PR updates the documentation and changelog. It does *not* update `go.mod` to pull in the OCI changes; that comes in the next release. 