### PR TITLE
api.Client:  support isolated read-after-write

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -438,7 +438,7 @@ func TestClone(t *testing.T) {
 		{
 			name: "preventStaleReads",
 			config: &Config{
-				PreventStaleReads: true,
+				ReadYourWrites: true,
 			},
 		},
 	}
@@ -520,11 +520,12 @@ func TestClone(t *testing.T) {
 					}
 				}
 			}
-			if tt.config.PreventStaleReads && client1.replicationStateStore == nil {
+			if tt.config.ReadYourWrites && client1.replicationStateStore == nil {
 				t.Fatalf("replicationStateStore is nil")
 			}
 			if !reflect.DeepEqual(client1.replicationStateStore, client2.replicationStateStore) {
-				t.Fatalf("expected replicationStateStore %v, actual %v", client1.replicationStateStore, client2.replicationStateStore)
+				t.Fatalf("expected replicationStateStore %v, actual %v", client1.replicationStateStore,
+					client2.replicationStateStore)
 			}
 		})
 	}
@@ -841,7 +842,7 @@ func TestReplicationStateStore_requireState(t *testing.T) {
 	}
 }
 
-func TestClient_PreventDirtyReads(t *testing.T) {
+func TestClient_ReadYourWrites(t *testing.T) {
 	b64enc := func(s string) string {
 		return base64.StdEncoding.EncodeToString([]byte(s))
 	}
@@ -949,7 +950,7 @@ func TestClient_PreventDirtyReads(t *testing.T) {
 			config, ln := testHTTPServer(t, handler)
 			defer ln.Close()
 
-			config.PreventStaleReads = true
+			config.ReadYourWrites = true
 			config.Address = fmt.Sprintf("http://%s", ln.Addr())
 			parent, err := NewClient(config)
 			if err != nil {

--- a/changelog/12814.txt
+++ b/changelog/12814.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-api: Add support for preventing stale reads by automatically requiring known cluster replication states in each request.
+api: Add configuration option for ensuring isolated read-after-write semantics for all Client requests.
 ```


### PR DESCRIPTION
This PR adds the ability for a Client to track all cluster replication states. The new `ReplicationStateStore` provides `response` and `request` callback methods to the Client, and can be used across Client clones.

```
import  (
        "log"

        "github.com/hashicorp/vault/api"
)

func main() {                        
        config := api.DefaultConfig()  
        config.ReadYourWrites = true     
        client, err := api.NewClient(config)
        if err != nil {                           
                log.Fatal(err)
        }

        [...]    
}

```

Related PR: https://github.com/hashicorp/terraform-provider-vault/pull/1188