### PR TITLE
secrets/gcp: update plugin to v0.11.1

### DIFF
--- a/changelog/13548.txt
+++ b/changelog/13548.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/gcp: Fixes role bindings for BigQuery dataset resources.
+```

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.11.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2
 	github.com/hashicorp/vault-plugin-secrets-azure v0.11.2
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.11.0
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.11.1
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.5.7-0.20211123171606-16933c88368a
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -962,8 +962,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2 h1:BzLD62yc5dU++yH66a
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
 github.com/hashicorp/vault-plugin-secrets-azure v0.11.2 h1:sjAaSo2p84C1oq1LAA5El8vUlDsLamGUwMoO1mRZJIA=
 github.com/hashicorp/vault-plugin-secrets-azure v0.11.2/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.11.0 h1:3i2uXY/n4jJv71baXeS1q19KQXKI+7FtA38k82sd0eI=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.11.0/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.11.1 h1:v8XfuZVrgP4pIwaZe/GgrPCmRuSxC/Xx8/MGvJIU5xQ=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.11.1/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0 h1:0Vi5WEIpZctk/ZoRClodV9WCnM/lCzw9XekMhRZdo8k=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0/go.mod h1:6DPwGu8oGR1sZRpjwkcAnrQZWQuAJ/Ph+rQHfUo1Yf4=
 github.com/hashicorp/vault-plugin-secrets-kv v0.5.7-0.20211123171606-16933c88368a h1:GVA3sY+FRhQrMexWGMCsIfVVMgcdru36WMKvDtKed5I=


### PR DESCRIPTION
This PR updates the GCP secrets plugin to [v0.11.1](https://github.com/hashicorp/vault-plugin-secrets-gcp/releases/tag/v0.11.1) to bring in a fix from https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/130.

This commit will be backported into the release/1.9.x branch.

Steps:
1. `go get github.com/hashicorp/vault-plugin-secrets-gcp@v0.11.1`
2. `go mod tidy`