### PR TITLE
Revert #12061 due to failures in TestLogical_RequestSizeLimit

### DIFF
--- a/api/response.go
+++ b/api/response.go
@@ -41,14 +41,12 @@ func (r *Response) Error() error {
 
 	r.Body.Close()
 	r.Body = ioutil.NopCloser(bodyBuf)
-	ns := r.Header.Get("X-Vault-Namespace")
 
 	// Build up the error object
 	respErr := &ResponseError{
-		HTTPMethod:    r.Request.Method,
-		URL:           r.Request.URL.String(),
-		StatusCode:    r.StatusCode,
-		NamespacePath: ns,
+		HTTPMethod: r.Request.Method,
+		URL:        r.Request.URL.String(),
+		StatusCode: r.StatusCode,
 	}
 
 	// Decode the error response if we can. Note that we wrap the bodyBuf
@@ -94,10 +92,6 @@ type ResponseError struct {
 
 	// Errors are the underlying errors returned by Vault.
 	Errors []string
-
-	// Namespace path to be reported to the client if it is set to anything other
-	// than root
-	NamespacePath string
 }
 
 // Error returns a human-readable error string for the response error.
@@ -107,15 +101,9 @@ func (r *ResponseError) Error() string {
 		errString = "Raw Message"
 	}
 
-	ns := r.NamespacePath
-	if ns != "" && ns != "root" {
-		ns = "Namespace: " + ns + "\n"
-	}
-
 	var errBody bytes.Buffer
 	errBody.WriteString(fmt.Sprintf(
 		"Error making API request.\n\n"+
-			ns+
 			"URL: %s %s\n"+
 			"Code: %d. %s:\n\n",
 		r.HTTPMethod, r.URL, r.StatusCode, errString))

--- a/changelog/12061.txt
+++ b/changelog/12061.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-core (enterprise): namespace header included in responses, Go client uses it when displaying error messages
-```

--- a/http/handler.go
+++ b/http/handler.go
@@ -350,10 +350,7 @@ func wrapGenericHandler(core *vault.Core, h http.Handler, props *vault.HandlerPr
 			return
 		}
 
-		h.ServeHTTP(&logical.NamespaceResponseWriter{
-			ResponseWriter: w,
-			NamespacePath:  r.Header.Get("X-Vault-Namespace"),
-		}, r)
+		h.ServeHTTP(w, r)
 
 		cancelFunc()
 		return

--- a/sdk/logical/response_util.go
+++ b/sdk/logical/response_util.go
@@ -155,17 +155,7 @@ func AdjustErrorStatusCode(status *int, err error) {
 	}
 }
 
-type NamespaceResponseWriter struct {
-	http.ResponseWriter
-	NamespacePath string
-}
-
 func RespondError(w http.ResponseWriter, status int, err error) {
-	nw, ok := w.(*NamespaceResponseWriter)
-	if ok && nw.NamespacePath != "" && nw.NamespacePath != "root" {
-		nw.Header().Set("X-Vault-Namespace", nw.NamespacePath)
-	}
-
 	AdjustErrorStatusCode(&status, err)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2925,12 +2925,7 @@ func (b *SystemBackend) handleMonitor(ctx context.Context, req *logical.Request,
 
 	flusher, ok := w.ResponseWriter.(http.Flusher)
 	if !ok {
-		// Casting the logical.ResponseWriter and try http.Flusher again
-		nw := w.ResponseWriter.(*logical.NamespaceResponseWriter)
-		flusher, ok = nw.ResponseWriter.(http.Flusher)
-		if !ok {
-			return logical.ErrorResponse("streaming not supported"), nil
-		}
+		return logical.ErrorResponse("streaming not supported"), nil
 	}
 
 	isJson := b.Core.LogFormat() == "json"


### PR DESCRIPTION
Example failure: https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/5806/workflows/ceee884a-cc93-4f49-af4c-ec9416896bbd/jobs/217709/tests#failed-test-0

This is reproducible locally, but not if you checkout the commit immediately preceding the merge of #12061.  On this branch that includes the revert, no longer reproducible.  