### PR TITLE
Backport pr 12652 1.8.x : Add missing read unlock calls in transit backend code

### DIFF
--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -122,11 +122,13 @@ func (b *backend) GetPolicy(ctx context.Context, polReq keysutil.PolicyRequest, 
 		currentCacheSize := b.lm.GetCacheSize()
 		storedCacheSize, err := GetCacheSizeFromStorage(ctx, polReq.Storage)
 		if err != nil {
+			b.configMutex.RUnlock()
 			return nil, false, err
 		}
 		if currentCacheSize != storedCacheSize {
 			err = b.lm.InitCache(storedCacheSize)
 			if err != nil {
+				b.configMutex.RUnlock()
 				return nil, false, err
 			}
 		}
@@ -135,6 +137,8 @@ func (b *backend) GetPolicy(ctx context.Context, polReq keysutil.PolicyRequest, 
 		b.configMutex.Lock()
 		defer b.configMutex.Unlock()
 		b.cacheSizeChanged = false
+	} else {
+		b.configMutex.RUnlock()
 	}
 	p, _, err := b.lm.GetPolicy(ctx, polReq, rand)
 	if err != nil {

--- a/builtin/logical/transit/path_cache_config.go
+++ b/builtin/logical/transit/path_cache_config.go
@@ -86,14 +86,17 @@ func (b *backend) pathCacheConfigRead(ctx context.Context, req *logical.Request,
 		return nil, err
 	}
 
+	if currentCacheSize != storedCacheSize {
+		err = b.lm.InitCache(storedCacheSize)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	resp := &logical.Response{
 		Data: map[string]interface{}{
 			"size": storedCacheSize,
 		},
-	}
-
-	if currentCacheSize != storedCacheSize {
-		resp.Warnings = []string{"This cache size will not be applied until the transit mount is reloaded"}
 	}
 
 	return resp, nil

--- a/changelog/12418.txt
+++ b/changelog/12418.txt
@@ -1,4 +1,3 @@
 ```release-note:bug
-Enforce minimum cache size for transit backend.
-Init cache size on transit backend without restart.
+secrets/transit: Enforce minimum cache size for transit backend and init cache size on transit backend without restart.
 ```


### PR DESCRIPTION
This PR is a followup for #12418 and in summary includes the following changes:
1 - Add missing read unlock calls for cacheSizeChanged variable
2 - Invoke initCache in pathCacheConfigRead routine if needed