### PR TITLE
[VAULT-3347] Ensure Deduplication in Provider and Client APIs in OIDC Provider

### DIFF
--- a/changelog/12460.txt
+++ b/changelog/12460.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+**OIDC Identity Provider**: Add deduplication to OIDC Provider API fields
+```

--- a/changelog/12460.txt
+++ b/changelog/12460.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-**OIDC Identity Provider**: Add deduplication to OIDC Provider API fields
-```

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -653,6 +653,10 @@ func (i *IdentityStore) pathOIDCCreateUpdateClient(ctx context.Context, req *log
 		client.Assignments = d.Get("assignments").([]string)
 	}
 
+	// Ensure there are no duplicate assignments or URIs
+	client.Assignments = strutil.RemoveDuplicates(client.Assignments, false)
+	client.RedirectURIs = strutil.RemoveDuplicates(client.RedirectURIs, false)
+
 	// enforce assignment existence
 	for _, assignment := range client.Assignments {
 		entry, err := req.Storage.Get(ctx, assignmentPath+assignment)

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -825,6 +825,10 @@ func (i *IdentityStore) pathOIDCCreateUpdateProvider(ctx context.Context, req *l
 		provider.Scopes = d.GetDefaultOrZero("scopes").([]string)
 	}
 
+	// Ensure that there are no duplicates
+	provider.AllowedClientIDs = strutil.RemoveDuplicates(provider.AllowedClientIDs, false)
+	provider.Scopes = strutil.RemoveDuplicates(provider.Scopes, false)
+
 	if provider.Issuer != "" {
 		// verify that issuer is the correct format:
 		//   - http or https

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -653,7 +653,7 @@ func (i *IdentityStore) pathOIDCCreateUpdateClient(ctx context.Context, req *log
 		client.Assignments = d.Get("assignments").([]string)
 	}
 
-	// Ensure there are no duplicate assignments or URIs
+	// remove duplicate assignments and redirect URIs
 	client.Assignments = strutil.RemoveDuplicates(client.Assignments, false)
 	client.RedirectURIs = strutil.RemoveDuplicates(client.RedirectURIs, false)
 
@@ -829,7 +829,7 @@ func (i *IdentityStore) pathOIDCCreateUpdateProvider(ctx context.Context, req *l
 		provider.Scopes = d.GetDefaultOrZero("scopes").([]string)
 	}
 
-	// Ensure that there are no duplicates
+	// remove duplicate allowed client IDs and scopes
 	provider.AllowedClientIDs = strutil.RemoveDuplicates(provider.AllowedClientIDs, false)
 	provider.Scopes = strutil.RemoveDuplicates(provider.Scopes, false)
 

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -259,7 +259,8 @@ func TestOIDC_Path_OIDC_ProviderClient(t *testing.T) {
 	}
 }
 
-// TestOIDC_Path_OIDC_ProviderClient tests CRUD operations for clients
+// TestOIDC_Path_OIDC_ProviderClient_DeDuplication tests that a
+// client doesn't have duplicate redirect URIs or Assignments
 func TestOIDC_Path_OIDC_ProviderClient_DeDuplication(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ctx := namespace.RootContext(nil)
@@ -1472,7 +1473,7 @@ func TestOIDC_Path_OIDCProvider_DeDuplication(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 
-	// Create a test provider "test-provider" with duplicate allowed_client_ids
+	// Create a test provider "test-provider" with duplicates
 	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
 		Path:      "oidc/provider/test-provider",
 		Operation: logical.CreateOperation,

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -261,7 +261,7 @@ func TestOIDC_Path_OIDC_ProviderClient(t *testing.T) {
 
 // TestOIDC_Path_OIDC_ProviderClient_DeDuplication tests that a
 // client doesn't have duplicate redirect URIs or Assignments
-func TestOIDC_Path_OIDC_ProviderClient_DeDuplication(t *testing.T) {
+func TestOIDC_Path_OIDC_ProviderClient_Deduplication(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ctx := namespace.RootContext(nil)
 	storage := &logical.InmemStorage{}
@@ -1456,7 +1456,7 @@ func TestOIDC_Path_OIDCProvider_DuplicateTemplateKeys(t *testing.T) {
 
 // TestOIDC_Path_OIDCProvider_DeDuplication tests that a
 // provider doensn't have duplicate scopes or client IDs
-func TestOIDC_Path_OIDCProvider_DeDuplication(t *testing.T) {
+func TestOIDC_Path_OIDCProvider_Deduplication(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ctx := namespace.RootContext(nil)
 	storage := &logical.InmemStorage{}


### PR DESCRIPTION
This PR removes any potential duplicate entries in the following fields in the OIDC Provider flow: 
- Provider: `allowed_client_ids`
- Provider: `scopes`
- Client: `redirect_uris`
- Client: `assignments`

This PR also included tests for deduplication on those fields.