### PR TITLE
fix(docs-k8s-helm): changed server's podAntiAffinity labelSelector example to match helm default values

### DIFF
--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -530,8 +530,8 @@ and consider if they're appropriate for your deployment.
       requiredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:
         matchLabels:
-          app: {{ template "vault.name" . }}
-          release: "{{ .Release.Name }}"
+          app.kubernetes.io/name: {{ template "vault.name" . }}
+          app.kubernetes.io/instance: "{{ .Release.Name }}"
           component: server
         topologyKey: kubernetes.io/hostname
   ```


### PR DESCRIPTION
The example in the docs reffer to labels which are not set by the helm-chart. In the `values.yaml` the default is set to 
```
app.kubernetes.io/name: {{ template "vault.name" . }}
app.kubernetes.io/instance: "{{ .Release.Name }}"
component: server
```

I've updated the docs to represent that.