### PR TITLE
Remove CreateOperation from transit/cache-config

### DIFF
--- a/builtin/logical/transit/path_cache_config.go
+++ b/builtin/logical/transit/path_cache_config.go
@@ -30,11 +30,6 @@ func (b *backend) pathCacheConfig() *framework.Path {
 				Callback: b.pathCacheConfigWrite,
 				Summary:  "Configures a new cache of the specified size",
 			},
-
-			logical.CreateOperation: &framework.PathOperation{
-				Callback: b.pathCacheConfigWrite,
-				Summary:  "Configures a new cache of the specified size",
-			},
 		},
 
 		HelpSynopsis:    pathCacheConfigHelpSyn,


### PR DESCRIPTION
A `logical.CreateOperation` without the implementation of an `ExistenceCheck` defaults to becoming a `logical.UpdateOperation`. We're removing the `logical.CreateOperation` from `/transit/cache-config` to improve the output of the OpenApi Spec.

Verified OAS Spec doesn't advertise the `x-vault-createSupported` in OpenApi spec. Also verified the transit/cache-config `POST` still works. 

See this gh issue [#12329](https://github.com/hashicorp/vault/issues/12329)