### PR TITLE
remove nil response to 404 translation for PatchOperation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-azure v0.11.1
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.11.0
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0
-	github.com/hashicorp/vault-plugin-secrets-kv v0.10.1
+	github.com/hashicorp/vault-plugin-secrets-kv v0.5.7-0.20211123171606-16933c88368a
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.5.1
 	github.com/hashicorp/vault-plugin-secrets-openldap v0.6.0
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -959,6 +959,8 @@ github.com/hashicorp/vault-plugin-secrets-gcp v0.11.0 h1:3i2uXY/n4jJv71baXeS1q19
 github.com/hashicorp/vault-plugin-secrets-gcp v0.11.0/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0 h1:0Vi5WEIpZctk/ZoRClodV9WCnM/lCzw9XekMhRZdo8k=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0/go.mod h1:6DPwGu8oGR1sZRpjwkcAnrQZWQuAJ/Ph+rQHfUo1Yf4=
+github.com/hashicorp/vault-plugin-secrets-kv v0.5.7-0.20211123171606-16933c88368a h1:GVA3sY+FRhQrMexWGMCsIfVVMgcdru36WMKvDtKed5I=
+github.com/hashicorp/vault-plugin-secrets-kv v0.5.7-0.20211123171606-16933c88368a/go.mod h1:TNPRoB53Twd9tYvlhqqEhMsQPiVN604kZw9jr2zUzDk=
 github.com/hashicorp/vault-plugin-secrets-kv v0.10.1 h1:88a6YkbU0FCboZoFdB5uv6ukBf3gc3zDLKM4z64dWxo=
 github.com/hashicorp/vault-plugin-secrets-kv v0.10.1/go.mod h1:TNPRoB53Twd9tYvlhqqEhMsQPiVN604kZw9jr2zUzDk=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.5.1 h1:Maewon4nu0KL1ALBOvL6Rsj+Qyr9hdULWflyMz7+9nk=

--- a/sdk/logical/response_util.go
+++ b/sdk/logical/response_util.go
@@ -17,7 +17,7 @@ import (
 func RespondErrorCommon(req *Request, resp *Response, err error) (int, error) {
 	if err == nil && (resp == nil || !resp.IsError()) {
 		switch {
-		case req.Operation == ReadOperation, req.Operation == PatchOperation:
+		case req.Operation == ReadOperation:
 			if resp == nil {
 				return http.StatusNotFound, nil
 			}


### PR DESCRIPTION
 PR #12687 included translation of a nil `logical.Response` for a `PatchOperation` request to a 404. After further review, there are cases where `CreateOperation` and `UpdateOperation` handlers return a nil response resulting in a 204. It is prudent to remain consistent for operations against the same endpoint. With that said, it makes sense to remove this global translation. Backends will need to call the `logical.RespondWithStatusCode` with `http.StatusNotFound` to embed a `404 Not Found` as the `http_status_code` for the `logical.Response`.

The `TestHandler_Patch_NotFound` test has been removed as that was written specifically to ensure that the global nil -> 404 translation occurred.

PR [#56](https://github.com/hashicorp/vault-plugin-secrets-kv/pull/56) for `vault-plugin-secrets-kv` removes the implied `404 Not Found` response by returning a nil `logical.Response` in favor of an explicit response.