### PR TITLE
Add AWS_DYNAMODB_REGION Environment variable

### DIFF
--- a/changelog/15054.txt
+++ b/changelog/15054.txt
@@ -1,5 +1,3 @@
-
-   
 ```release-note:feature
 storage/dynamodb: Added `AWS_DYNAMODB_REGION` environment variable.
 ```

--- a/changelog/15054.txt
+++ b/changelog/15054.txt
@@ -1,0 +1,5 @@
+
+   
+```release-note:feature
+storage/dynamodb: Added `AWS_DYNAMODB_REGION` environment variable.
+```

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -163,13 +163,16 @@ func NewDynamoDBBackend(conf map[string]string, logger log.Logger) (physical.Bac
 	if endpoint == "" {
 		endpoint = conf["endpoint"]
 	}
-	region := os.Getenv("AWS_REGION")
+	region := os.Getenv("AWS_DYNAMODB_REGION")
 	if region == "" {
-		region = os.Getenv("AWS_DEFAULT_REGION")
+		region := os.Getenv("AWS_REGION")
 		if region == "" {
-			region = conf["region"]
+			region = os.Getenv("AWS_DEFAULT_REGION")
 			if region == "" {
-				region = DefaultDynamoDBRegion
+				region = conf["region"]
+				if region == "" {
+					region = DefaultDynamoDBRegion
+				}
 			}
 		}
 	}

--- a/physical/dynamodb/dynamodb.go
+++ b/physical/dynamodb/dynamodb.go
@@ -165,7 +165,7 @@ func NewDynamoDBBackend(conf map[string]string, logger log.Logger) (physical.Bac
 	}
 	region := os.Getenv("AWS_DYNAMODB_REGION")
 	if region == "" {
-		region := os.Getenv("AWS_REGION")
+		region = os.Getenv("AWS_REGION")
 		if region == "" {
 			region = os.Getenv("AWS_DEFAULT_REGION")
 			if region == "" {


### PR DESCRIPTION
From eks 1.18 `AWS_REGION` and `AWS_DEFAULT_REGION` auto inject to pods. So if you can't use dynamodb table from other region it's read from `AWS_REGION` always and override on config file. Reorder setting can be break current vault settings. I added one new with `AWS_DYNAMODB_REGION`

https://github.com/aws/amazon-eks-pod-identity-webhook/issues/40

fix https://github.com/hashicorp/vault/issues/15071


changelog
```
storage/dynamodb: Added `AWS_DYNAMODB_REGION` environment variable
```