### PR TITLE
docs: vault-k8s v0.15.0 release

### DIFF
--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -28,7 +28,7 @@ them, optional commands to run, etc.
 
 - `vault.hashicorp.com/agent-image` - name of the Vault docker image to use. This
   value overrides the default image configured in the controller and is usually
-  not needed. Defaults to `hashicorp/vault:1.9.2`.
+  not needed. Defaults to `hashicorp/vault:1.9.4`.
 
 - `vault.hashicorp.com/agent-init-first` - configures the pod to run the Vault Agent
   init container first if `true` (last if `false`). This is useful when other init
@@ -54,6 +54,10 @@ them, optional commands to run, etc.
   `vault.hashicorp.com/agent-inject-template-foobar`. This should map to the same
   unique value provided in `vault.hashicorp.com/agent-inject-secret-`. If not provided,
   a default generic template is used.
+
+- `vault.hashicorp.com/agent-inject-containers` - comma-separated list that specifies in
+  which containers the secrets volume should be mounted. If not provided, the secrets
+  volume will be mounted in all containers in the pod.
 
 - `vault.hashicorp.com/secret-volume-path` - configures where on the filesystem a secret
   will be rendered. To map a path to a specific secret, use the same unique secret name:


### PR DESCRIPTION
New default `agent-image` and `agent-inject-containers` annotation added in [vault-k8s v0.15.0](https://github.com/hashicorp/vault/pull/new/docs/vault-k8s-0.15.0).

Preview: https://vault-3p7ponpci-hashicorp.vercel.app/docs/platform/k8s/injector/annotations#vault-hashicorp-com-agent-inject-containers