### PR TITLE
Refactor databaseVersionWrapper

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -205,7 +205,7 @@ func TestBackend_config_connection(t *testing.T) {
 				"someotherdata":  "testing",
 			},
 			"allowed_roles":                      []string{"*"},
-			"root_credentials_rotate_statements": []string{},
+			"root_credentials_rotate_statements": []string(nil),
 			"password_policy":                    "",
 		}
 		configReq.Operation = logical.ReadOperation
@@ -258,7 +258,7 @@ func TestBackend_config_connection(t *testing.T) {
 				"someotherdata":  "testing",
 			},
 			"allowed_roles":                      []string{"*"},
-			"root_credentials_rotate_statements": []string{},
+			"root_credentials_rotate_statements": []string(nil),
 			"password_policy":                    "",
 		}
 		configReq.Operation = logical.ReadOperation
@@ -300,7 +300,7 @@ func TestBackend_config_connection(t *testing.T) {
 				"someotherdata":  "testing",
 			},
 			"allowed_roles":                      []string{"flu", "barre"},
-			"root_credentials_rotate_statements": []string{},
+			"root_credentials_rotate_statements": []string(nil),
 			"password_policy":                    "",
 		}
 		configReq.Operation = logical.ReadOperation


### PR DESCRIPTION
This refactor changes the NewUser function so it returns response data  than parts of the ultimate response. NOTE: This does not change the `Database` interface itself, nor any external APIs. This change is purely internal to the DB engine. The new function handles kind of like a request handler in that it returns the response data that should be put into the `Secret.Data`. This refactor also improves the ability to support alternative credential types.