### PR TITLE
[Docs] Add documentation for username_template feature in AWS Secrets Engine

### DIFF
--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -66,13 +66,13 @@ valid AWS credentials with proper permissions.
   both conditional cases (see [Conditional Templates](https://pkg.go.dev/text/template)). As an example, if no template
   is provided the field defaults to the template:
 
-  `
+  ```
   {{ if (eq .Type "STS") }}
       {{ printf "vault-%s-%s" (unix_time) (random 20) | truncate 32 }}
   {{ else }}
       {{ printf "vault-%s-%s-%s" (printf "%s-%s" (.DisplayName) (.PolicyName) | truncate 42) (unix_time) (random 20) | truncate 64 }}
   {{ end }}
-  `
+  ```
 
 ### Sample Payload
 

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -58,6 +58,16 @@ valid AWS credentials with proper permissions.
 
 - `sts_endpoint` `(string: <optional>)` – Specifies a custom HTTP STS endpoint to use.
 
+- `username_template` `(string: <optional>)` - [Template](/docs/concepts/username-templating) describing how
+  dynamic usernames are generated. The `username_template` is used to generate both IAM usernames (capped at 64 characters) 
+  and STS usernames (capped at 32 characters). Longer usernames result in a 500 error.
+
+  To ensure generated usernames are within length limits for both STS/IAM, the template must adequately handle
+  both conditional cases (see [Conditional Templates](https://pkg.go.dev/text/template)). As an example, if no template
+  is provided the field defaults to the template:
+
+  `{{ if (eq .Type "STS") }}{{ printf "vault-%s-%s"  (unix_time) (random 20) | truncate 32 }}{{ else }}{{ printf "vault-%s-%s-%s" (printf "%s-%s" (.DisplayName) (.PolicyName) | truncate 42) (unix_time) (random 20) | truncate 64 }}{{ end }}`
+
 ### Sample Payload
 
 ```json

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -59,7 +59,7 @@ valid AWS credentials with proper permissions.
 - `sts_endpoint` `(string: <optional>)` – Specifies a custom HTTP STS endpoint to use.
 
 - `username_template` `(string: <optional>)` - [Template](/docs/concepts/username-templating) describing how
-  dynamic usernames are generated. The `username_template` is used to generate both IAM usernames (capped at 64 characters) 
+  dynamic usernames are generated. The username template is used to generate both IAM usernames (capped at 64 characters) 
   and STS usernames (capped at 32 characters). Longer usernames result in a 500 error.
 
   To ensure generated usernames are within length limits for both STS/IAM, the template must adequately handle

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -66,13 +66,13 @@ valid AWS credentials with proper permissions.
   both conditional cases (see [Conditional Templates](https://pkg.go.dev/text/template)). As an example, if no template
   is provided the field defaults to the template:
 
-  ```
+  `
   {{ if (eq .Type "STS") }}
       {{ printf "vault-%s-%s" (unix_time) (random 20) | truncate 32 }}
   {{ else }}
       {{ printf "vault-%s-%s-%s" (printf "%s-%s" (.DisplayName) (.PolicyName) | truncate 42) (unix_time) (random 20) | truncate 64 }}
   {{ end }}
-  ```
+  `
 
 ### Sample Payload
 

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -66,7 +66,13 @@ valid AWS credentials with proper permissions.
   both conditional cases (see [Conditional Templates](https://pkg.go.dev/text/template)). As an example, if no template
   is provided the field defaults to the template:
 
-  `{{ if (eq .Type "STS") }}{{ printf "vault-%s-%s"  (unix_time) (random 20) | truncate 32 }}{{ else }}{{ printf "vault-%s-%s-%s" (printf "%s-%s" (.DisplayName) (.PolicyName) | truncate 42) (unix_time) (random 20) | truncate 64 }}{{ end }}`
+  ```
+  {{ if (eq .Type "STS") }}
+      {{ printf "vault-%s-%s" (unix_time) (random 20) | truncate 32 }}
+  {{ else }}
+      {{ printf "vault-%s-%s-%s" (printf "%s-%s" (.DisplayName) (.PolicyName) | truncate 42) (unix_time) (random 20) | truncate 64 }}
+  {{ end }}
+  ```
 
 ### Sample Payload
 


### PR DESCRIPTION
Adds documentation about the `username_template` feature, including length limits, errors and an example conditional template.