### PR TITLE
add kv write retry logic for TestKVPatchCommand_RWMethodPolicyVariations

### DIFF
--- a/command/kv_test.go
+++ b/command/kv_test.go
@@ -1187,16 +1187,13 @@ func TestKVPatchCommand_RWMethodPolicyVariations(t *testing.T) {
 
 			client.SetToken(secretAuth.ClientToken)
 
-			if _, err := client.Logical().WriteWithContext(context.Background(), "kv/data/foo", map[string]interface{}{
-				"data": map[string]interface{}{
-					"foo": "bar",
-					"bar": "baz",
-				},
-			}); err != nil {
-				t.Fatalf("write failed, err: %#v\n", err)
+			putArgs := []string{"kv/foo", "foo=bar", "bar=baz"}
+			code, combined := kvPutWithRetry(t, client, putArgs)
+			if code != 0 {
+				t.Errorf("write failed, expected %d to be 0, output: %s", code, combined)
 			}
 
-			code, combined := kvPatchWithRetry(t, client, tc.args, nil)
+			code, combined = kvPatchWithRetry(t, client, tc.args, nil)
 			if code != tc.code {
 				t.Fatalf("expected code to be %d but was %d for patch cmd with args %#v\n", tc.code, code, tc.args)
 			}


### PR DESCRIPTION
A KV backend that is undergoing an upgrade from v1 to v2 will be temporarily unavailable. Any requests to it will be responded to with an error `Upgrading from non-versioned to versioned data. This backend will be unavailable for a brief period and will resume service shortly.` There are test helpers that will look for a substring of this error in the response and retry the request if necessary. There is a KV write performed for the test cases defined `TestKVPatchCommand_RWMethodPolicyVariations` that was not using a retry helper func.