### PR TITLE
UI: Show detailed error response on failed secret-engine list call

### DIFF
--- a/ui/app/adapters/secret-engine.js
+++ b/ui/app/adapters/secret-engine.js
@@ -36,9 +36,12 @@ export default ApplicationAdapter.extend({
         mountModel.data = { ...mountModel.data, ...configModel.data };
       }
     } catch (error) {
+      // no path means this was an error on listing
+      if (!query.path) {
+        throw error;
+      }
       // control groups will throw a 403 permission denied error. If this happens return the mountModel
       // error is handled on routing
-      console.log(error);
     }
     return mountModel;
   },

--- a/ui/app/adapters/secret-engine.js
+++ b/ui/app/adapters/secret-engine.js
@@ -31,7 +31,7 @@ export default ApplicationAdapter.extend({
       mountModel = await this.ajax(this.internalURL(query.path), 'GET');
       // if kv2 then add the config data to the mountModel
       // version comes in as a string
-      if (mountModel.data.type === 'kv' && mountModel.data.options.version === '2') {
+      if (mountModel?.data?.type === 'kv' && mountModel?.data?.options?.version === '2') {
         configModel = await this.ajax(this.urlForConfig(query.path), 'GET');
         mountModel.data = { ...mountModel.data, ...configModel.data };
       }


### PR DESCRIPTION
Fixes small bug introduced in #12498 where the secrets list page looks like this when user is logged in with a token that is then revoked:

**BEFORE**
<img width="1336" alt="Screen Shot 2021-11-03 at 2 54 08 PM" src="https://user-images.githubusercontent.com/82459713/140183065-3b012d6e-3453-48dc-ad0c-4e961d31e3b5.png">

**WITH THIS FIX**
<img width="1336" alt="Screen Shot 2021-11-03 at 2 54 20 PM" src="https://user-images.githubusercontent.com/82459713/140183070-d1fb4f7a-4f72-48f1-88fa-4ae575a1a9d0.png">
