### PR TITLE
docs: fix formatting in azure secrets overview

### DIFF
--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -29,7 +29,7 @@ management tool.
 
 1. Enable the Azure secrets engine:
 
-   ```text
+   ```shell
    $ vault secrets enable azure
    Success! Enabled the azure secrets engine at: azure/
    ```
@@ -39,12 +39,12 @@ management tool.
 
 1. Configure the secrets engine with account credentials:
 
-   ```text
+   ```shell
    $ vault write azure/config \
-   subscription_id=$AZURE_SUBSCRIPTION_ID \
-   tenant_id=$AZURE_TENANT_ID \
-   client_id=$AZURE_CLIENT_ID \
-   client_secret=$AZURE_CLIENT_SECRET
+       subscription_id=$AZURE_SUBSCRIPTION_ID \
+       tenant_id=$AZURE_TENANT_ID \
+       client_id=$AZURE_CLIENT_ID \
+       client_secret=$AZURE_CLIENT_SECRET
 
    Success! Data written to: azure/config
    ```
@@ -58,7 +58,9 @@ management tool.
 To configure a role called "my-role" with an existing service principal:
 
 ```shell-session
-$ vault write azure/roles/my-role application_object_id=<existing_app_obj_id> ttl=1h
+$ vault write azure/roles/my-role \
+    application_object_id=<existing_app_obj_id> \
+    ttl=1h
 ```
 
 Alternatively, to configure the role to create a new service principal with Azure roles:
@@ -140,7 +142,11 @@ Group specification by name must yield a single matching group.
 Example of role configuration:
 
 ```shell-session
-$ vault write azure/roles/my-role ttl=1h max_ttl=24h azure_roles=@az_roles.json azure_groups=@az_groups.json
+$ vault write azure/roles/my-role \
+    ttl=1h \
+    max_ttl=24h \
+    azure_roles=@az_roles.json \
+    azure_groups=@az_groups.json
 
 $ cat az_roles.json
 [


### PR DESCRIPTION
The Azure documentation is inconsistent in formatting, so I've added extra spaces/newlines and correct render formatting.