### PR TITLE
Vault documentation: changed integrated storage to upper-case

### DIFF
--- a/website/content/api-docs/system/storage/raftautopilot.mdx
+++ b/website/content/api-docs/system/storage/raftautopilot.mdx
@@ -10,13 +10,13 @@ description: |-
 
 # `/sys/storage/raft/autopilot`
 
-The `/sys/storage/raft/autopilot` endpoints are used to manage raft clusters using autopilot 
-with Vault's [Integrated Storage backend](/docs/internals/integrated-storage). 
-For a tutorial on integrated storage autopilot, see the [Learn guide here](https://learn.hashicorp.com/tutorials/vault/raft-autopilot?in=vault/raft).
+The `/sys/storage/raft/autopilot` endpoints are used to manage raft clusters using autopilot
+with Vault's [Integrated Storage backend](/docs/internals/integrated-storage).
+For a tutorial on Integrated Storage autopilot, see the [Learn guide here](https://learn.hashicorp.com/tutorials/vault/raft-autopilot?in=vault/raft).
 
 ## Get Cluster State
 
-This endpoint is used to retrieve the raft cluster state. See the [docs page](/docs/commands/operator/raft#autopilot-state) for a description of the output. 
+This endpoint is used to retrieve the raft cluster state. See the [docs page](/docs/commands/operator/raft#autopilot-state) for a description of the output.
 
 | Method | Path                                |
 | :----- | :---------------------------------- |
@@ -85,7 +85,7 @@ $ curl \
 
 ## Get Configuration
 
-This endpoint is used to get the configuration of the autopilot subsystem of integrated storage.
+This endpoint is used to get the configuration of the autopilot subsystem of Integrated Storage.
 
 | Method | Path                                        |
 | :----- | :------------------------------------------ |
@@ -114,7 +114,7 @@ $ curl \
 
 ## Set Configuration
 
-This endpoint is used to modify the configuration of the autopilot subsystem of integrated storage.
+This endpoint is used to modify the configuration of the autopilot subsystem of Integrated Storage.
 
 | Method | Path                                        |
 | :----- | :------------------------------------------ |

--- a/website/content/docs/commands/operator/raft.mdx
+++ b/website/content/docs/commands/operator/raft.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # operator raft
 
-This command groups subcommands for operators to manage the integrated Raft storage backend.
+This command groups subcommands for operators to manage the Integrated Storage Raft backend.
 
 ```text
 Usage: vault operator raft <subcommand> [options] [args]

--- a/website/content/docs/concepts/integrated-storage/index.mdx
+++ b/website/content/docs/concepts/integrated-storage/index.mdx
@@ -7,21 +7,21 @@ description: Learn about the integrated raft storage in Vault.
 # Integrated Storage
 
 Vault supports a number of storage options for the durable storage of Vault's
-information. As of Vault 1.4 an integrated storage option is offered. This
+information. As of Vault 1.4 an Integrated Storage option is offered. This
 storage backend does not rely on any third party systems, implements high
 availability semantics, supports Enterprise Replication features, and provides
 backup/restore workflows.
 
-The integrated storage option stores Vault's data on the server's filesystem and
+The option stores Vault's data on the server's filesystem and
 uses a consensus protocol to replicate data to each server in the cluster. More
-information on the internals of integrated storage can be found in the
-[integrated storage internals
+information on the internals of Integrated Storage can be found in the
+[Integrated Storage internals
 documentation](/docs/internals/integrated-storage/). Additionally, the
 [Configuration](/docs/configuration/storage/raft/) docs can help in configuring
-Vault to use integrated storage.
+Vault to use Integrated Storage.
 
 The sections below go into various details on how to operate Vault with
-integrated storage.
+Integrated Storage.
 
 ## Server-to-Server Communication
 
@@ -29,16 +29,16 @@ Once nodes are joined to one another they begin to communicate using mTLS over
 Vault's cluster port. The cluster port defaults to `8201`. The TLS information
 is exchanged at join time and is rotated on a cadence.
 
-A requirement for integrated storage is that the
+A requirement for Integrated Storage is that the
 [`cluster_addr`](/docs/concepts/ha#per-node-cluster-address) configuration option
 is set. This allows Vault to assign an address to the node ID at join time.
 
 ## Cluster Membership
 
 This section will outline how to bootstrap and manage a cluster of Vault nodes
-running integrated storage.
+running Integrated Storage.
 
-Integrated storage is bootstrapped during the [initialization
+Integrated Storage is bootstrapped during the [initialization
 process](https://learn.hashicorp.com/vault/getting-started/deploy#initializing-the-vault),
 and results in a cluster of size 1. Depending on the [desired deployment
 size](/docs/internals/integrated-storage/#deployment-table), nodes can be joined
@@ -89,7 +89,7 @@ storage "raft" {
 Note, in each [`retry_join`](/docs/configuration/storage/raft#retry_join-stanza)
 stanza, you may provide a single
 [`leader_api_addr`](/docs/configuration/storage/raft#leader_api_addr) or
-[`auto_join`](/docs/configuration/storage/raft#auto_join) value.  When a cloud
+[`auto_join`](/docs/configuration/storage/raft#auto_join) value. When a cloud
 [`auto_join`](/docs/configuration/storage/raft#auto_join) configuration value is
 provided, Vault will use [go-discover](https://github.com/hashicorp/go-discover)
 to automatically attempt to discover and resolve potential Raft leader
@@ -110,8 +110,7 @@ storage "raft" {
 }
 ```
 
-By default, Vault will attempt to reach discovered peers using HTTPS and port
-8200.  Operators may override these through the
+By default, Vault will attempt to reach discovered peers using HTTPS and port 8200. Operators may override these through the
 [`auto_join_scheme`](/docs/configuration/storage/raft#auto_join_scheme) and
 [`auto_join_port`](/docs/configuration/storage/raft#auto_join_port) fields
 respectively.
@@ -173,7 +172,7 @@ Peer removed successfully!
 To see the current peer set for the cluster you can issue a
 [`list-peers`](/docs/commands/operator/raft#list-peers) command. All the voting
 nodes that are listed here contribute to the quorum and a majority must be alive
-for integrated storage to continue to operate.
+for Integrated Storage to continue to operate.
 
 ```shell-session
 $ vault operator raft list-peers
@@ -206,31 +205,31 @@ The API port is where clients send their Vault HTTP requests.
 
 For a single-node Vault cluster you don't worry about a cluster port as it won't be used.
 
-When you have multiple nodes, you also need a cluster port.  This is used by Vault
+When you have multiple nodes, you also need a cluster port. This is used by Vault
 nodes to issue RPCs to one another, e.g. to forward requests from a standby node
 to the active node, or when Raft is in use, to handle leader election and
 replication of stored data.
 
 The cluster port is secured using a TLS certificate that the Vault active node
-generates internally.  It's clear how this can work when not using integrated
+generates internally. It's clear how this can work when not using integrated
 storage: every node has at least read access to storage, so once the active
 node has persisted the certificate, the standby nodes can fetch it, and all
 agree on how cluster traffic should be encrypted.
 
-It's less clear how this works with integrated storage, as there is a chicken
-and egg problem.  Nodes don't have a shared view of storage until the raft
-cluster has been formed, but we're trying to form the raft cluster!  To solve
+It's less clear how this works with Integrated Storage, as there is a chicken
+and egg problem. Nodes don't have a shared view of storage until the raft
+cluster has been formed, but we're trying to form the raft cluster! To solve
 this problem, a Vault node must speak to another Vault node using the API port
-instead of the cluster port.  This is currently the only situation in which
+instead of the cluster port. This is currently the only situation in which
 OSS Vault does this (Vault Enterprise also does something similar when setting
 up replication.)
 
-* `node2` wants to join the cluster, so issues challenge API request to existing member `node1`
-* `node1` replies to challenge request with (1) an encrypted random UUID and (2) seal config
-* `node2` must decrypt UUID using seal; if using auto-unseal can do it directly, if using Shamir must wait for user to provide enough unseal keys to perform decryption
-* `node2` sends decrypted UUID back to `node1` using answer API
-* `node1` sees `node2` can be trusted (since it has seal access) and replies with a bootstrap package which includes the cluster TLS certificate and private key
-* `node2` gets sent a raft snapshot over the cluster port
+- `node2` wants to join the cluster, so issues challenge API request to existing member `node1`
+- `node1` replies to challenge request with (1) an encrypted random UUID and (2) seal config
+- `node2` must decrypt UUID using seal; if using auto-unseal can do it directly, if using Shamir must wait for user to provide enough unseal keys to perform decryption
+- `node2` sends decrypted UUID back to `node1` using answer API
+- `node1` sees `node2` can be trusted (since it has seal access) and replies with a bootstrap package which includes the cluster TLS certificate and private key
+- `node2` gets sent a raft snapshot over the cluster port
 
 After this procedure the new node will never again send traffic to the API port.
 All subsequent inter-node communication will use the cluster port.
@@ -239,9 +238,8 @@ All subsequent inter-node communication will use the cluster port.
 
 ### Assisted raft join techniques
 
-The simplest option is to do it by hand: issue [`raft
-join`](/docs/commands/operator/raft#join) commands specifying the explicit names
-or IPs of the nodes to join to.  In this section we look at other TLS-compatible
+The simplest option is to do it by hand: issue [`raft join`](/docs/commands/operator/raft#join) commands specifying the explicit names
+or IPs of the nodes to join to. In this section we look at other TLS-compatible
 options that lend themselves more to automation.
 
 #### Autojoin with TLS servername
@@ -253,7 +251,7 @@ which matches a [DNS
 SAN](https://en.wikipedia.org/wiki/Subject_Alternative_Name) in the certificate.
 
 Note that names in a certificate's DNS SAN don't actually have to be registered
-in a DNS server.  Your nodes may have no names found in DNS, while still
+in a DNS server. Your nodes may have no names found in DNS, while still
 using certificate(s) that contain this shared `servername` in their DNS SANs.
 
 #### Autojoin but constrain CIDR, list all possible IPs in certificate
@@ -263,13 +261,13 @@ becomes practical to put all the IPs that exist in that subnet into the IP SANs
 of the TLS certificate the nodes will share.
 
 The drawback here is that the cluster may someday outgrow the CIDR and changing
-it may be a pain.  For similar reasons this solution may be impractical when
+it may be a pain. For similar reasons this solution may be impractical when
 using non-voting nodes and dynamically scaling clusters.
 
 #### Load balancer instead of autojoin
 
 Most Vault instances are going to have a load balancer (LB) between clients and
-the Vault nodes.  In that case, the LB knows how to route traffic to working
+the Vault nodes. In that case, the LB knows how to route traffic to working
 Vault nodes, and there's no need for auto-join: we can just use
 [`retry_join`](/docs/configuration/storage/raft#retry_join-stanza) with the LB
 address as the target.

--- a/website/content/docs/configuration/storage/index.mdx
+++ b/website/content/docs/configuration/storage/index.mdx
@@ -41,36 +41,36 @@ For configuration options which also read an environment variable, the
 environment variable will take precedence over values in the configuration
 file.
 
-## Integrated storage vs. external storage
+## Integrated Storage vs. External Storage
 
 HashiCorp recommends using Vault's [integrated
 storage](/docs/configuration/storage/raft) for most use cases rather than
-configuring another system to store Vault data externally. (Integrated storage is
+configuring another system to store Vault data externally. (Integrated Storage is
 an **embedded Vault data storage** available in Vault 1.4 or later.) Prior to Vault 1.4, Consul was the recommended Vault storage.
 
 -> **NOTE:** [HCP Vault](https://cloud.hashicorp.com/products/vault) clusters
-use integrated storage as their storage backend.
+use Integrated Storage as their storage backend.
 
-The table below compares the characteristics of integrated storage and external
-storage. Suppose you decide that the additional operational complexity of external storage is worth it for your use case. In that case, there are several external storage options to choose from (e.g., [Consul](/docs/configuration/storage/consul), [DynamoDB](/docs/configuration/storage/dynamodb), etc.).
+The table below compares the characteristics of Integrated Storage and External
+Storage. Suppose you decide that the additional operational complexity of external storage is worth it for your use case. In that case, there are several external storage options to choose from (e.g., [Consul](/docs/configuration/storage/consul), [DynamoDB](/docs/configuration/storage/dynamodb), etc.).
 
 |                                | Integrated Storage                                                                                                                                                                                                           | External Storage                                                                                                                                                                                                                      |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | HashiCorp Supported            | Yes                                                                                                                                                                                                                          | Limited support                                                                                                                                                                                                                       |
 | Operation                      | Operationally simpler with no additional software installation required.                                                                                                                                                     | Must install and configure the external storage environment outside of Vault. For high availability, the external storage should be clustered.                                                                                        |
 | Networking                     | One less network hop.                                                                                                                                                                                                        | Extra network hop between Vault and the external storage system (e.g., Consul cluster).                                                                                                                                               |
-| Troubleshooting and monitoring | Integrated storage is a part of Vault; therefore, Vault is the only system you need to monitor and troubleshoot.                                                                                                             | The source of failure could be the external storage; therefore, you need to check the health of both Vault and the external storage. This requires expertise in the chosen storage backend and additional monitoring of that storage. |
+| Troubleshooting and monitoring | Integrated Storage is a part of Vault; therefore, Vault is the only system you need to monitor and troubleshoot.                                                                                                             | The source of failure could be the external storage; therefore, you need to check the health of both Vault and the external storage. This requires expertise in the chosen storage backend and additional monitoring of that storage. |
 | Data location                  | The encrypted Vault data is stored on the same host where the Vault server process runs.                                                                                                                                     | The encrypted Vault data is stored where the external storage is located. Therefore, the Vault server and the data storage are hosted on physically separate hosts.                                                                   |
 | System requirements            | Avoid "burstable" CPU and storage options. SSDs should be used for the hard drive. <p />See the [Reference Architecture](https://learn.hashicorp.com/tutorials/vault/raft-reference-architecture#system-requirements) guide. | Follow the system requirements given by your chosen storage backend.                                                                                                                                                                  |
 
-### Integrated storage vs. Consul as Vault storage
+### Integrated Storage vs. Consul as Vault Storage
 
 [HashiCorp Consul](https://www.consul.io/docs/intro) is a comprehensive
 multi-cloud service networking solution including service mesh, service
 discovery, and network infrastructure automation. Vault can leverage
 Consul's [KV Store](https://www.consul.io/api-docs/kv) to persist Vault data.
 
-The table below highlights the differences between integrated storage and
+The table below highlights the differences between Integrated Storage and
 Consul.
 
 |                     | Integrated Storage                                                                                                 | Consul                                                                                                                                                                                                                                                                                                                                           |
@@ -82,7 +82,7 @@ Consul.
 | Max message size    | 1 MiB (Configurable using the [`max_entry_size`](/docs/configuration/storage/raft#max_entry_size) parameter)       | 512 KiB (Configurable using the [`kv_max_value_size`](https://www.consul.io/docs/agent/options#kv_max_value_size) parameter)                                                                                                                                                                                                                     |
 
 If you have a Vault cluster using Consul as its storage backend and wish to
-migrate to integrated storage, read the following tutorials:
+migrate to Integrated Storage, read the following tutorials:
 
 1. [Preflight Checklist - Migrating to Integrated
    Storage](https://learn.hashicorp.com/tutorials/vault/storage-migration-checklist)
@@ -93,4 +93,4 @@ migrate to integrated storage, read the following tutorials:
 
 Refer to the [Integrated
 Storage](https://learn.hashicorp.com/collections/vault/raft) tutorial collection
-to learn more about integrated storage.
+to learn more about Integrated Storage.

--- a/website/content/docs/configuration/storage/raft.mdx
+++ b/website/content/docs/configuration/storage/raft.mdx
@@ -85,7 +85,7 @@ set [`disable_mlock`](/docs/configuration#disable_mlock) to `true`, and to disab
   is increased significantly as more logs will need to be replayed.
 
 - `retry_join` `(list: [])` - There can be one or more
-  [`retry_join`](#retry_join-stanza) stanzas.  When the Raft cluster is getting
+  [`retry_join`](#retry_join-stanza) stanzas. When the Raft cluster is getting
   bootstrapped, if the connection details of all the nodes are known beforehand,
   then specifying this config stanzas enables the nodes to automatically join a
   Raft cluster. All the nodes would mention all other nodes that they could join
@@ -100,7 +100,7 @@ set [`disable_mlock`](/docs/configuration#disable_mlock) to `true`, and to disab
   Any put or transaction operation exceeding this configuration value will cause
   the respective operation to fail. Raft has a suggested max size of data in a
   Raft log entry. This is based on current architecture, default timing, etc.
-  Integrated storage also uses a chunk size that is the threshold used for
+  Integrated Storage also uses a chunk size that is the threshold used for
   breaking a large value into chunks. By default, the chunk size is the same as
   Raft's max size log entry. The default value for this configuration is 1048576
   -- two times the chunking size.
@@ -121,7 +121,7 @@ set [`disable_mlock`](/docs/configuration#disable_mlock) to `true`, and to disab
   [go-discover](https://github.com/hashicorp/go-discover) syntax.
 
 - `auto_join_scheme` `(string: "")` - The optional URI protocol scheme for addresses
-  discovered via auto-join. Available values are `http` or `https`. 
+  discovered via auto-join. Available values are `http` or `https`.
 
 - `auto_join_port` `(uint: "")` - The optional port used for addressed discovered
   via auto-join.
@@ -162,8 +162,7 @@ See the go-discover
 [README](https://github.com/hashicorp/go-discover/blob/master/README.md)
 for details on the format of the `auto_join` value.
 
-By default, Vault will attempt to reach discovered peers using HTTPS and port
-8200.  Operators may override these through the
+By default, Vault will attempt to reach discovered peers using HTTPS and port 8200. Operators may override these through the
 [`auto_join_scheme`](#auto_join_scheme) and [`auto_join_port`](#auto_join_port)
 fields respectively.
 
@@ -202,6 +201,6 @@ storage "raft" {
 
 Refer to [Integrated
 Storage](https://learn.hashicorp.com/collections/vault/raft) for a collection of
-tutorials on integrated storage.
+tutorials on Integrated Storage.
 
 [raft]: https://raft.github.io/ 'The Raft Consensus Algorithm'

--- a/website/content/docs/enterprise/automated-integrated-storage-snapshots.mdx
+++ b/website/content/docs/enterprise/automated-integrated-storage-snapshots.mdx
@@ -3,7 +3,7 @@ layout: docs
 page_title: Vault Enterprise Automated Integrated Storage Snapshots
 description: |-
   Vault Enterprise can be configured to take automated snapshots
-  when using raft integrated storage and store them locally or
+  when using raft Integrated Storage and store them locally or
   in the cloud.
 ---
 

--- a/website/content/docs/internals/integrated-storage.mdx
+++ b/website/content/docs/internals/integrated-storage.mdx
@@ -11,13 +11,13 @@ information. Each backend has pros, cons, advantages, and trade-offs. For
 example, some backends support high availability while others provide a more
 robust backup and restoration process.
 
-As of Vault 1.4 an integrated storage option is offered. This storage backend
+As of Vault 1.4 an Integrated Storage option is offered. This storage backend
 does not rely on any third party systems, it implements high availability,
 supports Enterprise Replication features, and provides backup/restore workflows.
 
 ## Consensus Protocol
 
-Vault's integrated storage uses a [consensus
+Vault's Integrated Storage uses a [consensus
 protocol](<https://en.wikipedia.org/wiki/Consensus_(computer_science)>) to provide
 [Consistency (as defined by CAP)](https://en.wikipedia.org/wiki/CAP_theorem).
 The consensus protocol is based on ["Raft: In search of an Understandable

--- a/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/enterprise-with-raft.mdx
@@ -10,7 +10,7 @@ description: |-
 
 ~> **Important Note:** This chart is not compatible with Helm 2. Please use Helm 3 with this chart.
 
-Integrated storage (raft) can be enabled using the `server.ha.raft.enabled` value:
+Integrated Storage (raft) can be enabled using the `server.ha.raft.enabled` value:
 
 ```shell
 helm install vault hashicorp/vault \

--- a/website/content/docs/platform/k8s/helm/examples/ha-with-raft.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/ha-with-raft.mdx
@@ -57,4 +57,4 @@ e6876c97-aaaa-a92e-b99a-0aafab105745    vault-1.vault-internal:8201    follower 
 4b5d7383-ff31-44df-e008-6a606828823b    vault-2.vault-internal:8201    follower    true
 ```
 
-Vault with integrated storage (Raft) is now ready to use!
+Vault with Integrated Storage (Raft) is now ready to use!


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/inbox/1200328878163177/1201807950008518/1201824531585809), performed a documentation search and replace to change **Integrated Storage** to upper-case, with the exception of instances where integrated storage appeared as part of the code.

:mag:[Deploy Preview-raft autopilot](https://vault-k7sb31m0g-hashicorp.vercel.app/api-docs/system/storage/raftautopilot)
:mag:[Deploy Preview-operator raft](https://vault-git-fix-integrate-storage-all-caps-hashicorp.vercel.app/docs/commands/operator/raft)
:mag:[Deploy Preview-integrated storage](https://vault-git-fix-integrate-storage-all-caps-hashicorp.vercel.app/docs/concepts/integrated-storage)
:mag:[Deploy Preview-storage stanza](https://vault-git-fix-integrate-storage-all-caps-hashicorp.vercel.app/docs/configuration/storage)
:mag:[Deploy Preview-integrated storage raft backend](https://vault-git-fix-integrate-storage-all-caps-hashicorp.vercel.app/docs/configuration/storage/raft)
:mag:[Deploy Preview-automated integrated storage snapshots](https://vault-git-fix-integrate-storage-all-caps-hashicorp.vercel.app/docs/enterprise/automated-integrated-storage-snapshots)
:mag:[Deploy Preview-integrated storage](https://vault-git-fix-integrate-storage-all-caps-hashicorp.vercel.app/docs/internals/integrated-storage)
:mag:[Deploy Preview-high availability vault enterprise cluster with integrated storage(raft)](https://vault-git-fix-integrate-storage-all-caps-hashicorp.vercel.app/docs/platform/k8s/helm/examples/enterprise-with-raft)
:mag:[Deploy Preview-high available vault cluster with integrated storage(raft)](https://vault-git-fix-integrate-storage-all-caps-hashicorp.vercel.app/docs/platform/k8s/helm/examples/ha-with-raft)