### PR TITLE
secrets/gcp: adds changelog for #13549

### DIFF
--- a/changelog/13549.txt
+++ b/changelog/13549.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/gcp: Fixes role bindings for BigQuery dataset resources.
+```


### PR DESCRIPTION
This PR adds a changelog entry to [release/1.8.x](https://github.com/hashicorp/vault/tree/release/1.8.x) for the bug fix introduced in #13549.