### PR TITLE
UI: Add null check before getting userRootNamespace from storage

### DIFF
--- a/changelog/11094.txt
+++ b/changelog/11094.txt
@@ -1,0 +1,3 @@
+```changelog:bug
+ui: Fix issue where logging in without namespace input causes error
+```

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -42,7 +42,7 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
     // use user's root namespace to redirect to properly param'd url
     if (!namespace && currentTokenName && !Ember.testing) {
       const storage = getStorage().getItem(currentTokenName);
-      namespace = storage.userRootNamespace;
+      namespace = storage?.userRootNamespace;
       // only redirect if something other than nothing
       if (namespace) {
         this.transitionTo({ queryParams: { namespace } });


### PR DESCRIPTION
This fixes an issue where if you log in without anything in the "namespace" input, there is a failure on the page: 
<img width="1785" alt="Screen Shot 2021-03-10 at 18 58 59" src="https://user-images.githubusercontent.com/16182107/110836090-440de080-8265-11eb-9782-32462e8a17c3.png">

Note: this should not affect OSS