### PR TITLE
Fix regression preventing non-docker tests from running.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1011,12 +1011,12 @@ jobs:
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname || true)
             else
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname || true)
             fi
             # Move back into root directory
             popd
@@ -1282,12 +1282,12 @@ jobs:
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname || true)
             else
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname || true)
             fi
             # Move back into root directory
             popd
@@ -1804,12 +1804,12 @@ jobs:
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname || true)
             else
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname || true)
             fi
             # Move back into root directory
             popd
@@ -2470,12 +2470,12 @@ jobs:
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname || true)
             else
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname || true)
             fi
             # Move back into root directory
             popd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1011,12 +1011,12 @@ jobs:
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
             else
-              package_names=$(< test-list-json jq -r 'select(.Deps != null) |
+              package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
             fi
             # Move back into root directory
             popd
@@ -1282,12 +1282,12 @@ jobs:
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
             else
-              package_names=$(< test-list-json jq -r 'select(.Deps != null) |
+              package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
             fi
             # Move back into root directory
             popd
@@ -1804,12 +1804,12 @@ jobs:
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
             else
-              package_names=$(< test-list-json jq -r 'select(.Deps != null) |
+              package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
             fi
             # Move back into root directory
             popd
@@ -2470,12 +2470,12 @@ jobs:
               package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
             else
-              package_names=$(< test-list-json jq -r 'select(.Deps != null) |
+              package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                   select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                   .ForTest | select(. != null)' |
-                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
+                  sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
             fi
             # Move back into root directory
             popd

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -74,12 +74,12 @@ steps:
             package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                 select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                 .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           else
-            package_names=$(< test-list-json jq -r 'select(.Deps != null) |
+            package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                 select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                 .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname) || true
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
           fi
           # Move back into root directory
           popd

--- a/.circleci/config/commands/go_test.yml
+++ b/.circleci/config/commands/go_test.yml
@@ -74,12 +74,12 @@ steps:
             package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                 select(any(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker"))) |
                 .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname || true)
           else
             package_names=$(< test-list.json jq -r 'select(.Deps != null) |
                 select(all(.Deps[] ; contains("github.com/hashicorp/vault/helper/testhelpers/docker")|not)) |
                 .ForTest | select(. != null)' |
-                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname)
+                sort -u | grep -v vault/integ | circleci tests split --split-by=timings --timings-type=classname || true)
           fi
           # Move back into root directory
           popd


### PR DESCRIPTION
Regression due to typo caused by: https://github.com/hashicorp/vault/pull/13017

I'm going to experiment with moving the `|| true`, since that helped masked the error.  These were introduced by #12630, and probably are needed, but I'd like to see how it fails without them and if there's a better way.