### PR TITLE
Add support for unauthenticated pprof access on a per-listener basis,…

### DIFF
--- a/changelog/11324.txt
+++ b/changelog/11324.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+core: Add per-listener config to allow unauthenticated pprof requests.
+```

--- a/changelog/11324.txt
+++ b/changelog/11324.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-core: Add per-listener config to allow unauthenticated pprof requests.
+core: Add per-listener config to allow unauthenticated pprof requests, and collect a few more pprof targets.
 ```

--- a/command/debug.go
+++ b/command/debug.go
@@ -748,6 +748,8 @@ func (c *DebugCommand) collectPprof(ctx context.Context) {
 			}(target)
 		}
 
+		// As a convenience, we'll also fetch the goroutine target using debug=2, which yields a text
+		// version of the stack traces that don't require using `go tool pprof` to view.
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/command/debug.go
+++ b/command/debug.go
@@ -985,6 +985,7 @@ func (c *DebugCommand) captureError(target string, err error) {
 
 func (c *DebugCommand) writeLogs(ctx context.Context) {
 	out, err := os.Create(filepath.Join(c.flagOutput, "vault.log"))
+	defer out.Close()
 	if err != nil {
 		c.captureError("log", err)
 		return

--- a/command/debug.go
+++ b/command/debug.go
@@ -674,15 +674,11 @@ func (c *DebugCommand) collectMetrics(ctx context.Context) {
 		}
 
 		// Check replication status. We skip on processing metrics if we're one
-		// of the following (since the request will be forwarded):
-		// 1. Any type of DR Node
-		// 2. Non-DR, non-performance standby nodes
+		// a DR node, though non-perf standbys will fail if they aren't using
+		// unauthenticated_metrics_access.
 		switch {
 		case healthStatus.ReplicationDRMode == "secondary":
 			c.logger.Info("skipping metrics capture on DR secondary node")
-			continue
-		case healthStatus.Standby && !healthStatus.PerformanceStandby:
-			c.logger.Info("skipping metrics on standby node")
 			continue
 		}
 

--- a/command/debug.go
+++ b/command/debug.go
@@ -985,11 +985,11 @@ func (c *DebugCommand) captureError(target string, err error) {
 
 func (c *DebugCommand) writeLogs(ctx context.Context) {
 	out, err := os.Create(filepath.Join(c.flagOutput, "vault.log"))
-	defer out.Close()
 	if err != nil {
 		c.captureError("log", err)
 		return
 	}
+	defer out.Close()
 
 	logCh, err := c.cachedClient.Sys().Monitor(ctx, "trace")
 	if err != nil {

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -711,6 +711,12 @@ listener "tcp" {
 	tls_max_version = "tls13"
 	tls_require_and_verify_client_cert = true
 	tls_disable_client_certs = true
+    telemetry {
+      unauthenticated_metrics_access = true
+    }
+    profiling {
+      unauthenticated_pprof_access = true
+    }
 }`))
 
 	config := Config{
@@ -742,6 +748,12 @@ listener "tcp" {
 					TLSMaxVersion:                 "tls13",
 					TLSRequireAndVerifyClientCert: true,
 					TLSDisableClientCerts:         true,
+					Telemetry: configutil.ListenerTelemetry{
+						UnauthenticatedMetricsAccess: true,
+					},
+					Profiling: configutil.ListenerProfiling{
+						UnauthenticatedPProfAccess: true,
+					},
 				},
 			},
 		},

--- a/http/handler.go
+++ b/http/handler.go
@@ -11,6 +11,7 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"net/textproto"
 	"net/url"
 	"os"
@@ -177,7 +178,13 @@ func Handler(props *vault.HandlerProperties) http.Handler {
 		}
 
 		if props.ListenerConfig != nil && props.ListenerConfig.Profiling.UnauthenticatedPProfAccess {
-			mux.Handle("/v1/sys/pprof/", handleUnauthenticated(core))
+			for _, name := range []string{"goroutine", "threadcreate", "heap", "allocs", "block", "mutex"} {
+				mux.Handle("/v1/sys/pprof/"+name, pprof.Handler(name))
+			}
+			mux.Handle("/v1/sys/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+			mux.Handle("/v1/sys/pprof/profile", http.HandlerFunc(pprof.Profile))
+			mux.Handle("/v1/sys/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+			mux.Handle("/v1/sys/pprof/trace", http.HandlerFunc(pprof.Trace))
 		} else {
 			mux.Handle("/v1/sys/pprof/", handleLogicalNoForward(core))
 		}

--- a/http/handler.go
+++ b/http/handler.go
@@ -130,7 +130,6 @@ func Handler(props *vault.HandlerProperties) http.Handler {
 		// Handle non-forwarded paths
 		mux.Handle("/v1/sys/config/state/", handleLogicalNoForward(core))
 		mux.Handle("/v1/sys/host-info", handleLogicalNoForward(core))
-		mux.Handle("/v1/sys/pprof/", handleLogicalNoForward(core))
 
 		mux.Handle("/v1/sys/init", handleSysInit(core))
 		mux.Handle("/v1/sys/seal-status", handleSysSealStatus(core))
@@ -175,6 +174,12 @@ func Handler(props *vault.HandlerProperties) http.Handler {
 			mux.Handle("/v1/sys/metrics", handleMetricsUnauthenticated(core))
 		} else {
 			mux.Handle("/v1/sys/metrics", handleLogicalNoForward(core))
+		}
+
+		if props.ListenerConfig != nil && props.ListenerConfig.Profiling.UnauthenticatedPProfAccess {
+			mux.Handle("/v1/sys/pprof/", handleUnauthenticated(core))
+		} else {
+			mux.Handle("/v1/sys/pprof/", handleLogicalNoForward(core))
 		}
 
 		additionalRoutes(mux, core)

--- a/http/handler.go
+++ b/http/handler.go
@@ -181,6 +181,7 @@ func Handler(props *vault.HandlerProperties) http.Handler {
 			for _, name := range []string{"goroutine", "threadcreate", "heap", "allocs", "block", "mutex"} {
 				mux.Handle("/v1/sys/pprof/"+name, pprof.Handler(name))
 			}
+			mux.Handle("/v1/sys/pprof/", http.HandlerFunc(pprof.Index))
 			mux.Handle("/v1/sys/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
 			mux.Handle("/v1/sys/pprof/profile", http.HandlerFunc(pprof.Profile))
 			mux.Handle("/v1/sys/pprof/symbol", http.HandlerFunc(pprof.Symbol))

--- a/http/sys_metrics.go
+++ b/http/sys_metrics.go
@@ -66,6 +66,6 @@ func handleUnauthenticated(core *vault.Core) http.Handler {
 		}
 
 		resp, err := core.HandleRequest(r.Context(), req)
-		respondLogical(w, r, req, resp, true)
+		respondLogical(core, w, r, req, resp, true)
 	})
 }

--- a/http/sys_metrics.go
+++ b/http/sys_metrics.go
@@ -1,14 +1,11 @@
 package http
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"io/ioutil"
+	"github.com/hashicorp/vault/sdk/logical"
 	"net/http"
 
 	"github.com/hashicorp/vault/helper/metricsutil"
-	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
 
@@ -48,24 +45,5 @@ func handleMetricsUnauthenticated(core *vault.Core) http.Handler {
 		default:
 			respondError(w, http.StatusInternalServerError, fmt.Errorf("wrong response returned"))
 		}
-	})
-}
-
-func handleUnauthenticated(core *vault.Core) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		origBody := new(bytes.Buffer)
-		reader := ioutil.NopCloser(io.TeeReader(r.Body, origBody))
-		r.Body = reader
-		req, _, status, err := buildLogicalRequestNoAuth(core.PerfStandby(), w, r)
-		if err != nil || status != 0 {
-			respondError(w, status, err)
-			return
-		}
-		if origBody != nil {
-			r.Body = ioutil.NopCloser(origBody)
-		}
-
-		resp, err := core.HandleRequest(r.Context(), req)
-		respondLogical(core, w, r, req, resp, true)
 	})
 }

--- a/http/sys_metrics.go
+++ b/http/sys_metrics.go
@@ -2,10 +2,10 @@ package http
 
 import (
 	"fmt"
-	"github.com/hashicorp/vault/sdk/logical"
 	"net/http"
 
 	"github.com/hashicorp/vault/helper/metricsutil"
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
 )
 

--- a/http/sys_metrics_test.go
+++ b/http/sys_metrics_test.go
@@ -64,9 +64,9 @@ func TestSysPProfUnauthenticated(t *testing.T) {
 	TestServerAuth(t, addr, token)
 
 	// Default: Only authenticated access
-	resp := testHttpGet(t, "", addr+"/v1/sys/pprof")
+	resp := testHttpGet(t, "", addr+"/v1/sys/pprof/cmdline")
 	testResponseStatus(t, resp, 400)
-	resp = testHttpGet(t, token, addr+"/v1/sys/pprof")
+	resp = testHttpGet(t, token, addr+"/v1/sys/pprof/cmdline")
 	testResponseStatus(t, resp, 200)
 
 	// Close listener
@@ -87,10 +87,10 @@ func TestSysPProfUnauthenticated(t *testing.T) {
 	TestServerAuth(t, addr, token)
 
 	// Test without token
-	resp = testHttpGet(t, "", addr+"/v1/sys/pprof")
+	resp = testHttpGet(t, "", addr+"/v1/sys/pprof/cmdline")
 	testResponseStatus(t, resp, 200)
 
 	// Should also work with token
-	resp = testHttpGet(t, token, addr+"/v1/sys/pprof")
+	resp = testHttpGet(t, token, addr+"/v1/sys/pprof/cmdline")
 	testResponseStatus(t, resp, 200)
 }

--- a/http/sys_metrics_test.go
+++ b/http/sys_metrics_test.go
@@ -56,3 +56,41 @@ func TestSysMetricsUnauthenticated(t *testing.T) {
 	resp = testHttpGet(t, "", addr+"/v1/sys/metrics?format=prometheus")
 	testResponseStatus(t, resp, 200)
 }
+
+func TestSysPProfUnauthenticated(t *testing.T) {
+	conf := &vault.CoreConfig{}
+	core, _, token := vault.TestCoreUnsealedWithConfig(t, conf)
+	ln, addr := TestServer(t, core)
+	TestServerAuth(t, addr, token)
+
+	// Default: Only authenticated access
+	resp := testHttpGet(t, "", addr+"/v1/sys/pprof")
+	testResponseStatus(t, resp, 400)
+	resp = testHttpGet(t, token, addr+"/v1/sys/pprof")
+	testResponseStatus(t, resp, 200)
+
+	// Close listener
+	ln.Close()
+
+	// Setup new custom listener with unauthenticated metrics access
+	ln, addr = TestListener(t)
+	props := &vault.HandlerProperties{
+		Core: core,
+		ListenerConfig: &configutil.Listener{
+			Profiling: configutil.ListenerProfiling{
+				UnauthenticatedPProfAccess: true,
+			},
+		},
+	}
+	TestServerWithListenerAndProperties(t, ln, addr, core, props)
+	defer ln.Close()
+	TestServerAuth(t, addr, token)
+
+	// Test without token
+	resp = testHttpGet(t, "", addr+"/v1/sys/pprof")
+	testResponseStatus(t, resp, 200)
+
+	// Should also work with token
+	resp = testHttpGet(t, token, addr+"/v1/sys/pprof")
+	testResponseStatus(t, resp, 200)
+}

--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -21,6 +21,11 @@ type ListenerTelemetry struct {
 	UnauthenticatedMetricsAccessRaw interface{} `hcl:"unauthenticated_metrics_access"`
 }
 
+type ListenerProfiling struct {
+	UnauthenticatedPProfAccess    bool        `hcl:"-"`
+	UnauthenticatedPProfAccessRaw interface{} `hcl:"unauthenticated_pprof_access"`
+}
+
 // Listener is the listener configuration for the server.
 type Listener struct {
 	RawConfig map[string]interface{}
@@ -81,6 +86,7 @@ type Listener struct {
 	SocketGroup string `hcl:"socket_group"`
 
 	Telemetry ListenerTelemetry `hcl:"telemetry"`
+	Profiling ListenerProfiling `hcl:"profiling"`
 
 	// RandomPort is used only for some testing purposes
 	RandomPort bool `hcl:"-"`
@@ -312,6 +318,17 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 				}
 
 				l.Telemetry.UnauthenticatedMetricsAccessRaw = nil
+			}
+		}
+
+		// Profiling
+		{
+			if l.Profiling.UnauthenticatedPProfAccessRaw != nil {
+				if l.Profiling.UnauthenticatedPProfAccess, err = parseutil.ParseBool(l.Profiling.UnauthenticatedPProfAccessRaw); err != nil {
+					return multierror.Prefix(fmt.Errorf("invalid value for profiling.unauthenticated_pprof_access: %w", err), fmt.Sprintf("listeners.%d", i))
+				}
+
+				l.Profiling.UnauthenticatedPProfAccessRaw = nil
 			}
 		}
 

--- a/vault/logical_system_pprof.go
+++ b/vault/logical_system_pprof.go
@@ -60,6 +60,94 @@ render pages.`,
 			},
 		},
 		{
+			Pattern: "pprof/allocs",
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.handlePprofAllocs,
+					Summary:     "Returns a sampling of all past memory allocations.",
+					Description: "Returns a sampling of all past memory allocations.",
+				},
+			},
+		},
+		{
+			Pattern: "pprof/threadcreate",
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.handlePprofThreadcreate,
+					Summary:     "Returns stack traces that led to the creation of new OS threads",
+					Description: "Returns stack traces that led to the creation of new OS threads",
+				},
+			},
+		},
+		{
+			Pattern: "pprof/block",
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.handlePprofBlock,
+					Summary:     "Returns stack traces that led to blocking on synchronization primitives",
+					Description: "Returns stack traces that led to blocking on synchronization primitives",
+				},
+			},
+		},
+		{
+			Pattern: "pprof/mutex",
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.handlePprofMutex,
+					Summary:     "Returns stack traces of holders of contended mutexes",
+					Description: "Returns stack traces of holders of contended mutexes",
+				},
+			},
+		},
+		{
+			Pattern: "pprof/allocs",
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.handlePprofAllocs,
+					Summary:     "Returns a sampling of all past memory allocations.",
+					Description: "Returns a sampling of all past memory allocations.",
+				},
+			},
+		},
+		{
+			Pattern: "pprof/threadcreate",
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.handlePprofThreadcreate,
+					Summary:     "Returns stack traces that led to the creation of new OS threads",
+					Description: "Returns stack traces that led to the creation of new OS threads",
+				},
+			},
+		},
+		{
+			Pattern: "pprof/block",
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.handlePprofBlock,
+					Summary:     "Returns stack traces that led to blocking on synchronization primitives",
+					Description: "Returns stack traces that led to blocking on synchronization primitives",
+				},
+			},
+		},
+		{
+			Pattern: "pprof/mutex",
+
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback:    b.handlePprofMutex,
+					Summary:     "Returns stack traces of holders of contended mutexes",
+					Description: "Returns stack traces of holders of contended mutexes",
+				},
+			},
+		},
+		{
 			Pattern: "pprof/profile",
 
 			Fields: map[string]*framework.FieldSchema{
@@ -143,6 +231,42 @@ func (b *SystemBackend) handlePprofHeap(ctx context.Context, req *logical.Reques
 	}
 
 	pprof.Handler("heap").ServeHTTP(req.ResponseWriter, req.HTTPRequest)
+	return nil, nil
+}
+
+func (b *SystemBackend) handlePprofAllocs(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if err := checkRequestHandlerParams(req); err != nil {
+		return nil, err
+	}
+
+	pprof.Handler("allocs").ServeHTTP(req.ResponseWriter, req.HTTPRequest)
+	return nil, nil
+}
+
+func (b *SystemBackend) handlePprofThreadcreate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if err := checkRequestHandlerParams(req); err != nil {
+		return nil, err
+	}
+
+	pprof.Handler("threadcreate").ServeHTTP(req.ResponseWriter, req.HTTPRequest)
+	return nil, nil
+}
+
+func (b *SystemBackend) handlePprofBlock(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if err := checkRequestHandlerParams(req); err != nil {
+		return nil, err
+	}
+
+	pprof.Handler("block").ServeHTTP(req.ResponseWriter, req.HTTPRequest)
+	return nil, nil
+}
+
+func (b *SystemBackend) handlePprofMutex(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	if err := checkRequestHandlerParams(req); err != nil {
+		return nil, err
+	}
+
+	pprof.Handler("mutex").ServeHTTP(req.ResponseWriter, req.HTTPRequest)
 	return nil, nil
 }
 

--- a/vault/logical_system_pprof.go
+++ b/vault/logical_system_pprof.go
@@ -104,50 +104,6 @@ render pages.`,
 			},
 		},
 		{
-			Pattern: "pprof/allocs",
-
-			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.ReadOperation: &framework.PathOperation{
-					Callback:    b.handlePprofAllocs,
-					Summary:     "Returns a sampling of all past memory allocations.",
-					Description: "Returns a sampling of all past memory allocations.",
-				},
-			},
-		},
-		{
-			Pattern: "pprof/threadcreate",
-
-			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.ReadOperation: &framework.PathOperation{
-					Callback:    b.handlePprofThreadcreate,
-					Summary:     "Returns stack traces that led to the creation of new OS threads",
-					Description: "Returns stack traces that led to the creation of new OS threads",
-				},
-			},
-		},
-		{
-			Pattern: "pprof/block",
-
-			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.ReadOperation: &framework.PathOperation{
-					Callback:    b.handlePprofBlock,
-					Summary:     "Returns stack traces that led to blocking on synchronization primitives",
-					Description: "Returns stack traces that led to blocking on synchronization primitives",
-				},
-			},
-		},
-		{
-			Pattern: "pprof/mutex",
-
-			Operations: map[logical.Operation]framework.OperationHandler{
-				logical.ReadOperation: &framework.PathOperation{
-					Callback:    b.handlePprofMutex,
-					Summary:     "Returns stack traces of holders of contended mutexes",
-					Description: "Returns stack traces of holders of contended mutexes",
-				},
-			},
-		},
-		{
 			Pattern: "pprof/profile",
 
 			Fields: map[string]*framework.FieldSchema{


### PR DESCRIPTION
… as we do for metrics.  Note that since this change doesn't affect the endpoint `sys/config/state/sanitized`, by default `vault debug` will fail with an error when no token is provided, even with the new option enabled.  However, using e.g. `-target=pprof` will work around that.