### PR TITLE
Ember With to Let

### DIFF
--- a/ui/app/templates/components/auth-form.hbs
+++ b/ui/app/templates/components/auth-form.hbs
@@ -3,7 +3,7 @@
     <nav class="tabs is-marginless">
       <ul>
         {{#each this.methodsToShow as |method|}}
-          {{#with (or method.path method.type) as |methodKey|}}
+          {{#let (or method.path method.type) as |methodKey|}}
             <li
               class={{if
                 (and this.selectedAuthIsPath (eq (or this.selectedAuthBackend.path this.selectedAuthBackend.type) methodKey))
@@ -21,7 +21,7 @@
                 {{or method.id (capitalize method.type)}}
               </LinkTo>
             </li>
-          {{/with}}
+          {{/let}}
         {{/each}}
         {{#if this.hasMethodsWithPath}}
           <li class={{unless this.selectedAuthIsPath "is-active" ""}} data-test-auth-method>

--- a/ui/app/templates/components/generated-item-list.hbs
+++ b/ui/app/templates/components/generated-item-list.hbs
@@ -17,7 +17,7 @@
     </h1>
   </p.levelLeft>
 </PageHeader>
-{{#with (tabs-for-auth-section this.methodModel "authConfig" this.paths) as |tabs|}}
+{{#let (tabs-for-auth-section this.methodModel "authConfig" this.paths) as |tabs|}}
   {{#if tabs.length}}
     <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
       <nav class="tabs">
@@ -33,7 +33,7 @@
       </nav>
     </div>
   {{/if}}
-{{/with}}
+{{/let}}
 <Toolbar>
   <ToolbarActions>
     <ToolbarLink

--- a/ui/app/templates/components/identity/popup-alias.hbs
+++ b/ui/app/templates/components/identity/popup-alias.hbs
@@ -1,6 +1,6 @@
 <PopupMenu @name="alias-menu">
   <Confirm as |c|>
-    {{#with this.params.firstObject as |item|}}
+    {{#let this.params.firstObject as |item|}}
       <nav class="menu">
         <ul class="menu-list">
           <li class="action">
@@ -36,6 +36,6 @@
           {{/if}}
         </ul>
       </nav>
-    {{/with}}
+    {{/let}}
   </Confirm>
 </PopupMenu>

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -2,14 +2,14 @@
   <p.levelLeft>
     <h1 class="title is-3 title-with-icon" data-test-mount-form-header="true">
       {{#if this.showEnable}}
-        {{#with (find-by "type" this.mountModel.type this.mountTypes) as |typeInfo|}}
+        {{#let (find-by "type" this.mountModel.type this.mountTypes) as |typeInfo|}}
           <Icon @name={{or typeInfo.glyph typeInfo.type}} @size="24" class="has-text-grey-light" />
           {{#if (eq this.mountType "auth")}}
             {{concat "Enable " typeInfo.displayName " Authentication Method"}}
           {{else}}
             {{concat "Enable " typeInfo.displayName " Secrets Engine"}}
           {{/if}}
-        {{/with}}
+        {{/let}}
       {{else if (eq this.mountType "auth")}}
         Enable an Authentication Method
       {{else}}

--- a/ui/app/templates/components/secret-list-header.hbs
+++ b/ui/app/templates/components/secret-list-header.hbs
@@ -1,4 +1,4 @@
-{{#with (options-for-backend @model.engineType) as |options|}}
+{{#let (options-for-backend @model.engineType) as |options|}}
   <PageHeader as |p|>
     <p.top>
       <KeyValueHeader @baseKey={{@baseKey}} @path="vault.cluster.secrets.backend.list" @root={{@backendCrumb}}>
@@ -79,4 +79,4 @@
       </nav>
     </div>
   {{/if}}
-{{/with}}
+{{/let}}

--- a/ui/app/templates/components/section-tabs.hbs
+++ b/ui/app/templates/components/section-tabs.hbs
@@ -1,4 +1,4 @@
-{{#with (tabs-for-auth-section this.model this.tabType this.paths) as |tabs|}}
+{{#let (tabs-for-auth-section this.model this.tabType this.paths) as |tabs|}}
   {{#if tabs.length}}
     <div class="tabs-container box is-sideless is-fullwidth is-paddingless is-marginless">
       <nav class="tabs">
@@ -14,4 +14,4 @@
       </nav>
     </div>
   {{/if}}
-{{/with}}
+{{/let}}

--- a/ui/app/templates/components/wizard/init-unseal.hbs
+++ b/ui/app/templates/components/wizard/init-unseal.hbs
@@ -10,13 +10,13 @@
       that you copied or downloaded to unseal the vault so that we can get started using it. You'll need
       {{pluralize this.componentState.threshold "key"}}
       total, and
-      {{#with (pluralize this.componentState.progress "key" without-count=true) as |word|}}
+      {{#let (pluralize this.componentState.progress "key" without-count=true) as |word|}}
         {{if
           (eq word "key")
           (concat this.componentState.progress " " word " has ")
           (concat this.componentState.progress " " word " have ")
         }}
-      {{/with}}
+      {{/let}}
       already been provided. Please provide
       {{pluralize (dec this.componentState.progress this.componentState.threshold) "more key"}}
       to unseal.

--- a/ui/app/templates/vault/cluster/access/namespaces/index.hbs
+++ b/ui/app/templates/vault/cluster/access/namespaces/index.hbs
@@ -32,7 +32,7 @@
           {{list.item.id}}
         </Item.content>
         <Item.menu as |m|>
-          {{#with (concat this.currentNamespace (if this.currentNamespace "/") list.item.id) as |targetNamespace|}}
+          {{#let (concat this.currentNamespace (if this.currentNamespace "/") list.item.id) as |targetNamespace|}}
             {{#if (contains targetNamespace this.accessibleNamespaces)}}
               <li class="action">
                 <NamespaceLink @targetNamespace={{targetNamespace}} @class="is-block">
@@ -40,7 +40,7 @@
                 </NamespaceLink>
               </li>
             {{/if}}
-          {{/with}}
+          {{/let}}
           <li class="action">
             <m.Message
               @id={{list.item.id}}

--- a/ui/app/templates/vault/cluster/secrets/backend/list.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backend/list.hbs
@@ -34,7 +34,7 @@
     </div>
   </div>
 {{else}}
-  {{#with (options-for-backend this.backendType this.tab) as |options|}}
+  {{#let (options-for-backend this.backendType this.tab) as |options|}}
     {{#if (or this.model.meta.total (not this.isConfigurableTab))}}
       <Toolbar>
         {{#if this.model.meta.total}}
@@ -170,5 +170,5 @@
         {{/if}}
       {{/if}}
     {{/if}}
-  {{/with}}
+  {{/let}}
 {{/if}}


### PR DESCRIPTION
As of Ember 4.0 the `with` helper will be deprecated. This converts all usages to the `let` helper.

https://deprecations.emberjs.com/v3.x/#toc_ember-glimmer-with-syntax 