### PR TITLE
approle: convert Callbacks to Operations

### DIFF
--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -26,9 +26,17 @@ func pathLogin(b *backend) *framework.Path {
 				Description: "SecretID belong to the App role",
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation:         b.pathLoginUpdate,
-			logical.AliasLookaheadOperation: b.pathLoginUpdateAliasLookahead,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback:                    b.pathLoginUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
+			logical.AliasLookaheadOperation: &framework.PathOperation{
+				Callback:                    b.pathLoginUpdateAliasLookahead,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
+			},
 		},
 		HelpSynopsis:    pathLoginHelpSys,
 		HelpDescription: pathLoginHelpDesc,

--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -28,9 +28,7 @@ func pathLogin(b *backend) *framework.Path {
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback:                    b.pathLoginUpdate,
-				ForwardPerformanceStandby:   true,
-				ForwardPerformanceSecondary: true,
+				Callback: b.pathLoginUpdate,
 			},
 			logical.AliasLookaheadOperation: &framework.PathOperation{
 				Callback: b.pathLoginUpdateAliasLookahead,

--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -33,9 +33,7 @@ func pathLogin(b *backend) *framework.Path {
 				ForwardPerformanceSecondary: true,
 			},
 			logical.AliasLookaheadOperation: &framework.PathOperation{
-				Callback:                    b.pathLoginUpdateAliasLookahead,
-				ForwardPerformanceStandby:   true,
-				ForwardPerformanceSecondary: true,
+				Callback: b.pathLoginUpdateAliasLookahead,
 			},
 		},
 		HelpSynopsis:    pathLoginHelpSys,

--- a/changelog/11893.txt
+++ b/changelog/11893.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-auth/approle: Prevent the `cannot write to readonly storage` error message when login is attempted against a performance standby
-```

--- a/changelog/11893.txt
+++ b/changelog/11893.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/approle: Prevent the `cannot write to readonly storage` error message when login is attempted against a performance standby
+```


### PR DESCRIPTION
Use the new style "Operations" instead of the old style "Callbacks". Because this request is an UpdateOperation, it should have automatically been routed to the primary/active by the router before it reaches the backend. Therefore there should be no need to set the Forward fields.