### PR TITLE
Allow generation of other types of SSH CA keys

### DIFF
--- a/builtin/logical/ssh/path_config_ca.go
+++ b/builtin/logical/ssh/path_config_ca.go
@@ -2,6 +2,10 @@ package ssh
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -44,6 +48,16 @@ func pathConfigCA(b *backend) *framework.Path {
 				Type:        framework.TypeBool,
 				Description: `Generate SSH key pair internally rather than use the private_key and public_key fields.`,
 				Default:     true,
+			},
+			"key_type": {
+				Type:        framework.TypeString,
+				Description: `Specifies the desired key type when generating; could be a OpenSSH key type identifier (ssh-rsa, ecdsa-sha2-nistp256, ecdsa-sha2-nistp384, ecdsa-sha2-nistp521, or ssh-ed25519) or an algorithm (rsa, ec, ed25519).`,
+				Default:     "ssh-rsa",
+			},
+			"key_bits": {
+				Type:        framework.TypeInt,
+				Description: `Specifies the desired key bits when generating variable-length keys (such as when key_type="ssh-rsa") or which NIST P-curve to use when key_type="ec" (256, 384, or 521).`,
+				Default:     0,
 			},
 		},
 
@@ -191,7 +205,10 @@ func (b *backend) pathConfigCAUpdate(ctx context.Context, req *logical.Request, 
 	}
 
 	if generateSigningKey {
-		publicKey, privateKey, err = generateSSHKeyPair(b.Backend.GetRandomReader())
+		keyType := data.Get("key_type").(string)
+		keyBits := data.Get("key_bits").(int)
+
+		publicKey, privateKey, err = generateSSHKeyPair(b.Backend.GetRandomReader(), keyType, keyBits)
 		if err != nil {
 			return nil, err
 		}
@@ -265,22 +282,98 @@ func (b *backend) pathConfigCAUpdate(ctx context.Context, req *logical.Request, 
 	return nil, nil
 }
 
-func generateSSHKeyPair(randomSource io.Reader) (string, string, error) {
+func generateSSHKeyPair(randomSource io.Reader, keyType string, keyBits int) (string, string, error) {
 	if randomSource == nil {
 		randomSource = rand.Reader
 	}
-	privateSeed, err := rsa.GenerateKey(randomSource, 4096)
-	if err != nil {
-		return "", "", err
+
+	var publicKey crypto.PublicKey
+	var privateBlock *pem.Block
+
+	switch keyType {
+	case ssh.KeyAlgoRSA, "rsa":
+		if keyBits == 0 {
+			keyBits = 4096
+		}
+
+		if keyBits < 2048 {
+			return "", "", fmt.Errorf("refusing to generate weak %v key: %v bits < 2048 bits", keyType, keyBits)
+		}
+
+		privateSeed, err := rsa.GenerateKey(randomSource, keyBits)
+		if err != nil {
+			return "", "", err
+		}
+
+		privateBlock = &pem.Block{
+			Type:    "RSA PRIVATE KEY",
+			Headers: nil,
+			Bytes:   x509.MarshalPKCS1PrivateKey(privateSeed),
+		}
+
+		publicKey = privateSeed.Public()
+	case ssh.KeyAlgoECDSA256, ssh.KeyAlgoECDSA384, ssh.KeyAlgoECDSA521, "ec":
+		var curve elliptic.Curve
+		switch keyType {
+		case ssh.KeyAlgoECDSA256:
+			curve = elliptic.P256()
+		case ssh.KeyAlgoECDSA384:
+			curve = elliptic.P384()
+		case ssh.KeyAlgoECDSA521:
+			curve = elliptic.P521()
+		default:
+			switch keyBits {
+			case 0, 256:
+				curve = elliptic.P256()
+			case 384:
+				curve = elliptic.P384()
+			case 521:
+				curve = elliptic.P521()
+			default:
+				return "", "", fmt.Errorf("unknown ECDSA key pair algorithm: %v", keyType)
+			}
+		}
+
+		privateSeed, err := ecdsa.GenerateKey(curve, randomSource)
+		if err != nil {
+			return "", "", err
+		}
+
+		marshalled, err := x509.MarshalECPrivateKey(privateSeed)
+		if err != nil {
+			return "", "", err
+		}
+
+		privateBlock = &pem.Block{
+			Type:    "EC PRIVATE KEY",
+			Headers: nil,
+			Bytes:   marshalled,
+		}
+
+		publicKey = privateSeed.Public()
+	case ssh.KeyAlgoED25519, "ed25519":
+		_, privateSeed, err := ed25519.GenerateKey(randomSource)
+		if err != nil {
+			return "", "", err
+		}
+
+		marshalled, err := x509.MarshalPKCS8PrivateKey(privateSeed)
+		if err != nil {
+			return "", "", err
+		}
+
+		privateBlock = &pem.Block{
+			Type:    "OPENSSH PRIVATE KEY",
+			Headers: nil,
+			Bytes:   marshalled,
+		}
+
+		publicKey = privateSeed.Public()
+	default:
+		return "", "", fmt.Errorf("unknown ssh key pair algorithm: %v", keyType)
 	}
 
-	privateBlock := &pem.Block{
-		Type:    "RSA PRIVATE KEY",
-		Headers: nil,
-		Bytes:   x509.MarshalPKCS1PrivateKey(privateSeed),
-	}
-
-	public, err := ssh.NewPublicKey(&privateSeed.PublicKey)
+	public, err := ssh.NewPublicKey(publicKey)
 	if err != nil {
 		return "", "", err
 	}

--- a/changelog/14008.txt
+++ b/changelog/14008.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/ssh: Add support for generating non-RSA SSH CAs
+```

--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -649,6 +649,21 @@ overridden._
   If `false`, then you must provide `private_key` and `public_key`, but these
   can be of any valid signing key type.
 
+- `key_type` `(string: ssh-rsa)` - Specifies the desired key type for the
+  generated SSH CA key when `generate_signing_key` is set to `true`. Valid
+  values are OpenSSH key type identifiers (`ssh-rsa`, `ecdsa-sha2-nistp256`,
+  `ecdsa-sha2-nistp384`, `ecdsa-sha2-nistp521`, or `ssh-ed25519`) or an
+  algorithm (`rsa`, `ec`, or `ed25519`).
+
+- `key_bits` `(int: 0)` - Specifies the desired key bits for the generated SSH
+  CA key when `generate_signing_key` is set to `true`. This is only used for
+  variable length keys (such as `ssh-rsa`, where the value of `key_bits`
+  specifies the size of the RSA key pair to generate; with the default `0`
+  value resulting in a 4096-bit key) or when the `ec` algorithm is specified
+  in `key_type` (where the value of `key_bits` identifies which NIST P-curve
+  to use; `256`, `384`, or `521`, with the default `0` value resulting in a
+  NIST P-256 key).
+
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
Curious about general sentiment here; if it is positive, I'll add docs and a changelog and we can decide what to do about the UI (leave it as-is or drop it for future work).

See https://github.com/hashicorp/vault/issues/11035 for context. We derive types from the `x/crypto/ssh` types (which match OpenSSH's constants), thus making key bits only relevant for RSA keys. We're notably short exporting the private key (for parity with PKI secrets engine).

Resolves: #11035 

---

This probably needs some additional UI work, but it works :laughing:

@ivana-mcconnell or @hellobontempo do either you have any thoughts here? It seems like the UI of SSH CA generation isn't at all like the PKI functionality; it looks like there's no dynamic fields (the hbs template needed to be updated manually) and lacks a lot of the `actions` for groups or changes &c. I couldn't figure out how to use a `<Select />` component either; it appears to require an `onChange` action (which we appear to lack completely) and even without it, the `options` didn't populate (either manually or from the element's chosen values). Similarly failed via `<FormFieldFromModel />` -- that didn't even display at all. :/

**Edit**: Screenshot

![Screenshot from 2022-02-14 10-09-32](https://user-images.githubusercontent.com/914030/153890173-6d10a1d5-a3ac-40fe-a9d1-f8dd42353781.png)
