### PR TITLE
internalshared: deprecate errwrap.Wrap()

### DIFF
--- a/internalshared/configutil/config.go
+++ b/internalshared/configutil/config.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
@@ -100,43 +99,43 @@ func ParseConfig(d string) (*SharedConfig, error) {
 
 	if o := list.Filter("hsm"); len(o.Items) > 0 {
 		if err := parseKMS(&result.Seals, o, "hsm", 2); err != nil {
-			return nil, errwrap.Wrapf("error parsing 'hsm': {{err}}", err)
+			return nil, fmt.Errorf("error parsing 'hsm': %w", err)
 		}
 	}
 
 	if o := list.Filter("seal"); len(o.Items) > 0 {
 		if err := parseKMS(&result.Seals, o, "seal", 3); err != nil {
-			return nil, errwrap.Wrapf("error parsing 'seal': {{err}}", err)
+			return nil, fmt.Errorf("error parsing 'seal': %w", err)
 		}
 	}
 
 	if o := list.Filter("kms"); len(o.Items) > 0 {
 		if err := parseKMS(&result.Seals, o, "kms", 3); err != nil {
-			return nil, errwrap.Wrapf("error parsing 'kms': {{err}}", err)
+			return nil, fmt.Errorf("error parsing 'kms': %w", err)
 		}
 	}
 
 	if o := list.Filter("entropy"); len(o.Items) > 0 {
 		if err := ParseEntropy(&result, o, "entropy"); err != nil {
-			return nil, errwrap.Wrapf("error parsing 'entropy': {{err}}", err)
+			return nil, fmt.Errorf("error parsing 'entropy': %w", err)
 		}
 	}
 
 	if o := list.Filter("listener"); len(o.Items) > 0 {
 		if err := ParseListeners(&result, o); err != nil {
-			return nil, errwrap.Wrapf("error parsing 'listener': {{err}}", err)
+			return nil, fmt.Errorf("error parsing 'listener': %w", err)
 		}
 	}
 
 	if o := list.Filter("telemetry"); len(o.Items) > 0 {
 		if err := parseTelemetry(&result, o); err != nil {
-			return nil, errwrap.Wrapf("error parsing 'telemetry': {{err}}", err)
+			return nil, fmt.Errorf("error parsing 'telemetry': %w", err)
 		}
 	}
 
 	entConfig := &(result.EntSharedConfig)
 	if err := entConfig.ParseConfig(list); err != nil {
-		return nil, errwrap.Wrapf("error parsing enterprise config: {{err}}", err)
+		return nil, fmt.Errorf("error parsing enterprise config: %w", err)
 	}
 
 	return &result, nil

--- a/internalshared/configutil/kms.go
+++ b/internalshared/configutil/kms.go
@@ -146,13 +146,13 @@ func ParseKMSes(d string) ([]*KMS, error) {
 
 	if o := list.Filter("seal"); len(o.Items) > 0 {
 		if err := parseKMS(&result.Seals, o, "seal", 3); err != nil {
-			return nil, errwrap.Wrapf("error parsing 'seal': {{err}}", err)
+			return nil, fmt.Errorf("error parsing 'seal': %w", err)
 		}
 	}
 
 	if o := list.Filter("kms"); len(o.Items) > 0 {
 		if err := parseKMS(&result.Seals, o, "kms", 3); err != nil {
-			return nil, errwrap.Wrapf("error parsing 'kms': {{err}}", err)
+			return nil, fmt.Errorf("error parsing 'kms': %w", err)
 		}
 	}
 

--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -14,7 +14,6 @@ import (
 	"github.com/armon/go-metrics/prometheus"
 	stackdriver "github.com/google/go-metrics-stackdriver"
 	stackdrivervault "github.com/google/go-metrics-stackdriver/vault"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
@@ -342,7 +341,7 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 
 		sink, err := datadog.NewDogStatsdSink(opts.Config.DogStatsDAddr, metricsConf.HostName)
 		if err != nil {
-			return nil, nil, false, errwrap.Wrapf("failed to start DogStatsD sink: {{err}}", err)
+			return nil, nil, false, fmt.Errorf("failed to start DogStatsD sink: %w", err)
 		}
 		sink.SetTags(tags)
 		fanout = append(fanout, sink)

--- a/internalshared/kv-builder/builder.go
+++ b/internalshared/kv-builder/builder.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/mitchellh/mapstructure"
 )
@@ -31,7 +30,7 @@ func (b *Builder) Map() map[string]interface{} {
 func (b *Builder) Add(args ...string) error {
 	for _, a := range args {
 		if err := b.add(a); err != nil {
-			return errwrap.Wrapf(fmt.Sprintf("invalid key/value pair %q: {{err}}", a), err)
+			return fmt.Errorf("invalid key/value pair %q: %w", a, err)
 		}
 	}
 
@@ -88,7 +87,7 @@ func (b *Builder) add(raw string) error {
 		if value[0] == '@' {
 			contents, err := ioutil.ReadFile(value[1:])
 			if err != nil {
-				return errwrap.Wrapf("error reading file: {{err}}", err)
+				return fmt.Errorf("error reading file: %w", err)
 			}
 
 			value = string(contents)

--- a/internalshared/listenerutil/listener.go
+++ b/internalshared/listenerutil/listener.go
@@ -96,7 +96,7 @@ func TLSConfig(
 				}
 			}
 		}
-		return nil, nil, errwrap.Wrapf("error loading TLS cert: {{err}}", err)
+		return nil, nil, fmt.Errorf("error loading TLS cert: %w", err)
 	}
 
 PASSPHRASECORRECT:
@@ -142,7 +142,7 @@ PASSPHRASECORRECT:
 				// Get the name of the current cipher.
 				cipherStr, err := tlsutil.GetCipherName(cipher)
 				if err != nil {
-					return nil, nil, errwrap.Wrapf("invalid value for 'tls_cipher_suites': {{err}}", err)
+					return nil, nil, fmt.Errorf("invalid value for 'tls_cipher_suites': %w", err)
 				}
 				badCiphers = append(badCiphers, cipherStr)
 			}
@@ -167,7 +167,7 @@ Please see https://tools.ietf.org/html/rfc7540#appendix-A for further informatio
 			caPool := x509.NewCertPool()
 			data, err := ioutil.ReadFile(l.TLSClientCAFile)
 			if err != nil {
-				return nil, nil, errwrap.Wrapf("failed to read tls_client_ca_file: {{err}}", err)
+				return nil, nil, fmt.Errorf("failed to read tls_client_ca_file: %w", err)
 			}
 
 			if !caPool.AppendCertsFromPEM(data) {

--- a/internalshared/reloadutil/reload.go
+++ b/internalshared/reloadutil/reload.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"sync"
-
-	"github.com/hashicorp/errwrap"
 )
 
 // ReloadFunc are functions that are called when a reload is requested
@@ -55,7 +53,7 @@ func (cg *CertificateGetter) Reload() error {
 	if x509.IsEncryptedPEMBlock(keyBlock) {
 		keyBlock.Bytes, err = x509.DecryptPEMBlock(keyBlock, []byte(cg.passphrase))
 		if err != nil {
-			return errwrap.Wrapf("Decrypting PEM block failed {{err}}", err)
+			return fmt.Errorf("Decrypting PEM block failed %w", err)
 		}
 		keyPEMBlock = pem.EncodeToMemory(keyBlock)
 	}


### PR DESCRIPTION
This removes `errwrap.Wrapf()` throughout the `internalshared` subpackages and replaces it with `fmt.Errorf()`.