### PR TITLE
identity/oidc: fix duplicate keys in well-known

### DIFF
--- a/changelog/14543.txt
+++ b/changelog/14543.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-identity/oidc: Fix duplicate keys in well-known
+identity/token: Fixes a bug where duplicate public keys could appear in the .well-known JWKS
 ```

--- a/changelog/14543.txt
+++ b/changelog/14543.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+identity/oidc: Fix duplicate keys in well-known
+```

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -621,9 +621,13 @@ func (i *IdentityStore) keyIDsByName(ctx context.Context, s logical.Storage, nam
 	if err := entry.DecodeJSON(&key); err != nil {
 		return keyIDs, err
 	}
+
 	for _, k := range key.KeyRing {
-		keyIDs = append(keyIDs, k.KeyID)
+		if !strutil.StrListContains(keyIDs, k.KeyID) {
+			keyIDs = append(keyIDs, k.KeyID)
+		}
 	}
+
 	return keyIDs, nil
 }
 
@@ -1685,11 +1689,20 @@ func (i *IdentityStore) generatePublicJWKS(ctx context.Context, s logical.Storag
 		}
 
 		for _, keyID := range keyIDs {
-			key, err := loadOIDCPublicKey(ctx, s, keyID)
-			if err != nil {
-				return nil, err
+			found := false
+			for _, key := range jwks.Keys {
+				if key.KeyID == keyID {
+					found = true
+				}
 			}
-			jwks.Keys = append(jwks.Keys, *key)
+
+			if !found {
+				key, err := loadOIDCPublicKey(ctx, s, keyID)
+				if err != nil {
+					return nil, err
+				}
+				jwks.Keys = append(jwks.Keys, *key)
+			}
 		}
 	}
 

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -623,9 +623,7 @@ func (i *IdentityStore) keyIDsByName(ctx context.Context, s logical.Storage, nam
 	}
 
 	for _, k := range key.KeyRing {
-		if !strutil.StrListContains(keyIDs, k.KeyID) {
-			keyIDs = append(keyIDs, k.KeyID)
-		}
+		keyIDs = append(keyIDs, k.KeyID)
 	}
 
 	return keyIDs, nil

--- a/vault/identity_store_oidc.go
+++ b/vault/identity_store_oidc.go
@@ -1662,10 +1662,6 @@ func (i *IdentityStore) generatePublicJWKS(ctx context.Context, s logical.Storag
 		return nil, err
 	}
 
-	jwks := &jose.JSONWebKeySet{
-		Keys: make([]jose.JSONWebKey, 0),
-	}
-
 	// only return keys that are associated with a role
 	roleNames, err := s.List(ctx, roleConfigPath)
 	if err != nil {
@@ -1691,6 +1687,10 @@ func (i *IdentityStore) generatePublicJWKS(ctx context.Context, s logical.Storag
 		for _, keyID := range roleKeyIDs {
 			keyIDs[keyID] = struct{}{}
 		}
+	}
+
+	jwks := &jose.JSONWebKeySet{
+		Keys: make([]jose.JSONWebKey, 0, len(keyIDs)),
 	}
 
 	// load the JSON web key for each key ID

--- a/vault/identity_store_oidc_test.go
+++ b/vault/identity_store_oidc_test.go
@@ -759,6 +759,54 @@ func TestOIDC_PublicKeys(t *testing.T) {
 	assertPublicKeyCount(t, ctx, storage, c, 2)
 }
 
+// TestOIDC_PublicKeys tests that public keys are updated by
+// key creation, rotation, and deletion
+func TestOIDC_SharedPublicKeysByRoles(t *testing.T) {
+	c, _, _ := TestCoreUnsealed(t)
+	ctx := namespace.RootContext(nil)
+	storage := &logical.InmemStorage{}
+
+	// Create a test key "test-key"
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/key/test-key",
+		Operation: logical.CreateOperation,
+		Storage:   storage,
+	})
+
+	// Create a test role "test-role"
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/role/test-role",
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"key": "test-key",
+		},
+		Storage: storage,
+	})
+
+	// Create a test role "test-role2"
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/role/test-role2",
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"key": "test-key",
+		},
+		Storage: storage,
+	})
+
+	// Create a test role "test-role3"
+	c.identityStore.HandleRequest(ctx, &logical.Request{
+		Path:      "oidc/role/test-role3",
+		Operation: logical.CreateOperation,
+		Data: map[string]interface{}{
+			"key": "test-key",
+		},
+		Storage: storage,
+	})
+
+	// .well-known/keys should contain 2 public keys
+	assertPublicKeyCount(t, ctx, storage, c, 2)
+}
+
 // TestOIDC_SignIDToken tests acquiring a signed token and verifying the public portion
 // of the signing key
 func TestOIDC_SignIDToken(t *testing.T) {


### PR DESCRIPTION
A bug was found where well-known keys would return duplicate entries when roles shared a key. This adds a check to ensure we haven't appended the keys already.