### PR TITLE
Add an option to configure the HTTP proxy to use with the AWS auth method

### DIFF
--- a/builtin/credential/aws/path_config_client.go
+++ b/builtin/credential/aws/path_config_client.go
@@ -53,6 +53,12 @@ func (b *backend) pathConfigClient() *framework.Path {
 				Description: "The region ID for the sts_endpoint, if set.",
 			},
 
+			"http_proxy": {
+				Type:    framework.TypeString,
+				Default: "",
+				Description: "The proxy to use for the AWS API calls.",
+			},
+
 			"iam_server_id_header_value": {
 				Type:        framework.TypeString,
 				Default:     "",
@@ -146,6 +152,7 @@ func (b *backend) pathConfigClientRead(ctx context.Context, req *logical.Request
 			"iam_endpoint":               clientConfig.IAMEndpoint,
 			"sts_endpoint":               clientConfig.STSEndpoint,
 			"sts_region":                 clientConfig.STSRegion,
+			"http_proxy":                clientConfig.HTTPProxy,
 			"iam_server_id_header_value": clientConfig.IAMServerIdHeaderValue,
 			"max_retries":                clientConfig.MaxRetries,
 			"allowed_sts_header_values":  clientConfig.AllowedSTSHeaderValues,
@@ -259,6 +266,14 @@ func (b *backend) pathConfigClientCreateUpdate(ctx context.Context, req *logical
 		}
 	}
 
+	httpsProxyStr, ok := data.GetOk("http_proxy")
+	if ok {
+		if configEntry.HTTPProxy != httpsProxyStr.(string) {
+			changedCreds = true
+			configEntry.HTTPProxy = httpsProxyStr.(string)
+		}
+	}
+
 	headerValStr, ok := data.GetOk("iam_server_id_header_value")
 	if ok {
 		if configEntry.IAMServerIdHeaderValue != headerValStr.(string) {
@@ -341,6 +356,7 @@ type clientConfig struct {
 	IAMEndpoint            string   `json:"iam_endpoint"`
 	STSEndpoint            string   `json:"sts_endpoint"`
 	STSRegion              string   `json:"sts_region"`
+	HTTPProxy             string   `json:"http_proxy"`
 	IAMServerIdHeaderValue string   `json:"iam_server_id_header_value"`
 	AllowedSTSHeaderValues []string `json:"allowed_sts_header_values"`
 	MaxRetries             int      `json:"max_retries"`

--- a/go.mod
+++ b/go.mod
@@ -170,7 +170,7 @@ require (
 	go.uber.org/atomic v1.9.0
 	go.uber.org/goleak v1.1.11-0.20210813005559-691160354723
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
-	golang.org/x/net v0.0.0-20211020060615-d418f374d309
+	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b

--- a/go.sum
+++ b/go.sum
@@ -1742,6 +1742,8 @@ golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211008194852-3b03d305991f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309 h1:A0lJIi+hcTR6aajJH4YqKWwohY4aW9RO7oRMcdv+HKI=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
+golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/website/content/api-docs/auth/aws.mdx
+++ b/website/content/api-docs/auth/aws.mdx
@@ -61,6 +61,7 @@ capabilities, the credentials are fetched automatically.
 - `sts_region` `(string: "")` - Region to override the default region for making
   AWS STS API calls. Should only be set if `sts_endpoint` is set. If so, should
   be set to the region in which the custom `sts_endpoint` resides.
+- `http_proxy` `(string: "")` - The proxy to use for the AWS API calls.
 - `iam_server_id_header_value` `(string: "")` - The value to require in the
   `X-Vault-AWS-IAM-Server-ID` header as part of GetCallerIdentity requests that
   are used in the iam auth method. If not set, then no value is required or
@@ -119,6 +120,7 @@ $ curl \
     "iam_endpoint": "",
     "sts_endpoint": "",
     "sts_region": "",
+    "http_proxy": "",
     "iam_server_id_header_value": ""
   }
 }


### PR DESCRIPTION
We are using Vault Enterprise with multiple namespaces in an environment
where we have to use an HTTP proxy to access the AWS API. The
configuration for the AWS auth method currently makes it possible to
change the endpoints VAult will contact by setting `endpoint`, `iam_endpoint`
and `sts_endpoint` but there is currently no way to set an HTTPS proxy.

While we could set the `HTTPS_PROXY` environment variable on the server
this has the drawback on impacting all the HTTP requests made by Vault,
not just the ones made by this authentication method. This is an issue
because we would like to use a proxy only for this auth method and not
for the JWT one. We might also need to use another proxy for the Azure
auth method and to use different proxies for different namespaces.

This patch adds a new `http_proxy` parameter that can be used for this
purpose. If not set the previous behavior on looking at the `HTTPS_PROXY`
environment variable is kept so that it will continue to work for users
already depending on it, however the environment variable will be
overriden by this new parameter when it is set.