### PR TITLE
UI/remove ie 11 browserstack

### DIFF
--- a/ui/testem.browserstack.js
+++ b/ui/testem.browserstack.js
@@ -5,7 +5,7 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed&nolint',
   tap_quiet_logs: true,
   disable_watching: true,
-  timeout: 1200,
+  timeout: 1500,
   browser_start_timeout: 2000,
   parallel: 4,
   launchers: {

--- a/ui/testem.browserstack.js
+++ b/ui/testem.browserstack.js
@@ -63,27 +63,9 @@ module.exports = {
       ],
       protocol: 'browser',
     },
-    BS_IE_11: {
-      exe: 'node_modules/.bin/browserstack-launch',
-      args: [
-        '--os',
-        'Windows',
-        '--osv',
-        '8.1',
-        '--b',
-        'ie',
-        '--bv',
-        '11.0',
-        '-t',
-        '1200',
-        '--u',
-        '<url>&legacy=true',
-      ],
-      protocol: 'browser',
-    },
   },
   launch_in_dev: [],
-  launch_in_ci: ['BS_IE_11'],
+  launch_in_ci: ['BS_Safari_Current'],
   proxies: {
     '/v1': {
       target: 'http://localhost:9200',


### PR DESCRIPTION
This change switches our browserstack test from IE 11 (which we [no longer support](https://www.vaultproject.io/docs/browser-support)) to Safari. CircleCI was terminating the test early due to timeout so I also bumped that a bit. 