### PR TITLE
Fixed typo for 'forward' value in relation to caching

### DIFF
--- a/website/content/docs/agent/caching/index.mdx
+++ b/website/content/docs/agent/caching/index.mdx
@@ -209,7 +209,7 @@ page.
   or `"never"`.
 
 - `when_inconsistent` `(string: optional)` - Set to one of `"fail"`, `"retry"`,
-   or `"forward-active_node"`.
+   or `"forward"`.
 
 ### Configuration (Persist)
 

--- a/website/content/docs/enterprise/consistency.mdx
+++ b/website/content/docs/enterprise/consistency.mdx
@@ -192,7 +192,7 @@ The option `when_inconsistent` controls how stale reads are prevented:
 - `"fail"` means that when a `412` response is seen, it is returned to the client
 - `"retry"` means that `412` responses will be retried automatically by Agent,
   so the client doesn't have to deal with them
-- `"forward-active-node"` makes Agent provide the
+- `"forward"` makes Agent provide the
   `X-Vault-Inconsistent: forward-active-node` header as described above under
   Conditional Forwarding
 


### PR DESCRIPTION
Per https://github.com/hashicorp/vault/blob/861454e0ed1390d67ddaf1a53c1798e5e291728c/command/agent.go#L440 the correct value to use should be documented as 'forward' instead of the two current incorrect values.

The value is referenced in the following two URL's:
https://www.vaultproject.io/docs/agent/caching#when_inconsistent
https://www.vaultproject.io/docs/enterprise/consistency#vault-agent-and-consistency-headers