### PR TITLE
auth/azure: add note about debug env

### DIFF
--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -192,6 +192,18 @@ for your server at `path/to/plugins`:
    $ vault auth enable -path=azure azure-auth
    ```
 
+## Azure Debug Logs
+
+The Azure Auth Plugin supports additional logging of all requests to the Azure API
+when additional information is needed (such as correlation ID headers).
+
+To enable the Azure debug logs, set the following environment variable on the Vault
+server:
+
+```shell
+AZURE_SDK_GO_LOGGING=debug
+```
+
 ## API
 
 The Azure Auth Plugin has a full HTTP API. Please see the [API documentation](/api/auth/azure) for more details.

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -194,7 +194,7 @@ for your server at `path/to/plugins`:
 
 ## Azure Debug Logs
 
-The Azure auth plugin supports additional debug logging which includes additional information 
+The Azure auth plugin supports debug logging which includes additional information 
 about requests and responses from the Azure API.
 
 To enable the Azure debug logs, set the following environment variable on the Vault

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -194,8 +194,8 @@ for your server at `path/to/plugins`:
 
 ## Azure Debug Logs
 
-The Azure Auth Plugin supports additional logging of all requests to the Azure API
-when additional information is needed (such as correlation ID headers).
+The Azure auth plugin supports additional debug logging which includes additional information 
+about requests and responses from the Azure API.
 
 To enable the Azure debug logs, set the following environment variable on the Vault
 server:


### PR DESCRIPTION
This adds documentation about the Azure Go SDK supporting additional request logging when communicating with the Azure API. 