### PR TITLE
Typo fix in 1.9 Release Notes

### DIFF
--- a/website/content/docs/release-notes/1.9.0.mdx
+++ b/website/content/docs/release-notes/1.9.0.mdx
@@ -49,7 +49,7 @@ The [KMS Engine for GCP](https://www.vaultproject.io/docs/secrets/gcpkms) provid
 
 This section describes other features and enhancements introduced as part of the Vault 1.9 release.
 
-### Vaut Agent improvements
+### Vault Agent improvements
 
 Improvements were made to the Vault Agent Cache to ensure that [consul-template is always routed through the Vault Agent cache](/docs/agent/template), therefore, eliminating the need for listeners to be defined in the Vault Agent for just templating.
 


### PR DESCRIPTION
Fixes a typo in "Vault Agent improvements"