### PR TITLE
Bump timeout for gauge testing to 500 ms from 100 ms.

### DIFF
--- a/helper/metricsutil/gauge_process_test.go
+++ b/helper/metricsutil/gauge_process_test.go
@@ -332,7 +332,7 @@ func waitForDone(t *testing.T,
 	done <-chan struct{},
 ) int {
 	t.Helper()
-	timeout := time.After(100 * time.Millisecond)
+	timeout := time.After(500 * time.Millisecond)
 
 	numTicks := 0
 	for {


### PR DESCRIPTION
# Summary
This fixes a flaky test around metrics gauge testing. Namely wanted to get @briankassouf's opinion on whether this is a reasonable change as I don't personally have much context.

# Testing
`make test TEST=./helper/metricsutil TESTARGS='-v -run TestGauge_MaximumMeasurements -test.count 1'`