### PR TITLE
improvement: refactor api module's logical type to be able to read kv v2

### DIFF
--- a/changelog/12284.txt
+++ b/changelog/12284.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Allow `Read`, `ReadWithData` and `List` methods on the `Logical` api type to work for KV V2 calls.
+```

--- a/command/kv_delete.go
+++ b/command/kv_delete.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -97,7 +98,7 @@ func (c *KVDeleteCommand) Run(args []string) int {
 	}
 
 	path := sanitizePath(args[0])
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -138,19 +139,19 @@ func (c *KVDeleteCommand) deleteV2(path, mountPath string, client *api.Client) (
 	var secret *api.Secret
 	switch {
 	case len(c.flagVersions) > 0:
-		path = addPrefixToVKVPath(path, mountPath, "delete")
+		path = api.AddPrefixToVKVPath(path, mountPath, "delete")
 		if err != nil {
 			return nil, err
 		}
 
 		data := map[string]interface{}{
-			"versions": kvParseVersionsFlags(c.flagVersions),
+			"versions": api.KvParseVersionsFlags(c.flagVersions),
 		}
 
 		secret, err = client.Logical().Write(path, data)
 	default:
 
-		path = addPrefixToVKVPath(path, mountPath, "data")
+		path = api.AddPrefixToVKVPath(path, mountPath, "data")
 		if err != nil {
 			return nil, err
 		}

--- a/command/kv_destroy.go
+++ b/command/kv_destroy.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -95,7 +97,7 @@ func (c *KVDestroyCommand) Run(args []string) int {
 		return 2
 	}
 
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -104,14 +106,14 @@ func (c *KVDestroyCommand) Run(args []string) int {
 		c.UI.Error("Destroy not supported on KV Version 1")
 		return 1
 	}
-	path = addPrefixToVKVPath(path, mountPath, "destroy")
+	path = api.AddPrefixToVKVPath(path, mountPath, "destroy")
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
 	}
 
 	data := map[string]interface{}{
-		"versions": kvParseVersionsFlags(c.flagVersions),
+		"versions": api.KvParseVersionsFlags(c.flagVersions),
 	}
 
 	secret, err := client.Logical().Write(path, data)

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -93,7 +95,7 @@ func (c *KVGetCommand) Run(args []string) int {
 	}
 
 	path := sanitizePath(args[0])
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -102,7 +104,7 @@ func (c *KVGetCommand) Run(args []string) int {
 	var versionParam map[string]string
 
 	if v2 {
-		path = addPrefixToVKVPath(path, mountPath, "data")
+		path = api.AddPrefixToVKVPath(path, mountPath, "data")
 
 		if c.flagVersion > 0 {
 			versionParam = map[string]string{
@@ -111,7 +113,7 @@ func (c *KVGetCommand) Run(args []string) int {
 		}
 	}
 
-	secret, err := kvReadRequest(client, path, versionParam)
+	secret, err := api.KvReadRequest(client, path, versionParam)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading %s: %s", path, err))
 		if secret != nil {
@@ -159,7 +161,7 @@ func (c *KVGetCommand) Run(args []string) int {
 	}
 
 	if metadata, ok := secret.Data["metadata"]; ok && metadata != nil {
-		c.UI.Info(getHeaderForMap("Metadata", metadata.(map[string]interface{})))
+		c.UI.Info(api.GetHeaderForMap("Metadata", metadata.(map[string]interface{})))
 		OutputData(c.UI, metadata)
 		c.UI.Info("")
 	}
@@ -174,7 +176,7 @@ func (c *KVGetCommand) Run(args []string) int {
 	}
 
 	if data != nil {
-		c.UI.Info(getHeaderForMap("Data", data))
+		c.UI.Info(api.GetHeaderForMap("Data", data))
 		OutputData(c.UI, data)
 	}
 

--- a/command/kv_list.go
+++ b/command/kv_list.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -83,14 +85,14 @@ func (c *KVListCommand) Run(args []string) int {
 
 	// Sanitize path
 	path = sanitizePath(path)
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
 	}
 
 	if v2 {
-		path = addPrefixToVKVPath(path, mountPath, "metadata")
+		path = api.AddPrefixToVKVPath(path, mountPath, "metadata")
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 2

--- a/command/kv_metadata_delete.go
+++ b/command/kv_metadata_delete.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -73,7 +75,7 @@ func (c *KVMetadataDeleteCommand) Run(args []string) int {
 	}
 
 	path := sanitizePath(args[0])
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -83,7 +85,7 @@ func (c *KVMetadataDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	path = addPrefixToVKVPath(path, mountPath, "metadata")
+	path = api.AddPrefixToVKVPath(path, mountPath, "metadata")
 	if secret, err := client.Logical().Delete(path); err != nil {
 		c.UI.Error(fmt.Sprintf("Error deleting %s: %s", path, err))
 		if secret != nil {

--- a/command/kv_metadata_get.go
+++ b/command/kv_metadata_get.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -77,7 +79,7 @@ func (c *KVMetadataGetCommand) Run(args []string) int {
 	}
 
 	path := sanitizePath(args[0])
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -87,7 +89,7 @@ func (c *KVMetadataGetCommand) Run(args []string) int {
 		return 1
 	}
 
-	path = addPrefixToVKVPath(path, mountPath, "metadata")
+	path = api.AddPrefixToVKVPath(path, mountPath, "metadata")
 	secret, err := client.Logical().Read(path)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading %s: %s", path, err))
@@ -117,7 +119,7 @@ func (c *KVMetadataGetCommand) Run(args []string) int {
 
 	delete(secret.Data, "versions")
 
-	c.UI.Info(getHeaderForMap("Metadata", secret.Data))
+	c.UI.Info(api.GetHeaderForMap("Metadata", secret.Data))
 	OutputSecret(c.UI, secret)
 
 	versionKeys := []int{}
@@ -134,7 +136,7 @@ func (c *KVMetadataGetCommand) Run(args []string) int {
 	sort.Ints(versionKeys)
 
 	for _, v := range versionKeys {
-		c.UI.Info("\n" + getHeaderForMap(fmt.Sprintf("Version %d", v), versions[strconv.Itoa(v)].(map[string]interface{})))
+		c.UI.Info("\n" + api.GetHeaderForMap(fmt.Sprintf("Version %d", v), versions[strconv.Itoa(v)].(map[string]interface{})))
 		OutputData(c.UI, versions[strconv.Itoa(v)])
 	}
 

--- a/command/kv_metadata_put.go
+++ b/command/kv_metadata_put.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -127,7 +129,7 @@ func (c *KVMetadataPutCommand) Run(args []string) int {
 	}
 
 	path := sanitizePath(args[0])
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -137,7 +139,7 @@ func (c *KVMetadataPutCommand) Run(args []string) int {
 		return 1
 	}
 
-	path = addPrefixToVKVPath(path, mountPath, "metadata")
+	path = api.AddPrefixToVKVPath(path, mountPath, "metadata")
 	data := map[string]interface{}{
 		"max_versions": c.flagMaxVersions,
 		"cas_required": c.flagCASRequired,

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -104,7 +106,7 @@ func (c *KVPatchCommand) Run(args []string) int {
 		return 1
 	}
 
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -115,7 +117,7 @@ func (c *KVPatchCommand) Run(args []string) int {
 		return 2
 	}
 
-	path = addPrefixToVKVPath(path, mountPath, "data")
+	path = api.AddPrefixToVKVPath(path, mountPath, "data")
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -125,7 +127,7 @@ func (c *KVPatchCommand) Run(args []string) int {
 	// Note that we don't want to see curl output for the read request.
 	curOutputCurl := client.OutputCurlString()
 	client.SetOutputCurlString(false)
-	secret, err := kvReadRequest(client, path, nil)
+	secret, err := api.KvReadRequest(client, path, nil)
 	client.SetOutputCurlString(curOutputCurl)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error doing pre-read at %s: %s", path, err))

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -123,14 +125,14 @@ func (c *KVPutCommand) Run(args []string) int {
 		return 1
 	}
 
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
 	}
 
 	if v2 {
-		path = addPrefixToVKVPath(path, mountPath, "data")
+		path = api.AddPrefixToVKVPath(path, mountPath, "data")
 		data = map[string]interface{}{
 			"data":    data,
 			"options": map[string]interface{}{},

--- a/command/kv_rollback.go
+++ b/command/kv_rollback.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -104,7 +106,7 @@ func (c *KVRollbackCommand) Run(args []string) int {
 		return 2
 	}
 
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -115,7 +117,7 @@ func (c *KVRollbackCommand) Run(args []string) int {
 		return 2
 	}
 
-	path = addPrefixToVKVPath(path, mountPath, "data")
+	path = api.AddPrefixToVKVPath(path, mountPath, "data")
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -124,7 +126,7 @@ func (c *KVRollbackCommand) Run(args []string) int {
 	// First, do a read to get the current version for check-and-set
 	var meta map[string]interface{}
 	{
-		secret, err := kvReadRequest(client, path, nil)
+		secret, err := api.KvReadRequest(client, path, nil)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error doing pre-read at %s: %s", path, err))
 			return 2
@@ -163,7 +165,7 @@ func (c *KVRollbackCommand) Run(args []string) int {
 	// Now run it again and read the version we want to roll back to
 	var data map[string]interface{}
 	{
-		secret, err := kvReadRequest(client, path, versionParam)
+		secret, err := api.KvReadRequest(client, path, versionParam)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error doing pre-read at %s: %s", path, err))
 			return 2

--- a/command/kv_undelete.go
+++ b/command/kv_undelete.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
+
+	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -94,7 +96,7 @@ func (c *KVUndeleteCommand) Run(args []string) int {
 	}
 
 	path := sanitizePath(args[0])
-	mountPath, v2, err := isKVv2(path, client)
+	mountPath, v2, err := api.IsKVv2(path, client)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 2
@@ -104,9 +106,9 @@ func (c *KVUndeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	path = addPrefixToVKVPath(path, mountPath, "undelete")
+	path = api.AddPrefixToVKVPath(path, mountPath, "undelete")
 	data := map[string]interface{}{
-		"versions": kvParseVersionsFlags(c.flagVersions),
+		"versions": api.KvParseVersionsFlags(c.flagVersions),
 	}
 
 	secret, err := client.Logical().Write(path, data)


### PR DESCRIPTION
This PR addresses issue #11853.

`kv_helpers` were moved into the `vault/api` package so that they could
be used by the methods attached to the `Logical` type (namely `List` and
`ReadWithData`) in order to support KV V2 calls.

We could potentially clean this up further by potentially removing the `KvReadRequest`
entirely and sticking with the `ReadWithData` method since there's so
much overlap, but will leave more refactoring suggestions to those more
familiar with the code-base.