### PR TITLE
docs: add missing csi mount config

### DIFF
--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -14,6 +14,9 @@ The following parameters are supported by the Vault provider:
 
 - `vaultNamespace` `(string: "")` - The Vault [namespace](/docs/enterprise/namespaces) to use.
 
+- `vaultKubernetesMountPath` `(string: "kubernetes")` - The mount path of the Kubernetes authentication
+  method in Vault.
+
 - `vaultSkipTLSVerify` `(string: "false")` - When set to true, skips verification of the Vault server
   certificiate. Setting this to true is not recommended for production.
 


### PR DESCRIPTION
The configurable for the mount path of the K8s auth method was missing from the CSI documentation.