### PR TITLE
Update container image tag used in SSH secrets tests

### DIFF
--- a/builtin/logical/ssh/backend_test.go
+++ b/builtin/logical/ssh/backend_test.go
@@ -121,7 +121,7 @@ SjOQL/GkH1nkRcDS9++aAAAAAmNhAQID
 	testPublicKeyInstall = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC9i+hFxZHGo6KblVme4zrAcJstR6I0PTJozW286X4WyvPnkMYDQ5mnhEYC7UWCvjoTWbPEXPX7NjhRtwQTGD67bV+lrxgfyzK1JZbUXK4PwgKJvQD+XyyWYMzDgGSQY61KUSqCxymSm/9NZkPU3ElaQ9xQuTzPpztM4ROfb8f2Yv6/ZESZsTo0MTAkp8Pcy+WkioI/uJ1H7zqs0EA4OMY4aDJRu0UtP4rTVeYNEAuRXdX+eH4aW3KMvhzpFTjMbaJHJXlEeUm2SaX5TNQyTOvghCeQILfYIL/Ca2ij8iwCmulwdV6eQGfd4VDu40PvSnmfoaE38o6HaPnX0kUcnKiT"
 
 	dockerImageTagSupportsRSA1   = "8.1_p1-r0-ls20"
-	dockerImageTagSupportsNoRSA1 = "8.3_p1-r0-ls21"
+	dockerImageTagSupportsNoRSA1 = "8.4_p1-r3-ls48"
 )
 
 func prepareTestContainer(t *testing.T, tag, caPublicKeyPEM string) (func(), string) {


### PR DESCRIPTION
This PR updates the container image tag used in the SSH backend tests to [8.4_p1-r3-ls48](https://hub.docker.com/layers/linuxserver/openssh-server/8.4_p1-r3-ls48/images/sha256-cde9b6e03c72b2a8b149c374bdf99d8d1556143c5e87736ef8784b534cef42ec?context=explore). The prior tag, [8.3_p1-r0-ls21](https://hub.docker.com/layers/linuxserver/openssh-server/8.3_p1-r0-ls21/images/sha256-777813ff07cd601956d2fc207c1cb420095761bd82aa580598bacaf668757151?context=explore), doesn't have SCP installed, which the test depends on. 

This fixes two tests that are currently failing in CI and locally:
- `TestSSHBackend_DynamicKeyCreate`
- `TestSSHBackend_CredsForZeroAddressRoles_dynamic`

It's not obvious when SCP was removed from the image. It appears the the image hasn't been updated in ~1 year (looking at docker hub).