### PR TITLE
Fix a simple typo

### DIFF
--- a/website/content/api-docs/system/monitor.mdx
+++ b/website/content/api-docs/system/monitor.mdx
@@ -8,7 +8,7 @@ description: The `/sys/monitor` endpoint is used to receive streaming logs from 
 
 The `/sys/monitor` endpoint is used to receive streaming logs from the Vault server.
 
-If Vault is emitting log messages faster than a receiver can process them, the
+If Vault is emitting log messages faster than a receiver can process them, then
 some log lines will be dropped.
 
 ## Monitor system logs


### PR DESCRIPTION
Fixes a simple typo in the [system backend - monitor endpoint documentation](https://www.vaultproject.io/api-docs/system/monitor).