### PR TITLE
Vault-2257: don't log token error on DR Secondary

### DIFF
--- a/vault/core_metrics.go
+++ b/vault/core_metrics.go
@@ -136,6 +136,11 @@ func (c *Core) metricsLoop(stopCh chan struct{}) {
 // TokenStore; there is one per method because an additional level of abstraction
 // seems confusing.
 func (c *Core) tokenGaugeCollector(ctx context.Context) ([]metricsutil.GaugeLabelValues, error) {
+	if c.IsDRSecondary() {
+		// there is no expiration manager on DR Secondaries
+		return []metricsutil.GaugeLabelValues{}, nil
+	}
+
 	// stateLock or authLock protects the tokenStore pointer
 	c.stateLock.RLock()
 	ts := c.tokenStore
@@ -147,6 +152,11 @@ func (c *Core) tokenGaugeCollector(ctx context.Context) ([]metricsutil.GaugeLabe
 }
 
 func (c *Core) tokenGaugePolicyCollector(ctx context.Context) ([]metricsutil.GaugeLabelValues, error) {
+	if c.IsDRSecondary() {
+		// there is no expiration manager on DR Secondaries
+		return []metricsutil.GaugeLabelValues{}, nil
+	}
+
 	c.stateLock.RLock()
 	ts := c.tokenStore
 	c.stateLock.RUnlock()
@@ -168,6 +178,11 @@ func (c *Core) leaseExpiryGaugeCollector(ctx context.Context) ([]metricsutil.Gau
 }
 
 func (c *Core) tokenGaugeMethodCollector(ctx context.Context) ([]metricsutil.GaugeLabelValues, error) {
+	if c.IsDRSecondary() {
+		// there is no expiration manager on DR Secondaries
+		return []metricsutil.GaugeLabelValues{}, nil
+	}
+
 	c.stateLock.RLock()
 	ts := c.tokenStore
 	c.stateLock.RUnlock()
@@ -178,6 +193,11 @@ func (c *Core) tokenGaugeMethodCollector(ctx context.Context) ([]metricsutil.Gau
 }
 
 func (c *Core) tokenGaugeTtlCollector(ctx context.Context) ([]metricsutil.GaugeLabelValues, error) {
+	if c.IsDRSecondary() {
+		// there is no expiration manager on DR Secondaries
+		return []metricsutil.GaugeLabelValues{}, nil
+	}
+
 	c.stateLock.RLock()
 	ts := c.tokenStore
 	c.stateLock.RUnlock()

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -65,9 +65,7 @@ func (e extendedSystemViewImpl) SudoPrivilege(ctx context.Context, path string, 
 	// Resolve the token policy
 	te, err := e.core.tokenStore.Lookup(ctx, token)
 	if err != nil {
-		if !e.core.IsDRSecondary() {
-			e.core.logger.Error("failed to lookup sudo token", "error", err)
-		}
+		e.core.logger.Error("failed to lookup sudo token", "error", err)
 		return false
 	}
 

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -65,7 +65,9 @@ func (e extendedSystemViewImpl) SudoPrivilege(ctx context.Context, path string, 
 	// Resolve the token policy
 	te, err := e.core.tokenStore.Lookup(ctx, token)
 	if err != nil {
-		e.core.logger.Error("failed to lookup sudo token", "error", err)
+		if !e.core.IsDRSecondary() {
+			e.core.logger.Error("failed to lookup sudo token", "error", err)
+		}
 		return false
 	}
 

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -65,7 +65,9 @@ func (e extendedSystemViewImpl) SudoPrivilege(ctx context.Context, path string, 
 	// Resolve the token policy
 	te, err := e.core.tokenStore.Lookup(ctx, token)
 	if err != nil {
-		e.core.logger.Error("failed to lookup token", "error", err)
+		if !e.core.IsDRSecondary() {
+			e.core.logger.Error("failed to lookup sudo token", "error", err)
+		}
 		return false
 	}
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -141,7 +141,9 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 		var err error
 		te, err = c.tokenStore.Lookup(ctx, req.ClientToken)
 		if err != nil {
-			c.logger.Error("failed to lookup token", "error", err)
+			if !c.IsDRSecondary() {
+				c.logger.Error("failed to lookup acl token", "error", err)
+			}
 			return nil, nil, nil, nil, ErrInternalError
 		}
 		// Set the token entry here since it has not been cached yet

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -143,6 +143,7 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 		if err != nil {
 			if !c.IsDRSecondary() {
 				c.logger.Error("failed to lookup acl token", "error", err)
+				panic("TODO SW let's see if a test can get me a call stack")
 			}
 			return nil, nil, nil, nil, ErrInternalError
 		}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -141,9 +141,7 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 		var err error
 		te, err = c.tokenStore.Lookup(ctx, req.ClientToken)
 		if err != nil {
-			if !c.IsDRSecondary() {
-				c.logger.Error("failed to lookup acl token", "error", err)
-			}
+			c.logger.Error("failed to lookup acl token", "error", err)
 			return nil, nil, nil, nil, ErrInternalError
 		}
 		// Set the token entry here since it has not been cached yet

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -143,7 +143,6 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 		if err != nil {
 			if !c.IsDRSecondary() {
 				c.logger.Error("failed to lookup acl token", "error", err)
-				panic("TODO SW let's see if a test can get me a call stack")
 			}
 			return nil, nil, nil, nil, ErrInternalError
 		}


### PR DESCRIPTION
- Stop gauge collector "expiration manager is nil" errors on DR Secondaries
- update log messages to be identifiable (two paths no longer yield the same message)

It looked like at least one of the two updated error messages was being hit on DR Secondaries, but after extensive testing I haven't found any evidence for that. Updating messages to identify if it does happen in the future.