### PR TITLE
Add support for templated values in SSH CA DefaultExtensions.

### DIFF
--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -361,16 +361,14 @@ func (b *backend) calculateExtensions(data *framework.FieldData, req *logical.Re
 	extensions := make(map[string]string)
 
 	if len(unparsedExtensions) > 0 {
-		parsedExtensions := convertMapToStringValue(unparsedExtensions)
+		extensions := convertMapToStringValue(unparsedExtensions)
 		if role.AllowedExtensions != "" {
 			notAllowed := []string{}
 			allowedExtensions := strings.Split(role.AllowedExtensions, ",")
 
-			for extensionKey, extensionValue := range parsedExtensions {
+			for extensionKey, _ := range extensions {
 				if !strutil.StrListContains(allowedExtensions, extensionKey) {
 					notAllowed = append(notAllowed, extensionKey)
-				} else {
-					extensions[extensionKey] = extensionValue
 				}
 			}
 
@@ -378,7 +376,10 @@ func (b *backend) calculateExtensions(data *framework.FieldData, req *logical.Re
 				return nil, fmt.Errorf("extensions %v are not on allowed list", notAllowed)
 			}
 		}
-	} else if role.DefaultExtensionsTemplate {
+		return extensions, nil
+	}
+
+	if role.DefaultExtensionsTemplate {
 		for extensionKey, extensionValue := range role.DefaultExtensions {
 			// Look for templating markers {{ .* }}
 			matched, _ := regexp.MatchString(`^{{.+?}}$`, extensionValue)

--- a/changelog/11495.txt
+++ b/changelog/11495.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ssh: add support for templated values in SSH CA DefaultExtensions
+```


### PR DESCRIPTION
This PR adds support for using identity templates in values used in Default Extensions. The primary focus here is to allow the Vault SSH CA backend to function as a point of identity/authentication for GitHub Enterprise (and Github.com) users, by supporting their identity semantics, as [documented here](https://docs.github.com/en/enterprise-server@2.22/organizations/managing-git-access-to-your-organizations-repositories/about-ssh-certificate-authorities).

I've based a large chunk of this on #7548 - happy to make changes as requested/needed to get this into the tree.