### PR TITLE
Implement PKI storage migration.

### DIFF
--- a/builtin/logical/pki/config_util.go
+++ b/builtin/logical/pki/config_util.go
@@ -1,0 +1,37 @@
+package pki
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func updateDefaultKeyId(ctx context.Context, s logical.Storage, id keyId) error {
+	config, err := getKeysConfig(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	if config.DefaultKeyId != id {
+		return setKeysConfig(ctx, s, &keyConfig{
+			DefaultKeyId: id,
+		})
+	}
+
+	return nil
+}
+
+func updateDefaultIssuerId(ctx context.Context, s logical.Storage, id issuerId) error {
+	config, err := getIssuersConfig(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	if config.DefaultIssuerId != id {
+		return setIssuersConfig(ctx, s, &issuerConfig{
+			DefaultIssuerId: id,
+		})
+	}
+
+	return nil
+}

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -1,0 +1,166 @@
+package pki
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// This allows us to record the version of the migration code within the log entry
+// in case we find out in the future that something was horribly wrong with the migration,
+// and we need to perform it again...
+const latestMigrationVersion = 1
+
+func migrateStorage(ctx context.Context, req *logical.InitializationRequest, logger log.Logger) error {
+	s := req.Storage
+	legacyBundle, err := getLegacyCertBundle(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	if legacyBundle == nil {
+		// No legacy certs to migrate, we are done...
+		logger.Debug("No legacy certs found, no migration required.")
+		return nil
+	}
+
+	migrationEntry, err := getLegacyBundleMigrationLog(ctx, s)
+	if err != nil {
+		return err
+	}
+	hash, err := computeHashOfLegacyBundle(legacyBundle)
+	if err != nil {
+		return err
+	}
+
+	if migrationEntry != nil {
+		// At this point we have already migrated something previously.
+		if migrationEntry.hash == hash &&
+			migrationEntry.migrationVersion == latestMigrationVersion {
+			// The hashes are the same, no need to try and re-import...
+			logger.Debug("existing migration hash found and matched legacy bundle, skipping migration.")
+			return nil
+		}
+	}
+
+	logger.Warn("performing PKI migration to new keys/issuers layout")
+
+	err = migrateToIssuers(ctx, s, legacyBundle)
+	if err != nil {
+		return err
+	}
+
+	err = setLegacyBundleMigrationLog(ctx, s, &legacyBundleMigration{
+		hash:             hash,
+		created:          time.Now(),
+		migrationVersion: latestMigrationVersion,
+	})
+	if err != nil {
+		return err
+	}
+	logger.Info("successfully completed migration to new keys/issuers layout")
+	return nil
+}
+
+func computeHashOfLegacyBundle(bundle *certutil.CertBundle) (string, error) {
+	// We only hash the main certificate and the certs within the CAChain,
+	// assuming that any sort of change that occurred would have influenced one of those two fields.
+	hasher := sha256.New()
+	if _, err := hasher.Write([]byte(bundle.Certificate)); err != nil {
+		return "", err
+	}
+	for _, cert := range bundle.CAChain {
+		if _, err := hasher.Write([]byte(cert)); err != nil {
+			return "", err
+		}
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func migrateToIssuers(ctx context.Context, s logical.Storage, bundle *certutil.CertBundle) error {
+	defaultKey, _, err := importKey(ctx, s, bundle.PrivateKey)
+	if err != nil {
+		return err
+	}
+
+	defaultIssuer, _, err := importIssuer(ctx, s, bundle.Certificate)
+	if err != nil {
+		return err
+	}
+
+	for _, cert := range bundle.CAChain {
+		if _, _, err = importIssuer(ctx, s, cert); err != nil {
+			return err
+		}
+	}
+
+	if err = updateDefaultKeyId(ctx, s, defaultKey.ID); err != nil {
+		return err
+	}
+
+	if err = updateDefaultIssuerId(ctx, s, defaultIssuer.ID); err != nil {
+		return err
+	}
+
+	// FIXME: Call function that will recompute the CAChain on issuers here.
+	return nil
+}
+
+type legacyBundleMigration struct {
+	hash             string
+	created          time.Time
+	migrationVersion int
+}
+
+func getLegacyBundleMigrationLog(ctx context.Context, s logical.Storage) (*legacyBundleMigration, error) {
+	entry, err := s.Get(ctx, legacyMigrationBundleLogKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if entry == nil {
+		return nil, nil
+	}
+
+	lbm := &legacyBundleMigration{}
+	err = entry.DecodeJSON(lbm)
+	if err != nil {
+		// If we can't decode our bundle, lets scrap it and assume a blank value,
+		// re-running the migration will at most bring back an older certificate/private key
+		return nil, nil
+	}
+	return lbm, nil
+}
+
+func setLegacyBundleMigrationLog(ctx context.Context, s logical.Storage, lbm *legacyBundleMigration) error {
+	json, err := logical.StorageEntryJSON(legacyMigrationBundleLogKey, lbm)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, json)
+}
+
+func getLegacyCertBundle(ctx context.Context, s logical.Storage) (*certutil.CertBundle, error) {
+	entry, err := s.Get(ctx, legacyCertBundlePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if entry == nil {
+		return nil, nil
+	}
+
+	cb := &certutil.CertBundle{}
+	err = entry.DecodeJSON(cb)
+	if err != nil {
+		return nil, err
+	}
+
+	return cb, nil
+}

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -1,0 +1,90 @@
+package pki
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_migrateStorageEmptyStorage(t *testing.T) {
+	ctx := context.Background()
+	b, s := createBackendWithStorage(t)
+	request := &logical.InitializationRequest{Storage: s}
+
+	err := migrateStorage(ctx, request, b.Logger())
+	require.NoError(t, err)
+
+	issuerIds, err := listIssuers(ctx, s)
+	require.NoError(t, err)
+	require.Empty(t, issuerIds)
+
+	keyIds, err := listKeys(ctx, s)
+	require.NoError(t, err)
+	require.Empty(t, keyIds)
+
+	logEntry, err := getLegacyBundleMigrationLog(ctx, s)
+	require.NoError(t, err)
+	require.Nil(t, logEntry)
+}
+
+func Test_migrateStorageSimpleBundle(t *testing.T) {
+	ctx := context.Background()
+	b, s := createBackendWithStorage(t)
+
+	bundle := genCertBundle(t, b)
+	json, err := logical.StorageEntryJSON(legacyCertBundlePath, bundle)
+	require.NoError(t, err)
+	err = s.Put(ctx, json)
+	require.NoError(t, err)
+
+	request := &logical.InitializationRequest{Storage: s}
+
+	err = migrateStorage(ctx, request, b.Logger())
+	require.NoError(t, err)
+
+	issuerIds, err := listIssuers(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(issuerIds))
+
+	keyIds, err := listKeys(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(keyIds))
+
+	logEntry, err := getLegacyBundleMigrationLog(ctx, s)
+	require.NoError(t, err)
+	require.NotNil(t, logEntry)
+
+	issuerId := issuerIds[0]
+	keyId := keyIds[0]
+	issuer, err := fetchIssuerById(ctx, s, issuerId)
+	require.NoError(t, err)
+
+	key, err := fetchKeyById(ctx, s, keyId)
+	require.NoError(t, err)
+
+	require.Equal(t, issuerId, issuer.ID)
+	require.Equal(t, bundle.SerialNumber, issuer.SerialNumber)
+	require.Equal(t, bundle.Certificate, issuer.Certificate)
+	require.Equal(t, keyId, issuer.KeyID)
+	// FIXME: Add tests for CAChain...
+
+	require.Equal(t, keyId, key.ID)
+	require.Equal(t, bundle.PrivateKey, key.PrivateKey)
+	require.Equal(t, bundle.PrivateKeyType, key.PrivateKeyType)
+
+	// Make sure we kept the old bundle
+	certBundle, err := getLegacyCertBundle(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, bundle, certBundle)
+
+	// Make sure we setup the default values
+	keysConfig, err := getKeysConfig(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, &keyConfig{DefaultKeyId: keyId}, keysConfig)
+
+	issuersConfig, err := getIssuersConfig(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, &issuerConfig{DefaultIssuerId: issuerId}, issuersConfig)
+}


### PR DESCRIPTION
 - Hook into the backend::initialize function, calling the migration on a primary only.
 - Migrate an existing certificate bundle to the new issuers and key layout