### PR TITLE
UI: fix KMIP bug and test

### DIFF
--- a/changelog/11011.txt
+++ b/changelog/11011.txt
@@ -1,0 +1,3 @@
+```changelog:bug
+ui: Fix KMIP failing test and a bug that ocurred because the configuration model was not being unloaded.
+```

--- a/ui/lib/kmip/addon/routes/configuration.js
+++ b/ui/lib/kmip/addon/routes/configuration.js
@@ -1,11 +1,13 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import UnloadModel from 'vault/mixins/unload-model-route';
 
-export default Route.extend({
+export default Route.extend(UnloadModel, {
   store: service(),
   secretMountPath: service(),
   pathHelp: service(),
-  beforeModel() {
+  async beforeModel() {
+    await this.store.unloadAll('kmip/config');
     return this.pathHelp.getNewModel('kmip/config', this.secretMountPath.currentPath);
   },
   model() {

--- a/ui/lib/kmip/addon/routes/configuration.js
+++ b/ui/lib/kmip/addon/routes/configuration.js
@@ -6,7 +6,7 @@ export default Route.extend(UnloadModel, {
   store: service(),
   secretMountPath: service(),
   pathHelp: service(),
-  async beforeModel() {
+  beforeModel() {
     return this.pathHelp.getNewModel('kmip/config', this.secretMountPath.currentPath);
   },
   model() {

--- a/ui/lib/kmip/addon/routes/configuration.js
+++ b/ui/lib/kmip/addon/routes/configuration.js
@@ -7,7 +7,6 @@ export default Route.extend(UnloadModel, {
   secretMountPath: service(),
   pathHelp: service(),
   async beforeModel() {
-    await this.store.unloadAll('kmip/config');
     return this.pathHelp.getNewModel('kmip/config', this.secretMountPath.currentPath);
   },
   model() {

--- a/ui/tests/acceptance/enterprise-kmip-test.js
+++ b/ui/tests/acceptance/enterprise-kmip-test.js
@@ -1,4 +1,4 @@
-import { currentURL, currentRouteName, settled } from '@ember/test-helpers';
+import { currentURL, currentRouteName, settled, fillIn } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
@@ -12,10 +12,16 @@ import mountSecrets from 'vault/tests/pages/settings/mount-secret-backend';
 
 const uiConsole = create(consoleClass);
 
+const getRandomPort = () => {
+  let a = Math.floor(100000 + Math.random() * 900000);
+  a = String(a);
+  return a.substring(0, 4);
+};
+
 const mount = async (shouldConfig = true) => {
   const now = Date.now();
   let path = `kmip-${now}`;
-  let addr = `127.0.0.1:${now % 1000}`; // use random port
+  let addr = `127.0.0.1:${getRandomPort()}`; // use random port
   let commands = shouldConfig
     ? [`write sys/mounts/${path} type=kmip`, `write ${path}/config listen_addrs=${addr}`]
     : [`write sys/mounts/${path} type=kmip`];
@@ -99,6 +105,8 @@ module('Acceptance | Enterprise | KMIP secrets', function(hooks) {
       `/vault/secrets/${path}/kmip/configure`,
       'configuration navigates to the configure page'
     );
+    let addr = `127.0.0.1:${getRandomPort()}`;
+    await fillIn('[data-test-string-list-input="0"]', addr);
 
     await scopesPage.submit();
     await settled();


### PR DESCRIPTION
The KMIP secrets had a bug where if you went from one KMIP engine that had a configuration model and then to another KMIP secret engine that did not have a configuration model it would pull from the Ember data store the first KMIP engine's `kmip/configuration` model.  To solve this, we clear the model using a mixin.

The second issue was a test failure because the ports needed to be random when setting up the configuration, this was fixed by creating a new method called `getRandomPort`.

Because Circle CI won't run the enterprise tests, I ran the enterprise test suite three times, and no failures.
