### PR TITLE
Add warning when generate_lease=no_store=true when writing PKI role

### DIFF
--- a/builtin/logical/pki/path_roles.go
+++ b/builtin/logical/pki/path_roles.go
@@ -583,6 +583,7 @@ func (b *backend) pathRoleList(ctx context.Context, req *logical.Request, d *fra
 
 func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	var err error
+	var resp *logical.Response
 	name := data.Get("name").(string)
 
 	entry := &roleEntry{
@@ -644,6 +645,10 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 	// no_store implies generate_lease := false
 	if entry.NoStore {
 		*entry.GenerateLease = false
+		if data.Get("generate_lease").(bool) {
+			resp = &logical.Response{}
+			resp.AddWarning("mutually exclusive values no_store=true and generate_lease=true were both specified; no_store=true takes priority")
+		}
 	} else {
 		*entry.GenerateLease = data.Get("generate_lease").(bool)
 	}
@@ -694,7 +699,7 @@ func (b *backend) pathRoleCreate(ctx context.Context, req *logical.Request, data
 		return nil, err
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func parseKeyUsages(input []string) int {

--- a/changelog/14292.txt
+++ b/changelog/14292.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/pki: Warn when `generate_lease` and `no_store` are both set to `true` on requests.
+```


### PR DESCRIPTION
When `no_store=true`, the value of `generate_lease` is ignored completely
(and set to false). This means that when `generate_lease=true` is
specified by the caller of the API, it is silently swallowed. While
changing the behavior could break callers, setting a warning on the
response (changing from a 204->200 in the process) seems to make the
most sense.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

This probably isn't that important (and can wait for 1.10 branching). I found it when looking at the docs around #14286 and thought it was interesting.

Can be tested with something like:

```
source devvault && vault secrets enable pki
vault write /pki/roles/example-com generate_lease=true no_store=true
```