### PR TITLE
(OSS) VAULT-2446: Re-enable server tests using env var VAULT_LICENSE_CI

### DIFF
--- a/command/server_test.go
+++ b/command/server_test.go
@@ -1,4 +1,4 @@
-// +build !race,!hsm,!enterprise
+// +build !race,!hsm
 
 // NOTE: we can't use this with HSM. We can't set testing mode on and it's not
 // safe to use env vars since that provides an attack vector in the real world.
@@ -22,6 +22,12 @@ import (
 	physInmem "github.com/hashicorp/vault/sdk/physical/inmem"
 	"github.com/mitchellh/cli"
 )
+
+func init() {
+	if signed := os.Getenv("VAULT_LICENSE_CI"); signed != "" {
+		os.Setenv("VAULT_LICENSE", signed)
+	}
+}
 
 func testBaseHCL(tb testing.TB, listenerExtras string) string {
 	tb.Helper()


### PR DESCRIPTION
We'd disabled these tests on enterprise temporarily, but now we're ready to make them run there again.

Vault cares about the VAULT_LICENSE env var, but we don't want to set that in CI because it would change behaviour of tests that don't intend for it to be set.  Instead, we use VAULT_LICENSE_CI so that only packages/tests that opt-in will use it.