### PR TITLE
docs: fix link rendering for Oracle

### DIFF
--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -72,9 +72,9 @@ you will need to enable ipc_lock capabilities for the plugin binary.
 If the version of Oracle you are using has a container database, you will need to connect to one of the
 pluggable databases rather than the container database in the `connection_url` field.
 
-1. It is highly recommended that you immediately rotate the "root" user's password. (see [Rotate Root Credentials]
-   (/api-docs/secret/databases#rotate-root-credentials)). This will ensure that only Vault is able to access
-   the "root" user that Vault uses to manipulate dynamic & static credentials.
+1. It is highly recommended that you immediately rotate the "root" user's password, see [Rotate Root Credentials]
+   (/api-docs/secret/databases#rotate-root-credentials) for more details. This will ensure that
+   only Vault is able to access the "root" user that Vault uses to manipulate dynamic & static credentials.
 
    !> **Use caution:** the root user's password will not be accessible once rotated so it is highly
    recommended that you create a user for Vault to utilize rather than using the actual root user.

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -72,9 +72,10 @@ you will need to enable ipc_lock capabilities for the plugin binary.
 If the version of Oracle you are using has a container database, you will need to connect to one of the
 pluggable databases rather than the container database in the `connection_url` field.
 
-1. It is highly recommended that you immediately rotate the "root" user's password, see [Rotate Root Credentials]
-   (/api-docs/secret/databases#rotate-root-credentials) for more details. This will ensure that
-   only Vault is able to access the "root" user that Vault uses to manipulate dynamic & static credentials.
+1. It is highly recommended that you immediately rotate the "root" user's password, see
+   [Rotate Root Credentials](/api-docs/secret/databases#rotate-root-credentials) for more details.
+   This will ensure that only Vault is able to access the "root" user that Vault uses to
+   manipulate dynamic & static credentials.
 
    !> **Use caution:** the root user's password will not be accessible once rotated so it is highly
    recommended that you create a user for Vault to utilize rather than using the actual root user.


### PR DESCRIPTION
The Oracle documentation is currently showing a link literal due to the wrapping `()`. I've removed them to hopefully fix the render.