### PR TITLE
[VAULT-4034] Only cache non-nil values

### DIFF
--- a/changelog/12993.txt
+++ b/changelog/12993.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk/physical: Fix to only populate cache with non-nil values
+```

--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -184,8 +184,10 @@ func (c *Cache) Get(ctx context.Context, key string) (*Entry, error) {
 		return nil, err
 	}
 
-	// Cache the result
-	c.lru.Add(key, ent)
+	if ent != nil {
+		// Cache the result
+		c.lru.Add(key, ent)
+	}
 
 	return ent, nil
 }

--- a/sdk/physical/inmem/cache_test.go
+++ b/sdk/physical/inmem/cache_test.go
@@ -328,3 +328,45 @@ func TestCache_Refresh(t *testing.T) {
 		t.Fatalf("expected value baz, got %s", string(r.Value))
 	}
 }
+
+// TestCache_UpdateFromStorage fetches a nil value from cache, updates
+// the underlying storage and checks the cache value on a subsequent lookup
+func TestCache_UpdateFromStorage(t *testing.T) {
+	logger := logging.NewVaultLogger(log.Debug)
+
+	inm, err := NewInmem(nil, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := physical.NewCache(inm, 0, logger, &metrics.BlackholeSink{})
+	cache.SetEnabled(true)
+
+	ent := &physical.Entry{
+		Key:   "foo",
+		Value: []byte("bar"),
+	}
+
+	// Read should return nil
+	out, err := cache.Get(context.Background(), "foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("should not have key")
+	}
+
+	// Add data to the underlying backend
+	inm.Put(context.Background(), ent)
+
+	// Read should return data
+	out, err = cache.Get(context.Background(), "foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out == nil {
+		t.Fatalf("should have key")
+	}
+	if string(out.Value) != "bar" {
+		t.Fatalf("expected value bar, got %s", string(out.Value))
+	}
+}


### PR DESCRIPTION
- This PR updates the cache layer to only cache non-nil values.
- The issue fixed here, is if a nil value is persisted into the cache, it appears like there is a cache entry for the key, and so subsequent lookups will not update the cache value even if the underlying storage has been updated to have a non-nil value for that key
- The inmem backend is being used to test this change, and removing the change in cache.go will make the new test fail.
- The scripts attached in the jira ticket were also run against an ent binary with these changes ( as the scripts require perf standbys ) using this commit https://github.com/hashicorp/vault-enterprise/commit/435fd6f1e865abc17fae3c4fe7fc269d45a600e7, and the token lookup was verified to work when the perf standbys were brought back up.