### PR TITLE
Backport 1.8: secrets/openldap: fix panic from nil logger

### DIFF
--- a/changelog/14170.txt
+++ b/changelog/14170.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/openldap: Fix panic from nil logger in backend
+```

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-gcpkms v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.9.0
 	github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.4.0
-	github.com/hashicorp/vault-plugin-secrets-openldap v0.5.2
+	github.com/hashicorp/vault-plugin-secrets-openldap v0.5.3
 	github.com/hashicorp/vault-plugin-secrets-terraform v0.2.0
 	github.com/hashicorp/vault/api v1.1.2-0.20210713235431-1fc8af4c041f
 	github.com/hashicorp/vault/sdk v0.2.2-0.20220103165610-48e31c378a61

--- a/go.sum
+++ b/go.sum
@@ -748,8 +748,8 @@ github.com/hashicorp/vault-plugin-secrets-kv v0.9.0 h1:nCw2IfWw2bWUGFZsNk8BvTEg9
 github.com/hashicorp/vault-plugin-secrets-kv v0.9.0/go.mod h1:B/Cybh5aVF7LNAMHwVBxY8t7r2eL0C6HVGgTyP4nKK4=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.4.0 h1:6ve+7hZmGn7OpML81iZUxYj2AaJptwys323S5XsvVas=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.4.0/go.mod h1:4mdgPqlkO+vfFX1cFAWcxkeqz6JAtZgKxL/67q/58Oo=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.5.2 h1:5f3Gh/gcsC2sbn5PhE3YbeXB0cfC3TlZpkrBUSf90p4=
-github.com/hashicorp/vault-plugin-secrets-openldap v0.5.2/go.mod h1:GiFI8Bxwx3+fn0A3SyVp9XdYQhm3cOgN8GzwKxyJ9So=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.5.3 h1:JbHfJgFW+huSO/tx8Va5Wk+jignqhuJz8sui9oRm+LA=
+github.com/hashicorp/vault-plugin-secrets-openldap v0.5.3/go.mod h1:GiFI8Bxwx3+fn0A3SyVp9XdYQhm3cOgN8GzwKxyJ9So=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.2.0 h1:U5hT6xUUbIhI12v+tjzmUz47gpzg5yxbdf+q62sIIvc=
 github.com/hashicorp/vault-plugin-secrets-terraform v0.2.0/go.mod h1:7r/0t51X/ZtSRh/TjBk7gCm1CUMk50aqLAx811OsGQ8=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyuqg7yuAWUg/jMZR1/0QTzTRdNR6Uw=


### PR DESCRIPTION
Backport of https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/36.