### PR TITLE
Fix link to Kubernetes 1.21 section

### DIFF
--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -20,7 +20,7 @@ Kubernetes auth.
 -> **Note:** If you are upgrading to Kubernetes v1.21+, ensure the config option
 `disable_iss_validation` is set to true. Assuming the default mount path, you
 can check with `vault read -field disable_iss_validation auth/kubernetes/config`.
-See [Kubernetes 1.21](#kubernetes-1.21) below for more details.
+See [Kubernetes 1.21](#kubernetes-1-21) below for more details.
 
 ## Authentication
 


### PR DESCRIPTION
The section anchor apparently uses a `-` instead of a `.`.