### PR TITLE
plugins: deprecate errwrap.Wrapf()

### DIFF
--- a/plugins/database/influxdb/connection_producer.go
+++ b/plugins/database/influxdb/connection_producer.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
@@ -62,7 +61,7 @@ func (i *influxdbConnectionProducer) Initialize(ctx context.Context, req dbplugi
 	}
 	i.connectTimeout, err = parseutil.ParseDurationSecond(i.ConnectTimeoutRaw)
 	if err != nil {
-		return dbplugin.InitializeResponse{}, errwrap.Wrapf("invalid connect_timeout: {{err}}", err)
+		return dbplugin.InitializeResponse{}, fmt.Errorf("invalid connect_timeout: %w", err)
 	}
 
 	switch {
@@ -80,11 +79,11 @@ func (i *influxdbConnectionProducer) Initialize(ctx context.Context, req dbplugi
 	case len(i.PemJSON) != 0:
 		parsedCertBundle, err = certutil.ParsePKIJSON([]byte(i.PemJSON))
 		if err != nil {
-			return dbplugin.InitializeResponse{}, errwrap.Wrapf("could not parse given JSON; it must be in the format of the output of the PKI backend certificate issuing command: {{err}}", err)
+			return dbplugin.InitializeResponse{}, fmt.Errorf("could not parse given JSON; it must be in the format of the output of the PKI backend certificate issuing command: %w", err)
 		}
 		certBundle, err = parsedCertBundle.ToCertBundle()
 		if err != nil {
-			return dbplugin.InitializeResponse{}, errwrap.Wrapf("Error marshaling PEM information: {{err}}", err)
+			return dbplugin.InitializeResponse{}, fmt.Errorf("Error marshaling PEM information: %w", err)
 		}
 		i.certificate = certBundle.Certificate
 		i.privateKey = certBundle.PrivateKey
@@ -94,11 +93,11 @@ func (i *influxdbConnectionProducer) Initialize(ctx context.Context, req dbplugi
 	case len(i.PemBundle) != 0:
 		parsedCertBundle, err = certutil.ParsePEMBundle(i.PemBundle)
 		if err != nil {
-			return dbplugin.InitializeResponse{}, errwrap.Wrapf("Error parsing the given PEM information: {{err}}", err)
+			return dbplugin.InitializeResponse{}, fmt.Errorf("Error parsing the given PEM information: %w", err)
 		}
 		certBundle, err = parsedCertBundle.ToCertBundle()
 		if err != nil {
-			return dbplugin.InitializeResponse{}, errwrap.Wrapf("Error marshaling PEM information: {{err}}", err)
+			return dbplugin.InitializeResponse{}, fmt.Errorf("Error marshaling PEM information: %w", err)
 		}
 		i.certificate = certBundle.Certificate
 		i.privateKey = certBundle.PrivateKey
@@ -112,7 +111,7 @@ func (i *influxdbConnectionProducer) Initialize(ctx context.Context, req dbplugi
 
 	if req.VerifyConnection {
 		if _, err := i.Connection(ctx); err != nil {
-			return dbplugin.InitializeResponse{}, errwrap.Wrapf("error verifying connection: {{err}}", err)
+			return dbplugin.InitializeResponse{}, fmt.Errorf("error verifying connection: %w", err)
 		}
 	}
 
@@ -185,12 +184,12 @@ func (i *influxdbConnectionProducer) createClient() (influx.Client, error) {
 
 			parsedCertBundle, err := certBundle.ToParsedCertBundle()
 			if err != nil {
-				return nil, errwrap.Wrapf("failed to parse certificate bundle: {{err}}", err)
+				return nil, fmt.Errorf("failed to parse certificate bundle: %w", err)
 			}
 
 			tlsConfig, err = parsedCertBundle.GetTLSConfig(certutil.TLSClient)
 			if err != nil || tlsConfig == nil {
-				return nil, errwrap.Wrapf(fmt.Sprintf("failed to get TLS configuration: tlsConfig:%#v err:{{err}}", tlsConfig), err)
+				return nil, fmt.Errorf("failed to get TLS configuration: tlsConfig:%#v err:%w", tlsConfig, err)
 			}
 		}
 
@@ -214,19 +213,19 @@ func (i *influxdbConnectionProducer) createClient() (influx.Client, error) {
 
 	cli, err := influx.NewHTTPClient(clientConfig)
 	if err != nil {
-		return nil, errwrap.Wrapf("error creating client: {{err}}", err)
+		return nil, fmt.Errorf("error creating client: %w", err)
 	}
 
 	// Checking server status
 	_, _, err = cli.Ping(i.connectTimeout)
 	if err != nil {
-		return nil, errwrap.Wrapf("error checking cluster status: {{err}}", err)
+		return nil, fmt.Errorf("error checking cluster status: %w", err)
 	}
 
 	// verifying infos about the connection
 	isAdmin, err := isUserAdmin(cli, i.Username)
 	if err != nil {
-		return nil, errwrap.Wrapf("error getting if provided username is admin: {{err}}", err)
+		return nil, fmt.Errorf("error getting if provided username is admin: %w", err)
 	}
 	if !isAdmin {
 		return nil, fmt.Errorf("the provided user is not an admin of the influxDB server")

--- a/plugins/database/influxdb/influxdb_test.go
+++ b/plugins/database/influxdb/influxdb_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/helper/testhelpers/docker"
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	dbtesting "github.com/hashicorp/vault/sdk/database/dbplugin/v5/testing"
@@ -78,12 +77,12 @@ func prepareInfluxdbTestContainer(t *testing.T) (func(), *Config) {
 		})
 		cli, err := influx.NewHTTPClient(c.apiConfig())
 		if err != nil {
-			return nil, errwrap.Wrapf("error creating InfluxDB client: {{err}}", err)
+			return nil, fmt.Errorf("error creating InfluxDB client: %w", err)
 		}
 		defer cli.Close()
 		_, _, err = cli.Ping(1)
 		if err != nil {
-			return nil, errwrap.Wrapf("error checking cluster status: {{err}}", err)
+			return nil, fmt.Errorf("error checking cluster status: %w", err)
 		}
 
 		return c, nil
@@ -421,20 +420,20 @@ func testCredsExist(address, username, password string) error {
 	}
 	cli, err := influx.NewHTTPClient(conf)
 	if err != nil {
-		return errwrap.Wrapf("Error creating InfluxDB Client: ", err)
+		return fmt.Errorf("Error creating InfluxDB Client: %w", err)
 	}
 	defer cli.Close()
 	_, _, err = cli.Ping(1)
 	if err != nil {
-		return errwrap.Wrapf("error checking server ping: {{err}}", err)
+		return fmt.Errorf("error checking server ping: %w", err)
 	}
 	q := influx.NewQuery("SHOW SERIES ON vault", "", "")
 	response, err := cli.Query(q)
 	if err != nil {
-		return errwrap.Wrapf("error querying influxdb server: {{err}}", err)
+		return fmt.Errorf("error querying influxdb server: %w", err)
 	}
 	if response != nil && response.Error() != nil {
-		return errwrap.Wrapf("error using the correct influx database: {{err}}", response.Error())
+		return fmt.Errorf("error using the correct influx database: %w", response.Error())
 	}
 	return nil
 }

--- a/plugins/database/mongodb/connection_producer.go
+++ b/plugins/database/mongodb/connection_producer.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -137,7 +136,7 @@ func (c *mongoDBConnectionProducer) getWriteConcern() (opts *options.ClientOptio
 	concern := &writeConcern{}
 	err = json.Unmarshal([]byte(input), concern)
 	if err != nil {
-		return nil, errwrap.Wrapf("error unmarshalling write_concern: {{err}}", err)
+		return nil, fmt.Errorf("error unmarshalling write_concern: %w", err)
 	}
 
 	// Translate write concern to mongo options

--- a/plugins/database/mssql/mssql.go
+++ b/plugins/database/mssql/mssql.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	_ "github.com/denisenkom/go-mssqldb"
-	"github.com/hashicorp/errwrap"
 	multierror "github.com/hashicorp/go-multierror"
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
@@ -279,10 +278,10 @@ func (m *MSSQL) revokeUserDefault(ctx context.Context, username string) error {
 
 	// can't drop if not all database users are dropped
 	if rows.Err() != nil {
-		return errwrap.Wrapf("could not generate sql statements for all rows: {{err}}", rows.Err())
+		return fmt.Errorf("could not generate sql statements for all rows: %w", rows.Err())
 	}
 	if lastStmtError != nil {
-		return errwrap.Wrapf("could not perform all sql statements: {{err}}", lastStmtError)
+		return fmt.Errorf("could not perform all sql statements: %w", lastStmtError)
 	}
 
 	// Drop this login

--- a/plugins/database/mysql/connection_producer.go
+++ b/plugins/database/mysql/connection_producer.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
@@ -88,7 +87,7 @@ func (c *mySQLConnectionProducer) Init(ctx context.Context, conf map[string]inte
 
 	c.maxConnectionLifetime, err = parseutil.ParseDurationSecond(c.MaxConnectionLifetimeRaw)
 	if err != nil {
-		return nil, errwrap.Wrapf("invalid max_connection_lifetime: {{err}}", err)
+		return nil, fmt.Errorf("invalid max_connection_lifetime: %w", err)
 	}
 
 	tlsConfig, err := c.getTLSAuth()
@@ -113,11 +112,11 @@ func (c *mySQLConnectionProducer) Init(ctx context.Context, conf map[string]inte
 
 	if verifyConnection {
 		if _, err := c.Connection(ctx); err != nil {
-			return nil, errwrap.Wrapf("error verifying connection: {{err}}", err)
+			return nil, fmt.Errorf("error verifying connection: %w", err)
 		}
 
 		if err := c.db.PingContext(ctx); err != nil {
-			return nil, errwrap.Wrapf("error verifying connection: {{err}}", err)
+			return nil, fmt.Errorf("error verifying connection: %w", err)
 		}
 	}
 

--- a/plugins/database/postgresql/postgresql.go
+++ b/plugins/database/postgresql/postgresql.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
@@ -445,10 +444,10 @@ func (p *PostgreSQL) defaultDeleteUser(ctx context.Context, username string) err
 
 	// can't drop if not all privileges are revoked
 	if rows.Err() != nil {
-		return errwrap.Wrapf("could not generate revocation statements for all rows: {{err}}", rows.Err())
+		return fmt.Errorf("could not generate revocation statements for all rows: %w", rows.Err())
 	}
 	if lastStmtError != nil {
-		return errwrap.Wrapf("could not perform all revocation statements: {{err}}", lastStmtError)
+		return fmt.Errorf("could not perform all revocation statements: %w", lastStmtError)
 	}
 
 	// Drop this user

--- a/plugins/database/redshift/redshift.go
+++ b/plugins/database/redshift/redshift.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	dbplugin "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/database/helper/connutil"
@@ -446,10 +445,10 @@ $$;`)
 
 	// can't drop if not all privileges are revoked
 	if rows.Err() != nil {
-		return dbplugin.DeleteUserResponse{}, errwrap.Wrapf("could not generate revocation statements for all rows: {{err}}", rows.Err())
+		return dbplugin.DeleteUserResponse{}, fmt.Errorf("could not generate revocation statements for all rows: %w", rows.Err())
 	}
 	if lastStmtError != nil {
-		return dbplugin.DeleteUserResponse{}, errwrap.Wrapf("could not perform all revocation statements: {{err}}", lastStmtError)
+		return dbplugin.DeleteUserResponse{}, fmt.Errorf("could not perform all revocation statements: %w", lastStmtError)
 	}
 
 	// Drop this user


### PR DESCRIPTION
This deprecates `errwrap.Wrapf()` throughout the `plugins/database` subpackages and replaces it with `fmt.Errorf()`. Additionally, a failed wrap is fixed in `plugins/database/influxdb`.