### PR TITLE
chore:  add local vault server wrappers in yarn and document in readme

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -44,6 +44,20 @@ running `yarn --force`.
 In order to enforce the same version of `yarn` across installs, the `yarn` binary is included in the repo
 in the `.yarn/releases` folder. To update to a different version of `yarn`, use the `yarn policies set-version VERSION` command. For more information on this, see the [documentation](https://yarnpkg.com/en/docs/cli/policies).
 
+## Running a Vault Server
+
+Before running Vault UI locally, a Vault server must be running.  First, ensure
+Vault dev is built according the the instructions in `../README.md`.  To start a
+single local Vault server:
+
+- `yarn vault`
+
+To start a local Vault cluster:
+
+- `yarn vault:cluster`
+
+These commands may also be [aliased on your local device](https://github.com/hashicorp/vault-tools/blob/master/users/noelle/vault_aliases).
+
 ## Running / Development
 
 To get all of the JavaScript dependencies installed, run this in the `ui` directory:

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,9 @@
     "build:storybook": "build-storybook -s ../pkg/web_ui",
     "storybook": "start-storybook -p 6006 -s ../pkg/web_ui",
     "deploy:storybook": "yarn build && yarn build:storybook",
-    "gen-story-md": "node scripts/gen-story-md.js"
+    "gen-story-md": "node scripts/gen-story-md.js",
+    "vault": "VAULT_REDIRECT_ADDR=http://127.0.0.1:8200 vault server -log-level=error -dev -dev-root-token-id=root -dev-ha -dev-transactional",
+    "vault:cluster": "VAULT_REDIRECT_ADDR=http://127.0.0.1:8202 vault server -log-level=error -dev -dev-root-token-id=root -dev-listen-address=127.0.0.1:8202 -dev-ha -dev-transactional"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
This PR adds convenient yarn wrappers around commonly-used local Vault server commands.  Since Vault UI development requires a running Vault server, documenting these commands in the README is helpful to get new developers up and running quickly.