### PR TITLE
Add support for client certificates to -output-curl-string

### DIFF
--- a/api/output_string.go
+++ b/api/output_string.go
@@ -15,9 +15,11 @@ var LastOutputStringError *OutputStringError
 
 type OutputStringError struct {
 	*retryablehttp.Request
-	TLSSkipVerify    bool
-	parsingError     error
-	parsedCurlString string
+	TLSSkipVerify              bool
+	ClientCACert, ClientCAPath string
+	ClientCert, ClientKey      string
+	parsingError               error
+	parsedCurlString           string
 }
 
 func (d *OutputStringError) Error() string {
@@ -45,6 +47,22 @@ func (d *OutputStringError) parseRequest() {
 	}
 	if d.Request.Method != "GET" {
 		d.parsedCurlString = fmt.Sprintf("%s-X %s ", d.parsedCurlString, d.Request.Method)
+	}
+	if d.ClientCACert != "" {
+		clientCACert := strings.Replace(d.ClientCACert, "'", "'\"'\"'", -1)
+		d.parsedCurlString = fmt.Sprintf("%s--cacert '%s' ", d.parsedCurlString, clientCACert)
+	}
+	if d.ClientCAPath != "" {
+		clientCAPath := strings.Replace(d.ClientCAPath, "'", "'\"'\"'", -1)
+		d.parsedCurlString = fmt.Sprintf("%s--capath '%s' ", d.parsedCurlString, clientCAPath)
+	}
+	if d.ClientCert != "" {
+		clientCert := strings.Replace(d.ClientCert, "'", "'\"'\"'", -1)
+		d.parsedCurlString = fmt.Sprintf("%s--cert '%s' ", d.parsedCurlString, clientCert)
+	}
+	if d.ClientKey != "" {
+		clientKey := strings.Replace(d.ClientKey, "'", "'\"'\"'", -1)
+		d.parsedCurlString = fmt.Sprintf("%s--key '%s' ", d.parsedCurlString, clientKey)
 	}
 	for k, v := range d.Request.Header {
 		for _, h := range v {

--- a/changelog/13660.txt
+++ b/changelog/13660.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+core: `-output-curl-string` now properly sets cURL options for client and CA
+certificates.
+```


### PR DESCRIPTION
I did not write tests for this feature as -output-curl-string was not
already tested and this is a simple change. Because the name of the
certificates would be lost once loaded I added fields to Config to keep
track of them. I did not add a public method for the user to set them
explicitely as I don't think anyone would need this functionnality
outside of the Vault CLI.

Closes https://github.com/hashicorp/vault/issues/13376