### PR TITLE
Add vault pki role-update subcommand

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -487,13 +487,8 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
-		"pki role-test": func() (cli.Command, error) {
-			return &PKIRoleTestCommand{
-				BaseCommand: getBaseCommand(),
-			}, nil
-		},
-		"pki initialize-topology": func() (cli.Command, error) {
-			return &PKICreateCACommand{
+		"pki add-intermediate": func() (cli.Command, error) {
+			return &PKIAddIntermediateCommand{
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
@@ -502,8 +497,18 @@ func initCommands(ui, serverCmdUi cli.Ui, runOpts *RunOptions) {
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},
-		"pki add-intermediate": func() (cli.Command, error) {
-			return &PKIAddIntermediateCommand{
+		"pki initialize-topology": func() (cli.Command, error) {
+			return &PKICreateCACommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"pki role-test": func() (cli.Command, error) {
+			return &PKIRoleTestCommand{
+				BaseCommand: getBaseCommand(),
+			}, nil
+		},
+		"pki role-update": func() (cli.Command, error) {
+			return &PKIRoleUpdateCommand{
 				BaseCommand: getBaseCommand(),
 			}, nil
 		},

--- a/command/pki.go
+++ b/command/pki.go
@@ -25,12 +25,17 @@ Usage: vault pki <subcommand> [options] [args]
   This command groups subcommands for interacting with Vault's PKI Secrets
   Engine. Operators can manage PKI mounts and roles.
 
+  To add a new intermediate CA mount:
+
+       $ vault pki add-intermediate pki pki-int example.com ttl=43800h
+
   To test role based issuance:
 
        $ vault pki role-test -mount=pki-int server-role example.com
 
-  To add new intermediate:
-       $ vault pki add-intermediate pki pki-int example.com ttl=43800h
+  To update a role, changing only newly specified fields:
+
+       $ vault pki role-update /pki-int/roles/server-role allow_localhost=false
 
   Please see the individual subcommand help for detailed usage information.
 `

--- a/command/pki_roleupdate.go
+++ b/command/pki_roleupdate.go
@@ -1,0 +1,104 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+)
+
+var (
+	_ cli.Command             = (*PKIRoleUpdateCommand)(nil)
+	_ cli.CommandAutocomplete = (*PKIRoleUpdateCommand)(nil)
+)
+
+type PKIRoleUpdateCommand struct {
+	*BaseCommand
+}
+
+func (c *PKIRoleUpdateCommand) Synopsis() string {
+	return "Update existing PKI Secrets Engine role"
+}
+
+func (c *PKIRoleUpdateCommand) Help() string {
+	helpText := `
+Usage: vault pki role-update ROLE_PATH [K=V...]
+
+  Update the specific role, fetching all present values and then updating
+  only the newly specified fields.
+
+  To disallow localhost issuance without modifying the rest of the role:
+
+      $ vault pki role-update /pki/roles/example-com allow_localhost=false
+
+` + c.Flags().Help()
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *PKIRoleUpdateCommand) Flags() *FlagSets {
+	set := c.flagSet(FlagSetHTTP)
+	return set
+}
+
+func (c *PKIRoleUpdateCommand) AutocompleteArgs() complete.Predictor {
+	// Return an anything predictor here, similar to `vault write`. We
+	// don't know what values are valid for the role and/or common names.
+	return complete.PredictAnything
+}
+
+func (c *PKIRoleUpdateCommand) AutocompleteFlags() complete.Flags {
+	return c.Flags().Completions()
+}
+
+func (c *PKIRoleUpdateCommand) Run(args []string) int {
+	f := c.Flags()
+
+	if err := f.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	args = f.Args()
+	if len(args) < 2 {
+		c.UI.Error(fmt.Sprintf("Not enough arguments (expected 2+, got %d)", len(args)))
+		return 1
+	}
+
+	rolePath := sanitizePath(args[0])
+	updateData, err := parseArgsData(nil, args[1:])
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to parse K=V data: %s", err))
+		return 1
+	}
+
+	client, err := c.Client()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 2
+	}
+
+	roleData, err := client.Logical().Read(rolePath)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading role: %v", err))
+		return 2
+	}
+
+	if roleData == nil || roleData.Data == nil {
+		c.UI.Error(fmt.Sprintf("Fetch succeeded but got empty role data: %v", roleData))
+		return 2
+	}
+
+	for key, value := range updateData {
+		roleData.Data[key] = value
+	}
+
+	_, err = client.Logical().Write(rolePath, roleData.Data)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error updating role: %v", err))
+		return 2
+	}
+
+	return 0
+}


### PR DESCRIPTION
Writing over an existing role (`vault write /pki/roles/example-com ...`)
results in a loss of data unless all previously specified options are
re-specified. This means there's no update capability. Add a new
subcommand, `vault pki role-update /pki/roles/example-com ...` to
handle fetching existing role data and augmenting it with new options.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`