### PR TITLE
Allow setting of Consul ServiceMeta tags from config file

### DIFF
--- a/changelog/11084.txt
+++ b/changelog/11084.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+serviceregistration: Added support for Consul ServiceMeta tags from config file from the new `service_meta` config field.
+```

--- a/serviceregistration/consul/consul_service_registration.go
+++ b/serviceregistration/consul/consul_service_registration.go
@@ -5,6 +5,7 @@ package consul
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -73,6 +74,7 @@ type serviceRegistration struct {
 	redirectPort        int64
 	serviceName         string
 	serviceTags         []string
+	serviceMeta         map[string]string
 	serviceAddress      *string
 	disableRegistration bool
 	checkTimeout        time.Duration
@@ -229,6 +231,20 @@ func (c *serviceRegistration) merge(conf map[string]string) error {
 		c.logger.Debug("config service_tags set", "service_tags", tags)
 	}
 
+	// Get user-defined meta tags to attach to the registered service name
+	metaTagsJSON, ok := conf["service_meta"]
+	var metaTags = map[string]string{}
+	if ok {
+		if err := json.Unmarshal([]byte(metaTagsJSON), &metaTags); err != nil {
+			return errors.New("service tags must be a dictionary of string keys and values")
+		}
+		metaTags["external-source"] = metaExternalSource
+
+		if c.logger.IsDebug() {
+			c.logger.Debug("config service_meta set", "service_meta", metaTags)
+		}
+	}
+
 	// Get the service-specific address to override the use of the HA redirect address
 	var serviceAddr *string
 	serviceAddrStr, ok := conf["service_address"]
@@ -294,6 +310,7 @@ func (c *serviceRegistration) merge(conf map[string]string) error {
 	c.config = consulConf
 	c.serviceName = service
 	c.serviceTags = strutil.ParseDedupAndSortStrings(tags, ",")
+	c.serviceMeta = metaTags
 	c.serviceAddress = serviceAddr
 	c.checkTimeout = checkTimeout
 	c.disableRegistration = disableRegistration
@@ -586,12 +603,10 @@ func (c *serviceRegistration) reconcileConsul() (serviceID string, err error) {
 		ID:                serviceID,
 		Name:              c.serviceName,
 		Tags:              tags,
+		Meta:              c.serviceMeta,
 		Port:              int(c.redirectPort),
 		Address:           serviceAddress,
 		EnableTagOverride: false,
-		Meta: map[string]string{
-			"external-source": metaExternalSource,
-		},
 	}
 
 	checkStatus := api.HealthCritical

--- a/serviceregistration/consul/consul_service_registration.go
+++ b/serviceregistration/consul/consul_service_registration.go
@@ -232,17 +232,15 @@ func (c *serviceRegistration) merge(conf map[string]string) error {
 	}
 
 	// Get user-defined meta tags to attach to the registered service name
-	metaTagsJSON, ok := conf["service_meta"]
 	var metaTags = map[string]string{}
-	if ok {
+	if metaTagsJSON, ok := conf["service_meta"]; ok {
 		if err := json.Unmarshal([]byte(metaTagsJSON), &metaTags); err != nil {
 			return errors.New("service tags must be a dictionary of string keys and values")
 		}
-		metaTags["external-source"] = metaExternalSource
-
-		if c.logger.IsDebug() {
-			c.logger.Debug("config service_meta set", "service_meta", metaTags)
-		}
+	}
+	metaTags["external-source"] = metaExternalSource
+	if c.logger.IsDebug() {
+		c.logger.Debug("config service_meta set", "service_meta", metaTags)
 	}
 
 	// Get the service-specific address to override the use of the HA redirect address

--- a/serviceregistration/consul/consul_service_registration.go
+++ b/serviceregistration/consul/consul_service_registration.go
@@ -232,7 +232,7 @@ func (c *serviceRegistration) merge(conf map[string]string) error {
 	}
 
 	// Get user-defined meta tags to attach to the registered service name
-	var metaTags = map[string]string{}
+	metaTags := map[string]string{}
 	if metaTagsJSON, ok := conf["service_meta"]; ok {
 		if err := json.Unmarshal([]byte(metaTagsJSON), &metaTags); err != nil {
 			return errors.New("service tags must be a dictionary of string keys and values")

--- a/serviceregistration/consul/consul_service_registration_test.go
+++ b/serviceregistration/consul/consul_service_registration_test.go
@@ -492,22 +492,32 @@ func TestConsul_serviceTags(t *testing.T) {
 	}
 }
 
-func TestConsul_serviceMeta(t *testing.T) {
+// TestConsul_ServiceMeta tests whether consul service meta registration works
+func TestConsul_ServiceMeta(t *testing.T) {
 	tests := []struct {
-		conf map[string]string
-		pass bool
+		conf   map[string]string
+		pass   bool
+		expect map[string]string
 	}{
 		{
-			conf: map[string]string{},
-			pass: true,
+			conf:   map[string]string{},
+			pass:   true,
+			expect: map[string]string{"external-source": "vault"},
 		},
 		{
-			conf: map[string]string{"service_meta": "true"},
-			pass: false,
+			conf:   map[string]string{"service_meta": "true"},
+			pass:   false,
+			expect: map[string]string{"external-source": "vault"},
 		},
 		{
-			conf: map[string]string{"service_meta": "{\"key\":\"value\"}"},
-			pass: true,
+			conf:   map[string]string{"service_meta": "{\"key\":\"value\"}"},
+			pass:   true,
+			expect: map[string]string{"key": "value", "external-source": "vault"},
+		},
+		{
+			conf:   map[string]string{"service_meta": "{\"external-source\":\"something-else\"}"},
+			pass:   true,
+			expect: map[string]string{"external-source": "vault"},
 		},
 	}
 
@@ -518,14 +528,27 @@ func TestConsul_serviceMeta(t *testing.T) {
 		defer func() {
 			close(shutdownCh)
 		}()
-		_, err := NewServiceRegistration(test.conf, logger, sr.State{})
-		if err == nil && !test.pass {
-			t.Fatal("Expected Consul to fail with error")
+		sr, err := NewServiceRegistration(test.conf, logger, sr.State{})
+		if !test.pass {
+			if err == nil {
+				t.Fatal("Expected Consul to fail with error")
+			}
+			continue
 		}
 
 		if err != nil && test.pass {
 			t.Fatalf("Expected Consul to initialize: %v", err)
 		}
+
+		c, ok := sr.(*serviceRegistration)
+		if !ok {
+			t.Fatalf("Expected serviceRegistration")
+		}
+
+		if !reflect.DeepEqual(c.serviceMeta, test.expect) {
+			t.Fatalf("Did not produce expected meta: wanted: %v, got %v", test.expect, c.serviceMeta)
+		}
+
 	}
 }
 

--- a/serviceregistration/consul/consul_service_registration_test.go
+++ b/serviceregistration/consul/consul_service_registration_test.go
@@ -492,6 +492,43 @@ func TestConsul_serviceTags(t *testing.T) {
 	}
 }
 
+func TestConsul_serviceMeta(t *testing.T) {
+	tests := []struct {
+		conf map[string]string
+		pass bool
+	}{
+		{
+			conf: map[string]string{},
+			pass: true,
+		},
+		{
+			conf: map[string]string{"service_meta": "true"},
+			pass: false,
+		},
+		{
+			conf: map[string]string{"service_meta": "{\"key\":\"value\"}"},
+			pass: true,
+		},
+	}
+
+	for _, test := range tests {
+		logger := logging.NewVaultLogger(log.Debug)
+
+		shutdownCh := make(chan struct{})
+		defer func() {
+			close(shutdownCh)
+		}()
+		_, err := NewServiceRegistration(test.conf, logger, sr.State{})
+		if err == nil && !test.pass {
+			t.Fatal("Expected Consul to fail with error")
+		}
+
+		if err != nil && test.pass {
+			t.Fatalf("Expected Consul to initialize: %v", err)
+		}
+	}
+}
+
 func TestConsul_setRedirectAddr(t *testing.T) {
 	tests := []struct {
 		addr string

--- a/website/content/docs/configuration/service-registration/consul.mdx
+++ b/website/content/docs/configuration/service-registration/consul.mdx
@@ -85,6 +85,9 @@ at Consul's service discovery layer.
 - `service_tags` `(string: "")` – Specifies a comma-separated list of case-sensitive
   tags to attach to the service registration in Consul.
 
+- `service_meta` `(map[string]string: {})` – Specifies a key-value list of meta tags to
+  attach to the service registration in Consul.
+
 - `service_address` `(string: nil)` – Specifies a service-specific address to
   set on the service registration in Consul. If unset, Vault will use what it
   knows to be the HA redirect address - which is usually desirable. Setting

--- a/website/content/docs/configuration/service-registration/consul.mdx
+++ b/website/content/docs/configuration/service-registration/consul.mdx
@@ -86,7 +86,7 @@ at Consul's service discovery layer.
   tags to attach to the service registration in Consul.
 
 - `service_meta` `(map[string]string: {})` – Specifies a key-value list of meta tags to
-  attach to the service registration in Consul. See [ServiceMeta](https://developer.hashicorp.com/consul/api-docs/catalog#servicemeta) in the Consul docs for more information.
+  attach to the service registration in Consul. See [ServiceMeta](/consul/api-docs/catalog#servicemeta) in the Consul docs for more information.
 
 - `service_address` `(string: nil)` – Specifies a service-specific address to
   set on the service registration in Consul. If unset, Vault will use what it

--- a/website/content/docs/configuration/service-registration/consul.mdx
+++ b/website/content/docs/configuration/service-registration/consul.mdx
@@ -86,7 +86,7 @@ at Consul's service discovery layer.
   tags to attach to the service registration in Consul.
 
 - `service_meta` `(map[string]string: {})` – Specifies a key-value list of meta tags to
-  attach to the service registration in Consul.
+  attach to the service registration in Consul. See [ServiceMeta](https://developer.hashicorp.com/consul/api-docs/catalog#servicemeta) in the Consul docs for more information.
 
 - `service_address` `(string: nil)` – Specifies a service-specific address to
   set on the service registration in Consul. If unset, Vault will use what it

--- a/website/content/docs/configuration/storage/consul.mdx
+++ b/website/content/docs/configuration/storage/consul.mdx
@@ -92,6 +92,9 @@ and [`cluster_addr`][cluster-addr] ([example][listener-example]).
 - `service_tags` `(string: "")` – Specifies a comma-separated list of tags to
   attach to the service registration in Consul.
 
+- `service_meta` `(map[string]string: {})` – Specifies a key-value list of meta tags to
+  attach to the service registration in Consul.
+
 - `service_address` `(string: nil)` – Specifies a service-specific address to
   set on the service registration in Consul. If unset, Vault will use what it
   knows to be the HA redirect address - which is usually desirable. Setting

--- a/website/content/docs/configuration/storage/consul.mdx
+++ b/website/content/docs/configuration/storage/consul.mdx
@@ -93,7 +93,7 @@ and [`cluster_addr`][cluster-addr] ([example][listener-example]).
   attach to the service registration in Consul.
 
 - `service_meta` `(map[string]string: {})` – Specifies a key-value list of meta tags to
-  attach to the service registration in Consul. See [ServiceMeta](https://developer.hashicorp.com/consul/api-docs/catalog#servicemeta) in the Consul docs for more information.
+  attach to the service registration in Consul. See [ServiceMeta](/consul/api-docs/catalog#servicemeta) in the Consul docs for more information.
 
 - `service_address` `(string: nil)` – Specifies a service-specific address to
   set on the service registration in Consul. If unset, Vault will use what it

--- a/website/content/docs/configuration/storage/consul.mdx
+++ b/website/content/docs/configuration/storage/consul.mdx
@@ -93,7 +93,7 @@ and [`cluster_addr`][cluster-addr] ([example][listener-example]).
   attach to the service registration in Consul.
 
 - `service_meta` `(map[string]string: {})` – Specifies a key-value list of meta tags to
-  attach to the service registration in Consul.
+  attach to the service registration in Consul. See [ServiceMeta](https://developer.hashicorp.com/consul/api-docs/catalog#servicemeta) in the Consul docs for more information.
 
 - `service_address` `(string: nil)` – Specifies a service-specific address to
   set on the service registration in Consul. If unset, Vault will use what it


### PR DESCRIPTION
Hi there!

I'd love to be able to set [`ServiceMeta`](https://www.consul.io/api-docs/catalog#servicemeta) on the Consul service registered by Vault by specifying the desired tags in the config file, and I'm submitting this PR to that effect.

I'm not happy about unmarshalling json during `NewServiceRegistration` but considered that a simpler change than the couple of alternatives I came up from a quick glance at the codebase. That is to say, I'd love feedback on the approach (and perhaps suggestions on a proper testing strategy should folks feel this approach works).

fixes #9121
see also #10233