### PR TITLE
dep: update vault-plugin-secrets-openldap to v0.5.2

### DIFF
--- a/changelog/12599.txt
+++ b/changelog/12599.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/openldap: Fix bug where Vault can rotate static role passwords early during start up under certain conditions. [#28](https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/28)
+```

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.4.0
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.5.1
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.5.2
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.2.0
 	github.com/hashicorp/vault/api v1.1.2-0.20210713235431-1fc8af4c041f
 	github.com/hashicorp/vault/sdk v0.2.2-0.20210825150427-9b1f4d486f5d

--- a/go.sum
+++ b/go.sum
@@ -742,8 +742,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.9.0 h1:nCw2IfWw2bWUGFZsNk8BvTEg9
 github.com/hashicorp/vault-plugin-secrets-kv v0.9.0/go.mod h1:B/Cybh5aVF7LNAMHwVBxY8t7r2eL0C6HVGgTyP4nKK4=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.4.0 h1:6ve+7hZmGn7OpML81iZUxYj2AaJptwys323S5XsvVas=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.4.0/go.mod h1:4mdgPqlkO+vfFX1cFAWcxkeqz6JAtZgKxL/67q/58Oo=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.5.1 h1:iUJU3D/sA5qNBZnhXI5jFdwoWXMhgb6jeABDLYw631Y=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.5.1/go.mod h1:GiFI8Bxwx3+fn0A3SyVp9XdYQhm3cOgN8GzwKxyJ9So=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.5.2 h1:5f3Gh/gcsC2sbn5PhE3YbeXB0cfC3TlZpkrBUSf90p4=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.5.2/go.mod h1:GiFI8Bxwx3+fn0A3SyVp9XdYQhm3cOgN8GzwKxyJ9So=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.2.0 h1:U5hT6xUUbIhI12v+tjzmUz47gpzg5yxbdf+q62sIIvc=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.2.0/go.mod h1:7r/0t51X/ZtSRh/TjBk7gCm1CUMk50aqLAx811OsGQ8=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyuqg7yuAWUg/jMZR1/0QTzTRdNR6Uw=


### PR DESCRIPTION
This PR updates vault-plugin-secrets-openldap to v0.5.2 which contains the fix from hashicorp/vault-plugin-secrets-openldap#28

Steps taken:
```
$ go get github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2

$ go mod tidy
```