### PR TITLE
Modify error response format for resources protected by OIDC access tokens

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -106,6 +106,8 @@ var (
 		"/v1/sys/rotate",
 		"/v1/sys/wrapping/wrap",
 	}
+
+	oidcProtectedPathRegex = regexp.MustCompile(`^identity/oidc/provider/\w(([\w-.]+)?\w)?/userinfo$`)
 )
 
 func init() {
@@ -1254,16 +1256,8 @@ func respondOk(w http.ResponseWriter, body interface{}) {
 // UserInfo Endpoint published by Vault OIDC providers and the given
 // error is a logical.ErrPermissionDenied.
 func oidcPermissionDenied(path string, err error) bool {
-	if !errwrap.Contains(err, logical.ErrPermissionDenied.Error()) {
-		return false
-	}
-
-	pattern := "^identity/oidc/provider/\\w(([\\w-.]+)?\\w)?/userinfo$"
-	match, err := regexp.MatchString(pattern, path)
-	if err != nil {
-		return false
-	}
-	return match
+	return errwrap.Contains(err, logical.ErrPermissionDenied.Error()) &&
+		oidcProtectedPathRegex.MatchString(path)
 }
 
 // respondOIDCPermissionDenied writes a response to the given w for


### PR DESCRIPTION
This PR modifies the error response format for resources protected by OIDC access tokens. At this time, only the [UserInfo Endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) is protected by OIDC access tokens. The motivation for this change is to prevent OIDC clients that are using the access token to refresh end-user info from needing to parse/know two JSON error formats. This also brings our UserInfo Endpoint in closer alignment with the spec by returning a 401 instead of a 403.

Prior to this PR, the format returned when an OIDC access token expired was:
```
curl -v -X GET \
    --header "Authorization: Bearer $ACCESS_TOKEN" \
    --header "X-Vault-Namespace: $VAULT_NAMESPACE" \
    http://127.0.0.1:8200/v1/identity/oidc/provider/my-provider/userinfo | jq
...
< HTTP/1.1 403 Forbidden
< Cache-Control: no-store
< Content-Type: application/json
< Strict-Transport-Security: max-age=31536000; includeSubDomains
< Date: Fri, 15 Oct 2021 02:34:37 GMT
< Content-Length: 33
< 
{ [33 bytes data]
100    33  100    33    0     0  16500      0 --:--:-- --:--:-- --:--:-- 16500
* Connection #0 to host 127.0.0.1 left intact
{
  "errors": [
    "permission denied"
  ]
}
```

With this PR, the format is consistent with [errors returned](https://github.com/hashicorp/vault/blob/main/vault/identity_store_oidc_provider.go#L1985-L2032) from the OIDC endpoint:
```
curl -v -X GET \
>     --header "Authorization: Bearer $ACCESS_TOKEN" \
>     --header "X-Vault-Namespace: $VAULT_NAMESPACE" \
>     http://127.0.0.1:8200/v1/identity/oidc/provider/my-provider/userinfo | jq
...
< HTTP/1.1 401 Unauthorized
< Cache-Control: no-store
< Content-Type: application/json
< Strict-Transport-Security: max-age=31536000; includeSubDomains
< Www-Authenticate: Bearer error="invalid_token",error_description="permission denied"
< Date: Fri, 15 Oct 2021 02:12:33 GMT
< Content-Length: 66
< 
{ [66 bytes data]
100    66  100    66    0     0     17      0  0:00:03  0:00:03 --:--:--    17
* Connection #0 to host 127.0.0.1 left intact
{
  "error": "invalid_token",
  "error_description": "permission denied"
}
```