### PR TITLE
docs: draft update guide for identity token roles

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.9.0.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.9.0.mdx
@@ -14,3 +14,14 @@ official guidance until the release has been completed.
 This page contains the list of deprecations and important or breaking changes
 for Vault 1.9.0 compared to 1.8. Please read it carefully.
 
+## Identity Tokens
+
+The Identity secrets engine has changed the procedure for creating Identity
+token roles. When creating a role, the key parameter is required and the key
+must exist. Previously, it was possible to create a role and assign it a named
+key that did not yet exist despite the documentation stating otherwise.
+
+All calls to [create or update a role](https://www.vaultproject.io/api/secret/identity/tokens#create-or-update-a-role)
+must be checked to ensure that roles are not being created or updated with
+non-existent keys.
+


### PR DESCRIPTION
The 1.9 release will change Identity token role validation for signing keys. Relevant PR: https://github.com/hashicorp/vault/pull/12208