### PR TITLE
Convert install instructions to use tabs

### DIFF
--- a/website/content/docs/get-started/developer-qs.mdx
+++ b/website/content/docs/get-started/developer-qs.mdx
@@ -46,49 +46,18 @@ Let's install the Vault client library for your language of choice.
 
 -> **Note**: Some of these libraries are currently community-maintained.
 
-- [Go](https://pkg.go.dev/github.com/hashicorp/vault/api) (official)
-   
-   ```shell-session 
-   $ go get github.com/hashicorp/vault/api
-   ```
-   
-- [Ruby](https://github.com/hashicorp/vault-ruby) (official)
-   
-   ```shell-session 
-   $ gem install vault
-   ```
-   
-- [C#](https://github.com/rajanadar/VaultSharp)
-   
-   ```shell-session
-   $ dotnet add package VaultSharp
-   ```
-   
-- [Python](https://github.com/hvac/hvac)
-   
-   ```shell-session 
-   $ pip install hvac
-   ```
-   
-- [Java (Spring)](https://spring.io/projects/spring-vault)
-   
-   Add the following to pom.xml:
+<Tabs>
+<Tab heading="Go">
 
-   ```xml
-   <dependency>
-        <groupId>org.springframework.vault</groupId>
-        <artifactId>spring-vault-core</artifactId>
-        <version>2.3.1</version>
-   </dependency>
-   ```
-
-### Import Vault library
+[Go](https://pkg.go.dev/github.com/hashicorp/vault/api) (official) client library:
+   
+```shell-session 
+$ go get github.com/hashicorp/vault/api
+```
 
 Now, let's add the import statements for the client library to the top of the file.
 
-<CodeTabs heading="import statements for client library">
-
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig heading="import statements for client library" lineNumbers>
 
 ```go
 import vault "github.com/hashicorp/vault/api"
@@ -96,7 +65,19 @@ import vault "github.com/hashicorp/vault/api"
 
 </CodeBlockConfig>
 
-<CodeBlockConfig lineNumbers>
+</Tab>
+<Tab heading="Ruby">
+
+   
+[Ruby](https://github.com/hashicorp/vault-ruby) (official) client library:
+   
+```shell-session 
+$ gem install vault
+```
+
+Now, let's add the import statements for the client library to the top of the file.
+
+<CodeBlockConfig heading="import statements for client library" lineNumbers>
 
 ```ruby
 require "vault"
@@ -104,7 +85,19 @@ require "vault"
 
 </CodeBlockConfig>
 
-<CodeBlockConfig lineNumbers>
+</Tab>
+<Tab heading="C#">
+
+   
+[C#](https://github.com/rajanadar/VaultSharp) client library:
+   
+```shell-session
+$ dotnet add package VaultSharp
+```
+
+Now, let's add the import statements for the client library to the top of the file.
+
+<CodeBlockConfig heading="import statements for client library" lineNumbers>
 
 ```cs
 using VaultSharp;
@@ -115,7 +108,19 @@ using VaultSharp.V1.Commons;
 
 </CodeBlockConfig>
 
-<CodeBlockConfig lineNumbers>
+</Tab>
+<Tab heading="Python">
+
+   
+[Python](https://github.com/hvac/hvac) client library:
+
+```shell-session 
+$ pip install hvac
+```
+
+Now, let's add the import statements for the client library to the top of the file.
+
+<CodeBlockConfig heading="import statements for client library" lineNumbers>
 
 ```Python
 import hvac
@@ -123,7 +128,25 @@ import hvac
 
 </CodeBlockConfig>
 
-<CodeBlockConfig lineNumbers>
+</Tab>
+<Tab heading="Java">
+
+   
+[Java (Spring)](https://spring.io/projects/spring-vault) client library:
+   
+Add the following to pom.xml:
+
+```xml
+<dependency>
+     <groupId>org.springframework.vault</groupId>
+     <artifactId>spring-vault-core</artifactId>
+     <version>2.3.1</version>
+</dependency>
+```
+
+Now, let's add the import statements for the client library to the top of the file.
+
+<CodeBlockConfig heading="import statements for client library" lineNumbers>
 
 ```Java
 import org.springframework.vault.authentication.TokenAuthentication;
@@ -134,7 +157,10 @@ import org.springframework.vault.core.VaultTemplate;
 
 </CodeBlockConfig>
 
-</CodeTabs>
+
+</Tab>
+</Tabs>
+
 
 ## Step 3: Authenticate to Vault
 


### PR DESCRIPTION
Converting the **Step 2** to use tabs. 

🔍 [Deploy preview](https://vault-git-tabs-conversion-hashicorp.vercel.app/docs/get-started/developer-qs#step-2-install-a-client-library)