### PR TITLE
Fix edit capabilities call in auth method

### DIFF
--- a/changelog/14966.txt
+++ b/changelog/14966.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes edit auth method capabilities issue
+```

--- a/ui/app/models/auth-method.js
+++ b/ui/app/models/auth-method.js
@@ -116,9 +116,9 @@ export default attachCapabilities(ModelExport, {
   deletePath: apiPath`sys/auth/${'id'}`,
   configPath: function (context) {
     if (context.type === 'aws') {
-      return apiPath`auth/${'id'}/config/client`;
+      return apiPath`auth/${'id'}/config/client`.call(this, context);
     } else {
-      return apiPath`auth/${'id'}/config`;
+      return apiPath`auth/${'id'}/config`.call(this, context);
     }
   },
 });


### PR DESCRIPTION
- Capabilities call was not getting triggered correctly as apiPath
  method was missing the correct context.