### PR TITLE
Unset Namespace on root API

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -826,6 +826,14 @@ func (c *Client) ClearNamespace() {
 	c.headers.Del(consts.NamespaceHeaderName)
 }
 
+// Namespace returns the namespace currently set by this client. It will
+// return the empty string if there is no namespace set.
+func (c *Client) Namespace() string {
+	c.modifyLock.Lock()
+	defer c.modifyLock.Unlock()
+	return c.headers.Get(consts.NamespaceHeaderName)
+}
+
 // Token returns the access token being used by this client. It will
 // return the empty string if there is no token set.
 func (c *Client) Token() string {

--- a/api/client.go
+++ b/api/client.go
@@ -820,17 +820,23 @@ func (c *Client) setNamespace(namespace string) {
 	c.headers.Set(consts.NamespaceHeaderName, namespace)
 }
 
+// ClearNamespace removes the namespace header if set.
 func (c *Client) ClearNamespace() {
 	c.modifyLock.Lock()
 	defer c.modifyLock.Unlock()
-	c.headers.Del(consts.NamespaceHeaderName)
+	if c.headers != nil {
+		c.headers.Del(consts.NamespaceHeaderName)
+	}
 }
 
-// Namespace returns the namespace currently set by this client. It will
-// return the empty string if there is no namespace set.
+// Namespace returns the namespace currently set in this client. It will
+// return an empty string if there is no namespace set.
 func (c *Client) Namespace() string {
 	c.modifyLock.Lock()
 	defer c.modifyLock.Unlock()
+	if c.headers == nil {
+		return ""
+	}
 	return c.headers.Get(consts.NamespaceHeaderName)
 }
 

--- a/api/sys_health.go
+++ b/api/sys_health.go
@@ -13,6 +13,13 @@ func (c *Sys) HealthWithContext(ctx context.Context) (*HealthResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
+	// clear the namespace for this call
+	ns := c.c.Namespace()
+	c.c.ClearNamespace()
+	if ns != "" {
+		defer c.c.SetNamespace(ns)
+	}
+
 	r := c.c.NewRequest(http.MethodGet, "/v1/sys/health")
 	// If the code is 400 or above it will automatically turn into an error,
 	// but the sys/health API defaults to returning 5xx when not sealed or

--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -13,6 +13,13 @@ func (c *Sys) InitStatusWithContext(ctx context.Context) (bool, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
+	// clear the namespace for this call
+	ns := c.c.Namespace()
+	c.c.ClearNamespace()
+	if ns != "" {
+		defer c.c.SetNamespace(ns)
+	}
+
 	r := c.c.NewRequest(http.MethodGet, "/v1/sys/init")
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
@@ -33,6 +40,13 @@ func (c *Sys) Init(opts *InitRequest) (*InitResponse, error) {
 func (c *Sys) InitWithContext(ctx context.Context, opts *InitRequest) (*InitResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
+
+	// clear the namespace for this call
+	ns := c.c.Namespace()
+	c.c.ClearNamespace()
+	if ns != "" {
+		defer c.c.SetNamespace(ns)
+	}
 
 	r := c.c.NewRequest(http.MethodPut, "/v1/sys/init")
 	if err := r.SetJSONBody(opts); err != nil {

--- a/api/sys_leader.go
+++ b/api/sys_leader.go
@@ -14,6 +14,13 @@ func (c *Sys) LeaderWithContext(ctx context.Context) (*LeaderResponse, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
+	// clear the namespace for this call
+	ns := c.c.Namespace()
+	c.c.ClearNamespace()
+	if ns != "" {
+		defer c.c.SetNamespace(ns)
+	}
+
 	r := c.c.NewRequest(http.MethodGet, "/v1/sys/leader")
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)

--- a/api/sys_raft.go
+++ b/api/sys_raft.go
@@ -119,6 +119,13 @@ func (c *Sys) RaftJoinWithContext(ctx context.Context, opts *RaftJoinRequest) (*
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
+	// clear the namespace for this call
+	ns := c.c.Namespace()
+	c.c.ClearNamespace()
+	if ns != "" {
+		defer c.c.SetNamespace(ns)
+	}
+
 	r := c.c.NewRequest(http.MethodPost, "/v1/sys/storage/raft/join")
 
 	if err := r.SetJSONBody(opts); err != nil {
@@ -223,6 +230,13 @@ func (c *Sys) RaftSnapshotRestoreWithContext(ctx context.Context, snapReader io.
 		path = "/v1/sys/storage/raft/snapshot-force"
 	}
 
+	// clear the namespace for this call
+	ns := c.c.Namespace()
+	c.c.ClearNamespace()
+	if ns != "" {
+		defer c.c.SetNamespace(ns)
+	}
+
 	r := c.c.NewRequest(http.MethodPost, path)
 	r.Body = snapReader
 
@@ -244,6 +258,13 @@ func (c *Sys) RaftAutopilotState() (*AutopilotState, error) {
 func (c *Sys) RaftAutopilotStateWithContext(ctx context.Context) (*AutopilotState, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
+
+	// clear the namespace for this call
+	ns := c.c.Namespace()
+	c.c.ClearNamespace()
+	if ns != "" {
+		defer c.c.SetNamespace(ns)
+	}
 
 	r := c.c.NewRequest(http.MethodGet, "/v1/sys/storage/raft/autopilot/state")
 
@@ -284,6 +305,13 @@ func (c *Sys) RaftAutopilotConfiguration() (*AutopilotConfig, error) {
 func (c *Sys) RaftAutopilotConfigurationWithContext(ctx context.Context) (*AutopilotConfig, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
+
+	// clear the namespace for this call
+	ns := c.c.Namespace()
+	c.c.ClearNamespace()
+	if ns != "" {
+		defer c.c.SetNamespace(ns)
+	}
 
 	r := c.c.NewRequest(http.MethodGet, "/v1/sys/storage/raft/autopilot/configuration")
 
@@ -332,6 +360,13 @@ func (c *Sys) PutRaftAutopilotConfiguration(opts *AutopilotConfig) error {
 func (c *Sys) PutRaftAutopilotConfigurationWithContext(ctx context.Context, opts *AutopilotConfig) error {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
+
+	// clear the namespace for this call
+	ns := c.c.Namespace()
+	c.c.ClearNamespace()
+	if ns != "" {
+		defer c.c.SetNamespace(ns)
+	}
 
 	r := c.c.NewRequest(http.MethodPost, "/v1/sys/storage/raft/autopilot/configuration")
 

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -33,6 +33,13 @@ func (c *Sys) KeyStatusWithContext(ctx context.Context) (*KeyStatus, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
+	// clear the namespace for this call
+	ns := c.c.Namespace()
+	c.c.ClearNamespace()
+	if ns != "" {
+		defer c.c.SetNamespace(ns)
+	}
+	
 	r := c.c.NewRequest(http.MethodGet, "/v1/sys/key-status")
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)

--- a/api/sys_rotate.go
+++ b/api/sys_rotate.go
@@ -39,7 +39,7 @@ func (c *Sys) KeyStatusWithContext(ctx context.Context) (*KeyStatus, error) {
 	if ns != "" {
 		defer c.c.SetNamespace(ns)
 	}
-	
+
 	r := c.c.NewRequest(http.MethodGet, "/v1/sys/key-status")
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)

--- a/changelog/14948.txt
+++ b/changelog/14948.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Unset namesapce header on calls that are intended for root endpoints
+```


### PR DESCRIPTION
Fixes: #14934 

In the API `Client` should ignore namespaces on calls that are intended to be issued against the [root](https://www.vaultproject.io/docs/enterprise/namespaces#root-only-api-paths).

This PR modifies the following calls to unset the namespace, issue the call, and reset the namespace configuration:
`(*client).Sys().Health()` / `(*client).Sys().HealthWithContext()`
`(*client).Sys().InitStatus()` / `(*client).Sys().InitStatusWithContext()` 
`(*client).Sys().Init()` / `(*client).Sys().InitWithContext()`
`(*client).Sys().KeyStatus()` / `(*client).Sys().KeyStatusWithContext()`
`(*client).Sys().Leader()` / `(*client).Sys().LeaderWithContext()`
as well as all of the `Sys()` methods that target `sys/storage/raft/*`