### PR TITLE
Don't use a metric name that may contain invalid chars like '/'. 

### DIFF
--- a/vault/audit_broker.go
+++ b/vault/audit_broker.go
@@ -133,7 +133,9 @@ func (a *AuditBroker) LogRequest(ctx context.Context, in *logical.LogInput, head
 
 		start := time.Now()
 		lrErr := be.backend.LogRequest(ctx, in)
-		metrics.MeasureSince([]string{"audit", name, "log_request"}, start)
+		metrics.MeasureSinceWithLabels([]string{"audit", "device", "log_request"}, start, []metrics.Label{
+			{"device_name", name},
+		})
 		if lrErr != nil {
 			a.logger.Error("backend failed to log request", "backend", name, "error", lrErr)
 		} else {
@@ -189,7 +191,9 @@ func (a *AuditBroker) LogResponse(ctx context.Context, in *logical.LogInput, hea
 
 		start := time.Now()
 		lrErr := be.backend.LogResponse(ctx, in)
-		metrics.MeasureSince([]string{"audit", name, "log_response"}, start)
+		metrics.MeasureSinceWithLabels([]string{"audit", "device", "log_response"}, start, []metrics.Label{
+			{"device_name", name},
+		})
 		if lrErr != nil {
 			a.logger.Error("backend failed to log response", "backend", name, "error", lrErr)
 		} else {


### PR DESCRIPTION
 Instead, put the device name into a label value.

The old format might have worked in some metrics systems - do we keep it around (in addition to the new one) for their sake?

Are we okay with exposing the file path to the audit log - that was the existing behaviour, but I could see it being considered sensitive information.  Maybe we should instead just use the audit device *type*, as the note [here](https://www.vaultproject.io/docs/internals/telemetry#audit-metrics) implies incorrectly.