### PR TITLE
docs: update vault-helm to 0.11.0

### DIFF
--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -229,7 +229,7 @@ and consider if they're appropriate for your deployment.
   - `updateStrategyType` (`string: "OnDelete"`) - Configure the [Update Strategy Type](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) for the StatefulSet.
 
   - `logLevel` (`string: ""`) - Configures the Vault server logging verbosity. If set this will override values defined in the Vault configuration file. 
-    Supported log levels include: `trace, debug, info, warn, error`.
+    Supported log levels include: `trace`, `debug`, `info`, `warn`, `error`.
 
     - `logFormat` (`string: ""`) - Configures the Vault server logging format. If set this will override values defined in the Vault configuration file. 
     Supported log formats include: `standard, json`.

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -231,7 +231,7 @@ and consider if they're appropriate for your deployment.
   - `logLevel` (`string: ""`) - Configures the Vault server logging verbosity. If set this will override values defined in the Vault configuration file. 
     Supported log levels include: `trace`, `debug`, `info`, `warn`, `error`.
 
-    - `logFormat` (`string: ""`) - Configures the Vault server logging format. If set this will override values defined in the Vault configuration file. 
+  - `logFormat` (`string: ""`) - Configures the Vault server logging format. If set this will override values defined in the Vault configuration file. 
     Supported log formats include: `standard`, `json`.
 
   - `resources` (`dictionary: {}`) - The resource requests and limits (CPU, memory, etc.) for each container of the server. This should be a YAML dictionary of a Kubernetes [ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcerequirements-v1-core) object. If this isn't specified, then the pods won't request any specific amount of resources, which limits the ability for Kubernetes to make efficient use of compute resources. **Setting this is highly recommended.**

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -232,7 +232,7 @@ and consider if they're appropriate for your deployment.
     Supported log levels include: `trace`, `debug`, `info`, `warn`, `error`.
 
     - `logFormat` (`string: ""`) - Configures the Vault server logging format. If set this will override values defined in the Vault configuration file. 
-    Supported log formats include: `standard, json`.
+    Supported log formats include: `standard`, `json`.
 
   - `resources` (`dictionary: {}`) - The resource requests and limits (CPU, memory, etc.) for each container of the server. This should be a YAML dictionary of a Kubernetes [ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcerequirements-v1-core) object. If this isn't specified, then the pods won't request any specific amount of resources, which limits the ability for Kubernetes to make efficient use of compute resources. **Setting this is highly recommended.**
 

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -73,7 +73,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault-k8s"`) - The name of the Docker image for Vault Agent Injector.
 
-    - `tag` (`string: "0.9.0"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "0.10.0"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -82,6 +82,19 @@ and consider if they're appropriate for your deployment.
     - `repository` (`string: "vault"`) - The name of the Docker image for the Vault Agent sidecar. This should be set to the official Vault Docker image.
 
     - `tag` (`string: "1.7.0"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
+
+- `agentDefaults` - Values that configure the injected Vault Agent containers default values.
+
+    - `cpuLimit` (`string: "500m"`) - The default CPU limit for injected Vault Agent containers.
+    
+    - `cpuRequest` (`string: "250m"`) - The default CPU request for injected Vault Agent containers.
+
+    - `memLimit` (`string: "128Mi"`) - The default memory limit for injected Vault Agent containers.
+    
+    - `memRequest` (`string: "64Mi"`) - The default memory request for injected Vault Agent containers.
+
+    - `template` (`string: "map"`) - The default template type for rendered secrets if no custom templates are defined.
+      Possible values include `map` and `json`.
 
   - `metrics` - Values that configure the Vault Agent Injector metric exporter.
 
@@ -196,8 +209,14 @@ and consider if they're appropriate for your deployment.
         "sample/annotation1": "foo"
         "sample/annotation2": "bar"
       ```
+  - `hostNetwork` (`boolean: false`) - When set to true, configures the Vault Agent Injector to run on the host network. This is useful 
+    when alternative cluster networking is used.
+
+  - `port` (`int: 8080`) - Configures the port the Vault Agent Injector listens on.
 
 - `server` - Values that configure running a Vault server within Kubernetes.
+
+  - `enabled` (`boolean: true`) - When set to `true`, the Vault server will be created.
 
   - `image` - Values that configure the Vault Docker image.
 
@@ -207,9 +226,15 @@ and consider if they're appropriate for your deployment.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
-    - `updateStrategyType` (`string: "OnDelete"`) - Configure the [Update Strategy Type](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) for the StatefulSet.
+  - `updateStrategyType` (`string: "OnDelete"`) - Configure the [Update Strategy Type](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) for the StatefulSet.
 
-    - `resources` (`dictionary: {}`) - The resource requests and limits (CPU, memory, etc.) for each container of the server. This should be a YAML dictionary of a Kubernetes [ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcerequirements-v1-core) object. If this isn't specified, then the pods won't request any specific amount of resources, which limits the ability for Kubernetes to make efficient use of compute resources. **Setting this is highly recommended.**
+  - `logLevel` (`string: ""`) - Configures the Vault server logging verbosity. If set this will override values defined in the Vault configuration file. 
+    Supported log levels include: `trace, debug, info, warn, error`.
+
+    - `logFormat` (`string: ""`) - Configures the Vault server logging format. If set this will override values defined in the Vault configuration file. 
+    Supported log formats include: `standard, json`.
+
+  - `resources` (`dictionary: {}`) - The resource requests and limits (CPU, memory, etc.) for each container of the server. This should be a YAML dictionary of a Kubernetes [ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcerequirements-v1-core) object. If this isn't specified, then the pods won't request any specific amount of resources, which limits the ability for Kubernetes to make efficient use of compute resources. **Setting this is highly recommended.**
 
       ```yaml
       resources:
@@ -219,16 +244,16 @@ and consider if they're appropriate for your deployment.
           memory: '10Gi'
       ```
 
-    * `ingress` - Values that configure Ingress services for Vault.
+  - `ingress` - Values that configure Ingress services for Vault.
 
-      ~> If deploying on OpenShift, these ingress settings are ignored. Use the [`route`](#route) configuration to expose Vault on OpenShift. <br/> <br/>
+    ~> If deploying on OpenShift, these ingress settings are ignored. Use the [`route`](#route) configuration to expose Vault on OpenShift. <br/> <br/>
       If [`ha`](#ha) is enabled the Ingress will point to the active vault server via the `active` Service. This requires vault 1.4+ and [service_registration](https://www.vaultproject.io/docs/configuration/service-registration/kubernetes) to be set in the vault config.
 
-      - `enabled` (`boolean: false`) - When set to `true`, an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) service will be created.
+    - `enabled` (`boolean: false`) - When set to `true`, an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) service will be created.
 
-      - `labels` (`dictionary: {}`) - Labels for the ingress service.
+    - `labels` (`dictionary: {}`) - Labels for the ingress service.
 
-      - `annotations` (`dictionary: {}`) - This value defines additional annotations to
+     - `annotations` (`dictionary: {}`) - This value defines additional annotations to
         add to the Ingress service. This can either be YAML or a YAML-formatted
         multi-line templated string.
 
@@ -242,262 +267,299 @@ and consider if they're appropriate for your deployment.
         kubernetes.io/tls-acme: "true"
       ```
 
-      - `hosts` - Values that configure the Ingress host rules.
-
-        - `host` (`string: required`): Name of the host to use for Ingress.
-
-        - `paths` (`array: []`): A list of paths that will be directed to the Vault service. At least one path is required.
-
-        ```yaml
-        paths:
-          - /
-          - /vault
-        ```
-
-    * `route` - Values that configure Route services for Vault in OpenShift
-
-      ~> If [`ha`](#ha) is enabled the Route will point to the active vault server via the `active` Service (requires vault 1.4+ and [service_registration](https://www.vaultproject.io/docs/configuration/service-registration/kubernetes) to be set in the vault config).
-
-      - `enabled` (`boolean: false`) - When set to `true`, a Route for Vault will be created.
-
-      - `labels` (`dictionary: {}`) - Labels for the Route
-
-      - `annotations` (`dictionary: {}`) - Annotations to add to the Route. This can either be YAML or a YAML-formatted multi-line templated string.
-
-      - `host` (`string: "chart-example.local"`) - Sets the hostname for the Route.
-
-    * `tls` - Values that configure the Ingress TLS rules.
-
-      - `hosts` (`array: []`): List of the hosts defined in the Common Name of the TLS Certificate.
-
-      - `secretName` (`string: null`): Name of the secret containing the required TLS files such as certificates and keys.
+    - `extraPaths` (`array: {}`) - Configures extra paths to prepend to the host configuration. 
+      This is useful when working with annotation based services.
 
       ```yaml
-      hosts:
-        - sslexample.foo.com
-        - sslexample.bar.com
-       secretName: testsecret-tls
+      extraPaths: 
+        - path: /*
+          backend:
+            serviceName: ssl-redirect
+            servicePort: use-annotation
       ```
 
-    * `authDelegator` - Values that configure the Cluster Role Binding attached to the Vault service account.
+    - `hosts` - Values that configure the Ingress host rules.
 
-      - `enabled` (`boolean: true`) - When set to `true`, a Cluster Role Binding will be bound to the Vault service account. This Cluster Role Binding has the necessary privileges for Vault to use the [Kubernetes Auth Method](/docs/auth/kubernetes).
+      - `host` (`string: required`): Name of the host to use for Ingress.
 
-    * `readinessProbe` - Values that configure the readiness probe for the Vault pods.
-
-      - `enabled` (`boolean: true`) - When set to `true`, a readiness probe will be applied to the Vault pods.
-
-      - `path` (`string: ""`) - When set to a value, enables HTTP/HTTPS probes instead of using the default `exec` probe. The http/https scheme is controlled by the `tlsDisable` value.
-
-      - `failureThreshold` (`int: 2`) - When set to a value, configures how many probe failures will be tolerated by Kubernetes.
-
-      - `initialDelaySeconds` (`int: 5`) - When set to a value, configures the number of seconds after the container has started before probe initiates.
-
-      - `periodSeconds` (`int: 5`) - When set to a value, configures how often (in seconds) to perform the probe.
-
-      - `successThreshold` (`int: 1`) - When set to a value, configures the minimum consecutive successes for the probe to be considered successful after having failed.
-
-      - `timeoutSeconds` (`int: 3`) - When set to a value, configures the number of seconds after which the probe times out.
+      - `paths` (`array: []`): Deprecated: `server.ingress.extraPaths` should be used instead. A list of paths that will be directed to the Vault service. At least one path is required.
 
       ```yaml
-      readinessProbe:
-        enabled: true
-        path: /v1/sys/health?standbyok=true
-        failureThreshold: 2
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        successThreshold: 1
-        timeoutSeconds: 3
+      paths:
+        - /
+        - /vault
       ```
 
-    - `livelinessProbes` - Values that configure the liveliness probe for the Vault pods.
+  - `route` - Values that configure Route services for Vault in OpenShift
 
-      - `enabled` (`boolean: false`) - When set to `true`, a liveliness probe will be applied to the Vault pods.
+    ~> If [`ha`](#ha) is enabled the Route will point to the active vault server via the `active` Service (requires vault 1.4+ and [service_registration](https://www.vaultproject.io/docs/configuration/service-registration/kubernetes) to be set in the vault config).
 
-      - `path` (`string: "/v1/sys/health?standbyok=true"`) - When set to a value, enables HTTP/HTTPS probes instead of using the default `exec` probe. The http/https scheme is controlled by the `tlsDisable` value.
+    - `enabled` (`boolean: false`) - When set to `true`, a Route for Vault will be created.
 
-      - `initialDelaySeconds` (`int: 60`) - Sets the initial delay of the liveliness probe when the container starts.
+    - `labels` (`dictionary: {}`) - Labels for the Route
 
-      - `failureThreshold` (`int: 2`) - When set to a value, configures how many probe failures will be tolerated by Kubernetes.
+    - `annotations` (`dictionary: {}`) - Annotations to add to the Route. This can either be YAML or a YAML-formatted multi-line templated string.
 
-      - `periodSeconds` (`int: 5`) - When set to a value, configures how often (in seconds) to perform the probe.
+    - `host` (`string: "chart-example.local"`) - Sets the hostname for the Route.
 
-      - `successThreshold` (`int: 1`) - When set to a value, configures the minimum consecutive successes for the probe to be considered successful after having failed.
+  - `tls` - Values that configure the Ingress TLS rules.
 
-      - `timeoutSeconds` (`int: 3`) - When set to a value, configures the number of seconds after which the probe times out.
+    - `hosts` (`array: []`): List of the hosts defined in the Common Name of the TLS Certificate.
 
-      ```yaml
-      livelinessProbe:
-        enabled: true
-        path: /v1/sys/health?standbyok=true
-        initialDelaySeconds: 60
-        failureThreshold: 2
-        periodSeconds: 5
-        successThreshold: 1
-        timeoutSeconds: 3
-      ```
-
-    - `preStopSleepSeconds` (`int: 5`) - Used to set the sleep time during the preStop step.
-
-    - `postStart` (`array: []`) - Used to define commands to run after the pod is ready. This can be used to automate processes such as initialization or bootstrapping auth methods.
+    - `secretName` (`string: null`): Name of the secret containing the required TLS files such as certificates and keys.
 
     ```yaml
-    postStart:
-      - /bin/sh
-      - -c
-      - /vault/userconfig/myscript/run.sh
+    hosts:
+      - sslexample.foo.com
+      - sslexample.bar.com
+      secretName: testsecret-tls
     ```
 
-    - `extraInitContainers` (`array: null`) - extraInitContainers is a list of init containers. Specified as a YAML list. This is useful if you need to run a script to provision TLS certificates or write out configuration files in a dynamic way.
+  - `authDelegator` - Values that configure the Cluster Role Binding attached to the Vault service account.
 
-    - `extraContainers` (`array: null`) - The extra containers to be applied to the Vault server pods.
+    - `enabled` (`boolean: true`) - When set to `true`, a Cluster Role Binding will be bound to the Vault service account. This Cluster Role Binding has the necessary privileges for Vault to use the [Kubernetes Auth Method](/docs/auth/kubernetes).
+
+  - `readinessProbe` - Values that configure the readiness probe for the Vault pods.
+
+    - `enabled` (`boolean: true`) - When set to `true`, a readiness probe will be applied to the Vault pods.
+
+    - `path` (`string: ""`) - When set to a value, enables HTTP/HTTPS probes instead of using the default `exec` probe. The http/https scheme is controlled by the `tlsDisable` value.
+
+    - `failureThreshold` (`int: 2`) - When set to a value, configures how many probe failures will be tolerated by Kubernetes.
+
+    - `initialDelaySeconds` (`int: 5`) - When set to a value, configures the number of seconds after the container has started before probe initiates.
+
+    - `periodSeconds` (`int: 5`) - When set to a value, configures how often (in seconds) to perform the probe.
+
+    - `successThreshold` (`int: 1`) - When set to a value, configures the minimum consecutive successes for the probe to be considered successful after having failed.
+
+    - `timeoutSeconds` (`int: 3`) - When set to a value, configures the number of seconds after which the probe times out.
 
     ```yaml
-    extraContainers:
-      - name: mycontainer
-        image: 'app:0.0.0'
-        env: ...
+    readinessProbe:
+      enabled: true
+      path: /v1/sys/health?standbyok=true
+      failureThreshold: 2
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 3
     ```
 
-    - `extraEnvironmentVars` (`dictionary: {}`) - The extra environment variables to be applied to the Vault server.
+  - `livenessProbe` - Values that configure the liveliness probe for the Vault pods.
+
+    - `enabled` (`boolean: false`) - When set to `true`, a liveliness probe will be applied to the Vault pods.
+
+    - `path` (`string: "/v1/sys/health?standbyok=true"`) - When set to a value, enables HTTP/HTTPS probes instead of using the default `exec` probe. The http/https scheme is controlled by the `tlsDisable` value.
+
+    - `initialDelaySeconds` (`int: 60`) - Sets the initial delay of the liveliness probe when the container starts.
+
+    - `failureThreshold` (`int: 2`) - When set to a value, configures how many probe failures will be tolerated by Kubernetes.
+
+    - `periodSeconds` (`int: 5`) - When set to a value, configures how often (in seconds) to perform the probe.
+
+    - `successThreshold` (`int: 1`) - When set to a value, configures the minimum consecutive successes for the probe to be considered successful after having failed.
+
+    - `timeoutSeconds` (`int: 3`) - When set to a value, configures the number of seconds after which the probe times out.
 
     ```yaml
-    # Extra Environment Variables are defined as key/value strings.
-    extraEnvironmentVars:
-      GOOGLE_REGION: global
-      GOOGLE_PROJECT: myproject
-      GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
+    livelinessProbe:
+      enabled: true
+      path: /v1/sys/health?standbyok=true
+      initialDelaySeconds: 60
+      failureThreshold: 2
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 3
     ```
 
-    - `shareProcessNamespace` (`boolean: false`) - Enables process namespace sharing between Vault and the extraContainers. This is useful if Vault must be signaled, e.g. to send a SIGHUP for log rotation.
+  - `preStopSleepSeconds` (`int: 5`) - Used to set the sleep time during the preStop step.
 
-    - `extraArgs` (`string: null`) - The extra arguments to be applied to the Vault server startup command.
+  - `postStart` (`array: []`) - Used to define commands to run after the pod is ready. This can be used to automate processes such as initialization or bootstrapping auth methods.
 
-      ```yaml
-      extraArgs: '-config=/path/to/extra/config.hcl -log-format=json'
-      ```
+  ```yaml
+  postStart:
+    - /bin/sh
+    - -c
+    - /vault/userconfig/myscript/run.sh
+  ```
 
-    - `extraSecretEnvironmentVars` (`string: null`) - The extra environment variables populated from a secret to be applied to the Vault server. This should be a multi-line key/value string.
+  - `extraInitContainers` (`array: null`) - extraInitContainers is a list of init containers. Specified as a YAML list. This is useful if you need to run a script to provision TLS certificates or write out configuration files in a dynamic way.
 
-      - `envName` (`string: required`) -
-        Name of the environment variable to be populated in the Vault container.
+  - `extraContainers` (`array: null`) - The extra containers to be applied to the Vault server pods.
 
-      - `secretName` (`string: required`) -
-        Name of Kubernetes secret used to populate the environment variable defined by `envName`.
+  ```yaml
+  extraContainers:
+    - name: mycontainer
+      image: 'app:0.0.0'
+      env: ...
+  ```
 
-      - `secretKey` (`string: required`) -
-        Name of the key where the requested secret value is located in the Kubernetes secret.
+  - `extraEnvironmentVars` (`dictionary: {}`) - The extra environment variables to be applied to the Vault server.
 
-      ```yaml
-      # Extra Environment Variables populated from a secret.
-      extraSecretEnvironmentVars:
-        - envName: AWS_SECRET_ACCESS_KEY
-          secretName: vault
-          secretKey: AWS_SECRET_ACCESS_KEY
-      ```
+  ```yaml
+  # Extra Environment Variables are defined as key/value strings.
+  extraEnvironmentVars:
+    GOOGLE_REGION: global
+    GOOGLE_PROJECT: myproject
+    GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
+  ```
 
-    - `extraVolumes` (`array: []`) - Deprecated: please use `volumes` instead. A list of extra volumes to mount to Vault servers. This is useful for bringing in extra data that can be referenced by other configurations at a well known path, such as TLS certificates. The value of this should be a list of objects. Each object supports the following keys:
+  - `shareProcessNamespace` (`boolean: false`) - Enables process namespace sharing between Vault and the extraContainers. This is useful if Vault must be signaled, e.g. to send a SIGHUP for log rotation.
 
-      - `type` (`string: required`) -
-        Type of the volume, must be one of "configMap" or "secret". Case sensitive.
-
-      - `name` (`string: required`) -
-        Name of the configMap or secret to be mounted. This also controls the path
-        that it is mounted to. The volume will be mounted to `/vault/userconfig/<name>` by default
-        unless `path` is configured.
-
-      - `path` (`string: /vault/userconfigs`) -
-        Name of the path where a configMap or secret is mounted. If not specified
-        the volume will be mounted to `/vault/userconfig/<name of volume>`.
-
-      - `defaultMode` (`string: "420"`) -
-        Default mode of the mounted files.
-
-      ```yaml
-      extraVolumes:
-        - type: 'secret'
-          name: 'vault-certs'
-          path: '/etc/pki'
-      ```
-
-    - `volumes` (`array: []`) - A list of volumes made available to all containers. This takes
-      standard Kubernetes volume definitions.
-
-      ```yaml
-      volumes:
-        - name: plugins
-          emptyDir: {}
-      ```
-
-    - `volumeMounts` (`array: []`) - A list of volumes mounts made available to all containers. This takes
-      standard Kubernetes volume definitions.
-
-      ```yaml
-      volumeMounts:
-        - mountPath: /usr/local/libexec/vault
-          name: plugins
-          readOnly: true
-      ```
-
-    - `affinity` - This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for server pods. It defaults to allowing only a single pod on each node, which minimizes risk of the cluster becoming unusable if a node is lost. If you need to run more pods per node (for example, testing on Minikube), set this value to `null`.
+  - `extraArgs` (`string: null`) - The extra arguments to be applied to the Vault server startup command.
 
     ```yaml
-    # Recommended default server affinity:
-    affinity: |
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-          matchLabels:
-            app: {{ template "vault.name" . }}
-            release: "{{ .Release.Name }}"
-            component: server
-          topologyKey: kubernetes.io/hostname
+    extraArgs: '-config=/path/to/extra/config.hcl -log-format=json'
     ```
 
-    - `tolerations` (`string: null`) - This value defines the [tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) that are acceptable when being scheduled. This should be a multi-line string matching the Toleration array in a PodSpec.
+  - `extraSecretEnvironmentVars` (`string: null`) - The extra environment variables populated from a secret to be applied to the Vault server. This should be a multi-line key/value string.
+
+    - `envName` (`string: required`) -
+      Name of the environment variable to be populated in the Vault container.
+
+    - `secretName` (`string: required`) -
+      Name of Kubernetes secret used to populate the environment variable defined by `envName`.
+
+    - `secretKey` (`string: required`) -
+      Name of the key where the requested secret value is located in the Kubernetes secret.
 
     ```yaml
-    tolerations: |
-      - key: 'node.kubernetes.io/unreachable'
-        operator: 'Exists'
-        effect: 'NoExecute'
-        tolerationSeconds: 6000
+    # Extra Environment Variables populated from a secret.
+    extraSecretEnvironmentVars:
+      - envName: AWS_SECRET_ACCESS_KEY
+        secretName: vault
+        secretKey: AWS_SECRET_ACCESS_KEY
     ```
 
-    - `nodeSelector` - This value defines additional node selection criteria for more control over where the Vault servers are deployed. This should be formatted as a multi-line string.
+  - `extraVolumes` (`array: []`) - Deprecated: please use `volumes` instead. A list of extra volumes to mount to Vault servers. This is useful for bringing in extra data that can be referenced by other configurations at a well known path, such as TLS certificates. The value of this should be a list of objects. Each object supports the following keys:
+
+    - `type` (`string: required`) -
+      Type of the volume, must be one of "configMap" or "secret". Case sensitive.
+
+    - `name` (`string: required`) -
+      Name of the configMap or secret to be mounted. This also controls the path
+      that it is mounted to. The volume will be mounted to `/vault/userconfig/<name>` by default
+      unless `path` is configured.
+
+    - `path` (`string: /vault/userconfigs`) -
+      Name of the path where a configMap or secret is mounted. If not specified
+      the volume will be mounted to `/vault/userconfig/<name of volume>`.
+
+    - `defaultMode` (`string: "420"`) -
+      Default mode of the mounted files.
 
     ```yaml
-    nodeSelector: |
-      disktype: ssd
+    extraVolumes:
+      - type: 'secret'
+        name: 'vault-certs'
+        path: '/etc/pki'
     ```
 
-    - `networkPolicy` - Values that configure the Vault Network Policy.
-
-      - `enabled` (`boolean: false`) - When set to `true`, enables a Network Policy for the Vault cluster.
-
-      - `egress` (`array: []`) - This value configures the [egress](https://kubernetes.io/docs/concepts/services-networking/network-policies/) network policy rules.
-
-      ```yaml
-      egress:
-        - to:
-            - ipBlock:
-                cidr: 10.0.0.0/24
-          ports:
-            - protocol: TCP
-              port: 8200
-      ```
-
-    - `priorityClassName` (`string: ""`) - Priority class for server pods
-
-    - `extraLabels` (`dictionary: {}`) - This value defines additional labels for server pods.
+  - `volumes` (`array: []`) - A list of volumes made available to all containers. This takes
+    standard Kubernetes volume definitions.
 
     ```yaml
-    extraLabels:
-      'sample/label1': 'foo'
-      'sample/label2': 'bar'
+    volumes:
+      - name: plugins
+        emptyDir: {}
     ```
 
-    - `annotations` (`dictionary: {}`) - This value defines additional annotations for server pods. This can either be YAML or a YAML-formatted multi-line templated string.
+  - `volumeMounts` (`array: []`) - A list of volumes mounts made available to all containers. This takes
+    standard Kubernetes volume definitions.
+
+    ```yaml
+    volumeMounts:
+      - mountPath: /usr/local/libexec/vault
+        name: plugins
+        readOnly: true
+    ```
+
+  - `affinity` - This value defines the [affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) for server pods. It defaults to allowing only a single pod on each node, which minimizes risk of the cluster becoming unusable if a node is lost. If you need to run more pods per node (for example, testing on Minikube), set this value to `null`.
+
+  ```yaml
+  # Recommended default server affinity:
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+        matchLabels:
+          app: {{ template "vault.name" . }}
+          release: "{{ .Release.Name }}"
+          component: server
+        topologyKey: kubernetes.io/hostname
+  ```
+
+  - `tolerations` (`string: null`) - This value defines the [tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) that are acceptable when being scheduled. This should be a multi-line string matching the Toleration array in a PodSpec.
+
+  ```yaml
+  tolerations: |
+    - key: 'node.kubernetes.io/unreachable'
+      operator: 'Exists'
+      effect: 'NoExecute'
+      tolerationSeconds: 6000
+  ```
+
+  - `nodeSelector` - This value defines additional node selection criteria for more control over where the Vault servers are deployed. This should be formatted as a multi-line string.
+
+  ```yaml
+  nodeSelector: |
+    disktype: ssd
+  ```
+
+  - `networkPolicy` - Values that configure the Vault Network Policy.
+
+    - `enabled` (`boolean: false`) - When set to `true`, enables a Network Policy for the Vault cluster.
+
+    - `egress` (`array: []`) - This value configures the [egress](https://kubernetes.io/docs/concepts/services-networking/network-policies/) network policy rules.
+
+    ```yaml
+    egress:
+      - to:
+          - ipBlock:
+              cidr: 10.0.0.0/24
+        ports:
+          - protocol: TCP
+            port: 8200
+    ```
+
+  - `priorityClassName` (`string: ""`) - Priority class for server pods
+
+  - `extraLabels` (`dictionary: {}`) - This value defines additional labels for server pods.
+
+  ```yaml
+  extraLabels:
+    'sample/label1': 'foo'
+    'sample/label2': 'bar'
+  ```
+
+  - `annotations` (`dictionary: {}`) - This value defines additional annotations for server pods. This can either be YAML or a YAML-formatted multi-line templated string.
+
+  ```yaml
+  annotations:
+    "sample/annotation1": "foo"
+    "sample/annotation2": "bar"
+  # or
+  annotations: |
+    "sample/annotation1": "foo"
+    "sample/annotation2": "bar"
+  ```
+
+  - `service` - Values that configure the Kubernetes service created for Vault. These options are also used for the `active` and `standby` services when [`ha`](#ha) is enabled.
+
+    - `enabled` (`boolean: true`) - When set to `true`, a Kubernetes service will be created for Vault.
+
+    - `clusterIP` (`string`) - ClusterIP controls whether an IP address (cluster IP) is attached to the Vault service within Kubernetes. By default the Vault service will be given a Cluster IP address, set to `None` to disable. When disabled Kubernetes will create a "headless" service. Headless services can be used to communicate with pods directly through DNS instead of a round robin load balancer.
+
+    - `type` (`string: "ClusterIP"`) - Sets the type of service to create, such as `NodePort`.
+
+    - `port` (`int: 8200`) - Port on which Vault server is listening inside the pod.
+
+    - `targetPort` (`int: 8200`) - Port on which the service is listening.
+
+    - `nodePort` (`int:`) - When type is set to `NodePort`, the bound node port can be configured using this value. A random port will be assigned if this is left blank.
+
+    - `annotations` (`dictionary: {}`) - This value defines additional annotations for the service. This can either be YAML or a YAML-formatted multi-line templated string.
 
     ```yaml
     annotations:
@@ -509,212 +571,186 @@ and consider if they're appropriate for your deployment.
       "sample/annotation2": "bar"
     ```
 
-    - `service` - Values that configure the Kubernetes service created for Vault. These options are also used for the `active` and `standby` services when [`ha`](#ha) is enabled.
+  - `serviceAccount` - Values that configure the Kubernetes service account created for Vault.
 
-      - `enabled` (`boolean: true`) - When set to `true`, a Kubernetes service will be created for Vault.
+    - `create` (`boolean: true`): If set to true, creates a service account used by Vault.
 
-      - `clusterIP` (`string`) - ClusterIP controls whether an IP address (cluster IP) is attached to the Vault service within Kubernetes. By default the Vault service will be given a Cluster IP address, set to `None` to disable. When disabled Kubernetes will create a "headless" service. Headless services can be used to communicate with pods directly through DNS instead of a round robin load balancer.
+    - `name` (`string: ""`): Name of the service account to use. If not set and create is true, a name is generated using the name of the installation (default is "vault").
 
-      - `type` (`string: "ClusterIP"`) - Sets the type of service to create, such as `NodePort`.
+    - `annotations` (`dictionary: {}`) - This value defines additional annotations for the service account. This can either be YAML or a YAML-formatted multi-line templated string.
 
-      - `port` (`int: 8200`) - Port on which Vault server is listening inside the pod.
+    ```yaml
+    annotations:
+      "sample/annotation1": "foo"
+      "sample/annotation2": "bar"
+    # or
+    annotations: |
+      "sample/annotation1": "foo"
+      "sample/annotation2": "bar"
+    ```
 
-      - `targetPort` (`int: 8200`) - Port on which the service is listening.
+  - `dataStorage` - This configures the volume used for storing Vault data when not using external storage such as Consul.
 
-      - `nodePort` (`int:`) - When type is set to `NodePort`, the bound node port can be configured using this value. A random port will be assigned if this is left blank.
+    - `enabled` (`boolean: true`) -
+      Enables a persistent volume to be created for storing Vault data when not using an external storage service.
 
-      - `annotations` (`dictionary: {}`) - This value defines additional annotations for the service. This can either be YAML or a YAML-formatted multi-line templated string.
+    - `size` (`string: 10Gi`) -
+      Size of the volume to be created for Vault's data storage when not using an external storage service.
 
-      ```yaml
-      annotations:
-        "sample/annotation1": "foo"
-        "sample/annotation2": "bar"
-      # or
-      annotations: |
-        "sample/annotation1": "foo"
-        "sample/annotation2": "bar"
-      ```
+    - `storageClass` (`string: null`) -
+      Name of the storage class to use when creating the data storage volume.
 
-    - `serviceAccount` - Values that configure the Kubernetes service account created for Vault.
+    - `mountPath` (`string: /vault/data`) -
+      Configures the path in the Vault pod where the data storage will be mounted.
 
-      - `create` (`boolean: true`): If set to true, creates a service account used by Vault.
+    - `accessMode` (`string: ReadWriteOnce`) -
+      Type of access mode of the storage device. See the [official Kubernetes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for more information.
 
-      - `name` (`string: ""`): Name of the service account to use. If not set and create is true, a name is generated using the name of the installation (default is "vault").
+    - `annotations` (`dictionary: {}`) - This value defines additional annotations to
+      add to the data PVCs. This can either be YAML or a YAML-formatted
+      multi-line templated string.
 
-      - `annotations` (`dictionary: {}`) - This value defines additional annotations for the service account. This can either be YAML or a YAML-formatted multi-line templated string.
+    ```yaml
+    annotations:
+      kubernetes.io/my-pvc: foobar
+    # or
+    annotations: |
+      kubernetes.io/my-pvc: foobar
+    ```
 
-      ```yaml
-      annotations:
-        "sample/annotation1": "foo"
-        "sample/annotation2": "bar"
-      # or
-      annotations: |
-        "sample/annotation1": "foo"
-        "sample/annotation2": "bar"
-      ```
+  - `auditStorage` - This configures the volume used for storing Vault's audit logs. See the [Vault documentation](/docs/audit) for more information.
 
-    - `dataStorage` - This configures the volume used for storing Vault data when not using external storage such as Consul.
+    - `enabled` (`boolean: true`) -
+      Enables a persistent volume to be created for storing Vault's audit logs.
 
-      - `enabled` (`boolean: true`) -
-        Enables a persistent volume to be created for storing Vault data when not using an external storage service.
+    - `size` (`string: 10Gi`) -
+      Size of the volume to be created for Vault's audit logs.
 
-      - `size` (`string: 10Gi`) -
-        Size of the volume to be created for Vault's data storage when not using an external storage service.
+    - `storageClass` (`string: null`) -
+      Name of the storage class to use when creating the audit storage volume.
 
-      - `storageClass` (`string: null`) -
-        Name of the storage class to use when creating the data storage volume.
+    - `mountPath` (`string: /vault/audit`) -
+      Configures the path in the Vault pod where the audit storage will be mounted.
 
-      - `mountPath` (`string: /vault/data`) -
-        Configures the path in the Vault pod where the data storage will be mounted.
+    - `accessMode` (`string: ReadWriteOnce`) -
+      Type of access mode of the storage device.
 
-      - `accessMode` (`string: ReadWriteOnce`) -
-        Type of access mode of the storage device. See the [official Kubernetes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for more information.
+    - `annotations` (`dictionary: {}`) - This value defines additional annotations to
+      add to the audit PVCs. This can either be YAML or a YAML-formatted
+      multi-line templated string.
 
-      - `annotations` (`dictionary: {}`) - This value defines additional annotations to
-        add to the data PVCs. This can either be YAML or a YAML-formatted
-        multi-line templated string.
+    ```yaml
+    annotations:
+      kubernetes.io/my-pvc: foobar
+    # or
+    annotations: |
+      kubernetes.io/my-pvc: foobar
+    ```
 
-      ```yaml
-      annotations:
-        kubernetes.io/my-pvc: foobar
-      # or
-      annotations: |
-        kubernetes.io/my-pvc: foobar
-      ```
+  - `dev` - This configures `dev` mode for the Vault server.
 
-    - `auditStorage` - This configures the volume used for storing Vault's audit logs. See the [Vault documentation](/docs/audit) for more information.
+    - `enabled` (`boolean: false`) -
+      Enables `dev` mode for the Vault server. This mode is useful for experimenting with Vault without needing to unseal.
 
-      - `enabled` (`boolean: true`) -
-        Enables a persistent volume to be created for storing Vault's audit logs.
+    - `devRootToken` (`string: "root"`) - Configures the root token for the Vault development server.
 
-      - `size` (`string: 10Gi`) -
-        Size of the volume to be created for Vault's audit logs.
+    ~> **Security Warning:** Never, ever, ever run a "dev" mode server in production. It is insecure and will lose data on every restart (since it stores data in-memory). It is only made for development or experimentation.
 
-      - `storageClass` (`string: null`) -
-        Name of the storage class to use when creating the audit storage volume.
+  - `standalone` - This configures `standalone` mode for the Vault server.
 
-      - `mountPath` (`string: /vault/audit`) -
-        Configures the path in the Vault pod where the audit storage will be mounted.
+    - `enabled` (`boolean: true`) -
+      Enables `standalone` mode for the Vault server. This mode uses the `file` storage backend and requires a volume for persistence (`dataStorage`).
 
-      - `accessMode` (`string: ReadWriteOnce`) -
-        Type of access mode of the storage device.
+    - `config` (`string: "{}"`) -
+      A raw string of extra HCL or JSON [configuration](/docs/configuration) for Vault servers.
+      This will be saved as-is into a ConfigMap that is read by the Vault servers.
+      This can be used to add additional configuration that isn't directly exposed by the chart.
 
-      - `annotations` (`dictionary: {}`) - This value defines additional annotations to
-        add to the audit PVCs. This can either be YAML or a YAML-formatted
-        multi-line templated string.
+    ```yaml
+    # ExtraConfig values are formatted as a multi-line string:
+    config: |
+      api_addr = "http://POD_IP:8200"
 
-      ```yaml
-      annotations:
-        kubernetes.io/my-pvc: foobar
-      # or
-      annotations: |
-        kubernetes.io/my-pvc: foobar
-      ```
+      listener "tcp" {
+        tls_disable = 1
+        address     = "0.0.0.0:8200"
+      }
 
-    - `dev` - This configures `dev` mode for the Vault server.
+      storage "file" {
+        path = "/vault/data"
+      }
+    ```
+
+    This can also be set using Helm's `--set` flag (vault-helm v0.1.0 and later), using the following syntax:
+
+    ```shell
+    --set server.standalone.config='{ listener "tcp" { address = "0.0.0.0:8200" }'
+    ```
+
+  - `ha` - This configures `ha` mode for the Vault server.
+
+    - `enabled` (`boolean: false`) -
+      Enables `ha` mode for the Vault server. This mode uses a highly available backend storage (such as Consul) to store Vault's data. By default this is configured to use [Consul Helm](https://github.com/hashicorp/consul-helm). For a complete list of storage backends, see the [Vault documentation](/docs/configuration).
+
+    - `apiAddr`: (`string: "{}"`) -
+      Set the API address configuration for a Vault cluster. If set to an empty string, the pod IP address is used.
+
+    - `raft` - This configures `raft` integrated storage mode for the Vault server.
 
       - `enabled` (`boolean: false`) -
-        Enables `dev` mode for the Vault server. This mode is useful for experimenting with Vault without needing to unseal.
+        Enables `raft` integrated storage mode for the Vault server. This mode uses persistent volumes for storage.
 
-      - `devRootToken` (`string: "root"`) - Configures the root token for the Vault development server.
-
-      ~> **Security Warning:** Never, ever, ever run a "dev" mode server in production. It is insecure and will lose data on every restart (since it stores data in-memory). It is only made for development or experimentation.
-
-    - `standalone` - This configures `standalone` mode for the Vault server.
-
-      - `enabled` (`boolean: true`) -
-        Enables `standalone` mode for the Vault server. This mode uses the `file` storage backend and requires a volume for persistence (`dataStorage`).
+      - `setNodeId` (`boolean: false`) - Set the Node Raft ID to the name of the pod.
 
       - `config` (`string: "{}"`) -
         A raw string of extra HCL or JSON [configuration](/docs/configuration) for Vault servers.
         This will be saved as-is into a ConfigMap that is read by the Vault servers.
         This can be used to add additional configuration that isn't directly exposed by the chart.
 
-      ```yaml
-      # ExtraConfig values are formatted as a multi-line string:
-      config: |
-        api_addr = "http://POD_IP:8200"
+    - `replicas` (`int: 5`) -
+      The number of pods to deploy to create a highly available cluster of Vault servers.
 
-        listener "tcp" {
+    - `updatePartition` (`int: 0`) -
+      If an updatePartition is specified, all Pods with an ordinal that is greater than or equal to the partition will be updated when the StatefulSet’s `.spec.template` is updated. If set to `0`, this disables partition updates. For more information see the [official Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#rolling-updates).
+
+    - `config` (`string: "{}"`) -
+      A raw string of extra HCL or JSON [configuration](/docs/configuration) for Vault servers.
+      This will be saved as-is into a ConfigMap that is read by the Vault servers.
+      This can be used to add additional configuration that isn't directly exposed by the chart.
+
+    ```yaml
+    # ExtraConfig values are formatted as a multi-line string:
+    config: |
+      ui = true
+      api_addr = "http://POD_IP:8200"
+      listener "tcp" {
           tls_disable = 1
           address     = "0.0.0.0:8200"
-        }
+      }
 
-        storage "file" {
-          path = "/vault/data"
-        }
-      ```
+      storage "consul" {
+          path = "vault"
+          address = "HOST_IP:8500"
+      }
+    ```
 
-      This can also be set using Helm's `--set` flag (vault-helm v0.1.0 and later), using the following syntax:
+    This can also be set using Helm's `--set` flag (vault-helm v0.1.0 and later), using the following syntax:
 
-      ```shell
-      --set server.standalone.config='{ listener "tcp" { address = "0.0.0.0:8200" }'
-      ```
+    ```shell
+    --set server.ha.config='{ listener "tcp" { address = "0.0.0.0:8200" }'
+    ```
 
-    - `ha` - This configures `ha` mode for the Vault server.
+  - `disruptionBudget` - Values that configures the disruption budget policy. See the [official Kubernetes documentation](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) for more information.
 
-      - `enabled` (`boolean: false`) -
-        Enables `ha` mode for the Vault server. This mode uses a highly available backend storage (such as Consul) to store Vault's data. By default this is configured to use [Consul Helm](https://github.com/hashicorp/consul-helm). For a complete list of storage backends, see the [Vault documentation](/docs/configuration).
+    - `enabled` (`boolean: true`) -
+      Enables disruption budget policy to limit the number of pods that are down simultaneously from voluntary disruptions.
 
-      - `apiAddr`: (`string: "{}"`) -
-        Set the API address configuration for a Vault cluster. If set to an empty string, the pod IP address is used.
-
-      - `raft` - This configures `raft` integrated storage mode for the Vault server.
-
-        - `enabled` (`boolean: false`) -
-          Enables `raft` integrated storage mode for the Vault server. This mode uses persistent volumes for storage.
-
-        - `setNodeId` (`boolean: false`) - Set the Node Raft ID to the name of the pod.
-
-        - `config` (`string: "{}"`) -
-          A raw string of extra HCL or JSON [configuration](/docs/configuration) for Vault servers.
-          This will be saved as-is into a ConfigMap that is read by the Vault servers.
-          This can be used to add additional configuration that isn't directly exposed by the chart.
-
-      - `replicas` (`int: 5`) -
-        The number of pods to deploy to create a highly available cluster of Vault servers.
-
-      - `updatePartition` (`int: 0`) -
-        If an updatePartition is specified, all Pods with an ordinal that is greater than or equal to the partition will be updated when the StatefulSet’s `.spec.template` is updated. If set to `0`, this disables partition updates. For more information see the [official Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#rolling-updates).
-
-      - `config` (`string: "{}"`) -
-        A raw string of extra HCL or JSON [configuration](/docs/configuration) for Vault servers.
-        This will be saved as-is into a ConfigMap that is read by the Vault servers.
-        This can be used to add additional configuration that isn't directly exposed by the chart.
-
-      ```yaml
-      # ExtraConfig values are formatted as a multi-line string:
-      config: |
-        ui = true
-        api_addr = "http://POD_IP:8200"
-        listener "tcp" {
-            tls_disable = 1
-            address     = "0.0.0.0:8200"
-        }
-
-        storage "consul" {
-            path = "vault"
-            address = "HOST_IP:8500"
-        }
-      ```
-
-      This can also be set using Helm's `--set` flag (vault-helm v0.1.0 and later), using the following syntax:
-
-      ```shell
-      --set server.ha.config='{ listener "tcp" { address = "0.0.0.0:8200" }'
-      ```
-
-    * `disruptionBudget` - Values that configures the disruption budget policy. See the [official Kubernetes documentation](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) for more information.
-
-      - `enabled` (`boolean: true`) -
-        Enables disruption budget policy to limit the number of pods that are down simultaneously from voluntary disruptions.
-
-      - `maxUnavailable` (`int: null`) -
-        The maximum number of unavailable pods. By default, this will be automatically
-        computed based on the `server.replicas` value to be `(n/2)-1`. If you need to set
-        this to `0`, you will need to add a `--set 'server.disruptionBudget.maxUnavailable=0'`
-        flag to the helm chart installation command because of a limitation in the Helm
-        templating language.
+    - `maxUnavailable` (`int: null`) -
+      The maximum number of unavailable pods. By default, this will be automatically
+      computed based on the `server.replicas` value to be `(n/2)-1`. If you need to set
+      this to `0`, you will need to add a `--set 'server.disruptionBudget.maxUnavailable=0'`
+      flag to the helm chart installation command because of a limitation in the Helm
+      templating language.
 
   - `statefulset` - This configures settings for the Vault Statefulset.
 
@@ -781,7 +817,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault-csi-provider"`) - The name of the Docker image for the Vault CSI Provider.
 
-    - `tag` (`string: "0.1.0"`) - The tag of the Docker image for the Vault CSI Provider.. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your CSI provider.
+    - `tag` (`string: "0.2.0"`) - The tag of the Docker image for the Vault CSI Provider.. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your CSI provider.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists locally.
 

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
@@ -21,7 +21,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.6.2_ent' \
+  --set='server.image.tag=1.7.0_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -73,7 +73,7 @@ disaster recovery replication.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.6.2_ent' \
+  --set='server.image.tag=1.7.0_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
@@ -21,7 +21,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.6.2_ent' \
+  --set='server.image.tag=1.7.0_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -72,7 +72,7 @@ With the primary cluster created, next create a secondary cluster.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.6.2_ent' \
+  --set='server.image.tag=1.7.0_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
@@ -15,7 +15,7 @@ Integrated storage (raft) can be enabled using the `server.ha.raft.enabled` valu
 ```shell
 helm install vault hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.6.2_ent' \
+  --set='server.image.tag=1.7.0_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/index.mdx
+++ b/website/content/docs/platform/k8s/helm/index.mdx
@@ -35,7 +35,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.10.0        	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -57,14 +57,16 @@ Installing a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.10.0        	1.7.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.1         	1.6.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.0         	1.6.1      	Official HashiCorp Vault Chart
-hashicorp/vault	0.8.0         	1.5.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.7.0         	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.10.0       	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
+hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.10.0
-$ helm install vault hashicorp/vault --version 0.10.0
+# Install version 0.11.0
+$ helm install vault hashicorp/vault --version 0.11.0
 ```
 
 ~> **Security Warning:** By default, the chart runs in standalone mode. This

--- a/website/content/docs/platform/k8s/helm/openshift.mdx
+++ b/website/content/docs/platform/k8s/helm/openshift.mdx
@@ -69,7 +69,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.10.0        	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -88,14 +88,16 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.10.0        	1.7.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.1         	1.6.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.0         	1.6.1      	Official HashiCorp Vault Chart
-hashicorp/vault	0.8.0         	1.5.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.7.0         	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.10.0       	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
+hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.10.0
-$ helm install vault hashicorp/vault --version 0.10.0
+# Install version 0.11.0
+$ helm install vault hashicorp/vault --version 0.11.0
 ```
 
 The `helm install` command accepts parameters to override default configuration

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -53,7 +53,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.10.0        	1.7.0     	Official HashiCorp Vault Chart
+hashicorp/vault	0.11.0        	1.7.0     	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -72,14 +72,16 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.10.0        	1.7.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.1         	1.6.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.0         	1.6.1      	Official HashiCorp Vault Chart
-hashicorp/vault	0.8.0         	1.5.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.7.0         	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.10.0       	1.7.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
+hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.10.0
-$ helm install vault hashicorp/vault --version 0.10.0
+# Install version 0.11.0
+$ helm install vault hashicorp/vault --version 0.11.0
 ```
 
 The `helm install` command accepts parameters to override default configuration


### PR DESCRIPTION
Updates the website for the latest Vault Helm release 0.11.0. I noticed that indentation was off in the configuration page, so I had to move it (hence the huge diff for that file). Going to spot check it once the preview is deployed.