### PR TITLE
secrets/database: Fixes marshalling bug for json.Number types

### DIFF
--- a/changelog/10433.txt
+++ b/changelog/10433.txt
@@ -1,3 +1,4 @@
 ```release-note:bug
 secrets/database/mysql: Fixes issue where the DisplayName within generated usernames was the incorrect length
 ```
+

--- a/changelog/10433.txt
+++ b/changelog/10433.txt
@@ -1,4 +1,3 @@
 ```release-note:bug
 secrets/database/mysql: Fixes issue where the DisplayName within generated usernames was the incorrect length
 ```
-

--- a/changelog/11451.txt
+++ b/changelog/11451.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-secrets/database: Fix marshalling to allow providing integer arguments to the `max_open_connections` and `max_idle_connections` fields.
+secrets/database: Fix marshalling to allow providing numeric arguments to external database plugins.
 ```

--- a/changelog/11451.txt
+++ b/changelog/11451.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/database: Fix marshalling to allow providing integer arguments to the `max_open_connections` and `max_idle_connections` fields.
+```

--- a/sdk/database/dbplugin/v5/grpc_client_test.go
+++ b/sdk/database/dbplugin/v5/grpc_client_test.go
@@ -2,6 +2,7 @@ package dbplugin
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -58,6 +59,29 @@ func TestGRPCClient_Initialize(t *testing.T) {
 				Config: map[string]interface{}{
 					"foo": "bar",
 					"baz": "biz",
+				},
+			},
+			assertErr: assertErrNil,
+		},
+		"JSON number type in initialize request": {
+			client: fakeClient{
+				initResp: &proto.InitializeResponse{
+					ConfigData: marshal(t, map[string]interface{}{
+						"foo": "bar",
+						"max": "10",
+					}),
+				},
+			},
+			req: InitializeRequest{
+				Config: map[string]interface{}{
+					"foo": "bar",
+					"max": json.Number("10"),
+				},
+			},
+			expectedResp: InitializeResponse{
+				Config: map[string]interface{}{
+					"foo": "bar",
+					"max": "10",
 				},
 			},
 			assertErr: assertErrNil,

--- a/sdk/database/dbplugin/v5/marshalling.go
+++ b/sdk/database/dbplugin/v5/marshalling.go
@@ -1,12 +1,21 @@
 package dbplugin
 
 import (
+	"encoding/json"
 	"math"
 
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func mapToStruct(m map[string]interface{}) (*structpb.Struct, error) {
+	// Convert any json.Number typed values to string, since the type
+	// does not have a conversion mapping defined in structpb
+	for k, v := range m {
+		if n, ok := v.(json.Number); ok {
+			m[k] = n.String()
+		}
+	}
+
 	return structpb.NewStruct(m)
 }
 

--- a/sdk/database/dbplugin/v5/marshalling.go
+++ b/sdk/database/dbplugin/v5/marshalling.go
@@ -8,11 +8,16 @@ import (
 )
 
 func mapToStruct(m map[string]interface{}) (*structpb.Struct, error) {
-	// Convert any json.Number typed values to string, since the type
-	// does not have a conversion mapping defined in structpb
+	// Convert any json.Number typed values to float64, since the
+	// type does not have a conversion mapping defined in structpb
 	for k, v := range m {
 		if n, ok := v.(json.Number); ok {
-			m[k] = n.String()
+			nf, err := n.Float64()
+			if err != nil {
+				return nil, err
+			}
+
+			m[k] = nf
 		}
 	}
 

--- a/vendor/github.com/hashicorp/vault/sdk/database/dbplugin/v5/marshalling.go
+++ b/vendor/github.com/hashicorp/vault/sdk/database/dbplugin/v5/marshalling.go
@@ -1,12 +1,21 @@
 package dbplugin
 
 import (
+	"encoding/json"
 	"math"
 
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func mapToStruct(m map[string]interface{}) (*structpb.Struct, error) {
+	// Convert any json.Number typed values to string, since the type
+	// does not have a conversion mapping defined in structpb
+	for k, v := range m {
+		if n, ok := v.(json.Number); ok {
+			m[k] = n.String()
+		}
+	}
+
 	return structpb.NewStruct(m)
 }
 

--- a/vendor/github.com/hashicorp/vault/sdk/database/dbplugin/v5/marshalling.go
+++ b/vendor/github.com/hashicorp/vault/sdk/database/dbplugin/v5/marshalling.go
@@ -8,11 +8,16 @@ import (
 )
 
 func mapToStruct(m map[string]interface{}) (*structpb.Struct, error) {
-	// Convert any json.Number typed values to string, since the type
-	// does not have a conversion mapping defined in structpb
+	// Convert any json.Number typed values to float64, since the
+	// type does not have a conversion mapping defined in structpb
 	for k, v := range m {
 		if n, ok := v.(json.Number); ok {
-			m[k] = n.String()
+			nf, err := n.Float64()
+			if err != nil {
+				return nil, err
+			}
+
+			m[k] = nf
 		}
 	}
 


### PR DESCRIPTION
## Overview

This PR fixes an issue that prevents numeric arguments from being provided to parameters such as [max_*_connections](https://www.vaultproject.io/api-docs/secret/databases/oracle#max_open_connections) in the database secrets engine. The Vault CLI provides the arguments as type string, so the error only occurs when using a different client, for example,`curl`. See an example of the error that's returned when providing an integer argument in the testing section below.

## Testing

I tested that integer arguments can be provided to configure the database secrets engine with `curl`. I also wrote a unit test case which exercises the `json.Number` conversion in `mapToStruct()`.

Example of error that's returned for integer arguments:
```
$ curl -X PUT -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" -d '{"allowed_roles":"*","connection_url":"{{username}}/{{password}}@//localhost:1521/oraclepdb","max_open_connections":10,"max_idle_connections":13,"password":"vaultpwd","plugin_name":"vault-plugin-database-oracle","username":"vaultadmin"}' http://127.0.0.1:8200/v1/database/config/oracle

{"errors":["error creating database object: unable to marshal config: proto: invalid type: json.Number"]}
```

Example of successful request using changes in this PR:
```
$ curl -X PUT -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" -d '{"allowed_roles":"*","connection_url":"{{username}}/{{password}}@//localhost:1521/oraclepdb","max_open_connections":10,"max_idle_connections":13,"password":"vaultpwd","plugin_name":"vault-plugin-database-oracle","username":"vaultadmin"}' http://127.0.0.1:8200/v1/database/config/oracle

$ vault read -format=json database/config/oracle
{
  "request_id": "bbc881b3-609a-1360-1a28-83ba8aa9fef5",
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "allowed_roles": [
      "*"
    ],
    "connection_details": {
      "connection_url": "{{username}}/{{password}}@//localhost:1521/oraclepdb",
      "max_idle_connections": 13,
      "max_open_connections": 10,
      "username": "vaultadmin"
    },
    "password_policy": "",
    "plugin_name": "vault-plugin-database-oracle",
    "root_credentials_rotate_statements": []
  },
  "warnings": null
}
```