### PR TITLE
oidc: check for nil signing key on rotation

### DIFF
--- a/changelog/13716.txt
+++ b/changelog/13716.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity/oidc: Check for a nil signing key on rotation to prevent panics.
+```

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -1043,7 +1043,7 @@ func (k *namedKey) generateAndSetNextKey(ctx context.Context, logger hclog.Logge
 
 func (k *namedKey) signPayload(payload []byte) (string, error) {
 	if k.SigningKey == nil {
-		return "", fmt.Errorf("signing key is nil")
+		return "", fmt.Errorf("signing key is nil; rotate the key and try again")
 	}
 	signingKey := jose.SigningKey{Key: k.SigningKey, Algorithm: jose.SignatureAlgorithm(k.Algorithm)}
 	signer, err := jose.NewSigner(signingKey, &jose.SignerOptions{})
@@ -1509,6 +1509,8 @@ func (k *namedKey) rotate(ctx context.Context, logger hclog.Logger, s logical.St
 			}
 		}
 	} else {
+		// this can occur for keys generated before vault 1.9.0 but rotated on
+		// vault 1.9.0
 		logger.Debug("nil signing key detected on rotation")
 	}
 


### PR DESCRIPTION
# Description

Check for a nil signing key before performing a rotation and before signing payloads. This is to prevent panics in the event that a nil signing key was written to storage.

If the current signing key is nil during rotation, we will skip setting the ExpireAt and allow the next signing key to be rotated into the current. If the signing key is nil during sign payload, we will return an error.

# Background
A panic can occur for any key which was created while being on a version < v1.9.0 but was rotated while being on v1.9.0.

Repro steps:

- start vault with persistent storage
- create keys/roles with Vault < v1.9.0
- upgrade vault to v1.9.0
- manually rotate the key or wait for an auto rotation
- once key rotation triggers, a panic will occur
  - this was fixed in #13298 
- restarting vault  v1.9.0 should result in panics on rotation
- upgrade vault to v1.9.1 or greater
- restart vault with same persistent storage backend
- once key rotation triggers, a panic will occur
  - this is being fix in the current PR