### PR TITLE
serviceregistration: add external-source meta value

### DIFF
--- a/changelog/12163.txt
+++ b/changelog/12163.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+serviceregistration: add `external-source: "vault"` metadata value for Consul registration.
+```

--- a/serviceregistration/consul/consul_service_registration.go
+++ b/serviceregistration/consul/consul_service_registration.go
@@ -49,6 +49,10 @@ const (
 	// reconcileTimeout is how often Vault should query Consul to detect
 	// and fix any state drift.
 	reconcileTimeout = 60 * time.Second
+
+	// metaExternalSource is a metadata value for external-source that can be
+	// used by the Consul UI.
+	metaExternalSource = "vault"
 )
 
 var hostnameRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
@@ -503,6 +507,9 @@ func (c *serviceRegistration) reconcileConsul(registeredServiceID string) (servi
 		Port:              int(c.redirectPort),
 		Address:           serviceAddress,
 		EnableTagOverride: false,
+		Meta: map[string]string{
+			"external-source": metaExternalSource,
+		},
 	}
 
 	checkStatus := api.HealthCritical


### PR DESCRIPTION
Small PR to add a new `Meta` KV pair for `external-source: vault`. This allows the Consul UI to signal that the service registered by Vault came from Vault.