### PR TITLE
Generated Model Bug

### DIFF
--- a/ui/app/utils/openapi-to-attrs.js
+++ b/ui/app/utils/openapi-to-attrs.js
@@ -29,7 +29,7 @@ export const expandOpenApiProps = function (props) {
       editType,
       helpText: description,
       possibleValues: prop['enum'],
-      fieldValue: isId ? 'id' : null,
+      fieldValue: isId ? 'mutableId' : null,
       fieldGroup: group || 'default',
       readOnly: isId,
       defaultValue: value || null,

--- a/ui/lib/core/addon/templates/components/field-group-show.hbs
+++ b/ui/lib/core/addon/templates/components/field-group-show.hbs
@@ -3,7 +3,7 @@
     {{#each-in fieldGroup as |group fields|}}
       {{#if (or (eq group "default") (eq group "Options"))}}
         {{#each fields as |attr|}}
-          {{#if (not-eq attr.options.fieldValue "id")}}
+          {{#if (not (includes attr.options.fieldValue (array "id" "mutableId")))}}
             <InfoTableRow
               @alwaysRender={{this.showAllFields}}
               @label={{capitalize (or attr.options.label (humanize (dasherize attr.name)))}}

--- a/ui/tests/unit/services/path-helper-test.js
+++ b/ui/tests/unit/services/path-helper-test.js
@@ -1,0 +1,73 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+const openapiStub = {
+  openapi: {
+    components: {
+      schemas: {
+        UsersRequest: {
+          type: 'object',
+          properties: {
+            password: {
+              description: 'Password for the user',
+              type: 'string',
+              'x-vault-displayAttrs': { sensitive: true },
+            },
+          },
+        },
+      },
+    },
+    paths: {
+      '/users/{username}': {
+        post: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/UsersRequest' },
+              },
+            },
+          },
+        },
+        parameters: [
+          {
+            description: 'Username for this user.',
+            in: 'path',
+            name: 'username',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        'x-vault-displayAttrs': { itemType: 'User', action: 'Create' },
+      },
+    },
+  },
+};
+
+module('Unit | Service | path-help', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.pathHelp = this.owner.lookup('service:path-help');
+    this.store = this.owner.lookup('service:store');
+  });
+
+  test('it should generate model with mutableId', async function (assert) {
+    assert.expect(2);
+
+    this.server.get('/auth/userpass/', () => openapiStub);
+    this.server.get('/auth/userpass/users/example', () => openapiStub);
+    this.server.post('/auth/userpass/users/test', () => {
+      assert.ok(true, 'POST request made to correct endpoint');
+      return;
+    });
+
+    const modelType = 'generated-user-userpass';
+    await this.pathHelp.getNewModel(modelType, 'userpass', 'auth/userpass/', 'user');
+    const model = this.store.createRecord(modelType);
+    model.set('mutableId', 'test');
+    await model.save();
+    assert.equal(model.get('id'), 'test', 'model id is set to mutableId value on save success');
+  });
+});


### PR DESCRIPTION
This bug was discovered when attempting to create a user for the userpass auth method. After the 3.28 Ember upgrade there was an error thrown when attempting to set the id field of the model after it was initially set. Rather than setting the id field on change a private value is set through a computed property and then the id field is set in the adapter on save success.