### PR TITLE
Docs add algo signer to support openssl as of recent

### DIFF
--- a/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
+++ b/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
@@ -106,6 +106,7 @@ team, or configuration management tooling.
     ```text
     $ vault write ssh-client-signer/roles/my-role -<<"EOH"
     {
+      "algorithm_signer": "rsa-sha2-256",
       "allow_user_certificates": true,
       "allowed_users": "*",
       "allowed_extensions": "permit-pty,permit-port-forwarding",


### PR DESCRIPTION
"algorithm_signer": "rsa-sha2-256"
to prevent /var/log/auth.log `userauth_pubkey: certificate signature algorithm ssh-rsa: signature algorithm not supported [preauth]` due to vault defaulting to ssh-rsa which is insecure