### PR TITLE
docs: winsvc update recommendations

### DIFF
--- a/website/content/docs/agent/winsvc.mdx
+++ b/website/content/docs/agent/winsvc.mdx
@@ -27,6 +27,9 @@ both will be shown below.
 
 ### Using sc.exe
 
+~> **Important Note:** Ensure the executable path of the service is quoted, especially when it contains spaces, to avoid
+potential privilege escalation risks.
+
 If you use `sc.exe`, make sure you specify `sc.exe` explicitly, and not just `sc`. The command below shows the creation
 of Vault Agent as a service, using "Vault Agent" as the display name, and starting automatically when Windows starts.
 The `binPath` argument should include the fully qualified path to the Vault executable, as well as any arguments required.


### PR DESCRIPTION
This documents _why_ paths should be quoted for the Vault Agent Windows service