### PR TITLE
Update maximum sleep time for TestExpiration_revokeEntry_token

### DIFF
--- a/vault/expiration_test.go
+++ b/vault/expiration_test.go
@@ -2080,7 +2080,7 @@ func TestExpiration_revokeEntry_token(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	limit := time.Now().Add(3 * time.Second)
+	limit := time.Now().Add(10 * time.Second)
 	for time.Now().Before(limit) {
 		indexEntry, err = exp.indexByToken(namespace.RootContext(nil), le)
 		if err != nil {


### PR DESCRIPTION
- We previously added a sleep to TestExpiration_revokeEntry_token, to make it wait till the secondary index of the token was deleted.
- The upper limit on this sleep was 3 seconds, which was not sufficient for all runs of the test, like this one https://app.circleci.com/pipelines/github/hashicorp/vault-enterprise/4864/workflows/09d63f1a-1d94-4945-89c1-0398f59ce995/jobs/281593
- This updates the maximum sleep time to 10 seconds, to reduce the test flakiness