### PR TITLE
[VAULT-1011] Update autoauth docs

### DIFF
--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -122,7 +122,7 @@ These are common configuration values that live within the `method` block:
 
 - `namespace` `(string: optional)` - Namespace in which the mount lives.
   The order of precedence is: this setting lowest, followed by the
-  environment variable `VAULT_NAMESPACE`, and then the highest prececence
+  environment variable `VAULT_NAMESPACE`, and then the highest precedence
   command-line option `-namespace`.
   If none of these are specified, defaults to the root namespace.
   Note that because sink response wrapping and templating are also based

--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -120,8 +120,13 @@ These are common configuration values that live within the `method` block:
 - `mount_path` `(string: optional)` - The mount path of the method. If not
   specified, defaults to a value of `auth/<method type>`.
 
-- `namespace` `(string: optional)` - The default namespace path for the mount.
-  If not specified, defaults to the root namespace.
+- `namespace` `(string: optional)` - Namespace in which the mount lives.
+  The order of precedence is: this setting lowest, followed by the
+  environment variable `VAULT_NAMESPACE`, and then the highest prececence
+  command-line option `-namespace`.
+  If none of these are specified, defaults to the root namespace.
+  Note that because sink response wrapping and templating are also based
+  on the client created by auto-auth, they use the same namespace.
 
 - `wrap_ttl` `(string or integer: optional)` - If specified, the written token
   will be response-wrapped by the agent. This is more secure than wrapping by


### PR DESCRIPTION
- Missed the autoauth docs update from this ENT pr https://github.com/hashicorp/vault-enterprise/pull/2441/files when I made its OSS pr https://github.com/hashicorp/vault/pull/13696/files, so this PR is to fix that by updating the docs in OSS
- This change is scheduled to go out with 1.10, so no backport labels will be required.