### PR TITLE
Make fairsharing stop function async

### DIFF
--- a/helper/fairshare/jobmanager.go
+++ b/helper/fairshare/jobmanager.go
@@ -34,7 +34,9 @@ type JobManager struct {
 	onceStart         sync.Once
 	onceStop          sync.Once
 	logger            log.Logger
-	wg                sync.WaitGroup
+
+	// waitgroup for testing stop functionality
+	wg sync.WaitGroup
 
 	// protects `queues`, `queuesIndex`, `lastQueueAccessed`
 	l sync.RWMutex
@@ -86,10 +88,9 @@ func (j *JobManager) Start() {
 // job manager to quit gracefully
 func (j *JobManager) Stop() {
 	j.onceStop.Do(func() {
-		j.logger.Trace("terminating job manager and waiting...")
-		j.workerPool.stop()
+		j.logger.Trace("terminating job manager...")
 		close(j.quit)
-		j.wg.Wait()
+		j.workerPool.stop()
 	})
 }
 

--- a/helper/fairshare/jobmanager.go
+++ b/helper/fairshare/jobmanager.go
@@ -84,8 +84,7 @@ func (j *JobManager) Start() {
 	})
 }
 
-// Stop stops the job manager, and waits for the worker pool and
-// job manager to quit gracefully
+// Stop stops the job manager asynchronously
 func (j *JobManager) Stop() {
 	j.onceStop.Do(func() {
 		j.logger.Trace("terminating job manager...")

--- a/helper/fairshare/jobmanager_test.go
+++ b/helper/fairshare/jobmanager_test.go
@@ -176,6 +176,7 @@ func TestJobManager_Stop(t *testing.T) {
 	timeout := time.After(5 * time.Second)
 	go func() {
 		j.Stop()
+		j.wg.Wait()
 		doneCh <- struct{}{}
 	}()
 
@@ -196,6 +197,7 @@ func TestFairshare_StopMultiple(t *testing.T) {
 	timeout := time.After(5 * time.Second)
 	go func() {
 		j.Stop()
+		j.wg.Wait()
 		doneCh <- struct{}{}
 	}()
 
@@ -217,6 +219,7 @@ func TestFairshare_StopMultiple(t *testing.T) {
 		}()
 
 		j.Stop()
+		j.wg.Wait()
 	}()
 
 	select {

--- a/helper/fairshare/workerpool.go
+++ b/helper/fairshare/workerpool.go
@@ -22,7 +22,9 @@ type worker struct {
 	jobCh  <-chan Job
 	quit   chan struct{}
 	logger log.Logger
-	wg     *sync.WaitGroup
+
+	// waitgroup for testing stop functionality
+	wg *sync.WaitGroup
 }
 
 // start starts the worker listening and working until the quit channel is closed
@@ -92,8 +94,6 @@ func (d *dispatcher) stop() {
 	d.onceStop.Do(func() {
 		d.logger.Trace("terminating dispatcher")
 		close(d.quit)
-		d.logger.Trace("waiting for worker pool to stop...")
-		d.wg.Wait()
 	})
 }
 

--- a/helper/fairshare/workerpool.go
+++ b/helper/fairshare/workerpool.go
@@ -89,7 +89,7 @@ func (d *dispatcher) start() {
 	})
 }
 
-// stop stops the worker pool and waits for all workers to finish their jobs
+// stop stops the worker pool asynchronously
 func (d *dispatcher) stop() {
 	d.onceStop.Do(func() {
 		d.logger.Trace("terminating dispatcher")

--- a/helper/fairshare/workerpool_test.go
+++ b/helper/fairshare/workerpool_test.go
@@ -243,6 +243,7 @@ func TestFairshare_stop(t *testing.T) {
 
 	go func() {
 		d.stop()
+		d.wg.Wait()
 		doneCh <- struct{}{}
 	}()
 
@@ -264,6 +265,7 @@ func TestFairshare_stopMultiple(t *testing.T) {
 
 	go func() {
 		d.stop()
+		d.wg.Wait()
 		doneCh <- struct{}{}
 	}()
 
@@ -285,6 +287,7 @@ func TestFairshare_stopMultiple(t *testing.T) {
 		}()
 
 		d.stop()
+		d.wg.Wait()
 	}()
 
 	select {


### PR DESCRIPTION
We were seeing occasional lock contention with `m.coreStateLock` during shutdown. This appears to have fixed it

Previously the lock contention happened after about 2000 runs of `TestTokenStore_Revoke$`. I have ran it about 75,000 times now with no issues.

Failure we saw: https://app.circleci.com/pipelines/github/hashicorp/vault/15495/workflows/abd55d71-742a-41f9-aa49-4347320518e3/jobs/155458

how to exercise multiple times (using @ncabatoff `untilfail` tool): go test -tags deadlock -c -o testvault ./vault; untilfail -parallel=20 ./testvault -test.run 'TestTokenStore_Revoke$'
 