### PR TITLE
feature: multiplexing: fix unit tests

### DIFF
--- a/sdk/database/dbplugin/v5/grpc_server.go
+++ b/sdk/database/dbplugin/v5/grpc_server.go
@@ -74,10 +74,6 @@ func (g gRPCServer) getDatabaseInternal(ctx context.Context) (Database, error) {
 		return nil, err
 	}
 
-	if id == "" {
-		return nil, fmt.Errorf("no instance ID found for multiplexed plugin")
-	}
-
 	if db, ok := g.instances[id]; ok {
 		return db, nil
 	}

--- a/sdk/database/dbplugin/v5/grpc_server_test.go
+++ b/sdk/database/dbplugin/v5/grpc_server_test.go
@@ -612,19 +612,24 @@ func TestGetMultiplexIDFromContext(t *testing.T) {
 			expectedResp: "",
 			expectedErr:  fmt.Errorf("empty multiplex ID in metadata"),
 		},
+		"happy path, id is returned from metadata": {
+			ctx:          idCtx(t, "12345"),
+			expectedResp: "12345",
+			expectedErr:  nil,
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			resp, err := getMultiplexIDFromContext(test.ctx)
 
-			if test.expectedErr.Error() != "" && err == nil {
+			if test.expectedErr != nil && test.expectedErr.Error() != "" && err == nil {
 				t.Fatalf("err expected, got nil")
 			} else if !reflect.DeepEqual(err, test.expectedErr) {
 				t.Fatalf("Actual error: %#v\nExpected error: %#v", err, test.expectedErr)
 			}
 
-			if test.expectedErr.Error() == "" && err != nil {
+			if test.expectedErr != nil && test.expectedErr.Error() == "" && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
 

--- a/sdk/helper/pluginutil/run_config_test.go
+++ b/sdk/helper/pluginutil/run_config_test.go
@@ -38,19 +38,21 @@ func TestMakeConfig(t *testing.T) {
 				args:    []string{"foo", "bar"},
 				sha256:  []byte("some_sha256"),
 				env:     []string{"initial=true"},
-				pluginSets: map[int]plugin.PluginSet{
-					1: {
-						"bogus": nil,
+				PluginClientConfig: PluginClientConfig{
+					PluginSets: map[int]plugin.PluginSet{
+						1: {
+							"bogus": nil,
+						},
 					},
+					HandshakeConfig: plugin.HandshakeConfig{
+						ProtocolVersion:  1,
+						MagicCookieKey:   "magic_cookie_key",
+						MagicCookieValue: "magic_cookie_value",
+					},
+					Logger:         hclog.NewNullLogger(),
+					IsMetadataMode: true,
+					AutoMTLS:       false,
 				},
-				hs: plugin.HandshakeConfig{
-					ProtocolVersion:  1,
-					MagicCookieKey:   "magic_cookie_key",
-					MagicCookieValue: "magic_cookie_value",
-				},
-				logger:         hclog.NewNullLogger(),
-				isMetadataMode: true,
-				autoMTLS:       false,
 			},
 
 			responseWrapInfoTimes: 0,
@@ -97,19 +99,21 @@ func TestMakeConfig(t *testing.T) {
 				args:    []string{"foo", "bar"},
 				sha256:  []byte("some_sha256"),
 				env:     []string{"initial=true"},
-				pluginSets: map[int]plugin.PluginSet{
-					1: {
-						"bogus": nil,
+				PluginClientConfig: PluginClientConfig{
+					PluginSets: map[int]plugin.PluginSet{
+						1: {
+							"bogus": nil,
+						},
 					},
+					HandshakeConfig: plugin.HandshakeConfig{
+						ProtocolVersion:  1,
+						MagicCookieKey:   "magic_cookie_key",
+						MagicCookieValue: "magic_cookie_value",
+					},
+					Logger:         hclog.NewNullLogger(),
+					IsMetadataMode: false,
+					AutoMTLS:       false,
 				},
-				hs: plugin.HandshakeConfig{
-					ProtocolVersion:  1,
-					MagicCookieKey:   "magic_cookie_key",
-					MagicCookieValue: "magic_cookie_value",
-				},
-				logger:         hclog.NewNullLogger(),
-				isMetadataMode: false,
-				autoMTLS:       false,
 			},
 
 			responseWrapInfo: &wrapping.ResponseWrapInfo{
@@ -161,19 +165,21 @@ func TestMakeConfig(t *testing.T) {
 				args:    []string{"foo", "bar"},
 				sha256:  []byte("some_sha256"),
 				env:     []string{"initial=true"},
-				pluginSets: map[int]plugin.PluginSet{
-					1: {
-						"bogus": nil,
+				PluginClientConfig: PluginClientConfig{
+					PluginSets: map[int]plugin.PluginSet{
+						1: {
+							"bogus": nil,
+						},
 					},
+					HandshakeConfig: plugin.HandshakeConfig{
+						ProtocolVersion:  1,
+						MagicCookieKey:   "magic_cookie_key",
+						MagicCookieValue: "magic_cookie_value",
+					},
+					Logger:         hclog.NewNullLogger(),
+					IsMetadataMode: true,
+					AutoMTLS:       true,
 				},
-				hs: plugin.HandshakeConfig{
-					ProtocolVersion:  1,
-					MagicCookieKey:   "magic_cookie_key",
-					MagicCookieValue: "magic_cookie_value",
-				},
-				logger:         hclog.NewNullLogger(),
-				isMetadataMode: true,
-				autoMTLS:       true,
 			},
 
 			responseWrapInfoTimes: 0,
@@ -220,19 +226,21 @@ func TestMakeConfig(t *testing.T) {
 				args:    []string{"foo", "bar"},
 				sha256:  []byte("some_sha256"),
 				env:     []string{"initial=true"},
-				pluginSets: map[int]plugin.PluginSet{
-					1: {
-						"bogus": nil,
+				PluginClientConfig: PluginClientConfig{
+					PluginSets: map[int]plugin.PluginSet{
+						1: {
+							"bogus": nil,
+						},
 					},
+					HandshakeConfig: plugin.HandshakeConfig{
+						ProtocolVersion:  1,
+						MagicCookieKey:   "magic_cookie_key",
+						MagicCookieValue: "magic_cookie_value",
+					},
+					Logger:         hclog.NewNullLogger(),
+					IsMetadataMode: false,
+					AutoMTLS:       true,
 				},
-				hs: plugin.HandshakeConfig{
-					ProtocolVersion:  1,
-					MagicCookieKey:   "magic_cookie_key",
-					MagicCookieValue: "magic_cookie_value",
-				},
-				logger:         hclog.NewNullLogger(),
-				isMetadataMode: false,
-				autoMTLS:       true,
 			},
 
 			responseWrapInfoTimes: 0,
@@ -327,6 +335,11 @@ var _ RunnerUtil = &mockRunnerUtil{}
 
 type mockRunnerUtil struct {
 	mock.Mock
+}
+
+func (m *mockRunnerUtil) NewPluginClient(ctx context.Context, config PluginClientConfig) (PluginClient, error) {
+	args := m.Called(ctx, config)
+	return args.Get(0).(PluginClient), args.Error(1)
 }
 
 func (m *mockRunnerUtil) ResponseWrapData(ctx context.Context, data map[string]interface{}, ttl time.Duration, jwt bool) (*wrapping.ResponseWrapInfo, error) {


### PR DESCRIPTION
This PR fixes some of the unit test failures introduced by the multiplexing feature.

The remaining test failures in `test-go-remote-docker` will be addressed in another PR.