### PR TITLE
UI: Parse OpenAPI response correctly if schema includes $ref

### DIFF
--- a/changelog/14508.txt
+++ b/changelog/14508.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Parse schema refs from OpenAPI
+```

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -207,7 +207,7 @@ export default Service.extend({
       let props = {};
       const schema = pathInfo?.post?.requestBody?.content['application/json'].schema;
       if (schema.$ref) {
-        // $ref will be shaped like `#/component/schema/MyResponseType
+        // $ref will be shaped like `#/components/schemas/MyResponseType
         // which maps to the location of the item within the openApi response
         let loc = schema.$ref.replace('#/', '').split('/');
         props = loc.reduce((prev, curr) => {

--- a/ui/app/services/path-help.js
+++ b/ui/app/services/path-help.js
@@ -204,10 +204,18 @@ export default Service.extend({
         };
       }
 
-      // TODO: handle post endpoints without requestBody
-      const props = pathInfo.post
-        ? pathInfo.post.requestBody.content['application/json'].schema.properties
-        : {};
+      let props = {};
+      const schema = pathInfo?.post?.requestBody?.content['application/json'].schema;
+      if (schema.$ref) {
+        // $ref will be shaped like `#/component/schema/MyResponseType
+        // which maps to the location of the item within the openApi response
+        let loc = schema.$ref.replace('#/', '').split('/');
+        props = loc.reduce((prev, curr) => {
+          return prev[curr] || {};
+        }, help.openapi).properties;
+      } else if (schema.properties) {
+        props = schema.properties;
+      }
       // put url params (e.g. {name}, {role})
       // at the front of the props list
       const newProps = assign({}, paramProp, props);


### PR DESCRIPTION
This PR adds UI support for the changes in #14217 

Before this change, the UI was broken where we try to generate the form based on OpenAPI:
![image](https://user-images.githubusercontent.com/82459713/158459397-771d4f6a-ede0-4dfb-9cad-958f9ed28d3e.png)


After, the form is rendered as expected:
![image](https://user-images.githubusercontent.com/82459713/158459369-f6257256-838c-45b8-b52e-3412f61308db.png)
