### PR TITLE
Fiddling with changelog formatting

### DIFF
--- a/changelog/13024.txt
+++ b/changelog/13024.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-**Report in-flight requests**:Adding a trace capability to show in-flight requests, and a new gauge metric to show the total number of in-flight requests
+**Report in-flight requests**: Adding a trace capability to show in-flight requests, and a new gauge metric to show the total number of in-flight requests
 ```

--- a/changelog/13367.txt
+++ b/changelog/13367.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-secrets/transit: Add support for SHA-3 in the Transit backend.
+**Transit SHA-3 Support**: Add support for SHA-3 in the Transit backend.
 ```


### PR DESCRIPTION
@schultz-is - could you give this a once-over please? The "feature" tag in the changelog has a slightly different format than other changelog entries (check the "Changelog Process" page on the wiki for details). This formatting is required to get the CL to format the way it's currently showing in the 1.10 preview. We highlight new features to give them extra visual pop.