### PR TITLE
Fix auth/aws so that config/rotate-root saves new key pair to vault

### DIFF
--- a/builtin/credential/aws/path_config_rotate_root.go
+++ b/builtin/credential/aws/path_config_rotate_root.go
@@ -145,6 +145,10 @@ func (b *backend) pathConfigRotateRootUpdate(ctx context.Context, req *logical.R
 		}
 	}()
 
+	oldAccessKey := clientConf.AccessKey
+	clientConf.AccessKey = *createAccessKeyRes.AccessKey.AccessKeyId
+	clientConf.SecretKey = *createAccessKeyRes.AccessKey.SecretAccessKey
+
 	// Now get ready to update storage, doing everything beforehand so we can minimize how long
 	// we need to hold onto the lock.
 	newEntry, err := b.configClientToEntry(clientConf)
@@ -152,10 +156,6 @@ func (b *backend) pathConfigRotateRootUpdate(ctx context.Context, req *logical.R
 		errs = multierror.Append(errs, fmt.Errorf("error generating new client config JSON: %w", err))
 		return nil, errs
 	}
-
-	oldAccessKey := clientConf.AccessKey
-	clientConf.AccessKey = *createAccessKeyRes.AccessKey.AccessKeyId
-	clientConf.SecretKey = *createAccessKeyRes.AccessKey.SecretAccessKey
 
 	// Someday we may want to allow the user to send a number of seconds to wait here
 	// before deleting the previous access key to allow work to complete. That would allow

--- a/changelog/12214.txt
+++ b/changelog/12214.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/aws: fix config/rotate-root to store new key
+```


### PR DESCRIPTION
This PR fixes an issue where when calling the endpoint config/rotate-root on auth/aws it would successfully rotate the keys in AWS but not save the updated keys back into vault.  After being called once you could no longer authenticate AWS services since the new key was unknown to Vault.  The issue was originally reported in #12214 