### PR TITLE
Backport 1.7: vault-agent: copy values retrieved from bolt (#12534)

### DIFF
--- a/changelog/12534.txt
+++ b/changelog/12534.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Avoid possible `unexpected fault address` panic when using persistent cache.
+```

--- a/command/agent/cache/cacheboltdb/bolt.go
+++ b/command/agent/cache/cacheboltdb/bolt.go
@@ -219,7 +219,11 @@ func (b *BoltStorage) GetAutoAuthToken(ctx context.Context) ([]byte, error) {
 		if meta == nil {
 			return fmt.Errorf("bucket %q not found", metaBucketName)
 		}
-		encryptedToken = meta.Get([]byte(AutoAuthToken))
+		value := meta.Get([]byte(AutoAuthToken))
+		if value != nil {
+			encryptedToken = make([]byte, len(value))
+			copy(encryptedToken, value)
+		}
 		return nil
 	})
 	if err != nil {
@@ -247,7 +251,11 @@ func (b *BoltStorage) GetRetrievalToken() ([]byte, error) {
 		if keyBucket == nil {
 			return fmt.Errorf("bucket %q not found", metaBucketName)
 		}
-		token = keyBucket.Get([]byte(RetrievalTokenMaterial))
+		value := keyBucket.Get([]byte(RetrievalTokenMaterial))
+		if value != nil {
+			token = make([]byte, len(value))
+			copy(token, value)
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
Backporting https://github.com/hashicorp/vault/pull/12534

Byte slices returned from Bolt are only valid during a transaction, so
this makes a copy.

Co-authored-by: Tom Proctor <tomhjp@users.noreply.github.com>