### PR TITLE
auth/ldap: add resp warning if userfilter doesn't consider userattr

### DIFF
--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -11,6 +11,7 @@ import (
 	goldap "github.com/go-ldap/ldap/v3"
 	"github.com/go-test/deep"
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/helper/testhelpers/ldap"
 	logicaltest "github.com/hashicorp/vault/helper/testhelpers/logical"
@@ -505,6 +506,30 @@ func TestBackend_basic_authbind_userfilter(t *testing.T) {
 	cleanup, cfg := ldap.PrepareTestContainer(t, "latest")
 	defer cleanup()
 
+	// userattr not used in the userfilter should result in a warning in the response
+	cfg.UserFilter = "((mail={{.Username}}))"
+	logicaltest.Test(t, logicaltest.TestCase{
+		CredentialBackend: b,
+		Steps: []logicaltest.TestStep{
+			testAccStepConfigUrlWarningCheck(t, cfg, logical.UpdateOperation, []string{userFilterWarning}),
+			testAccStepConfigUrlWarningCheck(t, cfg, logical.ReadOperation, []string{userFilterWarning}),
+		},
+	})
+
+	// If both upndomain and userfilter is set, ensure that a warning is still
+	// returned if userattr is not considered
+	cfg.UPNDomain = "planetexpress.com"
+
+	logicaltest.Test(t, logicaltest.TestCase{
+		CredentialBackend: b,
+		Steps: []logicaltest.TestStep{
+			testAccStepConfigUrlWarningCheck(t, cfg, logical.UpdateOperation, []string{userFilterWarning}),
+			testAccStepConfigUrlWarningCheck(t, cfg, logical.ReadOperation, []string{userFilterWarning}),
+		},
+	})
+
+	cfg.UPNDomain = ""
+
 	// Add a liberal user filter, allowing to log in with either cn or email
 	cfg.UserFilter = "(|({{.UserAttr}}={{.Username}})(mail={{.Username}}))"
 
@@ -838,6 +863,36 @@ func testAccStepConfigUrlNoGroupDN(t *testing.T, cfg *ldaputil.ConfigEntry) logi
 			"discoverdn":           true,
 			"case_sensitive_names": true,
 			"request_timeout":      cfg.RequestTimeout,
+		},
+	}
+}
+
+func testAccStepConfigUrlWarningCheck(t *testing.T, cfg *ldaputil.ConfigEntry, operation logical.Operation, warnings []string) logicaltest.TestStep {
+	return logicaltest.TestStep{
+		Operation: operation,
+		Path:      "config",
+		Data: map[string]interface{}{
+			"url":                  cfg.Url,
+			"userattr":             cfg.UserAttr,
+			"userdn":               cfg.UserDN,
+			"userfilter":           cfg.UserFilter,
+			"groupdn":              cfg.GroupDN,
+			"groupattr":            cfg.GroupAttr,
+			"binddn":               cfg.BindDN,
+			"bindpass":             cfg.BindPassword,
+			"case_sensitive_names": true,
+			"token_policies":       "abc,xyz",
+			"request_timeout":      cfg.RequestTimeout,
+		},
+		Check: func(response *logical.Response) error {
+			if len(response.Warnings) == 0 {
+				return fmt.Errorf("expected warnings, got none")
+			}
+
+			if !strutil.StrListSubset(response.Warnings, warnings) {
+				return fmt.Errorf("expected response to contain the following warnings:\n%s\ngot:\n%s", warnings, response.Warnings)
+			}
+			return nil
 		},
 	}
 }

--- a/changelog/14095.txt
+++ b/changelog/14095.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+auth/ldap: Add a response warning and server log whenever the config is accessed
+if `userfilter` doesn't consider `userattr`
+```

--- a/website/content/api-docs/auth/ldap.mdx
+++ b/website/content/api-docs/auth/ldap.mdx
@@ -90,6 +90,8 @@ This endpoint configures the LDAP auth method.
 
 @include 'tokenfields.mdx'
 
+@include 'ldap-auth-userfilter-warning.mdx'
+
 ### Sample Request
 
 ```shell-session

--- a/website/content/docs/auth/ldap.mdx
+++ b/website/content/docs/auth/ldap.mdx
@@ -118,7 +118,7 @@ There are two alternate methods of resolving the user object used to authenticat
 - `userattr` (string, optional) - Attribute on user attribute object matching the username passed when authenticating. Examples: `sAMAccountName`, `cn`, `uid`
 - `userfilter` (string, optional) - Go template used to construct a ldap user search filter. The template can access the following context variables: \[`UserAttr`, `Username`\]. The default userfilter is `({{.UserAttr}}={{.Username}})` or `(userPrincipalName={{.Username}}@UPNDomain)` if the `upndomain` parameter is set. The user search filter can be used to restrict what user can attempt to log in. For example, to limit login to users that are not contractors, you could write `(&(objectClass=user)({{.UserAttr}}={{.Username}})(!(employeeType=Contractor)))`.
 
-
+@include 'ldap-auth-userfilter-warning.mdx'
 
 #### Binding - Anonymous Search
 
@@ -128,6 +128,8 @@ There are two alternate methods of resolving the user object used to authenticat
 - `userfilter` (string, optional) - Go template used to construct a ldap user search filter. The template can access the following context variables: \[`UserAttr`, `Username`\]. The default userfilter is `({{.UserAttr}}={{.Username}})` or `(userPrincipalName={{.Username}}@UPNDomain)` if the `upndomain` parameter is set. The user search filter can be used to restrict what user can attempt to log in. For example, to limit login to users that are not contractors, you could write `(&(objectClass=user)({{.UserAttr}}={{.Username}})(!(employeeType=Contractor)))`.
 - `deny_null_bind` (bool, optional) - This option prevents users from bypassing authentication when providing an empty password. The default is `true`.
 - `anonymous_group_search` (bool, optional) - Use anonymous binds when performing LDAP group searches. Defaults to `false`.
+
+@include 'ldap-auth-userfilter-warning.mdx'
 
 #### Binding - User Principal Name (AD)
 

--- a/website/content/partials/ldap-auth-userfilter-warning.mdx
+++ b/website/content/partials/ldap-auth-userfilter-warning.mdx
@@ -1,0 +1,4 @@
+~> When specifying a `userfilter`, either the templated value `{{.UserAttr}}` or
+the literal value that matches `userattr` should be present in the filter to
+ensure that the search returns a unique result that takes `userattr` into
+consideration for entity alias mapping purposes and avoid possible collisions on login.


### PR DESCRIPTION
This PR adds a response warning to config read and write endpoints if we detect that a non-empty `userfilter` does not consider `userattr`.

The [default userfilter config value](https://github.com/hashicorp/vault/blob/4cc2673651bf095759b9531784380b9431c21c8f/sdk/helper/ldaputil/config.go#L98) contains the templated `{{.UserAttr}}` value which should take care of not issuing this warning for any config updates where this is not provided explicitly.

However, a config _may_ have an empty `userfilter` if users are upgrading existing Vault installations from 1.8 to 1.9, which is when `userfilter` was introduced. In order to avoid spamming the logs, a server-side log is only printed on config reads and writes if `userfilter` is non-empty. Thankfully the [rendered search filter will default](https://github.com/hashicorp/vault/blob/eadbe9650784ad579b66fbfd33f6aa712cc0652e/sdk/helper/ldaputil/client.go#L184) to a filter that references `userattr` if the config `userfilter` is empty, which in turn handles the upgrade case gracefully. 

Related to https://github.com/hashicorp/vault/pull/11000