### PR TITLE
docs: corrects JSON and issuer for identity tokens

### DIFF
--- a/website/content/api-docs/secret/identity/tokens.mdx
+++ b/website/content/api-docs/secret/identity/tokens.mdx
@@ -16,7 +16,7 @@ This endpoint updates configurations for OIDC-compliant identity tokens issued b
 
 ### Parameters
 
-- `issuer` `(string: "")` – Issuer URL to be used in the iss claim of the token. If not set, Vault's api_addr will be used. The issuer is a case sensitive URL using the https scheme that contains scheme, host, and optionally, port number and path components, but no query or fragment components.
+- `issuer` `(string: "")` – Issuer URL to be used in the iss claim of the token. If not set, Vault's api_addr will be used. The issuer is a case sensitive URL using the https scheme that contains scheme, host, and an optional port number.
 
 ### Sample Payload
 

--- a/website/content/docs/secrets/identity.mdx
+++ b/website/content/docs/secrets/identity.mdx
@@ -217,7 +217,7 @@ Identity tokens will always contain, at a minimum, the claims required by OIDC:
 - `iss` - Issuer URL
 - `sub` - Requester's entity ID
 - `aud` - `client_id` for the role
-- `iss` - Time of issue
+- `iat` - Time of issue
 - `exp` - Expiration time for the token
 
 In addition, the operator may configure per-role templates that allow a variety
@@ -233,8 +233,8 @@ For example:
   "userinfo": {
      "username": {{identity.entity.aliases.usermap_123.metadata.username}},
      "groups": {{identity.entity.group_names}}
-
-  "nbf": {{time.now}},
+  },
+  "nbf": {{time.now}}
 }
 ```
 
@@ -246,8 +246,8 @@ When a token is requested, the resulting template might be populated as:
   "userinfo": {
      "username": "bob",
      "groups": ["web", "engr", "default"]
-
-  "nbf": 1561411915,
+  },
+  "nbf": 1561411915
 }
 ```
 
@@ -258,7 +258,7 @@ which would be merged with the base OIDC claims into the final token:
   "iss": "https://10.1.1.45:8200/v1/identity/oidc",
   "sub": "a2cd63d3-5364-406f-980e-8d71bb0692f5",
   "aud": "SxSouteCYPBoaTFy94hFghmekos",
-  "iss": 1561411915,
+  "iat": 1561411915,
   "exp": 1561412215,
   "color": "green",
   "userinfo": {


### PR DESCRIPTION
This PR fixes the following parts of the identity token documentation:
- `issuer` parameter description is incorrect in stating that a path can be included. See [identity_store_oidc.go#L355-L359](https://github.com/hashicorp/vault/blob/main/vault/identity_store_oidc.go#L355-L359) for actual validation.
- `iss` incorrectly used in a couple of places where `iat` should be used.
- malformed JSON in both template and rendered template output