### PR TITLE
Backport (1.7.x): Cassandra DB plugin: Allow special chars in usernames (#11262)

### DIFF
--- a/changelog/11262.txt
+++ b/changelog/11262.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/database/cassandra: Updated default statement for password rotation to allow for special characters. This applies to root and static credentials.
+```

--- a/plugins/database/cassandra/cassandra.go
+++ b/plugins/database/cassandra/cassandra.go
@@ -17,7 +17,7 @@ import (
 const (
 	defaultUserCreationCQL   = `CREATE USER '{{username}}' WITH PASSWORD '{{password}}' NOSUPERUSER;`
 	defaultUserDeletionCQL   = `DROP USER '{{username}}';`
-	defaultChangePasswordCQL = `ALTER USER {{username}} WITH PASSWORD '{{password}}';`
+	defaultChangePasswordCQL = `ALTER USER '{{username}}' WITH PASSWORD '{{password}}';`
 	cassandraTypeName        = "cassandra"
 
 	defaultUserNameTemplate = `{{ printf "v_%s_%s_%s_%s" (.DisplayName | truncate 15) (.RoleName | truncate 15) (random 20) (unix_time) | truncate 100 | replace "-" "_" | lowercase }}`


### PR DESCRIPTION
Backports #11262 to 1.7.x

Allows special characters in Cassandra root user.