### PR TITLE
http: fix dropped test error

### DIFF
--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -1002,6 +1002,9 @@ func TestHandler_Patch_Audit(t *testing.T) {
 			"file_path": auditLogFile.Name(),
 		},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	writeData := map[string]interface{}{
 		"data": map[string]interface{}{


### PR DESCRIPTION
Can someone label this `no-changelog`?

This fixes a dropped test error in the `http` package.