### PR TITLE
Double the timeout for requests in the dbplugin test helpers to avoid sporadic test failures.

### DIFF
--- a/sdk/database/dbplugin/v5/testing/test_helpers.go
+++ b/sdk/database/dbplugin/v5/testing/test_helpers.go
@@ -12,7 +12,11 @@ import (
 func getRequestTimeout(t *testing.T) time.Duration {
 	rawDur := os.Getenv("VAULT_TEST_DATABASE_REQUEST_TIMEOUT")
 	if rawDur == "" {
-		return 5 * time.Second
+		// Note: we incremented the default timeout from 5 to 10 seconds in a bid
+		// to fix sporadic failures of mssql_test.go tests TestInitialize() and
+		// TestUpdateUser_password().
+
+		return 10 * time.Second
 	}
 
 	dur, err := time.ParseDuration(rawDur)


### PR DESCRIPTION
This change was originally committed in [vault-enterprise #2133](https://github.com/hashicorp/vault-enterprise/pull/2133).