### PR TITLE
Vault documentation: updated ssct faq page

### DIFF
--- a/website/content/docs/faq/ssct.mdx
+++ b/website/content/docs/faq/ssct.mdx
@@ -39,7 +39,7 @@ For the sake of standardization between OSS and Enterprise, and due to the value
 
 Server Side Consistent Tokens introduces the following key changes:
 
-- Token length : Server side consistent tokens are longer, being 95+ characters as opposed to 27+ characters.
+- Token length : Server side consistent tokens are longer, being 95+ characters as opposed to 27+ characters. Since the token can be subject to change (see [Token](/docs/concepts/tokens)), we recommend that you plan for a maximum length of 255 bytes to future proof yourself if you have workflows that rely on the token size.
 - By default, Vault 1.10 will use the new token prefixes and new token format.
 - Tokens don't visibly have a ".namespaceID" suffix
 - Token prefix: Token prefixes are being changed as follows:


### PR DESCRIPTION
Per Aarti's request, the server-side consistent token faq page was updated to include recommendations for setting token length based on use cases that rely on token size.

:mag:[Deploy Preview](https://vault-git-ssct-faq-updated-hashicorp.vercel.app/docs/faq/ssct#q-what-token-changes-does-the-server-side-consistent-tokens-feature-introduce)