### PR TITLE
Add documentation for vault-csi-provider namespace config

### DIFF
--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -12,6 +12,8 @@ The following parameters are supported by the Vault provider:
 
 - `vaultAddress` `(string: "")` - The address of the Vault server.
 
+- `vaultNamespace` `(string: "")` - The Vault [namespace](/docs/enterprise/namespaces) to use.
+
 - `vaultSkipTLSVerify` `(string: "false")` - When set to true, skips verification of the Vault server
   certificiate. Setting this to true is not recommended for production.
 


### PR DESCRIPTION
Adds website documentation for namespace support added in https://github.com/hashicorp/vault-csi-provider/pull/84.