### PR TITLE
Remove deprecated call to BuildNameToCertificate

### DIFF
--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -182,7 +182,6 @@ func VaultPluginTLSProvider(apiTLSConfig *TLSConfig) func() (*tls.Config, error)
 			Certificates: []tls.Certificate{cert},
 			ServerName:   serverCert.Subject.CommonName,
 		}
-		tlsConfig.BuildNameToCertificate()
 
 		return tlsConfig, nil
 	}

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -638,7 +638,6 @@ func (p *ParsedCertBundle) GetTLSConfig(usage TLSUsage) (*tls.Config, error) {
 
 	if tlsCert.Certificate != nil && len(tlsCert.Certificate) > 0 {
 		tlsConfig.Certificates = []tls.Certificate{tlsCert}
-		tlsConfig.BuildNameToCertificate()
 	}
 
 	return tlsConfig, nil

--- a/sdk/helper/pluginutil/tls.go
+++ b/sdk/helper/pluginutil/tls.go
@@ -83,8 +83,6 @@ func createClientTLSConfig(certBytes []byte, key *ecdsa.PrivateKey) (*tls.Config
 		MinVersion:   tls.VersionTLS12,
 	}
 
-	tlsConfig.BuildNameToCertificate()
-
 	return tlsConfig, nil
 }
 

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -1441,7 +1441,6 @@ func NewTestCluster(t testing.T, base *CoreConfig, opts *TestClusterOptions) *Te
 			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			testCluster.ClientAuthRequired = true
 		}
-		tlsConfig.BuildNameToCertificate()
 		tlsConfigs = append(tlsConfigs, tlsConfig)
 		lns := []*TestListener{
 			{


### PR DESCRIPTION
This function call was previously used to generate mappings from
potential subjects (or SANs) to certificates within the TLS client
object. However, newer Go versions have deprecated this method, instead
building the mapping automatically based on present certificates at
request time. Because the corresponding client configuration field is
not used in Vault (`NameToCertificate`), it is safe to remove this call
and leave it `nil`.

See also: https://github.com/golang/go/commit/67d894ee652a3c6fd0a883a33b86686371b96a0e
See also: https://pkg.go.dev/crypto/tls#Config.BuildNameToCertificate

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`