### PR TITLE
vault-agent: copy values retrieved from bolt

### DIFF
--- a/changelog/12534.txt
+++ b/changelog/12534.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-agent: Avoid possible `unexpected fault address` panic caused by using byte slices returned from Bolt outside their transactions; make a copy first.
+agent: Avoid possible `unexpected fault address` panic caused by using byte slices returned from Bolt outside their transactions; make a copy first in the persistent cache restore functions.
 ```

--- a/changelog/12534.txt
+++ b/changelog/12534.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Avoid possible `unexpected fault address` panic caused by using byte slices returned from Bolt outside their transactions; make a copy first.
+```

--- a/changelog/12534.txt
+++ b/changelog/12534.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-agent: Avoid possible `unexpected fault address` panic caused by using byte slices returned from Bolt outside their transactions; make a copy first in the persistent cache restore functions.
+agent: Avoid possible `unexpected fault address` panic when using persistent cache.
 ```

--- a/command/agent/cache/cacheboltdb/bolt.go
+++ b/command/agent/cache/cacheboltdb/bolt.go
@@ -219,7 +219,11 @@ func (b *BoltStorage) GetAutoAuthToken(ctx context.Context) ([]byte, error) {
 		if meta == nil {
 			return fmt.Errorf("bucket %q not found", metaBucketName)
 		}
-		encryptedToken = meta.Get([]byte(AutoAuthToken))
+		value := meta.Get([]byte(AutoAuthToken))
+		if value != nil {
+			encryptedToken = make([]byte, len(value))
+			copy(encryptedToken, value)
+		}
 		return nil
 	})
 	if err != nil {
@@ -247,7 +251,11 @@ func (b *BoltStorage) GetRetrievalToken() ([]byte, error) {
 		if keyBucket == nil {
 			return fmt.Errorf("bucket %q not found", metaBucketName)
 		}
-		token = keyBucket.Get([]byte(RetrievalTokenMaterial))
+		value := keyBucket.Get([]byte(RetrievalTokenMaterial))
+		if value != nil {
+			token = make([]byte, len(value))
+			copy(token, value)
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
[Byte slices returned from Bolt are only valid during a transaction](https://github.com/etcd-io/bbolt#caveats--limitations), and using them outside the transaction can cause an `unexpected fault address` panic so this makes a copy in the persistent caching functions.

Similar to the pattern in fsm.go: https://github.com/hashicorp/vault/blob/861454e0ed1390d67ddaf1a53c1798e5e291728c/physical/raft/fsm.go#L469-L479