### PR TITLE
Expiration Manager: Handle Presumed Irrevocable Leases Separately

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -2330,7 +2330,7 @@ func (m *ExpirationManager) removeFromPending(ctx context.Context, leaseID strin
 	}
 }
 
-// note: must be called with pending lock held
+// note: must be called with pending lock held test
 func (m *ExpirationManager) markLeaseAsZombie(ctx context.Context, le *leaseEntry, err error) {
 	if le.isZombie() {
 		m.logger.Info("attempted to re-mark lease as zombie", "original_error", le.RevokeErr, "new_error", err.Error())

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -2332,6 +2332,10 @@ func (m *ExpirationManager) removeFromPending(ctx context.Context, leaseID strin
 
 // note: must be called with pending lock held
 func (m *ExpirationManager) markLeaseAsZombie(ctx context.Context, le *leaseEntry, err error) {
+	if le == nil {
+		m.logger.Warn("attempted to mark nil lease as zombie")
+		return
+	}
 	if le.isZombie() {
 		m.logger.Info("attempted to re-mark lease as zombie", "original_error", le.RevokeErr, "new_error", err.Error())
 		return

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -2330,7 +2330,7 @@ func (m *ExpirationManager) removeFromPending(ctx context.Context, leaseID strin
 	}
 }
 
-// note: must be called with pending lock held test
+// note: must be called with pending lock held
 func (m *ExpirationManager) markLeaseAsZombie(ctx context.Context, le *leaseEntry, err error) {
 	if le.isZombie() {
 		m.logger.Info("attempted to re-mark lease as zombie", "original_error", le.RevokeErr, "new_error", err.Error())

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -2633,13 +2633,13 @@ func TestExpiration_FetchLeaseTimesZombies(t *testing.T) {
 	expectedLeaseTimes.ExpireTime = expectedLeaseTimes.ExpireTime.Round(0)
 	expectedLeaseTimes.LastRenewalTime = expectedLeaseTimes.LastRenewalTime.Round(0)
 
-	if zombieLeaseTimes.IssueTime != expectedLeaseTimes.IssueTime {
+	if !zombieLeaseTimes.IssueTime.Equal(expectedLeaseTimes.IssueTime) {
 		t.Errorf("bad issue time. expected %v, got %v", expectedLeaseTimes.IssueTime, zombieLeaseTimes.IssueTime)
 	}
-	if zombieLeaseTimes.ExpireTime != expectedLeaseTimes.ExpireTime {
+	if !zombieLeaseTimes.ExpireTime.Equal(expectedLeaseTimes.ExpireTime) {
 		t.Errorf("bad expire time. expected %v, got %v", expectedLeaseTimes.ExpireTime, zombieLeaseTimes.ExpireTime)
 	}
-	if zombieLeaseTimes.LastRenewalTime != expectedLeaseTimes.LastRenewalTime {
+	if !zombieLeaseTimes.LastRenewalTime.Equal(expectedLeaseTimes.LastRenewalTime) {
 		t.Errorf("bad last renew time. expected %v, got %v", expectedLeaseTimes.LastRenewalTime, zombieLeaseTimes.LastRenewalTime)
 	}
 }

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -2502,3 +2502,165 @@ func TestExpiration_FairsharingEnvVar(t *testing.T) {
 		}
 	}
 }
+
+// register one lease ID and return the leaseID
+func registerOneLease(t *testing.T, ctx context.Context, exp *ExpirationManager) string {
+	t.Helper()
+
+	req := &logical.Request{
+		Operation:   logical.ReadOperation,
+		Path:        "zombie/lease",
+		ClientToken: "sometoken",
+	}
+	req.SetTokenEntry(&logical.TokenEntry{ID: "sometoken", NamespaceID: "root"})
+	resp := &logical.Response{
+		Secret: &logical.Secret{
+			LeaseOptions: logical.LeaseOptions{
+				TTL: 10 * time.Hour,
+			},
+		},
+	}
+
+	leaseID, err := exp.Register(ctx, req, resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return leaseID
+}
+
+func TestExpiration_MarkZombie(t *testing.T) {
+	exp := mockExpiration(t)
+	ctx := namespace.RootContext(nil)
+
+	leaseID := registerOneLease(t, ctx, exp)
+	loadedLE, err := exp.loadEntry(ctx, leaseID)
+	if err != nil {
+		t.Fatalf("error loading non zombie lease: %v", err)
+	}
+
+	if loadedLE.isZombie() {
+		t.Fatalf("lease is zombie and shouldn't be")
+	}
+	if _, ok := exp.zombies.Load(leaseID); ok {
+		t.Fatalf("lease included in zombie map")
+	}
+	if _, ok := exp.pending.Load(leaseID); !ok {
+		t.Fatalf("lease not included in pending map")
+	}
+
+	zombieErr := fmt.Errorf("test zombie error")
+	exp.markLeaseAsZombie(ctx, loadedLE, zombieErr)
+
+	if !loadedLE.isZombie() {
+		t.Fatalf("zombie lease is not zombie and should be")
+	}
+	if loadedLE.RevokeErr != zombieErr.Error() {
+		t.Errorf("zombie lease has wrong error message. expected %s, got %s", zombieErr.Error(), loadedLE.RevokeErr)
+	}
+	if _, ok := exp.zombies.Load(leaseID); !ok {
+		t.Fatalf("zombie lease not included in zombie map")
+	}
+	if _, ok := exp.pending.Load(leaseID); ok {
+		t.Fatalf("zombie lease included in pending map")
+	}
+	if _, ok := exp.nonexpiring.Load(leaseID); ok {
+		t.Fatalf("zombie lease included in nonexpiring map")
+	}
+
+	// stop and restore to verify that zombies are properly loaded from storage
+	err = exp.Stop()
+	if err != nil {
+		t.Fatalf("error stopping expiration manager: %v", err)
+	}
+
+	err = exp.Restore(nil)
+	if err != nil {
+		t.Fatalf("error restoring expiration manager: %v", err)
+	}
+
+	loadedLE, err = exp.loadEntry(ctx, leaseID)
+	if err != nil {
+		t.Fatalf("error loading non zombie lease after restore: %v", err)
+	}
+
+	if !loadedLE.isZombie() {
+		t.Fatalf("zombie lease is not zombie and should be")
+	}
+	if loadedLE.RevokeErr != zombieErr.Error() {
+		t.Errorf("zombie lease has wrong error message. expected %s, got %s", zombieErr.Error(), loadedLE.RevokeErr)
+	}
+	if _, ok := exp.zombies.Load(leaseID); !ok {
+		t.Fatalf("zombie lease not included in zombie map")
+	}
+	if _, ok := exp.pending.Load(leaseID); ok {
+		t.Fatalf("zombie lease included in pending map")
+	}
+	if _, ok := exp.nonexpiring.Load(leaseID); ok {
+		t.Fatalf("zombie lease included in nonexpiring map")
+	}
+}
+
+func TestExpiration_FetchLeaseTimesZombies(t *testing.T) {
+	exp := mockExpiration(t)
+	ctx := namespace.RootContext(nil)
+
+	leaseID := registerOneLease(t, ctx, exp)
+	expectedLeaseTimes, err := exp.FetchLeaseTimes(ctx, leaseID)
+	if err != nil {
+		t.Fatalf("error getting lease times: %v", err)
+	}
+	if expectedLeaseTimes == nil {
+		t.Fatal("got nil lease")
+	}
+
+	le, err := exp.loadEntry(ctx, leaseID)
+	if err != nil {
+		t.Fatalf("error loading lease: %v", err)
+	}
+	exp.markLeaseAsZombie(ctx, le, fmt.Errorf("test zombie error"))
+
+	zombieLeaseTimes, err := exp.FetchLeaseTimes(ctx, leaseID)
+	if err != nil {
+		t.Fatalf("error getting zombie lease times: %v", err)
+	}
+	if zombieLeaseTimes == nil {
+		t.Fatal("got nil zombie lease")
+	}
+
+	// strip monotonic clock reading
+	expectedLeaseTimes.IssueTime = expectedLeaseTimes.IssueTime.Round(0)
+	expectedLeaseTimes.ExpireTime = expectedLeaseTimes.ExpireTime.Round(0)
+	expectedLeaseTimes.LastRenewalTime = expectedLeaseTimes.LastRenewalTime.Round(0)
+
+	if zombieLeaseTimes.IssueTime != expectedLeaseTimes.IssueTime {
+		t.Errorf("bad issue time. expected %v, got %v", expectedLeaseTimes.IssueTime, zombieLeaseTimes.IssueTime)
+	}
+	if zombieLeaseTimes.ExpireTime != expectedLeaseTimes.ExpireTime {
+		t.Errorf("bad expire time. expected %v, got %v", expectedLeaseTimes.ExpireTime, zombieLeaseTimes.ExpireTime)
+	}
+	if zombieLeaseTimes.LastRenewalTime != expectedLeaseTimes.LastRenewalTime {
+		t.Errorf("bad last renew time. expected %v, got %v", expectedLeaseTimes.LastRenewalTime, zombieLeaseTimes.LastRenewalTime)
+	}
+}
+
+func TestExpiration_StopClearsZombieCache(t *testing.T) {
+	exp := mockExpiration(t)
+	ctx := namespace.RootContext(nil)
+
+	leaseID := registerOneLease(t, ctx, exp)
+	le, err := exp.loadEntry(ctx, leaseID)
+	if err != nil {
+		t.Fatalf("error loading non zombie lease: %v", err)
+	}
+
+	exp.markLeaseAsZombie(ctx, le, fmt.Errorf("test zombie error"))
+	err = exp.Stop()
+	if err != nil {
+		t.Fatalf("error stopping expiration manager: %v", err)
+	}
+
+	if _, ok := exp.zombies.Load(leaseID); ok {
+		t.Error("expiration manager zombies cache should be cleared on stop")
+	}
+}


### PR DESCRIPTION
Note: this is a copy of pull #11333 (@HridoyRoy @sgmiller the one you already approved). I had to make a new branch/pr for CI to work after the Okta changes

This PR allows leases that are deemed irrevocable to be marked as "zombies", taking them out of the expiration rotation. This is to avoid wasting work on leases that are unlikely to be revoked without manual intervention. This can happen if a backing storage system is removed or misconfigured (e.g. leases stored in a database that cannot be accessed anymore).

Leases are currently only marked as zombies if they fail revocation 6 times. In the future they will also be marked as zombies if the backing systems return an irrevocable error. See VLT-145 for more details.

Question: I don't think zombies need to be included in walkLeases or WalkTokens - these appear to be for metrics, and I don't think zombies should be included in the metrics for potentially valid leases (there are/will be separate zombie metrics - again, see RFC).

Question: for those of you that have worked on this in the past: please let me know if I "missed a spot" - from my analysis it looks like this should do it!