### PR TITLE
Remove hard-coded version string.  

### DIFF
--- a/sdk/version/version_base.go
+++ b/sdk/version/version_base.go
@@ -8,7 +8,7 @@ var (
 	// Whether cgo is enabled or not; set at build time
 	CgoEnabled bool
 
-	Version           = "1.7.0"
+	Version           = ""
 	VersionPrerelease = ""
 	VersionMetadata   = ""
 )

--- a/vendor/github.com/hashicorp/vault/sdk/version/version_base.go
+++ b/vendor/github.com/hashicorp/vault/sdk/version/version_base.go
@@ -8,7 +8,7 @@ var (
 	// Whether cgo is enabled or not; set at build time
 	CgoEnabled bool
 
-	Version           = "1.7.0"
+	Version           = ""
 	VersionPrerelease = ""
 	VersionMetadata   = ""
 )


### PR DESCRIPTION
We'll rely solely on ldflags set by packagespec.  Doing this on 1.7 to start with so that I can prove the concept before applying it more widely.