### PR TITLE
go sdk version upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/hashicorp/vault/api v1.3.0
 	github.com/hashicorp/vault/api/auth/approle v0.0.0-00010101000000-000000000000
 	github.com/hashicorp/vault/api/auth/userpass v0.0.0-00010101000000-000000000000
-	github.com/hashicorp/vault/sdk v0.3.1-0.20211130211948-775834e16788
+	github.com/hashicorp/vault/sdk v0.3.1-0.20211209192327-a0822e64eae0
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f


### PR DESCRIPTION
This PR was made by running:

`go get github.com/hashicorp/vault/sdk@release/1.9.x` 
`go mod tidy`

after https://github.com/hashicorp/vault/pull/13381 was merged. 