### PR TITLE
website: Add Demandbase tag to consent manager

### DIFF
--- a/website/lib/consent-manager-services/index.ts
+++ b/website/lib/consent-manager-services/index.ts
@@ -9,6 +9,14 @@ const localConsentManagerServices: ConsentManagerService[] = [
     url: 'https://js.qualified.com/qualified.js?token=CWQA3q9CaEKHNF2t',
     async: true,
   },
+  {
+    name: 'Demandbase Tag',
+    description:
+      'The Demandbase tag is a tracking service to identify website visitors and measure interest on our website.',
+    category: 'Analytics',
+    url: 'https://tag.demandbase.com/960ab0a0f20fb102.min.js',
+    async: true,
+  },
 ]
 
 export default localConsentManagerServices


### PR DESCRIPTION
[:mag: Preview link](https://vault-git-nqweb-add-demandbase-consent-hashicorp.vercel.app/)

---

This PR adds a Demandbase tag to the consent manager for the Vault website.