### PR TITLE
auth/oidc: update plugin to v0.11.4

### DIFF
--- a/changelog/13492.txt
+++ b/changelog/13492.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/oidc: Fixes OIDC auth from the Vault UI when using the implicit flow and `form_post` response mode.
+```

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-centrify v0.10.0
 	github.com/hashicorp/vault-plugin-auth-cf v0.10.0
 	github.com/hashicorp/vault-plugin-auth-gcp v0.11.3
-	github.com/hashicorp/vault-plugin-auth-jwt v0.11.3
+	github.com/hashicorp/vault-plugin-auth-jwt v0.11.4
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.3
 	github.com/hashicorp/vault-plugin-auth-oci v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -938,8 +938,8 @@ github.com/hashicorp/vault-plugin-auth-cf v0.10.0 h1:c9jepaNQXfPNl7ryufVP9RBKb5S
 github.com/hashicorp/vault-plugin-auth-cf v0.10.0/go.mod h1:4HM4amMEcCyoLZNNjyz5AYILIlhMLTErxrinM3Vopy4=
 github.com/hashicorp/vault-plugin-auth-gcp v0.11.3 h1:kdfbpf4bLubMqeQZIAGVYAO7scqun6GYMqU4sGEadd0=
 github.com/hashicorp/vault-plugin-auth-gcp v0.11.3/go.mod h1:HJc8ih7gLNpBJYTwFlXJA3H48LKsP8mlVKYtPWfRkHs=
-github.com/hashicorp/vault-plugin-auth-jwt v0.11.3 h1:uo7Gz81YqiYjg1ne4ZvT5csV/L4UT/9jlNVdCdb1jEs=
-github.com/hashicorp/vault-plugin-auth-jwt v0.11.3/go.mod h1:jzjDdssus8sw8G6NOP7kNFMEeIvrjXvPHUR3pEn5+r0=
+github.com/hashicorp/vault-plugin-auth-jwt v0.11.4 h1:rL/hvd7uGB8CGpw1FKxxUD/dBJQZfzRTNaUWMnEssjU=
+github.com/hashicorp/vault-plugin-auth-jwt v0.11.4/go.mod h1:jzjDdssus8sw8G6NOP7kNFMEeIvrjXvPHUR3pEn5+r0=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0 h1:oORxeqOraVVLQrb+z3fj5JayPmH/JBxJWGywZ8ZRJt0=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0/go.mod h1:eqjae8tMBpAWgJNk1NjV/vtJYXQRZnYudUkBFowz3bY=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.3 h1:VTl62rRNhcALzsLw8romBZfTRpVna2IeLTN0kAQyXvY=


### PR DESCRIPTION
This PR updates the OIDC auth plugin to [v0.11.4](https://github.com/hashicorp/vault-plugin-auth-jwt/releases/tag/v0.11.4) to bring in a fix from https://github.com/hashicorp/vault-plugin-auth-jwt/pull/192.

This commit will be backported into the release/1.9.x branch.

Steps:
1. `go get github.com/hashicorp/vault-plugin-auth-jwt@v0.11.4`
2. `go mod tidy`