### PR TITLE
docs: add permissions required for cassandra

### DIFF
--- a/website/content/docs/secrets/databases/cassandra.mdx
+++ b/website/content/docs/secrets/databases/cassandra.mdx
@@ -24,6 +24,14 @@ more information about setting up the database secrets engine.
 
 ## Setup
 
+1. Vault will need a Cassandra user with the following permissions:
+   ```text
+   GRANT CREATE ON ALL ROLES to '<YOUR USER>';
+   GRANT ALTER ON ALL ROLES to '<YOUR USER>';
+   GRANT DROP ON ALL ROLES to '<YOUR USER>';
+   GRANT AUTHORIZE ON ALL ROLES to '<YOUR USER>';
+   ```
+
 1.  Enable the database secrets engine if it is not already enabled:
 
     ```text


### PR DESCRIPTION
This adds the required permissions for the Cassandra user Vault will use for management.