### PR TITLE
Backport 1.6.8: Fix a Deadlock on HA leadership transfer (#12691)

### DIFF
--- a/changelog/12691.txt
+++ b/changelog/12691.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix a deadlock on HA leadership transfer
+```


### PR DESCRIPTION
* Fix a Deadlock on HA leadership transfer when standby
was actively forwarding a request
fixes GH #12601

* adding the changelog