### PR TITLE
docs: update vault-helm to 0.10.0

### DIFF
--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -785,7 +785,7 @@ and consider if they're appropriate for your deployment.
 
     - `tag` (`string: "0.1.0"`) - The tag of the Docker image for the Vault CSI Provider.. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your CSI provider.
 
-    - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
+    - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists locally.
 
   - `volumes` (`array: []`) - A list of volumes made available to all containers. This takes
     standard Kubernetes volume definitions.

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -806,7 +806,7 @@ and consider if they're appropriate for your deployment.
         readOnly: true
     ```
 
-  - `resources` (`dictionary: {}`) - The resource requests and limits (CPU, memory, etc.) for each of the CSI containers. This should be a YAML dictionary of a Kubernetes [ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcerequirements-v1-core) object. If this isn't specified, then the pods won't request any specific amount of resources, which limits the ability for Kubernetes to make efficient use of compute resources.<br /> **Setting this is highly recommended.**
+  - `resources` (`dictionary: {}`) - The resource requests and limits (CPU, memory, etc.) for each of the CSI containers. This should be a YAML dictionary of a Kubernetes [ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcerequirements-v1-core) objects. If this isn't specified, then the pods won't request any specific amount of resources, which limits the ability for Kubernetes to make efficient use of compute resources.<br /> **Setting this is highly recommended.**
 
     ```yaml
     resources:

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -74,7 +74,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault-k8s"`) - The name of the Docker image for Vault Agent Injector.
 
-    - `tag` (`string: "0.7.0"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "0.9.0"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -82,7 +82,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "vault"`) - The name of the Docker image for the Vault Agent sidecar. This should be set to the official Vault Docker image.
 
-    - `tag` (`string: "1.6.1"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
+    - `tag` (`string: "1.7.0"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
 
   - `metrics` - Values that configure the Vault Agent Injector metric exporter.
 
@@ -115,6 +115,16 @@ and consider if they're appropriate for your deployment.
       matchLabels:
         injection: enabled
     ```
+
+  - `objectSelector` (`dictionary: {}`) - The selector used by the admission webhook controller to limit what objects can be effected by mutation.
+
+    ```yaml
+    # Selectors are defined as a YAML dictionary.
+    # In this example, all namespaces with the label "injection: enabled" are eligible:
+    objectSelector:
+      matchLabels:
+        injection: enabled
+
 
   - `extraLabels` (`dictionary: {}`) - This value defines additional labels for Vault Agent Injector pods.
 
@@ -194,7 +204,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "vault"`) - The name of the Docker image for the containers running Vault.
 
-    - `tag` (`string: "1.6.1"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "1.7.0"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -763,3 +773,117 @@ and consider if they're appropriate for your deployment.
     "sample/annotation1": "foo"
     "sample/annotation2": "bar"
   ```
+
+- `csi` - Values that configure running the Vault CSI Provider.
+
+  - `enabled` (`boolean: false`) - When set to `true`, the Vault CSI Provider daemonset will be created.
+
+  - `image` - Values that configure the Vault CSI Provider Docker image.
+
+    - `repository` (`string: "hashicorp/vault-csi-provider"`) - The name of the Docker image for the Vault CSI Provider.
+
+    - `tag` (`string: "0.1.0"`) - The tag of the Docker image for the Vault CSI Provider.. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your CSI provider.
+
+    - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
+
+  - `volumes` (`array: []`) - A list of volumes made available to all containers. This takes
+    standard Kubernetes volume definitions.
+
+    ```yaml
+    volumes:
+      - name: plugins
+        emptyDir: {}
+    ```
+
+  - `volumeMounts` (`array: []`) - A list of volumes mounts made available to all containers. This takes
+    standard Kubernetes volume mount definitions.
+
+    ```yaml
+    volumeMounts:
+      - mountPath: /usr/local/libexec/vault
+        name: plugins
+        readOnly: true
+    ```
+
+  - `resources` (`dictionary: {}`) - The resource requests and limits (CPU, memory, etc.) for each of the CSI containers. This should be a YAML dictionary of a Kubernetes [ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcerequirements-v1-core) object. If this isn't specified, then the pods won't request any specific amount of resources, which limits the ability for Kubernetes to make efficient use of compute resources.<br /> **Setting this is highly recommended.**
+
+    ```yaml
+    resources:
+      requests:
+        memory: '10Gi'
+      limits:
+        memory: '10Gi'
+    ```
+
+  - `daemonSet` - Values that configure the Vault CSI Provider daemonSet.
+
+    - `updateStrategy` - Values that configure the Vault CSI Provider update strategy.
+
+      - `type` (`string: "RollingUpdate"`) - The [type of update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) to be used when the daemonset is updated using Helm upgrades.
+
+      - `maxUnavailable` (`int: null`) - The maximum number of unavailable pods during an upgrade.
+
+    - `annotations` (`dictionary: {}`) - This value defines additional annotations to
+      add to the Vault CSI Provider daemonset. This can either be YAML or a YAML-formatted
+      multi-line templated string.
+
+      ```yaml
+      annotations:
+        foo: bar
+      # or
+      annotations: |
+        foo: bar
+      ```
+  - `pod` - Values that configure the Vault CSI Provider pod.
+
+   - `annotations` (`dictionary: {}`) - This value defines additional annotations to
+      add to the Vault CSI Provider pods. This can either be YAML or a YAML-formatted
+      multi-line templated string.
+
+      ```yaml
+      annotations:
+        foo: bar
+      # or
+      annotations: |
+        foo: bar
+      ```
+
+  - `serviceAccount` - Values that configure the Vault CSI Provider's serviceaccount.
+
+   - `annotations` (`dictionary: {}`) - This value defines additional annotations to
+      add to the Vault CSI Provider pods. This can either be YAML or a YAML-formatted
+      multi-line templated string.
+
+      ```yaml
+      annotations:
+        foo: bar
+      # or
+      annotations: |
+        foo: bar
+      ```
+
+  - `readinessProbe` - Values that configure the readiness probe for the Vault CSI Proivder  pods.
+
+    - `failureThreshold` (`int: 2`) - When set to a value, configures how many probe failures will be tolerated by Kubernetes.
+
+    - `initialDelaySeconds` (`int: 5`) - When set to a value, configures the number of seconds after the container has started before probe initiates.
+
+    - `periodSeconds` (`int: 5`) - When set to a value, configures how often (in seconds) to perform the probe.
+
+    - `successThreshold` (`int: 1`) - When set to a value, configures the minimum consecutive successes for the probe to be considered successful after having failed.
+
+    - `timeoutSeconds` (`int: 3`) - When set to a value, configures the number of seconds after which the probe times out.
+    
+  - `livelinessProbes` - Values that configure the liveliness probe for the Vault CSI Proivder pods.
+
+    - `initialDelaySeconds` (`int: 5`) - Sets the initial delay of the liveliness probe when the container starts.
+
+    - `failureThreshold` (`int: 2`) - When set to a value, configures how many probe failures will be tolerated by Kubernetes.
+
+    - `periodSeconds` (`int: 5`) - When set to a value, configures how often (in seconds) to perform the probe.
+
+    - `successThreshold` (`int: 1`) - When set to a value, configures the minimum consecutive successes for the probe to be considered successful after having failed.
+
+    - `timeoutSeconds` (`int: 3`) - When set to a value, configures the number of seconds after which the probe times out.
+
+  - `debug` (`bool: false`) - When set to true, enables debug logging on the Vault CSI Provider daemonset.

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -124,6 +124,7 @@ and consider if they're appropriate for your deployment.
     objectSelector:
       matchLabels:
         injection: enabled
+    ```
 
 
   - `extraLabels` (`dictionary: {}`) - This value defines additional labels for Vault Agent Injector pods.

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -875,7 +875,7 @@ and consider if they're appropriate for your deployment.
 
     - `timeoutSeconds` (`int: 3`) - When set to a value, configures the number of seconds after which the probe times out.
     
-  - `livelinessProbes` - Values that configure the liveliness probe for the Vault CSI Proivder pods.
+  - `livenessProbe` - Values that configure the liveliness probe for the Vault CSI Proivder pods.
 
     - `initialDelaySeconds` (`int: 5`) - Sets the initial delay of the liveliness probe when the container starts.
 

--- a/website/content/docs/platform/k8s/helm/index.mdx
+++ b/website/content/docs/platform/k8s/helm/index.mdx
@@ -36,7 +36,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.10.0        	1.7.0      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -58,14 +58,14 @@ Installing a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
-hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.10.0        	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1         	1.6.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.0         	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.8.0         	1.5.4      	Official HashiCorp Vault Chart
+hashicorp/vault	0.7.0         	1.5.2      	Official HashiCorp Vault Chart
 
-# Install version 0.9.1
-$ helm install vault hashicorp/vault --version 0.9.1
+# Install version 0.10.0
+$ helm install vault hashicorp/vault --version 0.10.0
 ```
 
 ~> **Security Warning:** By default, the chart runs in standalone mode. This

--- a/website/content/docs/platform/k8s/helm/openshift.mdx
+++ b/website/content/docs/platform/k8s/helm/openshift.mdx
@@ -70,7 +70,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.10.0        	1.7.0      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -89,14 +89,14 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
-hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.10.0        	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1         	1.6.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.0         	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.8.0         	1.5.4      	Official HashiCorp Vault Chart
+hashicorp/vault	0.7.0         	1.5.2      	Official HashiCorp Vault Chart
 
-# Install version 0.9.1
-$ helm install vault hashicorp/vault --version 0.9.1
+# Install version 0.10.0
+$ helm install vault hashicorp/vault --version 0.10.0
 ```
 
 The `helm install` command accepts parameters to override default configuration

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -54,7 +54,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.10.0        	1.7.0     	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -73,14 +73,14 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
-hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.10.0        	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1         	1.6.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.0         	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.8.0         	1.5.4      	Official HashiCorp Vault Chart
+hashicorp/vault	0.7.0         	1.5.2      	Official HashiCorp Vault Chart
 
-# Install version 0.9.1
-$ helm install vault hashicorp/vault --version 0.9.1
+# Install version 0.10.0
+$ helm install vault hashicorp/vault --version 0.10.0
 ```
 
 The `helm install` command accepts parameters to override default configuration
@@ -423,14 +423,14 @@ Next, list the Helm versions and choose the desired version to install.
 ```bash
 helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.10.0        	1.7.0     	Official HashiCorp Vault Chart
 ```
 
 Next, test the upgrade with `--dry-run` first to verify the changes sent to the
 Kubernetes cluster.
 
 ```shell-session
-$ helm upgrade vault hashicorp/vault --version=0.9.1 \
+$ helm upgrade vault hashicorp/vault --version=0.10.0 \
     --set='server.image.repository=vault' \
     --set='server.image.tag=123.456' \
     --dry-run


### PR DESCRIPTION
Documentation update for the upcoming [Vault Helm 0.10.0 release](https://github.com/hashicorp/vault-helm/blob/master/CHANGELOG.md#0100-march-25th-2021). 