### PR TITLE
builtin/credential/aws: fix dropped test error

### DIFF
--- a/builtin/credential/aws/path_config_rotate_root_test.go
+++ b/builtin/credential/aws/path_config_rotate_root_test.go
@@ -73,6 +73,9 @@ func TestPathConfigRotateRoot(t *testing.T) {
 		t.Fatalf("expected new access key buzz2 but received %s", resp.Data["access_key"])
 	}
 	newClientConf, err := b.nonLockedClientConfigEntry(ctx, req.Storage)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if resp.Data["access_key"].(string) != newClientConf.AccessKey {
 		t.Fatalf("expected new access key buzz2 to be saved to storage but receieved %s", clientConf.AccessKey)
 	}


### PR DESCRIPTION
This fixes a dropped error in `builtin/credential/aws`. 

Could someone add the `no-changelog` label?