### PR TITLE
Attempt to fix the flaky TestDeleteUser/TestUpdateUser mssql tests

### DIFF
--- a/helper/testhelpers/mssql/mssqlhelper.go
+++ b/helper/testhelpers/mssql/mssqlhelper.go
@@ -53,6 +53,8 @@ func connectMSSQL(ctx context.Context, host string, port int) (docker.ServiceCon
 		User:   url.UserPassword("sa", mssqlPassword),
 		Host:   fmt.Sprintf("%s:%d", host, port),
 	}
+	// Attempt to address connection flakiness within tests such as "Failed to initialize: error verifying connection ..."
+	u.Query().Add("Connection Timeout", "30")
 
 	db, err := sql.Open("mssql", u.String())
 	if err != nil {


### PR DESCRIPTION
 - Add a 'Connect Timeout' query parameter to the test helper to set
   a timeout value of 30 seconds in an attempt to address the following
   failure we see at times in TestDeleteUser and TestUpdateUser

   mssql_test.go:253: Failed to initialize: error verifying connection: TLS Handshake failed: cannot read handshake packet: EOF