### PR TITLE
auth/azure: Documents config env vars and fixes resource used in examples

### DIFF
--- a/website/content/api-docs/auth/azure.mdx
+++ b/website/content/api-docs/auth/azure.mdx
@@ -29,17 +29,25 @@ virtual machine.
 ### Parameters
 
 - `tenant_id` `(string: <required>)` - The tenant id for the Azure Active Directory organization.
-- `resource` `(string: <required>)` - The configured URL for the application registered in Azure Active Directory.
+  This value can also be provided with the `AZURE_TENANT_ID` environment variable.
+- `resource` `(string: <required>)` - The resource URL for the application registered in Azure Active Directory.
+  The value is expected to match the audience (`aud` claim) of the [JWT](/api-docs/auth/azure#jwt)
+  provided to the login API. See the [resource](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http)
+  parameter for how the audience is set when requesting a JWT access token from the Azure Instance Metadata Service (IMDS) endpoint.
+  This value can also be provided with the `AZURE_AD_RESOURCE` environment variable.
 - `environment` `(string: 'AzurePublicCloud')` - The Azure cloud environment. Valid values: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud.
+  This value can also be provided with the `AZURE_ENVIRONMENT` environment variable.
 - `client_id` `(string: '')` - The client id for credentials to query the Azure APIs. Currently read permissions to query compute resources are required.
+  This value can also be provided with the `AZURE_CLIENT_ID` environment variable.
 - `client_secret` `(string: '')` - The client secret for credentials to query the Azure APIs.
+  This value can also be provided with the `AZURE_CLIENT_SECRET` environment variable.
 
 ### Sample Payload
 
 ```json
 {
   "tenant_id": "kd83...",
-  "resource": "https://vault.hashicorp.com/",
+  "resource": "https://management.azure.com/",
   "client_id": "12ud...",
   "client_secret": "DUJDS3..."
 }
@@ -77,7 +85,7 @@ $ curl \
 {
   "data":{
     "tenant_id": "kd83...",
-    "resource": "https://vault.hashicorp.com/",
+    "resource": "https://management.azure.com/",
     "client_id": "12ud...",
     "client_secret": "DUJDS3..."
   },
@@ -261,7 +269,9 @@ entity and then authorizes the entity for the given role.
 
 - `role` `(string: <required>)` - Name of the role against which the login is being
   attempted.
-- `jwt` `(string: <required>)` - Signed [JSON Web Token](https://tools.ietf.org/html/rfc7519) (JWT) from Azure MSI.
+- `jwt` `(string: <required>)` - Signed [JSON Web Token](https://tools.ietf.org/html/rfc7519) (JWT)
+  from Azure MSI. See [Azure documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token)
+  for details on how to acquire a JWT access token through instance metadata.
 - `subscription_id` `(string: <required>)` - The subscription ID for the machine that
   generated the MSI token. This information can be obtained through instance
   metadata.

--- a/website/content/docs/auth/azure.mdx
+++ b/website/content/docs/auth/azure.mdx
@@ -61,7 +61,7 @@ For example:
 
 ```shell-session
 $ vault write auth/azure/login role="dev-role" \
-     jwt="$(curl -s 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.hashicorp.com%2F' -H Metadata:true | jq -r '.access_token')" \
+     jwt="$(curl -s 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' -H Metadata:true | jq -r '.access_token')" \
      subscription_id=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2017-08-01" | jq -r '.compute | .subscriptionId')  \
      resource_group_name=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2017-08-01" | jq -r '.compute | .resourceGroupName') \
      vm_name=$(curl -s -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2017-08-01" | jq -r '.compute | .name')
@@ -112,7 +112,7 @@ tool.
    ```text
    $ vault write auth/azure/config \
        tenant_id=7cd1f227-ca67-4fc6-a1a4-9888ea7f388c \
-       resource=https://vault.hashicorp.com \
+       resource=https://management.azure.com/ \
        client_id=dd794de4-4c6c-40b3-a930-d84cd32e9699 \
        client_secret=IT3B2XfZvWnfB98s1cie8EMe7zWg483Xy8zY004=
    ```


### PR DESCRIPTION
This PR improves the Azure auth documentation by:

1. Documenting [environment variables](https://github.com/hashicorp/vault-plugin-auth-azure/blob/master/azure.go#L194-L244) that can be used to configure the auth method.
2. Fixing the `resource` parameter that's used in examples for [requesting a JWT access token](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http) from the instance metadata service. The current example doesn't work and had caused some confusion. Using the Azure resource manager endpoint aligns with [defaults](https://github.com/hashicorp/vault/blob/main/api/auth/azure/azure.go#L53) in our Azure auth client library and examples.
3. Providing additional explanation for the `jwt` and `resource` parameters