### PR TITLE
docs/secrets/ad: remove case_sensitive_names from API docs

### DIFF
--- a/website/content/api-docs/secret/ad.mdx
+++ b/website/content/api-docs/secret/ad.mdx
@@ -43,7 +43,6 @@ text that fulfills those requirements. `{{PASSWORD}}` must appear exactly once a
 ### Connection parameters
 
 - `url` (string, optional) - The LDAP server to connect to. Examples: `ldaps://ldap.myorg.com`, `ldaps://ldap.myorg.com:636`. This can also be a comma-delineated list of URLs, e.g. `ldaps://ldap.myorg.com,ldaps://ldap.myorg.com:636`, in which case the servers will be tried in-order if there are errors during the connection process. Default is `ldap://127.0.0.1`.
-- `case_sensitive_names` `(bool: false)` – If set, user and group names assigned to policies within the backend will be case sensitive. Otherwise, names will be normalized to lower case. Case will still be preserved when sending the username to the LDAP server at login time; this is only for matching local user/group definitions.
 - `request_timeout` `(integer: 90 or string: "90s")` - Timeout, in seconds, for the connection when making requests against the server before returning back an error.
 - `starttls` (bool, optional) - If true, issues a `StartTLS` command after establishing an unencrypted connection.
 - `insecure_tls` - (bool, optional) - If true, skips LDAP server SSL certificate verification - insecure, use with caution!


### PR DESCRIPTION
PR to remove mention of `case_sensitive_names` in the API docs page for the AD Secrets Engine. The parameter is not applicable to the engine even though the it is [technically available](https://github.com/hashicorp/vault-plugin-secrets-ad/blob/main/plugin/path_config.go#L68) through the `ldaputil` package. The engine does not reference or use this parameter elsewhere.

The users tied to static roles is don’t map to vault ACL policies (or have to do with Vault policies at all), unlike the LDAP auth method which [does make use](https://github.com/hashicorp/vault/blob/b17e3256dde937a6248c9a2fa56206aac93d07de/builtin/credential/ldap/backend.go#L164-L169) of this parameter.