### PR TITLE
typo: Updated terraform dynamodb example

### DIFF
--- a/website/content/docs/configuration/storage/dynamodb.mdx
+++ b/website/content/docs/configuration/storage/dynamodb.mdx
@@ -129,17 +129,17 @@ resource "aws_dynamodb_table" "dynamodb-table" {
   write_capacity = 1
 	hash_key       = "Path"
 	range_key      = "Key"
-	attribute      = [
-		{
-			name = "Path"
-			type = "S"
-		},
-		{
-			name = "Key"
-			type = "S"
-		}
-	]
-  tags {
+  attribute {
+    name = "Path"
+    type = "S"
+  }
+
+  attribute {
+    name = "Key"
+    type = "S"
+  }
+
+  tags = {
     Name        = "vault-dynamodb-table"
     Environment = "prod"
   }


### PR DESCRIPTION
The terraform dynamodb example had a couple of issues:

- Tags was missing a `=`
- Attribute list is not supported