### PR TITLE
UI/ Client count permissions empty states

### DIFF
--- a/sdk/version/version_base.go
+++ b/sdk/version/version_base.go
@@ -8,7 +8,7 @@ var (
 	// Whether cgo is enabled or not; set at build time
 	CgoEnabled bool
 
-	Version           = "1.10.0"
+	Version           = "1.11.0"
 	VersionPrerelease = "dev1"
 	VersionMetadata   = ""
 )

--- a/ui/app/components/clients/history.js
+++ b/ui/app/components/clients/history.js
@@ -68,15 +68,16 @@ export default class History extends Component {
         id: namespace.label,
       }))
     : [];
+  @tracked selectedAuthMethod = null;
+  @tracked authMethodOptions = [];
 
   // TEMPLATE MESSAGING
   @tracked noActivityDate = '';
   @tracked responseRangeDiffMessage = null;
   @tracked isLoadingQuery = false;
   @tracked licenseStartIsCurrentMonth = this.args.model.activity?.isLicenseDateError || false;
-
-  @tracked selectedAuthMethod = null;
-  @tracked authMethodOptions = [];
+  @tracked isError = false;
+  @tracked errorObject = null;
 
   get versionText() {
     return this.version.isEnterprise
@@ -213,7 +214,7 @@ export default class History extends Component {
         end_time: this.endTimeRequested,
       });
       if (response.id === 'no-data') {
-        // empty response is the only time we want to update the displayed date with the requested time
+        // empty response (204) is the only time we want to update the displayed date with the requested time
         this.startTimeFromResponse = this.startTimeRequested;
         this.noActivityDate = this.startTimeDisplay;
       } else {
@@ -221,6 +222,7 @@ export default class History extends Component {
         this.startTimeFromResponse = response.formattedStartTime;
         this.endTimeFromResponse = response.formattedEndTime;
         this.storage().setItem(INPUTTED_START_DATE, this.startTimeFromResponse);
+        this.isError = false;
       }
       this.queriedActivityResponse = response;
       this.licenseStartIsCurrentMonth = response.isLicenseDateError;
@@ -238,6 +240,8 @@ export default class History extends Component {
         this.responseRangeDiffMessage = null;
       }
     } catch (e) {
+      this.isError = true;
+      this.errorObject = e;
       return e;
     } finally {
       this.isLoadingQuery = false;

--- a/ui/app/components/clients/history.js
+++ b/ui/app/components/clients/history.js
@@ -76,7 +76,6 @@ export default class History extends Component {
   @tracked responseRangeDiffMessage = null;
   @tracked isLoadingQuery = false;
   @tracked licenseStartIsCurrentMonth = this.args.model.activity?.isLicenseDateError || false;
-  @tracked isError = false;
   @tracked errorObject = null;
 
   get versionText() {
@@ -222,7 +221,6 @@ export default class History extends Component {
         this.startTimeFromResponse = response.formattedStartTime;
         this.endTimeFromResponse = response.formattedEndTime;
         this.storage().setItem(INPUTTED_START_DATE, this.startTimeFromResponse);
-        this.isError = false;
       }
       this.queriedActivityResponse = response;
       this.licenseStartIsCurrentMonth = response.isLicenseDateError;
@@ -240,7 +238,6 @@ export default class History extends Component {
         this.responseRangeDiffMessage = null;
       }
     } catch (e) {
-      this.isError = true;
       this.errorObject = e;
       return e;
     } finally {

--- a/ui/app/templates/components/clients/error.hbs
+++ b/ui/app/templates/components/clients/error.hbs
@@ -1,0 +1,25 @@
+<EmptyState
+  @title={{if (eq @error.httpStatus 403) "You are not authorized" "Error"}}
+  @subTitle={{concat "Error " @error.httpStatus}}
+  @icon="skip"
+>
+  {{#if (eq @error.httpStatus 403)}}
+    <p>
+      You must be granted permissions to view this page. Ask your administrator if you think you should have access to the
+      <code>{{@error.path}}</code>
+      endpoint.
+    </p>
+  {{else}}
+    <ul>
+      {{#if @error.message}}
+        <li>{{@error.message}}</li>
+      {{/if}}
+      <hr />
+      {{#each @error.errors as |error|}}
+        <li>
+          {{error}}
+        </li>
+      {{/each}}
+    </ul>
+  {{/if}}
+</EmptyState>

--- a/ui/app/templates/components/clients/error.hbs
+++ b/ui/app/templates/components/clients/error.hbs
@@ -13,8 +13,8 @@
     <ul>
       {{#if @error.message}}
         <li>{{@error.message}}</li>
+        <hr />
       {{/if}}
-      <hr />
       {{#each @error.errors as |error|}}
         <li>
           {{error}}

--- a/ui/app/templates/components/clients/error.hbs
+++ b/ui/app/templates/components/clients/error.hbs
@@ -1,8 +1,4 @@
-<EmptyState
-  @title={{if (eq @error.httpStatus 403) "You are not authorized" "Error"}}
-  @subTitle={{concat "Error " @error.httpStatus}}
-  @icon="skip"
->
+<EmptyState @title={{if (eq @error.httpStatus 403) "You are not authorized" "Error"}} @subTitle={{"Error "}} @icon="skip">
   {{#if (eq @error.httpStatus 403)}}
     <p>
       You must be granted permissions to view this page. Ask your administrator if you think you should have access to the

--- a/ui/app/templates/components/clients/history.hbs
+++ b/ui/app/templates/components/clients/history.hbs
@@ -145,6 +145,7 @@
         {{/if}}
       {{/if}}
     {{else if (and (not @model.startTimeFromLicense) (not this.startTimeFromResponse))}}
+      {{! Empty state for no billing/license start date }}
       <EmptyState @title={{this.versionText.title}} @message={{this.versionText.message}} />
     {{else}}
       <EmptyState

--- a/ui/app/templates/components/clients/history.hbs
+++ b/ui/app/templates/components/clients/history.hbs
@@ -142,14 +142,15 @@
               @timestamp={{this.responseTimestamp}}
             />
           {{/if}}
-        {{else}}
-          <EmptyState @title="No data received" @message="No data exists for that query period. Try searching again." />
         {{/if}}
       {{/if}}
-    {{else if (or (not @model.startTimeFromLicense) (not this.startTimeFromResponse))}}
+    {{else if (and (not @model.startTimeFromLicense) (not this.startTimeFromResponse))}}
       <EmptyState @title={{this.versionText.title}} @message={{this.versionText.message}} />
     {{else}}
-      <EmptyState @title="No data received" @message="No data exists for that query period. Try searching again." />
+      <EmptyState
+        @title={{concat "No data received " (if this.noActivityDate "from ") this.noActivityDate}}
+        @message="No data exists for that query period. Try searching again."
+      />
     {{/if}}
   {{/if}}
 

--- a/ui/app/templates/components/clients/history.hbs
+++ b/ui/app/templates/components/clients/history.hbs
@@ -49,6 +49,8 @@
         {{/if}}
       </EmptyState>
     {{/if}}
+  {{else if (eq this.isError true)}}
+    <Clients::Error @error={{this.errorObject}} />
   {{else}}
     {{#if (eq @model.config.enabled "Off")}}
       <AlertBanner data-test-tracking-disabled @type="warning" @title="Tracking is disabled">

--- a/ui/app/templates/components/clients/history.hbs
+++ b/ui/app/templates/components/clients/history.hbs
@@ -49,7 +49,7 @@
         {{/if}}
       </EmptyState>
     {{/if}}
-  {{else if (eq this.isError true)}}
+  {{else if this.errorObject}}
     <Clients::Error @error={{this.errorObject}} />
   {{else}}
     {{#if (eq @model.config.enabled "Off")}}

--- a/ui/app/templates/vault/cluster/clients/error.hbs
+++ b/ui/app/templates/vault/cluster/clients/error.hbs
@@ -16,8 +16,8 @@
       <ul>
         {{#if @model.message}}
           <li>{{@model.message}}</li>
+          <hr />
         {{/if}}
-        <hr />
         {{#each @model.errors as |error|}}
           <li>
             {{error}}

--- a/ui/app/templates/vault/cluster/clients/error.hbs
+++ b/ui/app/templates/vault/cluster/clients/error.hbs
@@ -1,11 +1,7 @@
 {{#if (eq @model.httpStatus 404)}}
   <NotFound @model={{this.model}} />
 {{else}}
-  <EmptyState
-    @title={{if (eq @model.httpStatus 403) "You are not authorized" "Error"}}
-    @subTitle={{concat "Error " @model.httpStatus}}
-    @icon="skip"
-  >
+  <EmptyState @title={{if (eq @model.httpStatus 403) "You are not authorized" "Error"}} @subTitle={{"Error "}} @icon="skip">
     {{#if (eq @model.httpStatus 403)}}
       <p>
         You must be granted permissions to view this page. Ask your administrator if you think you should have access to the

--- a/ui/tests/acceptance/client-history-test.js
+++ b/ui/tests/acceptance/client-history-test.js
@@ -292,7 +292,7 @@ module('Acceptance | clients history tab', function (hooks) {
     assert.equal(currentURL(), '/vault/clients/history', 'clients/history URL is correct');
     assert
       .dom(SELECTORS.emptyStateTitle)
-      .hasText('No billing start date found', 'Empty state shows no billing start date');
+      .includesText('No start date found', 'Empty state shows no billing start date');
     await click(SELECTORS.monthDropdown);
     await click(this.element.querySelector('[data-test-month-list] button:not([disabled])'));
     await click(SELECTORS.yearDropdown);

--- a/ui/tests/acceptance/client-history-test.js
+++ b/ui/tests/acceptance/client-history-test.js
@@ -253,8 +253,8 @@ module('Acceptance | clients history tab', function (hooks) {
     assert
       .dom(SELECTORS.dateDisplay)
       .hasText(format(licenseStart, 'MMMM yyyy'), 'Shows license date, gives ability to edit');
-    assert.dom('[data-test-popup-menu-trigger="month"]').exists('Dropdown exists to select month');
-    assert.dom('[data-test-popup-menu-trigger="year"]').exists('Dropdown exists to select year');
+    assert.dom(SELECTORS.monthDropdown).exists('Dropdown exists to select month');
+    assert.dom(SELECTORS.yearDropdown).exists('Dropdown exists to select year');
   });
 
   test('shows correct interface if no permissions on license', async function (assert) {

--- a/ui/tests/helpers/clients.js
+++ b/ui/tests/helpers/clients.js
@@ -22,6 +22,7 @@ export const SELECTORS = {
   attributionBlock: '[data-test-clients-attribution]',
   filterBar: '[data-test-clients-filter-bar]',
   rangeDropdown: '[data-test-popup-menu-trigger]',
+  dateDropdownSubmit: '[data-test-date-dropdown-submit]',
 };
 
 export function sendResponse(data, httpStatus = 200) {

--- a/ui/tests/helpers/clients.js
+++ b/ui/tests/helpers/clients.js
@@ -22,6 +22,8 @@ export const SELECTORS = {
   attributionBlock: '[data-test-clients-attribution]',
   filterBar: '[data-test-clients-filter-bar]',
   rangeDropdown: '[data-test-popup-menu-trigger]',
+  monthDropdown: '[data-test-popup-menu-trigger="month"]',
+  yearDropdown: '[data-test-popup-menu-trigger="year"]',
   dateDropdownSubmit: '[data-test-date-dropdown-submit]',
 };
 


### PR DESCRIPTION
Some client count permissions cleanup:

- Adds error handling on component level
- Shows correct empty state when config off for users with limited permissions
![Screen Shot 2022-03-01 at 12 42 38 PM](https://user-images.githubusercontent.com/68122737/156245681-60dd159f-175a-45b3-b09b-ae3e07243a07.png)


- Shows correct empty state when no data exists and user doesn't have config, activity or license permissions, so has to input billing start date.
![Screen Shot 2022-03-01 at 10 36 01 AM](https://user-images.githubusercontent.com/68122737/156228445-67d73992-dff8-4783-a033-b555a6940a0d.png)


