### PR TITLE
fix: algolia-index CircleCI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
     - GOTESTSUM_VERSION: 0.5.2
   algolia-index:
     docker:
-    - image: node:12
+    - image: node:14
     steps:
     - checkout
     - run:
@@ -159,6 +159,7 @@ jobs:
             exit 0
           fi
           cd website/
+          npm install -g npm@latest
           npm install
           node scripts/index_search_content.js
         name: Push content to Algolia Index

--- a/.circleci/config/jobs/algolia-index.yml
+++ b/.circleci/config/jobs/algolia-index.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: node:12
+  - image: node:14
 steps:
   - checkout
   - run:
@@ -10,5 +10,6 @@ steps:
           exit 0
         fi
         cd website/
+        npm install -g npm@latest
         npm install
         node scripts/index_search_content.js


### PR DESCRIPTION
This PR fixes the `algolia-index` test by installing the latest `npm` at test time.