### PR TITLE
docs/db2: adds documentation reference to db2 learn tutorial

### DIFF
--- a/website/content/docs/secrets/databases/db2.mdx
+++ b/website/content/docs/secrets/databases/db2.mdx
@@ -1,0 +1,26 @@
+---
+layout: docs
+page_title: IBM Db2 - Database - Credentials
+description: |-
+  Manage credentials for IBM Db2 using Vault's OpenLDAP secrets engine.
+---
+
+# IBM Db2
+
+Access to Db2 is managed by facilities that reside outside the Db2 database system. By
+default, user authentication is completed by a security facility that relies on operating
+system based authentication of users and passwords. This means that the lifecycle of user
+identities in Db2 aren't capable of being managed using SQL statements and Vault's
+database secrets engine.
+
+To provide flexibility in accommodating authentication needs, Db2 ships with authentication
+[plugin modules](https://www.ibm.com/docs/en/db2/11.5?topic=ins-ldap-based-authentication-group-lookup-support)
+for Lightweight Directory Access Protocol (LDAP). This enables the Db2 database manager to
+authenticate users and obtain group membership defined in an LDAP directory, removing the
+requirement that users and groups be defined to the operating system.
+
+Vault's [OpenLDAP secrets engine](/docs/secrets/openldap) can be used to manage the lifecycle
+of credentials for Db2 environments that have been configured to delegate user authentication
+and group membership to an LDAP server. A step-by-step guide on using Vault to manage both
+static and dynamic credentials for access to Db2 can be found in the [IBM Db2 Credential Management](TODO: not published yet)
+learn tutorial.

--- a/website/content/docs/secrets/databases/db2.mdx
+++ b/website/content/docs/secrets/databases/db2.mdx
@@ -22,5 +22,5 @@ requirement that users and groups be defined to the operating system.
 Vault's [OpenLDAP secrets engine](/docs/secrets/openldap) can be used to manage the lifecycle
 of credentials for Db2 environments that have been configured to delegate user authentication
 and group membership to an LDAP server. A step-by-step guide on using Vault to manage both
-static and dynamic credentials for access to Db2 can be found in the [IBM Db2 Credential Management](TODO: not published yet)
+static and dynamic credentials for access to Db2 can be found in the [IBM Db2 Credential Management](https://learn.hashicorp.com/tutorials/vault/ibm-db2-openldap)
 learn tutorial.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -965,6 +965,10 @@
             "path": "secrets/databases/hanadb"
           },
           {
+            "title": "IBM Db2",
+            "path": "secrets/databases/db2"
+          },
+          {
             "title": "InfluxDB",
             "path": "secrets/databases/influxdb"
           },


### PR DESCRIPTION
This PR adds a new page for IBM Db2 under "Secrets Engines" -> "Databases". The intent is to improve the discoverability of a learn guide being published for IBM Db2 credential management using Vault's OpenLDAP secrets engine. This solution doesn't use the database secrets engine, but this location in the documentation feels like the first place users would look.

Note that the tutorial isn't published yet. I've included a link to where the tutorial will be.