### PR TITLE
Rename PKI types to avoid constant variable name collisions

### DIFF
--- a/builtin/logical/pki/config_util.go
+++ b/builtin/logical/pki/config_util.go
@@ -25,14 +25,14 @@ func isDefaultIssuerSet(ctx context.Context, s logical.Storage) (bool, error) {
 	return strings.TrimSpace(config.DefaultIssuerId.String()) != "", nil
 }
 
-func updateDefaultKeyId(ctx context.Context, s logical.Storage, id keyId) error {
+func updateDefaultKeyId(ctx context.Context, s logical.Storage, id keyID) error {
 	config, err := getKeysConfig(ctx, s)
 	if err != nil {
 		return err
 	}
 
 	if config.DefaultKeyId != id {
-		return setKeysConfig(ctx, s, &keyConfig{
+		return setKeysConfig(ctx, s, &keyConfigEntry{
 			DefaultKeyId: id,
 		})
 	}
@@ -40,14 +40,14 @@ func updateDefaultKeyId(ctx context.Context, s logical.Storage, id keyId) error 
 	return nil
 }
 
-func updateDefaultIssuerId(ctx context.Context, s logical.Storage, id issuerId) error {
+func updateDefaultIssuerId(ctx context.Context, s logical.Storage, id issuerID) error {
 	config, err := getIssuersConfig(ctx, s)
 	if err != nil {
 		return err
 	}
 
 	if config.DefaultIssuerId != id {
-		return setIssuersConfig(ctx, s, &issuerConfig{
+		return setIssuersConfig(ctx, s, &issuerConfigEntry{
 			DefaultIssuerId: id,
 		})
 	}

--- a/builtin/logical/pki/path_fetch_issuers.go
+++ b/builtin/logical/pki/path_fetch_issuers.go
@@ -167,7 +167,7 @@ func (b *backend) pathUpdateIssuer(ctx context.Context, req *logical.Request, da
 	}
 
 	var updateChain bool
-	var constructedChain []issuerId
+	var constructedChain []issuerID
 	for index, newPathRef := range newPath {
 		// Allow self for the first entry.
 		if index == 0 && newPathRef == "self" {

--- a/builtin/logical/pki/storage_migrations_test.go
+++ b/builtin/logical/pki/storage_migrations_test.go
@@ -92,11 +92,11 @@ func Test_migrateStorageSimpleBundle(t *testing.T) {
 	// Make sure we setup the default values
 	keysConfig, err := getKeysConfig(ctx, s)
 	require.NoError(t, err)
-	require.Equal(t, &keyConfig{DefaultKeyId: keyId}, keysConfig)
+	require.Equal(t, &keyConfigEntry{DefaultKeyId: keyId}, keysConfig)
 
 	issuersConfig, err := getIssuersConfig(ctx, s)
 	require.NoError(t, err)
-	require.Equal(t, &issuerConfig{DefaultIssuerId: issuerId}, issuersConfig)
+	require.Equal(t, &issuerConfigEntry{DefaultIssuerId: issuerId}, issuersConfig)
 
 	// Make sure if we attempt to re-run the migration nothing happens...
 	err = migrateStorage(ctx, request, b.Logger())

--- a/builtin/logical/pki/storage_test.go
+++ b/builtin/logical/pki/storage_test.go
@@ -20,17 +20,17 @@ func Test_ConfigsRoundTrip(t *testing.T) {
 	// Verify we handle nothing stored properly
 	keyConfigEmpty, err := getKeysConfig(ctx, s)
 	require.NoError(t, err)
-	require.Equal(t, &keyConfig{}, keyConfigEmpty)
+	require.Equal(t, &keyConfigEntry{}, keyConfigEmpty)
 
 	issuerConfigEmpty, err := getIssuersConfig(ctx, s)
 	require.NoError(t, err)
-	require.Equal(t, &issuerConfig{}, issuerConfigEmpty)
+	require.Equal(t, &issuerConfigEntry{}, issuerConfigEmpty)
 
 	// Now attempt to store and reload properly
-	origKeyConfig := &keyConfig{
+	origKeyConfig := &keyConfigEntry{
 		DefaultKeyId: genKeyId(),
 	}
-	origIssuerConfig := &issuerConfig{
+	origIssuerConfig := &issuerConfigEntry{
 		DefaultIssuerId: genIssuerId(),
 	}
 
@@ -84,12 +84,12 @@ func Test_IssuerRoundTrip(t *testing.T) {
 	keys, err := listKeys(ctx, s)
 	require.NoError(t, err)
 
-	require.ElementsMatch(t, []keyId{key1.ID, key2.ID}, keys)
+	require.ElementsMatch(t, []keyID{key1.ID, key2.ID}, keys)
 
 	issuers, err := listIssuers(ctx, s)
 	require.NoError(t, err)
 
-	require.ElementsMatch(t, []issuerId{issuer1.ID, issuer2.ID}, issuers)
+	require.ElementsMatch(t, []issuerID{issuer1.ID, issuer2.ID}, issuers)
 }
 
 func Test_KeysIssuerImport(t *testing.T) {
@@ -158,12 +158,12 @@ func Test_KeysIssuerImport(t *testing.T) {
 	require.Equal(t, "", key2_ref.Name)
 }
 
-func genIssuerAndKey(t *testing.T, b *backend) (issuer, key) {
+func genIssuerAndKey(t *testing.T, b *backend) (issuerEntry, keyEntry) {
 	certBundle := genCertBundle(t, b)
 
 	keyId := genKeyId()
 
-	pkiKey := key{
+	pkiKey := keyEntry{
 		ID:             keyId,
 		PrivateKeyType: certBundle.PrivateKeyType,
 		PrivateKey:     certBundle.PrivateKey,
@@ -171,7 +171,7 @@ func genIssuerAndKey(t *testing.T, b *backend) (issuer, key) {
 
 	issuerId := genIssuerId()
 
-	pkiIssuer := issuer{
+	pkiIssuer := issuerEntry{
 		ID:           issuerId,
 		KeyID:        keyId,
 		Certificate:  strings.TrimSpace(certBundle.Certificate) + "\n",

--- a/builtin/logical/pki/util.go
+++ b/builtin/logical/pki/util.go
@@ -19,9 +19,11 @@ const (
 	defaultRef        = "default"
 )
 
-var nameMatcher = regexp.MustCompile("^" + framework.GenericNameRegex(issuerRefParam) + "$")
-var errIssuerNameInUse = errutil.UserError{Err: "issuer name already in use"}
-var errKeyNameInUse = errutil.UserError{Err: "key name already in use"}
+var (
+	nameMatcher        = regexp.MustCompile("^" + framework.GenericNameRegex(issuerRefParam) + "$")
+	errIssuerNameInUse = errutil.UserError{Err: "issuer name already in use"}
+	errKeyNameInUse    = errutil.UserError{Err: "key name already in use"}
+)
 
 func normalizeSerial(serial string) string {
 	return strings.Replace(strings.ToLower(serial), ":", "-", -1)
@@ -142,12 +144,12 @@ func getIssuerName(ctx context.Context, s logical.Storage, data *framework.Field
 		if !nameMatcher.MatchString(issuerName) {
 			return issuerName, errutil.UserError{Err: "issuer name contained invalid characters"}
 		}
-		issuer_id, err := resolveIssuerReference(ctx, s, issuerName)
+		issuerId, err := resolveIssuerReference(ctx, s, issuerName)
 		if err == nil {
 			return issuerName, errIssuerNameInUse
 		}
 
-		if err != nil && issuer_id != IssuerRefNotFound {
+		if err != nil && issuerId != IssuerRefNotFound {
 			return issuerName, errutil.InternalError{Err: err.Error()}
 		}
 	}


### PR DESCRIPTION
 keyId -> keyID
 issuerId -> issuerID
 key -> keyEntry
 issuer -> issuerEntry
 keyConfig -> keyConfigEntry
 issuerConfig -> issuerConfigEntry