### PR TITLE
Fix activity log pre-computed query boundary calculation

### DIFF
--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -109,7 +109,7 @@ func (b *SystemBackend) handleClientMetricQuery(ctx context.Context, req *logica
 	// Also convert any user inputs to UTC to avoid
 	// problems later.
 	if endTime.IsZero() {
-		endTime = timeutil.EndOfMonth(time.Now().UTC().AddDate(0, -1, 0))
+		endTime = timeutil.EndOfMonth(timeutil.StartOfPreviousMonth(time.Now().UTC()))
 	} else {
 		endTime = endTime.UTC()
 	}


### PR DESCRIPTION
The previous `time.Now().UTC().AddDate(0, -1, 0)` returned the start of the current month (at least, when we are later on in the month)