### PR TITLE
Correct flag name: -dev-kv-v1, not dev-kv-1.

### DIFF
--- a/website/content/docs/concepts/dev-server.mdx
+++ b/website/content/docs/concepts/dev-server.mdx
@@ -43,7 +43,8 @@ flags or by specifying a configuration file):
   seal/unseal, then only the single outputted key is required.
 
 - **Key Value store mounted** - A v2 KV secret engine is mounted at
-  `secret/`. Please be aware that there are differences with v1 KV. If you want to use v1, use this flag `-dev-kv-1`.
+  `secret/`. Please be aware that there are differences with v1 KV.
+  If you want to use v1, use this flag `-dev-kv-v1`.
 
 ## Use Case
 


### PR DESCRIPTION
Fixes #13248.