### PR TITLE
Fix typo in policies.mdx

### DIFF
--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -321,7 +321,7 @@ The following templated policy allow to read the path associated with the
 Kubernetes service account namespace of the identity:
 
 ```ruby
-path "secrets/data/{{identity.entity.aliases.auth_kubernetes_xxxx.metadata.service_account_namespace}}/*" {
+path "secret/data/{{identity.entity.aliases.auth_kubernetes_xxxx.metadata.service_account_namespace}}/*" {
   capabilities = ["read"]
 }
 ```


### PR DESCRIPTION
Fix typo in Kubernetes service account namespace-based policy example which prevents this example from working.