### PR TITLE
Fix documentation of "replication_performance_mode" in health API

### DIFF
--- a/website/content/api-docs/system/health.mdx
+++ b/website/content/api-docs/system/health.mdx
@@ -69,7 +69,7 @@ $ curl \
 
 This response is only returned for a `GET` request.
 
-Note: `replication_perf_mode` and `replication_dr_mode` reflect the state of
+Note: `replication_performance_mode` and `replication_dr_mode` reflect the state of
 the active node in the cluster; if you are querying it for a standby that has
 just come up, it can take a small time for the active node to inform the
 standby of its status.
@@ -80,10 +80,10 @@ standby of its status.
   "sealed": false,
   "standby": false,
   "performance_standby": false,
-  "replication_perf_mode": "disabled",
+  "replication_performance_mode": "disabled",
   "replication_dr_mode": "disabled",
   "server_time_utc": 1516639589,
-  "version": "0.9.1",
+  "version": "0.9.2",
   "cluster_name": "vault-cluster-3bd69ca2",
   "cluster_id": "00af5aa8-c87d-b5fc-e82e-97cd8dfaf731"
 }


### PR DESCRIPTION
The field `replication_perf_mode` was renamed in 0.9.2 (a109e2a11ea46c78f235b20632f9320d8813258b), but the docs have never been updated.

Update the documentation to present the correct name `replication_performance_mode` as used in the actual implementation:
https://github.com/hashicorp/vault/blob/a620c2dc8f82b91372521a149ce7e77b97587f9c/api/sys_health.go#L34
