### PR TITLE
plugins/cassandra: add tls_server_name (#11820)

### DIFF
--- a/changelog/11820.txt
+++ b/changelog/11820.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+db/cassandra: Added tls_server_name to specify server name for TLS validation
+```

--- a/website/content/api-docs/secret/databases/cassandra.mdx
+++ b/website/content/api-docs/secret/databases/cassandra.mdx
@@ -43,6 +43,9 @@ has a number of parameters to further configure a connection.
 - `insecure_tls` `(bool: false)` – Specifies whether to skip verification of the
   server certificate when using TLS.
 
+- `tls_server_name` `(string: "")` – Specifies the name to use as the SNI host when 
+  connecting to the Cassandra server via TLS.
+  
 - `pem_bundle` `(string: "")` – Specifies concatenated PEM blocks containing a
   certificate and private key; a certificate, private key, and issuing CA
   certificate; or just a CA certificate.


### PR DESCRIPTION
Backport #11820 to 1.7.x