### PR TITLE
Raft Snapshot Restore Bug

### DIFF
--- a/changelog/13107.txt
+++ b/changelog/13107.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes issue restoring raft storage snapshot
+```

--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -5,6 +5,7 @@ import { assign } from '@ember/polyfills';
 import { set } from '@ember/object';
 import RSVP from 'rsvp';
 import config from '../config/environment';
+import fetch from 'fetch';
 
 const { APP } = config;
 const { POLLING_URLS, NAMESPACE_ROOT_URLS } = APP;

--- a/ui/tests/integration/components/raft-storage-restore-test.js
+++ b/ui/tests/integration/components/raft-storage-restore-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { render, triggerEvent, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | raft-storage-restore', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it should restore snapshot', async function(assert) {
+    assert.expect(2);
+
+    this.server.post('/sys/storage/raft/snapshot', () => {
+      assert.ok(true, 'Request made to restore snapshot');
+      return;
+    });
+    this.server.post('/sys/storage/raft/snapshot-force', () => {
+      assert.ok(true, 'Request made to force restore snapshot');
+      return;
+    });
+
+    await render(hbs`<RaftStorageRestore />`);
+    await triggerEvent('[data-test-file-input]', 'change', {
+      files: [new Blob(['Raft Snapshot'])],
+    });
+    await click('[data-test-edit-form-submit]');
+    await click('#force-restore');
+    await click('[data-test-edit-form-submit]');
+  });
+});


### PR DESCRIPTION
Attempting to restore a raft snapshot in the UI would result in an error thrown from _fetch_. Updating the application adapter to use _ember-fetch_ fixes the issue. 

![image](https://user-images.githubusercontent.com/24611656/141020964-99cdb874-1cb5-4cdf-9291-6955aa72d000.png)
