### PR TITLE
[Vault-5248] MFA support for api login helpers

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -51,9 +51,9 @@ func (a *Auth) MFALogin(ctx context.Context, authMethod AuthMethod, creds ...str
 	return a.twoPhaseMFALogin(ctx, authMethod)
 }
 
-// MFAValidate validates an MFA request using the appropriate payload and a secret containing Auth.MFARequirement,
-// like the returned by MFALogin when credentials are not provided. Upon successful validation the client token
-// will be set accordingly.
+// MFAValidate validates an MFA request using the appropriate payload and a secret containing
+// Auth.MFARequirement, like the one returned by MFALogin when credentials are not provided.
+// Upon successful validation the client token will be set accordingly.
 //
 // The Secret returned is the authentication secret, which if desired can be
 // passed as input to the NewLifetimeWatcher method in order to start

--- a/api/auth.go
+++ b/api/auth.go
@@ -50,8 +50,8 @@ func (a *Auth) MFALogin(ctx context.Context, authMethod AuthMethod, creds ...str
 	return a.twoPhaseLogin(ctx, authMethod)
 }
 
-// MFAValidate validates an MFA request using the secret returned by MFALogin where credentials
-// are not provided and the appropriate payload. Upon successful validation the client token
+// MFAValidate validates an MFA request using the appropriate payload and a secret containing Auth.MFARequirement,
+// like the returned by MFALogin when credentials are not provided. Upon successful validation the client token
 // will be set accordingly.
 func (a *Auth) MFAValidate(ctx context.Context, mfaSecret *Secret, payload map[string]interface{}) (*Secret, error) {
 	if mfaSecret == nil || mfaSecret.Auth == nil || mfaSecret.Auth.MFARequirement == nil {

--- a/api/auth.go
+++ b/api/auth.go
@@ -31,7 +31,45 @@ func (a *Auth) Login(ctx context.Context, authMethod AuthMethod) (*Secret, error
 	if authMethod == nil {
 		return nil, fmt.Errorf("no auth method provided for login")
 	}
+	return a.login(ctx, authMethod)
+}
 
+// MFALogin is a wrapper that helps satisfy Vault's MFA implementation.
+// If optional credentials are provided a single-phase login will be attempted
+// and the resulting Secret will contain a ClientToken if the authentication is successful.
+// The client's token will also be set accordingly. If no credentials are provided a
+// two-phase MFA login will be assumed and the resulting Secret will have a
+// MFARequirement containing the MFARequestID to be used in a follow-up call to `sys/mfa/validate`
+// or by passing it to the method (*Auth).MFAValidate with the appropriate payload.
+func (a *Auth) MFALogin(ctx context.Context, authMethod AuthMethod, creds ...string) (*Secret, error) {
+	if len(creds) > 0 {
+		a.c.SetMFACreds(creds)
+		return a.login(ctx, authMethod)
+	}
+
+	return a.twoPhaseLogin(ctx, authMethod)
+}
+
+// MFAValidate validates an MFA request using the secret returned by MFALogin where credentials
+// are not provided and the appropriate payload. Upon successful validation the client token
+// will be set accordingly.
+func (a *Auth) MFAValidate(ctx context.Context, mfaSecret *Secret, payload map[string]interface{}) (*Secret, error) {
+	if mfaSecret == nil || mfaSecret.Auth == nil || mfaSecret.Auth.MFARequirement == nil {
+		return nil, fmt.Errorf("secret does not contain MFARequirements")
+	}
+
+	s, err := a.c.Sys().MFAValidateWithContext(ctx, mfaSecret.Auth.MFARequirement.GetMFARequestID(), payload)
+	if err != nil {
+		return nil, err
+	}
+
+	a.c.SetToken(s.Auth.ClientToken)
+
+	return s, nil
+}
+
+// login performs the (*AuthMethod).Login() with the configured client and checks that a ClientToken is returned
+func (a *Auth) login(ctx context.Context, authMethod AuthMethod) (*Secret, error) {
 	authSecret, err := authMethod.Login(ctx, a.c)
 	if err != nil {
 		return nil, fmt.Errorf("unable to log in to auth method: %w", err)
@@ -43,4 +81,18 @@ func (a *Auth) Login(ctx context.Context, authMethod AuthMethod) (*Secret, error
 	a.c.SetToken(authSecret.Auth.ClientToken)
 
 	return authSecret, nil
+}
+
+// twoPhaseLogin performs the (*AuthMethod).Login() with the configured client
+// and checks that an MFARequirement is returned
+func (a *Auth) twoPhaseLogin(ctx context.Context, authMethod AuthMethod) (*Secret, error) {
+	mfaSecret, err := authMethod.Login(ctx, a.c)
+	if err != nil {
+		return nil, fmt.Errorf("unable to log in to auth method: %w", err)
+	}
+	if mfaSecret == nil || mfaSecret.Auth == nil || mfaSecret.Auth.MFARequirement == nil {
+		return nil, fmt.Errorf("login response from auth method did not return MFA requirements")
+	}
+
+	return mfaSecret, nil
 }

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type mockAuthMethod struct {
+	mockedSecret *Secret
+	mockedError  error
+}
+
+func (m *mockAuthMethod) Login(_ context.Context, _ *Client) (*Secret, error) {
+	return m.mockedSecret, m.mockedError
+}
+
+func TestAuth_Login(t *testing.T) {
+	a := &Auth{
+		c: &Client{},
+	}
+
+	m := mockAuthMethod{
+		mockedSecret: &Secret{
+			Auth: &SecretAuth{
+				ClientToken: "a-client-token",
+			},
+		},
+		mockedError: nil,
+	}
+
+	t.Run("Login should set token on success", func(t *testing.T) {
+		if a.c.Token() != "" {
+			t.Errorf("client token was %v expected to be unset", a.c.Token())
+		}
+
+		_, err := a.Login(context.Background(), &m)
+		if err != nil {
+			t.Errorf("Login() error = %v", err)
+			return
+		}
+
+		if a.c.Token() != m.mockedSecret.Auth.ClientToken {
+			t.Errorf("client token was %v expected %v", a.c.Token(), m.mockedSecret.Auth.ClientToken)
+			return
+		}
+	})
+}
+
+func TestAuth_MFALogin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MFALogin() should succeed if credentials are passed in", func(t *testing.T) {
+		a := &Auth{
+			c: &Client{},
+		}
+		m := mockAuthMethod{
+			mockedSecret: &Secret{
+				Auth: &SecretAuth{
+					ClientToken: "a-client-token",
+				},
+			},
+			mockedError: nil,
+		}
+
+		_, err := a.MFALogin(context.Background(), &m, "testMethod:testPasscode")
+		if err != nil {
+			t.Errorf("MFALogin() error %v", err)
+			return
+		}
+		if a.c.Token() != m.mockedSecret.Auth.ClientToken {
+			t.Errorf("client token was %v expected %v", a.c.Token(), m.mockedSecret.Auth.ClientToken)
+			return
+		}
+	})
+
+	t.Run("MFALogin() should return requirements if no creds are provided", func(t *testing.T) {
+		a := &Auth{
+			c: &Client{},
+		}
+		m := mockAuthMethod{
+			mockedSecret: &Secret{
+				Auth: &SecretAuth{
+					MFARequirement: &logical.MFARequirement{
+						MFARequestID:   "a-req-id",
+						MFAConstraints: nil,
+					},
+				},
+			},
+			mockedError: nil,
+		}
+
+		secret, err := a.MFALogin(context.Background(), &m)
+		if err != nil {
+			t.Errorf("MFALogin() returned an error: %v", err)
+			return
+		}
+		if secret.Auth.MFARequirement != m.mockedSecret.Auth.MFARequirement {
+			t.Errorf("MFALogin() returned %v, expected %v", secret.Auth.MFARequirement, m.mockedSecret.Auth.MFARequirement)
+			return
+		}
+	})
+
+	t.Run("MFALogin() should error if no creds provided and no requirements returned", func(t *testing.T) {
+		a := &Auth{
+			c: &Client{},
+		}
+		m := mockAuthMethod{
+			mockedSecret: &Secret{
+				Auth: &SecretAuth{},
+			},
+			mockedError: nil,
+		}
+		if _, err := a.MFALogin(context.Background(), &m); err == nil {
+			t.Errorf("MFALogin() should error if no credentials are set and no MFARequirements are returned")
+			return
+		}
+	})
+}

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"context"
-	"github.com/hashicorp/vault/sdk/logical"
 	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 type mockAuthMethod struct {
@@ -95,7 +96,8 @@ func TestAuth_MFALoginTwoPhase(t *testing.T) {
 							MFAConstraints: nil,
 						},
 					},
-				}},
+				},
+			},
 			wantErr: false,
 		},
 		{
@@ -106,7 +108,8 @@ func TestAuth_MFALoginTwoPhase(t *testing.T) {
 			m: &mockAuthMethod{
 				mockedSecret: &Secret{
 					Auth: &SecretAuth{},
-				}},
+				},
+			},
 			wantErr: true,
 		},
 	}

--- a/api/sys_mfa.go
+++ b/api/sys_mfa.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+func (c *Sys) MFAValidate(requestID string, payload map[string]interface{}) (*Secret, error) {
+	return c.MFAValidateWithContext(context.Background(), requestID, payload)
+}
+
+func (c *Sys) MFAValidateWithContext(ctx context.Context, requestID string, payload map[string]interface{}) (*Secret, error) {
+	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
+	defer cancelFunc()
+
+	body := map[string]interface{}{
+		"mfa_request_id": requestID,
+		"mfa_payload":    payload,
+	}
+
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/mfa/validate"))
+	if err := r.SetJSONBody(body); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.c.rawRequestWithContext(ctx, r)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := ParseSecret(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if secret == nil {
+		return nil, fmt.Errorf("data from server response is empty")
+	}
+
+	return secret, nil
+}

--- a/api/sys_mfa.go
+++ b/api/sys_mfa.go
@@ -21,7 +21,7 @@ func (c *Sys) MFAValidateWithContext(ctx context.Context, requestID string, payl
 
 	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/mfa/validate"))
 	if err := r.SetJSONBody(body); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to set request body: %w", err)
 	}
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
@@ -34,7 +34,7 @@ func (c *Sys) MFAValidateWithContext(ctx context.Context, requestID string, payl
 
 	secret, err := ParseSecret(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse secret from response: %w", err)
 	}
 
 	if secret == nil {

--- a/changelog/14900.txt
+++ b/changelog/14900.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Added MFALogin() for handling MFA flow when using login helpers.
+```

--- a/command/base.go
+++ b/command/base.go
@@ -259,8 +259,8 @@ func (c *BaseCommand) validateMFA(reqID string, methodInfo MFAMethodInfo) int {
 	}
 
 	// passcode could be an empty string
-	mfaPayload := map[string][]string{
-		methodInfo.methodID: {passcode},
+	mfaPayload := map[string]interface{}{
+		methodInfo.methodID: []string{passcode},
 	}
 
 	client, err := c.Client()
@@ -269,12 +269,7 @@ func (c *BaseCommand) validateMFA(reqID string, methodInfo MFAMethodInfo) int {
 		return 2
 	}
 
-	path := "sys/mfa/validate"
-
-	secret, err := client.Logical().Write(path, map[string]interface{}{
-		"mfa_request_id": reqID,
-		"mfa_payload":    mfaPayload,
-	})
+	secret, err := client.Sys().MFAValidate(reqID, mfaPayload)
 	if err != nil {
 		c.UI.Error(err.Error())
 		if secret != nil {
@@ -285,7 +280,7 @@ func (c *BaseCommand) validateMFA(reqID string, methodInfo MFAMethodInfo) int {
 	if secret == nil {
 		// Don't output anything unless using the "table" format
 		if Format(c.UI) == "table" {
-			c.UI.Info(fmt.Sprintf("Success! Data written to: %s", path))
+			c.UI.Info("Success! Data written to: sys/mfa/validate")
 		}
 		return 0
 	}

--- a/vault/external_tests/identity/login_mfa_duo_test.go
+++ b/vault/external_tests/identity/login_mfa_duo_test.go
@@ -1,6 +1,7 @@
 package identity
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -241,7 +242,6 @@ func mfaGenerateLoginDUOTest(client *api.Client) error {
 			return fmt.Errorf("failed to configure MFAEnforcementConfig: %v", err)
 		}
 	}
-
 	secret, err = client.Logical().Write("auth/userpass/login/vaultmfa", map[string]interface{}{
 		"password": "testpassword",
 	})
@@ -272,12 +272,11 @@ func mfaGenerateLoginDUOTest(client *api.Client) error {
 	}
 
 	// validation
-	secret, err = client.Logical().Write("sys/mfa/validate", map[string]interface{}{
-		"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,
-		"mfa_payload": map[string][]string{
-			methodID: {},
-		},
-	})
+	secret, err = client.Sys().MFAValidateWithContext(context.Background(),
+		secret.Auth.MFARequirement.MFARequestID,
+		map[string]interface{}{
+			methodID: []string{},
+		})
 	if err != nil {
 		return fmt.Errorf("MFA failed: %v", err)
 	}

--- a/vault/external_tests/identity/login_mfa_okta_test.go
+++ b/vault/external_tests/identity/login_mfa_okta_test.go
@@ -327,7 +327,8 @@ func mfaGenerateOktaLoginMFATest(client *api.Client) error {
 		secret.Auth.MFARequirement.MFARequestID,
 		map[string]interface{}{
 			methodID: []string{},
-		})
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("MFA failed: %v", err)
 	}

--- a/vault/external_tests/identity/login_mfa_okta_test.go
+++ b/vault/external_tests/identity/login_mfa_okta_test.go
@@ -1,6 +1,7 @@
 package identity
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -322,12 +323,11 @@ func mfaGenerateOktaLoginMFATest(client *api.Client) error {
 	}
 
 	// validation
-	secret, err = client.Logical().Write("sys/mfa/validate", map[string]interface{}{
-		"mfa_request_id": secret.Auth.MFARequirement.MFARequestID,
-		"mfa_payload": map[string][]string{
-			methodID: {},
-		},
-	})
+	secret, err = client.Sys().MFAValidateWithContext(context.Background(),
+		secret.Auth.MFARequirement.MFARequestID,
+		map[string]interface{}{
+			methodID: []string{},
+		})
 	if err != nil {
 		return fmt.Errorf("MFA failed: %v", err)
 	}

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -90,7 +90,8 @@ func doTwoPhaseLogin(client *api.Client, totpCodePath, methodID, username string
 		mfaSecret,
 		map[string]interface{}{
 			methodID: []string{totpPasscode},
-		})
+		},
+	)
 	if err != nil {
 		t.Fatalf("MFA validation failed: %v", err)
 	}

--- a/vault/external_tests/identity/login_mfa_totp_test.go
+++ b/vault/external_tests/identity/login_mfa_totp_test.go
@@ -3,10 +3,11 @@ package identity
 import (
 	"context"
 	"fmt"
-	upAuth "github.com/hashicorp/vault/api/auth/userpass"
 	"strings"
 	"testing"
 	"time"
+
+	upAuth "github.com/hashicorp/vault/api/auth/userpass"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
@@ -90,7 +91,6 @@ func doTwoPhaseLogin(client *api.Client, totpCodePath, methodID, username string
 		map[string]interface{}{
 			methodID: []string{totpPasscode},
 		})
-
 	if err != nil {
 		t.Fatalf("MFA validation failed: %v", err)
 	}


### PR DESCRIPTION
This PR adds MFA support for auth methods (login helpers).

*Single Phase MFA with Login Helper*
Pass in credentials using same format as `(*client).SetMFACreds()` as variadic  parameter. This is a simple convenience approach around our existing code. 
```go
// existing code
(*client).SetMFACreds(fmt.Sprintf("%s:%s", methodID, passcode))
(*client).Auth().Login(context.Context, AuthMethod)

// PR simplification
(*client).Auth().MFALogin(context.Context, AuthMethod, fmt.Sprintf("%s:%s", methodID, passcode))
```

*Two Phase MFA with Login Helper*
Flow when no credentials are provided. Performs checks on secret to confirm it contains MFARequirements for follow up call.
```go
mfaSecret, err := (*client).Auth().MFALogin(context.Background(), &AuthMethod)
mfaPayload := map[string]interface{}{
  "method-id": []string{"a-passcode"},
}
authSecret, err := (*client).Auth().MFAValidate(context.Background(), mfaSecret, mfaPayload) 
```

This PR also adds the new method `(*client).Sys().MFAValidateWithContext()` a convenience method for calling `sys/mfa/validate`.