### PR TITLE
auth/ldap: add username_as_alias configurable

### DIFF
--- a/builtin/credential/ldap/backend_test.go
+++ b/builtin/credential/ldap/backend_test.go
@@ -1205,6 +1205,7 @@ func TestLdapAuthBackend_ConfigUpgrade(t *testing.T) {
 			CaseSensitiveNames:       falseBool,
 			UsePre111GroupCNBehavior: new(bool),
 			RequestTimeout:           cfg.RequestTimeout,
+			UsernameAsAlias:          false,
 		},
 	}
 

--- a/builtin/credential/ldap/path_login.go
+++ b/builtin/credential/ldap/path_login.go
@@ -103,6 +103,10 @@ func (b *backend) pathLogin(ctx context.Context, req *logical.Request, d *framew
 		},
 	}
 
+	if cfg.UsernameAsAlias {
+		auth.Alias.Name = username
+	}
+
 	cfg.PopulateTokenAuth(auth)
 
 	// Add in configured policies from mappings

--- a/changelog/14324.txt
+++ b/changelog/14324.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth/ldap: Add username_as_alias configurable to change how aliases are named
+```

--- a/sdk/helper/ldaputil/config.go
+++ b/sdk/helper/ldaputil/config.go
@@ -112,6 +112,12 @@ Default: ({{.UserAttr}}={{.Username}})`,
 			},
 		},
 
+		"username_as_alias": {
+			Type:        framework.TypeBool,
+			Default:     false,
+			Description: "If true, sets the alias name to the username",
+		},
+
 		"userattr": {
 			Type:        framework.TypeString,
 			Default:     "cn",
@@ -240,6 +246,10 @@ func NewConfigEntry(existing *ConfigEntry, d *framework.FieldData) (*ConfigEntry
 
 	if _, ok := d.Raw["anonymous_group_search"]; ok || !hadExisting {
 		cfg.AnonymousGroupSearch = d.Get("anonymous_group_search").(bool)
+	}
+
+	if _, ok := d.Raw["username_as_alias"]; ok || !hadExisting {
+		cfg.UsernameAsAlias = d.Get("username_as_alias").(bool)
 	}
 
 	if _, ok := d.Raw["url"]; ok || !hadExisting {
@@ -393,6 +403,7 @@ type ConfigEntry struct {
 	GroupFilter              string `json:"groupfilter"`
 	GroupAttr                string `json:"groupattr"`
 	UPNDomain                string `json:"upndomain"`
+	UsernameAsAlias          bool   `json:"username_as_alias"`
 	UserFilter               string `json:"userfilter"`
 	UserAttr                 string `json:"userattr"`
 	Certificate              string `json:"certificate"`
@@ -444,6 +455,7 @@ func (c *ConfigEntry) PasswordlessMap() map[string]interface{} {
 		"use_token_groups":       c.UseTokenGroups,
 		"anonymous_group_search": c.AnonymousGroupSearch,
 		"request_timeout":        c.RequestTimeout,
+		"username_as_alias":      c.UsernameAsAlias,
 	}
 	if c.CaseSensitiveNames != nil {
 		m["case_sensitive_names"] = *c.CaseSensitiveNames

--- a/sdk/helper/ldaputil/config_test.go
+++ b/sdk/helper/ldaputil/config_test.go
@@ -166,6 +166,7 @@ var jsonConfigDefault = []byte(`
   "tls_max_version": "tls12",
   "use_token_groups": false,
   "use_pre111_group_cn_behavior": null,
+  "username_as_alias": false,
   "request_timeout": 90,
   "CaseSensitiveNames": false,
   "ClientTLSCert": "",

--- a/website/content/api-docs/auth/ldap.mdx
+++ b/website/content/api-docs/auth/ldap.mdx
@@ -87,6 +87,8 @@ This endpoint configures the LDAP auth method.
   `groupfilter` in order to enumerate user group membership. Examples: for
   groupfilter queries returning _group_ objects, use: `cn`. For queries
   returning _user_ objects, use: `memberOf`. The default is `cn`.
+- `username_as_alias` `(bool: false)` - If set to true, forces the auth method
+  to use the username passed by the user as the alias name.
 
 @include 'tokenfields.mdx'
 
@@ -117,6 +119,7 @@ $ curl \
   "tls_max_version": "tls12",
   "tls_min_version": "tls12",
   "url": "ldaps://ldap.myorg.com:636",
+  "username_as_alias": false,
   "userattr": "samaccountname",
   "userdn": "ou=Users,dc=example,dc=com"
 }
@@ -160,6 +163,7 @@ $ curl \
     "tls_min_version": "tls12",
     "upndomain": "",
     "url": "ldaps://ldap.myorg.com:636",
+    "username_as_alias": false,
     "userattr": "samaccountname",
     "userdn": "ou=Users,dc=example,dc=com"
   },

--- a/website/content/docs/auth/ldap.mdx
+++ b/website/content/docs/auth/ldap.mdx
@@ -147,6 +147,11 @@ _Note_: When using _Authenticated Search_ for binding parameters (see above) the
 
 Use `vault path-help` for more details.
 
+### Other
+
+- `username_as_alias` (bool, optional) - If set to true, forces the auth method to use the username passed by the user as the alias name.
+
+
 ## Examples:
 
 ### Scenario 1


### PR DESCRIPTION
This adds a new config parameter to the LDAP util SDK `username_as_alias`. A change in https://github.com/hashicorp/vault/pull/11000 resulted in alias names changing, which has broken a number of users in 1.9+. Using this parameter, an operator can change alias names back.

For example, if LDAP auth was configured with no binddn or bindpass, in 1.8.8 the alias name would be:
```
[~] vault read identity/alias/id/66c3a58f-9a72-26cf-f5a9-438528398eb3
Key                          Value
---                          -----
...
mount_accessor               auth_ldap_6af4105c
mount_path                   auth/ldap/
mount_type                   ldap
name                         bob
namespace_id                 root
```

However, in 1.9.3, the same config would result in alias names like this:
```
[~] vault read identity/alias/id/67656061-c8d2-8379-a7a5-dfa2c89659c9
Key                          Value
---                          -----
...
mount_accessor               auth_ldap_01e39e22
mount_path                   auth/ldap/
mount_type                   ldap
name                         cn=bob,CN=Users,DC=corp,DC=example,DC=net
namespace_id                 root
```