### PR TITLE
Vault Raw Read Support (CLI & Client) 

### DIFF
--- a/changelog/14945.txt
+++ b/changelog/14945.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Support the -format=raw option, to read non-JSON Vault endpoints and original response bodies.
+```

--- a/command/format.go
+++ b/command/format.go
@@ -70,6 +70,7 @@ var Formatters = map[string]Formatter{
 	"yaml":   YamlFormatter{},
 	"yml":    YamlFormatter{},
 	"pretty": PrettyFormatter{},
+	"raw":    RawFormatter{},
 }
 
 func Format(ui cli.Ui) string {
@@ -121,6 +122,28 @@ func (j JsonFormatter) Output(ui cli.Ui, secret *api.Secret, data interface{}) e
 		}
 	}
 
+	ui.Output(string(b))
+	return nil
+}
+
+// An output formatter for raw output of the original request object
+type RawFormatter struct{}
+
+func (r RawFormatter) Format(data interface{}) ([]byte, error) {
+	byte_data, ok := data.([]byte)
+	if !ok {
+		panic("backtrace")
+		return nil, fmt.Errorf("unable to type assert to []byte: %T", data)
+	}
+
+	return byte_data, nil
+}
+
+func (r RawFormatter) Output(ui cli.Ui, secret *api.Secret, data interface{}) error {
+	b, err := r.Format(data)
+	if err != nil {
+		return err
+	}
 	ui.Output(string(b))
 	return nil
 }

--- a/command/format.go
+++ b/command/format.go
@@ -132,8 +132,7 @@ type RawFormatter struct{}
 func (r RawFormatter) Format(data interface{}) ([]byte, error) {
 	byte_data, ok := data.([]byte)
 	if !ok {
-		panic("backtrace")
-		return nil, fmt.Errorf("unable to type assert to []byte: %T", data)
+		return nil, fmt.Errorf("unable to type assert to []byte: %T; please share the command run", data)
 	}
 
 	return byte_data, nil

--- a/command/read.go
+++ b/command/read.go
@@ -91,19 +91,40 @@ func (c *ReadCommand) Run(args []string) int {
 		return 1
 	}
 
-	secret, err := client.Logical().ReadWithData(path, data)
+	if Format(c.UI) != "raw" {
+		secret, err := client.Logical().ReadWithData(path, data)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error reading %s: %s", path, err))
+			return 2
+		}
+		if secret == nil {
+			c.UI.Error(fmt.Sprintf("No value found at %s", path))
+			return 2
+		}
+
+		if c.flagField != "" {
+			return PrintRawField(c.UI, secret, c.flagField)
+		}
+
+		return OutputSecret(c.UI, secret)
+	}
+
+	resp, err := client.Logical().ReadRawWithData(path, data)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error reading %s: %s", path, err))
+		c.UI.Error(fmt.Sprintf("Error reading: %s: %s", path, err))
 		return 2
 	}
-	if secret == nil {
+	if resp == nil || resp.Body == nil {
 		c.UI.Error(fmt.Sprintf("No value found at %s", path))
 		return 2
 	}
+	defer resp.Body.Close()
 
-	if c.flagField != "" {
-		return PrintRawField(c.UI, secret, c.flagField)
+	contents, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading: %s: %s", path, err))
+		return 2
 	}
 
-	return OutputSecret(c.UI, secret)
+	return OutputData(c.UI, contents)
 }


### PR DESCRIPTION
Not really sure who should own this work :-) I realize the approach hasn't been popular in the past...
...but I figured I'd re-open a branch I had with this change to see where it'll go this time.

We expose a `ReadRaw...` operations, which returns a raw `Response` rather than a parsed `Secret`. This allows us to hit endpoints (such as the various PKI endpoints -- which are ever-expanding) which return non-JSON formatted responses from both the Client and the API. These responses include DER and PEM-formatted bundles.

From a CLI perspective, this lets the following succeed, which IMO, is a big improvement over the existing behavior:

```
$ vault read -format=raw pki/ca/pem
-----BEGIN CERTIFICATE-----
MIIDNTCCAh2gAwIBAgIUNTLfhEuAQITKoNnJWDrnJXrLDHwwDQYJKoZIhvcNAQEL
BQAwFjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMjIwNDAxMTk0NTU5WhcNMjIw
NTAzMTk0NjI5WjAWMRQwEgYDVQQDEwtleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcN
AQEBBQADggEPADCCAQoCggEBALtkk7bWsgwl4hqScjz2Fp+5imFYzLlSqAdG40Lf
HRu/EhomNm4tFufjY+AFZaF0wDergnRd1w/FSWczkmzwqCnJDaUHFGyjX1aTB8DJ
/3VnoNTuHewIDylR543/A/p73a+zzbQKvTDKLaGW3Z0AOCuwdiMz0un4GWh+6TLw
K+OWwgm7XaaiDZc5MSCj2g9f8qZyHaUNyKhrvkNI5HDr5IVT8JLFnmP1zH/iYgfE
q5wgnf6DBfTo1oO2ktaFJfymjnbJ+PlQJ4wOficRqQ6EpVUk/vhlLqtPA6Yns7rn
0iH7y7V+dVFU0xamXZGf+tAphlcJhv6UHyxTw9Mn0iXAeXECAwEAAaN7MHkwDgYD
VR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFFAeg7OMCL6s
kpGDnqZAqjr8ZrLMMB8GA1UdIwQYMBaAFFAeg7OMCL6skpGDnqZAqjr8ZrLMMBYG
A1UdEQQPMA2CC2V4YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQCL0jTwmVHu
ZlvPJgqfQ3DfFe6ECRoyUGulPBVK4duirKrqzvruOKywlK+ecIHSHD5Wi1FPDfuT
9Dq7avKSAYQWWA0pEN3P+QD0yBqs09wOSiOHJII8VUC/Bu1dfNzoOQ2yKnSvAPh4
rpJuoii00z6AGp7Bu4Zd1EMPadh6sBudciDrtCAsz98WaZkazCy6dGpjMx9F7d5H
qIX6wxs6r0LtpnifTmN9Yy1x7ju8Q9nGSYn0hIzdjRQpl/mgQ17LNr1e88R4ywlg
zVSJBWRM1YlB/98aEiYkMftO6Ogg3oUO1qL/GDCHORZ/BCxLqnKrLAdUhdGjxORk
bWYjf3LPCBup
-----END CERTIFICATE-----
$ vault read pki/ca/pem
Error reading pki/ca/pem: invalid character '-' in numeric literal
```

Having access to the `Response` object directly could also allow something like #14944 be implementable, wherein the raw `errors` value is accessible to the CLI to parse -- and (if not an error) -- optionally turn into a `Secret` if the response warrants it. It also allow JSON-formatted errors (which the API returns but `vault read -format=json` doesn't do something useful with).

Who knows what else this could enable... :-) 