### PR TITLE
Removed sentence from intro per PM's request

### DIFF
--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -6,7 +6,7 @@ description: An overview of license.
 
 # Frequently Asked Questions (FAQ)
 
-This FAQ section is for the license changes introduced in Vault Enterprise 1.8. We will no longer support the old license system (`vault write sys/license`), and autoload will be the only way to manage your license.
+This FAQ section is for the license changes introduced in Vault Enterprise 1.8.
 
 - [Q: When will these licensing changes be released for Vault?](#q-when-will-these-licensing-changes-be-released-for-vault)
 - [Q: Will these license changes impact HCP Vault?](#q-will-these-license-changes-impact-hcp-vault)


### PR DESCRIPTION
:mag: [Deploy preview](https://vault-5nfqqjov7-hashicorp.vercel.app/docs/enterprise/license/faq)

Removed the following sentence from the FAQ intro per Aarti's request: **We will no longer support the old license system (vault write sys/license), and autoload will be the only way to manage your license**.