### PR TITLE
Add IAM tagging support for iam_user roles in AWS secret engine

### DIFF
--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -1444,8 +1444,8 @@ func TestBackend_iamTagsCrud(t *testing.T) {
 		LogicalBackend: getBackend(t),
 		Steps: []logicaltest.TestStep{
 			testAccStepConfig(t),
-			testAccStepWriteIamTags(t, "test", map[string]string{"key1":"value1", "key2":"value2"}),
-			testAccStepReadIamTags(t, "test", map[string]string{"key1":"value1", "key2":"value2"}),
+			testAccStepWriteIamTags(t, "test", map[string]string{"key1": "value1", "key2": "value2"}),
+			testAccStepReadIamTags(t, "test", map[string]string{"key1": "value1", "key2": "value2"}),
 			testAccStepDeletePolicy(t, "test"),
 			testAccStepReadIamTags(t, "test", map[string]string{}),
 		},
@@ -1473,7 +1473,7 @@ func testAccStepReadIamTags(t *testing.T, name string, tags map[string]string) l
 					return nil
 				}
 
-				return fmt.Errorf("bad: %#v", resp)
+				return fmt.Errorf("vault response not received")
 			}
 
 			expected := map[string]interface{}{

--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -1438,7 +1438,6 @@ func testAccStepReadIamGroups(t *testing.T, name string, groups []string) logica
 }
 
 func TestBackend_iamTagsCrud(t *testing.T) {
-	t.Parallel()
 	logicaltest.Test(t, logicaltest.TestCase{
 		AcceptanceTest: true,
 		LogicalBackend: getBackend(t),

--- a/builtin/logical/aws/path_roles.go
+++ b/builtin/logical/aws/path_roles.go
@@ -313,7 +313,6 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	}
 
 	if iamTags, ok := d.GetOk("iam_tags"); ok {
-
 		roleEntry.IAMTags = iamTags.(map[string]string)
 	}
 

--- a/builtin/logical/aws/path_roles.go
+++ b/builtin/logical/aws/path_roles.go
@@ -93,6 +93,17 @@ and policy_arns parameters.`,
 				},
 			},
 
+			"iam_tags": &framework.FieldSchema{
+				Type: framework.TypeKVPairs,
+				Description: `IAM tags to be set for any users created by this role. These must be presented
+as Key-Value pairs. This can be represented as a map or a list of equal sign
+delimited key pairs.`,
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name:  "IAM Tags",
+					Value: "[key1=value1, key2=value2]",
+				},
+			},
+
 			"default_sts_ttl": &framework.FieldSchema{
 				Type:        framework.TypeDurationSecond,
 				Description: fmt.Sprintf("Default TTL for %s and %s credential types when no TTL is explicitly requested with the credentials", assumedRoleCred, federationTokenCred),
@@ -301,6 +312,11 @@ func (b *backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 		roleEntry.IAMGroups = iamGroups.([]string)
 	}
 
+	if iamTags, ok := d.GetOk("iam_tags"); ok {
+
+		roleEntry.IAMTags = iamTags.(map[string]string)
+	}
+
 	if legacyRole != "" {
 		roleEntry = upgradeLegacyPolicyEntry(legacyRole)
 		if roleEntry.InvalidData != "" {
@@ -481,18 +497,19 @@ func setAwsRole(ctx context.Context, s logical.Storage, roleName string, roleEnt
 }
 
 type awsRoleEntry struct {
-	CredentialTypes          []string      `json:"credential_types"`                      // Entries must all be in the set of ("iam_user", "assumed_role", "federation_token")
-	PolicyArns               []string      `json:"policy_arns"`                           // ARNs of managed policies to attach to an IAM user
-	RoleArns                 []string      `json:"role_arns"`                             // ARNs of roles to assume for AssumedRole credentials
-	PolicyDocument           string        `json:"policy_document"`                       // JSON-serialized inline policy to attach to IAM users and/or to specify as the Policy parameter in AssumeRole calls
-	IAMGroups                []string      `json:"iam_groups"`                            // Names of IAM groups that generated IAM users will be added to
-	InvalidData              string        `json:"invalid_data,omitempty"`                // Invalid role data. Exists to support converting the legacy role data into the new format
-	ProhibitFlexibleCredPath bool          `json:"prohibit_flexible_cred_path,omitempty"` // Disallow accessing STS credentials via the creds path and vice verse
-	Version                  int           `json:"version"`                               // Version number of the role format
-	DefaultSTSTTL            time.Duration `json:"default_sts_ttl"`                       // Default TTL for STS credentials
-	MaxSTSTTL                time.Duration `json:"max_sts_ttl"`                           // Max allowed TTL for STS credentials
-	UserPath                 string        `json:"user_path"`                             // The path for the IAM user when using "iam_user" credential type
-	PermissionsBoundaryARN   string        `json:"permissions_boundary_arn"`              // ARN of an IAM policy to attach as a permissions boundary
+	CredentialTypes          []string          `json:"credential_types"`                      // Entries must all be in the set of ("iam_user", "assumed_role", "federation_token")
+	PolicyArns               []string          `json:"policy_arns"`                           // ARNs of managed policies to attach to an IAM user
+	RoleArns                 []string          `json:"role_arns"`                             // ARNs of roles to assume for AssumedRole credentials
+	PolicyDocument           string            `json:"policy_document"`                       // JSON-serialized inline policy to attach to IAM users and/or to specify as the Policy parameter in AssumeRole calls
+	IAMGroups                []string          `json:"iam_groups"`                            // Names of IAM groups that generated IAM users will be added to
+	IAMTags                  map[string]string `json:"iam_tags"`                              // IAM tags that will be added to the generated IAM users
+	InvalidData              string            `json:"invalid_data,omitempty"`                // Invalid role data. Exists to support converting the legacy role data into the new format
+	ProhibitFlexibleCredPath bool              `json:"prohibit_flexible_cred_path,omitempty"` // Disallow accessing STS credentials via the creds path and vice verse
+	Version                  int               `json:"version"`                               // Version number of the role format
+	DefaultSTSTTL            time.Duration     `json:"default_sts_ttl"`                       // Default TTL for STS credentials
+	MaxSTSTTL                time.Duration     `json:"max_sts_ttl"`                           // Max allowed TTL for STS credentials
+	UserPath                 string            `json:"user_path"`                             // The path for the IAM user when using "iam_user" credential type
+	PermissionsBoundaryARN   string            `json:"permissions_boundary_arn"`              // ARN of an IAM policy to attach as a permissions boundary
 }
 
 func (r *awsRoleEntry) toResponseData() map[string]interface{} {
@@ -502,6 +519,7 @@ func (r *awsRoleEntry) toResponseData() map[string]interface{} {
 		"role_arns":                r.RoleArns,
 		"policy_document":          r.PolicyDocument,
 		"iam_groups":               r.IAMGroups,
+		"iam_tags":                 r.IAMTags,
 		"default_sts_ttl":          int64(r.DefaultSTSTTL.Seconds()),
 		"max_sts_ttl":              int64(r.MaxSTSTTL.Seconds()),
 		"user_path":                r.UserPath,

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -288,16 +288,16 @@ func (b *backend) secretAccessKeysCreate(
 		}
 	}
 
-	if len(role.IAMTags) > 0 {
-		var tags []*iam.Tag
-		for key, value := range role.IAMTags {
-			// This assignment needs to be done in order to create unique addresses for
-			// these variables. Without doing so, all the tags will be copies of the last
-			// tag listed in the role.
-			k, v := key, value
-			tags = append(tags, &iam.Tag{Key: &k, Value: &v})
-		}
+	var tags []*iam.Tag
+	for key, value := range role.IAMTags {
+		// This assignment needs to be done in order to create unique addresses for
+		// these variables. Without doing so, all the tags will be copies of the last
+		// tag listed in the role.
+		k, v := key, value
+		tags = append(tags, &iam.Tag{Key: &k, Value: &v})
+	}
 
+	if len(tags) > 0 {
 		_, err = iamClient.TagUser(&iam.TagUserInput{
 			Tags:     tags,
 			UserName: &username,

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -3,12 +3,13 @@ package aws
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/awsutil"
-	"github.com/hashicorp/vault/sdk/logical"
 	"math/rand"
 	"regexp"
 	"time"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/awsutil"
+	"github.com/hashicorp/vault/sdk/logical"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -290,12 +291,15 @@ func (b *backend) secretAccessKeysCreate(
 	if len(role.IAMTags) > 0 {
 		var tags []*iam.Tag
 		for key, value := range role.IAMTags {
+			// This assignment needs to be done in order to create unique addresses for
+			// these variables. Without doing so, all the tags will be copies of the last
+			// tag listed in the role.
 			k, v := key, value
 			tags = append(tags, &iam.Tag{Key: &k, Value: &v})
 		}
 
 		_, err = iamClient.TagUser(&iam.TagUserInput{
-			Tags: tags,
+			Tags:     tags,
 			UserName: &username,
 		})
 

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -261,6 +261,12 @@ updated with the new attributes.
   policies from each group in `iam_groups` combined with the `policy_document`
   and `policy_arns` parameters.
 
+- `iam_tags` `(list: [])` - A list of strings representing a key/value pair to be used as a
+  tag for any `iam_user` user that is created by this role. Format is a key and value
+  separated by an `=` (e.g. `test_key=value`). Note: when using the CLI multiple tags
+  can be specified in the role configuration by adding another `iam_tags` assignment
+  in the same command.
+
 - `default_sts_ttl` `(string)` - The default TTL for STS credentials. When a TTL is not
   specified when STS credentials are requested, and a default TTL is specified
   on the role, then this default TTL will be used. Valid only when
@@ -327,6 +333,22 @@ Using groups:
   "credential_type": "assumed_role",
   "iam_groups": ["group1", "group2"]
 }
+```
+
+Using tags:
+```json
+{
+  "credential_type": "iam_user",
+  "iam_tags": ["first_key=first_value", "second_key=second_value"]
+}
+```
+
+Using tags with CLI:
+```bash
+vault write aws/roles/example-role \
+credential_type=iam_user \
+iam_tags="first_key=first_value" \
+iam_tags="second_key=second_value" \
 ```
 
 ## Read Role

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -336,20 +336,47 @@ Using groups:
 ```
 
 Using tags:
-```json
-{
-  "credential_type": "iam_user",
-  "iam_tags": ["first_key=first_value", "second_key=second_value"]
-}
-```
-
-Using tags with CLI:
-```bash
-vault write aws/roles/example-role \
-credential_type=iam_user \
-iam_tags="first_key=first_value" \
-iam_tags="second_key=second_value" \
-```
+<Tabs>
+  <Tab heading="cURL">
+    ```json
+    {
+      "credential_type": "iam_user",
+      "iam_tags": [
+        "first_key=first_value",
+        "second_key=second_value"
+      ]
+    }
+    ```
+    or
+    ```json
+    {
+      "credential_type": "iam_user",
+      "iam_tags": {
+        "first_key": "first_value",
+        "second_key": "second_value"
+      }
+    }
+    ```
+  </Tab>
+  <Tab heading="CLI">
+    ```bash
+      vault write aws/roles/example-role \
+      credential_type=iam_user \
+      iam_tags="first_key=first_value" \
+      iam_tags="second_key=second_value" \
+    ```
+    or
+    ```bash
+      vault write aws/roles/example-role \
+      credential_type=iam_user \
+      iam_tags=@test.json
+    ```
+    where test.json is
+    ```json
+    ["tag1=42", "tag2=something"]
+    ```
+  </Tab>
+</Tabs>
 
 ## Read Role
 


### PR DESCRIPTION
This PR seeks to introduce the ability to add tags to user credentials generated by the AWS secret engine.

Details in  usage are provided in the docs that have been updated with this feature, however, for ease of use, the following is an example of adding two tags to a role:
```
vault write aws/roles/my-role \
credential_type=iam_user \
iam_tags=test_key=test_value \
iam_tags=test_key2=test_value2 \
policy_document=-<<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": "ec2:*",
      "Resource": "*"
    }
  ]
}
EOF
```