### PR TITLE
Docs: Add link to more sentinel examples

### DIFF
--- a/website/content/docs/enterprise/sentinel/examples.mdx
+++ b/website/content/docs/enterprise/sentinel/examples.mdx
@@ -10,6 +10,8 @@ Following are some examples that help to introduce concepts. If you are
 unfamiliar with writing Sentinel policies in Vault, please read through to
 understand some best practices.
 
+Additional examples can be found [here](https://github.com/hashicorp/vault-guides/tree/master/governance).
+
 ## MFA and CIDR Check on Login
 
 The following Sentinel policy requires the incoming user to successfully


### PR DESCRIPTION
Making more detailed examples easier to find. 