### PR TITLE
docs: update vault-k8s to 0.9.0

### DIFF
--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -144,7 +144,10 @@ them, optional commands to run, etc.
   (uid 0), the `run-as-same-user` annotation will fail injection with an error.
 
 - `vault.hashicorp.com/agent-cache-enable` - configures Vault Agent to enable
-  [caching](/docs/agent/caching). Defaults to `false`.
+  [caching](/docs/agent/caching). In Vault 1.7+ this annotation will also enable 
+  a Vault persistent cache. This persistent cache will be shared between the init 
+  and sidecar container to reuse tokens and leases retrieved by the init container. 
+  Defaults to `false`. 
 
 - `vault.hashicorp.com/agent-cache-use-auto-auth-token` - configures Vault Agent cache
   to authenticate on behalf of the requester. Set to `force` to enable. Disabled
@@ -163,8 +166,18 @@ Vault annotations change how the Vault Agent containers communicate with Vault. 
 example, Vault's address, TLS certificates to use, client parameters such as timeouts,
 etc.
 
-- `vault.hashicorp.com/auth-path` - configures the auth path for the Kubernetes
+- `vault.hashicorp.com/auth-config` - configures additional parameters for the configured 
+  authentication method. The name of the config is any unique string after 
+  `vault.hashicorp.com/auth-config-`, such as `vault.hashicorp.com/auth-config-role-id-file-path`. 
+  This annotation can be reused multiple times to configure multiple settings for the authentication
+  method. Some authentication methods may require additional secrets and should be mounted via the 
+  `vault.hashicorp.com/agent-extra-secret` annotation.
+
+- `vault.hashicorp.com/auth-path` - configures the authentication path for the Kubernetes
   auth method. Defaults to `auth/kubernetes`.
+
+- `vault.hashicorp.com/auth-type` - configures the authentication type for Vault Agent.
+  Defaults to `kubernetes`.
 
 - `vault.hashicorp.com/ca-cert` - path of the CA certificate used to verify Vault's
   TLS.
@@ -193,6 +206,9 @@ etc.
 
 - `vault.hashicorp.com/namespace` - configures the Vault Enterprise namespace to
   be used when requesting secrets from Vault.
+
+- `vault.hashicorp.com/proxy-address` - configures the HTTP proxy to use when connecting 
+  to a Vault server.
 
 - `vault.hashicorp.com/role` - configures the Vault role used by the Vault Agent
   auto-auth method. Required when `vault.hashicorp.com/agent-configmap` is not set.

--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -29,7 +29,7 @@ them, optional commands to run, etc.
 
 - `vault.hashicorp.com/agent-image` - name of the Vault docker image to use. This
   value overrides the default image configured in the controller and is usually
-  not needed. Defaults to `vault:1.4.2`.
+  not needed. Defaults to `vault:1.6.3`.
 
 - `vault.hashicorp.com/agent-init-first` - configures the pod to run the Vault Agent
   init container first if `true` (last if `false`). This is useful when other init

--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -171,13 +171,15 @@ etc.
   `vault.hashicorp.com/auth-config-`, such as `vault.hashicorp.com/auth-config-role-id-file-path`. 
   This annotation can be reused multiple times to configure multiple settings for the authentication
   method. Some authentication methods may require additional secrets and should be mounted via the 
-  `vault.hashicorp.com/agent-extra-secret` annotation.
+  `vault.hashicorp.com/agent-extra-secret` annotation. For a list of valid authentication configurations, 
+  see the Vault Agent [auto-auth documentation](/docs/agent/autoauth/methods).
 
 - `vault.hashicorp.com/auth-path` - configures the authentication path for the Kubernetes
   auth method. Defaults to `auth/kubernetes`.
 
 - `vault.hashicorp.com/auth-type` - configures the authentication type for Vault Agent.
-  Defaults to `kubernetes`.
+  Defaults to `kubernetes`. For a list of valid authentication methods, see the Vault Agent 
+  [auto-auth documentation](/docs/agent/autoauth/methods).
 
 - `vault.hashicorp.com/ca-cert` - path of the CA certificate used to verify Vault's
   TLS.

--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -145,7 +145,7 @@ them, optional commands to run, etc.
 
 - `vault.hashicorp.com/agent-cache-enable` - configures Vault Agent to enable
   [caching](/docs/agent/caching). In Vault 1.7+ this annotation will also enable 
-  a Vault persistent cache. This persistent cache will be shared between the init 
+  a Vault Agent persistent cache. This persistent cache will be shared between the init 
   and sidecar container to reuse tokens and leases retrieved by the init container. 
   Defaults to `false`. 
 

--- a/website/content/docs/platform/k8s/injector/examples.mdx
+++ b/website/content/docs/platform/k8s/injector/examples.mdx
@@ -290,3 +290,52 @@ spec:
           ports:
             - containerPort: 9090
 ```
+
+## AppRole Authentication
+
+The following example demonstrates how the AppRole authentication method can be by 
+Vault Agent for retrieving secrets. A Kubernetes secret containing the AppRole secret ID 
+and role ID should be created first.
+
+```yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-deployment
+  labels:
+    app: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/agent-extra-secret: "approle-example"
+        vault.hashicorp.com/auth-type: "approle"
+        vault.hashicorp.com/auth-path: "auth/approle"
+        vault.hashicorp.com/auth-config-role-id-file-path: "/vault/custom/role-id"
+        vault.hashicorp.com/auth-config-secret-id-file-path: "/vault/custom/secret-id"
+        vault.hashicorp.com/agent-inject-secret-db-creds: "database/creds/db-app"
+        vault.hashicorp.com/agent-inject-template-db-creds: |
+          {{- with secret "database/creds/db-app" -}}
+          postgres://{{ .Data.username }}:{{ .Data.password }}@postgres.postgres.svc:5432/wizard?sslmode=disable
+          {{- end }}
+        vault.hashicorp.com/role: "my-role"
+        vault.hashicorp.com/tls-secret: "vault-tls"
+        vault.hashicorp.com/ca-cert: "/vault/tls/ca.crt"
+    spec:
+      serviceAccountName: web
+      containers:
+        - name: web
+          image: alpine:latest
+          args:
+            ['sh', '-c', 'source /vault/secrets/config && <entrypoint script>']
+          ports:
+            - containerPort: 9090
+```

--- a/website/content/docs/platform/k8s/injector/examples.mdx
+++ b/website/content/docs/platform/k8s/injector/examples.mdx
@@ -293,7 +293,7 @@ spec:
 
 ## AppRole Authentication
 
-The following example demonstrates how the AppRole authentication method can be by 
+The following example demonstrates how the AppRole authentication method can be used by 
 Vault Agent for retrieving secrets. A Kubernetes secret containing the AppRole secret ID 
 and role ID should be created first.
 

--- a/website/content/docs/platform/k8s/injector/index.mdx
+++ b/website/content/docs/platform/k8s/injector/index.mdx
@@ -53,7 +53,7 @@ The primary method of authentication with Vault when using the Vault Agent Injec
 is the service account attached to the pod. Other authentication methods can be configured 
 using annotations.
 
-For Kubernetes authenticatioin, the service account must be bound to a Vault role and a 
+For Kubernetes authentication, the service account must be bound to a Vault role and a 
 policy granting access to the secrets desired.
 
 A service account must be present to use the Vault Agent Injector with the Kubernetes 

--- a/website/content/docs/platform/k8s/injector/index.mdx
+++ b/website/content/docs/platform/k8s/injector/index.mdx
@@ -50,15 +50,15 @@ useful to customize Vault Agent beyond what the provided annotations offer.
 ### Authenticating with Vault
 
 The primary method of authentication with Vault when using the Vault Agent Injector
-is the service account attached to the pod. At this time, no other authentication
-method is supported by the controller.
+is the service account attached to the pod. Other authentication methods can be configured 
+using annotations.
 
-The service account must be bound to a Vault role and a policy granting access to
-the secrets desired.
+For Kubernetes authenticatioin, the service account must be bound to a Vault role and a 
+policy granting access to the secrets desired.
 
-A service account must be present to use the Vault Agent Injector. It is _not_
-recommended to bind Vault roles to the default service account provided to pods
-if no service account is defined.
+A service account must be present to use the Vault Agent Injector with the Kubernetes 
+authentication method. It is _not_ recommended to bind Vault roles to the default service 
+account provided to pods if no service account is defined.
 
 ### Requesting Secrets
 


### PR DESCRIPTION
Updated for the newest release of Vault K8s: https://github.com/hashicorp/vault-k8s/blob/master/CHANGELOG.md. The version numbers in the Helm documentation are still valid until we release a new Helm chart.