### PR TITLE
Updated Docs For Specific Call Out

### DIFF
--- a/website/content/api-docs/secret/ssh.mdx
+++ b/website/content/api-docs/secret/ssh.mdx
@@ -105,12 +105,14 @@ This endpoint creates or updates a named role.
 - `cidr_list` `(string: "")` – Specifies a comma separated list of CIDR blocks
   for which the role is applicable for. It is possible that a same set of CIDR
   blocks are part of multiple roles. This is a required parameter, unless the
-  role is registered under the `/config/zeroaddress` endpoint.
+  role is registered under the `/config/zeroaddress` endpoint. Note: 
+  [Not applicable for CA type]
 
 - `exclude_cidr_list` `(string: "")` – Specifies a comma-separated list of CIDR
   blocks. IP addresses belonging to these blocks are not accepted by the role.
   This is particularly useful when big CIDR blocks are being used by the role
-  and certain parts need to be kept out.
+  and certain parts need to be kept out. Note: 
+  [Not applicable for CA type]
 
 - `port` `(int: 22)` – Specifies the port number for SSH connection. Port number
   does not play any role in OTP generation. For the `otp` secrets engine type, this is


### PR DESCRIPTION
The Parameter `cidr_list` is not support for Key_Type CA, customer was confused on this, so I feel we should specifically call this out to ensure there is no confusion