### PR TITLE
auth/oidc: update plugin to v0.9.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-centrify v0.8.0
 	github.com/hashicorp/vault-plugin-auth-cf v0.8.0
 	github.com/hashicorp/vault-plugin-auth-gcp v0.9.1
-	github.com/hashicorp/vault-plugin-auth-jwt v0.9.5
+	github.com/hashicorp/vault-plugin-auth-jwt v0.9.6
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.9.0
 	github.com/hashicorp/vault-plugin-auth-oci v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -473,7 +473,6 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.2 h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -685,8 +684,6 @@ github.com/hashicorp/vault-plugin-auth-cf v0.8.0/go.mod h1:exPUMj8yNohKM7yRiHa7O
 github.com/hashicorp/vault-plugin-auth-gcp v0.5.1/go.mod h1:eLj92eX8MPI4vY1jaazVLF2sVbSAJ3LRHLRhF/pUmlI=
 github.com/hashicorp/vault-plugin-auth-gcp v0.9.1 h1:DNwSe1Sk53olEaB7vSipyBNRB5iQuy9cib/rWKogOng=
 github.com/hashicorp/vault-plugin-auth-gcp v0.9.1/go.mod h1:Z+mj9fAqzXfDNxLmMoSS8NheVK7ugLvD8sTHO1GXfCA=
-github.com/hashicorp/vault-plugin-auth-jwt v0.9.5 h1:QSLS0FD7qgUIE//lPErYlw49maV2Zm+7Pyt3Wa61MB8=
-github.com/hashicorp/vault-plugin-auth-jwt v0.9.5/go.mod h1:3KxfehLIM7zH19+O8jHJ/QJsLGRzSKRqjsesOJmBuoI=
 github.com/hashicorp/vault-plugin-auth-jwt v0.9.6 h1:rn4YWCBaQcANoOJ3fzeR42MgIdaKZyPT+8uqpirCS+4=
 github.com/hashicorp/vault-plugin-auth-jwt v0.9.6/go.mod h1:3KxfehLIM7zH19+O8jHJ/QJsLGRzSKRqjsesOJmBuoI=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0 h1:QxW0gRevydrNfRvo1qI6p0jQkhedLUgiWqpCN36RXoQ=

--- a/go.sum
+++ b/go.sum
@@ -687,6 +687,8 @@ github.com/hashicorp/vault-plugin-auth-gcp v0.9.1 h1:DNwSe1Sk53olEaB7vSipyBNRB5i
 github.com/hashicorp/vault-plugin-auth-gcp v0.9.1/go.mod h1:Z+mj9fAqzXfDNxLmMoSS8NheVK7ugLvD8sTHO1GXfCA=
 github.com/hashicorp/vault-plugin-auth-jwt v0.9.5 h1:QSLS0FD7qgUIE//lPErYlw49maV2Zm+7Pyt3Wa61MB8=
 github.com/hashicorp/vault-plugin-auth-jwt v0.9.5/go.mod h1:3KxfehLIM7zH19+O8jHJ/QJsLGRzSKRqjsesOJmBuoI=
+github.com/hashicorp/vault-plugin-auth-jwt v0.9.6 h1:rn4YWCBaQcANoOJ3fzeR42MgIdaKZyPT+8uqpirCS+4=
+github.com/hashicorp/vault-plugin-auth-jwt v0.9.6/go.mod h1:3KxfehLIM7zH19+O8jHJ/QJsLGRzSKRqjsesOJmBuoI=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0 h1:QxW0gRevydrNfRvo1qI6p0jQkhedLUgiWqpCN36RXoQ=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0/go.mod h1:h+7pLm4Z2EeKHOGPefX0bGzdUQCMBUlvM/BpSMNgTFw=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.9.0 h1:X/eXFuJqVW8YN73ohTaI5YyCwcjd6C3mpnMv/elkNrw=

--- a/vendor/github.com/hashicorp/vault-plugin-auth-jwt/cli_responses.go
+++ b/vendor/github.com/hashicorp/vault-plugin-auth-jwt/cli_responses.go
@@ -449,7 +449,7 @@ func formpostHTML(path, code, state string) string {
       </div>
     </div>
 	<script>
-		window.opener.postMessage({ path: "%s", code: "%s", state: "%s"}, window.origin);
+		window.opener.postMessage({ source: 'oidc-callback', path: "%s", code: "%s", state: "%s"}, window.origin);
 	</script>
   </body>
 </html>

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -645,7 +645,7 @@ github.com/hashicorp/vault-plugin-auth-cf/util
 ## explicit
 github.com/hashicorp/vault-plugin-auth-gcp/plugin
 github.com/hashicorp/vault-plugin-auth-gcp/plugin/cache
-# github.com/hashicorp/vault-plugin-auth-jwt v0.9.5
+# github.com/hashicorp/vault-plugin-auth-jwt v0.9.6
 ## explicit
 github.com/hashicorp/vault-plugin-auth-jwt
 # github.com/hashicorp/vault-plugin-auth-kerberos v0.3.0


### PR DESCRIPTION
This PR updates the OIDC auth plugin to [v0.9.6](https://github.com/hashicorp/vault-plugin-auth-jwt/releases/tag/v0.9.6) to bring in a fix from https://github.com/hashicorp/vault-plugin-auth-jwt/pull/192.

Steps:
1. `go get github.com/hashicorp/vault-plugin-auth-jwt@v0.9.6`
2. `go mod tidy`