### PR TITLE
Add methods with context propagation to api

### DIFF
--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -27,7 +27,7 @@ func (c *TokenAuth) CreateWithContext(ctx context.Context, opts *TokenCreateRequ
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (c *TokenAuth) CreateOrphanWithContext(ctx context.Context, opts *TokenCrea
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (c *TokenAuth) CreateWithRoleWithContext(ctx context.Context, opts *TokenCr
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (c *TokenAuth) LookupWithContext(ctx context.Context, token string) (*Secre
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (c *TokenAuth) LookupAccessorWithContext(ctx context.Context, accessor stri
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (c *TokenAuth) LookupSelfWithContext(ctx context.Context) (*Secret, error) 
 
 	r := c.c.NewRequest("GET", "/v1/auth/token/lookup-self")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (c *TokenAuth) RenewAccessorWithContext(ctx context.Context, accessor strin
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (c *TokenAuth) RenewWithContext(ctx context.Context, token string, incremen
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (c *TokenAuth) RenewSelfWithContext(ctx context.Context, increment int) (*S
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func (c *TokenAuth) RenewTokenAsSelfWithContext(ctx context.Context, token strin
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func (c *TokenAuth) RevokeAccessorWithContext(ctx context.Context, accessor stri
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -294,7 +294,7 @@ func (c *TokenAuth) RevokeOrphanWithContext(ctx context.Context, token string) e
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func (c *TokenAuth) RevokeSelfWithContext(ctx context.Context, token string) err
 
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-self")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -345,7 +345,7 @@ func (c *TokenAuth) RevokeTreeWithContext(ctx context.Context, token string) err
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
 	}

--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -15,13 +15,17 @@ func (a *Auth) Token() *TokenAuth {
 }
 
 func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.CreateContext(ctx, opts)
+}
+
+func (c *TokenAuth) CreateContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -32,13 +36,17 @@ func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
 }
 
 func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.CreateOrphanContext(ctx, opts)
+}
+
+func (c *TokenAuth) CreateOrphanContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create-orphan")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -49,13 +57,17 @@ func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
 }
 
 func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.CreateWithRoleContext(ctx, opts, roleName)
+}
+
+func (c *TokenAuth) CreateWithRoleContext(ctx context.Context, opts *TokenCreateRequest, roleName string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create/"+roleName)
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -66,6 +78,12 @@ func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*
 }
 
 func (c *TokenAuth) Lookup(token string) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.LookupContext(ctx, token)
+}
+
+func (c *TokenAuth) LookupContext(ctx context.Context, token string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/lookup")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -73,8 +91,6 @@ func (c *TokenAuth) Lookup(token string) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -85,6 +101,12 @@ func (c *TokenAuth) Lookup(token string) (*Secret, error) {
 }
 
 func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.LookupAccessorContext(ctx, accessor)
+}
+
+func (c *TokenAuth) LookupAccessorContext(ctx context.Context, accessor string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/lookup-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
@@ -92,8 +114,6 @@ func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -104,10 +124,14 @@ func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
 }
 
 func (c *TokenAuth) LookupSelf() (*Secret, error) {
-	r := c.c.NewRequest("GET", "/v1/auth/token/lookup-self")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.LookupSelfContext(ctx)
+}
+
+func (c *TokenAuth) LookupSelfContext(ctx context.Context) (*Secret, error) {
+	r := c.c.NewRequest("GET", "/v1/auth/token/lookup-self")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -118,6 +142,12 @@ func (c *TokenAuth) LookupSelf() (*Secret, error) {
 }
 
 func (c *TokenAuth) RenewAccessor(accessor string, increment int) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RenewAccessorContext(ctx, accessor, increment)
+}
+
+func (c *TokenAuth) RenewAccessorContext(ctx context.Context, accessor string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/renew-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor":  accessor,
@@ -126,8 +156,6 @@ func (c *TokenAuth) RenewAccessor(accessor string, increment int) (*Secret, erro
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -138,6 +166,12 @@ func (c *TokenAuth) RenewAccessor(accessor string, increment int) (*Secret, erro
 }
 
 func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RenewContext(ctx, token, increment)
+}
+
+func (c *TokenAuth) RenewContext(ctx context.Context, token string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token":     token,
@@ -146,8 +180,6 @@ func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -158,6 +190,12 @@ func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
 }
 
 func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RenewSelfContext(ctx, increment)
+}
+
+func (c *TokenAuth) RenewSelfContext(ctx context.Context, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 
 	body := map[string]interface{}{"increment": increment}
@@ -165,8 +203,6 @@ func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -179,6 +215,13 @@ func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 // RenewTokenAsSelf behaves like renew-self, but authenticates using a provided
 // token instead of the token attached to the client.
 func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RenewTokenAsSelfContext(ctx, token, increment)
+}
+
+// RenewTokenAsSelfContext the same as RenewTokenAsSelf, but with a custom context.
+func (c *TokenAuth) RenewTokenAsSelfContext(ctx context.Context, token string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 	r.ClientToken = token
 
@@ -187,8 +230,6 @@ func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, erro
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -201,6 +242,13 @@ func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, erro
 // RevokeAccessor revokes a token associated with the given accessor
 // along with all the child tokens.
 func (c *TokenAuth) RevokeAccessor(accessor string) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RevokeAccessorContext(ctx, accessor)
+}
+
+// RevokeAccessorContext the same as RevokeAccessor but with a custom context.
+func (c *TokenAuth) RevokeAccessorContext(ctx context.Context, accessor string) error {
 	r := c.c.NewRequest("POST", "/v1/auth/token/revoke-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
@@ -208,8 +256,6 @@ func (c *TokenAuth) RevokeAccessor(accessor string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -222,6 +268,13 @@ func (c *TokenAuth) RevokeAccessor(accessor string) error {
 // RevokeOrphan revokes a token without revoking the tree underneath it (so
 // child tokens are orphaned rather than revoked)
 func (c *TokenAuth) RevokeOrphan(token string) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RevokeOrphanContext(ctx, token)
+}
+
+// RevokeOrphanContext the same as RevokeOrphan but with a custom context.
+func (c *TokenAuth) RevokeOrphanContext(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-orphan")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -229,8 +282,6 @@ func (c *TokenAuth) RevokeOrphan(token string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -244,10 +295,15 @@ func (c *TokenAuth) RevokeOrphan(token string) error {
 // for backwards compatibility but is ignored; only the client's set token has
 // an effect.
 func (c *TokenAuth) RevokeSelf(token string) error {
-	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-self")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RevokeSelfContext(ctx, token)
+}
+
+// RevokeSelfContext the same as RevokeSelf but with a custom context.
+func (c *TokenAuth) RevokeSelfContext(ctx context.Context, token string) error {
+	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-self")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -261,6 +317,13 @@ func (c *TokenAuth) RevokeSelf(token string) error {
 // the entire tree underneath -- all of its child tokens, their child tokens,
 // etc.
 func (c *TokenAuth) RevokeTree(token string) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RevokeTreeContext(ctx, token)
+}
+
+// RevokeTreeContext the same as RevokeTree but with a custom context.
+func (c *TokenAuth) RevokeTreeContext(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -268,8 +331,6 @@ func (c *TokenAuth) RevokeTree(token string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err

--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -15,9 +15,7 @@ func (a *Auth) Token() *TokenAuth {
 }
 
 func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.CreateWithContext(ctx, opts)
+	return c.CreateWithContext(context.Background(), opts)
 }
 
 func (c *TokenAuth) CreateWithContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
@@ -39,9 +37,7 @@ func (c *TokenAuth) CreateWithContext(ctx context.Context, opts *TokenCreateRequ
 }
 
 func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.CreateOrphanWithContext(ctx, opts)
+	return c.CreateOrphanWithContext(context.Background(), opts)
 }
 
 func (c *TokenAuth) CreateOrphanWithContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
@@ -63,9 +59,7 @@ func (c *TokenAuth) CreateOrphanWithContext(ctx context.Context, opts *TokenCrea
 }
 
 func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.CreateWithRoleWithContext(ctx, opts, roleName)
+	return c.CreateWithRoleWithContext(context.Background(), opts, roleName)
 }
 
 func (c *TokenAuth) CreateWithRoleWithContext(ctx context.Context, opts *TokenCreateRequest, roleName string) (*Secret, error) {
@@ -87,9 +81,7 @@ func (c *TokenAuth) CreateWithRoleWithContext(ctx context.Context, opts *TokenCr
 }
 
 func (c *TokenAuth) Lookup(token string) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.LookupWithContext(ctx, token)
+	return c.LookupWithContext(context.Background(), token)
 }
 
 func (c *TokenAuth) LookupWithContext(ctx context.Context, token string) (*Secret, error) {
@@ -113,9 +105,7 @@ func (c *TokenAuth) LookupWithContext(ctx context.Context, token string) (*Secre
 }
 
 func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.LookupAccessorWithContext(ctx, accessor)
+	return c.LookupAccessorWithContext(context.Background(), accessor)
 }
 
 func (c *TokenAuth) LookupAccessorWithContext(ctx context.Context, accessor string) (*Secret, error) {
@@ -139,9 +129,7 @@ func (c *TokenAuth) LookupAccessorWithContext(ctx context.Context, accessor stri
 }
 
 func (c *TokenAuth) LookupSelf() (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.LookupSelfWithContext(ctx)
+	return c.LookupSelfWithContext(context.Background())
 }
 
 func (c *TokenAuth) LookupSelfWithContext(ctx context.Context) (*Secret, error) {
@@ -160,9 +148,7 @@ func (c *TokenAuth) LookupSelfWithContext(ctx context.Context) (*Secret, error) 
 }
 
 func (c *TokenAuth) RenewAccessor(accessor string, increment int) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RenewAccessorWithContext(ctx, accessor, increment)
+	return c.RenewAccessorWithContext(context.Background(), accessor, increment)
 }
 
 func (c *TokenAuth) RenewAccessorWithContext(ctx context.Context, accessor string, increment int) (*Secret, error) {
@@ -187,9 +173,7 @@ func (c *TokenAuth) RenewAccessorWithContext(ctx context.Context, accessor strin
 }
 
 func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RenewWithContext(ctx, token, increment)
+	return c.RenewWithContext(context.Background(), token, increment)
 }
 
 func (c *TokenAuth) RenewWithContext(ctx context.Context, token string, increment int) (*Secret, error) {
@@ -214,9 +198,7 @@ func (c *TokenAuth) RenewWithContext(ctx context.Context, token string, incremen
 }
 
 func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RenewSelfWithContext(ctx, increment)
+	return c.RenewSelfWithContext(context.Background(), increment)
 }
 
 func (c *TokenAuth) RenewSelfWithContext(ctx context.Context, increment int) (*Secret, error) {
@@ -241,9 +223,7 @@ func (c *TokenAuth) RenewSelfWithContext(ctx context.Context, increment int) (*S
 
 // RenewTokenAsSelf wraps RenewTokenAsSelfWithContext using context.Background.
 func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RenewTokenAsSelfWithContext(ctx, token, increment)
+	return c.RenewTokenAsSelfWithContext(context.Background(), token, increment)
 }
 
 // RenewTokenAsSelfWithContext behaves like renew-self, but authenticates using a provided
@@ -271,9 +251,7 @@ func (c *TokenAuth) RenewTokenAsSelfWithContext(ctx context.Context, token strin
 
 // RevokeAccessor wraps RevokeAccessorWithContext using context.Background.
 func (c *TokenAuth) RevokeAccessor(accessor string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RevokeAccessorWithContext(ctx, accessor)
+	return c.RevokeAccessorWithContext(context.Background(), accessor)
 }
 
 // RevokeAccessorWithContext revokes a token associated with the given accessor
@@ -300,9 +278,7 @@ func (c *TokenAuth) RevokeAccessorWithContext(ctx context.Context, accessor stri
 
 // RevokeOrphan wraps RevokeOrphanWithContext using context.Background.
 func (c *TokenAuth) RevokeOrphan(token string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RevokeOrphanWithContext(ctx, token)
+	return c.RevokeOrphanWithContext(context.Background(), token)
 }
 
 // RevokeOrphanWithContext revokes a token without revoking the tree underneath it (so
@@ -329,9 +305,7 @@ func (c *TokenAuth) RevokeOrphanWithContext(ctx context.Context, token string) e
 
 // RevokeSelf wraps RevokeSelfWithContext using context.Background.
 func (c *TokenAuth) RevokeSelf(token string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RevokeSelfWithContext(ctx, token)
+	return c.RevokeSelfWithContext(context.Background(), token)
 }
 
 // RevokeSelfWithContext revokes the token making the call. The `token` parameter is kept
@@ -354,9 +328,7 @@ func (c *TokenAuth) RevokeSelfWithContext(ctx context.Context, token string) err
 
 // RevokeTree wraps RevokeTreeWithContext using context.Background.
 func (c *TokenAuth) RevokeTree(token string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RevokeTreeWithContext(ctx, token)
+	return c.RevokeTreeWithContext(context.Background(), token)
 }
 
 // RevokeTreeWithContext is the "normal" revoke operation that revokes the given token and

--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -212,15 +212,15 @@ func (c *TokenAuth) RenewSelfWithContext(ctx context.Context, increment int) (*S
 	return ParseSecret(resp.Body)
 }
 
-// RenewTokenAsSelf behaves like renew-self, but authenticates using a provided
-// token instead of the token attached to the client.
+// RenewTokenAsSelf wraps RenewTokenAsSelfWithContext using context.Background.
 func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RenewTokenAsSelfWithContext(ctx, token, increment)
 }
 
-// RenewTokenAsSelfWithContext the same as RenewTokenAsSelf, but with a custom context.
+// RenewTokenAsSelfWithContext behaves like renew-self, but authenticates using a provided
+// // token instead of the token attached to the client.
 func (c *TokenAuth) RenewTokenAsSelfWithContext(ctx context.Context, token string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 	r.ClientToken = token
@@ -239,15 +239,15 @@ func (c *TokenAuth) RenewTokenAsSelfWithContext(ctx context.Context, token strin
 	return ParseSecret(resp.Body)
 }
 
-// RevokeAccessor revokes a token associated with the given accessor
-// along with all the child tokens.
+// RevokeAccessor wraps RevokeAccessorWithContext using context.Background.
 func (c *TokenAuth) RevokeAccessor(accessor string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RevokeAccessorWithContext(ctx, accessor)
 }
 
-// RevokeAccessorWithContext the same as RevokeAccessor but with a custom context.
+// RevokeAccessorWithContext revokes a token associated with the given accessor
+// // along with all the child tokens.
 func (c *TokenAuth) RevokeAccessorWithContext(ctx context.Context, accessor string) error {
 	r := c.c.NewRequest("POST", "/v1/auth/token/revoke-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
@@ -265,15 +265,15 @@ func (c *TokenAuth) RevokeAccessorWithContext(ctx context.Context, accessor stri
 	return nil
 }
 
-// RevokeOrphan revokes a token without revoking the tree underneath it (so
-// child tokens are orphaned rather than revoked)
+// RevokeOrphan wraps RevokeOrphanWithContext using context.Background.
 func (c *TokenAuth) RevokeOrphan(token string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RevokeOrphanWithContext(ctx, token)
 }
 
-// RevokeOrphanWithContext the same as RevokeOrphan but with a custom context.
+// RevokeOrphanWithContext revokes a token without revoking the tree underneath it (so
+// // child tokens are orphaned rather than revoked)
 func (c *TokenAuth) RevokeOrphanWithContext(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-orphan")
 	if err := r.SetJSONBody(map[string]interface{}{
@@ -291,16 +291,16 @@ func (c *TokenAuth) RevokeOrphanWithContext(ctx context.Context, token string) e
 	return nil
 }
 
-// RevokeSelf revokes the token making the call. The `token` parameter is kept
-// for backwards compatibility but is ignored; only the client's set token has
-// an effect.
+// RevokeSelf wraps RevokeSelfWithContext using context.Background.
 func (c *TokenAuth) RevokeSelf(token string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RevokeSelfWithContext(ctx, token)
 }
 
-// RevokeSelfWithContext the same as RevokeSelf but with a custom context.
+// RevokeSelfWithContext revokes the token making the call. The `token` parameter is kept
+// // for backwards compatibility but is ignored; only the client's set token has
+// // an effect.
 func (c *TokenAuth) RevokeSelfWithContext(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-self")
 
@@ -313,16 +313,16 @@ func (c *TokenAuth) RevokeSelfWithContext(ctx context.Context, token string) err
 	return nil
 }
 
-// RevokeTree is the "normal" revoke operation that revokes the given token and
-// the entire tree underneath -- all of its child tokens, their child tokens,
-// etc.
+// RevokeTree wraps RevokeTreeWithContext using context.Background.
 func (c *TokenAuth) RevokeTree(token string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RevokeTreeWithContext(ctx, token)
 }
 
-// RevokeTreeWithContext the same as RevokeTree but with a custom context.
+// RevokeTreeWithContext is the "normal" revoke operation that revokes the given token and
+// // the entire tree underneath -- all of its child tokens, their child tokens,
+// // etc.
 func (c *TokenAuth) RevokeTreeWithContext(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke")
 	if err := r.SetJSONBody(map[string]interface{}{

--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -17,10 +17,10 @@ func (a *Auth) Token() *TokenAuth {
 func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.CreateContext(ctx, opts)
+	return c.CreateWithContext(ctx, opts)
 }
 
-func (c *TokenAuth) CreateContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
+func (c *TokenAuth) CreateWithContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
@@ -38,10 +38,10 @@ func (c *TokenAuth) CreateContext(ctx context.Context, opts *TokenCreateRequest)
 func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.CreateOrphanContext(ctx, opts)
+	return c.CreateOrphanWithContext(ctx, opts)
 }
 
-func (c *TokenAuth) CreateOrphanContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
+func (c *TokenAuth) CreateOrphanWithContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create-orphan")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
@@ -59,10 +59,10 @@ func (c *TokenAuth) CreateOrphanContext(ctx context.Context, opts *TokenCreateRe
 func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.CreateWithRoleContext(ctx, opts, roleName)
+	return c.CreateWithRoleWithContext(ctx, opts, roleName)
 }
 
-func (c *TokenAuth) CreateWithRoleContext(ctx context.Context, opts *TokenCreateRequest, roleName string) (*Secret, error) {
+func (c *TokenAuth) CreateWithRoleWithContext(ctx context.Context, opts *TokenCreateRequest, roleName string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/create/"+roleName)
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
@@ -80,10 +80,10 @@ func (c *TokenAuth) CreateWithRoleContext(ctx context.Context, opts *TokenCreate
 func (c *TokenAuth) Lookup(token string) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.LookupContext(ctx, token)
+	return c.LookupWithContext(ctx, token)
 }
 
-func (c *TokenAuth) LookupContext(ctx context.Context, token string) (*Secret, error) {
+func (c *TokenAuth) LookupWithContext(ctx context.Context, token string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/lookup")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -103,10 +103,10 @@ func (c *TokenAuth) LookupContext(ctx context.Context, token string) (*Secret, e
 func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.LookupAccessorContext(ctx, accessor)
+	return c.LookupAccessorWithContext(ctx, accessor)
 }
 
-func (c *TokenAuth) LookupAccessorContext(ctx context.Context, accessor string) (*Secret, error) {
+func (c *TokenAuth) LookupAccessorWithContext(ctx context.Context, accessor string) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/lookup-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
@@ -126,10 +126,10 @@ func (c *TokenAuth) LookupAccessorContext(ctx context.Context, accessor string) 
 func (c *TokenAuth) LookupSelf() (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.LookupSelfContext(ctx)
+	return c.LookupSelfWithContext(ctx)
 }
 
-func (c *TokenAuth) LookupSelfContext(ctx context.Context) (*Secret, error) {
+func (c *TokenAuth) LookupSelfWithContext(ctx context.Context) (*Secret, error) {
 	r := c.c.NewRequest("GET", "/v1/auth/token/lookup-self")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -144,10 +144,10 @@ func (c *TokenAuth) LookupSelfContext(ctx context.Context) (*Secret, error) {
 func (c *TokenAuth) RenewAccessor(accessor string, increment int) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RenewAccessorContext(ctx, accessor, increment)
+	return c.RenewAccessorWithContext(ctx, accessor, increment)
 }
 
-func (c *TokenAuth) RenewAccessorContext(ctx context.Context, accessor string, increment int) (*Secret, error) {
+func (c *TokenAuth) RenewAccessorWithContext(ctx context.Context, accessor string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("POST", "/v1/auth/token/renew-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor":  accessor,
@@ -168,10 +168,10 @@ func (c *TokenAuth) RenewAccessorContext(ctx context.Context, accessor string, i
 func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RenewContext(ctx, token, increment)
+	return c.RenewWithContext(ctx, token, increment)
 }
 
-func (c *TokenAuth) RenewContext(ctx context.Context, token string, increment int) (*Secret, error) {
+func (c *TokenAuth) RenewWithContext(ctx context.Context, token string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token":     token,
@@ -192,10 +192,10 @@ func (c *TokenAuth) RenewContext(ctx context.Context, token string, increment in
 func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RenewSelfContext(ctx, increment)
+	return c.RenewSelfWithContext(ctx, increment)
 }
 
-func (c *TokenAuth) RenewSelfContext(ctx context.Context, increment int) (*Secret, error) {
+func (c *TokenAuth) RenewSelfWithContext(ctx context.Context, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 
 	body := map[string]interface{}{"increment": increment}
@@ -217,11 +217,11 @@ func (c *TokenAuth) RenewSelfContext(ctx context.Context, increment int) (*Secre
 func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RenewTokenAsSelfContext(ctx, token, increment)
+	return c.RenewTokenAsSelfWithContext(ctx, token, increment)
 }
 
-// RenewTokenAsSelfContext the same as RenewTokenAsSelf, but with a custom context.
-func (c *TokenAuth) RenewTokenAsSelfContext(ctx context.Context, token string, increment int) (*Secret, error) {
+// RenewTokenAsSelfWithContext the same as RenewTokenAsSelf, but with a custom context.
+func (c *TokenAuth) RenewTokenAsSelfWithContext(ctx context.Context, token string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 	r.ClientToken = token
 
@@ -244,11 +244,11 @@ func (c *TokenAuth) RenewTokenAsSelfContext(ctx context.Context, token string, i
 func (c *TokenAuth) RevokeAccessor(accessor string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RevokeAccessorContext(ctx, accessor)
+	return c.RevokeAccessorWithContext(ctx, accessor)
 }
 
-// RevokeAccessorContext the same as RevokeAccessor but with a custom context.
-func (c *TokenAuth) RevokeAccessorContext(ctx context.Context, accessor string) error {
+// RevokeAccessorWithContext the same as RevokeAccessor but with a custom context.
+func (c *TokenAuth) RevokeAccessorWithContext(ctx context.Context, accessor string) error {
 	r := c.c.NewRequest("POST", "/v1/auth/token/revoke-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
@@ -270,11 +270,11 @@ func (c *TokenAuth) RevokeAccessorContext(ctx context.Context, accessor string) 
 func (c *TokenAuth) RevokeOrphan(token string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RevokeOrphanContext(ctx, token)
+	return c.RevokeOrphanWithContext(ctx, token)
 }
 
-// RevokeOrphanContext the same as RevokeOrphan but with a custom context.
-func (c *TokenAuth) RevokeOrphanContext(ctx context.Context, token string) error {
+// RevokeOrphanWithContext the same as RevokeOrphan but with a custom context.
+func (c *TokenAuth) RevokeOrphanWithContext(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-orphan")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -297,11 +297,11 @@ func (c *TokenAuth) RevokeOrphanContext(ctx context.Context, token string) error
 func (c *TokenAuth) RevokeSelf(token string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RevokeSelfContext(ctx, token)
+	return c.RevokeSelfWithContext(ctx, token)
 }
 
-// RevokeSelfContext the same as RevokeSelf but with a custom context.
-func (c *TokenAuth) RevokeSelfContext(ctx context.Context, token string) error {
+// RevokeSelfWithContext the same as RevokeSelf but with a custom context.
+func (c *TokenAuth) RevokeSelfWithContext(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-self")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -319,11 +319,11 @@ func (c *TokenAuth) RevokeSelfContext(ctx context.Context, token string) error {
 func (c *TokenAuth) RevokeTree(token string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RevokeTreeContext(ctx, token)
+	return c.RevokeTreeWithContext(ctx, token)
 }
 
-// RevokeTreeContext the same as RevokeTree but with a custom context.
-func (c *TokenAuth) RevokeTreeContext(ctx context.Context, token string) error {
+// RevokeTreeWithContext the same as RevokeTree but with a custom context.
+func (c *TokenAuth) RevokeTreeWithContext(ctx context.Context, token string) error {
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,

--- a/api/auth_token.go
+++ b/api/auth_token.go
@@ -21,6 +21,9 @@ func (c *TokenAuth) Create(opts *TokenCreateRequest) (*Secret, error) {
 }
 
 func (c *TokenAuth) CreateWithContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", "/v1/auth/token/create")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
@@ -42,6 +45,9 @@ func (c *TokenAuth) CreateOrphan(opts *TokenCreateRequest) (*Secret, error) {
 }
 
 func (c *TokenAuth) CreateOrphanWithContext(ctx context.Context, opts *TokenCreateRequest) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", "/v1/auth/token/create-orphan")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
@@ -63,6 +69,9 @@ func (c *TokenAuth) CreateWithRole(opts *TokenCreateRequest, roleName string) (*
 }
 
 func (c *TokenAuth) CreateWithRoleWithContext(ctx context.Context, opts *TokenCreateRequest, roleName string) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", "/v1/auth/token/create/"+roleName)
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
@@ -84,6 +93,9 @@ func (c *TokenAuth) Lookup(token string) (*Secret, error) {
 }
 
 func (c *TokenAuth) LookupWithContext(ctx context.Context, token string) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", "/v1/auth/token/lookup")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -107,6 +119,9 @@ func (c *TokenAuth) LookupAccessor(accessor string) (*Secret, error) {
 }
 
 func (c *TokenAuth) LookupAccessorWithContext(ctx context.Context, accessor string) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", "/v1/auth/token/lookup-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
@@ -130,6 +145,9 @@ func (c *TokenAuth) LookupSelf() (*Secret, error) {
 }
 
 func (c *TokenAuth) LookupSelfWithContext(ctx context.Context) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/auth/token/lookup-self")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -148,6 +166,9 @@ func (c *TokenAuth) RenewAccessor(accessor string, increment int) (*Secret, erro
 }
 
 func (c *TokenAuth) RenewAccessorWithContext(ctx context.Context, accessor string, increment int) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", "/v1/auth/token/renew-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor":  accessor,
@@ -172,6 +193,9 @@ func (c *TokenAuth) Renew(token string, increment int) (*Secret, error) {
 }
 
 func (c *TokenAuth) RenewWithContext(ctx context.Context, token string, increment int) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token":     token,
@@ -196,6 +220,9 @@ func (c *TokenAuth) RenewSelf(increment int) (*Secret, error) {
 }
 
 func (c *TokenAuth) RenewSelfWithContext(ctx context.Context, increment int) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 
 	body := map[string]interface{}{"increment": increment}
@@ -220,8 +247,11 @@ func (c *TokenAuth) RenewTokenAsSelf(token string, increment int) (*Secret, erro
 }
 
 // RenewTokenAsSelfWithContext behaves like renew-self, but authenticates using a provided
-// // token instead of the token attached to the client.
+// token instead of the token attached to the client.
 func (c *TokenAuth) RenewTokenAsSelfWithContext(ctx context.Context, token string, increment int) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/auth/token/renew-self")
 	r.ClientToken = token
 
@@ -247,8 +277,11 @@ func (c *TokenAuth) RevokeAccessor(accessor string) error {
 }
 
 // RevokeAccessorWithContext revokes a token associated with the given accessor
-// // along with all the child tokens.
+// along with all the child tokens.
 func (c *TokenAuth) RevokeAccessorWithContext(ctx context.Context, accessor string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", "/v1/auth/token/revoke-accessor")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"accessor": accessor,
@@ -273,8 +306,11 @@ func (c *TokenAuth) RevokeOrphan(token string) error {
 }
 
 // RevokeOrphanWithContext revokes a token without revoking the tree underneath it (so
-// // child tokens are orphaned rather than revoked)
+// child tokens are orphaned rather than revoked)
 func (c *TokenAuth) RevokeOrphanWithContext(ctx context.Context, token string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-orphan")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,
@@ -299,9 +335,12 @@ func (c *TokenAuth) RevokeSelf(token string) error {
 }
 
 // RevokeSelfWithContext revokes the token making the call. The `token` parameter is kept
-// // for backwards compatibility but is ignored; only the client's set token has
-// // an effect.
+// for backwards compatibility but is ignored; only the client's set token has
+// an effect.
 func (c *TokenAuth) RevokeSelfWithContext(ctx context.Context, token string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke-self")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -321,9 +360,12 @@ func (c *TokenAuth) RevokeTree(token string) error {
 }
 
 // RevokeTreeWithContext is the "normal" revoke operation that revokes the given token and
-// // the entire tree underneath -- all of its child tokens, their child tokens,
-// // etc.
+// the entire tree underneath -- all of its child tokens, their child tokens,
+// etc.
 func (c *TokenAuth) RevokeTreeWithContext(ctx context.Context, token string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/auth/token/revoke")
 	if err := r.SetJSONBody(map[string]interface{}{
 		"token": token,

--- a/api/client.go
+++ b/api/client.go
@@ -1089,6 +1089,9 @@ func (c *Client) NewRequest(method, requestPath string) *Request {
 // RawRequest performs the raw request given. This request may be against
 // a Vault server not configured with this client. This is an advanced operation
 // that generally won't need to be called externally.
+//
+// Deprecated: method is left for  backwards compatibility.
+// It is expected to be used internally. Use higher level methods instead.
 func (c *Client) RawRequest(r *Request) (*Response, error) {
 	return c.RawRequestWithContext(context.Background(), r)
 }
@@ -1096,9 +1099,15 @@ func (c *Client) RawRequest(r *Request) (*Response, error) {
 // RawRequestWithContext performs the raw request given. This request may be against
 // a Vault server not configured with this client. This is an advanced operation
 // that generally won't need to be called externally.
+//
+// Deprecated: method is left for backwards compatibility.
+// It is expected to be used internally. Use higher level methods instead.
 func (c *Client) RawRequestWithContext(ctx context.Context, r *Request) (*Response, error) {
-	ctx, cancelFunc := c.withConfiguredTimeout(ctx)
-	defer cancelFunc()
+	// Note: we purposefully do not call cancel manually. The reason is
+	// when canceled, the request.Body will EOF when reading due to the way
+	// it streams data in. Cancel will still be run when the timeout is
+	// hit, so this doesn't really harm anything.
+	ctx, _ = c.withConfiguredTimeout(ctx)
 	return c.rawRequestWithContext(ctx, r)
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -1090,8 +1090,8 @@ func (c *Client) NewRequest(method, requestPath string) *Request {
 // a Vault server not configured with this client. This is an advanced operation
 // that generally won't need to be called externally.
 //
-// Deprecated: method is left for  backwards compatibility.
-// It is expected to be used internally. Use higher level methods instead.
+// Deprecated: This method should not be used directly. Use higher level
+// methods instead.
 func (c *Client) RawRequest(r *Request) (*Response, error) {
 	return c.RawRequestWithContext(context.Background(), r)
 }
@@ -1100,8 +1100,8 @@ func (c *Client) RawRequest(r *Request) (*Response, error) {
 // a Vault server not configured with this client. This is an advanced operation
 // that generally won't need to be called externally.
 //
-// Deprecated: method is left for backwards compatibility.
-// It is expected to be used internally. Use higher level methods instead.
+// Deprecated: This method should not be used directly. Use higher level
+// methods instead.
 func (c *Client) RawRequestWithContext(ctx context.Context, r *Request) (*Response, error) {
 	// Note: we purposefully do not call cancel manually. The reason is
 	// when canceled, the request.Body will EOF when reading due to the way

--- a/api/client.go
+++ b/api/client.go
@@ -1097,6 +1097,12 @@ func (c *Client) RawRequest(r *Request) (*Response, error) {
 // a Vault server not configured with this client. This is an advanced operation
 // that generally won't need to be called externally.
 func (c *Client) RawRequestWithContext(ctx context.Context, r *Request) (*Response, error) {
+	ctx, cancelFunc := c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+	return c.rawRequestWithContext(ctx, r)
+}
+
+func (c *Client) rawRequestWithContext(ctx context.Context, r *Request) (*Response, error) {
 	c.modifyLock.RLock()
 	token := c.token
 

--- a/api/help.go
+++ b/api/help.go
@@ -7,9 +7,7 @@ import (
 
 // Help wraps HelpWithContext using context.Background.
 func (c *Client) Help(path string) (*Help, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.HelpWithContext(ctx, path)
+	return c.HelpWithContext(context.Background(), path)
 }
 
 // HelpWithContext reads the help information for the given path.

--- a/api/help.go
+++ b/api/help.go
@@ -18,7 +18,7 @@ func (c *Client) HelpWithContext(ctx context.Context, path string) (*Help, error
 	r := c.NewRequest("GET", fmt.Sprintf("/v1/%s", path))
 	r.Params.Add("help", "1")
 
-	resp, err := c.RawRequestWithContext(ctx, r)
+	resp, err := c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/help.go
+++ b/api/help.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 )
 
-// Help reads the help information for the given path.
+// Help wraps HelpWithContext using context.Background.
 func (c *Client) Help(path string) (*Help, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.HelpWithContext(ctx, path)
 }
 
-// HelpWithContext the same as Help but with a custom context.
+// HelpWithContext reads the help information for the given path.
 func (c *Client) HelpWithContext(ctx context.Context, path string) (*Help, error) {
 	r := c.NewRequest("GET", fmt.Sprintf("/v1/%s", path))
 	r.Params.Add("help", "1")

--- a/api/help.go
+++ b/api/help.go
@@ -14,6 +14,9 @@ func (c *Client) Help(path string) (*Help, error) {
 
 // HelpWithContext reads the help information for the given path.
 func (c *Client) HelpWithContext(ctx context.Context, path string) (*Help, error) {
+	ctx, cancelFunc := c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.NewRequest("GET", fmt.Sprintf("/v1/%s", path))
 	r.Params.Add("help", "1")
 

--- a/api/help.go
+++ b/api/help.go
@@ -7,11 +7,16 @@ import (
 
 // Help reads the help information for the given path.
 func (c *Client) Help(path string) (*Help, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.HelpContext(ctx, path)
+}
+
+// HelpContext the same as Help but with a custom context.
+func (c *Client) HelpContext(ctx context.Context, path string) (*Help, error) {
 	r := c.NewRequest("GET", fmt.Sprintf("/v1/%s", path))
 	r.Params.Add("help", "1")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/help.go
+++ b/api/help.go
@@ -9,11 +9,11 @@ import (
 func (c *Client) Help(path string) (*Help, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.HelpContext(ctx, path)
+	return c.HelpWithContext(ctx, path)
 }
 
-// HelpContext the same as Help but with a custom context.
-func (c *Client) HelpContext(ctx context.Context, path string) (*Help, error) {
+// HelpWithContext the same as Help but with a custom context.
+func (c *Client) HelpWithContext(ctx context.Context, path string) (*Help, error) {
 	r := c.NewRequest("GET", fmt.Sprintf("/v1/%s", path))
 	r.Params.Add("help", "1")
 

--- a/api/logical.go
+++ b/api/logical.go
@@ -58,9 +58,7 @@ func (c *Logical) ReadWithContext(ctx context.Context, path string) (*Secret, er
 }
 
 func (c *Logical) ReadWithData(path string, data map[string][]string) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ReadWithDataWithContext(ctx, path, data)
+	return c.ReadWithDataWithContext(context.Background(), path, data)
 }
 
 func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data map[string][]string) (*Secret, error) {
@@ -109,9 +107,7 @@ func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data
 }
 
 func (c *Logical) List(path string) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ListWithContext(ctx, path)
+	return c.ListWithContext(context.Background(), path)
 }
 
 func (c *Logical) ListWithContext(ctx context.Context, path string) (*Secret, error) {
@@ -150,9 +146,7 @@ func (c *Logical) ListWithContext(ctx context.Context, path string) (*Secret, er
 }
 
 func (c *Logical) Write(path string, data map[string]interface{}) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.WriteWithContext(ctx, path, data)
+	return c.WriteWithContext(context.Background(), path, data)
 }
 
 func (c *Logical) WriteWithContext(ctx context.Context, path string, data map[string]interface{}) (*Secret, error) {
@@ -216,9 +210,7 @@ func (c *Logical) write(ctx context.Context, path string, request *Request) (*Se
 }
 
 func (c *Logical) Delete(path string) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.DeleteWithContext(ctx, path)
+	return c.DeleteWithContext(context.Background(), path)
 }
 
 func (c *Logical) DeleteWithContext(ctx context.Context, path string) (*Secret, error) {
@@ -226,9 +218,7 @@ func (c *Logical) DeleteWithContext(ctx context.Context, path string) (*Secret, 
 }
 
 func (c *Logical) DeleteWithData(path string, data map[string][]string) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.DeleteWithDataWithContext(ctx, path, data)
+	return c.DeleteWithDataWithContext(context.Background(), path, data)
 }
 
 func (c *Logical) DeleteWithDataWithContext(ctx context.Context, path string, data map[string][]string) (*Secret, error) {
@@ -276,9 +266,7 @@ func (c *Logical) DeleteWithDataWithContext(ctx context.Context, path string, da
 }
 
 func (c *Logical) Unwrap(wrappingToken string) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.UnwrapWithContext(ctx, wrappingToken)
+	return c.UnwrapWithContext(context.Background(), wrappingToken)
 }
 
 func (c *Logical) UnwrapWithContext(ctx context.Context, wrappingToken string) (*Secret, error) {

--- a/api/logical.go
+++ b/api/logical.go
@@ -53,17 +53,17 @@ func (c *Logical) Read(path string) (*Secret, error) {
 	return c.ReadWithData(path, nil)
 }
 
-func (c *Logical) ReadContext(ctx context.Context, path string) (*Secret, error) {
-	return c.ReadWithDataContext(ctx, path, nil)
+func (c *Logical) ReadWithContext(ctx context.Context, path string) (*Secret, error) {
+	return c.ReadWithDataWithContext(ctx, path, nil)
 }
 
 func (c *Logical) ReadWithData(path string, data map[string][]string) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ReadWithDataContext(ctx, path, data)
+	return c.ReadWithDataWithContext(ctx, path, data)
 }
 
-func (c *Logical) ReadWithDataContext(ctx context.Context, path string, data map[string][]string) (*Secret, error) {
+func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data map[string][]string) (*Secret, error) {
 	r := c.c.NewRequest("GET", "/v1/"+path)
 
 	var values url.Values
@@ -108,10 +108,10 @@ func (c *Logical) ReadWithDataContext(ctx context.Context, path string, data map
 func (c *Logical) List(path string) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ListContext(ctx, path)
+	return c.ListWithContext(ctx, path)
 }
 
-func (c *Logical) ListContext(ctx context.Context, path string) (*Secret, error) {
+func (c *Logical) ListWithContext(ctx context.Context, path string) (*Secret, error) {
 	r := c.c.NewRequest("LIST", "/v1/"+path)
 	// Set this for broader compatibility, but we use LIST above to be able to
 	// handle the wrapping lookup function
@@ -146,10 +146,10 @@ func (c *Logical) ListContext(ctx context.Context, path string) (*Secret, error)
 func (c *Logical) Write(path string, data map[string]interface{}) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.WriteContext(ctx, path, data)
+	return c.WriteWithContext(ctx, path, data)
 }
 
-func (c *Logical) WriteContext(ctx context.Context, path string, data map[string]interface{}) (*Secret, error) {
+func (c *Logical) WriteWithContext(ctx context.Context, path string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/"+path)
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
@@ -171,10 +171,10 @@ func (c *Logical) JSONMergePatch(ctx context.Context, path string, data map[stri
 }
 
 func (c *Logical) WriteBytes(path string, data []byte) (*Secret, error) {
-	return c.WriteBytesContext(context.Background(), path, data)
+	return c.WriteBytesWithContext(context.Background(), path, data)
 }
 
-func (c *Logical) WriteBytesContext(ctx context.Context, path string, data []byte) (*Secret, error) {
+func (c *Logical) WriteBytesWithContext(ctx context.Context, path string, data []byte) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/"+path)
 	r.BodyBytes = data
 
@@ -209,20 +209,20 @@ func (c *Logical) write(ctx context.Context, path string, request *Request) (*Se
 func (c *Logical) Delete(path string) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.DeleteContext(ctx, path)
+	return c.DeleteWithContext(ctx, path)
 }
 
-func (c *Logical) DeleteContext(ctx context.Context, path string) (*Secret, error) {
-	return c.DeleteWithDataContext(ctx, path, nil)
+func (c *Logical) DeleteWithContext(ctx context.Context, path string) (*Secret, error) {
+	return c.DeleteWithDataWithContext(ctx, path, nil)
 }
 
 func (c *Logical) DeleteWithData(path string, data map[string][]string) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.DeleteWithDataContext(ctx, path, data)
+	return c.DeleteWithDataWithContext(ctx, path, data)
 }
 
-func (c *Logical) DeleteWithDataContext(ctx context.Context, path string, data map[string][]string) (*Secret, error) {
+func (c *Logical) DeleteWithDataWithContext(ctx context.Context, path string, data map[string][]string) (*Secret, error) {
 	r := c.c.NewRequest("DELETE", "/v1/"+path)
 
 	var values url.Values
@@ -266,10 +266,10 @@ func (c *Logical) DeleteWithDataContext(ctx context.Context, path string, data m
 func (c *Logical) Unwrap(wrappingToken string) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.UnwrapContext(ctx, wrappingToken)
+	return c.UnwrapWithContext(ctx, wrappingToken)
 }
 
-func (c *Logical) UnwrapContext(ctx context.Context, wrappingToken string) (*Secret, error) {
+func (c *Logical) UnwrapWithContext(ctx context.Context, wrappingToken string) (*Secret, error) {
 	var data map[string]interface{}
 	wt := strings.TrimSpace(wrappingToken)
 	if wrappingToken != "" {

--- a/api/logical.go
+++ b/api/logical.go
@@ -81,7 +81,7 @@ func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data
 		r.Params = values
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -120,7 +120,7 @@ func (c *Logical) ListWithContext(ctx context.Context, path string) (*Secret, er
 	r.Method = "GET"
 	r.Params.Set("list", "true")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -185,7 +185,7 @@ func (c *Logical) write(ctx context.Context, path string, request *Request) (*Se
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	resp, err := c.c.RawRequestWithContext(ctx, request)
+	resp, err := c.c.rawRequestWithContext(ctx, request)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -241,7 +241,7 @@ func (c *Logical) DeleteWithDataWithContext(ctx context.Context, path string, da
 		r.Params = values
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -290,7 +290,7 @@ func (c *Logical) UnwrapWithContext(ctx context.Context, wrappingToken string) (
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/api/logical.go
+++ b/api/logical.go
@@ -64,6 +64,9 @@ func (c *Logical) ReadWithData(path string, data map[string][]string) (*Secret, 
 }
 
 func (c *Logical) ReadWithDataWithContext(ctx context.Context, path string, data map[string][]string) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/"+path)
 
 	var values url.Values
@@ -112,6 +115,9 @@ func (c *Logical) List(path string) (*Secret, error) {
 }
 
 func (c *Logical) ListWithContext(ctx context.Context, path string) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("LIST", "/v1/"+path)
 	// Set this for broader compatibility, but we use LIST above to be able to
 	// handle the wrapping lookup function
@@ -182,6 +188,9 @@ func (c *Logical) WriteBytesWithContext(ctx context.Context, path string, data [
 }
 
 func (c *Logical) write(ctx context.Context, path string, request *Request) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	resp, err := c.c.RawRequestWithContext(ctx, request)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -223,6 +232,9 @@ func (c *Logical) DeleteWithData(path string, data map[string][]string) (*Secret
 }
 
 func (c *Logical) DeleteWithDataWithContext(ctx context.Context, path string, data map[string][]string) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", "/v1/"+path)
 
 	var values url.Values
@@ -270,6 +282,9 @@ func (c *Logical) Unwrap(wrappingToken string) (*Secret, error) {
 }
 
 func (c *Logical) UnwrapWithContext(ctx context.Context, wrappingToken string) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	var data map[string]interface{}
 	wt := strings.TrimSpace(wrappingToken)
 	if wrappingToken != "" {

--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -67,9 +68,16 @@ func (f *PluginAPIClientMeta) GetTLSConfig() *TLSConfig {
 	return nil
 }
 
-// VaultPluginTLSProvider is run inside a plugin and retrieves the response
-// wrapped TLS certificate from vault. It returns a configured TLS Config.
+// VaultPluginTLSProvider wraps VaultPluginTLSProviderContext using context.Background.
 func VaultPluginTLSProvider(apiTLSConfig *TLSConfig) func() (*tls.Config, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return VaultPluginTLSProviderContext(ctx, apiTLSConfig)
+}
+
+// VaultPluginTLSProviderContext is run inside a plugin and retrieves the response
+// wrapped TLS certificate from vault. It returns a configured TLS Config.
+func VaultPluginTLSProviderContext(ctx context.Context, apiTLSConfig *TLSConfig) func() (*tls.Config, error) {
 	if os.Getenv(PluginMetadataModeEnv) == "true" {
 		return nil
 	}
@@ -121,7 +129,7 @@ func VaultPluginTLSProvider(apiTLSConfig *TLSConfig) func() (*tls.Config, error)
 		// Reset token value to make sure nothing has been set by default
 		client.ClearToken()
 
-		secret, err := client.Logical().Unwrap(unwrapToken)
+		secret, err := client.Logical().UnwrapWithContext(ctx, unwrapToken)
 		if err != nil {
 			return nil, errwrap.Wrapf("error during token unwrap request: {{err}}", err)
 		}

--- a/api/plugin_helpers.go
+++ b/api/plugin_helpers.go
@@ -70,9 +70,7 @@ func (f *PluginAPIClientMeta) GetTLSConfig() *TLSConfig {
 
 // VaultPluginTLSProvider wraps VaultPluginTLSProviderContext using context.Background.
 func VaultPluginTLSProvider(apiTLSConfig *TLSConfig) func() (*tls.Config, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return VaultPluginTLSProviderContext(ctx, apiTLSConfig)
+	return VaultPluginTLSProviderContext(context.Background(), apiTLSConfig)
 }
 
 // VaultPluginTLSProviderContext is run inside a plugin and retrieves the response

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -26,13 +26,18 @@ func (c *Client) SSHWithMountPoint(mountPoint string) *SSH {
 
 // Credential invokes the SSH backend API to create a credential to establish an SSH session.
 func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.CredentialContext(ctx, role, data)
+}
+
+// CredentialContext the same as Credential but with a custom context.
+func (c *SSH) CredentialContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/creds/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -45,13 +50,18 @@ func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, err
 // SignKey signs the given public key and returns a signed public key to pass
 // along with the SSH request.
 func (c *SSH) SignKey(role string, data map[string]interface{}) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.SignKeyContext(ctx, role, data)
+}
+
+// SignKeyContext the same as SignKey but with a custom context.
+func (c *SSH) SignKeyContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/sign/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -26,9 +26,7 @@ func (c *Client) SSHWithMountPoint(mountPoint string) *SSH {
 
 // Credential wraps CredentialWithContext using context.Background.
 func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.CredentialWithContext(ctx, role, data)
+	return c.CredentialWithContext(context.Background(), role, data)
 }
 
 // CredentialWithContext invokes the SSH backend API to create a credential to establish an SSH session.
@@ -52,9 +50,7 @@ func (c *SSH) CredentialWithContext(ctx context.Context, role string, data map[s
 
 // SignKey wraps SignKeyWithContext using context.Background.
 func (c *SSH) SignKey(role string, data map[string]interface{}) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.SignKeyWithContext(ctx, role, data)
+	return c.SignKeyWithContext(context.Background(), role, data)
 }
 
 // SignKeyWithContext signs the given public key and returns a signed public key to pass

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -28,11 +28,11 @@ func (c *Client) SSHWithMountPoint(mountPoint string) *SSH {
 func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.CredentialContext(ctx, role, data)
+	return c.CredentialWithContext(ctx, role, data)
 }
 
-// CredentialContext the same as Credential but with a custom context.
-func (c *SSH) CredentialContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
+// CredentialWithContext the same as Credential but with a custom context.
+func (c *SSH) CredentialWithContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/creds/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
@@ -52,11 +52,11 @@ func (c *SSH) CredentialContext(ctx context.Context, role string, data map[strin
 func (c *SSH) SignKey(role string, data map[string]interface{}) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.SignKeyContext(ctx, role, data)
+	return c.SignKeyWithContext(ctx, role, data)
 }
 
-// SignKeyContext the same as SignKey but with a custom context.
-func (c *SSH) SignKeyContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
+// SignKeyWithContext the same as SignKey but with a custom context.
+func (c *SSH) SignKeyWithContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/sign/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -33,6 +33,9 @@ func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, err
 
 // CredentialWithContext invokes the SSH backend API to create a credential to establish an SSH session.
 func (c *SSH) CredentialWithContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/creds/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err
@@ -55,8 +58,11 @@ func (c *SSH) SignKey(role string, data map[string]interface{}) (*Secret, error)
 }
 
 // SignKeyWithContext signs the given public key and returns a signed public key to pass
-// // along with the SSH request.
+// along with the SSH request.
 func (c *SSH) SignKeyWithContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/sign/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
 		return nil, err

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -24,14 +24,14 @@ func (c *Client) SSHWithMountPoint(mountPoint string) *SSH {
 	}
 }
 
-// Credential invokes the SSH backend API to create a credential to establish an SSH session.
+// Credential wraps CredentialWithContext using context.Background.
 func (c *SSH) Credential(role string, data map[string]interface{}) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.CredentialWithContext(ctx, role, data)
 }
 
-// CredentialWithContext the same as Credential but with a custom context.
+// CredentialWithContext invokes the SSH backend API to create a credential to establish an SSH session.
 func (c *SSH) CredentialWithContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/creds/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {
@@ -47,15 +47,15 @@ func (c *SSH) CredentialWithContext(ctx context.Context, role string, data map[s
 	return ParseSecret(resp.Body)
 }
 
-// SignKey signs the given public key and returns a signed public key to pass
-// along with the SSH request.
+// SignKey wraps SignKeyWithContext using context.Background.
 func (c *SSH) SignKey(role string, data map[string]interface{}) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.SignKeyWithContext(ctx, role, data)
 }
 
-// SignKeyWithContext the same as SignKey but with a custom context.
+// SignKeyWithContext signs the given public key and returns a signed public key to pass
+// // along with the SSH request.
 func (c *SSH) SignKeyWithContext(ctx context.Context, role string, data map[string]interface{}) (*Secret, error) {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/%s/sign/%s", c.MountPoint, role))
 	if err := r.SetJSONBody(data); err != nil {

--- a/api/ssh.go
+++ b/api/ssh.go
@@ -39,7 +39,7 @@ func (c *SSH) CredentialWithContext(ctx context.Context, role string, data map[s
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (c *SSH) SignKeyWithContext(ctx context.Context, role string, data map[stri
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -223,7 +223,7 @@ func (c *SSHHelper) VerifyWithContext(ctx context.Context, otp string) (*SSHVeri
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -208,11 +208,11 @@ func (c *Client) SSHHelperWithMountPoint(mountPoint string) *SSHHelper {
 func (c *SSHHelper) Verify(otp string) (*SSHVerifyResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.VerifyContext(ctx, otp)
+	return c.VerifyWithContext(ctx, otp)
 }
 
-// VerifyContext the same as Verify but with a custom context.
-func (c *SSHHelper) VerifyContext(ctx context.Context, otp string) (*SSHVerifyResponse, error) {
+// VerifyWithContext the same as Verify but with a custom context.
+func (c *SSHHelper) VerifyWithContext(ctx context.Context, otp string) (*SSHVerifyResponse, error) {
 	data := map[string]interface{}{
 		"otp": otp,
 	}

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -206,9 +206,7 @@ func (c *Client) SSHHelperWithMountPoint(mountPoint string) *SSHHelper {
 // an echo response message is returned. This feature is used by ssh-helper to verify if
 // its configured correctly.
 func (c *SSHHelper) Verify(otp string) (*SSHVerifyResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.VerifyWithContext(ctx, otp)
+	return c.VerifyWithContext(context.Background(), otp)
 }
 
 // VerifyWithContext the same as Verify but with a custom context.

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -206,6 +206,13 @@ func (c *Client) SSHHelperWithMountPoint(mountPoint string) *SSHHelper {
 // an echo response message is returned. This feature is used by ssh-helper to verify if
 // its configured correctly.
 func (c *SSHHelper) Verify(otp string) (*SSHVerifyResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.VerifyContext(ctx, otp)
+}
+
+// VerifyContext the same as Verify but with a custom context.
+func (c *SSHHelper) VerifyContext(ctx context.Context, otp string) (*SSHVerifyResponse, error) {
 	data := map[string]interface{}{
 		"otp": otp,
 	}
@@ -215,8 +222,6 @@ func (c *SSHHelper) Verify(otp string) (*SSHVerifyResponse, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/ssh_agent.go
+++ b/api/ssh_agent.go
@@ -213,6 +213,9 @@ func (c *SSHHelper) Verify(otp string) (*SSHVerifyResponse, error) {
 
 // VerifyWithContext the same as Verify but with a custom context.
 func (c *SSHHelper) VerifyWithContext(ctx context.Context, otp string) (*SSHVerifyResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	data := map[string]interface{}{
 		"otp": otp,
 	}

--- a/api/sys_audit.go
+++ b/api/sys_audit.go
@@ -11,10 +11,10 @@ import (
 func (c *Sys) AuditHash(path string, input string) (string, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.AuditHashContext(ctx, path, input)
+	return c.AuditHashWithContext(ctx, path, input)
 }
 
-func (c *Sys) AuditHashContext(ctx context.Context, path string, input string) (string, error) {
+func (c *Sys) AuditHashWithContext(ctx context.Context, path string, input string) (string, error) {
 	body := map[string]interface{}{
 		"input": input,
 	}
@@ -53,10 +53,10 @@ func (c *Sys) AuditHashContext(ctx context.Context, path string, input string) (
 func (c *Sys) ListAudit() (map[string]*Audit, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ListAuditContext(ctx)
+	return c.ListAuditWithContext(ctx)
 }
 
-func (c *Sys) ListAuditContext(ctx context.Context) (map[string]*Audit, error) {
+func (c *Sys) ListAuditWithContext(ctx context.Context) (map[string]*Audit, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/audit")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -95,10 +95,10 @@ func (c *Sys) EnableAudit(
 func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.EnableAuditWithOptionsContext(ctx, path, options)
+	return c.EnableAuditWithOptionsWithContext(ctx, path, options)
 }
 
-func (c *Sys) EnableAuditWithOptionsContext(ctx context.Context, path string, options *EnableAuditOptions) error {
+func (c *Sys) EnableAuditWithOptionsWithContext(ctx context.Context, path string, options *EnableAuditOptions) error {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/sys/audit/%s", path))
 	if err := r.SetJSONBody(options); err != nil {
 		return err
@@ -116,10 +116,10 @@ func (c *Sys) EnableAuditWithOptionsContext(ctx context.Context, path string, op
 func (c *Sys) DisableAudit(path string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.DisableAuditContext(ctx, path)
+	return c.DisableAuditWithContext(ctx, path)
 }
 
-func (c *Sys) DisableAuditContext(ctx context.Context, path string) error {
+func (c *Sys) DisableAuditWithContext(ctx context.Context, path string) error {
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/audit/%s", path))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_audit.go
+++ b/api/sys_audit.go
@@ -9,6 +9,12 @@ import (
 )
 
 func (c *Sys) AuditHash(path string, input string) (string, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.AuditHashContext(ctx, path, input)
+}
+
+func (c *Sys) AuditHashContext(ctx context.Context, path string, input string) (string, error) {
 	body := map[string]interface{}{
 		"input": input,
 	}
@@ -18,8 +24,6 @@ func (c *Sys) AuditHash(path string, input string) (string, error) {
 		return "", err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return "", err
@@ -47,10 +51,14 @@ func (c *Sys) AuditHash(path string, input string) (string, error) {
 }
 
 func (c *Sys) ListAudit() (map[string]*Audit, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/audit")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.ListAuditContext(ctx)
+}
+
+func (c *Sys) ListAuditContext(ctx context.Context) (map[string]*Audit, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/audit")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -85,13 +93,17 @@ func (c *Sys) EnableAudit(
 }
 
 func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.EnableAuditWithOptionsContext(ctx, path, options)
+}
+
+func (c *Sys) EnableAuditWithOptionsContext(ctx context.Context, path string, options *EnableAuditOptions) error {
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/sys/audit/%s", path))
 	if err := r.SetJSONBody(options); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -102,10 +114,14 @@ func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) e
 }
 
 func (c *Sys) DisableAudit(path string) error {
-	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/audit/%s", path))
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.DisableAuditContext(ctx, path)
+}
+
+func (c *Sys) DisableAuditContext(ctx context.Context, path string) error {
+	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/audit/%s", path))
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 
 	if err == nil {

--- a/api/sys_audit.go
+++ b/api/sys_audit.go
@@ -15,6 +15,9 @@ func (c *Sys) AuditHash(path string, input string) (string, error) {
 }
 
 func (c *Sys) AuditHashWithContext(ctx context.Context, path string, input string) (string, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]interface{}{
 		"input": input,
 	}
@@ -57,6 +60,9 @@ func (c *Sys) ListAudit() (map[string]*Audit, error) {
 }
 
 func (c *Sys) ListAuditWithContext(ctx context.Context) (map[string]*Audit, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/audit")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -99,6 +105,9 @@ func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) e
 }
 
 func (c *Sys) EnableAuditWithOptionsWithContext(ctx context.Context, path string, options *EnableAuditOptions) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", fmt.Sprintf("/v1/sys/audit/%s", path))
 	if err := r.SetJSONBody(options); err != nil {
 		return err
@@ -120,6 +129,9 @@ func (c *Sys) DisableAudit(path string) error {
 }
 
 func (c *Sys) DisableAuditWithContext(ctx context.Context, path string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/audit/%s", path))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_audit.go
+++ b/api/sys_audit.go
@@ -25,7 +25,7 @@ func (c *Sys) AuditHashWithContext(ctx context.Context, path string, input strin
 		return "", err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return "", err
 	}
@@ -61,7 +61,7 @@ func (c *Sys) ListAuditWithContext(ctx context.Context) (map[string]*Audit, erro
 
 	r := c.c.NewRequest("GET", "/v1/sys/audit")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (c *Sys) EnableAuditWithOptionsWithContext(ctx context.Context, path string
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (c *Sys) DisableAuditWithContext(ctx context.Context, path string) error {
 
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/audit/%s", path))
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 
 	if err == nil {
 		defer resp.Body.Close()

--- a/api/sys_audit.go
+++ b/api/sys_audit.go
@@ -9,9 +9,7 @@ import (
 )
 
 func (c *Sys) AuditHash(path string, input string) (string, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.AuditHashWithContext(ctx, path, input)
+	return c.AuditHashWithContext(context.Background(), path, input)
 }
 
 func (c *Sys) AuditHashWithContext(ctx context.Context, path string, input string) (string, error) {
@@ -54,9 +52,7 @@ func (c *Sys) AuditHashWithContext(ctx context.Context, path string, input strin
 }
 
 func (c *Sys) ListAudit() (map[string]*Audit, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ListAuditWithContext(ctx)
+	return c.ListAuditWithContext(context.Background())
 }
 
 func (c *Sys) ListAuditWithContext(ctx context.Context) (map[string]*Audit, error) {
@@ -99,9 +95,7 @@ func (c *Sys) EnableAudit(
 }
 
 func (c *Sys) EnableAuditWithOptions(path string, options *EnableAuditOptions) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.EnableAuditWithOptionsWithContext(ctx, path, options)
+	return c.EnableAuditWithOptionsWithContext(context.Background(), path, options)
 }
 
 func (c *Sys) EnableAuditWithOptionsWithContext(ctx context.Context, path string, options *EnableAuditOptions) error {
@@ -123,9 +117,7 @@ func (c *Sys) EnableAuditWithOptionsWithContext(ctx context.Context, path string
 }
 
 func (c *Sys) DisableAudit(path string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.DisableAuditWithContext(ctx, path)
+	return c.DisableAuditWithContext(context.Background(), path)
 }
 
 func (c *Sys) DisableAuditWithContext(ctx context.Context, path string) error {

--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -15,6 +15,9 @@ func (c *Sys) ListAuth() (map[string]*AuthMount, error) {
 }
 
 func (c *Sys) ListAuthWithContext(ctx context.Context) (map[string]*AuthMount, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/auth")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -55,6 +58,9 @@ func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) err
 }
 
 func (c *Sys) EnableAuthWithOptionsWithContext(ctx context.Context, path string, options *EnableAuthOptions) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/auth/%s", path))
 	if err := r.SetJSONBody(options); err != nil {
 		return err
@@ -76,6 +82,9 @@ func (c *Sys) DisableAuth(path string) error {
 }
 
 func (c *Sys) DisableAuthWithContext(ctx context.Context, path string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/auth/%s", path))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -9,9 +9,7 @@ import (
 )
 
 func (c *Sys) ListAuth() (map[string]*AuthMount, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ListAuthWithContext(ctx)
+	return c.ListAuthWithContext(context.Background())
 }
 
 func (c *Sys) ListAuthWithContext(ctx context.Context) (map[string]*AuthMount, error) {
@@ -52,9 +50,7 @@ func (c *Sys) EnableAuth(path, authType, desc string) error {
 }
 
 func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.EnableAuthWithOptionsWithContext(ctx, path, options)
+	return c.EnableAuthWithOptionsWithContext(context.Background(), path, options)
 }
 
 func (c *Sys) EnableAuthWithOptionsWithContext(ctx context.Context, path string, options *EnableAuthOptions) error {
@@ -76,9 +72,7 @@ func (c *Sys) EnableAuthWithOptionsWithContext(ctx context.Context, path string,
 }
 
 func (c *Sys) DisableAuth(path string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.DisableAuthWithContext(ctx, path)
+	return c.DisableAuthWithContext(context.Background(), path)
 }
 
 func (c *Sys) DisableAuthWithContext(ctx context.Context, path string) error {

--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -11,10 +11,10 @@ import (
 func (c *Sys) ListAuth() (map[string]*AuthMount, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ListAuthContext(ctx)
+	return c.ListAuthWithContext(ctx)
 }
 
-func (c *Sys) ListAuthContext(ctx context.Context) (map[string]*AuthMount, error) {
+func (c *Sys) ListAuthWithContext(ctx context.Context) (map[string]*AuthMount, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/auth")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -51,10 +51,10 @@ func (c *Sys) EnableAuth(path, authType, desc string) error {
 func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.EnableAuthWithOptionsContext(ctx, path, options)
+	return c.EnableAuthWithOptionsWithContext(ctx, path, options)
 }
 
-func (c *Sys) EnableAuthWithOptionsContext(ctx context.Context, path string, options *EnableAuthOptions) error {
+func (c *Sys) EnableAuthWithOptionsWithContext(ctx context.Context, path string, options *EnableAuthOptions) error {
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/auth/%s", path))
 	if err := r.SetJSONBody(options); err != nil {
 		return err
@@ -72,10 +72,10 @@ func (c *Sys) EnableAuthWithOptionsContext(ctx context.Context, path string, opt
 func (c *Sys) DisableAuth(path string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.DisableAuthContext(ctx, path)
+	return c.DisableAuthWithContext(ctx, path)
 }
 
-func (c *Sys) DisableAuthContext(ctx context.Context, path string) error {
+func (c *Sys) DisableAuthWithContext(ctx context.Context, path string) error {
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/auth/%s", path))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -18,7 +18,7 @@ func (c *Sys) ListAuthWithContext(ctx context.Context) (map[string]*AuthMount, e
 
 	r := c.c.NewRequest("GET", "/v1/sys/auth")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (c *Sys) EnableAuthWithOptionsWithContext(ctx context.Context, path string,
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (c *Sys) DisableAuthWithContext(ctx context.Context, path string) error {
 
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/auth/%s", path))
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}

--- a/api/sys_auth.go
+++ b/api/sys_auth.go
@@ -9,10 +9,14 @@ import (
 )
 
 func (c *Sys) ListAuth() (map[string]*AuthMount, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/auth")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.ListAuthContext(ctx)
+}
+
+func (c *Sys) ListAuthContext(ctx context.Context) (map[string]*AuthMount, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/auth")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -45,13 +49,17 @@ func (c *Sys) EnableAuth(path, authType, desc string) error {
 }
 
 func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.EnableAuthWithOptionsContext(ctx, path, options)
+}
+
+func (c *Sys) EnableAuthWithOptionsContext(ctx context.Context, path string, options *EnableAuthOptions) error {
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/auth/%s", path))
 	if err := r.SetJSONBody(options); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -62,10 +70,14 @@ func (c *Sys) EnableAuthWithOptions(path string, options *EnableAuthOptions) err
 }
 
 func (c *Sys) DisableAuth(path string) error {
-	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/auth/%s", path))
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.DisableAuthContext(ctx, path)
+}
+
+func (c *Sys) DisableAuthContext(ctx context.Context, path string) error {
+	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/auth/%s", path))
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()

--- a/api/sys_capabilities.go
+++ b/api/sys_capabilities.go
@@ -42,7 +42,7 @@ func (c *Sys) CapabilitiesWithContext(ctx context.Context, token, path string) (
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_capabilities.go
+++ b/api/sys_capabilities.go
@@ -13,6 +13,9 @@ func (c *Sys) CapabilitiesSelf(path string) ([]string, error) {
 }
 
 func (c *Sys) CapabilitiesSelfWithContext(ctx context.Context, path string) ([]string, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	return c.CapabilitiesWithContext(ctx, c.c.Token(), path)
 }
 
@@ -23,6 +26,9 @@ func (c *Sys) Capabilities(token, path string) ([]string, error) {
 }
 
 func (c *Sys) CapabilitiesWithContext(ctx context.Context, token, path string) ([]string, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]string{
 		"token": token,
 		"path":  path,

--- a/api/sys_capabilities.go
+++ b/api/sys_capabilities.go
@@ -12,17 +12,17 @@ func (c *Sys) CapabilitiesSelf(path string) ([]string, error) {
 	return c.Capabilities(c.c.Token(), path)
 }
 
-func (c *Sys) CapabilitiesSelfContext(ctx context.Context, path string) ([]string, error) {
-	return c.CapabilitiesContext(ctx, c.c.Token(), path)
+func (c *Sys) CapabilitiesSelfWithContext(ctx context.Context, path string) ([]string, error) {
+	return c.CapabilitiesWithContext(ctx, c.c.Token(), path)
 }
 
 func (c *Sys) Capabilities(token, path string) ([]string, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.CapabilitiesContext(ctx, token, path)
+	return c.CapabilitiesWithContext(ctx, token, path)
 }
 
-func (c *Sys) CapabilitiesContext(ctx context.Context, token, path string) ([]string, error) {
+func (c *Sys) CapabilitiesWithContext(ctx context.Context, token, path string) ([]string, error) {
 	body := map[string]string{
 		"token": token,
 		"path":  path,

--- a/api/sys_capabilities.go
+++ b/api/sys_capabilities.go
@@ -12,7 +12,17 @@ func (c *Sys) CapabilitiesSelf(path string) ([]string, error) {
 	return c.Capabilities(c.c.Token(), path)
 }
 
+func (c *Sys) CapabilitiesSelfContext(ctx context.Context, path string) ([]string, error) {
+	return c.CapabilitiesContext(ctx, c.c.Token(), path)
+}
+
 func (c *Sys) Capabilities(token, path string) ([]string, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.CapabilitiesContext(ctx, token, path)
+}
+
+func (c *Sys) CapabilitiesContext(ctx context.Context, token, path string) ([]string, error) {
 	body := map[string]string{
 		"token": token,
 		"path":  path,
@@ -28,8 +38,6 @@ func (c *Sys) Capabilities(token, path string) ([]string, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_capabilities.go
+++ b/api/sys_capabilities.go
@@ -20,9 +20,7 @@ func (c *Sys) CapabilitiesSelfWithContext(ctx context.Context, path string) ([]s
 }
 
 func (c *Sys) Capabilities(token, path string) ([]string, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.CapabilitiesWithContext(ctx, token, path)
+	return c.CapabilitiesWithContext(context.Background(), token, path)
 }
 
 func (c *Sys) CapabilitiesWithContext(ctx context.Context, token, path string) ([]string, error) {

--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -8,10 +8,14 @@ import (
 )
 
 func (c *Sys) CORSStatus() (*CORSResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/config/cors")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.CORSStatusContext(ctx)
+}
+
+func (c *Sys) CORSStatusContext(ctx context.Context) (*CORSResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/config/cors")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -36,13 +40,17 @@ func (c *Sys) CORSStatus() (*CORSResponse, error) {
 }
 
 func (c *Sys) ConfigureCORS(req *CORSRequest) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ConfigureCORSContext(ctx, req)
+}
+
+func (c *Sys) ConfigureCORSContext(ctx context.Context, req *CORSRequest) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/config/cors")
 	if err := r.SetJSONBody(req); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -51,10 +59,14 @@ func (c *Sys) ConfigureCORS(req *CORSRequest) error {
 }
 
 func (c *Sys) DisableCORS() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/config/cors")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.DisableCORSContext(ctx)
+}
+
+func (c *Sys) DisableCORSContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/config/cors")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()

--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -8,9 +8,7 @@ import (
 )
 
 func (c *Sys) CORSStatus() (*CORSResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.CORSStatusWithContext(ctx)
+	return c.CORSStatusWithContext(context.Background())
 }
 
 func (c *Sys) CORSStatusWithContext(ctx context.Context) (*CORSResponse, error) {
@@ -43,9 +41,7 @@ func (c *Sys) CORSStatusWithContext(ctx context.Context) (*CORSResponse, error) 
 }
 
 func (c *Sys) ConfigureCORS(req *CORSRequest) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ConfigureCORSWithContext(ctx, req)
+	return c.ConfigureCORSWithContext(context.Background(), req)
 }
 
 func (c *Sys) ConfigureCORSWithContext(ctx context.Context, req *CORSRequest) error {
@@ -65,9 +61,7 @@ func (c *Sys) ConfigureCORSWithContext(ctx context.Context, req *CORSRequest) er
 }
 
 func (c *Sys) DisableCORS() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.DisableCORSWithContext(ctx)
+	return c.DisableCORSWithContext(context.Background())
 }
 
 func (c *Sys) DisableCORSWithContext(ctx context.Context) error {

--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -10,10 +10,10 @@ import (
 func (c *Sys) CORSStatus() (*CORSResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.CORSStatusContext(ctx)
+	return c.CORSStatusWithContext(ctx)
 }
 
-func (c *Sys) CORSStatusContext(ctx context.Context) (*CORSResponse, error) {
+func (c *Sys) CORSStatusWithContext(ctx context.Context) (*CORSResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/config/cors")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -42,10 +42,10 @@ func (c *Sys) CORSStatusContext(ctx context.Context) (*CORSResponse, error) {
 func (c *Sys) ConfigureCORS(req *CORSRequest) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ConfigureCORSContext(ctx, req)
+	return c.ConfigureCORSWithContext(ctx, req)
 }
 
-func (c *Sys) ConfigureCORSContext(ctx context.Context, req *CORSRequest) error {
+func (c *Sys) ConfigureCORSWithContext(ctx context.Context, req *CORSRequest) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/config/cors")
 	if err := r.SetJSONBody(req); err != nil {
 		return err
@@ -61,10 +61,10 @@ func (c *Sys) ConfigureCORSContext(ctx context.Context, req *CORSRequest) error 
 func (c *Sys) DisableCORS() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.DisableCORSContext(ctx)
+	return c.DisableCORSWithContext(ctx)
 }
 
-func (c *Sys) DisableCORSContext(ctx context.Context) error {
+func (c *Sys) DisableCORSWithContext(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/config/cors")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -14,6 +14,9 @@ func (c *Sys) CORSStatus() (*CORSResponse, error) {
 }
 
 func (c *Sys) CORSStatusWithContext(ctx context.Context) (*CORSResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/config/cors")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -46,6 +49,9 @@ func (c *Sys) ConfigureCORS(req *CORSRequest) error {
 }
 
 func (c *Sys) ConfigureCORSWithContext(ctx context.Context, req *CORSRequest) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/config/cors")
 	if err := r.SetJSONBody(req); err != nil {
 		return err
@@ -65,6 +71,9 @@ func (c *Sys) DisableCORS() error {
 }
 
 func (c *Sys) DisableCORSWithContext(ctx context.Context) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", "/v1/sys/config/cors")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_config_cors.go
+++ b/api/sys_config_cors.go
@@ -17,7 +17,7 @@ func (c *Sys) CORSStatusWithContext(ctx context.Context) (*CORSResponse, error) 
 
 	r := c.c.NewRequest("GET", "/v1/sys/config/cors")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (c *Sys) ConfigureCORSWithContext(ctx context.Context, req *CORSRequest) er
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -70,7 +70,7 @@ func (c *Sys) DisableCORSWithContext(ctx context.Context) error {
 
 	r := c.c.NewRequest("DELETE", "/v1/sys/config/cors")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}

--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -33,6 +33,9 @@ func (c *Sys) GenerateRecoveryOperationTokenStatusWithContext(ctx context.Contex
 }
 
 func (c *Sys) generateRootStatusCommonWithContext(ctx context.Context, path string) (*GenerateRootStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", path)
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -77,6 +80,9 @@ func (c *Sys) GenerateRecoveryOperationTokenInitWithContext(ctx context.Context,
 }
 
 func (c *Sys) generateRootInitCommonWithContext(ctx context.Context, path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]interface{}{
 		"otp":     otp,
 		"pgp_key": pgpKey,
@@ -129,6 +135,9 @@ func (c *Sys) GenerateRecoveryOperationTokenCancelWithContext(ctx context.Contex
 }
 
 func (c *Sys) generateRootCancelCommonWithContext(ctx context.Context, path string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", path)
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -169,6 +178,9 @@ func (c *Sys) GenerateRecoveryOperationTokenUpdateWithContext(ctx context.Contex
 }
 
 func (c *Sys) generateRootUpdateCommonWithContext(ctx context.Context, path, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,

--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -5,34 +5,34 @@ import "context"
 func (c *Sys) GenerateRootStatus() (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateRootStatusContext(ctx)
+	return c.GenerateRootStatusWithContext(ctx)
 }
 
 func (c *Sys) GenerateDROperationTokenStatus() (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateDROperationTokenStatusContext(ctx)
+	return c.GenerateDROperationTokenStatusWithContext(ctx)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenStatus() (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateRecoveryOperationTokenStatusContext(ctx)
+	return c.GenerateRecoveryOperationTokenStatusWithContext(ctx)
 }
 
-func (c *Sys) GenerateRootStatusContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommonContext(ctx, "/v1/sys/generate-root/attempt")
+func (c *Sys) GenerateRootStatusWithContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommonWithContext(ctx, "/v1/sys/generate-root/attempt")
 }
 
-func (c *Sys) GenerateDROperationTokenStatusContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+func (c *Sys) GenerateDROperationTokenStatusWithContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommonWithContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
 }
 
-func (c *Sys) GenerateRecoveryOperationTokenStatusContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommonContext(ctx, "/v1/sys/generate-recovery-token/attempt")
+func (c *Sys) GenerateRecoveryOperationTokenStatusWithContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommonWithContext(ctx, "/v1/sys/generate-recovery-token/attempt")
 }
 
-func (c *Sys) generateRootStatusCommonContext(ctx context.Context, path string) (*GenerateRootStatusResponse, error) {
+func (c *Sys) generateRootStatusCommonWithContext(ctx context.Context, path string) (*GenerateRootStatusResponse, error) {
 	r := c.c.NewRequest("GET", path)
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -49,34 +49,34 @@ func (c *Sys) generateRootStatusCommonContext(ctx context.Context, path string) 
 func (c *Sys) GenerateRootInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateRootInitContext(ctx, otp, pgpKey)
+	return c.GenerateRootInitWithContext(ctx, otp, pgpKey)
 }
 
 func (c *Sys) GenerateDROperationTokenInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateDROperationTokenInitContext(ctx, otp, pgpKey)
+	return c.GenerateDROperationTokenInitWithContext(ctx, otp, pgpKey)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateRecoveryOperationTokenInitContext(ctx, otp, pgpKey)
+	return c.GenerateRecoveryOperationTokenInitWithContext(ctx, otp, pgpKey)
 }
 
-func (c *Sys) GenerateRootInitContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommonContext(ctx, "/v1/sys/generate-root/attempt", otp, pgpKey)
+func (c *Sys) GenerateRootInitWithContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommonWithContext(ctx, "/v1/sys/generate-root/attempt", otp, pgpKey)
 }
 
-func (c *Sys) GenerateDROperationTokenInitContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt", otp, pgpKey)
+func (c *Sys) GenerateDROperationTokenInitWithContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommonWithContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt", otp, pgpKey)
 }
 
-func (c *Sys) GenerateRecoveryOperationTokenInitContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommonContext(ctx, "/v1/sys/generate-recovery-token/attempt", otp, pgpKey)
+func (c *Sys) GenerateRecoveryOperationTokenInitWithContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommonWithContext(ctx, "/v1/sys/generate-recovery-token/attempt", otp, pgpKey)
 }
 
-func (c *Sys) generateRootInitCommonContext(ctx context.Context, path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+func (c *Sys) generateRootInitCommonWithContext(ctx context.Context, path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
 	body := map[string]interface{}{
 		"otp":     otp,
 		"pgp_key": pgpKey,
@@ -101,34 +101,34 @@ func (c *Sys) generateRootInitCommonContext(ctx context.Context, path, otp, pgpK
 func (c *Sys) GenerateRootCancel() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateRootCancelContext(ctx)
+	return c.GenerateRootCancelWithContext(ctx)
 }
 
 func (c *Sys) GenerateDROperationTokenCancel() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateDROperationTokenCancelContext(ctx)
+	return c.GenerateDROperationTokenCancelWithContext(ctx)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenCancel() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateRecoveryOperationTokenCancelContext(ctx)
+	return c.GenerateRecoveryOperationTokenCancelWithContext(ctx)
 }
 
-func (c *Sys) GenerateRootCancelContext(ctx context.Context) error {
-	return c.generateRootCancelCommonContext(ctx, "/v1/sys/generate-root/attempt")
+func (c *Sys) GenerateRootCancelWithContext(ctx context.Context) error {
+	return c.generateRootCancelCommonWithContext(ctx, "/v1/sys/generate-root/attempt")
 }
 
-func (c *Sys) GenerateDROperationTokenCancelContext(ctx context.Context) error {
-	return c.generateRootCancelCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+func (c *Sys) GenerateDROperationTokenCancelWithContext(ctx context.Context) error {
+	return c.generateRootCancelCommonWithContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
 }
 
-func (c *Sys) GenerateRecoveryOperationTokenCancelContext(ctx context.Context) error {
-	return c.generateRootCancelCommonContext(ctx, "/v1/sys/generate-recovery-token/attempt")
+func (c *Sys) GenerateRecoveryOperationTokenCancelWithContext(ctx context.Context) error {
+	return c.generateRootCancelCommonWithContext(ctx, "/v1/sys/generate-recovery-token/attempt")
 }
 
-func (c *Sys) generateRootCancelCommonContext(ctx context.Context, path string) error {
+func (c *Sys) generateRootCancelCommonWithContext(ctx context.Context, path string) error {
 	r := c.c.NewRequest("DELETE", path)
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -141,34 +141,34 @@ func (c *Sys) generateRootCancelCommonContext(ctx context.Context, path string) 
 func (c *Sys) GenerateRootUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateRootUpdateContext(ctx, shard, nonce)
+	return c.GenerateRootUpdateWithContext(ctx, shard, nonce)
 }
 
 func (c *Sys) GenerateDROperationTokenUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateDROperationTokenUpdateContext(ctx, shard, nonce)
+	return c.GenerateDROperationTokenUpdateWithContext(ctx, shard, nonce)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GenerateRecoveryOperationTokenUpdateContext(ctx, shard, nonce)
+	return c.GenerateRecoveryOperationTokenUpdateWithContext(ctx, shard, nonce)
 }
 
-func (c *Sys) GenerateRootUpdateContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommonContext(ctx, "/v1/sys/generate-root/update", shard, nonce)
+func (c *Sys) GenerateRootUpdateWithContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommonWithContext(ctx, "/v1/sys/generate-root/update", shard, nonce)
 }
 
-func (c *Sys) GenerateDROperationTokenUpdateContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/update", shard, nonce)
+func (c *Sys) GenerateDROperationTokenUpdateWithContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommonWithContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/update", shard, nonce)
 }
 
-func (c *Sys) GenerateRecoveryOperationTokenUpdateContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommonContext(ctx, "/v1/sys/generate-recovery-token/update", shard, nonce)
+func (c *Sys) GenerateRecoveryOperationTokenUpdateWithContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommonWithContext(ctx, "/v1/sys/generate-recovery-token/update", shard, nonce)
 }
 
-func (c *Sys) generateRootUpdateCommonContext(ctx context.Context, path, shard, nonce string) (*GenerateRootStatusResponse, error) {
+func (c *Sys) generateRootUpdateCommonWithContext(ctx context.Context, path, shard, nonce string) (*GenerateRootStatusResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,

--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -3,22 +3,38 @@ package api
 import "context"
 
 func (c *Sys) GenerateRootStatus() (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommon("/v1/sys/generate-root/attempt")
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRootStatusContext(ctx)
 }
 
 func (c *Sys) GenerateDROperationTokenStatus() (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateDROperationTokenStatusContext(ctx)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenStatus() (*GenerateRootStatusResponse, error) {
-	return c.generateRootStatusCommon("/v1/sys/generate-recovery-token/attempt")
-}
-
-func (c *Sys) generateRootStatusCommon(path string) (*GenerateRootStatusResponse, error) {
-	r := c.c.NewRequest("GET", path)
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.GenerateRecoveryOperationTokenStatusContext(ctx)
+}
+
+func (c *Sys) GenerateRootStatusContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommonContext(ctx, "/v1/sys/generate-root/attempt")
+}
+
+func (c *Sys) GenerateDROperationTokenStatusContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenStatusContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
+	return c.generateRootStatusCommonContext(ctx, "/v1/sys/generate-recovery-token/attempt")
+}
+
+func (c *Sys) generateRootStatusCommonContext(ctx context.Context, path string) (*GenerateRootStatusResponse, error) {
+	r := c.c.NewRequest("GET", path)
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -31,18 +47,36 @@ func (c *Sys) generateRootStatusCommon(path string) (*GenerateRootStatusResponse
 }
 
 func (c *Sys) GenerateRootInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommon("/v1/sys/generate-root/attempt", otp, pgpKey)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRootInitContext(ctx, otp, pgpKey)
 }
 
 func (c *Sys) GenerateDROperationTokenInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt", otp, pgpKey)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateDROperationTokenInitContext(ctx, otp, pgpKey)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootInitCommon("/v1/sys/generate-recovery-token/attempt", otp, pgpKey)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRecoveryOperationTokenInitContext(ctx, otp, pgpKey)
 }
 
-func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+func (c *Sys) GenerateRootInitContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommonContext(ctx, "/v1/sys/generate-root/attempt", otp, pgpKey)
+}
+
+func (c *Sys) GenerateDROperationTokenInitContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt", otp, pgpKey)
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenInitContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootInitCommonContext(ctx, "/v1/sys/generate-recovery-token/attempt", otp, pgpKey)
+}
+
+func (c *Sys) generateRootInitCommonContext(ctx context.Context, path, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
 	body := map[string]interface{}{
 		"otp":     otp,
 		"pgp_key": pgpKey,
@@ -53,8 +87,6 @@ func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootSta
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -67,22 +99,38 @@ func (c *Sys) generateRootInitCommon(path, otp, pgpKey string) (*GenerateRootSta
 }
 
 func (c *Sys) GenerateRootCancel() error {
-	return c.generateRootCancelCommon("/v1/sys/generate-root/attempt")
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRootCancelContext(ctx)
 }
 
 func (c *Sys) GenerateDROperationTokenCancel() error {
-	return c.generateRootCancelCommon("/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateDROperationTokenCancelContext(ctx)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenCancel() error {
-	return c.generateRootCancelCommon("/v1/sys/generate-recovery-token/attempt")
-}
-
-func (c *Sys) generateRootCancelCommon(path string) error {
-	r := c.c.NewRequest("DELETE", path)
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.GenerateRecoveryOperationTokenCancelContext(ctx)
+}
+
+func (c *Sys) GenerateRootCancelContext(ctx context.Context) error {
+	return c.generateRootCancelCommonContext(ctx, "/v1/sys/generate-root/attempt")
+}
+
+func (c *Sys) GenerateDROperationTokenCancelContext(ctx context.Context) error {
+	return c.generateRootCancelCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/attempt")
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenCancelContext(ctx context.Context) error {
+	return c.generateRootCancelCommonContext(ctx, "/v1/sys/generate-recovery-token/attempt")
+}
+
+func (c *Sys) generateRootCancelCommonContext(ctx context.Context, path string) error {
+	r := c.c.NewRequest("DELETE", path)
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -91,18 +139,36 @@ func (c *Sys) generateRootCancelCommon(path string) error {
 }
 
 func (c *Sys) GenerateRootUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommon("/v1/sys/generate-root/update", shard, nonce)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRootUpdateContext(ctx, shard, nonce)
 }
 
 func (c *Sys) GenerateDROperationTokenUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommon("/v1/sys/replication/dr/secondary/generate-operation-token/update", shard, nonce)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateDROperationTokenUpdateContext(ctx, shard, nonce)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	return c.generateRootUpdateCommon("/v1/sys/generate-recovery-token/update", shard, nonce)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GenerateRecoveryOperationTokenUpdateContext(ctx, shard, nonce)
 }
 
-func (c *Sys) generateRootUpdateCommon(path, shard, nonce string) (*GenerateRootStatusResponse, error) {
+func (c *Sys) GenerateRootUpdateContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommonContext(ctx, "/v1/sys/generate-root/update", shard, nonce)
+}
+
+func (c *Sys) GenerateDROperationTokenUpdateContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommonContext(ctx, "/v1/sys/replication/dr/secondary/generate-operation-token/update", shard, nonce)
+}
+
+func (c *Sys) GenerateRecoveryOperationTokenUpdateContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {
+	return c.generateRootUpdateCommonContext(ctx, "/v1/sys/generate-recovery-token/update", shard, nonce)
+}
+
+func (c *Sys) generateRootUpdateCommonContext(ctx context.Context, path, shard, nonce string) (*GenerateRootStatusResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -113,8 +179,6 @@ func (c *Sys) generateRootUpdateCommon(path, shard, nonce string) (*GenerateRoot
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -32,7 +32,7 @@ func (c *Sys) generateRootStatusCommonWithContext(ctx context.Context, path stri
 
 	r := c.c.NewRequest("GET", path)
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (c *Sys) generateRootInitCommonWithContext(ctx context.Context, path, otp, 
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (c *Sys) generateRootCancelCommonWithContext(ctx context.Context, path stri
 
 	r := c.c.NewRequest("DELETE", path)
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -167,7 +167,7 @@ func (c *Sys) generateRootUpdateCommonWithContext(ctx context.Context, path, sha
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_generate_root.go
+++ b/api/sys_generate_root.go
@@ -3,21 +3,15 @@ package api
 import "context"
 
 func (c *Sys) GenerateRootStatus() (*GenerateRootStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateRootStatusWithContext(ctx)
+	return c.GenerateRootStatusWithContext(context.Background())
 }
 
 func (c *Sys) GenerateDROperationTokenStatus() (*GenerateRootStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateDROperationTokenStatusWithContext(ctx)
+	return c.GenerateDROperationTokenStatusWithContext(context.Background())
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenStatus() (*GenerateRootStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateRecoveryOperationTokenStatusWithContext(ctx)
+	return c.GenerateRecoveryOperationTokenStatusWithContext(context.Background())
 }
 
 func (c *Sys) GenerateRootStatusWithContext(ctx context.Context) (*GenerateRootStatusResponse, error) {
@@ -50,21 +44,15 @@ func (c *Sys) generateRootStatusCommonWithContext(ctx context.Context, path stri
 }
 
 func (c *Sys) GenerateRootInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateRootInitWithContext(ctx, otp, pgpKey)
+	return c.GenerateRootInitWithContext(context.Background(), otp, pgpKey)
 }
 
 func (c *Sys) GenerateDROperationTokenInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateDROperationTokenInitWithContext(ctx, otp, pgpKey)
+	return c.GenerateDROperationTokenInitWithContext(context.Background(), otp, pgpKey)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenInit(otp, pgpKey string) (*GenerateRootStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateRecoveryOperationTokenInitWithContext(ctx, otp, pgpKey)
+	return c.GenerateRecoveryOperationTokenInitWithContext(context.Background(), otp, pgpKey)
 }
 
 func (c *Sys) GenerateRootInitWithContext(ctx context.Context, otp, pgpKey string) (*GenerateRootStatusResponse, error) {
@@ -105,21 +93,15 @@ func (c *Sys) generateRootInitCommonWithContext(ctx context.Context, path, otp, 
 }
 
 func (c *Sys) GenerateRootCancel() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateRootCancelWithContext(ctx)
+	return c.GenerateRootCancelWithContext(context.Background())
 }
 
 func (c *Sys) GenerateDROperationTokenCancel() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateDROperationTokenCancelWithContext(ctx)
+	return c.GenerateDROperationTokenCancelWithContext(context.Background())
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenCancel() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateRecoveryOperationTokenCancelWithContext(ctx)
+	return c.GenerateRecoveryOperationTokenCancelWithContext(context.Background())
 }
 
 func (c *Sys) GenerateRootCancelWithContext(ctx context.Context) error {
@@ -148,21 +130,15 @@ func (c *Sys) generateRootCancelCommonWithContext(ctx context.Context, path stri
 }
 
 func (c *Sys) GenerateRootUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateRootUpdateWithContext(ctx, shard, nonce)
+	return c.GenerateRootUpdateWithContext(context.Background(), shard, nonce)
 }
 
 func (c *Sys) GenerateDROperationTokenUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateDROperationTokenUpdateWithContext(ctx, shard, nonce)
+	return c.GenerateDROperationTokenUpdateWithContext(context.Background(), shard, nonce)
 }
 
 func (c *Sys) GenerateRecoveryOperationTokenUpdate(shard, nonce string) (*GenerateRootStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GenerateRecoveryOperationTokenUpdateWithContext(ctx, shard, nonce)
+	return c.GenerateRecoveryOperationTokenUpdateWithContext(context.Background(), shard, nonce)
 }
 
 func (c *Sys) GenerateRootUpdateWithContext(ctx context.Context, shard, nonce string) (*GenerateRootStatusResponse, error) {

--- a/api/sys_hastatus.go
+++ b/api/sys_hastatus.go
@@ -6,10 +6,14 @@ import (
 )
 
 func (c *Sys) HAStatus() (*HAStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/ha-status")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.HAStatusContext(ctx)
+}
+
+func (c *Sys) HAStatusContext(ctx context.Context) (*HAStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/ha-status")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_hastatus.go
+++ b/api/sys_hastatus.go
@@ -15,7 +15,7 @@ func (c *Sys) HAStatusWithContext(ctx context.Context) (*HAStatusResponse, error
 
 	r := c.c.NewRequest("GET", "/v1/sys/ha-status")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_hastatus.go
+++ b/api/sys_hastatus.go
@@ -12,6 +12,9 @@ func (c *Sys) HAStatus() (*HAStatusResponse, error) {
 }
 
 func (c *Sys) HAStatusWithContext(ctx context.Context) (*HAStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/ha-status")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_hastatus.go
+++ b/api/sys_hastatus.go
@@ -6,9 +6,7 @@ import (
 )
 
 func (c *Sys) HAStatus() (*HAStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.HAStatusWithContext(ctx)
+	return c.HAStatusWithContext(context.Background())
 }
 
 func (c *Sys) HAStatusWithContext(ctx context.Context) (*HAStatusResponse, error) {

--- a/api/sys_hastatus.go
+++ b/api/sys_hastatus.go
@@ -8,10 +8,10 @@ import (
 func (c *Sys) HAStatus() (*HAStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.HAStatusContext(ctx)
+	return c.HAStatusWithContext(ctx)
 }
 
-func (c *Sys) HAStatusContext(ctx context.Context) (*HAStatusResponse, error) {
+func (c *Sys) HAStatusWithContext(ctx context.Context) (*HAStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/ha-status")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -3,9 +3,7 @@ package api
 import "context"
 
 func (c *Sys) Health() (*HealthResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.HealthWithContext(ctx)
+	return c.HealthWithContext(context.Background())
 }
 
 func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {

--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -17,7 +17,7 @@ func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {
 	r.Params.Add("drsecondarycode", "299")
 	r.Params.Add("performancestandbycode", "299")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -5,10 +5,10 @@ import "context"
 func (c *Sys) Health() (*HealthResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.HealthContext(ctx)
+	return c.HealthWithContext(ctx)
 }
 
-func (c *Sys) HealthContext(ctx context.Context) (*HealthResponse, error) {
+func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/health")
 	// If the code is 400 or above it will automatically turn into an error,
 	// but the sys/health API defaults to returning 5xx when not sealed or

--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -3,6 +3,12 @@ package api
 import "context"
 
 func (c *Sys) Health() (*HealthResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.HealthContext(ctx)
+}
+
+func (c *Sys) HealthContext(ctx context.Context) (*HealthResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/health")
 	// If the code is 400 or above it will automatically turn into an error,
 	// but the sys/health API defaults to returning 5xx when not sealed or
@@ -13,8 +19,6 @@ func (c *Sys) Health() (*HealthResponse, error) {
 	r.Params.Add("drsecondarycode", "299")
 	r.Params.Add("performancestandbycode", "299")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -3,10 +3,14 @@ package api
 import "context"
 
 func (c *Sys) InitStatus() (bool, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/init")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.InitStatusContext(ctx)
+}
+
+func (c *Sys) InitStatusContext(ctx context.Context) (bool, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/init")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return false, err
@@ -19,13 +23,17 @@ func (c *Sys) InitStatus() (bool, error) {
 }
 
 func (c *Sys) Init(opts *InitRequest) (*InitResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.InitContext(ctx, opts)
+}
+
+func (c *Sys) InitContext(ctx context.Context, opts *InitRequest) (*InitResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/init")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -5,10 +5,10 @@ import "context"
 func (c *Sys) InitStatus() (bool, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.InitStatusContext(ctx)
+	return c.InitStatusWithContext(ctx)
 }
 
-func (c *Sys) InitStatusContext(ctx context.Context) (bool, error) {
+func (c *Sys) InitStatusWithContext(ctx context.Context) (bool, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/init")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -25,10 +25,10 @@ func (c *Sys) InitStatusContext(ctx context.Context) (bool, error) {
 func (c *Sys) Init(opts *InitRequest) (*InitResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.InitContext(ctx, opts)
+	return c.InitWithContext(ctx, opts)
 }
 
-func (c *Sys) InitContext(ctx context.Context, opts *InitRequest) (*InitResponse, error) {
+func (c *Sys) InitWithContext(ctx context.Context, opts *InitRequest) (*InitResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/init")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err

--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -12,7 +12,7 @@ func (c *Sys) InitStatusWithContext(ctx context.Context) (bool, error) {
 
 	r := c.c.NewRequest("GET", "/v1/sys/init")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return false, err
 	}
@@ -36,7 +36,7 @@ func (c *Sys) InitWithContext(ctx context.Context, opts *InitRequest) (*InitResp
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -3,9 +3,7 @@ package api
 import "context"
 
 func (c *Sys) InitStatus() (bool, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.InitStatusWithContext(ctx)
+	return c.InitStatusWithContext(context.Background())
 }
 
 func (c *Sys) InitStatusWithContext(ctx context.Context) (bool, error) {
@@ -26,9 +24,7 @@ func (c *Sys) InitStatusWithContext(ctx context.Context) (bool, error) {
 }
 
 func (c *Sys) Init(opts *InitRequest) (*InitResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.InitWithContext(ctx, opts)
+	return c.InitWithContext(context.Background(), opts)
 }
 
 func (c *Sys) InitWithContext(ctx context.Context, opts *InitRequest) (*InitResponse, error) {

--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -9,6 +9,9 @@ func (c *Sys) InitStatus() (bool, error) {
 }
 
 func (c *Sys) InitStatusWithContext(ctx context.Context) (bool, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/init")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -29,6 +32,9 @@ func (c *Sys) Init(opts *InitRequest) (*InitResponse, error) {
 }
 
 func (c *Sys) InitWithContext(ctx context.Context, opts *InitRequest) (*InitResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/init")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -12,6 +12,9 @@ func (c *Sys) Leader() (*LeaderResponse, error) {
 }
 
 func (c *Sys) LeaderWithContext(ctx context.Context) (*LeaderResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/leader")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -15,7 +15,7 @@ func (c *Sys) LeaderWithContext(ctx context.Context) (*LeaderResponse, error) {
 
 	r := c.c.NewRequest("GET", "/v1/sys/leader")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -8,10 +8,10 @@ import (
 func (c *Sys) Leader() (*LeaderResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.LeaderContext(ctx)
+	return c.LeaderWithContext(ctx)
 }
 
-func (c *Sys) LeaderContext(ctx context.Context) (*LeaderResponse, error) {
+func (c *Sys) LeaderWithContext(ctx context.Context) (*LeaderResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/leader")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -6,10 +6,14 @@ import (
 )
 
 func (c *Sys) Leader() (*LeaderResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/leader")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.LeaderContext(ctx)
+}
+
+func (c *Sys) LeaderContext(ctx context.Context) (*LeaderResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/leader")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -6,9 +6,7 @@ import (
 )
 
 func (c *Sys) Leader() (*LeaderResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.LeaderWithContext(ctx)
+	return c.LeaderWithContext(context.Background())
 }
 
 func (c *Sys) LeaderWithContext(ctx context.Context) (*LeaderResponse, error) {

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -8,10 +8,10 @@ import (
 func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RenewContext(ctx, id, increment)
+	return c.RenewWithContext(ctx, id, increment)
 }
 
-func (c *Sys) RenewContext(ctx context.Context, id string, increment int) (*Secret, error) {
+func (c *Sys) RenewWithContext(ctx context.Context, id string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/renew")
 
 	body := map[string]interface{}{
@@ -34,10 +34,10 @@ func (c *Sys) RenewContext(ctx context.Context, id string, increment int) (*Secr
 func (c *Sys) Lookup(id string) (*Secret, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.LookupContext(ctx, id)
+	return c.LookupWithContext(ctx, id)
 }
 
-func (c *Sys) LookupContext(ctx context.Context, id string) (*Secret, error) {
+func (c *Sys) LookupWithContext(ctx context.Context, id string) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/lookup")
 
 	body := map[string]interface{}{
@@ -59,10 +59,10 @@ func (c *Sys) LookupContext(ctx context.Context, id string) (*Secret, error) {
 func (c *Sys) Revoke(id string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RevokeContext(ctx, id)
+	return c.RevokeWithContext(ctx, id)
 }
 
-func (c *Sys) RevokeContext(ctx context.Context, id string) error {
+func (c *Sys) RevokeWithContext(ctx context.Context, id string) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke")
 	body := map[string]interface{}{
 		"lease_id": id,
@@ -81,10 +81,10 @@ func (c *Sys) RevokeContext(ctx context.Context, id string) error {
 func (c *Sys) RevokePrefix(id string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RevokePrefixContext(ctx, id)
+	return c.RevokePrefixWithContext(ctx, id)
 }
 
-func (c *Sys) RevokePrefixContext(ctx context.Context, id string) error {
+func (c *Sys) RevokePrefixWithContext(ctx context.Context, id string) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-prefix/"+id)
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -97,10 +97,10 @@ func (c *Sys) RevokePrefixContext(ctx context.Context, id string) error {
 func (c *Sys) RevokeForce(id string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RevokeForceContext(ctx, id)
+	return c.RevokeForceWithContext(ctx, id)
 }
 
-func (c *Sys) RevokeForceContext(ctx context.Context, id string) error {
+func (c *Sys) RevokeForceWithContext(ctx context.Context, id string) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-force/"+id)
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -113,10 +113,10 @@ func (c *Sys) RevokeForceContext(ctx context.Context, id string) error {
 func (c *Sys) RevokeWithOptions(opts *RevokeOptions) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RevokeWithOptionsContext(ctx, opts)
+	return c.RevokeWithOptionsWithContext(ctx, opts)
 }
 
-func (c *Sys) RevokeWithOptionsContext(ctx context.Context, opts *RevokeOptions) error {
+func (c *Sys) RevokeWithOptionsWithContext(ctx context.Context, opts *RevokeOptions) error {
 	if opts == nil {
 		return errors.New("nil options provided")
 	}

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -12,6 +12,9 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 }
 
 func (c *Sys) RenewWithContext(ctx context.Context, id string, increment int) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/renew")
 
 	body := map[string]interface{}{
@@ -38,6 +41,9 @@ func (c *Sys) Lookup(id string) (*Secret, error) {
 }
 
 func (c *Sys) LookupWithContext(ctx context.Context, id string) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/lookup")
 
 	body := map[string]interface{}{
@@ -63,6 +69,9 @@ func (c *Sys) Revoke(id string) error {
 }
 
 func (c *Sys) RevokeWithContext(ctx context.Context, id string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke")
 	body := map[string]interface{}{
 		"lease_id": id,
@@ -85,6 +94,9 @@ func (c *Sys) RevokePrefix(id string) error {
 }
 
 func (c *Sys) RevokePrefixWithContext(ctx context.Context, id string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-prefix/"+id)
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -101,6 +113,9 @@ func (c *Sys) RevokeForce(id string) error {
 }
 
 func (c *Sys) RevokeForceWithContext(ctx context.Context, id string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-force/"+id)
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -117,6 +132,9 @@ func (c *Sys) RevokeWithOptions(opts *RevokeOptions) error {
 }
 
 func (c *Sys) RevokeWithOptionsWithContext(ctx context.Context, opts *RevokeOptions) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	if opts == nil {
 		return errors.New("nil options provided")
 	}

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -23,7 +23,7 @@ func (c *Sys) RenewWithContext(ctx context.Context, id string, increment int) (*
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (c *Sys) LookupWithContext(ctx context.Context, id string) (*Secret, error)
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (c *Sys) RevokeWithContext(ctx context.Context, id string) error {
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -91,7 +91,7 @@ func (c *Sys) RevokePrefixWithContext(ctx context.Context, id string) error {
 
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-prefix/"+id)
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -108,7 +108,7 @@ func (c *Sys) RevokeForceWithContext(ctx context.Context, id string) error {
 
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-force/"+id)
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -147,7 +147,7 @@ func (c *Sys) RevokeWithOptionsWithContext(ctx context.Context, opts *RevokeOpti
 		}
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -6,6 +6,12 @@ import (
 )
 
 func (c *Sys) Renew(id string, increment int) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RenewContext(ctx, id, increment)
+}
+
+func (c *Sys) RenewContext(ctx context.Context, id string, increment int) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/renew")
 
 	body := map[string]interface{}{
@@ -16,8 +22,6 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -28,6 +32,12 @@ func (c *Sys) Renew(id string, increment int) (*Secret, error) {
 }
 
 func (c *Sys) Lookup(id string) (*Secret, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.LookupContext(ctx, id)
+}
+
+func (c *Sys) LookupContext(ctx context.Context, id string) (*Secret, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/lookup")
 
 	body := map[string]interface{}{
@@ -37,8 +47,6 @@ func (c *Sys) Lookup(id string) (*Secret, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -49,6 +57,12 @@ func (c *Sys) Lookup(id string) (*Secret, error) {
 }
 
 func (c *Sys) Revoke(id string) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RevokeContext(ctx, id)
+}
+
+func (c *Sys) RevokeContext(ctx context.Context, id string) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke")
 	body := map[string]interface{}{
 		"lease_id": id,
@@ -57,8 +71,6 @@ func (c *Sys) Revoke(id string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -67,10 +79,14 @@ func (c *Sys) Revoke(id string) error {
 }
 
 func (c *Sys) RevokePrefix(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-prefix/"+id)
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RevokePrefixContext(ctx, id)
+}
+
+func (c *Sys) RevokePrefixContext(ctx context.Context, id string) error {
+	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-prefix/"+id)
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -79,10 +95,14 @@ func (c *Sys) RevokePrefix(id string) error {
 }
 
 func (c *Sys) RevokeForce(id string) error {
-	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-force/"+id)
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RevokeForceContext(ctx, id)
+}
+
+func (c *Sys) RevokeForceContext(ctx context.Context, id string) error {
+	r := c.c.NewRequest("PUT", "/v1/sys/leases/revoke-force/"+id)
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -91,6 +111,12 @@ func (c *Sys) RevokeForce(id string) error {
 }
 
 func (c *Sys) RevokeWithOptions(opts *RevokeOptions) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RevokeWithOptionsContext(ctx, opts)
+}
+
+func (c *Sys) RevokeWithOptionsContext(ctx context.Context, opts *RevokeOptions) error {
 	if opts == nil {
 		return errors.New("nil options provided")
 	}
@@ -115,8 +141,6 @@ func (c *Sys) RevokeWithOptions(opts *RevokeOptions) error {
 		}
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()

--- a/api/sys_leases.go
+++ b/api/sys_leases.go
@@ -6,9 +6,7 @@ import (
 )
 
 func (c *Sys) Renew(id string, increment int) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RenewWithContext(ctx, id, increment)
+	return c.RenewWithContext(context.Background(), id, increment)
 }
 
 func (c *Sys) RenewWithContext(ctx context.Context, id string, increment int) (*Secret, error) {
@@ -35,9 +33,7 @@ func (c *Sys) RenewWithContext(ctx context.Context, id string, increment int) (*
 }
 
 func (c *Sys) Lookup(id string) (*Secret, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.LookupWithContext(ctx, id)
+	return c.LookupWithContext(context.Background(), id)
 }
 
 func (c *Sys) LookupWithContext(ctx context.Context, id string) (*Secret, error) {
@@ -63,9 +59,7 @@ func (c *Sys) LookupWithContext(ctx context.Context, id string) (*Secret, error)
 }
 
 func (c *Sys) Revoke(id string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RevokeWithContext(ctx, id)
+	return c.RevokeWithContext(context.Background(), id)
 }
 
 func (c *Sys) RevokeWithContext(ctx context.Context, id string) error {
@@ -88,9 +82,7 @@ func (c *Sys) RevokeWithContext(ctx context.Context, id string) error {
 }
 
 func (c *Sys) RevokePrefix(id string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RevokePrefixWithContext(ctx, id)
+	return c.RevokePrefixWithContext(context.Background(), id)
 }
 
 func (c *Sys) RevokePrefixWithContext(ctx context.Context, id string) error {
@@ -107,9 +99,7 @@ func (c *Sys) RevokePrefixWithContext(ctx context.Context, id string) error {
 }
 
 func (c *Sys) RevokeForce(id string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RevokeForceWithContext(ctx, id)
+	return c.RevokeForceWithContext(context.Background(), id)
 }
 
 func (c *Sys) RevokeForceWithContext(ctx context.Context, id string) error {
@@ -126,9 +116,7 @@ func (c *Sys) RevokeForceWithContext(ctx context.Context, id string) error {
 }
 
 func (c *Sys) RevokeWithOptions(opts *RevokeOptions) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RevokeWithOptionsWithContext(ctx, opts)
+	return c.RevokeWithOptionsWithContext(context.Background(), opts)
 }
 
 func (c *Sys) RevokeWithOptionsWithContext(ctx context.Context, opts *RevokeOptions) error {

--- a/api/sys_monitor.go
+++ b/api/sys_monitor.go
@@ -17,7 +17,7 @@ func (c *Sys) Monitor(ctx context.Context, logLevel string) (chan string, error)
 		r.Params.Add("log_level", logLevel)
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -16,6 +16,9 @@ func (c *Sys) ListMounts() (map[string]*MountOutput, error) {
 }
 
 func (c *Sys) ListMountsWithContext(ctx context.Context) (map[string]*MountOutput, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/mounts")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -48,6 +51,9 @@ func (c *Sys) Mount(path string, mountInfo *MountInput) error {
 }
 
 func (c *Sys) MountWithContext(ctx context.Context, path string, mountInfo *MountInput) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s", path))
 	if err := r.SetJSONBody(mountInfo); err != nil {
 		return err
@@ -69,6 +75,9 @@ func (c *Sys) Unmount(path string) error {
 }
 
 func (c *Sys) UnmountWithContext(ctx context.Context, path string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/mounts/%s", path))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -86,7 +95,7 @@ func (c *Sys) Remount(from, to string) error {
 }
 
 // RemountWithContext kicks off a remount operation, polls the status endpoint using
-// // the migration ID till either success or failure state is observed
+// the migration ID till either success or failure state is observed
 func (c *Sys) RemountWithContext(ctx context.Context, from, to string) error {
 	remountResp, err := c.StartRemountWithContext(ctx, from, to)
 	if err != nil {
@@ -117,6 +126,9 @@ func (c *Sys) StartRemount(from, to string) (*MountMigrationOutput, error) {
 
 // StartRemountWithContext kicks off a mount migration and returns a response with the migration ID
 func (c *Sys) StartRemountWithContext(ctx context.Context, from, to string) (*MountMigrationOutput, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]interface{}{
 		"from": from,
 		"to":   to,
@@ -158,6 +170,9 @@ func (c *Sys) RemountStatus(migrationID string) (*MountMigrationStatusOutput, er
 
 // RemountStatusWithContext checks the status of a mount migration operation with the provided ID
 func (c *Sys) RemountStatusWithContext(ctx context.Context, migrationID string) (*MountMigrationStatusOutput, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/remount/status/%s", migrationID))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -189,6 +204,9 @@ func (c *Sys) TuneMount(path string, config MountConfigInput) error {
 }
 
 func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config MountConfigInput) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 	if err := r.SetJSONBody(config); err != nil {
 		return err
@@ -208,6 +226,9 @@ func (c *Sys) MountConfig(path string) (*MountConfigOutput, error) {
 }
 
 func (c *Sys) MountConfigWithContext(ctx context.Context, path string) (*MountConfigOutput, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -19,7 +19,7 @@ func (c *Sys) ListMountsWithContext(ctx context.Context) (map[string]*MountOutpu
 
 	r := c.c.NewRequest("GET", "/v1/sys/mounts")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (c *Sys) MountWithContext(ctx context.Context, path string, mountInfo *Moun
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (c *Sys) UnmountWithContext(ctx context.Context, path string) error {
 
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/mounts/%s", path))
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -129,7 +129,7 @@ func (c *Sys) StartRemountWithContext(ctx context.Context, from, to string) (*Mo
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (c *Sys) RemountStatusWithContext(ctx context.Context, migrationID string) 
 
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/remount/status/%s", migrationID))
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config Moun
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -215,7 +215,7 @@ func (c *Sys) MountConfigWithContext(ctx context.Context, path string) (*MountCo
 
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -78,15 +78,15 @@ func (c *Sys) UnmountWithContext(ctx context.Context, path string) error {
 	return err
 }
 
-// Remount kicks off a remount operation, polls the status endpoint using
-// the migration ID till either success or failure state is observed
+// Remount wraps RemountWithContext using context.Background.
 func (c *Sys) Remount(from, to string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RemountWithContext(ctx, from, to)
 }
 
-// RemountWithContext the same as Remount but with a custom context.
+// RemountWithContext kicks off a remount operation, polls the status endpoint using
+// // the migration ID till either success or failure state is observed
 func (c *Sys) RemountWithContext(ctx context.Context, from, to string) error {
 	remountResp, err := c.StartRemountWithContext(ctx, from, to)
 	if err != nil {
@@ -108,14 +108,14 @@ func (c *Sys) RemountWithContext(ctx context.Context, from, to string) error {
 	}
 }
 
-// StartRemount kicks off a mount migration and returns a response with the migration ID
+// StartRemount wraps StartRemountWithContext using context.Background.
 func (c *Sys) StartRemount(from, to string) (*MountMigrationOutput, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.StartRemountWithContext(ctx, from, to)
 }
 
-// StartRemountWithContext the same as StartRemount but with a custom context.
+// StartRemountWithContext kicks off a mount migration and returns a response with the migration ID
 func (c *Sys) StartRemountWithContext(ctx context.Context, from, to string) (*MountMigrationOutput, error) {
 	body := map[string]interface{}{
 		"from": from,
@@ -149,14 +149,14 @@ func (c *Sys) StartRemountWithContext(ctx context.Context, from, to string) (*Mo
 	return &result, err
 }
 
-// RemountStatus checks the status of a mount migration operation with the provided ID
+// RemountStatus wraps RemountStatusWithContext using context.Background.
 func (c *Sys) RemountStatus(migrationID string) (*MountMigrationStatusOutput, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RemountStatusWithContext(ctx, migrationID)
 }
 
-// RemountStatusWithContext the same as RemountStatus but with a custom context.
+// RemountStatusWithContext checks the status of a mount migration operation with the provided ID
 func (c *Sys) RemountStatusWithContext(ctx context.Context, migrationID string) (*MountMigrationStatusOutput, error) {
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/remount/status/%s", migrationID))
 

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -10,9 +10,7 @@ import (
 )
 
 func (c *Sys) ListMounts() (map[string]*MountOutput, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ListMountsWithContext(ctx)
+	return c.ListMountsWithContext(context.Background())
 }
 
 func (c *Sys) ListMountsWithContext(ctx context.Context) (map[string]*MountOutput, error) {
@@ -45,9 +43,7 @@ func (c *Sys) ListMountsWithContext(ctx context.Context) (map[string]*MountOutpu
 }
 
 func (c *Sys) Mount(path string, mountInfo *MountInput) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.MountWithContext(ctx, path, mountInfo)
+	return c.MountWithContext(context.Background(), path, mountInfo)
 }
 
 func (c *Sys) MountWithContext(ctx context.Context, path string, mountInfo *MountInput) error {
@@ -69,9 +65,7 @@ func (c *Sys) MountWithContext(ctx context.Context, path string, mountInfo *Moun
 }
 
 func (c *Sys) Unmount(path string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.UnmountWithContext(ctx, path)
+	return c.UnmountWithContext(context.Background(), path)
 }
 
 func (c *Sys) UnmountWithContext(ctx context.Context, path string) error {
@@ -89,9 +83,7 @@ func (c *Sys) UnmountWithContext(ctx context.Context, path string) error {
 
 // Remount wraps RemountWithContext using context.Background.
 func (c *Sys) Remount(from, to string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RemountWithContext(ctx, from, to)
+	return c.RemountWithContext(context.Background(), from, to)
 }
 
 // RemountWithContext kicks off a remount operation, polls the status endpoint using
@@ -119,9 +111,7 @@ func (c *Sys) RemountWithContext(ctx context.Context, from, to string) error {
 
 // StartRemount wraps StartRemountWithContext using context.Background.
 func (c *Sys) StartRemount(from, to string) (*MountMigrationOutput, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.StartRemountWithContext(ctx, from, to)
+	return c.StartRemountWithContext(context.Background(), from, to)
 }
 
 // StartRemountWithContext kicks off a mount migration and returns a response with the migration ID
@@ -163,9 +153,7 @@ func (c *Sys) StartRemountWithContext(ctx context.Context, from, to string) (*Mo
 
 // RemountStatus wraps RemountStatusWithContext using context.Background.
 func (c *Sys) RemountStatus(migrationID string) (*MountMigrationStatusOutput, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RemountStatusWithContext(ctx, migrationID)
+	return c.RemountStatusWithContext(context.Background(), migrationID)
 }
 
 // RemountStatusWithContext checks the status of a mount migration operation with the provided ID
@@ -198,9 +186,7 @@ func (c *Sys) RemountStatusWithContext(ctx context.Context, migrationID string) 
 }
 
 func (c *Sys) TuneMount(path string, config MountConfigInput) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.TuneMountWithContext(ctx, path, config)
+	return c.TuneMountWithContext(context.Background(), path, config)
 }
 
 func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config MountConfigInput) error {
@@ -220,9 +206,7 @@ func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config Moun
 }
 
 func (c *Sys) MountConfig(path string) (*MountConfigOutput, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.MountConfigWithContext(ctx, path)
+	return c.MountConfigWithContext(context.Background(), path)
 }
 
 func (c *Sys) MountConfigWithContext(ctx context.Context, path string) (*MountConfigOutput, error) {

--- a/api/sys_mounts.go
+++ b/api/sys_mounts.go
@@ -12,10 +12,10 @@ import (
 func (c *Sys) ListMounts() (map[string]*MountOutput, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ListMountsContext(ctx)
+	return c.ListMountsWithContext(ctx)
 }
 
-func (c *Sys) ListMountsContext(ctx context.Context) (map[string]*MountOutput, error) {
+func (c *Sys) ListMountsWithContext(ctx context.Context) (map[string]*MountOutput, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/mounts")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -44,10 +44,10 @@ func (c *Sys) ListMountsContext(ctx context.Context) (map[string]*MountOutput, e
 func (c *Sys) Mount(path string, mountInfo *MountInput) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.MountContext(ctx, path, mountInfo)
+	return c.MountWithContext(ctx, path, mountInfo)
 }
 
-func (c *Sys) MountContext(ctx context.Context, path string, mountInfo *MountInput) error {
+func (c *Sys) MountWithContext(ctx context.Context, path string, mountInfo *MountInput) error {
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s", path))
 	if err := r.SetJSONBody(mountInfo); err != nil {
 		return err
@@ -65,10 +65,10 @@ func (c *Sys) MountContext(ctx context.Context, path string, mountInfo *MountInp
 func (c *Sys) Unmount(path string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.UnmountContext(ctx, path)
+	return c.UnmountWithContext(ctx, path)
 }
 
-func (c *Sys) UnmountContext(ctx context.Context, path string) error {
+func (c *Sys) UnmountWithContext(ctx context.Context, path string) error {
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/mounts/%s", path))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -83,18 +83,18 @@ func (c *Sys) UnmountContext(ctx context.Context, path string) error {
 func (c *Sys) Remount(from, to string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RemountContext(ctx, from, to)
+	return c.RemountWithContext(ctx, from, to)
 }
 
-// RemountContext the same as Remount but with a custom context.
-func (c *Sys) RemountContext(ctx context.Context, from, to string) error {
-	remountResp, err := c.StartRemountContext(ctx, from, to)
+// RemountWithContext the same as Remount but with a custom context.
+func (c *Sys) RemountWithContext(ctx context.Context, from, to string) error {
+	remountResp, err := c.StartRemountWithContext(ctx, from, to)
 	if err != nil {
 		return err
 	}
 
 	for {
-		remountStatusResp, err := c.RemountStatusContext(ctx, remountResp.MigrationID)
+		remountStatusResp, err := c.RemountStatusWithContext(ctx, remountResp.MigrationID)
 		if err != nil {
 			return err
 		}
@@ -112,11 +112,11 @@ func (c *Sys) RemountContext(ctx context.Context, from, to string) error {
 func (c *Sys) StartRemount(from, to string) (*MountMigrationOutput, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.StartRemountContext(ctx, from, to)
+	return c.StartRemountWithContext(ctx, from, to)
 }
 
-// StartRemountContext the same as StartRemount but with a custom context.
-func (c *Sys) StartRemountContext(ctx context.Context, from, to string) (*MountMigrationOutput, error) {
+// StartRemountWithContext the same as StartRemount but with a custom context.
+func (c *Sys) StartRemountWithContext(ctx context.Context, from, to string) (*MountMigrationOutput, error) {
 	body := map[string]interface{}{
 		"from": from,
 		"to":   to,
@@ -153,11 +153,11 @@ func (c *Sys) StartRemountContext(ctx context.Context, from, to string) (*MountM
 func (c *Sys) RemountStatus(migrationID string) (*MountMigrationStatusOutput, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RemountStatusContext(ctx, migrationID)
+	return c.RemountStatusWithContext(ctx, migrationID)
 }
 
-// RemountStatusContext the same as RemountStatus but with a custom context.
-func (c *Sys) RemountStatusContext(ctx context.Context, migrationID string) (*MountMigrationStatusOutput, error) {
+// RemountStatusWithContext the same as RemountStatus but with a custom context.
+func (c *Sys) RemountStatusWithContext(ctx context.Context, migrationID string) (*MountMigrationStatusOutput, error) {
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/remount/status/%s", migrationID))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -185,10 +185,10 @@ func (c *Sys) RemountStatusContext(ctx context.Context, migrationID string) (*Mo
 func (c *Sys) TuneMount(path string, config MountConfigInput) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.TuneMountContext(ctx, path, config)
+	return c.TuneMountWithContext(ctx, path, config)
 }
 
-func (c *Sys) TuneMountContext(ctx context.Context, path string, config MountConfigInput) error {
+func (c *Sys) TuneMountWithContext(ctx context.Context, path string, config MountConfigInput) error {
 	r := c.c.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 	if err := r.SetJSONBody(config); err != nil {
 		return err
@@ -204,10 +204,10 @@ func (c *Sys) TuneMountContext(ctx context.Context, path string, config MountCon
 func (c *Sys) MountConfig(path string) (*MountConfigOutput, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.MountConfigContext(ctx, path)
+	return c.MountConfigWithContext(ctx, path)
 }
 
-func (c *Sys) MountConfigContext(ctx context.Context, path string) (*MountConfigOutput, error) {
+func (c *Sys) MountConfigWithContext(ctx context.Context, path string) (*MountConfigOutput, error) {
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -31,9 +31,7 @@ type ListPluginsResponse struct {
 
 // ListPlugins wraps ListPluginsWithContext using context.Background.
 func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ListPluginsWithContext(ctx, i)
+	return c.ListPluginsWithContext(context.Background(), i)
 }
 
 // ListPluginsWithContext lists all plugins in the catalog and returns their names as a
@@ -152,9 +150,7 @@ type GetPluginResponse struct {
 
 // GetPlugin wraps GetPluginWithContext using context.Background.
 func (c *Sys) GetPlugin(i *GetPluginInput) (*GetPluginResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GetPluginWithContext(ctx, i)
+	return c.GetPluginWithContext(context.Background(), i)
 }
 
 // GetPluginWithContext retrieves information about the plugin.
@@ -201,9 +197,7 @@ type RegisterPluginInput struct {
 
 // RegisterPlugin wraps RegisterPluginWithContext using context.Background.
 func (c *Sys) RegisterPlugin(i *RegisterPluginInput) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RegisterPluginWithContext(ctx, i)
+	return c.RegisterPluginWithContext(context.Background(), i)
 }
 
 // RegisterPluginWithContext registers the plugin with the given information.
@@ -236,9 +230,7 @@ type DeregisterPluginInput struct {
 
 // DeregisterPlugin wraps DeregisterPluginWithContext using context.Background.
 func (c *Sys) DeregisterPlugin(i *DeregisterPluginInput) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.DeregisterPluginWithContext(ctx, i)
+	return c.DeregisterPluginWithContext(context.Background(), i)
 }
 
 // DeregisterPluginWithContext removes the plugin with the given name from the plugin
@@ -271,9 +263,7 @@ type ReloadPluginInput struct {
 
 // ReloadPlugin wraps ReloadPluginWithContext using context.Background.
 func (c *Sys) ReloadPlugin(i *ReloadPluginInput) (string, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ReloadPluginWithContext(ctx, i)
+	return c.ReloadPluginWithContext(context.Background(), i)
 }
 
 // ReloadPluginWithContext reloads mounted plugin backends, possibly returning
@@ -328,9 +318,7 @@ type ReloadPluginStatusInput struct {
 
 // ReloadPluginStatus wraps ReloadPluginStatusWithContext using context.Background.
 func (c *Sys) ReloadPluginStatus(reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ReloadPluginStatusWithContext(ctx, reloadStatusInput)
+	return c.ReloadPluginStatusWithContext(context.Background(), reloadStatusInput)
 }
 
 // ReloadPluginStatusWithContext retrieves the status of a reload operation

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -29,15 +29,15 @@ type ListPluginsResponse struct {
 	Names []string `json:"names"`
 }
 
-// ListPlugins lists all plugins in the catalog and returns their names as a
-// list of strings.
+// ListPlugins wraps ListPluginsWithContext using context.Background.
 func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.ListPluginsWithContext(ctx, i)
 }
 
-// ListPluginsWithContext the same as ListPlugins but with a custom context.
+// ListPluginsWithContext lists all plugins in the catalog and returns their names as a
+// // list of strings.
 func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (*ListPluginsResponse, error) {
 	path := ""
 	method := ""
@@ -147,14 +147,14 @@ type GetPluginResponse struct {
 	SHA256  string   `json:"sha256"`
 }
 
-// GetPlugin retrieves information about the plugin.
+// GetPlugin wraps GetPluginWithContext using context.Background.
 func (c *Sys) GetPlugin(i *GetPluginInput) (*GetPluginResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.GetPluginWithContext(ctx, i)
 }
 
-// GetPluginWithContext the same as GetPlugin but with a custom context.
+// GetPluginWithContext retrieves information about the plugin.
 func (c *Sys) GetPluginWithContext(ctx context.Context, i *GetPluginInput) (*GetPluginResponse, error) {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodGet, path)
@@ -193,14 +193,14 @@ type RegisterPluginInput struct {
 	SHA256 string `json:"sha256,omitempty"`
 }
 
-// RegisterPlugin registers the plugin with the given information.
+// RegisterPlugin wraps RegisterPluginWithContext using context.Background.
 func (c *Sys) RegisterPlugin(i *RegisterPluginInput) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RegisterPluginWithContext(ctx, i)
 }
 
-// RegisterPluginWithContext the same as RegisterPlugin but with a custom context.
+// RegisterPluginWithContext registers the plugin with the given information.
 func (c *Sys) RegisterPluginWithContext(ctx context.Context, i *RegisterPluginInput) error {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodPut, path)
@@ -225,15 +225,15 @@ type DeregisterPluginInput struct {
 	Type consts.PluginType `json:"type"`
 }
 
-// DeregisterPlugin removes the plugin with the given name from the plugin
-// catalog.
+// DeregisterPlugin wraps DeregisterPluginWithContext using context.Background.
 func (c *Sys) DeregisterPlugin(i *DeregisterPluginInput) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.DeregisterPluginWithContext(ctx, i)
 }
 
-// DeregisterPluginWithContext the same as DeregisterPlugin but with a custom context.
+// DeregisterPluginWithContext removes the plugin with the given name from the plugin
+// // catalog.
 func (c *Sys) DeregisterPluginWithContext(ctx context.Context, i *DeregisterPluginInput) error {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodDelete, path)
@@ -257,15 +257,15 @@ type ReloadPluginInput struct {
 	Scope string `json:"scope"`
 }
 
-// ReloadPlugin reloads mounted plugin backends, possibly returning
-// reloadId for a cluster scoped reload
+// ReloadPlugin wraps ReloadPluginWithContext using context.Background.
 func (c *Sys) ReloadPlugin(i *ReloadPluginInput) (string, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.ReloadPluginWithContext(ctx, i)
 }
 
-// ReloadPluginWithContext the same as ReloadPlugin but with a custom context.
+// ReloadPluginWithContext reloads mounted plugin backends, possibly returning
+// // reloadId for a cluster scoped reload
 func (c *Sys) ReloadPluginWithContext(ctx context.Context, i *ReloadPluginInput) (string, error) {
 	path := "/v1/sys/plugins/reload/backend"
 	req := c.c.NewRequest(http.MethodPut, path)
@@ -311,14 +311,14 @@ type ReloadPluginStatusInput struct {
 	ReloadID string `json:"reload_id"`
 }
 
-// ReloadPluginStatus retrieves the status of a reload operation
+// ReloadPluginStatus wraps ReloadPluginStatusWithContext using context.Background.
 func (c *Sys) ReloadPluginStatus(reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.ReloadPluginStatusWithContext(ctx, reloadStatusInput)
 }
 
-// ReloadPluginStatusWithContext the same as ReloadPluginStatus but with a custom context.
+// ReloadPluginStatusWithContext retrieves the status of a reload operation
 func (c *Sys) ReloadPluginStatusWithContext(ctx context.Context, reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
 	path := "/v1/sys/plugins/reload/backend/status"
 	req := c.c.NewRequest(http.MethodGet, path)

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -58,7 +58,7 @@ func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (
 		req.Params.Set("list", "true")
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, req)
+	resp, err := c.c.rawRequestWithContext(ctx, req)
 	if err != nil && resp == nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (
 	// switch it to a LIST.
 	if resp.StatusCode == 405 {
 		req.Params.Set("list", "true")
-		resp, err := c.c.RawRequestWithContext(ctx, req)
+		resp, err := c.c.rawRequestWithContext(ctx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -161,7 +161,7 @@ func (c *Sys) GetPluginWithContext(ctx context.Context, i *GetPluginInput) (*Get
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodGet, path)
 
-	resp, err := c.c.RawRequestWithContext(ctx, req)
+	resp, err := c.c.rawRequestWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (c *Sys) RegisterPluginWithContext(ctx context.Context, i *RegisterPluginIn
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, req)
+	resp, err := c.c.rawRequestWithContext(ctx, req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -242,7 +242,7 @@ func (c *Sys) DeregisterPluginWithContext(ctx context.Context, i *DeregisterPlug
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodDelete, path)
 
-	resp, err := c.c.RawRequestWithContext(ctx, req)
+	resp, err := c.c.rawRequestWithContext(ctx, req)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -279,7 +279,7 @@ func (c *Sys) ReloadPluginWithContext(ctx context.Context, i *ReloadPluginInput)
 		return "", err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, req)
+	resp, err := c.c.rawRequestWithContext(ctx, req)
 	if err != nil {
 		return "", err
 	}
@@ -330,7 +330,7 @@ func (c *Sys) ReloadPluginStatusWithContext(ctx context.Context, reloadStatusInp
 	req := c.c.NewRequest(http.MethodGet, path)
 	req.Params.Add("reload_id", reloadStatusInput.ReloadID)
 
-	resp, err := c.c.RawRequestWithContext(ctx, req)
+	resp, err := c.c.rawRequestWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -37,8 +37,11 @@ func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 }
 
 // ListPluginsWithContext lists all plugins in the catalog and returns their names as a
-// // list of strings.
+// list of strings.
 func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (*ListPluginsResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	path := ""
 	method := ""
 	if i.Type == consts.PluginTypeUnknown {
@@ -156,6 +159,9 @@ func (c *Sys) GetPlugin(i *GetPluginInput) (*GetPluginResponse, error) {
 
 // GetPluginWithContext retrieves information about the plugin.
 func (c *Sys) GetPluginWithContext(ctx context.Context, i *GetPluginInput) (*GetPluginResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodGet, path)
 
@@ -202,6 +208,9 @@ func (c *Sys) RegisterPlugin(i *RegisterPluginInput) error {
 
 // RegisterPluginWithContext registers the plugin with the given information.
 func (c *Sys) RegisterPluginWithContext(ctx context.Context, i *RegisterPluginInput) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodPut, path)
 
@@ -233,8 +242,11 @@ func (c *Sys) DeregisterPlugin(i *DeregisterPluginInput) error {
 }
 
 // DeregisterPluginWithContext removes the plugin with the given name from the plugin
-// // catalog.
+// catalog.
 func (c *Sys) DeregisterPluginWithContext(ctx context.Context, i *DeregisterPluginInput) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodDelete, path)
 
@@ -265,8 +277,11 @@ func (c *Sys) ReloadPlugin(i *ReloadPluginInput) (string, error) {
 }
 
 // ReloadPluginWithContext reloads mounted plugin backends, possibly returning
-// // reloadId for a cluster scoped reload
+// reloadId for a cluster scoped reload
 func (c *Sys) ReloadPluginWithContext(ctx context.Context, i *ReloadPluginInput) (string, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	path := "/v1/sys/plugins/reload/backend"
 	req := c.c.NewRequest(http.MethodPut, path)
 
@@ -320,6 +335,9 @@ func (c *Sys) ReloadPluginStatus(reloadStatusInput *ReloadPluginStatusInput) (*R
 
 // ReloadPluginStatusWithContext retrieves the status of a reload operation
 func (c *Sys) ReloadPluginStatusWithContext(ctx context.Context, reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	path := "/v1/sys/plugins/reload/backend/status"
 	req := c.c.NewRequest(http.MethodGet, path)
 	req.Params.Add("reload_id", reloadStatusInput.ReloadID)

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -32,6 +32,13 @@ type ListPluginsResponse struct {
 // ListPlugins lists all plugins in the catalog and returns their names as a
 // list of strings.
 func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ListPluginsContext(ctx, i)
+}
+
+// ListPluginsContext the same as ListPlugins but with a custom context.
+func (c *Sys) ListPluginsContext(ctx context.Context, i *ListPluginsInput) (*ListPluginsResponse, error) {
 	path := ""
 	method := ""
 	if i.Type == consts.PluginTypeUnknown {
@@ -50,8 +57,6 @@ func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 		req.Params.Set("list", "true")
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err != nil && resp == nil {
 		return nil, err
@@ -144,11 +149,16 @@ type GetPluginResponse struct {
 
 // GetPlugin retrieves information about the plugin.
 func (c *Sys) GetPlugin(i *GetPluginInput) (*GetPluginResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.GetPluginContext(ctx, i)
+}
+
+// GetPluginContext the same as GetPlugin but with a custom context.
+func (c *Sys) GetPluginContext(ctx context.Context, i *GetPluginInput) (*GetPluginResponse, error) {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodGet, path)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err != nil {
 		return nil, err
@@ -185,6 +195,13 @@ type RegisterPluginInput struct {
 
 // RegisterPlugin registers the plugin with the given information.
 func (c *Sys) RegisterPlugin(i *RegisterPluginInput) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RegisterPluginContext(ctx, i)
+}
+
+// RegisterPluginContext the same as RegisterPlugin but with a custom context.
+func (c *Sys) RegisterPluginContext(ctx context.Context, i *RegisterPluginInput) error {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodPut, path)
 
@@ -192,8 +209,6 @@ func (c *Sys) RegisterPlugin(i *RegisterPluginInput) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err == nil {
 		defer resp.Body.Close()
@@ -213,11 +228,16 @@ type DeregisterPluginInput struct {
 // DeregisterPlugin removes the plugin with the given name from the plugin
 // catalog.
 func (c *Sys) DeregisterPlugin(i *DeregisterPluginInput) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.DeregisterPluginContext(ctx, i)
+}
+
+// DeregisterPluginContext the same as DeregisterPlugin but with a custom context.
+func (c *Sys) DeregisterPluginContext(ctx context.Context, i *DeregisterPluginInput) error {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodDelete, path)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err == nil {
 		defer resp.Body.Close()
@@ -240,15 +260,19 @@ type ReloadPluginInput struct {
 // ReloadPlugin reloads mounted plugin backends, possibly returning
 // reloadId for a cluster scoped reload
 func (c *Sys) ReloadPlugin(i *ReloadPluginInput) (string, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ReloadPluginContext(ctx, i)
+}
+
+// ReloadPluginContext the same as ReloadPlugin but with a custom context.
+func (c *Sys) ReloadPluginContext(ctx context.Context, i *ReloadPluginInput) (string, error) {
 	path := "/v1/sys/plugins/reload/backend"
 	req := c.c.NewRequest(http.MethodPut, path)
 
 	if err := req.SetJSONBody(i); err != nil {
 		return "", err
 	}
-
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err != nil {
@@ -289,12 +313,16 @@ type ReloadPluginStatusInput struct {
 
 // ReloadPluginStatus retrieves the status of a reload operation
 func (c *Sys) ReloadPluginStatus(reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ReloadPluginStatusContext(ctx, reloadStatusInput)
+}
+
+// ReloadPluginStatusContext the same as ReloadPluginStatus but with a custom context.
+func (c *Sys) ReloadPluginStatusContext(ctx context.Context, reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
 	path := "/v1/sys/plugins/reload/backend/status"
 	req := c.c.NewRequest(http.MethodGet, path)
 	req.Params.Add("reload_id", reloadStatusInput.ReloadID)
-
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 
 	resp, err := c.c.RawRequestWithContext(ctx, req)
 	if err != nil {

--- a/api/sys_plugins.go
+++ b/api/sys_plugins.go
@@ -34,11 +34,11 @@ type ListPluginsResponse struct {
 func (c *Sys) ListPlugins(i *ListPluginsInput) (*ListPluginsResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ListPluginsContext(ctx, i)
+	return c.ListPluginsWithContext(ctx, i)
 }
 
-// ListPluginsContext the same as ListPlugins but with a custom context.
-func (c *Sys) ListPluginsContext(ctx context.Context, i *ListPluginsInput) (*ListPluginsResponse, error) {
+// ListPluginsWithContext the same as ListPlugins but with a custom context.
+func (c *Sys) ListPluginsWithContext(ctx context.Context, i *ListPluginsInput) (*ListPluginsResponse, error) {
 	path := ""
 	method := ""
 	if i.Type == consts.PluginTypeUnknown {
@@ -151,11 +151,11 @@ type GetPluginResponse struct {
 func (c *Sys) GetPlugin(i *GetPluginInput) (*GetPluginResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GetPluginContext(ctx, i)
+	return c.GetPluginWithContext(ctx, i)
 }
 
-// GetPluginContext the same as GetPlugin but with a custom context.
-func (c *Sys) GetPluginContext(ctx context.Context, i *GetPluginInput) (*GetPluginResponse, error) {
+// GetPluginWithContext the same as GetPlugin but with a custom context.
+func (c *Sys) GetPluginWithContext(ctx context.Context, i *GetPluginInput) (*GetPluginResponse, error) {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodGet, path)
 
@@ -197,11 +197,11 @@ type RegisterPluginInput struct {
 func (c *Sys) RegisterPlugin(i *RegisterPluginInput) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RegisterPluginContext(ctx, i)
+	return c.RegisterPluginWithContext(ctx, i)
 }
 
-// RegisterPluginContext the same as RegisterPlugin but with a custom context.
-func (c *Sys) RegisterPluginContext(ctx context.Context, i *RegisterPluginInput) error {
+// RegisterPluginWithContext the same as RegisterPlugin but with a custom context.
+func (c *Sys) RegisterPluginWithContext(ctx context.Context, i *RegisterPluginInput) error {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodPut, path)
 
@@ -230,11 +230,11 @@ type DeregisterPluginInput struct {
 func (c *Sys) DeregisterPlugin(i *DeregisterPluginInput) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.DeregisterPluginContext(ctx, i)
+	return c.DeregisterPluginWithContext(ctx, i)
 }
 
-// DeregisterPluginContext the same as DeregisterPlugin but with a custom context.
-func (c *Sys) DeregisterPluginContext(ctx context.Context, i *DeregisterPluginInput) error {
+// DeregisterPluginWithContext the same as DeregisterPlugin but with a custom context.
+func (c *Sys) DeregisterPluginWithContext(ctx context.Context, i *DeregisterPluginInput) error {
 	path := catalogPathByType(i.Type, i.Name)
 	req := c.c.NewRequest(http.MethodDelete, path)
 
@@ -262,11 +262,11 @@ type ReloadPluginInput struct {
 func (c *Sys) ReloadPlugin(i *ReloadPluginInput) (string, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ReloadPluginContext(ctx, i)
+	return c.ReloadPluginWithContext(ctx, i)
 }
 
-// ReloadPluginContext the same as ReloadPlugin but with a custom context.
-func (c *Sys) ReloadPluginContext(ctx context.Context, i *ReloadPluginInput) (string, error) {
+// ReloadPluginWithContext the same as ReloadPlugin but with a custom context.
+func (c *Sys) ReloadPluginWithContext(ctx context.Context, i *ReloadPluginInput) (string, error) {
 	path := "/v1/sys/plugins/reload/backend"
 	req := c.c.NewRequest(http.MethodPut, path)
 
@@ -315,11 +315,11 @@ type ReloadPluginStatusInput struct {
 func (c *Sys) ReloadPluginStatus(reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ReloadPluginStatusContext(ctx, reloadStatusInput)
+	return c.ReloadPluginStatusWithContext(ctx, reloadStatusInput)
 }
 
-// ReloadPluginStatusContext the same as ReloadPluginStatus but with a custom context.
-func (c *Sys) ReloadPluginStatusContext(ctx context.Context, reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
+// ReloadPluginStatusWithContext the same as ReloadPluginStatus but with a custom context.
+func (c *Sys) ReloadPluginStatusWithContext(ctx context.Context, reloadStatusInput *ReloadPluginStatusInput) (*ReloadStatusResponse, error) {
 	path := "/v1/sys/plugins/reload/backend/status"
 	req := c.c.NewRequest(http.MethodGet, path)
 	req.Params.Add("reload_id", reloadStatusInput.ReloadID)

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -11,10 +11,10 @@ import (
 func (c *Sys) ListPolicies() ([]string, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ListPoliciesContext(ctx)
+	return c.ListPoliciesWithContext(ctx)
 }
 
-func (c *Sys) ListPoliciesContext(ctx context.Context) ([]string, error) {
+func (c *Sys) ListPoliciesWithContext(ctx context.Context) ([]string, error) {
 	r := c.c.NewRequest("LIST", "/v1/sys/policies/acl")
 	// Set this for broader compatibility, but we use LIST above to be able to
 	// handle the wrapping lookup function
@@ -47,10 +47,10 @@ func (c *Sys) ListPoliciesContext(ctx context.Context) ([]string, error) {
 func (c *Sys) GetPolicy(name string) (string, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.GetPolicyContext(ctx, name)
+	return c.GetPolicyWithContext(ctx, name)
 }
 
-func (c *Sys) GetPolicyContext(ctx context.Context, name string) (string, error) {
+func (c *Sys) GetPolicyWithContext(ctx context.Context, name string) (string, error) {
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -82,10 +82,10 @@ func (c *Sys) GetPolicyContext(ctx context.Context, name string) (string, error)
 func (c *Sys) PutPolicy(name, rules string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.PutPolicyContext(ctx, name, rules)
+	return c.PutPolicyWithContext(ctx, name, rules)
 }
 
-func (c *Sys) PutPolicyContext(ctx context.Context, name, rules string) error {
+func (c *Sys) PutPolicyWithContext(ctx context.Context, name, rules string) error {
 	body := map[string]string{
 		"policy": rules,
 	}
@@ -107,10 +107,10 @@ func (c *Sys) PutPolicyContext(ctx context.Context, name, rules string) error {
 func (c *Sys) DeletePolicy(name string) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.DeletePolicyContext(ctx, name)
+	return c.DeletePolicyWithContext(ctx, name)
 }
 
-func (c *Sys) DeletePolicyContext(ctx context.Context, name string) error {
+func (c *Sys) DeletePolicyWithContext(ctx context.Context, name string) error {
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -15,6 +15,9 @@ func (c *Sys) ListPolicies() ([]string, error) {
 }
 
 func (c *Sys) ListPoliciesWithContext(ctx context.Context) ([]string, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("LIST", "/v1/sys/policies/acl")
 	// Set this for broader compatibility, but we use LIST above to be able to
 	// handle the wrapping lookup function
@@ -51,6 +54,9 @@ func (c *Sys) GetPolicy(name string) (string, error) {
 }
 
 func (c *Sys) GetPolicyWithContext(ctx context.Context, name string) (string, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -86,6 +92,9 @@ func (c *Sys) PutPolicy(name, rules string) error {
 }
 
 func (c *Sys) PutPolicyWithContext(ctx context.Context, name, rules string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]string{
 		"policy": rules,
 	}
@@ -111,6 +120,9 @@ func (c *Sys) DeletePolicy(name string) error {
 }
 
 func (c *Sys) DeletePolicyWithContext(ctx context.Context, name string) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -9,14 +9,18 @@ import (
 )
 
 func (c *Sys) ListPolicies() ([]string, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ListPoliciesContext(ctx)
+}
+
+func (c *Sys) ListPoliciesContext(ctx context.Context) ([]string, error) {
 	r := c.c.NewRequest("LIST", "/v1/sys/policies/acl")
 	// Set this for broader compatibility, but we use LIST above to be able to
 	// handle the wrapping lookup function
 	r.Method = "GET"
 	r.Params.Set("list", "true")
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -41,10 +45,14 @@ func (c *Sys) ListPolicies() ([]string, error) {
 }
 
 func (c *Sys) GetPolicy(name string) (string, error) {
-	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.GetPolicyContext(ctx, name)
+}
+
+func (c *Sys) GetPolicyContext(ctx context.Context, name string) (string, error) {
+	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -72,6 +80,12 @@ func (c *Sys) GetPolicy(name string) (string, error) {
 }
 
 func (c *Sys) PutPolicy(name, rules string) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.PutPolicyContext(ctx, name, rules)
+}
+
+func (c *Sys) PutPolicyContext(ctx context.Context, name, rules string) error {
 	body := map[string]string{
 		"policy": rules,
 	}
@@ -81,8 +95,6 @@ func (c *Sys) PutPolicy(name, rules string) error {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -93,10 +105,14 @@ func (c *Sys) PutPolicy(name, rules string) error {
 }
 
 func (c *Sys) DeletePolicy(name string) error {
-	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.DeletePolicyContext(ctx, name)
+}
+
+func (c *Sys) DeletePolicyContext(ctx context.Context, name string) error {
+	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -9,9 +9,7 @@ import (
 )
 
 func (c *Sys) ListPolicies() ([]string, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ListPoliciesWithContext(ctx)
+	return c.ListPoliciesWithContext(context.Background())
 }
 
 func (c *Sys) ListPoliciesWithContext(ctx context.Context) ([]string, error) {
@@ -48,9 +46,7 @@ func (c *Sys) ListPoliciesWithContext(ctx context.Context) ([]string, error) {
 }
 
 func (c *Sys) GetPolicy(name string) (string, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.GetPolicyWithContext(ctx, name)
+	return c.GetPolicyWithContext(context.Background(), name)
 }
 
 func (c *Sys) GetPolicyWithContext(ctx context.Context, name string) (string, error) {
@@ -86,9 +82,7 @@ func (c *Sys) GetPolicyWithContext(ctx context.Context, name string) (string, er
 }
 
 func (c *Sys) PutPolicy(name, rules string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.PutPolicyWithContext(ctx, name, rules)
+	return c.PutPolicyWithContext(context.Background(), name, rules)
 }
 
 func (c *Sys) PutPolicyWithContext(ctx context.Context, name, rules string) error {
@@ -114,9 +108,7 @@ func (c *Sys) PutPolicyWithContext(ctx context.Context, name, rules string) erro
 }
 
 func (c *Sys) DeletePolicy(name string) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.DeletePolicyWithContext(ctx, name)
+	return c.DeletePolicyWithContext(context.Background(), name)
 }
 
 func (c *Sys) DeletePolicyWithContext(ctx context.Context, name string) error {

--- a/api/sys_policy.go
+++ b/api/sys_policy.go
@@ -22,7 +22,7 @@ func (c *Sys) ListPoliciesWithContext(ctx context.Context) ([]string, error) {
 	r.Method = "GET"
 	r.Params.Set("list", "true")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (c *Sys) GetPolicyWithContext(ctx context.Context, name string) (string, er
 
 	r := c.c.NewRequest("GET", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
 		if resp.StatusCode == 404 {
@@ -98,7 +98,7 @@ func (c *Sys) PutPolicyWithContext(ctx context.Context, name, rules string) erro
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (c *Sys) DeletePolicyWithContext(ctx context.Context, name string) error {
 
 	r := c.c.NewRequest("DELETE", fmt.Sprintf("/v1/sys/policies/acl/%s", name))
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -113,14 +113,19 @@ type AutopilotServer struct {
 // RaftJoin adds the node from which this call is invoked from to the raft
 // cluster represented by the leader address in the parameter.
 func (c *Sys) RaftJoin(opts *RaftJoinRequest) (*RaftJoinResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RaftJoinContext(ctx, opts)
+}
+
+// RaftJoinContext the same as RaftJoin but with a custom context.
+func (c *Sys) RaftJoinContext(ctx context.Context, opts *RaftJoinRequest) (*RaftJoinResponse, error) {
 	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/join")
 
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -135,6 +140,13 @@ func (c *Sys) RaftJoin(opts *RaftJoinRequest) (*RaftJoinResponse, error) {
 // RaftSnapshot invokes the API that takes the snapshot of the raft cluster and
 // writes it to the supplied io.Writer.
 func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RaftSnapshotContext(ctx, snapWriter)
+}
+
+// RaftSnapshotContext the same as RaftSnapshot but with a custom context.
+func (c *Sys) RaftSnapshotContext(ctx context.Context, snapWriter io.Writer) error {
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/snapshot")
 	r.URL.RawQuery = r.Params.Encode()
 
@@ -142,6 +154,8 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 	if err != nil {
 		return err
 	}
+
+	req = req.WithContext(ctx)
 
 	req.URL.User = r.URL.User
 	req.URL.Scheme = r.URL.Scheme
@@ -274,6 +288,13 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 // RaftSnapshotRestore reads the snapshot from the io.Reader and installs that
 // snapshot, returning the cluster to the state defined by it.
 func (c *Sys) RaftSnapshotRestore(snapReader io.Reader, force bool) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RaftSnapshotRestoreContext(ctx, snapReader, force)
+}
+
+// RaftSnapshotRestoreContext the same as RaftSnapshotRestore but with a custom context.
+func (c *Sys) RaftSnapshotRestoreContext(ctx context.Context, snapReader io.Reader, force bool) error {
 	path := "/v1/sys/storage/raft/snapshot"
 	if force {
 		path = "/v1/sys/storage/raft/snapshot-force"
@@ -282,8 +303,6 @@ func (c *Sys) RaftSnapshotRestore(snapReader io.Reader, force bool) error {
 
 	r.Body = snapReader
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
@@ -295,10 +314,15 @@ func (c *Sys) RaftSnapshotRestore(snapReader io.Reader, force bool) error {
 
 // RaftAutopilotState returns the state of the raft cluster as seen by autopilot.
 func (c *Sys) RaftAutopilotState() (*AutopilotState, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/state")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RaftAutopilotStateContext(ctx)
+}
+
+// RaftAutopilotStateContext the same as RaftAutopilotState but with a custom context.
+func (c *Sys) RaftAutopilotStateContext(ctx context.Context) (*AutopilotState, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/state")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -329,10 +353,15 @@ func (c *Sys) RaftAutopilotState() (*AutopilotState, error) {
 
 // RaftAutopilotConfiguration fetches the autopilot config.
 func (c *Sys) RaftAutopilotConfiguration() (*AutopilotConfig, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/configuration")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RaftAutopilotConfigurationContext(ctx)
+}
+
+// RaftAutopilotConfigurationContext the same as RaftAutopilotConfiguration but with a custom context.
+func (c *Sys) RaftAutopilotConfigurationContext(ctx context.Context) (*AutopilotConfig, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/configuration")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -371,14 +400,19 @@ func (c *Sys) RaftAutopilotConfiguration() (*AutopilotConfig, error) {
 
 // PutRaftAutopilotConfiguration allows modifying the raft autopilot configuration
 func (c *Sys) PutRaftAutopilotConfiguration(opts *AutopilotConfig) error {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.PutRaftAutopilotConfigurationContext(ctx, opts)
+}
+
+// PutRaftAutopilotConfigurationContext the same as PutRaftAutopilotConfiguration but with a custom context.
+func (c *Sys) PutRaftAutopilotConfigurationContext(ctx context.Context, opts *AutopilotConfig) error {
 	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/autopilot/configuration")
 
 	if err := r.SetJSONBody(opts); err != nil {
 		return err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return err

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -112,9 +112,7 @@ type AutopilotServer struct {
 
 // RaftJoin wraps RaftJoinWithContext using context.Background.
 func (c *Sys) RaftJoin(opts *RaftJoinRequest) (*RaftJoinResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RaftJoinWithContext(ctx, opts)
+	return c.RaftJoinWithContext(context.Background(), opts)
 }
 
 // RaftJoinWithContext adds the node from which this call is invoked from to the raft
@@ -142,9 +140,7 @@ func (c *Sys) RaftJoinWithContext(ctx context.Context, opts *RaftJoinRequest) (*
 
 // RaftSnapshot wraps RaftSnapshotWithContext using context.Background.
 func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RaftSnapshotWithContext(ctx, snapWriter)
+	return c.RaftSnapshotWithContext(context.Background(), snapWriter)
 }
 
 // RaftSnapshotWithContext invokes the API that takes the snapshot of the raft cluster and
@@ -293,9 +289,7 @@ func (c *Sys) RaftSnapshotWithContext(ctx context.Context, snapWriter io.Writer)
 
 // RaftSnapshotRestore wraps RaftSnapshotRestoreWithContext using context.Background.
 func (c *Sys) RaftSnapshotRestore(snapReader io.Reader, force bool) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RaftSnapshotRestoreWithContext(ctx, snapReader, force)
+	return c.RaftSnapshotRestoreWithContext(context.Background(), snapReader, force)
 }
 
 // RaftSnapshotRestoreWithContext reads the snapshot from the io.Reader and installs that
@@ -323,9 +317,7 @@ func (c *Sys) RaftSnapshotRestoreWithContext(ctx context.Context, snapReader io.
 
 // RaftAutopilotState wraps RaftAutopilotStateWithContext using context.Background.
 func (c *Sys) RaftAutopilotState() (*AutopilotState, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RaftAutopilotStateWithContext(ctx)
+	return c.RaftAutopilotStateWithContext(context.Background())
 }
 
 // RaftAutopilotStateWithContext returns the state of the raft cluster as seen by autopilot.
@@ -365,9 +357,7 @@ func (c *Sys) RaftAutopilotStateWithContext(ctx context.Context) (*AutopilotStat
 
 // RaftAutopilotConfiguration wraps RaftAutopilotConfigurationWithContext using context.Background.
 func (c *Sys) RaftAutopilotConfiguration() (*AutopilotConfig, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RaftAutopilotConfigurationWithContext(ctx)
+	return c.RaftAutopilotConfigurationWithContext(context.Background())
 }
 
 // RaftAutopilotConfigurationWithContext fetches the autopilot config.
@@ -415,9 +405,7 @@ func (c *Sys) RaftAutopilotConfigurationWithContext(ctx context.Context) (*Autop
 
 // PutRaftAutopilotConfiguration wraps PutRaftAutopilotConfigurationWithContext using context.Background.
 func (c *Sys) PutRaftAutopilotConfiguration(opts *AutopilotConfig) error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.PutRaftAutopilotConfigurationWithContext(ctx, opts)
+	return c.PutRaftAutopilotConfigurationWithContext(context.Background(), opts)
 }
 
 // PutRaftAutopilotConfigurationWithContext allows modifying the raft autopilot configuration

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -118,8 +118,11 @@ func (c *Sys) RaftJoin(opts *RaftJoinRequest) (*RaftJoinResponse, error) {
 }
 
 // RaftJoinWithContext adds the node from which this call is invoked from to the raft
-// // cluster represented by the leader address in the parameter.
+// cluster represented by the leader address in the parameter.
 func (c *Sys) RaftJoinWithContext(ctx context.Context, opts *RaftJoinRequest) (*RaftJoinResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/join")
 
 	if err := r.SetJSONBody(opts); err != nil {
@@ -145,8 +148,11 @@ func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 }
 
 // RaftSnapshotWithContext invokes the API that takes the snapshot of the raft cluster and
-// // writes it to the supplied io.Writer.
+// writes it to the supplied io.Writer.
 func (c *Sys) RaftSnapshotWithContext(ctx context.Context, snapWriter io.Writer) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/snapshot")
 	r.URL.RawQuery = r.Params.Encode()
 
@@ -293,8 +299,11 @@ func (c *Sys) RaftSnapshotRestore(snapReader io.Reader, force bool) error {
 }
 
 // RaftSnapshotRestoreWithContext reads the snapshot from the io.Reader and installs that
-// // snapshot, returning the cluster to the state defined by it.
+// snapshot, returning the cluster to the state defined by it.
 func (c *Sys) RaftSnapshotRestoreWithContext(ctx context.Context, snapReader io.Reader, force bool) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	path := "/v1/sys/storage/raft/snapshot"
 	if force {
 		path = "/v1/sys/storage/raft/snapshot-force"
@@ -321,6 +330,9 @@ func (c *Sys) RaftAutopilotState() (*AutopilotState, error) {
 
 // RaftAutopilotStateWithContext returns the state of the raft cluster as seen by autopilot.
 func (c *Sys) RaftAutopilotStateWithContext(ctx context.Context) (*AutopilotState, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/state")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -360,6 +372,9 @@ func (c *Sys) RaftAutopilotConfiguration() (*AutopilotConfig, error) {
 
 // RaftAutopilotConfigurationWithContext fetches the autopilot config.
 func (c *Sys) RaftAutopilotConfigurationWithContext(ctx context.Context) (*AutopilotConfig, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/configuration")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -407,6 +422,9 @@ func (c *Sys) PutRaftAutopilotConfiguration(opts *AutopilotConfig) error {
 
 // PutRaftAutopilotConfigurationWithContext allows modifying the raft autopilot configuration
 func (c *Sys) PutRaftAutopilotConfigurationWithContext(ctx context.Context, opts *AutopilotConfig) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/autopilot/configuration")
 
 	if err := r.SetJSONBody(opts); err != nil {

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -115,11 +115,11 @@ type AutopilotServer struct {
 func (c *Sys) RaftJoin(opts *RaftJoinRequest) (*RaftJoinResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RaftJoinContext(ctx, opts)
+	return c.RaftJoinWithContext(ctx, opts)
 }
 
-// RaftJoinContext the same as RaftJoin but with a custom context.
-func (c *Sys) RaftJoinContext(ctx context.Context, opts *RaftJoinRequest) (*RaftJoinResponse, error) {
+// RaftJoinWithContext the same as RaftJoin but with a custom context.
+func (c *Sys) RaftJoinWithContext(ctx context.Context, opts *RaftJoinRequest) (*RaftJoinResponse, error) {
 	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/join")
 
 	if err := r.SetJSONBody(opts); err != nil {
@@ -142,11 +142,11 @@ func (c *Sys) RaftJoinContext(ctx context.Context, opts *RaftJoinRequest) (*Raft
 func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RaftSnapshotContext(ctx, snapWriter)
+	return c.RaftSnapshotWithContext(ctx, snapWriter)
 }
 
-// RaftSnapshotContext the same as RaftSnapshot but with a custom context.
-func (c *Sys) RaftSnapshotContext(ctx context.Context, snapWriter io.Writer) error {
+// RaftSnapshotWithContext the same as RaftSnapshot but with a custom context.
+func (c *Sys) RaftSnapshotWithContext(ctx context.Context, snapWriter io.Writer) error {
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/snapshot")
 	r.URL.RawQuery = r.Params.Encode()
 
@@ -290,11 +290,11 @@ func (c *Sys) RaftSnapshotContext(ctx context.Context, snapWriter io.Writer) err
 func (c *Sys) RaftSnapshotRestore(snapReader io.Reader, force bool) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RaftSnapshotRestoreContext(ctx, snapReader, force)
+	return c.RaftSnapshotRestoreWithContext(ctx, snapReader, force)
 }
 
-// RaftSnapshotRestoreContext the same as RaftSnapshotRestore but with a custom context.
-func (c *Sys) RaftSnapshotRestoreContext(ctx context.Context, snapReader io.Reader, force bool) error {
+// RaftSnapshotRestoreWithContext the same as RaftSnapshotRestore but with a custom context.
+func (c *Sys) RaftSnapshotRestoreWithContext(ctx context.Context, snapReader io.Reader, force bool) error {
 	path := "/v1/sys/storage/raft/snapshot"
 	if force {
 		path = "/v1/sys/storage/raft/snapshot-force"
@@ -316,11 +316,11 @@ func (c *Sys) RaftSnapshotRestoreContext(ctx context.Context, snapReader io.Read
 func (c *Sys) RaftAutopilotState() (*AutopilotState, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RaftAutopilotStateContext(ctx)
+	return c.RaftAutopilotStateWithContext(ctx)
 }
 
-// RaftAutopilotStateContext the same as RaftAutopilotState but with a custom context.
-func (c *Sys) RaftAutopilotStateContext(ctx context.Context) (*AutopilotState, error) {
+// RaftAutopilotStateWithContext the same as RaftAutopilotState but with a custom context.
+func (c *Sys) RaftAutopilotStateWithContext(ctx context.Context) (*AutopilotState, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/state")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -355,11 +355,11 @@ func (c *Sys) RaftAutopilotStateContext(ctx context.Context) (*AutopilotState, e
 func (c *Sys) RaftAutopilotConfiguration() (*AutopilotConfig, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RaftAutopilotConfigurationContext(ctx)
+	return c.RaftAutopilotConfigurationWithContext(ctx)
 }
 
-// RaftAutopilotConfigurationContext the same as RaftAutopilotConfiguration but with a custom context.
-func (c *Sys) RaftAutopilotConfigurationContext(ctx context.Context) (*AutopilotConfig, error) {
+// RaftAutopilotConfigurationWithContext the same as RaftAutopilotConfiguration but with a custom context.
+func (c *Sys) RaftAutopilotConfigurationWithContext(ctx context.Context) (*AutopilotConfig, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/configuration")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -402,11 +402,11 @@ func (c *Sys) RaftAutopilotConfigurationContext(ctx context.Context) (*Autopilot
 func (c *Sys) PutRaftAutopilotConfiguration(opts *AutopilotConfig) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.PutRaftAutopilotConfigurationContext(ctx, opts)
+	return c.PutRaftAutopilotConfigurationWithContext(ctx, opts)
 }
 
-// PutRaftAutopilotConfigurationContext the same as PutRaftAutopilotConfiguration but with a custom context.
-func (c *Sys) PutRaftAutopilotConfigurationContext(ctx context.Context, opts *AutopilotConfig) error {
+// PutRaftAutopilotConfigurationWithContext the same as PutRaftAutopilotConfiguration but with a custom context.
+func (c *Sys) PutRaftAutopilotConfigurationWithContext(ctx context.Context, opts *AutopilotConfig) error {
 	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/autopilot/configuration")
 
 	if err := r.SetJSONBody(opts); err != nil {

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -110,15 +110,15 @@ type AutopilotServer struct {
 	Meta        map[string]string `mapstructure:"meta"`
 }
 
-// RaftJoin adds the node from which this call is invoked from to the raft
-// cluster represented by the leader address in the parameter.
+// RaftJoin wraps RaftJoinWithContext using context.Background.
 func (c *Sys) RaftJoin(opts *RaftJoinRequest) (*RaftJoinResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RaftJoinWithContext(ctx, opts)
 }
 
-// RaftJoinWithContext the same as RaftJoin but with a custom context.
+// RaftJoinWithContext adds the node from which this call is invoked from to the raft
+// // cluster represented by the leader address in the parameter.
 func (c *Sys) RaftJoinWithContext(ctx context.Context, opts *RaftJoinRequest) (*RaftJoinResponse, error) {
 	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/join")
 
@@ -137,15 +137,15 @@ func (c *Sys) RaftJoinWithContext(ctx context.Context, opts *RaftJoinRequest) (*
 	return &result, err
 }
 
-// RaftSnapshot invokes the API that takes the snapshot of the raft cluster and
-// writes it to the supplied io.Writer.
+// RaftSnapshot wraps RaftSnapshotWithContext using context.Background.
 func (c *Sys) RaftSnapshot(snapWriter io.Writer) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RaftSnapshotWithContext(ctx, snapWriter)
 }
 
-// RaftSnapshotWithContext the same as RaftSnapshot but with a custom context.
+// RaftSnapshotWithContext invokes the API that takes the snapshot of the raft cluster and
+// // writes it to the supplied io.Writer.
 func (c *Sys) RaftSnapshotWithContext(ctx context.Context, snapWriter io.Writer) error {
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/snapshot")
 	r.URL.RawQuery = r.Params.Encode()
@@ -285,15 +285,15 @@ func (c *Sys) RaftSnapshotWithContext(ctx context.Context, snapWriter io.Writer)
 	return nil
 }
 
-// RaftSnapshotRestore reads the snapshot from the io.Reader and installs that
-// snapshot, returning the cluster to the state defined by it.
+// RaftSnapshotRestore wraps RaftSnapshotRestoreWithContext using context.Background.
 func (c *Sys) RaftSnapshotRestore(snapReader io.Reader, force bool) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RaftSnapshotRestoreWithContext(ctx, snapReader, force)
 }
 
-// RaftSnapshotRestoreWithContext the same as RaftSnapshotRestore but with a custom context.
+// RaftSnapshotRestoreWithContext reads the snapshot from the io.Reader and installs that
+// // snapshot, returning the cluster to the state defined by it.
 func (c *Sys) RaftSnapshotRestoreWithContext(ctx context.Context, snapReader io.Reader, force bool) error {
 	path := "/v1/sys/storage/raft/snapshot"
 	if force {
@@ -312,14 +312,14 @@ func (c *Sys) RaftSnapshotRestoreWithContext(ctx context.Context, snapReader io.
 	return nil
 }
 
-// RaftAutopilotState returns the state of the raft cluster as seen by autopilot.
+// RaftAutopilotState wraps RaftAutopilotStateWithContext using context.Background.
 func (c *Sys) RaftAutopilotState() (*AutopilotState, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RaftAutopilotStateWithContext(ctx)
 }
 
-// RaftAutopilotStateWithContext the same as RaftAutopilotState but with a custom context.
+// RaftAutopilotStateWithContext returns the state of the raft cluster as seen by autopilot.
 func (c *Sys) RaftAutopilotStateWithContext(ctx context.Context) (*AutopilotState, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/state")
 
@@ -351,14 +351,14 @@ func (c *Sys) RaftAutopilotStateWithContext(ctx context.Context) (*AutopilotStat
 	return &result, err
 }
 
-// RaftAutopilotConfiguration fetches the autopilot config.
+// RaftAutopilotConfiguration wraps RaftAutopilotConfigurationWithContext using context.Background.
 func (c *Sys) RaftAutopilotConfiguration() (*AutopilotConfig, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.RaftAutopilotConfigurationWithContext(ctx)
 }
 
-// RaftAutopilotConfigurationWithContext the same as RaftAutopilotConfiguration but with a custom context.
+// RaftAutopilotConfigurationWithContext fetches the autopilot config.
 func (c *Sys) RaftAutopilotConfigurationWithContext(ctx context.Context) (*AutopilotConfig, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/configuration")
 
@@ -398,14 +398,14 @@ func (c *Sys) RaftAutopilotConfigurationWithContext(ctx context.Context) (*Autop
 	return &result, err
 }
 
-// PutRaftAutopilotConfiguration allows modifying the raft autopilot configuration
+// PutRaftAutopilotConfiguration wraps PutRaftAutopilotConfigurationWithContext using context.Background.
 func (c *Sys) PutRaftAutopilotConfiguration(opts *AutopilotConfig) error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	return c.PutRaftAutopilotConfigurationWithContext(ctx, opts)
 }
 
-// PutRaftAutopilotConfigurationWithContext the same as PutRaftAutopilotConfiguration but with a custom context.
+// PutRaftAutopilotConfigurationWithContext allows modifying the raft autopilot configuration
 func (c *Sys) PutRaftAutopilotConfigurationWithContext(ctx context.Context, opts *AutopilotConfig) error {
 	r := c.c.NewRequest("POST", "/v1/sys/storage/raft/autopilot/configuration")
 

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -127,7 +127,7 @@ func (c *Sys) RaftJoinWithContext(ctx context.Context, opts *RaftJoinRequest) (*
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (c *Sys) RaftSnapshotRestoreWithContext(ctx context.Context, snapReader io.
 
 	r.Body = snapReader
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -327,7 +327,7 @@ func (c *Sys) RaftAutopilotStateWithContext(ctx context.Context) (*AutopilotStat
 
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/state")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
 		if resp.StatusCode == 404 {
@@ -367,7 +367,7 @@ func (c *Sys) RaftAutopilotConfigurationWithContext(ctx context.Context) (*Autop
 
 	r := c.c.NewRequest("GET", "/v1/sys/storage/raft/autopilot/configuration")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil {
 		defer resp.Body.Close()
 		if resp.StatusCode == 404 {
@@ -419,7 +419,7 @@ func (c *Sys) PutRaftAutopilotConfigurationWithContext(ctx context.Context, opts
 		return err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return err
 	}

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -10,10 +10,10 @@ import (
 func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyStatusContext(ctx)
+	return c.RekeyStatusWithContext(ctx)
 }
 
-func (c *Sys) RekeyStatusContext(ctx context.Context) (*RekeyStatusResponse, error) {
+func (c *Sys) RekeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/init")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -30,10 +30,10 @@ func (c *Sys) RekeyStatusContext(ctx context.Context) (*RekeyStatusResponse, err
 func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyRecoveryKeyStatusContext(ctx)
+	return c.RekeyRecoveryKeyStatusWithContext(ctx)
 }
 
-func (c *Sys) RekeyRecoveryKeyStatusContext(ctx context.Context) (*RekeyStatusResponse, error) {
+func (c *Sys) RekeyRecoveryKeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/init")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -50,10 +50,10 @@ func (c *Sys) RekeyRecoveryKeyStatusContext(ctx context.Context) (*RekeyStatusRe
 func (c *Sys) RekeyVerificationStatus() (*RekeyVerificationStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyVerificationStatusContext(ctx)
+	return c.RekeyVerificationStatusWithContext(ctx)
 }
 
-func (c *Sys) RekeyVerificationStatusContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
+func (c *Sys) RekeyVerificationStatusWithContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/verify")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -70,10 +70,10 @@ func (c *Sys) RekeyVerificationStatusContext(ctx context.Context) (*RekeyVerific
 func (c *Sys) RekeyRecoveryKeyVerificationStatus() (*RekeyVerificationStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyRecoveryKeyVerificationStatusContext(ctx)
+	return c.RekeyRecoveryKeyVerificationStatusWithContext(ctx)
 }
 
-func (c *Sys) RekeyRecoveryKeyVerificationStatusContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
+func (c *Sys) RekeyRecoveryKeyVerificationStatusWithContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/verify")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -90,10 +90,10 @@ func (c *Sys) RekeyRecoveryKeyVerificationStatusContext(ctx context.Context) (*R
 func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyInitContext(ctx, config)
+	return c.RekeyInitWithContext(ctx, config)
 }
 
-func (c *Sys) RekeyInitContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+func (c *Sys) RekeyInitWithContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey/init")
 	if err := r.SetJSONBody(config); err != nil {
 		return nil, err
@@ -113,10 +113,10 @@ func (c *Sys) RekeyInitContext(ctx context.Context, config *RekeyInitRequest) (*
 func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyRecoveryKeyInitContext(ctx, config)
+	return c.RekeyRecoveryKeyInitWithContext(ctx, config)
 }
 
-func (c *Sys) RekeyRecoveryKeyInitContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+func (c *Sys) RekeyRecoveryKeyInitWithContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey-recovery-key/init")
 	if err := r.SetJSONBody(config); err != nil {
 		return nil, err
@@ -136,10 +136,10 @@ func (c *Sys) RekeyRecoveryKeyInitContext(ctx context.Context, config *RekeyInit
 func (c *Sys) RekeyCancel() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyCancelContext(ctx)
+	return c.RekeyCancelWithContext(ctx)
 }
 
-func (c *Sys) RekeyCancelContext(ctx context.Context) error {
+func (c *Sys) RekeyCancelWithContext(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/init")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -152,10 +152,10 @@ func (c *Sys) RekeyCancelContext(ctx context.Context) error {
 func (c *Sys) RekeyRecoveryKeyCancel() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyRecoveryKeyCancelContext(ctx)
+	return c.RekeyRecoveryKeyCancelWithContext(ctx)
 }
 
-func (c *Sys) RekeyRecoveryKeyCancelContext(ctx context.Context) error {
+func (c *Sys) RekeyRecoveryKeyCancelWithContext(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/init")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -168,10 +168,10 @@ func (c *Sys) RekeyRecoveryKeyCancelContext(ctx context.Context) error {
 func (c *Sys) RekeyVerificationCancel() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyVerificationCancelContext(ctx)
+	return c.RekeyVerificationCancelWithContext(ctx)
 }
 
-func (c *Sys) RekeyVerificationCancelContext(ctx context.Context) error {
+func (c *Sys) RekeyVerificationCancelWithContext(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/verify")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -184,10 +184,10 @@ func (c *Sys) RekeyVerificationCancelContext(ctx context.Context) error {
 func (c *Sys) RekeyRecoveryKeyVerificationCancel() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyRecoveryKeyVerificationCancelContext(ctx)
+	return c.RekeyRecoveryKeyVerificationCancelWithContext(ctx)
 }
 
-func (c *Sys) RekeyRecoveryKeyVerificationCancelContext(ctx context.Context) error {
+func (c *Sys) RekeyRecoveryKeyVerificationCancelWithContext(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/verify")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -200,10 +200,10 @@ func (c *Sys) RekeyRecoveryKeyVerificationCancelContext(ctx context.Context) err
 func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyUpdateContext(ctx, shard, nonce)
+	return c.RekeyUpdateWithContext(ctx, shard, nonce)
 }
 
-func (c *Sys) RekeyUpdateContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
+func (c *Sys) RekeyUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -228,10 +228,10 @@ func (c *Sys) RekeyUpdateContext(ctx context.Context, shard, nonce string) (*Rek
 func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyRecoveryKeyUpdateContext(ctx, shard, nonce)
+	return c.RekeyRecoveryKeyUpdateWithContext(ctx, shard, nonce)
 }
 
-func (c *Sys) RekeyRecoveryKeyUpdateContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
+func (c *Sys) RekeyRecoveryKeyUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -256,10 +256,10 @@ func (c *Sys) RekeyRecoveryKeyUpdateContext(ctx context.Context, shard, nonce st
 func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyRetrieveBackupContext(ctx)
+	return c.RekeyRetrieveBackupWithContext(ctx)
 }
 
-func (c *Sys) RekeyRetrieveBackupContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
+func (c *Sys) RekeyRetrieveBackupWithContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/backup")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -288,10 +288,10 @@ func (c *Sys) RekeyRetrieveBackupContext(ctx context.Context) (*RekeyRetrieveRes
 func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyRetrieveRecoveryBackupContext(ctx)
+	return c.RekeyRetrieveRecoveryBackupWithContext(ctx)
 }
 
-func (c *Sys) RekeyRetrieveRecoveryBackupContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
+func (c *Sys) RekeyRetrieveRecoveryBackupWithContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/recovery-key-backup")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -320,10 +320,10 @@ func (c *Sys) RekeyRetrieveRecoveryBackupContext(ctx context.Context) (*RekeyRet
 func (c *Sys) RekeyDeleteBackup() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyDeleteBackupContext(ctx)
+	return c.RekeyDeleteBackupWithContext(ctx)
 }
 
-func (c *Sys) RekeyDeleteBackupContext(ctx context.Context) error {
+func (c *Sys) RekeyDeleteBackupWithContext(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/backup")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -337,10 +337,10 @@ func (c *Sys) RekeyDeleteBackupContext(ctx context.Context) error {
 func (c *Sys) RekeyDeleteRecoveryBackup() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyDeleteRecoveryBackupContext(ctx)
+	return c.RekeyDeleteRecoveryBackupWithContext(ctx)
 }
 
-func (c *Sys) RekeyDeleteRecoveryBackupContext(ctx context.Context) error {
+func (c *Sys) RekeyDeleteRecoveryBackupWithContext(ctx context.Context) error {
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/recovery-key-backup")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -354,10 +354,10 @@ func (c *Sys) RekeyDeleteRecoveryBackupContext(ctx context.Context) error {
 func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyVerificationUpdateContext(ctx, shard, nonce)
+	return c.RekeyVerificationUpdateWithContext(ctx, shard, nonce)
 }
 
-func (c *Sys) RekeyVerificationUpdateContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
+func (c *Sys) RekeyVerificationUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -382,10 +382,10 @@ func (c *Sys) RekeyVerificationUpdateContext(ctx context.Context, shard, nonce s
 func (c *Sys) RekeyRecoveryKeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RekeyRecoveryKeyVerificationUpdateContext(ctx, shard, nonce)
+	return c.RekeyRecoveryKeyVerificationUpdateWithContext(ctx, shard, nonce)
 }
 
-func (c *Sys) RekeyRecoveryKeyVerificationUpdateContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
+func (c *Sys) RekeyRecoveryKeyVerificationUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -8,9 +8,7 @@ import (
 )
 
 func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyStatusWithContext(ctx)
+	return c.RekeyStatusWithContext(context.Background())
 }
 
 func (c *Sys) RekeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse, error) {
@@ -31,9 +29,7 @@ func (c *Sys) RekeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse,
 }
 
 func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyRecoveryKeyStatusWithContext(ctx)
+	return c.RekeyRecoveryKeyStatusWithContext(context.Background())
 }
 
 func (c *Sys) RekeyRecoveryKeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse, error) {
@@ -54,9 +50,7 @@ func (c *Sys) RekeyRecoveryKeyStatusWithContext(ctx context.Context) (*RekeyStat
 }
 
 func (c *Sys) RekeyVerificationStatus() (*RekeyVerificationStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyVerificationStatusWithContext(ctx)
+	return c.RekeyVerificationStatusWithContext(context.Background())
 }
 
 func (c *Sys) RekeyVerificationStatusWithContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
@@ -77,9 +71,7 @@ func (c *Sys) RekeyVerificationStatusWithContext(ctx context.Context) (*RekeyVer
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationStatus() (*RekeyVerificationStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyRecoveryKeyVerificationStatusWithContext(ctx)
+	return c.RekeyRecoveryKeyVerificationStatusWithContext(context.Background())
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationStatusWithContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
@@ -100,9 +92,7 @@ func (c *Sys) RekeyRecoveryKeyVerificationStatusWithContext(ctx context.Context)
 }
 
 func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyInitWithContext(ctx, config)
+	return c.RekeyInitWithContext(context.Background(), config)
 }
 
 func (c *Sys) RekeyInitWithContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
@@ -126,9 +116,7 @@ func (c *Sys) RekeyInitWithContext(ctx context.Context, config *RekeyInitRequest
 }
 
 func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyRecoveryKeyInitWithContext(ctx, config)
+	return c.RekeyRecoveryKeyInitWithContext(context.Background(), config)
 }
 
 func (c *Sys) RekeyRecoveryKeyInitWithContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
@@ -152,9 +140,7 @@ func (c *Sys) RekeyRecoveryKeyInitWithContext(ctx context.Context, config *Rekey
 }
 
 func (c *Sys) RekeyCancel() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyCancelWithContext(ctx)
+	return c.RekeyCancelWithContext(context.Background())
 }
 
 func (c *Sys) RekeyCancelWithContext(ctx context.Context) error {
@@ -171,9 +157,7 @@ func (c *Sys) RekeyCancelWithContext(ctx context.Context) error {
 }
 
 func (c *Sys) RekeyRecoveryKeyCancel() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyRecoveryKeyCancelWithContext(ctx)
+	return c.RekeyRecoveryKeyCancelWithContext(context.Background())
 }
 
 func (c *Sys) RekeyRecoveryKeyCancelWithContext(ctx context.Context) error {
@@ -190,9 +174,7 @@ func (c *Sys) RekeyRecoveryKeyCancelWithContext(ctx context.Context) error {
 }
 
 func (c *Sys) RekeyVerificationCancel() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyVerificationCancelWithContext(ctx)
+	return c.RekeyVerificationCancelWithContext(context.Background())
 }
 
 func (c *Sys) RekeyVerificationCancelWithContext(ctx context.Context) error {
@@ -209,9 +191,7 @@ func (c *Sys) RekeyVerificationCancelWithContext(ctx context.Context) error {
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationCancel() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyRecoveryKeyVerificationCancelWithContext(ctx)
+	return c.RekeyRecoveryKeyVerificationCancelWithContext(context.Background())
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationCancelWithContext(ctx context.Context) error {
@@ -228,9 +208,7 @@ func (c *Sys) RekeyRecoveryKeyVerificationCancelWithContext(ctx context.Context)
 }
 
 func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyUpdateWithContext(ctx, shard, nonce)
+	return c.RekeyUpdateWithContext(context.Background(), shard, nonce)
 }
 
 func (c *Sys) RekeyUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
@@ -259,9 +237,7 @@ func (c *Sys) RekeyUpdateWithContext(ctx context.Context, shard, nonce string) (
 }
 
 func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyRecoveryKeyUpdateWithContext(ctx, shard, nonce)
+	return c.RekeyRecoveryKeyUpdateWithContext(context.Background(), shard, nonce)
 }
 
 func (c *Sys) RekeyRecoveryKeyUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
@@ -290,9 +266,7 @@ func (c *Sys) RekeyRecoveryKeyUpdateWithContext(ctx context.Context, shard, nonc
 }
 
 func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyRetrieveBackupWithContext(ctx)
+	return c.RekeyRetrieveBackupWithContext(context.Background())
 }
 
 func (c *Sys) RekeyRetrieveBackupWithContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
@@ -325,9 +299,7 @@ func (c *Sys) RekeyRetrieveBackupWithContext(ctx context.Context) (*RekeyRetriev
 }
 
 func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyRetrieveRecoveryBackupWithContext(ctx)
+	return c.RekeyRetrieveRecoveryBackupWithContext(context.Background())
 }
 
 func (c *Sys) RekeyRetrieveRecoveryBackupWithContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
@@ -360,9 +332,7 @@ func (c *Sys) RekeyRetrieveRecoveryBackupWithContext(ctx context.Context) (*Reke
 }
 
 func (c *Sys) RekeyDeleteBackup() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyDeleteBackupWithContext(ctx)
+	return c.RekeyDeleteBackupWithContext(context.Background())
 }
 
 func (c *Sys) RekeyDeleteBackupWithContext(ctx context.Context) error {
@@ -380,9 +350,7 @@ func (c *Sys) RekeyDeleteBackupWithContext(ctx context.Context) error {
 }
 
 func (c *Sys) RekeyDeleteRecoveryBackup() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyDeleteRecoveryBackupWithContext(ctx)
+	return c.RekeyDeleteRecoveryBackupWithContext(context.Background())
 }
 
 func (c *Sys) RekeyDeleteRecoveryBackupWithContext(ctx context.Context) error {
@@ -400,9 +368,7 @@ func (c *Sys) RekeyDeleteRecoveryBackupWithContext(ctx context.Context) error {
 }
 
 func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyVerificationUpdateWithContext(ctx, shard, nonce)
+	return c.RekeyVerificationUpdateWithContext(context.Background(), shard, nonce)
 }
 
 func (c *Sys) RekeyVerificationUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
@@ -431,9 +397,7 @@ func (c *Sys) RekeyVerificationUpdateWithContext(ctx context.Context, shard, non
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RekeyRecoveryKeyVerificationUpdateWithContext(ctx, shard, nonce)
+	return c.RekeyRecoveryKeyVerificationUpdateWithContext(context.Background(), shard, nonce)
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -8,10 +8,14 @@ import (
 )
 
 func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/init")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyStatusContext(ctx)
+}
+
+func (c *Sys) RekeyStatusContext(ctx context.Context) (*RekeyStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey/init")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -24,10 +28,14 @@ func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
 }
 
 func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/init")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRecoveryKeyStatusContext(ctx)
+}
+
+func (c *Sys) RekeyRecoveryKeyStatusContext(ctx context.Context) (*RekeyStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/init")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -40,10 +48,14 @@ func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
 }
 
 func (c *Sys) RekeyVerificationStatus() (*RekeyVerificationStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/verify")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyVerificationStatusContext(ctx)
+}
+
+func (c *Sys) RekeyVerificationStatusContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey/verify")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -56,10 +68,14 @@ func (c *Sys) RekeyVerificationStatus() (*RekeyVerificationStatusResponse, error
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationStatus() (*RekeyVerificationStatusResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/verify")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRecoveryKeyVerificationStatusContext(ctx)
+}
+
+func (c *Sys) RekeyRecoveryKeyVerificationStatusContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/verify")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -72,13 +88,17 @@ func (c *Sys) RekeyRecoveryKeyVerificationStatus() (*RekeyVerificationStatusResp
 }
 
 func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyInitContext(ctx, config)
+}
+
+func (c *Sys) RekeyInitContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey/init")
 	if err := r.SetJSONBody(config); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -91,13 +111,17 @@ func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) 
 }
 
 func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyRecoveryKeyInitContext(ctx, config)
+}
+
+func (c *Sys) RekeyRecoveryKeyInitContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey-recovery-key/init")
 	if err := r.SetJSONBody(config); err != nil {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -110,10 +134,14 @@ func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusRespon
 }
 
 func (c *Sys) RekeyCancel() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/init")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyCancelContext(ctx)
+}
+
+func (c *Sys) RekeyCancelContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/init")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -122,10 +150,14 @@ func (c *Sys) RekeyCancel() error {
 }
 
 func (c *Sys) RekeyRecoveryKeyCancel() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/init")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRecoveryKeyCancelContext(ctx)
+}
+
+func (c *Sys) RekeyRecoveryKeyCancelContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/init")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -134,10 +166,14 @@ func (c *Sys) RekeyRecoveryKeyCancel() error {
 }
 
 func (c *Sys) RekeyVerificationCancel() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/verify")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyVerificationCancelContext(ctx)
+}
+
+func (c *Sys) RekeyVerificationCancelContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/verify")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -146,10 +182,14 @@ func (c *Sys) RekeyVerificationCancel() error {
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationCancel() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/verify")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRecoveryKeyVerificationCancelContext(ctx)
+}
+
+func (c *Sys) RekeyRecoveryKeyVerificationCancelContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/verify")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -158,6 +198,12 @@ func (c *Sys) RekeyRecoveryKeyVerificationCancel() error {
 }
 
 func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyUpdateContext(ctx, shard, nonce)
+}
+
+func (c *Sys) RekeyUpdateContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -168,8 +214,6 @@ func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -182,6 +226,12 @@ func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
 }
 
 func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyRecoveryKeyUpdateContext(ctx, shard, nonce)
+}
+
+func (c *Sys) RekeyRecoveryKeyUpdateContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -192,8 +242,6 @@ func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse,
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -206,10 +254,14 @@ func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse,
 }
 
 func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/backup")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRetrieveBackupContext(ctx)
+}
+
+func (c *Sys) RekeyRetrieveBackupContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey/backup")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -234,10 +286,14 @@ func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
 }
 
 func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/rekey/recovery-key-backup")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyRetrieveRecoveryBackupContext(ctx)
+}
+
+func (c *Sys) RekeyRetrieveRecoveryBackupContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/rekey/recovery-key-backup")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -262,10 +318,14 @@ func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
 }
 
 func (c *Sys) RekeyDeleteBackup() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/backup")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyDeleteBackupContext(ctx)
+}
+
+func (c *Sys) RekeyDeleteBackupContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/backup")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -275,10 +335,14 @@ func (c *Sys) RekeyDeleteBackup() error {
 }
 
 func (c *Sys) RekeyDeleteRecoveryBackup() error {
-	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/recovery-key-backup")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RekeyDeleteRecoveryBackupContext(ctx)
+}
+
+func (c *Sys) RekeyDeleteRecoveryBackupContext(ctx context.Context) error {
+	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/recovery-key-backup")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -288,6 +352,12 @@ func (c *Sys) RekeyDeleteRecoveryBackup() error {
 }
 
 func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyVerificationUpdateContext(ctx, shard, nonce)
+}
+
+func (c *Sys) RekeyVerificationUpdateContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -298,8 +368,6 @@ func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUp
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
@@ -312,6 +380,12 @@ func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUp
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.RekeyRecoveryKeyVerificationUpdateContext(ctx, shard, nonce)
+}
+
+func (c *Sys) RekeyRecoveryKeyVerificationUpdateContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -322,8 +396,6 @@ func (c *Sys) RekeyRecoveryKeyVerificationUpdate(shard, nonce string) (*RekeyVer
 		return nil, err
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -14,6 +14,9 @@ func (c *Sys) RekeyStatus() (*RekeyStatusResponse, error) {
 }
 
 func (c *Sys) RekeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/init")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -34,6 +37,9 @@ func (c *Sys) RekeyRecoveryKeyStatus() (*RekeyStatusResponse, error) {
 }
 
 func (c *Sys) RekeyRecoveryKeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/init")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -54,6 +60,9 @@ func (c *Sys) RekeyVerificationStatus() (*RekeyVerificationStatusResponse, error
 }
 
 func (c *Sys) RekeyVerificationStatusWithContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/verify")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -74,6 +83,9 @@ func (c *Sys) RekeyRecoveryKeyVerificationStatus() (*RekeyVerificationStatusResp
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationStatusWithContext(ctx context.Context) (*RekeyVerificationStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/verify")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -94,6 +106,9 @@ func (c *Sys) RekeyInit(config *RekeyInitRequest) (*RekeyStatusResponse, error) 
 }
 
 func (c *Sys) RekeyInitWithContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey/init")
 	if err := r.SetJSONBody(config); err != nil {
 		return nil, err
@@ -117,6 +132,9 @@ func (c *Sys) RekeyRecoveryKeyInit(config *RekeyInitRequest) (*RekeyStatusRespon
 }
 
 func (c *Sys) RekeyRecoveryKeyInitWithContext(ctx context.Context, config *RekeyInitRequest) (*RekeyStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/rekey-recovery-key/init")
 	if err := r.SetJSONBody(config); err != nil {
 		return nil, err
@@ -140,6 +158,9 @@ func (c *Sys) RekeyCancel() error {
 }
 
 func (c *Sys) RekeyCancelWithContext(ctx context.Context) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/init")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -156,6 +177,9 @@ func (c *Sys) RekeyRecoveryKeyCancel() error {
 }
 
 func (c *Sys) RekeyRecoveryKeyCancelWithContext(ctx context.Context) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/init")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -172,6 +196,9 @@ func (c *Sys) RekeyVerificationCancel() error {
 }
 
 func (c *Sys) RekeyVerificationCancelWithContext(ctx context.Context) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/verify")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -188,6 +215,9 @@ func (c *Sys) RekeyRecoveryKeyVerificationCancel() error {
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationCancelWithContext(ctx context.Context) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/verify")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -204,6 +234,9 @@ func (c *Sys) RekeyUpdate(shard, nonce string) (*RekeyUpdateResponse, error) {
 }
 
 func (c *Sys) RekeyUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -232,6 +265,9 @@ func (c *Sys) RekeyRecoveryKeyUpdate(shard, nonce string) (*RekeyUpdateResponse,
 }
 
 func (c *Sys) RekeyRecoveryKeyUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyUpdateResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -260,6 +296,9 @@ func (c *Sys) RekeyRetrieveBackup() (*RekeyRetrieveResponse, error) {
 }
 
 func (c *Sys) RekeyRetrieveBackupWithContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/backup")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -292,6 +331,9 @@ func (c *Sys) RekeyRetrieveRecoveryBackup() (*RekeyRetrieveResponse, error) {
 }
 
 func (c *Sys) RekeyRetrieveRecoveryBackupWithContext(ctx context.Context) (*RekeyRetrieveResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/recovery-key-backup")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -324,6 +366,9 @@ func (c *Sys) RekeyDeleteBackup() error {
 }
 
 func (c *Sys) RekeyDeleteBackupWithContext(ctx context.Context) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/backup")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -341,6 +386,9 @@ func (c *Sys) RekeyDeleteRecoveryBackup() error {
 }
 
 func (c *Sys) RekeyDeleteRecoveryBackupWithContext(ctx context.Context) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/recovery-key-backup")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -358,6 +406,9 @@ func (c *Sys) RekeyVerificationUpdate(shard, nonce string) (*RekeyVerificationUp
 }
 
 func (c *Sys) RekeyVerificationUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,
@@ -386,6 +437,9 @@ func (c *Sys) RekeyRecoveryKeyVerificationUpdate(shard, nonce string) (*RekeyVer
 }
 
 func (c *Sys) RekeyRecoveryKeyVerificationUpdateWithContext(ctx context.Context, shard, nonce string) (*RekeyVerificationUpdateResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]interface{}{
 		"key":   shard,
 		"nonce": nonce,

--- a/api/sys_rekey.go
+++ b/api/sys_rekey.go
@@ -17,7 +17,7 @@ func (c *Sys) RekeyStatusWithContext(ctx context.Context) (*RekeyStatusResponse,
 
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/init")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func (c *Sys) RekeyRecoveryKeyStatusWithContext(ctx context.Context) (*RekeyStat
 
 	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/init")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (c *Sys) RekeyVerificationStatusWithContext(ctx context.Context) (*RekeyVer
 
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/verify")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (c *Sys) RekeyRecoveryKeyVerificationStatusWithContext(ctx context.Context)
 
 	r := c.c.NewRequest("GET", "/v1/sys/rekey-recovery-key/verify")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (c *Sys) RekeyInitWithContext(ctx context.Context, config *RekeyInitRequest
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (c *Sys) RekeyRecoveryKeyInitWithContext(ctx context.Context, config *Rekey
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func (c *Sys) RekeyCancelWithContext(ctx context.Context) error {
 
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/init")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -166,7 +166,7 @@ func (c *Sys) RekeyRecoveryKeyCancelWithContext(ctx context.Context) error {
 
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/init")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -183,7 +183,7 @@ func (c *Sys) RekeyVerificationCancelWithContext(ctx context.Context) error {
 
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/verify")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -200,7 +200,7 @@ func (c *Sys) RekeyRecoveryKeyVerificationCancelWithContext(ctx context.Context)
 
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey-recovery-key/verify")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -225,7 +225,7 @@ func (c *Sys) RekeyUpdateWithContext(ctx context.Context, shard, nonce string) (
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (c *Sys) RekeyRecoveryKeyUpdateWithContext(ctx context.Context, shard, nonc
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +275,7 @@ func (c *Sys) RekeyRetrieveBackupWithContext(ctx context.Context) (*RekeyRetriev
 
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/backup")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (c *Sys) RekeyRetrieveRecoveryBackupWithContext(ctx context.Context) (*Reke
 
 	r := c.c.NewRequest("GET", "/v1/sys/rekey/recovery-key-backup")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +341,7 @@ func (c *Sys) RekeyDeleteBackupWithContext(ctx context.Context) error {
 
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/backup")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -359,7 +359,7 @@ func (c *Sys) RekeyDeleteRecoveryBackupWithContext(ctx context.Context) error {
 
 	r := c.c.NewRequest("DELETE", "/v1/sys/rekey/recovery-key-backup")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -385,7 +385,7 @@ func (c *Sys) RekeyVerificationUpdateWithContext(ctx context.Context, shard, non
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +414,7 @@ func (c *Sys) RekeyRecoveryKeyVerificationUpdateWithContext(ctx context.Context,
 		return nil, err
 	}
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -10,10 +10,10 @@ import (
 func (c *Sys) Rotate() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.RotateContext(ctx)
+	return c.RotateWithContext(ctx)
 }
 
-func (c *Sys) RotateContext(ctx context.Context) error {
+func (c *Sys) RotateWithContext(ctx context.Context) error {
 	r := c.c.NewRequest("POST", "/v1/sys/rotate")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -26,10 +26,10 @@ func (c *Sys) RotateContext(ctx context.Context) error {
 func (c *Sys) KeyStatus() (*KeyStatus, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.KeyStatusContext(ctx)
+	return c.KeyStatusWithContext(ctx)
 }
 
-func (c *Sys) KeyStatusContext(ctx context.Context) (*KeyStatus, error) {
+func (c *Sys) KeyStatusWithContext(ctx context.Context) (*KeyStatus, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/key-status")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -8,9 +8,7 @@ import (
 )
 
 func (c *Sys) Rotate() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.RotateWithContext(ctx)
+	return c.RotateWithContext(context.Background())
 }
 
 func (c *Sys) RotateWithContext(ctx context.Context) error {
@@ -27,9 +25,7 @@ func (c *Sys) RotateWithContext(ctx context.Context) error {
 }
 
 func (c *Sys) KeyStatus() (*KeyStatus, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.KeyStatusWithContext(ctx)
+	return c.KeyStatusWithContext(context.Background())
 }
 
 func (c *Sys) KeyStatusWithContext(ctx context.Context) (*KeyStatus, error) {

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -14,6 +14,9 @@ func (c *Sys) Rotate() error {
 }
 
 func (c *Sys) RotateWithContext(ctx context.Context) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("POST", "/v1/sys/rotate")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -30,6 +33,9 @@ func (c *Sys) KeyStatus() (*KeyStatus, error) {
 }
 
 func (c *Sys) KeyStatusWithContext(ctx context.Context) (*KeyStatus, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/key-status")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -17,7 +17,7 @@ func (c *Sys) RotateWithContext(ctx context.Context) error {
 
 	r := c.c.NewRequest("POST", "/v1/sys/rotate")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -34,7 +34,7 @@ func (c *Sys) KeyStatusWithContext(ctx context.Context) (*KeyStatus, error) {
 
 	r := c.c.NewRequest("GET", "/v1/sys/key-status")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -8,10 +8,14 @@ import (
 )
 
 func (c *Sys) Rotate() error {
-	r := c.c.NewRequest("POST", "/v1/sys/rotate")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.RotateContext(ctx)
+}
+
+func (c *Sys) RotateContext(ctx context.Context) error {
+	r := c.c.NewRequest("POST", "/v1/sys/rotate")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -20,10 +24,14 @@ func (c *Sys) Rotate() error {
 }
 
 func (c *Sys) KeyStatus() (*KeyStatus, error) {
-	r := c.c.NewRequest("GET", "/v1/sys/key-status")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.KeyStatusContext(ctx)
+}
+
+func (c *Sys) KeyStatusContext(ctx context.Context) (*KeyStatus, error) {
+	r := c.c.NewRequest("GET", "/v1/sys/key-status")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -9,6 +9,9 @@ func (c *Sys) SealStatus() (*SealStatusResponse, error) {
 }
 
 func (c *Sys) SealStatusWithContext(ctx context.Context) (*SealStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("GET", "/v1/sys/seal-status")
 	return sealStatusRequestWithContext(ctx, c, r)
 }
@@ -20,6 +23,9 @@ func (c *Sys) Seal() error {
 }
 
 func (c *Sys) SealWithContext(ctx context.Context) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/seal")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -36,6 +42,9 @@ func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
 }
 
 func (c *Sys) ResetUnsealProcessWithContext(ctx context.Context) (*SealStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]interface{}{"reset": true}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
@@ -53,6 +62,9 @@ func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
 }
 
 func (c *Sys) UnsealWithContext(ctx context.Context, shard string) (*SealStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	body := map[string]interface{}{"key": shard}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
@@ -70,6 +82,9 @@ func (c *Sys) UnsealWithOptions(opts *UnsealOpts) (*SealStatusResponse, error) {
 }
 
 func (c *Sys) UnsealWithOptionsWithContext(ctx context.Context, opts *UnsealOpts) (*SealStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
@@ -79,6 +94,9 @@ func (c *Sys) UnsealWithOptionsWithContext(ctx context.Context, opts *UnsealOpts
 }
 
 func sealStatusRequestWithContext(ctx context.Context, c *Sys, r *Request) (*SealStatusResponse, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -3,15 +3,25 @@ package api
 import "context"
 
 func (c *Sys) SealStatus() (*SealStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.SealStatusContext(ctx)
+}
+
+func (c *Sys) SealStatusContext(ctx context.Context) (*SealStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/seal-status")
-	return sealStatusRequest(c, r)
+	return sealStatusRequestContext(ctx, c, r)
 }
 
 func (c *Sys) Seal() error {
-	r := c.c.NewRequest("PUT", "/v1/sys/seal")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.SealContext(ctx)
+}
+
+func (c *Sys) SealContext(ctx context.Context) error {
+	r := c.c.NewRequest("PUT", "/v1/sys/seal")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
@@ -20,6 +30,12 @@ func (c *Sys) Seal() error {
 }
 
 func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.ResetUnsealProcessContext(ctx)
+}
+
+func (c *Sys) ResetUnsealProcessContext(ctx context.Context) (*SealStatusResponse, error) {
 	body := map[string]interface{}{"reset": true}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
@@ -27,10 +43,16 @@ func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
 		return nil, err
 	}
 
-	return sealStatusRequest(c, r)
+	return sealStatusRequestContext(ctx, c, r)
 }
 
 func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.UnsealContext(ctx, shard)
+}
+
+func (c *Sys) UnsealContext(ctx context.Context, shard string) (*SealStatusResponse, error) {
 	body := map[string]interface{}{"key": shard}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
@@ -38,21 +60,25 @@ func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
 		return nil, err
 	}
 
-	return sealStatusRequest(c, r)
+	return sealStatusRequestContext(ctx, c, r)
 }
 
 func (c *Sys) UnsealWithOptions(opts *UnsealOpts) (*SealStatusResponse, error) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	return c.UnsealWithOptionsContext(ctx, opts)
+}
+
+func (c *Sys) UnsealWithOptionsContext(ctx context.Context, opts *UnsealOpts) (*SealStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	return sealStatusRequest(c, r)
+	return sealStatusRequestContext(ctx, c, r)
 }
 
-func sealStatusRequest(c *Sys, r *Request) (*SealStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
+func sealStatusRequestContext(ctx context.Context, c *Sys, r *Request) (*SealStatusResponse, error) {
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -3,9 +3,7 @@ package api
 import "context"
 
 func (c *Sys) SealStatus() (*SealStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.SealStatusWithContext(ctx)
+	return c.SealStatusWithContext(context.Background())
 }
 
 func (c *Sys) SealStatusWithContext(ctx context.Context) (*SealStatusResponse, error) {
@@ -17,9 +15,7 @@ func (c *Sys) SealStatusWithContext(ctx context.Context) (*SealStatusResponse, e
 }
 
 func (c *Sys) Seal() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.SealWithContext(ctx)
+	return c.SealWithContext(context.Background())
 }
 
 func (c *Sys) SealWithContext(ctx context.Context) error {
@@ -36,9 +32,7 @@ func (c *Sys) SealWithContext(ctx context.Context) error {
 }
 
 func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.ResetUnsealProcessWithContext(ctx)
+	return c.ResetUnsealProcessWithContext(context.Background())
 }
 
 func (c *Sys) ResetUnsealProcessWithContext(ctx context.Context) (*SealStatusResponse, error) {
@@ -56,9 +50,7 @@ func (c *Sys) ResetUnsealProcessWithContext(ctx context.Context) (*SealStatusRes
 }
 
 func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.UnsealWithContext(ctx, shard)
+	return c.UnsealWithContext(context.Background(), shard)
 }
 
 func (c *Sys) UnsealWithContext(ctx context.Context, shard string) (*SealStatusResponse, error) {
@@ -76,9 +68,7 @@ func (c *Sys) UnsealWithContext(ctx context.Context, shard string) (*SealStatusR
 }
 
 func (c *Sys) UnsealWithOptions(opts *UnsealOpts) (*SealStatusResponse, error) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.UnsealWithOptionsWithContext(ctx, opts)
+	return c.UnsealWithOptionsWithContext(context.Background(), opts)
 }
 
 func (c *Sys) UnsealWithOptionsWithContext(ctx context.Context, opts *UnsealOpts) (*SealStatusResponse, error) {

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -5,21 +5,21 @@ import "context"
 func (c *Sys) SealStatus() (*SealStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.SealStatusContext(ctx)
+	return c.SealStatusWithContext(ctx)
 }
 
-func (c *Sys) SealStatusContext(ctx context.Context) (*SealStatusResponse, error) {
+func (c *Sys) SealStatusWithContext(ctx context.Context) (*SealStatusResponse, error) {
 	r := c.c.NewRequest("GET", "/v1/sys/seal-status")
-	return sealStatusRequestContext(ctx, c, r)
+	return sealStatusRequestWithContext(ctx, c, r)
 }
 
 func (c *Sys) Seal() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.SealContext(ctx)
+	return c.SealWithContext(ctx)
 }
 
-func (c *Sys) SealContext(ctx context.Context) error {
+func (c *Sys) SealWithContext(ctx context.Context) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/seal")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)
@@ -32,10 +32,10 @@ func (c *Sys) SealContext(ctx context.Context) error {
 func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.ResetUnsealProcessContext(ctx)
+	return c.ResetUnsealProcessWithContext(ctx)
 }
 
-func (c *Sys) ResetUnsealProcessContext(ctx context.Context) (*SealStatusResponse, error) {
+func (c *Sys) ResetUnsealProcessWithContext(ctx context.Context) (*SealStatusResponse, error) {
 	body := map[string]interface{}{"reset": true}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
@@ -43,16 +43,16 @@ func (c *Sys) ResetUnsealProcessContext(ctx context.Context) (*SealStatusRespons
 		return nil, err
 	}
 
-	return sealStatusRequestContext(ctx, c, r)
+	return sealStatusRequestWithContext(ctx, c, r)
 }
 
 func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.UnsealContext(ctx, shard)
+	return c.UnsealWithContext(ctx, shard)
 }
 
-func (c *Sys) UnsealContext(ctx context.Context, shard string) (*SealStatusResponse, error) {
+func (c *Sys) UnsealWithContext(ctx context.Context, shard string) (*SealStatusResponse, error) {
 	body := map[string]interface{}{"key": shard}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
@@ -60,25 +60,25 @@ func (c *Sys) UnsealContext(ctx context.Context, shard string) (*SealStatusRespo
 		return nil, err
 	}
 
-	return sealStatusRequestContext(ctx, c, r)
+	return sealStatusRequestWithContext(ctx, c, r)
 }
 
 func (c *Sys) UnsealWithOptions(opts *UnsealOpts) (*SealStatusResponse, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.UnsealWithOptionsContext(ctx, opts)
+	return c.UnsealWithOptionsWithContext(ctx, opts)
 }
 
-func (c *Sys) UnsealWithOptionsContext(ctx context.Context, opts *UnsealOpts) (*SealStatusResponse, error) {
+func (c *Sys) UnsealWithOptionsWithContext(ctx context.Context, opts *UnsealOpts) (*SealStatusResponse, error) {
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
 	if err := r.SetJSONBody(opts); err != nil {
 		return nil, err
 	}
 
-	return sealStatusRequestContext(ctx, c, r)
+	return sealStatusRequestWithContext(ctx, c, r)
 }
 
-func sealStatusRequestContext(ctx context.Context, c *Sys, r *Request) (*SealStatusResponse, error) {
+func sealStatusRequestWithContext(ctx context.Context, c *Sys, r *Request) (*SealStatusResponse, error) {
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -24,7 +24,7 @@ func (c *Sys) SealWithContext(ctx context.Context) error {
 
 	r := c.c.NewRequest("PUT", "/v1/sys/seal")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -87,7 +87,7 @@ func sealStatusRequestWithContext(ctx context.Context, c *Sys, r *Request) (*Sea
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sys_stepdown.go
+++ b/api/sys_stepdown.go
@@ -3,10 +3,14 @@ package api
 import "context"
 
 func (c *Sys) StepDown() error {
-	r := c.c.NewRequest("PUT", "/v1/sys/step-down")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	return c.StepDownContext(ctx)
+}
+
+func (c *Sys) StepDownContext(ctx context.Context) error {
+	r := c.c.NewRequest("PUT", "/v1/sys/step-down")
+
 	resp, err := c.c.RawRequestWithContext(ctx, r)
 	if resp != nil && resp.Body != nil {
 		resp.Body.Close()

--- a/api/sys_stepdown.go
+++ b/api/sys_stepdown.go
@@ -5,10 +5,10 @@ import "context"
 func (c *Sys) StepDown() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	return c.StepDownContext(ctx)
+	return c.StepDownWithContext(ctx)
 }
 
-func (c *Sys) StepDownContext(ctx context.Context) error {
+func (c *Sys) StepDownWithContext(ctx context.Context) error {
 	r := c.c.NewRequest("PUT", "/v1/sys/step-down")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_stepdown.go
+++ b/api/sys_stepdown.go
@@ -9,6 +9,9 @@ func (c *Sys) StepDown() error {
 }
 
 func (c *Sys) StepDownWithContext(ctx context.Context) error {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
 	r := c.c.NewRequest("PUT", "/v1/sys/step-down")
 
 	resp, err := c.c.RawRequestWithContext(ctx, r)

--- a/api/sys_stepdown.go
+++ b/api/sys_stepdown.go
@@ -12,7 +12,7 @@ func (c *Sys) StepDownWithContext(ctx context.Context) error {
 
 	r := c.c.NewRequest("PUT", "/v1/sys/step-down")
 
-	resp, err := c.c.RawRequestWithContext(ctx, r)
+	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if resp != nil && resp.Body != nil {
 		resp.Body.Close()
 	}

--- a/api/sys_stepdown.go
+++ b/api/sys_stepdown.go
@@ -3,9 +3,7 @@ package api
 import "context"
 
 func (c *Sys) StepDown() error {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	return c.StepDownWithContext(ctx)
+	return c.StepDownWithContext(context.Background())
 }
 
 func (c *Sys) StepDownWithContext(ctx context.Context) error {

--- a/changelog/14152.txt
+++ b/changelog/14152.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: added methods with context propagation to allow custom context transfer from the calling application.
+```


### PR DESCRIPTION
A fistful of methods with context was added to API. This will allow canceling long requests when the context is canceled, e.g. by a timeout or by the graceful shutdown.

Closes #14070