### PR TITLE
Remove IE 11 as Build Target

### DIFF
--- a/ui/config/targets.js
+++ b/ui/config/targets.js
@@ -1,15 +1,10 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-// TODO CBS: Remove ie 11
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
-  browsers,
+  browsers: [
+    'last 1 edge versions',
+    'last 1 Chrome versions',
+    'last 1 Firefox versions',
+    'last 1 Safari versions',
+  ],
 };

--- a/ui/ember-cli-build.js
+++ b/ui/ember-cli-build.js
@@ -48,8 +48,7 @@ const appConfig = {
   autoprefixer: {
     enabled: isTest || isProd,
     grid: true,
-    // TODO CBS: Remove IE
-    browsers: ['defaults', 'ie 11'],
+    browsers: ['defaults'],
   },
   autoImport: {
     forbidEval: true,

--- a/ui/testem.browserstack.js
+++ b/ui/testem.browserstack.js
@@ -83,7 +83,7 @@ module.exports = {
     },
   },
   launch_in_dev: [],
-  launch_in_ci: ['BS_IE_11'],
+  launch_in_ci: ['BS_Firefox_Current'],
   proxies: {
     '/v1': {
       target: 'http://localhost:9200',


### PR DESCRIPTION
As of Ember 4.0 support is being dropped for IE 11. This PR removes it as a build target and adds Edge.

https://deprecations.emberjs.com/v3.x/#toc_3-0-browser-support-policy
https://emberjs.com/browser-support/
https://cli.emberjs.com/release/advanced-use/build-targets/
