### PR TITLE
command: fix dropped errors

### DIFF
--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -971,6 +971,9 @@ func TestKVPatchCommand_CAS(t *testing.T) {
 			}
 
 			secret, err := kvClient.Logical().Read("kv/data/foo")
+			if err != nil {
+				t.Fatal(err)
+			}
 			bar := secret.Data["data"].(map[string]interface{})["bar"]
 			if bar != tc.expected {
 				t.Fatalf("expected bar to be %q but it was %q", tc.expected, bar)
@@ -1041,6 +1044,9 @@ func TestKVPatchCommand_Methods(t *testing.T) {
 			}
 
 			secret, err := kvClient.Logical().Read("kv/data/foo")
+			if err != nil {
+				t.Fatal(err)
+			}
 			bar := secret.Data["data"].(map[string]interface{})["bar"]
 			if bar != tc.expected {
 				t.Fatalf("expected bar to be %q but it was %q", tc.expected, bar)


### PR DESCRIPTION
This fixes two dropped `err` variables in the `command` package.