### PR TITLE
agent/azure: adds ability to use specific user-assigned managed identities for auto auth

### DIFF
--- a/changelog/14214.txt
+++ b/changelog/14214.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Adds ability to configure specific user-assigned managed identities for Azure auto-auth.
+```

--- a/command/agent/auth/azure/azure.go
+++ b/command/agent/auth/azure/azure.go
@@ -87,7 +87,7 @@ func NewAzureAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 	case a.resource == "":
 		return nil, errors.New("'resource' value is empty")
 	case a.objectID != "" && a.clientID != "":
-		return nil, errors.New("only one of 'object_id' or 'client_id' can be set")
+		return nil, errors.New("only one of 'object_id' or 'client_id' may be provided")
 	}
 
 	return a, nil

--- a/command/agent/auth/azure/azure.go
+++ b/command/agent/auth/azure/azure.go
@@ -30,6 +30,8 @@ type azureMethod struct {
 
 	role     string
 	resource string
+	objectID string
+	clientID string
 }
 
 func NewAzureAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
@@ -63,11 +65,29 @@ func NewAzureAuthMethod(conf *auth.AuthConfig) (auth.AuthMethod, error) {
 		return nil, errors.New("could not convert 'resource' config value to string")
 	}
 
+	objectIDRaw, ok := conf.Config["object_id"]
+	if ok {
+		a.objectID, ok = objectIDRaw.(string)
+		if !ok {
+			return nil, errors.New("could not convert 'object_id' config value to string")
+		}
+	}
+
+	clientIDRaw, ok := conf.Config["client_id"]
+	if ok {
+		a.clientID, ok = clientIDRaw.(string)
+		if !ok {
+			return nil, errors.New("could not convert 'client_id' config value to string")
+		}
+	}
+
 	switch {
 	case a.role == "":
 		return nil, errors.New("'role' value is empty")
 	case a.resource == "":
 		return nil, errors.New("'resource' value is empty")
+	case a.objectID != "" && a.clientID != "":
+		return nil, errors.New("only one of 'object_id' or 'client_id' can be set")
 	}
 
 	return a, nil
@@ -86,7 +106,7 @@ func (a *azureMethod) Authenticate(ctx context.Context, client *api.Client) (ret
 		}
 	}
 
-	body, err := getMetadataInfo(ctx, instanceEndpoint, "")
+	body, err := getMetadataInfo(ctx, instanceEndpoint, "", "", "")
 	if err != nil {
 		retErr = err
 		return
@@ -103,7 +123,7 @@ func (a *azureMethod) Authenticate(ctx context.Context, client *api.Client) (ret
 		AccessToken string `json:"access_token"`
 	}
 
-	body, err = getMetadataInfo(ctx, identityEndpoint, a.resource)
+	body, err = getMetadataInfo(ctx, identityEndpoint, a.resource, a.objectID, a.clientID)
 	if err != nil {
 		retErr = err
 		return
@@ -138,7 +158,7 @@ func (a *azureMethod) CredSuccess() {
 func (a *azureMethod) Shutdown() {
 }
 
-func getMetadataInfo(ctx context.Context, endpoint, resource string) ([]byte, error) {
+func getMetadataInfo(ctx context.Context, endpoint, resource, objectID, clientID string) ([]byte, error) {
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, err
@@ -148,6 +168,12 @@ func getMetadataInfo(ctx context.Context, endpoint, resource string) ([]byte, er
 	q.Add("api-version", apiVersion)
 	if resource != "" {
 		q.Add("resource", resource)
+	}
+	if objectID != "" {
+		q.Add("object_id", objectID)
+	}
+	if clientID != "" {
+		q.Add("client_id", clientID)
 	}
 	req.URL.RawQuery = q.Encode()
 	req.Header.Set("Metadata", "true")

--- a/website/content/docs/agent/autoauth/methods/azure.mdx
+++ b/website/content/docs/agent/autoauth/methods/azure.mdx
@@ -19,11 +19,11 @@ on the value of the `resource` parameter.
 - `resource` `(string: required)` - The resource name to use when getting instance information
 
 - `object_id` `(string: optional)` - The object ID of the user-assigned managed identity to use
-  when acquiring an [access token][azure-access-token].
-  Only one of `object_id` or `client_id` may be provided.
+  when acquiring an [access token][azure-access-token]. Only one of `object_id` or `client_id`
+  may be provided.
 
 - `client_id` `(string: optional)` - The client ID of the user-assigned managed identity to use
-  when acquiring an [access token][azure-access-token].
-  Only one of `object_id` or `client_id` may be provided.
-  
+  when acquiring an [access token][azure-access-token]. Only one of `object_id` or `client_id`
+  may be provided.
+
 [azure-access-token]: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http

--- a/website/content/docs/agent/autoauth/methods/azure.mdx
+++ b/website/content/docs/agent/autoauth/methods/azure.mdx
@@ -17,3 +17,13 @@ on the value of the `resource` parameter.
 - `role` `(string: required)` - The role to authenticate against on Vault
 
 - `resource` `(string: required)` - The resource name to use when getting instance information
+
+- `object_id` `(string: optional)` - The object ID of the user-assigned managed identity to use
+  when acquiring an [access token](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http).
+  This parameter is interchangeable with `client_id`. Only one of `object_id` and `client_id` can
+  be set.
+
+- `client_id` `(string: optional)` - The client ID of the user-assigned managed identity to use
+  when acquiring an [access token](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http).
+  This parameter is interchangeable with `object_id`. Only one of `object_id` and `client_id` can
+  be set.

--- a/website/content/docs/agent/autoauth/methods/azure.mdx
+++ b/website/content/docs/agent/autoauth/methods/azure.mdx
@@ -20,10 +20,8 @@ on the value of the `resource` parameter.
 
 - `object_id` `(string: optional)` - The object ID of the user-assigned managed identity to use
   when acquiring an [access token](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http).
-  This parameter is interchangeable with `client_id`. Only one of `object_id` and `client_id` can
-  be set.
+  This parameter is interchangeable with `client_id`. Only one of `object_id` or `client_id` may be provided.
 
 - `client_id` `(string: optional)` - The client ID of the user-assigned managed identity to use
   when acquiring an [access token](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http).
-  This parameter is interchangeable with `object_id`. Only one of `object_id` and `client_id` can
-  be set.
+  This parameter is interchangeable with `object_id`. Only one of `object_id` or `client_id` may be provided.

--- a/website/content/docs/agent/autoauth/methods/azure.mdx
+++ b/website/content/docs/agent/autoauth/methods/azure.mdx
@@ -19,9 +19,11 @@ on the value of the `resource` parameter.
 - `resource` `(string: required)` - The resource name to use when getting instance information
 
 - `object_id` `(string: optional)` - The object ID of the user-assigned managed identity to use
-  when acquiring an [access token](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http).
+  when acquiring an [access token][azure-access-token].
   Only one of `object_id` or `client_id` may be provided.
 
 - `client_id` `(string: optional)` - The client ID of the user-assigned managed identity to use
-  when acquiring an [access token](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http).
+  when acquiring an [access token][azure-access-token].
   Only one of `object_id` or `client_id` may be provided.
+  
+[azure-access-token]: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http

--- a/website/content/docs/agent/autoauth/methods/azure.mdx
+++ b/website/content/docs/agent/autoauth/methods/azure.mdx
@@ -20,8 +20,8 @@ on the value of the `resource` parameter.
 
 - `object_id` `(string: optional)` - The object ID of the user-assigned managed identity to use
   when acquiring an [access token](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http).
-  This parameter is interchangeable with `client_id`. Only one of `object_id` or `client_id` may be provided.
+  Only one of `object_id` or `client_id` may be provided.
 
 - `client_id` `(string: optional)` - The client ID of the user-assigned managed identity to use
   when acquiring an [access token](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http).
-  This parameter is interchangeable with `object_id`. Only one of `object_id` or `client_id` may be provided.
+  Only one of `object_id` or `client_id` may be provided.


### PR DESCRIPTION
## Overview

This PR adds the ability to specify the `object_id` xor `client_id` when configuring Vault agent auto-auth for Azure. This enables users that have more than one user-assigned managed identity associated with their VM to specify which one they'd like to use when authenticating via Vault's Azure auth method.

Note that providing these parameters is an "exclusive or". During my testing, I saw that providing both resulted in an error:
```
curl -s -H Metadata:true 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/&client_id=redacted&object_id=redacted' | jq
{
  "error": "invalid_request",
  "error_description": "Only one of 'client_id', 'object_id', 'principal_id', or 'mi_res_id' may be provided"
}
```

## Testing

I tested that using these parameters to [request an access token](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http) works when more than one user-assigned managed identity is associated with a VM.

Tested auto-auth using both `client_id` and `object_id` for different user-assigned managed identities:
```
auto_auth {
  method "azure" {
    config = {
      role = "dev-role"
      resource = "https://management.azure.com/"
      client_id = "<client_id>"
      # object_id = "<object_id>"
    }
  }

  sink "file" {
    config = {
      path = "${WORKDIR}/tokens/vault.token"
    }
  }
}
```