### PR TITLE
Update docs to reflect new plugin behavior.

### DIFF
--- a/website/content/docs/internals/plugins.mdx
+++ b/website/content/docs/internals/plugins.mdx
@@ -79,7 +79,7 @@ backend has HA enabled and supports automatic host address detection
 (e.g. Consul), Vault will automatically attempt to determine the `api_addr` as
 well.
 
-~> Note: Priot to Vault version 1.9.2, reading the original connection's TLS
+~> Note: Prior to Vault version 1.9.2, reading the original connection's TLS
 connection state is not supported in plugins.
 
 ## Plugin Registration

--- a/website/content/docs/internals/plugins.mdx
+++ b/website/content/docs/internals/plugins.mdx
@@ -79,8 +79,8 @@ backend has HA enabled and supports automatic host address detection
 (e.g. Consul), Vault will automatically attempt to determine the `api_addr` as
 well.
 
-~> Note: Reading the original connection's TLS connection state is not supported
-in plugins.
+~> Note: Priot to Vault version 1.9.2, reading the original connection's TLS
+connection state is not supported in plugins.
 
 ## Plugin Registration
 


### PR DESCRIPTION
Update docs to reflect that, as of v1.9.2, TLS connection state is now available to plugins.

See: https://github.com/hashicorp/vault/pull/12581