### PR TITLE
Remove broken AWS Vault Enterprise AMI Link

### DIFF
--- a/website/content/docs/platform/aws-mp/index.mdx
+++ b/website/content/docs/platform/aws-mp/index.mdx
@@ -16,7 +16,6 @@ There are two varieties of Vault AMIs available through the AWS Marketplace. Vau
 The AWS Marketplace listings can be found below.
 
 - [HashiCorp Vault OSS](http://aws.amazon.com/marketplace/pp/B07YLYPLYB)
-- [HashiCorp Vault Enterprise](http://aws.amazon.com/marketplace/pp/B07YLXD9TD)
 
 ## Use Cases
 


### PR DESCRIPTION
Small PR to remove a broken link. The link to [HashiCorp Vault Enterprise](https://aws.amazon.com/marketplace/pp/B07YLXD9TD) on the [project page](https://www.vaultproject.io/docs/platform/aws-mp) is broken and appears to have never worked, as customers need to go through sales to purchase the enterprise AMI. 