### PR TITLE
Fix case typo in docs

### DIFF
--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -792,7 +792,7 @@ and consider if they're appropriate for your deployment.
       flag to the helm chart installation command because of a limitation in the Helm
       templating language.
 
-  - `statefulset` - This configures settings for the Vault Statefulset.
+  - `statefulSet` - This configures settings for the Vault Statefulset.
 
     - `annotations` (`dictionary: {}`) - This value defines additional annotations to
       add to the Vault statefulset. This can either be YAML or a YAML-formatted


### PR DESCRIPTION
The k8s helm chart docs specifies `statefulset` as one of the keys for chart values when[ in fact it's `statefulSet`](https://github.com/hashicorp/vault-helm/blob/main/values.yaml#L690). Using lowercase won't work.