### PR TITLE
feature: OIDC Provider API

### DIFF
--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -193,3 +193,195 @@ func TestOIDC_Path_OIDC_ProviderAssignmentList(t *testing.T) {
 	delete(expectedStrings, "test-assignment2")
 	expectStrings(t, respListAssignmentAfterDelete.Data["keys"].([]string), expectedStrings)
 }
+
+// TestOIDC_Path_OIDCProvider tests CRUD operations for providers
+func TestOIDC_Path_OIDCProvider(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+	storage := &logical.InmemStorage{}
+
+	// Create a test provider "test-provider" -- should succeed
+	resp, err := c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.CreateOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, resp, err)
+
+	// Read "test-provider" and validate
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, resp, err)
+	expected := map[string]interface{}{
+		"issuer":             "",
+		"allowed_client_ids": []string{},
+		"scopes":             []string{},
+	}
+	if diff := deep.Equal(expected, resp.Data); diff != nil {
+		t.Fatal(diff)
+	}
+
+	// Update "test-provider" -- should succeed
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"issuer":             "test-issuer",
+			"allowed_client_ids": []string{"test-client-id"},
+			"scopes":             []string{"test-scope"},
+		},
+		Storage: storage,
+	})
+	expectSuccess(t, resp, err)
+
+	// Read "test-provider" again and validate
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, resp, err)
+	expected = map[string]interface{}{
+		"issuer":             "test-issuer",
+		"allowed_client_ids": []string{"test-client-id"},
+		"scopes":             []string{"test-scope"},
+	}
+	if diff := deep.Equal(expected, resp.Data); diff != nil {
+		t.Fatal(diff)
+	}
+
+	// Delete test-provider -- should succeed
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.DeleteOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, resp, err)
+
+	// Read "test-provider" again and validate
+	resp, _ = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	if resp != nil {
+		t.Fatalf("expected nil but got resp: %#v", resp)
+	}
+}
+
+// TestOIDC_Path_OIDCProvider_Update tests Update operations for providers
+func TestOIDC_Path_OIDCProvider_Update(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+	storage := &logical.InmemStorage{}
+
+	// Create a test provider "test-provider" -- should succeed
+	resp, err := c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.CreateOperation,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"issuer":             "test-issuer",
+			"allowed_client_ids": []string{"test-client-id"},
+			"scopes":             []string{"test-scope"},
+		},
+	})
+	expectSuccess(t, resp, err)
+
+	// Read "test-provider" and validate
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, resp, err)
+	expected := map[string]interface{}{
+		"issuer":             "test-issuer",
+		"allowed_client_ids": []string{"test-client-id"},
+		"scopes":             []string{"test-scope"},
+	}
+	if diff := deep.Equal(expected, resp.Data); diff != nil {
+		t.Fatal(diff)
+	}
+
+	// Update "test-provider" -- should succeed
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"issuer": "test-issuer-2",
+		},
+		Storage: storage,
+	})
+	expectSuccess(t, resp, err)
+
+	// Read "test-provider" again and validate
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, resp, err)
+	expected = map[string]interface{}{
+		"issuer":             "test-issuer-2",
+		"allowed_client_ids": []string{"test-client-id"},
+		"scopes":             []string{"test-scope"},
+	}
+	if diff := deep.Equal(expected, resp.Data); diff != nil {
+		t.Fatal(diff)
+	}
+}
+
+// TestOIDC_Path_OIDC_ProviderList tests the List operation for providers
+func TestOIDC_Path_OIDC_ProviderList(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+	storage := &logical.InmemStorage{}
+
+	// Prepare two providers, test-provider1 and test-provider2
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider1",
+		Operation: logical.CreateOperation,
+		Storage:   storage,
+	})
+
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider2",
+		Operation: logical.CreateOperation,
+		Storage:   storage,
+	})
+
+	// list providers
+	respListProviders, listErr := c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider",
+		Operation: logical.ListOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, respListProviders, listErr)
+
+	// validate list response
+	expectedStrings := map[string]interface{}{"test-provider1": true, "test-provider2": true}
+	expectStrings(t, respListProviders.Data["keys"].([]string), expectedStrings)
+
+	// delete test-provider2
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider2",
+		Operation: logical.DeleteOperation,
+		Storage:   storage,
+	})
+
+	// list providers again and validate response
+	respListProvidersAfterDelete, listErrAfterDelete := c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider",
+		Operation: logical.ListOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, respListProvidersAfterDelete, listErrAfterDelete)
+
+	// validate list response
+	delete(expectedStrings, "test-provider2")
+	expectStrings(t, respListProvidersAfterDelete.Data["keys"].([]string), expectedStrings)
+}


### PR DESCRIPTION
## Description
The provider API allows Vault admins to configure which Vault issuer, client IDs and scopes are permitted to authenticate via a specific client.

Acceptance Criteria:

A Vault user can perform operations using the provider API as specified in the RFC.