### PR TITLE
Empty state for current tab

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -10,10 +10,10 @@ project "vault" {
     repository = "vault"
     release_branches = [
       "main",
-      "release/1.6.x",
       "release/1.7.x",
       "release/1.8.x",
       "release/1.9.x",
+      "release/1.10.x",
     ]
   }
 }

--- a/ui/app/templates/components/clients/current.hbs
+++ b/ui/app/templates/components/clients/current.hbs
@@ -18,6 +18,11 @@
       @title="No data received"
       @message="Tracking is turned on and Vault is gathering data. It should appear here within 30 minutes."
     />
+  {{else if (eq @model.monthly.id "no-data")}}
+    <EmptyState
+      @title="No data available"
+      @message="Tracking may be turned off. Check with your administrator or check back later."
+    />
   {{else}}
     <div class="is-subtitle-gray has-bottom-margin-m">
       FILTERS

--- a/vault/seal_autoseal_test.go
+++ b/vault/seal_autoseal_test.go
@@ -177,33 +177,42 @@ func TestAutoSeal_HealthCheck(t *testing.T) {
 
 	metrics.NewGlobal(metricsConf, inmemSink)
 
-	core, _, _ := TestCoreUnsealed(t)
-	testSeal, setErr := seal.NewToggleableTestSeal(nil)
-
-	var encKeys []string
-	changeKey := func(key string) {
-		encKeys = append(encKeys, key)
-		testSeal.Wrapper.(*seal.ToggleableWrapper).Wrapper.(*wrapping.TestWrapper).SetKeyID(key)
-	}
-
-	// Set initial encryption key.
-	changeKey("kaz")
-
-	autoSeal := NewAutoSeal(testSeal)
-	autoSeal.SetCore(core)
 	pBackend := newTestBackend(t)
-	core.physical = pBackend
-	core.metricSink = metricsutil.NewClusterMetricSink("", inmemSink)
-
+	testSealAccess, setErr := seal.NewToggleableTestSeal(nil)
+	core, _, _ := TestCoreUnsealedWithConfig(t, &CoreConfig{
+		MetricSink: metricsutil.NewClusterMetricSink("", inmemSink),
+		Physical:   pBackend,
+	})
 	sealHealthTestIntervalNominal = 10 * time.Millisecond
 	sealHealthTestIntervalUnhealthy = 10 * time.Millisecond
-	setErr(errors.New("disconnected"))
+	autoSeal := NewAutoSeal(testSealAccess)
+	autoSeal.SetCore(core)
+	core.seal = autoSeal
 	autoSeal.StartHealthCheck()
 	defer autoSeal.StopHealthCheck()
+	setErr(errors.New("disconnected"))
 
+	asu := strings.Join(autoSealUnavailableDuration, ".") + ";cluster=" + core.clusterName
+	tries := 10
+	for tries = 10; tries > 0; tries-- {
+		intervals := inmemSink.Data()
+		if len(intervals) == 1 {
+			interval := inmemSink.Data()[0]
+
+			if _, ok := interval.Gauges[asu]; ok {
+				if interval.Gauges[asu].Value > 0 {
+					break
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if tries == 0 {
+		t.Fatalf("Expected value metric %s to be non-zero", asu)
+	}
+
+	setErr(nil)
 	time.Sleep(50 * time.Millisecond)
-
-	asu := strings.Join(autoSealUnavailableDuration, ".") + ";cluster="
 	intervals := inmemSink.Data()
 	if len(intervals) == 1 {
 		interval := inmemSink.Data()[0]
@@ -211,21 +220,8 @@ func TestAutoSeal_HealthCheck(t *testing.T) {
 		if _, ok := interval.Gauges[asu]; !ok {
 			t.Fatalf("Expected metrics to include a value for gauge %s", asu)
 		}
-		if interval.Gauges[asu].Value == 0 {
-			t.Fatalf("Expected value metric %s to be non-zero", asu)
-		}
-	}
-	setErr(nil)
-	time.Sleep(50 * time.Millisecond)
-	intervals = inmemSink.Data()
-	if len(intervals) == 1 {
-		interval := inmemSink.Data()[0]
-
-		if _, ok := interval.Gauges[asu]; !ok {
-			t.Fatalf("Expected metrics to include a value for gauge %s", asu)
-		}
 		if interval.Gauges[asu].Value != 0 {
-			t.Fatalf("Expected value metric %s to be non-zero", asu)
+			t.Fatalf("Expected value metric %s to be zero", asu)
 		}
 	}
 }


### PR DESCRIPTION
New empty state shows on "current" tab when config is off, but no read permissions on the config endpoint.

<img width="1243" alt="Screen Shot 2022-03-01 at 9 52 36 AM" src="https://user-images.githubusercontent.com/82459713/156214598-613240c7-b141-4352-8836-b720bc389272.png">
