### PR TITLE
Correct doc link for namespaces in API Explorer

### DIFF
--- a/ui/lib/open-api-explorer/addon/templates/components/swagger-ui.hbs
+++ b/ui/lib/open-api-explorer/addon/templates/components/swagger-ui.hbs
@@ -31,7 +31,7 @@
     <code>X-Vault-Namespace: {{R.namespace.path}}</code>. You can also use
     <code>{{R.namespace.path}}</code>
     as an API prefix. See
-    <DocLink @path="/api/overview#namespaces">docs</DocLink>
+    <DocLink @path="/api-docs#namespaces">docs</DocLink>
     for examples.
   </NamespaceReminder>
   <div id="{{this.elementId}}-swagger" class="swagger-ember"></div>


### PR DESCRIPTION
This updates a link in the API explorer that currently 404s.

Old link: 
https://www.vaultproject.io/api/overview#namespaces

New link:
https://www.vaultproject.io/api-docs#namespaces
