### PR TITLE
docs: fix limits docs to reflect listener variable name

### DIFF
--- a/website/content/docs/internals/limits.mdx
+++ b/website/content/docs/internals/limits.mdx
@@ -229,7 +229,7 @@ This limit depends on the key size.
 ### Request size
 
 The maximum size of an HTTP request sent to Vault is limited by
-the `maximum_request_size` option in the [listener stanza](/docs/configuration/listener/tcp). It defaults to 32 MiB. This value, minus the overhead of
+the `max_request_size` option in the [listener stanza](/docs/configuration/listener/tcp). It defaults to 32 MiB. This value, minus the overhead of
 the HTTP request itself, places an upper bound on any Transit operation,
 and on the maximum size of any key-value secrets.
 


### PR DESCRIPTION
`max_request_size` is appears to be the correct variable name, per https://github.com/hashicorp/vault/blob/1f20ad96dc5251e9599332e769b100335a6b7260/command/server.go#L961