### PR TITLE
patch(docs): fix link color

### DIFF
--- a/website/pages/style.css
+++ b/website/pages/style.css
@@ -96,3 +96,8 @@
   background: var(--gray-1);
   color: white;
 }
+
+/** DEBT: short term patch until the branding changes roll out. Remove this with this PR — https://github.com/hashicorp/vault/pull/11118 **/
+.g-content {
+  --brand-text: var(--vagrant) !important;
+}


### PR DESCRIPTION
The `brand-text` value is currently a dark grey, which makes links blend in with the black text on docs pages. This provides a temporary patch until the [new branding color values](https://github.com/hashicorp/vault/pull/11118) are released.