### PR TITLE
Use the system rand reader for SSH keypair generation

### DIFF
--- a/changelog/12560.txt
+++ b/changelog/12560.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/ssh: Use entropy augmentation when available for generation of the signing key.
+```


### PR DESCRIPTION
This allows the use of entropy augmentation if enabled.  Note this is just
for the SSH signing key, not dynamically generated SSH credentials where
performance is key.