### PR TITLE
Fix: link on database role item goes to correct URL

### DIFF
--- a/changelog/11597.txt
+++ b/changelog/11597.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix text link URL on database roles list
+```

--- a/ui/app/templates/components/database-list-item.hbs
+++ b/ui/app/templates/components/database-list-item.hbs
@@ -8,7 +8,7 @@
 }}
   <div class="columns is-mobile">
     <div class="column is-10">
-      <LinkTo @route={{concat "vault.cluster.secrets.backend.show" }} @model={{@item.id}} class="has-text-black has-text-weight-semibold">
+      <LinkTo @route={{concat "vault.cluster.secrets.backend.show" }} @model={{if keyTypeValue (concat 'role/' @item.id) @item.id}} class="has-text-black has-text-weight-semibold">
         <Icon
           @glyph="user-square-outline"
           class="has-text-grey-light is-pulled-left"


### PR DESCRIPTION
Fixes issue #11254 where clicking on the name of the role on the database roles list would take you to the incorrect page. It now takes you to the correct page

<img width="1181" alt="Screen Shot 2021-05-12 at 2 01 35 PM" src="https://user-images.githubusercontent.com/82459713/118030186-93869080-b32a-11eb-82cf-61941ab47d9d.png">
