### PR TITLE
Backport 1.8.x: database/cassandra: pin bitnami/cassandra docker image to 3.11 in tes…

### DIFF
--- a/plugins/database/cassandra/connection_producer_test.go
+++ b/plugins/database/cassandra/connection_producer_test.go
@@ -42,7 +42,7 @@ func TestSelfSignedCA(t *testing.T) {
 
 	host, cleanup := cassandra.PrepareTestContainer(t,
 		cassandra.ContainerName("cassandra"),
-		cassandra.Image("bitnami/cassandra", "latest"),
+		cassandra.Image("bitnami/cassandra", "3.11.11"),
 		cassandra.CopyFromTo(copyFromTo),
 		cassandra.SslOpts(sslOpts),
 		cassandra.Env("CASSANDRA_KEYSTORE_PASSWORD=cassandra"),


### PR DESCRIPTION
…t (#12311)

* database/cassandra: pin bitnami/cassandra docker image to 3.11 in test

* Update plugins/database/cassandra/connection_producer_test.go

Co-authored-by: Theron Voran <tvoran@users.noreply.github.com>

Co-authored-by: Theron Voran <tvoran@users.noreply.github.com>