### PR TITLE
Adds check to ensure authorization code can only be exchanged using the issuing provider

### DIFF
--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -130,6 +130,7 @@ type providerDiscovery struct {
 }
 
 type authCodeCacheEntry struct {
+	provider    string
 	clientID    string
 	entityID    string
 	redirectURI string
@@ -1557,6 +1558,7 @@ func (i *IdentityStore) pathOIDCAuthorize(ctx context.Context, req *logical.Requ
 
 	// Create the auth code cache entry
 	authCodeEntry := &authCodeCacheEntry{
+		provider:    name,
 		clientID:    clientID,
 		entityID:    entity.GetID(),
 		redirectURI: redirectURI,
@@ -1739,10 +1741,15 @@ func (i *IdentityStore) pathOIDCToken(ctx context.Context, req *logical.Request,
 
 	// Ensure the authorization code was issued to the authenticated client
 	if authCodeEntry.clientID != clientID {
-		return tokenResponse(nil, ErrTokenInvalidGrant, "authorization grant is invalid or expired")
+		return tokenResponse(nil, ErrTokenInvalidGrant, "authorization code was not issued to the client")
 	}
 
-	// Ensure that the redirect_uri parameter value is identical to the redirect_uri
+	// Ensure the authorization code was issued by the provider
+	if authCodeEntry.provider != name {
+		return tokenResponse(nil, ErrTokenInvalidGrant, "authorization code was not issued by the provider")
+	}
+
+	// Ensure the redirect_uri parameter value is identical to the redirect_uri
 	// parameter value that was included in the initial authorization request.
 	redirectURI := d.Get("redirect_uri").(string)
 	if redirectURI == "" {

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -23,6 +23,54 @@ import (
  in: vault/external_tests/identity/oidc_provider_test.go
 */
 
+const (
+	authCodeRegex = "[a-zA-Z0-9]{32}"
+)
+
+// Tests that an authorization code issued by one provider cannot be exchanged
+// for a token using a different provider that the client is allowed to use.
+func TestOIDC_Path_OIDC_Cross_Provider_Exchange(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+	s := new(logical.InmemStorage)
+
+	// Create the common OIDC configuration
+	entityID, _, clientID, clientSecret := setupOIDCCommon(t, c, s)
+
+	// Create a second provider
+	providerPath := "oidc/provider/test-provider-2"
+	req := testProviderReq(s, clientID)
+	req.Path = providerPath
+	resp, err := c.identityStore.HandleRequest(ctx, req)
+	require.NoError(t, err)
+
+	// Obtain an authorization code from the first provider
+	var authRes struct {
+		Code  string `json:"code"`
+		State string `json:"state"`
+	}
+	req = testAuthorizeReq(s, clientID)
+	req.EntityID = entityID
+	resp, err = c.identityStore.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Data["http_raw_body"].([]byte), &authRes))
+	require.Regexp(t, authCodeRegex, authRes.Code)
+	require.NotEmpty(t, authRes.State)
+
+	// Assert that the authorization code cannot be exchanged using the second provider
+	var tokenRes struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	req = testTokenReq(s, authRes.Code, clientID, clientSecret)
+	req.Path = providerPath + "/token"
+	resp, err = c.identityStore.HandleRequest(ctx, req)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Data["http_raw_body"].([]byte), &tokenRes))
+	require.Equal(t, ErrTokenInvalidGrant, tokenRes.Error)
+	require.Equal(t, "authorization code was not issued by the provider", tokenRes.ErrorDescription)
+}
+
 func TestOIDC_Path_OIDC_Token(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ctx := namespace.RootContext(nil)
@@ -282,7 +330,7 @@ func TestOIDC_Path_OIDC_Token(t *testing.T) {
 				State string `json:"state"`
 			}
 			require.NoError(t, json.Unmarshal(resp.Data["http_raw_body"].([]byte), &authRes))
-			require.Regexp(t, "[a-zA-Z0-9]{32}", authRes.Code)
+			require.Regexp(t, authCodeRegex, authRes.Code)
 			require.NotEmpty(t, authRes.State)
 
 			// Update the assignment
@@ -785,7 +833,7 @@ func TestOIDC_Path_OIDC_Authorize(t *testing.T) {
 			// Assert that we receive an authorization code (base62) and state
 			expectSuccess(t, resp, err)
 			require.Equal(t, http.StatusOK, resp.Data[logical.HTTPStatusCode].(int))
-			require.Regexp(t, "[a-zA-Z0-9]{32}", authRes.Code)
+			require.Regexp(t, authCodeRegex, authRes.Code)
 			require.NotEmpty(t, authRes.State)
 			require.Empty(t, authRes.Error)
 			require.Empty(t, authRes.ErrorDescription)


### PR DESCRIPTION
## Overview

This PR adds validation to the Token Endpoint to ensure that the given authorization code was issued by the provider being used for the token exchange. This ensures that authorization codes cannot be successfully exchanged between OIDC providers that a client is allowed to use (via `allowed_client_ids`). The entirely of the OIDC flow must be completed using the same provider that issued the authorization grant.

## Testing

I wrote a test to cover the bug being fixed in this PR. I also manually tested this to ensure that exchanging an authorization code between two providers results in an `invalid_grant` error code.