### PR TITLE
Agent error log level is mismatched

### DIFF
--- a/changelog/14424.txt
+++ b/changelog/14424.txt
@@ -1,4 +1,3 @@
 ```release-note:bug
-COMPONENT: summary of chan
-agent: Log level mismatch between ERR and ERROR
+agent: Fix log level mismatch between ERR and ERROR
 ```

--- a/changelog/14424.txt
+++ b/changelog/14424.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+COMPONENT: summary of chan
+agent: Log level mismatch between ERR and ERROR
+```

--- a/command/agent/template/template.go
+++ b/command/agent/template/template.go
@@ -341,7 +341,7 @@ func logLevelToStringPtr(level hclog.Level) *string {
 	case hclog.Warn:
 		levelStr = "WARN"
 	case hclog.Error:
-		levelStr = "ERROR"
+		levelStr = "ERR"
 	default:
 		levelStr = "INFO"
 	}

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -188,7 +188,7 @@ func TestCacheConfigNoListener(t *testing.T) {
 	assert.NotNil(t, ctConfig.Vault.Transport.CustomDialer)
 }
 
-func TestServerRun(t *testing.T) {
+func createHttpTestServer() *httptest.Server {
 	// create http test server
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/kv/myapp/config", func(w http.ResponseWriter, r *http.Request) {
@@ -203,8 +203,13 @@ func TestServerRun(t *testing.T) {
 		fmt.Fprintln(w, `{"errors":["1 error occurred:\n\t* permission denied\n\n"]}`)
 	})
 
-	ts := httptest.NewServer(mux)
+	return httptest.NewServer(mux)
+}
+
+func TestServerRun(t *testing.T) {
+	ts := createHttpTestServer()
 	defer ts.Close()
+
 	tmpDir, err := ioutil.TempDir("", "agent-tests")
 	defer os.RemoveAll(tmpDir)
 	if err != nil {
@@ -396,6 +401,70 @@ func TestServerRun(t *testing.T) {
 			if fileCount != len(templatesToRender) {
 				t.Fatalf("mismatch file to template: (%d) / (%d)", fileCount, len(templatesToRender))
 			}
+		})
+	}
+}
+
+// TestNewServerLogLevels tests that the server can be started with any log
+// level.
+func TestNewServerLogLevels(t *testing.T) {
+	ts := createHttpTestServer()
+	defer ts.Close()
+
+	tmpDir, err := ioutil.TempDir("", "agent-tests")
+	defer os.RemoveAll(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	levels := []hclog.Level{hclog.NoLevel, hclog.Trace, hclog.Debug, hclog.Info, hclog.Warn, hclog.Error}
+	for _, level := range levels {
+		name := fmt.Sprintf("log_%s", level)
+		t.Run(name, func(t *testing.T) {
+			server := NewServer(&ServerConfig{
+				Logger:        logging.NewVaultLogger(level),
+				LogWriter:     hclog.DefaultOutput,
+				LogLevel:      level,
+				ExitAfterAuth: true,
+				AgentConfig: &config.Config{
+					Vault: &config.Vault{
+						Address: ts.URL,
+					},
+				},
+			})
+			if server == nil {
+				t.Fatal("nil server returned")
+			}
+
+			templateTokenCh := make(chan string, 1)
+
+			templateTest := &ctconfig.TemplateConfig{
+				Contents: pointerutil.StringPtr(templateContents),
+			}
+			dstFile := fmt.Sprintf("%s/%s", tmpDir, name)
+			templateTest.Destination = pointerutil.StringPtr(dstFile)
+			templatesToRender := []*ctconfig.TemplateConfig{templateTest}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
+			errCh := make(chan error)
+			go func() {
+				errCh <- server.Run(ctx, templateTokenCh, templatesToRender)
+			}()
+
+			// send a dummy value to trigger auth so the server will exit
+			templateTokenCh <- "test"
+
+			select {
+			case <-ctx.Done():
+				t.Fatal("timeout reached before templates were rendered")
+			case err := <-errCh:
+				if err != nil {
+					t.Fatalf("did not expect error, got: %v", err)
+				}
+			}
+			cancel()
+			server.Stop()
 		})
 	}
 }

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -210,7 +209,7 @@ func TestServerRun(t *testing.T) {
 	ts := createHttpTestServer()
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "agent-tests")
+	tmpDir, err := os.MkdirTemp("", "agent-tests")
 	defer os.RemoveAll(tmpDir)
 	if err != nil {
 		t.Fatal(err)
@@ -384,7 +383,7 @@ func TestServerRun(t *testing.T) {
 				if template.Destination == nil {
 					t.Fatal("nil template destination")
 				}
-				content, err := ioutil.ReadFile(*template.Destination)
+				content, err := os.ReadFile(*template.Destination)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -411,7 +410,7 @@ func TestNewServerLogLevels(t *testing.T) {
 	ts := createHttpTestServer()
 	defer ts.Close()
 
-	tmpDir, err := ioutil.TempDir("", "agent-tests")
+	tmpDir, err := os.MkdirTemp("", "agent-tests")
 	defer os.RemoveAll(tmpDir)
 	if err != nil {
 		t.Fatal(err)

--- a/command/agent/template/template_test.go
+++ b/command/agent/template/template_test.go
@@ -435,6 +435,7 @@ func TestNewServerLogLevels(t *testing.T) {
 			if server == nil {
 				t.Fatal("nil server returned")
 			}
+			defer server.Stop()
 
 			templateTokenCh := make(chan string, 1)
 
@@ -446,6 +447,7 @@ func TestNewServerLogLevels(t *testing.T) {
 			templatesToRender := []*ctconfig.TemplateConfig{templateTest}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
 
 			errCh := make(chan error)
 			go func() {
@@ -463,8 +465,6 @@ func TestNewServerLogLevels(t *testing.T) {
 					t.Fatalf("did not expect error, got: %v", err)
 				}
 			}
-			cancel()
-			server.Stop()
 		})
 	}
 }


### PR DESCRIPTION
`logLevelToStringPtr` translates `go-hclog`'s `ERROR` to `"ERROR"` for
Consul Template's runner, but that expects `ERR` and is quite strict
about it.

This will address https://github.com/hashicorp/vault-k8s/issues/223
after it is set as the default image in `vault-k8s`.

I didn't find a simple way to test this other than starting up a full
server and agent and letting them run, which is unfortunately fairly
slow.

I confirmed that this addresses the original issue by modifying the helm
chart with the values in this commit and patching the log level to `err`.