### PR TITLE
Identity: check NextSigningKey existence during key rotation (#13298)

### DIFF
--- a/changelog/13298.txt
+++ b/changelog/13298.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity: Fixes a panic in the OIDC key rotation due to a missing nil check.
+```

--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -921,6 +921,7 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 		}
 	}{
 		{
+			// don't set NextSigningKey to ensure its non-existence can be handled
 			&namedKey{
 				name:            "test-key",
 				Algorithm:       "RS256",
@@ -928,7 +929,6 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 				RotationPeriod:  1 * cyclePeriod,
 				KeyRing:         nil,
 				SigningKey:      jwk,
-				NextSigningKey:  jwk,
 				NextRotation:    time.Now(),
 			},
 			[]struct {
@@ -936,8 +936,8 @@ func TestOIDC_PeriodicFunc(t *testing.T) {
 				numKeys       int
 				numPublicKeys int
 			}{
-				{1, 1, 1},
-				{2, 2, 2},
+				{1, 2, 2},
+				{2, 3, 3},
 				{3, 3, 3},
 				{4, 3, 3},
 				{5, 3, 3},


### PR DESCRIPTION
Backports https://github.com/hashicorp/vault/pull/13298 into release/1.9.x.

Steps:
```
git checkout release/1.9.x
git checkout -b backport/1.9.x-13298
git cherry-pick 8b72c3eb73c9bff6c7d83ef024bd38d2384c7a62
```