### PR TITLE
Add a new parameter "allowed_managed_keys" to mount config

### DIFF
--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -154,6 +154,7 @@ type MountConfigInput struct {
 	PassthroughRequestHeaders []string          `json:"passthrough_request_headers,omitempty" mapstructure:"passthrough_request_headers"`
 	AllowedResponseHeaders    []string          `json:"allowed_response_headers,omitempty" mapstructure:"allowed_response_headers"`
 	TokenType                 string            `json:"token_type,omitempty" mapstructure:"token_type"`
+	AllowedManagedKeys        []string          `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
 
 	// Deprecated: This field will always be blank for newer server responses.
 	PluginName string `json:"plugin_name,omitempty" mapstructure:"plugin_name"`
@@ -181,6 +182,7 @@ type MountConfigOutput struct {
 	PassthroughRequestHeaders []string `json:"passthrough_request_headers,omitempty" mapstructure:"passthrough_request_headers"`
 	AllowedResponseHeaders    []string `json:"allowed_response_headers,omitempty" mapstructure:"allowed_response_headers"`
 	TokenType                 string   `json:"token_type,omitempty" mapstructure:"token_type"`
+	AllowedManagedKeys        []string `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
 
 	// Deprecated: This field will always be blank for newer server responses.
 	PluginName string `json:"plugin_name,omitempty" mapstructure:"plugin_name"`

--- a/changelog/13202.txt
+++ b/changelog/13202.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+/sys/mounts/:path/tune: Add `allowed_managed_keys` field to mount config which is a list of managed key registry entry names that the mount in question is allowed to access.
+```

--- a/http/sys_mount_test.go
+++ b/http/sys_mount_test.go
@@ -1549,3 +1549,86 @@ func TestSysTuneMount_passthroughRequestHeaders(t *testing.T) {
 		t.Fatalf("bad:\nExpected: %#v\nActual:%#v", expected, actual)
 	}
 }
+
+func TestSysTuneMount_allowedManagedKeys(t *testing.T) {
+	core, _, token := vault.TestCoreUnsealed(t)
+	ln, addr := TestServer(t, core)
+	defer ln.Close()
+	TestServerAuth(t, addr, token)
+
+	// Mount-tune the allowed_managed_keys
+	resp := testHttpPost(t, token, addr+"/v1/sys/mounts/secret/tune", map[string]interface{}{
+		"allowed_managed_keys": "test_key",
+	})
+	testResponseStatus(t, resp, 204)
+
+	// Check results
+	resp = testHttpGet(t, token, addr+"/v1/sys/mounts/secret/tune")
+	testResponseStatus(t, resp, 200)
+
+	actual := map[string]interface{}{}
+	expected := map[string]interface{}{
+		"lease_id":       "",
+		"renewable":      false,
+		"lease_duration": json.Number("0"),
+		"wrap_info":      nil,
+		"warnings":       nil,
+		"auth":           nil,
+		"data": map[string]interface{}{
+			"description":                 "key/value secret storage",
+			"default_lease_ttl":           json.Number("2764800"),
+			"max_lease_ttl":               json.Number("2764800"),
+			"options":                     map[string]interface{}{"version": "1"},
+			"force_no_cache":              false,
+			"allowed_managed_keys": []interface{}{"test_key"},
+		},
+		"description":                 "key/value secret storage",
+		"default_lease_ttl":           json.Number("2764800"),
+		"max_lease_ttl":               json.Number("2764800"),
+		"options":                     map[string]interface{}{"version": "1"},
+		"force_no_cache":              false,
+		"allowed_managed_keys": []interface{}{"test_key"},
+	}
+	testResponseBody(t, resp, &actual)
+	expected["request_id"] = actual["request_id"]
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad:\nExpected: %#v\nActual:%#v", expected, actual)
+	}
+
+	// Unset the mount tune value
+	resp = testHttpPost(t, token, addr+"/v1/sys/mounts/secret/tune", map[string]interface{}{
+		"allowed_managed_keys": "",
+	})
+	testResponseStatus(t, resp, 204)
+
+	// Check results
+	resp = testHttpGet(t, token, addr+"/v1/sys/mounts/secret/tune")
+	testResponseStatus(t, resp, 200)
+
+	actual = map[string]interface{}{}
+	expected = map[string]interface{}{
+		"lease_id":       "",
+		"renewable":      false,
+		"lease_duration": json.Number("0"),
+		"wrap_info":      nil,
+		"warnings":       nil,
+		"auth":           nil,
+		"data": map[string]interface{}{
+			"description":       "key/value secret storage",
+			"default_lease_ttl": json.Number("2764800"),
+			"max_lease_ttl":     json.Number("2764800"),
+			"force_no_cache":    false,
+			"options":           map[string]interface{}{"version": "1"},
+		},
+		"description":       "key/value secret storage",
+		"default_lease_ttl": json.Number("2764800"),
+		"max_lease_ttl":     json.Number("2764800"),
+		"force_no_cache":    false,
+		"options":           map[string]interface{}{"version": "1"},
+	}
+	testResponseBody(t, resp, &actual)
+	expected["request_id"] = actual["request_id"]
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad:\nExpected: %#v\nActual:%#v", expected, actual)
+	}
+}

--- a/vault/logical_system_paths.go
+++ b/vault/logical_system_paths.go
@@ -1769,6 +1769,10 @@ func (b *SystemBackend) mountPaths() []*framework.Path {
 					Type:        framework.TypeString,
 					Description: strings.TrimSpace(sysHelp["token_type"][0]),
 				},
+				"allowed_managed_keys": {
+					Type:        framework.TypeCommaStringSlice,
+					Description: strings.TrimSpace(sysHelp["tune_allowed_managed_keys"][0]),
+				},
 			},
 
 			Callbacks: map[logical.Operation]framework.OperationFunc{

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -304,6 +304,7 @@ type MountConfig struct {
 	PassthroughRequestHeaders []string              `json:"passthrough_request_headers,omitempty" structs:"passthrough_request_headers" mapstructure:"passthrough_request_headers"`
 	AllowedResponseHeaders    []string              `json:"allowed_response_headers,omitempty" structs:"allowed_response_headers" mapstructure:"allowed_response_headers"`
 	TokenType                 logical.TokenType     `json:"token_type,omitempty" structs:"token_type" mapstructure:"token_type"`
+	AllowedManagedKeys        []string          `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
 
 	// PluginName is the name of the plugin registered in the catalog.
 	//
@@ -322,6 +323,7 @@ type APIMountConfig struct {
 	PassthroughRequestHeaders []string              `json:"passthrough_request_headers,omitempty" structs:"passthrough_request_headers" mapstructure:"passthrough_request_headers"`
 	AllowedResponseHeaders    []string              `json:"allowed_response_headers,omitempty" structs:"allowed_response_headers" mapstructure:"allowed_response_headers"`
 	TokenType                 string                `json:"token_type" structs:"token_type" mapstructure:"token_type"`
+	AllowedManagedKeys        []string          `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
 
 	// PluginName is the name of the plugin registered in the catalog.
 	//
@@ -378,6 +380,12 @@ func (e *MountEntry) SyncCache() {
 		e.synthesizedConfigCache.Delete("allowed_response_headers")
 	} else {
 		e.synthesizedConfigCache.Store("allowed_response_headers", e.Config.AllowedResponseHeaders)
+	}
+
+	if len(e.Config.AllowedManagedKeys) == 0 {
+		e.synthesizedConfigCache.Delete("allowed_managed_keys")
+	} else {
+		e.synthesizedConfigCache.Store("allowed_managed_keys", e.Config.AllowedManagedKeys)
 	}
 }
 

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -304,7 +304,7 @@ type MountConfig struct {
 	PassthroughRequestHeaders []string              `json:"passthrough_request_headers,omitempty" structs:"passthrough_request_headers" mapstructure:"passthrough_request_headers"`
 	AllowedResponseHeaders    []string              `json:"allowed_response_headers,omitempty" structs:"allowed_response_headers" mapstructure:"allowed_response_headers"`
 	TokenType                 logical.TokenType     `json:"token_type,omitempty" structs:"token_type" mapstructure:"token_type"`
-	AllowedManagedKeys        []string          `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
+	AllowedManagedKeys        []string              `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
 
 	// PluginName is the name of the plugin registered in the catalog.
 	//
@@ -323,7 +323,7 @@ type APIMountConfig struct {
 	PassthroughRequestHeaders []string              `json:"passthrough_request_headers,omitempty" structs:"passthrough_request_headers" mapstructure:"passthrough_request_headers"`
 	AllowedResponseHeaders    []string              `json:"allowed_response_headers,omitempty" structs:"allowed_response_headers" mapstructure:"allowed_response_headers"`
 	TokenType                 string                `json:"token_type" structs:"token_type" mapstructure:"token_type"`
-	AllowedManagedKeys        []string          `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
+	AllowedManagedKeys        []string              `json:"allowed_managed_keys,omitempty" mapstructure:"allowed_managed_keys"`
 
 	// PluginName is the name of the plugin registered in the catalog.
 	//

--- a/website/content/api-docs/system/mounts.mdx
+++ b/website/content/api-docs/system/mounts.mdx
@@ -336,6 +336,9 @@ This endpoint tunes configuration parameters for a given mount point.
 - `allowed_response_headers` `(array: [])` - List of headers to whitelist,
   allowing a plugin to include them in the response.
 
+- `allowed_managed_keys` `(array: [])` - List of managed key registry entry names
+  that the mount in question is allowed to access.
+
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
This tunable grants access to a managed key in the current or any parent namespaces, if "any_mount" was not set on the managed key. (VAULT-3880)