### PR TITLE
vault/external_tests/raft: fix dropped test error

### DIFF
--- a/vault/external_tests/raft/raft_test.go
+++ b/vault/external_tests/raft/raft_test.go
@@ -492,6 +492,9 @@ func TestRaft_SnapshotAPI(t *testing.T) {
 	// Take a snapshot
 	buf := new(bytes.Buffer)
 	err := leaderClient.Sys().RaftSnapshot(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	snap, err := io.ReadAll(buf)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This fixes a dropped test error in `vault/external_tests/raft`.

Could someone add the "no-changelog" label?