### PR TITLE
Handle Importing Key, Issuers to new PKI storage layout

### DIFF
--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -78,9 +78,10 @@ type BlockType string
 
 // Well-known formats
 const (
-	PKCS1Block BlockType = "RSA PRIVATE KEY"
-	PKCS8Block BlockType = "PRIVATE KEY"
-	ECBlock    BlockType = "EC PRIVATE KEY"
+	UnknownBlock BlockType = ""
+	PKCS1Block   BlockType = "RSA PRIVATE KEY"
+	PKCS8Block   BlockType = "PRIVATE KEY"
+	ECBlock      BlockType = "EC PRIVATE KEY"
 )
 
 // ParsedPrivateKeyContainer allows common key setting for certs and CSRs
@@ -135,6 +136,19 @@ type ParsedCSRBundle struct {
 	PrivateKey      crypto.Signer
 	CSRBytes        []byte
 	CSR             *x509.CertificateRequest
+}
+
+func GetPrivateKeyTypeFromSigner(signer crypto.Signer) PrivateKeyType {
+	switch signer.(type) {
+	case *rsa.PrivateKey:
+		return RSAPrivateKey
+	case *ecdsa.PrivateKey:
+		return ECPrivateKey
+	case ed25519.PrivateKey:
+		return Ed25519PrivateKey
+	default:
+		return UnknownPrivateKey
+	}
 }
 
 // ToPEMBundle converts a string-based certificate bundle


### PR DESCRIPTION
This PR is in two parts:

 - Small (non-exhaustive) refactoring of `certutil` to expose useful functionality.
 - Addition of two new methods, `importKey` and `importCert` to the PKI storage code from #14796.

Notably, importing a key or issuer is roughly the same:

 - Iterate all existing keys/issuers and check to see if we have a match; return it if we do.
 - Create a new entry instead.
    - Generate a UUID, compute field values.
    - Now, we need to iterate over all issuers/keys and see if there's a missing KeyID value we can assign.
 - Write the result to storage and return.

I'm sure there's more refactoring of `certutil` we could do with this if we wanted. And we definitely need some tests. :-) But wanted to get your thoughts before I get too far.

One thing I'm worried about is what do we do about failures in the detection loop? Should we still write the issuer/key (we don't in `importIssuer` but do in `importKey`)? In `importKey`, what do we do if the first write succeeds (e.g., writing the first `issuer`) but the second one fails (e.g., writing the second `issuer`)? Do we attempt to record which issuers we touched and revert it?