### PR TITLE
Backport 1.8.4: UI Auth method role edit form should be valid by default (#12646)

### DIFF
--- a/changelog/12646.txt
+++ b/changelog/12646.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix bug where edit role form on auth method is invalid by default
+```

--- a/ui/app/components/generated-item.js
+++ b/ui/app/components/generated-item.js
@@ -25,7 +25,7 @@ export default Component.extend({
   flashMessages: service(),
   router: service(),
   validationMessages: null,
-  isFormInvalid: true,
+  isFormInvalid: false,
   props: computed('model', function() {
     return this.model.serialize();
   }),


### PR DESCRIPTION
Backport for #12646 