### PR TITLE
fix(backport-docs): always run 2nd step

### DIFF
--- a/.github/workflows/backport-docs.yml
+++ b/.github/workflows/backport-docs.yml
@@ -21,6 +21,7 @@ jobs:
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes labeled website to latest release branch
+        if: always()
         run: |
           resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/releases?per_page=100")
           ret="$?"
@@ -37,7 +38,7 @@ jobs:
           target="${latest_version#v}"
           # replace patch version with "x"
           target="${target%.*}.x"
-          
+
           export BACKPORT_TARGET_TEMPLATE="release/$target"
           backport-assistant backport
         env:


### PR DESCRIPTION
# Description

On merge of PR's with the `backport/website`, 2 workflow steps should run.

This updates the workflow so that if the 1st (backport+automerge to `stable-website`) fails, the 2nd (backport PR to `release/<latest>`) still runs

### Notes

- an original PR https://github.com/hashicorp/vault/pull/13415 w/ `backport/website`
  - workflow with `405` https://github.com/hashicorp/vault/actions/runs/1604682279
  - Spawned backport PR https://github.com/hashicorp/vault/pull/13484