### PR TITLE
VAULT-4240 time.After() in a select statement can lead to memory leak

### DIFF
--- a/changelog/14814.txt
+++ b/changelog/14814.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: time.After() used in a select statement can lead to memory leak
+```

--- a/helper/fairshare/jobmanager.go
+++ b/helper/fairshare/jobmanager.go
@@ -265,6 +265,10 @@ func (j *JobManager) assignWork() {
 	j.wg.Add(1)
 
 	go func() {
+		// ticker is used to prevent memory leak of using time.After in
+		// for - select pattern.
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
 		for {
 			for {
 				// assign work while there are jobs to distribute
@@ -291,13 +295,14 @@ func (j *JobManager) assignWork() {
 				}
 			}
 
+			ticker.Reset(50 * time.Millisecond)
 			select {
 			case <-j.quit:
 				j.wg.Done()
 				return
 			case <-j.newWork:
 				// listen for wake-up when an empty job manager has been given work
-			case <-time.After(50 * time.Millisecond):
+			case <-ticker.C:
 				// periodically check if new workers can be assigned. with the
 				// fairsharing worker distribution it can be the case that there
 				// is work waiting, but no queues are eligible for another worker

--- a/physical/raft/raft.go
+++ b/physical/raft/raft.go
@@ -860,11 +860,16 @@ func (b *RaftBackend) SetupCluster(ctx context.Context, opts SetupOpts) error {
 	// StartAsLeader is only set during init, recovery mode, storage migration,
 	// and tests.
 	if opts.StartAsLeader {
+		// ticker is used to prevent memory leak of using time.After in
+		// for - select pattern.
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
 		for {
 			if raftObj.State() == raft.Leader {
 				break
 			}
 
+			ticker.Reset(10 * time.Millisecond)
 			select {
 			case <-ctx.Done():
 				future := raftObj.Shutdown()
@@ -873,7 +878,7 @@ func (b *RaftBackend) SetupCluster(ctx context.Context, opts SetupOpts) error {
 				}
 
 				return errors.New("shutdown while waiting for leadership")
-			case <-time.After(10 * time.Millisecond):
+			case <-ticker.C:
 			}
 		}
 	}


### PR DESCRIPTION
The time.After call in the for - select statement can lead to a memory leak because the garbage collector does not cleanup the underlying Timer object until the timer fires. A new timer is initialized at each iteration of the for loop (and hence select), which requires resources. So, many routines originating from the time.After call could lead to overconsumption of the memory. 