### PR TITLE
pki: calculate Subject Key Identifier according to RFC 5280

### DIFF
--- a/changelog/11218.txt
+++ b/changelog/11218.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Calculate the Subject Key Identifier as suggested in [RFC 5280, Section 4.2.1.2](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2).
+```


### PR DESCRIPTION
Calculate the Subject Key Identifier as suggested in RFC 5280, Section 4.2.1.2

> (1) The keyIdentifier is composed of the 160-bit SHA-1 hash of the
value of the BIT STRING subjectPublicKey (excluding the tag,
length, and number of unused bits).

fixes #11153

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hashicorp/vault/11218)
<!-- Reviewable:end -->
