### PR TITLE
plugin/database: update changelog to include db config connection return value change

### DIFF
--- a/changelog/14033.txt
+++ b/changelog/14033.txt
@@ -1,3 +1,7 @@
 ```release-note:feature
 **Database plugin multiplexing**: manage multiple database connections with a single plugin process
 ```
+
+```release-note:change
+plugin/database: The return value from `POST /database/config/:name` has been updated to "204 No Content"
+```


### PR DESCRIPTION
# Description

Update the return value for `POST /database/config/:name` to `< HTTP/1.1 204 No Content`

Previously vault returned a `< HTTP/1.1 200 OK` response.

This may well break stuff, but it's probably okay anyway. Rationale: anything that's insisting on a 200 specifically rather than 2xx is probably incorrect