### PR TITLE
docs: add troubleshooting sub-section on plugins

### DIFF
--- a/website/content/docs/internals/plugins.mdx
+++ b/website/content/docs/internals/plugins.mdx
@@ -124,8 +124,8 @@ given the ability to use the `mlock` syscall.
 
 #### Unrecognized remote plugin message
 
-If the following error is encountered when enabling mounting a plugin secret
-egine or auth method:
+If the following error is encountered when enabling a plugin secret engine or
+auth method:
 
 ```sh
 Unrecognized remote plugin message:

--- a/website/content/docs/internals/plugins.mdx
+++ b/website/content/docs/internals/plugins.mdx
@@ -120,6 +120,27 @@ settings. Like Vault, plugins support [the use of mlock when available](/docs/co
 plugin executable in your [plugins directory](/docs/internals/plugins#plugin-directory) must be
 given the ability to use the `mlock` syscall.
 
+### Troubleshooting
+
+#### Unrecognized remote plugin message
+
+If the following error is encountered when enabling mounting a plugin secret
+egine or auth method:
+
+```sh
+Unrecognized remote plugin message:
+
+This usually means that the plugin is either invalid or simply
+needs to be recompiled to support the latest protocol.
+```
+
+Verify whether the Vault process has `mlock` enabled, and if so run the
+following command against the plugin binary:
+
+```sh
+sudo setcap cap_ipc_lock=+ep <plugin-binary>
+```
+
 # Plugin Development
 
 ~> Advanced topic! Plugin development is a highly advanced topic in Vault, and


### PR DESCRIPTION
Add a troubleshooting section on the plugins internals page. Include the error message and resolution instruction for a common error when `mlock` is enabled on Vault.