### PR TITLE
PGP key list input fix 

### DIFF
--- a/changelog/13038.txt
+++ b/changelog/13038.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes issue with the number of PGP Key inputs not matching the key shares number in the initialization form on change
+```

--- a/ui/app/components/pgp-list.js
+++ b/ui/app/components/pgp-list.js
@@ -31,10 +31,7 @@ export default Component.extend({
       list = this.listData.slice(0, this.listLength);
     } else if (this.listLength > this.listData.length) {
       // add to the current list by creating a new list and copying over existing list
-      list = this.newList(this.listLength);
-      if (this.listData.length) {
-        list.splice(0, this.listData.length, ...this.listData);
-      }
+      list = [...this.listData, ...this.newList(this.listLength - this.listData.length)];
     }
     this.set('listData', list || this.listData);
     this.onDataUpdate((list || this.listData).compact().map(k => k.value));

--- a/ui/tests/integration/components/pgp-list-test.js
+++ b/ui/tests/integration/components/pgp-list-test.js
@@ -128,4 +128,26 @@ module('Integration | Component | pgp list', function(hooks) {
       'lengthening the list with an array with one base64 converted files'
     );
   });
+
+  test('it should render correct amount of file components on listLength change', async function(assert) {
+    assert.expect(4);
+
+    this.set('listLength', null);
+
+    await render(hbs`
+      <PgpList
+        @listLength={{this.listLength}}
+      />
+    `);
+    [1, 5, 3, 0].forEach(count => {
+      this.set('listLength', count);
+      if (count) {
+        assert
+          .dom('[data-test-pgp-file]')
+          .exists({ count }, `Correct number of file inputs render when listLength is updated to ${count}`);
+      } else {
+        assert.dom('[data-test-empty-text]').exists('Placeholder renders when list length is zero');
+      }
+    });
+  });
 });


### PR DESCRIPTION
Originally reported https://github.com/hashicorp/vault/issues/12056

This fix addresses an issue where the number of PGP Key inputs was not matching the key shares number in the initialization form on change.

![image](https://user-images.githubusercontent.com/24611656/140195208-f111783b-85de-4012-952a-fac2f2e6ae0a.png)

