### PR TITLE
Update google-cloud-storage backend documentation

### DIFF
--- a/changelog/14455.txt
+++ b/changelog/14455.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+storage/gcs: Add documentation explaining how to configure the gcs backend using environment variables instead of options in the configuration stanza
+```

--- a/website/content/docs/configuration/storage/google-cloud-storage.mdx
+++ b/website/content/docs/configuration/storage/google-cloud-storage.mdx
@@ -120,7 +120,7 @@ https://www.googleapis.com/auth/devstorage.read_write
   or "false". Alternatively, this parameter can be omitted and the 
   `GOOGLE_STORAGE_HA_ENABLED` environment variable can be used to 
   enable or disable high availability. If both the environment variable and 
-  the parameter in the stanza are set the value of the environment variable will 
+  the parameter in the stanza are set, the value of the environment variable will 
   take precedence.
   
 ## `gcs` Examples

--- a/website/content/docs/configuration/storage/google-cloud-storage.mdx
+++ b/website/content/docs/configuration/storage/google-cloud-storage.mdx
@@ -107,7 +107,7 @@ https://www.googleapis.com/auth/devstorage.read_write
   objects in Vault, it is recommended to set this to a low value (minimum is
   256), since it will reduce the amount of memory Vault uses. Alternatively, this parameter
   can be omitted and the `GOOGLE_STORAGE_CHUNK_SIZE` environment variable can be used to set 
-  the chunk size. If both the environment variable and the parameter in the stanza are set 
+  the chunk size. If both the environment variable and the parameter in the stanza are set, 
   the value of the environment variable will take precedence.
 
 - `max_parallel` `(int: 128)` - Specifies the maximum number of parallel

--- a/website/content/docs/configuration/storage/google-cloud-storage.mdx
+++ b/website/content/docs/configuration/storage/google-cloud-storage.mdx
@@ -96,24 +96,33 @@ https://www.googleapis.com/auth/devstorage.read_write
 ## `gcs` Parameters
 
 - `bucket` `(string: <required>)` – Specifies the name of the bucket to use for
-  storage.
+  storage. Alternatively, this parameter can be omitted and the `GOOGLE_STORAGE_BUCKET` 
+  environment variable can be used to set the name of the bucket. If both the environment
+  variable and the parameter in the stanza are set the value of the environment variable
+  will take precedence.
 
 - `chunk_size` `(string: "8192")` – Specifies the maximum size (in kilobytes) to
   send in a single request. If set to 0, it will attempt to send the whole
   object at once, but will not retry any failures. If you are not storing large
   objects in Vault, it is recommended to set this to a low value (minimum is
-
-  256. since it will reduce the amount of memory Vault uses.
+  256 ), since it will reduce the amount of memory Vault uses. Alternatively, this parameter
+  can be omitted and the `GOOGLE_STORAGE_CHUNK_SIZE` environment variable can be used to set 
+  the chunk size. If both the environment variable and the parameter in the stanza are set 
+  the value of the environment variable will take precedence.
 
 - `max_parallel` `(int: 128)` - Specifies the maximum number of parallel
-  operations to take place.
+  operations to take place. 
 
 ### High Availability Parameters
 
 - `ha_enabled` `(string: "false")` - Specifies if high availability mode is
   enabled. This is a boolean value, but it is specified as a string like "true"
-  or "false".
-
+  or "false". Alternatively, this parameter can be omitted and the 
+  `GOOGLE_STORAGE_HA_ENABLED` environment variable can be used to 
+  enable or disable high availability. If both the environment variable and 
+  the parameter in the stanza are set the value of the environment variable will 
+  take precedence.
+  
 ## `gcs` Examples
 
 ### High Availability

--- a/website/content/docs/configuration/storage/google-cloud-storage.mdx
+++ b/website/content/docs/configuration/storage/google-cloud-storage.mdx
@@ -98,7 +98,7 @@ https://www.googleapis.com/auth/devstorage.read_write
 - `bucket` `(string: <required>)` – Specifies the name of the bucket to use for
   storage. Alternatively, this parameter can be omitted and the `GOOGLE_STORAGE_BUCKET` 
   environment variable can be used to set the name of the bucket. If both the environment
-  variable and the parameter in the stanza are set the value of the environment variable
+  variable and the parameter in the stanza are set, the value of the environment variable
   will take precedence.
 
 - `chunk_size` `(string: "8192")` – Specifies the maximum size (in kilobytes) to

--- a/website/content/docs/configuration/storage/google-cloud-storage.mdx
+++ b/website/content/docs/configuration/storage/google-cloud-storage.mdx
@@ -105,13 +105,13 @@ https://www.googleapis.com/auth/devstorage.read_write
   send in a single request. If set to 0, it will attempt to send the whole
   object at once, but will not retry any failures. If you are not storing large
   objects in Vault, it is recommended to set this to a low value (minimum is
-  256 ), since it will reduce the amount of memory Vault uses. Alternatively, this parameter
+  256), since it will reduce the amount of memory Vault uses. Alternatively, this parameter
   can be omitted and the `GOOGLE_STORAGE_CHUNK_SIZE` environment variable can be used to set 
   the chunk size. If both the environment variable and the parameter in the stanza are set 
   the value of the environment variable will take precedence.
 
 - `max_parallel` `(int: 128)` - Specifies the maximum number of parallel
-  operations to take place. 
+  operations to take place.
 
 ### High Availability Parameters
 


### PR DESCRIPTION
Add mentions the environment variables that can be used to configure the backend instead of using the stanza parameters