### PR TITLE
website: fix release notes link

### DIFF
--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -50,7 +50,7 @@ export default function DownloadsPage(staticProps) {
           <MerchandisingSlot />
           <p className={s.releaseNote}>
             Release notes are available in our{' '}
-            <Link href={`/docs/release-notes/${VERSION}`}>
+            <Link href={`/docs/release-notes`}>
               <a>documentation</a>
             </Link>
             .


### PR DESCRIPTION
Remove the version from the release notes link on the downloads page as we only have release notes for non-patch releases. It appears that this was the behavior prior to rolling out the new downloads page, and this is likely more robust than a potentially dead link.