### PR TITLE
docs: fix typo in azure auth debug log mode

### DIFF
--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -194,14 +194,14 @@ for your server at `path/to/plugins`:
 
 ## Azure Debug Logs
 
-The Azure auth plugin supports debug logging which includes additional information 
+The Azure auth plugin supports debug logging which includes additional information
 about requests and responses from the Azure API.
 
 To enable the Azure debug logs, set the following environment variable on the Vault
 server:
 
 ```shell
-AZURE_SDK_GO_LOGGING=debug
+AZURE_GO_SDK_LOG_LEVEL=DEBUG
 ```
 
 ## API
@@ -295,7 +295,7 @@ using VaultSharp.V1.Commons;
 
 namespace Examples
 {
-    public class AzureAuthExample 
+    public class AzureAuthExample
     {
         public class InstanceMetadata
         {
@@ -307,7 +307,7 @@ namespace Examples
         const string MetadataEndPoint = "http://169.254.169.254/metadata/instance?api-version=2017-08-01";
         const string AccessTokenEndPoint = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/";
 
-        /// <summary> 
+        /// <summary>
         /// Fetches a key-value secret (kv-v2) after authenticating to Vault via Azure authentication.
         /// This example assumes you have a configured Azure AD Application.
         /// </summary>
@@ -323,7 +323,7 @@ namespace Examples
             if(String.IsNullOrEmpty(roleName))
             {
                 throw new System.ArgumentNullException("Vault Role Name");
-            }   
+            }
 
             string jwt = GetJWT();
             InstanceMetadata metadata = GetMetadata();
@@ -332,16 +332,16 @@ namespace Examples
             var vaultClientSettings = new VaultClientSettings(vaultAddr, authMethod);
 
             IVaultClient vaultClient = new VaultClient(vaultClientSettings);
-        
+
             // We can retrieve the secret from the VaultClient object
             Secret<SecretData> kv2Secret = null;
             kv2Secret = vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(path: "/creds").Result;
-            
+
             var password = kv2Secret.Data.Data["password"];
-            
+
             return password.ToString();
         }
-    
+
         /// <summary>
         /// Query Azure Resource Manage for metadata about the Azure instance
         /// </summary>
@@ -356,7 +356,7 @@ namespace Examples
             StreamReader streamResponse = new StreamReader(metadataResponse.GetResponseStream());
             string stringResponse = streamResponse.ReadToEnd();
             var resultsDict = JsonConvert.DeserializeObject<Dictionary<string, InstanceMetadata>>(stringResponse);
-            
+
             return resultsDict["compute"];
         }
 
@@ -372,7 +372,7 @@ namespace Examples
             HttpWebResponse response = (HttpWebResponse)request.GetResponse();
 
             // Pipe response Stream to a StreamReader and extract access token
-            StreamReader streamResponse = new StreamReader(response.GetResponseStream()); 
+            StreamReader streamResponse = new StreamReader(response.GetResponseStream());
             string stringResponse = streamResponse.ReadToEnd();
             var resultsDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(stringResponse);
 


### PR DESCRIPTION
I made a small error when documenting the debugger logging mode when using Azure auth. The correct environment variable is `AZURE_GO_SDK_LOG_LEVEL` (originates from go-autorest).