### PR TITLE
Add extra check for persistent cache when routing templating

### DIFF
--- a/changelog/10927.txt
+++ b/changelog/10927.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-agent: Route templating server through cache when enabled.
+agent: Route templating server through cache when persistent cahce is enabled.
 ```

--- a/changelog/10927.txt
+++ b/changelog/10927.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-agent: Route templating server through cache when persistent cahce is enabled.
+agent: Route templating server through cache when persistent cache is enabled.
 ```

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -256,7 +256,7 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 	}
 
 	// Use the cache if available or fallback to the Vault server values.
-	if sc.AgentConfig.Cache != nil && len(sc.AgentConfig.Listeners) != 0 {
+	if sc.AgentConfig.Cache != nil && sc.AgentConfig.Cache.Persist != nil && len(sc.AgentConfig.Listeners) != 0 {
 		scheme := "unix://"
 		if sc.AgentConfig.Listeners[0].Type == "tcp" {
 			scheme = "https://"

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -13,7 +13,6 @@ import (
 
 	ctconfig "github.com/hashicorp/consul-template/config"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/vault/command/agent/config"
 	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"
@@ -72,7 +71,7 @@ func newAgentConfig(listeners []*configutil.Listener, enableCache, enablePersise
 	}
 
 	if enablePersisentCache {
-		agent.Config.Cache.Persist = &config.Persist{Type: "kubernetes"}
+		agentConfig.Cache.Persist = &config.Persist{Type: "kubernetes"}
 	}
 
 	return agentConfig
@@ -270,7 +269,7 @@ func TestCacheConfigNoPersistentCache(t *testing.T) {
 func TestCacheConfigNoListener(t *testing.T) {
 	listeners := []*configutil.Listener{}
 
-	agentConfig := newAgentConfig(listeners, true)
+	agentConfig := newAgentConfig(listeners, true, true)
 	serverConfig := ServerConfig{AgentConfig: agentConfig}
 
 	ctConfig, err := newRunnerConfig(&serverConfig, ctconfig.TemplateConfigs{})
@@ -308,7 +307,7 @@ func TestCacheConfigRejectMTLS(t *testing.T) {
 		},
 	}
 
-	agentConfig := newAgentConfig(listeners, true)
+	agentConfig := newAgentConfig(listeners, true, true)
 	serverConfig := ServerConfig{AgentConfig: agentConfig}
 
 	_, err := newRunnerConfig(&serverConfig, ctconfig.TemplateConfigs{})


### PR DESCRIPTION
We only want to route the templating engine through the local cache if persistence is enabled, so adding another check here for that.