### PR TITLE
Update documentation to remove token_reviewer_jwt, removed from UI

### DIFF
--- a/ui/app/models/auth-config/kubernetes.js
+++ b/ui/app/models/auth-config/kubernetes.js
@@ -17,11 +17,6 @@ export default AuthConfig.extend({
     helpText: 'PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API',
   }),
 
-  tokenReviewerJwt: attr('string', {
-    helpText:
-      'A service account JWT used to access the TokenReview API to validate other JWTs during login. If not set the JWT used for login will be used to access the API',
-  }),
-
   pemKeys: attr({
     editType: 'stringArray',
   }),
@@ -32,7 +27,7 @@ export default AuthConfig.extend({
         default: ['kubernetesHost', 'kubernetesCaCert'],
       },
       {
-        'Kubernetes Options': ['tokenReviewerJwt', 'pemKeys'],
+        'Kubernetes Options': ['pemKeys'],
       },
     ];
     if (this.newFields) {

--- a/website/content/api-docs/auth/kubernetes.mdx
+++ b/website/content/api-docs/auth/kubernetes.mdx
@@ -29,9 +29,6 @@ access the Kubernetes API.
 
 - `kubernetes_host` `(string: <required>)` - Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.
 - `kubernetes_ca_cert` `(string: "")` - PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API. NOTE: Every line must end with a newline: `\n`
-- `token_reviewer_jwt` `(string: "")` - A service account JWT used to access the TokenReview
-  API to validate other JWTs during login. If not set,
-  the JWT submitted in the login payload will be used to access the Kubernetes TokenReview API.
 - `pem_keys` `(array: [])` - Optional list of PEM-formatted public keys or certificates
   used to verify the signatures of Kubernetes service account
   JWTs. If a certificate is given, its public key will be
@@ -44,10 +41,8 @@ access the Kubernetes API.
 
 ### Caveats
 
-If Vault is running in a Kubernetes Pod, the `kubernetes_ca_cert` and
-`token_reviewer_jwt` parameters will automatically default to the local CA cert
-(`/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`) and local service
-account JWT (`/var/run/secrets/kubernetes.io/serviceaccount/token`). This
+If Vault is running in a Kubernetes Pod, the `kubernetes_ca_cert` parameter will automatically default to the local CA cert
+(`/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`). This
 behavior may be disabled by setting `disable_local_ca_jwt` to `true`.
 
 When Vault is running in a non-Kubernetes environment, either

--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -72,7 +72,6 @@ management tool.
 
     ```text
     $ vault write auth/kubernetes/config \
-        token_reviewer_jwt="<your reviewer service account JWT>" \
         kubernetes_host=https://192.168.99.100:<your TCP port or blank for 443> \
         kubernetes_ca_cert=@ca.crt
     ```
@@ -134,7 +133,6 @@ This value is then used when configuring Kubernetes auth, e.g.:
 
 ```bash
 vault write auth/kubernetes/config \
-  token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443" \
   kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
   issuer="\"test-aks-cluster-dns-d6cbb78e.hcp.uksouth.azmk8s.io\""

--- a/website/content/docs/platform/k8s/helm/examples/kubernetes-auth.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/kubernetes-auth.mdx
@@ -38,7 +38,6 @@ Then run the following command to configure the Kubernetes Auth Method:
 
 ```bash
 vault write auth/kubernetes/config \
-   token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
    kubernetes_host=https://${KUBERNETES_PORT_443_TCP_ADDR}:443 \
    kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 ```


### PR DESCRIPTION
# Overview

Removing the usage of token_reviewer_jwt entry from Kubernetes's access UI. Removing from the documentation completely.

# Related Issues/Pull Requests
[Issue #12951](https://github.com/hashicorp/vault/issues/12951)
[PR #128](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/128)

# Contributor Checklist
[x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
The docs are altered in this PR
[x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
Vault keeps working as before, only difference will be approach of the validation of the sent-in JWT token. However, this PR aims towards removing this functionality. This PR however only focusses on UI changes.