### PR TITLE
Bug Fix: OIDC with hcp flag

### DIFF
--- a/changelog/11283.txt
+++ b/changelog/11283.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix footer URL linking to the correct version changelog.
+```

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -16,6 +16,7 @@ export { ERROR_WINDOW_CLOSED, ERROR_MISSING_PARAMS, ERROR_JWT_LOGIN };
 
 export default Component.extend({
   store: service(),
+  featureFlagService: service('featureFlag'),
   selectedAuthPath: null,
   selectedAuthType: null,
   roleName: null,
@@ -131,7 +132,7 @@ export default Component.extend({
     // The namespace can be either be passed as a query paramter, or be embedded
     // in the state param in the format `<state_id>,ns=<namespace>`. So if
     // `namespace` is empty, check for namespace in state as well.
-    if (namespace === '') {
+    if (namespace === '' || this.featureFlagService.managedNamespaceRoot) {
       let i = state.indexOf(',ns=');
       if (i >= 0) {
         // ",ns=" is 4 characters


### PR DESCRIPTION
There was an issue using OIDC when coming from a Vault HCP cluster.  This PR fixes that by adding a conditional using the feature-flag service.

Tested locally by flipping the flag.