### PR TITLE
When running under systemd, send ready when server completed reloading config #7028

### DIFF
--- a/changelog/15041.txt
+++ b/changelog/15041.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: fixed systemd reloading notification
+```

--- a/command/server.go
+++ b/command/server.go
@@ -1627,6 +1627,9 @@ func (c *ServerCommand) Run(args []string) int {
 			// changes in kms_libraries)
 			core.ReloadManagedKeyRegistryConfig()
 
+			// Notify systemd that the server has completed reloading config
+			c.notifySystemd(systemd.SdNotifyReady)
+
 		case <-c.SigUSR2Ch:
 			logWriter := c.logger.StandardWriter(&hclog.StandardLoggerOptions{})
 			pprof.Lookup("goroutine").WriteTo(logWriter, 2)


### PR DESCRIPTION
Server must call SdNotifyReady when it completed reloading. Otherwise systemd gets timeout after vault service reload as mentioned in #7028.