### PR TITLE
errwrap.Wrapf() mop-up

### DIFF
--- a/serviceregistration/consul/consul_service_registration.go
+++ b/serviceregistration/consul/consul_service_registration.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/errwrap"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/parseutil"
@@ -152,7 +151,7 @@ func NewServiceRegistration(conf map[string]string, logger log.Logger, state sr.
 	consulConf.HttpClient = &http.Client{Transport: consulConf.Transport}
 	client, err := api.NewClient(consulConf)
 	if err != nil {
-		return nil, errwrap.Wrapf("client setup failed: {{err}}", err)
+		return nil, fmt.Errorf("client setup failed: %w", err)
 	}
 
 	// Setup the backend

--- a/shamir/shamir.go
+++ b/shamir/shamir.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	mathrand "math/rand"
 	"time"
-
-	"github.com/hashicorp/errwrap"
 )
 
 const (
@@ -164,7 +162,7 @@ func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 	for idx, val := range secret {
 		p, err := makePolynomial(val, uint8(threshold-1))
 		if err != nil {
-			return nil, errwrap.Wrapf("failed to generate polynomial: {{err}}", err)
+			return nil, fmt.Errorf("failed to generate polynomial: %w", err)
 		}
 
 		// Generate a `parts` number of (x,y) pairs


### PR DESCRIPTION
This picks off a couple of spots where `errwrap.Wrapf()` got reintroduced as I was finishing its deprecation.