### PR TITLE
Grammar typo fix

### DIFF
--- a/ui/app/components/config-pki-ca.js
+++ b/ui/app/components/config-pki-ca.js
@@ -167,7 +167,7 @@ export default Component.extend({
         .destroyRecord()
         .then(() => {
           this.flashMessages.success(
-            `The CA key for ${backend} has been deleted. The old CA certificate will still be accessible for reading until a new certificate/key is generated or uploaded.`
+            `The CA key for ${backend} has been deleted. The old CA certificate will still be accessible for reading until a new certificate/key are generated or uploaded.`
           );
         })
         .finally(() => {

--- a/ui/app/components/config-pki-ca.js
+++ b/ui/app/components/config-pki-ca.js
@@ -167,7 +167,7 @@ export default Component.extend({
         .destroyRecord()
         .then(() => {
           this.flashMessages.success(
-            `The CA key for ${backend} has been deleted. The old CA certificate will still be accessible for reading until a new certificate/key are generated or uploaded.`
+            `The CA key for ${backend} has been deleted. The old CA certificate will still be accessible for reading until a new certificate/key is generated or uploaded.`
           );
         })
         .finally(() => {

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -52,7 +52,7 @@
             <ConfirmAction
               @buttonClasses="button"
               @confirmTitle="Delete this CA key?"
-              @confirmMessage="This CA certificate will still be available for reading until a new certificate/key are generated or uploaded."
+              @confirmMessage="This CA certificate will still be available for reading until a new certificate/key is generated or uploaded."
               @onConfirmAction={{action "deleteCA"}}
             >
               Delete

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -52,7 +52,7 @@
             <ConfirmAction
               @buttonClasses="button"
               @confirmTitle="Delete this CA key?"
-              @confirmMessage="This CA certificate will still be available for reading until a new certificate/key is generated or uploaded."
+              @confirmMessage="This CA certificate will still be available for reading until a new certificate/key are generated or uploaded."
               @onConfirmAction={{action "deleteCA"}}
             >
               Delete

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1175,7 +1175,7 @@ $ curl \
 ## Delete Root
 
 This endpoint deletes the current CA key (the old CA certificate will still be
-accessible for reading until a new certificate/key are generated or uploaded).
+accessible for reading until a new certificate/key is generated or uploaded).
 _This endpoint requires sudo/root privileges._
 
 | Method   | Path        |

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1175,7 +1175,7 @@ $ curl \
 ## Delete Root
 
 This endpoint deletes the current CA key (the old CA certificate will still be
-accessible for reading until a new certificate/key is generated or uploaded).
+accessible for reading until a new certificate/key are generated or uploaded).
 _This endpoint requires sudo/root privileges._
 
 | Method   | Path        |


### PR DESCRIPTION
Hi there! First time contributing, just noticed this _possible_ grammar error and made a PR for clarification. 

Is `certificate/key` intended to be interchangeable (as in "certificate or key") or are both created?

If the latter, then perhaps adjust text to explicitly say `certificate and key` ?

Cheers and thanks!
Claire


Also thank you @s-christoff for helping navigate HashiCorp contributing docs