### PR TITLE
[Docs] Update MSSQL DB Engine API docs with new `contained_db` field

### DIFF
--- a/website/content/api-docs/secret/databases/mssql.mdx
+++ b/website/content/api-docs/secret/databases/mssql.mdx
@@ -47,8 +47,8 @@ has a number of parameters to further configure a connection.
 - `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how
   dynamic usernames are generated.
 
-- `contained_db` `(bool: false)` - If set, the connection being configured is to a [Contained Database](https://docs.microsoft.com/en-us/sql/relational-databases/databases/contained-databases?view=sql-server-ver15)
-  with contained users.
+- `contained_db` `(bool: false)` - If set, specifies that the connection being configured is to a
+  [Contained Database](https://docs.microsoft.com/en-us/sql/relational-databases/databases/contained-databases?view=sql-server-ver15), like AzureSQL.
 
 
 <details>


### PR DESCRIPTION
Adds documentation for the new `contained_db` field in the MSSQL DB Secret engine. This field lets Vault know that the MSSQL DB being connected to is a contained database.

For more context, see merged PR https://github.com/hashicorp/vault/pull/12839