### PR TITLE
api: return parse errors if any for storage endpoints

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -81,7 +81,7 @@ func (c *Logical) ReadWithData(path string, data map[string][]string) (*Secret, 
 		case io.EOF:
 			return nil, nil
 		default:
-			return nil, err
+			return nil, parseErr
 		}
 		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
 			return secret, nil
@@ -159,7 +159,7 @@ func (c *Logical) write(path string, request *Request) (*Secret, error) {
 		case io.EOF:
 			return nil, nil
 		default:
-			return nil, err
+			return nil, parseErr
 		}
 		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
 			return secret, err
@@ -206,7 +206,7 @@ func (c *Logical) DeleteWithData(path string, data map[string][]string) (*Secret
 		case io.EOF:
 			return nil, nil
 		default:
-			return nil, err
+			return nil, parseErr
 		}
 		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
 			return secret, err
@@ -259,7 +259,7 @@ func (c *Logical) Unwrap(wrappingToken string) (*Secret, error) {
 	case io.EOF:
 		return nil, nil
 	default:
-		return nil, err
+		return nil, parseErr
 	}
 	if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
 		return secret, nil

--- a/api/logical.go
+++ b/api/logical.go
@@ -115,7 +115,7 @@ func (c *Logical) List(path string) (*Secret, error) {
 		case io.EOF:
 			return nil, nil
 		default:
-			return nil, err
+			return nil, parseErr
 		}
 		if secret != nil && (len(secret.Warnings) > 0 || len(secret.Data) > 0) {
 			return secret, nil

--- a/changelog/12338.txt
+++ b/changelog/12338.txt
@@ -1,3 +1,3 @@
 ```release-note: bug
-api/list: Fixes list storage API returning incorrect error when parsing responses
+api: Fixes storage APIs returning incorrect error when parsing responses
 ```

--- a/changelog/12338.txt
+++ b/changelog/12338.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+api/list: Fixes list storage API returning incorrect error when parsing responses
+```


### PR DESCRIPTION
I think this is returning the wrong error, which could result in an empty error being returned from Vault. If parsing the response body fails in some way not defined in the switch/case, we should return the error to the user.