### PR TITLE
Pass mount accessor rather than inferring from not always present group aliases when refreshing group memberships

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -1301,7 +1301,12 @@ func (m *ExpirationManager) RenewToken(ctx context.Context, req *logical.Request
 
 	// Refresh groups
 	if resp.Auth.EntityID != "" && m.core.identityStore != nil {
-		validAliases, err := m.core.identityStore.refreshExternalGroupMembershipsByEntityID(ctx, resp.Auth.EntityID, resp.Auth.GroupAliases)
+		mountAccessor := ""
+		if resp.Auth.Alias != nil {
+			mountAccessor = resp.Auth.Alias.MountAccessor
+		}
+
+		validAliases, err := m.core.identityStore.refreshExternalGroupMembershipsByEntityID(ctx, mountAccessor, resp.Auth.EntityID, resp.Auth.GroupAliases)
 		if err != nil {
 			return nil, err
 		}

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -1884,7 +1884,7 @@ func (i *IdentityStore) MemDBGroupByAliasID(aliasID string, clone bool) (*identi
 	return i.MemDBGroupByAliasIDInTxn(txn, aliasID, clone)
 }
 
-func (i *IdentityStore) refreshExternalGroupMembershipsByEntityID(ctx context.Context, entityID string, groupAliases []*logical.Alias) ([]*logical.Alias, error) {
+func (i *IdentityStore) refreshExternalGroupMembershipsByEntityID(ctx context.Context, mountAccessor string, entityID string, groupAliases []*logical.Alias) ([]*logical.Alias, error) {
 	defer metrics.MeasureSince([]string{"identity", "refresh_external_groups"}, time.Now())
 
 	if entityID == "" {
@@ -1903,11 +1903,6 @@ func (i *IdentityStore) refreshExternalGroupMembershipsByEntityID(ctx context.Co
 		oldGroups, err := i.MemDBGroupsByMemberEntityIDInTxn(txn, entityID, true, true)
 		if err != nil {
 			return false, nil, err
-		}
-
-		mountAccessor := ""
-		if len(groupAliases) != 0 {
-			mountAccessor = groupAliases[0].MountAccessor
 		}
 
 		var newGroups []*identity.Group

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -1203,7 +1203,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request) (re
 			}
 
 			auth.EntityID = entity.ID
-			validAliases, err := c.identityStore.refreshExternalGroupMembershipsByEntityID(ctx, auth.EntityID, auth.GroupAliases)
+			validAliases, err := c.identityStore.refreshExternalGroupMembershipsByEntityID(ctx, auth.Alias.MountAccessor, auth.EntityID, auth.GroupAliases)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
Fixes #11487

This addresses a bug causing entities to be incorrectly removed from external groups when multiple auth backends are used and one of those auth backends returns zero group aliases for an entity.

Full explanation of bug impact and cause can be found in #11487