### PR TITLE
builtin/logical/pki: fix dropped test error

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -1724,6 +1724,9 @@ func TestBackend_PathFetchValidRaw(t *testing.T) {
 		Value: expectedCert,
 	}
 	err = storage.Put(context.Background(), entry)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// get der cert
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{


### PR DESCRIPTION
This fixes a dropped test error in `builtin/logical/pki`.

Could someone add the "no-changelog" label?