### PR TITLE
Re-adding deleted changelog note

### DIFF
--- a/changelog/_2021Jul21_license.txt
+++ b/changelog/_2021Jul21_license.txt
@@ -1,0 +1,3 @@
+```release-note:changes
+core: License/EULA changes that ensure the presence of a valid HashiCorp license to start Vault. More information is available in the [Vault License FAQ](https://www.vaultproject.io/docs/enterprise/license/faqs)
+```


### PR DESCRIPTION
@kalafut I'm adding this back in - I think it will show up in the 1.8 changelog if you generate the changelog from the 1.8 branch, but I don't want to add the file in `main` now.

If we decide we don't need this note though I'm happy to close this PR.