### PR TITLE
Add checks for other error types within the PKI plugin

### DIFF
--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -112,11 +112,13 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 	if oldDisable != config.Disable {
 		// It wasn't disabled but now it is, rotate
 		crlErr := buildCRL(ctx, b, req, true)
-		switch crlErr.(type) {
-		case errutil.UserError:
-			return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil
-		case errutil.InternalError:
-			return nil, fmt.Errorf("error encountered during CRL building: %w", crlErr)
+		if crlErr != nil {
+			switch crlErr.(type) {
+			case errutil.UserError:
+				return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil
+			default:
+				return nil, fmt.Errorf("error encountered during CRL building: %w", crlErr)
+			}
 		}
 	}
 

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -192,13 +192,15 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 
 	if serial == "ca_chain" {
 		caInfo, err := fetchCAInfo(ctx, b, req)
-		switch err.(type) {
-		case errutil.UserError:
-			response = logical.ErrorResponse(err.Error())
-			goto reply
-		case errutil.InternalError:
-			retErr = err
-			goto reply
+		if err != nil {
+			switch err.(type) {
+			case errutil.UserError:
+				response = logical.ErrorResponse(err.Error())
+				goto reply
+			default:
+				retErr = err
+				goto reply
+			}
 		}
 
 		caChain := caInfo.GetCAChain()
@@ -232,7 +234,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		case errutil.UserError:
 			response = logical.ErrorResponse(funcErr.Error())
 			goto reply
-		case errutil.InternalError:
+		default:
 			retErr = funcErr
 			goto reply
 		}
@@ -260,7 +262,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 		case errutil.UserError:
 			response = logical.ErrorResponse(funcErr.Error())
 			goto reply
-		case errutil.InternalError:
+		default:
 			retErr = funcErr
 			goto reply
 		}

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -173,13 +173,15 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 
 	var caErr error
 	signingBundle, caErr := fetchCAInfo(ctx, b, req)
-	switch caErr.(type) {
-	case errutil.UserError:
-		return nil, errutil.UserError{Err: fmt.Sprintf(
-			"could not fetch the CA certificate (was one set?): %s", caErr)}
-	case errutil.InternalError:
-		return nil, errutil.InternalError{Err: fmt.Sprintf(
-			"error fetching CA certificate: %s", caErr)}
+	if caErr != nil {
+		switch caErr.(type) {
+		case errutil.UserError:
+			return nil, errutil.UserError{Err: fmt.Sprintf(
+				"could not fetch the CA certificate (was one set?): %s", caErr)}
+		default:
+			return nil, errutil.InternalError{Err: fmt.Sprintf(
+				"error fetching CA certificate: %s", caErr)}
+		}
 	}
 
 	input := &inputBundle{

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -69,18 +69,20 @@ func (b *backend) pathRotateCRLRead(ctx context.Context, req *logical.Request, d
 	defer b.revokeStorageLock.RUnlock()
 
 	crlErr := buildCRL(ctx, b, req, false)
-	switch crlErr.(type) {
-	case errutil.UserError:
-		return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil
-	case errutil.InternalError:
-		return nil, fmt.Errorf("error encountered during CRL building: %w", crlErr)
-	default:
-		return &logical.Response{
-			Data: map[string]interface{}{
-				"success": true,
-			},
-		}, nil
+	if crlErr != nil {
+		switch crlErr.(type) {
+		case errutil.UserError:
+			return logical.ErrorResponse(fmt.Sprintf("Error during CRL building: %s", crlErr)), nil
+		default:
+			return nil, fmt.Errorf("error encountered during CRL building: %w", crlErr)
+		}
 	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"success": true,
+		},
+	}, nil
 }
 
 const pathRevokeHelpSyn = `

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -137,7 +137,8 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	}
 	if entry != nil {
 		resp := &logical.Response{}
-		resp.AddWarning(fmt.Sprintf("Refusing to generate a root certificate over an existing root certificate. If you really want to destroy the original root certificate, please issue a delete against %sroot.", req.MountPoint))
+		resp.AddWarning(fmt.Sprintf("Refusing to generate a root certificate over an existing root certificate. "+
+			"If you really want to destroy the original root certificate, please issue a delete against %s root.", req.MountPoint))
 		return resp, nil
 	}
 
@@ -162,8 +163,6 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 		switch err.(type) {
 		case errutil.UserError:
 			return logical.ErrorResponse(err.Error()), nil
-		case errutil.InternalError:
-			return nil, err
 		default:
 			return nil, err
 		}
@@ -296,13 +295,15 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 
 	var caErr error
 	signingBundle, caErr := fetchCAInfo(ctx, b, req)
-	switch caErr.(type) {
-	case errutil.UserError:
-		return nil, errutil.UserError{Err: fmt.Sprintf(
-			"could not fetch the CA certificate (was one set?): %s", caErr)}
-	case errutil.InternalError:
-		return nil, errutil.InternalError{Err: fmt.Sprintf(
-			"error fetching CA certificate: %s", caErr)}
+	if caErr != nil {
+		switch caErr.(type) {
+		case errutil.UserError:
+			return nil, errutil.UserError{Err: fmt.Sprintf(
+				"could not fetch the CA certificate (was one set?): %s", caErr)}
+		default:
+			return nil, errutil.InternalError{Err: fmt.Sprintf(
+				"error fetching CA certificate: %s", caErr)}
+		}
 	}
 
 	useCSRValues := data.Get("use_csr_values").(bool)
@@ -323,8 +324,9 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 		switch err.(type) {
 		case errutil.UserError:
 			return logical.ErrorResponse(err.Error()), nil
-		case errutil.InternalError:
-			return nil, err
+		default:
+			return nil, errutil.InternalError{Err: fmt.Sprintf(
+				"error signing cert: %s", err)}
 		}
 	}
 
@@ -422,13 +424,14 @@ func (b *backend) pathCASignSelfIssued(ctx context.Context, req *logical.Request
 
 	var caErr error
 	signingBundle, caErr := fetchCAInfo(ctx, b, req)
-	switch caErr.(type) {
-	case errutil.UserError:
-		return nil, errutil.UserError{Err: fmt.Sprintf(
-			"could not fetch the CA certificate (was one set?): %s", caErr)}
-	case errutil.InternalError:
-		return nil, errutil.InternalError{Err: fmt.Sprintf(
-			"error fetching CA certificate: %s", caErr)}
+	if caErr != nil {
+		switch caErr.(type) {
+		case errutil.UserError:
+			return nil, errutil.UserError{Err: fmt.Sprintf(
+				"could not fetch the CA certificate (was one set?): %s", caErr)}
+		default:
+			return nil, errutil.InternalError{Err: fmt.Sprintf("error fetching CA certificate: %s", caErr)}
+		}
 	}
 
 	signingCB, err := signingBundle.ToCertBundle()

--- a/changelog/14195.txt
+++ b/changelog/14195.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Add error handling for error types other than UserError or InternalError
+```


### PR DESCRIPTION
## Overview 

The PKI plugin assumes the code it is calling always returns an error of type errutil.UserError or errutil.InternalError. While I believe so far this is still true, it would be easy to add a code path that just returns a generic error and we would completely ignore it. 

This is mainly to protect against a future code change that someone does not know this is an assumption within the handlers.

Issue: VAULT-5192

## Testing

This can't really be tested from outside of Vault, nor to my knowledge within the current codebase as we don't have code paths that do this. I accidentally added one which since has been modified to return within a wrapped errutil.InternalError.
