### PR TITLE
Backport 1.8: OSS parts of sighup license reload test (#11816)

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -99,10 +99,11 @@ type ServerCommand struct {
 
 	cleanupGuard sync.Once
 
-	reloadFuncsLock *sync.RWMutex
-	reloadFuncs     *map[string][]reloadutil.ReloadFunc
-	startedCh       chan (struct{}) // for tests
-	reloadedCh      chan (struct{}) // for tests
+	reloadFuncsLock   *sync.RWMutex
+	reloadFuncs       *map[string][]reloadutil.ReloadFunc
+	startedCh         chan (struct{}) // for tests
+	reloadedCh        chan (struct{}) // for tests
+	licenseReloadedCh chan (error)    // for tests
 
 	allLoggers []log.Logger
 
@@ -1563,8 +1564,13 @@ func (c *ServerCommand) Run(args []string) int {
 			}
 
 			// Reload license file
-			if err := vault.LicenseReload(core); err != nil {
-				c.UI.Error(fmt.Sprintf("Error reloading license: %v", err))
+			if err = vault.LicenseReload(core); err != nil {
+				c.UI.Error(err.Error())
+			}
+
+			select {
+			case c.licenseReloadedCh <- err:
+			default:
 			}
 
 		case <-c.SigUSR2Ch:

--- a/command/server_test.go
+++ b/command/server_test.go
@@ -96,8 +96,9 @@ func testServerCommand(tb testing.TB) (*cli.MockUi, *ServerCommand) {
 		},
 
 		// These prevent us from random sleep guessing...
-		startedCh:  make(chan struct{}, 5),
-		reloadedCh: make(chan struct{}, 5),
+		startedCh:         make(chan struct{}, 5),
+		reloadedCh:        make(chan struct{}, 5),
+		licenseReloadedCh: make(chan error),
 	}
 }
 


### PR DESCRIPTION
Original PR https://github.com/hashicorp/vault/pull/11816