### PR TITLE
Vault 2176 snapshot config issue

### DIFF
--- a/changelog/12317.txt
+++ b/changelog/12317.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+core (enterprise): Fixes reading raft auto-snapshot configuration from performance standby node
+```

--- a/http/handler.go
+++ b/http/handler.go
@@ -107,7 +107,9 @@ var (
 
 func init() {
 	alwaysRedirectPaths.AddPaths([]string{
+		"sys/storage/raft/snapshot",
 		"sys/storage/raft/snapshot-force",
+		"!sys/storage/raft/snapshot-auto/config",
 	})
 }
 

--- a/http/handler.go
+++ b/http/handler.go
@@ -107,7 +107,6 @@ var (
 
 func init() {
 	alwaysRedirectPaths.AddPaths([]string{
-		"sys/storage/raft/snapshot",
 		"sys/storage/raft/snapshot-force",
 	})
 }


### PR DESCRIPTION
Issue : When reading raft auto-snapshot configuration from performance standby node, API request results to 307 - Temporary Redirect error. It works just find on active node.Seems like for api's under path snapshot-auto the redirect is not handled correctly.

Jira Link : https://hashicorp.atlassian.net/browse/VAULT-2176

Testing:
curl -v --header X-Vault-Token:s.pxkZWVdsWpcnU6f3LYv4Z5sO --request LIST http://127.0.0.3:8200/v1/sys/storage/raft/snapshot-auto/config

Trying 127.0.0.3...
TCP_NODELAY set
Connected to 127.0.0.3 (127.0.0.3) port 8200 (#0)
LIST /v1/sys/storage/raft/snapshot-auto/config HTTP/1.1
Host: 127.0.0.3:8200
User-Agent: curl/7.64.1
Accept: /
X-Vault-Token:s.pxkZWVdsWpcnU6f3LYv4Z5sO

< HTTP/1.1 200 OK
< Cache-Control: no-store
< Content-Type: application/json
< Date: Wed, 11 Aug 2021 19:42:46 GMT
< Content-Length: 176
<
{"request_id":"672f8256-8a19-86fd-06da-2bd0835bb998","lease_id":"","renewable":false,"lease_duration":0,"data":{"keys":["daily"]},"wrap_info":null,"warnings":null,"auth":null}

Connection #0 to host 127.0.0.3 left intact
Closing connection 0