### PR TITLE
Use a 10s timeout instead of 3s in TestMySQLHABackend_LockFailPanic to reduce test flakiness.  

### DIFF
--- a/physical/mysql/mysql_test.go
+++ b/physical/mysql/mysql_test.go
@@ -233,9 +233,8 @@ func TestMySQLHABackend_LockFailPanic(t *testing.T) {
 		t.Fatalf("lock 2: %v", err)
 	}
 
-	// Cancel attempt in 50 msec
 	stopCh := make(chan struct{})
-	time.AfterFunc(3*time.Second, func() {
+	time.AfterFunc(10*time.Second, func() {
 		close(stopCh)
 	})
 
@@ -256,14 +255,13 @@ func TestMySQLHABackend_LockFailPanic(t *testing.T) {
 	// trigger the panic shown in https://github.com/hashicorp/vault/issues/8203
 	cleanup()
 
-	// Cancel attempt in 50 msec
 	stopCh2 := make(chan struct{})
-	time.AfterFunc(3*time.Second, func() {
+	time.AfterFunc(10*time.Second, func() {
 		close(stopCh2)
 	})
 	leaderCh2, err = lock2.Lock(stopCh2)
 	if err == nil {
-		t.Fatalf("expected error, got none")
+		t.Fatalf("expected error, got none, leaderCh2=%v", leaderCh2)
 	}
 }
 


### PR DESCRIPTION
The purpose of the timeout is to ensure that if something's broken the test doesn't run forever.  However if things are slow, it could lead to the test failing.  Also report on whether we got the lock so that if this fix doesn't solve the problem, we have more information to go on.

There are lots of failures in CI of this test, here's one example: https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/3521/workflows/c888b264-0ede-472d-9311-0f897e6a8b69/jobs/129943/tests#failed-test-0

```
=== RUN   TestMySQLHABackend_LockFailPanic
[mysql] 2021/03/24 18:05:45 packets.go:36: unexpected EOF
[mysql] 2021/03/24 18:05:47 packets.go:122: closing bad idle connection: EOF
[mysql] 2021/03/24 18:05:47 packets.go:122: closing bad idle connection: EOF
    mysql_test.go:266: expected error, got none
--- FAIL: TestMySQLHABackend_LockFailPanic (21.70s)
```