### PR TITLE
sdk/useragent: plugin version string consistent with Vault version string

### DIFF
--- a/sdk/helper/useragent/useragent.go
+++ b/sdk/helper/useragent/useragent.go
@@ -44,12 +44,29 @@ func String(comments ...string) string {
 // Given comments will be appended to the semicolon-delimited comment section.
 //
 // e.g. Vault/0.10.4 (+https://www.vaultproject.io/; azure-auth; go1.10.1; comment-0; comment-1)
+//
+// Returns an empty string if the given env is nil.
 func PluginString(env *logical.PluginEnvironment, pluginName string, comments ...string) string {
+	if env == nil {
+		return ""
+	}
+
+	// Construct comments
 	c := []string{"+" + projectURL}
 	if pluginName != "" {
 		c = append(c, pluginName)
 	}
 	c = append(c, rt)
 	c = append(c, comments...)
-	return fmt.Sprintf("Vault/%s (%s)", env.VaultVersion, strings.Join(c, "; "))
+
+	// Construct version string
+	v := env.VaultVersion
+	if env.VaultVersionPrerelease != "" {
+		v = fmt.Sprintf("%s-%s", v, env.VaultVersionPrerelease)
+	}
+	if env.VaultVersionMetadata != "" {
+		v = fmt.Sprintf("%s+%s", v, env.VaultVersionMetadata)
+	}
+
+	return fmt.Sprintf("Vault/%s (%s)", v, strings.Join(c, "; "))
 }


### PR DESCRIPTION
This PR adds version prerelease and metadata information to the version portion of the User-Agent string returned by `PluginString()`. This makes it consistent with the result that's returned from `String()` (see [useragent.go#L36](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L36)). Prior to this PR, the version portion from `PluginString()` didn't include the version prerelease or metadata. That's now possible with additions from https://github.com/hashicorp/vault/pull/14851.