### PR TITLE
Vault documentation: added new code sample to Kubernetes documentation

### DIFF
--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -256,7 +256,6 @@ func getSecretWithKubernetesAuth() (string, error) {
 	return value, nil
 }
 ```
-
 </CodeBlockConfig>
 
 </CodeTabs>


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/inbox/1200328878163177/1201106728049432/1201141378163348) task, the 'go' code sample was added to the Kubernetes documentation.

:mag: [Deploy Preview](https://vault-pw9rzbsay-hashicorp.vercel.app/docs/auth/kubernetes#code-example)