### PR TITLE
Updates docs for G Suite config in JWT/OIDC auth method

### DIFF
--- a/website/content/api-docs/auth/jwt.mdx
+++ b/website/content/api-docs/auth/jwt.mdx
@@ -41,7 +41,7 @@ set.
 - `bound_issuer` `(string: <optional>)` - The value against which to match the `iss` claim in a JWT.
 - `jwt_supported_algs` `(comma-separated string, or array of strings: <optional>)` - A list of supported signing algorithms. Defaults to [RS256] for OIDC roles. Defaults to all [available algorithms](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/master/vendor/github.com/hashicorp/cap/jwt/algs.go#L12-L21) for JWT roles.
 - `default_role` `(string: <optional>)` - The default role to use if none is provided during login.
-- `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include Azure; the options are described in each provider's section in [OIDC Provider Setup](/docs/auth/jwt_oidc_providers)
+- `provider_config` `(map: <optional>)` - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google. The options are described in each provider's section in [OIDC Provider Setup](/docs/auth/jwt_oidc_providers).
 - `namespace_in_state` `(bool: true)` - Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.
 
 ### Sample Payload

--- a/website/content/docs/auth/jwt_oidc_providers.mdx
+++ b/website/content/docs/auth/jwt_oidc_providers.mdx
@@ -60,7 +60,7 @@ You should set up a [Vault policy](https://learn.hashicorp.com/tutorials/vault/p
 1. In Vault, enable the OIDC auth method.
 
 1. Configure the OIDC auth method with the `oidc_client_id` (application ID), `oidc_client_secret`
-   (client secret), and `oidc_discovery_url` (endpoint URL) you recorded from Azure. 
+   (client secret), and `oidc_discovery_url` (endpoint URL) you recorded from Azure.
    ```shell
    vault write auth/oidc/config \
       oidc_client_id="your_client_id" \
@@ -101,7 +101,7 @@ You should set up a [Vault policy](https://learn.hashicorp.com/tutorials/vault/p
       canonical_id="vault_external_group_id"
    ```
 
-### Azure-specific handling configuration
+### Optional Azure-specific Configuration
 
 If a user is a member of more than 200 groups (directly or indirectly), extra configuration
 is required so that Vault can fetch the groups properly.
@@ -161,9 +161,9 @@ Main reference: [Using OAuth 2.0 to Access Google APIs](https://developers.googl
 1. Configure Authorized Redirect URIs.
 1. Save client ID and secret.
 
-### Google-specific handling configuration
+### Optional Google-specific Configuration
 
-Provider specific configuration is available when using Google as an identity provider from the
+Google-specific configuration is available when using Google as an identity provider from the
 Vault JWT/OIDC auth method. The configuration allows Vault to obtain G Suite group membership and
 user information during the JWT/OIDC authentication flow. The group membership obtained from G Suite
 may be used for Identity group alias association. The user information obtained from G Suite can be
@@ -200,8 +200,9 @@ host that Vault is running on.
 #### Configuration
 
 - `provider` `(string: <required>)` - Name of the provider. Must be set to "gsuite".
-- `gsuite_service_account` `(string: <required>)` - Path to the Google service account key file obtained
-  from setup. The path must refer to a file that's readable on the host that Vault is running on.
+- `gsuite_service_account` `(string: <required>)` - Either the path to or the contents of a Google service
+  account key file in JSON format. If given as a file path, it must refer to a file that's readable on
+  the host that Vault is running on. If given directly as JSON contents, the JSON must be properly escaped.
 - `gsuite_admin_impersonate` `(string: <required>)` - Email address of a G Suite admin to impersonate.
 - `fetch_groups` `(bool: false)` - If set to true, groups will be fetched from G Suite.
 - `fetch_user_info` `(bool: false)` - If set to true, user info will be fetched from G Suite using the configured [user_custom_schemas](#user_custom_schemas).


### PR DESCRIPTION
This PR updates documentation for the G Suite configuration available in the JWT/OIDC auth method. It updates the `gsuite_service_account` description to include a new enhancement introduced in https://github.com/hashicorp/vault/pull/11388.

Additionally, this PR seeks to make it more obvious that the provider-specific configuration for Azure and Google is optional.