### PR TITLE
Some docs notes (seal migration + go discover link)

### DIFF
--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -209,8 +209,9 @@ be migrated to be used as unseal keys.
 
 #### Migration From Auto Unseal to Auto Unseal
 
-~> **NOTE**: Migration between same Auto Unseal types is not currently
-supported. We plan to support this officially in a future release.
+~> **NOTE**: Migration between same Auto Unseal types is supported in Vault
+1.6.0 and higher. For these pre-1.5.1 steps, it is only possible to migrate from
+one type of Auto Unseal to a different type (ie Transit -> AWSKMS).
 
 To migrate from Auto Unseal to a different Auto Unseal configuration, take your
 server cluster offline and update the existing [seal

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -117,7 +117,8 @@ set [`disable_mlock`](/docs/configuration#disable_mlock) to `true`, and to disab
 
 - `leader_api_addr` `(string: "")` - Address of a possible leader node.
 
-- `auto_join` `(string: "")` - Cloud auto-join configuration.
+- `auto_join` `(string: "")` - Cloud auto-join configuration, using
+  [go-discover](https://github.com/hashicorp/go-discover) syntax.
 
 - `auto_join_scheme` `(string: "")` - The optional URI protocol scheme for addresses
   discovered via auto-join.


### PR DESCRIPTION
Without awareness that you're in the pre 1.5.1 setting, the note could be read in a way that doesn't take into account that we added the functionality in 1.6. I thought this edit would help clarify.