### PR TITLE
 Change version checks (version.isOSS, version.isEnterprise) to hasFeature

### DIFF
--- a/changelog/12133.txt
+++ b/changelog/12133.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Changes relevant version checks from isOSS/isEnterprise to hasFeature
+```

--- a/ui/app/adapters/cluster.js
+++ b/ui/app/adapters/cluster.js
@@ -42,7 +42,7 @@ export default ApplicationAdapter.extend({
       health: this.health(),
       sealStatus: this.sealStatus().catch(e => e),
     };
-    if (this.version.isEnterprise && this.namespaceService.inRootNamespace) {
+    if (this.version.hasNamespaces && this.namespaceService.inRootNamespace) {
       fetches.replicationStatus = this.replicationStatus().catch(e => e);
     }
     return hash(fetches).then(({ health, sealStatus, replicationStatus }) => {

--- a/ui/app/routes/vault/cluster/policies/index.js
+++ b/ui/app/routes/vault/cluster/policies/index.js
@@ -14,7 +14,10 @@ export default Route.extend(ClusterRoute, ListRoute, {
   },
 
   shouldReturnEmptyModel(policyType, version) {
-    return policyType !== 'acl' && (version.get('isOSS') || !version.get('hasSentinel'));
+    if (policyType === 'acl') {
+      return false;
+    }
+    return !version.hasSentinel;
   },
 
   model(params) {

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -84,7 +84,7 @@ export default Service.extend({
   checkForControlGroup(callbackArgs, response, wasWrapTTLRequested) {
     let creationPath = response && response?.wrap_info?.creation_path;
     if (
-      this.version?.hasControlGroups ||
+      !this.version?.hasControlGroups ||
       wasWrapTTLRequested ||
       !response ||
       (creationPath && WRAPPED_RESPONSE_PATHS.includes(creationPath)) ||

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -84,7 +84,7 @@ export default Service.extend({
   checkForControlGroup(callbackArgs, response, wasWrapTTLRequested) {
     let creationPath = response && response?.wrap_info?.creation_path;
     if (
-      !this.version.hasControlGroups ||
+      this.version.isOSS ||
       wasWrapTTLRequested ||
       !response ||
       (creationPath && WRAPPED_RESPONSE_PATHS.includes(creationPath)) ||

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -84,7 +84,7 @@ export default Service.extend({
   checkForControlGroup(callbackArgs, response, wasWrapTTLRequested) {
     let creationPath = response && response?.wrap_info?.creation_path;
     if (
-      this.version.isOSS ||
+      this.version?.hasControlGroups ||
       wasWrapTTLRequested ||
       !response ||
       (creationPath && WRAPPED_RESPONSE_PATHS.includes(creationPath)) ||

--- a/ui/app/services/control-group.js
+++ b/ui/app/services/control-group.js
@@ -84,7 +84,7 @@ export default Service.extend({
   checkForControlGroup(callbackArgs, response, wasWrapTTLRequested) {
     let creationPath = response && response?.wrap_info?.creation_path;
     if (
-      this.version.isOSS ||
+      !this.version.hasControlGroups ||
       wasWrapTTLRequested ||
       !response ||
       (creationPath && WRAPPED_RESPONSE_PATHS.includes(creationPath)) ||
@@ -102,7 +102,7 @@ export default Service.extend({
     transitionTo.paramNames.map(name => {
       let param = transitionTo.params[name];
       if (param.length) {
-        // push on to the front of the array since were're started at the end
+        // push on to the front of the array since we started at the end
         returnedParams.unshift(param);
       }
     });

--- a/ui/app/services/version.js
+++ b/ui/app/services/version.js
@@ -27,6 +27,7 @@ export default Service.extend({
 
   hasSentinel: hasFeature('Sentinel'),
   hasNamespaces: hasFeature('Namespaces'),
+  hasControlGroups: hasFeature('Control Groups'),
 
   isEnterprise: match('version', /\+.+$/),
 

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -405,6 +405,7 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     let url = `/vault/secrets/${backend}/list`;
     await visit(url);
     await click('[data-test-secret-link="secret"]');
+    await settled();
     assert.dom('[data-test-component="empty-state"]').exists('secret has been deleted');
     assert.dom('[data-test-secret-undelete]').exists('undelete button shows');
   });

--- a/ui/tests/unit/adapters/aws-credential-test.js
+++ b/ui/tests/unit/adapters/aws-credential-test.js
@@ -74,8 +74,6 @@ module('Unit | Adapter | aws credential', function(hooks) {
       let { method, url, requestBody } = this.server.handledRequests[0];
       assert.equal(url, '/v1/aws/creds/foo', `calls the correct url`);
       assert.equal(method, expectedMethod, `${description} uses the correct http verb: ${expectedMethod}`);
-      console.log({ requestBody });
-      console.log({ expectedRequestBody });
       assert.equal(requestBody, JSON.stringify(expectedRequestBody));
     });
   });

--- a/ui/tests/unit/adapters/aws-credential-test.js
+++ b/ui/tests/unit/adapters/aws-credential-test.js
@@ -74,6 +74,8 @@ module('Unit | Adapter | aws credential', function(hooks) {
       let { method, url, requestBody } = this.server.handledRequests[0];
       assert.equal(url, '/v1/aws/creds/foo', `calls the correct url`);
       assert.equal(method, expectedMethod, `${description} uses the correct http verb: ${expectedMethod}`);
+      console.log({ requestBody });
+      console.log({ expectedRequestBody });
       assert.equal(requestBody, JSON.stringify(expectedRequestBody));
     });
   });

--- a/ui/tests/unit/services/control-group-test.js
+++ b/ui/tests/unit/services/control-group-test.js
@@ -46,8 +46,8 @@ module('Unit | Service | control group', function(hooks) {
 
   hooks.afterEach(function() {});
 
-  let isOSS = context => set(context, 'version.isOSS', true);
-  let isEnt = context => set(context, 'version.isOSS', false);
+  let isOSS = context => set(context, 'version.hasControlGroups', false);
+  let isEnt = context => set(context, 'version.hasControlGroups', true);
   let resolvesArgs = (assert, result, expectedArgs) => {
     return result.then((...args) => {
       return assert.deepEqual(args, expectedArgs, 'resolves with the passed args');
@@ -56,31 +56,31 @@ module('Unit | Service | control group', function(hooks) {
 
   [
     [
-      'it resolves isOSS:true, wrapTTL: true, response: has wrap_info',
+      'it resolves hasControlGroups:false, wrapTTL:true, response: has wrap_info',
       isOSS,
       [[{ one: 'two', three: 'four' }], { wrap_info: { token: 'foo', accessor: 'bar' } }, true],
       (assert, result) => resolvesArgs(assert, result, [{ one: 'two', three: 'four' }]),
     ],
     [
-      'it resolves isOSS:true, wrapTTL: false, response: has no wrap_info',
+      'it resolves hasControlGroups:false, wrapTTL:false, response: has no wrap_info',
       isOSS,
       [[{ one: 'two', three: 'four' }], { wrap_info: null }, false],
       (assert, result) => resolvesArgs(assert, result, [{ one: 'two', three: 'four' }]),
     ],
     [
-      'it resolves isOSS: false and wrapTTL:true response: has wrap_info',
+      'it resolves hasControlGroups:true and wrapTTL:true response: has wrap_info',
       isEnt,
       [[{ one: 'two', three: 'four' }], { wrap_info: { token: 'foo', accessor: 'bar' } }, true],
       (assert, result) => resolvesArgs(assert, result, [{ one: 'two', three: 'four' }]),
     ],
     [
-      'it resolves isOSS: false and wrapTTL:false response: has no wrap_info',
+      'it resolves hasControlGroups:true and wrapTTL:false response: has no wrap_info',
       isEnt,
       [[{ one: 'two', three: 'four' }], { wrap_info: null }, false],
       (assert, result) => resolvesArgs(assert, result, [{ one: 'two', three: 'four' }]),
     ],
     [
-      'it rejects isOSS: false, wrapTTL:false, response: has wrap_info',
+      'it rejects hasControlGroups:true, wrapTTL:false, response: has wrap_info',
       isEnt,
       [
         [{ one: 'two', three: 'four' }],

--- a/ui/tests/unit/services/version-test.js
+++ b/ui/tests/unit/services/version-test.js
@@ -38,4 +38,11 @@ module('Unit | Service | version', function(hooks) {
     service.set('_features', ['DR Replication']);
     assert.equal(service.get('hasDRReplication'), true);
   });
+
+  test('hasControlGroups', function(assert) {
+    let service = this.owner.lookup('service:version');
+    assert.equal(service.get('hasControlGroups'), false);
+    service.set('_features', ['Control Groups']);
+    assert.equal(service.get('hasControlGroups'), true);
+  });
 });


### PR DESCRIPTION
Replaces `isEnterprise` and `isOSS` with more specific `hasFeature` conditionals now that Vault has switched to feature-based pricing which is dependent on a users' license not edition (OSS, Enterprise Pro, Enterprise Premium).