### PR TITLE
Make backport assistant work with ENT backport tags

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,6 +17,6 @@ jobs:
         run: |
           backport-assistant backport
         env:
-          BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.[\\w\\+]+)"
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.[+\\w]+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,6 +17,6 @@ jobs:
         run: |
           backport-assistant backport
         env:
-          BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.\\w+)"
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.[\\w\\+]+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
I want the regexp to include word characters and the plus sign on
enterprise. I'm confused about the levels of escaping required, because
this is a shell env var that gets passed to a go program as a regular
expression. I didn't escape the square brackets because the parens
weren't escaped. I matched what was done previously with the '.'s for
the '+' because I also want that literal, but it was unclear from
playing around with https://regex101.com/ and go regexps whether the
extra backslashes were required for the '+' char.