### PR TITLE
Add a reasonable application_name for PostgreSQL connection

### DIFF
--- a/sdk/database/helper/connutil/sql.go
+++ b/sdk/database/helper/connutil/sql.go
@@ -128,12 +128,18 @@ func (c *SQLConnectionProducer) Connection(ctx context.Context) (interface{}, er
 	// Otherwise, attempt to make connection
 	conn := c.ConnectionURL
 
-	// Ensure timezone is set to UTC for all the connections
+	// PostgreSQL specific settings
 	if strings.HasPrefix(conn, "postgres://") || strings.HasPrefix(conn, "postgresql://") {
+		// Ensure timezone is set to UTC for all the connections
 		if strings.Contains(conn, "?") {
 			conn += "&timezone=UTC"
 		} else {
 			conn += "?timezone=UTC"
+		}
+
+		// Ensure a reasonable application_name is set
+		if !strings.Contains(conn, "application_name") {
+			conn += "&application_name=vault"
 		}
 	}
 

--- a/vendor/github.com/hashicorp/vault/sdk/database/helper/connutil/sql.go
+++ b/vendor/github.com/hashicorp/vault/sdk/database/helper/connutil/sql.go
@@ -128,12 +128,18 @@ func (c *SQLConnectionProducer) Connection(ctx context.Context) (interface{}, er
 	// Otherwise, attempt to make connection
 	conn := c.ConnectionURL
 
-	// Ensure timezone is set to UTC for all the connections
+	// PostgreSQL specific settings
 	if strings.HasPrefix(conn, "postgres://") || strings.HasPrefix(conn, "postgresql://") {
+		// Ensure timezone is set to UTC for all the connections
 		if strings.Contains(conn, "?") {
 			conn += "&timezone=UTC"
 		} else {
 			conn += "?timezone=UTC"
+		}
+
+		// Ensure a reasonable application_name is set
+		if !strings.Contains(conn, "application_name") {
+			conn += "&application_name=vault"
 		}
 	}
 


### PR DESCRIPTION
I noticed that Vault sets no `application_name` for PostgreSQL connections.

If this is set to an good identifier like the name of the software which created the connection, it makes it much easier for DBAs and other database users to understand what is happening on the database.
The go-to solution to see what connections are open on your PostgreSQL instance and what they are doing is to look at pg_stat_activity `SELECT * FROM pg_stat_activity;`.
 `application_name` is the value used to identify what application is connected.

I set  `application_name` to "vault" which is a lot more helpful than the default empty string.
In the future it could also be useful to deliver more information like current version, but this is optional and has pros and cons.  

