### PR TITLE
Mirage MFA Fix

### DIFF
--- a/ui/tests/acceptance/mfa-test.js
+++ b/ui/tests/acceptance/mfa-test.js
@@ -4,12 +4,13 @@ import { click, currentRouteName, fillIn, visit } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import ENV from 'vault/config/environment';
 
-ENV['ember-cli-mirage'].handler = 'mfa';
-
 module('Acceptance | mfa', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  hooks.before(function () {
+    ENV['ember-cli-mirage'].handler = 'mfa';
+  });
   hooks.beforeEach(function () {
     this.select = async (select = 0, option = 1) => {
       const selector = `[data-test-mfa-select="${select}"]`;
@@ -22,7 +23,6 @@ module('Acceptance | mfa', function (hooks) {
   });
 
   const login = async (user) => {
-    // MfaHandler(server);
     await visit('/vault/auth');
     await fillIn('[data-test-select="auth-method"]', 'userpass');
     await fillIn('[data-test-username]', user);


### PR DESCRIPTION
This is another attempt to use the mfa mirage hanlder in the mfa acceptance test without breaking other tests. The initial set of the handler env variable has been moved back to the before test hook.