### PR TITLE
Use a 15s instead of 10s timeout in TestAgent_Template_Retry

### DIFF
--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -1415,7 +1415,7 @@ vault {
 				// the temp dir before Agent has had time to render and will
 				// likely fail the test
 				tick := time.Tick(1 * time.Second)
-				timeout := time.After(10 * time.Second)
+				timeout := time.After(15 * time.Second)
 				var err error
 				for {
 					select {


### PR DESCRIPTION
The `default` subtest takes 9s on my laptop, so pad that for CI.

Example failure: https://app.circleci.com/pipelines/github/hashicorp/vault/16245/workflows/203601da-94bf-4ec2-be25-d8e6dd4315b8/jobs/174151