### PR TITLE
Warn on upper case in policy name

### DIFF
--- a/changelog/14670.txt
+++ b/changelog/14670.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: warn when policy name contains upper-case letter
+cli/vault: warn when policy name contains upper-case letter
 ```

--- a/changelog/14670.txt
+++ b/changelog/14670.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: warn when policy name contains upper-case letter
+```

--- a/command/policy_write.go
+++ b/command/policy_write.go
@@ -91,8 +91,8 @@ func (c *PolicyWriteCommand) Run(args []string) int {
 	}
 
 	// Policies are normalized to lowercase
-	name := args[0]
-	formattedName := strings.TrimSpace(strings.ToLower(name))
+	policyName := args[0]
+	formattedName := strings.TrimSpace(strings.ToLower(policyName))
 	path := strings.TrimSpace(args[1])
 
 	// Get the policy contents, either from stdin of a file
@@ -125,8 +125,8 @@ func (c *PolicyWriteCommand) Run(args []string) int {
 		return 2
 	}
 
-	if name != formattedName {
-		c.UI.Warn(fmt.Sprintf("Policy name was converted to %s", formattedName))
+	if policyName != formattedName {
+		c.UI.Warn(fmt.Sprintf("Policy name was converted from \"%s\" to \"%s\"", policyName, formattedName))
 	}
 
 	c.UI.Output(fmt.Sprintf("Success! Uploaded policy: %s", formattedName))

--- a/command/policy_write.go
+++ b/command/policy_write.go
@@ -94,7 +94,7 @@ func (c *PolicyWriteCommand) Run(args []string) int {
 	// Policies are normalized to lowercase
 	policyName := args[0]
 	warnOnUpperCase(c.UI, policyName)
-	name := strings.TrimSpace(strings.ToLower(policyName))
+	formattedPolicyName := strings.TrimSpace(strings.ToLower(policyName))
 	path := strings.TrimSpace(args[1])
 
 	// Get the policy contents, either from stdin of a file
@@ -122,12 +122,12 @@ func (c *PolicyWriteCommand) Run(args []string) int {
 	}
 	rules := buf.String()
 
-	if err := client.Sys().PutPolicy(name, rules); err != nil {
+	if err := client.Sys().PutPolicy(formattedPolicyName, rules); err != nil {
 		c.UI.Error(fmt.Sprintf("Error uploading policy: %s", err))
 		return 2
 	}
 
-	c.UI.Output(fmt.Sprintf("Success! Uploaded policy: %s", name))
+	c.UI.Output(fmt.Sprintf("Success! Uploaded policy: %s", formattedPolicyName))
 	return 0
 }
 

--- a/command/policy_write.go
+++ b/command/policy_write.go
@@ -95,10 +95,6 @@ func (c *PolicyWriteCommand) Run(args []string) int {
 	formattedName := strings.TrimSpace(strings.ToLower(name))
 	path := strings.TrimSpace(args[1])
 
-	if name != formattedName {
-		c.UI.Warn(fmt.Sprintf("Policy name was converted to %s", formattedName))
-	}
-
 	// Get the policy contents, either from stdin of a file
 	var reader io.Reader
 	if path == "-" {
@@ -127,6 +123,10 @@ func (c *PolicyWriteCommand) Run(args []string) int {
 	if err := client.Sys().PutPolicy(formattedName, rules); err != nil {
 		c.UI.Error(fmt.Sprintf("Error uploading policy: %s", err))
 		return 2
+	}
+
+	if name != formattedName {
+		c.UI.Warn(fmt.Sprintf("Policy name was converted to %s", formattedName))
 	}
 
 	c.UI.Output(fmt.Sprintf("Success! Uploaded policy: %s", formattedName))

--- a/command/policy_write.go
+++ b/command/policy_write.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
@@ -91,7 +92,9 @@ func (c *PolicyWriteCommand) Run(args []string) int {
 	}
 
 	// Policies are normalized to lowercase
-	name := strings.TrimSpace(strings.ToLower(args[0]))
+	policyName := args[0]
+	warnOnUpperCase(c.UI, policyName)
+	name := strings.TrimSpace(strings.ToLower(policyName))
 	path := strings.TrimSpace(args[1])
 
 	// Get the policy contents, either from stdin of a file
@@ -126,4 +129,13 @@ func (c *PolicyWriteCommand) Run(args []string) int {
 
 	c.UI.Output(fmt.Sprintf("Success! Uploaded policy: %s", name))
 	return 0
+}
+
+func warnOnUpperCase(ui cli.Ui, s string) {
+	for _, r := range s {
+		if unicode.IsUpper(r) && unicode.IsLetter(r) {
+			ui.Warn("Policy name contains upper-case character(s) and will be converted to lower-case.")
+			break
+		}
+	}
 }

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2445,9 +2445,7 @@ func (b *SystemBackend) handlePoliciesSet(policyType PolicyType) framework.Opera
 			return logical.ErrorResponse("policy name must be provided in the URL"), nil
 		}
 		if name != policy.Name {
-			if resp == nil {
-				resp = &logical.Response{}
-			}
+			resp = &logical.Response{}
 			resp.AddWarning(fmt.Sprintf("policy name was converted to %s", policy.Name))
 		}
 

--- a/vault/logical_system.go
+++ b/vault/logical_system.go
@@ -2435,13 +2435,20 @@ func (b *SystemBackend) handlePoliciesSet(policyType PolicyType) framework.Opera
 			return nil, err
 		}
 
+		name := data.Get("name").(string)
 		policy := &Policy{
-			Name:      strings.ToLower(data.Get("name").(string)),
+			Name:      strings.ToLower(name),
 			Type:      policyType,
 			namespace: ns,
 		}
 		if policy.Name == "" {
 			return logical.ErrorResponse("policy name must be provided in the URL"), nil
+		}
+		if name != policy.Name {
+			if resp == nil {
+				resp = &logical.Response{}
+			}
+			resp.AddWarning(fmt.Sprintf("policy name was converted to %s", policy.Name))
 		}
 
 		policy.Raw = data.Get("policy").(string)
@@ -2485,6 +2492,7 @@ func (b *SystemBackend) handlePoliciesSet(policyType PolicyType) framework.Opera
 		if err := b.Core.policyStore.SetPolicy(ctx, policy); err != nil {
 			return handleError(err)
 		}
+
 		return resp, nil
 	}
 }


### PR DESCRIPTION
Provides a warning when an upper case character is given in a policy name, as our current behavior of just lower-casing anything that comes in without telling anyone has caused some users confusion (see https://github.com/hashicorp/vault/issues/13647).