### PR TITLE
UI/ Fixes flash message spacing

### DIFF
--- a/ui/app/styles/components/global-flash.scss
+++ b/ui/app/styles/components/global-flash.scss
@@ -13,7 +13,7 @@
       overflow-wrap: break-word;
       word-wrap: break-word;
       word-break: break-word;
-      white-space: pre-wrap;
+      display: inline-flex;
     }
   }
 }


### PR DESCRIPTION
Somewhere during the upgrade and/or flight icon update the body of flash messages adopted an indent on the top line and extra padding around:

**Before fix**
<img width="333" alt="Screen Shot 2022-01-07 at 2 45 46 PM" src="https://user-images.githubusercontent.com/68122737/148616916-30bb7d51-da6f-483f-bf93-1626afeccb3b.png">
 
**With fix**
<img width="341" alt="Screen Shot 2022-01-07 at 2 34 03 PM" src="https://user-images.githubusercontent.com/68122737/148616931-d6f30a22-b3dc-477e-b9d1-dfb54381a644.png">

