### PR TITLE
[Hackathon] PKI CLI Role issuance testing

### DIFF
--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -1193,6 +1193,11 @@ func generateCreationBundle(b *backend, data *inputBundle, caSign *certutil.CAIn
 		}
 	}
 
+	// Add any further validations above this line.
+	if dry_run, ok := data.apiData.GetOk("dry_run"); ok && dry_run.(bool) {
+		return nil, errDryRun
+	}
+
 	creation := &certutil.CreationBundle{
 		Params: &certutil.CreationParameters{
 			Subject:                       subject,

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -130,6 +130,13 @@ be larger than the role max TTL.`,
                       The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ`,
 	}
 
+	fields["dry_run"] = &framework.FieldSchema{
+		Type:    framework.TypeBool,
+		Default: false,
+		Description: `Test issuance without creating a certificate.
+Returns 204 No Content on success.`,
+	}
+
 	return fields
 }
 

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -199,6 +199,13 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		parsedBundle, err = generateCert(ctx, b, input, signingBundle, false, rand.Reader)
 	}
 	if err != nil {
+		// Issuance would've succeeded for this request, but didn't because
+		// the request included dry_run=true. Return 204 No Content in this
+		// case.
+		if err == errDryRun {
+			return nil, nil
+		}
+
 		switch err.(type) {
 		case errutil.UserError:
 			return logical.ErrorResponse(err.Error()), nil

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -1,6 +1,7 @@
 package pki
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -13,6 +14,8 @@ const (
 	managedKeyNameArg = "managed_key_name"
 	managedKeyIdArg   = "managed_key_id"
 )
+
+var errDryRun = errors.New("dry run issuance")
 
 func normalizeSerial(serial string) string {
 	return strings.Replace(strings.ToLower(serial), ":", "-", -1)

--- a/command/commands.go
+++ b/command/commands.go
@@ -487,6 +487,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"pki role-test": func() (cli.Command, error) {
+			return &PKIRoleTestCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"plugin": func() (cli.Command, error) {
 			return &PluginCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/commands.go
+++ b/command/commands.go
@@ -482,6 +482,11 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
+		"pki": func() (cli.Command, error) {
+			return &PKICommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
 		"plugin": func() (cli.Command, error) {
 			return &PluginCommand{
 				BaseCommand: getBaseCommand(),

--- a/command/pki.go
+++ b/command/pki.go
@@ -1,0 +1,38 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+)
+
+var _ cli.Command = (*PKICommand)(nil)
+
+type PKICommand struct {
+	*BaseCommand
+}
+
+func (c *PKICommand) Synopsis() string {
+	return "Interact with PKI Secret Engines"
+}
+
+func (c *PKICommand) Help() string {
+	helpText := `
+Usage: vault pki <subcommand> [options] [args]
+
+  This command groups subcommands for interacting with Vault's PKI Secrets
+  Engine. Operators can manage PKI mounts and roles.
+
+  To test role based issuance:
+
+       $ vault pki role-test -mount=pki-int server-role example.com
+
+  Please see the individual subcommand help for detailed usage information.
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *PKICommand) Run(args []string) int {
+	return cli.RunResultHelp
+}

--- a/command/pki_roletest.go
+++ b/command/pki_roletest.go
@@ -1,0 +1,152 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*PKIRoleTestCommand)(nil)
+	_ cli.CommandAutocomplete = (*PKIRoleTestCommand)(nil)
+)
+
+type PKIRoleTestCommand struct {
+	*BaseCommand
+
+	flagQuiet bool
+	flagMount string
+}
+
+func (c *PKIRoleTestCommand) Synopsis() string {
+	return "Test PKI Secrets Engine role issuance restrictions"
+}
+
+func (c *PKIRoleTestCommand) Help() string {
+	helpText := `
+Usage: vault pki role-test [options] ROLE COMMON_NAME [DNS-SANS...] [K=V]
+
+  Reports whether or not issuance will succeed against the PKI role with the
+  specified common name and optionally, DNS SAN names. Other parameters to
+  /pki/issue/:ROLE can be specified in K=V format (mirroring vault write).
+
+  Check whether the role will issue for localhost:
+
+      $ vault pki role-test -mount=pki-int server-role localhost
+
+  To withhold all output and only use return codes for indicating issuance
+  status:
+
+      $ vault pki role-test -quiet server-role foo.example.com
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *PKIRoleTestCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP)
+	f := set.NewFlagSet("Command Options")
+
+	f.BoolVar(&BoolVar{
+		Name:    "quiet",
+		Target:  &c.flagQuiet,
+		Default: false,
+		EnvVar:  "",
+		Usage: "Suppress CLI output; use return status to indicate success" +
+			" (return code 0) or failure (return code 3).",
+	})
+
+	f.StringVar(&StringVar{
+		Name:    "mount",
+		Target:  &c.flagMount,
+		Default: "pki",
+		EnvVar:  "",
+		Usage:   "PKI mount to test issuance under.",
+	})
+
+	return set
+}
+
+func (c *PKIRoleTestCommand) AutocompleteArgs() complete.Predictor {
+	// Return an anything predictor here, similar to `vault write`. We
+	// don't know what values are valid for the role and/or common names.
+	return complete.PredictAnything
+}
+
+func (c *PKIRoleTestCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *PKIRoleTestCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	if len(args) < 2 {
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2+, got %d)", len(args)))
+		return 1
+	}
+
+	mount := sanitizePath(c.flagMount)
+	role := sanitizePath(args[0])
+	path := mount + "/issue/" + role
+	commonName := args[1]
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	var dnsSans []string
+	remainder := args[2:]
+
+	for _, value := range args[2:] {
+		if strings.Contains(value, "=") {
+			// Start of K=V data.
+			break
+		}
+
+		dnsSans = append(dnsSans, value)
+		remainder = remainder[1:]
+	}
+
+	data, err := parseArgsData(nil, remainder)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to parse K=V data: %s", err))
+		return 1
+	}
+
+	if data == nil {
+		data = make(map[string]interface{})
+	}
+
+	data["dry_run"] = true
+	data["common_name"] = commonName
+	data["ttl"] = "1s"
+	if len(dnsSans) > 0 {
+		data["alt_names"] = strings.Join(dnsSans, ",")
+	}
+
+	_, err = client.Logical().Write(path, data)
+	if err != nil {
+		if !c.flagQuiet {
+			c.UI.Error(fmt.Sprintf("Error issuing certificate: %v", err))
+		}
+
+		return 3
+	}
+
+	if !c.flagQuiet {
+		c.UI.Info(fmt.Sprintf("Success! Certificate would be issued."))
+	}
+
+	return 0
+}


### PR DESCRIPTION
This starts the PKI CLI and adds a method to (more easily) test role-based issuance. 