### PR TITLE
Pin RabbitMQ and Cassandra docker image versions

### DIFF
--- a/builtin/logical/rabbitmq/backend_test.go
+++ b/builtin/logical/rabbitmq/backend_test.go
@@ -37,7 +37,7 @@ func prepareRabbitMQTestContainer(t *testing.T) (func(), string) {
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ImageRepo:     "rabbitmq",
-		ImageTag:      "3-management",
+		ImageTag:      "3.8-management",
 		ContainerName: "rabbitmq",
 		Ports:         []string{"15672/tcp"},
 	})

--- a/plugins/database/cassandra/cassandra_test.go
+++ b/plugins/database/cassandra/cassandra_test.go
@@ -139,7 +139,7 @@ func TestCreateUser(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			host, cleanup := cassandra.PrepareTestContainer(t,
-				cassandra.Version("latest"),
+				cassandra.Version("3.11"),
 				cassandra.CopyFromTo(insecureFileMounts),
 			)
 			defer cleanup()

--- a/plugins/database/cassandra/cassandra_test.go
+++ b/plugins/database/cassandra/cassandra_test.go
@@ -17,7 +17,7 @@ import (
 
 func getCassandra(t *testing.T, protocolVersion interface{}) (*Cassandra, func()) {
 	host, cleanup := cassandra.PrepareTestContainer(t,
-		cassandra.Version("latest"),
+		cassandra.Version("3.11"),
 		cassandra.CopyFromTo(insecureFileMounts),
 	)
 


### PR DESCRIPTION
Works around a rabbitmq regression in v3.9 with UserInfo.Tags; looks like they're now returning a string array into of a string?

This should fix these test failures:

https://app.circleci.com/pipelines/github/hashicorp/vault/19403/workflows/6758dc1c-b540-44f3-b4d5-0dae53366f32/jobs/251152/tests#failed-test-3

With the above changes I was seeing unrelated failures in Cassandra: looks like they came out with a 4.0.0 docker image just 7 hours ago.  

Failures: https://app.circleci.com/pipelines/github/hashicorp/vault/19404/workflows/206773e4-f72f-44fa-86dc-ac88ff6329bf/jobs/251201

So now I'm pinning Cassandra to 3.11 in this PR, in addition to pinning RabbitMQ 3.8.

Presumably we'll still need to make changes to Vault to support newer RabbitMQ/Cassandra versions.