### PR TITLE
plugins/cassandra: add tls_server_name (#11820)

### DIFF
--- a/changelog/11820.txt
+++ b/changelog/11820.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+db/cassandra: Added tls_server_name to specify server name for TLS validation
+```

--- a/plugins/database/cassandra/connection_producer.go
+++ b/plugins/database/cassandra/connection_producer.go
@@ -28,6 +28,7 @@ type cassandraConnectionProducer struct {
 	Password           string      `json:"password" structs:"password" mapstructure:"password"`
 	TLS                bool        `json:"tls" structs:"tls" mapstructure:"tls"`
 	InsecureTLS        bool        `json:"insecure_tls" structs:"insecure_tls" mapstructure:"insecure_tls"`
+	TLSServerName      string      `json:"tls_server_name" structs:"tls_server_name" mapstructure:"tls_server_name"`
 	ProtocolVersion    int         `json:"protocol_version" structs:"protocol_version" mapstructure:"protocol_version"`
 	ConnectTimeoutRaw  interface{} `json:"connect_timeout" structs:"connect_timeout" mapstructure:"connect_timeout"`
 	SocketKeepAliveRaw interface{} `json:"socket_keep_alive" structs:"socket_keep_alive" mapstructure:"socket_keep_alive"`
@@ -189,7 +190,7 @@ func (c *cassandraConnectionProducer) createSession(ctx context.Context) (*gocql
 	clusterConfig.SocketKeepalive = c.socketKeepAlive
 
 	if c.TLS {
-		sslOpts, err := getSslOpts(c.certBundle, c.TLSMinVersion, c.InsecureTLS)
+		sslOpts, err := getSslOpts(c.certBundle, c.TLSMinVersion, c.TLSServerName, c.InsecureTLS)
 		if err != nil {
 			return nil, err
 		}
@@ -235,7 +236,7 @@ func (c *cassandraConnectionProducer) createSession(ctx context.Context) (*gocql
 	return session, nil
 }
 
-func getSslOpts(certBundle *certutil.CertBundle, minTLSVersion string, insecureSkipVerify bool) (*gocql.SslOptions, error) {
+func getSslOpts(certBundle *certutil.CertBundle, minTLSVersion, serverName string, insecureSkipVerify bool) (*gocql.SslOptions, error) {
 	tlsConfig := &tls.Config{}
 	if certBundle != nil {
 		if certBundle.Certificate == "" && certBundle.PrivateKey != "" {
@@ -257,6 +258,10 @@ func getSslOpts(certBundle *certutil.CertBundle, minTLSVersion string, insecureS
 	}
 
 	tlsConfig.InsecureSkipVerify = insecureSkipVerify
+
+	if serverName != "" {
+		tlsConfig.ServerName = serverName
+	}
 
 	if minTLSVersion != "" {
 		var ok bool

--- a/website/pages/api-docs/secret/databases/cassandra.mdx
+++ b/website/pages/api-docs/secret/databases/cassandra.mdx
@@ -43,6 +43,9 @@ has a number of parameters to further configure a connection.
 - `insecure_tls` `(bool: false)` – Specifies whether to skip verification of the
   server certificate when using TLS.
 
+- `tls_server_name` `(string: "")` – Specifies the name to use as the SNI host when 
+  connecting to the Cassandra server via TLS.
+  
 - `pem_bundle` `(string: "")` – Specifies concatenated PEM blocks containing a
   certificate and private key; a certificate, private key, and issuing CA
   certificate; or just a CA certificate.


### PR DESCRIPTION
Backporting #11820 to 1.6.x.