### PR TITLE
Use the system rand reader for CA root and intermediate generation

### DIFF
--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -75,7 +75,7 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 		req:     req,
 		apiData: data,
 	}
-	parsedBundle, err := generateIntermediateCSR(b, input)
+	parsedBundle, err := generateIntermediateCSR(b, input, b.Backend.GetRandomReader())
 	if err != nil {
 		switch err.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -2,6 +2,7 @@ package pki
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"time"
@@ -219,7 +220,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	if useCSR {
 		parsedBundle, err = signCert(b, input, signingBundle, false, useCSRValues)
 	} else {
-		parsedBundle, err = generateCert(ctx, b, input, signingBundle, false)
+		parsedBundle, err = generateCert(ctx, b, input, signingBundle, false, rand.Reader)
 	}
 	if err != nil {
 		switch err.(type) {

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -155,7 +155,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 		apiData: data,
 		role:    role,
 	}
-	parsedBundle, err := generateCert(ctx, b, input, nil, true)
+	parsedBundle, err := generateCert(ctx, b, input, nil, true, b.Backend.GetRandomReader())
 	if err != nil {
 		switch err.(type) {
 		case errutil.UserError:

--- a/changelog/12559.txt
+++ b/changelog/12559.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Use entropy augmentation when available when generating root and intermediate CA key material.
+```


### PR DESCRIPTION
This will utilize entropy augmentation if enabled for these infrequent but
sensitive values.