### PR TITLE
Auto-join support for IPv6 discovery

### DIFF
--- a/changelog/12366.txt
+++ b/changelog/12366.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/raft: Support `addr_type=public_v6` in auto-join
+```

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -947,11 +947,6 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 				}
 
 			case leaderInfo.AutoJoin != "":
-				// go-discover returns IPs
-				addrs, err := disco.Addrs(leaderInfo.AutoJoin, c.logger.StandardLogger(nil))
-				if err != nil {
-					c.logger.Error("failed to parse addresses from auto-join metadata", "error", err)
-				}
 				scheme := leaderInfo.AutoJoinScheme
 				if scheme == "" {
 					// default to HTTPS when no scheme is provided
@@ -962,12 +957,17 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 					// default to 8200 when no port is provided
 					port = 8200
 				}
-				for _, addr := range addrs {
-					if strings.Count(addr, ":") != 0 {
-						// ipv6, make it explicit
-						addr = fmt.Sprintf("[%s]", addr)
+				// Addrs returns either IPv4 or IPv6 address sans scheme or port
+				clusterIPs, err := disco.Addrs(leaderInfo.AutoJoin, c.logger.StandardLogger(nil))
+				if err != nil {
+					c.logger.Error("failed to parse addresses from auto-join metadata", "error", err)
+				}
+				for _, ip := range clusterIPs {
+					if strings.Count(ip, ":") >= 2 && !strings.HasPrefix(ip, "["){
+						// An IPv6 address in implicit form, however we need it in explicit form to use in a URL.
+						ip = fmt.Sprintf("[%s]", ip)
 					}
-					u := fmt.Sprintf("%s://%s:%d", scheme, addr, port)
+					u := fmt.Sprintf("%s://%s:%d", scheme, ip, port)
 					if err := joinLeader(leaderInfo, u); err != nil {
 						c.logger.Warn("join attempt failed", "error", err)
 					} else {

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -947,39 +947,28 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 				}
 
 			case leaderInfo.AutoJoin != "":
+				// go-discover returns IPs
 				addrs, err := disco.Addrs(leaderInfo.AutoJoin, c.logger.StandardLogger(nil))
 				if err != nil {
 					c.logger.Error("failed to parse addresses from auto-join metadata", "error", err)
 				}
-
+				scheme := leaderInfo.AutoJoinScheme
+				if scheme == "" {
+					// default to HTTPS when no scheme is provided
+					scheme = "https"
+				}
+				port := leaderInfo.AutoJoinPort
+				if port == 0 {
+					// default to 8200 when no port is provided
+					port = 8200
+				}
 				for _, addr := range addrs {
-					u, err := url.Parse(addr)
-					if err != nil {
-						c.logger.Error("failed to parse discovered address", "error", err)
-						continue
+					if strings.Count(addr, ":") != 0 {
+						// ipv6, make it explicit
+						addr = fmt.Sprintf("[%s]", addr)
 					}
-
-					if u.Scheme == "" {
-						scheme := leaderInfo.AutoJoinScheme
-						if scheme == "" {
-							// default to HTTPS when no scheme is provided
-							scheme = "https"
-						}
-
-						addr = fmt.Sprintf("%s://%s", scheme, addr)
-					}
-
-					if u.Port() == "" {
-						port := leaderInfo.AutoJoinPort
-						if port == 0 {
-							// default to 8200 when no port is provided
-							port = 8200
-						}
-
-						addr = fmt.Sprintf("%s:%d", addr, port)
-					}
-
-					if err := joinLeader(leaderInfo, addr); err != nil {
+					u := fmt.Sprintf("%s://%s:%d", scheme, addr, port)
+					if err := joinLeader(leaderInfo, u); err != nil {
 						c.logger.Warn("join attempt failed", "error", err)
 					} else {
 						// successfully joined leader


### PR DESCRIPTION
The go-discover library returns IP addresses and not URLs. It just so
happens net.URL parses "127.0.0.1", which isn't a valid URL.

Instead, we construct the URL ourselves. Being careful to check if it's
an ipv6 address and making sure it's in explicit form if so.

Fixes #12323