### PR TITLE
Check ErrPluginStaticUnsupported for fallback to RotateRootCredentials

### DIFF
--- a/builtin/logical/database/version_wrapper.go
+++ b/builtin/logical/database/version_wrapper.go
@@ -152,7 +152,7 @@ func (d databaseVersionWrapper) changePasswordLegacy(ctx context.Context, userna
 	err = d.changeUserPasswordLegacy(ctx, username, passwordChange)
 
 	// If changing the root user's password but SetCredentials is unimplemented, fall back to RotateRootCredentials
-	if isRootUser && status.Code(err) == codes.Unimplemented {
+	if isRootUser && (err == v4.ErrPluginStaticUnsupported || status.Code(err) == codes.Unimplemented) {
 		saveConfig, err = d.changeRootUserPasswordLegacy(ctx, passwordChange)
 		if err != nil {
 			return nil, err

--- a/builtin/logical/database/version_wrapper_test.go
+++ b/builtin/logical/database/version_wrapper_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	v4 "github.com/hashicorp/vault/sdk/database/dbplugin"
 	v5 "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/mock"
@@ -672,7 +673,7 @@ func TestUpdateUser_legacyDB(t *testing.T) {
 			expectedConfig: nil,
 			expectErr:      true,
 		},
-		"change password - RotateRootCredentials": {
+		"change password - RotateRootCredentials (gRPC Unimplemented)": {
 			req: v5.UpdateUserRequest{
 				Username: "existing_user",
 				Password: &v5.ChangePassword{
@@ -682,6 +683,30 @@ func TestUpdateUser_legacyDB(t *testing.T) {
 			isRootUser: true,
 
 			setCredentialsErr:   status.Error(codes.Unimplemented, "SetCredentials is not implemented"),
+			setCredentialsCalls: 1,
+
+			rotateRootConfig: map[string]interface{}{
+				"foo": "bar",
+			},
+			rotateRootCalls: 1,
+
+			renewUserCalls: 0,
+
+			expectedConfig: map[string]interface{}{
+				"foo": "bar",
+			},
+			expectErr: false,
+		},
+		"change password - RotateRootCredentials (ErrPluginStaticUnsupported)": {
+			req: v5.UpdateUserRequest{
+				Username: "existing_user",
+				Password: &v5.ChangePassword{
+					NewPassword: "newpassowrd",
+				},
+			},
+			isRootUser: true,
+
+			setCredentialsErr:   v4.ErrPluginStaticUnsupported,
 			setCredentialsCalls: 1,
 
 			rotateRootConfig: map[string]interface{}{


### PR DESCRIPTION
When using the V4 DB engine and the user wants to rotate the root credentials, the `SetCredentials` call is attempted. If `SetCredentials` comes back with an "unimplemented" error, the DB engine should fall back to running `RotateRootCredentials`. Previously, it was making the check to determine if it should fall back by checking for an `Unimplemented` gRPC status code. This is never being hit because `ErrPluginStaticUnsupported` is returned instead: https://github.com/hashicorp/vault/blob/master/sdk/database/dbplugin/grpc_transport.go#L341-L345

This PR fixes this by adding `ErrPluginStaticUnsupported` as an additional check to determine if it should fall back to `RotateRootCredentials`.