### PR TITLE
Use application/pem-certificate-chain for PEMs

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1768,7 +1768,7 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 	if bytes.Compare(resp.Data[logical.HTTPRawBody].([]byte), pemCert) != 0 {
 		t.Fatalf("failed to get pem cert")
 	}
-	if resp.Data[logical.HTTPContentType] != "application/pkix-cert" {
+	if resp.Data[logical.HTTPContentType] != "application/pem-certificate-chain" {
 		t.Fatalf("failed to get raw cert content-type")
 	}
 }

--- a/builtin/logical/pki/ca_test.go
+++ b/builtin/logical/pki/ca_test.go
@@ -320,7 +320,7 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 			if diff := deep.Equal(resp.Data["http_raw_body"].([]byte), []byte(caCert)); diff != nil {
 				t.Fatal(diff)
 			}
-			if resp.Data["http_content_type"].(string) != "application/pkix-cert" {
+			if resp.Data["http_content_type"].(string) != "application/pem-certificate-chain" {
 				t.Fatal("wrong content type")
 			}
 		}

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -156,6 +156,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		contentType = "application/pkix-cert"
 		if req.Path == "ca/pem" {
 			pemType = "CERTIFICATE"
+			contentType = "application/pem-certificate-chain"
 		}
 	case req.Path == "ca_chain" || req.Path == "cert/ca_chain":
 		serial = "ca_chain"
@@ -167,6 +168,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		contentType = "application/pkix-crl"
 		if req.Path == "crl/pem" {
 			pemType = "X509 CRL"
+			contentType = "application/x-pem-file"
 		}
 	case req.Path == "cert/crl":
 		serial = "crl"
@@ -176,6 +178,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		contentType = "application/pkix-cert"
 		if strings.HasSuffix(req.Path, "/pem") {
 			pemType = "CERTIFICATE"
+			contentType = "application/pem-certificate-chain"
 		}
 	default:
 		serial = data.Get("serial").(string)

--- a/changelog/13927.txt
+++ b/changelog/13927.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Use application/pem-certificate-chain for PEM certificates, application/x-pem-file for PEM CRLs
+```


### PR DESCRIPTION
As mentioned in #10948, it appears we're incorrectly using the
`application/pkix-cert` media type for PEM blobs, when
`application/x-pem-file` is more appropriate. Per RFC 5280 Section
[4.2.1.13](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13), `application/pkix-crl` is only appropriate when the CRL is in
DER form. Likewise, Section [4.2.2.1](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.1) states that `application/pkix-cert`
is only applicable when a single DER certificate is used.

Per recommendation in RFC 8555 ("ACME"), Section [7.4.2](https://datatracker.ietf.org/doc/html/rfc8555#section-7.4.2) and [9.1](https://datatracker.ietf.org/doc/html/rfc8555#section-9.1), we use
the newer `application/pem-certificate-chain` media type for
certificates. However, this is not applicable for CRLs, so we use fall
back to `application/x-pem-file` for these. Notably, no official IETF
source is present for the latter. On the OpenSSL PKI tutorial
(https://pki-tutorial.readthedocs.io/en/latest/mime.html), this type is
cited as coming from S/MIME's predecessor, PEM, but neither of the main
PEM RFCs (RFC 934, 1421, 1422, 1423, or 1424) mention this type.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

While https://github.com/ietf-wg-acme/acme/issues/120#issuecomment-218182901 seems to suggest `application/x-pem-file` is appropriate for PEM blobs in general (regardless of type), they ended up removing this in the final draft and introducing a new type. 