### PR TITLE
License FAQs Updated 'plus' > 'pro'

### DIFF
--- a/website/content/docs/enterprise/license/faqs.mdx
+++ b/website/content/docs/enterprise/license/faqs.mdx
@@ -40,7 +40,7 @@ No, these changes will not impact HCP Vault.
 | --------------------------------------------------------------------------------------------------------------------------- | --------- |
 | ENT binaries (evaluation or non-evaluation downloaded from [releases.hashicorp.com](https://releases.hashicorp.com/vault/)) | Yes       |
 | Open-Source (OSS)                                                                                                           | No        |
-| Baked-in license binaries (plus/premium)                                                                                    | No        |
+| Baked-in license binaries (pro/premium)                                                                                     | No        |
 
 ### Q: What is the product behavior change introduced by the licensing changes?
 


### PR DESCRIPTION
This updates the `plus` to `pro` in the [table](docs-ent-license-faq). 

🔍  [Deploy Preview](https://vault-git-docs-ent-license-faq-hashicorp.vercel.app/docs/enterprise/license/faqs#q-do-these-license-changes-impact-all-vault-customers-licenses)