### PR TITLE
Expose secret_id_accessor as WrappedAccessor when wrapping secret-id creation.

### DIFF
--- a/changelog/12425.txt
+++ b/changelog/12425.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+auth/approle: expose secret_id_accessor as WrappedAccessor when creating wrapped secret-id.
+```

--- a/changelog/12425.txt
+++ b/changelog/12425.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:improvement
 auth/approle: expose secret_id_accessor as WrappedAccessor when creating wrapped secret-id.
 ```

--- a/sdk/helper/wrapping/wrapinfo.go
+++ b/sdk/helper/wrapping/wrapinfo.go
@@ -17,8 +17,8 @@ type ResponseWrapInfo struct {
 	// expected expiration.
 	CreationTime time.Time `json:"creation_time" structs:"creation_time" mapstructure:"creation_time" sentinel:""`
 
-	// If the contained response is the output of a token creation call, the
-	// created token's accessor will be accessible here
+	// If the contained response is the output of a token or approle secret-id creation call, the
+	// created token's/secret-id's accessor will be accessible here
 	WrappedAccessor string `json:"wrapped_accessor" structs:"wrapped_accessor" mapstructure:"wrapped_accessor" sentinel:""`
 
 	// WrappedEntityID is the entity identifier of the caller who initiated the

--- a/vault/external_tests/approle/wrapped_secretid_test.go
+++ b/vault/external_tests/approle/wrapped_secretid_test.go
@@ -1,0 +1,121 @@
+package approle
+
+import (
+	"testing"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/api"
+	credAppRole "github.com/hashicorp/vault/builtin/credential/approle"
+	vaulthttp "github.com/hashicorp/vault/http"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/hashicorp/vault/vault"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApproleSecretId_Wrapped(t *testing.T) {
+
+	var err error
+	coreConfig := &vault.CoreConfig{
+		DisableMlock: true,
+		DisableCache: true,
+		Logger:       log.NewNullLogger(),
+		CredentialBackends: map[string]logical.Factory{
+			"approle": credAppRole.Factory,
+		},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+
+	vault.TestWaitActive(t, cores[0].Core)
+
+	client := cores[0].Client
+	client.SetToken(cluster.RootToken)
+
+	err = client.Sys().EnableAuthWithOptions("approle", &api.EnableAuthOptions{
+		Type: "approle",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("auth/approle/role/test-role-1", map[string]interface{}{
+		"name": "test-role-1",
+	})
+	require.NoError(t, err)
+
+	client.SetWrappingLookupFunc(func(operation, path string) string {
+		return "5m"
+	})
+
+	resp, err := client.Logical().Write("/auth/approle/role/test-role-1/secret-id", map[string]interface{}{})
+	require.NoError(t, err)
+
+	wrappedAccessor := resp.WrapInfo.WrappedAccessor
+	wrappingToken := resp.WrapInfo.Token
+
+	client.SetWrappingLookupFunc(func(operation, path string) string {
+		return api.DefaultWrappingLookupFunc(operation, path)
+	})
+
+	unwrappedSecretid, err := client.Logical().Unwrap(wrappingToken)
+	unwrappedAccessor := unwrappedSecretid.Data["secret_id_accessor"].(string)
+
+	if wrappedAccessor != unwrappedAccessor {
+		t.Fatalf("Expected wrappedAccessor (%v) to match wrapped secret_id_accessor (%v)", wrappedAccessor, unwrappedAccessor)
+	}
+
+}
+
+func TestApproleSecretId_NotWrapped(t *testing.T) {
+
+	var err error
+	coreConfig := &vault.CoreConfig{
+		DisableMlock: true,
+		DisableCache: true,
+		Logger:       log.NewNullLogger(),
+		CredentialBackends: map[string]logical.Factory{
+			"approle": credAppRole.Factory,
+		},
+	}
+
+	cluster := vault.NewTestCluster(t, coreConfig, &vault.TestClusterOptions{
+		HandlerFunc: vaulthttp.Handler,
+	})
+
+	cluster.Start()
+	defer cluster.Cleanup()
+
+	cores := cluster.Cores
+
+	vault.TestWaitActive(t, cores[0].Core)
+
+	client := cores[0].Client
+	client.SetToken(cluster.RootToken)
+
+	err = client.Sys().EnableAuthWithOptions("approle", &api.EnableAuthOptions{
+		Type: "approle",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Logical().Write("auth/approle/role/test-role-1", map[string]interface{}{
+		"name": "test-role-1",
+	})
+	require.NoError(t, err)
+
+	resp, err := client.Logical().Write("/auth/approle/role/test-role-1/secret-id", map[string]interface{}{})
+	require.NoError(t, err)
+
+	if resp.WrapInfo != nil && resp.WrapInfo.WrappedAccessor != "" {
+		t.Fatalf("WrappedAccessor unexpectedly set")
+	}
+
+}

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -185,7 +185,7 @@ DONELISTHANDLING:
 	}
 
 	// Store the accessor of the approle secret in WrappedAccessor
-	if secretIdAccessor, ok := resp.Data["secret_id_accessor"]; ok && resp.Auth == nil {
+	if secretIdAccessor, ok := resp.Data["secret_id_accessor"]; ok && resp.Auth == nil && req.MountType == "approle" {
 		resp.WrapInfo.WrappedAccessor = secretIdAccessor.(string)
 	}
 

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -184,6 +184,11 @@ DONELISTHANDLING:
 		resp.WrapInfo.WrappedAccessor = resp.Auth.Accessor
 	}
 
+	// Make secret_id_accessor available as a WrappedAccessor.
+	if secretIdAccessor, ok := resp.Data["secret_id_accessor"]; ok {
+		resp.WrapInfo.WrappedAccessor = secretIdAccessor.(string)
+	}
+
 	switch resp.WrapInfo.Format {
 	case "jwt":
 		// Create the JWT

--- a/vault/wrapping.go
+++ b/vault/wrapping.go
@@ -184,8 +184,8 @@ DONELISTHANDLING:
 		resp.WrapInfo.WrappedAccessor = resp.Auth.Accessor
 	}
 
-	// Make secret_id_accessor available as a WrappedAccessor.
-	if secretIdAccessor, ok := resp.Data["secret_id_accessor"]; ok {
+	// Store the accessor of the approle secret in WrappedAccessor
+	if secretIdAccessor, ok := resp.Data["secret_id_accessor"]; ok && resp.Auth == nil {
 		resp.WrapInfo.WrappedAccessor = secretIdAccessor.(string)
 	}
 


### PR DESCRIPTION
Resolves #12173 for Secret-Ids. 

I'm not a Go developer (nor indeed any kind of developer), and was unable to find the right place to add a test for this functionality. Could you please point me in the right direction as to where this should be tested ?

