### PR TITLE
Require special privileges to list irrevocable leases

### DIFF
--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -61,9 +61,9 @@ type Backend struct {
 	// periodic timer of RollbackManager ticks. This can be used by
 	// backends to do anything it wishes to do periodically.
 	//
-	// PeriodicFunc can be invoked to, say to periodically delete stale
+	// PeriodicFunc can be invoked to, say periodically delete stale
 	// entries in backend's storage, while the backend is still being used.
-	// (Note the different of this action from what `Clean` does, which is
+	// (Note the difference between this action and `Clean`, which is
 	// invoked just before the backend is unmounted).
 	PeriodicFunc periodicFunc
 
@@ -80,7 +80,7 @@ type Backend struct {
 	// to the backend, if required.
 	Clean CleanupFunc
 
-	// Invalidate is called when a keys is modified if required
+	// Invalidate is called when a key is modified, if required.
 	Invalidate InvalidateFunc
 
 	// AuthRenew is the callback to call when a RenewRequest for an
@@ -88,7 +88,7 @@ type Backend struct {
 	// See the built-in AuthRenew helpers in lease.go for common callbacks.
 	AuthRenew OperationFunc
 
-	// Type is the logical.BackendType for the backend implementation
+	// BackendType is the logical.BackendType for the backend implementation
 	BackendType logical.BackendType
 
 	logger  log.Logger

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4789,6 +4789,6 @@ This path responds to the following HTTP methods.
 	},
 	"list-leases": {
 		"List leases associated with this Vault cluster",
-		"List leases associated with this Vault cluster",
+		"Requires sudo capability. List leases associated with this Vault cluster",
 	},
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -106,6 +106,8 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 				"leases/revoke-force/*",
 				"leases/lookup/*",
 				"storage/raft/snapshot-auto/config/*",
+				"leases",
+				"leases/",
 			},
 
 			Unauthenticated: []string{

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -57,6 +57,8 @@ func TestSystemBackend_RootPaths(t *testing.T) {
 		"leases/revoke-force/*",
 		"leases/lookup/*",
 		"storage/raft/snapshot-auto/config/*",
+		"leases",
+		"leases/",
 	}
 
 	b := testSystemBackend(t)


### PR DESCRIPTION
If anyone knows of a cleaner way to have an optional slash (**without** doing a prefix match on `leases`), please let me know! I just looked at the doc and no regex allowed.

Also just to verify, the way this is written will only add sudo requirements for `leases(/)?$` correct? not automatically make anything starting with leases require it (since i'm not doing it as a prefix)?