### PR TITLE
secrets/azure: Fixes use_microsoft_graph_api parameter description in API docs

### DIFF
--- a/website/content/api-docs/secret/azure.mdx
+++ b/website/content/api-docs/secret/azure.mdx
@@ -38,15 +38,15 @@ service principals. Environment variables will override any parameters set in th
   use when creating dynamic credentials. Defaults to generating an alphanumeric password if not set.
 - `use_microsoft_graph_api` `(bool: false)` - Indicates whether the secrets engine should use the
   [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api). If set to false, this will use the Azure
-  Active Directory API which is being [retired by Microsoft and will be removed in 2022](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-faq).
-- `root_password_ttl` `(string: 182d)` - Specifies how long the root password is valid for in Azure when
-  rotate-root generates a new client secret. This can be either a number of seconds or a time formatted
-  duration (ex: 24h, 48d).
+  Active Directory API which has been [deprecated by Microsoft and will be removed in 2022](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-faq).
 
   If set to true, the user specified via the `client_id` and `client_secret` will need to have the following permissions
   under the Microsoft Graph API: `Application.ReadWrite.All`, `Directory.ReadWrite.All`, and `Group.ReadWrite.All`.
 
   Aside from the permissions listed above, setting this to true should be transparent to users.
+- `root_password_ttl` `(string: 182d)` - Specifies how long the root password is valid for in Azure when
+  rotate-root generates a new client secret. This can be either a number of seconds or a time formatted
+  duration (ex: 24h, 48d).
 
 ### Sample Payload
 


### PR DESCRIPTION
This PR fixes the `use_microsoft_graph_api` parameter description in the Azure secrets API docs. See that a portion of the description comes after the [root_password_ttl](https://www.vaultproject.io/api-docs/secret/azure#root_password_ttl) parameter.