### PR TITLE
Cast constant to int64 so it doesn't overflow.

### DIFF
--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -2066,7 +2066,7 @@ func TestSystemBackend_rotateConfig(t *testing.T) {
 	}
 
 	req2 := logical.TestRequest(t, logical.UpdateOperation, "rotate/config")
-	req2.Data["max_operations"] = 2345678910
+	req2.Data["max_operations"] = int64(2345678910)
 	req2.Data["interval"] = "5432h0m0s"
 	req2.Data["enabled"] = false
 


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/4082/workflows/1eb83c6e-a08b-46e6-944f-223e8f7b2fd3/jobs/146853/steps