### PR TITLE
[VAULT-708] Zero out request counter on preSeal

### DIFF
--- a/changelog/11970.txt
+++ b/changelog/11970.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed double counting of http requests after operator stepdown
+```

--- a/vault/core.go
+++ b/vault/core.go
@@ -2184,6 +2184,9 @@ func (c *Core) preSeal() error {
 		result = multierror.Append(result, fmt.Errorf("error unloading mounts: %w", err))
 	}
 
+	// Zeros out the requests counter to avoid sending all requests for the month on stepdown
+	// when this runs on the active node. Unseal does the complementary operation of loading
+	// the counter from storage, so this operation should be a safe one.
 	atomic.StoreUint64(c.counters.requests, 0)
 
 	if err := enterprisePreSeal(c); err != nil {

--- a/vault/core.go
+++ b/vault/core.go
@@ -2183,6 +2183,9 @@ func (c *Core) preSeal() error {
 	if err := c.unloadMounts(context.Background()); err != nil {
 		result = multierror.Append(result, fmt.Errorf("error unloading mounts: %w", err))
 	}
+
+	atomic.StoreUint64(c.counters.requests, 0)
+
 	if err := enterprisePreSeal(c); err != nil {
 		result = multierror.Append(result, err)
 	}


### PR DESCRIPTION
The issue that is currently happening, is that when the active node steps down and becomes a standby node, the first time it syncs its requests to the new active node, it sends the total count of requests that it holds in memory to it. Since it was the active node before, that value is the total requests across all nodes in the cluster for the current month. This causes the request counter on the new active node to effectively double, as the new active node also had loaded the same value during unseal from storage.

The fix implemented here, is to zero out the internal request counters during the preSeal function. This function is invoked as part of the step down operation of the active node, hence before the node resumes emitting metrics this will have happened, preventing the request counts from doubling on the new active node.

As this is being placed in the preSeal operation, this will be invoked even when the node is not changing from active to standby mode. However, that should be a safe operation to do, and while that may result in losing a few requests that should've been emitted to the active node ( or persisted to storage by the active node ), the request counter does not guarantee exactness so this should be a tolerable loss. The duration for which data might be lost is determined by https://github.com/hashicorp/vault/blob/main/vault/counters.go#L37, and defaults to 30 seconds. Also, there does not appear to be a better alternative than `preSeal` for adding this check, in this stepdown block https://github.com/hashicorp/vault/blob/main/vault/ha.go#L592-L639, but alternate suggestions are welcome!