### PR TITLE
Add TFE/TFC auth plugin to plugin portal

### DIFF
--- a/website/content/docs/plugin-portal.mdx
+++ b/website/content/docs/plugin-portal.mdx
@@ -118,7 +118,7 @@ Plugin authors who wish to have their plugins listed may file a submission via a
 ### Auth
 
 - [Jenkins](https://plugins.jenkins.io/hashicorp-vault-plugin)
-- [TFE/TFC](https://github.com/gitrgoliveira/vault-plugin-auth-tfe)
+- [Terraform Enterprise/Terraform Cloud](https://github.com/gitrgoliveira/vault-plugin-auth-tfe)
 
 ### Secrets
 

--- a/website/content/docs/plugin-portal.mdx
+++ b/website/content/docs/plugin-portal.mdx
@@ -118,6 +118,7 @@ Plugin authors who wish to have their plugins listed may file a submission via a
 ### Auth
 
 - [Jenkins](https://plugins.jenkins.io/hashicorp-vault-plugin)
+- [TFE/TFC](https://github.com/gitrgoliveira/vault-plugin-auth-tfe)
 
 ### Secrets
 


### PR DESCRIPTION
As requested in #11202, this is an auth plugin designed to be run within TFE/TFC.