### PR TITLE
update `vault login` docs to cover stdin default

### DIFF
--- a/website/content/docs/commands/login.mdx
+++ b/website/content/docs/commands/login.mdx
@@ -35,7 +35,28 @@ the returned token is automatically unwrapped unless:
 
 ## Examples
 
-By default, login uses a "token" method:
+By default, login uses a "token" method and reads from stdin:
+
+```shell-session
+$ vault login
+Token (will be hidden):
+Success! You are now authenticated. The token information displayed below
+is already stored in the token helper. You do NOT need to run "vault login"
+again. Future Vault requests will automatically use this token.
+
+Key                  Value
+---                  -----
+token                s.nDj4BB2tK8NaFffwBZBxyIa1
+token_accessor       ZuaObqdTeCHZ4oa9HWmdQJuZ
+token_duration       ∞
+token_renewable      false
+token_policies       ["root"]
+identity_policies    []
+policies             ["root"]
+```
+
+Alternatively, the token may be provided as a command line argument (note that
+this may be captured by shell history or process listings):
 
 ```shell-session
 $ vault login s.3jnbMAKl1i4YS3QoKdbHzGXq


### PR DESCRIPTION
An external party reported via email to [security@hashicorp.com](mailto:security@hashicorp.com) that, on working through a Vault tutorial (https://learn.hashicorp.com/tutorials/vault/getting-started-deploy#seal-unseal in particular), they'd noticed an insecure `vault login <token>` pattern being used. (This is not preferred as the token may be captured by shell history logging or process listings.)

We will be updating that tutorial content separately, but this explicitly addresses the read-token-from-stdin default behavior in the base `vault login` docs.