### PR TITLE
Fix debug bundle panic on Windows

### DIFF
--- a/changelog/14399.txt
+++ b/changelog/14399.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+debug: Fix panic when capturing debug bundle on Windows
+```

--- a/command/debug.go
+++ b/command/debug.go
@@ -334,7 +334,7 @@ func (c *DebugCommand) generateIndex() error {
 
 		dir, file := filepath.Split(relPath)
 		if len(dir) != 0 {
-			dir = strings.TrimSuffix(dir, "/")
+			dir = filepath.Clean(dir)
 			filesArr := outputLayout[dir].(map[string]interface{})["files"]
 			outputLayout[dir].(map[string]interface{})["files"] = append(filesArr.([]string), file)
 		} else {
@@ -422,7 +422,7 @@ func (c *DebugCommand) preflight(rawArgs []string) (string, error) {
 	}
 
 	// Strip trailing slash before proceeding
-	c.flagOutput = strings.TrimSuffix(c.flagOutput, "/")
+	c.flagOutput = filepath.Clean(c.flagOutput)
 
 	// If compression is enabled, trim the extension so that the files are
 	// written to a directory even if compression somehow fails. We ensure the


### PR DESCRIPTION
This PR resolves a panic on Windows that occurs when capturing a vault debug bundle.

Fixes #14394 