### PR TITLE
Add methods with context propagation to api

### DIFF
--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -15,13 +15,17 @@ func (a *Auth) Token() *TokenAuth {
 }
 
 func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.CreateContext(ctx, opts)
+}
+
+func (c *TokenAuth) CreateContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -32,13 +36,17 @@ func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
 }
 
 func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.CreateOrphanContext(ctx, opts)
+}
+
+func (c *TokenAuth) CreateOrphanContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create-orphan")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -49,13 +57,17 @@ func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
 }
 
 func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.CreateWithRoleContext(ctx, opts, roleName)
+}
+
+func (c *TokenAuth) CreateWithRoleContext(ctx context.Context, opts *TokenCreateRequest, roleName string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create/"+roleName)
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -66,6 +78,12 @@ func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*
 }
 
 func (c *TokenAuth) Lookup(token string) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.LookupContext(ctx, token)
+}
+
+func (c *TokenAuth) LookupContext(ctx context.Context, token string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/lookup")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -73,8 +91,6 @@ func (c *TokenAuth) Lookup(token string) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -85,6 +101,12 @@ func (c *TokenAuth) Lookup(token string) (*Secret, error) {
 }
 
 func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.LookupAccessorContext(ctx, accessor)
+}
+
+func (c *TokenAuth) LookupAccessorContext(ctx context.Context, accessor string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/lookup-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
@@ -92,8 +114,6 @@ func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -104,10 +124,14 @@ func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
 }
 
 func (c *TokenAuth) LookupSelf() (*Secret, error) {
-	r := c.c.NewRequest("GET", "/v1/auth/token/lookup-self")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.LookupSelfContext(ctx)
+}
+
+func (c *TokenAuth) LookupSelfContext(ctx context.Context) (*Secret, error) {
+	r := c.c.NewRequest("GET", "/v1/auth/token/lookup-self")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -118,6 +142,12 @@ func (c *TokenAuth) LookupSelf() (*Secret, error) {
 }
 
 func (c *TokenAuth) RenewAccessor(accessor string, increment int) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RenewAccessorContext(ctx, accessor, increment)
+}
+
+func (c *TokenAuth) RenewAccessorContext(ctx context.Context, accessor string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/renew-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor":  accessor,
@@ -126,8 +156,6 @@ func (c *TokenAuth) RenewAccessor(accessor string, increment int) (*Secret, erro
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -138,6 +166,12 @@ func (c *TokenAuth) RenewAccessor(accessor string, increment int) (*Secret, erro
 }
 
 func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RenewContext(ctx, token, increment)
+}
+
+func (c *TokenAuth) RenewContext(ctx context.Context, token string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token":     token,
@@ -146,8 +180,6 @@ func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -158,6 +190,12 @@ func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
 }
 
 func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RenewSelfContext(ctx, increment)
+}
+
+func (c *TokenAuth) RenewSelfContext(ctx context.Context, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 
 	body := map[string]interface{}{"increment": increment}
@@ -165,8 +203,6 @@ func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -179,6 +215,13 @@ func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 // RenewTokenAsSelf behaves like renew-self, but authenticates using a provided
 // token instead of the token attached to the client.
 func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RenewTokenAsSelfContext(ctx, token, increment)
+}
+
+// RenewTokenAsSelfContext the same as RenewTokenAsSelf, but with a custom context.
+func (c *TokenAuth) RenewTokenAsSelfContext(ctx context.Context, token string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 	r.ClientToken = token
 
@@ -187,8 +230,6 @@ func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, erro
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -201,6 +242,13 @@ func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, erro
 // RevokeAccessor revokes a token associated with the given accessor
 // along with all the child tokens.
 func (c *TokenAuth) RevokeAccessor(accessor string) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RevokeAccessorContext(ctx, accessor)
+}
+
+// RevokeAccessorContext the same as RevokeAccessor but with a custom context.
+func (c *TokenAuth) RevokeAccessorContext(ctx context.Context, accessor string) error {
 	r := c.c.NewRequest("POST", "/v1/auth/token/revoke-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
@@ -208,8 +256,6 @@ func (c *TokenAuth) RevokeAccessor(accessor string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -222,6 +268,13 @@ func (c *TokenAuth) RevokeAccessor(accessor string) error {
 // RevokeOrphan revokes a token without revoking the tree underneath it (so
 // child tokens are orphaned rather than revoked)
 func (c *TokenAuth) RevokeOrphan(token string) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RevokeOrphanContext(ctx, token)
+}
+
+// RevokeOrphanContext the same as RevokeOrphan but with a custom context.
+func (c *TokenAuth) RevokeOrphanContext(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-orphan")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -229,8 +282,6 @@ func (c *TokenAuth) RevokeOrphan(token string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -244,10 +295,15 @@ func (c *TokenAuth) RevokeOrphan(token string) error {
 // for backwards compatibility but is ignored; only the client's set token has
 // an effect.
 func (c *TokenAuth) RevokeSelf(token string) error {
-	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-self")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RevokeSelfContext(ctx, token)
+}
+
+// RevokeSelfContext the same as RevokeSelf but with a custom context.
+func (c *TokenAuth) RevokeSelfContext(ctx context.Context, token string) error {
+	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-self")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -261,6 +317,13 @@ func (c *TokenAuth) RevokeSelf(token string) error {
 // the entire tree underneath -- all of its child tokens, their child tokens,
 // etc.
 func (c *TokenAuth) RevokeTree(token string) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RevokeTreeContext(ctx, token)
+}
+
+// RevokeTreeContext the same as RevokeTree but with a custom context.
+func (c *TokenAuth) RevokeTreeContext(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -268,8 +331,6 @@ func (c *TokenAuth) RevokeTree(token string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err

--- a/api/help.go
+++ b/api/help.go
@@ -7,11 +7,16 @@ import (
 
 // Help reads the help information for the given path.
 func (c *Client) Help(path string) (*Help, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.HelpContext(ctx, path)
+}
+
+// HelpContext the same as Help but with a custom context.
+func (c *Client) HelpContext(ctx context.Context, path string) (*Help, error) {
 	r := c.NewRequest("GET", fmt.Sprintf("/v1/%s", path))
 	r.Params.Add("help", "1")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -26,13 +26,18 @@ func (c *Client) SSHWithMountPoint(mountPoint string) *SSH {
 
 // Credential invokes the SSH backend API to create a credential to establish an SSH session.
 func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.CredentialContext(ctx, role, data)
+}
+
+// CredentialContext the same as Credential but with a custom context.
+func (c *SSH) CredentialContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/creds/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -45,13 +50,18 @@ func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, err
 // SignKey signs the given public key and returns a signed public key to pass
 // along with the SSH request.
 func (c *SSH) SignKey(role string, data map[string]interface{}) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.SignKeyContext(ctx, role, data)
+}
+
+// SignKeyContext the same as SignKey but with a custom context.
+func (c *SSH) SignKeyContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/sign/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -14,8 +14,9 @@ import (
 	rootcerts "github.com/hashicorp/go-rootcerts"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/vault/sdk/helper/hclutil"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/vault/sdk/helper/hclutil"
 )
 
 const (
@@ -206,6 +207,13 @@ func (c *Client) SSHHelperWithMountPoint(mountPoint string) *SSHHelper {
 // an echo response message is returned. This feature is used by ssh-helper to verify if
 // its configured correctly.
 func (c *SSHHelper) Verify(otp string) (*SSHVerifyResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.VerifyContext(ctx, otp)
+}
+
+// VerifyContext the same as Verify but with a custom context.
+func (c *SSHHelper) VerifyContext(ctx context.Context, otp string) (*SSHVerifyResponse, error) {
 	data := map[string]interface{}{
 		"otp": otp,
 	}
@@ -215,8 +223,6 @@ func (c *SSHHelper) Verify(otp string) (*SSHVerifyResponse, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_audit.go
+++ b/api/sys_audit.go
@@ -9,6 +9,12 @@ import (
 )
 
 func (c *Sys) AuditHash(path string, input string) (string, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.AuditHashContext(ctx, path, input)
+}
+
+func (c *Sys) AuditHashContext(ctx context.Context, path string, input string) (string, error) {
 	body := map[string]interface{}{
 		"input": input,
 	}
@@ -18,8 +24,6 @@ func (c *Sys) AuditHash(path string, input string) (string, error) {
 		return "", err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return "", err
@@ -47,10 +51,14 @@ func (c *Sys) AuditHash(path string, input string) (string, error) {
 }
 
 func (c *Sys) ListAudit() (map[string]*Audit, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/audit")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.ListAuditContext(ctx)
+}
+
+func (c *Sys) ListAuditContext(ctx context.Context) (map[string]*Audit, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/audit")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -85,13 +93,17 @@ func (c *Sys) EnableAudit(
 }
 
 func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.EnableAuditWithOptionsContext(ctx, path, options)
+}
+
+func (c *Sys) EnableAuditWithOptionsContext(ctx context.Context, path string, options *EnableAuditOptions) error {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/sys/audit/%s", path))
 	if err := r.SetJSONBody(options); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -102,10 +114,14 @@ func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) e
 }
 
 func (c *Sys) DisableAudit(path string) error {
-	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/audit/%s", path))
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.DisableAuditContext(ctx, path)
+}
+
+func (c *Sys) DisableAuditContext(ctx context.Context, path string) error {
+	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/audit/%s", path))
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 
 	if err == nil {

--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -9,10 +9,14 @@ import (
 )
 
 func (c *Sys) ListAuth() (map[string]*AuthMount, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/auth")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.ListAuthContext(ctx)
+}
+
+func (c *Sys) ListAuthContext(ctx context.Context) (map[string]*AuthMount, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/auth")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -45,13 +49,17 @@ func (c *Sys) EnableAuth(path, authType, desc string) error {
 }
 
 func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.EnableAuthWithOptionsContext(ctx, path, options)
+}
+
+func (c *Sys) EnableAuthWithOptionsContext(ctx context.Context, path string, options *EnableAuthOptions) error {
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/auth/%s", path))
 	if err := r.SetJSONBody(options); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -62,10 +70,14 @@ func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) err
 }
 
 func (c *Sys) DisableAuth(path string) error {
-	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/auth/%s", path))
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.DisableAuthContext(ctx, path)
+}
+
+func (c *Sys) DisableAuthContext(ctx context.Context, path string) error {
+	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/auth/%s", path))
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()

--- a/api/sys_capabilities.go
+++ b/api/sys_capabilities.go
@@ -12,7 +12,17 @@ func (c *Sys) CapabilitiesSelf(path string) ([]string, error) {
 	return c.Capabilities(c.c.Token(), path)
 }
 
+func (c *Sys) CapabilitiesSelfContext(ctx context.Context, path string) ([]string, error) {
+	return c.CapabilitiesContext(ctx, c.c.Token(), path)
+}
+
 func (c *Sys) Capabilities(token, path string) ([]string, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.CapabilitiesContext(ctx, token, path)
+}
+
+func (c *Sys) CapabilitiesContext(ctx context.Context, token, path string) ([]string, error) {
 	body := map[string]string{
 		"token": token,
 		"path":  path,
@@ -28,8 +38,6 @@ func (c *Sys) Capabilities(token, path string) ([]string, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -8,10 +8,14 @@ import (
 )
 
 func (c *Sys) CORSStatus() (*CORSResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/config/cors")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.CORSStatusContext(ctx)
+}
+
+func (c *Sys) CORSStatusContext(ctx context.Context) (*CORSResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/config/cors")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -36,13 +40,17 @@ func (c *Sys) CORSStatus() (*CORSResponse, error) {
 }
 
 func (c *Sys) ConfigureCORS(req *CORSRequest) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ConfigureCORSContext(ctx, req)
+}
+
+func (c *Sys) ConfigureCORSContext(ctx context.Context, req *CORSRequest) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/config/cors")
 	if err := r.SetJSONBody(req); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -51,10 +59,14 @@ func (c *Sys) ConfigureCORS(req *CORSRequest) error {
 }
 
 func (c *Sys) DisableCORS() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/config/cors")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.DisableCORSContext(ctx)
+}
+
+func (c *Sys) DisableCORSContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/config/cors")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()

--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -3,22 +3,38 @@ package api
 import "context"
 
 func (c *Sys) GenerateRootStatus() (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommon("/v1/sys/generate-root/attempt")
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRootStatusContext(ctx)
 }
 
 func (c *Sys) GenerateDROperationTokenStatus() (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateDROperationTokenStatusContext(ctx)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenStatus() (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommon("/v1/sys/generate-recovery-token/attempt")
-}
-
-func (c *Sys) generateRootStatusCommon(path string) (*GenerateRootStatusResponse, error) {
-	r := c.c.NewRequest("GET", path)
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.GenerateRecoveryOperationTokenStatusContext(ctx)
+}
+
+func (c *Sys) GenerateRootStatusContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommonContext(ctx, "/v1/sys/generate-root/attempt")
+}
+
+func (c *Sys) GenerateDROperationTokenStatusContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenStatusContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommonContext(ctx, "/v1/sys/generate-recovery-token/attempt")
+}
+
+func (c *Sys) generateRootStatusCommonContext(ctx context.Context, path string) (*GenerateRootStatusResponse, error) {
+	r := c.c.NewRequest("GET", path)
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -31,18 +47,36 @@ func (c *Sys) generateRootStatusCommon(path string) (*GenerateRootStatusResponse
 }
 
 func (c *Sys) GenerateRootInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommon("/v1/sys/generate-root/attempt", otp, pgpKey)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRootInitContext(ctx, otp, pgpKey)
 }
 
 func (c *Sys) GenerateDROperationTokenInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt", otp, pgpKey)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateDROperationTokenInitContext(ctx, otp, pgpKey)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommon("/v1/sys/generate-recovery-token/attempt", otp, pgpKey)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRecoveryOperationTokenInitContext(ctx, otp, pgpKey)
 }
 
-func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+func (c *Sys) GenerateRootInitContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommonContext(ctx, "/v1/sys/generate-root/attempt", otp, pgpKey)
+}
+
+func (c *Sys) GenerateDROperationTokenInitContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt", otp, pgpKey)
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenInitContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommonContext(ctx, "/v1/sys/generate-recovery-token/attempt", otp, pgpKey)
+}
+
+func (c *Sys) generateRootInitCommonContext(ctx context.Context, path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
 	body := map[string]interface{}{
 		"otp":     otp,
 		"pgp_key": pgpKey,
@@ -53,8 +87,6 @@ func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootSta
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -67,22 +99,38 @@ func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootSta
 }
 
 func (c *Sys) GenerateRootCancel() error {
-	return c.generateRootCancelCommon("/v1/sys/generate-root/attempt")
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRootCancelContext(ctx)
 }
 
 func (c *Sys) GenerateDROperationTokenCancel() error {
-	return c.generateRootCancelCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateDROperationTokenCancelContext(ctx)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenCancel() error {
-	return c.generateRootCancelCommon("/v1/sys/generate-recovery-token/attempt")
-}
-
-func (c *Sys) generateRootCancelCommon(path string) error {
-	r := c.c.NewRequest("DELETE", path)
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.GenerateRecoveryOperationTokenCancelContext(ctx)
+}
+
+func (c *Sys) GenerateRootCancelContext(ctx context.Context) error {
+	return c.generateRootCancelCommonContext(ctx, "/v1/sys/generate-root/attempt")
+}
+
+func (c *Sys) GenerateDROperationTokenCancelContext(ctx context.Context) error {
+	return c.generateRootCancelCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenCancelContext(ctx context.Context) error {
+	return c.generateRootCancelCommonContext(ctx, "/v1/sys/generate-recovery-token/attempt")
+}
+
+func (c *Sys) generateRootCancelCommonContext(ctx context.Context, path string) error {
+	r := c.c.NewRequest("DELETE", path)
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -91,18 +139,36 @@ func (c *Sys) generateRootCancelCommon(path string) error {
 }
 
 func (c *Sys) GenerateRootUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommon("/v1/sys/generate-root/update", shard, nonce)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRootUpdateContext(ctx, shard, nonce)
 }
 
 func (c *Sys) GenerateDROperationTokenUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommon("/v1/sys/replication/dr/secondary/generate-operation-token/update", shard, nonce)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateDROperationTokenUpdateContext(ctx, shard, nonce)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommon("/v1/sys/generate-recovery-token/update", shard, nonce)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRecoveryOperationTokenUpdateContext(ctx, shard, nonce)
 }
 
-func (c *Sys) generateRootUpdateCommon(path, shard, nonce string) (*GenerateRootStatusResponse, error) {
+func (c *Sys) GenerateRootUpdateContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommonContext(ctx, "/v1/sys/generate-root/update", shard, nonce)
+}
+
+func (c *Sys) GenerateDROperationTokenUpdateContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/update", shard, nonce)
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenUpdateContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommonContext(ctx, "/v1/sys/generate-recovery-token/update", shard, nonce)
+}
+
+func (c *Sys) generateRootUpdateCommonContext(ctx context.Context, path, shard, nonce string) (*GenerateRootStatusResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -113,8 +179,6 @@ func (c *Sys) generateRootUpdateCommon(path, shard, nonce string) (*GenerateRoot
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_hastatus.go
+++ b/api/sys_hastatus.go
@@ -6,10 +6,14 @@ import (
 )
 
 func (c *Sys) HAStatus() (*HAStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/ha-status")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.HAStatusContext(ctx)
+}
+
+func (c *Sys) HAStatusContext(ctx context.Context) (*HAStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/ha-status")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -3,6 +3,12 @@ package api
 import "context"
 
 func (c *Sys) Health() (*HealthResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.HealthContext(ctx)
+}
+
+func (c *Sys) HealthContext(ctx context.Context) (*HealthResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/health")
 	// If the code is 400 or above it will automatically turn into an error,
 	// but the sys/health API defaults to returning 5xx when not sealed or
@@ -13,8 +19,6 @@ func (c *Sys) Health() (*HealthResponse, error) {
 	r.Params.Add("drsecondarycode", "299")
 	r.Params.Add("performancestandbycode", "299")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -3,10 +3,14 @@ package api
 import "context"
 
 func (c *Sys) InitStatus() (bool, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/init")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.InitStatusContext(ctx)
+}
+
+func (c *Sys) InitStatusContext(ctx context.Context) (bool, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/init")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return false, err
@@ -19,13 +23,17 @@ func (c *Sys) InitStatus() (bool, error) {
 }
 
 func (c *Sys) Init(opts *InitRequest) (*InitResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.InitContext(ctx, opts)
+}
+
+func (c *Sys) InitContext(ctx context.Context, opts *InitRequest) (*InitResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/init")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -6,10 +6,14 @@ import (
 )
 
 func (c *Sys) Leader() (*LeaderResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/leader")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.LeaderContext(ctx)
+}
+
+func (c *Sys) LeaderContext(ctx context.Context) (*LeaderResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/leader")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -6,6 +6,12 @@ import (
 )
 
 func (c *Sys) Renew(id string, increment int) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RenewContext(ctx, id, increment)
+}
+
+func (c *Sys) RenewContext(ctx context.Context, id string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/renew")
 
 	body := map[string]interface{}{
@@ -16,8 +22,6 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -28,6 +32,12 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 }
 
 func (c *Sys) Lookup(id string) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.LookupContext(ctx, id)
+}
+
+func (c *Sys) LookupContext(ctx context.Context, id string) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/lookup")
 
 	body := map[string]interface{}{
@@ -37,8 +47,6 @@ func (c *Sys) Lookup(id string) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -49,6 +57,12 @@ func (c *Sys) Lookup(id string) (*Secret, error) {
 }
 
 func (c *Sys) Revoke(id string) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RevokeContext(ctx, id)
+}
+
+func (c *Sys) RevokeContext(ctx context.Context, id string) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke")
 	body := map[string]interface{}{
 		"lease_id": id,
@@ -57,8 +71,6 @@ func (c *Sys) Revoke(id string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -67,10 +79,14 @@ func (c *Sys) Revoke(id string) error {
 }
 
 func (c *Sys) RevokePrefix(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-prefix/"+id)
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RevokePrefixContext(ctx, id)
+}
+
+func (c *Sys) RevokePrefixContext(ctx context.Context, id string) error {
+	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-prefix/"+id)
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -79,10 +95,14 @@ func (c *Sys) RevokePrefix(id string) error {
 }
 
 func (c *Sys) RevokeForce(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-force/"+id)
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RevokeForceContext(ctx, id)
+}
+
+func (c *Sys) RevokeForceContext(ctx context.Context, id string) error {
+	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-force/"+id)
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -91,6 +111,12 @@ func (c *Sys) RevokeForce(id string) error {
 }
 
 func (c *Sys) RevokeWithOptions(opts *RevokeOptions) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RevokeWithOptionsContext(ctx, opts)
+}
+
+func (c *Sys) RevokeWithOptionsContext(ctx context.Context, opts *RevokeOptions) error {
 	if opts == nil {
 		return errors.New("nil options provided")
 	}
@@ -115,8 +141,6 @@ func (c *Sys) RevokeWithOptions(opts *RevokeOptions) error {
 		}
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/vault/sdk/helper/consts"
 )
 
 // ListPluginsInput is used as input to the ListPlugins function.
@@ -32,6 +33,13 @@ type ListPluginsResponse struct {
 // ListPlugins lists all plugins in the catalog and returns their names as a
 // list of strings.
 func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ListPluginsContext(ctx, i)
+}
+
+// ListPluginsContext the same as ListPlugins but with a custom context.
+func (c *Sys) ListPluginsContext(ctx context.Context, i *ListPluginsInput) (*ListPluginsResponse, error) {
 	path := ""
 	method := ""
 	if i.Type == consts.PluginTypeUnknown {
@@ -50,8 +58,6 @@ func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 		req.Params.Set("list", "true")
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err != nil && resp == nil {
 		return nil, err
@@ -144,11 +150,16 @@ type GetPluginResponse struct {
 
 // GetPlugin retrieves information about the plugin.
 func (c *Sys) GetPlugin(i *GetPluginInput) (*GetPluginResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GetPluginContext(ctx, i)
+}
+
+// GetPluginContext the same as GetPlugin but with a custom context.
+func (c *Sys) GetPluginContext(ctx context.Context, i *GetPluginInput) (*GetPluginResponse, error) {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodGet, path)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err != nil {
 		return nil, err
@@ -185,6 +196,13 @@ type RegisterPluginInput struct {
 
 // RegisterPlugin registers the plugin with the given information.
 func (c *Sys) RegisterPlugin(i *RegisterPluginInput) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RegisterPluginContext(ctx, i)
+}
+
+// RegisterPluginContext the same as RegisterPlugin but with a custom context.
+func (c *Sys) RegisterPluginContext(ctx context.Context, i *RegisterPluginInput) error {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodPut, path)
 
@@ -192,8 +210,6 @@ func (c *Sys) RegisterPlugin(i *RegisterPluginInput) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err == nil {
 		defer resp.Body.Close()
@@ -213,11 +229,16 @@ type DeregisterPluginInput struct {
 // DeregisterPlugin removes the plugin with the given name from the plugin
 // catalog.
 func (c *Sys) DeregisterPlugin(i *DeregisterPluginInput) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.DeregisterPluginContext(ctx, i)
+}
+
+// DeregisterPluginContext the same as DeregisterPlugin but with a custom context.
+func (c *Sys) DeregisterPluginContext(ctx context.Context, i *DeregisterPluginInput) error {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodDelete, path)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err == nil {
 		defer resp.Body.Close()
@@ -240,15 +261,19 @@ type ReloadPluginInput struct {
 // ReloadPlugin reloads mounted plugin backends, possibly returning
 // reloadId for a cluster scoped reload
 func (c *Sys) ReloadPlugin(i *ReloadPluginInput) (string, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ReloadPluginContext(ctx, i)
+}
+
+// ReloadPluginContext the same as ReloadPlugin but with a custom context.
+func (c *Sys) ReloadPluginContext(ctx context.Context, i *ReloadPluginInput) (string, error) {
 	path := "/v1/sys/plugins/reload/backend"
 	req := c.c.NewRequest(http.MethodPut, path)
 
 	if err := req.SetJSONBody(i); err != nil {
 		return "", err
 	}
-
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err != nil {
@@ -289,12 +314,16 @@ type ReloadPluginStatusInput struct {
 
 // ReloadPluginStatus retrieves the status of a reload operation
 func (c *Sys) ReloadPluginStatus(reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ReloadPluginStatusContext(ctx, reloadStatusInput)
+}
+
+// ReloadPluginStatusContext the same as ReloadPluginStatus but with a custom context.
+func (c *Sys) ReloadPluginStatusContext(ctx context.Context, reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
 	path := "/v1/sys/plugins/reload/backend/status"
 	req := c.c.NewRequest(http.MethodGet, path)
 	req.Params.Add("reload_id", reloadStatusInput.ReloadID)
-
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err != nil {

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -9,14 +9,18 @@ import (
 )
 
 func (c *Sys) ListPolicies() ([]string, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ListPoliciesContext(ctx)
+}
+
+func (c *Sys) ListPoliciesContext(ctx context.Context) ([]string, error) {
 	r := c.c.NewRequest("LIST", "/v1/sys/policies/acl")
 	// Set this for broader compatibility, but we use LIST above to be able to
 	// handle the wrapping lookup function
 	r.Method = "GET"
 	r.Params.Set("list", "true")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -41,10 +45,14 @@ func (c *Sys) ListPolicies() ([]string, error) {
 }
 
 func (c *Sys) GetPolicy(name string) (string, error) {
-	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.GetPolicyContext(ctx, name)
+}
+
+func (c *Sys) GetPolicyContext(ctx context.Context, name string) (string, error) {
+	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -72,6 +80,12 @@ func (c *Sys) GetPolicy(name string) (string, error) {
 }
 
 func (c *Sys) PutPolicy(name, rules string) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.PutPolicyContext(ctx, name, rules)
+}
+
+func (c *Sys) PutPolicyContext(ctx context.Context, name, rules string) error {
 	body := map[string]string{
 		"policy": rules,
 	}
@@ -81,8 +95,6 @@ func (c *Sys) PutPolicy(name, rules string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -93,10 +105,14 @@ func (c *Sys) PutPolicy(name, rules string) error {
 }
 
 func (c *Sys) DeletePolicy(name string) error {
-	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.DeletePolicyContext(ctx, name)
+}
+
+func (c *Sys) DeletePolicyContext(ctx context.Context, name string) error {
+	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -14,8 +14,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
-	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/vault/sdk/helper/consts"
 )
 
 var ErrIncompleteSnapshot = errors.New("incomplete snapshot, unable to read SHA256SUMS.sealed file")
@@ -113,14 +114,19 @@ type AutopilotServer struct {
 // RaftJoin adds the node from which this call is invoked from to the raft
 // cluster represented by the leader address in the parameter.
 func (c *Sys) RaftJoin(opts *RaftJoinRequest) (*RaftJoinResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RaftJoinContext(ctx, opts)
+}
+
+// RaftJoinContext the same as RaftJoin but with a custom context.
+func (c *Sys) RaftJoinContext(ctx context.Context, opts *RaftJoinRequest) (*RaftJoinResponse, error) {
 	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/join")
 
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -135,6 +141,13 @@ func (c *Sys) RaftJoin(opts *RaftJoinRequest) (*RaftJoinResponse, error) {
 // RaftSnapshot invokes the API that takes the snapshot of the raft cluster and
 // writes it to the supplied io.Writer.
 func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RaftSnapshotContext(ctx, snapWriter)
+}
+
+// RaftSnapshotContext the same as RaftSnapshot but with a custom context.
+func (c *Sys) RaftSnapshotContext(ctx context.Context, snapWriter io.Writer) error {
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/snapshot")
 	r.URL.RawQuery = r.Params.Encode()
 
@@ -142,6 +155,8 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 	if err != nil {
 		return err
 	}
+
+	req = req.WithContext(ctx)
 
 	req.URL.User = r.URL.User
 	req.URL.Scheme = r.URL.Scheme
@@ -274,6 +289,13 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 // RaftSnapshotRestore reads the snapshot from the io.Reader and installs that
 // snapshot, returning the cluster to the state defined by it.
 func (c *Sys) RaftSnapshotRestore(snapReader io.Reader, force bool) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RaftSnapshotRestoreContext(ctx, snapReader, force)
+}
+
+// RaftSnapshotRestoreContext the same as RaftSnapshotRestore but with a custom context.
+func (c *Sys) RaftSnapshotRestoreContext(ctx context.Context, snapReader io.Reader, force bool) error {
 	path := "/v1/sys/storage/raft/snapshot"
 	if force {
 		path = "/v1/sys/storage/raft/snapshot-force"
@@ -282,8 +304,6 @@ func (c *Sys) RaftSnapshotRestore(snapReader io.Reader, force bool) error {
 
 	r.Body = snapReader
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -295,10 +315,15 @@ func (c *Sys) RaftSnapshotRestore(snapReader io.Reader, force bool) error {
 
 // RaftAutopilotState returns the state of the raft cluster as seen by autopilot.
 func (c *Sys) RaftAutopilotState() (*AutopilotState, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/state")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RaftAutopilotStateContext(ctx)
+}
+
+// RaftAutopilotStateContext the same as RaftAutopilotState but with a custom context.
+func (c *Sys) RaftAutopilotStateContext(ctx context.Context) (*AutopilotState, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/state")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -329,10 +354,15 @@ func (c *Sys) RaftAutopilotState() (*AutopilotState, error) {
 
 // RaftAutopilotConfiguration fetches the autopilot config.
 func (c *Sys) RaftAutopilotConfiguration() (*AutopilotConfig, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/configuration")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RaftAutopilotConfigurationContext(ctx)
+}
+
+// RaftAutopilotConfigurationContext the same as RaftAutopilotConfiguration but with a custom context.
+func (c *Sys) RaftAutopilotConfigurationContext(ctx context.Context) (*AutopilotConfig, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/configuration")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -371,14 +401,19 @@ func (c *Sys) RaftAutopilotConfiguration() (*AutopilotConfig, error) {
 
 // PutRaftAutopilotConfiguration allows modifying the raft autopilot configuration
 func (c *Sys) PutRaftAutopilotConfiguration(opts *AutopilotConfig) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.PutRaftAutopilotConfigurationContext(ctx, opts)
+}
+
+// PutRaftAutopilotConfigurationContext the same as PutRaftAutopilotConfiguration but with a custom context.
+func (c *Sys) PutRaftAutopilotConfigurationContext(ctx context.Context, opts *AutopilotConfig) error {
 	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/autopilot/configuration")
 
 	if err := r.SetJSONBody(opts); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -8,10 +8,14 @@ import (
 )
 
 func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/init")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyStatusContext(ctx)
+}
+
+func (c *Sys) RekeyStatusContext(ctx context.Context) (*RekeyStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey/init")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -24,10 +28,14 @@ func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
 }
 
 func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/init")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRecoveryKeyStatusContext(ctx)
+}
+
+func (c *Sys) RekeyRecoveryKeyStatusContext(ctx context.Context) (*RekeyStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/init")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -40,10 +48,14 @@ func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
 }
 
 func (c *Sys) RekeyVerificationStatus() (*RekeyVerificationStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/verify")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyVerificationStatusContext(ctx)
+}
+
+func (c *Sys) RekeyVerificationStatusContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey/verify")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -56,10 +68,14 @@ func (c *Sys) RekeyVerificationStatus() (*RekeyVerificationStatusResponse, error
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationStatus() (*RekeyVerificationStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/verify")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRecoveryKeyVerificationStatusContext(ctx)
+}
+
+func (c *Sys) RekeyRecoveryKeyVerificationStatusContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/verify")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -72,13 +88,17 @@ func (c *Sys) RekeyRecoveryKeyVerificationStatus() (*RekeyVerificationStatusResp
 }
 
 func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyInitContext(ctx, config)
+}
+
+func (c *Sys) RekeyInitContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey/init")
 	if err := r.SetJSONBody(config); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -91,13 +111,17 @@ func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) 
 }
 
 func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyRecoveryKeyInitContext(ctx, config)
+}
+
+func (c *Sys) RekeyRecoveryKeyInitContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey-recovery-key/init")
 	if err := r.SetJSONBody(config); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -110,10 +134,14 @@ func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusRespon
 }
 
 func (c *Sys) RekeyCancel() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/init")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyCancelContext(ctx)
+}
+
+func (c *Sys) RekeyCancelContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/init")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -122,10 +150,14 @@ func (c *Sys) RekeyCancel() error {
 }
 
 func (c *Sys) RekeyRecoveryKeyCancel() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/init")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRecoveryKeyCancelContext(ctx)
+}
+
+func (c *Sys) RekeyRecoveryKeyCancelContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/init")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -134,10 +166,14 @@ func (c *Sys) RekeyRecoveryKeyCancel() error {
 }
 
 func (c *Sys) RekeyVerificationCancel() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/verify")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyVerificationCancelContext(ctx)
+}
+
+func (c *Sys) RekeyVerificationCancelContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/verify")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -146,10 +182,14 @@ func (c *Sys) RekeyVerificationCancel() error {
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationCancel() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/verify")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRecoveryKeyVerificationCancelContext(ctx)
+}
+
+func (c *Sys) RekeyRecoveryKeyVerificationCancelContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/verify")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -158,6 +198,12 @@ func (c *Sys) RekeyRecoveryKeyVerificationCancel() error {
 }
 
 func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyUpdateContext(ctx, shard, nonce)
+}
+
+func (c *Sys) RekeyUpdateContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -168,8 +214,6 @@ func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -182,6 +226,12 @@ func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
 }
 
 func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyRecoveryKeyUpdateContext(ctx, shard, nonce)
+}
+
+func (c *Sys) RekeyRecoveryKeyUpdateContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -192,8 +242,6 @@ func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse,
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -206,10 +254,14 @@ func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse,
 }
 
 func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/backup")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRetrieveBackupContext(ctx)
+}
+
+func (c *Sys) RekeyRetrieveBackupContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey/backup")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -234,10 +286,14 @@ func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
 }
 
 func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/recovery-key-backup")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRetrieveRecoveryBackupContext(ctx)
+}
+
+func (c *Sys) RekeyRetrieveRecoveryBackupContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey/recovery-key-backup")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -262,10 +318,14 @@ func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
 }
 
 func (c *Sys) RekeyDeleteBackup() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/backup")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyDeleteBackupContext(ctx)
+}
+
+func (c *Sys) RekeyDeleteBackupContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/backup")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -275,10 +335,14 @@ func (c *Sys) RekeyDeleteBackup() error {
 }
 
 func (c *Sys) RekeyDeleteRecoveryBackup() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/recovery-key-backup")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyDeleteRecoveryBackupContext(ctx)
+}
+
+func (c *Sys) RekeyDeleteRecoveryBackupContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/recovery-key-backup")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -288,6 +352,12 @@ func (c *Sys) RekeyDeleteRecoveryBackup() error {
 }
 
 func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyVerificationUpdateContext(ctx, shard, nonce)
+}
+
+func (c *Sys) RekeyVerificationUpdateContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -298,8 +368,6 @@ func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUp
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -312,6 +380,12 @@ func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUp
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyRecoveryKeyVerificationUpdateContext(ctx, shard, nonce)
+}
+
+func (c *Sys) RekeyRecoveryKeyVerificationUpdateContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -322,8 +396,6 @@ func (c *Sys) RekeyRecoveryKeyVerificationUpdate(shard, nonce string) (*RekeyVer
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -8,10 +8,14 @@ import (
 )
 
 func (c *Sys) Rotate() error {
-	r := c.c.NewRequest("POST", "/v1/sys/rotate")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RotateContext(ctx)
+}
+
+func (c *Sys) RotateContext(ctx context.Context) error {
+	r := c.c.NewRequest("POST", "/v1/sys/rotate")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -20,10 +24,14 @@ func (c *Sys) Rotate() error {
 }
 
 func (c *Sys) KeyStatus() (*KeyStatus, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/key-status")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.KeyStatusContext(ctx)
+}
+
+func (c *Sys) KeyStatusContext(ctx context.Context) (*KeyStatus, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/key-status")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -3,15 +3,25 @@ package api
 import "context"
 
 func (c *Sys) SealStatus() (*SealStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.SealStatusContext(ctx)
+}
+
+func (c *Sys) SealStatusContext(ctx context.Context) (*SealStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/seal-status")
-	return sealStatusRequest(c, r)
+	return sealStatusRequestContext(ctx, c, r)
 }
 
 func (c *Sys) Seal() error {
-	r := c.c.NewRequest("PUT", "/v1/sys/seal")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.SealContext(ctx)
+}
+
+func (c *Sys) SealContext(ctx context.Context) error {
+	r := c.c.NewRequest("PUT", "/v1/sys/seal")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -20,6 +30,12 @@ func (c *Sys) Seal() error {
 }
 
 func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ResetUnsealProcessContext(ctx)
+}
+
+func (c *Sys) ResetUnsealProcessContext(ctx context.Context) (*SealStatusResponse, error) {
 	body := map[string]interface{}{"reset": true}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
@@ -27,10 +43,16 @@ func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
 		return nil, err
 	}
 
-	return sealStatusRequest(c, r)
+	return sealStatusRequestContext(ctx, c, r)
 }
 
 func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.UnsealContext(ctx, shard)
+}
+
+func (c *Sys) UnsealContext(ctx context.Context, shard string) (*SealStatusResponse, error) {
 	body := map[string]interface{}{"key": shard}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
@@ -38,21 +60,25 @@ func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
 		return nil, err
 	}
 
-	return sealStatusRequest(c, r)
+	return sealStatusRequestContext(ctx, c, r)
 }
 
 func (c *Sys) UnsealWithOptions(opts *UnsealOpts) (*SealStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.UnsealWithOptionsContext(ctx, opts)
+}
+
+func (c *Sys) UnsealWithOptionsContext(ctx context.Context, opts *UnsealOpts) (*SealStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	return sealStatusRequest(c, r)
+	return sealStatusRequestContext(ctx, c, r)
 }
 
-func sealStatusRequest(c *Sys, r *Request) (*SealStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
+func sealStatusRequestContext(ctx context.Context, c *Sys, r *Request) (*SealStatusResponse, error) {
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_stepdown.go
+++ b/api/sys_stepdown.go
@@ -3,10 +3,14 @@ package api
 import "context"
 
 func (c *Sys) StepDown() error {
-	r := c.c.NewRequest("PUT", "/v1/sys/step-down")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.StepDownContext(ctx)
+}
+
+func (c *Sys) StepDownContext(ctx context.Context) error {
+	r := c.c.NewRequest("PUT", "/v1/sys/step-down")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if resp != nil && resp.Body != nil {
 		resp.Body.Close()

--- a/changelog/14151.txt
+++ b/changelog/14151.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: added methods with context propagation to allow custom context transfer from the calling application.
+```


### PR DESCRIPTION
A fistful of methods with context was added to API. This will allow canceling long requests when the context is canceled, e.g. by a timeout or by the graceful shutdown.

Closes #14070