### PR TITLE
KV bug fix on delete menu

### DIFF
--- a/ui/app/templates/components/secret-delete-menu.hbs
+++ b/ui/app/templates/components/secret-delete-menu.hbs
@@ -27,7 +27,7 @@
       <button
         type="button"
         class="toolbar-link"
-        {{on "click" (fn (mut this.showDeleteModal) false)}}
+        {{on "click" (fn (mut this.showDeleteModal) true)}}
         data-test-delete-open-modal
       >
         {{if (and (not @modelForData.deleted) (not @modelForData.destroyed)) "Delete" "Destroy"}}

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -641,6 +641,7 @@ module('Acceptance | secrets/secret/create', function(hooks) {
     await settled();
     await click('[data-test-delete-open-modal]');
     await settled();
+    assert.dom('.modal.is-active').exists('Modal appears');
     assert.dom('[data-test-delete-modal="destroy-all-versions"]').exists(); // we have a if Ember.testing catch in the delete action because it breaks things in testing
     // we can however destroy the versions
     await click('#destroy-all-versions');


### PR DESCRIPTION
Small fix. Jordan had correctly fixed the syntax but the parameter passed should have been true (my error). This was preventing the delete modal from showing.

Also, I made sure on tests that this was caught. Modals are tough because they are on the dom regardless of if they're open. I made this mistake and needed to check if the modal was active. I have corrected for this.

No changelog as this was a regression bug made recently by this [PR](https://github.com/hashicorp/vault/pull/12895). 

