### PR TITLE
Some changelog tidying for 1.10 preview

### DIFF
--- a/changelog/12792.txt
+++ b/changelog/12792.txt
@@ -1,3 +1,3 @@
-```release-note: feature
-core: reading `sys/mounts/:path` now returns the configuration for the secret engine at the given path
+```release-note:improvement
+core: Reading `sys/mounts/:path` now returns the configuration for the secret engine at the given path
 ```

--- a/changelog/12795.txt
+++ b/changelog/12795.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:improvement
 core/pki: Support Y10K value in notAfter field to be compliant with IEEE 802.1AR-2018 standard
 ```

--- a/changelog/13022.txt
+++ b/changelog/13022.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-implements Login method in Go client libraries for GCP and Azure auth methods
+api: Implements Login method in Go client libraries for GCP and Azure auth methods
 ```

--- a/changelog/13178.txt
+++ b/changelog/13178.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-raft: set InitialMmapSize to 100GB on 64bit architectures
+storage/raft: Set InitialMmapSize to 100GB on 64bit architectures
 ```

--- a/changelog/13202.txt
+++ b/changelog/13202.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:improvement
 /sys/mounts/:path/tune: Add `allowed_managed_keys` field to mount config which is a list of managed key registry entry names that the mount in question is allowed to access.
 ```

--- a/changelog/13202.txt
+++ b/changelog/13202.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-/sys/mounts/:path/tune: Add `allowed_managed_keys` field to mount config which is a list of managed key registry entry names that the mount in question is allowed to access.
-```


### PR DESCRIPTION
@raskchanky - storage/raft seemed more used than just "raft" as a subsystem in the changelog, but I wasn't 100% sure whether we used both prefixes to mean different things.

@divyapola5 - I wasn't sure what subsystem to use for the mount tune change. Maybe `config`?

Most of this is just FYI notes about feature formatting vs improvements. If any of these should be called out as new features in the FEATURES section though, could you make a change to this branch with what the description of the new feature should be?