### PR TITLE
[Vault-4628] OpenAPI endpoint not expanding root alternations

### DIFF
--- a/changelog/13487.txt
+++ b/changelog/13487.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk/framework: Generate proper specs for path patterns that use an alternation as the root.
+```

--- a/changelog/13487.txt
+++ b/changelog/13487.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-sdk/framework: Generate proper specs for path patterns that use an alternation as the root.
+sdk/framework: Generate proper OpenAPI specs for path patterns that use an alternation as the root.
 ```

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -200,7 +200,7 @@ var (
 	altFieldsGroupRe = regexp.MustCompile(`\(\?P<\w+>\w+(\|\w+)+\)`) // Match named groups that limit options, e.g. "(?<foo>a|b|c)"
 	altFieldsRe      = regexp.MustCompile(`\w+(\|\w+)+`)             // Match an options set, e.g. "a|b|c"
 	nonWordRe        = regexp.MustCompile(`[^\w]+`)                  // Match a sequence of non-word characters
-	altRoots         = regexp.MustCompile(`\(((\w*)[\||\)])+\/`)     // Paths that start with alts, e.g. "(creds|sts)/(?P<name>regex)"
+	altRootsRe       = regexp.MustCompile(`\(((\w*)[\||\)])+\/`)     // Paths that start with alts, e.g. "(creds|sts)/(?P<name>regex)"
 )
 
 // documentPaths parses all paths in a framework.Backend into OpenAPI paths.
@@ -467,7 +467,7 @@ func expandPattern(pattern string) []string {
 
 	// recursively operate on each pattern after determining a set of unique roots is present,
 	// e.g. "(rootOne|rootTwo)/(?P<name>regex)" should yield "rootOne/{name}", "rootTwo/{name}"
-	rootMatch := altRoots.FindAllString(pattern, -1)
+	rootMatch := altRootsRe.FindAllString(pattern, -1)
 	if len(rootMatch) > 0 {
 		m := strings.Replace(rootMatch[0][1:], ")/", "", -1)
 		if m != "" {

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -191,16 +191,16 @@ var OASStdRespNoContent = &OASResponse{
 var optRe = regexp.MustCompile(`(?U)\([^(]*\)\?|\(/\(\?P<[^(]*\)\)\?`)
 
 var (
-	reqdRe           = regexp.MustCompile(`\(?\?P<(\w+)>[^)]*\)?`)                // Capture required parameters, e.g. "(?P<name>regex)"
-	altRe            = regexp.MustCompile(`\((.*)\|(.*)\)`)                       // Capture alternation elements, e.g. "(raw/?$|raw/(?P<path>.+))"
-	pathFieldsRe     = regexp.MustCompile(`{(\w+)}`)                              // Capture OpenAPI-style named parameters, e.g. "lookup/{urltoken}",
-	cleanCharsRe     = regexp.MustCompile("[()^$?]")                              // Set of regex characters that will be stripped during cleaning
-	cleanSuffixRe    = regexp.MustCompile(`/\?\$?$`)                              // Path suffix patterns that will be stripped during cleaning
-	wsRe             = regexp.MustCompile(`\s+`)                                  // Match whitespace, to be compressed during cleaning
 	altFieldsGroupRe = regexp.MustCompile(`\(\?P<\w+>\w+(\|\w+)+\)`)              // Match named groups that limit options, e.g. "(?<foo>a|b|c)"
 	altFieldsRe      = regexp.MustCompile(`\w+(\|\w+)+`)                          // Match an options set, e.g. "a|b|c"
-	nonWordRe        = regexp.MustCompile(`[^\w]+`)                               // Match a sequence of non-word characters
+	altRe            = regexp.MustCompile(`\((.*)\|(.*)\)`)                       // Capture alternation elements, e.g. "(raw/?$|raw/(?P<path>.+))"
 	altRootsRe       = regexp.MustCompile(`^\(([\w\-_]+(?:\|[\w\-_]+)+)\)(/.*)$`) // Pattern starting with alts, e.g. "(root1|root2)/(?P<name>regex)"
+	cleanCharsRe     = regexp.MustCompile("[()^$?]")                              // Set of regex characters that will be stripped during cleaning
+	cleanSuffixRe    = regexp.MustCompile(`/\?\$?$`)                              // Path suffix patterns that will be stripped during cleaning
+	nonWordRe        = regexp.MustCompile(`[^\w]+`)                               // Match a sequence of non-word characters
+	pathFieldsRe     = regexp.MustCompile(`{(\w+)}`)                              // Capture OpenAPI-style named parameters, e.g. "lookup/{urltoken}",
+	reqdRe           = regexp.MustCompile(`\(?\?P<(\w+)>[^)]*\)?`)                // Capture required parameters, e.g. "(?P<name>regex)"
+	wsRe             = regexp.MustCompile(`\s+`)                                  // Match whitespace, to be compressed during cleaning
 )
 
 // documentPaths parses all paths in a framework.Backend into OpenAPI paths.

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -199,6 +199,7 @@ func TestOpenAPI_ExpandPattern(t *testing.T) {
 		{"^plugins/catalog/(?P<type>auth|database|secret)/?$", []string{
 			"plugins/catalog/{type}",
 		}},
+		{"(creds|sts)/" + GenericNameRegex("name"), []string{"creds/{name}", "sts/{name}"}},
 	}
 
 	for i, test := range tests {

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -199,7 +199,9 @@ func TestOpenAPI_ExpandPattern(t *testing.T) {
 		{"^plugins/catalog/(?P<type>auth|database|secret)/?$", []string{
 			"plugins/catalog/{type}",
 		}},
-		{"(creds|sts)/" + GenericNameRegex("name"), []string{"creds/{name}", "sts/{name}"}},
+		{"(pathOne|pathTwo)/" + GenericNameRegex("name"), []string{"pathOne/{name}", "pathTwo/{name}"}},
+		{"(pathOne|path-2|Path_3)/" + GenericNameRegex("name"),
+			[]string{"Path_3/{name}", "path-2/{name}", "pathOne/{name}"}},
 	}
 
 	for i, test := range tests {

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -199,6 +199,7 @@ func TestOpenAPI_ExpandPattern(t *testing.T) {
 		{"^plugins/catalog/(?P<type>auth|database|secret)/?$", []string{
 			"plugins/catalog/{type}",
 		}},
+		{"(pathOne|pathTwo)/", []string{"pathOne/", "pathTwo/"}},
 		{"(pathOne|pathTwo)/" + GenericNameRegex("name"), []string{"pathOne/{name}", "pathTwo/{name}"}},
 		{"(pathOne|path-2|Path_3)/" + GenericNameRegex("name"),
 			[]string{"Path_3/{name}", "path-2/{name}", "pathOne/{name}"}},


### PR DESCRIPTION
Improve OpenAPI endpoint `/sys/internal/specs/openapi` to generate proper specs for path patterns that use an alternation as the root.
Example:
```
(creds|sts)/(?P<name>\w(([\w-.@]+)?\w)?)
```
should generate two paths in OpenAPI
```
creds/{name}
sts/{name}
```