### PR TITLE
Add full CA Chain to /pki/cert/ca_chain response

### DIFF
--- a/changelog/13935.txt
+++ b/changelog/13935.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Return complete chain (in `ca_chain` field) on calls to `pki/cert/ca_chain`
+```

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -687,6 +687,21 @@ func (b *CAInfoBundle) GetCAChain() []*CertBlock {
 	return chain
 }
 
+func (b *CAInfoBundle) GetFullChain() []*CertBlock {
+	var chain []*CertBlock
+
+	chain = append(chain, &CertBlock{
+		Certificate: b.Certificate,
+		Bytes:       b.CertificateBytes,
+	})
+
+	if len(b.CAChain) > 0 {
+		chain = append(chain, b.CAChain...)
+	}
+
+	return chain
+}
+
 type CertExtKeyUsage int
 
 const (

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -75,6 +75,9 @@ $ curl \
 This endpoint retrieves the CA certificate chain, including the CA _in PEM
 format_. This is a bare endpoint that does not return a standard Vault data
 structure and cannot be read by the Vault CLI; use `/pki/cert` for that.
+Additionally, note that this doesn't include the root authority and so may
+return empty data depending on configuration; use `/pki/cert/ca_chain`'s
+`ca_chain` JSON data field for the entire chain including issuing authority.
 
 This is an unauthenticated endpoint.
 

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -114,7 +114,8 @@ This is an unauthenticated endpoint.
   - `<serial>` for the certificate with the given serial number
   - `ca` for the CA certificate
   - `crl` for the current CRL
-  - `ca_chain` for the CA trust chain or a serial number in either hyphen-separated or colon-separated octal format
+  - `ca_chain` for the CA trust chain; intermediate certificates in the `certificate`
+               field, full chain in the `ca_chain` field.
 
 ### Sample Request
 


### PR DESCRIPTION
As mentioned in #13489, calls to read `/pki/cert/ca_chain` would return a partial chain, excluding the root authority. By adding a new field, `ca_chain` to the response, we can include the entire chain without breaking backwards compatibility.

We test three main scenarios:
    
 1. A root-only CA's `/cert/ca_chain`'s `.data.ca_chain` field should contain only the root,
 2. An intermediate CA (with root provide) should contain both the root and the intermediate.
 3. An external (e.g., `/config/ca`-provided) CA with both root and intermediate should contain both certs.


n.b.: I think the existing note around `ca_chain` in the documentation is wrong, hence its removal. 

Additional note: this is only the full chain as _known to Vault_. If the entire (from a TLS client's PoV) chain wasn't provided during either `/intermediate/set-signed` or `/config/ca`, Vault wouldn't know the entire chain and thus couldn't provided. That'd be an enhancement for the future.  