### PR TITLE
Backport 1.7: Add ServerName to Vault Agent template config

### DIFF
--- a/changelog/11288.txt
+++ b/changelog/11288.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fixed agent templating to use configured tls servername values
+```

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -274,12 +274,13 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		skipVerify := sc.AgentConfig.Vault.TLSSkipVerify
 		verify := !skipVerify
 		conf.Vault.SSL = &ctconfig.SSLConfig{
-			Enabled: pointerutil.BoolPtr(true),
-			Verify:  &verify,
-			Cert:    &sc.AgentConfig.Vault.ClientCert,
-			Key:     &sc.AgentConfig.Vault.ClientKey,
-			CaCert:  &sc.AgentConfig.Vault.CACert,
-			CaPath:  &sc.AgentConfig.Vault.CAPath,
+			Enabled:    pointerutil.BoolPtr(true),
+			Verify:     &verify,
+			Cert:       &sc.AgentConfig.Vault.ClientCert,
+			Key:        &sc.AgentConfig.Vault.ClientKey,
+			CaCert:     &sc.AgentConfig.Vault.CACert,
+			CaPath:     &sc.AgentConfig.Vault.CAPath,
+			ServerName: &sc.AgentConfig.Vault.TLSServerName,
 		}
 	}
 	enabled := attempts > 0


### PR DESCRIPTION
Backport of https://github.com/hashicorp/vault/pull/11288