### PR TITLE
Respect WithWrappingToken for all secret ID's in approle auth

### DIFF
--- a/api/auth/approle/approle.go
+++ b/api/auth/approle/approle.go
@@ -105,31 +105,34 @@ func (a *AppRoleAuth) Login(ctx context.Context, client *api.Client) (*api.Secre
 		"role_id": a.roleID,
 	}
 
-	if a.secretIDFile != "" {
-		secretIDValue, err := a.readSecretIDFromFile()
+	var secretIDValue string
+
+	switch {
+	case a.secretIDFile != "":
+		s, err := a.readSecretIDFromFile()
 		if err != nil {
 			return nil, fmt.Errorf("error reading secret ID: %w", err)
 		}
+		secretIDValue = s
+	case a.secretIDEnv != "":
+		s := os.Getenv(a.secretIDEnv)
+		if s == "" {
+			return nil, fmt.Errorf("secret ID was specified with an environment variable %q with an empty value", a.secretIDEnv)
+		}
+		secretIDValue = s
+	default:
+		secretIDValue = a.secretID
+	}
 
-		// if it was indicated that the value in the file was actually a wrapping
-		// token, unwrap it first
-		if a.unwrap {
-			unwrappedToken, err := client.Logical().Unwrap(secretIDValue)
-			if err != nil {
-				return nil, fmt.Errorf("unable to unwrap token: %w. If the AppRoleAuth struct was initialized with the WithWrappingToken LoginOption, then the secret ID's filepath should be a path to a response-wrapping token", err)
-			}
-			loginData["secret_id"] = unwrappedToken.Data["secret_id"]
-		} else {
-			loginData["secret_id"] = secretIDValue
+	// if the caller indicated that the value was actually a wrapping token, unwrap it first
+	if a.unwrap {
+		unwrappedToken, err := client.Logical().Unwrap(secretIDValue)
+		if err != nil {
+			return nil, fmt.Errorf("unable to unwrap response wrapping token: %w", err)
 		}
-	} else if a.secretIDEnv != "" {
-		secretIDValue := os.Getenv(a.secretIDEnv)
-		if secretIDValue == "" {
-			return nil, fmt.Errorf("secret ID was specified with an environment variable with an empty value")
-		}
-		loginData["secret_id"] = secretIDValue
+		loginData["secret_id"] = unwrappedToken.Data["secret_id"]
 	} else {
-		loginData["secret_id"] = a.secretID
+		loginData["secret_id"] = secretIDValue
 	}
 
 	path := fmt.Sprintf("auth/%s/login", a.mountPath)

--- a/api/auth/approle/approle.go
+++ b/api/auth/approle/approle.go
@@ -22,13 +22,12 @@ type AppRoleAuth struct {
 var _ api.AuthMethod = (*AppRoleAuth)(nil)
 
 // SecretID is a struct that allows you to specify where your application is
-// storing the secret ID required for login to the AppRole auth method.
+// storing the secret ID required for login to the AppRole auth method. The
+// recommended secure pattern is to use response-wrapping tokens rather than
+// a plaintext value, by passing WithWrappingToken() to NewAppRoleAuth.
+// https://learn.hashicorp.com/tutorials/vault/approle-best-practices?in=vault/auth-methods#secretid-delivery-best-practices
 type SecretID struct {
-	// Path on the file system where a trusted orchestrator has placed the
-	// application's secret ID. The recommended secure pattern is to use
-	// response-wrapping tokens rather than a plaintext value, by passing
-	// WithWrappingToken() to NewAppRoleAuth.
-	// https://learn.hashicorp.com/tutorials/vault/approle-best-practices?in=vault/auth-methods#secretid-delivery-best-practices
+	// Path on the file system where the secret ID can be found.
 	FromFile string
 	// The name of the environment variable containing the application's
 	// secret ID.

--- a/changelog/13241.txt
+++ b/changelog/13241.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Respect WithWrappingToken() option during AppRole login authentication when used with secret ID specified from environment or from string
+```


### PR DESCRIPTION
### Background

When authenticating with vault via AppRole, the secret ID can be specified in one of 3 ways:

- `FromFile`
- `FromEnv`
- `FromString`

If the secret ID happens to be a wrapping token, the option `auth.WithWrappingToken()` will let the client know to treat it as such. However, the current implementation will only respect `auth.WithWrappingToken()` if the secret ID is specified from a file (`FromFile`) and silently fails otherwise, which could be surprising to callers. 

The rationale behind this was that the wrapping token should be provided through a [trusted orchestrator](https://learn.hashicorp.com/tutorials/vault/secure-introduction#trusted-orchestrator) and is typically written to a file. However, it is conceivable that the trusted orchestrator would write it to an environment variable instead.

### Solution

This PR will respect the `auth.WithWrappingToken()` for all secret ID's (whether specified via `FromFile`, `FromEnv` or `FromString`)