### PR TITLE
Update vault-plugin-auth-gcp to pseudo-version on main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/hashicorp/vault-plugin-auth-azure v0.10.0
 	github.com/hashicorp/vault-plugin-auth-centrify v0.11.0
 	github.com/hashicorp/vault-plugin-auth-cf v0.11.0
-	github.com/hashicorp/vault-plugin-auth-gcp v0.12.1
+	github.com/hashicorp/vault-plugin-auth-gcp v0.7.1-0.20220405202915-ab4f0f6abd2b
 	github.com/hashicorp/vault-plugin-auth-jwt v0.12.1
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.6.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -962,8 +962,8 @@ github.com/hashicorp/vault-plugin-auth-centrify v0.11.0 h1:W1Al8Kw4VvXm/mtDdzgBa
 github.com/hashicorp/vault-plugin-auth-centrify v0.11.0/go.mod h1:3fDbIVdwA/hkOVhwktKHDX5lo4DqIUUVbBdwQNNvxHw=
 github.com/hashicorp/vault-plugin-auth-cf v0.11.0 h1:W8KkpZv8AHM9eMYrTgCmc9aKac/KORzby7Go0I0MpQ8=
 github.com/hashicorp/vault-plugin-auth-cf v0.11.0/go.mod h1:4HM4amMEcCyoLZNNjyz5AYILIlhMLTErxrinM3Vopy4=
-github.com/hashicorp/vault-plugin-auth-gcp v0.12.1 h1:LOxL1IedHBEkgziRelh3yv8gIKognoyRDqTuhJFZsr4=
-github.com/hashicorp/vault-plugin-auth-gcp v0.12.1/go.mod h1:mNOajlE7KlNecnCqO1we+PG0/EIHgHMTuVhk/H2W+Tw=
+github.com/hashicorp/vault-plugin-auth-gcp v0.7.1-0.20220405202915-ab4f0f6abd2b h1:nrHWBFZOvSmjnrQmoCZ9GQXs2awypQhxpMI82JCVEM8=
+github.com/hashicorp/vault-plugin-auth-gcp v0.7.1-0.20220405202915-ab4f0f6abd2b/go.mod h1:M5FmdM8Af2X/DNQPPIIkXXKEboy6hqXwN/67tiwl/m8=
 github.com/hashicorp/vault-plugin-auth-jwt v0.12.1 h1:F8aNPecN7Bihyndku9g1XrGOy4ioQM8JE+Uhg/e8nFY=
 github.com/hashicorp/vault-plugin-auth-jwt v0.12.1/go.mod h1:+WL5kaq/0L5OROsA31X15U8yTIX4GTEv1rTLA9d15eo=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.6.0 h1:5GiKYqA8NTW9QPA1gahok2CVTKwa50lccB30i3GLffk=


### PR DESCRIPTION
This PR updates vault-plugin-auth-gcp to pull the latest from main for testing.