### PR TITLE
bumping alpine version, improving security

### DIFF
--- a/.circleci/config/executors/@executors.yml
+++ b/.circleci/config/executors/@executors.yml
@@ -20,7 +20,7 @@ python:
   working_directory: /go/src/github.com/hashicorp/vault
 alpine:
   docker:
-    - image: docker.mirror.hashicorp.services/alpine:3.10.2
+    - image: docker.mirror.hashicorp.services/alpine:3.13
   shell: /bin/sh
   working_directory: /go/src/github.com/hashicorp/vault
 docker-env-go-test-remote-docker:

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN make bootstrap \
 
 # Docker Image
 
-FROM alpine:3.10
+FROM alpine:3.13
 
 # Create a vault user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.

--- a/scripts/docker/Dockerfile.ui
+++ b/scripts/docker/Dockerfile.ui
@@ -42,7 +42,7 @@ RUN make bootstrap static-dist \
 
 # Docker Image
 
-FROM alpine:3.10
+FROM alpine:3.13
 
 # Create a vault user and group first so the IDs get set the same way,
 # even as the rest of this may change over time.


### PR DESCRIPTION
Security update,

Alpine 3.10 will be out of scope for security updates at the end of the month.

