### PR TITLE
use IsRoot helper before clientID generation in activity log

### DIFF
--- a/vault/activity_log.go
+++ b/vault/activity_log.go
@@ -1600,8 +1600,7 @@ func (a *ActivityLog) HandleTokenUsage(entry *logical.TokenEntry) {
 		return
 	}
 
-	// Do not count root tokens in client count. This includes generated root tokens
-	// as well.
+	// Do not count root tokens in client count.
 	if entry.IsRoot() {
 		return
 	}


### PR DESCRIPTION
Removed the milestone on this PR as it's very low priority, but since I just found out we have an `IsRoot` helper, I thought I'd go ahead and make use of it before I forgot. 