### PR TITLE
fix: backport squashes into stable-website

### DIFF
--- a/.github/workflows/backport-docs.yml
+++ b/.github/workflows/backport-docs.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Backport changes to stable-website
         run: |
-          backport-assistant backport -automerge
+          backport-assistant backport -automerge -merge-method=squash
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"


### PR DESCRIPTION
# Description

This fixes the `backport/website` label behavior to **squash** Backport PR's into `stable-website`

Note: This leverages recent backport assistant changes (no version-change)
  - https://github.com/hashicorp/backport-assistant/pull/30