### PR TITLE
helper: deprecate errwrap.Wrapf()

### DIFF
--- a/helper/identity/identity.go
+++ b/helper/identity/identity.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	proto "github.com/golang/protobuf/proto"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -15,13 +14,13 @@ func (g *Group) Clone() (*Group, error) {
 
 	marshaledGroup, err := proto.Marshal(g)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to marshal group: {{err}}", err)
+		return nil, fmt.Errorf("failed to marshal group: %w", err)
 	}
 
 	var clonedGroup Group
 	err = proto.Unmarshal(marshaledGroup, &clonedGroup)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to unmarshal group: {{err}}", err)
+		return nil, fmt.Errorf("failed to unmarshal group: %w", err)
 	}
 
 	return &clonedGroup, nil
@@ -34,13 +33,13 @@ func (e *Entity) Clone() (*Entity, error) {
 
 	marshaledEntity, err := proto.Marshal(e)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to marshal entity: {{err}}", err)
+		return nil, fmt.Errorf("failed to marshal entity: %w", err)
 	}
 
 	var clonedEntity Entity
 	err = proto.Unmarshal(marshaledEntity, &clonedEntity)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to unmarshal entity: {{err}}", err)
+		return nil, fmt.Errorf("failed to unmarshal entity: %w", err)
 	}
 
 	return &clonedEntity, nil
@@ -53,13 +52,13 @@ func (p *Alias) Clone() (*Alias, error) {
 
 	marshaledAlias, err := proto.Marshal(p)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to marshal alias: {{err}}", err)
+		return nil, fmt.Errorf("failed to marshal alias: %w", err)
 	}
 
 	var clonedAlias Alias
 	err = proto.Unmarshal(marshaledAlias, &clonedAlias)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to unmarshal alias: {{err}}", err)
+		return nil, fmt.Errorf("failed to unmarshal alias: %w", err)
 	}
 
 	return &clonedAlias, nil

--- a/helper/identity/mfa/mfa.go
+++ b/helper/identity/mfa/mfa.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/hashicorp/errwrap"
 )
 
 func (c *Config) Clone() (*Config, error) {
@@ -14,13 +13,13 @@ func (c *Config) Clone() (*Config, error) {
 
 	marshaledConfig, err := proto.Marshal(c)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to marshal config: {{err}}", err)
+		return nil, fmt.Errorf("failed to marshal config: %w", err)
 	}
 
 	var clonedConfig Config
 	err = proto.Unmarshal(marshaledConfig, &clonedConfig)
 	if err != nil {
-		return nil, errwrap.Wrapf("failed to unmarshal config: {{err}}", err)
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
 	return &clonedConfig, nil

--- a/helper/pgpkeys/encrypt_decrypt.go
+++ b/helper/pgpkeys/encrypt_decrypt.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/keybase/go-crypto/openpgp"
 	"github.com/keybase/go-crypto/openpgp/packet"
 )
@@ -29,11 +28,11 @@ func EncryptShares(input [][]byte, pgpKeys []string) ([]string, [][]byte, error)
 		ctBuf := bytes.NewBuffer(nil)
 		pt, err := openpgp.Encrypt(ctBuf, []*openpgp.Entity{entity}, nil, nil, nil)
 		if err != nil {
-			return nil, nil, errwrap.Wrapf("error setting up encryption for PGP message: {{err}}", err)
+			return nil, nil, fmt.Errorf("error setting up encryption for PGP message: %w", err)
 		}
 		_, err = pt.Write(input[i])
 		if err != nil {
-			return nil, nil, errwrap.Wrapf("error encrypting PGP message: {{err}}", err)
+			return nil, nil, fmt.Errorf("error encrypting PGP message: %w", err)
 		}
 		pt.Close()
 		encryptedShares = append(encryptedShares, ctBuf.Bytes())
@@ -73,11 +72,11 @@ func GetEntities(pgpKeys []string) ([]*openpgp.Entity, error) {
 	for _, keystring := range pgpKeys {
 		data, err := base64.StdEncoding.DecodeString(keystring)
 		if err != nil {
-			return nil, errwrap.Wrapf("error decoding given PGP key: {{err}}", err)
+			return nil, fmt.Errorf("error decoding given PGP key: %w", err)
 		}
 		entity, err := openpgp.ReadEntity(packet.NewReader(bytes.NewBuffer(data)))
 		if err != nil {
-			return nil, errwrap.Wrapf("error parsing given PGP key: {{err}}", err)
+			return nil, fmt.Errorf("error parsing given PGP key: %w", err)
 		}
 		ret = append(ret, entity)
 	}
@@ -92,23 +91,23 @@ func GetEntities(pgpKeys []string) ([]*openpgp.Entity, error) {
 func DecryptBytes(encodedCrypt, privKey string) (*bytes.Buffer, error) {
 	privKeyBytes, err := base64.StdEncoding.DecodeString(privKey)
 	if err != nil {
-		return nil, errwrap.Wrapf("error decoding base64 private key: {{err}}", err)
+		return nil, fmt.Errorf("error decoding base64 private key: %w", err)
 	}
 
 	cryptBytes, err := base64.StdEncoding.DecodeString(encodedCrypt)
 	if err != nil {
-		return nil, errwrap.Wrapf("error decoding base64 crypted bytes: {{err}}", err)
+		return nil, fmt.Errorf("error decoding base64 crypted bytes: %w", err)
 	}
 
 	entity, err := openpgp.ReadEntity(packet.NewReader(bytes.NewBuffer(privKeyBytes)))
 	if err != nil {
-		return nil, errwrap.Wrapf("error parsing private key: {{err}}", err)
+		return nil, fmt.Errorf("error parsing private key: %w", err)
 	}
 
 	entityList := &openpgp.EntityList{entity}
 	md, err := openpgp.ReadMessage(bytes.NewBuffer(cryptBytes), entityList, nil, nil)
 	if err != nil {
-		return nil, errwrap.Wrapf("error decrypting the messages: {{err}}", err)
+		return nil, fmt.Errorf("error decrypting the messages: %w", err)
 	}
 
 	ptBuf := bytes.NewBuffer(nil)

--- a/helper/pgpkeys/flag.go
+++ b/helper/pgpkeys/flag.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/keybase/go-crypto/openpgp"
 )
 
@@ -128,7 +127,7 @@ func ReadPGPFile(path string) (string, error) {
 		serializedEntity := bytes.NewBuffer(nil)
 		err = entityList[0].Serialize(serializedEntity)
 		if err != nil {
-			return "", errwrap.Wrapf(fmt.Sprintf("error serializing entity for file %q: {{err}}", path), err)
+			return "", fmt.Errorf("error serializing entity for file %q: %w", path, err)
 		}
 
 		return base64.StdEncoding.EncodeToString(serializedEntity.Bytes()), nil

--- a/helper/pgpkeys/keybase.go
+++ b/helper/pgpkeys/keybase.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/keybase/go-crypto/openpgp"
@@ -102,7 +101,7 @@ func FetchKeybasePubkeys(input []string) (map[string]string, error) {
 		serializedEntity.Reset()
 		err = entityList[0].Serialize(serializedEntity)
 		if err != nil {
-			return nil, errwrap.Wrapf(fmt.Sprintf("error serializing entity for user %q: {{err}}", usernames[i]), err)
+			return nil, fmt.Errorf("error serializing entity for user %q: %w", usernames[i], err)
 		}
 
 		// The API returns values in the same ordering requested, so this should properly match

--- a/helper/proxyutil/proxyutil.go
+++ b/helper/proxyutil/proxyutil.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	proxyproto "github.com/armon/go-proxyproto"
-	"github.com/hashicorp/errwrap"
 	sockaddr "github.com/hashicorp/go-sockaddr"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
 )
@@ -56,7 +55,7 @@ func WrapInProxyProto(listener net.Listener, config *ProxyProtoConfig) (net.List
 
 				sa, err := sockaddr.NewSockAddr(addr.String())
 				if err != nil {
-					return false, errwrap.Wrapf("error parsing remote address: {{err}}", err)
+					return false, fmt.Errorf("error parsing remote address: %w", err)
 				}
 
 				for _, authorizedAddr := range config.AuthorizedAddrs {

--- a/helper/xor/xor.go
+++ b/helper/xor/xor.go
@@ -3,8 +3,6 @@ package xor
 import (
 	"encoding/base64"
 	"fmt"
-
-	"github.com/hashicorp/errwrap"
 )
 
 // XORBytes takes two byte slices and XORs them together, returning the final
@@ -30,7 +28,7 @@ func XORBytes(a, b []byte) ([]byte, error) {
 func XORBase64(a, b string) ([]byte, error) {
 	aBytes, err := base64.StdEncoding.DecodeString(a)
 	if err != nil {
-		return nil, errwrap.Wrapf("error decoding first base64 value: {{err}}", err)
+		return nil, fmt.Errorf("error decoding first base64 value: %w", err)
 	}
 	if aBytes == nil || len(aBytes) == 0 {
 		return nil, fmt.Errorf("decoded first base64 value is nil or empty")
@@ -38,7 +36,7 @@ func XORBase64(a, b string) ([]byte, error) {
 
 	bBytes, err := base64.StdEncoding.DecodeString(b)
 	if err != nil {
-		return nil, errwrap.Wrapf("error decoding second base64 value: {{err}}", err)
+		return nil, fmt.Errorf("error decoding second base64 value: %w", err)
 	}
 	if bBytes == nil || len(bBytes) == 0 {
 		return nil, fmt.Errorf("decoded second base64 value is nil or empty")


### PR DESCRIPTION
This removes `errwrap.Wrapf()` throughout `helper` and its subpackages, and replaces it with `fmt.Errorf()`.