### PR TITLE
Add a place for us to link to external plugin examples/guides.

### DIFF
--- a/website/content/docs/internals/plugins.mdx
+++ b/website/content/docs/internals/plugins.mdx
@@ -231,6 +231,24 @@ func main() {
 ```
 
 And that's basically it! You would just need to change `myPlugin` to your actual
-plugin. For more information on how to register and enable your plugin, check out the [Building Plugin Backends](https://learn.hashicorp.com/vault/developer/plugin-backends) tutorial.
+plugin.
 
 [api_addr]: /docs/configuration#api_addr
+
+## Plugin Development - Resources
+
+For more information on how to register and enable your plugin, check out the
+[Building Plugin Backends](https://learn.hashicorp.com/vault/developer/plugin-backends)
+tutorial.
+
+Other HashiCorp plugin development resources:
+
+* [vault-auth-plugin-example](https://github.com/hashicorp/vault-auth-plugin-example)
+
+### Plugin Development - Resources - Community
+
+Community plugin examples/guides are developed by community members. HashiCorp
+does not validate these for correctness.
+
+Authors who wish to have their guides or examples listed may file a submission
+via a GitHub issue or directly open a pull request with changes to this page.


### PR DESCRIPTION
I included a link to vault-auth-plugin-example, but maybe we don't want to link that anymore if the learn guide supersedes it? 