### PR TITLE
dep: update vault-plugin-secrets-openldap to v0.3.1

### DIFF
--- a/changelog/12597.txt
+++ b/changelog/12597.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/openldap: Fix bug where Vault can rotate static role passwords early during start up under certain conditions. [#28](https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/28)
+```

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.7.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.2.1
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.3.0
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.3.1
 	github.com/hashicorp/vault/api v1.0.5-0.20201001211907-38d91b749c77
 	github.com/hashicorp/vault/sdk v0.1.14-0.20210824203509-535c9be10674
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4

--- a/go.sum
+++ b/go.sum
@@ -658,8 +658,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.7.0 h1:Sq5CmKWxQu+MtO6AXYM+STPHG
 github.com/hashicorp/vault-plugin-secrets-kv v0.7.0/go.mod h1:B/Cybh5aVF7LNAMHwVBxY8t7r2eL0C6HVGgTyP4nKK4=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.2.1 h1:eX89F+LcMmKAUeI/IM2hS9PKlNyGjdfqdWAfqg1rgSw=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.2.1/go.mod h1:4mdgPqlkO+vfFX1cFAWcxkeqz6JAtZgKxL/67q/58Oo=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.3.0 h1:aDdWZMdr93OtwZRE3TPKJyZgY6ZTe09G7bb2GL1HeAo=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.3.0/go.mod h1:pRE6pJzEVTSn3reeEn6YOV73R/6PcyylwQBz33zZKds=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.3.1 h1:5xGCt+2reDvSS+Sfq1dtsk6/4+/SBgGeYP058Go8W+A=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.3.1/go.mod h1:pRE6pJzEVTSn3reeEn6YOV73R/6PcyylwQBz33zZKds=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyuqg7yuAWUg/jMZR1/0QTzTRdNR6Uw=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35nTu0ey1EXjwNwPjI9xErAsoOCmcMb9GKvyxo=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -637,7 +637,7 @@ github.com/hashicorp/vault-plugin-secrets-kv
 # github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.2.1
 ## explicit
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas
-# github.com/hashicorp/vault-plugin-secrets-openldap v0.3.0
+# github.com/hashicorp/vault-plugin-secrets-openldap v0.3.1
 ## explicit
 github.com/hashicorp/vault-plugin-secrets-openldap
 github.com/hashicorp/vault-plugin-secrets-openldap/client


### PR DESCRIPTION
This PR updates vault-plugin-secrets-openldap to v0.3.1 which contains the fix from https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/28

Steps taken:
```
$ go get github.com/hashicorp/vault-plugin-secrets-openldap@v0.3.1

$ go mod vendor && go mod tidy
```
