### PR TITLE
OIDC: return full issuer uri on read provider

### DIFF
--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -1285,9 +1285,6 @@ func (i *IdentityStore) getOIDCProvider(ctx context.Context, s logical.Storage, 
 	}
 
 	provider.effectiveIssuer = i.getFullIssuerURI(ns.Path, provider.Issuer, name)
-	if err != nil {
-		return nil, err
-	}
 
 	return &provider, nil
 }

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -1228,6 +1228,11 @@ func (i *IdentityStore) pathOIDCListProvider(ctx context.Context, req *logical.R
 
 // pathOIDCReadProvider is used to read an existing provider
 func (i *IdentityStore) pathOIDCReadProvider(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	name := d.Get("name").(string)
 
 	provider, err := i.getOIDCProvider(ctx, req.Storage, name)
@@ -1238,13 +1243,26 @@ func (i *IdentityStore) pathOIDCReadProvider(ctx context.Context, req *logical.R
 		return nil, nil
 	}
 
+	issuer := i.getFullIssuerURI(ns.Path, provider.Issuer, name)
+
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"issuer":             provider.Issuer,
+			"issuer":             issuer,
 			"allowed_client_ids": provider.AllowedClientIDs,
 			"scopes_supported":   provider.ScopesSupported,
 		},
 	}, nil
+}
+
+func (i *IdentityStore) getFullIssuerURI(nsPath, issuer, name string) string {
+	fullIssuerURI := issuer
+	if fullIssuerURI == "" {
+		fullIssuerURI = i.redirectAddr
+	}
+
+	fullIssuerURI += "/v1/" + nsPath + "identity/oidc/provider/" + name
+
+	return fullIssuerURI
 }
 
 func (i *IdentityStore) getOIDCProvider(ctx context.Context, s logical.Storage, name string) (*provider, error) {
@@ -1266,12 +1284,10 @@ func (i *IdentityStore) getOIDCProvider(ctx context.Context, s logical.Storage, 
 		return nil, err
 	}
 
-	provider.effectiveIssuer = provider.Issuer
-	if provider.effectiveIssuer == "" {
-		provider.effectiveIssuer = i.redirectAddr
+	provider.effectiveIssuer = i.getFullIssuerURI(ns.Path, provider.Issuer, name)
+	if err != nil {
+		return nil, err
 	}
-
-	provider.effectiveIssuer += "/v1/" + ns.Path + "identity/oidc/provider/" + name
 
 	return &provider, nil
 }

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -2514,7 +2514,11 @@ func TestOIDC_pathOIDCAssignmentExistenceCheck(t *testing.T) {
 
 // TestOIDC_Path_OIDCProvider tests CRUD operations for providers
 func TestOIDC_Path_OIDCProvider(t *testing.T) {
-	c, _, _ := TestCoreUnsealed(t)
+	redirectAddr := "http://localhost:8200"
+	conf := &CoreConfig{
+		RedirectAddr: redirectAddr,
+	}
+	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
 	ctx := namespace.RootContext(nil)
 	storage := &logical.InmemStorage{}
 
@@ -2551,7 +2555,7 @@ func TestOIDC_Path_OIDCProvider(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected := map[string]interface{}{
-		"issuer":             "",
+		"issuer":             redirectAddr + "/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{},
 		"scopes_supported":   []string{},
 	}
@@ -2591,7 +2595,7 @@ func TestOIDC_Path_OIDCProvider(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected = map[string]interface{}{
-		"issuer":             "",
+		"issuer":             redirectAddr + "/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{"test-client-id"},
 		"scopes_supported":   []string{"test-scope"},
 	}
@@ -2634,7 +2638,7 @@ func TestOIDC_Path_OIDCProvider(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected = map[string]interface{}{
-		"issuer":             "https://example.com:8200",
+		"issuer":             "https://example.com:8200/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{"test-client-id"},
 		"scopes_supported":   []string{"test-scope"},
 	}
@@ -2733,7 +2737,12 @@ func TestOIDC_Path_OIDCProvider_DuplicateTemplateKeys(t *testing.T) {
 // TestOIDC_Path_OIDCProvider_DeDuplication tests that a
 // provider doensn't have duplicate scopes or client IDs
 func TestOIDC_Path_OIDCProvider_Deduplication(t *testing.T) {
-	c, _, _ := TestCoreUnsealed(t)
+	redirectAddr := "http://localhost:8200"
+	conf := &CoreConfig{
+		RedirectAddr: redirectAddr,
+	}
+	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
+
 	ctx := namespace.RootContext(nil)
 	storage := &logical.InmemStorage{}
 
@@ -2769,7 +2778,7 @@ func TestOIDC_Path_OIDCProvider_Deduplication(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected := map[string]interface{}{
-		"issuer":             "",
+		"issuer":             redirectAddr + "/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{"test-id1", "test-id2"},
 		"scopes_supported":   []string{"test-scope1"},
 	}
@@ -2804,7 +2813,7 @@ func TestOIDC_Path_OIDCProvider_Update(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected := map[string]interface{}{
-		"issuer":             "https://example.com:8200",
+		"issuer":             "https://example.com:8200/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{"test-client-id"},
 		"scopes_supported":   []string{},
 	}
@@ -2831,7 +2840,7 @@ func TestOIDC_Path_OIDCProvider_Update(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected = map[string]interface{}{
-		"issuer":             "https://changedurl.com",
+		"issuer":             "https://changedurl.com/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{"test-client-id"},
 		"scopes_supported":   []string{},
 	}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -188,6 +188,10 @@ func TestCoreWithSealAndUI(t testing.T, opts *CoreConfig) *Core {
 		conf.Logger = opts.Logger
 	}
 
+	if opts.RedirectAddr != "" {
+		conf.RedirectAddr = opts.RedirectAddr
+	}
+
 	for k, v := range opts.LogicalBackends {
 		conf.LogicalBackends[k] = v
 	}


### PR DESCRIPTION
## Description

If the `issuer` is not explicitly set on the provider then read operations on the provider resource will return an empty issuer field. For example:

```
$ vault read identity/oidc/provider/my-provider
Key                   Value
---                   -----
allowed_client_ids    [*]
issuer                n/a
scopes_supported      [groups user]
```

The issuer is not a required field when creating a provider resource in vault. When the issuer is not explicitly set on provider creation the default value is set as Vault’s `api_addr` as the `scheme://host:port` component and `/v1/:namespace/identity/oidc/provider/:name` as the path component.

We should be returning the full issuer uri on provider read operations for a better UX experience.