### PR TITLE
Update Azure secrets engine to use MS Graph

### DIFF
--- a/changelog/12629.txt
+++ b/changelog/12629.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/azure: Adds support for using Microsoft Graph API since Azure Active Directory API is being removed in 2022. [#67](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/67)
+```

--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.9.0
-	github.com/hashicorp/vault-plugin-secrets-azure v0.10.0
+	github.com/hashicorp/vault-plugin-secrets-azure v0.6.3-0.20210924190759-58a034528e35
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.10.2
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.5.7-0.20210811133805-e060c2307b24

--- a/go.sum
+++ b/go.sum
@@ -751,6 +751,8 @@ github.com/hashicorp/vault-plugin-secrets-ad v0.10.0 h1:iMS1SfIQtPfvPbw24W8HbNBb
 github.com/hashicorp/vault-plugin-secrets-ad v0.10.0/go.mod h1:4AN/0ynq1Krn7LhwzoP/roj9JRdxiuptPpktq7ftLjo=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.9.0 h1:EhTRXoWCjM3suD1atK97R2wWHBr/aacYByRnjzZvFCI=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.9.0/go.mod h1:SSkKpSTOMnX84PfgYiWHgwVg+YMhxHNjo+YCJGNBoZk=
+github.com/hashicorp/vault-plugin-secrets-azure v0.6.3-0.20210924190759-58a034528e35 h1:EOw71K6RZcteApYrO4TfJeDcppRzOyCNRO7I66RzMbk=
+github.com/hashicorp/vault-plugin-secrets-azure v0.6.3-0.20210924190759-58a034528e35/go.mod h1:Tqe5hI33oQ+bHLy/dE4zmvcJD1afRnjsrc5SjUgqvZ8=
 github.com/hashicorp/vault-plugin-secrets-azure v0.10.0 h1:pJTWKVHYqfnlB3xg3XnnF9BOpj2/J7LC/e0RgiwkwKI=
 github.com/hashicorp/vault-plugin-secrets-azure v0.10.0/go.mod h1:4jCVjTG809NCQ8mrSnbBtX17gX1Iush+558BVO6MJeo=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.10.2 h1:+DtlYJTsrFRInQpAo09KkYN64scrextjBiTSunpluo8=

--- a/website/content/api-docs/secret/azure.mdx
+++ b/website/content/api-docs/secret/azure.mdx
@@ -36,6 +36,14 @@ service principals. Environment variables will override any parameters set in th
   environment variable. If not specified, Vault will use Azure Public Cloud.
 - `password_policy` `(string: "")` - Specifies a [password policy](/docs/concepts/password-policies) to
   use when creating dynamic credentials. Defaults to generating an alphanumeric password if not set.
+- `use_microsoft_graph_api` `(bool: false)` - Indicates whether the secrets engine should use the
+  [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api). If set to false, this will use the Azure
+  Active Directory API which has been [deprecated by Microsoft and will be removed in 2022](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-faq).
+
+  If set to true, the user specified via the `client_id` and `client_secret` will need to have the following permissions
+  under the Microsoft Graph API: `Application.ReadWrite.All`, `Directory.ReadWrite.All`, and `Group.ReadWrite.All`.
+
+  Aside from the permissions listed above, setting this to true should be transparent to users.
 
 ### Sample Payload
 
@@ -46,7 +54,8 @@ service principals. Environment variables will override any parameters set in th
   "client_id": "e607c4...",
   "client_secret": "9a6346...",
   "environment": "AzureGermanCloud",
-  "password_policy": "azure_policy"
+  "password_policy": "azure_policy",
+  "use_microsoft_graph_api": true
 }
 ```
 

--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -21,6 +21,12 @@ If an existing service principal is specified as part of the role configuration,
 a new password will be dynamically generated instead of a new service principal.
 The password will be deleted when the lease is revoked.
 
+~> Microsoft has deprecated their Azure Active Directory API and will be removing it in
+   2022. If you are currently using this secret engine, you will need to update the
+   credentials to include Microsoft Graph API permissions and specify the
+   `use_microsoft_graph_api` configuration value as true. See the
+   [API Docs](/api-docs/secret/azure#use_microsoft_graph_api) for more details.
+
 ## Setup
 
 Most secrets engines must be configured in advance before they can perform their


### PR DESCRIPTION
Pulls in https://github.com/hashicorp/vault-plugin-secrets-azure/pull/67 to start migrating away from the deprecated Azure Active Directory API to the Microsoft Graph API.

Also adds docs for the new feature flag: `use_microsoft_graph_api` and a warning that current users should migrate their configurations before the AAD API is removed by Microsoft.