### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,8 @@ _testmain.go
 /pkg/
 
 # Generated Web UI goes here
-/http/web_ui/**
+/http/web_ui/*.*
+/http/web_ui/**/*.*
 
 # Vault-specific
 example.hcl


### PR DESCRIPTION
The previous `.gitignore` configuration was causing `http/web_ui/.gitkeep` to be deleted every time we created a new branch within the VSCode terminal. This update preserves the following behavior:

* Do not commit any of the files within `http/web_ui` 
* Preserve web_ui folder's complience with go_embed rules (#14246)

While removing the developer headache of making sure not to commit the deleted .gitkeep file in every branch.