### PR TITLE
Fix for `1.7.x`: Add vault revision to --version cmd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
 
         run: |
           mkdir dist out
-          VAULT_VERSION=${{ needs.get-product-version.outputs.product-version }}  VAULT_COMMIT=${GITHUB_SHA} GO_TAGS="${{ env.GO_TAGS }}" make build
+          GO_TAGS="${{ env.GO_TAGS }}" VAULT_VERSION=${{ needs.get-product-version.outputs.product-version }} VAULT_REVISION="$(git rev-parse HEAD)" make build
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
       - uses: actions/upload-artifact@v2
         with:
@@ -141,7 +141,7 @@ jobs:
 
         run: |
           mkdir dist out
-          VAULT_VERSION=${{ needs.get-product-version.outputs.product-version }}  VAULT_COMMIT=${GITHUB_SHA} GO_TAGS="${{ env.GO_TAGS }}" make build
+          GO_TAGS="${{ env.GO_TAGS }}" VAULT_VERSION=${{ needs.get-product-version.outputs.product-version }} VAULT_REVISION="$(git rev-parse HEAD)" make build
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
       - uses: actions/upload-artifact@v2
         with:
@@ -219,7 +219,7 @@ jobs:
 
         run: |
           mkdir dist out
-          VAULT_VERSION=${{ needs.get-product-version.outputs.product-version }}  VAULT_COMMIT=${GITHUB_SHA} GO_TAGS="${{ env.GO_TAGS }}" make build
+          GO_TAGS="${{ env.GO_TAGS }}" VAULT_VERSION=${{ needs.get-product-version.outputs.product-version }} VAULT_REVISION="$(git rev-parse HEAD)" make build
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
       - uses: actions/upload-artifact@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ ci-verify:
 # This is used for release builds by .github/workflows/build.yml
 build: static-dist
 	@echo "--> Building Vault $(VAULT_VERSION)"
-	@go build -v -tags "$(GO_TAGS)" -ldflags " -X $VERSION_PKG_PATH.Version=$(VAULT_VERSION) -X $VERSION_PKG_PATH.GitCommit=$(VAULT_COMMIT)" -o dist/
+	@@go build -v -tags "$(GO_TAGS)" -ldflags " -X github.com/hashicorp/vault/sdk/version.Version=$(VAULT_VERSION) -X github.com/hashicorp/vault/sdk/version.GitCommit=$(VAULT_REVISION)" -o dist/
 
 .PHONY: version
 # This is used for release builds by .github/workflows/build.yml

--- a/sdk/version/version.go
+++ b/sdk/version/version.go
@@ -7,10 +7,10 @@ import (
 
 // VersionInfo
 type VersionInfo struct {
-	Revision          string
-	Version           string
-	VersionPrerelease string
-	VersionMetadata   string
+	Revision          string `json:"revision,omitempty"`
+	Version           string `json:"version,omitempty"`
+	VersionPrerelease string `json:"version_prerelease,omitempty"`
+	VersionMetadata   string `json:"version_metadata,omitempty"`
 }
 
 func GetVersion() *VersionInfo {
@@ -37,7 +37,7 @@ func (c *VersionInfo) VersionNumber() string {
 		return "(version unknown)"
 	}
 
-	version := fmt.Sprintf("%s", c.Version)
+	version := c.Version
 
 	if c.VersionPrerelease != "" {
 		version = fmt.Sprintf("%s-%s", version, c.VersionPrerelease)

--- a/vendor/github.com/hashicorp/vault/sdk/version/version.go
+++ b/vendor/github.com/hashicorp/vault/sdk/version/version.go
@@ -7,10 +7,10 @@ import (
 
 // VersionInfo
 type VersionInfo struct {
-	Revision          string
-	Version           string
-	VersionPrerelease string
-	VersionMetadata   string
+	Revision          string `json:"revision,omitempty"`
+	Version           string `json:"version,omitempty"`
+	VersionPrerelease string `json:"version_prerelease,omitempty"`
+	VersionMetadata   string `json:"version_metadata,omitempty"`
 }
 
 func GetVersion() *VersionInfo {
@@ -37,7 +37,7 @@ func (c *VersionInfo) VersionNumber() string {
 		return "(version unknown)"
 	}
 
-	version := fmt.Sprintf("%s", c.Version)
+	version := c.Version
 
 	if c.VersionPrerelease != "" {
 		version = fmt.Sprintf("%s-%s", version, c.VersionPrerelease)


### PR DESCRIPTION
The output of `./vault --version` changed since Vault onboarded to CRT/GitHub Actions for building artifacts.

```
elle: ~/Users/elle/Downloads $ ./vault version
Vault v1.9.1
elle: ~/Users/elle/Downloads $ ./vault version
Vault v1.8.1 (4b0264f28defc05454c31277cfa6ff63695a458d)
```

This change adds back in the revision string to the version command. Output from the artifacts built on this branch:

```
elle: ~/Users/elle/Downloads $ ./vault --version
Vault v1.10.0-dev (9e2f21337b47d8ef59f057b6d192d6fde2c5fb19)
```
