### PR TITLE
cherry-pick: update CSI documentation on website

### DIFF
--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -14,9 +14,6 @@ The following parameters are supported by the Vault provider:
 
 - `vaultNamespace` `(string: "")` - The Vault [namespace](/docs/enterprise/namespaces) to use.
 
-- `vaultKubernetesMountPath` `(string: "kubernetes")` - The mount path of the Kubernetes authentication
-  method in Vault.
-
 - `vaultSkipTLSVerify` `(string: "false")` - When set to true, skips verification of the Vault server
   certificiate. Setting this to true is not recommended for production.
 

--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -20,6 +20,9 @@ The following parameters are supported by the Vault provider:
 - `vaultCACertPath` `(string: "")` - The path on disk where the Vault CA certificate can be found
   when verifying the Vault server certificate.
 
+- `vaultCADirectory` `(string: "")` - The directory on disk where the Vault CA certificate can be found
+  when verifying the Vault server certificate.
+
 - `vaultTLSClientCertPath` `(string: "")` - The path on disk where the client certificate can be found
   for mTLS communications with Vault.
 
@@ -27,6 +30,9 @@ The following parameters are supported by the Vault provider:
   for mTLS communications with Vault.
 
 - `vaultTLSServerName` `(string: "")` - The name to use as the SNI host when connecting via TLS.
+
+- `vaultKubernetesMountPath` `(string: "kubernetes")` - The name of the auth mount used for login.
+  At this time only the Kubernetes auth method is supported.
 
 - `objects` `(array)` - An array of secrets to retrieve from Vault.
 
@@ -36,6 +42,8 @@ The following parameters are supported by the Vault provider:
   - `method` `(string: "GET")` - The type of HTTP request. Supported values include "GET" and "PUT".
 
   - `secretPath` `(string: "")` - The path in Vault where the secret is located.
+
+  - `secretKey` `(string: "")` - The key in the Vault secret to extract. If omitted, the whole response from Vault will be written as JSON.
 
   - `secretArgs` `(map: {})` - Additional arguments to be sent to Vault for a specific secret. Arguments can vary
     for different secret engines. For example:

--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -12,7 +12,9 @@ The following parameters are supported by the Vault provider:
 
 - `vaultAddress` `(string: "")` - The address of the Vault server.
 
-- `vaultSkipTLSVerify` `(string: "false")` - When set to true, skips verification of the Vault server 
+- `vaultNamespace` `(string: "")` - The Vault [namespace](/docs/enterprise/namespaces) to use.
+
+- `vaultSkipTLSVerify` `(string: "false")` - When set to true, skips verification of the Vault server
   certificiate. Setting this to true is not recommended for production.
 
 - `vaultCACertPath` `(string: "")` - The path on disk where the Vault CA certificate can be found
@@ -28,15 +30,15 @@ The following parameters are supported by the Vault provider:
 
 - `objects` `(array)` - An array of secrets to retrieve from Vault.
 
-  - `objectName` `(string: "")` - The alias of the object which can be referenced within the secret provider class and 
+  - `objectName` `(string: "")` - The alias of the object which can be referenced within the secret provider class and
   the name of the secret file.
 
   - `method` `(string: "GET")` - The type of HTTP request. Supported values include "GET" and "PUT".
 
   - `secretPath` `(string: "")` - The path in Vault where the secret is located.
 
-  - `secretArgs` `(map: {})` - Additional arguments to be sent to Vault for a specific secret. Arguments can vary 
-    for different secret engines. For example: 
+  - `secretArgs` `(map: {})` - Additional arguments to be sent to Vault for a specific secret. Arguments can vary
+    for different secret engines. For example:
 
     ```yaml
     secretArgs:

--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -14,6 +14,9 @@ The following parameters are supported by the Vault provider:
 
 - `vaultNamespace` `(string: "")` - The Vault [namespace](/docs/enterprise/namespaces) to use.
 
+- `vaultKubernetesMountPath` `(string: "kubernetes")` - The mount path of the Kubernetes authentication
+  method in Vault.
+
 - `vaultSkipTLSVerify` `(string: "false")` - When set to true, skips verification of the Vault server
   certificiate. Setting this to true is not recommended for production.
 


### PR DESCRIPTION
Cherrypick automation is failing due to commit https://github.com/hashicorp/vault/commit/d6a10c1333cbdfe88e32721788434f00b071f854 missing from stable-website. I've cherry-picked this and all the other changes to this page to resolve issues.