### PR TITLE
Add tag to fix DNS bug with mac builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,7 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          GO_TAGS: "${{ env.GO_TAGS }} netcgo"
           CGO_ENABLED: 0
         run: |
           mkdir dist out


### PR DESCRIPTION
Per: https://hashicorp.atlassian.net/browse/RDX-205 (which goes into depth about our research on this issue) - this change adds the "netcgo" build tag to mac builds, which addresses a dns issue caused when our builds migrated to github runners.