### PR TITLE
database/cassandra: pin bitnami/cassandra docker image to 3.11 in test

### DIFF
--- a/plugins/database/cassandra/connection_producer_test.go
+++ b/plugins/database/cassandra/connection_producer_test.go
@@ -42,7 +42,7 @@ func TestSelfSignedCA(t *testing.T) {
 
 	host, cleanup := cassandra.PrepareTestContainer(t,
 		cassandra.ContainerName("cassandra"),
-		cassandra.Image("bitnami/cassandra", "latest"),
+		cassandra.Image("bitnami/cassandra", "3.11"),
 		cassandra.CopyFromTo(copyFromTo),
 		cassandra.SslOpts(sslOpts),
 		cassandra.Env("CASSANDRA_KEYSTORE_PASSWORD=cassandra"),

--- a/plugins/database/cassandra/connection_producer_test.go
+++ b/plugins/database/cassandra/connection_producer_test.go
@@ -42,7 +42,7 @@ func TestSelfSignedCA(t *testing.T) {
 
 	host, cleanup := cassandra.PrepareTestContainer(t,
 		cassandra.ContainerName("cassandra"),
-		cassandra.Image("bitnami/cassandra", "3.11"),
+		cassandra.Image("bitnami/cassandra", "3.11.11"),
 		cassandra.CopyFromTo(copyFromTo),
 		cassandra.SslOpts(sslOpts),
 		cassandra.Env("CASSANDRA_KEYSTORE_PASSWORD=cassandra"),


### PR DESCRIPTION
This PR addresses test failures being on `TestSelfSignedCA` by pinning the bitnami/cassandra docker image to version 3.11. We should backport this to 1.7.x and 1.8.x release branches as well to stop test failures. 

Related to https://github.com/hashicorp/vault/pull/12174