### PR TITLE
docs: fix typos in ui and website

### DIFF
--- a/ui/lib/core/stories/form-save-buttons.md
+++ b/ui/lib/core/stories/form-save-buttons.md
@@ -10,7 +10,7 @@
 | [saveButtonText] | <code>String</code> | <code>&quot;Save&quot;</code> | The text that will be rendered on the Save button. |
 | [isSaving] | <code>Boolean</code> | <code>false</code> | If the form is saving, this should be true. This will disable the save button and render a spinner on it; |
 | [cancelLinkParams] | <code>Array</code> | <code>[]</code> | An array of arguments used to construct a link to navigate back to when the Cancel button is clicked. |
-| [onCancel] | <code>Fuction</code> | <code></code> | If the form should call an action on cancel instead of route somewhere, the fucntion can be passed using onCancel instead of passing an array to cancelLinkParams. |
+| [onCancel] | <code>Fuction</code> | <code></code> | If the form should call an action on cancel instead of route somewhere, the function can be passed using onCancel instead of passing an array to cancelLinkParams. |
 | [includeBox] | <code>Boolean</code> | <code>true</code> | By default we include padding around the form with underlines. Passing this value as false will remove that padding. |
 
 **Example**

--- a/ui/lib/core/stories/list-view.md
+++ b/ui/lib/core/stories/list-view.md
@@ -1,7 +1,7 @@
 <!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in lib/core/addon/components/list-view.js. To make changes, first edit that file and run "yarn gen-story-md list-view" to re-generate the content.-->
 
 ## ListView
-`ListView` components are used in conjuction with `ListItem` for rendering a list.
+`ListView` components are used in conjunction with `ListItem` for rendering a list.
 
 
 | Param | Type | Default | Description |

--- a/ui/stories/file-to-array-buffer.md
+++ b/ui/stories/file-to-array-buffer.md
@@ -1,3 +1,4 @@
+
 <!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in app/components/file-to-array-buffer.js. To make changes, first edit that file and run "yarn gen-story-md file-to-array-buffer" to re-generate the content.-->
 
 ## FileToArrayBuffer
@@ -8,7 +9,7 @@ loaded, this file will be emitted as a JS ArrayBuffer to the passed `onChange` c
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| onChange | <code>function</code> | <code></code> | The function to call when the file read is complete. This function recieves the file as a JS ArrayBuffer |
+| onChange | <code>function</code> | <code></code> | The function to call when the file read is complete. This function receives the file as a JS ArrayBuffer |
 | [label] | <code>String</code> | <code></code> | Text to use as the label for the file input |
 | fileHelpText | <code>String</code> | <code></code> | Text to use as help under the file input |
 

--- a/website/README.md
+++ b/website/README.md
@@ -150,7 +150,7 @@ $ curl ...
 </Tab>
 </Tabs>
 
-Contined normal markdown content
+Continued normal markdown content
 ````
 
 The intentionally skipped line is a limitation of the mdx parser which is being actively worked on. All tabs must have a heading, and there is no limit to the number of tabs, though it is recommended to go for a maximum of three or four.


### PR DESCRIPTION
made corrections to the typos i have found in the documentations.