### PR TITLE
identity: allow creating a role with a non-existent key

### DIFF
--- a/changelog/12251.txt
+++ b/changelog/12251.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity: allow creating a role with a non-existent key
+```

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -989,7 +989,7 @@ func (i *IdentityStore) pathOIDCCreateUpdateRole(ctx context.Context, req *logic
 		role.TokenTTL = time.Duration(d.Get("ttl").(int)) * time.Second
 	}
 
-	// get the key referenced by this role
+	// get the key referenced by this role if it exists
 	var key namedKey
 	entry, err := req.Storage.Get(ctx, namedKeyConfigPath+role.Key)
 	if err != nil {
@@ -999,10 +999,11 @@ func (i *IdentityStore) pathOIDCCreateUpdateRole(ctx context.Context, req *logic
 		if err := entry.DecodeJSON(&key); err != nil {
 			return nil, err
 		}
-	}
 
-	if role.TokenTTL > key.VerificationTTL {
-		return logical.ErrorResponse("a role's token ttl cannot be longer than the verification_ttl of the key it references"), nil
+		if role.TokenTTL > key.VerificationTTL {
+			return logical.ErrorResponse("a role's token ttl cannot be longer than the verification_ttl of the key it references"), nil
+		}
+
 	}
 
 	if clientID, ok := d.GetOk("client_id"); ok {

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -1003,7 +1003,6 @@ func (i *IdentityStore) pathOIDCCreateUpdateRole(ctx context.Context, req *logic
 		if role.TokenTTL > key.VerificationTTL {
 			return logical.ErrorResponse("a role's token ttl cannot be longer than the verification_ttl of the key it references"), nil
 		}
-
 	}
 
 	if clientID, ok := d.GetOk("client_id"); ok {


### PR DESCRIPTION
This PR maintains the current behavior in 1.8 by ensuring that a role can be created with a non-existent key. Any change to this behavior would be a breaking change for those dependent on it.

## Background
https://github.com/hashicorp/vault/pull/12151 fixed a bug that allowed a role's token_ttl to be longer than the verification_ttl of the key it references. However that PR introduced a bug that would cause the creation of a role with a non-existent key to fail with the error:

```
$ vault write identity/oidc/role/role1 key=key1 ttl=1m
Error writing data to identity/oidc/role/role1: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/identity/oidc/role/role1
Code: 400. Errors:

* a role's token ttl cannot be longer than the verification_ttl of the key it references
```

Since the current plan is to ship https://github.com/hashicorp/vault/pull/12151 in 1.8.1 then we need to make sure this PR is also shipped in 1.8.1 to maintain backward compatibility with existing behavior.

Additionally, https://github.com/hashicorp/vault/pull/12208 is planned to be shipped in 1.9 and will enforce the key param and key existence on role creation.


