### PR TITLE
http: deprecate errwrap.Wrapf()

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -382,7 +382,7 @@ func WrapForwardedForHandler(h http.Handler, l *configutil.Listener) http.Handle
 				h.ServeHTTP(w, r)
 				return
 			}
-			respondError(w, http.StatusBadRequest, errwrap.Wrapf("error parsing client hostport: {{err}}", err))
+			respondError(w, http.StatusBadRequest, fmt.Errorf("error parsing client hostport: %w", err))
 			return
 		}
 
@@ -393,7 +393,7 @@ func WrapForwardedForHandler(h http.Handler, l *configutil.Listener) http.Handle
 				h.ServeHTTP(w, r)
 				return
 			}
-			respondError(w, http.StatusBadRequest, errwrap.Wrapf("error parsing client address: {{err}}", err))
+			respondError(w, http.StatusBadRequest, fmt.Errorf("error parsing client address: %w", err))
 			return
 		}
 
@@ -459,7 +459,7 @@ func wrappingVerificationFunc(ctx context.Context, core *vault.Core, req *logica
 
 	valid, err := core.ValidateWrappingToken(ctx, req)
 	if err != nil {
-		return errwrap.Wrapf("error validating wrapping token: {{err}}", err)
+		return fmt.Errorf("error validating wrapping token: %w", err)
 	}
 	if !valid {
 		return consts.ErrInvalidWrappingToken
@@ -655,7 +655,7 @@ func parseJSONRequest(perfStandby bool, r *http.Request, w http.ResponseWriter, 
 	}
 	err := jsonutil.DecodeJSONFromReader(reader, out)
 	if err != nil && err != io.EOF {
-		return nil, errwrap.Wrapf("failed to parse JSON input: {{err}}", err)
+		return nil, fmt.Errorf("failed to parse JSON input: %w", err)
 	}
 	if origBody != nil {
 		return ioutil.NopCloser(origBody), err

--- a/http/help.go
+++ b/http/help.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/hashicorp/errwrap"
@@ -44,7 +45,7 @@ func handleHelp(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusForbidden, nil)
 			return
 		}
-		respondError(w, http.StatusBadRequest, errwrap.Wrapf("error performing token check: {{err}}", err))
+		respondError(w, http.StatusBadRequest, fmt.Errorf("error performing token check: %w", err))
 		return
 	}
 

--- a/http/logical.go
+++ b/http/logical.go
@@ -153,7 +153,7 @@ func buildLogicalRequestNoAuth(perfStandby bool, w http.ResponseWriter, r *http.
 
 	requestId, err := uuid.GenerateUUID()
 	if err != nil {
-		return nil, nil, http.StatusBadRequest, errwrap.Wrapf("failed to generate identifier for the request: {{err}}", err)
+		return nil, nil, http.StatusBadRequest, fmt.Errorf("failed to generate identifier for the request: %w", err)
 	}
 
 	req := &logical.Request{
@@ -230,22 +230,22 @@ func buildLogicalRequest(core *vault.Core, w http.ResponseWriter, r *http.Reques
 		if errwrap.Contains(err, logical.ErrPermissionDenied.Error()) {
 			return nil, nil, http.StatusForbidden, nil
 		}
-		return nil, nil, http.StatusBadRequest, errwrap.Wrapf("error performing token check: {{err}}", err)
+		return nil, nil, http.StatusBadRequest, fmt.Errorf("error performing token check: %w", err)
 	}
 
 	req, err = requestWrapInfo(r, req)
 	if err != nil {
-		return nil, nil, http.StatusBadRequest, errwrap.Wrapf("error parsing X-Vault-Wrap-TTL header: {{err}}", err)
+		return nil, nil, http.StatusBadRequest, fmt.Errorf("error parsing X-Vault-Wrap-TTL header: %w", err)
 	}
 
 	err = parseMFAHeader(req)
 	if err != nil {
-		return nil, nil, http.StatusBadRequest, errwrap.Wrapf("failed to parse X-Vault-MFA header: {{err}}", err)
+		return nil, nil, http.StatusBadRequest, fmt.Errorf("failed to parse X-Vault-MFA header: %w", err)
 	}
 
 	err = requestPolicyOverride(r, req)
 	if err != nil {
-		return nil, nil, http.StatusBadRequest, errwrap.Wrapf(fmt.Sprintf(`failed to parse %s header: {{err}}`, PolicyOverrideHeaderName), err)
+		return nil, nil, http.StatusBadRequest, fmt.Errorf("failed to parse %s header: %w", PolicyOverrideHeaderName, err)
 	}
 
 	return req, origBody, 0, nil

--- a/http/sys_health.go
+++ b/http/sys_health.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
 	"github.com/hashicorp/vault/sdk/version"
@@ -79,14 +78,14 @@ func getSysHealth(core *vault.Core, r *http.Request) (int, *HealthResponse, erro
 	if standbyOK {
 		standbyOK, err = parseutil.ParseBool(standbyOKStr[0])
 		if err != nil {
-			return http.StatusBadRequest, nil, errwrap.Wrapf("bad value for standbyok parameter: {{err}}", err)
+			return http.StatusBadRequest, nil, fmt.Errorf("bad value for standbyok parameter: %w", err)
 		}
 	}
 	perfStandbyOKStr, perfStandbyOK := r.URL.Query()["perfstandbyok"]
 	if perfStandbyOK {
 		perfStandbyOK, err = parseutil.ParseBool(perfStandbyOKStr[0])
 		if err != nil {
-			return http.StatusBadRequest, nil, errwrap.Wrapf("bad value for perfstandbyok parameter: {{err}}", err)
+			return http.StatusBadRequest, nil, fmt.Errorf("bad value for perfstandbyok parameter: %w", err)
 		}
 	}
 

--- a/http/util.go
+++ b/http/util.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/vault/sdk/logical"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/vault"
 	"github.com/hashicorp/vault/vault/quotas"
@@ -69,7 +68,7 @@ func rateLimitQuotaWrapping(handler http.Handler, core *vault.Core) http.Handler
 		}
 
 		if !quotaResp.Allowed {
-			quotaErr := errwrap.Wrapf(fmt.Sprintf("request path %q: {{err}}", path), quotas.ErrRateLimitQuotaExceeded)
+			quotaErr := fmt.Errorf("request path %q: %w", path, quotas.ErrRateLimitQuotaExceeded)
 			respondError(w, http.StatusTooManyRequests, quotaErr)
 
 			if core.Logger().IsTrace() {


### PR DESCRIPTION
This replaces `errwrap.Wrapf()` with `fmt.Errorf()` throughout the `http` package.