### PR TITLE
Start /issuer-related PKI APIs

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -116,6 +116,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathIssuerSignIntermediate(&b),
 			pathIssuerSignSelfIssued(&b),
 			pathIssuerSignVerbatim(&b),
+			pathConfigIssuers(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -113,6 +113,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathListIssuers(&b),
 			pathGetIssuer(&b),
 			pathImportIssuer(&b),
+			pathIssuerSignIntermediate(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -112,6 +112,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			// Issuer APIs
 			pathListIssuers(&b),
 			pathGetIssuer(&b),
+			pathImportIssuer(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -115,6 +115,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathImportIssuer(&b),
 			pathIssuerSignIntermediate(&b),
 			pathIssuerSignSelfIssued(&b),
+			pathIssuerSignVerbatim(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -105,6 +105,15 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathSign(&b),
 			pathIssue(&b),
 			pathRotateCRL(&b),
+			pathRevoke(&b),
+			pathTidy(&b),
+			pathTidyStatus(&b),
+
+			// Issuer APIs
+			pathListIssuers(&b),
+			pathGetIssuer(&b),
+
+			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),
 			pathFetchCAChain(&b),
 			pathFetchCRL(&b),
@@ -112,9 +121,6 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathFetchValidRaw(&b),
 			pathFetchValid(&b),
 			pathFetchListCerts(&b),
-			pathRevoke(&b),
-			pathTidy(&b),
-			pathTidyStatus(&b),
 		},
 
 		Secrets: []*framework.Secret{

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -114,6 +114,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathGetIssuer(&b),
 			pathImportIssuer(&b),
 			pathIssuerSignIntermediate(&b),
+			pathIssuerSignSelfIssued(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -135,7 +135,10 @@ func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRe
 }
 
 // Allows fetching certificates from the backend; it handles the slightly
-// separate pathing for CA, CRL, and revoked certificates.
+// separate pathing for CRL, and revoked certificates.
+//
+// Support for fetching CA certificates was removed, due to the new issuers
+// changes.
 func fetchCertBySerial(ctx context.Context, req *logical.Request, prefix, serial string) (*logical.StorageEntry, error) {
 	var path, legacyPath string
 	var err error
@@ -145,13 +148,11 @@ func fetchCertBySerial(ctx context.Context, req *logical.Request, prefix, serial
 	colonSerial := strings.Replace(strings.ToLower(serial), "-", ":", -1)
 
 	switch {
-	// Revoked goes first as otherwise ca/crl get hardcoded paths which fail if
+	// Revoked goes first as otherwise crl get hardcoded paths which fail if
 	// we actually want revocation info
 	case strings.HasPrefix(prefix, "revoked/"):
 		legacyPath = "revoked/" + colonSerial
 		path = "revoked/" + hyphenSerial
-	case serial == "ca":
-		path = "ca"
 	case serial == "crl":
 		path = "crl"
 	default:

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -132,6 +132,12 @@ be larger than the role max TTL.`,
 The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ`,
 	}
 
+	fields["ref"] = &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
+		Default:     "default",
+	}
+
 	return fields
 }
 

--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -103,6 +103,72 @@ secret key and certificate.
 For security reasons, the secret key cannot be retrieved later.
 `
 
+func pathConfigIssuers(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "config/issuers",
+		Fields: map[string]*framework.FieldSchema{
+			"default": {
+				Type:        framework.TypeString,
+				Description: `Reference (name or identifier) to the default issuer.`,
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation:   b.pathCAIssuersRead,
+			logical.UpdateOperation: b.pathCAIssuersWrite,
+		},
+
+		HelpSynopsis:    pathConfigIssuersHelpSyn,
+		HelpDescription: pathConfigIssuersHelpDesc,
+	}
+}
+
+func (b *backend) pathCAIssuersRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	config, err := getIssuersConfig(ctx, req.Storage)
+	if err != nil {
+		return logical.ErrorResponse("Error loading issuers configuration: " + err.Error()), nil
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"default": config.DefaultIssuerId,
+		},
+	}, nil
+}
+
+func (b *backend) pathCAIssuersWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	newDefault := data.Get("default").(string)
+	if len(newDefault) == 0 || newDefault == "default" {
+		return logical.ErrorResponse("Invalid issuer specification; must be non-empty and can't be 'default'."), nil
+	}
+
+	parsedIssuer, err := resolveIssuerReference(ctx, req.Storage, newDefault)
+	if err != nil {
+		return logical.ErrorResponse("Error resolving issuer reference: " + err.Error()), nil
+	}
+
+	err = updateDefaultIssuerId(ctx, req.Storage, parsedIssuer)
+	if err != nil {
+		return logical.ErrorResponse("Error updating issuer configuration: " + err.Error()), nil
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"default": parsedIssuer,
+		},
+	}, nil
+}
+
+const pathConfigIssuersHelpSyn = `Read and set the default issuer certificate for signing.`
+
+const pathConfigIssuersHelpDesc = `
+This path allows configuration of issuer parameters.
+
+Presently, the "default" parameter controls which issuer is the default,
+accessible by the existing signing paths (/root/sign-intermediate,
+/root/sign-self-issued, /sign-verbatim, /sign/:role, and /issue/:role).
+`
+
 const pathConfigCAGenerateHelpSyn = `
 Generate a new CA certificate and private key used for signing.
 `

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -1,0 +1,252 @@
+package pki
+
+import (
+	"context"
+	"encoding/pem"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+var nameMatcher = regexp.MustCompile("^" + framework.GenericNameRegex("ref") + "$")
+
+func pathListIssuers(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "issuers/?$",
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ListOperation: b.pathListIssuersHandler,
+		},
+
+		HelpSynopsis:    pathListIssuersHelpSyn,
+		HelpDescription: pathListIssuersHelpDesc,
+	}
+}
+
+func (b *backend) pathListIssuersHandler(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	var responseKeys []string
+	responseInfo := make(map[string]interface{})
+
+	entries, err := listIssuers(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	// For each issuer, we need not only the identifier (as returned by
+	// listIssuers), but also the name of the issuer. This means we have to
+	// fetch the actual issuer object as well.
+	for _, identifier := range entries {
+		issuer, err := fetchIssuerById(ctx, req.Storage, identifier)
+		if err != nil {
+			return nil, err
+		}
+
+		responseKeys = append(responseKeys, string(identifier))
+		responseInfo[string(identifier)] = map[string]interface{}{
+			"name": issuer.Name,
+		}
+	}
+
+	return logical.ListResponseWithInfo(responseKeys, responseInfo), nil
+}
+
+const (
+	pathListIssuersHelpSyn  = `Fetch a list of CA certificates.`
+	pathListIssuersHelpDesc = `
+This endpoint allows listing of known issuing certificates, returning
+their identifier and their name (if set).
+`
+)
+
+func pathGetIssuer(b *backend) *framework.Path {
+	pattern := "issuer/" + framework.GenericNameRegex("ref") + "(/der|/pem)?"
+	return buildPathGetIssuer(b, pattern)
+}
+
+func buildPathGetIssuer(b *backend, pattern string) *framework.Path {
+	return &framework.Path{
+		// Returns a JSON entry.
+		Pattern: pattern,
+		Fields: map[string]*framework.FieldSchema{
+			"ref": {
+				Type:        framework.TypeString,
+				Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
+				Default:     "default",
+			},
+			"name": {
+				Type:        framework.TypeString,
+				Description: `Human-readable name for this issuer.`,
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation:   b.pathGetIssuer,
+			logical.UpdateOperation: b.pathUpdateIssuer,
+			logical.DeleteOperation: b.pathDeleteIssuer,
+		},
+
+		HelpSynopsis:    pathGetIssuerHelpSyn,
+		HelpDescription: pathGetIssuerHelpDesc,
+	}
+}
+
+func (b *backend) pathGetIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Handle raw issuers first.
+	if strings.HasSuffix(req.Path, "/der") || strings.HasSuffix(req.Path, "/pem") {
+		return b.pathGetRawIssuer(ctx, req, data)
+	}
+
+	issuerName := data.Get("ref").(string)
+	if len(issuerName) == 0 {
+		return logical.ErrorResponse("missing issuer reference"), nil
+	}
+
+	ref, err := resolveIssuerReference(ctx, req.Storage, issuerName)
+	if err != nil {
+		return nil, err
+	}
+	if ref == "" {
+		return logical.ErrorResponse("unable to resolve issuer id for reference: " + issuerName), nil
+	}
+
+	issuer, err := fetchIssuerById(ctx, req.Storage, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"id":          issuer.ID,
+			"name":        issuer.Name,
+			"key_id":      issuer.KeyID,
+			"certificate": issuer.Certificate,
+		},
+	}, nil
+}
+
+func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	issuerName := data.Get("ref").(string)
+	if len(issuerName) == 0 {
+		return logical.ErrorResponse("missing issuer reference"), nil
+	}
+
+	newName := data.Get("name").(string)
+	if len(newName) > 0 && !nameMatcher.MatchString(newName) {
+		return logical.ErrorResponse("new issuer name outside of valid character limits"), nil
+	}
+
+	ref, err := resolveIssuerReference(ctx, req.Storage, issuerName)
+	if err != nil {
+		return nil, err
+	}
+	if ref == "" {
+		return logical.ErrorResponse("unable to resolve issuer id for reference: " + issuerName), nil
+	}
+
+	issuer, err := fetchIssuerById(ctx, req.Storage, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	if newName != issuer.Name {
+		issuer.Name = newName
+
+		err := writeIssuer(ctx, req.Storage, issuer)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"id":          issuer.ID,
+			"name":        issuer.Name,
+			"key_id":      issuer.KeyID,
+			"certificate": issuer.Certificate,
+		},
+	}, nil
+}
+
+func (b *backend) pathGetRawIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	issuerName := data.Get("ref").(string)
+	if len(issuerName) == 0 {
+		return logical.ErrorResponse("missing issuer reference"), nil
+	}
+
+	ref, err := resolveIssuerReference(ctx, req.Storage, issuerName)
+	if err != nil {
+		return nil, err
+	}
+	if ref == "" {
+		return logical.ErrorResponse("unable to resolve issuer id for reference: " + issuerName), nil
+	}
+
+	issuer, err := fetchIssuerById(ctx, req.Storage, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	certificate := []byte(issuer.Certificate)
+	contentType := "application/pem-certificate-chain"
+
+	if strings.HasSuffix(req.Path, "/der") {
+		contentType = "application/pkix-cert"
+
+		pemBlock, _ := pem.Decode(certificate)
+		if pemBlock == nil {
+			return nil, err
+		}
+
+		certificate = pemBlock.Bytes
+	}
+
+	statusCode := 200
+	if len(certificate) == 0 {
+		statusCode = 204
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			logical.HTTPContentType: contentType,
+			logical.HTTPRawBody:     certificate,
+			logical.HTTPStatusCode:  statusCode,
+		},
+	}, nil
+}
+
+func (b *backend) pathDeleteIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	issuerName := data.Get("ref").(string)
+	if len(issuerName) == 0 {
+		return logical.ErrorResponse("missing issuer reference"), nil
+	}
+
+	ref, err := resolveIssuerReference(ctx, req.Storage, issuerName)
+	if err != nil {
+		return nil, err
+	}
+	if ref == "" {
+		return logical.ErrorResponse("unable to resolve issuer id for reference: " + issuerName), nil
+	}
+
+	return nil, deleteIssuer(ctx, req.Storage, ref)
+}
+
+const (
+	pathGetIssuerHelpSyn  = `Fetch a single issuer certificate.`
+	pathGetIssuerHelpDesc = `
+This allows fetching information associated with the underlying issuer
+certificate.
+
+:ref can be either the literal value "default", in which case /config/issuers
+will be consulted for the present default issuer, an identifier of an issuer,
+or its assigned name value.
+
+Use /issuer/:ref/der or /issuer/:ref/pem to return just the certificate in
+raw DER or PEM form, without the JSON structure of /issuer/:ref.
+
+Writing to /issuer/:ref allows updating of the name field associated with
+the certificate.
+`
+)

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -15,8 +15,18 @@ import (
 )
 
 func pathIssue(b *backend) *framework.Path {
+	pattern := "issue/" + framework.GenericNameRegex("role")
+	return buildPathIssue(b, pattern)
+}
+
+func pathIssuerIssue(b *backend) *framework.Path {
+	pattern := "issuer/" + framework.GenericNameRegex("ref") + "/issue/" + framework.GenericNameRegex("role")
+	return buildPathIssue(b, pattern)
+}
+
+func buildPathIssue(b *backend, pattern string) *framework.Path {
 	ret := &framework.Path{
-		Pattern: "issue/" + framework.GenericNameRegex("role"),
+		Pattern: pattern,
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.metricsWrap("issue", roleRequired, b.pathIssue),
@@ -31,8 +41,18 @@ func pathIssue(b *backend) *framework.Path {
 }
 
 func pathSign(b *backend) *framework.Path {
+	pattern := "sign/" + framework.GenericNameRegex("role")
+	return buildPathSign(b, pattern)
+}
+
+func pathIssuerSign(b *backend) *framework.Path {
+	pattern := "issuer/" + framework.GenericNameRegex("ref") + "/sign/" + framework.GenericNameRegex("role")
+	return buildPathSign(b, pattern)
+}
+
+func buildPathSign(b *backend, pattern string) *framework.Path {
 	ret := &framework.Path{
-		Pattern: "sign/" + framework.GenericNameRegex("role"),
+		Pattern: pattern,
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.metricsWrap("sign", roleRequired, b.pathSign),

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -1,0 +1,124 @@
+package pki
+
+import (
+	"bytes"
+	"context"
+	"encoding/pem"
+	"strings"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/errutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func pathImportIssuer(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "issuers/import/(cert|bundle)",
+		Fields: map[string]*framework.FieldSchema{
+			"pem_bundle": {
+				Type: framework.TypeString,
+				Description: `PEM-format, concatenated unencrypted
+secret-key (optional) and certificates.`,
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.UpdateOperation: b.pathImportIssuers,
+		},
+
+		HelpSynopsis:    pathImportIssuersHelpSyn,
+		HelpDescription: pathImportIssuersHelpDesc,
+	}
+}
+
+func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	keysAllowed := strings.HasSuffix(req.Path, "bundle")
+
+	pemBundle := data.Get("pem_bundle").(string)
+	if len(pemBundle) == 0 {
+		return logical.ErrorResponse("'pem_bundle' parameter was empty"), nil
+	}
+
+	var createdKeys []keyId
+	var createdIssuers []issuerId
+	issuerKeyMap := make(map[issuerId]keyId)
+
+	// Rather than using certutil.ParsePEMBundle (which restricts the
+	// construction of the PEM bundle), we manually parse the bundle instead.
+	pemBytes := []byte(pemBundle)
+	var pemBlock *pem.Block
+
+	var issuers []string
+	var keys []string
+
+	for len(bytes.TrimSpace(pemBytes)) > 0 {
+		pemBlock, pemBytes = pem.Decode(pemBytes)
+		if pemBlock == nil {
+			return nil, errutil.UserError{Err: "no data found in PEM block"}
+		}
+
+		pemBlockString := string(pem.EncodeToMemory(pemBlock))
+
+		switch pemBlock.Type {
+		case "CERTIFICATE", "X509 CERTIFICATE":
+			// Must be a certificate
+			issuers = append(issuers, pemBlockString)
+		case "CRL", "X509 CRL":
+			// Ignore any CRL entries.
+		default:
+			// Otherwise, treat them as keys.
+			keys = append(keys, pemBlockString)
+		}
+	}
+
+	if len(keys) > 0 && !keysAllowed {
+		return logical.ErrorResponse("private keys found in the PEM bundle but not allowed by the path; use /issuers/import/bundle"), nil
+	}
+
+	for _, keyPem := range keys {
+		// Handle import of private key.
+		key, existing, err := importKey(ctx, req.Storage, keyPem)
+		if err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+
+		if !existing {
+			createdKeys = append(createdKeys, key.ID)
+		}
+	}
+
+	for _, certPem := range issuers {
+		cert, existing, err := importIssuer(ctx, req.Storage, certPem)
+		if err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+
+		issuerKeyMap[cert.ID] = cert.KeyID
+		if !existing {
+			createdIssuers = append(createdIssuers, cert.ID)
+		}
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"mapping":          issuerKeyMap,
+			"imported_keys":    createdKeys,
+			"imported_issuers": createdIssuers,
+		},
+	}, nil
+}
+
+const (
+	pathImportIssuersHelpSyn  = `Import the specified issuing certificates.`
+	pathImportIssuersHelpDesc = `
+This endpoint allows importing the specified issuer certificates.
+
+:type is either the literal value "cert", to only allow importing
+certificates, else "bundle" to allow importing keys as well as
+certificates.
+
+Depending on the value of :type, the pem_bundle request parameter can
+either take PEM-formatted certificates, and, if :type="bundle", unencrypted
+secret-keys.
+`
+)

--- a/builtin/logical/pki/path_sign_issuers.go
+++ b/builtin/logical/pki/path_sign_issuers.go
@@ -1,0 +1,79 @@
+package pki
+
+import (
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func pathIssuerSignIntermediate(b *backend) *framework.Path {
+	pattern := "issuers/" + framework.GenericNameRegex("ref") + "/sign-intermediate"
+	return pathIssuerSignIntermediateRaw(b, pattern)
+}
+
+func pathSignIntermediate(b *backend) *framework.Path {
+	pattern := "root/sign-intermediate"
+	return pathIssuerSignIntermediateRaw(b, pattern)
+}
+
+func pathIssuerSignIntermediateRaw(b *backend, pattern string) *framework.Path {
+	path := &framework.Path{
+		Pattern: pattern,
+		Fields: map[string]*framework.FieldSchema{
+			"ref": {
+				Type:        framework.TypeString,
+				Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
+				Default:     "default",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.UpdateOperation: b.pathIssuerSignIntermediate,
+		},
+
+		HelpSynopsis:    pathIssuerSignIntermediateHelpSyn,
+		HelpDescription: pathIssuerSignIntermediateHelpDesc,
+	}
+
+	path.Fields = addCACommonFields(path.Fields)
+	path.Fields = addCAIssueFields(path.Fields)
+
+	path.Fields["csr"] = &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Default:     "",
+		Description: `PEM-format CSR to be signed.`,
+	}
+
+	path.Fields["use_csr_values"] = &framework.FieldSchema{
+		Type:    framework.TypeBool,
+		Default: false,
+		Description: `If true, then:
+1) Subject information, including names and alternate
+names, will be preserved from the CSR rather than
+using values provided in the other parameters to
+this path;
+2) Any key usages requested in the CSR will be
+added to the basic set of key usages used for CA
+certs signed by this path; for instance,
+the non-repudiation flag;
+3) Extensions requested in the CSR will be copied
+into the issued certificate.`,
+	}
+
+	return path
+}
+
+const (
+	pathIssuerSignIntermediateHelpSyn  = `Issue an intermediate CA certificate based on the provided CSR.`
+	pathIssuerSignIntermediateHelpDesc = `
+This API endpoint allows for signing the specified CSR, adding to it a basic
+constraint for IsCA=True. This allows the issued certificate to issue its own
+leaf certificates.
+
+Note that the resulting certificate is not imported as an issuer in this PKI
+mount. This means that you can use the resulting certificate in another Vault
+PKI mount point or to issue an external intermediate (e.g., for use with
+another X.509 CA).
+
+See the API documentation for more information about required parameters.
+`
+)


### PR DESCRIPTION
Based on top of #14843; will be rebased once that merges.

This pull request introduces several new APIs to the PKI Engine, based around the concept of an issuer:

 - `LIST /issuers` -- for listing issuers.
 - `GET /issuer/:ref{,/der,/pem}` - for fetching a specific issuer, both as JSON and in raw DER/PEM form. 
 - `POST /issuer/:ref` - for updating issuers (mostly their `name` field right now).
 - `POST /issuers/import/{cert,bundle}` - for importing issuers and keys.

This doesn't update any of the existing code to use the new paths. 

I'm also going to update this with delete code (not written yet) and signing operations as well. 