### PR TITLE
Recommended TOC change: Vault documentation

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -7,10 +7,7 @@
     "title": "Use Cases",
     "path": "use-cases"
   },
-  {
-    "title": "Vault Integration Program",
-    "path": "partnerships"
-  },
+
   {
     "divider": true
   },
@@ -1211,6 +1208,11 @@
   {
     "title": "Plugin Portal",
     "path": "plugin-portal"
+  },
+
+  {
+    "title": "Vault Integration Program",
+    "path": "partnerships"
   },
   {
     "divider": true

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1,5 +1,21 @@
 [
   {
+    "title": "What is Vault?",
+    "path": "what-is-vault"
+  },
+  {
+    "title": "Use Cases",
+    "path": "use-cases"
+  },
+  {
+    "title": "Vault Integration Program",
+    "path": "partnerships"
+  },
+  {
+    "divider": true
+  },
+
+  {
     "title": "Installing Vault",
     "path": "install"
   },
@@ -1195,21 +1211,6 @@
   {
     "title": "Plugin Portal",
     "path": "plugin-portal"
-  },
-  {
-    "divider": true
-  },
-  {
-    "title": "What is Vault?",
-    "path": "what-is-vault"
-  },
-  {
-    "title": "Use Cases",
-    "path": "use-cases"
-  },
-  {
-    "title": "Vault Integration Program",
-    "path": "partnerships"
   },
   {
     "divider": true


### PR DESCRIPTION
This is a minor change to the TOC, but makes a fairly big impact on user documentation journey. I recommend that we provide an overview of Vault first and foremost, before users learn about installation and the preceding sections.

:mag: [Deploy preview](https://vault-plwibjap5-hashicorp.vercel.app/docs)

![vault-docs](https://user-images.githubusercontent.com/7660718/127930136-65a841b9-2d55-4614-8abd-492b8415dd6c.png)
