### PR TITLE
docs: update for vault-helm v0.13.0

### DIFF
--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -73,7 +73,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault-k8s"`) - The name of the Docker image for Vault Agent Injector.
 
-    - `tag` (`string: "0.10.1"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "0.10.2"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -81,7 +81,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "vault"`) - The name of the Docker image for the Vault Agent sidecar. This should be set to the official Vault Docker image.
 
-    - `tag` (`string: "1.7.2"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
+    - `tag` (`string: "1.7.3"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
 
   - `agentDefaults` - Values that configure the injected Vault Agent containers default values.
 
@@ -218,11 +218,17 @@ and consider if they're appropriate for your deployment.
 
   - `enabled` (`boolean: true`) - When set to `true`, the Vault server will be created.
 
+  - `enterpriseLicense` - <EnterpriseAlert inline /> This value refers to a Kubernetes secret that you have created that contains your enterprise license. If you are not using an enterprise image or if you plan to introduce the license key via another route, then leave secretName blank ("") or set it to null. Requires Vault Enterprise 1.8 or later.
+
+    - `secretName` (`string: ""`) - The name of the Kubernetes secret that holds the enterprise license. The secret must be in the same namespace that Vault is installed into.
+
+    - `secretKey` (`string: "license"`) - The key within the Kubernetes secret that holds the enterprise license.
+
   - `image` - Values that configure the Vault Docker image.
 
     - `repository` (`string: "vault"`) - The name of the Docker image for the containers running Vault.
 
-    - `tag` (`string: "1.7.2"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "1.7.3"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -814,7 +820,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault-csi-provider"`) - The name of the Docker image for the Vault CSI Provider.
 
-    - `tag` (`string: "0.2.0"`) - The tag of the Docker image for the Vault CSI Provider.. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your CSI provider.
+    - `tag` (`string: "0.3.0"`) - The tag of the Docker image for the Vault CSI Provider.. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your CSI provider.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists locally.
 

--- a/website/content/docs/platform/k8s/helm/enterprise.mdx
+++ b/website/content/docs/platform/k8s/helm/enterprise.mdx
@@ -22,7 +22,7 @@ kubectl create secret generic vault-ent-license --from-literal="license=${secret
 
 -> **Note:** If you cannot find your `.hclic` file, please contact your sales team or Technical Account Manager.
 
-In your chart overrides, set the values of [`server.image`](/docs/platform/k8s/helm/configuration#image-2) to one of the enterprise [release tags](https://hub.docker.com/r/hashicorp/vault-enterprise/tags). Also set the name of the secret you just created in [`server.enterpriseLicense`](/docs/platform/k8s/helm/configuration#enterpriseLicense).
+In your chart overrides, set the values of [`server.image`](/docs/platform/k8s/helm/configuration#image-2) to one of the enterprise [release tags](https://hub.docker.com/r/hashicorp/vault-enterprise/tags). Also set the name of the secret you just created in [`server.enterpriseLicense`](/docs/platform/k8s/helm/configuration#enterpriselicense).
 
 ```yaml
 # config.yaml

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
@@ -21,7 +21,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.7.2_ent' \
+  --set='server.image.tag=1.7.3_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -73,7 +73,7 @@ disaster recovery replication.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.7.0_ent' \
+  --set='server.image.tag=1.7.3_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
@@ -21,7 +21,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.7.2_ent' \
+  --set='server.image.tag=1.7.3_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -72,7 +72,7 @@ With the primary cluster created, next create a secondary cluster.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.7.0_ent' \
+  --set='server.image.tag=1.7.3_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
@@ -15,7 +15,7 @@ Integrated storage (raft) can be enabled using the `server.ha.raft.enabled` valu
 ```shell
 helm install vault hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.7.2_ent' \
+  --set='server.image.tag=1.7.3_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/index.mdx
+++ b/website/content/docs/platform/k8s/helm/index.mdx
@@ -35,7 +35,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.12.0       	1.7.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -57,6 +57,7 @@ Installing a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
 hashicorp/vault	0.12.0       	1.7.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
 hashicorp/vault	0.10.0       	1.7.0      	Official HashiCorp Vault Chart
@@ -65,8 +66,8 @@ hashicorp/vault	0.9.0        	1.6.1      	Official HashiCorp Vault Chart
 hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
 
-# Install version 0.12.0
-$ helm install vault hashicorp/vault --version 0.12.0
+# Install version 0.13.0
+$ helm install vault hashicorp/vault --version 0.13.0
 ```
 
 ~> **Security Warning:** By default, the chart runs in standalone mode. This

--- a/website/content/docs/platform/k8s/helm/openshift.mdx
+++ b/website/content/docs/platform/k8s/helm/openshift.mdx
@@ -69,7 +69,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.12.0       	1.7.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -88,6 +88,7 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
 hashicorp/vault	0.12.0       	1.7.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
 hashicorp/vault	0.10.0       	1.7.0      	Official HashiCorp Vault Chart
@@ -97,8 +98,8 @@ hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.12.0
-$ helm install vault hashicorp/vault --version 0.12.0
+# Install version 0.13.0
+$ helm install vault hashicorp/vault --version 0.13.0
 ```
 
 The `helm install` command accepts parameters to override default configuration

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -53,7 +53,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.12.0        	1.7.2     	Official HashiCorp Vault Chart
+hashicorp/vault	0.13.0        	1.7.3     	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -72,6 +72,7 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
 hashicorp/vault	0.12.0       	1.7.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
 hashicorp/vault	0.10.0       	1.7.0      	Official HashiCorp Vault Chart
@@ -81,8 +82,8 @@ hashicorp/vault	0.8.0        	1.5.4      	Official HashiCorp Vault Chart
 hashicorp/vault	0.7.0        	1.5.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.6.0        	1.4.2      	Official HashiCorp Vault Chart
 
-# Install version 0.12.0
-$ helm install vault hashicorp/vault --version 0.12.0
+# Install version 0.13.0
+$ helm install vault hashicorp/vault --version 0.13.0
 ```
 
 The `helm install` command accepts parameters to override default configuration


### PR DESCRIPTION
This covers the new enterpriseLicense option in the chart.