### PR TITLE
Backport 1.7.2: UI database role item link goes to correct URL (#11597)

### DIFF
--- a/changelog/11597.txt
+++ b/changelog/11597.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix text link URL on database roles list
+```

--- a/ui/app/templates/components/database-list-item.hbs
+++ b/ui/app/templates/components/database-list-item.hbs
@@ -8,7 +8,7 @@
 }}
   <div class="columns is-mobile">
     <div class="column is-10">
-      <LinkTo @route={{concat "vault.cluster.secrets.backend.show" }} @model={{@item.id}} class="has-text-black has-text-weight-semibold">
+      <LinkTo @route={{concat "vault.cluster.secrets.backend.show" }} @model={{if keyTypeValue (concat 'role/' @item.id) @item.id}} class="has-text-black has-text-weight-semibold">
         <Icon
           @glyph="user-square-outline"
           class="has-text-grey-light is-pulled-left"


### PR DESCRIPTION
Backport of #11597 