### PR TITLE
Fix a bug with single-phase login MFA

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -108,7 +108,7 @@ var (
 	}
 
 	oidcProtectedPathRegex = regexp.MustCompile(`^identity/oidc/provider/\w(([\w-.]+)?\w)?/userinfo$`)
-	mfaMethodIDRegex       = regexp.MustCompile(logical.GenericOptionalUUIDRegex("method_id"))
+	mfaMethodIDRegex       = regexp.MustCompile(logical.LoginMFARegex)
 )
 
 func init() {

--- a/sdk/logical/auth.go
+++ b/sdk/logical/auth.go
@@ -7,6 +7,8 @@ import (
 	sockaddr "github.com/hashicorp/go-sockaddr"
 )
 
+const LoginMFARegex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
 // Auth is the resulting authentication information that is part of
 // Response for credential backends.
 type Auth struct {
@@ -110,5 +112,5 @@ func (a *Auth) GoString() string {
 }
 
 func GenericOptionalUUIDRegex(name string) string {
-	return fmt.Sprintf("(/(?P<%s>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}))?", name)
+	return fmt.Sprintf("(/(?P<%s>%s))?", name, LoginMFARegex)
 }

--- a/sdk/logical/auth.go
+++ b/sdk/logical/auth.go
@@ -108,3 +108,7 @@ type Auth struct {
 func (a *Auth) GoString() string {
 	return fmt.Sprintf("*%#v", *a)
 }
+
+func GenericOptionalUUIDRegex(name string) string {
+	return fmt.Sprintf("(/(?P<%s>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}))?", name)
+}

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -142,7 +142,7 @@ func (i *IdentityStore) paths() []*framework.Path {
 func mfaPaths(i *IdentityStore) []*framework.Path {
 	return []*framework.Path{
 		{
-			Pattern: "mfa/method/totp" + genericOptionalUUIDRegex("method_id"),
+			Pattern: "mfa/method/totp" + logical.GenericOptionalUUIDRegex("method_id"),
 			Fields: map[string]*framework.FieldSchema{
 				"method_id": {
 					Type:        framework.TypeString,
@@ -271,7 +271,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			},
 		},
 		{
-			Pattern: "mfa/method/okta" + genericOptionalUUIDRegex("method_id"),
+			Pattern: "mfa/method/okta" + logical.GenericOptionalUUIDRegex("method_id"),
 			Fields: map[string]*framework.FieldSchema{
 				"method_id": {
 					Type:        framework.TypeString,
@@ -331,7 +331,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			},
 		},
 		{
-			Pattern: "mfa/method/duo" + genericOptionalUUIDRegex("method_id"),
+			Pattern: "mfa/method/duo" + logical.GenericOptionalUUIDRegex("method_id"),
 			Fields: map[string]*framework.FieldSchema{
 				"method_id": {
 					Type:        framework.TypeString,
@@ -391,7 +391,7 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 			},
 		},
 		{
-			Pattern: "mfa/method/pingid" + genericOptionalUUIDRegex("method_id"),
+			Pattern: "mfa/method/pingid" + logical.GenericOptionalUUIDRegex("method_id"),
 			Fields: map[string]*framework.FieldSchema{
 				"method_id": {
 					Type:        framework.TypeString,

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -89,10 +89,6 @@ func (b *SystemBackend) loginMFAPaths() []*framework.Path {
 	}
 }
 
-func genericOptionalUUIDRegex(name string) string {
-	return fmt.Sprintf("(/(?P<%s>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}))?", name)
-}
-
 type MFABackend struct {
 	Core        *Core
 	mfaLock     *sync.RWMutex


### PR DESCRIPTION
If a method ID is used that does not need a passcode,
for single-phase login, a user passes an empty string to the X-Vault-MFA header.
Currently, this causes an error to be returned that the header value is invalid.