### PR TITLE
sts is PUT/POST request

### DIFF
--- a/changelog/11681.txt
+++ b/changelog/11681.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Correct request method for /aws/sts endpoint
+```

--- a/changelog/11681.txt
+++ b/changelog/11681.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-core: Correct request method for /aws/sts endpoint
-```

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -507,7 +507,7 @@ created before queried.
 | Method | Path               |
 | :----- | :----------------- |
 | `GET`  | `/aws/creds/:name` |
-| `GET`  | `/aws/sts/:name`   |
+| `PUT`  | `/aws/sts/:name`   |
 
 The `/aws/creds` and `/aws/sts` endpoints are almost identical. The exception is
 when retrieving credentials for a role that was specified with the legacy `arn`


### PR DESCRIPTION
The docs for the `/aws/sts` endpoint says its a `GET` request but it should be a PUT or POST request. 

In vault cli if i do a `vault write -output-curl-string aws/sts/admin-role ttl=15m` 

I get `curl -X PUT -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" -d '{"ttl":"15m"}' https://vault.mydomain.com/v1/aws/sts/admin-role` which works fine. 

If I try to do a GET like `curl -X GET -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" -d '{"ttl":"15m"}' https://vault.mydomain.com/v1/aws/sts/admin-role` 

I get the following error `{"errors":["1 error occurred:\n\t* permission denied\n\n"]}`. 

A post also works fine `curl -X POST -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" -d '{"ttl":"15m"}' https://vault.mydomain.com/v1/aws/sts/admin-role`

Note I am on an older version of vault 1.2.2 which im not sure if it was changed to a GET later. But i did look at the website docs for version 1.2.2 and it still said a GET