### PR TITLE
Backport 1.8.x: changelog: update feature formatting for gcp and key management secrets (#12120)

### DIFF
--- a/changelog/11958.txt
+++ b/changelog/11958.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-secrets/keymgmt (enterprise): Adds general availability for distributing and managing keys in AWS KMS.
+**Key Management Secrets Engine (Enterprise)**: Adds general availability for distributing and managing keys in AWS KMS.
 ```

--- a/changelog/12023.txt
+++ b/changelog/12023.txt
@@ -1,8 +1,9 @@
 ```release-note:feature
-secrets/gcp: Adds ability to use existing service accounts for generation of service account keys and access tokens.
+**GCP Secrets Engine Static Accounts**: Adds ability to use existing service accounts for generation
+of service account keys and access tokens.
 ```
 
 ```release-note:deprecation
-secrets/gcp: Deprecated the `/gcp/token/:roleset` and `/gcp/key/:roleset` paths for generating secrets for rolesets.
-Use `/gcp/roleset/:roleset/token` and `/gcp/roleset/:roleset/key` instead.
+secrets/gcp: Deprecated the `/gcp/token/:roleset` and `/gcp/key/:roleset` paths for generating
+secrets for rolesets. Use `/gcp/roleset/:roleset/token` and `/gcp/roleset/:roleset/key` instead.
 ```


### PR DESCRIPTION
This PR backports #12120 to update changelog entry formatting for 1.8 features.