### PR TITLE
change return in handler test to explicit nil

### DIFF
--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -903,7 +903,7 @@ func kvRequestWithRetry(t *testing.T, req func() (*api.Secret, error)) (*api.Sec
 			resp, err = req()
 
 			if err == nil {
-				return resp, err
+				return resp, nil
 			}
 
 			responseError := err.(*api.ResponseError)


### PR DESCRIPTION
In an OSS->ENT merge, I noticed the following semgrep error:

```
http/handler_test.go
severity:error rule:tools.semgrep.ci.return-nil: return nil err instead of nil value
```

This PR introduces a change to fix this error.