### PR TITLE
PKI: Add missing default cases within switch statements

### DIFF
--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -25,14 +25,14 @@ func (b *backend) getGenerationParams(ctx context.Context,
 	case "kms":
 	default:
 		errorResp = logical.ErrorResponse(
-			`the "exported" path parameter must be "internal" or "exported"`)
+			`the "exported" path parameter must be "internal", "exported" or "kms"`)
 		return
 	}
 
 	format = getFormat(data)
 	if format == "" {
 		errorResp = logical.ErrorResponse(
-			`the "format" path parameter must be "pem", "der", "der_pkcs", or "pem_bundle"`)
+			`the "format" path parameter must be "pem", "der", or "pem_bundle"`)
 		return
 	}
 

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -748,7 +748,7 @@ func signCert(b *backend,
 		}
 
 	default:
-		return nil, errutil.InternalError{Err: fmt.Sprintf("supported key type value: %s", data.role.KeyType)}
+		return nil, errutil.InternalError{Err: fmt.Sprintf("unsupported key type value: %s", data.role.KeyType)}
 	}
 
 	creation, err := generateCreationBundle(b, data, caSign, csr)

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -747,6 +747,8 @@ func signCert(b *backend,
 			return nil, errutil.UserError{Err: "RSA keys < 2048 bits are unsafe and not supported"}
 		}
 
+	default:
+		return nil, errutil.InternalError{Err: fmt.Sprintf("supported key type value: %s", data.role.KeyType)}
 	}
 
 	creation, err := generateCreationBundle(b, data, caSign, csr)

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -114,7 +114,7 @@ func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request) (*certut
 		return nil, errutil.InternalError{Err: "stored CA information not able to be parsed"}
 	}
 
-	caInfo := &certutil.CAInfoBundle{*parsedBundle, nil}
+	caInfo := &certutil.CAInfoBundle{ParsedCertBundle: *parsedBundle, URLs: nil}
 
 	entries, err := getURLs(ctx, req)
 	if err != nil {
@@ -721,7 +721,7 @@ func signCert(b *backend,
 
 	case "ed25519":
 		// Verify that the key matches the role type
-		if csr.PublicKeyAlgorithm != x509.PublicKeyAlgorithm(x509.Ed25519) {
+		if csr.PublicKeyAlgorithm != x509.Ed25519 {
 			return nil, errutil.UserError{Err: fmt.Sprintf(
 				"role requires keys of type %s",
 				data.role.KeyType)}
@@ -1441,5 +1441,5 @@ func stringToOid(in string) (asn1.ObjectIdentifier, error) {
 		}
 		ret = append(ret, i)
 	}
-	return asn1.ObjectIdentifier(ret), nil
+	return ret, nil
 }

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -124,6 +124,8 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 			resp.Data["private_key"] = base64.StdEncoding.EncodeToString(parsedBundle.PrivateKeyBytes)
 			resp.Data["private_key_type"] = csrb.PrivateKeyType
 		}
+	default:
+		return nil, fmt.Errorf("unsupported format argument: %s", format)
 	}
 
 	if data.Get("private_key_format").(string) == "pkcs8" {

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -263,6 +263,8 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 			respData["private_key"] = base64.StdEncoding.EncodeToString(parsedBundle.PrivateKeyBytes)
 			respData["private_key_type"] = cb.PrivateKeyType
 		}
+	default:
+		return nil, fmt.Errorf("unsupported format: %s", format)
 	}
 
 	var resp *logical.Response

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -220,6 +220,8 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 			resp.Data["private_key"] = base64.StdEncoding.EncodeToString(parsedBundle.PrivateKeyBytes)
 			resp.Data["private_key_type"] = cb.PrivateKeyType
 		}
+	default:
+		return nil, fmt.Errorf("unsupported format argument: %s", format)
 	}
 
 	if data.Get("private_key_format").(string) == "pkcs8" {
@@ -396,6 +398,8 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 		if caChain != nil && len(caChain) > 0 {
 			resp.Data["ca_chain"] = cb.CAChain
 		}
+	default:
+		return nil, fmt.Errorf("unsupported format argument: %s", format)
 	}
 
 	err = req.Storage.Put(ctx, &logical.StorageEntry{


### PR DESCRIPTION
 - Harden the code base a bit adding default's to switch statements
   to various error handlers and processing statements.
 - Fixup some error messages to include proper values we support.