### PR TITLE
Set systemd service type to notify

### DIFF
--- a/.release/linux/package/usr/lib/systemd/system/vault.service
+++ b/.release/linux/package/usr/lib/systemd/system/vault.service
@@ -8,6 +8,7 @@ StartLimitIntervalSec=60
 StartLimitBurst=3
 
 [Service]
+Type=notify
 EnvironmentFile=/etc/vault.d/vault.env
 User=vault
 Group=vault

--- a/changelog/14385.txt
+++ b/changelog/14385.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Systemd unit file included with the Linux packages now sets the service type to notify.
+```


### PR DESCRIPTION
Updates the systemd unit file shipped in the Linux packages to set the service type to `notify`

Fixes #14371 