### PR TITLE
Add the possibility to set the mount path for login in query params

### DIFF
--- a/changelog/14988.txt
+++ b/changelog/14988.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+ui: The mount path used when logging in Vault can now be specified with the
+`path` query param, e.g. https://vault.com/ui/vault/auth?with=jwt&path=my_custom_method.
+```

--- a/ui/app/components/auth-form-options.js
+++ b/ui/app/components/auth-form-options.js
@@ -1,3 +1,8 @@
 import Component from '@ember/component';
 
-export default Component.extend({});
+export default Component.extend({
+  init() {
+    this._super(...arguments);
+    this.set('isOpen', this.customPath !== '');
+  },
+});

--- a/ui/app/components/auth-form.js
+++ b/ui/app/components/auth-form.js
@@ -18,20 +18,20 @@ const BACKENDS = supportedAuthBackends();
  *
  * @example ```js
  * // All properties are passed in via query params.
- * <AuthForm @wrappedToken={{wrappedToken}} @cluster={{model}} @namespace={{namespaceQueryParam}} @selectedAuth={{authMethod}} @onSuccess={{action this.onSuccess}} />```
+ * <AuthForm @wrappedToken={{wrappedToken}} @cluster={{model}} @namespace={{namespaceQueryParam}} @selectedAuth={{authMethod}} @onSuccess={{action this.onSuccess}} @customPath={{mountPath}} />```
  *
  * @param {string} wrappedToken - The auth method that is currently selected in the dropdown.
  * @param {object} cluster - The auth method that is currently selected in the dropdown. This corresponds to an Ember Model.
  * @param {string} namespace- The currently active namespace.
  * @param {string} selectedAuth - The auth method that is currently selected in the dropdown.
  * @param {function} onSuccess - Fired on auth success
+ * @param {string} customPath - The mount path that is currently set.
  */
 
 const DEFAULTS = {
   token: null,
   username: null,
   password: null,
-  customPath: null,
 };
 
 export default Component.extend(DEFAULTS, {
@@ -47,6 +47,7 @@ export default Component.extend(DEFAULTS, {
   cluster: null,
   namespace: null,
   wrappedToken: null,
+  customPath: null,
   // internal
   oldNamespace: null,
   authMethods: BACKENDS,

--- a/ui/app/controllers/vault/cluster/auth.js
+++ b/ui/app/controllers/vault/cluster/auth.js
@@ -11,7 +11,7 @@ export default Controller.extend({
   auth: service(),
   router: service(),
 
-  queryParams: [{ authMethod: 'with', oidcProvider: 'o' }],
+  queryParams: [{ authMethod: 'with', oidcProvider: 'o', mountPath: 'path' }],
 
   namespaceQueryParam: alias('clusterController.namespaceQueryParam'),
   wrappedToken: alias('vaultController.wrappedToken'),
@@ -20,6 +20,7 @@ export default Controller.extend({
 
   authMethod: '',
   oidcProvider: '',
+  mountPath: '',
 
   get managedNamespaceChild() {
     let fullParam = this.namespaceQueryParam;

--- a/ui/app/templates/vault/cluster/auth.hbs
+++ b/ui/app/templates/vault/cluster/auth.hbs
@@ -108,6 +108,7 @@
         @redirectTo={{this.redirectTo}}
         @selectedAuth={{this.authMethod}}
         @onSuccess={{action "onAuthResponse"}}
+        @customPath={{this.mountPath}}
       />
     {{/if}}
   </Page.content>


### PR DESCRIPTION
This patch adds the possibility to set the mount path used for logging
in the UI using query params. When the mount path is given that way the
drawer is already open on page load.

Closes https://github.com/hashicorp/vault/issues/10140