### PR TITLE
Replace docs references to PUT with POST

### DIFF
--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -131,7 +131,7 @@ $ curl \
 The API documentation uses `LIST` as the HTTP verb, but you can still use `GET`
 with the `?list=true` query string.
 
-To use an API that consumes data via request body, issue a `POST` or `PUT`:
+To use an API that consumes data via request body, issue a `POST`:
 
 ```text
 /v1/secret/foo

--- a/website/content/api-docs/secret/aws.mdx
+++ b/website/content/api-docs/secret/aws.mdx
@@ -525,7 +525,7 @@ created before queried.
 | Method | Path               |
 | :----- | :----------------- |
 | `GET`  | `/aws/creds/:name` |
-| `PUT`  | `/aws/sts/:name`   |
+| `POST` | `/aws/sts/:name`   |
 
 The `/aws/creds` and `/aws/sts` endpoints are almost identical. The exception is
 when retrieving credentials for a role that was specified with the legacy `arn`

--- a/website/content/api-docs/secret/cubbyhole.mdx
+++ b/website/content/api-docs/secret/cubbyhole.mdx
@@ -99,7 +99,6 @@ This endpoint stores a secret at the specified location.
 | Method | Path               |
 | :----- | :----------------- |
 | `POST` | `/cubbyhole/:path` |
-| `PUT`  | `/cubbyhole/:path` |
 
 ### Parameters
 

--- a/website/content/api-docs/secret/key-management/awskms.mdx
+++ b/website/content/api-docs/secret/key-management/awskms.mdx
@@ -20,7 +20,7 @@ the given parameter values.
 
 | Method | Path                 |
 | :----- | :------------------- |
-| `PUT`  | `/keymgmt/kms/:name` |
+| `POST  | `/keymgmt/kms/:name` |
 
 ### Parameters
 

--- a/website/content/api-docs/secret/key-management/azurekeyvault.mdx
+++ b/website/content/api-docs/secret/key-management/azurekeyvault.mdx
@@ -21,7 +21,7 @@ the given parameter values.
 
 | Method | Path                 |
 | :----- | :------------------- |
-| `PUT`  | `/keymgmt/kms/:name` |
+| `POST` | `/keymgmt/kms/:name` |
 
 ### Parameters
 

--- a/website/content/api-docs/secret/key-management/gcpkms.mdx
+++ b/website/content/api-docs/secret/key-management/gcpkms.mdx
@@ -21,7 +21,7 @@ the given parameter values.
 
 | Method | Path                 |
 | :----- | :------------------- |
-| `PUT`  | `/keymgmt/kms/:name` |
+| `POST` | `/keymgmt/kms/:name` |
 
 ### Parameters
 

--- a/website/content/api-docs/secret/key-management/index.mdx
+++ b/website/content/api-docs/secret/key-management/index.mdx
@@ -137,7 +137,7 @@ This endpoint updates a named key.
 
 | Method | Path                 |
 | :----- | :------------------- |
-| `PUT`  | `/keymgmt/key/:name` |
+| `POST` | `/keymgmt/key/:name` |
 
 ### Parameters
 
@@ -165,7 +165,7 @@ This endpoint updates a named key.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/keymgmt/key/example-key
 ```
@@ -176,7 +176,7 @@ This endpoint rotates the version of a named key.
 
 | Method | Path                        |
 | :----- | :-------------------------- |
-| `PUT`  | `/keymgmt/key/:name/rotate` |
+| `POST` | `/keymgmt/key/:name/rotate` |
 
 ### Parameters
 
@@ -188,7 +188,7 @@ This endpoint rotates the version of a named key.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     http://127.0.0.1:8200/v1/keymgmt/key/example-key/rotate
 ```
 
@@ -256,7 +256,7 @@ the given parameter values.
 
 | Method | Path                 |
 | :----- | :------------------- |
-| `PUT`  | `/keymgmt/kms/:name` |
+| `POST` | `/keymgmt/kms/:name` |
 
 ### Parameters
 
@@ -306,7 +306,7 @@ set for each of the parameters listed below.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/keymgmt/kms/example-kms
 ```
@@ -402,7 +402,7 @@ provider. The parameters set cannot be changed after the key has been distribute
 
 | Method | Path                               |
 | :----- | :--------------------------------- |
-| `PUT`  | `/keymgmt/kms/:name/key/:key_name` |
+| `POST` | `/keymgmt/kms/:name/key/:key_name` |
 
 ### Parameters
 
@@ -444,7 +444,7 @@ provider. The parameters set cannot be changed after the key has been distribute
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/keymgmt/kms/example-kms/key/example-key
 ```

--- a/website/content/api-docs/secret/kv/kv-v1.mdx
+++ b/website/content/api-docs/secret/kv/kv-v1.mdx
@@ -110,7 +110,6 @@ policy granting the `update` capability.
 | Method | Path            |
 | :----- | :-------------- |
 | `POST` | `/secret/:path` |
-| `PUT`  | `/secret/:path` |
 
 ### Parameters
 

--- a/website/content/api-docs/system/audit.mdx
+++ b/website/content/api-docs/system/audit.mdx
@@ -54,7 +54,7 @@ single word name or a more complex, nested path.
 
 | Method | Path               |
 | :----- | :----------------- |
-| `PUT`  | `/sys/audit/:path` |
+| `POST` | `/sys/audit/:path` |
 
 ### Parameters
 
@@ -91,7 +91,7 @@ relevant functionality is only supported in Vault Enterprise:
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/audit/example-audit
 ```

--- a/website/content/api-docs/system/config-auditing.mdx
+++ b/website/content/api-docs/system/config-auditing.mdx
@@ -82,7 +82,7 @@ This endpoint enables auditing of a header.
 
 | Method | Path                                         |
 | :----- | :------------------------------------------- |
-| `PUT`  | `/sys/config/auditing/request-headers/:name` |
+| `POST` | `/sys/config/auditing/request-headers/:name` |
 
 ### Parameters
 
@@ -102,7 +102,7 @@ This endpoint enables auditing of a header.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/config/auditing/request-headers/my-header
 ```

--- a/website/content/api-docs/system/config-control-group.mdx
+++ b/website/content/api-docs/system/config-control-group.mdx
@@ -41,7 +41,7 @@ This endpoint allows configuring control groups.
 
 | Method | Path                        |
 | :----- | :-------------------------- |
-| `PUT`  | `/sys/config/control-group` |
+| `POST` | `/sys/config/control-group` |
 
 ### Parameters
 
@@ -60,7 +60,7 @@ This endpoint allows configuring control groups.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/config/control-group
 ```

--- a/website/content/api-docs/system/config-cors.mdx
+++ b/website/content/api-docs/system/config-cors.mdx
@@ -55,7 +55,7 @@ cross-origin requests, as well as headers that are allowed on cross-origin reque
 
 | Method | Path               |
 | :----- | :----------------- |
-| `PUT`  | `/sys/config/cors` |
+| `POST` | `/sys/config/cors` |
 
 ### Parameters
 
@@ -77,7 +77,7 @@ cross-origin requests, as well as headers that are allowed on cross-origin reque
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/config/cors
 ```

--- a/website/content/api-docs/system/config-reload.mdx
+++ b/website/content/api-docs/system/config-reload.mdx
@@ -11,7 +11,7 @@ Currently, it only supports reloading license information from files on disk.
 
 | Method | Path                          |
 | :----- | :---------------------------- |
-| `PUT`  | `/sys/config/reload/:subsystem` |
+| `POST` | `/sys/config/reload/:subsystem` |
 
 ### Parameters
 
@@ -31,7 +31,7 @@ of the given license are different from those of the license Vault is currently 
 
 ```shell-session
 $ curl \
-  -X PUT \
+  -X POST \
   --header "X-Vault-Token: ..." \
     'http://127.0.0.1:8200/v1/sys/config/reload/license'
 ```

--- a/website/content/api-docs/system/config-ui.mdx
+++ b/website/content/api-docs/system/config-ui.mdx
@@ -63,7 +63,7 @@ This endpoint allows configuring the values to be returned for the UI header.
 
 | Method | Path                           |
 | :----- | :----------------------------- |
-| `PUT`  | `/sys/config/ui/headers/:name` |
+| `POST` | `/sys/config/ui/headers/:name` |
 
 ### Parameters
 
@@ -84,7 +84,7 @@ This endpoint allows configuring the values to be returned for the UI header.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/config/ui/headers/X-Custom-Header
 ```

--- a/website/content/api-docs/system/generate-recovery-token.mdx
+++ b/website/content/api-docs/system/generate-recovery-token.mdx
@@ -65,7 +65,7 @@ recovery token generation attempt can take place at a time.
 
 | Method | Path                                   |
 | :----- | :------------------------------------- |
-| `PUT`  | `/sys/generate-recovery-token/attempt` |
+| `POST` | `/sys/generate-recovery-token/attempt` |
 
 ### Parameters
 
@@ -77,7 +77,7 @@ recovery token generation attempt can take place at a time.
 
 ```shell-session
 $ curl \
-    --request PUT \
+    --request POST \
     http://127.0.0.1:8200/v1/sys/generate-recovery-token/attempt
 ```
 
@@ -127,7 +127,7 @@ only in memory and thus will only be valid until the next restart.
 
 | Method | Path                                  |
 | :----- | :------------------------------------ |
-| `PUT`  | `/sys/generate-recovery-token/update` |
+| `POST` | `/sys/generate-recovery-token/update` |
 
 ### Parameters
 
@@ -148,7 +148,7 @@ only in memory and thus will only be valid until the next restart.
 
 ```shell-session
 $ curl \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/generate-recovery-token/update
 ```

--- a/website/content/api-docs/system/generate-root.mdx
+++ b/website/content/api-docs/system/generate-root.mdx
@@ -64,7 +64,7 @@ generation attempt can take place at a time.
 
 | Method | Path                         |
 | :----- | :--------------------------- |
-| `PUT`  | `/sys/generate-root/attempt` |
+| `POST` | `/sys/generate-root/attempt` |
 
 ### Parameters
 
@@ -76,7 +76,7 @@ generation attempt can take place at a time.
 
 ```shell-session
 $ curl \
-    --request PUT \
+    --request POST \
     http://127.0.0.1:8200/v1/sys/generate-root/attempt
 ```
 
@@ -122,7 +122,7 @@ nonce must be provided with each call.
 
 | Method | Path                        |
 | :----- | :-------------------------- |
-| `PUT`  | `/sys/generate-root/update` |
+| `POST` | `/sys/generate-root/update` |
 
 ### Parameters
 
@@ -143,7 +143,7 @@ nonce must be provided with each call.
 
 ```shell-session
 $ curl \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/generate-root/update
 ```

--- a/website/content/api-docs/system/init.mdx
+++ b/website/content/api-docs/system/init.mdx
@@ -39,7 +39,7 @@ available when using Auto Unseal.
 
 | Method | Path        |
 | :----- | :---------- |
-| `PUT`  | `/sys/init` |
+| `POST`  | `/sys/init` |
 
 ### Parameters
 
@@ -91,7 +91,7 @@ Additionally, the following options are only supported using Auto Unseal:
 
 ```shell-session
 $ curl \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/init
 ```

--- a/website/content/api-docs/system/leases.mdx
+++ b/website/content/api-docs/system/leases.mdx
@@ -14,7 +14,7 @@ This endpoint retrieve lease metadata.
 
 | Method | Path                 |
 | :----- | :------------------- |
-| `PUT`  | `/sys/leases/lookup` |
+| `POST` | `/sys/leases/lookup` |
 
 ### Parameters
 
@@ -33,7 +33,7 @@ This endpoint retrieve lease metadata.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/leases/lookup
 ```
@@ -87,7 +87,7 @@ cannot be renewed using this endpoint, use instead the auth/token/renew endpoint
 
 | Method | Path                |
 | :----- | :------------------ |
-| `PUT`  | `/sys/leases/renew` |
+| `POST` | `/sys/leases/renew` |
 
 ### Parameters
 
@@ -113,7 +113,7 @@ cannot be renewed using this endpoint, use instead the auth/token/renew endpoint
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/leases/renew
 ```
@@ -134,7 +134,7 @@ This endpoint revokes a lease immediately.
 
 | Method | Path                 |
 | :----- | :------------------- |
-| `PUT`  | `/sys/leases/revoke` |
+| `POST` | `/sys/leases/revoke` |
 
 ### Parameters
 
@@ -159,7 +159,7 @@ This endpoint revokes a lease immediately.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/leases/revoke
 ```
@@ -180,7 +180,7 @@ this endpoint should be tightly controlled.
 
 | Method | Path                               |
 | :----- | :--------------------------------- |
-| `PUT`  | `/sys/leases/revoke-force/:prefix` |
+| `POST` | `/sys/leases/revoke-force/:prefix` |
 
 ### Parameters
 
@@ -192,7 +192,7 @@ this endpoint should be tightly controlled.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     http://127.0.0.1:8200/v1/sys/leases/revoke-force/aws/creds
 ```
 
@@ -207,7 +207,7 @@ used to revoke very large numbers of secrets/tokens at once.
 
 | Method | Path                                |
 | :----- | :---------------------------------- |
-| `PUT`  | `/sys/leases/revoke-prefix/:prefix` |
+| `POST` | `/sys/leases/revoke-prefix/:prefix` |
 
 ### Parameters
 
@@ -222,7 +222,7 @@ used to revoke very large numbers of secrets/tokens at once.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     http://127.0.0.1:8200/v1/sys/leases/revoke-prefix/aws/creds
 ```
 

--- a/website/content/api-docs/system/license.mdx
+++ b/website/content/api-docs/system/license.mdx
@@ -88,7 +88,7 @@ performance replication cluster, this must be run against a Vault instance withi
 
 | Method | Path           |
 | :----- | :------------- |
-| `PUT`  | `/sys/license` |
+| `POST` | `/sys/license` |
 
 ### Parameters
 
@@ -121,7 +121,7 @@ capabilities = ["update"]
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/license
 ```
@@ -163,7 +163,7 @@ In the response:
 * `persisted_autoload` is the autoloaded license the active node last wrote to
   storage; this is only used to detect inconsistently licensed nodes in the
   cluster. It cannot be used as a license itself.
-* `stored` is the stored license if any, i.e. one written using `PUT sys/license`.
+* `stored` is the stored license if any, i.e. one written using `POST sys/license`.
 
 `autoloaded`, `persisted_autoload`, and `stored` all have the same structure,
 which is also the same structure as the top-level `data` returned by `GET sys/license`.

--- a/website/content/api-docs/system/plugins-catalog.mdx
+++ b/website/content/api-docs/system/plugins-catalog.mdx
@@ -100,7 +100,7 @@ supplied name.
 
 | Method | Path                               |
 | :----- | :--------------------------------- |
-| `PUT`  | `/sys/plugins/catalog/:type/:name` |
+| `POST` | `/sys/plugins/catalog/:type/:name` |
 
 ### Parameters
 
@@ -140,7 +140,7 @@ supplied name.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/plugins/catalog/secret/example-plugin
 ```

--- a/website/content/api-docs/system/plugins-reload-backend.mdx
+++ b/website/content/api-docs/system/plugins-reload-backend.mdx
@@ -17,7 +17,7 @@ This endpoint reloads mounted plugin backends.
 
 | Method | Path -                        |
 | :----- | :---------------------------- |
-| `PUT`  | `/sys/plugins/reload/backend` |
+| `POST` | `/sys/plugins/reload/backend` |
 
 ### Parameters
 
@@ -44,7 +44,7 @@ This endpoint reloads mounted plugin backends.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/plugins/reload/backend
 ```

--- a/website/content/api-docs/system/policies-password.mdx
+++ b/website/content/api-docs/system/policies-password.mdx
@@ -29,7 +29,7 @@ generation times.
 
 | Method | Path                           |
 | :----- | :----------------------------- |
-| `PUT`  | `/sys/policies/password/:name` |
+| `POST` | `/sys/policies/password/:name` |
 
 ### Parameters
 
@@ -60,7 +60,7 @@ $ cat payload.json
 
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/policies/password/my-policy
 ```

--- a/website/content/api-docs/system/policies.mdx
+++ b/website/content/api-docs/system/policies.mdx
@@ -73,7 +73,7 @@ updated, it takes effect immediately to all associated users.
 
 | Method | Path                      |
 | :----- | :------------------------ |
-| `PUT`  | `/sys/policies/acl/:name` |
+| `POST`  | `/sys/policies/acl/:name` |
 
 ### Parameters
 
@@ -96,7 +96,7 @@ updated, it takes effect immediately to all associated users.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/policies/acl/my-policy
 ```
@@ -187,7 +187,7 @@ updated, it takes effect immediately to all associated users.
 
 | Method | Path                      |
 | :----- | :------------------------ |
-| `PUT`  | `/sys/policies/rgp/:name` |
+| `POST` | `/sys/policies/rgp/:name` |
 
 ### Parameters
 
@@ -215,7 +215,7 @@ updated, it takes effect immediately to all associated users.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/policies/rgp/webapp
 ```
@@ -313,7 +313,7 @@ updated, it takes effect immediately to all associated users.
 
 | Method | Path                      |
 | :----- | :------------------------ |
-| `PUT`  | `/sys/policies/egp/:name` |
+| `POST` | `/sys/policies/egp/:name` |
 
 ### Parameters
 
@@ -347,7 +347,7 @@ updated, it takes effect immediately to all associated users.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/policies/egp/breakglass
 ```

--- a/website/content/api-docs/system/policy.mdx
+++ b/website/content/api-docs/system/policy.mdx
@@ -69,7 +69,7 @@ updated, it takes effect immediately to all associated users.
 
 | Method | Path                |
 | :----- | :------------------ |
-| `PUT`  | `/sys/policy/:name` |
+| `POST` | `/sys/policy/:name` |
 
 ### Parameters
 
@@ -91,7 +91,7 @@ updated, it takes effect immediately to all associated users.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/policy/my-policy
 ```

--- a/website/content/api-docs/system/raw.mdx
+++ b/website/content/api-docs/system/raw.mdx
@@ -56,7 +56,7 @@ mount system.
 
 | Method | Path             |
 | :----- | :--------------- |
-| `PUT`  | `/sys/raw/:path` |
+| `POST`  | `/sys/raw/:path` |
 
 ### Parameters
 
@@ -85,7 +85,7 @@ mount system.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/raw/secret/foo
 ```

--- a/website/content/api-docs/system/rekey-recovery-key.mdx
+++ b/website/content/api-docs/system/rekey-recovery-key.mdx
@@ -62,7 +62,7 @@ nonce.
 
 | Method | Path                           |
 | :----- | :----------------------------- |
-| `PUT`  | `/sys/rekey-recovery-key/init` |
+| `POST` | `/sys/rekey-recovery-key/init` |
 
 ### Parameters
 
@@ -108,7 +108,7 @@ nonce.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/rekey-recovery-key/init
 ```
@@ -197,7 +197,7 @@ for the verification operation.
 
 | Method | Path                             |
 | :----- | :------------------------------- |
-| `PUT`  | `/sys/rekey-recovery-key/update` |
+| `POST` | `/sys/rekey-recovery-key/update` |
 
 ### Parameters
 
@@ -219,7 +219,7 @@ for the verification operation.
 ```shell-session
 $ curl \
     --header "X-Vault-Token" \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/rekey-recovery-key/update
 ```
@@ -322,7 +322,7 @@ below; otherwise the response will be the same as the `GET` method against
 
 | Method | Path                             |
 | :----- | :------------------------------- |
-| `PUT`  | `/sys/rekey-recovery-key/verify` |
+| `POST` | `/sys/rekey-recovery-key/verify` |
 
 ### Parameters
 
@@ -346,7 +346,7 @@ below; otherwise the response will be the same as the `GET` method against
 ```shell-session
 $ curl \
     --header "X-Vault-Token" \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/rekey-recovery-key/verify
 ```

--- a/website/content/api-docs/system/rekey.mdx
+++ b/website/content/api-docs/system/rekey.mdx
@@ -62,7 +62,7 @@ and starting a new rekey, which will also provide a new nonce.
 
 | Method | Path              |
 | :----- | :---------------- |
-| `PUT`  | `/sys/rekey/init` |
+| `POST` | `/sys/rekey/init` |
 
 ### Parameters
 
@@ -108,7 +108,7 @@ and starting a new rekey, which will also provide a new nonce.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/rekey/init
 ```
@@ -197,7 +197,7 @@ for the verification operation.
 
 | Method | Path                |
 | :----- | :------------------ |
-| `PUT`  | `/sys/rekey/update` |
+| `POST` | `/sys/rekey/update` |
 
 ### Parameters
 
@@ -219,7 +219,7 @@ for the verification operation.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/rekey/update
 ```
@@ -322,7 +322,7 @@ below; otherwise the response will be the same as the `GET` method against
 
 | Method | Path                |
 | :----- | :------------------ |
-| `PUT`  | `/sys/rekey/verify` |
+| `POST` | `/sys/rekey/verify` |
 
 ### Parameters
 
@@ -346,7 +346,7 @@ below; otherwise the response will be the same as the `GET` method against
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/rekey/verify
 ```

--- a/website/content/api-docs/system/replication/replication-dr.mdx
+++ b/website/content/api-docs/system/replication/replication-dr.mdx
@@ -530,7 +530,7 @@ generation attempt can take place at a time.
 
 | Method | Path                                                             |
 | :----- | :--------------------------------------------------------------- |
-| `PUT`  | `/sys/replication/dr/secondary/generate-operation-token/attempt` |
+| `POST` | `/sys/replication/dr/secondary/generate-operation-token/attempt` |
 
 ### Parameters
 
@@ -542,7 +542,7 @@ generation attempt can take place at a time.
 
 ```shell-session
 $ curl \
-    --request PUT \
+    --request POST \
     http://127.0.0.1:8200/v1/sys/replication/dr/secondary/generate-operation-token/attempt
 ```
 
@@ -588,7 +588,7 @@ nonce must be provided with each call.
 
 | Method | Path                                                            |
 | :----- | :-------------------------------------------------------------- |
-| `PUT`  | `/sys/replication/dr/secondary/generate-operation-token/update` |
+| `POST` | `/sys/replication/dr/secondary/generate-operation-token/update` |
 
 ### Parameters
 
@@ -609,7 +609,7 @@ nonce must be provided with each call.
 
 ```shell-session
 $ curl \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/replication/dr/secondary/generate-operation-token/update
 ```

--- a/website/content/api-docs/system/rotate.mdx
+++ b/website/content/api-docs/system/rotate.mdx
@@ -19,13 +19,13 @@ This path requires `sudo` capability in addition to `update`.
 
 | Method | Path          |
 | :----- | :------------ |
-| `PUT`  | `/sys/rotate` |
+| `POST` | `/sys/rotate` |
 
 ### Sample Request
 
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     http://127.0.0.1:8200/v1/sys/rotate
 ```

--- a/website/content/api-docs/system/seal.mdx
+++ b/website/content/api-docs/system/seal.mdx
@@ -16,13 +16,13 @@ Standby nodes should be restarted to get the same effect. Requires a token with
 
 | Method | Path        |
 | :----- | :---------- |
-| `PUT`  | `/sys/seal` |
+| `POST` | `/sys/seal` |
 
 ### Sample Request
 
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     http://127.0.0.1:8200/v1/sys/seal
 ```

--- a/website/content/api-docs/system/step-down.mdx
+++ b/website/content/api-docs/system/step-down.mdx
@@ -19,13 +19,13 @@ the path.
 
 | Method | Path             |
 | :----- | :--------------- |
-| `PUT`  | `/sys/step-down` |
+| `POST` | `/sys/step-down` |
 
 ### Sample Request
 
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    --request PUT \
+    --request POST \
     http://127.0.0.1:8200/v1/sys/step-down
 ```

--- a/website/content/api-docs/system/unseal.mdx
+++ b/website/content/api-docs/system/unseal.mdx
@@ -20,7 +20,7 @@ Either the `key` or `reset` parameter must be provided; if both are provided,
 
 | Method | Path          |
 | :----- | :------------ |
-| `PUT`  | `/sys/unseal` |
+| `POST` | `/sys/unseal` |
 
 ### Parameters
 
@@ -46,7 +46,7 @@ Either the `key` or `reset` parameter must be provided; if both are provided,
 
 ```shell-session
 $ curl \
-    --request PUT \
+    --request POST \
     --data @payload.json \
     http://127.0.0.1:8200/v1/sys/unseal
 ```

--- a/website/content/docs/auth/jwt/oidc_providers.mdx
+++ b/website/content/docs/auth/jwt/oidc_providers.mdx
@@ -410,7 +410,7 @@ log in.
    # OR equivalent to:
    curl \
       --fail \
-      --request PUT \
+      --request POST \
       --header "X-Vault-Request: true" \
       --data '{"jwt":"<JWT-TOKEN-HERE>","role":"my-role"}' \
       "${VAULT_ADDR}/v1/auth/jwt/login"

--- a/website/content/docs/auth/oci.mdx
+++ b/website/content/docs/auth/oci.mdx
@@ -63,7 +63,7 @@ Follow the steps below to add policies to your tenancy that allow the OCI comput
 - Configure the home_tenancy_id parameter in the Vault.
 
 ```sh
-    curl --header "X-Vault-Token: $roottoken" --request PUT \
+    curl --header "X-Vault-Token: $roottoken" --request POST \
     --data @hometenancyid.json \
     http://127.0.0.1:8200/v1/auth/oci/config (127.0.0.1:8200/v1/auth/oci/config)
 ```
@@ -88,7 +88,7 @@ Group or Dynamic Group OCIDs in your tenancy that has users or instances that yo
 Create the Vault admin role:
 
 ```sh
-    curl --header "X-Vault-Token: $roottoken" --request PUT \
+    curl --header "X-Vault-Token: $roottoken" --request POST \
     --data @vaultadminrole.json \
     http://127.0.0.1:8200/v1/auth/oci/role/vaultadminrole (127.0.0.1:8200/v1/auth/oci/role/vaultadminrole)
 ```
@@ -129,7 +129,7 @@ You will see a response that includes a token with the previously added policy.
 1.  Add the role.
 
 ```sh
-curl --header "X-Vault-Token: $token" --request PUT \
+curl --header "X-Vault-Token: $token" --request POST \
 --data @devrole.json \
 http://127.0.0.1:8200/v1/auth/oci/role/devrole (127.0.0.1:8200/v1/auth/oci/role/devrole)
 ```

--- a/website/content/docs/enterprise/license/autoloading.mdx
+++ b/website/content/docs/enterprise/license/autoloading.mdx
@@ -8,7 +8,7 @@ description: An overview of license autoloading.
 
 Prior to Vault 1.8, Vault Enterprise would be licensed using special binaries
 that contained embedded licenses, or via a license written into Vault storage
-using the [PUT sys/license API](/api/system/license#install-license).
+using the [POST sys/license API](/api/system/license#install-license).
 
 As of Vault 1.8 those options still exist but are deprecated, and the recommended
 mechanism for managing licenses is called License Autoloading. New clusters are

--- a/website/content/docs/platform/k8s/helm/enterprise.mdx
+++ b/website/content/docs/platform/k8s/helm/enterprise.mdx
@@ -116,7 +116,7 @@ Finally, using curl, apply the license key to the Vault API:
 ```bash
 curl \
   --header "X-Vault-Token: VAULT_LOGIN_TOKEN_HERE" \
-  --request PUT \
+  --request POST \
   --data @payload.json \
   http://127.0.0.1:8200/v1/sys/license
 

--- a/website/content/docs/release-notes/1.8.0.mdx
+++ b/website/content/docs/release-notes/1.8.0.mdx
@@ -54,7 +54,7 @@ description: |-
 
 The following API endpoints have been deprecated and will be removed in a future release:
 
-- `PUT sys/license` to store licenses in storage; it is recommended to use
+- `POST sys/license` to store licenses in storage; it is recommended to use
   [License Autoloading](/docs/enterprise/license/autoloading) instead.
 
 - `/gcp/token/:roleset` and `/gcp/key/:roleset` paths for generating secrets for rolesets

--- a/website/content/docs/secrets/ad.mdx
+++ b/website/content/docs/secrets/ad.mdx
@@ -241,7 +241,7 @@ If no service accounts are available for check-out, Vault will return a 400 Bad 
 $ vault write -f ad/library/accounting-team/check-out
 Error writing data to ad/library/accounting-team/check-out: Error making API request.
 
-URL: PUT http://localhost:8200/v1/ad/library/accounting-team/check-out
+URL: POST http://localhost:8200/v1/ad/library/accounting-team/check-out
 Code: 400. Errors:
 
 * No service accounts available for check-out.

--- a/website/content/docs/secrets/aws.mdx
+++ b/website/content/docs/secrets/aws.mdx
@@ -446,7 +446,7 @@ $ vault read aws/creds/deploy
 $ vault revoke aws/creds/deploy/774cfb27-c22d-6e78-0077-254879d1af3c
 Revoke error: Error making API request.
 
-URL: PUT http://127.0.0.1:8200/v1/sys/revoke/aws/creds/deploy/774cfb27-c22d-6e78-0077-254879d1af3c
+URL: POST http://127.0.0.1:8200/v1/sys/revoke/aws/creds/deploy/774cfb27-c22d-6e78-0077-254879d1af3c
 Code: 400. Errors:
 
 * invalid request

--- a/website/content/docs/secrets/consul.mdx
+++ b/website/content/docs/secrets/consul.mdx
@@ -32,7 +32,7 @@ management tool.
     ```shell-session
     $ curl \
         --header "X-Consul-Token: my-management-token" \
-        --request PUT \
+        --request POST \
         --data '{"Name": "sample", "Type": "management"}' \
         https://consul.rocks/v1/acl/create
     ```

--- a/website/content/intro/getting-started/policies.mdx
+++ b/website/content/intro/getting-started/policies.mdx
@@ -163,7 +163,7 @@ version          1
 $ vault kv put secret/foo robot=beepboop
 Error writing data to secret/data/foo: Error making API request.
 
-URL: PUT http://127.0.0.1:8200/v1/secret/data/foo
+URL: POST http://127.0.0.1:8200/v1/secret/data/foo
 Code: 403. Errors:
 
 * permission denied
@@ -178,7 +178,7 @@ Success! Data written to: secret/bar
 $ vault kv put secret/foo robot=beepboop
 Error writing data to secret/foo: Error making API request.
 
-URL: PUT http://127.0.0.1:8200/v1/secret/foo
+URL: POST http://127.0.0.1:8200/v1/secret/foo
 Code: 403. Errors:
 
 * permission denied


### PR DESCRIPTION
The operations are handled identically, but ~85% of the references were
POST, and having a mix of PUT and POST has been a source of questions.

A subsequent commit will update the internal use of "PUT" such as by
the API client and `-output-curl-string`.