### PR TITLE
identity: fix identity token introspect doc

### DIFF
--- a/website/content/api-docs/secret/identity/tokens.mdx
+++ b/website/content/api-docs/secret/identity/tokens.mdx
@@ -393,7 +393,7 @@ This endpoint can verify the authenticity and active state of a signed ID token.
 
 - `token` `(string)` – A signed OIDC compliant ID token
 
-- `client_id` `(string: <optional>)` - Specifying the client ID optimizes validation time
+- `client_id` `(string: <optional>)` - Specifying the client ID additionally requires the token to contain a matching `aud` claim
 
 ### Sample Payload
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/vault/issues/11052

Which reported that the documentation incorrectly states that specifying the client ID optimizes validation time. However, the following links show that specifying the client ID requires the token to contain a matching `aud` claim:

- https://github.com/hashicorp/vault/blob/72124753858535347a05a2d140b480cad12fd222/vault/identity_store_oidc.go#L1216-L1218
- https://github.com/square/go-jose/blob/v2.5.1/jwt/validation.go#L89-L95