### PR TITLE
Add login enforcement listing

### DIFF
--- a/vault/external_tests/mfa/login_mfa_test.go
+++ b/vault/external_tests/mfa/login_mfa_test.go
@@ -291,6 +291,15 @@ func TestLoginMFA_LoginEnforcement_CRUD(t *testing.T) {
 		t.Fatal("expected input auth method accessors to equal output auth method accessors")
 	}
 
+	// listing should show it
+	resp, err = client.Logical().List("identity/mfa/login-enforcement")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Data["keys"].([]interface{})[0] != "foo" {
+		t.Fatal("expected foo in the list of enforcement names but it wasn't there")
+	}
+
 	// update it
 	data["identity_group_ids"] = []string{radGroupId, sadGroupId}
 	data["identity_entity_ids"] = []string{bobId, aliceId}

--- a/vault/identity_store.go
+++ b/vault/identity_store.go
@@ -215,11 +215,6 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Description: `The unique identifier for this MFA method.`,
 					Required:    true,
 				},
-				"entity_id": {
-					Type:        framework.TypeString,
-					Description: "Entity ID on which the generated secret needs to get stored.",
-					Required:    true,
-				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.UpdateOperation: &framework.PathOperation{
@@ -477,6 +472,11 @@ func mfaPaths(i *IdentityStore) []*framework.Path {
 					Callback: i.handleMFALoginEnforcementDelete,
 					Summary:  "Delete a login enforcement",
 				},
+			},
+		},
+		{
+			Pattern: "mfa/login-enforcement/?$",
+			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
 					Callback: i.handleMFALoginEnforcementList,
 					Summary:  "List login enforcements",

--- a/vault/login_mfa.go
+++ b/vault/login_mfa.go
@@ -621,7 +621,12 @@ func (c *Core) LoginMFACreateToken(ctx context.Context, reqPath string, cachedAu
 }
 
 func (i *IdentityStore) handleMFALoginEnforcementList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	return nil, nil
+	keys, configInfo, err := i.mfaBackend.mfaLoginEnforcementList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return logical.ListResponseWithInfo(keys, configInfo), nil
 }
 
 func (i *IdentityStore) handleMFALoginEnforcementRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -1112,6 +1117,51 @@ func (b *LoginMFABackend) mfaMethodList(ctx context.Context, methodType string) 
 	}
 
 	return keys, configInfo, nil
+}
+
+func (b *LoginMFABackend) mfaLoginEnforcementList(ctx context.Context) ([]string, map[string]interface{}, error) {
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ws := memdb.NewWatchSet()
+	txn := b.db.Txn(false)
+
+	// get all the login enforcements in our namespace
+	iter, err := txn.Get(memDBMFALoginEnforcementsTable, "namespace", ns.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch iterator for login enforcement configs in memdb: %w", err)
+	}
+
+	ws.Add(iter.WatchCh())
+
+	var keys []string
+	enforcementInfo := map[string]interface{}{}
+
+	for {
+		// check for timeouts
+		select {
+		case <-ctx.Done():
+			return keys, enforcementInfo, nil
+		default:
+			break
+		}
+
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		config := raw.(*mfa.MFAEnforcementConfig)
+		keys = append(keys, config.Name)
+		configInfoEntry, err := b.mfaLoginEnforcementConfigToMap(config)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to convert enforcement to map: %w", err)
+		}
+		enforcementInfo[config.Name] = configInfoEntry
+	}
+
+	return keys, enforcementInfo, nil
 }
 
 func (b *LoginMFABackend) mfaLoginEnforcementConfigByNameAndNamespace(name, namespaceId string) (map[string]interface{}, error) {
@@ -2053,6 +2103,13 @@ func loginEnforcementTableSchema() *memdb.TableSchema {
 				Unique: true,
 				Indexer: &memdb.StringFieldIndex{
 					Field: "ID",
+				},
+			},
+			"namespace": {
+				Name:   "namespace",
+				Unique: false,
+				Indexer: &memdb.StringFieldIndex{
+					Field: "NamespaceID",
 				},
 			},
 			"nameAndNamespace": {


### PR DESCRIPTION
After this PR merges, and we merge OSS -> ENT, I'll have an additional follow-on ENT only PR with tests that verify only login enforcements within the same namespace are returned.