### PR TITLE
auth/oidc: documents redirect URI for UI login with form_post response_mode

### DIFF
--- a/website/content/docs/auth/jwt/index.mdx
+++ b/website/content/docs/auth/jwt/index.mdx
@@ -147,7 +147,7 @@ The "host:port" must be correct for the Vault server, and "path" must match the 
 backend is mounted at (e.g. "oidc" or "jwt").
 
 If the [oidc_response_mode](/api-docs/auth/jwt#oidc_response_mode) is set to `form_post`, then
-logging in via the UI requires a redirect URI of the form:
+logging in via the Vault UI requires a redirect URI of the form:
 
 `https://{host:port}/v1/auth/{path}/oidc/callback`
 

--- a/website/content/docs/auth/jwt/index.mdx
+++ b/website/content/docs/auth/jwt/index.mdx
@@ -140,10 +140,16 @@ of the configured redirected URIs. These same "localhost" URIs must be added to 
 **Vault UI**
 
 Logging in via the Vault UI requires a redirect URI of the form:
+
 `https://{host:port}/ui/vault/auth/{path}/oidc/callback`
 
 The "host:port" must be correct for the Vault server, and "path" must match the path the JWT
 backend is mounted at (e.g. "oidc" or "jwt").
+
+If the [oidc_response_mode](/api-docs/auth/jwt#oidc_response_mode) is set to `form_post`, then
+logging in via the UI requires a redirect URI of the form:
+
+`https://{host:port}/v1/auth/{path}/oidc/callback`
 
 Prior to Vault 1.6, if [namespaces](/docs/enterprise/namespaces) are in use,
 they must be added as query parameters, for example:


### PR DESCRIPTION
This PR documents the redirect URI that needs to be configured for Vault UI-based login when the auth method has been configured with a [response_mode](https://www.vaultproject.io/api-docs/auth/jwt#oidc_response_mode) of `form_post`. The `ui/vault` path segments of the given redirect URI are replaced with `v1` in this particular mode (see [path_oidc.go#L415](https://github.com/hashicorp/vault-plugin-auth-jwt/blob/master/path_oidc.go#L415)).