### PR TITLE
Ui/Remove [at] from date formatter

### DIFF
--- a/ui/app/templates/components/identity/item-alias/alias-details.hbs
+++ b/ui/app/templates/components/identity/item-alias/alias-details.hbs
@@ -21,11 +21,11 @@
 </InfoTableRow>
 <InfoTableRow @label="Created" @value={{@model.creationTime}}>
   <time datetime={{@model.creationTime}} title={{@model.creationTime}}>
-    {{date-format @model.creationTime "MMM dd, yyyy [at] h:mm a"}}
+    {{date-format @model.creationTime "MMM dd, yyyy h:mm a"}}
   </time>
 </InfoTableRow>
 <InfoTableRow @label="Last Updated" @value={{@model.lastUpdateTime}}>
   <time datetime={{@model.lastUpdateTime}} title={{@model.lastUpdateTime}}>
-    {{date-format @model.lastUpdateTime "MMM dd, yyyy [at] h:mm a"}}
+    {{date-format @model.lastUpdateTime "MMM dd, yyyy h:mm a"}}
   </time>
 </InfoTableRow>

--- a/ui/app/templates/components/identity/item-details.hbs
+++ b/ui/app/templates/components/identity/item-details.hbs
@@ -27,12 +27,12 @@
   </InfoTableRow>
   <InfoTableRow @label="Created" @value={{@model.creationTime}}>
     <time datetime={{@model.creationTime}} title={{@model.creationTime}}>
-      {{date-format @model.creationTime "MMM dd, yyyy [at] h:mm a"}}
+      {{date-format @model.creationTime "MMM dd, yyyy h:mm a"}}
     </time>
   </InfoTableRow>
   <InfoTableRow @label="Last Updated" @value={{this.model.lastUpdateTime}}>
     <time datetime={{this.model.lastUpdateTime}} title={{this.model.lastUpdateTime}}>
-      {{date-format this.model.lastUpdateTime "MMM dd, yyyy [at] h:mm a"}}
+      {{date-format this.model.lastUpdateTime "MMM dd, yyyy h:mm a"}}
     </time>
   </InfoTableRow>
 </div>


### PR DESCRIPTION
Left over syntax from when we used moment.js was showing a weird timestamp in the UI (`[at]` is not supported in date-fns.)

Removed "at" together following our standard practice for showing dates, since we don't typically include

**before fix:**
<img width="500" alt="Screen Shot 2022-03-17 at 10 54 41 AM" src="https://user-images.githubusercontent.com/68122737/160507329-de6749e5-6595-4f1d-a7e6-9458e7a0d101.png">


**after**
<img width="526" alt="Screen Shot 2022-03-28 at 5 09 31 PM" src="https://user-images.githubusercontent.com/68122737/160507358-5a4eb941-6176-4108-b8e0-4ae73f0b095d.png">
