### PR TITLE
[#13750] Allow policies to control sub-fields of requests

### DIFF
--- a/vault/acl.go
+++ b/vault/acl.go
@@ -447,7 +447,23 @@ CHECK:
 	// parameters.
 	if op == logical.ReadOperation || op == logical.UpdateOperation || op == logical.CreateOperation || op == logical.PatchOperation {
 		for _, parameter := range permissions.RequiredParameters {
-			if _, ok := req.Data[strings.ToLower(parameter)]; !ok {
+			if !strings.Contains(parameter, ".") {
+				if _, ok := req.Data[strings.ToLower(parameter)]; !ok {
+					return
+				}
+				continue
+			}
+
+			parameterParts := strings.Split(strings.ToLower(parameter), ".")
+			data := req.Data
+			for _, part := range parameterParts[:len(parameterParts)-1] {
+				rawData, ok := data[part]
+				if !ok || reflect.TypeOf(rawData).String() != "map[string]interface {}" {
+					return
+				}
+				data = rawData.(map[string]interface{})
+			}
+			if _, ok := data[parameterParts[len(parameterParts)-1]]; !ok {
 				return
 			}
 		}
@@ -713,6 +729,7 @@ func valueInParameterList(v interface{}, list []interface{}) bool {
 }
 
 func valueInSlice(v interface{}, list []interface{}) bool {
+	var nestedGlobs []NestedParameter
 	for _, el := range list {
 		if el == nil || v == nil {
 			// It doesn't seem possible to set up a nil entry in the list, but it is possible
@@ -728,7 +745,66 @@ func valueInSlice(v interface{}, list []interface{}) bool {
 			if strutil.GlobbedStringsMatch(item, val) {
 				return true
 			}
+		} else if reflect.TypeOf(el).String() == "vault.NestedParameter" && reflect.TypeOf(v).String() == "map[string]interface {}" {
+			item := el.(NestedParameter)
+			val := v.(map[string]interface{})
+			if strings.HasSuffix(item.Key, "*") {
+				nestedGlobs = append(nestedGlobs, item)
+				continue
+			}
+
+			itemSections := strings.Split(item.Key, ".")
+			var vsec interface{}
+			ok := true
+			if len(itemSections) > 1 {
+				for _, name := range itemSections[:len(itemSections)-1] {
+					if vsec, ok = val[name]; !ok {
+						break
+					}
+					if reflect.TypeOf(vsec).String() != "map[string]interface {}" {
+						ok = false
+						break
+					}
+					val = vsec.(map[string]interface{})
+				}
+			}
+			vsec, ok = val[itemSections[len(itemSections)-1]]
+			if !ok {
+				continue
+			}
+			return ok && valueInParameterList(vsec, item.Parameter)
 		} else if reflect.DeepEqual(el, v) {
+			return true
+		}
+	}
+
+	// handle nested globs after normal keys
+	// to give them higher priority
+	for _, item := range nestedGlobs {
+		val := v.(map[string]interface{})
+		itemSections := strings.Split(item.Key, ".")
+		var vsec interface{}
+		ok := true
+		if len(itemSections) > 1 {
+			for _, name := range itemSections[:len(itemSections)-1] {
+				if vsec, ok = val[name]; !ok {
+					break
+				}
+				if reflect.TypeOf(vsec).String() != "map[string]interface {}" {
+					ok = false
+					break
+				}
+				val = vsec.(map[string]interface{})
+			}
+		}
+		if !ok {
+			continue
+		}
+		allIncluded := true
+		for _, v := range val {
+			allIncluded = allIncluded && valueInParameterList(v, item.Parameter)
+		}
+		if allIncluded {
 			return true
 		}
 	}

--- a/vault/acl_test.go
+++ b/vault/acl_test.go
@@ -622,6 +622,100 @@ func testACLValuePermissions(t *testing.T, ns *namespace.Namespace) {
 	}
 }
 
+func TestACL_NestedPermissions(t *testing.T) {
+	t.Run("root-ns", func(t *testing.T) {
+		t.Parallel()
+		testACLNestedPermissions(t, namespace.RootNamespace)
+	})
+}
+
+func testACLNestedPermissions(t *testing.T, ns *namespace.Namespace) {
+	policy, err := ParseACLPolicy(ns, nestedPolicy)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	ctx := namespace.ContextWithNamespace(context.Background(), ns)
+	acl, err := NewACL(ctx, []*Policy{policy})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	toperations := []logical.Operation{
+		logical.UpdateOperation,
+		logical.CreateOperation,
+	}
+
+	type tcase struct {
+		request map[string]interface{}
+		allowed bool
+	}
+
+	tCases := map[string]map[string]tcase{
+		"allow": {
+			"emptyReq":                       {map[string]interface{}{}, true},
+			"globbedParam":                   {map[string]interface{}{"kvstar": map[string]interface{}{"any": "vals"}}, true},
+			"matchParam":                     {map[string]interface{}{"kv": map[string]interface{}{"key1": "one"}}, true},
+			"matchNestedParam":               {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"some": map[string]interface{}{"key": "nested"}}}}, true},
+			"noMatchNestedParam":             {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"some": map[string]interface{}{"key": "invalid"}}}}, false},
+			"matchNestedGlobParam":           {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"other": map[string]interface{}{"key1": "neststar", "key2": "neststar"}}}}, true},
+			"matchNestedParamOverrideGlob":   {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"other": map[string]interface{}{"key": "val"}}}}, true},
+			"noMatchNestedParamOverrideGlob": {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"other": map[string]interface{}{"key": "neststar"}}}}, false},
+			"noMatchNestedGlobParam":         {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"other": map[string]interface{}{"key": "invalid", "key2": "nested"}}}}, false},
+			"noMatchParamValue":              {map[string]interface{}{"kv": map[string]interface{}{"key1": "uno"}}, false},
+			"unknownParam":                   {map[string]interface{}{"kv": map[string]interface{}{"key2": "two"}}, false},
+		},
+		"deny": {
+			"emptyReq":                     {map[string]interface{}{}, true},
+			"globbedParam":                 {map[string]interface{}{"kvstar": map[string]interface{}{"any": "vals"}}, false},
+			"matchParam":                   {map[string]interface{}{"kv": map[string]interface{}{"key1": "one"}}, false},
+			"matchNestedParam":             {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"some": map[string]interface{}{"key": "nested"}}}}, false},
+			"noMatchNestedParam":           {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"some": map[string]interface{}{"key": "invalid"}}}}, true},
+			"matchNestedGlobParam":         {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"other": map[string]interface{}{"key1": "neststar", "key2": "neststar"}}}}, false},
+			"matchNestedParamOverrideGlob": {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"other": map[string]interface{}{"key": "val"}}}}, false},
+			"noMatchNestedGlobParam":       {map[string]interface{}{"kv": map[string]interface{}{"nest": map[string]interface{}{"other": map[string]interface{}{"key": "invalid", "key2": "nested"}}}}, true},
+			"noMatchParamValue":            {map[string]interface{}{"kv": map[string]interface{}{"key1": "uno"}}, true},
+			"unknownParam":                 {map[string]interface{}{"kv": map[string]interface{}{"key2": "two"}}, true},
+		},
+		"require": {
+			"emptyReq":  {map[string]interface{}{}, false},
+			"oneParam":  {map[string]interface{}{"kv": map[string]interface{}{"key3": "val"}}, false},
+			"allParams": {map[string]interface{}{"kv": map[string]interface{}{"key3": "val", "nest": map[string]interface{}{"some": "val"}}}, true},
+		},
+		"combined": {
+			"emptyReq":                   {map[string]interface{}{}, false},
+			"missingRequired":            {map[string]interface{}{"kvstar": "val"}, false},
+			"denyOverridesAllowExplicit": {map[string]interface{}{"kv": map[string]interface{}{"key3": "val", "key1": "one"}}, false},
+			"denyOverridesAllowGlob":     {map[string]interface{}{"kv": map[string]interface{}{"key3": "val"}, "kvstar": map[string]interface{}{"nested": map[string]interface{}{"key": "val"}}}, false},
+			"validRequest":               {map[string]interface{}{"kv": map[string]interface{}{"key3": "val"}, "kvstar": map[string]interface{}{"nested": map[string]interface{}{"allowed": "val"}}}, true},
+		},
+	}
+
+	for path, cases := range tCases {
+		t.Run(path, func(t *testing.T) {
+			for name, tc := range cases {
+				t.Run(name, func(t *testing.T) {
+					request := &logical.Request{
+						Path: path,
+						Data: tc.request,
+					}
+					ctx := namespace.ContextWithNamespace(context.Background(), ns)
+
+					for _, op := range toperations {
+						t.Run(string(op), func(t *testing.T) {
+							request.Operation = op
+							authResults := acl.AllowOperation(ctx, request, false)
+							if authResults.Allowed != tc.allowed {
+								t.Fatalf("bad: case %#v: %v", tc, authResults.Allowed)
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestACL_SegmentWildcardPriority(t *testing.T) {
 	ns := namespace.RootNamespace
 	ctx := namespace.ContextWithNamespace(context.Background(), ns)
@@ -1197,6 +1291,50 @@ path "test/star" {
 		"bar" = [false]
 	}
 	denied_parameters = {
+	}
+}
+`
+
+var nestedPolicy = `
+path "allow" {
+	policy = "write"
+	allowed_parameters = {
+		"kv.key1" = ["one"]
+		"kv.nest.some.key" = ["nested"]
+		"kv.nest.other.key" = ["val"]
+		"kv.nest.other.*" = ["neststar"]
+		"kvstar.*" = []
+	}
+}
+	
+path "deny" {
+	policy = "write"
+	denied_parameters = {
+		"kv.key1" = ["one"]
+		"kv.nest.some.key" = ["nested"]
+		"kv.nest.other.key" = ["val"]
+		"kv.nest.other.*" = ["neststar"]
+		"kvstar.*" = []
+	}
+}
+
+path "require" {
+	policy = "write"
+	required_parameters = ["kv.key3", "kv.nest.some"]
+}
+
+path "combined" {
+	policy = "write"
+	required_parameters = ["kv.key3"]
+	allowed_parameters = {
+		"kv.key1" = ["one"]
+		"kv.key3" = []
+		"kvstar.*" = []
+	}
+	denied_parameters = {
+		"kv.key1" = []
+		"kv.key2" = ["two"]
+		"kvstar.nested.key" = []
 	}
 }
 `

--- a/vault/policy.go
+++ b/vault/policy.go
@@ -171,6 +171,13 @@ type ACLPermissions struct {
 	ControlGroup       *ControlGroup
 }
 
+type NestedParameter struct {
+	// Key is the supplied policy key, with the
+	// first section (the parameter name) removed.
+	Key       string
+	Parameter []interface{}
+}
+
 func (p *ACLPermissions) Clone() (*ACLPermissions, error) {
 	ret := &ACLPermissions{
 		CapabilitiesBitmap: p.CapabilitiesBitmap,
@@ -403,6 +410,17 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 		if pc.AllowedParametersHCL != nil {
 			pc.Permissions.AllowedParameters = make(map[string][]interface{}, len(pc.AllowedParametersHCL))
 			for key, val := range pc.AllowedParametersHCL {
+				if idx := strings.Index(key, "."); idx > 0 {
+					if !validNestedParameter(key) {
+						return fmt.Errorf("path %q: invalid allowed parameter %q", pc.Path, key)
+					}
+					rootKey := strings.ToLower(key[:idx])
+					pc.Permissions.AllowedParameters[rootKey] = append(pc.Permissions.AllowedParameters[rootKey], NestedParameter{
+						Key:       strings.ToLower(key[idx+1:]),
+						Parameter: val,
+					})
+					continue
+				}
 				pc.Permissions.AllowedParameters[strings.ToLower(key)] = val
 			}
 		}
@@ -410,6 +428,17 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 			pc.Permissions.DeniedParameters = make(map[string][]interface{}, len(pc.DeniedParametersHCL))
 
 			for key, val := range pc.DeniedParametersHCL {
+				if idx := strings.Index(key, "."); idx > 0 {
+					if !validNestedParameter(key) {
+						return fmt.Errorf("path %q: invalid denied parameter %q", pc.Path, key)
+					}
+					rootKey := strings.ToLower(key[:idx])
+					pc.Permissions.DeniedParameters[rootKey] = append(pc.Permissions.DeniedParameters[rootKey], NestedParameter{
+						Key:       strings.ToLower(key[idx+1:]),
+						Parameter: val,
+					})
+					continue
+				}
 				pc.Permissions.DeniedParameters[strings.ToLower(key)] = val
 			}
 		}
@@ -491,6 +520,11 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 			return errors.New("max_wrapping_ttl cannot be less than min_wrapping_ttl")
 		}
 		if len(pc.RequiredParametersHCL) > 0 {
+			for _, key := range pc.RequiredParametersHCL {
+				if !validNestedParameter(key) {
+					return fmt.Errorf("path %q: invalid required parameter %q", pc.Path, key)
+				}
+			}
 			pc.Permissions.RequiredParameters = pc.RequiredParametersHCL[:]
 		}
 
@@ -500,4 +534,21 @@ func parsePaths(result *Policy, list *ast.ObjectList, performTemplating bool, en
 
 	result.Paths = paths
 	return nil
+}
+
+// validNestedParamter returns false if a nested parameters ends with a '.' or contains any glob that is not '.*'.
+// Non-nested, and valid parameters return true.
+func validNestedParameter(key string) bool {
+	if !strings.Contains(key, ".") {
+		return true
+	}
+	if strings.HasSuffix(key, ".") {
+		return false
+	}
+
+	globIdx := strings.Index(key, "*")
+	if globIdx > 0 && (globIdx != len(key)-1 || !strings.HasSuffix(key, ".*")) {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
**Summary**
Introduce a dot-delimited ('.') syntax to policy parameters to allow the application of parameter restrictions to the _contents_ of request maps. These can be applied to `allowed`, `denied`, and `required` parameters.

**Description**
The unit tests for the ACL define this behaviour in more detail, but for an overview:
- Arbitrary nesting depths are supported
  - e.g. `map.top.middle.bottom`
- Globs for the final section are supported
  - e.g. `map.top.*` will match `map.top.foo` and `map.top.bar.baz`.
- Denies override allows
  - e.g. a denied parameter of `map.*` will overrule an allow for `map.foo`.
- Behaviour of the values for nested parameters match that of "flat" parameters
  - e.g. `map.foo = ["bar", "baz*"]` will allow `bar, baz, bazza, ...`

The policy parser contains validation for the new nested parameter format.

**Approach**
Nested parameter _values_ was considered as an approach. However, using a flat, delimited key format over nested values provides more flexibility when defining constraints. Their behaviour also proved more intuitive, in particular when combining `denied_parameters` with `allowed_parameters`.

**Drawbacks**
Any existing, "flat" parameter in a policy which contains a '.' will no longer be valid. As far as I can tell, these do not exist.

Resolves #13750.