### PR TITLE
validate mount accessor while configuring MFA enforcement

### DIFF
--- a/changelog/14335.txt
+++ b/changelog/14335.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/login mfa: The mount accessor on the MFA method config cannot be different from the accessor being logged in on.
+```

--- a/vault/external_tests/identity/login_mfa_duo_test.go
+++ b/vault/external_tests/identity/login_mfa_duo_test.go
@@ -218,7 +218,7 @@ func mfaGenerateLoginDUOTest(client *api.Client) error {
 			"integration_key": integration_key,
 			"api_hostname":    api_hostname,
 		}
-		resp, err := client.Logical().Write("identity/mfa/method-id/duo", mfaConfigData)
+		resp, err := client.Logical().Write("identity/mfa/method/duo", mfaConfigData)
 
 		if err != nil || (resp == nil) {
 			return fmt.Errorf("bad: resp: %#v\n err: %v", resp, err)


### PR DESCRIPTION
The mount accessor on the mfa method cannot be different from the accessor being logged in on.
So say I have an entity entity1  with alias12 on userpass12 and alias23 on userpass23. My email address on Okta is alias12@hashicorp,com. I try to login on userpass23 with alias23 .  It detects I am entity1 , looks up my alias on userpass12 which is configured on the okta mfa method, renders out my okta username as [alias12@hashicorp.com](mailto:alias12@hashicorp.com) , and allows me to login to userpass23.