### PR TITLE
Fix handling of SignatureBits for ECDSA issuers

### DIFF
--- a/changelog/14943.txt
+++ b/changelog/14943.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets/pki: Fixed bug where larger SHA-2 hashes were truncated with shorter ECDSA CA certificates
+```

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -585,17 +585,8 @@ func DefaultOrValueKeyBits(keyType string, keyBits int) (int, error) {
 // certain internal circumstances.
 func DefaultOrValueHashBits(keyType string, keyBits int, hashBits int) (int, error) {
 	if keyType == "ec" {
-		// To comply with BSI recommendations Section 4.2 and Mozilla root
-		// store policy section 5.1.2, enforce that NIST P-curves use a hash
-		// length corresponding to curve length. Note that ed25519 does not
-		// the "ec" key type.
-		expectedHashBits := expectedNISTPCurveHashBits[keyBits]
-
-		if expectedHashBits != hashBits && hashBits != 0 {
-			return hashBits, fmt.Errorf("unsupported signature hash algorithm length (%d) for NIST P-%d", hashBits, keyBits)
-		} else if hashBits == 0 {
-			hashBits = expectedHashBits
-		}
+		// Enforcement of curve moved to selectSignatureAlgorithmForECDSA. See
+		// note there about why.
 	} else if keyType == "rsa" && hashBits == 0 {
 		// To match previous behavior (and ignoring NIST's recommendations for
 		// hash size to align with RSA key sizes), default to SHA-2-256.
@@ -643,7 +634,7 @@ func ValidateDefaultOrValueKeyTypeSignatureLength(keyType string, keyBits int, h
 // Validates that the length of the hash (in bits) used in the signature
 // calculation is a known, approved value.
 func ValidateSignatureLength(keyType string, hashBits int) error {
-	if keyType == "any" || keyType == "ed25519" || keyType == "ed448" {
+	if keyType == "any" || keyType == "ec" || keyType == "ed25519" || keyType == "ed448" {
 		// ed25519 and ed448 include built-in hashing and is not externally
 		// configurable. There are three modes for each of these schemes:
 		//
@@ -658,6 +649,10 @@ func ValidateSignatureLength(keyType string, hashBits int) error {
 		//
 		// Additionally, when KeyType is any, we can't yet validate the
 		// signature algorithm size, so it takes the default zero value.
+		//
+		// When KeyType is ec, we also can't validate this value as we're
+		// forcefully ignoring the users' choice and specifying a value based
+		// on issuer type.
 		return nil
 	}
 
@@ -863,16 +858,25 @@ func createCertificate(data *CreationBundle, randReader io.Reader, privateKeyGen
 }
 
 func selectSignatureAlgorithmForECDSA(pub crypto.PublicKey, signatureBits int) x509.SignatureAlgorithm {
-	// If signature bits are configured, prefer them to the default choice.
-	switch signatureBits {
-	case 256:
-		return x509.ECDSAWithSHA256
-	case 384:
-		return x509.ECDSAWithSHA384
-	case 512:
-		return x509.ECDSAWithSHA512
-	}
-
+	// Previously we preferred the user-specified signature bits for ECDSA
+	// keys. However, this could result in using a longer hash function than
+	// the underlying NIST P-curve will encode (e.g., a SHA-512 hash with a
+	// P-256 key). This isn't ideal: the hash is implicitly truncated
+	// (effectively turning it into SHA-512/256) and we then need to rely
+	// on the prefix security of the hash. Since both NIST and Mozilla guidance
+	// suggest instead using the correct hash function, we should prefer that
+	// over the operator-specified signatureBits.
+	//
+	// Lastly, note that pub above needs to be the _signer's_ public key;
+	// the issue with DefaultOrValueHashBits is that it is called at role
+	// configuration time, which might _precede_ issuer generation. Thus
+	// it only has access to the desired key type and not the actual issuer.
+	// The reference from that function is reproduced below:
+	//
+	// > To comply with BSI recommendations Section 4.2 and Mozilla root
+	// > store policy section 5.1.2, enforce that NIST P-curves use a hash
+	// > length corresponding to curve length. Note that ed25519 does not
+	// > implement the "ec" key type.
 	key, ok := pub.(*ecdsa.PublicKey)
 	if !ok {
 		return x509.ECDSAWithSHA256

--- a/website/content/api-docs/secret/pki.mdx
+++ b/website/content/api-docs/secret/pki.mdx
@@ -973,6 +973,10 @@ request is denied.
   on key length (SHA-2-256 for RSA keys, and matching the curve size
   for NIST P-Curves).
 
+~> **Note**: ECDSA and Ed25519 issuers do not follow configuration of the
+   `signature_bits` value; only RSA issuers will change signature types
+   based on this parameter.
+
 - `key_usage` `(list: ["DigitalSignature", "KeyAgreement", "KeyEncipherment"])` –
   Specifies the allowed key usage constraint on issued certificates. Valid
   values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply


### PR DESCRIPTION
When adding SignatureBits control logic, we incorrectly allowed
specification of SignatureBits in the case of an ECDSA issuer. As noted
in the original request, NIST and Mozilla (and others) are fairly
prescriptive in the choice of signatures (matching the size of the
NIST P-curve), and we shouldn't usually use a smaller (or worse, larger
and truncate!) hash.

Ignore the configuration of signature bits and always use autodetection
for ECDSA like ed25519.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

This definitely warrants a changelog entry, but not sure if we need anything else? This was added in 1.10.0, we'll backport this to 1.10.1, fixing the issue. It only presently works on roles (it should probably be added to the other endpoints later?). 

Ticket: VAULT-5707