### PR TITLE
feature: OIDC discovery endpoint

### DIFF
--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -295,7 +295,7 @@ func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logi
 	scopes := append(p.Scopes, "openid")
 
 	disc := providerDiscovery{
-		AuthorizationEndpoint: p.effectiveIssuer + "/authorize",
+		AuthorizationEndpoint: strings.Replace(p.effectiveIssuer, "/v1/", "/ui/vault/", 1) + "/authorize",
 		IDTokenAlgs:           supportedAlgs,
 		Issuer:                p.effectiveIssuer,
 		Keys:                  p.effectiveIssuer + "/.well-known/keys",

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -283,6 +283,9 @@ func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logi
 	if err != nil {
 		return nil, err
 	}
+	if p == nil {
+		return nil, nil
+	}
 
 	disc := providerDiscovery{
 		discovery: discovery{

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -49,11 +49,15 @@ type provider struct {
 }
 
 type providerDiscovery struct {
-	discovery
-
-	AuthorizationEndpoint string `json:"authorization_endpoint"`
-	TokenEndpoint         string `json:"token_endpoint"`
-	UserinfoEndpoint      string `json:"userinfo_endpoint"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	IDTokenAlgs           []string `json:"id_token_signing_alg_values_supported"`
+	Issuer                string   `json:"issuer"`
+	Keys                  string   `json:"jwks_uri"`
+	ResponseTypes         []string `json:"response_types_supported"`
+	Scopes                []string `json:"scopes_supported"`
+	Subjects              []string `json:"subject_types_supported"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	UserinfoEndpoint      string   `json:"userinfo_endpoint"`
 }
 
 const (
@@ -287,15 +291,17 @@ func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logi
 		return nil, nil
 	}
 
+	// the "openid" scope is reserved and is included for every provider
+	scopes := append(p.Scopes, "openid")
+
 	disc := providerDiscovery{
-		discovery: discovery{
-			Issuer:        p.effectiveIssuer,
-			Keys:          p.effectiveIssuer + "/.well-known/keys",
-			ResponseTypes: []string{"code"},
-			Subjects:      []string{"public"},
-			IDTokenAlgs:   supportedAlgs,
-		},
 		AuthorizationEndpoint: p.effectiveIssuer + "/authorize",
+		IDTokenAlgs:           supportedAlgs,
+		Issuer:                p.effectiveIssuer,
+		Keys:                  p.effectiveIssuer + "/.well-known/keys",
+		ResponseTypes:         []string{"code"},
+		Scopes:                scopes,
+		Subjects:              []string{"public"},
 		TokenEndpoint:         p.effectiveIssuer + "/token",
 		UserinfoEndpoint:      p.effectiveIssuer + "/userinfo",
 	}

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -48,6 +48,14 @@ type provider struct {
 	effectiveIssuer string
 }
 
+type providerDiscovery struct {
+	discovery
+
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	UserinfoEndpoint      string `json:"userinfo_endpoint"`
+}
+
 const (
 	oidcProviderPrefix = "oidc_provider/"
 	assignmentPath     = oidcProviderPrefix + "assignment/"
@@ -208,7 +216,7 @@ func oidcProviderPaths(i *IdentityStore) []*framework.Path {
 			Fields: map[string]*framework.FieldSchema{
 				"name": {
 					Type:        framework.TypeString,
-					Description: "Name of the assignment",
+					Description: "Name of the provider",
 				},
 				"issuer": {
 					Type:        framework.TypeString,
@@ -251,7 +259,59 @@ func oidcProviderPaths(i *IdentityStore) []*framework.Path {
 			HelpSynopsis:    "List OIDC providers",
 			HelpDescription: "List all configured OIDC providers in the identity backend.",
 		},
+		{
+			Pattern: "oidc/provider/" + framework.GenericNameRegex("name") + "/.well-known/openid-configuration",
+			Fields: map[string]*framework.FieldSchema{
+				"name": {
+					Type:        framework.TypeString,
+					Description: "Name of the provider",
+				},
+			},
+			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.ReadOperation: i.pathOIDCProviderDiscovery,
+			},
+			HelpSynopsis:    "Query OIDC configurations",
+			HelpDescription: "Query this path to retrieve the configured OIDC Issuer and Keys endpoints, response types, subject types, and signing algorithms used by the OIDC backend.",
+		},
 	}
+}
+
+func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	name := d.Get("name").(string)
+
+	p, err := i.getOIDCProvider(ctx, req.Storage, name)
+	if err != nil {
+		return nil, err
+	}
+
+	disc := providerDiscovery{
+		discovery: discovery{
+			Issuer:        p.effectiveIssuer,
+			Keys:          p.effectiveIssuer + "/.well-known/keys",
+			ResponseTypes: []string{"code"},
+			Subjects:      []string{"public"},
+			IDTokenAlgs:   supportedAlgs,
+		},
+		AuthorizationEndpoint: p.effectiveIssuer + "/authorize",
+		TokenEndpoint:         p.effectiveIssuer + "/token",
+		UserinfoEndpoint:      p.effectiveIssuer + "/userinfo",
+	}
+
+	data, err := json.Marshal(disc)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			logical.HTTPStatusCode:      200,
+			logical.HTTPRawBody:         data,
+			logical.HTTPContentType:     "application/json",
+			logical.HTTPRawCacheControl: "max-age=3600",
+		},
+	}
+
+	return resp, nil
 }
 
 // clientsReferencingTargetAssignmentName returns a map of client names to

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -1698,3 +1698,24 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		t.Fatal(diff)
 	}
 }
+
+// TestOIDC_Path_OpenIDProviderConfig_ProviderDoesNotExist tests read
+// operations for the openid-configuration path when the provider does not
+// exist
+func TestOIDC_Path_OpenIDProviderConfig_ProviderDoesNotExist(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+	storage := &logical.InmemStorage{}
+
+	// Expect defaults from .well-known/openid-configuration
+	// test-provider does not exist
+	resp, err := c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider/.well-known/openid-configuration",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	expectedResp := &logical.Response{}
+	if resp != expectedResp && err != nil {
+		t.Fatalf("expected empty response but got success; error:\n%v\nresp: %#v", err, resp)
+	}
+}

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -1662,7 +1662,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		Scopes:                []string{"test-scope-1", "openid"},
 		Subjects:              []string{"public"},
 		IDTokenAlgs:           supportedAlgs,
-		AuthorizationEndpoint: basePath + "/authorize",
+		AuthorizationEndpoint: "/ui/vault/identity/oidc/provider/test-provider/authorize",
 		TokenEndpoint:         basePath + "/token",
 		UserinfoEndpoint:      basePath + "/userinfo",
 	}
@@ -1713,7 +1713,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		Scopes:                []string{"test-scope-2", "openid"},
 		Subjects:              []string{"public"},
 		IDTokenAlgs:           supportedAlgs,
-		AuthorizationEndpoint: basePath + "/authorize",
+		AuthorizationEndpoint: testIssuer + "/ui/vault/identity/oidc/provider/test-provider/authorize",
 		TokenEndpoint:         basePath + "/token",
 		UserinfoEndpoint:      basePath + "/userinfo",
 	}


### PR DESCRIPTION
## Description
This task involves implementing the OIDC Discovery endpoint that is defined in the RFC.

Acceptance Criteria:
- An OIDC client can discover information about an individual provider using its OIDC discovery endpoint

## Manual Test

```
# test with default issuer
$ vault write identity/oidc/provider/test-provider-1 \
  allowed_client_ids="*"

$ vault read identity/oidc/provider/test-provider-1
Key                   Value
---                   -----
allowed_client_ids    [*]
issuer                n/a
scopes                []

$ curl -s \
    -H "X-Vault-Token: root" \
    -X GET \
    http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider-1/.well-known/openid-configuration \
    | jq

{
  "issuer": "http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider-1",
  "jwks_uri": "http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider-1/.well-known/keys",
  "response_types_supported": [
    "code"
  ],
  "subject_types_supported": [
    "public"
  ],
  "id_token_signing_alg_values_supported": [
    "RS256",
    "RS384",
    "RS512",
    "ES256",
    "ES384",
    "ES512",
    "EdDSA"
  ],
  "authorization_endpoint": "http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider-1/authorize",
  "token_endpoint": "http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider-1/token",
  "userinfo_endpoint": "http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider-1/userinfo"
}

# test with custom issuer
$ vault write identity/oidc/provider/test-provider-2 \
  allowed_client_ids="*" \
  issuer=https://example.com:1234

WARNING! The following warnings were returned from Vault:

  * If "issuer" is set explicitly, all tokens must be validated against that
  address, including those issued by secondary clusters. Setting issuer to
  "" will restore the default behavior of using the cluster's api_addr as the
  issuer.

$ vault read identity/oidc/provider/test-provider-2

Key                   Value
---                   -----
allowed_client_ids    [*]
issuer                https://example.com:1234
scopes                []

$ curl -s \
    -H "X-Vault-Token: root" \
    -X GET \
    http://127.0.0.1:8200/v1/identity/oidc/provider/test-provider-2/.well-known/openid-configuration \
    | jq

{
  "issuer": "https://example.com:1234/v1/identity/oidc/provider/test-provider-2",
  "jwks_uri": "https://example.com:1234/v1/identity/oidc/provider/test-provider-2/.well-known/keys",
  "response_types_supported": [
    "code"
  ],
  "subject_types_supported": [
    "public"
  ],
  "id_token_signing_alg_values_supported": [
    "RS256",
    "RS384",
    "RS512",
    "ES256",
    "ES384",
    "ES512",
    "EdDSA"
  ],
  "authorization_endpoint": "https://example.com:1234/v1/identity/oidc/provider/test-provider-2/authorize",
  "token_endpoint": "https://example.com:1234/v1/identity/oidc/provider/test-provider-2/token",
  "userinfo_endpoint": "https://example.com:1234/v1/identity/oidc/provider/test-provider-2/userinfo"
}
```
