### PR TITLE
Fix sample request for Lease Count and Lease List

### DIFF
--- a/website/content/api-docs/system/leases.mdx
+++ b/website/content/api-docs/system/leases.mdx
@@ -275,8 +275,7 @@ This endpoint was added in Vault 1.8.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request GET \
-    http://127.0.0.1:8200/v1/sys/leases/count \
-    -d type=irrevocable
+    http://127.0.0.1:8200/v1/sys/leases/count?type=irrevocable
 ```
 
 ## Leases List
@@ -310,6 +309,5 @@ This endpoint was added in Vault 1.8.
 $ curl \
     --header "X-Vault-Token: ..." \
     --request GET \
-    http://127.0.0.1:8200/v1/sys/leases \
-    -d type=irrevocable
+    http://127.0.0.1:8200/v1/sys/leases?type=irrevocable
 ```


### PR DESCRIPTION
Original Sample requests were incorrect providing body data for a get request when the additional parameters should be passed as URL Parameters