### PR TITLE
UI/Wrong sentinel error message for auth methods

### DIFF
--- a/changelog/14551.txt
+++ b/changelog/14551.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix issue where UI incorrectly handled API errors when mounting backends
+```

--- a/ui/app/adapters/secret-engine.js
+++ b/ui/app/adapters/secret-engine.js
@@ -61,15 +61,8 @@ export default ApplicationAdapter.extend({
         data.id = path;
       }
       // first create the engine
-      try {
-        await this.ajax(this.url(path), 'POST', { data });
-      } catch (e) {
-        // determine if permissions, otherwise return API error message
-        if (e.httpStatus === 403) {
-          throw new Error('permissionIssue');
-        }
-        throw e;
-      }
+      await this.ajax(this.url(path), 'POST', { data });
+
       // second post to config
       try {
         await this.ajax(this.urlForConfig(path), 'POST', { data: configData });

--- a/ui/app/adapters/secret-engine.js
+++ b/ui/app/adapters/secret-engine.js
@@ -64,11 +64,11 @@ export default ApplicationAdapter.extend({
       try {
         await this.ajax(this.url(path), 'POST', { data });
       } catch (e) {
-        // if error determine if path duplicate or permissions
-        if (e.httpStatus === 400) {
-          throw new Error('samePath');
+        // determine if permissions, otherwise return API error message
+        if (e.httpStatus === 403) {
+          throw new Error('permissionIssue');
         }
-        throw new Error('mountIssue');
+        throw e;
       }
       // second post to config
       try {

--- a/ui/app/components/config-pki-ca.js
+++ b/ui/app/components/config-pki-ca.js
@@ -7,6 +7,7 @@ export default Component.extend({
   classNames: 'config-pki-ca',
   store: service('store'),
   flashMessages: service(),
+  errors: null,
 
   /*
    * @param boolean
@@ -150,8 +151,8 @@ export default Component.extend({
             );
           }
         })
-        .catch(() => {
-          // handle promise rejection - error will be shown by message-error component
+        .catch((e) => {
+          this.set('errors', e.errors);
         })
         .finally(() => {
           this.set('loading', false);

--- a/ui/app/components/config-pki.js
+++ b/ui/app/components/config-pki.js
@@ -5,7 +5,7 @@ import { get } from '@ember/object';
 export default Component.extend({
   classNames: 'config-pki',
   flashMessages: service(),
-
+  errors: null,
   /*
    *
    * @param String
@@ -55,8 +55,8 @@ export default Component.extend({
           }
           this.send('refresh');
         })
-        .catch(() => {
-          // handle promise rejection - error will be shown by message-error component
+        .catch((e) => {
+          this.set('errors', e.errors);
         })
         .finally(() => {
           this.set('loading', false);

--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -131,7 +131,7 @@ export default Component.extend({
       try {
         yield mountModel.save();
       } catch (err) {
-        if (err.message === 'mountIssue') {
+        if (err.message === 'permissionIssue') {
           this.mountIssue = true;
           this.set('isFormInvalid', this.mountIssue);
           this.flashMessages.danger(

--- a/ui/app/mixins/policy-edit-controller.js
+++ b/ui/app/mixins/policy-edit-controller.js
@@ -36,9 +36,8 @@ export default Mixin.create({
           }
           return this.transitionToRoute('vault.cluster.policy.show', m.get('policyType'), m.get('name'));
         })
-        .catch(() => {
-          // do nothing here...
-          // message-error component will show errors
+        .catch((e) => {
+          model.set('errors', e.errors);
         });
     },
 

--- a/ui/app/models/policy.js
+++ b/ui/app/models/policy.js
@@ -4,12 +4,12 @@ import { computed } from '@ember/object';
 import lazyCapabilities, { apiPath } from 'vault/macros/lazy-capabilities';
 
 export default Model.extend({
+  errors: attr('array'),
   name: attr('string'),
   policy: attr('string'),
   policyType: computed('constructor.modelName', function () {
     return this.constructor.modelName.split('/')[1];
   }),
-
   updatePath: lazyCapabilities(apiPath`sys/policies/${'policyType'}/${'id'}`, 'id', 'policyType'),
   canDelete: alias('updatePath.canDelete'),
   canEdit: alias('updatePath.canUpdate'),

--- a/ui/app/templates/components/config-pki-ca.hbs
+++ b/ui/app/templates/components/config-pki-ca.hbs
@@ -150,7 +150,7 @@
   {{else}}
     <h2 data-test-title class="title is-3">Sign intermediate</h2>
     <NamespaceReminder @mode="save" @noun="PKI change" />
-    <MessageError @model={{this.model}} />
+    <MessageError @model={{this.model}} @errors={{this.errors}} />
     <form {{action "saveCA" on="submit"}} data-test-sign-intermediate-form="true">
       <FormFieldGroupsLoop @model={{this.model}} @mode={{this.mode}} />
       <div class="field is-grouped box is-fullwidth is-bottomless">

--- a/ui/app/templates/components/config-pki.hbs
+++ b/ui/app/templates/components/config-pki.hbs
@@ -14,7 +14,7 @@
   </p>
 {{/if}}
 
-<MessageError @model={{this.config}} />
+<MessageError @model={{this.config}} @errors={{this.errors}} />
 <form {{action "save" this.section on="submit"}} class="box is-shadowless is-marginless is-fullwidth has-slim-padding">
   {{#each (get this.config (concat this.section "Attrs")) as |attr|}}
     <FormField @attr={{attr}} @model={{this.config}} @data-test-field={{attr.name}} />

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -21,7 +21,7 @@
 <form {{action (perform this.mountBackend) on="submit"}}>
   <div class="box is-sideless is-fullwidth is-marginless">
     <NamespaceReminder @mode="enable" @noun={{if (eq this.mountType "auth") "Auth Method" "Secret Engine"}} />
-    <MessageError @model={{this.model}} @errorMessage={{this.errorMessage}} />
+    <MessageError @model={{this.model}} @errorMessage={{this.errorMessage}} @errors={{this.errors}} />
     {{#if this.showEnable}}
       <FormFieldGroups
         @model={{this.mountModel}}

--- a/ui/app/templates/vault/cluster/policies/create.hbs
+++ b/ui/app/templates/vault/cluster/policies/create.hbs
@@ -19,7 +19,7 @@
 
 <form {{action "savePolicy" this.model on="submit"}}>
   <div class="box is-bottomless is-fullwidth is-marginless">
-    <MessageError @model={{@model}} @errors={{this.model.errors}} />
+    <MessageError @model={{this.model}} @errors={{this.model.errors}} />
     <NamespaceReminder @mode="create" @noun="policy" />
     <div class="field">
       <label for="policy-name" class="is-label">Name</label>

--- a/ui/app/templates/vault/cluster/policies/create.hbs
+++ b/ui/app/templates/vault/cluster/policies/create.hbs
@@ -19,7 +19,7 @@
 
 <form {{action "savePolicy" this.model on="submit"}}>
   <div class="box is-bottomless is-fullwidth is-marginless">
-    <MessageError @model={{this.model}} />
+    <MessageError @model={{@model}} @errors={{this.model.errors}} />
     <NamespaceReminder @mode="create" @noun="policy" />
     <div class="field">
       <label for="policy-name" class="is-label">Name</label>

--- a/ui/lib/core/addon/components/message-error.js
+++ b/ui/lib/core/addon/components/message-error.js
@@ -18,20 +18,29 @@ import { setComponentTemplate } from '@ember/component';
  */
 
 class MessageError extends Component {
+  get errorMessage() {
+    return this.args.errorMessage;
+  }
+
+  get errors() {
+    return this.args.errors;
+  }
+
+  get model() {
+    return this.args.model;
+  }
+
   get displayErrors() {
-    const errorMessage = this.args.errorMessage;
-    const errors = this.args.errors;
-    const modelIsError = this.args.model?.isError;
-    if (errorMessage) {
-      return [errorMessage];
+    if (this.errorMessage) {
+      return [this.errorMessage];
     }
 
-    if (errors && errors.length > 0) {
-      return errors;
+    if (this.errors && this.errors.length > 0) {
+      return this.errors;
     }
 
-    if (modelIsError) {
-      let adapterError = this.args.model.adapterError;
+    if (this.model?.isError) {
+      let adapterError = this.model?.adapterError;
       if (!adapterError) {
         return null;
       }
@@ -47,3 +56,59 @@ class MessageError extends Component {
   }
 }
 export default setComponentTemplate(layout, MessageError);
+
+// import { computed } from '@ember/object';
+// import Component from '@ember/component';
+// import layout from '../templates/components/message-error';
+
+// /**
+//  * @module MessageError
+// 	@@ -11,48 +11,39 @@ import layout from '../templates/components/message-error';
+//  * <MessageError @model={{model}} />
+//  * ```
+//  *
+//  * @param model=null{DS.Model} - An Ember data model that will be used to bind error statest to the internal
+//  * `errors` property.
+//  * @param errors=null{Array} - An array of error strings to show.
+//  * @param errorMessage=null{String} - An Error string to display.
+//  */
+// export default Component.extend({
+//   layout,
+//   model: null,
+//   errors: null,
+//   errorMessage: null,
+
+//   displayErrors: computed(
+//     'errorMessage',
+//     'model.{isError,adapterError.message,adapterError.errors.@each}',
+//     'errors',
+//     'errors.[]',
+//     function () {
+//       const errorMessage = this.errorMessage;
+//       const errors = this.errors;
+//       const modelIsError = this.model?.isError;
+//       if (errorMessage) {
+//         return [errorMessage];
+//       }
+
+//       if (errors && errors.length > 0) {
+//         return errors;
+//       }
+
+//       if (modelIsError) {
+//         if (!this.model.adapterError) {
+//           return;
+//         }
+//         if (this.model.adapterError.errors.length > 0) {
+//           return this.model.adapterError.errors.map((e) => {
+//             if (typeof e === 'object') return e.title || e.message || JSON.stringify(e);
+//             return e;
+//           });
+//         }
+//         return [this.model.adapterError.message];
+//       }
+
+//       return 'no error';
+//     }
+//   ),
+// });

--- a/ui/lib/core/addon/components/message-error.js
+++ b/ui/lib/core/addon/components/message-error.js
@@ -22,9 +22,16 @@ class MessageError extends Component {
     const errorMessage = this.args.errorMessage;
     const errors = this.args.errors;
     const modelIsError = this.args.model?.isError;
+    if (errorMessage) {
+      return [errorMessage];
+    }
+
+    if (errors && errors.length > 0) {
+      return errors;
+    }
 
     if (modelIsError) {
-      let adapterError = this.args.model?.adapterError;
+      let adapterError = this.args.model.adapterError;
       if (!adapterError) {
         return null;
       }
@@ -34,16 +41,9 @@ class MessageError extends Component {
           return e;
         });
       }
-      return adapterError.message;
-    }
-    if (errorMessage) {
-      return errorMessage;
-    }
-    if (errors && errors.length > 0) {
-      return errors;
+      return [adapterError.message];
     }
     return null;
   }
 }
-
 export default setComponentTemplate(layout, MessageError);

--- a/ui/lib/core/addon/components/message-error.js
+++ b/ui/lib/core/addon/components/message-error.js
@@ -18,29 +18,18 @@ import { setComponentTemplate } from '@ember/component';
  */
 
 class MessageError extends Component {
-  get errorMessage() {
-    return this.args.errorMessage;
-  }
-
-  get errors() {
-    return this.args.errors;
-  }
-
-  get model() {
-    return this.args.model;
-  }
-
   get displayErrors() {
-    if (this.errorMessage) {
-      return [this.errorMessage];
+    let { errorMessage, errors, model } = this.args;
+    if (errorMessage) {
+      return [errorMessage];
     }
 
-    if (this.errors && this.errors.length > 0) {
-      return this.errors;
+    if (errors && errors.length > 0) {
+      return errors;
     }
 
-    if (this.model?.isError) {
-      let adapterError = this.model?.adapterError;
+    if (model?.isError) {
+      let adapterError = model?.adapterError;
       if (!adapterError) {
         return null;
       }
@@ -56,59 +45,3 @@ class MessageError extends Component {
   }
 }
 export default setComponentTemplate(layout, MessageError);
-
-// import { computed } from '@ember/object';
-// import Component from '@ember/component';
-// import layout from '../templates/components/message-error';
-
-// /**
-//  * @module MessageError
-// 	@@ -11,48 +11,39 @@ import layout from '../templates/components/message-error';
-//  * <MessageError @model={{model}} />
-//  * ```
-//  *
-//  * @param model=null{DS.Model} - An Ember data model that will be used to bind error statest to the internal
-//  * `errors` property.
-//  * @param errors=null{Array} - An array of error strings to show.
-//  * @param errorMessage=null{String} - An Error string to display.
-//  */
-// export default Component.extend({
-//   layout,
-//   model: null,
-//   errors: null,
-//   errorMessage: null,
-
-//   displayErrors: computed(
-//     'errorMessage',
-//     'model.{isError,adapterError.message,adapterError.errors.@each}',
-//     'errors',
-//     'errors.[]',
-//     function () {
-//       const errorMessage = this.errorMessage;
-//       const errors = this.errors;
-//       const modelIsError = this.model?.isError;
-//       if (errorMessage) {
-//         return [errorMessage];
-//       }
-
-//       if (errors && errors.length > 0) {
-//         return errors;
-//       }
-
-//       if (modelIsError) {
-//         if (!this.model.adapterError) {
-//           return;
-//         }
-//         if (this.model.adapterError.errors.length > 0) {
-//           return this.model.adapterError.errors.map((e) => {
-//             if (typeof e === 'object') return e.title || e.message || JSON.stringify(e);
-//             return e;
-//           });
-//         }
-//         return [this.model.adapterError.message];
-//       }
-
-//       return 'no error';
-//     }
-//   ),
-// });

--- a/ui/lib/core/addon/components/message-error.js
+++ b/ui/lib/core/addon/components/message-error.js
@@ -1,6 +1,6 @@
-import { computed } from '@ember/object';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import layout from '../templates/components/message-error';
+import { setComponentTemplate } from '@ember/component';
 
 /**
  * @module MessageError
@@ -11,49 +11,39 @@ import layout from '../templates/components/message-error';
  * <MessageError @model={{model}} />
  * ```
  *
- * @param model=null{DS.Model} - An Ember data model that will be used to bind error states to the internal
+ * @param {object} [model=null] - An Ember data model that will be used to bind error states to the internal
  * `errors` property.
- * @param errors=null{Array} - An array of error strings to show.
- * @param errorMessage=null{String} - An Error string to display.
+ * @param {array} [errors=null] - An array of error strings to show.
+ * @param {string} [errorMessage=null] - An Error string to display.
  */
-export default Component.extend({
-  layout,
-  model: null,
-  errors: null,
-  errorMessage: null,
 
-  displayErrors: computed(
-    'errorMessage',
-    'errors.[]',
-    'model.adapterError.{errors.[],message}',
-    'model.isError',
-    'parentView.mountModel.{adapterError,isError}',
-    function () {
-      const errorMessage = this.errorMessage;
-      const errors = this.errors;
-      const modelIsError = this.model?.isError || this.parentView?.mountModel.isError;
+class MessageError extends Component {
+  get displayErrors() {
+    const errorMessage = this.args.errorMessage;
+    const errors = this.args.errors;
+    const modelIsError = this.args.model?.isError;
 
-      if (modelIsError) {
-        let adapterError = this.model?.adapterError || this.parentView?.mountModel?.adapterError;
-        if (!adapterError) {
-          return;
-        }
-        if (adapterError.errors.length > 0) {
-          return adapterError.errors.map((e) => {
-            if (typeof e === 'object') return e.title || e.message || JSON.stringify(e);
-            return e;
-          });
-        }
-        return [adapterError.message];
+    if (modelIsError) {
+      let adapterError = this.args.model?.adapterError;
+      if (!adapterError) {
+        return null;
       }
-      if (errorMessage) {
-        return [errorMessage];
+      if (adapterError.errors.length > 0) {
+        return adapterError.errors.map((e) => {
+          if (typeof e === 'object') return e.title || e.message || JSON.stringify(e);
+          return e;
+        });
       }
-
-      if (errors && errors.length > 0) {
-        return errors;
-      }
-      return 'no error';
+      return [adapterError.message];
     }
-  ),
-});
+    if (errorMessage) {
+      return [errorMessage];
+    }
+    if (errors && errors.length > 0) {
+      return errors;
+    }
+    return 'no error';
+  }
+}
+
+export default setComponentTemplate(layout, MessageError);

--- a/ui/lib/core/addon/components/message-error.js
+++ b/ui/lib/core/addon/components/message-error.js
@@ -34,15 +34,15 @@ class MessageError extends Component {
           return e;
         });
       }
-      return [adapterError.message];
+      return adapterError.message;
     }
     if (errorMessage) {
-      return [errorMessage];
+      return errorMessage;
     }
     if (errors && errors.length > 0) {
       return errors;
     }
-    return 'no error';
+    return null;
   }
 }
 

--- a/ui/lib/core/addon/templates/components/message-error.hbs
+++ b/ui/lib/core/addon/templates/components/message-error.hbs
@@ -1,4 +1,4 @@
-{{#if this.displayErrors.length}}
+{{#if this.displayErrors}}
   {{#each this.displayErrors as |error|}}
     <AlertBanner @type="danger" @message={{error}} data-test-error />
   {{/each}}

--- a/ui/lib/core/addon/templates/components/message-error.hbs
+++ b/ui/lib/core/addon/templates/components/message-error.hbs
@@ -1,5 +1,5 @@
 {{#if this.displayErrors}}
   {{#each this.displayErrors as |error|}}
-    <AlertBanner @type="danger" @message={{error}} data-test-error />
+    <AlertBanner @type="danger" @message={{error}} data-test-error ...attributes />
   {{/each}}
 {{/if}}

--- a/ui/tests/acceptance/client-current-test.js
+++ b/ui/tests/acceptance/client-current-test.js
@@ -112,9 +112,8 @@ module('Acceptance | clients current', function (hooks) {
     // FILTER BY NAMESPACE
     await clickTrigger();
     await searchSelect.options.objectAt(0).click();
-    await waitUntil(() => {
-      return find('[data-test-horizontal-bar-chart]');
-    });
+    await settled();
+    await waitUntil(() => find('[data-test-horizontal-bar-chart]'));
     assert.dom('[data-test-stat-text="total-clients"] .stat-value').hasText('15');
     assert.dom('[data-test-stat-text="entity-clients"] .stat-value').hasText('5');
     assert.dom('[data-test-stat-text="non-entity-clients"] .stat-value').hasText('10');
@@ -145,18 +144,14 @@ module('Acceptance | clients current', function (hooks) {
     // FILTER BY AUTH METHOD
     await clickTrigger();
     await searchSelect.options.objectAt(0).click();
-    await waitUntil(() => {
-      return find('#auth-method-search-select');
-    });
+    await waitUntil(() => find('#auth-method-search-select'));
     assert.dom('[data-test-stat-text="total-clients"] .stat-value').hasText('5');
     assert.dom('[data-test-stat-text="entity-clients"] .stat-value').hasText('3');
     assert.dom('[data-test-stat-text="non-entity-clients"] .stat-value').hasText('2');
     assert.dom(SELECTORS.attributionBlock).doesNotExist('Does not show attribution block');
     // Delete auth filter goes back to filtered only on namespace
     await click('#auth-method-search-select [data-test-selected-list-button="delete"]');
-    await waitUntil(() => {
-      return find('[data-test-horizontal-bar-chart]');
-    });
+    await waitUntil(() => find('[data-test-horizontal-bar-chart]'));
     assert.dom('[data-test-stat-text="total-clients"] .stat-value').hasText('15');
     assert.dom('[data-test-stat-text="entity-clients"] .stat-value').hasText('5');
     assert.dom('[data-test-stat-text="non-entity-clients"] .stat-value').hasText('10');

--- a/ui/tests/acceptance/settings/configure-secret-backends/pki/section-urls-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/pki/section-urls-test.js
@@ -22,7 +22,7 @@ module('Acceptance | settings/configure/secrets/pki/urls', function (hooks) {
 
     await page.form.fields.objectAt(0).textarea('foo').change();
     await page.form.submit();
-    await waitUntil(() => find(page.form.hasError));
+    await waitUntil(() => find('[data-test-error]'));
     assert.ok(page.form.hasError, 'shows error on invalid input');
 
     await page.form.fields.objectAt(0).textarea('foo.example.com').change();

--- a/ui/tests/acceptance/settings/configure-secret-backends/pki/section-urls-test.js
+++ b/ui/tests/acceptance/settings/configure-secret-backends/pki/section-urls-test.js
@@ -1,4 +1,4 @@
-import { currentRouteName, settled } from '@ember/test-helpers';
+import { currentRouteName, settled, find, waitUntil } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import page from 'vault/tests/pages/settings/configure-secret-backends/pki/section';
@@ -22,8 +22,7 @@ module('Acceptance | settings/configure/secrets/pki/urls', function (hooks) {
 
     await page.form.fields.objectAt(0).textarea('foo').change();
     await page.form.submit();
-    await settled();
-
+    await waitUntil(() => find(page.form.hasError));
     assert.ok(page.form.hasError, 'shows error on invalid input');
 
     await page.form.fields.objectAt(0).textarea('foo.example.com').change();

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -89,7 +89,7 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     await page.enableEngine();
     await page.selectType('kv');
     await page.next().path(path).submit();
-    assert.dom('.alert-banner-message-body').hasText('This mount path already exist.');
+    assert.dom('.alert-banner-message-body').containsText(`path is already in use at ${path}`);
     assert.equal(currentRouteName(), 'vault.cluster.settings.mount-secret-backend');
 
     await page.secretList();

--- a/ui/tests/integration/components/auth-form-test.js
+++ b/ui/tests/integration/components/auth-form-test.js
@@ -61,7 +61,7 @@ module('Integration | Component | auth form', function (hooks) {
     this.set('cluster', EmberObject.create({ standby: true }));
     this.set('selectedAuth', 'token');
     await render(hbs`{{auth-form cluster=cluster selectedAuth=selectedAuth}}`);
-    assert.equal(component.errorText, '');
+    assert.equal(component.errorMessagePresent, false);
     component.login();
     // because this is an ember-concurrency backed service,
     // we have to manually force settling the run queue

--- a/ui/tests/integration/components/ttl-picker-test.js
+++ b/ui/tests/integration/components/ttl-picker-test.js
@@ -17,11 +17,10 @@ module('Integration | Component | ttl picker', function (hooks) {
 
     let callCount = this.changeSpy.callCount;
     await fillIn('[data-test-ttl-value]', 'foo');
-    assert.equal(this.changeSpy.callCount, callCount, "it did't call onChange again");
+    assert.equal(this.changeSpy.callCount, callCount, "it didn't call onChange again");
     assert.dom('[data-test-ttl-error]').includesText('Error', 'renders the error box');
-
     await fillIn('[data-test-ttl-value]', '33');
-    assert.dom('[data-test-ttl-error]').doesNotIncludeText('Error', 'removes the error box');
+    assert.dom('[data-test-ttl-error]').doesNotExist('removes the error box');
   });
 
   test('it shows 30s for invalid duration initialValue input', async function (assert) {

--- a/ui/tests/pages/components/auth-form.js
+++ b/ui/tests/pages/components/auth-form.js
@@ -1,4 +1,4 @@
-import { collection, clickable, fillable, text, value } from 'ember-cli-page-object';
+import { collection, clickable, fillable, text, value, isPresent } from 'ember-cli-page-object';
 
 export default {
   tabs: collection('[data-test-auth-method]', {
@@ -11,6 +11,7 @@ export default {
   tokenValue: value('[data-test-token]'),
   password: fillable('[data-test-password]'),
   errorText: text('[data-test-auth-error]'),
+  errorMessagePresent: isPresent('[data-test-auth-error]'),
   descriptionText: text('[data-test-description]'),
   login: clickable('[data-test-auth-submit]'),
 };


### PR DESCRIPTION
### This PR cleans up some error handling that was slightly inaccurate and glimmerizes the `MessageError` component.

Previously the UI was intercepting the API error message and displaying an incorrect error message and warning flag. Below I was logged in as a user who did not have permission to enable the `userpass` auth method. The following warning displayed:

<img width="986" alt="Screen Shot 2022-03-16 at 4 24 45 PM" src="https://user-images.githubusercontent.com/68122737/158903753-70fa936f-a78c-4060-b22f-b2123d8188f5.png">

<hr>

**With fix:**
<img width="657" alt="Screen Shot 2022-03-17 at 12 47 26 PM" src="https://user-images.githubusercontent.com/68122737/158903739-c9f62510-d9d1-4da4-b794-dd915e51445a.png">
