### PR TITLE
treat logical.ErrRelativePath as 400 instead of 500

### DIFF
--- a/changelog/14328.txt
+++ b/changelog/14328.txt
@@ -1,0 +1,3 @@
+```release-note:change
+core: A request that fails path validation due to relative path check will now be responded to with a 400 rather than 500.
+```

--- a/sdk/logical/response_util.go
+++ b/sdk/logical/response_util.go
@@ -120,6 +120,8 @@ func RespondErrorCommon(req *Request, resp *Response, err error) (int, error) {
 			statusCode = http.StatusPreconditionFailed
 		case errwrap.Contains(err, ErrPathFunctionalityRemoved.Error()):
 			statusCode = http.StatusNotFound
+		case errwrap.Contains(err, ErrRelativePath.Error()):
+			statusCode = http.StatusBadRequest
 		}
 	}
 

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -321,7 +321,7 @@ func (c *Core) checkToken(ctx context.Context, req *logical.Request, unauth bool
 			// fail later via bad path to avoid confusing items in the log
 			checkExists = false
 		case logical.ErrRelativePath:
-			return nil, te, err
+			return nil, te, errutil.UserError{Err: err.Error()}
 		case nil:
 			if existsResp != nil && existsResp.IsError() {
 				return nil, te, existsResp.Error()

--- a/vault/request_handling.go
+++ b/vault/request_handling.go
@@ -320,6 +320,8 @@ func (c *Core) checkToken(ctx context.Context, req *logical.Request, unauth bool
 		case logical.ErrUnsupportedPath:
 			// fail later via bad path to avoid confusing items in the log
 			checkExists = false
+		case logical.ErrRelativePath:
+			return nil, te, err
 		case nil:
 			if existsResp != nil && existsResp.IsError() {
 				return nil, te, existsResp.Error()
@@ -825,6 +827,9 @@ func (c *Core) handleRequest(ctx context.Context, req *logical.Request) (retResp
 
 	// Validate the token
 	auth, te, ctErr := c.checkToken(ctx, req, false)
+	if ctErr == logical.ErrRelativePath {
+		return logical.ErrorResponse(ctErr.Error()), nil, ctErr
+	}
 	if ctErr == logical.ErrPerfStandbyPleaseForward {
 		return nil, nil, ctErr
 	}


### PR DESCRIPTION
The userpass auth backend may return a `500 Internal Server Error` to attempts to read or write usernames that contain `..`. The underlying cause is a check performed in `StorageView. SanityCheck`. It is theoretically possible for other endpoints to result in a 500 response for a path that contains `..`. The policies endpoints, for example `sys/policies/acl/:path`, have their own error handling which results in returning a 400 for various errors:

```
❯ bin/vault read sys/policies/acl/foo..bar
Error reading sys/policies/acl/foo..bar: Error making API request.

URL: GET http://127.0.0.1:8200/v1/sys/policies/acl/foo..bar
Code: 400. Errors:

* failed to read policy: relative paths not supported
```

The proposed fix is to treat `logical.ErrRelativePath` as a 400. Rather than do this directly within the userpass logic, it is done at a higher level in the request handling logic so that it has broad coverage across any backend.

```
❯ bin/vault read auth/userpass/users/foo..bar
Error reading auth/userpass/users/foo..bar: Error making API request.

URL: GET http://127.0.0.1:8200/v1/auth/userpass/users/foo..bar
Code: 400. Errors:

* 1 error occurred:
        * relative paths not supported
```