### PR TITLE
database/cassandra: Docs: Add known issue warning to `pem_bundle` field

### DIFF
--- a/website/content/api-docs/secret/databases/cassandra.mdx
+++ b/website/content/api-docs/secret/databases/cassandra.mdx
@@ -46,9 +46,9 @@ has a number of parameters to further configure a connection.
   certificate and private key; a certificate, private key, and issuing CA
   certificate; or just a CA certificate.
 
-!> **Known Issue:** If Cassandra is configured with a custom CA and not using mTLS, `pem_bundle`
-   will not parse the CA certificate correctly. Instead use `pem_json` with the following structure:
-   `{"ca_chain": ["-----BEGIN CERTIFICATE-----\nMIIEFjC...FNYakP7I\n-----END CERTIFICATE-----"]}`
+!> **Known Issue:** There is a known issue when using `pem_bundle` with only a CA (no client certificate & key)
+   where Vault will not parse the CA certificate correctly. To work around this, use `pem_json` with the
+   following structure: `{"ca_chain": ["-----BEGIN CERTIFICATE-----\nMIIEFjC...FNYakP7I\n-----END CERTIFICATE-----"]}`
    Also make sure the PEM data is properly JSON encoded with `\n` instead of newlines.
 
 - `pem_json` `(string: "")` – Specifies JSON containing a certificate and

--- a/website/content/api-docs/secret/databases/cassandra.mdx
+++ b/website/content/api-docs/secret/databases/cassandra.mdx
@@ -46,7 +46,7 @@ has a number of parameters to further configure a connection.
   certificate and private key; a certificate, private key, and issuing CA
   certificate; or just a CA certificate.
 
-!> *Known Issue:* If Cassandra is configured with a custom CA and not using mTLS, `pem_bundle`
+!> **Known Issue:** If Cassandra is configured with a custom CA and not using mTLS, `pem_bundle`
    will not parse the CA certificate correctly. Instead use `pem_json` with the following structure:
    `{"ca_chain": ["-----BEGIN CERTIFICATE-----\nMIIEFjC...FNYakP7I\n-----END CERTIFICATE-----"]}`
    Also make sure the PEM data is properly JSON encoded with `\n` instead of newlines.

--- a/website/content/api-docs/secret/databases/cassandra.mdx
+++ b/website/content/api-docs/secret/databases/cassandra.mdx
@@ -46,6 +46,11 @@ has a number of parameters to further configure a connection.
   certificate and private key; a certificate, private key, and issuing CA
   certificate; or just a CA certificate.
 
+!> *Known Issue:* If Cassandra is configured with a custom CA and not using mTLS, `pem_bundle`
+   will not parse the CA certificate correctly. Instead use `pem_json` with the following structure:
+   `{"ca_chain": ["-----BEGIN CERTIFICATE-----\nMIIEFjC...FNYakP7I\n-----END CERTIFICATE-----"]}`
+   Also make sure the PEM data is properly JSON encoded with `\n` instead of newlines.
+
 - `pem_json` `(string: "")` – Specifies JSON containing a certificate and
   private key; a certificate, private key, and issuing CA certificate; or just a
   CA certificate. For convenience format is the same as the output of the


### PR DESCRIPTION
Adds a note to `pem_bundle` about a known issue when using Cassandra with a custom CA and not using a client certificate.