### PR TITLE
Backport 1.7.x: #11345 - add ability to provide a role session name when generating STS credentials

### DIFF
--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -33,6 +33,10 @@ func pathUser(b *backend) *framework.Path {
 				Description: "Lifetime of the returned credentials in seconds",
 				Default:     3600,
 			},
+			"role_session_name": &framework.FieldSchema{
+				Type:        framework.TypeString,
+				Description: "Session name to use when assuming role. Max chars: 64",
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -81,6 +85,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 	}
 
 	roleArn := d.Get("role_arn").(string)
+	roleSessionName := d.Get("role_session_name").(string)
 
 	var credentialType string
 	switch {
@@ -126,7 +131,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		case !strutil.StrListContains(role.RoleArns, roleArn):
 			return logical.ErrorResponse(fmt.Sprintf("role_arn %q not in allowed role arns for Vault role %q", roleArn, roleName)), nil
 		}
-		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl)
+		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl, roleSessionName)
 	case federationTokenCred:
 		return b.getFederationToken(ctx, req.Storage, req.DisplayName, roleName, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl)
 	default:

--- a/changelog/11345.txt
+++ b/changelog/11345.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/aws: add ability to provide a role session name when generating STS credentials
+```

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -524,6 +524,10 @@ credentials retrieved through `/aws/creds` must be of the `iam_user` type.
   the Vault role is `assumed_role`. Must match one of the allowed role ARNs in
   the Vault role. Optional if the Vault role only allows a single AWS role ARN;
   required otherwise.
+- `role_session_name` `(string)` - The role session name to attach to the assumed role ARN.
+   `role_session_name` is limited to 64 characters; if exceeded, the `role_session_name` in the
+   assumed role ARN will be truncated to 64 characters. If `role_session_name` is not provided,
+   then it will be generated dynamically by default.
 - `ttl` `(string: "3600s")` – Specifies the TTL for the use of the STS token.
   This is specified as a string with a duration suffix. Valid only when
   `credential_type` is `assumed_role` or `federation_token`. When not specified,
@@ -551,7 +555,8 @@ $ curl \
   "data": {
     "access_key": "AKIA...",
     "secret_key": "xlCs...",
-    "security_token": null
+    "security_token": null,
+    "arn": "arn:aws:sts::123456789012:assumed-role/DeveloperRole/some-user-supplied-role-session-name"
   }
 }
 ```


### PR DESCRIPTION
Backports #11345 

For AWS, adds the ability to provide a role session name when generating STS credentials.