### PR TITLE
Remove version ref on internal counters docs

### DIFF
--- a/website/content/api-docs/system/internal-counters.mdx
+++ b/website/content/api-docs/system/internal-counters.mdx
@@ -244,8 +244,6 @@ The time period is from the start of the current month, up until the time that t
 Note: the client count may be inaccurate in the moments following a Vault reboot, or leadership change.
 The estimate will stabilize when background loading of client data has completed.
 
-This endpoint was added in Vault 1.6.4.
-
 | Method | Path                              |
 | :----- | :-------------------------------- |
 | `GET`  | `/sys/internal/counters/activity/monthly` |


### PR DESCRIPTION
We typically don't include "introduced in" version references, but even if we wanted to in this case it would be 1.7.