### PR TITLE
Include note about `ManageOwnAccessKeys` stanza

### DIFF
--- a/website/content/docs/auth/aws.mdx
+++ b/website/content/docs/auth/aws.mdx
@@ -337,6 +337,10 @@ are needed.
   all the roles for which you have configured cross-account access, and each of
   those roles should have this IAM policy attached (except for the
   `sts:AssumeRole` statement).
+- The `ManageOwnAccessKeys` stanza is necessary when you have configured Vault
+  with static credentials, and wish to rotate these credentials with the
+  [Rotate Root Credentials](https://www.vaultproject.io/api-docs/auth/aws#rotate-root-credentials)
+  API call.
 
 ## Client Nonce
 


### PR DESCRIPTION
Making it clear that these permissions are not required if _not_ using API keys for Vault's AWS API access.

For folks who have Vault installed on EC2 machines, making use of EC2 instance profiles for AWS API access, then these permissions are not required.  Dropping this stanza simplifies the policy document.