### PR TITLE
Vault documentation: fixed a link issue

### DIFF
--- a/website/content/docs/platform/k8s/helm/examples/index.mdx
+++ b/website/content/docs/platform/k8s/helm/examples/index.mdx
@@ -15,8 +15,8 @@ These are a collection of examples of common configurations for Vault using the 
 The following are different configuration examples to support a variety of
 deployment models. You can view the different examples from the list on the left.
 
-## Learn
+## Tutorial
 
 Refer to the [Run Vault on
 Kubernetes](https://learn.hashicorp.com/collections/vault/kubernetes)
-guides for step-by-step tutorials.
+tutorial series to learn how to run Vault on Kubernetes.

--- a/website/content/docs/what-is-vault.mdx
+++ b/website/content/docs/what-is-vault.mdx
@@ -62,6 +62,5 @@ To learn more about HCP Vault, see the [HCP Vault documentation](https://cloud.h
 ## Next Steps
 
 See the page on [Vault use cases](/docs/use-cases) to learn about the multiple ways
-Vault can be used. Then, continue onwards with the [Getting Started
-(https://learn.hashicorp.com/collections/vault/getting-started) tutorial to use Vault
+Vault can be used. Then, continue onwards with the [Getting Started](https://learn.hashicorp.com/collections/vault/getting-started) tutorial to use Vault
 to read, write, and create real secrets and see how it works in practice.


### PR DESCRIPTION
The **What is Vault?** doc had a linking error. I forgot to include a bracket.

:mag: [Deploy Preview](https://vault-git-vault-link-error-hashicorp.vercel.app/docs/what-is-vault#next-steps)