### PR TITLE
Cassandra DB plugin: Allow special chars in usernames

### DIFF
--- a/changelog/11262.txt
+++ b/changelog/11262.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/database/cassandra: Updated default statement for password rotation to allow for special characters. This applies to root and static credentials.
+```

--- a/plugins/database/cassandra/cassandra.go
+++ b/plugins/database/cassandra/cassandra.go
@@ -17,7 +17,7 @@ import (
 const (
 	defaultUserCreationCQL   = `CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER;`
 	defaultUserDeletionCQL   = `DROP USER '{{username}}';`
-	defaultChangePasswordCQL = `ALTER USER {{username}} WITH PASSWORD '{{password}}';`
+	defaultChangePasswordCQL = `ALTER USER '{{username}}' WITH PASSWORD '{{password}}';`
 	cassandraTypeName        = "cassandra"
 
 	defaultUserNameTemplate = `{{ printf "v_%s_%s_%s_%s" (.DisplayName | truncate 15) (.RoleName | truncate 15) (random 20) (unix_time) | truncate 100 | replace "-" "_" | lowercase }}`


### PR DESCRIPTION
Allows special characters in usernames by updating the default change-password statement to include quotes around the username.

In the meantime, this can be worked around by specifying the `root_rotation_statements` field on the database config:
```shell-session
$ vault write database/config/cassandra \
    plugin_name=cassandra-database-plugin \
    hosts=127.0.0.1 \
    protocol_version=3 \
    username="vault-admin" \
    password="myreallysecurepassword" \
    allowed_roles="*" \
    root_rotation_statements="ALTER USER '{{username}}' WITH PASSWORD '{{password}}'"
```

## Testing
Running this with an automated test is a bit tricky and the change is small enough I'm comfortable with some manual testing:

Before fix:
```shell-session
$ vault write database/config/cassandra \
    plugin_name=cassandra-database-plugin \
    hosts=127.0.0.1 \
    protocol_version=3 \
    username="vault-admin" \
    password="myreallysecurepassword"

$ vault write -force database/rotate-root/cassandra
Error writing data to database/rotate-root/cassandra: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/database/rotate-root/cassandra
Code: 500. Errors:

* 1 error occurred:
	* failed to update user: 1 error occurred:
	* line 1:16 mismatched input '-' expecting EOF (ALTER USER vault[-]...)
```

After fix:
```shell-session
$ vault write database/config/cassandra \
    plugin_name=cassandra-database-plugin \
    hosts=127.0.0.1 \
    protocol_version=3 \
    username="vault-admin" \
    password="myreallysecurepassword" \
    allowed_roles="*"

$ vault write -force database/rotate-root/cassandra
Success! Data written to: database/rotate-root/cassandra
```