### PR TITLE
secrets/gcp: update plugin to v0.10.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-azure v0.10.0
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.10.2
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.10.3
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.9.0 h1:EhTRXoWCjM3suD1atK9
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.9.0/go.mod h1:SSkKpSTOMnX84PfgYiWHgwVg+YMhxHNjo+YCJGNBoZk=
 github.com/hashicorp/vault-plugin-secrets-azure v0.10.0 h1:pJTWKVHYqfnlB3xg3XnnF9BOpj2/J7LC/e0RgiwkwKI=
 github.com/hashicorp/vault-plugin-secrets-azure v0.10.0/go.mod h1:4jCVjTG809NCQ8mrSnbBtX17gX1Iush+558BVO6MJeo=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.10.2 h1:+DtlYJTsrFRInQpAo09KkYN64scrextjBiTSunpluo8=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.10.2/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.10.3 h1:Drmo6OT9hZ8/5UjTY0xm0hhnjDk4rGY/jG1TLBUlG9c=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.10.3/go.mod h1:psRQ/dm5XatoUKLDUeWrpP9icMJNtu/jmscUr37YGK4=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.9.0 h1:7a0iWuFA/YNinQ1xXogyZHStolxMVtLV+sy1LpEHaZs=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.9.0/go.mod h1:hhwps56f2ATeC4Smgghrc5JH9dXR31b4ehSf1HblP5Q=
 github.com/hashicorp/vault-plugin-secrets-kv v0.9.0 h1:nCw2IfWw2bWUGFZsNk8BvTEg9k7jDpRn48+VAqjdQ3s=


### PR DESCRIPTION
This PR updates the GCP secrets plugin to [v0.10.3](https://github.com/hashicorp/vault-plugin-secrets-gcp/releases/tag/v0.10.3) to bring in a fix from https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/130.

Steps:
1. `go get github.com/hashicorp/vault-plugin-secrets-gcp@v0.10.3`
2. `go mod tidy`