### PR TITLE
Docs: API Docs: Identity tokens

### DIFF
--- a/website/content/api-docs/secret/identity/tokens.mdx
+++ b/website/content/api-docs/secret/identity/tokens.mdx
@@ -365,7 +365,6 @@ Use this endpoint to generate a signed ID (OIDC) token.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request GET \
-    --data @payload.json \
     http://127.0.0.1:8200/v1/identity/oidc/token/role-001
 ```
 


### PR DESCRIPTION
The sample request in the **Generate a Signed ID Token** section includes references to an unnecessary `--data` flag and `payload.json`.

The endpoint/request does not actually require a payload, so I removed it from the sample as it was reported to be confusing.
