### PR TITLE
Bug: DB secret engine not showing "Select one" in role select options

### DIFF
--- a/changelog/11294.txt
+++ b/changelog/11294.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix issue where select-one option was not showing in secrets database role creation
+```

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -22,6 +22,7 @@ export default Model.extend({
   }),
   type: attr('string', {
     label: 'Type of role',
+    noDefault: true,
     possibleValues: ['static', 'dynamic'],
   }),
   ttl: attr({


### PR DESCRIPTION
This [PR](https://github.com/hashicorp/vault/pull/11258/files) which addressed another issue, created a bug where because the "Select one" was not showing the Database Secret Engine when creating a role.

I checked the other Secret Engines to confirm this wasn't an issue anywhere else.

Here is the before (notice though it's selected Static, the below fields have not populated because it was by default and not selected which would trigger the fields changing).
![image](https://user-images.githubusercontent.com/6618863/114073198-42cdd480-9860-11eb-975b-3f109e1d2e64.png)

Here is the after (notice the fields below will change based on the selection, that was the key issue).
![image](https://user-images.githubusercontent.com/6618863/114073056-1d40cb00-9860-11eb-8710-b66db0faeac4.png)




