### PR TITLE
bump to go 1.16.9

### DIFF
--- a/packages-oss.yml
+++ b/packages-oss.yml
@@ -38,7 +38,7 @@ inputs:
     PRODUCT_VERSION: 0.0.0-snapshot
 
     # GO_VERSION is the version of the Go toolchain to use to compile this package.
-    GO_VERSION: 1.16.7
+    GO_VERSION: 1.16.9
 
     # YARN_VERSION is the version of Yarn to install for the UI layer.
     YARN_VERSION: 1.19.1-1


### PR DESCRIPTION
This bumps Go from 1.16.7 to 1.16.9 to fix https://github.com/golang/go/issues/47801