### PR TITLE
auth/ldap: Fix upndomain bug causing alias name to change

### DIFF
--- a/builtin/credential/ldap/path_login.go
+++ b/builtin/credential/ldap/path_login.go
@@ -96,8 +96,12 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 		},
 		DisplayName: username,
 		Alias: &logical.Alias{
-			Name: effectiveUsername,
+			Name: username,
 		},
+	}
+
+	if cfg.UPNDomain != "" {
+		auth.Alias.Metadata["upn_domain_username"] = effectiveUsername
 	}
 
 	cfg.PopulateTokenAuth(auth)


### PR DESCRIPTION
A change introduced in https://github.com/hashicorp/vault/pull/11000 introduced a subtle change to entity aliases when `upndomain` is configured. When using upndomain, the `name` value in the alias now contains the value stored in `upndomain`:

```json
{
  "data": {
    "aliases": [
      {
        ...
        "name": "bob@corp.example.net"
      }
    ],
  },
}
```

This has caused issues in 1.9.x where users are using templated policies and now the UPN domain is being appended. I've changed aliases.name to be the raw username (no UPN), and added the full username (username+upn domain) to `aliases.metadata.upn_domain_username` if you want that value.