### PR TITLE
dep: update database-couchbase plugin to v0.3.1

### DIFF
--- a/changelog/12299.txt
+++ b/changelog/12299.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+database/couchbase: change default template to truncate username at 128 characters
+```

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.9.0
 	github.com/hashicorp/vault-plugin-auth-oci v0.7.0
-	github.com/hashicorp/vault-plugin-database-couchbase v0.3.0
+	github.com/hashicorp/vault-plugin-database-couchbase v0.3.1
 	github.com/hashicorp/vault-plugin-database-elasticsearch v0.7.0
 	github.com/hashicorp/vault-plugin-database-mongodbatlas v0.3.0
 	github.com/hashicorp/vault-plugin-database-snowflake v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -690,8 +690,8 @@ github.com/hashicorp/vault-plugin-auth-kubernetes v0.9.0 h1:X/eXFuJqVW8YN73ohTaI
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.9.0/go.mod h1:2c/k3nsoGPKV+zpAWCiajt4e66vncEq8Li/eKLqErAc=
 github.com/hashicorp/vault-plugin-auth-oci v0.7.0 h1:saDgrjPcGbZ3ts2mZ/Cpf3PKaRPQ3PDo5/rOo9Xms7U=
 github.com/hashicorp/vault-plugin-auth-oci v0.7.0/go.mod h1:Cn5cjR279Y+snw8LTaiLTko3KGrbigRbsQPOd2D5xDw=
-github.com/hashicorp/vault-plugin-database-couchbase v0.3.0 h1:C3Lfwr7xtdhOTnOf+UgFZWDyBwTGqk0BuzG2GhNHD6k=
-github.com/hashicorp/vault-plugin-database-couchbase v0.3.0/go.mod h1:Seivjno/BOtkqX41d/DDYtTg6zNoxIgNaUVZ3ObZYi4=
+github.com/hashicorp/vault-plugin-database-couchbase v0.3.1 h1:X276hwmNnLFG4DEoxSXiYN2JkUwhYLHiirYXGlMViMc=
+github.com/hashicorp/vault-plugin-database-couchbase v0.3.1/go.mod h1:Seivjno/BOtkqX41d/DDYtTg6zNoxIgNaUVZ3ObZYi4=
 github.com/hashicorp/vault-plugin-database-elasticsearch v0.7.0 h1:EYicFs5dl4Ax1uQMw+EfbCCrarScVrqdGS471KKXDDo=
 github.com/hashicorp/vault-plugin-database-elasticsearch v0.7.0/go.mod h1:813Nvr1IQqAKdlk3yIY97M5WyxMhWOrXtYioPf9PqJg=
 github.com/hashicorp/vault-plugin-database-mongodbatlas v0.3.0 h1:qSTM0f71zhyYILdw2HiVw5zUumC+5QeI0F2vzDJvcUY=

--- a/vendor/github.com/hashicorp/vault-plugin-database-couchbase/couchbase.go
+++ b/vendor/github.com/hashicorp/vault-plugin-database-couchbase/couchbase.go
@@ -21,7 +21,7 @@ const (
 	defaultCouchbaseUserRole = `{"Roles": [{"role":"ro_admin"}]}`
 	defaultTimeout           = 20000 * time.Millisecond
 
-	defaultUserNameTemplate = `V_{{.DisplayName | uppercase | truncate 64}}_{{.RoleName | uppercase | truncate 64}}_{{random 20 | uppercase}}_{{unix_time}}`
+	defaultUserNameTemplate = `{{printf "V_%s_%s_%s_%s" (printf "%s" .DisplayName | uppercase | truncate 64) (printf "%s" .RoleName | uppercase | truncate 64) (random 20 | uppercase) (unix_time) | truncate 128}}`
 )
 
 var (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -654,7 +654,7 @@ github.com/hashicorp/vault-plugin-auth-kubernetes
 # github.com/hashicorp/vault-plugin-auth-oci v0.7.0
 ## explicit
 github.com/hashicorp/vault-plugin-auth-oci
-# github.com/hashicorp/vault-plugin-database-couchbase v0.3.0
+# github.com/hashicorp/vault-plugin-database-couchbase v0.3.1
 ## explicit
 github.com/hashicorp/vault-plugin-database-couchbase
 # github.com/hashicorp/vault-plugin-database-elasticsearch v0.7.0


### PR DESCRIPTION
Updates dependency on database-couchbase plugin to v0.3.1

Upgrade steps taken:
```sh
$ go get github.com/hashicorp/vault-plugin-database-couchbase@release/vault-1.7.x
go: downloading github.com/hashicorp/vault-plugin-database-couchbase v0.3.1
go get: upgraded github.com/hashicorp/vault-plugin-database-couchbase v0.3.0 => v0.3.1

$ go mod tidy
go: downloading github.com/hashicorp/hcl v1.0.1-0.20201015184941-809e678c39ec
go: downloading github.com/hashicorp/vault-plugin-auth-jwt v0.9.5

$ go mod vendor

```