### PR TITLE
(OSS Backport 1.6.7): Restrict Quota Deletion to Primary Cluster [vault-2399]

### DIFF
--- a/changelog/12339.txt
+++ b/changelog/12339.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ core (enterprise): Only delete quotas on primary cluster.
+ ```

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -339,10 +339,12 @@ func (c *Core) disableCredentialInternal(ctx context.Context, path string, updat
 
 	removePathCheckers(c, entry, viewPath)
 
-	if c.quotaManager != nil {
-		if err := c.quotaManager.HandleBackendDisabling(ctx, ns.Path, path); err != nil {
-			c.logger.Error("failed to update quotas after disabling auth", "path", path, "error", err)
-			return err
+	if !c.IsPerfSecondary() {
+		if c.quotaManager != nil {
+			if err := c.quotaManager.HandleBackendDisabling(ctx, ns.Path, path); err != nil {
+				c.logger.Error("failed to update quotas after disabling auth", "path", path, "error", err)
+				return err
+			}
 		}
 	}
 

--- a/vault/core.go
+++ b/vault/core.go
@@ -2507,6 +2507,10 @@ func (c *Core) IsDRSecondary() bool {
 	return c.ReplicationState().HasState(consts.ReplicationDRSecondary)
 }
 
+func (c *Core) IsPerfSecondary() bool {
+	return c.ReplicationState().HasState(consts.ReplicationPerformanceSecondary)
+}
+
 func (c *Core) AddLogger(logger log.Logger) {
 	c.allLoggersLock.Lock()
 	defer c.allLoggersLock.Unlock()

--- a/vault/quotas/quotas.go
+++ b/vault/quotas/quotas.go
@@ -763,7 +763,7 @@ func (m *Manager) Invalidate(key string) {
 	default:
 		splitKeys := strings.Split(key, "/")
 		if len(splitKeys) != 2 {
-			m.logger.Error("incorrect key while invalidating quota rule")
+			m.logger.Error("incorrect key while invalidating quota rule", "key", key)
 			return
 		}
 		qType := splitKeys[0]
@@ -985,7 +985,8 @@ func (m *Manager) HandleRemount(ctx context.Context, nsPath, fromPath, toPath st
 }
 
 // HandleBackendDisabling updates the quota subsystem with the disabling of auth
-// or secret engine disabling.
+// or secret engine disabling. This should only be called on the primary cluster
+// node.
 func (m *Manager) HandleBackendDisabling(ctx context.Context, nsPath, mountPath string) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()


### PR DESCRIPTION
Backport for: https://github.com/hashicorp/vault/pull/12339/files

Backport of Ent tests (for 1.6): https://github.com/hashicorp/vault-enterprise/pull/2138

Note:
In addition to a 1-1 backport of the code changes linked above, I also backported the `IsPerfSecondary` function from main as a part of this PR. As far as I can tell, it can be ported over as is. 