### PR TITLE
 UI/TTL helperEnabled/DisabledText fix 

### DIFF
--- a/changelog/12212.txt
+++ b/changelog/12212.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: updating database TTL picker help text.
+```

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -29,14 +29,14 @@ export default Model.extend({
     editType: 'ttl',
     defaultValue: '1h',
     label: 'Generated credentials’s Time-to-Live (TTL)',
-    helperTextDisabled: 'Vault will use a TTL of 1 hour',
+    helperTextDisabled: 'Vault will use a TTL of 1 hour.',
     defaultShown: 'Engine default',
   }),
   max_ttl: attr({
     editType: 'ttl',
     defaultValue: '24h',
     label: 'Generated credentials’s maximum Time-to-Live (Max TTL)',
-    helperTextDisabled: 'Vault will use a TTL of 24 hours',
+    helperTextDisabled: 'Vault will use a TTL of 24 hours.',
     defaultShown: 'Engine default',
   }),
   username: attr('string', {

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -45,7 +45,7 @@ export default Model.extend({
   rotation_period: attr({
     editType: 'ttl',
     defaultValue: '24h',
-    helperTextDisabled:
+    subText:
       'Specifies the amount of time Vault should wait before rotating the password. The minimum is 5 seconds. Default is 24 hours.',
   }),
   creation_statements: attr('array', {

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -45,7 +45,7 @@ export default Model.extend({
   rotation_period: attr({
     editType: 'ttl',
     defaultValue: '24h',
-    subText:
+    helperTextDisabled:
       'Specifies the amount of time Vault should wait before rotating the password. The minimum is 5 seconds. Default is 24 hours.',
   }),
   creation_statements: attr('array', {

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -47,6 +47,7 @@ export default Model.extend({
     defaultValue: '24h',
     helperTextDisabled:
       'Specifies the amount of time Vault should wait before rotating the password. The minimum is 5 seconds. Default is 24 hours.',
+    helperTextEnabled: 'Vault will rotate password after',
   }),
   creation_statements: attr('array', {
     editType: 'stringArray',

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -29,14 +29,14 @@ export default Model.extend({
     editType: 'ttl',
     defaultValue: '1h',
     label: 'Generated credentials’s Time-to-Live (TTL)',
-    subText: 'Vault will use the engine default of 1 hour',
+    helperTextDisabled: 'Vault will use the engine default of 1 hour',
     defaultShown: 'Engine default',
   }),
   max_ttl: attr({
     editType: 'ttl',
     defaultValue: '24h',
     label: 'Generated credentials’s maximum Time-to-Live (Max TTL)',
-    subText: 'Vault will use the engine default of 24 hours',
+    helperTextDisabled: 'Vault will use the engine default of 24 hours',
     defaultShown: 'Engine default',
   }),
   username: attr('string', {

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -29,14 +29,14 @@ export default Model.extend({
     editType: 'ttl',
     defaultValue: '1h',
     label: 'Generated credentials’s Time-to-Live (TTL)',
-    helperTextDisabled: 'Vault will use the engine default of 1 hour',
+    helperTextDisabled: 'Vault will use a TTL of 1 hour',
     defaultShown: 'Engine default',
   }),
   max_ttl: attr({
     editType: 'ttl',
     defaultValue: '24h',
     label: 'Generated credentials’s maximum Time-to-Live (Max TTL)',
-    helperTextDisabled: 'Vault will use the engine default of 24 hours',
+    helperTextDisabled: 'Vault will use a TTL of 24 hours',
     defaultShown: 'Engine default',
   }),
   username: attr('string', {

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -125,7 +125,7 @@
     <TtlPicker2
       @onChange={{action (action "setAndBroadcastTtl" valuePath)}}
       @label={{labelString}}
-      @helperTextDisabled={{or attr.options.helperTextDisabled "Vault will use the system TTL."}}
+      @helperTextDisabled={{or attr.options.helperTextDisabled "Vault will use the default lease duration."}}
       @helperTextEnabled={{or attr.options.helperTextEnabled "Lease will expire after"}}
       @description={{attr.helpText}}
       @initialValue={{or (get model valuePath) attr.options.setDefault}}

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -121,11 +121,12 @@
 {{else if (eq attr.options.editType "ttl")}}
   {{!-- TTL Picker --}}
   <div class="field">
+    {{log attr.options}}
     <TtlPicker2
       @onChange={{action (action "setAndBroadcastTtl" valuePath)}}
       @label={{labelString}}
-      @helperTextDisabled={{or attr.subText "Vault will use the default lease duration"}}
-      @helperTextEnabled={{or attr.subText "Lease will expire after"}}
+      @helperTextDisabled={{or attr.options.helperTextDisabled "Vault will use the system TTL."}}
+      @helperTextEnabled={{or attr.options.helperTextEnabled "Lease will expire after"}}
       @description={{attr.helpText}}
       @initialValue={{or (get model valuePath) attr.options.setDefault}}
     />

--- a/ui/lib/core/addon/templates/components/form-field.hbs
+++ b/ui/lib/core/addon/templates/components/form-field.hbs
@@ -121,7 +121,6 @@
 {{else if (eq attr.options.editType "ttl")}}
   {{!-- TTL Picker --}}
   <div class="field">
-    {{log attr.options}}
     <TtlPicker2
       @onChange={{action (action "setAndBroadcastTtl" valuePath)}}
       @label={{labelString}}

--- a/ui/lib/core/stories/read-more.stories.js
+++ b/ui/lib/core/stories/read-more.stories.js
@@ -9,11 +9,11 @@ storiesOf('ReadMore', module)
     template: hbs`
       <h5 class="title is-5">Read More</h5>
       <h6 class="has-text-grey">NOTE: normally this component has a "See More" button when it truncates text (which is calculated in the .js file). The button is clickable and will expand the height of the outer box (shown here with a black outline).</h6>
-      <div style="width: 500px; border: 1px solid black;">
-        <ReadMore>
-          <strong>Anything can go in here</strong> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam volutpat vulputate lacus sit amet lobortis. Nulla fermentum porta consequat. Mauris porttitor libero nibh, ac facilisis ex molestie non. Nulla dolor est, pharetra et maximus vel, varius eu augue. Maecenas eget nisl convallis, vehicula massa quis, pharetra justo.
-        </ReadMore>
-      </div>
+        <div style="width: 500px; border: 1px solid black;">
+          <ReadMore>
+            <strong>Anything can go in here</strong> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam volutpat vulputate lacus sit amet lobortis. Nulla fermentum porta consequat. Mauris porttitor libero nibh, ac facilisis ex molestie non. Nulla dolor est, pharetra et maximus vel, varius eu augue. Maecenas eget nisl convallis, vehicula massa quis, pharetra justo.
+          </ReadMore>
+        </div>
     `,
     context: {},
   }));

--- a/ui/lib/core/stories/read-more.stories.js
+++ b/ui/lib/core/stories/read-more.stories.js
@@ -9,11 +9,11 @@ storiesOf('ReadMore', module)
     template: hbs`
       <h5 class="title is-5">Read More</h5>
       <h6 class="has-text-grey">NOTE: normally this component has a "See More" button when it truncates text (which is calculated in the .js file). The button is clickable and will expand the height of the outer box (shown here with a black outline).</h6>
-        <div style="width: 500px; border: 1px solid black;">
-          <ReadMore>
-            <strong>Anything can go in here</strong> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam volutpat vulputate lacus sit amet lobortis. Nulla fermentum porta consequat. Mauris porttitor libero nibh, ac facilisis ex molestie non. Nulla dolor est, pharetra et maximus vel, varius eu augue. Maecenas eget nisl convallis, vehicula massa quis, pharetra justo.
-          </ReadMore>
-        </div>
+      <div style="width: 500px; border: 1px solid black;">
+        <ReadMore>
+          <strong>Anything can go in here</strong> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam volutpat vulputate lacus sit amet lobortis. Nulla fermentum porta consequat. Mauris porttitor libero nibh, ac facilisis ex molestie non. Nulla dolor est, pharetra et maximus vel, varius eu augue. Maecenas eget nisl convallis, vehicula massa quis, pharetra justo.
+        </ReadMore>
+      </div>
     `,
     context: {},
   }));


### PR DESCRIPTION
**The UI defaults to generate credentials' TTL and Max-TTL for a role respectively to expire after 1 hr and 24hrs respectively, so this update is to clarify this behavior to customers using the UI by explicitly stating these expiry times.**

 **Old Role Text:**
<img width="455" alt="Screen Shot 2021-07-30 at 2 33 35 PM" src="https://user-images.githubusercontent.com/68122737/127713620-719cfd71-022e-499a-84ba-5e05809b3c5c.png">

---

**New Role Text:**
<img width="490" alt="Screen Shot 2021-07-30 at 2 30 49 PM" src="https://user-images.githubusercontent.com/68122737/127713381-6db5d26b-4d4d-4db9-a2d9-f66680070023.png">

---

**Old Rotation TTL Text:**
_toggled off_
<img width="323" alt="Screen Shot 2021-07-30 at 2 33 54 PM" src="https://user-images.githubusercontent.com/68122737/127713644-078903c4-2c8d-4e37-b156-3b4d22a3ce66.png">

---

_toggled on_
<img width="460" alt="Screen Shot 2021-07-30 at 2 34 09 PM" src="https://user-images.githubusercontent.com/68122737/127713678-fd9e4856-582c-4135-aa09-118c359db2eb.png">

---

**Corrected Text:**
_toggled off_
<img width="739" alt="Screen Shot 2021-07-30 at 2 31 37 PM" src="https://user-images.githubusercontent.com/68122737/127713461-60da7c80-6e44-4fd8-8dc0-80299e51a4ec.png">

_toggled on_
<img width="472" alt="Screen Shot 2021-07-30 at 2 32 02 PM" src="https://user-images.githubusercontent.com/68122737/127713498-c83a5e50-d0ef-45d0-886d-1345566d31e4.png">
