### PR TITLE
Revert "Remove docs changes from CODEOWNERS"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,11 +25,7 @@
 /command/agent/               @hashicorp/vault-ecosystem
 /plugins/                     @hashicorp/vault-ecosystem
 
-# Disabling for now to see if manually adding the reviewer when a PR
-# is ready will be more useful and accurate. There have been cases where
-# docs are being reviewed against PRs that haven't been vetted for acceptance.
-# /website/content/                         @taoism4504
-
+/website/content/                         @taoism4504
 /website/content/docs/plugin-portal.mdx   @taoism4504  @acahn
 
 # UI code related to Vault's JWT/OIDC auth method and OIDC provider.


### PR DESCRIPTION
It was determined that it would be better to have these changes alert
the docs team. Additional guidance is in place to not approve docs+code
PRs ahead of code review.

This reverts commit 6d16840f605c1b58ce0b572274edf96c6d0e0b7f.