### PR TITLE
Return an error when trying to store a too-large key with Raft 

### DIFF
--- a/changelog/13282.txt
+++ b/changelog/13282.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/raft: Fix a panic when trying to write a key > 32KB
+```

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -1288,6 +1288,9 @@ func (b *RaftBackend) Get(ctx context.Context, path string) (*physical.Entry, er
 // or if the call to applyLog fails.
 func (b *RaftBackend) Put(ctx context.Context, entry *physical.Entry) error {
 	defer metrics.MeasureSince([]string{"raft-storage", "put"}, time.Now())
+	if len(entry.Key) > bolt.MaxKeySize {
+		return fmt.Errorf("%s, max key size for integrated storage is %d", physical.ErrKeyTooLarge, bolt.MaxKeySize)
+	}
 
 	if err := ctx.Err(); err != nil {
 		return err

--- a/sdk/physical/physical.go
+++ b/sdk/physical/physical.go
@@ -21,6 +21,7 @@ const (
 
 const (
 	ErrValueTooLarge = "put failed due to value being too large"
+	ErrKeyTooLarge   = "put failed due to key being too large"
 )
 
 // Backend is the interface required for a physical


### PR DESCRIPTION
…instead of panicing.  Fixes https://github.com/hashicorp/vault/issues/13281.