### PR TITLE
Match KV key value to kv-object-editor component

### DIFF
--- a/ui/app/styles/core/forms.scss
+++ b/ui/app/styles/core/forms.scss
@@ -13,7 +13,6 @@ label {
 
 .masked-font {
   font-family: obscure, text-security-square;
-  font-size: $size-medium;
   letter-spacing: 2px;
 }
 

--- a/ui/app/templates/components/kv-object-editor.hbs
+++ b/ui/app/templates/components/kv-object-editor.hbs
@@ -9,7 +9,7 @@
   </label>
 {{/if}}
 {{#each kvData as |row index|}}
-  <div class="columns is-variable is-1" data-test-kv-row>
+  <div class="columns is-variable" data-test-kv-row>
     <div class="column is-one-quarter">
       <Input data-test-kv-key={{true}} @value={{row.name}} placeholder="key" @change={{action "updateRow" row index}} class="input" />
     </div>

--- a/ui/app/templates/components/secret-edit-display.hbs
+++ b/ui/app/templates/components/secret-edit-display.hbs
@@ -59,7 +59,7 @@
       {{/if}}
     </label>
   {{#each @secretData as |secret index|}}
-    <div class="columns is-variable is-1 has-no-shadow">
+    <div class="columns is-variable has-no-shadow">
       <div class="column is-one-quarter ">
         <Input 
           data-test-secret-key={{true}}

--- a/ui/app/templates/components/secret-edit-display.hbs
+++ b/ui/app/templates/components/secret-edit-display.hbs
@@ -59,8 +59,8 @@
       {{/if}}
     </label>
   {{#each @secretData as |secret index|}}
-    <div class="info-table-row has-no-shadow">
-      <div class="column is-one-quarter info-table-row-edit">
+    <div class="columns is-variable is-1 has-no-shadow">
+      <div class="column is-one-quarter ">
         <Input 
           data-test-secret-key={{true}}
           @value={{secret.name}}
@@ -72,7 +72,7 @@
           {{on "keyup" (fn @onKeyUp "key" secret.name)}}
         />
       </div>
-      <div class="column info-table-row-edit">
+      <div class="column">
         <MaskedInput
           @name={{secret.name}}
           @onKeyDown={{@editActions.handleKeyDown}}
@@ -81,7 +81,7 @@
           data-test-secret-value="true"
         />
       </div>
-      <div class="column is-narrow info-table-row-edit">
+      <div class="column is-narrow ">
         {{#if (eq @secretData.length (inc index))}}
           <button type="button" {{action @editActions.addRow}} class="button is-outlined is-primary" data-test-secret-add-row="true">
             Add


### PR DESCRIPTION
While working on the kv custom metadata project we realized the kv-object-editor component and the kv key value inputs did not match. This pr matches their styling while keeping their functionality separate.

This matters because in the kv custom metadata project we will have both components on the page. Confirmed with design that the styles should match the gap space of the kv key value.

**New kv-object-editor look.**
![image](https://user-images.githubusercontent.com/6618863/127203844-8d3e805a-6e4d-4493-80bd-b270c475388d.png)

**Matches with the kv key value.**
![image](https://user-images.githubusercontent.com/6618863/127203759-33bd6559-5824-4ab0-a883-e3e0d696b865.png)

**Notes:**
I considered moving the secret key value fields into FormFields and using the kv-object-editor component. However, Form Fields works beacuse of model properties. KV key value are not set on the model but instead created in the component under the value secretData. TLDR: it's complicated to mix when we're only concerned with the styles not matching.