### PR TITLE
Logout Auth Method Test Update

### DIFF
--- a/ui/tests/acceptance/logout-auth-method-test.js
+++ b/ui/tests/acceptance/logout-auth-method-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, visit, fillIn, settled } from '@ember/test-helpers';
+import { click, visit, fillIn } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { fakeWindow, buildMessage } from '../helpers/oidc-window-stub';
 import sinon from 'sinon';
@@ -29,10 +29,11 @@ module('Acceptance | logout auth method', function (hooks) {
     sessionStorage.removeItem('selectedAuth');
     await visit('/vault/auth');
     await fillIn('[data-test-select="auth-method"]', 'oidc');
-    later(() => run.cancelTimers(), 50);
+    later(() => {
+      window.postMessage(buildMessage().data, window.origin);
+      run.cancelTimers();
+    }, 50);
     await click('[data-test-auth-submit]');
-    window.postMessage(buildMessage().data, window.origin);
-    await settled();
     await click('.nav-user-button button');
     await click('#logout');
     assert


### PR DESCRIPTION
Small tweak to `logout-auth-method` test to address failures on 1.8.x and 1.9.x versions which use a different test waiter for ember concurrency tasks. I tested the change locally on the specific release branches and the test is now passing. This is related to #14545 and the backports #14577 and #14578 