### PR TITLE
Bug Fix: max versions not saving on KV 2

### DIFF
--- a/changelog/11908.txt
+++ b/changelog/11908.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: max_versions was not being saved on create kv-2 secret.
+```

--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -232,13 +232,13 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
       secretData.set(secretData.pathAttr, key);
     }
 
+    let successKey = key;
     if (this.mode === 'create') {
-      key = JSON.stringify({
+      successKey = JSON.stringify({
         backend: secret.backend,
         id: key,
       });
     }
-
     return secretData
       .save()
       .then(() => {
@@ -251,13 +251,13 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
             secret
               .save()
               .then(() => {
-                this.saveComplete(successCallback, key);
+                this.saveComplete(successCallback, successKey);
               })
               .catch(e => {
                 this.set(e, e.errors.join(' '));
               });
           } else {
-            this.saveComplete(successCallback, key);
+            this.saveComplete(successCallback, successKey);
           }
         }
       })

--- a/ui/app/serializers/secret-v2.js
+++ b/ui/app/serializers/secret-v2.js
@@ -42,7 +42,9 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     payload.data.id = payload.id;
     return requestType === 'queryRecord' ? payload.data : [payload.data];
   },
-  serializeHasMany() {
-    return;
+  serializeHasMany(snapshot, json, relationship) {
+    let newJson = { ...json };
+    delete newJson.casRequired;
+    this._super(snapshot, newJson, relationship);
   },
 });

--- a/ui/app/serializers/secret-v2.js
+++ b/ui/app/serializers/secret-v2.js
@@ -42,9 +42,7 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     payload.data.id = payload.id;
     return requestType === 'queryRecord' ? payload.data : [payload.data];
   },
-  serializeHasMany(snapshot, json, relationship) {
-    let newJson = { ...json };
-    delete newJson.casRequired;
-    this._super(snapshot, newJson, relationship);
+  serializeHasMany() {
+    return;
   },
 });

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -65,7 +65,6 @@ module('Acceptance | secrets/secret/create', function(hooks) {
   });
 
   test('it can create a secret with a non default max version', async function(assert) {
-    // addressing bug where max version looked like it was saving but it wasn't
     let enginePath = `kv-${new Date().getTime()}`;
     let secretPath = 'maxVersions';
     let maxVersions = 101;

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -64,6 +64,30 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     assert.ok(showPage.editIsPresent, 'shows the edit button');
   });
 
+  test('it can create a secret with a non default max version', async function(assert) {
+    // addressing bug where max version looked like it was saving but it wasn't
+    let enginePath = `kv-${new Date().getTime()}`;
+    let secretPath = 'maxVersions';
+    let maxVersions = 101;
+    await mountSecrets.visit();
+    await mountSecrets.enable('kv', enginePath);
+    await click('[data-test-secret-create="true"]');
+    await fillIn('[data-test-secret-path="true"]', secretPath);
+    await fillIn('[data-test-input="maxVersions"]', maxVersions);
+    await fillIn('[data-test-secret-key]', 'key');
+    await click('[data-test-secret-save]');
+    await settled();
+    await click('[data-test-secret-edit="true"]');
+    await settled();
+
+    let savedMaxVersions = document.querySelector('[data-test-input="maxVersions"]').value;
+    assert.equal(
+      maxVersions,
+      savedMaxVersions,
+      'max_version displays the saved number set when creating the secret'
+    );
+  });
+
   test('it disables save when validation errors occur', async function(assert) {
     let enginePath = `kv-${new Date().getTime()}`;
     await mountSecrets.visit();


### PR DESCRIPTION
This PR fixes a regression bug where the max_versions on the metadata endpoint was not being saved.  I added test coverage for max_versions because this is an easy one to miss.

TODO:
- Confirm doesn't break the earlier fix where the regression occurred.