### PR TITLE
Clarify supported TCP listener config options for Agent

### DIFF
--- a/website/content/docs/agent/caching/index.mdx
+++ b/website/content/docs/agent/caching/index.mdx
@@ -221,8 +221,10 @@ These are common configuration values that live within the `persist` block:
 
 - `listener` `(array of objects: required)` - Configuration for the listeners.
 
-There can be one or more `listener` blocks at the top level.
-These configuration values are common to all `listener` blocks.
+There can be one or more `listener` blocks at the top level. These configuration
+values are common to both `tcp` and `unix` listener blocks. Blocks of type
+`tcp` support the standard `tcp` [listener](/docs/configuration/listener/tcp)
+options.
 
 - `type` `(string: required)` - The type of the listener to use. Valid values
   are `tcp` and `unix`.


### PR DESCRIPTION
I misinterpreted this documentation page to mean that Vault Agent listeners don't support mTLS, but they do. The documentation [here](https://www.vaultproject.io/docs/agent#listener-stanza) does a better job of explaining, so I've tried to make it closer to that. It does still seem a little awkward that we document this listener config twice, in both a parent and child page, but I suppose it makes sense for the child page to have space to get more detailed.