### PR TITLE
Fix max measurements gauge test

### DIFF
--- a/helper/metricsutil/gauge_process.go
+++ b/helper/metricsutil/gauge_process.go
@@ -197,16 +197,18 @@ func (p *GaugeCollectionProcess) collectAndFilterGauges() {
 	p.streamGaugesToSink(values)
 }
 
+// batchSize is the number of metrics to be sent per tick duration.
+const batchSize = 25
+
 func (p *GaugeCollectionProcess) streamGaugesToSink(values []GaugeLabelValues) {
 	// Dumping 500 metrics in one big chunk is somewhat unfriendly to UDP-based
 	// transport, and to the rest of the metrics trying to get through.
 	// Let's smooth things out over the course of a second.
-	// 1 second / 500 = 2 ms each, so we can send 25 per 50 milliseconds.
+	// 1 second / 500 = 2 ms each, so we can send 25 (batchSize) per 50 milliseconds.
 	// That should be one or two packets.
 	sendTick := p.clock.NewTicker(50 * time.Millisecond)
 	defer sendTick.Stop()
 
-	batchSize := 25
 	for i, lv := range values {
 		if i > 0 && i%batchSize == 0 {
 			select {

--- a/helper/metricsutil/gauge_process_test.go
+++ b/helper/metricsutil/gauge_process_test.go
@@ -433,11 +433,11 @@ func TestGauge_MaximumMeasurements(t *testing.T) {
 		2000000*time.Hour)
 
 	sink := NewClusterMetricSink("test", inmemSink)
-	sink.MaxGaugeCardinality = 500
+	sink.MaxGaugeCardinality = 100
 	sink.GaugeInterval = 2 * time.Hour
 
 	// Create a report larger than the default limit
-	excessGauges := 100
+	excessGauges := 20
 	values := makeLabels(sink.MaxGaugeCardinality + excessGauges)
 	rand.Shuffle(len(values), func(i, j int) {
 		values[i], values[j] = values[j], values[i]
@@ -468,9 +468,9 @@ func TestGauge_MaximumMeasurements(t *testing.T) {
 	sendTicker := s.waitForTicker(t)
 	numTicksSent := waitForDone(t, sendTicker.sender, done)
 
-	// 500 items, one delay after after each 25, means that
-	// 19 ticks are consumed, so 19 or 20 must be sent.
-	expectedTicks := sink.MaxGaugeCardinality/25 - 1
+	// 100 items, one delay after each batchSize (25), means that
+	// 3 ticks are consumed, so 3 or 4 must be sent.
+	expectedTicks := sink.MaxGaugeCardinality/batchSize - 1
 	if numTicksSent < expectedTicks || numTicksSent > expectedTicks+1 {
 		t.Errorf("Number of ticks = %v, expected %v.", numTicksSent, expectedTicks)
 	}


### PR DESCRIPTION
We have a theory that the amount of metrics emitted in `TestGauge_MaximumMeasurements` is causing the test to timeout in CircleCI. It seems like we can exercise the same functionality with a fraction of the original metric count. A constant for the batch size has also been added for clarification when debugging the test and associated underlying  `streamGaugesToSink` function.