### PR TITLE
Feat/OIDC loopback redirect dynamic

### DIFF
--- a/changelog/13871.txt
+++ b/changelog/13871.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-oidc: Support dynamic port for loopback redirect URI
+identity/oidc: Adds support for port-agnostic validation of loopback IP redirect URIs.
 ```

--- a/changelog/13871.txt
+++ b/changelog/13871.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+oidc: Support dynamic port for loopback redirect URI
+```

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -1514,7 +1514,7 @@ func (i *IdentityStore) pathOIDCAuthorize(ctx context.Context, req *logical.Requ
 		return authResponse("", state, ErrAuthInvalidRequest, "redirect_uri parameter is required")
 	}
 
-	if !strutil.StrListContains(client.RedirectURIs, redirectURI) && !isValidRedirectURI(redirectURI, client.RedirectURIs) {
+	if !validRedirect(redirectURI, client.RedirectURIs) {
 		return authResponse("", state, ErrAuthInvalidRedirectURI, "redirect_uri is not allowed for the client")
 	}
 

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -1513,7 +1513,8 @@ func (i *IdentityStore) pathOIDCAuthorize(ctx context.Context, req *logical.Requ
 	if redirectURI == "" {
 		return authResponse("", state, ErrAuthInvalidRequest, "redirect_uri parameter is required")
 	}
-	if !strutil.StrListContains(client.RedirectURIs, redirectURI) {
+
+	if !strutil.StrListContains(client.RedirectURIs, redirectURI) && !isValidRedirectURI(redirectURI, client.RedirectURIs) {
 		return authResponse("", state, ErrAuthInvalidRedirectURI, "redirect_uri is not allowed for the client")
 	}
 

--- a/vault/identity_store_oidc_provider_util.go
+++ b/vault/identity_store_oidc_provider_util.go
@@ -2,48 +2,37 @@ package vault
 
 import (
 	"net/url"
-	"regexp"
-	"strings"
+
+	"github.com/hashicorp/go-secure-stdlib/strutil"
 )
 
-func isValidRedirectURI(uri string, validUris []string) bool {
-	requestedUri, err := url.Parse(uri)
+// validRedirect checks whether uri is in allowed using special handling for loopback uris.
+// Ref: https://tools.ietf.org/html/rfc8252#section-7.3
+func validRedirect(uri string, allowed []string) bool {
+	inputURI, err := url.Parse(uri)
 	if err != nil {
 		return false
 	}
 
-	for _, validUri := range validUris {
-		if strings.ToLower(validUri) == strings.ToLower(uri) || isLoopbackURI(requestedUri, validUri) {
+	// if uri isn't a loopback, just string search the allowed list
+	if !strutil.StrListContains([]string{"localhost", "127.0.0.1", "::1"}, inputURI.Hostname()) {
+		return strutil.StrListContains(allowed, uri)
+	}
+
+	// otherwise, search for a match in a port-agnostic manner, per the OAuth RFC.
+	inputURI.Host = inputURI.Hostname()
+
+	for _, a := range allowed {
+		allowedURI, err := url.Parse(a)
+		if err != nil {
+			return false
+		}
+		allowedURI.Host = allowedURI.Hostname()
+
+		if inputURI.String() == allowedURI.String() {
 			return true
 		}
 	}
 
 	return false
-}
-
-func isLoopbackURI(requestUri *url.URL, validUri string) bool {
-	registeredUri, err := url.Parse(validUri)
-	if err != nil {
-		return false
-	}
-
-	// Verifies that the valid URL is HTTP and is the loopback address before
-	// proceeding, otherwise return false
-	if registeredUri.Scheme != "http" || !isLoopbackAddress(registeredUri.Host) {
-		return false
-	}
-
-	// Returns true if the path after the IP/port is the same
-	// Request URL and valid URL have already been validated as loopback
-	if requestUri.Scheme == "http" && isLoopbackAddress(requestUri.Host) && registeredUri.Path == requestUri.Path {
-		return true
-	}
-
-	return false
-}
-
-// Returns true if the address hostname is the IPv4 or IPv6 loopback address and ignores port
-func isLoopbackAddress(address string) bool {
-	match, _ := regexp.MatchString("^(127.0.0.1|\\[::1\\])(:?)(\\d*)$", address)
-	return match
 }

--- a/vault/identity_store_oidc_provider_util.go
+++ b/vault/identity_store_oidc_provider_util.go
@@ -1,0 +1,49 @@
+package vault
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+func isValidRedirectURI(uri string, validUris []string) bool {
+	requestedUri, err := url.Parse(uri)
+	if err != nil {
+		return false
+	}
+
+	for _, validUri := range validUris {
+		if strings.ToLower(validUri) == strings.ToLower(uri) || isLoopbackURI(requestedUri, validUri) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isLoopbackURI(requestUri *url.URL, validUri string) bool {
+	registeredUri, err := url.Parse(validUri)
+	if err != nil {
+		return false
+	}
+
+	// Verifies that the valid URL is HTTP and is the loopback address before
+	// proceeding, otherwise return false
+	if registeredUri.Scheme != "http" || !isLoopbackAddress(registeredUri.Host) {
+		return false
+	}
+
+	// Returns true if the path after the IP/port is the same
+	// Request URL and valid URL have already been validated as loopback
+	if requestUri.Scheme == "http" && isLoopbackAddress(requestUri.Host) && registeredUri.Path == requestUri.Path {
+		return true
+	}
+
+	return false
+}
+
+// Returns true if the address hostname is the IPv4 or IPv6 loopback address and ignores port
+func isLoopbackAddress(address string) bool {
+	match, _ := regexp.MatchString("^(127.0.0.1|\\[::1\\])(:?)(\\d*)$", address)
+	return match
+}


### PR DESCRIPTION
Addresses #13523.

Adds check to OIDC provider to allow for redirect URI to have a dynamic port # in the URI _if_ the loopback address is included in the OIDC client, and if the OIDC client's redirect URI is the loopback address.