### PR TITLE
docs/oracle: add wallet permissions example

### DIFF
--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -136,7 +136,7 @@ vault write database/config/oracle \
 server when using high availability clusters.
 
 The wallet used by Vault should be in a well known location with the proper filesystem permissions. For example, if Vault is running as the `vault` user, 
-the wallet directory may be setup as followed:
+the wallet directory may be setup as follows:
 
 ```shell
 mkdir -p /etc/vault/wallets

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -106,9 +106,6 @@ pluggable databases rather than the container database in the `connection_url` f
 
 ### Connect Using SSL
 
-~> **Note**: The wallets used when connecting via SSL should be available on every Vault
-server when using high availability clusters.
-
 If the Oracle server Vault is trying to connect to uses an SSL listener, the database
 plugin will require additional configuration using the `connection_url` parameter:
 
@@ -131,6 +128,21 @@ vault write database/config/oracle \
   allowed_roles="my-role" \
   username="admin" \
   password="password"
+```
+
+#### Wallet Permissions
+
+~> **Note**: The wallets used when connecting via SSL should be available on every Vault
+server when using high availability clusters.
+
+The wallet used by Vault should be in a well known location with the proper filesystem permissions. For example, if Vault is running as the `vault` user, 
+the wallet directory may be setup as followed:
+
+```shell
+mkdir -p /etc/vault/wallets
+cp cwallet.sso /etc/vault/wallets/cwallet.sso
+chown -R vault:vault /etc/vault
+chmod 600 /etc/vault/wallets/cwallet.sso
 ```
 
 ### Using TNS Names


### PR DESCRIPTION
Adding a note about wallet permissions when using Oracle TLS for additional guidance.