### PR TITLE
fix: print consul svc addr in debug log

### DIFF
--- a/changelog/12115.txt
+++ b/changelog/12115.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+service_registration/consul: Print config service_address set in DEBUG log
+```

--- a/serviceregistration/consul/consul_service_registration.go
+++ b/serviceregistration/consul/consul_service_registration.go
@@ -120,7 +120,7 @@ func NewServiceRegistration(conf map[string]string, logger log.Logger, state sr.
 		serviceAddr = &serviceAddrStr
 	}
 	if logger.IsDebug() {
-		logger.Debug("config service_address set", "service_address", serviceAddr)
+		logger.Debug("config service_address set", "service_address", serviceAddrStr)
 	}
 
 	checkTimeout := defaultCheckTimeout


### PR DESCRIPTION
Seems like a typo; noticed this today:

```
vault_1  | 2021-07-16T23:32:30.685Z [DEBUG] service_registration.consul: config disable_registration set: disable_registration=false
vault_1  | 2021-07-16T23:32:30.685Z [DEBUG] service_registration.consul: config service set: service=vault
vault_1  | 2021-07-16T23:32:30.685Z [DEBUG] service_registration.consul: config service_tags set: service_tags=""
vault_1  | 2021-07-16T23:32:30.685Z [DEBUG] service_registration.consul: config service_address set: service_address=0xc00087ca00
```

Pretty low-priority, but someone always complains eventually. 🙂