### PR TITLE
Updates codeowners for OIDC coordination with UI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,5 +28,8 @@
 /website/content/                         @taoism4504
 /website/content/docs/plugin-portal.mdx   @taoism4504  @acahn
 
+# UI code related to Vault's JWT/OIDC auth method and OIDC provider.
+# Changes to these files often require coordination with backend code, 
+# so stewards of the backend code are added below for notification. 
 /ui/app/components/auth-jwt.js         @austingebauer
 /ui/app/routes/vault/cluster/oidc-*.js @austingebauer

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,3 +27,6 @@
 
 /website/content/                         @taoism4504
 /website/content/docs/plugin-portal.mdx   @taoism4504  @acahn
+
+/ui/app/components/auth-jwt.js         @austingebauer
+/ui/app/routes/vault/cluster/oidc-*.js @austingebauer


### PR DESCRIPTION
This PR adds me as a codeowner for the OIDC-related bits of the Vault UI. The purpose is to become involved in code changes to this area so that coordination can happen in Vault's OIDC auth method and OIDC provider.