### PR TITLE
Set no_output_timeout for build-ui layer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,6 +493,7 @@ jobs:
 
           make -f packages*.lock/layer.mk 06-build-ui-26a986a756dd09ad76b230768f6d889c031d6fea-image
         name: Build build-ui layer
+        no_output_timeout: 15m
     - run:
         command: |2-
 

--- a/.circleci/config/@build-release.yml
+++ b/.circleci/config/@build-release.yml
@@ -157,6 +157,7 @@ jobs:
 
             make -f packages*.lock/layer.mk 06-build-ui-26a986a756dd09ad76b230768f6d889c031d6fea-image
           name: Build build-ui layer
+          no_output_timeout: 15m
       - run:
           command: |2-
 


### PR DESCRIPTION
I added the value at `.circleci/config/@build-release.yml` and then ran `make ci-config` per the instructions in `.circleci/config.yml`. I think it's ok to make the change here directly, rather than updating packagespec, as we plan to migrate vault + vault ENT to CRT within the quarter and remove packagespec. Tagging @sarahethompson for review! Thank you :) 