### PR TITLE
docs: add SSL connection example to oracle

### DIFF
--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -69,6 +69,8 @@ you will need to enable ipc_lock capabilities for the plugin binary.
         password="myreallysecurepassword"
     ```
 
+If Oracle uses SSL, see the [connecting using SSL](/docs/secret/databases/oracle#connect-using-ssl) example.
+
 If the version of Oracle you are using has a container database, you will need to connect to one of the
 pluggable databases rather than the container database in the `connection_url` field.
 
@@ -101,6 +103,32 @@ pluggable databases rather than the container database in the `connection_url` f
    ```
 
    See the [Commands](/docs/commands#files) docs for more details.
+
+### Connect Using SSL
+
+If the Oracle server Vault is trying to connect to uses an SSL listener, the database
+plugin will require additional configuration using the `connection_url` parameter:
+
+```shell
+vault write database/config/oracle \
+  plugin_name=vault-plugin-database-oracle \
+  connection_url='{{ username }}/{{ password }}@tcps://<host>:port/<service_name>?param1=...&param2=...&...'\
+  allowed_roles="my-role" \
+  username="admin" \
+  password="password"
+```
+
+For example, the SSL server certificate distinguished name and path to the Oracle Wallet
+to use for connection and verification could be configured using:
+
+```shell
+vault write database/config/oracle \
+  plugin_name=vault-plugin-database-oracle \
+  connection_url='{{ username }}/{{ password }}@tcps://<host>:port/<service_name>?ssl_server_cert_dn="CN=hashicorp.com,OU=TestCA,O=HashiCorp=com"&wallet_location=/etc/oracle/wallets' \
+  allowed_roles="my-role" \
+  username="admin" \
+  password="password"
+```
 
 ## Usage
 

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -124,7 +124,7 @@ to use for connection and verification could be configured using:
 ```shell
 vault write database/config/oracle \
   plugin_name=vault-plugin-database-oracle \
-  connection_url='{{ username }}/{{ password }}@tcps://<host>:port/<service_name>?ssl_server_cert_dn="CN=hashicorp.com,OU=TestCA,O=HashiCorp=com"&wallet_location=/etc/oracle/wallets' \
+  connection_url='{{ username }}/{{ password }}@tcps://<host>:port/<service_name>?ssl_server_cert_dn="CN=hashicorp.com,OU=TestCA,O=HashiCorp=com"&wallet_location="/etc/oracle/wallets"' \
   allowed_roles="my-role" \
   username="admin" \
   password="password"

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -69,7 +69,7 @@ you will need to enable ipc_lock capabilities for the plugin binary.
         password="myreallysecurepassword"
     ```
 
-If Oracle uses SSL, see the [connecting using SSL](/docs/secret/databases/oracle#connect-using-ssl) example.
+If Oracle uses SSL, see the [connecting using SSL](/docs/secrets/databases/oracle#connect-using-ssl) example.
 
 If the version of Oracle you are using has a container database, you will need to connect to one of the
 pluggable databases rather than the container database in the `connection_url` field.


### PR DESCRIPTION
The Oracle documentation lacks an SSL example, so I've added additional notes about `connection_url` taking optional security parameters.