### PR TITLE
Port: Allow Routing to Partial Monthly Client Count From Namespaces

### DIFF
--- a/changelog/13086.txt
+++ b/changelog/13086.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+activity log (enterprise): allow partial monthly client count to be accessed from namespaces
+```

--- a/vault/logical_system_activity.go
+++ b/vault/logical_system_activity.go
@@ -41,7 +41,7 @@ func (b *SystemBackend) activityQueryPath() *framework.Path {
 // monthlyActivityCountPath is available in every namespace
 func (b *SystemBackend) monthlyActivityCountPath() *framework.Path {
 	return &framework.Path{
-		Pattern:         "internal/counters/activity/monthly",
+		Pattern:         "internal/counters/activity/monthly$",
 		HelpSynopsis:    strings.TrimSpace(sysHelp["activity-monthly"][0]),
 		HelpDescription: strings.TrimSpace(sysHelp["activity-monthly"][1]),
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -50,6 +50,13 @@ func (b *SystemBackend) monthlyActivityCountPath() *framework.Path {
 				Summary:  "Report the number of clients for this month, for this namespace and all child namespaces.",
 			},
 		},
+	}
+}
+
+func (b *SystemBackend) activityPaths() []*framework.Path {
+	return []*framework.Path{
+		b.monthlyActivityCountPath(),
+		b.activityQueryPath(),
 	}
 }
 


### PR DESCRIPTION
This is an OSS port of: https://github.com/hashicorp/vault-enterprise/pull/2310/files