### PR TITLE
OIDC: Unique prefix to client_id and client_secret

### DIFF
--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -881,20 +881,20 @@ func (i *IdentityStore) pathOIDCCreateUpdateClient(ctx context.Context, req *log
 
 	if client.ClientID == "" {
 		// generate client_id
-		clientID, err := base62.Random(32)
+		clientID, err := base62.Random(29)
 		if err != nil {
 			return nil, err
 		}
-		client.ClientID = clientID
+		client.ClientID = "id_" + clientID
 	}
 
 	if client.ClientSecret == "" {
 		// generate client_secret
-		clientSecret, err := base62.Random(64)
+		clientSecret, err := base62.Random(57)
 		if err != nil {
 			return nil, err
 		}
-		client.ClientSecret = clientSecret
+		client.ClientSecret = "secret_" + clientSecret
 	}
 
 	// invalidate the cached client in memdb

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -1163,6 +1164,14 @@ func TestOIDC_Path_OIDC_ProviderClient(t *testing.T) {
 	}
 	if diff := deep.Equal(expected, resp.Data); diff != nil {
 		t.Fatal(diff)
+	}
+	clientID := resp.Data["client_id"].(string)
+	if !strings.HasPrefix(clientID, "id_") && len(clientID) != 32 {
+		t.Fatalf("client_id format is incorrect: %#v", clientID)
+	}
+	clientSecret := resp.Data["client_secret"].(string)
+	if !strings.HasPrefix(clientSecret, "id_") && len(clientSecret) != 64 {
+		t.Fatalf("client_secret format is incorrect: %#v", clientSecret)
 	}
 
 	// Create a test assignment "my-assignment" -- should succeed


### PR DESCRIPTION
This task involves adding a unique prefix to the client_id and client_secret generated by Vault during OIDC client creation. This can allow for easy recognition by code scanning tools.