### PR TITLE
Update key icons in Transit secret engine

### DIFF
--- a/ui/app/templates/components/secret-list/item.hbs
+++ b/ui/app/templates/components/secret-list/item.hbs
@@ -16,9 +16,13 @@
         @mode={{if @item.isFolder "list" "show" }}
         @secret={{@item.id}}
         @queryParams={{if (eq @backendModel.type "transit") (query-params tab="actions") ""}}
-        @class="has-text-black has-text-weight-semibold"><Icon
-          @glyph={{if @item.isFolder 'folder-outline' 'file-outline' }}
-          @class="has-text-grey-light"/>{{if (eq @item.id ' ') '(self)' (or @item.keyWithoutParent @item.id)}}
+        @class="has-text-black has-text-weight-semibold">
+          {{#if (eq @backendModel.type "transit")}}
+            <Icon @glyph="key" @class="has-text-grey-light"/>
+          {{else}}
+            <Icon @glyph={{if @item.isFolder 'folder-outline' 'file-outline' }} @class="has-text-grey-light"/>
+          {{/if}}
+        {{if (eq @item.id ' ') '(self)' (or @item.keyWithoutParent @item.id)}}
       </SecretLink>
     </div>
     <div class="column has-text-right">


### PR DESCRIPTION
Former Transit icons:

![image](https://user-images.githubusercontent.com/68122737/124666035-51795700-de62-11eb-9a16-39264123f512.png)

Updated to key glyphs:
<img width="984" alt="Screen Shot 2021-07-06 at 1 59 41 PM" src="https://user-images.githubusercontent.com/68122737/124666122-6a820800-de62-11eb-9d25-c54260586f4b.png">

Still a folder or file outline, respectively, if not Transit:

<img width="996" alt="Screen Shot 2021-07-06 at 2 01 58 PM" src="https://user-images.githubusercontent.com/68122737/124666321-bcc32900-de62-11eb-8219-175388d6f358.png">

<img width="1001" alt="Screen Shot 2021-07-06 at 1 59 55 PM" src="https://user-images.githubusercontent.com/68122737/124666143-72da4300-de62-11eb-91d0-4e4bd36c76c3.png">

