### PR TITLE
Seal wrap storage entries of the ManagedKeyRegistry.

### DIFF
--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -425,7 +425,7 @@ func TestSysMounts_headerAuth(t *testing.T) {
 					"passthrough_request_headers": []interface{}{"Accept"},
 				},
 				"local":     false,
-				"seal_wrap": false,
+				"seal_wrap": true,
 				"options":   interface{}(nil),
 			},
 			"cubbyhole/": map[string]interface{}{
@@ -480,7 +480,7 @@ func TestSysMounts_headerAuth(t *testing.T) {
 				"passthrough_request_headers": []interface{}{"Accept"},
 			},
 			"local":     false,
-			"seal_wrap": false,
+			"seal_wrap": true,
 			"options":   interface{}(nil),
 		},
 		"cubbyhole/": map[string]interface{}{

--- a/http/sys_mount_test.go
+++ b/http/sys_mount_test.go
@@ -52,7 +52,7 @@ func TestSysMounts(t *testing.T) {
 					"passthrough_request_headers": []interface{}{"Accept"},
 				},
 				"local":     false,
-				"seal_wrap": false,
+				"seal_wrap": true,
 				"options":   interface{}(nil),
 			},
 			"cubbyhole/": map[string]interface{}{
@@ -107,7 +107,7 @@ func TestSysMounts(t *testing.T) {
 				"passthrough_request_headers": []interface{}{"Accept"},
 			},
 			"local":     false,
-			"seal_wrap": false,
+			"seal_wrap": true,
 			"options":   interface{}(nil),
 		},
 		"cubbyhole/": map[string]interface{}{
@@ -222,7 +222,7 @@ func TestSysMount(t *testing.T) {
 					"passthrough_request_headers": []interface{}{"Accept"},
 				},
 				"local":     false,
-				"seal_wrap": false,
+				"seal_wrap": true,
 				"options":   interface{}(nil),
 			},
 			"cubbyhole/": map[string]interface{}{
@@ -290,7 +290,7 @@ func TestSysMount(t *testing.T) {
 				"passthrough_request_headers": []interface{}{"Accept"},
 			},
 			"local":     false,
-			"seal_wrap": false,
+			"seal_wrap": true,
 			"options":   interface{}(nil),
 		},
 		"cubbyhole/": map[string]interface{}{
@@ -424,7 +424,7 @@ func TestSysRemount(t *testing.T) {
 					"passthrough_request_headers": []interface{}{"Accept"},
 				},
 				"local":     false,
-				"seal_wrap": false,
+				"seal_wrap": true,
 				"options":   interface{}(nil),
 			},
 			"cubbyhole/": map[string]interface{}{
@@ -492,7 +492,7 @@ func TestSysRemount(t *testing.T) {
 				"passthrough_request_headers": []interface{}{"Accept"},
 			},
 			"local":     false,
-			"seal_wrap": false,
+			"seal_wrap": true,
 			"options":   interface{}(nil),
 		},
 		"cubbyhole/": map[string]interface{}{
@@ -594,7 +594,7 @@ func TestSysUnmount(t *testing.T) {
 					"passthrough_request_headers": []interface{}{"Accept"},
 				},
 				"local":     false,
-				"seal_wrap": false,
+				"seal_wrap": true,
 				"options":   interface{}(nil),
 			},
 			"cubbyhole/": map[string]interface{}{
@@ -649,7 +649,7 @@ func TestSysUnmount(t *testing.T) {
 				"passthrough_request_headers": []interface{}{"Accept"},
 			},
 			"local":     false,
-			"seal_wrap": false,
+			"seal_wrap": true,
 			"options":   interface{}(nil),
 		},
 		"cubbyhole/": map[string]interface{}{
@@ -850,7 +850,7 @@ func TestSysTuneMount(t *testing.T) {
 					"passthrough_request_headers": []interface{}{"Accept"},
 				},
 				"local":     false,
-				"seal_wrap": false,
+				"seal_wrap": true,
 				"options":   interface{}(nil),
 			},
 			"cubbyhole/": map[string]interface{}{
@@ -918,7 +918,7 @@ func TestSysTuneMount(t *testing.T) {
 				"passthrough_request_headers": []interface{}{"Accept"},
 			},
 			"local":     false,
-			"seal_wrap": false,
+			"seal_wrap": true,
 			"options":   interface{}(nil),
 		},
 		"cubbyhole/": map[string]interface{}{
@@ -1059,7 +1059,7 @@ func TestSysTuneMount(t *testing.T) {
 					"passthrough_request_headers": []interface{}{"Accept"},
 				},
 				"local":     false,
-				"seal_wrap": false,
+				"seal_wrap": true,
 				"options":   interface{}(nil),
 			},
 			"cubbyhole/": map[string]interface{}{
@@ -1127,7 +1127,7 @@ func TestSysTuneMount(t *testing.T) {
 				"passthrough_request_headers": []interface{}{"Accept"},
 			},
 			"local":     false,
-			"seal_wrap": false,
+			"seal_wrap": true,
 			"options":   interface{}(nil),
 		},
 		"cubbyhole/": map[string]interface{}{

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -153,6 +153,10 @@ func NewSystemBackend(core *Core, logger log.Logger) *SystemBackend {
 				expirationSubPath,
 				countersSubPath,
 			},
+
+			SealWrapStorage: []string{
+				managedKeyRegistrySubPath,
+			},
 		},
 	}
 

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -183,7 +183,7 @@ func TestSystemBackend_mounts(t *testing.T) {
 				"passthrough_request_headers": []string{"Accept"},
 			},
 			"local":     false,
-			"seal_wrap": false,
+			"seal_wrap": true,
 			"options":   map[string]string(nil),
 		},
 		"cubbyhole/": map[string]interface{}{
@@ -296,7 +296,7 @@ func TestSystemBackend_mount(t *testing.T) {
 				"passthrough_request_headers": []string{"Accept"},
 			},
 			"local":     false,
-			"seal_wrap": false,
+			"seal_wrap": true,
 			"options":   map[string]string(nil),
 		},
 		"cubbyhole/": map[string]interface{}{
@@ -2934,7 +2934,7 @@ func TestSystemBackend_InternalUIMounts(t *testing.T) {
 					"passthrough_request_headers": []string{"Accept"},
 				},
 				"local":     false,
-				"seal_wrap": false,
+				"seal_wrap": true,
 				"options":   map[string]string(nil),
 			},
 			"cubbyhole/": map[string]interface{}{

--- a/vault/managed_key_registry.go
+++ b/vault/managed_key_registry.go
@@ -2,6 +2,11 @@
 
 package vault
 
+// managedKeyRegistrySubPath is the storage prefix used by the registry.
+// We need to define the constant even though managed keys is a Vault Enterprise
+// feature in order to set up seal wrapping in the SystemBackend.
+const managedKeyRegistrySubPath = "managed-key-registry/"
+
 func (c *Core) setupManagedKeyRegistry() error {
 	return nil
 }

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1499,6 +1499,7 @@ func (c *Core) requiredMountTable() *MountTable {
 		UUID:             sysUUID,
 		Accessor:         sysAccessor,
 		BackendAwareUUID: sysBackendUUID,
+		SealWrap:         true, // Enable SealWrap since SystemBackend utilizes SealWrapStorage, see factory in addExtraLogicalBackends().
 		Config: MountConfig{
 			PassthroughRequestHeaders: []string{"Accept"},
 		},

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -841,6 +841,9 @@ func verifyDefaultTable(t *testing.T, table *MountTable, expected int) {
 			if entry.Type != "system" {
 				t.Fatalf("bad: %v", entry)
 			}
+			if !entry.SealWrap {
+				t.Fatalf("expected SealWrap to be enabled: %v", entry)
+			}
 		case "identity/":
 			if entry.Type != "identity" {
 				t.Fatalf("bad: %v", entry)


### PR DESCRIPTION
Specify the managed key registry's path in SealWrapStorage in the SystemBackend.

Enable SealWrap in the system mount entry.
