### PR TITLE
Updated Vault API documentation: added permissions table

### DIFF
--- a/website/content/api-docs/secret/azure.mdx
+++ b/website/content/api-docs/secret/azure.mdx
@@ -41,9 +41,34 @@ service principals. Environment variables will override any parameters set in th
   Active Directory API which has been [deprecated by Microsoft and will be removed in 2022](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-faq).
 
   If set to true, the user specified via the `client_id` and `client_secret` will need to have the following permissions
-  under the Microsoft Graph API: `Application.ReadWrite.All`, `Directory.ReadWrite.All`, and `Group.ReadWrite.All`.
+  under the **Microsoft Graph API**:
 
-  Aside from the permissions listed above, setting this to true should be transparent to users.
+| Permission Name               | Type        |
+| ----------------------------- | ----------- |
+| Application.Read.All          | Application |
+| Application.ReadWrite.All     | Application |
+| Application.ReadWrite.OwnedBy | Application |
+| Directory.Read.All            | Application |
+| Directory.ReadWrite.All       | Application |
+| Group.Read.All                | Application |
+| Group.ReadWrite.All           | Application |
+| GroupMember.Read.All          | Application |
+| GroupMember.ReadWrite.All     | Application |
+
+| Permission Name            | Type      |
+| -------------------------- | --------- |
+| Application.Read.All       | Delegated |
+| Application.ReadWrite.All  | Delegated |
+| Directory.AccessAsUser.All | Delegated |
+| Directory.Read.All         | Delegated |
+| Directory.ReadWrite.All    | Delegated |
+| Group.Read.All             | Delegated |
+| Group.ReadWrite.All        | Delegated |
+| GroupMember.Read.All       | Delegated |
+| GroupMember.ReadWrite.All  | Delegated |
+
+Aside from the permissions listed above, setting this to true should be transparent to users.
+
 - `root_password_ttl` `(string: 182d)` - Specifies how long the root password is valid for in Azure when
   rotate-root generates a new client secret. This can be either a number of seconds or a time formatted
   duration (ex: 24h, 48d).
@@ -172,11 +197,11 @@ This endpoint generates a new client secret for the root account defined in the 
 value generated will only be known by Vault.
 
 ~> Due to the eventual consistency of Microsoft Azure client secret APIs, the plugin
-   may briefly stop authenticating to Azure as the password propagates through their
-   datacenters.
+may briefly stop authenticating to Azure as the password propagates through their
+datacenters.
 
-| Method | Path                      |
-| :----- | :------------------------ |
+| Method | Path                 |
+| :----- | :------------------- |
 | `POST` | `/azure/rotate-root` |
 
 ### Parameters


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/563192436488770/1201614056663705), the permissions table was added to the **configure acces**s section of the **Azure Secrets Engine (API)** documentation.

:mag: [Deploy Preview](https://vault-git-configure-access-doc-update-hashicorp.vercel.app/api-docs/secret/azure#configure-access)