### PR TITLE
docs: Remove permissive policies in Consul ACL examples

### DIFF
--- a/website/content/docs/configuration/service-registration/consul.mdx
+++ b/website/content/docs/configuration/service-registration/consul.mdx
@@ -78,7 +78,7 @@ at Consul's service discovery layer.
   [`translate_wan_addrs`][consul-translate-wan-addrs] parameter.
 
 - `token` `(string: "")` – Specifies the [Consul ACL token][consul-acl] with
-  permission to read and write from the `path` in Consul's key-value store.
+  permission to register the Vault service into Consul's service catalog.
   This is **not** a Vault token. See the ACL section below for help.
 
 The following settings apply when communicating with Consul via an encrypted
@@ -109,67 +109,14 @@ connection. You can read more about encrypting Consul connections on the
 
 ## ACLs
 
-If using ACLs in Consul, you'll need appropriate permissions. For Consul 0.8,
-the following will work for most use-cases, assuming that your service name is
-`vault` and the prefix being used is `vault/`:
+If using ACLs in Consul, you'll need appropriate permissions to register the
+Vault service. The following ACL policy will work for most use-cases, assuming
+that your service name is `vault`:
 
 ```json
 {
-  "key": {
-    "vault/": {
-      "policy": "write"
-    }
-  },
-  "node": {
-    "": {
-      "policy": "write"
-    }
-  },
   "service": {
     "vault": {
-      "policy": "write"
-    }
-  },
-  "agent": {
-    "": {
-      "policy": "write"
-    }
-  },
-  "session": {
-    "": {
-      "policy": "write"
-    }
-  }
-}
-```
-
-For Consul 1.4+, the following example takes into account the changed ACL
-language:
-
-```json
-{
-  "key_prefix": {
-    "vault/": {
-      "policy": "write"
-    }
-  },
-  "node_prefix": {
-    "": {
-      "policy": "write"
-    }
-  },
-  "service": {
-    "vault": {
-      "policy": "write"
-    }
-  },
-  "agent_prefix": {
-    "": {
-      "policy": "write"
-    }
-  },
-  "session_prefix": {
-    "": {
       "policy": "write"
     }
   }

--- a/website/content/docs/configuration/storage/consul.mdx
+++ b/website/content/docs/configuration/storage/consul.mdx
@@ -152,11 +152,6 @@ the following will work for most use-cases, assuming that your service name is
       "policy": "write"
     }
   },
-  "node": {
-    "": {
-      "policy": "write"
-    }
-  },
   "service": {
     "vault": {
       "policy": "write"
@@ -164,7 +159,7 @@ the following will work for most use-cases, assuming that your service name is
   },
   "agent": {
     "": {
-      "policy": "write"
+      "policy": "read"
     }
   },
   "session": {
@@ -185,11 +180,6 @@ language:
       "policy": "write"
     }
   },
-  "node_prefix": {
-    "": {
-      "policy": "write"
-    }
-  },
   "service": {
     "vault": {
       "policy": "write"
@@ -197,7 +187,7 @@ language:
   },
   "agent_prefix": {
     "": {
-      "policy": "write"
+      "policy": "read"
     }
   },
   "session_prefix": {


### PR DESCRIPTION
The ACL policy examples documented on the Consul Storage Backend and Consul Service Registration pages are too permissive. Both policies unnecessarily grant `agent:write` and `node:write` access for all agents within the Consul datacenter. When Consul is used solely for service registration, `service:write` is only required permission.

This commit modifies the policy for the Consul Storage Backend to remove `node:write` access, and changes `agent:write` to `agent:read`.

The policy on the Consul Service Registration page is updated to remove all KV-related privileges, and solely grant the necessary `service:write` permission.

Related PR pending merge in Learn repo: hashicorp/learn#3839.