### PR TITLE
Fix: sign SSH key with extensions on web UI

### DIFF
--- a/ui/app/models/ssh-sign.js
+++ b/ui/app/models/ssh-sign.js
@@ -7,7 +7,7 @@ const CREATE_FIELDS = [
   'validPrincipals',
   'certType',
   'criticalOptions',
-  'extension',
+  'extensions',
   'ttl',
 ];
 
@@ -35,7 +35,7 @@ export default Model.extend({
     label: 'Key ID',
   }),
   criticalOptions: attr('object'),
-  extension: attr('object'),
+  extensions: attr('object'),
 
   leaseId: attr('string', {
     label: 'Lease ID',


### PR DESCRIPTION
closes #11191

SSH signing was sending an `extension` attribute instead of `extensions` as [documented](https://www.vaultproject.io/api-docs/secret/ssh#extensions) which meant extensions (if defined) were being ignored and not included in the signed certificate