### PR TITLE
Provide a new API endpoint for retrieving signed licenses

### DIFF
--- a/command/license_get.go
+++ b/command/license_get.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/mitchellh/cli"
@@ -82,7 +81,14 @@ func (c *LicenseGetCommand) Run(args []string) int {
 		return 2
 	}
 
-	secret, err := client.Logical().ReadWithData("sys/license", map[string][]string{"signed": {strconv.FormatBool(c.signed)}})
+	var path string
+	if c.signed {
+		path = "sys/license/signed"
+	} else {
+		path = "sys/license"
+	}
+
+	secret, err := client.Logical().Read(path)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error retrieving license: %s", err))
 		return 2

--- a/vault/logical_system_helpers.go
+++ b/vault/logical_system_helpers.go
@@ -55,24 +55,6 @@ var (
 		}
 	}
 
-	pathLicenseRead = func(b *SystemBackend) framework.OperationFunc {
-		return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-			return nil, nil
-		}
-	}
-
-	pathLicenseUpdate = func(b *SystemBackend) framework.OperationFunc {
-		return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-			return nil, nil
-		}
-	}
-
-	pathLicenseReadSigned = func(b *SystemBackend) framework.OperationFunc {
-		return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-			return nil, nil
-		}
-	}
-
 	entPaths = func(b *SystemBackend) []*framework.Path {
 		return []*framework.Path{
 			{

--- a/vault/logical_system_helpers.go
+++ b/vault/logical_system_helpers.go
@@ -67,6 +67,12 @@ var (
 		}
 	}
 
+	pathLicenseReadSigned = func(b *SystemBackend) framework.OperationFunc {
+		return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+			return nil, nil
+		}
+	}
+
 	entPaths = func(b *SystemBackend) []*framework.Path {
 		return []*framework.Path{
 			{

--- a/website/content/api-docs/system/license.mdx
+++ b/website/content/api-docs/system/license.mdx
@@ -2,7 +2,7 @@
 layout: api
 page_title: /sys/license - HTTP API
 description: |-
-  The `/sys/license` endpoint is used to view and update the license used in 
+  The `/sys/license` endpoint is used to view and update the license used in
   Vault.
 ---
 
@@ -40,6 +40,32 @@ $ curl \
     "start_time": "2017-11-14T16:04:36.546753-05:00"
   },
   "warnings": ["time left on license is 29m33s"]
+}
+```
+
+## Read Signed License
+
+This endpoint returns the signed license blob for the currently installed license.
+
+| Method | Path           |
+| :----- | :------------- |
+| `GET`  | `/sys/license/signed` |
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/license/signed
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "signed": "01ABCDEFG..."
+  }
 }
 ```
 


### PR DESCRIPTION
These are the (new) OSS changes from https://github.com/hashicorp/vault-enterprise/pull/1860 that move the signed license API to its own endpoint.