### PR TITLE
Address slow CI causing failures in TestRateLimitQuota_Allow_WithBlock

### DIFF
--- a/vault/quotas/quotas_rate_limit_test.go
+++ b/vault/quotas/quotas_rate_limit_test.go
@@ -182,9 +182,10 @@ func TestRateLimitQuota_Allow_WithBlock(t *testing.T) {
 
 			time.Sleep(2 * time.Millisecond)
 		}
-	}
 
-	wg.Wait()
+		// Limit the number of active go-routines to 5
+		wg.Wait()
+	}
 
 	for _, cr := range results {
 		numAllow := cr.atomicNumAllow.Load()


### PR DESCRIPTION
 - An attempt to fix CI runs that are extremely slow and the for loop
   runs across two BlockIntervals within the rate limit window of operation.
 - Increasing BlockInterval was looked at but the normal test times would
   be increased due to us also validating that we are releasing clients post
   BlockInterval.

```
=== RUN   TestRateLimitQuota_Allow_WithBlock
    quotas_rate_limit_test.go:194: 
        	Error Trace:	quotas_rate_limit_test.go:194
        	Error:      	Not equal: 
        	            	expected: 17
        	            	actual  : 33
        	Test:       	TestRateLimitQuota_Allow_WithBlock
--- FAIL: TestRateLimitQuota_Allow_WithBlock (5.08s)
```