### PR TITLE
Add community-maintained OAuth 2.0/OIDC secrets plugin to plugin portal docs

### DIFF
--- a/website/content/docs/plugin-portal.mdx
+++ b/website/content/docs/plugin-portal.mdx
@@ -125,6 +125,7 @@ Plugin authors who wish to have their plugins listed may file a submission via a
 - [Ethereum](https://github.com/immutability-io/vault-ethereum)
 - [GitHub](https://github.com/martinbaillie/vault-plugin-secrets-github)
 - [HSM PKI Plugin](https://github.com/mode51software/vaultplugin-hsmpki)
+- [OAuth 2.0/OIDC](https://github.com/puppetlabs/vault-plugin-secrets-oauthapp)
 
 [github-issue]: https://github.com/hashicorp/vault/issues/new?assignees=&labels=ecosystem%2Fplugin&template=plugin-submission.md&title=%5BPlugin+Portal%5D+Plugin+Submission+-+%3CPLUGIN+NAME%3E
-[plugin-portal-mdx]: https://github.com/hashicorp/vault/blob/master/website/pages/docs/plugin-portal/index.mdx
+[plugin-portal-mdx]: https://github.com/hashicorp/vault/blob/master/website/content/docs/plugin-portal.mdx


### PR DESCRIPTION
This PR adds Puppet's OAuth 2.0/OIDC application secrets plugin to the documentation. It also fixes the URL to the plugin portal page content on GitHub.