### PR TITLE
Updates docs for jwt_supported_algs in JWT/OIDC auth method

### DIFF
--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -20,7 +20,7 @@ at any location, please update your API calls accordingly.
 ## Configure
 
 Configures the validation information to be used globally across all roles. One
-(and only one) of `oidc_discovery_url` and `jwt_validation_pubkeys` must be
+(and only one) of `oidc_discovery_url`, `jwks_url`, and `jwt_validation_pubkeys` must be
 set.
 
 | Method | Path               |
@@ -40,7 +40,7 @@ set.
 - `jwks_ca_pem` `(string: <optional>)` - The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URL. If not set, system certificates are used.
 - `jwt_validation_pubkeys` `(comma-separated string, or array of strings: <optional>)` - A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with "jwks_url" or "oidc_discovery_url".
 - `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT.
-- `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256]. ([Available algorithms](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/master/vendor/github.com/coreos/go-oidc/jose.go#L7) + EdDSA)
+- `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256] for OIDC roles. Defaults to all [available algorithms](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/master/vendor/github.com/hashicorp/cap/jwt/algs.go#L12-L21) for JWT roles.
 - `default_role` `(string: <optional>)` - The default role to use if none is provided during login.
 - `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include Azure; the options are described in each provider's section in [OIDC Provider Setup](/docs/auth/jwt_oidc_providers)
 - `namespace_in_state` `(bool: true)` - Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.


### PR DESCRIPTION
This PR updates the API docs for the `jwt_supported_algs` parameter of the JWT/OIDC auth method. It clarifies the defaults that'll be used for both OIDC and JWT roles.

This also adds a missing configuration option (`jwks_url`) to the API description.