### PR TITLE
Fix typo in identity token templating example

### DIFF
--- a/website/content/docs/secrets/identity.mdx
+++ b/website/content/docs/secrets/identity.mdx
@@ -238,7 +238,7 @@ For example:
   "color": {{identity.entity.metadata.color}},
   "userinfo": {
      "username": {{identity.entity.aliases.usermap_123.metadata.username}},
-     "groups": {{identity.entity.group_names}}
+     "groups": {{identity.entity.groups.names}}
   },
   "nbf": {{time.now}}
 }


### PR DESCRIPTION
The example likely used an older naming scheme for groups. This makes it correct with the table below and working again.