### PR TITLE
Backport 1.8.x: UI Show day of month instead of day of year in the expiration warning

### DIFF
--- a/changelog/11984.txt
+++ b/changelog/11984.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Show day of month instead of day of year in the expiration warning dialog
+```

--- a/ui/app/templates/components/auth-info.hbs
+++ b/ui/app/templates/components/auth-info.hbs
@@ -10,8 +10,8 @@
           <li class="action">
             <AlertBanner @type="warning" @message="We've stopped auto-renewing your token due to inactivity.
                 It will expire in {{date-from-now this.auth.tokenExpirationDate interval=1000 hideSuffix=true}}.
-                On {{date-format this.auth.tokenExpirationDate 'MMMM Do yyyy, h:mm:ss a'}}" />
-          </li> 
+                On {{date-format this.auth.tokenExpirationDate 'MMMM do yyyy, h:mm:ss a'}}" />
+          </li>
         {{/if}}
         <li class="action">
           <button type="button" class="link" onclick={{action "restartGuide"}}>


### PR DESCRIPTION
See PR #11984 