### PR TITLE
vault/external_tests/approle: fix dropped test error

### DIFF
--- a/vault/external_tests/approle/wrapped_secretid_test.go
+++ b/vault/external_tests/approle/wrapped_secretid_test.go
@@ -64,6 +64,7 @@ func TestApproleSecretId_Wrapped(t *testing.T) {
 	})
 
 	unwrappedSecretid, err := client.Logical().Unwrap(wrappingToken)
+	require.NoError(t, err)
 	unwrappedAccessor := unwrappedSecretid.Data["secret_id_accessor"].(string)
 
 	if wrappedAccessor != unwrappedAccessor {


### PR DESCRIPTION
This fixes a dropped test `err` variable in `vault/external_tests/approle`.