### PR TITLE
Correcting API documentation to show status is unauthenticated

### DIFF
--- a/website/content/api-docs/system/replication/replication-dr.mdx
+++ b/website/content/api-docs/system/replication/replication-dr.mdx
@@ -15,7 +15,7 @@ description: >-
 This endpoint prints information about the status of replication (mode,
 sync progress, etc).
 
-This is an authenticated endpoint.
+This is an unauthenticated endpoint.
 
 | Method | Path                         |
 | :----- | :--------------------------- |

--- a/website/content/api-docs/system/replication/replication-performance.mdx
+++ b/website/content/api-docs/system/replication/replication-performance.mdx
@@ -15,7 +15,7 @@ description: >-
 This endpoint prints information about the status of replication (mode,
 sync progress, etc).
 
-This is an authenticated endpoint.
+This is an unauthenticated endpoint.
 
 | Method | Path                                  |
 | :----- | :------------------------------------ |


### PR DESCRIPTION
The [`sys/replication/status` doc correctly shows it as being unauthenticated](https://www.vaultproject.io/api-docs/system/replication#check-status), but the DR and Performance specific endpoints say they're authenticated.  This is demonstrably false:

```
$ vault token lookup
Error looking up token: Error making API request.

URL: GET https://localhost:8200/v1/auth/token/lookup-self
Code: 400. Errors:

* missing client token

$ vault read sys/replication/dr/status
Key                     Value
---                     -----
cluster_id              4d55b560-3f26-f90f-f8e6-53134170b6fd
known_secondaries       [v3]
last_dr_wal             37637
last_reindex_epoch      0
last_wal                37637
merkle_root             49d80babeb412fb4e8ca404c027ef3bead2aa422
mode                    primary
primary_cluster_addr    n/a
secondaries             [map[connection_status:disconnected node_id:v3]]
state                   running

$ vault read sys/replication/performance/status
Key                     Value
---                     -----
cluster_id              04345a09-e8dd-4f61-4003-e37f5f3324f8
known_secondaries       [v2]
last_performance_wal    37637
last_reindex_epoch      0
last_wal                37637
merkle_root             b5b3dcebb3a12380fb89651c1ed240a0f339ca84
mode                    primary
primary_cluster_addr    n/a
secondaries             [map[connection_status:disconnected node_id:v2]]
state                   running
```