### PR TITLE
Sync license deletion docs from Enterprise

### DIFF
--- a/website/content/api-docs/system/license.mdx
+++ b/website/content/api-docs/system/license.mdx
@@ -131,8 +131,8 @@ $ curl \
 ~> This API is deprecated as of Vault 1.8 and will be removed in a future version of Vault.
 Please use [license autoloading](/docs/enterprise/license/autoloading) instead.
 
-This endpoint is used to delete a stored license in Vault.  This will return
-an error unless license autoloading is in use.
+This endpoint is used to delete a license from Vault. Note that this API only works if license autoloading is in use.
+If license autoloading is in use, this API will remove the legacy license from Vault's storage.
 
 | Method | Path           |
 | :----- | :------------- |


### PR DESCRIPTION
This syncs the deletion text from one of Josh's PRs into OSS to be
visible on the website. Suggested by Nick.

```
Co-authored-by: Josh Black <raskchanky@users.noreply.github.com>
Co-authored-by: Nick Cabatoff <ncabatoff@hashicorp.com>
Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>
```

---

This should probably be backported to 1.10 and stable-website? 