### PR TITLE
KV v2 doc - fix format and update examples

### DIFF
--- a/website/content/docs/secrets/kv/kv-v2.mdx
+++ b/website/content/docs/secrets/kv/kv-v2.mdx
@@ -174,7 +174,7 @@ allows for writing keys with arbitrary values.
    Key              Value
    ---              -----
    created_time     2019-06-19T17:20:22.985303Z
-   custom_metadata  map[bar:123 foo:abc]
+   custom_metadata  <nil>
    deletion_time    n/a
    destroyed        false
    version          1
@@ -188,7 +188,7 @@ allows for writing keys with arbitrary values.
    Key              Value
    ---              -----
    created_time     2019-06-19T17:20:22.985303Z
-   custom_metadata  map[bar:123 foo:abc]
+   custom_metadata  <nil>
    deletion_time    n/a
    destroyed        false
    version          1
@@ -197,6 +197,7 @@ allows for writing keys with arbitrary values.
    Key         Value
    ---         -----
    foo         a
+   bar         b
    ```
 
 1. Write another version, the previous version will still be accessible. The
@@ -211,7 +212,7 @@ allows for writing keys with arbitrary values.
    Key              Value
    ---              -----
    created_time     2019-06-19T17:22:23.369372Z
-   custom_metadata  map[bar:123 foo:abc]
+   custom_metadata  <nil>
    deletion_time    n/a
    destroyed        false
    version          2
@@ -225,7 +226,7 @@ allows for writing keys with arbitrary values.
    Key              Value
    ---              -----
    created_time     2019-06-19T17:22:23.369372Z
-   custom_metadata  map[bar:123 foo:abc]
+   custom_metadata  <nil>
    deletion_time    n/a
    destroyed        false
    version          2
@@ -254,7 +255,7 @@ allows for writing keys with arbitrary values.
    Key              Value
    ---              -----
    created_time     2019-06-19T17:23:49.199802Z
-   custom_metadata  map[bar:123 foo:abc]
+   custom_metadata  <nil>
    deletion_time    n/a
    destroyed        false
    version          3
@@ -271,7 +272,7 @@ allows for writing keys with arbitrary values.
       Key              Value
       ---              -----
       created_time     2019-06-19T17:23:49.199802Z
-      custom_metadata  map[bar:123 foo:abc]
+      custom_metadata  <nil>
       deletion_time    n/a
       destroyed        false
       version          3
@@ -283,7 +284,7 @@ allows for writing keys with arbitrary values.
    Key              Value
    ---              -----
    created_time     2019-06-19T17:23:49.199802Z
-   custom_metadata  map[bar:123 foo:abc]
+   custom_metadata  <nil>
    deletion_time    n/a
    destroyed        false
    version          3
@@ -298,7 +299,7 @@ allows for writing keys with arbitrary values.
    Key              Value
    ---              -----
    created_time     2019-06-19T17:23:49.199802Z
-   custom_metadata  map[bar:123 foo:abc]
+   custom_metadata  <nil>
    deletion_time    n/a
    destroyed        false
    version          3
@@ -318,7 +319,7 @@ allows for writing keys with arbitrary values.
    Key              Value
    ---              -----
    created_time     2019-06-19T17:20:22.985303Z
-   custom_metadata  map[bar:123 foo:abc]
+   custom_metadata  <nil>
    deletion_time    n/a
    destroyed        false
    version          1
@@ -365,7 +366,7 @@ See the commands below for more information:
    Key              Value
    ---              -----
    created_time     2019-06-19T17:23:21.834403Z
-   custom_metadata  map[bar:123 foo:abc]
+   custom_metadata  <nil>
    deletion_time    n/a
    destroyed        false
    version          2
@@ -401,7 +402,7 @@ See the commands below for more information:
    cas_required            false
    created_time            2019-06-19T17:20:22.985303Z
    current_version         2
-   custom_metadata         map[bar:123 foo:abc]
+   custom_metadata         <nil>
    delete_version_after    0s
    max_versions            0
    oldest_version          0
@@ -437,7 +438,7 @@ See the commands below for more information:
    Key              Value
    ---              -----
    created_time     2019-06-19T17:31:16.662563Z
-   custom_metadata  map[bar:123 foo:abc]
+   custom_metadata  <nil>
    deletion_time    2019-06-19T20:56:35.662563Z
    destroyed        false
    version          4
@@ -454,7 +455,7 @@ See the commands below for more information:
    cas_required            false
    created_time            2019-06-19T17:20:22.985303Z
    current_version         4
-   custom_metadata         map[bar:123 foo:abc]
+   custom_metadata         <nil>
    delete_version_after    3h25m19s
    max_versions            2
    oldest_version          3
@@ -475,22 +476,56 @@ See the commands below for more information:
    destroyed        false
    ```
 
-  A secret's key metadata can contain custom metadata used to describe the secret. The
-  data will be stored as string-to-string key-value pairs. The `-custom-metadata`
-  flag can be repeated to add multiple key-value pairs.
+   A secret's key metadata can contain custom metadata used to describe the secret.
+   The data will be stored as string-to-string key-value pairs.
+   The `-custom-metadata` flag can be repeated to add multiple key-value pairs.
+ 
+   The `vault kv metadata put` command can be used to fully overwrite the value of  `custom_metadata`:
+ 
+   ```shell-session
+   $ vault kv metadata put -custom-metadata=foo=abc -custom-metadata=bar=123 secret/ my-secret
+   Success! Data written to: secret/metadata/my-secret
 
-  The `vault kv metadata put` command can be used to fully overwrite the value of `custom_metadata`:
+   $ vault kv get secret/my-secret
+   ====== Metadata ======
+   Key              Value
+   ---              -----
+   created_time     2019-06-19T17:22:23.369372Z
+   custom_metadata  map[bar:123 foo:abc]
+   deletion_time    n/a
+   destroyed        false
+   version          2
+ 
+   ====== Data ======
+   Key         Value
+   ---         -----
+   foo         aa
+   bar         bb
+   ```
+ 
+   The `vault kv metadata patch` command can be used to partially overwrite the  valueof `custom_metadata`.
+   The following invocation will update `custom_metadata` sub-field `foo` but leave `bar` untouched:
+ 
+   ```shell-session
+   $ vault kv metadata patch -custom-metadata=foo=def secret/my-secret
+   Success! Data written to: secret/metadata/my-secret
 
-  ```shell-session
-  $ vault kv metadata put -custom-metadata=foo=abc -custom-metadata=bar=123 secret/my-secret
-  ```
-
-    The `vault kv metadata patch` command can be used to partially overwrite the value of `custom_metadata`.
-    The following invocation will update `custom_metadata` sub-field `foo` but leave `bar` untouched:
-
-    ```shell-session
-    $ vault kv metadata patch -custom-metadata=foo=def secret/my-secret
-    ```
+   $ vault kv get secret/my-secret
+   ====== Metadata ======
+   Key              Value
+   ---              -----
+   created_time     2019-06-19T17:22:23.369372Z
+   custom_metadata  map[bar:123 foo:def]
+   deletion_time    n/a
+   destroyed        false
+   version          2
+ 
+   ====== Data ======
+   Key         Value
+   ---         -----
+   foo         aa
+   bar         bb
+   ```
 
 1. Permanently delete all metadata and versions for a key:
 


### PR DESCRIPTION
target page: https://www.vaultproject.io/docs/secrets/kv/kv-v2

- Removing `custom_metadata` from the output examples as it doesn't get set until the very last step in this doc.
- Fixing a few documentation errors introduced in: https://github.com/hashicorp/vault/pull/13215/files#diff-ce3260c596dc067cd8adcae584f336676df7162cb4d6cb4d75a6ca69da9fdcd7