### PR TITLE
Add troubleshooting guide

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1226,8 +1226,12 @@
     "path": "partnerships"
   },
   {
-    "divider": true
+    "title": "Troubleshoot",
+    "href": "https://learn.hashicorp.com/tutorials/vault/troubleshooting-vault"
   },
+  {
+    "divider": true
+  }, 
   {
     "title": "Platforms",
     "routes": [

--- a/website/redirects.next.js
+++ b/website/redirects.next.js
@@ -432,6 +432,11 @@ module.exports = [
   },
   // Guides and Intro redirects to Learn
   {
+    source: '/guides',
+    destination: 'https://learn.hashicorp.com/vault',
+    permanent: true,
+  },
+  {
     source: '/guides/getting-started',
     destination: 'https://learn.hashicorp.com/vault',
     permanent: true,


### PR DESCRIPTION
🔍 [Deploy Preview](https://vault-git-add-troubleshooting-guide-hashicorp.vercel.app/docs)

Per [discussion on Slack](https://hashicorp.slack.com/archives/CPEPB6WRL/p1636645479498100), adding **Troubleshoot** menu on the doc which takes to the troubleshooting guide on learn. 

![troubleshoot](https://user-images.githubusercontent.com/7660718/141342300-ef664f18-c6be-470d-9929-abfa74da1e89.png)

Also, adding missing redirect.  Apparently, some people type in `vaultproject.io/guides` in the browser to get to the old guides.  (TO DO: Remove the old markdown files post-Vault 1.9 to clean up.)
