### PR TITLE
Fix a transit deadlock

### DIFF
--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -234,7 +234,6 @@ func (b *backend) autoRotateKeys(ctx context.Context, req *logical.Request) erro
 		err = b.rotateIfRequired(ctx, req, key, p)
 		if err != nil {
 			errs = multierror.Append(errs, err)
-			continue
 		}
 	}
 

--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -225,14 +225,14 @@ func (b *backend) autoRotateKeys(ctx context.Context, req *logical.Request) erro
 			errs = multierror.Append(errs, err)
 			continue
 		}
-		if !b.System().CachingDisabled() {
-			p.Lock(true)
-		}
 
 		// If the policy is nil, move onto the next one.
 		if p == nil {
-			p.Unlock()
 			continue
+		}
+
+		if !b.System().CachingDisabled() {
+			p.Lock(true)
 		}
 
 		// If the policy's automatic rotation interval is 0, it should not


### PR DESCRIPTION
# Summary
In introducing transit time-based key autorotation, I managed to introduce a policy deadlock scenario when transit is run with caching disabled. Calls to `LockManager.GetPolicy` will return a locked policy when caching is disabled, which is why calls to `Policy.Unlock()` won't panic when caching is enabled. During autorotation, keys are retrieved with `GetPolicy` but locking and unlocking is only performed when the key is actually rotated. This means that keys without an autorotate interval defined and keys which haven't reached their autorotation deadline at the time of checking will be permanently locked. The fix in this PR was to elevate the locking and unlocking to cover the whole loop iteration rather than only when the key is due for rotation.