### PR TITLE
Backport of secrets/gcp: update to v0.11.2 into release/1.9.x

### DIFF
--- a/changelog/13974.txt
+++ b/changelog/13974.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/gcp: Fixed bug where error was not reported for invalid bindings 
+```

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-ad v0.11.1
 	github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2
 	github.com/hashicorp/vault-plugin-secrets-azure v0.11.3
-	github.com/hashicorp/vault-plugin-secrets-gcp v0.11.1
+	github.com/hashicorp/vault-plugin-secrets-gcp v0.11.2
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.10.1
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -968,8 +968,8 @@ github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2 h1:BzLD62yc5dU++yH66a
 github.com/hashicorp/vault-plugin-secrets-alicloud v0.10.2/go.mod h1:F4KWrlCQZbhP2dFXCkRvbHX2J6CTydlaY0cH+OrLHCE=
 github.com/hashicorp/vault-plugin-secrets-azure v0.11.3 h1:vYuHdqm9gpBRa6iTc7rauCND8LHyt5VJu0gvvTcz0Kk=
 github.com/hashicorp/vault-plugin-secrets-azure v0.11.3/go.mod h1:Xw8CQPkyZSJRK9BXKBruf6kOO8rLyXEf40o19ClK9kY=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.11.1 h1:v8XfuZVrgP4pIwaZe/GgrPCmRuSxC/Xx8/MGvJIU5xQ=
-github.com/hashicorp/vault-plugin-secrets-gcp v0.11.1/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.11.2 h1:IsNnBsat7/AsiVKSrlAHlINjEDXjYamIgE2igpbt1jM=
+github.com/hashicorp/vault-plugin-secrets-gcp v0.11.2/go.mod h1:ndpmRkIPHW5UYqv2nn2AJNVZsucJ8lY2bp5i5Ngvhuc=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0 h1:0Vi5WEIpZctk/ZoRClodV9WCnM/lCzw9XekMhRZdo8k=
 github.com/hashicorp/vault-plugin-secrets-gcpkms v0.10.0/go.mod h1:6DPwGu8oGR1sZRpjwkcAnrQZWQuAJ/Ph+rQHfUo1Yf4=
 github.com/hashicorp/vault-plugin-secrets-kv v0.10.1 h1:88a6YkbU0FCboZoFdB5uv6ukBf3gc3zDLKM4z64dWxo=


### PR DESCRIPTION
Automated backport failed so doing it manually: https://github.com/hashicorp/vault/pull/13979.