### PR TITLE
identity/oidc: prevent key rotation on performance secondary clusters

### DIFF
--- a/changelog/14426.txt
+++ b/changelog/14426.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity/oidc: Fixes potential write to readonly storage on performance secondary clusters during key rotation
+```

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -1790,12 +1790,12 @@ func (i *IdentityStore) expireOIDCPublicKeys(ctx context.Context, s logical.Stor
 	// use by some role.
 	for _, keyID := range publicKeyIDs {
 		if !strutil.StrListContains(usedKeys, keyID) {
-			didUpdate = true
 			if err := s.Delete(ctx, publicKeysConfigPath+keyID); err != nil {
 				i.Logger().Error("error deleting OIDC public key", "key_id", keyID, "error", err)
 				nextExpiration = now
 				continue
 			}
+			didUpdate = true
 			i.Logger().Debug("deleted OIDC public key", "key_id", keyID)
 		}
 	}


### PR DESCRIPTION
### Overview

This PR prevents the identity store's periodic func from running on performance secondary clusters. This fixes an issue where the key rotations were attempting to write to readonly storage.

Additionally, this adds some `continue` statements in a few places that I think are appropriate. This prevents some logging that didn't make sense (see delete logs below) and sets the `didUpdate` bool properly.

Example logs:
```
2022-03-08T15:09:41.745-0800 [DEBUG] secrets.identity.identity_2b8b62f2: rotating OIDC key: key=default
2022-03-08T15:09:41.862-0800 [WARN]  secrets.identity.identity_2b8b62f2: error rotating OIDC keys: err="cannot write to readonly storage"
2022-03-08T15:09:41.863-0800 [ERROR] secrets.identity.identity_2b8b62f2: error saving key: key="" error="cannot write to readonly storage"
2022-03-08T15:09:41.863-0800 [ERROR] secrets.identity.identity_2b8b62f2: error deleting OIDC public key: key_id=da41c8f4-0cac-f19c-16ad-b16f33a0d709 error="cannot write to readonly storage"
2022-03-08T15:09:41.863-0800 [DEBUG] secrets.identity.identity_2b8b62f2: deleted OIDC public key: key_id=da41c8f4-0cac-f19c-16ad-b16f33a0d709
```

### Testing

I manually tested this change using a performance secondary cluster to confirm that the key rotations in the periodic func are skipped on the active instance.