### PR TITLE
Add message while adding Oracle db connection

### DIFF
--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -87,7 +87,7 @@
   {{#if (eq @model.plugin_name "vault-plugin-database-oracle")}}
       <AlertBanner @type="warning">
         Please ensure that your Oracle plugin has the default name of <b>vault-plugin-database-oracle</b>. 
-        Custom naming is not supported in the UI at this time.
+        Custom naming is not supported in the UI at this time. If the plugin is already named vault-plugin-database-oracle, disregard this warning.
       </AlertBanner>
   {{/if}}
 

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -83,6 +83,12 @@
 {{/if}}
 
 {{#if (eq @mode 'create')}}
+
+  {{#if (eq @model.plugin_name "vault-plugin-database-oracle")}}
+    <AlertBanner @type="warning" @message={{"Custom plugin names are currently not supported in Vault UI. 
+        Please ensure Oracle database plugin is registered with the name vault-plugin-database-oracle."}} />
+  {{/if}}
+
   <form {{on 'submit' this.handleCreateConnection}}>
     {{#each @model.fieldAttrs as |attr|}}
       {{#if (not-eq attr.options.readOnly true)}}

--- a/ui/app/templates/components/database-connection.hbs
+++ b/ui/app/templates/components/database-connection.hbs
@@ -85,8 +85,10 @@
 {{#if (eq @mode 'create')}}
 
   {{#if (eq @model.plugin_name "vault-plugin-database-oracle")}}
-    <AlertBanner @type="warning" @message={{"Custom plugin names are currently not supported in Vault UI. 
-        Please ensure Oracle database plugin is registered with the name vault-plugin-database-oracle."}} />
+      <AlertBanner @type="warning">
+        Please ensure that your Oracle plugin has the default name of <b>vault-plugin-database-oracle</b>. 
+        Custom naming is not supported in the UI at this time.
+      </AlertBanner>
   {{/if}}
 
   <form {{on 'submit' this.handleCreateConnection}}>

--- a/ui/app/utils/database-helpers.js
+++ b/ui/app/utils/database-helpers.js
@@ -136,7 +136,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
     ],
   },
   {
-    value: 'oracle-database-plugin',
+    value: 'vault-plugin-database-oracle',
     displayName: 'Oracle',
     fields: [
       { attr: 'plugin_name' },
@@ -188,7 +188,7 @@ export const STATEMENT_FIELDS = {
     'mysql-aurora-database-plugin': [],
     'mysql-legacy-database-plugin': [],
     'mysql-rds-database-plugin': [],
-    'oracle-database-plugin': [],
+    'vault-plugin-database-oracle': [],
     'postgresql-database-plugin': [],
   },
   dynamic: {
@@ -200,7 +200,7 @@ export const STATEMENT_FIELDS = {
     'mysql-aurora-database-plugin': ['creation_statements', 'revocation_statements'],
     'mysql-legacy-database-plugin': ['creation_statements', 'revocation_statements'],
     'mysql-rds-database-plugin': ['creation_statements', 'revocation_statements'],
-    'oracle-database-plugin': ['creation_statements', 'revocation_statements'],
+    'vault-plugin-database-oracle': ['creation_statements', 'revocation_statements'],
     'postgresql-database-plugin': [
       'creation_statements',
       'revocation_statements',

--- a/ui/tests/acceptance/secrets/backend/database/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/database/secret-test.js
@@ -212,7 +212,7 @@ const connectionTests = [
   // keep oracle as last DB because it is skipped in some tests (line 285) the UI doesn't return to empty state after
   {
     name: 'oracle-connection',
-    plugin: 'oracle-database-plugin',
+    plugin: 'vault-plugin-database-oracle',
     url: `{{username}}/{{password}}@localhost:1521/OraDoc.localhost`,
     requiredFields: async (assert, name) => {
       assert.dom('[data-test-input="username"]').exists(`Username field exists for ${name}`);
@@ -282,7 +282,7 @@ module('Acceptance | secrets/database/*', function(hooks) {
         await connectionPage.connectionUrl(testCase.url);
       }
       // skip adding oracle db connection since plugin doesn't exist
-      if (testCase.plugin === 'oracle-database-plugin') {
+      if (testCase.plugin === 'vault-plugin-database-oracle') {
         testCase.requiredFields(assert, testCase.name);
         continue;
       }

--- a/ui/tests/integration/components/database-role-setting-form-test.js
+++ b/ui/tests/integration/components/database-role-setting-form-test.js
@@ -56,7 +56,7 @@ const testCases = [
     dynamicRoleFields: ['creation_statements', 'revocation_statements', 'ttl', 'max_ttl'],
   },
   {
-    pluginType: 'oracle-database-plugin',
+    pluginType: 'vault-plugin-database-oracle',
     staticRoleFields: ['username', 'rotation_period'],
     dynamicRoleFields: ['creation_statements', 'revocation_statements', 'ttl', 'max_ttl'],
   },


### PR DESCRIPTION
- Since UI currently doesn't have the support for custom plugin names, inform user to use the default plugin name for the oracle database

<img width="1785" alt="Screen Shot 2021-11-10 at 1 27 25 PM" src="https://user-images.githubusercontent.com/2932708/141196162-2dbaad03-7fd8-4956-9d78-a55279b83b17.png">
