### PR TITLE
Fix some go vet issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docker-dev: prep
 docker-dev-ui: prep
 	docker build --build-arg VERSION=$(GO_VERSION_MIN) --build-arg BUILD_TAGS="$(BUILD_TAGS)" -f scripts/docker/Dockerfile.ui -t vault:dev-ui .
 
-# test runs the unit tests and vets the code
+# test runs the unit tests
 test: prep
 	@CGO_ENABLED=$(CGO_ENABLED) \
 	VAULT_ADDR= \
@@ -93,12 +93,11 @@ cover:
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
 vet:
-	@$(GO_CMD) list -f '{{.Dir}}' ./... | grep -v /vendor/ \
-		| grep -v '.*github.com/hashicorp/vault$$' \
-		| xargs $(GO_CMD) vet ; if [ $$? -eq 1 ]; then \
+	@$(GO_CMD) vet ./...; if [ $$? -ne 0 ]; then \
 			echo ""; \
 			echo "Vet found suspicious constructs. Please check the reported constructs"; \
 			echo "and fix them if necessary before submitting the code for reviewal."; \
+			exit 1; \
 		fi
 
 # lint runs vet plus a number of other checkers, it is more comprehensive, but louder

--- a/builtin/logical/database/rotation_test.go
+++ b/builtin/logical/database/rotation_test.go
@@ -914,7 +914,8 @@ func testBackend_StaticRole_Rotations(t *testing.T, createUser userCreator, opts
 }
 
 func testCreateDBUser(t testing.TB, connURL, db, username, password string) {
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cf()
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(connURL))
 	if err != nil {
 		t.Fatal(err)

--- a/command/agent/auth/auth_test.go
+++ b/command/agent/auth/auth_test.go
@@ -72,7 +72,7 @@ func TestAuthHandler(t *testing.T) {
 	client := cluster.Cores[0].Client
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
-
+	defer cancelFunc()
 	ah := NewAuthHandler(&AuthHandlerConfig{
 		Logger: logger.Named("auth.handler"),
 		Client: client,

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -326,7 +326,8 @@ func TestServerRun(t *testing.T) {
 				templatesToRender = append(templatesToRender, templateTest.template)
 			}
 
-			ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+			ctx, cf := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cf()
 			sc := ServerConfig{
 				Logger: logging.NewVaultLogger(hclog.Trace),
 				AgentConfig: &config.Config{

--- a/helper/storagepacker/storagepacker_test.go
+++ b/helper/storagepacker/storagepacker_test.go
@@ -175,7 +175,7 @@ func TestStoragePacker_SerializeDeserializeComplexItem(t *testing.T) {
 	}
 
 	if !proto.Equal(&itemDecoded, entity) {
-		t.Fatalf("bad: expected: %#v\nactual: %#v\n", entity, itemDecoded)
+		t.Fatalf("bad: expected: %#v\nactual: %#v\n", entity, &itemDecoded)
 	}
 }
 

--- a/physical/postgresql/postgresql_test.go
+++ b/physical/postgresql/postgresql_test.go
@@ -180,13 +180,6 @@ const maxTries = 3
 func testPostgresSQLLockTTL(t *testing.T, ha physical.HABackend) {
 	t.Log("Skipping testPostgresSQLLockTTL portion of test.")
 	return
-
-	for tries := 1; tries <= maxTries; tries++ {
-		// Try this several times.  If the test environment is too slow the lock can naturally lapse
-		if attemptLockTTLTest(t, ha, tries) {
-			break
-		}
-	}
 }
 
 func attemptLockTTLTest(t *testing.T, ha physical.HABackend, tries int) bool {

--- a/plugins/database/mongodb/mongodb_test.go
+++ b/plugins/database/mongodb/mongodb_test.go
@@ -406,7 +406,8 @@ func assertDeepEqual(t *testing.T, a, b *options.ClientOptions) {
 func createDBUser(t testing.TB, connURL, db, username, password string) {
 	t.Helper()
 
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cf()
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(connURL))
 	if err != nil {
 		t.Fatal(err)
@@ -430,7 +431,8 @@ func assertCredsExist(t testing.TB, username, password, connURL string) {
 
 	connURL = strings.Replace(connURL, "mongodb://", fmt.Sprintf("mongodb://%s:%s@", username, password), 1)
 
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cf()
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(connURL))
 	if err != nil {
 		t.Fatalf("Failed to connect to mongo: %s", err)
@@ -447,7 +449,8 @@ func assertCredsDoNotExist(t testing.TB, username, password, connURL string) {
 
 	connURL = strings.Replace(connURL, "mongodb://", fmt.Sprintf("mongodb://%s:%s@", username, password), 1)
 
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cf()
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(connURL))
 	if err != nil {
 		return // Creds don't exist as expected

--- a/vault/expiration.go
+++ b/vault/expiration.go
@@ -911,7 +911,8 @@ func (m *ExpirationManager) attemptIrrevocableLeasesRevoke() {
 			}
 
 			ctxWithNS := namespace.ContextWithNamespace(m.core.activeContext, leaseNS)
-			ctxWithNSAndTimeout, _ := context.WithTimeout(ctxWithNS, time.Minute)
+			ctxWithNSAndTimeout, cf := context.WithTimeout(ctxWithNS, time.Minute)
+			defer cf()
 			if err := m.revokeCommon(ctxWithNSAndTimeout, leaseID, false, false); err != nil {
 				// on failure, force some delay to mitigate resource spike while
 				// this is running. if revocations succeed, we are okay with

--- a/vault/logical_system_raft.go
+++ b/vault/logical_system_raft.go
@@ -589,7 +589,7 @@ func (b *SystemBackend) handleStorageRaftSnapshotWrite(force bool) framework.Ope
 			}()
 
 			ctx, ctxCancel := context.WithCancel(namespace.RootContext(nil))
-
+			defer ctxCancel()
 			// We are calling the callback function synchronously here while we
 			// have the lock. So set it to nil and restore the callback when we
 			// finish.


### PR DESCRIPTION
There are more issues involving trivial composites and the
non trivial copylocks. The copylocks is interesting as inner mutexes
are sometime passed as value. One of fixing those is to use ref on the
to pass the enclosing struct around but that might need to subtle bugs like
nil pointer exception as the zero vault for these types would need to be
handled gracefully.

Run 'make vet' for  the results.

The vet command should be added to the CI when all issues are resolved
go vet -copylocks=false -composites=false ./... passes after this change