### PR TITLE
feat(aws): add ability to provide a role session name when generating STS credentials

### DIFF
--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -33,6 +33,10 @@ func pathUser(b *backend) *framework.Path {
 				Description: "Lifetime of the returned credentials in seconds",
 				Default:     3600,
 			},
+			"role_session_name": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Session name to use when assuming role. Max chars: 64",
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -81,6 +85,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 	}
 
 	roleArn := d.Get("role_arn").(string)
+	roleSessionName := d.Get("role_session_name").(string)
 
 	var credentialType string
 	switch {
@@ -126,7 +131,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		case !strutil.StrListContains(role.RoleArns, roleArn):
 			return logical.ErrorResponse(fmt.Sprintf("role_arn %q not in allowed role arns for Vault role %q", roleArn, roleName)), nil
 		}
-		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl)
+		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl, roleSessionName)
 	case federationTokenCred:
 		return b.getFederationToken(ctx, req.Storage, req.DisplayName, roleName, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl)
 	default:

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -172,7 +172,7 @@ func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 		roleSessionName = normalizeDisplayName(roleSessionName)
 		if len(roleSessionName) > 64 {
 			roleSessionName = roleSessionName[0:64]
-			roleSessionNameWarning = "the role session name were truncated to 64 chars fit into IAM session name length limits"
+			roleSessionNameWarning = "the role session name was truncated to 64 characters to fit within IAM session name length limits"
 		}
 	}
 

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -141,7 +141,7 @@ func (b *backend) getFederationToken(ctx context.Context, s logical.Storage,
 
 func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 	displayName, roleName, roleArn, policy string, policyARNs []string,
-	iamGroups []string, lifeTimeInSeconds int64) (*logical.Response, error) {
+	iamGroups []string, lifeTimeInSeconds int64, roleSessionName string) (*logical.Response, error) {
 
 	// grab any IAM group policies associated with the vault role, both inline
 	// and managed
@@ -165,10 +165,19 @@ func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
-	username, usernameWarning := genUsername(displayName, roleName, "iam_user")
+	roleSessionNameWarning := ""
+	if roleSessionName == "" {
+		roleSessionName, roleSessionNameWarning = genUsername(displayName, roleName, "iam_user")
+	} else {
+		roleSessionName = normalizeDisplayName(roleSessionName)
+		if len(roleSessionName) > 64 {
+			roleSessionName = roleSessionName[0:64]
+			roleSessionNameWarning = "the role session name were truncated to 64 chars fit into IAM session name length limits"
+		}
+	}
 
 	assumeRoleInput := &sts.AssumeRoleInput{
-		RoleSessionName: aws.String(username),
+		RoleSessionName: aws.String(roleSessionName),
 		RoleArn:         aws.String(roleArn),
 		DurationSeconds: &lifeTimeInSeconds,
 	}
@@ -187,8 +196,9 @@ func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 		"access_key":     *tokenResp.Credentials.AccessKeyId,
 		"secret_key":     *tokenResp.Credentials.SecretAccessKey,
 		"security_token": *tokenResp.Credentials.SessionToken,
+		"arn":            *tokenResp.AssumedRoleUser.Arn,
 	}, map[string]interface{}{
-		"username": username,
+		"username": roleSessionName,
 		"policy":   roleArn,
 		"is_sts":   true,
 	})
@@ -199,8 +209,8 @@ func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 	// STS are purposefully short-lived and aren't renewable
 	resp.Secret.Renewable = false
 
-	if usernameWarning != "" {
-		resp.AddWarning(usernameWarning)
+	if roleSessionNameWarning != "" {
+		resp.AddWarning(roleSessionNameWarning)
 	}
 
 	return resp, nil

--- a/changelog/11345.txt
+++ b/changelog/11345.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-feat(aws): add ability to provide a role session name when generating STS credentials
+secrets/aws: add ability to provide a role session name when generating STS credentials
 ```

--- a/changelog/11345.txt
+++ b/changelog/11345.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+feat(aws): add ability to provide a role session name when generating STS credentials
+```

--- a/changelog/11345.txt
+++ b/changelog/11345.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:improvement
 feat(aws): add ability to provide a role session name when generating STS credentials
 ```

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -523,6 +523,10 @@ credentials retrieved through `/aws/creds` must be of the `iam_user` type.
   the Vault role is `assumed_role`. Must match one of the allowed role ARNs in
   the Vault role. Optional if the Vault role only allows a single AWS role ARN;
   required otherwise.
+- `role_session_name` `(string)` - The role session name to attach to the assumed role ARN.
+   `role_session_name` is limited to 64 characters; if exceeded, the `role_session_name` in the
+   assumed role ARN will be truncated to 64 characters. If `role_session_name` is not provided,
+   then it will be generated dynamically by default.
 - `ttl` `(string: "3600s")` – Specifies the TTL for the use of the STS token.
   This is specified as a string with a duration suffix. Valid only when
   `credential_type` is `assumed_role` or `federation_token`. When not specified,
@@ -550,7 +554,8 @@ $ curl \
   "data": {
     "access_key": "AKIA...",
     "secret_key": "xlCs...",
-    "security_token": null
+    "security_token": null,
+    "arn": "arn:aws:sts::<AWS_ACCOUNT_ID>:assumed-role/<ASSUMED_ROLE_NAME>/<ROLE_SESSION_NAME>"
   }
 }
 ```

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -555,7 +555,7 @@ $ curl \
     "access_key": "AKIA...",
     "secret_key": "xlCs...",
     "security_token": null,
-    "arn": "arn:aws:sts::<AWS_ACCOUNT_ID>:assumed-role/<ASSUMED_ROLE_NAME>/<ROLE_SESSION_NAME>"
+    "arn": "arn:aws:sts::123456789012:assumed-role/DeveloperRole/some-user-supplied-role-session-name"
   }
 }
 ```


### PR DESCRIPTION
We have a need for an IAM session ARN to register an AWS CodeDeploy on-premises instance, more info [here](https://docs.aws.amazon.com/codedeploy/latest/userguide/register-on-premises-instance-iam-session-arn.html); the problem comes with renewing the temporary credentials. In Vault, the IAM session ARN associated with newly generated credentials (using [this endpoint](https://www.vaultproject.io/api/secret/aws#generate-credentials)) is dynamically built with the current time and a random int. Because of this, renewing temporary credentials using the same IAM session ARN would be impossible, as the ARN would be changed when Vault generates new credentials.

The proposed solution comes in two parts. The first is to add a new parameter called `role_session_name` when generating new credentials. With this, users can pass in a role session name and expect an ARN with a static role session name every time new STS credentials are read from Vault. If `role_session_name` isn't provided, then the previous behavior of dynamically creating a session name is followed.

The second part of this solution is to return the IAM session ARN generated when Vault assumed the role. In the return payload, the IAM session ARN will be in the `arn` field. This provides transparency on which IAM user/role the returned credentials are associated with.