### PR TITLE
KV: show delete when no read metadata

### DIFF
--- a/ui/app/components/secret-delete-menu.js
+++ b/ui/app/components/secret-delete-menu.js
@@ -98,9 +98,15 @@ export default class SecretDeleteMenu extends Component {
   @alias('secretDataPath.canDelete') canDeleteSecretData;
 
   get isLatestVersion() {
+    // must have metadata access.
     let { model } = this.args;
     if (!model) return false;
     let latestVersion = model.currentVersion;
+    if (latestVersion === undefined) {
+      // it means you do not have metadata access (current version is returned on the metadata endpoint)
+      // if that's the case they should see the delete button because they can't navigate to older versions
+      return true;
+    }
     let selectedVersion = model.selectedVersion.version;
     if (latestVersion !== selectedVersion) {
       return false;

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -137,15 +137,14 @@
 {{#if (eq @mode "edit")}}
   <form onsubmit={{action "createOrUpdateKey" "edit"}}>
     <div class="box is-sideless is-fullwidth is-marginless padding-top">
-      {{#if @model.canReadSecretData}}
-        <MessageError @model={{@modelForData}} @errorMessage={{this.error}} />
-      {{else}}
+      <MessageError @model={{@modelForData}} @errorMessage={{this.error}} />
+      {{#unless @model.canReadSecretData}}
         <AlertBanner
           @type="warning"
           @message="You do not have read permissions. If a secret exists here creating a new secret will overwrite it."
           data-test-warning-no-read-permissions
         />
-      {{/if}}
+      {{/unless}}
       <NamespaceReminder @mode="edit" @noun="secret" />
       {{#if this.isCreateNewVersionFromOldVersion}}
         <div class="form-section">


### PR DESCRIPTION
When you had the following policy, the delete button never showed because we compare the latest version to the current version. However, the current version comes from the metadata endpoint so it always returned false. Now I check for undefined which only happens when you have permissions errors and show the button instead.

To reproduce: 
1. In a KV 2 called secret, create any secret.

2. Create a user with policy like the following:
```path "secret/data/*" {capabilities = ["list", "read","create","update", "delete"]}
path "secret/metadata/*" {capabilities = ["list"]}```

3. Logged in as the user with the policy navigate to the show of the secret and you won't see the delete button. Though you have delete capabilities.

You can test this using the following CLI/ CURL:

LOGIN:

vault login -method=userpass username=<username> 

DELETE:

 curl --header "X-Vault-Token: root" --request DELETE http://127.0.0.1:4200/v1/secret/data/my-secret