### PR TITLE
Computed Property Overridability

### DIFF
--- a/ui/app/services/auth.js
+++ b/ui/app/services/auth.js
@@ -35,9 +35,14 @@ export default Service.extend({
   clusterAdapter() {
     return getOwner(this).lookup('adapter:cluster');
   },
-
-  tokens: computed(function () {
-    return this.getTokensFromStorage() || [];
+  // eslint-disable-next-line
+  tokens: computed({
+    get() {
+      return this._tokens || this.getTokensFromStorage() || [];
+    },
+    set(key, value) {
+      return (this._tokens = value);
+    },
   }),
 
   generateTokenName({ backend, clusterId }, policies) {

--- a/ui/app/services/store.js
+++ b/ui/app/services/store.js
@@ -29,8 +29,14 @@ export function keyForCache(query) {
 
 export default Store.extend({
   // this is a map of map that stores the caches
-  lazyCaches: computed(function () {
-    return new Map();
+  // eslint-disable-next-line
+  lazyCaches: computed({
+    get() {
+      return this._lazyCaches || new Map();
+    },
+    set(key, value) {
+      return (this._lazyCaches = value);
+    },
   }),
 
   setLazyCacheForModel(modelName, key, value) {


### PR DESCRIPTION
As of Ember 4.0, overriding computed properties without using the getter/setter pattern will be deprecated. 
https://deprecations.emberjs.com/v3.x/#toc_computed-property-override

I created a script that uses [jscodeshift](https://github.com/facebook/jscodeshift) to look for computed properties in a file and then check if those property names were used with either `this.set` or `this.setProperties`. For any found lines a comment is added so it can be investigated further. You can view a gist of the script run against some example code using [AST Explorer](https://astexplorer.net/#/gist/140ee6291cf97b4f4c243dd669da2c34/938b04fa5bca55a491708b7b403892ea58df449b).

The result running against 595 .js files in the `/app` directory found 2 files that were overriding computed properties. This PR provides updates for those instances.

While this experiment successfully found issues, it only covers basic usages. It would be more complex to track down a computed property on a model for example, which was then passed into a component and then mutated since the script is auditing files independently.