### PR TITLE
Add input validation to getRuleInfo to prevent panic

### DIFF
--- a/changelog/14501.txt
+++ b/changelog/14501.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix panic caused by parsing policies with empty slice values.
+```

--- a/helper/random/parser.go
+++ b/helper/random/parser.go
@@ -126,6 +126,11 @@ func getRuleInfo(rule map[string]interface{}) (data ruleInfo, err error) {
 		if err != nil {
 			return data, fmt.Errorf("unable to get rule data: %w", err)
 		}
+
+		if len(slice) == 0 {
+			return data, fmt.Errorf("rule info cannot be empty")
+		}
+
 		data = ruleInfo{
 			ruleType: key,
 			data:     slice[0],

--- a/helper/random/parser_test.go
+++ b/helper/random/parser_test.go
@@ -297,6 +297,15 @@ func TestParser_ParsePolicy(t *testing.T) {
 			expected:  StringGenerator{},
 			expectErr: true,
 		},
+		"config value with empty slice": {
+			registry: defaultRuleNameMapping,
+			rawConfig: `
+                rule {
+                    n = []
+                }`,
+			expected:  StringGenerator{},
+			expectErr: true,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
A panic can be caused if input to the `ParsePolicy` function contains a field whose value is an empty slice. This is due to a lack of length check in the underlying `getRuleInfo` function which assumes the parsed slice to contain at least one value. The panic can be prevented by returning an error from `getRuleInfo` if an empty slice is encountered.