### PR TITLE
Route renderTemplate Deprecation

### DIFF
--- a/ui/app/routes/loading.js
+++ b/ui/app/routes/loading.js
@@ -1,25 +1,9 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
 
 export default Route.extend({
-  router: service(),
-  init() {
+  setupController(controller) {
     this._super(...arguments);
-    this.router.on('routeWillChange', (transition) => {
-      this.set('myTargetRouteName', transition.to.name);
-    });
-  },
-  renderTemplate() {
-    let targetName = this.myTargetRouteName;
-    let isCallback =
-      targetName === 'vault.cluster.oidc-callback' || targetName === 'vault.cluster.oidc-callback-namespace';
-    if (isCallback) {
-      this.render('vault/cluster/oidc-callback', {
-        into: 'application',
-        outlet: 'main',
-      });
-    } else {
-      this._super(...arguments);
-    }
+    const targetRoute = location.pathname || '';
+    controller.set('isCallback', targetRoute.includes('oidc/callback'));
   },
 });

--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -13,10 +13,7 @@ export default Route.extend({
     let queryParams = { source, namespace, path, code, state };
     window.opener.postMessage(queryParams, window.origin);
   },
-  renderTemplate() {
-    this.render(this.templateName, {
-      into: 'application',
-      outlet: 'main',
-    });
+  setupController(controller) {
+    controller.set('pageContainer', document.querySelector('.page-container'));
   },
 });

--- a/ui/app/routes/vault/cluster/oidc-callback.js
+++ b/ui/app/routes/vault/cluster/oidc-callback.js
@@ -14,6 +14,7 @@ export default Route.extend({
     window.opener.postMessage(queryParams, window.origin);
   },
   setupController(controller) {
+    this._super(...arguments);
     controller.set('pageContainer', document.querySelector('.page-container'));
   },
 });

--- a/ui/app/templates/components/oidc-callback-splash.hbs
+++ b/ui/app/templates/components/oidc-callback-splash.hbs
@@ -1,0 +1,14 @@
+<div class="splash-page-container section is-flex-v-centered-tablet is-flex-1 is-fullwidth">
+  <div class="columns is-centered is-gapless is-fullwidth">
+    <div class="column is-4-desktop is-6-tablet">
+      <div class="has-text-grey has-bottom-margin-m has-current-color-fill">
+        <LogoEdition />
+      </div>
+      <AlertBanner
+        @type="success"
+        @title="Signing in with your OIDC provider..."
+        @message="This window will close automatically"
+      />
+    </div>
+  </div>
+</div>

--- a/ui/app/templates/loading.hbs
+++ b/ui/app/templates/loading.hbs
@@ -1,1 +1,5 @@
-<LogoSplash />
+{{#if this.isCallback}}
+  <OidcCallbackSplash />
+{{else}}
+  <LogoSplash />
+{{/if}}

--- a/ui/app/templates/vault/cluster/oidc-callback.hbs
+++ b/ui/app/templates/vault/cluster/oidc-callback.hbs
@@ -1,14 +1,3 @@
-<div class="splash-page-container section is-flex-v-centered-tablet is-flex-1 is-fullwidth">
-  <div class="columns is-centered is-gapless is-fullwidth">
-    <div class="column is-4-desktop is-6-tablet">
-      <div class="has-text-grey has-bottom-margin-m has-current-color-fill">
-        <LogoEdition />
-      </div>
-      <AlertBanner
-        @type="success"
-        @title="Signing in with your OIDC provider..."
-        @message="This window will close automatically"
-      />
-    </div>
-  </div>
-</div>
+{{#in-element this.pageContainer}}
+  <OidcCallbackSplash />
+{{/in-element}}

--- a/ui/lib/core/addon/components/masked-input.js
+++ b/ui/lib/core/addon/components/masked-input.js
@@ -52,7 +52,9 @@ export default Component.extend({
       this.onChange(value);
     },
     handleKeyUp(name, value) {
-      this.onKeyUp(name, value);
+      if (this.onKeyUp) {
+        this.onKeyUp(name, value);
+      }
     },
   },
 });


### PR DESCRIPTION
As of Ember 4.0 the `renderTemplate` method on routes is being deprecated. This PR removes the usages and refactors to retain the intended results.

https://deprecations.emberjs.com/v3.x/#toc_route-render-template