### PR TITLE
Skip flaky control group test

### DIFF
--- a/ui/tests/acceptance/enterprise-control-groups-test.js
+++ b/ui/tests/acceptance/enterprise-control-groups-test.js
@@ -1,5 +1,5 @@
 import { settled, currentURL, currentRouteName, visit } from '@ember/test-helpers';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
 
@@ -200,12 +200,12 @@ module('Acceptance | Enterprise | control groups', function(hooks) {
     }
   };
 
-  test('it allows the full flow to work without a saved token', async function(assert) {
+  skip('it allows the full flow to work without a saved token', async function(assert) {
     await workflow(assert, this);
     await settled();
   });
 
-  test('it allows the full flow to work with a saved token', async function(assert) {
+  skip('it allows the full flow to work with a saved token', async function(assert) {
     await workflow(assert, this, true);
     await settled();
   });


### PR DESCRIPTION
Locally I do occasionally hit test failures on this test, and it's becoming a more common issue in the enterprise merges and local branches.  For now we'll skip and revisit.