### PR TITLE
UI/fix safari oidc login

### DIFF
--- a/changelog/11884.txt
+++ b/changelog/11884.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix oidc login with Safari
+```

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -124,8 +124,7 @@ export default Component.extend({
       return;
     }
     this.onLoading(true);
-    // get the info from the event fired by the other window and
-    // then remove it from localStorage
+
     let { namespace, path, state, code } = oidcState;
 
     // The namespace can be either be passed as a query paramter, or be embedded

--- a/ui/app/components/auth-jwt.js
+++ b/ui/app/components/auth-jwt.js
@@ -120,7 +120,6 @@ export default Component.extend({
   },
 
   exchangeOIDC: task(function*(oidcState, oidcWindow) {
-    // in non-incognito mode we need to use a timeout because it takes time before oidcState is written to local storage.
     if (oidcState === null || oidcState === undefined) {
       return;
     }
@@ -176,6 +175,7 @@ export default Component.extend({
 
       await this.fetchRole.perform(this.roleName, { debounce: false });
       let win = this.getWindow();
+
       const POPUP_WIDTH = 500;
       const POPUP_HEIGHT = 600;
       let left = win.screen.width / 2 - POPUP_WIDTH / 2;
@@ -185,6 +185,7 @@ export default Component.extend({
         'vaultOIDCWindow',
         `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},resizable,scrollbars=yes,top=${top},left=${left}`
       );
+
       this.prepareForOIDC.perform(oidcWindow);
     },
   },

--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -10,7 +10,7 @@ export default Route.extend({
     let { namespaceQueryParam: namespace } = this.paramsFor('vault.cluster');
     path = window.decodeURIComponent(path);
     let queryParams = { namespace, path, code, state };
-    window.localStorage.setItem('oidcState', JSON.stringify(queryParams));
+    window.opener.postMessage(queryParams);
   },
   renderTemplate() {
     this.render(this.templateName, {

--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -10,7 +10,7 @@ export default Route.extend({
     let { namespaceQueryParam: namespace } = this.paramsFor('vault.cluster');
     path = window.decodeURIComponent(path);
     let queryParams = { namespace, path, code, state };
-    window.opener.postMessage(queryParams);
+    window.opener.postMessage(queryParams, window.origin);
   },
   renderTemplate() {
     this.render(this.templateName, {

--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -55,7 +55,7 @@
       @roleName={{this.roleName}}
       @selectedAuthType={{this.selectedAuthBackend.type}}
       @selectedAuthPath={{or this.customPath this.selectedAuthBackend.id}}
-      @disabled={{authenticate.isRunning}}
+      @disabled={{or authenticate.isRunning this.isLoading}}
     >
       <AuthFormOptions
         @customPath={{this.customPath}}
@@ -110,7 +110,7 @@
           <AlertInline
             @paddingTop=true
             @sizeSmall=true
-            @type="info" 
+            @type="info"
             @message="If login takes longer than usual, you may need to check your device for an MFA notification, or contact your administrator if login times out."
             data-test-auth-message="push"
           />

--- a/ui/tests/integration/components/auth-jwt-test.js
+++ b/ui/tests/integration/components/auth-jwt-test.js
@@ -17,7 +17,7 @@ const component = create(form);
 const windows = [];
 const buildMessage = opts => ({
   isTrusted: true,
-  origin: 'http://localhost:8200',
+  origin: 'https://my-vault.com',
   data: {},
   ...opts,
 });
@@ -35,7 +35,7 @@ const fakeWindow = EmberObject.extend(Evented, {
       width: 500,
     };
   }),
-  origin: 'http://localhost:8200',
+  origin: 'https://my-vault.com',
   closed: false,
 });
 

--- a/ui/tests/integration/components/auth-jwt-test.js
+++ b/ui/tests/integration/components/auth-jwt-test.js
@@ -238,8 +238,8 @@ module('Integration | Component | auth jwt', function(hooks) {
       })
     );
     run.cancelTimers();
-    // assert.equal(this.error, ERROR_MISSING_PARAMS, 'calls onError with params missing error');
-    assert.notOk(this.handler.calledOnce, 'should not call the submit handler');
+    await settled();
+    assert.notOk(this.handler.called, 'should not call the submit handler');
   });
 
   test('oidc: storage event fires with state key, correct params', async function(assert) {

--- a/ui/tests/integration/components/auth-jwt-test.js
+++ b/ui/tests/integration/components/auth-jwt-test.js
@@ -70,15 +70,8 @@ const renderIt = async (context, path = 'jwt') => {
   let fake = fakeWindow.create();
   context.set('window', fake);
   context.set('handler', sinon.spy(handler));
-  // context.set(
-  //   'onError',
-  //   sinon.spy(function(err) {
-  //     console.log('Error passed on error', err);
-  //   })
-  // );
   context.set('roleName', '');
   context.set('selectedAuthPath', path);
-
   await render(hbs`
     <AuthJwt
       @window={{window}}
@@ -274,6 +267,7 @@ module('Integration | Component | auth jwt', function(hooks) {
         },
       })
     );
+    await settled();
     assert.equal(this.selectedAuth, 'token', 'calls onSelectedAuth with token');
     assert.equal(this.token, 'token', 'calls onToken with token');
     assert.ok(this.handler.calledOnce, 'calls the onSubmit handler');


### PR DESCRIPTION
Due to a [Safari localStorage bug](https://twitter.com/jaffathecake/status/1389493762129375232?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1389493762129375232%7Ctwgr%5E%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fappleinsider.com%2Farticles%2F21%2F05%2F04%2Fmacos-bugs-causing-sporadic-browsing-issues-with-safari-firefox-others), logging into Vault with OIDC was not working because the login tab never saw the `localStorage` write from the popup tab. To resolve, we are replacing `localStorage` in this scenario with a [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) call between the two tabs. 

**Before:**
![safari-before](https://user-images.githubusercontent.com/82459713/122426438-e0770b80-cf55-11eb-86b0-0ffdc93c4cc1.gif)

**After:**
![safari-after](https://user-images.githubusercontent.com/82459713/122427103-727f1400-cf56-11eb-9fb0-7eef29d22115.gif)
