### PR TITLE
[VAULT-3252] Disallow alias creation if entity/accessor combination exists

### DIFF
--- a/vault/identity_store_aliases.go
+++ b/vault/identity_store_aliases.go
@@ -267,6 +267,12 @@ func (i *IdentityStore) handleAliasCreate(ctx context.Context, req *logical.Requ
 		}
 	}
 
+	for _, alias := range entity.Aliases {
+		if alias.MountAccessor == mountAccessor {
+			return logical.ErrorResponse("Alias already exists for requested entity and mount accessor"), nil
+		}
+	}
+
 	entity.Aliases = append(entity.Aliases, alias)
 
 	// ID creation and other validations; This is more useful for new entities


### PR DESCRIPTION
- This PR disallows entity alias creation if an alias for the specified entity and mount already exists, along with a test that checks the same
- It also logs a warning when entities are loaded on Vault startup, to tackle the case of such existing duplicates, in order to let the operator know this setup should be addressed ( should the log be a bit clearer about that ? )