### PR TITLE
Fix 1.8 regression preventing email addresses being used as common name within pki certificates (#12336)

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -330,7 +330,9 @@ func validateNames(b *backend, data *inputBundle, names []string) string {
 				// is enabled
 				if data.role.AllowBareDomains &&
 					(strings.EqualFold(sanitizedName, currDomain) ||
-						(isEmail && strings.EqualFold(emailDomain, currDomain))) {
+						(isEmail && strings.EqualFold(emailDomain, currDomain)) ||
+							// Handle the use case of AllowedDomain being an email address
+							(isEmail && strings.EqualFold(name, currDomain))) {
 					valid = true
 					break
 				}

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -164,7 +164,8 @@ func TestPki_PermitFQDNs(t *testing.T) {
 
 	cases := map[string]struct {
 		input    *inputBundle
-		expected []string
+		expectedDnsNames []string
+		expectedEmails []string
 	}{
 		"base valid case": {
 			input: &inputBundle{
@@ -181,7 +182,8 @@ func TestPki_PermitFQDNs(t *testing.T) {
 					EnforceHostnames: true,
 				},
 			},
-			expected: []string{"example.com."},
+			expectedDnsNames: []string{"example.com."},
+			expectedEmails: []string{},
 		},
 		"case insensitivity validation": {
 			input: &inputBundle{
@@ -199,20 +201,65 @@ func TestPki_PermitFQDNs(t *testing.T) {
 					MaxTTL:           3600,
 				},
 			},
-			expected: []string{"Example.Net", "eXaMPLe.COM"},
+			expectedDnsNames: []string{"Example.Net", "eXaMPLe.COM"},
+			expectedEmails: []string{},
+		},
+		"case email as AllowedDomain with bare domains": {
+			input: &inputBundle{
+				apiData: &framework.FieldData{
+					Schema: fields,
+					Raw: map[string]interface{}{
+						"common_name": "test@testemail.com",
+						"ttl":         3600,
+					},
+				},
+				role: &roleEntry{
+					AllowedDomains:   []string{"test@testemail.com"},
+					AllowBareDomains: true,
+					MaxTTL:           3600,
+				},
+			},
+			expectedDnsNames: []string{},
+			expectedEmails: []string{"test@testemail.com"},
+		},
+		"case email common name with bare domains": {
+			input: &inputBundle{
+				apiData: &framework.FieldData{
+					Schema: fields,
+					Raw: map[string]interface{}{
+						"common_name": "test@testemail.com",
+						"ttl":         3600,
+					},
+				},
+				role: &roleEntry{
+					AllowedDomains:   []string{"testemail.com"},
+					AllowBareDomains: true,
+					MaxTTL:           3600,
+				},
+			},
+			expectedDnsNames: []string{},
+			expectedEmails: []string{"test@testemail.com"},
 		},
 	}
 
-	for _, testCase := range cases {
-		cb, err := generateCreationBundle(&b, testCase.input, nil, nil)
-		if err != nil {
-			t.Fatalf("Error: %v", err)
-		}
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			cb, err := generateCreationBundle(&b, testCase.input, nil, nil)
+			if err != nil {
+				t.Fatalf("Error: %v", err)
+			}
 
-		actual := cb.Params.DNSNames
+			actualDnsNames := cb.Params.DNSNames
 
-		if !reflect.DeepEqual(testCase.expected, actual) {
-			t.Fatalf("Expected %v, got %v", testCase.expected, actual)
-		}
+			if !reflect.DeepEqual(testCase.expectedDnsNames, actualDnsNames) {
+				t.Fatalf("Expected dns names %v, got %v", testCase.expectedDnsNames, actualDnsNames)
+			}
+
+			actualEmails := cb.Params.EmailAddresses
+
+			if !reflect.DeepEqual(testCase.expectedEmails, actualEmails) {
+				t.Fatalf("Expected email addresses %v, got %v", testCase.expectedEmails, actualEmails)
+			}
+		})
 	}
 }

--- a/changelog/12716.txt
+++ b/changelog/12716.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+pki: Fix regression preventing email addresses being used as a common name within certificates
+```


### PR DESCRIPTION
This PR addresses a regression introduced within 1.8 that prevents email addresses from being leveraged as common names within pki certificates. It still enforces that the email address was listed as an allowed domain within the role as well as allow_bare_domains set to true. 

Added two test cases that validate the behaviour in the bug report 
- common name as an email address with a matching email address within allowed domain in the role
- common name as an email address with a matching allowed domain name within the allowed domain in the role. 

Addresses issue reported within #12336 