### PR TITLE
Add support to parameterize unauthenticated paths

### DIFF
--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -89,6 +89,7 @@ func NewIdentityStore(ctx context.Context, core *Core, config *logical.BackendCo
 		PathsSpecial: &logical.Paths{
 			Unauthenticated: []string{
 				"oidc/.well-known/*",
+				"oidc/provider/+/.well-known/*",
 			},
 		},
 		PeriodicFunc: func(ctx context.Context, req *logical.Request) error {

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -90,6 +90,7 @@ func NewIdentityStore(ctx context.Context, core *Core, config *logical.BackendCo
 			Unauthenticated: []string{
 				"oidc/.well-known/*",
 				"oidc/provider/+/.well-known/*",
+				"oidc/provider/+/token",
 			},
 		},
 		PeriodicFunc: func(ctx context.Context, req *logical.Request) error {

--- a/vault/plugin_reload.go
+++ b/vault/plugin_reload.go
@@ -188,7 +188,11 @@ func (c *Core) reloadBackendCommon(ctx context.Context, entry *MountEntry, isAut
 		paths := backend.SpecialPaths()
 		if paths != nil {
 			re.rootPaths.Store(pathsToRadix(paths.Root))
-			re.loginPaths.Store(pathsToRadix(paths.Unauthenticated))
+			loginPathsEntry, err := parseUnauthenticatedPaths(paths.Unauthenticated)
+			if err != nil {
+				return err
+			}
+			re.loginPaths.Store(loginPathsEntry)
 		}
 	}
 

--- a/vault/router_test.go
+++ b/vault/router_test.go
@@ -348,10 +348,10 @@ func TestRouter_LoginPath(t *testing.T) {
 		Login: []string{
 			"login",
 			"oauth/*",
-			"wildcard/+/",
-			"end/+/",
+			"end1/+",
+			"end2/+/",
+			"end3/+/*",
 			"+/begin",
-			"any/+",
 		},
 	}
 	err = r.Mount(n, "auth/foo/", &MountEntry{UUID: meUUID, Accessor: "authfooaccessor", NamespaceID: namespace.RootNamespaceID, namespace: namespace.RootNamespace}, view)
@@ -374,22 +374,25 @@ func TestRouter_LoginPath(t *testing.T) {
 
 		// Wildcard cases
 
-		// "wildcard/+/"
-		{"auth/foo/wildcard/bar", false},
-		{"auth/foo/wildcard/bar/", true},
-		{"auth/foo/wildcard/bar/baz", false},
-		// "end/+/"
-		{"auth/foo/end/baz/", true},
-		{"auth/foo/end/baz", false},
+		// "end1/+"
+		{"auth/foo/end1", false},
+		{"auth/foo/end1/bar", true},
+		{"auth/foo/end1/bar/", false},
+		{"auth/foo/end1/bar/baz", false},
+		// "end2/+/"
+		{"auth/foo/end2", false},
+		{"auth/foo/end2/bar", false},
+		{"auth/foo/end2/bar/", true},
+		{"auth/foo/end2/bar/baz", false},
+		// "end3/+/*"
+		{"auth/foo/end3", false},
+		{"auth/foo/end3/bar", false},
+		{"auth/foo/end3/bar/", true},
+		{"auth/foo/end3/bar/baz", true},
 		// "+/begin"
 		{"auth/foo/bar/begin", true},
 		{"auth/foo/bar/begin/", false},
 		{"auth/foo/begin", false},
-		// "any/+"
-		{"auth/foo/any", false},
-		{"auth/foo/any/bar", true},
-		{"auth/foo/any/bar/", false},
-		{"auth/foo/any/bar/baz", false},
 	}
 
 	for _, tc := range tcases {


### PR DESCRIPTION
## Description
This PR adds support to parameterize unauthenticated paths for a framework.Backend. This is needed to allow the following unauthenticated API paths for the upcoming OIDC Provider feature:

- `oidc/provider/+/.well-known/*`
- `oidc/provider/+/token`

## Background
Today, unauthenticated paths get stored in the [loginPaths](https://github.com/hashicorp/vault/blob/dd19e129776146e6c077f3e7d6e400a3105ac9d8/vault/router.go#L58) in the router when the backend is mounted. The structure used is a [radix tree](https://github.com/armon/go-radix) which is ultimately stored in an `atomic.Value`. 

The approach used in this PR is to store any unauthenticated paths containing wildcards in a map. All other unauthenticated paths (not containing wildcards) will continue to be stored in a radix tree. This PR introduces a new struct `loginPathsEntry` to hold both the map and radix tree.

## Alternative approaches
Several alternative approaches were considered:
- Store wildcard paths in the radix tree
  - the go-radix library does not handle wildcards in the middle of strings
  - an attempt was made to implement a custom Walk func for go-radix, however the lib doesn’t expose enough fields for this approach to be feasible
- Use regexes for unauthenticated paths
  - this will break backwards compatibility since the glob `*` character that is currently used to indicate a prefix match has a different meaning as a regular expression
  