### PR TITLE
Fixed parameter name to match AppRole code

### DIFF
--- a/website/content/api-docs/auth/approle.mdx
+++ b/website/content/api-docs/auth/approle.mdx
@@ -72,7 +72,7 @@ enabled while creating or updating a role.
 - `secret_id_ttl` `(string: "")` - Duration in either an integer number of
   seconds (`3600`) or an integer time unit (`60m`) after which any SecretID
   expires.
-- `enable_local_secret_ids` `(bool: false)` - If set, the secret IDs generated
+- `local_secret_ids` `(bool: false)` - If set, the secret IDs generated
   using this role will be cluster local. This can only be set during role
   creation and once set, it can't be reset later.
 


### PR DESCRIPTION
The documented [`enable_local_secret_ids` parameter](https://www.vaultproject.io/api-docs/auth/approle#enable_local_secret_ids) is wrong. It should read [`local_secret_id` to match the code](https://github.com/hashicorp/vault/blob/main/builtin/credential/approle/path_role.go#L165-L169).

A very small commit, but I would like to save fellow developpers an hour or two of debugging...