### PR TITLE
Add ServerName to Vault Agent template config

### DIFF
--- a/changelog/11288.txt
+++ b/changelog/11288.txt
@@ -1,4 +1,3 @@
 ```release-note:bug
 agent: Fixed agent templating to use configured tls servername values
 ```
-

--- a/changelog/11288.txt
+++ b/changelog/11288.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+agent: Fixed agent templating to use configured tls servername values
+```
+

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -274,12 +274,13 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		skipVerify := sc.AgentConfig.Vault.TLSSkipVerify
 		verify := !skipVerify
 		conf.Vault.SSL = &ctconfig.SSLConfig{
-			Enabled: pointerutil.BoolPtr(true),
-			Verify:  &verify,
-			Cert:    &sc.AgentConfig.Vault.ClientCert,
-			Key:     &sc.AgentConfig.Vault.ClientKey,
-			CaCert:  &sc.AgentConfig.Vault.CACert,
-			CaPath:  &sc.AgentConfig.Vault.CAPath,
+			Enabled:    pointerutil.BoolPtr(true),
+			Verify:     &verify,
+			Cert:       &sc.AgentConfig.Vault.ClientCert,
+			Key:        &sc.AgentConfig.Vault.ClientKey,
+			CaCert:     &sc.AgentConfig.Vault.CACert,
+			CaPath:     &sc.AgentConfig.Vault.CAPath,
+			ServerName: &sc.AgentConfig.Vault.TLSServerName,
 		}
 	}
 	enabled := attempts > 0

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -13,7 +13,6 @@ import (
 
 	ctconfig "github.com/hashicorp/consul-template/config"
 	"github.com/hashicorp/go-hclog"
-
 	"github.com/hashicorp/vault/command/agent/config"
 	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -13,6 +13,7 @@ import (
 
 	ctconfig "github.com/hashicorp/consul-template/config"
 	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/vault/command/agent/config"
 	"github.com/hashicorp/vault/internalshared/configutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"


### PR DESCRIPTION
Reopening the closed #9401 here:

> When preparing the consul-template Vault config, the provided
> TLSServerName (in the Vault agent config as tls_server_name) was not
> being passed along to the consul-template Vault config.
> 
> Using the VAULT_TLS_SERVER_NAME environment variable was working since
> the consul-template config building does consider it.
> 
> To fix that, pass it along when setting up the consul-template
> config. Add a test which verifies basic TLS connectivity to Vault,
> including passing along the server name.
> 
> Fixes #9183