### PR TITLE
Vault documentation: new os support doc

### DIFF
--- a/website/content/docs/browser-support.mdx
+++ b/website/content/docs/browser-support.mdx
@@ -3,7 +3,7 @@ layout: docs
 page_title: Browser Support
 sidebar_title: Browser Support
 description: |-
-  List of browser suppport.
+  List of browser support.
 ---
 
 # Vault UI Browser Support

--- a/website/content/docs/os-support.mdx
+++ b/website/content/docs/os-support.mdx
@@ -1,0 +1,15 @@
+---
+layout: docs
+page_title: OS Support
+sidebar_title: OS Support
+description: |-
+  Links to official release channel doc and packaging guide.
+---
+
+# Vault OS Support
+
+HashiCorp provides and maintains a list of **Official Release Channels**. We highly recommended using officially supported HashiCorp releases in production environments since they are maintained by our internal teams and go through extensive security reviews.
+Additionally, we also provide an **Official Packaging Guide** to help with installation of our packaging and distribution options.
+
+- [Official Release Channels](https://www.hashicorp.com/official-release-channels)
+- [Official Packaging Guide](https://www.hashicorp.com/official-packaging-guide)

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -16,6 +16,10 @@
     "path": "browser-support"
   },
   {
+    "title": "OS Support",
+    "path": "os-support"
+  },
+  {
     "title": "Installing Vault",
     "path": "install"
   },
@@ -1046,7 +1050,6 @@
             "path": "secrets/identity/oidc-provider"
           }
         ]
-
       },
       {
         "title": "MongoDB Atlas",


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/inbox/1200328878163177/1201071561970870/1201690450941858), the **OS Support** document was created to provide links to both the **Official Packaging Guide** and **Official Release Channels Guide** created by the release-engr team. 

:mag: [Deploy Preview](https://vault-git-os-support-doc-hashicorp.vercel.app/docs/os-support)
