### PR TITLE
Add universal default key_bits value for PKI endpoints

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1183,21 +1183,21 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 	}
 
 	getRandCsr := func(keyType string, errorOk bool, csrTemplate *x509.CertificateRequest) csrPlan {
-		rsaKeyBits := []int{2048, 4096}
+		rsaKeyBits := []int{2048, 3072, 4096}
 		ecKeyBits := []int{224, 256, 384, 521}
 		plan := csrPlan{errorOk: errorOk}
 
 		var testBitSize int
 		switch keyType {
 		case "rsa":
-			plan.roleKeyBits = rsaKeyBits[mathRand.Int()%2]
+			plan.roleKeyBits = rsaKeyBits[mathRand.Int()%len(rsaKeyBits)]
 			testBitSize = plan.roleKeyBits
 
 			// If we don't expect an error already, randomly choose a
 			// key size and expect an error if it's less than the role
 			// setting
 			if !keybitSizeRandOff && !errorOk {
-				testBitSize = rsaKeyBits[mathRand.Int()%2]
+				testBitSize = rsaKeyBits[mathRand.Int()%len(rsaKeyBits)]
 			}
 
 			if testBitSize < plan.roleKeyBits {
@@ -1205,14 +1205,14 @@ func generateRoleSteps(t *testing.T, useCSRs bool) []logicaltest.TestStep {
 			}
 
 		case "ec":
-			plan.roleKeyBits = ecKeyBits[mathRand.Int()%4]
+			plan.roleKeyBits = ecKeyBits[mathRand.Int()%len(ecKeyBits)]
 			testBitSize = plan.roleKeyBits
 
 			// If we don't expect an error already, randomly choose a
 			// key size and expect an error if it's less than the role
 			// setting
 			if !keybitSizeRandOff && !errorOk {
-				testBitSize = ecKeyBits[mathRand.Int()%4]
+				testBitSize = ecKeyBits[mathRand.Int()%len(ecKeyBits)]
 			}
 
 			if testBitSize < plan.roleKeyBits {

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -50,12 +50,7 @@ func (b *backend) getGenerationParams(
 		PostalCode:           data.Get("postal_code").([]string),
 	}
 
-	if role.KeyType == "rsa" && role.KeyBits < 2048 {
-		errorResp = logical.ErrorResponse("RSA keys < 2048 bits are unsafe and not supported")
-		return
-	}
-
-	if err := certutil.ValidateKeyTypeSignatureLength(role.KeyType, role.KeyBits, &role.SignatureBits); err != nil {
+	if err := certutil.ValidateKeyTypeSignatureLength(role.KeyType, &role.KeyBits, &role.SignatureBits); err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
 	}
 

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -50,7 +50,8 @@ func (b *backend) getGenerationParams(
 		PostalCode:           data.Get("postal_code").([]string),
 	}
 
-	if err := certutil.ValidateKeyTypeSignatureLength(role.KeyType, &role.KeyBits, &role.SignatureBits); err != nil {
+	var err error
+	if role.KeyBits, role.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits); err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
 	}
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -250,12 +250,13 @@ the private key!`,
 
 	fields["key_bits"] = &framework.FieldSchema{
 		Type:    framework.TypeInt,
-		Default: 2048,
-		Description: `The number of bits to use. You will almost
-certainly want to change this if you adjust
-the key_type.`,
+		Default: 0,
+		Description: `The number of bits to use. Allowed values are
+0 (universal default); with rsa key_type: 2048 (default), 3072, or
+4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
+ed25519.`,
 		DisplayAttrs: &framework.DisplayAttributes{
-			Value: 2048,
+			Value: 0,
 		},
 	}
 

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -616,17 +616,13 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		*entry.GenerateLease = data.Get("generate_lease").(bool)
 	}
 
-	if entry.KeyType == "rsa" && entry.KeyBits < 2048 {
-		return logical.ErrorResponse("RSA keys < 2048 bits are unsafe and not supported"), nil
-	}
-
 	if entry.MaxTTL > 0 && entry.TTL > entry.MaxTTL {
 		return logical.ErrorResponse(
 			`"ttl" value must be less than "max_ttl" value`,
 		), nil
 	}
 
-	if err := certutil.ValidateKeyTypeSignatureLength(entry.KeyType, entry.KeyBits, &entry.SignatureBits); err != nil {
+	if err := certutil.ValidateKeyTypeSignatureLength(entry.KeyType, &entry.KeyBits, &entry.SignatureBits); err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
 

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -199,10 +199,11 @@ protection use. Defaults to false.`,
 
 			"key_bits": {
 				Type:    framework.TypeInt,
-				Default: 2048,
-				Description: `The number of bits to use. You will almost
-certainly want to change this if you adjust
-the key_type.`,
+				Default: 0,
+				Description: `The number of bits to use. Allowed values are
+0 (universal default); with rsa key_type: 2048 (default), 3072, or
+4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with
+ed25519.`,
 			},
 
 			"signature_bits": &framework.FieldSchema{

--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -622,7 +622,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		), nil
 	}
 
-	if err := certutil.ValidateKeyTypeSignatureLength(entry.KeyType, &entry.KeyBits, &entry.SignatureBits); err != nil {
+	if entry.KeyBits, entry.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(entry.KeyType, entry.KeyBits, entry.SignatureBits); err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
 

--- a/changelog/13080.txt
+++ b/changelog/13080.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Default value for key_bits changed to 0, enabling key_type=ec key generation with default value
+```


### PR DESCRIPTION
Built on top of #12872; will be rebased once that merges.

----

PKI endpoints currently require `key_bits` field to be changed if `key_type` changes; this is because `key_bits` presently has default value 2048, which is nonsensical for `key_type=ec` keys (which support 224, 256, 384, and 521). Changing `key_bits` to a default value of 0 (a "universal default" similar to what was done with `signature_bits` in #12872) allows us to switch the actual default value of `key_bits` internally, based on what value `key_type` takes.

This retains the default value of 2048 for RSA and allows for a request with only `key_type=ec` to succeed, with 256-bit NIST P-Curve.

Also slightly refactors RSA small key detection and `pki/backend_test.go`. 