### PR TITLE
Add note about JSON encoding to password policies docs

### DIFF
--- a/website/content/docs/concepts/password-policies.mdx
+++ b/website/content/docs/concepts/password-policies.mdx
@@ -316,7 +316,8 @@ are generated from must be no longer than 256 characters.
 #### Parameters
 
 - `charset` `(string: <required>)` – A string representation of the character set that this rule observes.
-  Accepts UTF-8 compatible strings. All characters within the string must be printable.
+  Accepts UTF-8 compatible strings. All characters within the string must be printable.  
+  Please note that the JSON output returned may be escaped for the special and control characters such as <,>,& etc as per the JSON specification.
 - `min-chars` `(int: 0)` - Specifies a minimum number of characters required from the charset specified in
   this rule. For example: if `min-chars = 2`, the password must have at least 2 characters from `charset`.
 


### PR DESCRIPTION
Updated content to notify the users that the Special and Control characters will be escaped as per the JSON specification.