### PR TITLE
Backport: Use real version of auth modules in root go.mod (#13321)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,8 +114,8 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.3.0
 	github.com/hashicorp/vault-testing-stepwise v0.1.2
 	github.com/hashicorp/vault/api v1.3.0
-	github.com/hashicorp/vault/api/auth/approle v0.0.0-00010101000000-000000000000
-	github.com/hashicorp/vault/api/auth/userpass v0.0.0-00010101000000-000000000000
+	github.com/hashicorp/vault/api/auth/approle v0.1.0
+	github.com/hashicorp/vault/api/auth/userpass v0.1.0
 	github.com/hashicorp/vault/sdk v0.3.1-0.20220103172553-29ded54520a4
 	github.com/influxdata/influxdb v0.0.0-20190411212539-d24b7ba8c4c4
 	github.com/jcmturner/gokrb5/v8 v8.4.2


### PR DESCRIPTION
Original PR [here](https://github.com/hashicorp/vault/pull/13321).