### PR TITLE
add `entity-alias` parameter description

### DIFF
--- a/website/content/docs/commands/token/create.mdx
+++ b/website/content/docs/commands/token/create.mdx
@@ -74,6 +74,11 @@ flags](/docs/commands) included on all commands.
 - `-display-name` `(string: "")` - Name to associate with this token. This is a
   non-sensitive value that can be used to help identify created secrets (e.g.
   prefixes).
+  
+- `-entity-alias`  `(string: "")` - Name of the entity alias to associate with 
+  during token creation. Only works in combination with -role argument and used 
+  entity alias must be listed in allowed_entity_aliases. If this has been 
+  specified, the entity will not be inherited from the parent.
 
 - `-explicit-max-ttl` `(duration: "")` - Explicit maximum lifetime for the
   token. Unlike normal TTLs, the maximum TTL is a hard limit and cannot be


### PR DESCRIPTION
This page was missing the `entity-alias` parameter description, available in the `vault token create --help` command. Added it from the command output.