### PR TITLE
Consul acl role support

### DIFF
--- a/builtin/logical/consul/backend_test.go
+++ b/builtin/logical/consul/backend_test.go
@@ -22,7 +22,7 @@ func TestBackend_Config_Access(t *testing.T) {
 		t.Parallel()
 		t.Run("pre-1.4.0", func(t *testing.T) {
 			t.Parallel()
-			testBackendConfigAccess(t, "1.3.0")
+			testBackendConfigAccess(t, "1.3.1")
 		})
 		t.Run("post-1.4.0", func(t *testing.T) {
 			t.Parallel()
@@ -82,7 +82,7 @@ func TestBackend_Renew_Revoke(t *testing.T) {
 		t.Parallel()
 		t.Run("pre-1.4.0", func(t *testing.T) {
 			t.Parallel()
-			testBackendRenewRevoke(t, "1.3.0")
+			testBackendRenewRevoke(t, "1.3.1")
 		})
 		t.Run("post-1.4.0", func(t *testing.T) {
 			t.Parallel()
@@ -118,7 +118,7 @@ func testBackendRenewRevoke(t *testing.T, version string) {
 		Path:      "config/access",
 		Data:      connData,
 	}
-	resp, err := b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,14 +128,14 @@ func testBackendRenewRevoke(t *testing.T, version string) {
 		"policy": base64.StdEncoding.EncodeToString([]byte(testPolicy)),
 		"lease":  "6h",
 	}
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req.Operation = logical.ReadOperation
 	req.Path = "creds/test"
-	resp, err = b.HandleRequest(context.Background(), req)
+	resp, err := b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +186,7 @@ func testBackendRenewRevoke(t *testing.T, version string) {
 	}
 
 	req.Operation = logical.RevokeOperation
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func testBackendRenewRevoke14(t *testing.T, version string) {
 		Path:      "config/access",
 		Data:      connData,
 	}
-	resp, err := b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,14 +233,14 @@ func testBackendRenewRevoke14(t *testing.T, version string) {
 		"policies": []string{"test"},
 		"lease":    "6h",
 	}
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req.Operation = logical.ReadOperation
 	req.Path = "creds/test"
-	resp, err = b.HandleRequest(context.Background(), req)
+	resp, err := b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,7 +289,7 @@ func testBackendRenewRevoke14(t *testing.T, version string) {
 	}
 
 	req.Operation = logical.RevokeOperation
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -335,7 +335,7 @@ func TestBackend_LocalToken(t *testing.T) {
 		Path:      "config/access",
 		Data:      connData,
 	}
-	resp, err := b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +346,7 @@ func TestBackend_LocalToken(t *testing.T) {
 		"ttl":      "6h",
 		"local":    false,
 	}
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,14 +357,14 @@ func TestBackend_LocalToken(t *testing.T) {
 		"ttl":      "6h",
 		"local":    true,
 	}
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req.Operation = logical.ReadOperation
 	req.Path = "creds/test"
-	resp, err = b.HandleRequest(context.Background(), req)
+	resp, err := b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -447,12 +447,14 @@ func TestBackend_Management(t *testing.T) {
 		t.Parallel()
 		t.Run("pre-1.4.0", func(t *testing.T) {
 			t.Parallel()
-			testBackendManagement(t, "1.3.0")
+			testBackendManagement(t, "1.3.1")
 		})
 		t.Run("post-1.4.0", func(t *testing.T) {
 			t.Parallel()
 			testBackendManagement(t, "1.4.4")
 		})
+
+		testBackendManagement(t, "1.10.8")
 	})
 }
 
@@ -487,15 +489,16 @@ func TestBackend_Basic(t *testing.T) {
 		t.Parallel()
 		t.Run("pre-1.4.0", func(t *testing.T) {
 			t.Parallel()
-			testBackendBasic(t, "1.3.0")
+			testBackendBasic(t, "1.3.1")
 		})
 		t.Run("post-1.4.0", func(t *testing.T) {
 			t.Parallel()
 			t.Run("legacy", func(t *testing.T) {
 				t.Parallel()
-				testBackendRenewRevoke(t, "1.4.4")
+				testBackendBasic(t, "1.4.4")
 			})
-			testBackendBasic(t, "1.4.4")
+
+			testBackendBasic(t, "1.10.8")
 		})
 	})
 }
@@ -724,7 +727,7 @@ func TestBackend_Roles(t *testing.T) {
 		Path:      "config/access",
 		Data:      connData,
 	}
-	resp, err := b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -735,14 +738,14 @@ func TestBackend_Roles(t *testing.T) {
 		"consul_roles": []string{"role-test"},
 		"lease":        "6h",
 	}
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req.Operation = logical.ReadOperation
 	req.Path = "creds/test-consul-roles"
-	resp, err = b.HandleRequest(context.Background(), req)
+	resp, err := b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -791,7 +794,7 @@ func TestBackend_Roles(t *testing.T) {
 	}
 
 	req.Operation = logical.RevokeOperation
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -853,7 +856,7 @@ func testBackendEntNamespace(t *testing.T) {
 		Path:      "config/access",
 		Data:      connData,
 	}
-	resp, err := b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -865,14 +868,14 @@ func testBackendEntNamespace(t *testing.T) {
 		"lease":            "6h",
 		"consul_namespace": "ns1",
 	}
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req.Operation = logical.ReadOperation
 	req.Path = "creds/test-ns"
-	resp, err = b.HandleRequest(context.Background(), req)
+	resp, err := b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -926,7 +929,7 @@ func testBackendEntNamespace(t *testing.T) {
 	}
 
 	req.Operation = logical.RevokeOperation
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -973,7 +976,7 @@ func testBackendEntPartition(t *testing.T) {
 		Path:      "config/access",
 		Data:      connData,
 	}
-	resp, err := b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -985,14 +988,14 @@ func testBackendEntPartition(t *testing.T) {
 		"lease":     "6h",
 		"partition": "part1",
 	}
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req.Operation = logical.ReadOperation
 	req.Path = "creds/test-part"
-	resp, err = b.HandleRequest(context.Background(), req)
+	resp, err := b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1046,7 +1049,7 @@ func testBackendEntPartition(t *testing.T) {
 	}
 
 	req.Operation = logical.RevokeOperation
-	resp, err = b.HandleRequest(context.Background(), req)
+	_, err = b.HandleRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/consul/path_roles.go
+++ b/builtin/logical/consul/path_roles.go
@@ -37,8 +37,8 @@ for 'client' tokens. Required for Consul pre-1.4.`,
 
 			"policies": {
 				Type: framework.TypeCommaStringSlice,
-				Description: `List of policies to attach to the token. Required
-for Consul 1.4 or above.`,
+				Description: `List of policies to attach to the token. Policies required
+for Consul 1.4 or above, roles can be used for Consul 1.5 and above.`,
 			},
 
 			"local": {

--- a/builtin/logical/consul/path_roles.go
+++ b/builtin/logical/consul/path_roles.go
@@ -37,14 +37,14 @@ for 'client' tokens. Required for Consul pre-1.4.`,
 
 			"policies": {
 				Type: framework.TypeCommaStringSlice,
-				Description: `List of policies to attach to the token. Policies required
-for Consul 1.4 or above, roles can be used for Consul 1.5 and above.`,
+				Description: `List of policies to attach to the token. Either policies or 
+roles are required for Consul 1.5 and above, or just policies if using Consul 1.4.`,
 			},
 
 			"roles": {
 				Type: framework.TypeCommaStringSlice,
-				Description: `List of roles to attach to the token. Policies / roles required
-				for Consul 1.5 or above.`,
+				Description: `List of roles to attach to the token. Either policies or
+roles are required for Consul 1.5 and above.`,
 			},
 
 			"local": {
@@ -56,10 +56,8 @@ and instead be local to the current datacenter.  Available in Consul 1.4 and abo
 			"token_type": {
 				Type:    framework.TypeString,
 				Default: "client",
-				Description: `Which type of token to create: 'client'
-or 'management'. If a 'management' token,
-the "policy" parameter is not required.
-Defaults to 'client'.`,
+				Description: `Which type of token to create: 'client' or 'management'. If
+a 'management' token, the "policy" parameter is not required. Defaults to 'client'.`,
 			},
 
 			"ttl": {
@@ -119,35 +117,35 @@ func (b *backend) pathRolesRead(ctx context.Context, req *logical.Request, d *fr
 		return nil, nil
 	}
 
-	var result roleConfig
-	if err := entry.DecodeJSON(&result); err != nil {
+	var roleConfigData roleConfig
+	if err := entry.DecodeJSON(&roleConfigData); err != nil {
 		return nil, err
 	}
 
-	if result.TokenType == "" {
-		result.TokenType = "client"
+	if roleConfigData.TokenType == "" {
+		roleConfigData.TokenType = "client"
 	}
 
 	// Generate the response
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"lease":            int64(result.TTL.Seconds()),
-			"ttl":              int64(result.TTL.Seconds()),
-			"max_ttl":          int64(result.MaxTTL.Seconds()),
-			"token_type":       result.TokenType,
-			"local":            result.Local,
-			"consul_namespace": result.ConsulNamespace,
-			"partition":        result.Partition,
+			"lease":            int64(roleConfigData.TTL.Seconds()),
+			"ttl":              int64(roleConfigData.TTL.Seconds()),
+			"max_ttl":          int64(roleConfigData.MaxTTL.Seconds()),
+			"token_type":       roleConfigData.TokenType,
+			"local":            roleConfigData.Local,
+			"consul_namespace": roleConfigData.ConsulNamespace,
+			"partition":        roleConfigData.Partition,
 		},
 	}
-	if result.Policy != "" {
-		resp.Data["policy"] = base64.StdEncoding.EncodeToString([]byte(result.Policy))
+	if roleConfigData.Policy != "" {
+		resp.Data["policy"] = base64.StdEncoding.EncodeToString([]byte(roleConfigData.Policy))
 	}
-	if len(result.Policies) > 0 {
-		resp.Data["policies"] = result.Policies
+	if len(roleConfigData.Policies) > 0 {
+		resp.Data["policies"] = roleConfigData.Policies
 	}
-	if len(result.Roles) > 0 {
-		resp.Data["roles"] = result.Roles
+	if len(roleConfigData.Roles) > 0 {
+		resp.Data["roles"] = roleConfigData.Roles
 	}
 	return resp, nil
 }

--- a/builtin/logical/consul/path_token.go
+++ b/builtin/logical/consul/path_token.go
@@ -97,7 +97,7 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 	}
 
 	roleLinks := []*api.ACLTokenRoleLink{}
-	for _, roleName := range roleConfigData.Roles {
+	for _, roleName := range roleConfigData.ConsulRoles {
 		roleLinks = append(roleLinks, &api.ACLTokenRoleLink{
 			Name: roleName,
 		})

--- a/builtin/logical/consul/path_token.go
+++ b/builtin/logical/consul/path_token.go
@@ -22,21 +22,6 @@ func pathToken(b *backend) *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Name of the role.",
 			},
-
-			"policies": {
-				Type:        framework.TypeCommaStringSlice,
-				Description: `List of policies to attach to the token.`,
-			},
-
-			"consul_namespace": {
-				Type:        framework.TypeString,
-				Description: "Namespace to create the token in.",
-			},
-
-			"partition": {
-				Type:        framework.TypeString,
-				Description: "Admin partition to create the token in.",
-			},
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{

--- a/builtin/logical/consul/path_token.go
+++ b/builtin/logical/consul/path_token.go
@@ -111,9 +111,9 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 		})
 	}
 
-	roleLink := []*api.ACLTokenRoleLink{}
+	roleLinks := []*api.ACLTokenRoleLink{}
 	for _, roleName := range roleConfigData.Roles {
-		roleLink = append(roleLink, &api.ACLTokenRoleLink{
+		roleLinks = append(roleLinks, &api.ACLTokenRoleLink{
 			Name: roleName,
 		})
 	}
@@ -121,7 +121,7 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 	token, _, err := c.ACL().TokenCreate(&api.ACLToken{
 		Description: tokenName,
 		Policies:    policyLinks,
-		Roles:       roleLink,
+		Roles:       roleLinks,
 		Local:       roleConfigData.Local,
 		Namespace:   roleConfigData.ConsulNamespace,
 		Partition:   roleConfigData.Partition,

--- a/builtin/logical/consul/path_token.go
+++ b/builtin/logical/consul/path_token.go
@@ -105,16 +105,23 @@ func (b *backend) pathTokenRead(ctx context.Context, req *logical.Request, d *fr
 
 	// Create an ACLToken for Consul 1.4 and above
 	policyLinks := []*api.ACLTokenPolicyLink{}
-
 	for _, policyName := range roleConfigData.Policies {
 		policyLinks = append(policyLinks, &api.ACLTokenPolicyLink{
 			Name: policyName,
 		})
 	}
 
+	roleLink := []*api.ACLTokenRoleLink{}
+	for _, roleName := range roleConfigData.Roles {
+		roleLink = append(roleLink, &api.ACLTokenRoleLink{
+			Name: roleName,
+		})
+	}
+
 	token, _, err := c.ACL().TokenCreate(&api.ACLToken{
 		Description: tokenName,
 		Policies:    policyLinks,
+		Roles:       roleLink,
 		Local:       roleConfigData.Local,
 		Namespace:   roleConfigData.ConsulNamespace,
 		Partition:   roleConfigData.Partition,

--- a/changelog/14014.txt
+++ b/changelog/14014.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/consul: Add support for consul roles.
+```

--- a/go.mod
+++ b/go.mod
@@ -280,7 +280,7 @@ require (
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
 	github.com/hashicorp/go-slug v0.7.0 // indirect
 	github.com/hashicorp/go-tfe v0.20.0 // indirect
-	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/go-version v1.4.0 // indirect
 	github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/mdns v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -897,6 +897,8 @@ github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
+github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/helper/testhelpers/consul/consulhelper.go
+++ b/helper/testhelpers/consul/consulhelper.go
@@ -136,6 +136,20 @@ func PrepareTestContainer(t *testing.T, version string, isEnterprise bool) (func
 			return nil, err
 		}
 
+		// Create a Consul role that contains the test policy, for Consul 1.5 and newer
+		ACLList := []*consulapi.ACLLink{{Name: "test"}}
+
+		role := &consulapi.ACLRole{
+			Name:        "role-test",
+			Description: "consul roles test",
+			Policies:    ACLList,
+		}
+
+		_, _, err = consul.ACL().RoleCreate(role, q)
+		if err != nil {
+			return nil, err
+		}
+
 		// Configure a namespace and parition if testing enterprise Consul
 		if isEnterprise {
 

--- a/helper/testhelpers/consul/consulhelper.go
+++ b/helper/testhelpers/consul/consulhelper.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	consulapi "github.com/hashicorp/consul/api"
+	goversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/vault/helper/testhelpers/docker"
 )
 
@@ -43,7 +44,7 @@ func PrepareTestContainer(t *testing.T, version string, isEnterprise bool) (func
 		if consulVersion != "" {
 			version = consulVersion
 		} else {
-			version = "1.11.2" // Latest Consul version, update as new releases come out
+			version = "1.11.3" // Latest Consul version, update as new releases come out
 		}
 	}
 	if strings.HasPrefix(version, "1.3") {
@@ -137,68 +138,77 @@ func PrepareTestContainer(t *testing.T, version string, isEnterprise bool) (func
 		}
 
 		// Create a Consul role that contains the test policy, for Consul 1.5 and newer
-		ACLList := []*consulapi.ACLLink{{Name: "test"}}
+		currVersion, _ := goversion.NewVersion(version)
+		roleVersion, _ := goversion.NewVersion("1.5")
+		if currVersion.GreaterThanOrEqual(roleVersion) {
+			ACLList := []*consulapi.ACLLink{{Name: "test"}}
 
-		role := &consulapi.ACLRole{
-			Name:        "role-test",
-			Description: "consul roles test",
-			Policies:    ACLList,
-		}
+			role := &consulapi.ACLRole{
+				Name:        "role-test",
+				Description: "consul roles test",
+				Policies:    ACLList,
+			}
 
-		_, _, err = consul.ACL().RoleCreate(role, q)
-		if err != nil {
-			return nil, err
+			_, _, err = consul.ACL().RoleCreate(role, q)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		// Configure a namespace and parition if testing enterprise Consul
 		if isEnterprise {
-
 			// Namespaces require Consul 1.7 or newer
-			namespace := &consulapi.Namespace{
-				Name:        "ns1",
-				Description: "ns1 test",
-			}
+			namespaceVersion, _ := goversion.NewVersion("1.7")
+			if currVersion.GreaterThanOrEqual(namespaceVersion) {
+				namespace := &consulapi.Namespace{
+					Name:        "ns1",
+					Description: "ns1 test",
+				}
 
-			_, _, err = consul.Namespaces().Create(namespace, q)
-			if err != nil {
-				return nil, err
-			}
+				_, _, err = consul.Namespaces().Create(namespace, q)
+				if err != nil {
+					return nil, err
+				}
 
-			nsPolicy := &consulapi.ACLPolicy{
-				Name:        "ns-test",
-				Description: "namespace test",
-				Namespace:   "ns1",
-				Rules: `service_prefix "" {
+				nsPolicy := &consulapi.ACLPolicy{
+					Name:        "ns-test",
+					Description: "namespace test",
+					Namespace:   "ns1",
+					Rules: `service_prefix "" {
 							policy = "read"
 						}`,
-			}
-			_, _, err = consul.ACL().PolicyCreate(nsPolicy, q)
-			if err != nil {
-				return nil, err
+				}
+				_, _, err = consul.ACL().PolicyCreate(nsPolicy, q)
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			// Partitions require Consul 1.11 or newer
-			partition := &consulapi.Partition{
-				Name:        "part1",
-				Description: "part1 test",
-			}
+			partitionVersion, _ := goversion.NewVersion("1.11")
+			if currVersion.GreaterThanOrEqual(partitionVersion) {
+				partition := &consulapi.Partition{
+					Name:        "part1",
+					Description: "part1 test",
+				}
 
-			_, _, err = consul.Partitions().Create(ctx, partition, q)
-			if err != nil {
-				return nil, err
-			}
+				_, _, err = consul.Partitions().Create(ctx, partition, q)
+				if err != nil {
+					return nil, err
+				}
 
-			partPolicy := &consulapi.ACLPolicy{
-				Name:        "part-test",
-				Description: "partition test",
-				Partition:   "part1",
-				Rules: `service_prefix "" {
+				partPolicy := &consulapi.ACLPolicy{
+					Name:        "part-test",
+					Description: "partition test",
+					Partition:   "part1",
+					Rules: `service_prefix "" {
 							policy = "read"
 						}`,
-			}
-			_, _, err = consul.ACL().PolicyCreate(partPolicy, q)
-			if err != nil {
-				return nil, err
+				}
+				_, _, err = consul.ACL().PolicyCreate(partPolicy, q)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 

--- a/website/content/api-docs/secret/consul.mdx
+++ b/website/content/api-docs/secret/consul.mdx
@@ -79,15 +79,20 @@ updated attributes.
   which to create this Consul credential. This is part of the request URL.
 
 - `token_type` `(string: "client")` - Specifies the type of token to create when
-  using this role. Valid values are `"client"` or `"management"`.
+  using this role. Valid values are `"client"` or `"management"`. If a `"management"`
+  token, the `policy`, `policies`, and `consul_roles` parameters are not required.
+  Defaults to `"client`".
 
-- `policy` `(string: <policy or policies>)` – Specifies the base64 encoded ACL policy. The
-  ACL format can be found in the [Consul ACL
-  documentation](https://www.consul.io/docs/internals/acl). This is
-  required unless the `token_type` is `management`.
+- `policy` `(string: <policy>)` – Specifies the base64-encoded ACL policy. This is
+  required unless the `token_type` is `"management"`. [Deprecated as of Consul 1.4 and 
+  removed as of Consul 1.11.](https://www.consul.io/api/acl/legacy)
 
-- `policies` `(list: <policy or policies>)` – The list of policies to assign to the generated
-  token. This is only available in Consul 1.4 and greater.
+- `policies` `(list: <policy or policies>)` – The list of policies to assign to the
+  generated token. Either `policies` or `consul_roles` are required for Consul 1.5 and
+  above, or just `policies` if using Consul 1.4.
+
+- `consul_roles` `(list: <role or roles>)` – The list of Consul roles to assign to the
+  generated token. Either `policies` or `consul_roles` are required for Consul 1.5 and above.
 
 - `local` `(bool: false)` - Indicates that the token should not be replicated
   globally and instead be local to the current datacenter. Only available in Consul
@@ -111,11 +116,19 @@ To create management tokens:
 }
 ```
 
-To create a client token with a custom policy:
+To create a client token with defined policies:
 
 ```json
 {
-  "policy": "abd2...=="
+  "policies": "global-management,policy-2"
+}
+```
+
+To create a client token with defined roles:
+
+```json
+{
+  "consul_roles": "role-a,role-b"
 }
 ```
 
@@ -135,25 +148,29 @@ $ curl \
   as a string duration with a time suffix like `"30s"` or `"1h"`. If not
   provided, the default Vault lease is used.
 
-- `policies` `(string: <required>)` – Comma separated list of policies to be applied
-  to the tokens.
+- `policy` `(string: <policy>)` – Specifies the base64-encoded ACL policy. The
+  ACL format can be found in the [Consul ACL
+  documentation](https://www.consul.io/docs/security/acl/acl-legacy). This is
+  required unless the `token_type` is `"management"`.
 
 ### Sample payload
 
+To create a client token with a custom base64-encoded policy:
+
 ```json
 {
-  "policies": "global-management"
+  "policy": "a2V5ICIi...=="
 }
 ```
 
 ### Sample request
 
-```sh
-curl \
-→     --request POST \
-→     --header "X-Vault-Token: ..."\
-→     --data @payload.json \
-→     http://127.0.0.1:8200/v1/consul/roles/example-role
+```shell-session
+$ curl \
+    --request POST \
+    --header "X-Vault-Token: ..." \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/consul/roles/example-role
 ```
 
 ## Read Role

--- a/website/content/api-docs/secret/consul.mdx
+++ b/website/content/api-docs/secret/consul.mdx
@@ -89,6 +89,9 @@ updated attributes.
 - `policies` `(list: <policy or policies>)` – The list of policies to assign to the generated
   token. This is only available in Consul 1.4 and greater.
 
+- `roles` `(list: <role or roles>)` – The list of roles to assign to the generated
+  token. This is only available in Consul 1.5 and greater.
+
 - `local` `(bool: false)` - Indicates that the token should not be replicated
   globally and instead be local to the current datacenter. Only available in Consul
   1.4 and greater.
@@ -116,6 +119,14 @@ To create a client token with a custom policy:
 ```json
 {
   "policy": "abd2...=="
+}
+```
+
+To create a client token with defined roles:
+
+```json
+{
+  "roles": "role-a,role-b"
 }
 ```
 

--- a/website/content/api-docs/secret/consul.mdx
+++ b/website/content/api-docs/secret/consul.mdx
@@ -79,20 +79,15 @@ updated attributes.
   which to create this Consul credential. This is part of the request URL.
 
 - `token_type` `(string: "client")` - Specifies the type of token to create when
-  using this role. Valid values are `"client"` or `"management"`. If a `"management"`
-  token, the `policy`, `policies`, and `consul_roles` parameters are not required.
-  Defaults to `"client`".
+  using this role. Valid values are `"client"` or `"management"`.
 
-- `policy` `(string: <policy>)` – Specifies the base64-encoded ACL policy. This is
-  required unless the `token_type` is `"management"`. [Deprecated as of Consul 1.4 and 
-  removed as of Consul 1.11.](https://www.consul.io/api/acl/legacy)
+- `policy` `(string: <policy or policies>)` – Specifies the base64 encoded ACL policy. The
+  ACL format can be found in the [Consul ACL
+  documentation](https://www.consul.io/docs/internals/acl). This is
+  required unless the `token_type` is `management`.
 
-- `policies` `(list: <policy or policies>)` – The list of policies to assign to the
-  generated token. Either `policies` or `consul_roles` are required for Consul 1.5 and
-  above, or just `policies` if using Consul 1.4.
-
-- `consul_roles` `(list: <role or roles>)` – The list of Consul roles to assign to the
-  generated token. Either `policies` or `consul_roles` are required for Consul 1.5 and above.
+- `policies` `(list: <policy or policies>)` – The list of policies to assign to the generated
+  token. This is only available in Consul 1.4 and greater.
 
 - `local` `(bool: false)` - Indicates that the token should not be replicated
   globally and instead be local to the current datacenter. Only available in Consul
@@ -116,19 +111,11 @@ To create management tokens:
 }
 ```
 
-To create a client token with defined policies:
+To create a client token with a custom policy:
 
 ```json
 {
-  "policies": "global-management,policy-2"
-}
-```
-
-To create a client token with defined roles:
-
-```json
-{
-  "consul_roles": "role-a,role-b"
+  "policy": "abd2...=="
 }
 ```
 
@@ -148,29 +135,25 @@ $ curl \
   as a string duration with a time suffix like `"30s"` or `"1h"`. If not
   provided, the default Vault lease is used.
 
-- `policy` `(string: <policy>)` – Specifies the base64-encoded ACL policy. The
-  ACL format can be found in the [Consul ACL
-  documentation](https://www.consul.io/docs/security/acl/acl-legacy). This is
-  required unless the `token_type` is `"management"`.
+- `policies` `(string: <required>)` – Comma separated list of policies to be applied
+  to the tokens.
 
 ### Sample payload
 
-To create a client token with a custom base64-encoded policy:
-
 ```json
 {
-  "policy": "a2V5ICIi...=="
+  "policies": "global-management"
 }
 ```
 
 ### Sample request
 
-```shell-session
-$ curl \
-    --request POST \
-    --header "X-Vault-Token: ..." \
-    --data @payload.json \
-    http://127.0.0.1:8200/v1/consul/roles/example-role
+```sh
+curl \
+→     --request POST \
+→     --header "X-Vault-Token: ..."\
+→     --data @payload.json \
+→     http://127.0.0.1:8200/v1/consul/roles/example-role
 ```
 
 ## Read Role

--- a/website/content/api-docs/secret/consul.mdx
+++ b/website/content/api-docs/secret/consul.mdx
@@ -79,17 +79,20 @@ updated attributes.
   which to create this Consul credential. This is part of the request URL.
 
 - `token_type` `(string: "client")` - Specifies the type of token to create when
-  using this role. Valid values are `"client"` or `"management"`.
+  using this role. Valid values are `"client"` or `"management"`. If a `"management"`
+  token, the `policy`, `policies`, and `consul_roles` parameters are not required.
+  Defaults to `"client`".
 
 - `policy` `(string: <policy>)` – Specifies the base64-encoded ACL policy. This is
   required unless the `token_type` is `"management"`. [Deprecated as of Consul 1.4 and 
   removed as of Consul 1.11.](https://www.consul.io/api/acl/legacy)
 
 - `policies` `(list: <policy or policies>)` – The list of policies to assign to the
-  generated token. This is only available in Consul 1.4 and greater.
+  generated token. Either `policies` or `consul_roles` are required for Consul 1.5 and
+  above, or just `policies` if using Consul 1.4.
 
-- `roles` `(list: <role or roles>)` – The list of roles to assign to the generated
-  token. This is only available in Consul 1.5 and greater.
+- `consul_roles` `(list: <role or roles>)` – The list of Consul roles to assign to the
+  generated token. Either `policies` or `consul_roles` are required for Consul 1.5 and above.
 
 - `local` `(bool: false)` - Indicates that the token should not be replicated
   globally and instead be local to the current datacenter. Only available in Consul
@@ -125,7 +128,7 @@ To create a client token with defined roles:
 
 ```json
 {
-  "roles": "role-a,role-b"
+  "consul_roles": "role-a,role-b"
 }
 ```
 

--- a/website/content/api-docs/secret/consul.mdx
+++ b/website/content/api-docs/secret/consul.mdx
@@ -81,13 +81,12 @@ updated attributes.
 - `token_type` `(string: "client")` - Specifies the type of token to create when
   using this role. Valid values are `"client"` or `"management"`.
 
-- `policy` `(string: <policy or policies>)` – Specifies the base64 encoded ACL policy. The
-  ACL format can be found in the [Consul ACL
-  documentation](https://www.consul.io/docs/internals/acl). This is
-  required unless the `token_type` is `management`.
+- `policy` `(string: <policy>)` – Specifies the base64-encoded ACL policy. This is
+  required unless the `token_type` is `"management"`. [Deprecated as of Consul 1.4 and 
+  removed as of Consul 1.11.](https://www.consul.io/api/acl/legacy)
 
-- `policies` `(list: <policy or policies>)` – The list of policies to assign to the generated
-  token. This is only available in Consul 1.4 and greater.
+- `policies` `(list: <policy or policies>)` – The list of policies to assign to the
+  generated token. This is only available in Consul 1.4 and greater.
 
 - `roles` `(list: <role or roles>)` – The list of roles to assign to the generated
   token. This is only available in Consul 1.5 and greater.
@@ -114,11 +113,11 @@ To create management tokens:
 }
 ```
 
-To create a client token with a custom policy:
+To create a client token with defined policies:
 
 ```json
 {
-  "policy": "abd2...=="
+  "policies": "global-management,policy-2"
 }
 ```
 
@@ -146,25 +145,29 @@ $ curl \
   as a string duration with a time suffix like `"30s"` or `"1h"`. If not
   provided, the default Vault lease is used.
 
-- `policies` `(string: <required>)` – Comma separated list of policies to be applied
-  to the tokens.
+- `policy` `(string: <policy>)` – Specifies the base64-encoded ACL policy. The
+  ACL format can be found in the [Consul ACL
+  documentation](https://www.consul.io/docs/security/acl/acl-legacy). This is
+  required unless the `token_type` is `"management"`.
 
 ### Sample payload
 
+To create a client token with a custom base64-encoded policy:
+
 ```json
 {
-  "policies": "global-management"
+  "policy": "a2V5ICIi...=="
 }
 ```
 
 ### Sample request
 
-```sh
-curl \
-→     --request POST \
-→     --header "X-Vault-Token: ..."\
-→     --data @payload.json \
-→     http://127.0.0.1:8200/v1/consul/roles/example-role
+```shell-session
+$ curl \
+    --request POST \
+    --header "X-Vault-Token: ..." \
+    --data @payload.json \
+    http://127.0.0.1:8200/v1/consul/roles/example-role
 ```
 
 ## Read Role

--- a/website/content/docs/secrets/consul.mdx
+++ b/website/content/docs/secrets/consul.mdx
@@ -90,7 +90,7 @@ management tool.
     For Consul versions 1.5 and above, [generate a role in Consul](https://www.consul.io/api/acl/roles), and proceed to link it to the role:
 
     ```text
-    $ vault write consul/roles/my-role roles=api-server
+    $ vault write consul/roles/my-role consul_roles=api-server
     Success! Data written to: consul/roles/my-role
     ```
 

--- a/website/content/docs/secrets/consul.mdx
+++ b/website/content/docs/secrets/consul.mdx
@@ -29,7 +29,7 @@ management tool.
     `acl_master_token` from your Consul configuration file or another management
     token:
 
-    ```sh
+    ```shell-session
     $ curl \
         --header "X-Consul-Token: my-management-token" \
         --request PUT \
@@ -48,7 +48,7 @@ management tool.
 
     For Consul 1.4 and above, use the command line to generate a token with the appropriate policy:
 
-    ```sh
+    ```text
     $ CONSUL_HTTP_TOKEN=d54fe46a-1f57-a589-3583-6b78e334b03b consul acl token create -policy-name=global-management
     AccessorID:   865dc5e9-e585-3180-7b49-4ddc0fc45135
     SecretID:     ef35f0f1-885b-0cab-573c-7c91b65a7a7e
@@ -70,14 +70,15 @@ management tool.
 
 4.  Configure a role that maps a name in Vault to a Consul ACL policy. Depending on your Consul version,
     you will either provide a policy document and a token_type, or a set of policies.
-    When users generate credentials, they are generated against this role. For Consul versions below 1.4:
+    When users generate credentials, they are generated against this role.
+    
+    For Consul versions below 1.4, the policy must be base64-encoded. The policy language is [documented by Consul](https://www.consul.io/docs/security/acl/acl-legacy).
+    Write a policy and proceed to link it to the role:
 
     ```text
     $ vault write consul/roles/my-role policy=$(base64 <<< 'key "" { policy = "read" }')
     Success! Data written to: consul/roles/my-role
     ```
-
-    The policy must be base64-encoded. The policy language is [documented by Consul](https://www.consul.io/docs/internals/acl.html).
 
     For Consul versions 1.4 and above, [generate a policy in Consul](https://www.consul.io/docs/guides/acl.html), and proceed to link it to the role:
 
@@ -88,7 +89,7 @@ management tool.
 
     For Consul versions 1.5 and above, [generate a role in Consul](https://www.consul.io/api/acl/roles), and proceed to link it to the role:
 
-   ```text
+    ```text
     $ vault write consul/roles/my-role roles=api-server
     Success! Data written to: consul/roles/my-role
     ```

--- a/website/content/docs/secrets/consul.mdx
+++ b/website/content/docs/secrets/consul.mdx
@@ -86,6 +86,13 @@ management tool.
     Success! Data written to: consul/roles/my-role
     ```
 
+    For Consul versions 1.5 and above, [generate a role in Consul](https://www.consul.io/api/acl/roles), and proceed to link it to the role:
+
+   ```text
+    $ vault write consul/roles/my-role roles=api-server
+    Success! Data written to: consul/roles/my-role
+    ```
+
     -> **Token lease duration:** If you do not specify a value for `ttl` (or `lease` for Consul versions below 1.4) the tokens created using Vault's
     Consul secrets engine are created with a Time To Live (TTL) of 30 days. You can change the lease duration by passing `-ttl=<duration>` to the
     command above with "duration" being a string with a time suffix like "30s" or "1h".


### PR DESCRIPTION
This is a refresh of the PR submitted by @BrandonIngalls here: https://github.com/hashicorp/vault/pull/11025 which adds support for Consul ACL roles. This simplifies management of Vault tokens that use multiple Consul policies. Previously, you needed to replicate the work of assigning multiple Consul policies to a role in both Vault and Consul.

For example, let's say you work on assigning 20 different ACL policies into a single Consul role named "admin-access". With current Vault, you'd need to assign all 20 polices again to a Vault role like this:
```
❯ vault write consul/roles/my-role policies="policy1,policy2,policy3,...,policy20"
```

With Consul role support, it changes to this:
```
❯ vault write consul/roles/my-role roles="admin-access"
```

Additionally, if you want to assign multiple Consul roles to a Vault role, you can:
```
❯ vault write consul/roles/my-role roles="admin-access,role2,role3,...,etc"
```

&nbsp;

The original author's commits are retained to preserve credit for the work generously provided, save for merge conflicts, and the CLA was previously signed here: https://github.com/hashicorp/vault/pull/11025#issuecomment-787511814

Closes https://github.com/hashicorp/vault/issues/10752, https://github.com/hashicorp/vault/pull/11025