### PR TITLE
Backport 1.6.6: UI Allow metrics view without config read (#12348)

### DIFF
--- a/changelog/12348.txt
+++ b/changelog/12348.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+ui: Fixes metrics page when read on counter config not allowed
+```

--- a/ui/app/templates/vault/cluster/metrics/index.hbs
+++ b/ui/app/templates/vault/cluster/metrics/index.hbs
@@ -64,7 +64,7 @@
       @queryEnd={{model.queryEnd}}
       @resultStart={{model.activity.startTime}}
       @resultEnd={{model.activity.endTime}}
-      @defaultSpan={{model.config.defaultReportMonths}}
+      @defaultSpan={{or model.config.defaultReportMonths 12}}
       @retentionMonths={{model.config.retentionMonths}}
     />
     {{#unless model.activity.total}}


### PR DESCRIPTION
Backport of #12348 