### PR TITLE
agent/cache: differentiate open log messages

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -565,7 +565,7 @@ func (c *AgentCommand) Run(args []string) int {
 					AAD:     aad,
 				})
 				if err != nil {
-					c.UI.Error(fmt.Sprintf("Error opening persistent cache: %v", err))
+					c.UI.Error(fmt.Sprintf("Error opening persistent cache with wrapper: %v", err))
 					return 1
 				}
 


### PR DESCRIPTION
Changes the error output for the second open of the persistent cache file, to differentiate it from the c.UI.Error message for the initial open of the cache file on line 538, just to make it easier to tell where a problem occurred.

https://github.com/hashicorp/vault/blob/402c9bf4842bbe79a111e7bded2552db34bb4853/command/agent.go#L538-L542