### PR TITLE
update sdk in go mod for vault and api

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1
 	github.com/hashicorp/hcl v1.0.0
-	github.com/hashicorp/vault/sdk v0.3.1-0.20220222222524-cfa3741426a1
+	github.com/hashicorp/vault/sdk v0.3.0
 	github.com/mitchellh/mapstructure v1.4.2
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1

--- a/api/go.mod
+++ b/api/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1
 	github.com/hashicorp/hcl v1.0.0
-	github.com/hashicorp/vault/sdk v0.3.0
+	github.com/hashicorp/vault/sdk v0.3.1-0.20220222222524-cfa3741426a1
 	github.com/mitchellh/mapstructure v1.4.2
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/hashicorp/vault/api v1.3.1
 	github.com/hashicorp/vault/api/auth/approle v0.1.0
 	github.com/hashicorp/vault/api/auth/userpass v0.1.0
-	github.com/hashicorp/vault/sdk v0.3.1-0.20220112143259-b48602fdb885
+	github.com/hashicorp/vault/sdk v0.3.1-0.20220222222524-cfa3741426a1
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f


### PR DESCRIPTION
Steps to generate:

1. `go get github.com/hashicorp/vault/sdk@main  `
2. `go mod tidy`
3. `cd api`
4. `go get github.com/hashicorp/vault/sdk@main  `
5. `go mod tidy`

EDIT:

I removed the api upgrade by running go get github.com/hashicorp/vault/sdk@v0.3.1 and go mod tidy. 