### PR TITLE
Autopilot: Add JSON marshaler to CLI output of get-config

### DIFF
--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -44,6 +44,18 @@ type AutopilotConfig struct {
 	ServerStabilizationTime        time.Duration `json:"server_stabilization_time" mapstructure:"-"`
 }
 
+// MarshalJSON makes the autopilot config fields JSON compatible
+func (ac *AutopilotConfig) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"cleanup_dead_servers":               ac.CleanupDeadServers,
+		"last_contact_threshold":             ac.LastContactThreshold.String(),
+		"dead_server_last_contact_threshold": ac.DeadServerLastContactThreshold.String(),
+		"max_trailing_logs":                  ac.MaxTrailingLogs,
+		"min_quorum":                         ac.MinQuorum,
+		"server_stabilization_time":          ac.ServerStabilizationTime.String(),
+	})
+}
+
 // UnmarshalJSON parses the autopilot config JSON blob
 func (ac *AutopilotConfig) UnmarshalJSON(b []byte) error {
 	var data interface{}

--- a/vendor/github.com/hashicorp/vault/api/sys_raft.go
+++ b/vendor/github.com/hashicorp/vault/api/sys_raft.go
@@ -44,6 +44,18 @@ type AutopilotConfig struct {
 	ServerStabilizationTime        time.Duration `json:"server_stabilization_time" mapstructure:"-"`
 }
 
+// MarshalJSON makes the autopilot config fields JSON compatible
+func (ac *AutopilotConfig) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"cleanup_dead_servers":               ac.CleanupDeadServers,
+		"last_contact_threshold":             ac.LastContactThreshold.String(),
+		"dead_server_last_contact_threshold": ac.DeadServerLastContactThreshold.String(),
+		"max_trailing_logs":                  ac.MaxTrailingLogs,
+		"min_quorum":                         ac.MinQuorum,
+		"server_stabilization_time":          ac.ServerStabilizationTime.String(),
+	})
+}
+
 // UnmarshalJSON parses the autopilot config JSON blob
 func (ac *AutopilotConfig) UnmarshalJSON(b []byte) error {
 	var data interface{}


### PR DESCRIPTION
Before:
```
$vault operator raft autopilot get-config -format json
{
  "cleanup_dead_servers": false,
  "last_contact_threshold": 10000000000,
  "dead_server_last_contact_threshold": 86400000000000,
  "max_trailing_logs": 1000,
  "min_quorum": 0,
  "server_stabilization_time": 10000000000
}
```

After:
```
{
  "cleanup_dead_servers": false,
  "dead_server_last_contact_threshold": "24h0m0s",
  "last_contact_threshold": "10s",
  "max_trailing_logs": 1000,
  "min_quorum": 0,
  "server_stabilization_time": "10s"
}
```