### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,6 +24,7 @@
 
 /command/agent/               @hashicorp/vault-ecosystem
 /plugins/                     @hashicorp/vault-ecosystem
+/vault/plugin_catalog.go      @hashicorp/vault-ecosystem
 
 /website/content/                         @taoism4504
 /website/content/docs/plugin-portal.mdx   @taoism4504  @acahn


### PR DESCRIPTION
Update CODEOWNERS to assign `hashicorp/vault-ecosystem` as code owners of `/vault/plugin_catalog.go`