### PR TITLE
Update website documentaton with Trasnform FPE advanced I/O handling features

### DIFF
--- a/website/content/api-docs/secret/transform.mdx
+++ b/website/content/api-docs/secret/transform.mdx
@@ -188,7 +188,7 @@ configuration endpoints, and will be removed in a future release.
 ```json
 {
   "type": "fpe",
-  "template": "builtin/creditcardnumber",
+  "template": "example-template",
   "tweak_source": "internal",
   "allowed_roles": ["example-role"]
 }
@@ -237,7 +237,7 @@ transformation exists, it will be updated with the new attributes.
 
 ```json
 {
-  "template": "builtin/creditcardnumber",
+  "template": "example-template",
   "tweak_source": "internal",
   "allowed_roles": ["example-role"]
 }
@@ -381,7 +381,7 @@ $ curl \
 {
   "data": {
     "allowed_roles": ["example-role"],
-    "templates": ["builtin/creditcardnumber"],
+    "templates": ["example-template"],
     "tweak_source": "internal",
     "type": "fpe"
   }
@@ -468,13 +468,26 @@ template exists, it will be updated with the new attributes.
   Specifies the name of the alphabet to use when this template is used for FPE
   encoding and decoding operations.
 
+-	`encode_format` `(string)` -
+  The regular expression template to use to format encoded values. This is only
+  used during FPE transformations.
+
+- `decode_formats` `(key-value-map: {})` -
+  An optional map of regular expression templates that can be used to customize
+  decoded output. This is only used during FPE transformations.
+
 ### Sample Payload
 
 ```json
 {
   "type": "regex",
-  "pattern": "(\\d{9})",
-  "alphabet": "builtin/numeric"
+  "alphabet": "builtin/numeric",
+  "pattern": "(\\d{3})[-/](\\d{2})[-/](\\d{4})",
+  "encode_format": "$1-$2-$3",
+  "decode_formats": {
+    "first-three": "$1",
+    "last-four": "$3"
+  }
 }
 ```
 
@@ -513,7 +526,12 @@ $ curl \
 {
   "data": {
     "alphabet": "builtin/numeric",
-    "pattern": "(\\d{9})",
+    "decode_formats": {
+      "first-three": "$1",
+      "last-four": "$3"
+    },
+    "encode_format": "$1-$2-$3",
+    "pattern": "(\\d{3})[-/](\\d{2})[-/](\\d{4})",
     "type": "regex"
   }
 }
@@ -734,7 +752,7 @@ The database user configured here should only have permission to `SELECT`,
   The maximum number of idle connections to the database at any given time.
 
 - `max_connection_lifetime` `(duration: 0)` -
-  The maximum amount of time a connection can be open before closing it.  
+  The maximum amount of time a connection can be open before closing it.
   0 means no limit.
 
 ### Sample Payloads
@@ -934,16 +952,16 @@ This endpoint encodes the provided value using a named role.
   transformations with `supplied` as the tweak source. The tweak must be a
   7-byte value that is then base64 encoded.
 
-- `reference` `(string: "")` - 
+- `reference` `(string: "")` -
   Only valid on batch requests using 'batch_input' below.  A user supplied
-  string that will be present on the corresponding item in the batch 
+  string that will be present on the corresponding item in the batch
   response, to assist in correlating inputs with outputs.
 
 - `batch_input` `(array<object>: nil)` -
   Specifies a list of items to be encoded in a single batch. When this
   parameter is set, the 'value', 'transformation', 'ttl', 'tweak' and
-  'reference' parameters are ignored. Instead, the aforementioned parameters 
-  should be provided within each object in the list.  
+  'reference' parameters are ignored. Instead, the aforementioned parameters
+  should be provided within each object in the list.
 
   ```json
   [
@@ -1048,15 +1066,19 @@ $ curl \
 
 This endpoint decodes the provided value using a named role.
 
-| Method | Path                           |
-| :----- | :----------------------------- |
-| `POST` | `/transform/decode/:role_name` |
+| Method | Path                                            |
+| :----- | :---------------------------------------------- |
+| `POST` | `/transform/decode/:role_name(/:decode_format)` |
 
 ### Parameters
 
 - `role_name` `(string: <required>)` –
   Specifies the role name to use for this operation. This is specified as part
   of the URL.
+
+- `decode_format` `(string)` -
+  The name of the decode format to use for decoding. If one is not specified,
+  the template's pattern will be used. Only applicable for FPE transformations.
 
 - `value` `(string: <required>)` –
   Specifies the value to be decoded.
@@ -1071,16 +1093,16 @@ This endpoint decodes the provided value using a named role.
   applicable for FPE transformations with `supplied` or `generated` as the tweak
   source. The tweak must be a 7-byte value that is then base64 encoded.
 
-- `reference` `(string: "")` - 
+- `reference` `(string: "")` -
   Only valid on batch requests using 'batch_input' below.  A user supplied
-  string that will be present on the corresponding item in the batch 
+  string that will be present on the corresponding item in the batch
   response, to assist in correlating inputs with outputs.
 
 - `batch_input` `(array<object>: nil)` -
   Specifies a list of items to be encoded in a single batch. When this
   parameter is set, the 'value', 'transformation', 'tweak' and
-  'reference' parameters are ignored. Instead, the aforementioned parameters 
-  should be provided within each object in the list.  
+  'reference' parameters are ignored. Instead, the aforementioned parameters
+  should be provided within each object in the list.
 
   ```json
   [
@@ -1093,10 +1115,10 @@ This endpoint decodes the provided value using a named role.
 
 ### Sample Payload
 
-```json
+ ```json
 {
-  "value": "5682-4613-6822-8064",
-  "transformation": "ccn-fpe"
+  "value": "418-56-4374",
+  "transformation": "example-transformation"
 }
 ```
 
@@ -1107,7 +1129,7 @@ $ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
-    http://127.0.0.1:8200/v1/transform/encode/example-role
+    http://127.0.0.1:8200/v1/transform/decode/example-role
 ```
 
 ### Sample Response
@@ -1115,7 +1137,36 @@ $ curl \
 ```json
 {
   "data": {
-    "decoded_value": "1111-2222-3333-4444"
+    "decoded_value": "111-22-3333"
+  }
+}
+```
+
+### Sample Payload
+
+ ```json
+{
+  "value": "418-56-4374",
+  "transformation": "example-transformation"
+}
+```
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/transform/decode/example-role/last-four
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "decoded_value": "4444"
   }
 }
 ```
@@ -1190,16 +1241,16 @@ Only valid for tokenization transformations.
   may be skipped and will be inferred. If multiple transformations exist, one
   must be specified.
 
-- `reference` `(string: "")` - 
+- `reference` `(string: "")` -
   Only valid on batch requests using 'batch_input' below.  A user supplied
-  string that will be present on the corresponding item in the batch 
+  string that will be present on the corresponding item in the batch
   response, to assist in correlating inputs with outputs.
 
 - `batch_input` `(array<object>: nil)` -
   Specifies a list of items to be validated in a single batch. When this
   parameter is set, the 'value', 'transformation' and
-  'reference' parameters are ignored. Instead, the aforementioned parameters 
-  should be provided within each object in the list.  
+  'reference' parameters are ignored. Instead, the aforementioned parameters
+  should be provided within each object in the list.
 
   ```json
   [
@@ -1265,9 +1316,9 @@ transformations.
   may be skipped and will be inferred. If multiple transformations exist, one
   must be specified.
 
-- `reference` `(string: "")` - 
+- `reference` `(string: "")` -
   Only valid on batch requests using 'batch_input' below.  A user supplied
-  string that will be present on the corresponding item in the batch 
+  string that will be present on the corresponding item in the batch
   response, to assist in correlating inputs with outputs.
 
 - `batch_input` `(array<object>: nil)` -
@@ -1339,9 +1390,9 @@ Only valid for tokenization transformations.
   may be skipped and will be inferred. If multiple transformations exist, one
   must be specified.
 
-- `reference` `(string: "")` - 
+- `reference` `(string: "")` -
   Only valid on batch requests using 'batch_input' below.  A user supplied
-  string that will be present on the corresponding item in the batch 
+  string that will be present on the corresponding item in the batch
   response, to assist in correlating inputs with outputs.
 
 - `batch_input` `(array<object>: nil)` -

--- a/website/content/docs/secrets/transform/index.mdx
+++ b/website/content/docs/secrets/transform/index.mdx
@@ -61,7 +61,9 @@ management tool.
    ```text
    $ vault write transform/template/ccn \
      type=regex \
-     pattern='(\d{4})-(\d{4})-(\d{4})-(\d{4})' \
+     pattern='(\d{4})[- ](\d{4})[- ](\d{4})[- ](\d{4})' \
+     encode_format='$1-$2-$3-$4' \
+     decode_formats=last-four='$4' \
      alphabet=numerics
    Success! Data written to: transform/template/ccn
    ```
@@ -105,6 +107,20 @@ values.
    A transformation must be provided if the role contains more than one
    transformation. A tweak must be provided if the tweak source for the
    transformation is "supplied" or "generated".
+
+1. Decode some input value using the `/decode` endpoint with a named role and decode format:
+
+   ```text
+   $ vault write transform/decode/payments/last-four value=9300-3376-4943-8903
+   Key              Value
+   ---              -----
+   decoded_value    4444
+   ```
+
+   A transformation must be provided if the role contains more than one
+   transformation. A tweak must be provided if the tweak source for the
+   transformation is "supplied" or "generated". A decode format can optionally
+   be provided.
 
 ## Roles, Transformations, Templates, and Alphabets
 
@@ -250,7 +266,7 @@ for external storage.
 #### Mapping Modes
 
 [Tokenization](transform/tokenization) stores the results of an encode operation
-in storage using a cryptographic construct that enhances the safety of its values.  
+in storage using a cryptographic construct that enhances the safety of its values.
 In the `default` mapping mode, the token itself is transformed via a one way
 function involving the transform key and elements of the token. As Vault does
 not store the token, the values in Vault storage themselves cannot be used to


### PR DESCRIPTION
Add documentation for the new Transform documentation:
- New template fields encode_format and decode_formats.
- Specifying an output format during decoding.

To see the changes locally:
```
git checkout victorr/VAULT-3334-update-transform-fpe-documentation
cd website
make website
```

And then navigate to http://localhost:3000/docs/secrets/transform and http://localhost:3000/api-docs/secret/transform.