### PR TITLE
Warn user supplying nonce values in FIPS mode for transit encryption requests

### DIFF
--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -5,8 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -157,6 +157,10 @@ func (b *backend) pathDatakeyWrite(ctx context.Context, req *logical.Request, d 
 			"ciphertext":  ciphertext,
 			"key_version": keyVersion,
 		},
+	}
+
+	if consts.IsFIPS() && shouldWarnAboutNonceUsage(p, nonce) {
+		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS standards.")
 	}
 
 	if plaintextAllowed {

--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -160,7 +160,7 @@ func (b *backend) pathDatakeyWrite(ctx context.Context, req *logical.Request, d 
 	}
 
 	if consts.IsFIPS() && shouldWarnAboutNonceUsage(p, nonce) {
-		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS standards.")
+		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS 140 compliance.")
 	}
 
 	if plaintextAllowed {

--- a/builtin/logical/transit/path_datakey.go
+++ b/builtin/logical/transit/path_datakey.go
@@ -5,8 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -159,7 +159,7 @@ func (b *backend) pathDatakeyWrite(ctx context.Context, req *logical.Request, d 
 		},
 	}
 
-	if consts.IsFIPS() && shouldWarnAboutNonceUsage(p, nonce) {
+	if constants.IsFIPS() && shouldWarnAboutNonceUsage(p, nonce) {
 		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS 140 compliance.")
 	}
 

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/helper/constants"
 	"net/http"
 	"reflect"
 
@@ -417,7 +417,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		}
 	}
 
-	if consts.IsFIPS() && warnAboutNonceUsage {
+	if constants.IsFIPS() && warnAboutNonceUsage {
 		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS 140 compliance.")
 	}
 

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -418,7 +418,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 	}
 
 	if consts.IsFIPS() && warnAboutNonceUsage {
-		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS standards.")
+		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS 140 compliance.")
 	}
 
 	if req.Operation == logical.CreateOperation && !upserted {

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/hashicorp/vault/helper/constants"
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -195,7 +195,7 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 		}
 	}
 
-	if consts.IsFIPS() && warnAboutNonceUsage {
+	if constants.IsFIPS() && warnAboutNonceUsage {
 		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS 140 compliance.")
 	}
 

--- a/builtin/logical/transit/path_rewrap.go
+++ b/builtin/logical/transit/path_rewrap.go
@@ -196,7 +196,7 @@ func (b *backend) pathRewrapWrite(ctx context.Context, req *logical.Request, d *
 	}
 
 	if consts.IsFIPS() && warnAboutNonceUsage {
-		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS standards.")
+		resp.AddWarning("A provided nonce value was used within FIPS mode, this violates FIPS 140 compliance.")
 	}
 
 	p.Unlock()

--- a/helper/constants/fips.go
+++ b/helper/constants/fips.go
@@ -1,6 +1,6 @@
 // +build !fips_140_3
 
-package consts
+package constants
 
 // IsFIPS returns true if Vault is operating in a FIPS-140-{2,3} mode.
 func IsFIPS() bool {

--- a/sdk/helper/consts/fips.go
+++ b/sdk/helper/consts/fips.go
@@ -1,0 +1,9 @@
+//go:build !fips_140_3
+// +build !fips_140_3
+
+package consts
+
+// IsFIPS returns true if Vault is operating in a FIPS-140-{2,3} mode.
+func IsFIPS() bool {
+	return false
+}

--- a/sdk/helper/consts/fips.go
+++ b/sdk/helper/consts/fips.go
@@ -1,4 +1,3 @@
-//go:build !fips_140_3
 // +build !fips_140_3
 
 package consts


### PR DESCRIPTION
 - Send back a warning within the response if an end-user supplies nonce values that we use within the various transit encrypt apis.
 - We do not send a warning if an end-user supplies a nonce value but we don't use it.
 - Affected api methods are encrypt, rewrap and datakey
 - The warning is only sent when we are operating in FIPS mode.