### PR TITLE
UI: Remove options used only on kv-v2 from mount call

### DIFF
--- a/ui/app/serializers/secret-engine.js
+++ b/ui/app/serializers/secret-engine.js
@@ -53,6 +53,10 @@ export default ApplicationSerializer.extend({
   serialize(snapshot) {
     let type = snapshot.record.get('engineType');
     let data = this._super(...arguments);
+    // These items are on the model, but used by the kv-v2 config endpoint only
+    delete data.max_versions;
+    delete data.cas_required;
+    delete data.delete_version_after;
     // only KV uses options
     if (type !== 'kv' && type !== 'generic') {
       delete data.options;


### PR DESCRIPTION
As part of the updates to KV-V2 Secret Engine which allow for updating the configuration as you mount the secret engine, three attributes were added to the `secret-engine` model: `cas_required`, `max_versions`, and `delete_version_after`. Right now all secret engines that we mount are making a network request with these attributes because these are on the secret-engine model, even though only KV uses them. This makes sense because we use the model to generate the form fields, but for this PR we want to remove these fields if not KV when making the API call.