### PR TITLE
Fix broken interactions between glob_domains and wildcards

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -328,10 +328,8 @@ func validateNames(b *backend, data *inputBundle, names []string) string {
 				// First, allow an exact match of the base domain if that role flag
 				// is enabled
 				if data.role.AllowBareDomains &&
-					(strings.EqualFold(sanitizedName, currDomain) ||
-						(isEmail && strings.EqualFold(emailDomain, currDomain)) ||
-							// Handle the use case of AllowedDomain being an email address
-							(isEmail && strings.EqualFold(name, currDomain))) {
+					(strings.EqualFold(name, currDomain) ||
+						(isEmail && strings.EqualFold(emailDomain, currDomain))) {
 					valid = true
 					break
 				}
@@ -346,7 +344,7 @@ func validateNames(b *backend, data *inputBundle, names []string) string {
 
 				if data.role.AllowGlobDomains &&
 					strings.Contains(currDomain, "*") &&
-					glob.Glob(currDomain, sanitizedName) {
+					glob.Glob(currDomain, name) {
 					valid = true
 					break
 				}

--- a/changelog/14235.txt
+++ b/changelog/14235.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fix issuance of wildcard certificates matching glob patterns
+```


### PR DESCRIPTION
Backport of https://github.com/hashicorp/vault/pull/14235 to v1.8.x

```
* Allow issuance of wildcard via glob match

From Vault v1.8.0 onwards, we would incorrectly disallow issuance of a
wildcard certificate when allow_glob_domain was enabled with a
multi-part glob domain in allowed_domains (such as *.*.foo) when
attempting to issue a wildcard for a subdomain (such as *.bar.foo).

This fixes that by reverting an errant change in the case insensitivity
patch. Here, when validating against a very powerful glob construct, we
leave the wildcard prefix (*.) from the raw common_name element, to
allow multi-part globs to match wildcard entries.

It is important to note that "sanitizedName" is an incorrect variable
naming here. Wildcard parsing (per RFC 6125 which supercedes RFC 2818)
must be in the left-most segment of the domain, but we lack validation
to ensure no internal wildcards exist. Additionally per item 3 of
section 6.4.3 of RFC 6125, wildcards MAY be internal to a domain
segment, in which case sanitizedName again leaves the wildcard in place.

Resolves: #13530

Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>

* Remove duplicate email address check

As pointed out by Steven Clark (author of the removed conditional in
70012cd865b3dcdab376dba0c0e0abc88c48f508), this is duplicate from the
now-reintroduced comparison against name (versus the erroneous
sanitizedName at the time of his commit).

This is a reversion of the changes to builtin/logical/pki/cert_util.go,
but keeping the additional valuable test cases.

Co-authored-by: Steven Clark <steven.clark@hashicorp.com>
Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>

* Add multi-dimensional PKI role issuance tests

This commit introduces multi-dimensional testing of PKI secrets engine's
role-based certificate issuance with the intent of preventing future
regressions.

Here, dimensions of testing include:

 - AllowedDomains to decide which domains are approved for issuance,
 - AllowBareDomains to decide if raw entries of AllowedDomains are
   permitted,
 - AllowGlobDomains to decide if glob patterns in AllowedDomains are
   parsed,
 - AllowSubdomains to decide if subdomains of AllowedDomains are
   permitted,
 - AllowLocalhost to decide if localhost identifiers are permitted, and
 - CommonName of the certificate to request.

Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>

* Add changelog entry

Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>

Co-authored-by: Steven Clark <steven.clark@hashicorp.com>
```