### PR TITLE
Minimize time before initial single-node raft election 

### DIFF
--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -845,6 +845,10 @@ func (b *RaftBackend) SetupCluster(ctx context.Context, opts SetupOpts) error {
 		}
 	}
 
+	if opts.StartAsLeader {
+		raftConfig.HeartbeatTimeout = 5 * time.Millisecond // minimum allowed by raft lib
+		raftConfig.LeaderLeaseTimeout = raftConfig.HeartbeatTimeout
+	}
 	b.logger.Info("creating Raft", "config", fmt.Sprintf("%#v", raftConfig))
 	raftObj, err := raft.NewRaft(raftConfig, b.fsm.chunker, b.logStore, b.stableStore, b.snapStore, b.raftTransport)
 	b.fsm.SetNoopRestore(false)


### PR DESCRIPTION
This is just about speeding up tests involving raft.