### PR TITLE
Update openshift.mdx

### DIFF
--- a/website/content/docs/platform/k8s/helm/openshift.mdx
+++ b/website/content/docs/platform/k8s/helm/openshift.mdx
@@ -23,7 +23,7 @@ on OpenShift:
 - Vault Helm v0.6.0+
 - Vault K8s v0.4.0+
 
-~> **Note:** At this time, Consul does not support OpenShift. For highly available
+~> **Note:** Consul on OpenShift is supported since [Consul 1.9] (https://www.hashicorp.com/blog/introducing-openshift-support-for-consul-on-kubernetes). However, for highly available
 deployments, Raft integrated storage is recommended.
 
 ## Additional Resources


### PR DESCRIPTION
Consul Openshift is supported since Consul 1.9 as per https://www.hashicorp.com/blog/introducing-openshift-support-for-consul-on-kubernetes. Please verify.