### PR TITLE
Deny access to UserInfo endpoint if client no longer allowed by provider

### DIFF
--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -1981,6 +1981,12 @@ func (i *IdentityStore) pathOIDCUserInfo(ctx context.Context, req *logical.Reque
 		return userInfoResponse(nil, ErrUserInfoAccessDenied, "identity entity not authorized by client assignment")
 	}
 
+	// Validate that the client is authorized to use the provider
+	if !strutil.StrListContains(provider.AllowedClientIDs, "*") &&
+		!strutil.StrListContains(provider.AllowedClientIDs, clientID) {
+		return userInfoResponse(nil, ErrUserInfoAccessDenied, "client is not authorized to use the provider")
+	}
+
 	claims := map[string]interface{}{
 		// The subject claim must always be in the response
 		"sub": entity.ID,


### PR DESCRIPTION
## Overview

This PR adds a check to the UserInfo Endpoint which will deny access if the client the access token was issued for is no longer supported by the provider (via `allowed_client_ids`). This provides the means to revoke client access to end-user information for a given provider that holds a valid access token.

## Testing

I wrote a test to cover the behavior introduced in this PR. I also manually tested that user info is no longer returned when the client is removed from the `allowed_client_ids` of the provider.

```sh
$ curl -s -X GET \
    --header "Authorization: Bearer $ACCESS_TOKEN" \
    http://127.0.0.1:8200/v1/identity/oidc/provider/my-provider/userinfo | jq
{
  "contact": {
    "email": "vault@hashicorp.com",
    "phone_number": "123-456-7890"
  },
  "groups": [
    "engineering"
  ],
  "sub": "7cb3fb73-5ea4-1ed7-c7d7-6c52ddd25ae9",
  "username": "end-user"
}

$ vault write identity/oidc/provider/my-provider \
    allowed_client_ids="" \                         
    scopes_supported="groups,user"                  
Success! Data written to: identity/oidc/provider/my-provider

$ curl -s -X GET \                                
    --header "Authorization: Bearer $ACCESS_TOKEN" \
    http://127.0.0.1:8200/v1/identity/oidc/provider/my-provider/userinfo | jq
{
  "error": "access_denied",
  "error_description": "client is not authorized to use the provider"
}
```