### PR TITLE
PKI - Allow performance secondaries to generate and store certificates locally to them

### DIFF
--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -189,7 +189,8 @@ func (b *backend) pathSignVerbatim(ctx context.Context, req *logical.Request, da
 
 func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, data *framework.FieldData, role *roleEntry, useCSR, useCSRValues bool) (*logical.Response, error) {
 	// If storing the certificate and on a performance standby, forward this request on to the primary
-	if !role.NoStore && b.System().ReplicationState().HasState(consts.ReplicationPerformanceStandby|consts.ReplicationPerformanceSecondary) {
+	// Allow performance secondaries to generate and store certificates locally to them.
+	if !role.NoStore && b.System().ReplicationState().HasState(consts.ReplicationPerformanceStandby) {
 		return nil, logical.ErrReadOnly
 	}
 

--- a/changelog/13759.txt
+++ b/changelog/13759.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fix regression causing performance secondaries to forward certificate generation to the primary.
+```


### PR DESCRIPTION
Fix was made on ENT but should be on OSS as well.