### PR TITLE
Remove duplicated issuers in full chain

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -116,6 +116,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathIssuerSignIntermediate(&b),
 			pathIssuerSignSelfIssued(&b),
 			pathIssuerSignVerbatim(&b),
+			pathConfigIssuers(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -113,6 +113,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathListIssuers(&b),
 			pathGetIssuer(&b),
 			pathImportIssuer(&b),
+			pathIssuerSignIntermediate(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -112,6 +112,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			// Issuer APIs
 			pathListIssuers(&b),
 			pathGetIssuer(&b),
+			pathImportIssuer(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -115,6 +115,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathImportIssuer(&b),
 			pathIssuerSignIntermediate(&b),
 			pathIssuerSignSelfIssued(&b),
+			pathIssuerSignVerbatim(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -116,6 +116,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathIssuerSignIntermediate(&b),
 			pathIssuerSignSelfIssued(&b),
 			pathIssuerSignVerbatim(&b),
+			pathIssuerGenerateRoot(&b),
 			pathConfigIssuers(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -105,6 +105,15 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathSign(&b),
 			pathIssue(&b),
 			pathRotateCRL(&b),
+			pathRevoke(&b),
+			pathTidy(&b),
+			pathTidyStatus(&b),
+
+			// Issuer APIs
+			pathListIssuers(&b),
+			pathGetIssuer(&b),
+
+			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),
 			pathFetchCAChain(&b),
 			pathFetchCRL(&b),
@@ -112,9 +121,6 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathFetchValidRaw(&b),
 			pathFetchValid(&b),
 			pathFetchListCerts(&b),
-			pathRevoke(&b),
-			pathTidy(&b),
-			pathTidyStatus(&b),
 		},
 
 		Secrets: []*framework.Secret{

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -117,6 +117,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathIssuerSignSelfIssued(&b),
 			pathIssuerSignVerbatim(&b),
 			pathIssuerGenerateRoot(&b),
+			pathIssuerGenerateIntermediate(&b),
 			pathConfigIssuers(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints

--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -114,6 +114,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			pathGetIssuer(&b),
 			pathImportIssuer(&b),
 			pathIssuerSignIntermediate(&b),
+			pathIssuerSignSelfIssued(&b),
 
 			// Fetch APIs have been lowered to favor the newer issuer API endpoints
 			pathFetchCA(&b),

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2585,7 +2585,7 @@ func TestBackend_SignSelfIssued(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signingBundle, err := fetchCAInfo(context.Background(), b, &logical.Request{Storage: storage})
+	signingBundle, err := fetchCAInfo(context.Background(), b, &logical.Request{Storage: storage}, "default")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4680,6 +4680,23 @@ func TestRootWithExistingKey(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unable to find PKI key for reference: my-key1")
 
+	// Fail if the specified key name is default.
+	_, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/internal", map[string]interface{}{
+		"common_name": "root myvault.com",
+		"issuer_name": "my-issuer1",
+		"key_name":    "Default",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reserved keyword 'default' can not be used as key name")
+
+	// Fail if the specified issuer name is default.
+	_, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/internal", map[string]interface{}{
+		"common_name": "root myvault.com",
+		"issuer_name": "DEFAULT",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reserved keyword 'default' can not be used as issuer name")
+
 	// Create the first CA
 	resp, err := client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/internal", map[string]interface{}{
 		"common_name": "root myvault.com",
@@ -4693,11 +4710,20 @@ func TestRootWithExistingKey(t *testing.T) {
 	require.NotEmpty(t, myIssuerId1)
 	require.NotEmpty(t, myKeyId1)
 
+	// Fail if the specified issuer name is re-used.
+	_, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/internal", map[string]interface{}{
+		"common_name": "root myvault.com",
+		"issuer_name": "my-issuer1",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "issuer name already used")
+
 	// Create the second CA
 	resp, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/internal", map[string]interface{}{
 		"common_name": "root myvault.com",
 		"key_type":    "rsa",
 		"issuer_name": "my-issuer2",
+		"key_name":    "root-key2",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Data["certificate"])
@@ -4705,6 +4731,15 @@ func TestRootWithExistingKey(t *testing.T) {
 	myKeyId2 := resp.Data["key_id"]
 	require.NotEmpty(t, myIssuerId2)
 	require.NotEmpty(t, myKeyId2)
+
+	// Fail if the specified key name is re-used.
+	_, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/internal", map[string]interface{}{
+		"common_name": "root myvault.com",
+		"issuer_name": "my-issuer3",
+		"key_name":    "root-key2",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "key name already used")
 
 	// Create a third CA re-using key from CA 1
 	resp, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/existing", map[string]interface{}{
@@ -4788,6 +4823,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 	resp, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/intermediate/internal", map[string]interface{}{
 		"common_name": "root myvault.com",
 		"key_type":    "rsa",
+		"key_name":    "interkey1",
 	})
 	require.NoError(t, err)
 	// csr2 := resp.Data["csr"]

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4061,8 +4061,8 @@ func runFullCAChainTest(t *testing.T, keyType string) {
 	}
 
 	fullChain := resp.Data["ca_chain"].(string)
-	if !strings.Contains(fullChain, rootCert) {
-		t.Fatal("expected full chain to contain root certificate")
+	if strings.Count(fullChain, rootCert) != 1 {
+		t.Fatalf("expected full chain to contain root certificate; got %v occurrences", strings.Count(fullChain, rootCert))
 	}
 
 	// Now generate an intermediate at /pki-intermediate, signed by the root.
@@ -4125,11 +4125,11 @@ func runFullCAChainTest(t *testing.T, keyType string) {
 	}
 
 	fullChain = resp.Data["ca_chain"].(string)
-	if !strings.Contains(fullChain, intermediateCert) {
-		t.Fatal("expected full chain to contain intermediate certificate")
+	if strings.Count(fullChain, intermediateCert) != 1 {
+		t.Fatalf("expected full chain to contain intermediate certificate; got %v occurrences", strings.Count(fullChain, intermediateCert))
 	}
-	if !strings.Contains(fullChain, rootCert) {
-		t.Fatal("expected full chain to contain root certificate")
+	if strings.Count(fullChain, rootCert) != 1 {
+		t.Fatalf("expected full chain to contain root certificate; got %v occurrences", strings.Count(fullChain, rootCert))
 	}
 
 	// Finally, import this signing cert chain into a new mount to ensure
@@ -4162,11 +4162,11 @@ func runFullCAChainTest(t *testing.T, keyType string) {
 	}
 
 	fullChain = resp.Data["ca_chain"].(string)
-	if !strings.Contains(fullChain, intermediateCert) {
-		t.Fatal("expected full chain to contain intermediate certificate")
+	if strings.Count(fullChain, intermediateCert) != 1 {
+		t.Fatalf("expected full chain to contain intermediate certificate; got %v occurrences", strings.Count(fullChain, intermediateCert))
 	}
-	if !strings.Contains(fullChain, rootCert) {
-		t.Fatal("expected full chain to contain root certificate")
+	if strings.Count(fullChain, rootCert) != 1 {
+		t.Fatalf("expected full chain to contain root certificate; got %v occurrences", strings.Count(fullChain, rootCert))
 	}
 
 	// Now issue a short-lived certificate from our pki-external.

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4674,8 +4674,8 @@ func TestRootWithExistingKey(t *testing.T) {
 	// Fail if the specified key does not exist.
 	_, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/existing", map[string]interface{}{
 		"common_name": "root myvault.com",
-		"id":          "my-issuer1",
-		"key_id":      "my-key1",
+		"issuer_name": "my-issuer1",
+		"key_ref":     "my-key1",
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unable to find PKI key for reference: my-key1")
@@ -4684,11 +4684,11 @@ func TestRootWithExistingKey(t *testing.T) {
 	resp, err := client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/internal", map[string]interface{}{
 		"common_name": "root myvault.com",
 		"key_type":    "rsa",
-		"id":          "my-issuer1",
+		"issuer_name": "my-issuer1",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Data["certificate"])
-	myIssuerId1 := resp.Data["id"]
+	myIssuerId1 := resp.Data["issuer_id"]
 	myKeyId1 := resp.Data["key_id"]
 	require.NotEmpty(t, myIssuerId1)
 	require.NotEmpty(t, myKeyId1)
@@ -4697,11 +4697,11 @@ func TestRootWithExistingKey(t *testing.T) {
 	resp, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/internal", map[string]interface{}{
 		"common_name": "root myvault.com",
 		"key_type":    "rsa",
-		"id":          "my-issuer2",
+		"issuer_name": "my-issuer2",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Data["certificate"])
-	myIssuerId2 := resp.Data["id"]
+	myIssuerId2 := resp.Data["issuer_id"]
 	myKeyId2 := resp.Data["key_id"]
 	require.NotEmpty(t, myIssuerId2)
 	require.NotEmpty(t, myKeyId2)
@@ -4709,12 +4709,12 @@ func TestRootWithExistingKey(t *testing.T) {
 	// Create a third CA re-using key from CA 1
 	resp, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/existing", map[string]interface{}{
 		"common_name": "root myvault.com",
-		"id":          "my-issuer3",
-		"key_id":      myKeyId1,
+		"issuer_name": "my-issuer3",
+		"key_ref":     myKeyId1,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp.Data["certificate"])
-	myIssuerId3 := resp.Data["id"]
+	myIssuerId3 := resp.Data["issuer_id"]
 	myKeyId3 := resp.Data["key_id"]
 	require.NotEmpty(t, myIssuerId3)
 	require.NotEmpty(t, myKeyId3)
@@ -4769,7 +4769,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 	// Fail if the specified key does not exist.
 	_, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/intermediate/existing", map[string]interface{}{
 		"common_name": "root myvault.com",
-		"key_id":      "my-key1",
+		"key_ref":     "my-key1",
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unable to find PKI key for reference: my-key1")
@@ -4797,7 +4797,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 	// Create a third intermediate CA re-using key from intermediate CA 1
 	resp, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/intermediate/existing", map[string]interface{}{
 		"common_name": "root myvault.com",
-		"key_id":      myKeyId1,
+		"key_ref":     myKeyId1,
 	})
 	require.NoError(t, err)
 	// csr3 := resp.Data["csr"]

--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -2275,7 +2275,6 @@ func TestBackend_Root_Idempotency(t *testing.T) {
 	})
 	cluster.Start()
 	defer cluster.Cleanup()
-
 	client := cluster.Cores[0].Client
 	var err error
 	err = client.Sys().Mount("pki", &api.MountInput{
@@ -4841,7 +4840,7 @@ func TestIntermediateWithExistingKey(t *testing.T) {
 	require.NotEmpty(t, myKeyId3)
 
 	require.NotEqual(t, myKeyId1, myKeyId2)
-	require.Equal(t, myKeyId1, myKeyId3)
+	require.Equal(t, myKeyId1, myKeyId3, "our new ca did not seem to reuse the key as we expected.")
 }
 
 var (

--- a/builtin/logical/pki/ca_test.go
+++ b/builtin/logical/pki/ca_test.go
@@ -257,13 +257,13 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 	//  Load CA cert/key in and ensure we can fetch it back in various formats,
 	//  unauthenticated
 	{
-		// Attempt import but only provide one the cert
+		// Attempt import but only provide one the cert; this should work.
 		{
 			_, err := client.Logical().Write(rootName+"config/ca", map[string]interface{}{
 				"pem_bundle": caCert,
 			})
-			if err == nil {
-				t.Fatal("expected error")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		}
 
@@ -272,18 +272,18 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 			_, err := client.Logical().Write(rootName+"config/ca", map[string]interface{}{
 				"pem_bundle": caKey,
 			})
-			if err == nil {
-				t.Fatal("expected error")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		}
 
-		// Import CA bundle
+		// Import entire CA bundle; this should work as well
 		{
 			_, err := client.Logical().Write(rootName+"config/ca", map[string]interface{}{
 				"pem_bundle": strings.Join([]string{caKey, caCert}, "\n"),
 			})
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("unexpected error: %v", err)
 			}
 		}
 
@@ -464,8 +464,8 @@ func runSteps(t *testing.T, rootB, intB *backend, client *api.Client, rootName, 
 			if err != nil {
 				t.Fatal(err)
 			}
-			if resp != nil {
-				t.Fatal("expected nil response")
+			if resp == nil {
+				t.Fatal("nil response")
 			}
 		}
 

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -116,7 +116,7 @@ func getKeyTypeAndBitsForRole(ctx context.Context, b *backend, data *framework.F
 }
 
 func getExistingPublicKey(ctx context.Context, s logical.Storage, data *framework.FieldData) (crypto.PublicKey, error) {
-	keyRef, err := getExistingKeyRef(data)
+	keyRef, err := getKeyRefWithErr(data)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/ca_util.go
+++ b/builtin/logical/pki/ca_util.go
@@ -2,8 +2,10 @@ package pki
 
 import (
 	"context"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,18 +16,17 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func (b *backend) getGenerationParams(ctx context.Context,
-	data *framework.FieldData, mountPoint string,
-) (exported bool, format string, role *roleEntry, errorResp *logical.Response) {
+func (b *backend) getGenerationParams(ctx context.Context, data *framework.FieldData, mountPoint string) (exported bool, format string, role *roleEntry, errorResp *logical.Response) {
 	exportedStr := data.Get("exported").(string)
 	switch exportedStr {
 	case "exported":
 		exported = true
 	case "internal":
+	case "existing":
 	case "kms":
 	default:
 		errorResp = logical.ErrorResponse(
-			`the "exported" path parameter must be "internal", "exported" or "kms"`)
+			`the "exported" path parameter must be "internal", "existing", exported" or "kms"`)
 		return
 	}
 
@@ -36,46 +37,10 @@ func (b *backend) getGenerationParams(ctx context.Context,
 		return
 	}
 
-	keyType := data.Get("key_type").(string)
-	keyBits := data.Get("key_bits").(int)
-	if exportedStr == "kms" {
-		_, okKeyType := data.Raw["key_type"]
-		_, okKeyBits := data.Raw["key_bits"]
-
-		if okKeyType || okKeyBits {
-			errorResp = logical.ErrorResponse(
-				`invalid parameter for the kms path parameter, key_type nor key_bits arguments can be set in this mode`)
-			return
-		}
-
-		keyId, err := getManagedKeyId(data)
-		if err != nil {
-			errorResp = logical.ErrorResponse("unable to determine managed key id")
-			return
-		}
-		// Determine key type and key bits from the managed public key
-		err = withManagedPKIKey(ctx, b, keyId, mountPoint, func(ctx context.Context, key logical.ManagedSigningKey) error {
-			pubKey, err := key.GetPublicKey(ctx)
-			if err != nil {
-				return err
-			}
-			switch pubKey.(type) {
-			case *rsa.PublicKey:
-				keyType = "rsa"
-				keyBits = pubKey.(*rsa.PublicKey).Size() * 8
-			case *ecdsa.PublicKey:
-				keyType = "ec"
-			case *ed25519.PublicKey:
-				keyType = "ed25519"
-			default:
-				return fmt.Errorf("unsupported public key: %#v", pubKey)
-			}
-			return nil
-		})
-		if err != nil {
-			errorResp = logical.ErrorResponse("failed to lookup public key from managed key: %s", err.Error())
-			return
-		}
+	keyType, keyBits, err := getKeyTypeAndBitsForRole(ctx, b, data, mountPoint)
+	if err != nil {
+		errorResp = logical.ErrorResponse(err.Error())
+		return
 	}
 
 	role = &roleEntry{
@@ -101,10 +66,110 @@ func (b *backend) getGenerationParams(ctx context.Context,
 	}
 	*role.AllowWildcardCertificates = true
 
-	var err error
 	if role.KeyBits, role.SignatureBits, err = certutil.ValidateDefaultOrValueKeyTypeSignatureLength(role.KeyType, role.KeyBits, role.SignatureBits); err != nil {
 		errorResp = logical.ErrorResponse(err.Error())
 	}
 
 	return
+}
+
+func getKeyTypeAndBitsForRole(ctx context.Context, b *backend, data *framework.FieldData, mountPoint string) (string, int, error) {
+	exportedStr := data.Get("exported").(string)
+	var keyType string
+	var keyBits int
+
+	switch exportedStr {
+	case "internal":
+		fallthrough
+	case "exported":
+		keyType = data.Get("key_type").(string)
+		keyBits = data.Get("key_bits").(int)
+		return keyType, keyBits, nil
+	}
+
+	// existing and kms types don't support providing the key_type and key_bits args.
+	_, okKeyType := data.Raw["key_type"]
+	_, okKeyBits := data.Raw["key_bits"]
+
+	if okKeyType || okKeyBits {
+		return "", 0, errors.New("invalid parameter for the kms/existing path parameter, key_type nor key_bits arguments can be set in this mode")
+	}
+
+	var pubKey crypto.PublicKey
+	if kmsRequestedFromFieldData(data) {
+		pubKeyManagedKey, err := getManagedKeyPublicKey(ctx, b, data, mountPoint)
+		if err != nil {
+			return "", 0, errors.New("failed to lookup public key from managed key: " + err.Error())
+		}
+		pubKey = pubKeyManagedKey
+	}
+
+	if existingKeyRequestedFromFieldData(data) {
+		existingPubKey, err := getExistingPublicKey(ctx, b.storage, data)
+		if err != nil {
+			return "", 0, errors.New("failed to lookup public key from existing key: " + err.Error())
+		}
+		pubKey = existingPubKey
+	}
+
+	return getKeyTypeAndBitsFromPublicKeyForRole(pubKey)
+}
+
+func getExistingPublicKey(ctx context.Context, s logical.Storage, data *framework.FieldData) (crypto.PublicKey, error) {
+	keyRef, err := getExistingKeyRef(data)
+	if err != nil {
+		return nil, err
+	}
+	id, err := resolveKeyReference(ctx, s, keyRef)
+	if err != nil {
+		return nil, err
+	}
+	key, err := fetchKeyById(ctx, s, id)
+	if err != nil {
+		return nil, err
+	}
+	signer, err := key.GetSigner()
+	if err != nil {
+		return nil, err
+	}
+	return signer.Public(), nil
+}
+
+func getKeyTypeAndBitsFromPublicKeyForRole(pubKey crypto.PublicKey) (string, int, error) {
+	var keyType string
+	var keyBits int
+
+	switch pubKey.(type) {
+	case *rsa.PublicKey:
+		keyType = "rsa"
+		keyBits = certutil.GetPublicKeySize(pubKey)
+	case *ecdsa.PublicKey:
+		keyType = "ec"
+	case *ed25519.PublicKey:
+		keyType = "ed25519"
+	default:
+		return "", 0, fmt.Errorf("unsupported public key: %#v", pubKey)
+	}
+	return keyType, keyBits, nil
+}
+
+func getManagedKeyPublicKey(ctx context.Context, b *backend, data *framework.FieldData, mountPoint string) (crypto.PublicKey, error) {
+	keyId, err := getManagedKeyId(data)
+	if err != nil {
+		return nil, errors.New("unable to determine managed key id")
+	}
+	// Determine key type and key bits from the managed public key
+	var pubKey crypto.PublicKey
+	err = withManagedPKIKey(ctx, b, keyId, mountPoint, func(ctx context.Context, key logical.ManagedSigningKey) error {
+		pubKey, err = key.GetPublicKey(ctx)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.New("failed to lookup public key from managed key: " + err.Error())
+	}
+	return pubKey, nil
 }

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -135,7 +135,10 @@ func fetchCAInfo(ctx context.Context, b *backend, req *logical.Request, issuerRe
 }
 
 // Allows fetching certificates from the backend; it handles the slightly
-// separate pathing for CA, CRL, and revoked certificates.
+// separate pathing for CRL, and revoked certificates.
+//
+// Support for fetching CA certificates was removed, due to the new issuers
+// changes.
 func fetchCertBySerial(ctx context.Context, req *logical.Request, prefix, serial string) (*logical.StorageEntry, error) {
 	var path, legacyPath string
 	var err error
@@ -145,13 +148,11 @@ func fetchCertBySerial(ctx context.Context, req *logical.Request, prefix, serial
 	colonSerial := strings.Replace(strings.ToLower(serial), "-", ":", -1)
 
 	switch {
-	// Revoked goes first as otherwise ca/crl get hardcoded paths which fail if
+	// Revoked goes first as otherwise crl get hardcoded paths which fail if
 	// we actually want revocation info
 	case strings.HasPrefix(prefix, "revoked/"):
 		legacyPath = "revoked/" + colonSerial
 		path = "revoked/" + hyphenSerial
-	case serial == "ca":
-		path = "ca"
 	case serial == "crl":
 		path = "crl"
 	default:

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -92,13 +92,6 @@ func TestPki_FetchCertBySerial(t *testing.T) {
 		Prefix string
 		Serial string
 	}{
-		"ca": {
-			&logical.Request{
-				Storage: storage,
-			},
-			"",
-			"ca",
-		},
 		"crl": {
 			&logical.Request{
 				Storage: storage,

--- a/builtin/logical/pki/config_util.go
+++ b/builtin/logical/pki/config_util.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func isKeyDefaultSet(ctx context.Context, s logical.Storage) (bool, error) {
+func isDefaultKeySet(ctx context.Context, s logical.Storage) (bool, error) {
 	config, err := getKeysConfig(ctx, s)
 	if err != nil {
 		return false, err
@@ -16,7 +16,7 @@ func isKeyDefaultSet(ctx context.Context, s logical.Storage) (bool, error) {
 	return strings.TrimSpace(config.DefaultKeyId.String()) != "", nil
 }
 
-func isIssuerDefaultSet(ctx context.Context, s logical.Storage) (bool, error) {
+func isDefaultIssuerSet(ctx context.Context, s logical.Storage) (bool, error) {
 	config, err := getIssuersConfig(ctx, s)
 	if err != nil {
 		return false, err

--- a/builtin/logical/pki/config_util.go
+++ b/builtin/logical/pki/config_util.go
@@ -1,0 +1,37 @@
+package pki
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func updateDefaultKeyId(ctx context.Context, s logical.Storage, id keyId) error {
+	config, err := getKeysConfig(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	if config.DefaultKeyId != id {
+		return setKeysConfig(ctx, s, &keyConfig{
+			DefaultKeyId: id,
+		})
+	}
+
+	return nil
+}
+
+func updateDefaultIssuerId(ctx context.Context, s logical.Storage, id issuerId) error {
+	config, err := getIssuersConfig(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	if config.DefaultIssuerId != id {
+		return setIssuersConfig(ctx, s, &issuerConfig{
+			DefaultIssuerId: id,
+		})
+	}
+
+	return nil
+}

--- a/builtin/logical/pki/config_util.go
+++ b/builtin/logical/pki/config_util.go
@@ -2,9 +2,28 @@ package pki
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/vault/sdk/logical"
 )
+
+func isKeyDefaultSet(ctx context.Context, s logical.Storage) (bool, error) {
+	config, err := getKeysConfig(ctx, s)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.TrimSpace(config.DefaultKeyId.String()) != "", nil
+}
+
+func isIssuerDefaultSet(ctx context.Context, s logical.Storage) (bool, error) {
+	config, err := getIssuersConfig(ctx, s)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.TrimSpace(config.DefaultIssuerId.String()) != "", nil
+}
 
 func updateDefaultKeyId(ctx context.Context, s logical.Storage, id keyId) error {
 	config, err := getKeysConfig(ctx, s)

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -32,7 +32,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 		return nil, nil
 	}
 
-	signingBundle, caErr := fetchCAInfo(ctx, b, req)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:
@@ -223,7 +223,7 @@ func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bo
 	}
 
 WRITE:
-	signingBundle, caErr := fetchCAInfo(ctx, b, req)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -314,6 +314,18 @@ SHA-2-512. Defaults to 0 to automatically detect based on key length
 			Value: "rsa",
 		},
 	}
+
+	fields["key_id"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `Reference to a existing key; either "default"
+for the configured default key, an identifier or the name assigned
+to the key. Note this is only used for the existing generation type.`,
+	}
+
+	fields["id"] = &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Description: `Assign a name to the generated issuer.`,
+	}
 	return fields
 }
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -132,11 +132,7 @@ be larger than the role max TTL.`,
 The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ`,
 	}
 
-	fields["ref"] = &framework.FieldSchema{
-		Type:        framework.TypeString,
-		Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
-		Default:     "default",
-	}
+	fields = addIssuerRefField(fields)
 
 	return fields
 }
@@ -315,12 +311,8 @@ SHA-2-512. Defaults to 0 to automatically detect based on key length
 		},
 	}
 
-	fields["key_id"] = &framework.FieldSchema{
-		Type: framework.TypeString,
-		Description: `Reference to a existing key; either "default"
-for the configured default key, an identifier or the name assigned
-to the key. Note this is only used for the existing generation type.`,
-	}
+	fields = addKeyRefNameFields(fields)
+
 	return fields
 }
 
@@ -341,5 +333,61 @@ func addCAIssueFields(fields map[string]*framework.FieldSchema) map[string]*fram
 		},
 	}
 
+	fields = addIssuerNameField(fields)
+
+	return fields
+}
+
+func addKeyRefNameFields(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields = addKeyNameField(fields)
+	fields = addKeyRefField(fields)
+	return fields
+}
+
+func addIssuerRefNameFields(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields = addIssuerNameField(fields)
+	fields = addIssuerRefField(fields)
+	return fields
+}
+
+func addIssuerRefField(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields["issuer_ref"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `Reference to a existing issuer; either "default"
+for the configured default issuer, an identifier or the name assigned
+to the issuer.`,
+		Default: "default",
+	}
+	return fields
+}
+
+func addIssuerNameField(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields["issuer_name"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `Provide a name to the generated issuer, the name
+must be unique across all issuers and not be the reserved value 'default'`,
+	}
+	return fields
+}
+
+func addKeyNameField(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields["key_name"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `Provide a name for the key that will be generated,
+the name must be unique across all keys and not be the reserved value
+'default'`,
+	}
+
+	return fields
+}
+
+func addKeyRefField(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields["key_ref"] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `Reference to a existing key; either "default"
+for the configured default key, an identifier or the name assigned
+to the key.`,
+		Default: "default",
+	}
 	return fields
 }

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -321,11 +321,6 @@ SHA-2-512. Defaults to 0 to automatically detect based on key length
 for the configured default key, an identifier or the name assigned
 to the key. Note this is only used for the existing generation type.`,
 	}
-
-	fields["id"] = &framework.FieldSchema{
-		Type:        framework.TypeString,
-		Description: `Assign a name to the generated issuer.`,
-	}
 	return fields
 }
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -2,6 +2,10 @@ package pki
 
 import "github.com/hashicorp/vault/sdk/framework"
 
+const (
+	issuerRefParam = "issuer_ref"
+)
+
 // addIssueAndSignCommonFields adds fields common to both CA and non-CA issuing
 // and signing
 func addIssueAndSignCommonFields(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
@@ -338,26 +342,9 @@ func addCAIssueFields(fields map[string]*framework.FieldSchema) map[string]*fram
 	return fields
 }
 
-func addKeyRefNameFields(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
-	fields = addKeyNameField(fields)
-	fields = addKeyRefField(fields)
-	return fields
-}
-
 func addIssuerRefNameFields(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
 	fields = addIssuerNameField(fields)
 	fields = addIssuerRefField(fields)
-	return fields
-}
-
-func addIssuerRefField(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
-	fields["issuer_ref"] = &framework.FieldSchema{
-		Type: framework.TypeString,
-		Description: `Reference to a existing issuer; either "default"
-for the configured default issuer, an identifier or the name assigned
-to the issuer.`,
-		Default: "default",
-	}
 	return fields
 }
 
@@ -367,6 +354,23 @@ func addIssuerNameField(fields map[string]*framework.FieldSchema) map[string]*fr
 		Description: `Provide a name to the generated issuer, the name
 must be unique across all issuers and not be the reserved value 'default'`,
 	}
+	return fields
+}
+
+func addIssuerRefField(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields[issuerRefParam] = &framework.FieldSchema{
+		Type: framework.TypeString,
+		Description: `Reference to a existing issuer; either "default"
+for the configured default issuer, an identifier or the name assigned
+to the issuer.`,
+		Default: "default",
+	}
+	return fields
+}
+
+func addKeyRefNameFields(fields map[string]*framework.FieldSchema) map[string]*framework.FieldSchema {
+	fields = addKeyNameField(fields)
+	fields = addKeyRefField(fields)
 	return fields
 }
 

--- a/builtin/logical/pki/fields.go
+++ b/builtin/logical/pki/fields.go
@@ -132,6 +132,12 @@ be larger than the role max TTL.`,
 The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ`,
 	}
 
+	fields["ref"] = &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
+		Default:     "default",
+	}
+
 	return fields
 }
 

--- a/builtin/logical/pki/managed_key_util.go
+++ b/builtin/logical/pki/managed_key_util.go
@@ -32,6 +32,6 @@ func parseCABundle(_ context.Context, _ *backend, _ *logical.Request, bundle *ce
 	return bundle.ToParsedCertBundle()
 }
 
-func withManagedPKIKey(_ context.Context, _ *backend, _ keyId, _ string, _ logical.ManagedSigningKeyConsumer) error {
+func withManagedPKIKey(_ context.Context, _ *backend, _ managedKeyId, _ string, _ logical.ManagedSigningKeyConsumer) error {
 	return errEntOnly
 }

--- a/builtin/logical/pki/managed_key_util.go
+++ b/builtin/logical/pki/managed_key_util.go
@@ -4,6 +4,7 @@ package pki
 
 import (
 	"context"
+	"encoding/pem"
 	"errors"
 	"io"
 
@@ -13,9 +14,16 @@ import (
 
 var errEntOnly = errors.New("managed keys are supported within enterprise edition only")
 
-func generateCABundle(_ context.Context, _ *backend, input *inputBundle, data *certutil.CreationBundle, randomSource io.Reader) (*certutil.ParsedCertBundle, error) {
+func generateCABundle(ctx context.Context, _ *backend, input *inputBundle, data *certutil.CreationBundle, randomSource io.Reader) (*certutil.ParsedCertBundle, error) {
 	if kmsRequested(input) {
 		return nil, errEntOnly
+	}
+	if existingKeyRequested(input) {
+		keyRef, err := getExistingKeyRef(input.apiData)
+		if err != nil {
+			return nil, err
+		}
+		return certutil.CreateCertificateWithKeyGenerator(data, randomSource, existingGeneratePrivateKey(ctx, input.req.Storage, keyRef))
 	}
 	return certutil.CreateCertificateWithRandomSource(data, randomSource)
 }
@@ -34,4 +42,28 @@ func parseCABundle(_ context.Context, _ *backend, _ *logical.Request, bundle *ce
 
 func withManagedPKIKey(_ context.Context, _ *backend, _ managedKeyId, _ string, _ logical.ManagedSigningKeyConsumer) error {
 	return errEntOnly
+}
+
+func existingGeneratePrivateKey(ctx context.Context, s logical.Storage, keyRef string) certutil.KeyGenerator {
+	return func(keyType string, keyBits int, container certutil.ParsedPrivateKeyContainer, _ io.Reader) error {
+		keyId, err := resolveKeyReference(ctx, s, keyRef)
+		if err != nil {
+			return err
+		}
+		key, err := fetchKeyById(ctx, s, keyId)
+		if err != nil {
+			return err
+		}
+		signer, err := key.GetSigner()
+		if err != nil {
+			return err
+		}
+		privateKeyType := certutil.GetPrivateKeyTypeFromSigner(signer)
+		if privateKeyType == certutil.UnknownPrivateKey {
+			return errors.New("unknown private key type loaded from key id: " + keyId.String())
+		}
+		blk, _ := pem.Decode([]byte(key.PrivateKey))
+		container.SetParsedPrivateKey(signer, privateKeyType, blk.Bytes)
+		return nil
+	}
 }

--- a/builtin/logical/pki/managed_key_util.go
+++ b/builtin/logical/pki/managed_key_util.go
@@ -19,7 +19,7 @@ func generateCABundle(ctx context.Context, _ *backend, input *inputBundle, data 
 		return nil, errEntOnly
 	}
 	if existingKeyRequested(input) {
-		keyRef, err := getExistingKeyRef(input.apiData)
+		keyRef, err := getKeyRefWithErr(input.apiData)
 		if err != nil {
 			return nil, err
 		}
@@ -33,7 +33,7 @@ func generateCSRBundle(ctx context.Context, _ *backend, input *inputBundle, data
 		return nil, errEntOnly
 	}
 	if existingKeyRequested(input) {
-		keyRef, err := getExistingKeyRef(input.apiData)
+		keyRef, err := getKeyRefWithErr(input.apiData)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -103,6 +103,72 @@ secret key and certificate.
 For security reasons, the secret key cannot be retrieved later.
 `
 
+func pathConfigIssuers(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "config/issuers",
+		Fields: map[string]*framework.FieldSchema{
+			"default": {
+				Type:        framework.TypeString,
+				Description: `Reference (name or identifier) to the default issuer.`,
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation:   b.pathCAIssuersRead,
+			logical.UpdateOperation: b.pathCAIssuersWrite,
+		},
+
+		HelpSynopsis:    pathConfigIssuersHelpSyn,
+		HelpDescription: pathConfigIssuersHelpDesc,
+	}
+}
+
+func (b *backend) pathCAIssuersRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	config, err := getIssuersConfig(ctx, req.Storage)
+	if err != nil {
+		return logical.ErrorResponse("Error loading issuers configuration: " + err.Error()), nil
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"default": config.DefaultIssuerId,
+		},
+	}, nil
+}
+
+func (b *backend) pathCAIssuersWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	newDefault := data.Get("default").(string)
+	if len(newDefault) == 0 || newDefault == "default" {
+		return logical.ErrorResponse("Invalid issuer specification; must be non-empty and can't be 'default'."), nil
+	}
+
+	parsedIssuer, err := resolveIssuerReference(ctx, req.Storage, newDefault)
+	if err != nil {
+		return logical.ErrorResponse("Error resolving issuer reference: " + err.Error()), nil
+	}
+
+	err = updateDefaultIssuerId(ctx, req.Storage, parsedIssuer)
+	if err != nil {
+		return logical.ErrorResponse("Error updating issuer configuration: " + err.Error()), nil
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"default": parsedIssuer,
+		},
+	}, nil
+}
+
+const pathConfigIssuersHelpSyn = `Read and set the default issuer certificate for signing.`
+
+const pathConfigIssuersHelpDesc = `
+This path allows configuration of issuer parameters.
+
+Presently, the "default" parameter controls which issuer is the default,
+accessible by the existing signing paths (/root/sign-intermediate,
+/root/sign-self-issued, /sign-verbatim, /sign/:role, and /issue/:role).
+`
+
 const pathConfigCAGenerateHelpSyn = `
 Generate a new CA certificate and private key used for signing.
 `

--- a/builtin/logical/pki/path_config_ca.go
+++ b/builtin/logical/pki/path_config_ca.go
@@ -2,11 +2,8 @@ package pki
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/hashicorp/vault/sdk/helper/certutil"
-	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -22,73 +19,12 @@ secret key and certificate.`,
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathCAWrite,
+			logical.UpdateOperation: b.pathImportIssuers,
 		},
 
 		HelpSynopsis:    pathConfigCAHelpSyn,
 		HelpDescription: pathConfigCAHelpDesc,
 	}
-}
-
-func (b *backend) pathCAWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	pemBundle := data.Get("pem_bundle").(string)
-
-	if pemBundle == "" {
-		return logical.ErrorResponse("'pem_bundle' was empty"), nil
-	}
-
-	parsedBundle, err := certutil.ParsePEMBundle(pemBundle)
-	if err != nil {
-		switch err.(type) {
-		case errutil.InternalError:
-			return nil, err
-		default:
-			return logical.ErrorResponse(err.Error()), nil
-		}
-	}
-
-	if parsedBundle.PrivateKey == nil {
-		return logical.ErrorResponse("private key not found in the PEM bundle"), nil
-	}
-
-	if parsedBundle.PrivateKeyType == certutil.UnknownPrivateKey {
-		return logical.ErrorResponse("unknown private key found in the PEM bundle"), nil
-	}
-
-	if parsedBundle.Certificate == nil {
-		return logical.ErrorResponse("no certificate found in the PEM bundle"), nil
-	}
-
-	if !parsedBundle.Certificate.IsCA {
-		return logical.ErrorResponse("the given certificate is not marked for CA use and cannot be used with this backend"), nil
-	}
-
-	cb, err := parsedBundle.ToCertBundle()
-	if err != nil {
-		return nil, fmt.Errorf("error converting raw values into cert bundle: %w", err)
-	}
-
-	entry, err := logical.StorageEntryJSON("config/ca_bundle", cb)
-	if err != nil {
-		return nil, err
-	}
-	err = req.Storage.Put(ctx, entry)
-	if err != nil {
-		return nil, err
-	}
-
-	// For ease of later use, also store just the certificate at a known
-	// location, plus a fresh CRL
-	entry.Key = "ca"
-	entry.Value = parsedBundle.CertificateBytes
-	err = req.Storage.Put(ctx, entry)
-	if err != nil {
-		return nil, err
-	}
-
-	err = buildCRL(ctx, b, req, true)
-
-	return nil, err
 }
 
 const pathConfigCAHelpSyn = `

--- a/builtin/logical/pki/path_fetch.go
+++ b/builtin/logical/pki/path_fetch.go
@@ -191,7 +191,7 @@ func (b *backend) pathFetchRead(ctx context.Context, req *logical.Request, data 
 	}
 
 	if serial == "ca_chain" {
-		caInfo, err := fetchCAInfo(ctx, b, req)
+		caInfo, err := fetchCAInfo(ctx, b, req, "default")
 		if err != nil {
 			switch err.(type) {
 			case errutil.UserError:

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -1,0 +1,252 @@
+package pki
+
+import (
+	"context"
+	"encoding/pem"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+var nameMatcher = regexp.MustCompile("^" + framework.GenericNameRegex("ref") + "$")
+
+func pathListIssuers(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "issuers/?$",
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ListOperation: b.pathListIssuersHandler,
+		},
+
+		HelpSynopsis:    pathListIssuersHelpSyn,
+		HelpDescription: pathListIssuersHelpDesc,
+	}
+}
+
+func (b *backend) pathListIssuersHandler(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	var responseKeys []string
+	responseInfo := make(map[string]interface{})
+
+	entries, err := listIssuers(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	// For each issuer, we need not only the identifier (as returned by
+	// listIssuers), but also the name of the issuer. This means we have to
+	// fetch the actual issuer object as well.
+	for _, identifier := range entries {
+		issuer, err := fetchIssuerById(ctx, req.Storage, identifier)
+		if err != nil {
+			return nil, err
+		}
+
+		responseKeys = append(responseKeys, string(identifier))
+		responseInfo[string(identifier)] = map[string]interface{}{
+			"name": issuer.Name,
+		}
+	}
+
+	return logical.ListResponseWithInfo(responseKeys, responseInfo), nil
+}
+
+const (
+	pathListIssuersHelpSyn  = `Fetch a list of CA certificates.`
+	pathListIssuersHelpDesc = `
+This endpoint allows listing of known issuing certificates, returning
+their identifier and their name (if set).
+`
+)
+
+func pathGetIssuer(b *backend) *framework.Path {
+	pattern := "issuer/" + framework.GenericNameRegex("ref") + "(/der|/pem)?"
+	return buildPathGetIssuer(b, pattern)
+}
+
+func buildPathGetIssuer(b *backend, pattern string) *framework.Path {
+	return &framework.Path{
+		// Returns a JSON entry.
+		Pattern: pattern,
+		Fields: map[string]*framework.FieldSchema{
+			"ref": {
+				Type:        framework.TypeString,
+				Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
+				Default:     "default",
+			},
+			"name": {
+				Type:        framework.TypeString,
+				Description: `Human-readable name for this issuer.`,
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.ReadOperation:   b.pathGetIssuer,
+			logical.UpdateOperation: b.pathUpdateIssuer,
+			logical.DeleteOperation: b.pathDeleteIssuer,
+		},
+
+		HelpSynopsis:    pathGetIssuerHelpSyn,
+		HelpDescription: pathGetIssuerHelpDesc,
+	}
+}
+
+func (b *backend) pathGetIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Handle raw issuers first.
+	if strings.HasSuffix(req.Path, "/der") || strings.HasSuffix(req.Path, "/pem") {
+		return b.pathGetRawIssuer(ctx, req, data)
+	}
+
+	issuerName := data.Get("ref").(string)
+	if len(issuerName) == 0 {
+		return logical.ErrorResponse("missing issuer reference"), nil
+	}
+
+	ref, err := resolveIssuerReference(ctx, req.Storage, issuerName)
+	if err != nil {
+		return nil, err
+	}
+	if ref == "" {
+		return logical.ErrorResponse("unable to resolve issuer id for reference: " + issuerName), nil
+	}
+
+	issuer, err := fetchIssuerById(ctx, req.Storage, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"id":          issuer.ID,
+			"name":        issuer.Name,
+			"key_id":      issuer.KeyID,
+			"certificate": issuer.Certificate,
+		},
+	}, nil
+}
+
+func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	issuerName := data.Get("ref").(string)
+	if len(issuerName) == 0 {
+		return logical.ErrorResponse("missing issuer reference"), nil
+	}
+
+	newName := data.Get("name").(string)
+	if len(newName) > 0 && !nameMatcher.MatchString(newName) {
+		return logical.ErrorResponse("new issuer name outside of valid character limits"), nil
+	}
+
+	ref, err := resolveIssuerReference(ctx, req.Storage, issuerName)
+	if err != nil {
+		return nil, err
+	}
+	if ref == "" {
+		return logical.ErrorResponse("unable to resolve issuer id for reference: " + issuerName), nil
+	}
+
+	issuer, err := fetchIssuerById(ctx, req.Storage, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	if newName != issuer.Name {
+		issuer.Name = newName
+
+		err := writeIssuer(ctx, req.Storage, issuer)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"id":          issuer.ID,
+			"name":        issuer.Name,
+			"key_id":      issuer.KeyID,
+			"certificate": issuer.Certificate,
+		},
+	}, nil
+}
+
+func (b *backend) pathGetRawIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	issuerName := data.Get("ref").(string)
+	if len(issuerName) == 0 {
+		return logical.ErrorResponse("missing issuer reference"), nil
+	}
+
+	ref, err := resolveIssuerReference(ctx, req.Storage, issuerName)
+	if err != nil {
+		return nil, err
+	}
+	if ref == "" {
+		return logical.ErrorResponse("unable to resolve issuer id for reference: " + issuerName), nil
+	}
+
+	issuer, err := fetchIssuerById(ctx, req.Storage, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	certificate := []byte(issuer.Certificate)
+	contentType := "application/pem-certificate-chain"
+
+	if strings.HasSuffix(req.Path, "/der") {
+		contentType = "application/pkix-cert"
+
+		pemBlock, _ := pem.Decode(certificate)
+		if pemBlock == nil {
+			return nil, err
+		}
+
+		certificate = pemBlock.Bytes
+	}
+
+	statusCode := 200
+	if len(certificate) == 0 {
+		statusCode = 204
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			logical.HTTPContentType: contentType,
+			logical.HTTPRawBody:     certificate,
+			logical.HTTPStatusCode:  statusCode,
+		},
+	}, nil
+}
+
+func (b *backend) pathDeleteIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	issuerName := data.Get("ref").(string)
+	if len(issuerName) == 0 {
+		return logical.ErrorResponse("missing issuer reference"), nil
+	}
+
+	ref, err := resolveIssuerReference(ctx, req.Storage, issuerName)
+	if err != nil {
+		return nil, err
+	}
+	if ref == "" {
+		return logical.ErrorResponse("unable to resolve issuer id for reference: " + issuerName), nil
+	}
+
+	return nil, deleteIssuer(ctx, req.Storage, ref)
+}
+
+const (
+	pathGetIssuerHelpSyn  = `Fetch a single issuer certificate.`
+	pathGetIssuerHelpDesc = `
+This allows fetching information associated with the underlying issuer
+certificate.
+
+:ref can be either the literal value "default", in which case /config/issuers
+will be consulted for the present default issuer, an identifier of an issuer,
+or its assigned name value.
+
+Use /issuer/:ref/der or /issuer/:ref/pem to return just the certificate in
+raw DER or PEM form, without the JSON structure of /issuer/:ref.
+
+Writing to /issuer/:ref allows updating of the name field associated with
+the certificate.
+`
+)

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-var nameMatcher = regexp.MustCompile("^" + framework.GenericNameRegex("issuer_ref") + "$")
+var nameMatcher = regexp.MustCompile("^" + framework.GenericNameRegex(issuerRefParam) + "$")
 
 func pathListIssuers(b *backend) *framework.Path {
 	return &framework.Path{
@@ -61,7 +61,7 @@ their identifier and their name (if set).
 )
 
 func pathGetIssuer(b *backend) *framework.Path {
-	pattern := "issuer/" + framework.GenericNameRegex("issuer_ref") + "(/der|/pem)?"
+	pattern := "issuer/" + framework.GenericNameRegex(issuerRefParam) + "(/der|/pem)?"
 	return buildPathGetIssuer(b, pattern)
 }
 

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -25,7 +25,7 @@ func pathListIssuers(b *backend) *framework.Path {
 	}
 }
 
-func (b *backend) pathListIssuersHandler(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+func (b *backend) pathListIssuersHandler(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
 	var responseKeys []string
 	responseInfo := make(map[string]interface{})
 
@@ -90,7 +90,7 @@ func (b *backend) pathGetIssuer(ctx context.Context, req *logical.Request, data 
 		return b.pathGetRawIssuer(ctx, req, data)
 	}
 
-	issuerName := data.Get("issuer_ref").(string)
+	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
 	}
@@ -119,14 +119,14 @@ func (b *backend) pathGetIssuer(ctx context.Context, req *logical.Request, data 
 }
 
 func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	issuerName := data.Get("issuer_ref").(string)
+	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
 	}
 
-	newName := data.Get("issuer_name").(string)
-	if len(newName) > 0 && !nameMatcher.MatchString(newName) {
-		return logical.ErrorResponse("new issuer name outside of valid character limits"), nil
+	newName, err := getIssuerName(ctx, req.Storage, data)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
 	}
 
 	ref, err := resolveIssuerReference(ctx, req.Storage, issuerName)
@@ -162,7 +162,7 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 }
 
 func (b *backend) pathGetRawIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	issuerName := data.Get("issuer_ref").(string)
+	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
 	}
@@ -209,7 +209,7 @@ func (b *backend) pathGetRawIssuer(ctx context.Context, req *logical.Request, da
 }
 
 func (b *backend) pathDeleteIssuer(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	issuerName := data.Get("issuer_ref").(string)
+	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
 	}

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -12,7 +12,7 @@ import (
 )
 
 func pathGenerateIntermediate(b *backend) *framework.Path {
-	return commonGenerateIntermediate(b, "intermediate/generate/"+framework.GenericNameRegex("exported"))
+	return buildPathGenerateIntermediate(b, "intermediate/generate/"+framework.GenericNameRegex("exported"))
 }
 
 func pathSetSignedIntermediate(b *backend) *framework.Path {

--- a/builtin/logical/pki/path_intermediate.go
+++ b/builtin/logical/pki/path_intermediate.go
@@ -52,6 +52,10 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 		return errorResp, nil
 	}
 
+	keyName, err := getKeyName(ctx, req.Storage, data)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
 	var resp *logical.Response
 	input := &inputBundle{
 		role:    role,
@@ -110,7 +114,7 @@ func (b *backend) pathGenerateIntermediate(ctx context.Context, req *logical.Req
 		}
 	}
 
-	myKey, _, err := importKey(ctx, req.Storage, csrb.PrivateKey)
+	myKey, _, err := importKey(ctx, req.Storage, csrb.PrivateKey, keyName)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -218,7 +218,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		return nil, logical.ErrReadOnly
 	}
 
-	issuerName := data.Get("issuer_ref").(string)
+	issuerName := getIssuerRef(data)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
 	}

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -174,7 +174,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 	}
 
 	var caErr error
-	signingBundle, caErr := fetchCAInfo(ctx, b, req)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -15,8 +15,18 @@ import (
 )
 
 func pathIssue(b *backend) *framework.Path {
+	pattern := "issue/" + framework.GenericNameRegex("role")
+	return buildPathIssue(b, pattern)
+}
+
+func pathIssuerIssue(b *backend) *framework.Path {
+	pattern := "issuer/" + framework.GenericNameRegex("ref") + "/issue/" + framework.GenericNameRegex("role")
+	return buildPathIssue(b, pattern)
+}
+
+func buildPathIssue(b *backend, pattern string) *framework.Path {
 	ret := &framework.Path{
-		Pattern: "issue/" + framework.GenericNameRegex("role"),
+		Pattern: pattern,
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.metricsWrap("issue", roleRequired, b.pathIssue),
@@ -31,8 +41,18 @@ func pathIssue(b *backend) *framework.Path {
 }
 
 func pathSign(b *backend) *framework.Path {
+	pattern := "sign/" + framework.GenericNameRegex("role")
+	return buildPathSign(b, pattern)
+}
+
+func pathIssuerSign(b *backend) *framework.Path {
+	pattern := "issuer/" + framework.GenericNameRegex("ref") + "/sign/" + framework.GenericNameRegex("role")
+	return buildPathSign(b, pattern)
+}
+
+func buildPathSign(b *backend, pattern string) *framework.Path {
 	ret := &framework.Path{
-		Pattern: "sign/" + framework.GenericNameRegex("role"),
+		Pattern: pattern,
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.UpdateOperation: b.metricsWrap("sign", roleRequired, b.pathSign),

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -79,7 +79,7 @@ func pathIssuerSignVerbatim(b *backend) *framework.Path {
 }
 
 func pathSignVerbatim(b *backend) *framework.Path {
-	pattern := "root/sign-verbatim"
+	pattern := "sign-verbatim" + framework.OptionalParamRegex("role")
 	return buildPathIssuerSignVerbatim(b, pattern)
 }
 

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -20,7 +20,7 @@ func pathIssue(b *backend) *framework.Path {
 }
 
 func pathIssuerIssue(b *backend) *framework.Path {
-	pattern := "issuer/" + framework.GenericNameRegex("ref") + "/issue/" + framework.GenericNameRegex("role")
+	pattern := "issuer/" + framework.GenericNameRegex("issuer_ref") + "/issue/" + framework.GenericNameRegex("role")
 	return buildPathIssue(b, pattern)
 }
 
@@ -46,7 +46,7 @@ func pathSign(b *backend) *framework.Path {
 }
 
 func pathIssuerSign(b *backend) *framework.Path {
-	pattern := "issuer/" + framework.GenericNameRegex("ref") + "/sign/" + framework.GenericNameRegex("role")
+	pattern := "issuer/" + framework.GenericNameRegex("issuer_ref") + "/sign/" + framework.GenericNameRegex("role")
 	return buildPathSign(b, pattern)
 }
 
@@ -74,7 +74,7 @@ func buildPathSign(b *backend, pattern string) *framework.Path {
 }
 
 func pathIssuerSignVerbatim(b *backend) *framework.Path {
-	pattern := "issuers/" + framework.GenericNameRegex("ref") + "/sign-verbatim"
+	pattern := "issuers/" + framework.GenericNameRegex("issuer_ref") + "/sign-verbatim"
 	return buildPathIssuerSignVerbatim(b, pattern)
 }
 
@@ -218,7 +218,7 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 		return nil, logical.ErrReadOnly
 	}
 
-	issuerName := data.Get("ref").(string)
+	issuerName := data.Get("issuer_ref").(string)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
 	}

--- a/builtin/logical/pki/path_issue_sign.go
+++ b/builtin/logical/pki/path_issue_sign.go
@@ -20,7 +20,7 @@ func pathIssue(b *backend) *framework.Path {
 }
 
 func pathIssuerIssue(b *backend) *framework.Path {
-	pattern := "issuer/" + framework.GenericNameRegex("issuer_ref") + "/issue/" + framework.GenericNameRegex("role")
+	pattern := "issuer/" + framework.GenericNameRegex(issuerRefParam) + "/issue/" + framework.GenericNameRegex("role")
 	return buildPathIssue(b, pattern)
 }
 
@@ -46,7 +46,7 @@ func pathSign(b *backend) *framework.Path {
 }
 
 func pathIssuerSign(b *backend) *framework.Path {
-	pattern := "issuer/" + framework.GenericNameRegex("issuer_ref") + "/sign/" + framework.GenericNameRegex("role")
+	pattern := "issuer/" + framework.GenericNameRegex(issuerRefParam) + "/sign/" + framework.GenericNameRegex("role")
 	return buildPathSign(b, pattern)
 }
 
@@ -74,7 +74,7 @@ func buildPathSign(b *backend, pattern string) *framework.Path {
 }
 
 func pathIssuerSignVerbatim(b *backend) *framework.Path {
-	pattern := "issuers/" + framework.GenericNameRegex("issuer_ref") + "/sign-verbatim"
+	pattern := "issuers/" + framework.GenericNameRegex(issuerRefParam) + "/sign-verbatim"
 	return buildPathIssuerSignVerbatim(b, pattern)
 }
 

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -1,0 +1,124 @@
+package pki
+
+import (
+	"bytes"
+	"context"
+	"encoding/pem"
+	"strings"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/errutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func pathImportIssuer(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: "issuers/import/(cert|bundle)",
+		Fields: map[string]*framework.FieldSchema{
+			"pem_bundle": {
+				Type: framework.TypeString,
+				Description: `PEM-format, concatenated unencrypted
+secret-key (optional) and certificates.`,
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.UpdateOperation: b.pathImportIssuers,
+		},
+
+		HelpSynopsis:    pathImportIssuersHelpSyn,
+		HelpDescription: pathImportIssuersHelpDesc,
+	}
+}
+
+func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	keysAllowed := strings.HasSuffix(req.Path, "bundle")
+
+	pemBundle := data.Get("pem_bundle").(string)
+	if len(pemBundle) == 0 {
+		return logical.ErrorResponse("'pem_bundle' parameter was empty"), nil
+	}
+
+	var createdKeys []keyId
+	var createdIssuers []issuerId
+	issuerKeyMap := make(map[issuerId]keyId)
+
+	// Rather than using certutil.ParsePEMBundle (which restricts the
+	// construction of the PEM bundle), we manually parse the bundle instead.
+	pemBytes := []byte(pemBundle)
+	var pemBlock *pem.Block
+
+	var issuers []string
+	var keys []string
+
+	for len(bytes.TrimSpace(pemBytes)) > 0 {
+		pemBlock, pemBytes = pem.Decode(pemBytes)
+		if pemBlock == nil {
+			return nil, errutil.UserError{Err: "no data found in PEM block"}
+		}
+
+		pemBlockString := string(pem.EncodeToMemory(pemBlock))
+
+		switch pemBlock.Type {
+		case "CERTIFICATE", "X509 CERTIFICATE":
+			// Must be a certificate
+			issuers = append(issuers, pemBlockString)
+		case "CRL", "X509 CRL":
+			// Ignore any CRL entries.
+		default:
+			// Otherwise, treat them as keys.
+			keys = append(keys, pemBlockString)
+		}
+	}
+
+	if len(keys) > 0 && !keysAllowed {
+		return logical.ErrorResponse("private keys found in the PEM bundle but not allowed by the path; use /issuers/import/bundle"), nil
+	}
+
+	for _, keyPem := range keys {
+		// Handle import of private key.
+		key, existing, err := importKey(ctx, req.Storage, keyPem)
+		if err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+
+		if !existing {
+			createdKeys = append(createdKeys, key.ID)
+		}
+	}
+
+	for _, certPem := range issuers {
+		cert, existing, err := importIssuer(ctx, req.Storage, certPem)
+		if err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+
+		issuerKeyMap[cert.ID] = cert.KeyID
+		if !existing {
+			createdIssuers = append(createdIssuers, cert.ID)
+		}
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"mapping":          issuerKeyMap,
+			"imported_keys":    createdKeys,
+			"imported_issuers": createdIssuers,
+		},
+	}, nil
+}
+
+const (
+	pathImportIssuersHelpSyn  = `Import the specified issuing certificates.`
+	pathImportIssuersHelpDesc = `
+This endpoint allows importing the specified issuer certificates.
+
+:type is either the literal value "cert", to only allow importing
+certificates, else "bundle" to allow importing keys as well as
+certificates.
+
+Depending on the value of :type, the pem_bundle request parameter can
+either take PEM-formatted certificates, and, if :type="bundle", unencrypted
+secret-keys.
+`
+)

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -138,7 +138,7 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 
 	for _, keyPem := range keys {
 		// Handle import of private key.
-		key, existing, err := importKey(ctx, req.Storage, keyPem)
+		key, existing, err := importKey(ctx, req.Storage, keyPem, "")
 		if err != nil {
 			return logical.ErrorResponse(err.Error()), nil
 		}

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -12,10 +12,10 @@ import (
 )
 
 func pathIssuerGenerateRoot(b *backend) *framework.Path {
-	return commonGenerateRoot(b, "issuers/generate/root/"+framework.GenericNameRegex("exported"))
+	return buildPathGenerateRoot(b, "issuers/generate/root/"+framework.GenericNameRegex("exported"))
 }
 
-func commonGenerateRoot(b *backend, pattern string) *framework.Path {
+func buildPathGenerateRoot(b *backend, pattern string) *framework.Path {
 	ret := &framework.Path{
 		Pattern: pattern,
 
@@ -39,11 +39,11 @@ func commonGenerateRoot(b *backend, pattern string) *framework.Path {
 }
 
 func pathIssuerGenerateIntermediate(b *backend) *framework.Path {
-	return commonGenerateIntermediate(b,
+	return buildPathGenerateIntermediate(b,
 		"issuers/generate/intermediate/"+framework.GenericNameRegex("exported"))
 }
 
-func commonGenerateIntermediate(b *backend, pattern string) *framework.Path {
+func buildPathGenerateIntermediate(b *backend, pattern string) *framework.Path {
 	ret := &framework.Path{
 		Pattern: pattern,
 		Operations: map[logical.Operation]framework.OperationHandler{

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -35,12 +35,6 @@ func commonGenerateRoot(b *backend, pattern string) *framework.Path {
 	ret.Fields = addCACommonFields(map[string]*framework.FieldSchema{})
 	ret.Fields = addCAKeyGenerationFields(ret.Fields)
 	ret.Fields = addCAIssueFields(ret.Fields)
-
-	ret.Fields["id"] = &framework.FieldSchema{
-		Type:        framework.TypeString,
-		Description: `Assign a name to the generated issuer.`,
-	}
-
 	return ret
 }
 

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -55,17 +55,6 @@ func (b *backend) pathCADeleteRoot(ctx context.Context, req *logical.Request, da
 func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	var err error
 
-	entry, err := req.Storage.Get(ctx, "config/ca_bundle")
-	if err != nil {
-		return nil, err
-	}
-	if entry != nil {
-		resp := &logical.Response{}
-		resp.AddWarning(fmt.Sprintf("Refusing to generate a root certificate over an existing root certificate. "+
-			"If you really want to destroy the original root certificate, please issue a delete against %s root.", req.MountPoint))
-		return resp, nil
-	}
-
 	exported, format, role, errorResp := b.getGenerationParams(ctx, data, req.MountPoint)
 	if errorResp != nil {
 		return errorResp, nil

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -311,7 +311,7 @@ func (b *backend) pathCASignIntermediate(ctx context.Context, req *logical.Reque
 	}
 
 	var caErr error
-	signingBundle, caErr := fetchCAInfo(ctx, b, req)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:
@@ -442,7 +442,7 @@ func (b *backend) pathCASignSelfIssued(ctx context.Context, req *logical.Request
 	}
 
 	var caErr error
-	signingBundle, caErr := fetchCAInfo(ctx, b, req)
+	signingBundle, caErr := fetchCAInfo(ctx, b, req, "default")
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -153,7 +153,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	if err != nil {
 		return nil, err
 	}
-	resp.Data["id"] = myIssuer.ID
+	resp.Data["issuer_id"] = myIssuer.ID
 	resp.Data["key_id"] = myKey.ID
 
 	// Also store it as just the certificate identified by serial number, so it
@@ -192,7 +192,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	var err error
 
-	issuerName := data.Get("ref").(string)
+	issuerName := data.Get("issuer_ref").(string)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
 	}
@@ -341,7 +341,7 @@ func (b *backend) pathIssuerSignIntermediate(ctx context.Context, req *logical.R
 func (b *backend) pathIssuerSignSelfIssued(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	var err error
 
-	issuerName := data.Get("ref").(string)
+	issuerName := data.Get("issuer_ref").(string)
 	if len(issuerName) == 0 {
 		return logical.ErrorResponse("missing issuer reference"), nil
 	}

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -26,7 +26,7 @@ import (
 )
 
 func pathGenerateRoot(b *backend) *framework.Path {
-	return commonGenerateRoot(b, "root/generate/"+framework.GenericNameRegex("exported"))
+	return buildPathGenerateRoot(b, "root/generate/"+framework.GenericNameRegex("exported"))
 }
 
 func pathDeleteRoot(b *backend) *framework.Path {

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -26,27 +26,7 @@ import (
 )
 
 func pathGenerateRoot(b *backend) *framework.Path {
-	ret := &framework.Path{
-		Pattern: "root/generate/" + framework.GenericNameRegex("exported"),
-
-		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathCAGenerateRoot,
-				// Read more about why these flags are set in backend.go
-				ForwardPerformanceStandby:   true,
-				ForwardPerformanceSecondary: true,
-			},
-		},
-
-		HelpSynopsis:    pathGenerateRootHelpSyn,
-		HelpDescription: pathGenerateRootHelpDesc,
-	}
-
-	ret.Fields = addCACommonFields(map[string]*framework.FieldSchema{})
-	ret.Fields = addCAKeyGenerationFields(ret.Fields)
-	ret.Fields = addCAIssueFields(ret.Fields)
-
-	return ret
+	return commonGenerateRoot(b, "root/generate/"+framework.GenericNameRegex("exported"))
 }
 
 func pathDeleteRoot(b *backend) *framework.Path {

--- a/builtin/logical/pki/path_sign_issuers.go
+++ b/builtin/logical/pki/path_sign_issuers.go
@@ -6,7 +6,7 @@ import (
 )
 
 func pathIssuerSignIntermediate(b *backend) *framework.Path {
-	pattern := "issuers/" + framework.GenericNameRegex("issuer_ref") + "/sign-intermediate"
+	pattern := "issuers/" + framework.GenericNameRegex(issuerRefParam) + "/sign-intermediate"
 	return pathIssuerSignIntermediateRaw(b, pattern)
 }
 
@@ -19,7 +19,7 @@ func pathIssuerSignIntermediateRaw(b *backend, pattern string) *framework.Path {
 	path := &framework.Path{
 		Pattern: pattern,
 		Fields: map[string]*framework.FieldSchema{
-			"issuer_ref": {
+			issuerRefParam: {
 				Type:        framework.TypeString,
 				Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
 				Default:     "default",
@@ -79,7 +79,7 @@ See the API documentation for more information about required parameters.
 )
 
 func pathIssuerSignSelfIssued(b *backend) *framework.Path {
-	pattern := "issuers/" + framework.GenericNameRegex("issuer_ref") + "/sign-self-issued"
+	pattern := "issuers/" + framework.GenericNameRegex(issuerRefParam) + "/sign-self-issued"
 	return buildPathIssuerSignSelfIssued(b, pattern)
 }
 
@@ -92,7 +92,7 @@ func buildPathIssuerSignSelfIssued(b *backend, pattern string) *framework.Path {
 	path := &framework.Path{
 		Pattern: pattern,
 		Fields: map[string]*framework.FieldSchema{
-			"issuer_ref": {
+			issuerRefParam: {
 				Type:        framework.TypeString,
 				Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
 				Default:     "default",

--- a/builtin/logical/pki/path_sign_issuers.go
+++ b/builtin/logical/pki/path_sign_issuers.go
@@ -1,0 +1,79 @@
+package pki
+
+import (
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func pathIssuerSignIntermediate(b *backend) *framework.Path {
+	pattern := "issuers/" + framework.GenericNameRegex("ref") + "/sign-intermediate"
+	return pathIssuerSignIntermediateRaw(b, pattern)
+}
+
+func pathSignIntermediate(b *backend) *framework.Path {
+	pattern := "root/sign-intermediate"
+	return pathIssuerSignIntermediateRaw(b, pattern)
+}
+
+func pathIssuerSignIntermediateRaw(b *backend, pattern string) *framework.Path {
+	path := &framework.Path{
+		Pattern: pattern,
+		Fields: map[string]*framework.FieldSchema{
+			"ref": {
+				Type:        framework.TypeString,
+				Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
+				Default:     "default",
+			},
+		},
+
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.UpdateOperation: b.pathIssuerSignIntermediate,
+		},
+
+		HelpSynopsis:    pathIssuerSignIntermediateHelpSyn,
+		HelpDescription: pathIssuerSignIntermediateHelpDesc,
+	}
+
+	path.Fields = addCACommonFields(path.Fields)
+	path.Fields = addCAIssueFields(path.Fields)
+
+	path.Fields["csr"] = &framework.FieldSchema{
+		Type:        framework.TypeString,
+		Default:     "",
+		Description: `PEM-format CSR to be signed.`,
+	}
+
+	path.Fields["use_csr_values"] = &framework.FieldSchema{
+		Type:    framework.TypeBool,
+		Default: false,
+		Description: `If true, then:
+1) Subject information, including names and alternate
+names, will be preserved from the CSR rather than
+using values provided in the other parameters to
+this path;
+2) Any key usages requested in the CSR will be
+added to the basic set of key usages used for CA
+certs signed by this path; for instance,
+the non-repudiation flag;
+3) Extensions requested in the CSR will be copied
+into the issued certificate.`,
+	}
+
+	return path
+}
+
+const (
+	pathIssuerSignIntermediateHelpSyn  = `Issue an intermediate CA certificate based on the provided CSR.`
+	pathIssuerSignIntermediateHelpDesc = `
+This API endpoint allows for signing the specified CSR, adding to it a basic
+constraint for IsCA=True. This allows the issued certificate to issue its own
+leaf certificates.
+
+Note that the resulting certificate is not imported as an issuer in this PKI
+mount. This means that you can use the resulting certificate in another Vault
+PKI mount point or to issue an external intermediate (e.g., for use with
+another X.509 CA).
+
+See the API documentation for more information about required parameters.
+`
+)

--- a/builtin/logical/pki/path_sign_issuers.go
+++ b/builtin/logical/pki/path_sign_issuers.go
@@ -6,7 +6,7 @@ import (
 )
 
 func pathIssuerSignIntermediate(b *backend) *framework.Path {
-	pattern := "issuers/" + framework.GenericNameRegex("ref") + "/sign-intermediate"
+	pattern := "issuers/" + framework.GenericNameRegex("issuer_ref") + "/sign-intermediate"
 	return pathIssuerSignIntermediateRaw(b, pattern)
 }
 
@@ -19,7 +19,7 @@ func pathIssuerSignIntermediateRaw(b *backend, pattern string) *framework.Path {
 	path := &framework.Path{
 		Pattern: pattern,
 		Fields: map[string]*framework.FieldSchema{
-			"ref": {
+			"issuer_ref": {
 				Type:        framework.TypeString,
 				Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
 				Default:     "default",
@@ -79,7 +79,7 @@ See the API documentation for more information about required parameters.
 )
 
 func pathIssuerSignSelfIssued(b *backend) *framework.Path {
-	pattern := "issuers/" + framework.GenericNameRegex("ref") + "/sign-self-issued"
+	pattern := "issuers/" + framework.GenericNameRegex("issuer_ref") + "/sign-self-issued"
 	return buildPathIssuerSignSelfIssued(b, pattern)
 }
 
@@ -92,7 +92,7 @@ func buildPathIssuerSignSelfIssued(b *backend, pattern string) *framework.Path {
 	path := &framework.Path{
 		Pattern: pattern,
 		Fields: map[string]*framework.FieldSchema{
-			"ref": {
+			"issuer_ref": {
 				Type:        framework.TypeString,
 				Description: `Reference to issuer; either "default" for the configured default issuer, an identifier of an issuer, or the name assigned to the issuer.`,
 				Default:     "default",

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -85,6 +85,10 @@ func listKeys(ctx context.Context, s logical.Storage) ([]keyId, error) {
 }
 
 func fetchKeyById(ctx context.Context, s logical.Storage, keyId keyId) (*key, error) {
+	if len(keyId) == 0 {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki key: empty key identifier")}
+	}
+
 	keyEntry, err := s.Get(ctx, keyPrefix+keyId.String())
 	if err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki key: %v", err)}
@@ -259,6 +263,9 @@ func resolveKeyReference(ctx context.Context, s logical.Storage, reference strin
 		if err != nil {
 			return keyId("config-error"), err
 		}
+		if len(config.DefaultKeyId) == 0 {
+			return KeyRefNotFound, fmt.Errorf("no default key currently configured")
+		}
 
 		return config.DefaultKeyId, nil
 	}
@@ -292,6 +299,10 @@ func resolveKeyReference(ctx context.Context, s logical.Storage, reference strin
 }
 
 func fetchIssuerById(ctx context.Context, s logical.Storage, issuerId issuerId) (*issuer, error) {
+	if len(issuerId) == 0 {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki issuer: empty issuer identifier")}
+	}
+
 	issuerEntry, err := s.Get(ctx, issuerPrefix+issuerId.String())
 	if err != nil {
 		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki issuer: %v", err)}
@@ -488,6 +499,9 @@ func resolveIssuerReference(ctx context.Context, s logical.Storage, reference st
 		config, err := getIssuersConfig(ctx, s)
 		if err != nil {
 			return issuerId("config-error"), err
+		}
+		if len(config.DefaultIssuerId) == 0 {
+			return IssuerRefNotFound, fmt.Errorf("no default issuer currently configured")
 		}
 
 		return config.DefaultIssuerId, nil

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -215,7 +215,7 @@ func importKey(ctx context.Context, s logical.Storage, keyValue string, keyName 
 
 	// If there was no prior default value set and/or we had no known
 	// keys when we started, set this key as default.
-	keyDefaultSet, err := isKeyDefaultSet(ctx, s)
+	keyDefaultSet, err := isDefaultKeySet(ctx, s)
 	if err != nil {
 		return nil, false, err
 	}
@@ -418,7 +418,7 @@ func importIssuer(ctx context.Context, s logical.Storage, certValue string, issu
 
 	// If there was no prior default value set and/or we had no known
 	// issuers when we started, set this issuer as default.
-	issuerDefaultSet, err := isIssuerDefaultSet(ctx, s)
+	issuerDefaultSet, err := isDefaultIssuerSet(ctx, s)
 	if err != nil {
 		return nil, false, err
 	}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -575,7 +575,6 @@ func fetchCertBundleByIssuerId(ctx context.Context, s logical.Storage, id issuer
 
 	var bundle certutil.CertBundle
 	bundle.Certificate = issuer.Certificate
-	bundle.IssuingCA = issuer.CAChain[0]
 	bundle.CAChain = issuer.CAChain
 	bundle.SerialNumber = issuer.SerialNumber
 

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -1,0 +1,188 @@
+package pki
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/helper/errutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	storageKeyConfig     = "/config/keys"
+	storeageIssuerConfig = "/config/issuers"
+	keyPrefix            = "/config/key/"
+	issuerPrefix         = "/config/issuer/"
+)
+
+type keyId string
+
+func (p keyId) String() string {
+	return string(p)
+}
+
+type issuerId string
+
+func (p issuerId) String() string {
+	return string(p)
+}
+
+type key struct {
+	ID             keyId                   `json:"id" structs:"id" mapstructure:"id"`
+	PrivateKeyType certutil.PrivateKeyType `json:"private_key_type" structs:"private_key_type" mapstructure:"private_key_type"`
+	PrivateKey     string                  `json:"private_key" structs:"private_key" mapstructure:"private_key"`
+}
+
+type issuer struct {
+	ID           issuerId `json:"id" structs:"id" mapstructure:"id"`
+	Name         string   `json:"name" structs:"name" mapstructure:"name"`
+	KeyID        keyId    `json:"key_id" structs:"key_id" mapstructure:"key_id"`
+	Certificate  string   `json:"certificate" structs:"certificate" mapstructure:"certificate"`
+	CAChain      []string `json:"ca_chain" structs:"ca_chain" mapstructure:"ca_chain"`
+	SerialNumber string   `json:"serial_number" structs:"serial_number" mapstructure:"serial_number"`
+}
+
+type keyConfig struct {
+	DefaultKeyId keyId `json:"default" structs:"default" mapstructure:"default"`
+}
+
+type issuerConfig struct {
+	DefaultIssuerId issuerId `json:"default" structs:"default" mapstructure:"default"`
+}
+
+func listKeys(ctx context.Context, s logical.Storage) ([]keyId, error) {
+	strList, err := s.List(ctx, keyPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	keyIds := make([]keyId, 0, len(strList))
+	for _, entry := range strList {
+		keyIds = append(keyIds, keyId(entry))
+	}
+
+	return keyIds, nil
+}
+
+func fetchKeyById(ctx context.Context, s logical.Storage, keyId keyId) (*key, error) {
+	keyEntry, err := s.Get(ctx, keyPrefix+keyId.String())
+	if err != nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki key: %v", err)}
+	}
+	if keyEntry == nil {
+		// FIXME: Dedicated/specific error for this?
+		return nil, errutil.UserError{Err: fmt.Sprintf("pki key id %s does not exist", keyId.String())}
+	}
+
+	var key key
+	if err := keyEntry.DecodeJSON(&key); err != nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to decode pki key with id %s: %v", keyId.String(), err)}
+	}
+
+	return &key, nil
+}
+
+func writeKey(ctx context.Context, s logical.Storage, key key) error {
+	keyId := key.ID
+
+	json, err := logical.StorageEntryJSON(keyPrefix+keyId.String(), key)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, json)
+}
+
+func listIssuers(ctx context.Context, s logical.Storage) ([]issuerId, error) {
+	strList, err := s.List(ctx, issuerPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	issuerIds := make([]issuerId, 0, len(strList))
+	for _, entry := range strList {
+		issuerIds = append(issuerIds, issuerId(entry))
+	}
+
+	return issuerIds, nil
+}
+
+func fetchIssuerById(ctx context.Context, s logical.Storage, issuerId issuerId) (*issuer, error) {
+	issuerEntry, err := s.Get(ctx, issuerPrefix+issuerId.String())
+	if err != nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch pki issuer: %v", err)}
+	}
+	if issuerEntry == nil {
+		// FIXME: Dedicated/specific error for this?
+		return nil, errutil.UserError{Err: fmt.Sprintf("pki issuer id %s does not exist", issuerId.String())}
+	}
+
+	var issuer issuer
+	if err := issuerEntry.DecodeJSON(&issuer); err != nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to decode pki issuer with id %s: %v", issuerId.String(), err)}
+	}
+
+	return &issuer, nil
+}
+
+func writeIssuer(ctx context.Context, s logical.Storage, issuer issuer) error {
+	issuerId := issuer.ID
+
+	json, err := logical.StorageEntryJSON(issuerPrefix+issuerId.String(), issuer)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, json)
+}
+
+func setKeysConfig(ctx context.Context, s logical.Storage, config *keyConfig) error {
+	json, err := logical.StorageEntryJSON(storageKeyConfig, config)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, json)
+}
+
+func getKeysConfig(ctx context.Context, s logical.Storage) (*keyConfig, error) {
+	keyConfigEntry, err := s.Get(ctx, storageKeyConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	keyConfig := &keyConfig{}
+	if keyConfigEntry != nil {
+		if err := keyConfigEntry.DecodeJSON(keyConfig); err != nil {
+			return nil, errutil.InternalError{Err: fmt.Sprintf("unable to decode key configuration: %v", err)}
+		}
+	}
+
+	return keyConfig, nil
+}
+
+func setIssuersConfig(ctx context.Context, s logical.Storage, config *issuerConfig) error {
+	json, err := logical.StorageEntryJSON(storeageIssuerConfig, config)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, json)
+}
+
+func getIssuersConfig(ctx context.Context, s logical.Storage) (*issuerConfig, error) {
+	issuerConfigEntry, err := s.Get(ctx, storeageIssuerConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	issuerConfig := &issuerConfig{}
+	if issuerConfigEntry != nil {
+		if err := issuerConfigEntry.DecodeJSON(issuerConfig); err != nil {
+			return nil, errutil.InternalError{Err: fmt.Sprintf("unable to decode issuer configuration: %v", err)}
+		}
+	}
+
+	return issuerConfig, nil
+}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -117,8 +117,23 @@ func writeKey(ctx context.Context, s logical.Storage, key key) error {
 	return s.Put(ctx, json)
 }
 
-func deleteKey(ctx context.Context, s logical.Storage, id keyId) error {
-	return s.Delete(ctx, keyPrefix+id.String())
+func deleteKey(ctx context.Context, s logical.Storage, id keyId) (bool, error) {
+	wasDefault := false
+
+	config, err := getKeysConfig(ctx, s)
+	if err != nil {
+		return wasDefault, err
+	}
+
+	if config.DefaultKeyId == id {
+		wasDefault = true
+		config.DefaultKeyId = keyId("")
+		if err := setKeysConfig(ctx, s, config); err != nil {
+			return wasDefault, err
+		}
+	}
+
+	return wasDefault, s.Delete(ctx, keyPrefix+id.String())
 }
 
 func importKey(ctx context.Context, s logical.Storage, keyValue string, keyName string) (*key, bool, error) {
@@ -331,8 +346,23 @@ func writeIssuer(ctx context.Context, s logical.Storage, issuer *issuer) error {
 	return s.Put(ctx, json)
 }
 
-func deleteIssuer(ctx context.Context, s logical.Storage, id issuerId) error {
-	return s.Delete(ctx, issuerPrefix+id.String())
+func deleteIssuer(ctx context.Context, s logical.Storage, id issuerId) (bool, error) {
+	wasDefault := false
+
+	config, err := getIssuersConfig(ctx, s)
+	if err != nil {
+		return wasDefault, err
+	}
+
+	if config.DefaultIssuerId == id {
+		wasDefault = true
+		config.DefaultIssuerId = issuerId("")
+		if err := setIssuersConfig(ctx, s, config); err != nil {
+			return wasDefault, err
+		}
+	}
+
+	return wasDefault, s.Delete(ctx, issuerPrefix+id.String())
 }
 
 func importIssuer(ctx context.Context, s logical.Storage, certValue string, issuerName string) (*issuer, bool, error) {

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -2,8 +2,13 @@ package pki
 
 import (
 	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"strings"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 	"github.com/hashicorp/vault/sdk/helper/errutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -52,6 +57,11 @@ type issuerConfig struct {
 	DefaultIssuerId issuerId `json:"default" structs:"default" mapstructure:"default"`
 }
 
+func (k key) GetSigner() (crypto.Signer, error) {
+	signer, _, err := certutil.ParsePEMKey(k.PrivateKey)
+	return signer, err
+}
+
 func listKeys(ctx context.Context, s logical.Storage) ([]keyId, error) {
 	strList, err := s.List(ctx, keyPrefix)
 	if err != nil {
@@ -93,6 +103,118 @@ func writeKey(ctx context.Context, s logical.Storage, key key) error {
 	}
 
 	return s.Put(ctx, json)
+}
+
+func importKey(ctx context.Context, s logical.Storage, keyValue string) (*key, bool, error) {
+	// importKey imports the specified PEM-format key (from keyValue) into
+	// the new PKI storage format. The first return field is a reference to
+	// the new key; the second is whether or not the key already existed
+	// during import (in which case, *key points to the existing key reference
+	// and identifier); the last return field is whether or not an error
+	// occurred.
+	//
+	// Before we can import a known key, we first need to know if the key
+	// exists in storage already. This means iterating through all known
+	// keys and comparing their private value against this value.
+	knownKeys, err := listKeys(ctx, s)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Before we return below, we need to iterate over _all_ issuers and see if
+	// one of them has a missing KeyId link, and if so, point it back to
+	// ourselves. We fetch the list of issuers up front, even when don't need
+	// it, to give ourselves a better chance of succeeding below.
+	knownIssuers, err := listIssuers(ctx, s)
+	if err != nil {
+		return nil, false, err
+	}
+
+	for _, identifier := range knownKeys {
+		existingKey, err := fetchKeyById(ctx, s, identifier)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if existingKey.PrivateKey == keyValue {
+			// Here, we don't need to stitch together the issuer entries,
+			// because the last run should've done that for us (or, when
+			// importing an issuer).
+			return existingKey, true, nil
+		}
+	}
+
+	// Haven't found a key, so we've gotta create it and write it into storage.
+	var result key
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, false, err
+	}
+	result.ID = keyId(uuid)
+	result.PrivateKey = keyValue
+
+	// Extracting the signer is necessary for two reasons: first, to get the
+	// public key for comparison with existing issuers; second, to get the
+	// corresponding private key type.
+	keySigner, err := result.GetSigner()
+	if err != nil {
+		return nil, false, err
+	}
+	keyPublic := keySigner.Public()
+	result.PrivateKeyType = certutil.GetPrivateKeyTypeFromSigner(keySigner)
+
+	// Finally we can write the key to storage.
+	if err := writeKey(ctx, s, result); err != nil {
+		return nil, false, err
+	}
+
+	// Now, for each issuer, try and compute the issuer<->key link if missing.
+	for _, identifier := range knownIssuers {
+		existingIssuer, err := fetchIssuerById(ctx, s, identifier)
+		if err != nil {
+			return nil, false, err
+		}
+
+		// If the KeyID value is already present, we can skip it.
+		if len(existingIssuer.KeyID) > 0 {
+			continue
+		}
+
+		// Otherwise, compare public values. Note that there might be multiple
+		// certificates (e.g., cross-signed) with the same key.
+
+		cert, err := existingIssuer.GetCertificate()
+		if err != nil {
+			// Malformed issuer.
+			return nil, false, err
+		}
+
+		equal, err := certutil.ComparePublicKeys(cert.PublicKey, keyPublic)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if equal {
+			// These public keys are equal, so this key entry must be the
+			// corresponding private key to this issuer; update it accordingly.
+			existingIssuer.KeyID = result.ID
+			if err := writeIssuer(ctx, s, *existingIssuer); err != nil {
+				return nil, false, err
+			}
+		}
+	}
+
+	// All done; return our new key reference.
+	return &result, false, nil
+}
+
+func (i issuer) GetCertificate() (*x509.Certificate, error) {
+	block, _ := pem.Decode([]byte(i.Certificate))
+	if block == nil {
+		return nil, errutil.InternalError{Err: fmt.Sprintf("unable to parse certificate from issuer: invalid PEM: %v", i.ID)}
+	}
+
+	return x509.ParseCertificate(block.Bytes)
 }
 
 func listIssuers(ctx context.Context, s logical.Storage) ([]issuerId, error) {
@@ -175,6 +297,105 @@ func writeIssuer(ctx context.Context, s logical.Storage, issuer issuer) error {
 	}
 
 	return s.Put(ctx, json)
+}
+
+func importIssuer(ctx context.Context, s logical.Storage, certValue string) (*issuer, bool, error) {
+	// importIssuers imports the specified PEM-format certificate (from
+	// certValue) into the new PKI storage format. The first return field is a
+	// reference to the new issuer; the second is whether or not the issuer
+	// already existed during import (in which case, *issuer points to the
+	// existing issuer reference and identifier); the last return field is
+	// whether or not an error occurred.
+	//
+	// Before we can import a known issuer, we first need to know if the issuer
+	// exists in storage already. This means iterating through all known
+	// issuers and comparing their private value against this value.
+	knownIssuers, err := listIssuers(ctx, s)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Before we return below, we need to iterate over _all_ keys and see if
+	// one of them a public key matching this certificate, and if so, update our
+	// link accordingly. We fetch the list of keys up front, even may not need
+	// it, to give ourselves a better chance of succeeding below.
+	knownKeys, err := listKeys(ctx, s)
+	if err != nil {
+		return nil, false, err
+	}
+
+	for _, identifier := range knownIssuers {
+		existingIssuer, err := fetchIssuerById(ctx, s, identifier)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if existingIssuer.Certificate == certValue {
+			// Here, we don't need to stitch together the key entries,
+			// because the last run should've done that for us (or, when
+			// importing a key).
+			return existingIssuer, true, nil
+		}
+	}
+
+	// Haven't found an issuer, so we've gotta create it and write it into
+	// storage.
+	var result issuer
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, false, err
+	}
+	result.ID = issuerId(uuid)
+	result.Certificate = certValue
+	result.CAChain = []string{certValue}
+
+	// Extracting the certificate is necessary for two reasons: first, it lets
+	// us fetch the serial number; second, for the public key comparison with
+	// known keys.
+	issuerCert, err := result.GetCertificate()
+	if err != nil {
+		return nil, false, err
+	}
+
+	result.SerialNumber = strings.TrimSpace(certutil.GetHexFormatted(issuerCert.SerialNumber.Bytes(), ":"))
+
+	// Now, for each key, try and compute the issuer<->key link. We delay
+	// writing issuer to storage as we won't need to update the key, only
+	// the issuer.
+	for _, identifier := range knownKeys {
+		existingKey, err := fetchKeyById(ctx, s, identifier)
+		if err != nil {
+			return nil, false, err
+		}
+
+		// Fetch the signer for its Public() value.
+		signer, err := existingKey.GetSigner()
+		if err != nil {
+			return nil, false, err
+		}
+
+		equal, err := certutil.ComparePublicKeys(issuerCert.PublicKey, signer.Public())
+		if err != nil {
+			return nil, false, err
+		}
+
+		if equal {
+			result.KeyID = existingKey.ID
+			// Here, there's exactly one stored key with the same public key
+			// as us, per guarantees in importKey; as we're importing an
+			// issuer, there's no other keys or issuers we'd need to read or
+			// update, so exit.
+			break
+		}
+	}
+
+	// Finally we can write the issuer to storage.
+	if err := writeIssuer(ctx, s, result); err != nil {
+		return nil, false, err
+	}
+
+	// All done; return our new key reference.
+	return &result, false, nil
 }
 
 func setKeysConfig(ctx context.Context, s logical.Storage, config *keyConfig) error {

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -50,7 +50,7 @@ func migrateStorage(ctx context.Context, req *logical.InitializationRequest, log
 
 	logger.Warn("performing PKI migration to new keys/issuers layout")
 
-	anIssuer, aKey, err := writeCaBundle(ctx, s, legacyBundle, "")
+	anIssuer, aKey, err := writeCaBundle(ctx, s, legacyBundle, "", "")
 	if err != nil {
 		return err
 	}

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -1,0 +1,166 @@
+package pki
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// This allows us to record the version of the migration code within the log entry
+// in case we find out in the future that something was horribly wrong with the migration,
+// and we need to perform it again...
+const latestMigrationVersion = 1
+
+func migrateStorage(ctx context.Context, req *logical.InitializationRequest, logger log.Logger) error {
+	s := req.Storage
+	legacyBundle, err := getLegacyCertBundle(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	if legacyBundle == nil {
+		// No legacy certs to migrate, we are done...
+		logger.Debug("No legacy certs found, no migration required.")
+		return nil
+	}
+
+	migrationEntry, err := getLegacyBundleMigrationLog(ctx, s)
+	if err != nil {
+		return err
+	}
+	hash, err := computeHashOfLegacyBundle(legacyBundle)
+	if err != nil {
+		return err
+	}
+
+	if migrationEntry != nil {
+		// At this point we have already migrated something previously.
+		if migrationEntry.hash == hash &&
+			migrationEntry.migrationVersion == latestMigrationVersion {
+			// The hashes are the same, no need to try and re-import...
+			logger.Debug("existing migration hash found and matched legacy bundle, skipping migration.")
+			return nil
+		}
+	}
+
+	logger.Warn("performing PKI migration to new keys/issuers layout")
+
+	err = migrateToIssuers(ctx, s, legacyBundle)
+	if err != nil {
+		return err
+	}
+
+	err = setLegacyBundleMigrationLog(ctx, s, &legacyBundleMigration{
+		hash:             hash,
+		created:          time.Now(),
+		migrationVersion: latestMigrationVersion,
+	})
+	if err != nil {
+		return err
+	}
+	logger.Info("successfully completed migration to new keys/issuers layout")
+	return nil
+}
+
+func computeHashOfLegacyBundle(bundle *certutil.CertBundle) (string, error) {
+	// We only hash the main certificate and the certs within the CAChain,
+	// assuming that any sort of change that occurred would have influenced one of those two fields.
+	hasher := sha256.New()
+	if _, err := hasher.Write([]byte(bundle.Certificate)); err != nil {
+		return "", err
+	}
+	for _, cert := range bundle.CAChain {
+		if _, err := hasher.Write([]byte(cert)); err != nil {
+			return "", err
+		}
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func migrateToIssuers(ctx context.Context, s logical.Storage, bundle *certutil.CertBundle) error {
+	defaultKey, _, err := importKey(ctx, s, bundle.PrivateKey)
+	if err != nil {
+		return err
+	}
+
+	defaultIssuer, _, err := importIssuer(ctx, s, bundle.Certificate)
+	if err != nil {
+		return err
+	}
+
+	for _, cert := range bundle.CAChain {
+		if _, _, err = importIssuer(ctx, s, cert); err != nil {
+			return err
+		}
+	}
+
+	if err = updateDefaultKeyId(ctx, s, defaultKey.ID); err != nil {
+		return err
+	}
+
+	if err = updateDefaultIssuerId(ctx, s, defaultIssuer.ID); err != nil {
+		return err
+	}
+
+	// FIXME: Call function that will recompute the CAChain on issuers here.
+	return nil
+}
+
+type legacyBundleMigration struct {
+	hash             string
+	created          time.Time
+	migrationVersion int
+}
+
+func getLegacyBundleMigrationLog(ctx context.Context, s logical.Storage) (*legacyBundleMigration, error) {
+	entry, err := s.Get(ctx, legacyMigrationBundleLogKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if entry == nil {
+		return nil, nil
+	}
+
+	lbm := &legacyBundleMigration{}
+	err = entry.DecodeJSON(lbm)
+	if err != nil {
+		// If we can't decode our bundle, lets scrap it and assume a blank value,
+		// re-running the migration will at most bring back an older certificate/private key
+		return nil, nil
+	}
+	return lbm, nil
+}
+
+func setLegacyBundleMigrationLog(ctx context.Context, s logical.Storage, lbm *legacyBundleMigration) error {
+	json, err := logical.StorageEntryJSON(legacyMigrationBundleLogKey, lbm)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, json)
+}
+
+func getLegacyCertBundle(ctx context.Context, s logical.Storage) (*certutil.CertBundle, error) {
+	entry, err := s.Get(ctx, legacyCertBundlePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if entry == nil {
+		return nil, nil
+	}
+
+	cb := &certutil.CertBundle{}
+	err = entry.DecodeJSON(cb)
+	if err != nil {
+		return nil, err
+	}
+
+	return cb, nil
+}

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -1,0 +1,90 @@
+package pki
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_migrateStorageEmptyStorage(t *testing.T) {
+	ctx := context.Background()
+	b, s := createBackendWithStorage(t)
+	request := &logical.InitializationRequest{Storage: s}
+
+	err := migrateStorage(ctx, request, b.Logger())
+	require.NoError(t, err)
+
+	issuerIds, err := listIssuers(ctx, s)
+	require.NoError(t, err)
+	require.Empty(t, issuerIds)
+
+	keyIds, err := listKeys(ctx, s)
+	require.NoError(t, err)
+	require.Empty(t, keyIds)
+
+	logEntry, err := getLegacyBundleMigrationLog(ctx, s)
+	require.NoError(t, err)
+	require.Nil(t, logEntry)
+}
+
+func Test_migrateStorageSimpleBundle(t *testing.T) {
+	ctx := context.Background()
+	b, s := createBackendWithStorage(t)
+
+	bundle := genCertBundle(t, b)
+	json, err := logical.StorageEntryJSON(legacyCertBundlePath, bundle)
+	require.NoError(t, err)
+	err = s.Put(ctx, json)
+	require.NoError(t, err)
+
+	request := &logical.InitializationRequest{Storage: s}
+
+	err = migrateStorage(ctx, request, b.Logger())
+	require.NoError(t, err)
+
+	issuerIds, err := listIssuers(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(issuerIds))
+
+	keyIds, err := listKeys(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(keyIds))
+
+	logEntry, err := getLegacyBundleMigrationLog(ctx, s)
+	require.NoError(t, err)
+	require.NotNil(t, logEntry)
+
+	issuerId := issuerIds[0]
+	keyId := keyIds[0]
+	issuer, err := fetchIssuerById(ctx, s, issuerId)
+	require.NoError(t, err)
+
+	key, err := fetchKeyById(ctx, s, keyId)
+	require.NoError(t, err)
+
+	require.Equal(t, issuerId, issuer.ID)
+	require.Equal(t, bundle.SerialNumber, issuer.SerialNumber)
+	require.Equal(t, bundle.Certificate, issuer.Certificate)
+	require.Equal(t, keyId, issuer.KeyID)
+	// FIXME: Add tests for CAChain...
+
+	require.Equal(t, keyId, key.ID)
+	require.Equal(t, bundle.PrivateKey, key.PrivateKey)
+	require.Equal(t, bundle.PrivateKeyType, key.PrivateKeyType)
+
+	// Make sure we kept the old bundle
+	certBundle, err := getLegacyCertBundle(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, bundle, certBundle)
+
+	// Make sure we setup the default values
+	keysConfig, err := getKeysConfig(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, &keyConfig{DefaultKeyId: keyId}, keysConfig)
+
+	issuersConfig, err := getIssuersConfig(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, &issuerConfig{DefaultIssuerId: issuerId}, issuersConfig)
+}

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -113,13 +113,13 @@ func Test_KeysIssuerImport(t *testing.T) {
 	require.Equal(t, key1.PrivateKey, key1_ref1.PrivateKey)
 	require.Equal(t, key1_ref1.ID, key1_ref2.ID)
 
-	issuer1_ref1, existing, err := importIssuer(ctx, s, issuer1.Certificate)
+	issuer1_ref1, existing, err := importIssuer(ctx, s, issuer1.Certificate, "")
 	require.NoError(t, err)
 	require.False(t, existing)
 	require.Equal(t, issuer1.Certificate, issuer1_ref1.Certificate)
 	require.Equal(t, key1_ref1.ID, issuer1_ref1.KeyID)
 
-	issuer1_ref2, existing, err := importIssuer(ctx, s, issuer1.Certificate)
+	issuer1_ref2, existing, err := importIssuer(ctx, s, issuer1.Certificate, "")
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, issuer1.Certificate, issuer1_ref1.Certificate)
@@ -132,7 +132,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 	err = writeKey(ctx, s, key2)
 	require.NoError(t, err)
 
-	issuer2_ref, existing, err := importIssuer(ctx, s, issuer2.Certificate)
+	issuer2_ref, existing, err := importIssuer(ctx, s, issuer2.Certificate, "")
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, issuer2.Certificate, issuer2_ref.Certificate)

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -107,6 +107,8 @@ func Test_KeysIssuerImport(t *testing.T) {
 	require.False(t, existing)
 	require.Equal(t, key1.PrivateKey, key1_ref1.PrivateKey)
 
+	// Make sure if we attempt to re-import the same private key, no import/updates occur.
+	// So the existing flag should be set to true and we do not update the existing Name field.
 	key1_ref2, existing, err := importKey(ctx, s, key1.PrivateKey, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
@@ -121,6 +123,8 @@ func Test_KeysIssuerImport(t *testing.T) {
 	require.Equal(t, key1_ref1.ID, issuer1_ref1.KeyID)
 	require.Equal(t, "issuer1", issuer1_ref1.Name)
 
+	// Make sure if we attempt to re-import the same issuer, no import/updates occur.
+	// So the existing flag should be set to true and we do not update the existing Name field.
 	issuer1_ref2, existing, err := importIssuer(ctx, s, issuer1.Certificate, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
@@ -135,6 +139,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 	err = writeKey(ctx, s, key2)
 	require.NoError(t, err)
 
+	// Same double import tests as above, but make sure if the previous was created through writeIssuer not importIssuer.
 	issuer2_ref, existing, err := importIssuer(ctx, s, issuer2.Certificate, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
@@ -143,6 +148,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 	require.Equal(t, "", issuer2_ref.Name)
 	require.Equal(t, issuer2.KeyID, issuer2_ref.KeyID)
 
+	// Same double import tests as above, but make sure if the previous was created through writeKey not importKey.
 	key2_ref, existing, err := importKey(ctx, s, key2.PrivateKey, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -1,0 +1,163 @@
+package pki
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
+)
+
+var ctx = context.Background()
+
+func Test_ConfigsRoundTrip(t *testing.T) {
+	_, s := createBackendWithStorage(t)
+
+	// Verify we handle nothing stored properly
+	keyConfigEmpty, err := getKeysConfig(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, &keyConfig{}, keyConfigEmpty)
+
+	issuerConfigEmpty, err := getIssuersConfig(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, &issuerConfig{}, issuerConfigEmpty)
+
+	// Now attempt to store and reload properly
+	origKeyConfig := &keyConfig{
+		DefaultKeyId: genKeyId(t),
+	}
+	origIssuerConfig := &issuerConfig{
+		DefaultIssuerId: genIssuerId(t),
+	}
+
+	err = setKeysConfig(ctx, s, origKeyConfig)
+	require.NoError(t, err)
+	err = setIssuersConfig(ctx, s, origIssuerConfig)
+	require.NoError(t, err)
+
+	keyConfig, err := getKeysConfig(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, origKeyConfig, keyConfig)
+
+	issuerConfig, err := getIssuersConfig(ctx, s)
+	require.NoError(t, err)
+	require.Equal(t, origIssuerConfig, issuerConfig)
+}
+
+func Test_IssuerRoundTrip(t *testing.T) {
+	b, s := createBackendWithStorage(t)
+	issuer1, key1 := genIssuerAndKey(t, b)
+	issuer2, key2 := genIssuerAndKey(t, b)
+
+	// We get an error when issuer id not found
+	_, err := fetchIssuerById(ctx, s, issuer1.ID)
+	require.Error(t, err)
+
+	// We get an error when key id not found
+	_, err = fetchKeyById(ctx, s, key1.ID)
+	require.Error(t, err)
+
+	// Now write out our issuers and keys
+	err = writeKey(ctx, s, key1)
+	require.NoError(t, err)
+	err = writeIssuer(ctx, s, issuer1)
+	require.NoError(t, err)
+
+	err = writeKey(ctx, s, key2)
+	require.NoError(t, err)
+	err = writeIssuer(ctx, s, issuer2)
+	require.NoError(t, err)
+
+	fetchedKey1, err := fetchKeyById(ctx, s, key1.ID)
+	require.NoError(t, err)
+
+	fetchedIssuer1, err := fetchIssuerById(ctx, s, issuer1.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, &key1, fetchedKey1)
+	require.Equal(t, &issuer1, fetchedIssuer1)
+
+	keys, err := listKeys(ctx, s)
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []keyId{key1.ID, key2.ID}, keys)
+
+	issuers, err := listIssuers(ctx, s)
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []issuerId{issuer1.ID, issuer2.ID}, issuers)
+}
+
+func genIssuerAndKey(t *testing.T, b *backend) (issuer, key) {
+	certBundle, err := genCertBundle(t, b)
+	require.NoError(t, err)
+
+	keyId := genKeyId(t)
+
+	pkiKey := key{
+		ID:             keyId,
+		PrivateKeyType: certBundle.PrivateKeyType,
+		PrivateKey:     certBundle.PrivateKey,
+	}
+
+	issuerId := genIssuerId(t)
+
+	pkiIssuer := issuer{
+		ID:           issuerId,
+		KeyID:        keyId,
+		Certificate:  certBundle.Certificate,
+		CAChain:      certBundle.CAChain,
+		SerialNumber: certBundle.SerialNumber,
+	}
+
+	return pkiIssuer, pkiKey
+}
+
+func genIssuerId(t *testing.T) issuerId {
+	issuerIdStr, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	return issuerId(issuerIdStr)
+}
+
+func genKeyId(t *testing.T) keyId {
+	keyIdStr, err := uuid.GenerateUUID()
+	require.NoError(t, err)
+	return keyId(keyIdStr)
+}
+
+func genCertBundle(t *testing.T, b *backend) (*certutil.CertBundle, error) {
+	// Pretty gross just to generate a cert bundle, but
+	fields := addCACommonFields(map[string]*framework.FieldSchema{})
+	fields = addCAKeyGenerationFields(fields)
+	fields = addCAIssueFields(fields)
+	apiData := &framework.FieldData{
+		Schema: fields,
+		Raw: map[string]interface{}{
+			"exported": "internal",
+			"cn":       "example.com",
+			"ttl":      3600,
+		},
+	}
+	_, _, role, respErr := b.getGenerationParams(ctx, apiData, "/pki")
+	require.Nil(t, respErr)
+
+	input := &inputBundle{
+		req: &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      "issue/testrole",
+			Storage:   b.storage,
+		},
+		apiData: apiData,
+		role:    role,
+	}
+	parsedCertBundle, err := generateCert(ctx, b, input, nil, true, rand.Reader)
+
+	require.NoError(t, err)
+	certBundle, err := parsedCertBundle.ToCertBundle()
+	require.NoError(t, err)
+	return certBundle, err
+}

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -102,29 +102,32 @@ func Test_KeysIssuerImport(t *testing.T) {
 	issuer1.ID = ""
 	issuer1.KeyID = ""
 
-	key1_ref1, existing, err := importKey(ctx, s, key1.PrivateKey)
+	key1_ref1, existing, err := importKey(ctx, s, key1.PrivateKey, "key1")
 	require.NoError(t, err)
 	require.False(t, existing)
 	require.Equal(t, key1.PrivateKey, key1_ref1.PrivateKey)
 
-	key1_ref2, existing, err := importKey(ctx, s, key1.PrivateKey)
+	key1_ref2, existing, err := importKey(ctx, s, key1.PrivateKey, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, key1.PrivateKey, key1_ref1.PrivateKey)
 	require.Equal(t, key1_ref1.ID, key1_ref2.ID)
+	require.Equal(t, key1_ref1.Name, key1_ref2.Name)
 
-	issuer1_ref1, existing, err := importIssuer(ctx, s, issuer1.Certificate, "")
+	issuer1_ref1, existing, err := importIssuer(ctx, s, issuer1.Certificate, "issuer1")
 	require.NoError(t, err)
 	require.False(t, existing)
 	require.Equal(t, issuer1.Certificate, issuer1_ref1.Certificate)
 	require.Equal(t, key1_ref1.ID, issuer1_ref1.KeyID)
+	require.Equal(t, "issuer1", issuer1_ref1.Name)
 
-	issuer1_ref2, existing, err := importIssuer(ctx, s, issuer1.Certificate, "")
+	issuer1_ref2, existing, err := importIssuer(ctx, s, issuer1.Certificate, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, issuer1.Certificate, issuer1_ref1.Certificate)
 	require.Equal(t, issuer1_ref1.ID, issuer1_ref2.ID)
 	require.Equal(t, key1_ref1.ID, issuer1_ref2.KeyID)
+	require.Equal(t, issuer1_ref1.Name, issuer1_ref2.Name)
 
 	err = writeIssuer(ctx, s, &issuer2)
 	require.NoError(t, err)
@@ -132,18 +135,20 @@ func Test_KeysIssuerImport(t *testing.T) {
 	err = writeKey(ctx, s, key2)
 	require.NoError(t, err)
 
-	issuer2_ref, existing, err := importIssuer(ctx, s, issuer2.Certificate, "")
+	issuer2_ref, existing, err := importIssuer(ctx, s, issuer2.Certificate, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, issuer2.Certificate, issuer2_ref.Certificate)
-	require.Equal(t, issuer2_ref.ID, issuer2.ID)
-	require.Equal(t, issuer2_ref.KeyID, issuer2.KeyID)
+	require.Equal(t, issuer2.ID, issuer2_ref.ID)
+	require.Equal(t, "", issuer2_ref.Name)
+	require.Equal(t, issuer2.KeyID, issuer2_ref.KeyID)
 
-	key2_ref, existing, err := importKey(ctx, s, key2.PrivateKey)
+	key2_ref, existing, err := importKey(ctx, s, key2.PrivateKey, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
 	require.Equal(t, key2.PrivateKey, key2_ref.PrivateKey)
-	require.Equal(t, key2_ref.ID, key2.ID)
+	require.Equal(t, key2.ID, key2_ref.ID)
+	require.Equal(t, "", key2_ref.Name)
 }
 
 func genIssuerAndKey(t *testing.T, b *backend) (issuer, key) {

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -30,7 +30,7 @@ func kmsRequested(input *inputBundle) bool {
 	return exportedStr.(string) == "kms"
 }
 
-type keyId interface {
+type managedKeyId interface {
 	String() string
 }
 
@@ -49,13 +49,13 @@ func (n NameKey) String() string {
 
 // getManagedKeyId returns a NameKey or a UUIDKey, whichever was specified in the
 // request API data.
-func getManagedKeyId(data *framework.FieldData) (keyId, error) {
+func getManagedKeyId(data *framework.FieldData) (managedKeyId, error) {
 	name, UUID, err := getManagedKeyNameOrUUID(data)
 	if err != nil {
 		return nil, err
 	}
 
-	var keyId keyId = NameKey(name)
+	var keyId managedKeyId = NameKey(name)
 	if len(UUID) > 0 {
 		keyId = UUIDKey(UUID)
 	}

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -80,13 +80,13 @@ func getManagedKeyId(data *framework.FieldData) (managedKeyId, error) {
 }
 
 func getExistingKeyRef(data *framework.FieldData) (string, error) {
-	keyRef, ok := data.GetOk("key_id")
+	keyRef, ok := data.GetOk("key_ref")
 	if !ok {
-		return "", errutil.UserError{Err: fmt.Sprintf("missing argument key_id for existing type")}
+		return "", errutil.UserError{Err: fmt.Sprintf("missing argument key_ref for existing type")}
 	}
 	trimmedKeyRef := strings.TrimSpace(keyRef.(string))
 	if len(trimmedKeyRef) == 0 {
-		return "", errutil.UserError{Err: fmt.Sprintf("missing argument key_id for existing type")}
+		return "", errutil.UserError{Err: fmt.Sprintf("missing argument key_ref for existing type")}
 	}
 
 	return trimmedKeyRef, nil

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -182,15 +182,9 @@ func getKeyRef(data *framework.FieldData) string {
 }
 
 func extractRef(data *framework.FieldData, paramName string) string {
-	value := ""
-	issuerNameIface, ok := data.GetOk(paramName)
-	if ok {
-		value = strings.TrimSpace(issuerNameIface.(string))
-		if strings.ToLower(value) == "default" {
-			return "default"
-		}
-		return value
+	value := strings.TrimSpace(data.Get(paramName).(string))
+	if strings.ToLower(value) == "default" {
+		return "default"
 	}
-
 	return value
 }

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -23,11 +23,27 @@ func denormalizeSerial(serial string) string {
 }
 
 func kmsRequested(input *inputBundle) bool {
-	exportedStr, ok := input.apiData.GetOk("exported")
+	return kmsRequestedFromFieldData(input.apiData)
+}
+
+func kmsRequestedFromFieldData(data *framework.FieldData) bool {
+	exportedStr, ok := data.GetOk("exported")
 	if !ok {
 		return false
 	}
 	return exportedStr.(string) == "kms"
+}
+
+func existingKeyRequested(input *inputBundle) bool {
+	return existingKeyRequestedFromFieldData(input.apiData)
+}
+
+func existingKeyRequestedFromFieldData(data *framework.FieldData) bool {
+	exportedStr, ok := data.GetOk("exported")
+	if !ok {
+		return false
+	}
+	return exportedStr.(string) == "existing"
 }
 
 type managedKeyId interface {
@@ -61,6 +77,19 @@ func getManagedKeyId(data *framework.FieldData) (managedKeyId, error) {
 	}
 
 	return keyId, nil
+}
+
+func getExistingKeyRef(data *framework.FieldData) (string, error) {
+	keyRef, ok := data.GetOk("key_id")
+	if !ok {
+		return "", errutil.UserError{Err: fmt.Sprintf("missing argument key_id for existing type")}
+	}
+	trimmedKeyRef := strings.TrimSpace(keyRef.(string))
+	if len(trimmedKeyRef) == 0 {
+		return "", errutil.UserError{Err: fmt.Sprintf("missing argument key_id for existing type")}
+	}
+
+	return trimmedKeyRef, nil
 }
 
 func getManagedKeyNameOrUUID(data *framework.FieldData) (name string, UUID string, err error) {

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -174,7 +174,7 @@ func getKeyName(ctx context.Context, s logical.Storage, data *framework.FieldDat
 }
 
 func getIssuerRef(data *framework.FieldData) string {
-	return extractRef(data, "issuer_ref")
+	return extractRef(data, issuerRefParam)
 }
 
 func getKeyRef(data *framework.FieldData) string {

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -704,10 +704,14 @@ func (b *CAInfoBundle) GetCAChain() []*CertBlock {
 func (b *CAInfoBundle) GetFullChain() []*CertBlock {
 	var chain []*CertBlock
 
-	chain = append(chain, &CertBlock{
-		Certificate: b.Certificate,
-		Bytes:       b.CertificateBytes,
-	})
+	// Some bundles already include the root included in the chain,
+	// so don't include it twice.
+	if len(b.CAChain) == 0 || !bytes.Equal(b.CAChain[0].Bytes, b.CertificateBytes) {
+		chain = append(chain, &CertBlock{
+			Certificate: b.Certificate,
+			Bytes:       b.CertificateBytes,
+		})
+	}
 
 	if len(b.CAChain) > 0 {
 		chain = append(chain, b.CAChain...)

--- a/sdk/helper/certutil/types.go
+++ b/sdk/helper/certutil/types.go
@@ -78,9 +78,10 @@ type BlockType string
 
 // Well-known formats
 const (
-	PKCS1Block BlockType = "RSA PRIVATE KEY"
-	PKCS8Block BlockType = "PRIVATE KEY"
-	ECBlock    BlockType = "EC PRIVATE KEY"
+	UnknownBlock BlockType = ""
+	PKCS1Block   BlockType = "RSA PRIVATE KEY"
+	PKCS8Block   BlockType = "PRIVATE KEY"
+	ECBlock      BlockType = "EC PRIVATE KEY"
 )
 
 // ParsedPrivateKeyContainer allows common key setting for certs and CSRs
@@ -135,6 +136,19 @@ type ParsedCSRBundle struct {
 	PrivateKey      crypto.Signer
 	CSRBytes        []byte
 	CSR             *x509.CertificateRequest
+}
+
+func GetPrivateKeyTypeFromSigner(signer crypto.Signer) PrivateKeyType {
+	switch signer.(type) {
+	case *rsa.PrivateKey:
+		return RSAPrivateKey
+	case *ecdsa.PrivateKey:
+		return ECPrivateKey
+	case ed25519.PrivateKey:
+		return Ed25519PrivateKey
+	default:
+		return UnknownPrivateKey
+	}
 }
 
 // ToPEMBundle converts a string-based certificate bundle


### PR DESCRIPTION
This fixes full chain construction so that we don't accidentally introduce duplicate issuers into the chain. This also removes our incorrect setting of the legacy `IssuingCA` field, which was used prior to `CAChain` introduction.

Strictly, I believe this is caused by `CAChain` containing not just the strict issuer hierarchy but also the leaf cert. I believe this makes the most sense from a bundle perspective (at the cost of a duplication), but perhaps it is worth trimming it out.

Additionally, we haven't yet switched the old logic (for `certificate` field on the `ca_chain` endpoint) to the new full chain. I'd like to make that change, given the goals of rotation, and have it be for the default issuer only.

Thoughts?