### PR TITLE
Backport 1.7.x: Bug: DB secret engine not showing "Select one" in role select option

### DIFF
--- a/changelog/11294.txt
+++ b/changelog/11294.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix issue where select-one option was not showing in secrets database role creation
+```

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -22,6 +22,7 @@ export default Model.extend({
   }),
   type: attr('string', {
     label: 'Type of role',
+    noDefault: true,
     possibleValues: ['static', 'dynamic'],
   }),
   ttl: attr({


### PR DESCRIPTION
See original PR [here](https://github.com/hashicorp/vault/pull/11294)