### PR TITLE
sdk: move aws sts signing request to awsutil

### DIFF
--- a/builtin/credential/aws/cli.go
+++ b/builtin/credential/aws/cli.go
@@ -1,85 +1,15 @@
 package awsauth
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/awsutil"
 )
 
 type CLIHandler struct{}
-
-// STS is a really weird service that used to only have global endpoints but now has regional endpoints as well.
-// For backwards compatibility, even if you request a region other than us-east-1, it'll still sign for us-east-1.
-// See, e.g., https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#id_credentials_temp_enable-regions_writing_code
-// So we have to shim in this EndpointResolver to force it to sign for the right region
-func stsSigningResolver(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
-	defaultEndpoint, err := endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
-	if err != nil {
-		return defaultEndpoint, err
-	}
-	defaultEndpoint.SigningRegion = region
-	return defaultEndpoint, nil
-}
-
-// GenerateLoginData populates the necessary data to send to the Vault server for generating a token
-// This is useful for other API clients to use
-func GenerateLoginData(creds *credentials.Credentials, headerValue, configuredRegion string) (map[string]interface{}, error) {
-	loginData := make(map[string]interface{})
-
-	// Use the credentials we've found to construct an STS session
-	region, err := awsutil.GetRegion(configuredRegion)
-	if err != nil {
-		hclog.Default().Warn(fmt.Sprintf("defaulting region to %q due to %s", awsutil.DefaultRegion, err.Error()))
-		region = awsutil.DefaultRegion
-	}
-	stsSession, err := session.NewSessionWithOptions(session.Options{
-		Config: aws.Config{
-			Credentials:      creds,
-			Region:           &region,
-			EndpointResolver: endpoints.ResolverFunc(stsSigningResolver),
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	var params *sts.GetCallerIdentityInput
-	svc := sts.New(stsSession)
-	stsRequest, _ := svc.GetCallerIdentityRequest(params)
-
-	// Inject the required auth header value, if supplied, and then sign the request including that header
-	if headerValue != "" {
-		stsRequest.HTTPRequest.Header.Add(iamServerIdHeader, headerValue)
-	}
-	stsRequest.Sign()
-
-	// Now extract out the relevant parts of the request
-	headersJson, err := json.Marshal(stsRequest.HTTPRequest.Header)
-	if err != nil {
-		return nil, err
-	}
-	requestBody, err := ioutil.ReadAll(stsRequest.HTTPRequest.Body)
-	if err != nil {
-		return nil, err
-	}
-	loginData["iam_http_request_method"] = stsRequest.HTTPRequest.Method
-	loginData["iam_request_url"] = base64.StdEncoding.EncodeToString([]byte(stsRequest.HTTPRequest.URL.String()))
-	loginData["iam_request_headers"] = base64.StdEncoding.EncodeToString(headersJson)
-	loginData["iam_request_body"] = base64.StdEncoding.EncodeToString(requestBody)
-
-	return loginData, nil
-}
 
 func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, error) {
 	mount, ok := m["mount"]
@@ -108,7 +38,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	hlogger := hclog.Default()
 	hlogger.SetLevel(level)
 
-	creds, err := RetrieveCreds(m["aws_access_key_id"], m["aws_secret_access_key"], m["aws_security_token"], hlogger)
+	creds, err := awsutil.RetrieveCreds(m["aws_access_key_id"], m["aws_secret_access_key"], m["aws_security_token"], hlogger)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +47,8 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	if region == "" {
 		region = awsutil.DefaultRegion
 	}
-	loginData, err := GenerateLoginData(creds, headerValue, region)
+
+	loginData, err := awsutil.GenerateLoginData(creds, headerValue, region, hlogger)
 	if err != nil {
 		return nil, err
 	}
@@ -135,28 +66,6 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	}
 
 	return secret, nil
-}
-
-func RetrieveCreds(accessKey, secretKey, sessionToken string, logger hclog.Logger) (*credentials.Credentials, error) {
-	credConfig := &awsutil.CredentialsConfig{
-		AccessKey:    accessKey,
-		SecretKey:    secretKey,
-		SessionToken: sessionToken,
-		Logger:       logger,
-	}
-	creds, err := credConfig.GenerateCredentialChain()
-	if err != nil {
-		return nil, err
-	}
-	if creds == nil {
-		return nil, fmt.Errorf("could not compile valid credential providers from static config, environment, shared, or instance metadata")
-	}
-
-	_, err = creds.Get()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve credentials from credential chain: %w", err)
-	}
-	return creds, nil
 }
 
 func (h *CLIHandler) Help() string {

--- a/command/agent/auth/aws/aws.go
+++ b/command/agent/auth/aws/aws.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/api"
-	awsauth "github.com/hashicorp/vault/builtin/credential/aws"
 	"github.com/hashicorp/vault/command/agent/auth"
 	"github.com/hashicorp/vault/sdk/helper/awsutil"
 )
@@ -166,7 +165,7 @@ func NewAWSAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 
 		// Do an initial population of the creds because we want to err right away if we can't
 		// even get a first set.
-		creds, err := awsauth.RetrieveCreds(accessKey, secretKey, sessionToken, a.logger)
+		creds, err := awsutil.RetrieveCreds(accessKey, secretKey, sessionToken, a.logger)
 		if err != nil {
 			return nil, err
 		}
@@ -228,7 +227,7 @@ func (a *awsMethod) Authenticate(ctx context.Context, client *api.Client) (retTo
 		defer a.credLock.Unlock()
 
 		var err error
-		data, err = awsauth.GenerateLoginData(a.lastCreds, a.headerValue, a.region)
+		data, err = awsutil.GenerateLoginData(a.lastCreds, a.headerValue, a.region, a.logger)
 		if err != nil {
 			retErr = errwrap.Wrapf("error creating login value: {{err}}", err)
 			return
@@ -272,7 +271,7 @@ func (a *awsMethod) checkCreds(accessKey, secretKey, sessionToken string) error 
 	defer a.credLock.Unlock()
 
 	a.logger.Trace("checking for new credentials")
-	currentCreds, err := awsauth.RetrieveCreds(accessKey, secretKey, sessionToken, a.logger)
+	currentCreds, err := awsutil.RetrieveCreds(accessKey, secretKey, sessionToken, a.logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The code to sign AWS login data is needed elsewhere (terraform-provider-vault), so I've moved this to the SDK for better reusability.