### PR TITLE
Fix MSSQL compatibility with Azure SQL

### DIFF
--- a/plugins/database/mssql/mssql.go
+++ b/plugins/database/mssql/mssql.go
@@ -330,14 +330,6 @@ func (m *MSSQL) updateUserPass(ctx context.Context, username string, changePass 
 		return err
 	}
 
-	var exists bool
-
-	err = db.QueryRowContext(ctx, "SELECT 1 FROM master.sys.server_principals where name = N'$1'", username).Scan(&exists)
-
-	if err != nil && err != sql.ErrNoRows {
-		return err
-	}
-
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #10806

Removes a query from the MSSQL plugin that checks that a Server Login
exists before attempting to change its password. This behavior is
incompatible with SQL Server instances that rely on contained users
and that do not allow cross-database queries, as is the case with
Azure SQL Databases.

Additionally, some other engines (such as MySQL) do not check that
a user exists before attempting to change its password, which suggests
that this behavior is not essential.

The deletion of this query does not materially impact the behavior,
as attempting to change the password for a nonexistent login (on a
regular SQL Server instance) will result in an error message:

```shell
# Create a static login, create a static role, then delete the static login before running this command to replicate
$ vault write -force database/rotate-role/test-static
Error writing data to database/rotate-role/test-static: Error making API request.

URL: PUT http://localhost:8200/v1/database/rotate-role/test-static
Code: 500. Errors:

* 1 error occurred:
	* error setting credentials: unable to update user: rpc error: code = Internal desc = unable to update user: failed to execute query: mssql: Cannot alter the login 'staticuser', because it does not exist or you do not have permission.
```

If the Vault user is a contained user, then the "root rotation
statements" parameter can be modified to alter the password of a
`user` rather than a `login`:

```sql
ALTER USER vault WITH PASSWORD = 'securePassword123!';
```
