### PR TITLE
login instructions not correct for Radius auth method documentation

### DIFF
--- a/website/content/docs/auth/radius.mdx
+++ b/website/content/docs/auth/radius.mdx
@@ -19,7 +19,7 @@ path, specify `-path=/my-path` in the CLI.
 ### Via the CLI
 
 ```shell-session
-$ vault login -path=radius username=sethvargo
+$ vault login -method=radius username=sethvargo
 ```
 
 ### Via the API


### PR DESCRIPTION
vault login -path=radius username=sethvargo should be changed to -method, not -path