### PR TITLE
fix make ember-dist-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ ember-dist-dev:
 	@cd ui && yarn --ignore-optional
 	@cd ui && npm rebuild node-sass
 	@echo "--> Building Ember application"
-	@cd ui && yarn run build-dev
+	@cd ui && yarn run build:dev
 
 static-dist: ember-dist static-assets
 static-dist-dev: ember-dist-dev static-assets


### PR DESCRIPTION
Currently `make ember-dist-dev` fails with the following error.
```
error Command "build-dev" not found.
```