### PR TITLE
docs: add a note regarding the backend => storage config key aliasing

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-0.7.0.mdx
+++ b/website/content/docs/upgrading/upgrade-to-0.7.0.mdx
@@ -11,6 +11,13 @@ description: |-
 This page contains the list of deprecations and important or breaking changes
 for Vault 0.7.0 compared to the most recent release. Please read it carefully.
 
+## Rename of `backend` config key to `storage`
+
+When configuring Vault, the `backend` key that previously was used to configure
+storage has now been renamed to `storage`. Vault will alias the old key to the
+new path, though users are encouraged to update their configuration to ensure
+minimal disruption in the future when the alias is removed.
+
 ## List Operations Always Use Trailing Slash
 
 Any list operation, whether via the `GET` or `LIST` HTTP verb, will now

--- a/website/content/docs/upgrading/upgrade-to-0.7.0.mdx
+++ b/website/content/docs/upgrading/upgrade-to-0.7.0.mdx
@@ -13,7 +13,7 @@ for Vault 0.7.0 compared to the most recent release. Please read it carefully.
 
 ## Rename of `backend` config key to `storage`
 
-When configuring Vault, the `backend` key that previously was used to configure
+When configuring Vault, the `backend` key previously used to configure
 storage has now been renamed to `storage`. Vault will alias the old key to the
 new path, though users are encouraged to update their configuration to ensure
 minimal disruption in the future when the alias is removed.


### PR DESCRIPTION
This was missing from upgrade docs and implemented in #2456.