### PR TITLE
UI/Clarifies error message for exit test process

### DIFF
--- a/ui/scripts/start-vault.js
+++ b/ui/scripts/start-vault.js
@@ -78,9 +78,10 @@ async function processLines(input, eachLine = () => {}) {
         written = true;
         console.log('VAULT SERVER READY');
       } else if (initError) {
-        // If this is happening, run `export VAULT_LICENSE_PATH=/Users/username/license.hclic`
-        // to your valid local vault license filepath, or use OSS Vault
         console.log('VAULT SERVER START FAILED');
+        console.log(
+          'If this is happening, run `export VAULT_LICENSE_PATH=/Users/username/license.hclic` to your valid local vault license filepath, or use OSS Vault'
+        );
         process.exit(1);
       }
     });

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -332,7 +332,7 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     await editPage.visitEdit({ backend, id: 'secret' });
     assert.notOk(editPage.hasMetadataFields, 'hides the metadata form');
     await editPage.editSecret('bar', 'baz');
-
+    await settled();
     assert.equal(currentRouteName(), 'vault.cluster.secrets.backend.show', 'redirects to the show page');
     assert.ok(showPage.editIsPresent, 'shows the edit button');
   });


### PR DESCRIPTION
While running tests, a few of us ran into this error: 
`Error initializing core: license check failed: no autoloaded license provided and storage is not initialized. Licenses can be obtained at https://vaultproject.io/trial`
`VAULT SERVER START FAILED`
`error Command failed with exit code 1.`

It was a little confusing how to debug because it seemed like a backend error. The comments in `start-vault.js` were helpful and solved the problem, so moved those to log in the console to help future developers running into this issue.