### PR TITLE
skip hash bits verification for ed25519

### DIFF
--- a/changelog/13254.txt
+++ b/changelog/13254.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Skip signature bits validation for ed25519 curve
+secrets/pki: Skip signature bits validation for ed25519 curve key type
 ```

--- a/changelog/13254.txt
+++ b/changelog/13254.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Skip signature bits validation for ed25519 curve
+```

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -557,11 +557,12 @@ func ValidateKeyTypeSignatureLength(keyType string, keyBits int, hashBits *int) 
 		// To match previous behavior (and ignoring recommendations of hash
 		// size to match RSA key sizes), default to SHA-2-256.
 		*hashBits = 256
-	} /* else if keyType == "ed25519" {
+	} else if keyType == "ed25519" {
 		// No-op; ed25519 and ed448 internally specify their own hash and
 		// we do not need to select one. Double hashing isn't supported in
 		// certificate signing.
-	} */
+		return nil
+	}
 
 	// Note that this check must come after we've selected a value for
 	// hashBits above, in the event it was left as the default, but we


### PR DESCRIPTION
Addresses issue #13253 

The default value of signature_bits is 0 and will fail
at ValidateSignatureLength for ed25519. ed25519
specifies its own hash, so avoid this validation for
ed25519 curve.