### PR TITLE
Clarify docs for secretArgs

### DIFF
--- a/website/content/docs/platform/k8s/csi/configurations.mdx
+++ b/website/content/docs/platform/k8s/csi/configurations.mdx
@@ -75,6 +75,15 @@ The following parameters are supported by the Vault provider:
   - `method` `(string: "GET")` - The type of HTTP request. Supported values include "GET" and "PUT".
 
   - `secretPath` `(string: "")` - The path in Vault where the secret is located.
+    For secrets that are retrieved via HTTP GET method, the `secretPath` can include optional URI parameters,
+    for example, the [version of the KV2 secret](https://www.vaultproject.io/api/secret/kv/kv-v2#read-secret-version):
+
+    ```yaml
+    objects: |
+      - objectName: "app-secret"
+        secretPath: "secret/data/test?version=1"
+        secretKey: "password"
+    ```
 
   - `secretKey` `(string: "")` - The key in the Vault secret to extract. If omitted, the whole response from Vault will be written as JSON.
 
@@ -86,3 +95,7 @@ The following parameters are supported by the Vault provider:
       common_name: 'test.example.com'
       ttl: '24h'
     ```
+
+    ~> `secretArgs` are sent as part of the HTTP request body. Therefore, they are only effective for HTTP PUT/POST requests, for instance,
+        the [request used to generate a new certificate](https://www.vaultproject.io/api/secret/pki#generate-certificate).
+        To supply additional parameters for secrets retrieved via HTTP GET, include optional URI paramters in [`secretPath`](#secretpath).


### PR DESCRIPTION
This change clarifies the use of `secretArgs` and adds an example for
retrieving a specific version of a KV2 secret using URI parameters in
`secretPath`.

From a readers perspective, it is not evident which approach to use to
supply additional parameters to the request. Therefore, this change adds
a note on the effectiveness of the two configuration options.

The `secretArgs` seem only relevant for secrets retrieved via POST/PUT
request, since they are sent as part of the request body:
https://github.com/hashicorp/vault-csi-provider/blob/master/internal/provider/provider.go#L146