### PR TITLE
Backport 1.7.x: Handle api explorer routing error (#12354)

### DIFF
--- a/changelog/12354.txt
+++ b/changelog/12354.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed api explorer routing bug
+```

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -92,12 +92,11 @@ export default Component.extend({
 
   refreshRoute: task(function*() {
     let owner = getOwner(this);
-    let routeName = this.router.currentRouteName;
-    let route = owner.lookup(`route:${routeName}`);
+    let currentRoute = owner.lookup(`router:main`).get('currentRouteName');
 
     try {
       this.store.clearAllDatasets();
-      yield route.refresh();
+      yield this.router.transitionTo(currentRoute);
       this.logAndOutput(null, { type: 'success', content: 'The current screen has been refreshed!' });
     } catch (error) {
       this.logAndOutput(null, { type: 'error', content: 'The was a problem refreshing the current screen.' });
@@ -106,24 +105,31 @@ export default Component.extend({
 
   routeToExplore: task(function*(command) {
     let filter = command.replace('api', '').trim();
+    let content =
+      'Welcome to the Vault API explorer! \nYou can search for endpoints, see what parameters they accept, and even execute requests with your current token.';
+    if (filter) {
+      content = `Welcome to the Vault API explorer! \nWe've filtered the list of endpoints for '${filter}'.`;
+    }
     try {
       yield this.router.transitionTo('vault.cluster.open-api-explorer.index', {
         queryParams: { filter },
       });
-      let content =
-        'Welcome to the Vault API explorer! \nYou can search for endpoints, see what parameters they accept, and even execute requests with your current token.';
-      if (filter) {
-        content = `Welcome to the Vault API explorer! \nWe've filtered the list of endpoints for '${filter}'.`;
-      }
       this.logAndOutput(null, {
         type: 'success',
         content,
       });
     } catch (error) {
-      this.logAndOutput(null, {
-        type: 'error',
-        content: 'There was a problem navigating to the api explorer.',
-      });
+      if (error.message === 'TransitionAborted') {
+        this.logAndOutput(null, {
+          type: 'success',
+          content,
+        });
+      } else {
+        this.logAndOutput(null, {
+          type: 'error',
+          content: 'There was a problem navigating to the api explorer.',
+        });
+      }
     }
   }),
 


### PR DESCRIPTION
* Handle api explorer routing error

- For some reason when routing is done during async process, router transtionTo throws the TransitionAbortedError
- As a fix treat this particular error as success since it doesn't interfere in the routing
- Reference: https://github.com/emberjs/ember-test-helpers/issues/332

* Added changelog