### PR TITLE
Change changelog type for openldap bug fix

### DIFF
--- a/changelog/12019.txt
+++ b/changelog/12019.txt
@@ -1,3 +1,3 @@
-```release-note:bug-fix
+```release-note:bug
 secrets/openldap: Fix bug where schema was not compatible with rotate-root [#24](https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/24)
 ```


### PR DESCRIPTION
The type was incorrect for this changelog entry and should be `bug`.