### PR TITLE
Documentation consistency GPG keys are PGP keys.

### DIFF
--- a/command/operator_generate_root.go
+++ b/command/operator_generate_root.go
@@ -180,7 +180,7 @@ func (c *OperatorGenerateRootCommand) Flags() *FlagSets {
 		EnvVar:     "",
 		Completion: complete.PredictAnything,
 		Usage: "Path to a file on disk containing a binary or base64-encoded " +
-			"public GPG key. This can also be specified as a Keybase username " +
+			"public PGP key. This can also be specified as a Keybase username " +
 			"using the format \"keybase:<username>\". When supplied, the generated " +
 			"root token will be encrypted and base64-encoded with the given public " +
 			"key.",

--- a/command/operator_init.go
+++ b/command/operator_init.go
@@ -124,7 +124,7 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 		Value:      (*pgpkeys.PubKeyFilesFlag)(&c.flagPGPKeys),
 		Completion: complete.PredictAnything,
 		Usage: "Comma-separated list of paths to files on disk containing " +
-			"public GPG keys OR a comma-separated list of Keybase usernames using " +
+			"public PGP keys OR a comma-separated list of Keybase usernames using " +
 			"the format \"keybase:<username>\". When supplied, the generated " +
 			"unseal keys will be encrypted and base64-encoded in the order " +
 			"specified in this list. The number of entries must match -key-shares, " +
@@ -136,7 +136,7 @@ func (c *OperatorInitCommand) Flags() *FlagSets {
 		Value:      (*pgpkeys.PubKeyFileFlag)(&c.flagRootTokenPGPKey),
 		Completion: complete.PredictAnything,
 		Usage: "Path to a file on disk containing a binary or base64-encoded " +
-			"public GPG key. This can also be specified as a Keybase username " +
+			"public PGP key. This can also be specified as a Keybase username " +
 			"using the format \"keybase:<username>\". When supplied, the generated " +
 			"root token will be encrypted and base64-encoded with the given public " +
 			"key.",

--- a/command/operator_rekey.go
+++ b/command/operator_rekey.go
@@ -177,7 +177,7 @@ func (c *OperatorRekeyCommand) Flags() *FlagSets {
 		Value:      (*pgpkeys.PubKeyFilesFlag)(&c.flagPGPKeys),
 		Completion: complete.PredictAnything,
 		Usage: "Comma-separated list of paths to files on disk containing " +
-			"public GPG keys OR a comma-separated list of Keybase usernames using " +
+			"public PGP keys OR a comma-separated list of Keybase usernames using " +
 			"the format \"keybase:<username>\". When supplied, the generated " +
 			"unseal keys will be encrypted and base64-encoded in the order " +
 			"specified in this list.",

--- a/website/content/docs/commands/operator/generate-root.mdx
+++ b/website/content/docs/commands/operator/generate-root.mdx
@@ -82,7 +82,7 @@ flags](/docs/commands) included on all commands.
 - `-otp` `(string: "")` - OTP code to use with `-decode` or `-init`.
 
 - `-pgp-key` `(keybase or pgp)`- Path to a file on disk containing a binary or
-  base64-encoded public GPG key. This can also be specified as a Keybase
+  base64-encoded public PGP key. This can also be specified as a Keybase
   username using the format `keybase:<username>`. When supplied, the generated
   root token will be encrypted and base64-encoded with the given public key.
 

--- a/website/content/docs/commands/operator/init.mdx
+++ b/website/content/docs/commands/operator/init.mdx
@@ -79,13 +79,13 @@ flags](/docs/commands) included on all commands.
   `-t`.
 
 - `-pgp-keys` `(string: "...")` - Comma-separated list of paths to files on disk
-  containing public GPG keys OR a comma-separated list of Keybase usernames
+  containing public PGP keys OR a comma-separated list of Keybase usernames
   using the format `keybase:<username>`. When supplied, the generated unseal
   keys will be encrypted and base64-encoded in the order specified in this list.
   The number of entries must match -key-shares, unless -stored-shares are used.
 
 - `-root-token-pgp-key` `(string: "")` - Path to a file on disk containing a
-  binary or base64-encoded public GPG key. This can also be specified as a
+  binary or base64-encoded public PGP key. This can also be specified as a
   Keybase username using the format `keybase:<username>`. When supplied, the
   generated root token will be encrypted and base64-encoded with the given
   public key.

--- a/website/content/docs/commands/operator/rekey.mdx
+++ b/website/content/docs/commands/operator/rekey.mdx
@@ -125,7 +125,7 @@ flags](/docs/commands) included on all commands.
   nonce value must be provided with each unseal key.
 
 - `-pgp-keys` `(string: "...")` - Comma-separated list of paths to files on disk
-  containing public GPG keys OR a comma-separated list of Keybase usernames
+  containing public PGP keys OR a comma-separated list of Keybase usernames
   using the format `keybase:<username>`. When supplied, the generated unseal
   keys will be encrypted and base64-encoded in the order specified in this list.
 

--- a/website/content/docs/concepts/pgp-gpg-keybase.mdx
+++ b/website/content/docs/concepts/pgp-gpg-keybase.mdx
@@ -158,7 +158,7 @@ to Vishal, and the third to Seth. These keys can be distributed over almost any
 medium, although common sense and judgement are best advised. The encrypted
 keys are base64 encoded before returning.
 
-### Unsealing with a GnuPG
+### Unsealing with GnuPG
 
 Assuming you have been given an unseal key that was encrypted using your public
 PGP key, you are now tasked with entering your unseal key. To get the

--- a/website/content/docs/concepts/pgp-gpg-keybase.mdx
+++ b/website/content/docs/concepts/pgp-gpg-keybase.mdx
@@ -1,23 +1,23 @@
 ---
 layout: docs
-page_title: 'Using PGP, GPG, and Keybase'
+page_title: 'Using PGP, GnuPG, and Keybase'
 description: |-
-  Vault has the ability to integrate with OpenPGP-compatible programs like GPG
-  and services like Keybase.io to provide an additional layer of security when
-  performing certain operations.  This page details the various GPG
+  Vault has the ability to integrate with OpenPGP-compatible programs like
+  GnuPG and services like Keybase.io to provide an additional layer of security
+  when performing certain operations.  This page details the various PGP
   integrations, their use, and operation.
 ---
 
-# Using PGP, GPG, and Keybase
+# Using PGP, GnuPG, and Keybase
 
-Vault has the ability to integrate with OpenPGP-compatible programs like GPG
+Vault has the ability to integrate with OpenPGP-compatible programs like GnuPG
 and services like Keybase.io to provide an additional layer of security when
 performing certain operations. This page details the various PGP integrations,
 their use, and operation.
 
 Keybase.io support is available only in the command-line tool and not via the
 Vault HTTP API, tools that help with initialization should use the Keybase.io
-API in order to obtain the GPG keys needed for a secure initialization if you
+API in order to obtain the PGP keys needed for a secure initialization if you
 want them to use Keybase for keys.
 
 Once the Vault has been initialized, it is possible to use Keybase to decrypt
@@ -37,7 +37,7 @@ able to decrypt the value, revealing the plain-text unseal key.
 First, you must create, acquire, or import the appropriate key(s) onto the
 local machine from which you are initializing Vault. This guide will not
 attempt to cover all aspects of PGP keys but give examples using two popular
-programs: Keybase and GPG.
+programs: Keybase and GnuPG.
 
 For beginners, we suggest using [Keybase.io](https://keybase.io/) ("Keybase")
 as it can be both simpler and has a number of useful behaviors and properties
@@ -107,10 +107,10 @@ Key (will be hidden): ...
 
 ---
 
-## Initializing with GPG
+## Initializing with GnuPG
 
-GPG is an open-source implementation of the OpenPGP standard and is available
-on nearly every platform. For more information, please see the [GPG
+GnuPG is an open-source implementation of the OpenPGP standard and is available
+on nearly every platform. For more information, please see the [GnuPG
 manual](https://gnupg.org/gph/en/manual.html).
 
 To create a new PGP key, run, following the prompts:
@@ -158,7 +158,7 @@ to Vishal, and the third to Seth. These keys can be distributed over almost any
 medium, although common sense and judgement are best advised. The encrypted
 keys are base64 encoded before returning.
 
-### Unsealing with a GPG
+### Unsealing with a GnuPG
 
 Assuming you have been given an unseal key that was encrypted using your public
 PGP key, you are now tasked with entering your unseal key. To get the

--- a/website/content/docs/install.mdx
+++ b/website/content/docs/install.mdx
@@ -24,7 +24,7 @@ with the SHA256 sums that can be verified.
 
 We build and sign official packages for Ubuntu, Debian, Fedora, RHEL, Amazon
 Linux, and other distributions. Follow the instructions at [HashiCorp
-Learn][learn-vault-install] to add our GPG key, add our repository, and
+Learn][learn-vault-install] to add our PGP key, add our repository, and
 install.
 
 ## Precompiled Binaries

--- a/website/content/guides/operations/generate-root.mdx
+++ b/website/content/guides/operations/generate-root.mdx
@@ -90,7 +90,7 @@ In this method, an OTP is XORed with the generated token on final output.
 
 ### Using PGP
 
-1. Initialize a root token generation, providing the path to a GPG public key
+1. Initialize a root token generation, providing the path to a PGP public key
    or keybase username of a user to encrypted the resulting token.
 
    ```text

--- a/website/content/intro/getting-started/deploy.mdx
+++ b/website/content/intro/getting-started/deploy.mdx
@@ -145,7 +145,7 @@ somewhere, and continue. In a real deployment scenario, you would never
 save these keys together. Instead, you would likely use Vault's PGP and
 Keybase.io support to encrypt each of these keys with the users' PGP keys.
 This prevents one single person from having all the unseal keys. Please
-see the documentation on [using PGP, GPG, and Keybase](/docs/concepts/pgp-gpg-keybase)
+see the documentation on [using PGP, GnuPG, and Keybase](/docs/concepts/pgp-gpg-keybase)
 for more information.
 
 ## Seal/Unseal

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -137,7 +137,7 @@
         ]
       },
       {
-        "title": "PGP, GPG, and Keybase",
+        "title": "PGP, GnuPG, and Keybase",
         "path": "concepts/pgp-gpg-keybase"
       },
       {


### PR DESCRIPTION
This one is just a minor documentation fix, which irked me when I was reading some of the help guides.

In some places documentation rightfully refers to "PGP keys", then sporadically throughout this is used interchangeably with "GPG keys".

GPG is actually referred to as GnuPG in official upstream documentation, so I fixed that. As far as referring to the keys themselves, they are still PGP keys, whether created by GnuPG [or some other implementation](https://wiki.gnupg.org/OtherFreeSoftwareOpenPGP).