### PR TITLE
Check that all required fields in Transit API are present.

### DIFF
--- a/builtin/logical/transit/path_decrypt.go
+++ b/builtin/logical/transit/path_decrypt.go
@@ -67,7 +67,7 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 	var batchInputItems []BatchRequestItem
 	var err error
 	if batchInputRaw != nil {
-		err = decodeBatchRequestItems(batchInputRaw, &batchInputItems)
+		err = decodeDecryptBatchRequestItems(batchInputRaw, &batchInputItems)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse batch input: %w", err)
 		}

--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -249,14 +249,18 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 			return logical.ErrorResponse("missing batch input to process"), logical.ErrInvalidRequest
 		}
 	} else {
-		valueRaw, ok := d.GetOk("plaintext")
+		valueRaw, ok := d.Raw["plaintext"]
 		if !ok {
 			return logical.ErrorResponse("missing plaintext to encrypt"), logical.ErrInvalidRequest
+		}
+		plaintext, ok := valueRaw.(string)
+		if !ok {
+			return logical.ErrorResponse("expected plaintext of type 'string', got unconvertible type '%T'", valueRaw), logical.ErrInvalidRequest
 		}
 
 		batchInputItems = make([]BatchRequestItem, 1)
 		batchInputItems[0] = BatchRequestItem{
-			Plaintext:  valueRaw.(string),
+			Plaintext:  plaintext,
 			Context:    d.Get("context").(string),
 			Nonce:      d.Get("nonce").(string),
 			KeyVersion: d.Get("key_version").(int),

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -15,6 +15,41 @@ import (
 
 // Case1: Ensure that batch encryption did not affect the normal flow of
 // encrypting the plaintext with a pre-existing key.
+func TestTransit_MissingPlaintext(t *testing.T) {
+	var resp *logical.Response
+	var err error
+
+	b, s := createBackendWithStorage(t)
+
+	// Create the policy
+	policyReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "keys/existing_key",
+		Storage:   s,
+	}
+	resp, err = b.HandleRequest(context.Background(), policyReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+
+	encData := map[string]interface{}{
+		"plaintext": nil,
+	}
+
+	encReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "encrypt/existing_key",
+		Storage:   s,
+		Data:      encData,
+	}
+	resp, err = b.HandleRequest(context.Background(), encReq)
+	if resp == nil || !resp.IsError() {
+		t.Fatalf("err:%v resp:%#v", err, resp)
+	}
+}
+
+// Case1: Ensure that batch encryption did not affect the normal flow of
+// encrypting the plaintext with a pre-existing key.
 func TestTransit_BatchEncryptionCase1(t *testing.T) {
 	var resp *logical.Response
 	var err error

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -676,12 +676,12 @@ func TestTransit_BatchEncryptionCase13(t *testing.T) {
 // Test that the fast path function decodeBatchRequestItems behave like mapstructure.Decode() to decode []BatchRequestItem.
 func TestTransit_decodeBatchRequestItems(t *testing.T) {
 	tests := []struct {
-		name            string
-		src             interface{}
-		requirePlaintext bool
+		name              string
+		src               interface{}
+		requirePlaintext  bool
 		requireCiphertext bool
-		dest            []BatchRequestItem
-		wantErrContains string
+		dest              []BatchRequestItem
+		wantErrContains   string
 	}{
 		// basic edge cases of nil values
 		{name: "nil-nil", src: nil, dest: nil},
@@ -802,38 +802,38 @@ func TestTransit_decodeBatchRequestItems(t *testing.T) {
 		},
 		// required fields
 		{
-			name: "required_plaintext_present",
-			src:  []interface{}{map[string]interface{}{"plaintext": ""}},
+			name:             "required_plaintext_present",
+			src:              []interface{}{map[string]interface{}{"plaintext": ""}},
 			requirePlaintext: true,
-			dest: []BatchRequestItem{},
+			dest:             []BatchRequestItem{},
 		},
 		{
-			name: "required_plaintext_missing",
-			src:  []interface{}{map[string]interface{}{}},
+			name:             "required_plaintext_missing",
+			src:              []interface{}{map[string]interface{}{}},
 			requirePlaintext: true,
-			dest: []BatchRequestItem{},
-			wantErrContains: "missing plaintext",
+			dest:             []BatchRequestItem{},
+			wantErrContains:  "missing plaintext",
 		},
 		{
-			name: "required_ciphertext_present",
-			src:  []interface{}{map[string]interface{}{"ciphertext": "dGhlIHF1aWNrIGJyb3duIGZveA=="}},
+			name:              "required_ciphertext_present",
+			src:               []interface{}{map[string]interface{}{"ciphertext": "dGhlIHF1aWNrIGJyb3duIGZveA=="}},
 			requireCiphertext: true,
-			dest: []BatchRequestItem{},
+			dest:              []BatchRequestItem{},
 		},
 		{
-			name: "required_ciphertext_missing",
-			src:  []interface{}{map[string]interface{}{}},
+			name:              "required_ciphertext_missing",
+			src:               []interface{}{map[string]interface{}{}},
 			requireCiphertext: true,
-			dest: []BatchRequestItem{},
-			wantErrContains: "missing ciphertext",
+			dest:              []BatchRequestItem{},
+			wantErrContains:   "missing ciphertext",
 		},
 		{
-			name: "required_plaintext_and_ciphertext_missing",
-			src:  []interface{}{map[string]interface{}{}},
-			requirePlaintext: true,
+			name:              "required_plaintext_and_ciphertext_missing",
+			src:               []interface{}{map[string]interface{}{}},
+			requirePlaintext:  true,
 			requireCiphertext: true,
-			dest: []BatchRequestItem{},
-			wantErrContains: "missing ciphertext",
+			dest:              []BatchRequestItem{},
+			wantErrContains:   "missing ciphertext",
 		},
 	}
 	for _, tt := range tests {

--- a/builtin/logical/transit/path_hash.go
+++ b/builtin/logical/transit/path_hash.go
@@ -63,7 +63,16 @@ Defaults to "sha2-256".`,
 }
 
 func (b *backend) pathHashWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	inputB64 := d.Get("input").(string)
+	rawInput, ok := d.Raw["input"]
+	if !ok {
+		return logical.ErrorResponse("input missing"), logical.ErrInvalidRequest
+	}
+
+	inputB64, ok := rawInput.(string)
+	if !ok {
+		return logical.ErrorResponse("expected input of type 'string', got unconvertible type '%T'", rawInput), logical.ErrInvalidRequest
+	}
+
 	format := d.Get("format").(string)
 	algorithm := d.Get("urlalgorithm").(string)
 	if algorithm == "" {

--- a/builtin/logical/transit/path_hash_test.go
+++ b/builtin/logical/transit/path_hash_test.go
@@ -29,7 +29,7 @@ func TestTransit_Hash(t *testing.T) {
 		}
 		if errExpected {
 			if !resp.IsError() {
-				t.Fatalf("bad: got error response: %#v", *resp)
+				t.Fatalf("bad: did not get error response: %#v", *resp)
 			}
 			return
 		}
@@ -86,6 +86,10 @@ func TestTransit_Hash(t *testing.T) {
 	doRequest(req, false, "98rFrYMEIqVAizamCmBiBoe+GAdlo+KJW8O9vYV8nggkbIMGTU42EvDLkn8+rSCEE6uYYkv3sGF68PA/YggJdg==")
 
 	// Test bad input/format/algorithm
+	req.Data["input"] = nil
+	doRequest(req, true, "")
+
+	req.Data["input"] = "dGhlIHF1aWNrIGJyb3duIGZveA=="
 	req.Data["format"] = "base92"
 	doRequest(req, true, "")
 

--- a/builtin/logical/transit/path_trim.go
+++ b/builtin/logical/transit/path_trim.go
@@ -55,11 +55,14 @@ func (b *backend) pathTrimUpdate() framework.OperationFunc {
 		}
 		defer p.Unlock()
 
-		minAvailableVersionRaw, ok := d.GetOk("min_available_version")
+		minAvailableVersionRaw, ok := d.Raw["min_available_version"]
 		if !ok {
 			return logical.ErrorResponse("missing min_available_version"), nil
 		}
-		minAvailableVersion := minAvailableVersionRaw.(int)
+		minAvailableVersion, ok := minAvailableVersionRaw.(int)
+		if !ok {
+			return logical.ErrorResponse("expected min_available_version of type 'int', got unconvertible type '%T'", minAvailableVersionRaw), logical.ErrInvalidRequest
+		}
 
 		originalMinAvailableVersion := p.MinAvailableVersion
 

--- a/builtin/logical/transit/path_trim_test.go
+++ b/builtin/logical/transit/path_trim_test.go
@@ -79,7 +79,7 @@ func TestTransit_Trim(t *testing.T) {
 	}
 	doErrReq(t, req)
 
-	// Set min_encryption_version to 4
+	// Set min_encryption_version to 0
 	req.Path = "keys/aes/config"
 	req.Data = map[string]interface{}{
 		"min_encryption_version": 0,

--- a/builtin/logical/transit/path_trim_test.go
+++ b/builtin/logical/transit/path_trim_test.go
@@ -82,6 +82,20 @@ func TestTransit_Trim(t *testing.T) {
 	// Set min_encryption_version to 4
 	req.Path = "keys/aes/config"
 	req.Data = map[string]interface{}{
+		"min_encryption_version": 0,
+	}
+	doReq(t, req)
+
+	// Min available version should not be converted to 0 for nil values
+	req.Path = "keys/aes/trim"
+	req.Data = map[string]interface{}{
+		"min_available_version": nil,
+	}
+	doErrReq(t, req)
+
+	// Set min_encryption_version to 4
+	req.Path = "keys/aes/config"
+	req.Data = map[string]interface{}{
 		"min_encryption_version": 4,
 	}
 	doReq(t, req)

--- a/changelog/14074.txt
+++ b/changelog/14074.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/transit: Return an error if any required parameter is missing or nil. Do not encrypt nil plaintext as if it was an empty string.
+```


### PR DESCRIPTION
Ensure that an error is returned if any required field is nil or missing.

This fixes an issue that results in the empty string being encrypted when the plaintext is nil.

See [VAULT-2837](https://hashicorp.atlassian.net/browse/VAULT-2837) for details.