### PR TITLE
command: fix dropped test error

### DIFF
--- a/command/debug_test.go
+++ b/command/debug_test.go
@@ -182,7 +182,7 @@ func TestDebugCommand_Archive(t *testing.T) {
 			err = tgz.Walk(bundlePath, func(f archiver.File) error {
 				fh, ok := f.Header.(*tar.Header)
 				if !ok {
-					t.Fatalf("invalid file header: %#v", f.Header)
+					return fmt.Errorf("invalid file header: %#v", f.Header)
 				}
 
 				// Ignore base directory and index file
@@ -191,10 +191,13 @@ func TestDebugCommand_Archive(t *testing.T) {
 				}
 
 				if fh.Name != filepath.Join(basePath, "server_status.json") {
-					t.Fatalf("unxexpected file: %s", fh.Name)
+					return fmt.Errorf("unexpected file: %s", fh.Name)
 				}
 				return nil
 			})
+			if err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This fixes a test dropped error in the `command` package. Could someone add the `no-changelog` label?