### PR TITLE
Don't clone OutputCurlString value

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -588,7 +588,6 @@ func (c *Client) CloneConfig() *Config {
 	newConfig.CheckRetry = c.config.CheckRetry
 	newConfig.Logger = c.config.Logger
 	newConfig.Limiter = c.config.Limiter
-	newConfig.OutputCurlString = c.config.OutputCurlString
 	newConfig.SRVLookup = c.config.SRVLookup
 	newConfig.CloneHeaders = c.config.CloneHeaders
 	newConfig.CloneToken = c.config.CloneToken
@@ -1002,22 +1001,21 @@ func (c *Client) clone(cloneHeaders bool) (*Client, error) {
 	defer config.modifyLock.RUnlock()
 
 	newConfig := &Config{
-		Address:          config.Address,
-		HttpClient:       config.HttpClient,
-		MinRetryWait:     config.MinRetryWait,
-		MaxRetryWait:     config.MaxRetryWait,
-		MaxRetries:       config.MaxRetries,
-		Timeout:          config.Timeout,
-		Backoff:          config.Backoff,
-		CheckRetry:       config.CheckRetry,
-		Logger:           config.Logger,
-		Limiter:          config.Limiter,
-		OutputCurlString: config.OutputCurlString,
-		AgentAddress:     config.AgentAddress,
-		SRVLookup:        config.SRVLookup,
-		CloneHeaders:     config.CloneHeaders,
-		CloneToken:       config.CloneToken,
-		ReadYourWrites:   config.ReadYourWrites,
+		Address:        config.Address,
+		HttpClient:     config.HttpClient,
+		MinRetryWait:   config.MinRetryWait,
+		MaxRetryWait:   config.MaxRetryWait,
+		MaxRetries:     config.MaxRetries,
+		Timeout:        config.Timeout,
+		Backoff:        config.Backoff,
+		CheckRetry:     config.CheckRetry,
+		Logger:         config.Logger,
+		Limiter:        config.Limiter,
+		AgentAddress:   config.AgentAddress,
+		SRVLookup:      config.SRVLookup,
+		CloneHeaders:   config.CloneHeaders,
+		CloneToken:     config.CloneToken,
+		ReadYourWrites: config.ReadYourWrites,
 	}
 	client, err := NewClient(newConfig)
 	if err != nil {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -526,8 +526,8 @@ func TestClone(t *testing.T) {
 			if parent.MaxRetries() != clone.MaxRetries() {
 				t.Fatalf("maxRetries don't match: %v vs %v", parent.MaxRetries(), clone.MaxRetries())
 			}
-			if parent.OutputCurlString() != clone.OutputCurlString() {
-				t.Fatalf("outputCurlString doesn't match: %v vs %v", parent.OutputCurlString(), clone.OutputCurlString())
+			if parent.OutputCurlString() == clone.OutputCurlString() {
+				t.Fatalf("outputCurlString was copied over when it shouldn't have been: %v and %v", parent.OutputCurlString(), clone.OutputCurlString())
 			}
 			if parent.SRVLookup() != clone.SRVLookup() {
 				t.Fatalf("SRVLookup doesn't match: %v vs %v", parent.SRVLookup(), clone.SRVLookup())

--- a/changelog/14968.txt
+++ b/changelog/14968.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixes bug where OutputCurlString field was unintentionally being copied over during client cloning
+```

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -37,6 +37,11 @@ To get help for a subcommand, run:
 $ vault <subcommand> -h
 ```
 
+To see the equivalent API call required to perform the same operation, use the `-output-curl-string` flag after the subcommand.
+```shell-session
+vault auth enable -output-curl-string approle
+```
+
 ## CLI Command Structure
 
 There are a number of command and subcommand options available: HTTP options,


### PR DESCRIPTION
The OutputCurlString field comment claims that the field is not copied over as part of cloning the client, when in fact, it currently is.

This fixes that bug and also adds mention of this extremely useful but hard-to-discover flag to the CLI command overview.