### PR TITLE
UI/fix kv data cache

### DIFF
--- a/changelog/14489.txt
+++ b/changelog/14489.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes caching issue on kv new version create
+```

--- a/ui/app/adapters/secret-v2-version.js
+++ b/ui/app/adapters/secret-v2-version.js
@@ -149,6 +149,7 @@ export default ApplicationAdapter.extend({
     } else if (deleteType === 'soft-delete') {
       return this.softDelete(backend, path, version);
     } else {
+      version = version || currentVersionForNoReadMetadata;
       return this.deleteByDeleteType(backend, path, deleteType, version);
     }
   },

--- a/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
+++ b/ui/app/routes/vault/cluster/secrets/backend/secret-edit.js
@@ -248,20 +248,7 @@ export default Route.extend(UnloadModelRoute, {
     if (modelType === 'secret-v2') {
       // after the the base model fetch, kv-v2 has a second associated
       // version model that contains the secret data
-
-      // if no read access to metadata, return current Version from secret data.
-      if (!secretModel.currentVersion) {
-        let adapter = this.store.adapterFor('secret-v2-version');
-        try {
-          secretModel.currentVersion = await adapter.getSecretDataVersion(backend, secret);
-        } catch {
-          // will get error if you have deleted the secret
-          // if this is the case do nothing
-        }
-        secretModel = await this.fetchV2Models(capabilities, secretModel, params);
-      } else {
-        secretModel = await this.fetchV2Models(capabilities, secretModel, params);
-      }
+      secretModel = await this.fetchV2Models(capabilities, secretModel, params);
     }
     return {
       secret: secretModel,

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -152,13 +152,13 @@
   <form onsubmit={{action "createOrUpdateKey" "edit"}}>
     <div class="box is-sideless is-fullwidth is-marginless padding-top">
       <MessageError @model={{@modelForData}} @errorMessage={{this.error}} />
-      {{#unless @canReadSecretData}}
+      {{#if (eq @canReadSecretData false)}}
         <AlertBanner
           @type="warning"
           @message="You do not have read permissions. If a secret exists here creating a new secret will overwrite it."
           data-test-warning-no-read-permissions
         />
-      {{/unless}}
+      {{/if}}
       <NamespaceReminder @mode="edit" @noun="secret" />
       {{#if this.isCreateNewVersionFromOldVersion}}
         <div class="form-section">

--- a/ui/app/templates/components/secret-edit-toolbar.hbs
+++ b/ui/app/templates/components/secret-edit-toolbar.hbs
@@ -92,12 +92,15 @@
       {{#let (concat "vault.cluster.secrets.backend." (if (eq @mode "show") "edit" "show")) as |targetRoute|}}
         {{#if @isV2}}
           <ToolbarLink
-            @params={{array targetRoute @model.id (query-params version=@modelForData.version)}}
+            {{! Always create new version from latest if no metadata read access }}
+            @params={{array
+              targetRoute
+              @model.id
+              (query-params version=(if @model.canReadMetadata @modelForData.version ""))
+            }}
             @data-test-secret-edit="true"
             @replace={{true}}
             @type="add"
-            @disabled={{@model.failedServerRead}}
-            @disabledTooltip="Metadata read access is required to create new version"
           >
             Create new version
           </ToolbarLink>

--- a/ui/tests/acceptance/access/identity/_shared-alias-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-alias-tests.js
@@ -88,12 +88,11 @@ export const testAliasDeleteFromForm = async function (name, itemType, assert) {
   await page.editForm.delete();
   await page.editForm.waitForConfirm();
   await page.editForm.confirmDelete();
-  await page.editForm.waitForFlash();
+  await settled();
   assert.ok(
     aliasIndexPage.flashMessage.latestMessage.startsWith('Successfully deleted'),
     `${itemType}: shows flash message`
   );
-
   assert.equal(
     currentRouteName(),
     'vault.cluster.access.identity.aliases.index',

--- a/ui/tests/acceptance/access/identity/_shared-alias-tests.js
+++ b/ui/tests/acceptance/access/identity/_shared-alias-tests.js
@@ -86,9 +86,9 @@ export const testAliasDeleteFromForm = async function (name, itemType, assert) {
     `${itemType}: navigates to edit on create`
   );
   await page.editForm.delete();
-  await settled();
+  await page.editForm.waitForConfirm();
   await page.editForm.confirmDelete();
-  await settled();
+  await page.editForm.waitForFlash();
   assert.ok(
     aliasIndexPage.flashMessage.latestMessage.startsWith('Successfully deleted'),
     `${itemType}: shows flash message`

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -607,11 +607,22 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await assert
       .dom('[data-test-value-div="secret-key"]')
       .exists('secret view page and info table row with secret-key value');
-    // create new version should be disabled with no metadata read access
-    assert.dom('[data-test-secret-edit]').hasClass('disabled', 'Create new version action is disabled');
-    assert
-      .dom('[data-test-popup-menu-trigger="version"]')
-      .doesNotExist('the version drop down menu does not show');
+
+    // Create new version
+    assert.dom('[data-test-secret-edit]').doesNotHaveClass('disabled', 'Create new version is not disabled');
+    await click('[data-test-secret-edit]');
+
+    // create new version should not include version in the URL
+    assert.equal(
+      currentURL(),
+      `/vault/secrets/${enginePath}/edit/${secretPath}`,
+      'edit route does not include version query param'
+    );
+    // Update key
+    await editPage.secretKey('newKey');
+    await editPage.secretValue('some-value');
+    await editPage.save();
+    assert.dom('[data-test-value-div="newKey"]').exists('Info row table exists at newKey');
 
     // check metadata tab
     await click('[data-test-secret-metadata-tab]');
@@ -683,8 +694,9 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await settled(); // eslint-disable-line
     await click('[data-test-secret-tab]');
     await settled(); // eslint-disable-line
-    let text = document.querySelector('[data-test-empty-state-title]').innerText.trim();
-    assert.equal(text, 'Version 1 of this secret has been permanently destroyed');
+    assert
+      .dom('[data-test-empty-state-title]')
+      .includesText('Version 2 of this secret has been permanently destroyed');
   });
 
   test('version 2 with policy with only delete option does not show modal and undelete is an option', async function (assert) {

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -696,7 +696,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     await settled(); // eslint-disable-line
     assert
       .dom('[data-test-empty-state-title]')
-      .includesText('Version 2 of this secret has been permanently destroyed');
+      .includesText('Version 1 of this secret has been permanently destroyed');
   });
 
   test('version 2 with policy with only delete option does not show modal and undelete is an option', async function (assert) {

--- a/ui/tests/pages/components/identity/edit-form.js
+++ b/ui/tests/pages/components/identity/edit-form.js
@@ -1,4 +1,5 @@
 import { clickable, fillable, attribute } from 'ember-cli-page-object';
+import { waitFor } from '@ember/test-helpers';
 import fields from '../form-field';
 
 export default {
@@ -13,4 +14,10 @@ export default {
   submit: clickable('[data-test-identity-submit]'),
   delete: clickable('[data-test-confirm-action-trigger]'),
   confirmDelete: clickable('[data-test-confirm-button]'),
+  waitForConfirm() {
+    return waitFor('[data-test-confirm-button]');
+  },
+  waitForFlash() {
+    return waitFor('[data-test-flash-message-body]');
+  },
 };


### PR DESCRIPTION
This PR fixes some strange behavior within the KV secrets engine (see gifs below):

User `reader` has the following policy:
```
path "kv/metadata" {
  capabilities = ["list"]
}
path "kv/data/*" {
  capabilities = ["read", "update"]
}
```

User `admin` has the following policy:
```
path "kv/metadata" {
  capabilities = ["list"]
}
path "kv/data/*" {
  capabilities = ["read", "update"]
}
path "kv/metadata/*" {
  capabilities = ["read", "update"]
}
```
**BEFORE: reader cannot click button create new version, but experiences no issues when creating a version other than the new version doesn't show after redirect to show view**
![kv-new-version-before](https://user-images.githubusercontent.com/82459713/158228230-8df802d2-baf7-4fba-85df-c8ca43fc5dde.gif)

**AFTER: admin can still create new version from specific version (this behavior is preserved, if user has metadata read access)**
![kv-new-version-after](https://user-images.githubusercontent.com/82459713/158228220-ff34ea95-12b6-4988-8fc1-c17f51446689.gif)

**AFTER: reader can create new version, and it always creates from the most recent version due to no metadata read access**
![kv-new-version-metadata](https://user-images.githubusercontent.com/82459713/158228238-6052ee61-9e8b-483a-a1e5-107fe711322f.gif)
