### PR TITLE
docs: add known issues section to 1.9.x upgrade guide

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
@@ -102,7 +102,7 @@ backend](https://www.vaultproject.io/api-docs/secret/identity/tokens) and have
 keys](https://www.vaultproject.io/api-docs/secret/identity/tokens#create-a-named-key)
 generated will encounter a panic when any of those existing keys are rotated
 once passed its `rotation_period`. This issue affects Vault 1.9.0, and fixed in
-Vault 1.9.1. The workarounds for this issue are to 1) delete any existing keys
-before the update, or 2) increase the rotation period to allow ample time for
-updating past 1.9.0 before a rotation can occur. Workarounds are not necessary
-if an update to directly to 1.9.1 or above is performed.
+Vault 1.9.1. The workarounds for this issue are to either 1) delete any existing
+keys before the update, or 2) increase the rotation period to allow ample time
+for updating past 1.9.0 before a rotation can occur. Workarounds are not
+necessary if an update to directly to 1.9.1 or above is performed.

--- a/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
@@ -95,3 +95,14 @@ respects the order of suites given in `tls_cipher_suites`.
 
 See [this blog post](https://go.dev/blog/tls-cipher-suites) for more information.
 
+## Known Issues
+- Existing Vault installations that use the [Identity Token
+backend](https://www.vaultproject.io/api-docs/secret/identity/tokens) and have
+[named
+keys](https://www.vaultproject.io/api-docs/secret/identity/tokens#create-a-named-key)
+generated will encounter a panic when any of those existing keys are rotated
+once passed its `rotation_period`. This issue affects Vault 1.9.0, and fixed in
+Vault 1.9.1. The workarounds for this issue are to 1) delete any existing keys
+before the update, or 2) increase the rotation period to allow ample time for
+updating past 1.9.0 before a rotation can occur. Workarounds are not necessary
+if an update to directly to 1.9.1 or above is performed.

--- a/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
@@ -99,8 +99,8 @@ See [this blog post](https://go.dev/blog/tls-cipher-suites) for more information
 - Existing Vault installations that use the [Identity Token
 backend](/api-docs/secret/identity/tokens) and have [named
 keys](/api-docs/secret/identity/tokens#create-a-named-key) generated will
-encounter a panic when any of those existing keys are rotated once passed its
-`rotation_period`. This issue affects Vault 1.9.0, and fixed in Vault 1.9.1. The
+encounter a panic when any of those existing keys pass their
+`rotation_period`. This issue affects Vault 1.9.0, and is fixed in Vault 1.9.1. The
 workarounds for this issue are to either 1) delete any existing keys before the
 update, or 2) increase the rotation period to allow ample time for updating past
 1.9.0 before a rotation can occur. Workarounds are not necessary if an update to

--- a/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
@@ -96,12 +96,17 @@ respects the order of suites given in `tls_cipher_suites`.
 See [this blog post](https://go.dev/blog/tls-cipher-suites) for more information.
 
 ## Known Issues
-- Existing Vault installations that use the [Identity Token
+
+### Identity Token Backend Key Rotations
+
+Existing Vault installations that use the [Identity Token
 backend](/api-docs/secret/identity/tokens) and have [named
 keys](/api-docs/secret/identity/tokens#create-a-named-key) generated will
 encounter a panic when any of those existing keys pass their
-`rotation_period`. This issue affects Vault 1.9.0, and is fixed in Vault 1.9.1. The
-workarounds for this issue are to either 1) delete any existing keys before the
-update, or 2) increase the rotation period to allow ample time for updating past
-1.9.0 before a rotation can occur. Workarounds are not necessary if an update to
-directly to 1.9.1 or above is performed.
+`rotation_period`. This issue affects Vault 1.9.0, and is fixed in Vault 1.9.1.
+Users should upgrade directly to 1.9.1 or above in order to avoid this panic.
+
+If a panic is encountered after an upgrade to Vault 1.9.0, the named key will be
+corrupted on storage and become unusable. In this case, the key will need to be
+deleted and re-created. A fix to fully mitigate this panic will be addressed on
+Vault 1.9.3.

--- a/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
@@ -97,12 +97,11 @@ See [this blog post](https://go.dev/blog/tls-cipher-suites) for more information
 
 ## Known Issues
 - Existing Vault installations that use the [Identity Token
-backend](https://www.vaultproject.io/api-docs/secret/identity/tokens) and have
-[named
-keys](https://www.vaultproject.io/api-docs/secret/identity/tokens#create-a-named-key)
-generated will encounter a panic when any of those existing keys are rotated
-once passed its `rotation_period`. This issue affects Vault 1.9.0, and fixed in
-Vault 1.9.1. The workarounds for this issue are to either 1) delete any existing
-keys before the update, or 2) increase the rotation period to allow ample time
-for updating past 1.9.0 before a rotation can occur. Workarounds are not
-necessary if an update to directly to 1.9.1 or above is performed.
+backend](/api-docs/secret/identity/tokens) and have [named
+keys](/api-docs/secret/identity/tokens#create-a-named-key) generated will
+encounter a panic when any of those existing keys are rotated once passed its
+`rotation_period`. This issue affects Vault 1.9.0, and fixed in Vault 1.9.1. The
+workarounds for this issue are to either 1) delete any existing keys before the
+update, or 2) increase the rotation period to allow ample time for updating past
+1.9.0 before a rotation can occur. Workarounds are not necessary if an update to
+directly to 1.9.1 or above is performed.


### PR DESCRIPTION
Adds a "Known Issues" section to our 1.9.x upgrade guide, and includes a note about a panic that can be encountered on Vault installations that are using the ID token backend and have named keys created.