### PR TITLE
UI/fix db role ttl display

### DIFF
--- a/changelog/14224.txt
+++ b/changelog/14224.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ ui: Fix default TTL display and set on database role
+```

--- a/ui/app/models/database/role.js
+++ b/ui/app/models/database/role.js
@@ -26,7 +26,7 @@ export default Model.extend({
     noDefault: true,
     possibleValues: ['static', 'dynamic'],
   }),
-  ttl: attr({
+  default_ttl: attr({
     editType: 'ttl',
     defaultValue: '1h',
     label: 'Generated credentials’s Time-to-Live (TTL)',
@@ -98,7 +98,7 @@ export default Model.extend({
   roleSettingAttrs: computed(function () {
     // logic for which get displayed is on DatabaseRoleSettingForm
     let allRoleSettingFields = [
-      'ttl',
+      'default_ttl',
       'max_ttl',
       'username',
       'rotation_period',

--- a/ui/app/templates/components/database-role-edit.hbs
+++ b/ui/app/templates/components/database-role-edit.hbs
@@ -63,6 +63,14 @@
           @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
           @value={{stringify (get @model attr.name)}}
         />
+      {{else if (eq attr.options.editType "ttl")}}
+        <InfoTableRow
+          @alwaysRender={{true}}
+          @defaultShown={{defaultDisplay}}
+          @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}
+          @value={{format-duration (get @model attr.name)}}
+          @isLink={{eq attr.name "database"}}
+        />
       {{else}}
         <InfoTableRow
           @alwaysRender={{true}}

--- a/ui/app/utils/database-helpers.js
+++ b/ui/app/utils/database-helpers.js
@@ -175,7 +175,7 @@ export const AVAILABLE_PLUGIN_TYPES = [
 
 export const ROLE_FIELDS = {
   static: ['username', 'rotation_period'],
-  dynamic: ['ttl', 'max_ttl'],
+  dynamic: ['default_ttl', 'max_ttl'],
 };
 
 export const STATEMENT_FIELDS = {

--- a/ui/tests/integration/components/database-role-setting-form-test.js
+++ b/ui/tests/integration/components/database-role-setting-form-test.js
@@ -11,7 +11,7 @@ const testCases = [
     staticRoleFields: ['name', 'username', 'rotation_period', 'rotation_statements'],
     dynamicRoleFields: [
       'name',
-      'ttl',
+      'default_ttl',
       'max_ttl',
       'creation_statements',
       'revocation_statements',
@@ -22,49 +22,49 @@ const testCases = [
   {
     pluginType: 'elasticsearch-database-plugin',
     staticRoleFields: ['username', 'rotation_period'],
-    dynamicRoleFields: ['creation_statement', 'ttl', 'max_ttl'],
+    dynamicRoleFields: ['creation_statement', 'default_ttl', 'max_ttl'],
   },
   {
     pluginType: 'mongodb-database-plugin',
     staticRoleFields: ['username', 'rotation_period'],
-    dynamicRoleFields: ['creation_statement', 'revocation_statement', 'ttl', 'max_ttl'],
+    dynamicRoleFields: ['creation_statement', 'revocation_statement', 'default_ttl', 'max_ttl'],
     statementsHidden: true,
   },
   {
     pluginType: 'mssql-database-plugin',
     staticRoleFields: ['username', 'rotation_period'],
-    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'ttl', 'max_ttl'],
+    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'default_ttl', 'max_ttl'],
   },
   {
     pluginType: 'mysql-database-plugin',
     staticRoleFields: ['username', 'rotation_period'],
-    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'ttl', 'max_ttl'],
+    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'default_ttl', 'max_ttl'],
   },
   {
     pluginType: 'mysql-aurora-database-plugin',
     staticRoleFields: ['username', 'rotation_period'],
-    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'ttl', 'max_ttl'],
+    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'default_ttl', 'max_ttl'],
   },
   {
     pluginType: 'mysql-rds-database-plugin',
     staticRoleFields: ['username', 'rotation_period'],
-    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'ttl', 'max_ttl'],
+    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'default_ttl', 'max_ttl'],
   },
   {
     pluginType: 'mysql-legacy-database-plugin',
     staticRoleFields: ['username', 'rotation_period'],
-    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'ttl', 'max_ttl'],
+    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'default_ttl', 'max_ttl'],
   },
   {
     pluginType: 'vault-plugin-database-oracle',
     staticRoleFields: ['username', 'rotation_period'],
-    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'ttl', 'max_ttl'],
+    dynamicRoleFields: ['creation_statements', 'revocation_statements', 'default_ttl', 'max_ttl'],
   },
 ];
 
 // used to calculate checks that fields do NOT show up
 const ALL_ATTRS = [
-  { name: 'ttl', type: 'string', options: {} },
+  { name: 'default_ttl', type: 'string', options: {} },
   { name: 'max_ttl', type: 'string', options: {} },
   { name: 'username', type: 'string', options: {} },
   { name: 'rotation_period', type: 'string', options: {} },


### PR DESCRIPTION
This PR fixes a UI issue where the TTL looked like it never changed from 1h (the default) when really the adapter was not parsing the correct value from the API, which is `default_ttl`. 