### PR TITLE
[VAULT-3226] 1.7 backport for windows snapshot issue

### DIFF
--- a/changelog/12377.txt
+++ b/changelog/12377.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+physical/raft: Fix safeio.Rename error when restoring snapshots on windows
+```


### PR DESCRIPTION
* [VAULT-3226] Use os.rename on windows os

* [VAULT-3226] Add changelog

[VAULT-3226]: https://hashicorp.atlassian.net/browse/VAULT-3226
[VAULT-3226]: https://hashicorp.atlassian.net/browse/VAULT-3226