### PR TITLE
Update flaky expiration test

### DIFF
--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -1288,7 +1288,6 @@ func TestExpiration_RevokeByToken(t *testing.T) {
 		currentRequests := len(noop.Requests)
 		noop.Unlock()
 
-		// Break out of the loop, if all requests present
 		if currentRequests == 3 {
 			break
 		}

--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -1280,13 +1280,24 @@ func TestExpiration_RevokeByToken(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	time.Sleep(300 * time.Millisecond)
+	limit := time.Now().Add(3 * time.Second)
+	for time.Now().Before(limit) {
+		time.Sleep(50 * time.Millisecond)
+
+		noop.Lock()
+		currentRequests := len(noop.Requests)
+		noop.Unlock()
+
+		// Break out of the loop, if all requests present
+		if currentRequests == 3 {
+			break
+		}
+	}
 
 	noop.Lock()
 	defer noop.Unlock()
-
 	if len(noop.Requests) != 3 {
-		t.Fatalf("Bad: %#v", noop.Requests)
+		t.Errorf("Noop revocation requests less than expected, expected 3, found %d", len(noop.Requests))
 	}
 	for _, req := range noop.Requests {
 		if req.Operation != logical.RevokeOperation {


### PR DESCRIPTION
- Updates TestExpiration_RevokeByToken to loop for 3 seconds, sleeping every 50 ms, and check if noop.Requests has the desired number of requests
- This should reduce prior flakiness of sleeping for 300ms and then testing noop.Requests