### PR TITLE
Fix supported_transformations API docs markdown syntax

### DIFF
--- a/website/content/api-docs/secret/transform.mdx
+++ b/website/content/api-docs/secret/transform.mdx
@@ -708,8 +708,8 @@ The database user configured here should only have permission to `SELECT`,
   Specifies the database driver to use, and thus which SQL database type.
   Currently the supported options are `postgres` or `mysql`
 
-- `supported_transformations: `(list: ["tokenization"])` The types of transformations this store can host. Currently only`tokenization`
-  is supported.
+- `supported_transformations` `(list: ["tokenization"])` The types of 
+  transformations this store can host. Currently only `tokenization` is supported.
 
 - `connection_string` `(string: <required>)` -
   A database connection string with template slots for username and password that


### PR DESCRIPTION
Fix for an extraneous `:` and missing ` here:
![image](https://user-images.githubusercontent.com/1158545/117469425-53cf3b80-af1b-11eb-94e6-1bd6f9b4fca1.png)
