### PR TITLE
Remove old vault binary in GOPATH/bin/ before copying new one back into it

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -70,6 +70,7 @@ IFS=$OLDIFS
 DEV_PLATFORM=${DEV_PLATFORM:-"./pkg/$(${GO_CMD} env GOOS)_$(${GO_CMD} env GOARCH)"}
 for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
     cp ${F} bin/
+    rm -f ${MAIN_GOPATH}/bin/vault
     cp ${F} ${MAIN_GOPATH}/bin/
 done
 


### PR DESCRIPTION
With Apple-silicon devices, it's a hard requirement that all native ARM64 code be signed to execute. The build script, via executing `make dev`, puts a binary in both vault/bin/ and $GOPATH/bin. However, only the binary in vault/bin/ gets deleted before the new binary gets `cp`ed back into it.

The problem with this is that Apple apparently caches information regarding the code signature and that cache isn't flushed when a file gets modified. https://developer.apple.com/documentation/security/updating_mac_software

To resolve this, either the original binary needs to be `rm`ed before the new one gets copied back, or you have to `mv` the new file over the original. I opted for the former choice as a fix.

&nbsp;

Before fix:
```
❯ make dev 
==> Checking that build is using go version >= 1.17.5...
==> Using go version 1.17.5...
==> Removing old directory...
==> Building...
Number of parallel builds: 9

-->    darwin/arm64: github.com/hashicorp/vault

==> Results:
total 362912
-rwxr-xr-x  1 robmonte  staff   177M Feb  8 20:35 vault

❯ vault help 
zsh: killed     vault help
```
![image](https://user-images.githubusercontent.com/17119716/153114158-d8adb562-28cf-4f38-a291-3060a4d3fadd.png)

&nbsp;

After fix:
```
❯ make dev
==> Checking that build is using go version >= 1.17.5...
==> Using go version 1.17.5...
==> Removing old directory...
==> Building...
Number of parallel builds: 9

-->    darwin/arm64: github.com/hashicorp/vault

==> Results:
total 362912
-rwxr-xr-x  1 robmonte  staff   177M Feb  8 20:43 vault

❯ vault help
Usage: vault <command> [args]

Common commands:
    read        Read data and retrieves secrets
<etc>
```