### PR TITLE
UI/Add client counts by month to api

### DIFF
--- a/ui/app/models/clients/activity.js
+++ b/ui/app/models/clients/activity.js
@@ -1,10 +1,12 @@
 import Model, { attr } from '@ember-data/model';
 export default class Activity extends Model {
-  @attr('string') responseTimestamp;
+  @attr('array') byMonthTotalClients;
+  @attr('array') byMonthNewClients;
   @attr('array') byNamespace;
+  @attr('object') total;
   @attr('array') formattedEndTime;
   @attr('array') formattedStartTime;
   @attr('string') startTime;
   @attr('string') endTime;
-  @attr('object') total;
+  @attr('string') responseTimestamp;
 }

--- a/ui/app/serializers/clients/activity.js
+++ b/ui/app/serializers/clients/activity.js
@@ -1,5 +1,5 @@
 import ApplicationSerializer from '../application';
-import { format, formatISO } from 'date-fns';
+import { formatISO } from 'date-fns';
 export default class ActivitySerializer extends ApplicationSerializer {
   flattenDataset(byNamespaceArray) {
     return byNamespaceArray.map((ns) => {
@@ -33,7 +33,7 @@ export default class ActivitySerializer extends ApplicationSerializer {
     if (isNewClients) {
       return payload.map((m) => {
         return {
-          month: format(new Date(m.timestamp), 'M/yy'),
+          month: m.timestamp,
           entity_clients: m['new_clients']['counts']['entity_clients'],
           non_entity_clients: m['new_clients']['counts']['non_entity_clients'],
           total: m['new_clients']['counts']['clients'],
@@ -43,7 +43,7 @@ export default class ActivitySerializer extends ApplicationSerializer {
     } else {
       return payload.map((m) => {
         return {
-          month: format(new Date(m.timestamp), 'M/yy'),
+          month: m.timestamp,
           entity_clients: m['counts']['entity_clients'],
           non_entity_clients: m['counts']['non_entity_clients'],
           total: m['counts']['clients'],
@@ -109,7 +109,6 @@ export default class ActivitySerializer extends ApplicationSerializer {
     delete payload.data.by_namespace;
     delete payload.data.months;
     delete payload.data.total;
-    console.log(transformedPayload, 'TRASNFORMED');
     return super.normalizeResponse(store, primaryModelClass, transformedPayload, id, requestType);
   }
 }

--- a/ui/mirage/handlers/clients.js
+++ b/ui/mirage/handlers/clients.js
@@ -210,7 +210,7 @@ export default function (server) {
                 },
                 mounts: [
                   {
-                    path: 'auth/up2/',
+                    mount_path: 'auth/up2/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 8,
@@ -220,7 +220,7 @@ export default function (server) {
                     },
                   },
                   {
-                    path: 'auth/up1/',
+                    mount_path: 'auth/up1/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 0,
@@ -243,7 +243,7 @@ export default function (server) {
                 },
                 mounts: [
                   {
-                    path: 'auth/up1/',
+                    mount_path: 'auth/up1/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 0,
@@ -253,7 +253,7 @@ export default function (server) {
                     },
                   },
                   {
-                    path: 'auth/up2/',
+                    mount_path: 'auth/up2/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 5,
@@ -286,7 +286,7 @@ export default function (server) {
                   },
                   mounts: [
                     {
-                      path: 'auth/up2/',
+                      mount_path: 'auth/up2/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 3,
@@ -296,7 +296,7 @@ export default function (server) {
                       },
                     },
                     {
-                      path: 'auth/up1/',
+                      mount_path: 'auth/up1/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 0,
@@ -332,7 +332,7 @@ export default function (server) {
                 },
                 mounts: [
                   {
-                    path: 'auth/up1/',
+                    mount_path: 'auth/up1/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 0,
@@ -342,7 +342,7 @@ export default function (server) {
                     },
                   },
                   {
-                    path: 'auth/up2/',
+                    mount_path: 'auth/up2/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 5,
@@ -365,7 +365,7 @@ export default function (server) {
                 },
                 mounts: [
                   {
-                    path: 'auth/up1/',
+                    mount_path: 'auth/up1/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 0,
@@ -375,7 +375,7 @@ export default function (server) {
                     },
                   },
                   {
-                    path: 'auth/up2/',
+                    mount_path: 'auth/up2/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 2,
@@ -398,7 +398,7 @@ export default function (server) {
                 },
                 mounts: [
                   {
-                    path: 'auth/up2/',
+                    mount_path: 'auth/up2/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 3,
@@ -408,7 +408,7 @@ export default function (server) {
                     },
                   },
                   {
-                    path: 'auth/up1/',
+                    mount_path: 'auth/up1/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 0,
@@ -441,7 +441,7 @@ export default function (server) {
                   },
                   mounts: [
                     {
-                      path: 'auth/up1/',
+                      mount_path: 'auth/up1/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 0,
@@ -451,7 +451,7 @@ export default function (server) {
                       },
                     },
                     {
-                      path: 'auth/up2/',
+                      mount_path: 'auth/up2/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 5,
@@ -474,7 +474,7 @@ export default function (server) {
                   },
                   mounts: [
                     {
-                      path: 'auth/up1/',
+                      mount_path: 'auth/up1/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 0,
@@ -484,7 +484,7 @@ export default function (server) {
                       },
                     },
                     {
-                      path: 'auth/up2/',
+                      mount_path: 'auth/up2/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 2,
@@ -507,7 +507,7 @@ export default function (server) {
                   },
                   mounts: [
                     {
-                      path: 'auth/up2/',
+                      mount_path: 'auth/up2/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 3,
@@ -517,7 +517,7 @@ export default function (server) {
                       },
                     },
                     {
-                      path: 'auth/up1/',
+                      mount_path: 'auth/up1/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 0,
@@ -553,7 +553,7 @@ export default function (server) {
                 },
                 mounts: [
                   {
-                    path: 'auth/up1/',
+                    mount_path: 'auth/up1/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 0,
@@ -563,7 +563,7 @@ export default function (server) {
                     },
                   },
                   {
-                    path: 'auth/up2/',
+                    mount_path: 'auth/up2/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 5,
@@ -586,7 +586,7 @@ export default function (server) {
                 },
                 mounts: [
                   {
-                    path: 'auth/up1/',
+                    mount_path: 'auth/up1/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 0,
@@ -596,7 +596,7 @@ export default function (server) {
                     },
                   },
                   {
-                    path: 'auth/up2/',
+                    mount_path: 'auth/up2/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 2,
@@ -629,7 +629,7 @@ export default function (server) {
                   },
                   mounts: [
                     {
-                      path: 'auth/up1/',
+                      mount_path: 'auth/up1/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 0,
@@ -639,7 +639,7 @@ export default function (server) {
                       },
                     },
                     {
-                      path: 'auth/up2/',
+                      mount_path: 'auth/up2/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 2,
@@ -675,7 +675,7 @@ export default function (server) {
                 },
                 mounts: [
                   {
-                    path: 'auth/up2/',
+                    mount_path: 'auth/up2/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 5,
@@ -685,7 +685,7 @@ export default function (server) {
                     },
                   },
                   {
-                    path: 'auth/up1/',
+                    mount_path: 'auth/up1/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 0,
@@ -718,7 +718,7 @@ export default function (server) {
                   },
                   mounts: [
                     {
-                      path: 'auth/up2/',
+                      mount_path: 'auth/up2/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 3,
@@ -728,7 +728,7 @@ export default function (server) {
                       },
                     },
                     {
-                      path: 'auth/up1/',
+                      mount_path: 'auth/up1/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 0,
@@ -764,7 +764,7 @@ export default function (server) {
                 },
                 mounts: [
                   {
-                    path: 'auth/up1/',
+                    mount_path: 'auth/up1/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 0,
@@ -774,7 +774,7 @@ export default function (server) {
                     },
                   },
                   {
-                    path: 'auth/up2/',
+                    mount_path: 'auth/up2/',
                     counts: {
                       distinct_entities: 0,
                       entity_clients: 2,
@@ -807,7 +807,7 @@ export default function (server) {
                   },
                   mounts: [
                     {
-                      path: 'auth/up1/',
+                      mount_path: 'auth/up1/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 0,
@@ -817,7 +817,7 @@ export default function (server) {
                       },
                     },
                     {
-                      path: 'auth/up2/',
+                      mount_path: 'auth/up2/',
                       counts: {
                         distinct_entities: 0,
                         entity_clients: 2,

--- a/ui/mirage/handlers/clients.js
+++ b/ui/mirage/handlers/clients.js
@@ -187,7 +187,651 @@ export default function (server) {
           },
         ],
         end_time: end_time || formatISO(sub(new Date(), { months: 1 })),
-        months: [],
+        months: [
+          {
+            timestamp: '2021-05-01T00:00:00Z',
+            counts: {
+              distinct_entities: 0,
+              entity_clients: 13,
+              non_entity_tokens: 0,
+              non_entity_clients: 12,
+              clients: 25,
+            },
+            namespaces: [
+              {
+                namespace_id: 'root',
+                namespace_path: '',
+                counts: {
+                  distinct_entities: 0,
+                  entity_clients: 8,
+                  non_entity_tokens: 0,
+                  non_entity_clients: 7,
+                  clients: 15,
+                },
+                mounts: [
+                  {
+                    path: 'auth/up2/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 8,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 0,
+                      clients: 8,
+                    },
+                  },
+                  {
+                    path: 'auth/up1/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 0,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 7,
+                      clients: 7,
+                    },
+                  },
+                ],
+              },
+              {
+                namespace_id: 's07UR',
+                namespace_path: 'ns1/',
+                counts: {
+                  distinct_entities: 0,
+                  entity_clients: 5,
+                  non_entity_tokens: 0,
+                  non_entity_clients: 5,
+                  clients: 10,
+                },
+                mounts: [
+                  {
+                    path: 'auth/up1/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 0,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 5,
+                      clients: 5,
+                    },
+                  },
+                  {
+                    path: 'auth/up2/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 5,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 0,
+                      clients: 5,
+                    },
+                  },
+                ],
+              },
+            ],
+            new_clients: {
+              counts: {
+                distinct_entities: 0,
+                entity_clients: 3,
+                non_entity_tokens: 0,
+                non_entity_clients: 2,
+                clients: 5,
+              },
+              namespaces: [
+                {
+                  namespace_id: 'root',
+                  namespace_path: '',
+                  counts: {
+                    distinct_entities: 0,
+                    entity_clients: 3,
+                    non_entity_tokens: 0,
+                    non_entity_clients: 2,
+                    clients: 5,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/up2/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 3,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 0,
+                        clients: 3,
+                      },
+                    },
+                    {
+                      path: 'auth/up1/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 0,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 2,
+                        clients: 2,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            timestamp: '2021-04-01T00:00:00Z',
+            counts: {
+              distinct_entities: 0,
+              entity_clients: 10,
+              non_entity_tokens: 0,
+              non_entity_clients: 10,
+              clients: 20,
+            },
+            namespaces: [
+              {
+                namespace_id: 'oImjk',
+                namespace_path: 'ns2/',
+                counts: {
+                  distinct_entities: 0,
+                  entity_clients: 5,
+                  non_entity_tokens: 0,
+                  non_entity_clients: 5,
+                  clients: 10,
+                },
+                mounts: [
+                  {
+                    path: 'auth/up1/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 0,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 5,
+                      clients: 5,
+                    },
+                  },
+                  {
+                    path: 'auth/up2/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 5,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 0,
+                      clients: 5,
+                    },
+                  },
+                ],
+              },
+              {
+                namespace_id: 'root',
+                namespace_path: '',
+                counts: {
+                  distinct_entities: 0,
+                  entity_clients: 2,
+                  non_entity_tokens: 0,
+                  non_entity_clients: 3,
+                  clients: 5,
+                },
+                mounts: [
+                  {
+                    path: 'auth/up1/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 0,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 3,
+                      clients: 3,
+                    },
+                  },
+                  {
+                    path: 'auth/up2/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 2,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 0,
+                      clients: 2,
+                    },
+                  },
+                ],
+              },
+              {
+                namespace_id: 's07UR',
+                namespace_path: 'ns1/',
+                counts: {
+                  distinct_entities: 0,
+                  entity_clients: 3,
+                  non_entity_tokens: 0,
+                  non_entity_clients: 2,
+                  clients: 5,
+                },
+                mounts: [
+                  {
+                    path: 'auth/up2/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 3,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 0,
+                      clients: 3,
+                    },
+                  },
+                  {
+                    path: 'auth/up1/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 0,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 2,
+                      clients: 2,
+                    },
+                  },
+                ],
+              },
+            ],
+            new_clients: {
+              counts: {
+                distinct_entities: 0,
+                entity_clients: 10,
+                non_entity_tokens: 0,
+                non_entity_clients: 10,
+                clients: 20,
+              },
+              namespaces: [
+                {
+                  namespace_id: 'oImjk',
+                  namespace_path: 'ns2/',
+                  counts: {
+                    distinct_entities: 0,
+                    entity_clients: 5,
+                    non_entity_tokens: 0,
+                    non_entity_clients: 5,
+                    clients: 10,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/up1/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 0,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 5,
+                        clients: 5,
+                      },
+                    },
+                    {
+                      path: 'auth/up2/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 5,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 0,
+                        clients: 5,
+                      },
+                    },
+                  ],
+                },
+                {
+                  namespace_id: 'root',
+                  namespace_path: '',
+                  counts: {
+                    distinct_entities: 0,
+                    entity_clients: 2,
+                    non_entity_tokens: 0,
+                    non_entity_clients: 3,
+                    clients: 5,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/up1/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 0,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 3,
+                        clients: 3,
+                      },
+                    },
+                    {
+                      path: 'auth/up2/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 2,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 0,
+                        clients: 2,
+                      },
+                    },
+                  ],
+                },
+                {
+                  namespace_id: 's07UR',
+                  namespace_path: 'ns1/',
+                  counts: {
+                    distinct_entities: 0,
+                    entity_clients: 3,
+                    non_entity_tokens: 0,
+                    non_entity_clients: 2,
+                    clients: 5,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/up2/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 3,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 0,
+                        clients: 3,
+                      },
+                    },
+                    {
+                      path: 'auth/up1/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 0,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 2,
+                        clients: 2,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            timestamp: '2021-03-01T00:00:00Z',
+            counts: {
+              distinct_entities: 0,
+              entity_clients: 7,
+              non_entity_tokens: 0,
+              non_entity_clients: 8,
+              clients: 15,
+            },
+            namespaces: [
+              {
+                namespace_id: 'root',
+                namespace_path: '',
+                counts: {
+                  distinct_entities: 0,
+                  entity_clients: 5,
+                  non_entity_tokens: 0,
+                  non_entity_clients: 5,
+                  clients: 10,
+                },
+                mounts: [
+                  {
+                    path: 'auth/up1/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 0,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 5,
+                      clients: 5,
+                    },
+                  },
+                  {
+                    path: 'auth/up2/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 5,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 0,
+                      clients: 5,
+                    },
+                  },
+                ],
+              },
+              {
+                namespace_id: 's07UR',
+                namespace_path: 'ns1/',
+                counts: {
+                  distinct_entities: 0,
+                  entity_clients: 2,
+                  non_entity_tokens: 0,
+                  non_entity_clients: 3,
+                  clients: 5,
+                },
+                mounts: [
+                  {
+                    path: 'auth/up1/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 0,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 3,
+                      clients: 3,
+                    },
+                  },
+                  {
+                    path: 'auth/up2/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 2,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 0,
+                      clients: 2,
+                    },
+                  },
+                ],
+              },
+            ],
+            new_clients: {
+              counts: {
+                distinct_entities: 0,
+                entity_clients: 2,
+                non_entity_tokens: 0,
+                non_entity_clients: 3,
+                clients: 5,
+              },
+              namespaces: [
+                {
+                  namespace_id: 's07UR',
+                  namespace_path: 'ns1/',
+                  counts: {
+                    distinct_entities: 0,
+                    entity_clients: 2,
+                    non_entity_tokens: 0,
+                    non_entity_clients: 3,
+                    clients: 5,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/up1/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 0,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 3,
+                        clients: 3,
+                      },
+                    },
+                    {
+                      path: 'auth/up2/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 2,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 0,
+                        clients: 2,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            timestamp: '2021-02-01T00:00:00Z',
+            counts: {
+              distinct_entities: 0,
+              entity_clients: 5,
+              non_entity_tokens: 0,
+              non_entity_clients: 5,
+              clients: 10,
+            },
+            namespaces: [
+              {
+                namespace_id: 'root',
+                namespace_path: '',
+                counts: {
+                  distinct_entities: 0,
+                  entity_clients: 5,
+                  non_entity_tokens: 0,
+                  non_entity_clients: 5,
+                  clients: 10,
+                },
+                mounts: [
+                  {
+                    path: 'auth/up2/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 5,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 0,
+                      clients: 5,
+                    },
+                  },
+                  {
+                    path: 'auth/up1/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 0,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 5,
+                      clients: 5,
+                    },
+                  },
+                ],
+              },
+            ],
+            new_clients: {
+              counts: {
+                distinct_entities: 0,
+                entity_clients: 3,
+                non_entity_tokens: 0,
+                non_entity_clients: 2,
+                clients: 5,
+              },
+              namespaces: [
+                {
+                  namespace_id: 'root',
+                  namespace_path: '',
+                  counts: {
+                    distinct_entities: 0,
+                    entity_clients: 3,
+                    non_entity_tokens: 0,
+                    non_entity_clients: 2,
+                    clients: 5,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/up2/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 3,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 0,
+                        clients: 3,
+                      },
+                    },
+                    {
+                      path: 'auth/up1/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 0,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 2,
+                        clients: 2,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            timestamp: '2021-01-01T00:00:00Z',
+            counts: {
+              distinct_entities: 0,
+              entity_clients: 2,
+              non_entity_tokens: 0,
+              non_entity_clients: 3,
+              clients: 5,
+            },
+            namespaces: [
+              {
+                namespace_id: 'root',
+                namespace_path: '',
+                counts: {
+                  distinct_entities: 0,
+                  entity_clients: 2,
+                  non_entity_tokens: 0,
+                  non_entity_clients: 3,
+                  clients: 5,
+                },
+                mounts: [
+                  {
+                    path: 'auth/up1/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 0,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 3,
+                      clients: 3,
+                    },
+                  },
+                  {
+                    path: 'auth/up2/',
+                    counts: {
+                      distinct_entities: 0,
+                      entity_clients: 2,
+                      non_entity_tokens: 0,
+                      non_entity_clients: 0,
+                      clients: 2,
+                    },
+                  },
+                ],
+              },
+            ],
+            new_clients: {
+              counts: {
+                distinct_entities: 0,
+                entity_clients: 2,
+                non_entity_tokens: 0,
+                non_entity_clients: 3,
+                clients: 5,
+              },
+              namespaces: [
+                {
+                  namespace_id: 'root',
+                  namespace_path: '',
+                  counts: {
+                    distinct_entities: 0,
+                    entity_clients: 2,
+                    non_entity_tokens: 0,
+                    non_entity_clients: 3,
+                    clients: 5,
+                  },
+                  mounts: [
+                    {
+                      path: 'auth/up1/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 0,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 3,
+                        clients: 3,
+                      },
+                    },
+                    {
+                      path: 'auth/up2/',
+                      counts: {
+                        distinct_entities: 0,
+                        entity_clients: 2,
+                        non_entity_tokens: 0,
+                        non_entity_clients: 0,
+                        clients: 2,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
         start_time: isBefore(new Date(start_time), new Date(counts_start)) ? counts_start : start_time,
         total: {
           distinct_entities: 37389,


### PR DESCRIPTION
This PR adds the `months` key from the `/activity` response to the serializer so it can be consumed by the UI for the 1.11 client count designs.

This will be one of a series of PRs - will add a changelog for the feature work to the final PR