### PR TITLE
Backport 1.9.x: secrets/azure: Update plugin to v0.11.2 (#13277)

### DIFF
--- a/changelog/13277.txt
+++ b/changelog/13277.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/azure: Fixes service principal generation when assigning roles that have [DataActions](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-definitions#dataactions). 
+```

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.11.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2
-	github.com/hashicorp/vault-plugin-secrets-azure v0.11.1
+	github.com/hashicorp/vault-plugin-secrets-azure v0.11.2
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.11.0
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.10.1

--- a/go.sum
+++ b/go.sum
@@ -960,8 +960,8 @@ github.com/hashicorp/vault-plugin-secrets-ad v0.11.1 h1:/wQvrAucbd9TucOQndKsJKm1
 github.com/hashicorp/vault-plugin-secrets-ad v0.11.1/go.mod h1:WwwDLyCMncZnOOtN2GHw6O4pIWauHhJx2DjRFbGYvV4=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2 h1:BzLD62yc5dU++yH66azcyBduXmhtpvV/4EQ7ReO7bTU=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
-github.com/hashicorp/vault-plugin-secrets-azure v0.11.1 h1:67CEWi72zXxe017dyC+Cm2udfEkxOMpIT3otwb9F4xk=
-github.com/hashicorp/vault-plugin-secrets-azure v0.11.1/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
+github.com/hashicorp/vault-plugin-secrets-azure v0.11.2 h1:sjAaSo2p84C1oq1LAA5El8vUlDsLamGUwMoO1mRZJIA=
+github.com/hashicorp/vault-plugin-secrets-azure v0.11.2/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.11.0 h1:3i2uXY/n4jJv71baXeS1q19KQXKI+7FtA38k82sd0eI=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.11.0/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0 h1:0Vi5WEIpZctk/ZoRClodV9WCnM/lCzw9XekMhRZdo8k=


### PR DESCRIPTION
This PR backports #13277.

Steps:
1. `git checkout release/1.9.x`
2. `git checkout -b backport-pr-13277-1.9.x`
3. `git cherry-pick 905eb71b8f7023ebc6a902abca67d0121753ec08`