### PR TITLE
Fix mismatched quotes in /sys/monitor example

### DIFF
--- a/website/content/api-docs/system/monitor.mdx
+++ b/website/content/api-docs/system/monitor.mdx
@@ -31,7 +31,7 @@ default, this is text.
 ```shell-session
 $ curl \
     --header "X-Vault-Token: ..." \
-    http://127.0.0.1:8200/v1/sys/monitor?log_level=debug"
+    "http://127.0.0.1:8200/v1/sys/monitor?log_level=debug"
 ```
 
 ### Sample Response


### PR DESCRIPTION
Makes pasting the example into the terminal easier.