### PR TITLE
Hide verify-connection attribute on connection config show page

### DIFF
--- a/changelog/13152.txt
+++ b/changelog/13152.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Do not show verify connection value on database connection config page
+```

--- a/ui/app/utils/database-helpers.js
+++ b/ui/app/utils/database-helpers.js
@@ -5,7 +5,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
     fields: [
       { attr: 'plugin_name' },
       { attr: 'name' },
-      { attr: 'verify_connection' },
+      { attr: 'verify_connection', show: false },
       { attr: 'password_policy' },
       { attr: 'url', group: 'pluginConfig' },
       { attr: 'username', group: 'pluginConfig', show: false },
@@ -26,7 +26,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
       { attr: 'plugin_name' },
       { attr: 'name' },
       { attr: 'connection_url' },
-      { attr: 'verify_connection' },
+      { attr: 'verify_connection', show: false },
       { attr: 'password_policy' },
       { attr: 'username', group: 'pluginConfig', show: false },
       { attr: 'password', group: 'pluginConfig', show: false },
@@ -44,7 +44,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
       { attr: 'plugin_name' },
       { attr: 'name' },
       { attr: 'connection_url' },
-      { attr: 'verify_connection' },
+      { attr: 'verify_connection', show: false },
       { attr: 'password_policy' },
       { attr: 'username', group: 'pluginConfig', show: false },
       { attr: 'password', group: 'pluginConfig', show: false },
@@ -61,7 +61,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
     fields: [
       { attr: 'plugin_name' },
       { attr: 'name' },
-      { attr: 'verify_connection' },
+      { attr: 'verify_connection', show: false },
       { attr: 'password_policy' },
       { attr: 'connection_url', group: 'pluginConfig' },
       { attr: 'username', group: 'pluginConfig', show: false },
@@ -81,7 +81,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
     fields: [
       { attr: 'plugin_name' },
       { attr: 'name' },
-      { attr: 'verify_connection' },
+      { attr: 'verify_connection', show: false },
       { attr: 'password_policy' },
       { attr: 'connection_url', group: 'pluginConfig' },
       { attr: 'username', group: 'pluginConfig', show: false },
@@ -101,7 +101,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
     fields: [
       { attr: 'plugin_name' },
       { attr: 'name' },
-      { attr: 'verify_connection' },
+      { attr: 'verify_connection', show: false },
       { attr: 'password_policy' },
       { attr: 'connection_url', group: 'pluginConfig' },
       { attr: 'username', group: 'pluginConfig', show: false },
@@ -121,7 +121,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
     fields: [
       { attr: 'plugin_name' },
       { attr: 'name' },
-      { attr: 'verify_connection' },
+      { attr: 'verify_connection', show: false },
       { attr: 'password_policy' },
       { attr: 'connection_url', group: 'pluginConfig' },
       { attr: 'username', group: 'pluginConfig', show: false },
@@ -141,7 +141,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
     fields: [
       { attr: 'plugin_name' },
       { attr: 'name' },
-      { attr: 'verify_connection' },
+      { attr: 'verify_connection', show: false },
       { attr: 'password_policy' },
       { attr: 'connection_url', group: 'pluginConfig' },
       { attr: 'username', group: 'pluginConfig', show: false },
@@ -159,7 +159,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
     fields: [
       { attr: 'plugin_name' },
       { attr: 'name' },
-      { attr: 'verify_connection' },
+      { attr: 'verify_connection', show: false },
       { attr: 'password_policy' },
       { attr: 'connection_url', group: 'pluginConfig' },
       { attr: 'username', group: 'pluginConfig', show: false },


### PR DESCRIPTION
Fixes a misleading UI where `verify_connection` value is shown on the database secrets engine connection show page, where it is never returned from the API. Issue #13119 is related to this fix.

`verify_connection` is [only used when saving the connection](https://www.vaultproject.io/api-docs/secret/databases#configure-connection), so it isn't stored with the other attributes and shouldn't be shown on the connection page. 

**Before, after unchecking "Verify connection":**
<img width="1336" alt="Screen Shot 2021-11-15 at 4 35 11 PM" src="https://user-images.githubusercontent.com/82459713/141863605-59033a8c-7743-4e59-9c25-201c95d5b579.png">

**After, on same connection:**
<img width="1336" alt="Screen Shot 2021-11-15 at 4 34 54 PM" src="https://user-images.githubusercontent.com/82459713/141863602-c2c559c0-4e22-4c1e-af5a-025e3e0348bf.png">
