### PR TITLE
Prevent CWE-190/AllocationSizeOverflow in KDF

### DIFF
--- a/sdk/helper/kdf/kdf.go
+++ b/sdk/helper/kdf/kdf.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"math"
 )
 
 // PRF is a pseudo-random function that takes a key or seed,
@@ -35,6 +36,10 @@ func CounterMode(prf PRF, prfLen uint32, key []byte, context []byte, bits uint32
 	rounds := bits / prfLen
 	if bits%prfLen != 0 {
 		rounds++
+	}
+
+	if len(context) > math.MaxInt - 8 {
+		return nil, fmt.Errorf("too much context specified; would overflow: %d bytes", len(context))
 	}
 
 	// Allocate and setup the input


### PR DESCRIPTION
In the Counter-mode KBKDF implementation, due to the nature of the PRF
(being implemented as a function rather than a hash.Hash instance), we
need to allocate a buffer capable of storing the entire input to the
PRF. This consists of the user-supplied context with 8 additional bytes
(4 before and 4 after) of encoded integers.

If the user supplies a maximally-sized context, the internally allocated
buffer's size computation will overflow, resulting in a runtime panic.
Guard against this condition.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

I've executed CodeQL locally, confirmed it saw the issue, and that the issue should go away after this patch. Note that there's still other instances of this result elsewhere in the code base that this PR won't address. 