### PR TITLE
[VAULT-1836] Support kv-v1 generic mounts for vault.kv.secret.count metric

### DIFF
--- a/changelog/12020.txt
+++ b/changelog/12020.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/metrics: Add generic KV mount support for vault.kv.secret.count telemetry metric
+```

--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -323,7 +323,7 @@ func (c *Core) findKvMounts() []*kvMount {
 	}
 
 	for _, entry := range c.mounts.Entries {
-		if entry.Type == "kv" {
+		if entry.Type == "kv" || entry.Type == "generic" {
 			version, ok := entry.Options["version"]
 			if !ok {
 				version = "1"

--- a/vault/core_metrics_test.go
+++ b/vault/core_metrics_test.go
@@ -23,15 +23,17 @@ func TestCoreMetrics_KvSecretGauge(t *testing.T) {
 
 	testMounts := []struct {
 		Path          string
+		Type          string
 		Version       string
 		ExpectedCount int
 	}{
-		{"secret/", "2", 0},
-		{"secret1/", "1", 3},
-		{"secret2/", "1", 0},
-		{"secret3/", "2", 4},
-		{"prefix/secret3/", "2", 0},
-		{"prefix/secret4/", "2", 5},
+		{"secret/", "kv", "2", 0},
+		{"secret1/", "kv", "1", 3},
+		{"secret2/", "kv", "1", 0},
+		{"secret3/", "kv", "2", 4},
+		{"prefix/secret3/", "kv", "2", 0},
+		{"prefix/secret4/", "kv", "2", 5},
+		{"generic/", "generic", "1", 3},
 	}
 	ctx := namespace.RootContext(nil)
 
@@ -40,7 +42,7 @@ func TestCoreMetrics_KvSecretGauge(t *testing.T) {
 		me := &MountEntry{
 			Table:   mountTableType,
 			Path:    sanitizePath(tm.Path),
-			Type:    "kv",
+			Type:    tm.Type,
 			Options: map[string]string{"version": tm.Version},
 		}
 		err := core.mount(ctx, me)
@@ -53,6 +55,9 @@ func TestCoreMetrics_KvSecretGauge(t *testing.T) {
 		"secret1/a", // 3
 		"secret1/b",
 		"secret1/c/d",
+		"generic/a",
+		"generic/b",
+		"generic/c",
 	}
 	v2secrets := []string{
 		"secret3/data/a", // 4


### PR DESCRIPTION
KV mounts of type `generic` are not currently included in the `vault.kv.secret.count` telemetry metric. The gauge collector `kvSecretGaugeCollector` only includes mounts of type `kv` (see https://github.com/hashicorp/vault/blob/v1.6.2/vault/core_metrics.go#L253). The implemented fix is to accept mounts of either type `kv` or type `generic`.