### PR TITLE
Vault 4864 vault crl generation non compliance in issuer field

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -97,6 +97,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 	}
 
 	b.crlLifetime = time.Hour * 72
+	b.crlCounter = 0
 	b.tidyCASGuard = new(uint32)
 	b.tidyStatus = &tidyStatus{state: tidyStatusInactive}
 	b.storage = conf.StorageView
@@ -109,6 +110,8 @@ type backend struct {
 
 	storage           logical.Storage
 	crlLifetime       time.Duration
+	crlCounter        int64
+	crlCounterLock    sync.RWMutex
 	revokeStorageLock sync.RWMutex
 	tidyCASGuard      *uint32
 

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -97,7 +97,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 	}
 
 	b.crlLifetime = time.Hour * 72
-	b.crlCounter = 0
+	b.nextCrlNumber = 1
 	b.tidyCASGuard = new(uint32)
 	b.tidyStatus = &tidyStatus{state: tidyStatusInactive}
 	b.storage = conf.StorageView
@@ -110,7 +110,7 @@ type backend struct {
 
 	storage           logical.Storage
 	crlLifetime       time.Duration
-	crlCounter        int64
+	nextCrlNumber     int64
 	crlCounterLock    sync.RWMutex
 	revokeStorageLock sync.RWMutex
 	tidyCASGuard      *uint32

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -230,7 +230,7 @@ WRITE:
 
 	b.crlCounterLock.Lock()
 	defer b.crlCounterLock.Unlock()
-	crlSerial := b.crlCounter
+	crlSerial := b.nextCrlNumber
 	revocationList := &x509.RevocationList{
 		RevokedCertificates: revokedCerts,
 		Number:              big.NewInt(crlSerial),
@@ -241,7 +241,7 @@ WRITE:
 	if err != nil {
 		return errutil.InternalError{Err: fmt.Sprintf("error creating new CRL: %s", err)}
 	}
-	b.crlCounter += 1
+	b.nextCrlNumber += 1
 
 	err = req.Storage.Put(ctx, &logical.StorageEntry{
 		Key:   "crl",


### PR DESCRIPTION
Adds the necessary fields for https://www.rfc-editor.org/rfc/rfc5280.html compliant CRL generation, fixes a bug where:

In essence, OP's certificate is issued with a DN which contains only single-entity RDNs, but in a different order than Go's default. Go's x509.Certificate.CreateCRL mangles the certificate's subject field by round-tripping it through the non-compliant x509/pkix.Name. By switching to x509.CreateRevocationList(...), we can fix this behavior.

Notably, x509.CreateRevocationList requires a RevocationList template and validates this template has provided a Number value (a presumed monotonically increasing counter similar to CRL version). We need to add this to storage (and thus, acquire a lock when building the CRL) on each node which has a CRL. We can probably start at 1 (and increment from the previous omitempty/zero value).