### PR TITLE
Updates documentation for key management secrets engine

### DIFF
--- a/website/content/api-docs/secret/key-management/awskms.mdx
+++ b/website/content/api-docs/secret/key-management/awskms.mdx
@@ -1,0 +1,55 @@
+---
+layout: api
+page_title: AWS KMS - Key Management - Secrets Engines - HTTP API
+sidebar_title: AWS KMS
+description: The AWS KMS API documentation for the Key Management secrets engine.
+---
+
+# AWS KMS (API)
+
+~> **Note:** This provider is currently a **_beta_** feature and not recommended
+for deployment in production.
+
+The Key Management secrets engine supports lifecycle management of keys in [AWS KMS](https://aws.amazon.com/kms/)
+regions. This is accomplished by configuring a KMS provider resource with the `awskms` provider and
+other provider-specific parameter values.
+
+The following sections provide API documentation that is specific to AWS KMS.
+
+## Create/Update KMS Provider
+
+This endpoint creates or updates a KMS provider. If a KMS provider with the given `name`
+does not exist, it will be created. If the KMS provider exists, it will be updated with
+the given parameter values.
+
+| Method | Path                 |
+| :----- | :------------------- |
+| `PUT`  | `/keymgmt/kms/:name` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name of the KMS provider to create or update.
+  This is provided as part of the request URL.
+
+- `provider` `(string: <required>)` – Specifies the name of a KMS provider that's external to
+  Vault. Must be set to `awskms`. Cannot be changed after creation.
+
+- `key_collection` `(string: <required>)` – Refers to the name of an AWS
+  [region](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/?p=ngi&loc=2).
+  Cannot be changed after creation.
+
+- `credentials` `(map<string|string>: nil)` – The credentials to use for authentication with
+  AWS KMS. Supplying values for this parameter is optional, as credentials may also be specified
+  as environment variables. Credentials provided to this parameter will take precedence over
+  credentials provided via environment variables.
+
+    - `access_key` `(string: <required>)` - The AWS access key ID. May also be specified
+      by the `AWS_ACCESS_KEY_ID` environment variable.
+    - `secret_key` `(string: <required>)` - The AWS secret access key. May also be specified
+      by the `AWS_SECRET_ACCESS_KEY` environment variable.
+    - `session_token` `(string: <optional>)` - The AWS session token. May also be specified
+      by the `AWS_SESSION_TOKEN` environment variable.
+    - `endpoint` `(string: <optional>)` - The KMS API endpoint to be used to make AWS KMS
+      requests. May also be specified by the `AWS_KMS_ENDPOINT` environment variable. This
+      is useful when connecting to KMS over a [VPC Endpoint](https://docs.aws.amazon.com/kms/latest/developerguide/kms-vpc-endpoint.html).
+      If not set, the secrets engine will use the default API endpoint for the region.

--- a/website/content/api-docs/secret/key-management/azurekeyvault.mdx
+++ b/website/content/api-docs/secret/key-management/azurekeyvault.mdx
@@ -1,0 +1,50 @@
+---
+layout: api
+page_title: Azure Key Vault - Key Management - Secrets Engines - HTTP API
+sidebar_title: Azure Key Vault
+description: The Azure Key Vault API documentation for the Key Management secrets engine.
+---
+
+# Azure Key Vault (API)
+
+The Key Management secrets engine supports lifecycle management of keys in named
+[Azure Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/) instances.
+This is accomplished by configuring a KMS provider resource with the `azurekeyvault`
+provider and other provider-specific parameter values.
+
+The following sections provide API documentation that is specific to Azure Key Vault.
+
+## Create/Update KMS Provider
+
+This endpoint creates or updates a KMS provider. If a KMS provider with the given `name`
+does not exist, it will be created. If the KMS provider exists, it will be updated with
+the given parameter values.
+
+| Method | Path                 |
+| :----- | :------------------- |
+| `PUT`  | `/keymgmt/kms/:name` |
+
+### Parameters
+
+- `name` `(string: <required>)` – Specifies the name of the KMS provider to create or update.
+  This is provided as part of the request URL.
+
+- `provider` `(string: <required>)` – Specifies the name of a KMS provider that's external to
+  Vault. Must be set to `azurekeyvault`. Cannot be changed after creation.
+
+- `key_collection` `(string: <required>)` – Refers to the name of an existing Azure Key Vault
+  instance. Cannot be changed after creation.
+
+- `credentials` `(map<string|string>: nil)` – The credentials to use for authentication with
+  Azure Key Vault. Supplying values for this parameter is optional, as credentials may also
+  be specified as environment variables. Environment variables will take precedence over
+  credentials provided via this parameter.
+
+    - `tenant_id` `(string: <required>)` - The tenant ID for the Azure Active Directory
+      organization. May also be specified by the `AZURE_TENANT_ID` environment variable.
+    - `client_id` `(string: <required or MSI>)` - The client ID for credentials to invoke the
+      Azure APIs. May also be specified by the `AZURE_CLIENT_ID` environment variable.
+    - `client_secret` `(string: <required or MSI>)` - The client secret for credentials to invoke
+      the Azure APIs. May also be specified by the `AZURE_CLIENT_SECRET` environment variable.
+    - `environment` `(string: "AzurePublicCloud")` - The Azure Cloud environment API endpoints to
+      use. May also be specified by the `AZURE_ENVIRONMENT` environment variable.

--- a/website/content/api-docs/secret/key-management/index.mdx
+++ b/website/content/api-docs/secret/key-management/index.mdx
@@ -2,7 +2,7 @@
 layout: api
 page_title: Key Management - Secrets Engines - HTTP API
 sidebar_title: Key Management <sup>ENTERPRISE</sup>
-description: This is the API documentation for the Key Management secrets engine.
+description: The API documentation for the Key Management secrets engine.
 ---
 
 # Key Management Secrets Engine (API)
@@ -31,6 +31,8 @@ set cannot be changed after key creation.
 
 - `type` `(string: "rsa-2048")` – Specifies the type of cryptographic key to create. The
   following key types are supported:
+
+  - `aes256-gcm96` - AES-GCM with a 256-bit AES key and a 96-bit nonce (symmetric)
   - `rsa-2048` - RSA with bit size of 2048 (asymmetric)
   - `rsa-3072` - RSA with bit size of 3072 (asymmetric)
   - `rsa-4096` - RSA with bit size of 4096 (asymmetric)
@@ -57,7 +59,7 @@ $ curl \
 
 This endpoint returns information about a named key. The `keys` object will hold information
 regarding each key version. Different information will be returned depending on the key type.
-For example, an asymmetric key will return its public key in a standard format for the type.
+For example, an asymmetric key will return its public key in a PEM encoding.
 
 | Method | Path                 |
 | :----- | :------------------- |
@@ -85,13 +87,11 @@ $ curl \
     "keys": {
       "1": {
         "creation_time": "2020-11-02T15:54:58.768473-08:00",
-        "public_key": "-----BEGIN PUBLIC KEY----- ... -----END PUBLIC KEY-----",
-        "type": "rsa-2048"
+        "public_key": "-----BEGIN PUBLIC KEY----- ... -----END PUBLIC KEY-----"
       },
       "2": {
         "creation_time": "2020-11-04T16:58:47.591718-08:00",
-        "public_key": "-----BEGIN PUBLIC KEY----- ... -----END PUBLIC KEY-----",
-        "type": "rsa-2048"
+        "public_key": "-----BEGIN PUBLIC KEY----- ... -----END PUBLIC KEY-----"
       }
     },
     "latest_version": 2,
@@ -261,36 +261,28 @@ the given parameter values.
 - `name` `(string: <required>)` – Specifies the name of the KMS provider to create or update.
   This is provided as part of the request URL.
 
-- `provider` `(string: <required>)` – Specifies the name of a KMS provider that's external to Vault.
-  Cannot be changed after creation. Currently, `azurekeyvault` is supported. For more information
-  about each provider, refer to the [KMS Providers](/docs/secrets/key-management#kms-providers) section.
+- `provider` `(string: <required>)` – Specifies the name of a KMS provider that's external to
+  Vault. Cannot be changed after creation. For more information about each provider, refer to
+  the [KMS Providers](/docs/secrets/key-management#kms-providers) section. The following values
+  are supported:
+
+    - `azurekeyvault`
+    - `awskms`
+
+### Common Parameters
+
+There are common parameters that expect different values depending on the specified `provider`.
+Please reference the API documentation for individual KMS providers to determine which values to
+set for each of the parameters listed below.
 
 - `key_collection` `(string: <required>)` – Refers to a location to store keys in the specified
-  provider. Cannot be changed after creation. The expected value for this parameter will differ
-  depending on the specified provider.
-
-  The following values are expected for each provider:
-
-  - `azurekeyvault`
-    - The name of an existing Azure Key Vault instance.
+  `provider`. Cannot be changed after creation. The expected value for this parameter will differ
+  depending on the specified `provider`.
 
 - `credentials` `(map<string|string>: nil)` – The credentials to use for authentication with
-  the specified provider. Supplying values for this parameter is optional, as credentials may
-  also be specified as environment variables. Environment variables will take precedence over
-  credentials provided via this parameter. The expected keys and values for this parameter
-  will differ depending on the specified provider.
-
-  The following keys and values are expected for each provider:
-
-  - `azurekeyvault`
-    - `tenant_id` `(string: <required>)` - The tenant ID for the Azure Active Directory
-      organization. May also be specified by the `AZURE_TENANT_ID` environment variable.
-    - `client_id` `(string: <required or MSI>)` - The client ID for credentials to invoke the
-      Azure APIs. May also be specified by the `AZURE_CLIENT_ID` environment variable.
-    - `client_secret` `(string: <required or MSI>)` - The client secret for credentials to invoke
-      the Azure APIs. May also be specified by the `AZURE_CLIENT_SECRET` environment variable.
-    - `environment` `(string: "AzurePublicCloud")` - The Azure Cloud environment API endpoints to
-      use. May also be specified by the `AZURE_ENVIRONMENT` environment variable.
+  the specified `provider`. Supplying values for this parameter is optional, as credentials may
+  also be specified as environment variables. The expected keys and values for this parameter
+  will differ depending on the specified `provider`.
 
 ### Sample Payload
 
@@ -419,12 +411,21 @@ provider. The parameters set cannot be changed after the key has been distribute
 
 - `purpose` `([]string: <required>)` – Specifies the purpose of the key. The purpose defines a set
   of cryptographic capabilities that the key will have in the KMS provider. A key must have at
-  least one of the supported purposes. Currently, `encrypt`, `decrypt`, `sign`, `verify`, `wrap`,
-  and `unwrap` are supported.
+  least one of the supported purposes. The following values are supported:
+
+  - `encrypt`
+  - `decrypt`
+  - `sign`
+  - `verify`
+  - `wrap`
+  - `unwrap`
 
 - `protection` `(string: "hsm")` – Specifies the protection of the key. The protection defines
-  where cryptographic operations are performed with the key in the KMS provider. Currently,
-  `software` and `hsm` are supported.
+  where cryptographic operations are performed with the key in the KMS provider. The following
+  values are supported:
+
+  - `hsm`
+  - `software`
 
 ### Sample Payload
 
@@ -477,7 +478,11 @@ $ curl \
   "data": {
     "name": "example-key-<unix_timestamp>",
     "protection": "hsm",
-    "purpose": "encrypt,decrypt"
+    "purpose": "encrypt,decrypt",
+    "versions": {
+      "1": "c96a8956194f4632bc3837b64a1b45b1",
+      "2": "01ce657d33f64eb38f9432be543f3f52"
+    }
   }
 }
 ```

--- a/website/content/docs/secrets/key-management/awskms.mdx
+++ b/website/content/docs/secrets/key-management/awskms.mdx
@@ -14,16 +14,21 @@ The Key Management secrets engine supports lifecycle management of keys in [AWS 
 regions. This is accomplished by configuring a KMS provider resource with the `awskms` provider and
 other provider-specific parameter values.
 
-The following sections describe how to properly configure the KMS provider resource
-to enable the functionality.
+The following sections describe how to properly configure the secrets engine to enable
+the functionality.
 
 ## Authentication
 
-The Key Management secrets engine must have sufficient permissions to manage keys in an AWS KMS
-region. The authentication parameters can be set in the following order of precedence: KMS provider
-configuration, environment variables, shared credentials file, IAM role for AWS EC2 or ECS task.
-The individual parameters are described in the [credentials](/api/secret/key-management/awskms#credentials)
-section of the API documentation.
+The Key Management secrets engine must be configured with credentials that have sufficient
+permissions to manage keys in an AWS KMS region. The authentication parameters are described
+in the [credentials](/api/secret/key-management/awskms#credentials) section of the API
+documentation. The authentication parameters will be set with the following order of
+precedence:
+
+1. [KMS provider credentials](/api/secret/key-management/awskms#credentials)
+2. Environment variables
+3. Shared credentials file
+4. IAM role for AWS EC2 or ECS task
 
 The IAM principal associated with the provided credentials must have the following minimum
 [AWS KMS permissions](https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html):

--- a/website/content/docs/secrets/key-management/awskms.mdx
+++ b/website/content/docs/secrets/key-management/awskms.mdx
@@ -1,0 +1,62 @@
+---
+layout: docs
+page_title: AWS KMS - Key Management - Secrets Engines
+sidebar_title: AWS KMS
+description: AWS KMS is a supported KMS provider of the Key Management secrets engine.
+---
+
+# AWS KMS
+
+~> **Note:** This provider is currently a **_beta_** feature and not recommended
+for deployment in production.
+
+The Key Management secrets engine supports lifecycle management of keys in [AWS KMS](https://aws.amazon.com/kms/)
+regions. This is accomplished by configuring a KMS provider resource with the `awskms` provider and
+other provider-specific parameter values.
+
+The following sections describe how to properly configure the KMS provider resource
+to enable the functionality.
+
+## Authentication
+
+The Key Management secrets engine must have sufficient permissions to manage keys in an AWS KMS
+region. The authentication parameters can be set in the following order of precedence: KMS provider
+configuration, environment variables, shared credentials file, IAM role for AWS EC2 or ECS task.
+The individual parameters are described in the [credentials](/api/secret/key-management/awskms#credentials)
+section of the API documentation.
+
+The IAM principal associated with the provided credentials must have the following minimum
+[AWS KMS permissions](https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html):
+
+- `kms:CreateKey`
+- `kms:GetParametersForImport`
+- `kms:ImportKeyMaterial`
+- `kms:EnableKey`
+- `kms:DisableKey`
+- `kms:ScheduleKeyDeletion`
+- `kms:CreateAlias`
+- `kms:UpdateAlias`
+- `kms:DeleteAlias`
+- `kms:ListAliases`
+- `kms:TagResource`
+
+## Configuration
+
+The following is an example of how to configure the KMS provider resource using the Vault CLI:
+
+   ```text
+   $ vault write keymgmt/kms/example-kms \
+       provider="awskms" \
+       key_collection="us-west-1" \
+       credentials=access_key="ASIADJO3WTX6WPLJM42V" \
+       credentials=secret_key="bCiYmNroLxLmPNQ47VIvjlm8mQu5oktZcQdq195w"
+   ```
+
+Refer to the AWS KMS [API documentation](/api/secret/key-management/awskms)
+for a detailed description of individual configuration parameters.
+
+## Key Transfer Specification
+
+Keys are securely transferred from the secrets engine to AWS KMS regions in accordance
+with the AWS KMS [Bring Your Own Key](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+specification.

--- a/website/content/docs/secrets/key-management/azurekeyvault.mdx
+++ b/website/content/docs/secrets/key-management/azurekeyvault.mdx
@@ -12,16 +12,20 @@ The Key Management secrets engine supports lifecycle management of keys in named
 This is accomplished by configuring a KMS provider resource with the `azurekeyvault`
 provider and other provider-specific parameter values.
 
-The following sections describe how to properly configure the KMS provider resource
-to enable the functionality.
+The following sections describe how to properly configure the secrets engine to enable
+the functionality.
 
 ## Authentication
 
-The Key Management secrets engine must have sufficient permissions to manage keys in an Azure Key
-Vault instance. The authentication parameters can be set in the following order of precedence:
-environment variables, KMS provider configuration, [Managed Service Identity (MSI)](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview).
-The individual parameters are described in the [credentials](/api/secret/key-management/azurekeyvault#credentials)
-section of the API documentation.
+The Key Management secrets engine must be configured with credentials that have sufficient
+permissions to manage keys in an Azure Key Vault instance. The authentication parameters are
+described in the [credentials](/api/secret/key-management/azurekeyvault#credentials) section
+of the API documentation. The authentication parameters will be set with the following order
+of precedence:
+
+1. Environment variables
+2. [KMS provider credentials](/api/secret/key-management/azurekeyvault#credentials)
+3. [Managed Service Identity (MSI)](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview)
 
 If the client ID or secret are not provided and Vault is running on an Azure VM, Vault will attempt
 to use MSI to access Azure. Note that when MSI is used, the tenant ID must still be explicitly provided

--- a/website/content/docs/secrets/key-management/azurekeyvault.mdx
+++ b/website/content/docs/secrets/key-management/azurekeyvault.mdx
@@ -1,0 +1,61 @@
+---
+layout: docs
+page_title: Azure Key Vault - Key Management - Secrets Engines
+sidebar_title: Azure Key Vault
+description: Azure Key Vault is a supported KMS provider of the Key Management secrets engine.
+---
+
+# Azure Key Vault
+
+The Key Management secrets engine supports lifecycle management of keys in named
+[Azure Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/) instances.
+This is accomplished by configuring a KMS provider resource with the `azurekeyvault`
+provider and other provider-specific parameter values.
+
+The following sections describe how to properly configure the KMS provider resource
+to enable the functionality.
+
+## Authentication
+
+The Key Management secrets engine must have sufficient permissions to manage keys in an Azure Key
+Vault instance. The authentication parameters can be set in the following order of precedence:
+environment variables, KMS provider configuration, [Managed Service Identity (MSI)](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview).
+The individual parameters are described in the [credentials](/api/secret/key-management/azurekeyvault#credentials)
+section of the API documentation.
+
+If the client ID or secret are not provided and Vault is running on an Azure VM, Vault will attempt
+to use MSI to access Azure. Note that when MSI is used, the tenant ID must still be explicitly provided
+by the configuration or environment variable.
+
+An Azure Key Vault [access policy](https://docs.microsoft.com/en-us/azure/key-vault/general/assign-access-policy-portal)
+determines whether a given service principal, namely an application or user group, can perform certain
+operations on a Key Vault instance. The service principal associated with the provided credentials must
+have an access policy on the Key Vault instance with the following minimum key permissions:
+
+- `create`
+- `delete`
+- `get`
+- `import`
+- `update`
+
+## Configuration
+
+The following is an example of how to configure the KMS provider resource using the Vault CLI:
+
+   ```text
+   $ vault write keymgmt/kms/example-kms \
+       provider="azurekeyvault" \
+       key_collection="keyvault-name" \
+       credentials=client_id="a0454cd1-e28e-405e-bc50-7477fa8a00b7" \
+       credentials=client_secret="eR%HizuCVEpAKgeaUEx" \
+       credentials=tenant_id="cd4bf224-d114-4f96-9bbc-b8f45751c43f"
+   ```
+
+Refer to the Azure Key Vault [API documentation](/api/secret/key-management/azurekeyvault)
+for a detailed description of individual configuration parameters.
+
+## Key Transfer Specification
+
+Keys are securely transferred from the secrets engine to Azure key vault instances in accordance
+with the Azure [Bring Your Own Key](https://docs.microsoft.com/en-us/azure/key-vault/keys/byok-specification)
+specification.

--- a/website/content/docs/secrets/key-management/index.mdx
+++ b/website/content/docs/secrets/key-management/index.mdx
@@ -13,9 +13,6 @@ description: >-
 Enterprise](https://www.hashicorp.com/products/vault/) with the Advanced Data
 Protection Module.
 
-~> **Note:** This secrets engine is currently a **_Tech Preview_**
-feature and not recommended for deployment in production.
-
 The Key Management secrets engine provides a consistent workflow for distribution and lifecycle
 management of cryptographic keys in various key management service (KMS) providers. It allows
 organizations to maintain centralized control of their keys in Vault while still taking advantage
@@ -135,50 +132,33 @@ manage the lifecycle of cryptographic keys in [supported KMS providers](#kms-pro
 
 ## Key Types
 
-The Key Management secrets engine currently supports generation of the following key types:
+The Key Management secrets engine supports generation of the following key types:
 
+- `aes256-gcm96` - AES-GCM with a 256-bit AES key and a 96-bit nonce (symmetric)
 - `rsa-2048` - RSA with bit size of 2048 (asymmetric)
 - `rsa-3072` - RSA with bit size of 3072 (asymmetric)
 - `rsa-4096` - RSA with bit size of 4096 (asymmetric)
 
 ## KMS Providers
 
-The Key Management secrets engine currently supports lifecycle management of keys in the
-following KMS providers.
+The Key Management secrets engine supports lifecycle management of keys in the following
+KMS providers:
 
-### Azure Key Vault
+- [Azure Key Vault](/docs/secrets/key-management/azurekeyvault)
+- [AWS KMS](/docs/secrets/key-management/awskms)
 
-The `azurekeyvault` provider represents a named [Azure Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/)
-instance.
+Refer to the provider-specific documentation for details on how to properly configure each provider.
 
-#### Authentication
+## Compatibility
 
-The Key Management secrets engine must have sufficient permissions to manage keys in an Azure Key
-Vault instance. The authentication parameters can be set in the KMS provider configuration or as
-environment variables. Environment variables will take precedence. The individual parameters are
-described in the [credentials](/api/secret/key-management#credentials) section of the API documentation.
+The following table defines which key types are compatible with each KMS provider.
 
-If the client ID or secret are not provided and Vault is running on an Azure VM, Vault will attempt
-to use [Managed Service Identity (MSI)](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview)
-to access Azure. Note that when MSI is used, the tenant ID must still be explicitly provided by the
-configuration or environment variable.
-
-An Azure Key Vault [access policy](https://docs.microsoft.com/en-us/azure/key-vault/general/assign-access-policy-portal)
-determines whether a given service principal, namely an application or user group, can perform certain
-operations on a Key Vault instance. The service principal associated with the provided credentials must
-have an access policy on the Key Vault instance with the following minimum key permissions:
-
-- `create`
-- `delete`
-- `get`
-- `import`
-- `update`
-
-#### Key Transfer Specification
-
-Keys are securely transferred from the secrets engine to Azure key vault instances in accordance
-with the [Azure Bring Your Own Key](https://docs.microsoft.com/en-us/azure/key-vault/keys/byok-specification)
-specification.
+| Key Type       | Azure Key Vault | AWS KMS |
+| -------------- | --------------- | ------- |
+| `aes256-gcm96` | No              | **Yes** |
+| `rsa-2048`     | **Yes**         | No      |
+| `rsa-3072`     | **Yes**         | No      |
+| `rsa-4096`     | **Yes**         | No      |
 
 ## Learn
 

--- a/website/data/api-navigation.js
+++ b/website/data/api-navigation.js
@@ -39,7 +39,13 @@ export default [
       },
       'gcp',
       'gcpkms',
-      'key-management',
+      {
+        category: 'key-management',
+        content: [
+          'azurekeyvault',
+          'awskms',
+        ],
+      },
       'kmip',
       {
         category: 'kv',

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -243,7 +243,13 @@ export default [
       },
       'gcp',
       'gcpkms',
-      'key-management',
+      {
+        category: 'key-management',
+        content: [
+          'azurekeyvault',
+          'awskms',
+        ],
+      },
       'kmip',
       {
         category: 'kv',


### PR DESCRIPTION
This PR updates the documentation for the Key Management secrets engine for Vault 1.7. Notable changes include breaking out the documentation for each supported KMS provider (Azure Key Vault, AWS KMS) into individual subpages (similar to the database secrets engine).

Deploy Preview Links:
- [User docs](https://vault-g2lfm2t3q-hashicorp.vercel.app/docs/secrets/key-management)
- [API docs](https://vault-g2lfm2t3q-hashicorp.vercel.app/api-docs/secret/key-management)