### PR TITLE
Backport 1.6.x: Update Agent Auth with GCP to use new SignJWT endpoint (#11473)

### DIFF
--- a/changelog/11473.txt
+++ b/changelog/11473.txt
@@ -1,0 +1,4 @@
+```release-note:change
+agent: Update to use IAM Service Account Credentials endpoint for signing JWTs
+when using GCP Auto-Auth method
+```


### PR DESCRIPTION
Backports #11473 to the 1.6.x branch:


------


Updates Vault Agent's GCP auth to use GCP's IAM Service Account Credential endpoint for signing JWTs, as the IAM endpoint versions are deprecated. See https://cloud.google.com/iam/docs/migrating-to-credentials-api for more information on the deprecation and migration. 

See also for more backstory:

- https://github.com/hashicorp/vault-plugin-auth-gcp/issues/100
- https://github.com/hashicorp/vault-plugin-auth-gcp/pull/108
- https://github.com/hashicorp/go-gcp-common/pull/4