### PR TITLE
website: add Exoscale plugins to the list of partner plugins

### DIFF
--- a/website/content/docs/plugin-portal.mdx
+++ b/website/content/docs/plugin-portal.mdx
@@ -96,6 +96,10 @@ exists within the Vault repository, the plugin can be built as instructed in
 
 Partner plugins are developed by HashiCorp partners and are owned and maintained by the technology partner. HashiCorp has verified the authenticity of the partner’s plugin, and that the partner is a member of the [HashiCorp Technology Partner Program](https://www.hashicorp.com/partners/become-a-partner#technology). Compatibility and stability guarantees on these plugins are established by their authors.
 
+### Auth
+
+- [Exoscale](https://github.com/exoscale/vault-plugin-auth-exoscale)
+
 ### Database
 
 - [Aerospike](https://github.com/aerospike-community/vault-plugin-database-aerospike)
@@ -103,6 +107,7 @@ Partner plugins are developed by HashiCorp partners and are owned and maintained
 
 ### Secrets
 
+- [Exoscale](https://github.com/exoscale/vault-plugin-secrets-exoscale)
 - [PrimeKey EJBCA](https://github.com/primekeydevs/ejbca-vault-plugin)
 - [Venafi](https://github.com/Venafi/vault-pki-backend-venafi)
 


### PR DESCRIPTION
Adding the Exoscale auth/secrets Vault plugins to the list of partner plugins on the website "Plugin Portal" page.

This PR has been discussed with @acahn.