### PR TITLE
certutil: select appropriate hash algorithm for ECDSA signature

### DIFF
--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -600,7 +600,7 @@ func createCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertB
 		case RSAPrivateKey:
 			certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
 		case ECPrivateKey:
-			certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA256
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(data.SigningBundle.PrivateKey.Public())
 		}
 
 		caCert := data.SigningBundle.Certificate
@@ -620,7 +620,7 @@ func createCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertB
 		case "rsa":
 			certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
 		case "ec":
-			certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA256
+			certTemplate.SignatureAlgorithm = selectSignatureAlgorithmForECDSA(result.PrivateKey.Public())
 		}
 
 		certTemplate.AuthorityKeyId = subjKeyID
@@ -653,6 +653,23 @@ func createCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertB
 	}
 
 	return result, nil
+}
+
+func selectSignatureAlgorithmForECDSA(pub crypto.PublicKey) x509.SignatureAlgorithm {
+	key, ok := pub.(*ecdsa.PublicKey)
+	if !ok {
+		return x509.ECDSAWithSHA256
+	}
+	switch key.Curve {
+	case elliptic.P224(), elliptic.P256():
+		return x509.ECDSAWithSHA256
+	case elliptic.P384():
+		return x509.ECDSAWithSHA384
+	case elliptic.P521():
+		return x509.ECDSAWithSHA512
+	default:
+		return x509.ECDSAWithSHA256
+	}
 }
 
 var oidExtensionBasicConstraints = []int{2, 5, 29, 19}


### PR DESCRIPTION
Select the appropriate signature algorithm for certificates signed
with an ECDSA private key.

The algorithm is selected based on the curve:

- P-256 -> x509.ECDSAWithSHA256
- P-384 -> x509.ECDSAWithSHA384
- P-521 -> x509.ECDSAWithSHA512
- Other -> x509.ECDSAWithSHA256

fixes #11006