### PR TITLE
[Docs] Add code example

### DIFF
--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -69,6 +69,89 @@ The response will contain the token at `auth.client_token`:
 }
 ```
 
+### Code example
+
+The following code snippet demonstrates AppRole authentication with response
+wrapping.
+
+<CodeTabs heading="AppRole auth with response wrap">
+
+<CodeBlockConfig highlight="40-48">
+
+```go
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	vault "github.com/hashicorp/vault/api"
+)
+
+// Fetches a key-value secret (kv-v2) after authenticating via AppRole,
+// an auth method used by machines that are unable to use platform-based authentication mechanisms like AWS Auth, Kubernetes Auth, etc.
+func getSecretWithAppRole() (string, error) {
+	config := vault.DefaultConfig() // modify for more granular configuration
+
+	client, err := vault.NewClient(config)
+	if err != nil {
+		return "", fmt.Errorf("unable to initialize Vault client: %w", err)
+	}
+
+	wrappingToken, err := ioutil.ReadFile("path/to/wrapping-token") // placed here by a trusted orchestrator
+	if err != nil {
+		return "", fmt.Errorf("unable to read file containing wrapping token: %w", err)
+	}
+
+	unwrappedToken, err := client.Logical().Unwrap(strings.TrimSuffix(string(wrappingToken), "\n"))
+	if err != nil {
+		// a good opportunity to alert, in case the one-time use wrapping token appears to have already been used
+		return "", fmt.Errorf("unable to unwrap token: %w", err)
+	}
+	secretID := unwrappedToken.Data["secret_id"]
+
+	// the role ID given to you by your administrator
+	roleID := os.Getenv("APPROLE_ROLE_ID")
+	if roleID == "" {
+		return "", fmt.Errorf("no role ID was provided in APPROLE_ROLE_ID env var")
+	}
+
+	params := map[string]interface{}{
+		"role_id":   roleID,
+		"secret_id": secretID,
+	}
+	resp, err := client.Logical().Write("auth/approle/login", params)
+	if err != nil {
+		return "", fmt.Errorf("unable to log in with approle: %w", err)
+	}
+	client.SetToken(resp.Auth.ClientToken)
+
+	secret, err := client.Logical().Read("kv-v2/data/creds")
+	if err != nil {
+		return "", fmt.Errorf("unable to read secret: %w", err)
+	}
+
+	data, ok := secret.Data["data"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
+	}
+
+	key := "password"
+	value, ok := data[key].(string)
+	if !ok {
+		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+	}
+
+	return value, nil
+}
+```
+
+</CodeBlockConfig>
+
+</CodeTabs>
+
 ## Configuration
 
 Auth methods must be configured in advance before users or machines can
@@ -79,13 +162,13 @@ management tool.
 
 1. Enable the AppRole auth method:
 
-   ```text
+   ```shell-session
    $ vault auth enable approle
    ```
 
 1. Create a named role:
 
-   ```text
+   ```shell-session
    $ vault write auth/approle/role/my-role \
        secret_id_ttl=10m \
        token_num_uses=10 \
@@ -101,14 +184,14 @@ documentation.
 
 1. Fetch the RoleID of the AppRole:
 
-   ```text
+   ```shell-session
    $ vault read auth/approle/role/my-role/role-id
    role_id     db02de05-fa39-4855-059b-67221c5c2f63
    ```
 
 1. Get a SecretID issued against the AppRole:
 
-   ```text
+   ```shell-session
    $ vault write -f auth/approle/role/my-role/secret-id
    secret_id               6a174c20-f6de-a53c-74d2-6018fcceff64
    secret_id_accessor      c454f7e5-996e-7230-6074-6ef26b7bcf86
@@ -119,7 +202,7 @@ documentation.
 
 1. Enable the AppRole auth method:
 
-   ```sh
+   ```shell-session
    $ curl \
        --header "X-Vault-Token: ..." \
        --request POST \
@@ -129,7 +212,7 @@ documentation.
 
 1. Create an AppRole with desired set of policies:
 
-   ```sh
+   ```shell-session
    $ curl \
        --header "X-Vault-Token: ..." \
        --request POST \
@@ -139,7 +222,7 @@ documentation.
 
 1. Fetch the identifier of the role:
 
-   ```sh
+   ```shell-session
    $ curl \
        --header "X-Vault-Token: ..." \
        http://127.0.0.1:8200/v1/auth/approle/role/my-role/role-id
@@ -157,7 +240,7 @@ documentation.
 
 1. Create a new secret identifier under the role:
 
-   ```sh
+   ```shell-session
    $ curl \
        --header "X-Vault-Token: ..." \
        --request POST \
@@ -238,3 +321,87 @@ guide for a step-by-step tutorial.
 The AppRole auth method has a full HTTP API. Please see the
 [AppRole API](/api/auth/approle) for more
 details.
+
+## Code Example
+
+The following code snippet demonstrates AppRole authentication with response
+wrapping. You can download the code example from the
+[`hashicorp/vault-guies`](https://github.com/hashicorp/vault-guides) repository.
+
+<CodeTabs heading="AppRole auth with response wrap">
+
+<CodeBlockConfig lineNumbers>
+
+```go
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	vault "github.com/hashicorp/vault/api"
+)
+
+// Fetches a key-value secret (kv-v2) after authenticating via AppRole,
+// an auth method used by machines that are unable to use platform-based authentication mechanisms like AWS Auth, Kubernetes Auth, etc.
+func getSecretWithAppRole() (string, error) {
+	config := vault.DefaultConfig() // modify for more granular configuration
+
+	client, err := vault.NewClient(config)
+	if err != nil {
+		return "", fmt.Errorf("unable to initialize Vault client: %w", err)
+	}
+
+	wrappingToken, err := ioutil.ReadFile("path/to/wrapping-token") // placed here by a trusted orchestrator
+	if err != nil {
+		return "", fmt.Errorf("unable to read file containing wrapping token: %w", err)
+	}
+
+	unwrappedToken, err := client.Logical().Unwrap(strings.TrimSuffix(string(wrappingToken), "\n"))
+	if err != nil {
+		// a good opportunity to alert, in case the one-time use wrapping token appears to have already been used
+		return "", fmt.Errorf("unable to unwrap token: %w", err)
+	}
+	secretID := unwrappedToken.Data["secret_id"]
+
+	// the role ID given to you by your administrator
+	roleID := os.Getenv("APPROLE_ROLE_ID")
+	if roleID == "" {
+		return "", fmt.Errorf("no role ID was provided in APPROLE_ROLE_ID env var")
+	}
+
+	params := map[string]interface{}{
+		"role_id":   roleID,
+		"secret_id": secretID,
+	}
+	resp, err := client.Logical().Write("auth/approle/login", params)
+	if err != nil {
+		return "", fmt.Errorf("unable to log in with approle: %w", err)
+	}
+	client.SetToken(resp.Auth.ClientToken)
+
+	secret, err := client.Logical().Read("kv-v2/data/creds")
+	if err != nil {
+		return "", fmt.Errorf("unable to read secret: %w", err)
+	}
+
+	data, ok := secret.Data["data"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
+	}
+
+	key := "password"
+	value, ok := data[key].(string)
+	if !ok {
+		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+	}
+
+	return value, nil
+}
+```
+
+</CodeBlockConfig>
+
+</CodeTabs>

--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -69,89 +69,6 @@ The response will contain the token at `auth.client_token`:
 }
 ```
 
-### Code example
-
-The following code snippet demonstrates AppRole authentication with response
-wrapping.
-
-<CodeTabs heading="AppRole auth with response wrap">
-
-<CodeBlockConfig highlight="40-48">
-
-```go
-package main
-
-import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"strings"
-
-	vault "github.com/hashicorp/vault/api"
-)
-
-// Fetches a key-value secret (kv-v2) after authenticating via AppRole,
-// an auth method used by machines that are unable to use platform-based authentication mechanisms like AWS Auth, Kubernetes Auth, etc.
-func getSecretWithAppRole() (string, error) {
-	config := vault.DefaultConfig() // modify for more granular configuration
-
-	client, err := vault.NewClient(config)
-	if err != nil {
-		return "", fmt.Errorf("unable to initialize Vault client: %w", err)
-	}
-
-	wrappingToken, err := ioutil.ReadFile("path/to/wrapping-token") // placed here by a trusted orchestrator
-	if err != nil {
-		return "", fmt.Errorf("unable to read file containing wrapping token: %w", err)
-	}
-
-	unwrappedToken, err := client.Logical().Unwrap(strings.TrimSuffix(string(wrappingToken), "\n"))
-	if err != nil {
-		// a good opportunity to alert, in case the one-time use wrapping token appears to have already been used
-		return "", fmt.Errorf("unable to unwrap token: %w", err)
-	}
-	secretID := unwrappedToken.Data["secret_id"]
-
-	// the role ID given to you by your administrator
-	roleID := os.Getenv("APPROLE_ROLE_ID")
-	if roleID == "" {
-		return "", fmt.Errorf("no role ID was provided in APPROLE_ROLE_ID env var")
-	}
-
-	params := map[string]interface{}{
-		"role_id":   roleID,
-		"secret_id": secretID,
-	}
-	resp, err := client.Logical().Write("auth/approle/login", params)
-	if err != nil {
-		return "", fmt.Errorf("unable to log in with approle: %w", err)
-	}
-	client.SetToken(resp.Auth.ClientToken)
-
-	secret, err := client.Logical().Read("kv-v2/data/creds")
-	if err != nil {
-		return "", fmt.Errorf("unable to read secret: %w", err)
-	}
-
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
-	key := "password"
-	value, ok := data[key].(string)
-	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
-	}
-
-	return value, nil
-}
-```
-
-</CodeBlockConfig>
-
-</CodeTabs>
-
 ## Configuration
 
 Auth methods must be configured in advance before users or machines can
@@ -325,8 +242,7 @@ details.
 ## Code Example
 
 The following code snippet demonstrates AppRole authentication with response
-wrapping. You can download the code example from the
-[`hashicorp/vault-guies`](https://github.com/hashicorp/vault-guides) repository.
+wrapping.
 
 <CodeTabs heading="AppRole auth with response wrap">
 
@@ -353,6 +269,12 @@ func getSecretWithAppRole() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to initialize Vault client: %w", err)
 	}
+
+	// A combination of a Role ID and Secret ID is required to log in to Vault with an AppRole.
+	// The Secret ID is a value that needs to be protected, so instead of the app having knowledge of the secret ID directly,
+	// we have a trusted orchestrator (https://learn.hashicorp.com/tutorials/vault/secure-introduction?in=vault/app-integration#trusted-orchestrator)
+	// give the app access to a short-lived response-wrapping token (https://www.vaultproject.io/docs/concepts/response-wrapping).
+	// Read more at: https://learn.hashicorp.com/tutorials/vault/approle-best-practices?in=vault/auth-methods#secretid-delivery-best-practices
 
 	wrappingToken, err := ioutil.ReadFile("path/to/wrapping-token") // placed here by a trusted orchestrator
 	if err != nil {

--- a/website/content/docs/auth/approle.mdx
+++ b/website/content/docs/auth/approle.mdx
@@ -69,6 +69,10 @@ The response will contain the token at `auth.client_token`:
 }
 ```
 
+-> **Application Integration:** See the [Code Example](#code-example) section
+for a code snippet demonstrating the authentication with Vault using the
+AppRole auth method.
+
 ## Configuration
 
 Auth methods must be configured in advance before users or machines can

--- a/website/content/docs/auth/aws.mdx
+++ b/website/content/docs/auth/aws.mdx
@@ -741,7 +741,7 @@ details.
 
 ## Code Example
 
-The following code snippet demonstrates AWS authentication.
+The following code snippet uses the AWS auth method to authenticate with Vault.
 
 <CodeTabs heading="AppRole auth with response wrap">
 

--- a/website/content/docs/auth/aws.mdx
+++ b/website/content/docs/auth/aws.mdx
@@ -38,6 +38,11 @@ as it is more flexible and aligns with best practices to perform access
 control and authentication. See the section on comparing the two auth methods
 below for more information.
 
+-> **Usage:** See the [Authentication](#authentication) section for Vault CLI
+and API usage examples. The [Code Example](#code-example) section provides a
+code snippet demonstrating the authentication with Vault using the AWS auth
+method.
+
 ### IAM auth method
 
 The AWS STS API includes a method, [`sts:GetCallerIdentity`](http://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html), which allows you to validate the identity of a client. The client signs a `GetCallerIdentity` query using the [AWS Signature v4 algorithm](http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html) and sends it to the Vault server. The credentials used to sign the GetCallerIdentity request can come from the EC2 instance metadata service for an EC2 instance, or from the AWS environment variables in an AWS Lambda function execution, which obviates the need for an operator to manually provision some sort of identity material first. However, the credentials can, in principle, come from anywhere, not just from the locations AWS has provided for you.

--- a/website/content/docs/auth/aws.mdx
+++ b/website/content/docs/auth/aws.mdx
@@ -743,7 +743,7 @@ details.
 
 The following code snippet uses the AWS auth method to authenticate with Vault.
 
-<CodeTabs heading="AppRole auth with response wrap">
+<CodeTabs heading="AWS auth example">
 
 <CodeBlockConfig lineNumbers>
 

--- a/website/content/docs/auth/aws.mdx
+++ b/website/content/docs/auth/aws.mdx
@@ -738,3 +738,90 @@ The response will be in JSON. For example:
 The AWS auth method has a full HTTP API. Please see the
 [AWS Auth API](/api/auth/aws) for more
 details.
+
+## Code Example
+
+The following code snippet demonstrates AWS authentication.
+
+<CodeTabs heading="AppRole auth with response wrap">
+
+<CodeBlockConfig lineNumbers>
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/awsutil"
+	vault "github.com/hashicorp/vault/api"
+)
+
+// Fetches a key-value secret (kv-v2) after authenticating to Vault via AWS IAM,
+// one of two auth methods used to authenticate with AWS (the other is EC2 auth).
+// A role must first be created in Vault bound to the IAM ARN you wish to authenticate with, like so:
+// vault write auth/aws/role/dev-role-iam \
+//     auth_type=iam \
+//     bound_iam_principal_arn="arn:aws:iam::AWS-ACCOUNT-NUMBER:role/AWS-IAM-ROLE-NAME" \
+//     ttl=24h
+// Learn more about the available parameters at https://www.vaultproject.io/api/auth/aws#parameters-10
+func getSecretWithAWSAuthIAM() (string, error) {
+	config := vault.DefaultConfig() // modify for more granular configuration
+
+	client, err := vault.NewClient(config)
+	if err != nil {
+		return "", fmt.Errorf("unable to initialize Vault client: %w", err)
+	}
+
+	logger := hclog.Default()
+
+	// If environment variables are empty, will fall back on other AWS-provided mechanisms to retrieve credentials.
+	creds, err := awsutil.RetrieveCreds(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN"), logger)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve creds from STS: %w", err)
+	}
+
+	// the optional second parameter can be used to help mitigate replay attacks,
+	// when the role in Vault is configured with resolve_aws_unique_ids = true: https://www.vaultproject.io/docs/auth/aws#iam-auth-method
+	params, err := awsutil.GenerateLoginData(creds, "Replace-With-IAM-Server-Id", os.Getenv("AWS_DEFAULT_REGION"), logger)
+	if err != nil {
+		return "", err
+	}
+	if params == nil {
+		return "", fmt.Errorf("got nil response from GenerateLoginData")
+	}
+	params["role"] = "dev-role-iam" // the name of the role in Vault that was created with this IAM principal ARN bound to it
+
+	resp, err := client.Logical().Write("auth/aws/login", params)
+	if err != nil {
+		return "", fmt.Errorf("unable to log in with AWS IAM auth: %w", err)
+	}
+
+	client.SetToken(resp.Auth.ClientToken)
+
+	secret, err := client.Logical().Read("kv-v2/data/creds")
+	if err != nil {
+		return "", fmt.Errorf("unable to read secret: %w", err)
+	}
+
+	data, ok := secret.Data["data"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
+	}
+
+	// data map can contain more than one key-value pair, in this case we're just grabbing one of them
+	key := "password"
+	value, ok := data[key].(string)
+	if !ok {
+		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+	}
+
+	return value, nil
+}
+```
+
+</CodeBlockConfig>
+
+</CodeTabs>


### PR DESCRIPTION
This PR adds [Go code snippet written by the DevEx team](https://github.com/hashicorp/vault-examples/tree/main/go).

🔍 [Deploy Preview - AppRole auth method](https://vault-git-docs-auth-code-example-hashicorp.vercel.app/docs/auth/approle#code-example)

🔍 [Deploy Preview - AWS auth method](https://vault-git-docs-auth-code-example-hashicorp.vercel.app/docs/auth/aws#code-example)


The code example section appears on the navigation drop-down(?):

![code-example-final](https://user-images.githubusercontent.com/7660718/129078346-338ec395-502e-472f-b2e9-57ba7c2cd1f8.png)


