### PR TITLE
Add just the basic interfaces for managed keys to the OSS side.

### DIFF
--- a/vault/managed_key.go
+++ b/vault/managed_key.go
@@ -1,0 +1,11 @@
+package vault
+
+import "context"
+
+type ManagedKey interface {
+	Name() string
+}
+
+type ManagedKeySystemView interface {
+	GetManagedKey(context.Context, string) (ManagedKey, error)
+}


### PR DESCRIPTION
This will at least allow code to test whether the system view returned by
System() can be cast to ManagedKeySystemView, in which case you have access
to the managed key registry.