### PR TITLE
Add configurable exponential backoff to Agent auto-auth

### DIFF
--- a/changelog/10964.txt
+++ b/changelog/10964.txt
@@ -1,0 +1,5 @@
+```release-note:changes
+agent: Failed auto-auth attempts are now throttled by an exponential backoff instead of the
+~2 second retry delay. The maximum backoff may be configured with the new `max_backoff` parameter,
+which defaults to 5 minutes.
+```

--- a/command/agent.go
+++ b/command/agent.go
@@ -575,6 +575,7 @@ func (c *AgentCommand) Run(args []string) int {
 			Logger:                       c.logger.Named("auth.handler"),
 			Client:                       c.client,
 			WrapTTL:                      config.AutoAuth.Method.WrapTTL,
+			MaxBackoff:                   config.AutoAuth.Method.MaxBackoff,
 			EnableReauthOnNewCredentials: config.AutoAuth.EnableReauthOnNewCredentials,
 			EnableTemplateTokenCh:        enableTokenCh,
 		})

--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	initialBackoff    = 1 * time.Second
-	defaultMaxBackoff = 1 * time.Minute
+	defaultMaxBackoff = 5 * time.Minute
 )
 
 // AuthMethod is the interface that auto-auth methods implement for the agent

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -62,12 +62,14 @@ type AutoAuth struct {
 
 // Method represents the configuration for the authentication backend
 type Method struct {
-	Type       string
-	MountPath  string        `hcl:"mount_path"`
-	WrapTTLRaw interface{}   `hcl:"wrap_ttl"`
-	WrapTTL    time.Duration `hcl:"-"`
-	Namespace  string        `hcl:"namespace"`
-	Config     map[string]interface{}
+	Type          string
+	MountPath     string        `hcl:"mount_path"`
+	WrapTTLRaw    interface{}   `hcl:"wrap_ttl"`
+	WrapTTL       time.Duration `hcl:"-"`
+	MaxBackoffRaw interface{}   `hcl:"max_backoff"`
+	MaxBackoff    time.Duration `hcl:"-"`
+	Namespace     string        `hcl:"namespace"`
+	Config        map[string]interface{}
 }
 
 // Sink defines a location to write the authenticated token
@@ -356,6 +358,14 @@ func parseAutoAuth(result *Config, list *ast.ObjectList) error {
 		if result.AutoAuth.Sinks[0].WrapTTL > 0 {
 			return fmt.Errorf("error parsing auto_auth: wrapping enabled both on auth method and sink")
 		}
+	}
+
+	if result.AutoAuth.Method.MaxBackoffRaw != nil {
+		var err error
+		if result.AutoAuth.Method.MaxBackoff, err = parseutil.ParseDurationSecond(result.AutoAuth.Method.MaxBackoffRaw); err != nil {
+			return err
+		}
+		result.AutoAuth.Method.MaxBackoffRaw = nil
 	}
 
 	return nil

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -126,6 +126,7 @@ func TestLoadConfigFile(t *testing.T) {
 				Config: map[string]interface{}{
 					"role": "foobar",
 				},
+				MaxBackoff: 0,
 			},
 			Sinks: []*Sink{
 				{
@@ -178,9 +179,10 @@ func TestLoadConfigFile_Method_Wrapping(t *testing.T) {
 		},
 		AutoAuth: &AutoAuth{
 			Method: &Method{
-				Type:      "aws",
-				MountPath: "auth/aws",
-				WrapTTL:   5 * time.Minute,
+				Type:       "aws",
+				MountPath:  "auth/aws",
+				WrapTTL:    5 * time.Minute,
+				MaxBackoff: 2 * time.Minute,
 				Config: map[string]interface{}{
 					"role": "foobar",
 				},

--- a/command/agent/config/test-fixtures/config-method-wrapping.hcl
+++ b/command/agent/config/test-fixtures/config-method-wrapping.hcl
@@ -7,6 +7,7 @@ auto_auth {
 		config = {
 			role = "foobar"
 		}
+		max_backoff = "2m"
 	}
 
 	sink {

--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -20,9 +20,8 @@ are locations where the agent should write a token any time the current token
 value has changed.
 
 When the agent is started with Auto-Auth enabled, it will attempt to acquire a
-Vault token using the configured Method. On failure, it will back off for a
-short while (including some randomness to help prevent thundering herd
-scenarios) and retry. On success, unless the auth method is configured to wrap
+Vault token using the configured Method. On failure, it will exponentially back
+off and then retry. On success, unless the auth method is configured to wrap
 the tokens, it will keep the resulting token renewed until renewal is no longer
 allowed or fails, at which point it will attempt to reauthenticate.
 
@@ -127,6 +126,10 @@ These are common configuration values that live within the `method` block:
   [SecretWrapInfo](https://godoc.org/github.com/hashicorp/vault/api#SecretWrapInfo)
   structure. Values can be an integer number of seconds or a stringish value
   like `5m`.
+
+- `max_backoff` `(string or integer: "5m")` - The maximum time Agent will delay
+  before retrying after a failed auth attempt. The backoff will start at 1 second
+  and double (with some randomness) after successive failures, capped by `max_backoff.`
 
 - `config` `(object: required)` - Configuration of the method itself. See the
   sidebar for information about each method.


### PR DESCRIPTION
The existing Agent auto-auth retry delay simply dithers between 1-3s. If Agents continually fail to auth, they should exponentially back off. This PR does that, with a default max delay of 60s. That value is configurable via a new `max_backoff` auto-auth method configuration parameter.