### PR TITLE
Vault documentation: Update note about tokens

### DIFF
--- a/website/content/docs/concepts/tokens.mdx
+++ b/website/content/docs/concepts/tokens.mdx
@@ -6,6 +6,8 @@ description: Tokens are a core auth method in Vault. Concepts and important feat
 
 # Tokens
 
+!> **Warning**: Since tokens are considered opaque values, their structure is undocumented and subject to change. For these reasons, we do not recommend using tokens within your scripts or for automation since it can cause breakage.
+
 Tokens are the core method for _authentication_ within Vault. Tokens
 can be used directly or [auth methods](/docs/concepts/auth)
 can be used to dynamically generate tokens based on external identities.
@@ -27,9 +29,6 @@ holder is allowed to do within Vault. Other mapped information includes
 metadata that can be viewed and is added to the audit log, such as creation
 time, last renewal time, and more.
 
-~> Note that external to Vault, tokens are to be considered opaque values
-by users and as such, their structure is both currently undocumented and
-subject to change.
 
 Read on for a deeper dive into token concepts.
 


### PR DESCRIPTION
This change was a result of my conversation with Aarti last week regarding upcoming changes to the server side token feature for Vault 1.10. The request was to modify the existing note and make it more empathic to cover us for future changes made to the token formats. Additionally, the note was changed from **note** to **warning** and moved up higher within the content to emphasize its importance.

I've had both Meggie and Aarti review the modified text and they have approved it. 

:mag: [Deploy Preview](https://vault-git-update-note-for-tokens-hashicorp.vercel.app/docs/concepts/tokens)

Current note:
![image](https://user-images.githubusercontent.com/84412881/144915616-f0179d50-eb84-4cce-a3ab-cbdfdc976bd5.png)

New note:
![image](https://user-images.githubusercontent.com/84412881/144915681-05683eb4-85d3-4025-9310-287fb8a0fba3.png)
