### PR TITLE
Backport pr 12174 1.6.x

### DIFF
--- a/builtin/logical/rabbitmq/backend_test.go
+++ b/builtin/logical/rabbitmq/backend_test.go
@@ -37,7 +37,7 @@ func prepareRabbitMQTestContainer(t *testing.T) (func(), string) {
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ImageRepo:     "rabbitmq",
-		ImageTag:      "3-management",
+		ImageTag:      "3.8-management",
 		ContainerName: "rabbitmq",
 		Ports:         []string{"15672/tcp"},
 	})

--- a/plugins/database/cassandra/cassandra_test.go
+++ b/plugins/database/cassandra/cassandra_test.go
@@ -15,7 +15,7 @@ import (
 
 func getCassandra(t *testing.T, protocolVersion interface{}) (*Cassandra, func()) {
 	host, cleanup := cassandra.PrepareTestContainer(t,
-		cassandra.Version("latest"),
+		cassandra.Version("3.11"),
 		cassandra.CopyFromTo(insecureFileMounts),
 	)
 


### PR DESCRIPTION
`TestCreateUser()` changes not included - it looks like those don't exist in `release/1.6.x`