### PR TITLE
UI/Attribution component updates

### DIFF
--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -40,7 +40,7 @@ export default class Attribution extends Component {
   }
 
   get clientCountBreakdown() {
-    return this.isAllNamespaces ? 'Namespace path' : 'Auth method mount';
+    return this.isAllNamespaces ? 'Namespace' : 'Auth method';
   }
 
   get chartText() {
@@ -57,7 +57,7 @@ export default class Attribution extends Component {
     } else if (!this.isAllNamespaces) {
       return {
         description:
-          'This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where new clients and total clients are originating. Authentication methods are organized by path.',
+          'This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where clients are originating. Authentication methods are organized by path.',
         newCopy: `The new clients used by the auth method for this ${dateText}. This aids in understanding which auth methods create and use new clients 
         ${dateText === 'date range' ? ' over time.' : '.'}`,
         totalCopy: `The total clients used by the auth method for this ${dateText}. This number is useful for identifying overall usage volume. `,

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -1,45 +1,105 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
-// TODO: fill out below!!
 /**
  * @module Attribution
- * Attribution components are used to...
+ * Attribution components display the top 10 total client counts for namespaces or auth methods (mounts) during a billing period.
+ * If view is filtered for a single month, two graphs display and show a breakdown of new and total client counts by namespace or auth method, respectively 
  *
  * @example
  * ```js
- * <Attribution @requiredParam={requiredParam} @optionalParam={optionalParam} @param1={{param1}}>
- * Pass in export button
- * </Attribution>
+ * <Clients::Attribution
+ *    @newClientsData={{this.newClientData}}
+ *    @totalClientsData={{this.totalClientData}}
+ *    @chartLegend={{this.chartLegend}}
+ *    @isDateRange={{this.isDateRange}}
+ *    @isAllNamespaces={{this.isAllNamespaces}}
+    >
+      <button type="button"> Export attribution data </button>
+    </Clients::Attribution>
  * ```
- * @param {object} requiredParam - requiredParam is...
- * @param {string} [optionalParam] - optionalParam is...
- * @param {string} [param1=defaultValue] - param1 is...
+
+ * @param {array} newClientsData - (passed to child chart) must be an array of flattened objects
+ * @param {array} totalClientsData - (passed to child chart) must be an array of flattened objects
+ * @param {array} chartLegend - (passed to child) array of objects with key names 'key' and 'label' so data can be stacked
+ * @param {boolean} isDateRange - discerns if dataset from API is a date range or single month
+ * @param {boolean} isAllNamespaces - relays if filtered by all namespaces, or by single namespace
+ * @param {string} activityDateRange - for modal and csv download to display correct date range
  */
 
 export default class Attribution extends Component {
-  get dateRange() {
-    // some conditional that returns "date range" or "month" depending on what the params are
-    return 'date range';
+  @tracked showCSVDownloadModal = false;
+
+  // TODO should this be a getter? It will be updated from parent component's filter bar
+  get isDateRange() {
+    return this.args.isDateRange;
+  }
+
+  get isAllNamespaces() {
+    return this.args.isAllNamespaces;
+  }
+
+  get clientCountBreakdown() {
+    return this.isAllNamespaces ? 'Namespace path' : 'Auth method mount';
   }
 
   get chartText() {
-    // something that determines if data is by namespace or by auth method
-    // and returns text
-    // if byNamespace
-    return {
-      description:
-        'This data shows the top ten namespaces by client count and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, export this data.',
-      newCopy: `The new clients in the namespace for this ${this.dateRange}. 
-        This aids in understanding which namespaces create and use new clients 
-        ${this.dateRange === 'date range' ? ' over time.' : '.'}`,
-      totalCopy: `The total clients in the namespace for this ${this.dateRange}. This number is useful for identifying overall usage volume.`,
-    };
-    // if byAuthMethod
-    // return
-    // byAuthMethod = {
-    //   description: "This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where new clients and total clients are originating. Authentication methods are organized by path.",
-    //   newCopy: `The new clients used by the auth method for this {{@range}}. This aids in understanding which auth methods create and use new clients ${this.dateRange === "date range" ? " over time." : "."}`,
-    //   totalCopy: `The total clients used by the auth method for this ${this.dateRange}. This number is useful for identifying overall usage volume. `
-    // }
+    let dateText = this.isDateRange ? 'date range' : 'month';
+    if (this.isAllNamespaces) {
+      return {
+        description:
+          'This data shows the top ten namespaces by client count and can be used to understand where clients are originating. Namespaces are identified by path. To see all namespaces, export this data.',
+        newCopy: `The new clients in the namespace for this ${dateText}. 
+          This aids in understanding which namespaces create and use new clients 
+          ${dateText === 'date range' ? ' over time.' : '.'}`,
+        totalCopy: `The total clients in the namespace for this ${dateText}. This number is useful for identifying overall usage volume.`,
+      };
+    } else if (!this.isAllNamespaces) {
+      return {
+        description:
+          'This data shows the top ten authentication methods by client count within this namespace, and can be used to understand where new clients and total clients are originating. Authentication methods are organized by path.',
+        newCopy: `The new clients used by the auth method for this ${dateText}. This aids in understanding which auth methods create and use new clients 
+        ${dateText === 'date range' ? ' over time.' : '.'}`,
+        totalCopy: `The total clients used by the auth method for this ${dateText}. This number is useful for identifying overall usage volume. `,
+      };
+    } else {
+      return {
+        description: 'There is a problem gathering data',
+        newCopy: 'There is a problem gathering data',
+        totalCopy: 'There is a problem gathering data',
+      };
+    }
+  }
+
+  get getCsvData() {
+    let results = '',
+      data,
+      fields;
+    if (this.isDateRange) {
+      data = this.args.totalClientsData;
+      fields = [`${this.clientCountBreakdown}`, 'Active clients', 'Unique entities', 'Non-entity tokens'];
+    } else {
+      data = this.args.newClientsData;
+      // will need add a column for new clients
+      fields = [`${this.clientCountBreakdown}`, 'Active clients', 'Unique entities', 'Non-entity tokens'];
+    }
+
+    results = fields.join(',') + '\n';
+    data.forEach(function (item) {
+      // debugger
+      let path = item.label !== '' ? item.label : 'root',
+        total = item.total,
+        unique = item.distinct_entities,
+        non_entity = item.non_entity_tokens;
+
+      results += path + ',' + total + ',' + unique + ',' + non_entity + '\n';
+    });
+    return results;
+  }
+  // Return csv filename with start and end dates
+  get getCsvFileName() {
+    return this.args.activityDateRange
+      ? `clients-by-${this.clientCountBreakdown}-${this.args.activityDateRange}`
+      : `clients-by-${this.clientCountBreakdown}-${new Date()}`;
   }
 }

--- a/ui/app/components/clients/attribution.js
+++ b/ui/app/components/clients/attribution.js
@@ -30,7 +30,7 @@ import { tracked } from '@glimmer/tracking';
 export default class Attribution extends Component {
   @tracked showCSVDownloadModal = false;
 
-  // TODO should this be a getter? It will be updated from parent component's filter bar
+  // TODO CMB should this be a getter? It will be updated from parent component's filter bar
   get isDateRange() {
     return this.args.isDateRange;
   }
@@ -71,6 +71,7 @@ export default class Attribution extends Component {
     }
   }
 
+  // TODO CMB update with proper data format when we have
   get getCsvData() {
     let results = '',
       data,
@@ -80,7 +81,7 @@ export default class Attribution extends Component {
       fields = [`${this.clientCountBreakdown}`, 'Active clients', 'Unique entities', 'Non-entity tokens'];
     } else {
       data = this.args.newClientsData;
-      // will need add a column for new clients
+      // TODO CMB will need add a column for NEW clients
       fields = [`${this.clientCountBreakdown}`, 'Active clients', 'Unique entities', 'Non-entity tokens'];
     }
 
@@ -96,7 +97,7 @@ export default class Attribution extends Component {
     });
     return results;
   }
-  // Return csv filename with start and end dates
+  // TODO CMB - confirm with design file name structure
   get getCsvFileName() {
     return this.args.activityDateRange
       ? `clients-by-${this.clientCountBreakdown}-${this.args.activityDateRange}`

--- a/ui/app/components/clients/dashboard.js
+++ b/ui/app/components/clients/dashboard.js
@@ -24,10 +24,10 @@ export default class Dashboard extends Component {
   @tracked startYear = null;
   @tracked selectedNamespace = null;
 
-  // conditionals for filtering HBS file
-  // TODO update values depending on data returned from API
-  @tracked isDateRange = true; // false when viewing single month (true on init b/c defaults to billing period)
-  @tracked isAllNamespaces = true; // false when filtered down to auth methods (mounts)
+  // filtering conditionals for HBS file
+  // set initially based on response received from API & update based on filters
+  @tracked isDateRange;
+  @tracked isAllNamespaces; // false when filtered down to auth methods (mounts)
 
   constructor() {
     super(...arguments);

--- a/ui/app/components/clients/dashboard.js
+++ b/ui/app/components/clients/dashboard.js
@@ -24,6 +24,11 @@ export default class Dashboard extends Component {
   @tracked startYear = null;
   @tracked selectedNamespace = null;
 
+  // conditionals for filtering HBS file
+  // TODO update values depending on data returned from API
+  @tracked isDateRange = true; // false when viewing single month (true on init b/c defaults to billing period)
+  @tracked isAllNamespaces = true; // false when filtered down to auth methods (mounts)
+
   constructor() {
     super(...arguments);
     // ARG TODO will need to get startDate from license endpoint

--- a/ui/app/components/clients/horizontal-bar-chart.js
+++ b/ui/app/components/clients/horizontal-bar-chart.js
@@ -21,7 +21,7 @@ import { tracked } from '@glimmer/tracking';
  * @param {array} chartLegend - array of objects with key names 'key' and 'label' so data can be stacked
  */
 
-// TODO: delete original bar chart component
+// TODO CMB: delete original bar chart component
 
 // SIZING CONSTANTS
 const CHART_MARGIN = { top: 10, left: 95 }; // makes space for y-axis legend

--- a/ui/app/components/clients/line-chart.js
+++ b/ui/app/components/clients/line-chart.js
@@ -21,7 +21,7 @@ import { LIGHT_AND_DARK_BLUE, SVG_DIMENSIONS, formatNumbers } from '../../utils/
  */
 
 export default class LineChart extends Component {
-  // TODO make just one tracked variable tooltipText?
+  // TODO CMB make just one tracked variable tooltipText?
   @tracked tooltipTarget = '';
   @tracked tooltipMonth = '';
   @tracked tooltipTotal = '';

--- a/ui/app/components/clients/vertical-bar-chart.js
+++ b/ui/app/components/clients/vertical-bar-chart.js
@@ -40,7 +40,6 @@ export default class VerticalBarChart extends Component {
   @action
   registerListener(element, args) {
     let dataset = args[0];
-    // TODO pull out lines 44 - scales into helper? b/c same as line chart?
     let stackFunction = stack().keys(this.chartLegend.map((l) => l.key));
     let stackedData = stackFunction(dataset);
     let chartSvg = select(element);

--- a/ui/app/styles/components/modal.scss
+++ b/ui/app/styles/components/modal.scss
@@ -24,6 +24,10 @@
     margin: 0;
   }
 
+  .is-subtitle-gray {
+    color: $ui-gray-500;
+  }
+
   .copy-text {
     background-color: $grey-lightest;
     padding: $spacing-s;

--- a/ui/app/templates/components/clients/attribution.hbs
+++ b/ui/app/templates/components/clients/attribution.hbs
@@ -1,27 +1,52 @@
-<div class="chart-wrapper dual-chart-grid">
+<div class={{concat "chart-wrapper" (if @isDateRange " single-chart-grid") (unless @isDateRange " dual-chart-grid")}}>
   <div class="chart-header has-export">
     <div class="header-left">
-      <h2 class="chart-title">{{@title}}</h2>
+      <h2 class="chart-title">Attribution</h2>
       <p class="chart-description">{{this.chartText.description}}</p>
     </div>
     <div class="header-right">
       {{#if @totalClientsData}}
-        {{yield}}
+        <button type="button" class="button is-secondary" {{on "click" (fn (mut this.showCSVDownloadModal) true)}}>
+          Export attribution data
+        </button>
       {{/if}}
     </div>
   </div>
 
-  <div class="chart-container-left">
-    <h2 class="chart-title">New clients</h2>
-    <p class="chart-description">{{this.chartText.newCopy}}</p>
-    <Clients::HorizontalBarChart @dataset={{@newClientsData}} @chartLegend={{@chartLegend}} />
-  </div>
+  {{! show single chart if data is from a range, show two charts if from a single month}}
+  {{#if (eq @isDateRange true)}}
+    <div class="chart-container-wide">
+      <Clients::HorizontalBarChart @dataset={{@totalClientsData}} @chartLegend={{@chartLegend}} />
+    </div>
 
-  <div class="chart-container-right">
-    <h2 class="chart-title">Total clients</h2>
-    <p class="chart-description">{{this.chartText.totalCopy}}</p>
-    <Clients::HorizontalBarChart @dataset={{@totalClientsData}} @chartLegend={{@chartLegend}} />
-  </div>
+    <div class="chart-subTitle">
+      <p class="chart-subtext">{{this.chartText.totalCopy}}</p>
+    </div>
+
+    <div class="data-details-top">
+      <h3 class="data-details">Top namespace</h3>
+      <p class="data-details">ns/1</p>
+    </div>
+
+    <div class="data-details-bottom">
+      <h3 class="data-details">Clients in namespace</h3>
+      <p class="data-details">1,512</p>
+    </div>
+  {{else if (and @newClientsData (not @isDateRange))}}
+    <div class="chart-container-left">
+      <h2 class="chart-title">New clients</h2>
+      <p class="chart-description">{{this.chartText.newCopy}}</p>
+      <Clients::HorizontalBarChart @dataset={{@newClientsData}} @chartLegend={{@chartLegend}} />
+    </div>
+
+    <div class="chart-container-right">
+      <h2 class="chart-title">Total clients</h2>
+      <p class="chart-description">{{this.chartText.totalCopy}}</p>
+      <Clients::HorizontalBarChart @dataset={{@totalClientsData}} @chartLegend={{@chartLegend}} />
+    </div>
+  {{else}}
+    <EmptyState />
+  {{/if}}
 
   <div class="timestamp">
     Updated Nov 15 2021, 4:07:32 pm
@@ -32,3 +57,27 @@
     <span class="dark-dot"></span><span class="legend-label">{{capitalize @chartLegend.1.label}}</span>
   </div>
 </div>
+
+{{! MODAL FOR CSV DOWNLOAD BUTTON }}
+<Modal
+  @title="Export attribution data"
+  @glyph="info"
+  @isActive={{this.showCSVDownloadModal}}
+  @showCloseButton={{true}}
+  @onClose={{action (mut this.showCSVDownloadModal) false}}
+>
+  <section class="modal-card-body">
+    <p class="has-bottom-margin-s">
+      This export will include the namespace path, authentication method path, and the associated clients, unique entities,
+      and non-entity tokens for the below date range.
+    </p>
+    <p class="has-bottom-margin-s is-subtitle-gray">SELECTED DATE RANGE</p>
+    <p class="has-bottom-margin-s">{{@activityDateRange}}</p>
+  </section>
+  <footer class="modal-card-foot modal-card-foot-outlined">
+    <DownloadCsv @label="Export" @csvData={{this.getCsvData}} @fileName={{this.getCsvFileName}} />
+    <button type="button" class="button is-secondary" onclick={{action (mut this.showCSVDownloadModal) false}}>
+      Cancel
+    </button>
+  </footer>
+</Modal>

--- a/ui/app/templates/components/clients/attribution.hbs
+++ b/ui/app/templates/components/clients/attribution.hbs
@@ -61,7 +61,7 @@
 {{! MODAL FOR CSV DOWNLOAD BUTTON }}
 <Modal
   @title="Export attribution data"
-  @glyph="info"
+  @type="info"
   @isActive={{this.showCSVDownloadModal}}
   @showCloseButton={{true}}
   @onClose={{action (mut this.showCSVDownloadModal) false}}

--- a/ui/app/templates/components/clients/attribution.hbs
+++ b/ui/app/templates/components/clients/attribution.hbs
@@ -24,12 +24,12 @@
     </div>
 
     <div class="data-details-top">
-      <h3 class="data-details">Top namespace</h3>
+      <h3 class="data-details">Top {{lowercase this.clientCountBreakdown}}</h3>
       <p class="data-details">ns/1</p>
     </div>
 
     <div class="data-details-bottom">
-      <h3 class="data-details">Clients in namespace</h3>
+      <h3 class="data-details">Clients in {{lowercase this.clientCountBreakdown}}</h3>
       <p class="data-details">1,512</p>
     </div>
   {{else if (and @newClientsData (not @isDateRange))}}

--- a/ui/app/templates/components/clients/dashboard.hbs
+++ b/ui/app/templates/components/clients/dashboard.hbs
@@ -104,13 +104,14 @@
           />
 
           <Clients::Attribution
-            @title="Attribution"
             @newClientsData={{this.barChartDataset}}
             @totalClientsData={{this.barChartDataset}}
             @chartLegend={{this.chartLegend}}
-          >
-            <button type="button"> Export attribution data </button>
-          </Clients::Attribution>
+            @isDateRange={{this.isDateRange}}
+            @isAllNamespaces={{this.isAllNamespaces}}
+            {{! TODO this should be on the model?}}
+            @activityDateRange="January 2021 - December 2021"
+          />
 
           <Clients::MonthlyUsage
             @title="Vault usage"

--- a/ui/lib/core/addon/templates/components/download-csv.hbs
+++ b/ui/lib/core/addon/templates/components/download-csv.hbs
@@ -1,3 +1,3 @@
-<button type="button" class="link" {{on "click" this.downloadCsv}}>
+<button type="button" class="button is-primary" {{on "click" this.downloadCsv}}>
   {{or @label "Download"}}
 </button>

--- a/ui/mirage/handlers/activity.js
+++ b/ui/mirage/handlers/activity.js
@@ -1,0 +1,330 @@
+export default function (server) {
+  server.get('/sys/internal/counters/activity/monthly', function () {
+    return {
+      data: {
+        start_time: '2019-11-01T00:00:00Z',
+        end_time: '2020-10-31T23:59:59Z',
+        total: {
+          _comment1: 'total client counts',
+          clients: 300,
+          _comment2: 'following 2 fields are deprecated',
+          distinct_entities: 200,
+          non_entity_tokens: 100,
+        },
+        by_namespace: [
+          {
+            namespace_id: 'root',
+            namespace_path: '',
+            counts: {
+              distinct_entities: 110,
+              non_entity_tokens: 35,
+              clients: 145,
+            },
+            mounts: [
+              {
+                path: 'auth/aws/login',
+                counts: {
+                  clients: 44,
+                  entity_clients: 30,
+                  non_entity_clients: 14,
+                },
+              },
+              {
+                path: 'auth/approle/login',
+                counts: {
+                  clients: 51,
+                  entity_clients: 35,
+                  non_entity_clients: 16,
+                },
+              },
+            ],
+          },
+          {
+            namespace_id: 'DochC',
+            namespace_path: 'ns1',
+            counts: {
+              distinct_entities: 90,
+              non_entity_tokens: 65,
+              clients: 155,
+            },
+            mounts: [
+              {
+                path: 'auth/aws/login',
+                counts: {
+                  clients: 65,
+                  entity_clients: 50,
+                  non_entity_clients: 15,
+                },
+              },
+              {
+                path: 'auth/approle/login',
+                counts: {
+                  clients: 80,
+                  entity_clients: 60,
+                  non_entity_clients: 20,
+                },
+              },
+            ],
+          },
+        ],
+        months: [
+          {
+            month_year: 'January_2022',
+            counts: {
+              clients: 150,
+              entity_clients: 100,
+              non_entity_clients: 50,
+            },
+            namespaces: [
+              {
+                id: 'root',
+                path: '',
+                counts: {
+                  clients: 75,
+                  entity_clients: 50,
+                  non_entity_clients: 25,
+                },
+                mounts: [
+                  {
+                    path: 'auth/aws/login',
+                    counts: {
+                      clients: 37,
+                      entity_clients: 25,
+                      non_entity_clients: 12,
+                    },
+                  },
+                  {
+                    path: 'auth/approle/login',
+                    counts: {
+                      clients: 38,
+                      entity_clients: 25,
+                      non_entity_clients: 13,
+                    },
+                  },
+                ],
+              },
+              {
+                id: 'ns1',
+                path: '',
+                counts: {
+                  clients: 75,
+                  entity_clients: 50,
+                  non_entity_clients: 25,
+                },
+                mounts: [
+                  {
+                    path: 'auth/aws/login',
+                    counts: {
+                      clients: 30,
+                      entity_clients: 20,
+                      non_entity_clients: 10,
+                    },
+                  },
+                  {
+                    path: 'auth/approle/login',
+                    counts: {
+                      clients: 45,
+                      entity_clients: 30,
+                      non_entity_clients: 15,
+                    },
+                  },
+                ],
+              },
+            ],
+            new_clients: {
+              counts: {
+                clients: 40,
+                entity_clients: 30,
+                non_entity_clients: 10,
+              },
+              namespaces: [
+                {
+                  id: 'root',
+                  path: '',
+                  counts: {
+                    clients: 20,
+                    entity_clients: 15,
+                    non_entity_clients: 5,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/aws/login',
+                      counts: {
+                        clients: 7,
+                        entity_clients: 5,
+                        non_entity_clients: 2,
+                      },
+                    },
+                    {
+                      path: 'auth/aws/login',
+                      counts: {
+                        clients: 13,
+                        entity_clients: 10,
+                        non_entity_clients: 3,
+                      },
+                    },
+                  ],
+                },
+                {
+                  id: 'ns1',
+                  path: '',
+                  counts: {
+                    clients: 20,
+                    entity_clients: 15,
+                    non_entity_clients: 5,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/aws/login',
+                      counts: {
+                        clients: 11,
+                        entity_clients: 10,
+                        non_entity_clients: 1,
+                      },
+                    },
+                    {
+                      path: 'auth/aws/login',
+                      counts: {
+                        clients: 9,
+                        entity_clients: 5,
+                        non_entity_clients: 4,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            month_year: 'February_2022',
+            counts: {
+              _comment: 'total monthly clients',
+              clients: 150,
+              entity_clients: 100,
+              non_entity_clients: 50,
+            },
+            namespaces: [
+              {
+                id: 'root',
+                path: '',
+                counts: {
+                  clients: 70,
+                  entity_clients: 60,
+                  non_entity_clients: 10,
+                },
+                mounts: [
+                  {
+                    path: 'auth/aws/login',
+                    counts: {
+                      clients: 35,
+                      entity_clients: 30,
+                      non_entity_clients: 5,
+                    },
+                  },
+                  {
+                    path: 'auth/approle/login',
+                    counts: {
+                      clients: 35,
+                      entity_clients: 30,
+                      non_entity_clients: 5,
+                    },
+                  },
+                ],
+              },
+              {
+                id: 'ns1',
+                path: '',
+                counts: {
+                  clients: 80,
+                  entity_clients: 40,
+                  non_entity_clients: 40,
+                },
+                mounts: [
+                  {
+                    path: 'auth/aws/login',
+                    counts: {
+                      clients: 40,
+                      entity_clients: 20,
+                      non_entity_clients: 20,
+                    },
+                  },
+                  {
+                    path: 'auth/approle/login',
+                    counts: {
+                      clients: 40,
+                      entity_clients: 20,
+                      non_entity_clients: 20,
+                    },
+                  },
+                ],
+              },
+            ],
+            new_clients: {
+              counts: {
+                clients: 25,
+                entity_clients: 20,
+                non_entity_clients: 5,
+              },
+              namespaces: [
+                {
+                  id: 'root',
+                  path: '',
+                  counts: {
+                    clients: 13,
+                    entity_clients: 10,
+                    non_entity_clients: 3,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/aws/login',
+                      counts: {
+                        clients: 6,
+                        entity_clients: 5,
+                        non_entity_clients: 1,
+                      },
+                    },
+                    {
+                      path: 'auth/aws/login',
+                      counts: {
+                        clients: 7,
+                        entity_clients: 5,
+                        non_entity_clients: 2,
+                      },
+                    },
+                  ],
+                },
+                {
+                  id: 'ns1',
+                  path: '',
+                  counts: {
+                    clients: 12,
+                    entity_clients: 10,
+                    non_entity_clients: 2,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/aws/login',
+                      counts: {
+                        clients: 7,
+                        entity_clients: 5,
+                        non_entity_clients: 2,
+                      },
+                    },
+                    {
+                      path: 'auth/aws/login',
+                      counts: {
+                        clients: 5,
+                        entity_clients: 5,
+                        non_entity_clients: 0,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+  });
+}

--- a/ui/mirage/handlers/activity.js
+++ b/ui/mirage/handlers/activity.js
@@ -1,5 +1,6 @@
 export default function (server) {
-  server.get('/sys/internal/counters/activity/monthly', function () {
+  // 1.10 API response
+  server.get('/sys/internal/counters/activity', function () {
     return {
       data: {
         start_time: '2019-11-01T00:00:00Z',
@@ -35,6 +36,168 @@ export default function (server) {
                   clients: 51,
                   entity_clients: 35,
                   non_entity_clients: 16,
+                },
+              },
+            ],
+          },
+          {
+            namespace_id: 'DochC',
+            namespace_path: 'ns1',
+            counts: {
+              distinct_entities: 90,
+              non_entity_tokens: 65,
+              clients: 155,
+            },
+            mounts: [
+              {
+                path: 'auth/aws/login',
+                counts: {
+                  clients: 65,
+                  entity_clients: 50,
+                  non_entity_clients: 15,
+                },
+              },
+              {
+                path: 'auth/approle/login',
+                counts: {
+                  clients: 80,
+                  entity_clients: 60,
+                  non_entity_clients: 20,
+                },
+              },
+            ],
+          },
+          {
+            namespace_id: 'DochC',
+            namespace_path: 'ns1',
+            counts: {
+              distinct_entities: 90,
+              non_entity_tokens: 65,
+              clients: 155,
+            },
+            mounts: [
+              {
+                path: 'auth/aws/login',
+                counts: {
+                  clients: 65,
+                  entity_clients: 50,
+                  non_entity_clients: 15,
+                },
+              },
+              {
+                path: 'auth/approle/login',
+                counts: {
+                  clients: 80,
+                  entity_clients: 60,
+                  non_entity_clients: 20,
+                },
+              },
+            ],
+          },
+          {
+            namespace_id: 'DochC',
+            namespace_path: 'ns1',
+            counts: {
+              distinct_entities: 90,
+              non_entity_tokens: 65,
+              clients: 155,
+            },
+            mounts: [
+              {
+                path: 'auth/aws/login',
+                counts: {
+                  clients: 65,
+                  entity_clients: 50,
+                  non_entity_clients: 15,
+                },
+              },
+              {
+                path: 'auth/approle/login',
+                counts: {
+                  clients: 80,
+                  entity_clients: 60,
+                  non_entity_clients: 20,
+                },
+              },
+            ],
+          },
+          {
+            namespace_id: 'DochC',
+            namespace_path: 'ns1',
+            counts: {
+              distinct_entities: 90,
+              non_entity_tokens: 65,
+              clients: 155,
+            },
+            mounts: [
+              {
+                path: 'auth/aws/login',
+                counts: {
+                  clients: 65,
+                  entity_clients: 50,
+                  non_entity_clients: 15,
+                },
+              },
+              {
+                path: 'auth/approle/login',
+                counts: {
+                  clients: 80,
+                  entity_clients: 60,
+                  non_entity_clients: 20,
+                },
+              },
+            ],
+          },
+          {
+            namespace_id: 'DochC',
+            namespace_path: 'ns1',
+            counts: {
+              distinct_entities: 90,
+              non_entity_tokens: 65,
+              clients: 155,
+            },
+            mounts: [
+              {
+                path: 'auth/aws/login',
+                counts: {
+                  clients: 65,
+                  entity_clients: 50,
+                  non_entity_clients: 15,
+                },
+              },
+              {
+                path: 'auth/approle/login',
+                counts: {
+                  clients: 80,
+                  entity_clients: 60,
+                  non_entity_clients: 20,
+                },
+              },
+            ],
+          },
+          {
+            namespace_id: 'DochC',
+            namespace_path: 'ns1',
+            counts: {
+              distinct_entities: 90,
+              non_entity_tokens: 65,
+              clients: 155,
+            },
+            mounts: [
+              {
+                path: 'auth/aws/login',
+                counts: {
+                  clients: 65,
+                  entity_clients: 50,
+                  non_entity_clients: 15,
+                },
+              },
+              {
+                path: 'auth/approle/login',
+                counts: {
+                  clients: 80,
+                  entity_clients: 60,
+                  non_entity_clients: 20,
                 },
               },
             ],
@@ -324,6 +487,199 @@ export default function (server) {
             },
           },
         ],
+      },
+    };
+  });
+
+  // current (<= 1.9) API response
+  server.get('/sys/internal/counters/activity/monthly', function () {
+    return {
+      data: {
+        by_namespace: [
+          {
+            namespace_id: 'Z4Rzh',
+            namespace_path: 'namespace1/',
+            counts: {
+              distinct_entities: 867,
+              non_entity_tokens: 939,
+              clients: 1806,
+            },
+          },
+          {
+            namespace_id: 'DcgzU',
+            namespace_path: 'namespace17/',
+            counts: {
+              distinct_entities: 966,
+              non_entity_tokens: 550,
+              clients: 1516,
+            },
+          },
+          {
+            namespace_id: '5SWT8',
+            namespace_path: 'namespacelonglonglong4/',
+            counts: {
+              distinct_entities: 996,
+              non_entity_tokens: 417,
+              clients: 1413,
+            },
+          },
+          {
+            namespace_id: 'XGu7R',
+            namespace_path: 'namespace12/',
+            counts: {
+              distinct_entities: 829,
+              non_entity_tokens: 540,
+              clients: 1369,
+            },
+          },
+          {
+            namespace_id: 'yHcL9',
+            namespace_path: 'namespace11/',
+            counts: {
+              distinct_entities: 563,
+              non_entity_tokens: 705,
+              clients: 1268,
+            },
+          },
+          {
+            namespace_id: 'F0xGm',
+            namespace_path: 'namespace10/',
+            counts: {
+              distinct_entities: 925,
+              non_entity_tokens: 255,
+              clients: 1180,
+            },
+          },
+          {
+            namespace_id: 'aJuQG',
+            namespace_path: 'namespace9/',
+            counts: {
+              distinct_entities: 935,
+              non_entity_tokens: 239,
+              clients: 1174,
+            },
+          },
+          {
+            namespace_id: 'bw5UO',
+            namespace_path: 'namespace6/',
+            counts: {
+              distinct_entities: 810,
+              non_entity_tokens: 363,
+              clients: 1173,
+            },
+          },
+          {
+            namespace_id: 'IeyJp',
+            namespace_path: 'namespace14/',
+            counts: {
+              distinct_entities: 774,
+              non_entity_tokens: 392,
+              clients: 1166,
+            },
+          },
+          {
+            namespace_id: 'Uc0o8',
+            namespace_path: 'namespace16/',
+            counts: {
+              distinct_entities: 408,
+              non_entity_tokens: 743,
+              clients: 1151,
+            },
+          },
+          {
+            namespace_id: 'R6L40',
+            namespace_path: 'namespace2/',
+            counts: {
+              distinct_entities: 292,
+              non_entity_tokens: 736,
+              clients: 1028,
+            },
+          },
+          {
+            namespace_id: 'Rqa3W',
+            namespace_path: 'namespace13/',
+            counts: {
+              distinct_entities: 160,
+              non_entity_tokens: 803,
+              clients: 963,
+            },
+          },
+          {
+            namespace_id: 'MSgZE',
+            namespace_path: 'namespace7/',
+            counts: {
+              distinct_entities: 201,
+              non_entity_tokens: 657,
+              clients: 858,
+            },
+          },
+          {
+            namespace_id: 'kxU4t',
+            namespace_path: 'namespacelonglonglong3/',
+            counts: {
+              distinct_entities: 742,
+              non_entity_tokens: 26,
+              clients: 768,
+            },
+          },
+          {
+            namespace_id: '5xKya',
+            namespace_path: 'namespace15/',
+            counts: {
+              distinct_entities: 663,
+              non_entity_tokens: 19,
+              clients: 682,
+            },
+          },
+          {
+            namespace_id: '5KxXA',
+            namespace_path: 'namespace18anotherlong/',
+            counts: {
+              distinct_entities: 470,
+              non_entity_tokens: 196,
+              clients: 666,
+            },
+          },
+          {
+            namespace_id: 'AAidI',
+            namespace_path: 'namespace20/',
+            counts: {
+              distinct_entities: 429,
+              non_entity_tokens: 60,
+              clients: 489,
+            },
+          },
+          {
+            namespace_id: 'BCl56',
+            namespace_path: 'namespace8/',
+            counts: {
+              distinct_entities: 61,
+              non_entity_tokens: 201,
+              clients: 262,
+            },
+          },
+          {
+            namespace_id: 'yYNw2',
+            namespace_path: 'namespace19/',
+            counts: {
+              distinct_entities: 165,
+              non_entity_tokens: 85,
+              clients: 250,
+            },
+          },
+          {
+            namespace_id: 'root',
+            namespace_path: '',
+            counts: {
+              distinct_entities: 67,
+              non_entity_tokens: 9,
+              clients: 76,
+            },
+          },
+        ],
+        distinct_entities: 11323,
+        non_entity_tokens: 7935,
+        clients: 19258,
       },
     };
   });

--- a/ui/mirage/handlers/index.js
+++ b/ui/mirage/handlers/index.js
@@ -1,5 +1,6 @@
 // add all handlers here
 // individual lookup done in mirage config
 import base from './base';
+import activity from './activity';
 
-export { base };
+export { base, activity };


### PR DESCRIPTION
Adds csv export button and single chart view for when a date range is provided for client count data. Because _all_ clients are new in a given billing period having two separate charts (one for total client counts and one for only new counts) doesn't make sense when there is a date range provided. This breakdown is only available when the user had drilled down to a single month.      

Export button (still need designs for what the CSV file should look like once downloaded)
<img width="400" alt="Screen Shot 2022-01-12 at 3 26 12 PM" src="https://user-images.githubusercontent.com/68122737/149242692-3bead1d9-4b76-47fa-9f0f-600f1e6570c0.png">

### **Conditionals for single vs double charts**

_Sample data does not have auth methods included so differences are in chart view and copy. Some copy has not been finalized screen shots are to display accurate use of "Auth method" and "Namespace" and "month" vs "date range"_

**Namespace breakdown and date range**
`isDateRange=true`
`isAllNamespaces=true`
<img width="650" alt="Screen Shot 2022-01-12 at 4 10 26 PM" src="https://user-images.githubusercontent.com/68122737/149242786-33320830-f631-464b-8777-957f1eac7e4f.png">

**Namespace breakdown and single month**
`isDateRange=false` 
`isAllNamespaces=true`
<img width="650" alt="Screen Shot 2022-01-12 at 4 26 59 PM" src="https://user-images.githubusercontent.com/68122737/149244244-5a23c203-1a00-4f05-af43-a6699dc774fd.png">



**Auth method breakdown and date range**
`isDateRange=true`
`isAllNamespaces=false` (auth method breakdown)
<img width="650" alt="Screen Shot 2022-01-12 at 4 20 27 PM" src="https://user-images.githubusercontent.com/68122737/149243679-1b422cab-12ac-4223-b19a-052054676409.png">

**Auth method breakdown and single month**
`isDateRange=false`
`isAllNamespaces=false`
<img width="650" alt="Screen Shot 2022-01-12 at 4 24 53 PM" src="https://user-images.githubusercontent.com/68122737/149244062-8551b173-507d-42df-b274-731d9c8478d5.png">


 