### PR TITLE
Invalidate the ManagedKeyRegistry cache when Vault config is updated.

### DIFF
--- a/command/server.go
+++ b/command/server.go
@@ -1605,6 +1605,10 @@ func (c *ServerCommand) Run(args []string) int {
 			default:
 			}
 
+			// Let the managedKeyRegistry react to configuration changes (i.e.
+			// changes in kms_libraries)
+			core.ReloadManagedKeyRegistryConfig()
+
 		case <-c.SigUSR2Ch:
 			logWriter := c.logger.StandardWriter(&hclog.StandardLoggerOptions{})
 			pprof.Lookup("goroutine").WriteTo(logWriter, 2)

--- a/vault/managed_key_registry.go
+++ b/vault/managed_key_registry.go
@@ -8,5 +8,10 @@ package vault
 const managedKeyRegistrySubPath = "managed-key-registry/"
 
 func (c *Core) setupManagedKeyRegistry() error {
+	// Nothing to do, the registry is only used by enterprise features
 	return nil
+}
+
+func (c *Core) ReloadManagedKeyRegistryConfig() {
+	// Nothing to do, the registry is only used by enterprise features
 }


### PR DESCRIPTION
Add the hook needed to implement this functionality in vault-enterprise.