### PR TITLE
Backport 1.9: Attempt to address a data race issue within identity store - take 2

### DIFF
--- a/changelog/13476.txt
+++ b/changelog/13476.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/identity: Address a data race condition between local updates to aliases and invalidations
+```

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -750,7 +750,7 @@ func (i *IdentityStore) CreateOrFetchEntity(ctx context.Context, alias *logical.
 	}
 
 	// Check if an entity already exists for the given alias
-	entity, err = i.entityByAliasFactors(alias.MountAccessor, alias.Name, false)
+	entity, err = i.entityByAliasFactors(alias.MountAccessor, alias.Name, true)
 	if err != nil {
 		return nil, err
 	}
@@ -837,8 +837,7 @@ func (i *IdentityStore) CreateOrFetchEntity(ctx context.Context, alias *logical.
 	}
 
 	txn.Commit()
-
-	return entity, nil
+	return entity.Clone()
 }
 
 // changedAliasIndex searches an entity for changed alias metadata.

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -695,7 +695,7 @@ func (i *IdentityStore) processLocalAlias(ctx context.Context, lAlias *logical.A
 		return nil, fmt.Errorf("mount accessor %q is not local", lAlias.MountAccessor)
 	}
 
-	alias, err := i.MemDBAliasByFactors(lAlias.MountAccessor, lAlias.Name, true, false)
+	alias, err := i.MemDBAliasByFactors(lAlias.MountAccessor, lAlias.Name, false, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Backport #13476 to 1.9

* Attempt to address a data race issue within identity store
* Testcase TestIdentityStore_LocalAliasInvalidations identified a data race issue.
* This reverts the previous attempt to address the issue from #13093