### PR TITLE
auth/kubernetes: support for dynamically reloading short-lived tokens

### DIFF
--- a/changelog/13595.txt
+++ b/changelog/13595.txt
@@ -1,0 +1,2 @@
+```release-note:improvement
+auth/kubernetes: Added support for short-lived tokens for Kubernetes 1.21+ compatibility

--- a/changelog/13595.txt
+++ b/changelog/13595.txt
@@ -1,2 +1,3 @@
 ```release-note:improvement
-auth/kubernetes: Added support for short-lived tokens for Kubernetes 1.21+ compatibility
+auth/kubernetes: Added support for dynamically reloading short-lived tokens for better Kubernetes 1.21+ compatibility
+```

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-gcp v0.11.3
 	github.com/hashicorp/vault-plugin-auth-jwt v0.11.4
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0
-	github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.3
+	github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.1-0.20220107030939-d289258274b7
 	github.com/hashicorp/vault-plugin-auth-oci v0.9.0
 	github.com/hashicorp/vault-plugin-database-couchbase v0.5.1
 	github.com/hashicorp/vault-plugin-database-elasticsearch v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -941,6 +941,8 @@ github.com/hashicorp/vault-plugin-auth-jwt v0.11.4 h1:rL/hvd7uGB8CGpw1FKxxUD/dBJ
 github.com/hashicorp/vault-plugin-auth-jwt v0.11.4/go.mod h1:jzjDdssus8sw8G6NOP7kNFMEeIvrjXvPHUR3pEn5+r0=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0 h1:oORxeqOraVVLQrb+z3fj5JayPmH/JBxJWGywZ8ZRJt0=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0/go.mod h1:eqjae8tMBpAWgJNk1NjV/vtJYXQRZnYudUkBFowz3bY=
+github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.1-0.20220107030939-d289258274b7 h1:/VoIuHApeOStEIgLIF8J77OsLuCPLEhsfGnt3iYEivw=
+github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.1-0.20220107030939-d289258274b7/go.mod h1:HNcW9fnQIKw9g5qnxRQn6pHfGnSuVwBJAGb/v2/2dvw=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.3 h1:VTl62rRNhcALzsLw8romBZfTRpVna2IeLTN0kAQyXvY=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.3/go.mod h1:HNcW9fnQIKw9g5qnxRQn6pHfGnSuVwBJAGb/v2/2dvw=
 github.com/hashicorp/vault-plugin-auth-oci v0.9.0 h1:5wuHuPsW/MM5x0yvbr5ZwFLviNdF7q2t+z9saL7zjcI=

--- a/go.sum
+++ b/go.sum
@@ -943,8 +943,6 @@ github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0 h1:oORxeqOraVVLQrb+z3fj5J
 github.com/hashicorp/vault-plugin-auth-kerberos v0.5.0/go.mod h1:eqjae8tMBpAWgJNk1NjV/vtJYXQRZnYudUkBFowz3bY=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.1-0.20220107030939-d289258274b7 h1:/VoIuHApeOStEIgLIF8J77OsLuCPLEhsfGnt3iYEivw=
 github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.1-0.20220107030939-d289258274b7/go.mod h1:HNcW9fnQIKw9g5qnxRQn6pHfGnSuVwBJAGb/v2/2dvw=
-github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.3 h1:VTl62rRNhcALzsLw8romBZfTRpVna2IeLTN0kAQyXvY=
-github.com/hashicorp/vault-plugin-auth-kubernetes v0.11.3/go.mod h1:HNcW9fnQIKw9g5qnxRQn6pHfGnSuVwBJAGb/v2/2dvw=
 github.com/hashicorp/vault-plugin-auth-oci v0.9.0 h1:5wuHuPsW/MM5x0yvbr5ZwFLviNdF7q2t+z9saL7zjcI=
 github.com/hashicorp/vault-plugin-auth-oci v0.9.0/go.mod h1:Cn5cjR279Y+snw8LTaiLTko3KGrbigRbsQPOd2D5xDw=
 github.com/hashicorp/vault-plugin-database-couchbase v0.5.1 h1:WsXcOHHVwphwsrNGxpxRHcFzVgApN17ZNiE5RVD+q78=

--- a/website/content/api-docs/auth/kubernetes.mdx
+++ b/website/content/api-docs/auth/kubernetes.mdx
@@ -29,8 +29,10 @@ access the Kubernetes API.
 
 - `kubernetes_host` `(string: <required>)` - Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.
 - `kubernetes_ca_cert` `(string: "")` - PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API. NOTE: Every line must end with a newline: `\n`
+  If not set, the local CA cert will be used if running in a Kubernetes pod.
 - `token_reviewer_jwt` `(string: "")` - A service account JWT used to access the TokenReview
   API to validate other JWTs during login. If not set,
+  the local service account token is used if running in a Kubernetes pod, otherwise
   the JWT submitted in the login payload will be used to access the Kubernetes TokenReview API.
 - `pem_keys` `(array: [])` - Optional list of PEM-formatted public keys or certificates
   used to verify the signatures of Kubernetes service account

--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -125,9 +125,8 @@ Kubernetes auth:
 * The value of the JWT's `"iss"` claim depends on the cluster's configuration.
 
 The changes to token lifetime are important when configuring the
-[`token_reviewer_jwt`](/api-docs/auth/kubernetes#token_reviewer_jwt) option. You
-must avoid using a short-lived token because Vault stores that token in Vault
-storage and does not automatically refresh it. If a short-lived token is used,
+[`token_reviewer_jwt`](/api-docs/auth/kubernetes#token_reviewer_jwt) option.
+If a short-lived token is used,
 Kubernetes will revoke it as soon as the pod or service account are deleted, or
 if the expiry time passes, and Vault will no longer be able to use the
 `TokenReview` API. See [How to work with short-lived Kubernetes tokens][short-lived-tokens]
@@ -155,6 +154,7 @@ table summarizes the options, each of which is explained in more detail below.
 
 | Option                               | All tokens are short-lived | Can revoke tokens early | Other considerations |
 | ------------------------------------ | -------------------------- | ----------------------- | -------------------- |
+| Use local token as reviewer JWT      | Yes                        | Yes                     | Requires Vault VERSION_TODO |
 | Use client JWT as reviewer JWT       | Yes                        | Yes                     | Operational overhead |
 | Use long-lived token as reviewer JWT | No                         | Yes                     |                      |
 | Use JWT auth instead                 | Yes                        | No                      |                      |
@@ -167,6 +167,23 @@ short-lived tokens. If you would like to disable this, set
 [here](/docs/auth/jwt/oidc_providers#specifying-ttl-and-audience) for an example.
 
 [k8s-extended-tokens]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options
+
+#### Use local service account token as the reviewer JWT
+
+When running Vault in a Kubernetes pod the recommended option is to use local
+service account token. Vault will periodically re-read the file to support
+short-lived tokens. Local token and CA certificate are used by configuring the
+auth method without setting `token_reviewer_jwt` and `kubernetes_ca_cert`.
+
+```bash
+vault write auth/kubernetes/config \
+    kubernetes_host=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT
+```
+
+!> **Note:** Requires Vault VERSION_TODO. In earlier versions the service account
+token and CA certificate is read once and stored in Vault storage.
+When the service account token expires or is revoked, Vault will no longer be
+able to use the `TokenReview` API and client authentication will fail.
 
 #### Use the Vault client's JWT as the reviewer JWT
 

--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -154,7 +154,7 @@ table summarizes the options, each of which is explained in more detail below.
 
 | Option                               | All tokens are short-lived | Can revoke tokens early | Other considerations |
 | ------------------------------------ | -------------------------- | ----------------------- | -------------------- |
-| Use local token as reviewer JWT      | Yes                        | Yes                     | Requires Vault VERSION_TODO |
+| Use local token as reviewer JWT      | Yes                        | Yes                     | Requires Vault (1.10+) to be deployed on the Kubernetes cluster |
 | Use client JWT as reviewer JWT       | Yes                        | Yes                     | Operational overhead |
 | Use long-lived token as reviewer JWT | No                         | Yes                     |                      |
 | Use JWT auth instead                 | Yes                        | No                      |                      |
@@ -170,17 +170,19 @@ short-lived tokens. If you would like to disable this, set
 
 #### Use local service account token as the reviewer JWT
 
-When running Vault in a Kubernetes pod the recommended option is to use local
+When running Vault in a Kubernetes pod the recommended option is to use the pod's local
 service account token. Vault will periodically re-read the file to support
-short-lived tokens. Local token and CA certificate are used by configuring the
-auth method without setting `token_reviewer_jwt` and `kubernetes_ca_cert`.
+short-lived tokens. To use the local token and CA certificate, omit
+`token_reviewer_jwt` and `kubernetes_ca_cert` when configuring the auth method.
+Vault will attempt to load them from `token` and `ca.crt` respectively inside
+the default mount folder `/var/run/secrets/kubernetes.io/serviceaccount/`.
 
 ```bash
 vault write auth/kubernetes/config \
     kubernetes_host=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT
 ```
 
-!> **Note:** Requires Vault VERSION_TODO. In earlier versions the service account
+!> **Note:** Requires Vault 1.10+. In earlier versions the service account
 token and CA certificate is read once and stored in Vault storage.
 When the service account token expires or is revoked, Vault will no longer be
 able to use the `TokenReview` API and client authentication will fail.


### PR DESCRIPTION
This change is continuation to https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/122 where support was added for dynamically reloading Kubernetes short-lived tokens for better Kubernetes 1.21+ compatibility.  This change takes the feature into use in Vault.

* Uplift new version of Kubernetes auth plugin that does not store the  service account token persistently to Vault storage.
* Update the documentation to recommend local token again when running  Vault inside cluster.

Fixes #12855

Signed-off-by: Tero Saarni <tero.saarni@est.tech>