### PR TITLE
Vault documentation: Re-added missing heading

### DIFF
--- a/website/content/docs/enterprise/license/autoloading.mdx
+++ b/website/content/docs/enterprise/license/autoloading.mdx
@@ -4,27 +4,30 @@ page_title: License Autoloading
 description: An overview of license autoloading.
 ---
 
+# License Autoloading
+
 Prior to Vault 1.8, Vault Enterprise would be licensed using special binaries
 that contained embedded licenses, or via a license written into Vault storage
 using the [PUT sys/license API](/api/system/license#install-license).
 
 As of Vault 1.8 those options still exist but are deprecated, and the recommended
-mechanism for managing licenses is called License Autoloading.  New clusters are
+mechanism for managing licenses is called License Autoloading. New clusters are
 required to use the autoloading method.
 
 License Autoloading can be done using one of these mechanisms, in decreasing order
 of priority (i.e. `VAULT_LICENSE` takes precedence over `VAULT_LICENSE_PATH`, which
 takes precedence over `license_path` in config.)
-* [VAULT_LICENSE environment variable](/docs/commands#vault_license)
-* [VAULT_LICENSE_PATH environment variable](/docs/commands#vault_license_path)
-* [license_path in config](/docs/configuration#license_path)
+
+- [VAULT_LICENSE environment variable](/docs/commands#vault_license)
+- [VAULT_LICENSE_PATH environment variable](/docs/commands#vault_license_path)
+- [license_path in config](/docs/configuration#license_path)
 
 Nodes within a cluster should be consistently licensed. All nodes in a cluster
 should use autoloading, or none should. If autoloading is used, all nodes should
 use the same license string. Warnings will be written to the log when there
 are discrepancies.
 
-If autoloading is used, any existing stored license will be ignored.  The presence
+If autoloading is used, any existing stored license will be ignored. The presence
 of a stored license in conjunction with an autoloaded license will also result in
-logged warnings.  Once a migration to autoloading is completed, it is recommended to use
+logged warnings. Once a migration to autoloading is completed, it is recommended to use
 the [DELETE API](/api/system/license#delete-license) to remove the stored license.


### PR DESCRIPTION
The heading **License Autoloading** went missing. I went in and re-added it. 

:mag: [Deploy Preview](https://vault-git-missing-title-autoloading-hashicorp.vercel.app/docs/enterprise/license/autoloading)