### PR TITLE
1.9 backport: added add_basic_constraints parameter to PKI API docs (#14457)

### DIFF
--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -506,6 +506,10 @@ can be set in a CSR are supported.
   Otherwise Vault will generate a random serial for you. If you want more than
   one, specify alternative names in the alt_names map using OID 2.5.4.5.
 
+- `add_basic_constraints` `(bool: false)` – Whether to add a Basic Constraints
+  extension with CA: true. Only needed as a workaround in some compatibility
+  scenarios with Active Directory Certificate Services.
+
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
* added add_basic_constraints parameter to PKI API docs

Added add_basic_constraints parameter to PKI API docs for Generate Intermediate.

Copied description from https://github.com/hashicorp/vault/blob/ba533d006f2244103648785ebfe8a9a9763d2b6e/builtin/logical/pki/path_intermediate.go#L34-L37

---

Manual backport of "added add_basic_constraints parameter to PKI API docs" #14457 to 1.9.x due to merge conflicts. 