### PR TITLE
add value length check to approle createHMAC

### DIFF
--- a/builtin/credential/approle/validation.go
+++ b/builtin/credential/approle/validation.go
@@ -92,12 +92,19 @@ func verifyCIDRRoleSecretIDSubset(secretIDCIDRs []string, roleBoundCIDRList []st
 	return nil
 }
 
+const maxHmacInputLength = 1024
+
 // Creates a SHA256 HMAC of the given 'value' using the given 'key' and returns
 // a hex encoded string.
 func createHMAC(key, value string) (string, error) {
 	if key == "" {
 		return "", fmt.Errorf("invalid HMAC key")
 	}
+
+	if len(value) > maxHmacInputLength {
+		return "", fmt.Errorf("value is longer than maximum of %d bytes", maxHmacInputLength)
+	}
+
 	hm := hmac.New(sha256.New, []byte(key))
 	hm.Write([]byte(value))
 	return hex.EncodeToString(hm.Sum(nil)), nil

--- a/changelog/14746.txt
+++ b/changelog/14746.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-auth/approle: Add maximum input length values that result in SHA56 HMAC calculation
+auth/approle: Add maximum length for input values that result in SHA56 HMAC calculation
 ```

--- a/changelog/14746.txt
+++ b/changelog/14746.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth/approle: Add maximum input length values that result in SHA56 HMAC calculation
+```


### PR DESCRIPTION
Prevent clients from issuing approle login requests with unbounded input requiring SHA256 HMAC calculation by adding a limit check.