### PR TITLE
vault 1979: bug fixes and improvements from ent namespace work

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -2427,6 +2427,10 @@ func (m *ExpirationManager) getNamespaceFromLeaseID(ctx context.Context, leaseID
 		}
 	}
 
+	if leaseNS == nil {
+		return nil, namespace.ErrNoNamespace
+	}
+
 	return leaseNS, nil
 }
 


### PR DESCRIPTION
this is basically a port from some of the namespace testing i'm doing on the ent side

rough change summary
- i wasn't nil checking in a helper function (which can be convenient)
- mounting backends for various namespaces requires the namespace itself, so i defined a struct so it can work with and without custom namespaces
- re-organized some helpers now that i have a test utilities file