### PR TITLE
vault-2363: fix activity log test panic, improve log

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1577,7 +1577,7 @@ func (a *ActivityLog) precomputedQueryWorker() error {
 	}
 
 	lastMonth := intent.PreviousMonth
-	a.logger.Info("computing queries", "month", lastMonth)
+	a.logger.Info("computing queries", "month", time.Unix(lastMonth, 0).UTC())
 
 	times, err := a.getMostRecentActivityLogSegment(ctx)
 	if err != nil {

--- a/vault/activity_log_test.go
+++ b/vault/activity_log_test.go
@@ -1808,6 +1808,10 @@ func TestActivityLog_EndOfMonth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if intentRaw == nil {
+		t.Fatal("no intent log present")
+	}
+
 	var intent ActivityIntentLog
 	err = intentRaw.DecodeJSON(&intent)
 	if err != nil {


### PR DESCRIPTION
Note: this won't fix the reason that there is no data there, but at least it won't panic

Also, now the month part of that log is human-readable