### PR TITLE
Documentation update: Added tuner parameters to the Sensitive information section

### DIFF
--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -29,28 +29,21 @@ The audit logs contain the full request and response objects for every
 interaction with Vault. The request and response can be matched utilizing a
 unique identifier assigned to each request.
 
-With a few specific exceptions, all strings (including authentication tokens and lease information) contained within requests and
-responses are hashed with a salt using HMAC-SHA256. The purpose of the hash is
-so that secrets aren't in plaintext within your audit logs. However, you're
-still able to check the value of secrets by generating HMACs yourself; this can
-be done with the audit device's hash function and salt by using the
-`/sys/audit-hash` API endpoint (see the documentation for more details).
+Most strings contained within requests and responses are hashed with a salt using HMAC-SHA256. The purpose of the hash is so that secrets aren't in plaintext within your audit logs. However, you're still able to check the value of secrets by generating HMACs yourself; this can be done with the audit device's hash function and salt by using the `/sys/audit-hash` API endpoint (see the documentation for more details).
 
 Note that currently only strings coming from JSON or being returned in JSON are
 HMAC'd. Other data types, like integers, booleans, and so on, are passed
 through in plaintext.
 
-### Optional audit log flags
+Vault makes some exceptions, such as auth and secrets, and users can enable additional exceptions using the [secrets enable](https://www.vaultproject.io/docs/commands/secrets/enable) command, and then tune it afterward.
 
-The following flags can be applied if you wish to display the sensitive data in plaintext, within your audit log.
+**see also**:
 
-- `-audit-non-hmac-request-keys` `(string: "")` - Key that will not be HMAC'd
-  by audit devices in the request data object. Note that multiple keys may be
-  specified by providing this option multiple times, each time with 1 key.
+[secrets tune](https://www.vaultproject.io/docs/commands/secrets/tune)
 
-- `-audit-non-hmac-response-keys` `(string: "")` - Key that will not be HMAC'd
-  by audit devices in the response data object. Note that multiple keys may be
-  specified by providing this option multiple times, each time with 1 key.
+[auth enable](https://www.vaultproject.io/docs/commands/auth/enable)
+
+[auth tune](https://www.vaultproject.io/docs/commands/auth/tune)
 
 ## Enabling/Disabling Audit Devices
 

--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -40,6 +40,18 @@ Note that currently only strings coming from JSON or being returned in JSON are
 HMAC'd. Other data types, like integers, booleans, and so on, are passed
 through in plaintext.
 
+### Optional audit log flags
+
+The following flags can be applied if you wish to unmask the sensitive data within a request or response.
+
+- `-audit-non-hmac-request-keys` `(string: "")` - Key that will not be HMAC'd
+  by audit devices in the request data object. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.
+
+- `-audit-non-hmac-response-keys` `(string: "")` - Key that will not be HMAC'd
+  by audit devices in the response data object. Note that multiple keys may be
+  specified by providing this option multiple times, each time with 1 key.
+
 ## Enabling/Disabling Audit Devices
 
 When a Vault server is first initialized, no auditing is enabled. Audit
@@ -56,12 +68,12 @@ In the command above, we passed the "file_path" parameter to specify the path
 where the audit log will be written to. Each audit device has its own
 set of parameters. See the documentation to the left for more details.
 
-~> Note: Audit device configuration is replicated to all nodes within a 
-cluster by default, and to performance/DR secondaries for Vault Enterprise clusters. 
-Before enabling an audit device, ensure that all nodes within the cluster(s) 
-will be able to successfully log to the audit device to avoid Vault being 
-blocked from serving requests. 
-An audit device can be limited to only within the node's cluster with the [`local`](api/system/audit#local) parameter. 
+~> Note: Audit device configuration is replicated to all nodes within a
+cluster by default, and to performance/DR secondaries for Vault Enterprise clusters.
+Before enabling an audit device, ensure that all nodes within the cluster(s)
+will be able to successfully log to the audit device to avoid Vault being
+blocked from serving requests.
+An audit device can be limited to only within the node's cluster with the [`local`](api/system/audit#local) parameter.
 
 When an audit device is disabled, it will stop receiving logs immediately.
 The existing logs that it did store are untouched.

--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -35,7 +35,7 @@ Note that currently only strings coming from JSON or being returned in JSON are
 HMAC'd. Other data types, like integers, booleans, and so on, are passed
 through in plaintext.
 
-Vault makes some exceptions, such as auth and secrets, and users can enable additional exceptions using the [secrets enable](https://www.vaultproject.io/docs/commands/secrets/enable) command, and then tune it afterward.
+While most strings are hashed, Vault does make some exceptions, such as auth and secrets, and users can enable additional exceptions using the [secrets enable](https://www.vaultproject.io/docs/commands/secrets/enable) command, and then tune it afterward.
 
 **see also**:
 

--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -35,15 +35,15 @@ Note that currently only strings coming from JSON or being returned in JSON are
 HMAC'd. Other data types, like integers, booleans, and so on, are passed
 through in plaintext.
 
-While most strings are hashed, Vault does make some exceptions, such as auth and secrets, and users can enable additional exceptions using the [secrets enable](https://www.vaultproject.io/docs/commands/secrets/enable) command, and then tune it afterward.
+While most strings are hashed, Vault does make some exceptions, such as auth and secrets, and users can enable additional exceptions using the [secrets enable](/docs/commands/secrets/enable) command, and then tune it afterward.
 
 **see also**:
 
-[secrets tune](https://www.vaultproject.io/docs/commands/secrets/tune)
+[secrets tune](/docs/commands/secrets/tune)
 
-[auth enable](https://www.vaultproject.io/docs/commands/auth/enable)
+[auth enable](/docs/commands/auth/enable)
 
-[auth tune](https://www.vaultproject.io/docs/commands/auth/tune)
+[auth tune](/docs/commands/auth/tune)
 
 ## Enabling/Disabling Audit Devices
 

--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -42,7 +42,7 @@ through in plaintext.
 
 ### Optional audit log flags
 
-The following flags can be applied if you wish to unmask the sensitive data within a request or response.
+The following flags can be applied if you wish to display the sensitive data in plaintext, within your audit log.
 
 - `-audit-non-hmac-request-keys` `(string: "")` - Key that will not be HMAC'd
   by audit devices in the request data object. Note that multiple keys may be


### PR DESCRIPTION
This request was based on [Asana](https://app.asana.com/0/inbox/1200328878163177/1201034068213937/1201041323679728). 

Updated **Audit Devices > Sensitive Information** section by adding the tuner parameters from the Secrets tune documentation.

:mag: [Deploy Preview](https://vault-jenqjatmn-hashicorp.vercel.app/docs/audit#sensitive-information)