### PR TITLE
Typo fix in docs/commands/index.mdx

### DIFF
--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -323,7 +323,7 @@ used.
 
 There are different CLI flags that are available depending on subcommands. Some
 flags, such as those used for setting HTTP and output options, are available
-globally, while others are specific to a particular subcommand. For a completely
+globally, while others are specific to a particular subcommand. For a complete
 list of available flags, run:
 
 ```shell-session


### PR DESCRIPTION
Typo fix.