### PR TITLE
Cassandra: root_rotation_statements workaround for special chars

### DIFF
--- a/website/content/api-docs/secret/databases/cassandra.mdx
+++ b/website/content/api-docs/secret/databases/cassandra.mdx
@@ -175,3 +175,16 @@ list the plugin does not support that statement type.
   serialized JSON string array, or a base64-encoded serialized JSON string
   array. The '{{username}}' value will be substituted. If not provided, defaults to
   a generic drop user statement
+
+- `root_rotation_statements` `(list: [])` - Specifies the database statements
+  to be executed when rotating the root user's password. Must be a
+  semicolon-separated string, a base64-encoded semicolon-separated string, a
+  serialized JSON string array, or a base64-encoded serialized JSON string
+  array. The '{{username}}' value will be substituted. If not provided, defaults to
+  a reasonable default alter user statement.
+
+~> Prior to Vault 1.7.1 and 1.6.4 the default `root_rotation_statements` does not
+  allow for usernames with special characters in them due to missing quotes
+  around the username. To fix this issue in versions prior to Vault 1.7.1/1.6.4,
+  specify the following `root_rotation_statements`:<br/>
+  `ALTER USER '{{username}}' WITH PASSWORD '{{password}}';`


### PR DESCRIPTION
Updates the docs for Cassandra DB engine to include a workaround for using special characters in the root username.