### PR TITLE
Change address lookup behaviour if VAULT_SRV_LOOKUP is set.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1042,10 +1042,16 @@ func (c *Client) NewRequest(method, requestPath string) *Request {
 	// if SRV records exist (see https://tools.ietf.org/html/draft-andrews-http-srv-02), lookup the SRV
 	// record and take the highest match; this is not designed for high-availability, just discovery
 	// Internet Draft specifies that the SRV record is ignored if a port is given
+	// According to that draft, if there is not port it should follow
+	// https://datatracker.ietf.org/doc/html/rfc2782
+	// We expect an addr which looks for example like _vault._tcp.example.com
+	// DNS does randomization of the records if there are multiple
 	if addr.Port() == "" && c.config.SRVLookup {
-		_, addrs, err := net.LookupSRV("http", "tcp", addr.Hostname())
+		_, addrs, err := net.LookupSRV("", "", addr.Hostname())
 		if err == nil && len(addrs) > 0 {
 			host = fmt.Sprintf("%s:%d", addrs[0].Target, addrs[0].Port)
+			addr.Path = ""        // url.Parse seems to set this to the hostname if there is no scheme
+			addr.Scheme = "https" // override scheme
 		}
 	}
 


### PR DESCRIPTION
I think the behaviour of VAULT_SRV_LOOKUP is set is strange:
It should not expect http (what about a prod https setup?)
And actually the VAULT_ADDR should not contain a scheme in this case.

I made a minimal change to make it work for us. 
We are using SRV records like _vault._tcp.example.domain which return
a list of hosts with the port appended.

The impure thing is that it overrides the scheme to be https, because i expect to use a SRV record approach in prod only which should https.

I am not 100% sure if this is the correct way, maybe we should discuss howto work with SRV records. 