### PR TITLE
feat(TokenHelper): loading from non-standard path

### DIFF
--- a/changelog/13009.txt
+++ b/changelog/13009.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+core/token: Added possibility to load `.vault-token` file from non-standard path (outside Home directory), specified by the environment variable `VAULT_CLI_TOKEN_FILE`.
+```

--- a/command/token/helper.go
+++ b/command/token/helper.go
@@ -12,3 +12,7 @@ type TokenHelper interface {
 	Get() (string, error)
 	Store(string) error
 }
+
+const (
+	EnvTokenFileLocation = "VAULT_CLI_TOKEN_FILE"
+)

--- a/command/token/helper_internal.go
+++ b/command/token/helper_internal.go
@@ -30,9 +30,18 @@ func NewInternalTokenHelper() (*InternalTokenHelper, error) {
 }
 
 // populateTokenPath figures out the token path using homedir to get the user's
-// home directory
+// home directory or based on the env variable
 func (i *InternalTokenHelper) populateTokenPath() {
-	i.tokenPath = filepath.Join(i.homeDir, ".vault-token")
+	filename := ".vault-token"
+	location := os.Getenv(EnvTokenFileLocation)
+
+	if len(location) == 0 {
+		location = filepath.Join(i.homeDir, location)
+	} else if !strings.Contains(location, filename) {
+		location = filepath.Join(location, filename)
+	}
+
+	i.tokenPath = location
 }
 
 func (i *InternalTokenHelper) Path() string {

--- a/command/token/helper_internal.go
+++ b/command/token/helper_internal.go
@@ -36,7 +36,7 @@ func (i *InternalTokenHelper) populateTokenPath() {
 	location := os.Getenv(EnvTokenFileLocation)
 
 	if len(location) == 0 {
-		location = filepath.Join(i.homeDir, location)
+		location = filepath.Join(i.homeDir, filename)
 	} else if !strings.Contains(location, filename) {
 		location = filepath.Join(location, filename)
 	}


### PR DESCRIPTION
Added possibility to load `.vault-token` file from non-standard path (outside Home directory), specified by the environment variable `VAULT_CLI_TOKEN_FILE`.

Resolves hashicorp/vault#12494