### PR TITLE
UI: Masked inputs always look the same when value is hidden

### DIFF
--- a/changelog/15025.txt
+++ b/changelog/15025.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: masked values no longer give away length or location of special characters
+```

--- a/ui/lib/core/addon/templates/components/masked-input.hbs
+++ b/ui/lib/core/addon/templates/components/masked-input.hbs
@@ -4,11 +4,11 @@
   data-test-field
 >
   {{#if this.displayOnly}}
-    <pre class="masked-value display-only is-word-break {{unless this.showValue 'masked-font'}}">{{unless
-        this.showValue
-        (truncate this.value 20)
-        this.value
-      }}</pre>
+    {{#if this.showValue}}
+      <pre class="masked-value display-only is-word-break">{{this.value}}</pre>
+    {{else}}
+      <pre class="masked-value display-only masked-font">***********</pre>
+    {{/if}}
   {{else if this.inputField}}
     <input
       autocomplete="off"

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -251,7 +251,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     assert.dom('[data-test-list-item-content]').exists({ count: 1 }, 'renders a single version');
 
     await click('.linked-block');
-
+    await click('button.button.masked-input-toggle');
     assert.dom('[data-test-masked-input]').hasText('bar', 'renders secret on the secret version show page');
     assert.equal(
       currentURL(),

--- a/ui/tests/integration/components/masked-input-test.js
+++ b/ui/tests/integration/components/masked-input-test.js
@@ -70,11 +70,11 @@ module('Integration | Component | masked input', function (hooks) {
     assert.dom('.masked-value').hasClass('masked-font');
   });
 
-  test('it shortens long outputs when displayOnly and masked', async function (assert) {
+  test('it shortens all outputs when displayOnly and masked', async function (assert) {
     this.set('value', '123456789-123456789-123456789');
     await render(hbs`{{masked-input value=value displayOnly=true}}`);
     let maskedValue = document.querySelector('.masked-value').innerText;
-    assert.equal(maskedValue.length, 20);
+    assert.equal(maskedValue.length, 11);
 
     await component.toggleMasked();
     let unMaskedValue = document.querySelector('.masked-value').innerText;


### PR DESCRIPTION
Previous to this fix, if a masked value had special characters such as é, à, è the masked value would give away where chose characters are in the string. 

After this fix, masked display will be completely agnostic to the actual value -- always showing the same length and size of character. This PR addresses [issue 13270](https://github.com/hashicorp/vault/issues/13270)

**Before - you can tell without showing the value where the special character is**
<img width="647" alt="masked value display - before" src="https://user-images.githubusercontent.com/82459713/163263607-70f62a71-9b5d-4d60-818a-901b1e45000b.png">

**After - can no longer tell when masked the length or location of special characters**
<img width="588" alt="masked value display - after" src="https://user-images.githubusercontent.com/82459713/163263602-6f8f8da7-6e41-44ee-9211-c0abcce490fd.png">
<img width="639" alt="masked value show - after" src="https://user-images.githubusercontent.com/82459713/163263610-c067a1b7-680f-4091-858e-c148e3d08e5b.png">

It's worth noting that the input will still show the true length and location of the special character. This is so that the user can type in the field without unmasking the value.
<img width="608" alt="masked value input - after" src="https://user-images.githubusercontent.com/82459713/163263608-2399269b-b7ef-486b-8328-327a3a507fcf.png">
