### PR TITLE
builtin/logical/nomad: fix dropped test errors

### DIFF
--- a/builtin/logical/nomad/backend_test.go
+++ b/builtin/logical/nomad/backend_test.go
@@ -89,6 +89,9 @@ func prepareTestContainer(t *testing.T) (func(), *Config) {
 		nomadAuthConfig.Address = nomad.Address()
 		nomadAuthConfig.SecretID = nomadToken
 		nomadAuth, err := nomadapi.NewClient(nomadAuthConfig)
+		if err != nil {
+			return nil, err
+		}
 		_, err = nomadAuth.ACLPolicies().Upsert(policy, nil)
 		if err != nil {
 			return nil, err
@@ -254,6 +257,9 @@ func TestBackend_renew_revoke(t *testing.T) {
 	nomadmgmtConfig.Address = connData["address"].(string)
 	nomadmgmtConfig.SecretID = connData["token"].(string)
 	mgmtclient, err := nomadapi.NewClient(nomadmgmtConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	q := &nomadapi.QueryOptions{
 		Namespace: "default",


### PR DESCRIPTION
This fixes two dropped test errors in `builtin/logical/nomad`.

Could someone label this PR as no-changelog?
