### PR TITLE
Address some small nits in PKI rotation

### DIFF
--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -177,6 +177,13 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 		}
 	}
 
+	if len(createdIssuers) > 0 {
+		err := buildCRL(ctx, b, req, true)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"mapping":          issuerKeyMap,

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -190,16 +190,6 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 		return nil, fmt.Errorf("unable to store certificate locally: %w", err)
 	}
 
-	// For ease of later use, also store just the certificate at a known
-	// location
-	err = req.Storage.Put(ctx, &logical.StorageEntry{
-		Key:   "ca",
-		Value: parsedBundle.CertificateBytes,
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	// Build a fresh CRL
 	err = buildCRL(ctx, b, req, true)
 	if err != nil {

--- a/builtin/logical/pki/storage_migrations.go
+++ b/builtin/logical/pki/storage_migrations.go
@@ -50,7 +50,7 @@ func migrateStorage(ctx context.Context, req *logical.InitializationRequest, log
 
 	logger.Warn("performing PKI migration to new keys/issuers layout")
 
-	anIssuer, aKey, err := writeCaBundle(ctx, s, legacyBundle, "", "")
+	anIssuer, aKey, err := writeCaBundle(ctx, s, legacyBundle, "current", "current")
 	if err != nil {
 		return err
 	}

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -60,9 +60,11 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	keyId := keyIds[0]
 	issuer, err := fetchIssuerById(ctx, s, issuerId)
 	require.NoError(t, err)
+	require.Equal(t, "current", issuer.Name) // RFC says we should import with Name=current
 
 	key, err := fetchKeyById(ctx, s, keyId)
 	require.NoError(t, err)
+	require.Equal(t, "current", key.Name) // RFC says we should import with Name=current
 
 	require.Equal(t, issuerId, issuer.ID)
 	require.Equal(t, bundle.SerialNumber, issuer.SerialNumber)


### PR DESCRIPTION
- Reading the RFC, I had missed the detail about the migrated issuer/keys should have the Name set to `current`.
- Fix issue spotted that we were no longer building up a CRL after the set-signed api call. Fix that issue and add a corresponding test validating a CRL exists post set-signed.