### PR TITLE
Implemented device certificate with  Y10K expiry for certificate by providing the not_after field

### DIFF
--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -163,9 +163,9 @@ func TestPki_PermitFQDNs(t *testing.T) {
 	fields := addCACommonFields(map[string]*framework.FieldSchema{})
 
 	cases := map[string]struct {
-		input    *inputBundle
+		input            *inputBundle
 		expectedDnsNames []string
-		expectedEmails []string
+		expectedEmails   []string
 	}{
 		"base valid case": {
 			input: &inputBundle{
@@ -183,7 +183,7 @@ func TestPki_PermitFQDNs(t *testing.T) {
 				},
 			},
 			expectedDnsNames: []string{"example.com."},
-			expectedEmails: []string{},
+			expectedEmails:   []string{},
 		},
 		"case insensitivity validation": {
 			input: &inputBundle{
@@ -202,7 +202,7 @@ func TestPki_PermitFQDNs(t *testing.T) {
 				},
 			},
 			expectedDnsNames: []string{"Example.Net", "eXaMPLe.COM"},
-			expectedEmails: []string{},
+			expectedEmails:   []string{},
 		},
 		"case email as AllowedDomain with bare domains": {
 			input: &inputBundle{
@@ -220,7 +220,7 @@ func TestPki_PermitFQDNs(t *testing.T) {
 				},
 			},
 			expectedDnsNames: []string{},
-			expectedEmails: []string{"test@testemail.com"},
+			expectedEmails:   []string{"test@testemail.com"},
 		},
 		"case email common name with bare domains": {
 			input: &inputBundle{
@@ -238,7 +238,7 @@ func TestPki_PermitFQDNs(t *testing.T) {
 				},
 			},
 			expectedDnsNames: []string{},
-			expectedEmails: []string{"test@testemail.com"},
+			expectedEmails:   []string{"test@testemail.com"},
 		},
 	}
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -228,6 +228,11 @@ this value.`,
 more than one, specify alternative names in
 the alt_names map using OID 2.5.4.5.`,
 	}
+	fields["not_after"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `Set the not after field of the certificate with specified date value.
+                      The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ`,
+	}
 
 	return fields
 }
@@ -255,7 +260,7 @@ the key_type.`,
 	}
 
 	fields["signature_bits"] = &framework.FieldSchema{
-		Type: framework.TypeInt,
+		Type:    framework.TypeInt,
 		Default: 256,
 		Description: `The number of bits to use in the signature
 algorithm. Defaults to 256 for SHA256.

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -377,6 +377,11 @@ for "generate_lease".`,
 					Value: 30,
 				},
 			},
+			"not_after": {
+				Type: framework.TypeString,
+				Description: `Set the not after field of the certificate with specified date value.
+                              The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ`,
+			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -587,6 +592,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		PolicyIdentifiers:             data.Get("policy_identifiers").([]string),
 		BasicConstraintsValidForNonCA: data.Get("basic_constraints_valid_for_non_ca").(bool),
 		NotBeforeDuration:             time.Duration(data.Get("not_before_duration").(int)) * time.Second,
+		NotAfter:                      data.Get("not_after").(string),
 	}
 
 	allowedOtherSANs := data.Get("allowed_other_sans").([]string)
@@ -787,7 +793,7 @@ type roleEntry struct {
 	ExtKeyUsageOIDs               []string      `json:"ext_key_usage_oids" mapstructure:"ext_key_usage_oids"`
 	BasicConstraintsValidForNonCA bool          `json:"basic_constraints_valid_for_non_ca" mapstructure:"basic_constraints_valid_for_non_ca"`
 	NotBeforeDuration             time.Duration `json:"not_before_duration" mapstructure:"not_before_duration"`
-
+	NotAfter                      string        `json:"not_after" mapstructure:"not_after"`
 	// Used internally for signing intermediates
 	AllowExpirationPastCA bool
 }
@@ -833,6 +839,7 @@ func (r *roleEntry) ToResponseData() map[string]interface{} {
 		"policy_identifiers":                 r.PolicyIdentifiers,
 		"basic_constraints_valid_for_non_ca": r.BasicConstraintsValidForNonCA,
 		"not_before_duration":                int64(r.NotBeforeDuration.Seconds()),
+		"not_after":                          r.NotAfter,
 	}
 	if r.MaxPathLength != nil {
 		responseData["max_path_length"] = r.MaxPathLength

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -282,6 +282,7 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 		AllowedURISANs:        []string{"*"},
 		AllowedSerialNumbers:  []string{"*"},
 		AllowExpirationPastCA: true,
+		NotAfter:              data.Get("not_after").(string),
 	}
 
 	if cn := data.Get("common_name").(string); len(cn) == 0 {

--- a/changelog/12795.txt
+++ b/changelog/12795.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+core/pki: Support Y10K value in notAfter field to be compliant with IEEE 802.1AR-2018 standard
+```


### PR DESCRIPTION
fixes #12157

As per the IEE 802.1AR-2018 standard, the notAfter field of the IDevID certificate should use the Generalized Time value 99991231235959Z. However, in the PKI secrets engine currently, the max ttl value that can be specified is ~290 years.

Support an additional device_flag in certificate roles, which, when set ignores the ttl field and sets the notAfter value to Y10K.