### PR TITLE
UI/okta duo push notification

### DIFF
--- a/changelog/11442.txt
+++ b/changelog/11442.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Add role from database connection automatically populates the database for new role
+```

--- a/changelog/11442.txt
+++ b/changelog/11442.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-ui: Add role from database connection automatically populates the database for new role
+ui: Add push notification message when selecting okta auth.
 ```

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { match, alias, or } from '@ember/object/computed';
@@ -241,6 +242,11 @@ export default Component.extend(DEFAULTS, {
   }).withTestWaiter(),
 
   delayAuthMessageReminder: task(function*() {
+    if (Ember.testing) {
+      this.showLoading = true;
+      yield timeout(0);
+      return;
+    }
     yield timeout(5000);
   }),
 

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { match, alias, or } from '@ember/object/computed';
@@ -210,6 +211,10 @@ export default Component.extend(DEFAULTS, {
 
   delayPushMessageReminder: task(function*(backendType) {
     if (backendType === 'okta') {
+      if (Ember.testing) {
+        this.showPushNotificationMessage = true;
+        return;
+      }
       yield timeout(3000); // wait 3 seconds before displaying reminder about checking for push notifications
     }
   }),
@@ -218,6 +223,12 @@ export default Component.extend(DEFAULTS, {
     let clusterId = this.cluster.id;
     try {
       yield this.delayPushMessageReminder.perform(backendType);
+      if (backendType === 'okta') {
+        if (Ember.testing) {
+          this.showLoading = true;
+          return;
+        }
+      }
       let authResponse = yield this.auth.authenticate({ clusterId, backend: backendType, data });
 
       let { isRoot, namespace } = authResponse;

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -6,7 +6,7 @@ import { dasherize } from '@ember/string';
 import Component from '@ember/component';
 import { get, computed } from '@ember/object';
 import { supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
-import { task } from 'ember-concurrency';
+import { task, timeout } from 'ember-concurrency';
 const BACKENDS = supportedAuthBackends();
 
 /**
@@ -189,6 +189,7 @@ export default Component.extend(DEFAULTS, {
   }).withTestWaiter(),
 
   showLoading: or('isLoading', 'authenticate.isRunning', 'fetchMethods.isRunning', 'unwrapToken.isRunning'),
+  showPushNotificationMessage: alias('delayPushMessageReminder.isIdle'),
 
   handleError(e, prefixMessage = true) {
     this.set('loading', false);
@@ -207,9 +208,16 @@ export default Component.extend(DEFAULTS, {
     this.set('error', `${message}${errors.join('.')}`);
   },
 
+  delayPushMessageReminder: task(function*(backendType) {
+    if (backendType === 'okta') {
+      yield timeout(3000); // wait 3 seconds before displaying reminder about checking for push notifications
+    }
+  }),
+
   authenticate: task(function*(backendType, data) {
     let clusterId = this.cluster.id;
     try {
+      yield this.delayPushMessageReminder.perform(backendType);
       let authResponse = yield this.auth.authenticate({ clusterId, backend: backendType, data });
 
       let { isRoot, namespace } = authResponse;

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -190,7 +190,6 @@ export default Component.extend(DEFAULTS, {
   }).withTestWaiter(),
 
   showLoading: or('isLoading', 'authenticate.isRunning', 'fetchMethods.isRunning', 'unwrapToken.isRunning'),
-  showPushNotificationMessage: alias('delayPushMessageReminder.isIdle'),
 
   handleError(e, prefixMessage = true) {
     this.set('loading', false);
@@ -209,28 +208,11 @@ export default Component.extend(DEFAULTS, {
     this.set('error', `${message}${errors.join('.')}`);
   },
 
-  delayPushMessageReminder: task(function*(backendType) {
-    if (backendType === 'okta') {
-      if (Ember.testing) {
-        this.showPushNotificationMessage = true;
-        return;
-      }
-      yield timeout(3000); // wait 3 seconds before displaying reminder about checking for push notifications
-    }
-  }),
-
   authenticate: task(function*(backendType, data) {
     let clusterId = this.cluster.id;
     try {
       yield this.delayPushMessageReminder.perform(backendType);
-      if (backendType === 'okta') {
-        if (Ember.testing) {
-          this.showLoading = true;
-          return;
-        }
-      }
       let authResponse = yield this.auth.authenticate({ clusterId, backend: backendType, data });
-
       let { isRoot, namespace } = authResponse;
       let transition;
       let { redirectTo } = this;

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { match, alias, or } from '@ember/object/computed';
@@ -7,7 +6,7 @@ import { dasherize } from '@ember/string';
 import Component from '@ember/component';
 import { get, computed } from '@ember/object';
 import { supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
-import { task, timeout } from 'ember-concurrency';
+import { task } from 'ember-concurrency';
 const BACKENDS = supportedAuthBackends();
 
 /**
@@ -211,8 +210,8 @@ export default Component.extend(DEFAULTS, {
   authenticate: task(function*(backendType, data) {
     let clusterId = this.cluster.id;
     try {
-      yield this.delayPushMessageReminder.perform(backendType);
       let authResponse = yield this.auth.authenticate({ clusterId, backend: backendType, data });
+
       let { isRoot, namespace } = authResponse;
       let transition;
       let { redirectTo } = this;

--- a/ui/app/styles/components/auth-form.scss
+++ b/ui/app/styles/components/auth-form.scss
@@ -19,12 +19,6 @@
   align-items: center;
 }
 
-.push-notification {
-  display: flex;
-  padding: $size-8 0px;
-  font-size: $size-8;
-}
-
 .toolbar-namespace-picker {
   padding: 0 $spacing-s;
 

--- a/ui/app/styles/components/auth-form.scss
+++ b/ui/app/styles/components/auth-form.scss
@@ -19,6 +19,12 @@
   align-items: center;
 }
 
+.push-notification {
+  display: flex;
+  padding: $size-8 0px;
+  font-size: $size-8;
+}
+
 .toolbar-namespace-picker {
   padding: 0 $spacing-s;
 

--- a/ui/app/styles/core/message.scss
+++ b/ui/app/styles/core/message.scss
@@ -119,6 +119,15 @@
   &.has-top {
     margin-top: 1rem;
   }
+
+  &.size-small {
+    padding-bottom: $size-8;
+    font-size: $size-7;
+  }
+
+  &.padding-top {
+    padding-top: $size-8;
+  }
 }
 
 .has-text-highlight {

--- a/ui/app/styles/core/message.scss
+++ b/ui/app/styles/core/message.scss
@@ -121,7 +121,6 @@
   }
 
   &.size-small {
-    padding-bottom: $size-8;
     font-size: $size-7;
   }
 

--- a/ui/app/templates/components/auth-form-options.hbs
+++ b/ui/app/templates/components/auth-form-options.hbs
@@ -23,7 +23,8 @@
           @sizeSmall=true
           @paddingTop=true
           @type="info"
-          @message="If this backend was mounted using a non-default path, enter it here." />
+          @message="If this backend was mounted using a non-default path, enter it here."
+        />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/auth-form-options.hbs
+++ b/ui/app/templates/components/auth-form-options.hbs
@@ -19,7 +19,11 @@
              oninput={{action @onPathChange value="target.value"}}
           />
         </div>
-        <AlertInline @type="info" @message="If this backend was mounted using a non-default path, enter it here." />
+        <AlertInline
+          @sizeSmall=true
+          @paddingTop=true
+          @type="info"
+          @message="If this backend was mounted using a non-default path, enter it here." />
       </div>
     {{/if}}
   </div>

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -38,14 +38,6 @@
         @onChange={{action (mut this.selectedAuth)}}
         />
     {{/if}}
-    {{#if (eq this.selectedAuthBackend.type "okta")}}
-      <AlertInline 
-        @sizeSmall=true
-        @type="info" 
-        @message="If login takes longer than usual, you may need to check your device for an MFA notification, or contact your administrator if login times out."
-        data-test-auth-message="push"
-      />
-    {{/if}}
   {{#if (or (eq this.selectedAuthBackend.type "jwt") (eq this.selectedAuthBackend.type "oidc"))}}
     <AuthJwt
       @onError={{action "handleError"}}
@@ -83,6 +75,15 @@
         <button data-test-auth-submit=true type="submit" disabled={{authenticate.isRunning}} class="button is-primary {{if authenticate.isRunning 'is-loading'}}" id="auth-submit">
           Sign In
         </button>
+        {{#if (and delayAuthMessageReminder.isIdle showLoading)}}
+          <AlertInline
+            @paddingTop=true
+            @sizeSmall=true
+            @type="info" 
+            @message="If login takes longer than usual, you may need to check your device for an MFA notification, or contact your administrator if login times out."
+            data-test-auth-message="push"
+          />
+        {{/if}}
     </form>
   {{/if}}
   </div>

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -83,7 +83,10 @@
           Sign In
         </button>
         {{#if (and showLoading showPushNotificationMessage)}}
-          <p>Please wait. If login is taking longer than usual, you may need to check your device for an MFA notification. Vault will keep trying until timeout.</p>
+          <div class="push-notification" data-test-auth-message="push">
+            <Icon @glyph="info-circle-fill" class="has-text-info"/>
+            <p><strong>Please wait.</strong> If login is taking longer than usual, you may need to check your device for an MFA notification. Vault will keep trying until timeout.</p>
+          </div>
         {{/if}}
     </form>
   {{/if}}

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -1,11 +1,4 @@
 <div class="auth-form">
-  {{#if showLoading}}
-    {{#unless (eq selectedAuthBackend.type "okta")}}
-      <div class="vault-loader">
-        <VaultLogoSpinner />
-      </div>
-    {{/unless}}
-  {{/if}}
   {{#if hasMethodsWithPath}}
     <nav class="tabs is-marginless">
       <ul>
@@ -49,7 +42,7 @@
       <AlertInline 
         @sizeSmall=true
         @type="info" 
-        @message="If Okta login takes longer than usual, you may need to check your device for an MFA notification."
+        @message="If login takes longer than usual, you may need to check your device for an MFA notification, or contact your administrator if login times out."
         data-test-auth-message="push"
       />
     {{/if}}
@@ -87,10 +80,10 @@
             @selectedAuthIsPath={{this.selectedAuthIsPath}}
           />
         {{/if}}
-        <button data-test-auth-submit=true type="submit" disabled={{authenticate.isRunning}} class="button is-primary {{if authenticate.isRunning 'is-loading has-bottom-margin-s'}}" id="auth-submit">
+        <button data-test-auth-submit=true type="submit" disabled={{authenticate.isRunning}} class="button is-primary {{if authenticate.isRunning 'is-loading'}}" id="auth-submit">
           Sign In
         </button>
     </form>
   {{/if}}
-</div>
+  </div>
 </div>

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -45,6 +45,14 @@
         @onChange={{action (mut this.selectedAuth)}}
         />
     {{/if}}
+    {{#if (eq this.selectedAuthBackend.type "okta")}}
+      <AlertInline 
+        @sizeSmall=true
+        @type="info" 
+        @message="If Okta login takes longer than usual, you may need to check your device for an MFA notification."
+        data-test-auth-message="push"
+      />
+    {{/if}}
   {{#if (or (eq this.selectedAuthBackend.type "jwt") (eq this.selectedAuthBackend.type "oidc"))}}
     <AuthJwt
       @onError={{action "handleError"}}
@@ -82,12 +90,6 @@
         <button data-test-auth-submit=true type="submit" disabled={{authenticate.isRunning}} class="button is-primary {{if authenticate.isRunning 'is-loading has-bottom-margin-s'}}" id="auth-submit">
           Sign In
         </button>
-        {{#if (and showLoading showPushNotificationMessage)}}
-          <div class="push-notification" data-test-auth-message="push">
-            <Icon @glyph="info-circle-fill" class="has-text-info"/>
-            <p><strong>Please wait.</strong> If login is taking longer than usual, you may need to check your device for an MFA notification. Vault will keep trying until timeout.</p>
-          </div>
-        {{/if}}
     </form>
   {{/if}}
 </div>

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -82,8 +82,8 @@
         <button data-test-auth-submit=true type="submit" disabled={{authenticate.isRunning}} class="button is-primary {{if authenticate.isRunning 'is-loading has-bottom-margin-s'}}" id="auth-submit">
           Sign In
         </button>
-        {{#if (and showLoading (eq selectedAuthBackend.type "okta"))}}
-          <p>If this is running slowly, MFA might be enabled. Check your MFA device and accept the push request to continue.</p>
+        {{#if (and showLoading showPushNotificationMessage)}}
+          <p>Please wait. If login is taking longer than usual, you may need to check your device for an MFA notification. Vault will keep trying until timeout.</p>
         {{/if}}
     </form>
   {{/if}}

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -1,8 +1,10 @@
 <div class="auth-form">
   {{#if showLoading}}
-    <div class="vault-loader">
-      <VaultLogoSpinner />
-    </div>
+    {{#unless (eq selectedAuthBackend.type "okta")}}
+      <div class="vault-loader">
+        <VaultLogoSpinner />
+      </div>
+    {{/unless}}
   {{/if}}
   {{#if hasMethodsWithPath}}
     <nav class="tabs is-marginless">
@@ -77,9 +79,12 @@
             @selectedAuthIsPath={{this.selectedAuthIsPath}}
           />
         {{/if}}
-        <button data-test-auth-submit=true type="submit" disabled={{authenticate.isRunning}} class="button is-primary {{if authenticate.isRunning 'is-loading'}}" id="auth-submit">
+        <button data-test-auth-submit=true type="submit" disabled={{authenticate.isRunning}} class="button is-primary {{if authenticate.isRunning 'is-loading has-bottom-margin-s'}}" id="auth-submit">
           Sign In
         </button>
+        {{#if (and showLoading (eq selectedAuthBackend.type "okta"))}}
+          <p>If this is running slowly, MFA might be enabled. Check your MFA device and accept the push request to continue.</p>
+        {{/if}}
     </form>
   {{/if}}
 </div>

--- a/ui/app/templates/components/auth-jwt.hbs
+++ b/ui/app/templates/components/auth-jwt.hbs
@@ -18,7 +18,12 @@
         data-test-role
       />
     </div>
-    <AlertInline @type="info" @message="Leave blank to sign in with the default role if one is configured" />
+    <AlertInline
+      @sizeSmall=true 
+      @paddingTop=true
+      @type="info" 
+      @message="Leave blank to sign in with the default role if one is configured"
+    />
   </div>
   {{#unless this.isOIDC}}
     <div class="field">

--- a/ui/lib/core/addon/components/alert-inline.js
+++ b/ui/lib/core/addon/components/alert-inline.js
@@ -14,6 +14,8 @@ import layout from '../templates/components/alert-inline';
  *
  * @param type=null{String} - The alert type. This comes from the message-types helper.
  * @param [message=null]{String} - The message to display within the alert.
+ * @param [sizeSmall=false]{Boolean} - Whether or not to display a small font with padding below of alert message.
+ * @param [paddingTop=false]{Boolean} - Whether or not to add padding above component.
  *
  */
 
@@ -21,8 +23,10 @@ export default Component.extend({
   layout,
   type: null,
   message: null,
-
+  sizeSmall: false,
+  paddingTop: false,
   classNames: ['message-inline'],
+  classNameBindings: ['sizeSmall:size-small', 'paddingTop:padding-top'],
 
   textClass: computed('type', function() {
     if (this.type == 'danger') {

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import sinon from 'sinon';
-import { currentURL, visit, settled } from '@ember/test-helpers';
+import { click, currentURL, visit, settled } from '@ember/test-helpers';
 import { supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
 import authForm from '../pages/components/auth-form';
 import jwtForm from '../pages/components/auth-jwt';
@@ -106,17 +106,16 @@ module('Acceptance | auth', function(hooks) {
     assert.dom('[data-test-allow-expiration="true"]').doesNotExist('hides beacon when the api is used again');
   });
 
-  test('it shows the push notification warning only for okta auth method when it is selected', async function(assert) {
+  test('it shows the push notification warning only for okta auth method after submit', async function(assert) {
     await visit('/vault/auth');
     await component.selectMethod('token');
+    await click('[data-test-auth-submit="true"]');
     assert
       .dom('[data-test-auth-message="push"]')
       .doesNotExist('message is not shown for other authentication methods');
 
     await component.selectMethod('okta');
+    await click('[data-test-auth-submit="true"]');
     assert.dom('[data-test-auth-message="push"]').exists('shows push notification message');
-
-    await component.selectMethod('token');
-    assert.dom('[data-test-auth-message="push"]').doesNotExist('message has been cleared');
   });
 });

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import sinon from 'sinon';
-import { currentURL, visit, settled, fillIn, click } from '@ember/test-helpers';
+import { currentURL, visit, settled, click } from '@ember/test-helpers';
 import { supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
 import authForm from '../pages/components/auth-form';
 import jwtForm from '../pages/components/auth-jwt';

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import sinon from 'sinon';
-import { currentURL, visit, settled } from '@ember/test-helpers';
+import { currentURL, visit, settled, fillIn, click } from '@ember/test-helpers';
 import { supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
 import authForm from '../pages/components/auth-form';
 import jwtForm from '../pages/components/auth-jwt';
@@ -104,5 +104,20 @@ module('Acceptance | auth', function(hooks) {
 
     await visit('/vault/access');
     assert.dom('[data-test-allow-expiration="true"]').doesNotExist('hides beacon when the api is used again');
+  });
+
+  test('it shows the push notification warning only for okta auth method', async function(assert) {
+    await visit('/vault/auth');
+    await fillIn('[data-test-token]', 'password');
+    await click('[data-test-auth-submit="true"]');
+    assert
+      .dom('[data-test-auth-message="push"]')
+      .doesNotExist('message is not shown for other authentication methods');
+
+    await component.selectMethod('okta');
+    await fillIn('[data-test-username]', 'user@test.com');
+    await fillIn('[data-test-password]', 'password');
+    await click('[data-test-auth-submit="true"]');
+    assert.dom('[data-test-auth-message="push"]').exists('shows push notification message');
   });
 });

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import sinon from 'sinon';
-import { currentURL, visit, settled, click } from '@ember/test-helpers';
+import { currentURL, visit, settled } from '@ember/test-helpers';
 import { supportedAuthBackends } from 'vault/helpers/supported-auth-backends';
 import authForm from '../pages/components/auth-form';
 import jwtForm from '../pages/components/auth-jwt';

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -108,12 +108,15 @@ module('Acceptance | auth', function(hooks) {
 
   test('it shows the push notification warning only for okta auth method when it is selected', async function(assert) {
     await visit('/vault/auth');
-    await click('[data-test-auth-submit="true"]');
+    await component.selectMethod('token');
     assert
       .dom('[data-test-auth-message="push"]')
       .doesNotExist('message is not shown for other authentication methods');
 
     await component.selectMethod('okta');
     assert.dom('[data-test-auth-message="push"]').exists('shows push notification message');
+
+    await component.selectMethod('token');
+    assert.dom('[data-test-auth-message="push"]').doesNotExist('message has been cleared');
   });
 });

--- a/ui/tests/acceptance/auth-test.js
+++ b/ui/tests/acceptance/auth-test.js
@@ -106,18 +106,14 @@ module('Acceptance | auth', function(hooks) {
     assert.dom('[data-test-allow-expiration="true"]').doesNotExist('hides beacon when the api is used again');
   });
 
-  test('it shows the push notification warning only for okta auth method', async function(assert) {
+  test('it shows the push notification warning only for okta auth method when it is selected', async function(assert) {
     await visit('/vault/auth');
-    await fillIn('[data-test-token]', 'password');
     await click('[data-test-auth-submit="true"]');
     assert
       .dom('[data-test-auth-message="push"]')
       .doesNotExist('message is not shown for other authentication methods');
 
     await component.selectMethod('okta');
-    await fillIn('[data-test-username]', 'user@test.com');
-    await fillIn('[data-test-password]', 'password');
-    await click('[data-test-auth-submit="true"]');
     assert.dom('[data-test-auth-message="push"]').exists('shows push notification message');
   });
 });


### PR DESCRIPTION
This PR adds a push notification for Okta authentication.  There have been issues with people waiting for the loader, not knowing that it was actually the loader waiting on them to hit their okta push notifications.

**Functionality**: If you select the auth method "okta" a function called `delayAuthMessageReminder` is fired _concurrently_ while the `authenticate` concurrency task is also running.  If after five seconds the `authenticate` concurrency task is still running a message appears to remind folks to check their push notifications.  If the auth method takes less than five seconds (ex: you have okta setup with no MFA and its successful) you won't see the message reminder.

Here is a gif of a situation in which we wait 90 seconds for someone to hit their push notifications. 
<img width=500 src="https://user-images.githubusercontent.com/6618863/116921251-fbddbf80-ac10-11eb-9dd4-8bf7d4220817.gif">

Here is a gif of a situation where it takes less than 5 seconds to login to okta and you do not see the message.
<img width=500 src="https://user-images.githubusercontent.com/6618863/116909928-1ceae400-ac02-11eb-9381-6e424b578209.gif">

Here is a screenshot of the message:
<img width=300 src="https://user-images.githubusercontent.com/6618863/116910046-460b7480-ac02-11eb-91b9-abfa3275d443.png">

**Note:**
While I was in there, I removed the overlay loader per Design's request— we show this with a grey out readOnly button that has a spinning loading inside of it.  I also cleaned up the look of the `AlertInline` component that display messages for the JWT method and for under "More options".  The messages now match the font-size and padding that Design had specked the Okta notification message for.
