### PR TITLE
Add SSH auth plugin to plugin portal

### DIFF
--- a/website/content/docs/plugin-portal.mdx
+++ b/website/content/docs/plugin-portal.mdx
@@ -124,7 +124,8 @@ Plugin authors who wish to have their plugins listed may file a submission via a
 
 - [Jenkins](https://plugins.jenkins.io/hashicorp-vault-plugin)
 - [Terraform Enterprise/Terraform Cloud](https://github.com/gitrgoliveira/vault-plugin-auth-tfe)
-
+- [SSH](https://github.com/42wim/vault-plugin-auth-ssh) 
+ 
 ### Secrets
 
 - [Ethereum](https://github.com/immutability-io/vault-ethereum)


### PR DESCRIPTION
Add a Vault plugin to allow authentication via SSH certificates and public keys