### PR TITLE
Updates vault-plugin-auth-jwt to v0.9.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-centrify v0.8.0
 	github.com/hashicorp/vault-plugin-auth-cf v0.8.0
 	github.com/hashicorp/vault-plugin-auth-gcp v0.9.1
-	github.com/hashicorp/vault-plugin-auth-jwt v0.9.4
+	github.com/hashicorp/vault-plugin-auth-jwt v0.9.5
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.9.0
 	github.com/hashicorp/vault-plugin-auth-oci v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -647,10 +647,6 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-0.20201015184941-809e678c39ec h1:PJw/FrlC0tV2bapOg4WWiVDrEvC+UBzL4hOyciPXlz4=
 github.com/hashicorp/hcl v1.0.1-0.20201015184941-809e678c39ec/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl v1.0.1-0.20210329193548-cf4c4bf2466d h1:7lovqLls3wlz29GJ228z0IVQAFXkKrcOmnbcPawOJhE=
-github.com/hashicorp/hcl v1.0.1-0.20210329193548-cf4c4bf2466d/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl v1.0.1-vault h1:/JhJsLUPC73zeqSbkZApgsofP4iB++zgDHS5t6ZL0Lc=
-github.com/hashicorp/hcl v1.0.1-vault/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -686,8 +682,8 @@ github.com/hashicorp/vault-plugin-auth-cf v0.8.0/go.mod h1:exPUMj8yNohKM7yRiHa7O
 github.com/hashicorp/vault-plugin-auth-gcp v0.5.1/go.mod h1:eLj92eX8MPI4vY1jaazVLF2sVbSAJ3LRHLRhF/pUmlI=
 github.com/hashicorp/vault-plugin-auth-gcp v0.9.1 h1:DNwSe1Sk53olEaB7vSipyBNRB5iQuy9cib/rWKogOng=
 github.com/hashicorp/vault-plugin-auth-gcp v0.9.1/go.mod h1:Z+mj9fAqzXfDNxLmMoSS8NheVK7ugLvD8sTHO1GXfCA=
-github.com/hashicorp/vault-plugin-auth-jwt v0.9.4 h1:N90b4+AOQjCaNOt2NnyyUgx/q85e+MTEOOU4t3YzKNg=
-github.com/hashicorp/vault-plugin-auth-jwt v0.9.4/go.mod h1:3KxfehLIM7zH19+O8jHJ/QJsLGRzSKRqjsesOJmBuoI=
+github.com/hashicorp/vault-plugin-auth-jwt v0.9.5 h1:QSLS0FD7qgUIE//lPErYlw49maV2Zm+7Pyt3Wa61MB8=
+github.com/hashicorp/vault-plugin-auth-jwt v0.9.5/go.mod h1:3KxfehLIM7zH19+O8jHJ/QJsLGRzSKRqjsesOJmBuoI=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0 h1:QxW0gRevydrNfRvo1qI6p0jQkhedLUgiWqpCN36RXoQ=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0/go.mod h1:h+7pLm4Z2EeKHOGPefX0bGzdUQCMBUlvM/BpSMNgTFw=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.9.0 h1:X/eXFuJqVW8YN73ohTaI5YyCwcjd6C3mpnMv/elkNrw=

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/cli_responses.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/cli_responses.go
@@ -449,7 +449,7 @@ func formpostHTML(path, code, state string) string {
       </div>
     </div>
 	<script>
-		window.localStorage.setItem("oidcState", JSON.stringify({"path":"%s", "code":"%s", "state":"%s"}));
+		window.opener.postMessage({ path: "%s", code: "%s", state: "%s"}, window.origin);
 	</script>
   </body>
 </html>

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -642,7 +642,7 @@ github.com/hashicorp/vault-plugin-auth-cf/util
 ## explicit
 github.com/hashicorp/vault-plugin-auth-gcp/plugin
 github.com/hashicorp/vault-plugin-auth-gcp/plugin/cache
-# github.com/hashicorp/vault-plugin-auth-jwt v0.9.4
+# github.com/hashicorp/vault-plugin-auth-jwt v0.9.5
 ## explicit
 github.com/hashicorp/vault-plugin-auth-jwt
 # github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0


### PR DESCRIPTION
This PR updates vault-plugin-auth-jwt to `v0.9.5` to bring in a bug fix from https://github.com/hashicorp/vault-plugin-auth-jwt/pull/174.

The following steps were taken:
1. `git checkout release/1.7.x`
2. `git checkout -b update-plugin-auth-jwt-1.7.x`
3. `go get github.com/hashicorp/vault-plugin-auth-jwt@v0.9.5`
4. `go mod vendor && go mod tidy`