### PR TITLE
Vault documentation: fixed linking error

### DIFF
--- a/website/content/docs/internals/security.mdx
+++ b/website/content/docs/internals/security.mdx
@@ -109,7 +109,7 @@ This client token is then returned to the client.
 
 On each request a client provides this token. Vault then uses it to check that
 the token is valid and has not been revoked or expired, and generates an ACL
-based on the associated policies. Vault uses a strict default deny 
+based on the associated policies. Vault uses a strict default deny
 enforcement strategy. This means unless an associated policy allows for a given action,
 it will be denied. Each policy specifies a level of access granted to a path in
 Vault. When the policies are merged (if multiple policies are associated with a
@@ -118,7 +118,7 @@ client), the highest access level permitted is used. For example, if the
 "ops" policy permits read access to the "ops/" path, then the user gets the
 union of those. Policy is matched using the most specific defined policy, which
 may be an exact match or the longest-prefix match glob pattern. See
-[Policy Syntax](../concepts/policies#policy-syntax) for more details.
+[Policy Syntax](/docs/concepts/policies#policy-syntax) for more details.
 
 Certain operations are only permitted by "root" users, which is a distinguished
 policy built into Vault. This is similar to the concept of a root user on a


### PR DESCRIPTION
Fixing a linking issue for policy syntax in the Security Model documentation.

:mag: [Deploy Preview](https://vault-git-doc-policy-syntax-link-error-hashicorp.vercel.app/docs/internals/security#security-model)