### PR TITLE
builtin: deprecate errwrap.Wrapf() throughout

### DIFF
--- a/audit/format.go
+++ b/audit/format.go
@@ -10,7 +10,6 @@ import (
 
 	squarejwt "gopkg.in/square/go-jose.v2/jwt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/helper/salt"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -48,7 +47,7 @@ func (f *AuditFormatter) FormatRequest(ctx context.Context, w io.Writer, config 
 
 	salt, err := f.Salt(ctx)
 	if err != nil {
-		return errwrap.Wrapf("error fetching salt: {{err}}", err)
+		return fmt.Errorf("error fetching salt: %w", err)
 	}
 
 	// Set these to the input values at first
@@ -159,7 +158,7 @@ func (f *AuditFormatter) FormatResponse(ctx context.Context, w io.Writer, config
 
 	salt, err := f.Salt(ctx)
 	if err != nil {
-		return errwrap.Wrapf("error fetching salt: {{err}}", err)
+		return fmt.Errorf("error fetching salt: %w", err)
 	}
 
 	// Set these to the input values at first

--- a/builtin/audit/file/backend.go
+++ b/builtin/audit/file/backend.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/sdk/helper/salt"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -121,7 +120,7 @@ func Factory(ctx context.Context, conf *audit.BackendConfig) (audit.Backend, err
 		// otherwise it will be too late to catch later without problems
 		// (ref: https://github.com/hashicorp/vault/issues/550)
 		if err := b.open(); err != nil {
-			return nil, errwrap.Wrapf(fmt.Sprintf("sanity check failed; unable to open %q for writing: {{err}}", path), err)
+			return nil, fmt.Errorf("sanity check failed; unable to open %q for writing: %w", path, err)
 		}
 	}
 

--- a/builtin/credential/app-id/path_login.go
+++ b/builtin/credential/app-id/path_login.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/policyutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -169,7 +168,7 @@ func (b *backend) verifyCredentials(ctx context.Context, req *logical.Request, a
 	if raw, ok := appsMap["cidr_block"]; ok {
 		_, cidr, err := net.ParseCIDR(raw.(string))
 		if err != nil {
-			return "", nil, errwrap.Wrapf("invalid restriction cidr: {{err}}", err)
+			return "", nil, fmt.Errorf("invalid restriction cidr: %w", err)
 		}
 
 		var addr string

--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
@@ -654,7 +653,7 @@ func (b *backend) pathRoleSecretIDList(ctx context.Context, req *logical.Request
 
 	roleNameHMAC, err := createHMAC(role.HMACKey, role.name)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to create HMAC of role_name: {{err}}", err)
+		return nil, fmt.Errorf("failed to create HMAC of role_name: %w", err)
 	}
 
 	// Listing works one level at a time. Get the first level of data
@@ -750,7 +749,7 @@ func (b *backend) setRoleEntry(ctx context.Context, s logical.Storage, roleName 
 	// Check if the index from the role_id to role already exists
 	roleIDIndex, err := b.roleIDEntry(ctx, s, role.RoleID)
 	if err != nil {
-		return errwrap.Wrapf("failed to read role_id index: {{err}}", err)
+		return fmt.Errorf("failed to read role_id index: %w", err)
 	}
 
 	// If the entry exists, make sure that it belongs to the current role
@@ -762,7 +761,7 @@ func (b *backend) setRoleEntry(ctx context.Context, s logical.Storage, roleName 
 	// a new one is created
 	if previousRoleID != "" && previousRoleID != role.RoleID {
 		if err = b.roleIDEntryDelete(ctx, s, previousRoleID); err != nil {
-			return errwrap.Wrapf("failed to delete previous role ID index: {{err}}", err)
+			return fmt.Errorf("failed to delete previous role ID index: %w", err)
 		}
 	}
 
@@ -870,7 +869,7 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 	case role == nil && req.Operation == logical.CreateOperation:
 		hmacKey, err := uuid.GenerateUUID()
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to create role_id: {{err}}", err)
+			return nil, fmt.Errorf("failed to create role_id: %w", err)
 		}
 		role = &roleStorageEntry{
 			name:              strings.ToLower(roleName),
@@ -918,7 +917,7 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 	} else if req.Operation == logical.CreateOperation {
 		roleID, err := uuid.GenerateUUID()
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to generate role_id: {{err}}", err)
+			return nil, fmt.Errorf("failed to generate role_id: %w", err)
 		}
 		role.RoleID = roleID
 	}
@@ -939,7 +938,7 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 	if len(role.SecretIDBoundCIDRs) != 0 {
 		valid, err := cidrutil.ValidateCIDRListSlice(role.SecretIDBoundCIDRs)
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to validate CIDR blocks: {{err}}", err)
+			return nil, fmt.Errorf("failed to validate CIDR blocks: %w", err)
 		}
 		if !valid {
 			return logical.ErrorResponse("invalid CIDR blocks"), nil
@@ -1064,7 +1063,7 @@ func (b *backend) pathRoleRead(ctx context.Context, req *logical.Request, data *
 			})
 			if err != nil {
 				lockRelease()
-				return nil, errwrap.Wrapf(fmt.Sprintf("failed to create secondary index for role_id %q: {{err}}", role.RoleID), err)
+				return nil, fmt.Errorf("failed to create secondary index for role_id %q: %w", role.RoleID, err)
 			}
 			resp.AddWarning("Role identifier was missing an index back to role name. A new index has been added. Please report this observation.")
 		}
@@ -1096,12 +1095,12 @@ func (b *backend) pathRoleDelete(ctx context.Context, req *logical.Request, data
 
 	// Just before the role is deleted, remove all the SecretIDs issued as part of the role.
 	if err = b.flushRoleSecrets(ctx, req.Storage, role.name, role.HMACKey, role.SecretIDPrefix); err != nil {
-		return nil, errwrap.Wrapf(fmt.Sprintf("failed to invalidate the secrets belonging to role %q: {{err}}", role.name), err)
+		return nil, fmt.Errorf("failed to invalidate the secrets belonging to role %q: %w", role.name, err)
 	}
 
 	// Delete the reverse mapping from RoleID to the role
 	if err = b.roleIDEntryDelete(ctx, req.Storage, role.RoleID); err != nil {
-		return nil, errwrap.Wrapf(fmt.Sprintf("failed to delete the mapping from RoleID to role %q: {{err}}", role.name), err)
+		return nil, fmt.Errorf("failed to delete the mapping from RoleID to role %q: %w", role.name, err)
 	}
 
 	// After deleting the SecretIDs and the RoleID, delete the role itself
@@ -1140,13 +1139,13 @@ func (b *backend) pathRoleSecretIDLookupUpdate(ctx context.Context, req *logical
 	// Create the HMAC of the secret ID using the per-role HMAC key
 	secretIDHMAC, err := createHMAC(role.HMACKey, secretID)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to create HMAC of secret_id: {{err}}", err)
+		return nil, fmt.Errorf("failed to create HMAC of secret_id: %w", err)
 	}
 
 	// Create the HMAC of the roleName using the per-role HMAC key
 	roleNameHMAC, err := createHMAC(role.HMACKey, role.name)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to create HMAC of role_name: {{err}}", err)
+		return nil, fmt.Errorf("failed to create HMAC of role_name: %w", err)
 	}
 
 	// Create the index at which the secret_id would've been stored
@@ -1168,11 +1167,11 @@ func (b *backend) pathRoleSecretIDLookupUpdate(ctx context.Context, req *logical
 	// entry, revoke the secret ID immediately
 	accessorEntry, err := b.secretIDAccessorEntry(ctx, req.Storage, secretIDEntry.SecretIDAccessor, role.SecretIDPrefix)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to read secret ID accessor entry: {{err}}", err)
+		return nil, fmt.Errorf("failed to read secret ID accessor entry: %w", err)
 	}
 	if accessorEntry == nil {
 		if err := req.Storage.Delete(ctx, entryIndex); err != nil {
-			return nil, errwrap.Wrapf(fmt.Sprintf("error deleting secret ID %q from storage: {{err}}", secretIDHMAC), err)
+			return nil, fmt.Errorf("error deleting secret ID %q from storage: %w", secretIDHMAC, err)
 		}
 		return logical.ErrorResponse("invalid secret id"), nil
 	}
@@ -1225,12 +1224,12 @@ func (b *backend) pathRoleSecretIDDestroyUpdateDelete(ctx context.Context, req *
 
 	secretIDHMAC, err := createHMAC(role.HMACKey, secretID)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to create HMAC of secret_id: {{err}}", err)
+		return nil, fmt.Errorf("failed to create HMAC of secret_id: %w", err)
 	}
 
 	roleNameHMAC, err := createHMAC(role.HMACKey, role.name)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to create HMAC of role_name: {{err}}", err)
+		return nil, fmt.Errorf("failed to create HMAC of role_name: %w", err)
 	}
 
 	entryIndex := fmt.Sprintf("%s%s/%s", role.SecretIDPrefix, roleNameHMAC, secretIDHMAC)
@@ -1254,7 +1253,7 @@ func (b *backend) pathRoleSecretIDDestroyUpdateDelete(ctx context.Context, req *
 
 	// Delete the storage entry that corresponds to the SecretID
 	if err := req.Storage.Delete(ctx, entryIndex); err != nil {
-		return nil, errwrap.Wrapf("failed to delete secret_id: {{err}}", err)
+		return nil, fmt.Errorf("failed to delete secret_id: %w", err)
 	}
 
 	return nil, nil
@@ -1299,7 +1298,7 @@ func (b *backend) pathRoleSecretIDAccessorLookupUpdate(ctx context.Context, req 
 
 	roleNameHMAC, err := createHMAC(role.HMACKey, role.name)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to create HMAC of role_name: {{err}}", err)
+		return nil, fmt.Errorf("failed to create HMAC of role_name: %w", err)
 	}
 
 	secretLock := b.secretIDLock(accessorEntry.SecretIDHMAC)
@@ -1352,7 +1351,7 @@ func (b *backend) pathRoleSecretIDAccessorDestroyUpdateDelete(ctx context.Contex
 
 	roleNameHMAC, err := createHMAC(role.HMACKey, role.name)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to create HMAC of role_name: {{err}}", err)
+		return nil, fmt.Errorf("failed to create HMAC of role_name: %w", err)
 	}
 
 	entryIndex := fmt.Sprintf("%s%s/%s", role.SecretIDPrefix, roleNameHMAC, accessorEntry.SecretIDHMAC)
@@ -1368,7 +1367,7 @@ func (b *backend) pathRoleSecretIDAccessorDestroyUpdateDelete(ctx context.Contex
 
 	// Delete the storage entry that corresponds to the SecretID
 	if err := req.Storage.Delete(ctx, entryIndex); err != nil {
-		return nil, errwrap.Wrapf("failed to delete secret_id: {{err}}", err)
+		return nil, fmt.Errorf("failed to delete secret_id: %w", err)
 	}
 
 	return nil, nil
@@ -1418,7 +1417,7 @@ func (b *backend) pathRoleBoundCIDRUpdateCommon(ctx context.Context, req *logica
 		}
 		valid, err := cidrutil.ValidateCIDRListSlice(cidrs)
 		if err != nil {
-			return logical.ErrorResponse(errwrap.Wrapf("failed to validate CIDR blocks: {{err}}", err).Error()), nil
+			return logical.ErrorResponse(fmt.Errorf("failed to validate CIDR blocks: %w", err).Error()), nil
 		}
 		if !valid {
 			return logical.ErrorResponse("failed to validate CIDR blocks"), nil
@@ -1428,7 +1427,7 @@ func (b *backend) pathRoleBoundCIDRUpdateCommon(ctx context.Context, req *logica
 	} else if cidrsIfc, ok := data.GetOk("token_bound_cidrs"); ok {
 		cidrs, err := parseutil.ParseAddrs(cidrsIfc.([]string))
 		if err != nil {
-			return logical.ErrorResponse(errwrap.Wrapf("failed to parse token_bound_cidrs: {{err}}", err).Error()), nil
+			return logical.ErrorResponse(fmt.Errorf("failed to parse token_bound_cidrs: %w", err).Error()), nil
 		}
 		role.TokenBoundCIDRs = cidrs
 	}
@@ -2271,7 +2270,7 @@ func (b *backend) pathRoleTokenMaxTTLDelete(ctx context.Context, req *logical.Re
 func (b *backend) pathRoleSecretIDUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	secretID, err := uuid.GenerateUUID()
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to generate secret_id: {{err}}", err)
+		return nil, fmt.Errorf("failed to generate secret_id: %w", err)
 	}
 	return b.handleRoleSecretIDCommon(ctx, req, data, secretID)
 }
@@ -2312,7 +2311,7 @@ func (b *backend) handleRoleSecretIDCommon(ctx context.Context, req *logical.Req
 	if len(secretIDCIDRs) != 0 {
 		valid, err := cidrutil.ValidateCIDRListSlice(secretIDCIDRs)
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to validate CIDR blocks: {{err}}", err)
+			return nil, fmt.Errorf("failed to validate CIDR blocks: %w", err)
 		}
 		if !valid {
 			return logical.ErrorResponse("failed to validate CIDR blocks"), nil
@@ -2327,7 +2326,7 @@ func (b *backend) handleRoleSecretIDCommon(ctx context.Context, req *logical.Req
 	if len(secretIDTokenCIDRs) != 0 {
 		valid, err := cidrutil.ValidateCIDRListSlice(secretIDTokenCIDRs)
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to validate token CIDR blocks: {{err}}", err)
+			return nil, fmt.Errorf("failed to validate token CIDR blocks: %w", err)
 		}
 		if !valid {
 			return logical.ErrorResponse("failed to validate token CIDR blocks"), nil
@@ -2355,7 +2354,7 @@ func (b *backend) handleRoleSecretIDCommon(ctx context.Context, req *logical.Req
 	}
 
 	if secretIDStorage, err = b.registerSecretIDEntry(ctx, req.Storage, role.name, secretID, role.HMACKey, role.SecretIDPrefix, secretIDStorage); err != nil {
-		return nil, errwrap.Wrapf("failed to store secret_id: {{err}}", err)
+		return nil, fmt.Errorf("failed to store secret_id: %w", err)
 	}
 
 	resp := &logical.Response{

--- a/builtin/credential/approle/path_tidy_user_id.go
+++ b/builtin/credential/approle/path_tidy_user_id.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
@@ -114,7 +113,7 @@ func (b *backend) tidySecretIDinternal(s logical.Storage) {
 			entryIndex := fmt.Sprintf("%s%s%s", secretIDPrefixToUse, roleNameHMAC, secretIDHMAC)
 			secretIDEntry, err := s.Get(ctx, entryIndex)
 			if err != nil {
-				return errwrap.Wrapf(fmt.Sprintf("error fetching SecretID %q: {{err}}", secretIDHMAC), err)
+				return fmt.Errorf("error fetching SecretID %q: %w", secretIDHMAC, err)
 			}
 
 			if secretIDEntry == nil {
@@ -135,12 +134,12 @@ func (b *backend) tidySecretIDinternal(s logical.Storage) {
 			// entry, revoke the secret ID immediately
 			accessorEntry, err := b.secretIDAccessorEntry(ctx, s, result.SecretIDAccessor, secretIDPrefixToUse)
 			if err != nil {
-				return errwrap.Wrapf("failed to read secret ID accessor entry: {{err}}", err)
+				return fmt.Errorf("failed to read secret ID accessor entry: %w", err)
 			}
 			if accessorEntry == nil {
 				logger.Trace("found nil accessor")
 				if err := s.Delete(ctx, entryIndex); err != nil {
-					return errwrap.Wrapf(fmt.Sprintf("error deleting secret ID %q from storage: {{err}}", secretIDHMAC), err)
+					return fmt.Errorf("error deleting secret ID %q from storage: %w", secretIDHMAC, err)
 				}
 				return nil
 			}
@@ -151,11 +150,11 @@ func (b *backend) tidySecretIDinternal(s logical.Storage) {
 				// Clean up the accessor of the secret ID first
 				err = b.deleteSecretIDAccessorEntry(ctx, s, result.SecretIDAccessor, secretIDPrefixToUse)
 				if err != nil {
-					return errwrap.Wrapf("failed to delete secret ID accessor entry: {{err}}", err)
+					return fmt.Errorf("failed to delete secret ID accessor entry: %w", err)
 				}
 
 				if err := s.Delete(ctx, entryIndex); err != nil {
-					return errwrap.Wrapf(fmt.Sprintf("error deleting SecretID %q from storage: {{err}}", secretIDHMAC), err)
+					return fmt.Errorf("error deleting SecretID %q from storage: %w", secretIDHMAC, err)
 				}
 
 				return nil

--- a/builtin/credential/aws/cli.go
+++ b/builtin/credential/aws/cli.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/awsutil"
@@ -155,7 +154,7 @@ func RetrieveCreds(accessKey, secretKey, sessionToken string, logger hclog.Logge
 
 	_, err = creds.Get()
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to retrieve credentials from credential chain: {{err}}", err)
+		return nil, fmt.Errorf("failed to retrieve credentials from credential chain: %w", err)
 	}
 	return creds, nil
 }

--- a/builtin/credential/aws/client.go
+++ b/builtin/credential/aws/client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/vault/sdk/helper/awsutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -117,12 +116,12 @@ func (b *backend) getClientConfig(ctx context.Context, s logical.Storage, region
 			}
 			client := sts.New(sess)
 			if client == nil {
-				return nil, errwrap.Wrapf("could not obtain sts client: {{err}}", err)
+				return nil, fmt.Errorf("could not obtain sts client: %w", err)
 			}
 			inputParams := &sts.GetCallerIdentityInput{}
 			identity, err := client.GetCallerIdentity(inputParams)
 			if err != nil {
-				return nil, errwrap.Wrapf("unable to fetch current caller: {{err}}", err)
+				return nil, fmt.Errorf("unable to fetch current caller: %w", err)
 			}
 			if identity == nil {
 				return nil, fmt.Errorf("got nil result from GetCallerIdentity")
@@ -182,7 +181,7 @@ func (b *backend) stsRoleForAccount(ctx context.Context, s logical.Storage, acco
 	// Check if an STS configuration exists for the AWS account
 	sts, err := b.lockedAwsStsEntry(ctx, s, accountID)
 	if err != nil {
-		return "", errwrap.Wrapf(fmt.Sprintf("error fetching STS config for account ID %q: {{err}}", accountID), err)
+		return "", fmt.Errorf("error fetching STS config for account ID %q: %w", accountID, err)
 	}
 	// An empty STS role signifies the master account
 	if sts != nil {

--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -290,11 +289,11 @@ func (b *backend) roleInternal(ctx context.Context, s logical.Storage, roleName 
 
 	needUpgrade, err := b.upgradeRole(ctx, s, result)
 	if err != nil {
-		return nil, errwrap.Wrapf("error upgrading roleEntry: {{err}}", err)
+		return nil, fmt.Errorf("error upgrading roleEntry: %w", err)
 	}
 	if needUpgrade && (b.System().LocalMount() || !b.System().ReplicationState().HasState(consts.ReplicationPerformanceSecondary|consts.ReplicationPerformanceStandby)) {
 		if err = b.setRole(ctx, s, roleName, result); err != nil {
-			return nil, errwrap.Wrapf("error saving upgraded roleEntry: {{err}}", err)
+			return nil, fmt.Errorf("error saving upgraded roleEntry: %w", err)
 		}
 	}
 
@@ -574,7 +573,7 @@ func (b *backend) pathRoleDelete(ctx context.Context, req *logical.Request, data
 
 	err := req.Storage.Delete(ctx, "role/"+strings.ToLower(roleName))
 	if err != nil {
-		return nil, errwrap.Wrapf("error deleting role: {{err}}", err)
+		return nil, fmt.Errorf("error deleting role: %w", err)
 	}
 
 	b.roleCache.Delete(roleName)
@@ -923,7 +922,7 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 	if roleEntry.HMACKey == "" {
 		roleEntry.HMACKey, err = uuid.GenerateUUID()
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to generate role HMAC key: {{err}}", err)
+			return nil, fmt.Errorf("failed to generate role HMAC key: %w", err)
 		}
 	}
 

--- a/builtin/credential/aws/path_tidy_identity_accesslist.go
+++ b/builtin/credential/aws/path_tidy_identity_accesslist.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -70,7 +69,7 @@ func (b *backend) tidyAccessListIdentity(ctx context.Context, req *logical.Reque
 			for _, instanceID := range identities {
 				identityEntry, err := s.Get(ctx, identityAccessListStorage+instanceID)
 				if err != nil {
-					return errwrap.Wrapf(fmt.Sprintf("error fetching identity of instanceID %q: {{err}}", instanceID), err)
+					return fmt.Errorf("error fetching identity of instanceID %q: %w", instanceID, err)
 				}
 
 				if identityEntry == nil {
@@ -88,7 +87,7 @@ func (b *backend) tidyAccessListIdentity(ctx context.Context, req *logical.Reque
 
 				if time.Now().After(result.ExpirationTime.Add(bufferDuration)) {
 					if err := s.Delete(ctx, identityAccessListStorage+instanceID); err != nil {
-						return errwrap.Wrapf(fmt.Sprintf("error deleting identity of instanceID %q from storage: {{err}}", instanceID), err)
+						return fmt.Errorf("error deleting identity of instanceID %q from storage: %w", instanceID, err)
 					}
 				}
 			}

--- a/builtin/credential/aws/path_tidy_roletag_denylist.go
+++ b/builtin/credential/aws/path_tidy_roletag_denylist.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -74,7 +73,7 @@ func (b *backend) tidyDenyListRoleTag(ctx context.Context, req *logical.Request,
 			for _, tag := range tags {
 				tagEntry, err := s.Get(ctx, denyListRoletagStorage+tag)
 				if err != nil {
-					return errwrap.Wrapf(fmt.Sprintf("error fetching tag %q: {{err}}", tag), err)
+					return fmt.Errorf("error fetching tag %q: %w", tag, err)
 				}
 
 				if tagEntry == nil {
@@ -92,7 +91,7 @@ func (b *backend) tidyDenyListRoleTag(ctx context.Context, req *logical.Request,
 
 				if time.Now().After(result.ExpirationTime.Add(bufferDuration)) {
 					if err := s.Delete(ctx, denyListRoletagStorage+tag); err != nil {
-						return errwrap.Wrapf(fmt.Sprintf("error deleting tag %q from storage: {{err}}", tag), err)
+						return fmt.Errorf("error deleting tag %q from storage: %w", tag, err)
 					}
 				}
 			}

--- a/builtin/credential/cert/path_config.go
+++ b/builtin/credential/cert/path_config.go
@@ -2,8 +2,8 @@ package cert
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -52,7 +52,7 @@ func (b *backend) Config(ctx context.Context, s logical.Storage) (*config, error
 	var result config
 	if entry != nil {
 		if err := entry.DecodeJSON(&result); err != nil {
-			return nil, errwrap.Wrapf("error reading configuration: {{err}}", err)
+			return nil, fmt.Errorf("error reading configuration: %w", err)
 		}
 	}
 	return &result, nil

--- a/builtin/credential/cert/path_crls.go
+++ b/builtin/credential/cert/path_crls.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/fatih/structs"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -55,7 +54,7 @@ func (b *backend) populateCRLs(ctx context.Context, storage logical.Storage) err
 
 	keys, err := storage.List(ctx, "crls/")
 	if err != nil {
-		return errwrap.Wrapf("error listing CRLs: {{err}}", err)
+		return fmt.Errorf("error listing CRLs: %w", err)
 	}
 	if keys == nil || len(keys) == 0 {
 		return nil
@@ -65,7 +64,7 @@ func (b *backend) populateCRLs(ctx context.Context, storage logical.Storage) err
 		entry, err := storage.Get(ctx, "crls/"+key)
 		if err != nil {
 			b.crls = nil
-			return errwrap.Wrapf(fmt.Sprintf("error loading CRL %q: {{err}}", key), err)
+			return fmt.Errorf("error loading CRL %q: %w", key, err)
 		}
 		if entry == nil {
 			continue
@@ -74,7 +73,7 @@ func (b *backend) populateCRLs(ctx context.Context, storage logical.Storage) err
 		err = entry.DecodeJSON(&crlInfo)
 		if err != nil {
 			b.crls = nil
-			return errwrap.Wrapf(fmt.Sprintf("error decoding CRL %q: {{err}}", key), err)
+			return fmt.Errorf("error decoding CRL %q: %w", key, err)
 		}
 		b.crls[key] = crlInfo
 	}

--- a/builtin/credential/github/cli.go
+++ b/builtin/credential/github/cli.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/password"
 )
@@ -43,12 +42,12 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 				return nil, fmt.Errorf("user interrupted")
 			}
 
-			return nil, errwrap.Wrapf("An error occurred attempting to "+
+			return nil, fmt.Errorf("An error occurred attempting to "+
 				"ask for a token. The raw error message is shown below, but usually "+
 				"this is because you attempted to pipe a value into the command or "+
 				"you are executing outside of a terminal (tty). If you want to pipe "+
 				"the value, pass \"-\" as the argument to read from stdin. The raw "+
-				"error was: {{err}}", err)
+				"error was: %w", err)
 		}
 	}
 

--- a/builtin/credential/github/path_config.go
+++ b/builtin/credential/github/path_config.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/tokenutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -147,7 +146,7 @@ func (b *backend) Config(ctx context.Context, s logical.Storage) (*config, error
 	var result config
 	if entry != nil {
 		if err := entry.DecodeJSON(&result); err != nil {
-			return nil, errwrap.Wrapf("error reading configuration: {{err}}", err)
+			return nil, fmt.Errorf("error reading configuration: %w", err)
 		}
 	}
 

--- a/builtin/credential/github/path_login.go
+++ b/builtin/credential/github/path_login.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
 	"github.com/hashicorp/vault/sdk/helper/policyutil"
@@ -173,7 +172,7 @@ func (b *backend) verifyCredentials(ctx context.Context, req *logical.Request, t
 	if config.BaseURL != "" {
 		parsedURL, err := url.Parse(config.BaseURL)
 		if err != nil {
-			return nil, nil, errwrap.Wrapf("successfully parsed base_url when set but failing to parse now: {{err}}", err)
+			return nil, nil, fmt.Errorf("successfully parsed base_url when set but failing to parse now: %w", err)
 		}
 		client.BaseURL = parsedURL
 	}

--- a/builtin/credential/token/cli.go
+++ b/builtin/credential/token/cli.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/password"
 )
@@ -27,7 +26,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	if x, ok := m["lookup"]; ok {
 		parsed, err := strconv.ParseBool(x)
 		if err != nil {
-			return nil, errwrap.Wrapf("Failed to parse \"lookup\" as boolean: {{err}}", err)
+			return nil, fmt.Errorf("Failed to parse \"lookup\" as boolean: %w", err)
 		}
 		lookup = parsed
 	}
@@ -52,12 +51,12 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 				return nil, fmt.Errorf("user interrupted")
 			}
 
-			return nil, errwrap.Wrapf("An error occurred attempting to "+
+			return nil, fmt.Errorf("An error occurred attempting to "+
 				"ask for a token. The raw error message is shown below, but usually "+
 				"this is because you attempted to pipe a value into the command or "+
 				"you are executing outside of a terminal (tty). If you want to pipe "+
 				"the value, pass \"-\" as the argument to read from stdin. The raw "+
-				"error was: {{err}}", err)
+				"error was: %w", err)
 		}
 	}
 
@@ -87,7 +86,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 
 	secret, err := c.Auth().Token().LookupSelf()
 	if err != nil {
-		return nil, errwrap.Wrapf("error looking up token: {{err}}", err)
+		return nil, fmt.Errorf("error looking up token: %w", err)
 	}
 	if secret == nil {
 		return nil, fmt.Errorf("empty response from lookup-self")
@@ -98,28 +97,28 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	// mirror that data here.
 	id, err := secret.TokenID()
 	if err != nil {
-		return nil, errwrap.Wrapf("error accessing token ID: {{err}}", err)
+		return nil, fmt.Errorf("error accessing token ID: %w", err)
 	}
 	accessor, err := secret.TokenAccessor()
 	if err != nil {
-		return nil, errwrap.Wrapf("error accessing token accessor: {{err}}", err)
+		return nil, fmt.Errorf("error accessing token accessor: %w", err)
 	}
 	// This populates secret.Auth
 	_, err = secret.TokenPolicies()
 	if err != nil {
-		return nil, errwrap.Wrapf("error accessing token policies: {{err}}", err)
+		return nil, fmt.Errorf("error accessing token policies: %w", err)
 	}
 	metadata, err := secret.TokenMetadata()
 	if err != nil {
-		return nil, errwrap.Wrapf("error accessing token metadata: {{err}}", err)
+		return nil, fmt.Errorf("error accessing token metadata: %w", err)
 	}
 	dur, err := secret.TokenTTL()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting token TTL: {{err}}", err)
+		return nil, fmt.Errorf("error converting token TTL: %w", err)
 	}
 	renewable, err := secret.TokenIsRenewable()
 	if err != nil {
-		return nil, errwrap.Wrapf("error checking if token is renewable: {{err}}", err)
+		return nil, fmt.Errorf("error checking if token is renewable: %w", err)
 	}
 	return &api.Secret{
 		Auth: &api.SecretAuth{

--- a/builtin/logical/aws/client.go
+++ b/builtin/logical/aws/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/awsutil"
@@ -29,7 +28,7 @@ func getRootConfig(ctx context.Context, s logical.Storage, clientType string, lo
 	if entry != nil {
 		var config rootConfig
 		if err := entry.DecodeJSON(&config); err != nil {
-			return nil, errwrap.Wrapf("error reading root configuration: {{err}}", err)
+			return nil, fmt.Errorf("error reading root configuration: %w", err)
 		}
 
 		credsConfig.AccessKey = config.AccessKey

--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -51,7 +50,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 	// Read the policy
 	role, err := b.roleRead(ctx, req.Storage, roleName, true)
 	if err != nil {
-		return nil, errwrap.Wrapf("error retrieving role: {{err}}", err)
+		return nil, fmt.Errorf("error retrieving role: %w", err)
 	}
 	if role == nil {
 		return logical.ErrorResponse(fmt.Sprintf(

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -226,7 +226,7 @@ func (b *backend) secretAccessKeysCreate(
 		UserName: username,
 	})
 	if err != nil {
-		return nil, errwrap.Wrapf("error writing WAL entry: {{err}}", err)
+		return nil, fmt.Errorf("error writing WAL entry: %w", err)
 	}
 
 	userPath := role.UserPath
@@ -246,8 +246,8 @@ func (b *backend) secretAccessKeysCreate(
 	_, err = iamClient.CreateUser(createUserRequest)
 	if err != nil {
 		if walErr := framework.DeleteWAL(ctx, s, walID); walErr != nil {
-			iamErr := errwrap.Wrapf("error creating IAM user: {{err}}", err)
-			return nil, errwrap.Wrap(errwrap.Wrapf("failed to delete WAL entry: {{err}}", walErr), iamErr)
+			iamErr := fmt.Errorf("error creating IAM user: %w", err)
+			return nil, errwrap.Wrap(fmt.Errorf("failed to delete WAL entry: %w", walErr), iamErr)
 		}
 		return logical.ErrorResponse("Error creating IAM user: %s", err), awsutil.CheckAWSError(err)
 	}
@@ -318,7 +318,7 @@ func (b *backend) secretAccessKeysCreate(
 	// the secret because it'll get rolled back anyways, so we have to return
 	// an error here.
 	if err := framework.DeleteWAL(ctx, s, walID); err != nil {
-		return nil, errwrap.Wrapf("failed to commit WAL entry: {{err}}", err)
+		return nil, fmt.Errorf("failed to commit WAL entry: %w", err)
 	}
 
 	// Return the info!

--- a/builtin/logical/cassandra/secret_creds.go
+++ b/builtin/logical/cassandra/secret_creds.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -45,7 +44,7 @@ func (b *backend) secretCredsRenew(ctx context.Context, req *logical.Request, d 
 
 	role, err := getRole(ctx, req.Storage, roleName)
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to load role: {{err}}", err)
+		return nil, fmt.Errorf("unable to load role: %w", err)
 	}
 
 	resp := &logical.Response{Secret: req.Secret}

--- a/builtin/logical/cassandra/util.go
+++ b/builtin/logical/cassandra/util.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/tlsutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -54,12 +53,12 @@ func createSession(cfg *sessionConfig, s logical.Storage) (*gocql.Session, error
 
 			parsedCertBundle, err := certBundle.ToParsedCertBundle()
 			if err != nil {
-				return nil, errwrap.Wrapf("failed to parse certificate bundle: {{err}}", err)
+				return nil, fmt.Errorf("failed to parse certificate bundle: %w", err)
 			}
 
 			tlsConfig, err = parsedCertBundle.GetTLSConfig(certutil.TLSClient)
 			if err != nil || tlsConfig == nil {
-				return nil, errwrap.Wrapf(fmt.Sprintf("failed to get TLS configuration: tlsConfig: %#v; {{err}}", tlsConfig), err)
+				return nil, fmt.Errorf("failed to get TLS configuration: tlsConfig: %#v; %w", tlsConfig, err)
 			}
 			tlsConfig.InsecureSkipVerify = cfg.InsecureTLS
 
@@ -83,13 +82,13 @@ func createSession(cfg *sessionConfig, s logical.Storage) (*gocql.Session, error
 
 	session, err := clusterConfig.CreateSession()
 	if err != nil {
-		return nil, errwrap.Wrapf("error creating session: {{err}}", err)
+		return nil, fmt.Errorf("error creating session: %w", err)
 	}
 
 	// Verify the info
 	err = session.Query(`LIST USERS`).Exec()
 	if err != nil {
-		return nil, errwrap.Wrapf("error validating connection info: {{err}}", err)
+		return nil, fmt.Errorf("error validating connection info: %w", err)
 	}
 
 	return session, nil

--- a/builtin/logical/consul/path_config.go
+++ b/builtin/logical/consul/path_config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -70,7 +69,7 @@ func (b *backend) readConfigAccess(ctx context.Context, storage logical.Storage)
 
 	conf := &accessConfig{}
 	if err := entry.DecodeJSON(conf); err != nil {
-		return nil, nil, errwrap.Wrapf("error reading consul access configuration: {{err}}", err)
+		return nil, nil, fmt.Errorf("error reading consul access configuration: %w", err)
 	}
 
 	return conf, nil, nil

--- a/builtin/logical/consul/path_token.go
+++ b/builtin/logical/consul/path_token.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -36,7 +35,7 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 
 	entry, err := req.Storage.Get(ctx, "policy/"+role)
 	if err != nil {
-		return nil, errwrap.Wrapf("error retrieving role: {{err}}", err)
+		return nil, fmt.Errorf("error retrieving role: %w", err)
 	}
 	if entry == nil {
 		return logical.ErrorResponse(fmt.Sprintf("role %q not found", role)), nil

--- a/builtin/logical/consul/secret_token.go
+++ b/builtin/logical/consul/secret_token.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -42,7 +41,7 @@ func (b *backend) secretTokenRenew(ctx context.Context, req *logical.Request, d 
 
 	entry, err := req.Storage.Get(ctx, "policy/"+role)
 	if err != nil {
-		return nil, errwrap.Wrapf("error retrieving role: {{err}}", err)
+		return nil, fmt.Errorf("error retrieving role: %w", err)
 	}
 	if entry == nil {
 		return logical.ErrorResponse(fmt.Sprintf("issuing role %q not found", role)), nil

--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	v4 "github.com/hashicorp/vault/sdk/database/dbplugin"
@@ -135,7 +134,7 @@ type databaseBackend struct {
 func (b *databaseBackend) DatabaseConfig(ctx context.Context, s logical.Storage, name string) (*DatabaseConfig, error) {
 	entry, err := s.Get(ctx, fmt.Sprintf("config/%s", name))
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to read connection configuration: {{err}}", err)
+		return nil, fmt.Errorf("failed to read connection configuration: %w", err)
 	}
 	if entry == nil {
 		return nil, fmt.Errorf("failed to find entry for connection with name: %q", name)

--- a/builtin/logical/database/path_config_connection.go
+++ b/builtin/logical/database/path_config_connection.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/fatih/structs"
-	"github.com/hashicorp/errwrap"
 	uuid "github.com/hashicorp/go-uuid"
 	v5 "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/framework"
@@ -225,7 +224,7 @@ func (b *databaseBackend) connectionDeleteHandler() framework.OperationFunc {
 
 		err := req.Storage.Delete(ctx, fmt.Sprintf("config/%s", name))
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to delete connection configuration: {{err}}", err)
+			return nil, fmt.Errorf("failed to delete connection configuration: %w", err)
 		}
 
 		if err := b.ClearConnection(name); err != nil {

--- a/builtin/logical/database/rotation.go
+++ b/builtin/logical/database/rotation.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	v4 "github.com/hashicorp/vault/sdk/database/dbplugin"
 	v5 "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
@@ -354,7 +353,7 @@ func (b *databaseBackend) setStaticAccount(ctx context.Context, s logical.Storag
 			LastVaultRotation: input.Role.StaticAccount.LastVaultRotation,
 		})
 		if err != nil {
-			return output, errwrap.Wrapf("error writing WAL entry: {{err}}", err)
+			return output, fmt.Errorf("error writing WAL entry: %w", err)
 		}
 	}
 
@@ -370,7 +369,7 @@ func (b *databaseBackend) setStaticAccount(ctx context.Context, s logical.Storag
 	_, err = dbi.database.UpdateUser(ctx, updateReq, false)
 	if err != nil {
 		b.CloseIfShutdown(dbi, err)
-		return output, errwrap.Wrapf("error setting credentials: {{err}}", err)
+		return output, fmt.Errorf("error setting credentials: %w", err)
 	}
 
 	// Store updated role information

--- a/builtin/logical/mssql/secret_creds.go
+++ b/builtin/logical/mssql/secret_creds.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/dbtxn"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -140,10 +139,10 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, d
 
 	// can't drop if not all database users are dropped
 	if rows.Err() != nil {
-		return nil, errwrap.Wrapf("could not generate sql statements for all rows: {{err}}", rows.Err())
+		return nil, fmt.Errorf("could not generate sql statements for all rows: %w", rows.Err())
 	}
 	if lastStmtError != nil {
-		return nil, errwrap.Wrapf("could not perform all sql statements: {{err}}", lastStmtError)
+		return nil, fmt.Errorf("could not perform all sql statements: %w", lastStmtError)
 	}
 
 	// Drop this login

--- a/builtin/logical/nomad/path_config_access.go
+++ b/builtin/logical/nomad/path_config_access.go
@@ -2,8 +2,8 @@ package nomad
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -76,7 +76,7 @@ func (b *backend) readConfigAccess(ctx context.Context, storage logical.Storage)
 
 	conf := &accessConfig{}
 	if err := entry.DecodeJSON(conf); err != nil {
-		return nil, errwrap.Wrapf("error reading nomad access configuration: {{err}}", err)
+		return nil, fmt.Errorf("error reading nomad access configuration: %w", err)
 	}
 
 	return conf, nil

--- a/builtin/logical/nomad/path_creds_create.go
+++ b/builtin/logical/nomad/path_creds_create.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -42,7 +41,7 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 
 	role, err := b.Role(ctx, req.Storage, name)
 	if err != nil {
-		return nil, errwrap.Wrapf("error retrieving role: {{err}}", err)
+		return nil, fmt.Errorf("error retrieving role: %w", err)
 	}
 	if role == nil {
 		return logical.ErrorResponse(fmt.Sprintf("role %q not found", name)), nil

--- a/builtin/logical/nomad/path_roles.go
+++ b/builtin/logical/nomad/path_roles.go
@@ -3,8 +3,8 @@ package nomad
 import (
 	"context"
 	"errors"
+	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -77,7 +77,7 @@ func (b *backend) Role(ctx context.Context, storage logical.Storage, name string
 
 	entry, err := storage.Get(ctx, "role/"+name)
 	if err != nil {
-		return nil, errwrap.Wrapf("error retrieving role: {{err}}", err)
+		return nil, fmt.Errorf("error retrieving role: %w", err)
 	}
 	if entry == nil {
 		return nil, nil

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -92,7 +91,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 
 		cert, err := x509.ParseCertificate(certEntry.Value)
 		if err != nil {
-			return nil, errwrap.Wrapf("error parsing certificate: {{err}}", err)
+			return nil, fmt.Errorf("error parsing certificate: %w", err)
 		}
 		if cert == nil {
 			return nil, fmt.Errorf("got a nil certificate")
@@ -132,7 +131,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 	case errutil.UserError:
 		return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil
 	case errutil.InternalError:
-		return nil, errwrap.Wrapf("error encountered during CRL building: {{err}}", crlErr)
+		return nil, fmt.Errorf("error encountered during CRL building: %w", crlErr)
 	}
 
 	resp := &logical.Response{

--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -2,8 +2,8 @@ package pki
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
@@ -65,7 +65,7 @@ func (b *backend) pathCAWrite(ctx context.Context, req *logical.Request, data *f
 
 	cb, err := parsedBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw values into cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw values into cert bundle: %w", err)
 	}
 
 	entry, err := logical.StorageEntryJSON("config/ca_bundle", cb)

--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -117,7 +116,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 		case errutil.UserError:
 			return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil
 		case errutil.InternalError:
-			return nil, errwrap.Wrapf("error encountered during CRL building: {{err}}", crlErr)
+			return nil, fmt.Errorf("error encountered during CRL building: %w", crlErr)
 		}
 	}
 

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
@@ -88,7 +87,7 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 
 	csrb, err := parsedBundle.ToCSRBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw CSR bundle to CSR bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw CSR bundle to CSR bundle: %w", err)
 	}
 
 	resp = &logical.Response{
@@ -198,12 +197,12 @@ func (b *backend) pathSetSignedIntermediate(ctx context.Context, req *logical.Re
 	}
 
 	if err := inputBundle.Verify(); err != nil {
-		return nil, errwrap.Wrapf("verification of parsed bundle failed: {{err}}", err)
+		return nil, fmt.Errorf("verification of parsed bundle failed: %w", err)
 	}
 
 	cb, err = inputBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw values into cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw values into cert bundle: %w", err)
 	}
 
 	entry, err = logical.StorageEntryJSON("config/ca_bundle", cb)

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -229,18 +228,18 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		case errutil.InternalError:
 			return nil, err
 		default:
-			return nil, errwrap.Wrapf("error signing/generating certificate: {{err}}", err)
+			return nil, fmt.Errorf("error signing/generating certificate: %w", err)
 		}
 	}
 
 	signingCB, err := signingBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw signing bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw signing bundle to cert bundle: %w", err)
 	}
 
 	cb, err := parsedBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw cert bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw cert bundle to cert bundle: %w", err)
 	}
 
 	respData := map[string]interface{}{
@@ -321,7 +320,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 			Value: parsedBundle.CertificateBytes,
 		})
 		if err != nil {
-			return nil, errwrap.Wrapf("unable to store certificate locally: {{err}}", err)
+			return nil, fmt.Errorf("unable to store certificate locally: %w", err)
 		}
 	}
 

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
@@ -74,7 +73,7 @@ func (b *backend) pathRotateCRLRead(ctx context.Context, req *logical.Request, d
 	case errutil.UserError:
 		return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil
 	case errutil.InternalError:
-		return nil, errwrap.Wrapf("error encountered during CRL building: {{err}}", crlErr)
+		return nil, fmt.Errorf("error encountered during CRL building: %w", crlErr)
 	default:
 		return &logical.Response{
 			Data: map[string]interface{}{

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -588,7 +587,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 	default:
 		_, err := parseOtherSANs(allowedOtherSANs)
 		if err != nil {
-			return logical.ErrorResponse(errwrap.Wrapf("error parsing allowed_other_sans: {{err}}", err).Error()), nil
+			return logical.ErrorResponse(fmt.Errorf("error parsing allowed_other_sans: %w", err).Error()), nil
 		}
 	}
 	entry.AllowedOtherSANs = allowedOtherSANs

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -158,7 +157,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 
 	cb, err := parsedBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw cert bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw cert bundle to cert bundle: %w", err)
 	}
 
 	resp := &logical.Response{
@@ -221,7 +220,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 		Value: parsedBundle.CertificateBytes,
 	})
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to store certificate locally: {{err}}", err)
+		return nil, fmt.Errorf("unable to store certificate locally: %w", err)
 	}
 
 	// For ease of later use, also store just the certificate at a known
@@ -314,17 +313,17 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 	}
 
 	if err := parsedBundle.Verify(); err != nil {
-		return nil, errwrap.Wrapf("verification of parsed bundle failed: {{err}}", err)
+		return nil, fmt.Errorf("verification of parsed bundle failed: %w", err)
 	}
 
 	signingCB, err := signingBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw signing bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw signing bundle to cert bundle: %w", err)
 	}
 
 	cb, err := parsedBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw cert bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw cert bundle to cert bundle: %w", err)
 	}
 
 	resp := &logical.Response{
@@ -371,7 +370,7 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 		Value: parsedBundle.CertificateBytes,
 	})
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to store certificate locally: {{err}}", err)
+		return nil, fmt.Errorf("unable to store certificate locally: %w", err)
 	}
 
 	if parsedBundle.Certificate.MaxPathLen == 0 {
@@ -418,7 +417,7 @@ func (b *backend) pathCASignSelfIssued(ctx context.Context, req *logical.Request
 
 	signingCB, err := signingBundle.ToCertBundle()
 	if err != nil {
-		return nil, errwrap.Wrapf("error converting raw signing bundle to cert bundle: {{err}}", err)
+		return nil, fmt.Errorf("error converting raw signing bundle to cert bundle: %w", err)
 	}
 
 	urls := &certutil.URLEntries{}
@@ -431,7 +430,7 @@ func (b *backend) pathCASignSelfIssued(ctx context.Context, req *logical.Request
 
 	newCert, err := x509.CreateCertificate(rand.Reader, cert, signingBundle.Certificate, cert.PublicKey, signingBundle.PrivateKey)
 	if err != nil {
-		return nil, errwrap.Wrapf("error signing self-issued certificate: {{err}}", err)
+		return nil, fmt.Errorf("error signing self-issued certificate: %w", err)
 	}
 	if len(newCert) == 0 {
 		return nil, fmt.Errorf("nil cert was created when signing self-issued certificate")

--- a/builtin/logical/postgresql/secret_creds.go
+++ b/builtin/logical/postgresql/secret_creds.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/dbtxn"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
@@ -219,10 +218,10 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, d
 
 		// can't drop if not all privileges are revoked
 		if rows.Err() != nil {
-			return nil, errwrap.Wrapf("could not generate revocation statements for all rows: {{err}}", rows.Err())
+			return nil, fmt.Errorf("could not generate revocation statements for all rows: %w", rows.Err())
 		}
 		if lastStmtError != nil {
-			return nil, errwrap.Wrapf("could not perform all revocation statements: {{err}}", lastStmtError)
+			return nil, fmt.Errorf("could not perform all revocation statements: %w", lastStmtError)
 		}
 
 		// Drop this user

--- a/builtin/logical/rabbitmq/path_config_connection.go
+++ b/builtin/logical/rabbitmq/path_config_connection.go
@@ -2,8 +2,8 @@ package rabbitmq
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	rabbithole "github.com/michaelklishin/rabbit-hole"
@@ -73,12 +73,12 @@ func (b *backend) pathConnectionUpdate(ctx context.Context, req *logical.Request
 		// Create RabbitMQ management client
 		client, err := rabbithole.NewClient(uri, username, password)
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to create client: {{err}}", err)
+			return nil, fmt.Errorf("failed to create client: %w", err)
 		}
 
 		// Verify that configured credentials is capable of listing
 		if _, err = client.ListUsers(); err != nil {
-			return nil, errwrap.Wrapf("failed to validate the connection: {{err}}", err)
+			return nil, fmt.Errorf("failed to validate the connection: %w", err)
 		}
 	}
 

--- a/builtin/logical/rabbitmq/secret_creds.go
+++ b/builtin/logical/rabbitmq/secret_creds.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -63,7 +62,7 @@ func (b *backend) secretCredsRevoke(ctx context.Context, req *logical.Request, d
 	}
 
 	if _, err = client.DeleteUser(username); err != nil {
-		return nil, errwrap.Wrapf("could not delete user: {{err}}", err)
+		return nil, fmt.Errorf("could not delete user: %w", err)
 	}
 
 	return nil, nil

--- a/builtin/logical/ssh/communicator.go
+++ b/builtin/logical/ssh/communicator.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 
 	"golang.org/x/crypto/ssh"
@@ -278,7 +277,7 @@ func checkSCPStatus(r *bufio.Reader) error {
 		// Treat any non-zero (really 1 and 2) as fatal errors
 		message, _, err := r.ReadLine()
 		if err != nil {
-			return errwrap.Wrapf("error reading error message: {{err}}", err)
+			return fmt.Errorf("error reading error message: %w", err)
 		}
 
 		return errors.New(string(message))
@@ -299,7 +298,7 @@ func scpUploadFile(dst string, src io.Reader, w io.Writer, r *bufio.Reader, fi *
 		// so that we can determine the length, since SCP is length-prefixed.
 		tf, err := ioutil.TempFile("", "vault-ssh-upload")
 		if err != nil {
-			return errwrap.Wrapf("error creating temporary file for upload: {{err}}", err)
+			return fmt.Errorf("error creating temporary file for upload: %w", err)
 		}
 		defer os.Remove(tf.Name())
 		defer tf.Close()
@@ -313,17 +312,17 @@ func scpUploadFile(dst string, src io.Reader, w io.Writer, r *bufio.Reader, fi *
 		// Sync the file so that the contents are definitely on disk, then
 		// read the length of it.
 		if err := tf.Sync(); err != nil {
-			return errwrap.Wrapf("error creating temporary file for upload: {{err}}", err)
+			return fmt.Errorf("error creating temporary file for upload: %w", err)
 		}
 
 		// Seek the file to the beginning so we can re-read all of it
 		if _, err := tf.Seek(0, 0); err != nil {
-			return errwrap.Wrapf("error creating temporary file for upload: {{err}}", err)
+			return fmt.Errorf("error creating temporary file for upload: %w", err)
 		}
 
 		tfi, err := tf.Stat()
 		if err != nil {
-			return errwrap.Wrapf("error creating temporary file for upload: {{err}}", err)
+			return fmt.Errorf("error creating temporary file for upload: %w", err)
 		}
 
 		size = tfi.Size()

--- a/builtin/logical/ssh/path_config_ca.go
+++ b/builtin/logical/ssh/path_config_ca.go
@@ -8,7 +8,6 @@ import (
 	"encoding/pem"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -66,7 +65,7 @@ Read operations will return the public key, if already stored/generated.`,
 func (b *backend) pathConfigCARead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	publicKeyEntry, err := caKey(ctx, req.Storage, caPublicKey)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to read CA public key: {{err}}", err)
+		return nil, fmt.Errorf("failed to read CA public key: %w", err)
 	}
 
 	if publicKeyEntry == nil {
@@ -107,7 +106,7 @@ func caKey(ctx context.Context, storage logical.Storage, keyType string) (*keySt
 
 	entry, err := storage.Get(ctx, path)
 	if err != nil {
-		return nil, errwrap.Wrapf(fmt.Sprintf("failed to read CA key of type %q: {{err}}", keyType), err)
+		return nil, fmt.Errorf("failed to read CA key of type %q: %w", keyType, err)
 	}
 
 	if entry == nil {
@@ -203,12 +202,12 @@ func (b *backend) pathConfigCAUpdate(ctx context.Context, req *logical.Request, 
 
 	publicKeyEntry, err := caKey(ctx, req.Storage, caPublicKey)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to read CA public key: {{err}}", err)
+		return nil, fmt.Errorf("failed to read CA public key: %w", err)
 	}
 
 	privateKeyEntry, err := caKey(ctx, req.Storage, caPrivateKey)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to read CA private key: {{err}}", err)
+		return nil, fmt.Errorf("failed to read CA private key: %w", err)
 	}
 
 	if (publicKeyEntry != nil && publicKeyEntry.Key != "") || (privateKeyEntry != nil && privateKeyEntry.Key != "") {
@@ -240,12 +239,12 @@ func (b *backend) pathConfigCAUpdate(ctx context.Context, req *logical.Request, 
 	if err != nil {
 		var mErr *multierror.Error
 
-		mErr = multierror.Append(mErr, errwrap.Wrapf("failed to store CA private key: {{err}}", err))
+		mErr = multierror.Append(mErr, fmt.Errorf("failed to store CA private key: %w", err))
 
 		// If storing private key fails, the corresponding public key should be
 		// removed
 		if delErr := req.Storage.Delete(ctx, caPublicKeyStoragePath); delErr != nil {
-			mErr = multierror.Append(mErr, errwrap.Wrapf("failed to cleanup CA public key: {{err}}", delErr))
+			mErr = multierror.Append(mErr, fmt.Errorf("failed to cleanup CA public key: %w", delErr))
 			return nil, mErr
 		}
 

--- a/builtin/logical/ssh/path_creds_create.go
+++ b/builtin/logical/ssh/path_creds_create.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -56,7 +55,7 @@ func (b *backend) pathCredsCreateWrite(ctx context.Context, req *logical.Request
 
 	role, err := b.getRole(ctx, req.Storage, roleName)
 	if err != nil {
-		return nil, errwrap.Wrapf("error retrieving role: {{err}}", err)
+		return nil, fmt.Errorf("error retrieving role: %w", err)
 	}
 	if role == nil {
 		return logical.ErrorResponse(fmt.Sprintf("Role %q not found", roleName)), nil
@@ -98,7 +97,7 @@ func (b *backend) pathCredsCreateWrite(ctx context.Context, req *logical.Request
 
 	zeroAddressEntry, err := b.getZeroAddressRoles(ctx, req.Storage)
 	if err != nil {
-		return nil, errwrap.Wrapf("error retrieving zero-address roles: {{err}}", err)
+		return nil, fmt.Errorf("error retrieving zero-address roles: %w", err)
 	}
 	var zeroAddressRoles []string
 	if zeroAddressEntry != nil {
@@ -172,7 +171,7 @@ func (b *backend) GenerateDynamicCredential(ctx context.Context, req *logical.Re
 	// Fetch the host key to be used for dynamic key installation
 	keyEntry, err := req.Storage.Get(ctx, fmt.Sprintf("keys/%s", role.KeyName))
 	if err != nil {
-		return "", "", errwrap.Wrapf(fmt.Sprintf("key %q not found: {{err}}", role.KeyName), err)
+		return "", "", fmt.Errorf("key %q not found: %w", role.KeyName, err)
 	}
 
 	if keyEntry == nil {
@@ -181,13 +180,13 @@ func (b *backend) GenerateDynamicCredential(ctx context.Context, req *logical.Re
 
 	var hostKey sshHostKey
 	if err := keyEntry.DecodeJSON(&hostKey); err != nil {
-		return "", "", errwrap.Wrapf("error reading the host key: {{err}}", err)
+		return "", "", fmt.Errorf("error reading the host key: %w", err)
 	}
 
 	// Generate a new RSA key pair with the given key length.
 	dynamicPublicKey, dynamicPrivateKey, err := generateRSAKeys(role.KeyBits)
 	if err != nil {
-		return "", "", errwrap.Wrapf("error generating key: {{err}}", err)
+		return "", "", fmt.Errorf("error generating key: %w", err)
 	}
 
 	if len(role.KeyOptionSpecs) != 0 {
@@ -197,7 +196,7 @@ func (b *backend) GenerateDynamicCredential(ctx context.Context, req *logical.Re
 	// Add the public key to authorized_keys file in target machine
 	err = b.installPublicKeyInTarget(ctx, role.AdminUser, username, ip, role.Port, hostKey.Key, dynamicPublicKey, role.InstallScript, true)
 	if err != nil {
-		return "", "", errwrap.Wrapf("failed to add public key to authorized_keys file in target: {{err}}", err)
+		return "", "", fmt.Errorf("failed to add public key to authorized_keys file in target: %w", err)
 	}
 	return dynamicPublicKey, dynamicPrivateKey, nil
 }

--- a/builtin/logical/ssh/path_roles.go
+++ b/builtin/logical/ssh/path_roles.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
@@ -369,7 +368,7 @@ func (b *backend) pathRoleWrite(ctx context.Context, req *logical.Request, d *fr
 	if cidrList != "" {
 		valid, err := cidrutil.ValidateCIDRListString(cidrList, ",")
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to validate cidr_list: {{err}}", err)
+			return nil, fmt.Errorf("failed to validate cidr_list: %w", err)
 		}
 		if !valid {
 			return logical.ErrorResponse("failed to validate cidr_list"), nil
@@ -381,7 +380,7 @@ func (b *backend) pathRoleWrite(ctx context.Context, req *logical.Request, d *fr
 	if excludeCidrList != "" {
 		valid, err := cidrutil.ValidateCIDRListString(excludeCidrList, ",")
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to validate exclude_cidr_list entry: {{err}}", err)
+			return nil, fmt.Errorf("failed to validate exclude_cidr_list entry: %w", err)
 		}
 		if !valid {
 			return logical.ErrorResponse(fmt.Sprintf("failed to validate exclude_cidr_list entry: %v", err)), nil

--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
@@ -163,7 +162,7 @@ func (b *backend) pathSignCertificate(ctx context.Context, req *logical.Request,
 
 	privateKeyEntry, err := caKey(ctx, req.Storage, caPrivateKey)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to read CA private key: {{err}}", err)
+		return nil, fmt.Errorf("failed to read CA private key: %w", err)
 	}
 	if privateKeyEntry == nil || privateKeyEntry.Key == "" {
 		return nil, fmt.Errorf("failed to read CA private key")
@@ -171,7 +170,7 @@ func (b *backend) pathSignCertificate(ctx context.Context, req *logical.Request,
 
 	signer, err := ssh.ParsePrivateKey([]byte(privateKeyEntry.Key))
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to parse stored CA private key: {{err}}", err)
+		return nil, fmt.Errorf("failed to parse stored CA private key: %w", err)
 	}
 
 	cBundle := creationBundle{
@@ -532,7 +531,7 @@ func (b *creationBundle) sign() (retCert *ssh.Certificate, retErr error) {
 	algo := b.Role.AlgorithmSigner
 	sig, err := sshAlgorithmSigner.SignWithAlgorithm(rand.Reader, certificateBytes, algo)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to generate signed SSH key: sign error: {{err}}", err)
+		return nil, fmt.Errorf("failed to generate signed SSH key: sign error: %w", err)
 	}
 
 	certificate.Signature = sig

--- a/builtin/logical/ssh/secret_dynamic_key.go
+++ b/builtin/logical/ssh/secret_dynamic_key.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
@@ -49,13 +48,13 @@ func (b *backend) secretDynamicKeyRevoke(ctx context.Context, req *logical.Reque
 	intSec := &sec{}
 	err := mapstructure.Decode(req.Secret.InternalData, intSec)
 	if err != nil {
-		return nil, errwrap.Wrapf("secret internal data could not be decoded: {{err}}", err)
+		return nil, fmt.Errorf("secret internal data could not be decoded: %w", err)
 	}
 
 	// Fetch the host key using the key name
 	hostKey, err := b.getKey(ctx, req.Storage, intSec.HostKeyName)
 	if err != nil {
-		return nil, errwrap.Wrapf(fmt.Sprintf("key %q not found error: {{err}}", intSec.HostKeyName), err)
+		return nil, fmt.Errorf("key %q not found error: %w", intSec.HostKeyName, err)
 	}
 	if hostKey == nil {
 		return nil, fmt.Errorf("key %q not found", intSec.HostKeyName)

--- a/builtin/logical/ssh/util.go
+++ b/builtin/logical/ssh/util.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
 	"github.com/hashicorp/vault/sdk/logical"
 
@@ -26,7 +25,7 @@ import (
 func generateRSAKeys(keyBits int) (publicKeyRsa string, privateKeyRsa string, err error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, keyBits)
 	if err != nil {
-		return "", "", errwrap.Wrapf("error generating RSA key-pair: {{err}}", err)
+		return "", "", fmt.Errorf("error generating RSA key-pair: %w", err)
 	}
 
 	privateKeyRsa = string(pem.EncodeToMemory(&pem.Block{
@@ -36,7 +35,7 @@ func generateRSAKeys(keyBits int) (publicKeyRsa string, privateKeyRsa string, er
 
 	sshPublicKey, err := ssh.NewPublicKey(privateKey.Public())
 	if err != nil {
-		return "", "", errwrap.Wrapf("error generating RSA key-pair: {{err}}", err)
+		return "", "", fmt.Errorf("error generating RSA key-pair: %w", err)
 	}
 	publicKeyRsa = "ssh-rsa " + base64.StdEncoding.EncodeToString(sshPublicKey.Marshal())
 	return
@@ -64,7 +63,7 @@ func (b *backend) installPublicKeyInTarget(ctx context.Context, adminUser, usern
 
 	err = comm.Upload(publicKeyFileName, bytes.NewBufferString(dynamicPublicKey), nil)
 	if err != nil {
-		return errwrap.Wrapf("error uploading public key: {{err}}", err)
+		return fmt.Errorf("error uploading public key: %w", err)
 	}
 
 	// Transfer the script required to install or uninstall the key to the remote
@@ -73,14 +72,14 @@ func (b *backend) installPublicKeyInTarget(ctx context.Context, adminUser, usern
 	scriptFileName := fmt.Sprintf("%s.sh", publicKeyFileName)
 	err = comm.Upload(scriptFileName, bytes.NewBufferString(installScript), nil)
 	if err != nil {
-		return errwrap.Wrapf("error uploading install script: {{err}}", err)
+		return fmt.Errorf("error uploading install script: %w", err)
 	}
 
 	// Create a session to run remote command that triggers the script to install
 	// or uninstall the key.
 	session, err := comm.NewSession()
 	if err != nil {
-		return errwrap.Wrapf("unable to create SSH Session using public keys: {{err}}", err)
+		return fmt.Errorf("unable to create SSH Session using public keys: %w", err)
 	}
 	if session == nil {
 		return fmt.Errorf("invalid session object")
@@ -118,7 +117,7 @@ func roleContainsIP(ctx context.Context, s logical.Storage, roleName string, ip 
 
 	roleEntry, err := s.Get(ctx, fmt.Sprintf("roles/%s", roleName))
 	if err != nil {
-		return false, errwrap.Wrapf("error retrieving role {{err}}", err)
+		return false, fmt.Errorf("error retrieving role %w", err)
 	}
 	if roleEntry == nil {
 		return false, fmt.Errorf("role %q not found", roleName)

--- a/builtin/logical/totp/path_code.go
+++ b/builtin/logical/totp/path_code.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	otplib "github.com/pquerna/otp"
@@ -108,7 +107,7 @@ func (b *backend) pathValidateCode(ctx context.Context, req *logical.Request, da
 			int64(key.Period)*
 			int64((2+key.Skew))))
 	if err != nil {
-		return nil, errwrap.Wrapf("error adding code to used cache: {{err}}", err)
+		return nil, fmt.Errorf("error adding code to used cache: %w", err)
 	}
 
 	return &logical.Response{

--- a/builtin/logical/totp/path_keys.go
+++ b/builtin/logical/totp/path_keys.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	otplib "github.com/pquerna/otp"
@@ -357,7 +356,7 @@ func (b *backend) pathKeyCreate(ctx context.Context, req *logical.Request, data 
 			} else {
 				barcode, err := keyObject.Image(qrSize, qrSize)
 				if err != nil {
-					return nil, errwrap.Wrapf("failed to generate QR code image: {{err}}", err)
+					return nil, fmt.Errorf("failed to generate QR code image: %w", err)
 				}
 
 				var buff bytes.Buffer

--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -2,9 +2,9 @@ package transit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -66,7 +66,7 @@ func Backend(ctx context.Context, conf *logical.BackendConfig) (*backend, error)
 		var err error
 		cacheSize, err = GetCacheSizeFromStorage(ctx, conf.StorageView)
 		if err != nil {
-			return nil, errwrap.Wrapf("Error retrieving cache size from storage: {{err}}", err)
+			return nil, fmt.Errorf("Error retrieving cache size from storage: %w", err)
 		}
 	}
 

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -3,8 +3,8 @@ package transit
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
@@ -68,7 +68,7 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 	if batchInputRaw != nil {
 		err = decodeBatchRequestItems(batchInputRaw, &batchInputItems)
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to parse batch input: {{err}}", err)
+			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}
 
 		if len(batchInputItems) == 0 {

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
@@ -231,7 +230,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	if batchInputRaw != nil {
 		err = decodeBatchRequestItems(batchInputRaw, &batchInputItems)
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to parse batch input: {{err}}", err)
+			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}
 
 		if len(batchInputItems) == 0 {

--- a/builtin/logical/transit/path_hmac.go
+++ b/builtin/logical/transit/path_hmac.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -147,7 +146,7 @@ func (b *backend) pathHMACWrite(ctx context.Context, req *logical.Request, d *fr
 		err = mapstructure.Decode(batchInputRaw, &batchInputItems)
 		if err != nil {
 			p.Unlock()
-			return nil, errwrap.Wrapf("failed to parse batch input: {{err}}", err)
+			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}
 
 		if len(batchInputItems) == 0 {
@@ -253,7 +252,7 @@ func (b *backend) pathHMACVerify(ctx context.Context, req *logical.Request, d *f
 		err := mapstructure.Decode(batchInputRaw, &batchInputItems)
 		if err != nil {
 			p.Unlock()
-			return nil, errwrap.Wrapf("failed to parse batch input: {{err}}", err)
+			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}
 
 		if len(batchInputItems) == 0 {

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/crypto/ed25519"
 
 	"github.com/fatih/structs"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -296,7 +295,7 @@ func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *f
 					} else {
 						ver, err := strconv.Atoi(k)
 						if err != nil {
-							return nil, errwrap.Wrapf(fmt.Sprintf("invalid version %q: {{err}}", k), err)
+							return nil, fmt.Errorf("invalid version %q: %w", k, err)
 						}
 						derived, err := p.GetKey(context, ver, 32)
 						if err != nil {
@@ -321,7 +320,7 @@ func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *f
 				// API
 				derBytes, err := x509.MarshalPKIXPublicKey(v.RSAKey.Public())
 				if err != nil {
-					return nil, errwrap.Wrapf("error marshaling RSA public key: {{err}}", err)
+					return nil, fmt.Errorf("error marshaling RSA public key: %w", err)
 				}
 				pemBlock := &pem.Block{
 					Type:  "PUBLIC KEY",

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
@@ -61,7 +60,7 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 	if batchInputRaw != nil {
 		err = mapstructure.Decode(batchInputRaw, &batchInputItems)
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to parse batch input: {{err}}", err)
+			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}
 
 		if len(batchInputItems) == 0 {

--- a/builtin/logical/transit/path_sign_verify.go
+++ b/builtin/logical/transit/path_sign_verify.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
@@ -272,7 +271,7 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 		err = mapstructure.Decode(batchInputRaw, &batchInputItems)
 		if err != nil {
 			p.Unlock()
-			return nil, errwrap.Wrapf("failed to parse batch input: {{err}}", err)
+			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}
 
 		if len(batchInputItems) == 0 {
@@ -379,7 +378,7 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 	if batchInputRaw != nil {
 		err := mapstructure.Decode(batchInputRaw, &batchInputItems)
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to parse batch input: {{err}}", err)
+			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}
 
 		if len(batchInputItems) == 0 {


### PR DESCRIPTION
`github.com/hashicorp/errwrap` has deprecated `Wrapf()`, and recommends using `fmt.Errorf()`.

`fmt.Errorf()` added support for error wrapping in go1.13. Vault has a hard requirement of go1.16.2, so this isn't an issue.

This PR deprecates `errwrap.Wrapf` throughout `github.com/hashicorp/vault/builtin` and all of its subpackages. I organized the PR as one-commit-per-package to aid anyone who should ever need to do a `git bisect`, but I'm just as happy to squash this into a single commit.