### PR TITLE
UI/Only show form values if have read access

### DIFF
--- a/changelog/14794.txt
+++ b/changelog/14794.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix KV secret showing in the edit form after a user creates a new version but doesn't have read capabilities
+```

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -129,7 +129,7 @@ export default class SecretCreateOrUpdate extends Component {
     return secretData
       .save()
       .then(() => {
-        if (!this.args.canReadSecretData) {
+        if (!this.args.canReadSecretData && secret.selectedVersion) {
           delete secret.selectedVersion.secretData;
         }
         if (!secretData.isError) {

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -204,7 +204,6 @@ export default class SecretCreateOrUpdate extends Component {
   @action
   addRow() {
     const data = this.args.secretData;
-
     // fired off on init
     if (isNone(data.findBy('name', ''))) {
       data.pushObject({ name: '', value: '' });

--- a/ui/app/components/secret-create-or-update.js
+++ b/ui/app/components/secret-create-or-update.js
@@ -129,6 +129,9 @@ export default class SecretCreateOrUpdate extends Component {
     return secretData
       .save()
       .then(() => {
+        if (!this.args.canReadSecretData) {
+          delete secret.selectedVersion.secretData;
+        }
         if (!secretData.isError) {
           if (isV2) {
             secret.set('id', key);
@@ -201,6 +204,7 @@ export default class SecretCreateOrUpdate extends Component {
   @action
   addRow() {
     const data = this.args.secretData;
+
     // fired off on init
     if (isNone(data.findBy('name', ''))) {
       data.pushObject({ name: '', value: '' });

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -192,7 +192,7 @@
               <div class="column is-one-quarter">
                 <Input
                   data-test-secret-key={{true}}
-                  @value={{if (eq @canReadSecretData true) secret.name}}
+                  @value={{secret.name}}
                   placeholder="key"
                   {{on "change" (action "handleChange")}}
                   class="input"
@@ -205,7 +205,7 @@
                   @name={{secret.name}}
                   @onKeyDown={{action "handleKeyDown"}}
                   @onChange={{action "handleChange"}}
-                  @value={{if (eq @canReadSecretData true) secret.value}}
+                  @value={{secret.value}}
                   data-test-secret-value="true"
                 />
               </div>

--- a/ui/app/templates/components/secret-create-or-update.hbs
+++ b/ui/app/templates/components/secret-create-or-update.hbs
@@ -192,7 +192,7 @@
               <div class="column is-one-quarter">
                 <Input
                   data-test-secret-key={{true}}
-                  @value={{secret.name}}
+                  @value={{if (eq @canReadSecretData true) secret.name}}
                   placeholder="key"
                   {{on "change" (action "handleChange")}}
                   class="input"
@@ -205,7 +205,7 @@
                   @name={{secret.name}}
                   @onKeyDown={{action "handleKeyDown"}}
                   @onChange={{action "handleChange"}}
-                  @value={{secret.value}}
+                  @value={{if (eq @canReadSecretData true) secret.value}}
                   data-test-secret-value="true"
                 />
               </div>


### PR DESCRIPTION
This is a bug fix for when a user without **read** capabilities (but has **update**), creates a new version of a secret, then goes back to the previous version and clicks "Create new version+" and the recently created secret is populated in the form fields. Even though the user doesn't have read access - it was cached in the browser from the put request when the user updated the secret 