### PR TITLE
Backport 1.9: recognize ed25519 key type and return PKCS8 format (#13257)

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1162,6 +1162,12 @@ func convertRespToPKCS8(resp *logical.Response) error {
 		signer, err = x509.ParsePKCS1PrivateKey(keyData)
 	case certutil.ECPrivateKey:
 		signer, err = x509.ParseECPrivateKey(keyData)
+	case certutil.Ed25519PrivateKey:
+		k, err := x509.ParsePKCS8PrivateKey(keyData)
+		if err != nil {
+			return fmt.Errorf("error converting response to pkcs8: error parsing previous key: %w", err)
+		}
+		signer = k.(crypto.Signer)
 	default:
 		return fmt.Errorf("unknown private key type %q", privKeyType)
 	}

--- a/changelog/13257.txt
+++ b/changelog/13257.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Recognize ed25519 when requesting a response in PKCS8 format
+```


### PR DESCRIPTION
Backport of #13257 to address #13256 

* return pkcs8 format for ed25519 curve

convertRespToPKCS8 does not recognize the ed25519 key. Changes
to recognize ed25519 key and return its PKCS8 format