### PR TITLE
Changelog for orphan status fix

### DIFF
--- a/changelog/_1792.txt
+++ b/changelog/_1792.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core (enterprise): Fix orphan return value from auth methods executed on performance standby nodes.
+```


### PR DESCRIPTION
Release note for enterprise PR https://github.com/hashicorp/vault-enterprise/pull/1787
(No other OSS changes.)