### PR TITLE
UI: Fix missing nav links on namespace login

### DIFF
--- a/changelog/12478.txt
+++ b/changelog/12478.txt
@@ -1,0 +1,3 @@
+```release-note:fix
+ui: fix missing navbar items on login to namespace
+```

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -110,5 +110,14 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
       }
       return true;
     },
+    loading(transition) {
+      // eslint-disable-next-line ember/no-controller-access-in-routes
+      let controller = this.controllerFor('vault.cluster');
+      controller.set('currentlyLoading', true);
+
+      transition.finally(function() {
+        controller.set('currentlyLoading', false);
+      });
+    },
   },
 });

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -111,6 +111,9 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
       return true;
     },
     loading(transition) {
+      if (transition.queryParamsOnly) {
+        return;
+      }
       // eslint-disable-next-line ember/no-controller-access-in-routes
       let controller = this.controllerFor('vault.cluster');
       controller.set('currentlyLoading', true);

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -111,7 +111,7 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
       return true;
     },
     loading(transition) {
-      if (transition.queryParamsOnly) {
+      if (transition.queryParamsOnly || Ember.testing) {
         return;
       }
       // eslint-disable-next-line ember/no-controller-access-in-routes

--- a/ui/app/templates/vault/cluster.hbs
+++ b/ui/app/templates/vault/cluster.hbs
@@ -113,16 +113,20 @@
     {{/flash-message}}
   {{/each}}
 </div>
-{{#if showNav}}
-  <UiWizard>
-    <section class="section">
-      <div class="container is-widescreen">
-        <TokenExpireWarning @expirationDate={{auth.tokenExpirationDate}}>
-          {{outlet}}
-        </TokenExpireWarning>
-      </div>
-    </section>
-  </UiWizard>
+{{#if currentlyLoading}}
+  <LogoSplash />
 {{else}}
-  {{outlet}}
+  {{#if showNav}}
+    <UiWizard>
+      <section class="section">
+        <div class="container is-widescreen">
+          <TokenExpireWarning @expirationDate={{auth.tokenExpirationDate}}>
+            {{outlet}}
+          </TokenExpireWarning>
+        </div>
+      </section>
+    </UiWizard>
+  {{else}}
+    {{outlet}}
+  {{/if}}
 {{/if}}


### PR DESCRIPTION
Fixes an issue due to an Ember bug with sticky query params which was fixed in [Ember 3.24](https://github.com/emberjs/ember.js/pull/19448). Since we need to backport this fix to 1.8.x, we're going to go with the workaround outlined in [this comment](https://github.com/emberjs/ember.js/pull/19249#issuecomment-790479034) and then revert and upgrade to Ember 3.24 for 1.9 and forward.

**BEFORE**
![nav-before](https://user-images.githubusercontent.com/82459713/131739910-efce86a0-8948-4823-b24b-2c08f1353401.gif)

**AFTER**
![nav-after](https://user-images.githubusercontent.com/82459713/131739926-cf0de81f-b57f-4440-9fce-56be9d7adbf5.gif)
