### PR TITLE
identity: fix bug and increase logging for jwks cache control max age test

### DIFF
--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -1435,6 +1435,7 @@ func TestOIDC_GetKeysCacheControlHeader(t *testing.T) {
 	}
 	// headerVal will be a random value between 0 and jwksCacheControlMaxAge (in seconds)
 	if headerVal > durationSeconds {
+		t.Logf("jwksCacheControlMaxAge: %d", int(jwksCacheControlMaxAge))
 		t.Fatalf("unexpected header value, got %d expected less than %d", headerVal, durationSeconds)
 	}
 }

--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -1433,7 +1433,7 @@ func TestOIDC_GetKeysCacheControlHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// headerVal will be a random value between 0 and jwksCacheControlMaxAge
+	// headerVal will be a random value between 0 and jwksCacheControlMaxAge (in seconds)
 	if headerVal > durationSeconds {
 		t.Fatalf("unexpected header value, got %d expected less than %d", headerVal, durationSeconds)
 	}

--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -1413,7 +1413,8 @@ func TestOIDC_GetKeysCacheControlHeader(t *testing.T) {
 	}
 
 	// set jwksCacheControlMaxAge
-	jwksCacheControlMaxAge := time.Duration(60) * time.Second
+	durationSeconds := 60
+	jwksCacheControlMaxAge := time.Duration(durationSeconds) * time.Second
 	if err = c.identityStore.oidcCache.SetDefault(noNamespace, "jwksCacheControlMaxAge", jwksCacheControlMaxAge); err != nil {
 		t.Fatal(err)
 	}
@@ -1433,8 +1434,8 @@ func TestOIDC_GetKeysCacheControlHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	// headerVal will be a random value between 0 and jwksCacheControlMaxAge
-	if headerVal > int(jwksCacheControlMaxAge) {
-		t.Fatalf("unexpected header value, got %d", headerVal)
+	if headerVal > durationSeconds {
+		t.Fatalf("unexpected header value, got %d expected less than %d", headerVal, durationSeconds)
 	}
 }
 


### PR DESCRIPTION
There was a nightly failure of `TestOIDC_GetKeysCacheControlHeader`. I have been unable to reproduce the issue locally. This PR increases the logging to determine the cause of the flaky test. Additionally, fix a bug in the comparison `if headerVal > int(jwksCacheControlMaxAge)`