### PR TITLE
auth/jwt: Update plugin to v0.11.3

### DIFF
--- a/changelog/13365.txt
+++ b/changelog/13365.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+**Add PKCE support to OIDC Auth**: The Authorization Code flow makes use of the
+Proof Key for Code Exchange (PKCE) extension.
+```

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-centrify v0.10.0
 	github.com/hashicorp/vault-plugin-auth-cf v0.10.0
 	github.com/hashicorp/vault-plugin-auth-gcp v0.11.2
-	github.com/hashicorp/vault-plugin-auth-jwt v0.11.2
+	github.com/hashicorp/vault-plugin-auth-jwt v0.11.3
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.3
 	github.com/hashicorp/vault-plugin-auth-oci v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -938,8 +938,8 @@ github.com/hashicorp/vault-plugin-auth-cf v0.10.0 h1:c9jepaNQXfPNl7ryufVP9RBKb5S
 github.com/hashicorp/vault-plugin-auth-cf v0.10.0/go.mod h1:4HM4amMEcCyoLZNNjyz5AYILIlhMLTErxrinM3Vopy4=
 github.com/hashicorp/vault-plugin-auth-gcp v0.11.2 h1:nchN/UFZDZFQbNJHDwq86vDRk6JUkTS999aZcfpxbVY=
 github.com/hashicorp/vault-plugin-auth-gcp v0.11.2/go.mod h1:HJc8ih7gLNpBJYTwFlXJA3H48LKsP8mlVKYtPWfRkHs=
-github.com/hashicorp/vault-plugin-auth-jwt v0.11.2 h1:+dRT24GSDXKMF+phD+ejFDax8cI0gri6saj9p7cCXw0=
-github.com/hashicorp/vault-plugin-auth-jwt v0.11.2/go.mod h1:jzjDdssus8sw8G6NOP7kNFMEeIvrjXvPHUR3pEn5+r0=
+github.com/hashicorp/vault-plugin-auth-jwt v0.11.3 h1:uo7Gz81YqiYjg1ne4ZvT5csV/L4UT/9jlNVdCdb1jEs=
+github.com/hashicorp/vault-plugin-auth-jwt v0.11.3/go.mod h1:jzjDdssus8sw8G6NOP7kNFMEeIvrjXvPHUR3pEn5+r0=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0 h1:oORxeqOraVVLQrb+z3fj5JayPmH/JBxJWGywZ8ZRJt0=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0/go.mod h1:eqjae8tMBpAWgJNk1NjV/vtJYXQRZnYudUkBFowz3bY=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.3 h1:VTl62rRNhcALzsLw8romBZfTRpVna2IeLTN0kAQyXvY=


### PR DESCRIPTION
This PR updates the auth jwt plugin to [v0.11.3](https://github.com/hashicorp/vault-plugin-auth-jwt/releases/tag/v0.11.3) to bring in PKCE support from https://github.com/hashicorp/vault-plugin-auth-jwt/pull/188.

Steps:
1. `go get github.com/hashicorp/vault-plugin-auth-jwt@release/vault-1.9.x`
2. `go mod tidy`