### PR TITLE
Pin aerospike container image to a known working tag.

### DIFF
--- a/physical/aerospike/aerospike_test.go
+++ b/physical/aerospike/aerospike_test.go
@@ -43,7 +43,7 @@ func prepareAerospikeContainer(t *testing.T) (func(), *aerospikeConfig) {
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ImageRepo:     "aerospike/aerospike-server",
 		ContainerName: "aerospikedb",
-		ImageTag:      "latest",
+		ImageTag:      "5.5.0.10",
 		Ports:         []string{"3000/tcp", "3001/tcp", "3002/tcp", "3003/tcp"},
 	})
 	if err != nil {


### PR DESCRIPTION
5.5.0.10 works, 5.6.0.3 does not