### PR TITLE
secrets/gcp: update to v0.10.1 for static accounts

### DIFF
--- a/changelog/12023.txt
+++ b/changelog/12023.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+secrets/gcp: Adds ability to use existing service accounts for generation of service account keys and access tokens.
+```

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.8.0
 	github.com/hashicorp/vault-plugin-secrets-azure v0.9.1
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.9.0
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.10.1
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.8.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -717,8 +717,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.8.0 h1:dg1vrZl+XwGipfjet7M
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.8.0/go.mod h1:SSkKpSTOMnX84PfgYiWHgwVg+YMhxHNjo+YCJGNBoZk=
 github.com/hashicorp/vault-plugin-secrets-azure v0.9.1 h1:vZhWEafEedxLS7t906QSYFKT+jiNM6Mv6fDHxOX6O5I=
 github.com/hashicorp/vault-plugin-secrets-azure v0.9.1/go.mod h1:4jCVjTG809NCQ8mrSnbBtX17gX1Iush+558BVO6MJeo=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.9.0 h1:gfaTe+QNNk+wZLec0k9pUt2VSBKPB237F/Dh0a1u8ic=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.9.0/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.10.1 h1:04M7fG2SIyZqIpazX2fLg/wpoprZXMlGAISWVl3o550=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.10.1/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.8.0 h1:yoMAcYkdvuo0LMiPaD4OCNRO8ekkYVMhSo+GswZrgb4=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.8.0/go.mod h1:hhwps56f2ATeC4Smgghrc5JH9dXR31b4ehSf1HblP5Q=
 github.com/hashicorp/vault-plugin-secrets-kv v0.9.0 h1:nCw2IfWw2bWUGFZsNk8BvTEg9k7jDpRn48+VAqjdQ3s=


### PR DESCRIPTION
Updates the GCP secrets plugin to `v0.10.1` to bring in the static accounts feature from https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/107.

The following steps were taken:
- `go get github.com/hashicorp/vault-plugin-secrets-gcp@release/vault-1.8.x`
- `go mod tidy`