### PR TITLE
Allowing Unwrap w/ Newline files

### DIFF
--- a/api/logical.go
+++ b/api/logical.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -235,12 +236,13 @@ func (c *Logical) DeleteWithData(path string, data map[string][]string) (*Secret
 
 func (c *Logical) Unwrap(wrappingToken string) (*Secret, error) {
 	var data map[string]interface{}
+	wt := strings.TrimSuffix(string(wrappingToken), "\n")
 	if wrappingToken != "" {
 		if c.c.Token() == "" {
-			c.c.SetToken(wrappingToken)
+			c.c.SetToken(wt)
 		} else if wrappingToken != c.c.Token() {
 			data = map[string]interface{}{
-				"token": wrappingToken,
+				"token": wt,
 			}
 		}
 	}

--- a/api/logical.go
+++ b/api/logical.go
@@ -236,7 +236,7 @@ func (c *Logical) DeleteWithData(path string, data map[string][]string) (*Secret
 
 func (c *Logical) Unwrap(wrappingToken string) (*Secret, error) {
 	var data map[string]interface{}
-	wt := strings.TrimSuffix(string(wrappingToken), "\n")
+	wt := strings.TrimSpace(wrappingToken)
 	if wrappingToken != "" {
 		if c.c.Token() == "" {
 			c.c.SetToken(wt)

--- a/changelog/13044.txt
+++ b/changelog/13044.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+trims newline character from wrapping token in UnWrap Go SDK
+```

--- a/changelog/13044.txt
+++ b/changelog/13044.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-trims newline character from wrapping token in UnWrap Go SDK
+api: Trim newline character from wrapping token in logical.Unwrap from the api package
 ```


### PR DESCRIPTION
- Adding a fix in the unwrap function to handle newline characters in files so users don't get an error from newline characters

- Tested with local Vault server