### PR TITLE
DB engine: Check ErrPluginStaticUnsupported in rollback code

### DIFF
--- a/builtin/logical/database/rollback.go
+++ b/builtin/logical/database/rollback.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+
 	v5 "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
@@ -104,7 +106,7 @@ func (b *databaseBackend) rollbackDatabaseCredentials(ctx context.Context, confi
 	// It actually is the root user here, but we only want to use SetCredentials since
 	// RotateRootCredentials doesn't give any control over what password is used
 	_, err = dbi.database.UpdateUser(ctx, updateReq, false)
-	if status.Code(err) == codes.Unimplemented {
+	if status.Code(err) == codes.Unimplemented || err == dbplugin.ErrPluginStaticUnsupported {
 		return nil
 	}
 	return err

--- a/changelog/11585.txt
+++ b/changelog/11585.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/database: Fixes issue for V4 database interface where `SetCredentials` wasn't falling back to using `RotateRootCredentials` if `SetCredentials` is `Unimplemented`
+```


### PR DESCRIPTION
Updates the DB engine rollback code to also check `ErrPluginStaticUnsupported`. (Missed in #11585)

Also adds changelog for #11585 which I neglected to add in that PR.