### PR TITLE
UI/format-duration error fix

### DIFF
--- a/ui/app/helpers/format-duration.js
+++ b/ui/app/helpers/format-duration.js
@@ -1,5 +1,4 @@
 import { helper } from '@ember/component/helper';
-import { assert } from '@ember/debug';
 import { formatDuration, intervalToDuration } from 'date-fns';
 
 export function duration([time], { removeZero = false }) {
@@ -13,7 +12,9 @@ export function duration([time], { removeZero = false }) {
 
   // time must be in seconds
   let duration = Number.parseInt(time, 10);
-  assert('could not parse time', !isNaN(duration));
+  if (isNaN(duration)) {
+    return time;
+  }
   return formatDuration(intervalToDuration({ start: 0, end: duration * 1000 }));
 }
 


### PR DESCRIPTION
# Overview
When the output type of a transit key's `auto_rotate_period` changed, its template formatting helper also changed. Switching from `format-ttl` to `format-duration` navigating to the key details tab and then to the top-level transit backend page resulted in a value of `undefined` being passed to the template helper. This resulted in a parsing error and would prevent further navigation. This PR updates the return value of `format-duration` to mimic that of `format-ttl` when an invalid input is provided.

## Old Behavior
![old](https://user-images.githubusercontent.com/975680/154384406-05ac5318-187a-4e46-bc0a-513449f1854e.gif)

## New Behavior
![new](https://user-images.githubusercontent.com/975680/154384466-e7a9b28a-285b-4bd1-a0bc-ad19509a22f6.gif)

# Testing
## UI (Manual)
- Enable the transit secrets engine
- Create a transit key
- Navigate to the newly created transit key's "Details" tab
- Attempt to navigate to the transit secrets engine in the breadcrumb bar

## UI (Automated)
- `cd ui && yarn run test -s -f="transit backend: "`