### PR TITLE
Run UI tests in backport/ui/ prefixed branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     - run:
         command: |
           case "$CIRCLE_BRANCH" in
-          main|ui/*|release/*|merge*) ;;
+          main|ui/*|backport/ui/*|release/*|merge*) ;;
           *) # If the branch being tested doesn't match one of the above patterns,
              # we don't need to run test-ui and can abort the job.
              circleci-agent step halt

--- a/.circleci/config/commands/exit-if-branch-does-not-need-test-ui.yml
+++ b/.circleci/config/commands/exit-if-branch-does-not-need-test-ui.yml
@@ -6,7 +6,7 @@ steps:
       name: Check branch name
       command: |
         case "$CIRCLE_BRANCH" in
-        main|ui/*|release/*|merge*) ;;
+        main|ui/*|backport/ui/*|release/*|merge*) ;;
         *) # If the branch being tested doesn't match one of the above patterns,
            # we don't need to run test-ui and can abort the job.
            circleci-agent step halt


### PR DESCRIPTION
This change allows automatically-generated backport branches (which prefix the original branch name with `backport/` to run the UI tests if the original branch name was `ui/*`