### PR TITLE
Secrets header version badge

### DIFF
--- a/changelog/13015.txt
+++ b/changelog/13015.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Display badge for all versions in secrets engine header
+```

--- a/ui/app/components/secret-list-header.js
+++ b/ui/app/components/secret-list-header.js
@@ -8,4 +8,8 @@ export default class SecretListHeader extends Component {
   backendCrumb = null;
   model = null;
   options = null;
+
+  get isKV() {
+    return ['kv', 'generic'].includes(this.args.model.engineType);
+  }
 }

--- a/ui/app/templates/components/secret-list-header.hbs
+++ b/ui/app/templates/components/secret-list-header.hbs
@@ -16,9 +16,11 @@
       <h1 class="title is-3">
         <Icon @glyph={{or @model.engineType "secrets"}} @size="xl" class="has-text-grey-light" />
         {{@model.id}}
-        <span class="tag">
-          Version {{or @model.options.version "1"}}
-        </span>
+        {{#if this.isKV}}
+          <span class="tag" data-test-kv-version-badge>
+            Version {{or @model.options.version "1"}}
+          </span>
+        {{/if}}
       </h1>
     </p.levelLeft>
   </PageHeader>

--- a/ui/app/templates/components/secret-list-header.hbs
+++ b/ui/app/templates/components/secret-list-header.hbs
@@ -16,11 +16,9 @@
       <h1 class="title is-3">
         <Icon @glyph={{or @model.engineType "secrets"}} @size="xl" class="has-text-grey-light" />
         {{@model.id}}
-        {{#if (eq @model.options.version 2)}}
-          <span class="tag">
-            Version 2
-          </span>
-        {{/if}}
+        <span class="tag">
+          Version {{or @model.options.version "1"}}
+        </span>
       </h1>
     </p.levelLeft>
   </PageHeader>

--- a/ui/mirage/factories/secret-engine.js
+++ b/ui/mirage/factories/secret-engine.js
@@ -1,0 +1,31 @@
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
+import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
+
+export default Factory.extend({
+  path: () => faker.system.directoryPath(),
+  description: () => faker.git.commitMessage(),
+  local: () => faker.datatype.boolean(),
+  sealWrap: () => faker.datatype.boolean(),
+  // set in afterCreate
+  accessor: null,
+  type: null,
+  options: null,
+
+  afterCreate(secretEngine) {
+    if (!secretEngine.type) {
+      const type = faker.random.arrayElement(supportedSecretBackends());
+      secretEngine.type = type;
+
+      if (!secretEngine.accessor) {
+        secretEngine.accessor = `type_${faker.git.shortSha()}`;
+      }
+    }
+
+    if (!secretEngine.options && ['generic', 'kv'].includes(secretEngine.type)) {
+      secretEngine.options = {
+        version: faker.random.arrayElement('1', '2'),
+      };
+    }
+  },
+});

--- a/ui/mirage/serializers/application.js
+++ b/ui/mirage/serializers/application.js
@@ -1,3 +1,7 @@
 import { JSONAPISerializer } from 'ember-cli-mirage';
 
-export default JSONAPISerializer.extend({});
+export default JSONAPISerializer.extend({
+  // typeKeyForModel(model) {
+  //   return model.modelName;
+  // }
+});

--- a/ui/mirage/serializers/application.js
+++ b/ui/mirage/serializers/application.js
@@ -1,7 +1,7 @@
 import { JSONAPISerializer } from 'ember-cli-mirage';
 
 export default JSONAPISerializer.extend({
-  // typeKeyForModel(model) {
-  //   return model.modelName;
-  // }
+  typeKeyForModel(model) {
+    return model.modelName;
+  },
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -208,6 +208,7 @@
     ]
   },
   "dependencies": {
+    "faker": "^5.5.3",
     "handlebars": "^4.3.0",
     "highlight.js": "^10.4.1",
     "jquery": "^3.5.0",

--- a/ui/tests/helpers/mirage-to-models.js
+++ b/ui/tests/helpers/mirage-to-models.js
@@ -1,0 +1,12 @@
+import { getContext } from '@ember/test-helpers';
+
+export default data => {
+  const context = getContext();
+  const store = context.owner.lookup('service:store');
+  const modelName = Array.isArray(data) ? data[0].modelName : data.modelName;
+  const json = context.server.serializerOrRegistry.serialize(data);
+  store.push(json);
+  return Array.isArray(data)
+    ? data.map(({ id }) => store.peekRecord(modelName, id))
+    : store.peekRecord(modelName, data.id);
+};

--- a/ui/tests/integration/components/secret-list-header-test.js
+++ b/ui/tests/integration/components/secret-list-header-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { supportedSecretBackends } from 'vault/helpers/supported-secret-backends';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import mirageToModels from 'vault/tests/helpers/mirage-to-models';
+
+module('Integration | Component | secret-list-header', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it should render version badge for kv and generic engine types', async function(assert) {
+    const backends = supportedSecretBackends();
+    assert.expect(backends.length);
+
+    this.server.post('/sys/capabilities-self', () => {});
+
+    for (let type of backends) {
+      const data = this.server.create('secret-engine', 2, { type });
+      this.model = mirageToModels(data);
+      await render(hbs`
+        <SecretListHeader
+          @model={{this.model}}
+        />
+      `);
+      const selector = '[data-test-kv-version-badge]';
+      if (['kv', 'generic'].includes(type)) {
+        assert
+          .dom(selector)
+          .hasText(
+            `Version ${this.model.options.version}`,
+            `Badge renders with correct version for ${type} engine type`
+          );
+      } else {
+        assert.dom(selector).doesNotExist(`Version badge does not render for ${type} engine type`);
+      }
+    }
+  });
+});

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9620,6 +9620,11 @@ fake-xml-http-request@^2.1.1:
   resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-2.1.2.tgz#f1786720cae50bbb46273035a0173414f3e85e74"
   integrity sha512-HaFMBi7r+oEC9iJNpc3bvcW7Z7iLmM26hPDmlb0mFwyANSsOQAtJxbdWsXITKOzZUyMYK0zYCv3h5yDj9TsiXg==
 
+faker@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
+  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
+
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"


### PR DESCRIPTION
Small change to always show the version badge in the secrets engine header.

![image](https://user-images.githubusercontent.com/24611656/139942697-de983152-dd46-4799-89a0-32ac273361b5.png)