### PR TITLE
Fixed duplicate path issue for kv engine

### DIFF
--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -199,6 +199,13 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
       secretData.set(secretData.pathAttr, key);
     }
 
+    if (this.mode === 'create') {
+      key = JSON.stringify({
+        backend: secret.backend,
+        id: key,
+      });
+    }
+
     return secretData
       .save()
       .then(() => {
@@ -323,8 +330,14 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
         return;
       }
 
-      this.persistKey(() => {
-        this.transitionToRoute(SHOW_ROUTE, this.model.path || this.model.id);
+      this.persistKey(key => {
+        let secretKey;
+        try {
+          secretKey = JSON.parse(key).id;
+        } catch (error) {
+          secretKey = key;
+        }
+        this.transitionToRoute(SHOW_ROUTE, secretKey);
       });
     },
 


### PR DESCRIPTION
- Ids used to collide in ember data while creating a secret with any existing
path name from a different kv engine