### PR TITLE
auth/ldap: add known issue to 1.9 notes about alias names

### DIFF
--- a/website/content/docs/release-notes/1.9.0.mdx
+++ b/website/content/docs/release-notes/1.9.0.mdx
@@ -120,4 +120,4 @@ Please refer to the [Deprecation Plans and Notice](/docs/deprecation) page for u
 
 ## Known Issues
 
-- There is a known issue with LDAP auth alias names changing in 1.9. This occurs if the LDAP auth method is configured without either `binddn` or `upndomain`. If templated policies were depending on the older style alias names, those policies should be updated to use `alias.metadata.name`, which now stores the username. At this time there are no known workarounds.
+- There is a known issue with LDAP auth alias names changing in 1.9. This occurs if the LDAP auth method is in two different ways: `binddn` is not set and/or `upndomain` is set. If templated policies were depending on the older style alias names, those policies should be updated to use `alias.metadata.name`, which now stores the username. At this time there are no other known workarounds.

--- a/website/content/docs/release-notes/1.9.0.mdx
+++ b/website/content/docs/release-notes/1.9.0.mdx
@@ -117,3 +117,7 @@ As called out in the documentation, Vault does not make backwards compatible gua
 ## Feature Deprecations and EOL
 
 Please refer to the [Deprecation Plans and Notice](/docs/deprecation) page for up-to-date information on feature deprecations and plans. An [FAQ](/docs/deprecation/faq) page is also available to address questions concerning decisions made about Vault feature deprecations.
+
+## Known Issues
+
+- There is a known issue with LDAP auth alias names changing in 1.9. This occurs if the LDAP auth method is configured without either `binddn` or `upndomain`. If templated policies were depending on the older style alias names, those policies should be updated to use `alias.metadata.name`, which now stores the username. At this time there are no known workarounds.


### PR DESCRIPTION
This adds a known issue to 1.9 notes about alias names changing when certain configurations are used. This will serve as a temporary acknowledgment of the issue while a fix is worked out.