### PR TITLE
Add Rekey Example When Auto Unseal is Used

### DIFF
--- a/website/content/docs/commands/operator/rekey.mdx
+++ b/website/content/docs/commands/operator/rekey.mdx
@@ -35,6 +35,16 @@ $ vault operator rekey \
     -key-threshold=9
 ```
 
+Initialize a rekey when Auto Unseal is used for the Vault cluster:
+
+```shell-session
+$ vault operator rekey \
+    -target=recovery \
+    -init \
+    -key-shares=15 \
+    -key-threshold=9
+```
+
 Initialize a rekey and activate the verification process:
 
 ```shell-session


### PR DESCRIPTION
Added an example to explicitly show how to perform a Rekey operation when the Vault cluster is using Auto Unseal.  This is placed as the second example. 
The existing example code combines with the PGP keys so added a simple example without the PGP keys.