### PR TITLE
auth/kubernetes: add changelog for issuer deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@ outstanding dirty pages that were not flushed. [[GH-2093](https://github.com/has
 * ui: replaces Vault's use of elazarl/go-bindata-assetfs in building the UI with Go's native Embed package [[GH-11208](https://github.com/hashicorp/vault/pull/11208)]
 * ui: updated client tracking config view [[GH-12422](https://github.com/hashicorp/vault/pull/12422)]
 
+DEPRECATIONS:
+
+* auth/kubernetes: deprecate `disable_iss_validation` and `issuer` configuration fields [#127](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/127)
+
 BUG FIXES:
 
 * activity log (enterprise): allow partial monthly client count to be accessed from namespaces [[GH-13086](https://github.com/hashicorp/vault/pull/13086)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ outstanding dirty pages that were not flushed. [[GH-2093](https://github.com/has
 
 DEPRECATIONS:
 
-* auth/kubernetes: deprecate `disable_iss_validation` and `issuer` configuration fields [#127](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/127)
+* auth/kubernetes: deprecate `disable_iss_validation` and `issuer` configuration fields [#127](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/127) [[GH-12975](https://github.com/hashicorp/vault/pull/12975)]
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 CHANGES:
 
+* auth/kubernetes: `disable_iss_validation` defaults to true. [#127](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/127) [[GH-12975](https://github.com/hashicorp/vault/pull/12975)]
 * expiration: VAULT_16_REVOKE_PERMITPOOL environment variable has been removed. [[GH-12888](https://github.com/hashicorp/vault/pull/12888)]
 * expiration: VAULT_LEASE_USE_LEGACY_REVOCATION_STRATEGY environment variable has
 been removed. [[GH-12888](https://github.com/hashicorp/vault/pull/12888)]
@@ -10,7 +11,6 @@ been removed. [[GH-12888](https://github.com/hashicorp/vault/pull/12888)]
 * secrets/ssh: Roles with empty allowed_extensions will now forbid end-users
 specifying extensions when requesting ssh key signing. Update roles setting
 allowed_extensions to `*` to permit any extension to be specified by an end-user. [[GH-12847](https://github.com/hashicorp/vault/pull/12847)]
-* auth/kubernetes: `disable_iss_validation` defaults to true. [#127](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/127) [[GH-12975](https://github.com/hashicorp/vault/pull/12975)]
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ been removed. [[GH-12888](https://github.com/hashicorp/vault/pull/12888)]
 * secrets/ssh: Roles with empty allowed_extensions will now forbid end-users
 specifying extensions when requesting ssh key signing. Update roles setting
 allowed_extensions to `*` to permit any extension to be specified by an end-user. [[GH-12847](https://github.com/hashicorp/vault/pull/12847)]
+* auth/kubernetes: `disable_iss_validation` defaults to true. [#127](https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/127) [[GH-12975](https://github.com/hashicorp/vault/pull/12975)]
 
 FEATURES:
 


### PR DESCRIPTION
This adds a missing entry in 1.9 for Kubernetes auth issuer deprecation: hashicorp/vault-plugin-auth-kubernetes#127.

