### PR TITLE
builtin/logical/transit: fix dropped test error

### DIFF
--- a/builtin/logical/transit/path_config_test.go
+++ b/builtin/logical/transit/path_config_test.go
@@ -366,7 +366,9 @@ func TestTransit_UpdateKeyConfigWithAutorotation(t *testing.T) {
 			_, err = client.Logical().Write(fmt.Sprintf("transit/keys/%s", keyName), map[string]interface{}{
 				"auto_rotate_period": test.initialAutoRotatePeriod,
 			})
-
+			if err != nil {
+				t.Fatal(err)
+			}
 			resp, err := client.Logical().Write(fmt.Sprintf("transit/keys/%s/config", keyName), map[string]interface{}{
 				"auto_rotate_period": test.newAutoRotatePeriod,
 			})


### PR DESCRIPTION
This fixes a dropped test `err` variable in `builtin/logical/transit`.

Could someone add the "no-changelog" label?