### PR TITLE
Add UI feature allowing credential rotation for static DB roles

### DIFF
--- a/ui/app/adapters/database/credential.js
+++ b/ui/app/adapters/database/credential.js
@@ -11,7 +11,15 @@ export default ApplicationAdapter.extend({
       'GET'
     );
   },
+
   queryRecord(store, type, query) {
     return this.fetchByQuery(store, query);
+  },
+
+  rotateRoleCredentials(backend, id) {
+    return this.ajax(
+      `${this.buildURL()}/${encodeURIComponent(backend)}/rotate-role/${encodeURIComponent(id)}`,
+      'POST'
+    );
   },
 });

--- a/ui/app/components/secret-list/database-list-item.js
+++ b/ui/app/components/secret-list/database-list-item.js
@@ -58,4 +58,17 @@ export default class DatabaseListItem extends Component {
         this.flashMessages.danger(e.errors);
       });
   }
+  @action
+  rotateRoleCred(id) {
+    const { backend } = this.args.item;
+    let adapter = this.store.adapterFor('database/credential');
+    adapter
+      .rotateRoleCredentials(backend, id)
+      .then(() => {
+        this.flashMessages.success(`Success: Credentials for ${id} role were rotated`);
+      })
+      .catch(e => {
+        this.flashMessages.danger(e.errors);
+      });
+  }
 }

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -130,4 +130,6 @@ export default Model.extend({
   canGenerateCredentials: alias('credentialPath.canRead'),
   databasePath: lazyCapabilities(apiPath`${'backend'}/config/${'database[0]'}`, 'backend', 'database'),
   canUpdateDb: alias('databasePath.canUpdate'),
+  rotateRolePath: lazyCapabilities(apiPath`${'backend'}/rotate-role/+`, 'backend'),
+  canRotateRoleCredentials: alias('rotateRolePath.canUpdate'),
 });

--- a/ui/app/templates/components/secret-list/database-list-item.hbs
+++ b/ui/app/templates/components/secret-list/database-list-item.hbs
@@ -57,7 +57,7 @@
                 </LinkTo>
               </li>
             {{/if}}
-            {{#if @item.canRotateRoleCredentials}}
+            {{#if (and @item.canRotateRoleCredentials (eq this.keyTypeValue 'static'))}}
               <li class="action">
                 <button type="button" class="link" {{on "click" (fn this.rotateRoleCred @item.id)}}>
                   Rotate credentials

--- a/ui/app/templates/components/secret-list/database-list-item.hbs
+++ b/ui/app/templates/components/secret-list/database-list-item.hbs
@@ -57,6 +57,13 @@
                 </LinkTo>
               </li>
             {{/if}}
+            {{#if @item.canRotateRoleCredentials}}
+              <li class="action">
+                <button type="button" class="link" {{on "click" (fn this.rotateRoleCred @item.id)}}>
+                  Rotate credentials
+                </button>
+              </li>
+            {{/if}}
             {{#if @item.canRotateRoot}}
               <li class="action">
                 <button type="button" class="link" {{on "click" (fn this.rotateRootCred @item.id)}}>


### PR DESCRIPTION
This UI feature is the CLI equivalent of `vault write -f database/rotate-role/<role name>`.

I set it up to work almost the same way as the "Rotate root credentials" functionality works in the UI already for a database connection.