### PR TITLE
Add more detailed documentation on setting issuer for CSI provider

### DIFF
--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -37,7 +37,7 @@ If installing via the helm chart, they can be set using e.g.
   using Secrets Store CSI Driver v0.0.24+.
 
 
-# Secret Class Provider Configurations
+# Secret Provider Class Configurations
 
 The following parameters are supported by the Vault provider:
 

--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -4,6 +4,39 @@ page_title: Vault CSI Provider Configurations
 description: This section documents the configurables for the Vault CSI Provider.
 ---
 
+# Command line arguments
+
+The following command line arguments are supported by the Vault CSI provider.
+If installing via the helm chart, they can be set using e.g.
+`--set "csi.extraArgs={-debug=true}"`.
+
+- `-debug` `(bool: false)` - Set to true to enable debug level logging.
+
+- `-endpoint` `(string: "/tmp/vault.sock")` - Path to unix socket on which the
+  provider will listen for gRPC calls from the driver.
+
+- `-health-addr` `(string: ":8080")` - (v0.3.0+) The address of the HTTP listener
+  for reporting health.
+
+- `-health_addr` `(string: "")` - Deprecated, please use -health-addr. Slated
+  for removal in 0.5.0.
+
+- `-vault-addr` `(string: "https://127.0.0.1:8200")` - (v0.3.0+) Default address
+  for connecting to Vault. Can be overridden per Secret Provider Class object.
+
+- `-vault-mount` `(string: "kubernetes")` - (v0.3.0+) Default Vault mount path
+  for Kubernetes authentication. Can be overridden per Secret Provider Class
+  object.
+
+- `-version` `(bool: false)` - prints the version information
+
+- `-write-secrets` `(bool: true)` - (v0.3.0+) Write secrets directly to
+  filesystem (true), or send secrets to CSI driver in gRPC response (false).
+  Setting to false requires Secrets Store CSI Driver v0.0.21+. This flag will
+  default to false from v0.4.0, and setting it to false will be required when
+  using Secrets Store CSI Driver v0.0.24+.
+
+
 # Secret Class Provider Configurations
 
 The following parameters are supported by the Vault provider:

--- a/website/content/docs/platform/k8s/csi/index.mdx
+++ b/website/content/docs/platform/k8s/csi/index.mdx
@@ -18,7 +18,7 @@ Driver to be installed.
 At a high level, the CSI Secrets Store driver allows users to create `SecretProviderClass` objects.
 This object defines which secret provider to use and what secrets to retrieve. When pods requesting CSI volumes
 are created, the CSI Secrets Store driver will send the request to the Vault CSI Provider if the provider
-is `vault`. The Vault CSI Provider will then use Secret Class Provider specified and the pod's service account to retrieve
+is `vault`. The Vault CSI Provider will then use Secret Provider Class specified and the pod's service account to retrieve
 the secrets from Vault, and <span class="x x-first x-last">mount</span> them <span class="x x-first x-last">into</span> the pod<span class="x x-first x-last">'s CSI</span> volume.
 
 The secret is retrieved from Vault and populated to the CSI secrets store volume during the `ContainerCreation` phase.

--- a/website/content/docs/platform/k8s/csi/index.mdx
+++ b/website/content/docs/platform/k8s/csi/index.mdx
@@ -48,6 +48,52 @@ A service account must be present to use the Vault CSI Provider with the Kuberne
 authentication method. It is _not_ recommended to bind Vault roles to the default service
 account provided to pods if no service account is defined.
 
+### Setting `issuer` for Kubernetes authentication
+
+You will likely need to set [`issuer`](/api-docs/auth/kubernetes#issuer) when
+configuring Kubernetes authentication for the Vault CSI Provider.
+Vault CSI Provider does not use the default token associated with service accounts.
+Instead, it creates a token with a short TTL whose lifetime is also bound to the
+lifetime of the requesting pod. A key difference between default tokens and
+ephemeral tokens is the JWT issuer. Default tokens use `kubernetes/serviceaccount`,
+which is the default value that Kubernetes auth will try to validate. However,
+ephemeral tokens use the value of `kube-apiserver`'s `--service-account-issuer`
+flag as the issuer, which is normally a URL instead.
+
+When configuring Vault Kubernetes auth for the CSI provider, you will need to set
+[`issuer`](/api-docs/auth/kubernetes#issuer) to the same value as
+`kube-apiserver`'s `--service-account-issuer` flag. If you are unable to check
+this value directly, you can run the following and look for the `"iss"` field
+to find the required value:
+
+```bash
+kubectl proxy &
+curl --silent http://127.0.0.1:8001/api/v1/namespaces/default/serviceaccounts/default/token \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d '{"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest"}' \
+  | jq -r '.status.token' \
+  | cut -d. -f2 \
+  | base64 -D
+```
+
+This value is then used when configuring Kubernetes auth, e.g.:
+
+```bash
+vault write auth/kubernetes/config \
+  token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443" \
+  kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+  issuer="\"test-aks-cluster-dns-d6cbb78e.hcp.uksouth.azmk8s.io\""
+```
+
+Importantly, this means most common configurations of Vault Agent Injector and
+Vault CSI Provider **cannot share the same Kubernetes auth mount**. Vault
+Agent sidecars will most commonly be configured to authenticate using a
+long-lived default service account token, with an issuer different to the tokens
+Vault CSI Provider will create. But one Kubernetes auth mount can only be
+configured to validate a single issuer value.
+
 ## Secret Provider Class Example
 
 The following is an example of a Secret Provider Class using the `vault` provider:

--- a/website/content/docs/platform/k8s/csi/installation.mdx
+++ b/website/content/docs/platform/k8s/csi/installation.mdx
@@ -6,7 +6,15 @@ description: The Vault CSI Provider can be installed using Vault Helm.
 
 # Installing the Vault CSI Provider
 
-~> The Vault CSI Provider requires the [CSI Secret Store Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver).
+## Prerequisites
+
+* Kubernetes 1.16+ for both the master and worker nodes (Linux-only)
+* [Secrets store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html) installed
+* `TokenRequest` endpoint available, which requires setting the flags
+  `--service-account-signing-key-file` and `--service-account-issuer` for
+  `kube-apiserver`. Set by default from 1.20+ and earlier in most managed services.
+
+## Installation using helm
 
 The [Vault Helm chart](/docs/platform/k8s/helm) is the recommended way to
 install and configure the Vault CSI Provider in Kubernetes.


### PR DESCRIPTION
This has been a common tripping point for first-time setup of the Vault CSI provider, and isn't well addressed by existing documentation, so this is an attempt to explain the topic and help people find the correct configuration.

Also adds documentation for command line arguments now that the provider has some non-trivial configuration available from 0.3.0+.