### PR TITLE
docs: move deprecation notices down the navbar

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -12,19 +12,6 @@
     "divider": true
   },
   {
-    "title": "Feature Deprecation Notice and Plans",
-    "routes": [
-      {
-        "title": "Overview",
-        "path": "deprecation"
-      },
-      {
-        "title": "FAQ",
-        "path": "deprecation/faq"
-      }
-    ]
-  },
-  {
     "title": "Browser Support",
     "path": "browser-support"
   },
@@ -1745,7 +1732,22 @@
   {
     "divider": true
   },
-
+  {
+    "title": "Deprecation Notices",
+    "routes": [
+      {
+        "title": "Overview",
+        "path": "deprecation"
+      },
+      {
+        "title": "FAQ",
+        "path": "deprecation/faq"
+      }
+    ]
+  },
+  {
+    "divider": true
+  },
   {
     "title": "Glossary",
     "path": "glossary"


### PR DESCRIPTION
Moved from one of the first items in the navbar down to one of the last. They are not high priority information and should be grouped with upgrade and release notes.