### PR TITLE
identity/oidc: Adds section to 1.9 upgrade guide for ACL policy requirements

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.9.0.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.9.0.mdx
@@ -14,6 +14,26 @@ official guidance until the release has been completed.
 This page contains the list of deprecations and important or breaking changes
 for Vault 1.9.0 compared to 1.8. Please read it carefully.
 
+## OIDC Provider
+
+Vault 1.9.0 introduced the ability for Vault to be an OpenID Connect (OIDC) identity
+provider. To support the feature, Vault's [default policy](https://www.vaultproject.io/docs/concepts/policies#default-policy)
+was modified to include an ACL rule for its Authorization Endpoint. Due to the handling
+of Vault's default policy during upgrades, existing deployments of Vault that are upgraded
+to 1.9.0 will not have this required ACL rule.
+
+If you're upgrading to 1.9.0 and want to use the new OIDC provider feature, the following
+ACL rule must be applied to the default policy **or** a policy associated with the Vault
+[Auth Method](https://www.vaultproject.io/docs/auth) used to authenticate end-users during
+the OIDC flow.
+
+```hcl
+# Allow a token to make requests to the Authorization Endpoint for OIDC providers.
+path "identity/oidc/provider/+/authorize" {
+  capabilities = ["read", "update"]
+}
+```
+
 ## Identity Tokens
 
 The Identity secrets engine has changed the procedure for creating Identity

--- a/website/content/docs/upgrading/upgrade-to-1.9.0.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.9.0.mdx
@@ -23,7 +23,7 @@ of Vault's default policy during upgrades, existing deployments of Vault that ar
 to 1.9.0 will not have this required ACL rule.
 
 If you're upgrading to 1.9.0 and want to use the new OIDC provider feature, the following
-ACL rule must be applied to the default policy **or** a policy associated with the Vault
+ACL rule must be added to the default policy **or** a policy associated with the Vault
 [Auth Method](https://www.vaultproject.io/docs/auth) used to authenticate end-users during
 the OIDC flow.
 


### PR DESCRIPTION
This PR adds a section to the 1.9 upgrade guide to call out the ACL policy requirements for the OIDC provider feature. Existing deployments of Vault that are upgraded to 1.9 will not have the required ACL rule that was added to the default policy (see [policy_store.go#L154-L157](https://github.com/hashicorp/vault/blob/main/vault/policy_store.go#L154-L157)) for 1.9.

This functions as designed and is not a new discovery. We wanted the Authorization Endpoint to be an authenticated endpoint. This guide is necessary because changes to the default policy are not applied during upgrades.