### PR TITLE
Update AWS Auth docs for deprecated terms and endpoints

### DIFF
--- a/website/content/api-docs/auth/aws.mdx
+++ b/website/content/api-docs/auth/aws.mdx
@@ -15,6 +15,10 @@ This documentation assumes the AWS method is mounted at the `/auth/aws`
 path in Vault. Since it is possible to enable auth methods at any location,
 please update your API calls accordingly.
 
+~> **Vault 1.7** deprecated several AWS Auth URLs. The full
+[list of affected endpoints](#deprecations-effective-in-vault-1-7) and their
+replacements is provided at the end of this document.
+
 ## Configure Client
 
 Configures the credentials required to perform API calls to AWS as well as
@@ -508,13 +512,13 @@ $ curl \
     http://127.0.0.1:8200/v1/auth/aws/config/sts/111122223333
 ```
 
-## Configure Identity Whitelist Tidy Operation
+## Configure Identity Access List Tidy Operation
 
-Configures the periodic tidying operation of the whitelisted identity entries.
+Configures the periodic tidying operation of the access listed identity entries.
 
 | Method | Path                                       |
 | :----- | :----------------------------------------- |
-| `POST` | `/auth/aws/config/tidy/identity-whitelist` |
+| `POST` | `/auth/aws/config/tidy/identity-accesslist` |
 
 ### Parameters
 
@@ -522,7 +526,7 @@ Configures the periodic tidying operation of the whitelisted identity entries.
   passed beyond the `roletag` expiration, before it is removed from the method
   storage. Defaults to 72h.
 - `disable_periodic_tidy` `(bool: false)` - If set to 'true', disables the
-  periodic tidying of the `identity-whitelist/<instance_id>` entries.
+  periodic tidying of the `identity-accesslist/<instance_id>` entries.
 
 ### Sample Payload
 
@@ -539,23 +543,23 @@ $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
-    http://127.0.0.1:8200/v1/auth/aws/config/tidy/identity-whitelist
+    http://127.0.0.1:8200/v1/auth/aws/config/tidy/identity-accesslist
 ```
 
-## Read Identity Whitelist Tidy Settings
+## Read Identity Access List Tidy Settings
 
-Returns the previously configured periodic whitelist tidying settings.
+Returns the previously configured periodic access list tidying settings.
 
 | Method | Path                                       |
 | :----- | :----------------------------------------- |
-| `GET`  | `/auth/aws/config/tidy/identity-whitelist` |
+| `GET`  | `/auth/aws/config/tidy/identity-accesslist` |
 
 ### Sample Request
 
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    http://127.0.0.1:8200/v1/auth/aws/config/tidy/identity-whitelist
+    http://127.0.0.1:8200/v1/auth/aws/config/tidy/identity-accesslist
 ```
 
 ### Sample Response
@@ -569,13 +573,13 @@ $ curl \
 }
 ```
 
-## Delete Identity Whitelist Tidy Settings
+## Delete Identity Access List Tidy Settings
 
-Deletes the previously configured periodic whitelist tidying settings.
+Deletes the previously configured periodic access list tidying settings.
 
 | Method   | Path                                       |
 | :------- | :----------------------------------------- |
-| `DELETE` | `/auth/aws/config/tidy/identity-whitelist` |
+| `DELETE` | `/auth/aws/config/tidy/identity-accesslist` |
 
 ### Sample Request
 
@@ -583,16 +587,16 @@ Deletes the previously configured periodic whitelist tidying settings.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
-    http://127.0.0.1:8200/v1/auth/aws/config/tidy/identity-whitelist
+    http://127.0.0.1:8200/v1/auth/aws/config/tidy/identity-accesslist
 ```
 
-## Configure Role Tag Blacklist Tidy Operation
+## Configure Role Tag Deny List Tidy Operation
 
-Configures the periodic tidying operation of the blacklisted role tag entries.
+Configures the periodic tidying operation of the deny listed role tag entries.
 
 | Method | Path                                      |
 | :----- | :---------------------------------------- |
-| `POST` | `/auth/aws/config/tidy/roletag-blacklist` |
+| `POST` | `/auth/aws/config/tidy/roletag-denylist` |
 
 ### Parameters
 
@@ -600,7 +604,7 @@ Configures the periodic tidying operation of the blacklisted role tag entries.
   passed beyond the `roletag` expiration, before it is removed from the method
   storage. Defaults to 72h.
 - `disable_periodic_tidy` `(bool: false)` - If set to 'true', disables the
-  periodic tidying of the `roletag-blacklist/<instance_id>` entries.
+  periodic tidying of the `roletag-denylist/<instance_id>` entries.
 
 ### Sample Payload
 
@@ -617,23 +621,23 @@ $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
-    http://127.0.0.1:8200/v1/auth/aws/config/tidy/roletag-blacklist
+    http://127.0.0.1:8200/v1/auth/aws/config/tidy/roletag-denylist
 ```
 
-## Read Role Tag Blacklist Tidy Settings
+## Read Role Tag Deny List Tidy Settings
 
-Returns the previously configured periodic blacklist tidying settings.
+Returns the previously configured periodic deny list tidying settings.
 
 | Method | Path                                      |
 | :----- | :---------------------------------------- |
-| `GET`  | `/auth/aws/config/tidy/roletag-blacklist` |
+| `GET`  | `/auth/aws/config/tidy/roletag-denylist` |
 
 ### Sample Request
 
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    http://127.0.0.1:8200/v1/auth/aws/config/tidy/roletag-blacklist
+    http://127.0.0.1:8200/v1/auth/aws/config/tidy/roletag-denylist
 ```
 
 ### Sample Response
@@ -647,13 +651,13 @@ $ curl \
 }
 ```
 
-## Delete Role Tag Blacklist Tidy Settings
+## Delete Role Tag Deny List Tidy Settings
 
-Deletes the previously configured periodic blacklist tidying settings.
+Deletes the previously configured periodic deny list tidying settings.
 
 | Method   | Path                                      |
 | :------- | :---------------------------------------- |
-| `DELETE` | `/auth/aws/config/tidy/roletag-blacklist` |
+| `DELETE` | `/auth/aws/config/tidy/roletag-denylist` |
 
 ### Sample Request
 
@@ -661,7 +665,7 @@ Deletes the previously configured periodic blacklist tidying settings.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
-    http://127.0.0.1:8200/v1/auth/aws/config/tidy/roletag-blacklist
+    http://127.0.0.1:8200/v1/auth/aws/config/tidy/roletag-denylist
 ```
 
 ## Create Role
@@ -810,8 +814,8 @@ list in order to satisfy that constraint.
   `disallow_reauthentication`.
 - `disallow_reauthentication` `(bool: false)` - If set, only allows a single
   token to be granted per instance ID. In order to perform a fresh login, the
-  entry in whitelist for the instance ID needs to be cleared using
-  `auth/aws/identity-whitelist/<instance_id>` endpoint. Defaults to 'false'.
+  entry in the access list for the instance ID needs to be cleared using
+  `auth/aws/identity-accesslist/<instance_id>` endpoint. Defaults to 'false'.
   This only applies to authentications via the ec2 auth method. This is mutually
   exclusive with `allow_instance_migration`.
 
@@ -963,7 +967,7 @@ given instance can be allowed to gain in a worst-case scenario.
   Mutually exclusive with `disallow_reauthentication`.
 - `disallow_reauthentication` `(bool: false)` - If set, only allows a single
   token to be granted per instance ID. This can be cleared with the
-  auth/aws/identity-whitelist endpoint. Defaults to 'false'. Mutually exclusive
+  auth/aws/identity-accesslist endpoint. Defaults to 'false'. Mutually exclusive
   with `allow_instance_migration`.
 
 ### Sample Payload
@@ -1030,7 +1034,7 @@ along with its RSA digest can be supplied to this endpoint.
 - `nonce` `(string: "")` - The nonce to be used for subsequent login requests.
   If this parameter is not specified at all and if reauthentication is allowed,
   then the method will generate a random nonce, attaches it to the instance's
-  identity-whitelist entry and returns the nonce back as part of auth metadata.
+  identity-accesslist entry and returns the nonce back as part of auth metadata.
   This value should be used with further login requests, to establish client
   authenticity. Clients can choose to set a custom nonce if preferred, in which
   case, it is recommended that clients provide a strong nonce. If a nonce is
@@ -1097,21 +1101,21 @@ $ curl \
 }
 ```
 
-## Place Role Tags in Blacklist
+## Place Role Tags in Deny List
 
-Places a valid role tag in a blacklist. This ensures that the role tag
+Places a valid role tag in a deny list. This ensures that the role tag
 cannot be used by any instance to perform a login operation again. Note
 that if the role tag was previously used to perform a successful login,
-placing the tag in the blacklist does not invalidate the already issued
+placing the tag in the deny list does not invalidate the already issued
 token.
 
 | Method | Path                                    |
 | :----- | :-------------------------------------- |
-| `POST` | `/auth/aws/roletag-blacklist/:role_tag` |
+| `POST` | `/auth/aws/roletag-denylist/:role_tag` |
 
 ### Parameters
 
-- `role_tag` `(string: <required>)` - Role tag to be blacklisted. This is the `tag_value` returned when the role tag is
+- `role_tag` `(string: <required>)` - Role tag to be deny listed. This is the `tag_value` returned when the role tag is
   created. The tag can be supplied as-is. In order to avoid any encoding problems, it can be base64
   encoded.
 
@@ -1121,20 +1125,20 @@ token.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
-    http://127.0.0.1:8200/v1/auth/aws/roletag-blacklist/djE6MDlWcDBxR3V5Qjg9OmE9YW1pLWZjZTNjNjk2OnA9ZGVmYXVsdCxwcm9kOmQ9ZmFsc2U6dD0zMDBoMG0wczp1UExLQ1F4cXNlZlJocnAxcW1WYTF3c1FWVVhYSkc4VVpQLwo=
+    http://127.0.0.1:8200/v1/auth/aws/roletag-denylist/djE6MDlWcDBxR3V5Qjg9OmE9YW1pLWZjZTNjNjk2OnA9ZGVmYXVsdCxwcm9kOmQ9ZmFsc2U6dD0zMDBoMG0wczp1UExLQ1F4cXNlZlJocnAxcW1WYTF3c1FWVVhYSkc4VVpQLwo=
 ```
 
-### Read Role Tag Blacklist Information
+### Read Role Tag Deny List Information
 
-Returns the blacklist entry of a previously blacklisted role tag.
+Returns the deny list entry of a previously deny listed role tag.
 
 | Method | Path                                    |
 | :----- | :-------------------------------------- |
-| `GET`  | `/auth/aws/roletag-blacklist/:role_tag` |
+| `GET`  | `/auth/aws/roletag-denylist/:role_tag` |
 
 ### Parameters
 
-- `role_tag` `(string: <required>)` - Role tag to be blacklisted. The tag can be
+- `role_tag` `(string: <required>)` - Role tag to be deny listed. The tag can be
   supplied as-is. In order to avoid any encoding problems, it can be base64
   encoded.
 
@@ -1143,7 +1147,7 @@ Returns the blacklist entry of a previously blacklisted role tag.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    http://127.0.0.1:8200/v1/auth/aws/roletag-blacklist/djE6MDlWcDBxR3V5Qjg9OmE9YW1pLWZjZTNjNjk2OnA9ZGVmYXVsdCxwcm9kOmQ9ZmFsc2U6dD0zMDBoMG0wczp1UExLQ1F4cXNlZlJocnAxcW1WYTF3c1FWVVhYSkc4VVpQLwo=
+    http://127.0.0.1:8200/v1/auth/aws/roletag-denylist/djE6MDlWcDBxR3V5Qjg9OmE9YW1pLWZjZTNjNjk2OnA9ZGVmYXVsdCxwcm9kOmQ9ZmFsc2U6dD0zMDBoMG0wczp1UExLQ1F4cXNlZlJocnAxcW1WYTF3c1FWVVhYSkc4VVpQLwo=
 ```
 
 ### Sample Response
@@ -1157,13 +1161,13 @@ $ curl \
 }
 ```
 
-## List Blacklist Tags
+## List Deny List Tags
 
-Lists all the role tags that are blacklisted.
+Lists all the role tags that are deny listed.
 
 | Method | Path                          |
 | :----- | :---------------------------- |
-| `LIST` | `/auth/aws/roletag-blacklist` |
+| `LIST` | `/auth/aws/roletag-denylist` |
 
 ### Sample Request
 
@@ -1171,7 +1175,7 @@ Lists all the role tags that are blacklisted.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request LIST \
-    http://127.0.0.1:8200/v1/auth/aws/roletag-blacklist
+    http://127.0.0.1:8200/v1/auth/aws/roletag-denylist
 ```
 
 ### Sample Response
@@ -1186,17 +1190,17 @@ $ curl \
 }
 ```
 
-## Delete Blacklist Tags
+## Delete Deny List Tags
 
-Deletes a blacklisted role tag.
+Deletes a deny listed role tag.
 
 | Method   | Path                                    |
 | :------- | :-------------------------------------- |
-| `DELETE` | `/auth/aws/roletag-blacklist/:role_tag` |
+| `DELETE` | `/auth/aws/roletag-denylist/:role_tag` |
 
 ### Parameters
 
-- `role_tag` `(string: <required>)` - Role tag to be blacklisted. The tag can be
+- `role_tag` `(string: <required>)` - Role tag to be deny listed. The tag can be
   supplied as-is. In order to avoid any encoding problems, it can be base64
   encoded.
 
@@ -1206,17 +1210,17 @@ Deletes a blacklisted role tag.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
-    http://127.0.0.1:8200/v1/auth/aws/roletag-blacklist/djE6MDlWcDBxR3V5Qjg9OmE9YW1pLWZjZTNjNjk2OnA9ZGVmYXVsdCxwcm9kOmQ9ZmFsc2U6dD0zMDBoMG0wczp1UExLQ1F4cXNlZlJocnAxcW1WYTF3c1FWVVhYSkc4VVpQLwo=
+    http://127.0.0.1:8200/v1/auth/aws/roletag-denylist/djE6MDlWcDBxR3V5Qjg9OmE9YW1pLWZjZTNjNjk2OnA9ZGVmYXVsdCxwcm9kOmQ9ZmFsc2U6dD0zMDBoMG0wczp1UExLQ1F4cXNlZlJocnAxcW1WYTF3c1FWVVhYSkc4VVpQLwo=
 ```
 
-## Tidy Blacklist Tags
+## Tidy Deny List Tags
 
-Cleans up the entries in the blacklist based on expiration time on the entry and
+Cleans up the entries in the deny listed based on expiration time on the entry and
 `safety_buffer`.
 
 | Method | Path                               |
 | :----- | :--------------------------------- |
-| `POST` | `/auth/aws/tidy/roletag-blacklist` |
+| `POST` | `/auth/aws/tidy/roletag-denylist` |
 
 ### Parameters
 
@@ -1230,22 +1234,22 @@ Cleans up the entries in the blacklist based on expiration time on the entry and
 $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
-    http://127.0.0.1:8200/v1/auth/aws/tidy/roletag-blacklist
+    http://127.0.0.1:8200/v1/auth/aws/tidy/roletag-denylist
 ```
 
-### Read Identity Whitelist Information
+### Read Identity Access List Information
 
-Returns an entry in the whitelist. An entry will be created/updated by every
+Returns an entry in the identity access list. An entry will be created/updated by every
 successful login.
 
 | Method | Path                                        |
 | :----- | :------------------------------------------ |
-| `GET`  | `/auth/aws/identity-whitelist/:instance_id` |
+| `GET`  | `/auth/aws/identity-accesslist/:instance_id` |
 
 ### Parameters
 
 - `instance_id` `(string: <required>)` - EC2 instance ID. A successful login
-  operation from an EC2 instance gets cached in this whitelist, keyed off of
+  operation from an EC2 instance gets cached in th access list, keyed off of
   instance ID.
 
 ### Sample Request
@@ -1253,7 +1257,7 @@ successful login.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    http://127.0.0.1:8200/v1/auth/aws/identity-whitelist/i-aab47d37
+    http://127.0.0.1:8200/v1/auth/aws/identity-accesslist/i-aab47d37
 ```
 
 ### Sample Response
@@ -1270,13 +1274,13 @@ $ curl \
 }
 ```
 
-## List Identity Whitelist Entries
+## List Identity Access List Entries
 
-Lists all the instance IDs that are in the whitelist of successful logins.
+Lists all the instance IDs that are in the access list of successful logins.
 
 | Method | Path                           |
 | :----- | :----------------------------- |
-| `LIST` | `/auth/aws/identity-whitelist` |
+| `LIST` | `/auth/aws/identity-accesslist` |
 
 ### Sample Request
 
@@ -1284,7 +1288,7 @@ Lists all the instance IDs that are in the whitelist of successful logins.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request LIST \
-    http://127.0.0.1:8200/v1/auth/aws/identity-whitelist
+    http://127.0.0.1:8200/v1/auth/aws/identity-accesslist
 ```
 
 ### Sample Response
@@ -1297,18 +1301,18 @@ $ curl \
 }
 ```
 
-## Delete Identity Whitelist Entries
+## Delete Identity Access List Entries
 
 Deletes a cache of the successful login from an instance.
 
 | Method   | Path                                        |
 | :------- | :------------------------------------------ |
-| `DELETE` | `/auth/aws/identity-whitelist/:instance_id` |
+| `DELETE` | `/auth/aws/identity-accesslist/:instance_id` |
 
 ### Parameters
 
 - `instance_id` `(string: <required>)` - EC2 instance ID. A successful login
-  operation from an EC2 instance gets cached in this whitelist, keyed off of
+  operation from an EC2 instance gets cached in this access list, keyed off of
   instance ID.
 
 ### Sample Request
@@ -1317,17 +1321,17 @@ Deletes a cache of the successful login from an instance.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
-    http://127.0.0.1:8200/v1/auth/aws/identity-whitelist/i-aab47d37
+    http://127.0.0.1:8200/v1/auth/aws/identity-accesslist/i-aab47d37
 ```
 
-## Tidy Identity Whitelist Entries
+## Tidy Identity Access List Entries
 
-Cleans up the entries in the whitelist based on expiration time and
+Cleans up the entries in the access list based on expiration time and
 `safety_buffer`.
 
 | Method | Path                                |
 | :----- | :---------------------------------- |
-| `POST` | `/auth/aws/tidy/identity-whitelist` |
+| `POST` | `/auth/aws/tidy/identity-accesslist` |
 
 ### Parameters
 
@@ -1341,5 +1345,20 @@ Cleans up the entries in the whitelist based on expiration time and
 $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
-    http://127.0.0.1:8200/v1/auth/aws/tidy/identity-whitelist
+    http://127.0.0.1:8200/v1/auth/aws/tidy/identity-accesslist
 ```
+
+## Deprecations effective in Vault 1.7
+
+Vault 1.7 introduced new URLs for a number of AWS Auth APIs. The previous
+URLs are deprecated. The affected APIs include:
+
+| Current                                     | Deprecated in 1.7                          |
+| :------------------------------------------ | :----------------------------------------- |
+| `/auth/aws/roletag-denylist`                | `/auth/aws/roletag-blacklist`              |
+| `/auth/aws/identity-accesslist`             | `/auth/aws/identity-whitelist`             |
+| `/auth/aws/tidy/identity-accesslist`        | `/auth/aws/tidy/identity-whitelist`        |
+| `/auth/aws/tidy/roletag-denylist`           | `/auth/aws/tidy/roletag-blacklist`         |
+| `/auth/aws/config/tidy/identity-accesslist` | `/auth/aws/config/tidy/identity-whitelist` |
+| `/auth/aws/config/tidy/roletag-denylist`    | `/auth/aws/config/tidy/roletag-blacklist`  |
+

--- a/website/content/docs/auth/aws.mdx
+++ b/website/content/docs/auth/aws.mdx
@@ -151,7 +151,7 @@ tag on the instance is deleted for some reason, authentication fails.
 The role tags can be generated at will by an operator with appropriate API
 access. They are HMAC-signed by a per-role key stored within the method, allowing
 the method to verify the authenticity of a found role tag and ensure that it has
-not been tampered with. There is also a mechanism to blacklist role tags if one
+not been tampered with. There is also a mechanism to deny list role tags if one
 has been found to be distributed outside of its intended set of machines.
 
 ## IAM Authentication Inferences
@@ -354,8 +354,8 @@ the intended client will be unable to authenticate and can raise an alert for
 investigation.
 
 During the first login, the method stores the instance ID that authenticated
-in a `whitelist`. One method of operation of the method is to disallow any
-authentication attempt for an instance ID contained in the whitelist, using the
+in a `accesslist`. One method of operation of the method is to disallow any
+authentication attempt for an instance ID contained in the access list, using the
 `disallow_reauthentication` option on the role, meaning that an instance is
 allowed to login only once. However, this has consequences for token rotation,
 as it means that once a token has expired, subsequent authentication attempts
@@ -365,13 +365,13 @@ turned off using `disallow_reauthentication` parameter on the registered role.
 In the default method of operation, the method will return a unique nonce
 during the first authentication attempt, as part of auth `metadata`. Clients
 should present this `nonce` for subsequent login attempts and it should match
-the `nonce` cached at the identity-whitelist entry at the method. Since only
+the `nonce` cached at the identity-accesslist entry at the method. Since only
 the original client knows the `nonce`, only the original client is allowed to
-reauthenticate. (This is the reason that this is a whitelist rather than a
-blacklist; by default, it's keeping track of clients allowed to reauthenticate,
+reauthenticate. (This is the reason that this is a accesslist rather than a
+deny list; by default, it's keeping track of clients allowed to reauthenticate,
 rather than those that are not.). Clients can choose to provide a `nonce` even
 for the first login attempt, in which case the provided `nonce` will be tied to
-the cached identity-whitelist entry. It is recommended to use a strong `nonce`
+the cached identity-accesslist entry. It is recommended to use a strong `nonce`
 value in this case.
 
 It is up to the client to behave correctly with respect to the nonce; if the
@@ -386,7 +386,7 @@ are immutable and single-boot anyways, and in conjunction with a high max TTL,
 reauthentication may not be needed (and if it is, the instance can simply be
 shut down and allow ASG to start a new one).
 
-In both cases, entries can be removed from the whitelist by instance ID,
+In both cases, entries can be removed from the accesslist by instance ID,
 allowing reauthentication by a client if the nonce is lost (or not used) and an
 operator approves the process.
 
@@ -442,8 +442,8 @@ Note: This only applies to the ec2 auth method.
 If an EC2 instance loses its client nonce (due to a reboot, a stop/start of the
 client, etc.), subsequent login attempts will not succeed. If the client nonce
 is lost, normally the only option is to delete the entry corresponding to the
-instance ID from the identity `whitelist` in the method. This can be done via
-the `auth/aws/identity-whitelist/<instance_id>` endpoint. This allows a new
+instance ID from the identity `accesslist` in the method. This can be done via
+the `auth/aws/identity-accesslist/<instance_id>` endpoint. This allows a new
 client nonce to be accepted by the method during the next login request.
 
 Under certain circumstances there is another useful setting. When the instance
@@ -497,7 +497,7 @@ option is set to `false` on the role, a value of `true` in the role tag takes
 effect; however, if the option is set to `true` on the role, a value set in the
 role tag has no effect.
 
-### Blacklisting Role Tags
+### Deny listing Role Tags
 
 Note: this only applies to the ec2 auth method or the iam auth method
 when inferencing is used.
@@ -507,32 +507,32 @@ instances using that role, should have any particular role tag; that is purely u
 to the operator. Although role tags are only restrictive (a tag cannot escalate
 privileges above what is set on its role), if a role tag is found to have been
 used incorrectly, and the administrator wants to ensure that the role tag has no
-further effect, the role tag can be placed on a `blacklist` via the endpoint
-`auth/aws/roletag-blacklist/<role_tag>`. Note that this will not invalidate the
+further effect, the role tag can be placed on a `deny list` via the endpoint
+`auth/aws/roletag-denylist/<role_tag>`. Note that this will not invalidate the
 tokens that were already issued; this only blocks any further login requests from
-those instances that have the blacklisted tag attached to them.
+those instances that have the deny listed tag attached to them.
 
-### Expiration Times and Tidying of `blacklist` and `whitelist` Entries
+### Expiration Times and Tidying of `denylist` and `accesslist` Entries
 
-The expired entries in both identity `whitelist` and role tag `blacklist` are
+The expired entries in both identity `accesslist` and role tag `denylist` are
 deleted automatically. The entries in both of these lists contain an expiration
 time which is dynamically determined by three factors: `max_ttl` set on the role,
 `max_ttl` set on the role tag, and `max_ttl` value of the method mount. The
 least of these three dictates the maximum TTL of the issued token, and
 correspondingly will be set as the expiration times of these entries.
 
-The endpoints `auth/aws/tidy/identity-whitelist` and `auth/aws/tidy/roletag-blacklist` are
+The endpoints `auth/aws/tidy/identity-accesslist` and `auth/aws/tidy/roletag-denylist` are
 provided to clean up the entries present in these lists. These endpoints allow
 defining a safety buffer, such that an entry must not only be expired, but be
 past expiration by the amount of time dictated by the safety buffer in order
 to actually remove the entry.
 
 Automatic deletion of expired entries is performed by the periodic function
-of the method. This function does the tidying of both blacklist role tags
-and whitelist identities. Periodic tidying is activated by default and will
+of the method. This function does the tidying of both access list role tags
+and access list identities. Periodic tidying is activated by default and will
 have a safety buffer of 72 hours, meaning only those entries are deleted which
 were expired before 72 hours from when the tidy operation is being performed.
-This can be configured via `config/tidy/roletag-blacklist` and `config/tidy/identity-whitelist`
+This can be configured via `config/tidy/roletag-denylist` and `config/tidy/identity-accesslist`
 endpoints.
 
 ### Varying Public Certificates


### PR DESCRIPTION
Replace non-inclusive terminology and provide a list of updated endpoints.

Previews of affected pages:

- https://vault-jy4ql2i4f-hashicorp.vercel.app/api-docs/auth/aws
- https://vault-jy4ql2i4f-hashicorp.vercel.app/docs/auth/aws