### PR TITLE
improvement: add signature_bits field to CA and signers

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -683,6 +683,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		KeyType:   "rsa",
 		KeyBits:   2048,
 		RequireCN: true,
+		SignatureBits: 256,
 	}
 	issueVals := certutil.IssueData{}
 	ret := []logicaltest.TestStep{}

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -33,6 +33,7 @@ func (b *backend) getGenerationParams(
 		TTL:                  time.Duration(data.Get("ttl").(int)) * time.Second,
 		KeyType:              data.Get("key_type").(string),
 		KeyBits:              data.Get("key_bits").(int),
+		SignatureBits:        data.Get("signature_bits").(int),
 		AllowLocalhost:       true,
 		AllowAnyName:         true,
 		AllowIPSANs:          true,
@@ -56,6 +57,11 @@ func (b *backend) getGenerationParams(
 
 	if err := certutil.ValidateKeyTypeLength(role.KeyType, role.KeyBits); err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
+	}
+
+	if err := certutil.ValidateSignatureLength(role.SignatureBits); err != nil {
+		errorResp = logical.ErrorResponse(err.Error())
+		return
 	}
 
 	return

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1060,6 +1060,7 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 			OtherSANs:                     otherSANs,
 			KeyType:                       data.role.KeyType,
 			KeyBits:                       data.role.KeyBits,
+			SignatureBits:                 data.role.SignatureBits,
 			NotAfter:                      notAfter,
 			KeyUsage:                      x509.KeyUsage(parseKeyUsages(data.role.KeyUsage)),
 			ExtKeyUsage:                   parseExtKeyUsages(data.role),

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -254,6 +254,18 @@ the key_type.`,
 		},
 	}
 
+	fields["signature_bits"] = &framework.FieldSchema{
+		Type: framework.TypeInt,
+		Default: 256,
+		Description: `The number of bits to use in the signature
+algorithm. Defaults to 256 for SHA256.
+Set to 384 for SHA384 and 512 for SHA512.
+`,
+		DisplayAttrs: &framework.DisplayAttributes{
+			Value: 256,
+		},
+	}
+
 	fields["key_type"] = &framework.FieldSchema{
 		Type:    framework.TypeString,
 		Default: "rsa",

--- a/changelog/11245.txt
+++ b/changelog/11245.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+pki: adds signature_bits field to customize signature algorithm on CAs and certs signed by Vault
+```

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -490,6 +490,17 @@ func StringToOid(in string) (asn1.ObjectIdentifier, error) {
 	return asn1.ObjectIdentifier(ret), nil
 }
 
+func ValidateSignatureLength(keyBits int) error {
+	switch keyBits {
+	case 256:
+	case 384:
+	case 512:
+	default:
+		return fmt.Errorf("unsupported signature algorithm: %d", keyBits)
+	}
+	return nil
+}
+
 func ValidateKeyTypeLength(keyType string, keyBits int) error {
 	switch keyType {
 	case "rsa":
@@ -598,9 +609,23 @@ func createCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertB
 	if data.SigningBundle != nil {
 		switch data.SigningBundle.PrivateKeyType {
 		case RSAPrivateKey:
-			certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+			switch data.Params.SignatureBits {
+			case 256:
+				certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+			case 384:
+				certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
+			case 512:
+				certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
+			}
 		case ECPrivateKey:
-			certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA256
+			switch data.Params.SignatureBits {
+			case 256:
+				certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA256
+			case 384:
+				certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA384
+			case 512:
+				certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA512
+			}
 		}
 
 		caCert := data.SigningBundle.Certificate
@@ -618,9 +643,23 @@ func createCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertB
 
 		switch data.Params.KeyType {
 		case "rsa":
-			certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+			switch data.Params.SignatureBits {
+			case 256:
+				certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+			case 384:
+				certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
+			case 512:
+				certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
+			}
 		case "ec":
-			certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA256
+			switch data.Params.SignatureBits {
+			case 256:
+				certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA256
+			case 384:
+				certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA384
+			case 512:
+				certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA512
+			}
 		}
 
 		certTemplate.AuthorityKeyId = subjKeyID
@@ -791,9 +830,23 @@ func signCertificate(data *CreationBundle, randReader io.Reader) (*ParsedCertBun
 
 	switch data.SigningBundle.PrivateKeyType {
 	case RSAPrivateKey:
-		certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+		switch data.Params.SignatureBits {
+		case 256:
+			certTemplate.SignatureAlgorithm = x509.SHA256WithRSA
+		case 384:
+			certTemplate.SignatureAlgorithm = x509.SHA384WithRSA
+		case 512:
+			certTemplate.SignatureAlgorithm = x509.SHA512WithRSA
+		}
 	case ECPrivateKey:
-		certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA256
+		switch data.Params.SignatureBits {
+		case 256:
+			certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA256
+		case 384:
+			certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA384
+		case 512:
+			certTemplate.SignatureAlgorithm = x509.ECDSAWithSHA512
+		}
 	}
 
 	if data.Params.UseCSRValues {

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -677,6 +677,7 @@ type CreationParameters struct {
 	ExtKeyUsageOIDs               []string
 	PolicyIdentifiers             []string
 	BasicConstraintsValidForNonCA bool
+	SignatureBits                 int
 
 	// Only used when signing a CA cert
 	UseCSRValues        bool


### PR DESCRIPTION
This change adds the ability to set the signature algorithm of the
CAs that Vault generates and any certificates it signs.  This is a
potentially useful stepping stone for a SHA3 transition down the line.

Summary:
* Adds the field "signature_bits" to CA and Sign endpoints
* Adds support for SHA256, SHA384 and SHA512 signatures on EC and RSA
keytypes.