### PR TITLE
clarify keytab gen process

### DIFF
--- a/website/content/docs/auth/kerberos.mdx
+++ b/website/content/docs/auth/kerberos.mdx
@@ -59,7 +59,7 @@ $ vault auth enable \
     kerberos
 ```
 
-- Create a `keytab` for the Kerberos plugin:
+- Create a `keytab` for the Kerberos plugin (this keytab is used by the Vault server itself, another keytab should be generated for login purposes):
 
 ```shell-session
 $ ktutil


### PR DESCRIPTION
Updating the docs to have a clear statement that two keytabs are needed, one for the Vault server itself, and one for the login purposes which belongs to the user which would like to login via Kerberos auth method.