### PR TITLE
UI/add managed ns redirect prefix

### DIFF
--- a/changelog/14422.txt
+++ b/changelog/14422.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Redirects to managed namespace if incorrect namespace in URL param
+```

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -10,6 +10,16 @@ import ModelBoundaryRoute from 'vault/mixins/model-boundary-route';
 
 const POLL_INTERVAL_MS = 10000;
 
+export const getManagedNamespace = (nsParam, root) => {
+  if (!nsParam || nsParam.replaceAll('/', '') === root) return root;
+  // Check if param starts with root and /
+  if (nsParam.startsWith(`${root}/`)) {
+    return nsParam;
+  }
+  // Otherwise prepend the given param with the root
+  return `${root}/${nsParam}`;
+};
+
 export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
   namespaceService: service('namespace'),
   version: service(),
@@ -38,20 +48,25 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
     const params = this.paramsFor(this.routeName);
     let namespace = params.namespaceQueryParam;
     const currentTokenName = this.auth.get('currentTokenName');
-    // if no namespace queryParam and user authenticated,
-    // use user's root namespace to redirect to properly param'd url
-    if (this.featureFlagService.managedNamespaceRoot && this.version.isOSS) {
+    const managedRoot = this.featureFlagService.managedNamespaceRoot;
+    if (managedRoot && this.version.isOSS) {
+      // eslint-disable-next-line no-console
       console.error('Cannot use Cloud Admin Namespace flag with OSS Vault');
     }
-    if (!namespace && currentTokenName && !Ember.testing) {
+    if (typeof managedRoot === 'string') {
+      let managed = getManagedNamespace(namespace, managedRoot);
+      if (managed !== namespace) {
+        this.transitionTo({ queryParams: { namespace: managed } });
+      }
+    } else if (!namespace && currentTokenName && !Ember.testing) {
+      // if no namespace queryParam and user authenticated,
+      // use user's root namespace to redirect to properly param'd url
       const storage = getStorage().getItem(currentTokenName);
       namespace = storage?.userRootNamespace;
       // only redirect if something other than nothing
       if (namespace) {
         this.transitionTo({ queryParams: { namespace } });
       }
-    } else if (!namespace && !!this.featureFlagService.managedNamespaceRoot) {
-      this.transitionTo({ queryParams: { namespace: this.featureFlagService.managedNamespaceRoot } });
     }
     this.namespaceService.setNamespace(namespace);
     const id = this.getClusterId(params);

--- a/ui/app/routes/vault/cluster.js
+++ b/ui/app/routes/vault/cluster.js
@@ -53,12 +53,7 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
       // eslint-disable-next-line no-console
       console.error('Cannot use Cloud Admin Namespace flag with OSS Vault');
     }
-    if (typeof managedRoot === 'string') {
-      let managed = getManagedNamespace(namespace, managedRoot);
-      if (managed !== namespace) {
-        this.transitionTo({ queryParams: { namespace: managed } });
-      }
-    } else if (!namespace && currentTokenName && !Ember.testing) {
+    if (!namespace && currentTokenName && !Ember.testing) {
       // if no namespace queryParam and user authenticated,
       // use user's root namespace to redirect to properly param'd url
       const storage = getStorage().getItem(currentTokenName);
@@ -66,6 +61,11 @@ export default Route.extend(ModelBoundaryRoute, ClusterRoute, {
       // only redirect if something other than nothing
       if (namespace) {
         this.transitionTo({ queryParams: { namespace } });
+      }
+    } else if (managedRoot !== null) {
+      let managed = getManagedNamespace(namespace, managedRoot);
+      if (managed !== namespace) {
+        this.transitionTo({ queryParams: { namespace: managed } });
       }
     }
     this.namespaceService.setNamespace(namespace);

--- a/ui/tests/acceptance/managed-namespace-test.js
+++ b/ui/tests/acceptance/managed-namespace-test.js
@@ -3,6 +3,7 @@ import { currentURL, visit, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import Pretender from 'pretender';
 import logout from 'vault/tests/pages/logout';
+import { getManagedNamespace } from 'vault/routes/vault/cluster';
 
 const FEATURE_FLAGS_RESPONSE = {
   feature_flags: ['VAULT_CLOUD_ADMIN_NAMESPACE'],
@@ -37,7 +38,6 @@ module('Acceptance | Enterprise | Managed namespace root', function (hooks) {
     await visit('/vault/auth');
     assert.ok(currentURL().startsWith('/vault/auth'), 'Redirected to auth');
     assert.ok(currentURL().includes('?namespace=admin'), 'with base namespace');
-
     assert.dom('[data-test-namespace-toolbar]').doesNotExist('Normal namespace toolbar does not exist');
     assert.dom('[data-test-managed-namespace-toolbar]').exists('Managed namespace toolbar exists');
     assert.dom('[data-test-managed-namespace-root]').hasText('/admin', 'Shows /admin namespace prefix');
@@ -49,5 +49,33 @@ module('Acceptance | Enterprise | Managed namespace root', function (hooks) {
       `/vault/auth?namespace=${encodedNamespace}&with=token`,
       'Correctly prepends root to namespace'
     );
+  });
+
+  test('getManagedNamespace helper works as expected', function (assert) {
+    let managedNs = getManagedNamespace(null, 'admin');
+    assert.equal(managedNs, 'admin', 'returns root ns when no namespace present');
+    managedNs = getManagedNamespace('admin/', 'admin');
+    assert.equal(managedNs, 'admin', 'returns root ns when matches passed ns');
+    managedNs = getManagedNamespace('adminfoo/', 'admin');
+    assert.equal(
+      managedNs,
+      'admin/adminfoo/',
+      'appends passed namespace to root even if it matches without slashes'
+    );
+    managedNs = getManagedNamespace('admin/foo/', 'admin');
+    assert.equal(managedNs, 'admin/foo/', 'returns passed namespace if it starts with root and /');
+  });
+
+  test('it redirects to root prefixed ns when non-root passed', async function (assert) {
+    await logout.visit();
+    await visit('/vault/auth?namespace=admindev');
+    assert.ok(currentURL().startsWith('/vault/auth'), 'Redirected to auth');
+    assert.ok(
+      currentURL().includes(`?namespace=${encodeURIComponent('admin/admindev')}`),
+      'with appended namespace'
+    );
+
+    assert.dom('[data-test-managed-namespace-root]').hasText('/admin', 'Shows /admin namespace prefix');
+    assert.dom('input#namespace').hasValue('/admindev', 'Input has /dev value');
   });
 });


### PR DESCRIPTION
This PR updates the namespace redirect logic on managed vault clusters. 

Previous behavior caused a bug where if a namespace was provided in the URL but did not match the required format for managed clusters, it looked like you were logging into the `admin` namespace when in reality, the namespace passed to all requests is whatever is in the URL param. 

**UI Behavior when I try to log in with my token which is valid for the `admin` namespace:**
![managed-login-error](https://user-images.githubusercontent.com/82459713/157512088-131dfad8-374d-4402-a645-461816ac2444.gif)
Fails because request has the namespace which is in the URL param:
<img width="1336" alt="actual-request-ns" src="https://user-images.githubusercontent.com/82459713/157512139-30f62317-f2e1-48c9-bf87-ea1796c8c66a.png">

After this fix, whatever namespace passed is parsed and either appended to the root (`admin`) or kept as is, if the namespace param starts with `admin/`

**New Behavior**
![managed-namespace-fix](https://user-images.githubusercontent.com/82459713/157535741-4272ab19-e1cc-4d8d-9000-ee03c77420d2.gif)
