### PR TITLE
Allow explicit issuer chain path construction

### DIFF
--- a/builtin/logical/pki/backend_test.go
+++ b/builtin/logical/pki/backend_test.go
@@ -4724,7 +4724,7 @@ func TestRootWithExistingKey(t *testing.T) {
 		"issuer_name": "my-issuer1",
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "issuer name already used")
+	require.Contains(t, err.Error(), "issuer name already in use")
 
 	// Create the second CA
 	resp, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/internal", map[string]interface{}{
@@ -4747,7 +4747,7 @@ func TestRootWithExistingKey(t *testing.T) {
 		"key_name":    "root-key2",
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "key name already used")
+	require.Contains(t, err.Error(), "key name already in use")
 
 	// Create a third CA re-using key from CA 1
 	resp, err = client.Logical().WriteWithContext(ctx, "pki-root/issuers/generate/root/existing", map[string]interface{}{

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -130,6 +130,11 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 	var issuers []string
 	var keys []string
 
+	// By decoding and re-encoding PEM blobs, we can pass strict PEM blobs
+	// to the import functionality (importKeys, importIssuers). This allows
+	// them to validate no duplicate issuers exist (and place greater
+	// restrictions during parsing) but allows this code to accept OpenSSL
+	// parsed chains (with full textual output between PEM entries).
 	for len(bytes.TrimSpace(pemBytes)) > 0 {
 		pemBlock, pemBytes = pem.Decode(pemBytes)
 		if pemBlock == nil {

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -49,12 +49,13 @@ type key struct {
 }
 
 type issuer struct {
-	ID           issuerId `json:"id" structs:"id" mapstructure:"id"`
-	Name         string   `json:"name" structs:"name" mapstructure:"name"`
-	KeyID        keyId    `json:"key_id" structs:"key_id" mapstructure:"key_id"`
-	Certificate  string   `json:"certificate" structs:"certificate" mapstructure:"certificate"`
-	CAChain      []string `json:"ca_chain" structs:"ca_chain" mapstructure:"ca_chain"`
-	SerialNumber string   `json:"serial_number" structs:"serial_number" mapstructure:"serial_number"`
+	ID           issuerId   `json:"id" structs:"id" mapstructure:"id"`
+	Name         string     `json:"name" structs:"name" mapstructure:"name"`
+	KeyID        keyId      `json:"key_id" structs:"key_id" mapstructure:"key_id"`
+	Certificate  string     `json:"certificate" structs:"certificate" mapstructure:"certificate"`
+	CAChain      []string   `json:"ca_chain" structs:"ca_chain" mapstructure:"ca_chain"`
+	ManualChain  []issuerId `json:"manual_chain" structs:"manual_chain" mapstructure:"manual_chain"`
+	SerialNumber string     `json:"serial_number" structs:"serial_number" mapstructure:"serial_number"`
 }
 
 type keyConfig struct {

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -2,6 +2,7 @@ package pki
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/logical"
@@ -68,7 +69,7 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 
 	require.Equal(t, issuerId, issuer.ID)
 	require.Equal(t, bundle.SerialNumber, issuer.SerialNumber)
-	require.Equal(t, bundle.Certificate, issuer.Certificate)
+	require.Equal(t, strings.TrimSpace(bundle.Certificate), strings.TrimSpace(issuer.Certificate))
 	require.Equal(t, keyId, issuer.KeyID)
 	// FIXME: Add tests for CAChain...
 

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -3,6 +3,7 @@ package pki
 import (
 	"context"
 	"crypto/rand"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -119,7 +120,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 	issuer1_ref1, existing, err := importIssuer(ctx, s, issuer1.Certificate, "issuer1")
 	require.NoError(t, err)
 	require.False(t, existing)
-	require.Equal(t, issuer1.Certificate, issuer1_ref1.Certificate)
+	require.Equal(t, strings.TrimSpace(issuer1.Certificate), strings.TrimSpace(issuer1_ref1.Certificate))
 	require.Equal(t, key1_ref1.ID, issuer1_ref1.KeyID)
 	require.Equal(t, "issuer1", issuer1_ref1.Name)
 
@@ -128,7 +129,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 	issuer1_ref2, existing, err := importIssuer(ctx, s, issuer1.Certificate, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
-	require.Equal(t, issuer1.Certificate, issuer1_ref1.Certificate)
+	require.Equal(t, strings.TrimSpace(issuer1.Certificate), strings.TrimSpace(issuer1_ref1.Certificate))
 	require.Equal(t, issuer1_ref1.ID, issuer1_ref2.ID)
 	require.Equal(t, key1_ref1.ID, issuer1_ref2.KeyID)
 	require.Equal(t, issuer1_ref1.Name, issuer1_ref2.Name)
@@ -143,7 +144,7 @@ func Test_KeysIssuerImport(t *testing.T) {
 	issuer2_ref, existing, err := importIssuer(ctx, s, issuer2.Certificate, "ignore-me")
 	require.NoError(t, err)
 	require.True(t, existing)
-	require.Equal(t, issuer2.Certificate, issuer2_ref.Certificate)
+	require.Equal(t, strings.TrimSpace(issuer2.Certificate), strings.TrimSpace(issuer2_ref.Certificate))
 	require.Equal(t, issuer2.ID, issuer2_ref.ID)
 	require.Equal(t, "", issuer2_ref.Name)
 	require.Equal(t, issuer2.KeyID, issuer2_ref.KeyID)
@@ -173,7 +174,7 @@ func genIssuerAndKey(t *testing.T, b *backend) (issuer, key) {
 	pkiIssuer := issuer{
 		ID:           issuerId,
 		KeyID:        keyId,
-		Certificate:  certBundle.Certificate,
+		Certificate:  strings.TrimSpace(certBundle.Certificate) + "\n",
 		CAChain:      certBundle.CAChain,
 		SerialNumber: certBundle.SerialNumber,
 	}


### PR DESCRIPTION
This allows operators to manually construct complex CA chains manually, bypassing the existing chain building logic.

We add a new field, `manual_chain`, to the update issuers path, which explicitly constructs a chain (by ID), ignoring any unknown issuers.

@stevendpclark -- I added a commit here that fixes handling of duplicate names w.r.t. updating issuers, let me know what you think.

I also update some of the tests to exercise this.