### PR TITLE
Documentation grammar update for https://www.vaultproject.io/docs/concepts/seal#migration-post-vault-1-5-1

### DIFF
--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -172,10 +172,9 @@ any storage backend.
    and wait until this process is complete (look for `seal re-wrap completed`).
 
 1. Seal migration is now completed. Take down the old active node, update its
-   configuration of the old active node to use the new seal blocks (completely
-   unaware of the old seal type) and bring it back up. It will be auto-unsealed if
-   the new seal is one of the Auto seals, or will require unseal keys if the new
-   seal is Shamir.
+   configuration to use the new seal blocks (completely unaware of the old seal type)
+   and bring it back up. It will be auto-unsealed if the new seal is one of the
+   Auto seals, or will require unseal keys if the new seal is Shamir.
 
 1. At this point, configuration files of all the nodes can be updated to only have the
    new seal information. Standby nodes can be restarted right away and the active

--- a/website/content/docs/concepts/seal.mdx
+++ b/website/content/docs/concepts/seal.mdx
@@ -173,7 +173,7 @@ any storage backend.
 
 1. Seal migration is now completed. Take down the old active node, update its
    configuration to use the new seal blocks (completely unaware of the old seal type)
-   and bring it back up. It will be auto-unsealed if the new seal is one of the
+   ,and bring it back up. It will be auto-unsealed if the new seal is one of the
    Auto seals, or will require unseal keys if the new seal is Shamir.
 
 1. At this point, configuration files of all the nodes can be updated to only have the


### PR DESCRIPTION
The following sentence does not read easily:
"Take down the old active node, update its configuration of the old active node to use the new seal blocks (completely unaware of the old seal type) and bring it back up."
I have changed this to the sentence below, which I believe reads better.
"Take down the old active node, update its configuration to use the new seal blocks (completely unaware of the old seal type) and bring it back up."