### PR TITLE
Updates the JWT/OIDC auth plugin to v0.9.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-centrify v0.8.0
 	github.com/hashicorp/vault-plugin-auth-cf v0.8.0
 	github.com/hashicorp/vault-plugin-auth-gcp v0.9.0
-	github.com/hashicorp/vault-plugin-auth-jwt v0.9.0
+	github.com/hashicorp/vault-plugin-auth-jwt v0.9.1
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.9.0
 	github.com/hashicorp/vault-plugin-auth-oci v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -694,8 +694,8 @@ github.com/hashicorp/vault-plugin-auth-cf v0.8.0/go.mod h1:exPUMj8yNohKM7yRiHa7O
 github.com/hashicorp/vault-plugin-auth-gcp v0.5.1/go.mod h1:eLj92eX8MPI4vY1jaazVLF2sVbSAJ3LRHLRhF/pUmlI=
 github.com/hashicorp/vault-plugin-auth-gcp v0.9.0 h1:57uJ2Vqo+M+W7pD8xEONKJ1BBGS8V4xpm7VU56A9RWA=
 github.com/hashicorp/vault-plugin-auth-gcp v0.9.0/go.mod h1:sHDguHmyGScoalGLEjuxvDCrMPVlw2c3f+ieeiHcv6w=
-github.com/hashicorp/vault-plugin-auth-jwt v0.9.0 h1:82+2S9k06YAT/+yNJtDZQ+X5Hny+WZqtEkdhp2svlDI=
-github.com/hashicorp/vault-plugin-auth-jwt v0.9.0/go.mod h1:Gn6ELc1X5nmZ/pxoXf0nA4lG2gwuGnY6SNyW40tR/ws=
+github.com/hashicorp/vault-plugin-auth-jwt v0.9.1 h1:8CnT8z+o26/c8PUUhvp+BaiDSIgA5giazyYbZlfNJ5Q=
+github.com/hashicorp/vault-plugin-auth-jwt v0.9.1/go.mod h1:Gn6ELc1X5nmZ/pxoXf0nA4lG2gwuGnY6SNyW40tR/ws=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0 h1:QxW0gRevydrNfRvo1qI6p0jQkhedLUgiWqpCN36RXoQ=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0/go.mod h1:h+7pLm4Z2EeKHOGPefX0bGzdUQCMBUlvM/BpSMNgTFw=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.9.0 h1:X/eXFuJqVW8YN73ohTaI5YyCwcjd6C3mpnMv/elkNrw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -563,7 +563,7 @@ github.com/hashicorp/vault-plugin-auth-cf/util
 # github.com/hashicorp/vault-plugin-auth-gcp v0.9.0
 github.com/hashicorp/vault-plugin-auth-gcp/plugin
 github.com/hashicorp/vault-plugin-auth-gcp/plugin/cache
-# github.com/hashicorp/vault-plugin-auth-jwt v0.9.0
+# github.com/hashicorp/vault-plugin-auth-jwt v0.9.1
 github.com/hashicorp/vault-plugin-auth-jwt
 # github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0
 github.com/hashicorp/vault-plugin-auth-kerberos


### PR DESCRIPTION
Updates `go.mod` to bring in a bug fix from https://github.com/hashicorp/vault-plugin-auth-jwt/pull/161.

The following steps were taken:
1. `go get github.com/hashicorp/vault-plugin-auth-jwt@v0.9.1`
2. `go mod tidy`
3. `go mod vendor`