### PR TITLE
Don't say we've shut down cluster listener before having done so

### DIFF
--- a/changelog/13679.txt
+++ b/changelog/13679.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix how we report the cluster listener is done, prevents `bind: address already in use` errors.
+```

--- a/vault/cluster/cluster.go
+++ b/vault/cluster/cluster.go
@@ -6,8 +6,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/vault/sdk/helper/certutil"
-	"github.com/hashicorp/vault/sdk/helper/tlsutil"
 	"net"
 	"net/url"
 	"os"
@@ -16,7 +14,9 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
+	"github.com/hashicorp/vault/sdk/helper/tlsutil"
 	"golang.org/x/net/http2"
 )
 
@@ -279,9 +279,9 @@ func (cl *Listener) Run(ctx context.Context) error {
 		// Start our listening loop
 		go func(closeCh chan struct{}, tlsLn net.Listener) {
 			defer func() {
-				cl.shutdownWg.Done()
 				tlsLn.Close()
 				close(closeCh)
+				cl.shutdownWg.Done()
 			}()
 
 			// baseDelay is the initial delay after an Accept() error before attempting again


### PR DESCRIPTION
This was motivated by this output from a test on ent:

```
2022-01-14T09:09:34.006-0500 [DEBUG] core0.core: starting cluster listeners
2022-01-14T09:09:34.006-0500 [INFO]  core0.core.cluster-listener.tcp: starting listener: listener_address=127.0.0.1:0
2022-01-14T09:09:34.007-0500 [INFO]  core0.core.cluster-listener: serving cluster requests: cluster_listen_address=127.0.0.1:52477
2022-01-14T09:09:34.008-0500 [TRACE] core0.raft: setting up raft cluster
...
2022-01-14T09:09:52.591-0500 [INFO]  core0.core: stopping cluster listeners
2022-01-14T09:09:52.591-0500 [INFO]  core0.core.cluster-listener: forwarding rpc listeners stopped
2022-01-14T09:09:53.071-0500 [INFO]  core0.core.cluster-listener: rpc listeners successfully shut down
2022-01-14T09:09:53.071-0500 [INFO]  core0.core: cluster listeners successfully shut down
...
2022-01-14T09:09:53.072-0500 [INFO]  core0.core.cluster-listener.tcp: starting listener: listener_address=127.0.0.1:52477
2022-01-14T09:09:53.072-0500 [ERROR] core0.core.cluster-listener.tcp: error starting listener: error="listen tcp 127.0.0.1:52477: bind: address already in use"
```

The test in question, TestRaft_SnapshotAPI_RekeyRotate_Backward/rekey-with-perf-standby, was still in the initial setup stage: we'd done the initial raft cluster single-node setup, won the first election to be able to store the raft configuration in the first log entry, and were in the process of restarting raft with the real listener prior to joining the other nodes.

I have been unable to reproduce this failure even before making this change, so it's a speculative fix.