### PR TITLE
Vault documentation: added new code samples

### DIFF
--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -195,3 +195,317 @@ for your server at `path/to/plugins`:
 ## API
 
 The Azure Auth Plugin has a full HTTP API. Please see the [API documentation](/api/auth/azure) for more details.
+
+## Code Example
+
+The following code snippet demonstrates the Azure auth method to authenticate
+with Vault.
+
+<CodeTabs heading="azure auth example">
+
+<CodeBlockConfig lineNumbers>
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	vault "github.com/hashicorp/vault/api"
+)
+
+type responseJson struct {
+ AccessToken  string `json:"access_token"`
+ RefreshToken string `json:"refresh_token"`
+ ExpiresIn    string `json:"expires_in"`
+ ExpiresOn    string `json:"expires_on"`
+ NotBefore    string `json:"not_before"`
+ Resource     string `json:"resource"`
+ TokenType    string `json:"token_type"`
+}
+
+type metadataJson struct {
+Compute computeJson `json:"compute"`
+}
+
+type computeJson struct {
+ VirtualMachineName string `json:"name"`
+ SubscriptionId     string `json:"subscriptionId"`
+ ResourceGroupName  string `json:"resourceGroupName"`
+}
+
+// Fetches a key-value secret (kv-v2) after authenticating to Vault via Azure authentication.
+// This example assumes you have a configured Azure AD Application.
+// Learn more about Azure authentication prerequisites: https://www.vaultproject.io/docs/auth/azure
+//
+// A role must first be created in Vault bound to the resource groups and subscription ids:
+// 	vault write auth/azure/role/dev-role \
+//     policies="dev-policy"
+//     bound_subscription_ids=$AZURE_SUBSCRIPTION_ID \
+//     bound_resource_groups=test-rg \
+//     ttl=24h
+func getSecretWithAzureAuth() (string, error) {
+ config := vault.DefaultConfig() // modify for more granular configuration
+
+ client, err := vault.NewClient(config)
+ if err != nil {
+  return "", fmt.Errorf("unable to initialize Vault client: %w", err)
+ }
+
+// Get AccessToken
+ jwtResp, err := getJWT()
+ if err != nil {
+  return "", fmt.Errorf("unable to get access token: %w", err)
+}
+
+// Get metadata for Azure instance
+ metadataRespJson, err := getMetadata()
+ if err != nil {
+  return "", fmt.Errorf("unable to get instance metadata: %w", err)
+}
+
+// log in to Vault's  auth method with signed JWT token
+ params := map[string]interface{}{
+  "role":                "dev-role-azure", // the name of the role in Vault w/ bound subscription id and resource group
+  "jwt":                 jwtResp,
+  "vm_name":             metadataRespJson.Compute.VirtualMachineName,
+  "subscription_id":     metadataRespJson.Compute.SubscriptionId,
+  "resource_group_name": metadataRespJson.Compute.ResourceGroupName,
+}
+
+// log in to Vault's Azure auth method
+ resp, err := client.Logical().Write("auth/azure/login", params) // confirm with your Vault administrator that "azure" is the correct mount name
+ if err != nil {
+  return "", fmt.Errorf("unable to log in with Azure auth: %w", err)
+}
+ if resp == nil || resp.Auth == nil || resp.Auth.ClientToken == "" {
+  return "", fmt.Errorf("login response did not return client token")
+}
+
+client.SetToken(resp.Auth.ClientToken)
+
+// get secret
+ secret, err := client.Logical().Read("kv-v2/data/creds")
+ if err != nil {
+ return "", fmt.Errorf("unable to read secret: %w", err)
+}
+
+data, ok := secret.Data["data"].(map[string]interface{})
+if !ok {
+return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
+}
+
+// data map can contain more than one key-value pair, in this case we're just grabbing one of them
+ key := "password"
+ value, ok := data[key].(string)
+ if !ok {
+ return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+}
+
+ return value, nil
+}
+
+// Retrieve instance metadata from Azure
+func getMetadata() (metadataJson, error) {
+ metadataEndpoint, err := url.Parse("http://169.254.169.254/metadata/instance")
+ if err != nil {
+  fmt.Println("Error creating URL: ", err)
+		return metadataJson{}, err
+	}
+
+	metadataParameters := metadataEndpoint.Query()
+	metadataParameters.Add("api-version", "2018-02-01")
+ metadataEndpoint.RawQuery = metadataParameters.Encode()
+ req, err := http.NewRequest("GET", metadataEndpoint.String(), nil)
+ if err != nil {
+  return metadataJson{}, fmt.Errorf("Error creating HTTP Request: %w", err)
+ }
+ req.Header.Add("Metadata", "true")
+
+ client := &http.Client{}
+ resp, err := client.Do(req)
+ if err != nil {
+  fmt.Println("Error calling token endpoint: ", err)
+		return metadataJson{}, fmt.Errorf("Error calling token endpoint: %w", err)
+ }
+
+ responseBytes, err := ioutil.ReadAll(resp.Body)
+ defer resp.Body.Close()
+ if err != nil {
+  return metadataJson{}, fmt.Errorf("Error reading response body: %w", err)
+ }
+
+// Unmarshal response body into metadata struct
+ var r metadataJson
+ err = json.Unmarshal(responseBytes, &r)
+ if err != nil {
+  return metadataJson{}, fmt.Errorf("Error unmarshalling the response: %w", err)
+ }
+
+ return r, nil
+}
+
+// Retrieves an access token from Azure MSI
+// Learn more here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token
+func getJWT() (string, error) {
+// Create HTTP request for a managed services for Azure resources token to access Azure Resource Manager
+ msiEndpoint, err := url.Parse("http://169.254.169.254/metadata/identity/oauth2/token")
+ if err != nil {
+  return "", fmt.Errorf("Error creating URL: %w", err)
+ }
+
+ msiParameters := msiEndpoint.Query()
+ msiParameters.Add("api-version", "2018-02-01")
+ msiParameters.Add("resource", "https://management.azure.com/")
+ msiEndpoint.RawQuery = msiParameters.Encode()
+
+ req, err := http.NewRequest("GET", msiEndpoint.String(), nil)
+ if err != nil {
+  return "", fmt.Errorf("Error creating HTTP request: %w", err)
+ }
+ req.Header.Add("Metadata", "true")
+
+// Call managed services for Azure resources token endpoint
+ client := &http.Client{}
+ resp, err := client.Do(req)
+ if err != nil {
+  return "", fmt.Errorf("Error calling token endpoint: %w", err)
+ }
+
+ responseBytes, err := ioutil.ReadAll(resp.Body)
+ defer resp.Body.Close()
+ if err != nil {
+  return "", fmt.Errorf("Error reading response body: %w", err)
+ }
+
+// Unmarshal response body into struct
+ var r responseJson
+ err = json.Unmarshal(responseBytes, &r)
+ if err != nil {
+  return "", fmt.Errorf("Error unmarshalling the response: %w", err)
+ }
+
+ return r.AccessToken, nil
+}
+```
+</CodeBlockConfig>
+
+<CodeBlockConfig lineNumbers>
+
+```cs
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+using VaultSharp;
+using VaultSharp.V1.AuthMethods;
+using VaultSharp.V1.AuthMethods.Azure;
+using VaultSharp.V1.Commons;
+
+namespace Examples
+{
+    public class AzureAuthExample
+    {
+        public class InstanceMetadata
+        {
+            public string name { get; set; }
+            public string resourceGroupName { get; set; }
+            public string subscriptionId { get; set; }
+        }
+
+        const string MetadataEndPoint = "http://169.254.169.254/metadata/instance?api-version=2017-08-01";
+        const string AccessTokenEndPoint = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/";
+
+        /// <summary>
+        /// Fetches a key-value secret (kv-v2) after authenticating to Vault via Azure authentication.
+        /// This example assumes you have a configured Azure AD Application.
+        /// Learn more about Azure authentication prerequisites: https://www.vaultproject.io/docs/auth/azure
+        ///
+        /// A role must first be created in Vault bound to the resource groups and subscription ids:
+        /// 	vault write auth/azure/role/dev-role \
+        ///     policies="dev-policy"
+        ///     bound_subscription_ids=$AZURE_SUBSCRIPTION_ID \
+        ///     bound_resource_groups=test-rg \
+        ///     ttl=24h
+        /// </summary>
+        public string GetSecretWithAzureAuth()
+        {
+            string vaultAddr = Environment.GetEnvironmentVariable("VAULT_ADDR");
+            if(String.IsNullOrEmpty(vaultAddr))
+            {
+                throw new System.ArgumentNullException("Vault Address");
+            }
+
+            string roleName = Environment.GetEnvironmentVariable("VAULT_ROLE");
+            if(String.IsNullOrEmpty(roleName))
+            {
+                throw new System.ArgumentNullException("Vault Role Name");
+            }
+
+            string jwt = GetJWT();
+            InstanceMetadata metadata = GetMetadata();
+
+            IAuthMethodInfo authMethod = new AzureAuthMethodInfo(roleName: roleName, jwt: jwt, subscriptionId: metadata.subscriptionId, resourceGroupName: metadata.resourceGroupName, virtualMachineName: metadata.name);
+            var vaultClientSettings = new VaultClientSettings(vaultAddr, authMethod);
+
+            IVaultClient vaultClient = new VaultClient(vaultClientSettings);
+
+            // We can retrieve the secret from the VaultClient object
+            Secret<SecretData> kv2Secret = null;
+            kv2Secret = vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(path: "/creds").Result;
+
+            var password = kv2Secret.Data.Data["password"];
+
+            return password.ToString();
+        }
+
+        /// <summary>
+        /// Query Azure Resource Manage for metadata about the Azure instance
+        /// </summary>
+        private InstanceMetadata GetMetadata()
+        {
+            HttpWebRequest metadataRequest = (HttpWebRequest)WebRequest.Create(MetadataEndPoint);
+            metadataRequest.Headers["Metadata"] = "true";
+            metadataRequest.Method = "GET";
+
+            HttpWebResponse metadataResponse = (HttpWebResponse)metadataRequest.GetResponse();
+
+            StreamReader streamResponse = new StreamReader(metadataResponse.GetResponseStream());
+            string stringResponse = streamResponse.ReadToEnd();
+            var resultsDict = JsonConvert.DeserializeObject<Dictionary<string, InstanceMetadata>>(stringResponse);
+
+            return resultsDict["compute"];
+        }
+
+        /// <summary>
+        /// Query Azure Resource Manager (ARM) for an access token
+        /// </summary>
+        private string GetJWT()
+        {
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(AccessTokenEndPoint);
+            request.Headers["Metadata"] = "true";
+            request.Method = "GET";
+
+            HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+
+            // Pipe response Stream to a StreamReader and extract access token
+            StreamReader streamResponse = new StreamReader(response.GetResponseStream());
+            string stringResponse = streamResponse.ReadToEnd();
+            var resultsDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(stringResponse);
+
+            return resultsDict["access_token"];
+        }
+    }
+}
+```
+
+</CodeBlockConfig>
+
+</CodeTabs>

--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -258,4 +258,83 @@ func getSecretWithKubernetesAuth() (string, error) {
 ```
 </CodeBlockConfig>
 
+<CodeBlockConfig lineNumbers>
+
+```cs
+using System;
+using System.IO;
+using VaultSharp;
+using VaultSharp.V1.AuthMethods;
+using VaultSharp.V1.AuthMethods.Kubernetes;
+using VaultSharp.V1.Commons;
+
+namespace Examples
+{
+    public class KubernetesAuthExample
+    {
+        const string DefaultTokenPath = "path/to/service-account-token";
+
+        // Fetches a key-value secret (kv-v2) after authenticating to Vault with a Kubernetes service account.
+        //
+        // As the client, all we need to do is pass along the JWT token representing our application's Kubernetes Service Account in our login request to Vault.
+        // This token is automatically mounted to your application's container by Kubernetes. Read more at https://www.vaultproject.io/docs/auth/kubernetes
+        //
+        // SETUP NOTES: If an operator has not already set up Kubernetes auth in Vault for you, then you must also first configure the Vault server with its own Service Account token to be able to communicate with the Kubernetes API
+        // so it can verify that the client's service-account token is valid. The service account that will be performing that verification needs the ClusterRole system:auth-delegator.
+        //
+        //    export TOKEN_REVIEW_JWT=$(kubectl get secret $TOKEN_REVIEWER_SECRET --output='go-template={{ .data.token }}' | base64 --decode)
+        //    export KUBE_HOST=$(kubectl config view --raw --minify --flatten --output='jsonpath={.clusters[].cluster.server}')
+        //    kubectl config view --raw --minify --flatten --output='jsonpath={.clusters[].cluster.certificate-authority-data}' | base64 --decode > path/to/kube_ca_cert
+        //
+        //    vault write auth/kubernetes/config \
+        //  	token_reviewer_jwt=${TOKEN_REVIEW_JWT} \
+        //      kubernetes_host=${KUBE_HOST} \
+        //      kubernetes_ca_cert=@path/to/kube_ca_cert \
+        //      issuer="kubernetes/serviceaccount"
+        //
+        // The "issuer" field is normally only required when running Kubernetes 1.21 or above, and may differ from the default value above:
+        // https://www.vaultproject.io/docs/auth/kubernetes#discovering-the-service-account-issuer.
+        //
+        // Finally, make sure to create a role in Vault bound to your pod's service account:
+        //
+        // 	vault write auth/kubernetes/role/dev-role-k8s \
+        //     	policies="dev-policy" \
+        //     	bound_service_account_names="my-app" \
+        //		bound_service_account_namespaces="default"
+        public string GetSecretWithK8s()
+        {
+            var vaultAddr = Environment.GetEnvironmentVariable("VAULT_ADDR");
+            if(String.IsNullOrEmpty(vaultAddr))
+            {
+                throw new System.ArgumentNullException("Vault Address");
+            }
+
+            var roleName = Environment.GetEnvironmentVariable("VAULT_ROLE");
+            if(String.IsNullOrEmpty(roleName))
+            {
+                throw new System.ArgumentNullException("Vault Role Name");
+            }
+
+            // Get the path to service account token or fall back on default path
+            string pathToToken = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("SA_TOKEN_PATH")) ? DefaultTokenPath : Environment.GetEnvironmentVariable("SA_TOKEN_PATH");
+            string jwt = File.ReadAllText(pathToToken);
+
+            IAuthMethodInfo authMethod = new KubernetesAuthMethodInfo(roleName, jwt);
+            var vaultClientSettings = new VaultClientSettings(vaultAddr, authMethod);
+
+            IVaultClient vaultClient = new VaultClient(vaultClientSettings);
+
+            // We can retrieve the secret after creating our VaultClient object
+            Secret<SecretData> kv2Secret = null;
+            kv2Secret = vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(path: "/creds").Result;
+
+            var password = kv2Secret.Data.Data["password"];
+
+            return password.ToString();
+        }
+    }
+}
+```
+</CodeBlockConfig>
+
 </CodeTabs>


### PR DESCRIPTION
Per the Asana tasks, new code samples were added to the Vault documentation:

- Code sample for Kubernetes Auth C#([Asana](https://app.asana.com/0/inbox/1200328878163177/1201304802144927/1201315003492963)) :mag: [Deploy Preview](https://vault-git-vault-docs-add-code-samples-hashicorp.vercel.app/docs/auth/kubernetes#code-example)

- Code sample for Azure Auth C#([Asana](https://app.asana.com/0/inbox/1200328878163177/1201304802144930/1201315003481102)) :mag: [Deploy Preview](https://vault-git-vault-docs-add-code-samples-hashicorp.vercel.app/docs/auth/azure#code-example)

- Code sample for Azure Auth Go([Asana](https://app.asana.com/0/inbox/1200328878163177/1201304802144936/1201314976656585)) :mag:[Deploy Preview](https://vault-git-vault-docs-add-code-samples-hashicorp.vercel.app/docs/auth/azure#code-example)
