### PR TITLE
docs: fix plugin redirects and clarify plugin scaling

### DIFF
--- a/website/content/docs/audit/index.mdx
+++ b/website/content/docs/audit/index.mdx
@@ -66,7 +66,7 @@ cluster by default, and to performance/DR secondaries for Vault Enterprise clust
 Before enabling an audit device, ensure that all nodes within the cluster(s)
 will be able to successfully log to the audit device to avoid Vault being
 blocked from serving requests.
-An audit device can be limited to only within the node's cluster with the [`local`](api/system/audit#local) parameter.
+An audit device can be limited to only within the node's cluster with the [`local`](/api/system/audit#local) parameter.
 
 When an audit device is disabled, it will stop receiving logs immediately.
 The existing logs that it did store are untouched.

--- a/website/content/docs/plugins/plugin-architecture.mdx
+++ b/website/content/docs/plugins/plugin-architecture.mdx
@@ -50,9 +50,9 @@ without any explicit action by a plugin author. The default behavior of Vault
 Enterprise is to attempt to handle all requests, including requests to plugins,
 on performance standbys. If the plugin request makes any attempt to modify
 storage, the request will receive a readonly error, and the request routing
-code will then forward the request to the active node. In other words, plugins
-can scale horizontally on Vault Enterprise without any effort on the plugin
-author's part.
+code will then forward the full original request transparently to the active
+node. In other words, plugins can scale horizontally on Vault Enterprise
+without any effort on the plugin author's part.
 
 ## Plugin Communication
 

--- a/website/redirects.next.js
+++ b/website/redirects.next.js
@@ -232,12 +232,12 @@ module.exports = [
   },
   {
     source: '/docs/secrets/custom',
-    destination: '/docs/plugin',
+    destination: '/docs/plugins/plugin-management',
     permanent: true,
   },
   {
     source: '/docs/internals/plugins',
-    destination: '/docs/plugin',
+    destination: '/docs/plugins',
     permanent: true,
   },
   {


### PR DESCRIPTION
Ensure plugin redirects go to the appropriate page. Also add some clarification to the external plugin scaling text.