### PR TITLE
On bar chart selection replace search component with HTML

### DIFF
--- a/ui/app/components/clients/history.js
+++ b/ui/app/components/clients/history.js
@@ -8,6 +8,8 @@ export default class HistoryComponent extends Component {
 
   @tracked selectedNamespace = null;
 
+  @tracked barChartSelection = false;
+
   // Determine if we have client count data based on the current tab,
   // since model is slightly different for current month vs history api
   get hasClientData() {
@@ -52,7 +54,6 @@ export default class HistoryComponent extends Component {
         non_entity_tokens: d['counts']['non_entity_tokens'],
         distinct_entities: d['counts']['distinct_entities'],
         total: d['counts']['clients'],
-        id: d['namespace_id'],
       };
     });
   }
@@ -91,18 +92,6 @@ export default class HistoryComponent extends Component {
     }
     return defaultFileName;
   }
-  get getSearchSelectDefault() {
-    if (this.selectedNamespace) {
-      return [
-        {
-          id: this.selectedNamespace.namespace_path || 'root',
-          name: this.selectedNamespace.namespace_id,
-          searchText: '',
-        },
-      ];
-    }
-    return [];
-  }
 
   // Get the namespace by matching the path from the namespace list
   getNamespace(path) {
@@ -119,15 +108,17 @@ export default class HistoryComponent extends Component {
     // In case of search select component, value returned is an array
     if (Array.isArray(value)) {
       this.selectedNamespace = this.getNamespace(value[0]);
+      this.barChartSelection = false;
     } else if (typeof value === 'object') {
       // While D3 bar selection returns an object
       this.selectedNamespace = this.getNamespace(value.label);
-    } else {
-      this.selectedNamespace = null;
+      this.barChartSelection = true;
     }
   }
+
   @action
   resetData() {
+    this.barChartSelection = false;
     this.selectedNamespace = null;
   }
 }

--- a/ui/app/components/clients/history.js
+++ b/ui/app/components/clients/history.js
@@ -52,6 +52,7 @@ export default class HistoryComponent extends Component {
         non_entity_tokens: d['counts']['non_entity_tokens'],
         distinct_entities: d['counts']['distinct_entities'],
         total: d['counts']['clients'],
+        id: d['namespace_id'],
       };
     });
   }
@@ -90,6 +91,18 @@ export default class HistoryComponent extends Component {
     }
     return defaultFileName;
   }
+  get getSearchSelectDefault() {
+    if (this.selectedNamespace) {
+      return [
+        {
+          id: this.selectedNamespace.namespace_path || 'root',
+          name: this.selectedNamespace.namespace_id,
+          searchText: '',
+        },
+      ];
+    }
+    return [];
+  }
 
   // Get the namespace by matching the path from the namespace list
   getNamespace(path) {
@@ -112,5 +125,9 @@ export default class HistoryComponent extends Component {
     } else {
       this.selectedNamespace = null;
     }
+  }
+  @action
+  resetData() {
+    this.selectedNamespace = null;
   }
 }

--- a/ui/app/templates/components/clients/history.hbs
+++ b/ui/app/templates/components/clients/history.hbs
@@ -151,7 +151,22 @@
             <div class="column">
               <div class="card">
                   <div class="card-content">
-                    <SearchSelect
+                    {{#if (and this.barChartSelection this.selectedNamespace)}}
+                      <label class="title is-5 has-bottom-margin-m">Single namespace</label>
+                      <ul class="has-bottom-margin-l search-select-list">
+                        <li class="search-select-list-item">
+                          <div>
+                            {{or this.selectedNamespace.namespace_path 'root'}}
+                          </div>
+                          <div class="control">
+                            <button type="button" class="button is-ghost" {{action "resetData"}}>
+                            <Icon @glyph="trash" class="has-text-grey" />
+                          </button>
+                          </div>
+                        </li>
+                      </ul>
+                    {{else}}
+                      <SearchSelect
                         @id="namespaces"
                         @labelClass="title is-5"
                         @disallowNewItems={{true}}
@@ -160,26 +175,26 @@
                         @options={{or this.searchDataset []}}
                         @searchField="namespace_path"
                         @selectLimit={{1}}
-                        @inputValue={{ this.getSearchSelectDefault }}
                         />
-                        {{#if this.selectedNamespace}}
-                          <div class="columns">
-                              <div class="column">
-                                  <StatText @label="Active clients" @value={{this.selectedNamespace.counts.clients}} @size="l" /> 
-                              </div>
+                    {{/if}}
+                    {{#if this.selectedNamespace}}
+                      <div class="columns">
+                          <div class="column">
+                              <StatText @label="Active clients" @value={{this.selectedNamespace.counts.clients}} @size="l" /> 
                           </div>
-                          <div class="columns">
-                              <div class="column">
-                                  <StatText @label="Unique entities" @value={{this.selectedNamespace.counts.distinct_entities}} @size="m" />
-                              </div>
-                              <div class="column">
-                                  <StatText @label="Non-entity tokens" @value={{this.selectedNamespace.counts.non_entity_tokens}} @size="m" />
-                              </div>
+                      </div>
+                      <div class="columns">
+                          <div class="column">
+                              <StatText @label="Unique entities" @value={{this.selectedNamespace.counts.distinct_entities}} @size="m" />
                           </div>
-                        {{else}}
-                          <EmptyState @title="No namespace selected" 
-                              @message="Click on a namespace in the Top 10 chart or type its name in the box to view it's individual client counts." />
-                        {{/if}}
+                          <div class="column">
+                              <StatText @label="Non-entity tokens" @value={{this.selectedNamespace.counts.non_entity_tokens}} @size="m" />
+                          </div>
+                      </div>
+                    {{else}}
+                      <EmptyState @title="No namespace selected" 
+                          @message="Click on a namespace in the Top 10 chart or type its name in the box to view it's individual client counts." />
+                    {{/if}}
                   </div>
               </div>
             </div>

--- a/ui/app/templates/components/clients/history.hbs
+++ b/ui/app/templates/components/clients/history.hbs
@@ -132,7 +132,7 @@
           </div>
         </div>
         {{#if this.showGraphs}}
-          <div class="columns has-bottom-margin-m">
+          <div class="columns has-bottom-margin-m" {{did-update this.resetData}} {{did-insert this.resetData}}>
             <div class="column is-two-thirds" data-test-client-count-graph>
               <BarChart
                 @title="Top 10 Namespaces"
@@ -160,6 +160,7 @@
                         @options={{or this.searchDataset []}}
                         @searchField="namespace_path"
                         @selectLimit={{1}}
+                        @inputValue={{ this.getSearchSelectDefault }}
                         />
                         {{#if this.selectedNamespace}}
                           <div class="columns">

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -52,14 +52,6 @@ export default Component.extend({
     this._super(...arguments);
     this.set('selectedOptions', this.inputValue || []);
   },
-  didUpdateAttrs() {
-    this._super(...arguments);
-    let strInput = JSON.stringify(this.inputValue);
-    if (this._inputValue != strInput) {
-      this._inputValue = strInput;
-      this.set('selectedOptions', this.inputValue);
-    }
-  },
   didRender() {
     this._super(...arguments);
     let { oldOptions, options, selectedOptions } = this;
@@ -80,15 +72,13 @@ export default Component.extend({
     });
     this.set('allOptions', allOptions); // used by filter-wildcard helper
     let formattedOptions = this.selectedOptions.map(option => {
-      let matchingOption = options.findBy('id', typeof option === 'object' ? option.id : option);
-      if (matchingOption) {
-        options.removeObject(matchingOption);
-        return {
-          id: matchingOption.id,
-          name: matchingOption.name,
-          searchText: matchingOption.searchText,
-        };
-      }
+      let matchingOption = options.findBy('id', option);
+      options.removeObject(matchingOption);
+      return {
+        id: option,
+        name: matchingOption ? matchingOption.name : option,
+        searchText: matchingOption ? matchingOption.searchText : option,
+      };
     });
     this.set('selectedOptions', formattedOptions);
     if (this.options) {

--- a/ui/lib/core/addon/components/search-select.js
+++ b/ui/lib/core/addon/components/search-select.js
@@ -52,6 +52,14 @@ export default Component.extend({
     this._super(...arguments);
     this.set('selectedOptions', this.inputValue || []);
   },
+  didUpdateAttrs() {
+    this._super(...arguments);
+    let strInput = JSON.stringify(this.inputValue);
+    if (this._inputValue != strInput) {
+      this._inputValue = strInput;
+      this.set('selectedOptions', this.inputValue);
+    }
+  },
   didRender() {
     this._super(...arguments);
     let { oldOptions, options, selectedOptions } = this;
@@ -71,15 +79,16 @@ export default Component.extend({
       return option.id;
     });
     this.set('allOptions', allOptions); // used by filter-wildcard helper
-
     let formattedOptions = this.selectedOptions.map(option => {
-      let matchingOption = options.findBy('id', option);
-      options.removeObject(matchingOption);
-      return {
-        id: option,
-        name: matchingOption ? matchingOption.name : option,
-        searchText: matchingOption ? matchingOption.searchText : option,
-      };
+      let matchingOption = options.findBy('id', typeof option === 'object' ? option.id : option);
+      if (matchingOption) {
+        options.removeObject(matchingOption);
+        return {
+          id: matchingOption.id,
+          name: matchingOption.name,
+          searchText: matchingOption.searchText,
+        };
+      }
     });
     this.set('selectedOptions', formattedOptions);
     if (this.options) {


### PR DESCRIPTION
Maintaining state between search select component and bar chart component is tricky considering the time, so as a fallback solution, when user selects the namespace from chart, replace the search select component with custom HTML. Additionally clear out the namespace selection when new date is queried

https://user-images.githubusercontent.com/2932708/139498083-490eb793-d58f-42e9-911d-e4ab11ed7497.mov
