### PR TITLE
fixing the injector.webhookAnnotations annotation

### DIFF
--- a/website/content/docs/platform/k8s/helm/examples/injector-tls-cert-manager.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/injector-tls-cert-manager.mdx
@@ -139,5 +139,5 @@ $ helm install vault hashicorp/vault \
   --set injector.replicas=2 \
   --set injector.leaderElector.enabled=false \
   --set injector.certs.secretName=injector-tls \
-  --set injector.webhookAnnotations="cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/injector-tls"
+  --set injector.webhookAnnotations="cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/injector-certificate"
 ```


### PR DESCRIPTION
Fixing the `injector.webhookAnnotations` annotation in Helm install command which should contain the name of the `Certificate` resource, instead of the name of the underlying K8S secret which keeps the TLS cert.

[More info](https://cert-manager.io/docs/concepts/ca-injector/#injecting-ca-data-from-a-certificate-resource)

