### PR TITLE
UI: Connection "Add Role" automatically populates database in form

### DIFF
--- a/changelog/11119.txt
+++ b/changelog/11119.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Add role from database connection automatically populates the database for new role
+```

--- a/ui/app/components/database-role-edit.js
+++ b/ui/app/components/database-role-edit.js
@@ -19,6 +19,9 @@ export default class DatabaseRoleEdit extends Component {
     ) {
       this.wizard.transitionFeatureMachine(this.wizard.featureState, 'CONTINUE', 'database');
     }
+    if (this.args.initialKey) {
+      this.args.model.database = [this.args.initialKey];
+    }
   }
 
   @tracked loading = false;

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -60,7 +60,7 @@
         @secret=''
         @mode="create"
         @type="add"
-        @queryParams={{query-params initialKey=(or filter baseKey.id) itemType="role"}}
+        @queryParams={{query-params initialKey=@model.name itemType="role"}}
         @data-test-secret-create=true
       >
         Add role

--- a/ui/tests/acceptance/secrets/backend/database/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/secret-test.js
@@ -139,6 +139,14 @@ module('Acceptance | secrets/database/*', function(hooks) {
     assert
       .dom(`[data-test-row-value="Write concern"]`)
       .hasText('{ "wtimeout": 5000 }', 'Write concern is now showing on the table');
+    // click "Add Role"
+    await click('[data-test-secret-create="true"]');
+    await settled();
+    assert.equal(
+      searchSelectComponent.selectedOptions[0].text,
+      connectionDetails.id,
+      'Database connection is pre-selected on the form'
+    );
   });
 
   test('buttons show up for managing connection', async function(assert) {


### PR DESCRIPTION
Database role create form will automatically populate database from the query param `initialKey` when added from a connection:

![populated-db](https://user-images.githubusercontent.com/16182107/111369224-d1d23d00-8664-11eb-856f-041fc4f93d4f.gif)
