### PR TITLE
just update api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.4.1-0.20210921171411-e86105e4986d
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.3.0
 	github.com/hashicorp/vault-testing-stepwise v0.1.2
-	github.com/hashicorp/vault/api v1.2.0
+	github.com/hashicorp/vault/api v1.3.0
 	github.com/hashicorp/vault/api/auth/approle v0.0.0-00010101000000-000000000000
 	github.com/hashicorp/vault/api/auth/userpass v0.0.0-00010101000000-000000000000
 	github.com/hashicorp/vault/sdk v0.3.0


### PR DESCRIPTION
`go get github.com/hashicorp/vault/api@1.3.0` rather than `go get -u github.com/hashicorp/vault/api`

i think this is probably what we want, rather than https://github.com/hashicorp/vault/pull/12953