### PR TITLE
Backport 1.6: Fix goroutine leak caused by updating rate quotas (#11371)

### DIFF
--- a/changelog/11371.txt
+++ b/changelog/11371.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix goroutine leak when updating rate limit quota
+```

--- a/helper/metricsutil/wrapped_metrics.go
+++ b/helper/metricsutil/wrapped_metrics.go
@@ -110,7 +110,9 @@ func NamespaceLabel(ns *namespace.Namespace) metrics.Label {
 	case ns.ID == namespace.RootNamespaceID:
 		return metrics.Label{"namespace", "root"}
 	default:
-		return metrics.Label{"namespace",
-			strings.Trim(ns.Path, "/")}
+		return metrics.Label{
+			"namespace",
+			strings.Trim(ns.Path, "/"),
+		}
 	}
 }

--- a/vault/quotas/quotas_rate_limit.go
+++ b/vault/quotas/quotas_rate_limit.go
@@ -319,6 +319,7 @@ func (rlq *RateLimitQuota) allow(req *Request) (Response, error) {
 }
 
 // close stops the current running client purge loop.
+// It should be called with the write lock held.
 func (rlq *RateLimitQuota) close() error {
 	if rlq.purgeBlocked {
 		close(rlq.closePurgeBlockedCh)


### PR DESCRIPTION
Make sure that when we modify a rate quota, we stop the existing goroutine before starting the new one.

I didn't backport the test changes because it got messy.