### PR TITLE
Document timeout setting for raft snapshots

### DIFF
--- a/website/content/api-docs/system/storage/raft.mdx
+++ b/website/content/api-docs/system/storage/raft.mdx
@@ -171,6 +171,8 @@ Unavailable if Raft is used exclusively for `ha_storage`.
 | :----- | :--------------------------- |
 | `GET`  | `/sys/storage/raft/snapshot` |
 
+@include 'raft-large-snapshots.mdx'
+
 ### Sample Request
 
 ```shell-session
@@ -188,6 +190,8 @@ it. Unavailable if Raft is used exclusively for `ha_storage`.
 | Method | Path                         |
 | :----- | :--------------------------- |
 | `POST` | `/sys/storage/raft/snapshot` |
+
+@include 'raft-large-snapshots.mdx'
 
 ### Sample Request
 

--- a/website/content/partials/raft-large-snapshots.mdx
+++ b/website/content/partials/raft-large-snapshots.mdx
@@ -2,5 +2,5 @@
 
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
-[`VAULT_CLIENT_TIMEOUT`](commands#vault_client_timeout) environment variable can
+[`VAULT_CLIENT_TIMEOUT`](/docs/commands#vault_client_timeout) environment variable can
 be used to allow for more time to take or restore a snapshot.

--- a/website/content/partials/raft-large-snapshots.mdx
+++ b/website/content/partials/raft-large-snapshots.mdx
@@ -1,0 +1,6 @@
+### Large Raft Snapshots
+
+Taking and restoring Raft snapshots can exceed Vault's default and recommended
+timeout settings. The
+[`VAULT_CLIENT_TIMEOUT`](commands#vault_client_timeout) environment variable can
+be used to allow for more time to take or restore a snapshot.


### PR DESCRIPTION
We don't usually put this kind of information in the documentation, but
we are aware that snapshots can be slow and I could see this message
saving someone a lot of time. Open to closing this PR though if we
definitely don't want this kind of documentation.