### PR TITLE
Return integral seconds for transit auto_rotate_interval instead of a time string.

### DIFF
--- a/builtin/logical/transit/path_config_test.go
+++ b/builtin/logical/transit/path_config_test.go
@@ -3,6 +3,7 @@ package transit
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -384,10 +385,17 @@ func TestTransit_UpdateKeyConfigWithAutorotation(t *testing.T) {
 				if resp == nil {
 					t.Fatal("expected non-nil response")
 				}
-				got := resp.Data["auto_rotate_interval"]
-				want := test.expectedValue.String()
+				gotRaw, ok := resp.Data["auto_rotate_interval"].(json.Number)
+				if !ok {
+					t.Fatal("returned value is of unexpected type")
+				}
+				got, err := gotRaw.Int64()
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := int64(test.expectedValue.Seconds())
 				if got != want {
-					t.Fatalf("incorrect auto_rotate_interval returned, got: %s, want: %s", got, want)
+					t.Fatalf("incorrect auto_rotate_interval returned, got: %d, want: %d", got, want)
 				}
 			}
 		})

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -238,7 +238,7 @@ func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *f
 			"supports_decryption":    p.Type.DecryptionSupported(),
 			"supports_signing":       p.Type.SigningSupported(),
 			"supports_derivation":    p.Type.DerivationSupported(),
-			"auto_rotate_interval":   p.AutoRotateInterval.String(),
+			"auto_rotate_interval":   int64(p.AutoRotateInterval.Seconds()),
 		},
 	}
 

--- a/builtin/logical/transit/path_keys_test.go
+++ b/builtin/logical/transit/path_keys_test.go
@@ -2,6 +2,7 @@ package transit_test
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -176,10 +177,17 @@ func TestTransit_CreateKeyWithAutorotation(t *testing.T) {
 				if resp == nil {
 					t.Fatal("expected non-nil response")
 				}
-				got := resp.Data["auto_rotate_interval"]
-				want := test.expectedValue.String()
+				gotRaw, ok := resp.Data["auto_rotate_interval"].(json.Number)
+				if !ok {
+					t.Fatal("returned value is of unexpected type")
+				}
+				got, err := gotRaw.Int64()
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := int64(test.expectedValue.Seconds())
 				if got != want {
-					t.Fatalf("incorrect auto_rotate_interval returned, got: %s, want: %s", got, want)
+					t.Fatalf("incorrect auto_rotate_interval returned, got: %d, want: %d", got, want)
 				}
 			}
 		})


### PR DESCRIPTION
# Overview
This PR changes the type of transit's `auto_rotate_interval` from a time string (e.g. `"1h2m3s") to integral seconds as used elsewhere in vault.

# Testing
- `vault secrets enable transit`
- `vault write -f transit/keys/my-key auto_rotate_interval=1h2m3s`
- `vault read transit/keys/my-key`
- Observe the type of the returned `"auto_rotate_interval"` field. Output should look something like this:
```json
{
  "request_id": "7724661b-7f62-7c7b-3d9d-d4e719a5a3b0",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 0,
  "data": {
    "allow_plaintext_backup": false,
    "auto_rotate_interval": 3723,
...
```