### PR TITLE
Rework PKI test TestBackend_Root_Idempotency

### DIFF
--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -217,7 +217,7 @@ func importKey(ctx context.Context, s logical.Storage, keyValue string, keyName 
 			return nil, false, err
 		}
 
-		equal, err := certutil.ComparePublicKeys(cert.PublicKey, keyPublic)
+		equal, err := certutil.ComparePublicKeysAndType(cert.PublicKey, keyPublic)
 		if err != nil {
 			return nil, false, err
 		}
@@ -437,7 +437,7 @@ func importIssuer(ctx context.Context, s logical.Storage, certValue string, issu
 			return nil, false, err
 		}
 
-		equal, err := certutil.ComparePublicKeys(issuerCert.PublicKey, signer.Public())
+		equal, err := certutil.ComparePublicKeysAndType(issuerCert.PublicKey, signer.Public())
 		if err != nil {
 			return nil, false, err
 		}

--- a/sdk/helper/certutil/certutil_test.go
+++ b/sdk/helper/certutil/certutil_test.go
@@ -2,6 +2,7 @@ package certutil
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -851,6 +852,72 @@ func setCerts() {
 	}
 
 	issuingCaChainPem = []string{intCertPEM, caCertPEM}
+}
+
+func TestComparePublicKeysAndType(t *testing.T) {
+	rsa1 := genRsaKey(t).Public()
+	rsa2 := genRsaKey(t).Public()
+	eddsa1 := genEdDSA(t).Public()
+	eddsa2 := genEdDSA(t).Public()
+	ed25519_1, _ := genEd25519Key(t)
+	ed25519_2, _ := genEd25519Key(t)
+
+	type args struct {
+		key1Iface crypto.PublicKey
+		key2Iface crypto.PublicKey
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{name: "RSA_Equal", args: args{key1Iface: rsa1, key2Iface: rsa1}, want: true, wantErr: false},
+		{name: "RSA_NotEqual", args: args{key1Iface: rsa1, key2Iface: rsa2}, want: false, wantErr: false},
+		{name: "EDDSA_Equal", args: args{key1Iface: eddsa1, key2Iface: eddsa1}, want: true, wantErr: false},
+		{name: "EDDSA_NotEqual", args: args{key1Iface: eddsa1, key2Iface: eddsa2}, want: false, wantErr: false},
+		{name: "ED25519_Equal", args: args{key1Iface: ed25519_1, key2Iface: ed25519_1}, want: true, wantErr: false},
+		{name: "ED25519_NotEqual", args: args{key1Iface: ed25519_1, key2Iface: ed25519_2}, want: false, wantErr: false},
+		{name: "Mismatched_RSA", args: args{key1Iface: rsa1, key2Iface: ed25519_2}, want: false, wantErr: false},
+		{name: "Mismatched_EDDSA", args: args{key1Iface: ed25519_1, key2Iface: rsa1}, want: false, wantErr: false},
+		{name: "Mismatched_ED25519", args: args{key1Iface: ed25519_1, key2Iface: rsa1}, want: false, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ComparePublicKeysAndType(tt.args.key1Iface, tt.args.key2Iface)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ComparePublicKeysAndType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ComparePublicKeysAndType() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func genRsaKey(t *testing.T) *rsa.PrivateKey {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func genEdDSA(t *testing.T) *ecdsa.PrivateKey {
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func genEd25519Key(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	key, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key, priv
 }
 
 var (

--- a/sdk/helper/certutil/helpers.go
+++ b/sdk/helper/certutil/helpers.go
@@ -352,7 +352,21 @@ func generateSerialNumber(randReader io.Reader) (*big.Int, error) {
 	return serial, nil
 }
 
-// ComparePublicKeys compares two public keys and returns true if they match
+// ComparePublicKeysAndType compares two public keys and returns true if they match,
+// false if their types or contents differ, and an error on unsupported key types.
+func ComparePublicKeysAndType(key1Iface, key2Iface crypto.PublicKey) (bool, error) {
+	equal, err := ComparePublicKeys(key1Iface, key2Iface)
+	if err != nil {
+		if strings.Contains(err.Error(), "key types do not match:") {
+			return false, nil
+		}
+	}
+
+	return equal, err
+}
+
+// ComparePublicKeys compares two public keys and returns true if they match,
+// returns an error if public key types are mismatched, or they are an unsupported key type.
 func ComparePublicKeys(key1Iface, key2Iface crypto.PublicKey) (bool, error) {
 	switch key1Iface.(type) {
 	case *rsa.PublicKey:


### PR DESCRIPTION
 - Validate that generate/root calls are no longer idempotent, but the bundle importing
   does not generate new keys/issuers
 - As before make sure that the delete root api resets everything
 - Address a bug within the storage that we bombed when we had multiple different
   key types within storage.