### PR TITLE
OIDC provider: show success message in CLI

### DIFF
--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -1023,7 +1023,7 @@ func (i *IdentityStore) pathOIDCClientExistenceCheck(ctx context.Context, req *l
 
 // pathOIDCCreateUpdateProvider is used to create a new named provider or update an existing one
 func (i *IdentityStore) pathOIDCCreateUpdateProvider(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	resp := &logical.Response{}
+	var resp logical.Response
 	name := d.Get("name").(string)
 
 	var provider provider
@@ -1141,7 +1141,15 @@ func (i *IdentityStore) pathOIDCCreateUpdateProvider(ctx context.Context, req *l
 		return nil, err
 	}
 
-	return resp, req.Storage.Put(ctx, entry)
+	if err := req.Storage.Put(ctx, entry); err != nil {
+		return nil, err
+	}
+
+	if len(resp.Warnings) == 0 {
+		return nil, nil
+	}
+
+	return &resp, nil
 }
 
 // pathOIDCListProvider is used to list named providers


### PR DESCRIPTION
## Description
The create/update success message was not being returned to the client when creating/updating a provider. This PR ensures the response to the client is consistent with other write operations.

Example without the change (no response)
```
$ vault write identity/oidc/provider/provider1 allowed_client_ids="*"
```

Example with the change
```
$ vault write identity/oidc/provider/provider1 allowed_client_ids="*"
Success! Data written to: identity/oidc/provider/provider1
```