### PR TITLE
Fix barrier key autoration config edge cases

### DIFF
--- a/changelog/11541.txt
+++ b/changelog/11541.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix edge cases in the configuration endpoint for barrier key autorotation.
+```

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.4.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.1.0
 	github.com/hashicorp/vault/api v1.0.5-0.20210210214158-405eced08457
-	github.com/hashicorp/vault/sdk v0.1.14-0.20210505170539-fdd45b76614d
+	github.com/hashicorp/vault/sdk v0.1.14-0.20210505171055-299f311fa707
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4
 	github.com/jcmturner/gokrb5/v8 v8.0.0
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.4.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.1.0
 	github.com/hashicorp/vault/api v1.0.5-0.20210210214158-405eced08457
-	github.com/hashicorp/vault/sdk v0.1.14-0.20210204230556-cf85a862b7c6
+	github.com/hashicorp/vault/sdk v0.1.14-0.20210505170539-fdd45b76614d
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4
 	github.com/jcmturner/gokrb5/v8 v8.0.0
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f

--- a/sdk/framework/field_data.go
+++ b/sdk/framework/field_data.go
@@ -131,7 +131,7 @@ func (d *FieldData) GetOkErr(k string) (interface{}, bool, error) {
 	}
 
 	switch schema.Type {
-	case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
+	case TypeBool, TypeInt, TypeInt64, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
 		TypeLowerCaseString, TypeNameString, TypeSlice, TypeStringSlice, TypeCommaStringSlice,
 		TypeKVPairs, TypeCommaIntSlice, TypeHeader, TypeFloat, TypeTime:
 		return d.getPrimitive(k, schema)

--- a/sdk/framework/field_data.go
+++ b/sdk/framework/field_data.go
@@ -38,7 +38,7 @@ func (d *FieldData) Validate() error {
 		}
 
 		switch schema.Type {
-		case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
+		case TypeBool, TypeInt, TypeInt64, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
 			TypeLowerCaseString, TypeNameString, TypeSlice, TypeStringSlice, TypeCommaStringSlice,
 			TypeKVPairs, TypeCommaIntSlice, TypeHeader, TypeFloat, TypeTime:
 			_, _, err := d.getPrimitive(field, schema)
@@ -157,6 +157,13 @@ func (d *FieldData) getPrimitive(k string, schema *FieldSchema) (interface{}, bo
 
 	case TypeInt:
 		var result int
+		if err := mapstructure.WeakDecode(raw, &result); err != nil {
+			return nil, false, err
+		}
+		return result, true, nil
+
+	case TypeInt64:
+		var result int64
 		if err := mapstructure.WeakDecode(raw, &result); err != nil {
 			return nil, false, err
 		}

--- a/sdk/framework/field_type.go
+++ b/sdk/framework/field_type.go
@@ -7,6 +7,7 @@ const (
 	TypeInvalid FieldType = 0
 	TypeString  FieldType = iota
 	TypeInt
+	TypeInt64
 	TypeBool
 	TypeMap
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2566,7 +2566,7 @@ func (b *SystemBackend) handleKeyRotationConfigUpdate(ctx context.Context, req *
 		return nil, err
 	}
 	if ok {
-		rotConfig.MaxOperations = int64(maxOps.(int))
+		rotConfig.MaxOperations = maxOps.(int64)
 	}
 	interval, ok, err := data.GetOkErr("interval")
 	if err != nil {

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2585,7 +2585,7 @@ func (b *SystemBackend) handleKeyRotationConfigUpdate(ctx context.Context, req *
 	}
 
 	// Reject out of range settings
-	if rotConfig.Interval < minimumRotationInterval {
+	if rotConfig.Interval < minimumRotationInterval && rotConfig.Interval != 0 {
 		return logical.ErrorResponse("interval must be greater or equal to %s", minimumRotationInterval.String()), logical.ErrInvalidRequest
 	}
 

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -610,7 +610,7 @@ func (b *SystemBackend) sealPaths() []*framework.Path {
 					Description: strings.TrimSpace(sysHelp["rotation-enabled"][0]),
 				},
 				"max_operations": {
-					Type:        framework.TypeInt, // 64?
+					Type:        framework.TypeInt64,
 					Description: strings.TrimSpace(sysHelp["rotation-max-operations"][0]),
 				},
 				"interval": {

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -2066,7 +2066,7 @@ func TestSystemBackend_rotateConfig(t *testing.T) {
 	}
 
 	req2 := logical.TestRequest(t, logical.UpdateOperation, "rotate/config")
-	req2.Data["max_operations"] = 123456789
+	req2.Data["max_operations"] = int64(3221225472)
 	req2.Data["interval"] = "5432h0m0s"
 	req2.Data["enabled"] = false
 
@@ -2081,18 +2081,9 @@ func TestSystemBackend_rotateConfig(t *testing.T) {
 	}
 
 	exp = map[string]interface{}{
-		"max_operations": 123456789,
+		"max_operations": int64(3221225472),
 		"interval":       "5432h0m0s",
 		"enabled":        false,
-	}
-
-	// Not pretty, but on a 64-bit machine, the response value is 64-bit, while on a 32 bit machine it'll be an int
-	// DeepEqual rejects it due to the type difference
-	if d, ok := resp.Data["max_operations"]; ok {
-		v, ok := d.(int64)
-		if ok {
-			resp.Data["max_operations"] = int(v)
-		}
 	}
 
 	if !reflect.DeepEqual(resp.Data, exp) {

--- a/vendor/github.com/hashicorp/vault/sdk/framework/field_data.go
+++ b/vendor/github.com/hashicorp/vault/sdk/framework/field_data.go
@@ -131,7 +131,7 @@ func (d *FieldData) GetOkErr(k string) (interface{}, bool, error) {
 	}
 
 	switch schema.Type {
-	case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
+	case TypeBool, TypeInt, TypeInt64, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
 		TypeLowerCaseString, TypeNameString, TypeSlice, TypeStringSlice, TypeCommaStringSlice,
 		TypeKVPairs, TypeCommaIntSlice, TypeHeader, TypeFloat, TypeTime:
 		return d.getPrimitive(k, schema)

--- a/vendor/github.com/hashicorp/vault/sdk/framework/field_data.go
+++ b/vendor/github.com/hashicorp/vault/sdk/framework/field_data.go
@@ -38,7 +38,7 @@ func (d *FieldData) Validate() error {
 		}
 
 		switch schema.Type {
-		case TypeBool, TypeInt, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
+		case TypeBool, TypeInt, TypeInt64, TypeMap, TypeDurationSecond, TypeSignedDurationSecond, TypeString,
 			TypeLowerCaseString, TypeNameString, TypeSlice, TypeStringSlice, TypeCommaStringSlice,
 			TypeKVPairs, TypeCommaIntSlice, TypeHeader, TypeFloat, TypeTime:
 			_, _, err := d.getPrimitive(field, schema)
@@ -157,6 +157,13 @@ func (d *FieldData) getPrimitive(k string, schema *FieldSchema) (interface{}, bo
 
 	case TypeInt:
 		var result int
+		if err := mapstructure.WeakDecode(raw, &result); err != nil {
+			return nil, false, err
+		}
+		return result, true, nil
+
+	case TypeInt64:
+		var result int64
 		if err := mapstructure.WeakDecode(raw, &result); err != nil {
 			return nil, false, err
 		}

--- a/vendor/github.com/hashicorp/vault/sdk/framework/field_type.go
+++ b/vendor/github.com/hashicorp/vault/sdk/framework/field_type.go
@@ -7,6 +7,7 @@ const (
 	TypeInvalid FieldType = 0
 	TypeString  FieldType = iota
 	TypeInt
+	TypeInt64
 	TypeBool
 	TypeMap
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -709,7 +709,7 @@ github.com/hashicorp/vault-plugin-secrets-terraform
 # github.com/hashicorp/vault/api v1.0.5-0.20210210214158-405eced08457 => ./api
 ## explicit
 github.com/hashicorp/vault/api
-# github.com/hashicorp/vault/sdk v0.1.14-0.20210505170539-fdd45b76614d => ./sdk
+# github.com/hashicorp/vault/sdk v0.1.14-0.20210505171055-299f311fa707 => ./sdk
 ## explicit
 github.com/hashicorp/vault/sdk/database/dbplugin
 github.com/hashicorp/vault/sdk/database/dbplugin/v5

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -709,7 +709,7 @@ github.com/hashicorp/vault-plugin-secrets-terraform
 # github.com/hashicorp/vault/api v1.0.5-0.20210210214158-405eced08457 => ./api
 ## explicit
 github.com/hashicorp/vault/api
-# github.com/hashicorp/vault/sdk v0.1.14-0.20210204230556-cf85a862b7c6 => ./sdk
+# github.com/hashicorp/vault/sdk v0.1.14-0.20210505170539-fdd45b76614d => ./sdk
 ## explicit
 github.com/hashicorp/vault/sdk/database/dbplugin
 github.com/hashicorp/vault/sdk/database/dbplugin/v5


### PR DESCRIPTION
Introduces handling of a TypeInt64 in sdk field data, and uses it in order
to the ability to set values over 2^31 on 32 bit platforms.

Also fixes the ability to set a max_operations without specifying interval
if interval was previously unset.