### PR TITLE
Update gcp.mdx

### DIFF
--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -109,11 +109,11 @@ To configure a roleset that generates OAuth2 access tokens (preferred):
 
 ```text
 $ vault write gcp/roleset/my-token-roleset \
-    project="my-project" \
+    project="my-project-id" \
     secret_type="access_token"  \
     token_scopes="https://www.googleapis.com/auth/cloud-platform" \
     bindings=-<<EOF
-      resource "//cloudresourcemanager.googleapis.com/projects/my-project" {
+      resource "//cloudresourcemanager.googleapis.com/projects/my-project-id" {
         roles = ["roles/viewer"]
       }
     EOF


### PR DESCRIPTION
Updated the example for oauth.  In my testing I had to use the project-id for both the project attribute as well as within the bindings attribute.