### PR TITLE
This adds the ability to use the Subject from the CSR instead of using the Common Name.

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -332,8 +332,8 @@ func validateNames(b *backend, data *inputBundle, names []string) string {
 				if data.role.AllowBareDomains &&
 					(strings.EqualFold(sanitizedName, currDomain) ||
 						(isEmail && strings.EqualFold(emailDomain, currDomain)) ||
-							// Handle the use case of AllowedDomain being an email address
-							(isEmail && strings.EqualFold(name, currDomain))) {
+						// Handle the use case of AllowedDomain being an email address
+						(isEmail && strings.EqualFold(name, currDomain))) {
 					valid = true
 					break
 				}
@@ -1015,19 +1015,24 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 			}
 		}
 	}
-
-	// Most of these could also be RemoveDuplicateStable, or even
-	// leave duplicates in, but OU is the one most likely to be duplicated.
-	subject := pkix.Name{
-		CommonName:         cn,
-		SerialNumber:       ridSerialNumber,
-		Country:            strutil.RemoveDuplicatesStable(data.role.Country, false),
-		Organization:       strutil.RemoveDuplicatesStable(data.role.Organization, false),
-		OrganizationalUnit: strutil.RemoveDuplicatesStable(data.role.OU, false),
-		Locality:           strutil.RemoveDuplicatesStable(data.role.Locality, false),
-		Province:           strutil.RemoveDuplicatesStable(data.role.Province, false),
-		StreetAddress:      strutil.RemoveDuplicatesStable(data.role.StreetAddress, false),
-		PostalCode:         strutil.RemoveDuplicatesStable(data.role.PostalCode, false),
+	// determine if we use the CSR Subject or build from role
+	var subject pkix.Name
+	if csr != nil && data.apiData.Get("use_subject_from_csr").(bool) {
+		subject = csr.Subject
+	} else {
+		// Most of these could also be RemoveDuplicateStable, or even
+		// leave duplicates in, but OU is the one most likely to be duplicated.
+		subject = pkix.Name{
+			CommonName:         cn,
+			SerialNumber:       ridSerialNumber,
+			Country:            strutil.RemoveDuplicatesStable(data.role.Country, false),
+			Organization:       strutil.RemoveDuplicatesStable(data.role.Organization, false),
+			OrganizationalUnit: strutil.RemoveDuplicatesStable(data.role.OU, false),
+			Locality:           strutil.RemoveDuplicatesStable(data.role.Locality, false),
+			Province:           strutil.RemoveDuplicatesStable(data.role.Province, false),
+			StreetAddress:      strutil.RemoveDuplicatesStable(data.role.StreetAddress, false),
+			PostalCode:         strutil.RemoveDuplicatesStable(data.role.PostalCode, false),
+		}
 	}
 
 	// Get the TTL and verify it against the max allowed

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -71,6 +71,17 @@ comma-delimited list.`,
 		},
 	}
 
+	fields["use_subject_from_csr"] = &framework.FieldSchema{
+		Type:    framework.TypeBool,
+		Default: false,
+		Description: `If true, the Subject from the CSR will be
+used instead of using Common Name.
+Defaults to false (CN is sourced normally).`,
+		DisplayAttrs: &framework.DisplayAttributes{
+			Name: "Use Subject From CSR",
+		},
+	}
+
 	return fields
 }
 

--- a/ui/app/models/pki-certificate-sign.js
+++ b/ui/app/models/pki-certificate-sign.js
@@ -16,7 +16,7 @@ export default Certificate.extend({
   }),
 
   fieldGroups: computed('newFields', 'signVerbatim', function() {
-    const options = { Options: ['altNames', 'ipSans', 'ttl', 'excludeCnFromSans', 'otherSans'] };
+    const options = { Options: ['altNames', 'ipSans', 'ttl', 'excludeCnFromSans', 'useSubjectFromCsr', 'otherSans'] };
     let groups = [
       {
         default: ['csr', 'commonName', 'format', 'signVerbatim'],

--- a/ui/app/models/pki-certificate.js
+++ b/ui/app/models/pki-certificate.js
@@ -78,6 +78,10 @@ export default Model.extend({
   }),
   privateKeyType: attr('string'),
   serialNumber: attr('string'),
+  useSubjectFromCsr: attr('boolean', {
+    label: 'Use Subject from CSR',
+    defaultValue: false,
+  }),
 
   fieldsToAttrs(fieldGroups) {
     return fieldToAttrs(this, fieldGroups);

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -1446,6 +1446,11 @@ root CA need be in a client's trust store.
   Useful if the CN is not a hostname or email address, but is instead some
   human-readable identifier.
 
+- `use_subject_from_csr` `(bool: false)` – If true, the `subject` from the CSR will be
+  used instead of using `cn`. It will still extract `cn` from the CSR `subject` and use 
+  that for validation. Useful if you want to have the `subject` as requested instead of
+  the `cn` being used.
+
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
Related Issue: https://github.com/hashicorp/vault/issues/12912

it intorduces a data api value `use_subject_from_csr` that is a boolean to use either the Subject from the supplied csr or uses the Cn supplied either in the CSR or data api.

Example:
Generate CSR:
```
openssl req -new -newkey rsa:2048 -nodes -out star_example_com.txt -keyout star_example_com.key -subj "/C=AU/ST=Victoria/L=Melbourne/O=DarkEdges/OU=IT/CN=*.example.com"
```
returns
[star_example_com.txt](https://github.com/hashicorp/vault/files/7445311/star_example_com.txt)

send to HashiCorp Vault endpoint
```
curl --location --request POST 'http://127.0.0.1:8200/v1/darkedges_intermediate/sign/darkedges' \
--header 'X-Vault-Token:  s.neGIz9jiflquFyvo6X1ULAVr' \
--header 'Content-Type: application/json' \
--data-raw '{
  "csr": "-----BEGIN CERTIFICATE REQUEST-----\nMIICsjCCAZoCAQAwbTELMAkGA1UEBhMCQVUxETAPBgNVBAgMCFZpY3RvcmlhMRIw\nEAYDVQQHDAlNZWxib3VybmUxEjAQBgNVBAoMCURhcmtFZGdlczELMAkGA1UECwwC\nSVQxFjAUBgNVBAMMDSouZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IB\nDwAwggEKAoIBAQDdZDWoMgCZTHx0w6XFMcNKuW2TagbfW+5kQM2VY2F3eCEMaGff\nCk2M2+pl0dS/BF+Z/gWJ85qLMUFHVD/jSMtednQwstwCjmBvwSiC2ZvXPpIOQt+K\nBoAVjdLpIYXae/Zm8yCti0NpB8Oz+rZNwUdCnwp6eu1iTjPnNUQwUO9B3hfp+v/2\nFf3nO7c6DQRx15iv8UHjU6xCZA6CjgilS8uORZ7jZpvhMOETqEWeFseMcr3iKmO6\nOa7Ct97ecGbTPcMRIjKY4Sw4boOJUf/pL7TZJNz5WlG7OpCE+CICTMdt4dO+OdfU\nyyfS+vhNDkMsE5F6wuXID7EGRzb1Tf4yVOCbAgMBAAGgADANBgkqhkiG9w0BAQsF\nAAOCAQEAZ5Sk5qq9ngjk5Q3IGcMEw4gad3f14H7S7VRh7TrTMbry20selPG/n2dB\n8qq7oe8wmgnUY51zZ5kKRwbjBKjf78vk4+qUaPuSVXAcyFgWSsE6yPzD/5iSPqTh\no/HYoPmXOPakjKI3wMTVWc+CvtTDU3apES6cnnIzd685RhZrj0pw0+XjNoI9aRqp\na4thckrIW4MQW2qPzkaW/ETtPknyMJQUe1PMuaZtezlXunh3QbFndH/upe6i+kHO\nhtqc9fZ/zxqcRof2m86nZMGSHDxPJ6iEwJJSkMlDkEXzqIg8lAhtQYRAX3Qo6Xo0\n7GBKNWEZKbBMihA6ImU9Fv4FyK5nvA==\n-----END CERTIFICATE REQUEST-----",
  "use_subject_from_csr": true
}'
```
returns
[star_example_com_response.txt](https://github.com/hashicorp/vault/files/7445305/star_example_com_response.txt)

extracted certificate: 
[star_example_com.cert.txt](https://github.com/hashicorp/vault/files/7445307/star_example_com.cert.txt)
gives
```
$ openssl x509 -in star_example_com.cert.txt -text -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            50:13:a5:fa:0b:1e:82:38:62:5f:f3:9d:87:ee:08:02:30:e0:cf:2c
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: O = IT, OU = DarkEdges, CN = DarkEdges Intermediate
        Validity
            Not Before: Oct 29 22:19:48 2021 GMT
            Not After : Sep 22 10:20:18 2022 GMT
        Subject: C = AU, ST = Victoria, L = Melbourne, O = DarkEdges, OU = IT, CN = *.example.com
```


