### PR TITLE
Backport #11190 (Proxy fix) to 1.6.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190307165228-86c17b95fcd5
 	github.com/apple/foundationdb/bindings/go v0.0.0-20190411004307-cd5c9d91fad2
 	github.com/armon/go-metrics v0.3.4
-	github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e
+	github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a
 	github.com/armon/go-radix v1.0.0
 	github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf
 	github.com/aws/aws-sdk-go v1.34.28

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD
 github.com/armon/go-metrics v0.3.3/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-metrics v0.3.4 h1:Xqf+7f2Vhl9tsqDYmXhnXInUdcrtgpRNpIA15/uldSc=
 github.com/armon/go-metrics v0.3.4/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
-github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e h1:h0gP0hBU6DsA5IQduhLWGOEfIUKzJS5hhXQBSgHuF/g=
-github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
+github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a h1:AP/vsCIvJZ129pdm9Ek7bH7yutN3hByqsMoNrWAxRQc=
+github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/vendor/github.com/armon/go-proxyproto/protocol.go
+++ b/vendor/github.com/armon/go-proxyproto/protocol.go
@@ -49,6 +49,7 @@ type Listener struct {
 	Listener           net.Listener
 	ProxyHeaderTimeout time.Duration
 	SourceCheck        SourceChecker
+	UnknownOK          bool // allow PROXY UNKNOWN
 }
 
 // Conn is used to wrap and underlying connection which
@@ -62,28 +63,36 @@ type Conn struct {
 	useConnAddr        bool
 	once               sync.Once
 	proxyHeaderTimeout time.Duration
+	unknownOK          bool
 }
 
 // Accept waits for and returns the next connection to the listener.
 func (p *Listener) Accept() (net.Conn, error) {
 	// Get the underlying connection
-	conn, err := p.Listener.Accept()
-	if err != nil {
-		return nil, err
-	}
-	var useConnAddr bool
-	if p.SourceCheck != nil {
-		allowed, err := p.SourceCheck(conn.RemoteAddr())
+	for {
+		conn, err := p.Listener.Accept()
 		if err != nil {
 			return nil, err
 		}
-		if !allowed {
-			useConnAddr = true
+		var useConnAddr bool
+		if p.SourceCheck != nil {
+			allowed, err := p.SourceCheck(conn.RemoteAddr())
+			if err != nil {
+				if err == ErrInvalidUpstream {
+					conn.Close()
+					continue
+				}
+				return nil, err
+			}
+			if !allowed {
+				useConnAddr = true
+			}
 		}
+		newConn := NewConn(conn, p.ProxyHeaderTimeout)
+		newConn.useConnAddr = useConnAddr
+		newConn.unknownOK = p.UnknownOK
+		return newConn, nil
 	}
-	newConn := NewConn(conn, p.ProxyHeaderTimeout)
-	newConn.useConnAddr = useConnAddr
-	return newConn, nil
 }
 
 // Close closes the underlying listener.
@@ -117,6 +126,22 @@ func (p *Conn) Read(b []byte) (int, error) {
 		return 0, err
 	}
 	return p.bufReader.Read(b)
+}
+
+func (p *Conn) ReadFrom(r io.Reader) (int64, error) {
+	if rf, ok := p.conn.(io.ReaderFrom); ok {
+		return rf.ReadFrom(r)
+	}
+	return io.Copy(p.conn, r)
+}
+
+func (p *Conn) WriteTo(w io.Writer) (int64, error) {
+	var err error
+	p.once.Do(func() { err = p.checkPrefix() })
+	if err != nil {
+		return 0, err
+	}
+	return p.bufReader.WriteTo(w)
 }
 
 func (p *Conn) Write(b []byte) (int, error) {
@@ -209,18 +234,30 @@ func (p *Conn) checkPrefix() error {
 
 	// Split on spaces, should be (PROXY <type> <src addr> <dst addr> <src port> <dst port>)
 	parts := strings.Split(header, " ")
-	if len(parts) != 6 {
+	if len(parts) < 2 {
 		p.conn.Close()
 		return fmt.Errorf("Invalid header line: %s", header)
 	}
 
 	// Verify the type is known
 	switch parts[1] {
+	case "UNKNOWN":
+		if !p.unknownOK || len(parts) != 2 {
+			p.conn.Close()
+			return fmt.Errorf("Invalid UNKNOWN header line: %s", header)
+		}
+		p.useConnAddr = true
+		return nil
 	case "TCP4":
 	case "TCP6":
 	default:
 		p.conn.Close()
 		return fmt.Errorf("Unhandled address type: %s", parts[1])
+	}
+
+	if len(parts) != 6 {
+		p.conn.Close()
+		return fmt.Errorf("Invalid header line: %s", header)
 	}
 
 	// Parse out the source address

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/armon/go-metrics
 github.com/armon/go-metrics/circonus
 github.com/armon/go-metrics/datadog
 github.com/armon/go-metrics/prometheus
-# github.com/armon/go-proxyproto v0.0.0-20190211145416-68259f75880e
+# github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a
 github.com/armon/go-proxyproto
 # github.com/armon/go-radix v1.0.0
 github.com/armon/go-radix


### PR DESCRIPTION
Backports the update of the armon/go-protoproxy which fixes listener close on proxy error.