### PR TITLE
Fix connection_url in AzureSQL Config Example in Secret Engine Docs

### DIFF
--- a/changelog/12803.txt
+++ b/changelog/12803.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-secrets/database: Fix bug in AzureSQL example config provided in docs
-```


### PR DESCRIPTION
Updates the connection URL in the example config for AzureSQL DB in DB Secret Engines docs. The previous `\` was causing an error in reading the `user id` field.