### PR TITLE
agent: add caching encryption package

### DIFF
--- a/command/agent/cache/crypto/crypto.go
+++ b/command/agent/cache/crypto/crypto.go
@@ -12,7 +12,7 @@ type KeyManager interface {
 	GetKey() []byte
 	GetPersistentKey() []byte
 	Renewable() bool
-	Renewer(context.Context, chan struct{}) error
+	Renewer(context.Context) error
 	Encrypt(context.Context, []byte, []byte) ([]byte, error)
 	Decrypt(context.Context, []byte, []byte) ([]byte, error)
 }

--- a/command/agent/cache/crypto/crypto.go
+++ b/command/agent/cache/crypto/crypto.go
@@ -10,7 +10,7 @@ const (
 
 type KeyManager interface {
 	GetKey() []byte
-	GetPersistentKey() []byte
+	GetPersistentKey() ([]byte, error)
 	Renewable() bool
 	Renewer(context.Context) error
 	Encrypt(context.Context, []byte, []byte) ([]byte, error)

--- a/command/agent/cache/crypto/crypto.go
+++ b/command/agent/cache/crypto/crypto.go
@@ -1,0 +1,18 @@
+package crypto
+
+import (
+	"context"
+)
+
+const (
+	KeyID = "root"
+)
+
+// KeyManager TODO
+type KeyManager interface {
+	Get() []byte
+	Renewable() bool
+	Renewer(context.Context, chan struct{}) error
+	Encrypt(context.Context, []byte, []byte) ([]byte, error)
+	Decrypt(context.Context, []byte, []byte) ([]byte, error)
+}

--- a/command/agent/cache/crypto/crypto.go
+++ b/command/agent/cache/crypto/crypto.go
@@ -8,9 +8,9 @@ const (
 	KeyID = "root"
 )
 
-// KeyManager TODO
 type KeyManager interface {
-	Get() []byte
+	GetKey() []byte
+	GetPersistentKey() []byte
 	Renewable() bool
 	Renewer(context.Context, chan struct{}) error
 	Encrypt(context.Context, []byte, []byte) ([]byte, error)

--- a/command/agent/cache/crypto/k8s.go
+++ b/command/agent/cache/crypto/k8s.go
@@ -58,8 +58,8 @@ func (k *KubeEncryptionKey) GetKey() []byte {
 
 // GetPersistentKey returns the key which should be stored in the persisent
 // cache. In k8s we store the key as is, so just return the key stored.
-func (k *KubeEncryptionKey) GetPersistentKey() []byte {
-	return k.wrapper.GetKeyBytes()
+func (k *KubeEncryptionKey) GetPersistentKey() ([]byte, error) {
+	return k.wrapper.GetKeyBytes(), nil
 }
 
 // Renewable lets the caller know if this encryption key type is

--- a/command/agent/cache/crypto/k8s.go
+++ b/command/agent/cache/crypto/k8s.go
@@ -1,0 +1,91 @@
+package crypto
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+
+	wrapping "github.com/hashicorp/go-kms-wrapping"
+	"github.com/hashicorp/go-kms-wrapping/wrappers/aead"
+)
+
+var _ KeyManager = (*KubeEncryptionKey)(nil)
+
+// KubeEncryptionKey TODO
+type KubeEncryptionKey struct {
+	renewable bool
+	wrapper   *aead.Wrapper
+}
+
+// NewK8s returns a new instance of the Kube encryption key. Kubernetes
+// encryption keys aren't renewable.
+func NewK8s(existingKey []byte) (*KubeEncryptionKey, error) {
+	k := &KubeEncryptionKey{
+		renewable: false,
+		wrapper:   aead.NewWrapper(nil),
+	}
+
+	k.wrapper.SetConfig(map[string]string{"key_id": KeyID})
+
+	var rootKey []byte = nil
+	if len(existingKey) != 0 {
+		if len(existingKey) != 32 {
+			return k, fmt.Errorf("invalid key size, should be 32, got %d", len(existingKey))
+		}
+		rootKey = existingKey
+	}
+
+	if rootKey == nil {
+		newKey := make([]byte, 32)
+		_, err := rand.Read(newKey)
+		if err != nil {
+			return k, err
+		}
+		rootKey = newKey
+	}
+
+	if err := k.wrapper.SetAESGCMKeyBytes(rootKey); err != nil {
+		return k, err
+	}
+
+	return k, nil
+}
+
+// Get returns the encryption key in a format optimized for storage.
+// In k8s we store the key as is, so just return the key stored.
+func (k *KubeEncryptionKey) Get() []byte {
+	return k.wrapper.GetKeyBytes()
+}
+
+// Renewable lets the caller know if this encryption key type is
+// renewable. In Kubernetes the key isn't renewable.
+func (k *KubeEncryptionKey) Renewable() bool {
+	return k.renewable
+}
+
+// Renewer is used when the encryption key type is renewable. Since Kubernetes
+// keys aren't renewable, returning nothing.
+func (k *KubeEncryptionKey) Renewer(ctx context.Context, ch chan struct{}) error {
+	return nil
+}
+
+// Encrypt takes plaintext values and encrypts them using the store key and additional
+// data. The ciphertext and nonce are returned and should be used for decryption.
+func (k *KubeEncryptionKey) Encrypt(ctx context.Context, plaintext, aad []byte) ([]byte, error) {
+	blob, err := k.wrapper.Encrypt(ctx, plaintext, aad)
+	if err != nil {
+		return nil, err
+	}
+	return blob.Ciphertext, nil
+}
+
+// Decrypt takes ciphertext and nonce values and returns the decrypted value.
+func (k *KubeEncryptionKey) Decrypt(ctx context.Context, ciphertext, aad []byte) ([]byte, error) {
+	blob := &wrapping.EncryptedBlobInfo{
+		Ciphertext: ciphertext,
+		KeyInfo: &wrapping.KeyInfo{
+			KeyID: KeyID,
+		},
+	}
+	return k.wrapper.Decrypt(ctx, blob, aad)
+}

--- a/command/agent/cache/crypto/k8s.go
+++ b/command/agent/cache/crypto/k8s.go
@@ -11,7 +11,6 @@ import (
 
 var _ KeyManager = (*KubeEncryptionKey)(nil)
 
-// KubeEncryptionKey TODO
 type KubeEncryptionKey struct {
 	renewable bool
 	wrapper   *aead.Wrapper
@@ -70,7 +69,7 @@ func (k *KubeEncryptionKey) Renewer(ctx context.Context, ch chan struct{}) error
 }
 
 // Encrypt takes plaintext values and encrypts them using the store key and additional
-// data. The ciphertext and nonce are returned and should be used for decryption.
+// data. For Kubernetes the AAD should be the service account JWT.
 func (k *KubeEncryptionKey) Encrypt(ctx context.Context, plaintext, aad []byte) ([]byte, error) {
 	blob, err := k.wrapper.Encrypt(ctx, plaintext, aad)
 	if err != nil {
@@ -79,7 +78,8 @@ func (k *KubeEncryptionKey) Encrypt(ctx context.Context, plaintext, aad []byte) 
 	return blob.Ciphertext, nil
 }
 
-// Decrypt takes ciphertext and nonce values and returns the decrypted value.
+// Decrypt takes ciphertext and AAD values and returns the decrypted value. For Kubernetes the AAD
+// should be the service account JWT.
 func (k *KubeEncryptionKey) Decrypt(ctx context.Context, ciphertext, aad []byte) ([]byte, error) {
 	blob := &wrapping.EncryptedBlobInfo{
 		Ciphertext: ciphertext,

--- a/command/agent/cache/crypto/k8s.go
+++ b/command/agent/cache/crypto/k8s.go
@@ -70,7 +70,7 @@ func (k *KubeEncryptionKey) Renewable() bool {
 
 // Renewer is used when the encryption key type is renewable. Since Kubernetes
 // keys aren't renewable, returning nothing.
-func (k *KubeEncryptionKey) Renewer(ctx context.Context, ch chan struct{}) error {
+func (k *KubeEncryptionKey) Renewer(ctx context.Context) error {
 	return nil
 }
 

--- a/command/agent/cache/crypto/k8s.go
+++ b/command/agent/cache/crypto/k8s.go
@@ -50,9 +50,15 @@ func NewK8s(existingKey []byte) (*KubeEncryptionKey, error) {
 	return k, nil
 }
 
-// Get returns the encryption key in a format optimized for storage.
+// GetKey returns the encryption key in a format optimized for storage.
 // In k8s we store the key as is, so just return the key stored.
-func (k *KubeEncryptionKey) Get() []byte {
+func (k *KubeEncryptionKey) GetKey() []byte {
+	return k.wrapper.GetKeyBytes()
+}
+
+// GetPersistentKey returns the key which should be stored in the persisent
+// cache. In k8s we store the key as is, so just return the key stored.
+func (k *KubeEncryptionKey) GetPersistentKey() []byte {
 	return k.wrapper.GetKeyBytes()
 }
 

--- a/command/agent/cache/crypto/k8s_test.go
+++ b/command/agent/cache/crypto/k8s_test.go
@@ -17,7 +17,7 @@ func TestCrypto_KubernetesNewKey(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", key))
 	}
 
-	persistentKey := k8sKey.GetPersistentKey()
+	persistentKey, _ := k8sKey.GetPersistentKey()
 	if persistentKey == nil {
 		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", persistentKey))
 	}
@@ -64,7 +64,7 @@ func TestCrypto_KubernetesExistingKey(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", key))
 	}
 
-	persistentKey := k8sKey.GetPersistentKey()
+	persistentKey, _ := k8sKey.GetPersistentKey()
 	if persistentKey == nil {
 		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", persistentKey))
 	}
@@ -122,7 +122,7 @@ func TestCrypto_KubernetesPassGeneratedKey(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
 	}
 
-	loadedKey := k8sLoadedKey.GetPersistentKey()
+	loadedKey, _ := k8sLoadedKey.GetPersistentKey()
 	if loadedKey == nil {
 		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", loadedKey))
 	}

--- a/command/agent/cache/crypto/k8s_test.go
+++ b/command/agent/cache/crypto/k8s_test.go
@@ -1,0 +1,133 @@
+package crypto
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func TestCrypto_KubernetesNewKey(t *testing.T) {
+	k8sKey, err := NewK8s([]byte{})
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
+	}
+
+	key := k8sKey.Get()
+	if key == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", key))
+	}
+
+	plaintextInput := []byte("test")
+	aad := []byte("kubernetes")
+
+	ciphertext, err := k8sKey.Encrypt(nil, plaintextInput, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if ciphertext == nil {
+		t.Fatalf("ciphertext nil, it shouldn't be")
+	}
+
+	plaintext, err := k8sKey.Decrypt(nil, ciphertext, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if string(plaintext) != string(plaintextInput) {
+		t.Fatalf("expected %s, got %s", plaintextInput, plaintext)
+	}
+}
+
+func TestCrypto_KubernetesExistingKey(t *testing.T) {
+	rootKey := make([]byte, 32)
+	n, err := rand.Read(rootKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 32 {
+		t.Fatal(n)
+	}
+
+	k8sKey, err := NewK8s(rootKey)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
+	}
+
+	key := k8sKey.Get()
+	if key == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", key))
+	}
+
+	if string(key) != string(rootKey) {
+		t.Fatalf(fmt.Sprintf("expected keys to be the same, they weren't: expected: %s, got: %s", rootKey, key))
+	}
+
+	plaintextInput := []byte("test")
+	aad := []byte("kubernetes")
+
+	ciphertext, err := k8sKey.Encrypt(nil, plaintextInput, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if ciphertext == nil {
+		t.Fatalf("ciphertext nil, it shouldn't be")
+	}
+
+	plaintext, err := k8sKey.Decrypt(nil, ciphertext, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if string(plaintext) != string(plaintextInput) {
+		t.Fatalf("expected %s, got %s", plaintextInput, plaintext)
+	}
+}
+
+func TestCrypto_KubernetesPassGeneratedKey(t *testing.T) {
+	k8sFirstKey, err := NewK8s([]byte{})
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
+	}
+
+	firstKey := k8sFirstKey.Get()
+	if firstKey == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", firstKey))
+	}
+
+	plaintextInput := []byte("test")
+	aad := []byte("kubernetes")
+
+	ciphertext, err := k8sFirstKey.Encrypt(nil, plaintextInput, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if ciphertext == nil {
+		t.Fatalf("ciphertext nil, it shouldn't be")
+	}
+
+	k8sLoadedKey, err := NewK8s(firstKey)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
+	}
+
+	loadedKey := k8sLoadedKey.Get()
+	if loadedKey == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", loadedKey))
+	}
+
+	if string(loadedKey) != string(firstKey) {
+		t.Fatalf(fmt.Sprintf("keys do not match"))
+	}
+
+	plaintext, err := k8sFirstKey.Decrypt(nil, ciphertext, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if string(plaintext) != string(plaintextInput) {
+		t.Fatalf("expected %s, got %s", plaintextInput, plaintext)
+	}
+}

--- a/command/agent/cache/crypto/k8s_test.go
+++ b/command/agent/cache/crypto/k8s_test.go
@@ -22,6 +22,10 @@ func TestCrypto_KubernetesNewKey(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", persistentKey))
 	}
 
+	if string(key) != string(persistentKey) {
+		t.Fatalf("keys don't match, they should: key: %s, persistentKey: %s", key, persistentKey)
+	}
+
 	plaintextInput := []byte("test")
 	aad := []byte("kubernetes")
 
@@ -64,12 +68,21 @@ func TestCrypto_KubernetesExistingKey(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", key))
 	}
 
+	if string(key) != string(rootKey) {
+		t.Fatalf(fmt.Sprintf("expected keys to be the same, they weren't: expected: %s, got: %s", rootKey, key))
+	}
+
 	persistentKey, _ := k8sKey.GetPersistentKey()
 	if persistentKey == nil {
-		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", persistentKey))
+		t.Fatalf("key is nil, it shouldn't be")
 	}
+
 	if string(persistentKey) != string(rootKey) {
-		t.Fatalf(fmt.Sprintf("expected keys to be the same, they weren't: expected: %s, got: %s", rootKey, key))
+		t.Fatalf(fmt.Sprintf("expected keys to be the same, they weren't: expected: %s, got: %s", rootKey, persistentKey))
+	}
+
+	if string(key) != string(persistentKey) {
+		t.Fatalf(fmt.Sprintf("expected keys to be the same, they weren't: %s %s", rootKey, persistentKey))
 	}
 
 	plaintextInput := []byte("test")
@@ -131,7 +144,7 @@ func TestCrypto_KubernetesPassGeneratedKey(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("keys do not match"))
 	}
 
-	plaintext, err := k8sFirstKey.Decrypt(nil, ciphertext, aad)
+	plaintext, err := k8sLoadedKey.Decrypt(nil, ciphertext, aad)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/command/agent/cache/crypto/k8s_test.go
+++ b/command/agent/cache/crypto/k8s_test.go
@@ -12,9 +12,14 @@ func TestCrypto_KubernetesNewKey(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
 	}
 
-	key := k8sKey.Get()
+	key := k8sKey.GetKey()
 	if key == nil {
 		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", key))
+	}
+
+	persistentKey := k8sKey.GetPersistentKey()
+	if persistentKey == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", persistentKey))
 	}
 
 	plaintextInput := []byte("test")
@@ -54,12 +59,16 @@ func TestCrypto_KubernetesExistingKey(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
 	}
 
-	key := k8sKey.Get()
+	key := k8sKey.GetKey()
 	if key == nil {
 		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", key))
 	}
 
-	if string(key) != string(rootKey) {
+	persistentKey := k8sKey.GetPersistentKey()
+	if persistentKey == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", persistentKey))
+	}
+	if string(persistentKey) != string(rootKey) {
 		t.Fatalf(fmt.Sprintf("expected keys to be the same, they weren't: expected: %s, got: %s", rootKey, key))
 	}
 
@@ -91,9 +100,9 @@ func TestCrypto_KubernetesPassGeneratedKey(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
 	}
 
-	firstKey := k8sFirstKey.Get()
-	if firstKey == nil {
-		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", firstKey))
+	firstPersistentKey := k8sFirstKey.GetKey()
+	if firstPersistentKey == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", firstPersistentKey))
 	}
 
 	plaintextInput := []byte("test")
@@ -108,17 +117,17 @@ func TestCrypto_KubernetesPassGeneratedKey(t *testing.T) {
 		t.Fatalf("ciphertext nil, it shouldn't be")
 	}
 
-	k8sLoadedKey, err := NewK8s(firstKey)
+	k8sLoadedKey, err := NewK8s(firstPersistentKey)
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
 	}
 
-	loadedKey := k8sLoadedKey.Get()
+	loadedKey := k8sLoadedKey.GetPersistentKey()
 	if loadedKey == nil {
 		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", loadedKey))
 	}
 
-	if string(loadedKey) != string(firstKey) {
+	if string(loadedKey) != string(firstPersistentKey) {
 		t.Fatalf(fmt.Sprintf("keys do not match"))
 	}
 


### PR DESCRIPTION
This is a small package that AES encryption/decryption to be used in persistent caching. Currently this only implements a K8s specific use case but will follow up with response wrapping.

The configs to enable this will be added in a different PR relevant to caching persistence.