### PR TITLE
docs : Update GoLang library link in docs, typo

### DIFF
--- a/website/content/api-docs/libraries.mdx
+++ b/website/content/api-docs/libraries.mdx
@@ -17,7 +17,7 @@ These libraries are officially maintained by HashiCorp.
 
 ### Go
 
-- [Vault Go Client](https://github.com/hashicorp/vault/tree/master/api)
+- [Vault Go Client](https://github.com/hashicorp/vault/tree/main/api)
 
 ```shell-session
 $ go get github.com/hashicorp/vault/api


### PR DESCRIPTION
Previous link was to outdated master branch, this one is a link to the up-to-date main branch