### PR TITLE
Send x-forwarded-for in Okta Push Factor request

### DIFF
--- a/builtin/credential/okta/backend.go
+++ b/builtin/credential/okta/backend.go
@@ -3,6 +3,7 @@ package okta
 import (
 	"context"
 	"fmt"
+	"net/textproto"
 	"time"
 
 	"github.com/hashicorp/vault/helper/mfa"
@@ -215,6 +216,9 @@ func (b *backend) Login(ctx context.Context, req *logical.Request, username, pas
 		verifyReq, err := shim.NewRequest("POST", requestPath, payload)
 		if err != nil {
 			return nil, nil, nil, err
+		}
+		if len(req.Headers["X-Forwarded-For"]) > 0 {
+			verifyReq.Header.Set("X-Forwarded-For", req.Headers[textproto.CanonicalMIMEHeaderKey("X-Forwarded-For")][0])
 		}
 
 		rsp, err := shim.Do(verifyReq, &result)

--- a/changelog/12320.txt
+++ b/changelog/12320.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/okta: Send x-forwarded-for in Okta Push Factor request
+```


### PR DESCRIPTION
Why:

In order for Okta to properly report the location of the authentication
attempt, the X-Forwarded-For header must be included in the request to
Okta (if it exists).

This change addresses the need by:

* Duplicating the value of X-Forwarded-For if it's passed through to the
  auth backend

Fixes #12319 