### PR TITLE
Docs: Add AWS secret rotate-root cli

### DIFF
--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -153,6 +153,19 @@ the proper permission, it can generate credentials.
     the STS method of fetching keys. IAM credentials supported by an STS token
     are available for use as soon as they are generated.
 
+1.  Rotate the credentials that Vault uses to communicate with AWS:
+
+    ```test
+    $ vault write -f aws/config/rotate-root
+    Key           Value
+    ---           -----
+    access_key    AKIA3ALIVABCDG5XC8H4
+    ```
+    
+    ~> **Note:** Due to AWS eventual consistency, after calling this endpoint, 
+    subsequent calls from Vault to AWS may fail for a few seconds until AWS 
+    becomes consistent again.  See the [AWS secrets engine API](/api/secret/aws#rotate-root-iam-credentials) for further information on rotate-root functionality. 
+
 ## Example IAM Policy for Vault
 
 The `aws/config/root` credentials need permission to manage dynamic IAM users.


### PR DESCRIPTION
Just adding rotate-root to the docs, it was present in API but not in the main secrets/aws docs