### PR TITLE
docs/update replication seal table

### DIFF
--- a/website/content/docs/enterprise/replication.mdx
+++ b/website/content/docs/enterprise/replication.mdx
@@ -99,7 +99,7 @@ keys will be replaced. Here seal/recovery configuration means the number of
 seal/recovery key fragments and the required threshold of those
 fragments.
 
-| Primary seal | Secondary seal (before) | Secondary Seal (after)                 | Secondary Recovery Key (after) | Impact on secondary of enabling replication                                 |
+| Primary Seal | Secondary Seal (before) | Secondary Seal (after)                 | Secondary Recovery Key (after) | Impact on Secondary of Enabling Replication                                 |
 |--------------|-------------------------|----------------------------------------|--------------------------------|-----------------------------------------------------------------------------|
 | Shamir       | Shamir                  | Primary's shamir config & unseal keys  | N/A                            | Seal config and unseal keys replaced with primary's                         |
 | Shamir       | Auto                    | Unchanged                              | Receives primary seal          | Seal recovery config and keys replaced with primary's seal config and keys  |

--- a/website/content/docs/enterprise/replication.mdx
+++ b/website/content/docs/enterprise/replication.mdx
@@ -99,12 +99,14 @@ keys will be replaced. Here seal/recovery configuration means the number of
 seal/recovery key fragments and the required threshold of those
 fragments.
 
-| Primary seal | Secondary seal | Impact on secondary of enabling replication                                                |
-| ------------ | -------------- | ------------------------------------------------------------------------------------------ |
-| Shamir       | Shamir         | Seal config and unseal keys replaced with primary's                                        |
-| Shamir       | Auto           | Seal recovery config and recovery keys replaced with primary's seal config and unseal keys |
-| Auto         | Auto           | Seal recovery config and recovery keys replaced with primary's                             |
-| Auto         | Shamir         | Seal config and unseal keys replaced with primary's recovery seal config and recovery keys |
+| Primary seal | Secondary seal (before) | Secondary Seal (after)                 | Secondary Recovery Key (after) | Impact on secondary of enabling replication                                 |
+|--------------|-------------------------|----------------------------------------|--------------------------------|-----------------------------------------------------------------------------|
+| Shamir       | Shamir                  | Primary's shamir config & unseal keys  | N/A                            | Seal config and unseal keys replaced with primary's                         |
+| Shamir       | Auto                    | Unchanged                              | Receives primary seal          | Seal recovery config and keys replaced with primary's seal config and keys  |
+| Auto         | Auto                    | Unchanged                              | Receives primary recovery      | Seal recovery config and recovery keys replaced with primary's              |
+| Auto         | Shamir                  | Receives primary recovery              | N/A                            | Seal config and keys replaced with primary's recovery seal config and keys  |
+
+Note: Clusters with Shamir seal config do not have separate recovery keys. Auto includes HSM, Cloud KMS, and Transit auto-unseal.
 
 ### Vault versions
 


### PR DESCRIPTION
This PR expands the table explaining how performance replica seal/recovery configs are automatically updated when a secondary is joined to a primary.  The additional information makes it easier for readers who are new to Vault to distinguish between Shamir unseal keys and auto-unseal recovery keys.