### PR TITLE
Add clarification around vague "this" references

### DIFF
--- a/website/content/docs/agent/autoauth/index.mdx
+++ b/website/content/docs/agent/autoauth/index.mdx
@@ -58,8 +58,8 @@ There are two ways that tokens can be response-wrapped by the agent:
 
 ### Encrypting Tokens
 
-~> This is experimental; if input/output formats change we will make every
-effort to provide backwards compatibility.
+~> Support for encrypted tokens is experimental; if input/output formats
+change, we will make every effort to provide backwards compatibility.
 
 Tokens can be encrypted, using a Diffie-Hellman exchange to generate an
 ephemeral key. In this mechanism, the client receiving the token writes a
@@ -69,10 +69,11 @@ key, which is then used to encrypt the token via AES-GCM. The nonce, encrypted
 payload, and the sink's public key are then written to the output file, where
 the client can compute the shared secret and decrypt the token value.
 
-~> NOTE: This is not a protection against MITM attacks! The purpose of this
-feature is for forward-secrecy and coverage against bare token values being
-persisted. A MITM that can write to the sink's output and/or client public-key
-input files could attack this exchange.
+~> NOTE: Token encryption is not a protection against MITM attacks! The purpose
+of this feature is for forward-secrecy and coverage against bare token values
+being persisted. A MITM that can write to the sink's output and/or client
+public-key input files could attack this exchange. Using TLS to protect the
+transit of tokens is highly recommended.
 
 To help mitigate MITM attacks, additional authenticated data (AAD) can be
 provided to the agent. This data is written as part of the AES-GCM tag and must

--- a/website/content/docs/configuration/listener/tcp.mdx
+++ b/website/content/docs/configuration/listener/tcp.mdx
@@ -127,22 +127,27 @@ default value in the `"/sys/config/ui"` [API endpoint](/api/system/config-ui).
 - `tls_min_version` `(string: "tls12")` – Specifies the minimum supported
   version of TLS. Accepted values are "tls10", "tls11", "tls12" or "tls13".
 
-  ~> **Warning**: TLS 1.1 and lower are generally considered insecure.
+  ~> **Warning**: TLS 1.1 and lower (`tls10` and `tls11` values for the
+  `tls_min_version` and `tls_max_version` parameters) are widely considered
+  insecure.
 
 - `tls_cipher_suites` `(string: "")` – Specifies the list of supported
   ciphersuites as a comma-separated-list. The list of all available ciphersuites
   is available in the [Golang TLS documentation][golang-tls].
 
-  ~> **Note**: Go only consults this list for TLSv1.2 and earlier; the order of
-  ciphers is not important. For this parameter to be effective, the
-  `tls_max_version` property must be set to `tls12` to prevent negotiation of
-  TLSv1.3, which is not recommended. See the [Go blog post][go-tls-blog] for
-  more information.
+  ~> **Note**: Go only consults the `tls_cipher_suites` list for TLSv1.2 and
+  earlier; the order of ciphers is not important. For this parameter to be
+  effective, the `tls_max_version` property must be set to `tls12` to prevent
+  negotiation of TLSv1.3, which is not recommended. For more information about
+  this and other TLS related changes, see the [Go TLS blog post][go-tls-blog].
 
 - `tls_prefer_server_cipher_suites` `(string: "false")` – Specifies to prefer the
   server's ciphersuite over the client ciphersuites.
 
-  ~> **Warning**: This parameter is deprecated. Setting it has no effect.
+  ~> **Warning**: The `tls_prefer_server_cipher_suites` parameter is
+                  deprecated. Setting it has no effect. See the above
+                  [Go blog post][go-tls-blog] for more information about
+                  this change.
 
 - `tls_require_and_verify_client_cert` `(string: "false")` – Turns on client
   authentication for this listener; the listener will require a presented

--- a/website/content/docs/configuration/seal/pkcs11.mdx
+++ b/website/content/docs/configuration/seal/pkcs11.mdx
@@ -57,10 +57,10 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
 - `lib` `(string: <required>)`: The path to the PKCS#11 library shared object
   file. May also be specified by the `VAULT_HSM_LIB` environment variable.
 
-  ~> **Note:** Depending on your HSM, this may be either a binary or a dynamic
-  library, and its use may require other libraries depending on which system the
-  Vault binary is currently running on (e.g.: a Linux system may require other
-  libraries to interpret Windows .dll files).
+  ~> **Note:** Depending on your HSM, the value of the `lib` parameter may be
+  either a binary or a dynamic library, and its use may require other libraries
+  depending on which system the Vault binary is currently running on (e.g.: a
+  Linux system may require other libraries to interpret Windows .dll files).
 
 - `slot` `(string: <slot or token label required>)`: The slot number to use,
   specified as a string (e.g. `"2305843009213693953"`). May also be specified by

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -161,9 +161,11 @@ the proper permission, it can generate credentials.
     access_key    AKIA3ALIVABCDG5XC8H4
     ```
     
-    ~> **Note:** Due to AWS eventual consistency, after calling this endpoint, 
-    subsequent calls from Vault to AWS may fail for a few seconds until AWS 
-    becomes consistent again.  See the [AWS secrets engine API](/api/secret/aws#rotate-root-iam-credentials) for further information on rotate-root functionality. 
+    ~> **Note:** Due to AWS eventual consistency, after calling the
+    `aws/config/rotate-root` endpoint, subsequent calls from Vault to
+    AWS may fail for a few seconds until AWS becomes consistent again.
+    See the [AWS secrets engine API](/api/secret/aws#rotate-root-iam-credentials)
+    for further information on `config/rotate-root` functionality.
 
 ## Example IAM Policy for Vault
 

--- a/website/content/docs/secrets/databases/oracle.mdx
+++ b/website/content/docs/secrets/databases/oracle.mdx
@@ -187,8 +187,8 @@ To configure Vault to use TNS names, set the following environment variable on t
 TNS_ADMIN=/path/to/tnsnames/directory
 ```
 
-~> **Note**: If Vault returns a "could not open file" error, double check that this environment
-variable is available to the Vault server.
+~> **Note**: If Vault returns a "could not open file" error, double check that
+the `TNS_ADMIN` environment variable is available to the Vault server.
 
 Finally, use the alias in the `connection_url` parameter on the database configuration:
 

--- a/website/content/docs/secrets/gcp.mdx
+++ b/website/content/docs/secrets/gcp.mdx
@@ -648,7 +648,7 @@ for more details.
 
 ### Deprecation of Access Token Leases
 
-~> **NOTE**: This only affects access tokens. There is no change to the `service_account_key` secret type
+~> **NOTE**: This deprecation only affects access tokens. There is no change to the `service_account_key` secret type.
 
 Previous versions of this secrets engine (Vault <= 0.11.1) created a lease for
 each access token secret. We have removed them after discovering that these


### PR DESCRIPTION
As pointed out by @aphorise internally, the reference to "this" in the TLS section of the docs was vague. Clarify it and several other locations with vague use of the word "this".