### PR TITLE
Update ElasticSearch DB plugin to v0.8.0

### DIFF
--- a/changelog/11957.txt
+++ b/changelog/11957.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+secrets/database/elasticsearch: Add ability to customize dynamic usernames
+```

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.9.0
 	github.com/hashicorp/vault-plugin-auth-oci v0.7.0
 	github.com/hashicorp/vault-plugin-database-couchbase v0.3.0
-	github.com/hashicorp/vault-plugin-database-elasticsearch v0.7.0
+	github.com/hashicorp/vault-plugin-database-elasticsearch v0.8.0
 	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.3.0
 	github.com/hashicorp/vault-plugin-database-snowflake v0.1.1
 	github.com/hashicorp/vault-plugin-mock v0.16.1
@@ -105,7 +105,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.4.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.1.0
 	github.com/hashicorp/vault/api v1.0.5-0.20210210214158-405eced08457
-	github.com/hashicorp/vault/sdk v0.1.14-0.20210505171055-299f311fa707
+	github.com/hashicorp/vault/sdk v0.2.0
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4
 	github.com/jcmturner/gokrb5/v8 v8.0.0
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f

--- a/go.sum
+++ b/go.sum
@@ -703,8 +703,8 @@ github.com/hashicorp/vault-plugin-auth-oci v0.7.0 h1:saDgrjPcGbZ3ts2mZ/Cpf3PKaRP
 github.com/hashicorp/vault-plugin-auth-oci v0.7.0/go.mod h1:Cn5cjR279Y+snw8LTaiLTko3KGrbigRbsQPOd2D5xDw=
 github.com/hashicorp/vault-plugin-database-couchbase v0.3.0 h1:C3Lfwr7xtdhOTnOf+UgFZWDyBwTGqk0BuzG2GhNHD6k=
 github.com/hashicorp/vault-plugin-database-couchbase v0.3.0/go.mod h1:Seivjno/BOtkqX41d/DDYtTg6zNoxIgNaUVZ3ObZYi4=
-github.com/hashicorp/vault-plugin-database-elasticsearch v0.7.0 h1:EYicFs5dl4Ax1uQMw+EfbCCrarScVrqdGS471KKXDDo=
-github.com/hashicorp/vault-plugin-database-elasticsearch v0.7.0/go.mod h1:813Nvr1IQqAKdlk3yIY97M5WyxMhWOrXtYioPf9PqJg=
+github.com/hashicorp/vault-plugin-database-elasticsearch v0.8.0 h1:c9/fwjJf9XjXSM8WzCKL2fco4jyAudUSM9QIY4hY+5M=
+github.com/hashicorp/vault-plugin-database-elasticsearch v0.8.0/go.mod h1:QiQnpM6tI8LqIO+XfI/5AddV7d9cT1DhhOekLV2+AKY=
 github.com/hashicorp/vault-plugin-database-mongodbatlas v0.3.0 h1:qSTM0f71zhyYILdw2HiVw5zUumC+5QeI0F2vzDJvcUY=
 github.com/hashicorp/vault-plugin-database-mongodbatlas v0.3.0/go.mod h1:ewrdsH4iFG5TGZu7euYf4BCzLl+hoFkaKaOGuF0UcjI=
 github.com/hashicorp/vault-plugin-database-snowflake v0.1.1 h1:QKNjvd1GuI69u7ZLNTnvZ2LoBg9ENX7C/U+sgH40QBU=

--- a/website/content/api-docs/secret/databases/elasticdb.mdx
+++ b/website/content/api-docs/secret/databases/elasticdb.mdx
@@ -33,6 +33,7 @@ has a number of parameters to further configure a connection.
 - `client_key` `(string: "")` - The path to the key for the Elasticsearch client to use for communication.
 - `tls_server_name` `(string: "")` - This, if set, is used to set the SNI host when connecting via 1TLS.
 - `insecure` `(bool: false)` - Not recommended. Default to false. Can be set to true to disable SSL verification.
+- `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how dynamic usernames are generated.
 
 ### Sample Payload
 


### PR DESCRIPTION
## Description
Update go.mod to use the newest version of the Vault ElasticSearch DB plugin which adds the ability to customize username generation for dynamic users in ElasticSearch DB.

## Related issues
- Plugin update PR: https://github.com/hashicorp/vault-plugin-database-elasticsearch/pull/28