### PR TITLE
Runloop/Computed Dot Access Removal

### DIFF
--- a/ui/app/components/auth-info.js
+++ b/ui/app/components/auth-info.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { run } from '@ember/runloop';
+import { later } from '@ember/runloop';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
@@ -39,7 +39,7 @@ export default class AuthInfoComponent extends Component {
   @action
   renewToken() {
     this.fakeRenew = true;
-    run.later(() => {
+    later(() => {
       this.auth.renew().then(() => {
         this.fakeRenew = this.auth.isRenewing;
       });

--- a/ui/app/components/console/ui-panel.js
+++ b/ui/app/components/console/ui-panel.js
@@ -2,7 +2,7 @@ import { inject as service } from '@ember/service';
 import { alias, or } from '@ember/object/computed';
 import Component from '@ember/component';
 import { getOwner } from '@ember/application';
-import { run } from '@ember/runloop';
+import { schedule } from '@ember/runloop';
 import { task } from 'ember-concurrency';
 import ControlGroupError from 'vault/lib/control-group-error';
 import {
@@ -34,7 +34,7 @@ export default Component.extend({
 
   logAndOutput(command, logContent) {
     this.console.logAndOutput(command, logContent);
-    run.schedule('afterRender', () => this.scrollToBottom());
+    schedule('afterRender', () => this.scrollToBottom());
   },
 
   isRunning: or('executeCommand.isRunning', 'refreshRoute.isRunning'),

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -1,5 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
 import { fragment } from 'ember-data-model-fragments/attributes';
 import fieldToAttrs, { expandAttributeMeta } from 'vault/utils/field-to-attrs';
 import { validator, buildValidations } from 'ember-cp-validations';
@@ -78,7 +79,7 @@ export default Model.extend(Validations, {
     return modelType;
   }),
 
-  isV2KV: computed.equal('modelTypeForKV', 'secret-v2'),
+  isV2KV: equal('modelTypeForKV', 'secret-v2'),
 
   formFields: computed('engineType', 'options.version', function () {
     let type = this.engineType;

--- a/ui/stories/auth-config-form/config.stories.js
+++ b/ui/stories/auth-config-form/config.stories.js
@@ -1,8 +1,8 @@
-
 import hbs from 'htmlbars-inline-precompile';
 import { storiesOf } from '@storybook/ember';
 import { withKnobs, select } from '@storybook/addon-knobs';
 import notes from './config.md';
+import { getOwner } from '@ember/application';
 
 // This will need to be replaced with a fake model, since the form fields associated with
 // each model come from OpenApi and Storybook doesn't have a Vault server to call OpenApi from.
@@ -36,9 +36,7 @@ storiesOf('AuthConfigForm/Config', module)
       context: {
         actions: {
           getModel(modelType) {
-            return Ember.getOwner(this)
-              .lookup('service:store')
-              .createRecord(`auth-config/${modelType}`);
+            return getOwner(this).lookup('service:store').createRecord(`auth-config/${modelType}`);
           },
         },
         model: select('model', MODELS, DEFAULT_VALUE),

--- a/ui/stories/auth-config-form/options.stories.js
+++ b/ui/stories/auth-config-form/options.stories.js
@@ -1,8 +1,8 @@
-
 import hbs from 'htmlbars-inline-precompile';
 import { storiesOf } from '@storybook/ember';
 import { withKnobs, select } from '@storybook/addon-knobs';
 import notes from './options.md';
+import { getOwner } from '@ember/application';
 
 // This will need to be replaced with a fake model, since the form fields associated with
 // each model come from OpenApi and Storybook doesn't have a Vault server to call OpenApi from.
@@ -36,9 +36,7 @@ storiesOf('AuthConfigForm/Options', module)
       context: {
         actions: {
           getModel(modelType) {
-            return Ember.getOwner(this)
-              .lookup('service:store')
-              .createRecord(`auth-config/${modelType}`);
+            return getOwner(this).lookup('service:store').createRecord(`auth-config/${modelType}`);
           },
         },
         model: select('model', MODELS, DEFAULT_VALUE),

--- a/ui/tests/acceptance/logout-auth-method-test.js
+++ b/ui/tests/acceptance/logout-auth-method-test.js
@@ -4,7 +4,7 @@ import { click, visit, fillIn, settled } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { fakeWindow, buildMessage } from '../helpers/oidc-window-stub';
 import sinon from 'sinon';
-import { later, run } from '@ember/runloop';
+import { later, cancelTimers } from '@ember/runloop';
 
 module('Acceptance | logout auth method', function (hooks) {
   setupApplicationTest(hooks);
@@ -29,7 +29,7 @@ module('Acceptance | logout auth method', function (hooks) {
     sessionStorage.removeItem('selectedAuth');
     await visit('/vault/auth');
     await fillIn('[data-test-select="auth-method"]', 'oidc');
-    later(() => run.cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
     await click('[data-test-auth-submit]');
     window.postMessage(buildMessage().data, window.origin);
     await settled();

--- a/ui/tests/integration/components/auth-form-test.js
+++ b/ui/tests/integration/components/auth-form-test.js
@@ -1,4 +1,4 @@
-import { later, run } from '@ember/runloop';
+import { later, cancelTimers } from '@ember/runloop';
 import EmberObject from '@ember/object';
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
@@ -65,7 +65,7 @@ module('Integration | Component | auth form', function (hooks) {
     component.login();
     // because this is an ember-concurrency backed service,
     // we have to manually force settling the run queue
-    later(() => run.cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
     return settled().then(() => {
       assert.equal(component.errorText, CSP_ERR_TEXT);
     });
@@ -239,7 +239,7 @@ module('Integration | Component | auth form', function (hooks) {
     this.set('wrappedToken', wrappedToken);
     this.set('cluster', EmberObject.create({}));
     await render(hbs`<AuthForm @cluster={{cluster}} @wrappedToken={{wrappedToken}} />`);
-    later(() => run.cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
     await settled();
     assert.equal(server.handledRequests[0].url, '/v1/sys/wrapping/unwrap', 'makes call to unwrap the token');
     assert.equal(
@@ -267,7 +267,7 @@ module('Integration | Component | auth form', function (hooks) {
 
     this.set('wrappedToken', '54321');
     await render(hbs`{{auth-form cluster=cluster wrappedToken=wrappedToken}}`);
-    later(() => run.cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
 
     await settled();
     assert.equal(

--- a/ui/tests/integration/components/auth-jwt-test.js
+++ b/ui/tests/integration/components/auth-jwt-test.js
@@ -1,4 +1,4 @@
-import { run } from '@ember/runloop';
+import { cancelTimers } from '@ember/runloop';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
@@ -160,7 +160,7 @@ module('Integration | Component | auth jwt', function (hooks) {
     await waitUntil(() => {
       return this.openSpy.calledOnce;
     });
-    run.cancelTimers();
+    cancelTimers();
     let call = this.openSpy.getCall(0);
     assert.deepEqual(
       call.args,
@@ -194,7 +194,7 @@ module('Integration | Component | auth jwt', function (hooks) {
       'message',
       buildMessage({ data: { source: 'oidc-callback', state: 'state', foo: 'bar' } })
     );
-    run.cancelTimers();
+    cancelTimers();
     assert.equal(this.error, ERROR_MISSING_PARAMS, 'calls onError with params missing error');
   });
 
@@ -222,7 +222,7 @@ module('Integration | Component | auth jwt', function (hooks) {
       return this.openSpy.calledOnce;
     });
     this.window.trigger('message', buildMessage({ origin: 'http://hackerz.com' }));
-    run.cancelTimers();
+    cancelTimers();
     await settled();
     assert.notOk(this.handler.called, 'should not call the submit handler');
   });
@@ -236,7 +236,7 @@ module('Integration | Component | auth jwt', function (hooks) {
       return this.openSpy.calledOnce;
     });
     this.window.trigger('message', buildMessage({ isTrusted: false }));
-    run.cancelTimers();
+    cancelTimers();
     await settled();
     assert.notOk(this.handler.called, 'should not call the submit handler');
   });

--- a/ui/tests/integration/components/control-group-success-test.js
+++ b/ui/tests/integration/components/control-group-success-test.js
@@ -1,4 +1,4 @@
-import { later, run } from '@ember/runloop';
+import { later, run, cancelTimers } from '@ember/runloop';
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
@@ -61,7 +61,7 @@ module('Integration | Component | control group success', function (hooks) {
     await render(hbs`{{control-group-success model=model controlGroupResponse=response }}`);
     assert.ok(component.showsNavigateMessage, 'shows unwrap message');
     await component.navigate();
-    later(() => run.cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
     return settled().then(() => {
       assert.ok(this.controlGroup.markTokenForUnwrap.calledOnce, 'marks token for unwrap');
       assert.ok(this.router.transitionTo.calledOnce, 'calls router transition');
@@ -74,7 +74,7 @@ module('Integration | Component | control group success', function (hooks) {
     assert.ok(component.showsUnwrapForm, 'shows unwrap form');
     await component.token('token');
     component.unwrap();
-    later(() => run.cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
     return settled().then(() => {
       assert.ok(component.showsJsonViewer, 'shows unwrapped data');
     });

--- a/ui/tests/integration/components/edit-form-kmip-role-test.js
+++ b/ui/tests/integration/components/edit-form-kmip-role-test.js
@@ -1,4 +1,4 @@
-import { later, run } from '@ember/runloop';
+import { later, run, cancelTimers } from '@ember/runloop';
 import { resolve } from 'rsvp';
 import EmberObject, { computed } from '@ember/object';
 import Service from '@ember/service';
@@ -163,7 +163,7 @@ module('Integration | Component | edit form kmip role', function (hooks) {
 
       click('[data-test-edit-form-submit]');
 
-      later(() => run.cancelTimers(), 50);
+      later(() => cancelTimers(), 50);
       return settled().then(() => {
         for (let afterStateKey of Object.keys(stateAfterSave)) {
           assert.equal(

--- a/ui/tests/integration/components/edit-form-test.js
+++ b/ui/tests/integration/components/edit-form-test.js
@@ -1,4 +1,4 @@
-import { later, run } from '@ember/runloop';
+import { later, run, cancelTimers } from '@ember/runloop';
 import { resolve } from 'rsvp';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
@@ -63,7 +63,7 @@ module('Integration | Component | edit form', function (hooks) {
     await render(hbs`{{edit-form model=model onSave=onSave}}`);
 
     component.submit();
-    later(() => run.cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
     return settled().then(() => {
       assert.ok(saveSpy.calledOnce, 'calls passed onSave');
       assert.equal(saveSpy.getCall(0).args[0].saveType, 'save');

--- a/ui/tests/integration/components/mfa-form-test.js
+++ b/ui/tests/integration/components/mfa-form-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { fillIn, click, waitUntil } from '@ember/test-helpers';
-import { run, later } from '@ember/runloop';
+import { cancelTimers, later } from '@ember/runloop';
 import { VALIDATION_ERROR } from 'vault/components/mfa-form';
 
 module('Integration | Component | mfa-form', function (hooks) {
@@ -176,7 +176,7 @@ module('Integration | Component | mfa-form', function (hooks) {
     `);
 
     await fillIn('[data-test-mfa-passcode]', 'test-code');
-    later(() => run.cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
     await click('[data-test-mfa-validate]');
     assert
       .dom('[data-test-mfa-countdown]')
@@ -200,7 +200,7 @@ module('Integration | Component | mfa-form', function (hooks) {
     `);
 
     await fillIn('[data-test-mfa-passcode]', 'test-code');
-    later(() => run.cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
     await click('[data-test-mfa-validate]');
     assert
       .dom('[data-test-error]')

--- a/ui/tests/integration/components/mount-backend-form-test.js
+++ b/ui/tests/integration/components/mount-backend-form-test.js
@@ -1,4 +1,4 @@
-import { later, run } from '@ember/runloop';
+import { later, cancelTimers } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
@@ -63,7 +63,7 @@ module('Integration | Component | mount backend form', function (hooks) {
 
     await component.mount('approle', 'foo');
 
-    later(() => run.cancelTimers(), 50);
+    later(() => cancelTimers(), 50);
     await settled();
     let enableRequest = this.server.handledRequests.findBy('url', '/v1/sys/auth/foo');
     assert.ok(enableRequest, 'it calls enable on an auth method');

--- a/ui/tests/unit/components/auth-jwt-test.js
+++ b/ui/tests/unit/components/auth-jwt-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import EmberObject from '@ember/object';
 import Evented from '@ember/object/evented';
 import sinon from 'sinon';
-import { run } from '@ember/runloop';
+import { cancelTimers } from '@ember/runloop';
 
 const mockWindow = EmberObject.extend(Evented, {
   origin: 'http://localhost:4200',
@@ -23,7 +23,7 @@ module('Unit | Component | auth-jwt', function (hooks) {
     this.component.prepareForOIDC.perform(mockWindow.create());
     this.component.window.trigger('message', { origin: 'http://anotherdomain.com', isTrusted: true });
     assert.ok(this.errorSpy.calledOnce, 'Error handled from cross origin window message event');
-    run.cancelTimers();
+    cancelTimers();
   });
 
   test('it should handle error for untrusted messages while waiting for oidc callback', async function (assert) {
@@ -31,7 +31,7 @@ module('Unit | Component | auth-jwt', function (hooks) {
     this.component.prepareForOIDC.perform(mockWindow.create());
     this.component.window.trigger('message', { origin: 'http://localhost:4200', isTrusted: false });
     assert.ok(this.errorSpy.calledOnce, 'Error handled from untrusted window message event');
-    run.cancelTimers();
+    cancelTimers();
   });
   // test case for https://github.com/hashicorp/vault/issues/12436
   test('it should ignore messages sent from outside the app while waiting for oidc callback', async function (assert) {
@@ -60,6 +60,6 @@ module('Unit | Component | auth-jwt', function (hooks) {
       1,
       'exchangeOIDC method fires when oidc callback message is received'
     );
-    run.cancelTimers();
+    cancelTimers();
   });
 });


### PR DESCRIPTION
Accessing methods on `run` and `computed` functions is deprecated in Ember 4.0. This removes instances of those usages as well as accessing the `Ember` global which is also deprecated in 4.0.

https://deprecations.emberjs.com/v3.x/#toc_deprecated-run-loop-and-computed-dot-access
https://deprecations.emberjs.com/v3.x/#toc_ember-global