### PR TITLE
Remove Unknown Arguments From Builtin Components

### DIFF
--- a/ui/app/templates/components/auth-info.hbs
+++ b/ui/app/templates/components/auth-info.hbs
@@ -62,18 +62,15 @@
             {{/if}}
           {{/if}}
           <li class="action">
-            {{! invokeAction is provided by ember-link-action addon -- should consider removing in favor of on modifier }}
-            {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
             <LinkTo
               @route="vault.cluster.logout"
               @model={{@activeClusterName}}
               id="logout"
               class="is-destroy"
-              @invokeAction={{@onLinkClick}}
+              {{on "click" @onLinkClick}}
             >
               Sign out
             </LinkTo>
-            {{! template-lint-enable }}
           </li>
         </ul>
       </nav>

--- a/ui/app/templates/components/cluster-info.hbs
+++ b/ui/app/templates/components/cluster-info.hbs
@@ -4,20 +4,18 @@
       {{#if (and this.activeCluster.unsealed this.auth.currentToken)}}
         {{#if @cluster.dr.isSecondary}}
           {{#if (has-permission "status" routeParams="replication")}}
-            <nav class="menu">
+            <nav class="menu" aria-label="replication secondary menu">
               <p class="menu-label">Replication</p>
               <ul>
                 {{#if @cluster.anyReplicationEnabled}}
                   <li>
-                    {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
                     <LinkTo
                       @route="vault.cluster.replication-dr-promote.details"
                       disabled={{not this.auth.currentToken}}
-                      @invokeAction={{@onLinkClick}}
+                      {{on "click" @onLinkClick}}
                     >
                       <ReplicationModeSummary @mode="dr" @display="menu" @cluster={{@cluster}} />
                     </LinkTo>
-                    {{! template-lint-enable }}
                   </li>
                 {{/if}}
               </ul>
@@ -26,49 +24,42 @@
           {{/if}}
         {{else}}
           {{#if (has-permission "status" routeParams="replication")}}
-            <nav class="menu">
+            <nav class="menu" aria-label="replication menu">
               <p class="menu-label">Replication</p>
               <ul>
                 {{#if @cluster.anyReplicationEnabled}}
                   <li>
-                    {{! invokeAction is provided by ember-link-action addon -- should consider removing in favor of on modifier }}
-                    {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
                     <LinkTo
                       @route="vault.cluster.replication.mode.index"
                       @model="dr"
                       disabled={{not this.auth.currentToken}}
-                      @invokeAction={{@onLinkClick}}
+                      {{on "click" @onLinkClick}}
                     >
                       <ReplicationModeSummary @mode="dr" @display="menu" @cluster={{@cluster}} />
                     </LinkTo>
-                    {{! template-lint-enable }}
                   </li>
                   <li>
                     {{#if (has-feature "Performance Replication")}}
-                      {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
                       <LinkTo
                         @route="vault.cluster.replication.mode.index"
                         @model="performance"
                         disabled={{not this.auth.currentToken}}
-                        @invokeAction={{@onLinkClick}}
+                        {{on "click" @onLinkClick}}
                       >
                         <ReplicationModeSummary @mode="performance" @display="menu" @cluster={{@cluster}} @tagName="span" />
                       </LinkTo>
-                      {{! template-lint-enable }}
                     {{else}}
                       <ReplicationModeSummary @mode="performance" @display="menu" @cluster={{@cluster}} @class="menu-item" />
                     {{/if}}
                   </li>
                 {{else}}
                   <li>
-                    {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
-                    <LinkTo @route="vault.cluster.replication" @invokeAction={{@onLinkClick}}>
+                    <LinkTo @route="vault.cluster.replication" {{on "click" @onLinkClick}}>
                       <div class="level is-mobile">
                         <span class="level-left">Enable</span>
                         <Icon @name="plus-circle" class="has-text-grey-light level-right" />
                       </div>
                     </LinkTo>
-                    {{! template-lint-enable }}
                   </li>
                 {{/if}}
               </ul>
@@ -78,7 +69,7 @@
         {{/if}}
       {{/if}}
     {{/unless}}
-    <nav class="menu">
+    <nav class="menu" aria-label="server menu">
       <div class="menu-label">
         Server
       </div>
@@ -86,14 +77,12 @@
         <li class="action">
           {{#if this.activeCluster.unsealed}}
             {{#if (and (has-permission "status" routeParams="seal") (not @cluster.dr.isSecondary))}}
-              {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
-              <LinkTo @route="vault.cluster.settings.seal" @model={{@cluster.name}} @invokeAction={{@onLinkClick}}>
+              <LinkTo @route="vault.cluster.settings.seal" @model={{@cluster.name}} {{on "click" @onLinkClick}}>
                 <div class="level is-mobile">
                   <span class="level-left">Unsealed</span>
                   <Icon @name="check-circle" class="has-text-success level-right" />
                 </div>
               </LinkTo>
-              {{! template-lint-enable }}
             {{else}}
               <span class="menu-item">
                 <div class="level is-mobile">
@@ -124,26 +113,22 @@
         <ul class="menu-list">
           {{#if (and this.version.features (has-permission "status" routeParams="license") (not @cluster.dr.isSecondary))}}
             <li class="action">
-              {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
-              <LinkTo @route="vault.cluster.license" @model={{this.activeCluster.name}} @invokeAction={{@onLinkClick}}>
+              <LinkTo @route="vault.cluster.license" @model={{this.activeCluster.name}} {{on "click" @onLinkClick}}>
                 <div class="level is-mobile">
                   <span class="level-left">License</span>
                   <Chevron class="has-text-grey-light level-right" />
                 </div>
               </LinkTo>
-              {{! template-lint-enable }}
             </li>
           {{/if}}
           {{#if (and @cluster.usingRaft (has-permission "status" routeParams="raft"))}}
             <li class="action">
-              {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
-              <LinkTo @route="vault.cluster.storage" @model={{this.activeCluster.name}} @invokeAction={{@onLinkClick}}>
+              <LinkTo @route="vault.cluster.storage" @model={{this.activeCluster.name}} {{on "click" @onLinkClick}}>
                 <div class="level is-mobile">
                   <span class="level-left">Raft Storage</span>
                   <Chevron class="has-text-grey-light level-right" />
                 </div>
               </LinkTo>
-              {{! template-lint-enable }}
             </li>
           {{/if}}
         </ul>
@@ -151,14 +136,12 @@
       {{#if (and (has-permission "clients" routeParams="activity") (not @cluster.dr.isSecondary) this.auth.currentToken)}}
         <ul class="menu-list">
           <li class="action">
-            {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
-            <LinkTo @route="vault.cluster.clients.current" @invokeAction={{@onLinkClick}}>
+            <LinkTo @route="vault.cluster.clients.current" {{on "click" @onLinkClick}}>
               <div class="level is-mobile">
                 <span class="level-left">Client count</span>
                 <Chevron class="has-text-grey-light level-right" />
               </div>
             </LinkTo>
-            {{! template-lint-enable }}
           </li>
         </ul>
       {{/if}}

--- a/ui/app/templates/components/secret-version-menu.hbs
+++ b/ui/app/templates/components/secret-version-menu.hbs
@@ -17,12 +17,7 @@
         {{#each (reverse @model.versions) as |secretVersion|}}
           <li class="action">
             {{! invokeAction is provided by ember-link-action addon -- should consider removing in favor of on modifier }}
-            {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
-            <LinkTo
-              class="link"
-              @params={{array (query-params version=secretVersion.version)}}
-              @invokeAction={{action D.actions.close}}
-            >
+            <LinkTo class="link" @query={{hash version=secretVersion.version}} {{on "click" D.actions.close}}>
               Version
               {{secretVersion.version}}
               {{#if
@@ -37,7 +32,6 @@
                 <Icon @name="x-square-fill" class="has-text-grey is-pulled-right" />
               {{/if}}
             </LinkTo>
-            {{! template-lint-enable }}
           </li>
         {{/each}}
         <li class="action">


### PR DESCRIPTION
As of Ember 4.0, legacy arguments will be removed from builtin components (LinkTo, Input and Textarea). We still had a few templates where the lint rule was turned off to allow usage of some of the arguments. This PR removes those arguments along with the lint rule overrides.

https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-legacy-arguments
https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-legacy-attribute-arguments