### PR TITLE
docs: fix typo in CF auth ca maintenance

### DIFF
--- a/website/content/docs/auth/cf.mdx
+++ b/website/content/docs/auth/cf.mdx
@@ -260,7 +260,7 @@ valid.
 ```shell-session
 $ CURRENT=$(cat /path/to/current-ca.crt)
 $ FUTURE=$(cat /path/to/future-ca.crt)
-$ vault write auth/vault-plugin-auth-cf/config identity_ca_certificates="$CURRENT,$FUTURE"
+$ vault write auth/vault-plugin-auth-cf/config identity_ca_certificates="$CURRENT" identity_ca_certificates="$FUTURE"
 ```
 
 If Vault receives a `CF_INSTANCE_CERT` matching _any_ of the `identity_ca_certificates`,


### PR DESCRIPTION
`identity_ca_certificates` is `TypeStringSlice` and should not be a comma separated string. The current documentation would result in an error because it's trying to parse an invalid cert (two certs and a comma between them). This value instead should be defined multiple times.