### PR TITLE
Update postgresql.mdx

### DIFF
--- a/website/content/docs/secrets/databases/postgresql.mdx
+++ b/website/content/docs/secrets/databases/postgresql.mdx
@@ -48,7 +48,7 @@ options, including SSL options, can be found
     $ vault write database/config/my-postgresql-database \
         plugin_name=postgresql-database-plugin \
         allowed_roles="my-role" \
-        connection_url="postgresql://{{username}}:{{password}}@localhost:5432/" \
+        connection_url="postgresql://{{username}}:{{password}}@localhost:5432/database-name" \
         username="vaultuser" \
         password="vaultpass"
     ```


### PR DESCRIPTION
Line 51, if no db name is specified in the connection string after the port e.g. :5432/somedb, the command treats the username as the database name.
So whoever's running this command needs to specify the database name to which vault will create temp creds.