### PR TITLE
UI/Make revocation time and credential dates human-readable

### DIFF
--- a/ui/app/templates/components/generate-credentials.hbs
+++ b/ui/app/templates/components/generate-credentials.hbs
@@ -42,7 +42,9 @@
     {{/unless}}
     {{#each model.attrs as |attr|}}
       {{#if (eq attr.type "object")}}
-        <InfoTableRow @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} @value={{stringify (get model attr.name)}} />
+        <InfoTableRow 
+          @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
+          @value={{stringify (get model attr.name)}} />
       {{else}}
         {{#if (or
           (eq attr.name "key")
@@ -51,7 +53,9 @@
           (eq attr.name "privateKey")
           attr.options.masked
         )}}
-          <InfoTableRow @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} @value={{get model attr.name}}>
+          <InfoTableRow 
+            @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
+            @value={{get model attr.name}}>
             <MaskedInput
               @value={{get model attr.name}}
               @name={{attr.name}}
@@ -59,8 +63,14 @@
               @allowCopy={{true}}
             />
           </InfoTableRow>
+        {{else if (and (get model attr.name) (or (eq attr.name "issueDate") (eq attr.name "expiryDate")))}}
+          <InfoTableRow data-test-table-row 
+            @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
+            @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a' isFormatted=true}} />
         {{else}}
-          <InfoTableRow @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} @value={{get model attr.name}} />
+          <InfoTableRow 
+            @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
+            @value={{get model attr.name}} />
         {{/if}}
       {{/if}}
     {{/each}}

--- a/ui/app/templates/components/generate-credentials.hbs
+++ b/ui/app/templates/components/generate-credentials.hbs
@@ -67,6 +67,10 @@
           <InfoTableRow data-test-table-row 
             @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
             @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a' isFormatted=true}} />
+        {{else if (and (get model attr.name) (or (eq attr.name "revocationTime")))}}
+          <InfoTableRow data-test-table-row 
+            @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
+            @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a'}} />
         {{else}}
           <InfoTableRow 
             @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 

--- a/ui/app/templates/components/generate-credentials.hbs
+++ b/ui/app/templates/components/generate-credentials.hbs
@@ -67,7 +67,7 @@
           <InfoTableRow data-test-table-row 
             @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
             @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a' isFormatted=true}} />
-        {{else if (and (get model attr.name) (or (eq attr.name "revocationTime")))}}
+        {{else if (and (get model attr.name) (eq attr.name "revocationTime"))}}
           <InfoTableRow data-test-table-row 
             @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
             @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a'}} />

--- a/ui/app/templates/components/pki-cert-show.hbs
+++ b/ui/app/templates/components/pki-cert-show.hbs
@@ -28,7 +28,7 @@
           />
         </InfoTableRow>
       {{else if (and (get model attr.name) (or (eq attr.name "issueDate") (eq attr.name "expiryDate")))}}
-       <InfoTableRow data-test-table-row 
+        <InfoTableRow data-test-table-row 
           @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
           @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a' isFormatted=true}} />
       {{else}}

--- a/ui/app/templates/components/pki-cert-show.hbs
+++ b/ui/app/templates/components/pki-cert-show.hbs
@@ -31,7 +31,7 @@
         <InfoTableRow data-test-table-row 
           @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
           @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a' isFormatted=true}} />
-      {{else if (and (get model attr.name) (or (eq attr.name "revocationTime")))}}
+      {{else if (and (get model attr.name) (eq attr.name "revocationTime"))}}
         <InfoTableRow data-test-table-row 
           @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
           @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a'}} />

--- a/ui/app/templates/components/pki-cert-show.hbs
+++ b/ui/app/templates/components/pki-cert-show.hbs
@@ -31,6 +31,10 @@
         <InfoTableRow data-test-table-row 
           @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
           @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a' isFormatted=true}} />
+      {{else if (and (get model attr.name) (or (eq attr.name "revocationTime")))}}
+        <InfoTableRow data-test-table-row 
+          @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
+          @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a'}} />
       {{else}}
         <InfoTableRow data-test-table-row 
           @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 


### PR DESCRIPTION
### Make revocation time human-readable:

_**Before**_

<img width="462" alt="Screen Shot 2021-11-17 at 4 02 13 PM" src="https://user-images.githubusercontent.com/68122737/142301545-9d2d1d8c-eb94-43ef-97f5-e2078cd4810e.png">


**_With fix_**
<img width="508" alt="Screen Shot 2021-11-17 at 4 02 40 PM" src="https://user-images.githubusercontent.com/68122737/142301593-968d1f6b-d7b1-47af-830b-d0e7e1ad68f5.png">

### Reformat timestamps for generated cert credentials: 

_**Before**_

<img width="773" alt="Screen Shot 2021-11-17 at 3 09 31 PM" src="https://user-images.githubusercontent.com/68122737/142301689-4941dbd7-b70c-460f-8920-cd76dfd32bf1.png">


_**With fix**_

<img width="763" alt="Screen Shot 2021-11-17 at 4 01 32 PM" src="https://user-images.githubusercontent.com/68122737/142301489-98a7bd99-2dd8-44b1-8e9c-310f9de1d778.png">

