### PR TITLE
Backport sdk/queue: move lock before checking queue length (#13146)

### DIFF
--- a/changelog/13146.txt
+++ b/changelog/13146.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk/queue: move lock before length check to prevent panics.
+```

--- a/sdk/queue/priority_queue.go
+++ b/sdk/queue/priority_queue.go
@@ -85,12 +85,12 @@ func (pq *PriorityQueue) Len() int {
 // wrapper/convenience method that calls heap.Pop, so consumers do not need to
 // invoke heap functions directly
 func (pq *PriorityQueue) Pop() (*Item, error) {
-	if pq.Len() == 0 {
-		return nil, ErrEmpty
-	}
-
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
+
+	if pq.data.Len() == 0 {
+		return nil, ErrEmpty
+	}
 
 	item := heap.Pop(&pq.data).(*Item)
 	delete(pq.dataMap, item.Key)


### PR DESCRIPTION
Backport of #13146.