### PR TITLE
Remove a broken link

### DIFF
--- a/website/content/docs/secrets/transform/tokenization.mdx
+++ b/website/content/docs/secrets/transform/tokenization.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Tokenization Transform
 
-Not to be confused with Vault tokens, [Tokenization](transform/tokenization) exchanges a
+Not to be confused with Vault tokens, Tokenization exchanges a
 sensitive value for an unrelated value called a _token_. The original sensitive
 value cannot be recovered from a token alone, they are irreversible. Instead,
 unlike format preserving encryption, tokenization is stateful. To decode the


### PR DESCRIPTION
This PR fixes the [reported issue](https://hashicorp.slack.com/archives/CQS78SFQD/p1623186381025900).

I honestly don't see the reason for the hyperlink.  So, I went ahead and removed it. 

:mag: [Deploy Preview](https://vault-git-transform-doc-fix-link-hashicorp.vercel.app/docs/secrets/transform/tokenization)