### PR TITLE
Update socket entry

### DIFF
--- a/website/content/docs/audit/socket.mdx
+++ b/website/content/docs/audit/socket.mdx
@@ -35,7 +35,9 @@ $ vault audit enable socket address=127.0.0.1:9090 socket_type=tcp
   `127.0.0.1:9090` or `/tmp/audit.sock`.
 
 - `socket_type` `(string: "tcp")` - The socket type to use, any type compatible
-  with <a href="https://golang.org/pkg/net/#Dial">net.Dial</a> is acceptable.
+  with <a href="https://golang.org/pkg/net/#Dial">net.Dial</a> is acceptable. It's 
+  important to note if TCP is used and the destination socket becomes unavailable
+  Vault may become unresponsive per [Blocked Audit Devices](docs/audit/#blocked-audit-devices).
 
 - `log_raw` `(bool: false)` - If enabled, logs the security sensitive
   information without hashing, in the raw format.


### PR DESCRIPTION
Page edited: https://www.vaultproject.io/docs/audit/socket. We should include a note detailing that Vault may become unresponsive due to a TCP based socket output becoming unavailable per https://www.vaultproject.io/docs/audit#blocked-audit-devices