### PR TITLE
Fix client.go

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -203,7 +203,7 @@ func DefaultConfig() *Config {
 	return config
 }
 
-// ConfigureTLS takes a set of TLS configurations and applies those to the the
+// ConfigureTLS takes a set of TLS configurations and applies those to the
 // HTTP client.
 func (c *Config) ConfigureTLS(t *TLSConfig) error {
 	if c.HttpClient == nil {


### PR DESCRIPTION
Modify one annotation.
`ConfigureTLS takes a set of TLS configurations and applies those to the HTTP client.`