### PR TITLE
Use pointers to 64-bit atomics to enforce alignment in AES-GCM Barrier

### DIFF
--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -61,13 +61,6 @@ var (
 // bit. AES-GCM is high performance, and provides both confidentiality
 // and integrity.
 type AESGCMBarrier struct {
-	// Atomics must remain here for alignment on 32-bit architectures
-	UnaccountedEncryptions atomic.Int64
-	// Used only for testing
-	RemoteEncryptions     atomic.Int64
-	totalLocalEncryptions atomic.Int64
-	initialized atomic.Bool	
-
 	backend physical.Backend
 
 	l      sync.RWMutex
@@ -86,6 +79,13 @@ type AESGCMBarrier struct {
 	// future versioning of barrier implementations. It's var instead
 	// of const to allow for testing
 	currentAESGCMVersionByte byte
+
+	initialized atomic.Bool
+
+	UnaccountedEncryptions *atomic.Int64
+	// Used only for testing
+	RemoteEncryptions     *atomic.Int64
+	totalLocalEncryptions *atomic.Int64
 }
 
 func (b *AESGCMBarrier) RotationConfig() (kc KeyRotationConfig, err error) {
@@ -115,6 +115,9 @@ func NewAESGCMBarrier(physical physical.Backend) (*AESGCMBarrier, error) {
 		sealed:                   true,
 		cache:                    make(map[uint32]cipher.AEAD),
 		currentAESGCMVersionByte: byte(AESGCMVersion2),
+		UnaccountedEncryptions:   atomic.NewInt64(0),
+		RemoteEncryptions:        atomic.NewInt64(0),
+		totalLocalEncryptions:    atomic.NewInt64(0),
 	}
 	return b, nil
 }

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -61,6 +61,13 @@ var (
 // bit. AES-GCM is high performance, and provides both confidentiality
 // and integrity.
 type AESGCMBarrier struct {
+	// Atomics must remain here for alignment on 32-bit architectures
+	UnaccountedEncryptions atomic.Int64
+	// Used only for testing
+	RemoteEncryptions     atomic.Int64
+	totalLocalEncryptions atomic.Int64
+	initialized atomic.Bool	
+
 	backend physical.Backend
 
 	l      sync.RWMutex
@@ -79,13 +86,6 @@ type AESGCMBarrier struct {
 	// future versioning of barrier implementations. It's var instead
 	// of const to allow for testing
 	currentAESGCMVersionByte byte
-
-	initialized atomic.Bool
-
-	UnaccountedEncryptions atomic.Int64
-	// Used only for testing
-	RemoteEncryptions     atomic.Int64
-	totalLocalEncryptions atomic.Int64
 }
 
 func (b *AESGCMBarrier) RotationConfig() (kc KeyRotationConfig, err error) {


### PR DESCRIPTION
Fixes a panic on ARM-32 and likely other 32-bit architectures.