### PR TITLE
fix regression on Core.pluginDirectory when backend is builtin

### DIFF
--- a/vault/auth.go
+++ b/vault/auth.go
@@ -915,8 +915,16 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 
 	f, ok := c.credentialBackends[t]
 	if !ok {
-		f = plugin.Factory
-		if !c.builtinRegistry.Contains(entry.Type, consts.PluginTypeCredential) {
+
+		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential)
+		if err != nil {
+			return nil, err
+		}
+		if plug == nil {
+			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, entry.Type)
+		}
+
+		if !plug.Builtin {
 			f = wrapFactoryCheckPerms(c, plugin.Factory)
 		}
 	}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -915,7 +915,6 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 
 	f, ok := c.credentialBackends[t]
 	if !ok {
-
 		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential)
 		if err != nil {
 			return nil, err
@@ -924,6 +923,7 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, entry.Type)
 		}
 
+		f = plugin.Factory
 		if !plug.Builtin {
 			f = wrapFactoryCheckPerms(c, plugin.Factory)
 		}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -915,17 +915,8 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 
 	f, ok := c.credentialBackends[t]
 	if !ok {
-
-		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential)
-		if err != nil {
-			return nil, err
-		}
-		if plug == nil {
-			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, entry.Type)
-		}
-
 		f = plugin.Factory
-		if !plug.Builtin {
+		if !c.builtinRegistry.Contains(entry.Type, consts.PluginTypeCredential) {
 			f = wrapFactoryCheckPerms(c, plugin.Factory)
 		}
 	}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -915,7 +915,19 @@ func (c *Core) newCredentialBackend(ctx context.Context, entry *MountEntry, sysV
 
 	f, ok := c.credentialBackends[t]
 	if !ok {
-		f = wrapFactoryCheckPerms(c, plugin.Factory)
+
+		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential)
+		if err != nil {
+			return nil, err
+		}
+		if plug == nil {
+			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, entry.Type)
+		}
+
+		f = plugin.Factory
+		if !plug.Builtin {
+			f = wrapFactoryCheckPerms(c, plugin.Factory)
+		}
 	}
 
 	// Set up conf to pass in plugin_name

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -141,6 +141,33 @@ func TestCore_DefaultAuthTable(t *testing.T) {
 	}
 }
 
+func TestCore_BuiltinRegistry(t *testing.T) {
+	conf := &CoreConfig{
+		// set PluginDirectory and ensure that vault doesn't expect approle to
+		// be there when we are mounting the builtin approle
+		PluginDirectory: "/Users/foo",
+
+		DisableMlock:    true,
+		BuiltinRegistry: NewMockBuiltinRegistry(),
+	}
+	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
+
+	me := &MountEntry{
+		Table: credentialTableType,
+		Path:  "approle/",
+		Type:  "approle",
+	}
+	err := c.enableCredential(namespace.RootContext(nil), me)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	match := c.router.MatchingMount(namespace.RootContext(nil), "auth/approle/bar")
+	if match != "auth/approle/" {
+		t.Fatalf("missing mount, match: %q", match)
+	}
+}
+
 func TestCore_EnableCredential(t *testing.T) {
 	c, keys, _ := TestCoreUnsealed(t)
 	c.credentialBackends["noop"] = func(context.Context, *logical.BackendConfig) (logical.Backend, error) {

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -161,11 +161,6 @@ func TestCore_BuiltinRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
-	match := c.router.MatchingMount(namespace.RootContext(nil), "auth/approle/bar")
-	if match != "auth/approle/" {
-		t.Fatalf("missing mount, match: %q", match)
-	}
 }
 
 func TestCore_EnableCredential(t *testing.T) {

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1395,7 +1395,18 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 
 	f, ok := c.logicalBackends[t]
 	if !ok {
-		f = wrapFactoryCheckPerms(c, plugin.Factory)
+		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets)
+		if err != nil {
+			return nil, err
+		}
+		if plug == nil {
+			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, entry.Type)
+		}
+
+		f = plugin.Factory
+		if !plug.Builtin {
+			f = wrapFactoryCheckPerms(c, plugin.Factory)
+		}
 	}
 
 	// Set up conf to pass in plugin_name

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1395,16 +1395,8 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 
 	f, ok := c.logicalBackends[t]
 	if !ok {
-		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets)
-		if err != nil {
-			return nil, err
-		}
-		if plug == nil {
-			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, entry.Type)
-		}
-
 		f = plugin.Factory
-		if !plug.Builtin {
+		if !c.builtinRegistry.Contains(entry.Type, consts.PluginTypeSecrets) {
 			f = wrapFactoryCheckPerms(c, plugin.Factory)
 		}
 	}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1395,7 +1395,6 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 
 	f, ok := c.logicalBackends[t]
 	if !ok {
-
 		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets)
 		if err != nil {
 			return nil, err
@@ -1404,6 +1403,7 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, entry.Type)
 		}
 
+		f = plugin.Factory
 		if !plug.Builtin {
 			f = wrapFactoryCheckPerms(c, plugin.Factory)
 		}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1395,8 +1395,16 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 
 	f, ok := c.logicalBackends[t]
 	if !ok {
-		f = plugin.Factory
-		if !c.builtinRegistry.Contains(entry.Type, consts.PluginTypeSecrets) {
+
+		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential)
+		if err != nil {
+			return nil, err
+		}
+		if plug == nil {
+			return nil, fmt.Errorf("%w: %s", ErrPluginNotFound, entry.Type)
+		}
+
+		if !plug.Builtin {
 			f = wrapFactoryCheckPerms(c, plugin.Factory)
 		}
 	}

--- a/vault/mount.go
+++ b/vault/mount.go
@@ -1396,7 +1396,7 @@ func (c *Core) newLogicalBackend(ctx context.Context, entry *MountEntry, sysView
 	f, ok := c.logicalBackends[t]
 	if !ok {
 
-		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeCredential)
+		plug, err := c.pluginCatalog.Get(ctx, entry.Type, consts.PluginTypeSecrets)
 		if err != nil {
 			return nil, err
 		}

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -189,8 +189,8 @@ func TestCore_Mount(t *testing.T) {
 
 func TestCore_BuiltinRegistrySecrets(t *testing.T) {
 	conf := &CoreConfig{
-		// set PluginDirectory and ensure that vault doesn't expect ssh to
-		// be there when we are mounting the builtin ssh
+		// set PluginDirectory and ensure that vault doesn't expect totp to
+		// be there when we are mounting the builtin totp
 		PluginDirectory: "/Users/foo",
 
 		DisableMlock:    true,
@@ -200,17 +200,12 @@ func TestCore_BuiltinRegistrySecrets(t *testing.T) {
 
 	me := &MountEntry{
 		Table: mountTableType,
-		Path:  "ssh/",
-		Type:  "ssh",
+		Path:  "totp/",
+		Type:  "totp",
 	}
 	err := c.mount(namespace.RootContext(nil), me)
 	if err != nil {
 		t.Fatalf("err: %v", err)
-	}
-
-	match := c.router.MatchingMount(namespace.RootContext(nil), "ssh/bar")
-	if match != "ssh/" {
-		t.Fatalf("missing mount, match: %q", match)
 	}
 }
 

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -189,8 +189,8 @@ func TestCore_Mount(t *testing.T) {
 
 func TestCore_BuiltinRegistrySecrets(t *testing.T) {
 	conf := &CoreConfig{
-		// set PluginDirectory and ensure that vault doesn't expect totp to
-		// be there when we are mounting the builtin totp
+		// set PluginDirectory and ensure that vault doesn't expect nomad to
+		// be there when we are mounting the builtin nomad
 		PluginDirectory: "/Users/foo",
 
 		DisableMlock:    true,
@@ -200,8 +200,8 @@ func TestCore_BuiltinRegistrySecrets(t *testing.T) {
 
 	me := &MountEntry{
 		Table: mountTableType,
-		Path:  "totp/",
-		Type:  "totp",
+		Path:  "nomad/",
+		Type:  "nomad",
 	}
 	err := c.mount(namespace.RootContext(nil), me)
 	if err != nil {

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -187,28 +187,6 @@ func TestCore_Mount(t *testing.T) {
 	}
 }
 
-func TestCore_BuiltinRegistrySecrets(t *testing.T) {
-	conf := &CoreConfig{
-		// set PluginDirectory and ensure that vault doesn't expect nomad to
-		// be there when we are mounting the builtin nomad
-		PluginDirectory: "/Users/foo",
-
-		DisableMlock:    true,
-		BuiltinRegistry: NewMockBuiltinRegistry(),
-	}
-	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
-
-	me := &MountEntry{
-		Table: mountTableType,
-		Path:  "nomad/",
-		Type:  "nomad",
-	}
-	err := c.mount(namespace.RootContext(nil), me)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-}
-
 // Test that the local table actually gets populated as expected with local
 // entries, and that upon reading the entries from both are recombined
 // correctly

--- a/vault/mount_test.go
+++ b/vault/mount_test.go
@@ -187,6 +187,33 @@ func TestCore_Mount(t *testing.T) {
 	}
 }
 
+func TestCore_BuiltinRegistrySecrets(t *testing.T) {
+	conf := &CoreConfig{
+		// set PluginDirectory and ensure that vault doesn't expect ssh to
+		// be there when we are mounting the builtin ssh
+		PluginDirectory: "/Users/foo",
+
+		DisableMlock:    true,
+		BuiltinRegistry: NewMockBuiltinRegistry(),
+	}
+	c, _, _ := TestCoreUnsealedWithConfig(t, conf)
+
+	me := &MountEntry{
+		Table: mountTableType,
+		Path:  "ssh/",
+		Type:  "ssh",
+	}
+	err := c.mount(namespace.RootContext(nil), me)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	match := c.router.MatchingMount(namespace.RootContext(nil), "ssh/bar")
+	if match != "ssh/" {
+		t.Fatalf("missing mount, match: %q", match)
+	}
+}
+
 // Test that the local table actually gets populated as expected with local
 // entries, and that upon reading the entries from both are recombined
 // correctly

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -34,7 +34,7 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/builtin/credential/approle"
-	"github.com/hashicorp/vault/builtin/logical/totp"
+	"github.com/hashicorp/vault/builtin/logical/nomad"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
@@ -2153,7 +2153,7 @@ func NewMockBuiltinRegistry() *mockBuiltinRegistry {
 			"mysql-database-plugin":      consts.PluginTypeDatabase,
 			"postgresql-database-plugin": consts.PluginTypeDatabase,
 			"approle":                    consts.PluginTypeCredential,
-			"totp":                       consts.PluginTypeSecrets,
+			"nomad":                      consts.PluginTypeSecrets,
 		},
 	}
 }
@@ -2162,7 +2162,7 @@ type mockBuiltinRegistry struct {
 	forTesting map[string]consts.PluginType
 }
 
-// Get only supports getting database plugins, totp and approle
+// Get only supports getting database plugins, nomad and approle
 func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (func() (interface{}, error), bool) {
 	testPluginType, ok := m.forTesting[name]
 	if !ok {
@@ -2176,8 +2176,8 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 		return toFunc(approle.Factory), true
 	}
 
-	if name == "totp" {
-		return toFunc(totp.Factory), true
+	if name == "nomad" {
+		return toFunc(nomad.Factory), true
 	}
 
 	if name == "postgresql-database-plugin" {
@@ -2187,7 +2187,7 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 }
 
 // Keys only supports getting a realistic list of the keys for database plugins,
-// totp and approle
+// nomad and approle
 func (m *mockBuiltinRegistry) Keys(pluginType consts.PluginType) []string {
 	switch pluginType {
 	case consts.PluginTypeDatabase:
@@ -2218,7 +2218,7 @@ func (m *mockBuiltinRegistry) Keys(pluginType consts.PluginType) []string {
 		}
 	case consts.PluginTypeSecrets:
 		return []string{
-			"totp",
+			"nomad",
 		}
 	}
 	return []string{}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -34,7 +34,7 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/builtin/credential/approle"
-	"github.com/hashicorp/vault/builtin/logical/ssh"
+	"github.com/hashicorp/vault/builtin/logical/totp"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
@@ -2153,7 +2153,7 @@ func NewMockBuiltinRegistry() *mockBuiltinRegistry {
 			"mysql-database-plugin":      consts.PluginTypeDatabase,
 			"postgresql-database-plugin": consts.PluginTypeDatabase,
 			"approle":                    consts.PluginTypeCredential,
-			"ssh":                        consts.PluginTypeSecrets,
+			"totp":                       consts.PluginTypeSecrets,
 		},
 	}
 }
@@ -2162,7 +2162,7 @@ type mockBuiltinRegistry struct {
 	forTesting map[string]consts.PluginType
 }
 
-// Get only supports getting database plugins, ssh and approle
+// Get only supports getting database plugins, totp and approle
 func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (func() (interface{}, error), bool) {
 	testPluginType, ok := m.forTesting[name]
 	if !ok {
@@ -2176,8 +2176,8 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 		return toFunc(approle.Factory), true
 	}
 
-	if name == "ssh" {
-		return toFunc(ssh.Factory), true
+	if name == "totp" {
+		return toFunc(totp.Factory), true
 	}
 
 	if name == "postgresql-database-plugin" {
@@ -2187,7 +2187,7 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 }
 
 // Keys only supports getting a realistic list of the keys for database plugins,
-// ssh and approle
+// totp and approle
 func (m *mockBuiltinRegistry) Keys(pluginType consts.PluginType) []string {
 	switch pluginType {
 	case consts.PluginTypeDatabase:
@@ -2218,7 +2218,7 @@ func (m *mockBuiltinRegistry) Keys(pluginType consts.PluginType) []string {
 		}
 	case consts.PluginTypeSecrets:
 		return []string{
-			"ssh",
+			"totp",
 		}
 	}
 	return []string{}

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -33,6 +33,7 @@ import (
 	raftlib "github.com/hashicorp/raft"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
+	"github.com/hashicorp/vault/builtin/credential/approle"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
@@ -201,6 +202,7 @@ func TestCoreWithSealAndUINoCleanup(t testing.T, opts *CoreConfig) *Core {
 	conf.RawConfig = opts.RawConfig
 	conf.EnableResponseHeaderHostname = opts.EnableResponseHeaderHostname
 	conf.DisableSSCTokens = opts.DisableSSCTokens
+	conf.PluginDirectory = opts.PluginDirectory
 
 	if opts.Logger != nil {
 		conf.Logger = opts.Logger
@@ -1920,7 +1922,8 @@ func (testCluster *TestCluster) newCore(t testing.T, idx int, coreConfig *CoreCo
 
 func (testCluster *TestCluster) setupClusterListener(
 	t testing.T, idx int, core *Core, coreConfig *CoreConfig,
-	opts *TestClusterOptions, listeners []*TestListener, handler http.Handler) {
+	opts *TestClusterOptions, listeners []*TestListener, handler http.Handler,
+) {
 	if coreConfig.ClusterAddr == "" {
 		return
 	}
@@ -2106,7 +2109,8 @@ func (tc *TestCluster) initCores(t testing.T, opts *TestClusterOptions, addAudit
 
 func (testCluster *TestCluster) getAPIClient(
 	t testing.T, opts *TestClusterOptions,
-	port int, tlsConfig *tls.Config) *api.Client {
+	port int, tlsConfig *tls.Config,
+) *api.Client {
 	transport := cleanhttp.DefaultPooledTransport()
 	transport.TLSClientConfig = tlsConfig.Clone()
 	if err := http2.ConfigureTransport(transport); err != nil {
@@ -2136,11 +2140,18 @@ func (testCluster *TestCluster) getAPIClient(
 	return apiClient
 }
 
+func toFunc(f logical.Factory) func() (interface{}, error) {
+	return func() (interface{}, error) {
+		return f, nil
+	}
+}
+
 func NewMockBuiltinRegistry() *mockBuiltinRegistry {
 	return &mockBuiltinRegistry{
 		forTesting: map[string]consts.PluginType{
 			"mysql-database-plugin":      consts.PluginTypeDatabase,
 			"postgresql-database-plugin": consts.PluginTypeDatabase,
+			"approle":                    consts.PluginTypeCredential,
 		},
 	}
 }
@@ -2149,6 +2160,7 @@ type mockBuiltinRegistry struct {
 	forTesting map[string]consts.PluginType
 }
 
+// Get only supports getting database plugins and approle credential backend
 func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (func() (interface{}, error), bool) {
 	testPluginType, ok := m.forTesting[name]
 	if !ok {
@@ -2157,39 +2169,49 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 	if pluginType != testPluginType {
 		return nil, false
 	}
+
+	if name == "approle" {
+		return toFunc(approle.Factory), true
+	}
+
 	if name == "postgresql-database-plugin" {
 		return dbPostgres.New, true
 	}
 	return dbMysql.New(dbMysql.DefaultUserNameTemplate), true
 }
 
-// Keys only supports getting a realistic list of the keys for database plugins.
+// Keys only supports getting a realistic list of the keys for database plugins
+// and approle credential backend
 func (m *mockBuiltinRegistry) Keys(pluginType consts.PluginType) []string {
-	if pluginType != consts.PluginTypeDatabase {
-		return []string{}
-	}
-	/*
-		This is a hard-coded reproduction of the db plugin keys in helper/builtinplugins/registry.go.
-		The registry isn't directly used because it causes import cycles.
-	*/
-	return []string{
-		"mysql-database-plugin",
-		"mysql-aurora-database-plugin",
-		"mysql-rds-database-plugin",
-		"mysql-legacy-database-plugin",
+	switch pluginType {
+	case consts.PluginTypeDatabase:
+		// This is a hard-coded reproduction of the db plugin keys in
+		// helper/builtinplugins/registry.go. The registry isn't directly used
+		// because it causes import cycles.
+		return []string{
+			"mysql-database-plugin",
+			"mysql-aurora-database-plugin",
+			"mysql-rds-database-plugin",
+			"mysql-legacy-database-plugin",
 
-		"cassandra-database-plugin",
-		"couchbase-database-plugin",
-		"elasticsearch-database-plugin",
-		"hana-database-plugin",
-		"influxdb-database-plugin",
-		"mongodb-database-plugin",
-		"mongodbatlas-database-plugin",
-		"mssql-database-plugin",
-		"postgresql-database-plugin",
-		"redshift-database-plugin",
-		"snowflake-database-plugin",
+			"cassandra-database-plugin",
+			"couchbase-database-plugin",
+			"elasticsearch-database-plugin",
+			"hana-database-plugin",
+			"influxdb-database-plugin",
+			"mongodb-database-plugin",
+			"mongodbatlas-database-plugin",
+			"mssql-database-plugin",
+			"postgresql-database-plugin",
+			"redshift-database-plugin",
+			"snowflake-database-plugin",
+		}
+	case consts.PluginTypeCredential:
+		return []string{
+			"approle",
+		}
 	}
+	return []string{}
 }
 
 func (m *mockBuiltinRegistry) Contains(name string, pluginType consts.PluginType) bool {

--- a/vault/testing.go
+++ b/vault/testing.go
@@ -34,7 +34,6 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/audit"
 	"github.com/hashicorp/vault/builtin/credential/approle"
-	"github.com/hashicorp/vault/builtin/logical/nomad"
 	"github.com/hashicorp/vault/command/server"
 	"github.com/hashicorp/vault/helper/metricsutil"
 	"github.com/hashicorp/vault/helper/namespace"
@@ -2153,7 +2152,6 @@ func NewMockBuiltinRegistry() *mockBuiltinRegistry {
 			"mysql-database-plugin":      consts.PluginTypeDatabase,
 			"postgresql-database-plugin": consts.PluginTypeDatabase,
 			"approle":                    consts.PluginTypeCredential,
-			"nomad":                      consts.PluginTypeSecrets,
 		},
 	}
 }
@@ -2162,7 +2160,7 @@ type mockBuiltinRegistry struct {
 	forTesting map[string]consts.PluginType
 }
 
-// Get only supports getting database plugins, nomad and approle
+// Get only supports getting database plugins, and approle
 func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (func() (interface{}, error), bool) {
 	testPluginType, ok := m.forTesting[name]
 	if !ok {
@@ -2176,10 +2174,6 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 		return toFunc(approle.Factory), true
 	}
 
-	if name == "nomad" {
-		return toFunc(nomad.Factory), true
-	}
-
 	if name == "postgresql-database-plugin" {
 		return dbPostgres.New, true
 	}
@@ -2187,7 +2181,7 @@ func (m *mockBuiltinRegistry) Get(name string, pluginType consts.PluginType) (fu
 }
 
 // Keys only supports getting a realistic list of the keys for database plugins,
-// nomad and approle
+// and approle
 func (m *mockBuiltinRegistry) Keys(pluginType consts.PluginType) []string {
 	switch pluginType {
 	case consts.PluginTypeDatabase:
@@ -2215,10 +2209,6 @@ func (m *mockBuiltinRegistry) Keys(pluginType consts.PluginType) []string {
 	case consts.PluginTypeCredential:
 		return []string{
 			"approle",
-		}
-	case consts.PluginTypeSecrets:
-		return []string{
-			"nomad",
 		}
 	}
 	return []string{}


### PR DESCRIPTION
Fix a regression on `Core.pluginDirectory`. When enabling a secrets/auth plugin, vault looks in the `Core.pluginDirectory` if the `dev-plugin-dir` flag or `plugin_directory` config is set and fails if it doesn’t find it.
 
The following error would occur when the `dev-plugin-dir` flag or `plugin_directory` config was set on a vault dev server:

```
$ vault server -dev -dev-root-token-id=root -dev-plugin-dir=$HOME/dev/plugins
$ vault version
Vault v1.11.0-dev1 ('2d03150157a76099af193264dd97cdc52c433f14')
$ vault auth enable approle
Error enabling approle auth: Error making API request.

URL: POST http://127.0.0.1:8200/v1/sys/auth/approle
Code: 400. Errors:

* error stating "/Users/jmf/dev/plugins/approle": stat /Users/jmf/dev/plugins/approle: no such file or directory
```

