### PR TITLE
Add extra debugging to help identify failures within mssql test

### DIFF
--- a/plugins/database/mssql/mssql_test.go
+++ b/plugins/database/mssql/mssql_test.go
@@ -56,7 +56,7 @@ func TestInitialize(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			db := new()
-			dbtesting.AssertInitialize(t, db, test.req)
+			dbtesting.AssertInitializeCircleCiTest(t, db, test.req)
 			defer dbtesting.AssertClose(t, db)
 
 			if !db.Initialized {
@@ -144,7 +144,7 @@ func TestNewUser(t *testing.T) {
 			}
 
 			db := new()
-			dbtesting.AssertInitialize(t, db, initReq)
+			dbtesting.AssertInitializeCircleCiTest(t, db, initReq)
 			defer dbtesting.AssertClose(t, db)
 
 			createResp, err := db.NewUser(context.Background(), test.req)
@@ -250,7 +250,7 @@ func TestUpdateUser_password(t *testing.T) {
 			}
 
 			db := new()
-			dbtesting.AssertInitialize(t, db, initReq)
+			dbtesting.AssertInitializeCircleCiTest(t, db, initReq)
 			defer dbtesting.AssertClose(t, db)
 
 			createTestMSSQLUser(t, connURL, dbUser, initPassword, testMSSQLLogin)
@@ -313,7 +313,8 @@ func TestDeleteUser(t *testing.T) {
 	}
 
 	db := new()
-	dbtesting.AssertInitialize(t, db, initReq)
+
+	dbtesting.AssertInitializeCircleCiTest(t, db, initReq)
 	defer dbtesting.AssertClose(t, db)
 
 	createTestMSSQLUser(t, connURL, dbUser, initPassword, testMSSQLLogin)

--- a/sdk/database/dbplugin/v5/testing/test_helpers.go
+++ b/sdk/database/dbplugin/v5/testing/test_helpers.go
@@ -25,20 +25,22 @@ func getRequestTimeout(t *testing.T) time.Duration {
 // AssertInitializeCircleCiTest help to diagnose CircleCI failures within AssertInitialize for mssql tests failing
 // with "Failed to initialize: error verifying connection ..."
 func AssertInitializeCircleCiTest(t *testing.T, db dbplugin.Database, req dbplugin.InitializeRequest) dbplugin.InitializeResponse {
+	t.Helper()
 	maxAttempts := 5
 	var resp dbplugin.InitializeResponse
 	var err error
+
 	for i := 1; i <= maxAttempts; i++ {
 		resp, err = verifyInitialize(t, db, req)
-		if err != nil {
+		switch {
+		case err != nil:
 			t.Logf("Failed AssertInitialize attempt: %d with error:\n%+v\n", i, err)
-		} else {
-			if i > 1 {
-				t.Fatalf("AssertInitialize worked the %d time around with a 1 second sleep, but failed originally", i)
-			}
+			time.Sleep(1 * time.Second)
+		case i == 1:
 			return resp
+		default:
+			t.Fatalf("AssertInitialize worked the %d time around with a 1 second sleep, but failed originally", i)
 		}
-		time.Sleep(1 * time.Second)
 	}
 
 	t.Fatalf("Failed to initialize: %+v", err)
@@ -46,6 +48,7 @@ func AssertInitializeCircleCiTest(t *testing.T, db dbplugin.Database, req dbplug
 }
 
 func AssertInitialize(t *testing.T, db dbplugin.Database, req dbplugin.InitializeRequest) dbplugin.InitializeResponse {
+	t.Helper()
 	resp, err := verifyInitialize(t, db, req)
 	if err != nil {
 		t.Fatalf("Failed to initialize: %s", err)
@@ -54,8 +57,6 @@ func AssertInitialize(t *testing.T, db dbplugin.Database, req dbplugin.Initializ
 }
 
 func verifyInitialize(t *testing.T, db dbplugin.Database, req dbplugin.InitializeRequest) (dbplugin.InitializeResponse, error) {
-	t.Helper()
-
 	ctx, cancel := context.WithTimeout(context.Background(), getRequestTimeout(t))
 	defer cancel()
 


### PR DESCRIPTION
Even with the attempted fix in PR #13071, we are still occasionally seeing failures within CircleCI. This won't fix the problem
but perhaps will provide us additional insight into the issue when it does occur again.