### PR TITLE
Fix double read statelock in remount request

### DIFF
--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -1168,7 +1168,7 @@ func (b *SystemBackend) handleRemount(ctx context.Context, req *logical.Request,
 	}
 
 	// Attempt remount
-	if err := b.Core.remount(ctx, fromPath, toPath, !b.Core.PerfStandby()); err != nil {
+	if err := b.Core.remount(ctx, fromPath, toPath, !b.Core.perfStandby); err != nil {
 		b.Backend.Logger().Error("remount failed", "from_path", fromPath, "to_path", toPath, "error", err)
 		return handleError(err)
 	}


### PR DESCRIPTION
Use the field instead of the method because we don't want to try to grab the readlock when we're servicing a request, since that would've already caused a readlock to be grabbed.

Frankly I don't understand why this isn't causing more problems - how does remount even work with this code?  It wasn't recently added.