### PR TITLE
vault: fix dropped test errors

### DIFF
--- a/vault/activity/query_test.go
+++ b/vault/activity/query_test.go
@@ -67,6 +67,9 @@ func TestQueryStore_Inventory(t *testing.T) {
 	}
 
 	storedEndTimes, err := qs.listEndTimes(ctx, startTimes[1])
+	if err != nil {
+		t.Fatal(err)
+	}
 	expected := endTimes[1:]
 	if len(storedEndTimes) != len(expected) {
 		t.Fatalf("bad length, expected %v got %v", len(expected), storedEndTimes)

--- a/vault/barrier_test.go
+++ b/vault/barrier_test.go
@@ -12,6 +12,9 @@ import (
 
 func testBarrier(t *testing.T, b SecurityBarrier) {
 	err, e, key := testInitAndUnseal(t, b)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Operations should work
 	out, err := b.Get(context.Background(), "test")


### PR DESCRIPTION
This fixes a dropped test `err` variable in `vault` and another in `vault/activity`.