### PR TITLE
Update CRL handling for multiple issuers

### DIFF
--- a/builtin/logical/pki/backend.go
+++ b/builtin/logical/pki/backend.go
@@ -76,6 +76,7 @@ func Backend(conf *logical.BackendConfig) *backend {
 			LocalStorage: []string{
 				"revoked/",
 				"crl",
+				"crls/",
 				"certs/",
 			},
 

--- a/builtin/logical/pki/cert_util.go
+++ b/builtin/logical/pki/cert_util.go
@@ -154,7 +154,10 @@ func fetchCertBySerial(ctx context.Context, req *logical.Request, prefix, serial
 		legacyPath = "revoked/" + colonSerial
 		path = "revoked/" + hyphenSerial
 	case serial == "crl":
-		path = "crl"
+		path, err = resolveIssuerCRLPath(ctx, req.Storage, defaultRef)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		legacyPath = "certs/" + colonSerial
 		path = "certs/" + hyphenSerial

--- a/builtin/logical/pki/cert_util_test.go
+++ b/builtin/logical/pki/cert_util_test.go
@@ -86,36 +86,6 @@ func TestPki_FetchCertBySerial(t *testing.T) {
 			t.Fatalf("error on %s for hyphen-based storage path: err: %v, entry: %v", name, err, certEntry)
 		}
 	}
-
-	noConvCases := map[string]struct {
-		Req    *logical.Request
-		Prefix string
-		Serial string
-	}{
-		"crl": {
-			&logical.Request{
-				Storage: storage,
-			},
-			"",
-			"crl",
-		},
-	}
-
-	// Test for ca and crl case
-	for name, tc := range noConvCases {
-		err := storage.Put(context.Background(), &logical.StorageEntry{
-			Key:   tc.Serial,
-			Value: []byte("some data"),
-		})
-		if err != nil {
-			t.Fatalf("error writing to storage on %s: %s", name, err)
-		}
-
-		certEntry, err := fetchCertBySerial(context.Background(), tc.Req, tc.Prefix, tc.Serial)
-		if err != nil || certEntry == nil {
-			t.Fatalf("error on %s: err: %v, entry: %v", name, err, certEntry)
-		}
-	}
 }
 
 // Demonstrate that multiple OUs in the name are handled in an

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -1,6 +1,7 @@
 package pki
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/x509"
@@ -15,10 +16,13 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+const revokedPath = "revoked/"
+
 type revocationInfo struct {
 	CertificateBytes  []byte    `json:"certificate_bytes"`
 	RevocationTime    int64     `json:"revocation_time"`
 	RevocationTimeUTC time.Time `json:"revocation_time_utc"`
+	CertificateIssuer issuerID  `json:"issuer_id"`
 }
 
 // Revokes a cert, and tries to be smart about error recovery
@@ -53,7 +57,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 	alreadyRevoked := false
 	var revInfo revocationInfo
 
-	revEntry, err := fetchCertBySerial(ctx, req, "revoked/", serial)
+	revEntry, err := fetchCertBySerial(ctx, req, revokedPath, serial)
 	if err != nil {
 		switch err.(type) {
 		case errutil.UserError:
@@ -117,7 +121,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 		revInfo.RevocationTime = currTime.Unix()
 		revInfo.RevocationTimeUTC = currTime.UTC()
 
-		revEntry, err = logical.StorageEntryJSON("revoked/"+normalizeSerial(serial), revInfo)
+		revEntry, err = logical.StorageEntryJSON(revokedPath+normalizeSerial(serial), revInfo)
 		if err != nil {
 			return nil, fmt.Errorf("error creating revocation entry")
 		}
@@ -128,7 +132,7 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 		}
 	}
 
-	crlErr := buildCRL(ctx, b, req, false)
+	crlErr := buildCRLs(ctx, b, req, false)
 	if crlErr != nil {
 		switch crlErr.(type) {
 		case errutil.UserError:
@@ -149,9 +153,250 @@ func revokeCert(ctx context.Context, b *backend, req *logical.Request, serial st
 	return resp, nil
 }
 
+func buildCRLs(ctx context.Context, b *backend, req *logical.Request, forceNew bool) error {
+	// In order to build all CRLs, we need knowledge of all issuers. Any two
+	// issuers with the same keys _and_ subject should have the same CRL since
+	// they're functionally equivalent.
+	//
+	// When building CRLs, there's two types of CRLs: an "internal" CRL for
+	// just certificates issued by this issuer, and a "default" CRL, which
+	// not only contains certificates by this issuer, but also ones issued
+	// by "unknown" or past issuers. This means we need knowledge of not
+	// only all issuers (to tell whether or not to include these orphaned
+	// certs) but whether the present issuer is the configured default.
+	//
+	// If a configured default is lacking, we won't provision these
+	// certificates on any CRL.
+	//
+	// In order to know which CRL a given cert belongs on, we have to read
+	// it into memory, identify the corresponding issuer, and update its
+	// map with the revoked cert instance. If no such issuer is found, we'll
+	// place it in the default issuer's CRL.
+	//
+	// By not updating storage, we allow issuers to come and go (either by
+	// direct deletion or by having their keys delete, preventing CRLs from
+	// being signed) -- and when they return, we'll correctly place certs
+	// on their CRLs.
+	issuers, err := listIssuers(ctx, req.Storage)
+	if err != nil {
+		return fmt.Errorf("error building CRL: while listing issuers: %v", err)
+	}
+
+	config, err := getIssuersConfig(ctx, req.Storage)
+	if err != nil {
+		return fmt.Errorf("error building CRLs: while getting the default config: %v", err)
+	}
+
+	// We map issuerID->entry for fast lookup and also issuerID->Cert for
+	// signature verification and correlation of revoked certs.
+	issuerIDEntryMap := make(map[issuerID]*issuerEntry, len(issuers))
+	issuerIDCertMap := make(map[issuerID]*x509.Certificate, len(issuers))
+
+	// We use a double map (keyID->subject->issuerID) to store whether or not this
+	// key+subject paring has been seen before. We can then iterate over each
+	// key/subject and choose any representative issuer for that combination.
+	keySubjectIssuersMap := make(map[keyID]map[string][]issuerID)
+	for _, issuer := range issuers {
+		thisEntry, err := fetchIssuerById(ctx, req.Storage, issuer)
+		if err != nil {
+			return fmt.Errorf("error building CRLs: unable to fetch specified issuer (%v): %v", issuer, err)
+		}
+
+		if len(thisEntry.KeyID) == 0 {
+			continue
+		}
+
+		issuerIDEntryMap[issuer] = thisEntry
+
+		thisCert, err := thisEntry.GetCertificate()
+		if err != nil {
+			return fmt.Errorf("error building CRLs: unable to parse issuer (%v)'s certificate: %v", issuer, err)
+		}
+		issuerIDCertMap[issuer] = thisCert
+
+		subject := string(thisCert.RawIssuer)
+		if _, ok := keySubjectIssuersMap[thisEntry.KeyID]; !ok {
+			keySubjectIssuersMap[thisEntry.KeyID] = make(map[string][]issuerID)
+		}
+
+		keySubjectIssuersMap[thisEntry.KeyID][subject] = append(keySubjectIssuersMap[thisEntry.KeyID][subject], issuer)
+	}
+
+	// Fetch the cluster-local CRL mapping so we know where to write the
+	// CRLs.
+	crlConfig, err := getLocalCRLConfig(ctx, req.Storage)
+	if err != nil {
+		return fmt.Errorf("error building CRLs: unable to fetch cluster-local CRL configuration: %v", err)
+	}
+
+	// Next, we load and parse all revoked certificates. We need to assign
+	// these certificates to an issuer. Some certificates will not be
+	// assignable (if they were issued by a since-deleted issuer), so we need
+	// a separate pool for those.
+	unassignedCerts, revokedCertsMap, err := getRevokedCertEntries(ctx, req, issuerIDCertMap)
+	if err != nil {
+		return fmt.Errorf("error building CRLs: unable to get revoked certificate entries: %v", err)
+	}
+
+	// Now we can call buildCRL once, on an arbitrary/representative issuer
+	// from each of these (keyID, subject) sets.
+	for _, subjectIssuersMap := range keySubjectIssuersMap {
+		for _, issuersSet := range subjectIssuersMap {
+			if len(issuersSet) == 0 {
+				continue
+			}
+
+			var revokedCerts []pkix.RevokedCertificate
+			representative := issuersSet[0]
+			var crlIdentifier crlID
+			var crlIdIssuer issuerID
+			for _, issuerId := range issuersSet {
+				if issuerId == config.DefaultIssuerId {
+					if len(unassignedCerts) > 0 {
+						revokedCerts = append(revokedCerts, unassignedCerts...)
+					}
+
+					representative = issuerId
+				}
+
+				if thisRevoked, ok := revokedCertsMap[issuerId]; ok && len(thisRevoked) > 0 {
+					revokedCerts = append(revokedCerts, thisRevoked...)
+				}
+
+				if thisCRLId, ok := crlConfig.IssuerIDCRLMap[issuerId]; ok && len(thisCRLId) > 0 {
+					if len(crlIdentifier) > 0 && crlIdentifier != thisCRLId {
+						return fmt.Errorf("error building CRLs: two issuers with same keys/subjects (%v vs %v) have different internal CRL IDs: %v vs %v", issuerId, crlIdIssuer, thisCRLId, crlIdentifier)
+					}
+
+					crlIdentifier = thisCRLId
+					crlIdIssuer = issuerId
+				}
+			}
+
+			if len(crlIdentifier) == 0 {
+				// Create a new random UUID for this CRL if none exists.
+				crlIdentifier = genCRLId()
+			}
+
+			// Update all issuers in this group to set the CRL Issuer
+			for _, issuerId := range issuersSet {
+				crlConfig.IssuerIDCRLMap[issuerId] = crlIdentifier
+			}
+
+			if err := buildCRL(ctx, b, req, forceNew, representative, revokedCerts, crlIdentifier); err != nil {
+				return fmt.Errorf("error building CRLs: unable to build CRL for issuer (%v): %v", representative, err)
+			}
+		}
+	}
+
+	// Finally, persist our potentially updated local CRL config
+	if err := setLocalCRLConfig(ctx, req.Storage, crlConfig); err != nil {
+		return fmt.Errorf("error building CRLs: unable to persist updated cluster-local CRL config: %v", err)
+	}
+
+	// All good :-)
+	return nil
+}
+
+func getRevokedCertEntries(ctx context.Context, req *logical.Request, issuerIDCertMap map[issuerID]*x509.Certificate) ([]pkix.RevokedCertificate, map[issuerID][]pkix.RevokedCertificate, error) {
+	var unassignedCerts []pkix.RevokedCertificate
+	revokedCertsMap := make(map[issuerID][]pkix.RevokedCertificate)
+
+	revokedSerials, err := req.Storage.List(ctx, revokedPath)
+	if err != nil {
+		return nil, nil, errutil.InternalError{Err: fmt.Sprintf("error fetching list of revoked certs: %s", err)}
+	}
+
+	for _, serial := range revokedSerials {
+		var revInfo revocationInfo
+		revokedEntry, err := req.Storage.Get(ctx, revokedPath+serial)
+		if err != nil {
+			return nil, nil, errutil.InternalError{Err: fmt.Sprintf("unable to fetch revoked cert with serial %s: %s", serial, err)}
+		}
+		if revokedEntry == nil {
+			return nil, nil, errutil.InternalError{Err: fmt.Sprintf("revoked certificate entry for serial %s is nil", serial)}
+		}
+		if revokedEntry.Value == nil || len(revokedEntry.Value) == 0 {
+			// TODO: In this case, remove it and continue? How likely is this to
+			// happen? Alternately, could skip it entirely, or could implement a
+			// delete function so that there is a way to remove these
+			return nil, nil, errutil.InternalError{Err: fmt.Sprintf("found revoked serial but actual certificate is empty")}
+		}
+
+		err = revokedEntry.DecodeJSON(&revInfo)
+		if err != nil {
+			return nil, nil, errutil.InternalError{Err: fmt.Sprintf("error decoding revocation entry for serial %s: %s", serial, err)}
+		}
+
+		revokedCert, err := x509.ParseCertificate(revInfo.CertificateBytes)
+		if err != nil {
+			return nil, nil, errutil.InternalError{Err: fmt.Sprintf("unable to parse stored revoked certificate with serial %s: %s", serial, err)}
+		}
+
+		// NOTE: We have to change this to UTC time because the CRL standard
+		// mandates it but Go will happily encode the CRL without this.
+		newRevCert := pkix.RevokedCertificate{
+			SerialNumber: revokedCert.SerialNumber,
+		}
+		if !revInfo.RevocationTimeUTC.IsZero() {
+			newRevCert.RevocationTime = revInfo.RevocationTimeUTC
+		} else {
+			newRevCert.RevocationTime = time.Unix(revInfo.RevocationTime, 0).UTC()
+		}
+
+		// If we have a CertificateIssuer field on the revocation entry,
+		// prefer it to manually checking each issuer signature, assuming it
+		// appears valid. Its highly unlikely for two different issuers
+		// to have the same id (after the first was deleted).
+		if len(revInfo.CertificateIssuer) > 0 {
+			issuerId := revInfo.CertificateIssuer
+			if _, issuerExists := issuerIDCertMap[issuerId]; issuerExists {
+				revokedCertsMap[issuerId] = append(revokedCertsMap[issuerId], newRevCert)
+				continue
+			}
+
+			// Otherwise, fall through and update the entry.
+		}
+
+		// Now we need to assign the revoked certificate to an issuer.
+		foundParent := false
+		for issuerId, issuerCert := range issuerIDCertMap {
+			if bytes.Equal(revokedCert.RawIssuer, issuerCert.RawSubject) {
+				if err := revokedCert.CheckSignatureFrom(issuerCert); err == nil {
+					// Valid mapping. Add it to the specified entry.
+					revokedCertsMap[issuerId] = append(revokedCertsMap[issuerId], newRevCert)
+					revInfo.CertificateIssuer = issuerId
+					foundParent = true
+					break
+				}
+			}
+		}
+
+		if !foundParent {
+			// If the parent isn't found, add it to the unassigned bucket.
+			unassignedCerts = append(unassignedCerts, newRevCert)
+		} else {
+			// When the CertificateIssuer field wasn't found on the existing
+			// entry (or was invalid), and we've found a new value for it,
+			// we should update the entry to make future CRL builds faster.
+			revokedEntry, err = logical.StorageEntryJSON(revokedPath+serial, revInfo)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error creating revocation entry for existing cert: %v", serial)
+			}
+
+			err = req.Storage.Put(ctx, revokedEntry)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error updating revoked certificate at existing location: %v", serial)
+			}
+		}
+	}
+
+	return unassignedCerts, revokedCertsMap, nil
+}
+
 // Builds a CRL by going through the list of revoked certificates and building
 // a new CRL with the stored revocation times and serial numbers.
-func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bool) error {
+func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bool, thisIssuerId issuerID, revoked []pkix.RevokedCertificate, identifier crlID) error {
 	crlInfo, err := b.CRL(ctx, req.Storage)
 	if err != nil {
 		return errutil.InternalError{Err: fmt.Sprintf("error fetching CRL config information: %s", err)}
@@ -159,8 +404,6 @@ func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bo
 
 	crlLifetime := b.crlLifetime
 	var revokedCerts []pkix.RevokedCertificate
-	var revInfo revocationInfo
-	var revokedSerials []string
 
 	if crlInfo != nil {
 		if crlInfo.Expiry != "" {
@@ -179,51 +422,20 @@ func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bo
 		}
 	}
 
-	revokedSerials, err = req.Storage.List(ctx, "revoked/")
-	if err != nil {
-		return errutil.InternalError{Err: fmt.Sprintf("error fetching list of revoked certs: %s", err)}
-	}
-
-	for _, serial := range revokedSerials {
-		revokedEntry, err := req.Storage.Get(ctx, "revoked/"+serial)
-		if err != nil {
-			return errutil.InternalError{Err: fmt.Sprintf("unable to fetch revoked cert with serial %s: %s", serial, err)}
-		}
-		if revokedEntry == nil {
-			return errutil.InternalError{Err: fmt.Sprintf("revoked certificate entry for serial %s is nil", serial)}
-		}
-		if revokedEntry.Value == nil || len(revokedEntry.Value) == 0 {
-			// TODO: In this case, remove it and continue? How likely is this to
-			// happen? Alternately, could skip it entirely, or could implement a
-			// delete function so that there is a way to remove these
-			return errutil.InternalError{Err: fmt.Sprintf("found revoked serial but actual certificate is empty")}
-		}
-
-		err = revokedEntry.DecodeJSON(&revInfo)
-		if err != nil {
-			return errutil.InternalError{Err: fmt.Sprintf("error decoding revocation entry for serial %s: %s", serial, err)}
-		}
-
-		revokedCert, err := x509.ParseCertificate(revInfo.CertificateBytes)
-		if err != nil {
-			return errutil.InternalError{Err: fmt.Sprintf("unable to parse stored revoked certificate with serial %s: %s", serial, err)}
-		}
-
-		// NOTE: We have to change this to UTC time because the CRL standard
-		// mandates it but Go will happily encode the CRL without this.
-		newRevCert := pkix.RevokedCertificate{
-			SerialNumber: revokedCert.SerialNumber,
-		}
-		if !revInfo.RevocationTimeUTC.IsZero() {
-			newRevCert.RevocationTime = revInfo.RevocationTimeUTC
-		} else {
-			newRevCert.RevocationTime = time.Unix(revInfo.RevocationTime, 0).UTC()
-		}
-		revokedCerts = append(revokedCerts, newRevCert)
-	}
+	revokedCerts = revoked
 
 WRITE:
-	signingBundle, caErr := fetchCAInfo(ctx, b, req, defaultRef)
+	bundle, caErr := fetchCertBundleByIssuerId(ctx, req.Storage, thisIssuerId, true /* need the signing key */)
+	if caErr != nil {
+		switch caErr.(type) {
+		case errutil.UserError:
+			return errutil.UserError{Err: fmt.Sprintf("could not fetch the CA certificate: %s", caErr)}
+		default:
+			return errutil.InternalError{Err: fmt.Sprintf("error fetching CA certificate: %s", caErr)}
+		}
+	}
+
+	signingBundle, caErr := parseCABundle(ctx, b, req, bundle)
 	if caErr != nil {
 		switch caErr.(type) {
 		case errutil.UserError:
@@ -239,7 +451,7 @@ WRITE:
 	}
 
 	err = req.Storage.Put(ctx, &logical.StorageEntry{
-		Key:   "crl",
+		Key:   "crls/" + identifier.String(),
 		Value: crlBytes,
 	})
 	if err != nil {

--- a/builtin/logical/pki/crl_util.go
+++ b/builtin/logical/pki/crl_util.go
@@ -426,6 +426,13 @@ func buildCRL(ctx context.Context, b *backend, req *logical.Request, forceNew bo
 			if !forceNew {
 				return nil
 			}
+
+			// NOTE: in this case, the passed argument (revoked) is not added
+			// to the revokedCerts list. This is because we want to sign an
+			// **empty** CRL (as the CRL was disabled but we've specified the
+			// forceNew option). In previous versions of Vault (1.10 series and
+			// earlier), we'd have queried the certs below, whereas we now have
+			// an assignment from a pre-queried list.
 			goto WRITE
 		}
 	}

--- a/builtin/logical/pki/path_config_crl.go
+++ b/builtin/logical/pki/path_config_crl.go
@@ -111,7 +111,7 @@ func (b *backend) pathCRLWrite(ctx context.Context, req *logical.Request, d *fra
 
 	if oldDisable != config.Disable {
 		// It wasn't disabled but now it is, rotate
-		crlErr := buildCRL(ctx, b, req, true)
+		crlErr := buildCRLs(ctx, b, req, true)
 		if crlErr != nil {
 			switch crlErr.(type) {
 			case errutil.UserError:

--- a/builtin/logical/pki/path_manage_issuers.go
+++ b/builtin/logical/pki/path_manage_issuers.go
@@ -184,7 +184,7 @@ func (b *backend) pathImportIssuers(ctx context.Context, req *logical.Request, d
 	}
 
 	if len(createdIssuers) > 0 {
-		err := buildCRL(ctx, b, req, true)
+		err := buildCRLs(ctx, b, req, true)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/logical/pki/path_revoke.go
+++ b/builtin/logical/pki/path_revoke.go
@@ -68,7 +68,7 @@ func (b *backend) pathRotateCRLRead(ctx context.Context, req *logical.Request, d
 	b.revokeStorageLock.RLock()
 	defer b.revokeStorageLock.RUnlock()
 
-	crlErr := buildCRL(ctx, b, req, false)
+	crlErr := buildCRLs(ctx, b, req, false)
 	if crlErr != nil {
 		switch crlErr.(type) {
 		case errutil.UserError:

--- a/builtin/logical/pki/path_root.go
+++ b/builtin/logical/pki/path_root.go
@@ -191,7 +191,7 @@ func (b *backend) pathCAGenerateRoot(ctx context.Context, req *logical.Request, 
 	}
 
 	// Build a fresh CRL
-	err = buildCRL(ctx, b, req, true)
+	err = buildCRLs(ctx, b, req, true)
 	if err != nil {
 		return nil, err
 	}

--- a/builtin/logical/pki/path_tidy.go
+++ b/builtin/logical/pki/path_tidy.go
@@ -225,7 +225,7 @@ func (b *backend) pathTidyWrite(ctx context.Context, req *logical.Request, d *fr
 				}
 
 				if rebuildCRL {
-					if err := buildCRL(ctx, b, req, false); err != nil {
+					if err := buildCRLs(ctx, b, req, false); err != nil {
 						return err
 					}
 				}

--- a/builtin/logical/pki/storage.go
+++ b/builtin/logical/pki/storage.go
@@ -67,6 +67,7 @@ type issuerEntry struct {
 
 type localCRLConfigEntry struct {
 	IssuerIDCRLMap map[issuerID]crlID `json:"issuer_id_crl_map" structs:"issuer_id_crl_map" mapstructure:"issuer_id_crl_map"`
+	CRLNumberMap   map[crlID]int64    `json:"crl_number_map" structs:"crl_number_map" mapstructure:"crl_number_map"`
 }
 
 type keyConfigEntry struct {
@@ -537,6 +538,10 @@ func getLocalCRLConfig(ctx context.Context, s logical.Storage) (*localCRLConfigE
 
 	if len(mapping.IssuerIDCRLMap) == 0 {
 		mapping.IssuerIDCRLMap = make(map[issuerID]crlID)
+	}
+
+	if len(mapping.CRLNumberMap) == 0 {
+		mapping.CRLNumberMap = make(map[crlID]int64)
 	}
 
 	return mapping, nil


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

This updates the CRL handling code to support generating a per-issuer CRL. Notably, when two issuers use the same public/private key _and_ have the same Subject, their CRLs are functionally equivalent and can be combined.

We update revoked cert entries to have an issuer field, allowing us to do the (expensive) issuer check once. 

We also update to the CRLv2 format, using code from @kitography. 