### PR TITLE
Update oracle.mdx

### DIFF
--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -86,7 +86,7 @@ pluggable databases rather than the container database in the `connection_url` f
    ```shell
    $ vault write database/roles/my-role \
        db_name=my-oracle-database \
-       creation_statements="CREATE USER {{name}} IDENTIFIED BY {{password}}; GRANT CONNECT TO {{name}}; GRANT CREATE SESSION TO {{name}};" \
+       creation_statements='CREATE USER {{username}} IDENTIFIED BY "{{password}}"; GRANT CONNECT TO {{username}}; GRANT CREATE SESSION TO {{username}};' \
        default_ttl="1h" \
        max_ttl="24h"
    Success! Data written to: database/roles/my-role


### PR DESCRIPTION
This is related to vault oracle plugin, following the instruction from the documentation

As Vault 1.6 the password being generated have `-` , causing the command to fail.

In order to make this work, quotes `"` are need around the password


With the command as is on the current documentation, this fails

```
[vagrant@vault ~]$ export VAULT_ADDR=http://127.0.0.1:8200
[vagrant@vault ~]$ vault write database/roles/my-role     \
db_name=my-oracle-database     \
creation_statements="CREATE USER {{name}} IDENTIFIED BY {{password}}; GRANT CONNECT TO {{name}}; GRANT CREATE SESSION TO {{name}};"     \
default_ttl="1h"     max_ttl="24h"

Success! Data written to: database/roles/my-role
[vagrant@vault ~]$ vault read database/creds/my-role
Error reading database/creds/my-role: Error making API request.

URL: GET http://127.0.0.1:8200/v1/database/creds/my-role
Code: 500. Errors:

* 1 error occurred:
	* unable to create new user: rpc error: code = Internal desc = unable to create new user: failed to execute query: ORA-00922: missing or invalid option
```



this works

> Please note the `"` around `"{{password}}"`

```
[vagrant@vault ~]$ export VAULT_ADDR=http://127.0.0.1:8200
[vagrant@vault ~]$ vault write database/roles/my-role     \
db_name=my-oracle-database     \
creation_statements='CREATE USER {{name}} IDENTIFIED BY "{{password}}"; GRANT CONNECT TO {{name}}; GRANT CREATE SESSION TO {{name}};'     \
default_ttl="1h"     max_ttl="24h"
Success! Data written to: database/roles/my-role
[vagrant@vault ~]$ vault read database/creds/my-role
Key                Value
---                -----
lease_id           database/creds/my-role/kbQok7up0giEBK3KR3rjYYGn
lease_duration     1h
lease_renewable    true
password           Sgl2UcvbUDsv-xg2hSbP
username           V_TOKEN_MY_ROLE_4X31ZXKOJQ8OT0
[vagrant@vault ~]$ 

````


