### PR TITLE
UI: Allow metrics view without config read

### DIFF
--- a/changelog/12348.txt
+++ b/changelog/12348.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+ui: Fixes metrics page when read on counter config not allowed
+```

--- a/ui/app/templates/vault/cluster/metrics/index.hbs
+++ b/ui/app/templates/vault/cluster/metrics/index.hbs
@@ -50,7 +50,7 @@
       @queryEnd={{model.queryEnd}}
       @resultStart={{model.activity.startTime}}
       @resultEnd={{model.activity.endTime}}
-      @defaultSpan={{model.config.defaultReportMonths}}
+      @defaultSpan={{or model.config.defaultReportMonths 12}}
       @retentionMonths={{model.config.retentionMonths}}
     />
     {{#unless model.activity.total}}


### PR DESCRIPTION
Fixes a bug where if config is not read, the metrics do not render correctly due to badly assigned default value. Now, the parent component passes in a valid value even if the one read from config is not available. Notice in the screenshot, the config tab is still not visible if the user cannot read the config endpoint

<img width="1268" alt="Screen Shot 2021-08-18 at 12 33 41 PM" src="https://user-images.githubusercontent.com/82459713/129945189-eb883907-56c5-46b7-8568-2a6c0f9c09bc.png">
