### PR TITLE
Redirect from the old API docs page to the new API docs page

### DIFF
--- a/website/redirects.next.js
+++ b/website/redirects.next.js
@@ -15,6 +15,11 @@ module.exports = [
     permanent: false,
   },
   {
+    source: '/api',
+    destination: '/api-docs',
+    permanent: true,
+  },
+  {
     source: '/api/secret/generic',
     destination: '/api-docs/secret/kv',
     permanent: true,


### PR DESCRIPTION
API documentation used to be served on `/api`. Now it's served on `/api-docs`. This pull request adds a permanent redirect so users can find the new API documentation using the old link.
