### PR TITLE
Vault documentation: added a warning message to vault ui browser support doc

### DIFF
--- a/website/content/docs/browser-support.mdx
+++ b/website/content/docs/browser-support.mdx
@@ -16,4 +16,4 @@ Vault currently supports all 'evergreen' browsers, as they are generally on up-t
 - Microsoft Edge
 
 !> **Warning**: We strongly caution against using Internet Explorer 11 (IE 11) as you may experience degradation in feature functionality, and in some cases, Vault features may not work at all. HashiCorp no longer supports Internet Explorer 11 (IE 11) and we are in alignment with Microsoft's own stance on IE 11. You can find their statement about IE 11 on their [support website](https://docs.microsoft.com/en-US/lifecycle/faq/internet-explorer-microsoft-edge).
-We encourage that you move off of IE 11 and use one of the supported browsers listed.
+We encourage that you move off of IE 11 and use one of the supported browsers listed for Vault UI.

--- a/website/content/docs/browser-support.mdx
+++ b/website/content/docs/browser-support.mdx
@@ -15,4 +15,5 @@ Vault currently supports all 'evergreen' browsers, as they are generally on up-t
 - Safari
 - Microsoft Edge
 
-We do not support Internet Explorer 11 (IE 11). Vault follows a similar alignment with Microsoft's own stance on IE 11, found on their [support website](https://docs.microsoft.com/en-US/lifecycle/faq/internet-explorer-microsoft-edge).
+!> **Warning**: We strongly caution against using Internet Explorer 11 (IE 11) as you may experience degradation in feature functionality, and in some cases, Vault features may not work at all. HashiCorp no longer supports Internet Explorer 11 (IE 11) and we are in alignment with Microsoft's own stance on IE 11. You can find their statement about IE 11 on their [support website](https://docs.microsoft.com/en-US/lifecycle/faq/internet-explorer-microsoft-edge).
+We encourage that you move off of IE 11 and use one of the supported browsers listed.


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/1201712347646323/1201781747776428), I added a Warning message and replaced the existing text as the request from PM was to make the statement about the use of IE 11 more emphatic.

:mag:[Deploy Preview](https://vault-git-update-vault-browser-support-hashicorp.vercel.app/docs/browser-support)