### PR TITLE
contained_db DeleteUser unit test

### DIFF
--- a/plugins/database/mssql/mssql_test.go
+++ b/plugins/database/mssql/mssql_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/vault/sdk/database/dbplugin"
-
 	mssqlhelper "github.com/hashicorp/vault/helper/testhelpers/mssql"
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 	dbtesting "github.com/hashicorp/vault/sdk/database/dbplugin/v5/testing"

--- a/plugins/database/mssql/mssql_test.go
+++ b/plugins/database/mssql/mssql_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/hashicorp/vault/sdk/database/dbplugin"
 	"reflect"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
 
 	mssqlhelper "github.com/hashicorp/vault/helper/testhelpers/mssql"
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"

--- a/plugins/database/mssql/mssql_test.go
+++ b/plugins/database/mssql/mssql_test.go
@@ -377,7 +377,7 @@ func TestDeleteUserContainedDB(t *testing.T) {
 	dbtesting.AssertInitializeCircleCiTest(t, db, initReq)
 	defer dbtesting.AssertClose(t, db)
 
-	err := createTestMSSQLUser(connURL, dbUser, initPassword, testMSSQLLogin)
+	err := createTestMSSQLUser(connURL, dbUser, initPassword, testMSSQLContainedLogin)
 	if err != nil {
 		t.Fatalf("Failed to create user: %s", err)
 	}
@@ -471,6 +471,7 @@ func testContainedDBCredsExist(connURL, username string) error {
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 	userStmt, err := db.PrepareContext(ctx, fmt.Sprintf("DROP USER [%s]", username))
 	if err != nil {
 		return err
@@ -530,4 +531,9 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON SCHEMA::dbo TO [{{name}}];`
 
 const testMSSQLLogin = `
 CREATE LOGIN [{{name}}] WITH PASSWORD = '{{password}}';
+`
+
+const testMSSQLContainedLogin = `
+CREATE LOGIN [{{name}}] WITH PASSWORD = '{{password}}';
+CREATE USER [{{name}}] FOR LOGIN [{{name}}];
 `


### PR DESCRIPTION
This PR adds unit test `TestDeleteUserContainedDB` which allows us to test the inline SQL delete query. Two helper functions ( `assertContainedDBCredsDoNotExist` | `testContainedDBCredsExist` ) were added to check if the credentials exist after the delete query is executed. 