### PR TITLE
Fix activity log fragment race test

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1712,9 +1712,12 @@ func (a *ActivityLog) retentionWorker(currentTime time.Time, retentionMonths int
 
 	// Cancel the context if activity log is shut down.
 	// This will cause the next storage operation to fail.
+	a.l.RLock()
+	doneCh := a.doneCh
+	a.l.RUnlock()
 	go func() {
 		select {
-		case <-a.doneCh:
+		case <-doneCh:
 			cancel()
 		case <-ctx.Done():
 			break

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1125,6 +1125,8 @@ func (a *ActivityLog) activeFragmentWorker() {
 		}
 	}
 
+	// we modify the doneCh in some tests, so let's make sure we don't trip
+	// the race detector
 	a.l.RLock()
 	doneCh := a.doneCh
 	a.l.RUnlock()

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1125,9 +1125,12 @@ func (a *ActivityLog) activeFragmentWorker() {
 		}
 	}
 
+	a.l.RLock()
+	doneCh := a.doneCh
+	a.l.RUnlock()
 	for {
 		select {
-		case <-a.doneCh:
+		case <-doneCh:
 			// Shutting down activity log.
 			ticker.Stop()
 			return

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -1386,7 +1386,9 @@ func TestActivityLog_refreshFromStoredLogWithBackgroundLoadingCancelled(t *testi
 	var wg sync.WaitGroup
 	close(a.doneCh)
 	defer func() {
+		a.l.Lock()
 		a.doneCh = make(chan struct{}, 1)
+		a.l.Unlock()
 	}()
 
 	err := a.refreshFromStoredLog(context.Background(), &wg, time.Now().UTC())


### PR DESCRIPTION
functionally, this shouldn't do anything. but i think it'll make the race detector not mad anymore

goal is to fix these races: https://app.circleci.com/pipelines/github/hashicorp/vault/17270/workflows/716efca0-26cc-46b3-9b49-d73fbfa75eba/jobs/199011