### PR TITLE
Backport 1.8.x: Cap AWS Token TTL based on Default Lease TTL (#12026)

### DIFF
--- a/builtin/credential/aws/path_role.go
+++ b/builtin/credential/aws/path_role.go
@@ -889,11 +889,7 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 		}
 	}
 
-	defaultLeaseTTL := b.System().DefaultLeaseTTL()
 	systemMaxTTL := b.System().MaxLeaseTTL()
-	if roleEntry.TokenTTL > defaultLeaseTTL {
-		resp.AddWarning(fmt.Sprintf("Given ttl of %d seconds greater than current mount/system default of %d seconds; ttl will be capped at login time", roleEntry.TokenTTL/time.Second, defaultLeaseTTL/time.Second))
-	}
 	if roleEntry.TokenMaxTTL > systemMaxTTL {
 		resp.AddWarning(fmt.Sprintf("Given max ttl of %d seconds greater than current mount/system default of %d seconds; max ttl will be capped at login time", roleEntry.TokenMaxTTL/time.Second, systemMaxTTL/time.Second))
 	}

--- a/builtin/credential/aws/path_role_test.go
+++ b/builtin/credential/aws/path_role_test.go
@@ -762,10 +762,10 @@ func TestAwsEc2_RoleDurationSeconds(t *testing.T) {
 	}
 
 	if resp.Data["ttl"].(int64) != 10 {
-		t.Fatalf("bad: period; expected: 10, actual: %d", resp.Data["ttl"])
+		t.Fatalf("bad: ttl; expected: 10, actual: %d", resp.Data["ttl"])
 	}
 	if resp.Data["max_ttl"].(int64) != 20 {
-		t.Fatalf("bad: period; expected: 20, actual: %d", resp.Data["max_ttl"])
+		t.Fatalf("bad: max_ttl; expected: 20, actual: %d", resp.Data["max_ttl"])
 	}
 	if resp.Data["period"].(int64) != 30 {
 		t.Fatalf("bad: period; expected: 30, actual: %d", resp.Data["period"])

--- a/changelog/12026.txt
+++ b/changelog/12026.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/aws: Remove warning stating AWS Token TTL will be capped by the Default Lease TTL.
+```


### PR DESCRIPTION
- Removes TTL cap warning if Token TTL is greater than the `defaultLeaseTTL` since capping isn't necessary
- Fixes typos in error messages in tests