### PR TITLE
UI/Adds pagination to auth methods list

### DIFF
--- a/changelog/13054.txt
+++ b/changelog/13054.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Adds pagination to auth methods list view
+```

--- a/ui/app/templates/components/generated-item-list.hbs
+++ b/ui/app/templates/components/generated-item-list.hbs
@@ -52,7 +52,7 @@
     </ToolbarLink>
   </ToolbarActions>
 </Toolbar>
-<ListView @items={{model}} @itemNoun={{itemType}} as |list|>
+<ListView @items={{model}} @itemNoun={{itemType}} @paginationRouteName="vault.cluster.access.method.item.list" as |list|>
   {{#if list.empty}}
     <list.empty @title="No {{pluralize itemType}} yet"
       @message="A list of {{pluralize itemType}} will be listed here. Create your first {{itemType}} to get started.">


### PR DESCRIPTION
Fix for #12962 - when lots of auth method groups or users created there is no way to navigate to view the full list.

![auth-method-error](https://user-images.githubusercontent.com/68122737/140402957-0c378837-5dcf-489e-978a-1766ea1b3015.gif)


**With pagination:** 
![auth-method-pagination](https://user-images.githubusercontent.com/68122737/140402333-679f95b0-f8e0-49ec-82a1-68487b7401be.gif)
 