### PR TITLE
[VAULT-1986] Cap AWS Token TTL based on Default Lease TTL

### DIFF
--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -892,9 +892,11 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 	defaultLeaseTTL := b.System().DefaultLeaseTTL()
 	systemMaxTTL := b.System().MaxLeaseTTL()
 	if roleEntry.TokenTTL > defaultLeaseTTL {
+		roleEntry.TokenTTL = defaultLeaseTTL
 		resp.AddWarning(fmt.Sprintf("Given ttl of %d seconds greater than current mount/system default of %d seconds; ttl will be capped at login time", roleEntry.TokenTTL/time.Second, defaultLeaseTTL/time.Second))
 	}
 	if roleEntry.TokenMaxTTL > systemMaxTTL {
+		roleEntry.TokenMaxTTL = systemMaxTTL
 		resp.AddWarning(fmt.Sprintf("Given max ttl of %d seconds greater than current mount/system default of %d seconds; max ttl will be capped at login time", roleEntry.TokenMaxTTL/time.Second, systemMaxTTL/time.Second))
 	}
 	if roleEntry.TokenMaxTTL != 0 && roleEntry.TokenMaxTTL < roleEntry.TokenTTL {

--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -893,11 +893,11 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 	systemMaxTTL := b.System().MaxLeaseTTL()
 	if roleEntry.TokenTTL > defaultLeaseTTL {
 		roleEntry.TokenTTL = defaultLeaseTTL
-		resp.AddWarning(fmt.Sprintf("Given ttl of %d seconds greater than current mount/system default of %d seconds; ttl will be capped at login time", roleEntry.TokenTTL/time.Second, defaultLeaseTTL/time.Second))
+		resp.AddWarning(fmt.Sprintf("Given ttl of %d seconds greater than current mount/system default of %d seconds; ttl will be capped", roleEntry.TokenTTL/time.Second, defaultLeaseTTL/time.Second))
 	}
 	if roleEntry.TokenMaxTTL > systemMaxTTL {
 		roleEntry.TokenMaxTTL = systemMaxTTL
-		resp.AddWarning(fmt.Sprintf("Given max ttl of %d seconds greater than current mount/system default of %d seconds; max ttl will be capped at login time", roleEntry.TokenMaxTTL/time.Second, systemMaxTTL/time.Second))
+		resp.AddWarning(fmt.Sprintf("Given max ttl of %d seconds greater than current mount/system default of %d seconds; max ttl will be capped", roleEntry.TokenMaxTTL/time.Second, systemMaxTTL/time.Second))
 	}
 	if roleEntry.TokenMaxTTL != 0 && roleEntry.TokenMaxTTL < roleEntry.TokenTTL {
 		return logical.ErrorResponse("ttl should be shorter than max ttl"), nil

--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -889,14 +889,8 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 		}
 	}
 
-	defaultLeaseTTL := b.System().DefaultLeaseTTL()
 	systemMaxTTL := b.System().MaxLeaseTTL()
-	if roleEntry.TokenTTL > defaultLeaseTTL {
-		roleEntry.TokenTTL = defaultLeaseTTL
-		resp.AddWarning(fmt.Sprintf("Given ttl of %d seconds greater than current mount/system default of %d seconds; ttl will be capped", roleEntry.TokenTTL/time.Second, defaultLeaseTTL/time.Second))
-	}
 	if roleEntry.TokenMaxTTL > systemMaxTTL {
-		roleEntry.TokenMaxTTL = systemMaxTTL
 		resp.AddWarning(fmt.Sprintf("Given max ttl of %d seconds greater than current mount/system default of %d seconds; max ttl will be capped", roleEntry.TokenMaxTTL/time.Second, systemMaxTTL/time.Second))
 	}
 	if roleEntry.TokenMaxTTL != 0 && roleEntry.TokenMaxTTL < roleEntry.TokenTTL {

--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -891,7 +891,7 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 
 	systemMaxTTL := b.System().MaxLeaseTTL()
 	if roleEntry.TokenMaxTTL > systemMaxTTL {
-		resp.AddWarning(fmt.Sprintf("Given max ttl of %d seconds greater than current mount/system default of %d seconds; max ttl will be capped", roleEntry.TokenMaxTTL/time.Second, systemMaxTTL/time.Second))
+		resp.AddWarning(fmt.Sprintf("Given max ttl of %d seconds greater than current mount/system default of %d seconds; max ttl will be capped at login time", roleEntry.TokenMaxTTL/time.Second, systemMaxTTL/time.Second))
 	}
 	if roleEntry.TokenMaxTTL != 0 && roleEntry.TokenMaxTTL < roleEntry.TokenTTL {
 		return logical.ErrorResponse("ttl should be shorter than max ttl"), nil

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/go-test/deep"
 	"github.com/hashicorp/go-hclog"
@@ -770,102 +769,6 @@ func TestAwsEc2_RoleDurationSeconds(t *testing.T) {
 	}
 	if resp.Data["period"].(int64) != 30 {
 		t.Fatalf("bad: period; expected: 30, actual: %d", resp.Data["period"])
-	}
-}
-
-func TestAwsIam_RoleDurationSeconds(t *testing.T) {
-	config := logical.TestBackendConfig()
-	storage := &logical.InmemStorage{}
-	config.StorageView = storage
-
-	b, err := Backend(config)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = b.Setup(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	roleData := map[string]interface{}{
-		"auth_type":               "iam",
-		"bound_iam_principal_arn": "arn:aws:iam::123456789012:role/testrole",
-		"resolve_aws_unique_ids":  false,
-		"ttl":                     "20m",
-		"max_ttl":                 "30m",
-	}
-
-	roleReq := &logical.Request{
-		Operation: logical.CreateOperation,
-		Storage:   storage,
-		Path:      "role/testrole",
-		Data:      roleData,
-	}
-
-	resp, err := b.HandleRequest(context.Background(), roleReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("resp: %#v, err: %v", resp, err)
-	}
-
-	roleReq.Operation = logical.ReadOperation
-
-	resp, err = b.HandleRequest(context.Background(), roleReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("resp: %#v, err: %v", resp, err)
-	}
-
-	// since default lease TTL for system is 24hr, Token TTL should not be capped
-	// since max lease TTL for system is 48hr, Token Max TTL should not be capped
-	if resp.Data["token_ttl"].(int64) != 1200 {
-		t.Fatalf("bad: token_ttl; expected: 1200, actual: %d", resp.Data["ttl"])
-	}
-	if resp.Data["max_ttl"].(int64) != 1800 {
-		t.Fatalf("bad: max_ttl; expected: 1800, actual: %d", resp.Data["max_ttl"])
-	}
-
-	// set default lease TTL to 10m; Token TTL should be capped at 10m
-	// set max lease TTL to 20m; Token Max TTL should be capped at 20m
-	config = &logical.BackendConfig{
-		Logger: logging.NewVaultLogger(hclog.Trace),
-
-		System: &logical.StaticSystemView{
-			DefaultLeaseTTLVal: time.Minute * 10,
-			MaxLeaseTTLVal:     time.Minute * 20,
-		},
-		StorageView: &logical.InmemStorage{},
-	}
-
-	b, err = Backend(config)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = b.Setup(context.Background(), config)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	roleReq.Operation = logical.CreateOperation
-
-	resp, err = b.HandleRequest(context.Background(), roleReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("resp: %#v, err: %v", resp, err)
-	}
-
-	roleReq.Operation = logical.ReadOperation
-
-	resp, err = b.HandleRequest(context.Background(), roleReq)
-	if err != nil || (resp != nil && resp.IsError()) {
-		t.Fatalf("resp: %#v, err: %v", resp, err)
-	}
-
-	if resp.Data["token_ttl"].(int64) != 600 {
-		t.Fatalf("bad: token_ttl; expected: 600, actual: %d", resp.Data["ttl"])
-	}
-
-	if resp.Data["token_max_ttl"].(int64) != 1200 {
-		t.Fatalf("bad: token_max_ttl; expected: 1200, actual: %d", resp.Data["ttl"])
 	}
 }
 

--- a/changelog/12026.txt
+++ b/changelog/12026.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/aws: Fix a bug where the Token TTL for AWS is not capped by Default Lease TTL.
+```

--- a/changelog/12026.txt
+++ b/changelog/12026.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-auth/aws: Fix a bug where the Token TTL for AWS is not capped by Default Lease TTL.
+auth/aws: Remove warning stating AWS Token TTL will be capped by the Default Lease TTL.
 ```


### PR DESCRIPTION
This PR fixes a bug in capping the Token TTL for AWS based on the Default Lease TTL. Before, the Token TTL was not being capped by the default lease even though a warning displayed in the console stating that it will be capped.

This PR also includes a test for the bug fix, including some typo fixes in error messages.