### PR TITLE
ui/oidc: adds PKCE code_challenge and code_challenge_method parameters

### DIFF
--- a/ui/app/controllers/vault/cluster/oidc-provider.js
+++ b/ui/app/controllers/vault/cluster/oidc-provider.js
@@ -11,6 +11,8 @@ export default class VaultClusterOidcProviderController extends Controller {
     'display',
     'prompt',
     'max_age',
+    'code_challenge',
+    'code_challenge_method',
   ];
   scope = null;
   response_type = null;
@@ -21,4 +23,6 @@ export default class VaultClusterOidcProviderController extends Controller {
   display = null;
   prompt = null;
   max_age = null;
+  code_challenge = null;
+  code_challenge_method = null;
 }


### PR DESCRIPTION
## Overview

This PR adds PKCE `code_challenge` and `code_challenge_method` parameters to the Vault UI's OIDC provider controller. This is necessary for the parameters to be properly passed to the server. See https://github.com/hashicorp/vault/pull/13917 for context on the server side implementation.

## Testing

I've tested that adding these successfully passes the parameters on to the server. Without this change, the two parameters weren't being passed along which resulted in errors during testing via the browser.