### PR TITLE
Diagnose: Add Subspan and Timeout Logic

### DIFF
--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -227,11 +227,6 @@ func (c *OperatorDiagnoseCommand) offlineDiagnostics(ctx context.Context) error 
 		}
 		backend = &b
 
-		dirAccess := diagnose.ConsulDirectAccess(config.HAStorage.Config)
-		if dirAccess != "" {
-			diagnose.Warn(ctx, dirAccess)
-		}
-
 		if config.Storage != nil && config.Storage.Type == storageTypeConsul {
 			err = physconsul.SetupSecureTLS(api.DefaultConfig(), config.Storage.Config, server.logger, true)
 			if err != nil {
@@ -357,6 +352,10 @@ func (c *OperatorDiagnoseCommand) offlineDiagnostics(ctx context.Context) error 
 		disableClustering, err = initHaBackend(server, config, &coreConfig, *backend)
 		if err != nil {
 			return err
+		}
+		dirAccess := diagnose.ConsulDirectAccess(config.HAStorage.Config)
+		if dirAccess != "" {
+			diagnose.Warn(ctx, dirAccess)
 		}
 		return nil
 	}); err != nil {

--- a/command/operator_diagnose.go
+++ b/command/operator_diagnose.go
@@ -221,11 +221,16 @@ func (c *OperatorDiagnoseCommand) offlineDiagnostics(ctx context.Context) error 
 
 	var backend *physical.Backend
 	if err := diagnose.Test(ctx, "storage", func(ctx context.Context) error {
-		b, err := server.setupStorage(config)
-		if err != nil {
+		if err := diagnose.Test(ctx, "create-storage-backend", func(ctx context.Context) error {
+			b, err := server.setupStorage(config)
+			if err != nil {
+				return err
+			}
+			backend = &b
+			return nil
+		}); err != nil {
 			return err
 		}
-		backend = &b
 
 		if config.Storage != nil && config.Storage.Type == storageTypeConsul {
 			err = physconsul.SetupSecureTLS(api.DefaultConfig(), config.Storage.Config, server.logger, true)

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -49,6 +49,12 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:   "storage",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-storage-backend",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "service-discovery",
@@ -119,6 +125,12 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 					Name:    "storage",
 					Status:  diagnose.ErrorStatus,
 					Message: "A storage backend must be specified",
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-storage-backend",
+							Status: diagnose.ErrorStatus,
+						},
+					},
 				},
 				{
 					Name:   "service-discovery",
@@ -190,6 +202,12 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:   "storage",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-storage-backend",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "service-discovery",
@@ -256,6 +274,12 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:   "storage",
 					Status: diagnose.ErrorStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-storage-backend",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 			},
 		},
@@ -276,6 +300,12 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:   "storage",
 					Status: diagnose.ErrorStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-storage-backend",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 			},
 		},
@@ -296,6 +326,12 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:   "storage",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-storage-backend",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:    "service-discovery",
@@ -326,6 +362,12 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 					Status: diagnose.WarningStatus,
 					Warnings: []string{
 						diagnose.DirAccessErr,
+					},
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-storage-backend",
+							Status: diagnose.OkStatus,
+						},
 					},
 				},
 				{

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -76,7 +76,7 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				},
 				{
 					Name:   "init-core",
-					Status: diagnose.OkStatus,
+					Status: diagnose.ErrorStatus,
 				},
 				{
 					Name:   "init-listeners",
@@ -101,287 +101,287 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				},
 			},
 		},
-		// {
-		// 	"diagnose_invalid_storage",
-		// 	[]string{
-		// 		"-config", "./server/test-fixtures/nostore_config.hcl",
-		// 	},
-		// 	[]*diagnose.Result{
-		// 		{
-		// 			Name:   "parse-config",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "setup-telemetry",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:    "storage",
-		// 			Status:  diagnose.ErrorStatus,
-		// 			Message: "A storage backend must be specified",
-		// 		},
-		// 		{
-		// 			Name:   "service-discovery",
-		// 			Status: diagnose.ErrorStatus,
-		// 		},
-		// 		{
-		// 			Name:   "create-seal",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:    "setup-core",
-		// 			Status:  diagnose.ErrorStatus,
-		// 			Message: BackendUninitializedErr,
-		// 		},
-		// 		{
-		// 			Name:    "setup-ha-storage",
-		// 			Status:  diagnose.ErrorStatus,
-		// 			Message: BackendUninitializedErr,
-		// 		},
-		// 		{
-		// 			Name:   "determine-redirect",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "find-cluster-addr",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "init-core",
-		// 			Status: diagnose.ErrorStatus,
-		// 		},
-		// 		{
-		// 			Name:   "init-listeners",
-		// 			Status: diagnose.WarningStatus,
-		// 			Warnings: []string{
-		// 				"TLS is disabled in a Listener config stanza.",
-		// 			},
-		// 		},
-		// 		{
-		// 			Name:    "unseal",
-		// 			Status:  diagnose.ErrorStatus,
-		// 			Message: "core could not be initialized",
-		// 		},
-		// 		{
-		// 			Name:   "run-listeners",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:    "start-servers",
-		// 			Status:  diagnose.ErrorStatus,
-		// 			Message: CoreUninitializedErr,
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	"diagnose_listener_config_ok",
-		// 	[]string{
-		// 		"-config", "./server/test-fixtures/tls_config_ok.hcl",
-		// 	},
-		// 	[]*diagnose.Result{
-		// 		{
-		// 			Name:   "parse-config",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "setup-telemetry",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "storage",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "service-discovery",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "create-seal",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "setup-core",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "setup-ha-storage",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "determine-redirect",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "find-cluster-addr",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "init-core",
-		// 			Status: diagnose.ErrorStatus,
-		// 		},
-		// 		{
-		// 			Name:   "init-listeners",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:    "unseal",
-		// 			Status:  diagnose.ErrorStatus,
-		// 			Message: "core could not be initialized",
-		// 		},
-		// 		{
-		// 			Name:   "run-listeners",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:    "start-servers",
-		// 			Status:  diagnose.ErrorStatus,
-		// 			Message: CoreUninitializedErr,
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	"diagnose_invalid_https_storage",
-		// 	[]string{
-		// 		"-config", "./server/test-fixtures/config_bad_https_storage.hcl",
-		// 	},
-		// 	[]*diagnose.Result{
-		// 		{
-		// 			Name:   "parse-config",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "setup-telemetry",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "storage",
-		// 			Status: diagnose.ErrorStatus,
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	"diagnose_invalid_https_hastorage",
-		// 	[]string{
-		// 		"-config", "./server/test-fixtures/config_diagnose_hastorage_bad_https.hcl",
-		// 	},
-		// 	[]*diagnose.Result{
-		// 		{
-		// 			Name:   "parse-config",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "setup-telemetry",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "storage",
-		// 			Status: diagnose.ErrorStatus,
-		// 			Warnings: []string{
-		// 				diagnose.AddrDNExistErr,
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	"diagnose_invalid_https_sr",
-		// 	[]string{
-		// 		"-config", "./server/test-fixtures/diagnose_bad_https_consul_sr.hcl",
-		// 	},
-		// 	[]*diagnose.Result{
-		// 		{
-		// 			Name:   "parse-config",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "setup-telemetry",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "storage",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:    "service-discovery",
-		// 			Status:  diagnose.ErrorStatus,
-		// 			Message: "failed to verify certificate: x509: certificate has expired or is not yet valid",
-		// 			Warnings: []string{
-		// 				diagnose.DirAccessErr,
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	"diagnose_direct_storage_access",
-		// 	[]string{
-		// 		"-config", "./server/test-fixtures/diagnose_ok_storage_direct_access.hcl",
-		// 	},
-		// 	[]*diagnose.Result{
-		// 		{
-		// 			Name:   "parse-config",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "setup-telemetry",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "storage",
-		// 			Status: diagnose.WarningStatus,
-		// 			Warnings: []string{
-		// 				diagnose.DirAccessErr,
-		// 			},
-		// 		},
-		// 		{
-		// 			Name:   "service-discovery",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "create-seal",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "setup-core",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "setup-ha-storage",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "determine-redirect",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "find-cluster-addr",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:   "init-core",
-		// 			Status: diagnose.ErrorStatus,
-		// 		},
-		// 		{
-		// 			Name:   "init-listeners",
-		// 			Status: diagnose.WarningStatus,
-		// 			Warnings: []string{
-		// 				"TLS is disabled in a Listener config stanza.",
-		// 			},
-		// 		},
-		// 		{
-		// 			Name:    "unseal",
-		// 			Status:  diagnose.ErrorStatus,
-		// 			Message: "core could not be initialized",
-		// 		},
-		// 		{
-		// 			Name:   "run-listeners",
-		// 			Status: diagnose.OkStatus,
-		// 		},
-		// 		{
-		// 			Name:    "start-servers",
-		// 			Status:  diagnose.ErrorStatus,
-		// 			Message: CoreUninitializedErr,
-		// 		},
-		// 	},
-		// },
+		{
+			"diagnose_invalid_storage",
+			[]string{
+				"-config", "./server/test-fixtures/nostore_config.hcl",
+			},
+			[]*diagnose.Result{
+				{
+					Name:   "parse-config",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-telemetry",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:    "storage",
+					Status:  diagnose.ErrorStatus,
+					Message: "A storage backend must be specified",
+				},
+				{
+					Name:   "service-discovery",
+					Status: diagnose.ErrorStatus,
+				},
+				{
+					Name:   "create-seal",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:    "setup-core",
+					Status:  diagnose.ErrorStatus,
+					Message: BackendUninitializedErr,
+				},
+				{
+					Name:    "setup-ha-storage",
+					Status:  diagnose.ErrorStatus,
+					Message: BackendUninitializedErr,
+				},
+				{
+					Name:   "determine-redirect",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "find-cluster-addr",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "init-core",
+					Status: diagnose.ErrorStatus,
+				},
+				{
+					Name:   "init-listeners",
+					Status: diagnose.WarningStatus,
+					Warnings: []string{
+						"TLS is disabled in a Listener config stanza.",
+					},
+				},
+				{
+					Name:    "unseal",
+					Status:  diagnose.ErrorStatus,
+					Message: "core could not be initialized",
+				},
+				{
+					Name:   "run-listeners",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:    "start-servers",
+					Status:  diagnose.ErrorStatus,
+					Message: CoreUninitializedErr,
+				},
+			},
+		},
+		{
+			"diagnose_listener_config_ok",
+			[]string{
+				"-config", "./server/test-fixtures/tls_config_ok.hcl",
+			},
+			[]*diagnose.Result{
+				{
+					Name:   "parse-config",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-telemetry",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "storage",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "service-discovery",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "create-seal",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-core",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-ha-storage",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "determine-redirect",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "find-cluster-addr",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "init-core",
+					Status: diagnose.ErrorStatus,
+				},
+				{
+					Name:   "init-listeners",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:    "unseal",
+					Status:  diagnose.ErrorStatus,
+					Message: "core could not be initialized",
+				},
+				{
+					Name:   "run-listeners",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:    "start-servers",
+					Status:  diagnose.ErrorStatus,
+					Message: CoreUninitializedErr,
+				},
+			},
+		},
+		{
+			"diagnose_invalid_https_storage",
+			[]string{
+				"-config", "./server/test-fixtures/config_bad_https_storage.hcl",
+			},
+			[]*diagnose.Result{
+				{
+					Name:   "parse-config",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-telemetry",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "storage",
+					Status: diagnose.ErrorStatus,
+				},
+			},
+		},
+		{
+			"diagnose_invalid_https_hastorage",
+			[]string{
+				"-config", "./server/test-fixtures/config_diagnose_hastorage_bad_https.hcl",
+			},
+			[]*diagnose.Result{
+				{
+					Name:   "parse-config",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-telemetry",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "storage",
+					Status: diagnose.ErrorStatus,
+					Warnings: []string{
+						diagnose.AddrDNExistErr,
+					},
+				},
+			},
+		},
+		{
+			"diagnose_invalid_https_sr",
+			[]string{
+				"-config", "./server/test-fixtures/diagnose_bad_https_consul_sr.hcl",
+			},
+			[]*diagnose.Result{
+				{
+					Name:   "parse-config",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-telemetry",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "storage",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:    "service-discovery",
+					Status:  diagnose.ErrorStatus,
+					Message: "failed to verify certificate: x509: certificate has expired or is not yet valid",
+					Warnings: []string{
+						diagnose.DirAccessErr,
+					},
+				},
+			},
+		},
+		{
+			"diagnose_direct_storage_access",
+			[]string{
+				"-config", "./server/test-fixtures/diagnose_ok_storage_direct_access.hcl",
+			},
+			[]*diagnose.Result{
+				{
+					Name:   "parse-config",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-telemetry",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "storage",
+					Status: diagnose.WarningStatus,
+					Warnings: []string{
+						diagnose.DirAccessErr,
+					},
+				},
+				{
+					Name:   "service-discovery",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "create-seal",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-core",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-ha-storage",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "determine-redirect",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "find-cluster-addr",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "init-core",
+					Status: diagnose.ErrorStatus,
+				},
+				{
+					Name:   "init-listeners",
+					Status: diagnose.WarningStatus,
+					Warnings: []string{
+						"TLS is disabled in a Listener config stanza.",
+					},
+				},
+				{
+					Name:    "unseal",
+					Status:  diagnose.ErrorStatus,
+					Message: "core could not be initialized",
+				},
+				{
+					Name:   "run-listeners",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:    "start-servers",
+					Status:  diagnose.ErrorStatus,
+					Message: CoreUninitializedErr,
+				},
+			},
+		},
 	}
 
 	t.Run("validations", func(t *testing.T) {

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -54,11 +54,33 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 							Name:   "create-storage-backend",
 							Status: diagnose.OkStatus,
 						},
+						{
+							Name:   "test-storage-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-storage",
+							Status: diagnose.OkStatus,
+						},
 					},
 				},
 				{
 					Name:   "service-discovery",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "test-serviceregistration-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-service-discovery",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "init-consul-serviceregistration",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "create-seal",
@@ -67,10 +89,30 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:   "setup-core",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "init-randreader",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "setup-ha-storage",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-ha-storage-backend",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-storage",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-storage-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "determine-redirect",
@@ -86,9 +128,19 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				},
 				{
 					Name:   "init-listeners",
-					Status: diagnose.WarningStatus,
-					Warnings: []string{
-						"TLS is disabled in a Listener config stanza.",
+					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-listeners",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "check-listener-tls",
+							Status: diagnose.WarningStatus,
+							Warnings: []string{
+								"TLS is disabled in a Listener config stanza.",
+							},
+						},
 					},
 				},
 				{
@@ -124,7 +176,7 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:    "storage",
 					Status:  diagnose.ErrorStatus,
-					Message: "A storage backend must be specified",
+					Message: "no storage stanza found in config",
 					Children: []*diagnose.Result{
 						{
 							Name:   "create-storage-backend",
@@ -144,6 +196,12 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 					Name:    "setup-core",
 					Status:  diagnose.ErrorStatus,
 					Message: BackendUninitializedErr,
+					Children: []*diagnose.Result{
+						{
+							Name:   "init-randreader",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:    "setup-ha-storage",
@@ -164,9 +222,19 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				},
 				{
 					Name:   "init-listeners",
-					Status: diagnose.WarningStatus,
-					Warnings: []string{
-						"TLS is disabled in a Listener config stanza.",
+					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-listeners",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "check-listener-tls",
+							Status: diagnose.WarningStatus,
+							Warnings: []string{
+								"TLS is disabled in a Listener config stanza.",
+							},
+						},
 					},
 				},
 				{
@@ -207,11 +275,33 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 							Name:   "create-storage-backend",
 							Status: diagnose.OkStatus,
 						},
+						{
+							Name:   "test-storage-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-storage",
+							Status: diagnose.OkStatus,
+						},
 					},
 				},
 				{
 					Name:   "service-discovery",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "test-serviceregistration-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-service-discovery",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "init-consul-serviceregistration",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "create-seal",
@@ -220,10 +310,30 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:   "setup-core",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "init-randreader",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "setup-ha-storage",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-ha-storage-backend",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-storage",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-storage-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "determine-redirect",
@@ -240,6 +350,19 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:   "init-listeners",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-listeners",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "check-listener-tls",
+							Status: diagnose.WarningStatus,
+							Warnings: []string{
+								"TLS is disabled in a Listener config stanza.",
+							},
+						},
+					},
 				},
 				{
 					Name:    "unseal",
@@ -279,6 +402,64 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 							Name:   "create-storage-backend",
 							Status: diagnose.OkStatus,
 						},
+						{
+							Name:   "test-storage-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-storage",
+							Status: diagnose.OkStatus,
+						},
+					},
+				},
+				{
+					Name:   "service-discovery",
+					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "test-serviceregistration-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-service-discovery",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "init-consul-serviceregistration",
+							Status: diagnose.OkStatus,
+						},
+					},
+				},
+				{
+					Name:   "create-seal",
+					Status: diagnose.OkStatus,
+				},
+				{
+					Name:   "setup-core",
+					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "init-randreader",
+							Status: diagnose.OkStatus,
+						},
+					},
+				},
+				{
+					Name:   "setup-ha-storage",
+					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-ha-storage-backend",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-storage",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-storage-tls-consul",
+							Status: diagnose.OkStatus,
+						},
 					},
 				},
 			},
@@ -303,6 +484,14 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 					Children: []*diagnose.Result{
 						{
 							Name:   "create-storage-backend",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-storage-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-storage",
 							Status: diagnose.OkStatus,
 						},
 					},
@@ -331,14 +520,37 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 							Name:   "create-storage-backend",
 							Status: diagnose.OkStatus,
 						},
+						{
+							Name:   "test-storage-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-storage",
+							Status: diagnose.OkStatus,
+						},
 					},
 				},
 				{
 					Name:    "service-discovery",
 					Status:  diagnose.ErrorStatus,
 					Message: "failed to verify certificate: x509: certificate has expired or is not yet valid",
-					Warnings: []string{
-						diagnose.DirAccessErr,
+					Children: []*diagnose.Result{
+						{
+							Name:    "test-serviceregistration-tls-consul",
+							Status:  diagnose.ErrorStatus,
+							Message: "failed to verify certificate: x509: certificate has expired or is not yet valid",
+						},
+						{
+							Name:   "test-consul-direct-access-service-discovery",
+							Status: diagnose.WarningStatus,
+							Warnings: []string{
+								diagnose.DirAccessErr,
+							},
+						},
+						{
+							Name:   "init-consul-serviceregistration",
+							Status: diagnose.OkStatus,
+						},
 					},
 				},
 			},
@@ -359,20 +571,42 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				},
 				{
 					Name:   "storage",
-					Status: diagnose.WarningStatus,
-					Warnings: []string{
-						diagnose.DirAccessErr,
-					},
+					Status: diagnose.OkStatus,
 					Children: []*diagnose.Result{
 						{
 							Name:   "create-storage-backend",
 							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-storage-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-storage",
+							Status: diagnose.WarningStatus,
+							Warnings: []string{
+								diagnose.DirAccessErr,
+							},
 						},
 					},
 				},
 				{
 					Name:   "service-discovery",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "test-serviceregistration-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-service-discovery",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "init-consul-serviceregistration",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "create-seal",
@@ -381,10 +615,30 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:   "setup-core",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "init-randreader",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "setup-ha-storage",
 					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-ha-storage-backend",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-consul-direct-access-storage",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "test-storage-tls-consul",
+							Status: diagnose.OkStatus,
+						},
+					},
 				},
 				{
 					Name:   "determine-redirect",
@@ -400,9 +654,19 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				},
 				{
 					Name:   "init-listeners",
-					Status: diagnose.WarningStatus,
-					Warnings: []string{
-						"TLS is disabled in a Listener config stanza.",
+					Status: diagnose.OkStatus,
+					Children: []*diagnose.Result{
+						{
+							Name:   "create-listeners",
+							Status: diagnose.OkStatus,
+						},
+						{
+							Name:   "check-listener-tls",
+							Status: diagnose.WarningStatus,
+							Warnings: []string{
+								"TLS is disabled in a Listener config stanza.",
+							},
+						},
 					},
 				},
 				{

--- a/command/operator_diagnose_test.go
+++ b/command/operator_diagnose_test.go
@@ -276,9 +276,6 @@ func TestOperatorDiagnoseCommand_Run(t *testing.T) {
 				{
 					Name:   "storage",
 					Status: diagnose.ErrorStatus,
-					Warnings: []string{
-						diagnose.AddrDNExistErr,
-					},
 				},
 			},
 		},

--- a/command/server/test-fixtures/config_diagnose_hastorage_bad_https.hcl
+++ b/command/server/test-fixtures/config_diagnose_hastorage_bad_https.hcl
@@ -11,12 +11,13 @@ listener "tcp" {
 backend "consul" {
     foo = "bar"
     advertise_addr = "foo"
-    address = "127.0.0.1:1028"
+    address = "https://remoteconsulserverIP:1028"
 
 }
 
 ha_backend "consul" {
     bar = "baz"
+    address = "127.0.0.1:1028"
     advertise_addr = "snafu"
     disable_clustering = "true"
     scheme = "https"

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,6 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
-github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
-github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f h1:gJzxrodnNd/CtPXjO3WYiakyNzHg3rtAi7rO74ejHYU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=

--- a/vault/diagnose/helpers.go
+++ b/vault/diagnose/helpers.go
@@ -2,6 +2,8 @@ package diagnose
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -146,4 +148,23 @@ func Test(ctx context.Context, spanName string, function func(context.Context) e
 		span.SetStatus(codes.Error, err.Error())
 	}
 	return err
+}
+
+// WithTimeout wraps a context consuming function, and when called, returns an error if the sub-function does not
+// complete within the timeout, e.g.
+//
+// diagnose.Test(ctx, "my-span", diagnose.WithTimeout(5 * time.Second, myTestFunc))
+func WithTimeout(d time.Duration, f func(context.Context) error) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		rch := make(chan error)
+		t := time.NewTimer(d)
+		defer t.Stop()
+		go f(ctx)
+		select {
+		case <-t.C:
+			return fmt.Errorf("timed out after %s", d.String())
+		case err := <-rch:
+			return err
+		}
+	}
 }

--- a/website/content/docs/concepts/response-wrapping.mdx
+++ b/website/content/docs/concepts/response-wrapping.mdx
@@ -26,9 +26,12 @@ To help address this problem, Vault includes a feature called _response
 wrapping_. When requested, Vault can take the response it would have sent to an
 HTTP client and instead insert it into the
 [`cubbyhole`](/docs/secrets/cubbyhole) of a single-use token,
-returning that single-use token instead. Logically speaking, the response is
+returning that single-use token instead.
+
+Logically speaking, the response is
 wrapped by the token, and retrieving it requires an unwrap operation against
-this token.
+this token. Functionally speaking, the token provides authorization to use
+an encryption key from Vault's keyring to decrypt the data.
 
 This provides a powerful mechanism for information sharing in many
 environments. In the types of scenarios, described above, often the best


### PR DESCRIPTION
This PR aims to split up the diagnose checks into subspans (and corresponding substeps) when appropriate. It also aims to wrap relevant calls in timeout logic. The subspace logic is complete.

This PR is currently a draft because the timeout logic seems to wait for the entire time-span alotted to the timeout, even when the call does not hang. Consequently, everything has not been wrapped in timeouts. Also there is an open question around whether we should include the Telemetry setup at all (and if not, how we should instantiate metrics objects in the coreconfig setup step. 