### PR TITLE
Backport 1.8.x: Adds missing unlock of RWMutex in OIDC delete key (#12916)

### DIFF
--- a/changelog/12916.txt
+++ b/changelog/12916.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity/token: Adds missing call to unlock mutex in key deletion error handling
+```

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -634,6 +634,7 @@ func (i *IdentityStore) pathOIDCDeleteKey(ctx context.Context, req *logical.Requ
 
 	roleNames, err := i.roleNamesReferencingTargetKeyName(ctx, req, targetKeyName)
 	if err != nil {
+		i.oidcLock.Unlock()
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR backports #12916 into `release/1.8.x`.

Steps:

1. `git checkout release/1.8.x`
2. `git checkout -b backport-pr-12916-1.8.x`
3. `git cherry-pick f154559`