### PR TITLE
Backport 1.8.x: secrets/database: fixes external plugin reconnect after shutdown for v4 and v5 interface (#12087)

### DIFF
--- a/builtin/logical/database/backend.go
+++ b/builtin/logical/database/backend.go
@@ -315,7 +315,7 @@ func (b *databaseBackend) clearConnection(name string) error {
 func (b *databaseBackend) CloseIfShutdown(db *dbPluginInstance, err error) {
 	// Plugin has shutdown, close it so next call can reconnect.
 	switch err {
-	case rpc.ErrShutdown, v4.ErrPluginShutdown:
+	case rpc.ErrShutdown, v4.ErrPluginShutdown, v5.ErrPluginShutdown:
 		// Put this in a goroutine so that requests can run with the read or write lock
 		// and simply defer the unlock.  Since we are attaching the instance and matching
 		// the id in the connection map, we can safely do this.

--- a/builtin/logical/database/path_creds_create.go
+++ b/builtin/logical/database/path_creds_create.go
@@ -92,6 +92,7 @@ func (b *databaseBackend) pathCredsCreateRead() framework.OperationFunc {
 
 		password, err := dbi.database.GeneratePassword(ctx, b.System(), dbConfig.PasswordPolicy)
 		if err != nil {
+			b.CloseIfShutdown(dbi, err)
 			return nil, fmt.Errorf("unable to generate password: %w", err)
 		}
 

--- a/changelog/12087.txt
+++ b/changelog/12087.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/database: Fixed an issue that prevented external database plugin processes from restarting after a shutdown.
+```


### PR DESCRIPTION
This PR backports a bug fix from #12087.

The following steps were taken:
1. `git checkout release/1.8.x`
2. `git checkout -b backport-pr-12087-1.8.x`
3. `git cherry-pick 25eba851dcb546aba569c4ad92a6ef657d0de016`