### PR TITLE
Return non-retryable errors on transit encrypt and decrypt failures

### DIFF
--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -142,14 +141,9 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 
 		plaintext, err := p.Decrypt(item.DecodedContext, item.DecodedNonce, item.Ciphertext)
 		if err != nil {
-			switch err.(type) {
-			case errutil.UserError:
-				batchResponseItems[i].Error = err.Error()
-				continue
-			default:
-				p.Unlock()
-				return nil, err
-			}
+			// Policy decryption returns InternalError in some cases which might not actually be considered internal errors.
+			batchResponseItems[i].Error = err.Error()
+			continue
 		}
 		batchResponseItems[i].Plaintext = plaintext
 	}

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -169,6 +169,11 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 	} else {
 		if batchResponseItems[0].Error != "" {
 			p.Unlock()
+
+			if internalErrorInBatch {
+				return nil, errutil.InternalError{Err: batchResponseItems[0].Error}
+			}
+
 			return logical.ErrorResponse(batchResponseItems[0].Error), logical.ErrInvalidRequest
 		}
 		resp.Data = map[string]interface{}{
@@ -184,9 +189,9 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 	// to the user first.
 	switch {
 	case userErrorInBatch:
-		logical.RespondWithStatusCode(resp, req, http.StatusBadRequest)
+		return logical.RespondWithStatusCode(resp, req, http.StatusBadRequest)
 	case internalErrorInBatch:
-		logical.RespondWithStatusCode(resp, req, http.StatusInternalServerError)
+		return logical.RespondWithStatusCode(resp, req, http.StatusInternalServerError)
 	}
 
 	return resp, nil

--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -90,12 +92,16 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 	batchResponseItems := make([]DecryptBatchResponseItem, len(batchInputItems))
 	contextSet := len(batchInputItems[0].Context) != 0
 
+	userErrorInBatch := false
+	internalErrorInBatch := false
+
 	for i, item := range batchInputItems {
 		if (len(item.Context) == 0 && contextSet) || (len(item.Context) != 0 && !contextSet) {
 			return logical.ErrorResponse("context should be set either in all the request blocks or in none"), logical.ErrInvalidRequest
 		}
 
 		if item.Ciphertext == "" {
+			userErrorInBatch = true
 			batchResponseItems[i].Error = "missing ciphertext to decrypt"
 			continue
 		}
@@ -104,6 +110,7 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 		if len(item.Context) != 0 {
 			batchInputItems[i].DecodedContext, err = base64.StdEncoding.DecodeString(item.Context)
 			if err != nil {
+				userErrorInBatch = true
 				batchResponseItems[i].Error = err.Error()
 				continue
 			}
@@ -113,6 +120,7 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 		if len(item.Nonce) != 0 {
 			batchInputItems[i].DecodedNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
 			if err != nil {
+				userErrorInBatch = true
 				batchResponseItems[i].Error = err.Error()
 				continue
 			}
@@ -141,7 +149,12 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 
 		plaintext, err := p.Decrypt(item.DecodedContext, item.DecodedNonce, item.Ciphertext)
 		if err != nil {
-			// Policy decryption returns InternalError in some cases which might not actually be considered internal errors.
+			switch err.(type) {
+			case errutil.InternalError:
+				internalErrorInBatch = true
+			default:
+				userErrorInBatch = true
+			}
 			batchResponseItems[i].Error = err.Error()
 			continue
 		}
@@ -164,6 +177,18 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 	}
 
 	p.Unlock()
+
+	// Depending on the errors in the batch, different status codes should be returned. User errors
+	// will return a 400 and precede internal errors which return a 500. The reasoning behind this is
+	// that user errors are non-retryable without making changes to the request, and should be surfaced
+	// to the user first.
+	switch {
+	case userErrorInBatch:
+		logical.RespondWithStatusCode(resp, req, http.StatusBadRequest)
+	case internalErrorInBatch:
+		logical.RespondWithStatusCode(resp, req, http.StatusInternalServerError)
+	}
+
 	return resp, nil
 }
 

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -361,7 +361,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		}
 
 		if ciphertext == "" {
-			batchResponseItems[i].Error = fmt.Errorf("empty ciphertext returned for input item %d", i).Error()
+			batchResponseItems[i].Error = fmt.Sprintf("empty ciphertext returned for input item %d", i)
 			continue
 		}
 

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -397,6 +397,11 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	} else {
 		if batchResponseItems[0].Error != "" {
 			p.Unlock()
+
+			if internalErrorInBatch {
+				return nil, errutil.InternalError{Err: batchResponseItems[0].Error}
+			}
+
 			return logical.ErrorResponse(batchResponseItems[0].Error), logical.ErrInvalidRequest
 		}
 
@@ -418,9 +423,9 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	// to the user first.
 	switch {
 	case userErrorInBatch:
-		logical.RespondWithStatusCode(resp, req, http.StatusBadRequest)
+		return logical.RespondWithStatusCode(resp, req, http.StatusBadRequest)
 	case internalErrorInBatch:
-		logical.RespondWithStatusCode(resp, req, http.StatusInternalServerError)
+		return logical.RespondWithStatusCode(resp, req, http.StatusInternalServerError)
 	}
 
 	return resp, nil

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -5,9 +5,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
@@ -262,6 +264,9 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	batchResponseItems := make([]EncryptBatchResponseItem, len(batchInputItems))
 	contextSet := len(batchInputItems[0].Context) != 0
 
+	userErrorInBatch := false
+	internalErrorInBatch := false
+
 	// Before processing the batch request items, get the policy. If the
 	// policy is supposed to be upserted, then determine if 'derived' is to
 	// be set or not, based on the presence of 'context' field in all the
@@ -273,6 +278,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 
 		_, err := base64.StdEncoding.DecodeString(item.Plaintext)
 		if err != nil {
+			userErrorInBatch = true
 			batchResponseItems[i].Error = err.Error()
 			continue
 		}
@@ -281,6 +287,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		if len(item.Context) != 0 {
 			batchInputItems[i].DecodedContext, err = base64.StdEncoding.DecodeString(item.Context)
 			if err != nil {
+				userErrorInBatch = true
 				batchResponseItems[i].Error = err.Error()
 				continue
 			}
@@ -290,6 +297,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		if len(item.Nonce) != 0 {
 			batchInputItems[i].DecodedNonce, err = base64.StdEncoding.DecodeString(item.Nonce)
 			if err != nil {
+				userErrorInBatch = true
 				batchResponseItems[i].Error = err.Error()
 				continue
 			}
@@ -356,11 +364,18 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 
 		ciphertext, err := p.Encrypt(item.KeyVersion, item.DecodedContext, item.DecodedNonce, item.Plaintext)
 		if err != nil {
+			switch err.(type) {
+			case errutil.InternalError:
+				internalErrorInBatch = true
+			default:
+				userErrorInBatch = true
+			}
 			batchResponseItems[i].Error = err.Error()
 			continue
 		}
 
 		if ciphertext == "" {
+			userErrorInBatch = true
 			batchResponseItems[i].Error = fmt.Sprintf("empty ciphertext returned for input item %d", i)
 			continue
 		}
@@ -396,6 +411,18 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	}
 
 	p.Unlock()
+
+	// Depending on the errors in the batch, different status codes should be returned. User errors
+	// will return a 400 and precede internal errors which return a 500. The reasoning behind this is
+	// that user errors are non-retryable without making changes to the request, and should be surfaced
+	// to the user first.
+	switch {
+	case userErrorInBatch:
+		logical.RespondWithStatusCode(resp, req, http.StatusBadRequest)
+	case internalErrorInBatch:
+		logical.RespondWithStatusCode(resp, req, http.StatusInternalServerError)
+	}
+
 	return resp, nil
 }
 

--- a/changelog/13111.txt
+++ b/changelog/13111.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/transit: Don't abort transit encrypt or decrypt batches on single item failure.
+```


### PR DESCRIPTION
This also address an issue found with transit encrypt and decrypt paths where a single batch item failure would abort the whole batch and simply return a top-level error.