### PR TITLE
feature: OIDC keys endpoint

### DIFF
--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -1715,7 +1715,6 @@ func (i *IdentityStore) oidcKeyRotation(ctx context.Context, s logical.Storage) 
 // oidcPeriodFunc is invoked by the backend's periodFunc and runs regular key
 // rotations and expiration actions.
 func (i *IdentityStore) oidcPeriodicFunc(ctx context.Context) {
-	i.Logger().Debug("begin oidcPeriodicFunc")
 	var nextRun time.Time
 	now := time.Now()
 

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -361,7 +361,6 @@ func (i *IdentityStore) keyIDsReferencedByTargetClientIDs(ctx context.Context, s
 				return nil, err
 			}
 
-			i.Logger().Debug("==>", "client", client)
 			if client != nil {
 				keyNames = append(keyNames, client.Key)
 			}

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -277,7 +277,21 @@ func oidcProviderPaths(i *IdentityStore) []*framework.Path {
 			HelpSynopsis:    "Query OIDC configurations",
 			HelpDescription: "Query this path to retrieve the configured OIDC Issuer and Keys endpoints, response types, subject types, and signing algorithms used by the OIDC backend.",
 		},
+		{
+			Pattern: "oidc/provider/" + framework.GenericNameRegex("name") + "/.well-known/keys",
+			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.ReadOperation: i.pathOIDCReadProviderPublicKeys,
+			},
+			HelpSynopsis:    "Retrieve public keys",
+			HelpDescription: "Returns the public portion of keys for a named OIDC provider. Clients can use them to validate the authenticity of an ID token.",
+		},
 	}
+}
+
+// pathOIDCReadProviderPublicKeys is used to retrieve all public keys for a
+// named provider so that clients can verify the validity of a signed OIDC token.
+func (i *IdentityStore) pathOIDCReadProviderPublicKeys(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	return nil, nil
 }
 
 func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -10,7 +10,150 @@ import (
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
+	"gopkg.in/square/go-jose.v2"
 )
+
+// TestOIDC_Path_OIDC_ProviderReadPublicKey_ProviderDoesNotExist tests that the
+// path can handle the read operation when the provider does not exist
+func TestOIDC_Path_OIDC_ProviderReadPublicKey_ProviderDoesNotExist(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+	storage := &logical.InmemStorage{}
+
+	// Read "test-provider" .well-known keys
+	resp, err := c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider/.well-known/keys",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	expectedResp := &logical.Response{}
+	if resp != expectedResp && err != nil {
+		t.Fatalf("expected empty response but got success; error:\n%v\nresp: %#v", err, resp)
+	}
+}
+
+// TestOIDC_Path_OIDC_ProviderReadPublicKey tests the provider .well-known
+// keys endpoint read operations
+func TestOIDC_Path_OIDC_ProviderReadPublicKey(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+	storage := &logical.InmemStorage{}
+
+	// Create a test key "test-key-1"
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/key/test-key-1",
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"verification_ttl": "2m",
+			"rotation_period":  "2m",
+		},
+		Storage: storage,
+	})
+
+	// Create a test client "test-client-1"
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/client/test-client-1",
+		Operation: logical.CreateOperation,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"key": "test-key-1",
+		},
+	})
+
+	// get the clientID
+	resp, _ := c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/client/test-client-1",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	clientID := resp.Data["client_id"].(string)
+
+	// Create a test provider "test-provider" and allow all client IDs -- should succeed
+	resp, err := c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.CreateOperation,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"issuer":             "https://example.com:8200",
+			"allowed_client_ids": []string{"*"},
+		},
+	})
+	expectSuccess(t, resp, err)
+
+	// Read "test-provider" .well-known keys
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider/.well-known/keys",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, resp, err)
+
+	responseJWKS := &jose.JSONWebKeySet{}
+	json.Unmarshal(resp.Data["http_raw_body"].([]byte), responseJWKS)
+	if len(responseJWKS.Keys) != 1 {
+		t.Fatalf("expected 1 public key but instead got %d", len(responseJWKS.Keys))
+	}
+
+	// Create a test key "test-key-2"
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/key/test-key-2",
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"verification_ttl": "2m",
+			"rotation_period":  "2m",
+		},
+		Storage: storage,
+	})
+
+	// Create a test client "test-client-2"
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/client/test-client-2",
+		Operation: logical.CreateOperation,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"key": "test-key-2",
+		},
+	})
+
+	// Read "test-provider" .well-known keys
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider/.well-known/keys",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, resp, err)
+
+	responseJWKS = &jose.JSONWebKeySet{}
+	json.Unmarshal(resp.Data["http_raw_body"].([]byte), responseJWKS)
+	if len(responseJWKS.Keys) != 2 {
+		t.Fatalf("expected 2 public key but instead got %d", len(responseJWKS.Keys))
+	}
+
+	// Update the test provider "test-provider" to only allow test-client-1 -- should succeed
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider",
+		Operation: logical.UpdateOperation,
+		Storage:   storage,
+		Data: map[string]interface{}{
+			"allowed_client_ids": []string{clientID},
+		},
+	})
+	expectSuccess(t, resp, err)
+
+	// Read "test-provider" .well-known keys
+	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/provider/test-provider/.well-known/keys",
+		Operation: logical.ReadOperation,
+		Storage:   storage,
+	})
+	expectSuccess(t, resp, err)
+
+	responseJWKS = &jose.JSONWebKeySet{}
+	json.Unmarshal(resp.Data["http_raw_body"].([]byte), responseJWKS)
+	if len(responseJWKS.Keys) != 1 {
+		t.Fatalf("expected 1 public key but instead got %d", len(responseJWKS.Keys))
+	}
+}
 
 // TestOIDC_Path_OIDC_ProviderClient_NoKeyParameter tests that a client cannot
 // be created without a key parameter
@@ -97,7 +240,7 @@ func TestOIDC_Path_OIDC_ProviderClient_UpdateKey(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 
-	// Create a test client "test-client" -- should fail
+	// Update the test client "test-client" -- should fail
 	resp, err = c.identityStore.HandleRequest(ctx, &logical.Request{
 		Path:      "oidc/client/test-client",
 		Operation: logical.UpdateOperation,

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -90,8 +90,8 @@ func TestOIDC_Path_OIDC_ProviderReadPublicKey(t *testing.T) {
 
 	responseJWKS := &jose.JSONWebKeySet{}
 	json.Unmarshal(resp.Data["http_raw_body"].([]byte), responseJWKS)
-	if len(responseJWKS.Keys) != 1 {
-		t.Fatalf("expected 1 public key but instead got %d", len(responseJWKS.Keys))
+	if len(responseJWKS.Keys) != 2 {
+		t.Fatalf("expected 2 public key but instead got %d", len(responseJWKS.Keys))
 	}
 
 	// Create a test key "test-key-2"
@@ -125,8 +125,8 @@ func TestOIDC_Path_OIDC_ProviderReadPublicKey(t *testing.T) {
 
 	responseJWKS = &jose.JSONWebKeySet{}
 	json.Unmarshal(resp.Data["http_raw_body"].([]byte), responseJWKS)
-	if len(responseJWKS.Keys) != 2 {
-		t.Fatalf("expected 2 public key but instead got %d", len(responseJWKS.Keys))
+	if len(responseJWKS.Keys) != 4 {
+		t.Fatalf("expected 4 public key but instead got %d", len(responseJWKS.Keys))
 	}
 
 	// Update the test provider "test-provider" to only allow test-client-1 -- should succeed
@@ -150,8 +150,8 @@ func TestOIDC_Path_OIDC_ProviderReadPublicKey(t *testing.T) {
 
 	responseJWKS = &jose.JSONWebKeySet{}
 	json.Unmarshal(resp.Data["http_raw_body"].([]byte), responseJWKS)
-	if len(responseJWKS.Keys) != 1 {
-		t.Fatalf("expected 1 public key but instead got %d", len(responseJWKS.Keys))
+	if len(responseJWKS.Keys) != 2 {
+		t.Fatalf("expected 2 public key but instead got %d", len(responseJWKS.Keys))
 	}
 }
 


### PR DESCRIPTION
## Description

This task involves implementing the OIDC Keys endpoints that is defined in the RFC.

There are improvements that can be made to this code based on changes in https://github.com/hashicorp/vault/pull/12538 around MemDB. Those improvements will be handled in a separate PR.

Acceptance Criteria:
- An OIDC client can discover the public keys used to sign ID tokens via the `jwks_uri` key/value pair in the discovery document

## Manual Test

```
# create keys
$ vault write identity/oidc/key/key1 rotation_period=1m verification_ttl=1m
Success! Data written to: identity/oidc/key/key1
$ vault write identity/oidc/key/key2 rotation_period=1m verification_ttl=1m
Success! Data written to: identity/oidc/key/key2

# create client1
vault write identity/oidc/client/client1 \
  key=key1 \
  id_token_ttl=1m \
  access_token_ttl=1m
Success! Data written to: identity/oidc/client/client1

# create provider1
$ vault write identity/oidc/provider/provider1 \
    allowed_client_ids="*"
 
# query the .well-known keys endpoint  
$ curl -s \
  -H "X-Vault-Token: root" \
  -X GET \
  http://127.0.0.1:8200/v1/identity/oidc/provider/provider1/.well-known/keys \
  | jq

{
  "keys": [
    {
      "use": "sig",
      "kty": "RSA",
      "kid": "5ea5e4d0-8dae-19c1-21b6-22e31196bccb",
      "alg": "RS256",
      "n": "rLIb6mJWxchrsO4tPIcgH9KsMu2qDJq6CvP6CAgnySmk6XQ_1Ia3DVqB6SAdnB7YlDEu4_WwY6pshU8t4dWutlV4RcuI5fnLumprYScDCwJgYqtg56gAs9yGm3_6ULosWNPqhksvw11nswdpOaZ4nJ-0feSqCk4X636nSg6jI2Rw1PBCsi7rIkuqgvAnEk0dyDhxw2LwkSjr8Y_17x5qbIavMxU7yAf_OfeLLx4X_qTLx_DDMjReFNrPEQEwlgtVMctLLeZhxsqQ6oMsmZ3gAnbgPSa9xw1LxfOz3OqAU0_SIPJFtDAZl7m9H-N9D4O9f7QOQRm2KUbphajwsmAvXQ",
      "e": "AQAB"
    },
    {
      "use": "sig",
      "kty": "RSA",
      "kid": "204b2b72-7c3f-56b7-8006-9fa4ba6bf576",
      "alg": "RS256",
      "n": "y1fwRcfUIgVl98nl5-svz2NZrprXpI-LZDwBBqzYksvUUCqf41Ffo-OatXERyiuEaxRRxMOuKZuf6B2lWb__bvXFhI_aB69gg3ZK2mkINYcR05QfHGpVa1mxDuH2GjfePX5fmpMqPBwQa6SwwSvG7rGvaZpu2gM6ylekNPiylxNLXmuBKUyXI-7m0mZsAwJl11EEcmQZZRHb-3aaeAyaH8OIrScOVm8qJ6GIZFcLwmFNS30j797qZrbDFO8lxOMQUj-YPvhj3nvunoqSAMu4bexfmTF0aSL7O2f3HwgbP8AQpLr9S-8Lsf3FFeyNPDS3dqNN0nhkxpIegLhELwWDtw",
      "e": "AQAB"
    }
  ]
}
```

