### PR TITLE
agent: allow templating to indefinitely retry if explicitly set to zero

### DIFF
--- a/command/agent/cache/api_proxy.go
+++ b/command/agent/cache/api_proxy.go
@@ -119,6 +119,10 @@ func (ap *APIProxy) Send(ctx context.Context, req *SendRequest) (*SendResponse, 
 	}
 	client.SetToken(req.Token)
 
+	// Derive and set a logger for the client
+	clientLogger := ap.logger.Named("client")
+	client.SetLogger(clientLogger)
+
 	// http.Transport will transparently request gzip and decompress the response, but only if
 	// the client doesn't manually set the header. Removing any Accept-Encoding header allows the
 	// transparent compression to occur.

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -781,7 +781,8 @@ func TestLoadConfigFile_Vault_Retry(t *testing.T) {
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
 			Retry: &Retry{
-				NumRetries: 5,
+				NumRetries:    5,
+				NumRetriesRaw: 5,
 			},
 		},
 	}
@@ -826,7 +827,7 @@ func TestLoadConfigFile_Vault_Retry_Empty(t *testing.T) {
 		Vault: &Vault{
 			Address: "http://127.0.0.1:1111",
 			Retry: &Retry{
-				ctconfig.DefaultRetryAttempts,
+				NumRetries: ctconfig.DefaultRetryAttempts,
 			},
 		},
 	}

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -259,6 +259,13 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 	// is enabled. The templating engine and the cache have some inconsistencies
 	// that need to be fixed for 1.7x/1.8
 	if sc.AgentConfig.Cache != nil && sc.AgentConfig.Cache.Persist != nil && len(sc.AgentConfig.Listeners) != 0 {
+		// Disable template retries if attempts is greater than zero so that we
+		// don't end up performing n^2 retries by both template and the cache
+		// client.
+		if attempts > 0 {
+			enabled = false
+		}
+
 		scheme := "unix://"
 		if sc.AgentConfig.Listeners[0].Type == "tcp" {
 			scheme = "https://"


### PR DESCRIPTION
This PR re-introduces the ability for agent's template subsystem to perform indefinite retries that was removed in 1.6.0 through #9670. Indefinite retry can be toggled on by setting `vault.retry.num_retries = 0`. 

Since `vault.retry.num_retries` is used by both the cache client and the template config, the changeset moves setting these values closer to where the update is called. This reduces the behavioral change to the bare minimum, but introduces the difference on what `0` means for template vs cache.

Templating:
| vault.retry.num_retries  | Old | New |
| ------------- | ------------- | ----- |
| -1  | Disabled  | Disabled   |
| 0  | Default (12x)  |  **∞ retries** |
| N > 0 | N retries | N retries |
| Absent | Default (12x) | Default (12x) |

Cache:
| vault.retry.num_retries | Old           | New           |
|-------------------------|---------------|---------------|
| -1                      | Disabled      | Disabled      |
| 0                       | Default (12x) | **API Client default (2x)**     |
| N > 0                   | N retries     | N retries     |
| Absent                  | Default (12x) | Default (12x) |

Related to #9670
Related to #11113

Backport note:
We need to backport https://github.com/hashicorp/vault/pull/11696 if/when we backport this PR.

TODO:
- [ ] Update/add tests
- [ ] Update docs
- [ ] Include changelog