### PR TITLE
SSH: report signing error reason, and clarify docs re. non-RSA CA keys

### DIFF
--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -532,7 +532,7 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 	algo := b.Role.AlgorithmSigner
 	sig, err := sshAlgorithmSigner.SignWithAlgorithm(rand.Reader, certificateBytes, algo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate signed SSH key: sign error")
+		return nil, fmt.Errorf("failed to generate signed SSH key: sign error: %w", err)
 	}
 
 	certificate.Signature = sig

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -212,9 +212,11 @@ This endpoint creates or updates a named role.
   and their expected sizes which are allowed to be signed by the CA type.
 
 - `algorithm_signer` `(string: "")` - Algorithm to sign keys with. Valid
-  values are `ssh-rsa`, `rsa-sha2-256`, and `rsa-sha2-512`. Note that `ssh-rsa`
-  is now considered insecure and is not supported by current OpenSSH versions.
-  If not specified, it will use the signer's default algorithm.
+  values when the CA has an RSA key are `ssh-rsa`, `rsa-sha2-256`, and
+  `rsa-sha2-512`.  Note that `ssh-rsa` is now considered insecure and is not
+  supported by current OpenSSH versions.  If not specified, it will use the
+  signer's default algorithm.  This value must be left blank for CA key
+  types other than RSA.
 
 ### Sample Payload
 
@@ -642,7 +644,8 @@ overridden._
 
 - `generate_signing_key` `(bool: true)` – Specifies if Vault should generate
   the signing key pair internally. The generated public key will be returned so
-  you can add it to your configuration.
+  you can add it to your configuration.  The key generated will be RSA, but
+  other types of CA key can be imported if `generate_signing_key` is false.
 
 ### Sample Payload
 


### PR DESCRIPTION
See #10067