### PR TITLE
[VAULT-2825] Fix erroneous 500 resp for field validation errors

### DIFF
--- a/changelog/12042.txt
+++ b/changelog/12042.txt
@@ -1,0 +1,3 @@
+```release-note:changes
+api: A request that fails field validation will now be responded to with a 400 rather than 500.
+```

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -267,7 +267,7 @@ func (b *Backend) HandleRequest(ctx context.Context, req *logical.Request) (*log
 	if req.Operation != logical.HelpOperation {
 		err := fd.Validate()
 		if err != nil {
-			return nil, err
+			return logical.ErrorResponse(fmt.Sprintf("Field validation failed: %s", err.Error())), nil
 		}
 	}
 

--- a/sdk/framework/backend_test.go
+++ b/sdk/framework/backend_test.go
@@ -249,7 +249,7 @@ func TestBackendHandleRequest_badwrite(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if resp.Data["error"] != "Field validation failed: error converting input 3false3 for field \"value\": cannot parse '' as bool: strconv.ParseBool: parsing \"3false3\": invalid syntax" {
+	if !strings.Contains(resp.Data["error"].(string), "Field validation failed") {
 		t.Fatalf("bad: %#v", resp)
 	}
 }

--- a/sdk/framework/backend_test.go
+++ b/sdk/framework/backend_test.go
@@ -240,14 +240,17 @@ func TestBackendHandleRequest_badwrite(t *testing.T) {
 		},
 	}
 
-	_, err := b.HandleRequest(context.Background(), &logical.Request{
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
 		Path:      "foo/bar",
 		Data:      map[string]interface{}{"value": "3false3"},
 	})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
-	if err == nil {
-		t.Fatalf("should have thrown a conversion error")
+	if resp.Data["error"] != "Field validation failed: error converting input 3false3 for field \"value\": cannot parse '' as bool: strconv.ParseBool: parsing \"3false3\": invalid syntax" {
+		t.Fatalf("bad: %#v", resp)
 	}
 }
 


### PR DESCRIPTION
The server will currently respond with a 500 if an endpoint for which a schema is defined is provided with invalid data. The proposed fix is to instead respond with a 400 with an appropriate error message stating that field validation has failed.

Fixes #11645 