### PR TITLE
UI/Custom empty state messages for transit and transform

### DIFF
--- a/changelog/13090.txt
+++ b/changelog/13090.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-ui: customizes empty state messages for secret backends
+ui: customizes empty state messages for transit and transform
 ```

--- a/changelog/13090.txt
+++ b/changelog/13090.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: customizes empty state messages for secret backends
+```

--- a/ui/app/helpers/options-for-backend.js
+++ b/ui/app/helpers/options-for-backend.js
@@ -87,6 +87,7 @@ const SECRET_BACKENDS = {
     displayName: 'Transformation',
     navigateTree: false,
     listItemPartial: 'secret-list/transform-list-item',
+    message: 'a transformation and a role',
     tabs: [
       {
         name: 'transformations',
@@ -136,6 +137,7 @@ const SECRET_BACKENDS = {
     navigateTree: false,
     editComponent: 'transit-edit',
     listItemPartial: 'secret-list/item',
+    message: 'an encryption key',
   },
 };
 

--- a/ui/app/helpers/options-for-backend.js
+++ b/ui/app/helpers/options-for-backend.js
@@ -87,7 +87,7 @@ const SECRET_BACKENDS = {
     displayName: 'Transformation',
     navigateTree: false,
     listItemPartial: 'secret-list/transform-list-item',
-    message: 'create a transformation and a role',
+    firstStep: 'create a transformation and a role',
     tabs: [
       {
         name: 'transformations',
@@ -137,7 +137,7 @@ const SECRET_BACKENDS = {
     navigateTree: false,
     editComponent: 'transit-edit',
     listItemPartial: 'secret-list/item',
-    message: 'create an encryption key',
+    firstStep: 'create an encryption key',
   },
 };
 

--- a/ui/app/helpers/options-for-backend.js
+++ b/ui/app/helpers/options-for-backend.js
@@ -87,7 +87,7 @@ const SECRET_BACKENDS = {
     displayName: 'Transformation',
     navigateTree: false,
     listItemPartial: 'secret-list/transform-list-item',
-    message: 'a transformation and a role',
+    message: 'create a transformation and a role',
     tabs: [
       {
         name: 'transformations',
@@ -137,7 +137,7 @@ const SECRET_BACKENDS = {
     navigateTree: false,
     editComponent: 'transit-edit',
     listItemPartial: 'secret-list/item',
-    message: 'an encryption key',
+    message: 'create an encryption key',
   },
 };
 

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -4,8 +4,8 @@ import { fragment } from 'ember-data-model-fragments/attributes';
 import fieldToAttrs, { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import { validator, buildValidations } from 'ember-cp-validations';
 
-//identity will be managed separately and the inclusion
-//of the system backend is an implementation detail
+// identity will be managed separately and the inclusion
+// of the system backend is an implementation detail
 const LIST_EXCLUDED_BACKENDS = ['system', 'identity'];
 
 const Validations = buildValidations({

--- a/ui/app/routes/vault/cluster/secrets/backend/overview.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/overview.js
@@ -68,7 +68,7 @@ export default Route.extend({
       if (noConnectionCapabilities) {
         return 'You cannot yet generate credentials.  Ask your administrator if you think you should have access.';
       } else {
-        return 'You can connect and external database to Vault.  We recommend that you create a user for Vault rather than using the database root user.';
+        return 'You can connect an external database to Vault.  We recommend that you create a user for Vault rather than using the database root user.';
       }
     };
     controller.set('showEmptyState', showEmptyState);

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -113,10 +113,10 @@
       {{/if}}
     {{else}}
       {{#if (eq baseKey.id '')}}
-        {{#if (and options.message (not tab))}}
+        {{#if (and options.firstStep (not tab))}}
           <EmptyState
             @title="Get started with {{capitalize backendType}}"
-            @message="To use {{backendType}}, you'll need to {{options.message}}."
+            @message="To use {{backendType}}, you'll need to {{options.firstStep}}."
           >
             <SecretLink @mode="create" @secret="" @queryParams={{query-params initialKey=(or filter baseKey.id) itemType=tab}} @class="link">
               {{options.create}}

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -113,10 +113,10 @@
       {{/if}}
     {{else}}
       {{#if (eq baseKey.id '')}}
-        {{#if options.message}}
+        {{#if (and options.message (not tab))}}
           <EmptyState
             @title="Get started with {{capitalize backendType}}"
-            @message="To use {{backendType}}, you'll need to create {{options.message}}."
+            @message="To use {{backendType}}, you'll need to {{options.message}}."
           >
             <SecretLink @mode="create" @secret="" @queryParams={{query-params initialKey=(or filter baseKey.id) itemType=tab}} @class="link">
               {{options.create}}

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -113,14 +113,25 @@
       {{/if}}
     {{else}}
       {{#if (eq baseKey.id '')}}
-        <EmptyState
-          @title="No {{pluralize options.item}} in this backend"
-          @message="Secrets in this backend will be listed here. Add a secret to get started."
-        >
-          <SecretLink @mode="create" @secret="" @queryParams={{query-params initialKey=(or filter baseKey.id) itemType=tab}} @class="link">
-            {{options.create}}
-          </SecretLink>
-        </EmptyState>
+        {{#if options.message}}
+          <EmptyState
+            @title="Get started with {{capitalize backendType}}"
+            @message="To use {{backendType}}, you'll need to create {{options.message}}."
+          >
+            <SecretLink @mode="create" @secret="" @queryParams={{query-params initialKey=(or filter baseKey.id) itemType=tab}} @class="link">
+              {{options.create}}
+            </SecretLink>
+          </EmptyState>    
+        {{else}} 
+          <EmptyState
+            @title="No {{pluralize options.item}} in this backend"
+            @message="Secrets in this backend will be listed here. Add a secret to get started."
+          >
+            <SecretLink @mode="create" @secret="" @queryParams={{query-params initialKey=(or filter baseKey.id) itemType=tab}} @class="link">
+              {{options.create}}
+            </SecretLink>
+          </EmptyState>
+        {{/if}}
       {{else}}
         {{#if filterIsFolder}}
           <EmptyState


### PR DESCRIPTION
Previous empty state message read the following for secret backends: 
<img width="1569" alt="Screen Shot 2021-11-08 at 9 11 08 PM" src="https://user-images.githubusercontent.com/68122737/140866221-6c38872c-c509-4a60-82e4-ca18fb5adda7.png">

Updated copy for transform and transit: 
<img width="1549" alt="Screen Shot 2021-11-08 at 9 10 57 PM" src="https://user-images.githubusercontent.com/68122737/140866204-24b942ef-b40c-48e3-a2dc-9067c974d635.png">

<img width="1608" alt="Screen Shot 2021-11-08 at 9 12 18 PM" src="https://user-images.githubusercontent.com/68122737/140866330-d5fd0ce8-a5bd-4fb0-b713-fcbbbd6367aa.png">

