### PR TITLE
Update MMMM Do yyyy to MMMM do yyyy per date-fns format docs

### DIFF
--- a/changelog/11142.txt
+++ b/changelog/11142.txt
@@ -1,0 +1,3 @@
+```changelog:bug
+ui: Fix date display on expired token notice
+```

--- a/ui/app/templates/components/token-expire-warning.hbs
+++ b/ui/app/templates/components/token-expire-warning.hbs
@@ -3,7 +3,7 @@
     <AlertBanner
       @type="danger"
       @message="Your auth token expired on
-        {{date-format expirationDate "MMMM Do yyyy, h:mm:ss a"}}
+        {{date-format expirationDate "MMMM do yyyy, h:mm:ss a"}}
          . You will need to re-authenticate."
     >
       <LinkTo @route="vault.cluster.logout" class="button link">


### PR DESCRIPTION
This change corrects the output of the token expiration warning, which was using the key for day of year instead of day of month: 

![image (1)](https://user-images.githubusercontent.com/16182107/111694764-4d1c2600-8800-11eb-8583-db074f7e0e73.png)
