### PR TITLE
UI Add test and clean up for DBSE

### DIFF
--- a/ui/app/styles/components/empty-state.scss
+++ b/ui/app/styles/components/empty-state.scss
@@ -18,10 +18,6 @@
   font-weight: $font-weight-semibold;
   line-height: 1.2;
   margin-bottom: $spacing-xs;
-  // ARG TODO COME BACK
-  .no-wrap {
-    white-space: nowrap;
-  }
 }
 
 .empty-state-subTitle {

--- a/ui/app/styles/components/empty-state.scss
+++ b/ui/app/styles/components/empty-state.scss
@@ -13,12 +13,15 @@
 }
 
 .empty-state-title {
-  white-space: nowrap;
   color: $grey;
   font-size: $size-4;
   font-weight: $font-weight-semibold;
   line-height: 1.2;
   margin-bottom: $spacing-xs;
+  // ARG TODO COME BACK
+  .no-wrap {
+    white-space: nowrap;
+  }
 }
 
 .empty-state-subTitle {

--- a/ui/lib/core/addon/templates/components/info-table-item-array.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-item-array.hbs
@@ -14,7 +14,7 @@
           {{/if}}
         {{/let}}
       {{else}}
-        {{#link-to "vault.cluster.secrets.backend.show" (if queryParam (concat queryParam "/" name) name)}}
+        {{#link-to "vault.cluster.secrets.backend.show" (if queryParam (concat queryParam "/" name) name) data-test-item="array"}}
           <span>{{name}}</span>
         {{/link-to}}
       {{/if}}

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -42,8 +42,6 @@
           @viewAll={{viewAll}}
           @wildcardLabel={{wildcardLabel}}
         />
-      {{else if isLink}}
-        <LinkTo @route="vault.cluster.secrets.backend.show" @model={{value.[0]}} >{{value}}</LinkTo>
       {{else}}
         {{#if tooltipText}}
           <ToolTip

--- a/ui/tests/integration/components/info-table-row-test.js
+++ b/ui/tests/integration/components/info-table-row-test.js
@@ -1,0 +1,73 @@
+import { module, test } from 'qunit';
+import { resolve } from 'rsvp';
+import Service from '@ember/service';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+const VALUE = 'testing';
+const LABEL = 'item';
+const TYPE = 'array';
+
+const routerService = Service.extend({
+  transitionTo() {
+    return {
+      followRedirects() {
+        return resolve();
+      },
+    };
+  },
+  replaceWith() {
+    return resolve();
+  },
+});
+
+module('Integration | Component | InfoTableItem', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.set('value', VALUE);
+    this.set('label', LABEL);
+    this.set('type', TYPE);
+    this.owner.register('service:router', routerService);
+    this.router = this.owner.lookup('service:router');
+  });
+
+  hooks.afterEach(function() {
+    this.owner.unregister('service:store');
+  });
+
+  test('it renders', async function(assert) {
+    await render(hbs`<InfoTableRow
+        @value={{value}}
+        @label={{label}}
+      />`);
+
+    assert.dom('[data-test-component="info-table-row"]').exists();
+    let string = document.querySelector('code').textContent;
+    assert.equal(string, VALUE, 'renders value as passed through');
+  });
+
+  test('it renders a string with no link if isLink is true and the item type is not an array.', async function(assert) {
+    // This could be changed in the component so that it adds a link for any item type, but right it should only add a link if item type is an array.
+    await render(hbs`<InfoTableRow
+        @value={{value}}
+        @label={{label}}
+        @isLink={{true}}
+      />`);
+    let string = document.querySelector('code').textContent;
+    assert.equal(string, VALUE, 'renders value in code element and not in a tag');
+  });
+
+  test('it renders links if isLink is true and type is array', async function(assert) {
+    this.set('valueArray', ['valueArray']);
+    await render(hbs`<InfoTableRow
+      @value={{valueArray}}
+      @label={{label}}
+      @isLink={{true}}
+      @type={{type}}
+    />`);
+
+    assert.dom('[data-test-item="array"]').hasText('valueArray', 'Confirm link with item value exist');
+  });
+});


### PR DESCRIPTION
1.  Added an integration test to handle new situations for the `info-table-row` component.  Specifically, around arrays and links.
2. Removed no-wrap as it causes more problems, and after testing doesn't appear to be needed anymore.