### PR TITLE
Backport 1.9.3: UI/fix kmip role form (#13585)

### DIFF
--- a/changelog/13585.txt
+++ b/changelog/13585.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes issue saving KMIP role correctly
+```

--- a/ui/app/adapters/kmip/role.js
+++ b/ui/app/adapters/kmip/role.js
@@ -38,7 +38,7 @@ export default BaseAdapter.extend({
 
   serialize(snapshot) {
     // the endpoint here won't allow sending `operation_all` and `operation_none` at the same time or with
-    // other values, so we manually check for them and send an abbreviated object
+    // other operation_ values, so we manually check for them and send an abbreviated object
     let json = snapshot.serialize();
     let keys = snapshot.record.nonOperationFields.map(decamelize);
     let nonOperationFields = getProperties(json, keys);

--- a/ui/app/models/kmip/role.js
+++ b/ui/app/models/kmip/role.js
@@ -17,9 +17,15 @@ export const COMPUTEDS = {
     return ['tlsClientKeyBits', 'tlsClientKeyType', 'tlsClientTtl'];
   }),
 
-  nonOperationFields: computed('newFields', 'operationFields', 'tlsFields', function() {
+  // For rendering on the create/edit pages
+  defaultFields: computed('newFields', 'operationFields', 'tlsFields', function() {
     let excludeFields = ['role'].concat(this.operationFields, this.tlsFields);
     return this.newFields.slice().removeObjects(excludeFields);
+  }),
+
+  // For adapter/serializer
+  nonOperationFields: computed('newFields', 'operationFields', function() {
+    return this.newFields.slice().removeObjects(this.operationFields);
   }),
 };
 
@@ -31,10 +37,10 @@ const ModelExport = Model.extend(COMPUTEDS, {
   getHelpUrl(path) {
     return `/v1/${path}/scope/example/role/example?help=1`;
   },
-  fieldGroups: computed('fields', 'nonOperationFields.length', 'tlsFields', function() {
+  fieldGroups: computed('fields', 'defaultFields.length', 'tlsFields', function() {
     const groups = [{ TLS: this.tlsFields }];
-    if (this.nonOperationFields.length) {
-      groups.unshift({ default: this.nonOperationFields });
+    if (this.defaultFields.length) {
+      groups.unshift({ default: this.defaultFields });
     }
     let ret = fieldToAttrs(this, groups);
     return ret;
@@ -61,7 +67,7 @@ const ModelExport = Model.extend(COMPUTEDS, {
     ];
     if (others.length) {
       groups.push({
-        '': others,
+        Other: others,
       });
     }
     return fieldToAttrs(this, groups);
@@ -69,8 +75,8 @@ const ModelExport = Model.extend(COMPUTEDS, {
   tlsFormFields: computed('tlsFields', function() {
     return expandAttributeMeta(this, this.tlsFields);
   }),
-  fields: computed('nonOperationFields', function() {
-    return expandAttributeMeta(this, this.nonOperationFields);
+  fields: computed('defaultFields', function() {
+    return expandAttributeMeta(this, this.defaultFields);
   }),
 });
 


### PR DESCRIPTION
Backport of #13585 minus changes to InfoTableRow, which were made possible by the post-1.9 ember upgrade and flight icon updates. As such, this backport only fixes the issue of the data not saving correctly, not the UI issue of the TLS info not showing on the role details page:

<img width="1438" alt="Screen Shot 2022-01-07 at 11 52 27 AM" src="https://user-images.githubusercontent.com/82459713/148585795-faa324ab-dc1a-43c0-aa0b-9604727a7385.png">
