### PR TITLE
Use WriteWithContext in auth helpers

### DIFF
--- a/api/auth/approle/approle.go
+++ b/api/auth/approle/approle.go
@@ -100,6 +100,10 @@ func NewAppRoleAuth(roleID string, secretID *SecretID, opts ...LoginOption) (*Ap
 }
 
 func (a *AppRoleAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	loginData := map[string]interface{}{
 		"role_id": a.roleID,
 	}

--- a/api/auth/approle/approle.go
+++ b/api/auth/approle/approle.go
@@ -125,7 +125,7 @@ func (a *AppRoleAuth) Login(ctx context.Context, client *api.Client) (*api.Secre
 
 	// if the caller indicated that the value was actually a wrapping token, unwrap it first
 	if a.unwrap {
-		unwrappedToken, err := client.Logical().Unwrap(secretIDValue)
+		unwrappedToken, err := client.Logical().UnwrapWithContext(ctx, secretIDValue)
 		if err != nil {
 			return nil, fmt.Errorf("unable to unwrap response wrapping token: %w", err)
 		}
@@ -135,7 +135,7 @@ func (a *AppRoleAuth) Login(ctx context.Context, client *api.Client) (*api.Secre
 	}
 
 	path := fmt.Sprintf("auth/%s/login", a.mountPath)
-	resp, err := client.Logical().Write(path, loginData)
+	resp, err := client.Logical().WriteWithContext(ctx, path, loginData)
 	if err != nil {
 		return nil, fmt.Errorf("unable to log in with app role auth: %w", err)
 	}

--- a/api/auth/aws/aws.go
+++ b/api/auth/aws/aws.go
@@ -84,6 +84,10 @@ func NewAWSAuth(opts ...LoginOption) (*AWSAuth, error) {
 // variables. To specify a path to a credentials file on disk instead, set
 // the environment variable AWS_SHARED_CREDENTIALS_FILE.
 func (a *AWSAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	loginData := make(map[string]interface{})
 	switch a.authType {
 	case ec2Type:

--- a/api/auth/aws/aws.go
+++ b/api/auth/aws/aws.go
@@ -182,7 +182,7 @@ func (a *AWSAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, e
 	}
 
 	path := fmt.Sprintf("auth/%s/login", a.mountPath)
-	resp, err := client.Logical().Write(path, loginData)
+	resp, err := client.Logical().WriteWithContext(ctx, path, loginData)
 	if err != nil {
 		return nil, fmt.Errorf("unable to log in with AWS auth: %w", err)
 	}

--- a/api/auth/azure/azure.go
+++ b/api/auth/azure/azure.go
@@ -110,7 +110,7 @@ func (a *AzureAuth) Login(ctx context.Context, client *api.Client) (*api.Secret,
 	}
 
 	path := fmt.Sprintf("auth/%s/login", a.mountPath)
-	resp, err := client.Logical().Write(path, loginData)
+	resp, err := client.Logical().WriteWithContext(ctx, path, loginData)
 	if err != nil {
 		return nil, fmt.Errorf("unable to log in with Azure auth: %w", err)
 	}

--- a/api/auth/azure/azure.go
+++ b/api/auth/azure/azure.go
@@ -90,6 +90,10 @@ func NewAzureAuth(roleName string, opts ...LoginOption) (*AzureAuth, error) {
 // Login sets up the required request body for the Azure auth method's /login
 // endpoint, and performs a write to it.
 func (a *AzureAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	jwtResp, err := a.getJWT()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get access token: %w", err)

--- a/api/auth/gcp/gcp.go
+++ b/api/auth/gcp/gcp.go
@@ -86,7 +86,7 @@ func (a *GCPAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, e
 	}
 
 	path := fmt.Sprintf("auth/%s/login", a.mountPath)
-	resp, err := client.Logical().Write(path, loginData)
+	resp, err := client.Logical().WriteWithContext(ctx, path, loginData)
 	if err != nil {
 		return nil, fmt.Errorf("unable to log in with GCP auth: %w", err)
 	}

--- a/api/auth/gcp/gcp.go
+++ b/api/auth/gcp/gcp.go
@@ -67,6 +67,10 @@ func NewGCPAuth(roleName string, opts ...LoginOption) (*GCPAuth, error) {
 // endpoint, and performs a write to it. This method defaults to the "gce"
 // auth type unless NewGCPAuth is called with WithIAMAuth().
 func (a *GCPAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	loginData := map[string]interface{}{
 		"role": a.roleName,
 	}

--- a/api/auth/kubernetes/kubernetes.go
+++ b/api/auth/kubernetes/kubernetes.go
@@ -74,7 +74,7 @@ func (a *KubernetesAuth) Login(ctx context.Context, client *api.Client) (*api.Se
 	}
 
 	path := fmt.Sprintf("auth/%s/login", a.mountPath)
-	resp, err := client.Logical().Write(path, loginData)
+	resp, err := client.Logical().WriteWithContext(ctx, path, loginData)
 	if err != nil {
 		return nil, fmt.Errorf("unable to log in with Kubernetes auth: %w", err)
 	}

--- a/api/auth/kubernetes/kubernetes.go
+++ b/api/auth/kubernetes/kubernetes.go
@@ -68,6 +68,10 @@ func NewKubernetesAuth(roleName string, opts ...LoginOption) (*KubernetesAuth, e
 }
 
 func (a *KubernetesAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	loginData := map[string]interface{}{
 		"jwt":  a.serviceAccountToken,
 		"role": a.roleName,

--- a/api/auth/ldap/ldap.go
+++ b/api/auth/ldap/ldap.go
@@ -103,7 +103,7 @@ func (a *LDAPAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, 
 	}
 
 	path := fmt.Sprintf("auth/%s/login/%s", a.mountPath, a.username)
-	resp, err := client.Logical().Write(path, loginData)
+	resp, err := client.Logical().WriteWithContext(ctx, path, loginData)
 	if err != nil {
 		return nil, fmt.Errorf("unable to log in with LDAP auth: %w", err)
 	}

--- a/api/auth/ldap/ldap.go
+++ b/api/auth/ldap/ldap.go
@@ -84,6 +84,10 @@ func NewLDAPAuth(username string, password *Password, opts ...LoginOption) (*LDA
 }
 
 func (a *LDAPAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	loginData := make(map[string]interface{})
 
 	if a.passwordFile != "" {

--- a/api/auth/userpass/userpass.go
+++ b/api/auth/userpass/userpass.go
@@ -88,6 +88,10 @@ func NewUserpassAuth(username string, password *Password, opts ...LoginOption) (
 }
 
 func (a *UserpassAuth) Login(ctx context.Context, client *api.Client) (*api.Secret, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	loginData := make(map[string]interface{})
 
 	if a.passwordFile != "" {

--- a/api/auth/userpass/userpass.go
+++ b/api/auth/userpass/userpass.go
@@ -107,7 +107,7 @@ func (a *UserpassAuth) Login(ctx context.Context, client *api.Client) (*api.Secr
 	}
 
 	path := fmt.Sprintf("auth/%s/login/%s", a.mountPath, a.username)
-	resp, err := client.Logical().Write(path, loginData)
+	resp, err := client.Logical().WriteWithContext(ctx, path, loginData)
 	if err != nil {
 		return nil, fmt.Errorf("unable to log in with userpass auth: %w", err)
 	}

--- a/changelog/14775.txt
+++ b/changelog/14775.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Use the context passed to the api/auth Login helpers.
+```

--- a/command/agent/auth/approle/approle.go
+++ b/command/agent/auth/approle/approle.go
@@ -138,7 +138,7 @@ func (a *approleMethod) Authenticate(ctx context.Context, client *api.Client) (s
 				}
 				clonedClient.SetToken(stringSecretID)
 				// Validate the creation path
-				resp, err := clonedClient.Logical().Read("sys/wrapping/lookup")
+				resp, err := clonedClient.Logical().ReadWithContext(ctx, "sys/wrapping/lookup")
 				if err != nil {
 					return "", nil, nil, fmt.Errorf("error looking up wrapped secret ID: %w", err)
 				}
@@ -161,7 +161,7 @@ func (a *approleMethod) Authenticate(ctx context.Context, client *api.Client) (s
 					return "", nil, nil, errors.New("unable to validate wrapping token creation path")
 				}
 				// Now get the secret ID
-				resp, err = clonedClient.Logical().Unwrap("")
+				resp, err = clonedClient.Logical().UnwrapWithContext(ctx, "")
 				if err != nil {
 					return "", nil, nil, fmt.Errorf("error unwrapping secret ID: %w", err)
 				}

--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -172,7 +172,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 			ah.logger.Debug("lookup-self with preloaded token")
 			clientToUse.SetToken(ah.token)
 
-			secret, err = clientToUse.Logical().ReadWithContext(ctx, "auth/token/lookup-self")
+			secret, err = clientToUse.Auth().Token().LookupSelfWithContext(ctx)
 			if err != nil {
 				ah.logger.Error("could not look up token", "err", err, "backoff", backoff)
 				backoffOrQuit(ctx, backoff)

--- a/command/agent/auth/auth.go
+++ b/command/agent/auth/auth.go
@@ -172,7 +172,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 			ah.logger.Debug("lookup-self with preloaded token")
 			clientToUse.SetToken(ah.token)
 
-			secret, err = clientToUse.Logical().Read("auth/token/lookup-self")
+			secret, err = clientToUse.Logical().ReadWithContext(ctx, "auth/token/lookup-self")
 			if err != nil {
 				ah.logger.Error("could not look up token", "err", err, "backoff", backoff)
 				backoffOrQuit(ctx, backoff)
@@ -220,7 +220,7 @@ func (ah *AuthHandler) Run(ctx context.Context, am AuthMethod) error {
 		// This should only happen if there's no preloaded token (regular auto-auth login)
 		//  or if a preloaded token has expired and is now switching to auto-auth.
 		if secret.Auth == nil {
-			secret, err = clientToUse.Logical().Write(path, data)
+			secret, err = clientToUse.Logical().WriteWithContext(ctx, path, data)
 			// Check errors/sanity
 			if err != nil {
 				ah.logger.Error("error authenticating", "error", err, "backoff", backoff)


### PR DESCRIPTION
Fixes: #14724

Propagate the context passed to the auth helpers by using WriteWithContext function