### PR TITLE
Output full secret path in certain kv commands

### DIFF
--- a/changelog/14301.txt
+++ b/changelog/14301.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets/kv: add full secret path output to table-formatted responses
+```

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -159,7 +159,7 @@ func (c *KVGetCommand) Run(args []string) int {
 	}
 
 	if v2 {
-		outputPath(c.UI, path, false)
+		outputPath(c.UI, path, "Secret Path")
 	}
 
 	if metadata, ok := secret.Data["metadata"]; ok && metadata != nil {

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -158,7 +158,7 @@ func (c *KVGetCommand) Run(args []string) int {
 		tf.printWarnings(c.UI, secret)
 	}
 
-	outputSecretPath(c.UI, path)
+	outputPath(c.UI, path, false)
 
 	if metadata, ok := secret.Data["metadata"]; ok && metadata != nil {
 		c.UI.Info(getHeaderForMap("Metadata", metadata.(map[string]interface{})))

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -158,7 +158,9 @@ func (c *KVGetCommand) Run(args []string) int {
 		tf.printWarnings(c.UI, secret)
 	}
 
-	outputPath(c.UI, path, false)
+	if v2 {
+		outputPath(c.UI, path, false)
+	}
 
 	if metadata, ok := secret.Data["metadata"]; ok && metadata != nil {
 		c.UI.Info(getHeaderForMap("Metadata", metadata.(map[string]interface{})))

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -158,6 +158,8 @@ func (c *KVGetCommand) Run(args []string) int {
 		tf.printWarnings(c.UI, secret)
 	}
 
+	outputSecretPath(c.UI, path)
+
 	if metadata, ok := secret.Data["metadata"]; ok && metadata != nil {
 		c.UI.Info(getHeaderForMap("Metadata", metadata.(map[string]interface{})))
 		OutputData(c.UI, metadata)

--- a/command/kv_helpers.go
+++ b/command/kv_helpers.go
@@ -154,8 +154,12 @@ func kvParseVersionsFlags(versions []string) []string {
 	return versionsOut
 }
 
-func outputSecretPath(ui cli.Ui, path string) {
-	ui.Info(addEqualSigns("Secret Path", len(path)))
+func outputPath(ui cli.Ui, path string, isMetadataPath bool) {
+	header := "Secret Path"
+	if isMetadataPath {
+		header = "Metadata Path"
+	}
+	ui.Info(addEqualSigns(header, len(path)))
 	ui.Info(path)
 	ui.Info("")
 }

--- a/command/kv_helpers.go
+++ b/command/kv_helpers.go
@@ -142,7 +142,7 @@ func getHeaderForMap(header string, data map[string]interface{}) string {
 	// 4 for the column spaces and 5 for the len("value")
 	totalLen := maxKey + 4 + 5
 
-	return addEqualSigns(header, totalLen)
+	return padEqualSigns(header, totalLen)
 }
 
 func kvParseVersionsFlags(versions []string) []string {
@@ -154,18 +154,14 @@ func kvParseVersionsFlags(versions []string) []string {
 	return versionsOut
 }
 
-func outputPath(ui cli.Ui, path string, isMetadataPath bool) {
-	header := "Secret Path"
-	if isMetadataPath {
-		header = "Metadata Path"
-	}
-	ui.Info(addEqualSigns(header, len(path)))
+func outputPath(ui cli.Ui, path string, title string) {
+	ui.Info(padEqualSigns(title, len(path)))
 	ui.Info(path)
 	ui.Info("")
 }
 
 // Pad the table header with equal signs on each side
-func addEqualSigns(header string, totalLen int) string {
+func padEqualSigns(header string, totalLen int) string {
 	equalSigns := totalLen - (len(header) + 2)
 
 	// If we have zero or fewer equal signs bump it back up to two on either

--- a/command/kv_helpers.go
+++ b/command/kv_helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/api"
+	"github.com/mitchellh/cli"
 )
 
 func kvReadRequest(client *api.Client, path string, params map[string]string) (*api.Secret, error) {
@@ -141,6 +142,26 @@ func getHeaderForMap(header string, data map[string]interface{}) string {
 	// 4 for the column spaces and 5 for the len("value")
 	totalLen := maxKey + 4 + 5
 
+	return addEqualSigns(header, totalLen)
+}
+
+func kvParseVersionsFlags(versions []string) []string {
+	versionsOut := make([]string, 0, len(versions))
+	for _, v := range versions {
+		versionsOut = append(versionsOut, strutil.ParseStringSlice(v, ",")...)
+	}
+
+	return versionsOut
+}
+
+func outputSecretPath(ui cli.Ui, path string) {
+	ui.Info(addEqualSigns("Secret Path", len(path)))
+	ui.Info(path)
+	ui.Info("")
+}
+
+// Pad the table header with equal signs on each side
+func addEqualSigns(header string, totalLen int) string {
 	equalSigns := totalLen - (len(header) + 2)
 
 	// If we have zero or fewer equal signs bump it back up to two on either
@@ -155,13 +176,4 @@ func getHeaderForMap(header string, data map[string]interface{}) string {
 	}
 
 	return fmt.Sprintf("%s %s %s", strings.Repeat("=", equalSigns/2), header, strings.Repeat("=", equalSigns/2))
-}
-
-func kvParseVersionsFlags(versions []string) []string {
-	versionsOut := make([]string, 0, len(versions))
-	for _, v := range versions {
-		versionsOut = append(versionsOut, strutil.ParseStringSlice(v, ",")...)
-	}
-
-	return versionsOut
 }

--- a/command/kv_metadata_get.go
+++ b/command/kv_metadata_get.go
@@ -117,6 +117,8 @@ func (c *KVMetadataGetCommand) Run(args []string) int {
 
 	delete(secret.Data, "versions")
 
+	outputPath(c.UI, path, true)
+
 	c.UI.Info(getHeaderForMap("Metadata", secret.Data))
 	OutputSecret(c.UI, secret)
 

--- a/command/kv_metadata_get.go
+++ b/command/kv_metadata_get.go
@@ -117,7 +117,7 @@ func (c *KVMetadataGetCommand) Run(args []string) int {
 
 	delete(secret.Data, "versions")
 
-	outputPath(c.UI, path, true)
+	outputPath(c.UI, path, "Metadata Path")
 
 	c.UI.Info(getHeaderForMap("Metadata", secret.Data))
 	OutputSecret(c.UI, secret)

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -189,7 +189,7 @@ func (c *KVPatchCommand) Run(args []string) int {
 		return OutputSecret(c.UI, secret)
 	}
 
-	outputPath(c.UI, path, false)
+	outputPath(c.UI, path, "Secret Path")
 
 	metadata := secret.Data
 	c.UI.Info(getHeaderForMap("Metadata", metadata))

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -185,7 +185,17 @@ func (c *KVPatchCommand) Run(args []string) int {
 		return code
 	}
 
-	return OutputSecret(c.UI, secret)
+	if Format(c.UI) != "table" {
+		return OutputSecret(c.UI, secret)
+	}
+
+	outputPath(c.UI, path, false)
+
+	metadata := secret.Data
+	c.UI.Info(getHeaderForMap("Metadata", metadata))
+	OutputData(c.UI, metadata)
+
+	return 0
 }
 
 func (c *KVPatchCommand) readThenWrite(client *api.Client, path string, newData map[string]interface{}) (*api.Secret, int) {

--- a/command/kv_patch.go
+++ b/command/kv_patch.go
@@ -185,17 +185,14 @@ func (c *KVPatchCommand) Run(args []string) int {
 		return code
 	}
 
-	if Format(c.UI) != "table" {
-		return OutputSecret(c.UI, secret)
+	if Format(c.UI) == "table" {
+		outputPath(c.UI, path, "Secret Path")
+		metadata := secret.Data
+		c.UI.Info(getHeaderForMap("Metadata", metadata))
+		return OutputData(c.UI, metadata)
 	}
 
-	outputPath(c.UI, path, "Secret Path")
-
-	metadata := secret.Data
-	c.UI.Info(getHeaderForMap("Metadata", metadata))
-	OutputData(c.UI, metadata)
-
-	return 0
+	return OutputSecret(c.UI, secret)
 }
 
 func (c *KVPatchCommand) readThenWrite(client *api.Client, path string, newData map[string]interface{}) (*api.Secret, int) {

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -165,7 +165,7 @@ func (c *KVPutCommand) Run(args []string) int {
 		return OutputSecret(c.UI, secret)
 	}
 
-	outputPath(c.UI, path, false)
+	outputPath(c.UI, path, "Secret Path")
 
 	metadata := secret.Data
 	c.UI.Info(getHeaderForMap("Metadata", metadata))

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -165,7 +165,7 @@ func (c *KVPutCommand) Run(args []string) int {
 		return OutputSecret(c.UI, secret)
 	}
 
-	outputSecretPath(c.UI, path)
+	outputPath(c.UI, path, false)
 
 	metadata := secret.Data
 	c.UI.Info(getHeaderForMap("Metadata", metadata))

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -161,15 +161,24 @@ func (c *KVPutCommand) Run(args []string) int {
 		return PrintRawField(c.UI, secret, c.flagField)
 	}
 
-	if Format(c.UI) != "table" {
-		return OutputSecret(c.UI, secret)
+	// if Format(c.UI) != "table" {
+	// 	return OutputSecret(c.UI, secret)
+	// }
+
+	// outputPath(c.UI, path, "Secret Path")
+
+	// metadata := secret.Data
+	// c.UI.Info(getHeaderForMap("Metadata", metadata))
+	// OutputData(c.UI, metadata)
+
+	// return 0
+
+	if Format(c.UI) == "table" {
+		outputPath(c.UI, path, "Secret Path")
+		metadata := secret.Data
+		c.UI.Info(getHeaderForMap("Metadata", metadata))
+		return OutputData(c.UI, metadata)
 	}
 
-	outputPath(c.UI, path, "Secret Path")
-
-	metadata := secret.Data
-	c.UI.Info(getHeaderForMap("Metadata", metadata))
-	OutputData(c.UI, metadata)
-
-	return 0
+	return OutputSecret(c.UI, secret)
 }

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -161,5 +161,15 @@ func (c *KVPutCommand) Run(args []string) int {
 		return PrintRawField(c.UI, secret, c.flagField)
 	}
 
-	return OutputSecret(c.UI, secret)
+	if Format(c.UI) != "table" {
+		return OutputSecret(c.UI, secret)
+	}
+
+	outputSecretPath(c.UI, path)
+
+	metadata := secret.Data
+	c.UI.Info(getHeaderForMap("Metadata", metadata))
+	OutputData(c.UI, metadata)
+
+	return 0
 }

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -575,7 +575,7 @@ func TestKVMetadataGetCommand(t *testing.T) {
 		{
 			"path_exists",
 			[]string{"kv/foo"},
-			[]string{"=== Metadata Path ===", "kv/metadata/write/foo"},
+			[]string{"== Metadata Path ==", "kv/metadata/foo"},
 			0,
 		},
 	}

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -134,6 +134,12 @@ func TestKVPutCommand(t *testing.T) {
 			v2ExpectedFields,
 			0,
 		},
+		{
+			"v2_secret_path",
+			[]string{"kv/write/foo", "foo=bar"},
+			[]string{"== Secret Path ==", "kv/data/write/foo"},
+			0,
+		},
 	}
 
 	for _, tc := range cases {
@@ -441,6 +447,12 @@ func TestKVGetCommand(t *testing.T) {
 			append(baseV2ExpectedFields, "foo"),
 			0,
 		},
+		{
+			"v2_secret_path",
+			[]string{"kv/read/foo"},
+			[]string{"== Secret Path ==", "kv/data/read/foo"},
+			0,
+		},
 	}
 
 	t.Run("validations", func(t *testing.T) {
@@ -558,6 +570,12 @@ func TestKVMetadataGetCommand(t *testing.T) {
 			"versions_exist",
 			[]string{"kv/foo"},
 			append(expectedTopLevelFields, expectedVersionFields[:]...),
+			0,
+		},
+		{
+			"path_exists",
+			[]string{"kv/foo"},
+			[]string{"=== Metadata Path ===", "kv/metadata/write/foo"},
 			0,
 		},
 	}
@@ -867,6 +885,13 @@ func TestKVPatchCommand_RWMethodSucceeds(t *testing.T) {
 	}
 
 	for _, str := range expectedPatchFields() {
+		if !strings.Contains(combined, str) {
+			t.Errorf("expected %q to contain %q", combined, str)
+		}
+	}
+
+	// Test that full path was output
+	for _, str := range []string{"== Secret Path ==", "kv/data/patch/foo"} {
 		if !strings.Contains(combined, str) {
 			t.Errorf("expected %q to contain %q", combined, str)
 		}

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -447,12 +447,6 @@ func TestKVGetCommand(t *testing.T) {
 			append(baseV2ExpectedFields, "foo"),
 			0,
 		},
-		{
-			"v2_secret_path",
-			[]string{"kv/read/foo"},
-			[]string{"== Secret Path ==", "kv/data/read/foo"},
-			0,
-		},
 	}
 
 	t.Run("validations", func(t *testing.T) {
@@ -570,12 +564,6 @@ func TestKVMetadataGetCommand(t *testing.T) {
 			"versions_exist",
 			[]string{"kv/foo"},
 			append(expectedTopLevelFields, expectedVersionFields[:]...),
-			0,
-		},
-		{
-			"path_exists",
-			[]string{"kv/foo"},
-			[]string{"== Metadata Path ==", "kv/metadata/foo"},
 			0,
 		},
 	}


### PR DESCRIPTION
This PR is meant to mitigate some of the confusion for new Vault users, who often struggle with the discrepancy between the shortened path used by the CLI (`secret/foo`) and the real secret path (`secret/data/foo`). This bites people when they've only worked with the CLI but then need to write a policy or make a logical call with our Go and Ruby client libraries.

With this change, `vault kv get`, `vault kv put`, `vault kv patch`, and `vault kv metadata get` will all output another top-level section when run in `table` output mode. I did not add this to the kv commands that produce just a simple success message, and I did not add it to kv rollback as it seemed irrelevant given the use case.

Examples:

**Creating a new secret:**
```
$ vault kv put secret/my-secret foo=bar
==== Secret Path ====
secret/data/my-secret

======= Metadata =======
Key                Value
---                -----
created_time       2022-02-28T17:29:34.110676Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            1
```

**Reading a secret:**
```
$ vault kv get secret/my-secret
==== Secret Path ====
secret/data/my-secret

======= Metadata =======
Key                Value
---                -----
created_time       2022-02-28T17:29:34.110676Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            1

=== Data ===
Key    Value
---    -----
foo    bar
```

For `kv metadata get`, the same logic is used, but the header is slightly different:
```
$ vault kv metadata get secret/my-secret
===== Metadata Path =====
secret/metadata/my-secret

========== Metadata ==========
Key                     Value
---                     -----
cas_required            false
created_time            2022-02-28T17:29:34.110676Z
current_version         1
custom_metadata         <nil>
delete_version_after    0s
max_versions            0
oldest_version          0
updated_time            2022-02-28T17:29:34.110676Z

====== Version 1 ======
Key              Value
---              -----
created_time     2022-02-28T17:29:34.110676Z
deletion_time    n/a
destroyed        false
```

While "Data Path" may seem more internally accurate and matching with "Metadata Path", I chose to go with "Secret Path" for the main use case (regular kv commands) because I want totally new users who are not familiar with the /data /metadata subcategories to immediately intuit that this is the "real path" to their secret.