### PR TITLE
Change CTAs from Try Cloud to Try HCP Vault

### DIFF
--- a/website/components/subnav/index.jsx
+++ b/website/components/subnav/index.jsx
@@ -18,7 +18,7 @@ export default function ProductSubnav() {
           url: 'https://www.github.com/hashicorp/vault',
         },
         {
-          text: 'Try Cloud',
+          text: 'Try HCP Vault',
           url:
             'https://portal.cloud.hashicorp.com/sign-up?utm_source=vault_io&utm_content=top_nav_vault',
         },

--- a/website/pages/home/index.jsx
+++ b/website/pages/home/index.jsx
@@ -30,7 +30,7 @@ export default function Homepage({ content }) {
           buttons={[
             {
               external: false,
-              title: 'Try Cloud',
+              title: 'Try HCP Vault',
               url:
                 'https://portal.cloud.hashicorp.com/sign-up?utm_source=vault_io&utm_content=hero',
             },


### PR DESCRIPTION
[🔍 Preview Link](https://vault-git-nqvault-ctas-update-hashicorp.vercel.app/)

---

This PR updates some CTAs on the site to read "Try HCP Vault" instead of "Try Cloud". 