### PR TITLE
Mongo doesnt allow periods in usernames

### DIFF
--- a/changelog/11872.txt
+++ b/changelog/11872.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+mongo-db: default username template now strips invalid '.' characters
+```

--- a/plugins/database/mongodb/mongodb.go
+++ b/plugins/database/mongodb/mongodb.go
@@ -21,7 +21,7 @@ import (
 const (
 	mongoDBTypeName = "mongodb"
 
-	defaultUserNameTemplate = `{{ printf "v-%s-%s-%s-%s" (.DisplayName | truncate 15) (.RoleName | truncate 15) (random 20) (unix_time) | truncate 100 }}`
+	defaultUserNameTemplate = `{{ printf "v-%s-%s-%s-%s" (.DisplayName | replace "." "-" | truncate 15) (.RoleName | replace "." "-" | truncate 15) (random 20) (unix_time) | truncate 100 }}`
 )
 
 // MongoDB is an implementation of Database interface

--- a/plugins/database/mongodb/mongodb.go
+++ b/plugins/database/mongodb/mongodb.go
@@ -21,7 +21,7 @@ import (
 const (
 	mongoDBTypeName = "mongodb"
 
-	defaultUserNameTemplate = `{{ printf "v-%s-%s-%s-%s" (.DisplayName | replace "." "-" | truncate 15) (.RoleName | replace "." "-" | truncate 15) (random 20) (unix_time) | truncate 100 }}`
+	defaultUserNameTemplate = `{{ printf "v-%s-%s-%s-%s" (.DisplayName | truncate 15) (.RoleName | truncate 15) (random 20) (unix_time) | replace "." "-" | truncate 100 }}`
 )
 
 // MongoDB is an implementation of Database interface

--- a/plugins/database/mongodb/mongodb_test.go
+++ b/plugins/database/mongodb/mongodb_test.go
@@ -82,6 +82,23 @@ func TestNewUser_usernameTemplate(t *testing.T) {
 
 			expectedUsernameRegex: "^v-token-testrolenamewit-[a-zA-Z0-9]{20}-[0-9]{10}$",
 		},
+		"default username template with invalid chars": {
+			usernameTemplate: "",
+
+			newUserReq: dbplugin.NewUserRequest{
+				UsernameConfig: dbplugin.UsernameMetadata{
+					DisplayName: "a.bad.account",
+					RoleName:    "a.bad.role",
+				},
+				Statements: dbplugin.Statements{
+					Commands: []string{mongoAdminRole},
+				},
+				Password:   "98yq3thgnakjsfhjkl",
+				Expiration: time.Now().Add(time.Minute),
+			},
+
+			expectedUsernameRegex: "^v-a-bad-account-a-bad-role-[a-zA-Z0-9]{20}-[0-9]{10}$",
+		},
 		"custom username template": {
 			usernameTemplate: "{{random 2 | uppercase}}_{{unix_time}}_{{.RoleName | uppercase}}_{{.DisplayName | uppercase}}",
 

--- a/website/content/api-docs/secret/databases/mongodb.mdx
+++ b/website/content/api-docs/secret/databases/mongodb.mdx
@@ -52,7 +52,7 @@ has a number of parameters to further configure a connection.
 <summary><b>Default Username Template</b></summary>
 
 ```
-{{ printf "v-%s-%s-%s-%s" (.DisplayName | truncate 15) (.RoleName | truncate 15) (random 20) (unix_time) | truncate 100 }}
+{{ printf "v-%s-%s-%s-%s" (.DisplayName | truncate 15) (.RoleName | truncate 15) (random 20) (unix_time) | replace "." "-"  | truncate 100 }}
 ```
 
 <details>


### PR DESCRIPTION
We found that the default username template can create invalid usernames which aren't accepted by mongo.  Replacing the dots with an allowed character fixes it.