### PR TITLE
Vault documentation: fixed broken link in key management doc

### DIFF
--- a/website/content/docs/secrets/key-management/index.mdx
+++ b/website/content/docs/secrets/key-management/index.mdx
@@ -168,7 +168,7 @@ The following table defines which key types are compatible with each KMS provide
 
 ## Learn
 
-Refer to the [Key Management Secrets Engine](https://learn.hashicorp.com/tutorials/vault/key-management-secrets) guide for
+Refer to the [Key Management Secrets Engine](https://learn.hashicorp.com/collections/vault/key-management) guide for
 a step-by-step tutorial.
 
 ## API


### PR DESCRIPTION
Per [Asana](https://app.asana.com/0/1201712347646323/1201876860865520), the broken link referencing the learn tutorial has been updated to reference the correct link.

:mag:[Deploy Preview](https://vault-git-fix-key-mgmt-broken-link-hashicorp.vercel.app/docs/secrets/key-management#learn)