### PR TITLE
version test robustness backports

### DIFF
--- a/vault/core.go
+++ b/vault/core.go
@@ -1045,7 +1045,7 @@ func NewCore(conf *CoreConfig) (*Core, error) {
 	return c, nil
 }
 
-// HandleVersionTimeStamps stores the current version at the current time to
+// handleVersionTimeStamps stores the current version at the current time to
 // storage, and then loads all versions and upgrade timestamps out from storage.
 func (c *Core) handleVersionTimeStamps(ctx context.Context) error {
 	currentTime := time.Now()

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/physical"
 	"github.com/hashicorp/vault/sdk/physical/inmem"
+	"github.com/hashicorp/vault/sdk/version"
 )
 
 // invalidKey is used to test Unseal

--- a/vault/core_test.go
+++ b/vault/core_test.go
@@ -61,9 +61,9 @@ func TestCore_HasVaultVersion(t *testing.T) {
 	if c.VersionTimestamps == nil {
 		t.Fatalf("Version timestamps for core were not initialized for a new core")
 	}
-	upgradeTime, ok := c.VersionTimestamps["1.9.0"]
+	upgradeTime, ok := c.VersionTimestamps[version.Version]
 	if !ok {
-		t.Fatalf("1.9.0 upgrade time not found")
+		t.Fatalf("%s upgrade time not found", version.Version)
 	}
 	if upgradeTime.After(time.Now()) || upgradeTime.Before(time.Now().Add(-1*time.Hour)) {
 		t.Fatalf("upgrade time isn't within reasonable bounds of new core initialization. " +

--- a/vault/core_util_common_test.go
+++ b/vault/core_util_common_test.go
@@ -32,8 +32,9 @@ func TestGetOldestVersion(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	upgradeTimePlusEpsilon := time.Now()
 
-	c.storeVersionTimestamp(context.Background(), "1.9.1", upgradeTimePlusEpsilon.Add(-4*time.Hour))
-	c.storeVersionTimestamp(context.Background(), "1.9.2", upgradeTimePlusEpsilon.Add(2*time.Hour))
+	// 1.6.2 is stored before 1.6.1, so even though it is a higher number, it should be returned.
+	c.storeVersionTimestamp(context.Background(), "1.6.2", upgradeTimePlusEpsilon.Add(-4*time.Hour))
+	c.storeVersionTimestamp(context.Background(), "1.6.1", upgradeTimePlusEpsilon.Add(2*time.Hour))
 	c.loadVersionTimestamps(c.activeContext)
 	if len(c.VersionTimestamps) != 3 {
 		t.Fatalf("expected 3 entries in timestamps map after refresh, found: %d", len(c.VersionTimestamps))
@@ -42,8 +43,8 @@ func TestGetOldestVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if v != "1.9.1" {
-		t.Fatalf("expected 1.9.1, found: %s", v)
+	if v != "1.6.2" {
+		t.Fatalf("expected 1.6.2, found: %s", v)
 	}
 	if tm.Before(upgradeTimePlusEpsilon.Add(-6*time.Hour)) || tm.After(upgradeTimePlusEpsilon.Add(-2*time.Hour)) {
 		t.Fatalf("incorrect upgrade time logged: %v", tm)


### PR DESCRIPTION
Backport of: https://github.com/hashicorp/vault/pull/13310/files and one file of: https://github.com/hashicorp/vault/commit/67cd5ff849eee3b1ff574407fd7c4a66010441c4#diff-10d0929fb581b3935034b72da0d810e601d6a1dca42d9d340eef07e99b7c19bd