### PR TITLE
UI: reset database json fields

### DIFF
--- a/changelog/11708.txt
+++ b/changelog/11708.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: JSON fields on database can be cleared on edit
+```

--- a/changelog/11708.txt
+++ b/changelog/11708.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:improvement
 ui: JSON fields on database can be cleared on edit
 ```

--- a/ui/app/models/database/connection.js
+++ b/ui/app/models/database/connection.js
@@ -198,10 +198,10 @@ export default Model.extend({
   port: attr('string', {}),
   write_concern: attr('string', {
     subText: 'Optional. Must be in JSON. See our documentation for help.',
+    allowReset: true,
     editType: 'json',
     theme: 'hashi short',
     defaultShown: 'Default',
-    // defaultValue: '# For example: { "wmode": "majority", "wtimeout": 5000 }',
   }),
   username_template: attr('string', {
     editType: 'optionalText',

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -69,11 +69,13 @@ export default Model.extend({
   }),
   creation_statement: attr('string', {
     editType: 'json',
+    allowReset: true,
     theme: 'hashi short',
     defaultShown: 'Default',
   }),
   revocation_statement: attr('string', {
     editType: 'json',
+    allowReset: true,
     theme: 'hashi short',
     defaultShown: 'Default',
   }),

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -237,7 +237,7 @@
               null
             }}
           >
-            Restore default
+            Clear
             <Icon @glyph="refresh-default" aria-hidden="true" />
           </button>
         {{/if}}

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -236,6 +236,7 @@
               (action "setAndBroadcast" valuePath)
               null
             }}
+            data-test-json-clear-button
           >
             Clear
             <Icon @glyph="refresh-default" aria-hidden="true" />

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -227,6 +227,7 @@
         }}
         @helpText={{attr.options.helpText}}
       >
+      <button>{{if attr.options.allowReset "yes" "no"}}</button>
         {{#if attr.options.allowReset}}
           <button
             type="button"

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -227,7 +227,6 @@
         }}
         @helpText={{attr.options.helpText}}
       >
-      <button>{{if attr.options.allowReset "yes" "no"}}</button>
         {{#if attr.options.allowReset}}
           <button
             type="button"

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -213,9 +213,6 @@
         @spellcheck="false" />
     {{else if (eq attr.options.editType "json")}}
       {{!-- JSON Editor --}}
-      {{#if attr.options.subText}}
-        <p class="sub-text">{{attr.options.subText}} {{#if attr.options.docLink}}<a href="{{attr.options.docLink}}" target="_blank" rel="noopener noreferrer">See our documentation</a> for help.{{/if}}</p>
-      {{/if}}
       <JsonEditor
         data-test-input={{attr.name}}
         @title={{labelString}}
@@ -229,7 +226,25 @@
           theme=(or attr.options.theme 'hashi')
         }}
         @helpText={{attr.options.helpText}}
-      />
+      >
+        {{#if attr.options.allowReset}}
+          <button
+            type="button"
+            class="toolbar-link"
+            disabled={{not (get model valuePath)}}
+            onClick={{action
+              (action "setAndBroadcast" valuePath)
+              null
+            }}
+          >
+            Restore default
+            <Icon @glyph="refresh-default" aria-hidden="true" />
+          </button>
+        {{/if}}
+      </JsonEditor>
+      {{#if attr.options.subText}}
+        <p class="sub-text">{{attr.options.subText}} {{#if attr.options.docLink}}<a href="{{attr.options.docLink}}" target="_blank" rel="noopener noreferrer">See our documentation</a> for help.{{/if}}</p>
+      {{/if}}
     {{else}}
       {{!-- Regular Text Input --}}
       <input data-test-input={{attr.name}} id={{attr.name}} autocomplete="off" spellcheck="false"

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -13,6 +13,7 @@ module('Integration | Component | form field', function(hooks) {
   setupRenderingTest(hooks);
 
   const createAttr = (name, type, options) => {
+    console.log({ options });
     return {
       name,
       type,
@@ -85,8 +86,8 @@ module('Integration | Component | form field', function(hooks) {
     assert.ok(component.hasJSONEditor, 'renders the json editor');
   });
 
-  test('it renders: object with clear button', async function(assert) {
-    await setup.call(this, createAttr('foo', 'object', { allowReset: true }));
+  test('it renders: string as json with clear button', async function(assert) {
+    await setup.call(this, createAttr('foo', 'string', { editType: 'json', allowReset: true }));
     assert.equal(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
     assert.ok(component.hasJSONEditor, 'renders the json editor');
     assert.ok(component.hasJSONClearButton, 'renders button that will clear the JSON value');

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -13,7 +13,6 @@ module('Integration | Component | form field', function(hooks) {
   setupRenderingTest(hooks);
 
   const createAttr = (name, type, options) => {
-    console.log({ options });
     return {
       name,
       type,

--- a/ui/tests/integration/components/form-field-test.js
+++ b/ui/tests/integration/components/form-field-test.js
@@ -85,6 +85,13 @@ module('Integration | Component | form field', function(hooks) {
     assert.ok(component.hasJSONEditor, 'renders the json editor');
   });
 
+  test('it renders: object with clear button', async function(assert) {
+    await setup.call(this, createAttr('foo', 'object', { allowReset: true }));
+    assert.equal(component.fields.objectAt(0).labelText, 'Foo', 'renders a label');
+    assert.ok(component.hasJSONEditor, 'renders the json editor');
+    assert.ok(component.hasJSONClearButton, 'renders button that will clear the JSON value');
+  });
+
   test('it renders: editType textarea', async function(assert) {
     let [model, spy] = await setup.call(
       this,

--- a/ui/tests/pages/components/form-field.js
+++ b/ui/tests/pages/components/form-field.js
@@ -16,6 +16,7 @@ export default {
   hasTextFile: isPresent('[data-test-component=text-file]'),
   hasTTLPicker: isPresent('[data-test-toggle-input="Foo"]'),
   hasJSONEditor: isPresent('[data-test-component=json-editor]'),
+  hasJSONClearButton: isPresent('[data-test-json-clear-button]'),
   hasSelect: isPresent('select'),
   hasInput: isPresent('input'),
   hasCheckbox: isPresent('input[type=checkbox]'),


### PR DESCRIPTION
Allows JSON form-field inputs to be cleared, if `allowReset` option is provided on the model attr. This option is turned on for database connections and roles, and the flow looks something like this: 

![JSON-clear-button](https://user-images.githubusercontent.com/82459713/119713044-e7af6b80-be26-11eb-8db0-1fbfb8143cd9.gif)
