### PR TITLE
docs: clarify purposes in KMS for AWS

### DIFF
--- a/website/content/api-docs/secret/key-management/index.mdx
+++ b/website/content/api-docs/secret/key-management/index.mdx
@@ -419,6 +419,8 @@ provider. The parameters set cannot be changed after the key has been distribute
   - `wrap`
   - `unwrap`
 
+-> **Note**: AWS only supports `encrypt` and `decrypt` purposes.
+
 - `protection` `(string: "hsm")` – Specifies the protection of the key. The protection defines
   where cryptographic operations are performed with the key in the KMS provider. The following
   values are supported:


### PR DESCRIPTION
The `awskms` provider for KMS does not support all purposes:

```
   * 1 error occurred:
   	* "awskms" does not support key purpose "sign"
   * 1 error occurred:
   	* "awskms" does not support key purpose "unwrap"
   * 1 error occurred:
   	* "awskms" does not support key purpose "verify"
   * 1 error occurred:
   	* "awskms" does not support key purpose "wrap"
```

This adds a small note about only supporting decrypt and encrypt.