### PR TITLE
Reset agent backoff on successful auth

### DIFF
--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/rand"
 	"net/http"
 	"time"
@@ -87,11 +88,15 @@ func NewAuthHandler(conf *AuthHandlerConfig) *AuthHandler {
 	return ah
 }
 
-func backoffOrQuit(ctx context.Context, backoff time.Duration) {
+func backoffOrQuit(ctx context.Context, backoff *agentBackoff) {
 	select {
-	case <-time.After(backoff):
+	case <-time.After(backoff.current):
 	case <-ctx.Done():
 	}
+
+	// Increase exponential backoff for the next time if we don't
+	// successfully auth/renew/etc.
+	backoff.next()
 }
 
 func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
@@ -99,12 +104,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 		return errors.New("auth handler: nil auth method")
 	}
 
-	backoff := initialBackoff
-	maxBackoff := defaultMaxBackoff
-
-	if ah.maxBackoff > 0 {
-		maxBackoff = ah.maxBackoff
-	}
+	backoff := newAgentBackoff(ah.maxBackoff)
 
 	ah.logger.Info("starting auth handler")
 	defer func() {
@@ -145,8 +145,6 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 		default:
 		}
 
-		backoff = calculateBackoff(backoff, maxBackoff)
-
 		var clientToUse *api.Client
 		var err error
 		var path string
@@ -157,7 +155,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 		case AuthMethodWithClient:
 			clientToUse, err = am.(AuthMethodWithClient).AuthClient(ah.client)
 			if err != nil {
-				ah.logger.Error("error creating client for authentication call", "error", err, "backoff", backoff.Seconds())
+				ah.logger.Error("error creating client for authentication call", "error", err, "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
 				continue
 			}
@@ -175,7 +173,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 
 			secret, err = clientToUse.Logical().Read("auth/token/lookup-self")
 			if err != nil {
-				ah.logger.Error("could not look up token", "err", err, "backoff", backoff.Seconds())
+				ah.logger.Error("could not look up token", "err", err, "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
 				continue
 			}
@@ -191,7 +189,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 
 			path, header, data, err = am.Authenticate(ctx, ah.client)
 			if err != nil {
-				ah.logger.Error("error getting path or data from method", "error", err, "backoff", backoff.Seconds())
+				ah.logger.Error("error getting path or data from method", "error", err, "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
 				continue
 			}
@@ -200,7 +198,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 		if ah.wrapTTL > 0 {
 			wrapClient, err := clientToUse.Clone()
 			if err != nil {
-				ah.logger.Error("error creating client for wrapped call", "error", err, "backoff", backoff.Seconds())
+				ah.logger.Error("error creating client for wrapped call", "error", err, "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
 				continue
 			}
@@ -221,7 +219,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 			secret, err = clientToUse.Logical().Write(path, data)
 			// Check errors/sanity
 			if err != nil {
-				ah.logger.Error("error authenticating", "error", err, "backoff", backoff.Seconds())
+				ah.logger.Error("error authenticating", "error", err, "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
 				continue
 			}
@@ -230,18 +228,18 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 		switch {
 		case ah.wrapTTL > 0:
 			if secret.WrapInfo == nil {
-				ah.logger.Error("authentication returned nil wrap info", "backoff", backoff.Seconds())
+				ah.logger.Error("authentication returned nil wrap info", "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
 				continue
 			}
 			if secret.WrapInfo.Token == "" {
-				ah.logger.Error("authentication returned empty wrapped client token", "backoff", backoff.Seconds())
+				ah.logger.Error("authentication returned empty wrapped client token", "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
 				continue
 			}
 			wrappedResp, err := jsonutil.EncodeJSON(secret.WrapInfo)
 			if err != nil {
-				ah.logger.Error("failed to encode wrapinfo", "error", err, "backoff", backoff.Seconds())
+				ah.logger.Error("failed to encode wrapinfo", "error", err, "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
 				continue
 			}
@@ -252,6 +250,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 			}
 
 			am.CredSuccess()
+			backoff.reset()
 
 			select {
 			case <-ctx.Done():
@@ -265,12 +264,12 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 
 		default:
 			if secret == nil || secret.Auth == nil {
-				ah.logger.Error("authentication returned nil auth info", "backoff", backoff.Seconds())
+				ah.logger.Error("authentication returned nil auth info", "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
 				continue
 			}
 			if secret.Auth.ClientToken == "" {
-				ah.logger.Error("authentication returned empty client token", "backoff", backoff.Seconds())
+				ah.logger.Error("authentication returned empty client token", "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
 				continue
 			}
@@ -281,6 +280,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 			}
 
 			am.CredSuccess()
+			backoff.reset()
 		}
 
 		if watcher != nil {
@@ -291,7 +291,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 			Secret: secret,
 		})
 		if err != nil {
-			ah.logger.Error("error creating lifetime watcher, backing off and retrying", "error", err, "backoff", backoff.Seconds())
+			ah.logger.Error("error creating lifetime watcher, backing off and retrying", "error", err, "backoff", backoff)
 			backoffOrQuit(ctx, backoff)
 			continue
 		}
@@ -326,15 +326,41 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 	}
 }
 
-// calculateBackoff determines a new backoff duration that is roughly twice
-// the previous value, capped to a max value, with a measure of randomness.
-func calculateBackoff(previous, max time.Duration) time.Duration {
-	maxBackoff := 2 * previous
-	if maxBackoff > max {
-		maxBackoff = max
+// agentBackoff tracks exponential backoff state.
+type agentBackoff struct {
+	max     time.Duration
+	current time.Duration
+}
+
+func newAgentBackoff(max time.Duration) *agentBackoff {
+	if max <= 0 {
+		max = defaultMaxBackoff
+	}
+
+	return &agentBackoff{
+		max:     max,
+		current: initialBackoff,
+	}
+}
+
+// next determines the next backoff duration that is roughly twice
+// the current value, capped to a max value, with a measure of randomness.
+func (b *agentBackoff) next() {
+	maxBackoff := 2 * b.current
+
+	if maxBackoff > b.max {
+		maxBackoff = b.max
 	}
 
 	// Trim a random amount (0-25%) off the doubled duration
 	trim := rand.Int63n(int64(maxBackoff) / 4)
-	return maxBackoff - time.Duration(trim)
+	b.current = maxBackoff - time.Duration(trim)
+}
+
+func (b *agentBackoff) reset() {
+	b.current = initialBackoff
+}
+
+func (b agentBackoff) String() string {
+	return fmt.Sprintf("%.2fs", b.current.Seconds())
 }

--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math/rand"
 	"net/http"
 	"time"
@@ -362,5 +361,5 @@ func (b *agentBackoff) reset() {
 }
 
 func (b agentBackoff) String() string {
-	return fmt.Sprintf("%.2fs", b.current.Seconds())
+	return b.current.Truncate(10 * time.Millisecond).String()
 }


### PR DESCRIPTION
The existing code would retain the previous backoff value even after the system had recovered. This PR fixes that issue and improves the structure of the backoff code.