### PR TITLE
Add note that static role is rotated upon creation

### DIFF
--- a/website/content/api-docs/secret/databases/index.mdx
+++ b/website/content/api-docs/secret/databases/index.mdx
@@ -459,6 +459,9 @@ Static Roles, please see the database-specific documentation.
 
 ~> This endpoint distinguishes between `create` and `update` ACL capabilities.
 
+~> Vault will rotate the password when creating a static role. Vault must do
+this in order to know the password.
+
 | Method | Path                           |
 | :----- | :----------------------------- |
 | `POST` | `/database/static-roles/:name` |


### PR DESCRIPTION
It does not appear to be documented that Vault must rotate the password upon static role creation in order to know the password, as it is not provided.