### PR TITLE
Address semgrep 0.86.x breakage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -807,7 +807,7 @@ jobs:
     - run:
         command: |
           apk add --no-cache python3 py3-pip make
-          python3 -m pip install --user semgrep
+          python3 -m pip install --user semgrep==0.86.5
           export PATH="$HOME/.local/bin:$PATH"
 
           echo "$ semgrep --version"

--- a/.circleci/config/commands/setup-semgrep.yml
+++ b/.circleci/config/commands/setup-semgrep.yml
@@ -7,7 +7,7 @@ steps:
       name: Setup Semgrep
       command: |
         apk add --no-cache python3 py3-pip make
-        python3 -m pip install --user semgrep
+        python3 -m pip install --user semgrep==0.86.5
         export PATH="$HOME/.local/bin:$PATH"
 
         echo "$ semgrep --version"

--- a/builtin/logical/rabbitmq/path_role_create.go
+++ b/builtin/logical/rabbitmq/path_role_create.go
@@ -147,7 +147,6 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 			}
 			return nil
 		}()
-
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +176,6 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 				}
 				return nil
 			}()
-
 			if err != nil {
 				return nil, err
 			}

--- a/builtin/logical/rabbitmq/path_role_create.go
+++ b/builtin/logical/rabbitmq/path_role_create.go
@@ -127,7 +127,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 	// If the role had vhost permissions specified, assign those permissions
 	// to the created username for respective vhosts.
 	for vhost, permission := range role.VHosts {
-		if err := func() error {
+		err := func() error {
 			resp, err := client.UpdatePermissionsIn(vhost, username, rabbithole.Permissions{
 				Configure: permission.Configure,
 				Write:     permission.Write,
@@ -146,7 +146,9 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 				return fmt.Errorf("error updating vhost permissions for %s - %d: %s", vhost, resp.StatusCode, body)
 			}
 			return nil
-		}(); err != nil {
+		}()
+
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -155,7 +157,7 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 	// to the created username for respective vhosts and exchange.
 	for vhost, permissions := range role.VHostTopics {
 		for exchange, permission := range permissions {
-			if err := func() error {
+			err := func() error {
 				resp, err := client.UpdateTopicPermissionsIn(vhost, username, rabbithole.TopicPermissions{
 					Exchange: exchange,
 					Write:    permission.Write,
@@ -174,7 +176,9 @@ func (b *backend) pathCredsRead(ctx context.Context, req *logical.Request, d *fr
 					return fmt.Errorf("error updating vhost permissions for %s - %d: %s", vhost, resp.StatusCode, body)
 				}
 				return nil
-			}(); err != nil {
+			}()
+
+			if err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
Filed a bug against semgrep as they no longer seem to process the following code snippet, failing with the error 
`At line xxxx:1: (Failure "Found unexpected raw string literal without delimiters")`

```
package main

func main() {
	if err := func() error {
		return nil
	}(); err != nil {
		panic(err)
	}
}

const val = `
test literal
`
```

So fix up our codebase to not use that pattern and pin us to the latest version of semgrep 0.86.5