### PR TITLE
Remove Key validation on KV2

### DIFF
--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -87,7 +87,6 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
     }
     this.set('validationMessages', {
       path: '',
-      key: '',
       maxVersions: '',
     });
     // for validation, return array of path names already assigned
@@ -195,20 +194,18 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
   },
 
   checkValidation(name, value) {
-    // because path and key are not on the model performing custom validations instead of cp-validations
-    if (name === 'path' || name === 'key') {
-      // no value indicates missing presence
+    if (name === 'path') {
       !value
         ? set(this.validationMessages, name, `${name} can't be blank.`)
         : set(this.validationMessages, name, '');
-
-      // only check duplicate on path not on the key
-      if (name === 'path') {
-        this.secretPaths?.includes(value)
-          ? set(this.validationMessages, name, `A secret with this ${name} already exists.`)
-          : set(this.validationMessages, name, '');
-      }
     }
+    // check duplicate on path
+    if (name === 'path' && value) {
+      this.secretPaths?.includes(value)
+        ? set(this.validationMessages, name, `A secret with this ${name} already exists.`)
+        : set(this.validationMessages, name, '');
+    }
+    // check maxVersions is a number
     if (name === 'maxVersions') {
       // checking for value because value which is blank on first load. No keyup event has occurred and default is 10.
       if (value) {
@@ -221,9 +218,7 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
         set(this.validationMessages, name, '');
       }
     }
-
     let values = Object.values(this.validationMessages);
-
     this.set('validationErrorCount', values.filter(Boolean).length);
   },
 
@@ -362,13 +357,8 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
     createOrUpdateKey(type, event) {
       event.preventDefault();
       let model = this.modelForData;
-      let arraySecretKeys = Object.keys(model.secretData);
       if (type === 'create' && isBlank(model.path || model.id)) {
         this.checkValidation('path', '');
-        return;
-      }
-      if (arraySecretKeys.includes('')) {
-        this.checkValidation('key', '');
         return;
       }
 

--- a/ui/app/components/secret-edit.js
+++ b/ui/app/components/secret-edit.js
@@ -218,7 +218,9 @@ export default Component.extend(FocusOnInsertMixin, WithNavToNearestAncestor, {
         set(this.validationMessages, name, '');
       }
     }
+
     let values = Object.values(this.validationMessages);
+
     this.set('validationErrorCount', values.filter(Boolean).length);
   },
 

--- a/ui/app/templates/components/secret-edit-display.hbs
+++ b/ui/app/templates/components/secret-edit-display.hbs
@@ -46,8 +46,7 @@
       @title={{if isV2 "Version Data" "Secret Data"}}
       @value={{@codemirrorString}}
       @valueUpdated={{action @editActions.codemirrorUpdated}}
-      @onFocusOut={{action @editActions.formatJSON}}
-      {{on "keyup" (fn @onKeyUp "key" @codemirrorString)}}>
+      @onFocusOut={{action @editActions.formatJSON}}>
     </JsonEditor> 
   </div>
 {{else}}

--- a/ui/app/templates/components/secret-edit-display.hbs
+++ b/ui/app/templates/components/secret-edit-display.hbs
@@ -46,7 +46,8 @@
       @title={{if isV2 "Version Data" "Secret Data"}}
       @value={{@codemirrorString}}
       @valueUpdated={{action @editActions.codemirrorUpdated}}
-      @onFocusOut={{action @editActions.formatJSON}}>
+      @onFocusOut={{action @editActions.formatJSON}}
+      {{on "keyup" (fn @onKeyUp "key" @codemirrorString)}}>
     </JsonEditor> 
   </div>
 {{else}}
@@ -66,7 +67,7 @@
           @value={{secret.name}}
           placeholder="key"
           @change={{action @editActions.handleChange}}
-          class="input {{if @validationMessages.key "has-error-border"}}"
+          class="input"
           @autocomplete="off"
           @spellcheck="false"
           {{on "keyup" (fn @onKeyUp "key" secret.name)}}

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -73,13 +73,12 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     await click('[data-test-secret-create="true"]');
     await fillIn('[data-test-secret-path="true"]', secretPath);
     await fillIn('[data-test-input="maxVersions"]', maxVersions);
-    await fillIn('[data-test-secret-key]', 'key');
     await click('[data-test-secret-save]');
     await settled();
     await click('[data-test-secret-edit="true"]');
     await settled();
-
-    let savedMaxVersions = document.querySelector('[data-test-input="maxVersions"]').value;
+    // convert to number for IE11 browserstack test
+    let savedMaxVersions = Number(document.querySelector('[data-test-input="maxVersions"]').value);
     assert.equal(
       maxVersions,
       savedMaxVersions,


### PR DESCRIPTION
Originally I had set out to fix some issues with key validation when entering as JSON. However, after testing on the API, which does allow you to set a value with no key, and confirming with design, we decided to remove the original validation design of requiring a key.

I updated the tests appropriatly. 