### PR TITLE
update transform.mdx

### DIFF
--- a/website/content/api-docs/secret/transform.mdx
+++ b/website/content/api-docs/secret/transform.mdx
@@ -213,7 +213,7 @@ transformation exists, it will be updated with the new attributes.
 
 | Method | Path                                  |
 | :----- | :------------------------------------ |
-| `POST` | `/transform/transformation/fpe/:name` |
+| `POST` | `/transform/transformations/fpe/:name` |
 
 ### Parameters
 
@@ -251,7 +251,7 @@ $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
-    https://127.0.0.1:8200/v1/transform/transformation/fpe/example-transformation
+    https://127.0.0.1:8200/v1/transform/transformations/fpe/example-transformation
 ```
 
 ## Create/Update Masking Transformation
@@ -262,7 +262,7 @@ transformation exists, it will be updated with the new attributes.
 
 | Method | Path                                      |
 | :----- | :---------------------------------------- |
-| `POST` | `/transform/transformation/masking/:name` |
+| `POST` | `/transform/transformations/masking/:name` |
 
 ### Parameters
 
@@ -301,7 +301,7 @@ $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
-    https://127.0.0.1:8200/v1/transform/transformation/masking/example-transformation
+    https://127.0.0.1:8200/v1/transform/transformations/masking/example-transformation
 ```
 
 ## Create/Update Tokenization Transformation
@@ -312,7 +312,7 @@ transformation exists, it will be updated with the new attributes.
 
 | Method | Path                                           |
 | :----- | :--------------------------------------------- |
-| `POST` | `/transform/transformation/tokenization/:name` |
+| `POST` | `/transform/transformations/tokenization/:name` |
 
 ### Parameters
 
@@ -354,7 +354,7 @@ $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
-    https://127.0.0.1:8200/v1/transform/transformation/tokenization/example-transformation
+    https://127.0.0.1:8200/v1/transform/transformations/tokenization/example-transformation
 ```
 
 ## Read Transformation
@@ -363,7 +363,7 @@ This endpoint queries an existing transformation by the given name.
 
 | Method | Path                              |
 | :----- | :-------------------------------- |
-| `GET`  | `/transform/transformation/:name` |
+| `GET`  | `/transform/transformations/:name` |
 
 - `name` `(string: <required>)` –
   Specifies the name of the role to read. This is part of the request URL.
@@ -373,7 +373,7 @@ This endpoint queries an existing transformation by the given name.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    http://127.0.0.1:8200/v1/transform/transformation/example-transformation
+    http://127.0.0.1:8200/v1/transform/transformations/example-transformation
 ```
 
 ### Sample Response
@@ -422,7 +422,7 @@ This endpoint deletes an existing transformation by the given name.
 
 | Method   | Path                              |
 | :------- | :-------------------------------- |
-| `DELETE` | `/transform/transformation/:name` |
+| `DELETE` | `/transform/transformations/:name` |
 
 ### Parameters
 
@@ -436,7 +436,7 @@ This endpoint deletes an existing transformation by the given name.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
-    http://127.0.0.1:8200/v1/transform/transformation/example-transformation
+    http://127.0.0.1:8200/v1/transform/transformations/example-transformation
 ```
 
 ## Create/Update Template


### PR DESCRIPTION
Typo on path of creating/updating transformation in api docs. 
Fixed by updating `transform/transformation` to `transform/transformations`