### PR TITLE
fix(doc): mention that leases can be revoked on the UI

### DIFF
--- a/website/content/docs/concepts/lease.mdx
+++ b/website/content/docs/concepts/lease.mdx
@@ -31,9 +31,9 @@ access keys will be deleted from AWS the moment a lease is revoked. This
 renders the access keys invalid from that point forward.
 
 Revocation can happen manually via the API, via the `vault lease revoke` cli command,
-or automatically by Vault. When a lease is expired, Vault will automatically
-revoke that lease. When a token is revoked, Vault will revoke all leases that
-were created using that token.
+the user interface (UI) under the Access tab, or automatically by Vault. When a lease
+is expired, Vault will automatically revoke that lease. When a token is revoked,
+Vault will revoke all leases that were created using that token.
 
 **Note**: The [Key/Value Backend](/docs/secrets/kv) which stores
 arbitrary secrets does not issue leases although it will sometimes return a


### PR DESCRIPTION
The vault [Concepts / Lease documentation](https://www.vaultproject.io/docs/concepts/lease) does not mention that leases can be revoked from the UI, it only mentions the CLI or the API for manual operations. This PR fixes this issue.

https://github.com/hashicorp/vault/issues/14204