### PR TITLE
Vault documentation: batch2--changing references from learn to tutorial

### DIFF
--- a/website/content/docs/agent/autoauth/methods/kubernetes.mdx
+++ b/website/content/docs/agent/autoauth/methods/kubernetes.mdx
@@ -17,8 +17,8 @@ method](/docs/auth/kubernetes/).
 - `token_path` `(string: optional)` - The file path to a custom JWT token to use
   for authentication. If omitted, the default service account token path is used.
 
-## Learn
+## Tutorial
 
 Refer to the [Vault Agent with
 Kubernetes](https://learn.hashicorp.com/vault/identity-access-management/vault-agent-k8s)
-guide for a step-by-step tutorial.
+tutorial to learn how to authenticate the clients using a Kubernetes Service Account Token and manage the tokens lifecycle.

--- a/website/content/docs/configuration/seal/awskms.mdx
+++ b/website/content/docs/configuration/seal/awskms.mdx
@@ -115,7 +115,7 @@ or set to current under a key alias.
 
 @include 'aws-imds-timeout.mdx'
 
-## Learn
+## Tutorial
 
 Refer to the [Auto-unseal using AWS KMS](https://learn.hashicorp.com/vault/operations/ops-autounseal-aws-kms)
-guide for a step-by-step tutorial.
+tutorial to learn how to auto-unseal Vault using AWK KMS.

--- a/website/content/docs/configuration/seal/azurekeyvault.mdx
+++ b/website/content/docs/configuration/seal/azurekeyvault.mdx
@@ -81,7 +81,7 @@ and secret. MSI must be
 on the VMs hosting Vault, and it is the preferred configuration since MSI
 prevents your Azure credentials from being stored as clear text. Refer to the
 [Production
-Hardening](https://learn.hashicorp.com/vault/day-one/production-hardening) guide
+Hardening](https://learn.hashicorp.com/vault/day-one/production-hardening) tutorial
 for more best practices.
 
 -> **Note:** If you are using a Managed HSM KeyVault, `AZURE_AD_RESOURCE` or the `resource`
@@ -104,7 +104,7 @@ decryption operations. Simply [set up Azure Key Vault with key
 rotation](https://docs.microsoft.com/en-us/azure/key-vault/key-vault-key-rotation-log-monitoring)
 using Azure Automation Account and Vault will recognize newly rotated keys.
 
-## Learn
+## Tutorial
 
 Refer to the [Auto-unseal using Azure Key Vault](https://learn.hashicorp.com/vault/operations/autounseal-azure-keyvault)
-guide for a step-by-step tutorial.
+tutorial to learn how to use the Azure Key Vault to auto-unseal a Vault server.

--- a/website/content/docs/enterprise/entropy-augmentation.mdx
+++ b/website/content/docs/enterprise/entropy-augmentation.mdx
@@ -51,7 +51,7 @@ for a supported seal type.
 
 [configuration]: /docs/configuration
 
-## Learn
+## Tutorial
 
-Refer to the [HSM Integration - Entropy Augmentation](https://learn.hashicorp.com/vault/operations/hsm-entropy) guide
-for a step-by-step tutorial.
+Refer to the [HSM Integration - Entropy Augmentation](https://learn.hashicorp.com/vault/operations/hsm-entropy) tutorial
+to learn how to use the Entropy Augmentation function to leverage an external Hardware Security Module to augment system entropy.

--- a/website/content/docs/enterprise/sentinel/index.mdx
+++ b/website/content/docs/enterprise/sentinel/index.mdx
@@ -110,7 +110,7 @@ of Sentinel in action, and the
 [Properties](/docs/enterprise/sentinel/properties) page for detailed
 property documentation.
 
-## Learn
+## Tutorial
 
 Refer to the [Sentinel Policies](https://learn.hashicorp.com/vault/identity-access-management/iam-sentinel)
-guide for a step-by-step tutorial.
+tutorial to learn how to author Sentinel policies in Vault.

--- a/website/content/docs/platform/k8s/csi/index.mdx
+++ b/website/content/docs/platform/k8s/csi/index.mdx
@@ -145,7 +145,7 @@ spec:
 In this example `volumes.csi` is created on the application deployment and references
 the Secret Provider Class named `vault-db-creds`.
 
-## Learn
+## Tutorial
 
 Refer to the [Vault CSI Provider](https://learn.hashicorp.com/tutorials/vault/kubernetes-secret-store-driver?in=vault/kubernetes)
-guide for a step-by-step tutorial.
+tutorial to learn how to set up Vault and its depedencies with a Helm chart.

--- a/website/content/docs/platform/k8s/helm/run.mdx
+++ b/website/content/docs/platform/k8s/helm/run.mdx
@@ -42,7 +42,7 @@ checklist](/docs/platform/k8s/helm/run#architecture).
 
 Helm must be installed and configured on your machine. Please refer to the [Helm
 documentation](https://helm.sh/) or the [Vault Installation to Minikube via
-Helm](https://learn.hashicorp.com/vault/getting-started-k8s/minikube) guide.
+Helm](https://learn.hashicorp.com/vault/getting-started-k8s/minikube) tutorial.
 
 To use the Helm chart, add the Hashicorp helm repository and check that you have
 access to the chart:
@@ -126,9 +126,9 @@ $ helm install vault hashicorp/vault \
     --set "server.ha.enabled=true"
 ```
 
--> **Step-by-step instructions:** The [Vault Installation to Minikube via
-Helm](https://learn.hashicorp.com/vault/getting-started-k8s/minikube) guide
-demonstrates set up of Consul and Vault in HA mode.
+Refer to the [Vault Installation to Minikube via
+Helm](https://learn.hashicorp.com/vault/getting-started-k8s/minikube) tutorial
+to learn how to set up Consul and Vault in HA mode.
 
 #### External mode
 
@@ -142,10 +142,9 @@ $ helm install vault hashicorp/vault \
     --set "injector.externalVaultAddr=http://external-vault:8200"
 ```
 
--> **Step-by-step instructions:** The [Integrate a Kubernetes Cluster with an
-External
-Vault](https://learn.hashicorp.com/vault/getting-started-k8s/external-vault)
-guide demonstrates using an external Vault within a Kubernetes cluster.
+Refer to the [Integrate a Kubernetes Cluster with an
+External Vault](https://learn.hashicorp.com/vault/getting-started-k8s/external-vault)
+tutorial to learn how to use an external Vault within a Kubernetes cluster.
 
 ### View the Vault UI
 
@@ -514,7 +513,7 @@ We recommend running Vault on Kubernetes with the same
 [general architecture](/docs/internals/architecture)
 as running it anywhere else. There are some benefits Kubernetes can provide
 that eases operating a Vault cluster and we document those below. The standard
-[production deployment guide](https://learn.hashicorp.com/vault/day-one/production-hardening) is still an
+[production deployment](https://learn.hashicorp.com/vault/day-one/production-hardening) tutorial is still an
 important read even if running Vault within Kubernetes.
 
 ### Production Deployment Checklist

--- a/website/content/docs/secrets/key-management/index.mdx
+++ b/website/content/docs/secrets/key-management/index.mdx
@@ -166,10 +166,9 @@ The following table defines which key types are compatible with each KMS provide
 | `ecdsa-p384`   | No              | No      | **Yes**       |
 | `ecdsa-p521`   | No              | No      | No            |
 
-## Learn
+## Tutorial
 
-Refer to the [Key Management Secrets Engine](https://learn.hashicorp.com/collections/vault/key-management) guide for
-a step-by-step tutorial.
+Refer to the [Key Management Secrets Engine](https://learn.hashicorp.com/collections/vault/key-management) tutorial series to learn how to use the key management secrets engine for Azure and GCP.
 
 ## API
 

--- a/website/content/docs/secrets/ssh/one-time-ssh-passwords.mdx
+++ b/website/content/docs/secrets/ssh/one-time-ssh-passwords.mdx
@@ -107,11 +107,11 @@ username@<IP of remote host>:~$
 Note: `sshpass` cannot handle host key checking. Host key checking can be
 disabled by setting `-strict-host-key-checking=no`.
 
-## Learn
+## Tutorial
 
 Refer to the [SSH Secrets Engine: One-Time SSH
-Password](https://learn.hashicorp.com/vault/secrets-management/sm-ssh-otp) guide
-for a step-by-step tutorial.
+Password](https://learn.hashicorp.com/vault/secrets-management/sm-ssh-otp) tutorial
+to learn how to use the Vault SSH secrets engine to secure authentication and authorization for access to machines.
 
 ## API
 

--- a/website/content/docs/upgrading/index.mdx
+++ b/website/content/docs/upgrading/index.mdx
@@ -10,7 +10,7 @@ description: |-
 
 These are general upgrade instructions for Vault for both non-HA and HA setups.
 _Please ensure that you also read any version-specific upgrade notes which can be
-found in the sidebar._ 
+found in the sidebar._
 
 !> **IMPORTANT NOTE:** Always back up your data before upgrading! Vault does not
 make backward-compatibility guarantees for its data store. Simply replacing the
@@ -25,10 +25,10 @@ supported. The upgrade notes for each intervening version must be reviewed. The
 upgrade notes may describe additional steps or configuration to update before,
 during, or after the upgrade.
 
-## Learn
+## Tutorial
 
 Refer to the [Vault Upgrade Standard Procedure](https://learn.hashicorp.com/tutorials/vault/sop-upgrade)
-guide for step-by-step examples of upgrading Vault Enterprise.
+tutorial to learn how to upgrade Vault Enterprise.
 
 ## Agent
 
@@ -94,20 +94,20 @@ At this point all standby nodes will be upgraded and ready to take over. The
 upgrade will not be complete until one of the upgraded standby nodes takes over
 active duty. To do this:
 
-1. Properly shut down the remaining (active) node 
+1. Properly shut down the remaining (active) node
 
-   ~> **Note:** It is important that you shut the node down properly. 
+   ~> **Note:** It is important that you shut the node down properly.
    This will perform a step-down and release the HA lock, allowing a standby
    node to take over with a very short delay.
    If you kill Vault without letting it release the lock, a standby node will
    not be able to take over until the lock's timeout period has expired. This
    is backend-specific but could be ten seconds or more.
-   
+
 2. Replace the Vault binary with the new version; ensure that `mlock()` capability is added to the new binary with [setcap](/docs/configuration#disable_mlock)
-4. Start the node
-5. Unseal the node
+3. Start the node
+4. Unseal the node
 5. Verify `vault status` shows correct Version and HA Mode is `standby`
-7. Review the node's logs to ensure successful startup and unseal
+6. Review the node's logs to ensure successful startup and unseal
 
 Internal upgrade tasks will happen after one of the upgraded standby nodes
 takes over active duty.


### PR DESCRIPTION
To support the DevDot project (targeted for June release), all references to **learn** will be changed to **tutorial**. See [Asana](https://app.asana.com/0/inbox/1200328878163177/1202045912749027/1202045916030210)

This task will be addressed using multiple PRs to make global doc pages more manageable.