### PR TITLE
backport 1.7.x: core: set namespace within GeneratePasswordFromPolicy (#12635)

### DIFF
--- a/builtin/logical/database/backend_test.go
+++ b/builtin/logical/database/backend_test.go
@@ -45,7 +45,7 @@ func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
 
 	os.Setenv(pluginutil.PluginCACertPEMEnv, cluster.CACertPEMFile)
 
-	sys := vault.TestDynamicSystemView(cores[0].Core)
+	sys := vault.TestDynamicSystemView(cores[0].Core, nil)
 	vault.TestAddTestPlugin(t, cores[0].Core, "postgresql-database-plugin", consts.PluginTypeDatabase, "TestBackend_PluginMain_Postgres", []string{}, "")
 	vault.TestAddTestPlugin(t, cores[0].Core, "mongodb-database-plugin", consts.PluginTypeDatabase, "TestBackend_PluginMain_Mongo", []string{}, "")
 	vault.TestAddTestPlugin(t, cores[0].Core, "mongodbatlas-database-plugin", consts.PluginTypeDatabase, "TestBackend_PluginMain_MongoAtlas", []string{}, "")

--- a/builtin/logical/database/dbplugin/plugin_test.go
+++ b/builtin/logical/database/dbplugin/plugin_test.go
@@ -103,7 +103,7 @@ func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
 	cluster.Start()
 	cores := cluster.Cores
 
-	sys := vault.TestDynamicSystemView(cores[0].Core)
+	sys := vault.TestDynamicSystemView(cores[0].Core, nil)
 	vault.TestAddTestPlugin(t, cores[0].Core, "test-plugin", consts.PluginTypeDatabase, "TestPlugin_GRPC_Main", []string{}, "")
 
 	return cluster, sys

--- a/builtin/plugin/backend_test.go
+++ b/builtin/plugin/backend_test.go
@@ -80,7 +80,7 @@ func testConfig(t *testing.T) (*logical.BackendConfig, func()) {
 
 	core := cores[0]
 
-	sys := vault.TestDynamicSystemView(core.Core)
+	sys := vault.TestDynamicSystemView(core.Core, nil)
 
 	config := &logical.BackendConfig{
 		Logger: logging.NewVaultLogger(log.Debug),

--- a/changelog/12635.txt
+++ b/changelog/12635.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core (enterprise): Fix bug where password generation through password policies do not work on namespaces if performed outside a request callback or from an external plugin.
+```

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -341,6 +341,8 @@ func (d dynamicSystemView) GeneratePasswordFromPolicy(ctx context.Context, polic
 		defer cancel()
 	}
 
+	ctx = namespace.ContextWithNamespace(ctx, d.mountEntry.Namespace())
+
 	policyCfg, err := d.retrievePasswordPolicy(ctx, policyName)
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve password policy: %w", err)

--- a/vault/dynamic_system_view_test.go
+++ b/vault/dynamic_system_view_test.go
@@ -16,8 +16,9 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-var testPolicyName = "testpolicy"
-var rawTestPasswordPolicy = `
+var (
+	testPolicyName        = "testpolicy"
+	rawTestPasswordPolicy = `
 length = 20
 rule "charset" {
 	charset = "abcdefghijklmnopqrstuvwxyz"
@@ -31,6 +32,7 @@ rule "charset" {
 	charset = "0123456789"
 	min_chars = 1
 }`
+)
 
 func TestIdentity_BackendTemplating(t *testing.T) {
 	var err error
@@ -205,7 +207,7 @@ func TestDynamicSystemView_GeneratePasswordFromPolicy_successful(t *testing.T) {
 	defer cancel()
 
 	ctx = namespace.RootContext(ctx)
-	dsv := dynamicSystemView{core: cluster.Cores[0].Core}
+	dsv := TestDynamicSystemView(cluster.Cores[0].Core, nil)
 
 	runeset := map[rune]bool{}
 	runesFound := []rune{}
@@ -272,11 +274,11 @@ func TestDynamicSystemView_GeneratePasswordFromPolicy_failed(t *testing.T) {
 				getErr:   test.getErr,
 			}
 
-			dsv := dynamicSystemView{
-				core: &Core{
-					systemBarrierView: NewBarrierView(testStorage, "sys/"),
-				},
+			core := &Core{
+				systemBarrierView: NewBarrierView(testStorage, "sys/"),
 			}
+			dsv := TestDynamicSystemView(core, nil)
+
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			actualPassword, err := dsv.GeneratePasswordFromPolicy(ctx, test.policyName)

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -439,12 +439,19 @@ func TestKeyCopy(key []byte) []byte {
 	return result
 }
 
-func TestDynamicSystemView(c *Core) *dynamicSystemView {
+func TestDynamicSystemView(c *Core, ns *namespace.Namespace) *dynamicSystemView {
 	me := &MountEntry{
 		Config: MountConfig{
 			DefaultLeaseTTL: 24 * time.Hour,
 			MaxLeaseTTL:     2 * 24 * time.Hour,
 		},
+		NamespaceID: namespace.RootNamespace.ID,
+		namespace:   namespace.RootNamespace,
+	}
+
+	if ns != nil {
+		me.NamespaceID = ns.ID
+		me.namespace = ns
 	}
 
 	return &dynamicSystemView{c, me}


### PR DESCRIPTION
* core: set namespace from the sysview's mount entry on GeneratePasswordFromPolicy

* test: update TestDynamicSystemView to be ns-aware, update tests

* add changelog entry