### PR TITLE
Update upgrade guide and changelog with AWS Auth deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 CHANGES:
 
+* aws/auth: AWS Auth concepts and endpoints that use the "whitelist" and "blacklist" terms
+have been updated to more inclusive language (e.g. `/auth/aws/identity-whitelist` has been
+updated to`/auth/aws/identity-accesslist`). The legacy endpoint names are considered **deprecated**.
+The old and new endpoints are aliases, sharing the same underlying data. The complete
+list of endpoint changes is available in the [AWS Auth API docs](/api-docs/auth/aws).
 * go: Update Go version to 1.15.10 [[GH-11173](https://github.com/hashicorp/vault/pull/11173)]
 
 FEATURES:
@@ -126,6 +131,10 @@ the given key will be used to encrypt the snapshot using AWS KMS.
 * ui: Fix bug that double encodes secret route when there are spaces in the path and makes you unable to view the version history. [[GH-10596](https://github.com/hashicorp/vault/pull/10596)]
 * ui: Fix expected response from feature-flags endpoint [[GH-10684](https://github.com/hashicorp/vault/pull/10684)]
 * ui: Fix footer URL linking to the correct version changelog. [[GH-10491](https://github.com/hashicorp/vault/pull/10491)]
+
+DEPRECATIONS:
+* aws/auth: AWS Auth endpoints that use the "whitelist" and "blacklist" terms have been deprecated.
+Refer to the CHANGES section for additional details.
 
 ## 1.6.3
 ### February 25, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ CHANGES:
 
 * aws/auth: AWS Auth concepts and endpoints that use the "whitelist" and "blacklist" terms
 have been updated to more inclusive language (e.g. `/auth/aws/identity-whitelist` has been
-updated to`/auth/aws/identity-accesslist`). The legacy endpoint names are considered **deprecated**.
-The old and new endpoints are aliases, sharing the same underlying data. The complete
-list of endpoint changes is available in the [AWS Auth API docs](/api-docs/auth/aws#deprecations-effective-in-vault-1-7).
+updated to`/auth/aws/identity-accesslist`). The old and new endpoints are aliases,
+sharing the same underlying data. The legacy endpoint names are considered **deprecated**
+and will be removed in a future release (not before Vault 1.9). The complete list of
+endpoint changes is available in the [AWS Auth API docs](/api-docs/auth/aws#deprecations-effective-in-vault-1-7).
 * go: Update Go version to 1.15.10 [[GH-11173](https://github.com/hashicorp/vault/pull/11173)]
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGES:
 have been updated to more inclusive language (e.g. `/auth/aws/identity-whitelist` has been
 updated to`/auth/aws/identity-accesslist`). The legacy endpoint names are considered **deprecated**.
 The old and new endpoints are aliases, sharing the same underlying data. The complete
-list of endpoint changes is available in the [AWS Auth API docs](/api-docs/auth/aws).
+list of endpoint changes is available in the [AWS Auth API docs](/api-docs/auth/aws#deprecations-effective-in-vault-1-7).
 * go: Update Go version to 1.15.10 [[GH-11173](https://github.com/hashicorp/vault/pull/11173)]
 
 FEATURES:

--- a/website/content/docs/upgrading/upgrade-to-1.7.0.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.7.0.mdx
@@ -25,8 +25,9 @@ recommended by
 
 AWS Auth concepts and endpoints that use the "whitelist" and "blacklist" terms
 have been updated to more inclusive language (e.g. `/auth/aws/identity-whitelist` has been
-updated to`/auth/aws/identity-accesslist`). The legacy endpoint names are considered **deprecated**.
-The old and new endpoints are aliases, sharing the same underlying data. The complete list of
+updated to`/auth/aws/identity-accesslist`). The old and new endpoints are aliases,
+sharing the same underlying data. The legacy endpoint names are considered **deprecated**
+and will be removed in a future release (not before Vault 1.9). The complete list of
 endpoint changes is available in the [AWS Auth API docs](/api-docs/auth/aws#deprecations-effective-in-vault-1-7).
 
 ## Known Issues

--- a/website/content/docs/upgrading/upgrade-to-1.7.0.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.7.0.mdx
@@ -21,6 +21,14 @@ ensure the number of encryptions performed by the barrier key is fewer than that
 recommended by 
 [NIST SP 800-38D](https://csrc.nist.gov/publications/detail/sp/800-38d/final).
 
+## AWS Auth Endpoint Changes and Deprecations
+
+AWS Auth concepts and endpoints that use the "whitelist" and "blacklist" terms
+have been updated to more inclusive language (e.g. `/auth/aws/identity-whitelist` has been
+updated to`/auth/aws/identity-accesslist`). The legacy endpoint names are considered **deprecated**.
+The old and new endpoints are aliases, sharing the same underlying data. The complete list of
+endpoint changes is available in the [AWS Auth API docs](/api-docs/auth/aws).
+
 ## Known Issues
 
 Due to the known issue, Transform Secrets Engine users are recommended to upgrade to version 1.6.4 or 1.7.0.

--- a/website/content/docs/upgrading/upgrade-to-1.7.0.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.7.0.mdx
@@ -14,11 +14,11 @@ for Vault 1.7.0 compared to 1.6. Please read it carefully.
 
 ## Barrier Key Auto-Rotation
 
-If your Vault installation is at least a year old, the barrier key will be 
-automatically rotated once, and then subsequently will be rotated per the 
-settings in the new `sys/rotate/config` endpoint.  This is a precaution to 
-ensure the number of encryptions performed by the barrier key is fewer than that 
-recommended by 
+If your Vault installation is at least a year old, the barrier key will be
+automatically rotated once, and then subsequently will be rotated per the
+settings in the new `sys/rotate/config` endpoint.  This is a precaution to
+ensure the number of encryptions performed by the barrier key is fewer than that
+recommended by
 [NIST SP 800-38D](https://csrc.nist.gov/publications/detail/sp/800-38d/final).
 
 ## AWS Auth Endpoint Changes and Deprecations
@@ -27,7 +27,7 @@ AWS Auth concepts and endpoints that use the "whitelist" and "blacklist" terms
 have been updated to more inclusive language (e.g. `/auth/aws/identity-whitelist` has been
 updated to`/auth/aws/identity-accesslist`). The legacy endpoint names are considered **deprecated**.
 The old and new endpoints are aliases, sharing the same underlying data. The complete list of
-endpoint changes is available in the [AWS Auth API docs](/api-docs/auth/aws).
+endpoint changes is available in the [AWS Auth API docs](/api-docs/auth/aws#deprecations-effective-in-vault-1-7).
 
 ## Known Issues
 


### PR DESCRIPTION
These were missing from the initial publication.