### PR TITLE
OIDC Auth Bug

### DIFF
--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -9,7 +9,8 @@ export default Route.extend({
     let { auth_path: path, code, state } = this.paramsFor(this.routeName);
     let { namespaceQueryParam: namespace } = this.paramsFor('vault.cluster');
     path = window.decodeURIComponent(path);
-    let queryParams = { namespace, path, code, state };
+    const source = 'oidc-callback'; // required by event listener in auth-jwt component
+    let queryParams = { source, namespace, path, code, state };
     window.opener.postMessage(queryParams, window.origin);
   },
   renderTemplate() {

--- a/ui/tests/unit/components/auth-jwt-test.js
+++ b/ui/tests/unit/components/auth-jwt-test.js
@@ -1,0 +1,65 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import EmberObject from '@ember/object';
+import Evented from '@ember/object/evented';
+import sinon from 'sinon';
+import { run } from '@ember/runloop';
+
+const mockWindow = EmberObject.extend(Evented, {
+  origin: 'http://localhost:4200',
+});
+
+module('Unit | Component | auth-jwt', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.component = this.owner.lookup('component:auth-jwt');
+    this.component.set('window', mockWindow.create());
+    this.errorSpy = sinon.spy(this.component, 'handleOIDCError');
+  });
+
+  test('it should handle error for cross origin messages while waiting for oidc callback', async function(assert) {
+    assert.expect(1);
+    this.component.prepareForOIDC.perform(mockWindow.create());
+    this.component.window.trigger('message', { origin: 'http://anotherdomain.com', isTrusted: true });
+    assert.ok(this.errorSpy.calledOnce, 'Error handled from cross origin window message event');
+    run.cancelTimers();
+  });
+
+  test('it should handle error for untrusted messages while waiting for oidc callback', async function(assert) {
+    assert.expect(1);
+    this.component.prepareForOIDC.perform(mockWindow.create());
+    this.component.window.trigger('message', { origin: 'http://localhost:4200', isTrusted: false });
+    assert.ok(this.errorSpy.calledOnce, 'Error handled from untrusted window message event');
+    run.cancelTimers();
+  });
+  // test case for https://github.com/hashicorp/vault/issues/12436
+  test('it should ignore messages sent from outside the app while waiting for oidc callback', async function(assert) {
+    assert.expect(2);
+    this.component.prepareForOIDC.perform(mockWindow.create());
+    const message = {
+      origin: 'http://localhost:4200',
+      isTrusted: true,
+      data: {
+        namespace: 'foobar',
+        path: '/foo/bar',
+        state: 'authorized',
+        code: 204,
+      },
+    };
+
+    this.component.window.trigger('message', message);
+    message.data.source = 'foo-bar';
+    this.component.window.trigger('message', message);
+    message.data.source = 'oidc-callback';
+    this.component.window.trigger('message', message);
+
+    assert.ok(this.errorSpy.notCalled, 'Error handler not triggered while waiting for oidc callback message');
+    assert.equal(
+      this.component.exchangeOIDC.performCount,
+      1,
+      'exchangeOIDC method fires when oidc callback message is received'
+    );
+    run.cancelTimers();
+  });
+});


### PR DESCRIPTION
Resolves #12436

When using the MetaMask chrome extension it was reported that the OIDC auth login workflow was not working. After investigating the [source code](https://github.com/MetaMask/metamask-extension/blob/29fa00a97bd505c273b51c735cd03100c319db58/app/scripts/contentscript.js#L189) it was discovered that the javascript being injected calls `window.postMessage` which was being handled inadvertently by the _auth-jwt_ component. 

To guard against unintended messages from the same origin a `source` property was added to the message data which is then verified in the event handler. Unit tests were added to verify the functionality. 