### PR TITLE
Disable "you won't be able to access these later" warning for static DB creds

### DIFF
--- a/ui/app/templates/components/generate-credentials-database.hbs
+++ b/ui/app/templates/components/generate-credentials-database.hbs
@@ -42,13 +42,13 @@
       </nav>
     </EmptyState>
   {{/unless}}
-  {{#unless (or @model.errorMessage (not @roleType))}}
+  {{#if (and (not @model.errorMessage) (eq @roleType 'dynamic'))}}
     <AlertBanner
       @type="warning"
       @message="You will not be able to access these credentials later, so please copy them now."
       data-test-warning
     />
-  {{/unless}}
+  {{/if}}
   {{!-- DYNAMIC ROLE --}}
   {{#if (and (eq @roleType 'dynamic') @model.username)}}
     <InfoTableRow @label="Username" @value={{@model.username}}>


### PR DESCRIPTION
When accessing credentials for a static database role, a warning message incorrectly states that "You will not be able to access these credentials later". This message should only be shown for dynamic database roles.

![2021-07-22 09-40-40 (1)](https://user-images.githubusercontent.com/15101831/126609581-985bbb6c-baeb-44d9-97ce-8050dcd5307b.gif)
 