### PR TITLE
aws auth displayName

### DIFF
--- a/builtin/credential/aws/path_login.go
+++ b/builtin/credential/aws/path_login.go
@@ -1407,6 +1407,11 @@ func (b *backend) pathLoginUpdateIam(ctx context.Context, req *logical.Request, 
 			Name: identityAlias,
 		},
 	}
+
+	if entity.Type == "assumed-role" {
+		auth.DisplayName = strings.Join([]string{entity.FriendlyName, entity.SessionInfo}, "/")
+	}
+
 	roleEntry.PopulateTokenAuth(auth)
 	if err := identityConfigEntry.IAMAuthMetadataHandler.PopulateDesiredMetadata(auth, map[string]string{
 		"client_arn":           callerID.Arn,

--- a/changelog/14954.txt
+++ b/changelog/14954.txt
@@ -1,0 +1,3 @@
+```release-note:change
+auth/aws: Add RoleSession to DisplayName when using assumeRole for authentication
+```


### PR DESCRIPTION
What: 
Modify the AWS Auth engine such that it is capable of setting the field `displayName` to include the `RoleSessionName` when assume role process is used to authenticate to vault server.

Why:
This update would allow users to be capable of setting DB Engine dynamic credentials managed by the username template to match IAM User names. Please read details [here](https://github.com/hashicorp/vault/issues/14781#issuecomment-1091830812).