### PR TITLE
docs: fix exit flag reference on agent

### DIFF
--- a/website/content/docs/agent/index.mdx
+++ b/website/content/docs/agent/index.mdx
@@ -104,7 +104,7 @@ section.
 
 For requests from the templating engine, Agent will reset its retry counter and
 perform retries again once all retries are exhausted. This means that templating
-will retry on failures indefinitely unless `exit_after_retry_failure` from the
+will retry on failures indefinitely unless `exit_on_retry_failure` from the
 [`template_config`][template-config] stanza is set to `true`.
 
 Here are the options for the `retry` stanza:


### PR DESCRIPTION
Small PR to fix the reference on `exit_on_retry_failure` in the docs.

Closes https://github.com/hashicorp/vault/issues/12399