### PR TITLE
Fix raft parallel retry bug

### DIFF
--- a/vault/raft.go
+++ b/vault/raft.go
@@ -961,17 +961,17 @@ func (c *Core) JoinRaftCluster(ctx context.Context, leaderInfos []*raft.LeaderJo
 			return err
 		}
 		var wg sync.WaitGroup
-		for i := range leaderInfos {
+		for i := range expandedJoinInfos {
 			wg.Add(1)
 			go func(joinInfo *raft.LeaderJoinInfo) {
 				defer wg.Done()
 				raftInfo, err := c.getRaftChallenge(joinInfo)
 				if err != nil {
-					c.Logger().Trace("failed to get raft challenge", "leader_addr", joinInfo.LeaderAPIAddr, "error", err)
+					c.Logger().Error("failed to get raft challenge", "leader_addr", joinInfo.LeaderAPIAddr, "error", err)
 					return
 				}
 				challengeCh <- raftInfo
-			}(leaderInfos[i])
+			}(expandedJoinInfos[i])
 		}
 		go func() {
 			wg.Wait()


### PR DESCRIPTION
When parallel retries on raft join was added, the `expandedLeaderInfos` array was being used to store the results from go-discover looking up the auto join ips. When getting raft challenges from the cluster nodes, that same array needed to be used. We're currently using `leaderInfos` instead, which means we lose the results of the auto join lookups. This PR changes that to use `expandedLeaderInfos` when fetching raft challenges

Also changes a Trace log to be an Error log, as we noticed we were missing the error log cause our log level wasn't at trace ( which it typically won't be )

This has been tested using the setup here https://github.com/hashicorp/vault-tools/tree/main/users/prat/raft-autojoin-awskms-tf to setup a raft cluster on aws using autojoin