### PR TITLE
Backport 1.9: If we get a 405 doing an HTTP PATCH, assume the server is pre-1.9 and…

### DIFF
--- a/changelog/13615.txt
+++ b/changelog/13615.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix using kv patch with older server versions that don't support HTTP PATCH.
+```

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -281,6 +281,13 @@ func (c *KVPatchCommand) mergePatch(client *api.Client, path string, newData map
 
 	secret, err := client.Logical().JSONMergePatch(context.Background(), path, data)
 	if err != nil {
+		// If it's a 405, that probably means the server is running a pre-1.9
+		// Vault version that doesn't support the HTTP PATCH method.
+		// Fall back to the old way of doing it if the user didn't specify a -method.
+		// If they did, and it was "patch", then just error.
+		if re, ok := err.(*api.ResponseError); ok && re.StatusCode == 405 && rwFallback {
+			return c.readThenWrite(client, path, newData)
+		}
 		// If it's a 403, that probably means they don't have the patch capability in their policy. Fall back to
 		// the old way of doing it if the user didn't specify a -method. If they did, and it was "patch", then just error.
 		if re, ok := err.(*api.ResponseError); ok && re.StatusCode == 403 && rwFallback {


### PR DESCRIPTION
… fall back to old readThenWrite approach (#13615)