### PR TITLE
Remove defaultSerializer

### DIFF
--- a/ui/app/adapters/role-ssh.js
+++ b/ui/app/adapters/role-ssh.js
@@ -6,8 +6,6 @@ import { encodePath } from 'vault/utils/path-encoding-helpers';
 export default ApplicationAdapter.extend({
   namespace: 'v1',
 
-  defaultSerializer: 'role',
-
   createOrUpdate(store, type, snapshot, requestType) {
     const serializer = store.serializerFor(type.modelName);
     const data = serializer.serialize(snapshot, requestType);

--- a/ui/app/adapters/ssh.js
+++ b/ui/app/adapters/ssh.js
@@ -4,8 +4,6 @@ import ApplicationAdapter from './application';
 export default ApplicationAdapter.extend({
   namespace: 'v1',
 
-  defaultSerializer: 'ssh',
-
   url(/*role*/) {
     assert('Override the `url` method to extend the SSH adapter', false);
   },


### PR DESCRIPTION
Confirmed with [documentation](https://deprecations.emberjs.com/ember-data/v3.x/#toc_ember-data-default-serializers) that as long as we have a serializer with the proper naming convention attached to the adapter, it's safe to remove this method. Both the role.js and role-ssh adapters have serializers setup in this fashion. I also ran the test suite locally and everything passed (I even console log to make sure those serializers were hit).
