### PR TITLE
Show no config warning error bug fix

### DIFF
--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -114,11 +114,10 @@ export default Component.extend({
       }
 
       let changedAttrKeys = Object.keys(mountModel.changedAttributes());
-      const updatesConfig =
-        mountModel.isV2KV &&
-        (changedAttrKeys.includes('casRequired') ||
-          changedAttrKeys.includes('deleteVersionAfter') ||
-          changedAttrKeys.includes('maxVersions'));
+      let updatesConfig =
+        changedAttrKeys.includes('casRequired') ||
+        changedAttrKeys.includes('deleteVersionAfter') ||
+        changedAttrKeys.includes('maxVersions');
 
       try {
         yield mountModel.save();
@@ -144,7 +143,8 @@ export default Component.extend({
         }
         return;
       }
-      if (updatesConfig && !capabilities.get('canUpdate')) {
+      // mountModel must be after the save
+      if (mountModel.isV2KV && updatesConfig && !capabilities.get('canUpdate')) {
         // config error is not thrown from secret-engine adapter, so handling here
         this.flashMessages.warning(
           'You do not have access to the config endpoint. The secret engine was mounted, but the configuration settings were not saved.'

--- a/ui/tests/acceptance/settings/mount-secret-backend-test.js
+++ b/ui/tests/acceptance/settings/mount-secret-backend-test.js
@@ -1,4 +1,4 @@
-import { currentRouteName, settled, find } from '@ember/test-helpers';
+import { currentRouteName, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { create } from 'ember-cli-page-object';
@@ -131,10 +131,11 @@ module('Acceptance | settings/mount-secret-backend', function (hooks) {
     await mountSecrets.selectType('kv');
     await mountSecrets.next().path(enginePath).setMaxVersion(101).submit();
     await settled();
-    assert.ok(
-      find('[data-test-flash-message]').textContent.trim(),
-      `You do not have access to the config endpoint. The secret engine was mounted, but the configuration settings were not saved.`
-    );
+    assert
+      .dom('[data-test-flash-message]')
+      .containsText(
+        `You do not have access to the config endpoint. The secret engine was mounted, but the configuration settings were not saved.`
+      );
     await configPage.visit({ backend: enginePath });
     await settled();
     assert.dom('[data-test-row-value="Maximum number of versions"]').hasText('Not set');


### PR DESCRIPTION
[This PR correctly](https://github.com/hashicorp/vault/pull/14551) set the conditional to only show this warning at the right time, but something with `mountModel` always returned false when called before the save.

I also fixed a test that should have been catching this 🤦🏻‍♀️  (a test I wrote and incorrectly used ok when I should have been checking for the text).

