### PR TITLE
Don't cut off stack traces at 32MB.

### DIFF
--- a/changelog/11364.txt
+++ b/changelog/11364.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: allow arbitrary length stack traces upon receiving SIGUSR2 (was 32MB)
+```

--- a/command/server.go
+++ b/command/server.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"
@@ -1969,9 +1970,8 @@ CLUSTER_SYNTHESIS_COMPLETE:
 			}
 
 		case <-c.SigUSR2Ch:
-			buf := make([]byte, 32*1024*1024)
-			n := runtime.Stack(buf[:], true)
-			c.logger.Info("goroutine trace", "stack", string(buf[:n]))
+			logWriter := c.logger.StandardWriter(&hclog.StandardLoggerOptions{})
+			pprof.Lookup("goroutine").WriteTo(logWriter, 2)
 		}
 	}
 


### PR DESCRIPTION
I couldn't find a way to maintain the existing prefix "goroutine trace" prefix, but I think that's okay.  The result looks like this:

```
2021-04-15T13:44:42.714-0400 [INFO]  secrets.kv.kv_77220184: upgrading keys finished
2021-04-15T13:44:48.846-0400 [INFO]  goroutine 1 [running]:
runtime/pprof.writeGoroutineStacks(0x63b2400, 0xc00061ad80, 0xd0, 0x55a9bc0)
        /Users/ncc/go/go1.16.2/src/runtime/pprof/pprof.go:693 +0x9f

```