### PR TITLE
Add PutAutoPilotRaftConfiguration to api

### DIFF
--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -368,3 +368,22 @@ func (c *Sys) RaftAutopilotConfiguration() (*AutopilotConfig, error) {
 
 	return &result, err
 }
+
+// PutRaftAutopilotConfiguration allows modifying the raft autopilot configuration
+func (c *Sys) PutRaftAutopilotConfiguration(opts *AutopilotConfig) error {
+	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/autopilot/configuration")
+
+	if err := r.SetJSONBody(opts); err != nil {
+		return err
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	resp, err := c.c.RawRequestWithContext(ctx, r)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/changelog/12428.txt
+++ b/changelog/12428.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: add api method for modifying raft autopilot configuration
+```


### PR DESCRIPTION
The previous implementation only allows retrieving the autopilot state but not modifying it, hence the missing method has been added.

Misc:
- Update api to go1.16
- Update dependencies

Fix #12427