### PR TITLE
Rename transit's auto_rotate_interval to auto_rotate_period

### DIFF
--- a/builtin/logical/transit/backend.go
+++ b/builtin/logical/transit/backend.go
@@ -190,7 +190,7 @@ func (b *backend) periodicFunc(ctx context.Context, req *logical.Request) error 
 }
 
 // autoRotateKeys retrieves all transit keys and rotates those which have an
-// auto rotate interval defined which has passed. This operation only happens
+// auto rotate period defined which has passed. This operation only happens
 // on primary nodes and performance secondary nodes which have a local mount.
 func (b *backend) autoRotateKeys(ctx context.Context, req *logical.Request) error {
 	// Only check for autorotation once an hour to avoid unnecessarily iterating
@@ -247,15 +247,15 @@ func (b *backend) rotateIfRequired(ctx context.Context, req *logical.Request, ke
 	}
 	defer p.Unlock()
 
-	// If the policy's automatic rotation interval is 0, it should not
+	// If the policy's automatic rotation period is 0, it should not
 	// automatically rotate.
-	if p.AutoRotateInterval == 0 {
+	if p.AutoRotatePeriod == 0 {
 		return nil
 	}
 
 	// Retrieve the latest version of the policy and determine if it is time to rotate.
 	latestKey := p.Keys[strconv.Itoa(p.LatestVersion)]
-	if time.Now().After(latestKey.CreationTime.Add(p.AutoRotateInterval)) {
+	if time.Now().After(latestKey.CreationTime.Add(p.AutoRotatePeriod)) {
 		if b.Logger().IsDebug() {
 			b.Logger().Debug("automatically rotating key", "key", key)
 		}

--- a/builtin/logical/transit/backend_test.go
+++ b/builtin/logical/transit/backend_test.go
@@ -1607,7 +1607,7 @@ func TestTransit_AutoRotateKeys(t *testing.T) {
 					Operation: logical.UpdateOperation,
 					Path:      "keys/test2",
 					Data: map[string]interface{}{
-						"auto_rotate_interval": 24 * time.Hour,
+						"auto_rotate_period": 24 * time.Hour,
 					},
 				}
 				resp, err = b.HandleRequest(context.Background(), req)
@@ -1651,7 +1651,7 @@ func TestTransit_AutoRotateKeys(t *testing.T) {
 					t.Fatalf("incorrect latest_version found, got: %d, want: %d", resp.Data["latest_version"], 1)
 				}
 
-				// Update auto rotate interval on one key to be one nanosecond
+				// Update auto rotate period on one key to be one nanosecond
 				p, _, err := b.GetPolicy(context.Background(), keysutil.PolicyRequest{
 					Storage: storage,
 					Name:    "test2",
@@ -1662,7 +1662,7 @@ func TestTransit_AutoRotateKeys(t *testing.T) {
 				if p == nil {
 					t.Fatal("expected non-nil policy")
 				}
-				p.AutoRotateInterval = time.Nanosecond
+				p.AutoRotatePeriod = time.Nanosecond
 				err = p.Persist(context.Background(), storage)
 				if err != nil {
 					t.Fatal(err)

--- a/builtin/logical/transit/path_config.go
+++ b/builtin/logical/transit/path_config.go
@@ -49,7 +49,7 @@ the latest version of the key is allowed.`,
 				Description: `Enables taking a backup of the named key in plaintext format. Once set, this cannot be disabled.`,
 			},
 
-			"auto_rotate_interval": {
+			"auto_rotate_period": {
 				Type: framework.TypeDurationSecond,
 				Description: `Amount of time the key should live before
 being automatically rotated. A value of 0
@@ -193,19 +193,19 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, d *
 		}
 	}
 
-	autoRotateIntervalRaw, ok, err := d.GetOkErr("auto_rotate_interval")
+	autoRotatePeriodRaw, ok, err := d.GetOkErr("auto_rotate_period")
 	if err != nil {
 		return nil, err
 	}
 	if ok {
-		autoRotateInterval := time.Second * time.Duration(autoRotateIntervalRaw.(int))
+		autoRotatePeriod := time.Second * time.Duration(autoRotatePeriodRaw.(int))
 		// Provided value must be 0 to disable or at least an hour
-		if autoRotateInterval != 0 && autoRotateInterval < time.Hour {
-			return logical.ErrorResponse("auto rotate interval must be 0 to disable or at least an hour"), nil
+		if autoRotatePeriod != 0 && autoRotatePeriod < time.Hour {
+			return logical.ErrorResponse("auto rotate period must be 0 to disable or at least an hour"), nil
 		}
 
-		if autoRotateInterval != p.AutoRotateInterval {
-			p.AutoRotateInterval = autoRotateInterval
+		if autoRotatePeriod != p.AutoRotatePeriod {
+			p.AutoRotatePeriod = autoRotatePeriod
 			persistNeeded = true
 		}
 	}

--- a/builtin/logical/transit/path_config_test.go
+++ b/builtin/logical/transit/path_config_test.go
@@ -294,44 +294,44 @@ func TestTransit_ConfigSettings(t *testing.T) {
 
 func TestTransit_UpdateKeyConfigWithAutorotation(t *testing.T) {
 	tests := map[string]struct {
-		initialAutoRotateInterval interface{}
-		newAutoRotateInterval     interface{}
-		shouldError               bool
-		expectedValue             time.Duration
+		initialAutoRotatePeriod interface{}
+		newAutoRotatePeriod     interface{}
+		shouldError             bool
+		expectedValue           time.Duration
 	}{
 		"default (no value)": {
-			initialAutoRotateInterval: "5h",
-			shouldError:               false,
-			expectedValue:             5 * time.Hour,
+			initialAutoRotatePeriod: "5h",
+			shouldError:             false,
+			expectedValue:           5 * time.Hour,
 		},
 		"0 (int)": {
-			initialAutoRotateInterval: "5h",
-			newAutoRotateInterval:     0,
-			shouldError:               false,
-			expectedValue:             0,
+			initialAutoRotatePeriod: "5h",
+			newAutoRotatePeriod:     0,
+			shouldError:             false,
+			expectedValue:           0,
 		},
 		"0 (string)": {
-			initialAutoRotateInterval: "5h",
-			newAutoRotateInterval:     0,
-			shouldError:               false,
-			expectedValue:             0,
+			initialAutoRotatePeriod: "5h",
+			newAutoRotatePeriod:     0,
+			shouldError:             false,
+			expectedValue:           0,
 		},
 		"5 seconds": {
-			newAutoRotateInterval: "5s",
-			shouldError:           true,
+			newAutoRotatePeriod: "5s",
+			shouldError:         true,
 		},
 		"5 hours": {
-			newAutoRotateInterval: "5h",
-			shouldError:           false,
-			expectedValue:         5 * time.Hour,
+			newAutoRotatePeriod: "5h",
+			shouldError:         false,
+			expectedValue:       5 * time.Hour,
 		},
 		"negative value": {
-			newAutoRotateInterval: "-1800s",
-			shouldError:           true,
+			newAutoRotatePeriod: "-1800s",
+			shouldError:         true,
 		},
 		"invalid string": {
-			newAutoRotateInterval: "this shouldn't work",
-			shouldError:           true,
+			newAutoRotatePeriod: "this shouldn't work",
+			shouldError:         true,
 		},
 	}
 
@@ -364,11 +364,11 @@ func TestTransit_UpdateKeyConfigWithAutorotation(t *testing.T) {
 			keyName := hex.EncodeToString(keyNameBytes)
 
 			_, err = client.Logical().Write(fmt.Sprintf("transit/keys/%s", keyName), map[string]interface{}{
-				"auto_rotate_interval": test.initialAutoRotateInterval,
+				"auto_rotate_period": test.initialAutoRotatePeriod,
 			})
 
 			resp, err := client.Logical().Write(fmt.Sprintf("transit/keys/%s/config", keyName), map[string]interface{}{
-				"auto_rotate_interval": test.newAutoRotateInterval,
+				"auto_rotate_period": test.newAutoRotatePeriod,
 			})
 			switch {
 			case test.shouldError && err == nil:
@@ -385,7 +385,7 @@ func TestTransit_UpdateKeyConfigWithAutorotation(t *testing.T) {
 				if resp == nil {
 					t.Fatal("expected non-nil response")
 				}
-				gotRaw, ok := resp.Data["auto_rotate_interval"].(json.Number)
+				gotRaw, ok := resp.Data["auto_rotate_period"].(json.Number)
 				if !ok {
 					t.Fatal("returned value is of unexpected type")
 				}
@@ -395,7 +395,7 @@ func TestTransit_UpdateKeyConfigWithAutorotation(t *testing.T) {
 				}
 				want := int64(test.expectedValue.Seconds())
 				if got != want {
-					t.Fatalf("incorrect auto_rotate_interval returned, got: %d, want: %d", got, want)
+					t.Fatalf("incorrect auto_rotate_period returned, got: %d, want: %d", got, want)
 				}
 			}
 		})

--- a/builtin/logical/transit/path_keys.go
+++ b/builtin/logical/transit/path_keys.go
@@ -95,7 +95,7 @@ if the key type supports public keys, this will
 return the public key for the given context.`,
 			},
 
-			"auto_rotate_interval": {
+			"auto_rotate_period": {
 				Type:    framework.TypeDurationSecond,
 				Default: 0,
 				Description: `Amount of time the key should live before
@@ -132,10 +132,10 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 	keyType := d.Get("type").(string)
 	exportable := d.Get("exportable").(bool)
 	allowPlaintextBackup := d.Get("allow_plaintext_backup").(bool)
-	autoRotateInterval := time.Second * time.Duration(d.Get("auto_rotate_interval").(int))
+	autoRotatePeriod := time.Second * time.Duration(d.Get("auto_rotate_period").(int))
 
-	if autoRotateInterval != 0 && autoRotateInterval < time.Hour {
-		return logical.ErrorResponse("auto rotate interval must be 0 to disable or at least an hour"), nil
+	if autoRotatePeriod != 0 && autoRotatePeriod < time.Hour {
+		return logical.ErrorResponse("auto rotate period must be 0 to disable or at least an hour"), nil
 	}
 
 	if !derived && convergent {
@@ -150,7 +150,7 @@ func (b *backend) pathPolicyWrite(ctx context.Context, req *logical.Request, d *
 		Convergent:           convergent,
 		Exportable:           exportable,
 		AllowPlaintextBackup: allowPlaintextBackup,
-		AutoRotateInterval:   autoRotateInterval,
+		AutoRotatePeriod:     autoRotatePeriod,
 	}
 	switch keyType {
 	case "aes128-gcm96":
@@ -238,7 +238,7 @@ func (b *backend) pathPolicyRead(ctx context.Context, req *logical.Request, d *f
 			"supports_decryption":    p.Type.DecryptionSupported(),
 			"supports_signing":       p.Type.SigningSupported(),
 			"supports_derivation":    p.Type.DerivationSupported(),
-			"auto_rotate_interval":   int64(p.AutoRotateInterval.Seconds()),
+			"auto_rotate_period":     int64(p.AutoRotatePeriod.Seconds()),
 		},
 	}
 

--- a/builtin/logical/transit/path_keys_test.go
+++ b/builtin/logical/transit/path_keys_test.go
@@ -95,39 +95,39 @@ func TestTransit_Issue_2958(t *testing.T) {
 
 func TestTransit_CreateKeyWithAutorotation(t *testing.T) {
 	tests := map[string]struct {
-		autoRotateInterval interface{}
-		shouldError        bool
-		expectedValue      time.Duration
+		autoRotatePeriod interface{}
+		shouldError      bool
+		expectedValue    time.Duration
 	}{
 		"default (no value)": {
 			shouldError: false,
 		},
 		"0 (int)": {
-			autoRotateInterval: 0,
-			shouldError:        false,
-			expectedValue:      0,
+			autoRotatePeriod: 0,
+			shouldError:      false,
+			expectedValue:    0,
 		},
 		"0 (string)": {
-			autoRotateInterval: "0",
-			shouldError:        false,
-			expectedValue:      0,
+			autoRotatePeriod: "0",
+			shouldError:      false,
+			expectedValue:    0,
 		},
 		"5 seconds": {
-			autoRotateInterval: "5s",
-			shouldError:        true,
+			autoRotatePeriod: "5s",
+			shouldError:      true,
 		},
 		"5 hours": {
-			autoRotateInterval: "5h",
-			shouldError:        false,
-			expectedValue:      5 * time.Hour,
+			autoRotatePeriod: "5h",
+			shouldError:      false,
+			expectedValue:    5 * time.Hour,
 		},
 		"negative value": {
-			autoRotateInterval: "-1800s",
-			shouldError:        true,
+			autoRotatePeriod: "-1800s",
+			shouldError:      true,
 		},
 		"invalid string": {
-			autoRotateInterval: "this shouldn't work",
-			shouldError:        true,
+			autoRotatePeriod: "this shouldn't work",
+			shouldError:      true,
 		},
 	}
 
@@ -160,7 +160,7 @@ func TestTransit_CreateKeyWithAutorotation(t *testing.T) {
 			keyName := hex.EncodeToString(keyNameBytes)
 
 			_, err = client.Logical().Write(fmt.Sprintf("transit/keys/%s", keyName), map[string]interface{}{
-				"auto_rotate_interval": test.autoRotateInterval,
+				"auto_rotate_period": test.autoRotatePeriod,
 			})
 			switch {
 			case test.shouldError && err == nil:
@@ -177,7 +177,7 @@ func TestTransit_CreateKeyWithAutorotation(t *testing.T) {
 				if resp == nil {
 					t.Fatal("expected non-nil response")
 				}
-				gotRaw, ok := resp.Data["auto_rotate_interval"].(json.Number)
+				gotRaw, ok := resp.Data["auto_rotate_period"].(json.Number)
 				if !ok {
 					t.Fatal("returned value is of unexpected type")
 				}
@@ -187,7 +187,7 @@ func TestTransit_CreateKeyWithAutorotation(t *testing.T) {
 				}
 				want := int64(test.expectedValue.Seconds())
 				if got != want {
-					t.Fatalf("incorrect auto_rotate_interval returned, got: %d, want: %d", got, want)
+					t.Fatalf("incorrect auto_rotate_period returned, got: %d, want: %d", got, want)
 				}
 			}
 		})

--- a/sdk/helper/keysutil/lock_manager.go
+++ b/sdk/helper/keysutil/lock_manager.go
@@ -52,7 +52,7 @@ type PolicyRequest struct {
 	AllowPlaintextBackup bool
 
 	// How frequently the key should automatically rotate
-	AutoRotateInterval time.Duration
+	AutoRotatePeriod time.Duration
 }
 
 type LockManager struct {
@@ -383,7 +383,7 @@ func (lm *LockManager) GetPolicy(ctx context.Context, req PolicyRequest, rand io
 			Derived:              req.Derived,
 			Exportable:           req.Exportable,
 			AllowPlaintextBackup: req.AllowPlaintextBackup,
-			AutoRotateInterval:   req.AutoRotateInterval,
+			AutoRotatePeriod:     req.AutoRotatePeriod,
 		}
 
 		if req.Derived {

--- a/sdk/helper/keysutil/policy.go
+++ b/sdk/helper/keysutil/policy.go
@@ -374,9 +374,9 @@ type Policy struct {
 	// policy object.
 	StoragePrefix string `json:"storage_prefix"`
 
-	// AutoRotateInterval defines how frequently the key should automatically
+	// AutoRotatePeriod defines how frequently the key should automatically
 	// rotate. Setting this to zero disables automatic rotation for the key.
-	AutoRotateInterval time.Duration `json:"auto_rotate_interval"`
+	AutoRotatePeriod time.Duration `json:"auto_rotate_period"`
 
 	// versionPrefixCache stores caches of version prefix strings and the split
 	// version template.

--- a/ui/app/components/transit-edit.js
+++ b/ui/app/components/transit-edit.js
@@ -95,10 +95,10 @@ export default Component.extend(FocusOnInsertMixin, {
 
     handleAutoRotateChange(ttlObj) {
       if (ttlObj.enabled) {
-        set(this.key, 'autoRotateInterval', ttlObj.goSafeTimeString);
+        set(this.key, 'autoRotatePeriod', ttlObj.goSafeTimeString);
         this.set('autoRotateInvalid', ttlObj.seconds < 3600);
       } else {
-        set(this.key, 'autoRotateInterval', 0);
+        set(this.key, 'autoRotatePeriod', 0);
       }
     },
 

--- a/ui/app/helpers/format-duration.js
+++ b/ui/app/helpers/format-duration.js
@@ -2,10 +2,14 @@ import { helper } from '@ember/component/helper';
 import { assert } from '@ember/debug';
 import { formatDuration, intervalToDuration } from 'date-fns';
 
-export function duration([time]) {
+export function duration([time], { removeZero = false }) {
   // intervalToDuration creates a durationObject that turns the seconds (ex 3600) to respective:
   // { years: 0, months: 0, days: 0, hours: 1, minutes: 0, seconds: 0 }
   // then formatDuration returns the filled in keys of the durationObject
+
+  if (removeZero && time === '0') {
+    return null;
+  }
 
   // time must be in seconds
   let duration = Number.parseInt(time, 10);

--- a/ui/app/models/transit-key.js
+++ b/ui/app/models/transit-key.js
@@ -56,11 +56,11 @@ export default Model.extend({
     fieldValue: 'id',
     readOnly: true,
   }),
-  autoRotateInterval: attr({
+  autoRotatePeriod: attr({
     defaultValue: '0',
     defaultShown: 'Key is not automatically rotated',
     editType: 'ttl',
-    label: 'Auto-rotation interval',
+    label: 'Auto-rotation period',
   }),
   deletionAllowed: attr('boolean'),
   derived: attr('boolean'),

--- a/ui/app/serializers/transit-key.js
+++ b/ui/app/serializers/transit-key.js
@@ -50,12 +50,12 @@ export default RESTSerializer.extend({
       const min_decryption_version = snapshot.attr('minDecryptionVersion');
       const min_encryption_version = snapshot.attr('minEncryptionVersion');
       const deletion_allowed = snapshot.attr('deletionAllowed');
-      const auto_rotate_interval = snapshot.attr('autoRotateInterval');
+      const auto_rotate_period = snapshot.attr('autoRotatePeriod');
       return {
         min_decryption_version,
         min_encryption_version,
         deletion_allowed,
-        auto_rotate_interval,
+        auto_rotate_period,
       };
     } else {
       snapshot.id = snapshot.attr('name');

--- a/ui/app/templates/components/transit-form-create.hbs
+++ b/ui/app/templates/components/transit-form-create.hbs
@@ -10,7 +10,7 @@
       <TtlPicker2
         @initialValue="1h"
         @initialEnabled={{false}}
-        @label="Auto-rotation interval"
+        @label="Auto-rotation period"
         @helperTextDisabled="Key will never be automatically rotated"
         @helperTextEnabled="Key will be automatically rotated every"
         @onChange={{@handleAutoRotateChange}}

--- a/ui/app/templates/components/transit-form-edit.hbs
+++ b/ui/app/templates/components/transit-form-edit.hbs
@@ -18,9 +18,9 @@
     </div>
     <div class="field">
       <TtlPicker2
-        @initialValue={{or @key.autoRotateInterval "1h"}}
-        @initialEnabled={{not (eq @key.autoRotateInterval "0s")}}
-        @label="Auto-rotation interval"
+        @initialValue={{or @key.autoRotatePeriod "1h"}}
+        @initialEnabled={{not (eq @key.autoRotatePeriod "0s")}}
+        @label="Auto-rotation period"
         @helperTextDisabled="Key will never be automatically rotated"
         @helperTextEnabled="Key will be automatically rotated every"
         @onChange={{@handleAutoRotateChange}}

--- a/ui/app/templates/components/transit-form-show.hbs
+++ b/ui/app/templates/components/transit-form-show.hbs
@@ -171,8 +171,8 @@
 {{else}}
   <InfoTableRow @label="Type" @value={{@key.type}} />
   <InfoTableRow
-    @label="Auto-rotation interval"
-    @value={{or (format-ttl @key.autoRotateInterval removeZero=true) "Key will not be automatically rotated"}}
+    @label="Auto-rotation period"
+    @value={{or (format-duration @key.autoRotatePeriod removeZero=true) "Key will not be automatically rotated"}}
   />
   <InfoTableRow @label="Deletion allowed" @value={{stringify @key.deletionAllowed}} />
 

--- a/website/content/api-docs/secret/transit.mdx
+++ b/website/content/api-docs/secret/transit.mdx
@@ -64,7 +64,7 @@ values set here cannot be changed after key creation.
   - `rsa-3072` - RSA with bit size of 3072 (asymmetric)
   - `rsa-4096` - RSA with bit size of 4096 (asymmetric)
 
-- `auto_rotate_interval` `(duration: "0", optional)` – The interval at which
+- `auto_rotate_period` `(duration: "0", optional)` – The period at which
   this key should be rotated automatically. Setting this to "0" (the default)
   will disable automatic key rotation. This value cannot be shorter than one
   hour.
@@ -232,10 +232,10 @@ are returned during a read operation on the named key.)
 - `allow_plaintext_backup` `(bool: false)` - If set, enables taking backup of
   named key in the plaintext format. Once set, this cannot be disabled.
 
-- `auto_rotate_interval` `(duration: "", optional)` – The interval at which this
+- `auto_rotate_period` `(duration: "", optional)` – The period at which this
   key should be rotated automatically. Setting this to "0" will disable automatic
   key rotation. This value cannot be shorter than one hour. When no value is
-  provided, the interval remains unchanged.
+  provided, the period remains unchanged.
 
 ### Sample Payload
 


### PR DESCRIPTION
# Overview
This renames the `auto_rotate_interval` field on transit keys to `auto_rotate_period` for consistency’s sake and to get CLI pretty printing for free. Since these values will likely be on the order of days, weeks, or months, changing this will knock a couple orders of magnitude off of the CLI output (e.g. `3600` becomes `“1h”`). A separate UI fix is included to account for this field recently changing types from a time string to integral seconds.

Issue: VAULT-5128

# Testing
## CLI
- `vault secrets enable transit`
- `vault write -f transit/keys/test-key auto_rotate_period=1h`
- `vault read transit/keys/test-key`
- Observe the `auto_rotate_interval` field is now `auto_rotate_period` and formatted as a time string on the CLI (`"1h"`)
- `curl -H 'X-Vault-Token: $VAULT_TOKEN' $VAULT_ADDR/v1/transit/keys/test-key`
- Observe `auto_rotate_interval` field is now `auto_rotate_period` and formatted as integral seconds (`3600`)
## UI
- Enable transit secrets engine
- Create a transit key with an auto rotate period
- View the key and observe its auto rotate period is named and displayed correctly
- Create a transit key without an auto rotate period
- View the key and observe its auto rotate period is named and displayed correctly