### PR TITLE
UI/Truncate long secret names

### DIFF
--- a/changelog/13032.txt
+++ b/changelog/13032.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes long secret key names overlapping masked values
+```

--- a/ui/app/styles/components/info-table-row.scss
+++ b/ui/app/styles/components/info-table-row.scss
@@ -92,10 +92,15 @@
 }
 
 .label-overflow {
-  > span {
-    display: inline;
-  }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  // inline display necessary for nested elements so ellipsis shows
+  > div {
+    display: inline;
+  }
+  > div > span {
+    display: inline;
+  }
 }

--- a/ui/app/styles/components/info-table-row.scss
+++ b/ui/app/styles/components/info-table-row.scss
@@ -90,3 +90,12 @@
     padding-left: 0;
   }
 }
+
+.label-overflow {
+  > span {
+    display: inline;
+  }
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/ui/app/styles/components/tool-tip.scss
+++ b/ui/app/styles/components/tool-tip.scss
@@ -2,6 +2,7 @@
   font-size: $size-7;
   text-transform: none;
   margin: 8px 0px 0 -4px;
+
   .box {
     position: relative;
     color: $white;
@@ -10,6 +11,11 @@
     padding: 0.5rem;
     line-height: 1.4;
   }
+
+  .fit-content {
+    max-width: fit-content;
+  }
+
   @include css-top-arrow(8px, $grey, 1px, $grey-dark, 20px);
   &.ember-basic-dropdown-content--below.ember-basic-dropdown--transitioning-in {
     animation: drop-fade-above 0.15s;

--- a/ui/lib/core/addon/components/bar-chart.js
+++ b/ui/lib/core/addon/components/bar-chart.js
@@ -19,7 +19,7 @@
  * @param {string} title - title of the chart
  * @param {array} mapLegend - array of objects with key names 'key' and 'label' for the map legend
  * @param {object} dataset - dataset for the chart
- * @param {array} tooltipData - misc. information needed to display tooltip (i.e. total clients from query params)
+ * @param {any} tooltipData - misc. information needed to display tooltip (i.e. total clients from query params)
  * @param {string} [description] - description of the chart
  * @param {string} [labelKey=label] - labelKey is the key name in the dataset passed in that corresponds to the value labeling the y-axis
  * @param {function} [onClick] - takes function from parent and passes it to click event on data bars

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -42,6 +42,7 @@ export default Component.extend({
   tooltipText: '',
   isTooltipCopyable: false,
   defaultShown: '',
+  hasLabelOverflow: false,
 
   valueIsBoolean: computed('value', function() {
     return typeOf(this.value) === 'boolean';
@@ -70,6 +71,7 @@ export default Component.extend({
     const labelText = this.element.querySelector('.is-label');
     if (labelText.offsetWidth > labelDiv.offsetWidth) {
       labelDiv.classList.add('label-overflow');
+      this.set('hasLabelOverflow', true);
     }
   },
 });

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -63,4 +63,13 @@ export default Component.extend({
         return false;
     }
   }),
+
+  didInsertElement() {
+    this._super(...arguments);
+    const labelDiv = this.element.querySelector('div');
+    const labelText = this.element.querySelector('.is-label');
+    if (labelText.offsetWidth > labelDiv.offsetWidth) {
+      labelDiv.classList.add('label-overflow');
+    }
+  },
 });

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -42,7 +42,7 @@ export default Component.extend({
   tooltipText: '',
   isTooltipCopyable: false,
   defaultShown: '',
-  hasLabelOverflow: false,
+  hasLabelOverflow: false, // is calculated and set in didInsertElement
 
   valueIsBoolean: computed('value', function() {
     return typeOf(this.value) === 'boolean';

--- a/ui/lib/core/addon/components/info-table-row.js
+++ b/ui/lib/core/addon/components/info-table-row.js
@@ -69,9 +69,11 @@ export default Component.extend({
     this._super(...arguments);
     const labelDiv = this.element.querySelector('div');
     const labelText = this.element.querySelector('.is-label');
-    if (labelText.offsetWidth > labelDiv.offsetWidth) {
-      labelDiv.classList.add('label-overflow');
-      this.set('hasLabelOverflow', true);
+    if (labelDiv && labelText) {
+      if (labelText.offsetWidth > labelDiv.offsetWidth) {
+        labelDiv.classList.add('label-overflow');
+        this.set('hasLabelOverflow', true);
+      }
     }
   },
 });

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -1,7 +1,7 @@
 {{#if (or alwaysRender value)}}
   <div class="column is-one-quarter" data-test-label-div>
     {{#if label}}
-      <span class="is-label has-text-grey-dark" data-test-row-label="{{label}}">hi {{label}}</span>
+      <span class="is-label has-text-grey-dark" data-test-row-label="{{label}}">{{label}}</span>
       {{#if helperText}}
         <div> 
           <span class="is-label helper-text has-text-grey">{{helperText}}</span>

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -1,7 +1,7 @@
 {{#if (or alwaysRender value)}}
   <div class="column is-one-quarter" data-test-label-div>
     {{#if label}}
-      <span class="is-label has-text-grey-dark" data-test-row-label="{{label}}">{{label}}</span>
+      <span class="is-label has-text-grey-dark" data-test-row-label="{{label}}">hi {{label}}</span>
       {{#if helperText}}
         <div> 
           <span class="is-label helper-text has-text-grey">{{helperText}}</span>

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -3,7 +3,7 @@
     {{#if label}}
       {{#if hasLabelOverflow}}
         <ToolTip
-          @verticalPosition="above"
+          @verticalPosition="below"
           @horizontalPosition="left"
           as |T|>
           <T.trigger @tabindex=false>

--- a/ui/lib/core/addon/templates/components/info-table-row.hbs
+++ b/ui/lib/core/addon/templates/components/info-table-row.hbs
@@ -1,7 +1,23 @@
 {{#if (or alwaysRender value)}}
   <div class="column is-one-quarter" data-test-label-div>
     {{#if label}}
-      <span class="is-label has-text-grey-dark" data-test-row-label="{{label}}">{{label}}</span>
+      {{#if hasLabelOverflow}}
+        <ToolTip
+          @verticalPosition="above"
+          @horizontalPosition="left"
+          as |T|>
+          <T.trigger @tabindex=false>
+            <span class="is-label has-text-grey-dark" data-test-row-label="{{label}}">{{label}}</span>  
+          </T.trigger>
+          <T.content @class="tool-tip">
+            <div class="box fit-content">
+              {{label}}
+            </div>
+          </T.content>
+        </ToolTip>
+      {{else}}
+        <span class="is-label has-text-grey-dark" data-test-row-label="{{label}}">{{label}}</span>
+      {{/if}}
       {{#if helperText}}
         <div> 
           <span class="is-label helper-text has-text-grey">{{helperText}}</span>

--- a/ui/lib/core/stories/info-table-row.md
+++ b/ui/lib/core/stories/info-table-row.md
@@ -19,6 +19,7 @@ that the value breaks under the label on smaller viewports.
 | [backend] | <code>String</code> |  | Passed through to InfoTableItemArray. To specify secrets backend to point link to  Ex: transformation |
 | [viewAll] | <code>String</code> |  | Passed through to InfoTableItemArray. Specify the word at the end of the link View all. |
 | [tooltipText] | <code>String</code> |  | Text if a tooltip should display over the value. |
+| [isTooltipCopyable] | <code>Boolean</code> |  | Allows tooltip click to copy |
 | [defaultShown] | <code>String</code> |  | Text that renders as value if alwaysRender=true. Eg. "Vault default" |
 
 **Example**

--- a/ui/lib/core/stories/info-table-row.stories.js
+++ b/ui/lib/core/stories/info-table-row.stories.js
@@ -16,14 +16,18 @@ storiesOf('InfoTable/InfoTableRow', module)
         @label={{label}} 
         @helperText={{helperText}} 
         @alwaysRender={{alwaysRender}} 
-        @tooltipText={{tooltipText}} />
+        @defaultShown={{defaultShown}} 
+        @tooltipText={{tooltipText}}
+        @isTooltipCopyable={{isTooltipCopyable}} />
     `,
       context: {
         label: text('Label', 'TTL'),
         value: text('Value', '30m (hover to see the tooltip!)'),
         helperText: text('helperText', 'This is helperText - for a short description'),
         alwaysRender: boolean('Always render?', false),
+        defaultShown: text('Default value', 'Some default value'),
         tooltipText: text('tooltipText', 'This is tooltipText'),
+        isTooltipCopyable: boolean('Allow tooltip to be copied', true),
       },
     }),
     { notes }


### PR DESCRIPTION
Fixes overflow problem of long secret key values mentioned in #12962

**Previous behavior:**
![image](https://user-images.githubusercontent.com/68122737/140163041-ce9857ee-e3db-441a-a6bf-a9823af7cdc9.png)



**Current behavior:**

![truncate-long-labels](https://user-images.githubusercontent.com/68122737/140162629-3c7db701-b96d-4aaa-8088-e44958cb7c33.gif)
