### PR TITLE
Minor update to Secrets engine overview docs

### DIFF
--- a/website/content/docs/secrets/index.mdx
+++ b/website/content/docs/secrets/index.mdx
@@ -9,7 +9,7 @@ description: Secrets engines are mountable engines that store or generate secret
 
 Secrets engines are components which store, generate, or encrypt data. Secrets
 engines are incredibly flexible, so it is easiest to think about them in terms
-of their function. Secrets engines operate by receiving API calls that meet [this interface](https://github.com/hashicorp/vault/blob/061bc8ed2bbed49eb4f54c3a04647fbbefb13e48/sdk/framework/backend.go#L105). The calls receive data from the caller, take some
+of their function. Secrets engines are provided some set of data, they take some
 action on that data, and they return a result.
 
 Some secrets engines simply store and read data - like encrypted


### PR DESCRIPTION
The reference to API calls and link to code isn't a good fit here.

Reverts eb3e34d