### PR TITLE
builtin/logical/transit: fix clobbered err

### DIFF
--- a/builtin/logical/transit/stepwise_test.go
+++ b/builtin/logical/transit/stepwise_test.go
@@ -194,6 +194,9 @@ func testAccStepwiseDecrypt(
 		Path:      "decrypt/" + name,
 		Data:      decryptData,
 		Assert: func(resp *api.Secret, err error) error {
+			if err != nil {
+				return err
+			}
 			var d struct {
 				Plaintext string `mapstructure:"plaintext"`
 			}


### PR DESCRIPTION
This fixes an `err` variable passed into a test function but left unused.