### PR TITLE
add custom-metadata flag docs for 'vault kv metadata put' cmd

### DIFF
--- a/website/content/docs/commands/kv/metadata.mdx
+++ b/website/content/docs/commands/kv/metadata.mdx
@@ -150,4 +150,8 @@ be applied to new versions.
   `delete_version_after` will be used. Accepts [Go duration format
   string][duration-godoc].
 
+- `custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add multiple
+  pieces of metadata.
+
 [duration-godoc]: https://golang.org/pkg/time/#ParseDuration


### PR DESCRIPTION
Add description for the `-custom-metadata` flag in the `vault kv metadata put` command