### PR TITLE
Fix legacy PKI sign-verbatim api path

### DIFF
--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -79,7 +79,7 @@ func pathIssuerSignVerbatim(b *backend) *framework.Path {
 }
 
 func pathSignVerbatim(b *backend) *framework.Path {
-	pattern := "root/sign-verbatim"
+	pattern := "sign-verbatim" + framework.OptionalParamRegex("role")
 	return buildPathIssuerSignVerbatim(b, pattern)
 }
 


### PR DESCRIPTION
 - Addresses some test failures due to an incorrect refactoring of a legacy api
   path /sign-verbatim within PKI