### PR TITLE
Replace mount-filter with path-filter

### DIFF
--- a/ui/lib/replication/addon/templates/mode/secondaries/index.hbs
+++ b/ui/lib/replication/addon/templates/mode/secondaries/index.hbs
@@ -36,9 +36,9 @@
                         <LinkTo
                           @route="mode.secondaries.config-show"
                           @models={{array this.replicationMode secondary}}
-                          data-test-replication-mount-filter-link={{true}}
+                          data-test-replication-path-filter-link={{true}}
                         >
-                          Mount filter config
+                          Path filter config
                         </LinkTo>
                       </li>
                     {{/if}}

--- a/ui/tests/acceptance/enterprise-replication-test.js
+++ b/ui/tests/acceptance/enterprise-replication-test.js
@@ -115,7 +115,7 @@ module('Acceptance | Enterprise | replication', function (hooks) {
 
     await click('[data-test-popup-menu-trigger]');
 
-    await click('[data-test-replication-mount-filter-link]');
+    await click('[data-test-replication-path-filter-link]');
 
     assert.equal(currentURL(), `/vault/replication/performance/secondaries/config/show/${secondaryName}`);
     assert.dom('[data-test-mount-config-mode]').includesText(mode, 'show page renders the correct mode');


### PR DESCRIPTION
The mount-filter endpoint is being deprecated - see PR[ here](https://github.com/hashicorp/vault-enterprise/pull/2716). While we don't use this endpoint we do use the language "mount filter" in one spot. I confirmed that this action is using the path-filter endpoint and changed the language to match the docs that will be updated in 1.11.
