### PR TITLE
chore: bump docs-page for code-block fix

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -22,7 +22,7 @@
         "@hashicorp/react-button": "^6.0.1",
         "@hashicorp/react-call-to-action": "^4.1.1",
         "@hashicorp/react-consent-manager": "^7.0.1",
-        "@hashicorp/react-docs-page": "^14.14.2",
+        "@hashicorp/react-docs-page": "^14.14.3",
         "@hashicorp/react-featured-slider": "^5.0.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-hero": "^8.0.2",
@@ -1803,11 +1803,11 @@
       }
     },
     "node_modules/@hashicorp/platform-docs-mdx": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.3.tgz",
-      "integrity": "sha512-NPVvn3s/JuFfebvymJ9JkOd6CHKfCVISz/QenmPgPim1nzJfe3uXKFeqolYdfMb8k1++XpX7KM70nJMVDyQLpw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4.tgz",
+      "integrity": "sha512-/yAZDWR7pgrTkNzoNxZXyWZ1dvSO+KVw5/ZFsUR8d+kZhSKqiLAHVEAH6i7Jd4GlW074OytUzWmA3Je2jAVetA==",
       "dependencies": {
-        "@hashicorp/react-code-block": "^4.1.0",
+        "@hashicorp/react-code-block": "^4.4.2",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
@@ -1968,16 +1968,133 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "4.1.5",
-      "integrity": "sha512-94IHagrdqxvoPE130b2FOvyeSZ26DIhaNSnZ3b/isKMpaNdWjoi/uo+nckRu3auiSyxldbMty8W5EXclgGkCEA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
+      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
-        "@reach/listbox": "0.15.0",
+        "@reach/listbox": "0.16.2",
         "shellwords": "^0.1.1"
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
+      }
+    },
+    "node_modules/@hashicorp/react-code-block/node_modules/@reach/auto-id": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
+      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
+      "dependencies": {
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/react-code-block/node_modules/@reach/descendants": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
+      "dependencies": {
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/react-code-block/node_modules/@reach/listbox": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.16.2.tgz",
+      "integrity": "sha512-UBotBw7X8e2ajHn6tg1M9ArinisvSvwtu/aP3edEQKCvobd95nAa+dqnfAdihPAQFH2AQ2NFfa/73yawWV3LOQ==",
+      "dependencies": {
+        "@reach/auto-id": "0.16.0",
+        "@reach/descendants": "0.16.1",
+        "@reach/machine": "0.16.0",
+        "@reach/popover": "0.16.2",
+        "@reach/utils": "0.16.0",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/react-code-block/node_modules/@reach/machine": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.16.0.tgz",
+      "integrity": "sha512-c8SRQz2xGtg5M9aXuuM5pFgaV1ZW5/nyMIYpZzBwHUlNFKGO+VBhwedbnqUxO0yLcbgl3wPvjPh740O3YjqiHg==",
+      "dependencies": {
+        "@reach/utils": "0.16.0",
+        "@xstate/fsm": "1.4.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/react-code-block/node_modules/@reach/popover": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.16.2.tgz",
+      "integrity": "sha512-IwkRrHM7Vt33BEkSXneovymJv7oIToOfTDwRKpuYEB/BWYMAuNfbsRL7KVe6MjkgchDeQzAk24cYY1ztQj5HQQ==",
+      "dependencies": {
+        "@reach/portal": "0.16.2",
+        "@reach/rect": "0.16.0",
+        "@reach/utils": "0.16.0",
+        "tabbable": "^4.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/react-code-block/node_modules/@reach/portal": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
+      "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
+      "dependencies": {
+        "@reach/utils": "0.16.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/react-code-block/node_modules/@reach/rect": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz",
+      "integrity": "sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==",
+      "dependencies": {
+        "@reach/observe-rect": "1.2.0",
+        "@reach/utils": "0.16.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/react-code-block/node_modules/@reach/utils": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
+      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@hashicorp/react-consent-manager": {
@@ -2009,11 +2126,11 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "14.14.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.2.tgz",
-      "integrity": "sha512-3OKvIomaqD8y4G81P/EdXyf74RlnNSfmsGD6K57pCmlilUJRj3g8xVP7JFzjgsufY2PYoLlKfBViYztZrH56gQ==",
+      "version": "14.14.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3.tgz",
+      "integrity": "sha512-prRWKE/Ykr+LGouJgdYfxTOMrpjRQf72IJYFUrZx+wL+LV+bT5hFNyWiHgJWNKg7DCUMQreX7RNAidzNOoxc6g==",
       "dependencies": {
-        "@hashicorp/platform-docs-mdx": "^0.1.3",
+        "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
         "@hashicorp/react-content": "^8.2.1",
@@ -23538,11 +23655,11 @@
       }
     },
     "@hashicorp/platform-docs-mdx": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.3.tgz",
-      "integrity": "sha512-NPVvn3s/JuFfebvymJ9JkOd6CHKfCVISz/QenmPgPim1nzJfe3uXKFeqolYdfMb8k1++XpX7KM70nJMVDyQLpw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4.tgz",
+      "integrity": "sha512-/yAZDWR7pgrTkNzoNxZXyWZ1dvSO+KVw5/ZFsUR8d+kZhSKqiLAHVEAH6i7Jd4GlW074OytUzWmA3Je2jAVetA==",
       "requires": {
-        "@hashicorp/react-code-block": "^4.1.0",
+        "@hashicorp/react-code-block": "^4.4.2",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
@@ -23665,12 +23782,99 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "4.1.5",
-      "integrity": "sha512-94IHagrdqxvoPE130b2FOvyeSZ26DIhaNSnZ3b/isKMpaNdWjoi/uo+nckRu3auiSyxldbMty8W5EXclgGkCEA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
+      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
-        "@reach/listbox": "0.15.0",
+        "@reach/listbox": "0.16.2",
         "shellwords": "^0.1.1"
+      },
+      "dependencies": {
+        "@reach/auto-id": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
+          "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
+          "requires": {
+            "@reach/utils": "0.16.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@reach/descendants": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+          "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
+          "requires": {
+            "@reach/utils": "0.16.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@reach/listbox": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.16.2.tgz",
+          "integrity": "sha512-UBotBw7X8e2ajHn6tg1M9ArinisvSvwtu/aP3edEQKCvobd95nAa+dqnfAdihPAQFH2AQ2NFfa/73yawWV3LOQ==",
+          "requires": {
+            "@reach/auto-id": "0.16.0",
+            "@reach/descendants": "0.16.1",
+            "@reach/machine": "0.16.0",
+            "@reach/popover": "0.16.2",
+            "@reach/utils": "0.16.0",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@reach/machine": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.16.0.tgz",
+          "integrity": "sha512-c8SRQz2xGtg5M9aXuuM5pFgaV1ZW5/nyMIYpZzBwHUlNFKGO+VBhwedbnqUxO0yLcbgl3wPvjPh740O3YjqiHg==",
+          "requires": {
+            "@reach/utils": "0.16.0",
+            "@xstate/fsm": "1.4.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@reach/popover": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.16.2.tgz",
+          "integrity": "sha512-IwkRrHM7Vt33BEkSXneovymJv7oIToOfTDwRKpuYEB/BWYMAuNfbsRL7KVe6MjkgchDeQzAk24cYY1ztQj5HQQ==",
+          "requires": {
+            "@reach/portal": "0.16.2",
+            "@reach/rect": "0.16.0",
+            "@reach/utils": "0.16.0",
+            "tabbable": "^4.0.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@reach/portal": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
+          "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
+          "requires": {
+            "@reach/utils": "0.16.0",
+            "tiny-warning": "^1.0.3",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@reach/rect": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz",
+          "integrity": "sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==",
+          "requires": {
+            "@reach/observe-rect": "1.2.0",
+            "@reach/utils": "0.16.0",
+            "prop-types": "^15.7.2",
+            "tiny-warning": "^1.0.3",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@reach/utils": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
+          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
+          "requires": {
+            "tiny-warning": "^1.0.3",
+            "tslib": "^2.3.0"
+          }
+        }
       }
     },
     "@hashicorp/react-consent-manager": {
@@ -23693,11 +23897,11 @@
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "14.14.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.2.tgz",
-      "integrity": "sha512-3OKvIomaqD8y4G81P/EdXyf74RlnNSfmsGD6K57pCmlilUJRj3g8xVP7JFzjgsufY2PYoLlKfBViYztZrH56gQ==",
+      "version": "14.14.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3.tgz",
+      "integrity": "sha512-prRWKE/Ykr+LGouJgdYfxTOMrpjRQf72IJYFUrZx+wL+LV+bT5hFNyWiHgJWNKg7DCUMQreX7RNAidzNOoxc6g==",
       "requires": {
-        "@hashicorp/platform-docs-mdx": "^0.1.3",
+        "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
         "@hashicorp/react-content": "^8.2.1",

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "@hashicorp/react-button": "^6.0.1",
     "@hashicorp/react-call-to-action": "^4.1.1",
     "@hashicorp/react-consent-manager": "^7.0.1",
-    "@hashicorp/react-docs-page": "^14.14.2",
+    "@hashicorp/react-docs-page": "^14.14.3",
     "@hashicorp/react-featured-slider": "^5.0.1",
     "@hashicorp/react-head": "^3.1.2",
     "@hashicorp/react-hero": "^8.0.2",


### PR DESCRIPTION
👀 [Preview][preview]

This PR bumps to the latest `@hashicorp/react-docs-page` release, in order to fix an underlying issue in `@hashicorp/react-code-block` (via `@hashicorp/platform-docs-mdx`).

This fix is specific to Firefox browsers, and with this fix, newlines are now included when manually selecting and copying `code-block` contents.

See https://github.com/hashicorp/react-components/pull/503 for further details.

## Review notes

When using [Firefox](https://www.mozilla.org/en-US/firefox/new/):

- On [the live site][live], manually selecting code block contents, copying, and pasting into a plain text editor should result in missing newlines.
- On [the preview][preview], manually selecting code block contents, copying, and pasting into a plain text editor should result in the expected content, with newlines intact.

[preview]: https://vault-git-zsbump-docs-page-hashicorp.vercel.app/docs/configuration
[live]: https://www.vaultproject.io/docs/configuration
