### PR TITLE
Support token.metadata.<key> in ACL templates

### DIFF
--- a/changelog/13715.txt
+++ b/changelog/13715.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+acl: The ACL templating system now supports referencing a token metadata attribute
+with `{{ token.metadata.<attribute key> }}`.
+```

--- a/vault/capabilities.go
+++ b/vault/capabilities.go
@@ -76,7 +76,7 @@ func (c *Core) Capabilities(ctx context.Context, token, path string) ([]string, 
 	// Construct the corresponding ACL object. ACL construction should be
 	// performed on the token's namespace.
 	tokenCtx := namespace.ContextWithNamespace(ctx, tokenNS)
-	acl, err := c.policyStore.ACL(tokenCtx, entity, policyNames, policies...)
+	acl, err := c.policyStore.ACL(tokenCtx, te, entity, policyNames, policies...)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/dynamic_system_view.go
+++ b/vault/dynamic_system_view.go
@@ -114,7 +114,7 @@ func (e extendedSystemViewImpl) SudoPrivilege(ctx context.Context, path string, 
 
 	// Construct the corresponding ACL object. Derive and use a new context that
 	// uses the req.ClientToken's namespace
-	acl, err := e.core.policyStore.ACL(tokenCtx, entity, policyNames, policies...)
+	acl, err := e.core.policyStore.ACL(tokenCtx, te, entity, policyNames, policies...)
 	if err != nil {
 		e.core.logger.Error("failed to retrieve ACL for token's policies", "token_policies", te.Policies, "error", err)
 		return false

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -754,7 +754,7 @@ func (t *TemplateError) Error() string {
 
 // ACL is used to return an ACL which is built using the
 // named policies and pre-fetched policies if given.
-func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*Policy) (*ACL, error) {
+func (ps *PolicyStore) ACL(ctx context.Context, te *logical.TokenEntry, entity *identity.Entity, policyNames map[string][]string, additionalPolicies ...*Policy) (*ACL, error) {
 	var allPolicies []*Policy
 
 	// Fetch the named policies
@@ -795,7 +795,7 @@ func (ps *PolicyStore) ACL(ctx context.Context, entity *identity.Entity, policyN
 					groups = append(directGroups, inheritedGroups...)
 				}
 			}
-			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, entity, groups)
+			p, err := parseACLPolicyWithTemplating(policy.namespace, policy.Raw, true, te, entity, groups)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing templated policy %q: %w", policy.Name, err)
 			}

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -229,7 +229,7 @@ func (c *Core) fetchACLTokenEntryAndEntity(ctx context.Context, req *logical.Req
 
 	// Construct the corresponding ACL object. ACL construction should be
 	// performed on the token's namespace.
-	acl, err := c.policyStore.ACL(tokenCtx, entity, policyNames, policies...)
+	acl, err := c.policyStore.ACL(tokenCtx, te, entity, policyNames, policies...)
 	if err != nil {
 		if errwrap.ContainsType(err, new(TemplateError)) {
 			c.logger.Warn("permission denied due to a templated policy being invalid or containing directives not satisfied by the requestor", "error", err)

--- a/website/content/docs/concepts/policies.mdx
+++ b/website/content/docs/concepts/policies.mdx
@@ -251,8 +251,8 @@ credentials, the policy would grant `read` access on the appropriate path.
 ## Templated Policies
 
 The policy syntax allows for doing variable replacement in some policy strings
-with values available to the token. Currently `identity` information can be
-injected, and currently the `path` keys in policies allow injection.
+with values available to the token. Currently `identity` and `token` information
+can be injected, and currently the `path` keys in policies allow injection.
 
 ### Parameters
 
@@ -269,6 +269,7 @@ injected, and currently the `path` keys in policies allow injection.
 | `identity.groups.names.<group name>.id`                                          | The group ID for the given group name                                                  |
 | `identity.groups.ids.<group id>.metadata.<metadata key>`                         | Metadata associated with the group for the given key                                   |
 | `identity.groups.names.<group name>.metadata.<metadata key>`                     | Metadata associated with the group for the given key                                   |
+| `token.metadata.<metadata key>`                                                  | Metadata associated with the token for the given key                                   |
 
 ### Examples
 


### PR DESCRIPTION
We have a Vault Enterprise client that is using Sentinel for two
applications. What they need to do with Sentinel is quite simple and
could be done much more easily by using ACL templates if they supported
injecting a token's metadata. That would be more readable than a large
Sentinel script and make it much easier to onboard operators that need
to make changes to those applications.