### PR TITLE
docs/fix-code-block-in-tab

### DIFF
--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -59,7 +59,7 @@ valid AWS credentials with proper permissions.
 - `sts_endpoint` `(string: <optional>)` – Specifies a custom HTTP STS endpoint to use.
 
 - `username_template` `(string: <optional>)` - [Template](/docs/concepts/username-templating) describing how
-  dynamic usernames are generated. The username template is used to generate both IAM usernames (capped at 64 characters) 
+  dynamic usernames are generated. The username template is used to generate both IAM usernames (capped at 64 characters)
   and STS usernames (capped at 32 characters). Longer usernames result in a 500 error.
 
   To ensure generated usernames are within length limits for both STS/IAM, the template must adequately handle
@@ -377,6 +377,7 @@ Using tags:
 
   </Tab>
   <Tab heading="CLI">
+
     ```bash
       vault write aws/roles/example-role \
       credential_type=iam_user \
@@ -393,6 +394,7 @@ Using tags:
     ```json
     ["tag1=42", "tag2=something"]
     ```
+
   </Tab>
 </Tabs>
 
@@ -540,9 +542,9 @@ credentials retrieved through `/aws/creds` must be of the `iam_user` type.
   the Vault role. Optional if the Vault role only allows a single AWS role ARN;
   required otherwise.
 - `role_session_name` `(string)` - The role session name to attach to the assumed role ARN.
-   `role_session_name` is limited to 64 characters; if exceeded, the `role_session_name` in the
-   assumed role ARN will be truncated to 64 characters. If `role_session_name` is not provided,
-   then it will be generated dynamically by default.
+  `role_session_name` is limited to 64 characters; if exceeded, the `role_session_name` in the
+  assumed role ARN will be truncated to 64 characters. If `role_session_name` is not provided,
+  then it will be generated dynamically by default.
 - `ttl` `(string: "3600s")` – Specifies the TTL for the use of the STS token.
   This is specified as a string with a duration suffix. Valid only when
   `credential_type` is `assumed_role` or `federation_token`. When not specified,


### PR DESCRIPTION
## What

Fixes a code block under a `Tabs` component on the AWS Secrets Engine (API) API docs page, which currently looks like the following screenshot:

<img width="931" src="https://user-images.githubusercontent.com/43934258/153907036-5c614819-3cf6-4578-a06e-f711c0544c4b.png">

## How

The fix required adding some empty lines after the opening `<Tab>` tag and before the closing `</Tab>` tag for the Tab that was not rendering as desired. Some additional space characters were also removed in this file, identified automatically by my code editor, and these changes don't seem to affect the layout of the rendered page.

## Testing

- [ ] Go to the [Sample Payloads section under the Create/Update Role section of the AWS Secrets Engine (API) page](https://vault-git-ambdocs-fix-code-block-in-tab-hashicorp.vercel.app/api-docs/secret/aws#sample-payloads)
- [ ] Click the second Tab under the "Using tags:" text, labelled "CLI"
- [ ] The following code block should now render as follows:
  <img width="936" src="https://user-images.githubusercontent.com/43934258/153906822-e126676d-049b-4e8b-b9f8-2d398efc3c83.png">
