### PR TITLE
Fix out-dated hyperlink

### DIFF
--- a/website/content/docs/internals/limits.mdx
+++ b/website/content/docs/internals/limits.mdx
@@ -141,7 +141,7 @@ the `vault.identity.upsert_group_txn` metrics.
 
 Very large internal groups should be avoided (more than 1000 members),
 because the membership list in a group must reside in a single storage entry.
-Instead, consider using [external groups](/docs/secrets/identity#external-vs-internal-groups) or split the group up into multiple sub-groups.
+Instead, consider using [external groups](/docs/concepts/identity#external-vs-internal-groups) or split the group up into multiple sub-groups.
 
 ### Token limits
 


### PR DESCRIPTION
It was pointed out that the Vault Limits and Maximums docs points to a wrong doc. 

🗒️ [Slack message](https://hashicorp.slack.com/archives/C8DK5PR0B/p16367272500570000)

🔍 [Deploy Preview](https://vault-git-fix-external-grp-link-hashicorp.vercel.app/docs/internals/limits#entity-and-group-limits)

This PR fixes the hyper link to the correct doc. 
