### PR TITLE
UI: Add check for renewal time before triggering renew-self

### DIFF
--- a/changelog/13950.txt
+++ b/changelog/13950.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: trigger token renewal if inactive and half of TTL has passed
+```

--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -292,9 +292,10 @@ export default Service.extend({
   },
 
   setLastFetch(timestamp) {
+    const now = this.now();
     this.set('lastFetch', timestamp);
-    // if expiration was allowed we want to go ahead and renew here
-    if (this.allowExpiration) {
+    // if expiration was allowed and we're over half the ttl we want to go ahead and renew here
+    if (this.allowExpiration && now >= this.renewAfterEpoch) {
       this.renew();
     }
     this.set('allowExpiration', false);


### PR DESCRIPTION
This PR addresses a complaint where the background token renewal within the app was silently triggering a 3rd party MFA check after a few minutes of inactivity. The behavior in the UI is updated so that the token is only renewed if 3 minutes of inactivity pass *and* at least half of the token's TTL is passed from authentication time. 

Thank you @austingebauer for your deep contributions to this PR!