### PR TITLE
Remove nocursor from json-editor

### DIFF
--- a/ui/app/components/json-editor.js
+++ b/ui/app/components/json-editor.js
@@ -45,7 +45,6 @@ export default class JsonEditorComponent extends Component {
       delete this.options.autoHeight;
     }
     if (this.options.readOnly) {
-      this.options.readOnly = 'nocursor';
       this.options.lineNumbers = false;
       delete this.options.gutters;
     }


### PR DESCRIPTION
This fix is a one-off and not a backport. The original fix is much larger - see [PR here](https://github.com/hashicorp/vault/pull/14659). 

This will show a blinking cursor in readOnly but allows users to copy the text. This will be fixed in 1.10.x, 1.9.x and 1.8.x.

Original issue [here](https://github.com/hashicorp/vault/issues/12350).