### PR TITLE
website(style): Update gray brand colors

### DIFF
--- a/website/components/before-after-diagram/style.module.css
+++ b/website/components/before-after-diagram/style.module.css
@@ -151,7 +151,7 @@
   background-image: linear-gradient(
     90deg,
     var(--gray-6-transparent) 0%,
-    var(--gray-6) 100%
+    var(--gray-5) 100%
   );
   composes: lineSegment;
   right: calc(50% + 20px);
@@ -161,7 +161,7 @@
     background-image: linear-gradient(
       180deg,
       var(--gray-6-transparent) 0%,
-      var(--gray-6) 100%
+      var(--gray-5) 100%
     );
     height: 245px;
     right: auto;
@@ -173,7 +173,7 @@
 .lineSegmentTwo {
   background-image: linear-gradient(
     90deg,
-    var(--gray-6) 0%,
+    var(--gray-5) 0%,
     var(--product-color) 100%
   );
   composes: lineSegment;
@@ -183,7 +183,7 @@
   @media (max-width: 767px) {
     background-image: linear-gradient(
       180deg,
-      var(--gray-6) 0%,
+      var(--gray-5) 0%,
       var(--product-color) 100%
     );
     height: calc(100% + 375px);
@@ -253,7 +253,7 @@
 /* Content container */
 
 .contentContainer {
-  border: 1px solid var(--gray-6);
+  border: 1px solid var(--gray-5);
   flex-grow: 1;
   padding: 24px 32px 20px;
   position: relative;
@@ -282,7 +282,7 @@
 
   &::before {
     border-color: rgba(229, 230, 235, 0);
-    border-bottom-color: var(--gray-6);
+    border-bottom-color: var(--gray-5);
     border-width: 18px;
     margin-left: -18px;
   }
@@ -309,7 +309,7 @@
 /* Content headline */
 
 .contentHeadline {
-  border-bottom: 1px solid var(--gray-6);
+  border-bottom: 1px solid var(--gray-5);
   color: var(--black);
   composes: g-type-display-3 from global;
   margin: 0 0 24px;

--- a/website/components/hcp-callout-section/HCPCalloutSection.module.css
+++ b/website/components/hcp-callout-section/HCPCalloutSection.module.css
@@ -39,10 +39,10 @@
         margin-bottom: 8px;
       }
       & .chin {
-        color: var(--gray-4);
+        color: var(--gray-3);
       }
       & .description {
-        color: var(--gray-4);
+        color: var(--gray-3);
         margin-top: 28px;
         margin-bottom: 0;
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1468,9 +1468,9 @@
       "integrity": "sha512-AvRPKxi6bEzjS6U8dZR9FGjPmlqxxTdzPeFZXYTsc8kUGjoY/X9/GXY2zYCpzEpmUdnLzOSJrDl17INPEeL4Pw=="
     },
     "@hashicorp/mktg-global-styles": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-global-styles/-/mktg-global-styles-2.1.0.tgz",
-      "integrity": "sha512-REr07tPJDKpyTh/u9tUS3sf29LnkDrWFVgY7FTvDJfbJ60IJ/R1TYNmcE7QKREGJ8j0p43QWEDabqVWOWvOXFA=="
+      "version": "2.1.1-canary.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-global-styles/-/mktg-global-styles-2.1.1-canary.0.tgz",
+      "integrity": "sha512-P/PtJNKU8SQPwiVM4FAXT28D3IQqQCtm1CuyP/5uJvZCljzHQ8bTWqQuoV0wVw5ceAPbYoQyACB9fait9eCm7Q=="
     },
     "@hashicorp/nextjs-scripts": {
       "version": "16.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "HashiCorp",
   "dependencies": {
-    "@hashicorp/mktg-global-styles": "2.1.0",
+    "@hashicorp/mktg-global-styles": "2.1.1-canary.0",
     "@hashicorp/nextjs-scripts": "16.0.1",
     "@hashicorp/react-alert-banner": "^5.0.0",
     "@hashicorp/react-button": "4.0.0",


### PR DESCRIPTION
Removes references to deprecated gray CSS properties and maps all gray colors to new brand values.

[_Created by Sourcegraph campaign `kstraut/product-sites-migrate-v3-gray-colors`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/product-sites-migrate-v3-gray-colors)

## **Important**
Due to old imports of `react-global-styles` within `react-components`, the proper gray values will not show until we update `react-components` later on because the old style sheets are taking precedent.

## The Map
```
// v2 gray css properties to new v3 values
"--gray-3" --> "--gray-2" 
 
"--gray-4" --> "--gray-3" 
 
"--gray-5" --> "--gray-4" 
 
"--gray-6" --> "--gray-5" 
 
"--gray-7" --> "--gray-6" 
 

// Replace Deprecated Gray Value references
"DEPRECATED-gray-:[~1|2]" --> "gray-1" 
 
"DEPRECATED-gray-:[~3|4]" --> "gray-2" 
 
"DEPRECATED-gray-:[~5|6]" --> "gray-3" 
 
"DEPRECATED-gray-7" --> "gray-4" 
 
"DEPRECATED-gray-:[~8|9]" --> "gray-5" 
 
"DEPRECATED-gray-10" --> "gray-6" 
```