### PR TITLE
builtin/credential/cert: fix dropped test error

### DIFF
--- a/builtin/credential/cert/backend_test.go
+++ b/builtin/credential/cert/backend_test.go
@@ -1377,6 +1377,9 @@ func TestBackend_validCIDR(t *testing.T) {
 	}
 
 	readResult, err := b.HandleRequest(context.Background(), readCertReq)
+	if err != nil {
+		t.Fatal(err)
+	}
 	cidrsResult := readResult.Data["bound_cidrs"].([]*sockaddr.SockAddrMarshaler)
 
 	if cidrsResult[0].String() != boundCIDRs[0] ||


### PR DESCRIPTION
This fixes a dropped test error in `builtin/credential/cert`.

Could someone add the no-changelog label?
