### PR TITLE
Adding sys/internal/counters/activity endpoint

### DIFF
--- a/website/pages/api-docs/system/internal-counters.mdx
+++ b/website/pages/api-docs/system/internal-counters.mdx
@@ -130,3 +130,109 @@ $ curl \
   "auth": null
 }
 ```
+
+## Client Count
+
+This endpoint returns the number of clients per namespace, as the sum of clients calculated from the use 
+of active entities and non-entity tokens.
+An "active entity" is a distinct entity that has created one or more tokens in the given time period.
+A "non-entity token" is a token with no attached entity ID. 
+Both non-entity tokens and active entities have distinct client IDs. For more information on how clients
+map to these client IDs, and how clients are counted, please visit the 
+[client count](/docs/concepts/client-count) concepts page.
+
+A time period may be specified; otherwise it reports on a default reporting period, such as the
+previous twelve calendar months. Reports are only available with month granularity, after each month
+has completed. The response includes the actual time period covered, which may not exactly match
+the query parameters due to the monthly granularity of the data, or missing months in the requested
+time range.
+
+The response will include all child namespaces of the namespace in which the request was made.
+If some namespace has subsequently been deleted, its path will be listed as "deleted namespace :ID:".
+Deleted namespaces are reported only for queries in the root namespace, because the information about
+the namespace path is unknown.
+
+This endpoint was added in Vault 1.6.
+
+| Method | Path                              |
+| :----- | :-------------------------------- |
+| `GET`  | `/sys/internal/counters/activity` |
+
+### Parameters
+
+- `start_time` `(string, optional)` - An RFC3339 timestamp or Unix epoch time. Specifies the start of the
+  period for which client counts will be reported. If no start time is specified, the `default_report_months`
+  prior to the `end_time` will be used.
+- `end_time` `(string, optional)` - An RFC3339 timestamp or Unix epoch time. Specifies the end of the period
+  for which client counts will be reported. If no end time is specified, the end of the previous calendar
+  month will be used.
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request GET \
+    http://127.0.0.1:8200/v1/sys/internal/counters/activity
+```
+
+### Sample Response
+
+```json
+{
+  "request_id": "26be5ab9-dcac-9237-ec12-269a8ca647d5",
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": {
+    "start_time": "2019-11-01T00:00:00Z",
+    "end_time": "2020-10-31T23:59:59Z",
+    "total": {
+      "distinct_entities": 90,
+      "non_entity_tokens": 130,
+      "clients": 220
+    },
+    "by_namespace": [
+      {
+        "namespace_id": "root",
+        "namespace_path": "",
+        "counts": {
+          "distinct_entities": 85,
+          "non_entity_tokens": 15,
+          "clients": 100
+        }
+      },
+      {
+        "namespace_id": "DochC",
+        "namespace_path": "ns2/",
+        "counts": {
+          "distinct_entities": 0,
+          "non_entity_tokens": 100,
+          "clients": 100
+        }
+      },
+      {
+        "namespace_id": "RtgpW",
+        "namespace_path": "ns1/",
+        "counts": {
+          "distinct_entities": 5,
+          "non_entity_tokens": 15,
+          "clients": 20
+        }
+      }
+    ]
+  },
+  "wrap_info": null,
+  "warnings": null,
+  "auth": null
+}
+```
+
+### Sample request for a single month
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request GET \
+    http://127.0.0.1:8200/v1/sys/internal/counters/activity?end_time=2020-06-30T00%3A00%3A00Z&start_time=2020-06-01T00%3A00%3A00Z
+```


### PR DESCRIPTION
The sys/internal/counters/activity endpoint was introduced in 1.6 but is only present in versioned docs from 1.7 onward. This edit ports the details back into our versioned docs for 1.6.