### PR TITLE
When a standby does a ForwardRequest, it's not using the request cont…

### DIFF
--- a/changelog/11322.txt
+++ b/changelog/11322.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: requests forwarded by standby weren't always timed out.
+```

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -352,7 +352,7 @@ func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, erro
 		c.logger.Error("got nil forwarding RPC request")
 		return 0, nil, nil, fmt.Errorf("got nil forwarding RPC request")
 	}
-	resp, err := c.rpcForwardingClient.ForwardRequest(c.rpcClientConnContext, freq)
+	resp, err := c.rpcForwardingClient.ForwardRequest(req.Context(), freq)
 	if err != nil {
 		c.logger.Error("error during forwarded RPC request", "error", err)
 		return 0, nil, nil, fmt.Errorf("error during forwarding RPC request")


### PR DESCRIPTION
…ext, and thus not getting timed out properly when it takes too long. (#11322)

The rpcClientConnContext is still used to terminate gRPC internal/dialer-related goroutines, but the actual RPC is now timed out when the request times out, e.g. due to the default max request duration.  This mirrors what we do with the parallel forwarding code in ENT.