### PR TITLE
MfaForm Update

### DIFF
--- a/ui/app/templates/components/mfa-form.hbs
+++ b/ui/app/templates/components/mfa-form.hbs
@@ -22,17 +22,19 @@
               @onChange={{fn this.onSelect constraint}}
               data-test-mfa-select={{index}}
             />
-          {{/if}}
-          {{#if constraint.selectedMethod.uses_passcode}}
-            <label for="passcode" class="is-label" data-test-mfa-passcode-label>
+          {{else}}
+            <label for="passcode" class="is-label" data-test-mfa-label>
               {{constraint.selectedMethod.label}}
             </label>
+          {{/if}}
+          {{#if constraint.selectedMethod.uses_passcode}}
             <div class="control">
               <Input
                 id="passcode"
                 name="passcode"
                 class="input"
                 autocomplete="off"
+                placeholder={{if (gt constraint.methods.length 1) "Enter passcode"}}
                 spellcheck="false"
                 autofocus="true"
                 disabled={{or this.validate.isRunning this.newCodeDelay.isRunning}}
@@ -40,6 +42,10 @@
                 data-test-mfa-passcode={{index}}
               />
             </div>
+          {{else if (eq constraint.methods.length 1)}}
+            <p class="has-text-grey-400">
+              Check device for push notification
+            </p>
           {{/if}}
         {{/each}}
       </div>


### PR DESCRIPTION
Initially we were only showing passcode methods in the _MfaForm_ component when multiple methods needed to be fulfilled for a given enforcement since no action is needed for push methods
![image](https://user-images.githubusercontent.com/24611656/157553230-330999ee-57b8-4df4-aa95-7034f630f678.png)
Although it says in the description at the top that more than one method is required it's not clear what the other required method(s) are. Now when multiple methods are required each will be listed.
![image](https://user-images.githubusercontent.com/24611656/157553272-19c26cf9-a494-4fa7-aed2-6086b7d2e9a2.png)

