### PR TITLE
Update upgrade-to-1.3.10.mdx

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.3.10.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.3.10.mdx
@@ -9,6 +9,6 @@ description: |-
 # Overview
 
 This page contains the list of deprecations and important or breaking changes
-for Vault 1.3.10 compared to 1.3.10. Please read it carefully.
+for Vault 1.3.10 compared to 1.3.9. Please read it carefully.
 
 @include 'aws-invalid-header-fix.mdx'


### PR DESCRIPTION
The upgrade guide indicates the upgrade path between two identical versions:

> Vault 1.3.10 compared to 1.3.10

 Presumably you meant compared to `1.3.9`, which is the previous version listed here: https://www.vaultproject.io/docs/upgrading?

Similarly:
* The [1.3.9 upgrade guide](https://www.vaultproject.io/docs/upgrading/upgrade-to-1.3.9) states:
> Vault 1.3.9 compared to 1.3.7
But `1.3.7` is not listed at https://www.vaultproject.io/docs/upgrading

* The [1.3.8 upgrade guide](https://www.vaultproject.io/docs/upgrading/upgrade-to-1.3.8) states:
> Vault 1.3.8 compared to 1.3.7
But `1.3.7` is not listed at https://www.vaultproject.io/docs/upgrading