### PR TITLE
agent: skip restoring leases that are expired

### DIFF
--- a/command/agent/cache/cachememdb/index.go
+++ b/command/agent/cache/cachememdb/index.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 )
 
 // Index holds the response to be cached along with multiple other values that
@@ -61,6 +62,12 @@ type Index struct {
 
 	// RequestHeader is the header used in the request
 	RequestHeader http.Header
+
+	// LastRenewed is the timestamp of last renewal
+	LastRenewed time.Time
+
+	// Type is the index type (token, auth-lease, secret-lease)
+	Type string
 }
 
 type IndexName uint32

--- a/command/agent/cache/cachememdb/index_test.go
+++ b/command/agent/cache/cachememdb/index_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,6 +28,7 @@ func TestSerializeDeserialize(t *testing.T) {
 		RequestHeader: http.Header{
 			"X-Test": []string{"vault", "agent"},
 		},
+		LastRenewed: time.Now().UTC(),
 	}
 	indexBytes, err := testIndex.Serialize()
 	require.NoError(t, err)


### PR DESCRIPTION
When restoring persisted leases, checks that the elapsed time since the last renewal is less than the lease duration.

Adds new fields to Index: a LastRenewal timestamp, and a Type (used when updating in bolt db). The LastRenewal timestamp is updated whenever there's a notification on a lease's watcher.RenewCh.