### PR TITLE
Introduce defaultRef constant within PKI

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2584,7 +2584,7 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signingBundle, err := fetchCAInfo(context.Background(), b, &logical.Request{Storage: storage}, "default")
+	signingBundle, err := fetchCAInfo(context.Background(), b, &logical.Request{Storage: storage}, defaultRef)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -32,7 +32,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 		return nil, nil
 	}
 
-	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, defaultRef)
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:
@@ -223,7 +223,7 @@ func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bo
 	}
 
 WRITE:
-	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, defaultRef)
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -363,7 +363,7 @@ func addIssuerRefField(fields map[string]*framework.FieldSchema) map[string]*fra
 		Description: `Reference to a existing issuer; either "default"
 for the configured default issuer, an identifier or the name assigned
 to the issuer.`,
-		Default: "default",
+		Default: defaultRef,
 	}
 	return fields
 }
@@ -391,7 +391,7 @@ func addKeyRefField(fields map[string]*framework.FieldSchema) map[string]*framew
 		Description: `Reference to a existing key; either "default"
 for the configured default key, an identifier or the name assigned
 to the key.`,
-		Default: "default",
+		Default: defaultRef,
 	}
 	return fields
 }

--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -74,7 +74,7 @@ func (b *backend) pathCAIssuersRead(ctx context.Context, req *logical.Request, d
 
 func (b *backend) pathCAIssuersWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	newDefault := data.Get("default").(string)
-	if len(newDefault) == 0 || newDefault == "default" {
+	if len(newDefault) == 0 || newDefault == defaultRef {
 		return logical.ErrorResponse("Invalid issuer specification; must be non-empty and can't be 'default'."), nil
 	}
 

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -192,7 +192,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 
 	// Prefer fetchCAInfo to fetchCertBySerial for CA certificates.
 	if serial == "ca_chain" || serial == "ca" {
-		caInfo, err := fetchCAInfo(ctx, b, req, "default")
+		caInfo, err := fetchCAInfo(ctx, b, req, defaultRef)
 		if err != nil {
 			switch err.(type) {
 			case errutil.UserError:

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"encoding/pem"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
-
-var nameMatcher = regexp.MustCompile("^" + framework.GenericNameRegex(issuerRefParam) + "$")
 
 func pathListIssuers(b *backend) *framework.Path {
 	return &framework.Path{

--- a/builtin/logical/pki/path_sign_issuers.go
+++ b/builtin/logical/pki/path_sign_issuers.go
@@ -16,16 +16,10 @@ func pathSignIntermediate(b *backend) *framework.Path {
 }
 
 func pathIssuerSignIntermediateRaw(b *backend, pattern string) *framework.Path {
+	fields := addIssuerRefField(map[string]*framework.FieldSchema{})
 	path := &framework.Path{
 		Pattern: pattern,
-		Fields: map[string]*framework.FieldSchema{
-			issuerRefParam: {
-				Type:        framework.TypeString,
-				Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
-				Default:     "default",
-			},
-		},
-
+		Fields:  fields,
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.pathIssuerSignIntermediate,
 		},
@@ -89,25 +83,21 @@ func pathSignSelfIssued(b *backend) *framework.Path {
 }
 
 func buildPathIssuerSignSelfIssued(b *backend, pattern string) *framework.Path {
+	fields := map[string]*framework.FieldSchema{
+		"certificate": {
+			Type:        framework.TypeString,
+			Description: `PEM-format self-issued certificate to be signed.`,
+		},
+		"require_matching_certificate_algorithms": {
+			Type:        framework.TypeBool,
+			Default:     false,
+			Description: `If true, require the public key algorithm of the signer to match that of the self issued certificate.`,
+		},
+	}
+	fields = addIssuerRefField(fields)
 	path := &framework.Path{
 		Pattern: pattern,
-		Fields: map[string]*framework.FieldSchema{
-			issuerRefParam: {
-				Type:        framework.TypeString,
-				Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
-				Default:     "default",
-			},
-			"certificate": {
-				Type:        framework.TypeString,
-				Description: `PEM-format self-issued certificate to be signed.`,
-			},
-			"require_matching_certificate_algorithms": {
-				Type:        framework.TypeBool,
-				Default:     false,
-				Description: `If true, require the public key algorithm of the signer to match that of the self issued certificate.`,
-			},
-		},
-
+		Fields:  fields,
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.pathIssuerSignSelfIssued,
 		},

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -272,7 +272,7 @@ func listIssuers(ctx context.Context, s logical.Storage) ([]issuerId, error) {
 }
 
 func resolveKeyReference(ctx context.Context, s logical.Storage, reference string) (keyId, error) {
-	if reference == "default" {
+	if reference == defaultRef {
 		// Handle fetching the default key.
 		config, err := getKeysConfig(ctx, s)
 		if err != nil {
@@ -524,7 +524,7 @@ func getIssuersConfig(ctx context.Context, s logical.Storage) (*issuerConfig, er
 }
 
 func resolveIssuerReference(ctx context.Context, s logical.Storage, reference string) (issuerId, error) {
-	if reference == "default" {
+	if reference == defaultRef {
 		// Handle fetching the default issuer.
 		config, err := getIssuersConfig(ctx, s)
 		if err != nil {

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -3,6 +3,7 @@ package pki
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/vault/sdk/logical"
@@ -15,7 +16,10 @@ import (
 const (
 	managedKeyNameArg = "managed_key_name"
 	managedKeyIdArg   = "managed_key_id"
+	defaultRef        = "default"
 )
+
+var nameMatcher = regexp.MustCompile("^" + framework.GenericNameRegex(issuerRefParam) + "$")
 
 func normalizeSerial(serial string) string {
 	return strings.Replace(strings.ToLower(serial), ":", "-", -1)
@@ -129,7 +133,7 @@ func getIssuerName(ctx context.Context, s logical.Storage, data *framework.Field
 	if ok {
 		issuerName = strings.TrimSpace(issuerNameIface.(string))
 
-		if strings.ToLower(issuerName) == "default" {
+		if strings.ToLower(issuerName) == defaultRef {
 			return "", errutil.UserError{Err: "reserved keyword 'default' can not be used as issuer name"}
 		}
 
@@ -154,7 +158,7 @@ func getKeyName(ctx context.Context, s logical.Storage, data *framework.FieldDat
 	if ok {
 		keyName = strings.TrimSpace(keyNameIface.(string))
 
-		if strings.ToLower(keyName) == "default" {
+		if strings.ToLower(keyName) == defaultRef {
 			return "", errutil.UserError{Err: "reserved keyword 'default' can not be used as key name"}
 		}
 
@@ -183,8 +187,8 @@ func getKeyRef(data *framework.FieldData) string {
 
 func extractRef(data *framework.FieldData, paramName string) string {
 	value := strings.TrimSpace(data.Get(paramName).(string))
-	if strings.ToLower(value) == "default" {
-		return "default"
+	if strings.ToLower(value) == defaultRef {
+		return defaultRef
 	}
 	return value
 }


### PR DESCRIPTION
 - Replace hardcoded "default" references with a constant to easily identify various usages.
 - Use the addIssuerRefField function instead of redefining the field in various locations.

Builds on top of #14975