### PR TITLE
Backport 1.8: Omit wrapping tokens and control groups from client counts (#11826)

### DIFF
--- a/changelog/11826.txt
+++ b/changelog/11826.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+activity: Omit wrapping tokens and control groups from client counts
+```

--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1504,7 +1504,9 @@ func (a *ActivityLog) HandleTokenCreation(entry *logical.TokenEntry) {
 	if entry.EntityID != "" {
 		a.AddEntityToFragment(entry.EntityID, entry.NamespaceID, entry.CreationTime)
 	} else {
-		a.AddTokenToFragment(entry.NamespaceID)
+		if !IsWrappingToken(entry) {
+			a.AddTokenToFragment(entry.NamespaceID)
+		}
 	}
 }
 

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -444,11 +444,7 @@ func (c *Core) ValidateWrappingToken(ctx context.Context, req *logical.Request) 
 		return false, nil
 	}
 
-	if len(te.Policies) != 1 {
-		return false, nil
-	}
-
-	if te.Policies[0] != responseWrappingPolicyName && te.Policies[0] != controlGroupPolicyName {
+	if !IsWrappingToken(te) {
 		return false, nil
 	}
 
@@ -459,4 +455,16 @@ func (c *Core) ValidateWrappingToken(ctx context.Context, req *logical.Request) 
 	}
 
 	return true, nil
+}
+
+func IsWrappingToken(te *logical.TokenEntry) bool {
+	if len(te.Policies) != 1 {
+		return false
+	}
+
+	if te.Policies[0] != responseWrappingPolicyName && te.Policies[0] != controlGroupPolicyName {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
* Omit wrapping tokens and control groups from client counts

* add changelog note