### PR TITLE
[VAULT-2776] Add prefix_filter option to Vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ Vagrantfile
 # Configs
 *.hcl
 !command/agent/config/test-fixtures/*.hcl
-!command/server/test-fixtures/*/*.hcl
+!command/server/test-fixtures/**/*.hcl
 
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ Vagrantfile
 # Configs
 *.hcl
 !command/agent/config/test-fixtures/*.hcl
-!command/server/test-fixtures/*.hcl
+!command/server/test-fixtures/*/*.hcl
 
 
 .DS_Store

--- a/changelog/12025.txt
+++ b/changelog/12025.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Add `prefix_filter` to telemetry config
+```

--- a/command/server/config_telemetry_test.go
+++ b/command/server/config_telemetry_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricFilterConfigs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		configFile            string
+		expectedFilterDefault *bool
+		expectedPrefixFilter  []string
+	}{
+		{
+			"./test-fixtures/telemetry/valid_prefix_filter.hcl",
+			nil,
+			[]string{"-vault.expire", "-vault.audit", "+vault.expire.num_irrevocable_leases"},
+		},
+		{
+			"./test-fixtures/telemetry/filter_default_override.hcl",
+			boolPointer(false),
+			[]string(nil),
+		},
+	}
+	t.Run("validate metric filter configs", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range cases {
+			config, err := LoadConfigFile(tc.configFile)
+
+			if err != nil {
+				t.Fatalf("Error encountered when loading config %+v", err)
+			}
+
+			assert.Equal(t, tc.expectedFilterDefault, config.SharedConfig.Telemetry.FilterDefault)
+			assert.Equal(t, tc.expectedPrefixFilter, config.SharedConfig.Telemetry.PrefixFilter)
+		}
+	})
+}

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -16,6 +16,10 @@ import (
 	"github.com/hashicorp/vault/internalshared/configutil"
 )
 
+func boolPointer(x bool) *bool {
+	return &x
+}
+
 func testConfigRaftRetryJoin(t *testing.T) {
 	config, err := LoadConfigFile("./test-fixtures/raft_retry_join.hcl")
 	if err != nil {

--- a/command/server/test-fixtures/telemetry/filter_default_override.hcl
+++ b/command/server/test-fixtures/telemetry/filter_default_override.hcl
@@ -1,0 +1,7 @@
+disable_mlock = true
+ui            = true
+
+telemetry {
+  statsd_address = "foo"
+  filter_default = false
+}

--- a/command/server/test-fixtures/telemetry/valid_prefix_filter.hcl
+++ b/command/server/test-fixtures/telemetry/valid_prefix_filter.hcl
@@ -1,0 +1,7 @@
+disable_mlock = true
+ui            = true
+
+telemetry {
+  statsd_address = "foo"
+  prefix_filter = ["-vault.expire", "-vault.audit", "+vault.expire.num_irrevocable_leases"]
+}

--- a/internalshared/configutil/telemetry.go
+++ b/internalshared/configutil/telemetry.go
@@ -153,6 +153,10 @@ type Telemetry struct {
 	// Whether or not telemetry should add labels for namespaces
 	LeaseMetricsNameSpaceLabels bool `hcl:"add_lease_metrics_namespace_labels"`
 
+	// FilterDefault is the default for whether to allow a metric that's not
+	// covered by the prefix filter.
+	FilterDefault *bool `hcl:"filter_default"`
+
 	// PrefixFilter is a list of filter rules to apply for allowing
 	// or blocking metrics by prefix.
 	PrefixFilter []string `hcl:"prefix_filter"`
@@ -265,6 +269,9 @@ func SetupTelemetry(opts *SetupTelemetryOpts) (*metrics.InmemSink, *metricsutil.
 	metricsConf := metrics.DefaultConfig(opts.ServiceName)
 	metricsConf.EnableHostname = !opts.Config.DisableHostname
 	metricsConf.EnableHostnameLabel = opts.Config.EnableHostnameLabel
+	if opts.Config.FilterDefault != nil {
+		metricsConf.FilterDefault = *opts.Config.FilterDefault
+	}
 
 	// Configure the statsite sink
 	var fanout metrics.FanoutSink

--- a/internalshared/configutil/telemetry_test.go
+++ b/internalshared/configutil/telemetry_test.go
@@ -1,0 +1,19 @@
+package configutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePrefixFilters(t *testing.T) {
+	prefixFilters := []string{"", "+vault.abc", "-vault.abc", "vault.abc"}
+
+	allowedPrefixes, blockedPrefixes := parsePrefixFilter(prefixFilters)
+
+	assert.Equal(t, len(allowedPrefixes), 1)
+	assert.Equal(t, allowedPrefixes[0], prefixFilters[1][1:])
+
+	assert.Equal(t, len(blockedPrefixes), 1)
+	assert.Equal(t, blockedPrefixes[0], prefixFilters[2][1:])
+}

--- a/internalshared/configutil/telemetry_test.go
+++ b/internalshared/configutil/telemetry_test.go
@@ -43,6 +43,7 @@ func TestParsePrefixFilters(t *testing.T) {
 			if err != nil {
 				assert.EqualError(t, err, tc.expectedErrStr)
 			} else {
+				assert.Equal(t, "", tc.expectedErrStr)
 				assert.Equal(t, tc.expectedAllowedPrefixes, allowedPrefixes)
 
 				assert.Equal(t, tc.expectedBlockedPrefixes, blockedPrefixes)

--- a/website/content/docs/configuration/telemetry.mdx
+++ b/website/content/docs/configuration/telemetry.mdx
@@ -51,6 +51,17 @@ The following options are available on all telemetry configurations.
 - `add_lease_metrics_namespace_labels` `(bool: false)` - If this value is set to true, then `vault.expire.leases.by_expiration`
   will break down expiring leases by both time and namespace. This parameter is disabled by default because enabling it can lead
   to a large-cardinality metric.
+- `filter_default` - This controls whether to allow metrics that have not been specified by the filter.
+  Defaults to `true`, which will allow all metrics when no filters are provided.
+  When set to `false` with no filters, no metrics will be sent.
+- `prefix_filter` `(string array: [])` - This is a list of filter rules to apply for allowing/blocking metrics by
+  prefix in the following format:
+  ```json
+  ["+vault.token", "-vault.expire", "+vault.expire.num_leases"]
+  ```
+  A leading "**+**" will enable any metrics with the given prefix, and a leading "**-**" will block them. 
+  If there is overlap between two rules, the more specific rule will take precedence. Blocking will take priority if the same prefix is listed multiple times.
+
 
 ### `statsite`
 

--- a/website/content/docs/configuration/telemetry.mdx
+++ b/website/content/docs/configuration/telemetry.mdx
@@ -51,7 +51,7 @@ The following options are available on all telemetry configurations.
 - `add_lease_metrics_namespace_labels` `(bool: false)` - If this value is set to true, then `vault.expire.leases.by_expiration`
   will break down expiring leases by both time and namespace. This parameter is disabled by default because enabling it can lead
   to a large-cardinality metric.
-- `filter_default` - This controls whether to allow metrics that have not been specified by the filter.
+- `filter_default` `(bool: true)` - This controls whether to allow metrics that have not been specified by the filter.
   Defaults to `true`, which will allow all metrics when no filters are provided.
   When set to `false` with no filters, no metrics will be sent.
 - `prefix_filter` `(string array: [])` - This is a list of filter rules to apply for allowing/blocking metrics by


### PR DESCRIPTION
- Adds a `prefix_filter` option to the telemetry configs, that can explicitly allow or block certain metric prefixes.
- Adds a `filter_default` option to the telemetry configs, which is required in conjunction with the config above, to decide whether all metrics are allowed or denied by default. This is currently always true, but users may want to control this in their vault config along with `prefix_filter`.
- Updates documentation to cover both configs

Note that this attempts to maintain parity with this config in consul https://www.consul.io/docs/agent/options#telemetry-prefix_filter
Also, the logic for parsing the prefixFilter config is pretty much lifted from here https://github.com/hashicorp/consul/blob/main/agent/config/builder.go#L640-L654

Related GH issue: https://github.com/hashicorp/vault/issues/3792