### PR TITLE
fix dropped errors in external_tests

### DIFF
--- a/vault/external_tests/identity/identity_test.go
+++ b/vault/external_tests/identity/identity_test.go
@@ -80,6 +80,7 @@ func TestIdentityStore_ExternalGroupMemberships_DifferentMounts(t *testing.T) {
 			"canonical_id":   groupID,
 			"mount_accessor": accessor,
 		})
+		require.NoError(t, err)
 
 		// Create a user in Vault
 		_, err = client.Logical().Write("auth/"+path+"/users/hermes conrad", map[string]interface{}{
@@ -129,6 +130,7 @@ func TestIdentityStore_ExternalGroupMemberships_DifferentMounts(t *testing.T) {
 	secret, err = client.Logical().Write("auth/ldap/login/hermes conrad", map[string]interface{}{
 		"password": "hermes",
 	})
+	require.NoError(t, err)
 
 	secret, err = client.Logical().Read("identity/group/id/" + groupID1)
 	require.NoError(t, err)

--- a/vault/external_tests/token/token_test.go
+++ b/vault/external_tests/token/token_test.go
@@ -585,6 +585,9 @@ func TestTokenStore_RevocationOnStartup(t *testing.T) {
 	// Fake times in the past
 	for _, lease := range leases {
 		secret, err = client.Logical().Read(leasePath + lease.(string))
+		if err != nil {
+			t.Fatal(err)
+		}
 		var entry leaseEntry
 		if err := jsonutil.DecodeJSON([]byte(secret.Data["value"].(string)), &entry); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This fixes three dropped `err` variables under `vault/external_tests`.