### PR TITLE
Use HCL syntax for code snippet

### DIFF
--- a/website/content/docs/platform/servicenow/installation.mdx
+++ b/website/content/docs/platform/servicenow/installation.mdx
@@ -36,7 +36,7 @@ description: Installation steps for the Vault ServiceNow Credential Resolver.
   must set `cache.use_auto_auth_token = true`, and the `listener`, `vault` and
   `auto_auth` blocks are also required to set up a working Agent, e.g.:
 
-  ```
+  ```hcl
   listener "tcp" {
     address = "127.0.0.1:8200"
     tls_disable = false


### PR DESCRIPTION
Use `hcl` so the code snippet is more readable and is highlighted correctly.

<img width="913" alt="Screen Shot 2021-09-08 at 12 50 09 PM" src="https://user-images.githubusercontent.com/26/132575921-a1a30d20-800b-40d6-b172-2e45924b3e5a.png">
