### PR TITLE
raft auto_join_scheme documentation update

### DIFF
--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -121,7 +121,7 @@ set [`disable_mlock`](/docs/configuration#disable_mlock) to `true`, and to disab
   [go-discover](https://github.com/hashicorp/go-discover) syntax.
 
 - `auto_join_scheme` `(string: "")` - The optional URI protocol scheme for addresses
-  discovered via auto-join.
+  discovered via auto-join. Available values are `http` or `https`. 
 
 - `auto_join_port` `(uint: "")` - The optional port used for addressed discovered
   via auto-join.


### PR DESCRIPTION
An update to https://www.vaultproject.io/docs/configuration/storage/raft to detail the available configuration values for the `auto_join_scheme` configuration parameter as these don't appear to be documented anywhere.

Reference: https://github.com/hashicorp/vault/blob/861454e0ed1390d67ddaf1a53c1798e5e291728c/http/sys_raft.go#L70-L72