### PR TITLE
Makefile: don't go get -u for plugin upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ bootstrap: ci-bootstrap
 # Note: if you have plugins in GOPATH you can update all of them via something like:
 # for i in $(ls | grep vault-plugin-); do cd $i; git remote update; git reset --hard origin/master; dep ensure -update; git add .; git commit; git push; cd ..; done
 update-plugins:
-	grep vault-plugin- go.mod | cut -d ' ' -f 1 | while read -r P; do echo "Updating $P..."; go get -v -u "$P"; done
+	grep vault-plugin- go.mod | cut -d ' ' -f 1 | while read -r P; do echo "Updating $P..."; go get -v "$P"; done
 
 static-assets-dir:
 	@mkdir -p ./pkg/web_ui


### PR DESCRIPTION
- Not needed to upgrade the plugin itself.
- Can cause issues when transitive modules are updated.