### PR TITLE
plugin/catalog: support plugin registration when type is explicitly provided

### DIFF
--- a/builtin/logical/database/dbplugin/plugin_test.go
+++ b/builtin/logical/database/dbplugin/plugin_test.go
@@ -118,7 +118,7 @@ func getCluster(t *testing.T) (*vault.TestCluster, logical.SystemView) {
 // This is not an actual test case, it's a helper function that will be executed
 // by the go-plugin client via an exec call.
 func TestPlugin_GRPC_Main(t *testing.T) {
-	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" {
+	if os.Getenv(pluginutil.PluginUnwrapTokenEnv) == "" && os.Getenv(pluginutil.PluginMetadataModeEnv) != "true" {
 		return
 	}
 


### PR DESCRIPTION
This PR fixes plugin catalog registration for database plugins if the type is explicitly provided. 

It removes `multiplexingSupport` from setInternal's argument since that's already determined within the function. It also removes the need for calling getPluginTypeFromUnknown in UpgradePlugins since that's already called in setInternal.

Closes https://github.com/hashicorp/vault/pull/14113