### PR TITLE
KMSE Enable/Config

### DIFF
--- a/ui/app/components/mount-backend-form.js
+++ b/ui/app/components/mount-backend-form.js
@@ -4,7 +4,7 @@ import { computed, set } from '@ember/object';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import { methods } from 'vault/helpers/mountable-auth-methods';
-import { engines, KMIP, TRANSFORM } from 'vault/helpers/mountable-secret-engines';
+import { engines, KMIP, TRANSFORM, KEYMGMT } from 'vault/helpers/mountable-secret-engines';
 import { waitFor } from '@ember/test-waiters';
 
 const METHODS = methods();
@@ -69,7 +69,7 @@ export default Component.extend({
 
   engines: computed('version.{features[],isEnterprise}', function () {
     if (this.version.isEnterprise) {
-      return ENGINES.concat([KMIP, TRANSFORM]);
+      return ENGINES.concat([KMIP, TRANSFORM, KEYMGMT]);
     }
     return ENGINES;
   }),

--- a/ui/app/helpers/mountable-secret-engines.js
+++ b/ui/app/helpers/mountable-secret-engines.js
@@ -16,6 +16,15 @@ export const TRANSFORM = {
   requiredFeature: 'Transform Secrets Engine',
 };
 
+export const KEYMGMT = {
+  displayName: 'Key Management',
+  value: 'keymgmt',
+  type: 'keymgmt',
+  glyph: 'key',
+  category: 'generic',
+  requiredFeature: 'Key Management Secrets Engine',
+};
+
 const MOUNTABLE_SECRET_ENGINES = [
   {
     displayName: 'Active Directory',

--- a/ui/app/helpers/supported-secret-backends.js
+++ b/ui/app/helpers/supported-secret-backends.js
@@ -11,6 +11,7 @@ const SUPPORTED_SECRET_BACKENDS = [
   'transit',
   'kmip',
   'transform',
+  'keymgmt',
 ];
 
 export function supportedSecretBackends() {

--- a/ui/app/models/secret-engine.js
+++ b/ui/app/models/secret-engine.js
@@ -83,15 +83,10 @@ export default Model.extend(Validations, {
   formFields: computed('engineType', 'options.version', function () {
     let type = this.engineType;
     let version = this.options?.version;
-    let fields = [
-      'type',
-      'path',
-      'description',
-      'accessor',
-      'local',
-      'sealWrap',
-      'config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
-    ];
+    let fields = ['type', 'path', 'description', 'accessor', 'local', 'sealWrap'];
+    // no ttl options for keymgmt
+    const ttl = type !== 'keymgmt' ? 'defaultLeaseTtl,maxLeaseTtl,' : '';
+    fields.push(`config.{${ttl}auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}`);
     if (type === 'kv' || type === 'generic') {
       fields.push('options.{version}');
     }
@@ -112,14 +107,14 @@ export default Model.extend(Validations, {
       defaultGroup = { default: ['path'] };
     }
     let optionsGroup = {
-      'Method Options': [
-        'description',
-        'config.listingVisibility',
-        'local',
-        'sealWrap',
-        'config.{defaultLeaseTtl,maxLeaseTtl,auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}',
-      ],
+      'Method Options': ['description', 'config.listingVisibility', 'local', 'sealWrap'],
     };
+    // no ttl options for keymgmt
+    const ttl = type !== 'keymgmt' ? 'defaultLeaseTtl,maxLeaseTtl,' : '';
+    optionsGroup['Method Options'].push(
+      `config.{${ttl}auditNonHmacRequestKeys,auditNonHmacResponseKeys,passthroughRequestHeaders}`
+    );
+
     if (type === 'kv' || type === 'generic') {
       optionsGroup['Method Options'].unshift('options.{version}');
     }
@@ -148,6 +143,16 @@ export default Model.extend(Validations, {
 
   fieldGroups: computed('formFieldGroups', function () {
     return fieldToAttrs(this, this.formFieldGroups);
+  }),
+
+  icon: computed('engineType', function () {
+    if (!this.engineType || this.engineType === 'kmip') {
+      return 'secrets';
+    }
+    if (this.engineType === 'keymgmt') {
+      return 'key';
+    }
+    return this.engineType;
   }),
 
   // namespaces introduced types with a `ns_` prefix for built-in engines

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -47,7 +47,7 @@
               @onRadioChange={{queue (action (mut this.mountModel.type)) (action "onTypeChange" "type")}}
               @disabled={{if type.requiredFeature (not (has-feature type.requiredFeature)) false}}
               @tooltipMessage={{if
-                (or (eq type.type "transform") (eq type.type "kmip"))
+                (or (eq type.type "transform") (eq type.type "kmip") (eq type.type "keymgmt"))
                 (concat
                   type.displayName
                   " is part of the Advanced Data Protection module, which is not included in your enterprise license."

--- a/ui/app/templates/components/mount-backend-form.hbs
+++ b/ui/app/templates/components/mount-backend-form.hbs
@@ -46,6 +46,7 @@
               @groupName="mount-type"
               @onRadioChange={{queue (action (mut this.mountModel.type)) (action "onTypeChange" "type")}}
               @disabled={{if type.requiredFeature (not (has-feature type.requiredFeature)) false}}
+              {{! TODO: verify that keymgmt is in the ADP module }}
               @tooltipMessage={{if
                 (or (eq type.type "transform") (eq type.type "kmip") (eq type.type "keymgmt"))
                 (concat

--- a/ui/app/templates/components/secret-list-header.hbs
+++ b/ui/app/templates/components/secret-list-header.hbs
@@ -14,7 +14,7 @@
     </p.top>
     <p.levelLeft>
       <h1 class="title is-3">
-        <Icon @name={{or @model.engineType "secrets"}} @size="24" class="has-text-grey-light" />
+        <Icon @name={{@model.icon}} @size="24" class="has-text-grey-light" />
         {{@model.id}}
         {{#if this.isKV}}
           <span class="tag" data-test-kv-version-badge>

--- a/ui/app/templates/vault/cluster/secrets/backends.hbs
+++ b/ui/app/templates/vault/cluster/secrets/backends.hbs
@@ -34,7 +34,7 @@
         @accessor={{if (eq backend.options.version 2) (concat "v2 " backend.accessor) backend.accessor}}
         @description={{backend.description}}
         @glyphText={{backend.engineType}}
-        @glyph={{or (if (eq backend.engineType "kmip") "secrets" backend.engineType) "secrets"}}
+        @glyph={{backend.icon}}
         @link={{hash route=backendLink model=backend.id}}
         @title={{backend.path}}
       />

--- a/ui/lib/core/addon/helpers/has-feature.js
+++ b/ui/lib/core/addon/helpers/has-feature.js
@@ -15,6 +15,7 @@ const POSSIBLE_FEATURES = [
   'Namespaces',
   'KMIP',
   'Transform Secrets Engine',
+  'Key Management Secrets Engine',
 ];
 
 export function hasFeature(featureName, features) {


### PR DESCRIPTION
This PR addresses some initial phase 2 items for adding the key management secrets engine:
- add key management secrets engine as supported backend (enterprise only)
- disable and show tooltip if license does not include Advanced Data Protection module
- display correct icon for key management secret engine
- remove ttl fields from configuration options
- remove ttl fields from configuration view page