### PR TITLE
builtin/logical/consul: fix dropped test error

### DIFF
--- a/builtin/logical/consul/backend_test.go
+++ b/builtin/logical/consul/backend_test.go
@@ -298,7 +298,9 @@ func testBackendRenewRevoke14(t *testing.T, version string) {
 	consulmgmtConfig.Address = connData["address"].(string)
 	consulmgmtConfig.Token = connData["token"].(string)
 	mgmtclient, err := consulapi.NewClient(consulmgmtConfig)
-
+	if err != nil {
+		t.Fatal(err)
+	}
 	q := &consulapi.QueryOptions{
 		Datacenter: "DC1",
 	}


### PR DESCRIPTION
This fixes a dropped error variable in `builtin/logical/consul`.

Could someone add the `no-changelog` label?