### PR TITLE
Backport 1.7.1: pki: fix tidy removal on revoked entries (#11367)

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"math/big"
 	mathrand "math/rand"
@@ -2979,6 +2980,7 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 	secret, err = client.Logical().Write("pki/root/sign-intermediate", map[string]interface{}{
 		"permitted_dns_domains": ".myvault.com",
 		"csr":                   intermediateCSR,
+		"ttl":                   "10s",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -3017,14 +3019,77 @@ func TestBackend_RevokePlusTidy_Intermediate(t *testing.T) {
 	// Sleep a bit to make sure we're past the safety buffer
 	time.Sleep(2 * time.Second)
 
-	// Attempt to read the intermediate cert after revoke + tidy, and ensure
-	// that it's no longer present
-	secret, err = client.Logical().Read("pki/cert/" + intermediateCASerialColon)
+	// Get CRL and ensure the tidied cert is still in the list after the tidy
+	// operation since it's not past the NotAfter (ttl) value yet.
+	req := client.NewRequest("GET", "/v1/pki/crl")
+	resp, err := client.RawRequest(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if secret != nil {
-		t.Fatalf("expected empty response data, got: %#v", secret.Data)
+	defer resp.Body.Close()
+
+	crlBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(crlBytes) == 0 {
+		t.Fatalf("expected CRL in response body")
+	}
+
+	crl, err := x509.ParseDERCRL(crlBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	revokedCerts := crl.TBSCertList.RevokedCertificates
+	if len(revokedCerts) == 0 {
+		t.Fatal("expected CRL to be non-empty")
+	}
+
+	sn := certutil.GetHexFormatted(revokedCerts[0].SerialNumber.Bytes(), ":")
+	if sn != intermediateCertSerial {
+		t.Fatalf("expected: %v, got: %v", intermediateCertSerial, sn)
+	}
+
+	// Wait for cert to expire
+	time.Sleep(10 * time.Second)
+
+	// Issue a tidy on /pki
+	_, err = client.Logical().Write("pki/tidy", map[string]interface{}{
+		"tidy_cert_store":    true,
+		"tidy_revoked_certs": true,
+		"safety_buffer":      "1s",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sleep a bit to make sure we're past the safety buffer
+	time.Sleep(2 * time.Second)
+
+	req = client.NewRequest("GET", "/v1/pki/crl")
+	resp, err = client.RawRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	crlBytes, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(crlBytes) == 0 {
+		t.Fatalf("expected CRL in response body")
+	}
+
+	crl, err = x509.ParseDERCRL(crlBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	revokedCerts = crl.TBSCertList.RevokedCertificates
+	if len(revokedCerts) != 0 {
+		t.Fatal("expected CRL to be empty")
 	}
 
 }

--- a/changelog/11367.txt
+++ b/changelog/11367.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+pki: Only remove revoked entry for certificates during tidy if they are past their NotAfter value
+```

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1573,9 +1573,11 @@ expiration time.
 - `tidy_cert_store` `(bool: false)` Specifies whether to tidy up the certificate
   store.
 
-- `tidy_revoked_certs` `(bool: false)` Set to true to expire all revoked and
-  expired certificates, removing them both from the CRL and from storage. The
-  CRL will be rotated if this causes any values to be removed.
+- `tidy_revoked_certs` `(bool: false)` Set to true to remove all invalid and
+  expired certificates from storage. A revoked storage entry is considered
+  invalid if the entry is empty, or the value within the entry is empty. If a
+  certificate is removed due to expiry, the entry will also be removed from the
+  CRL, and the CRL will be rotated.
 
 - `safety_buffer` `(string: "")` Specifies A duration (given as an integer
   number of seconds or a string; defaults to `72h`) used as a safety buffer to
@@ -1605,29 +1607,29 @@ $ curl \
 
 # Cluster Scalability
 
-Most non-introspection operations in the PKI secrets engine require a write to 
-storage, and so are forwarded to the cluster's active node for execution.  
-This table outlines which operations can be executed on performance standbys 
+Most non-introspection operations in the PKI secrets engine require a write to
+storage, and so are forwarded to the cluster's active node for execution.
+This table outlines which operations can be executed on performance standbys
 and thus scale horizontally.
 
 | Path                        | Operations          |
-| --------------------------- | ------------------- | 
-| ca[/pem]                    | Read                | 
-| cert/<em>serial-number</em> | Read                | 
+| --------------------------- | ------------------- |
+| ca[/pem]                    | Read                |
+| cert/<em>serial-number</em> | Read                |
 | cert/ca_chain               | Read                |
 | config/crl                  | Read                |
-| certs                       | List                | 
+| certs                       | List                |
 | ca_chain                    | Read                |
 | crl[/pem]                   | Read                |
-| crl/pem                     | Read                | 
+| crl/pem                     | Read                |
 | issue                       | Update <sup>*</sup> |
 | revoked/*                   | Read, List          |
 | sign                        | Update <sup>*</sup> |
 | sign-verbatim               | Update <sup>*</sup> |
 
 \* Only if the corresponding role has `no_store` set to true and `generate_lease`
-set to false.  If `generate_lease` is true the lease creation will be forwarded to 
-the active node; if `no_store` is false the entire request will be forwarded to 
+set to false.  If `generate_lease` is true the lease creation will be forwarded to
+the active node; if `no_store` is false the entire request will be forwarded to
 the active node.
 
 


### PR DESCRIPTION
* pki: fix tidy removal on revoked entries

* add CL entry