### PR TITLE
docs: since Vault 1.0 Unseal is OSS

### DIFF
--- a/website/content/api-docs/system/init.mdx
+++ b/website/content/api-docs/system/init.mdx
@@ -60,8 +60,6 @@ available when using Vault HSM.
   `secret_shares`. If using Vault HSM with auto-unsealing, this value must be
   the same as `secret_shares`.
 
-Additionally, the following options are only supported on Vault Pro/Enterprise:
-
 - `stored_shares` `(int: <required>)` – Specifies the number of shares that
   should be encrypted by the HSM and stored for auto-unsealing. Currently must
   be the same as `secret_shares`.


### PR DESCRIPTION
Hi, I got confused reading the doc the other day.