### PR TITLE
Address algorithm not supported

### DIFF
--- a/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
+++ b/website/content/docs/secrets/ssh/signed-ssh-certificates.mdx
@@ -475,7 +475,6 @@ forwarding. See [no prompt after login](#no-prompt-after-login) for examples.
 ```
 
 ### Known Issues
-
 - On SELinux-enforcing systems, you may need to adjust related types so that the
   SSH daemon is able to read it. For example, adjust the signed host certificate
   to be an `sshd_key_t` type.
@@ -489,6 +488,17 @@ forwarding. See [no prompt after login](#no-prompt-after-login) for examples.
   This is a bug introduced in OpenSSH version 7.2 and fixed in 7.5. See
   [OpenSSH bug 2617](https://bugzilla.mindrot.org/show_bug.cgi?id=2617) for
   details.
+
+- On some versions of SSH, you may get the following error on target host:
+
+  ```text
+  userauth_pubkey: certificate signature algorithm ssh-rsa: signature algorithm not supported [preauth]
+  ```
+  Fix is to add below line to /etc/ssh/sshd_config
+  ```text
+  CASignatureAlgorithms ^ssh-rsa
+  ```
+  The ssh-rsa algorithm is no longer supported in [OpenSSH 8.2](https://www.openssh.com/txt/release-8.2)
 
 ## API
 


### PR DESCRIPTION
error seen on host /var/log/auth.log:
  userauth_pubkey: certificate signature algorithm ssh-rsa: signature algorithm not supported [preauth]