### PR TITLE
Remove deprecated reauth function from docs

### DIFF
--- a/website/content/docs/agent/autoauth/methods/jwt.mdx
+++ b/website/content/docs/agent/autoauth/methods/jwt.mdx
@@ -7,10 +7,7 @@ description: JWT Method for Vault Agent Auto-Auth
 # Vault Agent Auto-Auth JWT Method
 
 The `jwt` method reads in a JWT from a file and sends it to the [JWT Auth
-method](/docs/auth/jwt). Since JWTs often have
-limited lifetime, it constantly watches for a new JWT to be written, and when
-found it will immediately ingress this value, delete the file, and use the new
-JWT to perform a reauthentication.
+method](/docs/auth/jwt).
 
 ## Configuration
 


### PR DESCRIPTION
- The vault agent's reauth on new credentials feature was removed in https://github.com/hashicorp/vault/pull/5615. However, the current docs still note this as a feature for the auto-auth JWT. method https://www.vaultproject.io/docs/agent/autoauth/methods/jwt, causing confusion for users like here https://github.com/hashicorp/vault/issues/12233. This PR removes this information from the docs.