### PR TITLE
doc: Correctly close code-block in Azure API docs

### DIFF
--- a/website/content/api-docs/secret/azure.mdx
+++ b/website/content/api-docs/secret/azure.mdx
@@ -190,6 +190,7 @@ $ curl \
   --header "X-Vault-Token: ..." \
   --request POST \
   http://127.0.0.1:8200/v1/azure/rotate-root
+```
 
 ## Create/Update Role
 


### PR DESCRIPTION
This resolves a rendering issue in the Azure API documentation which caused a section to be rendered in its raw markdown form instead of the rich documentation that was expected.