### PR TITLE
Backport 1.7.6: Fix a Deadlock on HA leadership transfer (#12691)

### DIFF
--- a/changelog/12691.txt
+++ b/changelog/12691.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix a deadlock on HA leadership transfer
+```

--- a/vault/request_forwarding.go
+++ b/vault/request_forwarding.go
@@ -329,6 +329,9 @@ func (c *Core) clearForwardingClients() {
 // ForwardRequest forwards a given request to the active node and returns the
 // response.
 func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, error) {
+	// checking if the node is perfStandby here to avoid a deadlock between
+	// Core.stateLock and Core.requestForwardingConnectionLock
+	isPerfStandby := c.PerfStandby()
 	c.requestForwardingConnectionLock.RLock()
 	defer c.requestForwardingConnectionLock.RUnlock()
 
@@ -372,7 +375,7 @@ func (c *Core) ForwardRequest(req *http.Request) (int, http.Header, []byte, erro
 	// If we are a perf standby and the request was forwarded to the active node
 	// we should attempt to wait for the WAL to ship to offer best effort read after
 	// write guarantees
-	if c.PerfStandby() && resp.LastRemoteWal > 0 {
+	if isPerfStandby && resp.LastRemoteWal > 0 {
 		WaitUntilWALShipped(req.Context(), c, resp.LastRemoteWal)
 	}
 


### PR DESCRIPTION
* Fix a Deadlock on HA leadership transfer when standby
was actively forwarding a request
fixes GH #12601

* adding the changelog