### PR TITLE
[VAULT-5536] Add deprecated flag to operations in OpenApi Spec

### DIFF
--- a/scripts/gen_openapi.sh
+++ b/scripts/gen_openapi.sh
@@ -34,7 +34,7 @@ while read -r line; do
         codeLinesStarted=true
     elif [ $codeLinesStarted = true ] && [[ $line = *"}"* ]]  ; then
         break
-    elif [ $codeLinesStarted = true ] && [[ $line =~ $inQuotesRegex ]] && [[ $line != *"Deprecated"* ]] ; then
+    elif [ $codeLinesStarted = true ] && [[ $line =~ $inQuotesRegex ]] ; then
         backend=${BASH_REMATCH[0]}
         plugin=$(sed -e 's/^"//' -e 's/"$//' <<<"$backend")
         vault auth enable "${plugin}"
@@ -48,13 +48,14 @@ while read -r line; do
         codeLinesStarted=true
     elif [ $codeLinesStarted = true ] && [[ $line = *"}"* ]]  ; then
         break
-    elif [ $codeLinesStarted = true ] && [[ $line =~ $inQuotesRegex ]] && [[ $line != *"Deprecated"* ]] ; then
+    elif [ $codeLinesStarted = true ] && [[ $line =~ $inQuotesRegex ]] ; then
         backend=${BASH_REMATCH[0]}
         plugin=$(sed -e 's/^"//' -e 's/"$//' <<<"$backend")
         vault secrets enable "${plugin}"
     fi
 done <../../vault/helper/builtinplugins/registry.go
 
+vault secrets enable database
 
 # Enable enterprise features
 entRegFile=../../vault/helper/builtinplugins/registry_util_ent.go
@@ -68,7 +69,7 @@ if [ -f $entRegFile ] && [[ -n "$VAULT_LICENSE" ]]; then
         codeLinesStarted=true
     elif [ $codeLinesStarted = true ] && [[ $line = *"}"* ]]  ; then
         break
-    elif [ $codeLinesStarted = true ] && [[ $line =~ $inQuotesRegex ]] && [[ $line != *"Deprecated"* ]] ; then
+    elif [ $codeLinesStarted = true ] && [[ $line =~ $inQuotesRegex ]] ; then
         backend=${BASH_REMATCH[0]}
         plugin=$(sed -e 's/^"//' -e 's/"$//' <<<"$backend")
         vault secrets enable "${plugin}"

--- a/sdk/framework/openapi.go
+++ b/sdk/framework/openapi.go
@@ -325,7 +325,7 @@ func documentPath(p *Path, specialPaths *logical.Paths, requestResponsePrefix st
 
 			op.Summary = props.Summary
 			op.Description = props.Description
-			op.Deprecated = props.Deprecated
+			op.Deprecated = props.Deprecated || isDeprecatedPlugin(requestResponsePrefix)
 
 			// Add any fields not present in the path as body parameters for POST.
 			if opType == logical.CreateOperation || opType == logical.UpdateOperation {
@@ -759,4 +759,16 @@ func (d *OASDocument) CreateOperationIDs(context string) {
 			oasOperation.OperationID = opID
 		}
 	}
+}
+
+func isDeprecatedPlugin(plugin string) bool {
+	deprecatedPlugins := []string{"pcf", "cassandra", "mongodb", "mssql", "mysql", "postgresql"}
+
+	for _, v := range deprecatedPlugins {
+		if v == plugin {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
We're adding a deprecated flag to operations that are marked as deprecated in the `registry.go` file to create consistency and a more accurate OpenApi Spec as well as codegen.

Also re-adding these back into the `gen_openapi.sh` script