### PR TITLE
Fix a bug in Agent's handling of consistency headers

### DIFF
--- a/command/agent/cache/lease_cache.go
+++ b/command/agent/cache/lease_cache.go
@@ -23,6 +23,7 @@ import (
 	cachememdb "github.com/hashicorp/vault/command/agent/cache/cachememdb"
 	"github.com/hashicorp/vault/helper/namespace"
 	nshelper "github.com/hashicorp/vault/helper/namespace"
+	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/base62"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/cryptoutil"
@@ -540,8 +541,12 @@ func (c *LeaseCache) updateLastRenewed(ctx context.Context, index *cachememdb.In
 func computeIndexID(req *SendRequest) (string, error) {
 	var b bytes.Buffer
 
+	cloned := req.Request.Clone(context.Background())
+	cloned.Header.Del(vaulthttp.VaultIndexHeaderName)
+	cloned.Header.Del(vaulthttp.VaultForwardHeaderName)
+	cloned.Header.Del(vaulthttp.VaultInconsistentHeaderName)
 	// Serialize the request
-	if err := req.Request.Write(&b); err != nil {
+	if err := cloned.Write(&b); err != nil {
 		return "", fmt.Errorf("failed to serialize request: %v", err)
 	}
 

--- a/command/agent/cache/lease_cache_test.go
+++ b/command/agent/cache/lease_cache_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/vault/command/agent/cache/cacheboltdb"
 	"github.com/hashicorp/vault/command/agent/cache/cachememdb"
 	"github.com/hashicorp/vault/command/agent/cache/keymanager"
+	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/stretchr/testify/assert"
@@ -103,6 +104,23 @@ func TestCache_ComputeIndexID(t *testing.T) {
 				Request: &http.Request{
 					URL: &url.URL{
 						Path: "test",
+					},
+				},
+			},
+			"7b5db388f211fd9edca8c6c254831fb01ad4e6fe624dbb62711f256b5e803717",
+			false,
+		},
+		{
+			"ignore consistency headers",
+			&SendRequest{
+				Request: &http.Request{
+					URL: &url.URL{
+						Path: "test",
+					},
+					Header: http.Header{
+						vaulthttp.VaultIndexHeaderName:        []string{"foo"},
+						vaulthttp.VaultInconsistentHeaderName: []string{"foo"},
+						vaulthttp.VaultForwardHeaderName:      []string{"foo"},
 					},
 				},
 			},


### PR DESCRIPTION
They should be ignored when computing cache ID.