### PR TITLE
fix: upgrade vault-plugin-auth-kubernetes

### DIFF
--- a/changelog/12633.txt
+++ b/changelog/12633.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+auth/kubernetes: Add ability to configure entity alias names based on the serviceaccount's namespace and name
+```

--- a/changelog/12633.txt
+++ b/changelog/12633.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-auth/kubernetes: Add ability to configure entity alias names based on the serviceaccount's namespace and name
+auth/kubernetes: Add ability to configure entity alias names based on the serviceaccount's namespace and name. [#110](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/110) [#112](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/112)
 ```

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-gcp v0.10.0
 	github.com/hashicorp/vault-plugin-auth-jwt v0.10.1
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.4.0
-	github.com/hashicorp/vault-plugin-auth-kubernetes v0.10.1
+	github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.1-0.20210921194437-e5af6ccd8add
 	github.com/hashicorp/vault-plugin-auth-oci v0.8.0
 	github.com/hashicorp/vault-plugin-database-couchbase v0.3.1-0.20210902192635-c3ee7c5bc378
 	github.com/hashicorp/vault-plugin-database-elasticsearch v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -733,8 +733,8 @@ github.com/hashicorp/vault-plugin-auth-jwt v0.10.1 h1:7hvGSiICXpmp7Ras5glxVVxTDg
 github.com/hashicorp/vault-plugin-auth-jwt v0.10.1/go.mod h1:3KxfehLIM7zH19+O8jHJ/QJsLGRzSKRqjsesOJmBuoI=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.4.0 h1:7M7/DbFsUoOMBd2/R48ZNj4PM3Gdsg0dGcbMOdt5z1Q=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.4.0/go.mod h1:h+7pLm4Z2EeKHOGPefX0bGzdUQCMBUlvM/BpSMNgTFw=
-github.com/hashicorp/vault-plugin-auth-kubernetes v0.10.1 h1:7c2ufXt5oXSUISNHpO07W956fpgn00nT1IQFPEP5XQE=
-github.com/hashicorp/vault-plugin-auth-kubernetes v0.10.1/go.mod h1:2c/k3nsoGPKV+zpAWCiajt4e66vncEq8Li/eKLqErAc=
+github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.1-0.20210921194437-e5af6ccd8add h1:Spwfyp4obQ6MhXWCsYHiAlNsehb8PCVciF1vMZqn3so=
+github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.1-0.20210921194437-e5af6ccd8add/go.mod h1:Q13bq4paoPWW+bsSq2seyiLPQkFl5vrb+vIwwLDlQ8M=
 github.com/hashicorp/vault-plugin-auth-oci v0.8.0 h1:qYtVYsQlVnqqlCVqZ+CAiFEXuYJqUQCuqcWQVELybZY=
 github.com/hashicorp/vault-plugin-auth-oci v0.8.0/go.mod h1:Cn5cjR279Y+snw8LTaiLTko3KGrbigRbsQPOd2D5xDw=
 github.com/hashicorp/vault-plugin-database-couchbase v0.3.1-0.20210902192635-c3ee7c5bc378 h1:RATGqoJ/MeMyftaRBndUiSM9ZgCbGi7JiLzJtn31bHk=

--- a/website/content/api-docs/auth/kubernetes.mdx
+++ b/website/content/api-docs/auth/kubernetes.mdx
@@ -122,6 +122,14 @@ entities attempting to login.
 - `bound_service_account_namespaces` `(array: <required>)` - List of namespaces
   allowed to access this role. If set to "\*" all namespaces are allowed.
 - `audience` `(string: "")` - Optional Audience claim to verify in the JWT.
+- `alias_name_source` `(string: "serviceaccount_uid")` - Configures how identity aliases are generated.
+  Valid choices are: `serviceaccount_uid`, `serviceaccount_name`
+  When `serviceaccount_uid` is specified, the machine generated UID from the service account will be used as the identity alias name.
+  When `serviceaccount_name` is specified, the service account's namespace and name will be used as the identity alias name e.g `vault/vault-auth`.
+  While it is strongly advised that you use `serviceaccount_uid`, you may also use `serviceaccount_name` in cases where
+  you want to set the alias ahead of time, and the risks are mitigated or otherwise acceptable given your use case.
+  It is very important to limit who is able to delete/create service accounts within a given cluster.
+  Please see (/api-docs/secret/identity/entity-alias#create-an-entity-alias), which further elaborates on the related security implications.
 
 @include 'tokenfields.mdx'
 

--- a/website/content/api-docs/secret/identity/entity-alias.mdx
+++ b/website/content/api-docs/secret/identity/entity-alias.mdx
@@ -13,6 +13,12 @@ an entity with higher privileges.
 
 ## Create an Entity Alias
 
+~> **IMPORTANT NOTE:** Prior to creating any alias it is important to consider the cardinality of the alias' name,
+since there are potential security issues to be aware of. The main one revolves around alias reuse. It is possible
+for multiple authenticated entities to be bound to the same alias, and therefore gain access to all of its privileges.
+It is recommended, whenever possible, to create a unique alias for each entity. This is especially true in the case
+of machine generated entities.
+
 This endpoint creates a new alias for an entity.
 
 | Method | Path                     |


### PR DESCRIPTION
- brings in the alias_name_source feature which allows for setting
  alternate alias names based on the service accounts's namespace and
  name
- document the seurity related aspects for the feature addition above.