### PR TITLE
Handle resolving key, issuer references

### DIFF
--- a/builtin/logical/pki/managed_key_util.go
+++ b/builtin/logical/pki/managed_key_util.go
@@ -32,6 +32,6 @@ func parseCABundle(_ context.Context, _ *backend, _ *logical.Request, bundle *ce
 	return bundle.ToParsedCertBundle()
 }
 
-func withManagedPKIKey(_ context.Context, _ *backend, _ keyId, _ string, _ logical.ManagedSigningKeyConsumer) error {
+func withManagedPKIKey(_ context.Context, _ *backend, _ managedKeyId, _ string, _ logical.ManagedSigningKeyConsumer) error {
 	return errEntOnly
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -10,63 +10,65 @@ import (
 )
 
 const (
-	pkiKeyPrefix    = "/config/key/"
-	pkiIssuerPrefix = "/config/issuer/"
+	keyPrefix    = "/config/key/"
+	issuerPrefix = "/config/issuer/"
 )
 
 var (
-	emptyPkiKey = pkiKey{}
-	emptyIssuer = pkiIssuer{}
+	emptyKey        = key{}
+	emptyIssuer     = issuer{}
+	emptyCertBundle = certutil.CertBundle{}
 )
 
-type pkiKeyId string
+type keyId string
 
-func (p pkiKeyId) String() string {
+func (p keyId) String() string {
 	return string(p)
 }
 
-type pkiIssuerId string
+type issuerId string
 
-func (p pkiIssuerId) String() string {
+func (p issuerId) String() string {
 	return string(p)
 }
 
-type pkiKey struct {
-	ID             pkiKeyId                `json:"id" structs:"id" mapstructure:"id"`
+type key struct {
+	ID             keyId                   `json:"id" structs:"id" mapstructure:"id"`
 	PrivateKeyType certutil.PrivateKeyType `json:"private_key_type" structs:"private_key_type" mapstructure:"private_key_type"`
 	PrivateKey     string                  `json:"private_key" structs:"private_key" mapstructure:"private_key"`
 }
 
-type pkiIssuer struct {
-	ID           pkiIssuerId `json:"id" structs:"id" mapstructure:"id"`
-	PKIKeyID     pkiKeyId    `json:"pki_key_id" structs:"pki_key_id" mapstructure:"pki_key_id"`
-	Certificate  string      `json:"certificate" structs:"certificate" mapstructure:"certificate"`
-	CAChain      []string    `json:"ca_chain" structs:"ca_chain" mapstructure:"ca_chain"`
-	SerialNumber string      `json:"serial_number" structs:"serial_number" mapstructure:"serial_number"`
+type issuer struct {
+	ID           issuerId `json:"id" structs:"id" mapstructure:"id"`
+	Name         string   `json:"name" structs:"name" mapstructure:"name"`
+	KeyID        keyId    `json:"key_id" structs:"key_id" mapstructure:"key_id"`
+	Certificate  string   `json:"certificate" structs:"certificate" mapstructure:"certificate"`
+	CAChain      []string `json:"ca_chain" structs:"ca_chain" mapstructure:"ca_chain"`
+	SerialNumber string   `json:"serial_number" structs:"serial_number" mapstructure:"serial_number"`
 }
 
-func fetchPKIKeyById(ctx context.Context, s logical.Storage, keyId pkiKeyId) (pkiKey, error) {
-	keyEntry, err := s.Get(ctx, pkiKeyPrefix+keyId.String())
+func fetchKeyById(ctx context.Context, s logical.Storage, keyId keyId) (key, error) {
+	keyEntry, err := s.Get(ctx, keyPrefix+keyId.String())
 	if err != nil {
-		return emptyPkiKey, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki key: %v", err)}
+		return emptyKey, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki key: %v", err)}
 	}
 	if keyEntry == nil {
 		// FIXME: Dedicated/specific error for this?
-		return emptyPkiKey, errutil.UserError{Err: fmt.Sprintf("pki key id %s does not exist", keyId.String())}
+		return emptyKey, errutil.UserError{Err: fmt.Sprintf("pki key id %s does not exist", keyId.String())}
 	}
 
-	var pkiKey pkiKey
-	if err := keyEntry.DecodeJSON(&pkiKey); err != nil {
-		return emptyPkiKey, errutil.InternalError{Err: fmt.Sprintf("unable to decode pki key with id %s: %v", keyId.String(), err)}
+	var key key
+	if err := keyEntry.DecodeJSON(&key); err != nil {
+		return emptyKey, errutil.InternalError{Err: fmt.Sprintf("unable to decode pki key with id %s: %v", keyId.String(), err)}
 	}
 
-	return pkiKey, nil
+	return key, nil
 }
 
-func writePKIKey(ctx context.Context, s logical.Storage, pkiKey pkiKey) error {
-	keyId := pkiKey.ID
+func writeKey(ctx context.Context, s logical.Storage, key key) error {
+	keyId := key.ID
 
-	json, err := logical.StorageEntryJSON(pkiKeyPrefix+keyId.String(), pkiKey)
+	json, err := logical.StorageEntryJSON(keyPrefix+keyId.String(), key)
 	if err != nil {
 		return err
 	}
@@ -74,8 +76,8 @@ func writePKIKey(ctx context.Context, s logical.Storage, pkiKey pkiKey) error {
 	return s.Put(ctx, json)
 }
 
-func fetchPKIIssuerById(ctx context.Context, s logical.Storage, issuerId pkiIssuerId) (pkiIssuer, error) {
-	issuerEntry, err := s.Get(ctx, pkiIssuerPrefix+issuerId.String())
+func fetchIssuerById(ctx context.Context, s logical.Storage, issuerId issuerId) (issuer, error) {
+	issuerEntry, err := s.Get(ctx, issuerPrefix+issuerId.String())
 	if err != nil {
 		return emptyIssuer, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki issuer: %v", err)}
 	}
@@ -84,21 +86,45 @@ func fetchPKIIssuerById(ctx context.Context, s logical.Storage, issuerId pkiIssu
 		return emptyIssuer, errutil.UserError{Err: fmt.Sprintf("pki issuer id %s does not exist", issuerId.String())}
 	}
 
-	var pkiIssuer pkiIssuer
-	if err := issuerEntry.DecodeJSON(&pkiIssuer); err != nil {
+	var issuer issuer
+	if err := issuerEntry.DecodeJSON(&issuer); err != nil {
 		return emptyIssuer, errutil.InternalError{Err: fmt.Sprintf("unable to decode pki issuer with id %s: %v", issuerId.String(), err)}
 	}
 
-	return pkiIssuer, nil
+	return issuer, nil
 }
 
-func writePKIIssuer(ctx context.Context, s logical.Storage, pkiIssuer pkiIssuer) error {
-	issuerId := pkiIssuer.ID
+func writeIssuer(ctx context.Context, s logical.Storage, issuer issuer) error {
+	issuerId := issuer.ID
 
-	json, err := logical.StorageEntryJSON(pkiIssuerPrefix+issuerId.String(), pkiIssuer)
+	json, err := logical.StorageEntryJSON(issuerPrefix+issuerId.String(), issuer)
 	if err != nil {
 		return err
 	}
 
 	return s.Put(ctx, json)
+}
+
+func fetchCertBundleByIssuerId(ctx context.Context, s logical.Storage, issuerId issuerId) (certutil.CertBundle, error) {
+	issuer, err := fetchIssuerById(ctx, s, issuerId)
+	if err != nil {
+		return emptyCertBundle, err
+	}
+
+	if issuer.KeyID == "" {
+		return emptyCertBundle, errutil.UserError{Err: fmt.Sprintf("requested a cert bundle for an issuer id %s that did not contain a key", issuerId.String())}
+	}
+
+	key, err := fetchKeyById(ctx, s, issuer.KeyID)
+	if err != nil {
+		return emptyCertBundle, err
+	}
+	return certutil.CertBundle{
+		PrivateKeyType: key.PrivateKeyType,
+		Certificate:    issuer.Certificate,
+		IssuingCA:      issuer.CAChain[0],
+		CAChain:        issuer.CAChain,
+		PrivateKey:     key.PrivateKey,
+		SerialNumber:   issuer.SerialNumber,
+	}, nil
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -253,3 +253,31 @@ func resolveIssuerReference(ctx context.Context, s logical.Storage, reference st
 	// Otherwise, we must not have found the issuer.
 	return issuerId("not-found"), errutil.UserError{Err: fmt.Sprintf("unable to find PKI issuer for reference: %v", reference)}
 }
+
+// Builds a certutil.CertBundle from the specified issuer identifier,
+// optionally loading the key or not.
+func fetchCertBundleByIssuerId(ctx context.Context, s logical.Storage, id issuerId, loadKey bool) (*certutil.CertBundle, error) {
+	issuer, err := fetchIssuerById(ctx, s, id)
+	if err != nil {
+		return nil, err
+	}
+
+	var bundle certutil.CertBundle
+	bundle.Certificate = issuer.Certificate
+	bundle.IssuingCA = issuer.CAChain[0]
+	bundle.CAChain = issuer.CAChain
+	bundle.SerialNumber = issuer.SerialNumber
+
+	// Fetch the key if it exists. Sometimes we don't need the key immediately.
+	if loadKey && issuer.KeyID != keyId("") {
+		key, err := fetchKeyById(ctx, s, issuer.KeyID)
+		if err != nil {
+			return nil, err
+		}
+
+		bundle.PrivateKeyType = key.PrivateKeyType
+		bundle.PrivateKey = key.PrivateKey
+	}
+
+	return &bundle, nil
+}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -41,6 +41,20 @@ type issuer struct {
 	SerialNumber string   `json:"serial_number" structs:"serial_number" mapstructure:"serial_number"`
 }
 
+func listKeys(ctx context.Context, s logical.Storage) ([]keyId, error) {
+	strList, err := s.List(ctx, keyPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	keyIds := make([]keyId, 0, len(strList))
+	for _, entry := range strList {
+		keyIds = append(keyIds, keyId(entry))
+	}
+
+	return keyIds, nil
+}
+
 func fetchKeyById(ctx context.Context, s logical.Storage, keyId keyId) (*key, error) {
 	keyEntry, err := s.Get(ctx, keyPrefix+keyId.String())
 	if err != nil {
@@ -68,6 +82,20 @@ func writeKey(ctx context.Context, s logical.Storage, key key) error {
 	}
 
 	return s.Put(ctx, json)
+}
+
+func listIssuers(ctx context.Context, s logical.Storage) ([]issuerId, error) {
+	strList, err := s.List(ctx, issuerPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	issuerIds := make([]issuerId, 0, len(strList))
+	for _, entry := range strList {
+		issuerIds = append(issuerIds, issuerId(entry))
+	}
+
+	return issuerIds, nil
 }
 
 func fetchIssuerById(ctx context.Context, s logical.Storage, issuerId issuerId) (*issuer, error) {

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -1,0 +1,104 @@
+package pki
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/helper/errutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	pkiKeyPrefix    = "/config/key/"
+	pkiIssuerPrefix = "/config/issuer/"
+)
+
+var (
+	emptyPkiKey = pkiKey{}
+	emptyIssuer = pkiIssuer{}
+)
+
+type pkiKeyId string
+
+func (p pkiKeyId) String() string {
+	return string(p)
+}
+
+type pkiIssuerId string
+
+func (p pkiIssuerId) String() string {
+	return string(p)
+}
+
+type pkiKey struct {
+	ID             pkiKeyId                `json:"id" structs:"id" mapstructure:"id"`
+	PrivateKeyType certutil.PrivateKeyType `json:"private_key_type" structs:"private_key_type" mapstructure:"private_key_type"`
+	PrivateKey     string                  `json:"private_key" structs:"private_key" mapstructure:"private_key"`
+}
+
+type pkiIssuer struct {
+	ID           pkiIssuerId `json:"id" structs:"id" mapstructure:"id"`
+	PKIKeyID     pkiKeyId    `json:"pki_key_id" structs:"pki_key_id" mapstructure:"pki_key_id"`
+	Certificate  string      `json:"certificate" structs:"certificate" mapstructure:"certificate"`
+	CAChain      []string    `json:"ca_chain" structs:"ca_chain" mapstructure:"ca_chain"`
+	SerialNumber string      `json:"serial_number" structs:"serial_number" mapstructure:"serial_number"`
+}
+
+func fetchPKIKeyById(ctx context.Context, s logical.Storage, keyId pkiKeyId) (pkiKey, error) {
+	keyEntry, err := s.Get(ctx, pkiKeyPrefix+keyId.String())
+	if err != nil {
+		return emptyPkiKey, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki key: %v", err)}
+	}
+	if keyEntry == nil {
+		// FIXME: Dedicated/specific error for this?
+		return emptyPkiKey, errutil.UserError{Err: fmt.Sprintf("pki key id %s does not exist", keyId.String())}
+	}
+
+	var pkiKey pkiKey
+	if err := keyEntry.DecodeJSON(&pkiKey); err != nil {
+		return emptyPkiKey, errutil.InternalError{Err: fmt.Sprintf("unable to decode pki key with id %s: %v", keyId.String(), err)}
+	}
+
+	return pkiKey, nil
+}
+
+func writePKIKey(ctx context.Context, s logical.Storage, pkiKey pkiKey) error {
+	keyId := pkiKey.ID
+
+	json, err := logical.StorageEntryJSON(pkiKeyPrefix+keyId.String(), pkiKey)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, json)
+}
+
+func fetchPKIIssuerById(ctx context.Context, s logical.Storage, issuerId pkiIssuerId) (pkiIssuer, error) {
+	issuerEntry, err := s.Get(ctx, pkiIssuerPrefix+issuerId.String())
+	if err != nil {
+		return emptyIssuer, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki issuer: %v", err)}
+	}
+	if issuerEntry == nil {
+		// FIXME: Dedicated/specific error for this?
+		return emptyIssuer, errutil.UserError{Err: fmt.Sprintf("pki issuer id %s does not exist", issuerId.String())}
+	}
+
+	var pkiIssuer pkiIssuer
+	if err := issuerEntry.DecodeJSON(&pkiIssuer); err != nil {
+		return emptyIssuer, errutil.InternalError{Err: fmt.Sprintf("unable to decode pki issuer with id %s: %v", issuerId.String(), err)}
+	}
+
+	return pkiIssuer, nil
+}
+
+func writePKIIssuer(ctx context.Context, s logical.Storage, pkiIssuer pkiIssuer) error {
+	issuerId := pkiIssuer.ID
+
+	json, err := logical.StorageEntryJSON(pkiIssuerPrefix+issuerId.String(), pkiIssuer)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, json)
+}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -30,6 +30,7 @@ func (p issuerId) String() string {
 
 type key struct {
 	ID             keyId                   `json:"id" structs:"id" mapstructure:"id"`
+	Name           string                  `json:"name" structs:"name" mapstructure:"name"`
 	PrivateKeyType certutil.PrivateKeyType `json:"private_key_type" structs:"private_key_type" mapstructure:"private_key_type"`
 	PrivateKey     string                  `json:"private_key" structs:"private_key" mapstructure:"private_key"`
 }
@@ -98,6 +99,45 @@ func listIssuers(ctx context.Context, s logical.Storage) ([]issuerId, error) {
 	}
 
 	return issuerIds, nil
+}
+
+func resolveKeyReference(ctx context.Context, s logical.Storage, reference string) (keyId, error) {
+	if reference == "default" {
+		// Handle fetching the default key.
+		config, err := getKeysConfig(ctx, s)
+		if err != nil {
+			return keyId("config-error"), err
+		}
+
+		return keyId(config["default"]), nil
+	}
+
+	keys, err := listKeys(ctx, s)
+	if err != nil {
+		return keyId("list-error"), err
+	}
+
+	// Cheaper to list keys and check if an id is a match...
+	for _, key_id := range keys {
+		if key_id == keyId(reference) {
+			return key_id, nil
+		}
+	}
+
+	// ... than to pull all keys from storage.
+	for _, key_id := range keys {
+		key, err := fetchKeyById(ctx, s, key_id)
+		if err != nil {
+			return keyId("key-read"), err
+		}
+
+		if key.Name == reference {
+			return key.ID, nil
+		}
+	}
+
+	// Otherwise, we must not have found the key.
+	return keyId("not-found"), errutil.UserError{Err: fmt.Sprintf("unable to find PKI key for reference: %v", reference)}
 }
 
 func fetchIssuerById(ctx context.Context, s logical.Storage, issuerId issuerId) (*issuer, error) {
@@ -173,4 +213,43 @@ func getIssuersConfig(ctx context.Context, s logical.Storage) (map[string]issuer
 	}
 
 	return issuerConfig, nil
+}
+
+func resolveIssuerReference(ctx context.Context, s logical.Storage, reference string) (issuerId, error) {
+	if reference == "default" {
+		// Handle fetching the default issuer.
+		config, err := getIssuersConfig(ctx, s)
+		if err != nil {
+			return issuerId("config-error"), err
+		}
+
+		return issuerId(config["default"]), nil
+	}
+
+	issuers, err := listIssuers(ctx, s)
+	if err != nil {
+		return issuerId("list-error"), err
+	}
+
+	// Cheaper to list issuers and check if an id is a match...
+	for _, issuer_id := range issuers {
+		if issuer_id == issuerId(reference) {
+			return issuer_id, nil
+		}
+	}
+
+	// ... than to pull all issuers from storage.
+	for _, issuer_id := range issuers {
+		issuer, err := fetchIssuerById(ctx, s, issuer_id)
+		if err != nil {
+			return issuerId("issuer-read"), err
+		}
+
+		if issuer.Name == reference {
+			return issuer.ID, nil
+		}
+	}
+
+	// Otherwise, we must not have found the issuer.
+	return issuerId("not-found"), errutil.UserError{Err: fmt.Sprintf("unable to find PKI issuer for reference: %v", reference)}
 }

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -10,6 +10,8 @@ import (
 )
 
 const (
+	keyConfig    = "/config/keys"
+	issuerConfig = "/config/issuers"
 	keyPrefix    = "/config/key/"
 	issuerPrefix = "/config/issuer/"
 )
@@ -127,3 +129,48 @@ func writeIssuer(ctx context.Context, s logical.Storage, issuer issuer) error {
 	return s.Put(ctx, json)
 }
 
+func setKeysConfig(ctx context.Context, s logical.Storage, config map[string]keyId) error {
+	json, err := logical.StorageEntryJSON(keyConfig, config)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, json)
+}
+
+func getKeysConfig(ctx context.Context, s logical.Storage) (map[string]keyId, error) {
+	keyConfigEntry, err := s.Get(ctx, keyConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	var keyConfig map[string]keyId
+	if err := keyConfigEntry.DecodeJSON(&keyConfig); err != nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to decode key configuration: %v", err)}
+	}
+
+	return keyConfig, nil
+}
+
+func setIssuersConfig(ctx context.Context, s logical.Storage, config map[string]issuerId) error {
+	json, err := logical.StorageEntryJSON(issuerConfig, config)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, json)
+}
+
+func getIssuersConfig(ctx context.Context, s logical.Storage) (map[string]issuerId, error) {
+	issuerConfigEntry, err := s.Get(ctx, issuerConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	var issuerConfig map[string]issuerId
+	if err := issuerConfigEntry.DecodeJSON(&issuerConfig); err != nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to decode issuer configuration: %v", err)}
+	}
+
+	return issuerConfig, nil
+}

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -19,47 +19,47 @@ func Test_PKIIssuerRoundTrip(t *testing.T) {
 	pkiIssuer, pkiKey := genIssuerAndKey(t, b)
 
 	// We get an error when issuer id not found
-	_, err := fetchPKIIssuerById(ctx, s, pkiIssuer.ID)
+	_, err := fetchIssuerById(ctx, s, pkiIssuer.ID)
 	require.Error(t, err)
 
-	// We get an error when pkiKey id not found
-	_, err = fetchPKIKeyById(ctx, s, pkiKey.ID)
+	// We get an error when key id not found
+	_, err = fetchKeyById(ctx, s, pkiKey.ID)
 	require.Error(t, err)
 
 	// Now write out our issuer and key
-	err = writePKIKey(ctx, s, pkiKey)
+	err = writeKey(ctx, s, pkiKey)
 	require.NoError(t, err)
-	err = writePKIIssuer(ctx, s, pkiIssuer)
-	require.NoError(t, err)
-
-	pkiKey2, err := fetchPKIKeyById(ctx, s, pkiKey.ID)
+	err = writeIssuer(ctx, s, pkiIssuer)
 	require.NoError(t, err)
 
-	pkiIssuer2, err := fetchPKIIssuerById(ctx, s, pkiIssuer.ID)
+	pkiKey2, err := fetchKeyById(ctx, s, pkiKey.ID)
+	require.NoError(t, err)
+
+	pkiIssuer2, err := fetchIssuerById(ctx, s, pkiIssuer.ID)
 	require.NoError(t, err)
 
 	require.Equal(t, pkiKey, pkiKey2)
 	require.Equal(t, pkiIssuer, pkiIssuer2)
 }
 
-func genIssuerAndKey(t *testing.T, b *backend) (pkiIssuer, pkiKey) {
+func genIssuerAndKey(t *testing.T, b *backend) (issuer, key) {
 	certBundle, err := genCertBundle(t, b)
 
-	keyId, err := uuid.GenerateUUID()
+	keyIdStr, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 
-	pkiKey := pkiKey{
-		ID:             pkiKeyId(keyId),
+	pkiKey := key{
+		ID:             keyId(keyIdStr),
 		PrivateKeyType: certBundle.PrivateKeyType,
 		PrivateKey:     certBundle.PrivateKey,
 	}
 
-	issuerId, err := uuid.GenerateUUID()
+	issuerIdStr, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 
-	pkiIssuer := pkiIssuer{
-		ID:           pkiIssuerId(issuerId),
-		PKIKeyID:     pkiKeyId(keyId),
+	pkiIssuer := issuer{
+		ID:           issuerId(issuerIdStr),
+		KeyID:        keyId(keyIdStr),
 		Certificate:  certBundle.Certificate,
 		CAChain:      certBundle.CAChain,
 		SerialNumber: certBundle.SerialNumber,

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -14,7 +14,7 @@ import (
 
 var ctx = context.Background()
 
-func Test_PKIIssuerRoundTrip(t *testing.T) {
+func Test_IssuerRoundTrip(t *testing.T) {
 	b, s := createBackendWithStorage(t)
 	pkiIssuer, pkiKey := genIssuerAndKey(t, b)
 
@@ -38,8 +38,8 @@ func Test_PKIIssuerRoundTrip(t *testing.T) {
 	pkiIssuer2, err := fetchIssuerById(ctx, s, pkiIssuer.ID)
 	require.NoError(t, err)
 
-	require.Equal(t, pkiKey, pkiKey2)
-	require.Equal(t, pkiIssuer, pkiIssuer2)
+	require.Equal(t, &pkiKey, pkiKey2)
+	require.Equal(t, &pkiIssuer, pkiIssuer2)
 }
 
 func genIssuerAndKey(t *testing.T, b *backend) (issuer, key) {

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -14,6 +14,38 @@ import (
 
 var ctx = context.Background()
 
+func Test_KeyConfigRoundTrip(t *testing.T) {
+	_, s := createBackendWithStorage(t)
+
+	origConfig := map[string]keyId{
+		"default": genKeyId(t),
+	}
+
+	err := setKeysConfig(ctx, s, origConfig)
+	require.NoError(t, err)
+
+	config, err := getKeysConfig(ctx, s)
+	require.NoError(t, err)
+
+	require.Equal(t, origConfig, config)
+}
+
+func Test_IssuerConfigRoundTrip(t *testing.T) {
+	_, s := createBackendWithStorage(t)
+
+	origConfig := map[string]issuerId{
+		"default": genIssuerId(t),
+	}
+
+	err := setIssuersConfig(ctx, s, origConfig)
+	require.NoError(t, err)
+
+	config, err := getIssuersConfig(ctx, s)
+	require.NoError(t, err)
+
+	require.Equal(t, origConfig, config)
+}
+
 func Test_IssuerRoundTrip(t *testing.T) {
 	b, s := createBackendWithStorage(t)
 	issuer1, key1 := genIssuerAndKey(t, b)
@@ -60,28 +92,39 @@ func Test_IssuerRoundTrip(t *testing.T) {
 
 func genIssuerAndKey(t *testing.T, b *backend) (issuer, key) {
 	certBundle, err := genCertBundle(t, b)
-
-	keyIdStr, err := uuid.GenerateUUID()
 	require.NoError(t, err)
 
+	keyId := genKeyId(t)
+
 	pkiKey := key{
-		ID:             keyId(keyIdStr),
+		ID:             keyId,
 		PrivateKeyType: certBundle.PrivateKeyType,
 		PrivateKey:     certBundle.PrivateKey,
 	}
 
-	issuerIdStr, err := uuid.GenerateUUID()
-	require.NoError(t, err)
+	issuerId := genIssuerId(t)
 
 	pkiIssuer := issuer{
-		ID:           issuerId(issuerIdStr),
-		KeyID:        keyId(keyIdStr),
+		ID:           issuerId,
+		KeyID:        keyId,
 		Certificate:  certBundle.Certificate,
 		CAChain:      certBundle.CAChain,
 		SerialNumber: certBundle.SerialNumber,
 	}
 
 	return pkiIssuer, pkiKey
+}
+
+func genIssuerId(t *testing.T) issuerId {
+	issuerIdStr, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	return issuerId(issuerIdStr)
+}
+
+func genKeyId(t *testing.T) keyId {
+	keyIdStr, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	return keyId(keyIdStr)
 }
 
 func genCertBundle(t *testing.T, b *backend) (*certutil.CertBundle, error) {

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -1,0 +1,102 @@
+package pki
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+)
+
+var ctx = context.Background()
+
+func Test_PKIIssuerRoundTrip(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+	pkiIssuer, pkiKey := genIssuerAndKey(t, b)
+
+	// We get an error when issuer id not found
+	_, err := fetchPKIIssuerById(ctx, s, pkiIssuer.ID)
+	require.Error(t, err)
+
+	// We get an error when pkiKey id not found
+	_, err = fetchPKIKeyById(ctx, s, pkiKey.ID)
+	require.Error(t, err)
+
+	// Now write out our issuer and key
+	err = writePKIKey(ctx, s, pkiKey)
+	require.NoError(t, err)
+	err = writePKIIssuer(ctx, s, pkiIssuer)
+	require.NoError(t, err)
+
+	pkiKey2, err := fetchPKIKeyById(ctx, s, pkiKey.ID)
+	require.NoError(t, err)
+
+	pkiIssuer2, err := fetchPKIIssuerById(ctx, s, pkiIssuer.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, pkiKey, pkiKey2)
+	require.Equal(t, pkiIssuer, pkiIssuer2)
+}
+
+func genIssuerAndKey(t *testing.T, b *backend) (pkiIssuer, pkiKey) {
+	certBundle, err := genCertBundle(t, b)
+
+	keyId, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+
+	pkiKey := pkiKey{
+		ID:             pkiKeyId(keyId),
+		PrivateKeyType: certBundle.PrivateKeyType,
+		PrivateKey:     certBundle.PrivateKey,
+	}
+
+	issuerId, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+
+	pkiIssuer := pkiIssuer{
+		ID:           pkiIssuerId(issuerId),
+		PKIKeyID:     pkiKeyId(keyId),
+		Certificate:  certBundle.Certificate,
+		CAChain:      certBundle.CAChain,
+		SerialNumber: certBundle.SerialNumber,
+	}
+
+	return pkiIssuer, pkiKey
+}
+
+func genCertBundle(t *testing.T, b *backend) (*certutil.CertBundle, error) {
+	// Pretty gross just to generate a cert bundle, but
+	fields := addCACommonFields(map[string]*framework.FieldSchema{})
+	fields = addCAKeyGenerationFields(fields)
+	fields = addCAIssueFields(fields)
+	apiData := &framework.FieldData{
+		Schema: fields,
+		Raw: map[string]interface{}{
+			"exported": "internal",
+			"cn":       "example.com",
+			"ttl":      3600,
+		},
+	}
+	_, _, role, respErr := b.getGenerationParams(ctx, apiData, "/pki")
+	require.Nil(t, respErr)
+
+	input := &inputBundle{
+		req: &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "issue/testrole",
+			Storage:   b.storage,
+		},
+		apiData: apiData,
+		role:    role,
+	}
+	parsedCertBundle, err := generateCert(ctx, b, input, nil, true, rand.Reader)
+
+	require.NoError(t, err)
+	certBundle, err := parsedCertBundle.ToCertBundle()
+	require.NoError(t, err)
+	return certBundle, err
+}

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -30,7 +30,7 @@ func kmsRequested(input *inputBundle) bool {
 	return exportedStr.(string) == "kms"
 }
 
-type keyId interface {
+type managedKeyId interface {
 	String() string
 }
 
@@ -49,13 +49,13 @@ func (n NameKey) String() string {
 
 // getManagedKeyId returns a NameKey or a UUIDKey, whichever was specified in the
 // request API data.
-func getManagedKeyId(data *framework.FieldData) (keyId, error) {
+func getManagedKeyId(data *framework.FieldData) (managedKeyId, error) {
 	name, UUID, err := getManagedKeyNameOrUUID(data)
 	if err != nil {
 		return nil, err
 	}
 
-	var keyId keyId = NameKey(name)
+	var keyId managedKeyId = NameKey(name)
 	if len(UUID) > 0 {
 		keyId = UUIDKey(UUID)
 	}


### PR DESCRIPTION
The API context will usually have a user-specified reference to the key.
This is either the literal string "default" to select the default key,
an identifier of the key, or a slug name for the key. Here, we wish to
resolve this reference to an actual identifier that can be understood by
storage.

Also adds the missing Name field to keys.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

This depends on four unwritten methods and thus can't be built yet:

```
builtin/logical/pki/storage.go:83:18: undefined: getKeysConfig
builtin/logical/pki/storage.go:91:15: undefined: listKeys
builtin/logical/pki/storage.go:151:18: undefined: getIssuersConfig
builtin/logical/pki/storage.go:159:18: undefined: listIssuers
```

In `fetchCAInfo`, we'd call `resolveIssuerReference` and then call `fetchCertBundleByIssuerId`. 