### PR TITLE
Update vault/api version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.2.0
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.1.6-0.20210201204049-4f0f91977798
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.1.0
-	github.com/hashicorp/vault/api v1.0.5-0.20201001211907-38d91b749c77
+	github.com/hashicorp/vault/api v1.0.5-0.20210210214158-405eced08457
 	github.com/hashicorp/vault/sdk v0.1.14-0.20210127185906-6b455835fa8c
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4
 	github.com/jcmturner/gokrb5/v8 v8.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -596,7 +596,7 @@ github.com/hashicorp/vault-plugin-secrets-openldap
 github.com/hashicorp/vault-plugin-secrets-openldap/client
 # github.com/hashicorp/vault-plugin-secrets-terraform v0.1.0
 github.com/hashicorp/vault-plugin-secrets-terraform
-# github.com/hashicorp/vault/api v1.0.5-0.20201001211907-38d91b749c77 => ./api
+# github.com/hashicorp/vault/api v1.0.5-0.20210210214158-405eced08457 => ./api
 github.com/hashicorp/vault/api
 # github.com/hashicorp/vault/sdk v0.1.14-0.20210127185906-6b455835fa8c => ./sdk
 github.com/hashicorp/vault/sdk/database/dbplugin


### PR DESCRIPTION
The current vault/api version that is set in `go.mod` points to a version that doesn't exist which makes it impossible to import vault from an external project.

> go: github.com/hashicorp/vault@v1.6.2 requires
	github.com/hashicorp/vault/api@v1.0.5-0.20201001211907-38d91b749c77: invalid version: unknown revision 38d91b749c77