### PR TITLE
Added gcp auth jwt claim error details with default token and role setup

### DIFF
--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -294,7 +294,7 @@ If specified, expiration must be a
 Epoch). This value must be before the max JWT expiration allowed for a role.
 This defaults to 15 minutes and cannot be more than 1 hour. 
 
-If user generates a token that expires after 15 minutes and gcp role has `max_jwt_exp` set to default 15 minutes, Vault will return an error like `Expiration date must be set to no more that 15 mins in JWT_CLAIM, otherwise the login request returns error "role requires that service account JWTs expire within 900 seconds"`. In this case user must create a new signed JWT with a shorter expiration or set `max_jwt_exp` to higher value in gcp role.
+If a user generates a token that expires after 15 minutes and gcp role has `max_jwt_exp` set to default 15 minutes, Vault will return an error like `Expiration date must be set to no more that 15 mins in JWT_CLAIM, otherwise the login request returns error "role requires that service account JWTs expire within 900 seconds"`. In this case user must create a new signed JWT with a shorter expiration or set `max_jwt_exp` to higher value in gcp role.
 
 One you have all this information, the JWT token can be signed using curl and
 [oauth2l](https://github.com/google/oauth2l):

--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -292,7 +292,9 @@ For the API method, expiration is optional and will default to an hour.
 If specified, expiration must be a
 [NumericDate](https://tools.ietf.org/html/rfc7519#section-2) value (seconds from
 Epoch). This value must be before the max JWT expiration allowed for a role.
-This defaults to 15 minutes and cannot be more than 1 hour.
+This defaults to 15 minutes and cannot be more than 1 hour. 
+
+If user generates a token that expires after 15 minutes and gcp role has `max_jwt_exp` set to default 15 minutes, Vault will return an error like `Expiration date must be set to no more that 15 mins in JWT_CLAIM, otherwise the login request returns error "role requires that service account JWTs expire within 900 seconds"`. In this case user must create a new signed JWT with a shorter expiration or set `max_jwt_exp` to higher value in gcp role.
 
 One you have all this information, the JWT token can be signed using curl and
 [oauth2l](https://github.com/google/oauth2l):


### PR DESCRIPTION
When users follow gcp auth method doc, with default settings they get error related to jwt_claim expiration. 

```
Expiration date must be set to no more that 15 mins in JWT_CLAIM, otherwise the login request returns error "role requires that service account JWTs expire within 900 seconds"
```

Though we have mentioned about it in other places (https://www.vaultproject.io/api/auth/gcp#max_jwt_exp), it is ambiguous and causes customers to create ticket. I have added error details along with how to fix same. This should reduce the number of tickets on this topic. 