### PR TITLE
docs: vault-k8s-0.13.1 and vault-helm-0.16.1

### DIFF
--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -81,7 +81,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault-k8s"`) - The name of the Docker image for Vault Agent Injector.
 
-    - `tag` (`string: "0.13.0"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "0.13.1"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -89,7 +89,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault"`) - The name of the Docker image for the Vault Agent sidecar. This should be set to the official Vault Docker image.
 
-    - `tag` (`string: "1.8.2"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
+    - `tag` (`string: "1.8.3"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
 
   - `agentDefaults` - Values that configure the injected Vault Agent containers default values.
 
@@ -244,7 +244,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault"`) - The name of the Docker image for the containers running Vault.
 
-    - `tag` (`string: "1.8.2"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "1.8.3"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 

--- a/website/content/docs/platform/k8s/helm/enterprise.mdx
+++ b/website/content/docs/platform/k8s/helm/enterprise.mdx
@@ -31,7 +31,7 @@ In your chart overrides, set the values of [`server.image`](/docs/platform/k8s/h
 server:
   image:
     repository: hashicorp/vault-enterprise
-    tag: 1.8.2_ent
+    tag: 1.8.3_ent
   enterpriseLicense:
     secretName: vault-ent-license
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
@@ -23,7 +23,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.8.2_ent' \
+  --set='server.image.tag=1.8.3_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -75,7 +75,7 @@ disaster recovery replication.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.8.2_ent' \
+  --set='server.image.tag=1.8.3_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
@@ -23,7 +23,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.8.2_ent' \
+  --set='server.image.tag=1.8.3_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -74,7 +74,7 @@ With the primary cluster created, next create a secondary cluster.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.8.2_ent' \
+  --set='server.image.tag=1.8.3_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
@@ -15,7 +15,7 @@ Integrated storage (raft) can be enabled using the `server.ha.raft.enabled` valu
 ```shell
 helm install vault hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.8.2_ent' \
+  --set='server.image.tag=1.8.3_ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/index.mdx
+++ b/website/content/docs/platform/k8s/helm/index.mdx
@@ -35,7 +35,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.16.0       	1.8.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.16.1       	1.8.3      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -57,6 +57,7 @@ Installing a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.16.1       	1.8.3      	Official HashiCorp Vault Chart
 hashicorp/vault	0.16.0       	1.8.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.15.0       	1.8.1      	Official HashiCorp Vault Chart
 hashicorp/vault	0.14.0       	1.8.0      	Official HashiCorp Vault Chart
@@ -64,10 +65,9 @@ hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
 hashicorp/vault	0.12.0       	1.7.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
 hashicorp/vault	0.10.0       	1.7.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 
-# Install version 0.16.0
-$ helm install vault hashicorp/vault --version 0.16.0
+# Install version 0.16.1
+$ helm install vault hashicorp/vault --version 0.16.1
 ```
 
 ~> **Security Warning:** By default, the chart runs in standalone mode. This

--- a/website/content/docs/platform/k8s/helm/openshift.mdx
+++ b/website/content/docs/platform/k8s/helm/openshift.mdx
@@ -69,7 +69,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.16.0       	1.8.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.16.1       	1.8.3      	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -88,6 +88,7 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.16.1       	1.8.3      	Official HashiCorp Vault Chart
 hashicorp/vault	0.16.0       	1.8.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.15.0       	1.8.1      	Official HashiCorp Vault Chart
 hashicorp/vault	0.14.0       	1.8.0      	Official HashiCorp Vault Chart
@@ -95,10 +96,9 @@ hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
 hashicorp/vault	0.12.0       	1.7.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
 hashicorp/vault	0.10.0       	1.7.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 
-# Install version 0.16.0
-$ helm install vault hashicorp/vault --version 0.16.0
+# Install version 0.16.1
+$ helm install vault hashicorp/vault --version 0.16.1
 ```
 
 The `helm install` command accepts parameters to override default configuration

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -53,7 +53,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.16.0        	1.8.2     	Official HashiCorp Vault Chart
+hashicorp/vault	0.16.1        	1.8.3     	Official HashiCorp Vault Chart
 ```
 
 -> **Important:** The Helm chart is new and under significant development.
@@ -72,6 +72,7 @@ Or install a specific version of the chart.
 # List the available releases
 $ helm search repo hashicorp/vault -l
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.16.1       	1.8.3      	Official HashiCorp Vault Chart
 hashicorp/vault	0.16.0       	1.8.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.15.0       	1.8.1      	Official HashiCorp Vault Chart
 hashicorp/vault	0.14.0       	1.8.0      	Official HashiCorp Vault Chart
@@ -79,10 +80,9 @@ hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
 hashicorp/vault	0.12.0       	1.7.2      	Official HashiCorp Vault Chart
 hashicorp/vault	0.11.0       	1.7.0      	Official HashiCorp Vault Chart
 hashicorp/vault	0.10.0       	1.7.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.9.1        	1.6.2      	Official HashiCorp Vault Chart
 
-# Install version 0.16.0
-$ helm install vault hashicorp/vault --version 0.16.0
+# Install version 0.16.1
+$ helm install vault hashicorp/vault --version 0.16.1
 ```
 
 The `helm install` command accepts parameters to override default configuration
@@ -425,14 +425,14 @@ Next, list the Helm versions and choose the desired version to install.
 ```bash
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.14.0        	1.8.0     	Official HashiCorp Vault Chart
+hashicorp/vault	0.16.1        	1.8.3     	Official HashiCorp Vault Chart
 ```
 
 Next, test the upgrade with `--dry-run` first to verify the changes sent to the
 Kubernetes cluster.
 
 ```shell-session
-$ helm upgrade vault hashicorp/vault --version=0.14.0 \
+$ helm upgrade vault hashicorp/vault --version=0.16.1 \
     --set='server.image.repository=vault' \
     --set='server.image.tag=123.456' \
     --dry-run

--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -28,7 +28,7 @@ them, optional commands to run, etc.
 
 - `vault.hashicorp.com/agent-image` - name of the Vault docker image to use. This
   value overrides the default image configured in the controller and is usually
-  not needed. Defaults to `hashicorp/vault:1.8.2`.
+  not needed. Defaults to `hashicorp/vault:1.8.3`.
 
 - `vault.hashicorp.com/agent-init-first` - configures the pod to run the Vault Agent
   init container first if `true` (last if `false`). This is useful when other init

--- a/website/content/docs/platform/k8s/injector/installation.mdx
+++ b/website/content/docs/platform/k8s/injector/installation.mdx
@@ -20,7 +20,7 @@ $ helm repo add hashicorp https://helm.releases.hashicorp.com
 
 $ helm search repo hashicorp/vault
 NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.16.0       	1.8.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.16.1       	1.8.3      	Official HashiCorp Vault Chart
 ```
 
 Then install the chart and enable the injection feature by setting the


### PR DESCRIPTION
Vault K8s [0.13.1](https://github.com/hashicorp/vault-k8s/blob/main/CHANGELOG.md#0131-september-29-2021) and Vault Helm [0.16.1](https://github.com/hashicorp/vault-helm/blob/main/CHANGELOG.md#0161-september-29th-2021) updated the default Vault
image, so making the corresponding docs updates here.