### PR TITLE
Go api: removing 144 dependent packages, a proof-of-concept  (fixes #14017)

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
-	"github.com/hashicorp/vault/sdk/logical"
 )
 
 const (
@@ -1352,7 +1351,14 @@ func MergeReplicationStates(old []string, new string) []string {
 	return strutil.RemoveDuplicates(ret, false)
 }
 
-func ParseReplicationState(raw string, hmacKey []byte) (*logical.WALState, error) {
+// WALState is copied from github.com/hashicorp/vault/sdk/logical
+type WALState struct {
+	ClusterID       string
+	LocalIndex      uint64
+	ReplicatedIndex uint64
+}
+
+func ParseReplicationState(raw string, hmacKey []byte) (*WALState, error) {
 	cooked, err := base64.StdEncoding.DecodeString(raw)
 	if err != nil {
 		return nil, err
@@ -1390,7 +1396,7 @@ func ParseReplicationState(raw string, hmacKey []byte) (*logical.WALState, error
 		return nil, fmt.Errorf("invalid replicated index in state header: %w", err)
 	}
 
-	return &logical.WALState{
+	return &WALState{
 		ClusterID:       pieces[1],
 		LocalIndex:      localIndex,
 		ReplicatedIndex: replicatedIndex,

--- a/api/secret.go
+++ b/api/secret.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
-	"github.com/hashicorp/vault/sdk/logical"
 )
 
 // Secret is the structure returned for every secret within Vault.
@@ -299,7 +298,25 @@ type SecretAuth struct {
 	LeaseDuration int  `json:"lease_duration"`
 	Renewable     bool `json:"renewable"`
 
-	MFARequirement *logical.MFARequirement `json:"mfa_requirement"`
+	MFARequirement *MFARequirement `json:"mfa_requirement"`
+}
+
+// MFARequirement is copied from github.com/hashicorp/vault/sdk/logical
+type MFARequirement struct {
+	MFARequestID   string                       `json:"mfa_request_id,omitempty"`
+	MFAConstraints map[string]*MFAConstraintAny `json:"mfa_constraints,omitempty"`
+}
+
+// MFAConstraintAny is copied from github.com/hashicorp/vault/sdk/logical
+type MFAConstraintAny struct {
+	Any []*MFAMethodID `json:"any,omitempty"`
+}
+
+// MFAMethodID is copied from github.com/hashicorp/vault/sdk/logical
+type MFAMethodID struct {
+	Type         string `json:"type,omitempty"`
+	ID           string `json:"id,omitempty"`
+	UsesPasscode bool   `json:"uses_passcode,omitempty"`
 }
 
 // ParseSecret is used to parse a secret value from JSON from an io.Reader.


### PR DESCRIPTION
This simple copy of ~[a struct from package `sdk/logical`](https://pkg.go.dev/github.com/hashicorp/vault/sdk/logical#WALState)~ 4 types from package `sdk/logical` into package `api` allows a huge reduction of package dependencies: **144 packages removed** which were dragged by `sdk/logical` (almost halved).

This fixes #14017 and allows end-users of the vault/api package to have less dependencies to manage.

Before:
```console
$ go list -deps github.com/hashicorp/vault/api | wc -l
     313
```
After:
```console
$ go list -deps github.com/hashicorp/vault/api | wc -l
     169
```

That might not be the patch that the Vault dev team wants, but at least that shows that fixing that depdendency problem is possible and easy to do.

Cc: @hsimon-hashicorp @jefferai @vinay-gopalan 