### PR TITLE
fix consul tls error checking

### DIFF
--- a/physical/consul/consul.go
+++ b/physical/consul/consul.go
@@ -129,7 +129,9 @@ func NewConsulBackend(conf map[string]string, logger log.Logger) (physical.Backe
 	// Set MaxIdleConnsPerHost to the number of processes used in expiration.Restore
 	consulConf.Transport.MaxIdleConnsPerHost = consts.ExpirationRestoreWorkerCount
 
-	SetupSecureTLS(context.Background(), consulConf, conf, logger, false)
+	if err := SetupSecureTLS(context.Background(), consulConf, conf, logger, false); err != nil {
+		return nil, fmt.Errorf("client setup failed: %w", err)
+	}
 
 	consulConf.HttpClient = &http.Client{Transport: consulConf.Transport}
 	client, err := api.NewClient(consulConf)


### PR DESCRIPTION
We don't check for errors in the consul storage TLS setup. We might fail here
because of a missing certificate, bad permissions, etc. If anything is wrong,
vault just ignores the issues and continues, resulting in a lot of confusion.

Instead, lets return an error to the caller if this fails.