### PR TITLE
Remove duplicated certificates from chains

### DIFF
--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -221,7 +221,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 				Type:  "CERTIFICATE",
 				Bytes: ca.Bytes,
 			}
-			chainStr = strings.Join([]string{certStr, strings.TrimSpace(string(pem.EncodeToMemory(&block)))}, "\n")
+			chainStr = strings.Join([]string{chainStr, strings.TrimSpace(string(pem.EncodeToMemory(&block)))}, "\n")
 		}
 		fullChain = []byte(strings.TrimSpace(chainStr))
 


### PR DESCRIPTION
As reported by Steve Clark, building an intermediate mount in PKI (and
calling `/intermediate/set-signed`) results in a duplicate intermediate CA
certificate in the full chain output (`ca_chain` field of the
`/cert/ca_chain` API endpoint response).

While ideally we'd use proper chain building (and return a sorted
chain), for the time being, return certs in the order they appear and
remove any duplicate certificates.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

--

This was for the new full chain feature introduced in #13935.


Reproducer:

```
vault secrets enable -path=pki pki
vault write -field=certificate pki/root/generate/internal \
    common_name=root-kms.com \
    ttl=8760h > /tmp/CA_cert.crt
vault secrets enable -path=pki_int pki
vault write -format=json pki_int/intermediate/generate/internal \
    common_name="example.com Intermediate Authority" \
     | jq -r '.data.csr' > /tmp/pki_intermediate.csr
vault write -format=json pki/root/sign-intermediate csr=@/tmp/pki_intermediate.csr \
     format=pem_bundle ttl="43800h" \
     | jq -r '.data.certificate' > /tmp/intermediate.cert.pem
vault write pki_int/intermediate/set-signed certificate=@/tmp/intermediate.cert.pem
vault read /pki_int/cert/ca_chain
```