### PR TITLE
[Website] Bump hashi-stack-menu

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2128,9 +2128,9 @@
       }
     },
     "@hashicorp/react-hashi-stack-menu": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-2.0.4.tgz",
-      "integrity": "sha512-v/4kxIyTAntHsk4t/nY9f2REUlNzPcBduSdh4ZmTQRG9kZMMeIAjto/eu8ftXbe3iaV7rF/Ytdq9Q2XfSQC23g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-2.0.5.tgz",
+      "integrity": "sha512-Oxr+rBF6fyhc73IM2vqCwepab6t0OCWxIWECpxD5tTD1CtGgkNjDg5PVMSJ5sIeoNTGcKzlW/rcmT30owezVnQ==",
       "requires": {
         "@hashicorp/react-inline-svg": "^1.0.2",
         "slugify": "1.3.4"

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "@hashicorp/react-content": "7.0.1",
     "@hashicorp/react-docs-page": "13.4.0",
     "@hashicorp/react-featured-slider": "4.1.0",
-    "@hashicorp/react-hashi-stack-menu": "2.0.4",
+    "@hashicorp/react-hashi-stack-menu": "2.0.5",
     "@hashicorp/react-head": "3.1.0",
     "@hashicorp/react-hero": "7.3.0",
     "@hashicorp/react-image": "4.0.1",


### PR DESCRIPTION
[:mag: Preview Link](https://vault-jaq7psxfh-hashicorp.vercel.app/)

---

This PR bumps `<HashiStackMenu />` to `2.0.5`, removing the "About" link.