### PR TITLE
Fixing issue with FPE read and delete api docs

### DIFF
--- a/website/content/api-docs/secret/transform.mdx
+++ b/website/content/api-docs/secret/transform.mdx
@@ -362,7 +362,7 @@ This endpoint queries an existing transformation by the given name.
 
 | Method | Path                               |
 | :----- | :--------------------------------- |
-| `GET`  | `/transform/transformations/:name` |
+| `GET`  | `/transform/transformation/:name` |
 
 - `name` `(string: <required>)` –
   Specifies the name of the role to read. This is part of the request URL.
@@ -372,7 +372,7 @@ This endpoint queries an existing transformation by the given name.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    http://127.0.0.1:8200/v1/transform/transformations/example-transformation
+    http://127.0.0.1:8200/v1/transform/transformation/example-transformation
 ```
 
 ### Sample Response
@@ -421,7 +421,7 @@ This endpoint deletes an existing transformation by the given name.
 
 | Method   | Path                               |
 | :------- | :--------------------------------- |
-| `DELETE` | `/transform/transformations/:name` |
+| `DELETE` | `/transform/transformation/:name` |
 
 ### Parameters
 
@@ -435,7 +435,7 @@ This endpoint deletes an existing transformation by the given name.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request DELETE \
-    http://127.0.0.1:8200/v1/transform/transformations/example-transformation
+    http://127.0.0.1:8200/v1/transform/transformation/example-transformation
 ```
 
 ## Create/Update Template


### PR DESCRIPTION
Read and Delete FPE api-docs point to path `/transform/transformations/:name` instead it should be `/transform/transformation/:name`