### PR TITLE
Component test fixes

### DIFF
--- a/ui/tests/integration/components/replication-action-generate-token-test.js
+++ b/ui/tests/integration/components/replication-action-generate-token-test.js
@@ -2,9 +2,15 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | replication-action-generate-token', function(hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    this.server.get('/sys/replication/dr/secondary/generate-operation-token/attempt', () => {});
+  });
 
   test('it renders with the expected elements', async function(assert) {
     await render(hbs`

--- a/ui/tests/integration/components/shamir-modal-flow-test.js
+++ b/ui/tests/integration/components/shamir-modal-flow-test.js
@@ -3,13 +3,16 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | shamir-modal-flow', function(hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function() {
     this.set('isActive', true);
     this.set('onClose', sinon.spy());
+    this.server.get('/sys/replication/dr/secondary/generate-operation-token/attempt', () => {});
   });
 
   test('it renders with initial content by default', async function(assert) {


### PR DESCRIPTION
A couple of component tests were failing from a failed request to `GET /v1/sys/replication/dr/secondary/generate-operation-token/attempt`. Since it is not needed by the current tests an interceptor was added.