### PR TITLE
Add validation for nonce size when we aren't in convergent encryption mode within transit backend

### DIFF
--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -578,6 +578,31 @@ func TestTransit_BatchEncryptionCase12(t *testing.T) {
 	}
 }
 
+// Case13: Incorrect input for nonce when we aren't in convergent encryption should fail the operation
+func TestTransit_BatchEncryptionCase13(t *testing.T) {
+	var err error
+
+	b, s := createBackendWithStorage(t)
+
+	batchInput := []interface{}{
+		map[string]interface{}{"plaintext": "bXkgc2VjcmV0IGRhdGE=", "nonce": "YmFkbm9uY2U="},
+	}
+
+	batchData := map[string]interface{}{
+		"batch_input": batchInput,
+	}
+	batchReq := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "encrypt/my-key",
+		Storage:   s,
+		Data:      batchData,
+	}
+	_, err = b.HandleRequest(context.Background(), batchReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // Test that the fast path function decodeBatchRequestItems behave like mapstructure.Decode() to decode []BatchRequestItem.
 func TestTransit_decodeBatchRequestItems(t *testing.T) {
 	tests := []struct {

--- a/changelog/13690.txt
+++ b/changelog/13690.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/transit: Ensure that Vault does not panic for invalid nonce size when we aren't in convergent encryption mode.
+```

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -1655,6 +1655,8 @@ func (p *Policy) SymmetricEncryptRaw(ver int, encKey, plaintext []byte, opts Sym
 		if err != nil {
 			return nil, errutil.InternalError{Err: err.Error()}
 		}
+	} else if len(nonce) != aead.NonceSize() {
+		return nil, errutil.UserError{Err: fmt.Sprintf("base64-decoded nonce must be %d bytes long but given %d bytes", aead.NonceSize(), len(nonce))}
 	}
 
 	// Encrypt and tag with AEAD


### PR DESCRIPTION
The backend will panic when provided with a nonce value that is an invalid size when the key type is one of AES256_GCM96, AES128_GCM96, ChaCha20_Poly1305 within transit when the key does not have convergent encryption enabled. 

Within sdk/helper/keysutil/policy.go func SymmetricEncryptRaw we are missing a test for the nonce size when we aren't in convergent encryption mode. We only check the nonce size is 0 to generate a value.

See VAULT-4533 for more details.