### PR TITLE
go_test.yml on ent has needlessly diverged from oss; make them identical again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -916,13 +916,13 @@ jobs:
               jq -r 'select(.Deps != null) |
                 select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                 .ForTest | select(. != null)' |
-                sort -u | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           else
             package_names=$(go list -test -json ./... |
               jq -r 'select(.Deps != null) |
                 select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                 .ForTest | select(. != null)' |
-                sort -u | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           fi
 
           # After running tests split step, we are now running the following steps
@@ -932,6 +932,13 @@ jobs:
 
           make prep
           mkdir -p test-results/go-test
+
+          # Save the vault license for tests that want it
+          export VAULT_LICENSE_CI="$VAULT_LICENSE"
+
+          # Don't tempt fate by having the license env var populated: tests should
+          # have to use it explicitly rather than depending on an implicit var.
+          VAULT_LICENSE=
 
           # Create a docker network for our testcontainer
           if [ $USE_DOCKER == 1 ]; then
@@ -963,6 +970,7 @@ jobs:
 
             docker exec -w /go/src/github.com/hashicorp/vault/ \
               -e GO111MODULE -e CIRCLECI -e GOCACHE=/tmp/gocache -e VAULT_CI_GO_TEST_RACE \
+              -e VAULT_LICENSE_CI \
               testcontainer \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
@@ -974,7 +982,8 @@ jobs:
                  \
                 ${package_names}
           else
-            GOCACHE=/tmp/go-cache \
+            GOARCH=amd64 \
+              GOCACHE=/tmp/go-cache \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
                 --jsonfile test-results/go-test/results.json \
@@ -1131,13 +1140,13 @@ jobs:
               jq -r 'select(.Deps != null) |
                 select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                 .ForTest | select(. != null)' |
-                sort -u | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           else
             package_names=$(go list -test -json ./... |
               jq -r 'select(.Deps != null) |
                 select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                 .ForTest | select(. != null)' |
-                sort -u | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           fi
 
           # After running tests split step, we are now running the following steps
@@ -1147,6 +1156,13 @@ jobs:
 
           make prep
           mkdir -p test-results/go-test
+
+          # Save the vault license for tests that want it
+          export VAULT_LICENSE_CI="$VAULT_LICENSE"
+
+          # Don't tempt fate by having the license env var populated: tests should
+          # have to use it explicitly rather than depending on an implicit var.
+          VAULT_LICENSE=
 
           # Create a docker network for our testcontainer
           if [ $USE_DOCKER == 1 ]; then
@@ -1178,6 +1194,7 @@ jobs:
 
             docker exec -w /go/src/github.com/hashicorp/vault/ \
               -e GO111MODULE -e CIRCLECI -e GOCACHE=/tmp/gocache -e VAULT_CI_GO_TEST_RACE \
+              -e VAULT_LICENSE_CI \
               testcontainer \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
@@ -1189,7 +1206,8 @@ jobs:
                 -race \
                 ${package_names}
           else
-            GOCACHE=/tmp/go-cache \
+            GOARCH=amd64 \
+              GOCACHE=/tmp/go-cache \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
                 --jsonfile test-results/go-test/results.json \
@@ -1597,13 +1615,13 @@ jobs:
               jq -r 'select(.Deps != null) |
                 select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                 .ForTest | select(. != null)' |
-                sort -u | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           else
             package_names=$(go list -test -json ./... |
               jq -r 'select(.Deps != null) |
                 select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                 .ForTest | select(. != null)' |
-                sort -u | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           fi
 
           # After running tests split step, we are now running the following steps
@@ -1613,6 +1631,13 @@ jobs:
 
           make prep
           mkdir -p test-results/go-test
+
+          # Save the vault license for tests that want it
+          export VAULT_LICENSE_CI="$VAULT_LICENSE"
+
+          # Don't tempt fate by having the license env var populated: tests should
+          # have to use it explicitly rather than depending on an implicit var.
+          VAULT_LICENSE=
 
           # Create a docker network for our testcontainer
           if [ $USE_DOCKER == 1 ]; then
@@ -1644,6 +1669,7 @@ jobs:
 
             docker exec -w /go/src/github.com/hashicorp/vault/ \
               -e GO111MODULE -e CIRCLECI -e GOCACHE=/tmp/gocache -e VAULT_CI_GO_TEST_RACE \
+              -e VAULT_LICENSE_CI \
               testcontainer \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
@@ -1655,7 +1681,8 @@ jobs:
                  \
                 ${package_names}
           else
-            GOCACHE=/tmp/go-cache \
+            GOARCH=amd64 \
+              GOCACHE=/tmp/go-cache \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
                 --jsonfile test-results/go-test/results.json \
@@ -1743,13 +1770,13 @@ jobs:
               jq -r 'select(.Deps != null) |
                 select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                 .ForTest | select(. != null)' |
-                sort -u | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           else
             package_names=$(go list -test -json ./... |
               jq -r 'select(.Deps != null) |
                 select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                 .ForTest | select(. != null)' |
-                sort -u | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           fi
 
           # After running tests split step, we are now running the following steps
@@ -1759,6 +1786,13 @@ jobs:
 
           make prep
           mkdir -p test-results/go-test
+
+          # Save the vault license for tests that want it
+          export VAULT_LICENSE_CI="$VAULT_LICENSE"
+
+          # Don't tempt fate by having the license env var populated: tests should
+          # have to use it explicitly rather than depending on an implicit var.
+          VAULT_LICENSE=
 
           # Create a docker network for our testcontainer
           if [ $USE_DOCKER == 1 ]; then
@@ -1790,6 +1824,7 @@ jobs:
 
             docker exec -w /go/src/github.com/hashicorp/vault/ \
               -e GO111MODULE -e CIRCLECI -e GOCACHE=/tmp/gocache -e VAULT_CI_GO_TEST_RACE \
+              -e VAULT_LICENSE_CI \
               testcontainer \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
@@ -1801,7 +1836,8 @@ jobs:
                  \
                 ${package_names}
           else
-            GOCACHE=/tmp/go-cache \
+            GOARCH=amd64 \
+              GOCACHE=/tmp/go-cache \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
                 --jsonfile test-results/go-test/results.json \
@@ -2340,13 +2376,13 @@ jobs:
               jq -r 'select(.Deps != null) |
                 select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                 .ForTest | select(. != null)' |
-                sort -u | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           else
             package_names=$(go list -test -json ./... |
               jq -r 'select(.Deps != null) |
                 select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                 .ForTest | select(. != null)' |
-                sort -u | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           fi
 
           # After running tests split step, we are now running the following steps
@@ -2356,6 +2392,13 @@ jobs:
 
           make prep
           mkdir -p test-results/go-test
+
+          # Save the vault license for tests that want it
+          export VAULT_LICENSE_CI="$VAULT_LICENSE"
+
+          # Don't tempt fate by having the license env var populated: tests should
+          # have to use it explicitly rather than depending on an implicit var.
+          VAULT_LICENSE=
 
           # Create a docker network for our testcontainer
           if [ $USE_DOCKER == 1 ]; then
@@ -2387,6 +2430,7 @@ jobs:
 
             docker exec -w /go/src/github.com/hashicorp/vault/ \
               -e GO111MODULE -e CIRCLECI -e GOCACHE=/tmp/gocache -e VAULT_CI_GO_TEST_RACE \
+              -e VAULT_LICENSE_CI \
               testcontainer \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
@@ -2398,7 +2442,8 @@ jobs:
                 -race \
                 ${package_names}
           else
-            GOCACHE=/tmp/go-cache \
+            GOARCH=amd64 \
+              GOCACHE=/tmp/go-cache \
               gotestsum --format=short-verbose \
                 --junitfile test-results/go-test/results.xml \
                 --jsonfile test-results/go-test/results.json \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -933,11 +933,9 @@ jobs:
           make prep
           mkdir -p test-results/go-test
 
-          # Save the vault license for tests that want it
-          export VAULT_LICENSE_CI="$VAULT_LICENSE"
-
           # Don't tempt fate by having the license env var populated: tests should
-          # have to use it explicitly rather than depending on an implicit var.
+          # have to use it explicitly (via env var VAULT_LICENSE_CI) rather than
+          # depending on an implicit behaviour.
           VAULT_LICENSE=
 
           # Create a docker network for our testcontainer
@@ -1157,11 +1155,9 @@ jobs:
           make prep
           mkdir -p test-results/go-test
 
-          # Save the vault license for tests that want it
-          export VAULT_LICENSE_CI="$VAULT_LICENSE"
-
           # Don't tempt fate by having the license env var populated: tests should
-          # have to use it explicitly rather than depending on an implicit var.
+          # have to use it explicitly (via env var VAULT_LICENSE_CI) rather than
+          # depending on an implicit behaviour.
           VAULT_LICENSE=
 
           # Create a docker network for our testcontainer
@@ -1632,11 +1628,9 @@ jobs:
           make prep
           mkdir -p test-results/go-test
 
-          # Save the vault license for tests that want it
-          export VAULT_LICENSE_CI="$VAULT_LICENSE"
-
           # Don't tempt fate by having the license env var populated: tests should
-          # have to use it explicitly rather than depending on an implicit var.
+          # have to use it explicitly (via env var VAULT_LICENSE_CI) rather than
+          # depending on an implicit behaviour.
           VAULT_LICENSE=
 
           # Create a docker network for our testcontainer
@@ -1787,11 +1781,9 @@ jobs:
           make prep
           mkdir -p test-results/go-test
 
-          # Save the vault license for tests that want it
-          export VAULT_LICENSE_CI="$VAULT_LICENSE"
-
           # Don't tempt fate by having the license env var populated: tests should
-          # have to use it explicitly rather than depending on an implicit var.
+          # have to use it explicitly (via env var VAULT_LICENSE_CI) rather than
+          # depending on an implicit behaviour.
           VAULT_LICENSE=
 
           # Create a docker network for our testcontainer
@@ -2393,11 +2385,9 @@ jobs:
           make prep
           mkdir -p test-results/go-test
 
-          # Save the vault license for tests that want it
-          export VAULT_LICENSE_CI="$VAULT_LICENSE"
-
           # Don't tempt fate by having the license env var populated: tests should
-          # have to use it explicitly rather than depending on an implicit var.
+          # have to use it explicitly (via env var VAULT_LICENSE_CI) rather than
+          # depending on an implicit behaviour.
           VAULT_LICENSE=
 
           # Create a docker network for our testcontainer

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -76,11 +76,9 @@ steps:
         make prep
         mkdir -p test-results/go-test
 
-        # Save the vault license for tests that want it
-        export VAULT_LICENSE_CI="$VAULT_LICENSE"
-
         # Don't tempt fate by having the license env var populated: tests should
-        # have to use it explicitly rather than depending on an implicit var.
+        # have to use it explicitly (via env var VAULT_LICENSE_CI) rather than
+        # depending on an implicit behaviour.
         VAULT_LICENSE=
 
         # Create a docker network for our testcontainer

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -18,6 +18,10 @@ parameters:
   use_docker:
     type: boolean
     default: false
+  arch:
+    type: string
+    # Only supported for use_docker=false, and only other value allowed is 386
+    default: amd64
 steps:
   - run:
       name: Compute test cache key
@@ -55,13 +59,13 @@ steps:
             jq -r 'select(.Deps != null) |
               select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
               .ForTest | select(. != null)' |
-              sort -u | circleci tests split --split-by=timings --timings-type=classname)
+              sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
         else
           package_names=$(go list -test -json ./... |
             jq -r 'select(.Deps != null) |
               select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
               .ForTest | select(. != null)' |
-              sort -u | circleci tests split --split-by=timings --timings-type=classname)
+              sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
         fi
 
         # After running tests split step, we are now running the following steps
@@ -71,6 +75,13 @@ steps:
 
         make prep
         mkdir -p test-results/go-test
+
+        # Save the vault license for tests that want it
+        export VAULT_LICENSE_CI="$VAULT_LICENSE"
+
+        # Don't tempt fate by having the license env var populated: tests should
+        # have to use it explicitly rather than depending on an implicit var.
+        VAULT_LICENSE=
 
         # Create a docker network for our testcontainer
         if [ $USE_DOCKER == 1 ]; then
@@ -102,6 +113,7 @@ steps:
 
           docker exec -w /go/src/github.com/hashicorp/vault/ \
             -e GO111MODULE -e CIRCLECI -e GOCACHE=/tmp/gocache -e VAULT_CI_GO_TEST_RACE \
+            -e VAULT_LICENSE_CI \
             testcontainer \
             gotestsum --format=short-verbose \
               --junitfile test-results/go-test/results.xml \
@@ -113,7 +125,8 @@ steps:
               << parameters.extra_flags >> \
               ${package_names}
         else
-          GOCACHE=<< parameters.cache_dir >> \
+          GOARCH=<< parameters.arch >> \
+            GOCACHE=<< parameters.cache_dir >> \
             gotestsum --format=short-verbose \
               --junitfile test-results/go-test/results.xml \
               --jsonfile test-results/go-test/results.json \


### PR DESCRIPTION
This is actually not 100% identical to what's on ent, but that's ok, once we merge to ent they will be.