### PR TITLE
Backport 1.9.x: OIDC: return full issuer uri on read provider (#13058)

### DIFF
--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -1240,7 +1240,7 @@ func (i *IdentityStore) pathOIDCReadProvider(ctx context.Context, req *logical.R
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"issuer":             provider.Issuer,
+			"issuer":             provider.effectiveIssuer,
 			"allowed_client_ids": provider.AllowedClientIDs,
 			"scopes_supported":   provider.ScopesSupported,
 		},

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -2514,7 +2514,11 @@ func TestOIDC_pathOIDCAssignmentExistenceCheck(t *testing.T) {
 
 // TestOIDC_Path_OIDCProvider tests CRUD operations for providers
 func TestOIDC_Path_OIDCProvider(t *testing.T) {
-	c, _, _ := TestCoreUnsealed(t)
+	redirectAddr := "http://localhost:8200"
+	conf := &CoreConfig{
+		RedirectAddr: redirectAddr,
+	}
+	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
 	ctx := namespace.RootContext(nil)
 	storage := &logical.InmemStorage{}
 
@@ -2551,7 +2555,7 @@ func TestOIDC_Path_OIDCProvider(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected := map[string]interface{}{
-		"issuer":             "",
+		"issuer":             redirectAddr + "/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{},
 		"scopes_supported":   []string{},
 	}
@@ -2591,7 +2595,7 @@ func TestOIDC_Path_OIDCProvider(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected = map[string]interface{}{
-		"issuer":             "",
+		"issuer":             redirectAddr + "/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{"test-client-id"},
 		"scopes_supported":   []string{"test-scope"},
 	}
@@ -2634,7 +2638,7 @@ func TestOIDC_Path_OIDCProvider(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected = map[string]interface{}{
-		"issuer":             "https://example.com:8200",
+		"issuer":             "https://example.com:8200/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{"test-client-id"},
 		"scopes_supported":   []string{"test-scope"},
 	}
@@ -2733,7 +2737,12 @@ func TestOIDC_Path_OIDCProvider_DuplicateTemplateKeys(t *testing.T) {
 // TestOIDC_Path_OIDCProvider_DeDuplication tests that a
 // provider doensn't have duplicate scopes or client IDs
 func TestOIDC_Path_OIDCProvider_Deduplication(t *testing.T) {
-	c, _, _ := TestCoreUnsealed(t)
+	redirectAddr := "http://localhost:8200"
+	conf := &CoreConfig{
+		RedirectAddr: redirectAddr,
+	}
+	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
+
 	ctx := namespace.RootContext(nil)
 	storage := &logical.InmemStorage{}
 
@@ -2769,7 +2778,7 @@ func TestOIDC_Path_OIDCProvider_Deduplication(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected := map[string]interface{}{
-		"issuer":             "",
+		"issuer":             redirectAddr + "/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{"test-id1", "test-id2"},
 		"scopes_supported":   []string{"test-scope1"},
 	}
@@ -2804,7 +2813,7 @@ func TestOIDC_Path_OIDCProvider_Update(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected := map[string]interface{}{
-		"issuer":             "https://example.com:8200",
+		"issuer":             "https://example.com:8200/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{"test-client-id"},
 		"scopes_supported":   []string{},
 	}
@@ -2831,7 +2840,7 @@ func TestOIDC_Path_OIDCProvider_Update(t *testing.T) {
 	})
 	expectSuccess(t, resp, err)
 	expected = map[string]interface{}{
-		"issuer":             "https://changedurl.com",
+		"issuer":             "https://changedurl.com/v1/identity/oidc/provider/test-provider",
 		"allowed_client_ids": []string{"test-client-id"},
 		"scopes_supported":   []string{},
 	}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -188,6 +188,10 @@ func TestCoreWithSealAndUI(t testing.T, opts *CoreConfig) *Core {
 		conf.Logger = opts.Logger
 	}
 
+	if opts.RedirectAddr != "" {
+		conf.RedirectAddr = opts.RedirectAddr
+	}
+
 	for k, v := range opts.LogicalBackends {
 		conf.LogicalBackends[k] = v
 	}


### PR DESCRIPTION
backports https://github.com/hashicorp/vault/pull/13058 into release/vault-1.9.x.

Steps:

```
git checkout release/vault-1.9.x
git checkout -b backport/1.9.x-oidc-issuer
git cherry-pick b325d7b05b46419c5296b3abcaae5a90ff9286cb
```