### PR TITLE
Parallel retry join

### DIFF
--- a/changelog/13606.txt
+++ b/changelog/13606.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+storage/raft: When using retry_join stanzas, join against all of them in parallel.
+```

--- a/helper/testhelpers/testhelpers.go
+++ b/helper/testhelpers/testhelpers.go
@@ -655,7 +655,7 @@ func VerifyRaftPeers(t testing.T, client *api.Client, expected map[string]bool) 
 	// If the collection is non-empty, it means that the peer was not found in
 	// the response.
 	if len(expected) != 0 {
-		t.Fatalf("failed to read configuration successfully, expected peers no found in configuration list: %v", expected)
+		t.Fatalf("failed to read configuration successfully, expected peers not found in configuration list: %v", expected)
 	}
 }
 

--- a/vault/external_tests/raftha/raft_ha_test.go
+++ b/vault/external_tests/raftha/raft_ha_test.go
@@ -170,7 +170,7 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 	haStorage, haCleanup := teststorage.MakeReusableRaftHAStorage(t, logger, opts.NumCores, physBundle)
 	defer haCleanup()
 
-	updateCLuster := func(t *testing.T) {
+	updateCluster := func(t *testing.T) {
 		t.Log("simulating cluster update with raft as HABackend")
 
 		opts.SkipInit = true
@@ -240,5 +240,5 @@ func TestRaft_HA_ExistingCluster(t *testing.T) {
 		})
 	}
 
-	updateCLuster(t)
+	updateCluster(t)
 }

--- a/vault/raft.go
+++ b/vault/raft.go
@@ -932,7 +932,8 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 		if err != nil {
 			return fmt.Errorf("failed to check if core is initialized: %w", err)
 		}
-		if init {
+		if init && !isRaftHAOnly {
+			c.logger.Info("returning from raft join as the node is initialized")
 			return nil
 		}
 		challengeCh := make(chan *raftInformation)


### PR DESCRIPTION
When using retry_join stanzas to setup new raft nodes via config (instead of issuing explicit join requests), each of the "leaders" specified are tried in turn until one if found that works, with a 2s delay between each attempt.  It's common when using retry_join to use the same config that lists all nodes for every node's HCL, which means a new node could take quite a while to join if the actual leader in the cluster is listed last.

This PR changes how retry_join is handled so that we reach out to every node listed in parallel, and try to complete the join to the first node that replies without an error.  We maintain the current behaviour of a 2s delay between each attempt, only now it's a 2s delay between retrying all nodes, instead of a 2s delay between each node attempt.