### PR TITLE
UI/fix kvv2 version

### DIFF
--- a/changelog/11258.txt
+++ b/changelog/11258.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix bug where the UI does not recognize version 2 KV until refresh, and fix [object Object] error message
+```

--- a/ui/app/models/database/connection.js
+++ b/ui/app/models/database/connection.js
@@ -31,6 +31,7 @@ export default Model.extend({
   plugin_name: attr('string', {
     label: 'Database plugin',
     possibleValues: AVAILABLE_PLUGIN_TYPES,
+    noDefault: true,
   }),
   verify_connection: attr('boolean', {
     defaultValue: true,

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -36,6 +36,6 @@ export default Fragment.extend({
     helpText:
       "The type of token that should be generated via this role. Can be `service`, `batch`, or `default` to use the mount's default (which unless changed will be `service` tokens).",
     possibleValues: ['default', 'batch', 'service'],
-    defaultValue: 'default',
+    defaultFormValue: 'default',
   }),
 });

--- a/ui/app/models/mount-config.js
+++ b/ui/app/models/mount-config.js
@@ -36,6 +36,6 @@ export default Fragment.extend({
     helpText:
       "The type of token that should be generated via this role. Can be `service`, `batch`, or `default` to use the mount's default (which unless changed will be `service` tokens).",
     possibleValues: ['default', 'batch', 'service'],
-    defaultFormValue: 'default',
+    defaultValue: 'default',
   }),
 });

--- a/ui/app/models/mount-options.js
+++ b/ui/app/models/mount-options.js
@@ -7,6 +7,6 @@ export default Fragment.extend({
     helpText:
       'The KV Secrets Engine can operate in different modes. Version 1 is the original generic Secrets Engine the allows for storing of static key/value pairs. Version 2 added more features including data versioning, TTLs, and check and set.',
     possibleValues: [2, 1],
-    defaultFormValue: 2,
+    defaultValue: 2,
   }),
 });

--- a/ui/app/models/mount-options.js
+++ b/ui/app/models/mount-options.js
@@ -7,6 +7,7 @@ export default Fragment.extend({
     helpText:
       'The KV Secrets Engine can operate in different modes. Version 1 is the original generic Secrets Engine the allows for storing of static key/value pairs. Version 2 added more features including data versioning, TTLs, and check and set.',
     possibleValues: [2, 1],
-    defaultValue: 2,
+    // This shouldn't be defaultValue because if no version comes back from API we should assume it's v1
+    defaultFormValue: 2, // Set the form to 2 by default
   }),
 });

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -60,8 +60,17 @@ export default Model.extend({
   formFieldGroups: computed('engineType', function() {
     let type = this.engineType;
     let defaultGroup = { default: ['path'] };
+    let optionsGroup = {
+      'Method Options': [
+        'description',
+        'config.listingVisibility',
+        'local',
+        'sealWrap',
+        'config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
+      ],
+    };
     if (type === 'kv' || type === 'generic') {
-      defaultGroup.default.push('options.{version}');
+      optionsGroup['Method Options'].unshift('options.{version}');
     }
     if (type === 'database') {
       // For the Database Secret Engine we want to highlight the defaultLeaseTtl and maxLeaseTtl, removing them from the options object
@@ -79,18 +88,7 @@ export default Model.extend({
         },
       ];
     }
-    return [
-      defaultGroup,
-      {
-        'Method Options': [
-          'description',
-          'config.listingVisibility',
-          'local',
-          'sealWrap',
-          'config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
-        ],
-      },
-    ];
+    return [defaultGroup, optionsGroup];
   }),
 
   attrs: computed('formFields', function() {

--- a/ui/lib/core/addon/components/message-error.js
+++ b/ui/lib/core/addon/components/message-error.js
@@ -44,7 +44,10 @@ export default Component.extend({
           return;
         }
         if (this.model.adapterError.errors.length > 0) {
-          return this.model.adapterError.errors;
+          return this.model.adapterError.errors.map(e => {
+            if (typeof e === 'object') return e.title || e.message || JSON.stringify(e);
+            return e;
+          });
         }
         return [this.model.adapterError.message];
       }

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -38,11 +38,11 @@
           (action "setAndBroadcast" valuePath)
           value="target.value"
         }} data-test-input={{attr.name}}>
-        {{#unless attr.options.defaultValue}}
+        {{#if attr.options.noDefault}}
           <option value="">
             Select one
           </option>
-        {{/unless}}
+        {{/if}}
         {{#each (path-or-array attr.options.possibleValues model) as |val|}}
           <option selected={{eq (get model valuePath) (or val.value val)}} value={{or val.value val}}>
             {{or val.displayName val}}

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -65,6 +65,7 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     await mountSecrets
       .next()
       .path(enginePath)
+      .toggleOptions()
       .version(1)
       .submit();
     await listPage.create();
@@ -83,6 +84,7 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     await mountSecrets
       .next()
       .path(enginePath)
+      .toggleOptions()
       .version(1)
       .submit();
     await listPage.create();
@@ -137,6 +139,7 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     await mountSecrets
       .next()
       .path(enginePath)
+      .toggleOptions()
       .version(1)
       .submit();
     await listPage.create();


### PR DESCRIPTION
Unselected dropdown option caused a bug when enabling a v2 secrets engine and creating a secret, where the UI didn't recognize that the new secrets engine was `version 2` until a refresh caused a new network request. In addition to correctly setting the default kv version to 2, we moved that option under the Method Options dropdown:

<img width="1181" alt="Version selection is in Method Options toggle" src="https://user-images.githubusercontent.com/16182107/113310901-54e2cc80-92ce-11eb-9eaa-1fbc19819e47.png">

This PR also updates the `MessageError` component to better handle the type of error that was resulting in a message like `[object Object]`, so that arrays of objects are instead passed into the component as strings

<img width="1440" alt="Better error message than [object Object]" src="https://user-images.githubusercontent.com/16182107/113432379-e3c11900-93a2-11eb-91e9-426aaf075a67.png">
