### PR TITLE
[VAULT-4034] Only cache non-nil values (#12993)

### DIFF
--- a/changelog/12993.txt
+++ b/changelog/12993.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk/physical: Fix to only populate cache with non-nil values
+```

--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -184,8 +184,10 @@ func (c *Cache) Get(ctx context.Context, key string) (*Entry, error) {
 		return nil, err
 	}
 
-	// Cache the result
-	c.lru.Add(key, ent)
+	if ent != nil {
+		// Cache the result
+		c.lru.Add(key, ent)
+	}
 
 	return ent, nil
 }

--- a/sdk/physical/inmem/cache_test.go
+++ b/sdk/physical/inmem/cache_test.go
@@ -328,3 +328,45 @@ func TestCache_Refresh(t *testing.T) {
 		t.Fatalf("expected value baz, got %s", string(r.Value))
 	}
 }
+
+// TestCache_UpdateFromStorage fetches a nil value from cache, updates
+// the underlying storage and checks the cache value on a subsequent lookup
+func TestCache_UpdateFromStorage(t *testing.T) {
+	logger := logging.NewVaultLogger(log.Debug)
+
+	inm, err := NewInmem(nil, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := physical.NewCache(inm, 0, logger, &metrics.BlackholeSink{})
+	cache.SetEnabled(true)
+
+	ent := &physical.Entry{
+		Key:   "foo",
+		Value: []byte("bar"),
+	}
+
+	// Read should return nil
+	out, err := cache.Get(context.Background(), "foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != nil {
+		t.Fatalf("should not have key")
+	}
+
+	// Add data to the underlying backend
+	inm.Put(context.Background(), ent)
+
+	// Read should return data
+	out, err = cache.Get(context.Background(), "foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out == nil {
+		t.Fatalf("should have key")
+	}
+	if string(out.Value) != "bar" {
+		t.Fatalf("expected value bar, got %s", string(out.Value))
+	}
+}


### PR DESCRIPTION
1.8 backport for https://github.com/hashicorp/vault/pull/12993