### PR TITLE
KV: fix copy json bug

### DIFF
--- a/ui/app/templates/components/secret-edit-toolbar.hbs
+++ b/ui/app/templates/components/secret-edit-toolbar.hbs
@@ -48,7 +48,7 @@
                   <li class="action">
                     <CopyButton
                       @class="link link-plain has-text-weight-semibold is-ghost"
-                      @clipboardText={{@codemirrorString}}
+                      @clipboardText={{stringify @modelForData.secretData}}
                       @success={{action (set-flash-message "JSON Copied!")}}
                       data-test-copy-button
                     >


### PR DESCRIPTION
There was an issue where we were not copying the correct version data if a user was copying from various versions. This PR fixes that.

There is no changelog because this bug was introduced in the KV project work that is being pushed into 1.9.

I tried my darndest to write a test but I can't get the data off (consistently without making a flaky test) the clipboard.

https://user-images.githubusercontent.com/6618863/137022745-73a48b84-ac62-4689-a22a-d05ecbdbd7ef.mp4
