### PR TITLE
Raft/fix raft telemetry metric unit

### DIFF
--- a/changelog/13749.txt
+++ b/changelog/13749.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-physical/raft: Fix units being reported for bolt metrics from nanoseconds to milliseconds
+storage/raft: Units for bolt metrics now given in milliseconds instead of nanoseconds
 ```

--- a/changelog/13749.txt
+++ b/changelog/13749.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+physical/raft: Fix units being reported for bolt metrics from nanoseconds to milliseconds
+```

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -509,12 +509,12 @@ func (b *RaftBackend) collectMetricsWithStats(stats bolt.Stats, sink *metricsuti
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "node", "count"}, float32(txstats.NodeCount), labels)
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "node", "dereferences"}, float32(txstats.NodeDeref), labels)
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "rebalance", "count"}, float32(txstats.Rebalance), labels)
-	sink.AddSampleWithLabels([]string{"raft_storage", "bolt", "rebalance", "time"}, float32(txstats.RebalanceTime), labels)
+	sink.AddSampleWithLabels([]string{"raft_storage", "bolt", "rebalance", "time"}, float32(txstats.RebalanceTime.Milliseconds()), labels)
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "split", "count"}, float32(txstats.Split), labels)
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "spill", "count"}, float32(txstats.Spill), labels)
-	sink.AddSampleWithLabels([]string{"raft_storage", "bolt", "spill", "time"}, float32(txstats.SpillTime), labels)
+	sink.AddSampleWithLabels([]string{"raft_storage", "bolt", "spill", "time"}, float32(txstats.SpillTime.Milliseconds()), labels)
 	sink.SetGaugeWithLabels([]string{"raft_storage", "bolt", "write", "count"}, float32(txstats.Write), labels)
-	sink.AddSampleWithLabels([]string{"raft_storage", "bolt", "write", "time"}, float32(txstats.WriteTime), labels)
+	sink.AddSampleWithLabels([]string{"raft_storage", "bolt", "write", "time"}, float32(txstats.WriteTime.Milliseconds()), labels)
 }
 
 // RaftServer has information about a server in the Raft configuration


### PR DESCRIPTION
This PR is to update the Units being reported for the following Telemetry Metrics from Nanoseconds to Milliseconds to match documentation:
1. vault.raft_storage.bolt.rebalance.time
2. vault.raft_storage.bolt.spill.time
3. vault.raft_storage.bolt.write.time
