### PR TITLE
Backport 1.8: Use MAP_POPULATE for our bbolt mmaps (#13621)

### DIFF
--- a/changelog/13573.txt
+++ b/changelog/13573.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+storage/raft: On linux, use map_populate for bolt files to improve startup time.
+```

--- a/physical/raft/bolt_linux.go
+++ b/physical/raft/bolt_linux.go
@@ -1,0 +1,36 @@
+package raft
+
+import (
+	"context"
+	"os"
+
+	"github.com/shirou/gopsutil/mem"
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	getMmapFlags = getMmapFlagsLinux
+}
+
+func getMmapFlagsLinux(dbPath string) int {
+	if os.Getenv("VAULT_RAFT_ENABLE_MAP_POPULATE") == "" {
+		return 0
+	}
+	stat, err := os.Stat(dbPath)
+	if err != nil {
+		return 0
+	}
+	size := stat.Size()
+
+	v, err := mem.VirtualMemoryWithContext(context.Background())
+	if err != nil {
+		return 0
+	}
+
+	// We won't worry about swap, since we already tell people not to use it.
+	if v.Total > uint64(size) {
+		return unix.MAP_POPULATE
+	}
+
+	return 0
+}

--- a/physical/raft/fsm.go
+++ b/physical/raft/fsm.go
@@ -174,6 +174,7 @@ func (f *FSM) openDBFile(dbPath string) error {
 		Timeout:        1 * time.Second,
 		FreelistType:   freelistType,
 		NoFreelistSync: noFreelistSync,
+		MmapFlags:      getMmapFlags(dbPath),
 	})
 	if err != nil {
 		return err

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -40,6 +40,8 @@ const EnvVaultRaftNodeID = "VAULT_RAFT_NODE_ID"
 // EnvVaultRaftPath is used to fetch the path where Raft data is stored from the environment.
 const EnvVaultRaftPath = "VAULT_RAFT_PATH"
 
+var getMmapFlags = func(string) int { return 0 }
+
 // Verify RaftBackend satisfies the correct interfaces
 var (
 	_ physical.Backend       = (*RaftBackend)(nil)
@@ -364,12 +366,14 @@ func NewRaftBackend(conf map[string]string, logger log.Logger) (physical.Backend
 		}
 
 		// Create the backend raft store for logs and stable storage.
+		dbPath := filepath.Join(path, "raft.db")
 		freelistType, noFreelistSync := freelistOptions()
 		raftOptions := raftboltdb.Options{
-			Path: filepath.Join(path, "raft.db"),
+			Path: dbPath,
 			BoltOptions: &bolt.Options{
 				FreelistType:   freelistType,
 				NoFreelistSync: noFreelistSync,
+				MmapFlags:      getMmapFlags(dbPath),
 			},
 		}
 		store, err := raftboltdb.New(raftOptions)


### PR DESCRIPTION
* Use MAP_POPULATE for our bbolt mmaps, assuming the files fit in memory.  This should improve startup times when freelist sync is disabled.

* For 1.8-1.9, MAP_POPULATE will be opt-in, requiring env var VAULT_RAFT_ENABLE_MAP_POPULATE.