### PR TITLE
Fix Environment Variables in Kubernetes config

### DIFF
--- a/website/content/docs/auth/kubernetes.mdx
+++ b/website/content/docs/auth/kubernetes.mdx
@@ -179,7 +179,7 @@ the default mount folder `/var/run/secrets/kubernetes.io/serviceaccount/`.
 
 ```bash
 vault write auth/kubernetes/config \
-    kubernetes_host=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT
+    kubernetes_host=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT
 ```
 
 !> **Note:** Requires Vault 1.9.3+. In earlier versions the service account
@@ -290,7 +290,7 @@ This value is then used when configuring Kubernetes auth, e.g.:
 
 ```bash
 vault write auth/kubernetes/config \
-  kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443" \
+  kubernetes_host="https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT" \
   issuer="\"test-aks-cluster-dns-d6cbb78e.hcp.uksouth.azmk8s.io\""
 ```
 


### PR DESCRIPTION
The Environment Variables seems wrong as you can see:
```sh
$ echo "https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT"
https://172.20.0.1:tcp://172.20.0.1:443
```


Here are all `KUBE` variables on my cluster:
```sh
$ env | grep "KUBE" | sort
KUBERNETES_PORT=tcp://172.20.0.1:443
KUBERNETES_PORT_443_TCP=tcp://172.20.0.1:443
KUBERNETES_PORT_443_TCP_ADDR=172.20.0.1
KUBERNETES_PORT_443_TCP_PORT=443
KUBERNETES_PORT_443_TCP_PROTO=tcp
KUBERNETES_SERVICE_HOST=172.20.0.1
KUBERNETES_SERVICE_PORT=443
KUBERNETES_SERVICE_PORT_HTTPS=443
```