### PR TITLE
Fixes for db connection file type fields

### DIFF
--- a/ui/app/models/database/connection.js
+++ b/ui/app/models/database/connection.js
@@ -72,12 +72,14 @@ export default Model.extend({
   max_connection_lifetime: attr('string'),
   tls: attr('string', {
     label: 'TLS Certificate Key',
-    subText: 'x509 certificate for connecting to the database.',
+    helpText:
+      'x509 certificate for connecting to the database. This must be a PEM encoded version of the private key and the certificate combined.',
     editType: 'file',
   }),
   tls_ca: attr('string', {
     label: 'TLS CA',
-    subText: 'x509 CA file for validating the certificate presented by the MongoDB server.',
+    helpText:
+      'x509 CA file for validating the certificate presented by the MongoDB server. Must be PEM encoded.',
     editType: 'file',
   }),
   root_rotation_statements: attr({

--- a/ui/app/styles/components/form-section.scss
+++ b/ui/app/styles/components/form-section.scss
@@ -1,5 +1,5 @@
 .form-section {
-  padding-top: 1.75rem;
+  padding: 1.75rem 0;
   box-shadow: 0 -1px 0 0 rgba($black, 0.1);
 }
 

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -111,7 +111,8 @@
 {{!-- File Input --}}
   {{text-file
     index=""
-    helpText=attr.options.helpText
+    fileHelpText=attr.options.helpText
+    textareaHelpText=attr.options.helpText
     file=file
     onChange=(action "setFile")
     warning=attr.options.warning


### PR DESCRIPTION
1. Fixed helper text for file type form fields

<img width="1792" alt="Screen Shot 2021-04-09 at 10 58 28 AM" src="https://user-images.githubusercontent.com/2932708/114224161-935b3580-9925-11eb-8425-388b222cbcfc.png">

2. Added padding to bottom form section

<img width="1792" alt="Screen Shot 2021-04-09 at 10 58 17 AM" src="https://user-images.githubusercontent.com/2932708/114224207-a3731500-9925-11eb-877c-792f7c92b66a.png">
