### PR TITLE
Update default value of vault.hashicorp.com/agent-cache-listener-port

### DIFF
--- a/website/content/docs/platform/k8s/injector/annotations.mdx
+++ b/website/content/docs/platform/k8s/injector/annotations.mdx
@@ -184,7 +184,7 @@ them, optional commands to run, etc.
   by default.
 
 - `vault.hashicorp.com/agent-cache-listener-port` - configures Vault Agent cache
-  listening port. Defaults to `8080`.
+  listening port. Defaults to `8200`.
 
 - `vault.hashicorp.com/agent-copy-volume-mounts` - copies the mounts from the specified
   container and mounts them to the Vault Agent containers. The service account volume is


### PR DESCRIPTION
Base on this line and my experiment, I think the default value of `vault.hashicorp.com/agent-cache-listener-port` should be `8200`.

https://github.com/hashicorp/vault-k8s/blob/main/agent-inject/agent/agent.go#L30