### PR TITLE
Support tls-skip-verify for output-curl-string

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -973,7 +973,10 @@ START:
 	}
 
 	if outputCurlString {
-		LastOutputStringError = &OutputStringError{Request: req}
+		LastOutputStringError = &OutputStringError{
+			Request:       req,
+			TLSSkipVerify: c.config.HttpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify,
+		}
 		return nil, LastOutputStringError
 	}
 

--- a/api/output_string.go
+++ b/api/output_string.go
@@ -15,6 +15,7 @@ var LastOutputStringError *OutputStringError
 
 type OutputStringError struct {
 	*retryablehttp.Request
+	TLSSkipVerify    bool
 	parsingError     error
 	parsedCurlString string
 }
@@ -39,6 +40,9 @@ func (d *OutputStringError) parseRequest() {
 
 	// Build cURL string
 	d.parsedCurlString = "curl "
+	if d.TLSSkipVerify {
+		d.parsedCurlString += "--insecure "
+	}
 	if d.Request.Method != "GET" {
 		d.parsedCurlString = fmt.Sprintf("%s-X %s ", d.parsedCurlString, d.Request.Method)
 	}


### PR DESCRIPTION
**Problem**

Vault does not translate the `-tls-skip-verify` flag into the cURL `--insecure` flag when used with the `-output-curl-string` flag.

For example:

```
$ vault read -address=https:/myvault:8200 -tls-skip-verify -output-curl-string ssh/config/ca
curl -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" https://myvault/v1/ssh/config/ca

$ curl -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" https://myvault/v1/ssh/config/ca
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

**Changes**

The added logic remembers whether the last request was made over an insecure HTTP transport.
If so, it adds the `--insecure` flag to the cURL command.

Example:

```
$ vault read -address=https:/myvault:8200 -tls-skip-verify -output-curl-string ssh/config/ca
curl --insecure -H "X-Vault-Request: true" -H "X-Vault-Token: $(vault print token)" https://myvault/v1/ssh/config/ca
```