### PR TITLE
save billing start in local storage

### DIFF
--- a/ui/app/components/clients/history.js
+++ b/ui/app/components/clients/history.js
@@ -3,6 +3,9 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { isSameMonth, isAfter } from 'date-fns';
+import getStorage from 'vault/lib/token-storage';
+
+const CLIENT_COUNTING_START = 'vault:ui-client-counting-start';
 export default class History extends Component {
   @service store;
   @service version;
@@ -130,6 +133,9 @@ export default class History extends Component {
     return isAfter(versionDate, startTimeFromResponseAsDateObject) ? versionDate : false;
   }
 
+  storage() {
+    return getStorage();
+  }
   @action
   async handleClientActivityQuery(month, year, dateType) {
     if (dateType === 'cancel') {
@@ -142,8 +148,10 @@ export default class History extends Component {
     }
     // clicked "Edit" Billing start month in Dashboard which opens a modal.
     if (dateType === 'startTime') {
+      // this.storage().removeItem(CLIENT_COUNTING_START);
       let monthIndex = this.arrayOfMonths.indexOf(month);
       this.startTimeRequested = [year.toString(), monthIndex]; // ['2021', 0] (e.g. January 2021)
+      this.storage().setItem(CLIENT_COUNTING_START, this.startTimeRequested);
       this.endTimeRequested = null;
     }
     // clicked "Custom End Month" from the calendar-widget

--- a/ui/app/components/date-dropdown.js
+++ b/ui/app/components/date-dropdown.js
@@ -34,4 +34,9 @@ export default class DateDropdown extends Component {
   selectStartYear(year) {
     this.startYear = year;
   }
+
+  @action
+  saveDateSelection() {
+    this.args.handleDateSelection(this.startMonth, this.startYear, this.args.name);
+  }
 }

--- a/ui/app/routes/vault/cluster/clients/history.js
+++ b/ui/app/routes/vault/cluster/clients/history.js
@@ -1,7 +1,9 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import { action } from '@ember/object';
+import getStorage from 'vault/lib/token-storage';
 
+const CLIENT_COUNTING_START = 'vault:ui-client-counting-start';
 export default class HistoryRoute extends Route {
   async getActivity(start_time) {
     try {
@@ -22,7 +24,7 @@ export default class HistoryRoute extends Route {
       return license.startTime || null;
     } catch (e) {
       // if error due to permission denied, return null so user can input date manually
-      return null;
+      return getStorage().getItem(CLIENT_COUNTING_START) || null;
     }
   }
 
@@ -46,6 +48,10 @@ export default class HistoryRoute extends Route {
 
   parseRFC3339(timestamp) {
     // convert '2021-03-21T00:00:00Z' --> ['2021', 2] (e.g. 2021 March, month is zero indexed)
+    if (Array.isArray(timestamp)) {
+      // return if already formatted correctly
+      return timestamp;
+    }
     return timestamp
       ? [timestamp.split('-')[0], Number(timestamp.split('-')[1].replace(/^0+/, '')) - 1]
       : null;

--- a/ui/app/templates/components/date-dropdown.hbs
+++ b/ui/app/templates/components/date-dropdown.hbs
@@ -48,7 +48,7 @@
   type="button"
   class="button is-primary"
   disabled={{if (and this.startMonth this.startYear) false true}}
-  {{on "click" (fn @handleDateSelection this.startMonth this.startYear @name)}}
+  {{on "click" this.saveDateSelection}}
 >
   Save
 </button>


### PR DESCRIPTION
Stores selected start date in local storage. Updates copy depending on if on enterprise or OSS

### Copy Updates

**OSS**
<img width="756" alt="Screen Shot 2022-02-11 at 12 33 44 PM" src="https://user-images.githubusercontent.com/68122737/153666218-edb00b69-0948-4b8e-a184-9ccbddfa6816.png">

<img width="567" alt="Screen Shot 2022-02-11 at 12 29 24 PM" src="https://user-images.githubusercontent.com/68122737/153665626-e2e74826-6922-48f6-a39b-54868092013e.png">

<hr>
**Enterprise**

<img width="807" alt="Screen Shot 2022-02-11 at 12 30 24 PM" src="https://user-images.githubusercontent.com/68122737/153665753-9d595857-bba5-4f78-98c9-1635144c0782.png">

<img width="526" alt="Screen Shot 2022-02-11 at 12 31 35 PM" src="https://user-images.githubusercontent.com/68122737/153665896-6d743521-15f0-4513-8a78-58367a2e962a.png">

