### PR TITLE
Fix TestParseSockaddrTemplate to take into account CustomResponseHeaders

### DIFF
--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/vault/internalshared/configutil"
 )
 
-var DefaultCustomHeaders = map[string]map[string]string {
+var DefaultCustomHeaders = map[string]map[string]string{
 	"default": {
 		"Strict-Transport-Security": configutil.StrictTransportSecurity,
 	},
@@ -36,8 +36,8 @@ func testConfigRaftRetryJoin(t *testing.T) {
 		SharedConfig: &configutil.SharedConfig{
 			Listeners: []*configutil.Listener{
 				{
-					Type:    "tcp",
-					Address: "127.0.0.1:8200",
+					Type:                  "tcp",
+					Address:               "127.0.0.1:8200",
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
@@ -69,8 +69,8 @@ func testLoadConfigFile_topLevel(t *testing.T, entropy *configutil.Entropy) {
 		SharedConfig: &configutil.SharedConfig{
 			Listeners: []*configutil.Listener{
 				{
-					Type:    "tcp",
-					Address: "127.0.0.1:443",
+					Type:                  "tcp",
+					Address:               "127.0.0.1:443",
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
@@ -180,13 +180,13 @@ func testLoadConfigFile_json2(t *testing.T, entropy *configutil.Entropy) {
 		SharedConfig: &configutil.SharedConfig{
 			Listeners: []*configutil.Listener{
 				{
-					Type:    "tcp",
-					Address: "127.0.0.1:443",
+					Type:                  "tcp",
+					Address:               "127.0.0.1:443",
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 				{
-					Type:    "tcp",
-					Address: "127.0.0.1:444",
+					Type:                  "tcp",
+					Address:               "127.0.0.1:444",
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
@@ -344,8 +344,8 @@ func testLoadConfigFileIntegerAndBooleanValuesCommon(t *testing.T, path string) 
 		SharedConfig: &configutil.SharedConfig{
 			Listeners: []*configutil.Listener{
 				{
-					Type:    "tcp",
-					Address: "127.0.0.1:8200",
+					Type:                  "tcp",
+					Address:               "127.0.0.1:8200",
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
@@ -388,8 +388,8 @@ func testLoadConfigFile(t *testing.T) {
 		SharedConfig: &configutil.SharedConfig{
 			Listeners: []*configutil.Listener{
 				{
-					Type:    "tcp",
-					Address: "127.0.0.1:443",
+					Type:                  "tcp",
+					Address:               "127.0.0.1:443",
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
@@ -535,8 +535,8 @@ func testLoadConfigFile_json(t *testing.T) {
 		SharedConfig: &configutil.SharedConfig{
 			Listeners: []*configutil.Listener{
 				{
-					Type:    "tcp",
-					Address: "127.0.0.1:443",
+					Type:                  "tcp",
+					Address:               "127.0.0.1:443",
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
@@ -621,8 +621,8 @@ func testLoadConfigDir(t *testing.T) {
 
 			Listeners: []*configutil.Listener{
 				{
-					Type:    "tcp",
-					Address: "127.0.0.1:443",
+					Type:                  "tcp",
+					Address:               "127.0.0.1:443",
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
@@ -866,10 +866,11 @@ EOF
 		SharedConfig: &configutil.SharedConfig{
 			Listeners: []*configutil.Listener{
 				{
-					Type:           "tcp",
-					Address:        "127.0.0.1:443",
-					ClusterAddress: "127.0.0.1:8201",
-					TLSDisable:     true,
+					Type:                  "tcp",
+					Address:               "127.0.0.1:443",
+					ClusterAddress:        "127.0.0.1:8201",
+					TLSDisable:            true,
+					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
 		},
@@ -895,8 +896,8 @@ func testParseSeals(t *testing.T) {
 		SharedConfig: &configutil.SharedConfig{
 			Listeners: []*configutil.Listener{
 				{
-					Type:    "tcp",
-					Address: "127.0.0.1:443",
+					Type:                  "tcp",
+					Address:               "127.0.0.1:443",
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},
@@ -949,8 +950,8 @@ func testLoadConfigFileLeaseMetrics(t *testing.T) {
 		SharedConfig: &configutil.SharedConfig{
 			Listeners: []*configutil.Listener{
 				{
-					Type:    "tcp",
-					Address: "127.0.0.1:443",
+					Type:                  "tcp",
+					Address:               "127.0.0.1:443",
 					CustomResponseHeaders: DefaultCustomHeaders,
 				},
 			},


### PR DESCRIPTION
I neglected to merge in latest main to https://github.com/hashicorp/vault/pull/9109 before I merged the PR.