### PR TITLE
Vault documentation: batch3--changing references from learn to tutorial

### DIFF
--- a/website/content/docs/agent/autoauth/methods/aws.mdx
+++ b/website/content/docs/agent/autoauth/methods/aws.mdx
@@ -56,12 +56,11 @@ parameters unset in your configuration.
 - `header_value` `(string: optional)` - If configured in Vault, the value to use for
   [`iam_server_id_header_value`](/api-docs/auth/aws#iam_server_id_header_value).
 
-- `nonce` `(string: optional)` - If not provided, Vault will generate a new UUID every time `vault agent` runs. 
-  If set, make sure you understand the importance of generating a good, unique `nonce` and protecting it. 
+- `nonce` `(string: optional)` - If not provided, Vault will generate a new UUID every time `vault agent` runs.
+  If set, make sure you understand the importance of generating a good, unique `nonce` and protecting it.
   See [Client Nonce](/docs/auth/aws#client-nonce) for more information.
 
-## Learn
+## Tutorial
 
 Refer to the [Vault Agent with
-AWS](https://learn.hashicorp.com/vault/identity-access-management/vault-agent-aws)
-guide for a step-by-step tutorial.
+AWS](https://learn.hashicorp.com/vault/identity-access-management/vault-agent-aws) tutorial to learn how to integrate Vault with IAM AWS' native authentication.

--- a/website/content/docs/concepts/identity.mdx
+++ b/website/content/docs/concepts/identity.mdx
@@ -31,11 +31,11 @@ LDAP.
 
 However, if both aliases are created on the same auth mount, such as
 a Github mount, both aliases cannot be mapped to the same entity. The aliases can
-have the same auth type, as long as the auth mounts are different, and 
+have the same auth type, as long as the auth mounts are different, and
 still be associated to the same entity. The diagrams below illustrate both valid
 and invalid scenarios.
 
-![Valid Alias Mapping](/img/vault-identity-doc-4.png) 
+![Valid Alias Mapping](/img/vault-identity-doc-4.png)
 ![Invalid Alias Mapping](/img/vault-identity-doc-5.png)
 
 When a client authenticates via any credential backend (except the Token
@@ -46,7 +46,7 @@ are audit logged, marking a trail of actions performed by specific users.
 
 ~> Vault Entity is used to count the number of Vault clients. To learn more
 about client count, refer to the [Client Count](/docs/concepts/client-count)
-documentation. 
+documentation.
 
 ## Entity Management
 
@@ -81,10 +81,9 @@ identifier, the policies on the token should be taken into account.
 
 ~> **NOTE:** Be careful in granting permissions to non-readonly identity endpoints.
 If a user can modify an entity, they can grant it additional privileges through
-policies.  If a user can modify an alias they can login with, they can bind it to
-an entity with higher privileges.  If a user can modify group membership, they
+policies. If a user can modify an alias they can login with, they can bind it to
+an entity with higher privileges. If a user can modify group membership, they
 can add their entity to a group with higher privileges.
-
 
 ## Mount Bound Aliases
 
@@ -125,13 +124,13 @@ a particular auth mount point.
 
 ## Local Auth Methods
 
-**Vault Enterprise:** All the auth methods will generate an entity by default 
-when a token is being issued, with the exception of token store. This is applicable 
-for both mounts that are shared between clusters and cluster local auth mounts (using `local=true`) 
+**Vault Enterprise:** All the auth methods will generate an entity by default
+when a token is being issued, with the exception of token store. This is applicable
+for both mounts that are shared between clusters and cluster local auth mounts (using `local=true`)
 when Vault replication is in use.
-If the goal of marking an auth method as `local` was to comply to GDPR guidelines, 
-then care must be taken to not set the data pertaining to local auth mount or local auth 
-mount aliases in the metadata of the associated entity. 
+If the goal of marking an auth method as `local` was to comply to GDPR guidelines,
+then care must be taken to not set the data pertaining to local auth mount or local auth
+mount aliases in the metadata of the associated entity.
 
 ## Implicit Entities
 
@@ -189,9 +188,7 @@ subsequent login or renewal operation.
 
 For information about Identity Secrets Engine, refer to [Identity Secrets Engine](/docs/secrets/identity).
 
-
-## Learn
+## Tutorial
 
 Refer to the [Identity: Entities and
-Groups](https://learn.hashicorp.com/tutorials/vault/identity) tutorial for a
-step-by-step tutorial.
+Groups](https://learn.hashicorp.com/tutorials/vault/identity) tutorial to learn how Vault supports mutliple authentication methods and enables the same authentication method to be used with different mount paths.

--- a/website/content/docs/configuration/seal/transit.mdx
+++ b/website/content/docs/configuration/seal/transit.mdx
@@ -54,11 +54,11 @@ These parameters apply to the `seal` stanza in the Vault configuration file:
   decryption. This may also be supplied using the `VAULT_TRANSIT_SEAL_KEY_NAME`
   environment variable.
 
-- `mount_path` `(string: <required>)`: The mount path to the transit secret engine.  
+- `mount_path` `(string: <required>)`: The mount path to the transit secret engine.
   This may also be supplied using the `VAULT_TRANSIT_SEAL_MOUNT_PATH` environment
   variable.
 
-- `namespace` `(string: "")`: The namespace path to the transit secret engine.  
+- `namespace` `(string: "")`: The namespace path to the transit secret engine.
   This may also be supplied using the `VAULT_NAMESPACE` environment variable.
 
 - `disable_renewal` `(string: "false")`: Disables the automatic renewal of the token
@@ -115,7 +115,7 @@ This seal supports key rotation using the Transit Secret Engine's key rotation e
 [doc](/api-docs/secret/transit#rotate-key). Old keys must not be disabled or deleted and are
 used to decrypt older data.
 
-## Learn
+## Tutorial
 
 Refer to the [Auto-unseal using Transit Secrets Engine](https://learn.hashicorp.com/vault/operations/autounseal-transit)
-guide for a step-by-step tutorial.
+tutorial to learn how use the transit secrets engine to automatically unseal Vault.

--- a/website/content/docs/enterprise/control-groups.mdx
+++ b/website/content/docs/enterprise/control-groups.mdx
@@ -25,6 +25,7 @@ Control Groups can verify the following factors:
   groups.
 
 ### Controlled capabilities
+
 Control group factors can be configured to trigger the control group workflow
 on specific capabilities. This is done with the `controlled_capabilities` field.
 Not specifying the `controlled_capabilities` field will necessitate the factor to be
@@ -203,10 +204,10 @@ The above policy will reject the request unless two members of the `managers`
 group have authorized the request. Additionally it verifies the authorizations
 happened in the last hour.
 
-## Learn
+## Tutorial
 
 Refer to the [Control Groups](https://learn.hashicorp.com/vault/identity-access-management/iam-control-groups)
-guide for a step-by-step tutorial.
+tutorial to learn how to implement dual controller authorization within your policies.
 
 ## API
 

--- a/website/content/docs/enterprise/namespaces.mdx
+++ b/website/content/docs/enterprise/namespaces.mdx
@@ -97,7 +97,7 @@ may refer to parent identities (entities and groups) when writing policies that 
 within that child namespace. Similarly, a parent namespace can have policies asserted on child
 identities.
 
-## Learn
+## Tutorial
 
 Refer to the [Secure Multi-Tenancy with Namespaces](https://learn.hashicorp.com/vault/operations/namespaces)
-guide for a step-by-step tutorial.
+tutorial to learn how to use Vault as a Service to allow organizations(tenants) to manage their own secrets and policies.

--- a/website/content/docs/secrets/azure.mdx
+++ b/website/content/docs/secrets/azure.mdx
@@ -21,12 +21,11 @@ If an existing service principal is specified as part of the role configuration,
 a new password will be dynamically generated instead of a new service principal.
 The password will be deleted when the lease is revoked.
 
-~> Microsoft is shutting down their Azure Active Directory API and will be retiring it in
-   2022. If you are currently using this secret engine, you will need to update the
-   credentials to include Microsoft Graph API permissions and specify the
-   `use_microsoft_graph_api` configuration value as true. See the
-   [API Docs](/api-docs/secret/azure#use_microsoft_graph_api) for more details.
-   
+~> Microsoft is shutting down their Azure Active Directory API and will be retiring it in 2022. If you are currently using this secret engine, you will need to update the
+credentials to include Microsoft Graph API permissions and specify the
+`use_microsoft_graph_api` configuration value as true. See the
+[API Docs](/api-docs/secret/azure#use_microsoft_graph_api) for more details.
+
 ## Setup
 
 Most secrets engines must be configured in advance before they can perform their
@@ -198,7 +197,7 @@ If the client ID or secret are not present and Vault is running on an Azure VM, 
 The following Azure permissions should be assigned to the service principal provided to Vault for managing Azure:
 
 | Permission Name               | Type        |
-|-------------------------------|-------------|
+| ----------------------------- | ----------- |
 | Application.Read.All          | Application |
 | Application.ReadWrite.All     | Application |
 | Application.ReadWrite.OwnedBy | Application |
@@ -209,34 +208,33 @@ The following Azure permissions should be assigned to the service principal prov
 | GroupMember.Read.All          | Application |
 | GroupMember.ReadWrite.All     | Application |
 
-| Permission Name               | Type        |
-|-------------------------------|-------------|
-| Application.Read.All          | Delegated   |
-| Application.ReadWrite.All     | Delegated   |
-| Directory.AccessAsUser.All    | Delegated   |
-| Directory.Read.All            | Delegated   |
-| Directory.ReadWrite.All       | Delegated   |
-| Group.Read.All                | Delegated   |
-| Group.ReadWrite.All           | Delegated   |
-| GroupMember.Read.All          | Delegated   |
-| GroupMember.ReadWrite.All     | Delegated   |
+| Permission Name            | Type      |
+| -------------------------- | --------- |
+| Application.Read.All       | Delegated |
+| Application.ReadWrite.All  | Delegated |
+| Directory.AccessAsUser.All | Delegated |
+| Directory.Read.All         | Delegated |
+| Directory.ReadWrite.All    | Delegated |
+| Group.Read.All             | Delegated |
+| Group.ReadWrite.All        | Delegated |
+| GroupMember.Read.All       | Delegated |
+| GroupMember.ReadWrite.All  | Delegated |
 
-Additionally the following IAM roles are required and need to be added to the service 
+Additionally the following IAM roles are required and need to be added to the service
 principal using the Azure portal:
 
 - "Owner" role
 
 ### AAD (Azure Active Directory)
 
-~> Microsoft is shutting down their Azure Active Directory API and will be retiring it in
-   2022. If you are currently using this secret engine, you will need to update the
-   credentials to include Microsoft Graph API permissions and specify the
-   `use_microsoft_graph_api` configuration value as true. See the
-   [API Docs](/api-docs/secret/azure#use_microsoft_graph_api) for more details.
+~> Microsoft is shutting down their Azure Active Directory API and will be retiring it in 2022. If you are currently using this secret engine, you will need to update the
+credentials to include Microsoft Graph API permissions and specify the
+`use_microsoft_graph_api` configuration value as true. See the
+[API Docs](/api-docs/secret/azure#use_microsoft_graph_api) for more details.
 
-As part of the retirement of Azure Active Directory, new service principals can no longer 
-be granted Azure Active Directory permissions using the Azure Portal. To add the neccessary 
-API permissions for AAD, the Azure CLI is suggested. The following commands will add the 
+As part of the retirement of Azure Active Directory, new service principals can no longer
+be granted Azure Active Directory permissions using the Azure Portal. To add the neccessary
+API permissions for AAD, the Azure CLI is suggested. The following commands will add the
 correct privileges to an existing service principal:
 
 ```shell
@@ -254,23 +252,23 @@ az ad app permission add \
 az ad app permission grant --id ${APP_ID?} --api 00000002-0000-0000-c000-000000000000
 ```
 
-Additionally the following IAM roles are required and need to be added to the service 
+Additionally the following IAM roles are required and need to be added to the service
 principal using the Azure portal:
 
 - "Owner" role
 
 ### Migrating From AAD To Microsoft Graph
 
-In this example we will migrate the Azure secret engine from using Azure Active Directory 
+In this example we will migrate the Azure secret engine from using Azure Active Directory
 (AAD) to Microsoft Graph.
 
 First, create a new service principal [with the proper permissions](/docs/secrets/azure#authentication)
-for managing Azure accounts. After granting the appropriate permissions, the following will be needed 
+for managing Azure accounts. After granting the appropriate permissions, the following will be needed
 from the service principal to configure the secret engine:
 
-1. Application (client) ID 
+1. Application (client) ID
 1. Directory (tenant) ID
-1. Client Secret 
+1. Client Secret
 1. Subscription ID
 
 Finally, the Azure secret engine configuration can be updated with the new values:
@@ -341,11 +339,11 @@ Vault releases, but the code is managed separately.
 Please report issues, add feature requests, and submit contributions to the
 [vault-plugin-secrets-azure repo][repo] on GitHub.
 
-## Learn
+## Tutorial
 
 Refer to the [Azure Secrets
-Engine](https://learn.hashicorp.com/vault/secrets-management/azure-creds) guide
-for a step-by-step tutorial.
+Engine](https://learn.hashicorp.com/vault/secrets-management/azure-creds) tutorial
+to learn how to use the AWS secrets engine to dynamically generate AWS credentials.
 
 ## API
 

--- a/website/content/docs/secrets/cubbyhole.mdx
+++ b/website/content/docs/secrets/cubbyhole.mdx
@@ -51,10 +51,10 @@ engine allows for writing keys with arbitrary values.
    my-value    s3cr3t
    ```
 
-## Learn
+## Tutorial
 
 Refer to the [Cubbyhole Response Wrapping](https://learn.hashicorp.com/vault/secrets-management/sm-cubbyhole)
-guide for a step-by-step tutorial.
+tutorial to learn how to securetly distribute the initial token to the trusted entity.
 
 ## API
 

--- a/website/content/docs/secrets/databases/db2.mdx
+++ b/website/content/docs/secrets/databases/db2.mdx
@@ -21,6 +21,9 @@ requirement that users and groups be defined to the operating system.
 
 Vault's [OpenLDAP secrets engine](/docs/secrets/openldap) can be used to manage the lifecycle
 of credentials for Db2 environments that have been configured to delegate user authentication
-and group membership to an LDAP server. A step-by-step guide on using Vault to manage both
-static and dynamic credentials for access to Db2 can be found in the [IBM Db2 Credential Management](https://learn.hashicorp.com/tutorials/vault/ibm-db2-openldap)
-learn tutorial.
+and group membership to an LDAP server.
+
+## Tutorial
+
+Refer to the [IBM Db2 Credential Management](https://learn.hashicorp.com/tutorials/vault/ibm-db2-openldap)
+tutorial to learn how to use Vault to manage both static and dynamic credentials for access to Db2.

--- a/website/content/docs/secrets/kv/kv-v1.mdx
+++ b/website/content/docs/secrets/kv/kv-v1.mdx
@@ -98,11 +98,11 @@ my-value            s3cr3t
 ttl                 30m
 ```
 
-## Learn
+## Tutorial
 
 Refer to the [Static Secrets: Key/Value Secrets
 Engine](https://learn.hashicorp.com/vault/secrets-management/sm-static-secrets)
-guide for a step-by-step tutorial.
+tutorial to learn how to set up a uniform workflow to securely store sensitive information.
 
 ## API
 

--- a/website/content/docs/secrets/transit.mdx
+++ b/website/content/docs/secrets/transit.mdx
@@ -232,11 +232,11 @@ the proper permission, it can use this secrets engine.
     data, since the process would not be able to get access to the plaintext
     data.
 
-## Learn
+## Tutorial
 
 Refer to the [Encryption as a Service: Transit Secrets
 Engine](https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-transit)
-guide for a step-by-step tutorial.
+tutorial to learn how to use the transit secrets engine to handle cryptographic functions on data in-transit.
 
 ## API
 


### PR DESCRIPTION
To support the DevDot project (targeted for June release), all references to **learn** will be changed to **tutorial**. See [Asana](https://app.asana.com/0/inbox/1200328878163177/1202045912749027/1202045916030210)

This task will be addressed using multiple PRs to make global doc pages more manageable.