### PR TITLE
UI: Automatically refresh page on logout

### DIFF
--- a/changelog/12035.txt
+++ b/changelog/12035.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Automatically refresh the page when user logs out
+```

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -15,8 +15,9 @@ export default Route.extend(ModelBoundaryRoute, {
     return ['secret', 'secret-engine'];
   }),
 
-  beforeModel() {
-    let authType = this.auth.getAuthType();
+  async beforeModel() {
+    const authType = this.auth.getAuthType();
+    const baseUrl = window.location.origin;
     this.auth.deleteCurrentToken();
     this.controlGroup.deleteTokens();
     this.namespaceService.reset();
@@ -24,6 +25,6 @@ export default Route.extend(ModelBoundaryRoute, {
     this.console.clearLog(true);
     this.flashMessages.clearMessages();
     this.permissions.reset();
-    this.replaceWith('vault.cluster.auth', { queryParams: { with: authType } });
+    location.assign(`${baseUrl}/ui/vault/auth?with=${authType}`);
   },
 });

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -27,6 +27,11 @@ export default Route.extend(ModelBoundaryRoute, {
     this.console.clearLog(true);
     this.flashMessages.clearMessages();
     this.permissions.reset();
-    location.assign(`${baseUrl}${path}`);
+    if (Ember.testing) {
+      // Don't redirect on the test
+      this.replaceWith('vault.cluster.auth', { queryParams: { with: authType } });
+    } else {
+      location.assign(`${baseUrl}${path}`);
+    }
   },
 });

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -19,6 +19,7 @@ export default Route.extend(ModelBoundaryRoute, {
   beforeModel() {
     const authType = this.auth.getAuthType();
     const baseUrl = window.location.origin;
+    const ns = this.namespaceService.path;
     this.auth.deleteCurrentToken();
     this.controlGroup.deleteTokens();
     this.namespaceService.reset();
@@ -30,7 +31,11 @@ export default Route.extend(ModelBoundaryRoute, {
       // Don't redirect on the test
       this.replaceWith('vault.cluster.auth', { queryParams: { with: authType } });
     } else {
-      location.assign(`${baseUrl}/ui/vault/auth?with=${authType}`);
+      let params = `?with=${authType}`;
+      if (ns) {
+        params = `${params}&namespace=${ns}`;
+      }
+      location.assign(`${baseUrl}/ui/vault/auth${params}`);
     }
   },
 });

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -9,6 +9,7 @@ export default Route.extend(ModelBoundaryRoute, {
   flashMessages: service(),
   console: service(),
   permissions: service(),
+  router: service(),
   namespaceService: service('namespace'),
 
   modelTypes: computed(function() {
@@ -18,6 +19,7 @@ export default Route.extend(ModelBoundaryRoute, {
   beforeModel() {
     const authType = this.auth.getAuthType();
     const baseUrl = window.location.origin;
+    const path = this.router.urlFor('vault.cluster.auth', { queryParams: { with: authType } });
     this.auth.deleteCurrentToken();
     this.controlGroup.deleteTokens();
     this.namespaceService.reset();
@@ -25,6 +27,6 @@ export default Route.extend(ModelBoundaryRoute, {
     this.console.clearLog(true);
     this.flashMessages.clearMessages();
     this.permissions.reset();
-    location.assign(`${baseUrl}/ui/vault/auth?with=${authType}`);
+    location.assign(`${baseUrl}${path}`);
   },
 });

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -10,7 +10,6 @@ export default Route.extend(ModelBoundaryRoute, {
   flashMessages: service(),
   console: service(),
   permissions: service(),
-  router: service(),
   namespaceService: service('namespace'),
 
   modelTypes: computed(function() {
@@ -20,7 +19,6 @@ export default Route.extend(ModelBoundaryRoute, {
   beforeModel() {
     const authType = this.auth.getAuthType();
     const baseUrl = window.location.origin;
-    const path = this.router.urlFor('vault.cluster.auth', { queryParams: { with: authType } });
     this.auth.deleteCurrentToken();
     this.controlGroup.deleteTokens();
     this.namespaceService.reset();
@@ -32,7 +30,7 @@ export default Route.extend(ModelBoundaryRoute, {
       // Don't redirect on the test
       this.replaceWith('vault.cluster.auth', { queryParams: { with: authType } });
     } else {
-      location.assign(`${baseUrl}${path}`);
+      location.assign(`${baseUrl}/ui/vault/auth?with=${authType}`);
     }
   },
 });

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';

--- a/ui/app/routes/vault/cluster/logout.js
+++ b/ui/app/routes/vault/cluster/logout.js
@@ -15,7 +15,7 @@ export default Route.extend(ModelBoundaryRoute, {
     return ['secret', 'secret-engine'];
   }),
 
-  async beforeModel() {
+  beforeModel() {
     const authType = this.auth.getAuthType();
     const baseUrl = window.location.origin;
     this.auth.deleteCurrentToken();


### PR DESCRIPTION
When a Vault user logs out, automatically refresh the page by navigating to it with `location.assign` rather than using the router's `replaceWith` method.