### PR TITLE
Backport 1.6.x: #11585 & #11601 - DB Engine bugfix for falling back to RotateRootCredentials

### DIFF
--- a/builtin/logical/database/rollback.go
+++ b/builtin/logical/database/rollback.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+
 	v5 "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
@@ -104,7 +106,7 @@ func (b *databaseBackend) rollbackDatabaseCredentials(ctx context.Context, confi
 	// It actually is the root user here, but we only want to use SetCredentials since
 	// RotateRootCredentials doesn't give any control over what password is used
 	_, err = dbi.database.UpdateUser(ctx, updateReq, false)
-	if status.Code(err) == codes.Unimplemented {
+	if status.Code(err) == codes.Unimplemented || err == dbplugin.ErrPluginStaticUnsupported {
 		return nil
 	}
 	return err

--- a/builtin/logical/database/version_wrapper.go
+++ b/builtin/logical/database/version_wrapper.go
@@ -152,7 +152,7 @@ func (d databaseVersionWrapper) changePasswordLegacy(ctx context.Context, userna
 	err = d.changeUserPasswordLegacy(ctx, username, passwordChange)
 
 	// If changing the root user's password but SetCredentials is unimplemented, fall back to RotateRootCredentials
-	if isRootUser && status.Code(err) == codes.Unimplemented {
+	if isRootUser && (err == v4.ErrPluginStaticUnsupported || status.Code(err) == codes.Unimplemented) {
 		saveConfig, err = d.changeRootUserPasswordLegacy(ctx, passwordChange)
 		if err != nil {
 			return nil, err

--- a/builtin/logical/database/version_wrapper_test.go
+++ b/builtin/logical/database/version_wrapper_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	v4 "github.com/hashicorp/vault/sdk/database/dbplugin"
 	v5 "github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/mock"
@@ -672,7 +673,7 @@ func TestUpdateUser_legacyDB(t *testing.T) {
 			expectedConfig: nil,
 			expectErr:      true,
 		},
-		"change password - RotateRootCredentials": {
+		"change password - RotateRootCredentials (gRPC Unimplemented)": {
 			req: v5.UpdateUserRequest{
 				Username: "existing_user",
 				Password: &v5.ChangePassword{
@@ -682,6 +683,30 @@ func TestUpdateUser_legacyDB(t *testing.T) {
 			isRootUser: true,
 
 			setCredentialsErr:   status.Error(codes.Unimplemented, "SetCredentials is not implemented"),
+			setCredentialsCalls: 1,
+
+			rotateRootConfig: map[string]interface{}{
+				"foo": "bar",
+			},
+			rotateRootCalls: 1,
+
+			renewUserCalls: 0,
+
+			expectedConfig: map[string]interface{}{
+				"foo": "bar",
+			},
+			expectErr: false,
+		},
+		"change password - RotateRootCredentials (ErrPluginStaticUnsupported)": {
+			req: v5.UpdateUserRequest{
+				Username: "existing_user",
+				Password: &v5.ChangePassword{
+					NewPassword: "newpassowrd",
+				},
+			},
+			isRootUser: true,
+
+			setCredentialsErr:   v4.ErrPluginStaticUnsupported,
 			setCredentialsCalls: 1,
 
 			rotateRootConfig: map[string]interface{}{

--- a/changelog/11585.txt
+++ b/changelog/11585.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/database: Fixes issue for V4 database interface where `SetCredentials` wasn't falling back to using `RotateRootCredentials` if `SetCredentials` is `Unimplemented`
+```


### PR DESCRIPTION
Backports https://github.com/hashicorp/vault/pull/11585 and https://github.com/hashicorp/vault/pull/11601

Fixes issue where the V4 database plugin wasn't falling back to using `RotateRootCredentials` when `SetCredentials` returns an `Unimplemented` error.