### PR TITLE
Address incorrect table metric value for local mounts

### DIFF
--- a/changelog/14755.txt
+++ b/changelog/14755.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core/metrics: Fix incorrect table size metric for local mounts
+```

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1035,7 +1035,7 @@ func (c *Core) loadMounts(ctx context.Context) error {
 			return err
 		}
 		if localMountTable != nil && len(localMountTable.Entries) > 0 {
-			c.tableMetrics(len(localMountTable.Entries), true, false, raw.Value)
+			c.tableMetrics(len(localMountTable.Entries), true, false, rawLocal.Value)
 			c.mounts.Entries = append(c.mounts.Entries, localMountTable.Entries...)
 		}
 	}


### PR DESCRIPTION
 - Reported within issue #14750 as a panic, it was identified that we were using the wrong value for local mounts within the table metrics.
 - It is still unclear exactly how the raw variable could be nil other than a corrupted file storage. 