### PR TITLE
OIDC: add note on PKCE support for code flow

### DIFF
--- a/changelog/13206.txt
+++ b/changelog/13206.txt
@@ -1,4 +1,0 @@
-```release-note:feature
-**Add PKCE support to OIDC Auth**: The Authorization Code flow makes use of the
-Proof Key for Code Exchange (PKCE) extension.
-```

--- a/changelog/13206.txt
+++ b/changelog/13206.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+**Add PKCE support to OIDC Auth**: The Authorization Code flow makes use of the
+Proof Key for Code Exchange (PKCE) extension.
+```

--- a/website/content/docs/auth/jwt/index.mdx
+++ b/website/content/docs/auth/jwt/index.mdx
@@ -117,7 +117,8 @@ JSON Pointer can be used as a selector. Refer to the
 This section covers the setup and use of OIDC roles. If a JWT is to be provided directly,
 refer to the [JWT Authentication](/docs/auth/jwt#jwt-authentication) section below. Basic
 familiarity with [OIDC concepts](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1)
-is assumed.
+is assumed. The Authorization Code flow makes use of the Proof Key for Code
+Exchange (PKCE) extension.
 
 Vault includes two built-in OIDC login flows: the Vault UI, and the CLI
 using a `vault login`.


### PR DESCRIPTION
 Add a note on PKCE support for code flow added in vault-plugin-auth-jwt here: https://github.com/hashicorp/vault-plugin-auth-jwt/pull/188

