### PR TITLE
UI: Fix status menu bug

### DIFF
--- a/changelog/11213.txt
+++ b/changelog/11213.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix status menu no showing on login
+```

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -8,7 +8,7 @@ export default Service.extend({
   auth: service(),
   userRootNamespace: alias('auth.authData.userRootNamespace'),
   //populated by the query param on the cluster route
-  path: null,
+  path: '',
   // list of namespaces available to the current user under the
   // current namespace
   accessibleNamespaces: null,

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -17,7 +17,8 @@ export default Service.extend({
 
   setNamespace(path) {
     if (!path) {
-      return '';
+      this.set('path', '');
+      return;
     }
     this.set('path', path);
   },

--- a/ui/app/services/namespace.js
+++ b/ui/app/services/namespace.js
@@ -16,6 +16,9 @@ export default Service.extend({
   inRootNamespace: equal('path', ROOT_NAMESPACE),
 
   setNamespace(path) {
+    if (!path) {
+      return '';
+    }
     this.set('path', path);
   },
 


### PR DESCRIPTION
Fix an error where the status menu does not show on the initial login.  The workaround was to refresh.  This fix gets us back to the expected behavior.
