### PR TITLE
Changing from "changelog" to "release-note"

### DIFF
--- a/changelog/10812.txt
+++ b/changelog/10812.txt
@@ -1,3 +1,3 @@
-```changelog:bug
+```release-note:bug
 identity: When the identity/group endpoint is used to modify a group by name, correctly update its policy and member entities.
 ```

--- a/changelog/10826.txt
+++ b/changelog/10826.txt
@@ -1,3 +1,3 @@
-```changelog:changes
+```release-note:changes
 auth/approle: Secrets ID generation endpoint now returns `secret_id_ttl` as part of its response.
 ```

--- a/changelog/10997.txt
+++ b/changelog/10997.txt
@@ -1,4 +1,4 @@
-```changelog:change
+```release-note:change
 aws/auth: AWS Auth concepts and endpoints that use the "whitelist" and "blacklist" terms
 have been updated to more inclusive language (e.g. `/auth/aws/identity-whitelist` has been
 updated to`/auth/aws/identity-accesslist`). The legacy endpoint names have not been removed
@@ -7,7 +7,7 @@ the same underlying data. The complete list of endpoint changes is available in 
 [AWS Auth API docs](https://www.vaultproject.io/api-docs/auth/aws).
 ```
 
-```changelog:deprecation
+```release-note:deprecation
 aws/auth: AWS Auth endpoints that use the "whitelist" and "blacklist" terms have been deprecated.
 Refer to the CHANGES section for addition details.
 ```

--- a/changelog/11011.txt
+++ b/changelog/11011.txt
@@ -1,3 +1,3 @@
-```changelog:bug
+```release-note:bug
 ui: Fix KMIP failing test and a bug that ocurred because the configuration model was not being unloaded.
 ```

--- a/changelog/11015.txt
+++ b/changelog/11015.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-changelog: Add dependencies listed in dependencies/2-25-21
+release-note: Add dependencies listed in dependencies/2-25-21
 ```

--- a/changelog/11018.txt
+++ b/changelog/11018.txt
@@ -1,3 +1,3 @@
-```changelog:enhancement
+```release-note:enhancement
 ui: Add tests for database role setting form
 ```

--- a/changelog/11094.txt
+++ b/changelog/11094.txt
@@ -1,3 +1,3 @@
-```changelog:bug
+```release-note:bug
 ui: Fix issue where logging in without namespace input causes error
 ```

--- a/changelog/11113.txt
+++ b/changelog/11113.txt
@@ -1,3 +1,3 @@
-```changelog:enhancement
+```release-note:enhancement
 agent: Add a vault.retry stanza that allows specifying number of retries on failure; this applies both to templating and proxied requests.
 ```

--- a/changelog/11127.txt
+++ b/changelog/11127.txt
@@ -1,3 +1,3 @@
-```changelog:bug
+```release-note:bug
 ui: Fix bug where database secret engines with custom names cannot delete connections
 ```

--- a/changelog/11142.txt
+++ b/changelog/11142.txt
@@ -1,3 +1,3 @@
-```changelog:bug
+```release-note:bug
 ui: Fix date display on expired token notice
 ```

--- a/changelog/11226.txt
+++ b/changelog/11226.txt
@@ -1,3 +1,3 @@
-```changelog:enhancement
+```release-note:enhancement
 core: Add tls_max_version listener config option.
 ```

--- a/changelog/11259.txt
+++ b/changelog/11259.txt
@@ -1,3 +1,3 @@
-```changelog:enhancement
+```release-note:enhancement
 secret/pki: Preserve ordering of all DN attribute values when issuing certificates
 ```

--- a/changelog/_1712.txt
+++ b/changelog/_1712.txt
@@ -1,3 +1,3 @@
-```changelog:bug
+```release-note:bug
 quotas/lease-count (enterprise) : Fix quotas enforcing old lease count quota paths
 ```


### PR DESCRIPTION
Now that we know this is safe