### PR TITLE
Add multi-accessor support to ssh allowed_users_template feature 

### DIFF
--- a/builtin/logical/ssh/path_sign.go
+++ b/builtin/logical/ssh/path_sign.go
@@ -228,8 +228,6 @@ func (b *backend) calculateValidPrincipals(data *framework.FieldData, req *logic
 					if err == nil {
 						// Template returned a principal
 						allowedPrincipals = append(allowedPrincipals, templatePrincipal)
-					} else {
-						return nil, fmt.Errorf("template '%s' could not be rendered -> %s", principal, err)
 					}
 				}
 			} else {

--- a/changelog/13344.txt
+++ b/changelog/13344.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+builtin/logical/ssh: Add multi-accessor support to ssh allowed_users_template feature
+```


### PR DESCRIPTION
The issue is described here: https://github.com/hashicorp/vault/issues/12220

To test and verify: https://gist.github.com/prbinu/3a2e349eac5d265fd8683fcb01a84028#file-ssh-cert-template-test-sh
