### PR TITLE
crt: use the latest version of actions-packaging-linux@v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
           path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
       - name: Package
-        uses: hashicorp/actions-packaging-linux@v1.2
+        uses: hashicorp/actions-packaging-linux@v1
         with:
           name: ${{ github.event.repository.name }}
           description: "Vault is a tool for secrets management, encryption as a service, and privileged access management."


### PR DESCRIPTION
Use the latest version of the actions-packaging-linux@v1 to ensure that
.deb and .rpm artifacts are generated with release.

Signed-off-by: Ryan Cragun <me@ryan.ec>