### PR TITLE
Update GCP auth docs for signJwt transition to Service Account Credentials API

### DIFF
--- a/website/content/api-docs/auth/gcp.mdx
+++ b/website/content/api-docs/auth/gcp.mdx
@@ -468,5 +468,5 @@ $ curl \
 
 [gcp-adc]: https://developers.google.com/identity/protocols/application-default-credentials
 [jwt]: https://tools.ietf.org/html/rfc7519
-[signjwt-method]: https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts/signJwt
+[signjwt-method]: https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signJwt
 [instance-token]: https://cloud.google.com/compute/docs/instances/verifying-instance-identity#request_signature

--- a/website/content/docs/agent/autoauth/methods/gcp.mdx
+++ b/website/content/docs/agent/autoauth/methods/gcp.mdx
@@ -13,7 +13,7 @@ authentication types are supported.
 ## Credentials
 
 Vault will use the GCP SDK's normal credential chain behavior. You can set a
-static `credentials` value but it is usually not needed. If running on GCE
+static `credentials` value, but it is usually not needed. If running on GCE
 using Application Default Credentials, you may need to specify the service
 account and project since ADC does not provide metadata used to automatically
 determine these.
@@ -29,9 +29,6 @@ determine these.
 
 - `service_account` `(string: optional)` - The service account to use, if it
   cannot be automatically determined
-
-- `project` `(string: optional)` - The project to use, if it cannot be
-  automatically determined
 
 - `jwt_exp` `(string or int: optional)` - The number of minutes a generated JWT
   should be valid for when using the `iam` method; defaults to 15 minutes

--- a/website/content/docs/auth/gcp.mdx
+++ b/website/content/docs/auth/gcp.mdx
@@ -37,7 +37,6 @@ request to Vault. This helper is only available for IAM-type roles.
 $ vault login -method=gcp \
     role="my-role" \
     service_account="authenticating-account@my-project.iam.gserviceaccount.com" \
-    project="my-project" \
     jwt_exp="15m" \
     credentials=@path/to/signer/credentials.json
 ```
@@ -229,9 +228,9 @@ for IAM service accounts looks like this:
 
 [![Vault Google Cloud IAM Login Workflow](/img/vault-gcp-iam-auth-workflow.svg)](/img/vault-gcp-iam-auth-workflow.svg)
 
-1. The client generates a signed JWT using the IAM
-   [`projects.serviceAccounts.signJwt`][signjwt-method] method. For examples of
-   how to do this, see the [Generating JWTs](#generating-jwts) section.
+1. The client generates a signed JWT using the Service Account Credentials
+   [`projects.serviceAccounts.signJwt`][signjwt-method] API method. For examples
+   of how to do this, see the [Generating JWTs](#generating-jwts) section.
 
 2. The client sends this signed JWT to Vault along with a role name.
 
@@ -269,10 +268,10 @@ another cloud provider.
 This section details the various methods and examples for obtaining JWT
 tokens.
 
-### IAM
+### Service Account Credentials API
 
-This describes how to use the GCP IAM [API method][signjwt-method] directly
-to generate the signed JWT with the claims that Vault expects. Note the CLI
+This describes how to use the GCP Service Account Credentials [API method][signjwt-method]
+directly to generate the signed JWT with the claims that Vault expects. Note the CLI
 does this process for you and is much easier, and that there is very little
 reason to do this yourself.
 
@@ -288,33 +287,35 @@ Vault requires the following minimum claim set:
 }
 ```
 
-For the API method, expiration is optional and will default to an hour.
-If specified, expiration must be a
-[NumericDate](https://tools.ietf.org/html/rfc7519#section-2) value (seconds from
-Epoch). This value must be before the max JWT expiration allowed for a role.
-This defaults to 15 minutes and cannot be more than 1 hour.
+For the API method, providing the expiration claim `exp` is required. If it is omitted,
+it will not be added automatically and Vault will deny authentication. Expiration must
+be specified as a [NumericDate](https://tools.ietf.org/html/rfc7519#section-2) value
+(seconds from Epoch). This value must be before the max JWT expiration allowed for a
+role. This defaults to 15 minutes and cannot be more than 1 hour.
 
 One you have all this information, the JWT token can be signed using curl and
 [oauth2l](https://github.com/google/oauth2l):
 
 ```text
 ROLE="my-role"
-PROJECT="my-project"
 SERVICE_ACCOUNT="service-account@my-project.iam.gserviceaccount.com"
 OAUTH_TOKEN="$(oauth2l header cloud-platform)"
-JWT_CLAIM="{\\\"aud\\\":\\\"vault/${ROLE}\\\", \\\"sub\\\": \\\"${SERVICE_ACCOUNT}\\\"}"
+EXPIRATION="<your_token_expiration>"
+JWT_CLAIM="{\\\"aud\\\":\\\"vault/${ROLE}\\\", \\\"sub\\\": \\\"${SERVICE_ACCOUNT}\\\", \\\"exp\\\": ${EXPIRATION}}"
 
 curl \
   --header "${OAUTH_TOKEN}" \
   --header "Content-Type: application/json" \
   --request POST \
   --data "{\"payload\": \"${JWT_CLAIM}\"}" \
-  "https://iam.googleapis.com/v1/projects/${PROJECT}/serviceAccounts/${SERVICE_ACCOUNT}:signJwt"
+  "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${SERVICE_ACCOUNT}:signJwt"
 ```
 
 #### gcloud Example
 
-You can also do this through the (currently beta) gcloud command.
+You can also do this through the (currently beta) gcloud command. Note that you will
+be required to provide the expiration claim `exp` as a part of the JWT input to the
+command.
 
 ```shell-session
 $ gcloud beta iam service-accounts sign-jwt $INPUT_JWT_CLAIMS $OUTPUT_JWT_FILE \
@@ -352,7 +353,7 @@ The GCP Auth Plugin has a full HTTP API. Please see the
 [API docs][api-docs] for more details.
 
 [jwt]: https://tools.ietf.org/html/rfc7519
-[signjwt-method]: https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts/signJwt
+[signjwt-method]: https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signJwt
 [cloud-creds]: https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application
 [service-accounts]: https://cloud.google.com/compute/docs/access/service-accounts
 [api-docs]: /api/auth/gcp


### PR DESCRIPTION
## Overview

This PR updates documentation for the GCP auth method of Vault and Vault agent. It replaces all usage of the deprecated IAM [signJwt API](https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts/signJwt) with the Service Account Credentials [signJwt API](https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signJwt). It also removes appropriate instances of the `project` parameter, which is no longer needed.

I was able to successfully test the manual JWT signing instructions in the GCP auth method docs. See the [migrating-to-credentials-api#jwt-rest](https://cloud.google.com/iam/docs/migrating-to-credentials-api#jwt-rest) for details on the requirement of the `exp` claim using the new signJWT API. The [login helper](https://github.com/hashicorp/vault-plugin-auth-gcp/blob/master/plugin/cli.go#L51) and [agent auth](https://github.com/hashicorp/vault/blob/master/command/agent/auth/gcp/gcp.go#L192) code always provide the `exp` claim, so only the recommendations in the docs needed updating.

The related PRs provide a more detailed description of the changes that were made.

## Related PRs

- https://github.com/hashicorp/go-gcp-common/pull/4
- https://github.com/hashicorp/vault-plugin-auth-gcp/pull/108
- https://github.com/hashicorp/vault/pull/11473