### PR TITLE
Add links to vault-examples repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ check out our [Getting Started guides](https://learn.hashicorp.com/collections/v
 on HashiCorp's learning platform. There are also [additional guides](https://learn.hashicorp.com/vault)
 to continue your learning.
 
+For examples of how to interact with Vault from inside your application in different programming languages, see the [vault-examples](https://github.com/hashicorp/vault-examples) repo.
+
 Show off your Vault knowledge by passing a certification exam. Visit the
 [certification page](https://www.hashicorp.com/certification/#hashicorp-certified-vault-associate)
 for information about exams and find [study materials](https://learn.hashicorp.com/collections/vault/certification)

--- a/api/README.md
+++ b/api/README.md
@@ -3,4 +3,6 @@ Vault API
 
 This provides the `github.com/hashicorp/vault/api` package which contains code useful for interacting with a Vault server.
 
+For examples of how to use this module, see the [vault-examples](https://github.com/hashicorp/vault-examples/tree/main/go) repo.
+
 [![GoDoc](https://godoc.org/github.com/hashicorp/vault/api?status.png)](https://godoc.org/github.com/hashicorp/vault/api)

--- a/website/content/api-docs/libraries.mdx
+++ b/website/content/api-docs/libraries.mdx
@@ -11,6 +11,8 @@ description: >-
 The programming libraries listed on this page can be used to consume the API more conveniently.
 Some are officially maintained while others are provided by the community.
 
+For copy-pastable examples of how to use these libraries, see the [vault-examples](https://github.com/hashicorp/vault-examples) repo.
+
 ## Official
 
 These libraries are officially maintained by HashiCorp.
@@ -22,6 +24,8 @@ These libraries are officially maintained by HashiCorp.
 ```shell-session
 $ go get github.com/hashicorp/vault/api
 ```
+
+[Code samples](https://github.com/hashicorp/vault-examples/tree/main/go)
 
 ### Ruby
 
@@ -51,6 +55,8 @@ $ pip install ansible-modules-hashivault
 ```shell-session
 $ Install-Package VaultSharp
 ```
+
+[Code samples](https://github.com/hashicorp/vault-examples/tree/main/dotnet/Examples)
 
 - [Vault.NET](https://github.com/Chatham/Vault.NET)
 


### PR DESCRIPTION
Adds vault-examples repo links in various useful places so that users can find example code snippets more easily.