### PR TITLE
Sync PKI API and FrameworkField descriptions

### DIFF
--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -20,9 +20,10 @@ Defaults to false (CN is included).`,
 		Type:    framework.TypeString,
 		Default: "pem",
 		Description: `Format for returned data. Can be "pem", "der",
-or "pem_bundle". If "pem_bundle" any private
+or "pem_bundle". If "pem_bundle", any private
 key and issuing cert will be appended to the
-certificate pem. Defaults to "pem".`,
+certificate pem. If "der", the value will be
+base64 encoded. Defaults to "pem".`,
 		AllowedValues: []interface{}{"pem", "der", "pem_bundle"},
 		DisplayAttrs: &framework.DisplayAttributes{
 			Value: "pem",

--- a/builtin/logical/pki/path_config_urls.go
+++ b/builtin/logical/pki/path_config_urls.go
@@ -18,19 +18,19 @@ func pathConfigURLs(b *backend) *framework.Path {
 			"issuing_certificates": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of URLs to be used
-for the issuing certificate attribute`,
+for the issuing certificate attribute. See also RFC 5280 Section 4.2.2.1.`,
 			},
 
 			"crl_distribution_points": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of URLs to be used
-for the CRL distribution points attribute`,
+for the CRL distribution points attribute. See also RFC 5280 Section 4.2.1.13.`,
 			},
 
 			"ocsp_servers": {
 				Type: framework.TypeCommaStringSlice,
 				Description: `Comma-separated list of URLs to be used
-for the OCSP servers attribute`,
+for the OCSP servers attribute. See also RFC 5280 Section 4.2.2.1.`,
 			},
 		},
 

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -91,7 +91,9 @@ this path;
 2) Any key usages requested in the CSR will be
 added to the basic set of key usages used for CA
 certs signed by this path; for instance,
-the non-repudiation flag.`,
+the non-repudiation flag;
+3) Extensions requested in the CSR will be copied
+into the issued certificate.`,
 	}
 
 	return ret

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -226,7 +226,8 @@ certificate and key, they will be overridden._
 
 ### Parameters
 
-- `pem_bundle` `(string: <required>)` – Specifies the key and certificate concatenated in PEM format.
+- `pem_bundle` `(string: <required>)` – Specifies the unencrypted private key
+  and certificate, concatenated in PEM format.
 
 ### Sample Request
 
@@ -298,7 +299,7 @@ the CRL.
 
 ### Parameters
 
-- `expiry` `(string: "72h")` – Specifies the time until expiration.
+- `expiry` `(string: "72h")` – The amount of time the generated CRL should be valid.
 - `disable` `(bool: false)` – Disables or enables CRL building.
 
 ### Sample Payload
@@ -367,14 +368,18 @@ parameter.
 
 - `issuing_certificates` `(array<string>: nil)` – Specifies the URL values for
   the Issuing Certificate field. This can be an array or a comma-separated
-  string list.
+  string list. See also [RFC 5280 Section 4.2.2.1](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.1)
+  for information about about the Authority Information Access field.
 
 - `crl_distribution_points` `(array<string>: nil)` – Specifies the URL values
   for the CRL Distribution Points field. This can be an array or a
-  comma-separated string list.
+  comma-separated string list. See also [RFC 5280 Section 4.2.1.13](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13)
+  for information about the CRL Distribution Points field.
 
 - `ocsp_servers` `(array<string>: nil)` – Specifies the URL values for the OCSP
-  Servers field. This can be an array or a comma-separated string list.
+  Servers field. This can be an array or a comma-separated string list. See also
+  [RFC 5280 Section 4.2.2.1](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.1)
+  for information about about the Authority Information Access field.
 
 ### Sample Payload
 
@@ -475,7 +480,8 @@ can be set in a CSR are supported.
   later_. `kms` is also supported [see below](#managed-keys). This is part of the request URL.
 
 - `common_name` `(string: <required>)` – Specifies the requested CN for the
-  certificate.
+  certificate. If more than one `common_name` is desired, specify the
+  alternative names in the `alt_names` list.
 
 - `alt_names` `(string: "")` – Specifies the requested Subject Alternative
   Names, in a comma-delimited list. These can be host names or email addresses;
@@ -644,7 +650,9 @@ need to request a new certificate.**
   certificate against. This is part of the request URL.
 
 - `common_name` `(string: <required>)` – Specifies the requested CN for the
-  certificate. If the CN is allowed by role policy, it will be issued.
+  certificate. If the CN is allowed by role policy, it will be issued. If more
+  than one `common_name` is desired, specify the alternative names in the
+  `alt_names` list.
 
 - `alt_names` `(string: "")` – Specifies requested Subject Alternative Names, in
   a comma-delimited list. These can be host names or email addresses; they will
@@ -656,7 +664,8 @@ need to request a new certificate.**
   default).
 
 - `uri_sans` `(string: "")` – Specifies the requested URI Subject Alternative
-  Names, in a comma-delimited list.
+  Names, in a comma-delimited list. If any requested URIs do not match role policy,
+  the entire request will be denied.
 
 - `other_sans` `(string: "")` – Specifies custom OID/UTF8-string SANs. These
   must match values specified on the role in `allowed_other_sans` (see role
@@ -668,15 +677,16 @@ need to request a new certificate.**
 - `ttl` `(string: "")` – Specifies requested Time To Live. Cannot be greater
   than the role's `max_ttl` value. If not provided, the role's `ttl` value will
   be used. Note that the role values default to system values if not explicitly
-  set.
+  set. See `not_after` as an alternative for setting an absolute end date
+  (rather than a relative one).
 
-- `format` `(string: "")` – Specifies the format for returned data. Can be
+- `format` `(string: "pem")` – Specifies the format for returned data. Can be
   `pem`, `der`, or `pem_bundle`; defaults to `pem`. If `der`, the output is
   base64 encoded. If `pem_bundle`, the `certificate` field will contain the
   private key and certificate, concatenated; if the issuing CA is not a
   Vault-derived self-signed root, this will be included as well.
 
-- `private_key_format` `(string: "")` – Specifies the format for marshaling the
+- `private_key_format` `(string: "der")` – Specifies the format for marshaling the
   private key. Defaults to `der` which will return either base64-encoded DER or
   PEM-encoded DER, depending on the value of `format`. The other option is
   `pkcs8` which will return the key marshalled as PEM-encoded PKCS8.
@@ -685,6 +695,11 @@ need to request a new certificate.**
   not be included in DNS or Email Subject Alternate Names (as appropriate).
   Useful if the CN is not a hostname or email address, but is instead some
   human-readable identifier.
+
+- `not_after` `(string)` – Set the Not After field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
+  standard devices, `9999-12-31T23:59:59Z`.
 
 ### Sample Payload
 
@@ -788,9 +803,12 @@ request is denied.
 - `name` `(string: <required>)` – Specifies the name of the role to create. This
   is part of the request URL.
 
-- `ttl` `(string: "")` – Specifies the Time To Live value provided as a string
-  duration with time suffix. Hour is the largest suffix. If not set, uses the
-  system default value or the value of `max_ttl`, whichever is shorter.
+- `ttl` `(string: "")` – Specifies the Time To Live value to be used for the
+  validity period of the requested certificate, provided as a string duration
+  with time suffix. Hour is the largest suffix. If not set, uses the system
+  default value or the value of `max_ttl`, whichever is shorter. See
+  `not_after` as an alternative for setting an absolute end date (rather
+  than a relative one).
 
 - `max_ttl` `(string: "")` – Specifies the maximum Time To Live provided as a
   string duration with time suffix. Hour is the largest suffix. If not set,
@@ -805,11 +823,12 @@ request is denied.
    name is included in `allowed_domains`, the match rules for that option
    could permit issuance of a certificate for `localhost`.
 
-- `allowed_domains` `(list: [])` – Specifies the domains of the role. This is
-  used with the `allow_bare_domains`, `allow_subdomains`, and `allow_glob_domains`
-  options to determine the type of matching between these domains and the
-  values of common name, DNS-typed SAN entries, and Email-typed SAN entries.
-  When `allow_any_name` is used, this attribute has no effect.
+- `allowed_domains` `(list: [])` – Specifies the domains this role is allowed
+  to issue certificates for. This is used with the `allow_bare_domains`,
+  `allow_subdomains`, and `allow_glob_domains` options to determine the type
+  of matching between these domains and the values of common name, DNS-typed
+  SAN entries, and Email-typed SAN entries. When `allow_any_name` is used,
+  this attribute has no effect.
 
 ~> **Note**: The three options `allow_bare_domains`, `allow_subdomains`, and
    `allow_glob_domains` are each independent of each other. That is, at least
@@ -822,6 +841,7 @@ request is denied.
 
 - `allowed_domains_template` `(bool: false)` – When set, `allowed_domains`
   may contain templates, as with [ACL Path Templating](/docs/concepts/policies).
+  Non-templated domains are also still permitted.
 
 - `allow_bare_domains` `(bool: false)` – Specifies if clients can request
   certificates matching the value of the actual domains themselves; e.g. if a
@@ -889,6 +909,7 @@ request is denied.
 
 - `allowed_uri_sans_template` `()bool: false)` – When set, `allowed_uri_sans`
   may contain templates, as with [ACL Path Templating](/docs/concepts/policies).
+  Non-templated domains are also still permitted.
 
 - `allowed_other_sans` `(string: "")` – Defines allowed custom OID/UTF8-string
   SANs. This can be a comma-delimited list or a JSON string slice, where
@@ -897,49 +918,73 @@ request is denied.
   may be a `*` to allow any value with that OID.
   Alternatively, specifying a single `*` will allow any `other_sans` input.
 
+- `allowed_serial_numbers` `(string: "")` - If set, an array of allowed serial
+  numbers to be requested during certificate issuance. These values support
+  shell-style globbing. When empty, custom-specified serial numbers will be
+  forbidden. It is strongly recommended to allow Vault to generate random
+  serial numbers instead.
+
 - `server_flag` `(bool: true)` – Specifies if certificates are flagged for
-  server use.
+  server authentication use. See [RFC 5280 Section 4.2.1.12](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12)
+  for information about the Extended Key Usage field.
 
 - `client_flag` `(bool: true)` – Specifies if certificates are flagged for
-  client use.
+  client authentication use. See [RFC 5280 Section 4.2.1.12](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12)
+  for information about the Extended Key Usage field.
 
 - `code_signing_flag` `(bool: false)` – Specifies if certificates are flagged
-  for code signing use.
+  for code signing use. See [RFC 5280 Section 4.2.1.12](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12)
+  for information about the Extended Key Usage field.
 
 - `email_protection_flag` `(bool: false)` – Specifies if certificates are
-  flagged for email protection use.
+  flagged for email protection use. See [RFC 5280 Section 4.2.1.12](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12)
+  for information about the Extended Key Usage field.
 
 - `key_type` `(string: "rsa")` – Specifies the type of key to generate for
   generated private keys and the type of key expected for submitted CSRs.
-  Currently, `rsa` and `ec` are supported, or when signing CSRs `any` can be
-  specified to allow keys of either type and with any bit size (subject to >
-  1024 bits for RSA keys).
+  Currently, `rsa`, `ec`, and `ed25519` are supported, or when signing
+  existing CSRs, `any` can be specified to allow keys of either type
+  and with any bit size (subject to >1024 bits for RSA keys).
 
 - `key_bits` `(int: 2048)` – Specifies the number of bits to use for the
-  generated keys. This will need to be changed for `ec` keys, e.g., 224, 256, 384 or 521.
+  generated keys. Allowed values are 0 (universal default); with
+  `key_type=rsa`, allowed values are: 2048 (default), 3072, or
+  4096; with `key_type=ec`, allowed values are: 224, 256 (default),
+  384, or 521; ignored with `key_type=ed25519`.
+
+- `signature_bits` `(int: 0)` - Specifies the number of bits to use in
+  the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384,
+  and 512 for SHA-2-512. Defaults to 0 to automatically detect based
+  on key length (SHA-2-256 for RSA keys, and matching the curve size
+  for NIST P-Curves).
 
 - `key_usage` `(list: ["DigitalSignature", "KeyAgreement", "KeyEncipherment"])` –
   Specifies the allowed key usage constraint on issued certificates. Valid
   values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply
   drop the `KeyUsage` part of the value. Values are not case-sensitive. To
-  specify no key usage constraints, set this to an empty list.
+  specify no key usage constraints, set this to an empty list. See
+  [RFC 5280 Section 4.2.1.3](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3)
+  for more information about the Key Usage field.
 
 - `ext_key_usage` `(list: [])` –
   Specifies the allowed extended key usage constraint on issued certificates. Valid
   values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply
   drop the `ExtKeyUsage` part of the value. Values are not case-sensitive. To
-  specify no key usage constraints, set this to an empty list.
+  specify no key usage constraints, set this to an empty list. See
+  [RFC 5280 Section 4.2.1.12](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12)
+  for information about the Extended Key Usage field.
 
-- `ext_key_usage_oids` `(string: "")` - A comma-separated string or list of extended key usage oids.
+- `ext_key_usage_oids` `(string: "")` - A comma-separated string or list of extended
+  key usage oids. Useful for adding EKUs not supported by the Go standard library.
 
 - `use_csr_common_name` `(bool: true)` – When used with the CSR signing
   endpoint, the common name in the CSR will be used instead of taken from the
-  JSON data. This does `not` include any requested SANs in the CSR; use
+  JSON data. This does not include any requested SANs in the CSR; use
   `use_csr_sans` for that.
 
 - `use_csr_sans` `(bool: true)` – When used with the CSR signing endpoint, the
   subject alternate names in the CSR will be used instead of taken from the JSON
-  data. This does `not` include the common name in the CSR; use
+  data. This does not include the common name in the CSR; use
   `use_csr_common_name` for that.
 
 - `ou` `(string: "")` – Specifies the OU (OrganizationalUnit) values in the
@@ -970,16 +1015,14 @@ request is denied.
   subject field of issued certificates. This is a comma-separated string or
   JSON array.
 
-- `serial_number` `(string: "")` – Specifies the Serial Number, if any.
-  Otherwise Vault will generate a random serial for you. If you want more than
-  one, specify alternative names in the alt_names map using OID 2.5.4.5.
-
 - `generate_lease` `(bool: false)` – Specifies if certificates issued/signed
   against this role will have Vault leases attached to them. Certificates can be
   added to the CRL by `vault revoke <lease_id>` when certificates are associated
   with leases. It can also be done using the `pki/revoke` endpoint. However,
   when lease generation is disabled, invoking `pki/revoke` would be the only way
-  to add the certificates to the CRL.
+  to add the certificates to the CRL. When large number of certificates are
+  generated with long lifetimes, it is recommended that lease generation be
+  disabled, as large amount of leases adversely affect the startup time of Vault.
 
 - `no_store` `(bool: false)` – If set, certificates issued/signed against this
   role will not be stored in the storage backend. This can improve performance
@@ -998,6 +1041,11 @@ request is denied.
   valid when issuing non-CA certificates.
 
 - `not_before_duration` `(duration: "30s")` – Specifies the duration by which to backdate the NotBefore property.
+
+- `not_after` `(string)` – Set the Not After field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
+  standard devices, `9999-12-31T23:59:59Z`.
 
 ### Sample Payload
 
@@ -1151,7 +1199,8 @@ overwrite the existing cert/key with new values.
   request URL.
 
 - `common_name` `(string: <required>)` – Specifies the requested CN for the
-  certificate.
+  certificate. If more than one `common_name` is desired, specify the
+  alternative names in the `alt_names` list.
 
 - `alt_names` `(string: "")` – Specifies the requested Subject Alternative
   Names, in a comma-delimited list. These can be host names or email addresses;
@@ -1172,7 +1221,8 @@ overwrite the existing cert/key with new values.
 
 - `ttl` `(string: "")` – Specifies the requested Time To Live (after which the
   certificate will be expired). This cannot be larger than the engine's max (or,
-  if not set, the system max).
+  if not set, the system max). See `not_after` as an alternative for setting an
+  absolute end date (rather than a relative one).
 
 - `format` `(string: "pem")` – Specifies the format for returned data. Can be
   `pem`, `der`, or `pem_bundle`. If `der`, the output is base64 encoded. If
@@ -1180,7 +1230,7 @@ overwrite the existing cert/key with new values.
   exported) and certificate, concatenated; if the issuing CA is not a
   Vault-derived self-signed root, this will be included as well.
 
-- `private_key_format` `(string: "")` – Specifies the format for marshaling the
+- `private_key_format` `(string: "der")` – Specifies the format for marshaling the
   private key. Defaults to `der` which will return either base64-encoded DER or
   PEM-encoded DER, depending on the value of `format`. The other option is
   `pkcs8` which will return the key marshalled as PEM-encoded PKCS8.
@@ -1197,7 +1247,7 @@ overwrite the existing cert/key with new values.
   less than that of the signing certificate. A limit of `0` means a literal
   path length of zero.
 
-- `exclude_cn_from_sans` `(bool: false)` – If set, the given `common_name` will
+- `exclude_cn_from_sans` `(bool: false)` – If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).
   Useful if the CN is not a hostname or email address, but is instead some
   human-readable identifier.
@@ -1238,6 +1288,11 @@ overwrite the existing cert/key with new values.
 - `serial_number` `(string: "")` – Specifies the Serial Number, if any.
   Otherwise Vault will generate a random serial for you. If you want more than
   one, specify alternative names in the alt_names map using OID 2.5.4.5.
+
+- `not_after` `(string)` – Set the Not After field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
+  standard devices, `9999-12-31T23:59:59Z`.
 
 ### Managed Keys Parameters
 See [Managed Keys](#managed-keys) for additional details on this feature, if
@@ -1316,10 +1371,11 @@ verbatim.
 
 ### Parameters
 
-- `csr` `(string: <required>)` – Specifies the PEM-encoded CSR.
+- `csr` `(string: <required>)` – Specifies the PEM-encoded CSR to be signed.
 
 - `common_name` `(string: <required>)` – Specifies the requested CN for the
-  certificate.
+  certificate. If more than one `common_name` is desired, specify the
+  alternative names in the `alt_names` list.
 
 - `alt_names` `(string: "")` – Specifies the requested Subject Alternative
   Names, in a comma-delimited list. These can be host names or email addresses;
@@ -1341,7 +1397,8 @@ verbatim.
 - `ttl` `(string: "")` – Specifies the requested Time To Live (after which the
   certificate will be expired). This cannot be larger than the engine's max (or,
   if not set, the system max). However, this can be after the expiration of the
-  signing CA.
+  signing CA. See `not_after` as an alternative for setting an absolute end date
+  (rather than a relative one).
 
 - `format` `(string: "pem")` – Specifies the format for returned data. Can be
   `pem`, `der`, or `pem_bundle`. If `der`, the output is base64 encoded. If
@@ -1355,7 +1412,7 @@ verbatim.
   set to one less than that of the signing certificate. A limit of `0` means a
   literal path length of zero.
 
-- `exclude_cn_from_sans` `(string: "")` – Specifies the given `common_name` will
+- `exclude_cn_from_sans` `(bool: false)` – If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).
   Useful if the CN is not a hostname or email address, but is instead some
   human-readable identifier.
@@ -1405,6 +1462,11 @@ verbatim.
 - `serial_number` `(string: "")` – Specifies the Serial Number, if any.
   Otherwise Vault will generate a random serial for you. If you want more than
   one, specify alternative names in the alt_names map using OID 2.5.4.5.
+
+- `not_after` `(string)` – Set the Not After field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
+  standard devices, `9999-12-31T23:59:59Z`.
 
 ### Sample Payload
 
@@ -1521,7 +1583,9 @@ root CA need be in a client's trust store.
 - `csr` `(string: <required>)` – Specifies the PEM-encoded CSR.
 
 - `common_name` `(string: <required>)` – Specifies the requested CN for the
-  certificate. If the CN is allowed by role policy, it will be issued.
+  certificate. If the CN is allowed by role policy, it will be issued. If
+  more than one `common_name` is desired, specify the alternative names in
+  the `alt_names` list.
 
 - `alt_names` `(string: "")` – Specifies the requested Subject Alternative
   Names, in a comma-delimited list. These can be host names or email addresses;
@@ -1546,7 +1610,8 @@ root CA need be in a client's trust store.
 - `ttl` `(string: "")` – Specifies the requested Time To Live. Cannot be greater
   than the role's `max_ttl` value. If not provided, the role's `ttl` value will
   be used. Note that the role values default to system values if not explicitly
-  set.
+  set. See `not_after` as an alternative for setting an absolute end date
+  (rather than a relative one).
 
 - `format` `(string: "pem")` – Specifies the format for returned data. Can be
   `pem`, `der`, or `pem_bundle`. If `der`, the output is base64 encoded. If
@@ -1554,10 +1619,15 @@ root CA need be in a client's trust store.
   issuing CA is not a Vault-derived self-signed root, it will be concatenated
   with the certificate.
 
-- `exclude_cn_from_sans` `(bool: false)` – If set, the given `common_name` will
+- `exclude_cn_from_sans` `(bool: false)` – If true, the given `common_name` will
   not be included in DNS or Email Subject Alternate Names (as appropriate).
   Useful if the CN is not a hostname or email address, but is instead some
   human-readable identifier.
+
+- `not_after` `(string)` – Set the Not After field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
+  standard devices, `9999-12-31T23:59:59Z`.
 
 ### Sample Payload
 
@@ -1625,13 +1695,20 @@ have access.**
 
 - `ttl` `(string: "")` – Specifies the requested Time To Live. Cannot be greater
   than the engine's `max_ttl` value. If not provided, the engine's `ttl` value
-  will be used, which defaults to system values if not explicitly set.
+  will be used, which defaults to system values if not explicitly set. See
+  `not_after` as an alternative for setting an absolute end date (rather than
+  a relative one).
 
 - `format` `(string: "pem")` – Specifies the format for returned data. Can be
   `pem`, `der`, or `pem_bundle`. If `der`, the output is base64 encoded. If
   `pem_bundle`, the `certificate` field will contain the certificate and, if the
   issuing CA is not a Vault-derived self-signed root, it will be concatenated
   with the certificate.
+
+- `not_after` `(string)` – Set the Not After field of the certificate with
+  specified date value. The value format should be given in UTC format
+  `YYYY-MM-ddTHH:MM:SSZ`. Supports the Y10K end date for IEEE 802.1AR-2018
+  standard devices, `9999-12-31T23:59:59Z`.
 
 ### Sample Payload
 


### PR DESCRIPTION
As pointed out internally, a lot of the API docs and FrameworkField
descriptions of parameters were out of date. This syncs a number of
them, updating their descriptions where relevant.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

There's definitely more of these to do, but this at least gets us started. I'm inclined to open this for review and merge, rather than trying to do them all at once. 