### PR TITLE
Update examples.mdx

### DIFF
--- a/website/content/docs/platform/k8s/csi/examples.mdx
+++ b/website/content/docs/platform/k8s/csi/examples.mdx
@@ -140,7 +140,7 @@ spec:
       containers:
         - name: app
           image: my-app:1.0.0
-          envs:
+          env:
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Deployment manifest has incorrect `envs` tag. It should be `env`