### PR TITLE
Fix: Transit encrypt batch does not honor key_version

### DIFF
--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -3,6 +3,7 @@ package transit
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -193,6 +194,14 @@ func decodeBatchRequestItems(src interface{}, dst *[]BatchRequestItem) error {
 			if !reflect.ValueOf(v).IsValid() {
 			} else if casted, ok := v.(int); ok {
 				(*dst)[i].KeyVersion = casted
+			} else if js, ok := v.(json.Number); ok {
+				// https://github.com/hashicorp/vault/issues/10232
+				// Because API server parses json request with UseNumber=true, logical.Request.Data can include json.Number for a number field.
+				if casted, err := js.Int64(); err == nil {
+					(*dst)[i].KeyVersion = int(casted)
+				} else {
+					errs.Errors = append(errs.Errors, fmt.Sprintf(`error decoding %T into [%d].key_version: strconv.ParseInt: parsing "%s": invalid syntax`, v, i, v))
+				}
 			} else {
 				errs.Errors = append(errs.Errors, fmt.Sprintf("'[%d].key_version' expected type 'int', got unconvertible type '%T'", i, item["key_version"]))
 			}

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -2,6 +2,7 @@ package transit
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -632,6 +633,11 @@ func TestTransit_decodeBatchRequestItems(t *testing.T) {
 		{
 			name: "src_key_version_invalid-dest",
 			src:  []interface{}{map[string]interface{}{"key_version": "666"}},
+			dest: []BatchRequestItem{},
+		},
+		{
+			name: "src_key_version_invalid-number-dest",
+			src:  []interface{}{map[string]interface{}{"plaintext": "dGhlIHF1aWNrIGJyb3duIGZveA==", "key_version": json.Number("1.1")}},
 			dest: []BatchRequestItem{},
 		},
 		{

--- a/changelog/11628.txt
+++ b/changelog/11628.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secret: fix the bug where transit encrypt batch doesn't work with key_version
+```


### PR DESCRIPTION
Fix https://github.com/hashicorp/vault/issues/10232

This PR fixes the bug where batch encrypt API doesn't work with `key_version` ( https://github.com/hashicorp/vault/issues/10232).
Because HTTP server parses a JSON body as a `map[string]interface` with [UseNumber()](https://github.com/hashicorp/vault/blob/a71eebea012302e5ef0d44ac18d18d19835140d7/sdk/helper/jsonutil/json.go#L96), logica.Request.Data can include json.Number instead of a primitive number.

This PR fixes the issue by allowing additional json.Number in path_encrypt. I didn't use such as FieldSchema out of respect for this work: https://github.com/hashicorp/vault/pull/8775

I checked the following queries worked
```
$ curl --header "X-Vault-Token: dev" --request POST --data '{"batch_input":[{"key_version":1,"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="}]}' http://127.0.0.1:8200/v1/transit/encrypt/key1
{"request_id":"bfd9ae52-2e17-9fb7-24d3-77c52553cf8d","lease_id":"","renewable":false,"lease_duration":0,"data":{"batch_results":[{"ciphertext":"vault:v1:7YPcOIManbq2aW8Zwj1QlFzEM2+9BGyrC8Qu6QF0pRau/KcYiZK74AagVrp6hBs=","key_version":1}]},"wrap_info":null,"warnings":null,"auth":null}

$ curl --header "X-Vault-Token: dev" --request POST --data '{"key_version":1,"plaintext":"dGhlIHF1aWNrIGJyb3duIGZveA=="}' http://127.0.0.1:8200/v1/transit/encrypt/key1
{"request_id":"f786ad53-fcba-b24f-cf87-fab3ec1fecd0","lease_id":"","renewable":false,"lease_duration":0,"data":{"ciphertext":"vault:v1:j31QYZEnhsy8kdq1pM5nXflrFERTD3wY1t3OMUedhR/rRsxTkYuI9XmsH19UIp4=","key_version":1},"wrap_info":null,"warnings":null,"auth":null}
```