### PR TITLE
Pad TOTP input key so that it can be parsed by base32.DecodeString

### DIFF
--- a/builtin/logical/totp/path_keys.go
+++ b/builtin/logical/totp/path_keys.go
@@ -375,6 +375,10 @@ func (b *backend) pathKeyCreate(ctx context.Context, req *logical.Request, data 
 			return logical.ErrorResponse("the key value is required"), nil
 		}
 
+		if i := len(keyString) % 8; i != 0 {
+			keyString += strings.Repeat("=", 8-i)
+		}
+
 		_, err := base32.StdEncoding.DecodeString(strings.ToUpper(keyString))
 		if err != nil {
 			return logical.ErrorResponse(fmt.Sprintf(

--- a/changelog/11887.txt
+++ b/changelog/11887.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secret/totp: pad input key to ensure length is a multiple of 8
+```


### PR DESCRIPTION
base32.DecodeString expects length 8 for the buffer 

Resolves issue #11874 