### PR TITLE
SDK bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.2.1
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.3.1
 	github.com/hashicorp/vault/api v1.0.5-0.20201001211907-38d91b749c77
-	github.com/hashicorp/vault/sdk v0.1.14-0.20210824203509-535c9be10674
+	github.com/hashicorp/vault/sdk v0.1.14-0.20210922225103-627b314b8d0d
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4
 	github.com/jcmturner/gokrb5/v8 v8.0.0
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f

--- a/vendor/github.com/hashicorp/vault/sdk/version/version_base.go
+++ b/vendor/github.com/hashicorp/vault/sdk/version/version_base.go
@@ -8,7 +8,7 @@ var (
 	// Whether cgo is enabled or not; set at build time
 	CgoEnabled bool
 
-	Version           = "1.6.6"
+	Version           = "1.6.7"
 	VersionPrerelease = ""
 	VersionMetadata   = ""
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -644,7 +644,7 @@ github.com/hashicorp/vault-plugin-secrets-openldap/client
 # github.com/hashicorp/vault/api v1.0.5-0.20201001211907-38d91b749c77 => ./api
 ## explicit
 github.com/hashicorp/vault/api
-# github.com/hashicorp/vault/sdk v0.1.14-0.20210824203509-535c9be10674 => ./sdk
+# github.com/hashicorp/vault/sdk v0.1.14-0.20210922225103-627b314b8d0d => ./sdk
 ## explicit
 github.com/hashicorp/vault/sdk/database/dbplugin
 github.com/hashicorp/vault/sdk/database/dbplugin/v5


### PR DESCRIPTION
To generate this, I ran:

```
go get github.com/hashicorp/vault/sdk@release/1.6.x
go mod tidy
go mod vendor
```