### PR TITLE
sdk/ldaputil: check if logger is nil

### DIFF
--- a/changelog/14165.txt
+++ b/changelog/14165.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk/ldaputil: Fixed bug where nil logger would cause a panic
+```

--- a/sdk/helper/ldaputil/client.go
+++ b/sdk/helper/ldaputil/client.go
@@ -75,10 +75,8 @@ func (c *Client) DialLDAP(cfg *ConfigEntry) (Connection, error) {
 			continue
 		}
 		if err == nil {
-			if retErr != nil {
-				if c.Logger.IsDebug() {
-					c.Logger.Debug("errors connecting to some hosts", "error", retErr.Error())
-				}
+			if retErr != nil && c.Logger != nil {
+				c.Logger.Error("errors connecting to some hosts", "error", retErr.Error())
 			}
 			retErr = nil
 			break


### PR DESCRIPTION
If a logger is nil (not set by the secret engine backend) this can panic under the right circumstances:
1. Secret engine is setup correctly and is usable
2. Config `url` is updated with an list of URLs, but one of them isn't able to connect, followed by a connectable URL:

```bash
vault write openldap/config \
   binddn="cn=admin,dc=hashicorp,dc=com" \
   bindpass="admin" \
   url="ldaps://ldap,ldap://ldap"
```

The connect err is nil (successful connection), but multi err is not nil due to previous bad attempt. This attempts to use a logger and if its nil, you get a panic:

```log
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x12b56ae]
goroutine 1013 [running]:
 github.com/hashicorp/vault/sdk/helper/ldaputil.(*Client).DialLDAP(0xc005044bc0, 0xc004e89b00, 0xf, 0x203001, 0x203001, 0x203001)
 /home/runner/actions-runner/_work/vault-enterprise/vault-enterprise/sdk/helper/ldaputil/client.go:79 +0x80e
 github.com/hashicorp/vault-plugin-secrets-openldap/client.(*Client).Search(0xc003d8d590, 0xc005682640, 0xc0055f4e40, 0x56, 0xc004603a40, 0x0, 0x0, 0x0, 0x0, 0x0)
 /home/runner/go/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/client/client.go:43 +0x11a
 github.com/hashicorp/vault-plugin-secrets-openldap/client.(*Client).UpdateEntry(0xc003d8d590, 0xc005682640, 0xc0055f4e40, 0x56, 0xc004603a40, 0xc00569b320, 0x0, 0x0)
 /home/runner/go/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/client/client.go:66 +0x92
 github.com/hashicorp/vault-plugin-secrets-openldap/client.(*Client).UpdatePassword(...)
 /home/runner/go/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/client/client.go:99
 github.com/hashicorp/vault-plugin-secrets-openldap.(*Client).UpdatePassword(0xc003d8d590, 0xc005682640, 0xc0055f4e40, 0x56, 0xc0056be2d0, 0x14, 0x24, 0xc0050d9c70)
 /home/runner/go/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/client.go:60 +0x225
 github.com/hashicorp/vault-plugin-secrets-openldap.(*backend).setStaticAccountPassword(0xc00512e240, 0x62ee0b8, 0xc005629d40, 0x62efc48, 0xc003d4ad80, 0xc004603ed0, 0x0, 0x0, 0x0)
 /home/runner/go/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/rotation.go:379 +0x35e
 github.com/hashicorp/vault-plugin-secrets-openldap.(*backend).rotateCredential(0xc00512e240, 0x62ee048, 0xc004ffc680, 0x62efc48, 0xc003d4ad80, 0x0)
 /home/runner/go/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/rotation.go:210 +0x9dc
 github.com/hashicorp/vault-plugin-secrets-openldap.(*backend).rotateCredentials(...)
 /home/runner/go/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/rotation.go:144
 github.com/hashicorp/vault-plugin-secrets-openldap.(*backend).runTicker(0xc00512e240, 0x62ee048, 0xc004ffc680, 0x62efc48, 0xc003d4ad80)
 /home/runner/go/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/rotation.go:112 +0x116
 created by github.com/hashicorp/vault-plugin-secrets-openldap.(*backend).initQueue
 /home/runner/go/pkg/mod/github.com/hashicorp/vault-plugin-secrets-openldap@v0.5.2/rotation.go:449 +0x165
```

PR is also opened in the OpenLDAP secret engine to configure a logger correctly: https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/36