### PR TITLE
UI/Fix node-forge EC error

### DIFF
--- a/changelog/13238.txt
+++ b/changelog/13238.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes node-forge error when parsing EC (elliptical curve) certs
+```

--- a/ui/app/helpers/parse-pki-cert.js
+++ b/ui/app/helpers/parse-pki-cert.js
@@ -8,7 +8,7 @@ export function parsePkiCert([model]) {
   }
   let cert;
   // node-forge cannot parse EC (elliptical curve) certs
-  // so just return model (original response) if pki parse returns an error
+  // return original response if unable to convert a Forge cert from PEM
   try {
     cert = pki.certificateFromPem(model.certificate);
   } catch (error) {

--- a/ui/app/helpers/parse-pki-cert.js
+++ b/ui/app/helpers/parse-pki-cert.js
@@ -6,7 +6,14 @@ export function parsePkiCert([model]) {
   if (!model.certificate) {
     return;
   }
-  const cert = pki.certificateFromPem(model.certificate);
+  let cert;
+  // node-forge cannot parse EC (elliptical curve) certs
+  // so just return model (original response) if pki parse returns an error
+  try {
+    cert = pki.certificateFromPem(model.certificate);
+  } catch (error) {
+    return model;
+  }
   const commonName = cert.subject.getField('CN') ? cert.subject.getField('CN').value : null;
   const issueDate = cert.validity.notBefore;
   const expiryDate = cert.validity.notAfter;

--- a/ui/app/helpers/parse-pki-cert.js
+++ b/ui/app/helpers/parse-pki-cert.js
@@ -8,19 +8,22 @@ export function parsePkiCert([model]) {
   }
   let cert;
   // node-forge cannot parse EC (elliptical curve) certs
-  // return original response if unable to convert a Forge cert from PEM
+  // set canParse to false if unable to convert a Forge cert from PEM
   try {
     cert = pki.certificateFromPem(model.certificate);
   } catch (error) {
-    return model;
+    return {
+      can_parse: false,
+    };
   }
-  const commonName = cert.subject.getField('CN') ? cert.subject.getField('CN').value : null;
-  const issueDate = cert.validity.notBefore;
-  const expiryDate = cert.validity.notAfter;
+  const commonName = cert?.subject.getField('CN') ? cert.subject.getField('CN').value : null;
+  const expiryDate = cert?.validity.notAfter;
+  const issueDate = cert?.validity.notBefore;
   return {
+    can_parse: true,
     common_name: commonName,
-    issue_date: issueDate,
     expiry_date: expiryDate,
+    issue_date: issueDate,
   };
 }
 

--- a/ui/app/models/pki-ca-certificate.js
+++ b/ui/app/models/pki-ca-certificate.js
@@ -4,7 +4,6 @@ import { computed } from '@ember/object';
 import Certificate from './pki-certificate';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
-// TODO: alphabetize attrs
 export default Certificate.extend({
   DISPLAY_FIELDS: computed(function() {
     return [
@@ -28,6 +27,7 @@ export default Certificate.extend({
   backend: attr('string', {
     readOnly: true,
   }),
+  // canParse: attr('boolean'),
   caType: attr('string', {
     possibleValues: ['root', 'intermediate'],
     defaultValue: 'root',
@@ -35,18 +35,71 @@ export default Certificate.extend({
     readOnly: true,
   }),
   commonName: attr('string'),
+  csr: attr('string', {
+    editType: 'textarea',
+    label: 'CSR',
+    masked: true,
+  }),
   expiryDate: attr('string', {
     label: 'Expiration date',
   }),
   issueDate: attr('string'),
+  keyBits: attr('number', {
+    defaultValue: 2048,
+  }),
+  keyType: attr('string', {
+    possibleValues: ['rsa', 'ec', 'ed25519'],
+    defaultValue: 'rsa',
+  }),
+  maxPathLength: attr('number', {
+    defaultValue: -1,
+  }),
+  organization: attr({
+    editType: 'stringArray',
+  }),
+  ou: attr({
+    label: 'OU (OrganizationalUnit)',
+    editType: 'stringArray',
+  }),
   pemBundle: attr('string', {
     label: 'PEM bundle',
     editType: 'file',
+  }),
+  permittedDnsNames: attr('string', {
+    label: 'Permitted DNS domains',
+  }),
+  privateKeyFormat: attr('string', {
+    possibleValues: ['', 'der', 'pem', 'pkcs8'],
+    defaultValue: '',
+  }),
+  type: attr('string', {
+    possibleValues: ['internal', 'exported'],
+    defaultValue: 'internal',
   }),
   uploadPemBundle: attr('boolean', {
     label: 'Upload PEM bundle',
     readOnly: true,
   }),
+
+  // address attrs
+  country: attr({
+    editType: 'stringArray',
+  }),
+  locality: attr({
+    editType: 'stringArray',
+    label: 'Locality/City',
+  }),
+  streetAddress: attr({
+    editType: 'stringArray',
+  }),
+  postalCode: attr({
+    editType: 'stringArray',
+  }),
+  province: attr({
+    editType: 'stringArray',
+    label: 'Province/State',
+  }),
+
   fieldDefinition: computed('caType', 'uploadPemBundle', function() {
     const type = this.caType;
     const isUpload = this.uploadPemBundle;
@@ -97,58 +150,6 @@ export default Certificate.extend({
     });
 
     return groups;
-  }),
-  type: attr('string', {
-    possibleValues: ['internal', 'exported'],
-    defaultValue: 'internal',
-  }),
-  ou: attr({
-    label: 'OU (OrganizationalUnit)',
-    editType: 'stringArray',
-  }),
-  organization: attr({
-    editType: 'stringArray',
-  }),
-  country: attr({
-    editType: 'stringArray',
-  }),
-  locality: attr({
-    editType: 'stringArray',
-    label: 'Locality/City',
-  }),
-  province: attr({
-    editType: 'stringArray',
-    label: 'Province/State',
-  }),
-  streetAddress: attr({
-    editType: 'stringArray',
-  }),
-  postalCode: attr({
-    editType: 'stringArray',
-  }),
-
-  keyType: attr('string', {
-    possibleValues: ['rsa', 'ec','ed25519'],
-    defaultValue: 'rsa',
-  }),
-  keyBits: attr('number', {
-    defaultValue: 2048,
-  }),
-  privateKeyFormat: attr('string', {
-    possibleValues: ['', 'der', 'pem', 'pkcs8'],
-    defaultValue: '',
-  }),
-  maxPathLength: attr('number', {
-    defaultValue: -1,
-  }),
-  permittedDnsNames: attr('string', {
-    label: 'Permitted DNS domains',
-  }),
-
-  csr: attr('string', {
-    editType: 'textarea',
-    label: 'CSR',
-    masked: true,
   }),
 
   deletePath: lazyCapabilities(apiPath`${'backend'}/root`, 'backend'),

--- a/ui/app/models/pki-ca-certificate.js
+++ b/ui/app/models/pki-ca-certificate.js
@@ -27,7 +27,7 @@ export default Certificate.extend({
   backend: attr('string', {
     readOnly: true,
   }),
-  // canParse: attr('boolean'),
+  canParse: attr('boolean'),
   caType: attr('string', {
     possibleValues: ['root', 'intermediate'],
     defaultValue: 'root',

--- a/ui/app/models/pki-certificate.js
+++ b/ui/app/models/pki-certificate.js
@@ -6,10 +6,6 @@ import fieldToAttrs, { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 
 export default Model.extend({
   idPrefix: 'cert/',
-
-  backend: attr('string', {
-    readOnly: true,
-  }),
   //the id prefixed with `cert/` so we can use it as the *secret param for the secret show route
   idForNav: attr('string', {
     readOnly: true,
@@ -29,20 +25,39 @@ export default Model.extend({
     ];
   }),
 
-  commonName: attr('string'),
-  expiryDate: attr('string', {
-    label: 'Expiration date',
-  }),
-  issueDate: attr('string'),
-  role: attr('object', {
-    readOnly: true,
-  }),
-  revocationTime: attr('number'),
   altNames: attr('string', {
     label: 'DNS/Email Subject Alternative Names (SANs)',
   }),
+  backend: attr('string', {
+    readOnly: true,
+  }),
+  caChain: attr('string', {
+    label: 'CA chain',
+    masked: true,
+  }),
+  canParse: attr('boolean'),
+  certificate: attr('string', {
+    masked: true,
+  }),
+  commonName: attr('string'),
+  excludeCnFromSans: attr('boolean', {
+    label: 'Exclude Common Name from Subject Alternative Names (SANs)',
+    defaultValue: false,
+  }),
+  expiryDate: attr('string', {
+    label: 'Expiration date',
+  }),
+  format: attr('string', {
+    defaultValue: 'pem',
+    possibleValues: ['pem', 'der', 'pem_bundle'],
+  }),
   ipSans: attr('string', {
     label: 'IP Subject Alternative Names (SANs)',
+  }),
+  issueDate: attr('string'),
+  issuingCa: attr('string', {
+    label: 'Issuing CA',
+    masked: true,
   }),
   otherSans: attr({
     editType: 'stringArray',
@@ -50,34 +65,19 @@ export default Model.extend({
     helpText:
       'The format is the same as OpenSSL: <oid>;<type>:<value> where the only current valid type is UTF8',
   }),
-  ttl: attr({
-    label: 'TTL',
-    editType: 'ttl',
-  }),
-  format: attr('string', {
-    defaultValue: 'pem',
-    possibleValues: ['pem', 'der', 'pem_bundle'],
-  }),
-  excludeCnFromSans: attr('boolean', {
-    label: 'Exclude Common Name from Subject Alternative Names (SANs)',
-    defaultValue: false,
-  }),
-  certificate: attr('string', {
-    masked: true,
-  }),
-  issuingCa: attr('string', {
-    label: 'Issuing CA',
-    masked: true,
-  }),
-  caChain: attr('string', {
-    label: 'CA chain',
-    masked: true,
-  }),
   privateKey: attr('string', {
     masked: true,
   }),
   privateKeyType: attr('string'),
+  revocationTime: attr('number'),
+  role: attr('object', {
+    readOnly: true,
+  }),
   serialNumber: attr('string'),
+  ttl: attr({
+    label: 'TTL',
+    editType: 'ttl',
+  }),
 
   fieldsToAttrs(fieldGroups) {
     return fieldToAttrs(this, fieldGroups);

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -8,7 +8,7 @@
     {{/if}}
   </h2>
   {{#if (or model.certificate model.csr)}}
-    {{#if not (eq model.canParse true)}}
+    {{#if (not (eq model.canParse true))}}
       <AlertBanner
         @type="info"
         @message="There was an error parsing the certificate's metadata. As a result, Vault cannot display the common name or the issue and expiration dates. This will not interfere with the certificate's functionality."

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -8,13 +8,13 @@
     {{/if}}
   </h2>
   {{#if (or model.certificate model.csr)}}
-    {{#unless model.canParse}}
+    {{#if not (eq model.canParse true)}}
       <AlertBanner
         @type="info"
         @message="There was an error parsing the certificate's metadata. As a result, Vault cannot display the common name or the issue and expiration dates. This will not interfere with the certificate's functionality."
         data-test-warning
       />
-      {{/unless}}
+    {{/if}}
     {{#each model.attrs as |attr|}}
       {{#if attr.options.masked}}
         <InfoTableRow data-test-table-row

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -109,7 +109,7 @@
             @allowCopy={{true}}
           />
         </InfoTableRow>
-     {{else if (and (get model attr.name) (or (eq attr.name "issueDate") (eq attr.name "expiryDate")))}}
+      {{else if (and (get model attr.name) (or (eq attr.name "issueDate") (eq attr.name "expiryDate")))}}
         <InfoTableRow data-test-table-row={{value}}
           @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}} 
           @value={{date-format (get model attr.name) 'MMM dd, yyyy hh:mm:ss a' isFormatted=true}}/>

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -8,6 +8,13 @@
     {{/if}}
   </h2>
   {{#if (or model.certificate model.csr)}}
+    {{#unless model.canParse}}
+      <AlertBanner
+        @type="info"
+        @message="There was an error parsing the certificate's metadata. As a result, Vault cannot display the common name or the issue and expiration dates. This will not interfere with the certificate's functionality."
+        data-test-warning
+      />
+      {{/unless}}
     {{#each model.attrs as |attr|}}
       {{#if attr.options.masked}}
         <InfoTableRow data-test-table-row

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -11,7 +11,7 @@
     {{#if (not (eq model.canParse true))}}
       <AlertBanner
         @type="info"
-        @message="There was an error parsing the certificate's metadata. As a result, Vault cannot display the common name or the issue and expiration dates. This will not interfere with the certificate's functionality."
+        @message="There was an error parsing the certificate's metadata. As a result, Vault cannot display the issue and expiration dates. This will not interfere with the certificate's functionality."
         data-test-warning
       />
     {{/if}}

--- a/ui/app/templates/components/pki-cert-show.hbs
+++ b/ui/app/templates/components/pki-cert-show.hbs
@@ -8,7 +8,7 @@
     </h1>
   </p.levelLeft>
 </PageHeader>
-{{#if not (eq model.canParse true)}}
+{{#if (not (eq model.canParse true))}}
   <AlertBanner
     @type="info"
     @message="There was an error parsing the certificate's metadata. As a result, Vault cannot display the common name or the issue and expiration dates. This will not interfere with the certificate's functionality."

--- a/ui/app/templates/components/pki-cert-show.hbs
+++ b/ui/app/templates/components/pki-cert-show.hbs
@@ -8,7 +8,13 @@
     </h1>
   </p.levelLeft>
 </PageHeader>
-
+{{#unless model.canParse}}
+  <AlertBanner
+    @type="info"
+    @message="There was an error parsing the certificate's metadata. As a result, Vault cannot display the common name or the issue and expiration dates. This will not interfere with the certificate's functionality."
+    data-test-warning
+  />
+{{/unless}}
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   <MessageError @model={{model}} />
   {{#each model.attrs as |attr|}}

--- a/ui/app/templates/components/pki-cert-show.hbs
+++ b/ui/app/templates/components/pki-cert-show.hbs
@@ -8,13 +8,13 @@
     </h1>
   </p.levelLeft>
 </PageHeader>
-{{#unless model.canParse}}
+{{#if not (eq model.canParse true)}}
   <AlertBanner
     @type="info"
     @message="There was an error parsing the certificate's metadata. As a result, Vault cannot display the common name or the issue and expiration dates. This will not interfere with the certificate's functionality."
     data-test-warning
   />
-{{/unless}}
+{{/if}}
 <div class="box is-fullwidth is-sideless is-paddingless is-marginless">
   <MessageError @model={{model}} />
   {{#each model.attrs as |attr|}}

--- a/ui/tests/acceptance/settings/configure-secret-backends/pki/section-cert-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/pki/section-cert-test.js
@@ -1,4 +1,4 @@
-import { currentRouteName, settled, click } from '@ember/test-helpers';
+import { currentRouteName, settled, click, fillIn } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import page from 'vault/tests/pages/settings/configure-secret-backends/pki/section-cert';
@@ -92,6 +92,16 @@ BXUV2Uwtxf+QCphnlht9muX2fsLIzDJea0JipWj1uf2H8OZsjE8=
       page.flash.latestMessage.includes('You tried to generate a new root CA'),
       'shows warning message'
     );
+  });
+
+  test('EC cert config: generate', async function(assert) {
+    await mountAndNav(assert);
+    await settled();
+    assert.equal(currentRouteName(), 'vault.cluster.settings.configure-secret-backend.section');
+
+    await page.form.generateCAKeyTypeEC();
+
+    assert.dom('[data-test-warning]').exists('Info banner renders when unable to parse certificate metadata');
   });
 
   test('cert config: upload', async function(assert) {

--- a/ui/tests/acceptance/settings/configure-secret-backends/pki/section-cert-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/pki/section-cert-test.js
@@ -1,4 +1,4 @@
-import { currentRouteName, settled, click, fillIn } from '@ember/test-helpers';
+import { currentRouteName, settled, click } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import page from 'vault/tests/pages/settings/configure-secret-backends/pki/section-cert';

--- a/ui/tests/pages/components/config-pki-ca.js
+++ b/ui/tests/pages/components/config-pki-ca.js
@@ -32,6 +32,9 @@ export default {
   enterCertAsText: clickable('[data-test-text-toggle]'),
   pemBundle: fillable('[data-test-text-file-textarea="true"]'),
   commonName: fillable('[data-test-input="commonName"]'),
+  toggleOptions: clickable('[data-test-toggle-group="Options"]'),
+  keyType: fillable('[data-test-input="keyType"]'),
+  keyBits: fillable('[data-test-input="keyBits"]'),
 
   issueDateIsPresent: text('[data-test-row-value="Issue date"]'),
   expiryDateIsPresent: text('[data-test-row-value="Expiration date"]'),
@@ -45,6 +48,15 @@ export default {
     }
     return await this.replaceCA()
       .commonName(commonName)
+      .submit();
+  },
+
+  async generateCAKeyTypeEC(commonName = 'PKI CA EC') {
+    return await this.replaceCA()
+      .commonName(commonName)
+      .toggleOptions()
+      .keyType('ec')
+      .keyBits(256)
       .submit();
   },
 


### PR DESCRIPTION
Fix for #13219

Adds a catch for when `node-forge` returns an error converting or parsing a certificate, and returns unparsed certificate (so metadata will not display).

Addresses error returned when trying to read EC certs.  `Error: Cannot read public key. OID is not RSA.`

When unable to parse certificate metadata, UI reverts to original behavior and just displays serial number and certificate: 

<img width="1129" alt="Screen Shot 2021-11-22 at 4 19 04 PM" src="https://user-images.githubusercontent.com/68122737/142936763-ca035560-8d05-4dab-8a31-d5efe6386dfa.png">
