### PR TITLE
agent/template: add static_secret_render_interval configurable

### DIFF
--- a/changelog/11934.txt
+++ b/changelog/11934.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent/template: Added default_lease_duration to specify how often to fetch non-leased secrets
+```

--- a/changelog/11934.txt
+++ b/changelog/11934.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-agent/template: Added default_lease_duration to specify how often to fetch non-leased secrets
+agent/template: Added static_secret_render_interval to specify how often to fetch non-leased secrets
 ```

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -119,7 +119,9 @@ type Sink struct {
 
 // TemplateConfig defines global behaviors around template
 type TemplateConfig struct {
-	ExitOnRetryFailure bool `hcl:"exit_on_retry_failure"`
+	ExitOnRetryFailure      bool          `hcl:"exit_on_retry_failure"`
+	DefaultLeaseDurationRaw interface{}   `hcl:"default_lease_duration"`
+	DefaultLeaseDuration    time.Duration `hcl:"-"`
 }
 
 func NewConfig() *Config {
@@ -584,6 +586,14 @@ func parseTemplateConfig(result *Config, list *ast.ObjectList) error {
 	}
 
 	result.TemplateConfig = &cfg
+
+	if result.TemplateConfig.DefaultLeaseDurationRaw != nil {
+		var err error
+		if result.TemplateConfig.DefaultLeaseDuration, err = parseutil.ParseDurationSecond(result.TemplateConfig.DefaultLeaseDurationRaw); err != nil {
+			return err
+		}
+		result.TemplateConfig.DefaultLeaseDurationRaw = nil
+	}
 
 	return nil
 }

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -119,9 +119,9 @@ type Sink struct {
 
 // TemplateConfig defines global behaviors around template
 type TemplateConfig struct {
-	ExitOnRetryFailure      bool          `hcl:"exit_on_retry_failure"`
-	DefaultLeaseDurationRaw interface{}   `hcl:"default_lease_duration"`
-	DefaultLeaseDuration    time.Duration `hcl:"-"`
+	ExitOnRetryFailure       bool          `hcl:"exit_on_retry_failure"`
+	StaticSecretRenderIntRaw interface{}   `hcl:"static_secret_render_interval"`
+	StaticSecretRenderInt    time.Duration `hcl:"-"`
 }
 
 func NewConfig() *Config {
@@ -587,12 +587,12 @@ func parseTemplateConfig(result *Config, list *ast.ObjectList) error {
 
 	result.TemplateConfig = &cfg
 
-	if result.TemplateConfig.DefaultLeaseDurationRaw != nil {
+	if result.TemplateConfig.StaticSecretRenderIntRaw != nil {
 		var err error
-		if result.TemplateConfig.DefaultLeaseDuration, err = parseutil.ParseDurationSecond(result.TemplateConfig.DefaultLeaseDurationRaw); err != nil {
+		if result.TemplateConfig.StaticSecretRenderInt, err = parseutil.ParseDurationSecond(result.TemplateConfig.StaticSecretRenderIntRaw); err != nil {
 			return err
 		}
-		result.TemplateConfig.DefaultLeaseDurationRaw = nil
+		result.TemplateConfig.StaticSecretRenderIntRaw = nil
 	}
 
 	return nil

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -544,7 +544,8 @@ func TestLoadConfigFile_TemplateConfig(t *testing.T) {
 		"set-true": {
 			"./test-fixtures/config-template_config.hcl",
 			TemplateConfig{
-				ExitOnRetryFailure: true,
+				ExitOnRetryFailure:   true,
+				DefaultLeaseDuration: 1 * time.Minute,
 			},
 		},
 		"empty": {

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -544,8 +544,8 @@ func TestLoadConfigFile_TemplateConfig(t *testing.T) {
 		"set-true": {
 			"./test-fixtures/config-template_config.hcl",
 			TemplateConfig{
-				ExitOnRetryFailure:   true,
-				DefaultLeaseDuration: 1 * time.Minute,
+				ExitOnRetryFailure:    true,
+				StaticSecretRenderInt: 1 * time.Minute,
 			},
 		},
 		"empty": {

--- a/command/agent/config/test-fixtures/config-template_config.hcl
+++ b/command/agent/config/test-fixtures/config-template_config.hcl
@@ -7,6 +7,7 @@ vault {
 
 template_config {
   exit_on_retry_failure = true
+  default_lease_duration = 60
 }
 
 template {

--- a/command/agent/config/test-fixtures/config-template_config.hcl
+++ b/command/agent/config/test-fixtures/config-template_config.hcl
@@ -7,7 +7,7 @@ vault {
 
 template_config {
   exit_on_retry_failure = true
-  default_lease_duration = 60
+  static_secret_render_interval = 60
 }
 
 template {

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -240,6 +240,10 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		conf.Vault.Namespace = &sc.Namespace
 	}
 
+	if sc.AgentConfig.TemplateConfig.DefaultLeaseDuration != 0 {
+		conf.Vault.DefaultLeaseDuration = &sc.AgentConfig.TemplateConfig.DefaultLeaseDuration
+	}
+
 	conf.Vault.SSL = &ctconfig.SSLConfig{
 		Enabled:    pointerutil.BoolPtr(false),
 		Verify:     pointerutil.BoolPtr(false),

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -240,7 +240,7 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		conf.Vault.Namespace = &sc.Namespace
 	}
 
-	if sc.AgentConfig.TemplateConfig.DefaultLeaseDuration != 0 {
+	if sc.AgentConfig.TemplateConfig != nil && sc.AgentConfig.TemplateConfig.DefaultLeaseDuration != 0 {
 		conf.Vault.DefaultLeaseDuration = &sc.AgentConfig.TemplateConfig.DefaultLeaseDuration
 	}
 

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -240,8 +240,8 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 		conf.Vault.Namespace = &sc.Namespace
 	}
 
-	if sc.AgentConfig.TemplateConfig != nil && sc.AgentConfig.TemplateConfig.DefaultLeaseDuration != 0 {
-		conf.Vault.DefaultLeaseDuration = &sc.AgentConfig.TemplateConfig.DefaultLeaseDuration
+	if sc.AgentConfig.TemplateConfig != nil && sc.AgentConfig.TemplateConfig.StaticSecretRenderInt != 0 {
+		conf.Vault.StaticSecretRenderInt = &sc.AgentConfig.TemplateConfig.StaticSecretRenderInt
 	}
 
 	conf.Vault.SSL = &ctconfig.SSLConfig{

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -241,7 +241,7 @@ func newRunnerConfig(sc *ServerConfig, templates ctconfig.TemplateConfigs) (*ctc
 	}
 
 	if sc.AgentConfig.TemplateConfig != nil && sc.AgentConfig.TemplateConfig.StaticSecretRenderInt != 0 {
-		conf.Vault.StaticSecretRenderInt = &sc.AgentConfig.TemplateConfig.StaticSecretRenderInt
+		conf.Vault.DefaultLeaseDuration = &sc.AgentConfig.TemplateConfig.StaticSecretRenderInt
 	}
 
 	conf.Vault.SSL = &ctconfig.SSLConfig{

--- a/go.sum
+++ b/go.sum
@@ -113,7 +113,6 @@ github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
-github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -517,7 +516,6 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -744,7 +742,6 @@ github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQ
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -882,8 +879,6 @@ github.com/miekg/dns v1.1.40 h1:pyyPFfGMnciYUk/mXpKkVmeMQjfXqt3FAJ2hy7tPiLA=
 github.com/miekg/dns v1.1.40/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
-github.com/mitchellh/cli v1.1.1 h1:J64v/xD7Clql+JVKSvkYojLOXu1ibnY9ZjGLwSt/89w=
-github.com/mitchellh/cli v1.1.1/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/cli v1.1.2 h1:PvH+lL2B7IQ101xQL63Of8yFS2y+aDlsFcsqNc+u/Kw=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/website/content/docs/agent/template-config.mdx
+++ b/website/content/docs/agent/template-config.mdx
@@ -52,3 +52,8 @@ The top level `template_config` block has the following configuration entries:
 - `exit_on_retry_failure` `(bool: false)` - This option configures Vault Agent
 to exit after it has exhausted its number of template retry attempts due to
 failures.
+
+`default_lease_duration` `(string or integer: 5m)` - If specified, configures
+  how often Vault Agent Template should fetch non-leased secrets such as KV v2.
+  This setting will not change how often Vault Agent Templating renders leased
+  secrets.

--- a/website/content/docs/agent/template-config.mdx
+++ b/website/content/docs/agent/template-config.mdx
@@ -53,7 +53,7 @@ The top level `template_config` block has the following configuration entries:
 to exit after it has exhausted its number of template retry attempts due to
 failures.
 
-`static_secret_render_interval` `(string or integer: 5m)` - If specified, configures
+- `static_secret_render_interval` `(string or integer: 5m)` - If specified, configures
   how often Vault Agent Template should render non-leased secrets such as KV v2.
   This setting will not change how often Vault Agent Templating renders leased
   secrets.

--- a/website/content/docs/agent/template-config.mdx
+++ b/website/content/docs/agent/template-config.mdx
@@ -53,7 +53,7 @@ The top level `template_config` block has the following configuration entries:
 to exit after it has exhausted its number of template retry attempts due to
 failures.
 
-`static_secret_refresh_interval` `(string or integer: 5m)` - If specified, configures
-  how often Vault Agent Template should fetch non-leased secrets such as KV v2.
+`static_secret_render_interval` `(string or integer: 5m)` - If specified, configures
+  how often Vault Agent Template should render non-leased secrets such as KV v2.
   This setting will not change how often Vault Agent Templating renders leased
   secrets.

--- a/website/content/docs/agent/template-config.mdx
+++ b/website/content/docs/agent/template-config.mdx
@@ -53,7 +53,7 @@ The top level `template_config` block has the following configuration entries:
 to exit after it has exhausted its number of template retry attempts due to
 failures.
 
-`default_lease_duration` `(string or integer: 5m)` - If specified, configures
+`static_secret_refresh_interval` `(string or integer: 5m)` - If specified, configures
   how often Vault Agent Template should fetch non-leased secrets such as KV v2.
   This setting will not change how often Vault Agent Templating renders leased
   secrets.


### PR DESCRIPTION
[Consul Template recently added a feature](https://github.com/hashicorp/consul-template/commit/dc2df7fda88f8bc6b54e73de038d4cb4a8e07a98) to allow operators to override the default lease duration when a secret has no lease/isn't renewable. This default (5m) can be now altered using the following agent config:

```hcl
template_config {
    static_secret_render_interval = 60
}
```

We'll need to add this configurable to both Vault K8s and Vault Helm.