### PR TITLE
Updated documentation: added new code example and reference

### DIFF
--- a/website/content/docs/concepts/auth.mdx
+++ b/website/content/docs/concepts/auth.mdx
@@ -120,7 +120,6 @@ The following code snippet demonstrates how to renew auth tokens.
 <CodeBlockConfig lineNumbers>
 
 ```go
-
 package main
 
 import (

--- a/website/content/docs/concepts/auth.mdx
+++ b/website/content/docs/concepts/auth.mdx
@@ -110,3 +110,107 @@ how leasing is implemented.
 And just like secrets, identities can be renewed without having to
 completely reauthenticate. Just use `vault token renew <token>` with the
 leased token associated with your identity to renew it.
+
+## Code Example
+
+The following code snippet demonstrates how to renew auth tokens.
+
+<CodeTabs heading="gcp auth example">
+
+<CodeBlockConfig lineNumbers>
+
+```go
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	vault "github.com/hashicorp/vault/api"
+)
+
+// Once you've set the token for your Vault client, you will need to periodically renew its lease.
+//
+// A function like this should be run as a goroutine to avoid blocking.
+//
+// Production applications may also wish to be more tolerant of failures and retry rather than exiting.
+//
+// Additionally, enterprise Vault users should be aware that due to eventual consistency, the API may return unexpected errors when
+// running Vault with performance standbys or performance replication, despite the client having a freshly renewed token.
+// See https://www.vaultproject.io/docs/enterprise/consistency#vault-1-7-mitigations for several ways to mitigate this
+// which are outside the scope of this code sample.
+func renewToken(client *vault.Client) {
+	for {
+		vaultLoginResp, err := login(client)
+		if err != nil {
+			log.Fatalf("unable to authenticate to Vault: %v", err)
+		}
+		tokenErr := manageTokenLifecycle(client, vaultLoginResp)
+		if tokenErr != nil {
+			log.Fatalf("unable to start managing token lifecycle: %v", tokenErr)
+		}
+	}
+}
+
+// Starts token lifecycle management. Returns only fatal errors as errors, otherwise returns nil so we can attempt login again.
+func manageTokenLifecycle(client *vault.Client, token *vault.Secret) error {
+	renew := token.Auth.Renewable // You may notice a different top-level field called Renewable. That one is used for dynamic secrets renewal, not token renewal.
+	if !renew {
+		log.Printf("Token is not configured to be renewable. Re-attempting login.")
+		return nil
+	}
+
+	watcher, err := client.NewLifetimeWatcher(&vault.LifetimeWatcherInput{
+		Secret:    token,
+		Increment: 3600, // Learn more about this optional value in https://www.vaultproject.io/docs/concepts/lease#lease-durations-and-renewal
+	})
+	if err != nil {
+		return fmt.Errorf("unable to initialize new lifetime watcher for renewing auth token: %w", err)
+	}
+
+	go watcher.Start()
+	defer watcher.Stop()
+
+	for {
+		select {
+		// `DoneCh` will return if renewal fails, or if the remaining lease duration is
+   // under a built-in threshold and either renewing is not extending it or
+  // renewing is disabled.  In any case, the caller needs to attempt to log in again.
+  case err := <-watcher.DoneCh():
+   if err != nil {
+    log.Printf("Failed to renew token: %v. Re-attempting login.", err)
+    return nil
+   }
+   log.Printf("Token can no longer be renewed. Re-attempting login.")
+   return nil
+
+  // Successfully completed renewal
+  case renewal := <-watcher.RenewCh():
+   log.Printf("Successfully renewed: %#v", renewal)
+   }
+ }
+}
+
+func login(client *vault.Client) (*vault.Secret, error) {
+ // WARNING: A plaintext password like this is obviously insecure.
+ // See the files starting in auth-* in the hashicorp/vault-examples repo for full examples of how to securely log in to Vault using various auth methods.
+ // This is just demonstrating the basic idea that a *vault.Secret is returned by a call to an auth method's /login API endpoint.
+ resp, err := client.Logical().Write("auth/userpass/login/my-user", map[string]interface{}{"password": "my-password"})
+ if err != nil {
+  return nil, err
+ }
+ if resp == nil || resp.Auth == nil || resp.Auth.ClientToken == "" {
+  return nil, fmt.Errorf("login response did not return client token")
+ }
+
+ // have the client use that token for all Vault calls from now on
+ client.SetToken(resp.Auth.ClientToken)
+
+ return resp, nil
+}
+```
+
+</CodeBlockConfig>
+
+</CodeTabs>

--- a/website/content/docs/concepts/lease.mdx
+++ b/website/content/docs/concepts/lease.mdx
@@ -68,6 +68,9 @@ so often.
 As a result, the return value of renewals should be carefully inspected to
 determine what the new lease is.
 
+
+To implement token renewal logic in your application code, refer to the [code example in the Authentication doc](/docs/concepts/auth#code-example).
+
 ## Prefix-based Revocation
 
 In addition to revoking a single secret, operators with proper access control
@@ -84,4 +87,3 @@ This is very useful if there is an intrusion within a specific system: all
 secrets of a specific backend or a certain configured backend can be revoked
 quickly and easily.
 
-To implement token renewal logic in your application code, refer to the [code example in the Authentication doc](/docs/concepts/auth#code-example).

--- a/website/content/docs/concepts/lease.mdx
+++ b/website/content/docs/concepts/lease.mdx
@@ -83,3 +83,5 @@ command docs.
 This is very useful if there is an intrusion within a specific system: all
 secrets of a specific backend or a certain configured backend can be revoked
 quickly and easily.
+
+To programatically renew auth tokens, see [code example](/docs/concepts/auth#code-example).

--- a/website/content/docs/concepts/lease.mdx
+++ b/website/content/docs/concepts/lease.mdx
@@ -84,4 +84,4 @@ This is very useful if there is an intrusion within a specific system: all
 secrets of a specific backend or a certain configured backend can be revoked
 quickly and easily.
 
-To programatically renew auth tokens, see [code example](/docs/concepts/auth#code-example).
+To implement token renewal logic in your application code, refer to the [code example in the Authentication doc](/docs/concepts/auth#code-example).

--- a/website/content/docs/concepts/lease.mdx
+++ b/website/content/docs/concepts/lease.mdx
@@ -69,7 +69,7 @@ As a result, the return value of renewals should be carefully inspected to
 determine what the new lease is.
 
 
-To implement token renewal logic in your application code, refer to the [code example in the Authentication doc](/docs/concepts/auth#code-example).
+-> To implement token renewal logic in your application code, refer to the [code example in the Authentication doc](/docs/concepts/auth#code-example).
 
 ## Prefix-based Revocation
 


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/inbox/1200328878163177/1201051649808412/1201091064234777) task, code example was added to:
1. Authentication doc
2. Lease, Renew, and Revoke doc now contains a reference at the bottom of the page that links to the code example.

:mag: [Deploy Preview-authentication](https://vault-git-auth-go-sample-code-hashicorp.vercel.app//docs/concepts/auth#code-example)
:mag: [Deploy Preview-lease, renew, revoke](https://vault-git-auth-go-sample-code-hashicorp.vercel.app/docs/concepts/lease#lease-durations-and-renewal)