### PR TITLE
Backport 1.8: Pin RabbitMQ and Cassandra docker image versions (#12174)

### DIFF
--- a/builtin/logical/rabbitmq/backend_test.go
+++ b/builtin/logical/rabbitmq/backend_test.go
@@ -37,7 +37,7 @@ func prepareRabbitMQTestContainer(t *testing.T) (func(), string) {
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ImageRepo:     "rabbitmq",
-		ImageTag:      "3-management",
+		ImageTag:      "3.8-management",
 		ContainerName: "rabbitmq",
 		Ports:         []string{"15672/tcp"},
 	})

--- a/plugins/database/cassandra/cassandra_test.go
+++ b/plugins/database/cassandra/cassandra_test.go
@@ -17,7 +17,7 @@ import (
 
 func getCassandra(t *testing.T, protocolVersion interface{}) (*Cassandra, func()) {
 	host, cleanup := cassandra.PrepareTestContainer(t,
-		cassandra.Version("latest"),
+		cassandra.Version("3.11"),
 		cassandra.CopyFromTo(insecureFileMounts),
 	)
 
@@ -139,7 +139,7 @@ func TestCreateUser(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			host, cleanup := cassandra.PrepareTestContainer(t,
-				cassandra.Version("latest"),
+				cassandra.Version("3.11"),
 				cassandra.CopyFromTo(insecureFileMounts),
 			)
 			defer cleanup()


### PR DESCRIPTION
* Work around rabbitmq regression with UserInfo.Tags in rabbitmq 3.9: use v3.8 docker image in tests.

* Also pin cassandra docker image version to 3.11 (4.00 was making tests fail)