### PR TITLE
Clarify that backend authors can specify that all or no values are sealwrapped

### DIFF
--- a/website/content/docs/enterprise/sealwrap.mdx
+++ b/website/content/docs/enterprise/sealwrap.mdx
@@ -74,7 +74,7 @@ backend with the `seal_wrap` configuration value set to `true`. (This value
 cannot currently be changed later.)
 
 A given backend's author can specify which values should be seal-wrapped by
-identifying where CSPs are stored.  AbsentThey may also choose to seal wrap all or none
+identifying where CSPs are stored.  They may also choose to seal wrap all or none
 of their values.
 
 To see the current list of seal-wrapped data per backend type, see the latest

--- a/website/content/docs/enterprise/sealwrap.mdx
+++ b/website/content/docs/enterprise/sealwrap.mdx
@@ -74,8 +74,8 @@ backend with the `seal_wrap` configuration value set to `true`. (This value
 cannot currently be changed later.)
 
 A given backend's author can specify which values should be seal-wrapped by
-identifying where CSPs are stored. If no specific CSPs are identifiable, all
-data for the backend may be seal-wrapped.
+identifying where CSPs are stored.  AbsentThey may also choose to seal wrap all or none
+of their values.
 
 To see the current list of seal-wrapped data per backend type, see the latest
 audit letter and updates in the FIPS 140-2 Compliance section above.


### PR DESCRIPTION
...rather than the vague statement that all values _may_ be seal wrapped