### PR TITLE
Do not allow OIDC key rotation to be more frequent than the RollbackManager/PeriodicFunc will enforce

### DIFF
--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -459,8 +459,8 @@ func (i *IdentityStore) pathOIDCCreateUpdateKey(ctx context.Context, req *logica
 		key.RotationPeriod = time.Duration(d.Get("rotation_period").(int)) * time.Second
 	}
 
-	if key.RotationPeriod < 1*time.Minute {
-		return logical.ErrorResponse("rotation_period must be at least one minute"), nil
+	if key.RotationPeriod < 2*time.Minute {
+		return logical.ErrorResponse("rotation_period must be at least two minutes"), nil
 	}
 
 	if verificationTTLRaw, ok := d.GetOk("verification_ttl"); ok {


### PR DESCRIPTION
Fixes #11438

#11438 documents how Vault will currently not rotate an OIDC signing key more frequently than every 2 minutes.

This PR addresses that by altering the current configuration check on rotation period from a minimum of 1 minute to a minimum of 2 minutes