### PR TITLE
Use FieldData.GetOkError() to access required Transit parameters.

### DIFF
--- a/builtin/logical/transit/path_encrypt.go
+++ b/builtin/logical/transit/path_encrypt.go
@@ -261,18 +261,17 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 			return logical.ErrorResponse("missing batch input to process"), logical.ErrInvalidRequest
 		}
 	} else {
-		valueRaw, ok := d.Raw["plaintext"]
+		valueRaw, ok, err := d.GetOkErr("plaintext")
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
 			return logical.ErrorResponse("missing plaintext to encrypt"), logical.ErrInvalidRequest
-		}
-		plaintext, ok := valueRaw.(string)
-		if !ok {
-			return logical.ErrorResponse("expected plaintext of type 'string', got unconvertible type '%T'", valueRaw), logical.ErrInvalidRequest
 		}
 
 		batchInputItems = make([]BatchRequestItem, 1)
 		batchInputItems[0] = BatchRequestItem{
-			Plaintext:  plaintext,
+			Plaintext:  valueRaw.(string),
 			Context:    d.Get("context").(string),
 			Nonce:      d.Get("nonce").(string),
 			KeyVersion: d.Get("key_version").(int),

--- a/builtin/logical/transit/path_encrypt_test.go
+++ b/builtin/logical/transit/path_encrypt_test.go
@@ -30,15 +30,11 @@ func TestTransit_MissingPlaintext(t *testing.T) {
 		t.Fatalf("err:%v resp:%#v", err, resp)
 	}
 
-	encData := map[string]interface{}{
-		"plaintext": nil,
-	}
-
 	encReq := &logical.Request{
 		Operation: logical.UpdateOperation,
 		Path:      "encrypt/existing_key",
 		Storage:   s,
-		Data:      encData,
+		Data:      map[string]interface{}{},
 	}
 	resp, err = b.HandleRequest(context.Background(), encReq)
 	if resp == nil || !resp.IsError() {

--- a/builtin/logical/transit/path_hash.go
+++ b/builtin/logical/transit/path_hash.go
@@ -63,16 +63,15 @@ Defaults to "sha2-256".`,
 }
 
 func (b *backend) pathHashWrite(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	rawInput, ok := d.Raw["input"]
+	rawInput, ok, err := d.GetOkErr("input")
+	if err != nil {
+		return nil, err
+	}
 	if !ok {
 		return logical.ErrorResponse("input missing"), logical.ErrInvalidRequest
 	}
 
-	inputB64, ok := rawInput.(string)
-	if !ok {
-		return logical.ErrorResponse("expected input of type 'string', got unconvertible type '%T'", rawInput), logical.ErrInvalidRequest
-	}
-
+	inputB64 := rawInput.(string)
 	format := d.Get("format").(string)
 	algorithm := d.Get("urlalgorithm").(string)
 	if algorithm == "" {

--- a/builtin/logical/transit/path_hash_test.go
+++ b/builtin/logical/transit/path_hash_test.go
@@ -86,7 +86,7 @@ func TestTransit_Hash(t *testing.T) {
 	doRequest(req, false, "98rFrYMEIqVAizamCmBiBoe+GAdlo+KJW8O9vYV8nggkbIMGTU42EvDLkn8+rSCEE6uYYkv3sGF68PA/YggJdg==")
 
 	// Test bad input/format/algorithm
-	req.Data["input"] = nil
+	delete(req.Data, "input")
 	doRequest(req, true, "")
 
 	req.Data["input"] = "dGhlIHF1aWNrIGJyb3duIGZveA=="

--- a/builtin/logical/transit/path_trim.go
+++ b/builtin/logical/transit/path_trim.go
@@ -55,14 +55,14 @@ func (b *backend) pathTrimUpdate() framework.OperationFunc {
 		}
 		defer p.Unlock()
 
-		minAvailableVersionRaw, ok := d.Raw["min_available_version"]
+		minAvailableVersionRaw, ok, err := d.GetOkErr("min_available_version")
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
 			return logical.ErrorResponse("missing min_available_version"), nil
 		}
-		minAvailableVersion, ok := minAvailableVersionRaw.(int)
-		if !ok {
-			return logical.ErrorResponse("expected min_available_version of type 'int', got unconvertible type '%T'", minAvailableVersionRaw), logical.ErrInvalidRequest
-		}
+		minAvailableVersion := minAvailableVersionRaw.(int)
 
 		originalMinAvailableVersion := p.MinAvailableVersion
 

--- a/changelog/14074.txt
+++ b/changelog/14074.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-secrets/transit: Return an error if any required parameter is missing or nil. Do not encrypt nil plaintext as if it was an empty string.
+secrets/transit: Return an error if any required parameter is missing.
 ```


### PR DESCRIPTION
Instead of using the field FieldData.Raw, use method GetOkError() which does
type conversion but still allows to check whether a value for the parameter was
provided. Note that GetOkError() converts nil values to default or zero values,
so, for example, a nil plaintext value will result in the empty string being
encrypted.