### PR TITLE
Support configuring Vault agent TLS min/max version

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
@@ -267,18 +268,21 @@ func TestClientEnvSettings(t *testing.T) {
 	oldClientCert := os.Getenv(EnvVaultClientCert)
 	oldClientKey := os.Getenv(EnvVaultClientKey)
 	oldSkipVerify := os.Getenv(EnvVaultSkipVerify)
+	oldTLSMinVersion := os.Getenv(EnvVaultTLSMinVersion)
 	oldMaxRetries := os.Getenv(EnvVaultMaxRetries)
 	os.Setenv(EnvVaultCACert, cwd+"/test-fixtures/keys/cert.pem")
 	os.Setenv(EnvVaultCAPath, cwd+"/test-fixtures/keys")
 	os.Setenv(EnvVaultClientCert, cwd+"/test-fixtures/keys/cert.pem")
 	os.Setenv(EnvVaultClientKey, cwd+"/test-fixtures/keys/key.pem")
 	os.Setenv(EnvVaultSkipVerify, "true")
+	os.Setenv(EnvVaultTLSMinVersion, "tls13")
 	os.Setenv(EnvVaultMaxRetries, "5")
 	defer os.Setenv(EnvVaultCACert, oldCACert)
 	defer os.Setenv(EnvVaultCAPath, oldCAPath)
 	defer os.Setenv(EnvVaultClientCert, oldClientCert)
 	defer os.Setenv(EnvVaultClientKey, oldClientKey)
 	defer os.Setenv(EnvVaultSkipVerify, oldSkipVerify)
+	defer os.Setenv(EnvVaultTLSMinVersion, oldTLSMinVersion)
 	defer os.Setenv(EnvVaultMaxRetries, oldMaxRetries)
 
 	config := DefaultConfig()
@@ -295,6 +299,9 @@ func TestClientEnvSettings(t *testing.T) {
 	}
 	if tlsConfig.InsecureSkipVerify != true {
 		t.Fatalf("bad: %v", tlsConfig.InsecureSkipVerify)
+	}
+	if tlsConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("bad: expect setup TLS min version")
 	}
 }
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1
+	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/vault/sdk v0.3.0
 	github.com/mitchellh/mapstructure v1.4.2

--- a/api/go.sum
+++ b/api/go.sum
@@ -117,6 +117,7 @@ github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3
 github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1 h1:nd0HIW15E6FG1MsnArYaHfuw9C2zgzM8LxkG5Ty/788=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1/go.mod h1:gKOamz3EwoIoJq7mlMIRBpVTAUn8qPCrEclOKKWhD3U=
+github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1 h1:Yc026VyMyIpq1UWRnakHRG01U8fJm+nEfEmjoAb00n8=
 github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1/go.mod h1:l8slYwnJA26yBz+ErHpp2IRCLr0vuOMGBORIz4rRiAs=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=

--- a/command/agent.go
+++ b/command/agent.go
@@ -280,6 +280,13 @@ func (c *AgentCommand) Run(args []string) int {
 		EnvVar:  api.EnvVaultClientKey,
 	})
 	config.Vault.ClientKey = c.flagClientKey
+	c.setStringFlag(f, config.Vault.TLSMinVersion, &StringVar{
+		Name:    flagNameTLSMinVersion,
+		Target:  &c.flagTLSMinVersion,
+		Default: "tls12",
+		EnvVar:  api.EnvVaultTLSMinVersion,
+	})
+	config.Vault.TLSMinVersion = c.flagTLSMinVersion
 	c.setBoolFlag(f, config.Vault.TLSSkipVerify, &BoolVar{
 		Name:    flagNameTLSSkipVerify,
 		Target:  &c.flagTLSSkipVerify,

--- a/command/agent/config/config.go
+++ b/command/agent/config/config.go
@@ -58,6 +58,7 @@ type Vault struct {
 	Address          string      `hcl:"address"`
 	CACert           string      `hcl:"ca_cert"`
 	CAPath           string      `hcl:"ca_path"`
+	TLSMinVersion    string      `hcl:"tls_min_version"`
 	TLSSkipVerify    bool        `hcl:"-"`
 	TLSSkipVerifyRaw interface{} `hcl:"tls_skip_verify"`
 	ClientCert       string      `hcl:"client_cert"`

--- a/command/agent/config/config_test.go
+++ b/command/agent/config/config_test.go
@@ -990,3 +990,28 @@ func TestLoadConfigFile_EnforceConsistency(t *testing.T) {
 		t.Fatal(diff)
 	}
 }
+
+func TestLoadConfigFile_Vault_TLS(t *testing.T) {
+	config, err := LoadConfig("./test-fixtures/config-vault-tls.hcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &Config{
+		SharedConfig: &configutil.SharedConfig{
+			PidFile: "./pidfile",
+		},
+		Vault: &Vault{
+			Address:       "http://127.0.0.1:1111",
+			TLSMinVersion: "tls13",
+			Retry: &Retry{
+				NumRetries: 5,
+			},
+		},
+	}
+
+	config.Prune()
+	if diff := deep.Equal(config, expected); diff != nil {
+		t.Fatal(diff)
+	}
+}

--- a/command/agent/config/test-fixtures/config-vault-tls.hcl
+++ b/command/agent/config/test-fixtures/config-vault-tls.hcl
@@ -1,0 +1,9 @@
+pid_file = "./pidfile"
+
+vault {
+  address = "http://127.0.0.1:1111"
+  tls_min_version = "tls13"
+  retry {
+    num_retries = 5
+  }
+}

--- a/command/base.go
+++ b/command/base.go
@@ -47,6 +47,7 @@ type BaseCommand struct {
 	flagNamespace      string
 	flagNS             string
 	flagPolicyOverride bool
+	flagTLSMinVersion  string
 	flagTLSServerName  string
 	flagTLSSkipVerify  bool
 	flagWrapTTL        time.Duration
@@ -92,12 +93,13 @@ func (c *BaseCommand) Client() (*api.Client, error) {
 
 	// If we need custom TLS configuration, then set it
 	if c.flagCACert != "" || c.flagCAPath != "" || c.flagClientCert != "" ||
-		c.flagClientKey != "" || c.flagTLSServerName != "" || c.flagTLSSkipVerify {
+		c.flagClientKey != "" || c.flagTLSServerName != "" || c.flagTLSMinVersion != "" || c.flagTLSSkipVerify {
 		t := &api.TLSConfig{
 			CACert:        c.flagCACert,
 			CAPath:        c.flagCAPath,
 			ClientCert:    c.flagClientCert,
 			ClientKey:     c.flagClientKey,
+			TLSMinVersion: c.flagTLSMinVersion,
 			TLSServerName: c.flagTLSServerName,
 			Insecure:      c.flagTLSSkipVerify,
 		}

--- a/command/commands.go
+++ b/command/commands.go
@@ -96,8 +96,9 @@ const (
 	// flagNameClientCert is the flag used in the base command to read in the
 	// client cert
 	flagNameClientCert = "client-cert"
-	// flagNameTLSSkipVerify is the flag used in the base command to read in
-	// the option to ignore TLS certificate verification.
+	// flagNameTLSMinVersion specifies the maximum supported version of TLS.
+	flagNameTLSMinVersion = "tls-min-version"
+	// flagNameTLSSkipVerify specifies the minimum supported version of TLS.
 	flagNameTLSSkipVerify = "tls-skip-verify"
 	// flagTLSServerName is the flag used in the base command to read in
 	// the TLS server name.


### PR DESCRIPTION
It is useful to some environment has limited TLS version and test different TLS version performance.