### PR TITLE
Docs: Clarify more sink options

### DIFF
--- a/website/content/docs/agent/autoauth/sinks/file.mdx
+++ b/website/content/docs/agent/autoauth/sinks/file.mdx
@@ -22,3 +22,6 @@ written with `0640` permissions as default, but can be overridden with the optio
 
 - `path` `(string: required)` - The path to use to write the token file
 - `mode` `(int: optional)` - A string containing an octal number representing the bit pattern for the file mode, similar to chmod. Set to `0000` to prevent Vault from modifying the file mode. Note: This configuration option is only available in Vault 1.3.0 and above.
+
+~> Note: Configuration options for response-wrapping and encryption for the sink 
+file are located within the [options common to all sinks](/docs/agent/autoauth#configuration-sinks) documentation. 


### PR DESCRIPTION
Add link to make sure reader is aware of the more options. A little fuzzy as we only have one file-based sink but config are in two locations. 