### PR TITLE
Remove configuration parsing for tls_prefer_server_cipher_suites

### DIFF
--- a/internalshared/configutil/listener.go
+++ b/internalshared/configutil/listener.go
@@ -55,8 +55,6 @@ type Listener struct {
 	TLSMaxVersion                    string      `hcl:"tls_max_version"`
 	TLSCipherSuites                  []uint16    `hcl:"-"`
 	TLSCipherSuitesRaw               string      `hcl:"tls_cipher_suites"`
-	TLSPreferServerCipherSuites      bool        `hcl:"-"`
-	TLSPreferServerCipherSuitesRaw   interface{} `hcl:"tls_prefer_server_cipher_suites"`
 	TLSRequireAndVerifyClientCert    bool        `hcl:"-"`
 	TLSRequireAndVerifyClientCertRaw interface{} `hcl:"tls_require_and_verify_client_cert"`
 	TLSClientCAFile                  string      `hcl:"tls_client_ca_file"`
@@ -214,14 +212,6 @@ func ParseListeners(result *SharedConfig, list *ast.ObjectList) error {
 				if l.TLSCipherSuites, err = tlsutil.ParseCiphers(l.TLSCipherSuitesRaw); err != nil {
 					return multierror.Prefix(fmt.Errorf("invalid value for tls_cipher_suites: %w", err), fmt.Sprintf("listeners.%d", i))
 				}
-			}
-
-			if l.TLSPreferServerCipherSuitesRaw != nil {
-				if l.TLSPreferServerCipherSuites, err = parseutil.ParseBool(l.TLSPreferServerCipherSuitesRaw); err != nil {
-					return multierror.Prefix(fmt.Errorf("invalid value for tls_prefer_server_cipher_suites: %w", err), fmt.Sprintf("listeners.%d", i))
-				}
-
-				l.TLSPreferServerCipherSuitesRaw = nil
 			}
 
 			if l.TLSRequireAndVerifyClientCertRaw != nil {

--- a/internalshared/listenerutil/listener.go
+++ b/internalshared/listenerutil/listener.go
@@ -104,7 +104,6 @@ PASSPHRASECORRECT:
 		GetCertificate:           cg.GetCertificate,
 		NextProtos:               []string{"h2", "http/1.1"},
 		ClientAuth:               tls.RequestClientCert,
-		PreferServerCipherSuites: l.TLSPreferServerCipherSuites,
 	}
 
 	if l.TLSMinVersion == "" {


### PR DESCRIPTION
 - With our upgrade to Go 1.17 this configuration value is ignored by Go
   so completely remove it.
    - https://go.dev/blog/tls-cipher-suites
 - Vault documentation for the key already has a warning saying we
   ignore this key
 - The 1.9 upgrade guide also has a blurb about this already.