### PR TITLE
Password policies: Fix link from API docs to password policy syntax

### DIFF
--- a/website/content/api-docs/system/policies-password.mdx
+++ b/website/content/api-docs/system/policies-password.mdx
@@ -37,7 +37,7 @@ generation times.
   This is specified as part of the request URL.
 
 - `policy` `(string: <required>)` - Specifies the password policy document. This can be
-  base64-encoded to avoid string escaping. See [Password Policy Syntax](#password-policy-syntax)
+  base64-encoded to avoid string escaping. See [Password Policy Syntax](/docs/concepts/password-policies#password-policy-syntax)
   for details on password policy definitions.
 
 ### Sample Payload


### PR DESCRIPTION
Fixed the issue with the URL link for the Password Policy Syntax.