### PR TITLE
UI/Fixes secrets list breadcrumb 

### DIFF
--- a/changelog/13604.txt
+++ b/changelog/13604.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes breadcrumb bug for secrets navigation
+```

--- a/ui/app/templates/components/secret-list-header.hbs
+++ b/ui/app/templates/components/secret-list-header.hbs
@@ -1,7 +1,7 @@
 {{#with (options-for-backend @model.engineType) as |options|}}
   <PageHeader as |p|>
     <p.top>
-      <KeyValueHeader @baseKey={{this.baseKey}} @path="vault.cluster.secrets.backend.list" @root={{@backendCrumb}}>
+      <KeyValueHeader @baseKey={{@baseKey}} @path="vault.cluster.secrets.backend.list" @root={{@backendCrumb}}>
         <li>
           <span class="sep">
             /


### PR DESCRIPTION
Breadcrumbs weren't updating as file tree was navigated. Fixes #13581
 
**Bug**
![secrets_breadcrumb](https://user-images.githubusercontent.com/68122737/148622326-f57cb722-659e-4f15-91fe-2ce36e6b5155.gif)

**With fix**

![breadcrumb_bug](https://user-images.githubusercontent.com/68122737/148622373-2c6519f5-f1da-453f-9b79-6980d9db327a.gif)


