### PR TITLE
Fix startup failures when aliases from a pre-1.9 vault version exist

### DIFF
--- a/changelog/13169.txt
+++ b/changelog/13169.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity: Fix regression preventing startup when aliases were created pre-1.9.
+```

--- a/vault/identity_store_schema.go
+++ b/vault/identity_store_schema.go
@@ -71,7 +71,8 @@ func aliasesTableSchema(lowerCaseName bool) *memdb.TableSchema {
 				},
 			},
 			"local_bucket_key": {
-				Name: "local_bucket_key",
+				Name:         "local_bucket_key",
+				AllowMissing: true,
 				Indexer: &memdb.StringFieldIndex{
 					Field: "LocalBucketKey",
 				},


### PR DESCRIPTION
Add AllowMissing to local_bucket_key schema, preventing startup failures in post-unseal when aliases from an older version exist.  Fixes #13158.