### PR TITLE
Add a test for server stabilization

### DIFF
--- a/physical/raft/raft_autopilot.go
+++ b/physical/raft/raft_autopilot.go
@@ -670,13 +670,20 @@ func (b *RaftBackend) SetupAutopilot(ctx context.Context, storageConfig *Autopil
 	b.autopilotConfig.Merge(storageConfig)
 
 	// Create the autopilot instance
-	b.autopilot = autopilot.New(b.raft, newDelegate(b), autopilot.WithLogger(b.logger), autopilot.WithPromoter(b.autopilotPromoter()))
+	options := []autopilot.Option{
+		autopilot.WithLogger(b.logger),
+		autopilot.WithPromoter(b.autopilotPromoter()),
+	}
+	if b.autopilotReconcileInterval != 0 {
+		options = append(options, autopilot.WithReconcileInterval(b.autopilotReconcileInterval))
+	}
+	b.autopilot = autopilot.New(b.raft, newDelegate(b), options...)
 	b.followerStates = followerStates
 	b.followerHeartbeatTicker = time.NewTicker(1 * time.Second)
 
 	b.l.Unlock()
 
-	b.logger.Info("starting autopilot", "config", b.autopilotConfig)
+	b.logger.Info("starting autopilot", "config", b.autopilotConfig, "reconcile_interval", b.autopilotReconcileInterval)
 	b.autopilot.Start(ctx)
 
 	go b.startFollowerHeartbeatTracker()

--- a/vault/external_tests/raft/raft_autopilot_test.go
+++ b/vault/external_tests/raft/raft_autopilot_test.go
@@ -2,21 +2,26 @@ package rafttests
 
 import (
 	"context"
+	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/api"
-	"github.com/kr/pretty"
-
+	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-hclog"
 	autopilot "github.com/hashicorp/raft-autopilot"
-
-	"github.com/stretchr/testify/require"
-
+	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers"
+	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
 	"github.com/hashicorp/vault/physical/raft"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"github.com/hashicorp/vault/vault"
+	"github.com/kr/pretty"
+	testingintf "github.com/mitchellh/go-testing-interface"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRaft_Autopilot_Disable(t *testing.T) {
@@ -207,4 +212,186 @@ func TestRaft_Autopilot_Configuration(t *testing.T) {
 	cluster.UnsealCore(t, leaderCore)
 	vault.TestWaitActive(t, leaderCore.Core)
 	configCheckFunc(config)
+}
+
+func TestRaft_SnapshotDelay(t *testing.T) {
+	t.Parallel()
+
+	metricsConf := metrics.DefaultConfig("vault")
+	inmem := metrics.NewInmemSink(1000000*time.Hour, 2000000*time.Hour)
+	metrics.NewGlobal(metricsConf, inmem)
+
+	conf, opts := teststorage.ClusterSetup(nil, nil, teststorage.RaftBackendSetup)
+	opts.SetupFunc = nil
+	opts.Logger = logging.NewVaultLogger(hclog.Trace).Named(t.Name())
+	opts.PhysicalFactory = func(t testingintf.T, coreIdx int, logger hclog.Logger, conf map[string]interface{}) *vault.PhysicalBackendBundle {
+		config := map[string]interface{}{
+			"snapshot_threshold":     "50",
+			"trailing_logs":          "100",
+			"performance_multiplier": "1",
+		}
+		if coreIdx == 2 {
+			config["snapshot_delay"] = time.Duration(5 * time.Second).String()
+		}
+		return teststorage.MakeRaftBackend(t, coreIdx, logger, config)
+	}
+
+	cluster := vault.NewTestCluster(t, conf, opts)
+	cluster.Start()
+	defer cluster.Cleanup()
+	testhelpers.WaitForActiveNodeAndStandbys(t, cluster)
+
+	// At this point we have all nodes up and running and in sync.  Let's take
+	// one down so that once we write a bunch of data, it'll need a snapshot
+	// to come back in sync after we bring it back up.
+
+	testhelpers.EnsureCoreSealed(t, cluster.Cores[2])
+
+	dumpmetrics := func() {
+		data := inmem.Data()
+		latest := data[len(data)-1]
+		for key, val := range latest.Samples {
+			if strings.HasPrefix(key, "vault.raft.replication") && !strings.Contains(key, "core-0") && !strings.Contains(key, ";") {
+				t.Log(key, val)
+			}
+		}
+	}
+
+	dumpmetrics()
+
+	time.Sleep(5 * time.Second)
+	testhelpers.EnsureCoreUnsealed(t, cluster, cluster.Cores[2])
+	time.Sleep(15 * time.Second)
+	dumpmetrics()
+}
+
+// TestRaft_Autopilot_Stabilization_Delay verifies that if a node takes a long
+// time to become ready, it doesn't get promoted to voter until then.
+func TestRaft_Autopilot_Stabilization_Delay(t *testing.T) {
+	conf, opts := teststorage.ClusterSetup(nil, nil, teststorage.RaftBackendSetup)
+	conf.DisableAutopilot = false
+	opts.InmemClusterLayers = true
+	opts.KeepStandbysSealed = true
+	opts.SetupFunc = nil
+	timeToHealthyCore2 := 5 * time.Second
+	opts.PhysicalFactory = func(t testingintf.T, coreIdx int, logger hclog.Logger, conf map[string]interface{}) *vault.PhysicalBackendBundle {
+		config := map[string]interface{}{
+			"snapshot_threshold":           "50",
+			"trailing_logs":                "100",
+			"autopilot_reconcile_interval": "1s",
+			"performance_multiplier":       "1",
+		}
+		if coreIdx == 2 {
+			config["snapshot_delay"] = timeToHealthyCore2.String()
+		}
+		return teststorage.MakeRaftBackend(t, coreIdx, logger, config)
+	}
+
+	cluster := vault.NewTestCluster(t, conf, opts)
+	cluster.Start()
+	defer cluster.Cleanup()
+	testhelpers.WaitForActiveNode(t, cluster)
+
+	// Check that autopilot execution state is running
+	client := cluster.Cores[0].Client
+	state, err := client.Sys().RaftAutopilotState()
+	require.NotNil(t, state)
+	require.NoError(t, err)
+	require.Equal(t, true, state.Healthy)
+	require.Len(t, state.Servers, 1)
+	require.Equal(t, "core-0", state.Servers["core-0"].ID)
+	require.Equal(t, "alive", state.Servers["core-0"].NodeStatus)
+	require.Equal(t, "leader", state.Servers["core-0"].Status)
+
+	_, err = client.Logical().Write("sys/storage/raft/autopilot/configuration", map[string]interface{}{
+		"server_stabilization_time": "3s",
+	})
+	require.NoError(t, err)
+
+	config, err := client.Sys().RaftAutopilotConfiguration()
+	require.NoError(t, err)
+
+	// Wait for 110% of the stabilization time to add nodes
+	stabilizationKickOffWaitDuration := time.Duration(math.Ceil(1.1 * float64(config.ServerStabilizationTime)))
+	time.Sleep(stabilizationKickOffWaitDuration)
+
+	cli := cluster.Cores[0].Client
+	// Write more keys than snapshot_threshold
+	for i := 0; i < 250; i++ {
+		_, err := cli.Logical().Write(fmt.Sprintf("secret/%d", i), map[string]interface{}{
+			"test": "data",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	joinFunc := func(core *vault.TestClusterCore) {
+		_, err := core.JoinRaftCluster(namespace.RootContext(context.Background()), []*raft.LeaderJoinInfo{
+			{
+				LeaderAPIAddr: client.Address(),
+				TLSConfig:     cluster.Cores[0].TLSConfig,
+				Retry:         true,
+			},
+		}, false)
+		require.NoError(t, err)
+		time.Sleep(1 * time.Second)
+		cluster.UnsealCore(t, core)
+	}
+
+	checkState := func(nodeID string, numServers int, allHealthy bool, healthy bool, suffrage string) {
+		state, err = client.Sys().RaftAutopilotState()
+		require.NoError(t, err)
+		require.Equal(t, allHealthy, state.Healthy)
+		require.Len(t, state.Servers, numServers)
+		require.Equal(t, healthy, state.Servers[nodeID].Healthy)
+		require.Equal(t, "alive", state.Servers[nodeID].NodeStatus)
+		require.Equal(t, suffrage, state.Servers[nodeID].Status)
+	}
+
+	joinFunc(cluster.Cores[1])
+	checkState("core-1", 2, false, false, "non-voter")
+
+	core2shouldBeHealthyAt := time.Now().Add(timeToHealthyCore2)
+	joinFunc(cluster.Cores[2])
+	checkState("core-2", 3, false, false, "non-voter")
+
+	stabilizationWaitDuration := time.Duration(1.25 * float64(config.ServerStabilizationTime))
+	deadline := time.Now().Add(stabilizationWaitDuration)
+	var core1healthy, core2healthy bool
+	for time.Now().Before(deadline) {
+		state, err := client.Sys().RaftAutopilotState()
+		require.NoError(t, err)
+		core1healthy = state.Servers["core-1"].Healthy
+		core2healthy = state.Servers["core-2"].Healthy
+		time.Sleep(1 * time.Second)
+	}
+	if !core1healthy || core2healthy {
+		t.Fatalf("expected health: core1=true and core2=false, got: core=%v, core2=%v", core1healthy, core2healthy)
+	}
+
+	time.Sleep(2 * time.Second) // wait for reconciliation
+	state, err = client.Sys().RaftAutopilotState()
+	require.NoError(t, err)
+	require.Equal(t, []string{"core-0", "core-1"}, state.Voters)
+
+	for time.Now().Before(core2shouldBeHealthyAt) {
+		state, err := client.Sys().RaftAutopilotState()
+		require.NoError(t, err)
+		core2healthy = state.Servers["core-2"].Healthy
+		time.Sleep(1 * time.Second)
+		t.Log(core2healthy)
+	}
+
+	deadline = time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		state, err = client.Sys().RaftAutopilotState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strutil.EquivalentSlices(state.Voters, []string{"core-0", "core-1", "core-2"}) {
+			break
+		}
+	}
+	require.Equal(t, state.Voters, []string{"core-0", "core-1", "core-2"})
 }

--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -5,29 +5,24 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/sdk/logical"
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
-	"github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/vault/api"
 	credUserpass "github.com/hashicorp/vault/builtin/credential/userpass"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers"
 	"github.com/hashicorp/vault/helper/testhelpers/teststorage"
 	vaulthttp "github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/physical/raft"
-	"github.com/hashicorp/vault/sdk/helper/logging"
-
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
-	vaultcluster "github.com/hashicorp/vault/vault/cluster"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 )
@@ -55,20 +50,7 @@ func raftCluster(t testing.TB, ropts *RaftClusterOpts) *vault.TestCluster {
 	var opts = vault.TestClusterOptions{
 		HandlerFunc: vaulthttp.Handler,
 	}
-	opts.Logger = logging.NewVaultLogger(hclog.Trace).Named(t.Name())
-
-	if ropts.InmemCluster {
-		inmemCluster, err := vaultcluster.NewInmemLayerCluster("inmem-cluster", 3, hclog.New(&hclog.LoggerOptions{
-			Mutex: &sync.Mutex{},
-			Level: hclog.Trace,
-			Name:  "inmem-cluster",
-		}))
-		if err != nil {
-			t.Fatal(err)
-		}
-		opts.ClusterLayers = inmemCluster
-	}
-
+	opts.InmemClusterLayers = ropts.InmemCluster
 	opts.PhysicalFactoryConfig = ropts.PhysicalFactoryConfig
 	conf.DisablePerformanceStandby = ropts.DisablePerfStandby
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1081,6 +1081,9 @@ type TestClusterOptions struct {
 
 	// ClusterLayers are used to override the default cluster connection layer
 	ClusterLayers cluster.NetworkLayerSet
+	// InmemClusterLayers is a shorthand way of asking for ClusterLayers to be
+	// built using the inmem implementation.
+	InmemClusterLayers bool
 
 	// RaftAddressProvider is used to set the raft ServerAddressProvider on
 	// each core.
@@ -1560,6 +1563,17 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 	}
 	testCluster.pubKey = pubKey
 	testCluster.priKey = priKey
+
+	if opts.InmemClusterLayers {
+		if opts.ClusterLayers != nil {
+			t.Fatalf("cannot specify ClusterLayers when InmemClusterLayers is true")
+		}
+		inmemCluster, err := cluster.NewInmemLayerCluster("inmem-cluster", numCores, testCluster.Logger.Named("inmem-cluster"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		opts.ClusterLayers = inmemCluster
+	}
 
 	// Create cores
 	testCluster.cleanupFuncs = []func(){}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1564,7 +1564,7 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 	testCluster.pubKey = pubKey
 	testCluster.priKey = priKey
 
-	if opts.InmemClusterLayers {
+	if opts != nil && opts.InmemClusterLayers {
 		if opts.ClusterLayers != nil {
 			t.Fatalf("cannot specify ClusterLayers when InmemClusterLayers is true")
 		}


### PR DESCRIPTION
Add raft autopilot_reconcile_interval option.  Move the inmem cluster layer option to TestClusterOptions.  