### PR TITLE
validate cipher length before decrypting

### DIFF
--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -1014,6 +1014,9 @@ func termLabel(term uint32) []metrics.Label {
 
 // decrypt is used to decrypt a value using the keyring
 func (b *AESGCMBarrier) decrypt(path string, gcm cipher.AEAD, cipher []byte) ([]byte, error) {
+	if len(cipher) < 5+gcm.NonceSize() {
+		return nil, fmt.Errorf("invalid cipher length")
+	}
 	// Capture the parts
 	nonce := cipher[5 : 5+gcm.NonceSize()]
 	raw := cipher[5+gcm.NonceSize():]

--- a/vault/barrier_aes_gcm.go
+++ b/vault/barrier_aes_gcm.go
@@ -1065,7 +1065,14 @@ func (b *AESGCMBarrier) Decrypt(_ context.Context, key string, ciphertext []byte
 		return nil, ErrBarrierSealed
 	}
 
+	if len(ciphertext) == 0 {
+		return nil, fmt.Errorf("empty ciphertext")
+	}
+
 	// Verify the term
+	if len(ciphertext) < 4 {
+		return nil, fmt.Errorf("invalid ciphertext term")
+	}
 	term := binary.BigEndian.Uint32(ciphertext[:4])
 
 	// Get the GCM by term

--- a/vault/barrier_aes_gcm_test.go
+++ b/vault/barrier_aes_gcm_test.go
@@ -517,6 +517,39 @@ func TestEncrypt_BarrierEncryptor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	b, err := NewAESGCMBarrier(inm)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Initialize and unseal
+	key, err := b.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("err generating key: %v", err)
+	}
+	ctx := context.Background()
+	b.Initialize(ctx, key, nil, rand.Reader)
+	b.Unseal(ctx, key)
+
+	cipher, err := b.Encrypt(ctx, "foo", []byte("quick brown fox"))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	plain, err := b.Decrypt(ctx, "foo", cipher)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if string(plain) != "quick brown fox" {
+		t.Fatalf("bad: %s", plain)
+	}
+}
+
+// Ensure Decrypt returns an error (rather than panic) when given a ciphertext
+// that is nil or too short
+func TestDecrypt_InvalidCipherLength(t *testing.T) {
+	inm, err := inmem.NewInmem(nil, logger)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -525,23 +558,26 @@ func TestEncrypt_BarrierEncryptor(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Initialize and unseal
-	key, _ := b.GenerateKey(rand.Reader)
-	b.Initialize(context.Background(), key, nil, rand.Reader)
-	b.Unseal(context.Background(), key)
-
-	cipher, err := b.Encrypt(context.Background(), "foo", []byte("quick brown fox"))
+	key, err := b.GenerateKey(rand.Reader)
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		t.Fatalf("err generating key: %v", err)
+	}
+	ctx := context.Background()
+	b.Initialize(ctx, key, nil, rand.Reader)
+	b.Unseal(ctx, key)
+
+	var nilCipher []byte
+	if _, err = b.Decrypt(ctx, "", nilCipher); err == nil {
+		t.Fatal("expected error when given nil cipher")
+	}
+	emptyCipher := []byte{}
+	if _, err = b.Decrypt(ctx, "", emptyCipher); err == nil {
+		t.Fatal("expected error when given empty cipher")
 	}
 
-	plain, err := b.Decrypt(context.Background(), "foo", cipher)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if string(plain) != "quick brown fox" {
-		t.Fatalf("bad: %s", plain)
+	badTermLengthCipher := make([]byte, 3, 3)
+	if _, err = b.Decrypt(ctx, "", badTermLengthCipher); err == nil {
+		t.Fatal("expected error when given cipher with too short term")
 	}
 }
 


### PR DESCRIPTION
This addresses TOB-016.

I'm not sure if erroring when the `len(ciphertext) < 4` is revealing any important information to a potential attacker, so please let me know. As is, it would panic (which is less directly revealing the same information).

This will be backported back to 1.7.x