### PR TITLE
Fix KV Version History queryParams on the component LinkedBlock

### DIFF
--- a/changelog/12079.txt
+++ b/changelog/12079.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix Version History queryParams on LinkedBlock
+```

--- a/ui/app/templates/vault/cluster/secrets/backend/versions.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/versions.hbs
@@ -19,7 +19,11 @@
   </p.levelLeft>
 </PageHeader>
 <ListView @items={{reverse model.versions}} @itemNoun="version" as |list|>
-  <ListItem @hasMenu={{false}} @linkParams={{array 'vault.cluster.secrets.backend.show' model.id (query-params version=list.item.version) }} as |Item|>
+  <ListItem 
+    @hasMenu={{false}} 
+    @linkParams={{array 'vault.cluster.secrets.backend.show' model.id}}
+    @queryParams={{hash version=list.item.version}}
+  as |Item|>
     <Item.content>
       <div class="columns is-flex-1">
         <div>

--- a/ui/lib/core/addon/components/linked-block.js
+++ b/ui/lib/core/addon/components/linked-block.js
@@ -3,6 +3,28 @@ import Component from '@ember/component';
 import hbs from 'htmlbars-inline-precompile';
 import { encodePath } from 'vault/utils/path-encoding-helpers';
 
+/**
+ * @module LinkedBlock
+ * LinkedBlock components are linkable divs that yield any content nested within them. They are often used in list views such as when listing the secret engines.
+ *
+ * @example
+ * ```js
+ * <LinkedBlock
+ *  @params={{array 'vault.cluster.secrets.backend.show 'my-secret-path'}}
+ *  @queryParams={{hash version=1}}
+ *  @class="list-item-row"
+ *  data-test-list-item-link
+ *  >
+ * // Use any wrapped content here
+ * </LinkedBlock>
+ * ```
+ *
+ * @param {Array} params=null - These are values sent to the router's transitionTo method.  First item is route, second is the optional path.
+ * @param {Object} [queryParams=null] - queryParams can be passed via this property. It needs to be an object.
+ * @param {String} [linkPrefix=null] - Overwrite the params with custom route.  See KMIP.
+ * @param {Boolean} [encode=false] - Encode the path.
+ */
+
 let LinkedBlockComponent = Component.extend({
   router: service(),
 

--- a/ui/lib/core/addon/components/list-item.js
+++ b/ui/lib/core/addon/components/list-item.js
@@ -8,6 +8,7 @@ export default Component.extend({
   flashMessages: service(),
   tagName: '',
   linkParams: null,
+  queryParams: null,
   componentName: null,
   hasMenu: true,
 

--- a/ui/lib/core/addon/templates/components/list-item.hbs
+++ b/ui/lib/core/addon/templates/components/list-item.hbs
@@ -1,7 +1,13 @@
 {{#if componentName}}
   {{component componentName item=item}}
 {{else if linkParams}}
-  <LinkedBlock @params={{linkParams}} @linkPrefix={{@linkPrefix}} @class="list-item-row" data-test-list-item-link>
+  <LinkedBlock 
+    @params={{linkParams}}
+    @queryParams={{@queryParams}}
+    @linkPrefix={{@linkPrefix}}
+    @class="list-item-row"
+    data-test-list-item-link
+  >
     <div class="level is-mobile">
       <div class="level-left is-flex-1" data-test-list-item-content>
         {{#link-to params=linkParams class="has-text-weight-semibold has-text-black is-display-flex is-flex-1 is-no-underline"}}

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -133,6 +133,7 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     await click('.linked-block');
     await settled();
     let secret = document.querySelector('[data-test-masked-input]').innerText;
+    await settled();
     assert.equal(secret, 'bar', 'renders secret on the secret version show page');
     assert.equal(
       currentURL(),

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -124,7 +124,7 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     await click('[data-test-popup-menu-trigger="version"]');
     await settled();
     await click('[data-test-version-history]');
-
+    await settled();
     assert
       .dom('[data-test-list-item-content]')
       .hasText('Version 1 Current', 'shows version one data on the version history as current');
@@ -132,9 +132,8 @@ module('Acceptance | secrets/secret/create', function(hooks) {
 
     await click('.linked-block');
     await settled();
-    let secret = document.querySelector('[data-test-masked-input]').innerText;
     await settled();
-    assert.equal(secret, 'bar', 'renders secret on the secret version show page');
+    assert.dom('[data-test-masked-input]').hasText('bar', 'renders secret on the secret version show page');
     assert.equal(
       currentURL(),
       `/vault/secrets/secret/show/${path}?version=1`,


### PR DESCRIPTION
**The bug:** Originally `versions.hbs` was calling the component `ListItem` (which passes params through to LinkedBlock) using an ember helper `query-params`.  However, there appear to be some issues with this helper—[see the issue here](https://github.com/emberjs/ember.js/issues/18076). (As an aside I could not find solid Ember documentation on this helper and suspect though we use it in other places in the app, it's not something we should continue to use). Because of this, the actual query param `?version=X` was not be amended onto the params object that made its way [here](https://github.com/hashicorp/vault/pull/12079/files#diff-f1543c5c355e7974c72abe2ca53e3c37a747a2cfc8ad130cf8b7eb92c52df8f9R66). Thus the `transitionTo` method was borked.

**How I fixed it:** The `LinkedBlock` component was previously setup to handle `queryParams` by passing in the object directly. We followed this pattern and it fixed the bug. Additionally, I added test coverage and documentation on LinkedBlock so it would be a little easier to understand how to use it.

**Bug before** _to reproduce you have to click on the linkedblock. there is another nested link in the block that works. to hit it, just click on the edges of the block, away from the text._
![broken](https://user-images.githubusercontent.com/6618863/125687056-c6b5446c-e3bb-45f5-bad4-6ace7f0a6a67.gif)


**Fixed bug**
![fixed](https://user-images.githubusercontent.com/6618863/125687595-a02780ac-ef5c-4953-b5cb-6db6674e30be.gif)

