### PR TITLE
fix struct tags and test in ldaputil

### DIFF
--- a/sdk/helper/ldaputil/config.go
+++ b/sdk/helper/ldaputil/config.go
@@ -371,8 +371,6 @@ type ConfigEntry struct {
 	UPNDomain                string `json:"upndomain"`
 	UserAttr                 string `json:"userattr"`
 	Certificate              string `json:"certificate"`
-	ClientTLSCert            string `json:"client_tls_cert`
-	ClientTLSKey             string `json:"client_tls_key`
 	InsecureTLS              bool   `json:"insecure_tls"`
 	StartTLS                 bool   `json:"starttls"`
 	BindDN                   string `json:"binddn"`
@@ -385,11 +383,13 @@ type ConfigEntry struct {
 	UsePre111GroupCNBehavior *bool  `json:"use_pre111_group_cn_behavior"`
 	RequestTimeout           int    `json:"request_timeout"`
 
-	// This json tag deviates from snake case because there was a past issue
-	// where the tag was being ignored, causing it to be jsonified as "CaseSensitiveNames".
+	// These json tags deviate from snake case because there was a past issue
+	// where the tag was being ignored, causing it to be jsonified as "CaseSensitiveNames", etc.
 	// To continue reading in users' previously stored values,
 	// we chose to carry that forward.
-	CaseSensitiveNames *bool `json:"CaseSensitiveNames,omitempty"`
+	CaseSensitiveNames *bool  `json:"CaseSensitiveNames,omitempty"`
+	ClientTLSCert      string `json:"ClientTLSCert"`
+	ClientTLSKey       string `json:"ClientTLSKey"`
 }
 
 func (c *ConfigEntry) Map() map[string]interface{} {

--- a/sdk/helper/ldaputil/config_test.go
+++ b/sdk/helper/ldaputil/config_test.go
@@ -164,6 +164,6 @@ var jsonConfigDefault = []byte(`
   "use_token_groups": false,
   "use_pre111_group_cn_behavior": null,
   "request_timeout": 90,
-  "case_sensitive_names": false
+  "CaseSensitiveNames": false
 }
 `)

--- a/sdk/helper/ldaputil/config_test.go
+++ b/sdk/helper/ldaputil/config_test.go
@@ -164,6 +164,8 @@ var jsonConfigDefault = []byte(`
   "use_token_groups": false,
   "use_pre111_group_cn_behavior": null,
   "request_timeout": 90,
-  "CaseSensitiveNames": false
+  "CaseSensitiveNames": false,
+  "ClientTLSCert": "",
+  "ClientTLSKey": ""
 }
 `)

--- a/sdk/helper/ldaputil/config_test.go
+++ b/sdk/helper/ldaputil/config_test.go
@@ -78,6 +78,8 @@ func testConfig(t *testing.T) *ConfigEntry {
 		TLSMaxVersion:  "tls12",
 		TLSMinVersion:  "tls12",
 		RequestTimeout: 30,
+		ClientTLSCert:  "",
+		ClientTLSKey:   "",
 	}
 }
 
@@ -128,17 +130,17 @@ Beq3QOqp2+dga36IzQybzPQ8QtotrpSJ3q82zztEvyWiJ7E=
 -----END CERTIFICATE-----
 `
 
-var jsonConfig = []byte(`
-{
+var jsonConfig = []byte(`{
 	"url": "ldap://138.91.247.105",
 	"userdn": "example,com",
 	"binddn": "kitty",
 	"bindpass": "cats",
 	"tls_max_version": "tls12",
 	"tls_min_version": "tls12",
-	"request_timeout": 30
-}
-`)
+	"request_timeout": 30,
+	"ClientTLSCert":  "",
+	"ClientTLSKey":   ""
+}`)
 
 var jsonConfigDefault = []byte(`
 {


### PR DESCRIPTION
In sdk/helper/ldaputil/config.go, two of the struct tags are incomplete and now fail `vet`.

Because this is persisted data, the practical best we can do is fix them to be CamelCase, lest we break installations. We should do this though to avoid someone quickly “fixing” them by just adding the missing ".