### PR TITLE
Note that versionTimestamps are only loaded on the active node. 

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -570,9 +570,11 @@ type Core struct {
 	enableResponseHeaderHostname   bool
 	enableResponseHeaderRaftNodeID bool
 
-	// VersionTimestamps is a map of vault versions to timestamps when the version
-	// was first run
-	VersionTimestamps map[string]time.Time
+	// versionTimestamps is a map of vault versions to timestamps when the version
+	// was first run. Note that because perf standbys should be upgraded first, and
+	// only the active node will actually write the new version timestamp, a perf
+	// standby shouldn't rely on the stored version timestamps being present.
+	versionTimestamps map[string]time.Time
 }
 
 func (c *Core) HAState() consts.HAState {
@@ -1037,9 +1039,9 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 		return nil, err
 	}
 
-	if c.VersionTimestamps == nil {
-		c.logger.Info("Initializing VersionTimestamps for core")
-		c.VersionTimestamps = make(map[string]time.Time)
+	if c.versionTimestamps == nil {
+		c.logger.Info("Initializing versionTimestamps for core")
+		c.versionTimestamps = make(map[string]time.Time)
 	}
 
 	return c, nil

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -55,14 +55,14 @@ func TestSealConfig_Invalid(t *testing.T) {
 	}
 }
 
-// TestCore_HasVaultVersion checks that VersionTimestamps are correct and initialized
+// TestCore_HasVaultVersion checks that versionTimestamps are correct and initialized
 // after a core has been unsealed.
 func TestCore_HasVaultVersion(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
-	if c.VersionTimestamps == nil {
+	if c.versionTimestamps == nil {
 		t.Fatalf("Version timestamps for core were not initialized for a new core")
 	}
-	upgradeTime, ok := c.VersionTimestamps[version.Version]
+	upgradeTime, ok := c.versionTimestamps[version.Version]
 	if !ok {
 		t.Fatalf("%s upgrade time not found", version.Version)
 	}

--- a/vault/core_util_common.go
+++ b/vault/core_util_common.go
@@ -43,14 +43,14 @@ func (c *Core) storeVersionTimestamp(ctx context.Context, version string, curren
 // upgrade timestamp from storage. The earliest version this can be (barring
 // downgrades) is 1.9.0.
 func (c *Core) FindOldestVersionTimestamp() (string, time.Time, error) {
-	if c.VersionTimestamps == nil || len(c.VersionTimestamps) == 0 {
+	if c.versionTimestamps == nil || len(c.versionTimestamps) == 0 {
 		return "", time.Time{}, fmt.Errorf("version timestamps are not initialized")
 	}
 
 	// initialize oldestUpgradeTime to current time
 	oldestUpgradeTime := time.Now()
 	var oldestVersion string
-	for version, upgradeTime := range c.VersionTimestamps {
+	for version, upgradeTime := range c.versionTimestamps {
 		if upgradeTime.Before(oldestUpgradeTime) {
 			oldestVersion = version
 			oldestUpgradeTime = upgradeTime
@@ -83,7 +83,7 @@ func (c *Core) loadVersionTimestamps(ctx context.Context) (retErr error) {
 		if vaultVersion.Version == "" || vaultVersion.TimestampInstalled.IsZero() {
 			return fmt.Errorf("found empty serialized vault version at path %s", versionPath)
 		}
-		c.VersionTimestamps[vaultVersion.Version] = vaultVersion.TimestampInstalled
+		c.versionTimestamps[vaultVersion.Version] = vaultVersion.TimestampInstalled
 	}
 	return nil
 }

--- a/vault/core_util_common_test.go
+++ b/vault/core_util_common_test.go
@@ -17,7 +17,7 @@ func TestStoreMultipleVaultVersions(t *testing.T) {
 	if err != nil || wasStored {
 		t.Fatalf("vault version was re-stored: %v, err is: %s", wasStored, err.Error())
 	}
-	upgradeTime, ok := c.VersionTimestamps[version.Version]
+	upgradeTime, ok := c.versionTimestamps[version.Version]
 	if !ok {
 		t.Fatalf("no %s version timestamp found", version.Version)
 	}
@@ -35,8 +35,8 @@ func TestGetOldestVersion(t *testing.T) {
 	c.storeVersionTimestamp(context.Background(), "1.9.1", upgradeTimePlusEpsilon.Add(-4*time.Hour))
 	c.storeVersionTimestamp(context.Background(), "1.9.2", upgradeTimePlusEpsilon.Add(2*time.Hour))
 	c.loadVersionTimestamps(c.activeContext)
-	if len(c.VersionTimestamps) != 3 {
-		t.Fatalf("expected 3 entries in timestamps map after refresh, found: %d", len(c.VersionTimestamps))
+	if len(c.versionTimestamps) != 3 {
+		t.Fatalf("expected 3 entries in timestamps map after refresh, found: %d", len(c.versionTimestamps))
 	}
 	v, tm, err := c.FindOldestVersionTimestamp()
 	if err != nil {


### PR DESCRIPTION
Rationale: that's the only place they're needed currently, and making them reliably available on perf standbys would take some extra work, e.g. invalidation.

I was going to add a more specific error message to FindOldestVersionTimestamp (the only consumer atm), but
that func is invoked both with and without the statelock, making it tricky to determine if we're a standby.