### PR TITLE
sdk/useragent: adds optional ability to set additional comments

### DIFF
--- a/sdk/helper/useragent/useragent.go
+++ b/sdk/helper/useragent/useragent.go
@@ -26,22 +26,39 @@ var (
 // String returns the consistent user-agent string for Vault.
 //
 // e.g. Vault/0.10.4 (+https://www.vaultproject.io/; go1.10.1)
-func String() string {
-	return fmt.Sprintf("Vault/%s (+%s; %s)",
-		versionFunc(), projectURL, rt)
+//
+// Given comments will be appended to the semicolon-delimited comment section.
+//
+// e.g. Vault/0.10.4 (+https://www.vaultproject.io/; go1.10.1; comment-0; comment-1)
+func String(comments ...string) string {
+	ua := fmt.Sprintf("Vault/%s (+%s; %s", versionFunc(), projectURL, rt)
+
+	for _, c := range comments {
+		ua = fmt.Sprintf("%s; %s", ua, c)
+	}
+
+	return fmt.Sprintf("%s)", ua)
 }
 
 // PluginString is usable by plugins to return a user-agent string reflecting
 // the running Vault version and an optional plugin name.
 //
 // e.g. Vault/0.10.4 (+https://www.vaultproject.io/; azure-auth; go1.10.1)
-func PluginString(env *logical.PluginEnvironment, pluginName string) string {
+//
+// Given comments will be appended to the semicolon-delimited comment section.
+//
+// e.g. Vault/0.10.4 (+https://www.vaultproject.io/; azure-auth; go1.10.1; comment-0; comment-1)
+func PluginString(env *logical.PluginEnvironment, pluginName string, comments ...string) string {
 	var name string
-
 	if pluginName != "" {
 		name = pluginName + "; "
 	}
 
-	return fmt.Sprintf("Vault/%s (+%s; %s%s)",
-		env.VaultVersion, projectURL, name, rt)
+	ua := fmt.Sprintf("Vault/%s (+%s; %s%s", env.VaultVersion, projectURL, name, rt)
+
+	for _, c := range comments {
+		ua = fmt.Sprintf("%s; %s", ua, c)
+	}
+
+	return fmt.Sprintf("%s)", ua)
 }

--- a/sdk/helper/useragent/useragent.go
+++ b/sdk/helper/useragent/useragent.go
@@ -3,6 +3,7 @@ package useragent
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/sdk/version"
@@ -31,13 +32,13 @@ var (
 //
 // e.g. Vault/0.10.4 (+https://www.vaultproject.io/; go1.10.1; comment-0; comment-1)
 func String(comments ...string) string {
-	ua := fmt.Sprintf("Vault/%s (+%s; %s", versionFunc(), projectURL, rt)
-
-	for _, c := range comments {
-		ua = fmt.Sprintf("%s; %s", ua, c)
+	c := strings.Join(comments, "; ")
+	if len(c) > 0 {
+		c = "; " + c
 	}
 
-	return fmt.Sprintf("%s)", ua)
+	return fmt.Sprintf("Vault/%s (+%s; %s%s)",
+		versionFunc(), projectURL, rt, c)
 }
 
 // PluginString is usable by plugins to return a user-agent string reflecting
@@ -54,11 +55,11 @@ func PluginString(env *logical.PluginEnvironment, pluginName string, comments ..
 		name = pluginName + "; "
 	}
 
-	ua := fmt.Sprintf("Vault/%s (+%s; %s%s", env.VaultVersion, projectURL, name, rt)
-
-	for _, c := range comments {
-		ua = fmt.Sprintf("%s; %s", ua, c)
+	c := strings.Join(comments, "; ")
+	if len(c) > 0 {
+		c = "; " + c
 	}
 
-	return fmt.Sprintf("%s)", ua)
+	return fmt.Sprintf("Vault/%s (+%s; %s%s%s)",
+		env.VaultVersion, projectURL, name, rt, c)
 }

--- a/sdk/helper/useragent/useragent.go
+++ b/sdk/helper/useragent/useragent.go
@@ -32,13 +32,8 @@ var (
 //
 // e.g. Vault/0.10.4 (+https://www.vaultproject.io/; go1.10.1; comment-0; comment-1)
 func String(comments ...string) string {
-	c := strings.Join(comments, "; ")
-	if len(c) > 0 {
-		c = "; " + c
-	}
-
-	return fmt.Sprintf("Vault/%s (+%s; %s%s)",
-		versionFunc(), projectURL, rt, c)
+	c := append([]string{"+" + projectURL, rt}, comments...)
+	return fmt.Sprintf("Vault/%s (%s)", versionFunc(), strings.Join(c, "; "))
 }
 
 // PluginString is usable by plugins to return a user-agent string reflecting
@@ -50,16 +45,11 @@ func String(comments ...string) string {
 //
 // e.g. Vault/0.10.4 (+https://www.vaultproject.io/; azure-auth; go1.10.1; comment-0; comment-1)
 func PluginString(env *logical.PluginEnvironment, pluginName string, comments ...string) string {
-	var name string
+	c := []string{"+" + projectURL}
 	if pluginName != "" {
-		name = pluginName + "; "
+		c = append(c, pluginName)
 	}
-
-	c := strings.Join(comments, "; ")
-	if len(c) > 0 {
-		c = "; " + c
-	}
-
-	return fmt.Sprintf("Vault/%s (+%s; %s%s%s)",
-		env.VaultVersion, projectURL, name, rt, c)
+	c = append(c, rt)
+	c = append(c, comments...)
+	return fmt.Sprintf("Vault/%s (%s)", env.VaultVersion, strings.Join(c, "; "))
 }

--- a/sdk/helper/useragent/useragent_test.go
+++ b/sdk/helper/useragent/useragent_test.go
@@ -11,11 +11,40 @@ func TestUserAgent(t *testing.T) {
 	rt = "go5.0"
 	versionFunc = func() string { return "1.2.3" }
 
-	act := String()
-
-	exp := "Vault/1.2.3 (+https://vault-test.com; go5.0)"
-	if exp != act {
-		t.Errorf("expected %q to be %q", act, exp)
+	type args struct {
+		comments []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "User agent",
+			args: args{},
+			want: "Vault/1.2.3 (+https://vault-test.com; go5.0)",
+		},
+		{
+			name: "User agent with additional comment",
+			args: args{
+				comments: []string{"pid-abcdefg"},
+			},
+			want: "Vault/1.2.3 (+https://vault-test.com; go5.0; pid-abcdefg)",
+		},
+		{
+			name: "User agent with additional comments",
+			args: args{
+				comments: []string{"pid-abcdefg", "cloud-provider"},
+			},
+			want: "Vault/1.2.3 (+https://vault-test.com; go5.0; pid-abcdefg; cloud-provider)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := String(tt.args.comments...); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -25,20 +54,57 @@ func TestUserAgentPlugin(t *testing.T) {
 	env := &logical.PluginEnvironment{
 		VaultVersion: "1.2.3",
 	}
-	pluginName := "azure-auth"
 
-	act := PluginString(env, pluginName)
-
-	exp := "Vault/1.2.3 (+https://vault-test.com; azure-auth; go5.0)"
-	if exp != act {
-		t.Errorf("expected %q to be %q", act, exp)
+	type args struct {
+		pluginName string
+		comments   []string
 	}
-
-	pluginName = ""
-	act = PluginString(env, pluginName)
-
-	exp = "Vault/1.2.3 (+https://vault-test.com; go5.0)"
-	if exp != act {
-		t.Errorf("expected %q to be %q", act, exp)
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Plugin user agent without plugin name",
+			args: args{},
+			want: "Vault/1.2.3 (+https://vault-test.com; go5.0)",
+		},
+		{
+			name: "Plugin user agent with plugin name",
+			args: args{
+				pluginName: "azure-auth",
+			},
+			want: "Vault/1.2.3 (+https://vault-test.com; azure-auth; go5.0)",
+		},
+		{
+			name: "Plugin user agent with plugin name and additional comment",
+			args: args{
+				pluginName: "azure-auth",
+				comments:   []string{"pid-abcdefg"},
+			},
+			want: "Vault/1.2.3 (+https://vault-test.com; azure-auth; go5.0; pid-abcdefg)",
+		},
+		{
+			name: "Plugin user agent with plugin name and additional comments",
+			args: args{
+				pluginName: "azure-auth",
+				comments:   []string{"pid-abcdefg", "cloud-provider"},
+			},
+			want: "Vault/1.2.3 (+https://vault-test.com; azure-auth; go5.0; pid-abcdefg; cloud-provider)",
+		},
+		{
+			name: "Plugin user agent with no plugin name and additional comments",
+			args: args{
+				comments: []string{"pid-abcdefg", "cloud-provider"},
+			},
+			want: "Vault/1.2.3 (+https://vault-test.com; go5.0; pid-abcdefg; cloud-provider)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PluginString(env, tt.args.pluginName, tt.args.comments...); got != tt.want {
+				t.Errorf("PluginString() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR adds the ability to set additional comments in Vault's user agent string from the `useragent` package. The new comments parameter is variadic, so it shouldn't break API compatibility for the package.

The motivation for this change is to clean up code in plugins that need to add additional comments. For example, we currently add partner IDs in [vault-plugin-auth-azure](https://github.com/hashicorp/vault-plugin-auth-azure/blob/main/util.go#L54) and [vault-plugin-secrets-azure](https://github.com/hashicorp/vault-plugin-secrets-azure/blob/main/provider.go#L118) for usage attribution. Without this change, adding the additional comments requires assumptions about the format and string replacement.

I've improved the tests by turning them into table tests and adding additional coverage.