### PR TITLE
UI: Exit test process if vault fails to initialize

### DIFF
--- a/ui/scripts/start-vault.js
+++ b/ui/scripts/start-vault.js
@@ -23,7 +23,7 @@ function run(command, args = [], shareStd = true) {
 }
 
 var output = '';
-var unseal, root, written;
+var unseal, root, written, initError;
 
 async function processLines(input, eachLine = () => {}) {
   const rl = readline.createInterface({
@@ -49,7 +49,6 @@ async function processLines(input, eachLine = () => {}) {
       ],
       false
     );
-
     processLines(vault.stdout, function(line) {
       if (written) {
         output = null;
@@ -64,6 +63,10 @@ async function processLines(input, eachLine = () => {}) {
       if (rootMatch && !root) {
         root = rootMatch[1];
       }
+      var errorMatch = output.match(/Error initializing core: (.*)$/m);
+      if (errorMatch) {
+        initError = errorMatch[1];
+      }
       if (root && unseal && !written) {
         fs.writeFile(
           path.join(process.cwd(), 'tests/helpers/vault-keys.js'),
@@ -74,6 +77,11 @@ async function processLines(input, eachLine = () => {}) {
         );
         written = true;
         console.log('VAULT SERVER READY');
+      } else if (initError) {
+        // If this is happening, run `export VAULT_LICENSE_PATH=/Users/username/license.hclic`
+        // to your valid local vault license filepath, or use OSS Vault
+        console.log('VAULT SERVER START FAILED');
+        process.exit(1);
       }
     });
     try {


### PR DESCRIPTION
This is a developer ease-of-life update which has the test script exit with an error code if Vault does not start up when the tests start running (for example, if the vault binary is enterprise but you don't have a license). This avoids UI tests falsely failing due to API calls failing. 