### PR TITLE
Improving Handling of Unix Domain Socket Addresses

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -464,7 +464,8 @@ func (c *Config) ReadEnvironment() error {
 
 // ParseAddress transforms the provided address into a url.URL and handles
 // the case of Unix domain sockets by setting the DialContext in the
-// configuration's HttpClient.Transport.
+// configuration's HttpClient.Transport. This function must be called with
+// c.modifyLock held for write access.
 func (c *Config) ParseAddress(address string) (*url.URL, error) {
 	u, err := url.Parse(address)
 	if err != nil {
@@ -1103,8 +1104,8 @@ func (c *Client) clone(cloneHeaders bool) (*Client, error) {
 	defer c.modifyLock.RUnlock()
 
 	config := c.config
-	config.modifyLock.Lock()
-	defer config.modifyLock.Unlock()
+	config.modifyLock.RLock()
+	defer config.modifyLock.RUnlock()
 
 	newConfig := &Config{
 		Address:        config.Address,

--- a/api/client.go
+++ b/api/client.go
@@ -586,6 +586,13 @@ func ParseAddress(address string, config *Config) (*url.URL, error) {
 		u.Scheme = "http"
 		u.Host = socket
 		u.Path = ""
+	} else {
+		transport := config.HttpClient.Transport.(*http.Transport)
+		transport.DialContext = (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext
 	}
 
 	return u, nil

--- a/api/client.go
+++ b/api/client.go
@@ -1101,8 +1101,8 @@ func (c *Client) clone(cloneHeaders bool) (*Client, error) {
 	defer c.modifyLock.RUnlock()
 
 	config := c.config
-	config.modifyLock.RLock()
-	defer config.modifyLock.RUnlock()
+	config.modifyLock.Lock()
+	defer config.modifyLock.Unlock()
 
 	newConfig := &Config{
 		Address:        config.Address,

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -441,6 +441,20 @@ func TestClientNonTransportRoundTripper(t *testing.T) {
 	}
 }
 
+func TestClientNonTransportRoundTripperUnixAddress(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripperFunc(http.DefaultTransport.RoundTrip),
+	}
+
+	_, err := NewClient(&Config{
+		HttpClient: client,
+		Address:    "unix:///var/run/vault.sock",
+	})
+	if err == nil {
+		t.Fatal("bad: expected error got nil")
+	}
+}
+
 func TestClone(t *testing.T) {
 	type fields struct{}
 	tests := []struct {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1318,7 +1318,7 @@ func TestParseAddressWithUnixSocket(t *testing.T) {
 	address := "unix:///var/run/vault.sock"
 	config := DefaultConfig()
 
-	u, err := ParseAddress(address, config)
+	u, err := config.ParseAddress(address)
 	if err != nil {
 		t.Fatal("Error not expected")
 	}

--- a/changelog/11904.txt
+++ b/changelog/11904.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: extracting Unix domain socket handling to separate function
+```

--- a/changelog/11904.txt
+++ b/changelog/11904.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-api: extracting Unix domain socket handling to separate function
+api: properly handle switching to/from unix domain socket when changing client address
 ```


### PR DESCRIPTION
This PR started out as a fix for issue #11865.  After realizing that not much can be done to address the issue, it shifted into an attempt to provide a workaround.  That lead to extracting the Unix domain socket handling found in the **NewClient(\*Config)** function into its own function, **ParseAddress(string, \*Config)**.  In doing so, it became apparent that if a **Client** is originally created using a TCP based address but then the SetAddress is used to change to a Unix domain socket, the DialContext function in the **HttpClient.Transport** won't be updated as it is in the **NewClient(\*Config)** function.

The current state of this PR has the **SetAddress(string)** function also using this function, however, in order to support changing from a Unix domain socket back to a TCP based address, the best that can be done is setting the DialContext function the same way that the **cleanhttp.DefaultPooledTransport()** function does.

This has one unit test failing, because of a panic.  But before looking at addressing that, I like some feedback as to whether this is worthwhile or if I'm just going down a rabbit hole.