### PR TITLE
TestGetOldestVersion Robustness Updates

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1047,7 +1047,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	return c, nil
 }
 
-// HandleVersionTimeStamps stores the current version at the current time to
+// handleVersionTimeStamps stores the current version at the current time to
 // storage, and then loads all versions and upgrade timestamps out from storage.
 func (c *Core) handleVersionTimeStamps(ctx context.Context) error {
 	currentTime := time.Now()

--- a/vault/core_util_common_test.go
+++ b/vault/core_util_common_test.go
@@ -32,8 +32,9 @@ func TestGetOldestVersion(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	upgradeTimePlusEpsilon := time.Now()
 
-	c.storeVersionTimestamp(context.Background(), "1.9.1", upgradeTimePlusEpsilon.Add(-4*time.Hour))
-	c.storeVersionTimestamp(context.Background(), "1.9.2", upgradeTimePlusEpsilon.Add(2*time.Hour))
+	// 1.6.2 is stored before 1.6.1, so even though it is a higher number, it should be returned.
+	c.storeVersionTimestamp(context.Background(), "1.6.2", upgradeTimePlusEpsilon.Add(-4*time.Hour))
+	c.storeVersionTimestamp(context.Background(), "1.6.1", upgradeTimePlusEpsilon.Add(2*time.Hour))
 	c.loadVersionTimestamps(c.activeContext)
 	if len(c.versionTimestamps) != 3 {
 		t.Fatalf("expected 3 entries in timestamps map after refresh, found: %d", len(c.versionTimestamps))
@@ -42,8 +43,8 @@ func TestGetOldestVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if v != "1.9.1" {
-		t.Fatalf("expected 1.9.1, found: %s", v)
+	if v != "1.6.2" {
+		t.Fatalf("expected 1.6.2, found: %s", v)
 	}
 	if tm.Before(upgradeTimePlusEpsilon.Add(-6*time.Hour)) || tm.After(upgradeTimePlusEpsilon.Add(-2*time.Hour)) {
 		t.Fatalf("incorrect upgrade time logged: %v", tm)


### PR DESCRIPTION
Make TestGetOldestVersion not rely on finding version timestamps for versions that may conflict with the version found in version.Version. 

This fixes one of the test failures https://app.circleci.com/pipelines/github/hashicorp/vault/23628/workflows/0b56da33-d4db-4afa-95d9-d122a081bb01/jobs/351285 . When version.Version is 1.9.1, this test was only finding 2 versions, as the version recorded when the core started up was also 1.9.1, and thus only 2 versions (1.9.1 and 1.9.2) were recorded, as opposed to 3 (1.9.1, 1.9.2, and the current version). 