### PR TITLE
Don't claim that Vault obfuscates the environment variable for sensitive values

### DIFF
--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -77,8 +77,7 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
 
 - `pin` `(string: <required>)`: The PIN for login. May also be specified by the
   `VAULT_HSM_PIN` environment variable. _If set via the environment variable,
-  Vault will obfuscate the environment variable after reading it, and it will
-  need to be re-set if Vault is restarted._
+  it will need to be re-set if Vault is restarted._
 
 - `key_label` `(string: <required>)`: The label of the key to use. If the key
   does not exist and generation is enabled, this is the label that will be given


### PR DESCRIPTION
This doesn't work at least in recent version of Go, as Go makes a
copy of the environment, so we're only modifying that one, and not the one
visible to the rest of the system.