### PR TITLE
Removes grey shadow/line beneath secret form key/value input fields

### DIFF
--- a/ui/app/styles/components/info-table-row.scss
+++ b/ui/app/styles/components/info-table-row.scss
@@ -2,6 +2,10 @@
   box-shadow: 0 1px 0 $grey-light;
   margin: 0;
 
+  &.has-no-shadow {
+    box-shadow: none;
+  }
+
   @include from($tablet) {
     display: flex;
   }

--- a/ui/app/templates/components/secret-edit-display.hbs
+++ b/ui/app/templates/components/secret-edit-display.hbs
@@ -59,7 +59,7 @@
       {{/if}}
     </label>
   {{#each @secretData as |secret index|}}
-    <div class="info-table-row">
+    <div class="info-table-row has-no-shadow">
       <div class="column is-one-quarter info-table-row-edit">
         <Input 
           data-test-secret-key={{true}}


### PR DESCRIPTION
**Previously a grey line displayed beneath each input field.** 
<img width="1085" alt="Screen Shot 2021-07-23 at 5 07 13 PM" src="https://user-images.githubusercontent.com/68122737/126851470-7b66ffa3-d358-42b7-afea-4d7b7c35aa1c.png">

**No longer shows line**
<img width="1085" alt="Screen Shot 2021-07-23 at 5 06 38 PM" src="https://user-images.githubusercontent.com/68122737/126851450-36aeb4f6-3f5c-4a14-8b03-9a705032f441.png">
