### PR TITLE
Update http requests API link to versioned docs

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.9.x.mdx
@@ -63,7 +63,7 @@ specified by clients.
 ### HTTP Request Counter Deprecation
 
 In Vault 1.9, the internal HTTP Request count
-[API](https://www.vaultproject.io/api-docs/system/internal-counters#http-requests)
+[API](https://www.vaultproject.io/api-docs/v1.8.x/system/internal-counters#http-requests)
 will be removed from the product. Calls to the endpoint will result in a 404
 error with a message stating that `functionality on this path has been removed`.
 


### PR DESCRIPTION
In the "latest" version of the API docs, the HTTP requests endpoint has been removed. Updating to reference the 1.8.x docs.