### PR TITLE
Update Ubuntu Image used in CircleCI to `ubuntu-2004:202010-01`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,7 @@ jobs:
         - ui/node_modules
   build-common-layers:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202010-01
     resource_class: xlarge
     shell: /usr/bin/env bash -euo pipefail -c
     steps:


### PR DESCRIPTION
This PR updates the Ubuntu machine image used in `build-common-layers` within CircleCI from version `ubuntu-1604:202007-01` to `ubuntu-2004:202010-01`