### PR TITLE
Add root rotation statement support to mongoDB

### DIFF
--- a/changelog/11404.txt
+++ b/changelog/11404.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Add root rotation statements support to appropriate database secret engine plugins
+```

--- a/ui/app/models/database/connection.js
+++ b/ui/app/models/database/connection.js
@@ -20,6 +20,7 @@ const AVAILABLE_PLUGIN_TYPES = [
       { attr: 'username_template', group: 'pluginConfig' },
       { attr: 'tls', group: 'pluginConfig', subgroup: 'TLS options' },
       { attr: 'tls_ca', group: 'pluginConfig', subgroup: 'TLS options' },
+      { attr: 'root_rotation_statements', group: 'statements' },
     ],
   },
   {
@@ -37,6 +38,7 @@ const AVAILABLE_PLUGIN_TYPES = [
       { attr: 'max_open_connections', group: 'pluginConfig' },
       { attr: 'max_idle_connections', group: 'pluginConfig' },
       { attr: 'max_connection_lifetime', group: 'pluginConfig' },
+      { attr: 'root_rotation_statements', group: 'statements' },
     ],
   },
 ];


### PR DESCRIPTION
Fix adds support for `root_rotation_statements` for create connection form, as according to [this chart](https://www.vaultproject.io/docs/secrets/databases#database-capabilities)

<img width="926" alt="Screen Shot 2021-04-19 at 2 13 33 PM" src="https://user-images.githubusercontent.com/82459713/115290669-6f63d500-a119-11eb-8edd-f980f24c3ce6.png">
