### PR TITLE
feat: set tags on assumed role identities

### DIFF
--- a/builtin/logical/aws/path_roles.go
+++ b/builtin/logical/aws/path_roles.go
@@ -499,7 +499,7 @@ type awsRoleEntry struct {
 	RoleArns                 []string          `json:"role_arns"`                             // ARNs of roles to assume for AssumedRole credentials
 	PolicyDocument           string            `json:"policy_document"`                       // JSON-serialized inline policy to attach to IAM users and/or to specify as the Policy parameter in AssumeRole calls
 	IAMGroups                []string          `json:"iam_groups"`                            // Names of IAM groups that generated IAM users will be added to
-	IAMTags                  map[string]string `json:"iam_tags"`                              // IAM tags that will be added to the generated IAM users
+	IAMTags                  map[string]string `json:"iam_tags"`                              // IAM tags that will be added to the generated IAM users or AssumedRole credentials
 	InvalidData              string            `json:"invalid_data,omitempty"`                // Invalid role data. Exists to support converting the legacy role data into the new format
 	ProhibitFlexibleCredPath bool              `json:"prohibit_flexible_cred_path,omitempty"` // Disallow accessing STS credentials via the creds path and vice verse
 	Version                  int               `json:"version"`                               // Version number of the role format

--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -130,7 +130,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		case !strutil.StrListContains(role.RoleArns, roleArn):
 			return logical.ErrorResponse(fmt.Sprintf("role_arn %q not in allowed role arns for Vault role %q", roleArn, roleName)), nil
 		}
-		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl, roleSessionName)
+		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl, roleSessionName, role)
 	case federationTokenCred:
 		return b.getFederationToken(ctx, req.Storage, req.DisplayName, roleName, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl)
 	default:

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -277,10 +277,11 @@ updated with the new attributes.
   and `policy_arns` parameters.
 
 - `iam_tags` `(list: [])` - A list of strings representing a key/value pair to be used as a
-  tag for any `iam_user` user that is created by this role. Format is a key and value
-  separated by an `=` (e.g. `test_key=value`). Note: when using the CLI multiple tags
-  can be specified in the role configuration by adding another `iam_tags` assignment
-  in the same command.
+  tag for any `iam_user` user or AssumedRole identity that is created by this role. Format
+  is a key and value separated by an `=` (e.g. `test_key=value`). Note: when using the CLI
+  multiple tags can be specified in the role configuration by adding another `iam_tags`
+  assignment in the same command.  For AssumedRole identities, the TransitiveTagKeys are
+  also set.
 
 - `default_sts_ttl` `(string)` - The default TTL for STS credentials. When a TTL is not
   specified when STS credentials are requested, and a default TTL is specified


### PR DESCRIPTION
This feature adds the tags, if specified in the vault role, to the
AssumeRole call to AWS to set the tags on the assumed role identity.  It
also sets the TransitiveTagKeys to the list of keys for the tags.  This
will ensure that any chained AssumeRole identities retain the tags.