### PR TITLE
[Docs] Add relevant Learn tutorial links

### DIFF
--- a/website/content/docs/agent/caching/index.mdx
+++ b/website/content/docs/agent/caching/index.mdx
@@ -52,32 +52,32 @@ request to the Vault server.
 
 Vault Agent can be configured to force the use of the auto-auth token by using
 the value `force` for the `use_auto_auth_token` option. This configuration
-overrides the default behavior described above in [Using Auto-Auth
+overrides the default behavior described above in [Using Auth-Auth
 Token](/docs/agent/caching#using-auto-auth-token), and instead ignores any
 existing Vault token in the request and instead uses the auto-auth token.
 
 ## Persistent Cache
 
-Vault Agent can restore tokens and leases from a persistent cache file created by a previous
-Vault Agent process. The persistent cache is a BoltDB file that includes tuples encrypted
-by a generated encryption key. The encrypted tuples include the Vault token used to retrieve
+Vault Agent can restore tokens and leases from a persistent cache file created by a previous 
+Vault Agent process. The persistent cache is a BoltDB file that includes tuples encrypted 
+by a generated encryption key. The encrypted tuples include the Vault token used to retrieve 
 secrets, leases for tokens/secrets, and secret values.
 
--> **Note:** Vault Agent Caching persistent cache will only restore _leased_ secrets. Secrets
+-> **Note:** Vault Agent Caching persistent cache will only restore _leased_ secrets. Secrets 
 that are not renewable, such as KV v2, will not be persisted.
 
-In order to use Vault Agent persistent cache, auto-auth must be used. During the restoration
-of the cache, Vault Agent will pre-populate auto-auth with the persisted token. This token
-is required to renew restored leases. If the token has expired, the cached leases will be evicted and
+In order to use Vault Agent persistent cache, auto-auth must be used. During the restoration 
+of the cache, Vault Agent will pre-populate auto-auth with the persisted token. This token 
+is required to renew restored leases. If the token has expired, the cached leases will be evicted and 
 secrets will need to be retrieved from Vault.
 
-If Vault Agent templating is enabled alongside of the persistent cache, Vault Agent will automatically
+If Vault Agent templating is enabled alongside of the persistent cache, Vault Agent will automatically 
 route templating requests through the cache. This ensures template requests are cached and restored properly.
 
-At the time of this writing, Vault Agent persistent cache is only supported in a Kubernetes
+At the time of this writing, Vault Agent persistent cache is only supported in a Kubernetes 
 environment. In the future the persistent cache will be expanded to include other environments.
 
-For more information about the Vault Agent persistent cache, see the sidebar for specific persistent
+For more information about the Vault Agent persistent cache, see the sidebar for specific persistent 
 cache types.
 
 ## Cache Evictions
@@ -204,17 +204,17 @@ The top level `cache` block has the following configuration entries:
 
 These are common configuration values that live within the `persist` block:
 
-- `type` `(string: required)` - The type of the persistent cahce to use,
+- `type` `(string: required)` - The type of the persistent cahce to use, 
   e.g. `kubernetes`. _Note_: when using HCL this can be used as the key for
   the block, e.g. `persist "kubernetes" {...}`.
 
-- `path` `(string: required)` - The path on disk where the persistent cache file
+- `path` `(string: required)` - The path on disk where the persistent cache file 
   should be created or restored from.
 
-- `keep_after_import` `(bool: optional)` - When set to true, a restored cache file
+- `keep_after_import` `(bool: optional)` - When set to true, a restored cache file 
   is not deleted. Defaults to `false`.
 
-- `exit_on_err` `(bool: optional)` - When set to true, if any errors occur during
+- `exit_on_err` `(bool: optional)` - When set to true, if any errors occur during 
   a persitent cache restore, Vault Agent will exit with an error. Defaults to `true`.
 
 ## Configuration (`listener`)

--- a/website/content/docs/agent/caching/index.mdx
+++ b/website/content/docs/agent/caching/index.mdx
@@ -52,32 +52,32 @@ request to the Vault server.
 
 Vault Agent can be configured to force the use of the auto-auth token by using
 the value `force` for the `use_auto_auth_token` option. This configuration
-overrides the default behavior described above in [Using Auth-Auth
+overrides the default behavior described above in [Using Auto-Auth
 Token](/docs/agent/caching#using-auto-auth-token), and instead ignores any
 existing Vault token in the request and instead uses the auto-auth token.
 
 ## Persistent Cache
 
-Vault Agent can restore tokens and leases from a persistent cache file created by a previous 
-Vault Agent process. The persistent cache is a BoltDB file that includes tuples encrypted 
-by a generated encryption key. The encrypted tuples include the Vault token used to retrieve 
+Vault Agent can restore tokens and leases from a persistent cache file created by a previous
+Vault Agent process. The persistent cache is a BoltDB file that includes tuples encrypted
+by a generated encryption key. The encrypted tuples include the Vault token used to retrieve
 secrets, leases for tokens/secrets, and secret values.
 
--> **Note:** Vault Agent Caching persistent cache will only restore _leased_ secrets. Secrets 
+-> **Note:** Vault Agent Caching persistent cache will only restore _leased_ secrets. Secrets
 that are not renewable, such as KV v2, will not be persisted.
 
-In order to use Vault Agent persistent cache, auto-auth must be used. During the restoration 
-of the cache, Vault Agent will pre-populate auto-auth with the persisted token. This token 
-is required to renew restored leases. If the token has expired, the cached leases will be evicted and 
+In order to use Vault Agent persistent cache, auto-auth must be used. During the restoration
+of the cache, Vault Agent will pre-populate auto-auth with the persisted token. This token
+is required to renew restored leases. If the token has expired, the cached leases will be evicted and
 secrets will need to be retrieved from Vault.
 
-If Vault Agent templating is enabled alongside of the persistent cache, Vault Agent will automatically 
+If Vault Agent templating is enabled alongside of the persistent cache, Vault Agent will automatically
 route templating requests through the cache. This ensures template requests are cached and restored properly.
 
-At the time of this writing, Vault Agent persistent cache is only supported in a Kubernetes 
+At the time of this writing, Vault Agent persistent cache is only supported in a Kubernetes
 environment. In the future the persistent cache will be expanded to include other environments.
 
-For more information about the Vault Agent persistent cache, see the sidebar for specific persistent 
+For more information about the Vault Agent persistent cache, see the sidebar for specific persistent
 cache types.
 
 ## Cache Evictions
@@ -204,17 +204,17 @@ The top level `cache` block has the following configuration entries:
 
 These are common configuration values that live within the `persist` block:
 
-- `type` `(string: required)` - The type of the persistent cahce to use, 
+- `type` `(string: required)` - The type of the persistent cahce to use,
   e.g. `kubernetes`. _Note_: when using HCL this can be used as the key for
   the block, e.g. `persist "kubernetes" {...}`.
 
-- `path` `(string: required)` - The path on disk where the persistent cache file 
+- `path` `(string: required)` - The path on disk where the persistent cache file
   should be created or restored from.
 
-- `keep_after_import` `(bool: optional)` - When set to true, a restored cache file 
+- `keep_after_import` `(bool: optional)` - When set to true, a restored cache file
   is not deleted. Defaults to `false`.
 
-- `exit_on_err` `(bool: optional)` - When set to true, if any errors occur during 
+- `exit_on_err` `(bool: optional)` - When set to true, if any errors occur during
   a persitent cache restore, Vault Agent will exit with an error. Defaults to `true`.
 
 ## Configuration (`listener`)

--- a/website/content/docs/agent/caching/index.mdx
+++ b/website/content/docs/agent/caching/index.mdx
@@ -52,7 +52,7 @@ request to the Vault server.
 
 Vault Agent can be configured to force the use of the auto-auth token by using
 the value `force` for the `use_auto_auth_token` option. This configuration
-overrides the default behavior described above in [Using Auth-Auth
+overrides the default behavior described above in [Using Auto-Auth
 Token](/docs/agent/caching#using-auto-auth-token), and instead ignores any
 existing Vault token in the request and instead uses the auto-auth token.
 

--- a/website/content/docs/concepts/integrated-storage/autopilot.mdx
+++ b/website/content/docs/concepts/integrated-storage/autopilot.mdx
@@ -71,3 +71,9 @@ Performance secondary clusters have their own Autopilot configuration, managed
 independently of their primary.
 
 DR secondary clusters do not currently support Autopilot.
+
+## Learn
+
+Refer to [Integrated Storage
+Autopilot](https://learn.hashicorp.com/tutorials/vault/raft-autopilot) for a
+step-by-step tutorial.

--- a/website/content/docs/concepts/username-templating.mdx
+++ b/website/content/docs/concepts/username-templating.mdx
@@ -152,7 +152,7 @@ each field. This results in `v_token-wi_my_custo_abcdefghijklmnopqrst_1234567890
 
 ## Learn
 
-Refer to the following tutorials for a step-by-step instructions.
+Refer to the following tutorials for step-by-step instructions.
 
 - [Database Secrets Engine with MongoDB](https://learn.hashicorp.com/tutorials/vault/database-mongodb#customize-the-generated-username-schema)
 - [Dynamic Secrets: Database Secrets Engine](https://learn.hashicorp.com/tutorials/vault/database-secrets#define-a-username-template)

--- a/website/content/docs/concepts/username-templating.mdx
+++ b/website/content/docs/concepts/username-templating.mdx
@@ -149,3 +149,10 @@ v_token-wi_my_custo_abcdefghijklmnopqrst_1234
 Each of these values are passed to `printf "v_%s_%s_%s_%s"` which prepends them with `v_` and puts an underscore between
 each field. This results in `v_token-wi_my_custo_abcdefghijklmnopqrst_1234567890`. This value is then passed to
 `truncate 45` where the last 6 characters are removed which results in `v_token-wi_my_custo_abcdefghijklmnopqrst_1234`.
+
+## Learn
+
+Refer to the following tutorials for a step-by-step instructions.
+
+- [Database Secrets Engine with MongoDB](https://learn.hashicorp.com/tutorials/vault/database-mongodb#customize-the-generated-username-schema)
+- [Dynamic Secrets: Database Secrets Engine](https://learn.hashicorp.com/tutorials/vault/database-secrets#define-a-username-template)

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -187,4 +187,10 @@ storage "raft" {
 }
 ```
 
+## Learn
+
+Refer to [Integrated
+Storage](https://learn.hashicorp.com/collections/vault/raft) for a collection of
+tutorials on integrated storage.
+
 [raft]: https://raft.github.io/ 'The Raft Consensus Algorithm'

--- a/website/content/docs/secrets/databases/mongodb.mdx
+++ b/website/content/docs/secrets/databases/mongodb.mdx
@@ -98,6 +98,12 @@ from MongoDB with the exception that the Vault parameters are the contents of th
 the two options are independent of each other. See the [MongoDB Configuration Options](https://docs.mongodb.com/manual/reference/program/mongo/)
 for more information.
 
+## Learn
+
+Refer to [Database Secrets Engine with
+MongoDB](https://learn.hashicorp.com/tutorials/vault/database-mongodb) for a
+step-by-step tutorial.
+
 ## API
 
 The full list of configurable options can be seen in the [MongoDB database

--- a/website/content/docs/secrets/terraform.mdx
+++ b/website/content/docs/secrets/terraform.mdx
@@ -158,6 +158,12 @@ Please see the [Terraform Cloud API
 Token documentation for more
 information](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html).
 
+## Learn
+
+Refer to [Terraform Cloud Secrets
+Engine](https://learn.hashicorp.com/tutorials/vault/terraform-secrets-engine)
+for a step-by-step tutorial.
+
 ## API
 
 The Terraform Cloud secrets engine has a full HTTP API. Please see the


### PR DESCRIPTION
This PR makes the following changes:

- Fix a reported typo --> `Auth-Auth Token` should be `Auto-Auth Token`
- Add a link to Learn tutorial on the following docs:
   - Autopilot doc
   - Username Templating doc
   - Integrated Storage doc
   - MongoDB secrets engine doc
   - Terraform Cloud secrets engine doc