### PR TITLE
secrets/azure: update to v0.11.3

### DIFF
--- a/changelog/13973.txt
+++ b/changelog/13973.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/azure: Fixed bug where Azure environment did not change Graph URL
+```

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/hashicorp/vault-plugin-mock v0.16.1
 	github.com/hashicorp/vault-plugin-secrets-ad v0.11.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2
-	github.com/hashicorp/vault-plugin-secrets-azure v0.11.2
+	github.com/hashicorp/vault-plugin-secrets-azure v0.11.3
 	github.com/hashicorp/vault-plugin-secrets-gcp v0.11.1
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.5.7-0.20220112155832-c2eb38b5f5b6

--- a/go.sum
+++ b/go.sum
@@ -966,8 +966,8 @@ github.com/hashicorp/vault-plugin-secrets-ad v0.11.1 h1:/wQvrAucbd9TucOQndKsJKm1
 github.com/hashicorp/vault-plugin-secrets-ad v0.11.1/go.mod h1:WwwDLyCMncZnOOtN2GHw6O4pIWauHhJx2DjRFbGYvV4=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2 h1:BzLD62yc5dU++yH66azcyBduXmhtpvV/4EQ7ReO7bTU=
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
-github.com/hashicorp/vault-plugin-secrets-azure v0.11.2 h1:sjAaSo2p84C1oq1LAA5El8vUlDsLamGUwMoO1mRZJIA=
-github.com/hashicorp/vault-plugin-secrets-azure v0.11.2/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
+github.com/hashicorp/vault-plugin-secrets-azure v0.11.3 h1:vYuHdqm9gpBRa6iTc7rauCND8LHyt5VJu0gvvTcz0Kk=
+github.com/hashicorp/vault-plugin-secrets-azure v0.11.3/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.11.1 h1:v8XfuZVrgP4pIwaZe/GgrPCmRuSxC/Xx8/MGvJIU5xQ=
 github.com/hashicorp/vault-plugin-secrets-gcp v0.11.1/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0 h1:0Vi5WEIpZctk/ZoRClodV9WCnM/lCzw9XekMhRZdo8k=


### PR DESCRIPTION
Updating the azure secret plugin to the latest version https://github.com/hashicorp/vault-plugin-secrets-azure/releases/tag/v0.11.3.