### PR TITLE
sdk/db: Add private key secret to connutil

### DIFF
--- a/changelog/12294.txt
+++ b/changelog/12294.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sdk/db: Add private key template to specify a private key in connection URLs
+```

--- a/sdk/database/helper/connutil/sql.go
+++ b/sdk/database/helper/connutil/sql.go
@@ -26,6 +26,7 @@ type SQLConnectionProducer struct {
 	MaxConnectionLifetimeRaw interface{} `json:"max_connection_lifetime" mapstructure:"max_connection_lifetime" structs:"max_connection_lifetime"`
 	Username                 string      `json:"username" mapstructure:"username" structs:"username"`
 	Password                 string      `json:"password" mapstructure:"password" structs:"password"`
+	PrivateKey               string      `json:"private_key" mapstructure:"private_key" structs:"private_key"`
 
 	Type                  string
 	RawConfig             map[string]interface{}
@@ -64,8 +65,9 @@ func (c *SQLConnectionProducer) Init(ctx context.Context, conf map[string]interf
 	// QueryHelper doesn't do any SQL escaping, but if it starts to do so
 	// then maybe we won't be able to use it to do URL substitution any more.
 	c.ConnectionURL = dbutil.QueryHelper(c.ConnectionURL, map[string]string{
-		"username": url.PathEscape(c.Username),
-		"password": password,
+		"username":    url.PathEscape(c.Username),
+		"password":    password,
+		"private_key": url.PathEscape(c.PrivateKey),
 	})
 
 	if c.MaxOpenConnections == 0 {
@@ -160,7 +162,8 @@ func (c *SQLConnectionProducer) Connection(ctx context.Context) (interface{}, er
 
 func (c *SQLConnectionProducer) SecretValues() map[string]interface{} {
 	return map[string]interface{}{
-		c.Password: "[password]",
+		c.Password:   "[password]",
+		c.PrivateKey: "[private_key]",
 	}
 }
 

--- a/sdk/database/helper/connutil/sql_test.go
+++ b/sdk/database/helper/connutil/sql_test.go
@@ -89,7 +89,7 @@ func TestSQLPrivateKey(t *testing.T) {
 				}
 
 				if u.Query().Get("privateKey") != tc.PrivateKey {
-					t.Errorf("Private key not set in the connection URL: %q", u.String())
+					t.Errorf("Parsed privateKey %q != original privateKey %q", u.Query().Get("privateKey"), tc.PrivateKey)
 				}
 			}
 		}

--- a/website/content/api-docs/secret/databases/index.mdx
+++ b/website/content/api-docs/secret/databases/index.mdx
@@ -84,6 +84,10 @@ are supported and any additional details about them.
   configuration. This is typically used in the `connection_url` field via the templating
   directive `{{password}}`.
 
+- `private_key` `(string)` - Specifies a base 64 encoded private key to be used for authentication 
+  with certain databases.  This value will not be returned by Vault when performing a read upon the
+  configuration. This is typically used in the `connection_url` field via the templating
+  directive `{{private_key}}`.
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
Databases often support other forms of authentication instead of username & password. For example, Snowflake supports private key authentication.

This adds a new templateable secret, `private_key`, for use with DB connection URLs. Other features will need to be implemented to support generation and rotation of private keys, but this at least allows Vault to connect without using a password.