### PR TITLE
Fix broken OIDC Providers link

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1053,7 +1053,16 @@
       },
       {
         "title": "JWT/OIDC",
-        "path": "auth/jwt"
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "auth/jwt"
+          },
+          {
+            "title": "OIDC Providers",
+            "path": "auth/jwt_oidc_providers"
+          }
+        ]
       },
       {
         "title": "Kerberos",


### PR DESCRIPTION
Recent website framework changes don't render pages that aren't linked
from the sidebar. The OIDC Providers page has been (for now at least) added to the
sidebar to fix the issue.

Preview: https://vault-hxwqhagyy-hashicorp.vercel.app/docs/auth/jwt