### PR TITLE
Revert #13679 

### DIFF
--- a/changelog/13679.txt
+++ b/changelog/13679.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-core: Fix how we report the cluster listener is done, prevents `bind: address already in use` errors.
-```

--- a/vault/cluster/cluster.go
+++ b/vault/cluster/cluster.go
@@ -6,6 +6,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/helper/tlsutil"
 	"net"
 	"net/url"
 	"os"
@@ -14,9 +16,7 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/consts"
-	"github.com/hashicorp/vault/sdk/helper/tlsutil"
 	"golang.org/x/net/http2"
 )
 
@@ -279,9 +279,9 @@ func (cl *Listener) Run(ctx context.Context) error {
 		// Start our listening loop
 		go func(closeCh chan struct{}, tlsLn net.Listener) {
 			defer func() {
+				cl.shutdownWg.Done()
 				tlsLn.Close()
 				close(closeCh)
-				cl.shutdownWg.Done()
 			}()
 
 			// baseDelay is the initial delay after an Accept() error before attempting again

--- a/vault/cluster_test.go
+++ b/vault/cluster_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net/http"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -93,7 +91,7 @@ func TestCluster_ListenForRequests(t *testing.T) {
 	manualStepDownSleepPeriod = 5 * time.Second
 
 	cluster := NewTestCluster(t, nil, &TestClusterOptions{
-		NumCores: 1,
+		KeepStandbysSealed: true,
 	})
 	cluster.Start()
 	defer cluster.Cleanup()
@@ -157,11 +155,7 @@ func TestCluster_ListenForRequests(t *testing.T) {
 	checkListenersFunc(true)
 
 	// After this period it should be active again
-	if err := TestWaitActiveWithError(cores[0].Core); err != nil {
-		buf := make([]byte, 32*1024*1024)
-		n := runtime.Stack(buf[:], true)
-		fmt.Println(string(buf[:n]))
-	}
+	TestWaitActive(t, cores[0].Core)
 	cores[0].getClusterListener().AddClient(consts.RequestForwardingALPN, &requestForwardingClusterClient{cores[0].Core})
 	checkListenersFunc(false)
 


### PR DESCRIPTION
Reason: TestCluster_ListenForRequest now fails intermittently in alarming ways, e.g. https://app.circleci.com/pipelines/github/hashicorp/vault/25138/workflows/58ce7db1-3f32-4455-8258-fe2ba19e2e1b/jobs/368209