### PR TITLE
Replace non-inclusive language in AWS Auth

### DIFF
--- a/builtin/credential/aws/backend.go
+++ b/builtin/credential/aws/backend.go
@@ -210,22 +210,22 @@ func (b *backend) periodicFunc(ctx context.Context, req *logical.Request) error 
 		if b.System().LocalMount() || !b.System().ReplicationState().HasState(consts.ReplicationPerformanceSecondary|consts.ReplicationPerformanceStandby) {
 			// safetyBuffer defaults to 180 days for roletag deny list
 			safetyBuffer := 15552000
-			tidyBlacklistConfigEntry, err := b.lockedConfigTidyRoleTags(ctx, req.Storage)
+			tidyDenylistConfigEntry, err := b.lockedConfigTidyRoleTags(ctx, req.Storage)
 			if err != nil {
 				return err
 			}
-			skipBlacklistTidy := false
+			skipDenylistTidy := false
 			// check if tidying of role tags was configured
-			if tidyBlacklistConfigEntry != nil {
+			if tidyDenylistConfigEntry != nil {
 				// check if periodic tidying of role tags was disabled
-				if tidyBlacklistConfigEntry.DisablePeriodicTidy {
-					skipBlacklistTidy = true
+				if tidyDenylistConfigEntry.DisablePeriodicTidy {
+					skipDenylistTidy = true
 				}
 				// overwrite the default safetyBuffer with the configured value
-				safetyBuffer = tidyBlacklistConfigEntry.SafetyBuffer
+				safetyBuffer = tidyDenylistConfigEntry.SafetyBuffer
 			}
 			// tidy role tags if explicitly not disabled
-			if !skipBlacklistTidy {
+			if !skipDenylistTidy {
 				b.tidyDenyListRoleTag(ctx, req, safetyBuffer)
 			}
 		}
@@ -234,22 +234,22 @@ func (b *backend) periodicFunc(ctx context.Context, req *logical.Request) error 
 		// these are locally stored
 
 		safety_buffer := 259200
-		tidyWhitelistConfigEntry, err := b.lockedConfigTidyIdentities(ctx, req.Storage)
+		tidyAccesslistConfigEntry, err := b.lockedConfigTidyIdentities(ctx, req.Storage)
 		if err != nil {
 			return err
 		}
-		skipWhitelistTidy := false
+		skipAccesslistTidy := false
 		// check if tidying of identities was configured
-		if tidyWhitelistConfigEntry != nil {
+		if tidyAccesslistConfigEntry != nil {
 			// check if periodic tidying of identities was disabled
-			if tidyWhitelistConfigEntry.DisablePeriodicTidy {
-				skipWhitelistTidy = true
+			if tidyAccesslistConfigEntry.DisablePeriodicTidy {
+				skipAccesslistTidy = true
 			}
 			// overwrite the default safety_buffer with the configured value
-			safety_buffer = tidyWhitelistConfigEntry.SafetyBuffer
+			safety_buffer = tidyAccesslistConfigEntry.SafetyBuffer
 		}
 		// tidy identities if explicitly not disabled
-		if !skipWhitelistTidy {
+		if !skipAccesslistTidy {
 			b.tidyAccessListIdentity(ctx, req, safety_buffer)
 		}
 

--- a/builtin/credential/aws/backend_test.go
+++ b/builtin/credential/aws/backend_test.go
@@ -380,10 +380,10 @@ func TestBackend_TidyIdentities(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expiredIdentityWhitelist := &accessListIdentity{
+		expiredIdentityAccesslist := &accessListIdentity{
 			ExpirationTime: time.Now().Add(-1 * 24 * 365 * time.Hour),
 		}
-		entry, err := logical.StorageEntryJSON("whitelist/identity/id1", expiredIdentityWhitelist)
+		entry, err := logical.StorageEntryJSON("whitelist/identity/id1", expiredIdentityAccesslist)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -430,10 +430,10 @@ func TestBackend_TidyRoleTags(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expiredIdentityWhitelist := &roleTagBlacklistEntry{
+		expiredIdentityAccesslist := &roleTagDenylistEntry{
 			ExpirationTime: time.Now().Add(-1 * 24 * 365 * time.Hour),
 		}
-		entry, err := logical.StorageEntryJSON("blacklist/roletag/id1", expiredIdentityWhitelist)
+		entry, err := logical.StorageEntryJSON("blacklist/roletag/id1", expiredIdentityAccesslist)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -906,7 +906,7 @@ func TestBackend_PathRoleTag(t *testing.T) {
 	}
 }
 
-func TestBackend_PathBlacklistRoleTag(t *testing.T) {
+func TestBackend_PathDenylistRoleTag(t *testing.T) {
 
 	for _, path := range []string{"roletag-blacklist/", "roletag-denylist/"} {
 		// create the backend

--- a/builtin/credential/aws/path_config_tidy_identity_accesslist.go
+++ b/builtin/credential/aws/path_config_tidy_identity_accesslist.go
@@ -59,14 +59,14 @@ func (b *backend) pathConfigTidyIdentityAccessListExistenceCheck(ctx context.Con
 	return entry != nil, nil
 }
 
-func (b *backend) lockedConfigTidyIdentities(ctx context.Context, s logical.Storage) (*tidyWhitelistIdentityConfig, error) {
+func (b *backend) lockedConfigTidyIdentities(ctx context.Context, s logical.Storage) (*tidyAccesslistIdentityConfig, error) {
 	b.configMutex.RLock()
 	defer b.configMutex.RUnlock()
 
 	return b.nonLockedConfigTidyIdentities(ctx, s)
 }
 
-func (b *backend) nonLockedConfigTidyIdentities(ctx context.Context, s logical.Storage) (*tidyWhitelistIdentityConfig, error) {
+func (b *backend) nonLockedConfigTidyIdentities(ctx context.Context, s logical.Storage) (*tidyAccesslistIdentityConfig, error) {
 	entry, err := s.Get(ctx, identityAccessListConfigStorage)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (b *backend) nonLockedConfigTidyIdentities(ctx context.Context, s logical.S
 		return nil, nil
 	}
 
-	var result tidyWhitelistIdentityConfig
+	var result tidyAccesslistIdentityConfig
 	if err := entry.DecodeJSON(&result); err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (b *backend) pathConfigTidyIdentityAccessListCreateUpdate(ctx context.Conte
 		return nil, err
 	}
 	if configEntry == nil {
-		configEntry = &tidyWhitelistIdentityConfig{}
+		configEntry = &tidyAccesslistIdentityConfig{}
 	}
 
 	safetyBufferInt, ok := data.GetOk("safety_buffer")
@@ -144,7 +144,7 @@ func (b *backend) pathConfigTidyIdentityAccessListDelete(ctx context.Context, re
 	return nil, req.Storage.Delete(ctx, identityAccessListConfigStorage)
 }
 
-type tidyWhitelistIdentityConfig struct {
+type tidyAccesslistIdentityConfig struct {
 	SafetyBuffer        int  `json:"safety_buffer"`
 	DisablePeriodicTidy bool `json:"disable_periodic_tidy"`
 }

--- a/builtin/credential/aws/path_roletag_denylist.go
+++ b/builtin/credential/aws/path_roletag_denylist.go
@@ -32,8 +32,8 @@ to avoid any encoding problems, it can be base64 encoded.`,
 			},
 		},
 
-		HelpSynopsis:    pathRoletagBlacklistSyn,
-		HelpDescription: pathRoletagBlacklistDesc,
+		HelpSynopsis:    pathRoletagDenylistSyn,
+		HelpDescription: pathRoletagDenylistDesc,
 	}
 }
 
@@ -79,14 +79,14 @@ func (b *backend) pathRoletagDenyListsList(ctx context.Context, req *logical.Req
 
 // Fetch an entry from the role tag deny list for a given tag.
 // This method takes a role tag in its original form and not a base64 encoded form.
-func (b *backend) lockedDenyLististRoleTagEntry(ctx context.Context, s logical.Storage, tag string) (*roleTagBlacklistEntry, error) {
+func (b *backend) lockedDenyLististRoleTagEntry(ctx context.Context, s logical.Storage, tag string) (*roleTagDenylistEntry, error) {
 	b.denyListMutex.RLock()
 	defer b.denyListMutex.RUnlock()
 
 	return b.nonLockedDenyListRoleTagEntry(ctx, s, tag)
 }
 
-func (b *backend) nonLockedDenyListRoleTagEntry(ctx context.Context, s logical.Storage, tag string) (*roleTagBlacklistEntry, error) {
+func (b *backend) nonLockedDenyListRoleTagEntry(ctx context.Context, s logical.Storage, tag string) (*roleTagDenylistEntry, error) {
 	entry, err := s.Get(ctx, denyListRoletagStorage+base64.StdEncoding.EncodeToString([]byte(tag)))
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func (b *backend) nonLockedDenyListRoleTagEntry(ctx context.Context, s logical.S
 		return nil, nil
 	}
 
-	var result roleTagBlacklistEntry
+	var result roleTagDenylistEntry
 	if err := entry.DecodeJSON(&result); err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (b *backend) pathRoletagDenyListUpdate(ctx context.Context, req *logical.Re
 		return nil, err
 	}
 	if blEntry == nil {
-		blEntry = &roleTagBlacklistEntry{}
+		blEntry = &roleTagDenylistEntry{}
 	}
 
 	currentTime := time.Now()
@@ -226,16 +226,16 @@ func (b *backend) pathRoletagDenyListUpdate(ctx context.Context, req *logical.Re
 	return nil, nil
 }
 
-type roleTagBlacklistEntry struct {
+type roleTagDenylistEntry struct {
 	CreationTime   time.Time `json:"creation_time"`
 	ExpirationTime time.Time `json:"expiration_time"`
 }
 
-const pathRoletagBlacklistSyn = `
-Blacklist a previously created role tag.
+const pathRoletagDenylistSyn = `
+Denylist a previously created role tag.
 `
 
-const pathRoletagBlacklistDesc = `
+const pathRoletagDenylistDesc = `
 Add a role tag to the deny list so that it cannot be used by any EC2 instance to perform further
 logins. This can be used if the role tag is suspected or believed to be possessed by
 an unintended party.

--- a/builtin/credential/aws/path_tidy_roletag_denylist.go
+++ b/builtin/credential/aws/path_tidy_roletag_denylist.go
@@ -85,7 +85,7 @@ func (b *backend) tidyDenyListRoleTag(ctx context.Context, req *logical.Request,
 					return fmt.Errorf("found entry for tag %q but actual tag is empty", tag)
 				}
 
-				var result roleTagBlacklistEntry
+				var result roleTagDenylistEntry
 				if err := tagEntry.DecodeJSON(&result); err != nil {
 					return err
 				}


### PR DESCRIPTION
These occurrences were missed in the original PR. The changes here are limited to local variable and struct names.