### PR TITLE
Add AWS Cognito secrets engine to the plugins website page

### DIFF
--- a/website/content/docs/plugin-portal.mdx
+++ b/website/content/docs/plugin-portal.mdx
@@ -127,6 +127,7 @@ Plugin authors who wish to have their plugins listed may file a submission via a
 
 ### Secrets
 
+- [AWS Cognito](https://github.com/WealthWizardsEngineering/vault-plugin-secrets-cognito)
 - [Ethereum](https://github.com/immutability-io/vault-ethereum)
 - [GitHub](https://github.com/martinbaillie/vault-plugin-secrets-github)
 - [HSM PKI Plugin](https://github.com/mode51software/vaultplugin-hsmpki)


### PR DESCRIPTION
Please consider adding this new plugin to the Vault website.

Any feedback on the plugin is welcome.

Thanks.