### PR TITLE
Move SanitizedConfig back to a shared-ent file.

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -2614,6 +2614,16 @@ func (c *Core) SetConfig(conf *server.Config) {
 	c.logger.Debug("set config", "sanitized config", string(bz))
 }
 
+// SanitizedConfig returns a sanitized version of the current config.
+// See server.Config.Sanitized for specific values omitted.
+func (c *Core) SanitizedConfig() map[string]interface{} {
+	conf := c.rawConfig.Load()
+	if conf == nil {
+		return nil
+	}
+	return conf.(*server.Config).Sanitized()
+}
+
 // LogFormat returns the log format current in use.
 func (c *Core) LogFormat() string {
 	conf := c.rawConfig.Load()

--- a/vault/core_util.go
+++ b/vault/core_util.go
@@ -66,16 +66,6 @@ func (c *Core) GetCoreConfigInternal() *server.Config {
 	return conf.(*server.Config)
 }
 
-// SanitizedConfig returns a sanitized version of the current config.
-// See server.Config.Sanitized for specific values omitted.
-func (c *Core) SanitizedConfig() map[string]interface{} {
-	conf := c.rawConfig.Load()
-	if conf == nil {
-		return nil
-	}
-	return conf.(*server.Config).Sanitized()
-}
-
 func (c *Core) teardownReplicationResolverHandler() {}
 func createSecondaries(*Core, *CoreConfig)          {}
 


### PR DESCRIPTION
https://github.com/hashicorp/vault/pull/11249 broke ent because it moved SanitizedConfig to an oss-only file (core_util.go on OSS == core_util_ent.go on ENT). Fix breakage.