### PR TITLE
UI: Show error when connection roles fail to update on role create

### DIFF
--- a/changelog/10980.txt
+++ b/changelog/10980.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: better errors on Database secrets engine role create
+```

--- a/ui/app/adapters/database/role.js
+++ b/ui/app/adapters/database/role.js
@@ -127,11 +127,15 @@ export default ApplicationAdapter.extend({
     const backend = snapshot.attr('backend');
     const id = snapshot.attr('name');
     const db = snapshot.attr('database');
-    await this._updateAllowedRoles(store, {
-      role: id,
-      backend,
-      db: db[0],
-    });
+    try {
+      await this._updateAllowedRoles(store, {
+        role: id,
+        backend,
+        db: db[0],
+      });
+    } catch (e) {
+      throw new Error('Could not update allowed roles for selected database. Check Vault logs for details');
+    }
 
     return this.ajax(this.urlFor(backend, id, roleType), 'POST', { data }).then(() => {
       // ember data doesn't like 204s if it's not a DELETE

--- a/ui/app/components/database-connection.js
+++ b/ui/app/components/database-connection.js
@@ -8,7 +8,7 @@ const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
 
 const getErrorMessage = errors => {
   let errorMessage = errors?.join('. ') || 'Something went wrong. Check the Vault logs for more information.';
-  if (errors?.join(' ').indexOf('failed to verify')) {
+  if (errorMessage.indexOf('failed to verify') >= 0) {
     errorMessage =
       'There was a verification error for this connection. Check the Vault logs for more information.';
   }

--- a/ui/app/components/database-role-edit.js
+++ b/ui/app/components/database-role-edit.js
@@ -80,12 +80,10 @@ export default class DatabaseRoleEdit extends Component {
         }
       })
       .catch(e => {
-        const errorMessage = e.message || e.errors?.join('. ');
+        const errorMessage = e.errors?.join('. ') || e.message;
         this.flashMessages.danger(
           errorMessage || 'Could not save the role. Please check Vault logs for more information.'
         );
-      })
-      .finally(() => {
         this.loading = false;
       });
   }

--- a/ui/app/components/database-role-edit.js
+++ b/ui/app/components/database-role-edit.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 const LIST_ROOT_ROUTE = 'vault.cluster.secrets.backend.list-root';
 const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
@@ -8,6 +9,8 @@ const SHOW_ROUTE = 'vault.cluster.secrets.backend.show';
 export default class DatabaseRoleEdit extends Component {
   @service router;
   @service flashMessages;
+
+  @tracked loading = false;
 
   get warningMessages() {
     let warnings = {};
@@ -55,25 +58,10 @@ export default class DatabaseRoleEdit extends Component {
   }
 
   @action
-  handleCreateRole(evt) {
-    evt.preventDefault();
-    let roleSecret = this.args.model;
-    let secretId = roleSecret.name;
-    roleSecret.set('id', secretId);
-    let path = roleSecret.type === 'static' ? 'static-roles' : 'roles';
-    roleSecret.set('path', path);
-    roleSecret.save().then(() => {
-      try {
-        this.router.transitionTo(SHOW_ROUTE, `role/${secretId}`);
-      } catch (e) {
-        console.debug(e);
-      }
-    });
-  }
-
-  @action
   handleCreateEditRole(evt) {
     evt.preventDefault();
+    this.loading = true;
+
     const mode = this.args.mode;
     let roleSecret = this.args.model;
     let secretId = roleSecret.name;
@@ -82,12 +70,23 @@ export default class DatabaseRoleEdit extends Component {
       let path = roleSecret.type === 'static' ? 'static-roles' : 'roles';
       roleSecret.set('path', path);
     }
-    roleSecret.save().then(() => {
-      try {
-        this.router.transitionTo(SHOW_ROUTE, `role/${secretId}`);
-      } catch (e) {
-        console.debug(e);
-      }
-    });
+    roleSecret
+      .save()
+      .then(() => {
+        try {
+          this.router.transitionTo(SHOW_ROUTE, `role/${secretId}`);
+        } catch (e) {
+          console.debug(e);
+        }
+      })
+      .catch(e => {
+        const errorMessage = e.message || e.errors?.join('. ');
+        this.flashMessages.danger(
+          errorMessage || 'Could not save the role. Please check Vault logs for more information.'
+        );
+      })
+      .finally(() => {
+        this.loading = false;
+      });
   }
 }

--- a/ui/app/templates/components/database-role-edit.hbs
+++ b/ui/app/templates/components/database-role-edit.hbs
@@ -104,8 +104,8 @@
               <button
                 data-test-secret-save
                 type="submit"
-                {{!-- disabled={{this.missingFields}} // TODO validation --}}
-                class="button is-primary"
+                disabled={{this.loading}}
+                class="button is-primary {{if this.loading 'is-loading'}}"
               >
                 Save
               </button>


### PR DESCRIPTION
This PR fixes an issue where the role create action would fail silently if the underlying connection update fails. Steps to reproduce:

1. Create an unverified connection in Database secrets engine with a bad/nonexistent database url
2. Create a role connected to that database
3. On save, the adapter tries to first add the new role name to the database's list of allowed roles. **Before,** this would fail silently. Now, we surface a relevant error about what went wrong. Please note that Vault waits for a response from the bad database url, so the save action takes a long time (magnitude of seconds). I also added a loader on the save button so that it is obvious the request is processing

**Loader appears when save button is clicked**
![save-loader](https://user-images.githubusercontent.com/16182107/108871952-4c0c2600-75bf-11eb-93a4-51fb6d61b6a5.gif)

**Error appears when it fails on the connection update**
<img width="1181" alt="error-handled" src="https://user-images.githubusercontent.com/16182107/108872053-680fc780-75bf-11eb-8cd4-c3dd3f7cd64f.png">


**TODO**
- [x] Check other adapter error surfaces
- [x] Check happy path on connection + role