### PR TITLE
Vault-4010 Unauthenticated panic when processing "help" requests

### DIFF
--- a/changelog/14704.txt
+++ b/changelog/14704.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix panic for help request URL paths without /v1/ prefix   
+```

--- a/http/help.go
+++ b/http/help.go
@@ -1,7 +1,9 @@
 package http
 
 import (
+	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/vault/helper/namespace"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -29,6 +31,10 @@ func handleHelp(core *vault.Core, w http.ResponseWriter, r *http.Request) {
 	ns, err := namespace.FromContext(r.Context())
 	if err != nil {
 		respondError(w, http.StatusBadRequest, nil)
+		return
+	}
+	if !strings.HasPrefix(r.URL.Path, "/v1/") {
+		respondError(w, http.StatusNotFound, errors.New("Missing /v1/ prefix in path. Use vault path-help command to retrieve API help for paths"))
 		return
 	}
 	path := ns.TrimmedPath(r.URL.Path[len("/v1/"):])

--- a/http/help_test.go
+++ b/http/help_test.go
@@ -13,7 +13,11 @@ func TestHelp(t *testing.T) {
 	defer ln.Close()
 	TestServerAuth(t, addr, token)
 
-	resp := testHttpGet(t, "", addr+"/v1/sys/mounts?help=1")
+	// request without /v1/ prefix
+	resp := testHttpGet(t, token, addr+"/?help=1")
+	testResponseStatus(t, resp, 404)
+
+	resp = testHttpGet(t, "", addr+"/v1/sys/mounts?help=1")
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatal("expected permission denied with no token")
 	}


### PR DESCRIPTION
Approved PR on enterprise: https://github.com/hashicorp/vault-enterprise/pull/2556
Jira: https://hashicorp.atlassian.net/browse/VAULT-4010
The Vault server's wrapHelpHandler function incorrectly processes the requests sent to the Vault server. It assumes that all request URL paths start with the "/v1/" string, and when they do not, it panics. This panic is then recovered by the Go's HTTP server and while the server does not crash, this process is likely resource exhaustive and can be used for a denial of service attack.
Solution: Fix the Vault's help request processing, so it doesn't panic when the request URL path does not start with the "/v1/" prefix. Validate it before calling the handleHelp function. This will prevent a possibility of triggering an unauthenticated panic in a Vault server which could be used for a denial of service attack.

