### PR TITLE
Update `changelog/12621.txt` with the right category

### DIFF
--- a/changelog/12621.txt
+++ b/changelog/12621.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-agent: add profile support for AWS credentials when using the AWS auth method
+auth/aws: add profile support for AWS credentials when using the AWS auth method
 ```


### PR DESCRIPTION
Updates `changelog/12621.txt` with the right category from `agent` to `auth/aws`