### PR TITLE
identity/oidc: Adds proof key for code exchange (PKCE) support

### DIFF
--- a/vault/external_tests/identity/oidc_provider_test.go
+++ b/vault/external_tests/identity/oidc_provider_test.go
@@ -191,6 +191,10 @@ func TestOIDC_Auth_Code_Flow_CAP_Client(t *testing.T) {
 	require.NoError(t, err)
 	defer p.Done()
 
+	// Create the client-side PKCE code verifier
+	v, err := oidc.NewCodeVerifier()
+	require.NoError(t, err)
+
 	type args struct {
 		useStandby bool
 		options    []oidc.Option
@@ -254,6 +258,21 @@ func TestOIDC_Auth_Code_Flow_CAP_Client(t *testing.T) {
 				"namespace": "root",
 				"auth_time": %d
 			}`, discovery.Issuer, clientID, entityID, expectedAuthTime),
+		},
+		{
+			name: "active: authorization code flow with Proof Key for Code Exchange (PKCE)",
+			args: args{
+				options: []oidc.Option{
+					oidc.WithScopes("openid"),
+					oidc.WithPKCE(v),
+				},
+			},
+			expected: fmt.Sprintf(`{
+				"iss": "%s",
+				"aud": "%s",
+				"sub": "%s",
+				"namespace": "root"
+			}`, discovery.Issuer, clientID, entityID),
 		},
 		{
 			name: "standby: authorization code flow with additional scopes",


### PR DESCRIPTION
## Overview

This PR adds proof key for code exchange (PKCE) support to OIDC providers. Details on PKCE are available in [rfc7636](https://datatracker.ietf.org/doc/html/rfc7636).

The following table shows the behavior given various PKCE-related inputs. "Present" means that the parameter was provided to the API. "Absent" means the parameter was not provided to the API or is empty. Some of this behavior isn't defined by the RFC, so I'm flexible in changing it based on feedback.

#### Authorization Endpoint 

| code_challenge      | code_challenge_method | behavior |
| ------------------- | ------------------------ | --------- |
|  Absent | Absent | PKCE not used |
|  Absent | Present | PKCE not used |
| Present  | Absent | PKCE used with default method from rfc7636 (plain) |
| Present  | Present | PKCE used with given method |

#### Token Endpoint

| code_verifier |  PKCE used in authorization | behavior |
| ------------- | ----------------------------| --------- |
|  Absent | No | PKCE not used (code_verifier not verified) |
|  Absent | Yes | invalid_grant error |
|  Present | No | PKCE not used (code_verifier not verified) |
|  Present | Yes | code_verifier is verified using method |

## Testing

I've added tests that exercise PKCE using the [hashicorp/cap](https://github.com/hashicorp/cap/blob/main/oidc/pkce_verifier.go) OIDC client. I've also added some tests to verify that errors are returned when expected.

Documentation will also be added to this PR.