### PR TITLE
Accept both -f and --force in the web terminal

### DIFF
--- a/changelog/13683.txt
+++ b/changelog/13683.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+ui: The integrated web terminal now accepts both `-f` and `--force` as aliases
+for `-force` for the `write` commmand.
+```

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -71,7 +71,7 @@ export default Component.extend({
     let [method, flagArray, path, dataArray] = serviceArgs;
 
     if (dataArray || flagArray) {
-      var { data, flags } = extractDataAndFlags(dataArray, flagArray);
+      var { data, flags } = extractDataAndFlags(method, dataArray, flagArray);
     }
 
     let inputError = logErrorFromInput(path, method, flags, dataArray);

--- a/ui/app/lib/console-helpers.js
+++ b/ui/app/lib/console-helpers.js
@@ -5,7 +5,7 @@ import { parse } from 'shell-quote';
 const supportedCommands = ['read', 'write', 'list', 'delete'];
 const uiCommands = ['api', 'clearall', 'clear', 'fullscreen', 'refresh'];
 
-export function extractDataAndFlags(data, flags) {
+export function extractDataAndFlags(method, data, flags) {
   return data.concat(flags).reduce(
     (accumulator, val) => {
       // will be "key=value" or "-flag=value" or "foo=bar=baz"
@@ -16,6 +16,10 @@ export function extractDataAndFlags(data, flags) {
         let flagName = item.replace(/^-/, '');
         if (flagName === 'wrap-ttl') {
           flagName = 'wrapTTL';
+        } else if (method == 'write') {
+          if (flagName === 'f' || flagName === '-force') {
+            flagName = 'force';
+          }
         }
         accumulator.flags[flagName] = value || true;
         return accumulator;

--- a/ui/app/lib/console-helpers.js
+++ b/ui/app/lib/console-helpers.js
@@ -16,7 +16,7 @@ export function extractDataAndFlags(method, data, flags) {
         let flagName = item.replace(/^-/, '');
         if (flagName === 'wrap-ttl') {
           flagName = 'wrapTTL';
-        } else if (method == 'write') {
+        } else if (method === 'write') {
           if (flagName === 'f' || flagName === '-force') {
             flagName = 'force';
           }

--- a/ui/tests/unit/lib/console-helpers-test.js
+++ b/ui/tests/unit/lib/console-helpers-test.js
@@ -125,6 +125,7 @@ module('Unit | Lib | console helpers', function () {
 
   const testExtractCases = [
     {
+      method: 'read',
       name: 'data fields',
       input: [
         [
@@ -144,6 +145,7 @@ module('Unit | Lib | console helpers', function () {
       },
     },
     {
+      method: 'read',
       name: 'repeated data and a flag',
       input: [['allowed_domains=example.com', 'allowed_domains=foo.example.com'], ['-wrap-ttl=2h']],
       expected: {
@@ -156,6 +158,7 @@ module('Unit | Lib | console helpers', function () {
       },
     },
     {
+      method: 'read',
       name: 'data with more than one equals sign',
       input: [['foo=bar=baz', 'foo=baz=bop', 'some=value=val'], []],
       expected: {
@@ -167,6 +170,7 @@ module('Unit | Lib | console helpers', function () {
       },
     },
     {
+      method: 'read',
       name: 'data with empty values',
       input: [[`foo=`, 'some=thing'], []],
       expected: {
@@ -177,11 +181,44 @@ module('Unit | Lib | console helpers', function () {
         flags: {},
       },
     },
+    {
+      method: 'write',
+      name: 'write with force flag',
+      input: [[], ['-force']],
+      expected: {
+        data: {},
+        flags: {
+          force: true,
+        },
+      },
+    },
+    {
+      method: 'write',
+      name: 'write with force short flag',
+      input: [[], ['-f']],
+      expected: {
+        data: {},
+        flags: {
+          force: true,
+        },
+      },
+    },
+    {
+      method: 'write',
+      name: 'write with GNU style force flag',
+      input: [[], ['--force']],
+      expected: {
+        data: {},
+        flags: {
+          force: true,
+        },
+      },
+    },
   ];
 
   testExtractCases.forEach(function (testCase) {
     test(`#extractDataAndFlags: ${testCase.name}`, function (assert) {
-      let { data, flags } = extractDataAndFlags(...testCase.input);
+      let { data, flags } = extractDataAndFlags(testCase.method, ...testCase.input);
       assert.deepEqual(data, testCase.expected.data, 'has expected data');
       assert.deepEqual(flags, testCase.expected.flags, 'has expected flags');
     });


### PR DESCRIPTION
This aligns the behavior of the web terminal with the `vault write ...`
command to make it a bit more user friendly.