### PR TITLE
fix(website): install latest `npm` in `Dockerfile`

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -4,4 +4,5 @@ RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libp
 COPY ./package.json /website/package.json
 COPY ./package-lock.json /website/package-lock.json
 WORKDIR /website
+RUN npm install -g npm@latest
 RUN npm install


### PR DESCRIPTION
Fixing an error after `make build-image` and `make website-local` in `./website`
... and also `make`


<details>
<summary>Error output</summary>

```
Error: failed to load next.config.js, see more info here https://nextjs.org/docs/messages/next-config-error
(node:25) UnhandledPromiseRejectionWarning: Error: Cannot find module 'postcss'
Require stack:
- /website/node_modules/postcss-normalize/index.cjs
- /website/node_modules/@hashicorp/platform-nextjs-plugin/dist/plugins/with-css.js
- /website/node_modules/@hashicorp/platform-nextjs-plugin/dist/index.js
- /website/node_modules/@hashicorp/platform-nextjs-plugin/index.js
- /website/next.config.js
- /website/node_modules/next/dist/server/config.js
- /website/node_modules/next/dist/server/next.js
- /website/node_modules/next-remote-watch/bin/next-remote-watch
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:885:15)
    at Function.mod._resolveFilename (/website/node_modules/next/dist/build/webpack/require-hook.js:96:28)
    at Function.Module._load (internal/modules/cjs/loader.js:730:27)
    at Module.require (internal/modules/cjs/loader.js:957:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/website/node_modules/postcss-normalize/index.cjs:6:15)
    at Module._compile (internal/modules/cjs/loader.js:1068:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:933:32)
    at Function.Module._load (internal/modules/cjs/loader.js:774:14)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:25) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:25) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

</details>