### PR TITLE
Backport 1.6: InfluxDB has released a 2.x series of docker images, which is breakin…

### DIFF
--- a/plugins/database/influxdb/influxdb_test.go
+++ b/plugins/database/influxdb/influxdb_test.go
@@ -59,7 +59,7 @@ func prepareInfluxdbTestContainer(t *testing.T) (func(), *Config) {
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ImageRepo: "influxdb",
-		ImageTag:  "alpine",
+		ImageTag:  "1.8-alpine",
 		Env: []string{
 			"INFLUXDB_DB=vault",
 			"INFLUXDB_ADMIN_USER=" + c.Username,


### PR DESCRIPTION
…g our tests.  Use the 1.8 image instead. (#11005)