### PR TITLE
docs/k8s: Updates for vault-k8s 0.14.2 and vault-helm 0.19.0

### DIFF
--- a/website/content/docs/platform/k8s/csi/installation.mdx
+++ b/website/content/docs/platform/k8s/csi/installation.mdx
@@ -8,9 +8,9 @@ description: The Vault CSI Provider can be installed using Vault Helm.
 
 ## Prerequisites
 
-* Kubernetes 1.16+ for both the master and worker nodes (Linux-only)
-* [Secrets store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html) installed
-* `TokenRequest` endpoint available, which requires setting the flags
+- Kubernetes 1.16+ for both the master and worker nodes (Linux-only)
+- [Secrets store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html) installed
+- `TokenRequest` endpoint available, which requires setting the flags
   `--service-account-signing-key-file` and `--service-account-issuer` for
   `kube-apiserver`. Set by default from 1.20+ and earlier in most managed services.
 
@@ -24,14 +24,7 @@ HashiCorp helm repository and ensure you have access to the chart:
 
 ~> Vault CSI Provider Helm installation requires Vault Helm 0.10.0+.
 
-```shell-session
-$ helm repo add hashicorp https://helm.releases.hashicorp.com
-"hashicorp" has been added to your repositories
-
-$ helm search repo hashicorp/vault
-NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.10.0       	1.7.0      	Official HashiCorp Vault Chart
-```
+@include 'helm/repo.mdx'
 
 Then install the chart and enable the CSI feature by setting the
 `csi.enabled` value to `true`:

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -230,6 +230,29 @@ and consider if they're appropriate for your deployment.
 
   - `port` (`int: 8080`) - Configures the port the Vault Agent Injector listens on.
 
+  - `podDisruptionBudget` (`dictionary: {}`) - A disruption budget limits the number of pods of a replicated application that are down simultaneously from voluntary disruptions.
+
+    ```yaml
+    podDisruptionBudget:
+      maxUnavailable: 1
+    ```
+
+  - `strategy` (`dictionary: {}`) - Strategy for updating the deployment. This can be a multi-line string or a YAML map.
+
+    ```yaml
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    # or
+    strategy: |
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    ```
+
 - `server` - Values that configure running a Vault server within Kubernetes.
 
   - `enabled` (`boolean: true`) - When set to `true`, the Vault server will be created.
@@ -341,6 +364,8 @@ and consider if they're appropriate for your deployment.
 
     - `host` (`string: "chart-example.local"`) - Sets the hostname for the Route.
 
+    - `tls` (`dictionary: {termination: passthrough}`) - TLS config that will be passed directly to the route's TLS config, which can be used to configure other termination methods that terminate TLS at the router.
+
   - `tls` - Values that configure the Ingress TLS rules.
 
     - `hosts` (`array: []`): List of the hosts defined in the Common Name of the TLS Certificate.
@@ -411,6 +436,8 @@ and consider if they're appropriate for your deployment.
       successThreshold: 1
       timeoutSeconds: 3
     ```
+
+  - `terminationGracePeriodSeconds` (`int: 10`) - Optional duration in seconds the pod needs to terminate gracefully. See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 
   - `preStopSleepSeconds` (`int: 5`) - Used to set the sleep time during the preStop step.
 
@@ -857,7 +884,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault-csi-provider"`) - The name of the Docker image for the Vault CSI Provider.
 
-    - `tag` (`string: "0.3.0"`) - The tag of the Docker image for the Vault CSI Provider.. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your CSI provider.
+    - `tag` (`string: "0.4.0"`) - The tag of the Docker image for the Vault CSI Provider.. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your CSI provider.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists locally.
 
@@ -929,6 +956,8 @@ and consider if they're appropriate for your deployment.
       ```
 
     - `tolerations` (`array: []`) - Toleration Settings for CSI pods. This should be a multi-line string or YAML matching the Toleration array in a PodSpec.
+
+  - `priorityClassName` (`string: ""`) - Priority class for CSI Provider pods
 
   - `serviceAccount` - Values that configure the Vault CSI Provider's serviceaccount.
 

--- a/website/content/docs/platform/k8s/helm/configuration.mdx
+++ b/website/content/docs/platform/k8s/helm/configuration.mdx
@@ -71,7 +71,7 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault-k8s"`) - The name of the Docker image for Vault Agent Injector.
 
-    - `tag` (`string: "0.14.1"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "0.14.2"`) - The tag of the Docker image for the Vault Agent Injector. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
@@ -79,16 +79,16 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault"`) - The name of the Docker image for the Vault Agent sidecar. This should be set to the official Vault Docker image.
 
-    - `tag` (`string: "1.9.0"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
+    - `tag` (`string: "1.9.2"`) - The tag of the Vault Docker image to use for the Vault Agent Sidecar. **Vault 1.3.1+ is required by the admission controller**.
 
   - `agentDefaults` - Values that configure the injected Vault Agent containers default values.
 
     - `cpuLimit` (`string: "500m"`) - The default CPU limit for injected Vault Agent containers.
-    
+
     - `cpuRequest` (`string: "250m"`) - The default CPU request for injected Vault Agent containers.
 
     - `memLimit` (`string: "128Mi"`) - The default memory limit for injected Vault Agent containers.
-    
+
     - `memRequest` (`string: "64Mi"`) - The default memory request for injected Vault Agent containers.
 
     - `template` (`string: "map"`) - The default template type for rendered secrets if no custom templates are defined.
@@ -224,7 +224,8 @@ and consider if they're appropriate for your deployment.
         "sample/annotation1": "foo"
         "sample/annotation2": "bar"
       ```
-  - `hostNetwork` (`boolean: false`) - When set to true, configures the Vault Agent Injector to run on the host network. This is useful 
+
+  - `hostNetwork` (`boolean: false`) - When set to true, configures the Vault Agent Injector to run on the host network. This is useful
     when alternative cluster networking is used.
 
   - `port` (`int: 8080`) - Configures the port the Vault Agent Injector listens on.
@@ -243,40 +244,40 @@ and consider if they're appropriate for your deployment.
 
     - `repository` (`string: "hashicorp/vault"`) - The name of the Docker image for the containers running Vault.
 
-    - `tag` (`string: "1.9.0"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
+    - `tag` (`string: "1.9.2"`) - The tag of the Docker image for the containers running Vault. **This should be pinned to a specific version when running in production.** Otherwise, other changes to the chart may inadvertently upgrade your admission controller.
 
     - `pullPolicy` (`string: "IfNotPresent"`) - The pull policy for container images. The default pull policy is `IfNotPresent` which causes the Kubelet to skip pulling an image if it already exists.
 
   - `updateStrategyType` (`string: "OnDelete"`) - Configure the [Update Strategy Type](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) for the StatefulSet.
 
-  - `logLevel` (`string: ""`) - Configures the Vault server logging verbosity. If set this will override values defined in the Vault configuration file. 
+  - `logLevel` (`string: ""`) - Configures the Vault server logging verbosity. If set this will override values defined in the Vault configuration file.
     Supported log levels include: `trace`, `debug`, `info`, `warn`, `error`.
 
-  - `logFormat` (`string: ""`) - Configures the Vault server logging format. If set this will override values defined in the Vault configuration file. 
+  - `logFormat` (`string: ""`) - Configures the Vault server logging format. If set this will override values defined in the Vault configuration file.
     Supported log formats include: `standard`, `json`.
 
   - `resources` (`dictionary: {}`) - The resource requests and limits (CPU, memory, etc.) for each container of the server. This should be a YAML dictionary of a Kubernetes [ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcerequirements-v1-core) object. If this isn't specified, then the pods won't request any specific amount of resources, which limits the ability for Kubernetes to make efficient use of compute resources. **Setting this is highly recommended.**
 
-      ```yaml
-      resources:
-        requests:
-          memory: '10Gi'
-        limits:
-          memory: '10Gi'
-      ```
+    ```yaml
+    resources:
+      requests:
+        memory: '10Gi'
+      limits:
+        memory: '10Gi'
+    ```
 
   - `ingress` - Values that configure Ingress services for Vault.
 
     ~> If deploying on OpenShift, these ingress settings are ignored. Use the [`route`](#route) configuration to expose Vault on OpenShift. <br/> <br/>
-      If [`ha`](#ha) is enabled the Ingress will point to the active vault server via the `active` Service. This requires vault 1.4+ and [service_registration](https://www.vaultproject.io/docs/configuration/service-registration/kubernetes) to be set in the vault config.
+    If [`ha`](#ha) is enabled the Ingress will point to the active vault server via the `active` Service. This requires vault 1.4+ and [service_registration](https://www.vaultproject.io/docs/configuration/service-registration/kubernetes) to be set in the vault config.
 
     - `enabled` (`boolean: false`) - When set to `true`, an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) service will be created.
 
     - `labels` (`dictionary: {}`) - Labels for the ingress service.
 
     - `annotations` (`dictionary: {}`) - This value defines additional annotations to
-       add to the Ingress service. This can either be YAML or a YAML-formatted
-       multi-line templated string.
+      add to the Ingress service. This can either be YAML or a YAML-formatted
+      multi-line templated string.
 
       ```yaml
       annotations:
@@ -296,7 +297,7 @@ and consider if they're appropriate for your deployment.
       This is useful when working with annotation based services.
 
       ```yaml
-      extraPaths: 
+      extraPaths:
         - path: /*
           backend:
             service:
@@ -926,9 +927,8 @@ and consider if they're appropriate for your deployment.
       annotations: |
         foo: bar
       ```
-    
-    - `tolerations` (`array: []`) - Toleration Settings for CSI pods. This should be a multi-line string or YAML matching the Toleration array in a PodSpec.
 
+    - `tolerations` (`array: []`) - Toleration Settings for CSI pods. This should be a multi-line string or YAML matching the Toleration array in a PodSpec.
 
   - `serviceAccount` - Values that configure the Vault CSI Provider's serviceaccount.
 

--- a/website/content/docs/platform/k8s/helm/enterprise.mdx
+++ b/website/content/docs/platform/k8s/helm/enterprise.mdx
@@ -31,7 +31,7 @@ In your chart overrides, set the values of [`server.image`](/docs/platform/k8s/h
 server:
   image:
     repository: hashicorp/vault-enterprise
-    tag: 1.9.0_ent
+    tag: 1.9.2-ent
   enterpriseLicense:
     secretName: vault-ent-license
 ```
@@ -81,7 +81,7 @@ kubectl exec vault-0 -- vault license inspect
 kubectl exec vault-0 -- vault write -f sys/config/reload/license
 ```
 
-  Or you may issue an HUP signal directly to Vault:
+Or you may issue an HUP signal directly to Vault:
 
 ```shell
 kubectl exec vault-0 -- pkill -HUP vault

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-dr-with-raft.mdx
@@ -23,7 +23,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.9.0_ent' \
+  --set='server.image.tag=1.9.2-ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -75,7 +75,7 @@ disaster recovery replication.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.9.0_ent' \
+  --set='server.image.tag=1.9.2-ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-perf-with-raft.mdx
@@ -23,7 +23,7 @@ First, create the primary cluster:
 ```shell
 helm install vault-primary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.9.0_ent' \
+  --set='server.image.tag=1.9.2-ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```
@@ -74,7 +74,7 @@ With the primary cluster created, next create a secondary cluster.
 ```shell
 helm install vault-secondary hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.9.0_ent' \
+  --set='server.image.tag=1.9.2-ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
@@ -15,7 +15,7 @@ Integrated storage (raft) can be enabled using the `server.ha.raft.enabled` valu
 ```shell
 helm install vault hashicorp/vault \
   --set='server.image.repository=hashicorp/vault-enterprise' \
-  --set='server.image.tag=1.9.0_ent' \
+  --set='server.image.tag=1.9.2-ent' \
   --set='server.ha.enabled=true' \
   --set='server.ha.raft.enabled=true'
 ```

--- a/website/content/docs/platform/k8s/helm/index.mdx
+++ b/website/content/docs/platform/k8s/helm/index.mdx
@@ -29,14 +29,7 @@ Helm](https://learn.hashicorp.com/tutorials/vault/kubernetes-minikube) guide.
 To use the Helm chart, add the Hashicorp helm repository and check that you have
 access to the chart:
 
-```shell-session
-$ helm repo add hashicorp https://helm.releases.hashicorp.com
-"hashicorp" has been added to your repositories
-
-$ helm search repo hashicorp/vault
-NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.18.0       	1.9.0      	Official HashiCorp Vault Chart
-```
+@include 'helm/repo.mdx'
 
 -> **Important:** The Helm chart is new and under significant development.
 Please always run Helm with `--dry-run` before any install or upgrade to verify
@@ -53,22 +46,7 @@ $ helm install vault hashicorp/vault
 
 Installing a specific version of the chart.
 
-```sh
-# List the available releases
-$ helm search repo hashicorp/vault -l
-NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.18.0       	1.9.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.17.1       	1.8.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.17.0       	1.8.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.16.1       	1.8.3      	Official HashiCorp Vault Chart
-hashicorp/vault	0.16.0       	1.8.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.15.0       	1.8.1      	Official HashiCorp Vault Chart
-hashicorp/vault	0.14.0       	1.8.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
-
-# Install version 0.18.0
-$ helm install vault hashicorp/vault --version 0.18.0
-```
+@include 'helm/install.mdx'
 
 ~> **Security Warning:** By default, the chart runs in standalone mode. This
 mode uses a single Vault server with a file storage backend. This is a less

--- a/website/content/docs/platform/k8s/helm/openshift.mdx
+++ b/website/content/docs/platform/k8s/helm/openshift.mdx
@@ -63,14 +63,7 @@ checklist](/docs/platform/k8s/helm/run#architecture).
 To use the Helm chart, add the Hashicorp helm repository and check that you have
 access to the chart:
 
-```shell-session
-$ helm repo add hashicorp https://helm.releases.hashicorp.com
-"hashicorp" has been added to your repositories
-
-$ helm search repo hashicorp/vault
-NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.18.0       	1.9.0      	Official HashiCorp Vault Chart
-```
+@include 'helm/repo.mdx'
 
 -> **Important:** The Helm chart is new and under significant development.
 Please always run Helm with `--dry-run` before any install or upgrade to verify
@@ -84,22 +77,7 @@ $ helm install vault hashicorp/vault
 
 Or install a specific version of the chart.
 
-```shell-session
-# List the available releases
-$ helm search repo hashicorp/vault -l
-NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.18.0       	1.9.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.17.1       	1.8.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.17.0       	1.8.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.16.1       	1.8.3      	Official HashiCorp Vault Chart
-hashicorp/vault	0.16.0       	1.8.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.15.0       	1.8.1      	Official HashiCorp Vault Chart
-hashicorp/vault	0.14.0       	1.8.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
-
-# Install version 0.18.0
-$ helm install vault hashicorp/vault --version 0.18.0
-```
+`@include 'helm/install.mdx'
 
 The `helm install` command accepts parameters to override default configuration
 values inline or defined in a file. For all OpenShift deployments, `global.openshift`

--- a/website/content/docs/platform/k8s/helm/openshift.mdx
+++ b/website/content/docs/platform/k8s/helm/openshift.mdx
@@ -77,7 +77,7 @@ $ helm install vault hashicorp/vault
 
 Or install a specific version of the chart.
 
-`@include 'helm/install.mdx'
+@include 'helm/install.mdx'
 
 The `helm install` command accepts parameters to override default configuration
 values inline or defined in a file. For all OpenShift deployments, `global.openshift`

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -47,14 +47,7 @@ Helm](https://learn.hashicorp.com/vault/getting-started-k8s/minikube) guide.
 To use the Helm chart, add the Hashicorp helm repository and check that you have
 access to the chart:
 
-```shell-session
-$ helm repo add hashicorp https://helm.releases.hashicorp.com
-"hashicorp" has been added to your repositories
-
-$ helm search repo hashicorp/vault
-NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.18.0       	1.9.0      	Official HashiCorp Vault Chart
-```
+@include 'helm/repo.mdx'
 
 -> **Important:** The Helm chart is new and under significant development.
 Please always run Helm with `--dry-run` before any install or upgrade to verify
@@ -68,22 +61,7 @@ $ helm install vault hashicorp/vault
 
 Or install a specific version of the chart.
 
-```sh
-# List the available releases
-$ helm search repo hashicorp/vault -l
-NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.18.0       	1.9.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.17.1       	1.8.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.17.0       	1.8.4      	Official HashiCorp Vault Chart
-hashicorp/vault	0.16.1       	1.8.3      	Official HashiCorp Vault Chart
-hashicorp/vault	0.16.0       	1.8.2      	Official HashiCorp Vault Chart
-hashicorp/vault	0.15.0       	1.8.1      	Official HashiCorp Vault Chart
-hashicorp/vault	0.14.0       	1.8.0      	Official HashiCorp Vault Chart
-hashicorp/vault	0.13.0       	1.7.3      	Official HashiCorp Vault Chart
-
-# Install version 0.17.0
-$ helm install vault hashicorp/vault --version 0.17.0
-```
+`@include 'helm/install.mdx'
 
 The `helm install` command accepts parameters to override default configuration
 values inline or defined in a file.

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -61,7 +61,7 @@ $ helm install vault hashicorp/vault
 
 Or install a specific version of the chart.
 
-`@include 'helm/install.mdx'
+@include 'helm/install.mdx'
 
 The `helm install` command accepts parameters to override default configuration
 values inline or defined in a file.

--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -28,7 +28,7 @@ them, optional commands to run, etc.
 
 - `vault.hashicorp.com/agent-image` - name of the Vault docker image to use. This
   value overrides the default image configured in the controller and is usually
-  not needed. Defaults to `hashicorp/vault:1.9.0`.
+  not needed. Defaults to `hashicorp/vault:1.9.2`.
 
 - `vault.hashicorp.com/agent-init-first` - configures the pod to run the Vault Agent
   init container first if `true` (last if `false`). This is useful when other init

--- a/website/content/docs/platform/k8s/injector/installation.mdx
+++ b/website/content/docs/platform/k8s/injector/installation.mdx
@@ -14,14 +14,7 @@ install and configure the Agent Injector in Kubernetes.
 To install a new instance of Vault and the Vault Agent Injector, first add the
 Hashicorp helm repository and ensure you have access to the chart:
 
-```shell-session
-$ helm repo add hashicorp https://helm.releases.hashicorp.com
-"hashicorp" has been added to your repositories
-
-$ helm search repo hashicorp/vault
-NAME           	CHART VERSION	APP VERSION	DESCRIPTION
-hashicorp/vault	0.18.0       	1.9.0      	Official HashiCorp Vault Chart
-```
+@include 'helm/repo.mdx'
 
 Then install the chart and enable the injection feature by setting the
 `injector.enabled` value to `true`:
@@ -46,9 +39,9 @@ defaults to supporting TLS 1.2 and above, and supports configuring the minimum
 supported TLS version and list of enabled cipher suites. These can be set via
 the following environment variables:
 
-| Environment variable | Description |
-| -------------------- | ----------- |
-| `AGENT_INJECT_TLS_MIN_VERSION` | Minimum supported version of TLS. Defaults to **tls12**. Accepted values are `tls10`, `tls11`, `tls12`, or `tls13`. |
+| Environment variable             | Description                                                                                                                    |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `AGENT_INJECT_TLS_MIN_VERSION`   | Minimum supported version of TLS. Defaults to **tls12**. Accepted values are `tls10`, `tls11`, `tls12`, or `tls13`.            |
 | `AGENT_INJECT_TLS_CIPHER_SUITES` | Comma-separated list of enabled [cipher suites][tls-suites] for TLS 1.0-1.2. (Cipher suites are not configurable for TLS 1.3.) |
 
 ~> **Warning**: TLS 1.1 and lower are generally considered insecure.

--- a/website/content/partials/helm/install.mdx
+++ b/website/content/partials/helm/install.mdx
@@ -1,0 +1,16 @@
+```sh
+# List the available releases
+$ helm search repo hashicorp/vault -l
+NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.19.0       	1.9.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.18.0       	1.9.0      	Official HashiCorp Vault Chart
+hashicorp/vault	0.17.1       	1.8.4      	Official HashiCorp Vault Chart
+hashicorp/vault	0.17.0       	1.8.4      	Official HashiCorp Vault Chart
+hashicorp/vault	0.16.1       	1.8.3      	Official HashiCorp Vault Chart
+hashicorp/vault	0.16.0       	1.8.2      	Official HashiCorp Vault Chart
+hashicorp/vault	0.15.0       	1.8.1      	Official HashiCorp Vault Chart
+hashicorp/vault	0.14.0       	1.8.0      	Official HashiCorp Vault Chart
+
+# Install version 0.19.0
+$ helm install vault hashicorp/vault --version 0.19.0
+```

--- a/website/content/partials/helm/repo.mdx
+++ b/website/content/partials/helm/repo.mdx
@@ -1,0 +1,8 @@
+```shell-session
+$ helm repo add hashicorp https://helm.releases.hashicorp.com
+"hashicorp" has been added to your repositories
+
+$ helm search repo hashicorp/vault
+NAME           	CHART VERSION	APP VERSION	DESCRIPTION
+hashicorp/vault	0.19.0       	1.9.2      	Official HashiCorp Vault Chart
+```


### PR DESCRIPTION
Updating the doc for the latest releases of Vault K8s and Vault Helm:

https://github.com/hashicorp/vault-k8s/blob/main/CHANGELOG.md#0142-january-19-2022
https://github.com/hashicorp/vault-helm/blob/main/CHANGELOG.md#0190-january-20th-2022

Something a little different this time is the addition of partials for the helm commands that are duplicated across the docs. Now they are included from `website/content/partials/helm/{install,repo}.mdx`.