### PR TITLE
Edit form should be valid by default

### DIFF
--- a/changelog/12646.txt
+++ b/changelog/12646.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix bug where edit role form on auth method is invalid by default
+```

--- a/ui/app/components/generated-item.js
+++ b/ui/app/components/generated-item.js
@@ -25,7 +25,7 @@ export default Component.extend({
   flashMessages: service(),
   router: service(),
   validationMessages: null,
-  isFormInvalid: true,
+  isFormInvalid: false,
   props: computed('model', function() {
     return this.model.serialize();
   }),


### PR DESCRIPTION
This PR fixes an issue where specifically the K8S role edit form is invalid until a keypress is registered. We should instead assume a form is valid on load until it starts being filled out by the user. 

This bug was introduced with the validation work done in 1.8, so it does not need to be backported prior to that version. 

**Previous behavior**
![before-edit](https://user-images.githubusercontent.com/82459713/134973699-bcc4ed88-a6f4-4303-8e98-2f6558e77759.gif)
