### PR TITLE
website: upgrade react-head

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2149,9 +2149,9 @@
       }
     },
     "@hashicorp/react-head": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.0.2.tgz",
-      "integrity": "sha512-kKY/5XwWkBsDSvF8jHgNnxG4hx8ryPjoEtPFxPMVCly/ouwbslilIrWzqSYbeP7vUO686JzBLf5xkwq+HV0aig=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.1.0.tgz",
+      "integrity": "sha512-tXfxi9Aqhx83p6wt753WfiYUhOEMzrsWKON200zsNFdwN2WkHPwArWbR6+ludVXleEmsBufL8GRYq7iqnnKKlQ=="
     },
     "@hashicorp/react-hero": {
       "version": "7.3.0",

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "@hashicorp/react-docs-page": "13.4.0",
     "@hashicorp/react-featured-slider": "4.1.0",
     "@hashicorp/react-hashi-stack-menu": "2.0.4",
-    "@hashicorp/react-head": "3.0.2",
+    "@hashicorp/react-head": "3.1.0",
     "@hashicorp/react-hero": "7.3.0",
     "@hashicorp/react-image": "4.0.1",
     "@hashicorp/react-inline-svg": "6.0.1",


### PR DESCRIPTION
[Preview](https://vault-hj8gbpsgt-hashicorp.vercel.app/)

Upgrading `react-head` and dependencies to set the new Safari theme-color feature.

[_Created by Sourcegraph campaign `kstraut/upgrade-react-head`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/upgrade-react-head)

**Before**
<img width="1265" alt="Screen Shot 2021-06-25 at 8 24 51 AM" src="https://user-images.githubusercontent.com/36613477/123447844-26078a00-d58f-11eb-82f4-879b54c9b231.png">

**After**
<img width="1261" alt="Screen Shot 2021-06-25 at 8 24 57 AM" src="https://user-images.githubusercontent.com/36613477/123447859-27d14d80-d58f-11eb-8051-c8cd6b150f36.png">
