### PR TITLE
Fix KV permissions error

### DIFF
--- a/ui/app/routes/vault/cluster/secrets/backend/list.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/list.js
@@ -113,8 +113,9 @@ export default Route.extend({
         .catch((err) => {
           // if we're at the root we don't want to throw
           if (backendModel && err.httpStatus === 404 && secret === '') {
+            this.set('noMetadataPermissions', false);
             return [];
-          } else if (backendModel.engineType === 'kv' && backendModel.isV2KV) {
+          } else if (err.httpStatus === 403 && backendModel.isV2KV) {
             this.set('noMetadataPermissions', true);
             return [];
           } else {

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -582,6 +582,8 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     let userToken2 = consoleComponent.lastLogOutput;
     await settled();
     await listPage.visitRoot({ backend: enginePath });
+    // confirm they see an empty state and not the get-credentials card
+    await assert.dom('[data-test-empty-state-title]').hasText('No secrets in this backend');
     await settled();
     await listPage.create();
     await settled();

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -595,6 +595,11 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await settled();
     // test if metadata tab there with no read access message and no ability to edit.
     await click(`[data-test-auth-backend-link=${enginePath}]`);
+    await assert
+      .dom('[data-test-get-credentials]')
+      .exists(
+        'They do not have list access so when logged in under the restricted policy the see the get-credentials-card'
+      );
 
     // this fails in IE11 on browserstack so going directly to URL
     await visit(`/vault/secrets/${enginePath}/show/${secretPath}`);

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -598,7 +598,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await assert
       .dom('[data-test-get-credentials]')
       .exists(
-        'They do not have list access so when logged in under the restricted policy the see the get-credentials-card'
+        'They do not have list access so when logged in under the restricted policy they see the get-credentials-card'
       );
 
     // this fails in IE11 on browserstack so going directly to URL


### PR DESCRIPTION
This was a regression bug from this [PR](https://github.com/hashicorp/vault/pull/13872/files). When you first start an engine you are going to error on the model fetch because there are no secrets to list. This caused us to show the get credentials card on a fresh install of a secret engine. Now we're searching for a permissions error.

Will backport to 1.9.