### PR TITLE
Allow Agent auto auth to read symlinked JWT files

### DIFF
--- a/command/agent/auth/jwt/jwt.go
+++ b/command/agent/auth/jwt/jwt.go
@@ -164,7 +164,7 @@ func (j *jwtMethod) ingressToken() {
 	j.logger.Debug("new jwt file found")
 
 	// Check that the path refers to a file.
-	// If it's a sym link, it could still be a sym link to a directory,
+	// If it's a sym link, it could still be a symlink to a directory,
 	// but ioutil.ReadFile below will return a descriptive error.
 	if !fi.Mode().IsRegular() && (fi.Mode()&fs.ModeSymlink) == 0 {
 		j.logger.Error("jwt file is not a regular file or symlink")

--- a/command/agent/auth/jwt/jwt.go
+++ b/command/agent/auth/jwt/jwt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -31,6 +32,8 @@ type jwtMethod struct {
 	latestToken     *atomic.Value
 }
 
+// NewJWTAuthMethod returns an implementation of Agent's auth.AuthMethod
+// interface for JWT auth.
 func NewJWTAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 	if conf == nil {
 		return nil, errors.New("empty config")
@@ -86,7 +89,7 @@ func NewJWTAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 	return j, nil
 }
 
-func (j *jwtMethod) Authenticate(_ context.Context, client *api.Client) (string, http.Header, map[string]interface{}, error) {
+func (j *jwtMethod) Authenticate(_ context.Context, _ *api.Client) (string, http.Header, map[string]interface{}, error) {
 	j.logger.Trace("beginning authentication")
 
 	j.ingressToken()
@@ -160,8 +163,11 @@ func (j *jwtMethod) ingressToken() {
 
 	j.logger.Debug("new jwt file found")
 
-	if !fi.Mode().IsRegular() {
-		j.logger.Error("jwt file is not a regular file")
+	// Check that the path refers to a file.
+	// If it's a sym link, it could still be a sym link to a directory,
+	// but ioutil.ReadFile below will return a descriptive error.
+	if !fi.Mode().IsRegular() && (fi.Mode()&fs.ModeSymlink) == 0 {
+		j.logger.Error("jwt file is not a regular file or symlink")
 		return
 	}
 

--- a/command/agent/auth/jwt/jwt.go
+++ b/command/agent/auth/jwt/jwt.go
@@ -164,9 +164,14 @@ func (j *jwtMethod) ingressToken() {
 	j.logger.Debug("new jwt file found")
 
 	// Check that the path refers to a file.
-	// If it's a sym link, it could still be a symlink to a directory,
+	// If it's a symlink, it could still be a symlink to a directory,
 	// but ioutil.ReadFile below will return a descriptive error.
-	if !fi.Mode().IsRegular() && (fi.Mode()&fs.ModeSymlink) == 0 {
+	switch mode := fi.Mode(); {
+	case mode.IsRegular():
+		// regular file
+	case mode&fs.ModeSymlink != 0:
+		// symlink
+	default:
 		j.logger.Error("jwt file is not a regular file or symlink")
 		return
 	}

--- a/command/agent/auth/jwt/jwt_test.go
+++ b/command/agent/auth/jwt/jwt_test.go
@@ -101,7 +101,7 @@ func TestIngressToken(t *testing.T) {
 			}
 		} else {
 			if strings.Contains(logBuffer.String(), "[ERROR]") || strings.Contains(logBuffer.String(), "[WARN]") {
-				t.Fatal("logs contained unexepected error", logBuffer.String())
+				t.Fatal("logs contained unexpected error", logBuffer.String())
 			}
 		}
 	}

--- a/command/agent/auth/jwt/jwt_test.go
+++ b/command/agent/auth/jwt/jwt_test.go
@@ -1,0 +1,108 @@
+package jwt
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func TestIngressToken(t *testing.T) {
+	const (
+		dir       = "dir"
+		file      = "file"
+		empty     = "empty"
+		missing   = "missing"
+		symlinked = "symlinked"
+	)
+
+	rootDir, err := ioutil.TempDir("", "vault-agent-jwt-auth-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %s", err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	setupTestDir := func() string {
+		testDir, err := ioutil.TempDir(rootDir, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = ioutil.WriteFile(path.Join(testDir, file), []byte("test"), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = os.Create(path.Join(testDir, empty))
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = os.Mkdir(path.Join(testDir, dir), 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = os.Symlink(path.Join(testDir, file), path.Join(testDir, symlinked))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return testDir
+	}
+
+	for _, tc := range []struct {
+		name      string
+		path      string
+		errString string
+	}{
+		{
+			"happy path",
+			file,
+			"",
+		},
+		{
+			"path is directory",
+			dir,
+			"[ERROR] jwt file is not a regular file or symlink",
+		},
+		{
+			"path is symlink",
+			symlinked,
+			"",
+		},
+		{
+			"path is missing (implies nothing for ingressToken to do)",
+			missing,
+			"",
+		},
+		{
+			"path is empty file",
+			empty,
+			"[WARN]  empty jwt file read",
+		},
+	} {
+		testDir := setupTestDir()
+		logBuffer := bytes.Buffer{}
+		jwtAuth := &jwtMethod{
+			logger: hclog.New(&hclog.LoggerOptions{
+				Output: &logBuffer,
+			}),
+			latestToken: new(atomic.Value),
+			path:        path.Join(testDir, tc.path),
+		}
+
+		jwtAuth.ingressToken()
+
+		if tc.errString != "" {
+			if !strings.Contains(logBuffer.String(), tc.errString) {
+				t.Fatal("logs did no contain expected error", tc.errString, logBuffer.String())
+			}
+		} else {
+			if strings.Contains(logBuffer.String(), "[ERROR]") || strings.Contains(logBuffer.String(), "[WARN]") {
+				t.Fatal("logs contained unexepected error", logBuffer.String())
+			}
+		}
+	}
+}


### PR DESCRIPTION
This came up when helping someone to set up JWT auto auth with Vault Agent in Kubernetes. They had lots of Kubernetes clusters and so didn't want to have to set up a Kubernetes auth mount for each cluster, and instead wanted to use projected Service Account tokens with the JWT auth method. Kubernetes mounts projected tokens using symlinks from an immutable volume mount to help it rotate JWTs when they expire. In this case, the fact the JWT was a symlink stopped JWT auto auth from working, but I see no reason we can't support symlinks in this case.

Currently, the tests are a little fragile in relying on log output. I opted not to change the signature of `ingressToken` to return an error because the actual production code would never pay attention to or change its behaviour based on the return value, but I'm very open to feedback on that.

Lastly, I have opted to allow `ioutil.ReadFile` to handle any errors from cases such as a symlink pointing to a directory for simplicity, as when experimenting I found the error message was clear enough without additional handling, e.g. `read sym-dir: is a directory`. It's possible I've missed a separate motivation for the `IsRegular()` check though.