### PR TITLE
secrets/azure: fix API docs rendering of code block

### DIFF
--- a/website/content/api-docs/secret/azure.mdx
+++ b/website/content/api-docs/secret/azure.mdx
@@ -39,8 +39,8 @@ service principals. Environment variables will override any parameters set in th
 - `use_microsoft_graph_api` `(bool: false)` - Indicates whether the secrets engine should use the
   [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api). If set to false, this will use the Azure
   Active Directory API which is being [retired by Microsoft and will be removed in 2022](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-faq).
-- `root_password_ttl` `(string: 182d)` - Specifies how long the root password is valid for in Azure when 
-  rotate-root generates a new client secret. This can be either a number of seconds or a time formatted 
+- `root_password_ttl` `(string: 182d)` - Specifies how long the root password is valid for in Azure when
+  rotate-root generates a new client secret. This can be either a number of seconds or a time formatted
   duration (ex: 24h, 48d).
 
   If set to true, the user specified via the `client_id` and `client_secret` will need to have the following permissions
@@ -168,11 +168,11 @@ $ vault delete azure/config
 
 ## Rotate Root
 
-This endpoint generates a new client secret for the root account defined in the config. The 
+This endpoint generates a new client secret for the root account defined in the config. The
 value generated will only be known by Vault.
 
-~> Due to the eventual consistency of Microsoft Azure client secret APIs, the plugin 
-   may briefly stop authenticating to Azure as the password propagates through their 
+~> Due to the eventual consistency of Microsoft Azure client secret APIs, the plugin
+   may briefly stop authenticating to Azure as the password propagates through their
    datacenters.
 
 | Method | Path                      |
@@ -190,6 +190,7 @@ $ curl \
   --header "X-Vault-Token: ..." \
   --request POST \
   http://127.0.0.1:8200/v1/azure/rotate-root
+```
 
 ## Create/Update Role
 


### PR DESCRIPTION
This PR fixes the API docs for Azure secrets by adding missing backticks. See the current rendering with markdown in the code block: https://www.vaultproject.io/api-docs/secret/azure#sample-request-3