### PR TITLE
identity/oidc: optional nonce parameter for authorize request

### DIFF
--- a/changelog/13231.txt
+++ b/changelog/13231.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity/oidc: Make the `nonce` parameter optional for the Authorization Endpoint of OIDC providers.
+```

--- a/go.sum
+++ b/go.sum
@@ -830,7 +830,6 @@ github.com/hashicorp/go-kms-wrapping/entropy v0.1.0/go.mod h1:d1g9WGtAunDNpek8jU
 github.com/hashicorp/go-memdb v1.3.2 h1:RBKHOsnSszpU6vxq80LzC2BaQjuuvoyaQbkLTf7V7g8=
 github.com/hashicorp/go-memdb v1.3.2/go.mod h1:Mluclgwib3R93Hk5fxEfiRhB+6Dar64wWh71LpNSe3g=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
-github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9aZTuI=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v1.1.5 h1:9byZdVjKTe5mce63pRVNP1L7UAmdHOTEMGehn6KvJWs=
 github.com/hashicorp/go-msgpack v1.1.5/go.mod h1:gWVc3sv/wbDmR3rQsj1CAktEZzoz1YNK9NfGLXJ69/4=

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -111,7 +111,7 @@ const (
 )
 
 var (
-	requiredClaims = []string{
+	reservedClaims = []string{
 		"iat", "aud", "exp", "iss",
 		"sub", "namespace", "nonce",
 		"auth_time", "at_hash", "c_hash",
@@ -970,6 +970,7 @@ func (tok *idToken) generatePayload(logger hclog.Logger, templates ...string) ([
 		"iat":       tok.IssuedAt,
 	}
 
+	// Copy optional claims into output
 	if len(tok.Nonce) > 0 {
 		output["nonce"] = tok.Nonce
 	}
@@ -1009,7 +1010,7 @@ func mergeJSONTemplates(logger hclog.Logger, output map[string]interface{}, temp
 		}
 
 		for k, v := range parsed {
-			if !strutil.StrListContains(requiredClaims, k) {
+			if !strutil.StrListContains(reservedClaims, k) {
 				output[k] = v
 			} else {
 				logger.Warn("invalid top level OIDC template key", "template", template, "key", k)
@@ -1114,9 +1115,9 @@ func (i *IdentityStore) pathOIDCCreateUpdateRole(ctx context.Context, req *logic
 		}
 
 		for key := range tmp {
-			if strutil.StrListContains(requiredClaims, key) {
+			if strutil.StrListContains(reservedClaims, key) {
 				return logical.ErrorResponse(`top level key %q not allowed. Restricted keys: %s`,
-					key, strings.Join(requiredClaims, ", ")), nil
+					key, strings.Join(reservedClaims, ", ")), nil
 			}
 		}
 	}

--- a/website/content/api-docs/secret/identity/oidc-provider.mdx
+++ b/website/content/api-docs/secret/identity/oidc-provider.mdx
@@ -37,7 +37,7 @@ This endpoint creates or updates a Provider.
 ### Sample Request
 
 ```shell-session
-$ curl \         
+$ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
@@ -154,7 +154,7 @@ This endpoint creates or updates a scope.
 ### Sample Request
 
 ```shell-session
-$ curl \         
+$ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
@@ -281,7 +281,7 @@ This endpoint creates or updates a client.
 ### Sample Request
 
 ```shell-session
-$ curl \             
+$ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
@@ -402,7 +402,7 @@ This endpoint creates or updates an assignment.
 ### Sample Request
 
 ```shell-session
-$ curl \             
+$ curl \
     --header "X-Vault-Token: ..." \
     --request POST \
     --data @payload.json \
@@ -620,7 +620,7 @@ to be used for the [Authorization Code Flow](https://openid.net/specs/openid-con
 
 - `state` `(string: <required>)` - A value used to maintain state between the authentication request and client.
 
-- `nonce` `(string: <required>)` - A value that is returned in the ID token nonce claim. It is used to mitigate replay attacks.
+- `nonce` `(string: <optional>)` - A value that is returned in the ID token nonce claim. It is used to mitigate replay attacks, so we *strongly encourage* providing this optional parameter.
 
 ### Sample Request
 

--- a/website/content/docs/concepts/oidc-provider.mdx
+++ b/website/content/docs/concepts/oidc-provider.mdx
@@ -137,11 +137,11 @@ Each provider offers an unauthenticated endpoint that provides the public portio
 
 ### Authorization Endpoint
 
-Each provider offers an authenticated [authorization endpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint). The authorization endpoint for each provider is added to Vault's [default policy](/docs/concepts/policies#default-policy) using the `identity/oidc/provider/+/authorize` path. The endpoint incorporates all required [authentication request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) parameters as input. Additionally, the `state` and `nonce` parameters are required.
+Each provider offers an authenticated [authorization endpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint). The authorization endpoint for each provider is added to Vault's [default policy](/docs/concepts/policies#default-policy) using the `identity/oidc/provider/+/authorize` path. The endpoint incorporates all required [authentication request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) parameters as input. Additionally, the `state` parameter is required.
 
 The endpoint [validates](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequestValidation) client requests and ensures that all required parameters are present and valid. The `redirect_uri` of the request is validated against the client's `redirect_uris`. The requesting Vault entity will be validated against the client's `assignments`. An appropriate [error code](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) is returned for invalid requests.
 
-An authorization code is generated with a successful validation of the request. The authorization code is single-use and cached with a lifetime of approximately 5 minutes, which mitigates the risk of leaks. A response including the original `state` presented by the client and `code` will be returned to the Vault UI which initiated the request. Vault will issue an HTTP 302 redirect to the `redirect_uri` of the request, which includes the `code`, `state`, and `nonce` as query parameters.
+An authorization code is generated with a successful validation of the request. The authorization code is single-use and cached with a lifetime of approximately 5 minutes, which mitigates the risk of leaks. A response including the original `state` presented by the client and `code` will be returned to the Vault UI which initiated the request. Vault will issue an HTTP 302 redirect to the `redirect_uri` of the request, which includes the `code` and `state` as query parameters.
 
 ### Token Endpoint
 

--- a/website/content/docs/secrets/identity/oidc-provider.mdx
+++ b/website/content/docs/secrets/identity/oidc-provider.mdx
@@ -16,9 +16,10 @@ identity. Clients can configure their authentication logic to talk to Vault.
 Once enabled, Vault will act as the bridge to identity providers via its
 existing authentication methods. Clients will also obtain identity information
 for their end-users by leveraging custom templating of Vault identity
-information.
+information. For more information on the configuration resources and OIDC endpoints,
+please visit the [OIDC provider](/docs/concepts/oidc-provider) concepts page.
 
-The Vault OIDC provider feature currently only supports the 
+The Vault OIDC provider feature currently only supports the
 [authorization code flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth).
 
 ## OIDC Provider Configuration


### PR DESCRIPTION
## Overview

This PR makes the [nonce parameter](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) optional for the Authorization Endpoint published by Vault OIDC providers. It includes updates to documentation for this change.

Fixes #13204.

Additionally, this PR renames `requiredClaims` -> `reservedClaims` because it makes more sense as a variable name.

## Testing

I've added test coverage to this PR. I also manually tested that the nonce isn't required and doesn't appear as an ID token claim when omitted.