### PR TITLE
fix irrevocable leases API deadlock on m.coreStateLock

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -133,8 +133,7 @@ type ExpirationManager struct {
 	restoreLoaded      sync.Map
 	quitCh             chan struct{}
 
-	// do not hold coreStateLock in any code being called by API handlers
-	// as it is already held by the calling code
+	// do not hold coreStateLock in any API handler code - it is already held
 	coreStateLock     *DeadlockRWMutex
 	quitContext       context.Context
 	leaseCheckCounter *uint32

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -133,6 +133,8 @@ type ExpirationManager struct {
 	restoreLoaded      sync.Map
 	quitCh             chan struct{}
 
+	// do not hold coreStateLock in any code being called by API handlers
+	// as it is already held by the calling code
 	coreStateLock     *DeadlockRWMutex
 	quitContext       context.Context
 	leaseCheckCounter *uint32
@@ -270,7 +272,7 @@ func (r *revocationJob) OnFailure(err error) {
 func expireLeaseStrategyFairsharing(ctx context.Context, m *ExpirationManager, leaseID string, ns *namespace.Namespace) {
 	nsCtx := namespace.ContextWithNamespace(ctx, ns)
 
-	mountAccessor := m.getLeaseMountAccessor(ctx, leaseID)
+	mountAccessor := m.getLeaseMountAccessorLocked(ctx, leaseID)
 
 	job, err := newRevocationJob(nsCtx, leaseID, ns, m)
 	if err != nil {
@@ -2495,10 +2497,15 @@ func (m *ExpirationManager) getNamespaceFromLeaseID(ctx context.Context, leaseID
 	return leaseNS, nil
 }
 
-func (m *ExpirationManager) getLeaseMountAccessor(ctx context.Context, leaseID string) string {
+func (m *ExpirationManager) getLeaseMountAccessorLocked(ctx context.Context, leaseID string) string {
 	m.coreStateLock.RLock()
+	defer m.coreStateLock.RUnlock()
+	return m.getLeaseMountAccessor(ctx, leaseID)
+}
+
+// note: this function must be called with m.coreStateLock held for read
+func (m *ExpirationManager) getLeaseMountAccessor(ctx context.Context, leaseID string) string {
 	mount := m.core.router.MatchingMountEntry(ctx, leaseID)
-	m.coreStateLock.RUnlock()
 
 	var mountAccessor string
 	if mount == nil {


### PR DESCRIPTION
The locking behavior is slightly different, but i don't think it will be an issue

this will also be backported to `release/1.8.x`