### PR TITLE
[VAULT-2678] Fix: LDAP case_sensitive_names not normalizing to lowercase when false

### DIFF
--- a/builtin/credential/ldap/backend.go
+++ b/builtin/credential/ldap/backend.go
@@ -141,6 +141,9 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username stri
 		defer c.Close() // Defer closing of this connection as the deferal above closes the other defined connection
 	}
 
+	if !*cfg.CaseSensitiveNames {
+		username = strings.ToLower(username)
+	}
 	ldapGroups, err := ldapClient.GetLdapGroups(cfg.ConfigEntry, c, userDN, username)
 	if err != nil {
 		return nil, logical.ErrorResponse(err.Error()), nil, nil

--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -261,6 +261,17 @@ func TestLdapAuthBackend_CaseSensitivity(t *testing.T) {
 		if !reflect.DeepEqual(expected, resp.Auth.Policies) {
 			t.Fatalf("bad: policies: expected: %q, actual: %q", expected, resp.Auth.Policies)
 		}
+
+		switch caseSensitive {
+		case false:
+			if !(resp.Auth.Alias.Name == "hermes conrad") {
+				t.Fatalf("expected normalized username; got %s", resp.Auth.Alias.Name)
+			}
+		default:
+			if resp.Auth.Alias.Name == "hermes conrad" {
+				t.Fatalf("expected capitalized username; got normalized username")
+			}
+		}
 	}
 
 	cleanup, cfg := ldap.PrepareTestContainer(t, "latest")

--- a/builtin/credential/ldap/path_login.go
+++ b/builtin/credential/ldap/path_login.go
@@ -3,6 +3,7 @@ package ldap
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
@@ -85,6 +86,11 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 		}
 	} else {
 		resp = &logical.Response{}
+	}
+
+	// Confirm this behavior is expected
+	if !*cfg.CaseSensitiveNames {
+		username = strings.ToLower(username)
 	}
 
 	auth := &logical.Auth{

--- a/builtin/credential/ldap/path_login.go
+++ b/builtin/credential/ldap/path_login.go
@@ -37,11 +37,22 @@ func pathLogin(b *backend) *framework.Path {
 }
 
 func (b *backend) pathLoginAliasLookahead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	cfg, err := b.Config(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		return logical.ErrorResponse("auth method not configured"), nil
+	}
+
 	username := d.Get("username").(string)
 	if username == "" {
 		return nil, fmt.Errorf("missing username")
 	}
 
+	if !*cfg.CaseSensitiveNames {
+		username = strings.ToLower(username)
+	}
 	return &logical.Response{
 		Auth: &logical.Auth{
 			Alias: &logical.Alias{

--- a/changelog/12142.txt
+++ b/changelog/12142.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/ldap: Normalize usernames when `case_sensitive_names` is false
+```


### PR DESCRIPTION
This PR fixes a bug in the LDAP auth engine regarding uppercased username logins not being able to access secrets even though the `case_sensitive_names` config variable is `false`. The uppercased usernames are now assigned the appropriate groups and policies.