### PR TITLE
Vault documentation: added browser support

### DIFF
--- a/website/content/docs/browser-support.mdx
+++ b/website/content/docs/browser-support.mdx
@@ -1,0 +1,18 @@
+---
+layout: docs
+page_title: Browser Support
+sidebar_title: Browser Support
+description: |-
+  List of browser suppport.
+---
+
+# Vault UI Browser Support
+
+Vault currently supports all 'evergreen' browsers, as they are generally on up-to-date versions. Therefore, the follow browsers are supported:
+
+- Chrome
+- Firefox
+- Safari
+- Microsoft Edge
+
+We do not support Internet Explorer 11 (IE 11). Vault follows a similar alignment with Microsoft's own stance on IE 11, found on their [support website](https://docs.microsoft.com/en-US/lifecycle/faq/internet-explorer-microsoft-edge).

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -11,7 +11,10 @@
   {
     "divider": true
   },
-
+  {
+    "title": "Browser Support",
+    "path": "browser-support"
+  },
   {
     "title": "Installing Vault",
     "path": "install"


### PR DESCRIPTION
This PR was created to address this request: [Asana](https://app.asana.com/0/inbox/1200328878163177/1200788463472368/1200813681422763)

Originally, the request was to create a general FAQ page to include the browser support information and OS support. PM recently decided that we not move forward documenting the OS support right now (see Asana). In the absence of any further information to include in the FAQ, it didn't make any sense to create a whole new FAQ page at this time just to document browser support only. 

IMO, we should not bury this sort of information so I placed the content up near the top of the side navigation. Please advise if you feel it could be better served elsewhere. Thanks.

:mag:[Deploy Preview](https://vault-d4waxs2cd-hashicorp.vercel.app/docs/browser-support)