### PR TITLE
enhancement: Support CORS credentials

### DIFF
--- a/http/cors.go
+++ b/http/cors.go
@@ -50,6 +50,7 @@ func wrapCORSHandler(h http.Handler, core *vault.Core) http.Handler {
 		}
 
 		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Vary", "Origin")
 
 		// apply headers for preflight requests

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -173,6 +173,7 @@ func TestHandler_cors(t *testing.T) {
 	//
 	expHeaders := map[string]string{
 		"Access-Control-Allow-Origin":  addr,
+		"Access-Control-Allow-Credentials":  "true",
 		"Access-Control-Allow-Headers": strings.Join(vault.StdAllowedHeaders, ","),
 		"Access-Control-Max-Age":       "300",
 		"Vary":                         "Origin",


### PR DESCRIPTION
Raised from https://github.com/hashicorp/vault/issues/12537 "Support CORS credentials"

This PR adds an additional CORS header to the ones presently used within Vault. It enables cross origin requests to be made from domains behind certificate based authentication, and for those certificates to be used as an authentication mechanism with Vaults /v1/auth/cert/login path.

The additional header is documented on MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials

Associated tests have been updated to the best of my knowledge