### PR TITLE
mysql is also supported for transform external storage

### DIFF
--- a/website/content/docs/secrets/transform/index.mdx
+++ b/website/content/docs/secrets/transform/index.mdx
@@ -261,7 +261,7 @@ additional operations:
 #### Stores
 
 Tokenization is stateful. Tokenized state can be stored internally (the
-default) or in an external store. Currently only PostgreSQL is supported
+default) or in an external store. Currently only PostgreSQL and MySQL are supported
 for external storage.
 
 #### Mapping Modes


### PR DESCRIPTION
per https://www.vaultproject.io/api/secret/transform#driver and https://www.vaultproject.io/docs/secrets/transform/tokenization#external-sql-stores