### PR TITLE
client count doc:  corrected name and added link

### DIFF
--- a/website/content/docs/concepts/client-count/index.mdx
+++ b/website/content/docs/concepts/client-count/index.mdx
@@ -111,7 +111,7 @@ The number of active clients using a Vault cluster is the total of:
 that is not associated with an entity
 
 Prior to Vault 1.6, this metric could only be measured from the audit log, using the
-`vault-advisor` tool. Starting with Vault 1.6, the number of clients per month, or for
+[`vault-auditor`](https://learn.hashicorp.com/tutorials/vault/usage-metrics#vault-auditor-tool) tool. Starting with Vault 1.6, the number of clients per month, or for
 a contiguous sequence of months, can be measured by Vault itself.
 
 As of Vault 1.9, the total client count should always be measured using Vault itself. The


### PR DESCRIPTION
`vault auditor` was incorrectly named `vault advisor`.  I also added a link to our Learn guide which has details on how to use it.