### PR TITLE
Backport 1.7.1: Extract replication state before go routine for initQueue (#11161)

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -62,7 +62,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	ictx, cancel := context.WithCancel(initCtx)
 	b.cancelQueue = cancel
 	// Load queue and kickoff new periodic ticker
-	go b.initQueue(ictx, conf)
+	go b.initQueue(ictx, conf, conf.System.ReplicationState())
 	return b, nil
 }
 

--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -408,12 +408,11 @@ func (b *databaseBackend) setStaticAccount(ctx context.Context, s logical.Storag
 // not wait for success or failure of it's tasks before continuing. This is to
 // avoid blocking the mount process while loading and evaluating existing roles,
 // etc.
-func (b *databaseBackend) initQueue(ctx context.Context, conf *logical.BackendConfig) {
+func (b *databaseBackend) initQueue(ctx context.Context, conf *logical.BackendConfig, replicationState consts.ReplicationState) {
 	// Verify this mount is on the primary server, or is a local mount. If not, do
 	// not create a queue or launch a ticker. Both processing the WAL list and
 	// populating the queue are done sequentially and before launching a
 	// go-routine to run the periodic ticker.
-	replicationState := conf.System.ReplicationState()
 	if (conf.System.LocalMount() || !replicationState.HasState(consts.ReplicationPerformanceSecondary)) &&
 		!replicationState.HasState(consts.ReplicationDRSecondary) &&
 		!replicationState.HasState(consts.ReplicationPerformanceStandby) {


### PR DESCRIPTION
Backport of #11161 to `release/1.7.x` branch

Querying the state before launching the go routine avoids a possible race condition with replication.