### PR TITLE
auth/aws: log error if pkcs7 verification fails

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -103,8 +103,8 @@ This must match the request body included in the signature.`,
 			"iam_request_headers": {
 				Type: framework.TypeHeader,
 				Description: `Key/value pairs of headers for use in the
-sts:GetCallerIdentity HTTP requests headers when auth_type is iam. Can be either 
-a Base64-encoded, JSON-serialized string, or a JSON object of key/value pairs. 
+sts:GetCallerIdentity HTTP requests headers when auth_type is iam. Can be either
+a Base64-encoded, JSON-serialized string, or a JSON object of key/value pairs.
 This must at a minimum include the headers over which AWS has included a  signature.`,
 			},
 			"identity": {
@@ -349,7 +349,7 @@ func (b *backend) parseIdentityDocument(ctx context.Context, s logical.Storage, 
 	// Verify extracts the authenticated attributes in the PKCS#7 signature, and verifies
 	// the authenticity of the content using 'dsa.PublicKey' embedded in the public certificate.
 	if pkcs7Data.Verify() != nil {
-		return nil, fmt.Errorf("failed to verify the signature")
+		return nil, fmt.Errorf("failed to verify the signature: %w", err)
 	}
 
 	// Check if the signature has content inside of it

--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -103,8 +103,8 @@ This must match the request body included in the signature.`,
 			"iam_request_headers": {
 				Type: framework.TypeHeader,
 				Description: `Key/value pairs of headers for use in the
-sts:GetCallerIdentity HTTP requests headers when auth_type is iam. Can be either
-a Base64-encoded, JSON-serialized string, or a JSON object of key/value pairs.
+sts:GetCallerIdentity HTTP requests headers when auth_type is iam. Can be either 
+a Base64-encoded, JSON-serialized string, or a JSON object of key/value pairs. 
 This must at a minimum include the headers over which AWS has included a  signature.`,
 			},
 			"identity": {
@@ -348,7 +348,8 @@ func (b *backend) parseIdentityDocument(ctx context.Context, s logical.Storage, 
 
 	// Verify extracts the authenticated attributes in the PKCS#7 signature, and verifies
 	// the authenticity of the content using 'dsa.PublicKey' embedded in the public certificate.
-	if pkcs7Data.Verify() != nil {
+	err = pkcs7Data.Verify()
+	if err != nil {
 		return nil, fmt.Errorf("failed to verify the signature: %w", err)
 	}
 

--- a/changelog/12315.txt
+++ b/changelog/12315.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-auth/aws: Fixes bug where PKCS7 error was not returned if signature verification fails
+```release-note:improvement
+auth/aws: PKCS7 verification error messages are now returned to user
 ```

--- a/changelog/12315.txt
+++ b/changelog/12315.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/aws: Fixes bug where PKCS7 error was not returned if signature verification fails
+```


### PR DESCRIPTION
If an error occurs when verifying the pkcs7 signature, the error is not reported back to the user. Since a lot can go wrong in the verification process, we should return this error for easier debugging.