### PR TITLE
Add extra test coverage to PKI 

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -3493,7 +3493,7 @@ func TestReadWriteDeleteRoles(t *testing.T) {
 	}
 
 	if resp.Data == nil {
-		t.Fatal("response data was nil when it should have contained data")
+		t.Fatal("default data within response was nil when it should have contained data")
 	}
 
 	// Validate that we have not changed any defaults unknowingly

--- a/builtin/logical/pki/crl_test.go
+++ b/builtin/logical/pki/crl_test.go
@@ -70,7 +70,7 @@ func TestBackend_CRL_EnableDisable(t *testing.T) {
 		certList := getCrlCertificateList(t, client)
 		lenList := len(certList.RevokedCertificates)
 		if lenList != num {
-			t.Fatalf("expected %d, found %d", num, lenList)
+			t.Fatalf("expected %d revoked certificates, found %d", num, lenList)
 		}
 	}
 


### PR DESCRIPTION
 * Add a test that validates the behavior of the delete role api
 * Add a test for the crl/rotate api 
 * Rework existing test for fetch raw certs to no longer write directly to storage, instead use the proper apis 
 * Add test for ca_chain fetch api (returning nothing on root)