### PR TITLE
[MAR-3131] Set grace to 0 on non-positive lease duration

### DIFF
--- a/api/lifetime_watcher.go
+++ b/api/lifetime_watcher.go
@@ -377,7 +377,7 @@ func (r *LifetimeWatcher) doRenewWithOptions(tokenMode bool, nonRenewable bool, 
 // assumptions given the total lease time; it also adds some jitter to not have
 // clients be in sync.
 func (r *LifetimeWatcher) calculateGrace(leaseDuration time.Duration) {
-	if leaseDuration == 0 {
+	if leaseDuration <= 0 {
 		r.grace = 0
 		return
 	}

--- a/api/renewer_test.go
+++ b/api/renewer_test.go
@@ -149,6 +149,17 @@ func TestLifetimeWatcher(t *testing.T) {
 			nil,
 			false,
 		},
+		{
+			15 * time.Second,
+			"negative_lease_duration",
+			-15,
+			15,
+			func(_ string, _ int) (*Secret, error) {
+				return renewedSecret, nil
+			},
+			nil,
+			true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/changelog/12372.txt
+++ b/changelog/12372.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+core/api: Fix an arm64 bug converting a negative int to an unsigned int
+```


### PR DESCRIPTION
- There currently exists an arm64 bug, as when converting a negative float into a uint64 value on arm64 results in a 0, causing the grace calculation on L390 to panic due to a `modulo by 0` error. ( ref https://github.com/golang/go/issues/43047 )
- Expanding the current check, to set the grace value to 0 when the lease duration is negative, fixes this error by exiting the function on a negative value of leaseDuration, without causing any regression in the existing tests
- note that there is further discussion around this on this thread https://github.com/hashicorp/vault-enterprise/pull/2095#discussion_r691512265