### PR TITLE
Vault documentation: Fixed typo on browser support page

### DIFF
--- a/website/content/docs/browser-support.mdx
+++ b/website/content/docs/browser-support.mdx
@@ -8,7 +8,7 @@ description: |-
 
 # Vault UI Browser Support
 
-Vault currently supports all 'evergreen' browsers, as they are generally on up-to-date versions. Therefore, the follow browsers are supported:
+Vault currently supports all 'evergreen' browsers, as they are generally on up-to-date versions. Therefore, the following browsers are supported:
 
 - Chrome
 - Firefox


### PR DESCRIPTION
Just addressing a minor typo reported on the Vault browser support page.

:mag: [Deploy Preview](https://vault-git-fix-browser-support-doc-hashicorp.vercel.app/docs/browser-support)