### PR TITLE
Reverting fix on KV 2 for duplicate paths

### DIFF
--- a/changelog/12008.txt
+++ b/changelog/12008.txt
@@ -1,0 +1,3 @@
+```release-note:bug-fix
+ui: Revert fix for PR [11423](https://github.com/hashicorp/vault/pull/11423).
+```

--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -248,13 +248,6 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
       secretData.set(secretData.pathAttr, key);
     }
 
-    if (this.mode === 'create') {
-      key = JSON.stringify({
-        backend: secret.backend,
-        id: key,
-      });
-    }
-
     return secretData
       .save()
       .then(() => {
@@ -376,14 +369,8 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
         return;
       }
 
-      this.persistKey(key => {
-        let secretKey;
-        try {
-          secretKey = JSON.parse(key).id;
-        } catch (error) {
-          secretKey = key;
-        }
-        this.transitionToRoute(SHOW_ROUTE, secretKey);
+      this.persistKey(() => {
+        this.transitionToRoute(SHOW_ROUTE, this.model.path || this.model.id);
       });
     },
 

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -64,6 +64,29 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     assert.ok(showPage.editIsPresent, 'shows the edit button');
   });
 
+  test('it can create a secret with a non default max version', async function(assert) {
+    let enginePath = `kv-${new Date().getTime()}`;
+    let secretPath = 'maxVersions';
+    let maxVersions = 101;
+    await mountSecrets.visit();
+    await mountSecrets.enable('kv', enginePath);
+    await click('[data-test-secret-create="true"]');
+    await fillIn('[data-test-secret-path="true"]', secretPath);
+    await fillIn('[data-test-input="maxVersions"]', maxVersions);
+    await fillIn('[data-test-secret-key]', 'key');
+    await click('[data-test-secret-save]');
+    await settled();
+    await click('[data-test-secret-edit="true"]');
+    await settled();
+
+    let savedMaxVersions = document.querySelector('[data-test-input="maxVersions"]').value;
+    assert.equal(
+      maxVersions,
+      savedMaxVersions,
+      'max_version displays the saved number set when creating the secret'
+    );
+  });
+
   test('it disables save when validation errors occur', async function(assert) {
     let enginePath = `kv-${new Date().getTime()}`;
     await mountSecrets.visit();


### PR DESCRIPTION
Reverting the changes for [this PR.](https://github.com/hashicorp/vault/pull/11423)

The TLDR; is that this change broke the saving on secret create for metadata, meaning max_versions was not saving.  The real fix is to make it so the secret-v2 model is not using the path name as the id, but to something unique between engines.  See this [draft PR](https://github.com/hashicorp/vault/pull/11955) as an attempt.  We tried, but ultimately determined that a rewrite of the engine is the better approach than hacking this fix as it broke so many other things.

Additionally, I added test coverage for max versions as this was the regression bug we didn't recognize and is hard to spot.