### PR TITLE
Fix leak of restore worker go routines after an error

### DIFF
--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -668,8 +668,8 @@ func (m *ExpirationManager) Restore(errorFunc func()) (retErr error) {
 	broker := make(chan *lease)
 	quit := make(chan bool)
 	// Buffer these channels to prevent deadlocks
-	errs := make(chan error, len(existing))
-	result := make(chan struct{}, len(existing))
+	errs := make(chan error, leaseCount)
+	result := make(chan struct{}, leaseCount)
 
 	// Use a wait group
 	wg := &sync.WaitGroup{}


### PR DESCRIPTION
We were using the incorrect value to determine the buffer length of the err and result channels. 