### PR TITLE
docs: fix mongodb atlas username template doc

### DIFF
--- a/website/content/api-docs/secret/databases/mongodbatlas.mdx
+++ b/website/content/api-docs/secret/databases/mongodbatlas.mdx
@@ -26,6 +26,9 @@ has a number of parameters to further configure a connection.
 - `public_key` `(string: <required>)` – The Public Programmatic API Key used to authenticate with the MongoDB Atlas API.
 - `private_key` `(string: <required>)` - The Private Programmatic API Key used to connect with MongoDB Atlas API.
 - `project_id` `(string: <required>)` - The [Project ID](https://docs.atlas.mongodb.com/api/#project-id) the Database User should be created within.
+- `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how
+  dynamic usernames are generated.
+
 
 ### Sample Payload
 

--- a/website/content/api-docs/secret/mongodbatlas.mdx
+++ b/website/content/api-docs/secret/mongodbatlas.mdx
@@ -25,9 +25,6 @@ In addition to the parameters defined by the Secrets Engines Backend, this plugi
 
 - `public_key` `(string: <required>)` – The Public Programmatic API Key used to authenticate with the MongoDB Atlas API.
 - `private_key` `(string: <required>)` - The Private Programmatic API Key used to connect with MongoDB Atlas API.
-- `username_template` `(string)` - [Template](/docs/concepts/username-templating) describing how
-  dynamic usernames are generated.
-
 
 ### Sample Payload
 


### PR DESCRIPTION
Ensure MongoDB Atlas database secrets engine docs describe the username customization feature.

This PR fixes a change that was made which updated the wrong file: https://github.com/hashicorp/vault/pull/11943

