### PR TITLE
Adding ARN in description of kms_key_id

### DIFF
--- a/website/content/docs/configuration/seal/awskms.mdx
+++ b/website/content/docs/configuration/seal/awskms.mdx
@@ -53,7 +53,7 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
   also be specified by the `AWS_SECRET_ACCESS_KEY` environment variable or as
   part of the AWS profile from the AWS CLI or instance profile.
 
-- `kms_key_id` `(string: <required>)`: The AWS KMS key ID to use for encryption
+- `kms_key_id` `(string: <required>)`: The AWS KMS key ID or ARN to use for encryption
   and decryption. May also be specified by the `VAULT_AWSKMS_SEAL_KEY_ID`
   environment variable.
 


### PR DESCRIPTION
Updating description to [kms_key_id](https://www.vaultproject.io/docs/configuration/seal/awskms#kms_key_id) in docs to indicate to user that ARN can be used in this option as well.