### PR TITLE
Add vaultrs Rust crate to community libraries

### DIFF
--- a/website/content/api-docs/libraries.mdx
+++ b/website/content/api-docs/libraries.mdx
@@ -181,6 +181,7 @@ $ pip install async-hvac
 ### Rust
 
 - [HashicorpVault](https://crates.io/crates/hashicorp_vault)
+- [vaultrs](https://crates.io/crates/vaultrs)
 
 ### Scala
 


### PR DESCRIPTION
This change proposes adding [vaultrs](https://crates.io/crates/vaultrs) to the list of community-supported libraries. This crate has a mature base and is expected to expand to accommodate most of the API.