### PR TITLE
Updates vault-plugin-auth-jwt to v0.10.1

### DIFF
--- a/changelog/12265.txt
+++ b/changelog/12265.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/jwt: Fixes OIDC auth from the Vault UI when using `form_post` as the `oidc_response_mode`.
+```

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-centrify v0.9.0
 	github.com/hashicorp/vault-plugin-auth-cf v0.9.0
 	github.com/hashicorp/vault-plugin-auth-gcp v0.10.0
-	github.com/hashicorp/vault-plugin-auth-jwt v0.10.0
+	github.com/hashicorp/vault-plugin-auth-jwt v0.10.1
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.4.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.10.1
 	github.com/hashicorp/vault-plugin-auth-oci v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -709,8 +709,8 @@ github.com/hashicorp/vault-plugin-auth-cf v0.9.0/go.mod h1:exPUMj8yNohKM7yRiHa7O
 github.com/hashicorp/vault-plugin-auth-gcp v0.5.1/go.mod h1:eLj92eX8MPI4vY1jaazVLF2sVbSAJ3LRHLRhF/pUmlI=
 github.com/hashicorp/vault-plugin-auth-gcp v0.10.0 h1:EBvgbyiPXqmmEQqIwkorLLEjvv4GPl6DQ1LdE0zJkh0=
 github.com/hashicorp/vault-plugin-auth-gcp v0.10.0/go.mod h1:Z+mj9fAqzXfDNxLmMoSS8NheVK7ugLvD8sTHO1GXfCA=
-github.com/hashicorp/vault-plugin-auth-jwt v0.10.0 h1:9jzAxMnhTA0xsDE3p7IzUoa9O54ijwDfV/J1D7FpB2U=
-github.com/hashicorp/vault-plugin-auth-jwt v0.10.0/go.mod h1:3KxfehLIM7zH19+O8jHJ/QJsLGRzSKRqjsesOJmBuoI=
+github.com/hashicorp/vault-plugin-auth-jwt v0.10.1 h1:7hvGSiICXpmp7Ras5glxVVxTDg2dZL+l/jWeBQ6bzr0=
+github.com/hashicorp/vault-plugin-auth-jwt v0.10.1/go.mod h1:3KxfehLIM7zH19+O8jHJ/QJsLGRzSKRqjsesOJmBuoI=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.4.0 h1:7M7/DbFsUoOMBd2/R48ZNj4PM3Gdsg0dGcbMOdt5z1Q=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.4.0/go.mod h1:h+7pLm4Z2EeKHOGPefX0bGzdUQCMBUlvM/BpSMNgTFw=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.10.1 h1:7c2ufXt5oXSUISNHpO07W956fpgn00nT1IQFPEP5XQE=


### PR DESCRIPTION
This PR updates vault-plugin-auth-jwt to `v0.10.1` to bring in a bug fix from https://github.com/hashicorp/vault-plugin-auth-jwt/pull/174.

The following steps were taken:
1. `git checkout main`
2. `git checkout -b update-plugin-auth-jwt`
3. `go get github.com/hashicorp/vault-plugin-auth-jwt@v0.10.1`
4. `go mod tidy`