### PR TITLE
Backport (1.7.x): #11638 - AWS Auth: Update error message to include underlying error

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -1356,7 +1356,7 @@ func (b *backend) pathLoginUpdateIam(ctx context.Context, req *logical.Request, 
 	if roleEntry.InferredEntityType == ec2EntityType {
 		instance, err := b.validateInstance(ctx, req.Storage, entity.SessionInfo, roleEntry.InferredAWSRegion, callerID.Account)
 		if err != nil {
-			return logical.ErrorResponse(fmt.Sprintf("failed to verify %s as a valid EC2 instance in region %s", entity.SessionInfo, roleEntry.InferredAWSRegion)), nil
+			return logical.ErrorResponse("failed to verify %s as a valid EC2 instance in region %s: %s", entity.SessionInfo, roleEntry.InferredAWSRegion, err), nil
 		}
 
 		// build a fake identity doc to pass on metadata about the instance to verifyInstanceMeetsRoleRequirements

--- a/changelog/11638.txt
+++ b/changelog/11638.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/aws: Underlying error included in validation failure message.
+```


### PR DESCRIPTION
Backports https://github.com/hashicorp/vault/pull/11638 to 1.7.x
---
Updates an error message to include the underlying error to help users debug what the actual problem is instead of guessing based on an incomplete message.