### PR TITLE
docs: add vault-plugin-secrets-jenkins to plugin portal page

### DIFF
--- a/website/content/docs/plugin-portal.mdx
+++ b/website/content/docs/plugin-portal.mdx
@@ -136,6 +136,7 @@ Plugin authors who wish to have their plugins listed may file a submission via a
 - [GitHub](https://github.com/martinbaillie/vault-plugin-secrets-github)
 - [HSM PKI Plugin](https://github.com/mode51software/vaultplugin-hsmpki)
 - [OAuth 2.0/OIDC](https://github.com/puppetlabs/vault-plugin-secrets-oauthapp)
+- [Jenkins](https://github.com/circa10a/vault-plugin-secrets-jenkins)
 
 [github-issue]: https://github.com/hashicorp/vault/issues/new?assignees=&labels=ecosystem%2Fplugin&template=plugin-submission.md&title=%5BPlugin+Portal%5D+Plugin+Submission+-+%3CPLUGIN+NAME%3E
 [plugin-portal-mdx]: https://github.com/hashicorp/vault/blob/master/website/content/docs/plugin-portal.mdx


### PR DESCRIPTION
This PR adds a new entry to the community secrets plugins page for [vault-plugin-secrets-jenkins](https://github.com/circa10a/vault-plugin-secrets-jenkins)

Signed-off-by: circa10a <caleblemoine@gmail.com>