### PR TITLE
Update the expected error string in TestServer

### DIFF
--- a/command/server_test.go
+++ b/command/server_test.go
@@ -244,7 +244,7 @@ func TestServer(t *testing.T) {
 		{
 			"bad_listener_read_timeout_config",
 			testBaseHCL(t, badListenerReadTimeout) + inmemHCL,
-			"parsing \"34日\": invalid syntax",
+			"unknown unit \"\\xe6\\x97\\xa5\" in duration",
 			1,
 			"-test-server-config",
 		},


### PR DESCRIPTION
Update the error string expected from parsing unknown units in a
duration. The error changed in #12947.