### PR TITLE
KMS Providers

### DIFF
--- a/ui/app/adapters/keymgmt/key.js
+++ b/ui/app/adapters/keymgmt/key.js
@@ -103,8 +103,13 @@ export default class KeymgmtKeyAdapter extends ApplicationAdapter {
   }
 
   async query(store, type, query) {
-    const { backend } = query;
-    return this.ajax(this.url(backend), 'GET', {
+    const { backend, provider } = query;
+    const providerAdapter = store.adapterFor('keymgmt/provider');
+    const url = provider
+      ? `${providerAdapter.buildURL('keymgmt/provider')}/${provider}/key`
+      : this.url(backend);
+
+    return this.ajax(url, 'GET', {
       data: {
         list: true,
       },

--- a/ui/app/adapters/keymgmt/key.js
+++ b/ui/app/adapters/keymgmt/key.js
@@ -105,9 +105,7 @@ export default class KeymgmtKeyAdapter extends ApplicationAdapter {
   async query(store, type, query) {
     const { backend, provider } = query;
     const providerAdapter = store.adapterFor('keymgmt/provider');
-    const url = provider
-      ? `${providerAdapter.buildURL('keymgmt/provider')}/${provider}/key`
-      : this.url(backend);
+    const url = provider ? providerAdapter.buildKeysURL(query) : this.url(backend);
 
     return this.ajax(url, 'GET', {
       data: {

--- a/ui/app/adapters/keymgmt/provider.js
+++ b/ui/app/adapters/keymgmt/provider.js
@@ -18,6 +18,10 @@ export default class KeymgmtKeyAdapter extends ApplicationAdapter {
     }
     return url;
   }
+  buildKeysURL(query) {
+    const url = this.buildURL('keymgmt/provider', null, null, 'query', query);
+    return `${url}/${query.provider}/key`;
+  }
   async createRecord(store, { modelName }, snapshot) {
     // create uses PUT instead of POST
     const data = store.serializerFor(modelName).serialize(snapshot);

--- a/ui/app/adapters/keymgmt/provider.js
+++ b/ui/app/adapters/keymgmt/provider.js
@@ -1,0 +1,35 @@
+import ApplicationAdapter from '../application';
+import { all } from 'rsvp';
+
+export default class KeymgmtKeyAdapter extends ApplicationAdapter {
+  namespace = 'v1';
+  listPayload = { data: { list: true } };
+
+  pathForType() {
+    return 'keymgmt/kms';
+  }
+  async createRecord(store, type, snapshot) {
+    // create uses PUT instead of POST
+    const data = store.serializerFor(type.modelName).serialize(snapshot);
+    const url = `${this.buildURL(type.modelName)}/${snapshot.attr('name')}`;
+    return this.ajax(url, 'PUT', { data }).then(() => data);
+  }
+  findRecord(store, type, name) {
+    return super.findRecord(...arguments).then((resp) => {
+      resp.data = { ...resp.data, name };
+      return resp;
+    });
+  }
+  async query(store, type) {
+    return this.ajax(this.buildURL(type.modelName), 'GET', this.listPayload).then(async (resp) => {
+      // additional data is needed to fullfil the list view requirements
+      // pull in full record for listed items
+      const records = await all(resp.data.keys.map((name) => this.findRecord(store, type, name)));
+      resp.data.keys = records.map((record) => record.data);
+      return resp;
+    });
+  }
+  async queryRecord(store, type, query) {
+    return this.findRecord(store, type, query.id);
+  }
+}

--- a/ui/app/components/keymgmt/provider-edit.js
+++ b/ui/app/components/keymgmt/provider-edit.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
+import { waitFor } from '@ember/test-waiters';
 
 /**
  * @module KeymgmtKeyEdit
@@ -13,8 +14,8 @@ import { task } from 'ember-concurrency';
  * <KeymgmtProviderEdit @model={model} @mode="show" />
  * ```
  * @param {object} model - model is the data from the store
- * @param {string} [mode=show] - mode controls which view is shown on the component
- * * @param {string} [tab=details] - Options are "details" or "keys" for the show mode only
+ * @param {string} mode - mode controls which view is shown on the component - show | create |
+ * @param {string} [tab] - Options are "details" or "keys" for the show mode only
  */
 
 export default class KeymgmtKeyEdit extends Component {
@@ -23,7 +24,8 @@ export default class KeymgmtKeyEdit extends Component {
 
   constructor() {
     super(...arguments);
-    if (this.viewingKeys) {
+    // key count displayed in details tab and keys are listed in keys tab
+    if (this.args.mode === 'show') {
       this.fetchKeys.perform();
     }
   }
@@ -41,6 +43,7 @@ export default class KeymgmtKeyEdit extends Component {
   }
 
   @task
+  @waitFor
   *saveTask() {
     const { model } = this.args;
     try {
@@ -53,6 +56,7 @@ export default class KeymgmtKeyEdit extends Component {
     }
   }
   @task
+  @waitFor
   *fetchKeys(page = 1) {
     try {
       yield this.args.model.fetchKeys(page);

--- a/ui/app/components/keymgmt/provider-edit.js
+++ b/ui/app/components/keymgmt/provider-edit.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
-
+import { generateFormFieldErrors } from 'vault/utils/model-validations-helper';
 /**
  * @module KeymgmtKeyEdit
  * ProviderKeyEdit components are used to display KeyMgmt Secrets engine UI for Key items
@@ -72,18 +72,7 @@ export default class KeymgmtKeyEdit extends Component {
     if (validations.isValid) {
       this.saveTask.perform();
     } else {
-      // FormField expects validationMessages in a shape not output by ember-cp-validations
-      this.modelValidations = validations.errors.reduce(
-        (obj, e) => {
-          if (e.attribute.includes('credentials')) {
-            obj.credentials[e.attribute.split('.')[1]] = e.message;
-          } else {
-            obj[e.attribute] = e.message;
-          }
-          return obj;
-        },
-        { credentials: {} }
-      );
+      this.modelValidations = generateFormFieldErrors(validations);
     }
   }
   @action

--- a/ui/app/components/keymgmt/provider-edit.js
+++ b/ui/app/components/keymgmt/provider-edit.js
@@ -1,0 +1,104 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+
+/**
+ * @module KeymgmtKeyEdit
+ * ProviderKeyEdit components are used to display KeyMgmt Secrets engine UI for Key items
+ *
+ * @example
+ * ```js
+ * <KeymgmtProviderEdit @model={model} @mode="show" />
+ * ```
+ * @param {object} model - model is the data from the store
+ * @param {string} [mode=show] - mode controls which view is shown on the component
+ * * @param {string} [tab=details] - Options are "details" or "keys" for the show mode only
+ */
+
+export default class KeymgmtKeyEdit extends Component {
+  @service router;
+  @service flashMessages;
+
+  constructor() {
+    super(...arguments);
+    if (this.viewingKeys) {
+      this.fetchKeys.perform();
+    }
+  }
+
+  @tracked modelValidations;
+
+  get isShowing() {
+    return this.args.mode === 'show';
+  }
+  get isCreating() {
+    return this.args.mode === 'create';
+  }
+  get viewingKeys() {
+    return this.args.tab === 'keys';
+  }
+
+  @task
+  *saveTask() {
+    const { model } = this.args;
+    try {
+      yield model.save();
+      this.router.transitionTo('vault.cluster.secrets.backend.show', model.id, {
+        queryParams: { itemType: 'provider' },
+      });
+    } catch (error) {
+      this.flashMessages.danger(error.errors.join('. '));
+    }
+  }
+  @task
+  *fetchKeys(page = 1) {
+    try {
+      yield this.args.model.fetchKeys(page);
+    } catch (error) {
+      this.flashMessages.danger(error.errors.join('. '));
+    }
+  }
+
+  @action
+  async onSave(event) {
+    event.preventDefault();
+    const { validations } = await this.args.model.validate();
+    if (validations.isValid) {
+      this.saveTask.perform();
+    } else {
+      // FormField expects validationMessages in a shape not output by ember-cp-validations
+      this.modelValidations = validations.errors.reduce(
+        (obj, e) => {
+          if (e.attribute.includes('credentials')) {
+            obj.credentials[e.attribute.split('.')[1]] = e.message;
+          } else {
+            obj[e.attribute] = e.message;
+          }
+          return obj;
+        },
+        { credentials: {} }
+      );
+    }
+  }
+  @action
+  async onDelete() {
+    try {
+      const { model, root } = this.args;
+      await model.destroyRecord();
+      this.router.transitionTo(root.path, root.model, { queryParams: { tab: 'provider' } });
+    } catch (error) {
+      this.flashMessages.danger(error.errors.join('. '));
+    }
+  }
+  @action
+  async onDeleteKey(model) {
+    try {
+      await model.destroyRecord();
+      this.args.model.keys.removeObject(model);
+    } catch (error) {
+      this.flashMessages.danger(error.errors.join('. '));
+    }
+  }
+}

--- a/ui/app/components/pagination-controls.js
+++ b/ui/app/components/pagination-controls.js
@@ -1,0 +1,57 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+/**
+ * @module PaginationControls
+ * PaginationControls components are used to paginate through item lists
+ *
+ * @example
+ * ```js
+ * <PaginationControls @startPage={{1}} @total={{100}} @size={{15}} @onChange={{this.onPageChange}} />
+ * ```
+ * @param {number} total - total number of items
+ * @param {number} [startPage=1] - initial page number to select
+ * @param {number} [size=15] - number of items to display per page
+ * @param {function} onChange - callback fired on page change
+ */
+
+export default class PaginationControls extends Component {
+  @tracked page;
+
+  constructor() {
+    super(...arguments);
+    this.page = this.args.startPage || 1;
+    this.size = this.args.size || 15; // size selector may be added in future version
+  }
+
+  get totalPages() {
+    return Math.ceil(this.args.total / this.size);
+  }
+  get displayInfo() {
+    const { total } = this.args;
+    const end = this.page * this.size;
+    return `${end - this.size + 1}-${end > total ? total : end} of ${total}`;
+  }
+  get pages() {
+    // show 5 pages with 2 on either side of the current page
+    let start = this.page - 2 >= 1 ? this.page - 2 : 1;
+    const incrementer = start + 4;
+    const end = incrementer <= this.totalPages ? incrementer : this.totalPages;
+    const pageNumbers = [];
+    while (start <= end) {
+      pageNumbers.push(start);
+      start++;
+    }
+    return pageNumbers;
+  }
+  get hasMorePages() {
+    return this.pages.lastObject !== this.totalPages;
+  }
+
+  @action
+  changePage(page) {
+    this.page = page;
+    this.args.onChange(page);
+  }
+}

--- a/ui/app/controllers/vault/cluster/secrets/backend/edit.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/edit.js
@@ -3,10 +3,13 @@ import BackendCrumbMixin from 'vault/mixins/backend-crumb';
 
 export default Controller.extend(BackendCrumbMixin, {
   backendController: controller('vault.cluster.secrets.backend'),
-  queryParams: ['version'],
+  queryParams: ['version', 'itemType'],
   version: '',
+  itemType: '',
+
   reset() {
     this.set('version', '');
+    this.set('itemType', '');
   },
   actions: {
     refresh: function () {

--- a/ui/app/controllers/vault/cluster/secrets/backend/show.js
+++ b/ui/app/controllers/vault/cluster/secrets/backend/show.js
@@ -3,14 +3,16 @@ import BackendCrumbMixin from 'vault/mixins/backend-crumb';
 
 export default Controller.extend(BackendCrumbMixin, {
   backendController: controller('vault.cluster.secrets.backend'),
-  queryParams: ['tab', 'version', 'type'],
+  queryParams: ['tab', 'version', 'type', 'itemType', 'page'],
   version: '',
   tab: '',
   type: '',
+  itemType: '',
   reset() {
     this.set('tab', '');
     this.set('version', '');
     this.set('type', '');
+    this.set('itemType', '');
   },
   actions: {
     refresh: function () {

--- a/ui/app/helpers/options-for-backend.js
+++ b/ui/app/helpers/options-for-backend.js
@@ -96,10 +96,9 @@ const SECRET_BACKENDS = {
         create: 'Create key',
         editComponent: 'keymgmt/key-edit',
       },
-      /* TODO: Add this tab
       {
         name: 'provider',
-        modelPrefix: '/',
+        modelPrefix: 'provider/',
         label: 'Providers',
         searchPlaceholder: 'Filter providers',
         item: 'provider',
@@ -107,7 +106,6 @@ const SECRET_BACKENDS = {
         tab: 'provider',
         editComponent: 'keymgmt/provider-edit',
       },
-      */
     ],
   },
   transform: {

--- a/ui/app/helpers/secret-query-params.js
+++ b/ui/app/helpers/secret-query-params.js
@@ -1,13 +1,19 @@
 import { helper } from '@ember/component/helper';
 
-export function secretQueryParams([backendType, type = '']) {
-  if (backendType === 'transit') {
-    return { tab: 'actions' };
+export function secretQueryParams([backendType, type = ''], { asQueryParams }) {
+  const values = {
+    transit: { tab: 'actions' },
+    database: { type },
+    keymgmt: { itemType: type || 'key' },
+  }[backendType];
+  // format required when using LinkTo with positional params
+  if (values && asQueryParams) {
+    return {
+      isQueryParams: true,
+      values,
+    };
   }
-  if (backendType === 'database') {
-    return { type: type };
-  }
-  return;
+  return values;
 }
 
 export default helper(secretQueryParams);

--- a/ui/app/helpers/sub.js
+++ b/ui/app/helpers/sub.js
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function ([a, ...toSubtract]) {
+  return toSubtract.reduce((total, value) => total - parseInt(value, 0), a);
+});

--- a/ui/app/helpers/supported-secret-backends.js
+++ b/ui/app/helpers/supported-secret-backends.js
@@ -11,6 +11,7 @@ const SUPPORTED_SECRET_BACKENDS = [
   'transit',
   'kmip',
   'transform',
+  'keymgmt',
 ];
 
 export function supportedSecretBackends() {

--- a/ui/app/helpers/supported-secret-backends.js
+++ b/ui/app/helpers/supported-secret-backends.js
@@ -11,7 +11,6 @@ const SUPPORTED_SECRET_BACKENDS = [
   'transit',
   'kmip',
   'transform',
-  'keymgmt',
 ];
 
 export function supportedSecretBackends() {

--- a/ui/app/models/keymgmt/key.js
+++ b/ui/app/models/keymgmt/key.js
@@ -41,6 +41,8 @@ export default class KeymgmtKeyModel extends Model {
   // The following are from endpoints other than the main read one
   @attr('string') provider;
 
+  icon = 'key';
+
   get hasVersions() {
     return this.versions.length > 1;
   }

--- a/ui/app/models/keymgmt/provider.js
+++ b/ui/app/models/keymgmt/provider.js
@@ -77,7 +77,9 @@ export default class KeymgmtProviderModel extends ValidationsModel {
   get showFields() {
     const attrs = expandAttributeMeta(this, ['name', 'created', 'keyCollection']);
     attrs.splice(1, 0, { hasBlock: true, label: 'Type', value: this.typeName, icon: this.icon });
-    attrs.push({ hasBlock: true, label: 'Keys', value: this.keys.length || 'None' });
+    const l = this.keys.length;
+    const value = l ? `${l} ${l > 1 ? 'keys' : 'key'}` : 'None';
+    attrs.push({ hasBlock: true, isLink: l, label: 'Keys', value });
     return attrs;
   }
   get credentialProps() {

--- a/ui/app/models/keymgmt/provider.js
+++ b/ui/app/models/keymgmt/provider.js
@@ -1,0 +1,117 @@
+import Model, { attr } from '@ember-data/model';
+import { tracked } from '@glimmer/tracking';
+import { expandAttributeMeta } from 'vault/utils/field-to-attrs';
+import { validator, buildValidations } from 'ember-cp-validations';
+
+const CRED_PROPS = {
+  azurekeyvault: ['client_id', 'client_secret', 'tenant_id'],
+  awskms: ['access_key', 'secret_key', 'session_token', 'endpoint'],
+  gcpckms: ['service_account_file'],
+};
+const OPTIONAL_CRED_PROPS = ['session_token', 'endpoint'];
+// since we have dynamic credential attributes based on provider we need a dynamic presence validator
+// add validators for all cred props and return true for value if not associated with selected provider
+const credValidators = Object.keys(CRED_PROPS).reduce((obj, providerKey) => {
+  CRED_PROPS[providerKey].forEach((prop) => {
+    if (!OPTIONAL_CRED_PROPS.includes(prop)) {
+      obj[`credentials.${prop}`] = validator('presence', {
+        presence: true,
+        value(model) {
+          return model.credentialProps.includes(prop) ? model.credentials[prop] : true;
+        },
+      });
+    }
+  });
+  return obj;
+}, {});
+const Validations = buildValidations({
+  name: validator('presence', true),
+  keyCollection: validator('presence', true),
+  ...credValidators,
+});
+const ValidationsModel = Model.extend(Validations);
+
+export default class KeymgmtProviderModel extends ValidationsModel {
+  @attr('string', {
+    label: 'Provider name',
+    subText: 'This is the name of the provider that will be displayed in Vault. This cannot be edited later.',
+  })
+  name;
+
+  @attr('string', {
+    label: 'Type',
+    subText: 'Choose the provider type.',
+    possibleValues: ['azurekeyvault', 'awskms', 'gcpckms'],
+    defaultValue: 'azurekeyvault',
+  })
+  provider;
+
+  @attr('string', {
+    label: 'Key Vault instance name',
+    subText: 'The name of a Key Vault instance must be supplied. This cannot be edited later.',
+  })
+  keyCollection;
+
+  @attr('date') created;
+
+  idPrefix = 'provider/';
+  type = 'provider';
+
+  @tracked keys = [];
+  @tracked credentials = null; // never returned from API -- set only during create/edit
+
+  get icon() {
+    return {
+      azurekeyvault: 'azure-color',
+      awskms: 'aws-color',
+      gcpckms: 'gcp-color',
+    }[this.provider];
+  }
+  get typeName() {
+    return {
+      azurekeyvault: 'Azure Key Vault',
+      awskms: 'AWS Key Management Service',
+      gcpckms: 'Google Cloud Key Management Service',
+    }[this.provider];
+  }
+  get showFields() {
+    const attrs = expandAttributeMeta(this, ['name', 'created', 'keyCollection']);
+    attrs.splice(1, 0, { hasBlock: true, label: 'Type', value: this.typeName, icon: this.icon });
+    attrs.push({ hasBlock: true, label: 'Keys', value: this.keys.length || 'None' });
+    return attrs;
+  }
+  get credentialProps() {
+    return CRED_PROPS[this.provider];
+  }
+  get credentialFields() {
+    const [creds, fields] = this.credentialProps.reduce(
+      ([creds, fields], prop) => {
+        creds[prop] = null;
+        fields.push({ name: `credentials.${prop}`, type: 'string', options: { label: prop } });
+        return [creds, fields];
+      },
+      [{}, []]
+    );
+    this.credentials = creds;
+    return fields;
+  }
+  get createFields() {
+    return expandAttributeMeta(this, ['provider', 'name', 'keyCollection']);
+  }
+
+  async fetchKeys(page) {
+    try {
+      this.keys = await this.store.lazyPaginatedQuery('keymgmt/key', {
+        backend: 'keymgmt',
+        provider: this.name,
+        responsePath: 'data.keys',
+        page,
+      });
+    } catch (error) {
+      this.keys = [];
+      if (error.httpStatus !== 404) {
+        throw error;
+      }
+    }
+  }
+}

--- a/ui/app/models/keymgmt/provider.js
+++ b/ui/app/models/keymgmt/provider.js
@@ -32,6 +32,7 @@ const Validations = buildValidations({
 const ValidationsModel = Model.extend(Validations);
 
 export default class KeymgmtProviderModel extends ValidationsModel {
+  @attr('string') backend;
   @attr('string', {
     label: 'Provider name',
     subText: 'This is the name of the provider that will be displayed in Vault. This cannot be edited later.',

--- a/ui/app/routes/vault/cluster/secrets/backend/create-root.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create-root.js
@@ -31,7 +31,7 @@ export default EditBase.extend({
   wizard: service(),
   createModel(transition) {
     const { backend } = this.paramsFor('vault.cluster.secrets.backend');
-    let modelType = this.modelType(backend);
+    let modelType = this.modelType(backend, null, transition);
     if (modelType === 'role-ssh') {
       return this.store.createRecord(modelType, { keyType: 'ca' });
     }

--- a/ui/app/routes/vault/cluster/secrets/backend/create-root.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/create-root.js
@@ -31,7 +31,7 @@ export default EditBase.extend({
   wizard: service(),
   createModel(transition) {
     const { backend } = this.paramsFor('vault.cluster.secrets.backend');
-    let modelType = this.modelType(backend, null, transition);
+    let modelType = this.modelType(backend, null, { queryParams: transition.to.queryParams });
     if (modelType === 'role-ssh') {
       return this.store.createRecord(modelType, { keyType: 'ca' });
     }

--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -83,7 +83,7 @@ export default Route.extend({
       // secret or secret-v2
       cubbyhole: 'secret',
       kv: secretEngine.get('modelTypeForKV'),
-      keymgmt: 'keymgmt/key',
+      keymgmt: `keymgmt/${tab || 'key'}`,
       generic: secretEngine.get('modelTypeForKV'),
     };
     return types[type];

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -66,9 +66,9 @@ export default Route.extend(UnloadModelRoute, {
 
   templateName: 'vault/cluster/secrets/backend/secretEditLayout',
 
-  beforeModel() {
+  beforeModel(transition) {
     let secret = this.secretParam();
-    return this.buildModel(secret).then(() => {
+    return this.buildModel(secret, transition).then(() => {
       const parentKey = utils.parentKeyForKey(secret);
       const mode = this.routeName.split('.').pop();
       if (mode === 'edit' && utils.keyIsFolder(secret)) {
@@ -81,17 +81,16 @@ export default Route.extend(UnloadModelRoute, {
     });
   },
 
-  buildModel(secret) {
+  buildModel(secret, transition) {
     const backend = this.enginePathParam();
-
-    let modelType = this.modelType(backend, secret);
+    let modelType = this.modelType(backend, secret, transition);
     if (['secret', 'secret-v2'].includes(modelType)) {
       return resolve();
     }
     return this.pathHelp.getNewModel(modelType, backend);
   },
 
-  modelType(backend, secret) {
+  modelType(backend, secret, transition) {
     let backendModel = this.modelFor('vault.cluster.secrets.backend', backend);
     let type = backendModel.get('engineType');
     let types = {
@@ -103,7 +102,7 @@ export default Route.extend(UnloadModelRoute, {
       pki: secret && secret.startsWith('cert/') ? 'pki-certificate' : 'role-pki',
       cubbyhole: 'secret',
       kv: backendModel.get('modelTypeForKV'),
-      keymgmt: 'keymgmt/key',
+      keymgmt: `keymgmt/${transition.to.queryParams.itemType || 'key'}`,
       generic: backendModel.get('modelTypeForKV'),
     };
     return types[type];
@@ -213,10 +212,10 @@ export default Route.extend(UnloadModelRoute, {
     return secretModel;
   },
 
-  async model(params) {
+  async model(params, transition) {
     let secret = this.secretParam();
     let backend = this.enginePathParam();
-    let modelType = this.modelType(backend, secret);
+    let modelType = this.modelType(backend, secret, transition);
     let type = params.type || '';
     if (!secret) {
       secret = '\u0020';

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -66,9 +66,9 @@ export default Route.extend(UnloadModelRoute, {
 
   templateName: 'vault/cluster/secrets/backend/secretEditLayout',
 
-  beforeModel(transition) {
+  beforeModel({ to: { queryParams } }) {
     let secret = this.secretParam();
-    return this.buildModel(secret, transition).then(() => {
+    return this.buildModel(secret, queryParams).then(() => {
       const parentKey = utils.parentKeyForKey(secret);
       const mode = this.routeName.split('.').pop();
       if (mode === 'edit' && utils.keyIsFolder(secret)) {
@@ -81,16 +81,16 @@ export default Route.extend(UnloadModelRoute, {
     });
   },
 
-  buildModel(secret, transition) {
+  buildModel(secret, queryParams) {
     const backend = this.enginePathParam();
-    let modelType = this.modelType(backend, secret, transition);
+    let modelType = this.modelType(backend, secret, { queryParams });
     if (['secret', 'secret-v2'].includes(modelType)) {
       return resolve();
     }
     return this.pathHelp.getNewModel(modelType, backend);
   },
 
-  modelType(backend, secret, transition) {
+  modelType(backend, secret, options) {
     let backendModel = this.modelFor('vault.cluster.secrets.backend', backend);
     let type = backendModel.get('engineType');
     let types = {
@@ -102,7 +102,7 @@ export default Route.extend(UnloadModelRoute, {
       pki: secret && secret.startsWith('cert/') ? 'pki-certificate' : 'role-pki',
       cubbyhole: 'secret',
       kv: backendModel.get('modelTypeForKV'),
-      keymgmt: `keymgmt/${transition.to.queryParams.itemType || 'key'}`,
+      keymgmt: `keymgmt/${options.queryParams.itemType || 'key'}`,
       generic: backendModel.get('modelTypeForKV'),
     };
     return types[type];
@@ -212,10 +212,10 @@ export default Route.extend(UnloadModelRoute, {
     return secretModel;
   },
 
-  async model(params, transition) {
+  async model(params, { to: { queryParams } }) {
     let secret = this.secretParam();
     let backend = this.enginePathParam();
-    let modelType = this.modelType(backend, secret, transition);
+    let modelType = this.modelType(backend, secret, { queryParams });
     let type = params.type || '';
     if (!secret) {
       secret = '\u0020';

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -90,7 +90,7 @@ export default Route.extend(UnloadModelRoute, {
     return this.pathHelp.getNewModel(modelType, backend);
   },
 
-  modelType(backend, secret, options) {
+  modelType(backend, secret, options = {}) {
     let backendModel = this.modelFor('vault.cluster.secrets.backend', backend);
     let type = backendModel.get('engineType');
     let types = {
@@ -102,7 +102,7 @@ export default Route.extend(UnloadModelRoute, {
       pki: secret && secret.startsWith('cert/') ? 'pki-certificate' : 'role-pki',
       cubbyhole: 'secret',
       kv: backendModel.get('modelTypeForKV'),
-      keymgmt: `keymgmt/${options.queryParams.itemType || 'key'}`,
+      keymgmt: `keymgmt/${options.queryParams?.itemType || 'key'}`,
       generic: backendModel.get('modelTypeForKV'),
     };
     return types[type];

--- a/ui/app/serializers/keymgmt/provider.js
+++ b/ui/app/serializers/keymgmt/provider.js
@@ -1,0 +1,13 @@
+import ApplicationSerializer from '../application';
+
+export default class KeymgmtProviderSerializer extends ApplicationSerializer {
+  primaryKey = 'name';
+
+  serialize(snapshot) {
+    const json = super.serialize(...arguments);
+    return {
+      ...json,
+      credentials: snapshot.record.credentials,
+    };
+  }
+}

--- a/ui/app/styles/core/buttons.scss
+++ b/ui/app/styles/core/buttons.scss
@@ -41,6 +41,11 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
     min-width: auto;
     padding: 0;
   }
+  &.is-flat {
+    min-width: auto;
+    border: none;
+    box-shadow: none;
+  }
 
   @each $name, $pair in $colors {
     $color: nth($pair, 1);
@@ -96,6 +101,16 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
         &.is-active {
           background-color: transparent;
           border-color: darken($color, 10%);
+          color: darken($color, 10%);
+        }
+      }
+
+      &.is-underlined {
+        &:active,
+        &.is-active {
+          background-color: transparent;
+          border-bottom: 2px solid darken($color, 10%);
+          border-radius: unset;
           color: darken($color, 10%);
         }
       }
@@ -236,4 +251,13 @@ $button-box-shadow-standard: 0 3px 1px 0 rgba($black, 0.12);
   white-space: normal;
   padding: $size-8;
   width: 100%;
+}
+
+a.button.disabled {
+  color: $white;
+  background-color: $grey-dark;
+  opacity: 0.5;
+  border-color: transparent;
+  box-shadow: none;
+  cursor: default;
 }

--- a/ui/app/styles/core/helpers.scss
+++ b/ui/app/styles/core/helpers.scss
@@ -184,6 +184,31 @@
 .has-top-margin-xl {
   margin-top: $spacing-xl;
 }
+.has-left-margin-xxs {
+  margin-left: $spacing-xxs;
+}
+.has-left-margin-xs {
+  margin-left: $spacing-xs;
+}
+.has-left-margin-s {
+  margin-left: $spacing-s;
+}
+.has-left-margin-m {
+  margin-left: $spacing-m;
+}
+.has-left-margin-l {
+  margin-left: $spacing-l;
+}
+.has-left-margin-xl {
+  margin-left: $spacing-xl;
+}
+.has-right-margin-l {
+  margin-right: $spacing-l;
+}
+.has-border-top-light {
+  border-radius: 0;
+  border-top: 1px solid $grey-light;
+}
 .has-border-bottom-light {
   border-radius: 0;
   border-bottom: 1px solid $grey-light;

--- a/ui/app/styles/core/title.scss
+++ b/ui/app/styles/core/title.scss
@@ -11,6 +11,9 @@
     color: $black;
     text-decoration: none;
   }
+  .has-font-weight-normal {
+    font-weight: $font-weight-normal;
+  }
 }
 
 .form-section .title {

--- a/ui/app/templates/components/keymgmt/provider-edit.hbs
+++ b/ui/app/templates/components/keymgmt/provider-edit.hbs
@@ -3,7 +3,7 @@
     <KeyValueHeader @path="vault.cluster.secrets.backend.show" @mode={{@mode}} @root={{@root}} @showCurrent={{true}} />
   </p.top>
   <p.levelLeft>
-    <h1 class="title is-3" data-test-secret-header="true">
+    <h1 class="title is-3" data-test-kms-provider-header>
       {{#if this.isShowing}}
         Provider
         <span class="has-font-weight-normal">{{@model.id}}</span>
@@ -18,12 +18,12 @@
   <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
     <nav class="tabs">
       <ul>
-        <li class={{unless this.viewingKeys "is-active"}}>
+        <li class={{unless this.viewingKeys "is-active"}} data-test-kms-provider-tab="details">
           <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@model.id}} @query={{hash tab=""}}>
             Details
           </LinkTo>
         </li>
-        <li role="button" class={{if this.viewingKeys "is-active"}} {{on "click" (perform this.fetchKeys 1)}}>
+        <li role="button" class={{if this.viewingKeys "is-active"}} data-test-kms-provider-tab="keys">
           <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@model.id}} @query={{hash tab="keys"}}>
             Keys
           </LinkTo>
@@ -32,11 +32,28 @@
     </nav>
   </div>
   {{#unless this.viewingKeys}}
-    <Toolbar>
+    <Toolbar data-test-kms-provider-details-actions>
       <ToolbarActions>
-        <ConfirmAction @buttonClasses="toolbar-link" @onConfirmAction={{this.onDelete}} data-test-keymgmt-provider-delete>
-          Delete provider
-        </ConfirmAction>
+        <ToolTip @verticalPosition="above" @horizontalPosition="center" as |T|>
+          <T.Trigger data-test-tooltip-trigger>
+            <ConfirmAction
+              @buttonClasses="toolbar-link"
+              @onConfirmAction={{this.onDelete}}
+              @disabled={{@model.keys.length}}
+              data-test-kms-provider-delete={{true}}
+            >
+              Delete provider
+            </ConfirmAction>
+          </T.Trigger>
+          {{#if @model.keys.length}}
+            <T.Content class="tool-tip">
+              <div class="box" data-test-kms-provider-delete-tooltip>
+                This provider cannot be deleted until all 20 keys distributed to it are revoked. This can be done from the
+                Keys tab.
+              </div>
+            </T.Content>
+          {{/if}}
+        </ToolTip>
         <div class="toolbar-separator"></div>
         {{! Update once distribute route has been created }}
         {{! <LinkTo @route="vault.cluster.secrets.backend.kms-distribute">
@@ -48,7 +65,6 @@
           @mode="edit"
           @replace={{true}}
           @queryParams={{query-params itemType="provider"}}
-          @data-test-keymgmt-provider-edit={{true}}
         >
           Update credentials
         </ToolbarSecretLink>
@@ -62,7 +78,7 @@
         {{#each @model.createFields as |attr index|}}
           {{#if (eq index 2)}}
             <div class="has-border-top-light">
-              <h2 class="title is-5 has-top-margin-l has-bottom-margin-m">
+              <h2 class="title is-5 has-top-margin-l has-bottom-margin-m" data-test-kms-provider-config-title>
                 Provider configuration
               </h2>
             </div>
@@ -71,7 +87,7 @@
         {{/each}}
       {{/if}}
       {{#unless this.isCreating}}
-        <h2 class="title is-5" data-test-title="true">
+        <h2 class="title is-5" data-test-kms-provider-creds-title>
           New credentials
         </h2>
         <p class="sub-text has-bottom-margin-m">
@@ -88,6 +104,7 @@
           type="submit"
           disabled={{this.saveTask.isRunning}}
           class="button is-primary {{if this.saveTask.isRunning "is-loading"}}"
+          data-test-kms-provider-submit
         >
           {{if this.isCreating "Create provider" "Update"}}
         </button>
@@ -99,6 +116,7 @@
           @query={{if this.isCreating (hash tab="provider") (hash itemType="provider")}}
           @disabled={{this.saveTask.isRunning}}
           class="button"
+          data-test-kms-provider-cancel
         >
           Cancel
         </LinkTo>
@@ -145,11 +163,17 @@
     {{else}}
       {{#each @model.showFields as |attr|}}
         {{#if attr.hasBlock}}
-          <InfoTableRow @label={{attr.label}} @value={{attr.value}}>
+          <InfoTableRow @label={{attr.label}} @value={{attr.value}} data-test-kms-provider-field={{attr.name}}>
             {{#if attr.icon}}
               <Icon @name={{attr.icon}} class="icon" />
             {{/if}}
-            {{attr.value}}
+            {{#if attr.isLink}}
+              <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@model.id}} @query={{hash tab="keys"}}>
+                {{attr.value}}
+              </LinkTo>
+            {{else}}
+              {{attr.value}}
+            {{/if}}
           </InfoTableRow>
         {{else}}
           <InfoTableRow

--- a/ui/app/templates/components/keymgmt/provider-edit.hbs
+++ b/ui/app/templates/components/keymgmt/provider-edit.hbs
@@ -1,0 +1,166 @@
+<PageHeader as |p|>
+  <p.top>
+    <KeyValueHeader @path="vault.cluster.secrets.backend.show" @mode={{@mode}} @root={{@root}} @showCurrent={{true}} />
+  </p.top>
+  <p.levelLeft>
+    <h1 class="title is-3" data-test-secret-header="true">
+      {{#if this.isShowing}}
+        Provider
+        <span class="has-font-weight-normal">{{@model.id}}</span>
+      {{else}}
+        {{if this.isCreating "Create provider" "Update credentials"}}
+      {{/if}}
+    </h1>
+  </p.levelLeft>
+</PageHeader>
+
+{{#if this.isShowing}}
+  <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
+    <nav class="tabs">
+      <ul>
+        <li class={{unless this.viewingKeys "is-active"}}>
+          <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@model.id}} @query={{hash tab=""}}>
+            Details
+          </LinkTo>
+        </li>
+        <li role="button" class={{if this.viewingKeys "is-active"}} {{on "click" (perform this.fetchKeys 1)}}>
+          <LinkTo @route="vault.cluster.secrets.backend.show" @model={{@model.id}} @query={{hash tab="keys"}}>
+            Keys
+          </LinkTo>
+        </li>
+      </ul>
+    </nav>
+  </div>
+  {{#unless this.viewingKeys}}
+    <Toolbar>
+      <ToolbarActions>
+        <ConfirmAction @buttonClasses="toolbar-link" @onConfirmAction={{this.onDelete}} data-test-keymgmt-provider-delete>
+          Delete provider
+        </ConfirmAction>
+        <div class="toolbar-separator"></div>
+        {{! Update once distribute route has been created }}
+        {{! <LinkTo @route="vault.cluster.secrets.backend.kms-distribute">
+          Distribute key
+          <Icon @name="chevron-right" />
+        </LinkTo> }}
+        <ToolbarSecretLink
+          @secret={{@model.id}}
+          @mode="edit"
+          @replace={{true}}
+          @queryParams={{query-params itemType="provider"}}
+          @data-test-keymgmt-provider-edit={{true}}
+        >
+          Update credentials
+        </ToolbarSecretLink>
+      </ToolbarActions>
+    </Toolbar>
+  {{/unless}}
+{{else}}
+  <form aria-label="update credentials" {{on "submit" this.onSave}}>
+    <div class="box is-sideless is-fullwidth is-marginless">
+      {{#if this.isCreating}}
+        {{#each @model.createFields as |attr index|}}
+          {{#if (eq index 2)}}
+            <div class="has-border-top-light">
+              <h2 class="title is-5 has-top-margin-l has-bottom-margin-m">
+                Provider configuration
+              </h2>
+            </div>
+          {{/if}}
+          <FormField @attr={{attr}} @model={{@model}} @validationMessages={{this.modelValidations}} />
+        {{/each}}
+      {{/if}}
+      {{#unless this.isCreating}}
+        <h2 class="title is-5" data-test-title="true">
+          New credentials
+        </h2>
+        <p class="sub-text has-bottom-margin-m">
+          Old credentials cannot be read and will be lost as soon as new ones are added. Do this carefully.
+        </p>
+      {{/unless}}
+      {{#each @model.credentialFields as |cred|}}
+        <FormField @attr={{cred}} @model={{@model}} @validationMessages={{this.modelValidations}} />
+      {{/each}}
+    </div>
+    <div class="field is-grouped box is-fullwidth is-bottomless">
+      <div class="control">
+        <button
+          type="submit"
+          disabled={{this.saveTask.isRunning}}
+          class="button is-primary {{if this.saveTask.isRunning "is-loading"}}"
+        >
+          {{if this.isCreating "Create provider" "Update"}}
+        </button>
+      </div>
+      <div class="control">
+        <LinkTo
+          @route={{if this.isCreating @root.path "vault.cluster.secrets.backend.show"}}
+          @model={{if this.isCreating @root.model @model.id}}
+          @query={{if this.isCreating (hash tab="provider") (hash itemType="provider")}}
+          @disabled={{this.saveTask.isRunning}}
+          class="button"
+        >
+          Cancel
+        </LinkTo>
+      </div>
+    </div>
+  </form>
+{{/if}}
+
+{{#if this.isShowing}}
+  <div class="has-bottom-margin-s">
+    {{#if this.viewingKeys}}
+      {{#let (options-for-backend "keymgmt" "key") as |options|}}
+        {{#if @model.keys.meta.total}}
+          {{#each @model.keys as |key|}}
+            <SecretList::Item
+              @item={{key}}
+              @backendModel={{@root}}
+              @backendType="keymgmt"
+              @delete={{fn this.onDeleteKey key}}
+              @itemPath={{concat options.modelPrefix key.id}}
+              @itemType={{options.item}}
+              @modelType={{@modelType}}
+              @options={{options}}
+            />
+          {{/each}}
+          {{#if (gt @model.keys.meta.lastPage 1)}}
+            <PaginationControls
+              @total={{@model.keys.meta.total}}
+              @onChange={{perform this.fetchKeys}}
+              class="has-top-margin-xl has-bottom-margin-l"
+            />
+          {{/if}}
+        {{else}}
+          <EmptyState
+            @title="No keys for this provider"
+            @message="Keys for this provider will be listed here. Add a key to get started."
+          >
+            <SecretLink @mode="create" @secret="" @queryParams={{query-params itemType="key"}} @class="link">
+              Create key
+            </SecretLink>
+          </EmptyState>
+        {{/if}}
+      {{/let}}
+    {{else}}
+      {{#each @model.showFields as |attr|}}
+        {{#if attr.hasBlock}}
+          <InfoTableRow @label={{attr.label}} @value={{attr.value}}>
+            {{#if attr.icon}}
+              <Icon @name={{attr.icon}} class="icon" />
+            {{/if}}
+            {{attr.value}}
+          </InfoTableRow>
+        {{else}}
+          <InfoTableRow
+            @alwaysRender={{true}}
+            @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
+            @value={{get @model attr.name}}
+            @defaultShown={{attr.options.defaultShown}}
+            @formatDate={{if (eq attr.type "date") "MMM d yyyy, h:mm:ss aaa"}}
+          />
+        {{/if}}
+      {{/each}}
+    {{/if}}
+  </div>
+{{/if}}

--- a/ui/app/templates/components/pagination-controls.hbs
+++ b/ui/app/templates/components/pagination-controls.hbs
@@ -1,0 +1,44 @@
+<div class="is-flex-between is-flex-center" ...attributes>
+  <div class="is-fullwidth is-flex-center">
+    <p class="has-text-grey has-left-margin-l" data-test-page-display-info>
+      {{this.displayInfo}}
+    </p>
+  </div>
+  <div class="is-fullwidth is-flex-v-centered">
+    <button
+      type="button"
+      class="button is-flat has-short-padding"
+      disabled={{eq this.page 1}}
+      data-test-previous-page
+      {{on "click" (fn this.changePage (sub this.page 1))}}
+    >
+      <Icon @name="chevron-left" />
+      Previous
+    </button>
+    {{#each this.pages as |page|}}
+      <button
+        type="button"
+        class="button is-flat has-left-margin-xxs {{if (eq this.page page) "is-primary is-underlined is-active"}}"
+        data-test-page={{page}}
+        {{on "click" (fn this.changePage page)}}
+      >
+        {{page}}
+      </button>
+    {{/each}}
+    {{#if this.hasMorePages}}
+      <span class="has-text-grey has-left-margin-m" data-test-more-pages>...</span>
+    {{/if}}
+    <button
+      type="button"
+      class="button is-flat has-short-padding has-left-margin-l"
+      disabled={{eq this.page this.totalPages}}
+      data-test-next-page
+      {{on "click" (fn this.changePage (add this.page 1))}}
+    >
+      Next
+      <Icon @name="chevron-right" />
+    </button>
+  </div>
+  {{! intentionally empty to place buttons in the middle }}
+  <div class="is-fullwidth"></div>
+</div>

--- a/ui/app/templates/components/secret-list/item.hbs
+++ b/ui/app/templates/components/secret-list/item.hbs
@@ -4,20 +4,20 @@
   class="list-item-row"
   data-test-secret-link=@item.id
   encode=true
-  queryParams=(secret-query-params @backendModel.type)
+  queryParams=(secret-query-params @backendModel.type @item.type)
 }}
   <div class="columns is-mobile">
     <div class="column is-10">
       <SecretLink
         @mode={{if @item.isFolder "list" "show"}}
         @secret={{@item.id}}
-        @queryParams={{if (eq @backendModel.type "transit") (query-params tab="actions") ""}}
+        @queryParams={{secret-query-params @backendModel.type @item.type asQueryParams=true}}
         @class="has-text-black has-text-weight-semibold"
       >
         {{#if (eq @backendModel.type "transit")}}
           <Icon @name="key" class="has-text-grey-light" />
         {{else}}
-          <Icon @name={{if @item.isFolder "folder" "file"}} class="has-text-grey-light" />
+          <Icon @name={{if @item.isFolder "folder" (or @item.icon "file")}} class="has-text-grey-light" />
         {{/if}}
         {{if (eq @item.id " ") "(self)" (or @item.keyWithoutParent @item.id)}}
       </SecretLink>

--- a/ui/app/utils/model-validations-helper.js
+++ b/ui/app/utils/model-validations-helper.js
@@ -1,0 +1,23 @@
+import merge from 'lodash/merge';
+
+// FormField component expects validationMessages in a shape not output by ember-cp-validations
+// helper requires validations returned from model validate method
+// eg -> const { validations } = await this.model.validate();
+export function generateFormFieldErrors(validations) {
+  return validations.errors.reduce((errorObj, e) => {
+    // check for nested attribute
+    if (e.attribute.includes('.')) {
+      const keys = e.attribute.split('.').reverse(); // reverse to set value to deepest key first
+      const nested = keys.reduce((obj, key) => {
+        if (!obj) {
+          return { [key]: e.message };
+        }
+        return { [key]: obj };
+      }, null);
+      // lodash merge is deep so nested objects will not be replaced
+      return merge(errorObj, nested);
+    }
+    errorObj[e.attribute] = e.message;
+    return errorObj;
+  }, {});
+}

--- a/ui/mirage/handlers/kms.js
+++ b/ui/mirage/handlers/kms.js
@@ -45,4 +45,14 @@ export default function (server) {
   server.put('keymgmt/key/:name', function () {
     return {};
   });
+
+  server.get('/keymgmt/kms/:provider/key', () => {
+    const keys = [];
+    let i = 1;
+    while (i <= 75) {
+      keys.push(`testkey-${i}`);
+      i++;
+    }
+    return { data: { keys } };
+  });
 }

--- a/ui/stories/pagination-controls.md
+++ b/ui/stories/pagination-controls.md
@@ -1,0 +1,26 @@
+<!--THIS FILE IS AUTO GENERATED. This file is generated from JSDoc comments in app/components/pagination-controls.js. To make changes, first edit that file and run "yarn gen-story-md pagination-controls" to re-generate the content.-->
+
+## PaginationControls
+PaginationControls components are used to paginate through item lists
+
+**Params**
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| total | <code>number</code> |  | total number of items |
+| [startPage] | <code>number</code> | <code>1</code> | initial page number to select |
+| [size] | <code>number</code> | <code>15</code> | number of items to display per page |
+| onChange | <code>function</code> |  | callback fired on page change |
+
+**Example**
+  
+```js
+<PaginationControls @startPage={{1}} @total={{100}} @size={{15}} @onChange={{this.onPageChange}} />
+```
+
+**See**
+
+- [Uses of PaginationControls](https://github.com/hashicorp/vault/search?l=Handlebars&q=PaginationControls+OR+pagination-controls)
+- [PaginationControls Source Code](https://github.com/hashicorp/vault/blob/master/ui/app/components/pagination-controls.js)
+
+---

--- a/ui/tests/integration/components/keymgmt/provider-edit-test.js
+++ b/ui/tests/integration/components/keymgmt/provider-edit-test.js
@@ -1,0 +1,203 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { click, triggerEvent, settled, fillIn } from '@ember/test-helpers';
+import { format } from 'date-fns';
+
+const ts = 'data-test-kms-provider';
+const root = {
+  path: 'vault.cluster.secrets.backend.list-root',
+  model: 'keymgmt',
+  label: 'keymgmt',
+  text: 'keymgmt',
+};
+
+module('Integration | Component | keymgmt/provider-edit', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.store.push({
+      data: {
+        id: 'foo-bar',
+        type: 'keymgmt/provider',
+        attributes: {
+          name: 'foo-bar',
+          provider: 'azurekeyvault',
+          keyCollection: 'keyvault-1',
+          created: new Date(),
+        },
+      },
+    });
+    this.model = this.store.peekRecord('keymgmt/provider', 'foo-bar');
+    this.created = format(this.model.created, 'MMM d yyyy, h:mm:ss aaa');
+    this.root = root;
+    this.owner.lookup('service:router').reopen({
+      currentURL: '/ui/vault/secrets/keymgmt/show/foo-bar',
+      currentRouteName: 'secrets.keymgmt.provider.show',
+      urlFor() {
+        return '';
+      },
+    });
+  });
+
+  test('it should render show view', async function (assert) {
+    this.server.get('/keymgmt/kms/foo-bar/key', () => {
+      return {
+        data: {
+          keys: ['testkey-1', 'testkey-2'],
+        },
+      };
+    });
+    this.server.delete('/keymgmt/kms/foo-bar', () => {
+      assert.ok(true, 'Request made to delete key');
+      return {};
+    });
+    this.owner.lookup('service:router').reopen({
+      transitionTo(path, model, { queryParams: { tab } }) {
+        assert.equal(path, root.path, 'Root path sent in transitionTo on delete');
+        assert.equal(model, root.model, 'Root model sent in transitionTo on delete');
+        assert.deepEqual(tab, 'provider', 'Correct query params sent in transitionTo on delete');
+      },
+    });
+
+    const changeTab = async (tab) => {
+      this.set('tab', tab);
+      await settled();
+    };
+
+    await render(hbs`
+      <Keymgmt::ProviderEdit
+        @root={{this.root}}
+        @model={{this.model}}
+        @mode="show"
+        @tab={{this.tab}}
+      />`);
+
+    assert.dom(`[${ts}-header]`).hasText('Provider foo-bar', 'Page header renders');
+    assert.dom(`[${ts}-tab="details"]`).hasClass('is-active', 'Details tab is active');
+
+    const infoRows = this.element.querySelectorAll('[data-test-component="info-table-row"]');
+    assert.dom(infoRows[0]).hasText('Provider name foo-bar', 'Provider name field renders');
+    assert.dom(infoRows[1]).hasText('Type Azure Key Vault', 'Type field renders');
+    assert.dom('svg', infoRows[1]).hasAttribute('data-test-icon', 'azure-color', 'Icon renders for type');
+    assert.dom(infoRows[2]).hasText(`Created ${this.created}`, 'Created field renders');
+    assert.dom(infoRows[3]).hasText('Key Vault instance name keyvault-1', 'Key collection field renders');
+    assert.dom(infoRows[4]).hasText('Keys 2 keys', 'Keys field renders');
+
+    await changeTab('keys');
+    assert.dom(`[${ts}-details-actions]`).doesNotExist('Toolbar is hidden on keys tab');
+    assert.dom('[data-test-secret-link]').exists({ count: 2 }, 'Keys list renders');
+
+    await changeTab('details');
+    assert.dom(`[${ts}-delete] button`).isDisabled('Delete action disabled when keys exist');
+    await triggerEvent(`[data-test-tooltip-trigger]`, 'mouseenter');
+    assert.dom(`[${ts}-delete-tooltip]`).exists('Tooltip is show when delete action is disabled');
+
+    this.model.keys = [];
+    await settled();
+    assert
+      .dom('[data-test-value-div="Keys"]')
+      .hasText('None', 'None is displayed when no keys exist for provider');
+    await click(`[${ts}-delete] button`);
+    await click('[data-test-confirm-button]');
+  });
+
+  test('it should render create view', async function (assert) {
+    this.server.put('/keymgmt/kms/foo', (schema, req) => {
+      const params = {
+        name: 'foo',
+        provider: 'gcpckms',
+        key_collection: 'keyvault-1',
+        credentials: {
+          service_account_file: 'test',
+        },
+      };
+      assert.deepEqual(JSON.parse(req.requestBody), params, 'PUT request made with correct data');
+      return {};
+    });
+    this.owner.lookup('service:router').reopen({
+      transitionTo(path, model, { queryParams: { itemType } }) {
+        assert.equal(path, 'vault.cluster.secrets.backend.show', 'Show route sent in transitionTo on save');
+        assert.equal(model, 'foo', 'Model id sent in transitionTo on save');
+        assert.deepEqual(itemType, 'provider', 'Correct query params sent in transitionTo on save');
+      },
+    });
+    this.model = this.store.createRecord('keymgmt/provider');
+
+    await render(hbs`
+      <Keymgmt::ProviderEdit
+        @root={{this.root}}
+        @model={{this.model}}
+        @mode="create"
+      />`);
+
+    assert.dom(`[${ts}-header]`).hasText('Create provider', 'Page header renders');
+    assert.dom(`[${ts}-config-title]`).exists('Config header shown in create mode');
+    assert.dom(`[${ts}-creds-title]`).doesNotExist('New credentials header hidden in create mode');
+
+    await click(`[${ts}-submit]`);
+    assert
+      .dom('[data-test-inline-error-message]')
+      .exists({ count: 5 }, 'Required fields are shown on validation');
+
+    ['client_id', 'client_secret', 'tenant_id'].forEach((prop) => {
+      assert.dom(`[data-test-input="credentials.${prop}"]`).exists(`Azure ${prop} field renders`);
+    });
+
+    await fillIn('[data-test-input="provider"]', 'awskms');
+    ['access_key', 'secret_key'].forEach((prop) => {
+      assert.dom(`[data-test-input="credentials.${prop}"]`).exists(`AWS ${prop} field renders`);
+    });
+
+    await fillIn('[data-test-input="provider"]', 'gcpckms');
+    assert.dom(`[data-test-input="credentials.service_account_file"]`).exists(`GCP cred field renders`);
+
+    await fillIn('[data-test-input="name"]', 'foo');
+    await fillIn('[data-test-input="keyCollection"]', 'keyvault-1');
+    await fillIn('[data-test-input="credentials.service_account_file"]', 'test');
+    await click(`[${ts}-submit]`);
+  });
+
+  test('it should render edit view', async function (assert) {
+    this.server.put('/keymgmt/kms/foo', (schema, req) => {
+      const params = {
+        name: 'foo-bar',
+        provider: 'azurekeyvault',
+        key_collection: 'keyvault-1',
+        credentials: {
+          client_id: 'client_id test',
+          client_secret: 'client_secret test',
+          tenant_id: 'tenant_id test',
+        },
+      };
+      assert.deepEqual(JSON.parse(req.requestBody), params, 'PUT request made with correct data');
+      return {};
+    });
+    this.owner.lookup('service:router').reopen({
+      transitionTo(path, model, { queryParams: { itemType } }) {
+        assert.equal(path, 'vault.cluster.secrets.backend.show', 'Show route sent in transitionTo on save');
+        assert.equal(model, 'foo', 'Model id sent in transitionTo on save');
+        assert.deepEqual(itemType, 'provider', 'Correct query params sent in transitionTo on save');
+      },
+    });
+    await render(hbs`
+      <Keymgmt::ProviderEdit
+        @root={{this.root}}
+        @model={{this.model}}
+        @mode="edit"
+      />`);
+
+    assert.dom(`[${ts}-header]`).hasText('Update credentials', 'Page header renders');
+    assert.dom(`[${ts}-config-title]`).doesNotExist('Config header hidden in edit mode');
+    assert.dom(`[${ts}-creds-title]`).exists('New credentials header shown in edit mode');
+
+    for (const prop of ['client_id', 'client_secret', 'tenant_id']) {
+      await fillIn(`[data-test-input="credentials.${prop}"]`, `${prop} test`);
+    }
+    await click(`[${ts}-submit]`);
+  });
+});

--- a/ui/tests/integration/components/pagination-controls-test.js
+++ b/ui/tests/integration/components/pagination-controls-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { click } from '@ember/test-helpers';
+
+module('Integration | Component | pagination-controls', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders correct number of pages', async function (assert) {
+    const totals = [
+      [10, 1],
+      [40, 3],
+      [100, 5],
+    ];
+    for (const [total, count] of totals) {
+      this.total = total;
+      await render(hbs`<PaginationControls @total={{this.total}} />`);
+      assert
+        .dom('[data-test-page]')
+        .exists({ count }, `Correct page count of ${count} renders for ${total} total items`);
+      assert.dom('[data-test-more-pages]')[count === 5 ? 'exists' : 'doesNotExist']();
+    }
+  });
+
+  test('it changes pages', async function (assert) {
+    let expectedPage = 2;
+    this.onChange = (page) => {
+      assert.equal(page, expectedPage, 'onChange callback is fired with correct page number');
+    };
+
+    await render(hbs`<PaginationControls @total={{75}} @onChange={{this.onChange}} />`);
+
+    const isActive = (page) => {
+      return this.element
+        .querySelector(`[data-test-page="${page}"]`)
+        .classList.value.includes('is-primary is-underlined is-active');
+    };
+
+    assert.ok(isActive(1), 'Page 1 is active by default');
+    assert.dom('[data-test-previous-page]').isDisabled('Previous page button is disabled on page 1');
+
+    await click('[data-test-next-page]');
+    assert.ok(isActive(2), 'Page 2 is active');
+    assert.dom('[data-test-previous-page]').isNotDisabled('Previous page button is disabled on page 1');
+
+    expectedPage = 5;
+    await click('[data-test-page="5"]');
+    assert.ok(isActive(5), 'Page 5 is active');
+    assert.dom('[data-test-next-page]').isDisabled('Next page button is disabled on last page');
+
+    expectedPage = 4;
+    await click('[data-test-previous-page]');
+    assert.ok(isActive(4), 'Page 4 is active');
+  });
+
+  test('it renders correct display info', async function (assert) {
+    this.onChange = () => {};
+    await render(hbs`<PaginationControls @total={{68}} @onChange={{this.onChange}} />`);
+
+    const ranges = ['1-15', '16-30', '31-45', '46-60', '61-68'];
+    for (const [i, range] of ranges.entries()) {
+      assert
+        .dom('[data-test-page-display-info]')
+        .hasText(`${range} of 68`, `Correct display info renders for page ${i + 1}`);
+
+      if (i < 4) {
+        await click(`[data-test-next-page]`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR adds Providers to the _keymgmt_ secrets backend.

- added model, adapter and serializer
- added `provider-edit` component for show/create/edit views
- added `pagination-controls` component for more flexible pagination to be used in nested views, specifically the _Keys_ tab of the provider-edit show mode.  