### PR TITLE
Make fetchCAInfo aware of new storage layout

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2522,7 +2522,7 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signingBundle, err := fetchCAInfo(context.Background(), b, &logical.Request{Storage: storage})
+	signingBundle, err := fetchCAInfo(context.Background(), b, &logical.Request{Storage: storage}, "default")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -32,7 +32,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 		return nil, nil
 	}
 
-	signingBundle, caErr := fetchCAInfo(ctx, b, req)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:
@@ -223,7 +223,7 @@ func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bo
 	}
 
 WRITE:
-	signingBundle, caErr := fetchCAInfo(ctx, b, req)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -191,7 +191,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 	}
 
 	if serial == "ca_chain" {
-		caInfo, err := fetchCAInfo(ctx, b, req)
+		caInfo, err := fetchCAInfo(ctx, b, req, "default")
 		if err != nil {
 			switch err.(type) {
 			case errutil.UserError:

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -174,7 +174,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	}
 
 	var caErr error
-	signingBundle, caErr := fetchCAInfo(ctx, b, req)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -311,7 +311,7 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 	}
 
 	var caErr error
-	signingBundle, caErr := fetchCAInfo(ctx, b, req)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:
@@ -442,7 +442,7 @@ func (b *backend) pathCASignSelfIssued(ctx context.Context, req *logical.Request
 	}
 
 	var caErr error
-	signingBundle, caErr := fetchCAInfo(ctx, b, req)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:


### PR DESCRIPTION
This allows fetchCAInfo to fetch a specified issuer, via a reference
parameter provided by the user. We pass that into the storage layer and
have it return a cert bundle for us. Finally, we need to validate that
it truly has the key desired.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Just about everything (except for root deletion/generation which checks the `ca_bundle` storage entry directly) correctly uses `fetchCAInfo`; I think later work will be updating the calls to pass the desired issuer. But assuming we can create the bundle correctly (at the storage level) and find the right bundle (from API request), I think we should be in good shape. 