### PR TITLE
Revert the OpenAPI reference objects change #14217

### DIFF
--- a/changelog/14217.txt
+++ b/changelog/14217.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sdk: Change OpenAPI code generator to extract request objects into /components/schemas and reference them by name.
+```

--- a/changelog/14217.txt
+++ b/changelog/14217.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-sdk: Change OpenAPI code generator to extract request objects into /components/schemas and reference them by name.
-```

--- a/changelog/14506.txt
+++ b/changelog/14506.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+sdk: Revert the change to OpenAPI code generator to extract request objects into /components/schemas since it's causing issue with the UI.
+```

--- a/sdk/framework/backend.go
+++ b/sdk/framework/backend.go
@@ -198,7 +198,7 @@ func (b *Backend) HandleRequest(ctx context.Context, req *logical.Request) (*log
 
 	// If the path is empty and it is a help operation, handle that.
 	if req.Path == "" && req.Operation == logical.HelpOperation {
-		return b.handleRootHelp(req)
+		return b.handleRootHelp()
 	}
 
 	// Find the matching route
@@ -457,7 +457,7 @@ func (b *Backend) route(path string) (*Path, map[string]string) {
 	return nil, nil
 }
 
-func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error) {
+func (b *Backend) handleRootHelp() (*logical.Response, error) {
 	// Build a mapping of the paths and get the paths alphabetized to
 	// make the output prettier.
 	pathsMap := make(map[string]*Path)
@@ -486,18 +486,9 @@ func (b *Backend) handleRootHelp(req *logical.Request) (*logical.Response, error
 		return nil, err
 	}
 
-	// Plugins currently don't have a direct knowledge of their own "type"
-	// (e.g. "kv", "cubbyhole"). It defaults to the name of the executable but
-	// can be overridden when the plugin is mounted. Since we need this type to
-	// form the request & response full names, we are passing it as an optional
-	// request parameter to the plugin's root help endpoint. If specified in
-	// the request, the type will be used as part of the request/response body
-	// names in the OAS document.
-	requestResponsePrefix := req.GetString("requestResponsePrefix")
-
 	// Build OpenAPI response for the entire backend
 	doc := NewOASDocument()
-	if err := documentPaths(b, requestResponsePrefix, doc); err != nil {
+	if err := documentPaths(b, doc); err != nil {
 		b.Logger().Warn("error generating OpenAPI", "error", err)
 	}
 

--- a/sdk/framework/openapi_test.go
+++ b/sdk/framework/openapi_test.go
@@ -271,7 +271,7 @@ func TestOpenAPI_SpecialPaths(t *testing.T) {
 			Root:            test.rootPaths,
 			Unauthenticated: test.unauthPaths,
 		}
-		err := documentPath(&path, sp, "kv", logical.TypeLogical, doc)
+		err := documentPath(&path, sp, logical.TypeLogical, doc)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -515,11 +515,11 @@ func TestOpenAPI_OperationID(t *testing.T) {
 
 	for _, context := range []string{"", "bar"} {
 		doc := NewOASDocument()
-		err := documentPath(path1, nil, "kv", logical.TypeLogical, doc)
+		err := documentPath(path1, nil, logical.TypeLogical, doc)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = documentPath(path2, nil, "kv", logical.TypeLogical, doc)
+		err = documentPath(path2, nil, logical.TypeLogical, doc)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -579,7 +579,7 @@ func TestOpenAPI_CustomDecoder(t *testing.T) {
 	}
 
 	docOrig := NewOASDocument()
-	err := documentPath(p, nil, "kv", logical.TypeLogical, docOrig)
+	err := documentPath(p, nil, logical.TypeLogical, docOrig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -642,7 +642,7 @@ func testPath(t *testing.T, path *Path, sp *logical.Paths, expectedJSON string) 
 	t.Helper()
 
 	doc := NewOASDocument()
-	if err := documentPath(path, sp, "kv", logical.TypeLogical, doc); err != nil {
+	if err := documentPath(path, sp, logical.TypeLogical, doc); err != nil {
 		t.Fatal(err)
 	}
 	doc.CreateOperationIDs("")

--- a/sdk/framework/path.go
+++ b/sdk/framework/path.go
@@ -301,17 +301,9 @@ func (p *Path) helpCallback(b *Backend) OperationFunc {
 			return nil, errwrap.Wrapf("error executing template: {{err}}", err)
 		}
 
-		// The plugin type (e.g. "kv", "cubbyhole") is only assigned at the time
-		// the plugin is enabled (mounted). If specified in the request, the type
-		// will be used as part of the request/response names in the OAS document
-		var requestResponsePrefix string
-		if v, ok := req.Data["requestResponsePrefix"]; ok {
-			requestResponsePrefix = v.(string)
-		}
-
 		// Build OpenAPI response for this path
 		doc := NewOASDocument()
-		if err := documentPath(p, b.SpecialPaths(), requestResponsePrefix, b.BackendType, doc); err != nil {
+		if err := documentPath(p, b.SpecialPaths(), b.BackendType, doc); err != nil {
 			b.Logger().Warn("error generating OpenAPI", "error", err)
 		}
 

--- a/sdk/framework/testdata/legacy.json
+++ b/sdk/framework/testdata/legacy.json
@@ -41,7 +41,13 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/KvLookupRequest"
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "description": "My token"
+                  }
+                }
               }
             }
           }
@@ -49,19 +55,6 @@
         "responses": {
           "200": {
             "description": "OK"
-          }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "KvLookupRequest": {
-        "type": "object",
-        "properties": {
-          "token": {
-            "type": "string",
-            "description": "My token"
           }
         }
       }

--- a/sdk/framework/testdata/operations.json
+++ b/sdk/framework/testdata/operations.json
@@ -66,7 +66,39 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/KvFooRequest"
+                "type": "object",
+                "required": ["age"],
+                "properties": {
+                  "flavors": {
+                    "type": "array",
+                    "description": "the flavors",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "age": {
+                    "type": "integer",
+                    "description": "the age",
+                    "enum": [1, 2, 3],
+                    "x-vault-displayAttrs": {
+                      "name": "Age",
+                      "sensitive": true,
+                      "group": "Some Group",
+                      "value": 7
+                    }
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "the name",
+                    "default": "Larry",
+                    "pattern": "\\w([\\w-.]*\\w)?"
+                  },
+                  "x-abc-token": {
+                    "type": "string",
+                    "description": "a header value",
+                    "enum": ["a", "b", "c"]
+                  }
+                }
               }
             }
           }
@@ -74,45 +106,6 @@
         "responses": {
           "200": {
             "description": "OK"
-          }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "KvFooRequest": {
-        "type": "object",
-        "required": ["age"],
-        "properties": {
-          "flavors": {
-            "type": "array",
-            "description": "the flavors",
-            "items": {
-              "type": "string"
-            }
-          },
-          "age": {
-            "type": "integer",
-            "description": "the age",
-            "enum": [1, 2, 3],
-            "x-vault-displayAttrs": {
-              "name": "Age",
-              "sensitive": true,
-              "group": "Some Group",
-              "value": 7
-            }
-          },
-          "name": {
-            "type": "string",
-            "description": "the name",
-            "default": "Larry",
-            "pattern": "\\w([\\w-.]*\\w)?"
-          },
-          "x-abc-token": {
-            "type": "string",
-            "description": "a header value",
-            "enum": ["a", "b", "c"]
           }
         }
       }

--- a/sdk/framework/testdata/operations_list.json
+++ b/sdk/framework/testdata/operations_list.json
@@ -59,9 +59,5 @@
         ]
       }
     }
-  },
-  "components": {
-    "schemas": {
-    }
   }
 }

--- a/sdk/framework/testdata/responses.json
+++ b/sdk/framework/testdata/responses.json
@@ -46,10 +46,6 @@
         }
       }
     }
-  },
-  "components": {
-    "schemas": {
-    }
   }
 }
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -4034,13 +4034,7 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 	doc := framework.NewOASDocument()
 
 	procMountGroup := func(group, mountPrefix string) error {
-		for mount, entry := range resp.Data[group].(map[string]interface{}) {
-
-			var pluginType string
-			if t, ok := entry.(map[string]interface{})["type"]; ok {
-				pluginType = t.(string)
-			}
-
+		for mount := range resp.Data[group].(map[string]interface{}) {
 			backend := b.Core.router.MatchingBackend(ctx, mountPrefix+mount)
 
 			if backend == nil {
@@ -4050,7 +4044,6 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 			req := &logical.Request{
 				Operation: logical.HelpOperation,
 				Storage:   req.Storage,
-				Data:      map[string]interface{}{"requestResponsePrefix": pluginType},
 			}
 
 			resp, err := backend.HandleRequest(ctx, req)
@@ -4105,11 +4098,6 @@ func (b *SystemBackend) pathInternalOpenAPI(ctx context.Context, req *logical.Re
 				}
 
 				doc.Paths["/"+mountPrefix+mount+path] = obj
-			}
-
-			// Merge backend schema components
-			for e, schema := range backendDoc.Components.Schemas {
-				doc.Components.Schemas[e] = schema
 			}
 		}
 		return nil

--- a/vault/logical_system_test.go
+++ b/vault/logical_system_test.go
@@ -3436,9 +3436,6 @@ func TestSystemBackend_OpenAPI(t *testing.T) {
 			},
 		},
 		"paths": map[string]interface{}{},
-		"components": map[string]interface{}{
-			"schemas": map[string]interface{}{},
-		},
 	}
 
 	if diff := deep.Equal(oapi, exp); diff != nil {


### PR DESCRIPTION
The change in the structure of OpenAPI spec to add reference objects (#14217) caused portions of the UI to break. Reverting this change for now while we investigate & fix the issue.