### PR TITLE
[VAULT-3252] Disallow alias creation if entity/accessor combination e…

### DIFF
--- a/changelog/12747.txt
+++ b/changelog/12747.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/identity: Disallow entity alias creation/update if a conflicting alias exists for the target entity and mount combination
+```

--- a/vault/identity_store_aliases.go
+++ b/vault/identity_store_aliases.go
@@ -231,6 +231,12 @@ func (i *IdentityStore) handleAliasCreate(ctx context.Context, req *logical.Requ
 		}
 	}
 
+	for _, currentAlias := range entity.Aliases {
+		if currentAlias.MountAccessor == mountAccessor {
+			return logical.ErrorResponse("Alias already exists for requested entity and mount accessor"), nil
+		}
+	}
+
 	entity.Aliases = append(entity.Aliases, alias)
 
 	// ID creation and other validations; This is more useful for new entities
@@ -276,6 +282,29 @@ func (i *IdentityStore) handleAliasUpdate(ctx context.Context, req *logical.Requ
 
 	alias.LastUpdateTime = ptypes.TimestampNow()
 
+	// Get our current entity, which may be the same as the new one if the
+	// canonical ID hasn't changed
+	currentEntity, err := i.MemDBEntityByAliasID(alias.ID, true)
+	if err != nil {
+		return nil, err
+	}
+	if currentEntity == nil {
+		return logical.ErrorResponse("given alias is not associated with an entity"), nil
+	}
+
+	if currentEntity.NamespaceID != alias.NamespaceID {
+		return logical.ErrorResponse("alias and entity do not belong to the same namespace"), logical.ErrPermissionDenied
+	}
+
+	// If the accessor is being changed but the entity is not, check if the entity
+	// already has an alias corresponding to the new accessor
+	if mountAccessor != alias.MountAccessor && (canonicalID == "" || canonicalID == alias.CanonicalID) {
+		for _, currentAlias := range currentEntity.Aliases {
+			if currentAlias.MountAccessor == mountAccessor {
+				return logical.ErrorResponse("Alias cannot be updated as the entity already has an alias for the given 'mount_accessor' "), nil
+			}
+		}
+	}
 	// If we're changing one or the other or both of these, make sure that
 	// there isn't a matching alias already, and make sure it's in the same
 	// namespace.
@@ -306,19 +335,6 @@ func (i *IdentityStore) handleAliasUpdate(ctx context.Context, req *logical.Requ
 		alias.MountAccessor = mountAccessor
 	}
 
-	// Get our current entity, which may be the same as the new one if the
-	// canonical ID hasn't changed
-	currentEntity, err := i.MemDBEntityByAliasID(alias.ID, true)
-	if err != nil {
-		return nil, err
-	}
-	if currentEntity == nil {
-		return logical.ErrorResponse("given alias is not associated with an entity"), nil
-	}
-	if currentEntity.NamespaceID != alias.NamespaceID {
-		return logical.ErrorResponse("alias associated with an entity in a different namespace"), logical.ErrPermissionDenied
-	}
-
 	newEntity := currentEntity
 	if canonicalID != "" && canonicalID != alias.CanonicalID {
 		newEntity, err = i.MemDBEntityByID(canonicalID, true)
@@ -330,6 +346,13 @@ func (i *IdentityStore) handleAliasUpdate(ctx context.Context, req *logical.Requ
 		}
 		if newEntity.NamespaceID != alias.NamespaceID {
 			return logical.ErrorResponse("given 'canonical_id' associated with entity in a different namespace from the alias"), logical.ErrPermissionDenied
+		}
+
+		// Check if the entity the alias is being updated to, already has an alias for the mount
+		for _, alias := range newEntity.Aliases {
+			if alias.MountAccessor == mountAccessor {
+				return logical.ErrorResponse("Alias cannot be updated as the given entity already has an alias for this mount "), nil
+			}
 		}
 
 		// Update the canonical ID value and move it from the current entity to the new one

--- a/vault/identity_store_aliases_test.go
+++ b/vault/identity_store_aliases_test.go
@@ -399,6 +399,218 @@ func TestIdentityStore_AliasUpdate(t *testing.T) {
 	}
 }
 
+// Test to check that the alias cannot be updated with a new entity
+// which already has an alias for the mount on the alias to be updated
+func TestIdentityStore_AliasMove_DuplicateAccessor(t *testing.T) {
+	var err error
+	var resp *logical.Response
+	ctx := namespace.RootContext(nil)
+	is, githubAccessor, _ := testIdentityStoreWithGithubAuth(ctx, t)
+
+	// Create 2 entities and 1 alias on each, against the same github mount
+	resp, err = is.HandleRequest(ctx, &logical.Request{
+		Path:      "entity",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name": "testentity1",
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: err:%v\nresp: %#v", err, resp)
+	}
+	entity1ID := resp.Data["id"].(string)
+
+	alias1Data := map[string]interface{}{
+		"name":           "testaliasname1",
+		"mount_accessor": githubAccessor,
+		"canonical_id":   entity1ID,
+	}
+
+	aliasReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "entity-alias",
+		Data:      alias1Data,
+	}
+
+	// This will create an alias against the requested entity
+	resp, err = is.HandleRequest(ctx, aliasReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	resp, err = is.HandleRequest(ctx, &logical.Request{
+		Path:      "entity",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name": "testentity2",
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: err:%v\nresp: %#v", err, resp)
+	}
+	entity2ID := resp.Data["id"].(string)
+
+	alias2Data := map[string]interface{}{
+		"name":           "testaliasname2",
+		"mount_accessor": githubAccessor,
+		"canonical_id":   entity2ID,
+	}
+
+	aliasReq.Data = alias2Data
+
+	// This will create an alias against the requested entity
+	resp, err = is.HandleRequest(ctx, aliasReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+	alias2ID := resp.Data["id"].(string)
+
+	// Attempt to update the second alias to point to the first entity
+	updateData := map[string]interface{}{
+		"canonical_id": entity1ID,
+	}
+
+	aliasReq.Data = updateData
+	aliasReq.Path = "entity-alias/id/" + alias2ID
+	resp, err = is.HandleRequest(ctx, aliasReq)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil || !resp.IsError() {
+		t.Fatalf("expected an error as alias on the github accessor exists for testentity1")
+	}
+
+}
+
+// Test that the alias cannot be changed to a mount for which
+// the entity already has an alias
+func TestIdentityStore_AliasUpdate_DuplicateAccessor(t *testing.T) {
+	var err error
+	var resp *logical.Response
+	ctx := namespace.RootContext(nil)
+
+	is, ghAccessor, upAccessor, _ := testIdentityStoreWithGithubUserpassAuth(ctx, t)
+
+	// Create 1 entity and 2 aliases on it, one for each mount
+	resp, err = is.HandleRequest(ctx, &logical.Request{
+		Path:      "entity",
+		Operation: logical.UpdateOperation,
+		Data: map[string]interface{}{
+			"name": "testentity",
+		},
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: err:%v\nresp: %#v", err, resp)
+	}
+	entityID := resp.Data["id"].(string)
+
+	alias1Data := map[string]interface{}{
+		"name":           "testaliasname1",
+		"mount_accessor": ghAccessor,
+		"canonical_id":   entityID,
+	}
+
+	aliasReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "entity-alias",
+		Data:      alias1Data,
+	}
+
+	// This will create an alias against the requested entity
+	resp, err = is.HandleRequest(ctx, aliasReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	alias2Data := map[string]interface{}{
+		"name":           "testaliasname2",
+		"mount_accessor": upAccessor,
+		"canonical_id":   entityID,
+	}
+
+	aliasReq.Data = alias2Data
+
+	// This will create an alias against the requested entity
+	resp, err = is.HandleRequest(ctx, aliasReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+	alias2ID := resp.Data["id"].(string)
+
+	// Attempt to update the userpass mount to point to the github mount
+	updateData := map[string]interface{}{
+		"mount_accessor": ghAccessor,
+	}
+
+	aliasReq.Data = updateData
+	aliasReq.Path = "entity-alias/id/" + alias2ID
+	resp, err = is.HandleRequest(ctx, aliasReq)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil || !resp.IsError() {
+		t.Fatalf("expected an error as an alias on the github accessor already exists for testentity")
+	}
+
+}
+
+// Test that alias creation fails if an alias for the specified mount
+// and entity has already been created
+func TestIdentityStore_AliasCreate_DuplicateAccessor(t *testing.T) {
+	var err error
+	var resp *logical.Response
+	ctx := namespace.RootContext(nil)
+	is, githubAccessor, _ := testIdentityStoreWithGithubAuth(ctx, t)
+
+	resp, err = is.HandleRequest(ctx, &logical.Request{
+		Path:      "entity",
+		Operation: logical.UpdateOperation,
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: err:%v\nresp: %#v", err, resp)
+	}
+	entityID := resp.Data["id"].(string)
+
+	aliasData := map[string]interface{}{
+		"name":           "testaliasname",
+		"mount_accessor": githubAccessor,
+		"canonical_id":   entityID,
+	}
+
+	aliasReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "entity-alias",
+		Data:      aliasData,
+	}
+
+	// This will create an alias against the requested entity
+	resp, err = is.HandleRequest(ctx, aliasReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	aliasData["name"] = "testaliasname2"
+	aliasReq = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "entity-alias",
+		Data:      aliasData,
+	}
+
+	// This will try to create a new alias with the same accessor and entity
+	resp, err = is.HandleRequest(ctx, aliasReq)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatalf("expected an error as alias already exists for this accessor and entity")
+	}
+}
+
 func TestIdentityStore_AliasUpdate_ByID(t *testing.T) {
 	var err error
 	var resp *logical.Response

--- a/vault/identity_store_entities.go
+++ b/vault/identity_store_entities.go
@@ -766,6 +766,15 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 	}
 
 	isPerfSecondaryOrStandby := i.core.ReplicationState().HasState(consts.ReplicationPerformanceSecondary) || i.core.perfStandby
+
+	toEntityAccessors := make(map[string]struct{})
+
+	for _, alias := range toEntity.Aliases {
+		if _, ok := toEntityAccessors[alias.MountAccessor]; !ok {
+			toEntityAccessors[alias.MountAccessor] = struct{}{}
+		}
+	}
+
 	for _, fromEntityID := range fromEntityIDs {
 		if fromEntityID == toEntity.ID {
 			return errors.New("to_entity_id should not be present in from_entity_ids"), nil
@@ -795,6 +804,10 @@ func (i *IdentityStore) mergeEntity(ctx context.Context, txn *memdb.Txn, toEntit
 				return nil, fmt.Errorf("failed to update alias during merge: %w", err)
 			}
 
+			if _, ok := toEntityAccessors[alias.MountAccessor]; ok {
+				i.logger.Warn("skipping from_entity alias during entity merge as to_entity has an alias with its accessor", "from_entity", fromEntityID, "skipped_alias", alias.ID)
+				continue
+			}
 			// Add the alias to the desired entity
 			toEntity.Aliases = append(toEntity.Aliases, alias)
 		}

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -185,6 +185,7 @@ func (i *IdentityStore) loadEntities(ctx context.Context) error {
 	}
 	i.logger.Debug("entities collected", "num_existing", len(existing))
 
+	duplicatedAccessors := make(map[string]struct{})
 	// Make the channels used for the worker pool
 	broker := make(chan string)
 	quit := make(chan bool)
@@ -304,6 +305,13 @@ func (i *IdentityStore) loadEntities(ctx context.Context) error {
 					}
 				}
 
+				mountAccessors := getAccessorsOnDuplicateAliases(entity.Aliases)
+
+				for _, accessor := range mountAccessors {
+					if _, ok := duplicatedAccessors[accessor]; !ok {
+						duplicatedAccessors[accessor] = struct{}{}
+					}
+				}
 				// Only update MemDB and don't hit the storage again
 				err = i.upsertEntity(nsCtx, entity, nil, false)
 				if err != nil {
@@ -316,11 +324,42 @@ func (i *IdentityStore) loadEntities(ctx context.Context) error {
 	// Let all go routines finish
 	wg.Wait()
 
+	// Flatten the map into a list of keys, in order to log them
+	duplicatedAccessorsList := make([]string, len(duplicatedAccessors))
+	accessorCounter := 0
+	for accessor := range duplicatedAccessors {
+		duplicatedAccessorsList[accessorCounter] = accessor
+		accessorCounter++
+	}
+
+	if len(duplicatedAccessorsList) > 0 {
+		i.logger.Warn("One or more entities have multiple aliases on the same mount(s), remove duplicates to avoid ACL templating issues", "mount_accessors", duplicatedAccessorsList)
+	}
+
 	if i.logger.IsInfo() {
 		i.logger.Info("entities restored")
 	}
 
 	return nil
+}
+
+// getAccessorsOnDuplicateAliases returns a list of accessors by checking aliases in
+// the passed in list which belong to the same accessor(s)
+func getAccessorsOnDuplicateAliases(aliases []*identity.Alias) []string {
+	accessorCounts := make(map[string]int)
+	var mountAccessors []string
+
+	for _, alias := range aliases {
+		accessorCounts[alias.MountAccessor] += 1
+	}
+
+	for accessor, accessorCount := range accessorCounts {
+		if accessorCount > 1 {
+			mountAccessors = append(mountAccessors, accessor)
+		}
+	}
+
+	return mountAccessors
 }
 
 // upsertEntityInTxn either creates or updates an existing entity. The

--- a/website/content/docs/secrets/identity.mdx
+++ b/website/content/docs/secrets/identity.mdx
@@ -39,7 +39,8 @@ disabled or moved.
 Each user will have multiple accounts with various identity providers. Users
 can now be mapped as `Entities` and their corresponding accounts with
 authentication providers can be mapped as `Aliases`. In essence, each entity is
-made up of zero or more aliases.
+made up of zero or more aliases. An entity cannot have more than one alias for
+a particular authentication backend.
 
 ### Entity Management
 


### PR DESCRIPTION
- Backport PR for https://github.com/hashicorp/vault/pull/12747
- Some differences exist between the changes there and here, due to some other identity changes that haven't been backported. The mergeEntity code uses i.core vs i.localNode, fromEntityIDs versus sanitizedFromEntityIDs, and does not use fromEntityGroups. The missing sanitizedFromEntityIDs is the only one relevant to the actual lines changes.