### PR TITLE
Backport 1.6: Fix: leader_tls_servername raft option only worked when used with mTL…

### DIFF
--- a/vault/raft.go
+++ b/vault/raft.go
@@ -816,6 +816,12 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 				}
 				leaderInfo.TLSConfig.ServerName = leaderInfo.LeaderTLSServerName
 			}
+			if leaderInfo.TLSConfig == nil && leaderInfo.LeaderTLSServerName != "" {
+				leaderInfo.TLSConfig, err = tlsutil.SetupTLSConfig(map[string]string{"address": leaderInfo.LeaderTLSServerName}, "")
+				if err != nil {
+					return errwrap.Wrapf("failed to create TLS config: {{err}}", err)
+				}
+			}
 
 			if leaderInfo.TLSConfig != nil {
 				transport.TLSClientConfig = leaderInfo.TLSConfig.Clone()


### PR DESCRIPTION
…S and/or an explicit CA cert. (#11252)