### PR TITLE
UI/namespace bug

### DIFF
--- a/changelog/11182.txt
+++ b/changelog/11182.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Fix namespace-bug on login
+```
+

--- a/ui/app/components/namespace-link.js
+++ b/ui/app/components/namespace-link.js
@@ -18,7 +18,6 @@ export default Component.extend({
   }),
 
   namespaceDisplay: computed('normalizedNamespace', 'showLastSegment', function() {
-    console.error('meep');
     if (!ns) return 'root';
     let ns = this.normalizedNamespace;
     let showLastSegment = this.showLastSegment;

--- a/ui/app/components/namespace-link.js
+++ b/ui/app/components/namespace-link.js
@@ -18,8 +18,8 @@ export default Component.extend({
   }),
 
   namespaceDisplay: computed('normalizedNamespace', 'showLastSegment', function() {
-    if (!ns) return 'root';
     let ns = this.normalizedNamespace;
+    if (!ns) return 'root';
     let showLastSegment = this.showLastSegment;
     let parts = ns?.split('/');
     return showLastSegment ? parts[parts.length - 1] : ns;

--- a/ui/app/components/namespace-link.js
+++ b/ui/app/components/namespace-link.js
@@ -18,12 +18,11 @@ export default Component.extend({
   }),
 
   namespaceDisplay: computed('normalizedNamespace', 'showLastSegment', function() {
+    console.error('meep');
+    if (!ns) return 'root';
     let ns = this.normalizedNamespace;
     let showLastSegment = this.showLastSegment;
-    let parts = ns.split('/');
-    if (ns === '') {
-      return 'root';
-    }
+    let parts = ns?.split('/');
     return showLastSegment ? parts[parts.length - 1] : ns;
   }),
 


### PR DESCRIPTION
Only on the binary build, if the user logged in with an empty namespace (e.g. root) they would not see the top header.  Here is the error.
![image](https://user-images.githubusercontent.com/6618863/112210178-00f62a80-8be0-11eb-9e02-11e12f1c0b1f.png)
Here is the missing header
![image](https://user-images.githubusercontent.com/6618863/112210215-09e6fc00-8be0-11eb-93d7-e9ccc622de4b.png)

Note: Locally we could not reproduce, but we could on the binary build.  

