### PR TITLE
secrets/keymgmt: Adds documentation for using Azure Private Link

### DIFF
--- a/website/content/docs/secrets/key-management/awskms.mdx
+++ b/website/content/docs/secrets/key-management/awskms.mdx
@@ -64,7 +64,7 @@ specification.
 
 ## Key Rotation
 
-Customer master keys (CMKs) with imported key material are not eligible for
+AWS KMS keys with imported key material are not eligible for
 [automatic key rotation](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
 within AWS KMS. As such, key rotations performed by the secrets engine use the
 [manual key rotation](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-manually)

--- a/website/content/docs/secrets/key-management/azurekeyvault.mdx
+++ b/website/content/docs/secrets/key-management/azurekeyvault.mdx
@@ -73,3 +73,35 @@ for each key type supported by GCP Cloud KMS.
 | `rsa-2048`     | [All purposes](/api-docs/secret/key-management#purpose) |
 | `rsa-3072`     | [All purposes](/api-docs/secret/key-management#purpose) |
 | `rsa-4096`     | [All purposes](/api-docs/secret/key-management#purpose) |
+
+## Azure Private Link
+
+The secrets engine can be configured to communicate with Azure Key Vault instances
+using [Azure Private Endpoints](https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-overview).
+Follow the guide at [Integrate Key Vault with Azure Private Link](https://docs.microsoft.com/en-us/azure/key-vault/general/private-link-service?tabs=portal)
+to set up a Private Endpoint for your target Key Vault instance in Azure. The Private Endpoint must
+be network reachable by Vault. This means Vault needs to be running in the same virtual network or
+a peered virtual network to properly resolve the Key Vault domain name to the Private Endpoint IP
+address.
+
+The Private Endpoint configuration relies on a correct [Azure Private DNS](https://docs.microsoft.com/en-us/azure/dns/private-dns-overview)
+integration. From the host that Vault is running on, follow the steps in
+[Validate that the private link connection works](https://docs.microsoft.com/en-us/azure/key-vault/general/private-link-service?tabs=portal#validate-that-the-private-link-connection-works)
+to ensure that the Key Vault domain name resolves to the Private Endpoint IP address you've configured.
+
+```
+$ nslookup <keyvault-name>.vault.azure.net
+
+Non-authoritative answer:
+Name:
+Address:  10.0.2.5 (private IP address)
+Aliases:  <keyvault-name>.vault.azure.net
+          <keyvault-name>.privatelink.vaultcore.azure.net
+```
+
+The secrets engine doesn't require special configuration to communicate with a Key Vault instance
+over an Azure Private Endpoint. For example, the given [KMS configuration](https://www.vaultproject.io/docs/secrets/key-management/azurekeyvault#configuration)
+will result in the secrets engine resolving a Key Vault domain name of `keyvault-name.vault.azure.net`
+to the Private Endpoint IP address. Note that it's possible to change the Key Vault DNS suffix using the
+[environment](https://www.vaultproject.io/api-docs/secret/key-management/azurekeyvault#environment)
+configuration parameter or `AZURE_ENVIRONMENT` environment variable.

--- a/website/content/docs/secrets/key-management/azurekeyvault.mdx
+++ b/website/content/docs/secrets/key-management/azurekeyvault.mdx
@@ -100,8 +100,8 @@ Aliases:  <keyvault-name>.vault.azure.net
 ```
 
 The secrets engine doesn't require special configuration to communicate with a Key Vault instance
-over an Azure Private Endpoint. For example, the given [KMS configuration](https://www.vaultproject.io/docs/secrets/key-management/azurekeyvault#configuration)
+over an Azure Private Endpoint. For example, the given [KMS configuration](/docs/secrets/key-management/azurekeyvault#configuration)
 will result in the secrets engine resolving a Key Vault domain name of `keyvault-name.vault.azure.net`
 to the Private Endpoint IP address. Note that it's possible to change the Key Vault DNS suffix using the
-[environment](https://www.vaultproject.io/api-docs/secret/key-management/azurekeyvault#environment)
+[environment](/api-docs/secret/key-management/azurekeyvault#environment)
 configuration parameter or `AZURE_ENVIRONMENT` environment variable.


### PR DESCRIPTION
This PR adds documentation for configuring the Key Management secrets engine to communicate with a Key Vault instance over [Azure Private Link](https://docs.microsoft.com/en-us/azure/key-vault/general/private-link-service?tabs=portal). I set up this environment to ensure that the communication works as expected.

This also includes a small change to update AWS KMS documentation to replace the term customer master key (CMK) with AWS KMS key (see note on this [terminology change](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms_keys)).