### PR TITLE
[VAULT-4018] EscapeLDAPValue - catch trailing escape character 

### DIFF
--- a/changelog/13452.txt
+++ b/changelog/13452.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk/helper/ldaputil: properly escape a trailing escape character to prevent panics.
+```

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -512,7 +512,7 @@ func EscapeLDAPValue(input string) string {
 	// - null
 	for i := 0; i < len(input); i++ {
 		escaped := false
-		if input[i] == '\\' {
+		if input[i] == '\\' && i+1 < len(input)-1 {
 			i++
 			escaped = true
 		}

--- a/sdk/helper/ldaputil/client_test.go
+++ b/sdk/helper/ldaputil/client_test.go
@@ -32,6 +32,9 @@ func TestLDAPEscape(t *testing.T) {
 		"test\\hello": "test\\\\hello",
 		"  test  ":    "\\  test \\ ",
 		"":            "",
+		"\\test":      "\\\\test",
+		"test\\":      "test\\\\",
+		"test\\ ":     "test\\\\\\ ",
 	}
 
 	for test, answer := range testcases {


### PR DESCRIPTION
Properly escape a trailing escape character.

PR addresses findings from [Trail of Bits 018]: 
> The EscapeLDAPValue function does not validate input strings properly because it is possible to pass an input string that leads to panic. The bug occurs when the escaping character (“\”) in the passed string does not precede any character (is located at the end of the string).