### PR TITLE
Fix markdown formatting issue in 1.10 upgrade docs

### DIFF
--- a/website/content/docs/upgrading/upgrade-to-1.10.x.mdx
+++ b/website/content/docs/upgrading/upgrade-to-1.10.x.mdx
@@ -62,15 +62,15 @@ OIDC provider system to reduce configuration steps and enhance usability.
 The following built-in resources are included in each Vault namespace starting with Vault
 1.10:
 
-- A "default" OIDC provider that's usable by all client applications
-- A "default" key for signing and verification of ID tokens
-- An "allow_all" assignment which authorizes all Vault entities to authenticate via a
+- A `default` OIDC provider that's usable by all client applications
+- A `default` key for signing and verification of ID tokens
+- An `allow_all` assignment which authorizes all Vault entities to authenticate via a
   client application
 
 If you created an [OIDC provider](/api-docs/secret/identity/oidc-provider#create-or-update-a-provider)
-with the name "default", [key](/api-docs/secret/identity/tokens#create-a-named-key) with the
-name "default", or [assignment](/api-docs/secret/identity/oidc-provider#create-or-update-an-assignment)
-with the name "allow_all" using the Vault 1.9 tech preview, the installation of these built-in
+with the name `default`, [key](/api-docs/secret/identity/tokens#create-a-named-key) with the
+name `default`, or [assignment](/api-docs/secret/identity/oidc-provider#create-or-update-an-assignment)
+with the name `allow_all` using the Vault 1.9 tech preview, the installation of these built-in
 resources will be skipped. We *strongly* recommend that you delete any resources that have
 naming collisions before upgrading to Vault 1.10. Failing to delete resources with naming
 collisions could result unexpected default behavior. Additionally, we recommend reading the


### PR DESCRIPTION
The `allow_all` token on the ["Upgrading to Vault 1.10.x"](https://www.vaultproject.io/docs/upgrading/upgrade-to-1.10.x) page causes a run of unwanted italics (see attached screenshot).

<img width="917" alt="formatting-issue" src="https://user-images.githubusercontent.com/70562/159952147-f96b75c9-5afa-4b14-86f1-fb90c889e3d1.png">

This commit changes the quoting on that token from double-quotes to backquotes to avoid this issue. It also changes the quoting of other tokens in the same section for formatting consistency.

An alternative approach would be to escape just the underscore in the `allow_all` token, but backquoting API tokens seems to be typical style.