### PR TITLE
Update KV V2 docs to remove default on max_versions for config

### DIFF
--- a/website/content/api-docs/secret/kv/kv-v2.mdx
+++ b/website/content/api-docs/secret/kv/kv-v2.mdx
@@ -30,7 +30,8 @@ key-value store.
 - `max_versions` `(int: 0)` – The number of versions to keep per key. This value
   applies to all keys, but a key's metadata setting can overwrite this value.
   Once a key has more than the configured allowed versions the oldest version
-  will be permanently deleted. Defaults to 0, which keeps unlimited versions.
+  will be permanently deleted. When 0 is used or the value is unset, Vault 
+  will keep 10 versions.
 
 - `cas_required` `(bool: false)` – If true all keys will require the cas
   parameter to be set on all write requests.


### PR DESCRIPTION
We added the config endpoint to the UI and I realized in doing so that the API docs incorrectly state that the max_version defaults to 10. After testing, I confirmed it defaults to 0, which means it's effectively not set.

See screenshot of API docs - link[ here](https://www.vaultproject.io/api-docs/secret/kv/kv-v2#configure-the-kv-engine).
![image](https://user-images.githubusercontent.com/6618863/137527619-6db020d5-4bbc-4c79-b691-0663026de2ab.png)


To reproduce:
```
curl \
    --header "X-Vault-Token: root" \
    --request POST \
    --data @payload.json \
    http://127.0.0.1:4200/v1/my-mount/config
```
* have your payload.json file empty.

Then read the config endpoint:
```
curl \
    --header "X-Vault-Token: root" \
    http://127.0.0.1:4200/v1/my-mount/config |jq
```

The response (notice max_versions is 0).
```
{
  "request_id": "6b20e2e3-7fb6-d8d6-abd3-3fc1fdd14e70",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 0,
  "data": {
    "cas_required": false,
    "delete_version_after": "0s",
    "max_versions": 0
  },
  "wrap_info": null,
  "warnings": null,
  "auth": null
}
``