### PR TITLE
docs: add additional resources for vault agent templating language

### DIFF
--- a/website/content/docs/agent/template.mdx
+++ b/website/content/docs/agent/template.mdx
@@ -11,7 +11,7 @@ description: >-
 # Vault Agent Templates
 
 Vault Agent's Template functionality allows Vault secrets to be rendered to files
-using [Consul Template markup](https://github.com/hashicorp/consul-template/blob/master/docs/templating-language.md).
+using [Consul Template markup](https://github.com/hashicorp/consul-template/blob/v0.27.1/docs/templating-language.md).
 
 For globally applicable templating engine configuration, refer to the parameters
 within the [`template_config`](/docs/agent/template-config) stanza.


### PR DESCRIPTION
This adds links to the website for more information on Vault Agent's templating language and fixes a broken link in the documentation.