### PR TITLE
[VAULT-3226] Use os.rename on windows os

### DIFF
--- a/changelog/12377.txt
+++ b/changelog/12377.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+physical/raft: Fix safeio.Rename error when restoring snapshots on windows
+```


### PR DESCRIPTION
- Updates the file renaming when restoring snapshots, to do os.Rename on windows machines

Logs under current binary, when doing a snapshot save followed by restore
<img width="1249" alt="Screen Shot 2021-08-19 at 3 18 26 PM" src="https://user-images.githubusercontent.com/35388175/130151695-2c060b5d-90f9-49e1-aba2-0c51f84166f9.png">
