### PR TITLE
docs/identity: fix template parameter for groups

### DIFF
--- a/website/content/docs/concepts/oidc-provider.mdx
+++ b/website/content/docs/concepts/oidc-provider.mdx
@@ -51,12 +51,12 @@ Example of a JSON template for a scope:
 
 ```
 {
-  "userinfo": {
-    "groups": {{identity.entity.group_names}},
-    "email": {{identity.entity.metadata.user_email}},
-    "username": {{identity.entity.aliases.usermap_123.metadata.username}},
-  },
-  "nbf": {{time.now}}
+    "username": {{identity.entity.aliases.$MOUNT_ACCESSOR.name}},
+    "contact": {
+        "email": {{identity.entity.metadata.email}},
+        "phone_number": {{identity.entity.metadata.phone_number}}
+    },
+    "groups": {{identity.entity.groups.names}}
 }
 ```
 

--- a/website/content/docs/secrets/identity/identity-token.mdx
+++ b/website/content/docs/secrets/identity/identity-token.mdx
@@ -73,7 +73,7 @@ For example:
   "color": {{identity.entity.metadata.color}},
   "userinfo": {
      "username": {{identity.entity.aliases.usermap_123.metadata.username}},
-     "groups": {{identity.entity.group_names}}
+     "groups": {{identity.entity.groups.names}}
   },
   "nbf": {{time.now}}
 }

--- a/website/content/docs/secrets/identity/oidc-provider.mdx
+++ b/website/content/docs/secrets/identity/oidc-provider.mdx
@@ -55,11 +55,12 @@ authorized to use a specific OIDC client for authentication flows:
    ```text
    $ TOKEN_TEMPLATE=$(cat << EOF
    {
-       "username": {{identity.entity.aliases.$USERPASS_ACCESSOR.name}},
+       "username": {{identity.entity.aliases.$MOUNT_ACCESSOR.name}},
        "contact": {
            "email": {{identity.entity.metadata.email}},
            "phone_number": {{identity.entity.metadata.phone_number}}
-       }
+       },
+       "groups": {{identity.entity.groups.names}}
    }
    EOF
    )


### PR DESCRIPTION
This PR fixes the template parameter for groups that's documented for both OIDC providers and Identity tokens. Previously, the groups template parameter was documented as `identity.entity.group_names`, which is not a valid parameter from the [list of usable parameters](https://www.vaultproject.io/docs/secrets/identity#token-contents-and-templates). Using `identity.entity.group_names` resulted in a template validation error when used in both systems. It's replaced by `identity.entity.groups.names`.

Additionally, this PR makes the documented template a bit more consistent in both the regular and conceptual docs.