### PR TITLE
fix approle login IPBelongsToCIDRBlocksSlice err handling

### DIFF
--- a/builtin/credential/approle/path_login.go
+++ b/builtin/credential/approle/path_login.go
@@ -178,11 +178,14 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, dat
 				}
 
 				belongs, err := cidrutil.IPBelongsToCIDRBlocksSlice(req.Connection.RemoteAddr, entry.CIDRList)
-				if !belongs || err != nil {
+				if err != nil {
+					return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+				}
+
+				if !belongs {
 					return logical.ErrorResponse(fmt.Errorf(
-						"source address %q unauthorized through CIDR restrictions on the secret ID: %w",
+						"source address %q unauthorized through CIDR restrictions on the secret ID",
 						req.Connection.RemoteAddr,
-						err,
 					).Error()), nil
 				}
 			}

--- a/changelog/14107.txt
+++ b/changelog/14107.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/approle: Fix wrapping of nil errors in `login` endpoint
+```


### PR DESCRIPTION
Check `belongs` and `err` return values from `cidrutil.IPBelongsToCIDRBlocksSlice`. In the case that `err` is nil, the current `fmt.Errorf` with error wrapping, `%w` results in printing `%!w(<nil>)` which is not ideal. The errors returned from `cidrutil.IPBelongsToCIDRBlocksSlice` actually denote invalid inputs (e.g. missing IP address, empty `cidrs`). This change introduces the separation of checking both return values together. If an error occurs, a `Logical.ErrorResponse` will still be returned with a `logical.ErrInvalidRequest` error.

Fixes #14096