### PR TITLE
Restrict ECDSA/NIST P-Curve hash function sizes for cert signing

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -827,7 +827,6 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		KeyType:       "rsa",
 		KeyBits:       2048,
 		RequireCN:     true,
-		SignatureBits: -1,
 	}
 	issueVals := certutil.IssueData{}
 	ret := []logicaltest.TestStep{}

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -827,7 +827,7 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 		KeyType:       "rsa",
 		KeyBits:       2048,
 		RequireCN:     true,
-		SignatureBits: 256,
+		SignatureBits: -1,
 	}
 	issueVals := certutil.IssueData{}
 	ret := []logicaltest.TestStep{}

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -55,13 +55,8 @@ func (b *backend) getGenerationParams(
 		return
 	}
 
-	if err := certutil.ValidateKeyTypeLength(role.KeyType, role.KeyBits); err != nil {
+	if err := certutil.ValidateKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits); err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
-	}
-
-	if err := certutil.ValidateSignatureLength(role.SignatureBits); err != nil {
-		errorResp = logical.ErrorResponse(err.Error())
-		return
 	}
 
 	return

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -55,7 +55,7 @@ func (b *backend) getGenerationParams(
 		return
 	}
 
-	if err := certutil.ValidateKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits); err != nil {
+	if err := certutil.ValidateKeyTypeSignatureLength(role.KeyType, role.KeyBits, &role.SignatureBits); err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
 	}
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -261,13 +261,13 @@ the key_type.`,
 
 	fields["signature_bits"] = &framework.FieldSchema{
 		Type:    framework.TypeInt,
-		Default: -1,
+		Default: 0,
 		Description: `The number of bits to use in the signature
 algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384, and 512 for
-SHA-2-512. Defaults to -1 to automatically detect based on key length
+SHA-2-512. Defaults to 0 to automatically detect based on key length
 (SHA-2-256 for RSA keys, and matching the curve size for NIST P-Curves).`,
 		DisplayAttrs: &framework.DisplayAttributes{
-			Value: -1,
+			Value: 0,
 		},
 	}
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -261,13 +261,13 @@ the key_type.`,
 
 	fields["signature_bits"] = &framework.FieldSchema{
 		Type:    framework.TypeInt,
-		Default: 256,
+		Default: -1,
 		Description: `The number of bits to use in the signature
-algorithm. Defaults to 256 for SHA256.
-Set to 384 for SHA384 and 512 for SHA512.
-`,
+algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384, and 512 for
+SHA-2-512. Defaults to -1 to automatically detect based on key length
+(SHA-2-256 for RSA keys, and matching the curve size for NIST P-Curves).`,
 		DisplayAttrs: &framework.DisplayAttributes{
-			Value: 256,
+			Value: -1,
 		},
 	}
 

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -207,10 +207,11 @@ the key_type.`,
 
 			"signature_bits": &framework.FieldSchema{
 				Type:    framework.TypeInt,
-				Default: 256,
+				Default: -1,
 				Description: `The number of bits to use in the signature
-algorithm. Defaults to 256 for SHA256.
-Set to 384 for SHA384 and 512 for SHA512.`,
+algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384, and 512 for
+SHA-2-512. Defaults to -1 to automatically detect based on key length
+(SHA-2-256 for RSA keys, and matching the curve size for NIST P-Curves).`,
 			},
 
 			"key_usage": &framework.FieldSchema{

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -625,7 +625,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		), nil
 	}
 
-	if err := certutil.ValidateKeyTypeSignatureLength(entry.KeyType, entry.KeyBits, entry.SignatureBits); err != nil {
+	if err := certutil.ValidateKeyTypeSignatureLength(entry.KeyType, entry.KeyBits, &entry.SignatureBits); err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
 

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -207,10 +207,10 @@ the key_type.`,
 
 			"signature_bits": &framework.FieldSchema{
 				Type:    framework.TypeInt,
-				Default: -1,
+				Default: 0,
 				Description: `The number of bits to use in the signature
 algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384, and 512 for
-SHA-2-512. Defaults to -1 to automatically detect based on key length
+SHA-2-512. Defaults to 0 to automatically detect based on key length
 (SHA-2-256 for RSA keys, and matching the curve size for NIST P-Curves).`,
 			},
 

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -624,11 +624,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		), nil
 	}
 
-	if err := certutil.ValidateKeyTypeLength(entry.KeyType, entry.KeyBits); err != nil {
-		return logical.ErrorResponse(err.Error()), nil
-	}
-
-	if err := certutil.ValidateSignatureLength(entry.SignatureBits); err != nil {
+	if err := certutil.ValidateKeyTypeSignatureLength(entry.KeyType, entry.KeyBits, entry.SignatureBits); err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
 

--- a/changelog/12872.txt
+++ b/changelog/12872.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fixes around NIST P-curve signature hash length, default value for signature_bits changed to 0.
+```

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -546,14 +546,7 @@ func ValidateKeyTypeSignatureLength(keyType string, keyBits int, hashBits *int) 
 		// store policy section 5.1.2, enforce that NIST P-curves use a hash
 		// length corresponding to curve length. Note that ed25519 does not
 		// the "ec" key type.
-		expectedHashBits, present := expectedNISTPCurveHashBits[keyBits]
-		if !present {
-			// Because this is indexed over the NIST P-curve key length
-			// (224, 256, 384, 521) and it was validated above by the
-			// ValidKeyTypeLength(...) call, we panic here as this map
-			// is constructed at compile time to match.
-			panic(fmt.Sprintf("Unexpected NIST P-curve key length approved by ValidateKeyTypeLength: %d", keyBits))
-		}
+		expectedHashBits := expectedNISTPCurveHashBits[keyBits]
 
 		if expectedHashBits != *hashBits && *hashBits != -1 {
 			return fmt.Errorf("unsupported signature hash algorithm length (%d) for NIST P-%d", *hashBits, keyBits)
@@ -605,12 +598,8 @@ func ValidateKeyTypeLength(keyType string, keyBits int) error {
 			return fmt.Errorf("unsupported bit length for RSA key: %d", keyBits)
 		}
 	case "ec":
-		switch keyBits {
-		case 224:
-		case 256:
-		case 384:
-		case 521:
-		default:
+		_, present := expectedNISTPCurveHashBits[keyBits]
+		if !present {
 			return fmt.Errorf("unsupported bit length for EC key: %d", keyBits)
 		}
 	case "any", "ed25519":

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -548,12 +548,12 @@ func ValidateKeyTypeSignatureLength(keyType string, keyBits int, hashBits *int) 
 		// the "ec" key type.
 		expectedHashBits := expectedNISTPCurveHashBits[keyBits]
 
-		if expectedHashBits != *hashBits && *hashBits != -1 {
+		if expectedHashBits != *hashBits && *hashBits != 0 {
 			return fmt.Errorf("unsupported signature hash algorithm length (%d) for NIST P-%d", *hashBits, keyBits)
-		} else if *hashBits == -1 {
+		} else if *hashBits == 0 {
 			*hashBits = expectedHashBits
 		}
-	} else if keyType == "rsa" && *hashBits == -1 {
+	} else if keyType == "rsa" && *hashBits == 0 {
 		// To match previous behavior (and ignoring recommendations of hash
 		// size to match RSA key sizes), default to SHA-2-256.
 		*hashBits = 256
@@ -566,7 +566,7 @@ func ValidateKeyTypeSignatureLength(keyType string, keyBits int, hashBits *int) 
 	// Note that this check must come after we've selected a value for
 	// hashBits above, in the event it was left as the default, but we
 	// were allowed to update it.
-	if err := ValidateSignatureLength(*hashBits); err != nil || *hashBits == -1 {
+	if err := ValidateSignatureLength(*hashBits); err != nil || *hashBits == 0 {
 		return err
 	}
 


### PR DESCRIPTION
In #11006, it was mentioned that #11245 updated this behavior but didn't apply the size restrictions. We make the following changes (along side #11216, which I believe is still relevant):

 - Default to `0` signature bits, to perform auto detection if not otherwise specified. Presently this only does auto detection for ECDSA keys and leaves the default 256-bit hash function for all RSA key sizes. In the future, we could consider following NIST guidelines (and using 2048->256, 3072->384, 4096->512).
 - Introduce `ValidateKeyTypeSignatureLength` for cross Key/Signature validations (and which handles the actual autodetection)

Since #11216 lacks a changelog entry, ~~we should likely update #11245's changelog entry to match the new behavior and provide a unified changelog entry for the combined change (as it appears 11245 hasn't yet landed in a release yet)~~.

**Edit**: Added a changelog entry. 