### PR TITLE
docs: update oracle tls examples

### DIFF
--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -106,7 +106,7 @@ pluggable databases rather than the container database in the `connection_url` f
 
 ### Connect Using SSL
 
-~> The wallets used when connecting via SSL should be available on every Vault 
+~> **Note**: The wallets used when connecting via SSL should be available on every Vault 
 server when using high availability clusters.
 
 If the Oracle server Vault is trying to connect to uses an SSL listener, the database
@@ -135,7 +135,7 @@ vault write database/config/oracle \
 
 ### Using TNS Names
 
-~> The `tnsnames.ora` file and environment variable used when connecting via SSL should 
+~> **Note**: The `tnsnames.ora` file and environment variable used when connecting via SSL should 
 be available on every Vault server when using high availability clusters.
 
 Vault can optionally use TNS Names in the connection string when connecting to Oracle databases using a `tnsnames.ora` file. An example 

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -106,6 +106,9 @@ pluggable databases rather than the container database in the `connection_url` f
 
 ### Connect Using SSL
 
+~> The wallets used when connecting via SSL should be available on every Vault 
+server when using high availability clusters.
+
 If the Oracle server Vault is trying to connect to uses an SSL listener, the database
 plugin will require additional configuration using the `connection_url` parameter:
 
@@ -131,6 +134,9 @@ vault write database/config/oracle \
 ```
 
 ### Using TNS Names
+
+~> The `tnsnames.ora` file and environment variable used when connecting via SSL should 
+be available on every Vault server when using high availability clusters.
 
 Vault can optionally use TNS Names in the connection string when connecting to Oracle databases using a `tnsnames.ora` file. An example 
 of a `tnsnames.ora` file may look like the following:

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -112,7 +112,7 @@ plugin will require additional configuration using the `connection_url` paramete
 ```shell
 vault write database/config/oracle \
   plugin_name=vault-plugin-database-oracle \
-  connection_url='{{ username }}/{{ password }}@tcps://<host>:port/<service_name>?param1=...&param2=...&...'\
+  connection_url='{{ username }}/{{ password }}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=<host>(PORT=<port>))(CONNECT_DATA=(SERVICE_NAME=<service_name>))(SECURITY=(SSL_SERVER_CERT_DN="<cert_dn>")(MY_WALLET_DIRECTORY=<path_to_wallet>)))'
   allowed_roles="my-role" \
   username="admin" \
   password="password"
@@ -124,10 +124,70 @@ to use for connection and verification could be configured using:
 ```shell
 vault write database/config/oracle \
   plugin_name=vault-plugin-database-oracle \
-  connection_url='{{ username }}/{{ password }}@tcps://<host>:port/<service_name>?ssl_server_cert_dn="CN=hashicorp.com,OU=TestCA,O=HashiCorp=com"&wallet_location="/etc/oracle/wallets"' \
+  connection_url='{{ username }}/{{ password }}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=hashicorp.com)(PORT=1523))(CONNECT_DATA=(SERVICE_NAME=ORCL))(SECURITY=(SSL_SERVER_CERT_DN="CN=hashicorp.com,OU=TestCA,O=HashiCorp=com")(MY_WALLET_DIRECTORY=/etc/oracle/wallets)))'
   allowed_roles="my-role" \
   username="admin" \
   password="password"
+```
+
+### Using TNS Names
+
+Vault can optionally use TNS Names in the connection string when connecting to Oracle databases using a `tnsnames.ora` file. An example 
+of a `tnsnames.ora` file may look like the following:
+
+```shell
+AWSEAST=
+(DESCRIPTION =
+  (ADDRESS = (PROTOCOL = TCPS)(HOST = hashicorp.us-east-1.rds.amazonaws.com)(PORT = 1523))
+  (CONNECT_DATA =
+    (SERVER = DEDICATED)
+    (SID = ORCL)
+  )
+  (SECURITY =
+      (SSL_SERVER_CERT_DN = "CN=hashicorp.rds.amazonaws.com/OU=RDS/O=Amazon.com/L=Seattle/ST=Washington/C=US")
+      (MY_WALLET_DIRECTORY = /etc/oracle/wallet/east)
+  )
+)
+
+AWSWEST=
+(DESCRIPTION =
+  (ADDRESS = (PROTOCOL = TCPS)(HOST = hashicorp.us-west-1.rds.amazonaws.com)(PORT = 1523))
+  (CONNECT_DATA =
+    (SERVER = DEDICATED)
+    (SID = ORCL)
+  )
+  (SECURITY =
+      (SSL_SERVER_CERT_DN = "CN=hashicorp.rds.amazonaws.com/OU=RDS/O=Amazon.com/L=Seattle/ST=Washington/C=US")
+      (MY_WALLET_DIRECTORY = /etc/oracle/wallet/west)
+  )
+)
+```
+
+To configure Vault to use TNS names, set the following environment variable on the Vault server:
+
+```shell
+TNS_ADMIN=/path/to/tnsnames/directory
+```
+
+~> If Vault returns a "could not open file" error, double check that this environment 
+variable is available to the Vault server.
+
+Finally, use the alias in the `connection_url` parameter on the database configuration:
+
+```
+vault write database/config/oracle-east \
+    plugin_name=vault-plugin-database-oracle \
+    connection_url="{{ username }}/{{ password }}@AWSEAST" \
+    allowed_roles="my-role" \
+    username="VAULT_SUPER_USER" \
+    password="myreallysecurepassword"
+
+vault write database/config/oracle-west \
+    plugin_name=vault-plugin-database-oracle \
+    connection_url="{{ username }}/{{ password }}@AWSWEST" \
+    allowed_roles="my-role" \
+    username="VAULT_SUPER_USER" \
+    password="myreallysecurepassword"
 ```
 
 ## Usage

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -175,7 +175,7 @@ To configure Vault to use TNS names, set the following environment variable on t
 TNS_ADMIN=/path/to/tnsnames/directory
 ```
 
-~> If Vault returns a "could not open file" error, double check that this environment 
+~> **Note**: If Vault returns a "could not open file" error, double check that this environment 
 variable is available to the Vault server.
 
 Finally, use the alias in the `connection_url` parameter on the database configuration:


### PR DESCRIPTION
This updates the Oracle TLS documentation for connecting via TLS. The documented URL style does not seem to work with the Oracle driver but I was able to connect when using a more standard Oracle URL schema.