### PR TITLE
builtin/credential/approle: fix dropped test errors

### DIFF
--- a/builtin/credential/approle/path_role_test.go
+++ b/builtin/credential/approle/path_role_test.go
@@ -209,6 +209,9 @@ func TestAppRole_LocalSecretIDImmutability(t *testing.T) {
 		Storage:   storage,
 		Data:      roleData,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if resp == nil || !resp.IsError() {
 		t.Fatalf("expected an error since local_secret_ids can't be overwritten")
 	}

--- a/builtin/credential/approle/path_tidy_user_id_test.go
+++ b/builtin/credential/approle/path_tidy_user_id_test.go
@@ -44,8 +44,11 @@ func TestAppRole_TidyDanglingAccessors_Normal(t *testing.T) {
 			SecretIDHMAC: "samplesecretidhmac",
 		},
 	)
-	err = storage.Put(context.Background(), entry1)
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := storage.Put(context.Background(), entry1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -55,8 +58,10 @@ func TestAppRole_TidyDanglingAccessors_Normal(t *testing.T) {
 			SecretIDHMAC: "samplesecretidhmac2",
 		},
 	)
-	err = storage.Put(context.Background(), entry2)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.Put(context.Background(), entry2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -138,8 +143,11 @@ func TestAppRole_TidyDanglingAccessors_RaceTest(t *testing.T) {
 				SecretIDHMAC: "samplesecretidhmac",
 			},
 		)
-		err = storage.Put(context.Background(), entry)
 		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := storage.Put(context.Background(), entry); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
This fixes several dropped test `err` variables in `builtin/credential/approle`.

Can this be labeled as not requiring a changelog?