### PR TITLE
auth/oidc: adds changelog for #13494

### DIFF
--- a/changelog/13494.txt
+++ b/changelog/13494.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/oidc: Fixes OIDC auth from the Vault UI when using the implicit flow and `form_post` response mode.
+```


### PR DESCRIPTION
This PR adds a changelog entry to [release/1.8.x](https://github.com/hashicorp/vault/tree/release/1.8.x) for the bug fix introduced in #13494.