### PR TITLE
Template Lint Overrides

### DIFF
--- a/ui/.template-lintrc.js
+++ b/ui/.template-lintrc.js
@@ -1,4 +1,11 @@
 'use strict';
+const recommended = require('ember-template-lint/lib/config/recommended').rules; // octane extends recommended - no additions as of 3.14
+const stylistic = require('ember-template-lint/lib/config/stylistic').rules;
+
+const testOverrides = { ...recommended, ...stylistic };
+for (const key in testOverrides) {
+  testOverrides[key] = false;
+}
 
 module.exports = {
   extends: ['octane', 'stylistic'],
@@ -14,4 +21,12 @@ module.exports = {
     'self-closing-void-elements': 'off',
   },
   ignore: ['lib/story-md', 'tests/**'],
+  // ember language server vscode extension does not currently respect the ignore field
+  // override all rules manually as workround to align with cli
+  overrides: [
+    {
+      files: ['**/*-test.js'],
+      rules: testOverrides,
+    },
+  ],
 };


### PR DESCRIPTION
The [Ember Language Server](https://github.com/lifeart/ember-language-server) VSCode extension does not respect the `ignore` setting in the `.template-lintrc.js` config which results in the editor reporting errors in test files. To keep things aligned with `ember-template-lint` cli functionality, this change manually overrides all rules used and turns them off in test files. 