### PR TITLE
docs: add missing kubernetes role verb

### DIFF
--- a/website/content/docs/configuration/service-registration/kubernetes.mdx
+++ b/website/content/docs/configuration/service-registration/kubernetes.mdx
@@ -53,7 +53,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "update"]
+  verbs: ["get", "update", "patch"]
 ```
 
 ## Examples


### PR DESCRIPTION
The `patch` verb is required to update labels for the Service Registration feature.

#9073 with conflicts resolved, @jasonodonnell.