### PR TITLE
Ensure coefficients are non zero and unique for makePolynomial()

### DIFF
--- a/shamir/shamir.go
+++ b/shamir/shamir.go
@@ -3,6 +3,7 @@ package shamir
 import (
 	"crypto/rand"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	mathrand "math/rand"
 	"time"
@@ -15,6 +16,12 @@ const (
 	ShareOverhead = 1
 )
 
+// ErrZeroShare is returned when rand.Read returns 0
+var ErrZeroShare = errors.New("coefficients are zero")
+
+// ErrNonUniqueShare is returned when there are duplicate coefficients
+var ErrNonUniqueShare = errors.New("coefficients are not unique")
+
 // polynomial represents a polynomial of arbitrary degree
 type polynomial struct {
 	coefficients []uint8
@@ -23,6 +30,9 @@ type polynomial struct {
 // makePolynomial constructs a random polynomial of the given
 // degree but with the provided intercept value.
 func makePolynomial(intercept, degree uint8) (polynomial, error) {
+	// Choosing the degree and not degree+1 since we need to enforce uniqueness only to the coefficients and not
+	// the intercept
+	coefficientSet := make(map[byte]bool, degree)
 	// Create a wrapper
 	p := polynomial{
 		coefficients: make([]byte, degree+1),
@@ -34,6 +44,16 @@ func makePolynomial(intercept, degree uint8) (polynomial, error) {
 	// Assign random co-efficients to the polynomial
 	if _, err := rand.Read(p.coefficients[1:]); err != nil {
 		return p, err
+	}
+	// Safety check to ensure coefficients are non zero and unique
+	for i := 1; i < len(p.coefficients); i++ {
+		if p.coefficients[i] == 0 {
+			return p, ErrZeroShare
+		}
+		if ok := coefficientSet[p.coefficients[i]]; ok {
+			return p, ErrNonUniqueShare
+		}
+		coefficientSet[p.coefficients[i]] = true
 	}
 
 	return p, nil
@@ -162,7 +182,7 @@ func Split(secret []byte, parts, threshold int) ([][]byte, error) {
 	for idx, val := range secret {
 		p, err := makePolynomial(val, uint8(threshold-1))
 		if err != nil {
-			return nil, fmt.Errorf("failed to generate polynomial: %w", err)
+			return nil, err
 		}
 
 		// Generate a `parts` number of (x,y) pairs


### PR DESCRIPTION
This mitigates secret leak to the i-th share holder and prevents evaluating (0, S)
Having unique coefficients will also ensure that we don't run into calculating lagrangian
interpolation for the modular inverse of zero i.e Xi/(Xi - Xj) as it doesn't exist.

Issue: https://github.com/hashicorp/vault/issues/13498#issue-1086336740

Ran the tests in a loop for 100 times.
```
$ time go test -timeout 1h -count 100  github.com/hashicorp/vault/shamir
ok  	github.com/hashicorp/vault/shamir	640.335s

real	10m40.641s
user	0m0.422s
sys	0m0.463s
```