### PR TITLE
sdk/queue: move lock before checking queue length

### DIFF
--- a/changelog/13143.txt
+++ b/changelog/13143.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk/queue: move lock before length check to prevent panics.
+```

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -88,7 +88,9 @@ func (pq *PriorityQueue) Pop() (*Item, error) {
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
 
-	if pq.Len() == 0 {
+	// We're using pq.data.Len() here to avoid deadlocking the exported
+	// Len() method.
+	if pq.data.Len() == 0 {
 		return nil, ErrEmpty
 	}
 

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -85,12 +85,12 @@ func (pq *PriorityQueue) Len() int {
 // wrapper/convenience method that calls heap.Pop, so consumers do not need to
 // invoke heap functions directly
 func (pq *PriorityQueue) Pop() (*Item, error) {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+
 	if pq.Len() == 0 {
 		return nil, ErrEmpty
 	}
-
-	pq.lock.Lock()
-	defer pq.lock.Unlock()
 
 	item := heap.Pop(&pq.data).(*Item)
 	delete(pq.dataMap, item.Key)

--- a/vendor/github.com/hashicorp/vault/sdk/queue/priority_queue.go
+++ b/vendor/github.com/hashicorp/vault/sdk/queue/priority_queue.go
@@ -85,12 +85,12 @@ func (pq *PriorityQueue) Len() int {
 // wrapper/convenience method that calls heap.Pop, so consumers do not need to
 // invoke heap functions directly
 func (pq *PriorityQueue) Pop() (*Item, error) {
-	pq.lock.Lock()
-	defer pq.lock.Unlock()
-
 	if pq.Len() == 0 {
 		return nil, ErrEmpty
 	}
+
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
 
 	item := heap.Pop(&pq.data).(*Item)
 	delete(pq.dataMap, item.Key)

--- a/vendor/github.com/hashicorp/vault/sdk/queue/priority_queue.go
+++ b/vendor/github.com/hashicorp/vault/sdk/queue/priority_queue.go
@@ -85,12 +85,12 @@ func (pq *PriorityQueue) Len() int {
 // wrapper/convenience method that calls heap.Pop, so consumers do not need to
 // invoke heap functions directly
 func (pq *PriorityQueue) Pop() (*Item, error) {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+
 	if pq.Len() == 0 {
 		return nil, ErrEmpty
 	}
-
-	pq.lock.Lock()
-	defer pq.lock.Unlock()
 
 	item := heap.Pop(&pq.data).(*Item)
 	delete(pq.dataMap, item.Key)


### PR DESCRIPTION
A panic can occur when `head.Pop` is called if the length of the queue has changed since checking if it was empty. This is because `head.Pop` calls swap under the hood. Moving the lock prior to checking should prevent a panic from happening.

Panic as seen in OpenLDAP secret engine:
```
Nov 01 13:32:38  vault[3385105]: panic: runtime error: index out of range [0] with length 0
4Nov 01 13:32:38  vault[3385105]: goroutine 10378 [running]:
5Nov 01 13:32:38  vault[3385105]: github.com/hashicorp/vault/sdk/queue.queue.Swap(...)
6Nov 01 13:32:38  vault[3385105]:         /gopath/src/github.com/hashicorp/vault/sdk/queue/priority_queue.go:167
7Nov 01 13:32:38  vault[3385105]: container/heap.Pop(0x62f5198, 0xc010b59c80, 0x8b16dc0, 0xc001a30d50)
8Nov 01 13:32:38  vault[3385105]:         /goroot/src/container/heap/heap.go:62 +0x64
9Nov 01 13:32:38  vault[3385105]: github.com/hashicorp/vault/sdk/queue.(*PriorityQueue).Pop(0xc010b59c80, 0x0, 0x0, 0x0)
10Nov 01 13:32:38  vault[3385105]:         /gopath/src/github.com/hashicorp/vault/sdk/queue/priority_queue.go:95 +0xa7
11Nov 01 13:32:38  vault[3385105]: github.com/hashicorp/vault-plugin-secrets-openldap.(*backend).popFromRotationQueue(0xc01bf67e00, 0x0, 0x0, 0x0)
12Nov 01 13:32:38  vault[3385105]:         /gopath/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/rotation.go:545 +0x85
13Nov 01 13:32:38  vault[3385105]: github.com/hashicorp/vault-plugin-secrets-openldap.(*backend).rotateCredential(0xc01bf67e00, 0x62dd268, 0xc010b59cc0, 0x62dee68, 0xc002b7d8c0, 0x0)
14Nov 01 13:32:38  vault[3385105]:         /gopath/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/rotation.go:155 +0x8d
15Nov 01 13:32:38  vault[3385105]: github.com/hashicorp/vault-plugin-secrets-openldap.(*backend).rotateCredentials(...)
16Nov 01 13:32:38  vault[3385105]:         /gopath/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/rotation.go:144
17Nov 01 13:32:38  vault[3385105]: github.com/hashicorp/vault-plugin-secrets-openldap.(*backend).runTicker(0xc01bf67e00, 0x62dd268, 0xc010b59cc0, 0x62dee68, 0xc002b7d8c0)
18Nov 01 13:32:38  vault[3385105]:         /gopath/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/rotation.go:112 +0x116
19Nov 01 13:32:38  vault[3385105]: created by github.com/hashicorp/vault-plugin-secrets-openldap.(*backend).initQueue
20Nov 01 13:32:38  vault[3385105]:         /gopath/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/rotation.go:449 +0x165
21Nov 01 13:32:44  vault[3391153]: Fortanix C_GetFunctionList -> 0
```