### PR TITLE
Turning off binary secret scanning

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -5,7 +5,7 @@ container {
 }
 
 binary {
-	secrets      = true
+	secrets      = false
 	go_modules   = false
 	osv          = true
 	oss_index    = true


### PR DESCRIPTION
Turning off binary secret scanning to allow builds to be processed until https://github.com/hashicorp/security-scanner/issues/166 is addressed.