### PR TITLE
prevent int64 overflow for default_lease_ttl and max_lease_ttl

### DIFF
--- a/changelog/14206.txt
+++ b/changelog/14206.txt
@@ -1,4 +1,4 @@
 ```release-note:change
-core: Reduces the unit of `default_lease_ttl` and `max_lease_ttl` values returned by
+core: Changes the unit of `default_lease_ttl` and `max_lease_ttl` values returned by
 the `/sys/config/state/sanitized` endpoint from nanoseconds to seconds.
 ```

--- a/changelog/14206.txt
+++ b/changelog/14206.txt
@@ -1,0 +1,4 @@
+```release-note:change
+core: Reduces the unit of `default_lease_ttl` and `max_lease_ttl` values returned by
+the `/sys/config/state/sanitized` endpoint from nanoseconds to seconds.
+```

--- a/command/server/config.go
+++ b/command/server/config.go
@@ -831,8 +831,8 @@ func (c *Config) Sanitized() map[string]interface{} {
 
 		"enable_ui": c.EnableUI,
 
-		"max_lease_ttl":     c.MaxLeaseTTL,
-		"default_lease_ttl": c.DefaultLeaseTTL,
+		"max_lease_ttl":     c.MaxLeaseTTL / time.Second,
+		"default_lease_ttl": c.DefaultLeaseTTL / time.Second,
 
 		"cluster_cipher_suites": c.ClusterCipherSuites,
 

--- a/command/server/config_test_helpers.go
+++ b/command/server/config_test_helpers.go
@@ -687,7 +687,7 @@ func testConfig_Sanitized(t *testing.T) {
 		"cluster_addr":                        "top_level_cluster_addr",
 		"cluster_cipher_suites":               "",
 		"cluster_name":                        "testcluster",
-		"default_lease_ttl":                   10 * time.Hour,
+		"default_lease_ttl":                   (365 * 24 * time.Hour) / time.Second,
 		"default_max_request_duration":        0 * time.Second,
 		"disable_cache":                       true,
 		"disable_clustering":                  false,
@@ -718,7 +718,7 @@ func testConfig_Sanitized(t *testing.T) {
 		},
 		"log_format":       "",
 		"log_level":        "",
-		"max_lease_ttl":    10 * time.Hour,
+		"max_lease_ttl":    (30 * 24 * time.Hour) / time.Second,
 		"pid_file":         "./pidfile",
 		"plugin_directory": "",
 		"seals": []interface{}{

--- a/command/server/test-fixtures/config3.hcl
+++ b/command/server/test-fixtures/config3.hcl
@@ -45,8 +45,8 @@ seal "awskms" {
   secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 }
 
-max_lease_ttl = "10h"
-default_lease_ttl = "10h"
+max_lease_ttl = "30d"
+default_lease_ttl = "365d"
 cluster_name = "testcluster"
 pid_file = "./pidfile"
 raw_storage_endpoint = true


### PR DESCRIPTION
It is possible for `vault read sys/config/state/sanitized` to result in `int64` overflow for large values of `default_lease_ttl` and `max_lease_ttl`. This occurs in the duration parsing in `humanDurationInt` in `base_helpers.go`. In order to address this, the unit used has been changed from nanoseconds to seconds in `core.Config.Sanitzed()`. While this fixes the integer overflow issue, it also changes the contract of the API which is why the changelog lists a `change` instead of `bug`.

Fixes https://github.com/hashicorp/vault/issues/14175.

