### PR TITLE
chore(website): 'overview' nav item links to homepage

### DIFF
--- a/website/data/subnav.js
+++ b/website/data/subnav.js
@@ -1,5 +1,5 @@
 export default [
-  { text: 'Overview', url: '/intro/getting-started' },
+  { text: 'Overview', url: '/' },
   {
     text: 'Use Cases',
     submenu: [


### PR DESCRIPTION
This PR sets the 'overview' nav item to link to the home page instead of the learn platform.