### PR TITLE
Fix panic caused by parsing `json.Number` values for TypeCommaStringSlice fields

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/go-rootcerts v1.0.2
-	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/vault/sdk v0.4.1
 	github.com/mitchellh/mapstructure v1.4.2

--- a/api/go.sum
+++ b/api/go.sum
@@ -113,8 +113,9 @@ github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR3
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.1/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 h1:cCRo8gK7oq6A2L6LICkUZ+/a5rLiRXFMf1Qd4xSwxTc=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1/go.mod h1:zq93CJChV6L9QTfGKtfBxKqD7BqqXx5O04A/ns2p5+I=
-github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1 h1:78ki3QBevHwYrVxnyVeaEz+7WtifHhauYF23es/0KlI=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4 h1:hrIH/qrOTHfG9a1Jz6Z2jQf7Xe77AaD464W1fCFLwPQ=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1 h1:nd0HIW15E6FG1MsnArYaHfuw9C2zgzM8LxkG5Ty/788=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1/go.mod h1:gKOamz3EwoIoJq7mlMIRBpVTAUn8qPCrEclOKKWhD3U=

--- a/changelog/14522.txt
+++ b/changelog/14522.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix panic caused by parsing JSON integers for fields defined as comma-delimited strings
+```

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1
 	github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.1
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.2
-	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.3
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4
 	github.com/hashicorp/go-secure-stdlib/password v0.1.1
 	github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -882,8 +882,6 @@ github.com/hashicorp/go-secure-stdlib/mlock v0.1.2 h1:p4AKXPPS24tO8Wc8i1gLvSKdmk
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.2/go.mod h1:zq93CJChV6L9QTfGKtfBxKqD7BqqXx5O04A/ns2p5+I=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
-github.com/hashicorp/go-secure-stdlib/parseutil v0.1.3 h1:geBw3SBrxQq+buvbf4K+Qltv1gjaXJxy8asD4CjGYow=
-github.com/hashicorp/go-secure-stdlib/parseutil v0.1.3/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4 h1:hrIH/qrOTHfG9a1Jz6Z2jQf7Xe77AaD464W1fCFLwPQ=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1 h1:6JzmBqXprakgFEHwBgdchsjaA9x3GyjdI568bXKxa60=

--- a/go.sum
+++ b/go.sum
@@ -884,6 +884,8 @@ github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.3 h1:geBw3SBrxQq+buvbf4K+Qltv1gjaXJxy8asD4CjGYow=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.3/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4 h1:hrIH/qrOTHfG9a1Jz6Z2jQf7Xe77AaD464W1fCFLwPQ=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1 h1:6JzmBqXprakgFEHwBgdchsjaA9x3GyjdI568bXKxa60=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
 github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1 h1:SMGUnbpAcat8rIKHkBPjfv81yC46a8eCNZ2hsR2l1EI=

--- a/sdk/framework/field_data_test.go
+++ b/sdk/framework/field_data_test.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"encoding/json"
 	"net/http"
 	"reflect"
 	"testing"
@@ -1081,6 +1082,16 @@ func TestFieldDataGet_Error(t *testing.T) {
 			},
 			map[string]interface{}{
 				"foo": -42.0,
+			},
+			"foo",
+		},
+
+		"comma string slice type, single JSON number value": {
+			map[string]*FieldSchema{
+				"foo": {Type: TypeCommaStringSlice},
+			},
+			map[string]interface{}{
+				"foo": json.Number("123"),
 			},
 			"foo",
 		},

--- a/sdk/framework/field_data_test.go
+++ b/sdk/framework/field_data_test.go
@@ -856,6 +856,18 @@ func TestFieldDataGet(t *testing.T) {
 			false,
 		},
 
+		"comma string slice type, single JSON number value": {
+			map[string]*FieldSchema{
+				"foo": {Type: TypeCommaStringSlice},
+			},
+			map[string]interface{}{
+				"foo": json.Number("123"),
+			},
+			"foo",
+			[]string{"123"},
+			false,
+		},
+
 		"type kv pair, not supplied": {
 			map[string]*FieldSchema{
 				"foo": {Type: TypeKVPairs},
@@ -1082,16 +1094,6 @@ func TestFieldDataGet_Error(t *testing.T) {
 			},
 			map[string]interface{}{
 				"foo": -42.0,
-			},
-			"foo",
-		},
-
-		"comma string slice type, single JSON number value": {
-			map[string]*FieldSchema{
-				"foo": {Type: TypeCommaStringSlice},
-			},
-			map[string]interface{}{
-				"foo": json.Number("123"),
 			},
 			"foo",
 		},

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.1
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.1
-	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4
 	github.com/hashicorp/go-secure-stdlib/password v0.1.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.1
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -109,6 +109,8 @@ github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 h1:cCRo8gK7oq6A2L6LICkUZ+/a5r
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1/go.mod h1:zq93CJChV6L9QTfGKtfBxKqD7BqqXx5O04A/ns2p5+I=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1 h1:78ki3QBevHwYrVxnyVeaEz+7WtifHhauYF23es/0KlI=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4 h1:hrIH/qrOTHfG9a1Jz6Z2jQf7Xe77AaD464W1fCFLwPQ=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.4/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1 h1:6JzmBqXprakgFEHwBgdchsjaA9x3GyjdI568bXKxa60=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1 h1:nd0HIW15E6FG1MsnArYaHfuw9C2zgzM8LxkG5Ty/788=


### PR DESCRIPTION
Vault will panic when it attempts to parse fields with a schema of TypeCommaStringSlice if the provided value is an integer specifically if provided within the JSON body of an HTTP request. The underlying cause is within the `ParseCommaStringSlice` function in `go-secure-stdlib/parseutil`. The issue has been fixed in `go-secure-stdlib` [#29](https://github.com/hashicorp/go-secure-stdlib/pull/29).

The changes introduced within this PR are:
- Upgrading to  `v0.1.4` of `go-secure-stdlib/parseutil`
- Adding a test specifically for `json.Number` input

**Before fix:**

```
❯ vault auth enable userpass
Success! Enabled userpass auth method at: userpass/

❯ curl -v -XPOST -H "X-Vault-Token: $VAULT_TOKEN" --data '{"password":"abc123", "token_bound_cidrs": 123}' "$VAULT_ADDR/v1/auth/userpass/users/jdoe"
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8200 (#0)
> POST /v1/auth/userpass/users/jdoe HTTP/1.1
> Host: 127.0.0.1:8200
> User-Agent: curl/7.64.1
> Accept: */*
> X-Vault-Token: hvs.ogFGaKQ3F4DUEh2OtQ39L1bf
> Content-Length: 47
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 47 out of 47 bytes
* Empty reply from server
* Connection #0 to host 127.0.0.1 left intact
curl: (52) Empty reply from server
* Closing connection 0
```
Panic in server logs (truncated):
```
2022-03-16T10:42:16.943-0400 [INFO]  http: panic serving 127.0.0.1:51571: interface conversion: interface {} is json.Number, not string
goroutine 854 [running]:
net/http.(*conn).serve.func1()
        /usr/local/bin/go/src/net/http/server.go:1802 +0xb9
panic({0x514d440, 0xc000cce810})
        /usr/local/bin/go/src/runtime/panic.go:1047 +0x266
github.com/mitchellh/mapstructure.StringToSliceHookFunc.func1(0x51a9ec0, 0xc000dfd720, {0x51a9ec0, 0xc000dfd720})
        /Users/ccapurso/go/pkg/mod/github.com/mitchellh/mapstructure@v1.4.3/decode_hooks.go:91 +0xd1
github.com/mitchellh/mapstructure.DecodeHookExec({0x50be8e0, 0xc0009cbbc0}, {0x51a9ec0, 0xc000dfd720, 0x1054e26}, {0x4cf4fe0, 0xc0009cbba8, 0x203000})
        /Users/ccapurso/go/pkg/mod/github.com/mitchellh/mapstructure@v1.4.3/decode_hooks.go:49 +0x1f9
github.com/mitchellh/mapstructure.(*Decoder).decode(0xc001482120, {0x0, 0xc000cca501}, {0x51a9ec0, 0xc000dfd720}, {0x4cf4fe0, 0xc0009cbba8, 0x48})
        /Users/ccapurso/go/pkg/mod/github.com/mitchellh/mapstructure@v1.4.3/mapstructure.go:440 +0x179
github.com/mitchellh/mapstructure.(*Decoder).Decode(0xc001482120, {0x51a9ec0, 0xc000dfd720})
        /Users/ccapurso/go/pkg/mod/github.com/mitchellh/mapstructure@v1.4.3/mapstructure.go:398 +0xd8
github.com/hashicorp/go-secure-stdlib/parseutil.ParseCommaStringSlice({0x51a9ec0, 0xc000dfd720})
        /Users/ccapurso/go/pkg/mod/github.com/hashicorp/go-secure-stdlib/parseutil@v0.1.3/parseutil.go:354 +0x11e
github.com/hashicorp/vault/sdk/framework.(*FieldData).getPrimitive(0x50594e0, {0xc001325788, 0xc001325788}, 0xc0014a2230)
        /Users/ccapurso/git/vault/sdk/framework/field_data.go:289 +0x71b
github.com/hashicorp/vault/sdk/framework.(*FieldData).Validate(0xc000dfd8c0)
        /Users/ccapurso/git/vault/sdk/framework/field_data.go:44 +0xf3
github.com/hashicorp/vault/sdk/framework.(*Backend).HandleExistenceCheck(0x0, {0x64dd010, 0xc000cce4e0}, 0xc0001e9e00)
        /Users/ccapurso/git/vault/sdk/framework/backend.go:174 +0x3b4
github.com/hashicorp/vault/builtin/plugin.(*PluginBackend).HandleExistenceCheck.func1()
        /Users/ccapurso/git/vault/builtin/plugin/backend.go:211 +0x43
github.com/hashicorp/vault/builtin/plugin.(*PluginBackend).lazyLoadBackend(0xc001081860, {0x64dd010, 0xc000cce4e0}, {0x64de8c8, 0xc0007b7780}, 0xc000fe01d0)
        /Users/ccapurso/git/vault/builtin/plugin/backend.go:162 +0x19d
github.com/hashicorp/vault/builtin/plugin.(*PluginBackend).HandleExistenceCheck(0xc0007e1ea0, {0x64dd010, 0xc000cce4e0}, 0xc000e2dcb9)
        /Users/ccapurso/git/vault/builtin/plugin/backend.go:209 +0x9f
github.com/hashicorp/vault/vault.(*Router).routeCommon(0xc00047f9f0, {0x64dd010, 0xc000cce4e0}, 0xc0001e9e00, 0x1)
        /Users/ccapurso/git/vault/vault/router.go:720 +0x18a9
github.com/hashicorp/vault/vault.(*Router).RouteExistenceCheck(0x505c120, {0x64dd010, 0xc000cce4e0}, 0xd)
        /Users/ccapurso/git/vault/vault/router.go:511 +0x28
github.com/hashicorp/vault/vault.(*Core).checkToken(0xc00089ea00, {0x64dd010, 0xc000cce4e0}, 0xc0001e9e00, 0x0)
        /Users/ccapurso/git/vault/vault/request_handling.go:318 +0x6ab
```

**After fix:**
```
❯ vault auth enable userpass
Success! Enabled userpass auth method at: userpass/

❯ curl -v -XPOST -H "X-Vault-Token: $VAULT_TOKEN" --data '{"password":"abc123", "token_bound_cidrs": 123}' "$VAULT_ADDR/v1/auth/userpass/users/jdoe"
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8200 (#0)
> POST /v1/auth/userpass/users/jdoe HTTP/1.1
> Host: 127.0.0.1:8200
> User-Agent: curl/7.64.1
> Accept: */*
> X-Vault-Token: hvs.8isydRBWneASw7nO8wYfISCt
> Content-Length: 47
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 47 out of 47 bytes
< HTTP/1.1 400 Bad Request
< Cache-Control: no-store
< Content-Type: application/json
< Strict-Transport-Security: max-age=31536000; includeSubDomains
< Date: Wed, 16 Mar 2022 14:44:29 GMT
< Content-Length: 117
<
{"errors":["error parsing address \"123\": Unable to convert \"123\" to an IPv4 or IPv6 address, or a UNIX Socket"]}
* Connection #0 to host 127.0.0.1 left intact
* Closing connection 0
```