### PR TITLE
Adds additional OIDC discovery metadata

### DIFF
--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -55,6 +55,7 @@ type providerDiscovery struct {
 	AuthorizationEndpoint string   `json:"authorization_endpoint"`
 	TokenEndpoint         string   `json:"token_endpoint"`
 	UserinfoEndpoint      string   `json:"userinfo_endpoint"`
+	RequestURIParameter   bool     `json:"request_uri_parameter_supported"`
 	IDTokenAlgs           []string `json:"id_token_signing_alg_values_supported"`
 	ResponseTypes         []string `json:"response_types_supported"`
 	Scopes                []string `json:"scopes_supported"`
@@ -463,6 +464,7 @@ func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logi
 		UserinfoEndpoint:      p.effectiveIssuer + "/userinfo",
 		IDTokenAlgs:           supportedAlgs,
 		Scopes:                scopes,
+		RequestURIParameter:   false,
 		ResponseTypes:         []string{"code"},
 		Subjects:              []string{"public"},
 		GrantTypes:            []string{"authorization_code"},

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -50,15 +50,17 @@ type provider struct {
 }
 
 type providerDiscovery struct {
-	AuthorizationEndpoint string   `json:"authorization_endpoint"`
-	IDTokenAlgs           []string `json:"id_token_signing_alg_values_supported"`
 	Issuer                string   `json:"issuer"`
 	Keys                  string   `json:"jwks_uri"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	UserinfoEndpoint      string   `json:"userinfo_endpoint"`
+	IDTokenAlgs           []string `json:"id_token_signing_alg_values_supported"`
 	ResponseTypes         []string `json:"response_types_supported"`
 	Scopes                []string `json:"scopes_supported"`
 	Subjects              []string `json:"subject_types_supported"`
-	TokenEndpoint         string   `json:"token_endpoint"`
-	UserinfoEndpoint      string   `json:"userinfo_endpoint"`
+	GrantTypes            []string `json:"grant_types_supported"`
+	AuthMethods           []string `json:"token_endpoint_auth_methods_supported"`
 }
 
 const (
@@ -454,15 +456,17 @@ func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logi
 	scopes := append(p.Scopes, "openid")
 
 	disc := providerDiscovery{
-		AuthorizationEndpoint: strings.Replace(p.effectiveIssuer, "/v1/", "/ui/vault/", 1) + "/authorize",
-		IDTokenAlgs:           supportedAlgs,
 		Issuer:                p.effectiveIssuer,
 		Keys:                  p.effectiveIssuer + "/.well-known/keys",
-		ResponseTypes:         []string{"code"},
-		Scopes:                scopes,
-		Subjects:              []string{"public"},
+		AuthorizationEndpoint: strings.Replace(p.effectiveIssuer, "/v1/", "/ui/vault/", 1) + "/authorize",
 		TokenEndpoint:         p.effectiveIssuer + "/token",
 		UserinfoEndpoint:      p.effectiveIssuer + "/userinfo",
+		IDTokenAlgs:           supportedAlgs,
+		Scopes:                scopes,
+		ResponseTypes:         []string{"code"},
+		Subjects:              []string{"public"},
+		GrantTypes:            []string{"authorization_code"},
+		AuthMethods:           []string{"client_secret_basic"},
 	}
 
 	data, err := json.Marshal(disc)

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -1808,6 +1808,8 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		AuthorizationEndpoint: "/ui/vault/identity/oidc/provider/test-provider/authorize",
 		TokenEndpoint:         basePath + "/token",
 		UserinfoEndpoint:      basePath + "/userinfo",
+		GrantTypes:            []string{"authorization_code"},
+		AuthMethods:           []string{"client_secret_basic"},
 	}
 	discoveryResp := &providerDiscovery{}
 	json.Unmarshal(resp.Data["http_raw_body"].([]byte), discoveryResp)
@@ -1859,6 +1861,8 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		AuthorizationEndpoint: testIssuer + "/ui/vault/identity/oidc/provider/test-provider/authorize",
 		TokenEndpoint:         basePath + "/token",
 		UserinfoEndpoint:      basePath + "/userinfo",
+		GrantTypes:            []string{"authorization_code"},
+		AuthMethods:           []string{"client_secret_basic"},
 	}
 	discoveryResp = &providerDiscovery{}
 	json.Unmarshal(resp.Data["http_raw_body"].([]byte), discoveryResp)

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -1810,6 +1810,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		UserinfoEndpoint:      basePath + "/userinfo",
 		GrantTypes:            []string{"authorization_code"},
 		AuthMethods:           []string{"client_secret_basic"},
+		RequestURIParameter:   false,
 	}
 	discoveryResp := &providerDiscovery{}
 	json.Unmarshal(resp.Data["http_raw_body"].([]byte), discoveryResp)
@@ -1863,6 +1864,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		UserinfoEndpoint:      basePath + "/userinfo",
 		GrantTypes:            []string{"authorization_code"},
 		AuthMethods:           []string{"client_secret_basic"},
+		RequestURIParameter:   false,
 	}
 	discoveryResp = &providerDiscovery{}
 	json.Unmarshal(resp.Data["http_raw_body"].([]byte), discoveryResp)


### PR DESCRIPTION
This PR adds additional [OIDC provider metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) to be published by Vault OIDC providers.

It adds the following two fields:
- `grant_types_supported`
    - The spec states that "If omitted, the default value is ["authorization_code", "implicit"].". This is not true in our case, since we're only supporting ["authorization_code"] initially.
- `token_endpoint_auth_methods_supported`
    - This is additional information that may be useful to clients. We will support the `client_secret_basic` token authentication method.
- `request_uri_parameter_supported`
    - The spec states that the default is `true` if it is not included. We'll include it with a value of `false`.