### PR TITLE
[VAULT-1969]  Add support for custom IAM usernames based on templates

### DIFF
--- a/builtin/logical/aws/path_config_root.go
+++ b/builtin/logical/aws/path_config_root.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+const defaultUserNameTemplate = `{{ printf "vault-%s-%s-%s-%s" (.DisplayName) (.PolicyName) (unix_time) (random 20) | truncate 64 }}`
+
 func pathConfigRoot(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: "config/root",
@@ -38,6 +40,10 @@ func pathConfigRoot(b *backend) *framework.Path {
 				Type:        framework.TypeInt,
 				Default:     aws.UseServiceDefaultRetries,
 				Description: "Maximum number of retries for recoverable exceptions of AWS APIs",
+			},
+			"username_template": {
+				Type:        framework.TypeString,
+				Description: "Template to generate custom IAM usernames",
 			},
 		},
 
@@ -70,11 +76,12 @@ func (b *backend) pathConfigRootRead(ctx context.Context, req *logical.Request, 
 	}
 
 	configData := map[string]interface{}{
-		"access_key":   config.AccessKey,
-		"region":       config.Region,
-		"iam_endpoint": config.IAMEndpoint,
-		"sts_endpoint": config.STSEndpoint,
-		"max_retries":  config.MaxRetries,
+		"access_key":        config.AccessKey,
+		"region":            config.Region,
+		"iam_endpoint":      config.IAMEndpoint,
+		"sts_endpoint":      config.STSEndpoint,
+		"max_retries":       config.MaxRetries,
+		"username_template": config.UsernameTemplate,
 	}
 	return &logical.Response{
 		Data: configData,
@@ -86,17 +93,22 @@ func (b *backend) pathConfigRootWrite(ctx context.Context, req *logical.Request,
 	iamendpoint := data.Get("iam_endpoint").(string)
 	stsendpoint := data.Get("sts_endpoint").(string)
 	maxretries := data.Get("max_retries").(int)
+	usernameTemplate := data.Get("username_template").(string)
+	if usernameTemplate == "" {
+		usernameTemplate = defaultUserNameTemplate
+	}
 
 	b.clientMutex.Lock()
 	defer b.clientMutex.Unlock()
 
 	entry, err := logical.StorageEntryJSON("config/root", rootConfig{
-		AccessKey:   data.Get("access_key").(string),
-		SecretKey:   data.Get("secret_key").(string),
-		IAMEndpoint: iamendpoint,
-		STSEndpoint: stsendpoint,
-		Region:      region,
-		MaxRetries:  maxretries,
+		AccessKey:        data.Get("access_key").(string),
+		SecretKey:        data.Get("secret_key").(string),
+		IAMEndpoint:      iamendpoint,
+		STSEndpoint:      stsendpoint,
+		Region:           region,
+		MaxRetries:       maxretries,
+		UsernameTemplate: usernameTemplate,
 	})
 	if err != nil {
 		return nil, err
@@ -115,12 +127,13 @@ func (b *backend) pathConfigRootWrite(ctx context.Context, req *logical.Request,
 }
 
 type rootConfig struct {
-	AccessKey   string `json:"access_key"`
-	SecretKey   string `json:"secret_key"`
-	IAMEndpoint string `json:"iam_endpoint"`
-	STSEndpoint string `json:"sts_endpoint"`
-	Region      string `json:"region"`
-	MaxRetries  int    `json:"max_retries"`
+	AccessKey        string `json:"access_key"`
+	SecretKey        string `json:"secret_key"`
+	IAMEndpoint      string `json:"iam_endpoint"`
+	STSEndpoint      string `json:"sts_endpoint"`
+	Region           string `json:"region"`
+	MaxRetries       int    `json:"max_retries"`
+	UsernameTemplate string `json:"username_template"`
 }
 
 const pathConfigRootHelpSyn = `

--- a/builtin/logical/aws/path_config_root.go
+++ b/builtin/logical/aws/path_config_root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-const defaultUserNameTemplate = `{{ printf "vault-%s-%s-%s-%s" (.DisplayName) (.PolicyName) (unix_time) (random 20) | truncate 64 }}`
+const defaultUserNameTemplate = `{{ printf "vault-%s-%s-%s" (printf "%s-%s" (.DisplayName) (.PolicyName) | truncate 42) (unix_time) (random 20) | truncate 64 }}`
 
 func pathConfigRoot(b *backend) *framework.Path {
 	return &framework.Path{

--- a/builtin/logical/aws/path_config_root_test.go
+++ b/builtin/logical/aws/path_config_root_test.go
@@ -18,12 +18,13 @@ func TestBackend_PathConfigRoot(t *testing.T) {
 	}
 
 	configData := map[string]interface{}{
-		"access_key":   "AKIAEXAMPLE",
-		"secret_key":   "RandomData",
-		"region":       "us-west-2",
-		"iam_endpoint": "https://iam.amazonaws.com",
-		"sts_endpoint": "https://sts.us-west-2.amazonaws.com",
-		"max_retries":  10,
+		"access_key":        "AKIAEXAMPLE",
+		"secret_key":        "RandomData",
+		"region":            "us-west-2",
+		"iam_endpoint":      "https://iam.amazonaws.com",
+		"sts_endpoint":      "https://sts.us-west-2.amazonaws.com",
+		"max_retries":       10,
+		"username_template": defaultUserNameTemplate,
 	}
 
 	configReq := &logical.Request{

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	secretAccessKeyType = "access_keys"
-	storageKey          = "config/connection"
+	secretAccessKeyType     = "access_keys"
+	storageKey              = "config/connection"
+	defaultUserNameTemplate = `{{ printf "vault-%s-%s-%s-%s" (.DisplayName) (.PolicyName) (unix_time) (random 20) | truncate 64 }}`
 )
 
 func secretAccessKeys(b *backend) *framework.Secret {
@@ -68,7 +69,6 @@ func genUsername(displayName, policyName, userType, usernameTemplate string) (re
 		if err != nil {
 			return "", fmt.Sprintf("failed to generate username: %s", err)
 		}
-		fmt.Printf("username: %s\n", username)
 		if len(username) > 64 {
 			username = username[0:64]
 			warning = "the calling token display name/IAM policy name were truncated to fit into IAM username length limits"
@@ -261,7 +261,6 @@ func (b *backend) secretAccessKeysCreate(
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
-	defaultUserNameTemplate := `{{ printf "vault-%s-%s-%s-%s" (.DisplayName) (.PolicyName) (unix_time) (random 20) | truncate 64 }}`
 	config, err := readConfig(ctx, s)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read configuration: %w", err)

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -19,9 +19,8 @@ import (
 )
 
 const (
-	secretAccessKeyType     = "access_keys"
-	storageKey              = "config/connection"
-	defaultUserNameTemplate = `{{ printf "vault-%s-%s-%s-%s" (.DisplayName) (.PolicyName) (unix_time) (random 20) | truncate 64 }}`
+	secretAccessKeyType = "access_keys"
+	storageKey          = "config/root"
 )
 
 func secretAccessKeys(b *backend) *framework.Secret {
@@ -235,18 +234,18 @@ func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 	return resp, nil
 }
 
-func readConfig(ctx context.Context, storage logical.Storage) (connectionConfig, error) {
+func readConfig(ctx context.Context, storage logical.Storage) (rootConfig, error) {
 	entry, err := storage.Get(ctx, storageKey)
 	if err != nil {
-		return connectionConfig{}, err
+		return rootConfig{}, err
 	}
 	if entry == nil {
-		return connectionConfig{}, nil
+		return rootConfig{}, nil
 	}
 
-	var connConfig connectionConfig
+	var connConfig rootConfig
 	if err := entry.DecodeJSON(&connConfig); err != nil {
-		return connectionConfig{}, err
+		return rootConfig{}, err
 	}
 	return connConfig, nil
 }
@@ -484,22 +483,4 @@ func convertPolicyARNs(policyARNs []string) []*sts.PolicyDescriptorType {
 type UsernameMetadata struct {
 	DisplayName string
 	PolicyName  string
-}
-
-// connectionConfig contains the information required to make a connection to a AWS node
-type connectionConfig struct {
-	// URI of the AWS server
-	URI string `json:"connection_uri"`
-
-	// Username which has 'administrator' tag attached to it
-	Username string `json:"username"`
-
-	// Password for the Username
-	Password string `json:"password"`
-
-	// PasswordPolicy for generating passwords for dynamic credentials
-	PasswordPolicy string `json:"password_policy"`
-
-	// UsernameTemplate for storing the raw template in Vault's backing data store
-	UsernameTemplate string `json:"username_template"`
 }

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -193,11 +193,8 @@ func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 		return nil, fmt.Errorf("unable to read configuration: %w", err)
 	}
 
+	// Set as defaultUsernameTemplate if not provided
 	usernameTemplate := config.UsernameTemplate
-	if usernameTemplate == "" {
-		usernameTemplate = defaultUserNameTemplate
-	}
-
 	roleSessionNameWarning := ""
 	if roleSessionName == "" {
 		roleSessionName, roleSessionNameWarning = genUsername(displayName, roleName, "iam_user", usernameTemplate)
@@ -280,11 +277,8 @@ func (b *backend) secretAccessKeysCreate(
 		return nil, fmt.Errorf("unable to read configuration: %w", err)
 	}
 
+	// Set as defaultUsernameTemplate if not provided
 	usernameTemplate := config.UsernameTemplate
-	if usernameTemplate == "" {
-		usernameTemplate = defaultUserNameTemplate
-	}
-
 	username, usernameWarning := genUsername(displayName, policyName, "iam_user", usernameTemplate)
 
 	// Write to the WAL that this user will be created. We do this before

--- a/builtin/logical/aws/secret_access_keys_test.go
+++ b/builtin/logical/aws/secret_access_keys_test.go
@@ -48,11 +48,11 @@ func TestNormalizeDisplayName_NormNotRequired(t *testing.T) {
 
 func TestGenUsername(t *testing.T) {
 
-	testUsername, warning := genUsername("name1", "policy1", "iam_user", `{{ printf "vault-%s-%s-%s-%s" (.DisplayName) (.PolicyName) (unix_time) (random 20) | truncate 64 }}`)
-	if warning != "" {
+	testUsername, err := genUsername("name1", "policy1", "iam_user", `{{ printf "vault-%s-%s-%s-%s" (.DisplayName) (.PolicyName) (unix_time) (random 20) | truncate 64 }}`)
+	if err != nil {
 		t.Fatalf(
-			"expected no warning; got %s",
-			warning,
+			"expected no err; got %s",
+			err,
 		)
 	}
 
@@ -66,11 +66,11 @@ func TestGenUsername(t *testing.T) {
 		)
 	}
 
-	testUsername, warning = genUsername("name2", "policy2", "iam_user", `{{ printf "foo-%s-%s" (unix_time) (random 20) | truncate 64 }}`)
+	testUsername, err = genUsername("name2", "policy2", "iam_user", `{{ printf "foo-%s-%s" (unix_time) (random 20) | truncate 64 }}`)
 	expectedUsernameRegex = `^foo-[0-9]+-[a-zA-Z0-9]+`
 	require.Regexp(t, expectedUsernameRegex, testUsername)
 
-	testUsername, warning = genUsername("name1", "policy1", "sts", defaultSTSTemplate)
+	testUsername, err = genUsername("name1", "policy1", "sts", defaultSTSTemplate)
 	if strings.Contains(testUsername, "name1") || strings.Contains(testUsername, "policy1") {
 		t.Fatalf(
 			"expected sts username to not contain display name or policy name; got %s",

--- a/changelog/12066.txt
+++ b/changelog/12066.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+secrets/aws: add support for custom IAM usernames
+```

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -58,6 +58,9 @@ valid AWS credentials with proper permissions.
 
 - `sts_endpoint` `(string: <optional>)` – Specifies a custom HTTP STS endpoint to use.
 
+- `username_template` `(string: <optional>)` - [Template](/docs/concepts/username-templating) describing how
+  dynamic usernames are generated. IAM usernames are capped at 64 characters. Longer usernames will be truncated.
+
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
This PR enables users to customize their IAM usernames based on `UsernameTemplates` provided to the Secret Engine config. 