### PR TITLE
[VAULT-3248] Check api and sdk dirs in go_test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -995,15 +995,16 @@ jobs:
           USE_DOCKER=0
           USE_DOCKER=1
 
+          # Check all directories with a go.mod file
           modules=('.' 'api' 'sdk')
           all_package_names=""
 
           for dir in "${modules[@]}"
           do
             cd $dir
-            echo "checkin $dir"
             # Split Go tests by prior test times.  If use_docker is true, only run
             # tests that depend on docker, otherwise only those that don't.
+            # The appended true condition ensures the command will succeed if no packages are found
             if [ $USE_DOCKER == 1 ]; then
               package_names=$(go list -test -json ./... |
                 jq -r 'select(.Deps != null) |
@@ -1017,15 +1018,16 @@ jobs:
                   .ForTest | select(. != null)' |
                   sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
+            # Move back into root directory if needed
             if [ $dir != '.' ]; then
               cd ..
             fi
+            # Append the test packages into the global list, if any are found
             if [ "$package_names" != '' ]; then
               all_package_names+=" ${package_names}"
             fi
           done
 
-          echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
           # in multiple different containers, each getting a different subset of
           # the test packages in their package_names variable.  Each container
@@ -1266,15 +1268,16 @@ jobs:
 
           USE_DOCKER=0
 
+          # Check all directories with a go.mod file
           modules=('.' 'api' 'sdk')
           all_package_names=""
 
           for dir in "${modules[@]}"
           do
             cd $dir
-            echo "checkin $dir"
             # Split Go tests by prior test times.  If use_docker is true, only run
             # tests that depend on docker, otherwise only those that don't.
+            # The appended true condition ensures the command will succeed if no packages are found
             if [ $USE_DOCKER == 1 ]; then
               package_names=$(go list -test -json ./... |
                 jq -r 'select(.Deps != null) |
@@ -1288,15 +1291,16 @@ jobs:
                   .ForTest | select(. != null)' |
                   sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
+            # Move back into root directory if needed
             if [ $dir != '.' ]; then
               cd ..
             fi
+            # Append the test packages into the global list, if any are found
             if [ "$package_names" != '' ]; then
               all_package_names+=" ${package_names}"
             fi
           done
 
-          echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
           # in multiple different containers, each getting a different subset of
           # the test packages in their package_names variable.  Each container
@@ -1788,15 +1792,16 @@ jobs:
 
           USE_DOCKER=0
 
+          # Check all directories with a go.mod file
           modules=('.' 'api' 'sdk')
           all_package_names=""
 
           for dir in "${modules[@]}"
           do
             cd $dir
-            echo "checkin $dir"
             # Split Go tests by prior test times.  If use_docker is true, only run
             # tests that depend on docker, otherwise only those that don't.
+            # The appended true condition ensures the command will succeed if no packages are found
             if [ $USE_DOCKER == 1 ]; then
               package_names=$(go list -test -json ./... |
                 jq -r 'select(.Deps != null) |
@@ -1810,15 +1815,16 @@ jobs:
                   .ForTest | select(. != null)' |
                   sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
+            # Move back into root directory if needed
             if [ $dir != '.' ]; then
               cd ..
             fi
+            # Append the test packages into the global list, if any are found
             if [ "$package_names" != '' ]; then
               all_package_names+=" ${package_names}"
             fi
           done
 
-          echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
           # in multiple different containers, each getting a different subset of
           # the test packages in their package_names variable.  Each container
@@ -2454,15 +2460,16 @@ jobs:
           USE_DOCKER=0
           USE_DOCKER=1
 
+          # Check all directories with a go.mod file
           modules=('.' 'api' 'sdk')
           all_package_names=""
 
           for dir in "${modules[@]}"
           do
             cd $dir
-            echo "checkin $dir"
             # Split Go tests by prior test times.  If use_docker is true, only run
             # tests that depend on docker, otherwise only those that don't.
+            # The appended true condition ensures the command will succeed if no packages are found
             if [ $USE_DOCKER == 1 ]; then
               package_names=$(go list -test -json ./... |
                 jq -r 'select(.Deps != null) |
@@ -2476,15 +2483,16 @@ jobs:
                   .ForTest | select(. != null)' |
                   sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
+            # Move back into root directory if needed
             if [ $dir != '.' ]; then
               cd ..
             fi
+            # Append the test packages into the global list, if any are found
             if [ "$package_names" != '' ]; then
               all_package_names+=" ${package_names}"
             fi
           done
 
-          echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
           # in multiple different containers, each getting a different subset of
           # the test packages in their package_names variable.  Each container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1021,6 +1021,7 @@ jobs:
               cd ..
             fi
             all_package_names+=" ${package_names}"
+          done
 
           echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
@@ -1289,6 +1290,7 @@ jobs:
               cd ..
             fi
             all_package_names+=" ${package_names}"
+          done
 
           echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
@@ -1808,6 +1810,7 @@ jobs:
               cd ..
             fi
             all_package_names+=" ${package_names}"
+          done
 
           echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
@@ -2471,6 +2474,7 @@ jobs:
               cd ..
             fi
             all_package_names+=" ${package_names}"
+          done
 
           echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1009,13 +1009,13 @@ jobs:
                 jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             else
               package_names=$(go list -test -json ./... |
                 jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
             if [ $dir != '.' ]; then
               cd ..
@@ -1280,13 +1280,13 @@ jobs:
                 jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             else
               package_names=$(go list -test -json ./... |
                 jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
             if [ $dir != '.' ]; then
               cd ..
@@ -1802,13 +1802,13 @@ jobs:
                 jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             else
               package_names=$(go list -test -json ./... |
                 jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
             if [ $dir != '.' ]; then
               cd ..
@@ -2468,13 +2468,13 @@ jobs:
                 jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             else
               package_names=$(go list -test -json ./... |
                 jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
             if [ $dir != '.' ]; then
               cd ..

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -996,12 +996,12 @@ jobs:
           USE_DOCKER=1
 
           # Check all directories with a go.mod file
-          modules=('.' 'api' 'sdk')
+          modules=("." "api" "sdk")
           all_package_names=""
 
           for dir in "${modules[@]}"
           do
-            cd $dir
+            pushd "$dir"
             # Split Go tests by prior test times.  If use_docker is true, only run
             # tests that depend on docker, otherwise only those that don't.
             # The appended true condition ensures the command will succeed if no packages are found
@@ -1018,12 +1018,10 @@ jobs:
                   .ForTest | select(. != null)' |
                   sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
-            # Move back into root directory if needed
-            if [ $dir != '.' ]; then
-              cd ..
-            fi
+            # Move back into root directory
+            popd
             # Append the test packages into the global list, if any are found
-            if [ "$package_names" != '' ]; then
+            if [ -n "$package_names" ]; then
               all_package_names+=" ${package_names}"
             fi
           done
@@ -1269,12 +1267,12 @@ jobs:
           USE_DOCKER=0
 
           # Check all directories with a go.mod file
-          modules=('.' 'api' 'sdk')
+          modules=("." "api" "sdk")
           all_package_names=""
 
           for dir in "${modules[@]}"
           do
-            cd $dir
+            pushd "$dir"
             # Split Go tests by prior test times.  If use_docker is true, only run
             # tests that depend on docker, otherwise only those that don't.
             # The appended true condition ensures the command will succeed if no packages are found
@@ -1291,12 +1289,10 @@ jobs:
                   .ForTest | select(. != null)' |
                   sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
-            # Move back into root directory if needed
-            if [ $dir != '.' ]; then
-              cd ..
-            fi
+            # Move back into root directory
+            popd
             # Append the test packages into the global list, if any are found
-            if [ "$package_names" != '' ]; then
+            if [ -n "$package_names" ]; then
               all_package_names+=" ${package_names}"
             fi
           done
@@ -1793,12 +1789,12 @@ jobs:
           USE_DOCKER=0
 
           # Check all directories with a go.mod file
-          modules=('.' 'api' 'sdk')
+          modules=("." "api" "sdk")
           all_package_names=""
 
           for dir in "${modules[@]}"
           do
-            cd $dir
+            pushd "$dir"
             # Split Go tests by prior test times.  If use_docker is true, only run
             # tests that depend on docker, otherwise only those that don't.
             # The appended true condition ensures the command will succeed if no packages are found
@@ -1815,12 +1811,10 @@ jobs:
                   .ForTest | select(. != null)' |
                   sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
-            # Move back into root directory if needed
-            if [ $dir != '.' ]; then
-              cd ..
-            fi
+            # Move back into root directory
+            popd
             # Append the test packages into the global list, if any are found
-            if [ "$package_names" != '' ]; then
+            if [ -n "$package_names" ]; then
               all_package_names+=" ${package_names}"
             fi
           done
@@ -2461,12 +2455,12 @@ jobs:
           USE_DOCKER=1
 
           # Check all directories with a go.mod file
-          modules=('.' 'api' 'sdk')
+          modules=("." "api" "sdk")
           all_package_names=""
 
           for dir in "${modules[@]}"
           do
-            cd $dir
+            pushd "$dir"
             # Split Go tests by prior test times.  If use_docker is true, only run
             # tests that depend on docker, otherwise only those that don't.
             # The appended true condition ensures the command will succeed if no packages are found
@@ -2483,12 +2477,10 @@ jobs:
                   .ForTest | select(. != null)' |
                   sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
             fi
-            # Move back into root directory if needed
-            if [ $dir != '.' ]; then
-              cd ..
-            fi
+            # Move back into root directory
+            popd
             # Append the test packages into the global list, if any are found
-            if [ "$package_names" != '' ]; then
+            if [ -n "$package_names" ]; then
               all_package_names+=" ${package_names}"
             fi
           done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1020,7 +1020,9 @@ jobs:
             if [ $dir != '.' ]; then
               cd ..
             fi
-            all_package_names+=" ${package_names}"
+            if [ "$package_names" != '' ]; then
+              all_package_names+=" ${package_names}"
+            fi
           done
 
           echo "Testing packages $all_package_names"
@@ -1289,7 +1291,9 @@ jobs:
             if [ $dir != '.' ]; then
               cd ..
             fi
-            all_package_names+=" ${package_names}"
+            if [ "$package_names" != '' ]; then
+              all_package_names+=" ${package_names}"
+            fi
           done
 
           echo "Testing packages $all_package_names"
@@ -1809,7 +1813,9 @@ jobs:
             if [ $dir != '.' ]; then
               cd ..
             fi
-            all_package_names+=" ${package_names}"
+            if [ "$package_names" != '' ]; then
+              all_package_names+=" ${package_names}"
+            fi
           done
 
           echo "Testing packages $all_package_names"
@@ -2473,7 +2479,9 @@ jobs:
             if [ $dir != '.' ]; then
               cd ..
             fi
-            all_package_names+=" ${package_names}"
+            if [ "$package_names" != '' ]; then
+              all_package_names+=" ${package_names}"
+            fi
           done
 
           echo "Testing packages $all_package_names"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -995,22 +995,34 @@ jobs:
           USE_DOCKER=0
           USE_DOCKER=1
 
-          # Split Go tests by prior test times.  If use_docker is true, only run
-          # tests that depend on docker, otherwise only those that don't.
-          if [ $USE_DOCKER == 1 ]; then
-            package_names=$(go list -test -json ./... |
-              jq -r 'select(.Deps != null) |
-                select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
-                .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
-          else
-            package_names=$(go list -test -json ./... |
-              jq -r 'select(.Deps != null) |
-                select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
-                .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
-          fi
+          modules=('.' 'api' 'sdk')
+          all_package_names=""
 
+          for dir in "${modules[@]}"
+          do
+            cd $dir
+            echo "checkin $dir"
+            # Split Go tests by prior test times.  If use_docker is true, only run
+            # tests that depend on docker, otherwise only those that don't.
+            if [ $USE_DOCKER == 1 ]; then
+              package_names=$(go list -test -json ./... |
+                jq -r 'select(.Deps != null) |
+                  select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
+                  .ForTest | select(. != null)' |
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+            else
+              package_names=$(go list -test -json ./... |
+                jq -r 'select(.Deps != null) |
+                  select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
+                  .ForTest | select(. != null)' |
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+            fi
+            if [ $dir != '.' ]; then
+              cd ..
+            fi
+            all_package_names+=" ${package_names}"
+
+          echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
           # in multiple different containers, each getting a different subset of
           # the test packages in their package_names variable.  Each container
@@ -1085,7 +1097,7 @@ jobs:
                   -timeout=60m \
                   -parallel=20 \
                    \
-                  ${package_names}
+                  ${all_package_names}
           else
             GOARCH=amd64 \
               GOCACHE=/tmp/go-cache \
@@ -1097,7 +1109,7 @@ jobs:
                 -timeout=60m \
                 -parallel=20 \
                  \
-                ${package_names}
+                ${all_package_names}
           fi
         environment:
           GOPRIVATE: github.com/hashicorp/*
@@ -1251,22 +1263,34 @@ jobs:
 
           USE_DOCKER=0
 
-          # Split Go tests by prior test times.  If use_docker is true, only run
-          # tests that depend on docker, otherwise only those that don't.
-          if [ $USE_DOCKER == 1 ]; then
-            package_names=$(go list -test -json ./... |
-              jq -r 'select(.Deps != null) |
-                select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
-                .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
-          else
-            package_names=$(go list -test -json ./... |
-              jq -r 'select(.Deps != null) |
-                select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
-                .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
-          fi
+          modules=('.' 'api' 'sdk')
+          all_package_names=""
 
+          for dir in "${modules[@]}"
+          do
+            cd $dir
+            echo "checkin $dir"
+            # Split Go tests by prior test times.  If use_docker is true, only run
+            # tests that depend on docker, otherwise only those that don't.
+            if [ $USE_DOCKER == 1 ]; then
+              package_names=$(go list -test -json ./... |
+                jq -r 'select(.Deps != null) |
+                  select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
+                  .ForTest | select(. != null)' |
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+            else
+              package_names=$(go list -test -json ./... |
+                jq -r 'select(.Deps != null) |
+                  select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
+                  .ForTest | select(. != null)' |
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+            fi
+            if [ $dir != '.' ]; then
+              cd ..
+            fi
+            all_package_names+=" ${package_names}"
+
+          echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
           # in multiple different containers, each getting a different subset of
           # the test packages in their package_names variable.  Each container
@@ -1341,7 +1365,7 @@ jobs:
                   -timeout=60m \
                   -parallel=20 \
                   -race \
-                  ${package_names}
+                  ${all_package_names}
           else
             GOARCH=amd64 \
               GOCACHE=/tmp/go-cache \
@@ -1353,7 +1377,7 @@ jobs:
                 -timeout=60m \
                 -parallel=20 \
                 -race \
-                ${package_names}
+                ${all_package_names}
           fi
         environment:
           GOPRIVATE: github.com/hashicorp/*
@@ -1758,22 +1782,34 @@ jobs:
 
           USE_DOCKER=0
 
-          # Split Go tests by prior test times.  If use_docker is true, only run
-          # tests that depend on docker, otherwise only those that don't.
-          if [ $USE_DOCKER == 1 ]; then
-            package_names=$(go list -test -json ./... |
-              jq -r 'select(.Deps != null) |
-                select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
-                .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
-          else
-            package_names=$(go list -test -json ./... |
-              jq -r 'select(.Deps != null) |
-                select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
-                .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
-          fi
+          modules=('.' 'api' 'sdk')
+          all_package_names=""
 
+          for dir in "${modules[@]}"
+          do
+            cd $dir
+            echo "checkin $dir"
+            # Split Go tests by prior test times.  If use_docker is true, only run
+            # tests that depend on docker, otherwise only those that don't.
+            if [ $USE_DOCKER == 1 ]; then
+              package_names=$(go list -test -json ./... |
+                jq -r 'select(.Deps != null) |
+                  select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
+                  .ForTest | select(. != null)' |
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+            else
+              package_names=$(go list -test -json ./... |
+                jq -r 'select(.Deps != null) |
+                  select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
+                  .ForTest | select(. != null)' |
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+            fi
+            if [ $dir != '.' ]; then
+              cd ..
+            fi
+            all_package_names+=" ${package_names}"
+
+          echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
           # in multiple different containers, each getting a different subset of
           # the test packages in their package_names variable.  Each container
@@ -1848,7 +1884,7 @@ jobs:
                   -timeout=60m \
                   -parallel=20 \
                    \
-                  ${package_names}
+                  ${all_package_names}
           else
             GOARCH=amd64 \
               GOCACHE=/tmp/go-cache \
@@ -1860,7 +1896,7 @@ jobs:
                 -timeout=60m \
                 -parallel=20 \
                  \
-                ${package_names}
+                ${all_package_names}
           fi
         environment:
           GOPRIVATE: github.com/hashicorp/*
@@ -2409,22 +2445,34 @@ jobs:
           USE_DOCKER=0
           USE_DOCKER=1
 
-          # Split Go tests by prior test times.  If use_docker is true, only run
-          # tests that depend on docker, otherwise only those that don't.
-          if [ $USE_DOCKER == 1 ]; then
-            package_names=$(go list -test -json ./... |
-              jq -r 'select(.Deps != null) |
-                select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
-                .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
-          else
-            package_names=$(go list -test -json ./... |
-              jq -r 'select(.Deps != null) |
-                select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
-                .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
-          fi
+          modules=('.' 'api' 'sdk')
+          all_package_names=""
 
+          for dir in "${modules[@]}"
+          do
+            cd $dir
+            echo "checkin $dir"
+            # Split Go tests by prior test times.  If use_docker is true, only run
+            # tests that depend on docker, otherwise only those that don't.
+            if [ $USE_DOCKER == 1 ]; then
+              package_names=$(go list -test -json ./... |
+                jq -r 'select(.Deps != null) |
+                  select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
+                  .ForTest | select(. != null)' |
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+            else
+              package_names=$(go list -test -json ./... |
+                jq -r 'select(.Deps != null) |
+                  select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
+                  .ForTest | select(. != null)' |
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+            fi
+            if [ $dir != '.' ]; then
+              cd ..
+            fi
+            all_package_names+=" ${package_names}"
+
+          echo "Testing packages $all_package_names"
           # After running tests split step, we are now running the following steps
           # in multiple different containers, each getting a different subset of
           # the test packages in their package_names variable.  Each container
@@ -2499,7 +2547,7 @@ jobs:
                   -timeout=60m \
                   -parallel=20 \
                   -race \
-                  ${package_names}
+                  ${all_package_names}
           else
             GOARCH=amd64 \
               GOCACHE=/tmp/go-cache \
@@ -2511,7 +2559,7 @@ jobs:
                 -timeout=60m \
                 -parallel=20 \
                 -race \
-                ${package_names}
+                ${all_package_names}
           fi
         environment:
           GOPRIVATE: github.com/hashicorp/*

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -59,12 +59,12 @@ steps:
         <</ parameters.use_docker >>
 
         # Check all directories with a go.mod file
-        modules=('.' 'api' 'sdk')
+        modules=("." "api" "sdk")
         all_package_names=""
 
         for dir in "${modules[@]}"
         do
-          cd $dir
+          pushd "$dir"
           # Split Go tests by prior test times.  If use_docker is true, only run
           # tests that depend on docker, otherwise only those that don't.
           # The appended true condition ensures the command will succeed if no packages are found
@@ -81,12 +81,10 @@ steps:
                 .ForTest | select(. != null)' |
                 sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
           fi
-          # Move back into root directory if needed
-          if [ $dir != '.' ]; then
-            cd ..
-          fi
+          # Move back into root directory
+          popd
           # Append the test packages into the global list, if any are found
-          if [ "$package_names" != '' ]; then
+          if [ -n "$package_names" ]; then
             all_package_names+=" ${package_names}"
           fi
         done

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -84,6 +84,7 @@ steps:
             cd ..
           fi
           all_package_names+=" ${package_names}"
+        done
 
         echo "Testing packages $all_package_names"
         # After running tests split step, we are now running the following steps

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -58,22 +58,34 @@ steps:
         USE_DOCKER=1
         <</ parameters.use_docker >>
 
-        # Split Go tests by prior test times.  If use_docker is true, only run
-        # tests that depend on docker, otherwise only those that don't.
-        if [ $USE_DOCKER == 1 ]; then
-          package_names=$(go list -test -json ./... |
-            jq -r 'select(.Deps != null) |
-              select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
-              .ForTest | select(. != null)' |
-              sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
-        else
-          package_names=$(go list -test -json ./... |
-            jq -r 'select(.Deps != null) |
-              select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
-              .ForTest | select(. != null)' |
-              sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
-        fi
+        modules=('.' 'api' 'sdk')
+        all_package_names=""
 
+        for dir in "${modules[@]}"
+        do
+          cd $dir
+          echo "checkin $dir"
+          # Split Go tests by prior test times.  If use_docker is true, only run
+          # tests that depend on docker, otherwise only those that don't.
+          if [ $USE_DOCKER == 1 ]; then
+            package_names=$(go list -test -json ./... |
+              jq -r 'select(.Deps != null) |
+                select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
+                .ForTest | select(. != null)' |
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+          else
+            package_names=$(go list -test -json ./... |
+              jq -r 'select(.Deps != null) |
+                select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
+                .ForTest | select(. != null)' |
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+          fi
+          if [ $dir != '.' ]; then
+            cd ..
+          fi
+          all_package_names+=" ${package_names}"
+
+        echo "Testing packages $all_package_names"
         # After running tests split step, we are now running the following steps
         # in multiple different containers, each getting a different subset of
         # the test packages in their package_names variable.  Each container
@@ -148,7 +160,7 @@ steps:
                 -timeout=60m \
                 -parallel=20 \
                 << parameters.extra_flags >> \
-                ${package_names}
+                ${all_package_names}
         else
           GOARCH=<< parameters.arch >> \
             GOCACHE=<< parameters.cache_dir >> \
@@ -160,7 +172,7 @@ steps:
               -timeout=60m \
               -parallel=20 \
               << parameters.extra_flags >> \
-              ${package_names}
+              ${all_package_names}
         fi
 
   - when:

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -58,15 +58,16 @@ steps:
         USE_DOCKER=1
         <</ parameters.use_docker >>
 
+        # Check all directories with a go.mod file
         modules=('.' 'api' 'sdk')
         all_package_names=""
 
         for dir in "${modules[@]}"
         do
           cd $dir
-          echo "checkin $dir"
           # Split Go tests by prior test times.  If use_docker is true, only run
           # tests that depend on docker, otherwise only those that don't.
+          # The appended true condition ensures the command will succeed if no packages are found
           if [ $USE_DOCKER == 1 ]; then
             package_names=$(go list -test -json ./... |
               jq -r 'select(.Deps != null) |
@@ -80,15 +81,16 @@ steps:
                 .ForTest | select(. != null)' |
                 sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
           fi
+          # Move back into root directory if needed
           if [ $dir != '.' ]; then
             cd ..
           fi
+          # Append the test packages into the global list, if any are found
           if [ "$package_names" != '' ]; then
             all_package_names+=" ${package_names}"
           fi
         done
 
-        echo "Testing packages $all_package_names"
         # After running tests split step, we are now running the following steps
         # in multiple different containers, each getting a different subset of
         # the test packages in their package_names variable.  Each container

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -72,13 +72,13 @@ steps:
               jq -r 'select(.Deps != null) |
                 select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                 .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
           else
             package_names=$(go list -test -json ./... |
               jq -r 'select(.Deps != null) |
                 select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                 .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
           fi
           if [ $dir != '.' ]; then
             cd ..

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -83,7 +83,9 @@ steps:
           if [ $dir != '.' ]; then
             cd ..
           fi
-          all_package_names+=" ${package_names}"
+          if [ "$package_names" != '' ]; then
+            all_package_names+=" ${package_names}"
+          fi
         done
 
         echo "Testing packages $all_package_names"

--- a/api/go.sum
+++ b/api/go.sum
@@ -57,8 +57,7 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
-github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
- Api and Sdk tests are currently not being run in CI
- This updates the go_test.yml command, used by the race and non-race, docker and non-docker, go tests, to find the test packages in the api and sdk directories, and ensure they are run in CI as well.
- The api/go.sum has the snappy checksum updated to be for the currently used version. ( This was causing `go list ..` to fail)