### PR TITLE
docs/oracle: fix typo in connection_url example

### DIFF
--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -106,7 +106,7 @@ pluggable databases rather than the container database in the `connection_url` f
 
 ### Connect Using SSL
 
-~> **Note**: The wallets used when connecting via SSL should be available on every Vault 
+~> **Note**: The wallets used when connecting via SSL should be available on every Vault
 server when using high availability clusters.
 
 If the Oracle server Vault is trying to connect to uses an SSL listener, the database
@@ -115,7 +115,7 @@ plugin will require additional configuration using the `connection_url` paramete
 ```shell
 vault write database/config/oracle \
   plugin_name=vault-plugin-database-oracle \
-  connection_url='{{ username }}/{{ password }}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=<host>(PORT=<port>))(CONNECT_DATA=(SERVICE_NAME=<service_name>))(SECURITY=(SSL_SERVER_CERT_DN="<cert_dn>")(MY_WALLET_DIRECTORY=<path_to_wallet>)))'
+  connection_url='{{ username }}/{{ password }}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=<host>)(PORT=<port>))(CONNECT_DATA=(SERVICE_NAME=<service_name>))(SECURITY=(SSL_SERVER_CERT_DN="<cert_dn>")(MY_WALLET_DIRECTORY=<path_to_wallet>)))' \
   allowed_roles="my-role" \
   username="admin" \
   password="password"
@@ -127,7 +127,7 @@ to use for connection and verification could be configured using:
 ```shell
 vault write database/config/oracle \
   plugin_name=vault-plugin-database-oracle \
-  connection_url='{{ username }}/{{ password }}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=hashicorp.com)(PORT=1523))(CONNECT_DATA=(SERVICE_NAME=ORCL))(SECURITY=(SSL_SERVER_CERT_DN="CN=hashicorp.com,OU=TestCA,O=HashiCorp=com")(MY_WALLET_DIRECTORY=/etc/oracle/wallets)))'
+  connection_url='{{ username }}/{{ password }}@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=hashicorp.com)(PORT=1523))(CONNECT_DATA=(SERVICE_NAME=ORCL))(SECURITY=(SSL_SERVER_CERT_DN="CN=hashicorp.com,OU=TestCA,O=HashiCorp=com")(MY_WALLET_DIRECTORY=/etc/oracle/wallets)))' \
   allowed_roles="my-role" \
   username="admin" \
   password="password"
@@ -135,10 +135,10 @@ vault write database/config/oracle \
 
 ### Using TNS Names
 
-~> **Note**: The `tnsnames.ora` file and environment variable used when connecting via SSL should 
+~> **Note**: The `tnsnames.ora` file and environment variable used when connecting via SSL should
 be available on every Vault server when using high availability clusters.
 
-Vault can optionally use TNS Names in the connection string when connecting to Oracle databases using a `tnsnames.ora` file. An example 
+Vault can optionally use TNS Names in the connection string when connecting to Oracle databases using a `tnsnames.ora` file. An example
 of a `tnsnames.ora` file may look like the following:
 
 ```shell
@@ -175,7 +175,7 @@ To configure Vault to use TNS names, set the following environment variable on t
 TNS_ADMIN=/path/to/tnsnames/directory
 ```
 
-~> **Note**: If Vault returns a "could not open file" error, double check that this environment 
+~> **Note**: If Vault returns a "could not open file" error, double check that this environment
 variable is available to the Vault server.
 
 Finally, use the alias in the `connection_url` parameter on the database configuration:


### PR DESCRIPTION
There were small typos in the `connection_url` example for TLS connections.