### PR TITLE
Fix CLI panic caused by single backslash values

### DIFF
--- a/changelog/14523.txt
+++ b/changelog/14523.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix panic caused by parsing key=value fields whose value is a single backslash
+```

--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -140,6 +140,12 @@ func TestKVPutCommand(t *testing.T) {
 			[]string{"== Secret Path ==", "kv/data/write/foo"},
 			0,
 		},
+		{
+			"v2_single_value_backslash",
+			[]string{"kv/write/foo", "foo=\\"},
+			[]string{"== Secret Path ==", "kv/data/write/foo"},
+			0,
+		},
 	}
 
 	for _, tc := range cases {

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.1.5
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2
 	github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1
-	github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.1
+	github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.2
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.2
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.3
 	github.com/hashicorp/go-secure-stdlib/password v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -877,6 +877,8 @@ github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1 h1:9um9R8i0+HbRHS9d64kd
 github.com/hashicorp/go-secure-stdlib/gatedwriter v0.1.1/go.mod h1:6RoRTSMDK2H/rKh3P/JIsk1tK8aatKTt3JyvIopi3GQ=
 github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.1 h1:IJgULbAXuvWxzKFfu+Au1FUmHIJulS6N4F7Hkn+Kck0=
 github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.1/go.mod h1:rf5JPE13wi+NwjgsmGkbg4b2CgHq8v7Htn/F0nDe/hg=
+github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.2 h1:NS6BHieb/pDfx3M9jDdaPpGyyVp+aD4A3DjX3dgRmzs=
+github.com/hashicorp/go-secure-stdlib/kv-builder v0.1.2/go.mod h1:rf5JPE13wi+NwjgsmGkbg4b2CgHq8v7Htn/F0nDe/hg=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1/go.mod h1:zq93CJChV6L9QTfGKtfBxKqD7BqqXx5O04A/ns2p5+I=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.2 h1:p4AKXPPS24tO8Wc8i1gLvSKdmkiSY5xuju57czJ/IJQ=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.2/go.mod h1:zq93CJChV6L9QTfGKtfBxKqD7BqqXx5O04A/ns2p5+I=


### PR DESCRIPTION
Passing `key=value` fields whose value is a single backslash  to the CLI will cause a panic. The underlying cause exists in `go-secure-stdlib/kv-builder`. A fix has been introduced in `go-secure-stdlib/kv-builder` PR [#35](https://github.com/hashicorp/go-secure-stdlib/pull/35).

This PR introduces the following changes:
- Upgrade `go-secure-stdlib/kv-builder` to `v0.1.2`
- Add a KV test to ensure that single backslash values do not panic

Before change:

```
❯ vault kv put secret/foo 'bar=\'
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/hashicorp/go-secure-stdlib/kv-builder.(*Builder).add(0xc0008cb440, {0x7ffeefbff898, 0x11880ee8})
        /Users/ccapurso/go/pkg/mod/github.com/hashicorp/go-secure-stdlib/kv-builder@v0.1.1/builder.go:94 +0x832
github.com/hashicorp/go-secure-stdlib/kv-builder.(*Builder).Add(0x7ffeefbff88d, {0xc0001a6040, 0x1, 0x484dde5})
        /Users/ccapurso/go/pkg/mod/github.com/hashicorp/go-secure-stdlib/kv-builder@v0.1.1/builder.go:32 +0x89
github.com/hashicorp/vault/command.parseArgsData({0x6449e40, 0xc000194000}, {0xc0001a6040, 0x1, 0x1})
        /Users/ccapurso/git/vault/command/base_helpers.go:134 +0xaa
github.com/hashicorp/vault/command.(*KVPutCommand).Run(0xc0008cab20, {0xc0001a6030, 0x2, 0x2})
        /Users/ccapurso/git/vault/command/kv_put.go:120 +0x171
github.com/mitchellh/cli.(*CLI).Run(0xc000145cc0)
        /Users/ccapurso/go/pkg/mod/github.com/mitchellh/cli@v1.1.2/cli.go:262 +0x5f8
github.com/hashicorp/vault/command.RunCustom({0xc0001a6010, 0x4, 0x4}, 0xc0000001a0)
        /Users/ccapurso/git/vault/command/main.go:180 +0x9f7
github.com/hashicorp/vault/command.Run(...)
        /Users/ccapurso/git/vault/command/main.go:88
main.main()
        /Users/ccapurso/git/vault/main.go:10 +0x52
```

After change:

```
❯ vault kv put secret/foo 'bar=\'
= Secret Path =
secret/data/foo

======= Metadata =======
Key                Value
---                -----
created_time       2022-03-15T14:38:07.024316Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            1
```

```
❯ vault kv get secret/foo
= Secret Path =
secret/data/foo

======= Metadata =======
Key                Value
---                -----
created_time       2022-03-15T14:38:07.024316Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            1

=== Data ===
Key    Value
---    -----
bar    \
```