### PR TITLE
Identity: check NextSigningKey existence during key rotation

### DIFF
--- a/changelog/13298.txt
+++ b/changelog/13298.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity: Fixes a panic in the OIDC key rotation due to a missing nil check.
+```

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -561,18 +561,10 @@ func (i *IdentityStore) pathOIDCCreateUpdateKey(ctx context.Context, req *logica
 		}
 		i.Logger().Debug("generated OIDC public key to sign JWTs", "key_id", signingKey.Public().KeyID)
 
-		nextSigningKey, err := generateKeys(key.Algorithm)
+		err = key.generateAndSetNextKey(ctx, i.Logger(), req.Storage)
 		if err != nil {
 			return nil, err
 		}
-
-		key.NextSigningKey = nextSigningKey
-		key.KeyRing = append(key.KeyRing, &expireableKey{KeyID: nextSigningKey.Public().KeyID})
-
-		if err := saveOIDCPublicKey(ctx, req.Storage, nextSigningKey.Public()); err != nil {
-			return nil, err
-		}
-		i.Logger().Debug("generated OIDC public key for future use", "key_id", nextSigningKey.Public().KeyID)
 	}
 
 	if err := i.oidcCache.Flush(ns); err != nil {
@@ -1018,6 +1010,24 @@ func mergeJSONTemplates(logger hclog.Logger, output map[string]interface{}, temp
 		}
 	}
 
+	return nil
+}
+
+// generateAndSetNextKey will generate new signing and public key pairs and set
+// them as the NextSigningKey.
+func (k *namedKey) generateAndSetNextKey(ctx context.Context, logger hclog.Logger, s logical.Storage) error {
+	signingKey, err := generateKeys(k.Algorithm)
+	if err != nil {
+		return err
+	}
+
+	k.NextSigningKey = signingKey
+	k.KeyRing = append(k.KeyRing, &expireableKey{KeyID: signingKey.Public().KeyID})
+
+	if err := saveOIDCPublicKey(ctx, s, signingKey.Public()); err != nil {
+		return err
+	}
+	logger.Debug("generated OIDC public key for future use", "key_id", signingKey.Public().KeyID)
 	return nil
 }
 
@@ -1477,16 +1487,6 @@ func (k *namedKey) rotate(ctx context.Context, logger hclog.Logger, s logical.St
 		verificationTTL = overrideVerificationTTL
 	}
 
-	// generate new key
-	nextSigningKey, err := generateKeys(k.Algorithm)
-	if err != nil {
-		return err
-	}
-	if err := saveOIDCPublicKey(ctx, s, nextSigningKey.Public()); err != nil {
-		return err
-	}
-	logger.Debug("generated OIDC public key for future use", "key_id", nextSigningKey.Public().KeyID)
-
 	now := time.Now()
 	// set the previous public key's expiry time
 	for _, key := range k.KeyRing {
@@ -1496,26 +1496,23 @@ func (k *namedKey) rotate(ctx context.Context, logger hclog.Logger, s logical.St
 		}
 	}
 
-	k.KeyRing = append(k.KeyRing, &expireableKey{KeyID: nextSigningKey.KeyID})
-
 	if k.NextSigningKey == nil {
-		signingKey, err := generateKeys(k.Algorithm)
+		// keys will not have a NextSigningKey if they were generated before
+		// vault 1.9
+		err := k.generateAndSetNextKey(ctx, logger, s)
 		if err != nil {
 			return err
 		}
-
-		k.SigningKey = signingKey
-		k.KeyRing = append(k.KeyRing, &expireableKey{KeyID: signingKey.Public().KeyID})
-
-		if err := saveOIDCPublicKey(ctx, s, signingKey.Public()); err != nil {
-			return err
-		}
-		logger.Debug("generated OIDC public key to sign JWTs", "key_id", signingKey.Public().KeyID)
-	} else {
-		k.SigningKey = k.NextSigningKey
-		k.NextSigningKey = nextSigningKey
 	}
+	// do the rotation
+	k.SigningKey = k.NextSigningKey
 	k.NextRotation = now.Add(k.RotationPeriod)
+
+	// now that we have rotated, generate a new NextSigningKey
+	err := k.generateAndSetNextKey(ctx, logger, s)
+	if err != nil {
+		return err
+	}
 
 	// store named key (it was modified when rotate was called on it)
 	entry, err := logical.StorageEntryJSON(namedKeyConfigPath+k.name, k)

--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -921,6 +921,7 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 		}
 	}{
 		{
+			// don't set NextSigningKey to ensure its non-existence can be handled
 			&namedKey{
 				name:            "test-key",
 				Algorithm:       "RS256",
@@ -928,7 +929,6 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 				RotationPeriod:  1 * cyclePeriod,
 				KeyRing:         nil,
 				SigningKey:      jwk,
-				NextSigningKey:  jwk,
 				NextRotation:    time.Now(),
 			},
 			[]struct {
@@ -936,8 +936,8 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 				numKeys       int
 				numPublicKeys int
 			}{
-				{1, 1, 1},
-				{2, 2, 2},
+				{1, 2, 2},
+				{2, 3, 3},
 				{3, 3, 3},
 				{4, 3, 3},
 				{5, 3, 3},


### PR DESCRIPTION
## Description
Fix a panic in the OIDC key rotation due to a missing nil check.


Fixes: https://github.com/hashicorp/vault/issues/13223


## Background
Vault 1.9 introduced a feature to pre-publish signing keys. When keys are generated in Vault 1.8 and rotated with Vault 1.9 a panic will occur due to a missing nil check.

To reproduce the issue:
- create keys/roles with Vault 1.8.4
- upgrade vault to 1.9.0
- manually rotate the key or wait for an auto rotation
- once key rotation triggers, the panic will occur