### PR TITLE
agent: implement response wrapped encryption key

### DIFF
--- a/command/agent/cache/crypto/k8s_test.go
+++ b/command/agent/cache/crypto/k8s_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCrypto_KubernetesNewKey(t *testing.T) {
-	k8sKey, err := NewK8s([]byte{})
+	k8sKey, err := NewKubeEncrypter([]byte{})
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
 	}
@@ -58,7 +58,7 @@ func TestCrypto_KubernetesExistingKey(t *testing.T) {
 		t.Fatal(n)
 	}
 
-	k8sKey, err := NewK8s(rootKey)
+	k8sKey, err := NewKubeEncrypter(rootKey)
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
 	}
@@ -108,7 +108,7 @@ func TestCrypto_KubernetesExistingKey(t *testing.T) {
 }
 
 func TestCrypto_KubernetesPassGeneratedKey(t *testing.T) {
-	k8sFirstKey, err := NewK8s([]byte{})
+	k8sFirstKey, err := NewKubeEncrypter([]byte{})
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
 	}
@@ -130,7 +130,7 @@ func TestCrypto_KubernetesPassGeneratedKey(t *testing.T) {
 		t.Fatalf("ciphertext nil, it shouldn't be")
 	}
 
-	k8sLoadedKey, err := NewK8s(firstPersistentKey)
+	k8sLoadedKey, err := NewKubeEncrypter(firstPersistentKey)
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
 	}

--- a/command/agent/cache/crypto/response.go
+++ b/command/agent/cache/crypto/response.go
@@ -1,0 +1,196 @@
+package crypto
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	mathRand "math/rand"
+	"time"
+
+	wrapping "github.com/hashicorp/go-kms-wrapping"
+	"github.com/hashicorp/go-kms-wrapping/wrappers/aead"
+	"github.com/hashicorp/vault/api"
+)
+
+var _ KeyManager = (*ResponseEncrypter)(nil)
+
+const ResponseWrappedTokenTTL = "60"
+
+// ResponseEncrypter ...
+type ResponseEncrypter struct {
+	renewable bool
+	wrapper   *aead.Wrapper
+	token     []byte
+	ttl       string
+	Client    *api.Client
+	Notify    chan struct{}
+	Stop      chan struct{}
+	Done      chan error
+}
+
+// NewResponseEncrypter ..
+func NewResponseEncrypter(existingToken []byte, client *api.Client, ttl string) (*ResponseEncrypter, error) {
+	if ttl == "" {
+		ttl = ResponseWrappedTokenTTL
+	}
+
+	r := &ResponseEncrypter{
+		renewable: true,
+		wrapper:   aead.NewWrapper(nil),
+		Client:    client,
+		Notify:    make(chan struct{}, 1),
+		Stop:      make(chan struct{}, 1),
+		Done:      make(chan error, 1),
+		ttl:       ttl,
+	}
+	r.wrapper.SetConfig(map[string]string{"key_id": KeyID})
+
+	var rootKey []byte
+	switch tokenLength := len(existingToken); {
+	case tokenLength == 0:
+		newKey := make([]byte, 32)
+		_, err := rand.Read(newKey)
+		if err != nil {
+			return r, err
+		}
+		rootKey = newKey
+	case tokenLength > 0:
+		r.token = existingToken
+		key, err := r.unwrap()
+		if err != nil {
+			return r, err
+		}
+		rootKey = key
+	default:
+		return r, fmt.Errorf("unknown error")
+	}
+
+	if err := r.wrapper.SetAESGCMKeyBytes(rootKey); err != nil {
+		return r, err
+	}
+
+	return r, nil
+}
+
+// GetKey ...
+func (r *ResponseEncrypter) GetKey() []byte {
+	return r.wrapper.GetKeyBytes()
+}
+
+// GetPersistentKey ...
+func (r *ResponseEncrypter) GetPersistentKey() ([]byte, error) {
+	if r.token == nil {
+		if r.Client.Token() == "" {
+			return nil, fmt.Errorf("response wrapping requires a token set on client")
+		}
+
+		if err := r.wrapForStorage(); err != nil {
+			return nil, err
+		}
+	}
+	return r.token, nil
+}
+
+// Renewable ...
+func (r *ResponseEncrypter) Renewable() bool {
+	return r.renewable
+}
+
+// Renewer ...
+func (r *ResponseEncrypter) Renewer(ctx context.Context) error {
+	for {
+		token, ttl, err := r.rewrap()
+		if err != nil {
+			r.Done <- err
+			return err
+		}
+		r.token = []byte(token)
+		r.Notify <- struct{}{}
+
+		sleep := float64(time.Duration(ttl) * time.Second)
+		sleep = sleep * (.60 + mathRand.Float64()*0.1)
+		sleepDuration := time.Duration(sleep)
+
+		select {
+		case <-time.After(sleepDuration):
+		case <-ctx.Done():
+			return nil
+		case <-r.Stop:
+			// Should we try to rewrap before stopping?
+			r.Done <- nil
+		}
+	}
+}
+
+// Encrypt ...
+func (r *ResponseEncrypter) Encrypt(ctx context.Context, plaintext, aad []byte) ([]byte, error) {
+	blob, err := r.wrapper.Encrypt(ctx, plaintext, aad)
+	if err != nil {
+		return nil, err
+	}
+	return blob.Ciphertext, nil
+}
+
+// Decrypt ...
+func (r *ResponseEncrypter) Decrypt(ctx context.Context, ciphertext, aad []byte) ([]byte, error) {
+	blob := &wrapping.EncryptedBlobInfo{
+		Ciphertext: ciphertext,
+		KeyInfo: &wrapping.KeyInfo{
+			KeyID: KeyID,
+		},
+	}
+	return r.wrapper.Decrypt(ctx, blob, aad)
+}
+
+func (r *ResponseEncrypter) wrapForStorage() error {
+	ttl := ResponseWrappedTokenTTL
+	if r.ttl != "" {
+		ttl = r.ttl
+	}
+
+	r.Client.AddHeader("X-Vault-Wrap-TTL", ttl)
+	token, err := r.wrap()
+	if err != nil {
+		return err
+	}
+
+	r.token = []byte(token)
+	return nil
+}
+
+func (r *ResponseEncrypter) wrap() (string, error) {
+	b64Key := base64.StdEncoding.EncodeToString(r.wrapper.GetKeyBytes())
+	data := map[string]interface{}{"key": b64Key}
+
+	secret, err := r.Client.Logical().Write("/sys/wrapping/wrap", data)
+	if err != nil {
+		return "", err
+	}
+	return secret.WrapInfo.Token, nil
+}
+
+func (r *ResponseEncrypter) unwrap() ([]byte, error) {
+	// Clear any previous headers set else Vault might
+	// treat this as a wrap request (ie "X-Vault-Wrap-TTL")
+	r.Client.SetHeaders(nil)
+	secret, err := r.Client.Logical().Unwrap(string(r.token))
+	if err != nil {
+		return nil, err
+	}
+
+	key, ok := secret.Data["key"]
+	if !ok {
+		return nil, fmt.Errorf("key not found in unwrap response")
+	}
+	return base64.StdEncoding.DecodeString(key.(string))
+}
+
+func (r *ResponseEncrypter) rewrap() (string, int, error) {
+	data := map[string]interface{}{"token": string(r.token)}
+	secret, err := r.Client.Logical().Write("/sys/wrapping/rewrap", data)
+	if err != nil {
+		return "", -1, err
+	}
+	return secret.WrapInfo.Token, secret.WrapInfo.TTL, nil
+}

--- a/command/agent/cache/crypto/response_test.go
+++ b/command/agent/cache/crypto/response_test.go
@@ -1,0 +1,223 @@
+package crypto
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	log "github.com/hashicorp/go-hclog"
+	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault"
+)
+
+func TestCrypto_ResponseWrappingNewKey(t *testing.T) {
+	var err error
+	coreConfig := &vault.CoreConfig{
+		DisableMlock:       true,
+		DisableCache:       true,
+		Logger:             log.NewNullLogger(),
+		CredentialBackends: map[string]logical.Factory{},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+	vault.TestWaitActive(t, cores[0].Core)
+	client := cores[0].Client
+
+	responseWrappedKey, err := NewResponseEncrypter([]byte{}, client, ResponseWrappedTokenTTL)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
+	}
+
+	key := responseWrappedKey.GetKey()
+	if key == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", key))
+	}
+
+	plaintextInput := []byte("test")
+	aad := []byte("")
+
+	ciphertext, err := responseWrappedKey.Encrypt(nil, plaintextInput, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if ciphertext == nil {
+		t.Fatalf("ciphertext nil, it shouldn't be")
+	}
+
+	plaintext, err := responseWrappedKey.Decrypt(nil, ciphertext, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if string(plaintext) != string(plaintextInput) {
+		t.Fatalf("expected %s, got %s", plaintextInput, plaintext)
+	}
+
+	token, err := responseWrappedKey.GetPersistentKey()
+	if err != nil {
+		t.Fatalf("unxpected error: %s", err)
+	}
+
+	if token == nil {
+		t.Fatalf("persistent token nil, it shouldn't be")
+	}
+}
+
+func TestCrypto_ResponseWrappingExistingKey(t *testing.T) {
+	var err error
+
+	coreConfig := &vault.CoreConfig{
+		DisableMlock:       true,
+		DisableCache:       true,
+		Logger:             log.NewNullLogger(),
+		CredentialBackends: map[string]logical.Factory{},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+	vault.TestWaitActive(t, cores[0].Core)
+	client := cores[0].Client
+
+	responseWrappedKey, err := NewResponseEncrypter([]byte{}, client, ResponseWrappedTokenTTL)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
+	}
+
+	key := responseWrappedKey.GetKey()
+	if key == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", key))
+	}
+
+	plaintextInput := []byte("test")
+	aad := []byte("")
+
+	ciphertext, err := responseWrappedKey.Encrypt(nil, plaintextInput, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if ciphertext == nil {
+		t.Fatalf("ciphertext nil, it shouldn't be")
+	}
+
+	token, err := responseWrappedKey.GetPersistentKey()
+	if err != nil {
+		t.Fatalf("unxpected error: %s", err)
+	}
+
+	if token == nil {
+		t.Fatalf("persistent token nil, it shouldn't be")
+	}
+
+	responseWrappedKeyExisting, err := NewResponseEncrypter(token, client, ResponseWrappedTokenTTL)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
+	}
+
+	existingKey := responseWrappedKeyExisting.GetKey()
+	if existingKey == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", existingKey))
+	}
+
+	if string(key) != string(existingKey) {
+		t.Fatalf("keys don't match, they should: old: %s, new: %s", key, existingKey)
+	}
+
+	plaintext, err := responseWrappedKeyExisting.Decrypt(nil, ciphertext, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if string(plaintext) != string(plaintextInput) {
+		t.Fatalf("expected %s, got %s", plaintextInput, plaintext)
+	}
+}
+
+func TestCrypto_ResponseWrappingRenewer(t *testing.T) {
+	coreConfig := &vault.CoreConfig{
+		DisableMlock:       true,
+		DisableCache:       true,
+		Logger:             log.NewNullLogger(),
+		CredentialBackends: map[string]logical.Factory{},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+	vault.TestWaitActive(t, cores[0].Core)
+	client := cores[0].Client
+
+	responseWrappedKey, err := NewResponseEncrypter([]byte{}, client, "5")
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("unexpected error: %s", err))
+	}
+
+	key := responseWrappedKey.GetKey()
+	if key == nil {
+		t.Fatalf(fmt.Sprintf("key is nil, it shouldn't be: %s", key))
+	}
+
+	plaintextInput := []byte("test")
+	aad := []byte("")
+
+	ciphertext, err := responseWrappedKey.Encrypt(nil, plaintextInput, aad)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if ciphertext == nil {
+		t.Fatalf("ciphertext nil, it shouldn't be")
+	}
+
+	token, err := responseWrappedKey.GetPersistentKey()
+	if err != nil {
+		t.Fatalf("unxpected error: %s", err)
+	}
+
+	if token == nil {
+		t.Fatalf("persistent token nil, it shouldn't be")
+	}
+
+	if !responseWrappedKey.Renewable() {
+		t.Fatalf("response wrapped key isn't renewable, it should be")
+	}
+
+	ctx := context.Background()
+	go responseWrappedKey.Renewer(ctx)
+
+	firstToken := responseWrappedKey.token
+	if firstToken == nil {
+		t.Fatalf("first wrapped token is nil, it shouldn't be")
+	}
+
+	<-responseWrappedKey.Notify
+
+	secondToken := responseWrappedKey.token
+	if secondToken == nil {
+		t.Fatalf("second wrapped token is nil, it shouldn't be")
+	}
+
+	if string(firstToken) == string(secondToken) {
+		t.Fatalf("first token and rewrapped token mathch, they shouldn't")
+	}
+}


### PR DESCRIPTION
This PR is a rough draft for response wrapping the generated encryption key when using Vault Agent persistence caching. There's definitely some rough edges that need to be ironed out it currently supports:

* Wrapping the key
* Unwrapping the key
* Rewrapping the key on a periodic basis

The one gotcha with this implementation is wrapping requires a valid Vault token. Caching persistence won't have this token until auth-auth sinks the token through the in memory channel.