### PR TITLE
Splitting backport-asst GH action

### DIFF
--- a/.github/workflows/backport-docs.yml
+++ b/.github/workflows/backport-docs.yml
@@ -1,0 +1,45 @@
+---
+name: Backport Assistant Runner For Docs (OSS only)
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport-for-docs:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    container: hashicorpdev/backport-assistant:0.2.3
+    steps:
+      - name: Backport changes to stable-website
+        run: |
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
+          BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+      - name: Backport changes labeled website to latest release branch
+        run: |
+          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/releases?per_page=100")
+          ret="$?"
+          if [[ "$ret" -ne 0 ]]; then
+              echo "The GitHub API returned $ret"
+              exit $ret
+          fi
+
+          # find the latest non-rc release
+          latest_version=$(echo "$resp" | tr '\r\n' ' ' | jq -r '.[] | select(.name|test("^v\\d+\\.\\d+\\.\\d+$")) | .name' | sort -rV | head -n1)
+          echo "Latest non-rc version: $latest_version"
+
+          # strip leading "v" &
+          target="${latest_version#v}"
+          # replace patch version with "x"
+          target="${target%.*}.x"
+          
+          export BACKPORT_TARGET_TEMPLATE="release/$target"
+          backport-assistant backport
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,5 +1,5 @@
 ---
-name: Backport Assistant Runner
+name: Backport Assistant Runner (for OSS & ENT)
 
 on:
   pull_request_target:
@@ -8,41 +8,11 @@ on:
       - labeled
 
 jobs:
-  backport:
+  backport-targeted-release-branch:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     container: hashicorpdev/backport-assistant:0.2.3
     steps:
-      - name: Backport changes to stable-website
-        run: |
-          backport-assistant backport -automerge
-        env:
-          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
-          BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
-          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-      - name: Backport changes labeled website to latest release branch
-        run: |
-          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/releases?per_page=100")
-          ret="$?"
-          if [[ "$ret" -ne 0 ]]; then
-              echo "The GitHub API returned $ret"
-              exit $ret
-          fi
-
-          # find the latest non-rc release
-          latest_version=$(echo "$resp" | tr '\r\n' ' ' | jq -r '.[] | select(.name|test("^v\\d+\\.\\d+\\.\\d+$")) | .name' | sort -rV | head -n1)
-          echo "Latest non-rc version: $latest_version"
-
-          # strip leading "v" &
-          target="${latest_version#v}"
-          # replace patch version with "x"
-          target="${target%.*}.x"
-          
-          export BACKPORT_TARGET_TEMPLATE="release/$target"
-          backport-assistant backport
-        env:
-          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
-          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to targeted release branch
         run: |
           backport-assistant backport


### PR DESCRIPTION
This way we can have an OSS action, and an ENT action. We'll be able to
keep the backport-assistant workflows the same on OSS and ENT for normal
PRs, and have a separate labeling system on OSS for docs backports.

We should delete the backport-docs.yml file on ENT.

The jobs have the same triggers, so should still work the same way.