### PR TITLE
Clarify service_registration stanza version

### DIFF
--- a/website/content/docs/configuration/service-registration/consul.mdx
+++ b/website/content/docs/configuration/service-registration/consul.mdx
@@ -11,14 +11,13 @@ description: >-
 # Consul Service Registration
 
 Consul Service Registration registers Vault as a service in [Consul][consul] with
-a default health check. 
+a default health check. When Consul is configured as the storage backend, the stanza
+`service_registration` is not needed as it will automatically register Vault as a service.
 
-`service_registration` is not needed when using Consul as Vault's storage backend as Consul will automatically register Vault as a service. 
+~> **Version information:** The `service_registration` configuration option was introduced in Vault 1.4.0.
 
 - **HashiCorp Supported** – Consul Service Registration is officially supported
   by HashiCorp.
-
-~> **Version information** `service_registration` configuration option was introduced in Vault 1.4.0.
 
 ```hcl
 service_registration "consul" {

--- a/website/content/docs/configuration/service-registration/consul.mdx
+++ b/website/content/docs/configuration/service-registration/consul.mdx
@@ -16,6 +16,8 @@ a default health check.
 - **HashiCorp Supported** – Consul Service Registration is officially supported
   by HashiCorp.
 
+~> **Version information** Service Registration is only available on Vault 1.4.0 and above.
+
 ```hcl
 service_registration "consul" {
   address      = "127.0.0.1:8500"

--- a/website/content/docs/configuration/service-registration/consul.mdx
+++ b/website/content/docs/configuration/service-registration/consul.mdx
@@ -13,7 +13,7 @@ description: >-
 Consul Service Registration registers Vault as a service in [Consul][consul] with
 a default health check. 
 
-`service_registration` is not needed when using Consul as Vault's storage backend, as consul will automatically register Vault as a consul service. 
+`service_registration` is not needed when using Consul as Vault's storage backend as Consul will automatically register Vault as a service. 
 
 - **HashiCorp Supported** – Consul Service Registration is officially supported
   by HashiCorp.

--- a/website/content/docs/configuration/service-registration/consul.mdx
+++ b/website/content/docs/configuration/service-registration/consul.mdx
@@ -11,12 +11,14 @@ description: >-
 # Consul Service Registration
 
 Consul Service Registration registers Vault as a service in [Consul][consul] with
-a default health check.
+a default health check. 
+
+`service_registration` is not needed when using Consul as Vault's storage backend, as consul will automatically register Vault as a consul service. 
 
 - **HashiCorp Supported** – Consul Service Registration is officially supported
   by HashiCorp.
 
-~> **Version information** Service Registration is only available on Vault 1.4.0 and above.
+~> **Version information** `service_registration` configuration option was introduced in Vault 1.4.0.
 
 ```hcl
 service_registration "consul" {


### PR DESCRIPTION
A refactoring of https://github.com/hashicorp/vault/pull/8776

This PR simply clarifies in the docs when the `service_registration` configuration option was added to Vault, and that it is not required when using Consul as the storage backend for Vault.