### PR TITLE
Add alias to approle secret IDs

### DIFF
--- a/builtin/credential/approle/path_role.go
+++ b/builtin/credential/approle/path_role.go
@@ -463,10 +463,18 @@ to 0, meaning no expiration.`,
 					Type:        framework.TypeString,
 					Description: "Name of the role.",
 				},
+				"alias": {
+					Type: framework.TypeString,
+					Description: `Label to be tied to the secret ID. This should be a string uniquely identifier the
+secret ID user, in the sense that different secret IDs with the same label are
+identified as the same identity alias.`,
+				},
 				"metadata": {
 					Type: framework.TypeString,
 					Description: `Metadata to be tied to the SecretID. This should be a JSON
-formatted string containing the metadata in key value pairs.`,
+formatted string containing the metadata in key value pairs. If tokens of
+multiple secret IDs with the same alias coexist, the metadata of the latest
+authenticated secret ID will be used in templates for all those tokens.`,
 				},
 				"cidr_list": {
 					Type: framework.TypeCommaStringSlice,
@@ -572,10 +580,18 @@ the role.`,
 					Type:        framework.TypeString,
 					Description: "SecretID to be attached to the role.",
 				},
+				"alias": {
+					Type: framework.TypeString,
+					Description: `Label to be tied to the secret ID. This should be a string uniquely identifier the
+secret ID user, in the sense that different secret IDs with the same label are
+identified as the same identity alias.`,
+				},
 				"metadata": {
 					Type: framework.TypeString,
 					Description: `Metadata to be tied to the SecretID. This should be a JSON
-formatted string containing metadata in key value pairs.`,
+formatted string containing the metadata in key value pairs. If tokens of
+multiple secret IDs with the same alias coexist, the metadata of the latest
+authenticated secret ID will be used in templates for all those tokens.`,
 				},
 				"cidr_list": {
 					Type: framework.TypeCommaStringSlice,
@@ -1193,6 +1209,7 @@ func (entry *secretIDStorageEntry) ToResponseData() map[string]interface{} {
 		"creation_time":      entry.CreationTime,
 		"expiration_time":    entry.ExpirationTime,
 		"last_updated_time":  entry.LastUpdatedTime,
+		"alias":              entry.Alias,
 		"metadata":           entry.Metadata,
 		"cidr_list":          entry.CIDRList,
 		"token_bound_cidrs":  entry.TokenBoundCIDRs,
@@ -2348,6 +2365,7 @@ func (b *backend) handleRoleSecretIDCommon(ctx context.Context, req *logical.Req
 	secretIDStorage := &secretIDStorageEntry{
 		SecretIDNumUses: role.SecretIDNumUses,
 		SecretIDTTL:     role.SecretIDTTL,
+		Alias:           data.Get("alias").(string),
 		Metadata:        make(map[string]string),
 		CIDRList:        secretIDCIDRs,
 		TokenBoundCIDRs: secretIDTokenCIDRs,

--- a/builtin/credential/approle/path_tidy_user_id.go
+++ b/builtin/credential/approle/path_tidy_user_id.go
@@ -147,6 +147,7 @@ func (b *backend) tidySecretIDinternal(s logical.Storage) {
 			// ExpirationTime not being set indicates non-expiring SecretIDs
 			if !result.ExpirationTime.IsZero() && time.Now().After(result.ExpirationTime) {
 				logger.Trace("found expired secret ID")
+
 				// Clean up the accessor of the secret ID first
 				err = b.deleteSecretIDAccessorEntry(ctx, s, result.SecretIDAccessor, secretIDPrefixToUse)
 				if err != nil {

--- a/builtin/credential/approle/validation.go
+++ b/builtin/credential/approle/validation.go
@@ -44,6 +44,11 @@ type secretIDStorageEntry struct {
 	// The time representing the last time this storage entry was modified
 	LastUpdatedTime time.Time `json:"last_updated_time" mapstructure:"last_updated_time"`
 
+	// Alias that belongs to the SecretID, to identify the user of the secret id
+	// when registering the identity alias. The metadata of the latest authenticated
+	// secret ID with the same alias will win when using templates.
+	Alias string `json:"alias" mapstructure:"alias"`
+
 	// Metadata that belongs to the SecretID
 	Metadata map[string]string `json:"metadata" mapstructure:"metadata"`
 

--- a/changelog/12032.txt
+++ b/changelog/12032.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+auth/approle: Adds ability to set identity aliases on secret_ids to distinguish different sets of metadata in templates.
+```

--- a/website/content/api-docs/auth/approle.mdx
+++ b/website/content/api-docs/auth/approle.mdx
@@ -261,10 +261,18 @@ itself, and also to delete the SecretID from the AppRole.
 ### Parameters
 
 - `role_name` `(string: <required>)` - Name of the AppRole.
+- `alias` `(string: "")` - Label to be tied to the SecretID. When using multiple
+  SecretIDs with the same role_name and putting metadata to distinguish them in
+  policy templates, the label should be used to identify the SecretIDs of
+  different end users, e.g. by putting a hostname.
 - `metadata` `(string: "")` - Metadata to be tied to the SecretID. This should be
   a JSON-formatted string containing the metadata in key-value pairs. This
   metadata will be set on tokens issued with this SecretID, and is logged in
-  audit logs _in plaintext_.
+  audit logs _in plaintext_. Note that for a given alias, the metadata of the
+  latest authenticated SecretID will be used in templates using the
+  `identity.entity.aliases.<mount accessor>.metadata.<metadata key>` variable
+  for all tokens, also for tokens that where earlier acquired using another
+  SecretID with the same alias.
 - `cidr_list` `(array: [])` - Comma separated string or list of CIDR blocks
   enforcing secret IDs to be used from specific set of IP addresses. If
   `bound_cidr_list` is set on the role, then the list of CIDR blocks listed
@@ -277,6 +285,7 @@ itself, and also to delete the SecretID from the AppRole.
 
 ```json
 {
+  "alias": "production-server",
   "metadata": "{ \"tag1\": \"production\" }"
 }
 ```
@@ -490,10 +499,18 @@ Assigns a "custom" SecretID against an existing AppRole. This is used in the
 
 - `role_name` `(string: <required>)` - Name of the AppRole.
 - `secret_id` `(string: <required>)` - SecretID to be attached to the Role.
+- `alias` `(string: "")` - Label to be tied to the SecretID. When using multiple
+  SecretIDs with the same role_name and putting metadata to distinguish them in
+  policy templates, the label should be used to identify the SecretIDs of
+  different end users, e.g. by putting a hostname.
 - `metadata` `(string: "")` - Metadata to be tied to the SecretID. This should be
   a JSON-formatted string containing the metadata in key-value pairs. This
   metadata will be set on tokens issued with this SecretID, and is logged in
-  audit logs _in plaintext_.
+  audit logs _in plaintext_. Note that for a given alias, the metadata of the
+  latest authenticated SecretID will be used in templates using the
+  `identity.entity.aliases.<mount accessor>.metadata.<metadata key>` variable
+  for all tokens, also for tokens that where earlier acquired using another
+  SecretID with the same alias.
 - `cidr_list` `(array: [])` - Comma separated string or list of CIDR blocks
   enforcing secret IDs to be used from specific set of IP addresses. If
   `bound_cidr_list` is set on the role, then the list of CIDR blocks listed


### PR DESCRIPTION
When using a single approle role_id with multiple secret_ids, each
carrying different metadata, the latest authenticated secret id will
define the identity alias for that role_id. This means that all earlier
obtained tokens for the same role_id will use the metadata of the latest
created token in templating (e.g. policy templating), breaking the
scenario of a single role_id with multiple secret_ids to hand out to
different clients that need different permissions.

We fix this by adding an alias field to secret_id, which should contain
a unique value for each "end client", and which is used to define the
identy alias. I.e. in general secret IDs with different metadata should
have different aliases. Other options would be to use the secret
accessor id as identity alias, or to put simply a hash of the metadata,
but we opted for this solution to have a limit on the entries in the
identity alias table - we would flood it over time if secret IDs change
rapidly or a metadata field like a timestamp would be added.

Fixes #11798

Signed-off-by: Peter Verraedt <peter@verraedt.be>