### PR TITLE
Backport 1.6.x - secrets/database: Fixes marshalling bug for json.Number types (#11451)

### DIFF
--- a/changelog/11451.txt
+++ b/changelog/11451.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/database: Fix marshalling to allow providing numeric arguments to external database plugins.
+```

--- a/sdk/database/dbplugin/v5/grpc_client_test.go
+++ b/sdk/database/dbplugin/v5/grpc_client_test.go
@@ -2,6 +2,7 @@ package dbplugin
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -58,6 +59,29 @@ func TestGRPCClient_Initialize(t *testing.T) {
 				Config: map[string]interface{}{
 					"foo": "bar",
 					"baz": "biz",
+				},
+			},
+			assertErr: assertErrNil,
+		},
+		"JSON number type in initialize request": {
+			client: fakeClient{
+				initResp: &proto.InitializeResponse{
+					ConfigData: marshal(t, map[string]interface{}{
+						"foo": "bar",
+						"max": "10",
+					}),
+				},
+			},
+			req: InitializeRequest{
+				Config: map[string]interface{}{
+					"foo": "bar",
+					"max": json.Number("10"),
+				},
+			},
+			expectedResp: InitializeResponse{
+				Config: map[string]interface{}{
+					"foo": "bar",
+					"max": "10",
 				},
 			},
 			assertErr: assertErrNil,

--- a/sdk/database/dbplugin/v5/marshalling.go
+++ b/sdk/database/dbplugin/v5/marshalling.go
@@ -1,12 +1,26 @@
 package dbplugin
 
 import (
+	"encoding/json"
 	"math"
 
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func mapToStruct(m map[string]interface{}) (*structpb.Struct, error) {
+	// Convert any json.Number typed values to float64, since the
+	// type does not have a conversion mapping defined in structpb
+	for k, v := range m {
+		if n, ok := v.(json.Number); ok {
+			nf, err := n.Float64()
+			if err != nil {
+				return nil, err
+			}
+
+			m[k] = nf
+		}
+	}
+
 	return structpb.NewStruct(m)
 }
 

--- a/vendor/github.com/hashicorp/vault/sdk/database/dbplugin/v5/marshalling.go
+++ b/vendor/github.com/hashicorp/vault/sdk/database/dbplugin/v5/marshalling.go
@@ -1,12 +1,26 @@
 package dbplugin
 
 import (
+	"encoding/json"
 	"math"
 
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func mapToStruct(m map[string]interface{}) (*structpb.Struct, error) {
+	// Convert any json.Number typed values to float64, since the
+	// type does not have a conversion mapping defined in structpb
+	for k, v := range m {
+		if n, ok := v.(json.Number); ok {
+			nf, err := n.Float64()
+			if err != nil {
+				return nil, err
+			}
+
+			m[k] = nf
+		}
+	}
+
 	return structpb.NewStruct(m)
 }
 


### PR DESCRIPTION
This PR backports a bug fix from https://github.com/hashicorp/vault/pull/11451.

The following steps were taken:
1. `git checkout release/1.6.x`
2. `git checkout -b backport-pr-11451-1.6.x`
3. `git cherry-pick 0d2ae70`