### PR TITLE
Backport 1.9.5: UI Masked inputs always look the same when value is hidden (#15025)

### DIFF
--- a/changelog/15025.txt
+++ b/changelog/15025.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: masked values no longer give away length or location of special characters
+```

--- a/ui/lib/core/addon/templates/components/masked-input.hbs
+++ b/ui/lib/core/addon/templates/components/masked-input.hbs
@@ -7,7 +7,6 @@
     {{else}}
       <pre class="masked-value display-only masked-font">***********</pre>
     {{/if}}
-    <pre class="masked-value display-only is-word-break {{unless showValue "masked-font"}}">{{unless showValue (truncate value 20) value}}</pre>
   {{else if inputField}}
     <input
       autocomplete="off"

--- a/ui/lib/core/addon/templates/components/masked-input.hbs
+++ b/ui/lib/core/addon/templates/components/masked-input.hbs
@@ -2,6 +2,11 @@
 <div class="masked-input {{if displayOnly "display-only"}} {{if allowCopy "allow-copy"}}"
   data-test-masked-input data-test-field>
   {{#if displayOnly}}
+    {{#if showValue}}
+      <pre class="masked-value display-only is-word-break">{{value}}</pre>
+    {{else}}
+      <pre class="masked-value display-only masked-font">***********</pre>
+    {{/if}}
     <pre class="masked-value display-only is-word-break {{unless showValue "masked-font"}}">{{unless showValue (truncate value 20) value}}</pre>
   {{else if inputField}}
     <input
@@ -13,7 +18,7 @@
       data-test-input
     />
   {{else}}
-    <textarea 
+    <textarea
       class="input masked-value {{unless showValue "masked-font"}}"
       rows=1 wrap="off"
       onkeydown={{action onKeyDown}}
@@ -23,7 +28,7 @@
         value="target.value"
       }}
       value={{value}}
-      data-test-textarea 
+      data-test-textarea
     />
   {{/if}}
   {{#if allowCopy}}
@@ -35,7 +40,7 @@
       <Icon @glyph="copy-action" aria-hidden="Copy value" />
     </CopyButton>
   {{/if}}
-  <button 
+  <button
     onclick={{action "toggleMask"}}
     type="button"
     class="{{if (eq value "") "has-text-grey"}} masked-input-toggle button"

--- a/ui/tests/acceptance/secrets/backend/kv/secret-test.js
+++ b/ui/tests/acceptance/secrets/backend/kv/secret-test.js
@@ -253,8 +253,7 @@ module('Acceptance | secrets/secret/create', function (hooks) {
     assert.dom('[data-test-list-item-content]').exists({ count: 1 }, 'renders a single version');
 
     await click('.linked-block');
-    await settled();
-    await settled();
+    await click('button.button.masked-input-toggle');
     assert.dom('[data-test-masked-input]').hasText('bar', 'renders secret on the secret version show page');
     assert.equal(
       currentURL(),

--- a/ui/tests/integration/components/masked-input-test.js
+++ b/ui/tests/integration/components/masked-input-test.js
@@ -7,52 +7,52 @@ import maskedInput from 'vault/tests/pages/components/masked-input';
 
 const component = create(maskedInput);
 
-module('Integration | Component | masked input', function(hooks) {
+module('Integration | Component | masked input', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     await render(hbs`{{masked-input}}`);
     assert.dom('[data-test-masked-input]').exists('shows expiration beacon');
   });
 
-  test('it renders a textarea', async function(assert) {
+  test('it renders a textarea', async function (assert) {
     await render(hbs`{{masked-input}}`);
 
     assert.ok(component.textareaIsPresent);
   });
 
-  test('it renders an input with obscure font', async function(assert) {
+  test('it renders an input with obscure font', async function (assert) {
     await render(hbs`{{masked-input}}`);
 
     assert.dom('[data-test-textarea]').hasClass('masked-font', 'loading class with correct font');
   });
 
-  test('it renders obscure font when displayOnly', async function(assert) {
+  test('it renders obscure font when displayOnly', async function (assert) {
     this.set('value', 'value');
     await render(hbs`{{masked-input displayOnly=true value=value}}`);
 
     assert.dom('.masked-value').hasClass('masked-font', 'loading class with correct font');
   });
 
-  test('it does not render a textarea when displayOnly is true', async function(assert) {
+  test('it does not render a textarea when displayOnly is true', async function (assert) {
     await render(hbs`{{masked-input displayOnly=true}}`);
 
     assert.notOk(component.textareaIsPresent);
   });
 
-  test('it renders a copy button when allowCopy is true', async function(assert) {
+  test('it renders a copy button when allowCopy is true', async function (assert) {
     await render(hbs`{{masked-input allowCopy=true}}`);
 
     assert.ok(component.copyButtonIsPresent);
   });
 
-  test('it does not render a copy button when allowCopy is false', async function(assert) {
+  test('it does not render a copy button when allowCopy is false', async function (assert) {
     await render(hbs`{{masked-input allowCopy=false}}`);
 
     assert.notOk(component.copyButtonIsPresent);
   });
 
-  test('it unmasks text when button is clicked', async function(assert) {
+  test('it unmasks text when button is clicked', async function (assert) {
     this.set('value', 'value');
     await render(hbs`{{masked-input value=value}}`);
     await component.toggleMasked();
@@ -60,7 +60,7 @@ module('Integration | Component | masked input', function(hooks) {
     assert.dom('.masked-value').doesNotHaveClass('masked-font');
   });
 
-  test('it remasks text when button is clicked', async function(assert) {
+  test('it remasks text when button is clicked', async function (assert) {
     this.set('value', 'value');
     await render(hbs`{{masked-input value=value}}`);
 
@@ -70,18 +70,18 @@ module('Integration | Component | masked input', function(hooks) {
     assert.dom('.masked-value').hasClass('masked-font');
   });
 
-  test('it shortens long outputs when displayOnly and masked', async function(assert) {
+  test('it shortens all outputs when displayOnly and masked', async function (assert) {
     this.set('value', '123456789-123456789-123456789');
     await render(hbs`{{masked-input value=value displayOnly=true}}`);
     let maskedValue = document.querySelector('.masked-value').innerText;
-    assert.equal(maskedValue.length, 20);
+    assert.equal(maskedValue.length, 11);
 
     await component.toggleMasked();
     let unMaskedValue = document.querySelector('.masked-value').innerText;
     assert.equal(unMaskedValue.length, this.value.length);
   });
 
-  test('it does not unmask text on focus', async function(assert) {
+  test('it does not unmask text on focus', async function (assert) {
     this.set('value', '123456789-123456789-123456789');
     await render(hbs`{{masked-input value=value}}`);
     assert.dom('.masked-value').hasClass('masked-font');
@@ -89,7 +89,7 @@ module('Integration | Component | masked input', function(hooks) {
     assert.dom('.masked-value').hasClass('masked-font');
   });
 
-  test('it does not remove value on tab', async function(assert) {
+  test('it does not remove value on tab', async function (assert) {
     this.set('value', 'hello');
     await render(hbs`{{masked-input value=value}}`);
     await triggerKeyEvent('[data-test-textarea]', 'keydown', 9);


### PR DESCRIPTION
Backport of #15025 