### PR TITLE
Backport 1.7.x: Adds a changelog entry for key management secrets engine

### DIFF
--- a/changelog/_1739.txt
+++ b/changelog/_1739.txt
@@ -1,0 +1,6 @@
+```release-note:feature
+secrets/keymgmt (enterprise): Adds general availability for distributing and managing keys in Azure Key Vault.
+```
+```release-note:feature
+secrets/keymgmt (enterprise): Adds beta support for distributing and managing keys in AWS KMS.
+```


### PR DESCRIPTION
This PR backports a changelog entry from #11164.

The following steps were taken:
1. `git checkout release/1.7.x`
2. `git checkout -b backport-pr-11164-1.7.x`
3. `git cherry-pick d5241e4`