### PR TITLE
AWS Secret Engine: Support Session Tokens

### DIFF
--- a/builtin/logical/aws/backend_test.go
+++ b/builtin/logical/aws/backend_test.go
@@ -1286,6 +1286,36 @@ func TestBackend_FederationTokenWithGroups(t *testing.T) {
 	})
 }
 
+func TestBackend_SessionToken(t *testing.T) {
+	t.Parallel()
+	userName := generateUniqueName(t.Name())
+	accessKey := &awsAccessKey{}
+
+	roleData := map[string]interface{}{
+		"credential_type": sessionTokenCred,
+	}
+	logicaltest.Test(t, logicaltest.TestCase{
+		AcceptanceTest: true,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createUser(t, userName, accessKey)
+			// Sleep sometime because AWS is eventually consistent
+			log.Println("[WARN] Sleeping for 10 seconds waiting for AWS...")
+			time.Sleep(10 * time.Second)
+		},
+		LogicalBackend: getBackend(t),
+		Steps: []logicaltest.TestStep{
+			testAccStepConfigWithCreds(t, accessKey),
+			testAccStepWriteRole(t, "test", roleData),
+			testAccStepRead(t, "sts", "test", []credentialTestFunc{listDynamoTablesTest}),
+			testAccStepRead(t, "creds", "test", []credentialTestFunc{listDynamoTablesTest}),
+		},
+		Teardown: func() error {
+			return deleteTestUser(accessKey, userName)
+		},
+	})
+}
+
 func TestBackend_RoleDefaultSTSTTL(t *testing.T) {
 	t.Parallel()
 	roleName := generateUniqueName(t.Name())

--- a/builtin/logical/aws/path_roles.go
+++ b/builtin/logical/aws/path_roles.go
@@ -47,7 +47,7 @@ func pathRoles(b *backend) *framework.Path {
 
 			"credential_type": {
 				Type:        framework.TypeString,
-				Description: fmt.Sprintf("Type of credential to retrieve. Must be one of %s, %s, or %s", assumedRoleCred, iamUserCred, federationTokenCred),
+				Description: fmt.Sprintf("Type of credential to retrieve. Must be one of %s, %s, %s, or %s", assumedRoleCred, iamUserCred, federationTokenCred, sessionTokenCred),
 			},
 
 			"role_arns": {
@@ -104,7 +104,7 @@ delimited key pairs.`,
 
 			"default_sts_ttl": {
 				Type:        framework.TypeDurationSecond,
-				Description: fmt.Sprintf("Default TTL for %s and %s credential types when no TTL is explicitly requested with the credentials", assumedRoleCred, federationTokenCred),
+				Description: fmt.Sprintf("Default TTL for %s, %s, and %s credential types when no TTL is explicitly requested with the credentials", assumedRoleCred, federationTokenCred, sessionTokenCred),
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Default STS TTL",
 				},
@@ -112,7 +112,7 @@ delimited key pairs.`,
 
 			"max_sts_ttl": {
 				Type:        framework.TypeDurationSecond,
-				Description: fmt.Sprintf("Max allowed TTL for %s and %s credential types", assumedRoleCred, federationTokenCred),
+				Description: fmt.Sprintf("Max allowed TTL for %s, %s, and %s credential types", assumedRoleCred, federationTokenCred, sessionTokenCred),
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name: "Max STS TTL",
 				},
@@ -536,19 +536,19 @@ func (r *awsRoleEntry) validate() error {
 		errors = multierror.Append(errors, fmt.Errorf("did not supply credential_type"))
 	}
 
-	allowedCredentialTypes := []string{iamUserCred, assumedRoleCred, federationTokenCred}
+	allowedCredentialTypes := []string{iamUserCred, assumedRoleCred, federationTokenCred, sessionTokenCred}
 	for _, credType := range r.CredentialTypes {
 		if !strutil.StrListContains(allowedCredentialTypes, credType) {
 			errors = multierror.Append(errors, fmt.Errorf("unrecognized credential type: %s", credType))
 		}
 	}
 
-	if r.DefaultSTSTTL != 0 && !strutil.StrListContains(r.CredentialTypes, assumedRoleCred) && !strutil.StrListContains(r.CredentialTypes, federationTokenCred) {
-		errors = multierror.Append(errors, fmt.Errorf("default_sts_ttl parameter only valid for %s and %s credential types", assumedRoleCred, federationTokenCred))
+	if r.DefaultSTSTTL != 0 && !strutil.StrListContains(r.CredentialTypes, assumedRoleCred) && !strutil.StrListContains(r.CredentialTypes, federationTokenCred)  && !strutil.StrListContains(r.CredentialTypes, sessionTokenCred) {
+		errors = multierror.Append(errors, fmt.Errorf("default_sts_ttl parameter only valid for %s, %s, and %s credential types", assumedRoleCred, federationTokenCred, sessionTokenCred))
 	}
 
-	if r.MaxSTSTTL != 0 && !strutil.StrListContains(r.CredentialTypes, assumedRoleCred) && !strutil.StrListContains(r.CredentialTypes, federationTokenCred) {
-		errors = multierror.Append(errors, fmt.Errorf("max_sts_ttl parameter only valid for %s and %s credential types", assumedRoleCred, federationTokenCred))
+	if r.MaxSTSTTL != 0 && !strutil.StrListContains(r.CredentialTypes, assumedRoleCred) && !strutil.StrListContains(r.CredentialTypes, federationTokenCred) && !strutil.StrListContains(r.CredentialTypes, sessionTokenCred) {
+		errors = multierror.Append(errors, fmt.Errorf("max_sts_ttl parameter only valid for %s, %s, and %s credential types", assumedRoleCred, federationTokenCred, sessionTokenCred))
 	}
 
 	if r.MaxSTSTTL > 0 &&
@@ -592,6 +592,7 @@ const (
 	assumedRoleCred     = "assumed_role"
 	iamUserCred         = "iam_user"
 	federationTokenCred = "federation_token"
+	sessionTokenCred    = "session_token"
 )
 
 const pathListRolesHelpSyn = `List the existing roles in this backend`

--- a/builtin/logical/aws/path_user.go
+++ b/builtin/logical/aws/path_user.go
@@ -133,6 +133,8 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 		return b.assumeRole(ctx, req.Storage, req.DisplayName, roleName, roleArn, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl, roleSessionName)
 	case federationTokenCred:
 		return b.getFederationToken(ctx, req.Storage, req.DisplayName, roleName, role.PolicyDocument, role.PolicyArns, role.IAMGroups, ttl)
+	case sessionTokenCred:
+		return b.getSessionToken(ctx, req.Storage, ttl)
 	default:
 		return logical.ErrorResponse(fmt.Sprintf("unknown credential_type: %q", credentialType)), nil
 	}

--- a/builtin/logical/aws/secret_access_keys.go
+++ b/builtin/logical/aws/secret_access_keys.go
@@ -174,6 +174,41 @@ func (b *backend) getFederationToken(ctx context.Context, s logical.Storage,
 	return resp, nil
 }
 
+func (b *backend) getSessionToken(ctx context.Context, s logical.Storage,
+	lifeTimeInSeconds int64) (*logical.Response, error) {
+
+	stsClient, err := b.clientSTS(ctx, s)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+
+
+	getTokenInput := &sts.GetSessionTokenInput{
+		DurationSeconds: &lifeTimeInSeconds,
+	}
+
+	tokenResp, err := stsClient.GetSessionToken(getTokenInput)
+	if err != nil {
+		return logical.ErrorResponse("Error generating STS keys: %s", err), awsutil.CheckAWSError(err)
+	}
+
+	resp := b.Secret(secretAccessKeyType).Response(map[string]interface{}{
+		"access_key":     *tokenResp.Credentials.AccessKeyId,
+		"secret_key":     *tokenResp.Credentials.SecretAccessKey,
+		"security_token": *tokenResp.Credentials.SessionToken,
+	}, map[string]interface{}{
+		"is_sts":   true,
+	})
+
+	// Set the secret TTL to appropriately match the expiration of the token
+	resp.Secret.TTL = tokenResp.Credentials.Expiration.Sub(time.Now())
+
+	// STS are purposefully short-lived and aren't renewable
+	resp.Secret.Renewable = false
+
+	return resp, nil
+}
+
 func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 	displayName, roleName, roleArn, policy string, policyARNs []string,
 	iamGroups []string, lifeTimeInSeconds int64, roleSessionName string) (*logical.Response, error) {

--- a/changelog/12735.txt
+++ b/changelog/12735.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+secrets/aws: support issuing an STS Session Token directly from the root credential.
+```

--- a/ui/app/models/aws-credential.js
+++ b/ui/app/models/aws-credential.js
@@ -14,6 +14,10 @@ const CREDENTIAL_TYPES = [
     value: 'federation_token',
     displayName: 'Federation Token',
   },
+  {
+    value: 'session_token',
+    displayName: 'Session Token',
+  },
 ];
 
 const DISPLAY_FIELDS = ['accessKey', 'secretKey', 'securityToken', 'leaseId', 'renewable', 'leaseDuration'];
@@ -42,7 +46,7 @@ export default Model.extend({
     setDefault: true,
     label: 'TTL',
     helpText:
-      'Specifies the TTL for the use of the STS token. Valid only when credential_type is assumed_role or federation_token.',
+      'Specifies the TTL for the use of the STS token. Valid only when credential_type is assumed_role, federation_token, or session_token.',
   }),
   leaseId: attr('string'),
   renewable: attr('boolean'),
@@ -57,6 +61,7 @@ export default Model.extend({
       iam_user: ['credentialType'],
       assumed_role: ['credentialType', 'ttl', 'roleArn'],
       federation_token: ['credentialType', 'ttl'],
+      session_token: ['ttl'],
     };
     if (this.accessKey || this.securityToken) {
       return expandAttributeMeta(this, DISPLAY_FIELDS.slice(0));

--- a/ui/app/models/role-aws.js
+++ b/ui/app/models/role-aws.js
@@ -17,6 +17,10 @@ const CREDENTIAL_TYPES = [
     value: 'federation_token',
     displayName: 'Federation Token',
   },
+  {
+    value: 'session_token',
+    displayName: 'Session Token',
+  },
 ];
 export default Model.extend({
   backend: attr('string', {
@@ -58,6 +62,7 @@ export default Model.extend({
       iam_user: ['name', 'credentialType', 'policyArns', 'policyDocument'],
       assumed_role: ['name', 'credentialType', 'roleArns', 'policyDocument'],
       federation_token: ['name', 'credentialType', 'policyDocument'],
+      session_token: [],
     };
 
     return expandAttributeMeta(this, keysForType[credentialType]);

--- a/ui/tests/unit/adapters/aws-credential-test.js
+++ b/ui/tests/unit/adapters/aws-credential-test.js
@@ -49,6 +49,17 @@ module('Unit | Adapter | aws credential', function(hooks) {
       'POST',
     ],
     [
+      'session_token type with ttl',
+      [storeStub, type, makeSnapshot({ credentialType: 'session_token', ttl: '3h' })],
+      'POST',
+      { ttl: '3h' },
+    ],
+    [
+      'session_token type no ttl',
+      [storeStub, type, makeSnapshot({ credentialType: 'session_token' })],
+      'POST',
+    ],
+    [
       'assumed_role type no arn, no ttl',
       [storeStub, type, makeSnapshot({ credentialType: 'assumed_role' })],
       'POST',

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -59,7 +59,7 @@ valid AWS credentials with proper permissions.
 - `sts_endpoint` `(string: <optional>)` – Specifies a custom HTTP STS endpoint to use.
 
 - `username_template` `(string: <optional>)` - [Template](/docs/concepts/username-templating) describing how
-  dynamic usernames are generated. The username template is used to generate both IAM usernames (capped at 64 characters) 
+  dynamic usernames are generated. The username template is used to generate both IAM usernames (capped at 64 characters)
   and STS usernames (capped at 32 characters). Longer usernames result in a 500 error.
 
   To ensure generated usernames are within length limits for both STS/IAM, the template must adequately handle
@@ -248,7 +248,7 @@ updated with the new attributes.
 
 - `credential_type` `(string: <required>)` – Specifies the type of credential to be used when
   retrieving credentials from the role. Must be one of `iam_user`,
-  `assumed_role`, or `federation_token`.
+  `assumed_role`, `federation_token`, or `session_token`.
 
 - `role_arns` `(list: [])` – Specifies the ARNs of the AWS roles this Vault role
   is allowed to assume. Required when `credential_type` is `assumed_role` and
@@ -329,6 +329,14 @@ Using an inline IAM policy:
 {
   "credential_type": "federation_token",
   "policy_document": "{\"Version\": \"...\"}"
+}
+```
+
+Using a Session Token:
+
+```json
+{
+  "credential_type": "session_token"
 }
 ```
 
@@ -545,15 +553,17 @@ credentials retrieved through `/aws/creds` must be of the `iam_user` type.
    then it will be generated dynamically by default.
 - `ttl` `(string: "3600s")` – Specifies the TTL for the use of the STS token.
   This is specified as a string with a duration suffix. Valid only when
-  `credential_type` is `assumed_role` or `federation_token`. When not specified,
+  `credential_type` is `assumed_role` `federation_token`, or 'session_token'. When not specified,
   the `default_sts_ttl` set for the role will be used. If that is also not set, then
   the default value of `3600s` will be used. AWS places limits
   on the maximum TTL allowed. See the AWS documentation on the `DurationSeconds`
   parameter for
   [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
-  (for `assumed_role` credential types) and
+  (for `assumed_role` credential types),
   [GetFederationToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html)
-  (for `federation_token` credential types) for more details.
+  (for `federation_token` credential types), or
+  [GetSessionToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html)
+  (for `session_token` credential types) for more details.
 
 ### Sample Request
 

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -31,6 +31,9 @@ Vault supports three different types of credentials to retrieve from AWS:
    [sts:GetFederationToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html)
    passing in the supplied AWS policy document and return the access key, secret
    key, and session token to the caller.
+4. `session_token_token`: Vault will call
+   [sts:GetSessionToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html)
+   and return the access key, secret key, and session token to the caller.
 
 ## Setup
 
@@ -160,10 +163,10 @@ the proper permission, it can generate credentials.
     ---           -----
     access_key    AKIA3ALIVABCDG5XC8H4
     ```
-    
-    ~> **Note:** Due to AWS eventual consistency, after calling this endpoint, 
-    subsequent calls from Vault to AWS may fail for a few seconds until AWS 
-    becomes consistent again.  See the [AWS secrets engine API](/api/secret/aws#rotate-root-iam-credentials) for further information on rotate-root functionality. 
+
+    ~> **Note:** Due to AWS eventual consistency, after calling this endpoint,
+    subsequent calls from Vault to AWS may fail for a few seconds until AWS
+    becomes consistent again.  See the [AWS secrets engine API](/api/secret/aws#rotate-root-iam-credentials) for further information on rotate-root functionality.
 
 ## Example IAM Policy for Vault
 
@@ -252,7 +255,8 @@ them).
 ## STS credentials
 
 The above demonstrated usage with `iam_user` credential types. As mentioned,
-Vault also supports `assumed_role` and `federation_token` credential types.
+Vault also supports `assumed_role`, `federation_token`, and 'session_token`
+credential types.
 
 ### STS Federation Tokens
 
@@ -325,6 +329,38 @@ the role using the aws/sts endpoint:
 $ vault write aws/sts/ec2_admin ttl=60m
 Key            	Value
 lease_id       	aws/sts/ec2_admin/31d771a6-fb39-f46b-fdc5-945109106422
+lease_duration 	60m0s
+lease_renewable	false
+access_key     	ASIAJYYYY2AA5K4WIXXX
+secret_key     	HSs0DYYYYYY9W81DXtI0K7X84H+OVZXK5BXXXX
+security_token 	AQoDYXdzEEwasAKwQyZUtZaCjVNDiXXXXXXXXgUgBBVUUbSyujLjsw6jYzboOQ89vUVIehUw/9MreAifXFmfdbjTr3g6zc0me9M+dB95DyhetFItX5QThw0lEsVQWSiIeIotGmg7mjT1//e7CJc4LpxbW707loFX1TYD1ilNnblEsIBKGlRNXZ+QJdguY4VkzXxv2urxIH0Sl14xtqsRPboV7eYruSEZlAuP3FLmqFbmA0AFPCT37cLf/vUHinSbvw49C4c9WQLH7CeFPhDub7/rub/QU/lCjjJ43IqIRo9jYgcEvvdRkQSt70zO8moGCc7pFvmL7XGhISegQpEzudErTE/PdhjlGpAKGR3d5qKrHpPYK/k480wk1Ai/t1dTa/8/3jUYTUeIkaJpNBnupQt7qoaXXXXXXXXXX
+```
+
+### STS Session Tokens
+
+~> **Notice:** Due to limitations in AWS, in order to use the `session_token`
+credential type, Vault **must** be configured with IAM user credentials. AWS
+does not allow temporary credentials (such as those from an IAM instance
+profile) to be used.
+
+An STS session token inherits the exact same set of permissions which are
+granted to the `aws/config/root` credentials.
+
+A `root_access` role would then assign an inline policy with the same `ec2:*`
+permissions.
+
+```shell-session
+$ vault write aws/roles/root_access \
+    credential_type=session_token
+```
+
+To generate a new set of STS federation token credentials, we simply write to
+the role using the aws/creds endpoint:
+
+```shell-session
+$ vault write aws/sts/root_access ttl=60m
+Key            	Value
+lease_id       	aws/creds/root_access/w4eKbMaJOi1xLqG3MWk7y8n6
 lease_duration 	60m0s
 lease_renewable	false
 access_key     	ASIAJYYYY2AA5K4WIXXX


### PR DESCRIPTION
Sometimes people will give you an AWS access key and secret and not
be interested in setting up a better approach for key exchange.

In cases like this, options are limited for distributing access to
the key material. However, AWS's STS GetSessionToken can be used
to general ephemeral credentials "underneath" that token. This
at least limits the spread of that root key, and the duration of
its users' access.

It should almost definitely not be used for other use cases, since
it does not limit behavior on an otherwise probably administrative
key.

Closes #12734