### PR TITLE
feat: add `backport.yml`

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,49 @@
+---
+name: Backport Assistant Runner
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    container: hashicorpdev/backport-assistant:0.2.3
+    steps:
+      - name: Backport changes to stable-website
+        run: |
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
+          BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+      - name: Backport changes to latest release branch
+        run: |
+          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/labels?per_page=100")
+          ret="$?"
+          if [[ "$ret" -ne 0 ]]; then
+              echo "The GitHub API returned $ret"
+              exit $ret
+          fi
+
+          # get the latest backport label excluding any website labels, ex: `backport/0.3.x` and not `backport/website`
+          latest_backport_label=$(echo "$resp" | jq -r '.[] | select(.name | (startswith("backport/") and (contains("website") | not))) | .name' | sort -rV | head -n1)
+          echo "Latest backport label: $latest_backport_label"
+
+          # set BACKPORT_TARGET_TEMPLATE for backport-assistant
+          # trims backport/ from the beginning with parameter substitution
+          export BACKPORT_TARGET_TEMPLATE="release/${latest_backport_label#backport/}"
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+      - name: Backport changes to targeted release branch
+        run: |
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.\\w+)"
+          BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -20,7 +20,7 @@ jobs:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      - name: Backport changes to latest release branch
+      - name: Backport changes labeled website to latest release branch
         run: |
           resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/releases?per_page=100")
           ret="$?"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,20 +22,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to latest release branch
         run: |
-          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/labels?per_page=100")
+          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/releases?per_page=100")
           ret="$?"
           if [[ "$ret" -ne 0 ]]; then
               echo "The GitHub API returned $ret"
               exit $ret
           fi
 
-          # get the latest backport label excluding any website labels, ex: `backport/0.3.x` and not `backport/website`
-          latest_backport_label=$(echo "$resp" | jq -r '.[] | select(.name | (startswith("backport/") and (contains("website") | not))) | .name' | sort -rV | head -n1)
-          echo "Latest backport label: $latest_backport_label"
+          # find the latest non-rc release
+          latest_version=$(echo "$resp" | tr '\r\n' ' ' | jq -r '.[] | select(.name|test("^v\\d+\\.\\d+\\.\\d+$")) | .name' | sort -rV | head -n1)
+          echo "Latest non-rc version: $latest_version"
 
-          # set BACKPORT_TARGET_TEMPLATE for backport-assistant
-          # trims backport/ from the beginning with parameter substitution
-          export BACKPORT_TARGET_TEMPLATE="release/${latest_backport_label#backport/}"
+          # strip leading "v" &
+          target="${latest_version#v}"
+          # replace patch version with "x"
+          target="${target%.*}.x"
+          
+          export BACKPORT_TARGET_TEMPLATE="release/$target"
           backport-assistant backport -automerge
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -39,7 +39,7 @@ jobs:
           target="${target%.*}.x"
           
           export BACKPORT_TARGET_TEMPLATE="release/$target"
-          backport-assistant backport -automerge
+          backport-assistant backport
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to targeted release branch
         run: |
-          backport-assistant backport -automerge
+          backport-assistant backport
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.\\w+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"


### PR DESCRIPTION
# Description

This introduces a workflow that uses [backport-assistant](https://github.com/hashicorp/backport-assistant) to backport changes (primarily docs changes) to designated release/branches and/or stable-website

The incoming behavior based on [Waypoint](https://github.com/hashicorp/waypoint/blob/main/.github/workflows/backport.yml)

## Usage

This replaces <kbd><a href="https://github.com/hashicorp/vault/labels/docs-cherrypick">docs-cherrypick</a></kbd> with a set of new labels.

Labels:
- <kbd>backport/website</kbd>
  - will backport changes to `stable-website` (YES AUTOMERGE)
    - **AND** `release/{LATEST}` (NO AUTOMERGE)
  - `{LATEST}` is determined by the greatest semver out of all GitHub releases that match a regex (`^v\d+\.\d+\.\d+$`)
- <kbd>backport/{TARGET}</kbd>
  - will backport changes to `release/{TARGET}` (NO AUTOMERGE)
  - ex. <kbd>backport/1.8.x</kbd>
    - will backport changes to `release/1.8.x`


![image](https://user-images.githubusercontent.com/26389321/143084369-ea184497-7e18-4b91-a3b5-05fd674b82cc.png)

## Why is this being proposed?

The intent is to provide a more flexible backporting flow that...
- is easy to use
- is standardized across different teams (less for authors and engineers to re/learn when authoring docs-changes in different product repositories)
- supports the future of versioned-docs


## Dependencies

Requires a GitHub repo secret, `ELEVATED_GITHUB_TOKEN` to be created and added (should belong to a "hc-vault-bot" GitHub bot account)

Requires GitHub labels to be created - ex:
- <kbd>backport/website</kbd>
- <kbd>backport/1.8.x</kbd>
- <kbd>backport/1.7.x</kbd>
