### PR TITLE
fix TypeCommaIntSlice panic caused by json.Number input

### DIFF
--- a/changelog/15072.txt
+++ b/changelog/15072.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fix panic caused by parsing JSON integers for fields defined as comma-delimited integers
+```

--- a/sdk/framework/field_data.go
+++ b/sdk/framework/field_data.go
@@ -243,6 +243,12 @@ func (d *FieldData) getPrimitive(k string, schema *FieldSchema) (interface{}, bo
 
 	case TypeCommaIntSlice:
 		var result []int
+
+		jsonIn, ok := raw.(json.Number)
+		if ok {
+			raw = jsonIn.String()
+		}
+
 		config := &mapstructure.DecoderConfig{
 			Result:           &result,
 			WeaklyTypedInput: true,

--- a/sdk/framework/field_data_test.go
+++ b/sdk/framework/field_data_test.go
@@ -593,6 +593,19 @@ func TestFieldDataGet(t *testing.T) {
 			[]int{},
 			false,
 		},
+
+		"comma int slice type, json number": {
+			map[string]*FieldSchema{
+				"foo": {Type: TypeCommaIntSlice},
+			},
+			map[string]interface{}{
+				"foo": json.Number("1"),
+			},
+			"foo",
+			[]int{1},
+			false,
+		},
+
 		"name string type, valid string": {
 			map[string]*FieldSchema{
 				"foo": {Type: TypeNameString},


### PR DESCRIPTION
Vault will panic when it attempts to parse fields with a schema of `TypeCommaIntSlice` if the provided value is an integer specifically if provided within the JSON body of an HTTP request. This is similar to a recent fix that was implemented for `TypeCommaStringSlice` which was fixed in https://github.com/hashicorp/vault/pull/14522. The issue resides in `mapstructure.StringToSliceHookFunc`.

The fix provided in this pull request is to check if the raw input is of type `json.Number` and then calling `String()`.

Fixes https://github.com/hashicorp/vault/issues/15057