### PR TITLE
Add iam:GetUser permission to the example.

### DIFF
--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -185,6 +185,7 @@ permissions Vault needs:
         "iam:DeleteUser",
         "iam:DeleteUserPolicy",
         "iam:DetachUserPolicy",
+        "iam:GetUser",
         "iam:ListAccessKeys",
         "iam:ListAttachedUserPolicies",
         "iam:ListGroupsForUser",


### PR DESCRIPTION
Without `iam:GetUser` permission, I wasn't able to get Vault to rotate its own credentials.