### PR TITLE
 fix typo in vault operator init cmd

### DIFF
--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -448,7 +448,7 @@ func (c *OperatorInitCommand) init(client *api.Client, req *api.InitRequest) int
 		c.UI.Output("")
 		c.UI.Output(wrapAtLength(fmt.Sprintf(
 			"Vault does not store the generated master key. Without at least %d "+
-				"key to reconstruct the master key, Vault will remain permanently "+
+				"keys to reconstruct the master key, Vault will remain permanently "+
 				"sealed!",
 			req.SecretThreshold)))
 

--- a/website/content/intro/getting-started/deploy.mdx
+++ b/website/content/intro/getting-started/deploy.mdx
@@ -128,7 +128,7 @@ distribute the key shares printed above. When the Vault is re-sealed,
 restarted, or stopped, you must supply at least 3 of these keys to unseal it
 before it can start servicing requests.
 
-Vault does not store the generated master key. Without at least 3 key to
+Vault does not store the generated master key. Without at least 3 keys to
 reconstruct the master key, Vault will remain permanently sealed!
 
 It is possible to generate new unseal keys, provided you have a quorum of


### PR DESCRIPTION
## Description

Fixed typo while running `vault operator init` command
https://github.com/hashicorp/vault/issues/11727