### PR TITLE
identity/oidc: Adds default provider, key, and allow_all assignment

### DIFF
--- a/changelog/14119.txt
+++ b/changelog/14119.txt
@@ -1,0 +1,9 @@
+```release-note:improvement
+identity/oidc: Adds a default OIDC provider
+```
+```release-note:improvement
+identity/oidc: Adds a default key for OIDC clients
+```
+```release-note:improvement
+identity/oidc: Adds an `allow_all` assignment that permits all entities to authenticate via an OIDC client
+```

--- a/vault/external_tests/identity/oidc_provider_test.go
+++ b/vault/external_tests/identity/oidc_provider_test.go
@@ -39,6 +39,228 @@ const (
 	`
 )
 
+// TestOIDC_Auth_Code_Flow_Default_Resources tests the authorization
+// code flow using the default OIDC provider, default key, and allow_all
+// assignment. This ensures that the resources are created and usable with
+// an initial setup of Vault.
+func TestOIDC_Auth_Code_Flow_Default_Resources(t *testing.T) {
+	cluster := setupOIDCTestCluster(t, 2)
+	defer cluster.Cleanup()
+	active := cluster.Cores[0].Client
+	standby := cluster.Cores[1].Client
+
+	// Enable userpass auth and create a user
+	err := active.Sys().EnableAuthWithOptions("userpass", &api.EnableAuthOptions{
+		Type: "userpass",
+	})
+	require.NoError(t, err)
+	_, err = active.Logical().Write("auth/userpass/users/end-user", map[string]interface{}{
+		"password": testPassword,
+	})
+	require.NoError(t, err)
+
+	// Create a confidential client
+	_, err = active.Logical().Write("identity/oidc/client/confidential", map[string]interface{}{
+		"redirect_uris":    []string{testRedirectURI},
+		"assignments":      []string{"allow_all"},
+		"id_token_ttl":     "1h",
+		"access_token_ttl": "30m",
+	})
+	require.NoError(t, err)
+
+	// Read the client ID and secret in order to configure the OIDC client
+	resp, err := active.Logical().Read("identity/oidc/client/confidential")
+	require.NoError(t, err)
+	clientID := resp.Data["client_id"].(string)
+	clientSecret := resp.Data["client_secret"].(string)
+
+	// We aren't going to open up a browser to facilitate the login and redirect
+	// from this test, so we'll log in via userpass and set the client's token as
+	// the token that results from the authentication.
+	resp, err = active.Logical().Write("auth/userpass/login/end-user", map[string]interface{}{
+		"password": testPassword,
+	})
+	require.NoError(t, err)
+	clientToken := resp.Auth.ClientToken
+	entityID := resp.Auth.EntityID
+
+	// Look up the token to get its creation time. This will be used for test
+	// cases that make assertions on the max_age parameter and auth_time claim.
+	resp, err = active.Logical().Write("auth/token/lookup", map[string]interface{}{
+		"token": clientToken,
+	})
+	require.NoError(t, err)
+	expectedAuthTime, err := strconv.Atoi(string(resp.Data["creation_time"].(json.Number)))
+	require.NoError(t, err)
+
+	// Read the issuer from the OIDC provider's discovery document
+	var discovery struct {
+		Issuer string `json:"issuer"`
+	}
+	decodeRawRequest(t, active, http.MethodGet,
+		"/v1/identity/oidc/provider/default/.well-known/openid-configuration",
+		nil, &discovery)
+
+	// Create the client-side OIDC provider config
+	pc, err := oidc.NewConfig(discovery.Issuer, clientID,
+		oidc.ClientSecret(clientSecret), []oidc.Alg{oidc.RS256},
+		[]string{testRedirectURI}, oidc.WithProviderCA(string(cluster.CACertPEM)))
+	require.NoError(t, err)
+
+	// Create the client-side OIDC provider
+	p, err := oidc.NewProvider(pc)
+	require.NoError(t, err)
+	defer p.Done()
+
+	// Create the client-side PKCE code verifier
+	v, err := oidc.NewCodeVerifier()
+	require.NoError(t, err)
+
+	type args struct {
+		useStandby bool
+		options    []oidc.Option
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected string
+	}{
+		{
+			name: "active: authorization code flow",
+			args: args{
+				options: []oidc.Option{
+					oidc.WithScopes("openid"),
+				},
+			},
+			expected: fmt.Sprintf(`{
+					"iss": "%s",
+					"aud": "%s",
+					"sub": "%s",
+					"namespace": "root"
+				}`, discovery.Issuer, clientID, entityID),
+		},
+		{
+			name: "active: authorization code flow with max_age parameter",
+			args: args{
+				options: []oidc.Option{
+					oidc.WithScopes("openid"),
+					oidc.WithMaxAge(60),
+				},
+			},
+			expected: fmt.Sprintf(`{
+				"iss": "%s",
+				"aud": "%s",
+				"sub": "%s",
+				"namespace": "root",
+				"auth_time": %d
+			}`, discovery.Issuer, clientID, entityID, expectedAuthTime),
+		},
+		{
+			name: "active: authorization code flow with Proof Key for Code Exchange (PKCE)",
+			args: args{
+				options: []oidc.Option{
+					oidc.WithScopes("openid"),
+					oidc.WithPKCE(v),
+				},
+			},
+			expected: fmt.Sprintf(`{
+				"iss": "%s",
+				"aud": "%s",
+				"sub": "%s",
+				"namespace": "root"
+			}`, discovery.Issuer, clientID, entityID),
+		},
+		{
+			name: "standby: authorization code flow",
+			args: args{
+				useStandby: true,
+				options: []oidc.Option{
+					oidc.WithScopes("openid"),
+				},
+			},
+			expected: fmt.Sprintf(`{
+				"iss": "%s",
+				"aud": "%s",
+				"sub": "%s",
+				"namespace": "root"
+			}`, discovery.Issuer, clientID, entityID),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := active
+			if tt.args.useStandby {
+				client = standby
+			}
+			client.SetToken(clientToken)
+
+			// Create the client-side OIDC request state
+			oidcRequest, err := oidc.NewRequest(10*time.Minute, testRedirectURI, tt.args.options...)
+			require.NoError(t, err)
+
+			// Get the URL for the authorization endpoint from the OIDC client
+			authURL, err := p.AuthURL(context.Background(), oidcRequest)
+			require.NoError(t, err)
+			parsedAuthURL, err := url.Parse(authURL)
+			require.NoError(t, err)
+
+			// This replace only occurs because we're not using the browser in this test
+			authURLPath := strings.Replace(parsedAuthURL.Path, "/ui/vault/", "/v1/", 1)
+
+			// Kick off the authorization code flow
+			var authResp struct {
+				Code  string `json:"code"`
+				State string `json:"state"`
+			}
+			decodeRawRequest(t, client, http.MethodGet, authURLPath, parsedAuthURL.Query(), &authResp)
+
+			// The returned state must match the OIDC client state
+			require.Equal(t, oidcRequest.State(), authResp.State)
+
+			// Exchange the authorization code for an ID token and access token.
+			// The ID token signature is verified using the provider's public keys after
+			// the exchange takes place. The ID token is also validated according to the
+			// client-side requirements of the OIDC spec. See the validation code at:
+			// - https://github.com/hashicorp/cap/blob/main/oidc/provider.go#L240
+			// - https://github.com/hashicorp/cap/blob/main/oidc/provider.go#L441
+			token, err := p.Exchange(context.Background(), oidcRequest, authResp.State, authResp.Code)
+			require.NoError(t, err)
+			require.NotNil(t, token)
+			idToken := token.IDToken()
+			accessToken := token.StaticTokenSource()
+
+			// Get the ID token claims
+			allClaims := make(map[string]interface{})
+			require.NoError(t, idToken.Claims(&allClaims))
+
+			// Get the sub claim for userinfo validation
+			require.NotEmpty(t, allClaims["sub"])
+			subject := allClaims["sub"].(string)
+
+			// Request userinfo using the access token
+			err = p.UserInfo(context.Background(), accessToken, subject, &allClaims)
+			require.NoError(t, err)
+
+			// Assert that claims computed during the flow (i.e., not known
+			// ahead of time in this test) are present as top-level keys
+			for _, claim := range []string{"iat", "exp", "nonce", "at_hash", "c_hash"} {
+				_, ok := allClaims[claim]
+				require.True(t, ok)
+			}
+
+			// Assert that all other expected claims are populated
+			expectedClaims := make(map[string]interface{})
+			require.NoError(t, json.Unmarshal([]byte(tt.expected), &expectedClaims))
+			for k, expectedVal := range expectedClaims {
+				actualVal, ok := allClaims[k]
+				require.True(t, ok)
+				require.EqualValues(t, expectedVal, actualVal)
+			}
+		})
+	}
+}
+
 // TestOIDC_Auth_Code_Flow_Confidential_CAP_Client tests the authorization code
 // flow using a Vault OIDC provider. The test uses the CAP OIDC client to verify
 // that the Vault OIDC provider's responses pass the various client-side validation

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -143,6 +143,10 @@ func (i *IdentityStore) initialize(ctx context.Context, req *logical.Initializat
 		return nil
 	}
 
+	if err := i.storeOIDCDefaultResources(ctx, req.Storage); err != nil {
+		return err
+	}
+
 	entry, err := logical.StorageEntryJSON(caseSensitivityKey, &casesensitivity{
 		DisableLowerCasedNames: i.disableLowerCasedNames,
 	})

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -449,11 +449,6 @@ func (i *IdentityStore) pathOIDCCreateUpdateKey(ctx context.Context, req *logica
 
 	name := d.Get("name").(string)
 
-	if name == defaultKeyName {
-		return logical.ErrorResponse("modification of key %q not allowed",
-			defaultKeyName), nil
-	}
-
 	i.oidcLock.Lock()
 	defer i.oidcLock.Unlock()
 

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -449,6 +449,11 @@ func (i *IdentityStore) pathOIDCCreateUpdateKey(ctx context.Context, req *logica
 
 	name := d.Get("name").(string)
 
+	if name == defaultKeyName {
+		return logical.ErrorResponse("modification of key %q not allowed",
+			defaultKeyName), nil
+	}
+
 	i.oidcLock.Lock()
 	defer i.oidcLock.Unlock()
 
@@ -682,6 +687,11 @@ func (i *IdentityStore) pathOIDCDeleteKey(ctx context.Context, req *logical.Requ
 	}
 
 	targetKeyName := d.Get("name").(string)
+
+	if targetKeyName == defaultKeyName {
+		return logical.ErrorResponse("deletion of key %q not allowed",
+			defaultKeyName), nil
+	}
 
 	i.oidcLock.Lock()
 

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -1171,11 +1171,6 @@ func (i *IdentityStore) pathOIDCCreateUpdateProvider(ctx context.Context, req *l
 	var resp logical.Response
 	name := d.Get("name").(string)
 
-	if name == defaultProviderName {
-		return logical.ErrorResponse("modification of OIDC provider %q not allowed",
-			defaultProviderName), nil
-	}
-
 	i.oidcLock.Lock()
 	defer i.oidcLock.Unlock()
 

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -2391,6 +2391,7 @@ func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
 		if err := i.view.Put(ctx, entry); err != nil {
 			return err
 		}
+		i.Logger().Debug("wrote OIDC default provider")
 	}
 
 	// Store the default key
@@ -2420,6 +2421,7 @@ func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
 		if err := i.view.Put(ctx, entry); err != nil {
 			return err
 		}
+		i.Logger().Debug("wrote OIDC default key")
 	}
 
 	// Store the allow all assignment
@@ -2436,6 +2438,7 @@ func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
 		if err := i.view.Put(ctx, entry); err != nil {
 			return err
 		}
+		i.Logger().Debug("wrote OIDC allow_all assignment")
 	}
 
 	return nil

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -2376,10 +2376,10 @@ func allowAllAssignment() assignment {
 	}
 }
 
-func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
+func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context, view logical.Storage) error {
 	// Store the default provider
 	storageKey := providerPath + defaultProviderName
-	entry, err := i.view.Get(ctx, storageKey)
+	entry, err := view.Get(ctx, storageKey)
 	if err != nil {
 		return err
 	}
@@ -2388,7 +2388,7 @@ func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := i.view.Put(ctx, entry); err != nil {
+		if err := view.Put(ctx, entry); err != nil {
 			return err
 		}
 		i.Logger().Debug("wrote OIDC default provider")
@@ -2396,7 +2396,7 @@ func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
 
 	// Store the default key
 	storageKey = namedKeyConfigPath + defaultKeyName
-	entry, err = i.view.Get(ctx, storageKey)
+	entry, err = view.Get(ctx, storageKey)
 	if err != nil {
 		return err
 	}
@@ -2404,11 +2404,11 @@ func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
 		defaultKey := defaultOIDCKey()
 
 		// Generate initial key material for current and next keys
-		err = defaultKey.generateAndSetKey(ctx, i.Logger(), i.view)
+		err = defaultKey.generateAndSetKey(ctx, i.Logger(), view)
 		if err != nil {
 			return err
 		}
-		err = defaultKey.generateAndSetNextKey(ctx, i.Logger(), i.view)
+		err = defaultKey.generateAndSetNextKey(ctx, i.Logger(), view)
 		if err != nil {
 			return err
 		}
@@ -2418,7 +2418,7 @@ func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := i.view.Put(ctx, entry); err != nil {
+		if err := view.Put(ctx, entry); err != nil {
 			return err
 		}
 		i.Logger().Debug("wrote OIDC default key")
@@ -2426,7 +2426,7 @@ func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
 
 	// Store the allow all assignment
 	storageKey = assignmentPath + allowAllAssignmentName
-	entry, err = i.view.Get(ctx, storageKey)
+	entry, err = view.Get(ctx, storageKey)
 	if err != nil {
 		return err
 	}
@@ -2435,7 +2435,7 @@ func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := i.view.Put(ctx, entry); err != nil {
+		if err := view.Put(ctx, entry); err != nil {
 			return err
 		}
 		i.Logger().Debug("wrote OIDC allow_all assignment")

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -35,6 +35,9 @@ const (
 	clientSecretPrefix       = "hvo_secret_"
 	codeChallengeMethodPlain = "plain"
 	codeChallengeMethodS256  = "S256"
+	defaultProviderName      = "default"
+	defaultKeyName           = "default"
+	allowAllAssignmentName   = "allow_all"
 
 	// Storage path constants
 	oidcProviderPrefix = "oidc_provider/"
@@ -266,8 +269,8 @@ func oidcProviderPaths(i *IdentityStore) []*framework.Path {
 				},
 				"key": {
 					Type:        framework.TypeString,
-					Description: "A reference to a named key resource. Cannot be modified after creation.",
-					Required:    true,
+					Description: "A reference to a named key resource. Cannot be modified after creation. Defaults to the 'default' key.",
+					Default:     "default",
 				},
 				"id_token_ttl": {
 					Type:        framework.TypeDurationSecond,
@@ -654,6 +657,11 @@ func (i *IdentityStore) providersReferencingTargetScopeName(ctx context.Context,
 func (i *IdentityStore) pathOIDCCreateUpdateAssignment(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
 
+	if name == allowAllAssignmentName {
+		return logical.ErrorResponse("modification of assignment %q not allowed",
+			allowAllAssignmentName), nil
+	}
+
 	i.oidcLock.Lock()
 	defer i.oidcLock.Unlock()
 
@@ -748,6 +756,11 @@ func (i *IdentityStore) getOIDCAssignment(ctx context.Context, s logical.Storage
 // pathOIDCDeleteAssignment is used to delete an assignment
 func (i *IdentityStore) pathOIDCDeleteAssignment(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
+
+	if name == allowAllAssignmentName {
+		return logical.ErrorResponse("deletion of assignment %q not allowed",
+			allowAllAssignmentName), nil
+	}
 
 	i.oidcLock.Lock()
 	defer i.oidcLock.Unlock()
@@ -1005,10 +1018,6 @@ func (i *IdentityStore) pathOIDCCreateUpdateClient(ctx context.Context, req *log
 		client.Key = d.Get("key").(string)
 	}
 
-	if client.Key == "" {
-		return logical.ErrorResponse("the key parameter is required"), nil
-	}
-
 	// enforce key existence on client creation
 	key, err := i.getNamedKey(ctx, req.Storage, client.Key)
 	if err != nil {
@@ -1161,6 +1170,11 @@ func (i *IdentityStore) pathOIDCClientExistenceCheck(ctx context.Context, req *l
 func (i *IdentityStore) pathOIDCCreateUpdateProvider(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	var resp logical.Response
 	name := d.Get("name").(string)
+
+	if name == defaultProviderName {
+		return logical.ErrorResponse("modification of OIDC provider %q not allowed",
+			defaultProviderName), nil
+	}
 
 	i.oidcLock.Lock()
 	defer i.oidcLock.Unlock()
@@ -1348,6 +1362,12 @@ func (i *IdentityStore) getOIDCProvider(ctx context.Context, s logical.Storage, 
 // pathOIDCDeleteProvider is used to delete a provider
 func (i *IdentityStore) pathOIDCDeleteProvider(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	name := d.Get("name").(string)
+
+	if name == defaultProviderName {
+		return logical.ErrorResponse("deletion of OIDC provider %q not allowed",
+			defaultProviderName), nil
+	}
+
 	return nil, req.Storage.Delete(ctx, providerPath+name)
 }
 
@@ -1388,7 +1408,7 @@ func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logi
 		ResponseTypes:         []string{"code"},
 		Subjects:              []string{"public"},
 		GrantTypes:            []string{"authorization_code"},
-		AuthMethods:           []string{"client_secret_basic"},
+		AuthMethods:           []string{"client_secret_basic", "none"},
 	}
 
 	data, err := json.Marshal(disc)
@@ -2294,6 +2314,10 @@ func (i *IdentityStore) entityHasAssignment(ctx context.Context, s logical.Stora
 		return false, nil
 	}
 
+	if strutil.StrListContains(assignments, allowAllAssignmentName) {
+		return true, nil
+	}
+
 	// Get the group IDs that the entity is a member of
 	groups, inheritedGroups, err := i.groupsByEntityID(entity.GetID())
 	if err != nil {
@@ -2327,6 +2351,128 @@ func (i *IdentityStore) entityHasAssignment(ctx context.Context, s logical.Stora
 	}
 
 	return false, nil
+}
+
+func defaultOIDCProvider() provider {
+	return provider{
+		AllowedClientIDs: []string{"*"},
+		ScopesSupported:  []string{},
+	}
+}
+
+func defaultOIDCKey() namedKey {
+	return namedKey{
+		Algorithm:        "RS256",
+		VerificationTTL:  24 * time.Hour,
+		RotationPeriod:   24 * time.Hour,
+		NextRotation:     time.Now().Add(24 * time.Hour),
+		AllowedClientIDs: []string{"*"},
+	}
+}
+
+func allowAllAssignment() assignment {
+	return assignment{
+		EntityIDs: []string{"*"},
+		GroupIDs:  []string{"*"},
+	}
+}
+
+func (i *IdentityStore) storeOIDCDefaultResources(ctx context.Context) error {
+	// Store the default provider
+	storageKey := providerPath + defaultProviderName
+	entry, err := i.view.Get(ctx, storageKey)
+	if err != nil {
+		return err
+	}
+	if entry == nil {
+		entry, err := logical.StorageEntryJSON(storageKey, defaultOIDCProvider())
+		if err != nil {
+			return err
+		}
+		if err := i.view.Put(ctx, entry); err != nil {
+			return err
+		}
+	}
+
+	// Store the default key
+	storageKey = namedKeyConfigPath + defaultKeyName
+	entry, err = i.view.Get(ctx, storageKey)
+	if err != nil {
+		return err
+	}
+	if entry == nil {
+		defaultKey := defaultOIDCKey()
+
+		// Generate initial key material for current and next keys
+		err = defaultKey.generateAndSetKey(ctx, i.Logger(), i.view)
+		if err != nil {
+			return err
+		}
+		err = defaultKey.generateAndSetNextKey(ctx, i.Logger(), i.view)
+		if err != nil {
+			return err
+		}
+
+		// Store the entry
+		entry, err := logical.StorageEntryJSON(storageKey, defaultKey)
+		if err != nil {
+			return err
+		}
+		if err := i.view.Put(ctx, entry); err != nil {
+			return err
+		}
+	}
+
+	// Store the allow all assignment
+	storageKey = assignmentPath + allowAllAssignmentName
+	entry, err = i.view.Get(ctx, storageKey)
+	if err != nil {
+		return err
+	}
+	if entry == nil {
+		entry, err := logical.StorageEntryJSON(storageKey, allowAllAssignment())
+		if err != nil {
+			return err
+		}
+		if err := i.view.Put(ctx, entry); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (i *IdentityStore) loadOIDCClients(ctx context.Context) error {
+	i.logger.Debug("identity loading OIDC clients")
+
+	clients, err := i.view.List(ctx, clientPath)
+	if err != nil {
+		return err
+	}
+
+	txn := i.db.Txn(true)
+	defer txn.Abort()
+	for _, name := range clients {
+		entry, err := i.view.Get(ctx, clientPath+name)
+		if err != nil {
+			return err
+		}
+		if entry == nil {
+			continue
+		}
+
+		var client client
+		if err := entry.DecodeJSON(&client); err != nil {
+			return err
+		}
+
+		if err := i.memDBUpsertClientInTxn(txn, &client); err != nil {
+			return err
+		}
+	}
+	txn.Commit()
+
+	return nil
 }
 
 // clientByID returns the client with the given ID.

--- a/vault/identity_store_oidc_provider.go
+++ b/vault/identity_store_oidc_provider.go
@@ -1408,7 +1408,11 @@ func (i *IdentityStore) pathOIDCProviderDiscovery(ctx context.Context, req *logi
 		ResponseTypes:         []string{"code"},
 		Subjects:              []string{"public"},
 		GrantTypes:            []string{"authorization_code"},
-		AuthMethods:           []string{"client_secret_basic", "none"},
+		AuthMethods: []string{
+			// PKCE is required for auth method "none"
+			"none",
+			"client_secret_basic",
+		},
 	}
 
 	data, err := json.Marshal(disc)

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -1652,7 +1652,7 @@ func TestOIDC_Path_OIDC_Client_Type(t *testing.T) {
 func TestOIDC_Path_OIDC_ProviderClient_DefaultKey(t *testing.T) {
 	c, _, _ := TestCoreUnsealed(t)
 	ctx := namespace.RootContext(nil)
-	require.NoError(t, c.identityStore.storeOIDCDefaultResources(ctx))
+	require.NoError(t, c.identityStore.storeOIDCDefaultResources(ctx, c.identityStore.view))
 
 	// Create a test client "test-client" without a key param
 	resp, err := c.identityStore.HandleRequest(ctx, &logical.Request{

--- a/vault/identity_store_oidc_provider_test.go
+++ b/vault/identity_store_oidc_provider_test.go
@@ -3400,7 +3400,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		TokenEndpoint:         basePath + "/token",
 		UserinfoEndpoint:      basePath + "/userinfo",
 		GrantTypes:            []string{"authorization_code"},
-		AuthMethods:           []string{"client_secret_basic", "none"},
+		AuthMethods:           []string{"none", "client_secret_basic"},
 		RequestURIParameter:   false,
 	}
 	discoveryResp := &providerDiscovery{}
@@ -3454,7 +3454,7 @@ func TestOIDC_Path_OpenIDProviderConfig(t *testing.T) {
 		TokenEndpoint:         basePath + "/token",
 		UserinfoEndpoint:      basePath + "/userinfo",
 		GrantTypes:            []string{"authorization_code"},
-		AuthMethods:           []string{"client_secret_basic", "none"},
+		AuthMethods:           []string{"none", "client_secret_basic"},
 		RequestURIParameter:   false,
 	}
 	discoveryResp = &providerDiscovery{}

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -50,11 +50,6 @@ func (c *Core) loadIdentityStoreArtifacts(ctx context.Context) error {
 		if err := c.identityStore.loadCachedEntitiesOfLocalAliases(ctx); err != nil {
 			return err
 		}
-		if !c.perfStandby && c.isPrimary() {
-			if err := c.identityStore.storeOIDCDefaultResources(ctx); err != nil {
-				return err
-			}
-		}
 
 		return nil
 	}

--- a/vault/identity_store_util.go
+++ b/vault/identity_store_util.go
@@ -50,8 +50,10 @@ func (c *Core) loadIdentityStoreArtifacts(ctx context.Context) error {
 		if err := c.identityStore.loadCachedEntitiesOfLocalAliases(ctx); err != nil {
 			return err
 		}
-		if err := c.identityStore.storeOIDCDefaultResources(ctx); err != nil {
-			return err
+		if !c.perfStandby && c.isPrimary() {
+			if err := c.identityStore.storeOIDCDefaultResources(ctx); err != nil {
+				return err
+			}
 		}
 
 		return nil


### PR DESCRIPTION
## Overview

This PR introduces default resources that seek to decrease the amount of steps it takes to get Vault's OIDC provider configured for simple use cases. With this change, a user can simply configure a Vault auth method + OIDC client and successfully use Vault as an identity provider. The introduction of these resources is not limiting and will still allow users to create more advanced configurations.

### Default OIDC Provider

A default OIDC provider will be created per namespace. It will have a minimal configuration that allows all clients to authenticate using it. Users won't be able to delete it, but they'll be able to modify it.

### Default Key

A default key will be created per namespace. The [key](https://www.vaultproject.io/api-docs/secret/identity/oidc-provider#key) parameter on OIDC clients will be optional and use the key by default. Users won't be able to delete it, but they'll be able to modify it.

### Allow All Assignment

An `allow_all` assignment will be created per namespace. This assignment can be associated with a client to allow all Vault entities/groups to authenticate using the client. The assignment parameter will not use this by default, so it's an explicit decision of the user to allow all entities/groups. Users won't be able to modify or delete this assignment.

## Testing

I've manually tested using these resources with Waypoint as an OIDC client.

Example of simplified usage with Vault and Waypoint:
```
# Run Vault and Waypoint

# Configure a Vault auth method
vault auth enable userpass
vault write auth/userpass/users/end-user password="password"

# Create an OIDC client that uses the default key and allow_all assignment
vault write identity/oidc/client/waypoint \
    redirect_uris="https://localhost:9702/auth/oidc-callback" \
    assignments="allow_all"

# Configure Waypoint OIDC auth method to use the default provider
waypoint auth-method set oidc \
  -issuer=$(curl -s http://localhost:8200/v1/identity/oidc/provider/default/.well-known/openid-configuration | jq -r .issuer) \
  -client-id=$(vault read -field=client_id identity/oidc/client/waypoint) \
  -client-secret=$(vault read -field=client_secret identity/oidc/client/waypoint) \
  -allowed-redirect-uri="https://localhost:9702/auth/oidc-callback" \
  vault

# Authenticate using OIDC in Waypoint UI
open https://localhost:9702/auth
```