### PR TITLE
Sharpen how sts:AssumeRole can be allowed for AWS secrets engine.

### DIFF
--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -339,37 +339,40 @@ authentication or single sign-on (SSO) scenarios. In order to use an
    instance in an IAM instance profile) can retrieve `assumed_role` credentials
    (but cannot retrieve `federation_token` credentials).
 
-The `aws/config/root` credentials must have an IAM policy that allows `sts:AssumeRole`
-against the target role:
+To allow your `aws/config/root` credentials to perform `sts:AssumeRole` against
+the target role, there are two not mutually exclusive options:
 
-```javascript
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "sts:AssumeRole",
-    "Resource": "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:role/RoleNameToAssume"
-  }
-}
-```
+1. The `aws/config/root` credentials must have an IAM policy that allows
+   `sts:AssumeRole` against the target role:
 
-You must attach a trust policy to the target IAM role to assume, allowing
-the aws/root/config credentials to assume the role.
+   ```javascript
+   {
+       "Version": "2012-10-17",
+         "Statement": {
+           "Effect": "Allow",
+           "Action": "sts:AssumeRole",
+           "Resource": "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:role/RoleNameToAssume"
+         }
+       }
+   ```
 
-```javascript
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:user/VAULT-AWS-ROOT-CONFIG-USER-NAME"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-```
+2. Or, you must attach a trust policy to the target IAM role to assume, allowing
+the aws/root/config credentials to assume the role or both.
+
+   ```javascript
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Principal": {
+           "AWS": "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:user/VAULT-AWS-ROOT-CONFIG-USER-NAME"
+         },
+         "Action": "sts:AssumeRole"
+       }
+     ]
+   }
+   ```
 
 When specifying a Vault role with a `credential_type` of `assumed_role`, you can
 specify more than one IAM role ARN. If you do so, Vault clients can select which


### PR DESCRIPTION
Be more precise in how sts:AssumeRole permission can be allowed for AWS secrets engine.

See details here in the AWS Documentation: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics