### PR TITLE
Rework agent retry config, extend it to cover proxy cache as well

### DIFF
--- a/changelog/11113.txt
+++ b/changelog/11113.txt
@@ -1,0 +1,3 @@
+```changelog:enhancement
+agent: Revert template-retry feature, replace with a vault.retry stanza that applies both to templating and proxied requests.
+```

--- a/changelog/11113.txt
+++ b/changelog/11113.txt
@@ -1,3 +1,3 @@
 ```changelog:enhancement
-agent: Revert template-retry feature, replace with a vault.retry stanza that applies both to templating and proxied requests.
+agent: Add a vault.retry stanza that allows specifying number of retries on failure; this applies both to templating and proxied requests.
 ```

--- a/command/agent.go
+++ b/command/agent.go
@@ -728,9 +728,8 @@ func (c *AgentCommand) Run(args []string) int {
 	}
 
 	// Inform any tests that the server is ready
-	select {
-	case c.startedCh <- struct{}{}:
-	default:
+	if c.startedCh != nil {
+		close(c.startedCh)
 	}
 
 	// Listen for signals

--- a/command/agent.go
+++ b/command/agent.go
@@ -234,13 +234,6 @@ func (c *AgentCommand) Run(args []string) int {
 		c.UI.Info("No auto_auth block found in config file, not starting automatic authentication feature")
 	}
 
-	// create an empty Vault configuration if none was loaded from file. The
-	// follow-up setStringFlag calls will populate with defaults if otherwise
-	// omitted
-	if config.Vault == nil {
-		config.Vault = new(agentConfig.Vault)
-	}
-
 	exitAfterAuth := config.ExitAfterAuth
 	f.Visit(func(fl *flag.Flag) {
 		if fl.Name == "exit-after-auth" {
@@ -424,7 +417,7 @@ func (c *AgentCommand) Run(args []string) int {
 	// We do this after autoauth has been configured, because we don't want to
 	// confuse the issue of retries for auth failures which have their own
 	// config and are handled a bit differently.
-	if os.Getenv(api.EnvVaultMaxRetries) == "" && config.Vault != nil && config.Vault.Retry != nil && config.Vault.Retry.NumRetries > 0 {
+	if os.Getenv(api.EnvVaultMaxRetries) == "" {
 		client.SetMaxRetries(config.Vault.Retry.NumRetries)
 	}
 

--- a/command/agent.go
+++ b/command/agent.go
@@ -414,7 +414,7 @@ func (c *AgentCommand) Run(args []string) int {
 		}
 	}
 
-	// We do this after autoauth has been configured, because we don't want to
+	// We do this after auto-auth has been configured, because we don't want to
 	// confuse the issue of retries for auth failures which have their own
 	// config and are handled a bit differently.
 	if os.Getenv(api.EnvVaultMaxRetries) == "" {

--- a/command/agent.go
+++ b/command/agent.go
@@ -421,6 +421,13 @@ func (c *AgentCommand) Run(args []string) int {
 		}
 	}
 
+	// We do this after autoauth has been configured, because we don't want to
+	// confuse the issue of retries for auth failures which have their own
+	// config and are handled a bit differently.
+	if os.Getenv(api.EnvVaultMaxRetries) == "" && config.Vault != nil && config.Vault.Retry != nil && config.Vault.Retry.NumRetries > 0 {
+		client.SetMaxRetries(config.Vault.Retry.NumRetries)
+	}
+
 	enforceConsistency := cache.EnforceConsistencyNever
 	whenInconsistent := cache.WhenInconsistentFail
 	if config.Cache != nil {

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -233,8 +233,11 @@ func parseVault(result *Config, list *ast.ObjectList) error {
 	if v.Retry == nil {
 		v.Retry = &Retry{}
 	}
-	if v.Retry.NumRetries < 1 {
+	switch v.Retry.NumRetries {
+	case 0:
 		v.Retry.NumRetries = ctconfig.DefaultRetryAttempts
+	case -1:
+		v.Retry.NumRetries = 0
 	}
 
 	return nil

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -188,6 +188,21 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, errwrap.Wrapf("error parsing 'vault':{{err}}", err)
 	}
 
+	if result.Vault == nil {
+		result.Vault = &Vault{}
+	}
+
+	// Set defaults
+	if result.Vault.Retry == nil {
+		result.Vault.Retry = &Retry{}
+	}
+	switch result.Vault.Retry.NumRetries {
+	case 0:
+		result.Vault.Retry.NumRetries = ctconfig.DefaultRetryAttempts
+	case -1:
+		result.Vault.Retry.NumRetries = 0
+	}
+
 	return result, nil
 }
 
@@ -227,17 +242,6 @@ func parseVault(result *Config, list *ast.ObjectList) error {
 
 	if err := parseRetry(result, subs.List); err != nil {
 		return errwrap.Wrapf("error parsing 'retry': {{err}}", err)
-	}
-
-	// Set defaults
-	if v.Retry == nil {
-		v.Retry = &Retry{}
-	}
-	switch v.Retry.NumRetries {
-	case 0:
-		v.Retry.NumRetries = ctconfig.DefaultRetryAttempts
-	case -1:
-		v.Retry.NumRetries = 0
 	}
 
 	return nil

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -161,6 +161,11 @@ func TestLoadConfigFile(t *testing.T) {
 				},
 			},
 		},
+		Vault: &Vault{
+			Retry: &Retry{
+				NumRetries: 12,
+			},
+		},
 	}
 
 	if diff := deep.Equal(config, expected); diff != nil {
@@ -206,6 +211,11 @@ func TestLoadConfigFile_Method_Wrapping(t *testing.T) {
 				},
 			},
 		},
+		Vault: &Vault{
+			Retry: &Retry{
+				NumRetries: 12,
+			},
+		},
 	}
 
 	if diff := deep.Equal(config, expected); diff != nil {
@@ -229,6 +239,11 @@ func TestLoadConfigFile_AgentCache_NoAutoAuth(t *testing.T) {
 					Address:    "127.0.0.1:8300",
 					TLSDisable: true,
 				},
+			},
+		},
+		Vault: &Vault{
+			Retry: &Retry{
+				NumRetries: 12,
 			},
 		},
 	}
@@ -319,6 +334,11 @@ func TestLoadConfigFile_AgentCache_AutoAuth_NoSink(t *testing.T) {
 			UseAutoAuthTokenRaw: true,
 			ForceAutoAuthToken:  false,
 		},
+		Vault: &Vault{
+			Retry: &Retry{
+				NumRetries: 12,
+			},
+		},
 	}
 
 	config.Listeners[0].RawConfig = nil
@@ -358,6 +378,11 @@ func TestLoadConfigFile_AgentCache_AutoAuth_Force(t *testing.T) {
 			UseAutoAuthTokenRaw: "force",
 			ForceAutoAuthToken:  true,
 		},
+		Vault: &Vault{
+			Retry: &Retry{
+				NumRetries: 12,
+			},
+		},
 	}
 
 	config.Listeners[0].RawConfig = nil
@@ -396,6 +421,11 @@ func TestLoadConfigFile_AgentCache_AutoAuth_True(t *testing.T) {
 			UseAutoAuthToken:    true,
 			UseAutoAuthTokenRaw: "true",
 			ForceAutoAuthToken:  false,
+		},
+		Vault: &Vault{
+			Retry: &Retry{
+				NumRetries: 12,
+			},
 		},
 	}
 
@@ -447,6 +477,11 @@ func TestLoadConfigFile_AgentCache_AutoAuth_False(t *testing.T) {
 			UseAutoAuthTokenRaw: "false",
 			ForceAutoAuthToken:  false,
 		},
+		Vault: &Vault{
+			Retry: &Retry{
+				NumRetries: 12,
+			},
+		},
 	}
 
 	config.Listeners[0].RawConfig = nil
@@ -479,6 +514,11 @@ func TestLoadConfigFile_AgentCache_Persist(t *testing.T) {
 					Address:    "127.0.0.1:8300",
 					TLSDisable: true,
 				},
+			},
+		},
+		Vault: &Vault{
+			Retry: &Retry{
+				NumRetries: 12,
 			},
 		},
 	}
@@ -596,6 +636,11 @@ func TestLoadConfigFile_Template(t *testing.T) {
 						},
 					},
 				},
+				Vault: &Vault{
+					Retry: &Retry{
+						NumRetries: 12,
+					},
+				},
 				Templates: tc.expectedTemplates,
 			}
 
@@ -692,6 +737,11 @@ func TestLoadConfigFile_Template_NoSinks(t *testing.T) {
 					Sinks: nil,
 				},
 				Templates: tc.expectedTemplates,
+				Vault: &Vault{
+					Retry: &Retry{
+						NumRetries: 12,
+					},
+				},
 			}
 
 			if diff := deep.Equal(config, expected); diff != nil {
@@ -809,6 +859,11 @@ func TestLoadConfigFile_EnforceConsistency(t *testing.T) {
 		Cache: &Cache{
 			EnforceConsistency: "always",
 			WhenInconsistent:   "retry",
+		},
+		Vault: &Vault{
+			Retry: &Retry{
+				NumRetries: 12,
+			},
 		},
 	}
 

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -82,6 +82,9 @@ func TestLoadConfigFile_AgentCache(t *testing.T) {
 			TLSSkipVerify:    true,
 			ClientCert:       "config_client_cert",
 			ClientKey:        "config_client_key",
+			Retry: &Retry{
+				NumRetries: 12,
+			},
 		},
 	}
 

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -731,14 +731,9 @@ func TestLoadConfigFile_Vault_Retry(t *testing.T) {
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
-		},
-		TemplateRetry: &TemplateRetry{
-			Enabled:       true,
-			Attempts:      5,
-			BackoffRaw:    nil,
-			Backoff:       100 * time.Millisecond,
-			MaxBackoffRaw: nil,
-			MaxBackoff:    400 * time.Millisecond,
+			Retry: &Retry{
+				NumRetries: 5,
+			},
 		},
 	}
 
@@ -780,14 +775,9 @@ func TestLoadConfigFile_Vault_Retry_Empty(t *testing.T) {
 		},
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
-		},
-		TemplateRetry: &TemplateRetry{
-			Enabled:       false,
-			Attempts:      ctconfig.DefaultRetryAttempts,
-			BackoffRaw:    nil,
-			Backoff:       ctconfig.DefaultRetryBackoff,
-			MaxBackoffRaw: nil,
-			MaxBackoff:    ctconfig.DefaultRetryMaxBackoff,
+			Retry: &Retry{
+				ctconfig.DefaultRetryAttempts,
+			},
 		},
 	}
 

--- a/command/agent/config/test-fixtures/config-vault-retry-empty.hcl
+++ b/command/agent/config/test-fixtures/config-vault-retry-empty.hcl
@@ -23,6 +23,6 @@ auto_auth {
 
 vault {
   address = "http://127.0.0.1:1111"
+  retry {}
 }
 
-template_retry {}

--- a/command/agent/config/test-fixtures/config-vault-retry.hcl
+++ b/command/agent/config/test-fixtures/config-vault-retry.hcl
@@ -23,11 +23,7 @@ auto_auth {
 
 vault {
   address = "http://127.0.0.1:1111"
-}
-
-template_retry {
-  enabled = true
-  attempts = 5
-  backoff = "100ms"
-  max_backoff = "400ms"
+  retry {
+    num_retries = 5
+  }
 }

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -282,8 +282,10 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 			CaPath:  &sc.AgentConfig.Vault.CAPath,
 		}
 	}
+	enabled := attempts > 0
 	conf.Vault.Retry = &ctconfig.RetryConfig{
 		Attempts: &attempts,
+		Enabled:  &enabled,
 	}
 
 	conf.Finalize()

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -65,10 +65,6 @@ type Server struct {
 
 	logger        hclog.Logger
 	exitAfterAuth bool
-
-	// testingLimitRetry is used for tests to limit the number of retries
-	// performed by the template server
-	testingLimitRetry int
 }
 
 // NewServer returns a new configured server
@@ -164,19 +160,6 @@ func (ts *Server) Run(ctx context.Context, incoming chan string, templates []*ct
 					},
 				}
 
-				if ts.config.AgentConfig.TemplateRetry != nil && ts.config.AgentConfig.TemplateRetry.Enabled {
-					ctv.Vault.Retry = &ctconfig.RetryConfig{
-						Attempts:   &ts.config.AgentConfig.TemplateRetry.Attempts,
-						Backoff:    &ts.config.AgentConfig.TemplateRetry.Backoff,
-						MaxBackoff: &ts.config.AgentConfig.TemplateRetry.MaxBackoff,
-						Enabled:    &ts.config.AgentConfig.TemplateRetry.Enabled,
-					}
-				} else if ts.testingLimitRetry != 0 {
-					// If we're testing, limit retries to 3 attempts to avoid
-					// long test runs from exponential back-offs
-					ctv.Vault.Retry = &ctconfig.RetryConfig{Attempts: &ts.testingLimitRetry}
-				}
-
 				runnerConfig = runnerConfig.Merge(&ctv)
 				var runnerErr error
 				ts.runner, runnerErr = manager.NewRunner(runnerConfig, false)
@@ -255,8 +238,21 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		ServerName: pointerutil.StringPtr(""),
 	}
 
+	// The cache does its own retry management based on sc.AgentConfig.Retry,
+	// so we only want to set this up for templating if we're not routing
+	// templating through the cache.  We do need to assign something to Retry
+	// though or it will use its default of 12 retries.
+	var attempts int
+	if sc.AgentConfig.Vault != nil && sc.AgentConfig.Vault.Retry != nil {
+		attempts = sc.AgentConfig.Vault.Retry.NumRetries
+	}
+
 	// Use the cache if available or fallback to the Vault server values.
+	// For now we're only routing templating through the cache when persistence
+	// is enabled. The templating engine and the cache have some inconsistencies
+	// that need to be fixed for 1.7x/1.8
 	if sc.AgentConfig.Cache != nil && sc.AgentConfig.Cache.Persist != nil && len(sc.AgentConfig.Listeners) != 0 {
+		attempts = 0
 		scheme := "unix://"
 		if sc.AgentConfig.Listeners[0].Type == "tcp" {
 			scheme = "https://"
@@ -285,6 +281,9 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 			CaCert:  &sc.AgentConfig.Vault.CACert,
 			CaPath:  &sc.AgentConfig.Vault.CAPath,
 		}
+	}
+	conf.Vault.Retry = &ctconfig.RetryConfig{
+		Attempts: &attempts,
 	}
 
 	conf.Finalize()

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -454,6 +454,9 @@ func TestServerRun(t *testing.T) {
 				AgentConfig: &config.Config{
 					Vault: &config.Vault{
 						Address: ts.URL,
+						Retry: &config.Retry{
+							NumRetries: 3,
+						},
 					},
 				},
 				LogLevel:      hclog.Trace,
@@ -466,7 +469,6 @@ func TestServerRun(t *testing.T) {
 			if ts == nil {
 				t.Fatal("nil server returned")
 			}
-			server.testingLimitRetry = 3
 
 			errCh := make(chan error)
 			go func() {

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -1362,22 +1362,32 @@ func TestAgent_Template_Retry(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDirRoot)
 
+	intRef := func(i int) *int {
+		return &i
+	}
 	// start test cases here
 	testCases := map[string]struct {
-		retries     int
+		retries     *int
 		expectError bool
 	}{
-		"default": {
-			// Not specifying retries means you keep the default of 12
-			retries:     -1,
-			expectError: false,
+		"none": {
+			retries:     intRef(-1),
+			expectError: true,
 		},
 		"one": {
-			retries:     1,
+			retries:     intRef(1),
 			expectError: true,
 		},
 		"two": {
-			retries:     2,
+			retries:     intRef(2),
+			expectError: false,
+		},
+		"missing": {
+			retries:     nil,
+			expectError: false,
+		},
+		"default": {
+			retries:     intRef(0),
 			expectError: false,
 		},
 	}
@@ -1428,8 +1438,8 @@ auto_auth {
 %s
 `
 			var retryConf string
-			if tc.retries >= 0 {
-				retryConf = fmt.Sprintf("retry { num_retries = %d }", tc.retries)
+			if tc.retries != nil {
+				retryConf = fmt.Sprintf("retry { num_retries = %d }", *tc.retries)
 			}
 
 			config := fmt.Sprintf(configPat, serverClient.Address(), retryConf, roleIDPath, secretIDPath, templateConfig)

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -1517,7 +1517,7 @@ path "/secret/*" {
 	roleID := resp.Data["role_id"].(string)
 	roleIDFile := makeTempFile(t, "role_id.txt", roleID+"\n")
 
-	return fmt.Sprintf(`
+	config := fmt.Sprintf(`
 auto_auth {
     method "approle" {
         mount_path = "auth/approle"
@@ -1528,10 +1528,13 @@ auto_auth {
         }
     }
 }
-`, roleIDFile, secretIDFile), func() {
-			_ = os.Remove(roleIDFile)
-			_ = os.Remove(secretIDFile)
-		}
+`, roleIDFile, secretIDFile)
+
+	cleanup := func() {
+		_ = os.Remove(roleIDFile)
+		_ = os.Remove(secretIDFile)
+	}
+	return config, cleanup
 }
 
 func TestAgent_Cache_Retry(t *testing.T) {


### PR DESCRIPTION
Remove template_retry config section.  Add new vault.retry section which only has num_retries field; if num_retries is 0 or absent, default it to 12 for backwards compat.

Configured retries are used for both templating and api proxy, though if template requests go through proxy (currently requires persistence enabled) we'll only configure retries for the latter to avoid duplicate retrying.  Though there is some duplicate retrying already because whenever the template server does a retry when not going through the proxy, the Vault client it uses allows for two behind-the-scenes retries for some 400/500 http error codes.
